### PR TITLE
190 create person search tool

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,10 +65,12 @@ instance); end users do not need to set this for normal operation.
   Currently empty. Do not put internal/developer scripts here; they
   belong in `mcp-server/dev/`.
 - `mcp-server/src/utils/` — Shared utility modules consumed by multiple
-  MCP tools. Currently houses `gedcomx-convert.ts` (round-trip between
+  MCP tools. Houses `gedcomx-convert.ts` (round-trip between
   full GedcomX and the simplified format defined in
   `docs/specs/simplified-gedcomx-spec.md`; implementation spec at
-  `docs/specs/gedcomx-convert-spec.md`).
+  `docs/specs/gedcomx-convert-spec.md`) and `search-helpers.ts` (shared
+  input validators and error parsing used by the search tools
+  `record_search` and `person_search`).
 - `releases/` — Build output. Gitignored except for `.gitkeep`.
 - `docs/plan/` — Implementation plans for tools (how we intend to build).
 - `docs/specs/` — Finalized specs (what the tool must do). Specs are the
@@ -136,8 +138,8 @@ The interview lives in `init-project/SKILL.md`.
 ## Auth architecture (`mcp-server/src/auth/`)
 
 All authenticated tools (`place_collections`, `record_search`,
-`person_read`, and `fulltext_search`) must go through this module — do not
-re-implement token plumbing.
+`person_search`, `person_read`, and `fulltext_search`) must go through this
+module — do not re-implement token plumbing.
 
 - `config.ts` — OAuth URLs, callback port, scopes, a per-user
   config store at `~/.familysearch-mcp/config.json` (`loadConfig` /

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ the same; the tools just help you meet it faster.
 
 ## MCP tools
 
-The MCP server exposes 20 tools.
+The MCP server exposes 21 tools.
 
 ### FamilySearch records and places
 
@@ -54,6 +54,7 @@ The MCP server exposes 20 tools.
 | `place_search` | FamilySearch place data + Wikipedia enrichment | None |
 | `place_collections` | FamilySearch record collections for a place (list mode) or details for a single collection (detail mode) | OAuth |
 | `record_search` | FamilySearch historical-record search for a person | OAuth |
+| `person_search` | FamilySearch Family Tree search for a person — ranked candidate tree persons to pick and research (chains into `person_read`) | OAuth |
 | `fulltext_search` | Full-text search of FS AI-transcribed document images — finds non-principal mentions (witnesses, neighbors, heirs) | OAuth |
 | `match_two_examples` | Asks FamilySearch whether two record extractions describe the same person — match confidence + score | OAuth |
 | `person_record_matches` | Historical-record matches for a tree person (accepted/pending/rejected) | OAuth |
@@ -381,13 +382,14 @@ then narrows the search.
 
 What's shipped:
 
-- **20 MCP tools.** OAuth (`login`, `logout`, `auth_status`); public
+- **21 MCP tools.** OAuth (`login`, `logout`, `auth_status`); public
   reference tools (`wikipedia_search`, `place_search`, `place_population`,
   `place_external_links`, `place_distance`, `image_read`); authenticated
-  read tools (`place_collections`, `record_search`, `fulltext_search`,
-  `match_two_examples`, `person_record_matches`, `record_person_matches`,
-  `person_person_matches`, `record_record_matches`, `person_read`); FamilySearch Wiki tools
-  (`wiki_search`, `wiki_read`, and four `wiki_country_*` tools).
+  read tools (`place_collections`, `record_search`, `person_search`,
+  `fulltext_search`, `match_two_examples`, `person_record_matches`,
+  `record_person_matches`, `person_person_matches`, `record_record_matches`,
+  `person_read`); FamilySearch Wiki tools (`wiki_search`, `wiki_read`, and
+  four `wiki_country_*` tools).
 - **24 skills.** Full GPS research cycle from `init-project` through
   `proof-conclusion`, plus reference skills (locality-guide,
   historical-context, translation, search-wiki, search-wikipedia) and

--- a/docs/specs/person-search-tool-spec.md
+++ b/docs/specs/person-search-tool-spec.md
@@ -1,0 +1,591 @@
+# Person Search Tool — Implementation Spec
+
+## Overview
+
+An MCP tool that searches the **FamilySearch Family Tree** for people.
+The caller passes clues — a name, a birth/death/marriage/residence year
+or place, the name of a parent or spouse — and gets back a ranked list
+of **tree persons** who might be that individual, each with their key
+facts and a stable tree-person ID. The skill displays the list and asks
+the user which person they want to research.
+
+Requires authentication (OAuth tokens from the `login` tool). Uses the
+documented FamilySearch platform endpoint
+`GET /platform/tree/search` ("Search Tree Persons").
+
+This is the **find-a-person-in-the-tree** primitive. It does **not**
+return each match's relatives — the matched person's own data only.
+Expanding a chosen match into their family is already handled by
+`person_read`, so the tools chain:
+
+```
+place_search(query: "Kentucky")              // (optional) confirm an ambiguous place
+  ↓
+person_search({ givenName, surname, ... })   // find candidate tree persons
+  ↓  user picks one → personId (e.g. "LZJW-C31")
+person_read({ personId, relatives: true })   // expand to parents, spouse, children
+```
+
+Sibling to `record_search`: that tool searches indexed historical
+**records** (documents); this tool searches the collaborative
+**tree** (conclusion persons). They share the same `q.*` query-parameter
+family, so this spec follows `record_search`'s input-naming convention.
+
+### Name-anchor rule (design note)
+
+A search must include at least one of:
+
+- `givenName`
+- `surname`
+
+A search with no name (only dates, places, or relative names) is
+rejected. The tree-search service is heavily fuzzy — an empty or
+relative-only query returns thousands of irrelevant matches (a gibberish
+surname alone returned ~9,700), wasting a call and giving the user
+nothing usable to choose from. Every other field is optional and only
+narrows an already-named search.
+
+---
+
+## Input
+
+Inputs are grouped by purpose. Every field is optional individually, but
+the name-anchor rule above must be satisfied. Input field names follow
+the `record_search` convention; the wire mapping to the upstream `q.*`
+parameters is in *FamilySearch API Reference → mapping table*.
+
+### Person fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `givenName` | string | Given (first) name. Anchor — at least one of `givenName` / `surname` is required. |
+| `surname` | string | Family name. Anchor. |
+| `sex` | `"Male"` \| `"Female"` \| `"Unknown"` | Sex of the person. Case-insensitive — `"male"` normalizes to `"Male"`. |
+| `givenNameExact` | boolean | When `true`, disables fuzzy matching on the given name (no nicknames/spelling variants). |
+| `surnameExact` | boolean | When `true`, disables fuzzy matching on the surname. |
+
+### Life-event fields
+
+Each event group (birth, death, marriage, residence) has a year range
+and a place, each with an `Exact` toggle.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `birthYearFrom` | number | Lower bound of the birth-year range. 4-digit year. Pair with `birthYearTo`. |
+| `birthYearTo` | number | Upper bound of the birth-year range. Pair with `birthYearFrom`. |
+| `birthYearExact` | boolean | When `true`, the year range is matched exactly (no fuzz). |
+| `birthPlace` | string | Birth place name. |
+| `birthPlaceExact` | boolean | When `true`, the place is matched exactly (no expansion to parent jurisdictions). |
+| `deathYearFrom` / `deathYearTo` / `deathYearExact` | number / number / boolean | Death-year range and exactness. |
+| `deathPlace` / `deathPlaceExact` | string / boolean | Death place and exactness. |
+| `marriageYearFrom` / `marriageYearTo` / `marriageYearExact` | number / number / boolean | Marriage-year range and exactness. |
+| `marriagePlace` / `marriagePlaceExact` | string / boolean | Marriage place and exactness. |
+| `residenceYearFrom` / `residenceYearTo` / `residenceYearExact` | number / number / boolean | Residence-year range and exactness (census-style anchor). |
+| `residencePlace` / `residencePlaceExact` | string / boolean | Residence place and exactness. |
+
+Year inputs are 4-digit years; the search engine processes only the year
+even though the upstream parameter is a full GedcomX date. A range
+endpoint is inclusive. To match a single year, set `From` and `To` to
+the same value.
+
+### Family-member fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `spouseGivenName` / `spouseSurname` | string | Spouse's given / family name. |
+| `spouseGivenNameExact` / `spouseSurnameExact` | boolean | Strict match on the spouse's given / family name. |
+| `fatherGivenName` / `fatherSurname` | string | Father's given / family name. |
+| `fatherGivenNameExact` / `fatherSurnameExact` | boolean | Strict match on the father's given / family name. |
+| `fatherBirthPlace` / `fatherBirthPlaceExact` | string / boolean | Father's birth place and exactness. |
+| `motherGivenName` / `motherSurname` | string | Mother's given / family name. |
+| `motherGivenNameExact` / `motherSurnameExact` | boolean | Strict match on the mother's given / family name. |
+| `motherBirthPlace` / `motherBirthPlaceExact` | string / boolean | Mother's birth place and exactness. |
+| `parentGivenName` / `parentSurname` | string | A parent's given / family name when the parent's sex is unknown. |
+| `parentGivenNameExact` / `parentSurnameExact` | boolean | Strict match on the parent's given / family name. |
+| `parentBirthPlace` / `parentBirthPlaceExact` | string / boolean | A parent's birth place and exactness. |
+
+### Scope & pagination
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `treeId` | string | Restrict results to a single tree (e.g. `"MMMM-MMMM"`). Omit for the default shared Family Tree. |
+| `count` | number | Results per call. Default 20, range 1–100. |
+| `offset` | number | 0-based index of the first result. Default 0, range 0–4999 (FamilySearch's search-depth limit). |
+
+### Examples
+
+Specific person:
+```json
+{ "givenName": "Abraham", "surname": "Lincoln",
+  "birthYearFrom": 1809, "birthYearTo": 1809, "birthPlace": "Kentucky" }
+```
+
+Narrow by a parent:
+```json
+{ "givenName": "Abraham", "surname": "Lincoln",
+  "birthYearFrom": 1809, "birthYearTo": 1809,
+  "fatherGivenName": "Thomas", "fatherSurname": "Lincoln" }
+```
+
+Strict surname + birth-place match:
+```json
+{ "surname": "Smyth", "surnameExact": true,
+  "birthPlace": "Hodgenville, Kentucky", "birthPlaceExact": true }
+```
+
+---
+
+## Output
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `query` | object | Echo of the input fields the caller supplied. |
+| `totalMatches` | number | Total tree persons matching the query. |
+| `paginationCappedAt` | number | Hard limit on how deep pagination can reach (4999). When `totalMatches > paginationCappedAt`, the remainder is unreachable — narrow the query. |
+| `returned` | number | Number of results in this response (≤ `count`). |
+| `offset` | number | Echo of the input offset (0 if not supplied). |
+| `hasMore` | boolean | `true` when more pages are available (response carries `links.next`). |
+| `results` | PersonSearchResult[] | Ranked results, best-scoring first. |
+
+Each `PersonSearchResult`:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `personId` | string | Bare Family-Tree person ID (e.g. `"LZJW-C31"`). Pass this to `person_read`. Always equals `gedcomx.persons[0].id`. |
+| `name` | string \| undefined | Matched person's display name. Undefined when the upstream carries no display name and no fallback name form. |
+| `score` | number \| undefined | Relevance score within this query. Higher = better-ranked. Not comparable across queries. |
+| `confidence` | number \| undefined | A 1–5 confidence band (5 highest). Surface for transparency; rank with `score`. |
+| `sex` | string \| undefined | `"Male"`, `"Female"`, or undefined. |
+| `birthDate` | string \| undefined | Birth date as recorded (e.g. `"12 February 1809"`). |
+| `birthPlace` | string \| undefined | Birth place as recorded. |
+| `deathDate` | string \| undefined | Death date as recorded. |
+| `deathPlace` | string \| undefined | Death place as recorded. |
+| `arkUrl` | string \| undefined | Persistent link to the tree person. Undefined when the persona has no `Persistent` identifier. |
+| `gedcomx` | SimplifiedGedcomX | The **matched person only** (their names + facts), converted via `toSimplified` (see `simplified-gedcomx-spec.md`). Relatives are intentionally excluded — call `person_read` with `relatives: true` to expand them. |
+
+Output `*Date` fields keep their names because they hold the date as
+recorded — which can carry month and day even though inputs are
+year-only.
+
+Example:
+
+```json
+{
+  "query": { "givenName": "Abraham", "surname": "Lincoln", "birthYearFrom": 1809, "birthYearTo": 1809, "birthPlace": "Kentucky" },
+  "totalMatches": 7,
+  "paginationCappedAt": 4999,
+  "returned": 1,
+  "offset": 0,
+  "hasMore": false,
+  "results": [
+    {
+      "personId": "LZJW-C31",
+      "name": "President Abraham Lincoln",
+      "score": 5.1136,
+      "confidence": 3,
+      "sex": "Male",
+      "birthDate": "12 February 1809",
+      "birthPlace": "Hardin, Kentucky, United States",
+      "deathDate": "15 April 1865",
+      "deathPlace": "Washington, District of Columbia, United States",
+      "arkUrl": "https://familysearch.org/ark:/61903/4:1:LZJW-C31",
+      "gedcomx": {
+        "persons": [
+          {
+            "id": "LZJW-C31",
+            "gender": "Male",
+            "names": [{ "fullText": "President Abraham Lincoln" }],
+            "facts": [
+              { "type": "Birth", "date": "12 February 1809", "place": "Hardin, Kentucky, United States" },
+              { "type": "Death", "date": "15 April 1865", "place": "Washington, District of Columbia, United States" }
+            ]
+          }
+        ]
+      }
+    }
+  ]
+}
+```
+
+---
+
+## Tool Schema
+
+```typescript
+{
+  name: "person_search",
+  description:
+    "Search the FamilySearch Family Tree for a person. Requires at least " +
+    "one anchor: givenName or surname. Other fields (life-event years and " +
+    "places, parent/spouse names) narrow the ranking. Returns a ranked list " +
+    "of candidate tree persons with their key facts and a tree-person ID, so " +
+    "the user can pick which one to research. To expand a chosen match into " +
+    "parents, spouses, and children, call person_read with relatives: true. " +
+    "Requires authentication — call the login tool first if not logged in. " +
+    "For ambiguous place names, call the place_search tool first.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      // Person
+      givenName:            { type: "string", description: "Given (first) name. At least one of `givenName` or `surname` must be supplied." },
+      surname:              { type: "string", description: "Family name. At least one of `givenName` or `surname` must be supplied." },
+      sex:                  { type: "string", enum: ["Male", "Female", "Unknown"], description: "Sex of the person. Case-insensitive on input." },
+      givenNameExact:       { type: "boolean", description: "When `true`, requires an exact given-name match (no fuzzy nicknames or spelling variants)." },
+      surnameExact:         { type: "boolean", description: "When `true`, requires an exact surname match (no fuzzy nicknames or spelling variants)." },
+
+      // Birth
+      birthYearFrom:        { type: "number", description: "Lower bound of the birth-year range. 4-digit year. Must be paired with `birthYearTo`." },
+      birthYearTo:          { type: "number", description: "Upper bound of the birth-year range. 4-digit year. Must be paired with `birthYearFrom`." },
+      birthYearExact:       { type: "boolean", description: "When `true`, the birth-year range is matched exactly." },
+      birthPlace:           { type: "string", description: "Birth place name. For ambiguous places, call `place_search` first." },
+      birthPlaceExact:      { type: "boolean", description: "When `true`, requires an exact place match (no expansion to parent jurisdictions)." },
+
+      // Death
+      deathYearFrom:        { type: "number", description: "Lower bound of the death-year range. 4-digit year. Must be paired with `deathYearTo`." },
+      deathYearTo:          { type: "number", description: "Upper bound of the death-year range. 4-digit year. Must be paired with `deathYearFrom`." },
+      deathYearExact:       { type: "boolean", description: "When `true`, the death-year range is matched exactly." },
+      deathPlace:           { type: "string", description: "Death place name." },
+      deathPlaceExact:      { type: "boolean", description: "When `true`, requires an exact place match." },
+
+      // Marriage
+      marriageYearFrom:     { type: "number", description: "Lower bound of the marriage-year range. 4-digit year. Must be paired with `marriageYearTo`." },
+      marriageYearTo:       { type: "number", description: "Upper bound of the marriage-year range. 4-digit year. Must be paired with `marriageYearFrom`." },
+      marriageYearExact:    { type: "boolean", description: "When `true`, the marriage-year range is matched exactly." },
+      marriagePlace:        { type: "string", description: "Marriage place name." },
+      marriagePlaceExact:   { type: "boolean", description: "When `true`, requires an exact place match." },
+
+      // Residence
+      residenceYearFrom:    { type: "number", description: "Lower bound of the residence-year range. 4-digit year. Must be paired with `residenceYearTo`." },
+      residenceYearTo:      { type: "number", description: "Upper bound of the residence-year range. 4-digit year. Must be paired with `residenceYearFrom`." },
+      residenceYearExact:   { type: "boolean", description: "When `true`, the residence-year range is matched exactly." },
+      residencePlace:       { type: "string", description: "Residence place name." },
+      residencePlaceExact:  { type: "boolean", description: "When `true`, requires an exact place match." },
+
+      // Spouse
+      spouseGivenName:      { type: "string", description: "Spouse's given name." },
+      spouseSurname:        { type: "string", description: "Spouse's family name." },
+      spouseGivenNameExact: { type: "boolean", description: "When `true`, requires an exact match on the spouse's given name." },
+      spouseSurnameExact:   { type: "boolean", description: "When `true`, requires an exact match on the spouse's family name." },
+
+      // Father
+      fatherGivenName:      { type: "string", description: "Father's given name." },
+      fatherSurname:        { type: "string", description: "Father's family name." },
+      fatherGivenNameExact: { type: "boolean", description: "When `true`, requires an exact match on the father's given name." },
+      fatherSurnameExact:   { type: "boolean", description: "When `true`, requires an exact match on the father's family name." },
+      fatherBirthPlace:     { type: "string", description: "Father's birth place name." },
+      fatherBirthPlaceExact:{ type: "boolean", description: "When `true`, requires an exact match on the father's birth place." },
+
+      // Mother
+      motherGivenName:      { type: "string", description: "Mother's given name." },
+      motherSurname:        { type: "string", description: "Mother's family name." },
+      motherGivenNameExact: { type: "boolean", description: "When `true`, requires an exact match on the mother's given name." },
+      motherSurnameExact:   { type: "boolean", description: "When `true`, requires an exact match on the mother's family name." },
+      motherBirthPlace:     { type: "string", description: "Mother's birth place name." },
+      motherBirthPlaceExact:{ type: "boolean", description: "When `true`, requires an exact match on the mother's birth place." },
+
+      // Parent (sex unknown)
+      parentGivenName:      { type: "string", description: "A parent's given name when the parent's sex is unknown." },
+      parentSurname:        { type: "string", description: "A parent's family name when the parent's sex is unknown." },
+      parentGivenNameExact: { type: "boolean", description: "When `true`, requires an exact match on the parent's given name." },
+      parentSurnameExact:   { type: "boolean", description: "When `true`, requires an exact match on the parent's family name." },
+      parentBirthPlace:     { type: "string", description: "A parent's birth place name." },
+      parentBirthPlaceExact:{ type: "boolean", description: "When `true`, requires an exact match on the parent's birth place." },
+
+      // Scope & pagination
+      treeId:               { type: "string", description: "Restrict results to a single tree ID. Omit for the default shared Family Tree." },
+      count:                { type: "number", description: "Results per call. Default 20, range 1–100." },
+      offset:               { type: "number", description: "0-based index of the first result. Default 0, range 0–4999." }
+    }
+  }
+}
+```
+
+The name-anchor rule is enforced in `validateInput`, not via JSON
+Schema's `required` (which can only require a single field, not
+"one of these two").
+
+---
+
+## Authentication
+
+Requires a valid FamilySearch access token. Calls `getValidToken()` from
+`src/auth/refresh.ts` — the single entry point for authenticated tools.
+Do not re-implement token plumbing. If the user is not authenticated,
+`getValidToken()` throws an LLM-instruction error directing them to the
+`login` tool; the handler lets it propagate (same pattern as the other
+tools in `index.ts`).
+
+**No browser User-Agent is required.** *(Empirical, probe 2026-05-28:
+the platform host `api.familysearch.org` is not behind the Imperva WAF —
+requests succeed with no UA. This differs from `record_search`, whose
+`www.familysearch.org/service/...` host 403s without the browser UA.)*
+
+---
+
+## FamilySearch API Reference
+
+**Endpoint (auth required):**
+
+```
+GET https://api.familysearch.org/platform/tree/search
+Authorization: Bearer <access_token>
+Accept: application/x-gedcomx-atom+json
+Accept-Language: en
+```
+
+**Required headers:**
+
+- `Authorization: Bearer <token>` — without it, 401.
+- `Accept: application/x-gedcomx-atom+json` — the GedcomX-Atom search
+  feed. *(`application/json` returns the same envelope; the atom media
+  type is the documented default for this endpoint.)*
+- `Accept-Language: en` — **required.** *(Empirical, probe 2026-05-28:
+  without it, normalized place names and the `display` block come back
+  in the account's session locale. A test account set to Mongolian
+  returned `"Hardin, Кентаки, ..."`; with `Accept-Language: en` it
+  returned `"Hardin, Kentucky, United States"`.)*
+
+**Default flags sent on every request:**
+
+| Flag | Value | Purpose |
+|------|-------|---------|
+| `m.queryRequireDefault` | `on` | **Required.** Treats every `q.*` term as a hard filter. *(Empirical, probe 2026-05-28: without this flag, additional `q.*` terms do not narrow at all — `surname=Lincoln` and `surname=Lincoln&givenName=Abraham` both returned 56,177. With the flag the same query returned 2,916, and the full clue set narrowed to 7.)* |
+
+The platform feed does not return facet aggregations, so no
+facet-suppression flag is needed (unlike `record_search`'s service
+endpoint).
+
+**Tool input → API parameter mapping:**
+
+| Tool input | API parameter |
+|------------|---------------|
+| `givenName` | `q.givenName` |
+| `surname` | `q.surname` |
+| `givenNameExact=true` | `q.givenName.exact=on` |
+| `surnameExact=true` | `q.surname.exact=on` |
+| `sex` | `q.sex` |
+| `birthYearFrom` / `birthYearTo` | `q.birthLikeDate.from` / `q.birthLikeDate.to` |
+| `birthYearExact=true` | `q.birthLikeDate.exact=on` |
+| `birthPlace` / `birthPlaceExact=true` | `q.birthLikePlace` / `q.birthLikePlace.exact=on` |
+| `deathYearFrom` / `deathYearTo` / `deathYearExact` | `q.deathLikeDate.from` / `.to` / `.exact=on` |
+| `deathPlace` / `deathPlaceExact` | `q.deathLikePlace` / `q.deathLikePlace.exact=on` |
+| `marriageYearFrom` / `marriageYearTo` / `marriageYearExact` | `q.marriageLikeDate.from` / `.to` / `.exact=on` |
+| `marriagePlace` / `marriagePlaceExact` | `q.marriageLikePlace` / `q.marriageLikePlace.exact=on` |
+| `residenceYearFrom` / `residenceYearTo` / `residenceYearExact` | `q.residenceDate.from` / `.to` / `.exact=on` |
+| `residencePlace` / `residencePlaceExact` | `q.residencePlace` / `q.residencePlace.exact=on` |
+| `spouseGivenName` / `spouseSurname` (+`Exact`) | `q.spouseGivenName` / `q.spouseSurname` (+`.exact=on`) |
+| `fatherGivenName` / `fatherSurname` (+`Exact`) | `q.fatherGivenName` / `q.fatherSurname` (+`.exact=on`) |
+| `fatherBirthPlace` (+`Exact`) | `q.fatherBirthLikePlace` (+`.exact=on`) |
+| `motherGivenName` / `motherSurname` (+`Exact`) | `q.motherGivenName` / `q.motherSurname` (+`.exact=on`) |
+| `motherBirthPlace` (+`Exact`) | `q.motherBirthLikePlace` (+`.exact=on`) |
+| `parentGivenName` / `parentSurname` (+`Exact`) | `q.parentGivenName` / `q.parentSurname` (+`.exact=on`) |
+| `parentBirthPlace` (+`Exact`) | `q.parentBirthLikePlace` (+`.exact=on`) |
+| `treeId` | `f.treeId` |
+| `count` | `count` |
+| `offset` | `offset` |
+
+`sex` normalizes to `"Male"` / `"Female"` / `"Unknown"` before sending.
+URL-encode every value with `encodeURIComponent`.
+
+**Response shape** *(confirmed by probe 2026-05-28):*
+
+```
+response.results                          -> total match count (number)
+response.index                            -> current offset (0-based)
+response.links.next?.href                 -> next-page URL (omitted on last page)
+response.entries[]
+  .id                                     -> bare tree-person ID (e.g. "LZJW-C31")
+  .title                                  -> "Person <ID> (<name>)"
+  .score                                  -> relevance score (number)
+  .confidence                             -> 1-5 (number)
+  .content.gedcomx.persons[]              -> a CLUSTER: the matched person PLUS relatives
+    .id                                   -> tree-person ID; the matched person's equals entry.id
+    .display                              -> normalized summary block (locale-sensitive)
+      .name / .gender / .birthDate / .birthPlace / .deathDate / .deathPlace
+    .gender.type                          -> URL form (e.g. "http://gedcomx.org/Male")
+    .names[].nameForms[].fullText         -> fallback name
+    .facts[]                              -> { type (URL), date.original, place.original, value }
+    .identifiers["http://gedcomx.org/Persistent"][0] -> ark URL of the tree person
+  .content.gedcomx.relationships[]        -> cluster relationships (NOT surfaced by this tool)
+```
+
+Each entry returns a family cluster (3–15 persons), but this tool
+surfaces only the matched person.
+
+---
+
+## Mapping Logic
+
+For each `entry` in `response.entries`:
+
+1. **Resolve the matched person.** Find the person in
+   `entry.content.gedcomx.persons[]` whose `id` equals `entry.id`.
+   Fallbacks, in order: the person whose
+   `identifiers["http://gedcomx.org/Persistent"][0]` ends with
+   `entry.id`; then `persons[0]`. If `persons` is empty, skip the entry.
+2. `personId` ← `entry.id`.
+3. `name` ← `person.display?.name`, falling back to
+   `person.names[0].nameForms[0].fullText`.
+4. `score` ← `entry.score`. `confidence` ← `entry.confidence`.
+5. `sex` ← `person.display?.gender` if present (already `"Male"` /
+   `"Female"`); otherwise the last path segment of `person.gender?.type`;
+   otherwise undefined.
+6. `birthDate` / `birthPlace` / `deathDate` / `deathPlace` ←
+   `person.display?.*`.
+7. `arkUrl` ← `person.identifiers["http://gedcomx.org/Persistent"][0]`.
+8. `gedcomx` ← `toSimplified({ persons: [person] })` — the matched
+   person only, no relatives.
+
+**Top-level fields:**
+
+- `query` ← echo of supplied input.
+- `totalMatches` ← `response.results`.
+- `paginationCappedAt` ← `4999` (constant).
+- `returned` ← mapped `results.length`.
+- `offset` ← `response.index ?? 0`.
+- `hasMore` ← `response.links?.next?.href != null`.
+- `results` ← the mapped `PersonSearchResult[]`.
+
+---
+
+## Error Handling
+
+| Condition | Behavior |
+|-----------|----------|
+| Neither `givenName` nor `surname` present | Throw: `"person_search needs at least a givenName or surname. Searches without a name return thousands of irrelevant matches."` |
+| `count` outside `[1, 100]` | Throw: `"count must be between 1 and 100."` |
+| `offset` outside `[0, 4999]` | Throw: `"offset must be between 0 and 4999 (FamilySearch search-depth limit). Narrow the query instead of paging deeper."` |
+| Year input not a 4-digit year | Throw: `"<field> must be a 4-digit year (e.g., 1809)."` |
+| `<event>YearFrom` without `<event>YearTo` (or vice versa) | Throw: `"<event>YearFrom and <event>YearTo must be provided together."` |
+| `<event>YearFrom > <event>YearTo` | Throw: `"<event>YearFrom must be <= <event>YearTo."` |
+| `sex` not in `{Male, Female, Unknown}` (case-insensitive) | Throw: `"sex must be 'Male', 'Female', or 'Unknown' (case-insensitive)."` |
+| Not authenticated | Let `getValidToken()` throw its LLM-instruction error. |
+| API returns 401 | Throw: `"FamilySearch session not accepted; call the login tool to re-authenticate."` |
+| API returns 400 | Read body as JSON, extract error detail, throw: `"FamilySearch tree search rejected the query: ${detail}."` Fall back to a generic message if the body isn't parseable. |
+| API returns 429 | Throw: `"FamilySearch rate limit reached. Wait a moment and try again."` |
+| API returns 204 (no matches) | Return `{ ..., totalMatches: 0, returned: 0, results: [], hasMore: false }`. |
+| API returns other non-OK status | Throw: `"FamilySearch tree search API error: ${status} ${statusText}."` |
+| API returns 200 with empty `entries` | Return `{ ..., totalMatches: <upstream>, returned: 0, results: [], hasMore: false }`. |
+
+---
+
+## Caching
+
+None. Search queries are high-cardinality and the tree changes as users
+edit it; caching wouldn't pay off and would risk staleness.
+
+---
+
+## Files
+
+### `mcp-server/src/types/person-search.ts`
+FS response types (`FSTreeSearchResponse`, `FSTreeSearchEntry`,
+`FSTreeSearchPerson`, `FSDisplay`, `FSFact`) and tool I/O types
+(`PersonSearchInput`, `PersonSearchResult`, `PersonSearchToolResponse`).
+Reuse shared GedcomX types from `src/types/gedcomx.ts` where possible.
+
+### `mcp-server/src/tools/person-search.ts`
+- `personSearchToolSchema` — the MCP schema above.
+- `personSearchTool(input)` — entry point: validate, authenticate, fetch, map.
+- `validateInput(input)` — name-anchor rule + per-field validation.
+- `buildSearchUrl(input)` — `q.*`/`f.*` parameter builder; applies
+  `.exact`/`.from`/`.to` modifiers, the `m.queryRequireDefault=on` flag,
+  and `encodeURIComponent`.
+- `mapEntry(entry)` — `FSTreeSearchEntry → PersonSearchResult` (the
+  8-step procedure above).
+- `findMatchedPerson(entry)` — the person-by-id resolution in step 1.
+
+### `mcp-server/src/tool-schemas.ts`
+Add `personSearchToolSchema` to `allToolSchemas`.
+
+### `mcp-server/src/index.ts`
+Add the `person_search` dispatch branch (import tool + input type,
+call within the existing try/catch pattern).
+
+### `mcp-server/manifest.json`
+Add `{ "name": "person_search" }` to `tools`.
+
+### `mcp-server/dev/try-person-search.ts`
+Live smoke-test CLI, e.g.
+`npx tsx dev/try-person-search.ts Lincoln Abraham --birth-year 1809`.
+
+---
+
+## Testing
+
+### `tests/tools/person-search.test.ts`
+
+| # | Test case | Verifies |
+|---|-----------|----------|
+| 1 | Returns ranked results for `givenName` + `surname` | Happy path |
+| 2 | Throws when neither `givenName` nor `surname` is supplied (only `birthPlace`) | Name-anchor rule |
+| 3 | Throws when `count` < 1 or > 100 | Bound check |
+| 4 | Throws when `offset` < 0 or > 4999 | Pagination cap |
+| 5 | Throws when `<event>YearFrom` is supplied without `<event>YearTo` | Range-pair validation |
+| 6 | Throws when `<event>YearFrom > <event>YearTo` | Range-order validation |
+| 7 | Throws on `sex` outside Male/Female/Unknown (case-insensitive accepted) | sex enum validation |
+| 8 | Builds URL with all `q.*` params mapped correctly | Param mapping |
+| 9 | `surnameExact=true` emits `q.surname.exact=on` | Modifier mapping |
+| 10 | `birthYearFrom/To` emit `q.birthLikeDate.from`/`.to`; `birthYearExact` emits `.exact=on` | Year-range mapping |
+| 11 | `fatherBirthPlace` maps to `q.fatherBirthLikePlace` | Relative-place mapping |
+| 12 | `treeId` maps to `f.treeId` | Scope mapping |
+| 13 | `m.queryRequireDefault=on` is sent on every request | Default-flag enforcement |
+| 14 | `Accept-Language: en` header is sent | Locale-leak guard |
+| 15 | No `User-Agent` header is required (request succeeds without it) | Host contract |
+| 16 | Maps entry → result using `display{}` first, `facts`/`names` fallback | Field mapping |
+| 17 | Resolves the matched person by `entry.id` within a multi-person cluster | Cluster resolution |
+| 18 | `gedcomx` contains only the matched person (no relatives) | Lean-output contract |
+| 19 | `hasMore: true` when `links.next` exists | Pagination flag |
+| 20 | Echoes `totalMatches` and `paginationCappedAt` | Total-count surfacing |
+| 21 | Returns empty results on 200 with empty `entries` and on 204 | Zero-match handling |
+| 22 | Throws auth error when not authenticated | Auth propagation |
+| 23 | Throws on 401 with re-login guidance; on 400 with extracted detail | API errors |
+
+### Smoke test
+
+```bash
+cd mcp-server
+npx tsx dev/try-person-search.ts Lincoln Abraham
+npx tsx dev/try-person-search.ts Lincoln Abraham --birth-year 1809 --birth-place Kentucky
+npx tsx dev/try-person-search.ts --given Mary --surname Todd --spouse-surname Lincoln
+```
+
+---
+
+## Verification
+
+### Automated
+```bash
+cd mcp-server && npm run build && npm test
+```
+
+### Manual Layer 1 (MCP Inspector)
+```bash
+npx @modelcontextprotocol/inspector node build/index.js
+```
+- `person_search({ givenName: "Abraham", surname: "Lincoln", birthYearFrom: 1809, birthYearTo: 1809, birthPlace: "Kentucky" })` — top result is `personId: "LZJW-C31"`, `name: "President Abraham Lincoln"`, English place strings.
+- `person_search({ birthPlace: "Kentucky" })` — fails with the name-anchor error.
+- `person_search({ surname: "Lincoln", count: 200 })` — fails with the count-bound error.
+- `person_search` without logging in — returns the auth error.
+
+### Manual Layer 2 (Claude Code)
+- *"Find Abraham Lincoln born 1809 in Kentucky in the family tree."* — Claude calls `person_search`, surfaces the ranked matches.
+- *"Now show me his parents and children."* — Claude chains to `person_read({ personId: "LZJW-C31", relatives: true })`.
+
+### Manual Layers 3 + 4 (Cowork via WSL2 + native Windows)
+Per `docs/testing-guides/oauth-tool-testing-guide.md`.
+
+---
+
+## References
+
+- Search Tree Persons (endpoint reference): https://developers.familysearch.org/main/reference/searchtreepersons *(verified live 2026-05-28)*
+- Family Tree Search (parameter guide): https://developers.familysearch.org/main/docs/family-tree-search *(verified live 2026-05-28)*
+- `docs/specs/simplified-gedcomx-spec.md` — output format for the `gedcomx` field.
+- `docs/specs/record-search-tool-spec-v2.md` — sibling tool; input-naming convention and shared `q.*` family.
+- `docs/specs/person-read-tool-spec.md` — the chained tool for expanding a chosen match.
+
+Evidence trail: `mcp-server/dev/probe-tree-search.ts`,
+`probe-tree-search-narrowing.ts`, `probe-svc-tree-search.ts`,
+`probe-tree-search-platform-lang.ts` (run 2026-05-28).
+```

--- a/docs/specs/person-search-tool-spec.md
+++ b/docs/specs/person-search-tool-spec.md
@@ -31,26 +31,34 @@ Sibling to `record_search`: that tool searches indexed historical
 **tree** (conclusion persons). They share the same `q.*` query-parameter
 family, so this spec follows `record_search`'s input-naming convention.
 
-### Name-anchor rule (design note)
+### Surname-plus-one rule (design note)
 
-A search must include at least one of:
+A search must include:
 
-- `givenName`
-- `surname`
+- `surname` (always required), **and**
+- at least one **other** search field — a `givenName`, any life-event
+  year or place (birth / death / marriage / residence), or any relative
+  name (`spouse*`, `father*`, `mother*`, `parent*`, including relative
+  birth places).
 
-A search with no name (only dates, places, or relative names) is
-rejected. The tree-search service is heavily fuzzy — an empty or
-relative-only query returns thousands of irrelevant matches (a gibberish
-surname alone returned ~9,700), wasting a call and giving the user
-nothing usable to choose from. Every other field is optional and only
-narrows an already-named search.
+`sex`, the `*Exact` toggles, and `count` / `offset` do **not** count as
+the "other" field: `sex` barely narrows, the toggles only modify an
+existing term, and pagination is not a search criterion. So `surname`
+alone, `surname` + `sex`, and `surname` + `surnameExact` are all
+rejected.
+
+The tree-search service is heavily fuzzy: a surname alone returns the
+whole surname pool (`surname=Lincoln` → 56,177) and even a gibberish
+surname returned ~9,700. Requiring a second narrowing field keeps the
+result set small enough to be a usable pick-list.
 
 ---
 
 ## Input
 
-Inputs are grouped by purpose. Every field is optional individually, but
-the name-anchor rule above must be satisfied. Input field names follow
+Inputs are grouped by purpose. The surname-plus-one rule above must be
+satisfied — `surname` plus at least one other search field. Input field
+names follow
 the `record_search` convention; the wire mapping to the upstream `q.*`
 parameters is in *FamilySearch API Reference → mapping table*.
 
@@ -58,8 +66,8 @@ parameters is in *FamilySearch API Reference → mapping table*.
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `givenName` | string | Given (first) name. Anchor — at least one of `givenName` / `surname` is required. |
-| `surname` | string | Family name. Anchor. |
+| `givenName` | string | Given (first) name. Counts as the required "other" field alongside `surname`. |
+| `surname` | string | Family name. **Required on every search**, plus at least one other search field (see the surname-plus-one rule). |
 | `sex` | `"Male"` \| `"Female"` \| `"Unknown"` | Sex of the person. Case-insensitive — `"male"` normalizes to `"Male"`. |
 | `givenNameExact` | boolean | When `true`, disables fuzzy matching on the given name (no nicknames/spelling variants). |
 | `surnameExact` | boolean | When `true`, disables fuzzy matching on the surname. |
@@ -104,13 +112,16 @@ the same value.
 | `parentGivenNameExact` / `parentSurnameExact` | boolean | Strict match on the parent's given / family name. |
 | `parentBirthPlace` / `parentBirthPlaceExact` | string / boolean | A parent's birth place and exactness. |
 
-### Scope & pagination
+### Pagination
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `treeId` | string | Restrict results to a single tree (e.g. `"MMMM-MMMM"`). Omit for the default shared Family Tree. |
 | `count` | number | Results per call. Default 20, range 1–100. |
 | `offset` | number | 0-based index of the first result. Default 0, range 0–4999 (FamilySearch's search-depth limit). |
+
+This tool always searches the main shared FamilySearch Family Tree. The
+endpoint's `f.treeId` filter is intentionally **not** exposed — omitting
+it defaults to the shared tree, which is the only tree we search.
 
 ### Examples
 
@@ -154,7 +165,7 @@ Each `PersonSearchResult`:
 | `personId` | string | Bare Family-Tree person ID (e.g. `"LZJW-C31"`), taken verbatim from `entry.id`. The handle the user's pick passes to `person_read`. Also present as `gedcomx.persons[0].id`. |
 | `score` | number \| undefined | Search-relevance score for this query (higher = better). **Search metadata — not part of any GedcomX**, so it lives at the top level. Not comparable across queries. |
 | `confidence` | number \| undefined | A 1–5 confidence band (5 highest). Search metadata, not GedcomX. Rank with `score`. |
-| `gedcomx` | SimplifiedGedcomX | The matched person as simplified GedcomX: `id`, `ark`, `gender`, `names` (given/surname), and `facts` (Birth, Death, …) — produced by `toSimplified` (see `simplified-gedcomx-spec.md`). The skill renders its pick-list from this. Relatives are excluded by design (see *Picking a result*). |
+| `gedcomx` | SimplifiedGedcomX | The matched person as simplified GedcomX: `id`, `ark`, `gender`, `names` (given/surname), and `facts` (Birth, Death, …) — produced by `toSimplified` (see `simplified-gedcomx-spec.md`). The skill renders its pick-list from this. Relatives are excluded by design (see *Picking a result*). Per-person **source references are also stripped** — they'd be dangling IDs here (the source descriptions aren't included), and the full sources come from `person_read` on the chosen person. |
 
 `personId`, `score`, and `confidence` are the only non-GedcomX fields,
 because they are search metadata the endpoint returns at the entry level
@@ -227,9 +238,10 @@ away.
 {
   name: "person_search",
   description:
-    "Search the FamilySearch Family Tree for a person. Requires at least " +
-    "one anchor: givenName or surname. Other fields (life-event years and " +
-    "places, parent/spouse names) narrow the ranking. Returns a ranked list " +
+    "Search the FamilySearch Family Tree for a person. Requires a surname " +
+    "plus at least one other search field (a given name, a life-event year " +
+    "or place, or a relative's name; sex and exact-match toggles don't " +
+    "count). Additional fields narrow the ranking. Returns a ranked list " +
     "of candidate tree persons with their key facts and a tree-person ID, so " +
     "the user can pick which one to research. To expand a chosen match into " +
     "parents, spouses, and children, call person_read with relatives: true. " +
@@ -239,8 +251,8 @@ away.
     type: "object",
     properties: {
       // Person
-      givenName:            { type: "string", description: "Given (first) name. At least one of `givenName` or `surname` must be supplied." },
-      surname:              { type: "string", description: "Family name. At least one of `givenName` or `surname` must be supplied." },
+      givenName:            { type: "string", description: "Given (first) name. Counts as a qualifying 'other' field alongside the required surname." },
+      surname:              { type: "string", description: "Family name. Required on every search, and must be accompanied by at least one other search field (a given name, a life-event year/place, or a relative's name). `sex` and `*Exact` toggles do not count." },
       sex:                  { type: "string", enum: ["Male", "Female", "Unknown"], description: "Sex of the person. Case-insensitive on input." },
       givenNameExact:       { type: "boolean", description: "When `true`, requires an exact given-name match (no fuzzy nicknames or spelling variants)." },
       surnameExact:         { type: "boolean", description: "When `true`, requires an exact surname match (no fuzzy nicknames or spelling variants)." },
@@ -303,8 +315,7 @@ away.
       parentBirthPlace:     { type: "string", description: "A parent's birth place name." },
       parentBirthPlaceExact:{ type: "boolean", description: "When `true`, requires an exact match on the parent's birth place." },
 
-      // Scope & pagination
-      treeId:               { type: "string", description: "Restrict results to a single tree ID. Omit for the default shared Family Tree." },
+      // Pagination
       count:                { type: "number", description: "Results per call. Default 20, range 1–100." },
       offset:               { type: "number", description: "0-based index of the first result. Default 0, range 0–4999." }
     }
@@ -312,9 +323,12 @@ away.
 }
 ```
 
-The name-anchor rule is enforced in `validateInput`, not via JSON
-Schema's `required` (which can only require a single field, not
-"one of these two").
+The surname-plus-one rule is enforced in `validateInput`, not via JSON
+Schema's `required`. Although `surname` is always required (which JSON
+Schema *could* express), the "+1 other field" half cannot be, and
+keeping both halves in `validateInput` yields a single descriptive error
+message rather than a generic schema-validation error for a missing
+surname.
 
 ---
 
