### PR TITLE
Add detail mode to collections tool (id parameter)

### DIFF
--- a/docs/specs/collection-detail-tool-spec.md
+++ b/docs/specs/collection-detail-tool-spec.md
@@ -1,0 +1,368 @@
+# Collection Detail Tool — Implementation Spec
+
+## Overview
+
+Extends the existing `collections` MCP tool with a third call mode: **detail
+mode**, triggered by passing an `id` parameter. Detail mode returns the
+FamilySearch search API response for a single collection **as-is**, with
+HTML-bearing string fields converted to markdown.
+
+This is a single-tool extension, not a new tool. The schema gains one
+optional property (`id`); the return shape switches based on which input
+mode was used. List-mode behavior is unchanged.
+
+### Design rationale (stakeholder transcript, 2026-05-12)
+
+> *Dallan:* "Let's just have it come back with the JSON. ... what if we
+> return ... so return the JSON, just like this is? Except ... take that
+> HTML content, and convert it to Markdown."
+
+This is a thin adapter, not a curated client. No LLM enhancement, no field
+selection, no structural flattening, no pre-parsing of GEDCOMX timestamps.
+The upstream API response shape is the contract; the tool's only job is to
+fetch it and convert HTML strings to markdown before returning.
+
+---
+
+## Input
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `query` | string | No* | Place name to search collection titles (list mode) |
+| `placeIds` | number[] | No* | Internal collection place IDs (list mode) |
+| `id` | string | No* | FamilySearch collection ID for single-collection detail (detail mode) |
+
+*Exactly one of `query`, `placeIds`, or `id` must be provided.
+
+### Input precedence
+
+1. `id` — takes precedence; runs detail mode, silently ignores `query`/`placeIds`.
+2. `query` — takes precedence over `placeIds` (existing behavior).
+3. `placeIds` — used when neither `id` nor `query` is set.
+
+Example:
+
+```json
+{ "id": "1473181" }
+```
+
+---
+
+## Output
+
+### List mode (unchanged)
+
+When `id` is absent, the output is the existing `CollectionsResult`.
+
+### Detail mode
+
+When `id` is present, the output is the **raw FamilySearch response** from
+`GET /service/search/hr/v2/collections/{id}?embedWikiAboutCollection=true`,
+with exactly one modification applied:
+
+- Every `documents[*]` whose `textType === "html"` has its `text` field
+  converted to markdown AND its `textType` flipped to `"markdown"`.
+
+**No other transformations.** Citations are left as-is (HTML tags
+preserved). Per stakeholder direction (Dallan, 2026-05-12 meeting), only
+the `documents` section is touched. Top-level keys, nesting, field names,
+and data types match the FS response exactly. The TypeScript type is:
+
+```typescript
+export type CollectionDetailResult = FSCollectionDetailResponse;
+```
+
+### Example output for `id: "1473181"` (US Census 1860)
+
+```json
+{
+  "sourceDescriptions": [
+    {
+      "id": "1473181",
+      "about": "https://www.familysearch.org/platform/records/collections/1473181",
+      "modified": "2026-04-21T13:18:12.810+00:00",
+      "descriptions": [{ "value": "Name index and images...", "lang": "en_US" }],
+      "citations": [
+        { "value": "\"United States, Census, 1860.\" Database with images. <i>FamilySearch</i>. http://FamilySearch.org : 29 April 2026. ..." }
+      ],
+      "titles": [{ "value": "United States, Census, 1860", "lang": "en_US" }],
+      "rights": ["http://familysearch.org/records/permissionGroup/FamilySearch"],
+      "coverage": [
+        {
+          "spatial": { "original": "United States", "description": "1" },
+          "temporal": { "original": "1860", "formal": "+1860" },
+          "recordType": "http://gedcomx.org/Census"
+        }
+      ],
+      "identifiers": {
+        "http://gedcomx.org/Primary": ["https://www.familysearch.org/platform/records/collections/1473181"]
+      }
+    }
+  ],
+  "documents": [
+    {
+      "id": "1473181",
+      "text": "# United States, Census, 1860\n\n## What is in This Collection?\n\nAn index of population schedules...",
+      "textType": "markdown",
+      "extracted": false
+    }
+  ],
+  "collections": [
+    {
+      "id": "1473181",
+      "title": "United States, Census, 1860",
+      "content": [
+        { "completeness": 0.99, "count": 27176265, "resourceType": "http://gedcomx.org/Record" },
+        { "completeness": 0.99, "count": 28747506, "resourceType": "http://gedcomx.org/Person" },
+        { "count": 703834, "resourceType": "http://gedcomx.org/DigitalArtifact#FamilySearch" }
+      ],
+      "searchMetadata": [
+        {
+          "imageCount": 703834,
+          "recordCount": 27176265,
+          "lastUpdated": 1776777492810,
+          "typeFacet": "CENSUS",
+          "startYear": 1860,
+          "endYear": 1860,
+          "region": "UNITED_STATES",
+          "placeIds": [1]
+        }
+      ]
+    }
+  ],
+  "description": "#1473181",
+  "id": "1473181",
+  "links": {
+    "collection": { "href": "https://www.familysearch.org/service/search/hr/v2/collections/1473181?..." },
+    "waypoints": { "href": "https://www.familysearch.org/service/cds/recapi/collections/1473181/waypoints" }
+  }
+}
+```
+
+Note that this shape **preserves GEDCOMX conventions**: the top-level
+`description` is a `#id` ref, not text. Consumers of the tool resolve
+that ref themselves when needed.
+
+---
+
+## Tool Schema
+
+```typescript
+{
+  name: "collections",
+  description:
+    "List FamilySearch record collections for a place, OR get detailed " +
+    "information about a single collection. Pass `query` (a place name) to " +
+    "list, or `id` (a collection ID like \"1743384\") to get the FS API " +
+    "response for that collection, with HTML strings (citations, Research " +
+    "Wiki page) converted to markdown. Requires authentication — call the " +
+    "login tool first if not logged in.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      query:    { type: "string", description: "..." },
+      placeIds: { type: "array",  items: { type: "number" }, description: "..." },
+      id:       { type: "string", description: "..." }
+    }
+  }
+}
+```
+
+---
+
+## Authentication
+
+Detail mode requires the same authentication as list mode. Calls
+`getValidToken()` from `src/auth/refresh.js`. If the user is not logged in,
+the LLM-instruction error propagates.
+
+---
+
+## FamilySearch API Reference
+
+**Endpoint:**
+
+```
+GET https://www.familysearch.org/service/search/hr/v2/collections/{id}?embedWikiAboutCollection=true
+Authorization: Bearer <access_token>
+User-Agent: <browser-like user agent string>
+```
+
+User-Agent is required (FS WAF). Reuses the existing `USER_AGENT` constant.
+
+The `?embedWikiAboutCollection=true` query parameter triggers FS to embed
+the FamilySearch Research Wiki "about" page as HTML in `documents[0].text`.
+Without the flag, `documents` is absent.
+
+---
+
+## HTML → Markdown Conversion
+
+Uses [`turndown`](https://www.npmjs.com/package/turndown) (MIT, ~600K
+weekly downloads). Single module-level instance:
+
+```typescript
+const turndown = new TurndownService({
+  headingStyle: "atx",
+  codeBlockStyle: "fenced",
+  emDelimiter: "*",
+});
+turndown.remove(["head", "title", "style", "script"]);
+turndown.addRule("dropHidden", {
+  filter: (node) => /display\s*:\s*none/i.test(
+    (node as HTMLElement).getAttribute?.("style") ?? ""
+  ),
+  replacement: () => "",
+});
+```
+
+The `remove` and `dropHidden` rules neutralize four quirks observed in
+live wiki HTML:
+
+| Quirk | Without the rule | With the rule |
+|-------|------------------|---------------|
+| `<title>` hoisted out of `<head>` by DOM normalization | Title duplicated above the H1 | Dropped |
+| `<style>` CSS rendered as plain text | Long CSS preamble | Dropped |
+| `<script>` content rendered as plain text | Code visible | Dropped |
+| MediaWiki `{{{CID*}}}` placeholders inside `<div style="display: none">` | Visible noise | Dropped |
+
+### `htmlToMarkdown(html)` helper
+
+- Returns `null` for null/undefined/empty input.
+- Returns `null` when conversion yields only whitespace.
+- Otherwise returns the trimmed markdown string.
+
+### `convertHtmlToMarkdown(response)` helper
+
+Walks the response and produces a new object with:
+
+- Each `documents[*]` with `textType === "html"` has its `text` replaced by markdown and `textType` flipped to `"markdown"`.
+- All other fields passed through unchanged, including `sourceDescriptions[*].citations[*].value` (citations stay as raw HTML).
+
+---
+
+## Caching
+
+Detail-mode calls are **not** cached. Single HTTP call per `id`.
+
+---
+
+## Error Handling
+
+| Condition | Behavior |
+|-----------|----------|
+| None of `query`, `placeIds`, `id` provided | Throw existing error from list mode (unchanged) |
+| Not authenticated | Let `getValidToken()` throw |
+| 404 from upstream | Throw: `"No FamilySearch collection found with id \"{id}\". Use collections({ query: ... }) to list available collections."` |
+| Non-OK status other than 404 | Throw: `"FamilySearch collection detail API error: {status} {statusText}"` |
+| Upstream 200 but malformed JSON | Throw: `"FamilySearch collection detail API returned malformed response."` |
+
+---
+
+## Files
+
+### `mcp-server/package.json` (MODIFIED)
+
+Adds `turndown` to `dependencies` and `@types/turndown` to `devDependencies`.
+
+### `mcp-server/src/types/collection.ts` (MODIFIED)
+
+Adds API types for the detail response. `CollectionDetailResult` is a
+type alias for `FSCollectionDetailResponse` — no curated shape.
+
+### `mcp-server/src/tools/collections.ts` (MODIFIED)
+
+- Add `id?: string` to `CollectionsToolInput`.
+- Detail-mode branch in `collectionsTool()`: fetch + convert + return.
+- Module-level `turndown` instance with rules above.
+- Exported helpers (for testing):
+  - `fetchCollectionDetail(token, id)` — HTTP call with the embed flag.
+  - `htmlToMarkdown(html)` — single-string conversion.
+  - `convertHtmlToMarkdown(response)` — walks the response per the rules.
+- Update `collectionsToolSchema` to add the `id` property.
+
+### `mcp-server/dev/try-collection-detail.ts` (NEW)
+
+```bash
+npx tsx dev/try-collection-detail.ts 1473181        # US Census 1860 (wiki present)
+npx tsx dev/try-collection-detail.ts 1743384        # Alabama Marriages
+npx tsx dev/try-collection-detail.ts 9999999        # 404 message
+```
+
+### `mcp-server/dev/probe-collection-detail.ts` (CANONICAL)
+
+Documents the endpoint investigation and the RESULTS table.
+
+---
+
+## Testing
+
+### Helper-level tests
+
+- `htmlToMarkdown`: emphasis conversion, headings/links, null cases, head/style/script removal, hidden-element removal.
+- `convertHtmlToMarkdown`: citation conversion, document conversion (textType flip), non-html docs unchanged, preserves all other fields.
+
+### Integration tests (`collectionsTool` detail mode)
+
+| # | Test case | What it verifies |
+|---|-----------|------------------|
+| 1 | Returns FS response shape, no `{ collection: ... }` wrapper | Pass-through shape |
+| 2 | Citation HTML inside sourceDescriptions converted | `<i>` → `*` |
+| 3 | documents[0].text converted; textType flipped | wiki content as markdown |
+| 4 | Container-parent SD preserved (no stripping) | Faithful pass-through |
+| 5 | searchMetadata preserved inside collections[0] | Nested data intact |
+| 6 | Single HTTP call | No list-cache dual-fetch |
+| 7 | Friendly 404 error | Exact message |
+| 8 | Generic API error on non-404 | Status in message |
+| 9 | Auth error propagates; no fetch | Defensive |
+| 10 | Malformed response throws | Defensive |
+| 11 | `id` wins over `query` | Input precedence |
+
+### Smoke
+
+```bash
+cd mcp-server
+npx tsx dev/try-collection-detail.ts 1473181
+npx tsx dev/try-collection-detail.ts 1743384
+npx tsx dev/try-collection-detail.ts 9999999
+npx tsx dev/try-collections.ts Alabama
+```
+
+---
+
+## Verification
+
+### Automated
+
+```bash
+cd mcp-server && npm run build && npm test
+```
+
+### Manual Layer 1 (MCP Inspector)
+
+- `collections({ id: "1473181" })` → returns FS pass-through with markdown wiki
+- `collections({ id: "9999999" })` → friendly 404
+- `collections({ query: "Alabama" })` → list mode unchanged
+- `collections({ id, query })` → detail returned, query dropped
+
+### Manual Layer 2 (Cowork)
+
+Natural-language prompts:
+
+- *"Tell me more about FamilySearch collection 1473181"*
+- *"What's the citation for collection 1743384?"*
+- *"Show me the wiki page for collection 1473181"*
+
+Layer 2 testing inside this dev repo is unreliable — Claude finds
+`dev/try-collection-detail.ts` and runs it via Bash. Run Layer 2 in Cowork.
+
+---
+
+## Out of Scope
+
+- Lifting `USER_AGENT` into a shared `src/util/userAgent.ts` module.
+- Per-id detail caching.
+- Curating the response shape (handpicking fields, flattening, parsing
+  GEDCOMX timestamps) — explicitly rejected per stakeholder direction.
+- A separate `collection` (singular) tool — single-tool extension chosen
+  per the `places` precedent.

