### PR TITLE
Distance between two place ids

### DIFF
--- a/mcp-server/dev/try-place-distance.ts
+++ b/mcp-server/dev/try-place-distance.ts
@@ -1,0 +1,14 @@
+import { placeDistanceTool } from "../src/tools/distance.js";
+
+const [placeId1, placeId2] = process.argv.slice(2);
+
+if (!placeId1 || !placeId2) {
+  console.error("Usage: npx tsx dev/try-place-distance.ts <placeId1> <placeId2>");
+  console.error("Example: npx tsx dev/try-place-distance.ts 267 456");
+  process.exit(1);
+}
+
+const result = await placeDistanceTool({ placeId1, placeId2 });
+console.log(`Distance from ${result.place1Name} to ${result.place2Name}:`);
+console.log(`  ${result.miles.toLocaleString()} miles`);
+console.log(`  ${result.kilometers.toLocaleString()} km`);

--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -17,6 +17,29 @@
         "vitest": "^4.1.4"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
@@ -429,7 +452,6 @@
       "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -971,7 +993,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -1209,7 +1230,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.15.tgz",
       "integrity": "sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -1834,7 +1854,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2313,7 +2332,6 @@
       "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -2534,7 +2552,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -17,29 +17,6 @@
         "vitest": "^4.1.4"
       }
     },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
@@ -452,6 +429,7 @@
       "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -993,6 +971,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -1230,6 +1209,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.15.tgz",
       "integrity": "sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -1854,6 +1834,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2332,6 +2313,7 @@
       "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -2552,6 +2534,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -10,6 +10,7 @@ import { loginTool, loginToolSchema, type LoginToolInput } from "./tools/login.j
 import { logoutTool, logoutToolSchema, type LogoutToolInput } from "./tools/logout.js";
 import { authStatusTool, authStatusToolSchema, type AuthStatusToolInput } from "./tools/auth-status.js";
 import { collectionsTool, collectionsToolSchema, type CollectionsToolInput } from "./tools/collections.js";
+import { placeDistanceTool, placeDistanceToolSchema, type PlaceDistanceInput } from "./tools/distance.js";
 
 const server = new Server(
   { name: "genealogy-mcp", version: "0.0.1" },
@@ -24,6 +25,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
     logoutToolSchema,
     authStatusToolSchema,
     collectionsToolSchema,
+    placeDistanceToolSchema,
   ],
 }));
 
