### PR TITLE
Add ParentChild subtype and relationship notes to simplified format

### DIFF
--- a/docs/specs/gedcomx-convert-spec.md
+++ b/docs/specs/gedcomx-convert-spec.md
@@ -88,7 +88,14 @@ export type GedcomXRelationship = {
   person1?: { resource: string };
   person2?: { resource: string };
   facts?: GedcomXFact[];
+  notes?: GedcomXNote[];
   sources?: GedcomXSourceReference[];
+};
+
+export type GedcomXNote = {
+  subject?: string;
+  text?: string;
+  lang?: string;
 };
 
 export type GedcomXSourceReference = {
@@ -161,9 +168,11 @@ export type SimplifiedRelationship = {
   type?: string;             // "ParentChild" | "Couple"
   parent?: string;           // ParentChild only
   child?: string;            // ParentChild only
+  subtype?: string;          // ParentChild only — Biological | Adoptive | Step | Foster | Guardian
   person1?: string;          // Couple only
   person2?: string;          // Couple only
   facts?: SimplifiedFact[];
+  notes?: string[];          // Flat text content; subject/lang/attribution dropped
   sources?: SimplifiedSourceReference[];
 };
 
@@ -317,15 +326,53 @@ top-level `places[]` array (Rule 12). `toGedcomX` writes
 {
   "type": "http://gedcomx.org/ParentChild",
   "person1": { "resource": "#I2" },
-  "person2": { "resource": "#I1" }
+  "person2": { "resource": "#I1" },
+  "facts": [
+    { "type": "http://gedcomx.org/BiologicalParent" }
+  ]
 }
 ↓
-{ "type": "ParentChild", "parent": "I2", "child": "I1" }
+{ "type": "ParentChild", "parent": "I2", "child": "I1", "subtype": "Biological" }
 ```
 
 - `person1` → `parent` (strip leading `#`)
 - `person2` → `child` (strip leading `#`)
 - `toGedcomX`: re-wrap `{ resource: "#<id>" }`
+
+**Subtype mapping.** The simplified `subtype` field captures the kind of
+parent-child relationship. Five values are recognized; their corresponding
+GedcomX fact URIs are:
+
+| `subtype` value | GedcomX fact URI |
+|---|---|
+| `Biological` | `http://gedcomx.org/BiologicalParent` |
+| `Adoptive` | `http://gedcomx.org/AdoptiveParent` |
+| `Step` | `http://gedcomx.org/StepParent` |
+| `Foster` | `http://gedcomx.org/FosterParent` |
+| `Guardian` | `http://gedcomx.org/GuardianParent` |
+
+- `toSimplified` on a ParentChild relationship: scan `facts[]` for the first
+  fact whose `type` matches one of the five URIs above. Strip the `Parent`
+  suffix and lift the short name to `subtype`. **The matched fact is
+  removed from the `facts[]` carried into simplified output** so the
+  information lives in exactly one place. Other facts (e.g. an adoption
+  date) stay in `facts[]`.
+- `toGedcomX` on a simplified ParentChild relationship with `subtype` set:
+  synthesize a fact `{ type: "http://gedcomx.org/<Subtype>Parent" }` and
+  **prepend it** to the GedcomX `facts[]` array.
+- Unrecognized subtype-style facts pass through unchanged in `facts[]`;
+  `subtype` is omitted.
+
+**Round-trip caveat.** If the input GedcomX had the subtype fact at a
+non-zero index in `facts[]`, the round trip normalizes it to index 0. This
+is a deliberate, documented loss; GedcomX does not assign semantic ordering
+to facts.
+
+**Out of scope.** FamilySearch's `ChildAndParentsRelationship` extension
+(which uses `parent1Facts` / `parent2Facts` rather than standard
+`Relationship.facts`) is not handled here. The `tree` MCP tool is
+responsible for normalizing FS extension responses into standard GedcomX
+shape before calling `toSimplified`.
 
 ### 9. Relationships — `Couple`
 
@@ -414,7 +461,38 @@ The top-level array is renamed `sourceDescriptions` ↔ `sources`.
 - `names[0].value` → `name` (omit if names missing/empty)
 - Top-level array key stays `places` on both sides
 
-### 13. IDs
+### 13. Notes on relationships
+
+```
+{
+  "type": "http://gedcomx.org/ParentChild",
+  "person1": { "resource": "#I2" },
+  "person2": { "resource": "#I1" },
+  "notes": [
+    { "subject": "Adoption record", "text": "Adopted in 1923 per county records.", "lang": "en" }
+  ]
+}
+↓
+{
+  "type": "ParentChild",
+  "parent": "I2",
+  "child": "I1",
+  "notes": ["Adopted in 1923 per county records."]
+}
+```
+
+- `toSimplified`: for each entry in `relationship.notes[]`, take the `text`
+  field as a flat string. Entries missing `text` are dropped. The
+  simplified `notes` array preserves order. If the input has no notes (or
+  the array is empty after filtering), the field is omitted.
+- `toGedcomX`: wrap each simplified string in `{ text: <string> }`. Order
+  preserved.
+- **Lossy fields.** `subject`, `lang`, and `attribution` are not preserved.
+  Round-trip identity holds for the `text` value only.
+
+This rule applies to both `ParentChild` and `Couple` relationships.
+
+### 14. IDs
 
 IDs are passed through verbatim. The functions do not generate IDs. If input
 GedcomX lacks an ID on a name, fact, or relationship, the simplified output
@@ -454,6 +532,12 @@ also lacks it. ID generation (with `I`/`N`/`F`/`R`/`S` prefixes per
 | Person with no name | Include person with `id` and `gender` only | Same |
 | Unknown gender URI | `gender: "Unknown"` | Omit `gender` |
 | Non-`gedcomx.org` URI in `type` field | Pass through unchanged | Pass through unchanged |
+| ParentChild with no subtype-fact in `facts[]` | `subtype` omitted | No subtype-fact emitted |
+| ParentChild subtype-fact at non-zero index in `facts[]` | Subtype lifted; other facts retain order | Subtype-fact prepended at index 0 (round-trip normalizes ordering) |
+| ParentChild with subtype-fact + unrelated facts | Subtype lifted; unrelated facts stay in `facts[]` | Subtype-fact prepended; unrelated facts follow in original order |
+| ParentChild with parent-style fact URI outside the recognized five | Fact passes through unchanged in `facts[]`; `subtype` omitted | Same on the way back |
+| `notes` array missing or empty | Omit `notes` | Omit `notes` |
+| `notes` entry has no `text` field | Drop that entry from simplified output | n/a |
 
 ---
 
@@ -682,14 +766,20 @@ fall into the `fullText` fallback path and emit a warning.
 | 17 | `fsmcp:quality` qualifier → `quality` as string; passed through unchanged | Rule 10 |
 | 18 | Source descriptions round-trip with `title`, `citation`, `url` | Rule 11 |
 | 19 | Top-level `places[]` array round-trips | Rule 12 |
-| 20 | IDs pass through verbatim; no IDs are generated | Rule 13 |
-| 21 | Function returns `{}` on `null` / `undefined` input | Error handling |
-| 22 | Person with no names is preserved in output | Error handling |
-| 23 | Malformed `gender` (string instead of object) does not throw | Error handling |
-| 24 | Empty top-level arrays are omitted from output | Edge case |
-| 25 | `preferred: false` and `primary: false` are never emitted | Schema compliance |
-| 26 | **Identity round-trip A** — `toGedcomX(toSimplified(raw))` equals `raw` for a "clean" GedcomX input (no `date.formal`, no `place.description`, parts-based names, no lossy qualifiers) | Round-trip identity |
-| 27 | **Identity round-trip B** — `toSimplified(toGedcomX(simplified))` equals `simplified` for a comprehensive simplified input | Round-trip identity |
+| 20 | Each of the five subtype URIs (Biological/Adoptive/Step/Foster/Guardian) round-trips correctly | Rule 8 |
+| 21 | ParentChild with subtype-fact + unrelated facts: subtype lifted, unrelated facts preserved in `facts[]` | Rule 8 |
+| 22 | ParentChild with no recognized subtype-fact has no `subtype` field; other facts pass through | Rule 8 |
+| 23 | Note `text` content is preserved on relationships; entries without `text` are dropped | Rule 13 |
+| 24 | Multiple notes on a relationship preserve order | Rule 13 |
+| 25 | Empty/missing `notes` array is omitted from simplified output | Rule 13 |
+| 26 | IDs pass through verbatim; no IDs are generated | Rule 14 |
+| 27 | Function returns `{}` on `null` / `undefined` input | Error handling |
+| 28 | Person with no names is preserved in output | Error handling |
+| 29 | Malformed `gender` (string instead of object) does not throw | Error handling |
+| 30 | Empty top-level arrays are omitted from output | Edge case |
+| 31 | `preferred: false` and `primary: false` are never emitted | Schema compliance |
+| 32 | **Identity round-trip A** — `toGedcomX(toSimplified(raw))` equals `raw` for a "clean" GedcomX input (no `date.formal`, no `place.description`, parts-based names, no lossy qualifiers; includes a ParentChild with subtype and notes) | Round-trip identity |
+| 33 | **Identity round-trip B** — `toSimplified(toGedcomX(simplified))` equals `simplified` for a comprehensive simplified input (includes a ParentChild with subtype and notes) | Round-trip identity |
 
 ### Smoke-test script
 

--- a/docs/specs/simplified-gedcomx-spec.md
+++ b/docs/specs/simplified-gedcomx-spec.md
@@ -118,9 +118,9 @@ Array of relationship objects.
 | `type` | string | yes | `ParentChild` |
 | `parent` | string | yes | Person ID of the parent |
 | `child` | string | yes | Person ID of the child |
+| `subtype` | string | no | Nature of the parent-child relationship. See `parent_subtype` enum below. Omit when the relationship is implicit/default (treated as biological by FamilySearch's data model) |
+| `notes` | string[] | no | Free-text notes attached to this relationship. Each entry is the text of one note |
 | `sources` | object[] | no | Source references |
-
-ParentChild relationships have no `facts` field — the relationship itself is the fact. Events related to the parent-child bond (adoption, custody changes) are not modeled in v1.
 
 **Couple:**
 
@@ -131,6 +131,7 @@ ParentChild relationships have no `facts` field — the relationship itself is t
 | `person1` | string | yes | Person ID of first partner |
 | `person2` | string | yes | Person ID of second partner |
 | `facts` | object[] | no | Relationship facts (marriage, divorce, etc.). Same schema as person facts |
+| `notes` | string[] | no | Free-text notes attached to this relationship. Each entry is the text of one note |
 | `sources` | object[] | no | Source references |
 
 ### 4.3 `sources`
@@ -189,6 +190,19 @@ Skills should prefer the recognized patterns. The conversion function will attem
 |------|-------------------|---------|
 | `fact_type` | See table below | person facts, relationship facts |
 | `name_type` | `BirthName`, `MarriedName`, `AlsoKnownAs`, `Nickname`, `Formal`, `Religious` | names |
+| `parent_subtype` | `Biological`, `Adoptive`, `Step`, `Foster`, `Guardian` | ParentChild relationships |
+
+**Parent subtype values and GedcomX compatibility:**
+
+| Value | GedcomX URI | Notes |
+|-------|-------------|-------|
+| `Biological` | `http://gedcomx.org/BiologicalParent` | Standard GedcomX fact type emitted on the relationship's `facts[]` array at upload |
+| `Adoptive` | `http://gedcomx.org/AdoptiveParent` | |
+| `Step` | `http://gedcomx.org/StepParent` | |
+| `Foster` | `http://gedcomx.org/FosterParent` | |
+| `Guardian` | `http://gedcomx.org/GuardianParent` | |
+
+The `Parent` suffix is dropped in the simplified format because the parent-child context is implicit on a ParentChild relationship. The conversion function restores it when round-tripping to GedcomX.
 
 **Fact type values and GedcomX compatibility:**
 
@@ -249,6 +263,7 @@ The following full GedcomX fields are not represented in the simplified format a
 - Source reference `qualifiers` beyond `CitationDetail` — only the citation detail qualifier maps to `page`
 - `contributors`, `attribution`, `analysis` on source descriptions
 - `confidence` on conclusions (use `research.json` proof tiers instead)
+- `subject`, `lang`, and `attribution` on `Note` objects — only the `text` field is preserved as a flat string in the simplified `notes` array
 
 These losses are acceptable for the target use case (English-language Western genealogy). For projects requiring multi-script names or formal date encoding, the full GedcomX format should be used directly.
 

--- a/mcp-server/dev/try-gedcomx-convert.ts
+++ b/mcp-server/dev/try-gedcomx-convert.ts
@@ -56,6 +56,23 @@ const turner: GedcomX = {
       ],
       sources: [{ description: "#sd1" }],
     },
+    {
+      id: "p3",
+      gender: { type: "http://gedcomx.org/Male" },
+      names: [
+        {
+          type: "http://gedcomx.org/BirthName",
+          nameForms: [{ fullText: "James Turner" }],
+        },
+      ],
+      facts: [
+        {
+          type: "http://gedcomx.org/Birth",
+          date: { original: "12 February 1878" },
+          place: { original: "Liverpool, England" },
+        },
+      ],
+    },
   ],
   relationships: [
     {
@@ -68,6 +85,21 @@ const turner: GedcomX = {
           date: { original: "20 April 1875", formal: "+1875-04-20" },
         },
       ],
+    },
+    {
+      type: "http://gedcomx.org/ParentChild",
+      person1: { resource: "#p1" },
+      person2: { resource: "#p3" },
+      facts: [{ type: "http://gedcomx.org/AdoptiveParent" }],
+      notes: [
+        { text: "Adoption recorded in parish register, 1879." },
+      ],
+    },
+    {
+      type: "http://gedcomx.org/ParentChild",
+      person1: { resource: "#p2" },
+      person2: { resource: "#p3" },
+      facts: [{ type: "http://gedcomx.org/StepParent" }],
     },
   ],
 };

