### PR TITLE
Update README, CLAUDE, PROJECT-GOAL for shipped collections tool

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -182,6 +182,41 @@ Commands in `plugin/commands/<name>.md` give users explicit triggers
 for skills. They're shortcuts users can type instead of describing
 what they want.
 
+## Code reuse
+
+Before writing new logic, check whether something equivalent already
+exists. If it does, call it. If it's close but not quite, extend the
+existing function (add a parameter, widen the return type) rather
+than create a parallel copy. If you find yourself pasting code from
+one tool into another, stop — lift the shared piece into a proper
+module instead.
+
+Where to look first:
+
+- **`src/auth/`** — `getValidToken()` is the only correct way to
+  read a FamilySearch access token. Don't re-implement token
+  loading, expiry checks, or refresh. The same applies to anything
+  else here (PKCE, config loading, token storage).
+- **`src/auth/config.ts`** — `loadConfig()` / `getClientId()` is
+  the single source for app config. New provider keys go on
+  `AppConfig` in `src/types/auth.ts`, not into env vars or
+  ad-hoc files.
+- **`src/types/`** — shared API response and tool I/O types live
+  here. If a second tool touches the same upstream API, put the
+  response shape here so both stay in sync.
+- **Exported helpers in `src/tools/`** — for example, `places.ts`
+  exports `searchPlace`, `getPlaceById`, and `getWikipediaSummary`,
+  and `collections.ts` exports `fetchAllCollections`,
+  `filterByQuery`, and `filterByPlaceIds`. A new tool that needs
+  place lookup or Wikipedia enrichment should call these, not
+  re-fetch.
+
+Soft caveat: don't pre-extract for hypothetical reuse. Wait for the
+second concrete need before factoring code into a shared module —
+premature abstractions calcify around the first caller's assumptions
+and make the next use case harder to fit. Two near-duplicates is the
+signal to consolidate; one isn't.
+
 ## How to add a new feature
 
 Example: adding a "list providers" feature.

--- a/PROJECT-GOAL.md
+++ b/PROJECT-GOAL.md
@@ -1,39 +1,59 @@
 # Project Goal — FamilySearch MCP Server
 
-This file tracks the implementation goal and progress. For detailed research
-(OAuth patterns, full API documentation, risk analysis), see `local/project-goal.md`.
+## What this project is
+
+A two-piece system that lets Claude do FamilySearch genealogy
+research from inside Cowork:
+
+1. **An MCP server** (TypeScript, `mcp-server/`) that runs on the
+   host and wraps FamilySearch + Wikipedia APIs as MCP tools.
+2. **A Cowork plugin** (`plugin/`) with skills, slash commands, and
+   templates that teach Claude when and how to use those tools.
+
+The two are coupled but isolated. Cowork's sandboxed VM has
+restricted egress, so anything that calls the network has to live
+on the host (the MCP server). Skills inside the VM call host tools
+through structured JSON over MCP — they never share files or
+runtime code with the server.
+
+For full architecture, conventions, and the developer guide, see
+`CLAUDE.md`. For the long-form research and design history, see
+`local/project-goal.md` (gitignored).
 
 ## Goal
 
-Build an MCP server that gives Claude access to FamilySearch genealogy data
-through five tools:
+Expose seven FamilySearch + reference-data tools to Claude:
 
 | Tool | Purpose | Auth |
 |------|---------|------|
-| `collections` | List record collections for a geographic area | Yes |
-| `places` | Place details from FamilySearch + Wikipedia | No |
+| `wikipedia_search` | Wikipedia article summary | None |
+| `places` | FamilySearch place data + Wikipedia enrichment | None |
+| `login` / `logout` / `auth_status` | OAuth 2.0 + PKCE session management | — |
+| `collections` | Record collections for a place | Yes |
 | `search` | Search historical records | Yes |
-| `tree` | Read from shared Family Tree | Yes |
+| `tree` | Read from shared FamilySearch Family Tree | Yes |
 | `cets` | Read/write personal user trees | Yes |
 
 ## Current Focus
 
-**Phase 1 — Authentication**. Implement the OAuth login flow using the
-FamilySearch dev key, then build authenticated tools (`collections`, `search`,
-`tree`, `cets`).
+**Phase 3 — Authenticated read tools.** With OAuth and `collections`
+shipped, the next two tools are `search` (historical records) and
+`tree` (shared Family Tree). `cets` (personal trees, includes write
+operations) follows.
 
 ## Key API Endpoints
 
 ```
-# Collections (requires auth — lower-level API)
-GET https://www.familysearch.org/service/search/hr/v2/collections
-
-# Places (public)
+# Public
 GET https://api.familysearch.org/platform/places/search?q={query}
 GET https://api.familysearch.org/platform/places/{placeId}
-
-# Wikipedia summary (for places enrichment)
 GET https://en.wikipedia.org/api/rest_v1/page/summary/{title}
+
+# Authenticated (Bearer token)
+GET https://www.familysearch.org/service/search/hr/v2/collections
+GET https://api.familysearch.org/platform/records/personas
+GET https://api.familysearch.org/platform/tree/persons/{pid}
+GET / POST / PATCH .../platform/tree/trees/{treeId}/persons[/{personId}]
 ```
 
 ---