--- a/mcp-server/dev/probe-collection-detail.ts
+++ b/mcp-server/dev/probe-collection-detail.ts
@@ -1,0 +1,258 @@
+/**
+ * Probe — evidence trail behind docs/specs/collection-detail-tool-spec.md.
+ *
+ * Documents the full investigation behind `collections({ id })` detail mode.
+ *
+ *   SECTION A — Endpoint survey. Tries 4 candidate endpoints against a
+ *   real collection ID, prints HTTP status + top-level keys for each.
+ *
+ *   SECTION B — Deep dump of the chosen endpoint with the embed flag.
+ *   Recursively prints the structure of each top-level field
+ *   (sourceDescriptions, documents, collections) plus the raw body.
+ *
+ * RESULTS (recorded here so a future reader doesn't need to re-run):
+ *
+ *   1. /platform/records/collections/{id}        → 200. Returns
+ *      `recordDescriptors[]` (structured field schema) but NOT the
+ *      wiki "about" page. Initially chosen; then rejected by
+ *      stakeholders in favor of #2 — wiki content was preferred over
+ *      the field schema.
+ *
+ *   2. /service/search/hr/v2/collections/{id}?embedWikiAboutCollection=true
+ *      ✓ CHOSEN. Top-level keys: sourceDescriptions, documents,
+ *      collections, description, id, links. The MCP tool returns this
+ *      response shape verbatim, with two HTML-bearing strings converted
+ *      to markdown:
+ *        - sourceDescriptions[*].citations[*].value  (was <i>X</i>, now *X*)
+ *        - documents[*].text                          (textType flipped
+ *          from "html" to "markdown")
+ *      Otherwise unchanged — no field selection, no flattening, no
+ *      pre-parsing of GEDCOMX timestamps. Per stakeholder direction
+ *      (Dallan, meeting on 2026-05-12).
+ *
+ *   3. /service/search/hr/v2/collections?id={id}   → same shape as the
+ *      list endpoint, filtered to one entry. Duplicates cached data.
+ *
+ *   4. /platform/sources/descriptions/{id}         → 400 Bad Request.
+ *      Collection IDs don't address this resource family. Dead end.
+ *
+ * Temporal.formal formats observed across endpoints:
+ *   - `+1809/+1950` — slash separator (platform/records, legacy)
+ *   - `+1711-1992` — hyphen separator (service/search/hr/v2)
+ *   - `+1860`      — single year (service/search/hr/v2)
+ * The current parser handles all three.
+ *
+ * Usage:
+ *   npx tsx dev/probe-collection-detail.ts                # uses default 1473181
+ *   npx tsx dev/probe-collection-detail.ts 1743384        # Alabama Marriages
+ */
+import { getValidToken } from "../src/auth/refresh.js";
+import { fetchAllCollections } from "../src/tools/collections.js";
+
+const BROWSER_UA =
+  "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/136.0.0.0 Safari/537.36";
+
+const DEFAULT_ID = "1473181";
+const CHOSEN_URL_BASE =
+  "https://www.familysearch.org/service/search/hr/v2/collections";
+const CHOSEN_URL_QUERY = "?embedWikiAboutCollection=true";
+
+interface Probe {
+  label: string;
+  url: string;
+}
+
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return v !== null && typeof v === "object" && !Array.isArray(v);
+}
+
+function topKeys(obj: unknown): string[] {
+  if (!isPlainObject(obj)) return [];
+  return Object.keys(obj);
+}
+
+/**
+ * Recursive structural dump (depth-limited). Arrays show length + first
+ * element shape; objects show their keys; primitives print inline.
+ */
+function dump(label: string, value: unknown, depth = 0, maxDepth = 5): void {
+  const pad = "  ".repeat(depth);
+
+  if (value === null) {
+    console.log(`${pad}${label}: null`);
+    return;
+  }
+  if (Array.isArray(value)) {
+    console.log(`${pad}${label}: [] length=${value.length}`);
+    if (value.length > 0 && depth < maxDepth) {
+      dump("[0]", value[0], depth + 1, maxDepth);
+    }
+    if (value.length > 1 && depth < maxDepth) {
+      const first = value[0];
+      const sameShape =
+        isPlainObject(first) &&
+        value.every(
+          (v) =>
+            isPlainObject(v) &&
+            JSON.stringify(Object.keys(v).sort()) ===
+              JSON.stringify(Object.keys(first).sort())
+        );
+      console.log(
+        `${pad}  (all ${value.length} elements share same key set: ${sameShape ? "yes" : "no"})`
+      );
+    }
+    return;
+  }
+  if (!isPlainObject(value)) {
+    const s = JSON.stringify(value);
+    const preview = s.length > 200 ? `${s.slice(0, 197)}...` : s;
+    console.log(`${pad}${label}: <${typeof value}> ${preview}`);
+    return;
+  }
+
+  console.log(`${pad}${label}: { keys: [${Object.keys(value).join(", ")}] }`);
+  if (depth >= maxDepth) return;
+  for (const k of Object.keys(value)) {
+    dump(k, value[k], depth + 1, maxDepth);
+  }
+}
+
+/**
+ * Quick endpoint hit — prints HTTP status, content-type, top-level keys.
+ * Used in SECTION A. Body errors print first 400 chars for debugging.
+ */
+async function quickHit(token: string, probe: Probe): Promise<void> {
+  console.log(`\n--- [${probe.label}] ---`);
+  console.log(`URL: ${probe.url}`);
+
+  let res: Response;
+  try {
+    res = await fetch(probe.url, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: "application/json",
+        "User-Agent": BROWSER_UA,
+      },
+    });
+  } catch (err) {
+    console.log(`FETCH ERROR: ${(err as Error).message}`);
+    return;
+  }
+
+  console.log(`HTTP ${res.status} ${res.statusText}`);
+  console.log(`Content-Type: ${res.headers.get("content-type") ?? "(none)"}`);
+
+  const bodyText = await res.text();
+  if (!res.ok) {
+    console.log(`Body (first 400c): ${bodyText.slice(0, 400)}`);
+    return;
+  }
+
+  let data: unknown;
+  try {
+    data = JSON.parse(bodyText);
+  } catch {
+    console.log(`Non-JSON body (first 400c): ${bodyText.slice(0, 400)}`);
+    return;
+  }
+
+  console.log(`Top-level keys: [${topKeys(data).join(", ")}]`);
+}
+
+async function main(): Promise<void> {
+  const id = process.argv[2] ?? DEFAULT_ID;
+  console.log(`Probing collection detail for ID: ${id}\n`);
+
+  const token = await getValidToken();
+
+  // ----------------------------------------------------------------
+  // Section 0: what does the cached list endpoint already give us?
+  // ----------------------------------------------------------------
+  console.log("================================================================");
+  console.log("SECTION 0 — Already-cached record for this ID (list endpoint)");
+  console.log("================================================================");
+  const list = await fetchAllCollections(token);
+  const match = (list.entries ?? [])
+    .map((e) => e.content?.gedcomx?.collections?.[0])
+    .filter((c): c is NonNullable<typeof c> => c?.id === id);
+  if (match.length === 0) {
+    console.log(`(no entry in list response with id=${id})`);
+  } else {
+    console.log("Full record from list response:");
+    console.log(JSON.stringify(match[0], null, 2));
+  }
+
+  // ----------------------------------------------------------------
+  // SECTION A — Endpoint survey
+  // ----------------------------------------------------------------
+  console.log("\n================================================================");
+  console.log("SECTION A — Endpoint survey");
+  console.log("================================================================");
+
+  const probes: Probe[] = [
+    {
+      label: "1. /platform/records/collections/{id}  (legacy — has recordDescriptors, no wiki)",
+      url: `https://www.familysearch.org/platform/records/collections/${id}`,
+    },
+    {
+      label: "2. /service/search/hr/v2/collections/{id}?embedWikiAboutCollection=true  (CHOSEN)",
+      url: `${CHOSEN_URL_BASE}/${id}${CHOSEN_URL_QUERY}`,
+    },
+    {
+      label: "3. /service/search/hr/v2/collections?id={id}  (filtered list, dupes cached data)",
+      url: `${CHOSEN_URL_BASE}?id=${id}&count=1`,
+    },
+    {
+      label: "4. /platform/sources/descriptions/{id}  (wrong resource family — 400)",
+      url: `https://www.familysearch.org/platform/sources/descriptions/${id}`,
+    },
+  ];
+
+  for (const p of probes) {
+    await quickHit(token, p);
+  }
+
+  // ----------------------------------------------------------------
+  // SECTION B — Deep dump of the chosen endpoint
+  // ----------------------------------------------------------------
+  console.log("\n================================================================");
+  console.log("SECTION B — Deep dump of the chosen endpoint (with embed flag)");
+  console.log("================================================================");
+
+  const chosenUrl = `${CHOSEN_URL_BASE}/${id}${CHOSEN_URL_QUERY}`;
+  const res = await fetch(chosenUrl, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: "application/json",
+      "User-Agent": BROWSER_UA,
+    },
+  });
+
+  if (!res.ok) {
+    console.log(`HTTP ${res.status} ${res.statusText}`);
+    console.log(`Body (first 600c): ${(await res.text()).slice(0, 600)}`);
+    return;
+  }
+
+  const data = (await res.json()) as Record<string, unknown>;
+
+  console.log(`\nTop-level keys: [${Object.keys(data).join(", ")}]\n`);
+
+  for (const key of Object.keys(data)) {
+    console.log(`---- ${key} ----`);
+    dump(key, data[key]);
+    console.log("");
+  }
+
+  console.log("---- RAW BODY (first 4000 chars) ----");
+  console.log(JSON.stringify(data, null, 2).slice(0, 4000));
+
+  console.log("\n================================================================");
+  console.log("DONE");
+  console.log("================================================================");
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/mcp-server/dev/try-collection-detail.ts
+++ b/mcp-server/dev/try-collection-detail.ts
@@ -1,0 +1,27 @@
+/**
+ * Smoke test for collection-detail mode (collections({ id })).
+ *
+ * Invokes the tool directly against the live FamilySearch API. Useful for
+ * eyeballing the real output and debugging issues that the MCP harness
+ * would otherwise hide.
+ *
+ * Usage:
+ *   npx tsx dev/try-collection-detail.ts 1743384       # Alabama County Marriages (known good)
+ *   npx tsx dev/try-collection-detail.ts 9999999       # Unknown id (expect friendly 404)
+ */
+import { collectionsTool } from "../src/tools/collections.js";
+
+const id = process.argv[2];
+if (!id) {
+  console.error("Usage: npx tsx dev/try-collection-detail.ts <collection-id>");
+  console.error("Example: npx tsx dev/try-collection-detail.ts 1743384");
+  process.exit(1);
+}
+
+try {
+  const result = await collectionsTool({ id });
+  console.log(JSON.stringify(result, null, 2));
+} catch (err) {
+  console.error("ERROR:", err instanceof Error ? err.message : err);
+  process.exit(1);
+}

