### PR TITLE
Prevent stale mcp-server build from corrupting test runs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,10 @@
+## Summary
+
+<!-- 1-3 bullets describing what changed and why. -->
+
+## Test plan
+
+- [ ] I ran `scripts/test.sh` and it passed.
+- [ ] For every skill whose files I changed (SKILL.md, scenarios, fixtures,
+      tests, or supporting MCP/harness code), I ran `RunTests.bat <skill>`
+      and committed an all-pass runlog under `eval/runlogs/unit/<skill>/`.

--- a/eval/harness/run_tests.py
+++ b/eval/harness/run_tests.py
@@ -202,6 +202,37 @@ def _print_summary(rows: list[dict]) -> None:
     print()
 
 
+def _check_mcp_build_fresh() -> list[tuple[Path, str]]:
+    """Verify mcp-server build artifacts exist and are at least as new as
+    their TypeScript sources.
+
+    The harness loads compiled JS from mcp-server/build/ when skills call
+    MCP tools (e.g., validate_research_schema). A stale or missing build
+    surfaces as a `build not found` error inside the tool response, which
+    looks like a skill failure rather than an environment problem. Fail
+    fast with a clear remediation instead.
+
+    Returns a list of (ts_path, reason) for stale or missing artifacts.
+    Empty list means the build is fresh.
+    """
+    src_root = REPO_ROOT / "mcp-server" / "src"
+    build_root = REPO_ROOT / "mcp-server" / "build"
+    if not src_root.exists():
+        return []
+
+    stale: list[tuple[Path, str]] = []
+    for ts_path in src_root.rglob("*.ts"):
+        if ts_path.name.endswith(".d.ts"):
+            continue
+        rel = ts_path.relative_to(src_root).with_suffix(".js")
+        js_path = build_root / rel
+        if not js_path.exists():
+            stale.append((ts_path, "missing"))
+        elif js_path.stat().st_mtime < ts_path.stat().st_mtime:
+            stale.append((ts_path, "outdated"))
+    return stale
+
+
 def _classify_invocation(args) -> tuple[str, bool]:
     """Return (mode, has_tag_filter). mode ∈ {test, skill, all, tag}."""
     has_tag_filter = bool(args.tag)
@@ -248,6 +279,28 @@ def main(argv: list[str] | None = None) -> int:
         for name in skills:
             print(f"  {name}")
         return 0
+
+    stale = _check_mcp_build_fresh()
+    if stale:
+        print(
+            "ERROR: mcp-server build is stale or missing. The harness loads "
+            "compiled JS from mcp-server/build/ when skills call MCP tools; "
+            "running against stale artifacts produces misleading test "
+            "failures.",
+            file=sys.stderr,
+        )
+        for ts, reason in stale[:5]:
+            print(
+                f"  - {ts.relative_to(REPO_ROOT)} ({reason})",
+                file=sys.stderr,
+            )
+        if len(stale) > 5:
+            print(f"  ... and {len(stale) - 5} more", file=sys.stderr)
+        print(
+            "\nFix: cd mcp-server && npm run build",
+            file=sys.stderr,
+        )
+        return 2
 
     paths_kwargs = {"tests_dir": tests_dir}
     if args.runlogs_root is not None:

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "build": "tsc",
     "start": "node build/index.js",
+    "pretest": "npm run build",
     "test": "vitest run",
     "test:watch": "vitest"
   },


### PR DESCRIPTION
## Summary

- Add a `pretest` hook to `mcp-server/package.json` so `npm test` (directly or via `scripts/test.sh`) always rebuilds first.
- Add a `_check_mcp_build_fresh()` guard to `eval/harness/run_tests.py` that refuses to start (exit 2) when any `mcp-server/src/**/*.ts` is newer than its `build/**/*.js` counterpart, with a clear remediation message.
- Add `.github/pull_request_template.md` with a checklist for running `scripts/test.sh` and the affected skill harness before opening a PR.

The harness loads compiled JS from `mcp-server/build/` when skills call MCP tools (notably `validate_research_schema`). A stale or missing build surfaces as a `build not found` error inside the tool response, which looks like a skill failure rather than an environment problem and pollutes committed runlogs. These safeguards force the build to be fresh at every test entry point.

## Test plan

- [x] `pretest` hook fires: confirmed `npm test` in `mcp-server/` invokes `npm run build` first.
- [x] Stale-build guard fires: `touch mcp-server/src/tools/validate-research-schema.ts && uv run python eval/harness/run_tests.py --test ut_check_warnings_001` exits 2 with the expected error message.
- [x] Guard passes through cleanly after `cd mcp-server && npm run build`.
- [x] `--list-skills` short-circuits before the guard (no false trips).
- [x] Existing harness CLI unit tests (22 tests in `tests/unit/test_cli.py`) still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)