@@ -396,7 +410,6 @@ endpoint).
 | `motherBirthPlace` (+`Exact`) | `q.motherBirthLikePlace` (+`.exact=on`) |
 | `parentGivenName` / `parentSurname` (+`Exact`) | `q.parentGivenName` / `q.parentSurname` (+`.exact=on`) |
 | `parentBirthPlace` (+`Exact`) | `q.parentBirthLikePlace` (+`.exact=on`) |
-| `treeId` | `f.treeId` |
 | `count` | `count` |
 | `offset` | `offset` |
 
@@ -445,7 +458,10 @@ For each `entry` in `response.entries`:
    person only, no relatives. Name (given/surname), `gender`, `ark`, and
    the Birth/Death facts all come through inside this from the person's
    `names`, `gender`, `identifiers`, and `facts`. The tool does **not**
-   read the FS `display` block.
+   read the FS `display` block. After conversion, **per-person `sources`
+   are stripped** from the result (they'd be dangling references with no
+   included source descriptions); `toSimplified` itself is unchanged, so
+   other callers keep their sources.
 
 **Top-level fields:**
 
@@ -463,7 +479,7 @@ For each `entry` in `response.entries`:
 
 | Condition | Behavior |
 |-----------|----------|
-| Neither `givenName` nor `surname` present | Throw: `"person_search needs at least a givenName or surname. Searches without a name return thousands of irrelevant matches."` |
+| `surname` missing, or `surname` present with no other qualifying field | Throw: `"person_search requires a surname plus at least one other search field (a given name, a life-event date or place, or a relative's name). sex and exact-match toggles don't count."` |
 | `count` outside `[1, 100]` | Throw: `"count must be between 1 and 100."` |
 | `offset` outside `[0, 4999]` | Throw: `"offset must be between 0 and 4999 (FamilySearch search-depth limit). Narrow the query instead of paging deeper."` |
 | Year input not a 4-digit year | Throw: `"<field> must be a 4-digit year (e.g., 1809)."` |
