### PR TITLE
Implement collections tool

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,6 +101,25 @@ exchanges the auth code for tokens. `auth_status` reports session state;
 The first-ever call must pass `clientId` (a FamilySearch dev key);
 subsequent calls read it from the on-disk config (see below).
 
+### `collections`
+
+Returns FamilySearch record collections for a place, with record, person,
+and image counts. **Requires auth** (uses `getValidToken()`). Spec:
+`docs/specs/collections-tool-spec.md`.
+
+```typescript
+collections({ query: "Alabama" })    // Search by place name (recommended)
+collections({ placeIds: [33] })      // Filter by internal collection IDs
+```
+
+The `query` parameter searches collection titles (case-insensitive). This
+is the primary input — the `places` tool and `collections` tool use
+different place ID systems, so pass a place name, not a places-API ID.
+
+Returns: `query`, `matchingCollections`, and `collections[]` with `id`,
+`title`, `dateRange`, `placeIds`, `recordCount`, `personCount`,
+`imageCount`, and `url`.
+
 ## Auth architecture (`mcp-server/src/auth/`)
 
 All future authenticated tools (`collections`, `search`, `tree`, `cets`)

--- a/docs/collections-tool-testing-guide.md
+++ b/docs/collections-tool-testing-guide.md
@@ -1,0 +1,458 @@
+# Collections Tool Testing Guide
+
+This guide walks you through testing the `collections` tool after it's
+built. Follow each layer in order. Don't skip ahead — each layer
+catches different problems.
+
+## What the collections tool does (30 seconds)
+
+The `collections` tool returns FamilySearch record collections that
+cover given place IDs. You get it a list of place IDs (which you get
+from the `places` tool), and it returns collections with record counts,
+person counts, image counts, and date ranges.
+
+This is the first **authenticated** data tool — it requires a valid
+FamilySearch login session (obtained via the `login` tool). Under the
+hood it calls the lower-level FamilySearch search API to fetch all
+~5000 collections in one call, then filters client-side by place ID
+chains.
+
+The typical user workflow is:
+```
+places("Alabama") → get placeId 33 → collections([33]) → list of collections
+```
+
+## Before You Start
+
+### 1. Make sure the server builds and all tests pass
+
+```bash
+cd ~/cowork-genealogy/mcp-server
+npm run build
+npm test
+```
+
+All tests should pass (including 8 new collections tests). If anything
+is red, fix it first.
+
+### 2. You need a valid FamilySearch session
+
+The `collections` tool requires authentication. You must be able to
+log in via the `login` tool first. If you haven't tested OAuth yet,
+complete the [OAuth Testing Guide](./oauth-tool-testing-guide.md)
+through at least Layer 1 Part C before continuing.
+
+You'll need:
+- A FamilySearch developer app with a registered client ID
+- The redirect URI `http://127.0.0.1:1837/callback` registered on
+  your FS app
+- A FamilySearch account you can log in with
+
+---
+
+## Layer 0: Smoke-Test Script
+
+**What this tests:** Does the tool function work against the live API?
+
+This bypasses the MCP harness entirely and calls the tool function
+directly. It's the fastest way to catch API response shape mismatches.
+
+### Steps
+
+1. Make sure you're logged in (you should have `~/.familysearch-mcp/tokens.json`
+   from a previous `login` call). If not:
+
+   ```bash
+   cd ~/cowork-genealogy/mcp-server
+   npx @modelcontextprotocol/inspector node build/index.js
+   ```
+
+   Call `login` with your client ID, complete the browser flow, then
+   stop the Inspector.
+
+2. Run the smoke test:
+
+   ```bash
+   cd ~/cowork-genealogy/mcp-server
+   npx tsx scripts/try-collections.ts 33
+   ```
+
+   This calls `collectionsTool({ placeIds: [33] })` for Alabama.
+
+3. You should see JSON output with:
+   - `placeIds: [33]`
+   - `matchingCollections` — a number > 0
+   - `collections` — an array of objects, each with `id`, `title`,
+     `dateRange`, `placeIds`, `recordCount`, `personCount`,
+     `imageCount`, and `url`
+
+4. Try multiple place IDs:
+
+   ```bash
+   npx tsx scripts/try-collections.ts 33,325
+   ```
+
+   This should return collections for both Alabama (33) and
+   England (325). The count should be higher than either alone.
+
+5. Try a place ID that has no collections:
+
+   ```bash
+   npx tsx scripts/try-collections.ts 999999
+   ```
+
+   Should return `matchingCollections: 0` and an empty `collections`
+   array — no crash.
+
+### What success looks like
+
+You get back structured JSON with real collection data. The `url`
+fields should be valid FamilySearch links (try opening one in your
+browser).
+
+### What failure looks like
+
+| Symptom | Likely cause | Fix |
+|---------|--------------|-----|
+| Auth error ("not logged in") | No valid session | Run `login` first via Inspector |
+| API returns unexpected shape | API types don't match reality | Compare the raw response to `FSCollectionEntry` in `src/types/collection.ts` and adjust |
+| Empty results for known places | placeId chain format doesn't match | Check what the API actually returns for `placeId` field vs what `parsePlaceIdChain` expects |
+| `fetch` error or timeout | Network issue or wrong URL | Check the URL constant in `src/tools/collections.ts` |
+
+### When to move on
+
+Move to Layer 1 once the smoke test returns real collections for
+place ID 33 (Alabama).
+
+---
+
+## Layer 1: MCP Inspector
+
+**What this tests:** Does the tool register correctly? Does it work
+through the MCP protocol?
+
+### Start the Inspector
+
+```bash
+cd ~/cowork-genealogy/mcp-server
+npx @modelcontextprotocol/inspector node build/index.js
+```
+
+Look at the tools list. You should see **six** tools:
+- `wikipedia_search`
+- `places`
+- `login`
+- `logout`
+- `auth_status`
+- `collections`
+
+If `collections` is missing, check that `src/index.ts` imports and
+registers it.
+
+### Part A — Not authenticated (error message)
+
+1. Wipe any existing session:
+
+   ```bash
+   rm -f ~/.familysearch-mcp/tokens.json
+   ```
+
+2. In the Inspector, call **`collections`** with:
+
+   ```json
+   { "placeIds": [33] }
+   ```
+
+3. Expected response: an error with `isError: true` and a message like:
+
+   ```
+   User is not logged in to FamilySearch. Call the login tool to authenticate.
+   ```
+
+   This confirms auth error propagation works. The message is an
+   LLM instruction — Claude will understand it means it should call
+   `login` first.
+
+### Part B — Authenticated (happy path)
+
+1. In the Inspector, call **`login`** with your client ID. Complete the
+   browser flow.
+
+2. Call **`collections`** with:
+
+   ```json
+   { "placeIds": [33] }
+   ```
+
+3. Expected response: JSON with `placeIds`, `matchingCollections`, and
+   a `collections` array containing Alabama-related collections.
+
+4. Try multiple IDs:
+
+   ```json
+   { "placeIds": [33, 325] }
+   ```
+
+   Should return collections covering Alabama and/or England.
+
+5. Try a non-existent place ID:
+
+   ```json
+   { "placeIds": [999999] }
+   ```
+
+   Should return `matchingCollections: 0` with an empty array — not an
+   error.
+
+### What success looks like (Layer 1)
+
+- Tool shows up in the Inspector.
+- Without auth: clear error message directing to login.
+- With auth: structured collection data returned.
+- Non-matching IDs: empty result, no crash.
+
+### What failure looks like
+
+| Symptom | Likely cause | Fix |
+|---------|--------------|-----|
+| Tool missing from Inspector | Not registered in `index.ts` | Check import + ListTools + CallTool blocks |
+| Auth error despite being logged in | Token expired, cache issue | Log out and log in again |
+| Unexpected error shape | API response doesn't match types | Check the smoke test output and adjust types |
+
+### When to move on
+
+Move to Layer 2 when Part B works — you can get collections for real
+place IDs through the Inspector.
+
+---
+
+## Layer 2: Claude Code as Client
+
+**What this tests:** Does Claude understand the two-step workflow
+(places → collections)?
+
+### Steps
+
+1. Open a terminal and create a scratch folder:
+
+   ```bash
+   mkdir -p ~/mcp-test-scratch
+   cd ~/mcp-test-scratch
+   ```
+
+2. Register the server with Claude Code (if not already):
+
+   ```bash
+   claude mcp add --transport stdio genealogy-dev -- node /home/<your-wsl-user>/cowork-genealogy/mcp-server/build/index.js
+   ```
+
+3. Start Claude Code:
+
+   ```bash
+   claude
+   ```
+
+4. Make sure you have a valid session. If needed:
+
+   > "Log me in to FamilySearch. My client ID is YOUR-KEY."
+
+5. Test the natural two-step workflow:
+
+   > "What FamilySearch record collections cover Alabama?"
+
+6. Watch what Claude does:
+   - Claude should call `places` with query "Alabama" to get the
+     place ID (33).
+   - Claude should then call `collections` with `placeIds: [33]`.
+   - Claude should present the results — collection names, record
+     counts, date ranges.
+
+7. Test a multi-place query:
+
+   > "Find collections that cover England."
+
+8. Test a place that Claude needs to disambiguate:
+
+   > "What collections are available for Madison?"
+
+   Claude should call `places("Madison")`, see multiple results
+   (Madison County in various states, Madison city, etc.), and either
+   pick the most relevant one or ask you to clarify.
+
+### What success looks like
+
+Claude chains `places` → `collections` without being told the
+explicit steps. It presents the collection data clearly.
+
+### What failure looks like
+
+- Claude calls `collections` without calling `places` first → the
+  tool descriptions may need to be stronger about the workflow.
+- Claude doesn't use `collections` at all → the tool description
+  doesn't match the user's natural language.
+- Claude passes a place name instead of IDs to `collections` → the
+  `placeIds` parameter description needs clarification.
+- Claude calls `collections` but gets an auth error and doesn't
+  recover → the auth error message should tell Claude to call `login`.
+
+### Troubleshooting
+
+If you change the server code:
+
+1. Rebuild: `cd ~/cowork-genealogy/mcp-server && npm run build`
+2. In Claude Code, type `/mcp` to reconnect.
+3. Try again.
+
+### When to move on
+
+Move to Layer 3 when Claude successfully drives the places →
+collections workflow from natural language.
+
+---
+
+## Choose Your Layer 3 Order
+
+Layers 1 and 2 are platform-agnostic — everyone runs them. Layer 3
+splits by where Cowork's MCP server runs, and **both sub-layers are
+required**:
+
+| Your dev environment | Run first | Then |
+|----------------------|-----------|------|
+| WSL2 | Layer 3a (WSL2) | Layer 3b (Native Windows) |
+| Native Windows | Layer 3b (Native Windows) | Layer 3a (WSL2) |
+
+---
+
+## Layer 3a: Cowork via WSL2
+
+**What this tests:** Does the full pipeline work in Cowork, talking
+through the WSL2 bridge?
+
+**Prerequisite:** Claude Desktop installed, configured with the
+`genealogy-dev` server entry pointing to WSL2 (see the
+[OAuth Testing Guide](./oauth-tool-testing-guide.md) Layer 3a for
+setup instructions — the config is the same).
+
+### Steps
+
+1. FULLY restart Claude Desktop if you changed the server config
+   or rebuilt.
+
+2. Open a Cowork session.
+
+3. Make sure you're logged in:
+
+   > "What's my FamilySearch auth status?"
+
+   If not logged in:
+
+   > "Log me in to FamilySearch. My client ID is YOUR-KEY."
+
+4. Test the collections workflow:
+
+   > "What FamilySearch collections cover Alabama?"
+
+5. Verify Claude:
+   - Calls `places` to resolve "Alabama" → place ID 33
+   - Calls `collections` with `[33]`
+   - Presents collection names, record counts, date ranges
+
+6. Test a second query to verify caching doesn't break anything:
+
+   > "Now show me collections for England."
+
+### What success looks like
+
+Same as Layer 2, but running through the full Cowork → Claude
+Desktop → WSL2 → MCP server pipeline.
+
+### What failure looks like
+
+- Claude doesn't see the tools → config typo or Claude Desktop
+  wasn't fully restarted.
+- Server error `ETIMEDOUT` or `fetch failed` → Node 22 networking
+  bug; switch to Node 20.
+- Auth error despite logging in → token file path mismatch between
+  WSL2 and Windows.
+
+### When to move on
+
+Move to Layer 3b once the WSL2 bridge handles the full places →
+collections workflow.
+
+---
+
+## Layer 3b: Cowork via Native Windows
+
+**What this tests:** Does the full pipeline work running natively
+on Windows?
+
+**Prerequisite:** See the [OAuth Testing Guide](./oauth-tool-testing-guide.md)
+Layer 3b for the full native Windows setup (copy project, npm install,
+npm run build, update Claude Desktop config). The same setup applies
+here.
+
+### Steps
+
+1. Make sure the native Windows build is up to date:
+
+   ```powershell
+   cd C:\Users\<your-windows-user>\cowork-genealogy\mcp-server
+   npm run build
+   ```
+
+2. Update Claude Desktop config to point to the native build (see
+   OAuth guide Layer 3b for the exact config).
+
+3. FULLY restart Claude Desktop.
+
+4. Open Cowork and test:
+
+   > "Log me in to FamilySearch. My client ID is YOUR-KEY."
+   > "What FamilySearch collections cover Alabama?"
+
+5. Verify the same workflow works as in Layer 3a.
+
+### What success looks like
+
+Same results as Layer 3a, but running natively on Windows.
+
+### What failure looks like
+
+Same issues as Layer 3a, plus potential cross-platform problems.
+See the OAuth guide's Layer 3b troubleshooting table.
+
+### You're done when
+
+The places → collections workflow works in Cowork on native Windows.
+
+---
+
+## Quick Reference: Commands
+
+| What | Command |
+|------|---------|
+| Build server | `cd mcp-server && npm run build` |
+| Run tests | `cd mcp-server && npm test` |
+| Smoke test (Alabama) | `cd mcp-server && npx tsx scripts/try-collections.ts 33` |
+| Smoke test (multi) | `cd mcp-server && npx tsx scripts/try-collections.ts 33,325` |
+| Run Inspector | `npx @modelcontextprotocol/inspector node build/index.js` |
+| Wipe session | `rm -f ~/.familysearch-mcp/tokens.json` |
+| Reconnect in Claude Code | `/mcp` |
+| Claude Desktop config | Settings → Developer → Edit Config |
+| Claude Desktop logs | Settings → Developer → View Logs |
+
+---
+
+## Summary: What Each Layer Catches
+
+| Layer | What it tests | Bugs it catches |
+|-------|---------------|-----------------|
+| 0 - Smoke test | Direct function call vs live API | API shape mismatches, placeId parsing |
+| 1 - Inspector (no auth) | Auth error propagation | Missing/wrong error messages |
+| 1 - Inspector (with auth) | Tool through MCP protocol | Schema errors, serialization bugs |
+| 2 - Claude Code | LLM chaining (places → collections) | Bad tool descriptions, workflow confusion |
+| 3a - Cowork WSL2 | Full path through WSL2 | WSL2 bridge + token path issues |
+| 3b - Cowork Native | Full path on native Windows | Cross-platform bugs |
+
+**Don't skip layers.** Each one catches bugs the others miss.

