### PR TITLE
Lift Persistent ARK to flat `ark` field on SimplifiedPerson

### DIFF
--- a/docs/specs/gedcomx-convert-spec.md
+++ b/docs/specs/gedcomx-convert-spec.md
@@ -52,6 +52,7 @@ export type GedcomXPerson = {
   names?: GedcomXName[];
   facts?: GedcomXFact[];
   sources?: GedcomXSourceReference[];
+  identifiers?: Record<string, string[]>;
 };
 
 export type GedcomXName = {
@@ -137,6 +138,7 @@ export type SimplifiedGedcomX = {
 
 export type SimplifiedPerson = {
   id?: string;
+  ark?: string;              // First http://gedcomx.org/Persistent identifier
   gender?: string;           // "Male" | "Female" | "Unknown"
   names?: SimplifiedName[];
   facts?: SimplifiedFact[];
@@ -499,6 +501,43 @@ GedcomX lacks an ID on a name, fact, or relationship, the simplified output
 also lacks it. ID generation (with `I`/`N`/`F`/`R`/`S` prefixes per
 `simplified-gedcomx-spec.md` §3) is the caller's responsibility.
 
+### 15. Person identifiers — flat `ark`
+
+GedcomX `Person.identifiers` is a map from identifier-type URI to a list of
+identifier values. The entry under `http://gedcomx.org/Persistent` carries
+the canonical FamilySearch ARK URL for the persona — the anchor that
+record-search APIs use to identify which record a persona represents.
+
+The simplified format lifts the first Persistent value to a flat `ark`
+string on `SimplifiedPerson`, following the same flattening convention used
+by other single-dominant-value structures in the spec (`date.original` →
+`date`, `place.original` → `place`, `titles[0].value` → `title`,
+`nameForms[0].parts` → `given`/`surname`). Other identifier types
+(`Primary`, `Authority`, etc.) are dropped — this is a documented loss,
+matching Rule 6's drop of `date.formal` and Rule 10's drop of qualifiers
+outside `CitationDetail` / `fsmcp:quality`.
+
+```
+{
+  "http://gedcomx.org/Persistent": ["https://familysearch.org/ark:/61903/4:1:KGS8-LY1"],
+  "http://gedcomx.org/Primary":    ["KGS8-LY1"]
+}
+↓
+"ark": "https://familysearch.org/ark:/61903/4:1:KGS8-LY1"
+```
+
+- `toSimplified`: read `person.identifiers["http://gedcomx.org/Persistent"][0]`.
+  If it is a non-empty string, set `out.ark` to that value. All other entries
+  in the `identifiers` map are dropped. If the Persistent entry is missing,
+  empty, or the first value is not a non-empty string, omit `ark`.
+- `toGedcomX`: when `person.ark` is a non-empty string, write
+  `out.identifiers = { "http://gedcomx.org/Persistent": [person.ark] }`. When
+  `ark` is missing or an empty string, omit `identifiers`.
+
+**Documented losses.** Round-tripping through this rule loses:
+1. Identifier types other than `Persistent` (input → output).
+2. Persistent values beyond the first one in the array (multiple-value collapse).
+
 ---
 
 ## Edge cases
@@ -538,6 +577,13 @@ also lacks it. ID generation (with `I`/`N`/`F`/`R`/`S` prefixes per
 | ParentChild with parent-style fact URI outside the recognized five | Fact passes through unchanged in `facts[]`; `subtype` omitted | Same on the way back |
 | `notes` array missing or empty | Omit `notes` | Omit `notes` |
 | `notes` entry has no `text` field | Drop that entry from simplified output | n/a |
+| `identifiers` map missing | Omit `ark` | n/a |
+| `identifiers` present but no `Persistent` key | Omit `ark` | n/a |
+| `Persistent` array empty | Omit `ark` | n/a |
+| `Persistent[0]` not a string or empty string | Omit `ark` | n/a |
+| `Persistent` array has multiple values | Lift first; rest dropped | Round-trip emits single-element array containing only the first |
+| Other identifier types present alongside `Persistent` (e.g. `Primary`) | First Persistent surfaces as `ark`; other types dropped | n/a |
+| `ark` missing or empty string on simplified input | n/a | Omit `identifiers` |
 
 ---
 
@@ -780,6 +826,10 @@ fall into the `fullText` fallback path and emit a warning.
 | 31 | `preferred: false` and `primary: false` are never emitted | Schema compliance |
 | 32 | **Identity round-trip A** — `toGedcomX(toSimplified(raw))` equals `raw` for a "clean" GedcomX input (no `date.formal`, no `place.description`, parts-based names, no lossy qualifiers; includes a ParentChild with subtype and notes) | Round-trip identity |
 | 33 | **Identity round-trip B** — `toSimplified(toGedcomX(simplified))` equals `simplified` for a comprehensive simplified input (includes a ParentChild with subtype and notes) | Round-trip identity |
+| 34 | First `Persistent` value lifts to `SimplifiedPerson.ark`; `toGedcomX` rebuilds `identifiers["http://gedcomx.org/Persistent"]: [ark]` | Rule 15 |
+| 35 | Other identifier types (`Primary`, `Authority`, etc.) are dropped on simplification; round-trip emits only Persistent | Rule 15 |
+| 36 | Missing `identifiers` and missing `Persistent` key both omit `ark`; missing or empty-string `ark` omits `identifiers` on `toGedcomX` | Rule 15 |
+| 37 | Multiple Persistent values: first wins, rest dropped; round-trip emits a single-element array | Rule 15 |
 
 ### Smoke-test script
 

--- a/docs/specs/simplified-gedcomx-spec.md
+++ b/docs/specs/simplified-gedcomx-spec.md
@@ -52,6 +52,7 @@ These rules define how full GedcomX maps to simplified GedcomX. The MCP conversi
 | Source references: `description: "#S1"` + qualifiers | `ref: "S1"`, `page: "..."`, `quality: N` | Flattened. `quality` mimics GEDCOM's QUAY. |
 | `sourceDescriptions[].citations[0].value` | `sources[].citation` | Flattened from nested array. |
 | `sourceDescriptions[].titles[0].value` | `sources[].title` | Flattened from nested array. |
+| `persons[].identifiers["http://gedcomx.org/Persistent"][0]` | `persons[].ark` | Flattened. The persistent ARK URL anchors a persona to a real FamilySearch record; record-search APIs require it. Other identifier types and additional Persistent values are dropped. |
 
 ---
 
@@ -81,6 +82,7 @@ Array of person objects.
 | `gender` | string | yes | `Male`, `Female`, or `Unknown` |
 | `names` | object[] | yes | At least one name. See below |
 | `facts` | object[] | no | Person facts (birth, death, etc.). May be empty or omitted for stub persons |
+| `ark` | string | no | Persistent FamilySearch ARK URL (e.g. `https://familysearch.org/ark:/61903/4:1:KGS8-LY1`). The flat lift of full GedcomX's `identifiers["http://gedcomx.org/Persistent"][0]`. Required by tools whose API responses reference persons by ARK (`matchTwoExamples`, future `tree`/`cets`). Omit on synthesized stub persons with no real-world FS persona. See Section 4.6 |
 
 **Stub persons:** A minimal valid person requires `id`, `gender` (which may be `Unknown`), and one name with at least a `surname`. `given` may be an empty string when only the surname is known. `facts` may be omitted entirely. Example: `{ "id": "I1", "gender": "Unknown", "names": [{ "id": "N1", "preferred": true, "given": "", "surname": "Flynn" }] }`
 
@@ -173,6 +175,27 @@ Dates are freeform human-readable strings. The MCP conversion function best-effo
 
 Skills should prefer the recognized patterns. The conversion function will attempt to parse any string but may produce lossy GedcomX formal dates from free text. Dates that don't match any pattern are stored as `date.original` in full GedcomX with no `date.formal`.
 
+### 4.6 Persistent ARK (`ark`)
+
+`persons[].ark` is the persistent FamilySearch ARK URL for the person. It
+maps to full GedcomX's `identifiers["http://gedcomx.org/Persistent"][0]` —
+the first Persistent value is lifted to a flat string here, following the
+same convention that produces flat `given`/`surname`, `date`, `place`, and
+`title`.
+
+```json
+"ark": "https://familysearch.org/ark:/61903/4:1:KGS8-LY1"
+```
+
+The ARK is required by record-search APIs (`matchTwoExamples`, future
+`tree`/`cets`) that anchor on the persistent identifier to know which FS
+record a persona represents. Stub persons populated during research will
+typically lack `ark` entirely.
+
+Other identifier types on the full GedcomX side (`Primary`, `Authority`,
+etc.) and additional Persistent values beyond the first are dropped on
+round-trip. See §7 below.
+
 ---
 
 ## 5. Enums
@@ -264,6 +287,7 @@ The following full GedcomX fields are not represented in the simplified format a
 - `contributors`, `attribution`, `analysis` on source descriptions
 - `confidence` on conclusions (use `research.json` proof tiers instead)
 - `subject`, `lang`, and `attribution` on `Note` objects — only the `text` field is preserved as a flat string in the simplified `notes` array
+- `persons[].identifiers` entries other than `http://gedcomx.org/Persistent` (e.g. `Primary`, `Authority`) — only the first Persistent value is preserved (as `ark`). Additional Persistent values beyond the first are also dropped.
 
 These losses are acceptable for the target use case (English-language Western genealogy). For projects requiring multi-script names or formal date encoding, the full GedcomX format should be used directly.
 

--- a/mcp-server/dev/probe-gedcomx-roundtrip.ts
+++ b/mcp-server/dev/probe-gedcomx-roundtrip.ts
@@ -1,0 +1,368 @@
+/**
+ * Probe — measure data loss when round-tripping a matchTwoExamples
+ * request body through toSimplified → toGedcomX.
+ *
+ * The matchTwoExamples endpoint
+ * (POST /service/search/record/collections/match/matchTwoExamples)
+ * is a record-search persona shape that carries Person.identifiers
+ * (persistent ARK URLs) and other fields outside the tree/cets subset
+ * the converter was originally specified for. This probe loads a real
+ * request body, runs each entry's `content.gedcomx` through the
+ * converter, and diffs the result against the original to enumerate
+ * every dropped or mutated field.
+ *
+ * Output: stdout. Run with:
+ *   cd mcp-server && npx tsx dev/probe-gedcomx-roundtrip.ts
+ */
+import { toSimplified, toGedcomX } from "../src/utils/gedcomx-convert.js";
+import type { GedcomX } from "../src/types/gedcomx.js";
+
+// ─── matchTwoExamples request body (verbatim sample) ───
+
+const matchEntries: { content: { gedcomx: Record<string, unknown> } }[] = [
+  {
+    content: {
+      gedcomx: {
+        persons: [
+          {
+            gender: { type: "http://gedcomx.org/Male" },
+            names: [
+              {
+                preferred: true,
+                nameForms: [
+                  {
+                    fullText: "Johann Georg Hufenreuter",
+                    parts: [
+                      { type: "http://gedcomx.org/Given", value: "Johann Georg" },
+                      { type: "http://gedcomx.org/Surname", value: "Hufenreuter" },
+                    ],
+                  },
+                ],
+                type: "http://gedcomx.org/BirthName",
+              },
+            ],
+            facts: [
+              {
+                date: { original: "11Jan1758", formal: "+1758-01-11" },
+                place: { original: "Biesenrode, Schsn, Prss" },
+                type: "http://gedcomx.org/Birth",
+              },
+            ],
+            id: "id1",
+            identifiers: {
+              "http://gedcomx.org/Persistent": [
+                "https://familysearch.org/ark:/61903/4:1:KGS8-LY1",
+              ],
+            },
+            putativeGender: [{ type: "http://gedcomx.org/Male" }],
+          },
+          {
+            gender: { type: "http://gedcomx.org/Male" },
+            names: [
+              {
+                preferred: true,
+                nameForms: [
+                  {
+                    fullText: "Johann Tobias Hufenreuter",
+                    parts: [
+                      { type: "http://gedcomx.org/Given", value: "Johann Tobias" },
+                      { type: "http://gedcomx.org/Surname", value: "Hufenreuter" },
+                    ],
+                  },
+                ],
+                type: "http://gedcomx.org/BirthName",
+              },
+            ],
+            facts: [
+              {
+                date: { original: "16Mar1721", formal: "+1721-03-16" },
+                place: { original: "Biesenrode, Schsn, Prss" },
+                type: "http://gedcomx.org/Birth",
+              },
+            ],
+            id: "ark:/61903/4:1:KGS8-LY7",
+            identifiers: {
+              "http://gedcomx.org/Persistent": [
+                "https://familysearch.org/ark:/61903/4:1:KGS8-LY7",
+              ],
+            },
+            putativeGender: [{ type: "http://gedcomx.org/Male" }],
+          },
+          {
+            gender: { type: "http://gedcomx.org/Female" },
+            names: [
+              {
+                preferred: true,
+                nameForms: [
+                  {
+                    fullText: "Elisabeth Henrica Dorothea",
+                    parts: [
+                      { type: "http://gedcomx.org/Given", value: "Elisabeth Henrica Dorothea" },
+                    ],
+                  },
+                ],
+                type: "http://gedcomx.org/BirthName",
+              },
+            ],
+            facts: [
+              {
+                date: { original: "1720", formal: "+1720" },
+                place: { original: "Biesenrode, Schsn, Prss" },
+                type: "http://gedcomx.org/Birth",
+              },
+              {
+                date: { original: "16May1780", formal: "+1780-05-16" },
+                place: { original: "Biesenrode, Schsn, Prss" },
+                type: "http://gedcomx.org/Burial",
+              },
+            ],
+            id: "ark:/61903/4:1:KGS8-LYC",
+            identifiers: {
+              "http://gedcomx.org/Persistent": [
+                "https://familysearch.org/ark:/61903/4:1:KGS8-LYC",
+              ],
+            },
+            putativeGender: [{ type: "http://gedcomx.org/Female" }],
+          },
+        ],
+        relationships: [
+          {
+            person1: { resource: "#ark:/61903/4:1:KGS8-LY7", resourceId: "KGS8-LY7" },
+            person2: { resource: "#ark:/61903/4:1:KGS8-LY1", resourceId: "KGS8-LY1" },
+            type: "http://gedcomx.org/ParentChild",
+          },
+          {
+            person1: { resource: "#ark:/61903/4:1:KGS8-LYC", resourceId: "KGS8-LYC" },
+            person2: { resource: "#ark:/61903/4:1:KGS8-LY1", resourceId: "KGS8-LY1" },
+            type: "http://gedcomx.org/ParentChild",
+          },
+        ],
+      },
+    },
+  },
+  {
+    content: {
+      gedcomx: {
+        persons: [
+          {
+            gender: { type: "http://gedcomx.org/Male" },
+            names: [
+              {
+                preferred: true,
+                nameForms: [
+                  {
+                    fullText: "Johann Georg Hufenreuter",
+                    parts: [
+                      { type: "http://gedcomx.org/Given", value: "Johann Georg" },
+                      { type: "http://gedcomx.org/Surname", value: "Hufenreuter" },
+                    ],
+                  },
+                ],
+                type: "http://gedcomx.org/BirthName",
+              },
+            ],
+            facts: [
+              {
+                date: { original: "11Jan1758", formal: "+1758-01-11" },
+                place: { original: "Biesenrode, Schsn, Prss" },
+                type: "http://gedcomx.org/Birth",
+              },
+            ],
+            id: "ark:/61903/4:1:KCWM-J9H",
+            identifiers: {
+              "http://gedcomx.org/Persistent": [
+                "https://familysearch.org/ark:/61903/4:1:KCWM-J9H",
+              ],
+            },
+            putativeGender: [{ type: "http://gedcomx.org/Male" }],
+          },
+          {
+            gender: { type: "http://gedcomx.org/Male" },
+            names: [
+              {
+                preferred: true,
+                nameForms: [
+                  {
+                    fullText: "Johann Tobias Hufenreuter",
+                    parts: [
+                      { type: "http://gedcomx.org/Given", value: "Johann Tobias" },
+                      { type: "http://gedcomx.org/Surname", value: "Hufenreuter" },
+                    ],
+                  },
+                ],
+                type: "http://gedcomx.org/BirthName",
+              },
+            ],
+            facts: [
+              {
+                date: { original: "16Mar1721", formal: "+1721-03-16" },
+                place: { original: "Biesenrode, Schsn, Prss" },
+                type: "http://gedcomx.org/Birth",
+              },
+            ],
+            id: "ark:/61903/4:1:KDBD-Y1Q",
+            identifiers: {
+              "http://gedcomx.org/Persistent": [
+                "https://familysearch.org/ark:/61903/4:1:KDBD-Y1Q",
+              ],
+            },
+            putativeGender: [{ type: "http://gedcomx.org/Male" }],
+          },
+          {
+            gender: { type: "http://gedcomx.org/Female" },
+            names: [
+              {
+                preferred: true,
+                nameForms: [
+                  {
+                    fullText: "Elisabeth Henrica Dorothea",
+                    parts: [
+                      { type: "http://gedcomx.org/Given", value: "Elisabeth Henrica Dorothea" },
+                    ],
+                  },
+                ],
+                type: "http://gedcomx.org/BirthName",
+              },
+            ],
+            facts: [
+              {
+                date: { original: "1720", formal: "+1720" },
+                place: { original: "Biesenrode, Schsn, Prss" },
+                type: "http://gedcomx.org/Birth",
+              },
+              {
+                date: { original: "16May1780", formal: "+1780-05-16" },
+                place: { original: "Biesenrode, Schsn, Prss" },
+                type: "http://gedcomx.org/Burial",
+              },
+            ],
+            id: "ark:/61903/4:1:KH11-B46",
+            identifiers: {
+              "http://gedcomx.org/Persistent": [
+                "https://familysearch.org/ark:/61903/4:1:KH11-B46",
+              ],
+            },
+            putativeGender: [{ type: "http://gedcomx.org/Female" }],
+          },
+        ],
+        relationships: [
+          {
+            person1: { resource: "#ark:/61903/4:1:KDBD-Y1Q", resourceId: "KDBD-Y1Q" },
+            person2: { resource: "#ark:/61903/4:1:KCWM-J9H", resourceId: "KCWM-J9H" },
+            type: "http://gedcomx.org/ParentChild",
+          },
+          {
+            person1: { resource: "#ark:/61903/4:1:KH11-B46", resourceId: "KH11-B46" },
+            person2: { resource: "#ark:/61903/4:1:KCWM-J9H", resourceId: "KCWM-J9H" },
+            type: "http://gedcomx.org/ParentChild",
+          },
+        ],
+      },
+    },
+  },
+];
+
+// ─── Loss enumeration ──────────────────────────────────────────────────
+
+interface Diff {
+  path: string;
+  status: "DROPPED" | "MUTATED";
+  before: unknown;
+  after: unknown;
+}
+
+function diff(original: unknown, roundTripped: unknown, path = ""): Diff[] {
+  const diffs: Diff[] = [];
+
+  // Identity / primitive comparison.
+  if (original === roundTripped) return diffs;
+
+  // Original missing/null but roundTripped has value → ignore (added field — not lossy).
+  // We only care about loss.
+  if (
+    original !== null &&
+    typeof original === "object" &&
+    roundTripped !== null &&
+    typeof roundTripped === "object"
+  ) {
+    if (Array.isArray(original) && Array.isArray(roundTripped)) {
+      const maxLen = Math.max(original.length, roundTripped.length);
+      for (let i = 0; i < maxLen; i++) {
+        diffs.push(...diff(original[i], roundTripped[i], `${path}[${i}]`));
+      }
+      return diffs;
+    }
+    if (Array.isArray(original) !== Array.isArray(roundTripped)) {
+      diffs.push({ path, status: "MUTATED", before: original, after: roundTripped });
+      return diffs;
+    }
+    const origObj = original as Record<string, unknown>;
+    const rtObj = roundTripped as Record<string, unknown>;
+    const keys = new Set([...Object.keys(origObj), ...Object.keys(rtObj)]);
+    for (const key of keys) {
+      const childPath = path ? `${path}.${key}` : key;
+      if (!(key in rtObj)) {
+        diffs.push({
+          path: childPath,
+          status: "DROPPED",
+          before: origObj[key],
+          after: undefined,
+        });
+        continue;
+      }
+      if (!(key in origObj)) continue; // added — not a loss
+      diffs.push(...diff(origObj[key], rtObj[key], childPath));
+    }
+    return diffs;
+  }
+
+  // Different primitives.
+  if (original !== roundTripped) {
+    diffs.push({ path, status: "MUTATED", before: original, after: roundTripped });
+  }
+  return diffs;
+}
+
+// ─── Main ──────────────────────────────────────────────────────────────
+
+function summarize(diffs: Diff[]): Map<string, { count: number; sample: Diff }> {
+  // Group by leaf key (last segment, stripping array indices) to deduplicate.
+  const groups = new Map<string, { count: number; sample: Diff }>();
+  for (const d of diffs) {
+    const leaf = d.path.replace(/\[\d+\]/g, "[]");
+    const existing = groups.get(leaf);
+    if (existing) existing.count++;
+    else groups.set(leaf, { count: 1, sample: d });
+  }
+  return groups;
+}
+
+let totalLosses = 0;
+matchEntries.forEach((entry, idx) => {
+  const original = entry.content.gedcomx as GedcomX;
+  const simplified = toSimplified(original);
+  const roundTripped = toGedcomX(simplified);
+  const diffs = diff(original, roundTripped);
+  totalLosses += diffs.length;
+
+  console.log(`\n══ Entry ${idx} ════════════════════════════════════════════════`);
+  console.log(`  persons:        ${original.persons?.length ?? 0}`);
+  console.log(`  relationships:  ${original.relationships?.length ?? 0}`);
+  console.log(`  losses found:   ${diffs.length}`);
+
+  const groups = summarize(diffs);
+  console.log(`\n  Grouped losses (${groups.size} unique paths):`);
+  for (const [path, { count, sample }] of groups) {
+    console.log(`    [${sample.status}] ${path}  ×${count}`);
+    console.log(`        before: ${JSON.stringify(sample.before)}`);
+    console.log(`        after:  ${JSON.stringify(sample.after)}`);
+  }
+});
+
+console.log(`\n══ Summary ════════════════════════════════════════════════════`);
+console.log(`Total field-level losses across both entries: ${totalLosses}`);
+console.log(
+  totalLosses === 0
+    ? "✓ No data loss detected."
+    : "✗ Data loss detected. See per-entry breakdown above.",
+);

--- a/mcp-server/src/types/gedcomx.ts
+++ b/mcp-server/src/types/gedcomx.ts
@@ -14,6 +14,7 @@ export interface GedcomXPerson {
   names?: GedcomXName[];
   facts?: GedcomXFact[];
   sources?: GedcomXSourceReference[];
+  identifiers?: Record<string, string[]>;
 }
 
 export interface GedcomXName {
@@ -96,6 +97,7 @@ export interface SimplifiedGedcomX {
 
 export interface SimplifiedPerson {
   id?: string;
+  ark?: string;
   gender?: string;
   names?: SimplifiedName[];
   facts?: SimplifiedFact[];

--- a/mcp-server/src/utils/gedcomx-convert.ts
+++ b/mcp-server/src/utils/gedcomx-convert.ts
@@ -23,6 +23,7 @@ import type {
 const URI_PREFIX = "http://gedcomx.org/";
 const CITATION_DETAIL = "http://gedcomx.org/CitationDetail";
 const QUALITY_QUALIFIER = "fsmcp:quality";
+const PERSISTENT_ID = "http://gedcomx.org/Persistent";
 const PARENT_CHILD = "ParentChild";
 
 type NamePartKind = "Prefix" | "Given" | "Surname" | "Suffix";
@@ -108,6 +109,16 @@ export function toSimplified(gedcomx: GedcomX): SimplifiedGedcomX {
 function simplifyPerson(person: GedcomXPerson): SimplifiedPerson {
   const out: SimplifiedPerson = {};
   if (person.id !== undefined) out.id = person.id;
+
+  // Lift the first Persistent identifier (the canonical FamilySearch ARK
+  // URL) to a flat `ark` field, mirroring how the spec flattens other
+  // single-dominant-value structures (date, place, title). Other
+  // identifier types (Primary, Authority, etc.) are dropped — only
+  // Persistent is needed by downstream tools.
+  const persistent = person.identifiers?.[PERSISTENT_ID];
+  if (Array.isArray(persistent) && typeof persistent[0] === "string" && persistent[0].length > 0) {
+    out.ark = persistent[0];
+  }
 
   const gender = simplifyGender(person.gender);
   if (gender !== undefined) out.gender = gender;
@@ -368,6 +379,11 @@ export function toGedcomX(simplified: SimplifiedGedcomX): GedcomX {
 function expandPerson(person: SimplifiedPerson): GedcomXPerson {
   const out: GedcomXPerson = {};
   if (person.id !== undefined) out.id = person.id;
+
+  // Rebuild the GedcomX identifiers map from the flat `ark` field.
+  if (typeof person.ark === "string" && person.ark.length > 0) {
+    out.identifiers = { [PERSISTENT_ID]: [person.ark] };
+  }
 
   const gender = expandGender(person.gender);
   if (gender) out.gender = gender;

--- a/mcp-server/tests/utils/gedcomx-convert.test.ts
+++ b/mcp-server/tests/utils/gedcomx-convert.test.ts
@@ -738,6 +738,123 @@ describe("gedcomx-convert — transformation rules", () => {
     expect("notes" in (missing.relationships?.[0] ?? {})).toBe(false);
   });
 
+  // Test 34 — Rule 15: ark round-trips between SimplifiedPerson.ark and
+  // GedcomXPerson.identifiers["http://gedcomx.org/Persistent"][0]
+  it("lifts first Persistent ARK to flat `ark` and rebuilds it on toGedcomX", () => {
+    const input: GedcomX = {
+      persons: [
+        {
+          id: "ark:/61903/4:1:KGS8-LY1",
+          identifiers: {
+            "http://gedcomx.org/Persistent": [
+              "https://familysearch.org/ark:/61903/4:1:KGS8-LY1",
+            ],
+          },
+        },
+      ],
+    };
+    const simplified = toSimplified(input);
+    expect(simplified.persons?.[0].ark).toBe(
+      "https://familysearch.org/ark:/61903/4:1:KGS8-LY1",
+    );
+    // The map shape must no longer appear on the simplified side.
+    expect(
+      "identifiers" in (simplified.persons?.[0] ?? {}),
+    ).toBe(false);
+
+    const back = toGedcomX(simplified);
+    expect(back.persons?.[0].identifiers).toEqual({
+      "http://gedcomx.org/Persistent": [
+        "https://familysearch.org/ark:/61903/4:1:KGS8-LY1",
+      ],
+    });
+  });
+
+  // Test 35 — Rule 15: non-Persistent identifier types are dropped
+  it("drops non-Persistent identifier types (Primary, Authority, etc.)", () => {
+    const input: GedcomX = {
+      persons: [
+        {
+          id: "p1",
+          identifiers: {
+            "http://gedcomx.org/Persistent": ["https://example.com/p1-ark"],
+            "http://gedcomx.org/Primary": ["primary-id-1"],
+            "http://gedcomx.org/Authority": ["authority-id-1"],
+          },
+        },
+      ],
+    };
+    const simplified = toSimplified(input);
+    expect(simplified.persons?.[0].ark).toBe("https://example.com/p1-ark");
+
+    // Only Persistent survives the expand back.
+    const back = toGedcomX(simplified);
+    expect(back.persons?.[0].identifiers).toEqual({
+      "http://gedcomx.org/Persistent": ["https://example.com/p1-ark"],
+    });
+  });
+
+  // Test 36 — Rule 15: missing identifiers → no ark; missing ark → no identifiers; empty
+  // string ark → no identifiers
+  it("omits ark when no Persistent identifier; omits identifiers when no ark", () => {
+    // Missing identifiers entirely.
+    const noIds = toSimplified({ persons: [{ id: "p1" }] });
+    expect("ark" in (noIds.persons?.[0] ?? {})).toBe(false);
+
+    // identifiers present but no Persistent key.
+    const onlyPrimary = toSimplified({
+      persons: [
+        {
+          id: "p1",
+          identifiers: { "http://gedcomx.org/Primary": ["primary-id"] },
+        },
+      ],
+    });
+    expect("ark" in (onlyPrimary.persons?.[0] ?? {})).toBe(false);
+
+    // Persistent array empty.
+    const emptyArr = toSimplified({
+      persons: [
+        { id: "p1", identifiers: { "http://gedcomx.org/Persistent": [] } },
+      ],
+    });
+    expect("ark" in (emptyArr.persons?.[0] ?? {})).toBe(false);
+
+    // Missing ark on simplified → no identifiers on toGedcomX.
+    const backNoArk = toGedcomX({ persons: [{ id: "p1" }] });
+    expect("identifiers" in (backNoArk.persons?.[0] ?? {})).toBe(false);
+
+    // Empty string ark → no identifiers (don't emit a useless entry).
+    const backEmptyArk = toGedcomX({ persons: [{ id: "p1", ark: "" }] });
+    expect("identifiers" in (backEmptyArk.persons?.[0] ?? {})).toBe(false);
+  });
+
+  // Test 37 — Rule 15: multiple Persistent values — first wins (documented loss)
+  it("flattens multiple Persistent values to the first; rest dropped", () => {
+    const input: GedcomX = {
+      persons: [
+        {
+          id: "p1",
+          identifiers: {
+            "http://gedcomx.org/Persistent": [
+              "https://example.com/ark-1",
+              "https://example.com/ark-2",
+              "https://example.com/ark-3",
+            ],
+          },
+        },
+      ],
+    };
+    const simplified = toSimplified(input);
+    expect(simplified.persons?.[0].ark).toBe("https://example.com/ark-1");
+
+    // Round-trip back surfaces only the first value as a single-element array.
+    const back = toGedcomX(simplified);
+    expect(back.persons?.[0].identifiers).toEqual({
+      "http://gedcomx.org/Persistent": ["https://example.com/ark-1"],
+    });
+  });
+
   // Test 26 — Rule 14: IDs pass through verbatim
   it("passes IDs through verbatim and does not generate new ones", () => {
     const result = toSimplified({
@@ -882,6 +999,11 @@ describe("gedcomx-convert — identity round-trips", () => {
         {
           id: "p1",
           gender: { type: "http://gedcomx.org/Male" },
+          identifiers: {
+            "http://gedcomx.org/Persistent": [
+              "https://familysearch.org/ark:/61903/4:1:KGS8-LY1",
+            ],
+          },
           names: [
             {
               id: "n1",
@@ -964,6 +1086,7 @@ describe("gedcomx-convert — identity round-trips", () => {
       persons: [
         {
           id: "p1",
+          ark: "https://familysearch.org/ark:/61903/4:1:KGS8-LY1",
           gender: "Female",
           names: [
             {


### PR DESCRIPTION
GedcomX Person.identifiers carries the canonical FamilySearch ARK URL under the http://gedcomx.org/Persistent key. Without round-trip support, payloads that anchor a persona on its persistent ARK lose that anchor on toSimplified → toGedcomX.

This commit follows the simplified spec's convention of flattening single-dominant-value nested structures (the same rule that produces flat `given`/`surname`, `date`, `place`, `title`): the first Persistent value is lifted to `SimplifiedPerson.ark` on simplification and rebuilt on expand. Other identifier types (Primary, etc.) are dropped, matching how date.formal and qualifiers outside CitationDetail are intentionally dropped.

Adds Rule 15 to gedcomx-convert-spec.md, an `ark` row + §4.6 in simplified-gedcomx-spec.md, and direct converter unit tests covering the round-trip, missing-field, and multiple-Persistent edge cases.