### PR TITLE
Add 5 wiki page fetching MCP endpoints for country research

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -410,6 +410,9 @@ Currently recognized fields in `~/.familysearch-mcp/config.json`:
 |-------|---------|----------|-------|
 | `clientId` | `login` / OAuth flow | When using FamilySearch authenticated tools | Read by `getClientId()` in `src/auth/config.ts` |
 | `wikiApiUrl` | `search_wiki` | When using `search_wiki` | Base URL of the upstream `wiki-query-api` FastAPI. Local dev: `"http://localhost:8000"`. Read by `getWikiApiUrl()` in `src/auth/config.ts`. Trailing slash is stripped. |
+| `wikiMarkdownDir` | `wiki_fetch_page`, `wiki_country_*` | When using any wiki page tool | Path to the pre-crawled wiki markdown files (e.g. `.../wiki/02_markdown/20260416_160227/`). Read by `getWikiMarkdownDir()` in `src/auth/config.ts`. |
+| `learningCenterDir` | (future) | Optional | Path to the pre-crawled learning center markdown files. Read by `getLearningCenterDir()` in `src/auth/config.ts`. Returns `null` when absent (not an error). |
+| `libraryDir` | (future) | Optional | Path to the pre-crawled library markdown files. Read by `getLibraryDir()` in `src/auth/config.ts`. Returns `null` when absent (not an error). |
 
 Each `get*` helper throws an LLM-instruction error when its required
 field is missing — the error message tells Claude what to put in the

--- a/mcp-server/dev/try-wiki-country-page.ts
+++ b/mcp-server/dev/try-wiki-country-page.ts
@@ -1,0 +1,35 @@
+import {
+  wikiCountryHomeTool,
+  wikiCountryGettingStartedTool,
+  wikiCountryRecordsTool,
+  wikiCountryResearchTipsTool,
+} from "../src/tools/wikiCountryPage.js";
+
+// Usage: npx tsx dev/try-wiki-country-page.ts <placeRepId> <home|getting_started|records|research_tips>
+// Example: npx tsx dev/try-wiki-country-page.ts 267 getting_started
+const placeRepId = process.argv[2] ?? "267";
+const endpoint = process.argv[3] ?? "home";
+
+const tools = {
+  home: wikiCountryHomeTool,
+  getting_started: wikiCountryGettingStartedTool,
+  records: wikiCountryRecordsTool,
+  research_tips: wikiCountryResearchTipsTool,
+} as const;
+
+type Endpoint = keyof typeof tools;
+
+if (!Object.keys(tools).includes(endpoint)) {
+  console.error(`Unknown endpoint: ${endpoint}`);
+  console.error("Valid options: home, getting_started, records, research_tips");
+  process.exit(1);
+}
+
+const result = await tools[endpoint as Endpoint]({ placeRepId });
+console.log(`Place: ${result.placeName} (repId: ${result.placeRepId})`);
+console.log(`Endpoint: wiki_country_${endpoint}`);
+console.log(`URL: ${result.url}`);
+console.log(`Cached: ${result.cached}`);
+console.log(`Content length: ${result.content.length} chars`);
+console.log("\n--- Content Preview (first 2000 chars) ---\n");
+console.log(result.content.slice(0, 2000));

--- a/mcp-server/dev/try-wiki-country-page.ts
+++ b/mcp-server/dev/try-wiki-country-page.ts
@@ -5,10 +5,18 @@ import {
   wikiCountryResearchTipsTool,
 } from "../src/tools/wikiCountryPage.js";
 
-// Usage: npx tsx dev/try-wiki-country-page.ts <placeRepId> <home|getting_started|records|research_tips>
-// Example: npx tsx dev/try-wiki-country-page.ts 267 getting_started
-const placeRepId = process.argv[2] ?? "267";
+// Usage: npx tsx dev/try-wiki-country-page.ts <placeId> <home|getting_started|records|research_tips>
+// Example: npx tsx dev/try-wiki-country-page.ts 1927089 home
+const placeId = process.argv[2];
 const endpoint = process.argv[3] ?? "home";
+
+if (!placeId) {
+  console.error(
+    "Usage: npx tsx dev/try-wiki-country-page.ts <placeId> <home|getting_started|records|research_tips>"
+  );
+  console.error("Example: npx tsx dev/try-wiki-country-page.ts 1927089 home");
+  process.exit(1);
+}
 
 const tools = {
   home: wikiCountryHomeTool,
@@ -25,11 +33,10 @@ if (!Object.keys(tools).includes(endpoint)) {
   process.exit(1);
 }
 
-const result = await tools[endpoint as Endpoint]({ placeRepId });
-console.log(`Place: ${result.placeName} (repId: ${result.placeRepId})`);
+const result = await tools[endpoint as Endpoint]({ placeId });
+console.log(`Place: ${result.placeName} (placeId: ${result.placeId})`);
 console.log(`Endpoint: wiki_country_${endpoint}`);
 console.log(`URL: ${result.url}`);
-console.log(`Cached: ${result.cached}`);
 console.log(`Content length: ${result.content.length} chars`);
 console.log("\n--- Content Preview (first 2000 chars) ---\n");
 console.log(result.content.slice(0, 2000));

--- a/mcp-server/dev/try-wiki-fetch-page.ts
+++ b/mcp-server/dev/try-wiki-fetch-page.ts
@@ -1,11 +1,18 @@
 import { wikiFetchPageTool } from "../src/tools/wikiFetchPage.js";
 
-const url =
-  process.argv[2] ?? "https://www.familysearch.org/en/wiki/Portugal_Genealogy";
+// Usage: npx tsx dev/try-wiki-fetch-page.ts <url>
+// Example: npx tsx dev/try-wiki-fetch-page.ts https://www.familysearch.org/en/wiki/Portugal_Genealogy
+const url = process.argv[2];
+if (!url) {
+  console.error("Usage: npx tsx dev/try-wiki-fetch-page.ts <url>");
+  console.error(
+    "Example: npx tsx dev/try-wiki-fetch-page.ts https://www.familysearch.org/en/wiki/Portugal_Genealogy"
+  );
+  process.exit(1);
+}
 
 const result = await wikiFetchPageTool({ url });
 console.log(`URL: ${result.url}`);
-console.log(`Cached: ${result.cached}`);
 console.log(`Content length: ${result.content.length} chars`);
 console.log("\n--- Content Preview (first 2000 chars) ---\n");
 console.log(result.content.slice(0, 2000));

--- a/mcp-server/dev/try-wiki-fetch-page.ts
+++ b/mcp-server/dev/try-wiki-fetch-page.ts
@@ -1,0 +1,11 @@
+import { wikiFetchPageTool } from "../src/tools/wikiFetchPage.js";
+
+const url =
+  process.argv[2] ?? "https://www.familysearch.org/en/wiki/Portugal_Genealogy";
+
+const result = await wikiFetchPageTool({ url });
+console.log(`URL: ${result.url}`);
+console.log(`Cached: ${result.cached}`);
+console.log(`Content length: ${result.content.length} chars`);
+console.log("\n--- Content Preview (first 2000 chars) ---\n");
+console.log(result.content.slice(0, 2000));

--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -9,10 +9,13 @@
       "version": "0.0.1",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",
-        "open": "^10.2.0"
+        "cheerio": "^1.0.0",
+        "open": "^10.2.0",
+        "turndown": "^7.2.0"
       },
       "devDependencies": {
         "@types/node": "^20.0.0",
+        "@types/turndown": "^5.0.5",
         "typescript": "^5.0.0",
         "vitest": "^4.1.4"
       }
@@ -69,6 +72,12 @@
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@mixmark-io/domino": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@mixmark-io/domino/-/domino-2.2.0.tgz",
+      "integrity": "sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/@modelcontextprotocol/sdk": {
       "version": "1.29.0",
@@ -456,6 +465,13 @@
         "undici-types": "~6.21.0"
       }
     },
+    "node_modules/@types/turndown": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@types/turndown/-/turndown-5.0.6.tgz",
+      "integrity": "sha512-ru00MoyeeouE5BX4gRL+6m/BsDfbRayOskWqUvh7CLGW+UXxHQItqALa38kKnOiZPqJrtzJUgAC2+F0rL1S4Pg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@vitest/expect": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.5.tgz",
@@ -649,6 +665,12 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+      "license": "ISC"
+    },
     "node_modules/bundle-name": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
@@ -710,6 +732,48 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/cheerio": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.2.0.tgz",
+      "integrity": "sha512-WDrybc/gKFpTYQutKIK6UvfcuxijIZfMfXaYm8NMsPQxSYvf+13fXUJ4rztGGbJcBQ/GF55gvrZ0Bc0bj/mqvg==",
+      "license": "MIT",
+      "dependencies": {
+        "cheerio-select": "^2.1.0",
+        "dom-serializer": "^2.0.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "encoding-sniffer": "^0.2.1",
+        "htmlparser2": "^10.1.0",
+        "parse5": "^7.3.0",
+        "parse5-htmlparser2-tree-adapter": "^7.1.0",
+        "parse5-parser-stream": "^7.1.2",
+        "undici": "^7.19.0",
+        "whatwg-mimetype": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.1"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
+      }
+    },
+    "node_modules/cheerio-select": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
+      "integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-select": "^5.1.0",
+        "css-what": "^6.1.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
       }
     },
     "node_modules/content-disposition": {
@@ -790,6 +854,34 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-select": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -866,6 +958,61 @@
         "node": ">=8"
       }
     },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -893,6 +1040,43 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/encoding-sniffer": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-0.2.1.tgz",
