### PR TITLE
Add external_links tool

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -181,8 +181,8 @@ external_links({ placeId: "1927089", startYear: 1880, endYear: 1950 })
 
 Filters server results so only collections whose own date range
 overlaps `[startYear, endYear]` are returned (undated wiki entries
-are included permissively). Place IDs come from the `population`
-tool — Claude should not guess them.
+are included permissively). Place IDs come from the `places` tool —
+Claude should not guess them.
 
 Returns: `place`, `totalResults`, `matchedCount`, and `results[]` with
 `url` and `linkText` only.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -167,6 +167,31 @@ cd /path/to/search-agent-tools/pop-stats-api
 uv run uvicorn api.app:app --port 8000
 ```
 
+### `external_links`
+
+Returns FamilySearch-curated third-party genealogy resource URLs
+(Ancestry, MyHeritage, FindMyPast, national archives, wiki pages,
+etc.) for a place and year range. **No auth** — wraps the public
+`/external/collections/search` endpoint. Spec:
+`docs/specs/external-links-tool-spec.md`.
+
+```typescript
+external_links({ placeId: "1927089", startYear: 1880, endYear: 1950 })
+```
+
+Filters server results so only collections whose own date range
+overlaps `[startYear, endYear]` are returned (undated wiki entries
+are included permissively). Place IDs come from the `population`
+tool — Claude should not guess them.
+
+Returns: `place`, `totalResults`, `matchedCount`, and `results[]` with
+`url` and `linkText` only.
+
+This tool is the public/no-auth counterpart to `collections`. Both
+hit the same FS WAF, so both share the same browser-style
+`User-Agent` constant. When a third tool needs the same constant,
+factor it into a shared module.
+
 ## Specced tools (not yet implemented)
 
 ### `search`

--- a/PROJECT-GOAL.md
+++ b/PROJECT-GOAL.md
@@ -22,13 +22,14 @@ For full architecture, conventions, and the developer guide, see
 
 ## Goal
 
-Expose eight FamilySearch + reference-data tools to Claude:
+Expose nine FamilySearch + reference-data tools to Claude:
 
 | Tool | Purpose | Auth |
 |------|---------|------|
 | `wikipedia_search` | Wikipedia article summary | None |
 | `places` | FamilySearch place data + Wikipedia enrichment | None |
 | `population` | Historical population data + indexed record counts | None |
+| `external_links` | FS-curated third-party genealogy URLs by place + year | None |
 | `login` / `logout` / `auth_status` | OAuth 2.0 + PKCE session management | — |
 | `collections` | Record collections for a place | Yes |
 | `search` | Search historical records | Yes |
@@ -48,6 +49,10 @@ operations) follows.
 # Public
 GET https://api.familysearch.org/platform/places/search?q={query}
 GET https://api.familysearch.org/platform/places/{placeId}
+
+# External links (public)
+GET https://www.familysearch.org/service/search/hr/external/collections/search?q.placeId={id}
+
 GET https://en.wikipedia.org/api/rest_v1/page/summary/{title}
 
 # Authenticated (Bearer token)
@@ -84,20 +89,21 @@ GET / POST / PATCH .../platform/tree/trees/{treeId}/persons[/{personId}]
 | 7 | `wikipedia_search` tool | **Done** |
 | 8 | `places` tool | **Done** |
 | 8b | `population` tool | **Done** |
+| 8c | `external_links` tool | **Done** |
 
 ### Phase 3 — Authenticated Tools
 
 | # | Task | Status |
 |---|------|--------|
-| 9 | `collections` tool | **Done** |
-| 10 | `search` tool | **Spec'd** (v2 at `docs/specs/search-tool-spec-v2.md`); implementation pending |
-| 11 | `tree` tool | Not started |
-| 12 | `cets` tool | Not started |
+| 10 | `collections` tool | **Done** |
+| 11 | `search` tool | **Spec'd** (v2 at `docs/specs/search-tool-spec-v2.md`); implementation pending |
+| 12 | `tree` tool | Not started |
+| 13 | `cets` tool | Not started |
 
 ### Phase 4 — Testing & Polish
 
 | # | Task | Status |
 |---|------|--------|
-| 13 | End-to-end testing | In progress (per-tool testing guides under `docs/`) |
-| 14 | Error handling and edge cases | In progress |
-| 15 | Documentation and installation guide | In progress (`README.md`, `CLAUDE.md`, `docs/specs/`) |
+| 14 | End-to-end testing | In progress (per-tool testing guides under `docs/`) |
+| 15 | Error handling and edge cases | In progress |
+| 16 | Documentation and installation guide | In progress (`README.md`, `CLAUDE.md`, `docs/specs/`) |

--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ The MCP server exposes seven tools:
 | `login` | OAuth 2.0 + PKCE login to FamilySearch | — |
 | `logout` | Clear stored FamilySearch tokens | — |
 | `auth_status` | Report current FamilySearch session state | — |
-| `collections` | FamilySearch record collections for a place | Yes |
+| `collections` | FamilySearch record collections for a place (with counts) | Yes |
+| `external_links` | FS-curated third-party genealogy URLs by place + year | None |
 
 The `population` tool calls the Pop Stats API — a separate FastAPI
 service that must be running on the host. It combines data from

--- a/docs/external-links-tool-testing-guide.md
+++ b/docs/external-links-tool-testing-guide.md
@@ -26,14 +26,15 @@ The typical workflow is:
 ```
 [user request: "find me genealogy resources for France 1880-1950"]
         ↓
-[population MCP server]   → place_id, place name, etc.
+places({ query: "France" })  → placeId, place name, etc.
         ↓
-[external_links]          → list of curated third-party URLs
+external_links({ placeId, startYear, endYear })
+                              → list of curated third-party URLs
 ```
 
-The population MCP server is a separate project owned by another
-teammate. Its place IDs are the input to this tool. Claude should not
-guess place IDs — it should obtain them from that tool or from the user.
+The `places` tool (sibling in this server) is the upstream source of
+place IDs. Claude should not guess place IDs — it should obtain them
+from `places` or from the user.
 
 ## Before you start
 
@@ -63,7 +64,7 @@ For manual testing, the IDs below are stable:
 | Canada | `1927164` |
 | Iceland | `1927031` |
 
-In production these come from the population MCP server.
+In production these come from the `places` tool.
 
 ---
 

--- a/docs/external-links-tool-testing-guide.md
+++ b/docs/external-links-tool-testing-guide.md
@@ -80,7 +80,7 @@ Fastest way to catch API-shape regressions or pagination bugs.
 
    ```bash
    cd mcp-server
-   npx tsx scripts/try-external-links.ts 1927089 1880 1950
+   npx tsx dev/try-external-links.ts 1927089 1880 1950
    ```
 
 2. You should see JSON with:
@@ -94,7 +94,7 @@ Fastest way to catch API-shape regressions or pagination bugs.
 3. Try a different country:
 
    ```bash
-   npx tsx scripts/try-external-links.ts 1927164 1880 1950
+   npx tsx dev/try-external-links.ts 1927164 1880 1950
    ```
 
    Should return `place: "Canada"` and `totalResults` ~470.
@@ -102,7 +102,7 @@ Fastest way to catch API-shape regressions or pagination bugs.
 4. Try the validation guard:
 
    ```bash
-   npx tsx scripts/try-external-links.ts 1927089 1950 1880
+   npx tsx dev/try-external-links.ts 1927089 1950 1880
    ```
 
    The script should fail loudly with an error mentioning `endYear must
@@ -410,7 +410,7 @@ Cowork → Claude Desktop → WSL2 → MCP server.
 | Server doesn't appear in Settings → Developer | Config edit landed in the unredirected `%APPDATA%\Claude\` path that MSIX Desktop ignores | Use the Edit Config button to open the right file |
 | `wsl.exe: command not found` in log | Desktop's MSIX sandbox can't find wsl.exe on PATH | Use full path: `"command": "C:\\Windows\\System32\\wsl.exe"` (note doubled backslashes for JSON) |
 | `Cannot find module ... build/index.js` | `--cd` path wrong, or `mcp-server/build/` doesn't exist | From WSL2: `ls /home/<you>/cowork-genealogy/mcp-server/build/index.js` |
-| `ETIMEDOUT` / `fetch failed` from the server itself | WSL2 networking issue | Verify the smoke-test script (`npx tsx scripts/try-external-links.ts ...`) works inside WSL2 first |
+| `ETIMEDOUT` / `fetch failed` from the server itself | WSL2 networking issue | Verify the smoke-test script (`npx tsx dev/try-external-links.ts ...`) works inside WSL2 first |
 
 ### When to move on
 
@@ -498,8 +498,8 @@ The same prompt returns curated URLs in Cowork on native Windows.
 |------|---------|
 | Build server | `cd mcp-server && npm run build` |
 | Run all tests | `cd mcp-server && npm test` |
-| Smoke test (France) | `cd mcp-server && npx tsx scripts/try-external-links.ts 1927089 1880 1950` |
-| Smoke test (Canada) | `cd mcp-server && npx tsx scripts/try-external-links.ts 1927164 1880 1950` |
+| Smoke test (France) | `cd mcp-server && npx tsx dev/try-external-links.ts 1927089 1880 1950` |
+| Smoke test (Canada) | `cd mcp-server && npx tsx dev/try-external-links.ts 1927164 1880 1950` |
 | Run Inspector | `cd mcp-server && npx @modelcontextprotocol/inspector node build/index.js` |
 | Reconnect in Claude Code | `/mcp` |
 | Claude Desktop config | Settings → Developer → Edit Config |

