### PR TITLE
Remove references to record_read and record_profiles

### DIFF
--- a/eval/harness/validators/test_record_extraction.py
+++ b/eval/harness/validators/test_record_extraction.py
@@ -208,7 +208,7 @@ def test_new_sources_have_citation_detail(before_state, after_state):
 def test_only_allowed_mcp_tools(skill_frontmatter, tool_calls):
     """Every MCP tool called must be listed in SKILL.md allowed-tools.
 
-    record-extraction legitimately calls record_search, record_read, and
+    record-extraction legitimately calls record_search and
     image_transcribe. This check catches accidental calls to MCP tools
     outside the skill's declared allowlist (e.g., wikipedia_search,
     fulltext_search).

--- a/plugin/skills/question-selection/SKILL.md
+++ b/plugin/skills/question-selection/SKILL.md
@@ -148,11 +148,9 @@ Read:
 - Log entries for this question's plan items (via `plan_item_id`)
 - Assertions produced (via `produced_assertion_ids`)
 - Skipped plan items and their reasons
-- Call `record_profiles` for the jurisdiction and time period
 - Call `place_population` to check indexed record coverage for the place and period
 
 ```
-record_profiles({ country: "United States", timeperiod: "1840-1910" })
 place_population({ place_id: "<id>", year_start: 1840, year_end: 1910 })
 ```
 
@@ -179,7 +177,7 @@ Write a 1-2 sentence assessment for each:
 | Criterion | Key question |
 |-----------|-------------|
 | `goal_alignment` | Convincing answer obtained? |
-| `repository_breadth` | All relevant repositories, jurisdictions, and name variants tried? Compare against `record_profiles`. |
+| `repository_breadth` | All relevant repositories, jurisdictions, and name variants tried? |
 | `original_substitution` | Derivatives replaced with originals where available? |
 | `independent_verification` | At least two independent sources? (Same informant = one unit.) |
 | `evidence_class` | At least one original record with primary information? |
@@ -211,7 +209,7 @@ the conclusion cannot meet the GPS standard.
     "log_entry_ids": ["log_001", "log_002", "log_003"],
     "stop_criteria": {
       "goal_alignment": "Yes — three sources name Thomas Flynn as Patrick's father.",
-      "repository_breadth": "Census, vital records, and probate all searched per record_profiles.",
+      "repository_breadth": "Census, vital records, and probate all searched.",
       "original_substitution": "Original images accessed; derivative index confirmed.",
       "independent_verification": "Three independent sources with different informants.",
       "evidence_class": "1860 census (original, primary) and death certificate (original, direct).",

--- a/plugin/skills/record-extraction/SKILL.md
+++ b/plugin/skills/record-extraction/SKILL.md
@@ -52,8 +52,8 @@ The governing principles:
 
 Record data arrives in one of three ways:
 
-1. **MCP tool response in context** — search-records called `record_read`
-   or `record_search` and Claude holds the structured data in context.
+1. **MCP tool response in context** — search-records called `record_search`
+   and Claude holds the structured data in context.
    This is the most common path.
 
 2. **PDF capture** — the user uploaded a PDF from an external site

--- a/plugin/skills/search-records/SKILL.md
+++ b/plugin/skills/search-records/SKILL.md
@@ -233,17 +233,10 @@ not the records themselves. Before extraction:
    Index entries typically contain only name, date, place, and a
    record identifier. Full records contain additional detail
    (household members, witnesses, document text, etc.).
-2. If it is an index entry, call `record_read` to retrieve the
-   full record before extraction:
-
-```
-record_read({ recordId: "ark:/61903/1:1:MXYZ" })
-```
-
-3. If the full record is unavailable but an image exists, call
+2. If the full record is unavailable but an image exists, call
    `image_search` to find the image and let record-extraction
    handle transcription via `image_transcribe`.
-4. If only the index entry is available (no image, no full record),
+3. If only the index entry is available (no image, no full record),
    flag it in the log notes as "derivative only — original not
    located" so the researcher knows the data has not been verified
    against the original source.


### PR DESCRIPTION
## Summary

 - Removes references to `record_read` and `record_profiles` from the skills that mentioned them. Neither tool exists in the MCP server, so the references were dead pointers.

 ## Changes

 - **`plugin/skills/record-extraction/SKILL.md`** — input bullet now mentions only `record_search` (the tool search-records actually calls).
- **`plugin/skills/search-records/SKILL.md`** — dropped the "call `record_read` to retrieve the full record" step and its code block. Numbered list renumbered from 1/2/3/4 to 1/2/3 (classify result, fall back to image if available, flag as derivative-only otherwise).
- **`plugin/skills/question-selection/SKILL.md`** — dropped the `record_profiles` bullet, its code-block call, the "Compare against `record_profiles`" tail in the 7-Point criteria table, and the "per record_profiles" tail in the example declaration JSON.
- **`eval/harness/validators/test_record_extraction.py`** — docstring no longer lists `record_read` as a legitimate call.