--- a/docs/collections-tool-testing-guide.md
+++ b/docs/collections-tool-testing-guide.md
@@ -7,32 +7,47 @@ catches different problems.
 ## What the collections tool does (30 seconds)
 
 The `collections` tool returns FamilySearch record collections that
-cover given place IDs. You get it a list of place IDs (which you get
-from the `places` tool), and it returns collections with record counts,
-person counts, image counts, and date ranges.
+match a place name. You pass it a query like `"Alabama"` and it
+returns collections whose titles contain that string, with record
+counts, person counts, image counts, and date ranges.
 
 This is the first **authenticated** data tool — it requires a valid
 FamilySearch login session (obtained via the `login` tool). Under the
 hood it calls the lower-level FamilySearch search API to fetch all
-~5000 collections in one call, then filters client-side by place ID
-chains.
+~3400 collections in one call, caches for 1 hour, then filters
+client-side by title.
 
 The typical user workflow is:
 ```
-places("Alabama") → get placeId 33 → collections([33]) → list of collections
+User: "What collections cover Alabama?"
+Claude: collections({ query: "Alabama" }) → 29 collections
 ```
+
+For ambiguous place names, Claude can use `places` first to
+disambiguate, then pass the resolved name to `collections`:
+```
+User: "What collections cover Madison?"
+Claude: places("Madison") → multiple results → ask user which one
+Claude: collections({ query: "Alabama" }) → Alabama collections
+```
+
+**Note:** The `places` tool and `collections` tool use different
+place ID systems. The `query` parameter (place name) is the primary
+way to search collections. A `placeIds` parameter exists for internal
+collection IDs, but these are NOT the same IDs the `places` tool
+returns.
 
 ## Before You Start
 
 ### 1. Make sure the server builds and all tests pass
 
 ```bash
-cd ~/cowork-genealogy/mcp-server
+cd mcp-server
 npm run build
 npm test
 ```
 
-All tests should pass (including 8 new collections tests). If anything
+All tests should pass (including 13 collections tests). If anything
 is red, fix it first.
 
 ### 2. You need a valid FamilySearch session
@@ -63,7 +78,7 @@ directly. It's the fastest way to catch API response shape mismatches.
    from a previous `login` call). If not:
 
    ```bash
-   cd ~/cowork-genealogy/mcp-server
+   cd mcp-server
    npx @modelcontextprotocol/inspector node build/index.js
    ```
 
@@ -73,36 +88,43 @@ directly. It's the fastest way to catch API response shape mismatches.
 2. Run the smoke test:
 
    ```bash
-   cd ~/cowork-genealogy/mcp-server
-   npx tsx scripts/try-collections.ts 33
+   cd mcp-server
+   npx tsx scripts/try-collections.ts Alabama
    ```
 
-   This calls `collectionsTool({ placeIds: [33] })` for Alabama.
+   This calls `collectionsTool({ query: "Alabama" })`.
 
 3. You should see JSON output with:
-   - `placeIds: [33]`
-   - `matchingCollections` — a number > 0
+   - `query: "Alabama"`
+   - `matchingCollections` — a number > 0 (expect ~29)
    - `collections` — an array of objects, each with `id`, `title`,
      `dateRange`, `placeIds`, `recordCount`, `personCount`,
      `imageCount`, and `url`
 
-4. Try multiple place IDs:
+4. Try another place:
 
    ```bash
-   npx tsx scripts/try-collections.ts 33,325
+   npx tsx scripts/try-collections.ts England
    ```
 
-   This should return collections for both Alabama (33) and
-   England (325). The count should be higher than either alone.
+   Should return England-related collections.
 
-5. Try a place ID that has no collections:
+5. Try a query that matches nothing:
 
    ```bash
-   npx tsx scripts/try-collections.ts 999999
+   npx tsx scripts/try-collections.ts xyznonexistent
    ```
 
    Should return `matchingCollections: 0` and an empty `collections`
    array — no crash.
+
+6. (Optional) Try the placeIds mode with internal IDs:
+
+   ```bash
+   npx tsx scripts/try-collections.ts --ids 33
+   ```
+
+   Should return the same Alabama collections.
 
 ### What success looks like
 
@@ -115,14 +137,15 @@ browser).
 | Symptom | Likely cause | Fix |
 |---------|--------------|-----|
 | Auth error ("not logged in") | No valid session | Run `login` first via Inspector |
-| API returns unexpected shape | API types don't match reality | Compare the raw response to `FSCollectionEntry` in `src/types/collection.ts` and adjust |
-| Empty results for known places | placeId chain format doesn't match | Check what the API actually returns for `placeId` field vs what `parsePlaceIdChain` expects |
+| 403 "blocked by security service" | Missing User-Agent header | Check that `User-Agent` header is set in `fetchAllCollections` |
+| API returns unexpected shape | API types don't match reality | Compare the raw response to types in `src/types/collection.ts` and adjust |
+| Empty results for known places | Title matching not working | Check that the query matches the collection title (case-insensitive) |
 | `fetch` error or timeout | Network issue or wrong URL | Check the URL constant in `src/tools/collections.ts` |
 
 ### When to move on
 
 Move to Layer 1 once the smoke test returns real collections for
-place ID 33 (Alabama).
+Alabama.
 
 ---
 
@@ -134,7 +157,7 @@ through the MCP protocol?
 ### Start the Inspector
 
 ```bash
-cd ~/cowork-genealogy/mcp-server
+cd mcp-server
 npx @modelcontextprotocol/inspector node build/index.js
 ```
 
@@ -157,10 +180,16 @@ registers it.
    rm -f ~/.familysearch-mcp/tokens.json
    ```
 
+   On Windows PowerShell:
+
+   ```powershell
+   Remove-Item $env:USERPROFILE\.familysearch-mcp\tokens.json
+   ```
+
 2. In the Inspector, call **`collections`** with:
 
    ```json
-   { "placeIds": [33] }
+   { "query": "Alabama" }
    ```
 
 3. Expected response: an error with `isError: true` and a message like:
@@ -181,24 +210,24 @@ registers it.
 2. Call **`collections`** with:
 
    ```json
-   { "placeIds": [33] }
+   { "query": "Alabama" }
    ```
 
-3. Expected response: JSON with `placeIds`, `matchingCollections`, and
+3. Expected response: JSON with `query`, `matchingCollections`, and
    a `collections` array containing Alabama-related collections.
 
-4. Try multiple IDs:
+4. Try another place:
 
    ```json
-   { "placeIds": [33, 325] }
+   { "query": "England" }
    ```
 
-   Should return collections covering Alabama and/or England.
+   Should return England collections.
 
-5. Try a non-existent place ID:
+5. Try a query that matches nothing:
 
    ```json
-   { "placeIds": [999999] }
+   { "query": "xyznonexistent" }
    ```
 
    Should return `matchingCollections: 0` with an empty array — not an
@@ -209,7 +238,7 @@ registers it.
 - Tool shows up in the Inspector.
 - Without auth: clear error message directing to login.
 - With auth: structured collection data returned.
-- Non-matching IDs: empty result, no crash.
+- Non-matching queries: empty result, no crash.
 
 ### What failure looks like
 
@@ -222,14 +251,14 @@ registers it.
 ### When to move on
 
 Move to Layer 2 when Part B works — you can get collections for real
-place IDs through the Inspector.
+place names through the Inspector.
 
 ---
 
 ## Layer 2: Claude Code as Client
 
-**What this tests:** Does Claude understand the two-step workflow
-(places → collections)?
+**What this tests:** Does Claude understand when and how to use the
+collections tool from natural language?
 
 ### Steps
 
@@ -240,10 +269,17 @@ place IDs through the Inspector.
    cd ~/mcp-test-scratch
    ```
 
+   On Windows PowerShell:
+
+   ```powershell
+   mkdir -Force $env:USERPROFILE\mcp-test-scratch
+   cd $env:USERPROFILE\mcp-test-scratch
+   ```
+
 2. Register the server with Claude Code (if not already):
 
    ```bash
-   claude mcp add --transport stdio genealogy-dev -- node /home/<your-wsl-user>/cowork-genealogy/mcp-server/build/index.js
+   claude mcp add --transport stdio genealogy-dev -- node /path/to/cowork-genealogy/mcp-server/build/index.js
    ```
 
 3. Start Claude Code:
@@ -256,42 +292,39 @@ place IDs through the Inspector.
 
    > "Log me in to FamilySearch. My client ID is YOUR-KEY."
 
-5. Test the natural two-step workflow:
+5. Test the collections query:
 
    > "What FamilySearch record collections cover Alabama?"
 
 6. Watch what Claude does:
-   - Claude should call `places` with query "Alabama" to get the
-     place ID (33).
-   - Claude should then call `collections` with `placeIds: [33]`.
+   - Claude should call `collections` with `query: "Alabama"`.
    - Claude should present the results — collection names, record
      counts, date ranges.
+   - Claude should NOT need to call `places` first (the query
+     parameter takes a name directly).
 
-7. Test a multi-place query:
+7. Test another place:
 
    > "Find collections that cover England."
 
-8. Test a place that Claude needs to disambiguate:
+8. Test a place that might need disambiguation:
 
    > "What collections are available for Madison?"
 
-   Claude should call `places("Madison")`, see multiple results
-   (Madison County in various states, Madison city, etc.), and either
-   pick the most relevant one or ask you to clarify.
+   Claude may call `places("Madison")` first to disambiguate, then
+   call `collections` with the resolved state or country name.
 
 ### What success looks like
 
-Claude chains `places` → `collections` without being told the
-explicit steps. It presents the collection data clearly.
+Claude calls `collections({ query: "Alabama" })` and presents the
+collection data clearly — categorized, with counts and date ranges.
 
 ### What failure looks like
 
-- Claude calls `collections` without calling `places` first → the
-  tool descriptions may need to be stronger about the workflow.
 - Claude doesn't use `collections` at all → the tool description
   doesn't match the user's natural language.
-- Claude passes a place name instead of IDs to `collections` → the
-  `placeIds` parameter description needs clarification.
+- Claude tries to pass place IDs from the `places` tool → the schema
+  description should clarify these are different ID systems.
 - Claude calls `collections` but gets an auth error and doesn't
   recover → the auth error message should tell Claude to call `login`.
 
@@ -299,14 +332,14 @@ explicit steps. It presents the collection data clearly.
 
 If you change the server code:
 
-1. Rebuild: `cd ~/cowork-genealogy/mcp-server && npm run build`
+1. Rebuild: `cd mcp-server && npm run build`
 2. In Claude Code, type `/mcp` to reconnect.
 3. Try again.
 
 ### When to move on
 
-Move to Layer 3 when Claude successfully drives the places →
-collections workflow from natural language.
+Move to Layer 3 when Claude successfully uses the collections tool
+from natural language.
 
 ---
 
@@ -328,15 +361,37 @@ required**:
 **What this tests:** Does the full pipeline work in Cowork, talking
 through the WSL2 bridge?
 