--- a/docs/external-links-tool-testing-guide.md
+++ b/docs/external-links-tool-testing-guide.md
@@ -1,0 +1,447 @@
+# External Links Tool Testing Guide
+
+This guide walks you through testing the `external_links` tool after
+it's built. Follow each layer in order. Don't skip ahead — each layer
+catches different problems.
+
+## What `external_links` does (30 seconds)
+
+The `external_links` tool returns FamilySearch-curated third-party
+genealogy resource URLs for a place and year range. You pass it a
+FamilySearch place ID plus a `[startYear, endYear]` window, and it
+returns every collection FS knows about whose date range overlaps that
+window — plus undated wiki/website resources for that place.
+
+Compared to the existing `collections` tool:
+
+- `external_links` calls the **public** `/external/collections/search`
+  endpoint — no OAuth required.
+- Its primary input is a **place ID** (numeric string, e.g. `"1927089"`
+  for France), not a place name.
+- Output is `{ url, linkText }[]` plus paging metadata — no record
+  counts, because the external endpoint doesn't expose them.
+
+The typical workflow is:
+
+```
+[user request: "find me genealogy resources for France 1880-1950"]
+        ↓
+[population MCP server]   → place_id, place name, etc.
+        ↓
+[external_links]          → list of curated third-party URLs
+```
+
+The population MCP server is a separate project owned by another
+teammate. Its place IDs are the input to this tool. Claude should not
+guess place IDs — it should obtain them from that tool or from the user.
+
+## Before you start
+
+### 1. Make sure the server builds and all tests pass
+
+```bash
+cd mcp-server
+npm run build
+npm test
+```
+
+All tests should pass (including 12 `external_links` tests). If
+anything is red, fix it first.
+
+### 2. No FamilySearch login is needed
+
+The endpoint is public. Unlike `collections`, this tool does not call
+`getValidToken()` and does not require an OAuth session.
+
+### 3. You'll need a real FamilySearch place ID
+
+For manual testing, the IDs below are stable:
+
+| Place | Place ID |
+|-------|----------|
+| France | `1927089` |
+| Canada | `1927164` |
+| Iceland | `1927031` |
+
+In production these come from the population MCP server.
+
+---
+
+## Layer 0: Smoke-Test Script
+
+**What this tests:** Does the tool function work against the live API?
+
+This bypasses the MCP harness entirely and calls the handler directly.
+Fastest way to catch API-shape regressions or pagination bugs.
+
+### Steps
+
+1. Run a populated window:
+
+   ```bash
+   cd mcp-server
+   npx tsx scripts/try-external-links.ts 1927089 1880 1950
+   ```
+
+2. You should see JSON with:
+   - `place: "France"`
+   - `totalResults` around `221` (FS's data shifts slightly over time;
+     ±10 is fine).
+   - `matchedCount` smaller than `totalResults` — collections outside
+     1880–1950 are filtered out.
+   - `results[]` — array of `{ url, linkText }` items.
+
+3. Try a different country:
+
+   ```bash
+   npx tsx scripts/try-external-links.ts 1927164 1880 1950
+   ```
+
+   Should return `place: "Canada"` and `totalResults` ~470.
+
+4. Try the validation guard:
+
+   ```bash
+   npx tsx scripts/try-external-links.ts 1927089 1950 1880
+   ```
+
+   The script should fail loudly with an error mentioning `endYear must
+   be greater than or equal to startYear`. **No network call** — the
+   guard fires inside the handler before any fetch.
+
+### What success looks like
+
+You get back structured JSON with real curated URLs. Open one or two
+in your browser to confirm they're not 404s.
+
+### What failure looks like
+
+| Symptom | Likely cause | Fix |
+|---------|--------------|-----|
+| 403 "blocked by security service" | Browser-spoofed UA missing | Verify the `USER_AGENT` constant in `src/tools/external-links.ts` matches the one in `collections.ts` (Chrome UA). |
+| `ETIMEDOUT` / `fetch failed` | Network or DNS issue | Try the live curl from the spec; if it fails too, fix WSL2 DNS or VPN. |
+| Pagination loops forever | Bad stop condition | Check the loop in `src/tools/external-links.ts` — it should bail when `offset >= totalResults` or page is empty. |
+| Output `matchedCount` is wrong | Overlap logic broken | Re-read `overlapsRange()` against the spec's "Overlap Logic" table. |
+
+### When to move on
+
+Move to Layer 1 once two different placeIds return real data and the
+validation guard fires.
+
+---
+
+## Layer 1: MCP Inspector
+
+**What this tests:** Does the tool register correctly? Does it work
+through the MCP protocol?
+
+### Start the Inspector
+
+```bash
+cd mcp-server
+npx @modelcontextprotocol/inspector node build/index.js
+```
+
+Look at the tools list. You should see **seven** tools:
+
+- `wikipedia_search`
+- `places`
+- `login`
+- `logout`
+- `auth_status`
+- `collections`
+- `external_links`
+
+If `external_links` is missing, check `src/index.ts` registration
+(import + ListTools entry + CallTool block).
+
+### Part A — Happy path
+
+Call `external_links` with:
+
+```json
+{ "placeId": "1927089", "startYear": 1880, "endYear": 1950 }
+```
+
+Expected: JSON with `place: "France"`, `totalResults: ~221`,
+`matchedCount: ~178+`, `results[]`.
+
+### Part B — Sparse window
+
+```json
+{ "placeId": "1927089", "startYear": 1700, "endYear": 1750 }
+```
+
+Expected: smaller `matchedCount`. Mostly undated wiki entries plus a
+handful of pre-1750 collections.
+
+### Part C — Validation error
+
+```json
+{ "placeId": "1927089", "startYear": 1950, "endYear": 1880 }
+```
+
+Expected: a tool error with `isError: true` and a message containing
+`endYear must be greater than or equal to startYear`.
+
+### Part D — Empty result for unknown placeId
+
+```json
+{ "placeId": "999999999", "startYear": 1880, "endYear": 1950 }
+```
+
+Expected: a *successful* response (not an error) containing
+`place: null, totalResults: 0, matchedCount: 0, results: []`.
+
+### What success looks like (Layer 1)
+
+- Tool appears in the Inspector.
+- Parameters render with their descriptions.
+- All four parts return the expected shapes.
+
+### What failure looks like
+
+| Symptom | Likely cause | Fix |
+|---------|--------------|-----|
+| Tool missing from Inspector | Not registered in `index.ts` | Check the import, ListTools array, and CallTool block. |
+| Validation error not shown clearly | Error wrapping wrong | The handler throws; the index.ts CallTool block should wrap with `isError: true`. |
+| "Unknown tool" returned | Tool name mismatch | The schema's `name` and the CallTool `if` check must both be `"external_links"`. |
+
+### When to move on
+
+Move to Layer 2 when Parts A–D all behave as expected.
+
+---
+
+## Layer 2: Claude Code as Client
+
+**What this tests:** Does Claude understand when and how to use this
+tool from natural language?
+
+### Steps
+
+1. Open a terminal and create a scratch folder:
+
+   ```bash
+   mkdir -p ~/mcp-test-scratch
+   cd ~/mcp-test-scratch
+   ```
+
+   On Windows PowerShell:
+
+   ```powershell
+   mkdir -Force $env:USERPROFILE\mcp-test-scratch
+   cd $env:USERPROFILE\mcp-test-scratch
+   ```
+
+2. Register the server with Claude Code (if not already):
+
+   ```bash
+   claude mcp add --transport stdio genealogy-dev -- node /path/to/cowork-genealogy/mcp-server/build/index.js
+   ```
+
+3. Start Claude Code (`claude`).
+
+4. Test with a natural-language prompt:
+
+   > "Find FamilySearch resource links for place ID 1927089 between
+   > 1880 and 1950."
+
+5. Watch what Claude does:
+   - Claude should call `external_links` with the three fields.
+   - Claude should present the URLs (probably summarized or grouped),
+     not dump raw JSON.
+   - Claude should not invent a place ID.
+
+6. Test a less explicit prompt:
+
+   > "I'm researching France from 1880 to 1950. The FamilySearch place
+   > ID is 1927089. What external genealogy resources are available?"
+
+   Claude should still pick `external_links` — the description mentions
+   place ID and year range explicitly.
+
+### What success looks like
+
+Claude calls the tool with correct inputs, doesn't try to guess place
+IDs, and presents the URLs in a way the user can act on.
+
+### What failure looks like
+
+- Claude doesn't pick the tool → the description doesn't match the
+  user's natural language. **Fix the description, not the user.**
+- Claude tries to invent a place ID → strengthen the "do not guess"
+  wording in the schema.
+- Claude confuses `external_links` with `collections` → tighten the
+  description to clarify they return different things (collections are
+  FS's own collections; external_links are third-party URLs FS curates).
+
+### Troubleshooting
+
+If you change the server code:
+
+1. Rebuild: `cd mcp-server && npm run build`.
+2. In Claude Code, run `/mcp` to reconnect.
+3. Try again.
+
+### When to move on
+
+Move to Layer 3 when Claude consistently uses the tool from
+natural-language prompts that mention a place ID and year range.
+
+---
+
+## Choose Your Layer 3 Order
+
+Layers 1 and 2 are platform-agnostic. Layer 3 splits by where the MCP
+server runs. Both sub-layers are required:
+
+| Your dev environment | Run first | Then |
+|----------------------|-----------|------|
+| WSL2 | Layer 3a (WSL2) | Layer 3b (Native Windows) |
+| Native Windows | Layer 3b (Native Windows) | Layer 3a (WSL2) |
+
+---
+
+## Layer 3a: Cowork via WSL2
+
+**What this tests:** Does the full pipeline work in Cowork through the
+WSL2 bridge?
+
+**Prerequisite:** Claude Desktop installed with a WSL2 MCP server entry.
+Example `claude_desktop_config.json` (Windows side):
+
+```json
+{
+  "mcpServers": {
+    "genealogy-wsl": {
+      "command": "wsl.exe",
+      "args": [
+        "-d", "Ubuntu-22.04",
+        "--cd", "/mnt/c/path/to/cowork-genealogy/mcp-server",
+        "--",
+        "/usr/bin/node",
+        "build/index.js"
+      ]
+    }
+  }
+}
+```
+
+Adjust the distro name and path. `wsl.exe -l` lists distros;
+`wsl.exe -- which node` finds the node path.
+
+### Steps
+
+1. FULLY restart Claude Desktop (system tray → right-click → Quit →
+   reopen). Closing the window is not enough.
+
+2. Open a Cowork session.
+
+3. Test:
+
+   > "Find FamilySearch external links for place ID 1927089 between
+   > 1880 and 1950."
+
+4. Verify Claude calls `external_links` and presents the URLs.
+
+### What success looks like
+
+Claude calls `external_links` and returns curated URLs, running through
+Cowork → Claude Desktop → WSL2 → MCP server.
+
+### What failure looks like
+
+- Claude doesn't see the tool → config typo or Claude Desktop wasn't
+  fully restarted.
+- `ETIMEDOUT` from the server → WSL2 networking issue; verify the
+  smoke-test script works inside WSL2 first.
+- "Cannot find module" → wrong path or `npm run build` not run inside
+  WSL2.
+
+### When to move on
+
+Move to Layer 3b once the WSL2 bridge handles a full request.
+
+---
+
+## Layer 3b: Cowork via Native Windows
+
+**What this tests:** Does the full pipeline work running natively on
+Windows?
+
+**Prerequisite:** Claude Desktop configured with a native Windows entry:
+
+```json
+{
+  "mcpServers": {
+    "genealogy-native": {
+      "command": "node",
+      "args": [
+        "C:\\path\\to\\cowork-genealogy\\mcp-server\\build\\index.js"
+      ]
+    }
+  }
+}
+```
+
+Remove or rename the WSL2 entry while testing this layer.
+
+### Steps
+
+1. Build natively:
+
+   ```powershell
+   cd C:\path\to\cowork-genealogy\mcp-server
+   npm install
+   npm run build
+   ```
+
+2. FULLY restart Claude Desktop.
+
+3. Test the same prompt as Layer 3a.
+
+### What success looks like
+
+Same results as Layer 3a, running natively on Windows.
+
+### What failure looks like
+
+| Problem | Fix |
+|---------|-----|
+| Build fails on Windows | Look for hardcoded path separators. |
+| Server crashes on startup | Check for hardcoded `~` or POSIX paths. |
+| `npx` not found in config | Use `npx.cmd` on Windows. |
+
+### You're done when
+
+The same prompt returns curated URLs in Cowork on native Windows.
+
+---
+
+## Quick Reference: Commands
+
+| What | Command |
+|------|---------|
+| Build server | `cd mcp-server && npm run build` |
+| Run all tests | `cd mcp-server && npm test` |
+| Smoke test (France) | `cd mcp-server && npx tsx scripts/try-external-links.ts 1927089 1880 1950` |
+| Smoke test (Canada) | `cd mcp-server && npx tsx scripts/try-external-links.ts 1927164 1880 1950` |
+| Run Inspector | `cd mcp-server && npx @modelcontextprotocol/inspector node build/index.js` |
+| Reconnect in Claude Code | `/mcp` |
+| Claude Desktop config | Settings → Developer → Edit Config |
+| Claude Desktop logs | Settings → Developer → View Logs |
+
+---
+
+## Summary: What Each Layer Catches
+
+| Layer | What it tests | Bugs it catches |
+|-------|---------------|-----------------|
+| 0 — Smoke script | Direct function call vs live API | API shape mismatches, WAF blocks, pagination bugs |
+| 1 — Inspector | Tool through MCP protocol | Schema errors, validation routing, error-message wording |
+| 2 — Claude Code | LLM tool selection from natural language | Bad descriptions, parameter-name confusion |
+| 3a — Cowork WSL2 | Full path through WSL2 bridge | Bridge config, node path, build artifacts |
+| 3b — Cowork Native | Full path on native Windows | Cross-platform path bugs, line endings, `npx.cmd` |
+
+**Don't skip layers.** Each one catches bugs the others miss.

--- a/docs/external-links-tool-testing-guide.md
+++ b/docs/external-links-tool-testing-guide.md
@@ -308,8 +308,30 @@ server runs. Both sub-layers are required:
 **What this tests:** Does the full pipeline work in Cowork through the
 WSL2 bridge?
 
-**Prerequisite:** Claude Desktop installed with a WSL2 MCP server entry.
-Example `claude_desktop_config.json` (Windows side):
+**Prerequisite:** Claude Desktop installed.
+
+### Where the config file actually lives
+
+Claude Desktop reads its MCP server config from
+`claude_desktop_config.json`. Two important things about the path:
+
+- **The MSIX/Microsoft Store install of Claude Desktop redirects
+  `%APPDATA%\Claude\` to a per-package sandbox at**
+  `%LOCALAPPDATA%\Packages\Claude_<id>\LocalCache\Roaming\Claude\`. Editing
+  the unredirected path has no effect — Desktop only reads the redirected
+  one. Logs (`logs/mcp-server-<name>.log`) also live under the redirected
+  path.
+- **Don't open the file directly. Use the Edit Config button** in
+  Settings → Developer. That button always opens the file Desktop actually
+  reads, regardless of install method.
+
+### Editing the config (in-app)
+
+1. In Claude Desktop, open **Settings → Developer**.
+2. Click **Edit Config**. The OS opens
+   `claude_desktop_config.json` in your default editor.
+3. Add a `mcpServers` entry alongside any existing top-level keys (e.g.
+   `preferences`). Don't replace the file — merge into it.
 
 ```json
 {
@@ -317,10 +339,10 @@ Example `claude_desktop_config.json` (Windows side):
     "genealogy-wsl": {
       "command": "wsl.exe",
       "args": [
-        "-d", "Ubuntu-22.04",
-        "--cd", "/mnt/c/path/to/cowork-genealogy/mcp-server",
+        "-d", "Ubuntu",
+        "--cd", "/home/<you>/cowork-genealogy/mcp-server",
         "--",
-        "/usr/bin/node",
+        "/home/<you>/.nvm/versions/node/<version>/bin/node",
         "build/index.js"
       ]
     }
@@ -328,22 +350,52 @@ Example `claude_desktop_config.json` (Windows side):
 }
 ```
 
-Adjust the distro name and path. `wsl.exe -l` lists distros;
-`wsl.exe -- which node` finds the node path.
+Adjust three things to match your machine:
+
+- **`-d Ubuntu`** — your WSL2 distro name. Run `wsl.exe -l` from
+  PowerShell. If it's `Ubuntu-22.04`, `Ubuntu-24.04`, etc., use that
+  exact value.
+- **`--cd /home/<you>/cowork-genealogy/mcp-server`** — absolute WSL2 path
+  to the built `mcp-server/` folder. Don't use the `/mnt/c/...` Windows
+  path; that's slower and more permission-prone.
+- **Node binary path** — run `which node` inside WSL2. nvm-installed Node
+  lives at `/home/<you>/.nvm/versions/node/<version>/bin/node`; system
+  Node is at `/usr/bin/node`. Use whichever your `which node` returned.
+
+### Encoding gotcha
+
+The file must be **UTF-8 without BOM**. If you save through the Edit
+Config button, the OS handles this correctly. If you ever need to write
+the file via PowerShell, **don't use `Set-Content -Encoding UTF8`** —
+PowerShell 5.x emits a BOM and Desktop will fail to parse the file with
+`"Unexpected token "*" ... is not valid JSON"`. Either use the Edit
+Config button or write from the WSL2 side via the
+`/mnt/c/Users/<you>/AppData/Local/Packages/Claude_<id>/LocalCache/Roaming/Claude/`
+mount.
 
 ### Steps
 
-1. FULLY restart Claude Desktop (system tray → right-click → Quit →
-   reopen). Closing the window is not enough.
+1. Save the config file.
 
-2. Open a Cowork session.
+2. **Fully quit** Claude Desktop. System tray icon (bottom-right of
+   taskbar, expand `^` if hidden) → right-click → Quit. Closing the
+   window is not enough; the app keeps running. Wait 5 seconds.
 
-3. Test:
+3. Reopen Claude Desktop.
+
+4. **Verify in Settings → Developer** that `genealogy-wsl` appears as
+   connected. If it doesn't, check the log file at
+   `%LOCALAPPDATA%\Packages\Claude_<id>\LocalCache\Roaming\Claude\logs\mcp-server-genealogy-wsl.log`
+   for the actual error.
+
+5. Open a Cowork session inside Claude Desktop.
+
+6. Test:
 
    > "Find FamilySearch external links for place ID 1927089 between
    > 1880 and 1950."
 
-4. Verify Claude calls `external_links` and presents the URLs.
+7. Verify Claude calls `external_links` and presents the URLs.
 
 ### What success looks like
 
@@ -352,12 +404,13 @@ Cowork → Claude Desktop → WSL2 → MCP server.
 
 ### What failure looks like
 
-- Claude doesn't see the tool → config typo or Claude Desktop wasn't
-  fully restarted.
-- `ETIMEDOUT` from the server → WSL2 networking issue; verify the
-  smoke-test script works inside WSL2 first.
-- "Cannot find module" → wrong path or `npm run build` not run inside
-  WSL2.
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| Desktop shows a JSON parse-error dialog on launch | File has a BOM or stray character at the start | Re-save through Edit Config, or rewrite from WSL2 side without BOM |
+| Server doesn't appear in Settings → Developer | Config edit landed in the unredirected `%APPDATA%\Claude\` path that MSIX Desktop ignores | Use the Edit Config button to open the right file |
+| `wsl.exe: command not found` in log | Desktop's MSIX sandbox can't find wsl.exe on PATH | Use full path: `"command": "C:\\Windows\\System32\\wsl.exe"` (note doubled backslashes for JSON) |
+| `Cannot find module ... build/index.js` | `--cd` path wrong, or `mcp-server/build/` doesn't exist | From WSL2: `ls /home/<you>/cowork-genealogy/mcp-server/build/index.js` |
+| `ETIMEDOUT` / `fetch failed` from the server itself | WSL2 networking issue | Verify the smoke-test script (`npx tsx scripts/try-external-links.ts ...`) works inside WSL2 first |
 
 ### When to move on
 
@@ -368,9 +421,17 @@ Move to Layer 3b once the WSL2 bridge handles a full request.
 ## Layer 3b: Cowork via Native Windows
 
 **What this tests:** Does the full pipeline work running natively on
-Windows?
+Windows (no WSL2 hop)?
 
-**Prerequisite:** Claude Desktop configured with a native Windows entry:
+**Prerequisite:** Node 20+ installed natively on Windows (from
+nodejs.org, not via WSL2) and on the user PATH.
+
+### Editing the config
+
+Use the same **Settings → Developer → Edit Config** flow as Layer 3a
+(see that section for the path-redirection and BOM gotchas).
+
+Add a native Windows entry alongside (or in place of) the WSL2 entry:
 
 ```json
 {
@@ -378,28 +439,40 @@ Windows?
     "genealogy-native": {
       "command": "node",
       "args": [
-        "C:\\path\\to\\cowork-genealogy\\mcp-server\\build\\index.js"
+        "C:\\absolute\\path\\to\\cowork-genealogy\\mcp-server\\build\\index.js"
       ]
     }
   }
 }
 ```
 
-Remove or rename the WSL2 entry while testing this layer.
+Notes on the entry:
+
+- **Doubled backslashes** in the path. JSON requires `\\` to encode a
+  literal backslash; `C:\path` is invalid JSON.
+- **`"command": "node"`** assumes `node` is on Desktop's PATH. If
+  Desktop can't find it, use the absolute path:
+  `"command": "C:\\Program Files\\nodejs\\node.exe"`.
+- Remove or rename the WSL2 entry while testing this layer so you know
+  the native path is being exercised.
 
 ### Steps
 
-1. Build natively:
+1. Build natively from PowerShell (not WSL2):
 
    ```powershell