--- a/mcp-server/src/types/gedcomx.ts
+++ b/mcp-server/src/types/gedcomx.ts
@@ -50,7 +50,14 @@ export interface GedcomXRelationship {
   person1?: { resource: string };
   person2?: { resource: string };
   facts?: GedcomXFact[];
+  notes?: GedcomXNote[];
   sources?: GedcomXSourceReference[];
+}
+
+export interface GedcomXNote {
+  subject?: string;
+  text?: string;
+  lang?: string;
 }
 
 export interface GedcomXSourceReference {
@@ -120,9 +127,11 @@ export interface SimplifiedRelationship {
   type?: string;
   parent?: string;
   child?: string;
+  subtype?: string;
   person1?: string;
   person2?: string;
   facts?: SimplifiedFact[];
+  notes?: string[];
   sources?: SimplifiedSourceReference[];
 }
 

--- a/mcp-server/src/utils/gedcomx-convert.ts
+++ b/mcp-server/src/utils/gedcomx-convert.ts
@@ -3,6 +3,7 @@ import type {
   GedcomXFact,
   GedcomXName,
   GedcomXNamePart,
+  GedcomXNote,
   GedcomXPerson,
   GedcomXPlaceDescription,
   GedcomXQualifier,
@@ -31,6 +32,27 @@ const KNOWN_NAME_PARTS: readonly NamePartKind[] = [
   "Surname",
   "Suffix",
 ];
+
+// Parent-child relationship subtypes. The simplified short name drops the
+// "Parent" suffix from the GedcomX URI because the parent-child context is
+// implicit on a ParentChild relationship.
+const SUBTYPE_URIS: readonly string[] = [
+  URI_PREFIX + "BiologicalParent",
+  URI_PREFIX + "AdoptiveParent",
+  URI_PREFIX + "StepParent",
+  URI_PREFIX + "FosterParent",
+  URI_PREFIX + "GuardianParent",
+];
+
+function uriToSubtype(uri: string): string | undefined {
+  if (!SUBTYPE_URIS.includes(uri)) return undefined;
+  // Strip "http://gedcomx.org/" prefix and "Parent" suffix.
+  return uri.slice(URI_PREFIX.length, -"Parent".length);
+}
+
+function subtypeToUri(subtype: string): string {
+  return URI_PREFIX + subtype + "Parent";
+}
 
 function stripUri(uri: string | undefined): string | undefined {
   if (typeof uri !== "string") return undefined;
@@ -222,15 +244,41 @@ function simplifyRelationship(
     if (p2 !== undefined) out.person2 = p2;
   }
 
-  if (Array.isArray(rel.facts) && rel.facts.length > 0) {
-    out.facts = rel.facts.map(simplifyFact);
+  // For ParentChild only: lift the first recognized subtype-fact out of
+  // facts[] and surface it on `subtype`. Other facts pass through.
+  const inputFacts = Array.isArray(rel.facts) ? rel.facts : [];
+  let remainingFacts: GedcomXFact[] = inputFacts;
+  if (stripped === PARENT_CHILD && inputFacts.length > 0) {
+    const subtypeIndex = inputFacts.findIndex(
+      (f) => typeof f.type === "string" && uriToSubtype(f.type) !== undefined,
+    );
+    if (subtypeIndex !== -1) {
+      const subtypeFact = inputFacts[subtypeIndex];
+      out.subtype = uriToSubtype(subtypeFact.type as string);
+      remainingFacts = inputFacts.filter((_, i) => i !== subtypeIndex);
+    }
   }
+  if (remainingFacts.length > 0) {
+    out.facts = remainingFacts.map(simplifyFact);
+  }
+
+  const notes = simplifyNotes(rel.notes);
+  if (notes !== undefined) out.notes = notes;
 
   if (Array.isArray(rel.sources) && rel.sources.length > 0) {
     out.sources = rel.sources.map(simplifySourceRef);
   }
 
   return out;
+}
+
+function simplifyNotes(notes: GedcomXNote[] | undefined): string[] | undefined {
+  if (!Array.isArray(notes) || notes.length === 0) return undefined;
+  const out: string[] = [];
+  for (const note of notes) {
+    if (typeof note?.text === "string") out.push(note.text);
+  }
+  return out.length > 0 ? out : undefined;
 }
 
 function simplifySourceRef(
@@ -421,8 +469,19 @@ function expandRelationship(
     if (p2 !== undefined) out.person2 = { resource: p2 };
   }
 
+  // For ParentChild only: if a subtype is set, prepend a subtype-fact to
+  // the GedcomX facts[] array. Other facts retain their original order.
+  const expandedFacts: GedcomXFact[] = [];
+  if (rel.type === PARENT_CHILD && typeof rel.subtype === "string") {
+    expandedFacts.push({ type: subtypeToUri(rel.subtype) });
+  }
   if (Array.isArray(rel.facts) && rel.facts.length > 0) {
-    out.facts = rel.facts.map(expandFact);
+    for (const f of rel.facts) expandedFacts.push(expandFact(f));
+  }
+  if (expandedFacts.length > 0) out.facts = expandedFacts;
+
+  if (Array.isArray(rel.notes) && rel.notes.length > 0) {
+    out.notes = rel.notes.map((text) => ({ text }));
   }
 
   if (Array.isArray(rel.sources) && rel.sources.length > 0) {

--- a/mcp-server/tests/utils/gedcomx-convert.test.ts
+++ b/mcp-server/tests/utils/gedcomx-convert.test.ts
@@ -586,7 +586,159 @@ describe("gedcomx-convert — transformation rules", () => {
     });
   });
 
-  // Test 20 — Rule 13: IDs pass through verbatim
+  // Test 20 — Rule 8: each of the five subtype URIs round-trips
+  it("round-trips each recognized parent-child subtype", () => {
+    const subtypes: { short: string; uri: string }[] = [
+      { short: "Biological", uri: "http://gedcomx.org/BiologicalParent" },
+      { short: "Adoptive", uri: "http://gedcomx.org/AdoptiveParent" },
+      { short: "Step", uri: "http://gedcomx.org/StepParent" },
+      { short: "Foster", uri: "http://gedcomx.org/FosterParent" },
+      { short: "Guardian", uri: "http://gedcomx.org/GuardianParent" },
+    ];
+    for (const { short, uri } of subtypes) {
+      const input: GedcomX = {
+        relationships: [
+          {
+            type: "http://gedcomx.org/ParentChild",
+            person1: { resource: "#I2" },
+            person2: { resource: "#I1" },
+            facts: [{ type: uri }],
+          },
+        ],
+      };
+      const simplified = toSimplified(input);
+      expect(simplified.relationships?.[0].subtype).toBe(short);
+      // The subtype-fact must not also appear in simplified facts[].
+      expect(simplified.relationships?.[0].facts).toBeUndefined();
+
+      const roundTripped = toGedcomX(simplified);
+      expect(roundTripped.relationships?.[0].facts?.[0].type).toBe(uri);
+    }
+  });
+
+  // Test 21 — Rule 8: subtype lifted, unrelated facts retained in facts[]
+  it("lifts subtype from facts[] but preserves unrelated facts on a ParentChild", () => {
+    const input: GedcomX = {
+      relationships: [
+        {
+          type: "http://gedcomx.org/ParentChild",
+          person1: { resource: "#I2" },
+          person2: { resource: "#I1" },
+          facts: [
+            { type: "http://gedcomx.org/AdoptiveParent" },
+            {
+              type: "http://gedcomx.org/Adoption",
+              date: { original: "1923" },
+            },
+          ],
+        },
+      ],
+    };
+    const simplified = toSimplified(input);
+    expect(simplified.relationships?.[0].subtype).toBe("Adoptive");
+    expect(simplified.relationships?.[0].facts).toHaveLength(1);
+    expect(simplified.relationships?.[0].facts?.[0].type).toBe("Adoption");
+    expect(simplified.relationships?.[0].facts?.[0].date).toBe("1923");
+
+    const back = toGedcomX(simplified);
+    // Subtype fact prepended at index 0; unrelated fact follows.
+    expect(back.relationships?.[0].facts?.[0].type).toBe(
+      "http://gedcomx.org/AdoptiveParent",
+    );
+    expect(back.relationships?.[0].facts?.[1].type).toBe(
+      "http://gedcomx.org/Adoption",
+    );
+  });
+
+  // Test 22 — Rule 8: ParentChild with no recognized subtype-fact
+  it("omits subtype when no recognized subtype-fact is present; unrelated facts pass through", () => {
+    const result = toSimplified({
+      relationships: [
+        {
+          type: "http://gedcomx.org/ParentChild",
+          person1: { resource: "#I2" },
+          person2: { resource: "#I1" },
+          facts: [{ type: "http://gedcomx.org/Adoption" }],
+        },
+      ],
+    });
+    expect("subtype" in (result.relationships?.[0] ?? {})).toBe(false);
+    expect(result.relationships?.[0].facts).toHaveLength(1);
+    expect(result.relationships?.[0].facts?.[0].type).toBe("Adoption");
+  });
+
+  // Test 23 — Rule 13: notes text content preserved; entries missing text dropped
+  it("extracts note text on relationships; drops entries with no text", () => {
+    const result = toSimplified({
+      relationships: [
+        {
+          type: "http://gedcomx.org/ParentChild",
+          person1: { resource: "#I2" },
+          person2: { resource: "#I1" },
+          notes: [
+            { subject: "Adoption", text: "Adopted in 1923.", lang: "en" },
+            { subject: "Empty note" }, // no text — must be dropped
+            { text: "Plain second note." },
+          ],
+        },
+      ],
+    });
+    expect(result.relationships?.[0].notes).toEqual([
+      "Adopted in 1923.",
+      "Plain second note.",
+    ]);
+  });
+
+  // Test 24 — Rule 13: multiple notes preserve order
+  it("preserves the order of notes on relationships", () => {
+    const result = toSimplified({
+      relationships: [
+        {
+          type: "http://gedcomx.org/Couple",
+          person1: { resource: "#I1" },
+          person2: { resource: "#I2" },
+          notes: [
+            { text: "First." },
+            { text: "Second." },
+            { text: "Third." },
+          ],
+        },
+      ],
+    });
+    expect(result.relationships?.[0].notes).toEqual([
+      "First.",
+      "Second.",
+      "Third.",
+    ]);
+  });
+
+  // Test 25 — Rule 13: empty/missing notes omitted from simplified output
+  it("omits empty or missing notes from simplified output", () => {
+    const emptyArr = toSimplified({
+      relationships: [
+        {
+          type: "http://gedcomx.org/ParentChild",
+          person1: { resource: "#I2" },
+          person2: { resource: "#I1" },
+          notes: [],
+        },
+      ],
+    });
+    expect("notes" in (emptyArr.relationships?.[0] ?? {})).toBe(false);
+
+    const missing = toSimplified({
+      relationships: [
+        {
+          type: "http://gedcomx.org/ParentChild",
+          person1: { resource: "#I2" },
+          person2: { resource: "#I1" },
+        },
+      ],
+    });
+    expect("notes" in (missing.relationships?.[0] ?? {})).toBe(false);
+  });
+
+  // Test 26 — Rule 14: IDs pass through verbatim
   it("passes IDs through verbatim and does not generate new ones", () => {
     const result = toSimplified({
       persons: [
@@ -638,7 +790,7 @@ describe("gedcomx-convert — transformation rules", () => {
 });
 
 describe("gedcomx-convert — error handling and edge cases", () => {
-  // Test 21
+  // Test 27
   it("returns {} on null / undefined input", () => {
     expect(toSimplified(null as unknown as GedcomX)).toEqual({});
     expect(toSimplified(undefined as unknown as GedcomX)).toEqual({});
@@ -646,7 +798,7 @@ describe("gedcomx-convert — error handling and edge cases", () => {
     expect(toGedcomX(undefined as unknown as SimplifiedGedcomX)).toEqual({});
   });
 
-  // Test 22
+  // Test 28
   it("preserves persons with no names in the output", () => {
     const result = toSimplified({
       persons: [{ id: "p1", gender: { type: "http://gedcomx.org/Male" } }],
@@ -657,7 +809,7 @@ describe("gedcomx-convert — error handling and edge cases", () => {
     expect(result.persons?.[0].names).toBeUndefined();
   });
 
-  // Test 23
+  // Test 29
   it("does not throw on malformed gender (string instead of object)", () => {
     expect(() =>
       toSimplified({
@@ -668,7 +820,7 @@ describe("gedcomx-convert — error handling and edge cases", () => {
     ).not.toThrow();
   });
 
-  // Test 24
+  // Test 30
   it("omits empty top-level arrays from output", () => {
     const result = toSimplified({
       persons: [],
@@ -679,7 +831,7 @@ describe("gedcomx-convert — error handling and edge cases", () => {
     expect(result).toEqual({});
   });
 
-  // Test 25
+  // Test 31
   it("never emits preferred: false or primary: false", () => {
     // Even if the input asserts the false values explicitly, simplification
     // should omit them (since `false` is the default per schema convention).
@@ -719,10 +871,11 @@ describe("gedcomx-convert — error handling and edge cases", () => {
 });
 
 describe("gedcomx-convert — identity round-trips", () => {
-  // Test 26 — A "clean" raw GedcomX input survives toSimplified → toGedcomX.
+  // Test 32 — A "clean" raw GedcomX input survives toSimplified → toGedcomX.
   // "Clean" means no fields that are documented as lossy:
   // no date.formal, no place.description, names use parts (not fullText fallback),
-  // no qualifiers outside CitationDetail / fsmcp:quality.
+  // no qualifiers outside CitationDetail / fsmcp:quality, and the ParentChild
+  // subtype-fact is at index 0 of facts[] (round-trip ordering convention).
   it("identity: toGedcomX(toSimplified(raw)) === raw for a clean input", () => {
     const clean: GedcomX = {
       persons: [
@@ -776,6 +929,11 @@ describe("gedcomx-convert — identity round-trips", () => {
           type: "http://gedcomx.org/ParentChild",
           person1: { resource: "#p2" },
           person2: { resource: "#p1" },
+          facts: [{ type: "http://gedcomx.org/AdoptiveParent" }],
+          notes: [
+            { text: "Adoption finalized 1923." },
+            { text: "Source: county courthouse." },
+          ],
         },
       ],
       sourceDescriptions: [
@@ -799,7 +957,7 @@ describe("gedcomx-convert — identity round-trips", () => {
     expect(toGedcomX(toSimplified(clean))).toEqual(clean);
   });
 
-  // Test 27 — A comprehensive simplified input survives toGedcomX → toSimplified
+  // Test 33 — A comprehensive simplified input survives toGedcomX → toSimplified
   // unchanged. Simplified → raw is lossless by construction.
   it("identity: toSimplified(toGedcomX(simplified)) === simplified", () => {
     const simplified: SimplifiedGedcomX = {
@@ -847,6 +1005,15 @@ describe("gedcomx-convert — identity round-trips", () => {
           person1: "p1",
           person2: "p2",
           facts: [{ type: "Marriage", primary: true, date: "1975" }],
+          notes: ["Married at city hall.", "Witnessed by two neighbors."],
+        },
+        {
+          id: "r2",
+          type: "ParentChild",
+          parent: "p1",
+          child: "p3",
+          subtype: "Step",
+          notes: ["Step-relationship from p1's second marriage."],
         },
       ],
       sources: [


### PR DESCRIPTION
 ## Summary

  - New `subtype` field on `SimplifiedRelationship` for ParentChild:
    `Biological`, `Adoptive`, `Step`, `Foster`, `Guardian`. Lifted from a
    recognized GedcomX subtype-fact (`BiologicalParent`/`AdoptiveParent`/
    etc.); other facts on the relationship pass through in `facts[]`.
    
    Round-trip prepends the subtype-fact at index 0 of GedcomX `facts[]`.
  - New `notes` field on `SimplifiedRelationship` (applies to both
    ParentChild and Couple): array of plain strings, one per GedcomX Note.
    `subject`, `lang`, `attribution` are dropped — documented.
    
  - Both specs updated together:
    - `simplified-gedcomx-spec.md` — drops the v1 ParentChild "no facts"
      limitation, adds the `parent_subtype` open enum.
    - `gedcomx-convert-spec.md` — extends Rule 8 (ParentChild subtype),
      adds Rule 13 (notes), edge cases table updated.
  - Tests grew 27 → 33. Six new cases plus the identity round-trips
    extended to cover a ParentChild with subtype + notes.

  ## Test plan

  - [x] `cd mcp-server && npx vitest run tests/utils/gedcomx-convert.test.ts` — 33/33 pass
  - [x] `cd mcp-server && npx tsx dev/try-gedcomx-convert.ts` — smoke output
        shows the new ParentChild relationships round-tripping with subtype
        and notes preserved