-**Prerequisite:** Claude Desktop installed, configured with the
-`genealogy-dev` server entry pointing to WSL2 (see the
-[OAuth Testing Guide](./oauth-tool-testing-guide.md) Layer 3a for
-setup instructions — the config is the same).
+**Prerequisite:** Claude Desktop installed with a WSL2 MCP server
+entry. Example `claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "genealogy-wsl": {
+      "command": "wsl.exe",
+      "args": [
+        "-d", "Ubuntu-22.04",
+        "--cd", "/mnt/c/path/to/cowork-genealogy/mcp-server",
+        "--",
+        "/usr/bin/node",
+        "build/index.js"
+      ]
+    }
+  }
+}
+```
+
+Adjust the distro name, path, and node path for your setup. Use
+`wsl.exe -l` to find your distro name and `wsl.exe -- which node`
+to find the node path.
+
+**Important:** Remove or rename any native Windows MCP server entry
+while testing this layer, so you know the WSL2 bridge is being used.
 
 ### Steps
 
 1. FULLY restart Claude Desktop if you changed the server config
-   or rebuilt.
+   or rebuilt (system tray → right-click → Quit → reopen).
 
 2. Open a Cowork session.
 
@@ -352,10 +407,8 @@ setup instructions — the config is the same).
 
    > "What FamilySearch collections cover Alabama?"
 
-5. Verify Claude:
-   - Calls `places` to resolve "Alabama" → place ID 33
-   - Calls `collections` with `[33]`
-   - Presents collection names, record counts, date ranges
+5. Verify Claude calls `collections` with `query: "Alabama"` and
+   presents collection names, record counts, and date ranges.
 
 6. Test a second query to verify caching doesn't break anything:
 
@@ -363,7 +416,8 @@ setup instructions — the config is the same).
 
 ### What success looks like
 
-Same as Layer 2, but running through the full Cowork → Claude
+Claude calls `collections({ query: "Alabama" })` and returns 29
+Alabama collections, running through the full Cowork → Claude
 Desktop → WSL2 → MCP server pipeline.
 
 ### What failure looks like
@@ -377,8 +431,8 @@ Desktop → WSL2 → MCP server pipeline.
 
 ### When to move on
 
-Move to Layer 3b once the WSL2 bridge handles the full places →
-collections workflow.
+Move to Layer 3b once the WSL2 bridge handles the collections
+workflow.
 
 ---
 
@@ -387,31 +441,49 @@ collections workflow.
 **What this tests:** Does the full pipeline work running natively
 on Windows?
 
-**Prerequisite:** See the [OAuth Testing Guide](./oauth-tool-testing-guide.md)
-Layer 3b for the full native Windows setup (copy project, npm install,
-npm run build, update Claude Desktop config). The same setup applies
-here.
+**Prerequisite:** Claude Desktop configured with a native Windows
+MCP server entry:
+
+```json
+{
+  "mcpServers": {
+    "genealogy-native": {
+      "command": "node",
+      "args": [
+        "C:\\path\\to\\cowork-genealogy\\mcp-server\\build\\index.js"
+      ]
+    }
+  }
+}
+```
+
+**Important:** Remove or rename any WSL2 MCP server entry while
+testing this layer.
 
 ### Steps
 
 1. Make sure the native Windows build is up to date:
 
    ```powershell
-   cd C:\Users\<your-windows-user>\cowork-genealogy\mcp-server
+   cd C:\path\to\cowork-genealogy\mcp-server
    npm run build
    ```
 
-2. Update Claude Desktop config to point to the native build (see
-   OAuth guide Layer 3b for the exact config).
+2. FULLY restart Claude Desktop.
 
-3. FULLY restart Claude Desktop.
+3. Open Cowork and test:
 
-4. Open Cowork and test:
+   > "What's my FamilySearch auth status?"
+
+   If not logged in:
 
    > "Log me in to FamilySearch. My client ID is YOUR-KEY."
+
+   Then:
+
    > "What FamilySearch collections cover Alabama?"
 
-5. Verify the same workflow works as in Layer 3a.
+4. Verify the same results as Layer 3a.
 
 ### What success looks like
 
@@ -419,12 +491,17 @@ Same results as Layer 3a, but running natively on Windows.
 
 ### What failure looks like
 
-Same issues as Layer 3a, plus potential cross-platform problems.
-See the OAuth guide's Layer 3b troubleshooting table.
+Same issues as Layer 3a, plus potential cross-platform problems:
+
+| Problem | Fix |
+|---------|-----|
+| Build fails on Windows | Check for Linux-specific code |
+| Server crashes on startup | Check for hardcoded paths |
+| `npx` not found in config | Use `npx.cmd` on Windows |
 
 ### You're done when
 
-The places → collections workflow works in Cowork on native Windows.
+The collections workflow works in Cowork on native Windows.
 
 ---
 
@@ -434,10 +511,12 @@ The places → collections workflow works in Cowork on native Windows.
 |------|---------|
 | Build server | `cd mcp-server && npm run build` |
 | Run tests | `cd mcp-server && npm test` |
-| Smoke test (Alabama) | `cd mcp-server && npx tsx scripts/try-collections.ts 33` |
-| Smoke test (multi) | `cd mcp-server && npx tsx scripts/try-collections.ts 33,325` |
-| Run Inspector | `npx @modelcontextprotocol/inspector node build/index.js` |
-| Wipe session | `rm -f ~/.familysearch-mcp/tokens.json` |
+| Smoke test (Alabama) | `cd mcp-server && npx tsx scripts/try-collections.ts Alabama` |
+| Smoke test (England) | `cd mcp-server && npx tsx scripts/try-collections.ts England` |
+| Smoke test (internal IDs) | `cd mcp-server && npx tsx scripts/try-collections.ts --ids 33` |
+| Run Inspector | `cd mcp-server && npx @modelcontextprotocol/inspector node build/index.js` |
+| Wipe session (Linux/WSL) | `rm -f ~/.familysearch-mcp/tokens.json` |
+| Wipe session (PowerShell) | `Remove-Item $env:USERPROFILE\.familysearch-mcp\tokens.json` |
 | Reconnect in Claude Code | `/mcp` |
 | Claude Desktop config | Settings → Developer → Edit Config |
 | Claude Desktop logs | Settings → Developer → View Logs |
@@ -448,10 +527,10 @@ The places → collections workflow works in Cowork on native Windows.
 
 | Layer | What it tests | Bugs it catches |
 |-------|---------------|-----------------|
-| 0 - Smoke test | Direct function call vs live API | API shape mismatches, placeId parsing |
+| 0 - Smoke test | Direct function call vs live API | API shape mismatches, WAF blocks, title matching |
 | 1 - Inspector (no auth) | Auth error propagation | Missing/wrong error messages |
 | 1 - Inspector (with auth) | Tool through MCP protocol | Schema errors, serialization bugs |
-| 2 - Claude Code | LLM chaining (places → collections) | Bad tool descriptions, workflow confusion |
+| 2 - Claude Code | LLM tool selection + presentation | Bad descriptions, workflow confusion |
 | 3a - Cowork WSL2 | Full path through WSL2 | WSL2 bridge + token path issues |
 | 3b - Cowork Native | Full path on native Windows | Cross-platform bugs |
 

--- a/docs/specs/collections-tool-spec.md
+++ b/docs/specs/collections-tool-spec.md
@@ -2,10 +2,26 @@
 
 ## Overview
 
-An MCP tool that returns FamilySearch record collections for given place IDs,
+An MCP tool that returns FamilySearch record collections for a place,
 with record, person, and image counts. Requires authentication (OAuth tokens
 obtained via the `login` tool). Uses the lower-level FamilySearch search API
 to get all collections with counts in a single call.
+
+The primary input is a `query` parameter (place name string) that filters
+collections by title. A secondary `placeIds` parameter is available for
+filtering by internal collection place IDs.
+
+### Place ID mismatch (design note)
+
+The FamilySearch Places API (`/platform/places/`) and the Collections API
+(`/service/search/hr/v2/collections`) use **different place ID systems**.
+Alabama is 351 in the Places API but 33 in the Collections API. These IDs
+are not interchangeable.
+
+The `query` parameter was added to work around this — Claude passes the
+place name (e.g., `"Alabama"`) directly to the collections tool and filters
+by collection title. The `places` tool is still useful for disambiguation
+(e.g., which "Madison"?) but its IDs are not passed to `collections`.
 
 ---
 
@@ -13,11 +29,22 @@ to get all collections with counts in a single call.
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `placeIds` | number[] | Yes | FamilySearch place IDs to filter by (obtain from the `places` tool) |
+| `query` | string | No* | Place name to search for in collection titles (e.g., `"Alabama"`, `"England"`) |
+| `placeIds` | number[] | No* | Internal FamilySearch collection place IDs (NOT from the `places` tool) |
 
-Example:
+*At least one of `query` or `placeIds` must be provided.
+
+`query` is the recommended parameter for the LLM workflow. `placeIds` is
+for advanced use when internal collection IDs are already known.
+
+Example (recommended):
 ```json
-{ "placeIds": [33, 351] }
+{ "query": "Alabama" }
+```
+
+Example (advanced):
+```json
+{ "placeIds": [33] }
 ```
 
 ---
@@ -26,7 +53,8 @@ Example:
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `placeIds` | number[] | The place IDs that were requested |
+| `query` | string? | The query string (present when query was used) |
+| `placeIds` | number[]? | The place IDs (present when placeIds was used) |
 | `matchingCollections` | number | Total count of matching collections |
 | `collections` | Collection[] | The matching collection objects |
 
@@ -36,8 +64,8 @@ Each `Collection` object:
 |-------|------|-------------|
 | `id` | string | FamilySearch collection identifier |
 | `title` | string | Human-readable collection name |
-| `dateRange` | string | Time period the collection covers |
-| `placeIds` | number[] | Place IDs from the collection's spatial coverage |
+| `dateRange` | string | Time period the collection covers (e.g., `"1809-1950"`) |
+| `placeIds` | number[] | Internal place IDs from the collection's spatial coverage |
 | `recordCount` | number | Number of records in the collection |
 | `personCount` | number | Number of persons in the collection |
 | `imageCount` | number | Number of images in the collection |
@@ -46,18 +74,18 @@ Each `Collection` object:
 Example:
 ```json
 {
-  "placeIds": [33],
-  "matchingCollections": 2,
+  "query": "Alabama",
+  "matchingCollections": 29,
   "collections": [
     {
-      "id": "1234",
-      "title": "Alabama, County Marriages, 1809-1950",
-      "dateRange": "1809-1950",
-      "placeIds": [1, 33],
-      "recordCount": 524000,
-      "personCount": 1048000,
-      "imageCount": 120000,
-      "url": "https://www.familysearch.org/search/collection/1234"
+      "id": "1743384",
+      "title": "Alabama County Marriages, 1711-1992",
+      "dateRange": "1711-1992",
+      "placeIds": [33],
+      "recordCount": 6049744,
+      "personCount": 22361103,
+      "imageCount": 1231203,
+      "url": "https://www.familysearch.org/search/collection/1743384"
     }
   ]
 }
@@ -70,17 +98,20 @@ Example:
 ```typescript
 {
   name: "collections",
-  description: "List FamilySearch record collections for given place IDs, with record counts. Use the places tool first to get place IDs.",
+  description: "List FamilySearch record collections for a place, with record counts. Pass a place name as query (e.g., \"Alabama\") to search collection titles. Requires authentication — call the login tool first if not logged in.",
   inputSchema: {
     type: "object",
     properties: {
+      query: {
+        type: "string",
+        description: "Place name to search for in collection titles (e.g., \"Alabama\", \"England\"). This is the recommended parameter — use the places tool first to disambiguate if needed."
+      },
       placeIds: {
         type: "array",
         items: { type: "number" },
-        description: "FamilySearch place IDs (e.g., [33, 351] for Alabama). Get these from the places tool."
+        description: "Internal FamilySearch collection place IDs. These are NOT the same as place IDs from the places tool. Only use if you know the internal IDs."
       }
-    },
-    required: ["placeIds"]
+    }
   }
 }
 ```
@@ -105,7 +136,12 @@ this error propagate (same try/catch pattern as other tools in `index.ts`).
 ```
 GET https://www.familysearch.org/service/search/hr/v2/collections
 Authorization: Bearer <access_token>