@@ -498,8 +514,8 @@ Reuse shared GedcomX types from `src/types/gedcomx.ts` where possible.
 ### `mcp-server/src/tools/person-search.ts`
 - `personSearchToolSchema` — the MCP schema above.
 - `personSearchTool(input)` — entry point: validate, authenticate, fetch, map.
-- `validateInput(input)` — name-anchor rule + per-field validation.
-- `buildSearchUrl(input)` — `q.*`/`f.*` parameter builder; applies
+- `validateInput(input)` — surname-plus-one rule + per-field validation.
+- `buildSearchUrl(input)` — `q.*` parameter builder; applies
   `.exact`/`.from`/`.to` modifiers, the `m.queryRequireDefault=on` flag,
   and `encodeURIComponent`.
 - `mapEntry(entry)` — `FSTreeSearchEntry → PersonSearchResult` (the
@@ -528,8 +544,8 @@ Live smoke-test CLI, e.g.
 
 | # | Test case | Verifies |
 |---|-----------|----------|
-| 1 | Returns ranked results for `givenName` + `surname` | Happy path |
-| 2 | Throws when neither `givenName` nor `surname` is supplied (only `birthPlace`) | Name-anchor rule |
+| 1 | Returns ranked results for `surname` + `givenName` | Happy path |
+| 2 | Surname-plus-one rule: accepts `surname`+`givenName` and `surname`+`birthPlace`; rejects `surname` alone, no-surname (`givenName`+`birthPlace`), `surname`+`sex` only, and `surname`+`surnameExact` only | Input validation |
 | 3 | Throws when `count` < 1 or > 100 | Bound check |
 | 4 | Throws when `offset` < 0 or > 4999 | Pagination cap |
 | 5 | Throws when `<event>YearFrom` is supplied without `<event>YearTo` | Range-pair validation |
@@ -539,18 +555,17 @@ Live smoke-test CLI, e.g.
 | 9 | `surnameExact=true` emits `q.surname.exact=on` | Modifier mapping |
 | 10 | `birthYearFrom/To` emit `q.birthLikeDate.from`/`.to`; `birthYearExact` emits `.exact=on` | Year-range mapping |
 | 11 | `fatherBirthPlace` maps to `q.fatherBirthLikePlace` | Relative-place mapping |
-| 12 | `treeId` maps to `f.treeId` | Scope mapping |
-| 13 | `m.queryRequireDefault=on` is sent on every request | Default-flag enforcement |
-| 14 | `Accept-Language: en` header is sent | Defensive header (output reads `.original`, locale-independent) |
-| 15 | No `User-Agent` header is required (request succeeds without it) | Host contract |
-| 16 | `gedcomx` carries the matched person's name (given/surname), gender, ark, and Birth/Death facts (via `toSimplified`, not `display`) | Field mapping |
-| 17 | Resolves the matched person by `entry.id` within a multi-person cluster | Cluster resolution |
-| 18 | `gedcomx` contains only the matched person (no relatives) | Lean-output contract |
-| 19 | `hasMore: true` when `links.next` exists | Pagination flag |
-| 20 | Echoes `totalMatches` and `paginationCappedAt` | Total-count surfacing |
-| 21 | Returns empty results on 200 with empty `entries` and on 204 | Zero-match handling |
-| 22 | Throws auth error when not authenticated | Auth propagation |
-| 23 | Throws on 401 with re-login guidance; on 400 with extracted detail | API errors |
+| 12 | `m.queryRequireDefault=on` is sent on every request | Default-flag enforcement |
+| 13 | `Accept-Language: en` header is sent | Defensive header (output reads `.original`, locale-independent) |
+| 14 | No `User-Agent` header is required (request succeeds without it) | Host contract |
+| 15 | `gedcomx` carries the matched person's name (given/surname), gender, ark, and Birth/Death facts (via `toSimplified`, not `display`) | Field mapping |
+| 16 | Resolves the matched person by `entry.id` within a multi-person cluster | Cluster resolution |
+| 17 | `gedcomx` contains only the matched person (no relatives) | Lean-output contract |
+| 18 | `hasMore: true` when `links.next` exists | Pagination flag |
+| 19 | Echoes `totalMatches` and `paginationCappedAt` | Total-count surfacing |
+| 20 | Returns empty results on 200 with empty `entries` and on 204 | Zero-match handling |
+| 21 | Throws auth error when not authenticated | Auth propagation |
+| 22 | Throws on 401 with re-login guidance; on 400 with extracted detail | API errors |
 
 ### Smoke test
 
@@ -575,7 +590,8 @@ cd mcp-server && npm run build && npm test
 npx @modelcontextprotocol/inspector node build/index.js
 ```
 - `person_search({ givenName: "Abraham", surname: "Lincoln", birthYearFrom: 1809, birthYearTo: 1809, birthPlace: "Kentucky" })` — top result has `personId: "LZJW-C31"`, and its `gedcomx.persons[0]` carries the Lincoln name (given/surname) plus Birth (1809, Kentucky) and Death (1865) facts.
-- `person_search({ birthPlace: "Kentucky" })` — fails with the name-anchor error.
+- `person_search({ surname: "Lincoln" })` — fails: surname alone needs one more field.
+- `person_search({ birthPlace: "Kentucky" })` — fails: surname is required.
 - `person_search({ surname: "Lincoln", count: 200 })` — fails with the count-bound error.
 - `person_search` without logging in — returns the auth error.
 
@@ -583,8 +599,10 @@ npx @modelcontextprotocol/inspector node build/index.js
 - *"Find Abraham Lincoln born 1809 in Kentucky in the family tree."* — Claude calls `person_search`, surfaces the ranked matches.
 - *"Now show me his parents and children."* — Claude chains to `person_read({ personId: "LZJW-C31", relatives: true })`.
 
-### Manual Layers 3 + 4 (Cowork via WSL2 + native Windows)
-Per `docs/testing-guides/oauth-tool-testing-guide.md`.
+### Manual Layers 0–3 (smoke → Inspector → Claude Code → Cowork)
+Full layered playbook in
+`docs/testing-guides/person-search-tool-testing-guide.md` (OAuth setup
+per `docs/testing-guides/oauth-tool-testing-guide.md`).
 
 ---
 

--- a/docs/specs/person-search-tool-spec.md
+++ b/docs/specs/person-search-tool-spec.md
@@ -151,21 +151,27 @@ Each `PersonSearchResult`:
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `personId` | string | Bare Family-Tree person ID (e.g. `"LZJW-C31"`). Pass this to `person_read`. Always equals `gedcomx.persons[0].id`. |
-| `name` | string \| undefined | Matched person's display name. Undefined when the upstream carries no display name and no fallback name form. |
-| `score` | number \| undefined | Relevance score within this query. Higher = better-ranked. Not comparable across queries. |
-| `confidence` | number \| undefined | A 1–5 confidence band (5 highest). Surface for transparency; rank with `score`. |
-| `sex` | string \| undefined | `"Male"`, `"Female"`, or undefined. |
-| `birthDate` | string \| undefined | Birth date as recorded (e.g. `"12 February 1809"`). |
-| `birthPlace` | string \| undefined | Birth place as recorded. |
-| `deathDate` | string \| undefined | Death date as recorded. |
-| `deathPlace` | string \| undefined | Death place as recorded. |
-| `arkUrl` | string \| undefined | Persistent link to the tree person. Undefined when the persona has no `Persistent` identifier. |
-| `gedcomx` | SimplifiedGedcomX | The **matched person only** (their names + facts), converted via `toSimplified` (see `simplified-gedcomx-spec.md`). Relatives are intentionally excluded — call `person_read` with `relatives: true` to expand them. |
+| `personId` | string | Bare Family-Tree person ID (e.g. `"LZJW-C31"`), taken verbatim from `entry.id`. The handle the user's pick passes to `person_read`. Also present as `gedcomx.persons[0].id`. |
+| `score` | number \| undefined | Search-relevance score for this query (higher = better). **Search metadata — not part of any GedcomX**, so it lives at the top level. Not comparable across queries. |
+| `confidence` | number \| undefined | A 1–5 confidence band (5 highest). Search metadata, not GedcomX. Rank with `score`. |
+| `gedcomx` | SimplifiedGedcomX | The matched person as simplified GedcomX: `id`, `ark`, `gender`, `names` (given/surname), and `facts` (Birth, Death, …) — produced by `toSimplified` (see `simplified-gedcomx-spec.md`). The skill renders its pick-list from this. Relatives are excluded by design (see *Picking a result*). |
 
-Output `*Date` fields keep their names because they hold the date as
-recorded — which can carry month and day even though inputs are
-year-only.
+`personId`, `score`, and `confidence` are the only non-GedcomX fields,
+because they are search metadata the endpoint returns at the entry level
+(`entry.id` / `entry.score` / `entry.confidence`) and cannot live inside
+a person's GedcomX. Everything else about the person — name, sex, dates,
+places, ark — is **inside** `gedcomx`, never duplicated outside it. This
+matches what the endpoint returns; the tool invents no flat summary
+fields of its own.
+
+**ID note (don't "fix" this):** `toSimplified` preserves the source
+person's ID (`gedcomx-convert.ts` `simplifyPerson`), so
+`gedcomx.persons[0].id` is the FamilySearch tree ID (e.g. `"LZJW-C31"`),
+identical to `personId`. It is **not** renumbered to the abstract
+`I1`/`N1`/`F1` IDs that `simplified-gedcomx-spec.md` §3 prescribes —
+those are assigned only when curating the `tree.gedcomx.json`
+deliverable. Emitting FS IDs here is correct and matches how
+`person_read` and `record_search` return GedcomX from live API data.
 
 Example:
 
@@ -180,21 +186,15 @@ Example:
   "results": [
     {
       "personId": "LZJW-C31",
-      "name": "President Abraham Lincoln",
       "score": 5.1136,
       "confidence": 3,
-      "sex": "Male",
-      "birthDate": "12 February 1809",
-      "birthPlace": "Hardin, Kentucky, United States",
-      "deathDate": "15 April 1865",
-      "deathPlace": "Washington, District of Columbia, United States",
-      "arkUrl": "https://familysearch.org/ark:/61903/4:1:LZJW-C31",
       "gedcomx": {
         "persons": [
           {
             "id": "LZJW-C31",
+            "ark": "https://familysearch.org/ark:/61903/4:1:LZJW-C31",
             "gender": "Male",
-            "names": [{ "fullText": "President Abraham Lincoln" }],
+            "names": [{ "preferred": true, "type": "BirthName", "given": "Abraham", "surname": "Lincoln" }],
             "facts": [
               { "type": "Birth", "date": "12 February 1809", "place": "Hardin, Kentucky, United States" },
               { "type": "Death", "date": "15 April 1865", "place": "Washington, District of Columbia, United States" }
@@ -206,6 +206,18 @@ Example:
   ]
 }
 ```
+
+### Picking a result (why this output is terminal)
+
+When the user chooses a match, the LLM passes only the `personId` string
+to `person_read({ personId, relatives: true })`. `person_read` re-fetches
+the authoritative person from FamilySearch by ID and runs its own
+GedcomX→simplified conversion. This tool's `gedcomx` is therefore never
+read back as input, and the simplified→raw reverse converter
+(`toGedcomX`) is **not** used in this chain. That is why the output can
+be lossy-simplified and scoped to the matched person without losing
+anything — the full, current record is always one `person_read` call
+away.
 
 ---
 
@@ -339,11 +351,15 @@ Accept-Language: en
 - `Accept: application/x-gedcomx-atom+json` — the GedcomX-Atom search
   feed. *(`application/json` returns the same envelope; the atom media
   type is the documented default for this endpoint.)*
-- `Accept-Language: en` — **required.** *(Empirical, probe 2026-05-28:
-  without it, normalized place names and the `display` block come back
-  in the account's session locale. A test account set to Mongolian
-  returned `"Hardin, Кентаки, ..."`; with `Accept-Language: en` it
-  returned `"Hardin, Kentucky, United States"`.)*
+- `Accept-Language: en` — sent defensively; **not load-bearing for this
+  tool's output.** *(Empirical, probe 2026-05-28: the session locale only
+  affects the `.normalized` place values and the `display` block — a
+  Mongolian-locale account returned `"Hardin, Кентаки, ..."` in those.
+  This tool reads `fact.place.original` / `fact.date.original` through
+  `toSimplified` — the contributor's as-entered text, which is
+  locale-independent — and never surfaces `display` / `.normalized`. So
+  the header doesn't change our output; we send it as
+  belt-and-suspenders.)*
 
 **Default flags sent on every request:**
 
