### PR TITLE
Track mcp-server source in runlog snapshots

### DIFF
--- a/.github/workflows/check-runlogs.yml
+++ b/.github/workflows/check-runlogs.yml
@@ -29,6 +29,7 @@ on:
       - 'plugin/skills/**'
       - 'eval/fixtures/**'
       - 'eval/harness/**'
+      - 'mcp-server/src/**'
 
 jobs:
   check:

--- a/eval/CLAUDE.md
+++ b/eval/CLAUDE.md
@@ -97,12 +97,13 @@ The run-log-level `outcome` (`pass | partial | fail | aborted | xfail | xpass`) 
 
 ## Snapshot model
 
-Every run log embeds a `snapshot: {repo-relative-path: normalized content}` block covering every skill-side file used:
+Every run log embeds a `snapshot: {repo-relative-path: normalized content}` block covering every file the run depended on:
 
 - `plugin/skills/<skill>/**`
 - `eval/tests/unit/<skill>/**` (rubric + test JSONs)
 - referenced `eval/fixtures/scenarios/<name>/**`
 - referenced `eval/fixtures/mcp/<name>.json`
+- `mcp-server/src/**` (all MCP tool source — conservative: changes to any shared util can affect any tool's behavior, so the whole tree is tracked rather than a per-skill subset)
 
 `eval/harness/judge/prompt.md` is **not** in the snapshot — it's project-global and gets a separate `judge_prompt_hash` field. This keeps "activate this run log" a per-skill operation; activating skill A's v1 doesn't clobber skill B's judge calibration.
 

--- a/eval/harness/harness/snapshot.py
+++ b/eval/harness/harness/snapshot.py
@@ -104,6 +104,11 @@ def build_snapshot(
       - `eval/fixtures/scenarios/<name>/**` for each scenario referenced
         by an included test
       - `eval/fixtures/mcp/<name>.json` for each MCP fixture referenced
+      - `mcp-server/src/**/*.ts` (all MCP tool source). Conservative:
+        any change to MCP source invalidates every skill's runlog. A
+        change to a shared util (`auth/`, `constants.ts`, `types/`) can
+        affect any tool's behavior, so tracking the whole tree is the
+        only way to avoid silently missed invalidations.
 
     When `test_ids` is given, only those tests' scenarios + fixtures are
     embedded. When None, every test in the skill contributes.
@@ -127,6 +132,9 @@ def build_snapshot(
         if fixture_path.is_file():
             rel = f"eval/fixtures/mcp/{fixture}.json"
             snapshot[rel] = normalize(rel, fixture_path.read_bytes())
+
+    mcp_src_dir = repo_root / "mcp-server" / "src"
+    _embed_tree(snapshot, mcp_src_dir, repo_root)
 
     return snapshot
 

--- a/eval/harness/tests/unit/test_snapshot.py
+++ b/eval/harness/tests/unit/test_snapshot.py
@@ -161,6 +161,24 @@ def test_build_snapshot_skips_missing_skill(tmp_path: Path):
     assert snap == {}
 
 
+def test_build_snapshot_embeds_mcp_server_source(tmp_path: Path):
+    """Any TS file under mcp-server/src/ is embedded so that MCP-side
+    changes invalidate the runlog. Conservative: shared utils
+    (auth/, constants.ts, types/) affect any tool, so the whole tree
+    is tracked rather than a per-skill subset."""
+    repo = tmp_path
+    (repo / "plugin" / "skills" / "x").mkdir(parents=True)
+    src_dir = repo / "mcp-server" / "src"
+    tools_dir = src_dir / "tools"
+    tools_dir.mkdir(parents=True)
+    (tools_dir / "wikipedia.ts").write_text("export const x = 1;\n")
+    (src_dir / "constants.ts").write_text("export const UA = 'mozilla';\n")
+
+    snap = build_snapshot(skill="x", repo_root=repo)
+    assert "mcp-server/src/tools/wikipedia.ts" in snap
+    assert "mcp-server/src/constants.ts" in snap
+
+
 # ---- diff vs disk --------------------------------------------------------
 
 


### PR DESCRIPTION
## Summary

- Extend `build_snapshot()` to embed `mcp-server/src/**/*.ts` so any MCP tool change invalidates skill runlogs that depended on the old source.
- Add `mcp-server/src/**` to the `check-runlogs.yml` PR path filter so MCP-only PRs fire the runlog discipline checks.
- Document the expanded snapshot scope in `eval/CLAUDE.md`.
- Add a unit test locking the new embedding behavior.

The existing Rule 2 check already catches "dev edited SKILL.md / test JSON / scenario / fixture after generating a runlog and committed both." But MCP tool source was not in the snapshot, and the workflow's PR path filter did not watch `mcp-server/` — so a dev could edit `mcp-server/src/tools/<tool>.ts` after generating a runlog and the discipline check would pass (and on MCP-only PRs, wouldn't even run). This closes that gap.

## Design choice: full mcp-server/src vs. per-skill subset

Conservative — the whole tree is tracked rather than `allowed-tools` subsets. Shared utilities under `auth/`, `constants.ts`, and `types/` can affect any tool's behavior; restricting the snapshot to a skill's declared tools would silently miss those invalidations. The size cost is small (~150KB per runlog) and re-running an unaffected skill suite is a mild inconvenience next to merging a stale runlog.

## Backwards compatibility

Existing runlogs have no `mcp-server/` entries in their snapshots, so Rule 2 won't suddenly fail on them — `diff_snapshot_vs_disk` only compares files IN the snapshot. Only NEW runlogs generated after this change track `mcp-server/src/`. Smooth rollout, no forced re-run of every existing skill.

## Test plan

- [x] All 19 snapshot tests pass (existing 18 + new `test_build_snapshot_embeds_mcp_server_source`).
- [x] All 284 harness unit tests pass.
- [x] Smoke test against real `check-warnings` skill: snapshot grows from 14 → 55 entries, picking up all 41 `mcp-server/src/**/*.ts` files.
- [x] `eval/app/lib/snapshot.ts` reviewed: it doesn't build snapshots, only diffs them via `diffSnapshotVsDisk`, which naturally handles new keys — no TS change needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)