+      "integrity": "sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "^0.6.3",
+        "whatwg-encoding": "^3.1.1"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/encoding-sniffer?sponsor=1"
+      }
+    },
+    "node_modules/encoding-sniffer/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/es-define-property": {
@@ -1232,6 +1416,37 @@
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
+      }
+    },
+    "node_modules/htmlparser2": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
+      "integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "entities": "^7.0.1"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/http-errors": {
@@ -1735,6 +1950,18 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -1804,6 +2031,55 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-htmlparser2-tree-adapter": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.1.0.tgz",
+      "integrity": "sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==",
+      "license": "MIT",
+      "dependencies": {
+        "domhandler": "^5.0.3",
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-parser-stream": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5-parser-stream/-/parse5-parser-stream-7.1.2.tgz",
+      "integrity": "sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==",
+      "license": "MIT",
+      "dependencies": {
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/parseurl": {
@@ -2273,6 +2549,19 @@
       "license": "0BSD",
       "optional": true
     },
+    "node_modules/turndown": {
+      "version": "7.2.4",
+      "resolved": "https://registry.npmjs.org/turndown/-/turndown-7.2.4.tgz",
+      "integrity": "sha512-I8yFsfRzmzK0WV1pNNOA4A7y4RDfFxPRxb3t+e3ui14qSGOxGtiSP6GjeX+Y6CHb7HYaFj7ECUD7VE5kQMZWGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@mixmark-io/domino": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=18",
+        "npm": ">=9"
+      }
+    },
     "node_modules/type-is": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
@@ -2299,6 +2588,15 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {
@@ -2492,6 +2790,40 @@
         "vite": {
           "optional": false
         }
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-encoding/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/which": {

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -12,10 +12,13 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",
-    "open": "^10.2.0"
+    "cheerio": "^1.0.0",
+    "open": "^10.2.0",
+    "turndown": "^7.2.0"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",
+    "@types/turndown": "^5.0.5",
     "typescript": "^5.0.0",
     "vitest": "^4.1.4"
   }

--- a/mcp-server/src/auth/config.ts
+++ b/mcp-server/src/auth/config.ts
@@ -34,6 +34,12 @@ export const WIKI_API_URL_MISSING_MESSAGE =
   "and start the wiki-query-api server with " +
   "`python scripts/wiki/30_serve.py` from the wiki-query-api repo.";
 
+export const WIKI_MARKDOWN_DIR_MISSING_MESSAGE =
+  "Wiki markdown directory is not configured. Add " +
+  '"wikiMarkdownDir": "/path/to/wiki/markdown" ' +
+  "to ~/.familysearch-mcp/config.json. " +
+  "Ask your team lead for the path to the pre-crawled wiki markdown files.";
+
 export async function loadConfig(): Promise<AppConfig> {
   try {
     const raw = await readFile(CONFIG_STORAGE_PATH, "utf8");
@@ -74,4 +80,23 @@ export async function getWikiApiUrl(): Promise<string> {
     throw new Error(WIKI_API_URL_MISSING_MESSAGE);
   }
   return url;
+}
+
+export async function getWikiMarkdownDir(): Promise<string> {
+  const config = await loadConfig();
+  const dir = config.wikiMarkdownDir?.trim();
+  if (!dir) {
+    throw new Error(WIKI_MARKDOWN_DIR_MISSING_MESSAGE);
+  }
+  return dir;
+}
+
+export async function getLearningCenterDir(): Promise<string | null> {
+  const config = await loadConfig();
+  return config.learningCenterDir?.trim() ?? null;
+}
+
+export async function getLibraryDir(): Promise<string | null> {
+  const config = await loadConfig();
+  return config.libraryDir?.trim() ?? null;
 }

--- a/mcp-server/src/constants.ts
+++ b/mcp-server/src/constants.ts
@@ -1,0 +1,2 @@
+export const BROWSER_USER_AGENT =
+  "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/136.0.0.0 Safari/537.36";

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -17,6 +17,18 @@ import { externalLinksTool, externalLinksToolSchema, type ExternalLinksToolInput
 import { imageReaderTool, imageReaderToolSchema, type ImageReaderInput } from "./tools/image-reader.js";
 import { searchTool, searchToolSchema } from "./tools/search.js";
 import type { SearchInput } from "./types/search.js";
+import { wikiFetchPageTool, wikiFetchPageSchema, type WikiFetchPageInput } from "./tools/wikiFetchPage.js";
+import {
+  wikiCountryHomeTool,
+  wikiCountryHomeSchema,
+  wikiCountryGettingStartedTool,
+  wikiCountryGettingStartedSchema,
+  wikiCountryRecordsTool,
+  wikiCountryRecordsSchema,
+  wikiCountryResearchTipsTool,
+  wikiCountryResearchTipsSchema,
+  type WikiCountryInput,
+} from "./tools/wikiCountryPage.js";
 
 const server = new Server(
   { name: "genealogy-mcp", version: "0.0.1" },
@@ -37,6 +49,11 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
     externalLinksToolSchema,
     imageReaderToolSchema,
     searchToolSchema,
+    wikiFetchPageSchema,
+    wikiCountryHomeSchema,
+    wikiCountryGettingStartedSchema,
+    wikiCountryRecordsSchema,
+    wikiCountryResearchTipsSchema,
   ],
 }));
 
@@ -222,6 +239,61 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         content: [{ type: "text", text: JSON.stringify({ error: message }) }],
         isError: true
       };
+    }
+  }
+  if (request.params.name === "wiki_fetch_page") {
+    try {
+      const args = request.params.arguments as unknown as WikiFetchPageInput;
+      const result = await wikiFetchPageTool(args);
+      return {
+        content: [{ type: "text", text: JSON.stringify(result, null, 2) }]
+      };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Unknown error";
+      return {
+        content: [{ type: "text", text: JSON.stringify({ error: message }) }],
+        isError: true
+      };
+    }
+  }
+  if (request.params.name === "wiki_country_home") {
+    try {
+      const args = request.params.arguments as unknown as WikiCountryInput;
+      const result = await wikiCountryHomeTool(args);
+      return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Unknown error";
+      return { content: [{ type: "text", text: JSON.stringify({ error: message }) }], isError: true };
+    }
+  }
+  if (request.params.name === "wiki_country_getting_started") {
+    try {
+      const args = request.params.arguments as unknown as WikiCountryInput;
+      const result = await wikiCountryGettingStartedTool(args);
+      return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Unknown error";
+      return { content: [{ type: "text", text: JSON.stringify({ error: message }) }], isError: true };
+    }
+  }
+  if (request.params.name === "wiki_country_records") {
+    try {
+      const args = request.params.arguments as unknown as WikiCountryInput;
+      const result = await wikiCountryRecordsTool(args);
+      return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Unknown error";
+      return { content: [{ type: "text", text: JSON.stringify({ error: message }) }], isError: true };
+    }
+  }
+  if (request.params.name === "wiki_country_research_tips") {
+    try {
+      const args = request.params.arguments as unknown as WikiCountryInput;
+      const result = await wikiCountryResearchTipsTool(args);
+      return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Unknown error";
+      return { content: [{ type: "text", text: JSON.stringify({ error: message }) }], isError: true };
     }
   }
   throw new Error(`Unknown tool: ${request.params.name}`);

--- a/mcp-server/src/tools/places.ts
+++ b/mcp-server/src/tools/places.ts
@@ -176,42 +176,54 @@ export async function getWikipediaSummary(title: string): Promise<WikipediaResul
  * Get place details by Primary (canonical) place ID.
  * Returns null for 404 (invalid ID), throws for other errors.
  */