@@ -400,7 +416,7 @@ response.entries[]
   .confidence                             -> 1-5 (number)
   .content.gedcomx.persons[]              -> a CLUSTER: the matched person PLUS relatives
     .id                                   -> tree-person ID; the matched person's equals entry.id
-    .display                              -> normalized summary block (locale-sensitive)
+    .display                              -> normalized summary block (locale-sensitive; NOT read by this tool)
       .name / .gender / .birthDate / .birthPlace / .deathDate / .deathPlace
     .gender.type                          -> URL form (e.g. "http://gedcomx.org/Male")
     .names[].nameForms[].fullText         -> fallback name
@@ -424,17 +440,12 @@ For each `entry` in `response.entries`:
    `identifiers["http://gedcomx.org/Persistent"][0]` ends with
    `entry.id`; then `persons[0]`. If `persons` is empty, skip the entry.
 2. `personId` ← `entry.id`.
-3. `name` ← `person.display?.name`, falling back to
-   `person.names[0].nameForms[0].fullText`.
-4. `score` ← `entry.score`. `confidence` ← `entry.confidence`.
-5. `sex` ← `person.display?.gender` if present (already `"Male"` /
-   `"Female"`); otherwise the last path segment of `person.gender?.type`;
-   otherwise undefined.
-6. `birthDate` / `birthPlace` / `deathDate` / `deathPlace` ←
-   `person.display?.*`.
-7. `arkUrl` ← `person.identifiers["http://gedcomx.org/Persistent"][0]`.
-8. `gedcomx` ← `toSimplified({ persons: [person] })` — the matched
-   person only, no relatives.
+3. `score` ← `entry.score`. `confidence` ← `entry.confidence`.
+4. `gedcomx` ← `toSimplified({ persons: [matchedPerson] })` — the matched
+   person only, no relatives. Name (given/surname), `gender`, `ark`, and
+   the Birth/Death facts all come through inside this from the person's
+   `names`, `gender`, `identifiers`, and `facts`. The tool does **not**
+   read the FS `display` block.
 
 **Top-level fields:**
 
@@ -530,9 +541,9 @@ Live smoke-test CLI, e.g.
 | 11 | `fatherBirthPlace` maps to `q.fatherBirthLikePlace` | Relative-place mapping |
 | 12 | `treeId` maps to `f.treeId` | Scope mapping |
 | 13 | `m.queryRequireDefault=on` is sent on every request | Default-flag enforcement |
-| 14 | `Accept-Language: en` header is sent | Locale-leak guard |
+| 14 | `Accept-Language: en` header is sent | Defensive header (output reads `.original`, locale-independent) |
 | 15 | No `User-Agent` header is required (request succeeds without it) | Host contract |
-| 16 | Maps entry → result using `display{}` first, `facts`/`names` fallback | Field mapping |
+| 16 | `gedcomx` carries the matched person's name (given/surname), gender, ark, and Birth/Death facts (via `toSimplified`, not `display`) | Field mapping |
 | 17 | Resolves the matched person by `entry.id` within a multi-person cluster | Cluster resolution |
 | 18 | `gedcomx` contains only the matched person (no relatives) | Lean-output contract |
 | 19 | `hasMore: true` when `links.next` exists | Pagination flag |
@@ -563,7 +574,7 @@ cd mcp-server && npm run build && npm test
 ```bash
 npx @modelcontextprotocol/inspector node build/index.js
 ```
-- `person_search({ givenName: "Abraham", surname: "Lincoln", birthYearFrom: 1809, birthYearTo: 1809, birthPlace: "Kentucky" })` — top result is `personId: "LZJW-C31"`, `name: "President Abraham Lincoln"`, English place strings.
+- `person_search({ givenName: "Abraham", surname: "Lincoln", birthYearFrom: 1809, birthYearTo: 1809, birthPlace: "Kentucky" })` — top result has `personId: "LZJW-C31"`, and its `gedcomx.persons[0]` carries the Lincoln name (given/surname) plus Birth (1809, Kentucky) and Death (1865) facts.
 - `person_search({ birthPlace: "Kentucky" })` — fails with the name-anchor error.
 - `person_search({ surname: "Lincoln", count: 200 })` — fails with the count-bound error.
 - `person_search` without logging in — returns the auth error.

