### PR TITLE
Run skill tests: assertion-classification

### DIFF
--- a/eval/runlogs/unit/assertion-classification/v1_2026-05-21_08-17-40.json
+++ b/eval/runlogs/unit/assertion-classification/v1_2026-05-21_08-17-40.json
@@ -1,0 +1,626 @@
+{
+  "schema_version": 2,
+  "skill": "assertion-classification",
+  "version": 1,
+  "released": false,
+  "releasable": true,
+  "invocation": "skill",
+  "timestamp": "2026-05-21_08-17-40",
+  "harness_version": "0.1.0",
+  "model": "claude-sonnet-4-6",
+  "judge_prompt_hash": "05bca05cc954435b55ffd5cb64e41b1ab060a928181252ed2756374990ab7645",
+  "snapshot": {
+    "plugin/skills/assertion-classification/SKILL.md": "---\nname: assertion-classification\nmodel: claude-sonnet-4-6\ndescription: Refines GPS three-layer evidence classifications on assertions in research.json \u2014\n  information quality (Primary/Secondary/Indeterminate) with informant\n  analysis, and evidence type (Direct/Indirect/Negative). GPS Step 3 \u2014\n  Analysis and Correlation. Use when the user says \"classify this evidence\",\n  \"primary or secondary?\", \"what type of evidence is this?\", \"evaluate\n  the informant\", \"analyze these assertions\", after record-extraction\n  produces assertions with best-effort classifications, or when the user\n  questions an existing classification. Do NOT use when the user wants to\n  extract assertions from a record (use record-extraction), wants to\n  resolve conflicting evidence (use conflict-resolution), or wants to\n  write a conclusion (use proof-conclusion).\n---\n\n# Assertion Classification\n\n**Narration:** Read `researcher_profile.narration_guidance` from `research.json` and apply it as your narration style for this invocation. If absent, default to a one-line preamble per action.\n\nRefines the three-layer GPS evidence classifications on existing\nassertions. record-extraction creates assertions with best-effort\nclassifications; this skill applies rigorous taxonomic reasoning to\nupgrade or correct them.\n\nLoad `references/three-layer-model.md` for the full classification\nframework, BCG standards, and special cases.\n\n## Core Principles\n\nThe three layers (source, information, evidence) are INDEPENDENT.\nAn original source can contain secondary information. A derivative\nsource can provide direct evidence. Classify each layer on its own\nterms. Never let one layer's classification influence another.\n\n**This skill classifies Layer 2 (information quality) and Layer 3\n(evidence type).** Layer 1 (source classification) is set by\nrecord-extraction and is read-only here.\n\n## Steps\n\n### 1. Read the assertions\n\nRead `research.json` and identify assertions needing classification\nrefinement. Focus on:\n- Assertions with `undetermined` information quality that might be\n  upgradable with informant analysis\n- Assertions where record-extraction's best-effort classification\n  may be wrong\n- Assertions the user specifically asks about\n\n### 2. Analyze the informant for each assertion\n\nFor each assertion, answer three questions:\n\n**A. Who is the informant?** Not who created the record -- who\nprovided THIS specific fact. Indexers and transcribers are never\nthe informant; look through derivatives to the original provider.\n\n**B. What is their proximity to the event?**\n\n- `self` -- The informant IS the subject (testator naming heirs)\n- `witness` -- Directly witnessed the event (physician at death)\n- `household_member` -- Household member reporting family facts\n- `family_not_present` -- Family member reporting events they did\n  not witness (son-in-law reporting birth date on death cert)\n- `official_duty` -- Official whose job produced the record but is\n  not the informant for the specific fact\n- `unknown` -- Cannot determine who provided this information\n\n**C. Is there potential bias?** Document in `informant_bias_notes`:\n- Motive to misreport (age fraud, hiding ethnicity, pension claims)\n- Decades between event and reporting (memory degradation)\n- Secondhand reporting (told by someone else)\n- Cultural/social pressure on reporting\n- Stress or duress at time of reporting\n\n### 3. Classify information quality\n\nApply the two-question decision tree:\n\n1. **Do we know the informant?**\n   - NO --> **Undetermined**\n   - YES --> proceed to question 2\n\n2. **Did the informant witness/participate/have first-hand knowledge?**\n   - YES --> **Primary**\n   - NO --> **Secondary**\n   - CANNOT TELL --> **Undetermined**\n\nKey rules:\n- **Primary does NOT mean accurate.** An eyewitness can lie or err.\n  Classification is about proximity, not reliability.\n- **A person cannot provide primary information about their own\n  birth** (not cognitively aware). Their mother or the physician can.\n- **A single source can contain BOTH primary and secondary\n  information.** Classify each assertion independently.\n- **Delayed birth certificates** filed decades later are secondary\n  even though the source is original -- the information is recollection.\n- **Pre-1940 census**: respondent unknown, so most facts are\n  undetermined. Exception: parents' birthplaces are always secondary\n  (no household member witnessed grandparents' births).\n\n### 4. Classify evidence type\n\nFor each assertion, evaluate against the ACTIVE research questions\nin `research.json`.\n\n**If there are NO open research questions**, evidence type cannot be\nclassified. Suggest the user create questions (question-selection)\nbefore proceeding with this step.\n\nDecision rules:\n- **Direct**: explicitly answers a question with no inference needed.\n- **Indirect**: implies an answer but requires inference or\n  correlation with other facts.\n- **Negative**: meaningful absence of EXPECTED information. The record\n  must be one where the fact SHOULD appear if true, and the absence\n  must be meaningful given context.\n- **No evidence**: the information is irrelevant to any open question.\n\n**Critical distinctions:**\n- Absence of information NOT expected in a record type = \"no evidence\"\n  (e.g., parents' names missing from a marriage record)\n- A nil search result is NOT negative evidence unless search was\n  reasonably exhaustive\n- Evidence type can change when new questions are added -- update\n  `extracted_for_question_ids` accordingly\n\n### 5. Flag evidence independence concerns (GPS Standard 46)\n\nWhen two or more assertions share the SAME informant (even across\ndifferent sources), note this in the output. Related information items\nfrom the same informant form a unit that gets no more credibility than\nthe strongest single item. Examples:\n- Same son-in-law reported birth facts on both the death certificate\n  and a pension affidavit -- these are ONE evidence unit for birth facts\n- An Ancestry index and the census image it was indexed from are ONE\n  source, not two\n\n### 6. Update assertions\n\nWrite the refined classifications back to `research.json`. For each\nassertion updated, change:\n- `information_quality` -- if the refined value differs from\n  record-extraction's best-effort\n- `informant` -- if the analysis identifies a more specific informant\n- `informant_proximity` -- if the analysis changes the proximity\n- `informant_bias_notes` -- add bias analysis if relevant\n- `evidence_type` -- if the refined classification differs\n- `extracted_for_question_ids` -- add any newly relevant question IDs\n\nDo NOT change: `id`, `source_id`, `record_id`, `record_role`,\n`fact_type`, `value`, `structured_value`, `date`, `date_certainty`,\n`place`, `log_entry_id`. These are set by record-extraction and are\nimmutable.\n\n### 7. Validate\n\nInvoke `validate-schema` after writing updates.\n\n### 8. Present results\n\nShow the user:\n- Each assertion with its refined classification\n- The reasoning for each classification (informant analysis,\n  proximity, bias)\n- Any assertions where the classification changed from\n  record-extraction's initial value and why\n- Any evidence independence concerns flagged in step 5\n- Suggest next steps: citation (if citations need refining) or\n  person-evidence (if assertions need linking to persons)\n\n## Example: Death certificate (same source, different classifications)\n\n**a_011** -- Death date: \"Died 12 March 1908\"\n- Informant: Attending physician. Proximity: `witness`.\n- Known? YES. First-hand? YES. --> **primary**\n- Evidence type: `direct`\n\n**a_012** -- Birth facts: \"Born 1845, Pennsylvania\"\n- Informant: James Brown (son-in-law). Proximity: `family_not_present`.\n- Known? YES. First-hand? NO. --> **secondary**\n- Bias: \"Son-in-law reporting 63 years after event. Census records\n  say Ireland -- informant may not have known true birthplace.\"\n- Evidence type: `direct` (explicitly states birthplace, even though\n  it conflicts with other sources -- direct does not mean correct)\n\n**a_013** -- Parentage: \"Father: Thomas Flynn\"\n- Same informant (son-in-law). --> **secondary**\n- Evidence type: `direct`\n\n**Takeaway:** Same original source, three assertions, two different\ninformation classifications. Classify per-assertion, never per-source.\n\n## Example: Pre-1940 Census (undetermined vs. forced secondary)\n\n**a_022** -- Age: \"35\"\n- Informant: Unknown (pre-1940). --> **undetermined**\n\n**a_023** -- Father's birthplace: \"Ireland\"\n- Informant: Unknown. BUT: no one in the household could have\n  witnessed the father's birth. Even if we knew the respondent, it\n  would be secondary. --> **secondary**\n\n**Takeaway:** When NO possible respondent could have first-hand\nknowledge, classify as secondary regardless of informant identity.\n",
+    "plugin/skills/assertion-classification/references/three-layer-model.md": "# The Three-Layer Classification Model\n\n## Core Principle: Independence of Layers\n\nThe three layers -- source, information, and evidence -- are evaluated\nindependently. The classification at one layer does NOT determine the\nclassification at another. An original source can contain secondary\ninformation. A derivative source can provide direct evidence. Each\nlayer operates on its own terms.\n\n---\n\n## Layer 1: Source Classification\n\nSource classification addresses the FORM of the record -- how close is\nthis document to the first recording?\n\n### Original\n\nThe first recording of information, or the earliest surviving version.\n\nIncludes:\n- Handwritten documents created at or near the time of the event\n- Faithful reproductions: facsimiles, photocopies, microfilm, digital\n  images (if true, unaltered copies)\n- Government \"record copies\" made by the recording office as part of\n  its official function (e.g., deed recorded in county deed book)\n- Certified transcripts issued by the custodial agency\n\n### Derivative\n\nAny record derived from another source through copying, transcribing,\nabstracting, indexing, or translating. Always at least one step removed\nfrom the original.\n\nTypes: indexes, abstracts, transcripts, translations, extracts,\ndatabase entries.\n\n### Authored Narrative\n\nA work that synthesizes findings from many sources, incorporating the\nauthor's analysis, conclusions, and narrative structure. Examples:\ncompiled genealogies, biographies, proof summaries, county histories.\n\n### Special Cases for Source Classification\n\n- A derivative of a derivative does NOT make the first derivative an\n  original. If A is original, B is a transcript of A, and C is a\n  transcript of B, both B and C remain derivatives.\n- A county register arranged in alphabetical order may be derivative --\n  alphabetical arrangement suggests entries were recopied from loose\n  original certificates.\n- Census sheets found in alphabetical order may have been recopied from\n  the enumerator's original returns.\n- Court copies of wills: derivative if the original still exists; if\n  the original was lost/destroyed, the court copy becomes the earliest\n  existing version (treated as original).\n- A digital image of an original is treated as original if it is a\n  true, unaltered copy.\n\n### Why Classify Sources?\n\nThe practical reason: ensure original records are used whenever\npossible. Derivatives introduce opportunities for transcription errors,\nomissions, and misinterpretation.\n\n---\n\n## Layer 2: Information Classification\n\nInformation classification is about the INFORMANT -- the person who\nprovided the information. This is completely independent of source\nclassification.\n\n### The Informant-Centric Approach\n\nThe key question is always: who provided THIS specific piece of\ninformation, and what was their relationship to the event?\n\nCritical rules:\n- Indexers and transcribers are NOT informants. When classifying\n  information in a derivative, look back to who the informant was for\n  the original record.\n- A single source often has multiple informants, each contributing\n  different facts with varying knowledge levels.\n- Each fact must be classified separately based on the specific\n  informant's knowledge of that specific event.\n\n### The Two-Question Decision Tree\n\n1. Do we know the informant?\n   - NO --> Undetermined\n   - YES --> proceed to question 2\n\n2. Did the informant witness, participate in, or have first-hand\n   knowledge of the event?\n   - YES --> Primary\n   - NO --> Secondary\n   - CANNOT TELL --> Undetermined\n\n### Primary Information\n\nProvided by an eyewitness or participant -- someone with first-hand\nknowledge. The test: \"Was the informant there and aware?\"\n\nCritical nuance: Primary information CAN STILL BE WRONG. An eyewitness\ncan misremember, lie, or be mistaken. Being wrong does not change the\nclassification -- it remains primary because the informant had\nfirst-hand knowledge. Classification describes the informant's\nrelationship to the event, not the accuracy of their report.\n\n### Secondary Information\n\nProvided by someone who did NOT have first-hand knowledge. They were\nnot an eyewitness or participant.\n\nCritical nuance: The informant may be highly reliable, may have known\nthe fact their entire life, but if they did not personally witness the\nevent, their information is secondary. Example: you \"know\" your birth\ndate -- you have been told it your whole life. But you cannot provide\nprimary information about your own birth because you were not\ncognitively aware during the event. Only a conscious adult present at\nyour birth (mother, physician, midwife) can provide primary information.\n\n### Undetermined Information\n\nCannot determine whether the informant had first-hand knowledge. This\nis the only classification that can change with discovery of new\nevidence (e.g., identifying who the informant was).\n\n### Multiple Informants Per Source\n\nA death certificate typically has three distinct informants:\n\n1. Personal information provider (usually a family member) -- provides\n   decedent's name, birth date, birthplace, parents' names, occupation\n2. Attending physician -- provides cause of death, date of death,\n   duration of illness\n3. Undertaker/funeral director -- provides burial date, burial\n   location\n\nEach informant's contribution must be classified separately.\n\n### Pre-1940 US Census Special Case\n\nBefore 1940, the census enumerator did not record who in the household\nanswered questions. In most cases, information is therefore undetermined.\n\nHowever, some facts can still be classified regardless of who answered:\n- Parents' birthplaces reported by anyone in a household of father,\n  mother, and small children = secondary information no matter who\n  spoke. No one in that household could have had first-hand knowledge\n  of where the grandparents were born.\n\nThe 1940 census introduced identification of the respondent, enabling\nclassification of each data point.\n\n### Informant Lookup by Record Type\n\n| Record type | Fact | Likely informant | Proximity |\n|------------|------|-----------------|-----------|\n| Census (any year) | Name | Unknown household member | `unknown` |\n| Census (any year) | Age/birthplace | Household member (head or spouse) | `household_member` |\n| Census (any year) | Residence | Census enumerator | `witness` |\n| Census (1850) | Relationship | No informant -- inferred from position | `unknown` |\n| Census (1860+) | Relationship | Household respondent | `household_member` |\n| Death certificate | Death date/cause | Attending physician | `witness` |\n| Death certificate | Birth date/place, parents | Named family informant | `family_not_present` |\n| Vital record (birth) | Birth facts | Physician or midwife | `witness` |\n| Vital record (birth) | Parent names | Parent (usually mother) | `self` |\n| Probate/will | Bequests, heirs named | Testator | `self` |\n| Land deed | Property facts | Parties to the deed | `self` |\n| Church register | Baptism/marriage | Clergyman | `witness` |\n| Obituary | Death/biographical facts | Reporter (from family/funeral home) | `family_not_present` or `unknown` |\n| Military pension | Service facts | Veteran | `self` |\n| Military pension | Family details | Veteran or widow | `self` or `family_not_present` |\n\n---\n\n## Layer 3: Evidence Classification\n\nEvidence classification addresses HOW information answers a specific\nresearch question. Evidence is conceptual -- it is the relationship\nbetween information and the question being asked.\n\nThis layer is independent of source and information classification.\n\n### Direct Evidence\n\nExplicitly answers the research question. The information states the\nanswer outright; no inference is needed.\n\nCritical: direct evidence CAN STILL BE WRONG. A birth certificate\nmight state the wrong father. \"Direct\" means only that the information\nexplicitly addresses the question -- it says nothing about accuracy.\n\n### Indirect Evidence\n\nDoes NOT explicitly answer the question but allows a reasonable\ninference. The researcher must combine the information with other\nknowledge to derive an answer.\n\nExample: A burial record states \"buried 3 March 1890\" -- direct\nevidence of burial date, but indirect evidence of death date (we infer\ndeath occurred one to three days before burial).\n\n### Negative Evidence\n\nArises when EXPECTED information is meaningfully absent.\n\nRequirements for negative evidence:\n- The record must be one where the information SHOULD appear if the\n  fact were true\n- The absence must be meaningful given the context\n\nContext matters: The absence of a christening record in 1800s England\n(where parish christening was nearly universal) is significant. The\nsame absence in the US (where christening was not universal) is far\nless meaningful.\n\n### No Evidence\n\nSometimes information simply does not answer the research question at\nall. It is irrelevant to the question being asked.\n\nCritical distinction -- nil search vs. negative evidence:\n- A failure to find a record is NOT negative evidence unless you have\n  searched ALL pertinent collections and can demonstrate the record\n  should exist if the event occurred.\n- Only after reasonably exhaustive searching does absence become\n  meaningful negative evidence.\n- The absence of information that would not normally be present in a\n  record type is simply \"no evidence,\" not negative evidence. Example:\n  a marriage record without parents' names is not negative evidence\n  about parentage -- parents' names are not expected on most marriage\n  records.\n\n### Evidence Exists Only in Relation to Questions\n\nThe same piece of information can be:\n- Direct evidence for one research question\n- Indirect evidence for a different question\n- No evidence for a third question\n\nIf there is no research question, there is no evidence.\n\n---\n\n## BCG Standards 35-46: Key Principles\n\n### Source Analysis (Standard 35)\n\nWhen examining sources, appraise each source's likely accuracy,\nintegrity, and completeness. Consider: physical condition, legibility,\nwhether original or derivative, internal consistency, external\nconsistency, provenance, purpose, and time lapse between events and\nrecording.\n\n### Information Analysis (Standard 36)\n\nFor each information item, appraise accuracy, integrity, completeness.\nConsider: legibility, who provided the information, that person's\nreliability and consistency, whether primary or secondary, internal\nconsistency, and external consistency with other information in the\nsame source.\n\n### Evidence Mining (Standard 40)\n\nSeek evidence that answers questions directly, indirectly, or\nnegatively. Ignore no potentially useful evidence -- including indirect\nand negative evidence or evidence conflicting with a working\nhypothesis. Give equal attention to all evidence types.\n\n### Evidence Integrity (Standard 43)\n\nNever trim, tailor, slight, or ignore potentially relevant evidence to\nfit a bias, to harmonize with other evidence, or for any other reason.\n\n### Evidence Reliability (Standard 44)\n\nAny evidence item may be proved reliable or not. Unreliable evidence\nmay still be useful: to follow as a clue, explain an error, or resolve\nconflicting evidence.\n\n### Evidence Independence (Standard 46)\n\nWeigh evidence from independent information items. When items are\nrelated (e.g., birthdate from obituary and death certificate sharing\nthe same informant), group them into a unit and assign that unit no\nmore credibility than the strongest item in the group.\n\n### Evidence Correlation (Standard 47)\n\nTest evidence by comparing and contrasting items. Use correlation to\ndiscover parallels, patterns, and inconsistencies.\n",
+    "plugin/skills/assertion-classification/references/validation-protocol.md": "# Validation Protocol\n\nAfter writing to `research.json` or `tree.gedcomx.json`, follow these steps:\n\n1. **Invoke `validate-schema`** to verify both files conform to the\n   published schemas. If validation fails, fix the errors before\n   proceeding.\n\n2. **Invoke `check-warnings`** if you added assertions or\n   person_evidence entries. This checks for genealogical\n   impossibilities (married before 12, died after 120, child born\n   after parent's death, etc.).\n\nThese are not auto-triggered \u2014 you must invoke them explicitly.\n",
+    "eval/tests/unit/assertion-classification/death-cert-secondary-informant.json": "{\n  \"input\": {\n    \"scenario\": \"mid-research-flynn\",\n    \"user_message\": \"Review the classification on a_012 \u2014 the death certificate birth fact for Patrick Flynn.\"\n  },\n  \"judge_context\": [\n    \"Should explain why source_classification stays 'original' even though information_quality is secondary \u2014 the three layers are independent (the 1908 death certificate is itself an original source; the informant being distant from the event affects information quality, not source classification)\",\n    \"Should explain why the son-in-law is a secondary informant for Patrick's birth (James Brown was not present at his father-in-law's birth six decades earlier) \u2014 citing the relationship and the temporal gap\",\n    \"Should populate `informant_bias_notes` flagging that Brown may have confused Patrick's place of residence with his place of birth (the death cert says Pennsylvania, but the census records say Ireland \u2014 the conflict resolution in c_001 favored Ireland)\"\n  ],\n  \"test\": {\n    \"id\": \"ut_assertion_classification_002\",\n    \"skill\": \"assertion-classification\",\n    \"type\": \"positive\"\n  }\n}\n",
+    "eval/tests/unit/assertion-classification/negative-extraction.json": "{\n  \"input\": {\n    \"scenario\": \"mid-research-flynn\",\n    \"user_message\": \"I have a new census record. Extract the assertions and classify them properly.\"\n  },\n  \"judge_context\": [\n    \"Should route to record-extraction rather than treating the request as a classification-refinement task\"\n  ],\n  \"negative\": {\n    \"correct_skill\": [\n      \"record-extraction\"\n    ],\n    \"explanation\": \"The user wants assertions extracted from a new record. record-extraction's job is to produce new assertion entries from records; it does the initial classification at extraction time. assertion-classification only operates on existing assertions to refine their classification layers \u2014 it doesn't create new assertions from raw record data.\"\n  },\n  \"test\": {\n    \"id\": \"ut_assertion_classification_003\",\n    \"skill\": \"assertion-classification\",\n    \"type\": \"negative\"\n  }\n}\n",
+    "eval/tests/unit/assertion-classification/reclassify-census-informant.json": "{\n  \"input\": {\n    \"scenario\": \"mid-research-flynn\",\n    \"user_message\": \"Review the evidence classification for assertion a_001.\"\n  },\n  \"judge_context\": [\n    \"Should distinguish the census enumerator (recorder) from the informant \u2014 name facts in 1850 censuses don't have an identified informant; the enumerator may have read a sign, asked a neighbor, or asked a household member, and the census doesn't say which\",\n    \"Should keep `informant_proximity: \\\"unknown\\\"` for name facts in the 1850 census (this is the correct conservative classification), OR if the skill argues for `household_member`, the rationale must explain why a name fact specifically requires active reporting (which it doesn't \u2014 names can be inferred from a doorplate or neighbor)\",\n    \"Should keep `evidence_type: \\\"direct\\\"` for a_001 \u2014 the assertion was extracted for q_002 ('Where was Patrick Flynn in the 1850 census?'), and finding Patrick Flynn in the census record IS the direct answer to that question. The name assertion identifies the subject within the record, which directly answers q_002. Changing evidence_type to 'indirect' would be incorrect here.\"\n  ],\n  \"test\": {\n    \"id\": \"ut_assertion_classification_001\",\n    \"skill\": \"assertion-classification\",\n    \"type\": \"positive\"\n  }\n}\n",
+    "eval/tests/unit/assertion-classification/rubric.md": "# Assertion Classification Rubric\n\nGrading dimensions for assertion-classification unit tests. Evaluated by the LLM judge alongside the base rubric (correctness, completeness).\n\n## Three-layer accuracy\n\nDid the skill correctly apply all three GPS classification layers: source classification (original/derivative/authored), information quality (primary/secondary/indeterminate), and evidence type (direct/indirect/negative)?\n\n- **pass:** All three layers are populated and values match the source/informant facts as a knowledgeable genealogist would classify them.\n- **partial:** All three layers populated but at least one is debatable \u2014 an indeterminate informant marked primary, or an indirect inference labeled direct \u2014 though defensible.\n- **fail:** A layer is missing, or values are clearly wrong (derivative index marked original; son-in-law's report of birth labeled primary).\n\n## Informant analysis\n\nDid the skill identify the actual informant and assess their proximity to the event? The recorder (e.g., census enumerator) is not the informant \u2014 the person who provided the information is.\n\n- **pass:** Informant is named or characterized specifically, distinguished from the recorder, and `informant_proximity` matches the GPS proximity scale (self / witness / household_member / family_not_present / official_duty / unknown).\n- **partial:** Informant is identified but proximity is mis-coded by one tier (household_member when family_not_present is more accurate), or recorder vs informant distinction is partially blurred.\n- **fail:** Recorder is named as the informant (census enumerator as informant for birth facts), or proximity is left blank/unknown when evidence supports a specific value.\n\n## Classification justification\n\nDid the skill explain why each classification was chosen, citing specific characteristics of the source and informant? Classifications without reasoning are not useful.\n\n- **pass:** Each classification has a rationale referencing specific facts (when the record was created, who provided the information, whether it's original or a copy).\n- **partial:** Rationale exists but is generic (\"primary because the informant was close\") rather than citing specific source/informant attributes.\n- **fail:** No rationale, or rationale contradicts the chosen classification.\n",
+    "eval/fixtures/scenarios/mid-research-flynn/README.md": "# mid-research-flynn\n\nPatrick Flynn parentage research, mid-project.\n\n- **Objective:** Identify the parents of Patrick Flynn (b. ~1845, d. 1908)\n- **Questions:** q_001 (parentage, in_progress), q_002 (1850 census placement, resolved)\n- **Plans:** pl_001 (1850 census search, completed), pl_002 (parentage evidence, active)\n- **Log:** 5 entries \u2014 1850 census on FamilySearch/Ancestry/MyHeritage, 1860 census, death cert\n- **Sources:** 4 sources (1850 census FS, 1850 census Ancestry, 1860 census, death cert)\n- **Assertions:** 13 assertions across 4 sources\n- **Person evidence:** 6 links (Patrick \u2192 I1, Thomas \u2192 I2)\n- **Conflicts:** 1 resolved (birthplace: Ireland vs Pennsylvania)\n- **Hypotheses:** h_001 (Thomas is Patrick's father, supported)\n- **Timelines:** t_001 (Patrick, 4 events, 1 gap)\n- **Proof summaries:** ps_001 (parentage, probable)\n- **GedcomX persons:** I1 (Patrick Flynn), I2 (Thomas Flynn)\n- **GedcomX relationships:** R1 (ParentChild, Thomas \u2192 Patrick)\n",
+    "eval/fixtures/scenarios/mid-research-flynn/research.json": "{\n  \"assertions\": [\n    {\n      \"date\": null,\n      \"date_certainty\": null,\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_002\"\n      ],\n      \"fact_type\": \"name\",\n      \"id\": \"a_001\",\n      \"informant\": \"Unknown household member reporting to census enumerator\",\n      \"informant_bias_notes\": \"Census enumerator is the recorder, not the informant. The household member who provided the name is unknown. Proximity is 'unknown' rather than 'household_member' because for names specifically, the enumerator may have read a sign, heard a neighbor, or made an assumption \u2014 the name fact doesn't necessarily require active reporting the way age/birthplace does.\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_001\",\n      \"place\": null,\n      \"record_id\": \"ark:/61903/1:1:MXYZ\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_001\",\n      \"structured_value\": {\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"value\": \"Patrick Flynn\"\n    },\n    {\n      \"date\": \"~1845\",\n      \"date_certainty\": \"estimated\",\n      \"evidence_type\": \"indirect\",\n      \"extracted_for_question_ids\": [\n        \"q_002\"\n      ],\n      \"fact_type\": \"birth\",\n      \"id\": \"a_002\",\n      \"informant\": \"Unknown household member (likely Thomas Flynn or wife)\",\n      \"informant_bias_notes\": \"Age and birthplace require active reporting by a household member \u2014 someone had to tell the enumerator these facts. Proximity is 'household_member' rather than 'unknown' because these facts could only come from someone in the household.\",\n      \"informant_proximity\": \"household_member\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_001\",\n      \"place\": \"Ireland\",\n      \"record_id\": \"ark:/61903/1:1:MXYZ\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_001\",\n      \"structured_value\": {\n        \"place\": \"Ireland\",\n        \"year\": 1845\n      },\n      \"value\": \"age 5\"\n    },\n    {\n      \"date\": \"1850\",\n      \"date_certainty\": \"exact\",\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_002\"\n      ],\n      \"fact_type\": \"residence\",\n      \"id\": \"a_003\",\n      \"informant\": \"Census enumerator (witness to residence by visiting the dwelling)\",\n      \"informant_bias_notes\": \"For residence facts specifically, the enumerator is a direct witness \u2014 they physically visited the dwelling and recorded who lived there. This distinguishes residence from other census facts where the household member is the true informant.\",\n      \"informant_proximity\": \"witness\",\n      \"information_quality\": \"primary\",\n      \"log_entry_id\": \"log_001\",\n      \"place\": \"Schuylkill County, Pennsylvania\",\n      \"record_id\": \"ark:/61903/1:1:MXYZ\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_001\",\n      \"value\": \"Schuylkill County, Pennsylvania\"\n    },\n    {\n      \"date\": \"1850\",\n      \"date_certainty\": \"exact\",\n      \"evidence_type\": \"indirect\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"relationship\",\n      \"id\": \"a_004\",\n      \"informant\": \"Inferred from household structure \u2014 no explicit informant for relationships in 1850 census\",\n      \"informant_bias_notes\": \"1850 census does not state relationships; this assertion is inferred from household position and shared surname, not directly reported by any informant. The relationship is indirect evidence constructed by the researcher, not information provided by a census informant.\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_001\",\n      \"place\": \"Schuylkill County, Pennsylvania\",\n      \"record_id\": \"ark:/61903/1:1:MXYZ\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_001\",\n      \"structured_value\": {\n        \"related_person_role\": \"head_of_household\",\n        \"relationship_type\": \"child_inferred\"\n      },\n      \"value\": \"Listed in household of Thomas Flynn (head), position consistent with child\"\n    },\n    {\n      \"date\": null,\n      \"date_certainty\": null,\n      \"evidence_type\": \"indirect\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"name\",\n      \"id\": \"a_005\",\n      \"informant\": \"Unknown household member (likely Thomas Flynn himself) reporting to census enumerator\",\n      \"informant_bias_notes\": \"Census enumerator is the recorder, not the informant. As head of household, Thomas likely provided his own name, but the 1850 census does not identify the informant.\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_001\",\n      \"place\": null,\n      \"record_id\": \"ark:/61903/1:1:MXYZ\",\n      \"record_role\": \"head_of_household\",\n      \"source_id\": \"src_001\",\n      \"value\": \"Thomas Flynn\"\n    },\n    {\n      \"date\": null,\n      \"date_certainty\": null,\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_002\"\n      ],\n      \"fact_type\": \"name\",\n      \"id\": \"a_006\",\n      \"informant\": \"Ancestry transcriber (derivative of census enumerator)\",\n      \"informant_bias_notes\": \"Derivative index \u2014 transcription errors possible\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_002\",\n      \"place\": null,\n      \"record_id\": \"ancestry:8054:patrick-flynn-1850\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_002\",\n      \"value\": \"Patrick Flynn\"\n    },\n    {\n      \"date\": \"~1845\",\n      \"date_certainty\": \"estimated\",\n      \"evidence_type\": \"indirect\",\n      \"extracted_for_question_ids\": [\n        \"q_002\"\n      ],\n      \"fact_type\": \"birth\",\n      \"id\": \"a_007\",\n      \"informant\": \"Ancestry transcriber (derivative)\",\n      \"informant_bias_notes\": null,\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_002\",\n      \"place\": \"Ireland\",\n      \"record_id\": \"ancestry:8054:patrick-flynn-1850\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_002\",\n      \"value\": \"age 5\"\n    },\n    {\n      \"date\": null,\n      \"date_certainty\": null,\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"name\",\n      \"id\": \"a_008\",\n      \"informant\": \"Unknown household member reporting to census enumerator\",\n      \"informant_bias_notes\": \"Census enumerator is the recorder, not the informant. Proximity is 'unknown' for names (same reasoning as a_001 \u2014 name facts don't necessarily require active reporting).\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_004\",\n      \"place\": null,\n      \"record_id\": \"ark:/61903/1:1:MABC\",\n      \"record_role\": \"child_2\",\n      \"source_id\": \"src_003\",\n      \"value\": \"Patrick Flynn\"\n    },\n    {\n      \"date\": \"~1845\",\n      \"date_certainty\": \"estimated\",\n      \"evidence_type\": \"indirect\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"birth\",\n      \"id\": \"a_009\",\n      \"informant\": \"Unknown household member (likely Thomas Flynn or wife)\",\n      \"informant_bias_notes\": \"Age and birthplace require active reporting by a household member (same reasoning as a_002).\",\n      \"informant_proximity\": \"household_member\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_004\",\n      \"place\": \"Ireland\",\n      \"record_id\": \"ark:/61903/1:1:MABC\",\n      \"record_role\": \"child_2\",\n      \"source_id\": \"src_003\",\n      \"value\": \"age 15\"\n    },\n    {\n      \"date\": \"1860\",\n      \"date_certainty\": \"exact\",\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"relationship\",\n      \"id\": \"a_010\",\n      \"informant\": \"Household member (likely Thomas Flynn or wife) reporting to census enumerator\",\n      \"informant_bias_notes\": \"1860 census states relationships explicitly, unlike 1850. The informant is the household member who answered the enumerator's questions, not the enumerator himself \u2014 the enumerator is the recorder, not the informant. The household member (likely Thomas or wife) is a direct witness to the relationship, so primary information is defensible.\",\n      \"informant_proximity\": \"household_member\",\n      \"information_quality\": \"primary\",\n      \"log_entry_id\": \"log_004\",\n      \"place\": \"Schuylkill County, Pennsylvania\",\n      \"record_id\": \"ark:/61903/1:1:MABC\",\n      \"record_role\": \"child_2\",\n      \"source_id\": \"src_003\",\n      \"structured_value\": {\n        \"related_person_role\": \"head_of_household\",\n        \"relationship_type\": \"son\"\n      },\n      \"value\": \"Listed as 'son' in household of Thomas Flynn (head)\"\n    },\n    {\n      \"date\": \"1908-03-12\",\n      \"date_certainty\": \"exact\",\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [],\n      \"fact_type\": \"death\",\n      \"id\": \"a_011\",\n      \"informant\": \"Attending physician (signature on certificate)\",\n      \"informant_bias_notes\": null,\n      \"informant_proximity\": \"witness\",\n      \"information_quality\": \"primary\",\n      \"log_entry_id\": \"log_005\",\n      \"place\": \"Schuylkill County, Pennsylvania\",\n      \"record_id\": \"ark:/61903/1:1:MDEF\",\n      \"record_role\": \"deceased\",\n      \"source_id\": \"src_004\",\n      \"value\": \"Died 12 March 1908\"\n    },\n    {\n      \"date\": \"1845\",\n      \"date_certainty\": \"approximate\",\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"birth\",\n      \"id\": \"a_012\",\n      \"informant\": \"James Brown (son-in-law)\",\n      \"informant_bias_notes\": \"Son-in-law reporting birth facts decades after the event. Note: death cert says Pennsylvania, but census records say Ireland. Son-in-law may not have known Patrick was born in Ireland.\",\n      \"informant_proximity\": \"family_not_present\",\n      \"information_quality\": \"secondary\",\n      \"log_entry_id\": \"log_005\",\n      \"place\": \"Pennsylvania\",\n      \"record_id\": \"ark:/61903/1:1:MDEF\",\n      \"record_role\": \"deceased\",\n      \"source_id\": \"src_004\",\n      \"structured_value\": {\n        \"place\": \"Pennsylvania\",\n        \"year\": 1845\n      },\n      \"value\": \"Born 1845, Pennsylvania\"\n    },\n    {\n      \"date\": null,\n      \"date_certainty\": null,\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"relationship\",\n      \"id\": \"a_013\",\n      \"informant\": \"James Brown (son-in-law)\",\n      \"informant_bias_notes\": \"Secondary information \u2014 son-in-law reporting what he was told about father-in-law's parentage\",\n      \"informant_proximity\": \"family_not_present\",\n      \"information_quality\": \"secondary\",\n      \"log_entry_id\": \"log_005\",\n      \"place\": null,\n      \"record_id\": \"ark:/61903/1:1:MDEF\",\n      \"record_role\": \"deceased\",\n      \"source_id\": \"src_004\",\n      \"structured_value\": {\n        \"related_person_role\": \"deceased\",\n        \"relationship_type\": \"father\"\n      },\n      \"value\": \"Father: Thomas Flynn\"\n    }\n  ],\n  \"conflicts\": [\n    {\n      \"blocks_question_ids\": [],\n      \"competing_assertion_ids\": [\n        \"a_002\",\n        \"a_009\",\n        \"a_012\"\n      ],\n      \"conflict_type\": \"fact\",\n      \"description\": \"Patrick Flynn's birthplace: Ireland (1850 and 1860 censuses) vs. Pennsylvania (1908 death certificate)\",\n      \"disputed_attribute\": \"birthplace\",\n      \"id\": \"c_001\",\n      \"identity_question\": null,\n      \"independence_analysis\": \"The two census records (1850, 1860) are independent original sources with different enumerators. The death certificate is a third independent original source. However, the census informants are likely the same household member (Thomas Flynn or wife), so the two census assertions may share a single informant \u2014 potentially not fully independent for this fact.\",\n      \"preferred_assertion_id\": \"a_002\",\n      \"resolution_rationale\": \"Ireland is accepted as the birthplace. The 1908 death certificate birthplace of 'Pennsylvania' is rejected as a likely error by the son-in-law informant, who may have confused Patrick's place of residence with his place of birth, or may not have known Patrick was born in Ireland before immigrating as a young child.\",\n      \"status\": \"resolved\",\n      \"weighing_analysis\": \"The census records are contemporary recordings made near the time of Patrick's birth, while the death certificate was created 63 years later. The census informant was likely a household member with firsthand knowledge (primary or indeterminate), while the death certificate informant (son-in-law) is clearly secondary for birth facts. Two contemporary sources outweigh one later recollection by a secondary informant.\"\n    }\n  ],\n  \"hypotheses\": [\n    {\n      \"claim\": \"Patrick Flynn's father was Thomas Flynn of Schuylkill County, Pennsylvania\",\n      \"contradicting_assertion_ids\": [],\n      \"id\": \"h_001\",\n      \"notes\": \"Three independent pieces of evidence: 1850 census co-enumeration (indirect), 1860 census explicit 'son' relationship (direct), death certificate naming Thomas as father (direct, secondary informant). Awaiting probate records for additional confirmation.\",\n      \"related_question_ids\": [\n        \"q_001\"\n      ],\n      \"ruled_out\": false,\n      \"ruled_out_reason\": null,\n      \"status\": \"supported\",\n      \"supporting_assertion_ids\": [\n        \"a_004\",\n        \"a_010\",\n        \"a_013\"\n      ]\n    }\n  ],\n  \"log\": [\n    {\n      \"external_site\": null,\n      \"id\": \"log_001\",\n      \"notes\": \"Found Patrick Flynn age 5 in household of Thomas Flynn, dwelling 84, Schuylkill Co. Three other Flynn results examined \u2014 ages and locations don't match.\",\n      \"outcome\": \"positive\",\n      \"performed\": \"2026-05-01T10:15:00Z\",\n      \"plan_item_id\": \"pli_001\",\n      \"query\": {\n        \"birth_place\": \"Pennsylvania\",\n        \"birth_year\": 1845,\n        \"collection\": \"1850 Census\",\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"results_examined\": 8,\n      \"tool\": \"record_search\"\n    },\n    {\n      \"external_site\": {\n        \"capture_filename\": \"ancestry-1850-flynn-results.pdf\",\n        \"capture_received\": true,\n        \"site\": \"ancestry\",\n        \"url_generated\": \"https://www.ancestry.com/search/collections/8054/?name=Patrick_Flynn&birth=1845&birthplace=Pennsylvania\"\n      },\n      \"id\": \"log_002\",\n      \"notes\": \"Ancestry index confirms same household. Transcription matches FamilySearch except Ancestry reads dwelling as 84, FamilySearch as 84 \u2014 consistent.\",\n      \"outcome\": \"positive\",\n      \"performed\": \"2026-05-01T11:30:00Z\",\n      \"plan_item_id\": \"pli_002\",\n      \"query\": {\n        \"birth_place\": \"Pennsylvania\",\n        \"birth_year\": 1845,\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"results_examined\": 12,\n      \"tool\": \"external_site\"\n    },\n    {\n      \"external_site\": {\n        \"capture_filename\": \"myheritage-1850-flynn-nil.pdf\",\n        \"capture_received\": true,\n        \"site\": \"myheritage\",\n        \"url_generated\": \"https://www.myheritage.com/research?action=query&first=Patrick&last=Flynn&birth_year=1845&birth_place=Pennsylvania\"\n      },\n      \"id\": \"log_003\",\n      \"notes\": \"MyHeritage returned no results for Patrick Flynn in 1850 Schuylkill County. Site may not have this collection indexed. Searched broader Pennsylvania \u2014 still no match.\",\n      \"outcome\": \"negative\",\n      \"performed\": \"2026-05-01T14:00:00Z\",\n      \"plan_item_id\": \"pli_003\",\n      \"query\": {\n        \"birth_place\": \"Pennsylvania\",\n        \"birth_year\": 1845,\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"results_examined\": 0,\n      \"tool\": \"external_site\"\n    },\n    {\n      \"external_site\": null,\n      \"id\": \"log_004\",\n      \"notes\": \"Patrick Flynn age 15 in household of Thomas Flynn, Schuylkill Co. Consistent with 1850 placement.\",\n      \"outcome\": \"positive\",\n      \"performed\": \"2026-05-02T09:00:00Z\",\n      \"plan_item_id\": \"pli_004\",\n      \"query\": {\n        \"birth_place\": \"Pennsylvania\",\n        \"birth_year\": 1845,\n        \"collection\": \"1860 Census\",\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"results_examined\": 5,\n      \"tool\": \"record_search\"\n    },\n    {\n      \"external_site\": null,\n      \"id\": \"log_005\",\n      \"notes\": \"Death certificate found. Names Thomas Flynn as father. Informant was son-in-law James Brown.\",\n      \"outcome\": \"positive\",\n      \"performed\": \"2026-05-03T10:00:00Z\",\n      \"plan_item_id\": \"pli_005\",\n      \"query\": {\n        \"death_place\": \"Schuylkill County, Pennsylvania\",\n        \"death_year\": 1908,\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"results_examined\": 2,\n      \"tool\": \"record_search\"\n    }\n  ],\n  \"person_evidence\": [\n    {\n      \"assertion_id\": \"a_001\",\n      \"confidence\": \"confident\",\n      \"created\": \"2026-05-01\",\n      \"id\": \"pe_001\",\n      \"match_score\": null,\n      \"person_id\": \"I1\",\n      \"rationale\": \"Name matches (Patrick Flynn), age consistent with ~1845 birth, located in Schuylkill County where subject is known to have lived. Only Patrick Flynn of this age in the county in 1850.\",\n      \"superseded_by\": null\n    },\n    {\n      \"assertion_id\": \"a_004\",\n      \"confidence\": \"probable\",\n      \"created\": \"2026-05-01\",\n      \"id\": \"pe_002\",\n      \"match_score\": null,\n      \"person_id\": \"I1\",\n      \"rationale\": \"Same record as pe_001, same person. Household position and shared surname with head Thomas Flynn suggest parent-child relationship, but 1850 census does not state relationships explicitly.\",\n      \"superseded_by\": null\n    },\n    {\n      \"assertion_id\": \"a_004\",\n      \"confidence\": \"probable\",\n      \"created\": \"2026-05-01\",\n      \"id\": \"pe_006\",\n      \"match_score\": null,\n      \"person_id\": \"I2\",\n      \"rationale\": \"Same assertion as pe_002 but linked to Thomas Flynn (I2). The relationship assertion ('position consistent with child') equally bears on the head of household. Thomas Flynn is the other party in the implied parent-child relationship.\",\n      \"superseded_by\": null\n    },\n    {\n      \"assertion_id\": \"a_005\",\n      \"confidence\": \"probable\",\n      \"created\": \"2026-05-01\",\n      \"id\": \"pe_003\",\n      \"match_score\": 0.82,\n      \"person_id\": \"I2\",\n      \"rationale\": \"Thomas Flynn, head of household where Patrick was found. Age (~32 in 1850, born ~1818) is consistent with being Patrick's father. Name matches candidate father.\",\n      \"superseded_by\": null\n    },\n    {\n      \"assertion_id\": \"a_010\",\n      \"confidence\": \"confident\",\n      \"created\": \"2026-05-02\",\n      \"id\": \"pe_004\",\n      \"match_score\": null,\n      \"person_id\": \"I1\",\n      \"rationale\": \"Patrick Flynn age 15 in Thomas Flynn household, 1860 census. Same county, age consistent with 1850 enumeration. 1860 census explicitly states relationship as 'son'.\",\n      \"superseded_by\": null\n    },\n    {\n      \"assertion_id\": \"a_013\",\n      \"confidence\": \"confident\",\n      \"created\": \"2026-05-03\",\n      \"id\": \"pe_005\",\n      \"match_score\": null,\n      \"person_id\": \"I1\",\n      \"rationale\": \"Death certificate for Patrick Flynn, d. 1908, Schuylkill County. Names match, death location matches known residence. Names Thomas Flynn as father.\",\n      \"superseded_by\": null\n    }\n  ],\n  \"plans\": [\n    {\n      \"created\": \"2026-05-01\",\n      \"id\": \"pl_001\",\n      \"items\": [\n        {\n          \"date_range\": \"1850\",\n          \"fallback_for\": null,\n          \"id\": \"pli_001\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"1850 census fully indexed on FamilySearch. Free access, start here.\",\n          \"record_type\": \"census\",\n          \"repository\": \"FamilySearch\",\n          \"sequence\": 1,\n          \"status\": \"completed\"\n        },\n        {\n          \"date_range\": \"1850\",\n          \"fallback_for\": null,\n          \"id\": \"pli_002\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"Ancestry has independent indexing; cross-check for transcription errors.\",\n          \"record_type\": \"census\",\n          \"repository\": \"Ancestry\",\n          \"sequence\": 2,\n          \"status\": \"completed\"\n        },\n        {\n          \"date_range\": \"1850\",\n          \"fallback_for\": null,\n          \"id\": \"pli_003\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"Third independent index for coverage confirmation.\",\n          \"record_type\": \"census\",\n          \"repository\": \"MyHeritage\",\n          \"sequence\": 3,\n          \"status\": \"completed\"\n        }\n      ],\n      \"question_id\": \"q_002\",\n      \"status\": \"completed\"\n    },\n    {\n      \"created\": \"2026-05-02\",\n      \"id\": \"pl_002\",\n      \"items\": [\n        {\n          \"date_range\": \"1860\",\n          \"fallback_for\": null,\n          \"id\": \"pli_004\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"Confirm Patrick still in Thomas Flynn household in 1860. Strengthens parent-child identification.\",\n          \"record_type\": \"census\",\n          \"repository\": \"FamilySearch\",\n          \"sequence\": 1,\n          \"status\": \"completed\"\n        },\n        {\n          \"date_range\": \"1908\",\n          \"fallback_for\": null,\n          \"id\": \"pli_005\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"Death certificate may name parents directly.\",\n          \"record_type\": \"vital_record\",\n          \"repository\": \"FamilySearch\",\n          \"sequence\": 2,\n          \"status\": \"completed\"\n        },\n        {\n          \"date_range\": \"1870-1890\",\n          \"fallback_for\": null,\n          \"id\": \"pli_006\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"Thomas Flynn probate/will may name Patrick as son.\",\n          \"record_type\": \"probate\",\n          \"repository\": \"FamilySearch\",\n          \"sequence\": 3,\n          \"status\": \"in_progress\"\n        }\n      ],\n      \"question_id\": \"q_001\",\n      \"status\": \"active\"\n    }\n  ],\n  \"project\": {\n    \"created\": \"2026-05-01\",\n    \"id\": \"rp_001\",\n    \"objective\": \"Identify the parents of Patrick Flynn, born ca. 1845 in Pennsylvania, died 1908 in Schuylkill County, PA\",\n    \"status\": \"active\",\n    \"subject_person_ids\": [\n      \"I1\"\n    ],\n    \"updated\": \"2026-05-04\"\n  },\n  \"proof_summaries\": [\n    {\n      \"exhaustive_search_summary\": \"Searched 1850 census (FamilySearch, Ancestry, MyHeritage \u2014 log_001, log_002, log_003), 1860 census (FamilySearch \u2014 log_004), and death certificate (FamilySearch \u2014 log_005). Probate search in progress. 1870, 1880, and 1900 censuses not yet searched.\",\n      \"id\": \"ps_001\",\n      \"narrative_markdown\": \"## Parentage of Patrick Flynn (ca. 1845\u20131908)\\n\\nPatrick Flynn is **Probably** the son of Thomas Flynn of Schuylkill County, Pennsylvania.\\n\\n### Evidence Summary\\n\\nThree independent lines of evidence support this conclusion:\\n\\n1. **1850 U.S. Census** (Original Source). Patrick Flynn, age 5, born Ireland, appears in the household of Thomas Flynn, age 32, born Ireland, in Schuylkill County, Pennsylvania (dwelling 84, family 91). The 1850 census does not state relationships, but Patrick's position in the household and shared surname are consistent with a parent-child relationship. The informant is indeterminate but likely a household member. This constitutes indirect evidence of parentage.\\n\\n2. **1860 U.S. Census** (Original Source). Patrick Flynn, age 15, born Ireland, appears as \\\"son\\\" in the household of Thomas Flynn in Schuylkill County (dwelling 112, family 119). Unlike the 1850 census, the 1860 census explicitly states the relationship. The household member who answered the enumerator's questions \u2014 likely Thomas Flynn or his wife \u2014 was a direct witness to the parent-child relationship, making this primary information. This constitutes direct evidence of parentage.\\n\\n3. **1908 Death Certificate** (Original Source). Patrick Flynn's death certificate (no. 4521, Pennsylvania Department of Health) names \\\"Thomas Flynn\\\" as his father. The informant was James Brown, identified as Patrick's son-in-law. As a son-in-law reporting his father-in-law's parentage, Brown is a secondary informant for this fact \u2014 he was not a witness to Patrick's birth and is reporting what he was told. Nevertheless, this is direct evidence naming the father.\\n\\n### Conflict Resolution\\n\\nA birthplace conflict exists: the 1850 and 1860 censuses list Patrick's birthplace as Ireland, while the 1908 death certificate states Pennsylvania. The two census records are contemporary recordings with informants likely present in the household, while the death certificate was created 63 years after Patrick's birth by a son-in-law with no firsthand knowledge of the event. Per the GPS preponderance hierarchy, contemporary recordings by closer informants outweigh later recollections by secondary informants. Ireland is accepted as the birthplace; the death certificate entry is attributed to informant error.\\n\\n### Assessment\\n\\nThe conclusion is rated **Probable** rather than **Proved** because: (a) the 1850 census evidence is indirect (relationships not stated), (b) the death certificate informant is secondary, and (c) research is not yet exhaustive \u2014 the 1870, 1880, and 1900 censuses have not been searched, and Thomas Flynn's probate records have not been located. If Thomas Flynn's will names Patrick as a son, or if additional census records confirm the relationship, the conclusion would advance to **Proved**.\\n\\n### Citations\\n\\n1. 1850 U.S. Census, Schuylkill County, Pennsylvania, population schedule, dwelling 84, family 91, Thomas Flynn household; NARA microfilm publication M432, roll 810; digital image, FamilySearch.org, accessed 1 May 2026.\\n2. 1860 U.S. Census, Schuylkill County, Pennsylvania, population schedule, dwelling 112, family 119, Thomas Flynn household; NARA microfilm publication M653, roll 1141; digital image, FamilySearch.org, accessed 2 May 2026.\\n3. Pennsylvania Department of Health, death certificate no. 4521 (1908), Patrick Flynn; Pennsylvania State Archives, Harrisburg; digital image, FamilySearch.org, accessed 3 May 2026.\",\n      \"question_id\": \"q_001\",\n      \"resolved_conflict_ids\": [\n        \"c_001\"\n      ],\n      \"supporting_assertion_ids\": [\n        \"a_004\",\n        \"a_010\",\n        \"a_013\"\n      ],\n      \"tier\": \"probable\",\n      \"vehicle\": \"summary\"\n    }\n  ],\n  \"questions\": [\n    {\n      \"created\": \"2026-05-01\",\n      \"depends_on\": [],\n      \"exhaustive_declaration\": {\n        \"declared\": false,\n        \"justification\": null,\n        \"log_entry_ids\": [],\n        \"stop_criteria\": null\n      },\n      \"id\": \"q_001\",\n      \"priority\": \"high\",\n      \"question\": \"Who were the parents of Patrick Flynn (b. ~1845, PA, d. 1908)?\",\n      \"rationale\": \"This is the primary research objective.\",\n      \"resolution_assertion_ids\": [],\n      \"resolved\": null,\n      \"selection_basis\": \"objective_decomposition\",\n      \"status\": \"in_progress\",\n      \"unblocks\": []\n    },\n    {\n      \"created\": \"2026-05-01\",\n      \"depends_on\": [],\n      \"exhaustive_declaration\": {\n        \"declared\": true,\n        \"justification\": \"Searched 1850 census for Schuylkill County on FamilySearch (indexed and browse), Ancestry (indexed), and MyHeritage (indexed). All three returned the same household. No other Patrick Flynn of matching age found in the county.\",\n        \"log_entry_ids\": [\n          \"log_001\",\n          \"log_002\",\n          \"log_003\"\n        ],\n        \"stop_criteria\": {\n          \"conflict_resolution\": \"No conflicts on the 1850 census placement question.\",\n          \"evidence_class\": \"Yes \u2014 FamilySearch provides original census image with indeterminate-quality information.\",\n          \"goal_alignment\": \"Yes \u2014 Patrick Flynn located in a specific 1850 household, answering the question.\",\n          \"independent_verification\": \"FamilySearch (original) and Ancestry (derivative) both return the same household. Two access paths, one underlying original.\",\n          \"original_substitution\": \"FamilySearch provides the original census image; Ancestry index is derivative but confirmed consistent.\",\n          \"overturn_risk\": \"Low \u2014 all three repositories agree, and no competing Patrick Flynn of matching age exists in the county.\",\n          \"repository_breadth\": \"Three major repositories searched (FamilySearch, Ancestry, MyHeritage). No additional known indexes of the 1850 Schuylkill County census exist.\"\n        }\n      },\n      \"id\": \"q_002\",\n      \"priority\": \"high\",\n      \"question\": \"Where was Patrick Flynn in the 1850 census?\",\n      \"rationale\": \"The 1850 census is the earliest enumeration where Patrick would appear by name (age ~5). Locating him in a household identifies candidate parents.\",\n      \"resolution_assertion_ids\": [\n        \"a_001\",\n        \"a_002\",\n        \"a_003\"\n      ],\n      \"resolved\": \"2026-05-02\",\n      \"selection_basis\": \"objective_decomposition\",\n      \"status\": \"resolved\",\n      \"unblocks\": [\n        \"q_001\"\n      ]\n    }\n  ],\n  \"sources\": [\n    {\n      \"access_date\": \"2026-05-01\",\n      \"citation\": \"1850 U.S. Census, Schuylkill County, Pennsylvania, population schedule, dwelling 84, family 91, Thomas Flynn household; NARA microfilm publication M432, roll 810; digital image, FamilySearch.org, accessed 1 May 2026.\",\n      \"citation_detail\": {\n        \"what\": \"1850 U.S. Federal Census, population schedule\",\n        \"when_accessed\": \"2026-05-01\",\n        \"when_created\": \"1850\",\n        \"where\": \"FamilySearch.org (NARA microfilm M432, roll 810)\",\n        \"where_within\": \"Schuylkill County, dwelling 84, family 91\",\n        \"who\": \"U.S. Census Bureau\"\n      },\n      \"gedcomx_source_description_id\": \"S1\",\n      \"id\": \"src_001\",\n      \"log_entry_id\": \"log_001\",\n      \"notes\": \"Image quality good. Enumerator handwriting clear.\",\n      \"repository\": \"FamilySearch\",\n      \"source_classification\": \"original\",\n      \"url\": \"https://www.familysearch.org/ark:/61903/1:1:MXYZ\",\n      \"url_archived\": null\n    },\n    {\n      \"access_date\": \"2026-05-01\",\n      \"citation\": \"1850 U.S. Census, Schuylkill County, Pennsylvania, population schedule, dwelling 84, Thomas Flynn household; digital image, Ancestry.com, accessed 1 May 2026.\",\n      \"citation_detail\": {\n        \"what\": \"1850 U.S. Federal Census, population schedule (Ancestry index)\",\n        \"when_accessed\": \"2026-05-01\",\n        \"when_created\": \"1850\",\n        \"where\": \"Ancestry.com\",\n        \"where_within\": \"Schuylkill County, dwelling 84\",\n        \"who\": \"U.S. Census Bureau\"\n      },\n      \"gedcomx_source_description_id\": \"S1\",\n      \"id\": \"src_002\",\n      \"log_entry_id\": \"log_002\",\n      \"notes\": \"Ancestry's index of the same original census. Transcription consistent with FamilySearch.\",\n      \"repository\": \"Ancestry\",\n      \"source_classification\": \"derivative\",\n      \"url\": null,\n      \"url_archived\": null\n    },\n    {\n      \"access_date\": \"2026-05-02\",\n      \"citation\": \"1860 U.S. Census, Schuylkill County, Pennsylvania, population schedule, dwelling 112, family 119, Thomas Flynn household; NARA microfilm publication M653, roll 1141; digital image, FamilySearch.org, accessed 2 May 2026.\",\n      \"citation_detail\": {\n        \"what\": \"1860 U.S. Federal Census, population schedule\",\n        \"when_accessed\": \"2026-05-02\",\n        \"when_created\": \"1860\",\n        \"where\": \"FamilySearch.org (NARA microfilm M653, roll 1141)\",\n        \"where_within\": \"Schuylkill County, dwelling 112, family 119\",\n        \"who\": \"U.S. Census Bureau\"\n      },\n      \"gedcomx_source_description_id\": \"S2\",\n      \"id\": \"src_003\",\n      \"log_entry_id\": \"log_004\",\n      \"notes\": null,\n      \"repository\": \"FamilySearch\",\n      \"source_classification\": \"original\",\n      \"url\": \"https://www.familysearch.org/ark:/61903/1:1:MABC\",\n      \"url_archived\": null\n    },\n    {\n      \"access_date\": \"2026-05-03\",\n      \"citation\": \"Pennsylvania Department of Health, death certificate no. 4521 (1908), Patrick Flynn; Pennsylvania State Archives, Harrisburg; digital image, FamilySearch.org, accessed 3 May 2026.\",\n      \"citation_detail\": {\n        \"what\": \"Death certificate no. 4521\",\n        \"when_accessed\": \"2026-05-03\",\n        \"when_created\": \"1908-03-14\",\n        \"where\": \"FamilySearch.org (Pennsylvania State Archives, Harrisburg)\",\n        \"where_within\": \"Certificate no. 4521\",\n        \"who\": \"Pennsylvania Department of Health; informant: James Brown (son-in-law)\"\n      },\n      \"gedcomx_source_description_id\": \"S3\",\n      \"id\": \"src_004\",\n      \"log_entry_id\": \"log_005\",\n      \"notes\": \"Informant is son-in-law James Brown. Primary for death facts, secondary for birth facts.\",\n      \"repository\": \"FamilySearch\",\n      \"source_classification\": \"original\",\n      \"url\": \"https://www.familysearch.org/ark:/61903/1:1:MDEF\",\n      \"url_archived\": null\n    }\n  ],\n  \"timelines\": [\n    {\n      \"events\": [\n        {\n          \"assertion_ids\": [\n            \"a_002\",\n            \"a_009\"\n          ],\n          \"date\": \"~1845\",\n          \"date_certainty\": \"estimated\",\n          \"description\": \"Born in Ireland, estimated from census ages\",\n          \"event_type\": \"birth\",\n          \"place\": \"Ireland\"\n        },\n        {\n          \"assertion_ids\": [\n            \"a_003\",\n            \"a_004\"\n          ],\n          \"date\": \"1850\",\n          \"date_certainty\": \"exact\",\n          \"description\": \"Enumerated age 5 in Thomas Flynn household, dwelling 84\",\n          \"event_type\": \"census\",\n          \"place\": \"Schuylkill County, Pennsylvania\"\n        },\n        {\n          \"assertion_ids\": [\n            \"a_008\",\n            \"a_009\",\n            \"a_010\"\n          ],\n          \"date\": \"1860\",\n          \"date_certainty\": \"exact\",\n          \"description\": \"Enumerated age 15 as son in Thomas Flynn household, dwelling 112\",\n          \"event_type\": \"census\",\n          \"place\": \"Schuylkill County, Pennsylvania\"\n        },\n        {\n          \"assertion_ids\": [\n            \"a_011\",\n            \"a_013\"\n          ],\n          \"date\": \"1908-03-12\",\n          \"date_certainty\": \"exact\",\n          \"description\": \"Died, death certificate names Thomas Flynn as father\",\n          \"event_type\": \"death\",\n          \"place\": \"Schuylkill County, Pennsylvania\"\n        }\n      ],\n      \"gaps\": [\n        {\n          \"end\": \"1908-03-12\",\n          \"expected_events\": [\n            \"marriage\",\n            \"1870_census\",\n            \"1880_census\",\n            \"1900_census\",\n            \"residence\",\n            \"occupation\"\n          ],\n          \"severity\": \"high\",\n          \"start\": \"1860-01-01\"\n        }\n      ],\n      \"generated\": \"2026-05-03T12:00:00Z\",\n      \"hypothesis_id\": \"h_001\",\n      \"id\": \"t_001\",\n      \"impossibilities\": [],\n      \"label\": \"Patrick Flynn \u2014 assuming Thomas Flynn parentage\",\n      \"person_ids\": [\n        \"I1\"\n      ]\n    }\n  ]\n}\n",
+    "eval/fixtures/scenarios/mid-research-flynn/tree.gedcomx.json": "{\n  \"persons\": [\n    {\n      \"facts\": [\n        {\n          \"date\": \"~1845\",\n          \"id\": \"F1\",\n          \"place\": \"Ireland\",\n          \"primary\": true,\n          \"sources\": [\n            {\n              \"page\": \"1850 Census, Schuylkill Co., dwelling 84\",\n              \"ref\": \"S1\"\n            }\n          ],\n          \"type\": \"Birth\"\n        },\n        {\n          \"date\": \"1908-03-12\",\n          \"id\": \"F2\",\n          \"place\": \"Schuylkill County, Pennsylvania\",\n          \"sources\": [\n            {\n              \"page\": \"Death cert. no. 4521\",\n              \"ref\": \"S3\"\n            }\n          ],\n          \"type\": \"Death\"\n        }\n      ],\n      \"gender\": \"Male\",\n      \"id\": \"I1\",\n      \"names\": [\n        {\n          \"given\": \"Patrick\",\n          \"id\": \"N1\",\n          \"preferred\": true,\n          \"surname\": \"Flynn\",\n          \"type\": \"BirthName\"\n        }\n      ]\n    },\n    {\n      \"facts\": [\n        {\n          \"date\": \"~1818\",\n          \"id\": \"F3\",\n          \"place\": \"Ireland\",\n          \"primary\": true,\n          \"type\": \"Birth\"\n        }\n      ],\n      \"gender\": \"Male\",\n      \"id\": \"I2\",\n      \"names\": [\n        {\n          \"given\": \"Thomas\",\n          \"id\": \"N2\",\n          \"preferred\": true,\n          \"surname\": \"Flynn\",\n          \"type\": \"BirthName\"\n        }\n      ]\n    }\n  ],\n  \"relationships\": [\n    {\n      \"child\": \"I1\",\n      \"id\": \"R1\",\n      \"parent\": \"I2\",\n      \"sources\": [\n        {\n          \"page\": \"1850 Census, Schuylkill Co., dwelling 84\",\n          \"quality\": 2,\n          \"ref\": \"S1\"\n        },\n        {\n          \"page\": \"1860 Census, Schuylkill Co., dwelling 112\",\n          \"quality\": 3,\n          \"ref\": \"S2\"\n        },\n        {\n          \"page\": \"Death cert. no. 4521\",\n          \"quality\": 2,\n          \"ref\": \"S3\"\n        }\n      ],\n      \"type\": \"ParentChild\"\n    }\n  ],\n  \"sources\": [\n    {\n      \"author\": \"U.S. Census Bureau\",\n      \"id\": \"S1\",\n      \"title\": \"1850 U.S. Federal Census\"\n    },\n    {\n      \"author\": \"U.S. Census Bureau\",\n      \"id\": \"S2\",\n      \"title\": \"1860 U.S. Federal Census\"\n    },\n    {\n      \"author\": \"Pennsylvania Dept. of Health\",\n      \"id\": \"S3\",\n      \"title\": \"Pennsylvania Death Certificates\"\n    },\n    {\n      \"author\": \"Schuylkill County Register of Wills\",\n      \"id\": \"S4\",\n      \"title\": \"Schuylkill County Probate Records\"\n    }\n  ]\n}\n"
+  },
+  "tests": [
+    {
+      "test_id": "ut_assertion_classification_002",
+      "test_type": "positive",
+      "expected_outcome": "pass",
+      "scenario": "mid-research-flynn",
+      "mcp_fixtures": [],
+      "outcome": "pass",
+      "flaky": false,
+      "outcome_summary": {
+        "per_run_outcomes": [
+          "pass"
+        ],
+        "aggregated_dimensions": [
+          {
+            "source": "base",
+            "name": "Correctness",
+            "score": 3,
+            "rationale": "The skill's core analysis is factually correct. Claude accurately identified that a_012 (birth year/place) should not be extracted for q_001 (parentage identification), correctly distinguished James Brown as son-in-law (secondary informant, not recorder), and properly applied the schema constraint that 'no_evidence' is not a valid enum value\u2014using empty extracted_for_question_ids instead. The classification layers (secondary/family_not_present/direct) are all justified by the source facts."
+          },
+          {
+            "source": "base",
+            "name": "Completeness",
+            "score": 3,
+            "rationale": "The skill addressed everything the test author expected: explained why source_classification remained 'original' despite secondary information_quality (layers are independent), identified the son-in-law as secondary informant with temporal gap (~63 years), explained why birth year/place do not answer parentage, and populated informant_bias_notes flagging potential confusion between Pennsylvania residence and Ireland birthplace. No silent omissions."
+          },
+          {
+            "source": "base",
+            "name": "Tool Arguments",
+            "score": null,
+            "rationale": "No MCP tool calls were made. The skill performed analysis and file updates locally without invoking external tools. This is appropriate for the assertion-classification task in this context."
+          },
+          {
+            "source": "rubric",
+            "name": "Three-layer accuracy",
+            "score": 3,
+            "rationale": "All three GPS layers are correctly applied and justified. Source classification: 'original' (the death certificate itself is an original source, unaffected by informant proximity). Information quality: 'secondary' (son-in-law reporting 63 years after birth, not present at event). Evidence type: 'direct' (birth year/place would directly answer a birth question if one were open). The skill correctly explained the independence of layers\u2014that informant distance affects quality, not source classification."
+          },
+          {
+            "source": "rubric",
+            "name": "Informant analysis",
+            "score": 3,
+            "rationale": "The informant is correctly identified as James Brown (son-in-law) and distinguished from the recorder (the death certificate official). The skill explicitly noted he is not a blood relative and had zero exposure to Patrick's 1845 birth, correctly assigning 'family_not_present' proximity. The skill cited the specific relationship (son-in-law) and temporal gap (~63 years) to justify why secondary is appropriate, and flagged potential bias (Pennsylvania/Ireland confusion)."
+          },
+          {
+            "source": "rubric",
+            "name": "Classification justification",
+            "score": 3,
+            "rationale": "Each classification includes specific rationale. Secondary justified by: son-in-law's distant relationship, 63-year gap, no first-hand knowledge of Patrick's origins. Family_not_present proximity justified by: not present at birth, reporting 63 years later as in-law. Direct evidence-type justified by: birth year/place would directly answer a birth question (even though no such question is currently open). The skill cited specific source/informant attributes rather than generic assertions."
+          }
+        ]
+      },
+      "totals": {
+        "duration_ms": 270580.8795999992,
+        "input_tokens": 3329,
+        "cached_input_tokens": 317538,
+        "output_tokens": 12264,
+        "judge_input_tokens": 5360,
+        "judge_cached_input_tokens": 0,
+        "judge_output_tokens": 810,
+        "skill_cost_usd": 0.45894440000000003,
+        "judge_cost_usd": 0.00941,
+        "total_cost_usd": 0.4683544
+      },
+      "runs": [
+        {
+          "run_index": 0,
+          "run_id": "run_ut_assertion_classification_002_2026-05-21_08-17-40_0",
+          "outcome": "pass",
+          "aborted_reason": null,
+          "duration_ms": 270580.8795999992,
+          "input_tokens": 3329,
+          "cached_input_tokens": 317538,
+          "output_tokens": 12264,
+          "skill_cost_usd": 0.45894440000000003,
+          "output": {
+            "text_response": "I'll start by reading the project files to understand the current state of `a_012`.I have everything I need. Let me now work through the three-layer analysis on `a_012`.\n\n---\n\n## Analysis of a_012 \u2014 Birth Fact on Patrick Flynn's Death Certificate\n\n**Current state:**\n- `information_quality`: secondary\n- `informant`: James Brown (son-in-law)\n- `informant_proximity`: family_not_present\n- `evidence_type`: **direct**\n- `extracted_for_question_ids`: [\"q_001\"]\n\n---\n\n### Layer 2 \u2014 Information Quality (read-only check, set by record-extraction)\n\n**Informant:** James Brown, identified as son-in-law in `src_004`'s `citation_detail` and confirmed in `log_005`.\n\n**Who is he?** A son-in-law \u2014 he married Patrick's daughter. He is not a blood relative of Patrick and would have had zero direct exposure to Patrick's birth or early-life origins.\n\n**Proximity decision tree:**\n1. Do we know the informant? **YES** \u2014 James Brown (son-in-law)\n2. Did he witness/participate in/have first-hand knowledge of Patrick's 1845 birth? **NO** \u2014 not present, reporting ~63 years after the event\n\n\u2192 **Secondary** \u2713\n\nThe existing `information_quality: \"secondary\"`, `informant_proximity: \"family_not_present\"`, and informant identity are all **correct**. However, the `informant_bias_notes` can be sharpened \u2014 the current text mentions \"decades after the event\" but the gap is specifically ~63 years. I'll also add that a son-in-law occupies a more distant position than a child of the deceased: he has no direct family memory of Patrick's pre-immigration origins, making knowledge of the birthplace particularly tenuous.\n\n---\n\n### Layer 3 \u2014 Evidence Type \u2190 **This is the problem**\n\nThe active question is **q_001**: *\"Who were the parents of Patrick Flynn (b. ~1845, PA, d. 1908)?\"*\n\nThe assertion states: `\"Born 1845, Pennsylvania\"` (birth year + birthplace).\n\n**Does this explicitly answer q_001?** No \u2014 it names no parent.\n**Does it imply parentage through inference?** No \u2014 knowing Patrick was born in 1845 in Pennsylvania does not tell us who his parents were. At most it corroborates the subject's identity, but identity corroboration is not the same as parentage evidence.\n**Negative evidence for q_001?** No \u2014 a birth fact's absence of parental names is not meaningful absence; parents aren't expected in a birth-fact field.\n\n**Correct classification: `no_evidence`** for q_001. The parentage is addressed by `a_013` (\"Father: Thomas Flynn\"), not by `a_012`. The birth year/place is useful context (and relevant to the resolved conflict `c_001` about birthplace discrepancy), but it does not speak to parentage.\n\nThis also means `extracted_for_question_ids` should be cleared \u2014 there is no open question this assertion evidences.\n\n**Change required:** `evidence_type` direct \u2192 **no_evidence**; `extracted_for_question_ids` [\"q_001\"] \u2192 **[]**\n\n---\n\nNow writing the update:Now validating:Let me locate the script and the GedcomX file, then run the validation.Both files exist. Running the validation script now:I can't execute shell commands in this environment. Let me read the validation script directly to manually apply its checks against the updated file.Now I can see the problem. The `CLOSED_ENUMS` for `evidence_type` only allows `{\"direct\", \"indirect\", \"negative\"}` \u2014 **`\"no_evidence\"` is not a valid schema value.** My write would produce an enum error. I need to correct this before the file is invalid.\n\nHere's the right approach: \"no evidence\" is a conceptual category, but the schema represents it differently \u2014 `extracted_for_question_ids: []` (empty, no question linked) with `evidence_type` reflecting what the assertion *would* answer if a relevant question existed. Since \"Born 1845, Pennsylvania\" would directly state the birth year/place, `\"direct\"` is appropriate; the empty `extracted_for_question_ids` is what correctly signals it isn't answering any currently-open question. Fixing now:Now let me manually walk through the full validator logic on the updated file to confirm there are no remaining issues. Let me check the GedcomX file too, since the validator runs cross-file checks:Good. I can now manually apply the full validator logic. Let me trace through every check relevant to `a_012` and its surroundings:\n\n**Enum checks on a_012:**\n- `information_quality: \"secondary\"` \u2192 in `{\"primary\", \"secondary\", \"indeterminate\"}` \u2713\n- `evidence_type: \"direct\"` \u2192 in `{\"direct\", \"indirect\", \"negative\"}` \u2713\n- `informant_proximity: \"family_not_present\"` \u2192 in the proximity enum \u2713\n\n**Cross-references:**\n- `source_id: \"src_004\"` \u2192 exists \u2713\n- `log_entry_id: \"log_005\"` \u2192 exists \u2713\n- `extracted_for_question_ids: []` \u2192 nothing to resolve \u2713\n\n**GedcomX cross-file:**\n- `src_004.gedcomx_source_description_id: \"S3\"` \u2192 S3 exists in tree.gedcomx.json \u2713\n- All `person_evidence.person_id` values (I1, I2) \u2192 both exist \u2713\n- `subject_person_ids: [\"I1\"]` \u2192 I1 exists \u2713\n- `timelines[0].person_ids: [\"I1\"]` \u2192 I1 exists \u2713\n\n**All other assertions, sources, plans, log, conflicts, hypotheses** \u2014 none were touched; they were already passing. No new issues introduced.\n\n**Both project files are valid.** \u2713\n\n---\n\n## Classification Review \u2014 a_012 Summary\n\n| Layer | Field | Was | Now | Verdict |\n|---|---|---|---|---|\n| 2 | `information_quality` | `secondary` | `secondary` (unchanged) | \u2705 Correct |\n| 2 | `informant` | James Brown (son-in-law) | unchanged | \u2705 Correct |\n| 2 | `informant_proximity` | `family_not_present` | unchanged | \u2705 Correct |\n| 2 | `informant_bias_notes` | vague \u2014 \"decades after\" | **Updated** \u2014 63 years, son-in-law's lack of blood-relative knowledge, Pennsylvania/Ireland confusion explained | \u2705 Improved |\n| 3 | `evidence_type` | `direct` | `direct` (unchanged) | \u2705 Correct \u2014 birth year/place *would* directly answer a birth question if one were open |\n| 3 | `extracted_for_question_ids` | `[\"q_001\"]` | **`[]`** | \u2705 Fixed |\n\n### The one real error: `extracted_for_question_ids`\n\n\"Born 1845, Pennsylvania\" was incorrectly linked to **q_001** (\"Who were the parents of Patrick Flynn?\"). Birth year and birthplace do not name parents, do not imply parentage through inference, and do not create meaningful absence on the parentage question. The parentage answer lives in **a_013** (\"Father: Thomas Flynn\"), not here. Removing q_001 from this assertion's question links is the substantive correction.\n\n### The schema nuance worth knowing\n\nThe `evidence_type` enum only permits `direct`, `indirect`, and `negative` \u2014 there is no `\"no_evidence\"` stored value. \"No evidence\" is expressed structurally: `extracted_for_question_ids: []` (nothing linked) with `evidence_type` reflecting what the assertion *would* answer if a relevant question existed. That's the pattern already used by a_011 (the death-date assertion, also `[]`).\n\n### Evidence independence note (GPS Standard 46)\n\n`a_012` and `a_013` share the **same informant** \u2014 James Brown. Both are already classified as `secondary / family_not_present`. This means the birth-place fact on the death certificate and the father-name fact on the death certificate form a **single evidence unit** for purposes of corroboration weight. They cannot independently reinforce each other, which is already correctly reflected in the conflict analysis at `c_001`.\n\n**Suggested next step:** `person-evidence` \u2014 there is currently no `pe_` entry linking `a_012` to I1, which is fine since it's now unlinked from any question. If a birth-specific question is opened later, `a_012` can be wired up at that point.",
+            "activated": true,
+            "skills_invoked": [
+              "assertion-classification",
+              "validate-schema"
+            ],
+            "tool_calls": [],
+            "files_created": [],
+            "file_changes": {
+              "research.json": {
+                "sections_modified": [
+                  "assertions"
+                ],
+                "diff": {
+                  "assertions": {
+                    "added": [],
+                    "modified": [
+                      {
+                        "id": "a_012",
+                        "changed_fields": {
+                          "informant_bias_notes": {
+                            "before": "Son-in-law reporting birth facts decades after the event. Note: death cert says Pennsylvania, but census records say Ireland. Son-in-law may not have known Patrick was born in Ireland.",
+                            "after": "Son-in-law reporting birth facts approximately 63 years after the event (1845 birth, 1908 death certificate). As a son-in-law, Brown was not a blood relative of Patrick and would have had no direct family memory of Patrick's birth or pre-immigration origins \u2014 more distant than a child of the deceased would be. The death certificate states Pennsylvania while the 1850 and 1860 census records consistently state Ireland; Brown likely did not know Patrick was born in Ireland before immigrating, and may have confused Patrick's place of long-term residence with his birthplace."
+                          },
+                          "extracted_for_question_ids": {
+                            "before": [
+                              "q_001"
+                            ],
+                            "after": []
+                          }
+                        }
+                      }
+                    ],
+                    "deleted": []
+                  }
+                }
+              }
+            }
+          },
+          "validators": {
+            "passed": true,
+            "results": [
+              {
+                "name": "test_id_references_resolve",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_log_append_only",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_entries_deleted",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_research_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tool_allowlist",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_gedcomx_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_a001_preserves_classification",
+                "passed": true,
+                "error": "skipped: not an a001-preserves-classification scenario"
+              },
+              {
+                "name": "test_a012_secondary_family_not_present",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_does_not_add_new_assertions",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_mcp_tools_called",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_source_classification_unchanged",
+                "passed": true,
+                "error": null
+              }
+            ]
+          },
+          "judge": {
+            "skipped": false,
+            "dimensions": [
+              {
+                "source": "base",
+                "name": "Correctness",
+                "score": 3,
+                "rationale": "The skill's core analysis is factually correct. Claude accurately identified that a_012 (birth year/place) should not be extracted for q_001 (parentage identification), correctly distinguished James Brown as son-in-law (secondary informant, not recorder), and properly applied the schema constraint that 'no_evidence' is not a valid enum value\u2014using empty extracted_for_question_ids instead. The classification layers (secondary/family_not_present/direct) are all justified by the source facts."
+              },
+              {
+                "source": "base",
+                "name": "Completeness",
+                "score": 3,
+                "rationale": "The skill addressed everything the test author expected: explained why source_classification remained 'original' despite secondary information_quality (layers are independent), identified the son-in-law as secondary informant with temporal gap (~63 years), explained why birth year/place do not answer parentage, and populated informant_bias_notes flagging potential confusion between Pennsylvania residence and Ireland birthplace. No silent omissions."
+              },
+              {
+                "source": "base",
+                "name": "Tool Arguments",
+                "score": null,
+                "rationale": "No MCP tool calls were made. The skill performed analysis and file updates locally without invoking external tools. This is appropriate for the assertion-classification task in this context."
+              },
+              {
+                "source": "rubric",
+                "name": "Three-layer accuracy",
+                "score": 3,
+                "rationale": "All three GPS layers are correctly applied and justified. Source classification: 'original' (the death certificate itself is an original source, unaffected by informant proximity). Information quality: 'secondary' (son-in-law reporting 63 years after birth, not present at event). Evidence type: 'direct' (birth year/place would directly answer a birth question if one were open). The skill correctly explained the independence of layers\u2014that informant distance affects quality, not source classification."
+              },
+              {
+                "source": "rubric",
+                "name": "Informant analysis",
+                "score": 3,
+                "rationale": "The informant is correctly identified as James Brown (son-in-law) and distinguished from the recorder (the death certificate official). The skill explicitly noted he is not a blood relative and had zero exposure to Patrick's 1845 birth, correctly assigning 'family_not_present' proximity. The skill cited the specific relationship (son-in-law) and temporal gap (~63 years) to justify why secondary is appropriate, and flagged potential bias (Pennsylvania/Ireland confusion)."
+              },
+              {
+                "source": "rubric",
+                "name": "Classification justification",
+                "score": 3,
+                "rationale": "Each classification includes specific rationale. Secondary justified by: son-in-law's distant relationship, 63-year gap, no first-hand knowledge of Patrick's origins. Family_not_present proximity justified by: not present at birth, reporting 63 years later as in-law. Direct evidence-type justified by: birth year/place would directly answer a birth question (even though no such question is currently open). The skill cited specific source/informant attributes rather than generic assertions."
+              }
+            ],
+            "judge_cost_usd": 0.00941,
+            "error": null,
+            "input_tokens": 5360,
+            "cached_input_tokens": 0,
+            "output_tokens": 810
+          }
+        }
+      ]
+    },
+    {
+      "test_id": "ut_assertion_classification_003",
+      "test_type": "negative",
+      "expected_outcome": "pass",
+      "scenario": "mid-research-flynn",
+      "mcp_fixtures": [],
+      "outcome": "fail",
+      "flaky": false,
+      "outcome_summary": {
+        "per_run_outcomes": [
+          "fail"
+        ],
+        "aggregated_dimensions": [
+          {
+            "source": "base",
+            "name": "Correctness",
+            "score": 1,
+            "rationale": "The skill did not extract or classify any assertions from a census record. Instead, it asked the user to provide the record, which is incorrect routing behavior. The test context indicates the skill should route to record-extraction and process the provided record directly."
+          },
+          {
+            "source": "base",
+            "name": "Completeness",
+            "score": 1,
+            "rationale": "The skill failed to address the user's request entirely. The user stated 'I have a new census record' and asked to 'Extract the assertions and classify them properly,' but the skill did not extract or classify any assertions. It only asked for the record without attempting to process what was presented."
+          },
+          {
+            "source": "base",
+            "name": "Tool Arguments",
+            "score": null,
+            "rationale": "No MCP tool calls were made. The skill made zero tool calls and therefore this dimension is N/A."
+          },
+          {
+            "source": "rubric",
+            "name": "Three-layer accuracy",
+            "score": 1,
+            "rationale": "No assertions were classified. The skill produced zero classifications across any of the three GPS layers (source classification, information quality, evidence type), making it impossible to assess accuracy of these classifications."
+          },
+          {
+            "source": "rubric",
+            "name": "Informant analysis",
+            "score": 1,
+            "rationale": "No informant analysis was performed. The skill did not identify any informant, distinguish recorder from informant, or assign any informant_proximity values, as no record extraction or classification occurred."
+          },
+          {
+            "source": "rubric",
+            "name": "Classification justification",
+            "score": 1,
+            "rationale": "No classifications were provided and therefore no justification or rationale for any classification exists. The skill did not attempt to explain why any assertion would be classified in any particular way."
+          }
+        ]
+      },
+      "totals": {
+        "duration_ms": 51900.80550000039,
+        "input_tokens": 918,
+        "cached_input_tokens": 41932,
+        "output_tokens": 983,
+        "judge_input_tokens": 3282,
+        "judge_cached_input_tokens": 0,
+        "judge_output_tokens": 517,
+        "skill_cost_usd": 0.10417409999999999,
+        "judge_cost_usd": 0.005867000000000001,
+        "total_cost_usd": 0.11004109999999999
+      },
+      "runs": [
+        {
+          "run_index": 0,
+          "run_id": "run_ut_assertion_classification_003_2026-05-21_08-17-40_0",
+          "outcome": "fail",
+          "aborted_reason": null,
+          "duration_ms": 51900.80550000039,
+          "input_tokens": 918,
+          "cached_input_tokens": 41932,
+          "output_tokens": 983,
+          "skill_cost_usd": 0.10417409999999999,
+          "output": {
+            "text_response": "I'll start by reading the project files to understand the current research context, then I'll need the census record from you.I've reviewed the project. The research is focused on identifying the parents of **Patrick Flynn** (b. ~1845 Ireland, d. 1908 Schuylkill Co., PA). The active hypothesis is that **Thomas Flynn** is his father, currently rated *Probable*. The 1870, 1880, and 1900 censuses are notably unsearched gaps in the timeline.\n\nPlease share the census record \u2014 you can paste the transcription, describe the household, or give me a FamilySearch/Ancestry URL or image ARK and I'll pull it up directly.",
+            "activated": false,
+            "skills_invoked": [
+              "record-extraction"
+            ],
+            "tool_calls": [],
+            "files_created": []
+          },
+          "validators": {
+            "passed": true,
+            "results": [
+              {
+                "name": "test_id_references_resolve",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_log_append_only",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_entries_deleted",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_ownership_table",
+                "passed": true,
+                "error": "skipped: ownership is not checked on negative tests \u2014 writes belong to the routed-to skill, not the skill under test"
+              },
+              {
+                "name": "test_research_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tool_allowlist",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_gedcomx_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_ownership_table",
+                "passed": true,
+                "error": "skipped: ownership is not checked on negative tests \u2014 writes belong to the routed-to skill, not the skill under test"
+              },
+              {
+                "name": "test_a001_preserves_classification",
+                "passed": true,
+                "error": "skipped: not an a001-preserves-classification scenario"
+              },
+              {
+                "name": "test_a012_secondary_family_not_present",
+                "passed": true,
+                "error": "skipped: not an a012-secondary-family-not-present scenario"
+              },
+              {
+                "name": "test_does_not_add_new_assertions",
+                "passed": true,
+                "error": "skipped: negative tests don't run the skill body"
+              },
+              {
+                "name": "test_no_mcp_tools_called",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_source_classification_unchanged",
+                "passed": true,
+                "error": "skipped: negative tests don't run the skill body"
+              }
+            ]
+          },
+          "judge": {
+            "skipped": false,
+            "dimensions": [
+              {
+                "source": "base",
+                "name": "Correctness",
+                "score": 1,
+                "rationale": "The skill did not extract or classify any assertions from a census record. Instead, it asked the user to provide the record, which is incorrect routing behavior. The test context indicates the skill should route to record-extraction and process the provided record directly."
+              },
+              {
+                "source": "base",
+                "name": "Completeness",
+                "score": 1,
+                "rationale": "The skill failed to address the user's request entirely. The user stated 'I have a new census record' and asked to 'Extract the assertions and classify them properly,' but the skill did not extract or classify any assertions. It only asked for the record without attempting to process what was presented."
+              },
+              {
+                "source": "base",
+                "name": "Tool Arguments",
+                "score": null,
+                "rationale": "No MCP tool calls were made. The skill made zero tool calls and therefore this dimension is N/A."
+              },
+              {
+                "source": "rubric",
+                "name": "Three-layer accuracy",
+                "score": 1,
+                "rationale": "No assertions were classified. The skill produced zero classifications across any of the three GPS layers (source classification, information quality, evidence type), making it impossible to assess accuracy of these classifications."
+              },
+              {
+                "source": "rubric",
+                "name": "Informant analysis",
+                "score": 1,
+                "rationale": "No informant analysis was performed. The skill did not identify any informant, distinguish recorder from informant, or assign any informant_proximity values, as no record extraction or classification occurred."
+              },
+              {
+                "source": "rubric",
+                "name": "Classification justification",
+                "score": 1,
+                "rationale": "No classifications were provided and therefore no justification or rationale for any classification exists. The skill did not attempt to explain why any assertion would be classified in any particular way."
+              }
+            ],
+            "judge_cost_usd": 0.005867000000000001,
+            "error": null,
+            "input_tokens": 3282,
+            "cached_input_tokens": 0,
+            "output_tokens": 517
+          }
+        }
+      ]
+    },
+    {
+      "test_id": "ut_assertion_classification_001",
+      "test_type": "positive",
+      "expected_outcome": "pass",
+      "scenario": "mid-research-flynn",
+      "mcp_fixtures": [],
+      "outcome": "fail",
+      "flaky": false,
+      "outcome_summary": {
+        "per_run_outcomes": [
+          "fail"
+        ],
+        "aggregated_dimensions": []
+      },
+      "totals": {
+        "duration_ms": 235426.24119999981,
+        "input_tokens": 18,
+        "cached_input_tokens": 311756,
+        "output_tokens": 11658,
+        "judge_input_tokens": 0,
+        "judge_cached_input_tokens": 0,
+        "judge_output_tokens": 0,
+        "skill_cost_usd": 0.42148504999999997,
+        "judge_cost_usd": 0.0,
+        "total_cost_usd": 0.42148504999999997
+      },
+      "runs": [
+        {
+          "run_index": 0,
+          "run_id": "run_ut_assertion_classification_001_2026-05-21_08-17-40_0",
+          "outcome": "fail",
+          "aborted_reason": null,
+          "duration_ms": 235426.24119999981,
+          "input_tokens": 18,
+          "cached_input_tokens": 311756,
+          "output_tokens": 11658,
+          "skill_cost_usd": 0.42148504999999997,
+          "output": {
+            "text_response": "I'll start by reading the project files to locate assertion `a_001` and the classification framework.I have everything I need. Let me now work through the three layers for `a_001`.\n\n---\n\n## Analysis of Assertion a_001\n\n**The assertion:** `name = \"Patrick Flynn\"` \u2014 drawn from `src_001`, the 1850 U.S. Census, Schuylkill County (original source on FamilySearch).\n\n---\n\n### Layer 1 \u2014 Source Classification *(read-only)*\n`original` \u2014 correct. FamilySearch provides a digital image of the NARA microfilm, which is a true copy of the original enumerator's return. No change here.\n\n---\n\n### Layer 2 \u2014 Information Quality\n\n**A. Who is the informant?**\nPre-1940 census: the enumerator recorded who lived in the dwelling but did not note who in the household answered questions. For a *name* fact specifically, the situation is even less certain than for age or birthplace \u2014 the enumerator may have read a door sign, heard a neighbor call out, or simply written what the head of household said. The current informant field (\"Unknown household member reporting to census enumerator\") is accurate.\n\n**B. Proximity?**\n`unknown` \u2014 consistent with the three-layer model lookup table: *Census (any year) | Name | Unknown household member | unknown*. \u2713\n\n**C. Decision tree:**\n> Do we know the informant? **No** \u2192 **Undetermined (indeterminate)**\n\n**Verdict: `indeterminate` is correct.** The existing bias note is also sound \u2014 it correctly distinguishes name facts (where even the act of reporting is uncertain) from age/birthplace facts (where a household member *must* have actively volunteered the information). No change needed in Layer 2.\n\n---\n\n### Layer 3 \u2014 Evidence Type \u26a0\ufe0f Needs correction\n\nThe active research question a_001 is linked to:\n\n> **q_002:** \"Where was Patrick Flynn in the 1850 census?\"\n\nCurrent classification: **`direct`**\n\nApply the definition: *Direct evidence explicitly answers the research question \u2014 the information states the answer outright; no inference is needed.*\n\nDoes **\"Name: Patrick Flynn\"** explicitly answer \"where was he\"? No. The name fact establishes *who* is in this record; it says nothing about location. To extract a location answer from a_001, you must reason:\n\n> *\"A person named Patrick Flynn appears in this record \u2192 this record originates from Schuylkill County, PA \u2192 therefore Patrick was in Schuylkill County in 1850.\"*\n\nThat inference step disqualifies it as direct evidence. The information that *explicitly* answers q_002 is **a_003** (`residence: Schuylkill County, Pennsylvania`). The name fact is a prerequisite for attribution \u2014 it helps confirm the person enumerated is our subject \u2014 but it answers *identity*, not *location*.\n\n**Corrected classification: `indirect`.**\n\n> Compare with a_003 (same record, same question): \"Schuylkill County, Pennsylvania\" explicitly states the location \u2192 `direct`. The contrast confirms the name assertion should be `indirect`.\n\n---\n\n### Evidence Independence (GPS Standard 46)\n\nNote for the record: `a_001` (name from `src_001`, original FamilySearch image) and `a_006` (name from `src_002`, Ancestry index of the same census) share the same underlying informant \u2014 the same unknown household member speaking to the same enumerator. The Ancestry index added no new informant; it only added a transcription layer. These two assertions constitute **one evidence unit** for the name fact and should not be counted as independent corroboration of the name.\n\n---\n\nNow applying the correction to `research.json`:Now validating:I need to run the validation script. Let me first check what files are available, then run the validator via Monitor.Both project files exist. Running the validator:I can't execute shell commands in this environment. Let me read the validation script directly and apply its checks manually.Good \u2014 I have the full script. Since I can't execute it directly, let me trace every check it applies to the modified assertion and the rest of the file.I can trace the full validator logic manually against both files. Here are the relevant checks:\n\n**research.json \u2014 a_001 post-edit:**\n| Check | Value | Result |\n|---|---|---|\n| `id` prefix | `a_001` \u2192 starts with `a_` | \u2713 |\n| `source_id` cross-ref | `src_001` \u2192 exists in sources | \u2713 |\n| `information_quality` enum | `indeterminate` \u2192 in `{primary, secondary, indeterminate}` | \u2713 |\n| `informant_proximity` enum | `unknown` \u2192 in `{self, witness, household_member, family_not_present, official_duty, unknown}` | \u2713 |\n| **`evidence_type` enum** | **`indirect` \u2192 in `{direct, indirect, negative}`** | **\u2713** |\n| `log_entry_id` cross-ref | `log_001` \u2192 exists | \u2713 |\n| `extracted_for_question_ids` cross-ref | `q_002` \u2192 exists | \u2713 |\n| nullable fields (`date`, `date_certainty`, `place`) | `null` | \u2713 |\n\n**tree.gedcomx.json \u2014 unchanged:** All persons (`I1`, `I2`), sources (`S1`\u2013`S4`), relationship (`R1`), fact types (`Birth`, `Death` \u2014 PascalCase), and source refs pass.\n\n**Cross-file:** All `gedcomx_source_description_id` values (`S1`, `S2`, `S3`) resolve \u2713. All `person_id` values in `person_evidence` (`I1`, `I2`) resolve \u2713. `subject_person_ids: [\"I1\"]` resolves \u2713.\n\n**Both project files are valid.** \u2713\n\n---\n\n## Classification Review Summary \u2014 `a_001`\n\n| Layer | Field | Before | After | Verdict |\n|---|---|---|---|---|\n| **Source** | `source_classification` | `original` | *(unchanged)* | \u2713 Correct \u2014 read-only |\n| **Information** | `information_quality` | `indeterminate` | *(unchanged)* | \u2713 Correct |\n| | `informant` | *\"Unknown household member\u2026\"* | *(unchanged)* | \u2713 Correct |\n| | `informant_proximity` | `unknown` | *(unchanged)* | \u2713 Correct |\n| | `informant_bias_notes` | *see file* | *(unchanged)* | \u2713 Sound |\n| **Evidence** | `evidence_type` | `direct` | **`indirect`** | \u26a0 Corrected |\n\n### Why the evidence type changed\n\n`q_002` asks **\"Where** was Patrick Flynn in the 1850 census?\" The name fact `\"Patrick Flynn\"` identifies *who* was enumerated \u2014 it does not state a location. To derive a location answer from `a_001` alone you must reason: *\"This name appears in a record originating from Schuylkill County \u2192 therefore Patrick was in Schuylkill County.\"* That inference step makes it **indirect** evidence for `q_002`. The assertion that *directly* answers the where-question is `a_003` (`residence: Schuylkill County, Pennsylvania`), which states the location outright.\n\n### Evidence independence flag\n\n`a_001` (`src_001`, FamilySearch original image) and `a_006` (`src_002`, Ancestry index of the same image) share the same underlying informant \u2014 the same unknown household member speaking to the same enumerator. The Ancestry entry adds only a transcription layer, no new informant. Per **GPS Standard 46**, these two name assertions form a **single evidence unit** and should receive no more combined weight than the stronger of the two (`a_001`).\n\n### Suggested next steps\n\n- **`citation` skill** \u2014 `src_001`'s citation is already well-formed, but `src_002`'s citation could be tightened to make explicit that it is a derivative index of `src_001`.\n- **`person-evidence` skill** \u2014 `a_001` is linked to `pe_001` (person I1); the current confidence is `confident`, which is appropriate given the identity reasoning in the rationale.",
+            "activated": true,
+            "skills_invoked": [
+              "assertion-classification",
+              "validate-schema"
+            ],
+            "tool_calls": [],
+            "files_created": [],
+            "file_changes": {
+              "research.json": {
+                "sections_modified": [
+                  "assertions"
+                ],
+                "diff": {
+                  "assertions": {
+                    "added": [],
+                    "modified": [
+                      {
+                        "id": "a_001",
+                        "changed_fields": {
+                          "evidence_type": {
+                            "before": "direct",
+                            "after": "indirect"
+                          }
+                        }
+                      }
+                    ],
+                    "deleted": []
+                  }
+                }
+              }
+            }
+          },
+          "validators": {
+            "passed": false,
+            "results": [
+              {
+                "name": "test_id_references_resolve",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_log_append_only",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_entries_deleted",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_research_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tool_allowlist",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_gedcomx_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_a001_preserves_classification",
+                "passed": false,
+                "error": "a_001 evidence_type should be 'direct'; got 'indirect'"
+              },
+              {
+                "name": "test_a012_secondary_family_not_present",
+                "passed": true,
+                "error": "skipped: not an a012-secondary-family-not-present scenario"
+              },
+              {
+                "name": "test_does_not_add_new_assertions",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_mcp_tools_called",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_source_classification_unchanged",
+                "passed": true,
+                "error": null
+              }
+            ]
+          },
+          "judge": {
+            "skipped": true,
+            "dimensions": [],
+            "judge_cost_usd": 0.0,
+            "error": null,
+            "input_tokens": 0,
+            "cached_input_tokens": 0,
+            "output_tokens": 0
+          }
+        }
+      ]
+    }
+  ],
+  "totals": {
+    "duration_ms": 557907.9262999995,
+    "input_tokens": 4265,
+    "cached_input_tokens": 671226,
+    "output_tokens": 24905,
+    "judge_input_tokens": 8642,
+    "judge_cached_input_tokens": 0,
+    "judge_output_tokens": 1327,
+    "skill_cost_usd": 0.9846035500000001,
+    "judge_cost_usd": 0.015277,
+    "total_cost_usd": 0.9998805499999999
+  }
+}

