### PR TITLE
Package mcp-server as a validated, installable .mcpb extension

### DIFF
--- a/.claude/agents/mcp-tool-scaffolder.md
+++ b/.claude/agents/mcp-tool-scaffolder.md
@@ -1,6 +1,6 @@
 ---
 name: mcp-tool-scaffolder
-description: Use when adding a new MCP tool to mcp-server/. Trigger phrases include "scaffold a new tool", "add an MCP tool for X", "generate the boilerplate for a tool". Given a tool name and a brief description of what it does, produces the standard four files (tool, types, smoke script, tests) and wires up index.ts. Always follows the existing wikipedia.ts as the canonical template.
+description: Use when adding a new MCP tool to mcp-server/. Trigger phrases include "scaffold a new tool", "add an MCP tool for X", "generate the boilerplate for a tool". Given a tool name and a brief description of what it does, produces the standard four files (tool, types, smoke script, tests) and wires it into tool-schemas.ts, index.ts, and manifest.json. Always follows the existing wikipedia.ts as the canonical template.
 ---
 
 # MCP Tool Scaffolder
@@ -29,15 +29,17 @@ Five files touched, in this order:
    `dev/try-wiki-search.ts` exactly.
 4. **`mcp-server/tests/tools/<name>.test.ts`** — vitest unit tests
    with mocked `fetch`. Cover happy path + each error path.
-5. **`mcp-server/src/index.ts`** — three additions, mirroring how
-   every existing tool is wired:
-   - Import the tool function, schema, and input type at the top
-     of the file.
-   - Add the schema to the `tools` array in
-     `ListToolsRequestSchema`.
-   - Add an `if (request.params.name === "<snake_case_name>")`
+5. **Wiring across `mcp-server/`** — mirroring how every existing
+   tool is wired:
+   - `src/tool-schemas.ts` — import the schema constant and add it to
+     the `allToolSchemas` array (this is the advertised tool list).
+   - `src/index.ts` — import the tool function and input type at the
+     top, then add an `if (request.params.name === "<snake_case_name>")`
      block in `CallToolRequestSchema`. Copy the structure of any
      existing block exactly — the try/catch shape is uniform.
+   - `manifest.json` — add `{ "name": "<snake_case_name>" }` to the
+     `tools` array. The packaging test (`tests/packaging/manifest.test.ts`)
+     fails if the manifest and `allToolSchemas` drift apart.
 
 ## Naming conventions (do not deviate)
 
@@ -83,7 +85,8 @@ match that. Read the directory and follow the majority.
    `wiki-search.ts` or `population.ts`) to match style.
 4. **Generate the five files** in the order above. Each file should
    compile with `npm run build` standalone.
-5. **Update `index.ts`** with the three additions. Don't break
+5. **Wire it up** in `src/tool-schemas.ts`, `src/index.ts`, and
+   `manifest.json` (per step 5 in the file list above). Don't break
    existing tools — only add.
 6. **Run `npm run build`** to verify the TypeScript compiles. Fix
    any errors before declaring done.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,11 +84,19 @@ catalog (descriptions, workflow), see `README.md`. This file is the
 agent operating manual — it covers architecture, conventions, and how
 to make changes, not what each individual tool/skill does.
 
-Tools are registered in `mcp-server/src/index.ts` and live in
-`mcp-server/src/tools/`. Per-tool behavioral contracts are in
+Tool implementations live in `mcp-server/src/tools/`. Their schemas are
+listed in `mcp-server/src/tool-schemas.ts` (`allToolSchemas`, the single
+source of truth for the advertised tool list); `src/index.ts` imports that
+list and dispatches calls. Per-tool behavioral contracts are in
 `docs/specs/<tool>-tool-spec.md`. Implementation plans (including for
 tools not yet built, such as `tree_attachments`) are in `docs/plan/`.
 Skills live in `plugin/skills/<skill>/SKILL.md`.
+
+The host artifact is the `.mcpb` desktop extension, built from
+`mcp-server/` with the `@anthropic-ai/mcpb` CLI. Its `manifest.json` is the
+install contract — including a `tools` array that must stay in sync with
+`allToolSchemas` (enforced by `tests/packaging/manifest.test.ts`). See
+`docs/specs/mcpb-package-spec.md`.
 
 ## Researcher profile in `research.json`
 
@@ -188,8 +196,10 @@ file so end users can be guided to fix it.
 ### MCP server tools
 
 Tools are defined in `mcp-server/src/tools/`. Each tool exports a
-single function and its schema. The entry point in `src/index.ts`
-imports them and registers them with the MCP server.
+single function and its schema. Add the schema to `allToolSchemas` in
+`src/tool-schemas.ts` (the list `src/index.ts` advertises and the
+packaging drift test checks), add the call dispatch to `src/index.ts`,
+and add the tool name to `manifest.json`'s `tools` array.
 
 Use generic tool names with provider parameters when scaling, not
 one tool per provider. For example, when we add real APIs, use
