### PR TITLE
SKILL.md fixes for six failing-test patterns

### DIFF
--- a/plugin/skills/conflict-resolution/SKILL.md
+++ b/plugin/skills/conflict-resolution/SKILL.md
@@ -273,6 +273,13 @@ Suggest next steps:
 - **Never ignore a conflict.** GPS Element 4 requires ALL conflicts
   to be addressed. An unresolved conflict is acceptable (with
   explanation); an unacknowledged conflict is a GPS violation.
+- **Do NOT modify `proof_summaries`.** When a conflict resolves and
+  a proof summary already exists for the relevant question, updating
+  `proof_summaries[].resolved_conflict_ids` (or any other
+  proof-summary field) is `proof-conclusion`'s job — not this
+  skill's. Add the resolved conflict to the `conflicts` section
+  only; in your text reply, recommend the user invoke
+  `proof-conclusion` to refresh the affected proof summary.
 - **Independence analysis and weighing are separate steps.** Do not
   skip the independence analysis (Standard 46).
 - **The resolution rationale must be defensible.** "I think source A

--- a/plugin/skills/question-selection/SKILL.md
+++ b/plugin/skills/question-selection/SKILL.md
@@ -48,6 +48,9 @@ Read all sections of `research.json` and persons in
 - **Objective:** The overarching research goal. Every question must
   trace back to it.
 - **Open questions:** Status `open` or `in_progress`
+- **In-progress plan items:** Any `plan_items[].status == "in_progress"`
+  on an open question. These represent in-flight research the user
+  has already committed to.
 - **Resolved questions:** What has been answered
 - **Pedigree gaps:** Individuals missing a name, specific date, or
   locality at county/parish level (see `references/pedigree-analysis.md`)
@@ -57,6 +60,24 @@ Read all sections of `research.json` and persons in
 - **Hypotheses:** Active candidates being tested
 - **Log coverage:** What has been searched and where gaps remain
 - **Assertions:** The current evidence landscape