+User-Agent: <browser-like user agent string>
 ```
+
+**Important:** The `User-Agent` header is required. FamilySearch's WAF
+(Imperva/Incapsula) blocks requests without a browser-like user agent,
+returning a 403 with `"This request was blocked by our security service"`.
 
 **Query parameters:**
 
@@ -113,18 +149,29 @@ Authorization: Bearer <access_token>
 |-----------|-------|---------|
 | `count` | `5000` | Return all collections in a single call |
 | `offset` | `0` | Pagination offset |
-| `countryId` | place ID | Server-side filter by place (optional) |
-| `collectionsWithRecordsFromLocation` | `true` | Required when filtering by place |
 | `facets` | `OFF` | Disable facet aggregation |
+
+**API response shape (GEDCOMX-wrapped):**
+
+The response is NOT a flat array. Each entry is wrapped in GEDCOMX format:
+
+```
+response.entries[].content.gedcomx.collections[0]
+```
+
+Each collection object contains:
+- `id` — collection identifier
+- `title` — human-readable name (e.g., `"Alabama County Marriages, 1711-1992"`)
+- `content[]` — array of counts by `resourceType` (`/Record`, `/Person`, `/DigitalArtifact`)
+- `searchMetadata[0]` — contains `placeIds` (number array), `startYear`, `endYear`, `imageCount`, `recordCount`
 
 **Key API details:**
 
 - The lower-level API (`/service/search/hr/v2/collections`) was chosen over
   the platform API (`/platform/records/collections`) because the platform API
   does not include counts — it would require N+1 calls.
-- The API returns a placeId chain (e.g., `"1-33"` = United States -> Alabama)
-  per collection for spatial coverage. Filter by matching any requested place
-  ID against this chain.
+- Place IDs in `searchMetadata.placeIds` are internal to the collections
+  system and do NOT match the Places API IDs.
 - Some collections have access restrictions (church membership, FamilySearch
   Center access). The API respects these based on the user's session.
 
@@ -132,9 +179,14 @@ Authorization: Bearer <access_token>
 
 ## Filtering Logic
 
-Filter collections by matching requested place IDs against the placeId chain
-in each collection's spatial coverage. A collection matches if **any** of its
-place IDs appear in the requested list.
+**Query mode (recommended):** Case-insensitive substring match against
+collection titles. `"Alabama"` matches any collection whose title contains
+"Alabama" (e.g., `"Alabama, County Marriages, 1711-1992"`).
+
+**PlaceIds mode:** Filter collections where any of the requested place IDs
+appear in the collection's `searchMetadata[0].placeIds` array.
+
+When `query` is provided, it takes precedence over `placeIds`.
 
 ---
 
@@ -142,120 +194,92 @@ place IDs appear in the requested list.
 
 | Condition | Behavior |
 |-----------|----------|
+| Neither `query` nor `placeIds` provided | Throw error with usage instructions |
 | Not authenticated | Let `getValidToken()` throw its LLM-instruction error ("Call the login tool to authenticate.") |
 | API returns non-OK status | Throw error: `"FamilySearch collections API error: {status}"` |
-| API returns empty/malformed response | Return `{ placeIds, matchingCollections: 0, collections: [] }` |
+| API returns empty/malformed response | Return `{ matchingCollections: 0, collections: [] }` |
 
 ---
 
 ## Caching
 
-The full collection list (~5000 entries) changes infrequently. Cache the
-API response for a configurable TTL (e.g., 1 hour) to avoid re-fetching on
-every call. The cache is keyed on the access token (different users may see
-different collections due to access restrictions).
+The full collection list (~3400 entries) changes infrequently. Cache the
+API response for 1 hour to avoid re-fetching on every call. The cache is
+keyed on the access token (different users may see different collections
+due to access restrictions).
 
 ---
 
-## Files to Create
+## Files
 
-### 1. `mcp-server/src/types/collection.ts`
+### `mcp-server/src/types/collection.ts`
 
-Define two types:
+API response types (`FSCollectionEntry`, `FSCollectionsResponse`, etc.)
+and output types (`Collection`, `CollectionsResult`).
 
-- `Collection` — shape of a single collection in the tool's output
-- `CollectionsResult` — shape of what the tool returns
+### `mcp-server/src/tools/collections.ts`
 
-### 2. `mcp-server/src/tools/collections.ts`
-
-Contains:
-
-- `collectionsToolSchema` — MCP tool schema (name, description, inputSchema)
-- `collectionsTool(input)` — async function that authenticates, fetches
-  collections, filters by place IDs, and returns results
-
-Internal helpers:
-
-- `fetchAllCollections(token)` — calls the lower-level API with auth
-- `filterByPlaceIds(collections, placeIds)` — matches placeId chains
-
----
-
-## Files to Modify
+- `collectionsToolSchema` — MCP tool schema
+- `collectionsTool(input)` — main function (authenticates, fetches, filters, maps)
+- `fetchAllCollections(token)` — cached API call with auth + User-Agent
+- `filterByQuery(entries, query)` — case-insensitive title matching
+- `filterByPlaceIds(entries, placeIds)` — internal placeId matching
+- `clearCollectionsCache()` — for testing
 
 ### `mcp-server/src/index.ts`
 
-Register the `collections` tool following the existing pattern:
-
-| Change | Detail |
-|--------|--------|
-| Import | Add import for `collectionsTool` and `collectionsToolSchema` |
-| ListTools | Add `collectionsToolSchema` to the tools array |
-| CallTool | Add `if` block for `"collections"` (same try/catch pattern) |
+Registered following the existing tool pattern (import, ListTools, CallTool).
 
 ---
 
-## Patterns to Follow
+## Testing
 
-Match the style of the existing tools (`places.ts`, `wikipedia.ts`):
-
-- Export function + schema from the tool module
-- Use `getValidToken()` for authentication (same as all future auth tools)
-- Parse API response as JSON and map to output types
-- Throw descriptive errors that help Claude understand what went wrong
-- Errors as LLM instructions (per project conventions)
-- Never `console.log` (stdio transport)
-
----
-
-## Testing Plan
-
-### `tests/tools/collections.test.ts`
+### `tests/tools/collections.test.ts` (13 cases)
 
 | # | Test case | What it verifies |
 |---|-----------|------------------|
-| 1 | Returns collections matching a single place ID | Happy path with one place ID |
-| 2 | Returns collections matching multiple place IDs | Union filtering across several IDs |
-| 3 | Returns empty array when no collections match | Zero-match case |
-| 4 | Throws auth error when not authenticated | `getValidToken()` propagation |
-| 5 | Throws on non-OK API response | HTTP error handling |
-| 6 | Handles malformed API response gracefully | Returns empty result |
-| 7 | Filters correctly against placeId chains | Chain matching logic (e.g., `"1-33"` matches placeId 33) |
-| 8 | Maps API response fields to Collection shape | Field mapping correctness |
+| 1 | Returns collections matching a place name query | Query happy path |
+| 2 | Query matching is case-insensitive | Case handling |
+| 3 | Returns empty array when query matches no titles | Query zero-match |
+| 4 | Query matches anywhere in the title | Substring matching |
+| 5 | Returns collections matching a single place ID | PlaceIds happy path |
+| 6 | Returns collections matching multiple place IDs | Union filtering |
+| 7 | Returns empty array when no place IDs match | PlaceIds zero-match |
+| 8 | Filters correctly against placeIds in searchMetadata | PlaceIds logic |
+| 9 | Throws auth error when not authenticated | Auth propagation |
+| 10 | Throws on non-OK API response | HTTP error handling |
+| 11 | Handles malformed API response gracefully | Empty/null response |
+| 12 | Throws when neither query nor placeIds provided | Input validation |
+| 13 | Maps API response fields to Collection shape | Field mapping |
 
-**Mocks:** `fetch` (global stub), `getValidToken` from `src/auth/refresh.ts`
-
----
-
-## Smoke-Test Script
-
-Create `mcp-server/scripts/try-collections.ts` following the pattern of
-`try-wikipedia.ts` and `try-places.ts`. Requires a valid access token
-(load from `~/.familysearch-mcp/tokens.json`).
+### Smoke-test script
 
 ```bash