@@ -107,6 +109,21 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
     try {
       const args = request.params.arguments as unknown as CollectionsToolInput;
       const result = await collectionsTool(args);
+      return {
+        content: [{ type: "text", text: JSON.stringify(result, null, 2) }]
+      };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Unknown error";
+      return {
+        content: [{ type: "text", text: JSON.stringify({ error: message }) }],
+        isError: true
+      };
+    }
+  }
+  if (request.params.name === "place_distance") {
+    try {
+      const args = request.params.arguments as unknown as PlaceDistanceInput;
+      const result = await placeDistanceTool(args);
       return {
         content: [{ type: "text", text: JSON.stringify(result, null, 2) }]
       };

--- a/mcp-server/src/tools/distance.ts
+++ b/mcp-server/src/tools/distance.ts
@@ -1,0 +1,106 @@
+import { getPlaceById } from "./places.js";
+
+const EARTH_RADIUS_KM = 6371;
+const KM_TO_MILES = 0.621371;
+
+function toRadians(degrees: number): number {
+  return (degrees * Math.PI) / 180;
+}
+
+export function haversineDistance(
+  lat1: number,
+  lon1: number,
+  lat2: number,
+  lon2: number
+): { miles: number; kilometers: number } {
+  const dLat = toRadians(lat2 - lat1);
+  const dLon = toRadians(lon2 - lon1);
+  const a =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos(toRadians(lat1)) *
+      Math.cos(toRadians(lat2)) *
+      Math.sin(dLon / 2) ** 2;
+  const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+  const kilometers = EARTH_RADIUS_KM * c;
+  return {
+    kilometers: Math.round(kilometers),
+    miles: Math.round(kilometers * KM_TO_MILES),
+  };
+}
+
+export interface PlaceDistanceInput {
+  placeId1: string;
+  placeId2: string;
+}
+
+export interface PlaceDistanceResult {
+  placeId1: string;
+  placeId2: string;
+  place1Name: string;
+  place2Name: string;
+  miles: number;
+  kilometers: number;
+}
+
+export async function placeDistanceTool(
+  input: PlaceDistanceInput
+): Promise<PlaceDistanceResult> {
+  const [place1, place2] = await Promise.all([
+    getPlaceById(input.placeId1),
+    getPlaceById(input.placeId2),
+  ]);
+
+  if (!place1) {
+    throw new Error(`Place not found: ${input.placeId1}`);
+  }
+  if (!place2) {
+    throw new Error(`Place not found: ${input.placeId2}`);
+  }
+  if (place1.latitude === undefined || place1.longitude === undefined) {
+    throw new Error(
+      `Place "${place1.name}" (ID ${input.placeId1}) has no coordinates.`
+    );
+  }
+  if (place2.latitude === undefined || place2.longitude === undefined) {
+    throw new Error(
+      `Place "${place2.name}" (ID ${input.placeId2}) has no coordinates.`
+    );
+  }
+
+  const { miles, kilometers } = haversineDistance(
+    place1.latitude,
+    place1.longitude,
+    place2.latitude,
+    place2.longitude
+  );
+
+  return {
+    placeId1: input.placeId1,
+    placeId2: input.placeId2,
+    place1Name: place1.fullName,
+    place2Name: place2.fullName,
+    miles,
+    kilometers,
+  };
+}
+
+export const placeDistanceToolSchema = {
+  name: "place_distance",
+  description:
+    "Calculate the approximate straight-line distance in miles and kilometers between two FamilySearch places. " +
+    "Pass two numeric FamilySearch place IDs. Use the places tool first if you only have place names and need their IDs.",
+  inputSchema: {
+    type: "object" as const,
+    properties: {
+      placeId1: {
+        type: "string",
+        description: "The FamilySearch place ID of the first place.",
+      },
+      placeId2: {
+        type: "string",
+        description: "The FamilySearch place ID of the second place.",
+      },
+    },
+    required: ["placeId1", "placeId2"],
+  },
+};

--- a/mcp-server/tests/tools/distance.test.ts
+++ b/mcp-server/tests/tools/distance.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { haversineDistance, placeDistanceTool } from "../../src/tools/distance.js";
+
+vi.mock("../../src/tools/places.js", () => ({
+  getPlaceById: vi.fn(),
+}));
+
+import { getPlaceById } from "../../src/tools/places.js";
+const mockGetPlaceById = vi.mocked(getPlaceById);
+
+beforeEach(() => {
+  mockGetPlaceById.mockReset();
+});
+
+const englandPlace = {
+  placeId: "267",
+  name: "England",
+  fullName: "England, United Kingdom",
+  type: "Country",
+  latitude: 52.0,
+  longitude: -1.0,
+};
+
+const ohioPlace = {
+  placeId: "456",
+  name: "Ohio",
+  fullName: "Ohio, United States",
+  type: "State",
+  latitude: 40.4,
+  longitude: -82.9,
+};
+
+describe("haversineDistance", () => {
+  it("returns a reasonable distance between London and New York", () => {
+    const result = haversineDistance(51.5074, -0.1278, 40.7128, -74.006);
+    // ~5570 km / ~3461 miles, allow ±100 km tolerance
+    expect(result.kilometers).toBeGreaterThan(5470);
+    expect(result.kilometers).toBeLessThan(5670);
+    expect(result.miles).toBeGreaterThan(3400);
+    expect(result.miles).toBeLessThan(3520);
+  });
+
+  it("returns zero distance for the same point", () => {
+    const result = haversineDistance(52.0, -1.0, 52.0, -1.0);
+    expect(result.kilometers).toBe(0);
+    expect(result.miles).toBe(0);
+  });
+
+  it("returns rounded integer values", () => {
+    const result = haversineDistance(52.0, -1.0, 40.4, -82.9);
+    expect(Number.isInteger(result.miles)).toBe(true);
+    expect(Number.isInteger(result.kilometers)).toBe(true);
+  });
+});
+
+describe("placeDistanceTool", () => {
+  it("returns distance between two valid places", async () => {
+    mockGetPlaceById.mockResolvedValueOnce(englandPlace);
+    mockGetPlaceById.mockResolvedValueOnce(ohioPlace);
+
+    const result = await placeDistanceTool({ placeId1: "267", placeId2: "456" });
+
+    expect(result.placeId1).toBe("267");
+    expect(result.placeId2).toBe("456");
+    expect(result.place1Name).toBe("England, United Kingdom");
+    expect(result.place2Name).toBe("Ohio, United States");
+    expect(result.miles).toBeGreaterThan(0);
+    expect(result.kilometers).toBeGreaterThan(0);
+  });
+
+  it("throws when the first place ID is not found", async () => {
+    mockGetPlaceById.mockResolvedValueOnce(null);
+    mockGetPlaceById.mockResolvedValueOnce(ohioPlace);
+
+    await expect(
+      placeDistanceTool({ placeId1: "999", placeId2: "456" })
+    ).rejects.toThrow("Place not found: 999");
+  });
+
+  it("throws when the second place ID is not found", async () => {
+    mockGetPlaceById.mockResolvedValueOnce(englandPlace);
+    mockGetPlaceById.mockResolvedValueOnce(null);
+
+    await expect(
+      placeDistanceTool({ placeId1: "267", placeId2: "999" })
+    ).rejects.toThrow("Place not found: 999");
+  });
+
+  it("throws when the first place has no coordinates", async () => {
+    const noCoords = { ...englandPlace, latitude: undefined, longitude: undefined };
+    mockGetPlaceById.mockResolvedValueOnce(noCoords);
+    mockGetPlaceById.mockResolvedValueOnce(ohioPlace);
+
+    await expect(
+      placeDistanceTool({ placeId1: "267", placeId2: "456" })
+    ).rejects.toThrow('Place "England" (ID 267) has no coordinates.');
+  });
+
+  it("throws when the second place has no coordinates", async () => {
+    const noCoords = { ...ohioPlace, latitude: undefined, longitude: undefined };
+    mockGetPlaceById.mockResolvedValueOnce(englandPlace);
+    mockGetPlaceById.mockResolvedValueOnce(noCoords);
+
+    await expect(
+      placeDistanceTool({ placeId1: "267", placeId2: "456" })
+    ).rejects.toThrow('Place "Ohio" (ID 456) has no coordinates.');
+  });
+});

--- a/mcp-server/tsconfig.json
+++ b/mcp-server/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "module": "ES2022",
-    "moduleResolution": "node",
+    "module": "Node16",
+    "moduleResolution": "node16",
     "outDir": "./build",
     "rootDir": "./src",
     "strict": true,


### PR DESCRIPTION
Adds a place_distance MCP tool that calculates the straight-line distance in miles and kilometers between two FamilySearch place IDs using the haversine formula. Fetches coordinates via the existing places tool infrastructure. Also fixes a TypeScript module Resolution deprecation introduced in TS 5.9.