--- a/docs/testing-guides/person-search-tool-testing-guide.md
+++ b/docs/testing-guides/person-search-tool-testing-guide.md
@@ -1,0 +1,553 @@
+# Person Search Tool Testing Guide
+
+This guide walks you through testing the `person_search` tool after it's
+built. Follow each layer in order. Don't skip ahead — each layer
+catches different problems.
+
+## What the person_search tool does (30 seconds)
+
+The `person_search` tool searches the **FamilySearch Family Tree** for
+people. You pass a surname plus at least one other clue — a given name,
+a life-event year or place (birth/death/marriage/residence), or a
+relative's name — and it returns a ranked list of candidate tree
+persons. Each result carries a tree-person ID, a relevance `score` and
+`confidence`, and the matched person as simplified GedcomX (name +
+facts).
+
+This is an **authenticated** tool — it requires a valid FamilySearch
+login session (obtained via the `login` tool). Under the hood it calls
+the documented FamilySearch platform endpoint
+`GET /platform/tree/search` ("Search Tree Persons"). Unlike
+`record_search` and `place_collections`, this endpoint is **not** behind
+the Imperva WAF, so it needs **no** browser User-Agent header.
+
+The output is deliberately **lean**: each result is just
+`personId`, `score`, `confidence`, and the matched person's `gedcomx` —
+no relatives. The typical workflow finds candidates, the user picks one,
+then `person_read` expands the family:
+
+```
+User: "Find Abraham Lincoln, born 1809 in Kentucky, in the family tree."
+Claude: person_search({ surname: "Lincoln", givenName: "Abraham",
+                        birthYearFrom: 1809, birthYearTo: 1809,
+                        birthPlace: "Kentucky" }) → ranked candidates
+User picks "President Abraham Lincoln" (LZJW-C31)
+Claude: person_read({ personId: "LZJW-C31", relatives: true }) → family
+```
+
+**The surname-plus-one rule.** A search must include `surname` **and**
+at least one other search field. `surname` alone — or `surname` + only
+`sex`, or `surname` + only an `*Exact` toggle — is rejected, because the
+tree search is heavily fuzzy and an under-constrained query returns tens
+of thousands of irrelevant matches.
+
+## Before You Start
+
+### 1. Make sure the server builds and all tests pass
+
+```bash
+cd mcp-server
+npm run build
+npm test
+```
+
+All tests should pass (including the `person_search` suite). If anything
+is red, fix it first.
+
+### 2. You need a valid FamilySearch session
+
+The `person_search` tool requires authentication. You must be able to
+log in via the `login` tool first. If you haven't tested OAuth yet,
+complete the [OAuth Testing Guide](./oauth-tool-testing-guide.md)
+through at least Layer 1 Part C before continuing.
+
+You'll need:
+- A FamilySearch developer app with a registered client ID
+- The redirect URI `http://127.0.0.1:1837/callback` registered on
+  your FS app
+- A FamilySearch account you can log in with
+
+---
+
+## Layer 0: Smoke-Test Script
+
+**What this tests:** Does the tool function work against the live API?
+
+This bypasses the MCP harness entirely and calls the tool function
+directly. It's the fastest way to catch API response shape mismatches.
+
+### Steps
+
+1. Make sure you're logged in (you should have `~/.familysearch-mcp/tokens.json`
+   from a previous `login` call). If not:
+
+   ```bash
+   cd mcp-server
+   npx @modelcontextprotocol/inspector node build/index.js
+   ```
+
+   Call `login` with your client ID, complete the browser flow, then
+   stop the Inspector.
+
+2. Run the smoke test:
+
+   ```bash
+   cd mcp-server
+   npx tsx dev/try-person-search.ts Lincoln Abraham --birth-year 1809 --birth-place Kentucky
+   ```
+
+   This calls `personSearchTool({ surname: "Lincoln", givenName: "Abraham",
+   birthYearFrom: 1809, birthYearTo: 1809, birthPlace: "Kentucky" })`.
+
+3. You should see JSON output with:
+   - `query` — an echo of the fields you supplied
+   - `totalMatches` — a number > 0 (expect ~7 for this query)
+   - `paginationCappedAt: 4999`
+   - `results` — an array; the top result should have
+     `personId: "LZJW-C31"`, a `score`, a `confidence`, and a `gedcomx`
+     whose single person is **President Abraham Lincoln** with Birth
+     (12 February 1809, Hardin, Kentucky) and Death (15 April 1865) facts
+   - Place strings should be in **English** (e.g. `"Hardin, Kentucky, United States"`)
+
+4. Confirm the lean shape: each result has only `personId`, `score`,
+   `confidence`, and `gedcomx` — **no** relatives, and `gedcomx.persons`
+   has exactly one person (the matched one).
+
+5. Verify the surname-plus-one rule rejects an under-constrained search:
+
+   ```bash
+   npx tsx dev/try-person-search.ts Lincoln
+   ```
+
+   Should error with *"person_search requires a surname plus at least
+   one other search field …"* — no API call made.
+
+6. Try another person:
+
+   ```bash
+   npx tsx dev/try-person-search.ts Tippitt William --birth-year 1820
+   ```
+
+   Should return ranked candidates (or an empty `results` array if none
+   match — no crash).
+
+### What success looks like
+
+You get back structured JSON with a ranked candidate list. The top hit
+for the Lincoln query is `LZJW-C31` (President Abraham Lincoln), and you
+can paste that `personId` into `person_read` to pull the full record.
+
+### What failure looks like
+
+| Symptom | Likely cause | Fix |
+|---------|--------------|-----|
+| Auth error ("User is not logged in") | No valid session | Run `login` first via Inspector |
+| "requires a surname plus at least one other search field" | Only `surname` supplied (or `surname` + only `sex` / an `*Exact` toggle) | Add a real second field — a given name, a year/place, or a relative's name |
+| Place names come back non-English | (rare) reading the wrong field | The tool reads the as-entered `original` text; confirm `toSimplified` isn't switched to `normalized` |
+| API returns unexpected shape | API types don't match reality | Compare the raw response to types in `src/types/person-search.ts` and adjust |
+| Empty results for a known person | Query too loose, or the person isn't in the tree | Narrow with a birth year + place; `m.queryRequireDefault=on` is sent automatically |
+| `fetch` error or timeout | Network issue or wrong URL | Check `FS_TREE_SEARCH_URL` in `src/tools/person-search.ts` |
+
+### When to move on
+
+Move to Layer 1 once the smoke test returns `LZJW-C31` for the Lincoln
+query and rejects the surname-only query.
+
+---
+
+## Layer 1: MCP Inspector
+
+**What this tests:** Does the tool register correctly? Does it work
+through the MCP protocol?
+
+### Start the Inspector
+
+```bash
+cd mcp-server
+npx @modelcontextprotocol/inspector node build/index.js
+```
+
+Look at the tools list and confirm **`person_search`** is present. If it
+is missing, check that it's imported and dispatched in `src/index.ts`,
+listed in `src/tool-schemas.ts`, and named in `manifest.json`.
+
+### Part A — Not authenticated (error message)
+
+1. Wipe any existing session:
+
+   ```bash
+   rm -f ~/.familysearch-mcp/tokens.json
+   ```
+
+   On Windows PowerShell:
+
+   ```powershell
+   Remove-Item $env:USERPROFILE\.familysearch-mcp\tokens.json
+   ```
+
+2. In the Inspector, call **`person_search`** with:
+
+   ```json
+   { "surname": "Lincoln", "givenName": "Abraham" }
+   ```
+
+3. Expected response: an error with `isError: true` and a message like:
+
+   ```
+   User is not logged in to FamilySearch. Call the login tool to authenticate.
+   ```
+
+   This confirms auth error propagation works. The message is an LLM
+   instruction — Claude will understand it means it should call `login`
+   first.
+
+### Part B — Authenticated (happy path + validation)
+
+1. In the Inspector, call **`login`** with your client ID. Complete the
+   browser flow.
+
+2. Call **`person_search`** with:
+
+   ```json
+   { "surname": "Lincoln", "givenName": "Abraham", "birthYearFrom": 1809, "birthYearTo": 1809, "birthPlace": "Kentucky" }
+   ```
+
+3. Expected response: JSON with `query`, `totalMatches`, and a `results`
+   array whose top entry is `personId: "LZJW-C31"` with a one-person
+   `gedcomx`.
+
+4. Verify the surname-plus-one rule. Call:
+
+   ```json
+   { "surname": "Lincoln" }
+   ```
+
+   Expected: an error with `isError: true` and the *"requires a surname
+   plus at least one other search field"* message. Same for:
+
+   ```json
+   { "surname": "Lincoln", "sex": "Male" }
+   ```
+
+   (`sex` does not count as the "other" field.)
+
+5. Try a broader valid search:
+
+   ```json
+   { "surname": "Lincoln", "givenName": "Mary" }
+   ```
+
+   Should return candidates without error.
+
+### What success looks like (Layer 1)
+
+- Tool shows up in the Inspector.
+- Without auth: clear error message directing to login.
+- With auth + a valid surname-plus-one query: ranked candidate data.
+- Surname-only / surname+sex: rejected with the rule message, no crash.
+
+### What failure looks like
+
+| Symptom | Likely cause | Fix |
+|---------|--------------|-----|
+| Tool missing from Inspector | Not registered | Check `index.ts`, `tool-schemas.ts`, `manifest.json` |
+| Auth error despite being logged in | Token expired, cache issue | Log out and log in again |
+| Surname-only query returns results instead of erroring | Validation not enforced | Check `validateInput` in `src/tools/person-search.ts` |
+| Unexpected error shape | API response doesn't match types | Check the smoke test output and adjust types |
+
+### When to move on
+
+Move to Layer 2 when Part B works — you can get tree-person candidates
+for a valid query through the Inspector, and bad queries are rejected.
+
+---
+
+## Layer 2: Claude Code as Client
+
+**What this tests:** Does Claude understand when and how to use the
+person_search tool from natural language — and does it chain into
+`person_read`?
+
+### Steps
+
+1. Open a terminal and create a scratch folder:
+
+   ```bash
+   mkdir -p ~/mcp-test-scratch
+   cd ~/mcp-test-scratch
+   ```
+
+   On Windows PowerShell:
+
+   ```powershell
+   mkdir -Force $env:USERPROFILE\mcp-test-scratch
+   cd $env:USERPROFILE\mcp-test-scratch
+   ```
+
+2. Register the server with Claude Code (if not already):
+
+   ```bash
+   claude mcp add --transport stdio genealogy-dev -- node /path/to/cowork-genealogy/mcp-server/build/index.js
+   ```
+
+3. Start Claude Code:
+
+   ```bash
+   claude
+   ```
+
+4. Make sure you have a valid session. If needed:
+
+   > "Log me in to FamilySearch. My client ID is YOUR-KEY."
+
+5. Test the tree-search query:
+
+   > "Find Abraham Lincoln, born 1809 in Kentucky, in the family tree."
+
+6. Watch what Claude does:
+   - Claude should call `person_search` (NOT `record_search`) with
+     `surname`, `givenName`, and the birth year/place.
+   - Claude should present the candidates — name, dates, places, and the
+     tree-person ID for each.
+
+7. Test the chain into `person_read`:
+
+   > "Show me that person's parents and children."
+
+   Claude should call `person_read({ personId: "LZJW-C31", relatives: true })`.
+
+8. Test a disambiguation-style query:
+
+   > "Search the tree for a Mary Lincoln."
+
+   Claude should call `person_search` with `surname` + `givenName`.
+
+### What success looks like
+
+Claude calls `person_search` with a surname plus a real second field,
+presents the ranked candidates clearly, and — when asked for the family
+— chains into `person_read` with the chosen `personId`.
+
+### What failure looks like
+
+- Claude uses `record_search` for a tree query → the tool descriptions
+  don't draw the records-vs-tree line clearly enough.
+- Claude calls `person_search` with only a surname → it should know the
+  surname-plus-one rule from the description and add a second field.
+- Claude has the `personId` but re-searches instead of calling
+  `person_read` for the family → the chaining hint in the description
+  isn't landing.
+
+### Troubleshooting
+
+If you change the server code:
+
+1. Rebuild: `cd mcp-server && npm run build`
+2. In Claude Code, type `/mcp` to reconnect.
+3. Try again.
+
+### When to move on
+
+Move to Layer 3 when Claude successfully uses `person_search` from
+natural language and chains into `person_read`.
+
+---
+
+## Choose Your Layer 3 Order
+
+Layers 1 and 2 are platform-agnostic — everyone runs them. Layer 3
+splits by where Cowork's MCP server runs, and **both sub-layers are
+required**:
+
+| Your dev environment | Run first | Then |
+|----------------------|-----------|------|
+| WSL2 | Layer 3a (WSL2) | Layer 3b (Native Windows) |
+| Native Windows | Layer 3b (Native Windows) | Layer 3a (WSL2) |
+
+---
+
+## Layer 3a: Cowork via WSL2
+
+**What this tests:** Does the full pipeline work in Cowork, talking
+through the WSL2 bridge?
+
+**Prerequisite:** Claude Desktop installed with a WSL2 MCP server
+entry. Example `claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "genealogy-wsl": {
+      "command": "wsl.exe",
+      "args": [
+        "-d", "Ubuntu-22.04",
+        "--cd", "/mnt/c/path/to/cowork-genealogy/mcp-server",
+        "--",
+        "/usr/bin/node",
+        "build/index.js"
+      ]
+    }
+  }
+}
+```
+
+Adjust the distro name, path, and node path for your setup. Use
+`wsl.exe -l` to find your distro name and `wsl.exe -- which node`
+to find the node path.
+
+**Important:** Remove or rename any native Windows MCP server entry
+while testing this layer, so you know the WSL2 bridge is being used.
+
+### Steps
+
+1. FULLY restart Claude Desktop if you changed the server config
+   or rebuilt (system tray → right-click → Quit → reopen).
+
+2. Open a Cowork session.
+
+3. Make sure you're logged in:
+
+   > "What's my FamilySearch auth status?"
+
+   If not logged in:
+
+   > "Log me in to FamilySearch. My client ID is YOUR-KEY."
+
+4. Test the tree-search workflow:
+
+   > "Find Abraham Lincoln, born 1809 in Kentucky, in the family tree."
+
+5. Verify Claude calls `person_search` and presents the candidates with
+   tree-person IDs.
+
+6. Test the chain:
+
+   > "Show me his parents and children."
+
+   Verify Claude calls `person_read` with the chosen `personId` and
+   `relatives: true`.
+
+### What success looks like
+
+Claude calls `person_search`, returns `LZJW-C31` (President Abraham
+Lincoln) among the candidates, then expands the family via `person_read`
+— all through the full Cowork → Claude Desktop → WSL2 → MCP server
+pipeline.
+
+### What failure looks like
+
+- Claude doesn't see the tools → config typo or Claude Desktop
+  wasn't fully restarted.
+- Server error `ETIMEDOUT` or `fetch failed` → Node 22 networking
+  bug; switch to Node 20.
+- Auth error despite logging in → token file path mismatch between
+  WSL2 and Windows.
+
+### When to move on
+
+Move to Layer 3b once the WSL2 bridge handles the person-search
+workflow.
+
+---
+
+## Layer 3b: Cowork via Native Windows
+
+**What this tests:** Does the full pipeline work running natively
+on Windows?
+
+**Prerequisite:** Claude Desktop configured with a native Windows
+MCP server entry:
+
+```json
+{
+  "mcpServers": {
+    "genealogy-native": {
+      "command": "node",
+      "args": [
+        "C:\\path\\to\\cowork-genealogy\\mcp-server\\build\\index.js"
+      ]
+    }
+  }
+}
+```
+
+**Important:** Remove or rename any WSL2 MCP server entry while
+testing this layer.
+
+### Steps
+
+1. Make sure the native Windows build is up to date:
+
+   ```powershell
+   cd C:\path\to\cowork-genealogy\mcp-server
+   npm run build
+   ```
+
+2. FULLY restart Claude Desktop.
+
+3. Open Cowork and test:
+
+   > "What's my FamilySearch auth status?"
+
+   If not logged in:
+
+   > "Log me in to FamilySearch. My client ID is YOUR-KEY."
+
+   Then:
+
+   > "Find Abraham Lincoln, born 1809 in Kentucky, in the family tree."
+
+4. Verify the same results as Layer 3a, including the `person_read`
+   follow-up.
+
+### What success looks like
+
+Same results as Layer 3a, but running natively on Windows.
+
+### What failure looks like
+
+Same issues as Layer 3a, plus potential cross-platform problems:
+
+| Problem | Fix |
+|---------|-----|
+| Build fails on Windows | Check for Linux-specific code |
+| Server crashes on startup | Check for hardcoded paths |
+| `npx` not found in config | Use `npx.cmd` on Windows |
+
+### You're done when
+
+The person-search workflow (find candidates → expand with `person_read`)
+works in Cowork on native Windows.
+
+---
+
+## Quick Reference: Commands
+
+| What | Command |
+|------|---------|
+| Build server | `cd mcp-server && npm run build` |
+| Run tests | `cd mcp-server && npm test` |
+| Smoke test (Lincoln) | `cd mcp-server && npx tsx dev/try-person-search.ts Lincoln Abraham --birth-year 1809 --birth-place Kentucky` |
+| Smoke test (rule rejection) | `cd mcp-server && npx tsx dev/try-person-search.ts Lincoln` |
+| Smoke test (another person) | `cd mcp-server && npx tsx dev/try-person-search.ts Tippitt William --birth-year 1820` |
+| Run Inspector | `cd mcp-server && npx @modelcontextprotocol/inspector node build/index.js` |
+| Wipe session (Linux/WSL) | `rm -f ~/.familysearch-mcp/tokens.json` |
+| Wipe session (PowerShell) | `Remove-Item $env:USERPROFILE\.familysearch-mcp\tokens.json` |
+| Reconnect in Claude Code | `/mcp` |
+| Claude Desktop config | Settings → Developer → Edit Config |
+| Claude Desktop logs | Settings → Developer → View Logs |
+
+---
+
+## Summary: What Each Layer Catches
+
+| Layer | What it tests | Bugs it catches |
+|-------|---------------|-----------------|
+| 0 - Smoke test | Direct function call vs live API | API shape mismatches, lean-output regressions, surname-plus-one rule, locale leaks |
+| 1 - Inspector (no auth) | Auth error propagation | Missing/wrong error messages |
+| 1 - Inspector (with auth) | Tool through MCP protocol | Schema errors, validation enforcement, serialization bugs |
+| 2 - Claude Code | LLM tool selection + the person_read chain | Records-vs-tree confusion, missing chain, bad descriptions |
+| 3a - Cowork WSL2 | Full path through WSL2 | WSL2 bridge + token path issues |
+| 3b - Cowork Native | Full path on native Windows | Cross-platform bugs |
+
+**Don't skip layers.** Each one catches bugs the others miss.

--- a/mcp-server/dev/try-person-search.ts
+++ b/mcp-server/dev/try-person-search.ts
@@ -1,0 +1,54 @@
+/**
+ * Smoke-test for the `person_search` MCP tool against the live FamilySearch
+ * tree-search endpoint. Requires a logged-in session (see the `login` tool).
+ *
+ * Usage:
+ *   npx tsx dev/try-person-search.ts Lincoln Abraham
+ *   npx tsx dev/try-person-search.ts Lincoln Abraham --birth-year 1809 --birth-place Kentucky
+ *   npx tsx dev/try-person-search.ts Lincoln --given Mary --spouse-surname Lincoln
+ *
+ * Positional args: <surname> [givenName]. Flags override / add fields.
+ * Remember the surname-plus-one rule: a surname alone is rejected.
+ */
+import { personSearchTool } from "../src/tools/person-search.js";
+import type { PersonSearchInput } from "../src/types/person-search.js";
+
+const argv = process.argv.slice(2);
+const input: PersonSearchInput = {};
+const positionals: string[] = [];
+
+for (let i = 0; i < argv.length; i++) {
+  const arg = argv[i];
+  if (arg.startsWith("--")) {
+    const value = argv[++i];
+    switch (arg) {
+      case "--given": input.givenName = value; break;
+      case "--surname": input.surname = value; break;
+      case "--birth-place": input.birthPlace = value; break;
+      case "--death-place": input.deathPlace = value; break;
+      case "--birth-year": input.birthYearFrom = input.birthYearTo = Number(value); break;
+      case "--death-year": input.deathYearFrom = input.deathYearTo = Number(value); break;
+      case "--father-surname": input.fatherSurname = value; break;
+      case "--mother-surname": input.motherSurname = value; break;
+      case "--spouse-surname": input.spouseSurname = value; break;
+      case "--count": input.count = Number(value); break;
+      default:
+        console.error(`Unknown flag: ${arg}`);
+        process.exit(1);
+    }
+  } else {
+    positionals.push(arg);
+  }
+}
+if (positionals[0] && !input.surname) input.surname = positionals[0];
+if (positionals[1] && !input.givenName) input.givenName = positionals[1];
+
+if (!input.surname) {
+  console.error(
+    "Usage: npx tsx dev/try-person-search.ts <surname> [givenName] [--birth-year YYYY] [--birth-place X] [--father-surname X] [--spouse-surname X] [--count N]"
+  );
+  process.exit(1);
+}
+
+const result = await personSearchTool(input);
+console.log(JSON.stringify(result, null, 2));