@@ -44,37 +64,38 @@ GET https://en.wikipedia.org/api/rest_v1/page/summary/{title}
 
 | # | Task | Status |
 |---|------|--------|
-| 1 | Register with FamilySearch developer program | Not started |
+| 1 | Register with FamilySearch developer program | **Done** |
 | 2 | Initialize TypeScript MCP server project | **Done** |
-| 3 | Create FamilySearch API client module | Not started |
+| 3 | Central FamilySearch API client module | **Skipped** (per-tool fetch chosen instead — see CLAUDE.md "Code reuse") |
 
 ### Phase 1 — Authentication
 
 | # | Task | Status |
 |---|------|--------|
-| 4 | Implement token storage | **Done** |
-| 5 | Implement OAuth login flow | **Done** |
+| 4 | Token storage | **Done** |
+| 5 | OAuth login flow with PKCE | **Done** |
 | 6 | Token refresh + register login tool | **Done** |
 
 ### Phase 2 — Public Tools
 
 | # | Task | Status |
 |---|------|--------|
-| 7 | Build `places` tool | **Done** |
+| 7 | `wikipedia_search` tool | **Done** |
+| 8 | `places` tool | **Done** |
 
 ### Phase 3 — Authenticated Tools
 
 | # | Task | Status |
 |---|------|--------|
-| 8 | Build `collections` tool | Not started |
-| 9 | Build `search` tool | Not started |
-| 10 | Build `tree` tool | Not started |
-| 11 | Build `cets` tool | Not started |
+| 9 | `collections` tool | **Done** |
+| 10 | `search` tool | Not started |
+| 11 | `tree` tool | Not started |
+| 12 | `cets` tool | Not started |
 
 ### Phase 4 — Testing & Polish
 
 | # | Task | Status |
 |---|------|--------|
-| 12 | End-to-end testing | Not started |
-| 13 | Error handling and edge cases | Not started |
-| 14 | Documentation and installation guide | Not started |
+| 13 | End-to-end testing | In progress (per-tool testing guides under `docs/`) |
+| 14 | Error handling and edge cases | In progress |
+| 15 | Documentation and installation guide | In progress (`README.md`, `CLAUDE.md`, `docs/specs/`) |

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ has to live in the server.
 
 ## What it does today
 
-The MCP server exposes five tools:
+The MCP server exposes six tools:
 
 | Tool | Purpose | Auth |
 |------|---------|------|
@@ -27,9 +27,10 @@ The MCP server exposes five tools:
 | `login` | OAuth 2.0 + PKCE login to FamilySearch | — |
 | `logout` | Clear stored FamilySearch tokens | — |
 | `auth_status` | Report current FamilySearch session state | — |
+| `collections` | FamilySearch record collections for a place | Yes |
 
-Authenticated FamilySearch tools (`collections`, `search`, `tree`,
-`cets`) are next — see `PROJECT-GOAL.md` for the roadmap.
+The remaining FamilySearch tools (`search`, `tree`, `cets`) are next —
+see `PROJECT-GOAL.md` for the roadmap.
 
 The plugin ships one working reference skill (`wiki-lookup` /
 `/wiki`) demonstrating the end-to-end pipeline.
@@ -71,6 +72,12 @@ Claude calls the `places` tool directly and reports what it learned.
 Exercises the OAuth flow. See `docs/oauth-tool-testing-guide.md` for
 getting a FamilySearch dev key and walking through the full flow.
 
+> "What FamilySearch record collections cover Alabama?"
+
+Once logged in, Claude calls the `collections` tool and reports the
+matching record collections with their record, person, and image
+counts.
+
 ## Development
 
 See [CLAUDE.md](./CLAUDE.md) for the developer guide — architecture,
@@ -95,9 +102,10 @@ ls releases/
 
 ## Project status
 
-Foundation phases complete: OAuth authentication and public tools
-(Wikipedia, FamilySearch places). Authenticated FamilySearch tools
-are next. See `PROJECT-GOAL.md` for full task progress.
+Foundation phases complete: OAuth authentication, public tools
+(Wikipedia, FamilySearch places), and the first authenticated tool
+(`collections`). The remaining authenticated tools (`search`, `tree`,
+`cets`) are next. See `PROJECT-GOAL.md` for full task progress.
 
 ## License
 


### PR DESCRIPTION
Update collections tool documentation
  - **README.md** — bumps the user-facing tool count from 5 → 6, adds
    `collections` to the tool table, adds the "What FamilySearch record
    collections cover Alabama?" example query, and updates Project
    status to reflect the first authenticated tool shipped.
  - **CLAUDE.md** — adds a new "Code reuse" section with guidance on
    calling existing helpers (`getValidToken`, `loadConfig`, exported
    tool helpers in `places.ts` and `collections.ts`) before writing
    parallel logic. Soft caveat about not pre-extracting for
    hypothetical reuse.
  - **PROJECT-GOAL.md** — structural refresh: adds a "What this project
    is" intro pointing to `CLAUDE.md` and `local/project-goal.md`,
    expands the tool table from 5 to 7 (adds `wikipedia_search` and the
    OAuth tools), updates Current Focus to "Phase 3 — Authenticated
    read tools," reorganizes Key API Endpoints into Public /
    Authenticated sections, marks the collections task **Done**, and
    renumbers Phase 3 entries.