--- a/eval/tests/unit/assertion-classification/reclassify-census-informant.json
+++ b/eval/tests/unit/assertion-classification/reclassify-census-informant.json
@@ -13,6 +13,7 @@
   },
   "judge_context": [
     "Should distinguish the census enumerator (recorder) from the informant — name facts in 1850 censuses don't have an identified informant; the enumerator may have read a sign, asked a neighbor, or asked a household member, and the census doesn't say which",
-    "Should keep `informant_proximity: \"unknown\"` for name facts in the 1850 census (this is the correct conservative classification), OR if the skill argues for `household_member`, the rationale must explain why a name fact specifically requires active reporting (which it doesn't — names can be inferred from a doorplate or neighbor)"
+    "Should keep `informant_proximity: \"unknown\"` for name facts in the 1850 census (this is the correct conservative classification), OR if the skill argues for `household_member`, the rationale must explain why a name fact specifically requires active reporting (which it doesn't — names can be inferred from a doorplate or neighbor)",
+    "Should keep `evidence_type: \"direct\"` for a_001 — the assertion was extracted for q_002 ('Where was Patrick Flynn in the 1850 census?'), and finding Patrick Flynn in the census record IS the direct answer to that question. The name assertion identifies the subject within the record, which directly answers q_002. Changing evidence_type to 'indirect' would be incorrect here."
   ]
 }


### PR DESCRIPTION
## Summary
- Ran assertion-classification skill tests (3 tests) via the eval harness
- Added `evidence_type` guidance to `reclassify-census-informant.json` judge_context — the validator expects `evidence_type: "direct"` for a_001 but the judge_context didn't mention it, causing the LLM to change it to `indirect` without guidance
- Included run log `v1_2026-05-21_08-17-40.json`

## Test Results

| Test | Outcome | Notes |
|------|---------|-------|
| ut_002 (death-cert-secondary-informant) | **pass** | All dimensions scored 3 |
| ut_001 (reclassify-census-informant) | **fail** | LLM changes evidence_type from direct to indirect despite guidance — validator catches it |
| ut_003 (negative-extraction) | **fail** | Routing is correct (activated: false, routed to record-extraction) but LLM judge grades rubric dimensions as 1 on a negative test |

Both failures are LLM-level issues, not fixture/tool issues.

Closes #120