### PR TITLE
Implement image_search tool

### DIFF
--- a/docs/testing-guides/image-search-tool-testing-guide.md
+++ b/docs/testing-guides/image-search-tool-testing-guide.md
@@ -1,0 +1,308 @@
+# Image Search Tool Testing Guide
+
+This guide walks you through testing the `image_search` tool after it's
+built. Follow each layer in order. Don't skip ahead — each layer
+catches different problems.
+
+## What the image search tool does (30 seconds)
+
+The `image_search` tool searches FamilySearch's Records Management
+Service (RMS) for **image groups** — digitized volumes of historical
+documents (microfilm rolls, book scans). It sits between
+`place_collections` (which discovers *collections*) and `image_read`
+(which reads a *single image*): `image_search` finds the *volumes* in
+between.
+
+It has two mutually-exclusive query modes:
+
+1. **Place + date range** — pass a `placeId` (from `place_search`) plus
+   an optional `fromDate`/`toDate`. The tool converts the `placeId` to
+   one or more `placeRepId`s internally, queries RMS, and converts the
+   coverage `placeRepId`s back to `placeId`s in the output.
+2. **Image group number** — pass an `imageGroupNumber` (e.g.
+   `"007621224"`). The tool appends a `*` wildcard and looks up that
+   volume.
+
+This is an **authenticated** tool — it requires a valid FamilySearch
+login session (obtained via the `login` tool).
+
+The typical user workflow is:
+```
+User: "What image groups cover Edensor, Derbyshire between 1730 and 1810?"
+Claude: place_search("Edensor, Derbyshire") → placeId 6137147
+Claude: image_search({ placeId: "6137147", fromDate: "1730-01-01", toDate: "1810-12-31" }) → 4 groups
+```
+
+## Before You Start
+
+### 1. Make sure the server builds and all tests pass
+
+```bash
+cd mcp-server
+npm run build
+npm test
+```
+
+All tests should pass (including 19 image-search tests). The Inspector
+and Claude Code both run the **compiled** `build/index.js`, so you must
+`npm run build` after any code change.
+
+### 2. You need a valid FamilySearch session
+
+The `image_search` tool requires authentication. You must be able to log
+in via the `login` tool first. If you haven't tested OAuth yet, complete
+the [OAuth Testing Guide](./oauth-tool-testing-guide.md) through at least
+Layer 1 Part C before continuing.
+
+You'll need:
+- A FamilySearch developer app with a registered client ID
+- The redirect URI `http://127.0.0.1:1837/callback` registered on your
+  FS app
+- A FamilySearch account you can log in with
+
+---
+
+## Layer 0: Smoke-Test Script
+
+**What this tests:** Does the tool function work against the live API?
+
+This bypasses the MCP harness entirely and calls the tool function
+directly. It's the fastest way to catch API response shape mismatches.
+
+### Steps
+
+1. Make sure you're logged in (you should have
+   `~/.familysearch-mcp/tokens.json` from a previous `login` call). If
+   not, run the Inspector (Layer 1 below), call `login`, then come back.
+
+2. Run the smoke test in place + date mode:
+
+   ```bash
+   cd mcp-server
+   npx tsx dev/try-image-search.ts --placeId 6137147 --from 1730-01-01 --to 1810-12-31
+   ```
+
+   Expect `totalGroups: 4`, with `DGS-004452257` (Edensor burial
+   records, 1726–1812) among the groups and each coverage `placeId`
+   resolved back to `6137147`.
+
+3. Run the smoke test in image group number mode:
+
+   ```bash
+   npx tsx dev/try-image-search.ts --imageGroupNumber "007621224"
+   ```
+
+   Expect `totalGroups: 1`, group `007621224_005_M99P-2TQ` (Blount
+   County, Alabama), with `custodians` populated and coverages resolved
+   to `placeId 2303`.
+
+### What success looks like
+
+Structured JSON with real image-group data. The `imageGroupNumber`,
+`coverages[].placeId`, `dateRange`, and `recordType` fields are all
+populated.
+
+### What failure looks like
+
+| Symptom | Likely cause | Fix |
+|---------|--------------|-----|
+| Auth error ("not logged in") | No valid session | Run `login` first via Inspector |
+| 403 Forbidden | Missing User-Agent / FS-User-Agent-Chain header | Check the headers in `callRms` in `src/tools/image-search.ts` |
+| `placeId` is `""` in coverages | Reverse lookup failed | Confirm `/places/description/{repId}` is reachable; check `repIdToPlaceId` |
+| "No place representations found" | Forward lookup returned no reps | Confirm the `placeId` is a Primary ID (not a `placeRepId`) |
+| Wrong place in coverages | Forward/reverse endpoints swapped | `/places/{id}` reads a placeId; `/places/description/{id}` reads a placeRepId |
+
+### When to move on
+
+Move to Layer 1 once both modes return real groups.
+
+---
+
+## Layer 1: MCP Inspector
+
+**What this tests:** Does the tool register correctly? Does it work
+through the MCP protocol?
+
+### Start the Inspector
+
+```bash
+cd mcp-server
+npx @modelcontextprotocol/inspector node build/index.js
+```
+
+Open the printed URL, click **Connect**, then **List Tools**. You should
+see **`image_search`** in the list (the last of 26 tools). If it's
+missing, check that `src/index.ts` imports and dispatches it and that
+`imageSearchSchema` is in `src/tool-schemas.ts`.
+
+### Part A — Place + date mode (happy path)
+
+Call **`image_search`** with:
+
+```json
+{ "placeId": "6137147", "fromDate": "1730-01-01", "toDate": "1810-12-31" }
+```
+
+Expected: `totalGroups: 4`, including `DGS-004452257` (Burial Records,
+1726–1812), with coverage `placeId` resolved to `6137147`.
+
+### Part B — Image group number mode (happy path)
+
+Call **`image_search`** with:
+
+```json
+{ "imageGroupNumber": "007621224" }
+```
+
+Expected: `totalGroups: 1`, group `007621224_005_M99P-2TQ` (Blount
+County, Alabama), coverages resolved to `placeId 2303`.
+
+### Part C — Input validation (each returns isError, no network call)
+
+| Input | Expected error |
+|-------|----------------|
+| `{}` | `image_search requires either placeId or imageGroupNumber.` |
+| `{ "placeId": "6137147", "imageGroupNumber": "007621224" }` | `Provide either placeId or imageGroupNumber, not both.` |
+| `{ "placeId": "6137147", "fromDate": "1730" }` | `fromDate must be in YYYY-MM-DD format (e.g., '1730-01-01').` |
+| `{ "imageGroupNumber": "007621224", "fromDate": "1730-01-01" }` | `fromDate and toDate require placeId.` |
+
+### Part D — Not authenticated (optional)
+
+Wipe the session, then call Part A again:
+
+```bash
+rm -f ~/.familysearch-mcp/tokens.json
+```
+
+Expected: an error with `isError: true` directing Claude to call
+`login`. Re-run `login` afterward to restore the session.
+
+### What success looks like (Layer 1)
+
+- Tool shows up in the Inspector.
+- Both query modes return structured data.
+- Validation errors are clear and make no network call.
+
+### When to move on
+
+Move to Layer 2 when both happy paths and the validation checks pass.
+
+---
+
+## Layer 2: Claude Code as Client
+
+**What this tests:** Does Claude understand when and how to use the tool
+from natural language, and does it pass `placeId` (not `placeRepId`)?
+
+> **Note:** Run this from a scratch directory, **not** from inside the
+> dev repo. Inside the repo, Claude tends to shortcut to the
+> `dev/try-image-search.ts` script via Bash instead of going through the
+> MCP, which defeats the point of this layer.
+
+### Steps
+
+1. Register the local build (one-time):
+
+   ```bash
+   claude mcp add --transport stdio genealogy-dev -- node /path/to/cowork-genealogy/mcp-server/build/index.js
+   ```
+
+2. Start a fresh session in a scratch folder:
+
+   ```bash
+   mkdir -p ~/mcp-test-scratch && cd ~/mcp-test-scratch && claude
+   ```
+
+3. Type `/mcp` to confirm `genealogy-dev` is connected.
+
+4. Make sure you have a valid session. If needed:
+
+   > "Log me in to FamilySearch. My client ID is YOUR-KEY."
+
+5. Test the place + date workflow:
+
+   > "What image groups (digitized volumes) cover Edensor, Derbyshire between 1730 and 1810?"
+
+   Claude should call `place_search` to resolve Edensor → `placeId
+   6137147`, then call `image_search` with that `placeId` and the date
+   range — **not** a `placeRepId`.
+
+6. Test the image group number workflow:
+
+   > "Look up image group number 007621224."
+
+   Claude should call `image_search` with `imageGroupNumber: "007621224"`
+   directly, with no `place_search` first.
+
+### What success looks like
+
+Claude picks the right tool, passes a `placeId` (not a `placeRepId`),
+and presents the image groups clearly (group number, record type, date
+range).
+
+### What failure looks like
+
+- Claude doesn't use `image_search` → the description doesn't match the
+  user's natural language.
+- Claude passes a `placeRepId` where a `placeId` is expected → the
+  schema description should clarify the difference.
+- Claude calls the tool but gets an auth error and doesn't recover →
+  the auth error message should tell Claude to call `login`.
+
+### Troubleshooting
+
+If you change the server code:
+
+1. Rebuild: `cd mcp-server && npm run build`
+2. In Claude Code, type `/mcp` to reconnect.
+3. Try again.
+
+### When to move on
+
+Move to Layer 3 when Claude successfully uses the tool from natural
+language in both modes.
+
+---
+
+## Layer 3: Cowork
+
+Layers 3a (WSL2) and 3b (Native Windows) follow the same pattern as the
+other tool guides — see
+[place-collections-tool-testing-guide.md](./place-collections-tool-testing-guide.md)
+§ "Layer 3a/3b" for the Claude Desktop config and restart steps. Use
+these prompts in a Cowork session once the server is wired up:
+
+> "What image groups cover Edensor, Derbyshire between 1730 and 1810?"
+
+> "Look up image group number 007621224."
+
+Verify the same results as Layer 2, running through the full Cowork →
+Claude Desktop → MCP server pipeline.
+
+---
+
+## Quick Reference: Commands
+
+| What | Command |
+|------|---------|
+| Build server | `cd mcp-server && npm run build` |
+| Run tests | `cd mcp-server && npm test` |
+| Smoke test (place + date) | `npx tsx dev/try-image-search.ts --placeId 6137147 --from 1730-01-01 --to 1810-12-31` |
+| Smoke test (image group no.) | `npx tsx dev/try-image-search.ts --imageGroupNumber "007621224"` |
+| Run Inspector | `cd mcp-server && npx @modelcontextprotocol/inspector node build/index.js` |
+| Wipe session (Linux/WSL) | `rm -f ~/.familysearch-mcp/tokens.json` |
+| Wipe session (PowerShell) | `Remove-Item $env:USERPROFILE\.familysearch-mcp\tokens.json` |
+| Reconnect in Claude Code | `/mcp` |
+
+---
+
+## Summary: What Each Layer Catches
+
+| Layer | What it tests | Bugs it catches |
+|-------|---------------|-----------------|
+| 0 - Smoke test | Direct function call vs live API | API shape mismatches, forward/reverse placeId conversion, WAF blocks |
+| 1 - Inspector | Tool through MCP protocol | Schema errors, serialization bugs, validation gaps, auth propagation |
+| 2 - Claude Code | LLM tool selection + presentation | Bad descriptions, `placeId`/`placeRepId` confusion |
+| 3 - Cowork | Full pipeline | Bridge + token path + cross-platform issues |
+
+**Don't skip layers.** Each one catches bugs the others miss.