-cd mcp-server && npx tsx scripts/try-collections.ts 33   # Alabama
-cd mcp-server && npx tsx scripts/try-collections.ts 325  # England
+cd mcp-server
+npx tsx scripts/try-collections.ts Alabama        # Search by place name
+npx tsx scripts/try-collections.ts England         # Another place
+npx tsx scripts/try-collections.ts --ids 33        # Internal place ID
+npx tsx scripts/try-collections.ts --ids 33,325    # Multiple internal IDs
 ```
 
 ---
 
 ## Verification
 
-### Automated (mocked, no credentials)
+### Automated
 ```bash
 cd mcp-server && npm run build && npm test
 ```
 
-### Manual Layer 1 (MCP Inspector, with valid session)
+### Manual Layer 1 (MCP Inspector)
 ```bash
 npx @modelcontextprotocol/inspector node build/index.js
 ```
-- Call `collections({ placeIds: [33] })` — returns Alabama collections
-- Call `collections({ placeIds: [325] })` — returns England collections
-- Call `collections({ placeIds: [999999] })` — returns empty list
+- Call `collections({ query: "Alabama" })` — returns 29 Alabama collections
+- Call `collections({ query: "England" })` — returns England collections
+- Call `collections({ query: "xyznonexistent" })` — returns empty list
 - Call `collections` without logging in first — returns auth error message
 
 ### Manual Layer 2 (Claude Code)
 - "What FamilySearch collections cover Alabama?" — Claude should call
-  `places` for the ID, then `collections` with the result
+  `collections` with query `"Alabama"` and present the results

--- a/docs/specs/collections-tool-spec.md
+++ b/docs/specs/collections-tool-spec.md
@@ -1,0 +1,261 @@
+# Collections Tool — Implementation Spec
+
+## Overview
+
+An MCP tool that returns FamilySearch record collections for given place IDs,
+with record, person, and image counts. Requires authentication (OAuth tokens
+obtained via the `login` tool). Uses the lower-level FamilySearch search API
+to get all collections with counts in a single call.
+
+---
+
+## Input
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `placeIds` | number[] | Yes | FamilySearch place IDs to filter by (obtain from the `places` tool) |
+
+Example:
+```json
+{ "placeIds": [33, 351] }
+```
+
+---
+
+## Output
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `placeIds` | number[] | The place IDs that were requested |
+| `matchingCollections` | number | Total count of matching collections |
+| `collections` | Collection[] | The matching collection objects |
+
+Each `Collection` object:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | string | FamilySearch collection identifier |
+| `title` | string | Human-readable collection name |
+| `dateRange` | string | Time period the collection covers |
+| `placeIds` | number[] | Place IDs from the collection's spatial coverage |
+| `recordCount` | number | Number of records in the collection |
+| `personCount` | number | Number of persons in the collection |
+| `imageCount` | number | Number of images in the collection |
+| `url` | string | Link to the collection on FamilySearch |
+
+Example:
+```json
+{
+  "placeIds": [33],
+  "matchingCollections": 2,
+  "collections": [
+    {
+      "id": "1234",
+      "title": "Alabama, County Marriages, 1809-1950",
+      "dateRange": "1809-1950",
+      "placeIds": [1, 33],
+      "recordCount": 524000,
+      "personCount": 1048000,
+      "imageCount": 120000,
+      "url": "https://www.familysearch.org/search/collection/1234"
+    }
+  ]
+}
+```
+
+---
+
+## Tool Schema
+
+```typescript
+{
+  name: "collections",
+  description: "List FamilySearch record collections for given place IDs, with record counts. Use the places tool first to get place IDs.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      placeIds: {
+        type: "array",
+        items: { type: "number" },
+        description: "FamilySearch place IDs (e.g., [33, 351] for Alabama). Get these from the places tool."
+      }
+    },
+    required: ["placeIds"]
+  }
+}
+```
+
+---
+
+## Authentication
+
+This tool requires a valid FamilySearch access token. It must call
+`getValidToken()` from `src/auth/refresh.ts` — the single entry point for
+all authenticated tools. Do not re-implement token plumbing.
+
+If the user is not authenticated, `getValidToken()` throws an LLM-instruction
+error directing the user to call the `login` tool. The tool handler should let
+this error propagate (same try/catch pattern as other tools in `index.ts`).
+
+---
+
+## FamilySearch API Reference
+
+**Endpoint (auth required):**
+```
+GET https://www.familysearch.org/service/search/hr/v2/collections
+Authorization: Bearer <access_token>
+```
+
+**Query parameters:**
+
+| Parameter | Value | Purpose |
+|-----------|-------|---------|
+| `count` | `5000` | Return all collections in a single call |
+| `offset` | `0` | Pagination offset |
+| `countryId` | place ID | Server-side filter by place (optional) |
+| `collectionsWithRecordsFromLocation` | `true` | Required when filtering by place |
+| `facets` | `OFF` | Disable facet aggregation |
+
+**Key API details:**
+
+- The lower-level API (`/service/search/hr/v2/collections`) was chosen over
+  the platform API (`/platform/records/collections`) because the platform API
+  does not include counts — it would require N+1 calls.
+- The API returns a placeId chain (e.g., `"1-33"` = United States -> Alabama)
+  per collection for spatial coverage. Filter by matching any requested place
+  ID against this chain.
+- Some collections have access restrictions (church membership, FamilySearch
+  Center access). The API respects these based on the user's session.
+
+---
+
+## Filtering Logic
+
+Filter collections by matching requested place IDs against the placeId chain
+in each collection's spatial coverage. A collection matches if **any** of its
+place IDs appear in the requested list.
+
+---
+
+## Error Handling
+
+| Condition | Behavior |
+|-----------|----------|
+| Not authenticated | Let `getValidToken()` throw its LLM-instruction error ("Call the login tool to authenticate.") |
+| API returns non-OK status | Throw error: `"FamilySearch collections API error: {status}"` |
+| API returns empty/malformed response | Return `{ placeIds, matchingCollections: 0, collections: [] }` |
+
+---
+
+## Caching
+
+The full collection list (~5000 entries) changes infrequently. Cache the
+API response for a configurable TTL (e.g., 1 hour) to avoid re-fetching on
+every call. The cache is keyed on the access token (different users may see
+different collections due to access restrictions).
+
+---
+
+## Files to Create
+
+### 1. `mcp-server/src/types/collection.ts`
+
+Define two types:
+
+- `Collection` — shape of a single collection in the tool's output
+- `CollectionsResult` — shape of what the tool returns
+
+### 2. `mcp-server/src/tools/collections.ts`
+
+Contains:
+
+- `collectionsToolSchema` — MCP tool schema (name, description, inputSchema)
+- `collectionsTool(input)` — async function that authenticates, fetches
+  collections, filters by place IDs, and returns results
+
+Internal helpers:
+
+- `fetchAllCollections(token)` — calls the lower-level API with auth
+- `filterByPlaceIds(collections, placeIds)` — matches placeId chains
+
+---
+
+## Files to Modify
+
+### `mcp-server/src/index.ts`
+
+Register the `collections` tool following the existing pattern:
+
+| Change | Detail |
+|--------|--------|
+| Import | Add import for `collectionsTool` and `collectionsToolSchema` |
+| ListTools | Add `collectionsToolSchema` to the tools array |
+| CallTool | Add `if` block for `"collections"` (same try/catch pattern) |
+
+---
+
+## Patterns to Follow
+
+Match the style of the existing tools (`places.ts`, `wikipedia.ts`):
+
+- Export function + schema from the tool module
+- Use `getValidToken()` for authentication (same as all future auth tools)
+- Parse API response as JSON and map to output types
+- Throw descriptive errors that help Claude understand what went wrong
+- Errors as LLM instructions (per project conventions)
+- Never `console.log` (stdio transport)
+
+---
+
+## Testing Plan
+
+### `tests/tools/collections.test.ts`
+
+| # | Test case | What it verifies |
+|---|-----------|------------------|
+| 1 | Returns collections matching a single place ID | Happy path with one place ID |
+| 2 | Returns collections matching multiple place IDs | Union filtering across several IDs |
+| 3 | Returns empty array when no collections match | Zero-match case |
+| 4 | Throws auth error when not authenticated | `getValidToken()` propagation |
+| 5 | Throws on non-OK API response | HTTP error handling |
+| 6 | Handles malformed API response gracefully | Returns empty result |
+| 7 | Filters correctly against placeId chains | Chain matching logic (e.g., `"1-33"` matches placeId 33) |
+| 8 | Maps API response fields to Collection shape | Field mapping correctness |
+
+**Mocks:** `fetch` (global stub), `getValidToken` from `src/auth/refresh.ts`
+
+---
+
+## Smoke-Test Script
+
+Create `mcp-server/scripts/try-collections.ts` following the pattern of
+`try-wikipedia.ts` and `try-places.ts`. Requires a valid access token
+(load from `~/.familysearch-mcp/tokens.json`).
+
+```bash
+cd mcp-server && npx tsx scripts/try-collections.ts 33   # Alabama
+cd mcp-server && npx tsx scripts/try-collections.ts 325  # England
+```
+
+---
+
+## Verification
+
+### Automated (mocked, no credentials)
+```bash
+cd mcp-server && npm run build && npm test
+```
+
+### Manual Layer 1 (MCP Inspector, with valid session)
+```bash
+npx @modelcontextprotocol/inspector node build/index.js
+```
+- Call `collections({ placeIds: [33] })` — returns Alabama collections
+- Call `collections({ placeIds: [325] })` — returns England collections
+- Call `collections({ placeIds: [999999] })` — returns empty list
+- Call `collections` without logging in first — returns auth error message
+
+### Manual Layer 2 (Claude Code)
+- "What FamilySearch collections cover Alabama?" — Claude should call
+  `places` for the ID, then `collections` with the result

--- a/docs/specs/collections-tool-spec.md
+++ b/docs/specs/collections-tool-spec.md
@@ -53,8 +53,8 @@ Example (advanced):
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `query` | string? | The query string (present when query was used) |
-| `placeIds` | number[]? | The place IDs (present when placeIds was used) |
+| `query` | string? | Echo of the query input (present when supplied) |
+| `placeIds` | number[]? | Echo of the placeIds input (present when supplied) |
 | `matchingCollections` | number | Total count of matching collections |
 | `collections` | Collection[] | The matching collection objects |
 
@@ -195,8 +195,8 @@ When `query` is provided, it takes precedence over `placeIds`.
 | Condition | Behavior |
 |-----------|----------|
 | Neither `query` nor `placeIds` provided | Throw error with usage instructions |
-| Not authenticated | Let `getValidToken()` throw its LLM-instruction error ("Call the login tool to authenticate.") |
-| API returns non-OK status | Throw error: `"FamilySearch collections API error: {status}"` |
+| Not authenticated | Let `getValidToken()` throw its LLM-instruction error ("User is not logged in to FamilySearch. Call the login tool to authenticate.") |
+| API returns non-OK status | Throw error: `"FamilySearch collections API error: {status} {statusText}"` |
 | API returns empty/malformed response | Return `{ matchingCollections: 0, collections: [] }` |
 
 ---

--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -18,9 +18,9 @@
       }
     },
     "node_modules/@emnapi/core": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
-      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -30,9 +30,9 @@
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
-      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -52,9 +52,9 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.13",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.13.tgz",
-      "integrity": "sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==",
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
       "license": "MIT",
       "engines": {
         "node": ">=18.14.1"
@@ -111,9 +111,9 @@
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.3.tgz",
-      "integrity": "sha512-xK9sGVbJWYb08+mTJt3/YV24WxvxpXcXtP6B172paPZ+Ts69Re9dAr7lKwJoeIx8OoeuimEiRZ7umkiUVClmmQ==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -130,9 +130,9 @@
       }
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.124.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.124.0.tgz",
-      "integrity": "sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg==",
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.127.0.tgz",
+      "integrity": "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -140,9 +140,9 @@
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.15.tgz",
-      "integrity": "sha512-YYe6aWruPZDtHNpwu7+qAHEMbQ/yRl6atqb/AhznLTnD3UY99Q1jE7ihLSahNWkF4EqRPVC4SiR4O0UkLK02tA==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==",
       "cpu": [
         "arm64"
       ],
@@ -157,9 +157,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.15.tgz",
-      "integrity": "sha512-oArR/ig8wNTPYsXL+Mzhs0oxhxfuHRfG7Ikw7jXsw8mYOtk71W0OkF2VEVh699pdmzjPQsTjlD1JIOoHkLP1Fg==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==",
       "cpu": [
         "arm64"
       ],
@@ -174,9 +174,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.15.tgz",
-      "integrity": "sha512-YzeVqOqjPYvUbJSWJ4EDL8ahbmsIXQpgL3JVipmN+MX0XnXMeWomLN3Fb+nwCmP/jfyqte5I3XRSm7OfQrbyxw==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==",
       "cpu": [
         "x64"
       ],
@@ -191,9 +191,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.15.tgz",
-      "integrity": "sha512-9Erhx956jeQ0nNTyif1+QWAXDRD38ZNjr//bSHrt6wDwB+QkAfl2q6Mn1k6OBPerznjRmbM10lgRb1Pli4xZPw==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==",
       "cpu": [
         "x64"
       ],
@@ -208,9 +208,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.15.tgz",
-      "integrity": "sha512-cVwk0w8QbZJGTnP/AHQBs5yNwmpgGYStL88t4UIaqcvYJWBfS0s3oqVLZPwsPU6M0zlW4GqjP0Zq5MnAGwFeGA==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.17.tgz",
+      "integrity": "sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==",
       "cpu": [
         "arm"
       ],
@@ -225,9 +225,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.15.tgz",
-      "integrity": "sha512-eBZ/u8iAK9SoHGanqe/jrPnY0JvBN6iXbVOsbO38mbz+ZJsaobExAm1Iu+rxa4S1l2FjG0qEZn4Rc6X8n+9M+w==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==",
       "cpu": [
         "arm64"
       ],
@@ -242,9 +242,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.15.tgz",
-      "integrity": "sha512-ZvRYMGrAklV9PEkgt4LQM6MjQX2P58HPAuecwYObY2DhS2t35R0I810bKi0wmaYORt6m/2Sm+Z+nFgb0WhXNcQ==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.17.tgz",
+      "integrity": "sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==",
       "cpu": [
         "arm64"
       ],
@@ -259,9 +259,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.15.tgz",
-      "integrity": "sha512-VDpgGBzgfg5hLg+uBpCLoFG5kVvEyafmfxGUV0UHLcL5irxAK7PKNeC2MwClgk6ZAiNhmo9FLhRYgvMmedLtnQ==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==",
       "cpu": [
         "ppc64"
       ],
@@ -276,9 +276,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.15.tgz",
-      "integrity": "sha512-y1uXY3qQWCzcPgRJATPSOUP4tCemh4uBdY7e3EZbVwCJTY3gLJWnQABgeUetvED+bt1FQ01OeZwvhLS2bpNrAQ==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==",
       "cpu": [
         "s390x"
       ],
@@ -293,9 +293,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.15.tgz",
-      "integrity": "sha512-023bTPBod7J3Y/4fzAN6QtpkSABR0rigtrwaP+qSEabUh5zf6ELr9Nc7GujaROuPY3uwdSIXWrvhn1KxOvurWA==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==",
       "cpu": [
         "x64"
       ],
@@ -310,9 +310,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.15.tgz",
-      "integrity": "sha512-witB2O0/hU4CgfOOKUoeFgQ4GktPi1eEbAhaLAIpgD6+ZnhcPkUtPsoKKHRzmOoWPZue46IThdSgdo4XneOLYw==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.17.tgz",
+      "integrity": "sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==",
       "cpu": [
         "x64"
       ],
@@ -327,9 +327,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.15.tgz",
-      "integrity": "sha512-UCL68NJ0Ud5zRipXZE9dF5PmirzJE4E4BCIOOssEnM7wLDsxjc6Qb0sGDxTNRTP53I6MZpygyCpY8Aa8sPfKPg==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==",
       "cpu": [
         "arm64"
       ],
@@ -344,9 +344,9 @@
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.15.tgz",
-      "integrity": "sha512-ApLruZq/ig+nhaE7OJm4lDjayUnOHVUa77zGeqnqZ9pn0ovdVbbNPerVibLXDmWeUZXjIYIT8V3xkT58Rm9u5Q==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.17.tgz",
+      "integrity": "sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==",
       "cpu": [
         "wasm32"
       ],
@@ -354,18 +354,18 @@
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/core": "1.9.2",
-        "@emnapi/runtime": "1.9.2",
-        "@napi-rs/wasm-runtime": "^1.1.3"
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.15.tgz",
-      "integrity": "sha512-KmoUoU7HnN+Si5YWJigfTws1jz1bKBYDQKdbLspz0UaqjjFkddHsqorgiW1mxcAj88lYUE6NC/zJNwT+SloqtA==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.17.tgz",
+      "integrity": "sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==",
       "cpu": [
         "arm64"
       ],
@@ -380,9 +380,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.15.tgz",
-      "integrity": "sha512-3P2A8L+x75qavWLe/Dll3EYBJLQmtkJN8rfh+U/eR3MqMgL/h98PhYI+JFfXuDPgPeCB7iZAKiqii5vqOvnA0g==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.17.tgz",
+      "integrity": "sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==",
       "cpu": [
         "x64"
       ],
@@ -397,9 +397,9 @@
       }
     },
     "node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.15.tgz",
-      "integrity": "sha512-UromN0peaE53IaBRe9W7CjrZgXl90fqGpK+mIZbA3qSTeYqg3pqpROBdIPvOG3F5ereDHNwoHBI2e50n1BDr1g==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.17.tgz",
+      "integrity": "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==",
       "dev": true,
       "license": "MIT"
     },
@@ -457,16 +457,16 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.4.tgz",
-      "integrity": "sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.5.tgz",
+      "integrity": "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.1.4",
-        "@vitest/utils": "4.1.4",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
         "chai": "^6.2.2",
         "tinyrainbow": "^3.1.0"
       },
@@ -475,13 +475,13 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.4.tgz",
-      "integrity": "sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.5.tgz",
+      "integrity": "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.1.4",
+        "@vitest/spy": "4.1.5",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.21"
       },
@@ -502,9 +502,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.4.tgz",
-      "integrity": "sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.5.tgz",
+      "integrity": "sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -515,13 +515,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.4.tgz",
-      "integrity": "sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.5.tgz",
+      "integrity": "sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.1.4",
+        "@vitest/utils": "4.1.5",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -529,14 +529,14 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.4.tgz",
-      "integrity": "sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.5.tgz",
+      "integrity": "sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.4",
-        "@vitest/utils": "4.1.4",
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/utils": "4.1.5",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -545,9 +545,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.4.tgz",
-      "integrity": "sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.5.tgz",
+      "integrity": "sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -555,13 +555,13 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.4.tgz",
-      "integrity": "sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.5.tgz",
+      "integrity": "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.4",
+        "@vitest/pretty-format": "4.1.5",
         "convert-source-map": "^2.0.0",
         "tinyrainbow": "^3.1.0"
       },
@@ -583,9 +583,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
-      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -914,9 +914,9 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
-      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -970,9 +970,9 @@
       }
     },
     "node_modules/eventsource-parser": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
-      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.8.tgz",
+      "integrity": "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
@@ -1032,9 +1032,9 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.2.tgz",
-      "integrity": "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==",
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.4.1.tgz",
+      "integrity": "sha512-NGVYwQSAyEQgzxX1iCM978PP9AdO/hW93gMcF6ZwQCm+rFvLsBH6w4xcXWTcliS8La5EPRN3p9wzItqBwJrfNw==",
       "license": "MIT",
       "dependencies": {
         "ip-address": "10.1.0"
@@ -1214,9 +1214,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -1226,9 +1226,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.12",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
-      "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
+      "version": "4.12.15",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.15.tgz",
+      "integrity": "sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -1355,9 +1355,9 @@
       "license": "ISC"
     },
     "node_modules/jose": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
-      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
@@ -1871,9 +1871,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.9",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.9.tgz",
-      "integrity": "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==",
+      "version": "8.5.12",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
+      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
       "dev": true,
       "funding": [
         {
@@ -1961,14 +1961,14 @@
       }
     },
     "node_modules/rolldown": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.15.tgz",
-      "integrity": "sha512-Ff31guA5zT6WjnGp0SXw76X6hzGRk/OQq2hE+1lcDe+lJdHSgnSX6nK3erbONHyCbpSj9a9E+uX/OvytZoWp2g==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.17.tgz",
+      "integrity": "sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.124.0",
-        "@rolldown/pluginutils": "1.0.0-rc.15"
+        "@oxc-project/types": "=0.127.0",
+        "@rolldown/pluginutils": "1.0.0-rc.17"
       },
       "bin": {
         "rolldown": "bin/cli.mjs"
@@ -1977,21 +1977,21 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.0-rc.15",
-        "@rolldown/binding-darwin-arm64": "1.0.0-rc.15",
-        "@rolldown/binding-darwin-x64": "1.0.0-rc.15",
-        "@rolldown/binding-freebsd-x64": "1.0.0-rc.15",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.15",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.15",
-        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.15",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.15",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.15",
-        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.15",
-        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.15",
-        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.15",
-        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.15",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.15",
-        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.15"
+        "@rolldown/binding-android-arm64": "1.0.0-rc.17",
+        "@rolldown/binding-darwin-arm64": "1.0.0-rc.17",
+        "@rolldown/binding-darwin-x64": "1.0.0-rc.17",
+        "@rolldown/binding-freebsd-x64": "1.0.0-rc.17",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.17",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.17",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.17",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.17",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.17",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.17",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17"
       }
     },
     "node_modules/router": {
@@ -2206,9 +2206,9 @@
       }
     },
     "node_modules/std-env": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.0.0.tgz",
-      "integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -2327,17 +2327,17 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.0.8",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.8.tgz",
-      "integrity": "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==",
+      "version": "8.0.10",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.10.tgz",
+      "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
-        "postcss": "^8.5.8",
-        "rolldown": "1.0.0-rc.15",
-        "tinyglobby": "^0.2.15"
+        "postcss": "^8.5.10",
+        "rolldown": "1.0.0-rc.17",
+        "tinyglobby": "^0.2.16"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -2405,19 +2405,19 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.4.tgz",
-      "integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.5.tgz",
+      "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.1.4",
-        "@vitest/mocker": "4.1.4",
-        "@vitest/pretty-format": "4.1.4",
-        "@vitest/runner": "4.1.4",
-        "@vitest/snapshot": "4.1.4",
-        "@vitest/spy": "4.1.4",
-        "@vitest/utils": "4.1.4",
+        "@vitest/expect": "4.1.5",
+        "@vitest/mocker": "4.1.5",
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/runner": "4.1.5",
+        "@vitest/snapshot": "4.1.5",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
         "es-module-lexer": "^2.0.0",
         "expect-type": "^1.3.0",
         "magic-string": "^0.30.21",
@@ -2445,12 +2445,12 @@
         "@edge-runtime/vm": "*",
         "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.1.4",
-        "@vitest/browser-preview": "4.1.4",
-        "@vitest/browser-webdriverio": "4.1.4",
-        "@vitest/coverage-istanbul": "4.1.4",
-        "@vitest/coverage-v8": "4.1.4",
-        "@vitest/ui": "4.1.4",
+        "@vitest/browser-playwright": "4.1.5",
+        "@vitest/browser-preview": "4.1.5",
+        "@vitest/browser-webdriverio": "4.1.5",
+        "@vitest/coverage-istanbul": "4.1.5",
+        "@vitest/coverage-v8": "4.1.5",
+        "@vitest/ui": "4.1.5",
         "happy-dom": "*",
         "jsdom": "*",
         "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"

--- a/mcp-server/scripts/try-collections.ts
+++ b/mcp-server/scripts/try-collections.ts
@@ -2,13 +2,24 @@ import { collectionsTool } from "../src/tools/collections.js";
 
 const arg = process.argv[2];
 if (!arg) {
-  console.error("Usage: npx tsx scripts/try-collections.ts <placeId>[,<placeId>,...]");
-  console.error("Example: npx tsx scripts/try-collections.ts 33");
-  console.error("Example: npx tsx scripts/try-collections.ts 33,325");
+  console.error("Usage:");
+  console.error("  npx tsx scripts/try-collections.ts Alabama          # Search by place name");
+  console.error("  npx tsx scripts/try-collections.ts --ids 33         # Filter by internal place IDs");
+  console.error("  npx tsx scripts/try-collections.ts --ids 33,325     # Multiple internal IDs");
   process.exit(1);
 }
 
-const placeIds = arg.split(",").map((s) => parseInt(s.trim(), 10));
+let result;
+if (arg === "--ids") {
+  const idsArg = process.argv[3];
+  if (!idsArg) {
+    console.error("Provide comma-separated place IDs after --ids");
+    process.exit(1);
+  }
+  const placeIds = idsArg.split(",").map((s) => parseInt(s.trim(), 10));
+  result = await collectionsTool({ placeIds });
+} else {
+  result = await collectionsTool({ query: arg });
+}
 
-const result = await collectionsTool({ placeIds });
 console.log(JSON.stringify(result, null, 2));

--- a/mcp-server/scripts/try-collections.ts
+++ b/mcp-server/scripts/try-collections.ts
@@ -1,0 +1,14 @@
+import { collectionsTool } from "../src/tools/collections.js";
+
+const arg = process.argv[2];
+if (!arg) {
+  console.error("Usage: npx tsx scripts/try-collections.ts <placeId>[,<placeId>,...]");
+  console.error("Example: npx tsx scripts/try-collections.ts 33");
+  console.error("Example: npx tsx scripts/try-collections.ts 33,325");
+  process.exit(1);
+}
+
+const placeIds = arg.split(",").map((s) => parseInt(s.trim(), 10));
+
+const result = await collectionsTool({ placeIds });
+console.log(JSON.stringify(result, null, 2));

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -9,6 +9,7 @@ import { placesTool, placesToolSchema, type PlacesToolInput } from "./tools/plac
 import { loginTool, loginToolSchema, type LoginToolInput } from "./tools/login.js";
 import { logoutTool, logoutToolSchema, type LogoutToolInput } from "./tools/logout.js";
 import { authStatusTool, authStatusToolSchema, type AuthStatusToolInput } from "./tools/auth-status.js";
+import { collectionsTool, collectionsToolSchema, type CollectionsToolInput } from "./tools/collections.js";
 
 const server = new Server(
   { name: "genealogy-mcp", version: "0.0.1" },
@@ -22,6 +23,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
     loginToolSchema,
     logoutToolSchema,
     authStatusToolSchema,
+    collectionsToolSchema,
   ],
 }));
 
@@ -90,6 +92,21 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
     try {
       const args = (request.params.arguments ?? {}) as unknown as AuthStatusToolInput;
       const result = await authStatusTool(args);
+      return {
+        content: [{ type: "text", text: JSON.stringify(result, null, 2) }]
+      };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Unknown error";
+      return {
+        content: [{ type: "text", text: JSON.stringify({ error: message }) }],
+        isError: true
+      };
+    }
+  }
+  if (request.params.name === "collections") {
+    try {
+      const args = request.params.arguments as unknown as CollectionsToolInput;
+      const result = await collectionsTool(args);
       return {
         content: [{ type: "text", text: JSON.stringify(result, null, 2) }]
       };

--- a/mcp-server/src/tools/collections.ts
+++ b/mcp-server/src/tools/collections.ts
@@ -1,0 +1,140 @@
+import { getValidToken } from "../auth/refresh.js";
+import type {
+  FSCollectionEntry,
+  FSCollectionsResponse,
+  Collection,
+  CollectionsResult,
+} from "../types/collection.js";
+
+const FS_COLLECTIONS_URL =
+  "https://www.familysearch.org/service/search/hr/v2/collections";
+const CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
+
+// Module-level cache for the full collections response
+let cache: {
+  token: string;
+  data: FSCollectionsResponse;
+  fetchedAt: number;
+} | null = null;
+
+/**
+ * Parse a placeId chain like "1-33" into an array of numbers [1, 33].
+ */
+export function parsePlaceIdChain(chain: string): number[] {
+  if (!chain) return [];
+  return chain
+    .split("-")
+    .map((s) => parseInt(s, 10))
+    .filter((n) => !isNaN(n));
+}
+
+/**
+ * Filter collections to those whose placeId chain contains any of the requested IDs.
+ */
+export function filterByPlaceIds(
+  collections: FSCollectionEntry[],
+  placeIds: number[]
+): FSCollectionEntry[] {
+  const requested = new Set(placeIds);
+  return collections.filter((c) => {
+    const chain = parsePlaceIdChain(c.placeId ?? "");
+    return chain.some((id) => requested.has(id));
+  });
+}
+
+/**
+ * Fetch all collections from FamilySearch (cached for 1 hour per token).
+ */
+export async function fetchAllCollections(
+  token: string
+): Promise<FSCollectionsResponse> {
+  if (
+    cache &&
+    cache.token === token &&
+    Date.now() - cache.fetchedAt < CACHE_TTL_MS
+  ) {
+    return cache.data;
+  }
+
+  const url = `${FS_COLLECTIONS_URL}?count=5000&offset=0&facets=OFF`;
+
+  const response = await fetch(url, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: "application/json",
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `FamilySearch collections API error: ${response.status} ${response.statusText}`
+    );
+  }
+
+  const data: FSCollectionsResponse = await response.json();
+
+  cache = { token, data, fetchedAt: Date.now() };
+  return data;
+}
+
+/**
+ * Clear the module-level cache (for testing).
+ */
+export function clearCollectionsCache(): void {
+  cache = null;
+}
+
+function toCollection(entry: FSCollectionEntry): Collection {
+  return {
+    id: entry.id,
+    title: entry.title,
+    dateRange: entry.coverageTemporal ?? "",
+    placeIds: parsePlaceIdChain(entry.placeId ?? ""),
+    recordCount: entry.recordCount ?? 0,
+    personCount: entry.personCount ?? 0,
+    imageCount: entry.imageCount ?? 0,
+    url: `https://www.familysearch.org/search/collection/${entry.id}`,
+  };
+}
+
+export interface CollectionsToolInput {
+  placeIds: number[];
+}
+
+export async function collectionsTool(
+  input: CollectionsToolInput
+): Promise<CollectionsResult> {
+  const token = await getValidToken();
+  const data = await fetchAllCollections(token);
+  const allCollections = data.collections ?? [];
+  const filtered = filterByPlaceIds(allCollections, input.placeIds);
+  const collections = filtered.map(toCollection);
+
+  return {
+    placeIds: input.placeIds,
+    matchingCollections: collections.length,
+    collections,
+  };
+}
+
+/**
+ * MCP Tool Schema for collections tool
+ */
+export const collectionsToolSchema = {
+  name: "collections",
+  description:
+    "List FamilySearch record collections for given place IDs, with record counts. " +
+    "Use the places tool first to get place IDs.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      placeIds: {
+        type: "array",
+        items: { type: "number" },
+        description:
+          "FamilySearch place IDs (e.g., [33, 351] for Alabama). Get these from the places tool.",
+      },
+    },
+    required: ["placeIds"],
+  },
+};