--- a/mcp-server/src/tools/collections.ts
+++ b/mcp-server/src/tools/collections.ts
@@ -1,11 +1,15 @@
+import TurndownService from "turndown";
 import { getValidToken } from "../auth/refresh.js";
 import { BROWSER_USER_AGENT } from "../constants.js";
 import type {
   FSCollectionData,
   FSCollectionEntry,
   FSCollectionsResponse,
+  FSCollectionDetailResponse,
+  FSContentCount,
   Collection,
   CollectionsResult,
+  CollectionDetailResult,
 } from "../types/collection.js";
 
 const FS_COLLECTIONS_URL =
@@ -123,10 +127,13 @@ export function clearCollectionsCache(): void {
 }
 
 /**
- * Get a count from the content array by resourceType suffix.
+ * Get a count from a content array by resourceType suffix.
  */
-function getCount(data: FSCollectionData, typeSuffix: string): number {
-  const entry = data.content?.find((c) => c.resourceType.endsWith(typeSuffix));
+function getCount(
+  content: FSContentCount[] | undefined,
+  typeSuffix: string
+): number {
+  const entry = content?.find((c) => c.resourceType.endsWith(typeSuffix));
   return entry?.count ?? 0;
 }
 
@@ -146,24 +153,106 @@ function toCollection(data: FSCollectionData): Collection {
     title: data.title,
     dateRange,
     placeIds: getPlaceIds(data),
-    recordCount: getCount(data, "/Record"),
-    personCount: getCount(data, "/Person"),
+    recordCount: getCount(data.content, "/Record"),
+    personCount: getCount(data.content, "/Person"),
     imageCount: meta?.imageCount ?? 0,
     url: `https://www.familysearch.org/search/collection/${data.id}`,
   };
 }
 
