### PR TITLE
Two small validator/rubric drift fixes

### DIFF
--- a/eval/harness/validators/test_citation.py
+++ b/eval/harness/validators/test_citation.py
@@ -5,12 +5,11 @@ Explained compliance, Replication test, Source vs information
 distinction) are pure GPS craft and stay graded by the LLM judge.
 See docs/plan/criteria-demotion-and-rubric-opt-in.md.
 
-This file holds mechanical checks: source-section-only writes, no MCP
-tools, and tag-gated assertions on specific source fields. Universal
-`test_ownership_table` already enforces that citation only writes
-`sources`; this file backs that with append-only checks on the section
-(per spec: citation never creates new source entries — it refines
-existing ones).
+This file holds the append-only source-section check (per spec:
+citation never creates new source entries — it refines existing
+ones). Tool-allowlist enforcement is delegated to universal
+`test_tool_allowlist`, which correctly honors the skill's declared
+`allowed-tools` (currently `[validate_research_schema]`).
 
 See test_universal.py module docstring for the validator function-
 signature contract.
@@ -19,28 +18,6 @@ signature contract.
 from __future__ import annotations
 
 import pytest
-
-
-# --- Tool-allowlist enforcement ---------------------------------------
-
-def test_no_mcp_tools_called(tool_calls):
-    """citation must not call any MCP tools.
-
-    Per SKILL.md, this is a pure analysis skill — it reads source
-    entries from research.json and rewrites their `citation` and
-    `citation_detail` fields. The frontmatter declares no
-    `allowed-tools`, so universal `test_tool_allowlist` also catches
-    this; duplicated here to surface the violation against the
-    skill-specific check too.
-    """
-    mcp_calls = [
-        tc for tc in tool_calls
-        if tc.get("tool", "").startswith("mcp__")
-    ]
-    assert not mcp_calls, (
-        f"citation should not call MCP tools, but called: "
-        f"{[tc['tool'] for tc in mcp_calls]}"
-    )
 
 
 # --- No-new-sources enforcement ---------------------------------------

--- a/eval/tests/unit/check-warnings/rubric.md
+++ b/eval/tests/unit/check-warnings/rubric.md
@@ -22,6 +22,7 @@ Are warnings classified appropriately by severity? An impossibility (born after 
 
 Does each warning suggest what to investigate? "Birth year conflict between census and death certificate" is more useful than "possible date error."
 
+- **N/A:** No warnings were found (the project is clean). There is nothing to make actionable — score this dimension as `null`, not as a pass or fail. This avoids mechanically failing close-out reports on resolved projects where the correct response is "no warnings."
 - **pass:** Every warning names the specific records involved and the action a genealogist should take.
 - **partial:** Most warnings are actionable but at least one is generic ("possible date issue") without naming records or next steps.
 - **fail:** Warnings are decoupled from records, or suggested actions are too vague to act on.


### PR DESCRIPTION
## Summary

Two small, independent drift fixes bundled together.

### 1. check-warnings rubric: Actionability N/A for clean projects

The Actionability dimension was mechanically failing close-out reports on resolved projects. When `check-warnings` correctly reports "no warnings" on a clean project (e.g., the resolved-flynn scenario in `ut_check_warnings_002`), there's nothing to make actionable — so the dimension should grade as N/A (null), not as a fail. Added an explicit N/A clause above pass in `eval/tests/unit/check-warnings/rubric.md`.

### 2. test_citation.py: remove duplicate skill-specific tool-allowlist check

The skill-specific `test_no_mcp_tools_called` validator's docstring claimed "frontmatter declares no `allowed-tools`," but the current `plugin/skills/citation/SKILL.md` declares `[validate_research_schema]`. The hard-coded "reject any `mcp__*` call" assertion would now fail when the skill legitimately calls `validate_research_schema` for post-write validation, even though the universal `test_tool_allowlist` correctly allows it (it checks tool calls against the skill's declared `allowed-tools`). Removed the duplicate; the universal check is the right home for this rule.

## Test plan

- [x] All 284 harness unit tests pass.
- [x] Pre-existing e2e failure in `test_search_wikipedia_e2e` is unrelated.
- [ ] After merge: re-run `RunTests.bat check-warnings` — expect `ut_check_warnings_002` Actionability to grade null (no longer mechanically failing).
- [ ] After merge: re-run `RunTests.bat citation` — expect no regression; the universal allowlist check continues to enforce tool boundaries correctly.

## Note

check-runlogs Rule 2 will fail on this PR (rubric / validator changes invalidate existing runlog snapshots). Cleared by a follow-up runlog regen sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)