--- a/mcp-server/manifest.json
+++ b/mcp-server/manifest.json
@@ -37,6 +37,7 @@
     { "name": "place_external_links" },
     { "name": "image_read" },
     { "name": "record_search" },
+    { "name": "person_search" },
     { "name": "match_two_examples" },
     { "name": "person_record_matches" },
     { "name": "record_person_matches" },

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -17,6 +17,7 @@ import { placeExternalLinksTool, type PlaceExternalLinksToolInput } from "./tool
 import { imageReadTool, type ImageReadInput } from "./tools/image-read.js";
 import { recordSearchTool } from "./tools/record-search.js";
 import type { RecordSearchInput } from "./types/record-search.js";
+import { personSearchTool, type PersonSearchInput } from "./tools/person-search.js";
 import { matchTwoExamples } from "./tools/match-two-examples.js";
 import type { MatchTwoExamplesInput } from "./types/match-two-examples.js";
 import { personReadTool, type PersonReadToolInput } from "./tools/person-read.js";
@@ -227,6 +228,21 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
     try {
       const args = request.params.arguments as unknown as RecordSearchInput;
       const result = await recordSearchTool(args);
+      return {
+        content: [{ type: "text", text: JSON.stringify(result, null, 2) }]
+      };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Unknown error";
+      return {
+        content: [{ type: "text", text: JSON.stringify({ error: message }) }],
+        isError: true
+      };
+    }
+  }
+  if (request.params.name === "person_search") {
+    try {
+      const args = request.params.arguments as unknown as PersonSearchInput;
+      const result = await personSearchTool(args);
       return {
         content: [{ type: "text", text: JSON.stringify(result, null, 2) }]
       };

--- a/mcp-server/src/tool-schemas.ts
+++ b/mcp-server/src/tool-schemas.ts
@@ -16,6 +16,7 @@ import { populationToolSchema } from "./tools/place-population.js";
 import { placeExternalLinksToolSchema } from "./tools/place-external-links.js";
 import { imageReadToolSchema } from "./tools/image-read.js";
 import { recordSearchToolSchema } from "./tools/record-search.js";
+import { personSearchToolSchema } from "./tools/person-search.js";
 import { matchTwoExamplesSchema } from "./tools/match-two-examples.js";
 import {
   personRecordMatchesSchema,
@@ -48,6 +49,7 @@ export const allToolSchemas = [
   placeExternalLinksToolSchema,
   imageReadToolSchema,
   recordSearchToolSchema,
+  personSearchToolSchema,
   matchTwoExamplesSchema,
   personRecordMatchesSchema,
   recordPersonMatchesSchema,

--- a/mcp-server/src/tools/person-search.ts
+++ b/mcp-server/src/tools/person-search.ts
@@ -1,0 +1,411 @@
+import { getValidToken } from "../auth/refresh.js";
+import { toSimplified } from "../utils/gedcomx-convert.js";
+import {
+  isFourDigitYear,
+  normalizeSex,
+  parseUpstreamErrorBody,
+  echoQuery,
+} from "../utils/search-helpers.js";
+import type { GedcomX } from "../types/gedcomx.js";
+import type {
+  FSTreeSearchEntry,
+  FSTreeSearchPerson,
+  FSTreeSearchResponse,
+  PersonSearchInput,
+  PersonSearchResult,
+  PersonSearchToolResponse,
+} from "../types/person-search.js";
+
+const FS_TREE_SEARCH_URL = "https://api.familysearch.org/platform/tree/search";
+const ACCEPT_HEADER = "application/x-gedcomx-atom+json";
+const PAGINATION_CAP = 4999;
+const PERSISTENT_ID_URI = "http://gedcomx.org/Persistent";
+
+interface EventGroup {
+  prefix: string;
+  apiDate: string;
+  apiPlace: string;
+}
+
+const EVENT_GROUPS: EventGroup[] = [
+  { prefix: "birth", apiDate: "q.birthLikeDate", apiPlace: "q.birthLikePlace" },
+  { prefix: "death", apiDate: "q.deathLikeDate", apiPlace: "q.deathLikePlace" },
+  {
+    prefix: "marriage",
+    apiDate: "q.marriageLikeDate",
+    apiPlace: "q.marriageLikePlace",
+  },
+  {
+    prefix: "residence",
+    apiDate: "q.residenceDate",
+    apiPlace: "q.residencePlace",
+  },
+];
+
+interface KinGroup {
+  prefix: string;
+  apiGiven: string;
+  apiSurname: string;
+  // father/mother/parent accept a birth place; spouse does not.
+  apiBirthPlace?: string;
+}
+
+const KIN_GROUPS: KinGroup[] = [
+  { prefix: "spouse", apiGiven: "q.spouseGivenName", apiSurname: "q.spouseSurname" },
+  {
+    prefix: "father",
+    apiGiven: "q.fatherGivenName",
+    apiSurname: "q.fatherSurname",
+    apiBirthPlace: "q.fatherBirthLikePlace",
+  },
+  {
+    prefix: "mother",
+    apiGiven: "q.motherGivenName",
+    apiSurname: "q.motherSurname",
+    apiBirthPlace: "q.motherBirthLikePlace",
+  },
+  {
+    prefix: "parent",
+    apiGiven: "q.parentGivenName",
+    apiSurname: "q.parentSurname",
+    apiBirthPlace: "q.parentBirthLikePlace",
+  },
+];
+
+function get(input: PersonSearchInput, key: string): unknown {
+  return input[key as keyof PersonSearchInput];
+}
+
+// True when the input carries at least one "other" search field — anything
+// besides surname that meaningfully narrows. Per the surname-plus-one rule,
+// `sex`, the `*Exact` toggles, and `count`/`offset` do NOT count.
+function hasOtherSearchField(input: PersonSearchInput): boolean {
+  if (input.givenName) return true;
+  for (const group of EVENT_GROUPS) {
+    if (get(input, `${group.prefix}YearFrom`) !== undefined) return true;
+    if (get(input, `${group.prefix}YearTo`) !== undefined) return true;
+    if (get(input, `${group.prefix}Place`)) return true;
+  }
+  for (const group of KIN_GROUPS) {
+    if (get(input, `${group.prefix}GivenName`)) return true;
+    if (get(input, `${group.prefix}Surname`)) return true;
+    if (group.apiBirthPlace && get(input, `${group.prefix}BirthPlace`)) return true;
+  }
+  return false;
+}
+
+export function validateInput(input: PersonSearchInput): void {
+  if (!input.surname || !hasOtherSearchField(input)) {
+    throw new Error(
+      "person_search requires a surname plus at least one other search field (a given name, a life-event date or place, or a relative's name). sex and exact-match toggles don't count."
+    );
+  }
+
+  if (input.count !== undefined) {
+    if (!Number.isInteger(input.count) || input.count < 1 || input.count > 100) {
+      throw new Error("count must be between 1 and 100.");
+    }
+  }
+  if (input.offset !== undefined) {
+    if (
+      !Number.isInteger(input.offset) ||
+      input.offset < 0 ||
+      input.offset > PAGINATION_CAP
+    ) {
+      throw new Error(
+        "offset must be between 0 and 4999 (FamilySearch search-depth limit). Narrow the query instead of paging deeper."
+      );
+    }
+  }
+
+  for (const group of EVENT_GROUPS) {
+    const fromKey = `${group.prefix}YearFrom`;
+    const toKey = `${group.prefix}YearTo`;
+    const from = get(input, fromKey) as number | undefined;
+    const to = get(input, toKey) as number | undefined;
+    if (from !== undefined && !isFourDigitYear(from)) {
+      throw new Error(`${fromKey} must be a 4-digit year (e.g., 1809).`);
+    }
+    if (to !== undefined && !isFourDigitYear(to)) {
+      throw new Error(`${toKey} must be a 4-digit year (e.g., 1809).`);
+    }
+    if ((from === undefined) !== (to === undefined)) {
+      throw new Error(
+        `${fromKey} and ${toKey} must be provided together.`
+      );
+    }
+    if (from !== undefined && to !== undefined && from > to) {
+      throw new Error(`${fromKey} must be <= ${toKey}.`);
+    }
+  }
+
+  if (input.sex !== undefined && !normalizeSex(input.sex)) {
+    throw new Error(
+      "sex must be 'Male', 'Female', or 'Unknown' (case-insensitive)."
+    );
+  }
+}
+
+export function buildSearchUrl(input: PersonSearchInput): string {
+  const params: string[] = [];
+  const add = (key: string, value: string | number | boolean): void => {
+    params.push(`${key}=${encodeURIComponent(String(value))}`);
+  };
+
+  if (input.surname) add("q.surname", input.surname);
+  if (input.givenName) add("q.givenName", input.givenName);
+  if (input.sex) {
+    const normalized = normalizeSex(input.sex);
+    if (normalized) add("q.sex", normalized);
+  }
+  if (input.surnameExact) add("q.surname.exact", "on");
+  if (input.givenNameExact) add("q.givenName.exact", "on");
+
+  for (const group of EVENT_GROUPS) {
+    const from = get(input, `${group.prefix}YearFrom`) as number | undefined;
+    const to = get(input, `${group.prefix}YearTo`) as number | undefined;
+    const place = get(input, `${group.prefix}Place`) as string | undefined;
+    if (from !== undefined && to !== undefined) {
+      add(`${group.apiDate}.from`, from);
+      add(`${group.apiDate}.to`, to);
+    }
+    if (get(input, `${group.prefix}YearExact`)) add(`${group.apiDate}.exact`, "on");
+    if (place) add(group.apiPlace, place);
+    if (get(input, `${group.prefix}PlaceExact`)) add(`${group.apiPlace}.exact`, "on");
+  }
+
+  for (const group of KIN_GROUPS) {
+    const given = get(input, `${group.prefix}GivenName`) as string | undefined;
+    const surname = get(input, `${group.prefix}Surname`) as string | undefined;
+    if (given) add(group.apiGiven, given);
+    if (surname) add(group.apiSurname, surname);
+    if (get(input, `${group.prefix}GivenNameExact`)) add(`${group.apiGiven}.exact`, "on");
+    if (get(input, `${group.prefix}SurnameExact`)) add(`${group.apiSurname}.exact`, "on");
+    if (group.apiBirthPlace) {
+      const birthPlace = get(input, `${group.prefix}BirthPlace`) as string | undefined;
+      if (birthPlace) add(group.apiBirthPlace, birthPlace);
+      if (get(input, `${group.prefix}BirthPlaceExact`)) {
+        add(`${group.apiBirthPlace}.exact`, "on");
+      }
+    }
+  }
+
+  add("count", input.count ?? 20);
+  add("offset", input.offset ?? 0);
+
+  // Required: without this, q.* terms only rerank — they don't filter.
+  add("m.queryRequireDefault", "on");
+
+  return `${FS_TREE_SEARCH_URL}?${params.join("&")}`;
+}
+
+// Each entry's cluster holds the matched person plus relatives. The matched
+// person is the one whose `id` equals `entry.id`; fall back to ark-suffix
+// match, then the first person.
+export function findMatchedPerson(
+  entry: FSTreeSearchEntry
+): FSTreeSearchPerson | null {
+  const persons = entry.content?.gedcomx?.persons ?? [];
+  if (persons.length === 0) return null;
+
+  const entryId = entry.id;
+  if (entryId) {
+    const byId = persons.find((p) => p.id === entryId);
+    if (byId) return byId;
+    const byArk = persons.find((p) =>
+      (p.identifiers?.[PERSISTENT_ID_URI] ?? []).some((url) => url.endsWith(entryId))
+    );
+    if (byArk) return byArk;
+  }
+
+  return persons[0] ?? null;
+}
+
+export function mapEntry(entry: FSTreeSearchEntry): PersonSearchResult | null {
+  if (!entry.id) return null;
+  const person = findMatchedPerson(entry);
+  if (!person) return null;
+
+  // Lean output: only the matched person — no relatives, no relationships.
+  // The matched person is full GedcomX at runtime; FSTreeSearchPerson is a
+  // narrower declaration, hence the cast.
+  const gedcomx = toSimplified({ persons: [person] } as unknown as GedcomX);
+
+  // Drop per-person source references. We pass only the person (not its
+  // sourceDescriptions) to toSimplified, so these are dangling IDs that bloat
+  // the pick-list without resolving to anything. Full sources come from
+  // person_read on the chosen person. This mutates person_search's own
+  // result only — toSimplified is untouched, so record_search / person_read
+  // keep their sources behavior.
+  for (const p of gedcomx.persons ?? []) delete p.sources;
+
+  // Order keys metadata-first (personId, score, confidence) so the large
+  // gedcomx blob reads last — matches the spec's result example.
+  return {
+    personId: entry.id,
+    ...(entry.score !== undefined ? { score: entry.score } : {}),
+    ...(entry.confidence !== undefined ? { confidence: entry.confidence } : {}),
+    gedcomx,
+  };
+}
+
+function emptyResponse(input: PersonSearchInput): PersonSearchToolResponse {
+  return {
+    query: echoQuery(input),
+    totalMatches: 0,
+    paginationCappedAt: PAGINATION_CAP,
+    returned: 0,
+    offset: input.offset ?? 0,
+    hasMore: false,
+    results: [],
+  };
+}
+
+export async function personSearchTool(
+  input: PersonSearchInput
+): Promise<PersonSearchToolResponse> {
+  validateInput(input);
+
+  const token = await getValidToken();
+  const url = buildSearchUrl(input);
+
+  const response = await fetch(url, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: ACCEPT_HEADER,
+      "Accept-Language": "en",
+    },
+  });
+
+  // 204: a hard filter matched nothing — no body to read.
+  if (response.status === 204) {
+    return emptyResponse(input);
+  }
+
+  if (!response.ok) {
+    if (response.status === 401) {
+      throw new Error(
+        "FamilySearch session not accepted; call the login tool to re-authenticate."
+      );
+    }
+    if (response.status === 400) {
+      let detail: string | null = null;
+      try {
+        detail = parseUpstreamErrorBody(await response.json());
+      } catch {
+        detail = null;
+      }
+      if (detail) {
+        throw new Error(`FamilySearch tree search rejected the query: ${detail}.`);
+      }
+      throw new Error(
+        `FamilySearch tree search rejected the query (400 ${response.statusText}).`
+      );
+    }
+    if (response.status === 429) {
+      throw new Error(
+        "FamilySearch rate limit reached. Wait a moment and try again."
+      );
+    }
+    throw new Error(
+      `FamilySearch tree search API error: ${response.status} ${response.statusText}`
+    );
+  }
+
+  const data: FSTreeSearchResponse = await response.json();
+  const entries = data.entries ?? [];
+  const results = entries
+    .map(mapEntry)
+    .filter((r): r is PersonSearchResult => r !== null);
+
+  return {
+    query: echoQuery(input),
+    totalMatches: data.results ?? 0,
+    paginationCappedAt: PAGINATION_CAP,
+    returned: results.length,
+    offset: data.index ?? input.offset ?? 0,
+    hasMore: data.links?.next?.href != null,
+    results,
+  };
+}
+
+export const personSearchToolSchema = {
+  name: "person_search",
+  description:
+    "Search the FamilySearch Family Tree for a person. Requires a surname " +
+    "plus at least one other search field (a given name, a life-event year " +
+    "or place, or a relative's name; sex and exact-match toggles don't " +
+    "count). Additional fields narrow the ranking. Returns a ranked list of " +
+    "candidate tree persons, each with a tree-person ID and simplified " +
+    "GedcomX (name + facts), so the user can pick which one to research. To " +
+    "expand a chosen match into parents, spouses, and children, call " +
+    "person_read with relatives: true. Requires authentication — call the " +
+    "login tool first if not logged in. For ambiguous place names, call the " +
+    "place_search tool first.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      givenName: { type: "string", description: "Given (first) name. Counts as a qualifying 'other' field alongside the required surname." },
+      surname: { type: "string", description: "Family name. Required on every search, and must be accompanied by at least one other search field (a given name, a life-event year/place, or a relative's name). `sex` and `*Exact` toggles do not count." },
+      sex: { type: "string", enum: ["Male", "Female", "Unknown"], description: "Sex of the person. Case-insensitive on input — `'male'` is normalized to `'Male'`. Does not satisfy the surname-plus-one rule on its own." },
+      givenNameExact: { type: "boolean", description: "When `true`, requires an exact given-name match (no fuzzy nicknames or spelling variants)." },
+      surnameExact: { type: "boolean", description: "When `true`, requires an exact surname match (no fuzzy nicknames or spelling variants)." },
+
+      birthYearFrom: { type: "number", description: "Lower bound of the birth-year range. 4-digit year (e.g., 1809). Must be paired with `birthYearTo`." },
+      birthYearTo: { type: "number", description: "Upper bound of the birth-year range. 4-digit year. Must be paired with `birthYearFrom`. For a single year, set From and To equal." },
+      birthYearExact: { type: "boolean", description: "When `true`, the birth-year range is matched exactly." },
+      birthPlace: { type: "string", description: "Birth place name. For ambiguous place names, call the `place_search` tool first." },
+      birthPlaceExact: { type: "boolean", description: "When `true`, requires an exact place match (no expansion to parent jurisdictions)." },
+
+      deathYearFrom: { type: "number", description: "Lower bound of the death-year range. 4-digit year. Must be paired with `deathYearTo`." },
+      deathYearTo: { type: "number", description: "Upper bound of the death-year range. 4-digit year. Must be paired with `deathYearFrom`." },
+      deathYearExact: { type: "boolean", description: "When `true`, the death-year range is matched exactly." },
+      deathPlace: { type: "string", description: "Death place name." },
+      deathPlaceExact: { type: "boolean", description: "When `true`, requires an exact place match." },
+
+      marriageYearFrom: { type: "number", description: "Lower bound of the marriage-year range. 4-digit year. Must be paired with `marriageYearTo`." },
+      marriageYearTo: { type: "number", description: "Upper bound of the marriage-year range. 4-digit year. Must be paired with `marriageYearFrom`." },
+      marriageYearExact: { type: "boolean", description: "When `true`, the marriage-year range is matched exactly." },
+      marriagePlace: { type: "string", description: "Marriage place name." },
+      marriagePlaceExact: { type: "boolean", description: "When `true`, requires an exact place match." },
+
+      residenceYearFrom: { type: "number", description: "Lower bound of the residence-year range. 4-digit year. Must be paired with `residenceYearTo`." },
+      residenceYearTo: { type: "number", description: "Upper bound of the residence-year range. 4-digit year. Must be paired with `residenceYearFrom`." },
+      residenceYearExact: { type: "boolean", description: "When `true`, the residence-year range is matched exactly." },
+      residencePlace: { type: "string", description: "Residence place name." },
+      residencePlaceExact: { type: "boolean", description: "When `true`, requires an exact place match." },
+
+      spouseGivenName: { type: "string", description: "Spouse's given name." },
+      spouseSurname: { type: "string", description: "Spouse's family name." },
+      spouseGivenNameExact: { type: "boolean", description: "When `true`, requires an exact match on the spouse's given name." },
+      spouseSurnameExact: { type: "boolean", description: "When `true`, requires an exact match on the spouse's family name." },
+
+      fatherGivenName: { type: "string", description: "Father's given name." },
+      fatherSurname: { type: "string", description: "Father's family name." },
+      fatherGivenNameExact: { type: "boolean", description: "When `true`, requires an exact match on the father's given name." },
+      fatherSurnameExact: { type: "boolean", description: "When `true`, requires an exact match on the father's family name." },
+      fatherBirthPlace: { type: "string", description: "Father's birth place name." },
+      fatherBirthPlaceExact: { type: "boolean", description: "When `true`, requires an exact match on the father's birth place." },
+
+      motherGivenName: { type: "string", description: "Mother's given name." },
+      motherSurname: { type: "string", description: "Mother's family name." },
+      motherGivenNameExact: { type: "boolean", description: "When `true`, requires an exact match on the mother's given name." },
+      motherSurnameExact: { type: "boolean", description: "When `true`, requires an exact match on the mother's family name." },
+      motherBirthPlace: { type: "string", description: "Mother's birth place name." },
+      motherBirthPlaceExact: { type: "boolean", description: "When `true`, requires an exact match on the mother's birth place." },
+
+      parentGivenName: { type: "string", description: "A parent's given name when the parent's sex is unknown." },
+      parentSurname: { type: "string", description: "A parent's family name when the parent's sex is unknown." },
+      parentGivenNameExact: { type: "boolean", description: "When `true`, requires an exact match on the parent's given name." },
+      parentSurnameExact: { type: "boolean", description: "When `true`, requires an exact match on the parent's family name." },
+      parentBirthPlace: { type: "string", description: "A parent's birth place name." },
+      parentBirthPlaceExact: { type: "boolean", description: "When `true`, requires an exact match on the parent's birth place." },
+
+      count: { type: "number", description: "Results per call. Default 20, range 1–100." },
+      offset: { type: "number", description: "0-based index of the first result. Default 0, range 0–4999 (FamilySearch's search-depth limit)." },
+    },
+  },
+} as const;
+
+// Re-export the input type for index.ts wiring.
+export type { PersonSearchInput };