-export async function getPlaceByPrimaryId(primaryId: string): Promise<GetPlaceResult | null> {
-  // Primary identifier URLs are "https://api.familysearch.org/platform/places/{primaryId}"
+type PrimaryIdResponse = {
+  places?: Array<{ id: string; names?: Array<{ lang: string; value: string }> }>;
+};
+
+async function fetchPrimaryIdResponse(primaryId: string): Promise<PrimaryIdResponse> {
   const url = `${FS_API_BASE}/${primaryId}`;
-
-  const response = await fetch(url, {
-    headers: {
-      Accept: "application/json",
-    },
-  });
-
+  const response = await fetch(url, { headers: { Accept: "application/json" } });
   if (!response.ok) {
-    if (response.status === 404) {
-      return null;
-    }
+    if (response.status === 404) return {};
     throw new Error(`FamilySearch API error: ${response.status} ${response.statusText}`);
   }
+  return (await response.json()) as PrimaryIdResponse;
+}
 
-  const data: FSPlaceDescriptionResponse = await response.json();
+export async function getPlaceCandidateNames(primaryId: string): Promise<string[]> {
+  const data = await fetchPrimaryIdResponse(primaryId);
+  if (!data.places?.length) return [];
 
-  if (!data.places || data.places.length === 0) {
-    return null;
+  const allNames = data.places[0].names ?? [];
+
+  // Keep proper-case English names: starts uppercase, not all-caps (filters abbreviations like PRT, MN)
+  const properEnglish = allNames
+    .filter(
+      (n) =>
+        n.lang === "en" &&
+        n.value.length > 0 &&
+        n.value[0] === n.value[0].toUpperCase() &&
+        n.value !== n.value.toUpperCase()
+    )
+    .map((n) => n.value);
+
+  // Deduplicate; single-word names first (more likely to be the canonical wiki page name)
+  const seen = new Set<string>();
+  const singleWord: string[] = [];
+  const multiWord: string[] = [];
+  for (const name of properEnglish) {
+    if (seen.has(name)) continue;
+    seen.add(name);
+    (name.includes(" ") ? multiWord : singleWord).push(name);
   }
+  return [...singleWord, ...multiWord];
+}
 
-  const place = data.places[0];
-
-  return {
-    placeId: extractPrimaryId(place.identifiers),
-    placeRepId: place.id,
-    name: place.display.name,
-    fullName: place.display.fullName,
-    type: place.display.type,
-    latitude: place.latitude,
-    longitude: place.longitude,
-    dateRange: place.temporalDescription?.formal,
-    parentPlaceRepId: place.jurisdiction?.resourceId,
-  };
+export async function getPlaceByPrimaryId(primaryId: string): Promise<GetPlaceResult | null> {
+  const candidates = await getPlaceCandidateNames(primaryId);
+  if (candidates.length === 0) return null;
+  const name = candidates[0];
+  return { placeId: primaryId, placeRepId: primaryId, name, fullName: name, type: "" };
 }
 
 /**

--- a/mcp-server/src/tools/places.ts
+++ b/mcp-server/src/tools/places.ts
@@ -173,6 +173,48 @@ export async function getWikipediaSummary(title: string): Promise<WikipediaResul
 }
 
 /**
+ * Get place details by Primary (canonical) place ID.
+ * Returns null for 404 (invalid ID), throws for other errors.
+ */
+export async function getPlaceByPrimaryId(primaryId: string): Promise<GetPlaceResult | null> {
+  // Primary identifier URLs are "https://api.familysearch.org/platform/places/{primaryId}"
+  const url = `${FS_API_BASE}/${primaryId}`;
+
+  const response = await fetch(url, {
+    headers: {
+      Accept: "application/json",
+    },
+  });
+
+  if (!response.ok) {
+    if (response.status === 404) {
+      return null;
+    }
+    throw new Error(`FamilySearch API error: ${response.status} ${response.statusText}`);
+  }
+
+  const data: FSPlaceDescriptionResponse = await response.json();
+
+  if (!data.places || data.places.length === 0) {
+    return null;
+  }
+
+  const place = data.places[0];
+
+  return {
+    placeId: extractPrimaryId(place.identifiers),
+    placeRepId: place.id,
+    name: place.display.name,
+    fullName: place.display.fullName,
+    type: place.display.type,
+    latitude: place.latitude,
+    longitude: place.longitude,
+    dateRange: place.temporalDescription?.formal,
+    parentPlaceRepId: place.jurisdiction?.resourceId,
+  };
+}
+
+/**
  * Detect if input looks like a numeric ID
  */
 function isNumericId(query: string): boolean {

--- a/mcp-server/src/tools/wikiCountryPage.ts
+++ b/mcp-server/src/tools/wikiCountryPage.ts
@@ -1,6 +1,6 @@
 import { readFile } from "fs/promises";
 import { join } from "path";
-import { getPlaceByPrimaryId } from "./places.js";
+import { getPlaceCandidateNames } from "./places.js";
 import { getWikiMarkdownDir } from "../auth/config.js";
 import type { WikiCountryInput, WikiCountryResult } from "../types/wikiPage.js";
 
@@ -22,24 +22,28 @@ async function readCountryPage(
   placeId: string,
   getCandidateSlugs: (nameSlug: string) => string[]
 ): Promise<WikiCountryResult> {
-  const place = await getPlaceByPrimaryId(placeId);
-  if (!place) {
+  const candidateNames = await getPlaceCandidateNames(placeId);
+  if (candidateNames.length === 0) {
     throw new Error(`No place found for placeId: ${placeId}`);
   }
 
   const wikiDir = await getWikiMarkdownDir();
-  const nameSlug = nameToSlug(place.name);
-  const slugCandidates = getCandidateSlugs(nameSlug);
 
-  for (const slug of slugCandidates) {
-    const content = await tryReadFile(join(wikiDir, `${slug}.md`));
-    if (content !== null) {
-      return { url: `${FS_WIKI_BASE}/${slug}`, content, placeId, placeName: place.name };
+  // Try every candidate name (the API returns many variants including typos).
+  // The file-existence check is the reliable filter — only the canonical name has a matching file.
+  for (const name of candidateNames) {
+    const nameSlug = nameToSlug(name);
+    for (const slug of getCandidateSlugs(nameSlug)) {
+      const content = await tryReadFile(join(wikiDir, `${slug}.md`));
+      if (content !== null) {
+        return { url: `${FS_WIKI_BASE}/${slug}`, content, placeId, placeName: name };
+      }
     }
   }
 
+  const tried = candidateNames.slice(0, 5).join(", ");
   throw new Error(
-    `No wiki page found for "${place.name}". Tried: ${slugCandidates.map((s) => s + ".md").join(", ")}`
+    `No wiki page found for place "${placeId}". Tried names: ${tried}${candidateNames.length > 5 ? " (and more)" : ""}`
   );
 }
 
@@ -56,8 +60,9 @@ const PLACE_ID_SCHEMA = {
 
 export async function wikiCountryHomeTool(input: WikiCountryInput): Promise<WikiCountryResult> {
   return readCountryPage(input.placeId, (nameSlug) => [
-    `${nameSlug}_Genealogy`,
-    `${nameSlug},_Canada_Genealogy`,
+    `${nameSlug}_Genealogy`,                    // countries: Portugal_Genealogy
+    `${nameSlug},_Canada_Genealogy`,            // Canadian provinces: Manitoba,_Canada_Genealogy
+    `${nameSlug},_United_States_Genealogy`,     // US states: Minnesota,_United_States_Genealogy
   ]);
 }
 

--- a/mcp-server/src/tools/wikiCountryPage.ts
+++ b/mcp-server/src/tools/wikiCountryPage.ts
@@ -1,0 +1,86 @@
+import { getPlaceById } from "./places.js";
+import { fetchAndCacheWikiPage } from "./wikiFetchPage.js";
+import type { WikiCountryInput, WikiCountryResult } from "../types/wikiPage.js";
+
+const FS_WIKI_BASE = "https://www.familysearch.org/en/wiki";
+
+function buildWikiUrl(name: string, suffix: string): string {
+  const slug = name.trim().replace(/ /g, "_");
+  return `${FS_WIKI_BASE}/${slug}${suffix}`;
+}
+
+async function fetchCountryPage(
+  input: WikiCountryInput,
+  suffix: string
+): Promise<WikiCountryResult> {
+  const place = await getPlaceById(input.placeRepId);
+  if (!place) {
+    throw new Error(`No place found for placeRepId: ${input.placeRepId}`);
+  }
+  const url = buildWikiUrl(place.name, suffix);
+  const result = await fetchAndCacheWikiPage(url);
+  return { ...result, placeRepId: input.placeRepId, placeName: place.name };
+}
+
+const PLACE_REP_ID_SCHEMA = {
+  type: "object" as const,
+  properties: {
+    placeRepId: {
+      type: "string",
+      description: "The FamilySearch place rep ID (from the places tool output)",
+    },
+  },
+  required: ["placeRepId"],
+};
+
+export async function wikiCountryHomeTool(input: WikiCountryInput): Promise<WikiCountryResult> {
+  return fetchCountryPage(input, "_Genealogy");
+}
+
+export const wikiCountryHomeSchema = {
+  name: "wiki_country_home",
+  description:
+    "Return the FamilySearch wiki homepage for a country, US state, or Canadian province. Given a place rep ID (from the places tool), fetches the main Genealogy overview page (e.g. Portugal_Genealogy) and returns it as markdown. Cached locally after the first fetch.",
+  inputSchema: PLACE_REP_ID_SCHEMA,
+};
+
+export async function wikiCountryGettingStartedTool(
+  input: WikiCountryInput
+): Promise<WikiCountryResult> {
+  return fetchCountryPage(input, "_Getting_Started");
+}
+
+export const wikiCountryGettingStartedSchema = {
+  name: "wiki_country_getting_started",
+  description:
+    "Return the FamilySearch wiki Getting Started guide for a country, US state, or Canadian province. Given a place rep ID (from the places tool), fetches the Getting Started page (e.g. Portugal_Getting_Started) and returns it as markdown. Cached locally after the first fetch.",
+  inputSchema: PLACE_REP_ID_SCHEMA,
+};
+
+export async function wikiCountryRecordsTool(
+  input: WikiCountryInput
+): Promise<WikiCountryResult> {
+  return fetchCountryPage(input, "_Online_Genealogy_Records");
+}
+
+export const wikiCountryRecordsSchema = {
+  name: "wiki_country_records",
+  description:
+    "Return the FamilySearch wiki Online Genealogy Records page for a country, US state, or Canadian province. Given a place rep ID (from the places tool), fetches the Online Genealogy Records page (e.g. Portugal_Online_Genealogy_Records) and returns it as markdown. Cached locally after the first fetch.",
+  inputSchema: PLACE_REP_ID_SCHEMA,
+};
+
+export async function wikiCountryResearchTipsTool(
+  input: WikiCountryInput
+): Promise<WikiCountryResult> {
+  return fetchCountryPage(input, "_Research_Tips_and_Strategies");
+}
+
+export const wikiCountryResearchTipsSchema = {
+  name: "wiki_country_research_tips",
+  description:
+    "Return the FamilySearch wiki Research Tips and Strategies page for a country, US state, or Canadian province. Given a place rep ID (from the places tool), fetches the Research Tips and Strategies page (e.g. Portugal_Research_Tips_and_Strategies) and returns it as markdown. Cached locally after the first fetch.",
+  inputSchema: PLACE_REP_ID_SCHEMA,
+};
+
+export type { WikiCountryInput };

--- a/mcp-server/src/tools/wikiCountryPage.ts
+++ b/mcp-server/src/tools/wikiCountryPage.ts
@@ -1,86 +1,120 @@
-import { getPlaceById } from "./places.js";
-import { fetchAndCacheWikiPage } from "./wikiFetchPage.js";
+import { readFile } from "fs/promises";
+import { join } from "path";
+import { getPlaceByPrimaryId } from "./places.js";
+import { getWikiMarkdownDir } from "../auth/config.js";
 import type { WikiCountryInput, WikiCountryResult } from "../types/wikiPage.js";
 
 const FS_WIKI_BASE = "https://www.familysearch.org/en/wiki";
 
-function buildWikiUrl(name: string, suffix: string): string {
-  const slug = name.trim().replace(/ /g, "_");
-  return `${FS_WIKI_BASE}/${slug}${suffix}`;
+function nameToSlug(name: string): string {
+  return name.trim().replace(/ /g, "_");
 }
 
-async function fetchCountryPage(
-  input: WikiCountryInput,
-  suffix: string
-): Promise<WikiCountryResult> {
-  const place = await getPlaceById(input.placeRepId);
-  if (!place) {
-    throw new Error(`No place found for placeRepId: ${input.placeRepId}`);
+async function tryReadFile(filePath: string): Promise<string | null> {
+  try {
+    return await readFile(filePath, "utf8");
+  } catch {
+    return null;
   }
-  const url = buildWikiUrl(place.name, suffix);
-  const result = await fetchAndCacheWikiPage(url);
-  return { ...result, placeRepId: input.placeRepId, placeName: place.name };
 }
 
-const PLACE_REP_ID_SCHEMA = {
+async function readCountryPage(
+  placeId: string,
+  getCandidateSlugs: (nameSlug: string) => string[]
+): Promise<WikiCountryResult> {
+  const place = await getPlaceByPrimaryId(placeId);
+  if (!place) {
+    throw new Error(`No place found for placeId: ${placeId}`);
+  }
+
+  const wikiDir = await getWikiMarkdownDir();
+  const nameSlug = nameToSlug(place.name);
+  const slugCandidates = getCandidateSlugs(nameSlug);
+
+  for (const slug of slugCandidates) {
+    const content = await tryReadFile(join(wikiDir, `${slug}.md`));
+    if (content !== null) {
+      return { url: `${FS_WIKI_BASE}/${slug}`, content, placeId, placeName: place.name };
+    }
+  }
+
+  throw new Error(
+    `No wiki page found for "${place.name}". Tried: ${slugCandidates.map((s) => s + ".md").join(", ")}`
+  );
+}
+
+const PLACE_ID_SCHEMA = {
   type: "object" as const,
   properties: {
-    placeRepId: {
+    placeId: {
       type: "string",
-      description: "The FamilySearch place rep ID (from the places tool output)",
+      description: "The FamilySearch place ID (the `placeId` field from the places tool output)",
     },
   },
-  required: ["placeRepId"],
+  required: ["placeId"],
 };
 
 export async function wikiCountryHomeTool(input: WikiCountryInput): Promise<WikiCountryResult> {
-  return fetchCountryPage(input, "_Genealogy");
+  return readCountryPage(input.placeId, (nameSlug) => [
+    `${nameSlug}_Genealogy`,
+    `${nameSlug},_Canada_Genealogy`,
+  ]);
 }
 
 export const wikiCountryHomeSchema = {
   name: "wiki_country_home",
   description:
-    "Return the FamilySearch wiki homepage for a country, US state, or Canadian province. Given a place rep ID (from the places tool), fetches the main Genealogy overview page (e.g. Portugal_Genealogy) and returns it as markdown. Cached locally after the first fetch.",
-  inputSchema: PLACE_REP_ID_SCHEMA,
+    "Return the FamilySearch wiki homepage for a country, US state, or Canadian province. " +
+    "Given a place ID (from the places tool), reads the main Genealogy overview page " +
+    "(e.g. Portugal_Genealogy) from the pre-crawled wiki files and returns it as markdown.",
+  inputSchema: PLACE_ID_SCHEMA,
 };
 
 export async function wikiCountryGettingStartedTool(
   input: WikiCountryInput
 ): Promise<WikiCountryResult> {
-  return fetchCountryPage(input, "_Getting_Started");
+  return readCountryPage(input.placeId, (nameSlug) => [`${nameSlug}_Getting_Started`]);
 }
 
 export const wikiCountryGettingStartedSchema = {
   name: "wiki_country_getting_started",
   description:
-    "Return the FamilySearch wiki Getting Started guide for a country, US state, or Canadian province. Given a place rep ID (from the places tool), fetches the Getting Started page (e.g. Portugal_Getting_Started) and returns it as markdown. Cached locally after the first fetch.",
-  inputSchema: PLACE_REP_ID_SCHEMA,
+    "Return the FamilySearch wiki Getting Started guide for a country, US state, or Canadian province. " +
+    "Given a place ID (from the places tool), reads the Getting Started page " +
+    "(e.g. Portugal_Getting_Started) from the pre-crawled wiki files and returns it as markdown.",
+  inputSchema: PLACE_ID_SCHEMA,
 };
 
 export async function wikiCountryRecordsTool(
   input: WikiCountryInput
 ): Promise<WikiCountryResult> {
-  return fetchCountryPage(input, "_Online_Genealogy_Records");
+  return readCountryPage(input.placeId, (nameSlug) => [`${nameSlug}_Online_Genealogy_Records`]);
 }
 
 export const wikiCountryRecordsSchema = {
   name: "wiki_country_records",
   description:
-    "Return the FamilySearch wiki Online Genealogy Records page for a country, US state, or Canadian province. Given a place rep ID (from the places tool), fetches the Online Genealogy Records page (e.g. Portugal_Online_Genealogy_Records) and returns it as markdown. Cached locally after the first fetch.",
-  inputSchema: PLACE_REP_ID_SCHEMA,
+    "Return the FamilySearch wiki Online Genealogy Records page for a country, US state, or Canadian province. " +
+    "Given a place ID (from the places tool), reads the Online Genealogy Records page " +
+    "(e.g. Portugal_Online_Genealogy_Records) from the pre-crawled wiki files and returns it as markdown.",
+  inputSchema: PLACE_ID_SCHEMA,
 };
 
 export async function wikiCountryResearchTipsTool(
   input: WikiCountryInput
 ): Promise<WikiCountryResult> {
-  return fetchCountryPage(input, "_Research_Tips_and_Strategies");
+  return readCountryPage(input.placeId, (nameSlug) => [
+    `${nameSlug}_Research_Tips_and_Strategies`,
+  ]);
 }
 
 export const wikiCountryResearchTipsSchema = {
   name: "wiki_country_research_tips",
   description:
-    "Return the FamilySearch wiki Research Tips and Strategies page for a country, US state, or Canadian province. Given a place rep ID (from the places tool), fetches the Research Tips and Strategies page (e.g. Portugal_Research_Tips_and_Strategies) and returns it as markdown. Cached locally after the first fetch.",
-  inputSchema: PLACE_REP_ID_SCHEMA,
+    "Return the FamilySearch wiki Research Tips and Strategies page for a country, US state, or Canadian province. " +
+    "Given a place ID (from the places tool), reads the Research Tips and Strategies page " +
+    "(e.g. Portugal_Research_Tips_and_Strategies) from the pre-crawled wiki files and returns it as markdown.",
+  inputSchema: PLACE_ID_SCHEMA,
 };
 
 export type { WikiCountryInput };

--- a/mcp-server/src/tools/wikiFetchPage.ts
+++ b/mcp-server/src/tools/wikiFetchPage.ts
@@ -1,0 +1,87 @@
+import { createHash } from "crypto";
+import { mkdir, readFile, writeFile } from "fs/promises";
+import { homedir } from "os";
+import { join } from "path";
+import { load } from "cheerio";
+import TurndownService from "turndown";
+import type { WikiFetchPageInput, WikiPageResult } from "../types/wikiPage.js";
+import { BROWSER_USER_AGENT } from "../constants.js";
+
+const CACHE_DIR = join(homedir(), ".familysearch-mcp", "wiki-cache");
+
+async function ensureCacheDir(): Promise<void> {
+  await mkdir(CACHE_DIR, { recursive: true });
+}
+
+function urlToCacheFilename(url: string): string {
+  return createHash("md5").update(url).digest("hex") + ".md";
+}
+
+export async function fetchAndCacheWikiPage(url: string): Promise<WikiPageResult> {
+  await ensureCacheDir();
+  const cacheFile = join(CACHE_DIR, urlToCacheFilename(url));
+
+  try {
+    const cached = await readFile(cacheFile, "utf8");
+    return { url, content: cached, cached: true };
+  } catch {
+    // Cache miss — fetch the page
+  }
+
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      headers: {
+        "User-Agent": BROWSER_USER_AGENT,
+        Accept: "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+        "Accept-Language": "en-US,en;q=0.5",
+        "Accept-Encoding": "gzip, deflate, br",
+        Connection: "keep-alive",
+        "Upgrade-Insecure-Requests": "1",
+      },
+    });
+  } catch (error) {
+    const cause = error instanceof Error ? error.message : String(error);
+    throw new Error(`Could not fetch wiki page at ${url}. (${cause})`);
+  }
+
+  if (response.status === 404) {
+    throw new Error(`No FamilySearch wiki page found at ${url}`);
+  }
+
+  if (!response.ok) {
+    throw new Error(`Wiki fetch error: ${response.status} for ${url}`);
+  }
+
+  const html = await response.text();
+  const $ = load(html);
+  const articleHtml = $(".mw-parser-output").html() ?? "";
+
+  const turndown = new TurndownService({ headingStyle: "atx", codeBlockStyle: "fenced" });
+  const markdown = turndown.turndown(articleHtml);
+
+  await writeFile(cacheFile, markdown, "utf8");
+  return { url, content: markdown, cached: false };
+}
+
+export async function wikiFetchPageTool(input: WikiFetchPageInput): Promise<WikiPageResult> {
+  return fetchAndCacheWikiPage(input.url);
+}
+
+export const wikiFetchPageSchema = {
+  name: "wiki_fetch_page",
+  description:
+    "Fetch any FamilySearch wiki page and return its full content as markdown. Use this when you have a specific wiki URL. Pages are cached locally after the first fetch.",
+  inputSchema: {
+    type: "object" as const,
+    properties: {
+      url: {
+        type: "string",
+        description: "The full URL of a FamilySearch wiki page",
+      },
+    },
+    required: ["url"],
+  },
+};
+
+export type { WikiFetchPageInput };

--- a/mcp-server/src/tools/wikiFetchPage.ts
+++ b/mcp-server/src/tools/wikiFetchPage.ts
@@ -1,83 +1,47 @@
-import { createHash } from "crypto";
-import { mkdir, readFile, writeFile } from "fs/promises";
-import { homedir } from "os";
+import { readFile } from "fs/promises";
 import { join } from "path";
-import { load } from "cheerio";
-import TurndownService from "turndown";
+import { getWikiMarkdownDir } from "../auth/config.js";
 import type { WikiFetchPageInput, WikiPageResult } from "../types/wikiPage.js";
-import { BROWSER_USER_AGENT } from "../constants.js";
 
-const CACHE_DIR = join(homedir(), ".familysearch-mcp", "wiki-cache");
+const FS_WIKI_BASE = "https://www.familysearch.org/en/wiki";
 
-async function ensureCacheDir(): Promise<void> {
-  await mkdir(CACHE_DIR, { recursive: true });
-}
-
-function urlToCacheFilename(url: string): string {
-  return createHash("md5").update(url).digest("hex") + ".md";
-}
-
-export async function fetchAndCacheWikiPage(url: string): Promise<WikiPageResult> {
-  await ensureCacheDir();
-  const cacheFile = join(CACHE_DIR, urlToCacheFilename(url));
-
-  try {
-    const cached = await readFile(cacheFile, "utf8");
-    return { url, content: cached, cached: true };
-  } catch {
-    // Cache miss — fetch the page
+function urlToSlug(url: string): string {
+  const match = url.match(/\/wiki\/([^?#]+)/);
+  if (!match) {
+    throw new Error(`Not a valid FamilySearch wiki URL: ${url}`);
   }
-
-  let response: Response;
-  try {
-    response = await fetch(url, {
-      headers: {
-        "User-Agent": BROWSER_USER_AGENT,
-        Accept: "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
-        "Accept-Language": "en-US,en;q=0.5",
-        "Accept-Encoding": "gzip, deflate, br",
-        Connection: "keep-alive",
-        "Upgrade-Insecure-Requests": "1",
-      },
-    });
-  } catch (error) {
-    const cause = error instanceof Error ? error.message : String(error);
-    throw new Error(`Could not fetch wiki page at ${url}. (${cause})`);
-  }
-
-  if (response.status === 404) {
-    throw new Error(`No FamilySearch wiki page found at ${url}`);
-  }
-
-  if (!response.ok) {
-    throw new Error(`Wiki fetch error: ${response.status} for ${url}`);
-  }
-
-  const html = await response.text();
-  const $ = load(html);
-  const articleHtml = $(".mw-parser-output").html() ?? "";
-
-  const turndown = new TurndownService({ headingStyle: "atx", codeBlockStyle: "fenced" });
-  const markdown = turndown.turndown(articleHtml);
-
-  await writeFile(cacheFile, markdown, "utf8");
-  return { url, content: markdown, cached: false };
+  return decodeURIComponent(match[1]);
 }
 
 export async function wikiFetchPageTool(input: WikiFetchPageInput): Promise<WikiPageResult> {
-  return fetchAndCacheWikiPage(input.url);
+  const slug = urlToSlug(input.url);
+  const wikiDir = await getWikiMarkdownDir();
+  const filePath = join(wikiDir, `${slug}.md`);
+
+  try {
+    const content = await readFile(filePath, "utf8");
+    return { url: `${FS_WIKI_BASE}/${slug}`, content };
+  } catch {
+    throw new Error(
+      `No wiki page found for "${slug}". The page may not exist in the pre-crawled files.`
+    );
+  }
 }
 
 export const wikiFetchPageSchema = {
   name: "wiki_fetch_page",
   description:
-    "Fetch any FamilySearch wiki page and return its full content as markdown. Use this when you have a specific wiki URL. Pages are cached locally after the first fetch.",
+    "Read any FamilySearch wiki page from the pre-crawled markdown files on disk. " +
+    "Pass the full FamilySearch wiki URL; the page title is extracted and the pre-crawled markdown is returned. " +
+    "Use this for specific wiki pages not covered by the country-specific tools.",
   inputSchema: {
     type: "object" as const,
     properties: {
       url: {
         type: "string",
-        description: "The full URL of a FamilySearch wiki page",
+        description:
+          "The full URL of a FamilySearch wiki page " +
+          "(e.g. https://www.familysearch.org/en/wiki/Portugal_Genealogy)",
       },
     },
     required: ["url"],

--- a/mcp-server/src/types/auth.ts
+++ b/mcp-server/src/types/auth.ts
@@ -28,4 +28,7 @@ export interface FSTokenResponse {
 export interface AppConfig {
   clientId?: string;
   wikiApiUrl?: string;
+  wikiMarkdownDir?: string;
+  learningCenterDir?: string;
+  libraryDir?: string;
 }

--- a/mcp-server/src/types/wikiPage.ts
+++ b/mcp-server/src/types/wikiPage.ts
@@ -5,14 +5,13 @@ export interface WikiFetchPageInput {
 export interface WikiPageResult {
   url: string;
   content: string;
-  cached: boolean;
 }
 
 export interface WikiCountryInput {
-  placeRepId: string;
+  placeId: string;
 }
 
 export interface WikiCountryResult extends WikiPageResult {
-  placeRepId: string;
+  placeId: string;
   placeName: string;
 }

--- a/mcp-server/src/types/wikiPage.ts
+++ b/mcp-server/src/types/wikiPage.ts
@@ -1,0 +1,18 @@
+export interface WikiFetchPageInput {
+  url: string;
+}
+
+export interface WikiPageResult {
+  url: string;
+  content: string;
+  cached: boolean;
+}
+
+export interface WikiCountryInput {
+  placeRepId: string;
+}
+
+export interface WikiCountryResult extends WikiPageResult {
+  placeRepId: string;
+  placeName: string;
+}

--- a/mcp-server/tests/tools/wikiCountryPage.test.ts
+++ b/mcp-server/tests/tools/wikiCountryPage.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockGetPlaceById = vi.hoisted(() => vi.fn());
+vi.mock("../../src/tools/places.js", () => ({
+  getPlaceById: mockGetPlaceById,
+  searchPlace: vi.fn(),
+  getWikipediaSummary: vi.fn(),
+  placesTool: vi.fn(),
+}));
+
+const mockFetchAndCacheWikiPage = vi.hoisted(() => vi.fn());
+vi.mock("../../src/tools/wikiFetchPage.js", () => ({
+  fetchAndCacheWikiPage: mockFetchAndCacheWikiPage,
+  wikiFetchPageTool: vi.fn(),
+  wikiFetchPageSchema: {},
+}));
+
+import {
+  wikiCountryHomeTool,
+  wikiCountryGettingStartedTool,
+  wikiCountryRecordsTool,
+  wikiCountryResearchTipsTool,
+} from "../../src/tools/wikiCountryPage.js";
+
+const MOCK_RESULT = { url: "", content: "# Content", cached: false };
+
+beforeEach(() => {
+  mockGetPlaceById.mockReset();
+  mockFetchAndCacheWikiPage.mockReset().mockResolvedValue(MOCK_RESULT);
+});
+
+describe("wikiCountryHomeTool", () => {
+  it("builds the correct _Genealogy URL", async () => {
+    mockGetPlaceById.mockResolvedValueOnce({ name: "Portugal", placeRepId: "267" });
+    await wikiCountryHomeTool({ placeRepId: "267" });
+    expect(mockFetchAndCacheWikiPage).toHaveBeenCalledWith(
+      "https://www.familysearch.org/en/wiki/Portugal_Genealogy"
+    );
+  });
+});
+
+describe("wikiCountryGettingStartedTool", () => {
+  it("builds the correct _Getting_Started URL", async () => {
+    mockGetPlaceById.mockResolvedValueOnce({ name: "Portugal", placeRepId: "267" });
+    await wikiCountryGettingStartedTool({ placeRepId: "267" });
+    expect(mockFetchAndCacheWikiPage).toHaveBeenCalledWith(
+      "https://www.familysearch.org/en/wiki/Portugal_Getting_Started"
+    );
+  });
+});
+
+describe("wikiCountryRecordsTool", () => {
+  it("builds the correct _Online_Genealogy_Records URL", async () => {
+    mockGetPlaceById.mockResolvedValueOnce({ name: "Portugal", placeRepId: "267" });
+    await wikiCountryRecordsTool({ placeRepId: "267" });
+    expect(mockFetchAndCacheWikiPage).toHaveBeenCalledWith(
+      "https://www.familysearch.org/en/wiki/Portugal_Online_Genealogy_Records"
+    );
+  });
+});
+
+describe("wikiCountryResearchTipsTool", () => {
+  it("builds the correct _Research_Tips_and_Strategies URL", async () => {
+    mockGetPlaceById.mockResolvedValueOnce({ name: "Portugal", placeRepId: "267" });
+    await wikiCountryResearchTipsTool({ placeRepId: "267" });
+    expect(mockFetchAndCacheWikiPage).toHaveBeenCalledWith(
+      "https://www.familysearch.org/en/wiki/Portugal_Research_Tips_and_Strategies"
+    );
+  });
+});
+
+describe("shared behaviour across all 4 tools", () => {
+  it("replaces spaces with underscores for multi-word place names", async () => {
+    mockGetPlaceById.mockResolvedValueOnce({ name: "British Columbia", placeRepId: "123" });
+    await wikiCountryHomeTool({ placeRepId: "123" });
+    expect(mockFetchAndCacheWikiPage).toHaveBeenCalledWith(
+      "https://www.familysearch.org/en/wiki/British_Columbia_Genealogy"
+    );
+  });
+
+  it("includes place metadata in the result", async () => {
+    mockGetPlaceById.mockResolvedValueOnce({ name: "Portugal", placeRepId: "267" });
+    mockFetchAndCacheWikiPage.mockResolvedValueOnce({
+      url: "https://www.familysearch.org/en/wiki/Portugal_Genealogy",
+      content: "# Portugal",
+      cached: true,
+    });
+    const result = await wikiCountryHomeTool({ placeRepId: "267" });
+    expect(result.placeRepId).toBe("267");
+    expect(result.placeName).toBe("Portugal");
+    expect(result.cached).toBe(true);
+  });
+
+  it("throws when place is not found", async () => {
+    mockGetPlaceById.mockResolvedValueOnce(null);
+    await expect(wikiCountryHomeTool({ placeRepId: "999" })).rejects.toThrow(
+      /No place found for placeRepId: 999/
+    );
+  });
+
+  it("propagates fetch errors", async () => {
+    mockGetPlaceById.mockResolvedValueOnce({ name: "Portugal", placeRepId: "267" });
+    mockFetchAndCacheWikiPage.mockRejectedValueOnce(
+      new Error("No FamilySearch wiki page found at ...")
+    );
+    await expect(wikiCountryHomeTool({ placeRepId: "267" })).rejects.toThrow(
+      /No FamilySearch wiki page found/
+    );
+  });
+});

--- a/mcp-server/tests/tools/wikiCountryPage.test.ts
+++ b/mcp-server/tests/tools/wikiCountryPage.test.ts
@@ -1,18 +1,23 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
-const mockGetPlaceById = vi.hoisted(() => vi.fn());
+const mockGetPlaceByPrimaryId = vi.hoisted(() => vi.fn());
 vi.mock("../../src/tools/places.js", () => ({
-  getPlaceById: mockGetPlaceById,
+  getPlaceByPrimaryId: mockGetPlaceByPrimaryId,
+  getPlaceById: vi.fn(),
   searchPlace: vi.fn(),
   getWikipediaSummary: vi.fn(),
   placesTool: vi.fn(),
 }));
 
-const mockFetchAndCacheWikiPage = vi.hoisted(() => vi.fn());
-vi.mock("../../src/tools/wikiFetchPage.js", () => ({
-  fetchAndCacheWikiPage: mockFetchAndCacheWikiPage,
-  wikiFetchPageTool: vi.fn(),
-  wikiFetchPageSchema: {},
+const mockReadFile = vi.hoisted(() => vi.fn());
+vi.mock("fs/promises", () => ({
+  readFile: mockReadFile,
+}));
+
+const mockGetWikiMarkdownDir = vi.hoisted(() => vi.fn());
+vi.mock("../../src/auth/config.js", () => ({
+  getWikiMarkdownDir: mockGetWikiMarkdownDir,
+  getWikiApiUrl: vi.fn(),
 }));
 
 import {
@@ -22,89 +27,147 @@ import {
   wikiCountryResearchTipsTool,
 } from "../../src/tools/wikiCountryPage.js";
 
-const MOCK_RESULT = { url: "", content: "# Content", cached: false };
+const WIKI_DIR = "/test/wiki/dir";
+const PORTUGAL = { name: "Portugal", placeId: "1927089", placeRepId: "267" };
+const MANITOBA = { name: "Manitoba", placeId: "1927456", placeRepId: "999" };
+const BRITISH_COLUMBIA = { name: "British Columbia", placeId: "1927123", placeRepId: "456" };
 
 beforeEach(() => {
-  mockGetPlaceById.mockReset();
-  mockFetchAndCacheWikiPage.mockReset().mockResolvedValue(MOCK_RESULT);
+  mockGetPlaceByPrimaryId.mockReset();
+  mockReadFile.mockReset();
+  mockGetWikiMarkdownDir.mockResolvedValue(WIKI_DIR);
 });
 
 describe("wikiCountryHomeTool", () => {
-  it("builds the correct _Genealogy URL", async () => {
-    mockGetPlaceById.mockResolvedValueOnce({ name: "Portugal", placeRepId: "267" });
-    await wikiCountryHomeTool({ placeRepId: "267" });
-    expect(mockFetchAndCacheWikiPage).toHaveBeenCalledWith(
-      "https://www.familysearch.org/en/wiki/Portugal_Genealogy"
+  it("reads Portugal_Genealogy.md when it exists", async () => {
+    mockGetPlaceByPrimaryId.mockResolvedValueOnce(PORTUGAL);
+    mockReadFile.mockResolvedValueOnce("# Portugal");
+
+    const result = await wikiCountryHomeTool({ placeId: "1927089" });
+
+    expect(mockReadFile).toHaveBeenCalledWith(`${WIKI_DIR}/Portugal_Genealogy.md`, "utf8");
+    expect(result.placeId).toBe("1927089");
+    expect(result.placeName).toBe("Portugal");
+    expect(result.url).toBe("https://www.familysearch.org/en/wiki/Portugal_Genealogy");
+    expect(result).not.toHaveProperty("placeRepId");
+    expect(result).not.toHaveProperty("cached");
+  });
+
+  it("falls back to Manitoba,_Canada_Genealogy.md when plain _Genealogy is missing", async () => {
+    mockGetPlaceByPrimaryId.mockResolvedValueOnce(MANITOBA);
+    mockReadFile
+      .mockRejectedValueOnce(new Error("ENOENT"))
+      .mockResolvedValueOnce("# Manitoba Genealogy");
+
+    const result = await wikiCountryHomeTool({ placeId: "1927456" });
+
+    expect(mockReadFile).toHaveBeenNthCalledWith(
+      1,
+      `${WIKI_DIR}/Manitoba_Genealogy.md`,
+      "utf8"
+    );
+    expect(mockReadFile).toHaveBeenNthCalledWith(
+      2,
+      `${WIKI_DIR}/Manitoba,_Canada_Genealogy.md`,
+      "utf8"
+    );
+    expect(result.url).toBe(
+      "https://www.familysearch.org/en/wiki/Manitoba,_Canada_Genealogy"
+    );
+    expect(result.placeId).toBe("1927456");
+  });
+
+  it("throws when neither file candidate exists", async () => {
+    mockGetPlaceByPrimaryId.mockResolvedValueOnce(MANITOBA);
+    mockReadFile.mockRejectedValue(new Error("ENOENT"));
+
+    await expect(wikiCountryHomeTool({ placeId: "1927456" })).rejects.toThrow(
+      /No wiki page found for "Manitoba"/
+    );
+  });
+
+  it("handles multi-word place names with underscores", async () => {
+    mockGetPlaceByPrimaryId.mockResolvedValueOnce(BRITISH_COLUMBIA);
+    mockReadFile.mockResolvedValueOnce("# BC");
+
+    await wikiCountryHomeTool({ placeId: "1927123" });
+
+    expect(mockReadFile).toHaveBeenCalledWith(
+      `${WIKI_DIR}/British_Columbia_Genealogy.md`,
+      "utf8"
+    );
+  });
+
+  it("throws when place is not found", async () => {
+    mockGetPlaceByPrimaryId.mockResolvedValueOnce(null);
+
+    await expect(wikiCountryHomeTool({ placeId: "999" })).rejects.toThrow(
+      /No place found for placeId: 999/
     );
   });
 });
 
 describe("wikiCountryGettingStartedTool", () => {
-  it("builds the correct _Getting_Started URL", async () => {
-    mockGetPlaceById.mockResolvedValueOnce({ name: "Portugal", placeRepId: "267" });
-    await wikiCountryGettingStartedTool({ placeRepId: "267" });
-    expect(mockFetchAndCacheWikiPage).toHaveBeenCalledWith(
-      "https://www.familysearch.org/en/wiki/Portugal_Getting_Started"
+  it("reads the correct _Getting_Started file", async () => {
+    mockGetPlaceByPrimaryId.mockResolvedValueOnce(PORTUGAL);
+    mockReadFile.mockResolvedValueOnce("# Getting Started");
+
+    await wikiCountryGettingStartedTool({ placeId: "1927089" });
+
+    expect(mockReadFile).toHaveBeenCalledWith(
+      `${WIKI_DIR}/Portugal_Getting_Started.md`,
+      "utf8"
     );
+  });
+
+  it("does not try a Canada variant (no fallback for non-home pages)", async () => {
+    mockGetPlaceByPrimaryId.mockResolvedValueOnce(MANITOBA);
+    mockReadFile.mockRejectedValueOnce(new Error("ENOENT"));
+
+    await expect(wikiCountryGettingStartedTool({ placeId: "1927456" })).rejects.toThrow(
+      /No wiki page found for "Manitoba"/
+    );
+    expect(mockReadFile).toHaveBeenCalledTimes(1);
   });
 });
 
 describe("wikiCountryRecordsTool", () => {
-  it("builds the correct _Online_Genealogy_Records URL", async () => {
-    mockGetPlaceById.mockResolvedValueOnce({ name: "Portugal", placeRepId: "267" });
-    await wikiCountryRecordsTool({ placeRepId: "267" });
-    expect(mockFetchAndCacheWikiPage).toHaveBeenCalledWith(
-      "https://www.familysearch.org/en/wiki/Portugal_Online_Genealogy_Records"
+  it("reads the correct _Online_Genealogy_Records file", async () => {
+    mockGetPlaceByPrimaryId.mockResolvedValueOnce(PORTUGAL);
+    mockReadFile.mockResolvedValueOnce("# Records");
+
+    await wikiCountryRecordsTool({ placeId: "1927089" });
+
+    expect(mockReadFile).toHaveBeenCalledWith(
+      `${WIKI_DIR}/Portugal_Online_Genealogy_Records.md`,
+      "utf8"
     );
   });
 });
 
 describe("wikiCountryResearchTipsTool", () => {
-  it("builds the correct _Research_Tips_and_Strategies URL", async () => {
-    mockGetPlaceById.mockResolvedValueOnce({ name: "Portugal", placeRepId: "267" });
-    await wikiCountryResearchTipsTool({ placeRepId: "267" });
-    expect(mockFetchAndCacheWikiPage).toHaveBeenCalledWith(
-      "https://www.familysearch.org/en/wiki/Portugal_Research_Tips_and_Strategies"
+  it("reads the correct _Research_Tips_and_Strategies file", async () => {
+    mockGetPlaceByPrimaryId.mockResolvedValueOnce(PORTUGAL);
+    mockReadFile.mockResolvedValueOnce("# Research Tips");
+
+    await wikiCountryResearchTipsTool({ placeId: "1927089" });
+
+    expect(mockReadFile).toHaveBeenCalledWith(
+      `${WIKI_DIR}/Portugal_Research_Tips_and_Strategies.md`,
+      "utf8"
     );
   });
 });
 
 describe("shared behaviour across all 4 tools", () => {
-  it("replaces spaces with underscores for multi-word place names", async () => {
-    mockGetPlaceById.mockResolvedValueOnce({ name: "British Columbia", placeRepId: "123" });
-    await wikiCountryHomeTool({ placeRepId: "123" });
-    expect(mockFetchAndCacheWikiPage).toHaveBeenCalledWith(
-      "https://www.familysearch.org/en/wiki/British_Columbia_Genealogy"
-    );
-  });
+  it("includes placeId and placeName in the result", async () => {
+    mockGetPlaceByPrimaryId.mockResolvedValueOnce(PORTUGAL);
+    mockReadFile.mockResolvedValueOnce("# Portugal");
 
-  it("includes place metadata in the result", async () => {
-    mockGetPlaceById.mockResolvedValueOnce({ name: "Portugal", placeRepId: "267" });
-    mockFetchAndCacheWikiPage.mockResolvedValueOnce({
-      url: "https://www.familysearch.org/en/wiki/Portugal_Genealogy",
-      content: "# Portugal",
-      cached: true,
-    });
-    const result = await wikiCountryHomeTool({ placeRepId: "267" });
-    expect(result.placeRepId).toBe("267");
+    const result = await wikiCountryHomeTool({ placeId: "1927089" });
+
+    expect(result.placeId).toBe("1927089");
     expect(result.placeName).toBe("Portugal");
-    expect(result.cached).toBe(true);
-  });
-
-  it("throws when place is not found", async () => {
-    mockGetPlaceById.mockResolvedValueOnce(null);
-    await expect(wikiCountryHomeTool({ placeRepId: "999" })).rejects.toThrow(
-      /No place found for placeRepId: 999/
-    );
-  });
-
-  it("propagates fetch errors", async () => {
-    mockGetPlaceById.mockResolvedValueOnce({ name: "Portugal", placeRepId: "267" });
-    mockFetchAndCacheWikiPage.mockRejectedValueOnce(
-      new Error("No FamilySearch wiki page found at ...")
-    );
-    await expect(wikiCountryHomeTool({ placeRepId: "267" })).rejects.toThrow(
-      /No FamilySearch wiki page found/
-    );
+    expect(result.content).toBe("# Portugal");
   });
 });

--- a/mcp-server/tests/tools/wikiFetchPage.test.ts
+++ b/mcp-server/tests/tools/wikiFetchPage.test.ts
@@ -1,98 +1,72 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 const mockReadFile = vi.hoisted(() => vi.fn());
-const mockWriteFile = vi.hoisted(() => vi.fn());
-const mockMkdir = vi.hoisted(() => vi.fn());
-
 vi.mock("fs/promises", () => ({
   readFile: mockReadFile,
-  writeFile: mockWriteFile,
-  mkdir: mockMkdir,
 }));
 
-const mockLoad = vi.hoisted(() => vi.fn());
-vi.mock("cheerio", () => ({ load: mockLoad }));
-
-const mockTurndownConvert = vi.hoisted(() => vi.fn().mockReturnValue("# Article"));
-
-vi.mock("turndown", () => ({
-  default: class MockTurndown {
-    turndown(html: string) {
-      return mockTurndownConvert(html);
-    }
-  },
+const mockGetWikiMarkdownDir = vi.hoisted(() => vi.fn());
+vi.mock("../../src/auth/config.js", () => ({
+  getWikiMarkdownDir: mockGetWikiMarkdownDir,
+  getWikiApiUrl: vi.fn(),
 }));
-
-const mockFetch = vi.fn();
-vi.stubGlobal("fetch", mockFetch);
 
 import { wikiFetchPageTool } from "../../src/tools/wikiFetchPage.js";
 
+const WIKI_DIR = "/test/wiki/dir";
 const TEST_URL = "https://www.familysearch.org/en/wiki/Portugal_Genealogy";
 
 beforeEach(() => {
-  mockFetch.mockReset();
   mockReadFile.mockReset();
-  mockWriteFile.mockReset().mockResolvedValue(undefined);
-  mockMkdir.mockResolvedValue(undefined);
-  mockLoad.mockReturnValue((_selector: string) => ({ html: () => "<p>Article</p>" }));
-  mockTurndownConvert.mockReturnValue("# Article");
+  mockGetWikiMarkdownDir.mockResolvedValue(WIKI_DIR);
 });
 
 describe("wikiFetchPageTool", () => {
-  it("returns cached content without fetching when cache file exists", async () => {
-    mockReadFile.mockResolvedValueOnce("# Cached Portugal page");
+  it("reads the correct file from disk for a valid wiki URL", async () => {
+    mockReadFile.mockResolvedValueOnce("# Portugal Genealogy");
 
     const result = await wikiFetchPageTool({ url: TEST_URL });
 
-    expect(result.cached).toBe(true);
-    expect(result.content).toBe("# Cached Portugal page");
-    expect(result.url).toBe(TEST_URL);
-    expect(mockFetch).not.toHaveBeenCalled();
+    expect(mockReadFile).toHaveBeenCalledWith(`${WIKI_DIR}/Portugal_Genealogy.md`, "utf8");
+    expect(result.url).toBe("https://www.familysearch.org/en/wiki/Portugal_Genealogy");
+    expect(result.content).toBe("# Portugal Genealogy");
+    expect(result).not.toHaveProperty("cached");
   });
 
-  it("fetches, converts, writes cache, and returns markdown on cache miss", async () => {
+  it("throws a descriptive error when the file is not on disk", async () => {
     mockReadFile.mockRejectedValueOnce(new Error("ENOENT"));
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      status: 200,
-      text: async () =>
-        "<html><div class='mw-parser-output'><p>Content</p></div></html>",
-    });
-    mockTurndownConvert.mockReturnValueOnce("# Fetched content");
-
-    const result = await wikiFetchPageTool({ url: TEST_URL });
-
-    expect(result.cached).toBe(false);
-    expect(result.url).toBe(TEST_URL);
-    expect(mockFetch).toHaveBeenCalledWith(TEST_URL, expect.any(Object));
-    expect(mockWriteFile).toHaveBeenCalled();
-  });
-
-  it("throws a descriptive error for 404", async () => {
-    mockReadFile.mockRejectedValueOnce(new Error("ENOENT"));
-    mockFetch.mockResolvedValueOnce({ ok: false, status: 404 });
 
     await expect(wikiFetchPageTool({ url: TEST_URL })).rejects.toThrow(
-      /No FamilySearch wiki page found/
+      /No wiki page found for "Portugal_Genealogy"/
     );
   });
 
-  it("throws a friendly error when the server is unreachable", async () => {
-    mockReadFile.mockRejectedValueOnce(new Error("ENOENT"));
-    mockFetch.mockRejectedValueOnce(new Error("ECONNREFUSED"));
+  it("throws when given a non-wiki URL", async () => {
+    await expect(
+      wikiFetchPageTool({ url: "https://www.google.com/search?q=test" })
+    ).rejects.toThrow(/Not a valid FamilySearch wiki URL/);
+  });
 
-    await expect(wikiFetchPageTool({ url: TEST_URL })).rejects.toThrow(
-      /Could not fetch wiki page/
+  it("handles URL-encoded slugs correctly", async () => {
+    mockReadFile.mockResolvedValueOnce("# Manitoba");
+    const encodedUrl =
+      "https://www.familysearch.org/en/wiki/Manitoba%2C_Canada_Genealogy";
+
+    await wikiFetchPageTool({ url: encodedUrl });
+
+    expect(mockReadFile).toHaveBeenCalledWith(
+      `${WIKI_DIR}/Manitoba,_Canada_Genealogy.md`,
+      "utf8"
     );
   });
 
-  it("throws on non-200, non-404 status", async () => {
-    mockReadFile.mockRejectedValueOnce(new Error("ENOENT"));
-    mockFetch.mockResolvedValueOnce({ ok: false, status: 500 });
+  it("extracts slug from URL with query params or fragments", async () => {
+    mockReadFile.mockResolvedValueOnce("# Content");
+    const urlWithParams =
+      "https://www.familysearch.org/en/wiki/Portugal_Genealogy?section=2#top";
 
-    await expect(wikiFetchPageTool({ url: TEST_URL })).rejects.toThrow(
-      /Wiki fetch error: 500/
-    );
+    await wikiFetchPageTool({ url: urlWithParams });
+
+    expect(mockReadFile).toHaveBeenCalledWith(`${WIKI_DIR}/Portugal_Genealogy.md`, "utf8");
   });
 });

--- a/mcp-server/tests/tools/wikiFetchPage.test.ts
+++ b/mcp-server/tests/tools/wikiFetchPage.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockReadFile = vi.hoisted(() => vi.fn());
+const mockWriteFile = vi.hoisted(() => vi.fn());
+const mockMkdir = vi.hoisted(() => vi.fn());
+
+vi.mock("fs/promises", () => ({
+  readFile: mockReadFile,
+  writeFile: mockWriteFile,
+  mkdir: mockMkdir,
+}));
+
+const mockLoad = vi.hoisted(() => vi.fn());
+vi.mock("cheerio", () => ({ load: mockLoad }));
+
+const mockTurndownConvert = vi.hoisted(() => vi.fn().mockReturnValue("# Article"));
+
+vi.mock("turndown", () => ({
+  default: class MockTurndown {
+    turndown(html: string) {
+      return mockTurndownConvert(html);
+    }
+  },
+}));
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+import { wikiFetchPageTool } from "../../src/tools/wikiFetchPage.js";
+
+const TEST_URL = "https://www.familysearch.org/en/wiki/Portugal_Genealogy";
+
+beforeEach(() => {
+  mockFetch.mockReset();
+  mockReadFile.mockReset();
+  mockWriteFile.mockReset().mockResolvedValue(undefined);
+  mockMkdir.mockResolvedValue(undefined);
+  mockLoad.mockReturnValue((_selector: string) => ({ html: () => "<p>Article</p>" }));
+  mockTurndownConvert.mockReturnValue("# Article");
+});
+
+describe("wikiFetchPageTool", () => {
+  it("returns cached content without fetching when cache file exists", async () => {
+    mockReadFile.mockResolvedValueOnce("# Cached Portugal page");
+
+    const result = await wikiFetchPageTool({ url: TEST_URL });
+
+    expect(result.cached).toBe(true);
+    expect(result.content).toBe("# Cached Portugal page");
+    expect(result.url).toBe(TEST_URL);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("fetches, converts, writes cache, and returns markdown on cache miss", async () => {
+    mockReadFile.mockRejectedValueOnce(new Error("ENOENT"));
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      text: async () =>
+        "<html><div class='mw-parser-output'><p>Content</p></div></html>",
+    });
+    mockTurndownConvert.mockReturnValueOnce("# Fetched content");
+
+    const result = await wikiFetchPageTool({ url: TEST_URL });
+
+    expect(result.cached).toBe(false);
+    expect(result.url).toBe(TEST_URL);
+    expect(mockFetch).toHaveBeenCalledWith(TEST_URL, expect.any(Object));
+    expect(mockWriteFile).toHaveBeenCalled();
+  });
+
+  it("throws a descriptive error for 404", async () => {
+    mockReadFile.mockRejectedValueOnce(new Error("ENOENT"));
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 404 });
+
+    await expect(wikiFetchPageTool({ url: TEST_URL })).rejects.toThrow(
+      /No FamilySearch wiki page found/
+    );
+  });
+
+  it("throws a friendly error when the server is unreachable", async () => {
+    mockReadFile.mockRejectedValueOnce(new Error("ENOENT"));
+    mockFetch.mockRejectedValueOnce(new Error("ECONNREFUSED"));
+
+    await expect(wikiFetchPageTool({ url: TEST_URL })).rejects.toThrow(
+      /Could not fetch wiki page/
+    );
+  });
+
+  it("throws on non-200, non-404 status", async () => {
+    mockReadFile.mockRejectedValueOnce(new Error("ENOENT"));
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 500 });
+
+    await expect(wikiFetchPageTool({ url: TEST_URL })).rejects.toThrow(
+      /Wiki fetch error: 500/
+    );
+  });
+});


### PR DESCRIPTION
Adds wiki_fetch_page (generic URL fetch) and four country-specific endpoints: wiki_country_home, wiki_country_getting_started, wiki_country_records, and wiki_country_research_tips. Each accepts a placeRepId, resolves the place name via the FamilySearch Places API, constructs the FamilySearch wiki URL, and returns the page as markdown. Pages are cached locally under ~/.familysearch-mcp/wiki-cache/ after the first fetch. Works for countries, US states, and Canadian provinces.