-   cd C:\path\to\cowork-genealogy\mcp-server
+   cd C:\absolute\path\to\cowork-genealogy\mcp-server
    npm install
    npm run build
    ```
 
-2. FULLY restart Claude Desktop.
+2. Edit Claude Desktop config (see above), save.
 
-3. Test the same prompt as Layer 3a.
+3. Fully quit Claude Desktop from the tray, wait 5 seconds, reopen.
+
+4. Verify the server appears in Settings → Developer.
+
+5. Test the same prompt as Layer 3a.
 
 ### What success looks like
 

--- a/docs/specs/external-links-tool-spec.md
+++ b/docs/specs/external-links-tool-spec.md
@@ -17,21 +17,21 @@ Where those two scope inward (record collections inside FS, persons
 inside collections), `external_links` scopes outward — pointing the
 user at the third-party genealogy resources FS curates on its wiki.
 
-### Composition with future tools
+### Composition with sibling tools
 
 A near-term workflow this tool participates in:
 
 ```
-[population MCP server]  → place_id, place name, population data
+population({ place_id })  → place_id, place name, population data
         ↓
-[external_links]         → curated third-party URLs covering that
-                            place + year window
+external_links({ placeId, startYear, endYear })
+        → curated third-party URLs covering that place + year window
 ```
 
-The population MCP server is a separate project owned by another
-teammate. It is the upstream source of place IDs for `external_links`.
-This tool does not resolve place names to IDs; the place ID must come
-from the caller. **The LLM should not guess place IDs.**
+The `population` tool (sibling in this server) is the upstream source
+of place IDs. `external_links` does not resolve place names to IDs;
+the place ID must come from the caller. **The LLM should not guess
+place IDs.**
 
 ### Why no `recordType` filter
 
@@ -49,7 +49,7 @@ window," not "URLs of a specific record category."
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `placeId` | string | Yes | FamilySearch place ID (numeric string), e.g. `"1927089"` for France. Sourced from the population MCP server. |
+| `placeId` | string | Yes | FamilySearch place ID (numeric string), e.g. `"1927089"` for France. Sourced from the `places` tool. |
 | `startYear` | number (integer, 1500–2100) | Yes | Earliest year of interest (inclusive). |
 | `endYear` | number (integer, 1500–2100) | Yes | Latest year of interest (inclusive). Must be `>= startYear`. |
 
@@ -128,7 +128,7 @@ default is to preserve API truth.
     "Use when the user wants links to external record collections (Ancestry, MyHeritage, FindMyPast, " +
     "national archives, etc.) covering a specific place by FamilySearch place ID and time period. " +
     "Returns every collection whose date range overlaps [startYear, endYear], plus undated wiki/website " +
-    "resources for that place. Requires a place ID — do not guess; obtain it from the population tool " +
+    "resources for that place. Requires a place ID — do not guess; obtain it from the places tool " +
     "or the user.",
   inputSchema: {
     type: "object",
@@ -138,7 +138,7 @@ default is to preserve API truth.
         type: "string",
         description:
           "FamilySearch place ID (numeric string), e.g. '1927089' for France. " +
-          "Get this from the population MCP server, not by guessing."
+          "Get this from the places tool, not by guessing."
       },
       startYear: {
         type: "integer",
@@ -368,7 +368,7 @@ npx @modelcontextprotocol/inspector node build/index.js
 
 ## Out of scope
 
-- Place name → place ID lookup (handled by the population MCP server).
+- Place ID lookup (handled by the `places` tool).
 - OAuth (this endpoint is public).
 - Deduplication of repeated URLs (FS-side data quality issue; flagged
   as future product decision).

--- a/docs/specs/external-links-tool-spec.md
+++ b/docs/specs/external-links-tool-spec.md
@@ -283,9 +283,9 @@ and output types (`ExternalLink`, `ExternalLinksResult`).
 
 ### `mcp-server/src/tools/external-links.ts`
 
-- `externalLinksSchema` — MCP tool schema (hand-rolled JSON Schema,
+- `externalLinksToolSchema` — MCP tool schema (hand-rolled JSON Schema,
   matching the existing tools' style).
-- `externalLinks(input)` — main handler: validate, paginate, filter
+- `externalLinksTool(input)` — main handler: validate, paginate, filter
   by overlap, map to `{ url, linkText }`.
 - `fetchPage(placeId, offset)` — one HTTP call with model-actionable
   error mapping.
@@ -298,13 +298,13 @@ CallTool).
 
 ### `mcp-server/tests/tools/external-links.test.ts`
 
-11 vitest cases covering happy path, pagination, error modes, and the
-handler-level year-order guard. All use a stubbed global `fetch` —
-no real network.
+12 vitest cases covering happy path, pagination, error modes, and
+handler-level guards. All use a stubbed global `fetch` — no real
+network.
 
 ### `mcp-server/dev/try-external-links.ts`
 
-One-shot smoke script that invokes `externalLinks()` against the live
+One-shot smoke script that invokes `externalLinksTool()` against the live
 API. Bypasses the MCP harness for fast debugging. Modeled on
 `try-collections.ts`.
 
@@ -312,7 +312,7 @@ API. Bypasses the MCP harness for fast debugging. Modeled on
 
 ## Testing
 
-### `tests/tools/external-links.test.ts` (11 cases)
+### `tests/tools/external-links.test.ts` (12 cases)
 
 | # | Test case | What it verifies |
 |---|-----------|------------------|
@@ -320,13 +320,14 @@ API. Bypasses the MCP harness for fast debugging. Modeled on
 | 2 | Includes collections with empty start/end years | Permissive empty-year inclusion |
 | 3 | Fetches every page until totalResults is exhausted | Multi-page pagination loop |
 | 4 | Stops looping when an empty page is returned | Defensive bail on bad API state |
-| 5 | Throws an instructional error on 403 | Rate-limit / WAF error wording |
-| 6 | Throws an instructional error on 429 | Rate-limit error wording |
-| 7 | Throws a retry-once error on generic 5xx | Transient-error wording |
-| 8 | Throws an instructional error on malformed JSON | Parse-failure handling |
-| 9 | Rejects endYear < startYear without hitting the network | Handler-level guard + no fetch |
-| 10 | Accepts endYear === startYear (single-year query) | Boundary case |
-| 11 | Returns empty results cleanly for unknown placeId | Empty-data path |
+| 5 | Returns empty results cleanly for unknown placeId | Empty-data path |
+| 6 | Throws an instructional error on 403 | Rate-limit / WAF error wording |
+| 7 | Throws an instructional error on 429 | Rate-limit error wording |
+| 8 | Throws a retry-once error on generic 5xx | Transient-error wording |
+| 9 | Throws an instructional error on malformed JSON | Parse-failure handling |
+| 10 | Rejects endYear < startYear without hitting the network | Handler-level guard + no fetch |
+| 11 | Accepts endYear === startYear (single-year query) | Boundary case |
+| 12 | Rejects empty placeId without hitting the network | Handler-level guard + no fetch |
 
 ### Smoke-test script
 

--- a/docs/specs/external-links-tool-spec.md
+++ b/docs/specs/external-links-tool-spec.md
@@ -302,7 +302,7 @@ CallTool).
 handler-level year-order guard. All use a stubbed global `fetch` —
 no real network.
 
-### `mcp-server/scripts/try-external-links.ts`
+### `mcp-server/dev/try-external-links.ts`
 
 One-shot smoke script that invokes `externalLinks()` against the live
 API. Bypasses the MCP harness for fast debugging. Modeled on
@@ -332,9 +332,9 @@ API. Bypasses the MCP harness for fast debugging. Modeled on
 
 ```bash
 cd mcp-server