--- a/mcp-server/src/tools/record-search.ts
+++ b/mcp-server/src/tools/record-search.ts
@@ -13,6 +13,15 @@ import type {
   TreeMatch,
   RecordSearchToolResponse,
 } from "../types/record-search.js";
+import {
+  isFourDigitYear,
+  normalizeSex,
+  parseUpstreamErrorBody,
+  echoQuery,
+} from "../utils/search-helpers.js";
+
+// Re-exported so existing importers (and tests) keep resolving it here.
+export { parseUpstreamErrorBody };
 
 const FS_SEARCH_URL =
   "https://www.familysearch.org/service/search/hr/v2/personas";
@@ -73,19 +82,6 @@ const KIN_GROUPS: KinGroup[] = [
   { prefix: "parent", apiGiven: "q.parentGivenName", apiSurname: "q.parentSurname" },
   { prefix: "other", apiGiven: "q.otherGivenName", apiSurname: "q.otherSurname" },
 ];
-
-function isFourDigitYear(value: number): boolean {
-  return Number.isInteger(value) && value >= 1000 && value <= 9999;
-}
-
-function normalizeSex(value: string): string | null {
-  const lookup: Record<string, string> = {
-    male: "Male",
-    female: "Female",
-    unknown: "Unknown",
-  };
-  return lookup[value.toLowerCase()] ?? null;
-}
 
 export function applyAltNameAutoPair(input: RecordSearchInput): RecordSearchInput {
   const out = { ...input };
@@ -431,32 +427,6 @@ export function mapEntry(entry: FSSearchEntry): RecordSearchResult | null {
   if (person.id) result.primaryId = person.id;
 
   return result;
-}
-
-export function parseUpstreamErrorBody(body: unknown): string | null {
-  if (!body || typeof body !== "object") return null;
-  const errors = (body as { errors?: unknown }).errors;
-  if (!Array.isArray(errors) || errors.length === 0) return null;
-  const detail = errors
-    .map((e) => {
-      if (typeof e === "string") return e;
-      if (e && typeof e === "object") {
-        const msg = (e as { message?: unknown }).message;
-        if (typeof msg === "string") return msg;
-      }
-      return null;
-    })
-    .filter((s): s is string => s !== null)
-    .join("; ");
-  return detail || null;
-}
-
-function echoQuery(input: RecordSearchInput): Partial<RecordSearchInput> {
-  const echo: Record<string, unknown> = {};
-  for (const [key, value] of Object.entries(input)) {
-    if (value !== undefined) echo[key] = value;
-  }
-  return echo as Partial<RecordSearchInput>;
 }
 
 export async function recordSearchTool(

--- a/mcp-server/src/types/person-search.ts
+++ b/mcp-server/src/types/person-search.ts
@@ -1,0 +1,119 @@
+// FamilySearch Tree Search API response + tool I/O types
+// GET https://api.familysearch.org/platform/tree/search
+
+import type { SimplifiedGedcomX } from "./gedcomx.js";
+
+// ─── Upstream (FS) response shapes ──────────────────────────────────────
+// Only the fields the tool reads directly are declared. The matched person
+// is otherwise passed straight to `toSimplified` (cast to GedcomX), which
+// reads the full runtime structure (names, facts, gender, identifiers).
+
+export interface FSTreeSearchPerson {
+  id?: string;
+  identifiers?: Record<string, string[]>;
+}
+
+export interface FSTreeSearchGedcomx {
+  id?: string;
+  description?: string;
+  persons?: FSTreeSearchPerson[];
+  relationships?: unknown[];
+}
+
+export interface FSTreeSearchEntry {
+  id?: string;
+  title?: string;
+  score?: number;
+  confidence?: number;
+  content?: { gedcomx?: FSTreeSearchGedcomx };
+}
+
+export interface FSTreeSearchResponse {
+  results?: number;
+  index?: number;
+  links?: { next?: { href?: string } };
+  entries?: FSTreeSearchEntry[];
+}
+
+// ─── Tool I/O ───────────────────────────────────────────────────────────
+
+export interface PersonSearchInput {
+  givenName?: string;
+  surname?: string;
+  sex?: string;
+  givenNameExact?: boolean;
+  surnameExact?: boolean;
+
+  birthYearFrom?: number;
+  birthYearTo?: number;
+  birthYearExact?: boolean;
+  birthPlace?: string;
+  birthPlaceExact?: boolean;
+
+  deathYearFrom?: number;
+  deathYearTo?: number;
+  deathYearExact?: boolean;
+  deathPlace?: string;
+  deathPlaceExact?: boolean;
+
+  marriageYearFrom?: number;
+  marriageYearTo?: number;
+  marriageYearExact?: boolean;
+  marriagePlace?: string;
+  marriagePlaceExact?: boolean;
+
+  residenceYearFrom?: number;
+  residenceYearTo?: number;
+  residenceYearExact?: boolean;
+  residencePlace?: string;
+  residencePlaceExact?: boolean;
+
+  spouseGivenName?: string;
+  spouseSurname?: string;
+  spouseGivenNameExact?: boolean;
+  spouseSurnameExact?: boolean;
+
+  fatherGivenName?: string;
+  fatherSurname?: string;
+  fatherGivenNameExact?: boolean;
+  fatherSurnameExact?: boolean;
+  fatherBirthPlace?: string;
+  fatherBirthPlaceExact?: boolean;
+
+  motherGivenName?: string;
+  motherSurname?: string;
+  motherGivenNameExact?: boolean;
+  motherSurnameExact?: boolean;
+  motherBirthPlace?: string;
+  motherBirthPlaceExact?: boolean;
+
+  parentGivenName?: string;
+  parentSurname?: string;
+  parentGivenNameExact?: boolean;
+  parentSurnameExact?: boolean;
+  parentBirthPlace?: string;
+  parentBirthPlaceExact?: boolean;
+
+  count?: number;
+  offset?: number;
+}
+
+export interface PersonSearchResult {
+  // Bare Family-Tree person ID (e.g. "LZJW-C31"); the handle for person_read.
+  personId: string;
+  // Search-relevance metadata — not part of any GedcomX.
+  score?: number;
+  confidence?: number;
+  // The matched person only (id, ark, gender, names, facts). No relatives.
+  gedcomx: SimplifiedGedcomX;
+}
+
+export interface PersonSearchToolResponse {
+  query: Partial<PersonSearchInput>;
+  totalMatches: number;
+  paginationCappedAt: number;
+  returned: number;
+  offset: number;
+  hasMore: boolean;
+  results: PersonSearchResult[];
+}

--- a/mcp-server/src/utils/search-helpers.ts
+++ b/mcp-server/src/utils/search-helpers.ts
@@ -1,0 +1,60 @@
+// Shared helpers for the FamilySearch search tools (`record_search`,
+// `person_search`). Both wrap FS search endpoints and need the same generic
+// input validators and response helpers — kept here so there is a single
+// copy rather than a near-duplicate in each tool.
+
+/** True for a plausible 4-digit calendar year. */
+export function isFourDigitYear(value: number): boolean {
+  return Number.isInteger(value) && value >= 1000 && value <= 9999;
+}
+
+/**
+ * Normalize a sex string to the GedcomX canonical form, case-insensitively.
+ * Returns null for unrecognized values so callers can raise a validation
+ * error.
+ */
+export function normalizeSex(value: string): string | null {
+  const lookup: Record<string, string> = {
+    male: "Male",
+    female: "Female",
+    unknown: "Unknown",
+  };
+  return lookup[value.toLowerCase()] ?? null;
+}
+
+/**
+ * Pull a human-readable detail out of an FS search 400 error body
+ * (shape: `{ errors: [{ message }] }` or `{ errors: ["..."] }`). Returns
+ * null when nothing usable is present, so callers can fall back to a
+ * generic message.
+ */
+export function parseUpstreamErrorBody(body: unknown): string | null {
+  if (!body || typeof body !== "object") return null;
+  const errors = (body as { errors?: unknown }).errors;
+  if (!Array.isArray(errors) || errors.length === 0) return null;
+  const detail = errors
+    .map((e) => {
+      if (typeof e === "string") return e;
+      if (e && typeof e === "object") {
+        const msg = (e as { message?: unknown }).message;
+        if (typeof msg === "string") return msg;
+      }
+      return null;
+    })
+    .filter((s): s is string => s !== null)
+    .join("; ");
+  return detail || null;
+}
+
+/**
+ * Echo back only the input fields the caller actually supplied (drops
+ * `undefined`), preserving the input's shape. Used to mirror the query in
+ * a tool's response.
+ */
+export function echoQuery<T extends object>(input: T): Partial<T> {
+  const echo: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(input)) {
+    if (value !== undefined) echo[key] = value;
+  }
+  return echo as Partial<T>;
+}

--- a/mcp-server/tests/tools/person-search.test.ts
+++ b/mcp-server/tests/tools/person-search.test.ts
@@ -1,0 +1,491 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("../../src/auth/refresh.js", () => ({
+  getValidToken: vi.fn(),
+}));
+
+import {
+  personSearchTool,
+  buildSearchUrl,
+  validateInput,
+  mapEntry,
+  findMatchedPerson,
+} from "../../src/tools/person-search.js";
+import { getValidToken } from "../../src/auth/refresh.js";
+import type {
+  FSTreeSearchEntry,
+  FSTreeSearchResponse,
+} from "../../src/types/person-search.js";
+
+const mockedGetValidToken = vi.mocked(getValidToken);
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+beforeEach(() => {
+  mockFetch.mockReset();
+  mockedGetValidToken.mockReset();
+  mockedGetValidToken.mockResolvedValue("test-token");
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// ─── Fixtures ───────────────────────────────────────────────────────────
+
+function makeOkResponse(body: FSTreeSearchResponse) {
+  return {
+    ok: true,
+    status: 200,
+    statusText: "OK",
+    json: async () => body,
+  };
+}
+
+function make204Response() {
+  return { ok: true, status: 204, statusText: "No Content", json: async () => ({}) };
+}
+
+function makeErrorResponse(status: number, statusText: string, body: unknown = {}) {
+  return {
+    ok: false,
+    status,
+    statusText,
+    json: async () => body,
+  };
+}
+
+function emptyResponse(): FSTreeSearchResponse {
+  return { results: 0, index: 0, entries: [] };
+}
+
+/** Matched person (Lincoln) + a relative (his father) + a relationship. */
+function lincolnTreeEntry(): FSTreeSearchEntry {
+  return {
+    id: "LZJW-C31",
+    title: "Person LZJW-C31 (President Abraham Lincoln)",
+    score: 5.11,
+    confidence: 3,
+    content: {
+      gedcomx: {
+        id: "ark:/61903/4:1:LZJW-C31",
+        description: "#sdp_LZJW-C31",
+        persons: [
+          {
+            id: "LZJW-C31",
+            gender: { type: "http://gedcomx.org/Male" },
+            names: [
+              {
+                type: "http://gedcomx.org/BirthName",
+                preferred: true,
+                nameForms: [
+                  {
+                    fullText: "President Abraham Lincoln",
+                    parts: [
+                      { type: "http://gedcomx.org/Given", value: "Abraham" },
+                      { type: "http://gedcomx.org/Surname", value: "Lincoln" },
+                    ],
+                  },
+                ],
+              },
+            ],
+            facts: [
+              {
+                type: "http://gedcomx.org/Birth",
+                date: { original: "12 February 1809" },
+                place: { original: "Hardin, Kentucky, United States" },
+              },
+              {
+                type: "http://gedcomx.org/Death",
+                date: { original: "15 April 1865" },
+                place: { original: "Washington, District of Columbia, United States" },
+              },
+            ],
+            identifiers: {
+              "http://gedcomx.org/Persistent": [
+                "https://familysearch.org/ark:/61903/4:1:LZJW-C31",
+              ],
+            },
+            // Source references on the matched person — dangling IDs that the
+            // tool should strip from the lean output.
+            sources: [
+              { description: "#sd_1_1_4CT4-N1ZM" },
+              { description: "#sd_1_1_QK4J-2GJL" },
+            ],
+          },
+          {
+            // A relative in the cluster — must NOT appear in the lean output.
+            id: "LZ99-DAD",
+            gender: { type: "http://gedcomx.org/Male" },
+            names: [
+              {
+                nameForms: [
+                  {
+                    parts: [
+                      { type: "http://gedcomx.org/Given", value: "Thomas" },
+                      { type: "http://gedcomx.org/Surname", value: "Lincoln" },
+                    ],
+                  },
+                ],
+              },
+            ],
+            facts: [
+              { type: "http://gedcomx.org/Birth", date: { original: "1778" } },
+            ],
+            identifiers: {
+              "http://gedcomx.org/Persistent": [
+                "https://familysearch.org/ark:/61903/4:1:LZ99-DAD",
+              ],
+            },
+          },
+        ],
+        relationships: [
+          {
+            type: "http://gedcomx.org/ParentChild",
+            person1: { resource: "#LZ99-DAD" },
+            person2: { resource: "#LZJW-C31" },
+          },
+        ],
+      },
+    },
+  };
+}
+
+const VALID_QUERY = { surname: "Lincoln", givenName: "Abraham" };
+
+// ─── Happy path ─────────────────────────────────────────────────────────
+
+describe("personSearchTool happy path", () => {
+  it("1. returns ranked results for surname + givenName", async () => {
+    mockFetch.mockResolvedValueOnce(
+      makeOkResponse({ results: 7, index: 0, entries: [lincolnTreeEntry()] }),
+    );
+
+    const result = await personSearchTool(VALID_QUERY);
+
+    expect(result.totalMatches).toBe(7);
+    expect(result.returned).toBe(1);
+    expect(result.results[0].personId).toBe("LZJW-C31");
+    expect(result.results[0].score).toBe(5.11);
+    expect(result.results[0].confidence).toBe(3);
+    expect(result.paginationCappedAt).toBe(4999);
+  });
+});
+
+// ─── Surname-plus-one rule (test #2 in the spec table) ──────────────────
+
+describe("personSearchTool surname-plus-one rule", () => {
+  it("2a. accepts surname + givenName", async () => {
+    mockFetch.mockResolvedValueOnce(makeOkResponse(emptyResponse()));
+    await expect(
+      personSearchTool({ surname: "Lincoln", givenName: "Abraham" }),
+    ).resolves.toBeDefined();
+  });
+
+  it("2b. accepts surname + birthPlace", async () => {
+    mockFetch.mockResolvedValueOnce(makeOkResponse(emptyResponse()));
+    await expect(
+      personSearchTool({ surname: "Lincoln", birthPlace: "Kentucky" }),
+    ).resolves.toBeDefined();
+  });
+
+  it("2c. rejects surname alone", async () => {
+    await expect(personSearchTool({ surname: "Lincoln" })).rejects.toThrow(
+      /requires a surname plus at least one other/,
+    );
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("2d. rejects no-surname (givenName + birthPlace)", async () => {
+    await expect(
+      personSearchTool({ givenName: "Abraham", birthPlace: "Kentucky" }),
+    ).rejects.toThrow(/requires a surname/);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("2e. rejects surname + sex only (sex doesn't count)", async () => {
+    await expect(
+      personSearchTool({ surname: "Lincoln", sex: "Male" }),
+    ).rejects.toThrow(/requires a surname plus at least one other/);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("2f. rejects surname + surnameExact only (a toggle doesn't count)", async () => {
+    await expect(
+      personSearchTool({ surname: "Lincoln", surnameExact: true }),
+    ).rejects.toThrow(/requires a surname plus at least one other/);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("2g. accepts surname + a relative name", async () => {
+    mockFetch.mockResolvedValueOnce(makeOkResponse(emptyResponse()));
+    await expect(
+      personSearchTool({ surname: "Lincoln", fatherSurname: "Lincoln" }),
+    ).resolves.toBeDefined();
+  });
+});
+
+// ─── Validation ─────────────────────────────────────────────────────────
+
+describe("personSearchTool input validation", () => {
+  it("3. throws when count is out of [1,100]", async () => {
+    await expect(
+      personSearchTool({ ...VALID_QUERY, count: 0 }),
+    ).rejects.toThrow(/count must be between 1 and 100/);
+    await expect(
+      personSearchTool({ ...VALID_QUERY, count: 101 }),
+    ).rejects.toThrow(/count must be between 1 and 100/);
+  });
+
+  it("4. throws when offset is out of [0,4999]", async () => {
+    await expect(
+      personSearchTool({ ...VALID_QUERY, offset: -1 }),
+    ).rejects.toThrow(/offset must be between 0 and 4999/);
+    await expect(
+      personSearchTool({ ...VALID_QUERY, offset: 5000 }),
+    ).rejects.toThrow(/offset must be between 0 and 4999/);
+  });
+
+  it("5. throws when a year-range half is supplied without the other", () => {
+    expect(() =>
+      validateInput({ ...VALID_QUERY, birthYearFrom: 1809 }),
+    ).toThrow(/birthYearFrom and birthYearTo must be provided together/);
+  });
+
+  it("6. throws when YearFrom > YearTo", () => {
+    expect(() =>
+      validateInput({ ...VALID_QUERY, birthYearFrom: 1900, birthYearTo: 1800 }),
+    ).toThrow(/birthYearFrom must be <= birthYearTo/);
+  });
+
+  it("6b. throws when a year is not 4 digits", () => {
+    expect(() =>
+      validateInput({ ...VALID_QUERY, birthYearFrom: 99, birthYearTo: 99 }),
+    ).toThrow(/must be a 4-digit year/);
+  });
+
+  it("7. throws on sex outside Male/Female/Unknown (case-insensitive accepted)", () => {
+    expect(() => validateInput({ ...VALID_QUERY, sex: "X" })).toThrow(
+      /sex must be 'Male', 'Female', or 'Unknown'/,
+    );
+    expect(() =>
+      validateInput({ ...VALID_QUERY, sex: "male" }),
+    ).not.toThrow();
+  });
+});
+
+// ─── URL building ───────────────────────────────────────────────────────
+
+describe("buildSearchUrl", () => {
+  it("8. maps core q.* params and targets the platform endpoint", () => {
+    const url = buildSearchUrl({
+      surname: "Lincoln",
+      givenName: "Abraham",
+      sex: "Male",
+    });
+    expect(url).toContain("https://api.familysearch.org/platform/tree/search?");
+    expect(url).toContain("q.surname=Lincoln");
+    expect(url).toContain("q.givenName=Abraham");
+    expect(url).toContain("q.sex=Male");
+  });
+
+  it("9. surnameExact emits q.surname.exact=on", () => {
+    const url = buildSearchUrl({ ...VALID_QUERY, surnameExact: true });
+    expect(url).toContain("q.surname.exact=on");
+  });
+
+  it("10. birthYearFrom/To emit q.birthLikeDate.from/.to; birthYearExact emits .exact=on", () => {
+    const url = buildSearchUrl({
+      ...VALID_QUERY,
+      birthYearFrom: 1809,
+      birthYearTo: 1810,
+      birthYearExact: true,
+    });
+    expect(url).toContain("q.birthLikeDate.from=1809");
+    expect(url).toContain("q.birthLikeDate.to=1810");
+    expect(url).toContain("q.birthLikeDate.exact=on");
+  });
+
+  it("10b. places and relatives map to the right q.* params", () => {
+    const url = buildSearchUrl({
+      surname: "Lincoln",
+      birthPlace: "Kentucky",
+      residenceYearFrom: 1860,
+      residenceYearTo: 1860,
+      spouseGivenName: "Mary",
+      spouseSurname: "Todd",
+    });
+    expect(url).toContain("q.birthLikePlace=Kentucky");
+    expect(url).toContain("q.residenceDate.from=1860");
+    expect(url).toContain("q.spouseGivenName=Mary");
+    expect(url).toContain("q.spouseSurname=Todd");
+  });
+
+  it("11. fatherBirthPlace maps to q.fatherBirthLikePlace", () => {
+    const url = buildSearchUrl({ ...VALID_QUERY, fatherBirthPlace: "Virginia" });
+    expect(url).toContain("q.fatherBirthLikePlace=Virginia");
+  });
+
+  it("12. sends m.queryRequireDefault=on and default count/offset", () => {
+    const url = buildSearchUrl(VALID_QUERY);
+    expect(url).toContain("m.queryRequireDefault=on");
+    expect(url).toContain("count=20");
+    expect(url).toContain("offset=0");
+  });
+});
+
+// ─── Headers / host contract ────────────────────────────────────────────
+
+describe("personSearchTool request headers", () => {
+  it("13. sends Accept-Language: en and the atom Accept header", async () => {
+    mockFetch.mockResolvedValueOnce(makeOkResponse(emptyResponse()));
+    await personSearchTool(VALID_QUERY);
+    const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+    const headers = init.headers as Record<string, string>;
+    expect(headers["Accept-Language"]).toBe("en");
+    expect(headers["Accept"]).toBe("application/x-gedcomx-atom+json");
+    expect(headers["Authorization"]).toBe("Bearer test-token");
+  });
+
+  it("14. does NOT send a User-Agent header (platform host needs none)", async () => {
+    mockFetch.mockResolvedValueOnce(makeOkResponse(emptyResponse()));
+    await personSearchTool(VALID_QUERY);
+    const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+    const headers = init.headers as Record<string, string>;
+    expect(headers["User-Agent"]).toBeUndefined();
+  });
+});
+
+// ─── Mapping: lean output ───────────────────────────────────────────────
+
+describe("mapEntry / lean output", () => {
+  it("15. gedcomx carries the matched person's name, gender, ark, and facts", () => {
+    const result = mapEntry(lincolnTreeEntry());
+    expect(result).not.toBeNull();
+    const person = result!.gedcomx.persons![0];
+    expect(person.id).toBe("LZJW-C31");
+    expect(person.gender).toBe("Male");
+    expect(person.ark).toBe("https://familysearch.org/ark:/61903/4:1:LZJW-C31");
+    expect(person.names![0].given).toBe("Abraham");
+    expect(person.names![0].surname).toBe("Lincoln");
+    const birth = person.facts!.find((f) => f.type === "Birth");
+    expect(birth?.date).toBe("12 February 1809");
+    expect(birth?.place).toBe("Hardin, Kentucky, United States");
+  });
+
+  it("16. resolves the matched person by entry.id even when not first in the cluster", () => {
+    const entry = lincolnTreeEntry();
+    // Reverse the cluster so the matched person (entry.id) is last.
+    entry.content!.gedcomx!.persons!.reverse();
+    const person = findMatchedPerson(entry);
+    expect(person?.id).toBe("LZJW-C31");
+    const result = mapEntry(entry);
+    expect(result!.gedcomx.persons![0].id).toBe("LZJW-C31");
+  });
+
+  it("17. gedcomx contains only the matched person — no relatives, no relationships", () => {
+    const result = mapEntry(lincolnTreeEntry());
+    expect(result!.gedcomx.persons).toHaveLength(1);
+    expect(result!.gedcomx.persons![0].id).toBe("LZJW-C31");
+    expect(result!.gedcomx.relationships).toBeUndefined();
+  });
+
+  it("17b. carries no flat summary fields beyond personId/score/confidence/gedcomx", () => {
+    const result = mapEntry(lincolnTreeEntry())!;
+    expect(Object.keys(result).sort()).toEqual(
+      ["confidence", "gedcomx", "personId", "score"].sort(),
+    );
+  });
+
+  it("17c. strips per-person source references (dangling IDs) from the gedcomx", () => {
+    // The fixture's matched person carries source references; the lean
+    // output must drop them (full sources come from person_read).
+    const result = mapEntry(lincolnTreeEntry())!;
+    expect(result.gedcomx.persons![0].sources).toBeUndefined();
+  });
+});
+
+// ─── Envelope + pagination ──────────────────────────────────────────────
+
+describe("personSearchTool envelope", () => {
+  it("18. sets hasMore: true when links.next exists", async () => {
+    mockFetch.mockResolvedValueOnce(
+      makeOkResponse({
+        results: 100,
+        index: 0,
+        links: { next: { href: "https://api.familysearch.org/platform/tree/search?offset=20" } },
+        entries: [lincolnTreeEntry()],
+      }),
+    );
+    const result = await personSearchTool(VALID_QUERY);
+    expect(result.hasMore).toBe(true);
+  });
+
+  it("19. echoes totalMatches and paginationCappedAt", async () => {
+    mockFetch.mockResolvedValueOnce(
+      makeOkResponse({ results: 42, index: 0, entries: [] }),
+    );
+    const result = await personSearchTool(VALID_QUERY);
+    expect(result.totalMatches).toBe(42);
+    expect(result.paginationCappedAt).toBe(4999);
+    expect(result.hasMore).toBe(false);
+  });
+});
+
+// ─── Zero-match handling ────────────────────────────────────────────────
+
+describe("personSearchTool zero matches", () => {
+  it("20a. returns empty results on 200 with empty entries", async () => {
+    mockFetch.mockResolvedValueOnce(
+      makeOkResponse({ results: 0, index: 0, entries: [] }),
+    );
+    const result = await personSearchTool(VALID_QUERY);
+    expect(result.results).toEqual([]);
+    expect(result.returned).toBe(0);
+  });
+
+  it("20b. returns empty results on 204 No Content", async () => {
+    mockFetch.mockResolvedValueOnce(make204Response());
+    const result = await personSearchTool(VALID_QUERY);
+    expect(result.results).toEqual([]);
+    expect(result.returned).toBe(0);
+    expect(result.totalMatches).toBe(0);
+  });
+});
+
+// ─── Errors ─────────────────────────────────────────────────────────────
+
+describe("personSearchTool errors", () => {
+  it("21. propagates the auth error when not authenticated", async () => {
+    mockedGetValidToken.mockRejectedValueOnce(
+      new Error("User is not logged in to FamilySearch. Call the login tool to authenticate."),
+    );
+    await expect(personSearchTool(VALID_QUERY)).rejects.toThrow(/not logged in/);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("22a. throws on 401 with re-login guidance", async () => {
+    mockFetch.mockResolvedValueOnce(makeErrorResponse(401, "Unauthorized"));
+    await expect(personSearchTool(VALID_QUERY)).rejects.toThrow(
+      /session not accepted; call the login tool/,
+    );
+  });
+
+  it("22b. throws on 400 with extracted error detail", async () => {
+    mockFetch.mockResolvedValueOnce(
+      makeErrorResponse(400, "Bad Request", {
+        errors: [{ message: "invalid date" }],
+      }),
+    );
+    await expect(personSearchTool(VALID_QUERY)).rejects.toThrow(
+      /rejected the query: invalid date/,
+    );
+  });
+
+  it("22c. throws a generic error on other non-OK status", async () => {
+    mockFetch.mockResolvedValueOnce(makeErrorResponse(500, "Server Error"));
+    await expect(personSearchTool(VALID_QUERY)).rejects.toThrow(
+      /tree search API error: 500/,
+    );
+  });
+});


### PR DESCRIPTION
Closes #190 

Summary

- Adds person_search, an authenticated MCP tool that searches the FamilySearch Family Tree (GET /platform/tree/search) and returns a ranked list of candidate tree persons for a name query — the "find a person in the tree" step, which chains into person_read to expand a chosen match. Output is lean:
each result is personId + score + confidence + the matched person as simplified GedcomX (id/ark/gender/names/facts); relatives and dangling per-person source references are omitted.

- Enforces a surname-plus-one input rule (a surname plus at least one other search field — given name, life-event year/place, or relative name; sex and *Exact toggles don't count). Maps inputs to the q.* parameter family with m.queryRequireDefault=on so terms actually filter, plus Accept-Language: en; needs no browser User-Agent (the platform host isn't behind the WAF).

- Factors the search tools' shared validators and error parsing into src/utils/search-helpers.ts, now used by both record_search and person_search (one copy, no duplication). Registers the tool in tool-schemas.ts, index.ts, and manifest.json, and ships the spec, a layered testing guide, a dev smoke script, README/CLAUDE updates, and 35 unit tests.

Test plan

- [x] cd mcp-server && npm run build && npm test — full suite passes (367 tests, 25 files), including the manifest drift test and the record_search / person_read suites (unaffected by the search-helpers.ts refactor — same toSimplified, one shared copy).
- [x] Spec-reviewed against docs/specs/person-search-tool-spec.md — clean, no drift.
- [x] Manual layers per docs/testing-guides/person-search-tool-testing-guide.md: 
Layer 0 smoke (live API returns LZJW-C31 / President Abraham Lincoln for "Abraham Lincoln, b. 1809, Kentucky"), MCP Inspector, Claude Code, and Cowork — including verifying the "no confident match" path hedges gracefully instead of dumping fuzzy results.