+// ---------- Detail mode helpers ----------
+
+const turndown = new TurndownService({
+  headingStyle: "atx",
+  codeBlockStyle: "fenced",
+  emDelimiter: "*",
+});
+turndown.remove(["head", "title", "style", "script"]);
+turndown.addRule("dropHidden", {
+  filter: (node) => {
+    const style = (node as HTMLElement).getAttribute?.("style") ?? "";
+    return /display\s*:\s*none/i.test(style);
+  },
+  replacement: () => "",
+});
+
+export function htmlToMarkdown(html: string | undefined | null): string | null {
+  if (!html) return null;
+  const md = turndown.turndown(html).trim();
+  return md.length > 0 ? md : null;
+}
+
+export async function fetchCollectionDetail(
+  token: string,
+  id: string
+): Promise<FSCollectionDetailResponse> {
+  const url = `${FS_COLLECTIONS_URL}/${encodeURIComponent(id)}?embedWikiAboutCollection=true`;
+  const response = await fetch(url, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: "application/json",
+      "User-Agent": BROWSER_USER_AGENT,
+    },
+  });
+
+  if (response.status === 404) {
+    throw new Error(
+      `No FamilySearch collection found with id "${id}". Use collections({ query: ... }) to list available collections.`
+    );
+  }
+  if (!response.ok) {
+    throw new Error(
+      `FamilySearch collection detail API error: ${response.status} ${response.statusText}`
+    );
+  }
+
+  try {
+    return (await response.json()) as FSCollectionDetailResponse;
+  } catch {
+    throw new Error("FamilySearch collection detail API returned malformed response.");
+  }
+}
+
+// Convert documents[*].text from HTML to markdown when textType === "html".
+// Per stakeholder direction (Dallan, 2026-05-12), only this field is converted;
+// citations stay as HTML.
+export function convertHtmlToMarkdown(
+  response: FSCollectionDetailResponse
+): FSCollectionDetailResponse {
+  const documents = response.documents?.map((d) => {
+    if (d.textType !== "html" || !d.text) return d;
+    const md = htmlToMarkdown(d.text);
+    return md == null ? d : { ...d, text: md, textType: "markdown" };
+  });
+
+  return { ...response, documents };
+}
+
+async function getCollectionDetail(id: string): Promise<CollectionDetailResult> {
+  const token = await getValidToken();
+  const detail = await fetchCollectionDetail(token, id);
+  return convertHtmlToMarkdown(detail);
+}
+
+// ---------- Tool entry point ----------
+
 export interface CollectionsToolInput {
   query?: string;
   placeIds?: number[];
+  id?: string;
 }
 
 export async function collectionsTool(
   input: CollectionsToolInput
-): Promise<CollectionsResult> {
+): Promise<CollectionsResult | CollectionDetailResult> {
+  // Detail mode wins over list inputs.
+  if (input.id) {
+    return await getCollectionDetail(input.id);
+  }
+
   if (!input.query && (!input.placeIds || input.placeIds.length === 0)) {
     throw new Error(
-      "Provide either a query (place name like \"Alabama\") or placeIds (internal collection IDs like [33])."
+      "Provide one of: id (single-collection detail), query (place name like \"Alabama\"), or placeIds (internal collection IDs like [33])."
     );
   }
 
@@ -194,8 +283,11 @@ export async function collectionsTool(
 export const collectionsToolSchema = {
   name: "collections",
   description:
-    "List FamilySearch record collections for a place, with record counts. " +
-    "Pass a place name as query (e.g., \"Alabama\") to search collection titles. " +
+    "List FamilySearch record collections for a place, OR get detailed " +
+    "information about a single collection. Pass `query` (a place name like " +
+    "\"Alabama\") to list collections, or `id` (a collection ID like \"1743384\") " +
+    "to get the FamilySearch API response for that collection, with HTML " +
+    "content (formal citation, FS Research Wiki page) converted to markdown. " +
     "Requires authentication — call the login tool first if not logged in.",
   inputSchema: {
     type: "object",
@@ -204,7 +296,7 @@ export const collectionsToolSchema = {
         type: "string",
         description:
           "Place name to search for in collection titles (e.g., \"Alabama\", \"England\"). " +
-          "This is the recommended parameter — use the places tool first to disambiguate if needed.",
+          "This is the recommended list-mode parameter — use the places tool first to disambiguate if needed.",
       },
       placeIds: {
         type: "array",
@@ -212,6 +304,14 @@ export const collectionsToolSchema = {
         description:
           "Internal FamilySearch collection place IDs. These are NOT the same as " +
           "place IDs from the places tool. Only use if you know the internal IDs.",
+      },
+      id: {
+        type: "string",
+        description:
+          "FamilySearch collection ID (e.g., \"1743384\"). When set, returns the " +
+          "FS API response for that collection (sourceDescriptions, documents, " +
+          "collections), with HTML strings (citations, Research Wiki page) " +
+          "converted to markdown. Use list mode (query) first to discover the ID.",
       },
     },
   },

--- a/mcp-server/src/types/collection.ts
+++ b/mcp-server/src/types/collection.ts
@@ -40,6 +40,37 @@ export interface FSCollectionsResponse {
   entries?: FSCollectionEntry[];
 }
 
+// GET /service/search/hr/v2/collections/{id}?embedWikiAboutCollection=true
+
+export interface FSSourceDescription {
+  id?: string;
+  about?: string;
+  modified?: string;
+  descriptions?: { lang?: string; value?: string }[];
+  citations?: { value?: string }[];
+  titles?: { lang?: string; value?: string }[];
+  rights?: string[];
+  coverage?: {
+    spatial?: { original?: string; description?: string };
+    temporal?: { original?: string; formal?: string };
+    recordType?: string;
+  }[];
+}
+
+export interface FSDocument {
+  id?: string;
+  text?: string;
+  textType?: string;
+  extracted?: boolean;
+}
+
+export interface FSCollectionDetailResponse {
+  description?: string; // GEDCOMX "#id" ref into sourceDescriptions
+  sourceDescriptions?: FSSourceDescription[];
+  collections?: FSCollectionData[];
+  documents?: FSDocument[];
+}
+
 // Tool Output Types
 
 export interface Collection {
@@ -59,3 +90,9 @@ export interface CollectionsResult {
   matchingCollections: number;
   collections: Collection[];
 }
+
+// Detail mode is a pass-through of FSCollectionDetailResponse with two
+// HTML-bearing string fields converted to markdown:
+//   - sourceDescriptions[*].citations[*].value
+//   - documents[*].text   (textType also flipped from "html" to "markdown")
+export type CollectionDetailResult = FSCollectionDetailResponse;

--- a/mcp-server/tests/tools/collections.test.ts
+++ b/mcp-server/tests/tools/collections.test.ts
@@ -10,10 +10,17 @@ import {
   filterByQuery,
   fetchAllCollections,
   clearCollectionsCache,
+  htmlToMarkdown,
+  convertHtmlToMarkdown,
 } from "../../src/tools/collections.js";
 import { getValidToken } from "../../src/auth/refresh.js";
 import { BROWSER_USER_AGENT } from "../../src/constants.js";
-import type { FSCollectionEntry, FSCollectionsResponse } from "../../src/types/collection.js";
+import type {
+  FSCollectionEntry,
+  FSCollectionsResponse,
+  FSCollectionDetailResponse,
+  CollectionDetailResult,
+} from "../../src/types/collection.js";
 
 const mockedGetValidToken = vi.mocked(getValidToken);
 
@@ -270,10 +277,8 @@ describe("collectionsTool error handling", () => {
     expect(result.collections).toEqual([]);
   });
 
-  it("throws when neither query nor placeIds provided", async () => {
-    await expect(collectionsTool({})).rejects.toThrow(
-      "Provide either a query"
-    );
+  it("throws when none of id, query, or placeIds is provided", async () => {
+    await expect(collectionsTool({})).rejects.toThrow(/Provide one of/);
   });
 });
 
@@ -328,5 +333,366 @@ describe("collectionsTool — User-Agent contract", () => {
     const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
     const headers = init.headers as Record<string, string>;
     expect(headers["User-Agent"]).toBe(BROWSER_USER_AGENT);
+  });
+});
+
+// ------------------------------------------------------------------
+// Detail-mode tests (id parameter)
+// ------------------------------------------------------------------
+
+// Fixture mirroring the real /service/search/hr/v2/collections/{id}?embedWikiAboutCollection=true
+// response shape captured by dev/probe-collection-detail.ts.
+function makeDetailResponse(): FSCollectionDetailResponse {
+  return {
+    description: "#1743384",
+    sourceDescriptions: [
+      {
+        id: "1743384",
+        about: "https://www.familysearch.org/platform/records/collections/1743384",
+        modified: "2025-04-22T14:16:50.905+00:00", // ISO string on this endpoint
+        descriptions: [
+          { lang: "en_US", value: "This collection of marriage records includes images..." },
+        ],
+        citations: [
+          {
+            value:
+              '"Alabama County Marriages, 1711-1992." Database with images. <i>FamilySearch</i>. https://FamilySearch.org : 29 December 2025. County Probate Courts, Alabama.',
+          },
+        ],
+        titles: [{ lang: "en_US", value: "Alabama County Marriages, 1711-1992" }],
+        rights: ["http://familysearch.org/records/permissionGroup/FamilySearch"],
+        coverage: [
+          {
+            spatial: { original: "United States, Alabama", description: "#place_351" },
+            temporal: { original: "1809/1950", formal: "+1809/+1950" },
+            recordType: "http://gedcomx.org/Vital",
+          },
+          {
+            spatial: { original: "Alabama, United States", description: "#place_351" },
+            temporal: { original: "1711/1992", formal: "+1711/+1992" },
+            recordType: "http://gedcomx.org/Marriage",
+          },
+        ],
+      },
+      // Container parent — kept for resolveCollectionSourceDescription tests.
+      {
+        id: "1743384_c",
+        about: "https://www.familysearch.org/platform/records/collections",
+      },
+    ],
+    collections: [
+      {
+        id: "1743384",
+        title: "Alabama County Marriages, 1711-1992",
+        content: [
+          { count: 6252135, resourceType: "http://gedcomx.org/Record", completeness: 0.64 },
+          { count: 22361722, resourceType: "http://gedcomx.org/Person", completeness: 0.64 },
+          { count: 1231203, resourceType: "http://gedcomx.org/DigitalArtifact#FamilySearch" },
+        ],
+        // searchMetadata is INSIDE collections[0] on the new endpoint —
+        // no dual-fetch with list endpoint needed.
+        searchMetadata: [
+          {
+            imageCount: 1231203,
+            recordCount: 6049744,
+            lastUpdated: 1745331410905,
+            startYear: 1711,
+            endYear: 1992,
+            placeIds: [33],
+          },
+        ],
+      },
+    ],
+    documents: [
+      {
+        id: "1743384",
+        text:
+          '<h1>Alabama County Marriages, 1711-1992</h1>' +
+          '<p>Source: <a href="https://www.familysearch.org/en/wiki/Alabama">Wiki link</a></p>' +
+          '<h2>What is in This Collection?</h2>' +
+          '<p>Marriage records from <i>Alabama</i> counties.</p>',
+        textType: "html",
+        extracted: false,
+      },
+    ],
+  };
+}
+
+// Helper: route mock fetches by URL. Detail endpoint is now
+// /service/search/hr/v2/collections/{id}?embedWikiAboutCollection=true.
+// List endpoint shares the same /service/search/hr/v2/collections path but
+// uses ?count=...&facets=OFF — discriminate on the wiki flag.
+function routeFetchMocks(opts: {
+  listResponse?: FSCollectionsResponse;
+  detailResponse?: FSCollectionDetailResponse;
+  detailStatus?: number;
+  detailMalformed?: boolean;
+}) {
+  mockFetch.mockImplementation((url: string) => {
+    const isDetail = url.includes("embedWikiAboutCollection=true");
+    if (isDetail) {
+      if (opts.detailStatus && opts.detailStatus !== 200) {
+        return Promise.resolve({
+          ok: false,
+          status: opts.detailStatus,
+          statusText: opts.detailStatus === 404 ? "Not Found" : "Error",
+          text: async () => "",
+        });
+      }
+      if (opts.detailMalformed) {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: async () => {
+            throw new Error("invalid JSON");
+          },
+        });
+      }
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        json: async () => opts.detailResponse ?? makeDetailResponse(),
+      });
+    }
+    return Promise.resolve({
+      ok: true,
+      status: 200,
+      json: async () => opts.listResponse ?? mockApiResponse,
+    });
+  });
+}
+
+describe("htmlToMarkdown", () => {
+  it("converts <i> to markdown emphasis", () => {
+    expect(htmlToMarkdown("<i>FamilySearch</i>")).toBe("*FamilySearch*");
+  });
+
+  it("converts headings, paragraphs, and links", () => {
+    const md = htmlToMarkdown(
+      '<h1>Title</h1><p>Text with <a href="https://example.com">a link</a>.</p>'
+    );
+    expect(md).toContain("# Title");
+    expect(md).toContain("[a link](https://example.com)");
+  });
+
+  it("returns null for null/undefined/empty inputs", () => {
+    expect(htmlToMarkdown(null)).toBeNull();
+    expect(htmlToMarkdown(undefined)).toBeNull();
+    expect(htmlToMarkdown("")).toBeNull();
+  });
+
+  it("returns null when conversion yields only whitespace", () => {
+    expect(htmlToMarkdown("<div></div>")).toBeNull();
+  });
+
+  it("preserves plain text", () => {
+    expect(htmlToMarkdown("Just text, no markup.")).toBe("Just text, no markup.");
+  });
+});
+
+describe("htmlToMarkdown — wiki content quirks", () => {
+  it("drops <head>, <style>, and <script> blocks entirely", () => {
+    const html =
+      "<!DOCTYPE html><html><head><title>Drop</title><style>body{x:1}</style></head>" +
+      "<body><h1>Keep</h1><script>alert(1)</script><p>Text</p></body></html>";
+    const md = htmlToMarkdown(html);
+    expect(md).not.toContain("Drop");
+    expect(md).not.toContain("body{x:1}");
+    expect(md).not.toContain("alert(1)");
+    expect(md).toContain("# Keep");
+    expect(md).toContain("Text");
+  });
+
+  it("drops elements with style=\"display: none\" (MediaWiki template placeholders)", () => {
+    const html =
+      '<div><p>Visible</p>' +
+      '<div style="display: none">{{{CID2}}}</div>' +
+      '<div style="display:none">{{{CID3}}}</div>' +
+      '<p>Also visible</p></div>';
+    const md = htmlToMarkdown(html);
+    expect(md).toContain("Visible");
+    expect(md).toContain("Also visible");
+    expect(md).not.toContain("CID2");
+    expect(md).not.toContain("CID3");
+  });
+});
+
+describe("convertHtmlToMarkdown", () => {
+  it("does NOT touch citations[*].value (citations stay as HTML)", () => {
+    const original = "Title. <i>FamilySearch</i>. http://...";
+    const out = convertHtmlToMarkdown({
+      sourceDescriptions: [{ id: "x", citations: [{ value: original }] }],
+    });
+    expect(out.sourceDescriptions?.[0].citations?.[0].value).toBe(original);
+  });
+
+  it("converts documents[*].text and flips textType from html to markdown", () => {
+    const out = convertHtmlToMarkdown({
+      documents: [
+        { id: "x", textType: "html", text: "<h1>Title</h1><p>Body</p>" },
+      ],
+    });
+    expect(out.documents?.[0].text).toContain("# Title");
+    expect(out.documents?.[0].text).not.toContain("<h1>");
+    expect(out.documents?.[0].textType).toBe("markdown");
+  });
+
+  it("leaves documents with textType !== 'html' untouched", () => {
+    const out = convertHtmlToMarkdown({
+      documents: [{ id: "x", textType: "plain", text: "<not html>" }],
+    });
+    expect(out.documents?.[0].text).toBe("<not html>");
+    expect(out.documents?.[0].textType).toBe("plain");
+  });
+
+  it("preserves all other top-level fields unchanged", () => {
+    const input = {
+      description: "#1473181",
+      id: "1473181",
+      collections: [
+        {
+          id: "1473181",
+          title: "Foo",
+          content: [{ count: 1, resourceType: "x" }],
+          searchMetadata: [{ placeIds: [1], imageCount: 2 }],
+        },
+      ],
+      sourceDescriptions: [{ id: "1473181", titles: [{ value: "Foo" }] }],
+    };
+    const out = convertHtmlToMarkdown(input);
+    expect(out.description).toBe("#1473181");
+    expect(out.id).toBe("1473181");
+    expect(out.collections).toEqual(input.collections);
+    expect(out.sourceDescriptions?.[0].titles).toEqual(input.sourceDescriptions[0].titles);
+  });
+});
+
+describe("collectionsTool detail mode (pass-through)", () => {
+  it("returns the FS response shape, not a wrapped { collection: ... }", async () => {
+    mockedGetValidToken.mockResolvedValue("test-token");
+    routeFetchMocks({});
+
+    const result = (await collectionsTool({ id: "1743384" })) as CollectionDetailResult;
+
+    // Top-level keys come from the FS response, no { collection: ... } wrapper.
+    expect("collection" in result).toBe(false);
+    expect(result.sourceDescriptions).toBeDefined();
+    expect(result.documents).toBeDefined();
+    expect(result.collections).toBeDefined();
+  });
+
+  it("leaves citation HTML untouched (stays as raw HTML, not markdown)", async () => {
+    mockedGetValidToken.mockResolvedValue("test-token");
+    routeFetchMocks({});
+
+    const result = (await collectionsTool({ id: "1743384" })) as CollectionDetailResult;
+    const citation = result.sourceDescriptions?.[0].citations?.[0].value ?? "";
+
+    // Per stakeholder direction, only documents[*].text gets converted.
+    expect(citation).toContain("<i>FamilySearch</i>");
+    expect(citation).not.toContain("*FamilySearch*");
+  });
+
+  it("converts documents[0].text to markdown and flips textType to 'markdown'", async () => {
+    mockedGetValidToken.mockResolvedValue("test-token");
+    routeFetchMocks({});
+
+    const result = (await collectionsTool({ id: "1743384" })) as CollectionDetailResult;
+    const doc = result.documents?.[0];
+
+    expect(doc?.text).toContain("# Alabama County Marriages");
+    expect(doc?.text).toContain("## What is in This Collection?");
+    expect(doc?.text).not.toContain("<h1>");
+    expect(doc?.textType).toBe("markdown");
+  });
+
+  it("preserves container-parent sourceDescriptions (no stripping)", async () => {
+    mockedGetValidToken.mockResolvedValue("test-token");
+    routeFetchMocks({});
+
+    const result = (await collectionsTool({ id: "1743384" })) as CollectionDetailResult;
+    const ids = result.sourceDescriptions?.map((sd) => sd.id);
+
+    // Both the primary SD and the container parent are passed through.
+    expect(ids).toContain("1743384");
+    expect(ids).toContain("1743384_c");
+  });
+
+  it("preserves searchMetadata inside collections[0]", async () => {
+    mockedGetValidToken.mockResolvedValue("test-token");
+    routeFetchMocks({});
+
+    const result = (await collectionsTool({ id: "1743384" })) as CollectionDetailResult;
+    const meta = result.collections?.[0].searchMetadata?.[0];
+
+    expect(meta?.placeIds).toEqual([33]);
+    expect(meta?.imageCount).toBe(1231203);
+    expect(meta?.lastUpdated).toBe(1745331410905);
+    expect(meta?.startYear).toBe(1711);
+    expect(meta?.endYear).toBe(1992);
+  });
+
+  it("does NOT call the list endpoint in detail mode", async () => {
+    mockedGetValidToken.mockResolvedValue("test-token");
+    routeFetchMocks({});
+
+    await collectionsTool({ id: "1743384" });
+
+    const urls = mockFetch.mock.calls.map((call) => call[0] as string);
+    expect(urls).toHaveLength(1);
+    expect(urls[0]).toContain("embedWikiAboutCollection=true");
+  });
+
+  it("throws a friendly error on 404 from the detail endpoint", async () => {
+    mockedGetValidToken.mockResolvedValue("test-token");
+    routeFetchMocks({ detailStatus: 404 });
+
+    await expect(collectionsTool({ id: "9999999" })).rejects.toThrow(
+      /No FamilySearch collection found with id "9999999"/
+    );
+  });
+
+  it("throws a generic API error on non-404 detail failure", async () => {
+    mockedGetValidToken.mockResolvedValue("test-token");
+    routeFetchMocks({ detailStatus: 500 });
+
+    await expect(collectionsTool({ id: "1743384" })).rejects.toThrow(
+      /FamilySearch collection detail API error: 500/
+    );
+  });
+
+  it("throws auth error when not logged in", async () => {
+    mockedGetValidToken.mockRejectedValue(
+      new Error(
+        "User is not logged in to FamilySearch. Call the login tool to authenticate."
+      )
+    );
+
+    await expect(collectionsTool({ id: "1743384" })).rejects.toThrow(
+      /User is not logged in/
+    );
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("throws on malformed detail response", async () => {
+    mockedGetValidToken.mockResolvedValue("test-token");
+    routeFetchMocks({ detailMalformed: true });
+
+    await expect(collectionsTool({ id: "1743384" })).rejects.toThrow(
+      /malformed response/
+    );
+  });
+
+  it("id wins when both id and query are passed", async () => {
+    mockedGetValidToken.mockResolvedValue("test-token");
+    routeFetchMocks({});
+
+    const result = (await collectionsTool({
+      id: "1743384",
+      query: "ignored",
+    })) as CollectionDetailResult;
+
+    // Detail-mode shape (sourceDescriptions present), not list-mode (collections array of summaries).
+    expect(result.sourceDescriptions).toBeDefined();
   });
 });


### PR DESCRIPTION
## Summary
  - Extend `collections` MCP tool with an `id` parameter that returns the FamilySearch search API response for a single
  collection.
  - HTML inside `documents[*].text` is converted to markdown via `turndown`; `textType` is flipped from `"html"` to
  `"markdown"`.
## Test plan
  - [x] 116 unit tests pass (helper + integration)
  - [x] MCP Inspector — happy path, 404, list-mode regression, `id` precedence all verified
  - [x] Cowork end-to-end — Claude navigates the raw GEDCOMX response and uses both the wiki markdown and the structured
  fields correctly