+
+### 1a. Finish what's already open before selecting a new question
+
+If any open question has plan items with `status: "in_progress"`,
+**do NOT create a new question.** Instead, recommend that the user
+complete the in-flight plan items first. Reference them by `pli_XXX`
+ID and name the repository/record type so the user knows exactly
+what to finish (e.g., "Complete `pli_006` — the Thomas Flynn
+probate search on FamilySearch — before adding new questions").
+
+Adding new questions while existing plans are mid-flight churns
+research direction without resolving anything; the in-flight item
+may produce evidence that changes which question is next-highest
+value. Only proceed to Step 2 (priority selection) when no
+in-progress plan items exist, or when the user explicitly overrides
+with "add a question anyway." In the override case, set the new
+question's `depends_on` to include the question whose plan is in
+flight.
 
 ### 2. Identify the highest-value question
 
@@ -234,6 +255,9 @@ fails, fix the errors before presenting. Tell the user:
 
 - **One question at a time.** Each invocation produces at most one
   new question or one exhaustive declaration.
+- **Finish what's open.** Do not introduce new questions while any
+  open question's plan items are `in_progress`. Recommend completing
+  the in-flight work first (see Step 1a).
 - **Sound basis required.** Do not build questions on unsound
   assumptions (claims that may be plausible but have no supporting
   evidence). If the premise is unverified, verify it first.

--- a/plugin/skills/search-full-text/SKILL.md
+++ b/plugin/skills/search-full-text/SKILL.md
@@ -124,6 +124,13 @@ Read `references/query-syntax.md` for operator rules.
 - **Abbreviations must be searched explicitly.** FTS does not
   auto-expand. If searching for William, also search Wm. If
   searching for Thomas, also search Thos.
+- **Mine prior records for known surname variants before querying.**
+  Scan existing `research.json` assertions and log entries for the
+  target surname. If prior records show a transcription variant
+  (e.g., a "Flinn" assertion or log entry when searching "Flynn"),
+  include the variant in your initial query set. FTS does not
+  auto-expand spelling variants — the work has already been done
+  upstream, and ignoring it wastes queries on the wrong spelling.
 - **Phrases tolerate one intervening word.** `"Ezekiel Pearce"`
   also matches "Ezekiel John Pearce."
 - **Wildcards:** `?` (one char), `*` (zero or more). Cannot appear
@@ -273,6 +280,14 @@ When a search returns no results:
 4. **Assess whether absence is meaningful** (negative evidence) —
    only when coverage is known to be good for that locality/period.
 5. Check for fallback plan items or suggest search-records/re-plan.
+6. **Do NOT execute unrelated diagnostic queries to "test" the FTS
+   index.** When a long string of variant queries returns zeros, the
+   right next step is to declare a coverage gap and log the negative
+   finding — not to query a common surname (`+Smith`, `+Jones`) to
+   see whether the tool is "broken." The tool's response is
+   authoritative. Diagnostic probes both inflate Tool Arguments cost
+   on unrelated subjects and rationalize away genuine negative
+   findings as "must be a test environment issue."
 
 ### 11. Queue cross-reference searches
 

--- a/plugin/skills/tree-edit/SKILL.md
+++ b/plugin/skills/tree-edit/SKILL.md
@@ -2,15 +2,19 @@
 name: tree-edit
 model: claude-sonnet-4-6
 description: Handles direct edits to tree.gedcomx.json — adding facts,
-  correcting values, creating persons, adding relationships, and merging
-  two persons confirmed to be the same individual. Use when the user says
-  "correct this name", "change birth year", "add occupation", "merge these
-  two persons", "fix this fact", "add a relationship", "this person's
-  name is wrong", when proof-conclusion requests a person merge after
-  confirming identity, or when the user needs to make a direct correction
-  to the tree file. Do NOT use when the user wants to search records (use
-  search-records), wants to write a conclusion (use proof-conclusion), or
-  wants to link assertions to persons (use person-evidence).
+  correcting values, creating persons, adding relationships, merging
+  two persons confirmed to be the same individual, and verifying that
+  the tree already reflects a known fact (no-op confirmation). Use when
+  the user says "correct this name", "change birth year", "add
+  occupation", "merge these two persons", "fix this fact", "add a
+  relationship", "this person's name is wrong", "verify the tree
+  reflects this", "check the tree", "make sure the tree shows", "confirm
+  this fact is in the tree", when proof-conclusion requests a person
+  merge after confirming identity, or when the user needs to make a
+  direct correction or verification against the tree file. Do NOT use
+  when the user wants to search records (use search-records), wants to
+  write a conclusion (use proof-conclusion), or wants to link assertions
+  to persons (use person-evidence).
 allowed-tools:
   - validate_research_schema
 ---
@@ -240,3 +244,14 @@ proof-conclusion first.
 
 **Conflicting evidence not yet resolved:** Do not pick a side. Tell the
 user to resolve the conflict in proof-conclusion before editing the tree.
+
+**Requested state already satisfied:** If the user asks to add, verify,
+or ensure something that already exists in `tree.gedcomx.json` with the
+correct value AND the supporting source, make NO changes. Report
+explicitly: "No edit needed — R1 (or F1, P1, etc.) already reflects this
+with source S1." Do NOT add `confidence`, `notes`, or any field not
+listed in `docs/specs/simplified-gedcomx-spec.md` §4.2 just to "mark"
+the verification — the simplified format deliberately omits GedcomX
+conclusion metadata (proof tiers live in `research.json`, not on the
+tree). The audit trail of the verification belongs in your text reply
+to the user, not in tree fields.


### PR DESCRIPTION
## Summary

Six targeted SKILL.md edits across four skills, all driven by the runlog triage earlier in this session. Each closes a specific gap the LLM legitimately stumbled into because the guidance was missing.

### `tree-edit` (2 fixes)

1. **Frontmatter description** — added verification trigger phrases (`"verify the tree"`, `"check the tree"`, `"make sure the tree shows"`, `"confirm this fact is in the tree"`). Fixes `ut_tree_edit_001` — the skill was failing to activate on "Please verify the tree reflects this correctly" because the trigger list covered only mutation phrasings.
2. **New decision-rule block: "Requested state already satisfied → no-op"** — when the user asks to add or verify something that already exists with correct value + source, make NO changes and say so explicitly. Forbids `confidence`, `notes`, and other non-spec fields per `docs/specs/simplified-gedcomx-spec.md` §4.2. Fixes `ut_tree_edit_002` where the skill added invalid schema fields on a no-op scenario.

### `question-selection` (1 fix)

- **New Step 1a: "Finish what's already open before selecting a new question"** — if any open question has plan items with `status: "in_progress"`, do NOT create a new question; recommend completing the in-flight items first (cite by `pli_XXX` ID). Plus a matching one-liner rule "Finish what's open." in Rules. Closes the gap that broke `ut_question_selection_001`: the test validator enforced "don't churn — finish what's open," but SKILL.md never documented the rule.

### `search-full-text` (2 fixes)

1. **Step 5 (Construct query)** — added bullet: *"Mine prior records for known surname variants before querying"*. Scan existing `research.json` assertions and log entries for the target surname; if prior records show a transcription variant (e.g., a "Flinn" assertion when searching "Flynn"), include the variant in the initial query set. Fixes `ut_search_full_text_010` — the test scenario already had a Flinn variant in `log_003` but the skill ignored it, wasting queries on Flynn-only.
2. **Step 10 (Handle nil results)** — added rule: *"Do NOT execute unrelated diagnostic queries (e.g., `+Smith`) to 'test' the FTS index."* Treat the tool's response as authoritative; log a coverage gap rather than rationalizing zero results as a tool malfunction. Fixes `ut_search_full_text_002` where the skill made a `+Smith` probe after seven valid Flynn variants returned zero.

### `conflict-resolution` (1 fix)

- **Important rules** — added: *"Do NOT modify `proof_summaries` — that's proof-conclusion's job."* Updating `proof_summaries[].resolved_conflict_ids` when a conflict resolves belongs to `proof-conclusion`; this skill should add the resolution to the `conflicts` section and recommend the user invoke `proof-conclusion` next. Fixes `ut_conflict_resolution_002` where the skill overran scope by updating `ps_001`.

## Intentionally NOT included

The triage also flagged a `locality-guide` SKILL.md fix (remove `wikipedia_search` from `allowed-tools`). PR-A's `derive_activated` fix supersedes the false-positive activation issue that prompted it, so removing the tool here would harm a legitimate capability surface for marginal benefit.

## Test plan

- [x] All 284 harness unit tests pass.
- [x] Pre-existing failure in `test_search_wikipedia_e2e` is unrelated.
- [ ] After merge: re-run skill suites for `tree-edit`, `question-selection`, `search-full-text`, `conflict-resolution` — expect the six previously-failing/partial tests to improve.

## Note

check-runlogs Rule 2 will fail on this PR (SKILL.md changes invalidate the runlog snapshots that referenced the old content). Cleared by a follow-up runlog regen sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)