--- a/mcp-server/src/tools/collections.ts
+++ b/mcp-server/src/tools/collections.ts
@@ -1,5 +1,6 @@
 import { getValidToken } from "../auth/refresh.js";
 import type {
+  FSCollectionData,
   FSCollectionEntry,
   FSCollectionsResponse,
   Collection,
@@ -9,6 +10,8 @@ import type {
 const FS_COLLECTIONS_URL =
   "https://www.familysearch.org/service/search/hr/v2/collections";
 const CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
+const USER_AGENT =
+  "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/136.0.0.0 Safari/537.36";
 
 // Module-level cache for the full collections response
 let cache: {
@@ -18,28 +21,63 @@ let cache: {
 } | null = null;
 
 /**
- * Parse a placeId chain like "1-33" into an array of numbers [1, 33].
+ * Extract the FSCollectionData from a GEDCOMX-wrapped entry.
+ * Returns null if the entry structure is unexpected.
  */
-export function parsePlaceIdChain(chain: string): number[] {
-  if (!chain) return [];
-  return chain
-    .split("-")
-    .map((s) => parseInt(s, 10))
-    .filter((n) => !isNaN(n));
+function unwrapEntry(entry: FSCollectionEntry): FSCollectionData | null {
+  const collections = entry.content?.gedcomx?.collections;
+  if (!collections || collections.length === 0) return null;
+  return collections[0];
 }
 
 /**
- * Filter collections to those whose placeId chain contains any of the requested IDs.
+ * Get the place IDs from a collection's searchMetadata.
+ */
+function getPlaceIds(data: FSCollectionData): number[] {
+  return data.searchMetadata?.[0]?.placeIds ?? [];
+}
+
+/**
+ * Filter entries to those whose searchMetadata placeIds overlap with the requested set.
  */
 export function filterByPlaceIds(
-  collections: FSCollectionEntry[],
+  entries: FSCollectionEntry[],
   placeIds: number[]
-): FSCollectionEntry[] {
+): FSCollectionData[] {
   const requested = new Set(placeIds);
-  return collections.filter((c) => {
-    const chain = parsePlaceIdChain(c.placeId ?? "");
-    return chain.some((id) => requested.has(id));
-  });
+  const results: FSCollectionData[] = [];
+
+  for (const entry of entries) {
+    const data = unwrapEntry(entry);
+    if (!data) continue;
+    const entryPlaceIds = getPlaceIds(data);
+    if (entryPlaceIds.some((id) => requested.has(id))) {
+      results.push(data);
+    }
+  }
+
+  return results;
+}
+
+/**
+ * Filter entries whose title contains the query string (case-insensitive).
+ */
+export function filterByQuery(
+  entries: FSCollectionEntry[],
+  query: string
+): FSCollectionData[] {
+  const lowerQuery = query.toLowerCase();
+  const results: FSCollectionData[] = [];
+
+  for (const entry of entries) {
+    const data = unwrapEntry(entry);
+    if (!data) continue;
+    if (data.title.toLowerCase().includes(lowerQuery)) {
+      results.push(data);
+    }
+  }
+
+  return results;
 }
 
 /**
@@ -62,6 +100,7 @@ export async function fetchAllCollections(
     headers: {
       Authorization: `Bearer ${token}`,
       Accept: "application/json",
+      "User-Agent": USER_AGENT,
     },
   });
 
@@ -84,34 +123,67 @@ export function clearCollectionsCache(): void {
   cache = null;
 }
 
-function toCollection(entry: FSCollectionEntry): Collection {
+/**
+ * Get a count from the content array by resourceType suffix.
+ */
+function getCount(data: FSCollectionData, typeSuffix: string): number {
+  const entry = data.content?.find((c) => c.resourceType.endsWith(typeSuffix));
+  return entry?.count ?? 0;
+}
+
+function toCollection(data: FSCollectionData): Collection {
+  const meta = data.searchMetadata?.[0];
+  const startYear = meta?.startYear;
+  const endYear = meta?.endYear;
+  const dateRange =
+    startYear != null && endYear != null
+      ? `${startYear}-${endYear}`
+      : startYear != null
+        ? `${startYear}`
+        : "";
+
   return {
-    id: entry.id,
-    title: entry.title,
-    dateRange: entry.coverageTemporal ?? "",
-    placeIds: parsePlaceIdChain(entry.placeId ?? ""),
-    recordCount: entry.recordCount ?? 0,
-    personCount: entry.personCount ?? 0,
-    imageCount: entry.imageCount ?? 0,
-    url: `https://www.familysearch.org/search/collection/${entry.id}`,
+    id: data.id,
+    title: data.title,
+    dateRange,
+    placeIds: getPlaceIds(data),
+    recordCount: getCount(data, "/Record"),
+    personCount: getCount(data, "/Person"),
+    imageCount: meta?.imageCount ?? 0,
+    url: `https://www.familysearch.org/search/collection/${data.id}`,
   };
 }
 
 export interface CollectionsToolInput {
-  placeIds: number[];
+  query?: string;
+  placeIds?: number[];
 }
 
 export async function collectionsTool(
   input: CollectionsToolInput
 ): Promise<CollectionsResult> {
+  if (!input.query && (!input.placeIds || input.placeIds.length === 0)) {
+    throw new Error(
+      "Provide either a query (place name like \"Alabama\") or placeIds (internal collection IDs like [33])."
+    );
+  }
+
   const token = await getValidToken();
   const data = await fetchAllCollections(token);
-  const allCollections = data.collections ?? [];
-  const filtered = filterByPlaceIds(allCollections, input.placeIds);
+  const entries = data.entries ?? [];
+
+  let filtered: FSCollectionData[];
+  if (input.query) {
+    filtered = filterByQuery(entries, input.query);
+  } else {
+    filtered = filterByPlaceIds(entries, input.placeIds!);
+  }
+
   const collections = filtered.map(toCollection);
 
   return {
-    placeIds: input.placeIds,
+    ...(input.query ? { query: input.query } : {}),
+    ...(input.placeIds ? { placeIds: input.placeIds } : {}),
     matchingCollections: collections.length,
     collections,
   };
@@ -123,18 +195,25 @@ export async function collectionsTool(
 export const collectionsToolSchema = {
   name: "collections",
   description:
-    "List FamilySearch record collections for given place IDs, with record counts. " +
-    "Use the places tool first to get place IDs.",
+    "List FamilySearch record collections for a place, with record counts. " +
+    "Pass a place name as query (e.g., \"Alabama\") to search collection titles. " +
+    "Requires authentication — call the login tool first if not logged in.",
   inputSchema: {
     type: "object",
     properties: {
+      query: {
+        type: "string",
+        description:
+          "Place name to search for in collection titles (e.g., \"Alabama\", \"England\"). " +
+          "This is the recommended parameter — use the places tool first to disambiguate if needed.",
+      },
       placeIds: {
         type: "array",
         items: { type: "number" },
         description:
-          "FamilySearch place IDs (e.g., [33, 351] for Alabama). Get these from the places tool.",
+          "Internal FamilySearch collection place IDs. These are NOT the same as " +
+          "place IDs from the places tool. Only use if you know the internal IDs.",
       },
     },
-    required: ["placeIds"],
   },
 };

--- a/mcp-server/src/types/collection.ts
+++ b/mcp-server/src/types/collection.ts
@@ -1,21 +1,43 @@
 // FamilySearch Collections API Response Types
 // GET https://www.familysearch.org/service/search/hr/v2/collections
 
-export interface FSCollectionEntry {
+export interface FSContentCount {
+  completeness?: number;
+  count: number;
+  resourceType: string;
+}
+
+export interface FSSearchMetadata {
+  imageCount?: number;
+  recordCount?: number;
+  lastUpdated?: number;
+  typeFacet?: string;
+  startYear?: number;
+  endYear?: number;
+  region?: string;
+  placeIds?: number[];
+}
+
+export interface FSCollectionData {
   id: string;
   title: string;
-  collectionType?: string;
-  recordCount?: number;
-  personCount?: number;
-  imageCount?: number;
-  placeId?: string; // chain like "1-33"
-  coverageSpatial?: string;
-  coverageTemporal?: string;
+  content?: FSContentCount[];
+  searchMetadata?: FSSearchMetadata[];
+}
+
+export interface FSCollectionEntry {
+  content?: {
+    gedcomx?: {
+      collections?: FSCollectionData[];
+      id?: string;
+    };
+  };
 }
 
 export interface FSCollectionsResponse {
-  collections?: FSCollectionEntry[];
-  total?: number;
+  results?: number;
+  index?: number;
+  entries?: FSCollectionEntry[];
 }
 
 // Tool Output Types
@@ -32,7 +54,8 @@ export interface Collection {
 }
 
 export interface CollectionsResult {
-  placeIds: number[];
+  query?: string;
+  placeIds?: number[];
   matchingCollections: number;
   collections: Collection[];
 }

--- a/mcp-server/src/types/collection.ts
+++ b/mcp-server/src/types/collection.ts
@@ -1,0 +1,38 @@
+// FamilySearch Collections API Response Types
+// GET https://www.familysearch.org/service/search/hr/v2/collections
+
+export interface FSCollectionEntry {
+  id: string;
+  title: string;
+  collectionType?: string;
+  recordCount?: number;
+  personCount?: number;
+  imageCount?: number;
+  placeId?: string; // chain like "1-33"
+  coverageSpatial?: string;
+  coverageTemporal?: string;
+}
+
+export interface FSCollectionsResponse {
+  collections?: FSCollectionEntry[];
+  total?: number;
+}
+
+// Tool Output Types
+
+export interface Collection {
+  id: string;
+  title: string;
+  dateRange: string;
+  placeIds: number[];
+  recordCount: number;
+  personCount: number;
+  imageCount: number;
+  url: string;
+}
+
+export interface CollectionsResult {
+  placeIds: number[];
+  matchingCollections: number;
+  collections: Collection[];
+}

--- a/mcp-server/tests/tools/collections.test.ts
+++ b/mcp-server/tests/tools/collections.test.ts
@@ -6,8 +6,8 @@ vi.mock("../../src/auth/refresh.js", () => ({
 
 import {
   collectionsTool,
-  parsePlaceIdChain,
   filterByPlaceIds,
+  filterByQuery,
   fetchAllCollections,
   clearCollectionsCache,
 } from "../../src/tools/collections.js";
@@ -19,6 +19,45 @@ const mockedGetValidToken = vi.mocked(getValidToken);
 // Mock fetch globally
 const mockFetch = vi.fn();
 vi.stubGlobal("fetch", mockFetch);
+
+// Helper to build a GEDCOMX-wrapped entry matching the real API shape
+function makeEntry(opts: {
+  id: string;
+  title: string;
+  placeIds: number[];
+  recordCount?: number;
+  personCount?: number;
+  imageCount?: number;
+  startYear?: number;
+  endYear?: number;
+}): FSCollectionEntry {
+  return {
+    content: {
+      gedcomx: {
+        collections: [
+          {
+            id: opts.id,
+            title: opts.title,
+            content: [
+              { count: opts.recordCount ?? 0, resourceType: "http://gedcomx.org/Record" },
+              { count: opts.personCount ?? 0, resourceType: "http://gedcomx.org/Person" },
+              { count: opts.imageCount ?? 0, resourceType: "http://gedcomx.org/DigitalArtifact#FamilySearch" },
+            ],
+            searchMetadata: [
+              {
+                imageCount: opts.imageCount ?? 0,
+                recordCount: opts.recordCount ?? 0,
+                startYear: opts.startYear,
+                endYear: opts.endYear,
+                placeIds: opts.placeIds,
+              },
+            ],
+          },
+        ],
+      },
+    },
+  };
+}
 
 beforeEach(() => {
   mockFetch.mockReset();
@@ -32,53 +71,98 @@ afterEach(() => {
 
 // Test fixtures
 const mockApiResponse: FSCollectionsResponse = {
-  collections: [
-    {
+  results: 3,
+  entries: [
+    makeEntry({
       id: "1234",
       title: "Alabama, County Marriages, 1809-1950",
+      placeIds: [1, 33],
       recordCount: 524000,
       personCount: 1048000,
       imageCount: 120000,
-      placeId: "1-33",
-      coverageTemporal: "1809-1950",
-    },
-    {
+      startYear: 1809,
+      endYear: 1950,
+    }),
+    makeEntry({
       id: "5678",
       title: "England, Births and Christenings, 1538-1975",
+      placeIds: [1, 325],
       recordCount: 300000,
       personCount: 300000,
       imageCount: 0,
-      placeId: "1-325",
-      coverageTemporal: "1538-1975",
-    },
-    {
+      startYear: 1538,
+      endYear: 1975,
+    }),
+    makeEntry({
       id: "9999",
       title: "United States Federal Census, 1790-1950",
+      placeIds: [1],
       recordCount: 1000000,
       personCount: 2000000,
       imageCount: 500000,
-      placeId: "1",
-      coverageTemporal: "1790-1950",
-    },
+      startYear: 1790,
+      endYear: 1950,
+    }),
   ],
-  total: 3,
 };
 
-describe("parsePlaceIdChain", () => {
-  it("parses a chain like '1-33' into [1, 33]", () => {
-    expect(parsePlaceIdChain("1-33")).toEqual([1, 33]);
+describe("collectionsTool with query", () => {
+  it("returns collections matching a place name query", async () => {
+    mockedGetValidToken.mockResolvedValueOnce("test-token");
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockApiResponse,
+    });
+
+    const result = await collectionsTool({ query: "Alabama" });
+
+    expect(result.query).toBe("Alabama");
+    expect(result.placeIds).toBeUndefined();
+    expect(result.matchingCollections).toBe(1);
+    expect(result.collections[0].id).toBe("1234");
   });
 
-  it("parses a single ID", () => {
-    expect(parsePlaceIdChain("1")).toEqual([1]);
+  it("query matching is case-insensitive", async () => {
+    mockedGetValidToken.mockResolvedValueOnce("test-token");
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockApiResponse,
+    });
+
+    const result = await collectionsTool({ query: "alabama" });
+
+    expect(result.matchingCollections).toBe(1);
+    expect(result.collections[0].id).toBe("1234");
   });
 
-  it("returns empty array for empty string", () => {
-    expect(parsePlaceIdChain("")).toEqual([]);
+  it("returns empty array when query matches no titles", async () => {
+    mockedGetValidToken.mockResolvedValueOnce("test-token");
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockApiResponse,
+    });
+
+    const result = await collectionsTool({ query: "Narnia" });
+
+    expect(result.matchingCollections).toBe(0);
+    expect(result.collections).toEqual([]);
+  });
+
+  it("query matches anywhere in the title", async () => {
+    mockedGetValidToken.mockResolvedValueOnce("test-token");
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockApiResponse,
+    });
+
+    const result = await collectionsTool({ query: "Census" });
+
+    expect(result.matchingCollections).toBe(1);
+    expect(result.collections[0].id).toBe("9999");
   });
 });
 
-describe("collectionsTool", () => {
+describe("collectionsTool with placeIds", () => {
   it("returns collections matching a single place ID", async () => {
     mockedGetValidToken.mockResolvedValueOnce("test-token");
     mockFetch.mockResolvedValueOnce({
@@ -89,10 +173,9 @@ describe("collectionsTool", () => {
     const result = await collectionsTool({ placeIds: [33] });
 
     expect(result.placeIds).toEqual([33]);
+    expect(result.query).toBeUndefined();
     expect(result.matchingCollections).toBe(1);
-    expect(result.collections).toHaveLength(1);
     expect(result.collections[0].id).toBe("1234");
-    expect(result.collections[0].title).toBe("Alabama, County Marriages, 1809-1950");
   });
 
   it("returns collections matching multiple place IDs", async () => {
@@ -106,7 +189,6 @@ describe("collectionsTool", () => {
 
     expect(result.placeIds).toEqual([33, 325]);
     expect(result.matchingCollections).toBe(2);
-    expect(result.collections).toHaveLength(2);
     const ids = result.collections.map((c) => c.id);
     expect(ids).toContain("1234");
     expect(ids).toContain("5678");
@@ -121,17 +203,41 @@ describe("collectionsTool", () => {
 
     const result = await collectionsTool({ placeIds: [999999] });
 
-    expect(result.placeIds).toEqual([999999]);
     expect(result.matchingCollections).toBe(0);
     expect(result.collections).toEqual([]);
   });
 
+  it("filters correctly against placeIds in searchMetadata", async () => {
+    mockedGetValidToken.mockResolvedValueOnce("test-token");
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        results: 3,
+        entries: [
+          makeEntry({ id: "a", title: "A", placeIds: [1, 33, 500] }),
+          makeEntry({ id: "b", title: "B", placeIds: [1, 44] }),
+          makeEntry({ id: "c", title: "C", placeIds: [33] }),
+        ],
+      }),
+    });
+
+    const result = await collectionsTool({ placeIds: [33] });
+
+    expect(result.matchingCollections).toBe(2);
+    const ids = result.collections.map((c) => c.id);
+    expect(ids).toContain("a");
+    expect(ids).toContain("c");
+    expect(ids).not.toContain("b");
+  });
+});
+
+describe("collectionsTool error handling", () => {
   it("throws auth error when not authenticated", async () => {
     mockedGetValidToken.mockRejectedValueOnce(
       new Error("User is not logged in to FamilySearch. Call the login tool to authenticate.")
     );
 
-    await expect(collectionsTool({ placeIds: [33] })).rejects.toThrow(
+    await expect(collectionsTool({ query: "Alabama" })).rejects.toThrow(
       "User is not logged in to FamilySearch. Call the login tool to authenticate."
     );
     expect(mockFetch).not.toHaveBeenCalled();
@@ -145,7 +251,7 @@ describe("collectionsTool", () => {
       statusText: "Internal Server Error",
     });
 
-    await expect(collectionsTool({ placeIds: [33] })).rejects.toThrow(
+    await expect(collectionsTool({ query: "Alabama" })).rejects.toThrow(
       "FamilySearch collections API error: 500 Internal Server Error"
     );
   });
@@ -157,55 +263,42 @@ describe("collectionsTool", () => {
       json: async () => ({}),
     });
 
-    const result = await collectionsTool({ placeIds: [33] });
+    const result = await collectionsTool({ query: "Alabama" });
 
     expect(result.matchingCollections).toBe(0);
     expect(result.collections).toEqual([]);
   });
 
-  it("filters correctly against placeId chains", async () => {
-    mockedGetValidToken.mockResolvedValueOnce("test-token");
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({
-        collections: [
-          { id: "a", title: "A", placeId: "1-33-500", recordCount: 10 },
-          { id: "b", title: "B", placeId: "1-44", recordCount: 20 },
-          { id: "c", title: "C", placeId: "33", recordCount: 30 },
-        ],
-      }),
-    });
-
-    const result = await collectionsTool({ placeIds: [33] });
-
-    // Should match "a" (chain contains 33) and "c" (chain is 33), but not "b"
-    expect(result.matchingCollections).toBe(2);
-    const ids = result.collections.map((c) => c.id);
-    expect(ids).toContain("a");
-    expect(ids).toContain("c");
-    expect(ids).not.toContain("b");
+  it("throws when neither query nor placeIds provided", async () => {
+    await expect(collectionsTool({})).rejects.toThrow(
+      "Provide either a query"
+    );
   });
+});
 
+describe("collectionsTool field mapping", () => {
   it("maps API response fields to Collection shape", async () => {
     mockedGetValidToken.mockResolvedValueOnce("test-token");
     mockFetch.mockResolvedValueOnce({
       ok: true,
       json: async () => ({
-        collections: [
-          {
+        results: 1,
+        entries: [
+          makeEntry({
             id: "1234",
             title: "Alabama, County Marriages, 1809-1950",
+            placeIds: [1, 33],
             recordCount: 524000,
             personCount: 1048000,
             imageCount: 120000,
-            placeId: "1-33",
-            coverageTemporal: "1809-1950",
-          },
+            startYear: 1809,
+            endYear: 1950,
+          }),
         ],
       }),
     });
 
-    const result = await collectionsTool({ placeIds: [33] });
+    const result = await collectionsTool({ query: "Alabama" });
 
     expect(result.collections[0]).toEqual({
       id: "1234",

--- a/mcp-server/tests/tools/collections.test.ts
+++ b/mcp-server/tests/tools/collections.test.ts
@@ -1,0 +1,221 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("../../src/auth/refresh.js", () => ({
+  getValidToken: vi.fn(),
+}));
+
+import {
+  collectionsTool,
+  parsePlaceIdChain,
+  filterByPlaceIds,
+  fetchAllCollections,
+  clearCollectionsCache,
+} from "../../src/tools/collections.js";
+import { getValidToken } from "../../src/auth/refresh.js";
+import type { FSCollectionEntry, FSCollectionsResponse } from "../../src/types/collection.js";
+
+const mockedGetValidToken = vi.mocked(getValidToken);
+
+// Mock fetch globally
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+beforeEach(() => {
+  mockFetch.mockReset();
+  mockedGetValidToken.mockReset();
+  clearCollectionsCache();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// Test fixtures
+const mockApiResponse: FSCollectionsResponse = {
+  collections: [
+    {
+      id: "1234",
+      title: "Alabama, County Marriages, 1809-1950",
+      recordCount: 524000,
+      personCount: 1048000,
+      imageCount: 120000,
+      placeId: "1-33",
+      coverageTemporal: "1809-1950",
+    },
+    {
+      id: "5678",
+      title: "England, Births and Christenings, 1538-1975",
+      recordCount: 300000,
+      personCount: 300000,
+      imageCount: 0,
+      placeId: "1-325",
+      coverageTemporal: "1538-1975",
+    },
+    {
+      id: "9999",
+      title: "United States Federal Census, 1790-1950",
+      recordCount: 1000000,
+      personCount: 2000000,
+      imageCount: 500000,
+      placeId: "1",
+      coverageTemporal: "1790-1950",
+    },
+  ],
+  total: 3,
+};
+
+describe("parsePlaceIdChain", () => {
+  it("parses a chain like '1-33' into [1, 33]", () => {
+    expect(parsePlaceIdChain("1-33")).toEqual([1, 33]);
+  });
+
+  it("parses a single ID", () => {
+    expect(parsePlaceIdChain("1")).toEqual([1]);
+  });
+
+  it("returns empty array for empty string", () => {
+    expect(parsePlaceIdChain("")).toEqual([]);
+  });
+});
+
+describe("collectionsTool", () => {
+  it("returns collections matching a single place ID", async () => {
+    mockedGetValidToken.mockResolvedValueOnce("test-token");
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockApiResponse,
+    });
+
+    const result = await collectionsTool({ placeIds: [33] });
+
+    expect(result.placeIds).toEqual([33]);
+    expect(result.matchingCollections).toBe(1);
+    expect(result.collections).toHaveLength(1);
+    expect(result.collections[0].id).toBe("1234");
+    expect(result.collections[0].title).toBe("Alabama, County Marriages, 1809-1950");
+  });
+
+  it("returns collections matching multiple place IDs", async () => {
+    mockedGetValidToken.mockResolvedValueOnce("test-token");
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockApiResponse,
+    });
+
+    const result = await collectionsTool({ placeIds: [33, 325] });
+
+    expect(result.placeIds).toEqual([33, 325]);
+    expect(result.matchingCollections).toBe(2);
+    expect(result.collections).toHaveLength(2);
+    const ids = result.collections.map((c) => c.id);
+    expect(ids).toContain("1234");
+    expect(ids).toContain("5678");
+  });
+
+  it("returns empty array when no collections match", async () => {
+    mockedGetValidToken.mockResolvedValueOnce("test-token");
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockApiResponse,
+    });
+
+    const result = await collectionsTool({ placeIds: [999999] });
+
+    expect(result.placeIds).toEqual([999999]);
+    expect(result.matchingCollections).toBe(0);
+    expect(result.collections).toEqual([]);
+  });
+
+  it("throws auth error when not authenticated", async () => {
+    mockedGetValidToken.mockRejectedValueOnce(
+      new Error("User is not logged in to FamilySearch. Call the login tool to authenticate.")
+    );
+
+    await expect(collectionsTool({ placeIds: [33] })).rejects.toThrow(
+      "User is not logged in to FamilySearch. Call the login tool to authenticate."
+    );
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("throws on non-OK API response", async () => {
+    mockedGetValidToken.mockResolvedValueOnce("test-token");
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      statusText: "Internal Server Error",
+    });
+
+    await expect(collectionsTool({ placeIds: [33] })).rejects.toThrow(
+      "FamilySearch collections API error: 500 Internal Server Error"
+    );
+  });
+
+  it("handles malformed API response gracefully", async () => {
+    mockedGetValidToken.mockResolvedValueOnce("test-token");
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({}),
+    });
+
+    const result = await collectionsTool({ placeIds: [33] });
+
+    expect(result.matchingCollections).toBe(0);
+    expect(result.collections).toEqual([]);
+  });
+
+  it("filters correctly against placeId chains", async () => {
+    mockedGetValidToken.mockResolvedValueOnce("test-token");
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        collections: [
+          { id: "a", title: "A", placeId: "1-33-500", recordCount: 10 },
+          { id: "b", title: "B", placeId: "1-44", recordCount: 20 },
+          { id: "c", title: "C", placeId: "33", recordCount: 30 },
+        ],
+      }),
+    });
+
+    const result = await collectionsTool({ placeIds: [33] });
+
+    // Should match "a" (chain contains 33) and "c" (chain is 33), but not "b"
+    expect(result.matchingCollections).toBe(2);
+    const ids = result.collections.map((c) => c.id);
+    expect(ids).toContain("a");
+    expect(ids).toContain("c");
+    expect(ids).not.toContain("b");
+  });
+
+  it("maps API response fields to Collection shape", async () => {
+    mockedGetValidToken.mockResolvedValueOnce("test-token");
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        collections: [
+          {
+            id: "1234",
+            title: "Alabama, County Marriages, 1809-1950",
+            recordCount: 524000,
+            personCount: 1048000,
+            imageCount: 120000,
+            placeId: "1-33",
+            coverageTemporal: "1809-1950",
+          },
+        ],
+      }),
+    });
+
+    const result = await collectionsTool({ placeIds: [33] });
+
+    expect(result.collections[0]).toEqual({
+      id: "1234",
+      title: "Alabama, County Marriages, 1809-1950",
+      dateRange: "1809-1950",
+      placeIds: [1, 33],
+      recordCount: 524000,
+      personCount: 1048000,
+      imageCount: 120000,
+      url: "https://www.familysearch.org/search/collection/1234",
+    });
+  });
+});


### PR DESCRIPTION
Add the `collections` MCP tool, which returns FamilySearch record collections
  for a place with record/person/image counts. Authenticated via the existing
  `getValidToken()` entry point — no new token plumbing.

  - **Primary input is `query`** (place name like `"Alabama"`), filtering by
    collection title. The Places API and Collections API use **different place
    ID systems** (Alabama is 351 in Places, 33 in Collections), so passing IDs
    between the two tools is unsafe — `query` works around this. `placeIds`
    remains available for advanced use.
  - Calls the lower-level `/service/search/hr/v2/collections` endpoint to get
    ID systems** (Alabama is 351 in Places, 33 in Collections), so passing IDs
    between the two tools is unsafe — `query` works around this. `placeIds`
    remains available for advanced use.
  - Calls the lower-level `/service/search/hr/v2/collections` endpoint to get
    all collections + counts in a single request (the platform API would have
    required N+1 calls for counts).
  - Sets a browser-like `User-Agent` to bypass FamilySearch's WAF
    (Imperva/Incapsula), which 403s requests without one.
  - Caches the full collection list for 1 hour, keyed on access token.

  ## Files

  - `mcp-server/src/tools/collections.ts` — tool implementation
  - `mcp-server/src/types/collection.ts` — API + output types
  - `mcp-server/src/index.ts` — tool registration
  - `mcp-server/tests/tools/collections.test.ts` — 13 vitest cases
  - `mcp-server/scripts/try-collections.ts` — direct smoke-test script
  - `docs/specs/collections-tool-spec.md` — spec
  - `docs/collections-tool-testing-guide.md` — layered manual testing playbook
  - `CLAUDE.md` — updated with the new tool