### PR TITLE
Run skill tests: citation (re-run after main update)

### DIFF
--- a/eval/runlogs/unit/citation/v1_2026-05-22_09-22-53.json
+++ b/eval/runlogs/unit/citation/v1_2026-05-22_09-22-53.json
@@ -1,0 +1,660 @@
+{
+  "schema_version": 2,
+  "skill": "citation",
+  "version": 1,
+  "released": false,
+  "releasable": true,
+  "invocation": "skill",
+  "timestamp": "2026-05-22_09-22-53",
+  "harness_version": "0.1.0",
+  "model": "claude-sonnet-4-6",
+  "judge_prompt_hash": "05bca05cc954435b55ffd5cb64e41b1ab060a928181252ed2756374990ab7645",
+  "snapshot": {
+    "plugin/skills/citation/SKILL.md": "---\nname: citation\nmodel: claude-sonnet-4-6\ndescription: Refines source citations to Evidence Explained standards. Updates\n  the citation and citation_detail fields on existing source entries in\n  research.json. GPS Step 2 \u2014 Complete and Accurate Source Citation. Use\n  when the user says \"cite this source\", \"fix citations\", \"format citation\",\n  \"Evidence Explained\", \"improve citations\", \"who what when where\", or when\n  source entries have rough working citations that need polishing. Do NOT\n  use when the user wants to search for records (use search-records), wants\n  to extract assertions from a record (use record-extraction), or wants to\n  classify evidence (use assertion-classification). This skill never creates\n  new source entries \u2014 it only refines entries created by record-extraction.\n---\n\n# Citation\n\n**Narration:** Read `researcher_profile.narration_guidance` from `research.json` and apply it as your narration style for this invocation. If absent, default to a one-line preamble per action.\n\nRefines source citations in `research.json` to meet Evidence Explained\nstandards. record-extraction creates source entries with best-effort\nworking citations; this skill upgrades them to GPS-compliant citations\nthat enable research replication.\n\nLoad `references/gps-citation-standards.md` before beginning work for\nthe full BCG documentation standards (Standards 1-8) and principles.\n\n**The replication test:** Could another researcher find the exact same\nrecord using only your citation? If not, the citation is incomplete.\n\n## The Who/What/When/Where/Wherein Framework (BCG Standard 5)\n\nEvery citation must describe at least four facets of the source, plus\na fifth facet (Wherein) for reference-note citations that document\nspecific facts. These map to the `citation_detail` object:\n\n| Element | Field | What to capture | Example |\n|---------|-------|----------------|---------|\n| **Who** | `who` | The person, agency, or body that CREATED the record -- not the repository that hosts it. If an informant is identified, note them. | \"U.S. Census Bureau\", \"Pennsylvania Department of Health\", \"St. Mary's Catholic Church\" |\n| **What** | `what` | Title or name of the source. If untitled, a clear item-specific description. | \"1850 U.S. Federal Census, population schedule\", \"Death certificate no. 4521\" |\n| **When** | `when_created` | Date the record was created or the event it reports | \"1850\", \"1908-03-14\" |\n| | `when_accessed` | Date the researcher accessed the record (required for online sources) | \"2026-05-04\" |\n| **Where** | `where` | Where the record was VIEWED (cite what you see), then the original repository | \"FamilySearch.org (NARA microfilm M432, roll 810)\", \"Ancestry.com\" |\n| **Wherein** | `where_within` | Specific locator: page, image, entry, certificate, dwelling, family, box, folder number | \"Schuylkill County, dwelling 84, family 91\", \"Certificate no. 4521\", \"Page 12, entry 47\" |\n\n### The \"Cite What You See\" Principle\n\nThe `where` field follows a layered path from access point back to\norigin. The first location is where you actually viewed the record:\n\n1. Access point (FamilySearch.org, Ancestry.com)\n2. Medium (NARA microfilm M432, roll 810)\n3. Original custodian (Schuylkill County Courthouse)\n\n### Collection Citation vs. Document Citation\n\n- **Collection citation**: Identifies the record set as a whole.\n  Appropriate for research planning and negative-search documentation.\n- **Document citation**: Identifies a specific record within the\n  collection. Required when supporting factual claims about individuals.\n\nAlways cite at the document level. The `where_within` field is what\ndistinguishes a document citation from a mere collection reference.\n\n## Steps\n\n### 1. Read existing sources\n\nRead `research.json` and identify source entries needing citation\nrefinement. Prioritize:\n- Sources with incomplete `citation_detail` (missing fields)\n- Sources with rough `citation` strings that don't follow Evidence\n  Explained patterns\n- Sources the user specifically asks about\n\n### 2. Refine citation_detail\n\nFor each source, ensure all six `citation_detail` fields are\ncomplete and accurate:\n\n```json\n{\n  \"who\": \"U.S. Census Bureau\",\n  \"what\": \"1850 U.S. Federal Census, population schedule\",\n  \"when_created\": \"1850\",\n  \"when_accessed\": \"2026-05-04\",\n  \"where\": \"FamilySearch.org (NARA microfilm M432, roll 810)\",\n  \"where_within\": \"Schuylkill County, dwelling 84, family 91\"\n}\n```\n\n**Common problems to fix:**\n- `who` says \"FamilySearch\" \u2014 that's the repository, not the creator.\n  The creator is the agency that produced the original record.\n- `what` is too vague (\"census record\") \u2014 specify the exact title,\n  year, and schedule type.\n- `where_within` is missing \u2014 every citation must include a specific\n  locator. Page numbers, entry numbers, dwelling numbers, certificate\n  numbers, image numbers, microfilm roll numbers.\n- `when_accessed` is missing \u2014 always include the access date for\n  digital sources.\n\n**Fixing auto-generated citations:**\n\nWebsites like FamilySearch and Ancestry provide machine-generated\ncitations that are starting points, not finished products. When\nrefining these, check for:\n- Creator listed as the website rather than the originating agency\n- Only the collection name cited, not the specific document within it\n- Missing locators (volume, page, entry, image numbers visible in\n  the record image)\n- Informant not identified (critical for death certificates)\n- Formatting inconsistent with humanities-style standards\n\n**URL best practices:**\n\n- A URL alone is NEVER a complete citation. URLs break and sites\n  restructure.\n- Shorten query strings: remove everything after the first `?` in\n  FamilySearch and Ancestry URLs. Query parameters contain\n  session-specific search data useless to future researchers.\n- Include the shortened URL as a convenience locator alongside the\n  full descriptive citation, not as a substitute.\n\n### 3. Format the citation string\n\nGenerate the `citation` field following Evidence Explained patterns.\nThe citation is a single formatted string that encodes all five\nelements.\n\n**Template by source type:**\n\n#### Census records\n```\n[YEAR] U.S. Census, [COUNTY], [STATE], population schedule,\n[LOCATOR]; NARA microfilm publication [SERIES], roll [ROLL];\ndigital image, [REPOSITORY], accessed [DATE].\n```\nExample:\n```\n1850 U.S. Census, Schuylkill County, Pennsylvania, population\nschedule, dwelling 84, family 91, Thomas Flynn household; NARA\nmicrofilm publication M432, roll 810; digital image,\nFamilySearch.org, accessed 1 May 2026.\n```\n\n#### Vital records (death certificate)\n```\n[STATE] Department of Health, death certificate no. [NUMBER]\n([YEAR]), [PERSON NAME]; [ARCHIVES], [CITY]; digital image,\n[REPOSITORY], accessed [DATE].\n```\nExample:\n```\nPennsylvania Department of Health, death certificate no. 4521\n(1908), Patrick Flynn; Pennsylvania State Archives, Harrisburg;\ndigital image, FamilySearch.org, accessed 3 May 2026.\n```\n\n#### Vital records (birth certificate)\n```\n[STATE/COUNTY] [OFFICE], birth certificate no. [NUMBER] ([YEAR]),\n[PERSON NAME]; [ARCHIVES/OFFICE], [CITY]; digital image,\n[REPOSITORY], accessed [DATE].\n```\n\n#### Probate records (will)\n```\n[COUNTY] [COURT], [STATE], [DOCUMENT TYPE], [PERSON NAME],\n[DATE]; [BOOK/VOLUME], [PAGE]; [ARCHIVES], [CITY].\n```\nExample:\n```\nSchuylkill County Orphans' Court, Pennsylvania, will of Thomas\nFlynn, 15 March 1881; Will Book 12, p. 247; Schuylkill County\nCourthouse, Pottsville.\n```\n\n#### Church records\n```\n[CHURCH NAME], [CITY/TOWN], [STATE/COUNTRY], [RECORD TYPE],\n[DATE], [PERSON NAME]; [VOLUME/PAGE]; [REPOSITORY].\n```\n\n#### Land records (deed)\n```\n[COUNTY] [OFFICE], [STATE], [DOCUMENT TYPE], [GRANTOR] to\n[GRANTEE], [DATE]; [BOOK], [PAGE]; [REPOSITORY].\n```\n\n#### Newspaper\n```\n\"[ARTICLE TITLE],\" [NEWSPAPER NAME] ([CITY], [STATE]), [DATE],\np. [PAGE], col. [COLUMN]; digital image, [REPOSITORY], accessed\n[DATE].\n```\n\n#### Ancestry/MyHeritage/FindMyPast (derivative index)\n```\n[ORIGINAL RECORD TITLE]; digital index, [SITE].com\n([SITE URL]): accessed [DATE]), [COLLECTION NAME],\n[PERSON NAME] entry.\n```\nExample:\n```\n1850 U.S. Census, Schuylkill County, Pennsylvania, population\nschedule, dwelling 84, Thomas Flynn household; digital index,\nAncestry.com, accessed 1 May 2026.\n```\n\n#### FindAGrave\n```\nFind A Grave, memorial [MEMORIAL NUMBER], [PERSON NAME]\n([DATES]), [CEMETERY NAME], [LOCATION]; digital memorial,\nFindAGrave.com, accessed [DATE].\n```\n\n### 4. Handle special cases\n\n**Negative searches:** When a source was searched but yielded nil\nresults, the citation documents what was searched. The citation\nstring should indicate the scope of the search:\n```\n1870 U.S. Census, Schuylkill County, Pennsylvania, population\nschedule; searched all Smith/Flynn entries, no match found;\nNARA microfilm M593; digital image, FamilySearch.org,\naccessed 2 May 2026.\n```\n\n**User-captured PDFs from external sites:** The citation must\nidentify both the original record and the access method:\n```\n1850 U.S. Census, Schuylkill County, Pennsylvania, population\nschedule, dwelling 84, Thomas Flynn household; digital image,\nAncestry.com (user-captured PDF), accessed 1 May 2026.\n```\n\n**Image transcriptions:** Note that the text was transcribed from\nan image, and whether the transcription was reviewed:\n```\nSt. Mary's Catholic Church, Pottsville, Pennsylvania, baptismal\nregister, 1845, Patrick Flynn entry; transcribed from digital\nimage, FamilySearch.org, accessed 3 May 2026; transcription\nreviewed by user.\n```\n\n### 5. Update source entries\n\nWrite the refined `citation` and `citation_detail` fields back to\n`research.json`. This is an in-place update to existing `src_`\nentries \u2014 never create new source entries.\n\nDo NOT change: `id`, `gedcomx_source_description_id`,\n`source_classification`, `repository`, `access_date`, `url`,\n`url_archived`. These are set by record-extraction.\n\nThe `notes` field may be updated if the citation analysis reveals\nprovenance concerns not previously noted.\n\n### 6. Validate\n\nInvoke `validate-schema` after writing updates.\n\n### 7. Present results\n\nShow the user each refined citation with the formatted string and\nthe structured citation_detail. Highlight any gaps that couldn't\nbe filled (e.g., missing microfilm roll number, unknown creator).\n\n## Terminology guardrail\n\nIf the user says \"primary source\" or \"secondary source,\" gently\ncorrect: sources are classified as Original, Derivative, or Authored.\nThe terms \"primary\" and \"secondary\" apply only to information quality\n(informant proximity), not to sources themselves. Source classification\nis handled by record-extraction, not this skill \u2014 but correct the\nterminology if it appears in a citation string being refined.\n\n## Example\n\n**Before (working citation from record-extraction):**\n```json\n{\n  \"citation\": \"1850 census, Schuylkill Co PA, Thomas Flynn\",\n  \"citation_detail\": {\n    \"who\": \"FamilySearch\",\n    \"what\": \"1850 census\",\n    \"when_created\": \"1850\",\n    \"when_accessed\": \"2026-05-01\",\n    \"where\": \"FamilySearch\",\n    \"where_within\": \"dwelling 84\"\n  }\n}\n```\n\n**After (refined by citation skill):**\n```json\n{\n  \"citation\": \"1850 U.S. Census, Schuylkill County, Pennsylvania, population schedule, dwelling 84, family 91, Thomas Flynn household; NARA microfilm publication M432, roll 810; digital image, FamilySearch.org, accessed 1 May 2026.\",\n  \"citation_detail\": {\n    \"who\": \"U.S. Census Bureau\",\n    \"what\": \"1850 U.S. Federal Census, population schedule\",\n    \"when_created\": \"1850\",\n    \"when_accessed\": \"2026-05-01\",\n    \"where\": \"FamilySearch.org (NARA microfilm M432, roll 810)\",\n    \"where_within\": \"Schuylkill County, dwelling 84, family 91\"\n  }\n}\n```\n\nChanges: `who` corrected from repository to creator, `what` expanded\nto full title, `where` includes both digital and physical repository,\n`where_within` expanded with full locator, `citation` string follows\nEvidence Explained census pattern.\n\n## Decision rules\n\n| Situation | Action |\n|-----------|--------|\n| User provides only a URL | Expand to full citation. A URL alone never constitutes a citation. Use the URL as a convenience locator within the formatted string |\n| Record type has no matching template above | Follow the general pattern: Creator, Record title, specific locator; repository chain; access method and date. Consult Evidence Explained chapter headings for analogous source types |\n| Cannot determine the creator (who) | Use the custodial agency as a fallback and note the uncertainty in `notes`. Never leave `who` blank |\n| Missing locator (where_within) | Flag the gap to the user. Ask if they can check the record image for page/entry/certificate numbers. Do not leave `where_within` empty without explanation |\n| citation_detail fields contradict the citation string | The `citation_detail` fields are the structured truth; regenerate the `citation` string from them |\n| Source was accessed both online and in person | Cite the version you are working from. If the user viewed a digital image, cite the digital access path even if the original is in a courthouse |\n| Multiple informants on one record | This is an extraction/classification concern \u2014 do not address it here. Only note the primary creator in `who` |\n| User asks to classify or assess source quality | Redirect to assertion-classification. This skill formats citations, it does not evaluate evidence weight |\n",
+    "plugin/skills/citation/references/gps-citation-standards.md": "# GPS Citation Standards Reference\n\nThis document summarizes the eight BCG documentation standards and\nsupporting principles for genealogical citation. Use it as a checklist\nwhen refining citations.\n\n## The Eight BCG Documentation Standards\n\n### Standard 1: Scope\n\nCite the source of ALL substantive information and images gathered or\nused. The only exception is \"common knowledge\" that is beyond dispute\n(e.g., the year a major war began). When in doubt, cite it.\n\n### Standard 2: Specificity\n\nEvery statement, fact, image, or conclusion must be connected to its\nsource with enough precision that no reader can wonder \"where did this\ncome from?\" Each parent-child link, each deduction, each piece of\nnon-obvious information requires its own traceable citation.\n\n### Standard 3: Purposes\n\nA citation must enable three things:\n1. Assessment of the source's credibility\n2. Location of the source or image\n3. Understanding of the research scope (what was searched)\n\n### Standard 4: Citation Uses\n\nCitations appear everywhere: research plans, logs, working notes,\nfinished products. In finished products, footnotes are the standard\nplacement. Research logs need full citations for every source consulted,\nwhether or not results were found.\n\n### Standard 5: Citation Elements (Who/What/When/Where/Wherein)\n\nEvery complete citation describes at minimum four facets:\n\n- **Who** -- The person, agency, business, government office, or\n  religious body that authored, created, or was responsible for the\n  source. This is the CREATOR, not the repository. If a specific\n  informant is identified, include them.\n- **What** -- The source's title or name. If untitled, provide a clear,\n  item-specific description.\n- **When** -- The date the source was created, published, last modified,\n  or accessed. For unpublished sources, the event date may substitute.\n- **Where** -- For unpublished sources: the physical repository. For\n  published books/microfilm: the place of publication. For online\n  resources: a stable URL.\n\nReference-note citations (documenting specific facts) add a fifth facet:\n\n- **Wherein** -- The specific location within the source: page number,\n  image number, entry number, certificate number, box number, folder\n  name, dwelling/family number, etc.\n\n### Standard 6: Format\n\nGenealogists use humanities-style citations (footnotes/endnotes plus\nbibliography). The two governing style guides are:\n\n1. **Evidence Explained** (Elizabeth Shown Mills) -- covers the full\n   range of genealogical source types\n2. **The Chicago Manual of Style** -- governs punctuation, capitalization,\n   foreign languages, and general documentation mechanics\n\nOther citation styles (APA, MLA, scientific author-date) are NOT\nstandard for genealogical writing.\n\n### Standard 7: Shortcuts\n\nAfter a source has been cited in full once, subsequent references may\nuse a short-form citation or \"ibid.\" within the same document or\nsection. The full citation must always appear first.\n\n### Standard 8: Separation Safeguards\n\nCitations must not become mechanically or digitally separated from the\nstatements they document. Safeguards include:\n- Footnotes on the same page as the referenced text\n- Metadata embedded in digital image files\n- Citations written on the front of photocopied materials\n- Page numbering showing page X of Y\n- Firmly attached endnote pages\n\n## The \"Cite What You See\" Principle\n\nThe first location in a citation is where the researcher actually viewed\nthe document. If you viewed a digital image on FamilySearch of a\nmicrofilmed county record, the citation path is:\n\n1. FamilySearch (where you saw it) -- the access point\n2. The microfilm publication (the medium)\n3. The original record and its creating office (the origin)\n\nThis layered approach documents the full chain from access point back to\noriginal creation.\n\n## Collection Citation vs. Document Citation\n\n- **Collection citation**: Identifies an entire record set without\n  pointing to a specific person or entry. Used when discussing what a\n  collection contains or its research value.\n- **Document citation**: Identifies a specific record, entry, page, or\n  image within a collection. This is what supports evidence about an\n  individual.\n\nAlways cite at the document level when supporting a factual claim.\nCollection-level citations are appropriate only for research planning\nand negative-search documentation.\n\n## Fixing Auto-Generated Citations\n\nWebsites like FamilySearch and Ancestry provide machine-generated\ncitations. These are starting points, not finished products. Common\ndeficiencies:\n\n- Missing document specifics (just the collection name, not the\n  individual record)\n- Creator listed as the website rather than the originating agency\n- No informant identification\n- Overly long URLs with session-specific query parameters\n- Missing volume, page, entry, or image numbers visible in the record\n- Formatting that does not match humanities-style standards\n\n## URL Best Practices\n\n- A URL alone is NEVER a complete citation. URLs break, sites\n  restructure, and links expire.\n- Shorten query strings: remove everything after the first `?` in\n  FamilySearch and Ancestry URLs. The query portion contains\n  session-specific search parameters that will not help a future\n  researcher locate the record.\n- Include the URL as a convenience locator alongside the full\n  descriptive citation, not as a replacement for it.\n\n## Footnotes vs. Endnotes\n\n- **Footnotes** (bottom of the same page): Preferred in genealogical\n  writing because the reader can immediately check the source without\n  flipping pages.\n- **Endnotes** (grouped at the end): Acceptable but less convenient\n  for the reader.\n\nIn digital research files, footnote-style placement means keeping the\ncitation physically adjacent to or embedded with the claim it supports.\n\n## The Replication Test\n\nThe ultimate measure of a citation's quality: could another researcher,\nusing only the citation, find the exact same record? If the answer is\nno, the citation is incomplete. Missing locators (page numbers, entry\nnumbers, dwelling numbers) are the most common cause of failure.\n\n## Negative Search Citations\n\nWhen a source was searched but yielded no relevant results, the citation\ndocuments what was searched, how it was searched, and the scope of the\nsearch. Negative results are evidence -- they narrow the field and\ndemonstrate thoroughness. The citation format is the same as a positive\nresult, with an added note about the search scope and null outcome.\n",
+    "plugin/skills/citation/references/validation-protocol.md": "# Validation Protocol\n\nAfter writing to `research.json` or `tree.gedcomx.json`, follow these steps:\n\n1. **Invoke `validate-schema`** to verify both files conform to the\n   published schemas. If validation fails, fix the errors before\n   proceeding.\n\n2. **Invoke `check-warnings`** if you added assertions or\n   person_evidence entries. This checks for genealogical\n   impossibilities (married before 12, died after 120, child born\n   after parent's death, etc.).\n\nThese are not auto-triggered \u2014 you must invoke them explicitly.\n",
+    "eval/tests/unit/citation/citation-replication-test.json": "{\n  \"input\": {\n    \"scenario\": \"mid-research-flynn\",\n    \"user_message\": \"Apply the Evidence Explained replication test to the citation for src_004. Could another researcher find the same record with just this citation?\"\n  },\n  \"judge_context\": [\n    \"Should confirm the citation passes the replication test: certificate number 4521 + jurisdiction (Pennsylvania Dept. of Health) + collection name + year (1908) is enough specificity for a researcher to retrieve the exact record\",\n    \"Should identify the locator field: `citation_detail.where_within` should hold the certificate number (4521) \u2014 that's the within-collection identifier for vital records\",\n    \"Should NOT recommend adding redundant detail (page numbers when the citation already has a certificate number) \u2014 over-specifying a citation that already replicates is busywork\",\n    \"Should distinguish source-level classification (original) from information quality at the assertion level (some assertions on the death cert will be primary, others secondary depending on the informant) \u2014 these are independent classifications per research-schema-spec.md \u00a77\"\n  ],\n  \"test\": {\n    \"id\": \"ut_citation_002\",\n    \"skill\": \"citation\",\n    \"type\": \"positive\"\n  }\n}\n",
+    "eval/tests/unit/citation/negative-search-request.json": "{\n  \"input\": {\n    \"scenario\": \"mid-research-flynn\",\n    \"user_message\": \"Find another record I can use to corroborate the 1850 census source.\"\n  },\n  \"judge_context\": [\n    \"Should route to search-records rather than reformatting the existing src_001 citation\"\n  ],\n  \"negative\": {\n    \"correct_skill\": [\n      \"search-records\"\n    ],\n    \"explanation\": \"The user wants to search for more records, not refine the format of an existing citation. citation operates on entries already in research.json's `sources` array. Finding new records is search-records' job; once those records are extracted and a new source entry exists, then citation could be asked to format its citation.\"\n  },\n  \"test\": {\n    \"id\": \"ut_citation_003\",\n    \"skill\": \"citation\",\n    \"type\": \"negative\"\n  }\n}\n",
+    "eval/tests/unit/citation/refine-census-citation.json": "{\n  \"input\": {\n    \"scenario\": \"mid-research-flynn\",\n    \"user_message\": \"Review the citation for source src_001 and make sure it follows Evidence Explained standards.\"\n  },\n  \"judge_context\": [\n    \"Should verify all six citation_detail fields are populated: `who` (U.S. Census Bureau), `what` (1850 U.S. Federal Census, population schedule), `when_created` (1850), `when_accessed`, `where` (FamilySearch.org with the NARA microfilm details), `where_within` (Schuylkill County, dwelling and family numbers)\",\n    \"Should apply the replication test: a researcher with only this citation should be able to find the exact record \u2014 dwelling 84, family 91 is the level of specificity needed\"\n  ],\n  \"test\": {\n    \"id\": \"ut_citation_001\",\n    \"skill\": \"citation\",\n    \"type\": \"positive\"\n  }\n}\n",
+    "eval/tests/unit/citation/rubric.md": "# Citation Rubric\n\nGrading dimensions for citation unit tests. Evaluated by the LLM judge alongside the base rubric (correctness, completeness).\n\n## Evidence Explained compliance\n\nDoes the citation follow the Who/What/When/Where/Where-within framework from Evidence Explained? All five elements should be present and correctly populated.\n\n- **pass:** All five elements present, each populated with specific data appropriate to the source type (NARA microfilm publication for a census; certificate number for a death record).\n- **partial:** Four of five elements present, or all five present but one is generic (\"various records\" instead of the specific collection name).\n- **fail:** Two or more elements missing, or the citation conflates elements (location and repository merged into one field).\n\n## Replication test\n\nCould another researcher find the exact same record using only this citation? The citation must include enough specificity (page, entry, certificate number, microfilm roll) to locate the source.\n\n- **pass:** A genealogist following the citation would arrive at the same record \u2014 page, entry, dwelling number, or equivalent identifier is included.\n- **partial:** Locator information present but coarser than ideal (citation names the right collection and date range but no page/entry number).\n- **fail:** No locator beyond the collection name, or locator pointing to the wrong scope (page number for a record that needs an entry number).\n\n## Source vs information distinction\n\nIs the source classified at the source level (original/derivative/authored), not confused with information quality? A single original source can contain both primary and secondary information.\n\n- **pass:** `source_classification` reflects the source itself (the death certificate is original); information quality is reserved for assertions (the father's name reported by a son-in-law is secondary).\n- **partial:** Source classification mostly right but blurred in one place (a death certificate labeled \"secondary\" because the informant was distant).\n- **fail:** The two layers are systematically conflated, or `source_classification` is omitted.\n",
+    "eval/fixtures/scenarios/mid-research-flynn/README.md": "# mid-research-flynn\n\nPatrick Flynn parentage research, mid-project.\n\n- **Objective:** Identify the parents of Patrick Flynn (b. ~1845, d. 1908)\n- **Questions:** q_001 (parentage, in_progress), q_002 (1850 census placement, resolved)\n- **Plans:** pl_001 (1850 census search, completed), pl_002 (parentage evidence, active)\n- **Log:** 5 entries \u2014 1850 census on FamilySearch/Ancestry/MyHeritage, 1860 census, death cert\n- **Sources:** 4 sources (1850 census FS, 1850 census Ancestry, 1860 census, death cert)\n- **Assertions:** 13 assertions across 4 sources\n- **Person evidence:** 6 links (Patrick \u2192 I1, Thomas \u2192 I2)\n- **Conflicts:** 1 resolved (birthplace: Ireland vs Pennsylvania)\n- **Hypotheses:** h_001 (Thomas is Patrick's father, supported)\n- **Timelines:** t_001 (Patrick, 4 events, 1 gap)\n- **Proof summaries:** ps_001 (parentage, probable)\n- **GedcomX persons:** I1 (Patrick Flynn), I2 (Thomas Flynn)\n- **GedcomX relationships:** R1 (ParentChild, Thomas \u2192 Patrick)\n",
+    "eval/fixtures/scenarios/mid-research-flynn/research.json": "{\n  \"assertions\": [\n    {\n      \"date\": null,\n      \"date_certainty\": null,\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_002\"\n      ],\n      \"fact_type\": \"name\",\n      \"id\": \"a_001\",\n      \"informant\": \"Unknown household member reporting to census enumerator\",\n      \"informant_bias_notes\": \"Census enumerator is the recorder, not the informant. The household member who provided the name is unknown. Proximity is 'unknown' rather than 'household_member' because for names specifically, the enumerator may have read a sign, heard a neighbor, or made an assumption \u2014 the name fact doesn't necessarily require active reporting the way age/birthplace does.\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_001\",\n      \"place\": null,\n      \"record_id\": \"ark:/61903/1:1:MXYZ\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_001\",\n      \"structured_value\": {\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"value\": \"Patrick Flynn\"\n    },\n    {\n      \"date\": \"~1845\",\n      \"date_certainty\": \"estimated\",\n      \"evidence_type\": \"indirect\",\n      \"extracted_for_question_ids\": [\n        \"q_002\"\n      ],\n      \"fact_type\": \"birth\",\n      \"id\": \"a_002\",\n      \"informant\": \"Unknown household member (likely Thomas Flynn or wife)\",\n      \"informant_bias_notes\": \"Age and birthplace require active reporting by a household member \u2014 someone had to tell the enumerator these facts. Proximity is 'household_member' rather than 'unknown' because these facts could only come from someone in the household.\",\n      \"informant_proximity\": \"household_member\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_001\",\n      \"place\": \"Ireland\",\n      \"record_id\": \"ark:/61903/1:1:MXYZ\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_001\",\n      \"structured_value\": {\n        \"place\": \"Ireland\",\n        \"year\": 1845\n      },\n      \"value\": \"age 5\"\n    },\n    {\n      \"date\": \"1850\",\n      \"date_certainty\": \"exact\",\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_002\"\n      ],\n      \"fact_type\": \"residence\",\n      \"id\": \"a_003\",\n      \"informant\": \"Census enumerator (witness to residence by visiting the dwelling)\",\n      \"informant_bias_notes\": \"For residence facts specifically, the enumerator is a direct witness \u2014 they physically visited the dwelling and recorded who lived there. This distinguishes residence from other census facts where the household member is the true informant.\",\n      \"informant_proximity\": \"witness\",\n      \"information_quality\": \"primary\",\n      \"log_entry_id\": \"log_001\",\n      \"place\": \"Schuylkill County, Pennsylvania\",\n      \"record_id\": \"ark:/61903/1:1:MXYZ\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_001\",\n      \"value\": \"Schuylkill County, Pennsylvania\"\n    },\n    {\n      \"date\": \"1850\",\n      \"date_certainty\": \"exact\",\n      \"evidence_type\": \"indirect\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"relationship\",\n      \"id\": \"a_004\",\n      \"informant\": \"Inferred from household structure \u2014 no explicit informant for relationships in 1850 census\",\n      \"informant_bias_notes\": \"1850 census does not state relationships; this assertion is inferred from household position and shared surname, not directly reported by any informant. The relationship is indirect evidence constructed by the researcher, not information provided by a census informant.\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_001\",\n      \"place\": \"Schuylkill County, Pennsylvania\",\n      \"record_id\": \"ark:/61903/1:1:MXYZ\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_001\",\n      \"structured_value\": {\n        \"related_person_role\": \"head_of_household\",\n        \"relationship_type\": \"child_inferred\"\n      },\n      \"value\": \"Listed in household of Thomas Flynn (head), position consistent with child\"\n    },\n    {\n      \"date\": null,\n      \"date_certainty\": null,\n      \"evidence_type\": \"indirect\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"name\",\n      \"id\": \"a_005\",\n      \"informant\": \"Unknown household member (likely Thomas Flynn himself) reporting to census enumerator\",\n      \"informant_bias_notes\": \"Census enumerator is the recorder, not the informant. As head of household, Thomas likely provided his own name, but the 1850 census does not identify the informant.\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_001\",\n      \"place\": null,\n      \"record_id\": \"ark:/61903/1:1:MXYZ\",\n      \"record_role\": \"head_of_household\",\n      \"source_id\": \"src_001\",\n      \"value\": \"Thomas Flynn\"\n    },\n    {\n      \"date\": null,\n      \"date_certainty\": null,\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_002\"\n      ],\n      \"fact_type\": \"name\",\n      \"id\": \"a_006\",\n      \"informant\": \"Ancestry transcriber (derivative of census enumerator)\",\n      \"informant_bias_notes\": \"Derivative index \u2014 transcription errors possible\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_002\",\n      \"place\": null,\n      \"record_id\": \"ancestry:8054:patrick-flynn-1850\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_002\",\n      \"value\": \"Patrick Flynn\"\n    },\n    {\n      \"date\": \"~1845\",\n      \"date_certainty\": \"estimated\",\n      \"evidence_type\": \"indirect\",\n      \"extracted_for_question_ids\": [\n        \"q_002\"\n      ],\n      \"fact_type\": \"birth\",\n      \"id\": \"a_007\",\n      \"informant\": \"Ancestry transcriber (derivative)\",\n      \"informant_bias_notes\": null,\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_002\",\n      \"place\": \"Ireland\",\n      \"record_id\": \"ancestry:8054:patrick-flynn-1850\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_002\",\n      \"value\": \"age 5\"\n    },\n    {\n      \"date\": null,\n      \"date_certainty\": null,\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"name\",\n      \"id\": \"a_008\",\n      \"informant\": \"Unknown household member reporting to census enumerator\",\n      \"informant_bias_notes\": \"Census enumerator is the recorder, not the informant. Proximity is 'unknown' for names (same reasoning as a_001 \u2014 name facts don't necessarily require active reporting).\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_004\",\n      \"place\": null,\n      \"record_id\": \"ark:/61903/1:1:MABC\",\n      \"record_role\": \"child_2\",\n      \"source_id\": \"src_003\",\n      \"value\": \"Patrick Flynn\"\n    },\n    {\n      \"date\": \"~1845\",\n      \"date_certainty\": \"estimated\",\n      \"evidence_type\": \"indirect\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"birth\",\n      \"id\": \"a_009\",\n      \"informant\": \"Unknown household member (likely Thomas Flynn or wife)\",\n      \"informant_bias_notes\": \"Age and birthplace require active reporting by a household member (same reasoning as a_002).\",\n      \"informant_proximity\": \"household_member\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_004\",\n      \"place\": \"Ireland\",\n      \"record_id\": \"ark:/61903/1:1:MABC\",\n      \"record_role\": \"child_2\",\n      \"source_id\": \"src_003\",\n      \"value\": \"age 15\"\n    },\n    {\n      \"date\": \"1860\",\n      \"date_certainty\": \"exact\",\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"relationship\",\n      \"id\": \"a_010\",\n      \"informant\": \"Household member (likely Thomas Flynn or wife) reporting to census enumerator\",\n      \"informant_bias_notes\": \"1860 census states relationships explicitly, unlike 1850. The informant is the household member who answered the enumerator's questions, not the enumerator himself \u2014 the enumerator is the recorder, not the informant. The household member (likely Thomas or wife) is a direct witness to the relationship, so primary information is defensible.\",\n      \"informant_proximity\": \"household_member\",\n      \"information_quality\": \"primary\",\n      \"log_entry_id\": \"log_004\",\n      \"place\": \"Schuylkill County, Pennsylvania\",\n      \"record_id\": \"ark:/61903/1:1:MABC\",\n      \"record_role\": \"child_2\",\n      \"source_id\": \"src_003\",\n      \"structured_value\": {\n        \"related_person_role\": \"head_of_household\",\n        \"relationship_type\": \"son\"\n      },\n      \"value\": \"Listed as 'son' in household of Thomas Flynn (head)\"\n    },\n    {\n      \"date\": \"1908-03-12\",\n      \"date_certainty\": \"exact\",\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [],\n      \"fact_type\": \"death\",\n      \"id\": \"a_011\",\n      \"informant\": \"Attending physician (signature on certificate)\",\n      \"informant_bias_notes\": null,\n      \"informant_proximity\": \"witness\",\n      \"information_quality\": \"primary\",\n      \"log_entry_id\": \"log_005\",\n      \"place\": \"Schuylkill County, Pennsylvania\",\n      \"record_id\": \"ark:/61903/1:1:MDEF\",\n      \"record_role\": \"deceased\",\n      \"source_id\": \"src_004\",\n      \"value\": \"Died 12 March 1908\"\n    },\n    {\n      \"date\": \"1845\",\n      \"date_certainty\": \"approximate\",\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"birth\",\n      \"id\": \"a_012\",\n      \"informant\": \"James Brown (son-in-law)\",\n      \"informant_bias_notes\": \"Son-in-law reporting birth facts decades after the event. Note: death cert says Pennsylvania, but census records say Ireland. Son-in-law may not have known Patrick was born in Ireland.\",\n      \"informant_proximity\": \"family_not_present\",\n      \"information_quality\": \"secondary\",\n      \"log_entry_id\": \"log_005\",\n      \"place\": \"Pennsylvania\",\n      \"record_id\": \"ark:/61903/1:1:MDEF\",\n      \"record_role\": \"deceased\",\n      \"source_id\": \"src_004\",\n      \"structured_value\": {\n        \"place\": \"Pennsylvania\",\n        \"year\": 1845\n      },\n      \"value\": \"Born 1845, Pennsylvania\"\n    },\n    {\n      \"date\": null,\n      \"date_certainty\": null,\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"relationship\",\n      \"id\": \"a_013\",\n      \"informant\": \"James Brown (son-in-law)\",\n      \"informant_bias_notes\": \"Secondary information \u2014 son-in-law reporting what he was told about father-in-law's parentage\",\n      \"informant_proximity\": \"family_not_present\",\n      \"information_quality\": \"secondary\",\n      \"log_entry_id\": \"log_005\",\n      \"place\": null,\n      \"record_id\": \"ark:/61903/1:1:MDEF\",\n      \"record_role\": \"deceased\",\n      \"source_id\": \"src_004\",\n      \"structured_value\": {\n        \"related_person_role\": \"deceased\",\n        \"relationship_type\": \"father\"\n      },\n      \"value\": \"Father: Thomas Flynn\"\n    }\n  ],\n  \"conflicts\": [\n    {\n      \"blocks_question_ids\": [],\n      \"competing_assertion_ids\": [\n        \"a_002\",\n        \"a_009\",\n        \"a_012\"\n      ],\n      \"conflict_type\": \"fact\",\n      \"description\": \"Patrick Flynn's birthplace: Ireland (1850 and 1860 censuses) vs. Pennsylvania (1908 death certificate)\",\n      \"disputed_attribute\": \"birthplace\",\n      \"id\": \"c_001\",\n      \"identity_question\": null,\n      \"independence_analysis\": \"The two census records (1850, 1860) are independent original sources with different enumerators. The death certificate is a third independent original source. However, the census informants are likely the same household member (Thomas Flynn or wife), so the two census assertions may share a single informant \u2014 potentially not fully independent for this fact.\",\n      \"preferred_assertion_id\": \"a_002\",\n      \"resolution_rationale\": \"Ireland is accepted as the birthplace. The 1908 death certificate birthplace of 'Pennsylvania' is rejected as a likely error by the son-in-law informant, who may have confused Patrick's place of residence with his place of birth, or may not have known Patrick was born in Ireland before immigrating as a young child.\",\n      \"status\": \"resolved\",\n      \"weighing_analysis\": \"The census records are contemporary recordings made near the time of Patrick's birth, while the death certificate was created 63 years later. The census informant was likely a household member with firsthand knowledge (primary or indeterminate), while the death certificate informant (son-in-law) is clearly secondary for birth facts. Two contemporary sources outweigh one later recollection by a secondary informant.\"\n    }\n  ],\n  \"hypotheses\": [\n    {\n      \"claim\": \"Patrick Flynn's father was Thomas Flynn of Schuylkill County, Pennsylvania\",\n      \"contradicting_assertion_ids\": [],\n      \"id\": \"h_001\",\n      \"notes\": \"Three independent pieces of evidence: 1850 census co-enumeration (indirect), 1860 census explicit 'son' relationship (direct), death certificate naming Thomas as father (direct, secondary informant). Awaiting probate records for additional confirmation.\",\n      \"related_question_ids\": [\n        \"q_001\"\n      ],\n      \"ruled_out\": false,\n      \"ruled_out_reason\": null,\n      \"status\": \"supported\",\n      \"supporting_assertion_ids\": [\n        \"a_004\",\n        \"a_010\",\n        \"a_013\"\n      ]\n    }\n  ],\n  \"log\": [\n    {\n      \"external_site\": null,\n      \"id\": \"log_001\",\n      \"notes\": \"Found Patrick Flynn age 5 in household of Thomas Flynn, dwelling 84, Schuylkill Co. Three other Flynn results examined \u2014 ages and locations don't match.\",\n      \"outcome\": \"positive\",\n      \"performed\": \"2026-05-01T10:15:00Z\",\n      \"plan_item_id\": \"pli_001\",\n      \"query\": {\n        \"birth_place\": \"Pennsylvania\",\n        \"birth_year\": 1845,\n        \"collection\": \"1850 Census\",\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"results_examined\": 8,\n      \"tool\": \"record_search\"\n    },\n    {\n      \"external_site\": {\n        \"capture_filename\": \"ancestry-1850-flynn-results.pdf\",\n        \"capture_received\": true,\n        \"site\": \"ancestry\",\n        \"url_generated\": \"https://www.ancestry.com/search/collections/8054/?name=Patrick_Flynn&birth=1845&birthplace=Pennsylvania\"\n      },\n      \"id\": \"log_002\",\n      \"notes\": \"Ancestry index confirms same household. Transcription matches FamilySearch except Ancestry reads dwelling as 84, FamilySearch as 84 \u2014 consistent.\",\n      \"outcome\": \"positive\",\n      \"performed\": \"2026-05-01T11:30:00Z\",\n      \"plan_item_id\": \"pli_002\",\n      \"query\": {\n        \"birth_place\": \"Pennsylvania\",\n        \"birth_year\": 1845,\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"results_examined\": 12,\n      \"tool\": \"external_site\"\n    },\n    {\n      \"external_site\": {\n        \"capture_filename\": \"myheritage-1850-flynn-nil.pdf\",\n        \"capture_received\": true,\n        \"site\": \"myheritage\",\n        \"url_generated\": \"https://www.myheritage.com/research?action=query&first=Patrick&last=Flynn&birth_year=1845&birth_place=Pennsylvania\"\n      },\n      \"id\": \"log_003\",\n      \"notes\": \"MyHeritage returned no results for Patrick Flynn in 1850 Schuylkill County. Site may not have this collection indexed. Searched broader Pennsylvania \u2014 still no match.\",\n      \"outcome\": \"negative\",\n      \"performed\": \"2026-05-01T14:00:00Z\",\n      \"plan_item_id\": \"pli_003\",\n      \"query\": {\n        \"birth_place\": \"Pennsylvania\",\n        \"birth_year\": 1845,\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"results_examined\": 0,\n      \"tool\": \"external_site\"\n    },\n    {\n      \"external_site\": null,\n      \"id\": \"log_004\",\n      \"notes\": \"Patrick Flynn age 15 in household of Thomas Flynn, Schuylkill Co. Consistent with 1850 placement.\",\n      \"outcome\": \"positive\",\n      \"performed\": \"2026-05-02T09:00:00Z\",\n      \"plan_item_id\": \"pli_004\",\n      \"query\": {\n        \"birth_place\": \"Pennsylvania\",\n        \"birth_year\": 1845,\n        \"collection\": \"1860 Census\",\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"results_examined\": 5,\n      \"tool\": \"record_search\"\n    },\n    {\n      \"external_site\": null,\n      \"id\": \"log_005\",\n      \"notes\": \"Death certificate found. Names Thomas Flynn as father. Informant was son-in-law James Brown.\",\n      \"outcome\": \"positive\",\n      \"performed\": \"2026-05-03T10:00:00Z\",\n      \"plan_item_id\": \"pli_005\",\n      \"query\": {\n        \"death_place\": \"Schuylkill County, Pennsylvania\",\n        \"death_year\": 1908,\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"results_examined\": 2,\n      \"tool\": \"record_search\"\n    }\n  ],\n  \"person_evidence\": [\n    {\n      \"assertion_id\": \"a_001\",\n      \"confidence\": \"confident\",\n      \"created\": \"2026-05-01\",\n      \"id\": \"pe_001\",\n      \"match_score\": null,\n      \"person_id\": \"I1\",\n      \"rationale\": \"Name matches (Patrick Flynn), age consistent with ~1845 birth, located in Schuylkill County where subject is known to have lived. Only Patrick Flynn of this age in the county in 1850.\",\n      \"superseded_by\": null\n    },\n    {\n      \"assertion_id\": \"a_004\",\n      \"confidence\": \"probable\",\n      \"created\": \"2026-05-01\",\n      \"id\": \"pe_002\",\n      \"match_score\": null,\n      \"person_id\": \"I1\",\n      \"rationale\": \"Same record as pe_001, same person. Household position and shared surname with head Thomas Flynn suggest parent-child relationship, but 1850 census does not state relationships explicitly.\",\n      \"superseded_by\": null\n    },\n    {\n      \"assertion_id\": \"a_004\",\n      \"confidence\": \"probable\",\n      \"created\": \"2026-05-01\",\n      \"id\": \"pe_006\",\n      \"match_score\": null,\n      \"person_id\": \"I2\",\n      \"rationale\": \"Same assertion as pe_002 but linked to Thomas Flynn (I2). The relationship assertion ('position consistent with child') equally bears on the head of household. Thomas Flynn is the other party in the implied parent-child relationship.\",\n      \"superseded_by\": null\n    },\n    {\n      \"assertion_id\": \"a_005\",\n      \"confidence\": \"probable\",\n      \"created\": \"2026-05-01\",\n      \"id\": \"pe_003\",\n      \"match_score\": 0.82,\n      \"person_id\": \"I2\",\n      \"rationale\": \"Thomas Flynn, head of household where Patrick was found. Age (~32 in 1850, born ~1818) is consistent with being Patrick's father. Name matches candidate father.\",\n      \"superseded_by\": null\n    },\n    {\n      \"assertion_id\": \"a_010\",\n      \"confidence\": \"confident\",\n      \"created\": \"2026-05-02\",\n      \"id\": \"pe_004\",\n      \"match_score\": null,\n      \"person_id\": \"I1\",\n      \"rationale\": \"Patrick Flynn age 15 in Thomas Flynn household, 1860 census. Same county, age consistent with 1850 enumeration. 1860 census explicitly states relationship as 'son'.\",\n      \"superseded_by\": null\n    },\n    {\n      \"assertion_id\": \"a_013\",\n      \"confidence\": \"confident\",\n      \"created\": \"2026-05-03\",\n      \"id\": \"pe_005\",\n      \"match_score\": null,\n      \"person_id\": \"I1\",\n      \"rationale\": \"Death certificate for Patrick Flynn, d. 1908, Schuylkill County. Names match, death location matches known residence. Names Thomas Flynn as father.\",\n      \"superseded_by\": null\n    }\n  ],\n  \"plans\": [\n    {\n      \"created\": \"2026-05-01\",\n      \"id\": \"pl_001\",\n      \"items\": [\n        {\n          \"date_range\": \"1850\",\n          \"fallback_for\": null,\n          \"id\": \"pli_001\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"1850 census fully indexed on FamilySearch. Free access, start here.\",\n          \"record_type\": \"census\",\n          \"repository\": \"FamilySearch\",\n          \"sequence\": 1,\n          \"status\": \"completed\"\n        },\n        {\n          \"date_range\": \"1850\",\n          \"fallback_for\": null,\n          \"id\": \"pli_002\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"Ancestry has independent indexing; cross-check for transcription errors.\",\n          \"record_type\": \"census\",\n          \"repository\": \"Ancestry\",\n          \"sequence\": 2,\n          \"status\": \"completed\"\n        },\n        {\n          \"date_range\": \"1850\",\n          \"fallback_for\": null,\n          \"id\": \"pli_003\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"Third independent index for coverage confirmation.\",\n          \"record_type\": \"census\",\n          \"repository\": \"MyHeritage\",\n          \"sequence\": 3,\n          \"status\": \"completed\"\n        }\n      ],\n      \"question_id\": \"q_002\",\n      \"status\": \"completed\"\n    },\n    {\n      \"created\": \"2026-05-02\",\n      \"id\": \"pl_002\",\n      \"items\": [\n        {\n          \"date_range\": \"1860\",\n          \"fallback_for\": null,\n          \"id\": \"pli_004\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"Confirm Patrick still in Thomas Flynn household in 1860. Strengthens parent-child identification.\",\n          \"record_type\": \"census\",\n          \"repository\": \"FamilySearch\",\n          \"sequence\": 1,\n          \"status\": \"completed\"\n        },\n        {\n          \"date_range\": \"1908\",\n          \"fallback_for\": null,\n          \"id\": \"pli_005\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"Death certificate may name parents directly.\",\n          \"record_type\": \"vital_record\",\n          \"repository\": \"FamilySearch\",\n          \"sequence\": 2,\n          \"status\": \"completed\"\n        },\n        {\n          \"date_range\": \"1870-1890\",\n          \"fallback_for\": null,\n          \"id\": \"pli_006\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"Thomas Flynn probate/will may name Patrick as son.\",\n          \"record_type\": \"probate\",\n          \"repository\": \"FamilySearch\",\n          \"sequence\": 3,\n          \"status\": \"in_progress\"\n        }\n      ],\n      \"question_id\": \"q_001\",\n      \"status\": \"active\"\n    }\n  ],\n  \"project\": {\n    \"created\": \"2026-05-01\",\n    \"id\": \"rp_001\",\n    \"objective\": \"Identify the parents of Patrick Flynn, born ca. 1845 in Pennsylvania, died 1908 in Schuylkill County, PA\",\n    \"status\": \"active\",\n    \"subject_person_ids\": [\n      \"I1\"\n    ],\n    \"updated\": \"2026-05-04\"\n  },\n  \"proof_summaries\": [\n    {\n      \"exhaustive_search_summary\": \"Searched 1850 census (FamilySearch, Ancestry, MyHeritage \u2014 log_001, log_002, log_003), 1860 census (FamilySearch \u2014 log_004), and death certificate (FamilySearch \u2014 log_005). Probate search in progress. 1870, 1880, and 1900 censuses not yet searched.\",\n      \"id\": \"ps_001\",\n      \"narrative_markdown\": \"## Parentage of Patrick Flynn (ca. 1845\u20131908)\\n\\nPatrick Flynn is **Probably** the son of Thomas Flynn of Schuylkill County, Pennsylvania.\\n\\n### Evidence Summary\\n\\nThree independent lines of evidence support this conclusion:\\n\\n1. **1850 U.S. Census** (Original Source). Patrick Flynn, age 5, born Ireland, appears in the household of Thomas Flynn, age 32, born Ireland, in Schuylkill County, Pennsylvania (dwelling 84, family 91). The 1850 census does not state relationships, but Patrick's position in the household and shared surname are consistent with a parent-child relationship. The informant is indeterminate but likely a household member. This constitutes indirect evidence of parentage.\\n\\n2. **1860 U.S. Census** (Original Source). Patrick Flynn, age 15, born Ireland, appears as \\\"son\\\" in the household of Thomas Flynn in Schuylkill County (dwelling 112, family 119). Unlike the 1850 census, the 1860 census explicitly states the relationship. The household member who answered the enumerator's questions \u2014 likely Thomas Flynn or his wife \u2014 was a direct witness to the parent-child relationship, making this primary information. This constitutes direct evidence of parentage.\\n\\n3. **1908 Death Certificate** (Original Source). Patrick Flynn's death certificate (no. 4521, Pennsylvania Department of Health) names \\\"Thomas Flynn\\\" as his father. The informant was James Brown, identified as Patrick's son-in-law. As a son-in-law reporting his father-in-law's parentage, Brown is a secondary informant for this fact \u2014 he was not a witness to Patrick's birth and is reporting what he was told. Nevertheless, this is direct evidence naming the father.\\n\\n### Conflict Resolution\\n\\nA birthplace conflict exists: the 1850 and 1860 censuses list Patrick's birthplace as Ireland, while the 1908 death certificate states Pennsylvania. The two census records are contemporary recordings with informants likely present in the household, while the death certificate was created 63 years after Patrick's birth by a son-in-law with no firsthand knowledge of the event. Per the GPS preponderance hierarchy, contemporary recordings by closer informants outweigh later recollections by secondary informants. Ireland is accepted as the birthplace; the death certificate entry is attributed to informant error.\\n\\n### Assessment\\n\\nThe conclusion is rated **Probable** rather than **Proved** because: (a) the 1850 census evidence is indirect (relationships not stated), (b) the death certificate informant is secondary, and (c) research is not yet exhaustive \u2014 the 1870, 1880, and 1900 censuses have not been searched, and Thomas Flynn's probate records have not been located. If Thomas Flynn's will names Patrick as a son, or if additional census records confirm the relationship, the conclusion would advance to **Proved**.\\n\\n### Citations\\n\\n1. 1850 U.S. Census, Schuylkill County, Pennsylvania, population schedule, dwelling 84, family 91, Thomas Flynn household; NARA microfilm publication M432, roll 810; digital image, FamilySearch.org, accessed 1 May 2026.\\n2. 1860 U.S. Census, Schuylkill County, Pennsylvania, population schedule, dwelling 112, family 119, Thomas Flynn household; NARA microfilm publication M653, roll 1141; digital image, FamilySearch.org, accessed 2 May 2026.\\n3. Pennsylvania Department of Health, death certificate no. 4521 (1908), Patrick Flynn; Pennsylvania State Archives, Harrisburg; digital image, FamilySearch.org, accessed 3 May 2026.\",\n      \"question_id\": \"q_001\",\n      \"resolved_conflict_ids\": [\n        \"c_001\"\n      ],\n      \"supporting_assertion_ids\": [\n        \"a_004\",\n        \"a_010\",\n        \"a_013\"\n      ],\n      \"tier\": \"probable\",\n      \"vehicle\": \"summary\"\n    }\n  ],\n  \"questions\": [\n    {\n      \"created\": \"2026-05-01\",\n      \"depends_on\": [],\n      \"exhaustive_declaration\": {\n        \"declared\": false,\n        \"justification\": null,\n        \"log_entry_ids\": [],\n        \"stop_criteria\": null\n      },\n      \"id\": \"q_001\",\n      \"priority\": \"high\",\n      \"question\": \"Who were the parents of Patrick Flynn (b. ~1845, PA, d. 1908)?\",\n      \"rationale\": \"This is the primary research objective.\",\n      \"resolution_assertion_ids\": [],\n      \"resolved\": null,\n      \"selection_basis\": \"objective_decomposition\",\n      \"status\": \"in_progress\",\n      \"unblocks\": []\n    },\n    {\n      \"created\": \"2026-05-01\",\n      \"depends_on\": [],\n      \"exhaustive_declaration\": {\n        \"declared\": true,\n        \"justification\": \"Searched 1850 census for Schuylkill County on FamilySearch (indexed and browse), Ancestry (indexed), and MyHeritage (indexed). All three returned the same household. No other Patrick Flynn of matching age found in the county.\",\n        \"log_entry_ids\": [\n          \"log_001\",\n          \"log_002\",\n          \"log_003\"\n        ],\n        \"stop_criteria\": {\n          \"conflict_resolution\": \"No conflicts on the 1850 census placement question.\",\n          \"evidence_class\": \"Yes \u2014 FamilySearch provides original census image with indeterminate-quality information.\",\n          \"goal_alignment\": \"Yes \u2014 Patrick Flynn located in a specific 1850 household, answering the question.\",\n          \"independent_verification\": \"FamilySearch (original) and Ancestry (derivative) both return the same household. Two access paths, one underlying original.\",\n          \"original_substitution\": \"FamilySearch provides the original census image; Ancestry index is derivative but confirmed consistent.\",\n          \"overturn_risk\": \"Low \u2014 all three repositories agree, and no competing Patrick Flynn of matching age exists in the county.\",\n          \"repository_breadth\": \"Three major repositories searched (FamilySearch, Ancestry, MyHeritage). No additional known indexes of the 1850 Schuylkill County census exist.\"\n        }\n      },\n      \"id\": \"q_002\",\n      \"priority\": \"high\",\n      \"question\": \"Where was Patrick Flynn in the 1850 census?\",\n      \"rationale\": \"The 1850 census is the earliest enumeration where Patrick would appear by name (age ~5). Locating him in a household identifies candidate parents.\",\n      \"resolution_assertion_ids\": [\n        \"a_001\",\n        \"a_002\",\n        \"a_003\"\n      ],\n      \"resolved\": \"2026-05-02\",\n      \"selection_basis\": \"objective_decomposition\",\n      \"status\": \"resolved\",\n      \"unblocks\": [\n        \"q_001\"\n      ]\n    }\n  ],\n  \"sources\": [\n    {\n      \"access_date\": \"2026-05-01\",\n      \"citation\": \"1850 U.S. Census, Schuylkill County, Pennsylvania, population schedule, dwelling 84, family 91, Thomas Flynn household; NARA microfilm publication M432, roll 810; digital image, FamilySearch.org, accessed 1 May 2026.\",\n      \"citation_detail\": {\n        \"what\": \"1850 U.S. Federal Census, population schedule\",\n        \"when_accessed\": \"2026-05-01\",\n        \"when_created\": \"1850\",\n        \"where\": \"FamilySearch.org (NARA microfilm M432, roll 810)\",\n        \"where_within\": \"Schuylkill County, dwelling 84, family 91\",\n        \"who\": \"U.S. Census Bureau\"\n      },\n      \"gedcomx_source_description_id\": \"S1\",\n      \"id\": \"src_001\",\n      \"log_entry_id\": \"log_001\",\n      \"notes\": \"Image quality good. Enumerator handwriting clear.\",\n      \"repository\": \"FamilySearch\",\n      \"source_classification\": \"original\",\n      \"url\": \"https://www.familysearch.org/ark:/61903/1:1:MXYZ\",\n      \"url_archived\": null\n    },\n    {\n      \"access_date\": \"2026-05-01\",\n      \"citation\": \"1850 U.S. Census, Schuylkill County, Pennsylvania, population schedule, dwelling 84, Thomas Flynn household; digital image, Ancestry.com, accessed 1 May 2026.\",\n      \"citation_detail\": {\n        \"what\": \"1850 U.S. Federal Census, population schedule (Ancestry index)\",\n        \"when_accessed\": \"2026-05-01\",\n        \"when_created\": \"1850\",\n        \"where\": \"Ancestry.com\",\n        \"where_within\": \"Schuylkill County, dwelling 84\",\n        \"who\": \"U.S. Census Bureau\"\n      },\n      \"gedcomx_source_description_id\": \"S1\",\n      \"id\": \"src_002\",\n      \"log_entry_id\": \"log_002\",\n      \"notes\": \"Ancestry's index of the same original census. Transcription consistent with FamilySearch.\",\n      \"repository\": \"Ancestry\",\n      \"source_classification\": \"derivative\",\n      \"url\": null,\n      \"url_archived\": null\n    },\n    {\n      \"access_date\": \"2026-05-02\",\n      \"citation\": \"1860 U.S. Census, Schuylkill County, Pennsylvania, population schedule, dwelling 112, family 119, Thomas Flynn household; NARA microfilm publication M653, roll 1141; digital image, FamilySearch.org, accessed 2 May 2026.\",\n      \"citation_detail\": {\n        \"what\": \"1860 U.S. Federal Census, population schedule\",\n        \"when_accessed\": \"2026-05-02\",\n        \"when_created\": \"1860\",\n        \"where\": \"FamilySearch.org (NARA microfilm M653, roll 1141)\",\n        \"where_within\": \"Schuylkill County, dwelling 112, family 119\",\n        \"who\": \"U.S. Census Bureau\"\n      },\n      \"gedcomx_source_description_id\": \"S2\",\n      \"id\": \"src_003\",\n      \"log_entry_id\": \"log_004\",\n      \"notes\": null,\n      \"repository\": \"FamilySearch\",\n      \"source_classification\": \"original\",\n      \"url\": \"https://www.familysearch.org/ark:/61903/1:1:MABC\",\n      \"url_archived\": null\n    },\n    {\n      \"access_date\": \"2026-05-03\",\n      \"citation\": \"Pennsylvania Department of Health, death certificate no. 4521 (1908), Patrick Flynn; Pennsylvania State Archives, Harrisburg; digital image, FamilySearch.org, accessed 3 May 2026.\",\n      \"citation_detail\": {\n        \"what\": \"Death certificate no. 4521\",\n        \"when_accessed\": \"2026-05-03\",\n        \"when_created\": \"1908-03-14\",\n        \"where\": \"FamilySearch.org (Pennsylvania State Archives, Harrisburg)\",\n        \"where_within\": \"Certificate no. 4521\",\n        \"who\": \"Pennsylvania Department of Health; informant: James Brown (son-in-law)\"\n      },\n      \"gedcomx_source_description_id\": \"S3\",\n      \"id\": \"src_004\",\n      \"log_entry_id\": \"log_005\",\n      \"notes\": \"Informant is son-in-law James Brown. Primary for death facts, secondary for birth facts.\",\n      \"repository\": \"FamilySearch\",\n      \"source_classification\": \"original\",\n      \"url\": \"https://www.familysearch.org/ark:/61903/1:1:MDEF\",\n      \"url_archived\": null\n    }\n  ],\n  \"timelines\": [\n    {\n      \"events\": [\n        {\n          \"assertion_ids\": [\n            \"a_002\",\n            \"a_009\"\n          ],\n          \"date\": \"~1845\",\n          \"date_certainty\": \"estimated\",\n          \"description\": \"Born in Ireland, estimated from census ages\",\n          \"event_type\": \"birth\",\n          \"place\": \"Ireland\"\n        },\n        {\n          \"assertion_ids\": [\n            \"a_003\",\n            \"a_004\"\n          ],\n          \"date\": \"1850\",\n          \"date_certainty\": \"exact\",\n          \"description\": \"Enumerated age 5 in Thomas Flynn household, dwelling 84\",\n          \"event_type\": \"census\",\n          \"place\": \"Schuylkill County, Pennsylvania\"\n        },\n        {\n          \"assertion_ids\": [\n            \"a_008\",\n            \"a_009\",\n            \"a_010\"\n          ],\n          \"date\": \"1860\",\n          \"date_certainty\": \"exact\",\n          \"description\": \"Enumerated age 15 as son in Thomas Flynn household, dwelling 112\",\n          \"event_type\": \"census\",\n          \"place\": \"Schuylkill County, Pennsylvania\"\n        },\n        {\n          \"assertion_ids\": [\n            \"a_011\",\n            \"a_013\"\n          ],\n          \"date\": \"1908-03-12\",\n          \"date_certainty\": \"exact\",\n          \"description\": \"Died, death certificate names Thomas Flynn as father\",\n          \"event_type\": \"death\",\n          \"place\": \"Schuylkill County, Pennsylvania\"\n        }\n      ],\n      \"gaps\": [\n        {\n          \"end\": \"1908-03-12\",\n          \"expected_events\": [\n            \"marriage\",\n            \"1870_census\",\n            \"1880_census\",\n            \"1900_census\",\n            \"residence\",\n            \"occupation\"\n          ],\n          \"severity\": \"high\",\n          \"start\": \"1860-01-01\"\n        }\n      ],\n      \"generated\": \"2026-05-03T12:00:00Z\",\n      \"hypothesis_id\": \"h_001\",\n      \"id\": \"t_001\",\n      \"impossibilities\": [],\n      \"label\": \"Patrick Flynn \u2014 assuming Thomas Flynn parentage\",\n      \"person_ids\": [\n        \"I1\"\n      ]\n    }\n  ]\n}\n",
+    "eval/fixtures/scenarios/mid-research-flynn/tree.gedcomx.json": "{\n  \"persons\": [\n    {\n      \"facts\": [\n        {\n          \"date\": \"~1845\",\n          \"id\": \"F1\",\n          \"place\": \"Ireland\",\n          \"primary\": true,\n          \"sources\": [\n            {\n              \"page\": \"1850 Census, Schuylkill Co., dwelling 84\",\n              \"ref\": \"S1\"\n            }\n          ],\n          \"type\": \"Birth\"\n        },\n        {\n          \"date\": \"1908-03-12\",\n          \"id\": \"F2\",\n          \"place\": \"Schuylkill County, Pennsylvania\",\n          \"sources\": [\n            {\n              \"page\": \"Death cert. no. 4521\",\n              \"ref\": \"S3\"\n            }\n          ],\n          \"type\": \"Death\"\n        }\n      ],\n      \"gender\": \"Male\",\n      \"id\": \"I1\",\n      \"names\": [\n        {\n          \"given\": \"Patrick\",\n          \"id\": \"N1\",\n          \"preferred\": true,\n          \"surname\": \"Flynn\",\n          \"type\": \"BirthName\"\n        }\n      ]\n    },\n    {\n      \"facts\": [\n        {\n          \"date\": \"~1818\",\n          \"id\": \"F3\",\n          \"place\": \"Ireland\",\n          \"primary\": true,\n          \"type\": \"Birth\"\n        }\n      ],\n      \"gender\": \"Male\",\n      \"id\": \"I2\",\n      \"names\": [\n        {\n          \"given\": \"Thomas\",\n          \"id\": \"N2\",\n          \"preferred\": true,\n          \"surname\": \"Flynn\",\n          \"type\": \"BirthName\"\n        }\n      ]\n    }\n  ],\n  \"relationships\": [\n    {\n      \"child\": \"I1\",\n      \"id\": \"R1\",\n      \"parent\": \"I2\",\n      \"sources\": [\n        {\n          \"page\": \"1850 Census, Schuylkill Co., dwelling 84\",\n          \"quality\": 2,\n          \"ref\": \"S1\"\n        },\n        {\n          \"page\": \"1860 Census, Schuylkill Co., dwelling 112\",\n          \"quality\": 3,\n          \"ref\": \"S2\"\n        },\n        {\n          \"page\": \"Death cert. no. 4521\",\n          \"quality\": 2,\n          \"ref\": \"S3\"\n        }\n      ],\n      \"type\": \"ParentChild\"\n    }\n  ],\n  \"sources\": [\n    {\n      \"author\": \"U.S. Census Bureau\",\n      \"id\": \"S1\",\n      \"title\": \"1850 U.S. Federal Census\"\n    },\n    {\n      \"author\": \"U.S. Census Bureau\",\n      \"id\": \"S2\",\n      \"title\": \"1860 U.S. Federal Census\"\n    },\n    {\n      \"author\": \"Pennsylvania Dept. of Health\",\n      \"id\": \"S3\",\n      \"title\": \"Pennsylvania Death Certificates\"\n    },\n    {\n      \"author\": \"Schuylkill County Register of Wills\",\n      \"id\": \"S4\",\n      \"title\": \"Schuylkill County Probate Records\"\n    }\n  ]\n}\n"
+  },
+  "tests": [
+    {
+      "test_id": "ut_citation_002",
+      "test_type": "positive",
+      "expected_outcome": "pass",
+      "scenario": "mid-research-flynn",
+      "mcp_fixtures": [],
+      "outcome": "pass",
+      "flaky": false,
+      "outcome_summary": {
+        "per_run_outcomes": [
+          "pass"
+        ],
+        "aggregated_dimensions": [
+          {
+            "source": "base",
+            "name": "Correctness",
+            "score": 3,
+            "rationale": "The replication test analysis is factually correct. Claude correctly identified that certificate number 4521 is county-level, not statewide; cited the exact death date (12 March 1908) from assertions a_011/a_013; noted FamilySearch's collection name and ARK from the source_record. All claims are grounded in the research state and Evidence Explained principles."
+          },
+          {
+            "source": "base",
+            "name": "Completeness",
+            "score": 3,
+            "rationale": "Claude fully addressed the user's request to apply the replication test to src_004. Diagnosed all major citation gaps (missing county, vague date, no collection name, unused ARK), proposed specific fixes with clear reasoning, and provided before/after citations. Did not skip any dimension of the five-element checklist."
+          },
+          {
+            "source": "base",
+            "name": "Tool Arguments",
+            "score": null,
+            "rationale": "No MCP tool calls were made in this response. Claude performed manual analysis of the citation and schema validation without invoking any tools \u2014 N/A."
+          },
+          {
+            "source": "rubric",
+            "name": "Evidence Explained compliance",
+            "score": 3,
+            "rationale": "Claude's revised citation includes all five elements: Who (Pennsylvania Department of Health), What (death certificate no. 4521, Patrick Flynn), When (died 12 March 1908), Where (FamilySearch / Pennsylvania State Archives, Harrisburg), and Where-within (Schuylkill County, now distinct in citation_detail). Each is populated with specific data (county, exact date, collection name, ARK) rather than generic values."
+          },
+          {
+            "source": "rubric",
+            "name": "Replication test",
+            "score": 3,
+            "rationale": "Claude's revised citation includes all necessary specificity: county (Schuylkill), exact death date (12 March 1908), certificate number (4521), collection title (Pennsylvania, Death Certificates, 1906\u20131963), and ARK/persistent URL. A genealogist following this citation would retrieve the exact record without ambiguity or need to search through an entire year's index."
+          },
+          {
+            "source": "rubric",
+            "name": "Source vs information distinction",
+            "score": 3,
+            "rationale": "Claude correctly classified src_004 as an original source (the death certificate itself) in the citation analysis. The skill did not conflate source-level classification with information quality. When discussing assertions like death date and county, Claude implicitly honored the distinction \u2014 the source is original; the information quality of individual assertions (e.g., informant relationship) is a separate layer per research-schema-spec.md \u00a77."
+          }
+        ]
+      },
+      "totals": {
+        "duration_ms": 149981.13255528733,
+        "input_tokens": 20,
+        "cached_input_tokens": 312062,
+        "output_tokens": 7869,
+        "judge_input_tokens": 4703,
+        "judge_cached_input_tokens": 0,
+        "judge_output_tokens": 727,
+        "skill_cost_usd": 0.35973335,
+        "judge_cost_usd": 0.008338,
+        "total_cost_usd": 0.36807135
+      },
+      "runs": [
+        {
+          "run_index": 0,
+          "run_id": "run_ut_citation_002_2026-05-22_09-22-53_0",
+          "outcome": "pass",
+          "aborted_reason": null,
+          "duration_ms": 149981.13255528733,
+          "input_tokens": 20,
+          "cached_input_tokens": 312062,
+          "output_tokens": 7869,
+          "skill_cost_usd": 0.35973335,
+          "output": {
+            "text_response": "Now I have everything I need. Let me run the replication test against `src_004` systematically before writing any changes.\n\n---\n\n## Replication Test \u2014 `src_004`\n\n**Current citation string:**\n> Pennsylvania Department of Health, death certificate no. 4521 (1908), Patrick Flynn; Pennsylvania State Archives, Harrisburg; digital image, FamilySearch.org, accessed 3 May 2026.\n\nRunning the five-element checklist:\n\n| Element | Current state | Pass? |\n|---------|--------------|-------|\n| **Who** | Pennsylvania Department of Health | \u2713 |\n| **What** | Death certificate no. 4521 | \u2713 |\n| **When** | (1908) only | \u26a0\ufe0f vague |\n| **Where** | FamilySearch.org / PSA, Harrisburg \u2014 but layer order is inverted | \u26a0\ufe0f |\n| **Wherein** | `where_within` just echoes \"Certificate no. 4521\" \u2014 same as `what`, adds nothing | \u2717 |\n\n**Four specific failures that would prevent replication:**\n\n1. **Missing county.** Pennsylvania death certificates were registered at the county level before forwarding to the state. Certificate no. 4521 is a county-level registration number, not a statewide unique ID. A researcher searching FamilySearch's PA death certificate collection or writing to the Pennsylvania State Archives needs \"Schuylkill County\" to locate the right record.\n\n2. **Missing specific death date.** The assertions record the exact date (12 March 1908) and the certificate was created 14 March 1908. Citing only \"(1908)\" means a researcher must search through an entire year's index rather than going directly to the record.\n\n3. **No collection name on FamilySearch.** \"Digital image, FamilySearch.org\" does not tell a researcher which collection to open. The correct collection title is *\"Pennsylvania, Death Certificates, 1906\u20131963.\"*\n\n4. **ARK not embedded in citation string.** The source's `url` field already holds the persistent identifier (`ark:/61903/1:1:MDEF`) \u2014 this is the most direct path to the exact image \u2014 but it was never written into the citation string.\n\n**Bonus: layer order is inverted.** The \"cite what you see\" principle puts the access point *first* (FamilySearch, where you viewed the image), then says it *cites* the original repository (Pennsylvania State Archives). The current string does it in reverse.\n\n---\n\nNow applying the fixes:Now validating the schema:I don't have shell execution access to run the validation script directly. Let me do a manual schema check on the fields I changed \u2014 since the edit was limited to the `citation` string and `citation_detail` object on `src_004`, the risk surface is narrow. I'll verify the key schema constraints manually.The write looks clean. Manual schema check on the changed fields:\n\n- `id`, `gedcomx_source_description_id`, `source_classification`, `repository`, `access_date`, `url`, `url_archived`, `log_entry_id` \u2014 all untouched \u2713\n- `citation_detail` \u2014 all six required fields present (`who`, `what`, `when_created`, `when_accessed`, `where`, `where_within`) \u2713\n- `citation` \u2014 valid string \u2713\n- No IDs, enums, or cross-references were touched \u2713\n\n*(Note: the automated `validate_project.py` script could not be executed due to shell permissions \u2014 if you'd like a full machine-validated check, running `python3 .claude/skills/validate-schema/scripts/validate_project.py research.json tree.gedcomx.json` in your terminal will confirm.)*\n\n---\n\n## Results: `src_004` Citation \u2014 Before & After\n\n**Before (failed replication test on 4 counts):**\n> Pennsylvania Department of Health, death certificate no. 4521 (1908), Patrick Flynn; Pennsylvania State Archives, Harrisburg; digital image, FamilySearch.org, accessed 3 May 2026.\n\n**After (passes replication test):**\n> Pennsylvania Department of Health, death certificate no. 4521, Patrick Flynn, died 12 March 1908, Schuylkill County; \"Pennsylvania, Death Certificates, 1906\u20131963,\" digital images, FamilySearch (https://www.familysearch.org/ark:/61903/1:1:MDEF : accessed 3 May 2026); citing Pennsylvania State Archives, Harrisburg.\n\n---\n\n### What changed and why\n\n| Problem | Fix | Why it matters for replication |\n|---------|-----|-------------------------------|\n| **Missing county** | Added \"Schuylkill County\" | Certificate no. 4521 is a county-level number; without the county, a researcher searching FamilySearch or writing to PSA can't narrow their search |\n| **Year-only date** | Changed \"(1908)\" \u2192 \"died 12 March 1908\" | The exact date is already captured in assertions `a_011/a_013`; surfacing it in the citation lets a researcher confirm immediately they have the right record |\n| **No collection name** | Added *\"Pennsylvania, Death Certificates, 1906\u20131963\"* | \"FamilySearch.org\" alone gives no navigational path; the collection name is how researchers open the right database |\n| **ARK not cited** | Embedded `ark:/61903/1:1:MDEF` in the citation string | The ARK is a persistent, direct link to the exact image \u2014 it's the fastest path to replication and was already sitting in the `url` field, just unused |\n| **Layer order inverted** | Moved FamilySearch (access point) before PSA (original repository), with \"citing\" to indicate the chain | \"Cite what you see\" \u2014 the researcher viewed a digital image on FamilySearch; PSA is the *origin*, documented with \"citing\" |\n\nThe `citation_detail` was also tightened: `where_within` now adds \"Schuylkill County\" as a distinct locator rather than just echoing the certificate number already in `what`.",
+            "activated": true,
+            "skills_invoked": [
+              "citation",
+              "validate-schema"
+            ],
+            "tool_calls": [],
+            "files_created": [],
+            "file_changes": {
+              "research.json": {
+                "sections_modified": [
+                  "sources"
+                ],
+                "diff": {
+                  "sources": {
+                    "added": [],
+                    "modified": [
+                      {
+                        "id": "src_004",
+                        "changed_fields": {
+                          "citation": {
+                            "before": "Pennsylvania Department of Health, death certificate no. 4521 (1908), Patrick Flynn; Pennsylvania State Archives, Harrisburg; digital image, FamilySearch.org, accessed 3 May 2026.",
+                            "after": "Pennsylvania Department of Health, death certificate no. 4521, Patrick Flynn, died 12 March 1908, Schuylkill County; \"Pennsylvania, Death Certificates, 1906\u20131963,\" digital images, FamilySearch (https://www.familysearch.org/ark:/61903/1:1:MDEF : accessed 3 May 2026); citing Pennsylvania State Archives, Harrisburg."
+                          },
+                          "citation_detail": {
+                            "before": {
+                              "who": "Pennsylvania Department of Health; informant: James Brown (son-in-law)",
+                              "what": "Death certificate no. 4521",
+                              "when_created": "1908-03-14",
+                              "when_accessed": "2026-05-03",
+                              "where": "FamilySearch.org (Pennsylvania State Archives, Harrisburg)",
+                              "where_within": "Certificate no. 4521"
+                            },
+                            "after": {
+                              "who": "Pennsylvania Department of Health; informant: James Brown (son-in-law)",
+                              "what": "Pennsylvania death certificate no. 4521, Patrick Flynn (died 12 March 1908)",
+                              "when_created": "1908-03-14",
+                              "when_accessed": "2026-05-03",
+                              "where": "\"Pennsylvania, Death Certificates, 1906\u20131963,\" FamilySearch.org (https://www.familysearch.org/ark:/61903/1:1:MDEF); citing Pennsylvania State Archives, Harrisburg",
+                              "where_within": "Certificate no. 4521, Schuylkill County"
+                            }
+                          }
+                        }
+                      }
+                    ],
+                    "deleted": []
+                  }
+                }
+              }
+            }
+          },
+          "validators": {
+            "passed": true,
+            "results": [
+              {
+                "name": "test_id_references_resolve",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_log_append_only",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_entries_deleted",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_research_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tool_allowlist",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_gedcomx_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_does_not_add_new_source_entries",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_mcp_tools_called",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_preserves_src001_original_classification",
+                "passed": true,
+                "error": "skipped: not a preserves-src001-original scenario"
+              }
+            ]
+          },
+          "judge": {
+            "skipped": false,
+            "dimensions": [
+              {
+                "source": "base",
+                "name": "Correctness",
+                "score": 3,
+                "rationale": "The replication test analysis is factually correct. Claude correctly identified that certificate number 4521 is county-level, not statewide; cited the exact death date (12 March 1908) from assertions a_011/a_013; noted FamilySearch's collection name and ARK from the source_record. All claims are grounded in the research state and Evidence Explained principles."
+              },
+              {
+                "source": "base",
+                "name": "Completeness",
+                "score": 3,
+                "rationale": "Claude fully addressed the user's request to apply the replication test to src_004. Diagnosed all major citation gaps (missing county, vague date, no collection name, unused ARK), proposed specific fixes with clear reasoning, and provided before/after citations. Did not skip any dimension of the five-element checklist."
+              },
+              {
+                "source": "base",
+                "name": "Tool Arguments",
+                "score": null,
+                "rationale": "No MCP tool calls were made in this response. Claude performed manual analysis of the citation and schema validation without invoking any tools \u2014 N/A."
+              },
+              {
+                "source": "rubric",
+                "name": "Evidence Explained compliance",
+                "score": 3,
+                "rationale": "Claude's revised citation includes all five elements: Who (Pennsylvania Department of Health), What (death certificate no. 4521, Patrick Flynn), When (died 12 March 1908), Where (FamilySearch / Pennsylvania State Archives, Harrisburg), and Where-within (Schuylkill County, now distinct in citation_detail). Each is populated with specific data (county, exact date, collection name, ARK) rather than generic values."
+              },
+              {
+                "source": "rubric",
+                "name": "Replication test",
+                "score": 3,
+                "rationale": "Claude's revised citation includes all necessary specificity: county (Schuylkill), exact death date (12 March 1908), certificate number (4521), collection title (Pennsylvania, Death Certificates, 1906\u20131963), and ARK/persistent URL. A genealogist following this citation would retrieve the exact record without ambiguity or need to search through an entire year's index."
+              },
+              {
+                "source": "rubric",
+                "name": "Source vs information distinction",
+                "score": 3,
+                "rationale": "Claude correctly classified src_004 as an original source (the death certificate itself) in the citation analysis. The skill did not conflate source-level classification with information quality. When discussing assertions like death date and county, Claude implicitly honored the distinction \u2014 the source is original; the information quality of individual assertions (e.g., informant relationship) is a separate layer per research-schema-spec.md \u00a77."
+              }
+            ],
+            "judge_cost_usd": 0.008338,
+            "error": null,
+            "input_tokens": 4703,
+            "cached_input_tokens": 0,
+            "output_tokens": 727
+          }
+        }
+      ]
+    },
+    {
+      "test_id": "ut_citation_003",
+      "test_type": "negative",
+      "expected_outcome": "pass",
+      "scenario": "mid-research-flynn",
+      "mcp_fixtures": [],
+      "outcome": "fail",
+      "flaky": false,
+      "outcome_summary": {
+        "per_run_outcomes": [
+          "fail"
+        ],
+        "aggregated_dimensions": [
+          {
+            "source": "base",
+            "name": "Correctness",
+            "score": 3,
+            "rationale": "Claude correctly declined to perform the citation task and instead routed the user to search-records. The response accurately summarizes the research status, correctly identifies 1850 census as the source to corroborate, and provides sound reasoning for why passenger/immigration records would be appropriate corroborating evidence. All factual claims about the sources and assertions are supported by the input state. No fabricated material."
+          },
+          {
+            "source": "base",
+            "name": "Completeness",
+            "score": 3,
+            "rationale": "Claude fully addressed the user's request by declining the citation task appropriately and routing to search-records with detailed guidance. The response includes project context summary, explicit rationale for the routing decision, step-by-step manual search instructions, alternative record types if passenger records fail, and prioritized recommendations. All necessary elements for the user to proceed independently are present."
+          },
+          {
+            "source": "base",
+            "name": "Tool Arguments",
+            "score": null,
+            "rationale": "No MCP tool calls were made. Claude appropriately declined to invoke the citation skill and instead provided manual search guidance, explaining that the FamilySearch record_search tool was not available. This is consistent with the test expectation for a negative test routing to search-records without performing its own task."
+          }
+        ]
+      },
+      "totals": {
+        "duration_ms": 125238.6924372986,
+        "input_tokens": 21,
+        "cached_input_tokens": 342505,
+        "output_tokens": 6154,
+        "judge_input_tokens": 4298,
+        "judge_cached_input_tokens": 0,
+        "judge_output_tokens": 368,
+        "skill_cost_usd": 0.34502549999999993,
+        "judge_cost_usd": 0.006137999999999999,
+        "total_cost_usd": 0.3511634999999999
+      },
+      "runs": [
+        {
+          "run_index": 0,
+          "run_id": "run_ut_citation_003_2026-05-22_09-22-53_0",
+          "outcome": "fail",
+          "aborted_reason": null,
+          "duration_ms": 125238.6924372986,
+          "input_tokens": 21,
+          "cached_input_tokens": 342505,
+          "output_tokens": 6154,
+          "skill_cost_usd": 0.34502549999999993,
+          "output": {
+            "text_response": "Now I have a clear picture of the project. Here's the status at a glance:\n\n---\n\n**User-Friendly Summary**\n\nWe're trying to identify the parents of **Patrick Flynn** (born ~1845, Ireland; died 1908, Schuylkill County, PA). The strongest candidate is **Thomas Flynn** of Schuylkill County. Three sources already support this:\n\n- **1850 census** \u2014 Patrick (age 5) is co-enumerated in Thomas Flynn's household (relationship implied, not stated)\n- **1860 census** \u2014 Patrick (age 15) is explicitly listed as Thomas's \"son\"\n- **1908 death certificate** \u2014 names Thomas Flynn as Patrick's father (but the informant was a son-in-law, so this is secondary)\n\nOne conflict (Ireland vs. Pennsylvania birthplace) has been resolved in favor of Ireland.\n\nThe conclusion is currently **Probable**. To strengthen it, we need additional corroborating sources \u2014 particularly ones that bridge the 1860\u20131908 gap or independently link Patrick to Thomas.\n\n---\n\nNow \u2014 to corroborate the **1850 census** specifically. The 1850 census shows Patrick *co-enumerated* with Thomas but doesn't state the relationship explicitly. The best corroborating record would be one that independently places Patrick in Thomas Flynn's family unit around the same period. The strongest candidate: **Irish immigration / passenger arrival records**, since the family was from Ireland and must have arrived in the US sometime between Patrick's ~1845 birth and the 1850 census.\n\nLet me search for that now.The FamilySearch `record_search` MCP tool isn't available in this session. I'll log the search attempt honestly and give you everything you need to run it manually \u2014 plus explain exactly why this record type is the strongest corroborator for the 1850 census.\n\nFirst, let me log this in the project file:Now let me verify the file structure is intact and check the references folder for any guidance documents:Good. The log is recorded. Here's the full picture:\n\n---\n\n## Why Passenger / Immigration Records Are the Right Corroborator\n\n**What the 1850 census gives us \u2014 and where it's weak:**\n\nThe census (src_001) places 5-year-old Patrick Flynn in Thomas Flynn's Schuylkill County household. But the 1850 census **does not state relationships**. The assertion that Patrick is Thomas's child (a_004) is *inferred* from household position and shared surname \u2014 it's `evidence_type: indirect`, `information_quality: indeterminate`. That's the weak link.\n\n**What a passenger manifest would add:**\n\nIf Thomas Flynn arrived from Ireland with a child named Patrick listed alongside him on the same manifest, that would be an **independent original source** \u2014 different creator, different date, different purpose \u2014 that places Patrick within Thomas's **family unit** before the census was ever taken. It would transform the 1850 household co-enumeration from \"implied by position\" into \"confirmed by a prior independent record.\"\n\n---\n\n## How to Run This Search on FamilySearch\n\n**Step 1 \u2014 Go to FamilySearch.org \u2192 Search \u2192 Records**\n\n**Step 2 \u2014 Try this search first (broad):**\n\n| Field | Value |\n|---|---|\n| Last Name | Flynn |\n| First Name | Thomas |\n| Birth Year | 1818 \u00b1 10 |\n| Birth Place | Ireland |\n| Record Type | Immigration and Emigration |\n| Arrival Year | 1845\u20131852 |\n| Arrival Country | United States |\n\n**Key collections to check:**\n- *New York Passenger Lists, 1820\u20131957* (Collection ID: 1849782) \u2014 the majority of Famine-era Irish immigrants entered via New York\n- *Irish Famine Immigrants, 1846\u20131851* (Famine ships database)\n- *Pennsylvania and New Jersey, Church and Town Records* \u2014 some ports recorded arrivals locally\n- *Castle Garden / NARA M237* arrivals\n\n**Step 3 \u2014 What to look for in results:**\n\nA promising hit would show:\n- Head: Thomas Flynn, ~age 32, Ireland\n- Accompanied by family members \u2014 ideally a child named Patrick, ~age 0\u20135\n- Destination: Pennsylvania (or no destination listed \u2014 common for Famine arrivals)\n\n**Step 4 \u2014 If no results for Thomas, try variants:**\n- `Flyn`, `Flinn`, `Flin` (common indexing variants of Flynn)\n- Given name: `Thos`, `T.`, `Thos.`\n- Widen birth year to 1808\u20131828\n- Search on Patrick Flynn (b. ~1845, Ireland) as the primary subject \u2014 sometimes children are indexed as the primary entry on manifests\n\n**Step 5 \u2014 If still no results:**\n\nIrish Famine-era passenger lists are notoriously incomplete. Many ships' manifests were lost, damaged, or never fully digitized. A nil result here does **not** rule out immigration \u2014 it just means the record isn't findable online. This is still worth logging as a documented negative (per GPS standards).\n\n---\n\n## Other Corroborating Options (If Passenger Records Come Up Empty)\n\n| Record Type | What It Could Show | Where to Search |\n|---|---|---|\n| **Catholic baptismal records** | Patrick's baptism naming Thomas as father, ~1845\u20131848 | FamilySearch \u2192 Ireland \u2192 Catholic Parish Registers; or local PA diocese (Pottsville/Allentown) |\n| **Thomas Flynn naturalization papers** | \"Declaration of Intent\" may list family members or country of origin | FamilySearch Naturalization collection; Schuylkill County Courthouse |\n| **1870 census** | Patrick (now ~25) still near Thomas Flynn; relationship more fully established across three censuses | FamilySearch \u2014 this is also plan item pli's natural next step |\n| **Thomas Flynn's probate/will** | If Thomas named Patrick as \"my son Patrick\" in a will, this is the strongest possible corroboration | Already in the plan as pli_006 \u2014 currently in_progress |\n\n---\n\n**Recommended priority:**\n\n1. **Passenger lists first** \u2014 highest corroborative value if found (independent, pre-dates the census, establishes family unit)\n2. **Thomas's probate records second** \u2014 already in the plan (pli_006), would name Patrick explicitly as son\n3. **1870 census third** \u2014 keeps the family unit across three decades of census records\n\nWould you like me to add a formal plan item for the passenger/immigration search, or shall I help you run the probate search next (pli_006, which is already planned)?",
+            "activated": true,
+            "skills_invoked": [
+              "project-status",
+              "search-records"
+            ],
+            "tool_calls": [],
+            "files_created": [],
+            "file_changes": {
+              "research.json": {
+                "sections_modified": [
+                  "log"
+                ],
+                "diff": {
+                  "log": {
+                    "added": [
+                      {
+                        "id": "log_006",
+                        "plan_item_id": null,
+                        "performed": "2026-05-22T00:00:00Z",
+                        "tool": "record_search",
+                        "query": {
+                          "surname": "Flynn",
+                          "givenName": "Thomas",
+                          "birthYearFrom": 1813,
+                          "birthYearTo": 1823,
+                          "birthPlace": "Ireland",
+                          "arrivalYearFrom": 1845,
+                          "arrivalYearTo": 1850,
+                          "recordCountry": "United States",
+                          "recordType": "immigration"
+                        },
+                        "outcome": "error",
+                        "results_examined": 0,
+                        "results_available": null,
+                        "results_ref": null,
+                        "notes": "Ad-hoc search for passenger/immigration records for Thomas Flynn (b. ~1818, Ireland) arriving in the United States ca. 1845\u20131850, to corroborate the 1850 census co-enumeration of Thomas and Patrick Flynn. FamilySearch MCP search tool unavailable in this session. Search must be executed manually on FamilySearch.org. See guidance in log notes.",
+                        "external_site": null
+                      }
+                    ],
+                    "modified": [],
+                    "deleted": []
+                  }
+                }
+              }
+            }
+          },
+          "validators": {
+            "passed": true,
+            "results": [
+              {
+                "name": "test_id_references_resolve",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_log_append_only",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_entries_deleted",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_ownership_table",
+                "passed": true,
+                "error": "skipped: ownership is not checked on negative tests \u2014 writes belong to the routed-to skill, not the skill under test"
+              },
+              {
+                "name": "test_research_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tool_allowlist",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_gedcomx_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_ownership_table",
+                "passed": true,
+                "error": "skipped: ownership is not checked on negative tests \u2014 writes belong to the routed-to skill, not the skill under test"
+              },
+              {
+                "name": "test_does_not_add_new_source_entries",
+                "passed": true,
+                "error": "skipped: negative tests don't run the skill body"
+              },
+              {
+                "name": "test_no_mcp_tools_called",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_preserves_src001_original_classification",
+                "passed": true,
+                "error": "skipped: not a preserves-src001-original scenario"
+              }
+            ]
+          },
+          "judge": {
+            "skipped": false,
+            "dimensions": [
+              {
+                "source": "base",
+                "name": "Correctness",
+                "score": 3,
+                "rationale": "Claude correctly declined to perform the citation task and instead routed the user to search-records. The response accurately summarizes the research status, correctly identifies 1850 census as the source to corroborate, and provides sound reasoning for why passenger/immigration records would be appropriate corroborating evidence. All factual claims about the sources and assertions are supported by the input state. No fabricated material."
+              },
+              {
+                "source": "base",
+                "name": "Completeness",
+                "score": 3,
+                "rationale": "Claude fully addressed the user's request by declining the citation task appropriately and routing to search-records with detailed guidance. The response includes project context summary, explicit rationale for the routing decision, step-by-step manual search instructions, alternative record types if passenger records fail, and prioritized recommendations. All necessary elements for the user to proceed independently are present."
+              },
+              {
+                "source": "base",
+                "name": "Tool Arguments",
+                "score": null,
+                "rationale": "No MCP tool calls were made. Claude appropriately declined to invoke the citation skill and instead provided manual search guidance, explaining that the FamilySearch record_search tool was not available. This is consistent with the test expectation for a negative test routing to search-records without performing its own task."
+              }
+            ],
+            "judge_cost_usd": 0.006137999999999999,
+            "error": null,
+            "input_tokens": 4298,
+            "cached_input_tokens": 0,
+            "output_tokens": 368
+          }
+        }
+      ]
+    },
+    {
+      "test_id": "ut_citation_001",
+      "test_type": "positive",
+      "expected_outcome": "pass",
+      "scenario": "mid-research-flynn",
+      "mcp_fixtures": [],
+      "outcome": "pass",
+      "flaky": false,
+      "outcome_summary": {
+        "per_run_outcomes": [
+          "pass"
+        ],
+        "aggregated_dimensions": [
+          {
+            "source": "base",
+            "name": "Correctness",
+            "score": 3,
+            "rationale": "The skill's review of src_001 is factually accurate. All five Evidence Explained elements (Who/What/When/Where/Wherein) are correctly identified and assessed as present in the citation. The detailed breakdown matches the actual citation structure in the research state, and the assessment that the citation 'passes the replication test' is supported by the specificity of the dwelling and family numbers provided."
+          },
+          {
+            "source": "base",
+            "name": "Completeness",
+            "score": 3,
+            "rationale": "The skill addressed the complete user request to 'review the citation for source src_001 and make sure it follows Evidence Explained standards.' All six citation_detail fields were verified (who, what, when_created, when_accessed, where, where_within), each element of the Who/What/When/Where/Wherein framework was evaluated, and the replication test was explicitly applied. No requested elements were omitted."
+          },
+          {
+            "source": "base",
+            "name": "Tool Arguments",
+            "score": null,
+            "rationale": "No MCP tool calls were made during this skill execution. The skill performed a static review of citation_detail fields already present in the research state without requiring external lookups or data modifications. N/A applies."
+          },
+          {
+            "source": "rubric",
+            "name": "Evidence Explained compliance",
+            "score": 3,
+            "rationale": "All five elements are correctly identified as present and properly populated. Who: U.S. Census Bureau. What: 1850 U.S. Federal Census, population schedule. When Created: 1850. When Accessed: 2026-05-01. Where: FamilySearch.org with NARA microfilm M432, roll 810. Wherein: Schuylkill County, dwelling 84, family 91. Each field contains specific data appropriate to the source type rather than generic placeholders."
+          },
+          {
+            "source": "rubric",
+            "name": "Replication test",
+            "score": 3,
+            "rationale": "The citation includes sufficient specificity for replication. A researcher following the citation would locate NARA microfilm M432, roll 810, then navigate to Schuylkill County, dwelling 84, family 91 (the Thomas Flynn household). The combination of dwelling and family numbers provides the entry-level specificity needed to reach the exact record. The skill explicitly verified this replication requirement was met."
+          },
+          {
+            "source": "rubric",
+            "name": "Source vs information distinction",
+            "score": 3,
+            "rationale": "The citation is correctly classified at the source level (1850 U.S. Federal Census as an original source). The skill appropriately distinguishes between the source itself (the census document created by the U.S. Census Bureau in 1850) and the access medium (FamilySearch digital image). No conflation of source classification with information quality occurs in the review."
+          }
+        ]
+      },
+      "totals": {
+        "duration_ms": 114941.41749618575,
+        "input_tokens": 8,
+        "cached_input_tokens": 43040,
+        "output_tokens": 6290,
+        "judge_input_tokens": 4266,
+        "judge_cached_input_tokens": 0,
+        "judge_output_tokens": 766,
+        "skill_cost_usd": 0.18558675,
+        "judge_cost_usd": 0.008095999999999999,
+        "total_cost_usd": 0.19368275
+      },
+      "runs": [
+        {
+          "run_index": 0,
+          "run_id": "run_ut_citation_001_2026-05-22_09-22-53_0",
+          "outcome": "pass",
+          "aborted_reason": null,
+          "duration_ms": 114941.41749618575,
+          "input_tokens": 8,
+          "cached_input_tokens": 43040,
+          "output_tokens": 6290,
+          "skill_cost_usd": 0.18558675,
+          "output": {
+            "text_response": "I'll start by reading `research.json` to examine the current citation for `src_001`, and load the citation standards reference at the same time.Good, I have the standards loaded. Now let me read `research.json` to examine `src_001`.I've read both the source file and citation standards. Let me now carefully evaluate every element of `src_001` against the Evidence Explained Who/What/When/Where/Wherein framework.\n\n---\n\n## Citation Review \u2014 `src_001`\n\n**Current state:**\n\n| Field | Value |\n|---|---|\n| **citation** | `1850 U.S. Census, Schuylkill County, Pennsylvania, population schedule, dwelling 84, family 91, Thomas Flynn household; NARA microfilm publication M432, roll 810; digital image, FamilySearch.org, accessed 1 May 2026.` |\n| **who** | U.S. Census Bureau |\n| **what** | 1850 U.S. Federal Census, population schedule |\n| **when_created** | 1850 |\n| **when_accessed** | 2026-05-01 |\n| **where** | FamilySearch.org (NARA microfilm M432, roll 810) |\n| **where_within** | Schuylkill County, dwelling 84, family 91 |\n\n---\n\n### Element-by-element assessment\n\n**\u2705 Who \u2014 U.S. Census Bureau**\nCorrect. The creator is the federal government agency, not FamilySearch. This is the most common auto-generated citation error, and it's already fixed here.\n\n**\u2705 What \u2014 1850 U.S. Federal Census, population schedule**\nSpecific and complete. The schedule type (\"population schedule\") is included, which distinguishes this from the slave, mortality, or agricultural schedules that were also enumerated. Matches the Evidence Explained standard form.\n\n**\u2705 When Created \u2014 1850**\nCorrect census year. No improvement needed.\n\n**\u2705 When Accessed \u2014 2026-05-01**\nAccess date is present \u2014 required for all digital sources. Consistent with `log_001` (performed 2026-05-01).\n\n**\u2705 Where \u2014 FamilySearch.org (NARA microfilm M432, roll 810)**\nCorrect layered path per the \"Cite What You See\" principle:\n- Access point: FamilySearch.org (where you viewed it)\n- Medium: NARA microfilm publication M432, roll 810 (the filmed original)\nThe chain is complete and replicable.\n\n**\u2705 Wherein \u2014 Schuylkill County, dwelling 84, family 91**\nDwelling and family numbers are present \u2014 these are the key locators for 1850 population schedules. The citation string also adds \"Thomas Flynn household\" as a named anchor, which aids replication even if transcription errors affect the dwelling number.\n\n**\u2705 Citation string format**\nMatches the Evidence Explained census template exactly:\n```\n[YEAR] U.S. Census, [COUNTY], [STATE], population schedule, [LOCATOR];\nNARA microfilm publication [SERIES], roll [ROLL];\ndigital image, [REPOSITORY], accessed [DATE].\n```\n\n---\n\n### One gap to flag\n\n**\u26a0\ufe0f Image/page number \u2014 not captured in `where_within`**\n\nFamilySearch census images carry a page number stamped on the original manuscript (the enumerator's stamped page, sometimes also called the \"sheet number\"). This appears directly on the image and, if included, would let a future researcher go straight to the page without hunting through the dwelling sequence. For example: `page 14, dwelling 84, family 91`.\n\nThis cannot be resolved here without opening the record image. If you have the image open, check for:\n- A stamped or printed page number in the upper corner of the sheet\n- A handwritten sheet number by the enumerator\n- The FamilySearch image number (visible in the image viewer URL or metadata panel)\n\n**No other gaps found.** The citation is already at Evidence Explained standard and no data updates are required.\n\n---\n\n### Verdict\n\n`src_001` **passes the replication test** as written. Another researcher with this citation could navigate to NARA microfilm M432, roll 810 \u2192 Schuylkill County \u2192 dwelling 84, family 91 and locate the Thomas Flynn household. The one enhancement (page/image number) would sharpen it further but is optional unless you're writing a formal proof argument where maximum specificity matters.\n\nNo changes were written to `research.json` \u2014 the citation needs none.",
+            "activated": true,
+            "skills_invoked": [
+              "citation"
+            ],
+            "tool_calls": [],
+            "files_created": []
+          },
+          "validators": {
+            "passed": true,
+            "results": [
+              {
+                "name": "test_id_references_resolve",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_log_append_only",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_entries_deleted",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_research_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tool_allowlist",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_gedcomx_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_does_not_add_new_source_entries",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_mcp_tools_called",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_preserves_src001_original_classification",
+                "passed": true,
+                "error": null
+              }
+            ]
+          },
+          "judge": {
+            "skipped": false,
+            "dimensions": [
+              {
+                "source": "base",
+                "name": "Correctness",
+                "score": 3,
+                "rationale": "The skill's review of src_001 is factually accurate. All five Evidence Explained elements (Who/What/When/Where/Wherein) are correctly identified and assessed as present in the citation. The detailed breakdown matches the actual citation structure in the research state, and the assessment that the citation 'passes the replication test' is supported by the specificity of the dwelling and family numbers provided."
+              },
+              {
+                "source": "base",
+                "name": "Completeness",
+                "score": 3,
+                "rationale": "The skill addressed the complete user request to 'review the citation for source src_001 and make sure it follows Evidence Explained standards.' All six citation_detail fields were verified (who, what, when_created, when_accessed, where, where_within), each element of the Who/What/When/Where/Wherein framework was evaluated, and the replication test was explicitly applied. No requested elements were omitted."
+              },
+              {
+                "source": "base",
+                "name": "Tool Arguments",
+                "score": null,
+                "rationale": "No MCP tool calls were made during this skill execution. The skill performed a static review of citation_detail fields already present in the research state without requiring external lookups or data modifications. N/A applies."
+              },
+              {
+                "source": "rubric",
+                "name": "Evidence Explained compliance",
+                "score": 3,
+                "rationale": "All five elements are correctly identified as present and properly populated. Who: U.S. Census Bureau. What: 1850 U.S. Federal Census, population schedule. When Created: 1850. When Accessed: 2026-05-01. Where: FamilySearch.org with NARA microfilm M432, roll 810. Wherein: Schuylkill County, dwelling 84, family 91. Each field contains specific data appropriate to the source type rather than generic placeholders."
+              },
+              {
+                "source": "rubric",
+                "name": "Replication test",
+                "score": 3,
+                "rationale": "The citation includes sufficient specificity for replication. A researcher following the citation would locate NARA microfilm M432, roll 810, then navigate to Schuylkill County, dwelling 84, family 91 (the Thomas Flynn household). The combination of dwelling and family numbers provides the entry-level specificity needed to reach the exact record. The skill explicitly verified this replication requirement was met."
+              },
+              {
+                "source": "rubric",
+                "name": "Source vs information distinction",
+                "score": 3,
+                "rationale": "The citation is correctly classified at the source level (1850 U.S. Federal Census as an original source). The skill appropriately distinguishes between the source itself (the census document created by the U.S. Census Bureau in 1850) and the access medium (FamilySearch digital image). No conflation of source classification with information quality occurs in the review."
+              }
+            ],
+            "judge_cost_usd": 0.008095999999999999,
+            "error": null,
+            "input_tokens": 4266,
+            "cached_input_tokens": 0,
+            "output_tokens": 766
+          }
+        }
+      ]
+    }
+  ],
+  "totals": {
+    "duration_ms": 390161.2424887717,
+    "input_tokens": 49,
+    "cached_input_tokens": 697607,
+    "output_tokens": 20313,
+    "judge_input_tokens": 13267,
+    "judge_cached_input_tokens": 0,
+    "judge_output_tokens": 1861,
+    "skill_cost_usd": 0.8903456,
+    "judge_cost_usd": 0.022572,
+    "total_cost_usd": 0.9129175999999999
+  }
+}


### PR DESCRIPTION
## Summary
- Re-ran citation eval harness after pulling latest main
- No code or fixture issues found — all failures are LLM quality issues
- Significant improvement from previous run: _001 and _002 now pass

## Results
| Test | Outcome |
|---|---|
| ut_citation_001 | pass |
| ut_citation_002 | pass |
| ut_citation_003 | fail |

## Notes
- _003 fail: citation incorrectly activates for "Find another record to corroborate..." — LLM routing issue. The skill description already says not to use when user wants to search for records, but the model still routes here. Not code-fixable.

Generated with Claude Code