@@ -265,9 +275,9 @@ request, or you can call them explicitly with the Agent tool.
   tool.
 - **`mcp-tool-scaffolder`** — generates the standard four-file
   scaffolding (`src/types/<name>.ts`, `src/tools/<name>.ts`,
-  `dev/try-<name>.ts`, `tests/tools/<name>.test.ts`) and wires up
-  `mcp-server/src/index.ts`. Follows `wikipedia.ts` as the canonical
-  template. Requires the spec exist first.
+  `dev/try-<name>.ts`, `tests/tools/<name>.test.ts`) and wires it into
+  `src/tool-schemas.ts`, `src/index.ts`, and `manifest.json`. Follows
+  `wikipedia.ts` as the canonical template. Requires the spec exist first.
 - **`cowork-skill-builder`** — generates a Cowork skill that wraps
   an existing MCP tool, following `plugin/skills/search-wikipedia/` as
   the reference. Refuses to put network code in skills (architectural

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -15,6 +15,7 @@ cd mcp-server && npm test                            # Run MCP server tests only
 cd mcp-server && npx vitest run tests/tools/places.test.ts   # Run a single test file
 cd mcp-server && npx vitest run -t "test name"       # Run tests matching a name
 ./scripts/build-mcpb.sh                              # Package .mcpb extension (→ releases/)
+./scripts/verify-mcpb.sh                             # Verify the packed .mcpb (contents + boots)
 ./scripts/package-plugin.sh                          # Package plugin .zip (→ releases/)
 ```
 
@@ -47,7 +48,12 @@ Example: adding a "list providers" feature.
 
 1. **Add the tool to the MCP server.**
    - Create `mcp-server/src/tools/list-providers.ts`
-   - Register it in `mcp-server/src/index.ts`
+   - Add its schema to `allToolSchemas` in `mcp-server/src/tool-schemas.ts`
+     and its dispatch case to the `CallTool` handler in
+     `mcp-server/src/index.ts`
+   - Add its name to `tools` in `mcp-server/manifest.json` — the packaging
+     test (`tests/packaging/manifest.test.ts`) fails if the manifest and
+     the registry drift apart
    - Run `npm run build` in `mcp-server/`
    - Create `mcp-server/dev/try-list-providers.ts` — a one-shot smoke
      script that invokes the tool directly against live APIs. Follows

--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ You need both pieces.
 1. Download `genealogy-mcp.mcpb` from the latest release
 2. Open Claude Desktop → Settings → Extensions
 3. Click "Install Extension..." and select the .mcpb file
-4. The "Genealogy MCP" extension should appear in your list
+4. The "Genealogy Research" extension should appear in your list
 
 ### 2. Install the Cowork plugin
 

--- a/docs/specs/mcpb-package-spec.md
+++ b/docs/specs/mcpb-package-spec.md
@@ -1,0 +1,170 @@
+# MCPB Package — Build & Manifest Spec
+
+## Overview
+
+Defines what the host-side artifact — the Claude Desktop extension
+`releases/genealogy-mcp.mcpb` — must contain and how it is built, so that
+it installs cleanly in Claude Desktop and exposes the MCP server's tools.
+
+The `.mcpb` is a ZIP archive of the compiled MCP server plus a
+`manifest.json` that conforms to the official MCPB manifest schema. It is
+built from `mcp-server/` with the official `@anthropic-ai/mcpb` CLI.
+
+This spec is the source of truth the `spec-review` agent and
+`mcp-server/tests/packaging/manifest.test.ts` check the manifest and build
+against.
+
+---
+
+## Manifest contract
+
+`mcp-server/manifest.json` MUST conform to MCPB manifest schema version
+**`0.3`** (the current version as of 2025-12-02). Required and pinned
+fields:
+
+| Field | Requirement |
+|-------|-------------|
+| `manifest_version` | `"0.3"` |
+| `name` | `"genealogy-mcp"` (machine-readable id) |
+| `display_name` | `"Genealogy Research"` |
+| `version` | Semver; MUST equal `mcp-server/package.json` `version` |
+| `description` | Real one-line summary. MUST NOT contain `scaffold` or `hello-world` |
+| `author` | Object with non-empty `name` (MUST NOT be `"Your Name"`), plus `url` |
+| `repository` | `{ "type": "git", "url": "https://github.com/PioneerAIAcademy/cowork-genealogy" }` |
+| `homepage` | Repository URL |
+| `license` | `"Apache-2.0"` (matches `LICENSE`) |
+| `keywords` | Includes `genealogy`, `familysearch`, `mcp` |
+| `server` | See below |
+| `tools` | Array of `{ name }` for every registered tool (see Tool list) |
+| `compatibility` | See below |
+
+The manifest MUST NOT declare a `user_config` block. Per-user settings
+(`wikiApiUrl`, `wikiMarkdownDir`) are read only from
+`~/.familysearch-mcp/config.json` (`src/auth/config.ts`); the project
+convention forbids env-var injection, which is the only channel
+`user_config` offers.
+
+### `server`
+
+```json
+{
+  "type": "node",
+  "entry_point": "build/index.js",
+  "mcp_config": {
+    "command": "node",
+    "args": ["${__dirname}/build/index.js"]
+  }
+}
+```
+
+`${__dirname}` is the MCPB-substituted absolute path to the installed
+extension directory.
+
+### `compatibility`
+
+```json
+{
+  "platforms": ["darwin", "win32", "linux"],
+  "runtimes": { "node": ">=18.0.0" }
+}
+```
+
+A `claude_desktop` version constraint is intentionally omitted to avoid
+falsely blocking installs.
+
+### Tool list (`tools`)
+
+Every tool registered in `src/index.ts`'s `ListTools` handler MUST appear
+in `manifest.tools`, and no extras. As of this spec the set is the 21
+tools below; the drift test enforces equality with `allToolSchemas`
+(`src/tool-schemas.ts`):
+
+```
+wikipedia_search, place_search, login, logout, auth_status,
+place_collections, wiki_search, place_distance, place_population,
+place_external_links, image_read, record_search, match_two_examples,
+tree_read, fulltext_search, wiki_read, wiki_country_home,
+wiki_country_getting_started, wiki_country_online_records,
+wiki_country_research_tips, validate_research_schema
+```
+
+---
+
+## Bundle contract
+
+The packed `.mcpb` MUST contain:
+
+| Path | Why |
+|------|-----|
+| `manifest.json` | Install metadata + server config |
+| `package.json` | Node entry-point resolution |
+| `build/` | Compiled JS (`tsc` output); `build/index.js` is the entry point |
+| `config/familysearch.json` | Bundled OAuth clientId — without it every authenticated tool breaks (guarded by `tests/auth/bundled-client-config.test.ts`) |
+| `node_modules/` | **Production dependencies only** |
+
+The packed `.mcpb` MUST NOT contain:
+
+- `src/`, `tests/`, `dev/` (TypeScript source, tests, dev scripts)
+- `tsconfig.json`, `vitest.config.ts`
+- devDependencies (`typescript`, `vitest`, `@types/*`, `@anthropic-ai/mcpb`)
+- `node_modules/.cache/`, `node_modules/.bin/`
+
+Production-only `node_modules` is achieved by staging a clean tree and
+running `npm ci --omit=dev` against it — never by mutating the developer's
+`mcp-server/node_modules`. Source exclusions are enforced by
+`mcp-server/.mcpbignore`.
+
+---
+
+## Build process
+
+`scripts/build-mcpb.sh`:
+
+1. `cd mcp-server && npm install && npm run build` — compile to `build/`.
+2. Stage a temp dir (`mktemp -d`): copy `manifest.json`, `package.json`,
+   `package-lock.json`, `build/`, `config/`, `.mcpbignore`.
+3. `npm ci --omit=dev --ignore-scripts` inside the stage — production
+   `node_modules` only (`--ignore-scripts` skips dependency lifecycle
+   scripts for a deterministic, side-effect-free install).
+4. `npx mcpb validate <stage>` — fails the build on a non-conformant
+   manifest (`mcpb pack` also validates).
+5. `npx mcpb pack <stage> releases/genealogy-mcp.mcpb`.
+6. `npx mcpb info releases/genealogy-mcp.mcpb` — print the packed summary.
+
+Output: `releases/genealogy-mcp.mcpb` (gitignored via `releases/*`).
+
+---
+
+## Verification
+
+`scripts/verify-mcpb.sh` (run after build):
+
+1. Unzip `releases/genealogy-mcp.mcpb` to a temp dir.
+2. Assert every required bundle path is present and every forbidden path
+   is absent (per the Bundle contract).
+3. Launch `node build/index.js` from the unpacked dir and drive a
+   JSON-RPC `initialize` → `initialized` → `tools/list` handshake over
+   stdio. Assert the response lists exactly the 21 tools above.
+
+This proves the packed artifact — not just the source tree — boots and
+advertises its tools, which is the closest programmatic stand-in for an
+end-user install (the GUI "Install Extension" step is a manual layer in
+`docs/testing-guides/mcpb-install-testing-guide.md`).
+
+---
+
+## Versioning
+
+`manifest.json` `version`, `mcp-server/package.json` `version`, and the
+`new Server({ version })` literal in `src/index.ts` MUST stay in sync.
+This spec's baseline is `0.1.0` (first real packaged release, replacing
+the `0.0.1` scaffold).
+
+---
+
+## References
+
+- MCPB manifest schema: https://github.com/anthropics/mcpb/blob/main/MANIFEST.md
+- MCPB CLI commands: https://github.com/anthropics/mcpb/blob/main/CLI.md
+- Bundled clientId convention: `CLAUDE.md` → "Secrets/config convention"
+- Per-user config (`wikiApiUrl`, `wikiMarkdownDir`): `src/auth/config.ts`

--- a/docs/testing-guides/mcpb-install-testing-guide.md
+++ b/docs/testing-guides/mcpb-install-testing-guide.md
@@ -1,0 +1,195 @@
+# MCPB Install Testing Guide
+
+This guide walks **you (a developer/tester)** through verifying that the
+`.mcpb` desktop extension builds, validates, and installs correctly. Run
+it whenever you change the manifest, the build/verify scripts, the tool
+registry, or anything that ships inside the bundle.
+
+It is **not** end-user documentation — end-user install steps live in
+[README.md](../../README.md) → "Installation (for end users)".
+
+The contract these layers check is
+[`docs/specs/mcpb-package-spec.md`](../specs/mcpb-package-spec.md).
+
+Follow the layers in order. The first three are scriptable and run on any
+machine (including WSL2/Linux). Layers 4–5 require Claude Desktop and are
+the manual install/round-trip checks.
+
+---
+
+## Layer 1: Build the artifact
+
+**What this tests:** The build script compiles, stages a production-only
+tree, validates the manifest, and packs a `.mcpb`.
+
+**Time needed:** 2 minutes
+
+### Steps
+
+```bash
+cd /home/gennesis/cowork-genealogy
+./scripts/build-mcpb.sh
+```
+
+### What success looks like
+
+- `Manifest schema validation passes!`
+- An `mcpb info` summary: `genealogy-mcp@0.1.0`, a package size of a few MB
+  (production deps only), and a non-trivial `ignored (.mcpbignore) files`
+  count.
+- `Done. Created .../releases/genealogy-mcp.mcpb`
+
+### What failure looks like
+
+- A manifest validation error → the manifest violates the 0.3 schema; fix
+  it and re-run. The unit guard `mcp-server/tests/packaging/manifest.test.ts`
+  catches most of these earlier.
+- `npm ci` fails in the stage → `package-lock.json` is out of sync; run
+  `npm install` in `mcp-server/` and retry.
+
+---
+
+## Layer 2: Validate and inspect
+
+**What this tests:** The manifest conforms to the schema and the packed
+archive has no surprises.
+
+**Time needed:** 2 minutes
+
+### Steps
+
+```bash
+cd /home/gennesis/cowork-genealogy/mcp-server
+npx mcpb validate manifest.json
+npx mcpb info ../releases/genealogy-mcp.mcpb
+```
+
+### What success looks like
+
+- `Manifest schema validation passes!`
+- The archive's top-level entries are `manifest.json`, `package.json`,
+  `build/`, `config/`, `node_modules/` — nothing else.
+
+---
+
+## Layer 3: Boot the packed server
+
+**What this tests:** The packed bundle (not just the source tree) contains
+every production dependency and actually starts, and the server advertises
+exactly the tools the manifest declares.
+
+**Time needed:** 1 minute
+
+### Steps
+
+```bash
+cd /home/gennesis/cowork-genealogy
+./scripts/verify-mcpb.sh
+```
+
+### What success looks like
+
+- Every `present:` / `absent:` content check prints `ok`.
+- `server booted; tools/list returned all 21 tools`
+- `Verification passed.`
+
+### What failure looks like
+
+- A missing prod dependency → the unpacked server can't start; check that
+  the dep is in `dependencies` (not `devDependencies`) in
+  `mcp-server/package.json`.
+- A forbidden path present (e.g. `node_modules/typescript`) → the staging
+  step or `.mcpbignore` regressed.
+- Tool mismatch → `manifest.tools` drifted from the registry; the script
+  prints which names are missing/extra.
+
+---
+
+## Layer 4: Install in Claude Desktop
+
+**What this tests:** Claude Desktop accepts the bundle and registers the
+extension. **Prerequisite:** Claude Desktop installed (Windows or macOS).
+
+**Time needed:** 5 minutes
+
+### Steps
+
+1. Copy `releases/genealogy-mcp.mcpb` to the machine running Claude Desktop
+   (if you built in WSL2, copy it to the Windows side).
+2. Open Claude Desktop → **Settings → Extensions**.
+3. Click **Install Extension…** and select `genealogy-mcp.mcpb`.
+4. Confirm **"Genealogy Research"** appears in the extensions list.
+
+### What success looks like
+
+- The extension installs without an error dialog. (Claude Desktop will
+  note it is **unsigned** — that is expected; we do not sign the bundle
+  yet. Approve/allow it.)
+- Expanding the extension shows its tools.
+
+### What failure looks like
+
+- "Invalid extension" → the manifest or archive layout is wrong; re-run
+  Layers 1–3.
+- The extension installs but shows 0 tools → the server failed to start on
+  the host; check Claude Desktop's MCP logs.
+
+---
+
+## Layer 5: Exercise a tool + full Cowork round-trip
+
+**What this tests:** The installed host server actually responds, and the
+host → VM → skill pipeline works end-to-end.
+
+**Time needed:** 10 minutes
+
+### Steps
+
+1. In a Claude Desktop chat (with the extension installed), ask:
+
+   > "Find FamilySearch info for Ohio."
+
+   Claude should call `place_search` and report structured place data.
+
+2. Install the Cowork plugin too (`releases/genealogy-plugin.zip`, see
+   README → "Install the Cowork plugin"), then in a Cowork session ask:
+
+   > "Look up Albert Einstein on Wikipedia."
+
+   The `search-wikipedia` skill should call `wikipedia_search` and save a
+   markdown file to your working folder.
+
+### What success looks like
+
+A tool call returns structured JSON and (for the skill path) a file is
+written — proving host → MCP server → SDK bridge → VM → skill → file write.
+
+---
+
+## Known limitation: wiki-page tools need a local corpus
+
+Five tools — `wiki_read`, `wiki_country_home`,
+`wiki_country_getting_started`, `wiki_country_online_records`,
+`wiki_country_research_tips` — register and are callable, but read a
+pre-crawled markdown corpus via `wikiMarkdownDir` in
+`~/.familysearch-mcp/config.json`. That corpus is **not bundled in the
+`.mcpb`**, so on a stock install those tools throw a config-missing error
+at runtime. Shipping/hosting the corpus is tracked separately. The other
+16 tools work out of the box (the bundled FamilySearch clientId covers the
+authenticated tools; `wiki_search` and `place_population` use hosted
+services).
+
+---
+
+## Troubleshooting
+
+**Changes don't take effect after re-installing.** The MCP server is a
+*built* artifact. Rebuild (`./scripts/build-mcpb.sh`), then **fully quit
+Claude Desktop** (system tray → right-click → Quit; closing the window is
+not enough) before re-installing. See
+[DEVELOPMENT.md](../../DEVELOPMENT.md) → "Deploying a code change to Claude
+Desktop".
+
+**`login` opens no browser tab.** Expected in sandboxed contexts — Claude
+returns the authorization URL in its reply instead. See DEVELOPMENT.md →
+"`login` doesn't open a browser tab".

--- a/mcp-server/.mcpbignore
+++ b/mcp-server/.mcpbignore
@@ -1,0 +1,18 @@
+# Patterns excluded when packing the .mcpb (gitignore syntax).
+# The build script (scripts/build-mcpb.sh) packs a staged, production-only
+# tree, so these mainly guard against a direct `mcpb pack mcp-server/`
+# accidentally shipping source or dev files.
+
+# TypeScript source, tests, and developer-only scripts.
+src/
+tests/
+dev/
+tsconfig.json
+vitest.config.ts
+
+# Declaration files and source maps have no runtime purpose.
+*.d.ts
+*.map
+
+# Dependency caches.
+node_modules/.cache/

--- a/mcp-server/manifest.json
+++ b/mcp-server/manifest.json
@@ -1,12 +1,21 @@
 {
-  "manifest_version": "0.2",
+  "manifest_version": "0.3",
   "name": "genealogy-mcp",
   "display_name": "Genealogy Research",
-  "version": "0.0.1",
-  "description": "MCP server for genealogy research (hello-world scaffold)",
+  "version": "0.1.0",
+  "description": "Host-side genealogy research tools for Claude Cowork: FamilySearch records, places, the FamilySearch Wiki, and OAuth login.",
+  "long_description": "An MCP server that gives Claude host-side access to genealogy research tools: FamilySearch record and full-text search, place lookup with historical population data, FamilySearch Wiki retrieval, Wikipedia summaries, and a FamilySearch OAuth login flow. Network-dependent work runs here on the host; it pairs with the Genealogy Research Cowork plugin that runs inside the sandboxed VM.",
   "author": {
-    "name": "Your Name"
+    "name": "Pioneer AI Academy",
+    "url": "https://github.com/PioneerAIAcademy/cowork-genealogy"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/PioneerAIAcademy/cowork-genealogy"
+  },
+  "homepage": "https://github.com/PioneerAIAcademy/cowork-genealogy",
+  "license": "Apache-2.0",
+  "keywords": ["genealogy", "familysearch", "family-history", "mcp", "research"],
   "server": {
     "type": "node",
     "entry_point": "build/index.js",
@@ -14,5 +23,32 @@
       "command": "node",
       "args": ["${__dirname}/build/index.js"]
     }
+  },
+  "tools": [
+    { "name": "wikipedia_search" },
+    { "name": "place_search" },
+    { "name": "login" },
+    { "name": "logout" },
+    { "name": "auth_status" },
+    { "name": "place_collections" },
+    { "name": "wiki_search" },
+    { "name": "place_distance" },
+    { "name": "place_population" },
+    { "name": "place_external_links" },
+    { "name": "image_read" },
+    { "name": "record_search" },
+    { "name": "match_two_examples" },
+    { "name": "tree_read" },
+    { "name": "fulltext_search" },
+    { "name": "wiki_read" },
+    { "name": "wiki_country_home" },
+    { "name": "wiki_country_getting_started" },
+    { "name": "wiki_country_online_records" },
+    { "name": "wiki_country_research_tips" },
+    { "name": "validate_research_schema" }
+  ],
+  "compatibility": {
+    "platforms": ["darwin", "win32", "linux"],
+    "runtimes": { "node": ">=18.0.0" }
   }
 }

--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "genealogy-mcp-server",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "genealogy-mcp-server",
-      "version": "0.0.1",
+      "version": "0.1.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",
         "cheerio": "^1.0.0",
@@ -14,10 +14,42 @@
         "turndown": "^7.2.0"
       },
       "devDependencies": {
+        "@anthropic-ai/mcpb": "^2.1.2",
         "@types/node": "^20.0.0",
         "@types/turndown": "^5.0.5",
         "typescript": "^5.0.0",
         "vitest": "^4.1.4"
+      }
+    },
+    "node_modules/@anthropic-ai/mcpb": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/mcpb/-/mcpb-2.1.2.tgz",
+      "integrity": "sha512-goRbBC8ySo7SWb7tRzr+tL6FxDc4JPTRCdgfD2omba7freofvjq5rom1lBnYHZHo6Mizs1jAHJeN53aZbDoy8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/prompts": "^6.0.1",
+        "commander": "^13.1.0",
+        "fflate": "^0.8.2",
+        "galactus": "^1.0.0",
+        "ignore": "^7.0.5",
+        "node-forge": "^1.3.2",
+        "pretty-bytes": "^5.6.0",
+        "zod": "^3.25.67",
+        "zod-to-json-schema": "^3.24.6"
+      },
+      "bin": {
+        "mcpb": "dist/cli/cli.js"
+      }
+    },
+    "node_modules/@anthropic-ai/mcpb/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@emnapi/core": {
@@ -64,6 +96,237 @@
       },
       "peerDependencies": {
         "hono": "^4"
+      }
+    },
+    "node_modules/@inquirer/checkbox": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-3.0.1.tgz",
+      "integrity": "sha512-0hm2nrToWUdD6/UHnel/UKGdk1//ke5zGUpHIvk5ZWmaKezlGxZkOJXNSWsdxO/rEqTkbB3lNC2J6nBElV2aAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^9.2.1",
+        "@inquirer/figures": "^1.0.6",
+        "@inquirer/type": "^2.0.0",
+        "ansi-escapes": "^4.3.2",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/confirm": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-4.0.1.tgz",
+      "integrity": "sha512-46yL28o2NJ9doViqOy0VDcoTzng7rAb6yPQKU7VDLqkmbCaH4JqK4yk4XqlzNWy9PVC5pG1ZUXPBQv+VqnYs2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^9.2.1",
+        "@inquirer/type": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/core": {
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-9.2.1.tgz",
+      "integrity": "sha512-F2VBt7W/mwqEU4bL0RnHNZmC/OxzNx9cOYxHqnXX3MP6ruYvZUZAW9imgN9+h/uBT/oP8Gh888J2OZSbjSeWcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/figures": "^1.0.6",
+        "@inquirer/type": "^2.0.0",
+        "@types/mute-stream": "^0.0.4",
+        "@types/node": "^22.5.5",
+        "@types/wrap-ansi": "^3.0.0",
+        "ansi-escapes": "^4.3.2",
+        "cli-width": "^4.1.0",
+        "mute-stream": "^1.0.0",
+        "signal-exit": "^4.1.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^6.2.0",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/@types/node": {
+      "version": "22.19.19",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
+      "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@inquirer/editor": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-3.0.1.tgz",
+      "integrity": "sha512-VA96GPFaSOVudjKFraokEEmUQg/Lub6OXvbIEZU1SDCmBzRkHGhxoFAVaF30nyiB4m5cEbDgiI2QRacXZ2hw9Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^9.2.1",
+        "@inquirer/type": "^2.0.0",
+        "external-editor": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/expand": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-3.0.1.tgz",
+      "integrity": "sha512-ToG8d6RIbnVpbdPdiN7BCxZGiHOTomOX94C2FaT5KOHupV40tKEDozp12res6cMIfRKrXLJyexAZhWVHgbALSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^9.2.1",
+        "@inquirer/type": "^2.0.0",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/figures": {
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.15.tgz",
+      "integrity": "sha512-t2IEY+unGHOzAaVM5Xx6DEWKeXlDDcNPeDyUpsRc6CUhBfU3VQOEl+Vssh7VNp1dR8MdUJBWhuObjXCsVpjN5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/input": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-3.0.1.tgz",
+      "integrity": "sha512-BDuPBmpvi8eMCxqC5iacloWqv+5tQSJlUafYWUe31ow1BVXjW2a5qe3dh4X/Z25Wp22RwvcaLCc2siHobEOfzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^9.2.1",
+        "@inquirer/type": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/number": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-2.0.1.tgz",
+      "integrity": "sha512-QpR8jPhRjSmlr/mD2cw3IR8HRO7lSVOnqUvQa8scv1Lsr3xoAMMworcYW3J13z3ppjBFBD2ef1Ci6AE5Qn8goQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^9.2.1",
+        "@inquirer/type": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/password": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-3.0.1.tgz",
+      "integrity": "sha512-haoeEPUisD1NeE2IanLOiFr4wcTXGWrBOyAyPZi1FfLJuXOzNmxCJPgUrGYKVh+Y8hfGJenIfz5Wb/DkE9KkMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^9.2.1",
+        "@inquirer/type": "^2.0.0",
+        "ansi-escapes": "^4.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/prompts": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-6.0.1.tgz",
+      "integrity": "sha512-yl43JD/86CIj3Mz5mvvLJqAOfIup7ncxfJ0Btnl0/v5TouVUyeEdcpknfgc+yMevS/48oH9WAkkw93m7otLb/A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/checkbox": "^3.0.1",
+        "@inquirer/confirm": "^4.0.1",
+        "@inquirer/editor": "^3.0.1",
+        "@inquirer/expand": "^3.0.1",
+        "@inquirer/input": "^3.0.1",
+        "@inquirer/number": "^2.0.1",
+        "@inquirer/password": "^3.0.1",
+        "@inquirer/rawlist": "^3.0.1",
+        "@inquirer/search": "^2.0.1",
+        "@inquirer/select": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/rawlist": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-3.0.1.tgz",
+      "integrity": "sha512-VgRtFIwZInUzTiPLSfDXK5jLrnpkuSOh1ctfaoygKAdPqjcjKYmGh6sCY1pb0aGnCGsmhUxoqLDUAU0ud+lGXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^9.2.1",
+        "@inquirer/type": "^2.0.0",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/search": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-2.0.1.tgz",
+      "integrity": "sha512-r5hBKZk3g5MkIzLVoSgE4evypGqtOannnB3PKTG9NRZxyFRKcfzrdxXXPcoJQsxJPzvdSU2Rn7pB7lw0GCmGAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^9.2.1",
+        "@inquirer/figures": "^1.0.6",
+        "@inquirer/type": "^2.0.0",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/select": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-3.0.1.tgz",
+      "integrity": "sha512-lUDGUxPhdWMkN/fHy1Lk7pF3nK1fh/gqeyWXmctefhxLYxlDsc7vsPBEpxrfVGDsVdyYJsiJoD4bJ1b623cV1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^9.2.1",
+        "@inquirer/figures": "^1.0.6",
+        "@inquirer/type": "^2.0.0",
+        "ansi-escapes": "^4.3.2",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-2.0.0.tgz",
+      "integrity": "sha512-XvJRx+2KR3YXyYtPUUy+qd9i7p+GO9Ko6VIIpWlBrpWwXDv8WLFeHTxz35CfQFUiBMLXlGHhGzys7lqit9gWag==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mute-stream": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
@@ -455,6 +718,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/mute-stream": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mute-stream/-/mute-stream-0.0.4.tgz",
+      "integrity": "sha512-CPM9nzrCPPJHQNA9keH9CVkVI+WR5kMa+7XEs5jcGQ0VoAGnLv242w8lIVgwAEfmE4oufJRaTc9PNLQl0ioAow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/node": {
       "version": "20.19.41",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.41.tgz",
@@ -469,6 +742,13 @@
       "version": "5.0.6",
       "resolved": "https://registry.npmjs.org/@types/turndown/-/turndown-5.0.6.tgz",
       "integrity": "sha512-ru00MoyeeouE5BX4gRL+6m/BsDfbRayOskWqUvh7CLGW+UXxHQItqALa38kKnOiZPqJrtzJUgAC2+F0rL1S4Pg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/wrap-ansi": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/wrap-ansi/-/wrap-ansi-3.0.0.tgz",
+      "integrity": "sha512-ltIpx+kM7g/MLRZfkbL7EsCEjfzCcScLpkg37eXEtx5kmrAKBkTJwd1GIAjDSL8wTpM6Hzn5YO4pSb91BEwu1g==",
       "dev": true,
       "license": "MIT"
     },
@@ -631,6 +911,48 @@
         }
       }
     },
+    "node_modules/ansi-escapes": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.21.3"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -750,6 +1072,13 @@
         "node": ">=18"
       }
     },
+    "node_modules/chardet": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cheerio": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.2.0.tgz",
@@ -790,6 +1119,46 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/cli-width": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
+      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/commander": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
+      "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/content-disposition": {
@@ -1049,6 +1418,13 @@
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
       "license": "MIT"
     },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/encodeurl": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
@@ -1237,6 +1613,34 @@
         "express": ">= 4.11"
       }
     },
+    "node_modules/external-editor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
+      "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chardet": "^0.7.0",
+        "iconv-lite": "^0.4.24",
+        "tmp": "^0.0.33"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/external-editor/node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -1277,6 +1681,13 @@
         }
       }
     },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/finalhandler": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
@@ -1298,6 +1709,20 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/flora-colossus": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/flora-colossus/-/flora-colossus-2.0.0.tgz",
+      "integrity": "sha512-dz4HxH6pOvbUzZpZ/yXhafjbR2I8cenK5xL0KtBFb7U2ADsR+OwXifnxZjij/pZWF775uSCMzWVd+jDik2H2IA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.4",
+        "fs-extra": "^10.1.0"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -1314,6 +1739,21 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/fsevents": {
@@ -1338,6 +1778,21 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/galactus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/galactus/-/galactus-1.0.0.tgz",
+      "integrity": "sha512-R1fam6D4CyKQGNlvJne4dkNF+PvUUl7TAJInvTGa9fti9qAv95quQz29GXapA4d8Ec266mJJxFVh82M4GIIGDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.4",
+        "flora-colossus": "^2.0.0",
+        "fs-extra": "^10.1.0"
+      },
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/get-intrinsic": {
@@ -1388,6 +1843,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/has-symbols": {
       "version": "1.1.0",
@@ -1485,6 +1947,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -1522,6 +1994,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-inside-container": {
@@ -1589,6 +2071,19 @@
       "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
       "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
       "license": "BSD-2-Clause"
+    },
+    "node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
     },
     "node_modules/lightningcss": {
       "version": "1.32.0",
@@ -1922,6 +2417,16 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
+    "node_modules/mute-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-1.0.0.tgz",
+      "integrity": "sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
     "node_modules/nanoid": {
       "version": "3.3.12",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
@@ -1948,6 +2453,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-forge": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
+      "integrity": "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==",
+      "dev": true,
+      "license": "(BSD-3-Clause OR GPL-2.0)",
+      "engines": {
+        "node": ">= 6.13.0"
       }
     },
     "node_modules/nth-check": {
@@ -2031,6 +2546,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/parse5": {
@@ -2173,6 +2698,19 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/pretty-bytes": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.6.0.tgz",
+      "integrity": "sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/proxy-addr": {
@@ -2471,6 +3009,19 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -2503,6 +3054,34 @@
       "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
@@ -2548,6 +3127,19 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "os-tmpdir": "~1.0.2"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
     "node_modules/toidentifier": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
@@ -2576,6 +3168,19 @@
       "engines": {
         "node": ">=18",
         "npm": ">=9"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/type-is": {
@@ -2638,6 +3243,16 @@
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
     },
     "node_modules/unpipe": {
       "version": "1.0.0",
@@ -2879,6 +3494,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -2893,6 +3523,19 @@
       "dependencies": {
         "is-wsl": "^3.1.0"
       },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yoctocolors-cjs": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.3.tgz",
+      "integrity": "sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==",
+      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       },

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "genealogy-mcp-server",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "description": "MCP server for genealogy research",
   "main": "build/index.js",
   "type": "module",
@@ -18,6 +18,7 @@
     "turndown": "^7.2.0"
   },
   "devDependencies": {
+    "@anthropic-ai/mcpb": "^2.1.2",
     "@types/node": "^20.0.0",
     "@types/turndown": "^5.0.5",
     "typescript": "^5.0.0",

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -4,71 +4,45 @@ import {
   CallToolRequestSchema,
   ListToolsRequestSchema
 } from "@modelcontextprotocol/sdk/types.js";
-import { wikipediaSearch, wikipediaSearchSchema, type WikipediaSearchInput } from "./tools/wikipedia.js";
-import { placeSearchTool, placeSearchToolSchema, type PlaceSearchToolInput } from "./tools/place-search.js";
-import { loginTool, loginToolSchema, type LoginToolInput } from "./tools/login.js";
-import { logoutTool, logoutToolSchema, type LogoutToolInput } from "./tools/logout.js";
-import { authStatusTool, authStatusToolSchema, type AuthStatusToolInput } from "./tools/auth-status.js";
-import { placeCollectionsTool, placeCollectionsToolSchema, type PlaceCollectionsToolInput } from "./tools/place-collections.js";
-import { wikiSearch, wikiSearchSchema, type WikiSearchInput } from "./tools/wiki-search.js";
-import { placeDistanceTool, placeDistanceToolSchema, type PlaceDistanceInput } from "./tools/distance.js";
-import { populationTool, populationToolSchema, type PopulationToolInput } from "./tools/place-population.js";
-import { placeExternalLinksTool, placeExternalLinksToolSchema, type PlaceExternalLinksToolInput } from "./tools/place-external-links.js";
-import { imageReadTool, imageReadToolSchema, type ImageReadInput } from "./tools/image-read.js";
-import { recordSearchTool, recordSearchToolSchema } from "./tools/record-search.js";
+import { wikipediaSearch, type WikipediaSearchInput } from "./tools/wikipedia.js";
+import { placeSearchTool, type PlaceSearchToolInput } from "./tools/place-search.js";
+import { loginTool, type LoginToolInput } from "./tools/login.js";
+import { logoutTool, type LogoutToolInput } from "./tools/logout.js";
+import { authStatusTool, type AuthStatusToolInput } from "./tools/auth-status.js";
+import { placeCollectionsTool, type PlaceCollectionsToolInput } from "./tools/place-collections.js";
+import { wikiSearch, type WikiSearchInput } from "./tools/wiki-search.js";
+import { placeDistanceTool, type PlaceDistanceInput } from "./tools/distance.js";
+import { populationTool, type PopulationToolInput } from "./tools/place-population.js";
+import { placeExternalLinksTool, type PlaceExternalLinksToolInput } from "./tools/place-external-links.js";
+import { imageReadTool, type ImageReadInput } from "./tools/image-read.js";
+import { recordSearchTool } from "./tools/record-search.js";
 import type { RecordSearchInput } from "./types/record-search.js";
-import { matchTwoExamples, matchTwoExamplesSchema } from "./tools/match-two-examples.js";
+import { matchTwoExamples } from "./tools/match-two-examples.js";
 import type { MatchTwoExamplesInput } from "./types/match-two-examples.js";
-import { treeReadTool, treeReadToolSchema, type TreeReadToolInput } from "./tools/tree-read.js";
-import { fulltextSearchTool, fulltextSearchToolSchema } from "./tools/fulltext-search.js";
+import { treeReadTool, type TreeReadToolInput } from "./tools/tree-read.js";
+import { fulltextSearchTool } from "./tools/fulltext-search.js";
 import type { FulltextSearchInput } from "./types/fulltext-search.js";
-import { wikiReadTool, wikiReadSchema, type WikiReadInput } from "./tools/wiki-read.js";
+import { wikiReadTool, type WikiReadInput } from "./tools/wiki-read.js";
 import {
   wikiCountryHomeTool,
-  wikiCountryHomeSchema,
   wikiCountryGettingStartedTool,
-  wikiCountryGettingStartedSchema,
   wikiCountryOnlineRecordsTool,
-  wikiCountryOnlineRecordsSchema,
   wikiCountryResearchTipsTool,
-  wikiCountryResearchTipsSchema,
   type WikiCountryInput,
 } from "./tools/wiki-country-page.js";
 import {
   validateResearchSchema,
-  validateResearchSchemaSchema,
   type ValidateResearchSchemaInput,
 } from "./tools/validate-research-schema.js";
+import { allToolSchemas } from "./tool-schemas.js";
 
 const server = new Server(
-  { name: "genealogy-mcp", version: "0.0.1" },
+  { name: "genealogy-mcp", version: "0.1.0" },
   { capabilities: { tools: {} } }
 );
 
 server.setRequestHandler(ListToolsRequestSchema, async () => ({
-  tools: [
-    wikipediaSearchSchema,
-    placeSearchToolSchema,
-    loginToolSchema,
-    logoutToolSchema,
-    authStatusToolSchema,
-    placeCollectionsToolSchema,
-    wikiSearchSchema,
-    placeDistanceToolSchema,
-    populationToolSchema,
-    placeExternalLinksToolSchema,
-    imageReadToolSchema,
-    recordSearchToolSchema,
-    matchTwoExamplesSchema,
-    treeReadToolSchema,
-    fulltextSearchToolSchema,
-    wikiReadSchema,
-    wikiCountryHomeSchema,
-    wikiCountryGettingStartedSchema,
-    wikiCountryOnlineRecordsSchema,
-    wikiCountryResearchTipsSchema,
-    validateResearchSchemaSchema,
-  ],
+  tools: allToolSchemas,
 }));
 
 server.setRequestHandler(CallToolRequestSchema, async (request) => {

--- a/mcp-server/src/tool-schemas.ts
+++ b/mcp-server/src/tool-schemas.ts
@@ -1,0 +1,53 @@
+// Single source of truth for the tool schemas advertised by the MCP
+// server. `index.ts` spreads this into its ListTools handler, and the
+// packaging drift test (tests/packaging/manifest.test.ts) imports it to
+// assert manifest.tools stays in sync with what's registered. Keeping it
+// in its own module means the test can read the list without importing
+// index.ts, which connects the stdio transport as a side effect.
+import { wikipediaSearchSchema } from "./tools/wikipedia.js";
+import { placeSearchToolSchema } from "./tools/place-search.js";
+import { loginToolSchema } from "./tools/login.js";
+import { logoutToolSchema } from "./tools/logout.js";
+import { authStatusToolSchema } from "./tools/auth-status.js";
+import { placeCollectionsToolSchema } from "./tools/place-collections.js";
+import { wikiSearchSchema } from "./tools/wiki-search.js";
+import { placeDistanceToolSchema } from "./tools/distance.js";
+import { populationToolSchema } from "./tools/place-population.js";
+import { placeExternalLinksToolSchema } from "./tools/place-external-links.js";
+import { imageReadToolSchema } from "./tools/image-read.js";
+import { recordSearchToolSchema } from "./tools/record-search.js";
+import { matchTwoExamplesSchema } from "./tools/match-two-examples.js";
+import { treeReadToolSchema } from "./tools/tree-read.js";
+import { fulltextSearchToolSchema } from "./tools/fulltext-search.js";
+import { wikiReadSchema } from "./tools/wiki-read.js";
+import {
+  wikiCountryHomeSchema,
+  wikiCountryGettingStartedSchema,
+  wikiCountryOnlineRecordsSchema,
+  wikiCountryResearchTipsSchema,
+} from "./tools/wiki-country-page.js";
+import { validateResearchSchemaSchema } from "./tools/validate-research-schema.js";
+
+export const allToolSchemas = [
+  wikipediaSearchSchema,
+  placeSearchToolSchema,
+  loginToolSchema,
+  logoutToolSchema,
+  authStatusToolSchema,
+  placeCollectionsToolSchema,
+  wikiSearchSchema,
+  placeDistanceToolSchema,
+  populationToolSchema,
+  placeExternalLinksToolSchema,
+  imageReadToolSchema,
+  recordSearchToolSchema,
+  matchTwoExamplesSchema,
+  treeReadToolSchema,
+  fulltextSearchToolSchema,
+  wikiReadSchema,
+  wikiCountryHomeSchema,
+  wikiCountryGettingStartedSchema,
+  wikiCountryOnlineRecordsSchema,
+  wikiCountryResearchTipsSchema,
+  validateResearchSchemaSchema,
+];

--- a/mcp-server/tests/packaging/manifest.test.ts
+++ b/mcp-server/tests/packaging/manifest.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { allToolSchemas } from "../../src/tool-schemas.js";
+
+// Contract: docs/specs/mcpb-package-spec.md § "Manifest contract".
+// These guard the .mcpb manifest against shipping scaffold placeholders,
+// a stale schema version, or a tool list that has drifted from what the
+// server actually registers.
+
+const here = dirname(fileURLToPath(import.meta.url));
+const mcpRoot = join(here, "..", "..");
+
+const manifest = JSON.parse(
+  readFileSync(join(mcpRoot, "manifest.json"), "utf8"),
+) as Record<string, any>;
+const pkg = JSON.parse(
+  readFileSync(join(mcpRoot, "package.json"), "utf8"),
+) as { version: string };
+
+describe("mcpb manifest", () => {
+  it("uses manifest schema version 0.3", () => {
+    expect(manifest.manifest_version).toBe("0.3");
+  });
+
+  it("has the required top-level fields", () => {
+    for (const field of ["name", "version", "description", "author", "server"]) {
+      expect(manifest[field], `missing ${field}`).toBeDefined();
+    }
+    expect(manifest.name).toBe("genealogy-mcp");
+  });
+
+  it("keeps version in sync with package.json", () => {
+    expect(manifest.version).toBe(pkg.version);
+  });
+
+  it("carries no scaffold placeholders", () => {
+    expect(manifest.author?.name).toBeTruthy();
+    expect(manifest.author.name).not.toBe("Your Name");
+    const desc = String(manifest.description).toLowerCase();
+    expect(desc).not.toContain("scaffold");
+    expect(desc).not.toContain("hello-world");
+  });
+
+  it("declares the node server with the build entry point", () => {
+    expect(manifest.server.type).toBe("node");
+    expect(manifest.server.entry_point).toBe("build/index.js");
+    expect(manifest.server.mcp_config.command).toBe("node");
+    expect(manifest.server.mcp_config.args).toContain(
+      "${__dirname}/build/index.js",
+    );
+  });
+
+  it("declares cross-platform compatibility and a node runtime", () => {
+    const platforms: string[] = manifest.compatibility?.platforms ?? [];
+    for (const p of ["darwin", "win32", "linux"]) {
+      expect(platforms, `missing platform ${p}`).toContain(p);
+    }
+    expect(manifest.compatibility?.runtimes?.node).toBeTruthy();
+  });
+
+  it("does not declare user_config (per the config-file convention)", () => {
+    expect(manifest.user_config).toBeUndefined();
+  });
+
+  it("lists exactly the tools registered in tool-schemas.ts", () => {
+    const declared: string[] = (manifest.tools ?? [])
+      .map((t: { name: string }) => t.name)
+      .sort();
+    const registered = allToolSchemas.map((s) => s.name).sort();
+    expect(declared).toEqual(registered);
+  });
+});

--- a/scripts/build-mcpb.sh
+++ b/scripts/build-mcpb.sh
@@ -1,23 +1,40 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Builds the Claude Desktop extension at releases/genealogy-mcp.mcpb.
+# Contract: docs/specs/mcpb-package-spec.md.
+#
+# We pack a staged, production-only copy of mcp-server/ (not the dev tree)
+# so the bundle ships compiled JS + prod deps only — never devDependencies
+# (typescript, vitest, @anthropic-ai/mcpb) or TypeScript source.
+
 cd "$(dirname "$0")/.."
+ROOT="$(pwd)"
+OUT="$ROOT/releases/genealogy-mcp.mcpb"
 
 echo "Building MCP server..."
-cd mcp-server
+cd "$ROOT/mcp-server"
 npm install
 npm run build
-cd ..
 
-echo "Packaging .mcpb..."
-mkdir -p releases
-cd mcp-server
-zip -r ../releases/genealogy-mcp.mcpb \
-  manifest.json \
-  package.json \
-  build/ \
-  config/ \
-  node_modules/
-cd ..
+echo "Staging production-only tree..."
+STAGE="$(mktemp -d)"
+trap 'rm -rf "$STAGE"' EXIT
+cp manifest.json package.json package-lock.json .mcpbignore "$STAGE/"
+cp -R build config "$STAGE/"
 
-echo "Done. Created releases/genealogy-mcp.mcpb"
+echo "Installing production dependencies into the stage..."
+( cd "$STAGE" && npm ci --omit=dev --ignore-scripts )
+
+echo "Validating manifest..."
+npx mcpb validate "$STAGE"
+
+echo "Packing .mcpb..."
+mkdir -p "$ROOT/releases"
+npx mcpb pack "$STAGE" "$OUT"
+
+echo
+npx mcpb info "$OUT"
+echo
+echo "Done. Created $OUT"
+echo "Verify it with: ./scripts/verify-mcpb.sh"

--- a/scripts/verify-mcpb.sh
+++ b/scripts/verify-mcpb.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Verifies the packed releases/genealogy-mcp.mcpb against the bundle
+# contract in docs/specs/mcpb-package-spec.md: required files present,
+# forbidden files (source/tests/devDeps) absent, and the packed server
+# actually boots and advertises all its tools over stdio.
+#
+# This is the programmatic stand-in for an end-user install. The manual
+# Claude Desktop install is a layer in
+# docs/testing-guides/mcpb-install-testing-guide.md.
+
+cd "$(dirname "$0")/.."
+ROOT="$(pwd)"
+MCPB="$ROOT/releases/genealogy-mcp.mcpb"
+
+if [ ! -f "$MCPB" ]; then
+  echo "ERROR: $MCPB not found. Run ./scripts/build-mcpb.sh first." >&2
+  exit 1
+fi
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+echo "Unpacking $(basename "$MCPB") ..."
+unzip -q "$MCPB" -d "$TMP"
+
+fail=0
+require() {
+  if [ -e "$TMP/$1" ]; then echo "  ok    present: $1"; else echo "  FAIL  missing: $1"; fail=1; fi
+}
+forbid() {
+  if [ -e "$TMP/$1" ]; then echo "  FAIL  present (should be absent): $1"; fail=1; else echo "  ok    absent:  $1"; fi
+}
+
+echo "Checking bundle contents..."
+require manifest.json
+require package.json
+require build/index.js
+require config/familysearch.json
+require node_modules/@modelcontextprotocol/sdk
+
+forbid src
+forbid tests
+forbid dev
+forbid tsconfig.json
+forbid vitest.config.ts
+forbid node_modules/typescript
+forbid node_modules/vitest
+forbid node_modules/@anthropic-ai/mcpb
+
+if [ "$fail" -ne 0 ]; then
+  echo "Bundle content checks FAILED." >&2
+  exit 1
+fi
+echo "Bundle content checks passed."
+
+echo "Booting packed server (initialize + tools/list over stdio)..."
+cat > "$TMP/handshake.mjs" <<'EOF'
+import { spawn } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const dir = process.argv[2];
+const manifest = JSON.parse(readFileSync(join(dir, "manifest.json"), "utf8"));
+const expected = (manifest.tools ?? []).map((t) => t.name).sort();
+
+const child = spawn("node", ["build/index.js"], {
+  cwd: dir,
+  stdio: ["pipe", "pipe", "inherit"],
+});
+
+let buf = "";
+const pending = new Map();
+child.stdout.on("data", (chunk) => {
+  buf += chunk.toString();
+  let i;
+  while ((i = buf.indexOf("\n")) >= 0) {
+    const line = buf.slice(0, i).trim();
+    buf = buf.slice(i + 1);
+    if (!line) continue;
+    let msg;
+    try { msg = JSON.parse(line); } catch { continue; }
+    if (msg.id != null && pending.has(msg.id)) {
+      pending.get(msg.id)(msg);
+      pending.delete(msg.id);
+    }
+  }
+});
+
+const send = (obj) => child.stdin.write(JSON.stringify(obj) + "\n");
+const request = (id, method, params) =>
+  new Promise((resolve) => {
+    pending.set(id, resolve);
+    send({ jsonrpc: "2.0", id, method, params });
+  });
+
+const timeout = setTimeout(() => {
+  console.error("  FAIL  timed out waiting for the server");
+  child.kill();
+  process.exit(1);
+}, 15000);
+
+try {
+  const init = await request(1, "initialize", {
+    protocolVersion: "2024-11-05",
+    capabilities: {},
+    clientInfo: { name: "verify-mcpb", version: "1.0.0" },
+  });
+  if (init.error) throw new Error("initialize failed: " + JSON.stringify(init.error));
+
+  send({ jsonrpc: "2.0", method: "notifications/initialized" });
+
+  const list = await request(2, "tools/list", {});
+  if (list.error) throw new Error("tools/list failed: " + JSON.stringify(list.error));
+
+  clearTimeout(timeout);
+  child.kill();
+
+  const got = (list.result?.tools ?? []).map((t) => t.name).sort();
+  const missing = expected.filter((n) => !got.includes(n));
+  const extra = got.filter((n) => !expected.includes(n));
+  if (missing.length || extra.length || got.length !== expected.length) {
+    console.error(`  FAIL  tool mismatch (manifest ${expected.length}, server ${got.length})`);
+    if (missing.length) console.error("        missing from server:", missing.join(", "));
+    if (extra.length) console.error("        extra on server:", extra.join(", "));
+    process.exit(1);
+  }
+  console.log(`  ok    server booted; tools/list returned all ${got.length} tools`);
+  process.exit(0);
+} catch (e) {
+  clearTimeout(timeout);
+  child.kill();
+  console.error("  FAIL ", e.message);
+  process.exit(1);
+}
+EOF
+
+node "$TMP/handshake.mjs" "$TMP"
+echo "Verification passed."


### PR DESCRIPTION
  Closes #94 

  ## Summary

Turns the host-side artifact from a scaffold into a real, installable Claude Desktop extension. Previously `manifest.json` pinned the stale MCPB `0.2` schema with placeholder content (`"Your Name"`, `"hello-world scaffold"`, `v0.0.1`) and the build hand-rolled a `zip` that bundled the *entire* `node_modules` (devDeps included) with no manifest validation. This PR produces a validated, production-only `.mcpb` that installs in Claude Desktop and boots with all 21 tools.


## What changed

- **Manifest** — complete MCPB **0.3** manifest: real metadata, all 21 tools, `compatibility` (darwin/win32/linux, node >=18), `Apache-2.0`, repository/homepage. Version bumped to **0.1.0**, synced across `manifest.json`, `package.json`, and the `Server({ version })` in `index.ts`. No `user_config` (keeps the `~/.familysearch-mcp/config.json` convention; no env-var injection).
- **Tool registry** — extracted `allToolSchemas` into `src/tool-schemas.ts` as the single source of the advertised tool list (`index.ts` spreads it). New `tests/packaging/manifest.test.ts` guards against placeholders, stale schema version, version drift, and manifest↔registry tool drift. - **Build** — `scripts/build-mcpb.sh` rewritten to stage a **production-only** tree (`npm ci --omit=dev`) and pack via the official `@anthropic-ai/mcpb` CLI (`mcpb validate` + `mcpb pack`); added `mcp-server/.mcpbignore`.
Result: ~6.2 MB bundle (was bundling all devDeps before).
- **Verify** — new `scripts/verify-mcpb.sh` unpacks the bundle, asserts required/forbidden contents, and boots the packed server over stdio (`initialize` + `tools/list`) confirming all 21 tools.
- **Docs** — added `docs/specs/mcpb-package-spec.md` (the build/manifest contract) and a dev-facing `docs/testing-guides/mcpb-install-testing-guide.md`; updated `DEVELOPMENT.md`, `README.md`, `CLAUDE.md`, and the `mcp-tool-scaffolder` agent for the new `tool-schemas.ts` wiring.

  ## Verification

  ```bash
  cd mcp-server && npm install
  npx vitest run tests/packaging/manifest.test.ts   # packaging guards
  cd .. && ./scripts/build-mcpb.sh                  # → releases/genealogy-mcp.mcpb
  ./scripts/verify-mcpb.sh                           # contents + boot handshake
  ./scripts/test.sh                                  # full suite
  ```
- Full test suite green: **MCP server 299 / eval app 106 / eval harness 292**.
- `mcpb validate` passes; `verify-mcpb.sh` boots the packed server and lists all 21 tools; archive has no `src/`/`tests/`/`dev/`/devDeps.
- `spec-review` agent: **compliant** with `mcpb-package-spec.md`.
- Manually installed in Claude Desktop — "Genealogy Research" extension registers and appears.

  ## Known limitation (separate task)

The 5 wiki-page tools (`wiki_read`, `wiki_country_*`) register and are callable but read a pre-crawled markdown corpus via `wikiMarkdownDir` that isn't bundled, so they return a "not configured" error on a stock install. The other 16 tools work out of the box (bundled clientId + hosted services). Bundling vs. hosting that corpus is intentionally out of scope here.

 ## Follow-ups / out of scope

- Distributing the wiki-markdown corpus (bundle vs. host) — separate task.
- Signing the `.mcpb` (`mcpb sign`) — unsigned installs fine with an "Install Anyway" prompt; revisit when the signing/key tooling matures. - An extension `icon` PNG (optional manifest field).