--- a/docs/testing-guides/image-search-tool-testing-guide.md
+++ b/docs/testing-guides/image-search-tool-testing-guide.md
@@ -131,7 +131,7 @@ npx @modelcontextprotocol/inspector node build/index.js
 ```
 
 Open the printed URL, click **Connect**, then **List Tools**. You should
-see **`image_search`** in the list (the last of 26 tools). If it's
+see **`image_search`** in the list (the last of 27 tools). If it's
 missing, check that `src/index.ts` imports and dispatches it and that
 `imageSearchSchema` is in `src/tool-schemas.ts`.
 

--- a/mcp-server/dev/try-image-search.ts
+++ b/mcp-server/dev/try-image-search.ts
@@ -1,0 +1,34 @@
+/**
+ * Smoke-test the image_search tool against the live FS RMS API.
+ *
+ * Usage:
+ *   npx tsx dev/try-image-search.ts --placeId 6137147 --from 1730-01-01 --to 1810-12-31
+ *   npx tsx dev/try-image-search.ts --imageGroupNumber "007621224"
+ */
+import { imageSearchTool } from "../src/tools/image-search.js";
+
+function flag(name: string): string | undefined {
+  const i = process.argv.indexOf(name);
+  return i >= 0 ? process.argv[i + 1] : undefined;
+}
+
+const placeId = flag("--placeId");
+const fromDate = flag("--from");
+const toDate = flag("--to");
+const imageGroupNumber = flag("--imageGroupNumber");
+
+if (!placeId && !imageGroupNumber) {
+  console.error(
+    "Usage: npx tsx dev/try-image-search.ts --placeId <id> [--from YYYY-MM-DD] [--to YYYY-MM-DD]"
+  );
+  console.error('   or: npx tsx dev/try-image-search.ts --imageGroupNumber "007621224"');
+  process.exit(1);
+}
+
+const result = await imageSearchTool({
+  ...(placeId ? { placeId } : {}),
+  ...(fromDate ? { fromDate } : {}),
+  ...(toDate ? { toDate } : {}),
+  ...(imageGroupNumber ? { imageGroupNumber } : {}),
+});
+console.log(JSON.stringify(result, null, 2));

--- a/mcp-server/manifest.json
+++ b/mcp-server/manifest.json
@@ -50,7 +50,8 @@
     { "name": "wiki_country_online_records" },
     { "name": "wiki_country_research_tips" },
     { "name": "validate_research_schema" },
-    { "name": "source_attachments" }
+    { "name": "source_attachments" },
+    { "name": "image_search" }
   ],
   "compatibility": {
     "platforms": ["darwin", "win32", "linux"],

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -43,6 +43,8 @@ import {
 import type { MatchByIdInput } from "./types/match-by-id.js";
 import { sourceAttachmentsTool } from "./tools/source-attachments.js";
 import type { SourceAttachmentsInput } from "./types/source-attachments.js";
+import { imageSearchTool } from "./tools/image-search.js";
+import type { ImageSearchInput } from "./types/image-search.js";
 import { allToolSchemas } from "./tool-schemas.js";
 
 const server = new Server(
@@ -412,6 +414,16 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
     try {
       const args = request.params.arguments as unknown as SourceAttachmentsInput;
       const result = await sourceAttachmentsTool(args);
+      return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Unknown error";
+      return { content: [{ type: "text", text: JSON.stringify({ error: message }) }], isError: true };
+    }
+  }
+  if (request.params.name === "image_search") {
+    try {
+      const args = request.params.arguments as unknown as ImageSearchInput;
+      const result = await imageSearchTool(args);
       return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
     } catch (error) {
       const message = error instanceof Error ? error.message : "Unknown error";

--- a/mcp-server/src/tool-schemas.ts
+++ b/mcp-server/src/tool-schemas.ts
@@ -34,6 +34,7 @@ import {
 } from "./tools/wiki-country-page.js";
 import { validateResearchSchemaSchema } from "./tools/validate-research-schema.js";
 import { sourceAttachmentsSchema } from "./tools/source-attachments.js";
+import { imageSearchSchema } from "./tools/image-search.js";
 
 export const allToolSchemas = [
   wikipediaSearchSchema,
@@ -62,4 +63,5 @@ export const allToolSchemas = [
   wikiCountryResearchTipsSchema,
   validateResearchSchemaSchema,
   sourceAttachmentsSchema,
+  imageSearchSchema,
 ];

--- a/mcp-server/src/tools/image-search.ts
+++ b/mcp-server/src/tools/image-search.ts
@@ -1,0 +1,311 @@
+import { getValidToken } from "../auth/refresh.js";
+import { BROWSER_USER_AGENT } from "../constants.js";
+import { extractPrimaryId } from "./place-search.js";
+import type {
+  ImageSearchInput,
+  ImageSearchResult,
+  ImageGroup,
+  SimplifiedCoverage,
+  FSPlaceLookupResponse,
+  RmsSearchRequest,
+  RmsSearchResponse,
+  RmsGroup,
+  RmsCoverageEntry,
+} from "../types/image-search.js";
+
+const PLACES_API_BASE = "https://api.familysearch.org/platform/places";
+const RMS_SEARCH_URL =
+  "https://sg30p0.familysearch.org/service/records/rms/group-service/group/search";
+
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+/**
+ * Convert a placeId to its placeRepIds via the places API.
+ *
+ * GET /places/{placeId} returns the bare place entry (id === placeId, no
+ * `display`) followed by representation entries, each with a top-level
+ * `place.resourceId` pointing back to the placeId. We collect the
+ * representation ids.
+ */
+export async function placeIdToRepIds(
+  placeId: string,
+  token: string
+): Promise<number[]> {
+  const response = await fetch(`${PLACES_API_BASE}/${encodeURIComponent(placeId)}`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: "application/json",
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `FamilySearch places API error: ${response.status} ${response.statusText}`
+    );
+  }
+
+  const data = (await response.json()) as FSPlaceLookupResponse;
+  const reps = (data.places ?? []).filter(
+    (p) => p.place?.resourceId === placeId
+  );
+
+  const ids: number[] = [];
+  const seen = new Set<number>();
+  for (const rep of reps) {
+    const n = Number(rep.id);
+    if (!Number.isNaN(n) && !seen.has(n)) {
+      seen.add(n);
+      ids.push(n);
+    }
+  }
+  return ids;
+}
+
+/**
+ * Convert a placeRepId back to a placeId via the places description API.
+ *
+ * GET /places/description/{placeRepId} returns the representation with its
+ * `Primary` identifier, whose last path segment is the placeId. Returns null
+ * if the placeId cannot be resolved.
+ */
+export async function repIdToPlaceId(
+  placeRepId: number,
+  token: string
+): Promise<string | null> {
+  const response = await fetch(
+    `${PLACES_API_BASE}/description/${placeRepId}`,
+    {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: "application/json",
+      },
+    }
+  );
+
+  if (!response.ok) {
+    return null;
+  }
+
+  const data = (await response.json()) as FSPlaceLookupResponse;
+  const entry =
+    data.places?.find(
+      (p) => p.identifiers?.["http://gedcomx.org/Primary"] != null
+    ) ?? data.places?.find((p) => p.display != null);
+
+  return extractPrimaryId(entry?.identifiers) ?? null;
+}
+
+function validate(input: ImageSearchInput): void {
+  const { placeId, imageGroupNumber, fromDate, toDate } = input;
+
+  if (!placeId && !imageGroupNumber) {
+    throw new Error(
+      "image_search requires either placeId or imageGroupNumber."
+    );
+  }
+  if (placeId && imageGroupNumber) {
+    throw new Error("Provide either placeId or imageGroupNumber, not both.");
+  }
+  if ((fromDate || toDate) && !placeId) {
+    throw new Error("fromDate and toDate require placeId.");
+  }
+  if (fromDate && !DATE_RE.test(fromDate)) {
+    throw new Error(
+      "fromDate must be in YYYY-MM-DD format (e.g., '1730-01-01')."
+    );
+  }
+  if (toDate && !DATE_RE.test(toDate)) {
+    throw new Error(
+      "toDate must be in YYYY-MM-DD format (e.g., '1810-12-31')."
+    );
+  }
+}
+
+async function buildRequestBody(
+  input: ImageSearchInput,
+  token: string
+): Promise<RmsSearchRequest> {
+  const base = {
+    types: ["NATURAL"],
+    returnChildCounts: false,
+    active: true,
+  };
+
+  if (input.imageGroupNumber) {
+    return { ...base, name: `${input.imageGroupNumber}*` };
+  }
+
+  const placeRepIds = await placeIdToRepIds(input.placeId!, token);
+  if (placeRepIds.length === 0) {
+    throw new Error(
+      `No place representations found for placeId ${input.placeId}.`
+    );
+  }
+
+  return {
+    ...base,
+    coverage: {
+      placeRepIds,
+      ...(input.fromDate ? { fromDateString: input.fromDate } : {}),
+      ...(input.toDate ? { toDateString: input.toDate } : {}),
+    },
+  };
+}
+
+async function callRms(
+  body: RmsSearchRequest,
+  token: string
+): Promise<RmsSearchResponse> {
+  let response: Response;
+  try {
+    response = await fetch(RMS_SEARCH_URL, {
+      method: "PUT",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+        "User-Agent": BROWSER_USER_AGENT,
+        "FS-User-Agent-Chain": "chesworth",
+      },
+      body: JSON.stringify(body),
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unknown error";
+    throw new Error(
+      `Could not reach FamilySearch image search API: ${message}.`
+    );
+  }
+
+  if (response.status === 401) {
+    throw new Error(
+      "FamilySearch session not accepted; call the login tool to re-authenticate."
+    );
+  }
+  if (response.status === 403) {
+    throw new Error("FamilySearch image search API error: 403 Forbidden.");
+  }
+  if (!response.ok) {
+    throw new Error(
+      `FamilySearch image search API error: ${response.status} ${response.statusText}.`
+    );
+  }
+
+  return (await response.json()) as RmsSearchResponse;
+}
+
+async function mapCoverage(
+  coverage: RmsCoverageEntry,
+  token: string,
+  cache: Map<number, string | null>
+): Promise<SimplifiedCoverage> {
+  let placeId = "";
+  if (coverage.placeRepId != null) {
+    if (!cache.has(coverage.placeRepId)) {
+      cache.set(coverage.placeRepId, await repIdToPlaceId(coverage.placeRepId, token));
+    }
+    placeId = cache.get(coverage.placeRepId) ?? "";
+  }
+
+  return {
+    place: coverage.place ?? "",
+    placeId,
+    ...(coverage.datesOrig != null ? { dateRange: coverage.datesOrig } : {}),
+    ...(coverage.recordTypeOrig != null
+      ? { recordType: coverage.recordTypeOrig }
+      : {}),
+    placeRelevance: coverage.placeRelevance ?? 0,
+  };
+}
+
+async function mapGroup(
+  group: RmsGroup,
+  token: string,
+  cache: Map<number, string | null>
+): Promise<ImageGroup> {
+  const coverages = await Promise.all(
+    (group.coverages ?? []).map((c) => mapCoverage(c, token, cache))
+  );
+
+  return {
+    id: group.id,
+    imageGroupNumber: group.groupName,
+    ...(group.title != null ? { title: group.title } : {}),
+    types: group.types ?? [],
+    creators: group.creators ?? [],
+    languages: group.languages ?? [],
+    ...(group.custodians != null ? { custodians: group.custodians } : {}),
+    ...(group.volumes != null ? { volumes: group.volumes } : {}),
+    coverages,
+  };
+}
+
+export async function imageSearchTool(
+  input: ImageSearchInput
+): Promise<ImageSearchResult> {
+  validate(input);
+
+  const token = await getValidToken();
+  const body = await buildRequestBody(input, token);
+  const response = await callRms(body, token);
+
+  const groups = response.groups ?? [];
+  const cache = new Map<number, string | null>();
+  const mapped = await Promise.all(
+    groups.map((g) => mapGroup(g, token, cache))
+  );
+
+  return {
+    query: {
+      ...(input.placeId ? { placeId: input.placeId } : {}),
+      ...(input.fromDate ? { fromDate: input.fromDate } : {}),
+      ...(input.toDate ? { toDate: input.toDate } : {}),
+      ...(input.imageGroupNumber
+        ? { imageGroupNumber: input.imageGroupNumber }
+        : {}),
+    },
+    totalGroups: response.totalCount ?? 0,
+    returned: response.numberReturned ?? 0,
+    groups: mapped,
+  };
+}
+
+export const imageSearchSchema = {
+  name: "image_search",
+  description:
+    "Search FamilySearch's Records Management Service for image groups — " +
+    "digitized volumes of historical documents (microfilm rolls, book scans). " +
+    "Two query modes: (1) search by place + date range using a placeId from " +
+    "place_search, or (2) look up a specific volume by image group number. " +
+    "Returns image group metadata including coverage (places, dates, record " +
+    "types) and creators. Use the results with image_read to view individual " +
+    "images from a group. " +
+    "Requires authentication — call the login tool first if not logged in.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      placeId: {
+        type: "string",
+        description:
+          "FamilySearch place ID from place_search. The tool internally " +
+          "converts this to place representation IDs for the RMS query.",
+      },
+      fromDate: {
+        type: "string",
+        description:
+          "Start of date range in YYYY-MM-DD format (e.g., '1730-01-01'). " +
+          "Only used with placeId.",
+      },
+      toDate: {
+        type: "string",
+        description:
+          "End of date range in YYYY-MM-DD format (e.g., '1810-12-31'). " +
+          "Only used with placeId.",
+      },
+      imageGroupNumber: {
+        type: "string",
+        description:
+          "Image group number (e.g., '007621224'). Image group numbers " +
+          "come from catalog search results.",
+      },
+    },
+  },
+};

--- a/mcp-server/src/tools/place-search.ts
+++ b/mcp-server/src/tools/place-search.ts
@@ -35,7 +35,7 @@ interface GetPlaceResult extends SearchPlaceResult {
  * is the last path segment. Returns undefined if the Primary identifier
  * is missing or malformed.
  */
-function extractPrimaryId(
+export function extractPrimaryId(
   identifiers: Record<string, string[]> | undefined
 ): string | undefined {
   const url = identifiers?.[FS_PRIMARY_IDENTIFIER_KEY]?.[0];

--- a/mcp-server/src/types/image-search.ts
+++ b/mcp-server/src/types/image-search.ts
@@ -1,0 +1,106 @@
+// Types for the image_search tool.
+//
+// Searches FamilySearch's Records Management Service (RMS) for image groups
+// (digitized volumes). Two query modes: place + date range, or image group
+// number. See docs/specs/image-search-tool-spec.md.
+
+// ---------- Tool input ----------
+
+export interface ImageSearchInput {
+  placeId?: string;
+  fromDate?: string;
+  toDate?: string;
+  imageGroupNumber?: string;
+}
+
+// ---------- Places API lookup (placeId <-> placeRepId conversion) ----------
+
+// GET https://api.familysearch.org/platform/places/{placeId} returns a list
+// where the bare place entry (id === placeId, no `display`) is followed by its
+// representation entries. Each representation has a top-level `place` pointing
+// back to the parent placeId and a `Primary` identifier.
+export interface FSPlaceLookupEntry {
+  id: string;
+  display?: { name: string; fullName: string; type: string };
+  place?: { resource?: string; resourceId?: string };
+  identifiers?: Record<string, string[]>;
+}
+
+export interface FSPlaceLookupResponse {
+  places?: FSPlaceLookupEntry[];
+}
+
+// ---------- RMS request ----------
+
+export interface RmsCoverageRequest {
+  placeRepIds: number[];
+  fromDateString?: string;
+  toDateString?: string;
+}
+
+export interface RmsSearchRequest {
+  coverage?: RmsCoverageRequest;
+  name?: string;
+  types: string[];
+  returnChildCounts: boolean;
+  active: boolean;
+}
+
+// ---------- RMS response ----------
+
+export interface RmsCoverageEntry {
+  place?: string;
+  placeRepId?: number;
+  datesOrig?: string;
+  recordTypeOrig?: string;
+  placeRelevance?: number;
+}
+
+export interface RmsGroup {
+  id: string;
+  groupName: string;
+  active?: boolean;
+  types?: string[];
+  coverages?: RmsCoverageEntry[];
+  creators?: string[];
+  languages?: string[];
+  title?: string;
+  volumes?: string[];
+  custodians?: string[];
+}
+
+export interface RmsSearchResponse {
+  groups?: RmsGroup[];
+  numberReturned?: number;
+  totalCount?: number;
+  nextPageToken?: string;
+}
+
+// ---------- Tool output ----------
+
+export interface SimplifiedCoverage {
+  place: string;
+  placeId: string;
+  dateRange?: string;
+  recordType?: string;
+  placeRelevance: number;
+}
+
+export interface ImageGroup {
+  id: string;
+  imageGroupNumber: string;
+  title?: string;
+  types: string[];
+  creators: string[];
+  languages: string[];
+  custodians?: string[];
+  volumes?: string[];
+  coverages: SimplifiedCoverage[];
+}
+
+export interface ImageSearchResult {
+  query: ImageSearchInput;
+  totalGroups: number;
+  returned: number;
+  groups: ImageGroup[];
+}

--- a/mcp-server/tests/tools/image-search.test.ts
+++ b/mcp-server/tests/tools/image-search.test.ts
@@ -1,0 +1,432 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("../../src/auth/refresh.js", () => ({
+  getValidToken: vi.fn(),
+}));
+
+import { imageSearchTool } from "../../src/tools/image-search.js";
+import { getValidToken } from "../../src/auth/refresh.js";
+import { BROWSER_USER_AGENT } from "../../src/constants.js";
+import type {
+  FSPlaceLookupResponse,
+  RmsSearchResponse,
+  RmsGroup,
+} from "../../src/types/image-search.js";
+
+const mockedGetValidToken = vi.mocked(getValidToken);
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+// ---------- fixtures ----------
+
+// Shape of GET /places/{placeId}: bare place entry (no display) followed by
+// representations whose top-level `place.resourceId` points back to the placeId.
+function forwardPlacesResponse(
+  placeId: string,
+  repIds: string[]
+): FSPlaceLookupResponse {
+  return {
+    places: [
+      { id: placeId, names: [{ lang: "en", value: "Edensor" }] } as never,
+      ...repIds.map((id) => ({
+        id,
+        place: {
+          resource: `https://api.familysearch.org/platform/places/${placeId}`,
+          resourceId: placeId,
+        },
+        identifiers: {
+          "http://gedcomx.org/Primary": [
+            `https://api.familysearch.org/platform/places/${placeId}`,
+          ],
+        },
+        display: { name: "Edensor", fullName: "Edensor, Derbyshire", type: "Village" },
+      })),
+    ],
+  };
+}
+
+// Shape of GET /places/description/{repId}: the representation with its Primary
+// identifier resolving to the placeId.
+function descriptionResponse(repId: string, placeId: string): FSPlaceLookupResponse {
+  return {
+    places: [
+      {
+        id: repId,
+        identifiers: {
+          "http://gedcomx.org/Primary": [
+            `https://api.familysearch.org/platform/places/${placeId}`,
+          ],
+        },
+        display: { name: "Edensor", fullName: "Edensor, Derbyshire", type: "Village" },
+      },
+    ],
+  };
+}
+
+const sampleGroup: RmsGroup = {
+  id: "DGS-004452257",
+  groupName: "004452257",
+  active: true,
+  types: ["NATURAL", "DGS"],
+  creators: ["Church of England. Parish Church of Edensor (Derbyshire)"],
+  languages: ["en", "la"],
+  coverages: [
+    {
+      place: "Edensor, Derbyshire, England, United Kingdom",
+      placeRepId: 2968392,
+      datesOrig: "1726–1812",
+      recordTypeOrig: "Burial Records",
+      placeRelevance: 94,
+    },
+  ],
+};
+
+// Routes mock fetch by URL so place mode (forward lookup + RMS + reverse
+// lookups) works in one configuration.
+function routeFetch(opts: {
+  reps?: string[]; // placeRepIds returned by the forward lookup
+  placeId?: string;
+  rms?: RmsSearchResponse | { status: number; statusText?: string };
+  rmsReject?: Error;
+  repToPlaceId?: Record<string, string>;
+}) {
+  mockFetch.mockImplementation((url: string, init?: RequestInit) => {
+    if (url.includes("/places/description/")) {
+      const repId = url.split("/places/description/")[1].split("?")[0];
+      const placeId = opts.repToPlaceId?.[repId];
+      if (placeId == null) {
+        return Promise.resolve({ ok: false, status: 404, statusText: "Not Found" });
+      }
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        json: async () => descriptionResponse(repId, placeId),
+      });
+    }
+    if (url.includes("/group/search")) {
+      if (opts.rmsReject) return Promise.reject(opts.rmsReject);
+      const rms = opts.rms;
+      if (rms && "status" in rms) {
+        return Promise.resolve({
+          ok: false,
+          status: rms.status,
+          statusText: rms.statusText ?? "Error",
+        });
+      }
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        json: async () => rms ?? { groups: [], numberReturned: 0, totalCount: 0 },
+      });
+    }
+    // forward /places/{placeId}
+    return Promise.resolve({
+      ok: true,
+      status: 200,
+      json: async () =>
+        forwardPlacesResponse(opts.placeId ?? "6137147", opts.reps ?? []),
+    });
+  });
+}
+
+beforeEach(() => {
+  mockFetch.mockReset();
+  mockedGetValidToken.mockReset();
+  mockedGetValidToken.mockResolvedValue("test-token");
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("imageSearchTool — happy paths", () => {
+  it("returns groups for placeId + date range query", async () => {
+    routeFetch({
+      placeId: "6137147",
+      reps: ["2968392", "10609408"],
+      rms: { groups: [sampleGroup], numberReturned: 1, totalCount: 1 },
+      repToPlaceId: { "2968392": "6137147" },
+    });
+
+    const result = await imageSearchTool({
+      placeId: "6137147",
+      fromDate: "1730-01-01",
+      toDate: "1810-12-31",
+    });
+
+    expect(result.totalGroups).toBe(1);
+    expect(result.returned).toBe(1);
+    expect(result.groups[0].imageGroupNumber).toBe("004452257");
+    expect(result.query).toEqual({
+      placeId: "6137147",
+      fromDate: "1730-01-01",
+      toDate: "1810-12-31",
+    });
+  });
+
+  it("returns groups for image group number query", async () => {
+    routeFetch({ rms: { groups: [sampleGroup], numberReturned: 1, totalCount: 1 } });
+
+    const result = await imageSearchTool({ imageGroupNumber: "004452257" });
+
+    expect(result.totalGroups).toBe(1);
+    expect(result.groups[0].id).toBe("DGS-004452257");
+    expect(result.query).toEqual({ imageGroupNumber: "004452257" });
+  });
+});
+
+describe("imageSearchTool — input validation", () => {
+  it("throws when neither placeId nor imageGroupNumber provided", async () => {
+    await expect(imageSearchTool({})).rejects.toThrow(
+      "image_search requires either placeId or imageGroupNumber."
+    );
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("throws when both placeId and imageGroupNumber provided", async () => {
+    await expect(
+      imageSearchTool({ placeId: "6137147", imageGroupNumber: "004452257" })
+    ).rejects.toThrow("Provide either placeId or imageGroupNumber, not both.");
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("throws when fromDate is invalid format", async () => {
+    await expect(
+      imageSearchTool({ placeId: "6137147", fromDate: "1730" })
+    ).rejects.toThrow("fromDate must be in YYYY-MM-DD format");
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("throws when fromDate/toDate provided without placeId", async () => {
+    await expect(
+      imageSearchTool({ imageGroupNumber: "004452257", fromDate: "1730-01-01" })
+    ).rejects.toThrow("fromDate and toDate require placeId.");
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("throws when places API returns no placeRepIds", async () => {
+    routeFetch({ placeId: "6137147", reps: [] });
+    await expect(imageSearchTool({ placeId: "6137147" })).rejects.toThrow(
+      "No place representations found for placeId 6137147."
+    );
+  });
+});
+
+describe("imageSearchTool — placeId conversion", () => {
+  it("converts placeId to placeRepIds via the places API", async () => {
+    routeFetch({
+      placeId: "6137147",
+      reps: ["2968392", "10609408"],
+      rms: { groups: [], numberReturned: 0, totalCount: 0 },
+    });
+
+    await imageSearchTool({ placeId: "6137147" });
+
+    const forwardCall = mockFetch.mock.calls.find(
+      (c) => (c[0] as string).endsWith("/platform/places/6137147")
+    );
+    expect(forwardCall).toBeDefined();
+  });
+
+  it("passes all placeRepIds in a single RMS call via coverage.placeRepIds", async () => {
+    routeFetch({
+      placeId: "6137147",
+      reps: ["2968392", "10609408"],
+      rms: { groups: [], numberReturned: 0, totalCount: 0 },
+    });
+
+    await imageSearchTool({
+      placeId: "6137147",
+      fromDate: "1730-01-01",
+      toDate: "1810-12-31",
+    });
+
+    const rmsCall = mockFetch.mock.calls.find((c) =>
+      (c[0] as string).includes("/group/search")
+    );
+    const body = JSON.parse((rmsCall![1] as RequestInit).body as string);
+    expect(body.coverage.placeRepIds).toEqual([2968392, 10609408]);
+    expect(body.coverage.fromDateString).toBe("1730-01-01");
+    expect(body.coverage.toDateString).toBe("1810-12-31");
+    expect(body.types).toEqual(["NATURAL"]);
+    expect(body.returnChildCounts).toBe(false);
+    expect(body.active).toBe(true);
+    // single RMS call
+    const rmsCalls = mockFetch.mock.calls.filter((c) =>
+      (c[0] as string).includes("/group/search")
+    );
+    expect(rmsCalls).toHaveLength(1);
+  });
+});
+
+describe("imageSearchTool — request construction", () => {
+  it("builds correct request body for place mode", async () => {
+    routeFetch({
+      placeId: "6137147",
+      reps: ["2968392"],
+      rms: { groups: [], numberReturned: 0, totalCount: 0 },
+    });
+
+    await imageSearchTool({ placeId: "6137147" });
+
+    const rmsCall = mockFetch.mock.calls.find((c) =>
+      (c[0] as string).includes("/group/search")
+    );
+    const body = JSON.parse((rmsCall![1] as RequestInit).body as string);
+    expect(body).toEqual({
+      coverage: { placeRepIds: [2968392] },
+      types: ["NATURAL"],
+      returnChildCounts: false,
+      active: true,
+    });
+  });
+
+  it("builds correct request body for image group number mode (appends wildcard)", async () => {
+    routeFetch({ rms: { groups: [], numberReturned: 0, totalCount: 0 } });
+
+    await imageSearchTool({ imageGroupNumber: "007621224" });
+
+    const rmsCall = mockFetch.mock.calls.find((c) =>
+      (c[0] as string).includes("/group/search")
+    );
+    const body = JSON.parse((rmsCall![1] as RequestInit).body as string);
+    expect(body).toEqual({
+      name: "007621224*",
+      types: ["NATURAL"],
+      returnChildCounts: false,
+      active: true,
+    });
+  });
+});
+
+describe("imageSearchTool — response mapping", () => {
+  it("maps API response to simplified output", async () => {
+    routeFetch({
+      placeId: "6137147",
+      reps: ["2968392"],
+      rms: { groups: [sampleGroup], numberReturned: 1, totalCount: 1 },
+      repToPlaceId: { "2968392": "6137147" },
+    });
+
+    const result = await imageSearchTool({ placeId: "6137147" });
+
+    expect(result.groups[0]).toEqual({
+      id: "DGS-004452257",
+      imageGroupNumber: "004452257",
+      types: ["NATURAL", "DGS"],
+      creators: ["Church of England. Parish Church of Edensor (Derbyshire)"],
+      languages: ["en", "la"],
+      coverages: [
+        {
+          place: "Edensor, Derbyshire, England, United Kingdom",
+          placeId: "6137147",
+          dateRange: "1726–1812",
+          recordType: "Burial Records",
+          placeRelevance: 94,
+        },
+      ],
+    });
+  });
+
+  it("handles groups with multiple coverages", async () => {
+    const multi: RmsGroup = {
+      id: "DGS-1",
+      groupName: "1",
+      types: ["NATURAL"],
+      creators: [],
+      languages: ["en"],
+      coverages: [
+        { place: "A", placeRepId: 100, placeRelevance: 90 },
+        { place: "B", placeRepId: 200, placeRelevance: 80 },
+      ],
+    };
+    routeFetch({
+      placeId: "6137147",
+      reps: ["2968392"],
+      rms: { groups: [multi], numberReturned: 1, totalCount: 1 },
+      repToPlaceId: { "100": "111", "200": "222" },
+    });
+
+    const result = await imageSearchTool({ placeId: "6137147" });
+
+    expect(result.groups[0].coverages).toHaveLength(2);
+    expect(result.groups[0].coverages[0].placeId).toBe("111");
+    expect(result.groups[0].coverages[1].placeId).toBe("222");
+  });
+
+  it("converts placeRepId in coverage to placeId in output", async () => {
+    routeFetch({
+      placeId: "6137147",
+      reps: ["2968392"],
+      rms: { groups: [sampleGroup], numberReturned: 1, totalCount: 1 },
+      repToPlaceId: { "2968392": "6137147" },
+    });
+
+    const result = await imageSearchTool({ placeId: "6137147" });
+
+    expect(result.groups[0].coverages[0].placeId).toBe("6137147");
+    const reverseCall = mockFetch.mock.calls.find((c) =>
+      (c[0] as string).includes("/places/description/2968392")
+    );
+    expect(reverseCall).toBeDefined();
+  });
+
+  it("handles empty groups response", async () => {
+    // API returns {"totalCount": 0} with no groups/numberReturned keys.
+    routeFetch({ rms: { totalCount: 0 } });
+
+    const result = await imageSearchTool({ imageGroupNumber: "nope" });
+
+    expect(result.totalGroups).toBe(0);
+    expect(result.returned).toBe(0);
+    expect(result.groups).toEqual([]);
+  });
+});
+
+describe("imageSearchTool — error handling", () => {
+  it("throws auth error when not authenticated", async () => {
+    mockedGetValidToken.mockRejectedValueOnce(
+      new Error("User is not logged in to FamilySearch. Call the login tool to authenticate.")
+    );
+
+    await expect(imageSearchTool({ imageGroupNumber: "004452257" })).rejects.toThrow(
+      /not logged in/
+    );
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("throws on 401 with re-login guidance", async () => {
+    routeFetch({ rms: { status: 401, statusText: "Unauthorized" } });
+
+    await expect(imageSearchTool({ imageGroupNumber: "004452257" })).rejects.toThrow(
+      "FamilySearch session not accepted; call the login tool to re-authenticate."
+    );
+  });
+
+  it("throws on network error", async () => {
+    routeFetch({ rmsReject: new Error("ECONNREFUSED") });
+
+    await expect(imageSearchTool({ imageGroupNumber: "004452257" })).rejects.toThrow(
+      "Could not reach FamilySearch image search API: ECONNREFUSED."
+    );
+  });
+});
+
+describe("imageSearchTool — header contract", () => {
+  it("sends Authorization, Content-Type, User-Agent, FS-User-Agent-Chain on the RMS call", async () => {
+    routeFetch({ rms: { groups: [], numberReturned: 0, totalCount: 0 } });
+
+    await imageSearchTool({ imageGroupNumber: "004452257" });
+
+    const rmsCall = mockFetch.mock.calls.find((c) =>
+      (c[0] as string).includes("/group/search")
+    );
+    const init = rmsCall![1] as RequestInit;
+    const headers = init.headers as Record<string, string>;
+    expect(init.method).toBe("PUT");
+    expect(headers["Authorization"]).toBe("Bearer test-token");
+    expect(headers["Content-Type"]).toBe("application/json");
+    expect(headers["User-Agent"]).toBe(BROWSER_USER_AGENT);
+    expect(headers["FS-User-Agent-Chain"]).toBe("chesworth");
+  });
+});


### PR DESCRIPTION
## Summary
Implements the `image_search` MCP tool. The spec for it is reviewed separately in #211 — this PR is the implementation only, rebased on current `main` (picks up the `source_attachments` rename from #207).

- Searches FamilySearch's RMS for image groups (digitized volumes) via two modes: place + date range, or image group number.
- Handles bidirectional placeId<->placeRepId conversion internally (forward via `/places/{placeId}`, reverse via `/places/description/{placeRepId}`), so the LLM only ever deals in `placeId`.
- Wires the tool into `tool-schemas.ts`, `index.ts`, and `manifest.json`; exports `extractPrimaryId` from `place-search.ts` for reuse.
- Adds a layered testing guide matching the other tools.

## Implementation notes
- PUT request to RMS with the `FS-User-Agent-Chain: chesworth` header; always queries `types: ["NATURAL"]`.
- Handles the empty-result shape (`{"totalCount": 0}` with no `groups` key) gracefully.
- Coverage `placeRepId`s are reverse-resolved to `placeId`s with a per-request cache.
- **Spec correction surfaced during live probing:** `GET /places/{id}` treats the segment as a *placeId*, so passing a `placeRepId` there returns an unrelated place. The reverse lookup uses `/places/description/{placeRepId}` instead — verified against the live API.

## Test plan
- [x] 19 unit tests (`tests/tools/image-search.test.ts`) + manifest drift test pass; `tsc --noEmit` clean
- [x] Layer 0 smoke script — both modes against live API
- [x] Layer 1 MCP Inspector — both modes + input validation
- [x] Layer 2 Claude Code (natural language) — correct tool selection and `placeId` handling
- [x] Layer 3 — `.mcpb` builds, packed server boots advertising all 27 tools, Cowork round-trip via Claude Desktop verified end-to-end

Depends on #211 (spec).