-npx tsx scripts/try-external-links.ts 1927089 1880 1950   # France, populated
-npx tsx scripts/try-external-links.ts 1927089 1700 1750   # France, sparse
-npx tsx scripts/try-external-links.ts 1927164 1880 1950   # Canada
+npx tsx dev/try-external-links.ts 1927089 1880 1950   # France, populated
+npx tsx dev/try-external-links.ts 1927089 1700 1750   # France, sparse
+npx tsx dev/try-external-links.ts 1927164 1880 1950   # Canada
 ```
 
 ---

--- a/docs/specs/external-links-tool-spec.md
+++ b/docs/specs/external-links-tool-spec.md
@@ -1,0 +1,374 @@
+# External Links Tool — Implementation Spec
+
+## Overview
+
+An MCP tool that returns FamilySearch-curated genealogy resource URLs
+for a place and year range. Given a FamilySearch place ID and a
+`[startYear, endYear]` window, it fetches every collection FS knows
+about for that place, filters to those whose own date range overlaps
+the requested window, and returns the resource URLs (plus their
+human-readable link text).
+
+This wraps the **public** `/external/collections/search` endpoint —
+no OAuth required. It complements the existing `collections` tool
+(authenticated, surfaces FS's own collections) and the in-flight
+`search` tool (authenticated, surfaces individual person records).
+Where those two scope inward (record collections inside FS, persons
+inside collections), `external_links` scopes outward — pointing the
+user at the third-party genealogy resources FS curates on its wiki.
+
+### Composition with future tools
+
+A near-term workflow this tool participates in:
+
+```
+[population MCP server]  → place_id, place name, population data
+        ↓
+[external_links]         → curated third-party URLs covering that
+                            place + year window
+```
+
+The population MCP server is a separate project owned by another
+teammate. It is the upstream source of place IDs for `external_links`.
+This tool does not resolve place names to IDs; the place ID must come
+from the caller. **The LLM should not guess place IDs.**
+
+### Why no `recordType` filter
+
+An earlier draft of this spec proposed a `recordType` enum input.
+A direct curl with `recordType=Census` showed the parameter is **not
+honored**: the response included Marriages, Military, Civil
+Registration, and undated wiki links regardless. The field was
+dropped from the schema rather than papered over with client-side
+filtering. The contract is "URLs whose date range overlaps the
+window," not "URLs of a specific record category."
+
+---
+
+## Input
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `placeId` | string | Yes | FamilySearch place ID (numeric string), e.g. `"1927089"` for France. Sourced from the population MCP server. |
+| `startYear` | number (integer, 1500–2100) | Yes | Earliest year of interest (inclusive). |
+| `endYear` | number (integer, 1500–2100) | Yes | Latest year of interest (inclusive). Must be `>= startYear`. |
+
+Validation:
+
+- `placeId` must be a non-empty string.
+- `startYear` and `endYear` must be integers in `[1500, 2100]`.
+- `endYear >= startYear` is enforced inside the handler — the JSON
+  Schema reports the range constraints, and the handler throws a
+  model-actionable error before any network call if the order is
+  inverted.
+
+Example:
+
+```json
+{ "placeId": "1927089", "startYear": 1880, "endYear": 1950 }
+```
+
+---
+
+## Output
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `place` | string \| null | Place name resolved by FS (e.g. `"France"`). `null` if no collections were returned. |
+| `totalResults` | number | Raw total reported by the FS API for this `placeId` (before overlap filter). |
+| `matchedCount` | number | Number of items in `results[]` after overlap filter. |
+| `results` | `{ url, linkText }[]` | URLs FS curates for this place that overlap the requested year range. |
+
+Each `results[]` item:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `url` | string | Direct URL to the curated resource (Ancestry, MyHeritage, FindMyPast, archives, wiki page, etc.). |
+| `linkText` | string | Human-readable link text from the FS wiki. May be empty for malformed entries. |
+
+Example:
+
+```json
+{
+  "place": "France",
+  "totalResults": 221,
+  "matchedCount": 178,
+  "results": [
+    {
+      "url": "https://www.findmypast.com/search/results?...",
+      "linkText": "Passenger Lists Leaving UK, 1890-1960"
+    },
+    {
+      "url": "https://www.myheritage.com/research/collection-14009/...",
+      "linkText": "France, Censuses of Hérault, 1836-1936"
+    }
+  ]
+}
+```
+
+`totalResults` and `matchedCount` are both reported on purpose: the
+difference lets the LLM distinguish "place has no data" from "place
+has data but nothing in this window."
+
+Pass-through behavior: the output preserves whatever order FS returned
+and does **not** deduplicate. FS itself returns the same URL multiple
+times across categories (e.g. "Search Your French Ancestors" appears
+~11 times for France). Whether to dedupe is a future product decision;
+default is to preserve API truth.
+
+---
+
+## Tool Schema
+
+```typescript
+{
+  name: "external_links",
+  description:
+    "Return FamilySearch-curated third-party genealogy resource URLs for a place and year range. " +
+    "Use when the user wants links to external record collections (Ancestry, MyHeritage, FindMyPast, " +
+    "national archives, etc.) covering a specific place by FamilySearch place ID and time period. " +
+    "Returns every collection whose date range overlaps [startYear, endYear], plus undated wiki/website " +
+    "resources for that place. Requires a place ID — do not guess; obtain it from the population tool " +
+    "or the user.",
+  inputSchema: {
+    type: "object",
+    required: ["placeId", "startYear", "endYear"],
+    properties: {
+      placeId: {
+        type: "string",
+        description:
+          "FamilySearch place ID (numeric string), e.g. '1927089' for France. " +
+          "Get this from the population MCP server, not by guessing."
+      },
+      startYear: {
+        type: "integer",
+        minimum: 1500,
+        maximum: 2100,
+        description: "Earliest year of interest (inclusive)."
+      },
+      endYear: {
+        type: "integer",
+        minimum: 1500,
+        maximum: 2100,
+        description: "Latest year of interest (inclusive). Must be >= startYear."
+      }
+    }
+  }
+}
+```
+
+---
+
+## Authentication
+
+This tool **does not require authentication**. The endpoint is public,
+unlike the sibling `collections` and `search` tools which call
+`getValidToken()`. Do not add auth to this tool's handler.
+
+---
+
+## FamilySearch API Reference
+
+**Endpoint (no auth required):**
+
+```
+GET https://www.familysearch.org/service/search/hr/external/collections/search
+    ?q.placeId=<placeId>
+    &offset=<offset>
+    &count=<count>
+```
+
+**Headers:**
+
+| Header | Value | Why |
+|--------|-------|-----|
+| `User-Agent` | Chrome browser UA (same constant `collections.ts` uses) | FS's WAF (Imperva/Incapsula) blocks the simple identifying UA on this endpoint with a 403 — confirmed via curl. The endpoint sits behind the same WAF rules as `/v2/collections`, so the same UA pattern works. |
+| `Accept` | `application/json` | Without this, FS may return HTML. |
+
+The `USER_AGENT` constant is duplicated between `collections.ts` and
+`external-links.ts` for now. Both tools share the same WAF-bypass need;
+when a third tool follows the same pattern (or any other shared FS
+constant emerges), factor into a shared module.
+
+**Pagination (observed via curl, not documented):**
+
+| Field | Behavior |
+|-------|----------|
+| `count` query param | Page size; `count=100` is honored. |
+| `offset` query param | Returns the next slice. |
+| `totalResults` response field | Total available items for this placeId. |
+
+For typical places this is 1–5 calls. The implementation caps the
+loop at `MAX_PAGES = 50` (5,000 results) as a safety against an API
+that misreports `totalResults`.
+
+**Response shape (observed via curl):**
+
+```json
+{
+  "count": 100,
+  "offset": 0,
+  "totalResults": 221,
+  "collections": [
+    {
+      "url": "https://...",
+      "linkText": "...",
+      "place": "France",
+      "startYear": "1866",   // string; may be ""
+      "endYear": "1866",     // string; may be ""
+      "record_type": "Census",
+      "recordTypeId": "3",
+      "cost": "free|paid",
+      "content_type": "index & images",
+      "source_url": "https://www.familysearch.org/en/wiki/..."
+    }
+  ]
+}
+```
+
+The implementation only reads `url`, `linkText`, `place`, `startYear`,
+`endYear`. The other fields are ignored to keep the output minimal.
+
+---
+
+## Overlap Logic
+
+A collection is included in `results[]` if its date range overlaps the
+user's `[startYear, endYear]`.
+
+**Year parsing:** API year fields are strings (`"1866"`, `""`). Empty
+strings parse as `null`.
+
+**Cases:**
+
+| Collection state | Decision |
+|---|---|
+| Both years null (undated wiki/website link) | Include — permissive default. |
+| One year null | Treat the missing side as equal to the present one (e.g. `[1900, null]` → `[1900, 1900]`). |
+| Both years present | Include if `cStart <= userEnd AND cEnd >= userStart`. |
+
+The permissive empty-year default was an explicit product decision —
+undated FS wiki resources ("France Genealogy Resources List") are
+still useful and excluding them would silently drop ~70% of results
+for some places.
+
+`endYear < startYear` at input is rejected by the handler before any
+network call.
+
+---
+
+## Error Handling
+
+All thrown errors are written as **instructions to the LLM**, per the
+project convention:
+
+| Condition | Handler behavior |
+|-----------|------------------|
+| `endYear < startYear` | Throw: `"endYear must be greater than or equal to startYear. Re-read the tool's input schema and retry with corrected arguments."` |
+| HTTP 403 / 429 | Throw: `"FamilySearch rejected the request (status N). This usually means rate limiting or a User-Agent block. Wait 60 seconds and retry once. If it persists, surface this to the user."` |
+| Other non-2xx | Throw: `"FamilySearch returned N. Treat this as a transient error and retry once before giving up."` |
+| Invalid JSON in response | Throw: `"FamilySearch returned a response that was not valid JSON. Retry once; if it persists, surface this to the user."` |
+| Pagination cap reached | Log warning to stderr (`[external_links] pagination cap reached`). Return what we have. Do not throw. |
+| Empty page mid-pagination | Stop the loop. Return what we have. |
+| Zero matches after filter | Return `matchedCount: 0` and `results: []`. Not an error. |
+
+---
+
+## Files
+
+### `mcp-server/src/types/external-links.ts`
+
+Internal API response types (`FSExternalCollection`, `FSExternalResponse`)
+and output types (`ExternalLink`, `ExternalLinksResult`).
+
+### `mcp-server/src/tools/external-links.ts`
+
+- `externalLinksSchema` — MCP tool schema (hand-rolled JSON Schema,
+  matching the existing tools' style).
+- `externalLinks(input)` — main handler: validate, paginate, filter
+  by overlap, map to `{ url, linkText }`.
+- `fetchPage(placeId, offset)` — one HTTP call with model-actionable
+  error mapping.
+- Internal helpers: `parseYear`, `overlapsRange`.
+
+### `mcp-server/src/index.ts`
+
+Registered following the existing tool pattern (import, ListTools,
+CallTool).
+
+### `mcp-server/tests/tools/external-links.test.ts`
+
+11 vitest cases covering happy path, pagination, error modes, and the
+handler-level year-order guard. All use a stubbed global `fetch` —
+no real network.
+
+### `mcp-server/scripts/try-external-links.ts`
+
+One-shot smoke script that invokes `externalLinks()` against the live
+API. Bypasses the MCP harness for fast debugging. Modeled on
+`try-collections.ts`.
+
+---
+
+## Testing
+
+### `tests/tools/external-links.test.ts` (11 cases)
+
+| # | Test case | What it verifies |
+|---|-----------|------------------|
+| 1 | Returns matching collections with url + linkText only | Happy path + field stripping |
+| 2 | Includes collections with empty start/end years | Permissive empty-year inclusion |
+| 3 | Fetches every page until totalResults is exhausted | Multi-page pagination loop |
+| 4 | Stops looping when an empty page is returned | Defensive bail on bad API state |
+| 5 | Throws an instructional error on 403 | Rate-limit / WAF error wording |
+| 6 | Throws an instructional error on 429 | Rate-limit error wording |
+| 7 | Throws a retry-once error on generic 5xx | Transient-error wording |
+| 8 | Throws an instructional error on malformed JSON | Parse-failure handling |
+| 9 | Rejects endYear < startYear without hitting the network | Handler-level guard + no fetch |
+| 10 | Accepts endYear === startYear (single-year query) | Boundary case |
+| 11 | Returns empty results cleanly for unknown placeId | Empty-data path |
+
+### Smoke-test script
+
+```bash
+cd mcp-server
+npx tsx scripts/try-external-links.ts 1927089 1880 1950   # France, populated
+npx tsx scripts/try-external-links.ts 1927089 1700 1750   # France, sparse
+npx tsx scripts/try-external-links.ts 1927164 1880 1950   # Canada
+```
+
+---
+
+## Verification
+
+### Automated
+
+```bash
+cd mcp-server && npm run build && npm test
+```
+
+### Manual Layer 1 (MCP Inspector)
+
+```bash
+cd mcp-server
+npx @modelcontextprotocol/inspector node build/index.js
+```
+
+- Call `external_links({ placeId: "1927089", startYear: 1880, endYear: 1950 })` → `~178` results, `totalResults: 221`.
+- Call with `startYear: 1700, endYear: 1750` → far fewer matches (proves the filter works).
+- Call with `startYear: 1950, endYear: 1880` → handler error mentioning `endYear must be greater than or equal to startYear`.
+- Call with `placeId: "999999999"` → `place: null`, `totalResults: 0`, `matchedCount: 0`, `results: []`.
+
+### Manual Layer 2 (Claude Code)
+
+- "Find FamilySearch resources for placeId 1927089 between 1880 and 1950." — Claude should call `external_links` with those inputs and present the URLs.
+
+---
+
+## Out of scope
+
+- Place name → place ID lookup (handled by the population MCP server).
+- OAuth (this endpoint is public).
+- Deduplication of repeated URLs (FS-side data quality issue; flagged
+  as future product decision).
+- `recordType` filtering (FS endpoint does not honor the param).

--- a/mcp-server/dev/try-external-links.ts
+++ b/mcp-server/dev/try-external-links.ts
@@ -1,4 +1,4 @@
-import { externalLinks } from "../src/tools/external-links.js";
+import { externalLinksTool } from "../src/tools/external-links.js";
 
 const placeId = process.argv[2];
 const startYear = process.argv[3];
@@ -20,7 +20,7 @@ if (!placeId || !startYear || !endYear) {
   process.exit(1);
 }
 
-const result = await externalLinks({
+const result = await externalLinksTool({
   placeId,
   startYear: Number.parseInt(startYear, 10),
   endYear: Number.parseInt(endYear, 10),

--- a/mcp-server/dev/try-external-links.ts
+++ b/mcp-server/dev/try-external-links.ts
@@ -1,0 +1,29 @@
+import { externalLinks } from "../src/tools/external-links.js";
+
+const placeId = process.argv[2];
+const startYear = process.argv[3];
+const endYear = process.argv[4];
+
+if (!placeId || !startYear || !endYear) {
+  console.error("Usage:");
+  console.error(
+    "  npx tsx dev/try-external-links.ts <placeId> <startYear> <endYear>"
+  );
+  console.error("");
+  console.error("Examples:");
+  console.error(
+    "  npx tsx dev/try-external-links.ts 1927089 1880 1950   # France"
+  );
+  console.error(
+    "  npx tsx dev/try-external-links.ts 1927164 1880 1950   # Canada"
+  );
+  process.exit(1);
+}
+
+const result = await externalLinks({
+  placeId,
+  startYear: Number.parseInt(startYear, 10),
+  endYear: Number.parseInt(endYear, 10),
+});
+
+console.log(JSON.stringify(result, null, 2));

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -11,7 +11,7 @@ import { logoutTool, logoutToolSchema, type LogoutToolInput } from "./tools/logo
 import { authStatusTool, authStatusToolSchema, type AuthStatusToolInput } from "./tools/auth-status.js";
 import { collectionsTool, collectionsToolSchema, type CollectionsToolInput } from "./tools/collections.js";
 import { populationTool, populationToolSchema, type PopulationToolInput } from "./tools/population.js";
-import { externalLinks, externalLinksSchema, type ExternalLinksToolInput } from "./tools/external-links.js";
+import { externalLinksTool, externalLinksToolSchema, type ExternalLinksToolInput } from "./tools/external-links.js";
 
 const server = new Server(
   { name: "genealogy-mcp", version: "0.0.1" },
@@ -27,7 +27,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
     authStatusToolSchema,
     collectionsToolSchema,
     populationToolSchema,
-    externalLinksSchema,
+    externalLinksToolSchema,
   ],
 }));
 
@@ -140,7 +140,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
   if (request.params.name === "external_links") {
     try {
       const args = request.params.arguments as unknown as ExternalLinksToolInput;
-      const result = await externalLinks(args);
+      const result = await externalLinksTool(args);
       return {
         content: [{ type: "text", text: JSON.stringify(result, null, 2) }]
       };

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -11,6 +11,7 @@ import { logoutTool, logoutToolSchema, type LogoutToolInput } from "./tools/logo
 import { authStatusTool, authStatusToolSchema, type AuthStatusToolInput } from "./tools/auth-status.js";
 import { collectionsTool, collectionsToolSchema, type CollectionsToolInput } from "./tools/collections.js";
 import { populationTool, populationToolSchema, type PopulationToolInput } from "./tools/population.js";
+import { externalLinks, externalLinksSchema, type ExternalLinksToolInput } from "./tools/external-links.js";
 
 const server = new Server(
   { name: "genealogy-mcp", version: "0.0.1" },
@@ -26,6 +27,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
     authStatusToolSchema,
     collectionsToolSchema,
     populationToolSchema,
+    externalLinksSchema,
   ],
 }));
 
@@ -124,6 +126,21 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
     try {
       const args = request.params.arguments as unknown as PopulationToolInput;
       const result = await populationTool(args);
+      return {
+        content: [{ type: "text", text: JSON.stringify(result, null, 2) }]
+      };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Unknown error";
+      return {
+        content: [{ type: "text", text: JSON.stringify({ error: message }) }],
+        isError: true
+      };
+    }
+  }
+  if (request.params.name === "external_links") {
+    try {
+      const args = request.params.arguments as unknown as ExternalLinksToolInput;
+      const result = await externalLinks(args);
       return {
         content: [{ type: "text", text: JSON.stringify(result, null, 2) }]
       };

--- a/mcp-server/src/tools/external-links.ts
+++ b/mcp-server/src/tools/external-links.ts
@@ -36,8 +36,8 @@ function overlapsRange(
   const cStart = parseYear(collection.startYear);
   const cEnd = parseYear(collection.endYear);
   if (cStart === null && cEnd === null) return true;
-  const effectiveStart = cStart ?? cEnd ?? userStart;
-  const effectiveEnd = cEnd ?? cStart ?? userEnd;
+  const effectiveStart = cStart ?? (cEnd as number);
+  const effectiveEnd = cEnd ?? (cStart as number);
   return effectiveStart <= userEnd && effectiveEnd >= userStart;
 }
 
@@ -81,7 +81,7 @@ async function fetchPage(
   }
 }
 
-export async function externalLinks(
+export async function externalLinksTool(
   input: ExternalLinksToolInput
 ): Promise<ExternalLinksResult> {
   const { placeId, startYear, endYear } = input;
@@ -142,7 +142,7 @@ export async function externalLinks(
   };
 }
 
-export const externalLinksSchema = {
+export const externalLinksToolSchema = {
   name: "external_links",
   description:
     "Return FamilySearch-curated third-party genealogy resource URLs for a place and year range. " +

--- a/mcp-server/src/tools/external-links.ts
+++ b/mcp-server/src/tools/external-links.ts
@@ -149,7 +149,7 @@ export const externalLinksToolSchema = {
     "Use when the user wants links to external record collections (Ancestry, MyHeritage, FindMyPast, " +
     "national archives, etc.) covering a specific place by FamilySearch place ID and time period. " +
     "Returns every collection whose date range overlaps [startYear, endYear], plus undated wiki/website " +
-    "resources for that place. Requires a place ID — do not guess; obtain it from the population tool " +
+    "resources for that place. Requires a place ID — do not guess; obtain it from the places tool " +
     "or the user.",
   inputSchema: {
     type: "object" as const,
@@ -158,7 +158,7 @@ export const externalLinksToolSchema = {
         type: "string",
         description:
           "FamilySearch place ID (numeric string), e.g. '1927089' for France. " +
-          "Get this from the population MCP server, not by guessing.",
+          "Get this from the places tool, not by guessing.",
       },
       startYear: {
         type: "integer",

--- a/mcp-server/src/tools/external-links.ts
+++ b/mcp-server/src/tools/external-links.ts
@@ -1,0 +1,179 @@
+import type {
+  ExternalLink,
+  ExternalLinksResult,
+  FSExternalCollection,
+  FSExternalResponse,
+} from "../types/external-links.js";
+
+export interface ExternalLinksToolInput {
+  placeId: string;
+  startYear: number;
+  endYear: number;
+}
+
+const FS_EXTERNAL_URL =
+  "https://www.familysearch.org/service/search/hr/external/collections/search";
+
+const PAGE_SIZE = 100;
+const MAX_PAGES = 50;
+
+// Same WAF-bypass UA as collections.ts. FS's Imperva/Incapsula layer
+// 403s requests without a browser-like User-Agent on this endpoint.
+const USER_AGENT =
+  "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/136.0.0.0 Safari/537.36";
+
+function parseYear(raw: string | undefined): number | null {
+  if (!raw) return null;
+  const n = Number.parseInt(raw, 10);
+  return Number.isFinite(n) ? n : null;
+}
+
+function overlapsRange(
+  collection: FSExternalCollection,
+  userStart: number,
+  userEnd: number
+): boolean {
+  const cStart = parseYear(collection.startYear);
+  const cEnd = parseYear(collection.endYear);
+  if (cStart === null && cEnd === null) return true;
+  const effectiveStart = cStart ?? cEnd ?? userStart;
+  const effectiveEnd = cEnd ?? cStart ?? userEnd;
+  return effectiveStart <= userEnd && effectiveEnd >= userStart;
+}
+
+async function fetchPage(
+  placeId: string,
+  offset: number
+): Promise<FSExternalResponse> {
+  const url = new URL(FS_EXTERNAL_URL);
+  url.searchParams.set("q.placeId", placeId);
+  url.searchParams.set("offset", String(offset));
+  url.searchParams.set("count", String(PAGE_SIZE));
+
+  const res = await fetch(url, {
+    headers: {
+      "User-Agent": USER_AGENT,
+      Accept: "application/json",
+    },
+  });
+
+  if (res.status === 403 || res.status === 429) {
+    throw new Error(
+      `FamilySearch rejected the request (status ${res.status}). ` +
+        "This usually means rate limiting or a User-Agent block. " +
+        "Wait 60 seconds and retry once. If it persists, surface this to the user."
+    );
+  }
+  if (!res.ok) {
+    throw new Error(
+      `FamilySearch returned ${res.status}. ` +
+        "Treat this as a transient error and retry once before giving up."
+    );
+  }
+
+  try {
+    return (await res.json()) as FSExternalResponse;
+  } catch {
+    throw new Error(
+      "FamilySearch returned a response that was not valid JSON. " +
+        "Retry once; if it persists, surface this to the user."
+    );
+  }
+}
+
+export async function externalLinks(
+  input: ExternalLinksToolInput
+): Promise<ExternalLinksResult> {
+  const { placeId, startYear, endYear } = input;
+
+  if (!placeId || typeof placeId !== "string") {
+    throw new Error(
+      "placeId is required and must be a non-empty string. " +
+        "Re-read the tool's input schema and retry with corrected arguments."
+    );
+  }
+  if (endYear < startYear) {
+    throw new Error(
+      "endYear must be greater than or equal to startYear. " +
+        "Re-read the tool's input schema and retry with corrected arguments."
+    );
+  }
+
+  const all: FSExternalCollection[] = [];
+  let offset = 0;
+  let totalResults = 0;
+
+  for (let page = 0; page < MAX_PAGES; page++) {
+    const data = await fetchPage(placeId, offset);
+    const collections = data.collections ?? [];
+    totalResults = data.totalResults ?? 0;
+    all.push(...collections);
+
+    const advanced = collections.length;
+    if (advanced === 0) break;
+    offset += advanced;
+    if (offset >= totalResults) break;
+  }
+
+  if (offset < totalResults) {
+    console.error(
+      `[external_links] pagination cap reached: fetched ${offset} of ${totalResults} for placeId=${placeId}`
+    );
+  }
+
+  const matched = all.filter((c) => overlapsRange(c, startYear, endYear));
+
+  const place =
+    all.find((c) => typeof c.place === "string" && c.place.length > 0)
+      ?.place ?? null;
+
+  const results: ExternalLink[] = matched
+    .filter((c) => typeof c.url === "string" && c.url.length > 0)
+    .map((c) => ({
+      url: c.url as string,
+      linkText: c.linkText ?? "",
+    }));
+
+  return {
+    place,
+    totalResults,
+    matchedCount: results.length,
+    results,
+  };
+}
+
+export const externalLinksSchema = {
+  name: "external_links",
+  description:
+    "Return FamilySearch-curated third-party genealogy resource URLs for a place and year range. " +
+    "Use when the user wants links to external record collections (Ancestry, MyHeritage, FindMyPast, " +
+    "national archives, etc.) covering a specific place by FamilySearch place ID and time period. " +
+    "Returns every collection whose date range overlaps [startYear, endYear], plus undated wiki/website " +
+    "resources for that place. Requires a place ID — do not guess; obtain it from the population tool " +
+    "or the user.",
+  inputSchema: {
+    type: "object" as const,
+    properties: {
+      placeId: {
+        type: "string",
+        description:
+          "FamilySearch place ID (numeric string), e.g. '1927089' for France. " +
+          "Get this from the population MCP server, not by guessing.",
+      },
+      startYear: {
+        type: "integer",
+        minimum: 1500,
+        maximum: 2100,
+        description: "Earliest year of interest (inclusive).",
+      },
+      endYear: {
+        type: "integer",
+        minimum: 1500,
+        maximum: 2100,
+        description:
+          "Latest year of interest (inclusive). Must be >= startYear.",
+      },
+    },
+    required: ["placeId", "startYear", "endYear"],
+  },
+};

--- a/mcp-server/src/types/external-links.ts
+++ b/mcp-server/src/types/external-links.ts
@@ -1,0 +1,35 @@
+/**
+ * Types for the external_links tool.
+ *
+ * The FS endpoint returns a list of curated third-party genealogy
+ * resource links per place. Year fields are strings (may be empty).
+ */
+
+export interface FSExternalCollection {
+  url?: string;
+  linkText?: string;
+  place?: string;
+  startYear?: string;
+  endYear?: string;
+  // Other fields (record_type, recordTypeId, cost, content_type,
+  // source_url) exist in the response but the tool ignores them.
+}
+
+export interface FSExternalResponse {
+  count?: number;
+  offset?: number;
+  totalResults?: number;
+  collections?: FSExternalCollection[];
+}
+
+export interface ExternalLink {
+  url: string;
+  linkText: string;
+}
+
+export interface ExternalLinksResult {
+  place: string | null;
+  totalResults: number;
+  matchedCount: number;
+  results: ExternalLink[];
+}

--- a/mcp-server/tests/tools/external-links.test.ts
+++ b/mcp-server/tests/tools/external-links.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { externalLinks } from "../../src/tools/external-links.js";
+import { externalLinksTool } from "../../src/tools/external-links.js";
 
 const mockFetch = vi.fn();
 vi.stubGlobal("fetch", mockFetch);
@@ -40,7 +40,7 @@ function pageAt(collections: unknown[], offset: number, totalResults: number) {
   });
 }
 
-describe("externalLinks — happy path", () => {
+describe("externalLinksTool — happy path", () => {
   beforeEach(() => {
     mockFetch.mockReset();
   });
@@ -66,7 +66,7 @@ describe("externalLinks — happy path", () => {
     ];
     mockFetch.mockResolvedValueOnce(singlePage(collections));
 
-    const result = await externalLinks({
+    const result = await externalLinksTool({
       placeId: "1927089",
       startYear: 1880,
       endYear: 1950,
@@ -99,7 +99,7 @@ describe("externalLinks — happy path", () => {
     ];
     mockFetch.mockResolvedValueOnce(singlePage(collections));
 
-    const result = await externalLinks({
+    const result = await externalLinksTool({
       placeId: "1927089",
       startYear: 1880,
       endYear: 1950,
@@ -110,7 +110,7 @@ describe("externalLinks — happy path", () => {
   });
 });
 
-describe("externalLinks — pagination", () => {
+describe("externalLinksTool — pagination", () => {
   beforeEach(() => {
     mockFetch.mockReset();
   });
@@ -130,7 +130,7 @@ describe("externalLinks — pagination", () => {
       .mockResolvedValueOnce(pageAt(makePage(100, 100), 100, 250))
       .mockResolvedValueOnce(pageAt(makePage(200, 50), 200, 250));
 
-    const result = await externalLinks({
+    const result = await externalLinksTool({
       placeId: "1927089",
       startYear: 1880,
       endYear: 1950,
@@ -148,7 +148,7 @@ describe("externalLinks — pagination", () => {
       jsonResponse({ count: 0, offset: 0, totalResults: 999, collections: [] })
     );
 
-    const result = await externalLinks({
+    const result = await externalLinksTool({
       placeId: "1927089",
       startYear: 1880,
       endYear: 1950,
@@ -163,7 +163,7 @@ describe("externalLinks — pagination", () => {
       jsonResponse({ count: 0, offset: 0, totalResults: 0, collections: [] })
     );
 
-    const result = await externalLinks({
+    const result = await externalLinksTool({
       placeId: "999999999",
       startYear: 1880,
       endYear: 1950,
@@ -176,52 +176,33 @@ describe("externalLinks — pagination", () => {
   });
 });
 
-describe("externalLinks — error handling", () => {
+describe("externalLinksTool — error handling", () => {
   beforeEach(() => {
     mockFetch.mockReset();
   });
 
-  it("throws an instructional error on 403", async () => {
-    mockFetch.mockResolvedValueOnce(jsonResponse({}, 403));
+  it.each([
+    { label: "403", mock: () => jsonResponse({}, 403), pattern: /Wait 60 seconds and retry once/i },
+    { label: "429", mock: () => jsonResponse({}, 429), pattern: /Wait 60 seconds and retry once/i },
+    { label: "5xx (503)", mock: () => jsonResponse({}, 503), pattern: /retry once before giving up/i },
+    { label: "malformed JSON", mock: () => brokenJsonResponse(200), pattern: /not valid JSON/i },
+  ])("throws an instructional error on $label", async ({ mock, pattern }) => {
+    mockFetch.mockResolvedValueOnce(mock());
 
     await expect(
-      externalLinks({ placeId: "x", startYear: 1900, endYear: 1950 })
-    ).rejects.toThrow(/Wait 60 seconds and retry once/i);
-  });
-
-  it("throws an instructional error on 429", async () => {
-    mockFetch.mockResolvedValueOnce(jsonResponse({}, 429));
-
-    await expect(
-      externalLinks({ placeId: "x", startYear: 1900, endYear: 1950 })
-    ).rejects.toThrow(/Wait 60 seconds and retry once/i);
-  });
-
-  it("throws a retry-once error on generic 5xx", async () => {
-    mockFetch.mockResolvedValueOnce(jsonResponse({}, 503));
-
-    await expect(
-      externalLinks({ placeId: "x", startYear: 1900, endYear: 1950 })
-    ).rejects.toThrow(/retry once before giving up/i);
-  });
-
-  it("throws an instructional error on malformed JSON", async () => {
-    mockFetch.mockResolvedValueOnce(brokenJsonResponse(200));
-
-    await expect(
-      externalLinks({ placeId: "x", startYear: 1900, endYear: 1950 })
-    ).rejects.toThrow(/not valid JSON/i);
+      externalLinksTool({ placeId: "x", startYear: 1900, endYear: 1950 })
+    ).rejects.toThrow(pattern);
   });
 });
 
-describe("externalLinks — handler-level guards", () => {
+describe("externalLinksTool — handler-level guards", () => {
   beforeEach(() => {
     mockFetch.mockReset();
   });
 
   it("rejects endYear < startYear without hitting the network", async () => {
     await expect(
-      externalLinks({ placeId: "1927089", startYear: 1950, endYear: 1880 })
+      externalLinksTool({ placeId: "1927089", startYear: 1950, endYear: 1880 })
     ).rejects.toThrow(/endYear must be greater than or equal to startYear/i);
     expect(mockFetch).not.toHaveBeenCalled();
   });
@@ -229,7 +210,7 @@ describe("externalLinks — handler-level guards", () => {
   it("accepts endYear === startYear (single-year query)", async () => {
     mockFetch.mockResolvedValueOnce(singlePage([]));
 
-    const result = await externalLinks({
+    const result = await externalLinksTool({
       placeId: "1927089",
       startYear: 1900,
       endYear: 1900,
@@ -241,7 +222,7 @@ describe("externalLinks — handler-level guards", () => {
 
   it("rejects empty placeId without hitting the network", async () => {
     await expect(
-      externalLinks({ placeId: "", startYear: 1900, endYear: 1950 })
+      externalLinksTool({ placeId: "", startYear: 1900, endYear: 1950 })
     ).rejects.toThrow(/placeId is required/i);
     expect(mockFetch).not.toHaveBeenCalled();
   });

--- a/mcp-server/tests/tools/external-links.test.ts
+++ b/mcp-server/tests/tools/external-links.test.ts
@@ -1,0 +1,248 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { externalLinks } from "../../src/tools/external-links.js";
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  } as unknown as Response;
+}
+
+function brokenJsonResponse(status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => {
+      throw new SyntaxError("Unexpected token < in JSON");
+    },
+  } as unknown as Response;
+}
+
+function singlePage(collections: unknown[], totalResults?: number) {
+  return jsonResponse({
+    count: collections.length,
+    offset: 0,
+    totalResults: totalResults ?? collections.length,
+    collections,
+  });
+}
+
+function pageAt(collections: unknown[], offset: number, totalResults: number) {
+  return jsonResponse({
+    count: collections.length,
+    offset,
+    totalResults,
+    collections,
+  });
+}
+
+describe("externalLinks — happy path", () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  it("returns matching collections with url + linkText only", async () => {
+    const collections = [
+      {
+        url: "https://example.com/census-1940",
+        linkText: "1940 Census",
+        place: "France",
+        startYear: "1940",
+        endYear: "1940",
+        recordTypeId: "3",
+        cost: "free",
+      },
+      {
+        url: "https://example.com/marriages-1700",
+        linkText: "1700 Marriages",
+        place: "France",
+        startYear: "1700",
+        endYear: "1700",
+      },
+    ];
+    mockFetch.mockResolvedValueOnce(singlePage(collections));
+
+    const result = await externalLinks({
+      placeId: "1927089",
+      startYear: 1880,
+      endYear: 1950,
+    });
+
+    expect(result.place).toBe("France");
+    expect(result.totalResults).toBe(2);
+    expect(result.matchedCount).toBe(1);
+    expect(result.results).toEqual([
+      { url: "https://example.com/census-1940", linkText: "1940 Census" },
+    ]);
+  });
+
+  it("includes collections with empty start/end years (permissive)", async () => {
+    const collections = [
+      {
+        url: "https://example.com/wiki-undated",
+        linkText: "France Genealogy Resources List",
+        place: "France",
+        startYear: "",
+        endYear: "",
+      },
+      {
+        url: "https://example.com/out-of-range",
+        linkText: "1700 Marriages",
+        place: "France",
+        startYear: "1700",
+        endYear: "1700",
+      },
+    ];
+    mockFetch.mockResolvedValueOnce(singlePage(collections));
+
+    const result = await externalLinks({
+      placeId: "1927089",
+      startYear: 1880,
+      endYear: 1950,
+    });
+
+    expect(result.matchedCount).toBe(1);
+    expect(result.results[0]?.url).toBe("https://example.com/wiki-undated");
+  });
+});
+
+describe("externalLinks — pagination", () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  it("fetches every page until totalResults is exhausted", async () => {
+    const makePage = (offset: number, size: number) =>
+      Array.from({ length: size }, (_, i) => ({
+        url: `https://example.com/c${offset + i}`,
+        linkText: `Collection ${offset + i}`,
+        place: "France",
+        startYear: "1900",
+        endYear: "1900",
+      }));
+
+    mockFetch
+      .mockResolvedValueOnce(pageAt(makePage(0, 100), 0, 250))
+      .mockResolvedValueOnce(pageAt(makePage(100, 100), 100, 250))
+      .mockResolvedValueOnce(pageAt(makePage(200, 50), 200, 250));
+
+    const result = await externalLinks({
+      placeId: "1927089",
+      startYear: 1880,
+      endYear: 1950,
+    });
+
+    expect(mockFetch).toHaveBeenCalledTimes(3);
+    expect(result.totalResults).toBe(250);
+    expect(result.matchedCount).toBe(250);
+    expect(result.results[0]?.url).toBe("https://example.com/c0");
+    expect(result.results.at(-1)?.url).toBe("https://example.com/c249");
+  });
+
+  it("stops looping when an empty page is returned (defensive)", async () => {
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({ count: 0, offset: 0, totalResults: 999, collections: [] })
+    );
+
+    const result = await externalLinks({
+      placeId: "1927089",
+      startYear: 1880,
+      endYear: 1950,
+    });
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(result.matchedCount).toBe(0);
+  });
+
+  it("returns empty results cleanly for an unknown placeId", async () => {
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({ count: 0, offset: 0, totalResults: 0, collections: [] })
+    );
+
+    const result = await externalLinks({
+      placeId: "999999999",
+      startYear: 1880,
+      endYear: 1950,
+    });
+
+    expect(result.place).toBeNull();
+    expect(result.totalResults).toBe(0);
+    expect(result.matchedCount).toBe(0);
+    expect(result.results).toEqual([]);
+  });
+});
+
+describe("externalLinks — error handling", () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  it("throws an instructional error on 403", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse({}, 403));
+
+    await expect(
+      externalLinks({ placeId: "x", startYear: 1900, endYear: 1950 })
+    ).rejects.toThrow(/Wait 60 seconds and retry once/i);
+  });
+
+  it("throws an instructional error on 429", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse({}, 429));
+
+    await expect(
+      externalLinks({ placeId: "x", startYear: 1900, endYear: 1950 })
+    ).rejects.toThrow(/Wait 60 seconds and retry once/i);
+  });
+
+  it("throws a retry-once error on generic 5xx", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse({}, 503));
+
+    await expect(
+      externalLinks({ placeId: "x", startYear: 1900, endYear: 1950 })
+    ).rejects.toThrow(/retry once before giving up/i);
+  });
+
+  it("throws an instructional error on malformed JSON", async () => {
+    mockFetch.mockResolvedValueOnce(brokenJsonResponse(200));
+
+    await expect(
+      externalLinks({ placeId: "x", startYear: 1900, endYear: 1950 })
+    ).rejects.toThrow(/not valid JSON/i);
+  });
+});
+
+describe("externalLinks — handler-level guards", () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  it("rejects endYear < startYear without hitting the network", async () => {
+    await expect(
+      externalLinks({ placeId: "1927089", startYear: 1950, endYear: 1880 })
+    ).rejects.toThrow(/endYear must be greater than or equal to startYear/i);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("accepts endYear === startYear (single-year query)", async () => {
+    mockFetch.mockResolvedValueOnce(singlePage([]));
+
+    const result = await externalLinks({
+      placeId: "1927089",
+      startYear: 1900,
+      endYear: 1900,
+    });
+
+    expect(result.matchedCount).toBe(0);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects empty placeId without hitting the network", async () => {
+    await expect(
+      externalLinks({ placeId: "", startYear: 1900, endYear: 1950 })
+    ).rejects.toThrow(/placeId is required/i);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
 ## Summary
 
- New `external_links` MCP tool wraps FamilySearch's public `/external/collections/search` endpoint. Given a place ID and a `[startYear, endYear]` window, returns the curated third-party genealogy URLs (Ancestry, MyHeritage, FindMyPast, archives, wiki pages, etc.) whose date ranges overlap the window.
- Year filtering is done client-side — the FS endpoint doesn't honor a year filter (verified via curl). Undated wiki entries are included permissively so we don't silently drop valid resources.
- Reuses the browser-style `User-Agent` constant from `collections.ts` to bypass FS's Imperva WAF.
- Paginates `count=100` per page with `MAX_PAGES=50` safety cap.
- Errors are written as instructions to the LLM (e.g. "wait 60 seconds and retry once" on 403/429). `endYear < startYear` and empty `placeId` are rejected inside the handler before any network call.

## Test plan

- `cd mcp-server && npm test` — 82/82 pass
- `npx tsx dev/try-external-links.ts 1927089 1880 1950` → France, ~221 total / ~205 matched, real URLs
- `npx tsx dev/try-external-links.ts 1927164 1880 1950` → Canada, ~470 total, multi-page pagination exercised
- `npx tsx dev/try-external-links.ts 999999999 1880 1950` → empty result, no crash
- `npx tsx dev/try-external-links.ts 1927089 1950 1880` → handler-level guard fires before any fetch
- MCP Inspector: tool registers, all four parameters render with descriptions, validation error surfaces with `isError: true`
- Claude Code CLI: picks `external_links` correctly from explicit, prose, and fuzzy ("ancestors in the 1880s through end of WWII") prompts