### PR TITLE
eval/app: show scenario + fixture context when reviewing scores

### DIFF
--- a/docs/plan/eval-scoring-scenario-context.md
+++ b/docs/plan/eval-scoring-scenario-context.md
@@ -1,0 +1,199 @@
+# Implementation Plan: Scenario & Fixture Context for Score Review
+
+## Goal
+
+Give genealogists, while correcting LLM scores on
+`eval/app/app/results/[...id]`, the context they need to judge
+correctness:
+
+- **(A)** the **scenario** — what's been researched — rendered as the
+  desktop app's resolved cards (not README prose), and
+- **(B)** each tool call's **fixture result**, upgraded from a raw JSON
+  dump to the shared `JsonViewer`.
+
+Both read entirely from data already in the run-log **snapshot** — no
+new network/API calls.
+
+Senior genealogists reported that without understanding what has been
+researched (the scenario) they cannot tell whether the LLM's scores
+need correcting. README prose is insufficient; they need the resolved,
+structured view.
+
+## Surface decision (locked)
+
+The scoring page's third pane becomes **tabbed: `Trace` | `Scenario`**.
+Grades (pane 2) stay visible at all times; the reviewer flips the right
+pane between "what Claude did" and "what's been researched." The
+`Scenario` tab appears only when `entry.scenario` is set and its files
+are in the snapshot. Non-blocking, roomy, resizable via the existing
+`HSplit` — no overlay idiom added.
+
+Rationale: seniors consult the scenario *continuously while assigning
+each score*, not as a one-time peek. That rules out modal/drawer
+overlays (which block the grades pane). A tabbed pane is non-blocking,
+persistent, and fits the app's existing pane-based layout.
+
+## Reuse strategy (locked)
+
+Lift (copy) the relevant viewer code from the sibling
+`cowork-genealogy-ui` Electron app into `eval/app`; **do not share** a
+package. The two apps will evolve independently. Accepted consequence:
+`eval/app` owns a second renderer of the research schema, which can lag
+`docs/specs/schemas/research.schema.json` over time.
+
+---
+
+## Phase 0 — Fixtures upgrade (small, independent)
+
+In `TracePane` (`results/[...id]/page.tsx`), replace the raw
+`<Code block>{JSON.stringify(fixtureBody)}` inside the existing
+collapsed `<details>` with the shared `<JsonViewer data={fixtureBody} />`
+(the same component the Fixtures page uses), keeping it collapsed by
+default.
+
+> Note: `JsonViewer` today is pretty-printed JSON in a scroll area, not
+> an interactive collapsible tree. Using it makes the tool-call fixture
+> display consistent with the Fixtures page. A true expand/collapse tree
+> would be a future upgrade to `JsonViewer` itself (benefiting the
+> Fixtures page too) — out of scope; fixtures are lower priority.
+
+**Touches:** `results/[...id]/page.tsx` only.
+
+---
+
+## Phase 1 — Pane-tab scaffolding (surface, no viewer yet)
+
+1. In `results/[...id]/page.tsx`, wrap the third `HSplit` child in
+   Mantine `<Tabs>` with `Trace` (the existing `<TracePane>`) and
+   `Scenario` (placeholder for now). Show `Scenario` only when
+   `selectedEntry.scenario` is truthy. Default tab: `Trace`.
+2. Parse scenario data from the snapshot (new small helper, mirroring
+   `findFixtureResponse`):
+   ```ts
+   function findScenarioData(snapshot, scenarioName) {
+     const base = `eval/fixtures/scenarios/${scenarioName}`;
+     const research = tryParse(snapshot[`${base}/research.json`]);
+     const gedcomx  = tryParse(snapshot[`${base}/tree.gedcomx.json`]);
+     return research ? { research, gedcomx } : null;
+   }
+   ```
+   (Confirmed present in the snapshot:
+   `eval/fixtures/scenarios/<name>/{research.json,tree.gedcomx.json}`.)
+
+**Touches:** `results/[...id]/page.tsx`.
+
+---
+
+## Phase 2 — Lift the resolved-card viewer
+
+Lift from `cowork-genealogy-ui/src/renderer/src/` into a self-contained
+`eval/app/components/scenario/`, **preserving the internal directory
+layout** so the lifted files' relative imports (`../../contexts/...`,
+`../shared/...`, `../../lib/...`) resolve with near-zero edits:
+
+```
+eval/app/components/scenario/
+  ScenarioViewer.tsx          (new — entry point)
+  ScenarioDataProvider.tsx    (new — thin, replaces the Electron provider)
+  scenario-tokens.css         (new — design tokens, re-scoped)
+  contexts/ResearchDataContext.ts        (lift as-is)
+  lib/schema.ts                          (lift as-is)
+  lib/relationship-label.ts              (lift as-is)
+  components/shared/{Card,DetailPanel,StatusBadge,PersonCard}.tsx + .module.css   (lift as-is)
+  components/shared/CrossLink.tsx + .module.css            (adapt -> plain text)
+  components/sections/*.tsx + *.module.css                (lift; ResearchLog/Assertions/ProofSummaries adapted)
+```
+
+### Lift as-is (copy + their `.module.css`)
+`ResearchDataContext.ts`, `schema.ts`, `relationship-label.ts`, `Card`,
+`DetailPanel`, `StatusBadge`, `PersonCard`, and 8 of the 10 sections:
+`ProjectOverview`, `QuestionsSection`, `PlansSection`, `SourcesSection`,
+`PersonEvidenceSection`, `ConflictsSection`, `HypothesesSection`,
+`TimelinesSection`.
+
+### New: `ScenarioDataProvider` (the key unlock)
+The lifted sections consume everything via `useResearchData()`. Reuse
+the **same** `ResearchDataContext` but feed it from props instead of
+Electron IPC:
+
+```tsx
+export function ScenarioDataProvider({ research, gedcomx, children }) {
+  const [activeSection, setActiveSection] = useState('project_overview');
+  const index = useMemo(() => buildIndex(research, gedcomx), [research, gedcomx]);
+  const getById = useCallback(id => index.get(id) ?? null, [index]);
+  const value = { research, gedcomx, getById, activeSection, setActiveSection,
+                  devMode: false, sidecar: { status: 'closed' },
+                  /* unused-but-typed no-ops: openSidecar, closeSidecar,
+                     selectFolder, setDevMode, clearError, clearFocusPersona,
+                     error: null, lastUpdated: null, folderPath: null */ };
+  return <ResearchDataContext.Provider value={value}>{children}</ResearchDataContext.Provider>;
+}
+```
+No file-watchers, no `window.api`, no sidecar fetching.
+
+### New: `ScenarioViewer`
+Renders the sections **stacked in one vertical scroll** (no sidebar nav
+— simpler than the desktop app's one-section-at-a-time), inside a
+wrapper that scopes the design tokens.
+
+### Adaptations (small, surgical)
+- **`CrossLink.tsx`** -> render a non-interactive `<span>{label ?? id}</span>`.
+  Drops the navigation per decision, removes cross-pane scroll risk.
+  (Reversible: with the single-stack layout, real in-pane
+  `scrollIntoView` would work since cards carry `id={id}`.)
+- **`ResearchLogSection.tsx`** -> simplify to a plain table
+  (date / tool / outcome / result count / notes). **Drop** the
+  "view results" sidecar button (those `results/<id>.json` sidecars are
+  not in the snapshot) and the cross-links. Lets us drop
+  `lib/index-by-log-entry.ts`.
+- **`AssertionsSection.tsx`** -> remove the "View in record ->" button
+  (sidecar-only).
+- **`ProofSummariesSection.tsx`** -> swap `react-markdown` for the
+  existing `@/components/common/MarkdownViewer` (avoids a new dep).
+
+### Design tokens — scoped, not global
+Copy the `:root` token block from `cowork-genealogy-ui/.../styles/global.css`
+into `scenario-tokens.css`, **re-scoped** from `:root` to
+`.scenarioViewer { ... }`. CSS custom properties cascade, so every
+lifted `.module.css`'s `var(--bg-card)` resolves within the scenario
+subtree only — zero leakage into the Mantine chrome (and `globals.css`
+defines no `:root` tokens today). Ship the **light** palette for v1;
+dark mode deferred. Fonts (Cormorant/IBM Plex) fall back to the system
+stack in the token definitions.
+
+### Drop entirely (don't lift)
+`ResearchDataProvider.tsx` (Electron), `SidecarPanel`,
+`SidecarResultCard`, `Pill`, `FeedbackDialog`, `layout/*`, `lib/progress.ts`,
+`lib/index-by-log-entry.ts`, `useFileWatcher.ts`, `global.css` base resets.
+
+### Wire-up
+The `Scenario` tab renders `<ScenarioViewer research gedcomx />` from the
+parsed snapshot data. The page is already `'use client'`, so lifted
+client components need no per-file `'use client'` directive.
+
+---
+
+## Risks / caveats
+
+1. **Schema drift (accepted).** `schema.ts` is the desktop app's reading
+   of `research.json`; sections render defensively (optional chaining),
+   so drift degrades to blank fields, not crashes.
+2. **CSS isolation** is the main technical risk; mitigated by the
+   `.scenarioViewer` token scoping + CSS-Module local class names.
+3. **TS strictness** may differ; budget one `tsc`/lint pass (React 19
+   matches, so `React.JSX.Element` is fine).
+4. **Log results & cross-links intentionally absent** — by decision; not
+   a regression.
+
+## Testing
+- Unit: `findScenarioData` parses snapshot research/tree; `ScenarioViewer`
+  renders given a fixture scenario.
+- E2E: extend `tests/e2e/scoring-flow.spec.ts` to assert the `Scenario`
+  tab appears for a scenario-backed test and shows objective/person cards.
+- Manual: load a run log for a scenario-backed skill (e.g.
+  `question-selection`, scenario `mid-research-flynn`).
+
+## Sequencing
+Phase 0 (fixtures) and Phase 1 (pane tabs) first — small, low-risk.
+Phase 2 (viewer lift) is the bulk (~2,000 lines copied + ~4 adapted +
+2 new files).

--- a/eval/app/app/results/[...id]/page.tsx
+++ b/eval/app/app/results/[...id]/page.tsx
@@ -20,6 +20,7 @@ import {
   Modal,
   SegmentedControl,
   Stack,
+  Tabs,
   Text,
   Textarea,
   Title,
@@ -28,6 +29,9 @@ import {
 } from '@mantine/core';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { HSplit } from '@/components/layout/HSplit';
+import { JsonViewer } from '@/components/common/JsonViewer';
+import { ScenarioViewer } from '@/components/scenario/ScenarioViewer';
+import { findScenarioData } from '@/lib/scenarioSnapshot';
 import type {
   AnnotationCorrection,
   AnnotationFile,
@@ -614,11 +618,15 @@ const TracePane = memo(function TracePane({
                           <summary style={{ cursor: 'pointer', fontSize: 12, color: 'var(--mantine-color-dimmed)' }}>
                             fixture response (click to expand)
                           </summary>
-                          <Code block style={{ whiteSpace: 'pre-wrap', marginTop: 4, maxHeight: 400, overflow: 'auto' }}>
-                            {typeof fixtureBody === 'string'
-                              ? fixtureBody
-                              : JSON.stringify(fixtureBody, null, 2)}
-                          </Code>
+                          <Box mt={4}>
+                            {typeof fixtureBody === 'string' ? (
+                              <Code block style={{ whiteSpace: 'pre-wrap', maxHeight: 400, overflow: 'auto' }}>
+                                {fixtureBody}
+                              </Code>
+                            ) : (
+                              <JsonViewer data={fixtureBody} />
+                            )}
+                          </Box>
                         </details>
                       </Box>
                     ) : null}
@@ -654,6 +662,51 @@ const TracePane = memo(function TracePane({
     </Box>
   );
 });
+
+// The third pane: tabs the per-run Trace against the Scenario (what's
+// been researched). The Scenario tab appears only when the test references
+// a scenario whose files are in the snapshot. Genealogists need the
+// scenario to judge whether the LLM's scores are correct, but consult it
+// *alongside* scoring — hence a non-blocking tab, not a modal/drawer.
+function EvidencePane({
+  entry,
+  skill,
+  snapshot,
+}: {
+  entry: TestEntry;
+  skill: string;
+  snapshot: Record<string, string>;
+}) {
+  const scenarioData = useMemo(
+    () => (entry.scenario ? findScenarioData(snapshot, entry.scenario) : null),
+    [entry.scenario, snapshot],
+  );
+
+  return (
+    <Box h="100%" style={{ display: 'flex', flexDirection: 'column', minHeight: 0 }}>
+      <Tabs
+        defaultValue="trace"
+        keepMounted={false}
+        style={{ display: 'flex', flexDirection: 'column', flex: 1, minHeight: 0 }}
+      >
+        <Tabs.List>
+          <Tabs.Tab value="trace">Trace</Tabs.Tab>
+          {scenarioData ? <Tabs.Tab value="scenario">Scenario</Tabs.Tab> : null}
+        </Tabs.List>
+
+        <Tabs.Panel value="trace" style={{ flex: 1, minHeight: 0, overflow: 'auto' }}>
+          <TracePane entry={entry} skill={skill} snapshot={snapshot} />
+        </Tabs.Panel>
+
+        {scenarioData ? (
+          <Tabs.Panel value="scenario" style={{ flex: 1, minHeight: 0, overflow: 'auto' }}>
+            <ScenarioViewer research={scenarioData.research} gedcomx={scenarioData.gedcomx} />
+          </Tabs.Panel>
+        ) : null}
+      </Tabs>
+    </Box>
+  );
+}
 
 function TestsPane({
   tests,
@@ -1155,7 +1208,7 @@ export default function RunLogDetailPage({
             <Box p="md"><Text c="dimmed">no test selected</Text></Box>
           )}
           {selectedEntry ? (
-            <TracePane entry={selectedEntry} skill={log.skill} snapshot={log.snapshot} />
+            <EvidencePane entry={selectedEntry} skill={log.skill} snapshot={log.snapshot} />
           ) : (
             <Box p="md"><Text c="dimmed">no test selected</Text></Box>
           )}

--- a/eval/app/components/scenario/ScenarioDataProvider.tsx
+++ b/eval/app/components/scenario/ScenarioDataProvider.tsx
@@ -1,0 +1,63 @@
+import { useCallback, useMemo, useState } from 'react';
+import type { ReactNode } from 'react';
+import type { ResearchData, GedcomxData } from './lib/schema';
+import {
+  ResearchDataContext,
+  buildIndex,
+  type IndexEntry,
+  type ResearchDataState,
+} from './contexts/ResearchDataContext';
+
+/**
+ * A network-free, file-watcher-free stand-in for the desktop app's
+ * Electron `ResearchDataProvider`. The lifted section components consume
+ * everything through `useResearchData()`, so we feed the SAME context from
+ * plain props (parsed out of the run-log snapshot) instead of Electron IPC.
+ *
+ * Everything the scoring viewer doesn't need — sidecar fetching, folder
+ * selection, dev mode, file watching — is supplied as an inert no-op so the
+ * context value still satisfies `ResearchDataState`.
+ */
+export function ScenarioDataProvider({
+  research,
+  gedcomx,
+  children,
+}: {
+  research: ResearchData | null;
+  gedcomx: GedcomxData | null;
+  children: ReactNode;
+}): React.JSX.Element {
+  // Kept as local state so CrossLink's (now inert) setActiveSection contract
+  // still resolves; nothing in the read-only viewer drives navigation.
+  const [activeSection, setActiveSection] = useState('project_overview');
+
+  const index = useMemo(() => buildIndex(research, gedcomx), [research, gedcomx]);
+  const getById = useCallback(
+    (id: string): IndexEntry | null => index.get(id) ?? null,
+    [index],
+  );
+
+  const value: ResearchDataState = useMemo(
+    () => ({
+      research,
+      gedcomx,
+      error: null,
+      clearError: () => {},
+      lastUpdated: null,
+      folderPath: null,
+      devMode: false,
+      setDevMode: () => {},
+      getById,
+      selectFolder: async () => {},
+      activeSection,
+      setActiveSection,
+      sidecar: { status: 'closed' },
+      openSidecar: () => {},
+      closeSidecar: () => {},
+      clearFocusPersona: () => {},
+    }),
+    [research, gedcomx, getById, activeSection],
+  );
+
+  return <ResearchDataContext.Provider value={value}>{children}</ResearchDataContext.Provider>;
+}

--- a/eval/app/components/scenario/ScenarioViewer.tsx
+++ b/eval/app/components/scenario/ScenarioViewer.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import type { ResearchData, GedcomxData } from './lib/schema';
+import { ScenarioDataProvider } from './ScenarioDataProvider';
+import ProjectOverview from './components/sections/ProjectOverview';
+import QuestionsSection from './components/sections/QuestionsSection';
+import PlansSection from './components/sections/PlansSection';
+import ResearchLogSection from './components/sections/ResearchLogSection';
+import SourcesSection from './components/sections/SourcesSection';
+import AssertionsSection from './components/sections/AssertionsSection';
+import PersonEvidenceSection from './components/sections/PersonEvidenceSection';
+import ConflictsSection from './components/sections/ConflictsSection';
+import HypothesesSection from './components/sections/HypothesesSection';
+import TimelinesSection from './components/sections/TimelinesSection';
+import ProofSummariesSection from './components/sections/ProofSummariesSection';
+import tokenStyles from './scenario-tokens.module.css';
+
+/**
+ * Read-only research-project viewer for the score-review screen. Lifted from
+ * the cowork-genealogy-ui desktop app (see
+ * docs/plan/eval-scoring-scenario-context.md). Renders the whole project as
+ * one vertical stack of sections so a genealogist can see what has been
+ * researched while judging the LLM's scores.
+ *
+ * `research`/`gedcomx` come straight from the run-log snapshot as parsed JSON;
+ * we cast to the desktop app's schema types. Sections render defensively, so
+ * any schema drift degrades to blank fields rather than a crash.
+ */
+export function ScenarioViewer({
+  research,
+  gedcomx,
+}: {
+  research: Record<string, unknown> | null;
+  gedcomx: Record<string, unknown> | null;
+}): React.JSX.Element {
+  return (
+    <div className={tokenStyles.scenarioViewer} style={{ padding: 16 }}>
+      <ScenarioDataProvider
+        research={(research as unknown as ResearchData) ?? null}
+        gedcomx={(gedcomx as unknown as GedcomxData) ?? null}
+      >
+        <ProjectOverview />
+        <QuestionsSection />
+        <PlansSection />
+        <ResearchLogSection />
+        <SourcesSection />
+        <AssertionsSection />
+        <PersonEvidenceSection />
+        <ConflictsSection />
+        <HypothesesSection />
+        <TimelinesSection />
+        <ProofSummariesSection />
+      </ScenarioDataProvider>
+    </div>
+  );
+}

--- a/eval/app/components/scenario/components/sections/AssertionsSection.module.css
+++ b/eval/app/components/scenario/components/sections/AssertionsSection.module.css
@@ -1,0 +1,126 @@
+.section {
+  padding: var(--spacing-xl);
+}
+
+.sectionTitle {
+  font-size: 20px;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin-bottom: var(--spacing-lg);
+}
+
+.filters {
+  display: flex;
+  gap: var(--spacing-md);
+  margin-bottom: var(--spacing-lg);
+  flex-wrap: wrap;
+}
+
+.filterGroup {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+}
+
+.filterLabel {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-tertiary);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.filterSelect {
+  font-size: 13px;
+  padding: var(--spacing-xs) var(--spacing-sm);
+  border: 1px solid var(--border-color);
+  border-radius: var(--border-radius-sm);
+  background: var(--bg-card);
+  color: var(--text-primary);
+  cursor: pointer;
+}
+
+.filterSelect:focus {
+  outline: none;
+  border-color: var(--text-link);
+}
+
+.field {
+  margin-bottom: var(--spacing-md);
+}
+
+.field:last-child {
+  margin-bottom: 0;
+}
+
+.fieldLabel {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-tertiary);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  margin-bottom: var(--spacing-xs);
+}
+
+.fieldValue {
+  font-size: 13px;
+  color: var(--text-primary);
+}
+
+.structuredValue {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: var(--spacing-xs) var(--spacing-md);
+  font-size: 13px;
+}
+
+.structuredKey {
+  font-weight: 500;
+  color: var(--text-secondary);
+}
+
+.structuredVal {
+  color: var(--text-primary);
+}
+
+.footerLinks {
+  display: flex;
+  gap: var(--spacing-md);
+  flex-wrap: wrap;
+}
+
+.personaId {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  background: var(--bg-code);
+  padding: 1px 6px;
+  border-radius: var(--border-radius-sm);
+  color: var(--text-primary);
+}
+
+.personaLink {
+  background: none;
+  border: none;
+  padding: 0;
+  font-family: inherit;
+  font-size: 12px;
+  color: var(--accent-gold-strong);
+  cursor: pointer;
+  margin-left: var(--spacing-xs);
+}
+
+.personaLink:hover {
+  text-decoration: underline;
+}
+
+.empty {
+  font-size: 13px;
+  color: var(--text-tertiary);
+  font-style: italic;
+}
+
+.resultCount {
+  font-size: 12px;
+  color: var(--text-tertiary);
+  margin-bottom: var(--spacing-md);
+}

--- a/eval/app/components/scenario/components/sections/AssertionsSection.tsx
+++ b/eval/app/components/scenario/components/sections/AssertionsSection.tsx
@@ -1,0 +1,171 @@
+import { useState, useMemo } from 'react'
+import { useResearchData } from '../../contexts/ResearchDataContext'
+import Card from '../shared/Card'
+import StatusBadge from '../shared/StatusBadge'
+import CrossLink from '../shared/CrossLink'
+import type { Assertion } from '../../lib/schema'
+import styles from './AssertionsSection.module.css'
+
+function AssertionCard({ assertion }: { assertion: Assertion }): React.JSX.Element {
+  return (
+    <Card
+      id={assertion.id}
+      title={`${assertion.fact_type}: ${assertion.value}`}
+      badges={
+        <>
+          <StatusBadge value={assertion.information_quality} />
+          <StatusBadge value={assertion.evidence_type} />
+        </>
+      }
+      summary={`${assertion.informant} (${assertion.informant_proximity.replace(/_/g, ' ')})`}
+      footer={
+        <div className={styles.footerLinks}>
+          <CrossLink id={assertion.source_id} label={`Source: ${assertion.source_id}`} />
+          {assertion.log_entry_id && (
+            <CrossLink id={assertion.log_entry_id} label={`Log: ${assertion.log_entry_id}`} />
+          )}
+        </div>
+      }
+      rawData={assertion}
+    >
+      {assertion.date && (
+        <div className={styles.field}>
+          <div className={styles.fieldLabel}>Date</div>
+          <div className={styles.fieldValue}>
+            {assertion.date}
+            {assertion.date_certainty && ` (${assertion.date_certainty})`}
+          </div>
+        </div>
+      )}
+
+      {assertion.place && (
+        <div className={styles.field}>
+          <div className={styles.fieldLabel}>Place</div>
+          <div className={styles.fieldValue}>{assertion.place}</div>
+        </div>
+      )}
+
+      <div className={styles.field}>
+        <div className={styles.fieldLabel}>Record</div>
+        <div className={styles.fieldValue}>
+          {assertion.record_id} &middot; Role: {assertion.record_role}
+        </div>
+      </div>
+
+      {assertion.record_persona_id && (
+        <div className={styles.field}>
+          <div className={styles.fieldLabel}>Persona</div>
+          <div className={styles.fieldValue}>
+            <code className={styles.personaId}>{assertion.record_persona_id}</code>
+          </div>
+        </div>
+      )}
+
+      {assertion.structured_value && Object.keys(assertion.structured_value).length > 0 && (
+        <div className={styles.field}>
+          <div className={styles.fieldLabel}>Structured Value</div>
+          <div className={styles.structuredValue}>
+            {Object.entries(assertion.structured_value).map(([key, val]) => (
+              <div key={key} style={{ display: 'contents' }}>
+                <span className={styles.structuredKey}>{key}:</span>
+                <span className={styles.structuredVal}>{String(val)}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {assertion.informant_bias_notes && (
+        <div className={styles.field}>
+          <div className={styles.fieldLabel}>Informant Bias Notes</div>
+          <div className={styles.fieldValue}>{assertion.informant_bias_notes}</div>
+        </div>
+      )}
+    </Card>
+  )
+}
+
+export default function AssertionsSection(): React.JSX.Element {
+  const { research } = useResearchData()
+  const assertions = useMemo(() => research?.assertions ?? [], [research?.assertions])
+
+  const [factTypeFilter, setFactTypeFilter] = useState('all')
+  const [evidenceTypeFilter, setEvidenceTypeFilter] = useState('all')
+
+  const factTypes = useMemo(
+    () => Array.from(new Set(assertions.map((a) => a.fact_type))).sort(),
+    [assertions]
+  )
+
+  const evidenceTypes = useMemo(
+    () => Array.from(new Set(assertions.map((a) => a.evidence_type))).sort(),
+    [assertions]
+  )
+
+  const filtered = useMemo(
+    () =>
+      assertions.filter((a) => {
+        if (factTypeFilter !== 'all' && a.fact_type !== factTypeFilter) return false
+        if (evidenceTypeFilter !== 'all' && a.evidence_type !== evidenceTypeFilter) return false
+        return true
+      }),
+    [assertions, factTypeFilter, evidenceTypeFilter]
+  )
+
+  return (
+    <div className={styles.section}>
+      <h2 className={styles.sectionTitle}>Assertions</h2>
+
+      {assertions.length > 0 && (
+        <div className={styles.filters}>
+          <div className={styles.filterGroup}>
+            <label className={styles.filterLabel}>Fact Type</label>
+            <select
+              className={styles.filterSelect}
+              value={factTypeFilter}
+              onChange={(e) => setFactTypeFilter(e.target.value)}
+            >
+              <option value="all">All</option>
+              {factTypes.map((t) => (
+                <option key={t} value={t}>
+                  {t}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className={styles.filterGroup}>
+            <label className={styles.filterLabel}>Evidence Type</label>
+            <select
+              className={styles.filterSelect}
+              value={evidenceTypeFilter}
+              onChange={(e) => setEvidenceTypeFilter(e.target.value)}
+            >
+              <option value="all">All</option>
+              {evidenceTypes.map((t) => (
+                <option key={t} value={t}>
+                  {t}
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
+      )}
+
+      {assertions.length > 0 && (
+        <div className={styles.resultCount}>
+          Showing {filtered.length} of {assertions.length} assertions
+        </div>
+      )}
+
+      {filtered.length === 0 ? (
+        <p className={styles.empty}>
+          {assertions.length === 0
+            ? 'No assertions yet.'
+            : 'No assertions match the current filters.'}
+        </p>
+      ) : (
+        filtered.map((a) => <AssertionCard key={a.id} assertion={a} />)
+      )}
+    </div>
+  )
+}

--- a/eval/app/components/scenario/components/sections/ConflictsSection.module.css
+++ b/eval/app/components/scenario/components/sections/ConflictsSection.module.css
@@ -1,0 +1,99 @@
+.section {
+  padding: var(--spacing-xl);
+}
+
+.sectionTitle {
+  font-size: 20px;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin-bottom: var(--spacing-lg);
+}
+
+.empty {
+  font-size: 13px;
+  color: var(--text-tertiary);
+  font-style: italic;
+  padding: var(--spacing-md);
+  background: var(--bg-secondary);
+  border-radius: var(--border-radius);
+}
+
+.unresolved {
+  background: var(--conflict-unresolved-bg);
+  border-color: var(--conflict-unresolved-border);
+}
+
+.body {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-md);
+}
+
+.subsection {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+}
+
+.subLabel {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.assertionList {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+}
+
+.assertionItem {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  font-size: 13px;
+  color: var(--text-primary);
+  padding: var(--spacing-xs) var(--spacing-sm);
+  background: var(--bg-secondary);
+  border-radius: var(--border-radius-sm);
+}
+
+.assertionItem.preferred {
+  background: var(--badge-green-bg);
+  border-left: 3px solid var(--badge-green-text);
+}
+
+.assertionText {
+  flex: 1;
+}
+
+.preferredBadge {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--badge-green-text);
+  background: var(--badge-green-bg);
+  padding: 1px var(--spacing-xs);
+  border-radius: var(--border-radius-sm);
+}
+
+.analysis {
+  font-size: 13px;
+  color: var(--text-secondary);
+  line-height: 1.5;
+}
+
+.footer {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  flex-wrap: wrap;
+}
+
+.footerLabel {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-tertiary);
+}

--- a/eval/app/components/scenario/components/sections/ConflictsSection.tsx
+++ b/eval/app/components/scenario/components/sections/ConflictsSection.tsx
@@ -1,0 +1,107 @@
+import { useResearchData } from '../../contexts/ResearchDataContext'
+import type { Assertion } from '../../lib/schema'
+import Card from '../shared/Card'
+import StatusBadge from '../shared/StatusBadge'
+import CrossLink from '../shared/CrossLink'
+import styles from './ConflictsSection.module.css'
+
+export default function ConflictsSection(): React.JSX.Element {
+  const { research, getById } = useResearchData()
+  const items = research?.conflicts ?? []
+
+  if (items.length === 0) {
+    return (
+      <div className={styles.section}>
+        <h2 className={styles.sectionTitle}>Conflicts</h2>
+        <p className={styles.empty}>No conflicts recorded.</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className={styles.section}>
+      <h2 className={styles.sectionTitle}>Conflicts</h2>
+      {items.map((conflict) => {
+        const summaryText =
+          conflict.conflict_type === 'fact'
+            ? conflict.disputed_attribute
+            : conflict.identity_question
+
+        return (
+          <Card
+            key={conflict.id}
+            id={conflict.id}
+            title={conflict.description}
+            className={conflict.status === 'unresolved' ? styles.unresolved : undefined}
+            badges={
+              <>
+                <StatusBadge value={conflict.status} />
+                <StatusBadge value={conflict.conflict_type} />
+              </>
+            }
+            summary={summaryText}
+            rawData={conflict}
+            footer={
+              conflict.blocks_question_ids.length > 0 ? (
+                <div className={styles.footer}>
+                  <span className={styles.footerLabel}>Blocks:</span>
+                  {conflict.blocks_question_ids.map((qid) => (
+                    <CrossLink key={qid} id={qid} />
+                  ))}
+                </div>
+              ) : undefined
+            }
+          >
+            <div className={styles.body}>
+              {conflict.competing_assertion_ids.length > 0 && (
+                <div className={styles.subsection}>
+                  <div className={styles.subLabel}>Competing Assertions</div>
+                  <ul className={styles.assertionList}>
+                    {conflict.competing_assertion_ids.map((aid) => {
+                      const entry = getById(aid)
+                      const assertion = entry?.item as Assertion | undefined
+                      const isPreferred = conflict.preferred_assertion_id === aid
+                      return (
+                        <li
+                          key={aid}
+                          className={`${styles.assertionItem} ${isPreferred ? styles.preferred : ''}`}
+                        >
+                          <span className={styles.assertionText}>
+                            {assertion ? `${assertion.fact_type}: ${assertion.value}` : aid}
+                          </span>
+                          {isPreferred && <span className={styles.preferredBadge}>Preferred</span>}
+                          <CrossLink id={aid} label="View" />
+                        </li>
+                      )
+                    })}
+                  </ul>
+                </div>
+              )}
+
+              {conflict.independence_analysis && (
+                <div className={styles.subsection}>
+                  <div className={styles.subLabel}>Independence Analysis</div>
+                  <p className={styles.analysis}>{conflict.independence_analysis}</p>
+                </div>
+              )}
+
+              {conflict.weighing_analysis && (
+                <div className={styles.subsection}>
+                  <div className={styles.subLabel}>Weighing Analysis</div>
+                  <p className={styles.analysis}>{conflict.weighing_analysis}</p>
+                </div>
+              )}
+
+              {conflict.resolution_rationale && (
+                <div className={styles.subsection}>
+                  <div className={styles.subLabel}>Resolution Rationale</div>
+                  <p className={styles.analysis}>{conflict.resolution_rationale}</p>
+                </div>
+              )}
+            </div>
+          </Card>
+        )
+      })}
+    </div>
+  )
+}

--- a/eval/app/components/scenario/components/sections/HypothesesSection.module.css
+++ b/eval/app/components/scenario/components/sections/HypothesesSection.module.css
@@ -1,0 +1,64 @@
+.section {
+  padding: var(--spacing-xl);
+}
+
+.sectionTitle {
+  font-size: 20px;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin-bottom: var(--spacing-lg);
+}
+
+.empty {
+  font-size: 13px;
+  color: var(--text-tertiary);
+  font-style: italic;
+  padding: var(--spacing-md);
+  background: var(--bg-secondary);
+  border-radius: var(--border-radius);
+}
+
+.body {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-md);
+}
+
+.subsection {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+}
+
+.subLabel {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.linkList {
+  display: flex;
+  gap: var(--spacing-sm);
+  flex-wrap: wrap;
+}
+
+.text {
+  font-size: 13px;
+  color: var(--text-secondary);
+  line-height: 1.5;
+}
+
+.footer {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  flex-wrap: wrap;
+}
+
+.footerLabel {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-tertiary);
+}

--- a/eval/app/components/scenario/components/sections/HypothesesSection.tsx
+++ b/eval/app/components/scenario/components/sections/HypothesesSection.tsx
@@ -1,0 +1,89 @@
+import { useResearchData } from '../../contexts/ResearchDataContext'
+import Card from '../shared/Card'
+import StatusBadge from '../shared/StatusBadge'
+import CrossLink from '../shared/CrossLink'
+import styles from './HypothesesSection.module.css'
+
+export default function HypothesesSection(): React.JSX.Element {
+  const { research } = useResearchData()
+  const items = research?.hypotheses ?? []
+
+  if (items.length === 0) {
+    return (
+      <div className={styles.section}>
+        <h2 className={styles.sectionTitle}>Hypotheses</h2>
+        <p className={styles.empty}>No hypotheses recorded.</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className={styles.section}>
+      <h2 className={styles.sectionTitle}>Hypotheses</h2>
+      {items.map((hyp) => {
+        const supportCount = hyp.supporting_assertion_ids.length
+        const contradictCount = hyp.contradicting_assertion_ids.length
+        const summaryText = `${supportCount} supporting, ${contradictCount} contradicting`
+
+        return (
+          <Card
+            key={hyp.id}
+            id={hyp.id}
+            title={hyp.claim}
+            badges={<StatusBadge value={hyp.status} />}
+            summary={summaryText}
+            rawData={hyp}
+            footer={
+              hyp.related_question_ids.length > 0 ? (
+                <div className={styles.footer}>
+                  <span className={styles.footerLabel}>Related questions:</span>
+                  {hyp.related_question_ids.map((qid) => (
+                    <CrossLink key={qid} id={qid} />
+                  ))}
+                </div>
+              ) : undefined
+            }
+          >
+            <div className={styles.body}>
+              {hyp.supporting_assertion_ids.length > 0 && (
+                <div className={styles.subsection}>
+                  <div className={styles.subLabel}>Supporting Assertions</div>
+                  <div className={styles.linkList}>
+                    {hyp.supporting_assertion_ids.map((aid) => (
+                      <CrossLink key={aid} id={aid} />
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              {hyp.contradicting_assertion_ids.length > 0 && (
+                <div className={styles.subsection}>
+                  <div className={styles.subLabel}>Contradicting Assertions</div>
+                  <div className={styles.linkList}>
+                    {hyp.contradicting_assertion_ids.map((aid) => (
+                      <CrossLink key={aid} id={aid} />
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              {hyp.ruled_out_reason && (
+                <div className={styles.subsection}>
+                  <div className={styles.subLabel}>Ruled Out Reason</div>
+                  <p className={styles.text}>{hyp.ruled_out_reason}</p>
+                </div>
+              )}
+
+              {hyp.notes && (
+                <div className={styles.subsection}>
+                  <div className={styles.subLabel}>Notes</div>
+                  <p className={styles.text}>{hyp.notes}</p>
+                </div>
+              )}
+            </div>
+          </Card>
+        )
+      })}
+    </div>
+  )
+}

--- a/eval/app/components/scenario/components/sections/PersonEvidenceSection.module.css
+++ b/eval/app/components/scenario/components/sections/PersonEvidenceSection.module.css
@@ -1,0 +1,52 @@
+.section {
+  padding: var(--spacing-xl);
+}
+
+.sectionTitle {
+  font-size: 20px;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin-bottom: var(--spacing-lg);
+}
+
+.empty {
+  font-size: 13px;
+  color: var(--text-tertiary);
+  font-style: italic;
+  padding: var(--spacing-md);
+  background: var(--bg-secondary);
+  border-radius: var(--border-radius);
+}
+
+.body {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+}
+
+.detail {
+  font-size: 13px;
+  color: var(--text-secondary);
+}
+
+.label {
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.superseded {
+  font-size: 13px;
+  color: var(--badge-amber-text);
+  background: var(--badge-amber-bg);
+  padding: var(--spacing-xs) var(--spacing-sm);
+  border-radius: var(--border-radius-sm);
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+}
+
+.footer {
+  display: flex;
+  gap: var(--spacing-sm);
+  flex-wrap: wrap;
+}

--- a/eval/app/components/scenario/components/sections/PersonEvidenceSection.tsx
+++ b/eval/app/components/scenario/components/sections/PersonEvidenceSection.tsx
@@ -1,0 +1,72 @@
+import { useResearchData } from '../../contexts/ResearchDataContext'
+import type { Assertion, GedcomxPerson } from '../../lib/schema'
+import { getPreferredName } from '../../lib/schema'
+import Card from '../shared/Card'
+import StatusBadge from '../shared/StatusBadge'
+import CrossLink from '../shared/CrossLink'
+import styles from './PersonEvidenceSection.module.css'
+
+export default function PersonEvidenceSection(): React.JSX.Element {
+  const { research, gedcomx, getById } = useResearchData()
+  const items = research?.person_evidence ?? []
+
+  if (items.length === 0) {
+    return (
+      <div className={styles.section}>
+        <h2 className={styles.sectionTitle}>Person Evidence</h2>
+        <p className={styles.empty}>No person evidence recorded.</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className={styles.section}>
+      <h2 className={styles.sectionTitle}>Person Evidence</h2>
+      {items.map((pe) => {
+        const person = gedcomx?.persons.find((p) => p.id === pe.person_id)
+        const personName = person ? getPreferredName(person as GedcomxPerson) : pe.person_id
+
+        const assertionEntry = getById(pe.assertion_id)
+        const assertion = assertionEntry?.item as Assertion | undefined
+        const assertionSummary = assertion
+          ? `${assertion.fact_type}: ${assertion.value}`
+          : pe.assertion_id
+
+        const title = `${personName} — ${assertionSummary}`
+
+        return (
+          <Card
+            key={pe.id}
+            id={pe.id}
+            title={title}
+            badges={<StatusBadge value={pe.confidence} />}
+            summary={pe.rationale}
+            rawData={pe}
+            footer={
+              <div className={styles.footer}>
+                <CrossLink id={pe.assertion_id} label="Assertion" />
+                <CrossLink id={pe.person_id} label="Person" />
+              </div>
+            }
+          >
+            <div className={styles.body}>
+              {pe.match_score !== null && (
+                <div className={styles.detail}>
+                  <span className={styles.label}>Match:</span> {Math.round(pe.match_score * 100)}%
+                </div>
+              )}
+              <div className={styles.detail}>
+                <span className={styles.label}>Created:</span> {pe.created}
+              </div>
+              {pe.superseded_by && (
+                <div className={styles.superseded}>
+                  Superseded by <CrossLink id={pe.superseded_by} />
+                </div>
+              )}
+            </div>
+          </Card>
+        )
+      })}
+    </div>
+  )
+}

--- a/eval/app/components/scenario/components/sections/PlansSection.module.css
+++ b/eval/app/components/scenario/components/sections/PlansSection.module.css
@@ -1,0 +1,80 @@
+.section {
+  padding: var(--spacing-xl);
+}
+
+.sectionTitle {
+  font-size: 20px;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin-bottom: var(--spacing-lg);
+}
+
+.group {
+  margin-bottom: var(--spacing-xl);
+}
+
+.groupHeader {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text-secondary);
+  margin-bottom: var(--spacing-md);
+  padding-bottom: var(--spacing-xs);
+  border-bottom: 1px solid var(--border-color);
+}
+
+.itemList {
+  list-style: none;
+  margin-top: var(--spacing-md);
+}
+
+.item {
+  padding: var(--spacing-sm) 0;
+  border-bottom: 1px solid var(--border-color);
+  font-size: 13px;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--spacing-sm);
+}
+
+.item:last-child {
+  border-bottom: none;
+}
+
+.itemSequence {
+  font-weight: 600;
+  color: var(--text-tertiary);
+  min-width: 24px;
+}
+
+.itemRecordType {
+  font-weight: 500;
+  color: var(--text-primary);
+}
+
+.itemDetail {
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+
+.fallbackLabel {
+  font-size: 11px;
+  color: var(--badge-amber-text);
+  background: var(--badge-amber-bg);
+  padding: 1px 6px;
+  border-radius: var(--border-radius-sm);
+}
+
+.itemRationale {
+  width: 100%;
+  font-size: 12px;
+  color: var(--text-secondary);
+  margin-top: var(--spacing-xs);
+  padding-left: 32px;
+}
+
+.empty {
+  font-size: 13px;
+  color: var(--text-tertiary);
+  font-style: italic;
+}

--- a/eval/app/components/scenario/components/sections/PlansSection.tsx
+++ b/eval/app/components/scenario/components/sections/PlansSection.tsx
@@ -1,0 +1,83 @@
+import { useMemo } from 'react'
+import { useResearchData } from '../../contexts/ResearchDataContext'
+import Card from '../shared/Card'
+import StatusBadge from '../shared/StatusBadge'
+import type { Plan, Question } from '../../lib/schema'
+import styles from './PlansSection.module.css'
+
+export default function PlansSection(): React.JSX.Element {
+  const { research, getById } = useResearchData()
+  const plans = useMemo(() => research?.plans ?? [], [research?.plans])
+
+  const grouped = useMemo(() => {
+    const groups = new Map<string, Plan[]>()
+    for (const plan of plans) {
+      const key = plan.question_id
+      const existing = groups.get(key)
+      if (existing) {
+        existing.push(plan)
+      } else {
+        groups.set(key, [plan])
+      }
+    }
+    return groups
+  }, [plans])
+
+  if (plans.length === 0) {
+    return (
+      <div className={styles.section}>
+        <h2 className={styles.sectionTitle}>Plans</h2>
+        <p className={styles.empty}>No plans defined yet.</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className={styles.section}>
+      <h2 className={styles.sectionTitle}>Plans</h2>
+      {Array.from(grouped.entries()).map(([questionId, questionPlans]) => {
+        const entry = getById(questionId)
+        const questionText = entry ? (entry.item as Question).question : questionId
+
+        return (
+          <div key={questionId} className={styles.group}>
+            <div className={styles.groupHeader}>{questionText}</div>
+            {questionPlans.map((plan) => {
+              const sortedItems = [...plan.items].sort((a, b) => a.sequence - b.sequence)
+
+              return (
+                <Card
+                  key={plan.id}
+                  id={plan.id}
+                  title={plan.id}
+                  badges={<StatusBadge value={plan.status} />}
+                  footer={<span>Created {plan.created}</span>}
+                  rawData={plan}
+                >
+                  <ol className={styles.itemList}>
+                    {sortedItems.map((item) => (
+                      <li key={item.id} className={styles.item}>
+                        <span className={styles.itemSequence}>{item.sequence}.</span>
+                        <span className={styles.itemRecordType}>{item.record_type}</span>
+                        <span className={styles.itemDetail}>
+                          {item.jurisdiction} &middot; {item.date_range} &middot; {item.repository}
+                        </span>
+                        <StatusBadge value={item.status} />
+                        {item.fallback_for && (
+                          <span className={styles.fallbackLabel}>(fallback)</span>
+                        )}
+                        {item.rationale && (
+                          <div className={styles.itemRationale}>{item.rationale}</div>
+                        )}
+                      </li>
+                    ))}
+                  </ol>
+                </Card>
+              )
+            })}
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/eval/app/components/scenario/components/sections/ProjectOverview.module.css
+++ b/eval/app/components/scenario/components/sections/ProjectOverview.module.css
@@ -1,0 +1,121 @@
+.section {
+  padding: var(--spacing-xl);
+}
+
+.sectionTitle {
+  font-size: 20px;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin-bottom: var(--spacing-lg);
+}
+
+.objective {
+  font-size: 15px;
+  color: var(--text-primary);
+  line-height: 1.6;
+  margin-bottom: var(--spacing-lg);
+}
+
+.meta {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-md);
+  margin-bottom: var(--spacing-xl);
+  font-size: 12px;
+  color: var(--text-tertiary);
+}
+
+.subHeading {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text-secondary);
+  margin-bottom: var(--spacing-sm);
+  margin-top: var(--spacing-lg);
+}
+
+.personsGrid {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-md);
+}
+
+.notIdentified {
+  font-size: 13px;
+  color: var(--text-tertiary);
+  font-style: italic;
+  padding: var(--spacing-md);
+  background: var(--bg-secondary);
+  border-radius: var(--border-radius);
+}
+
+.profileBox {
+  padding: var(--spacing-md);
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: var(--border-radius);
+  margin-bottom: var(--spacing-md);
+}
+
+.profileRow {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  flex-wrap: wrap;
+}
+
+.profileBadge {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--accent-gold);
+}
+
+.profileSubs {
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+
+.profileSubsEmpty {
+  font-size: 12px;
+  color: var(--text-tertiary);
+  font-style: italic;
+}
+
+.profileGuidance {
+  font-size: 12px;
+  color: var(--text-secondary);
+  margin-top: var(--spacing-sm);
+  line-height: 1.5;
+}
+
+.relNotesList {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-md);
+}
+
+.relNoteItem {
+  padding: var(--spacing-md);
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: var(--border-radius);
+}
+
+.relNoteHeader {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin-bottom: var(--spacing-xs);
+}
+
+.relNoteBullets {
+  margin: 0;
+  padding-left: var(--spacing-lg);
+  font-size: 12px;
+  color: var(--text-secondary);
+  line-height: 1.5;
+}

--- a/eval/app/components/scenario/components/sections/ProjectOverview.tsx
+++ b/eval/app/components/scenario/components/sections/ProjectOverview.tsx
@@ -1,0 +1,176 @@
+import { useMemo } from 'react'
+import { useResearchData } from '../../contexts/ResearchDataContext'
+import StatusBadge from '../shared/StatusBadge'
+import PersonCard from '../shared/PersonCard'
+import type { GedcomxPerson, GedcomxRelationship, ResearcherProfile } from '../../lib/schema'
+import { getPreferredName } from '../../lib/schema'
+import { parentChildLabel, describeRelationship } from '../../lib/relationship-label'
+import styles from './ProjectOverview.module.css'
+
+function deriveRelationship(
+  personId: string,
+  subjectIds: string[],
+  relationships: GedcomxRelationship[],
+  persons: GedcomxPerson[]
+): string | undefined {
+  for (const rel of relationships) {
+    if (rel.type === 'ParentChild') {
+      if (rel.child === personId && subjectIds.includes(rel.parent)) {
+        const parent = persons.find((p) => p.id === rel.parent)
+        return parentChildLabel(rel, parent ? getPreferredName(parent) : 'subject', 'child')
+      }
+      if (rel.parent === personId && subjectIds.includes(rel.child)) {
+        const child = persons.find((p) => p.id === rel.child)
+        return parentChildLabel(rel, child ? getPreferredName(child) : 'subject', 'parent')
+      }
+      if (subjectIds.includes(rel.parent) && rel.child === personId) {
+        return parentChildLabel(rel, '', 'child').replace(' of ', '')
+      }
+      if (subjectIds.includes(rel.child) && rel.parent === personId) {
+        return parentChildLabel(rel, '', 'parent').replace(' of ', '')
+      }
+    }
+    if (rel.type === 'Couple') {
+      if (rel.person1 === personId && subjectIds.includes(rel.person2)) {
+        return 'Spouse'
+      }
+      if (rel.person2 === personId && subjectIds.includes(rel.person1)) {
+        return 'Spouse'
+      }
+    }
+  }
+  return undefined
+}
+
+function ResearcherProfileBlock({ profile }: { profile: ResearcherProfile }): React.JSX.Element {
+  const subs = profile.subscriptions?.filter((s) => s !== 'none') ?? []
+  return (
+    <div className={styles.profileBox}>
+      <div className={styles.profileRow}>
+        {profile.experience_level && (
+          <span className={styles.profileBadge}>{profile.experience_level}</span>
+        )}
+        {subs.length > 0 && <span className={styles.profileSubs}>{subs.join(', ')}</span>}
+        {subs.length === 0 && (
+          <span className={styles.profileSubsEmpty}>No paid subscriptions</span>
+        )}
+      </div>
+      {profile.narration_guidance && (
+        <div className={styles.profileGuidance}>{profile.narration_guidance}</div>
+      )}
+    </div>
+  )
+}
+
+interface NotedRelationship {
+  id: string
+  description: string
+  notes: string[]
+}
+
+export default function ProjectOverview(): React.JSX.Element {
+  const { research, gedcomx } = useResearchData()
+  const project = research?.project
+  const profile = research?.researcher_profile
+
+  const { subjectPersons, otherPersons, notedRelationships } = useMemo(() => {
+    if (!gedcomx)
+      return {
+        subjectPersons: [] as GedcomxPerson[],
+        otherPersons: [] as { person: GedcomxPerson; relationship?: string }[],
+        notedRelationships: [] as NotedRelationship[]
+      }
+
+    const subjectIds = project?.subject_person_ids ?? []
+    const subjects = subjectIds
+      .map((id) => gedcomx.persons.find((p) => p.id === id))
+      .filter((p): p is GedcomxPerson => !!p)
+
+    const others = gedcomx.persons
+      .filter((p) => !subjectIds.includes(p.id))
+      .map((p) => ({
+        person: p,
+        relationship: deriveRelationship(p.id, subjectIds, gedcomx.relationships, gedcomx.persons)
+      }))
+
+    const noted: NotedRelationship[] = gedcomx.relationships
+      .filter((r) => Array.isArray(r.notes) && r.notes.length > 0)
+      .map((r) => ({
+        id: r.id,
+        description: describeRelationship(r, gedcomx.persons),
+        notes: r.notes as string[]
+      }))
+
+    return { subjectPersons: subjects, otherPersons: others, notedRelationships: noted }
+  }, [gedcomx, project])
+
+  if (!project) {
+    return (
+      <div className={styles.section}>
+        <h2 className={styles.sectionTitle}>Project Overview</h2>
+        <p className={styles.notIdentified}>No project data loaded.</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className={styles.section}>
+      <h2 className={styles.sectionTitle}>Project Overview</h2>
+
+      <p className={styles.objective}>{project.objective}</p>
+
+      <div className={styles.meta}>
+        <StatusBadge value={project.status} />
+        <span>Created {project.created}</span>
+        <span>Updated {project.updated}</span>
+      </div>
+
+      {profile && (
+        <>
+          <h3 className={styles.subHeading}>Researcher Profile</h3>
+          <ResearcherProfileBlock profile={profile} />
+        </>
+      )}
+
+      <h3 className={styles.subHeading}>Subject Persons</h3>
+      {project.subject_person_ids === null || project.subject_person_ids.length === 0 ? (
+        <p className={styles.notIdentified}>Subject not yet identified</p>
+      ) : (
+        <div className={styles.personsGrid}>
+          {subjectPersons.map((person) => (
+            <PersonCard key={person.id} person={person} />
+          ))}
+        </div>
+      )}
+
+      {otherPersons.length > 0 && (
+        <>
+          <h3 className={styles.subHeading}>Other Persons</h3>
+          <div className={styles.personsGrid}>
+            {otherPersons.map(({ person, relationship }) => (
+              <PersonCard key={person.id} person={person} relationship={relationship} />
+            ))}
+          </div>
+        </>
+      )}
+
+      {notedRelationships.length > 0 && (
+        <>
+          <h3 className={styles.subHeading}>Relationship Notes</h3>
+          <ul className={styles.relNotesList}>
+            {notedRelationships.map((rel) => (
+              <li key={rel.id} className={styles.relNoteItem}>
+                <div className={styles.relNoteHeader}>{rel.description}</div>
+                <ul className={styles.relNoteBullets}>
+                  {rel.notes.map((note, idx) => (
+                    <li key={idx}>{note}</li>
+                  ))}
+                </ul>
+              </li>
+            ))}
+          </ul>
+        </>
+      )}
+    </div>
+  )
+}

--- a/eval/app/components/scenario/components/sections/ProofSummariesSection.module.css
+++ b/eval/app/components/scenario/components/sections/ProofSummariesSection.module.css
@@ -1,0 +1,73 @@
+.section {
+  padding: var(--spacing-xl);
+}
+
+.sectionTitle {
+  font-size: 20px;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin-bottom: var(--spacing-lg);
+}
+
+.empty {
+  font-size: 13px;
+  color: var(--text-tertiary);
+  font-style: italic;
+  padding: var(--spacing-md);
+  background: var(--bg-secondary);
+  border-radius: var(--border-radius);
+}
+
+.body {
+  display: flex;
+  flex-direction: column;
+}
+
+.narrative {
+  font-size: 13px;
+  color: var(--text-primary);
+  line-height: 1.6;
+  background: var(--bg-secondary);
+  padding: var(--spacing-md);
+  border-radius: var(--border-radius);
+  border: 1px solid var(--border-color);
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.narrative h2 {
+  font-size: 16px;
+  margin: var(--spacing-lg) 0 var(--spacing-sm);
+}
+
+.narrative h3 {
+  font-size: 14px;
+  margin: var(--spacing-md) 0 var(--spacing-xs);
+}
+
+.narrative p {
+  margin-bottom: var(--spacing-sm);
+}
+
+.narrative ol,
+.narrative ul {
+  padding-left: var(--spacing-xl);
+  margin-bottom: var(--spacing-sm);
+}
+
+.narrative strong {
+  font-weight: 600;
+}
+
+.footer {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  flex-wrap: wrap;
+}
+
+.footerLabel {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-tertiary);
+}

--- a/eval/app/components/scenario/components/sections/ProofSummariesSection.tsx
+++ b/eval/app/components/scenario/components/sections/ProofSummariesSection.tsx
@@ -1,0 +1,74 @@
+import { MarkdownViewer } from '@/components/common/MarkdownViewer'
+import { useResearchData } from '../../contexts/ResearchDataContext'
+import type { Question } from '../../lib/schema'
+import Card from '../shared/Card'
+import StatusBadge from '../shared/StatusBadge'
+import CrossLink from '../shared/CrossLink'
+import styles from './ProofSummariesSection.module.css'
+
+export default function ProofSummariesSection(): React.JSX.Element {
+  const { research, getById } = useResearchData()
+  const items = research?.proof_summaries ?? []
+
+  if (items.length === 0) {
+    return (
+      <div className={styles.section}>
+        <h2 className={styles.sectionTitle}>Proof Summaries</h2>
+        <p className={styles.empty}>No proof summaries recorded.</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className={styles.section}>
+      <h2 className={styles.sectionTitle}>Proof Summaries</h2>
+      {items.map((ps) => {
+        const questionEntry = getById(ps.question_id)
+        const question = questionEntry?.item as Question | undefined
+        const title = question?.question ?? ps.question_id
+
+        return (
+          <Card
+            key={ps.id}
+            id={ps.id}
+            title={title}
+            badges={
+              <>
+                <StatusBadge value={ps.tier} />
+                <StatusBadge value={ps.vehicle} />
+              </>
+            }
+            summary={ps.exhaustive_search_summary}
+            rawData={ps}
+            footer={
+              <div className={styles.footer}>
+                {ps.supporting_assertion_ids.length > 0 && (
+                  <>
+                    <span className={styles.footerLabel}>Assertions:</span>
+                    {ps.supporting_assertion_ids.map((aid) => (
+                      <CrossLink key={aid} id={aid} />
+                    ))}
+                  </>
+                )}
+                {ps.resolved_conflict_ids.length > 0 && (
+                  <>
+                    <span className={styles.footerLabel}>Resolved conflicts:</span>
+                    {ps.resolved_conflict_ids.map((cid) => (
+                      <CrossLink key={cid} id={cid} />
+                    ))}
+                  </>
+                )}
+              </div>
+            }
+          >
+            <div className={styles.body}>
+              <div className={styles.narrative}>
+                <MarkdownViewer content={ps.narrative_markdown} />
+              </div>
+            </div>
+          </Card>
+        )
+      })}
+    </div>
+  )
+}

--- a/eval/app/components/scenario/components/sections/QuestionsSection.module.css
+++ b/eval/app/components/scenario/components/sections/QuestionsSection.module.css
@@ -1,0 +1,64 @@
+.section {
+  padding: var(--spacing-xl);
+}
+
+.sectionTitle {
+  font-size: 20px;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin-bottom: var(--spacing-lg);
+}
+
+.field {
+  margin-bottom: var(--spacing-md);
+}
+
+.fieldLabel {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-tertiary);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  margin-bottom: var(--spacing-xs);
+}
+
+.fieldValue {
+  font-size: 13px;
+  color: var(--text-primary);
+}
+
+.linkList {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-xs);
+}
+
+.stopCriteria {
+  margin-top: var(--spacing-md);
+  padding: var(--spacing-md);
+  background: var(--bg-secondary);
+  border-radius: var(--border-radius);
+}
+
+.stopCriteria dt {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-secondary);
+  margin-top: var(--spacing-sm);
+}
+
+.stopCriteria dt:first-child {
+  margin-top: 0;
+}
+
+.stopCriteria dd {
+  font-size: 13px;
+  color: var(--text-primary);
+  margin-left: 0;
+}
+
+.empty {
+  font-size: 13px;
+  color: var(--text-tertiary);
+  font-style: italic;
+}

--- a/eval/app/components/scenario/components/sections/QuestionsSection.tsx
+++ b/eval/app/components/scenario/components/sections/QuestionsSection.tsx
@@ -1,0 +1,97 @@
+import { useResearchData } from '../../contexts/ResearchDataContext'
+import Card from '../shared/Card'
+import StatusBadge from '../shared/StatusBadge'
+import CrossLink from '../shared/CrossLink'
+import type { Question } from '../../lib/schema'
+import styles from './QuestionsSection.module.css'
+
+function QuestionCard({ question }: { question: Question }): React.JSX.Element {
+  const { exhaustive_declaration } = question
+
+  return (
+    <Card
+      id={question.id}
+      title={question.question}
+      badges={
+        <>
+          <StatusBadge value={question.status} />
+          <StatusBadge value={question.priority} />
+          {exhaustive_declaration.declared && <StatusBadge value="exhaustive" color="blue" />}
+        </>
+      }
+      summary={question.rationale}
+      footer={
+        <>
+          <span>Created {question.created}</span>
+          {question.resolved && <span>Resolved {question.resolved}</span>}
+        </>
+      }
+      rawData={question}
+    >
+      <div className={styles.field}>
+        <div className={styles.fieldLabel}>Selection Basis</div>
+        <div className={styles.fieldValue}>{question.selection_basis.replace(/_/g, ' ')}</div>
+      </div>
+
+      {question.depends_on.length > 0 && (
+        <div className={styles.field}>
+          <div className={styles.fieldLabel}>Depends On</div>
+          <div className={styles.linkList}>
+            {question.depends_on.map((id) => (
+              <CrossLink key={id} id={id} />
+            ))}
+          </div>
+        </div>
+      )}
+
+      {question.unblocks.length > 0 && (
+        <div className={styles.field}>
+          <div className={styles.fieldLabel}>Unblocks</div>
+          <div className={styles.linkList}>
+            {question.unblocks.map((id) => (
+              <CrossLink key={id} id={id} />
+            ))}
+          </div>
+        </div>
+      )}
+
+      {question.resolution_assertion_ids.length > 0 && (
+        <div className={styles.field}>
+          <div className={styles.fieldLabel}>Resolution Assertions</div>
+          <div className={styles.linkList}>
+            {question.resolution_assertion_ids.map((id) => (
+              <CrossLink key={id} id={id} />
+            ))}
+          </div>
+        </div>
+      )}
+
+      {exhaustive_declaration.declared && exhaustive_declaration.stop_criteria && (
+        <dl className={styles.stopCriteria}>
+          {Object.entries(exhaustive_declaration.stop_criteria).map(([key, value]) => (
+            <div key={key}>
+              <dt>{key.replace(/_/g, ' ')}</dt>
+              <dd>{value}</dd>
+            </div>
+          ))}
+        </dl>
+      )}
+    </Card>
+  )
+}
+
+export default function QuestionsSection(): React.JSX.Element {
+  const { research } = useResearchData()
+  const questions = research?.questions ?? []
+
+  return (
+    <div className={styles.section}>
+      <h2 className={styles.sectionTitle}>Questions</h2>
+      {questions.length === 0 ? (
+        <p className={styles.empty}>No questions defined yet.</p>
+      ) : (
+        questions.map((q) => <QuestionCard key={q.id} question={q} />)
+      )}
+    </div>
+  )
+}

--- a/eval/app/components/scenario/components/sections/ResearchLogSection.module.css
+++ b/eval/app/components/scenario/components/sections/ResearchLogSection.module.css
@@ -1,0 +1,139 @@
+.section {
+  padding: var(--spacing-xl);
+}
+
+.sectionTitle {
+  font-size: 20px;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin-bottom: var(--spacing-lg);
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.table th {
+  text-align: left;
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-tertiary);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  padding: var(--spacing-sm) var(--spacing-md);
+  border-bottom: 2px solid var(--border-color);
+  cursor: pointer;
+  user-select: none;
+  white-space: nowrap;
+}
+
+.table th:hover {
+  color: var(--text-primary);
+}
+
+.sortIndicator {
+  margin-left: 4px;
+  font-size: 10px;
+}
+
+.table td {
+  font-size: 13px;
+  color: var(--text-primary);
+  padding: var(--spacing-sm) var(--spacing-md);
+  border-bottom: 1px solid var(--border-color);
+  vertical-align: top;
+}
+
+.clickableRow {
+  cursor: pointer;
+  transition: background 0.1s;
+}
+
+.clickableRow:hover {
+  background: var(--bg-hover);
+}
+
+.expandedRow td {
+  padding: 0;
+}
+
+.expandedContent {
+  padding: var(--spacing-lg);
+  background: var(--bg-secondary);
+  border-radius: var(--border-radius);
+  margin: var(--spacing-sm) var(--spacing-md);
+}
+
+.field {
+  margin-bottom: var(--spacing-md);
+}
+
+.field:last-child {
+  margin-bottom: 0;
+}
+
+.fieldLabel {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-tertiary);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  margin-bottom: var(--spacing-xs);
+}
+
+.fieldValue {
+  font-size: 13px;
+  color: var(--text-primary);
+}
+
+.queryBlock {
+  background: var(--bg-primary);
+  border: 1px solid var(--border-color);
+  border-radius: var(--border-radius-sm);
+  padding: var(--spacing-sm);
+  font-family: monospace;
+  font-size: 12px;
+  white-space: pre-wrap;
+  overflow-x: auto;
+}
+
+.linkList {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-xs);
+  align-items: center;
+}
+
+.count {
+  font-size: 12px;
+  color: var(--text-secondary);
+  margin-right: var(--spacing-xs);
+}
+
+.empty {
+  font-size: 13px;
+  color: var(--text-tertiary);
+  font-style: italic;
+}
+
+.viewResultsButton {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: var(--border-radius-sm);
+  padding: var(--spacing-xs) var(--spacing-md);
+  font-family: inherit;
+  font-size: 13px;
+  color: var(--accent-gold-strong);
+  cursor: pointer;
+  transition: background 0.12s;
+}
+
+.viewResultsButton:hover {
+  background: var(--bg-hover);
+}
+
+.viewResultsButton:focus-visible {
+  outline: 2px solid var(--accent-gold-strong);
+  outline-offset: 1px;
+}

--- a/eval/app/components/scenario/components/sections/ResearchLogSection.tsx
+++ b/eval/app/components/scenario/components/sections/ResearchLogSection.tsx
@@ -1,0 +1,196 @@
+import { useState, useMemo } from 'react'
+import { useResearchData } from '../../contexts/ResearchDataContext'
+import StatusBadge from '../shared/StatusBadge'
+import CrossLink from '../shared/CrossLink'
+import type { LogEntry, Source, Assertion } from '../../lib/schema'
+import { indexByLogEntry } from '../../lib/index-by-log-entry'
+import styles from './ResearchLogSection.module.css'
+
+type SortKey = 'performed' | 'tool' | 'outcome' | 'results_examined'
+type SortDir = 'asc' | 'desc'
+
+function compareEntries(a: LogEntry, b: LogEntry, key: SortKey, dir: SortDir): number {
+  let cmp = 0
+  switch (key) {
+    case 'performed':
+      cmp = a.performed.localeCompare(b.performed)
+      break
+    case 'tool':
+      cmp = a.tool.localeCompare(b.tool)
+      break
+    case 'outcome':
+      cmp = a.outcome.localeCompare(b.outcome)
+      break
+    case 'results_examined':
+      cmp = a.results_examined - b.results_examined
+      break
+  }
+  return dir === 'desc' ? -cmp : cmp
+}
+
+function viewResultsLabel(entry: LogEntry): string {
+  const examined = entry.results_examined
+  const available = entry.results_available
+  if (available !== undefined && available !== null && available > examined) {
+    return `${examined} of ${available} results examined`
+  }
+  return `${examined} results examined`
+}
+
+export default function ResearchLogSection(): React.JSX.Element {
+  const { research, devMode } = useResearchData()
+  const logEntries = useMemo(() => research?.log ?? [], [research?.log])
+  const sources = useMemo<Source[]>(() => research?.sources ?? [], [research?.sources])
+  const assertions = useMemo<Assertion[]>(() => research?.assertions ?? [], [research?.assertions])
+
+  const [sortKey, setSortKey] = useState<SortKey>('performed')
+  const [sortDir, setSortDir] = useState<SortDir>('desc')
+  const [expandedId, setExpandedId] = useState<string | null>(null)
+
+  const sorted = useMemo(
+    () => [...logEntries].sort((a, b) => compareEntries(a, b, sortKey, sortDir)),
+    [logEntries, sortKey, sortDir]
+  )
+
+  const sourcesByLogEntry = useMemo(() => indexByLogEntry(sources), [sources])
+  const assertionsByLogEntry = useMemo(() => indexByLogEntry(assertions), [assertions])
+
+  const handleSort = (key: SortKey): void => {
+    if (sortKey === key) {
+      setSortDir(sortDir === 'asc' ? 'desc' : 'asc')
+    } else {
+      setSortKey(key)
+      setSortDir('desc')
+    }
+  }
+
+  const renderSortIndicator = (key: SortKey): React.JSX.Element | null => {
+    if (sortKey !== key) return null
+    return <span className={styles.sortIndicator}>{sortDir === 'asc' ? '▲' : '▼'}</span>
+  }
+
+  if (logEntries.length === 0) {
+    return (
+      <div className={styles.section}>
+        <h2 className={styles.sectionTitle}>Research Log</h2>
+        <p className={styles.empty}>No log entries yet.</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className={styles.section}>
+      <h2 className={styles.sectionTitle}>Research Log</h2>
+      <table className={styles.table}>
+        <thead>
+          <tr>
+            <th onClick={() => handleSort('performed')}>Date{renderSortIndicator('performed')}</th>
+            <th onClick={() => handleSort('tool')}>Tool{renderSortIndicator('tool')}</th>
+            <th onClick={() => handleSort('outcome')}>Outcome{renderSortIndicator('outcome')}</th>
+            <th onClick={() => handleSort('results_examined')}>
+              Results{renderSortIndicator('results_examined')}
+            </th>
+            <th>Sources</th>
+            <th>Assertions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {sorted.map((entry) => {
+            const isExpanded = expandedId === entry.id
+            const capturedSources = sourcesByLogEntry.get(entry.id) ?? []
+            const producedAssertions = assertionsByLogEntry.get(entry.id) ?? []
+            return (
+              <tr key={entry.id} id={entry.id}>
+                <td colSpan={6} style={{ padding: 0 }}>
+                  <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+                    <tbody>
+                      <tr
+                        className={styles.clickableRow}
+                        onClick={() => setExpandedId(isExpanded ? null : entry.id)}
+                      >
+                        <td>{entry.performed}</td>
+                        <td>{entry.tool}</td>
+                        <td>
+                          <StatusBadge value={entry.outcome} />
+                        </td>
+                        <td>{entry.results_examined}</td>
+                        <td>
+                          <div className={styles.linkList}>
+                            <span className={styles.count}>{capturedSources.length}</span>
+                            {capturedSources.map((source) => (
+                              <CrossLink key={source.id} id={source.id} />
+                            ))}
+                          </div>
+                        </td>
+                        <td>
+                          <div className={styles.linkList}>
+                            <span className={styles.count}>{producedAssertions.length}</span>
+                            {producedAssertions.map((assertion) => (
+                              <CrossLink key={assertion.id} id={assertion.id} />
+                            ))}
+                          </div>
+                        </td>
+                      </tr>
+                      {isExpanded && (
+                        <tr className={styles.expandedRow}>
+                          <td colSpan={6}>
+                            <div className={styles.expandedContent}>
+                              <div className={styles.field}>
+                                <div className={styles.fieldLabel}>Query</div>
+                                <pre className={styles.queryBlock}>
+                                  {JSON.stringify(entry.query, null, 2)}
+                                </pre>
+                              </div>
+
+                              {entry.notes && (
+                                <div className={styles.field}>
+                                  <div className={styles.fieldLabel}>Notes</div>
+                                  <div className={styles.fieldValue}>{entry.notes}</div>
+                                </div>
+                              )}
+
+                              {entry.results_ref && (
+                                <div className={styles.field}>
+                                  <div className={styles.fieldLabel}>Results</div>
+                                  <div className={styles.fieldValue}>{viewResultsLabel(entry)}</div>
+                                </div>
+                              )}
+
+                              {entry.external_site && (
+                                <div className={styles.field}>
+                                  <div className={styles.fieldLabel}>External Site</div>
+                                  <div className={styles.fieldValue}>
+                                    {entry.external_site.site} &middot;{' '}
+                                    {entry.external_site.capture_received
+                                      ? 'Captured'
+                                      : 'Not captured'}
+                                    {entry.external_site.capture_filename && (
+                                      <> &middot; {entry.external_site.capture_filename}</>
+                                    )}
+                                  </div>
+                                </div>
+                              )}
+
+                              {devMode && (
+                                <div className={styles.field}>
+                                  <div className={styles.fieldLabel}>Raw JSON</div>
+                                  <pre className={styles.queryBlock}>
+                                    {JSON.stringify(entry, null, 2)}
+                                  </pre>
+                                </div>
+                              )}
+                            </div>
+                          </td>
+                        </tr>
+                      )}
+                    </tbody>
+                  </table>
+                </td>
+              </tr>
+            )
+          })}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/eval/app/components/scenario/components/sections/SourcesSection.module.css
+++ b/eval/app/components/scenario/components/sections/SourcesSection.module.css
@@ -1,0 +1,96 @@
+.section {
+  padding: var(--spacing-xl);
+}
+
+.sectionTitle {
+  font-size: 20px;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin-bottom: var(--spacing-lg);
+}
+
+.field {
+  margin-bottom: var(--spacing-md);
+}
+
+.field:last-child {
+  margin-bottom: 0;
+}
+
+.fieldLabel {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-tertiary);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  margin-bottom: var(--spacing-xs);
+}
+
+.fieldValue {
+  font-size: 13px;
+  color: var(--text-primary);
+}
+
+.detailGrid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--spacing-md);
+  margin-bottom: var(--spacing-md);
+}
+
+.externalLink {
+  color: var(--text-link);
+  text-decoration: none;
+  cursor: pointer;
+  font-size: 13px;
+}
+
+.externalLink:hover {
+  text-decoration: underline;
+}
+
+.notes {
+  font-size: 13px;
+  color: var(--text-secondary);
+  white-space: pre-wrap;
+}
+
+.empty {
+  font-size: 13px;
+  color: var(--text-tertiary);
+  font-style: italic;
+}
+
+.footerLinks {
+  display: flex;
+  gap: var(--spacing-md);
+  flex-wrap: wrap;
+}
+
+.transcriptionBlock {
+  background: var(--bg-code);
+  border: 1px solid var(--border-color);
+  border-radius: var(--border-radius-sm);
+  padding: var(--spacing-sm);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--text-primary);
+  white-space: pre-wrap;
+  overflow-x: auto;
+  margin: 0;
+}
+
+.transcriptionToggle {
+  margin-top: var(--spacing-xs);
+  background: none;
+  border: none;
+  padding: 0;
+  font-size: 12px;
+  color: var(--text-link);
+  cursor: pointer;
+  text-decoration: none;
+}
+
+.transcriptionToggle:hover {
+  text-decoration: underline;
+}

--- a/eval/app/components/scenario/components/sections/SourcesSection.tsx
+++ b/eval/app/components/scenario/components/sections/SourcesSection.tsx
@@ -1,0 +1,139 @@
+import { useState } from 'react'
+import { useResearchData } from '../../contexts/ResearchDataContext'
+import Card from '../shared/Card'
+import StatusBadge from '../shared/StatusBadge'
+import CrossLink from '../shared/CrossLink'
+import type { Source } from '../../lib/schema'
+import styles from './SourcesSection.module.css'
+
+const TRANSCRIPTION_PREVIEW_CHARS = 300
+
+function truncate(text: string, max: number): string {
+  if (text.length <= max) return text
+  return text.slice(0, max) + '...'
+}
+
+function Transcription({ text }: { text: string }): React.JSX.Element {
+  const [expanded, setExpanded] = useState(false)
+  const isLong = text.length > TRANSCRIPTION_PREVIEW_CHARS
+  const displayed = expanded || !isLong ? text : text.slice(0, TRANSCRIPTION_PREVIEW_CHARS) + '…'
+  return (
+    <>
+      <pre className={styles.transcriptionBlock}>{displayed}</pre>
+      {isLong && (
+        <button
+          type="button"
+          className={styles.transcriptionToggle}
+          onClick={() => setExpanded((v) => !v)}
+        >
+          {expanded ? 'Show less' : 'Show more'}
+        </button>
+      )}
+    </>
+  )
+}
+
+function SourceCard({ source }: { source: Source }): React.JSX.Element {
+  const { citation_detail: detail } = source
+
+  const handleLinkClick = (url: string): void => {
+    window.open(url, '_blank', 'noopener,noreferrer')
+  }
+
+  return (
+    <Card
+      id={source.id}
+      title={detail.what}
+      badges={<StatusBadge value={source.source_classification} />}
+      summary={truncate(source.citation, 200)}
+      footer={
+        <div className={styles.footerLinks}>
+          <CrossLink
+            id={source.gedcomx_source_description_id}
+            label={`GedcomX: ${source.gedcomx_source_description_id}`}
+          />
+          {source.log_entry_id && (
+            <CrossLink id={source.log_entry_id} label={`Captured by: ${source.log_entry_id}`} />
+          )}
+        </div>
+      }
+      rawData={source}
+    >
+      <div className={styles.detailGrid}>
+        <div className={styles.field}>
+          <div className={styles.fieldLabel}>Who</div>
+          <div className={styles.fieldValue}>{detail.who}</div>
+        </div>
+        <div className={styles.field}>
+          <div className={styles.fieldLabel}>What</div>
+          <div className={styles.fieldValue}>{detail.what}</div>
+        </div>
+        <div className={styles.field}>
+          <div className={styles.fieldLabel}>When Created</div>
+          <div className={styles.fieldValue}>{detail.when_created}</div>
+        </div>
+        <div className={styles.field}>
+          <div className={styles.fieldLabel}>When Accessed</div>
+          <div className={styles.fieldValue}>{detail.when_accessed}</div>
+        </div>
+        <div className={styles.field}>
+          <div className={styles.fieldLabel}>Where</div>
+          <div className={styles.fieldValue}>{detail.where}</div>
+        </div>
+        <div className={styles.field}>
+          <div className={styles.fieldLabel}>Where Within</div>
+          <div className={styles.fieldValue}>{detail.where_within}</div>
+        </div>
+      </div>
+
+      <div className={styles.field}>
+        <div className={styles.fieldLabel}>Repository</div>
+        <div className={styles.fieldValue}>{source.repository}</div>
+      </div>
+
+      <div className={styles.field}>
+        <div className={styles.fieldLabel}>Access Date</div>
+        <div className={styles.fieldValue}>{source.access_date}</div>
+      </div>
+
+      {source.url && (
+        <div className={styles.field}>
+          <div className={styles.fieldLabel}>URL</div>
+          <button className={styles.externalLink} onClick={() => handleLinkClick(source.url!)}>
+            {source.url}
+          </button>
+        </div>
+      )}
+
+      {source.notes && (
+        <div className={styles.field}>
+          <div className={styles.fieldLabel}>Notes</div>
+          <div className={styles.notes}>{source.notes}</div>
+        </div>
+      )}
+
+      {source.transcription && (
+        <div className={styles.field}>
+          <div className={styles.fieldLabel}>Transcription</div>
+          <Transcription text={source.transcription} />
+        </div>
+      )}
+    </Card>
+  )
+}
+
+export default function SourcesSection(): React.JSX.Element {
+  const { research } = useResearchData()
+  const sources = research?.sources ?? []
+
+  return (
+    <div className={styles.section}>
+      <h2 className={styles.sectionTitle}>Sources</h2>
+      {sources.length === 0 ? (
+        <p className={styles.empty}>No sources captured yet.</p>
+      ) : (
+        sources.map((s) => <SourceCard key={s.id} source={s} />)
+      )}
+    </div>
+  )
+}

--- a/eval/app/components/scenario/components/sections/TimelinesSection.module.css
+++ b/eval/app/components/scenario/components/sections/TimelinesSection.module.css
@@ -1,0 +1,280 @@
+.section {
+  padding: var(--spacing-xl);
+}
+
+.sectionTitle {
+  font-size: 20px;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin-bottom: var(--spacing-lg);
+}
+
+.empty {
+  font-size: 13px;
+  color: var(--text-tertiary);
+  font-style: italic;
+  padding: var(--spacing-md);
+  background: var(--bg-secondary);
+  border-radius: var(--border-radius);
+}
+
+.body {
+  display: flex;
+  flex-direction: column;
+}
+
+.timeline {
+  position: relative;
+  padding-left: var(--spacing-sm);
+}
+
+/* Event row */
+.event {
+  display: grid;
+  grid-template-columns: 100px 20px 1fr;
+  gap: var(--spacing-xs);
+  align-items: start;
+  padding: var(--spacing-sm) 0;
+}
+
+.eventLeft {
+  text-align: right;
+  padding-right: var(--spacing-sm);
+}
+
+.eventDate {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.eventCertainty {
+  font-size: 11px;
+  color: var(--text-tertiary);
+  font-style: italic;
+}
+
+.eventDot {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.eventDot::before {
+  content: '';
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: var(--text-link);
+  flex-shrink: 0;
+}
+
+.eventDot::after {
+  content: '';
+  position: absolute;
+  top: 14px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 2px;
+  height: calc(100% + var(--spacing-sm));
+  background: var(--border-color);
+}
+
+.event:last-child .eventDot::after {
+  display: none;
+}
+
+.eventRight {
+  padding-left: var(--spacing-sm);
+}
+
+.eventType {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.eventPlace {
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+
+.eventDesc {
+  font-size: 12px;
+  color: var(--text-secondary);
+  margin-top: var(--spacing-xs);
+}
+
+.eventLinks {
+  display: flex;
+  gap: var(--spacing-xs);
+  flex-wrap: wrap;
+  margin-top: var(--spacing-xs);
+}
+
+/* Gap segment */
+.gap {
+  display: grid;
+  grid-template-columns: 100px 20px 1fr;
+  gap: var(--spacing-xs);
+  padding: var(--spacing-xs) 0;
+}
+
+.gapLine {
+  grid-column: 2;
+  position: relative;
+}
+
+.gapLine::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 2px;
+  height: 100%;
+  border-left: 2px dashed var(--border-color);
+}
+
+.gapContent {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding-left: var(--spacing-sm);
+}
+
+.gapLabel {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.gapExpected {
+  font-size: 11px;
+  color: var(--text-tertiary);
+}
+
+.gap_high .gapLabel {
+  color: var(--badge-red-text);
+}
+
+.gap_high .gapLine::before {
+  border-color: var(--badge-red-text);
+}
+
+.gap_medium .gapLabel {
+  color: var(--badge-amber-text);
+}
+
+.gap_medium .gapLine::before {
+  border-color: var(--badge-amber-text);
+}
+
+.gap_low .gapLabel {
+  color: var(--text-tertiary);
+}
+
+.gap_low .gapLine::before {
+  border-color: var(--text-tertiary);
+}
+
+/* Distance between events */
+.distance {
+  display: grid;
+  grid-template-columns: 100px 20px 1fr;
+  gap: var(--spacing-xs);
+  padding: 2px 0;
+}
+
+.distanceLine {
+  grid-column: 2;
+  position: relative;
+}
+
+.distanceLabel {
+  grid-column: 3;
+  padding-left: var(--spacing-sm);
+  font-size: 11px;
+  color: var(--text-tertiary);
+  font-variant-numeric: tabular-nums;
+  font-style: italic;
+}
+
+/* Impossibility alert */
+.impossibility {
+  display: grid;
+  grid-template-columns: 100px 20px 1fr;
+  gap: var(--spacing-xs);
+  padding: var(--spacing-sm) 0;
+}
+
+.impossibilityDesc {
+  grid-column: 3;
+  font-size: 12px;
+  color: var(--badge-red-text);
+  background: var(--badge-red-bg);
+  padding: var(--spacing-sm);
+  border-radius: var(--border-radius-sm);
+  border-left: 3px solid var(--badge-red-text);
+}
+
+.impossibilityLinks {
+  grid-column: 3;
+  display: flex;
+  gap: var(--spacing-sm);
+  margin-top: var(--spacing-xs);
+}
+
+.footer {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  flex-wrap: wrap;
+}
+
+.footerLabel {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-tertiary);
+}
+
+.footerPersons {
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+
+/* B6: gap.notes — italic supplementary text under the gap badge */
+.gapNotes {
+  font-size: 12px;
+  color: var(--text-tertiary);
+  font-style: italic;
+  margin-top: var(--spacing-xs);
+}
+
+/* B5: conflict chip — warm-sandstone background per --conflict-unresolved-* */
+.conflictChip {
+  background: var(--conflict-unresolved-bg);
+  border: 1px solid var(--conflict-unresolved-border);
+  color: var(--text-primary);
+  border-radius: var(--border-radius-sm);
+  padding: var(--spacing-xs) var(--spacing-sm);
+  margin-top: var(--spacing-xs);
+  font-size: 12px;
+}
+
+.conflictLabel {
+  font-weight: 600;
+}
+
+.conflictNote {
+  color: var(--text-secondary);
+}
+
+.conflictLinks {
+  display: flex;
+  gap: var(--spacing-xs);
+  margin-top: var(--spacing-xs);
+  flex-wrap: wrap;
+}

--- a/eval/app/components/scenario/components/sections/TimelinesSection.tsx
+++ b/eval/app/components/scenario/components/sections/TimelinesSection.tsx
@@ -1,0 +1,168 @@
+import { useResearchData } from '../../contexts/ResearchDataContext'
+import type { GedcomxPerson } from '../../lib/schema'
+import { getPreferredName } from '../../lib/schema'
+import Card from '../shared/Card'
+import CrossLink from '../shared/CrossLink'
+import styles from './TimelinesSection.module.css'
+
+export default function TimelinesSection(): React.JSX.Element {
+  const { research, gedcomx } = useResearchData()
+  const items = research?.timelines ?? []
+
+  if (items.length === 0) {
+    return (
+      <div className={styles.section}>
+        <h2 className={styles.sectionTitle}>Timelines</h2>
+        <p className={styles.empty}>No timelines recorded.</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className={styles.section}>
+      <h2 className={styles.sectionTitle}>Timelines</h2>
+      {items.map((tl) => {
+        const eventCount = tl.events.length
+        const firstDate = tl.events[0]?.date
+        const lastDate = tl.events[eventCount - 1]?.date
+        const dateRange = firstDate && lastDate ? `${firstDate} – ${lastDate}` : ''
+        const summaryText = `${eventCount} event${eventCount !== 1 ? 's' : ''}${dateRange ? ` · ${dateRange}` : ''}`
+
+        const personNames = tl.person_ids
+          .map((pid) => {
+            const person = gedcomx?.persons.find((p) => p.id === pid)
+            return person ? getPreferredName(person as GedcomxPerson) : pid
+          })
+          .join(', ')
+
+        return (
+          <Card
+            key={tl.id}
+            id={tl.id}
+            title={tl.label}
+            summary={summaryText}
+            rawData={tl}
+            footer={
+              <div className={styles.footer}>
+                {tl.hypothesis_id && (
+                  <>
+                    <span className={styles.footerLabel}>Hypothesis:</span>
+                    <CrossLink id={tl.hypothesis_id} />
+                  </>
+                )}
+                {personNames && <span className={styles.footerPersons}>{personNames}</span>}
+              </div>
+            }
+          >
+            <div className={styles.body}>
+              <div className={styles.timeline}>
+                {tl.events.map((event, idx) => {
+                  // Check if there's a gap before this event
+                  const gapBefore =
+                    idx > 0
+                      ? tl.gaps.find(
+                          (g) => g.start === tl.events[idx - 1].date && g.end === event.date
+                        )
+                      : null
+
+                  // Check if there's an impossibility involving this event
+                  const impossibility = tl.impossibilities.find(
+                    (imp) =>
+                      event.assertion_ids.includes(imp.event_1_assertion_id) ||
+                      event.assertion_ids.includes(imp.event_2_assertion_id)
+                  )
+
+                  const distanceKm = idx > 0 ? (event.distance_from_previous_km ?? null) : null
+
+                  return (
+                    <div key={idx}>
+                      {gapBefore && (
+                        <div className={`${styles.gap} ${styles[`gap_${gapBefore.severity}`]}`}>
+                          <div className={styles.gapLine} />
+                          <div className={styles.gapContent}>
+                            <span className={styles.gapLabel}>Gap ({gapBefore.severity})</span>
+                            {gapBefore.expected_events.length > 0 && (
+                              <span className={styles.gapExpected}>
+                                Expected: {gapBefore.expected_events.join(', ')}
+                              </span>
+                            )}
+                            {gapBefore.notes && (
+                              <span className={styles.gapNotes}>{gapBefore.notes}</span>
+                            )}
+                          </div>
+                        </div>
+                      )}
+
+                      {distanceKm !== null && (
+                        <div className={styles.distance}>
+                          <div className={styles.distanceLine} />
+                          <div className={styles.distanceLabel}>
+                            {Math.round(distanceKm).toLocaleString()} km
+                          </div>
+                        </div>
+                      )}
+
+                      <div className={styles.event}>
+                        <div className={styles.eventLeft}>
+                          <div className={styles.eventDate}>{event.date}</div>
+                          {event.date_certainty !== 'exact' && (
+                            <div className={styles.eventCertainty}>{event.date_certainty}</div>
+                          )}
+                        </div>
+                        <div className={styles.eventDot} />
+                        <div className={styles.eventRight}>
+                          <div className={styles.eventType}>{event.event_type}</div>
+                          {event.place && <div className={styles.eventPlace}>{event.place}</div>}
+                          {event.description && (
+                            <div className={styles.eventDesc}>{event.description}</div>
+                          )}
+                          {event.assertion_ids.length > 0 && (
+                            <div className={styles.eventLinks}>
+                              {event.assertion_ids.map((aid) => (
+                                <CrossLink key={aid} id={aid} />
+                              ))}
+                            </div>
+                          )}
+                          {event.conflict_ids && event.conflict_ids.length > 0 && (
+                            <div className={styles.conflictChip}>
+                              <span className={styles.conflictLabel}>
+                                Conflict ({event.conflict_ids.length})
+                              </span>
+                              {event.conflict_note && (
+                                <span className={styles.conflictNote}>
+                                  {' — '}
+                                  {event.conflict_note}
+                                </span>
+                              )}
+                              <div className={styles.conflictLinks}>
+                                {event.conflict_ids.map((cid) => (
+                                  <CrossLink key={cid} id={cid} />
+                                ))}
+                              </div>
+                            </div>
+                          )}
+                        </div>
+                      </div>
+
+                      {impossibility && (
+                        <div className={styles.impossibility}>
+                          <div className={styles.impossibilityDesc}>
+                            {impossibility.description}
+                          </div>
+                          <div className={styles.impossibilityLinks}>
+                            <CrossLink id={impossibility.event_1_assertion_id} label="Event 1" />
+                            <CrossLink id={impossibility.event_2_assertion_id} label="Event 2" />
+                          </div>
+                        </div>
+                      )}
+                    </div>
+                  )
+                })}
+              </div>
+            </div>
+          </Card>
+        )
+      })}
+    </div>
+  )
+}

--- a/eval/app/components/scenario/components/shared/Card.module.css
+++ b/eval/app/components/scenario/components/shared/Card.module.css
@@ -1,0 +1,92 @@
+.card {
+  background: var(--bg-card);
+  border: 1px solid var(--border-color);
+  border-radius: var(--border-radius);
+  padding: var(--spacing-lg) var(--spacing-xl);
+  margin-bottom: var(--spacing-md);
+  box-shadow: var(--card-shadow);
+  transition: box-shadow 0.2s ease, border-color 0.2s ease;
+}
+
+.card:hover {
+  box-shadow: var(--card-shadow-hover);
+  border-color: var(--border-color-strong);
+}
+
+.header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--spacing-sm);
+  cursor: pointer;
+  user-select: none;
+}
+
+.title {
+  font-family: var(--font-body);
+  font-weight: 500;
+  font-size: 0.93rem;
+  color: var(--text-primary);
+  flex: 1;
+  min-width: 0;
+  line-height: 1.4;
+}
+
+.badges {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+  flex-shrink: 0;
+}
+
+.chevron {
+  color: var(--text-tertiary);
+  font-size: 0.7rem;
+  width: 16px;
+  text-align: center;
+  transition: color 0.15s;
+}
+
+.card:hover .chevron {
+  color: var(--text-secondary);
+}
+
+.summary {
+  font-size: 0.87rem;
+  color: var(--text-secondary);
+  margin-top: 4px;
+  line-height: 1.55;
+}
+
+.body {
+  margin-top: var(--spacing-md);
+  padding-top: var(--spacing-md);
+  border-top: 1px solid var(--border-color);
+  font-size: 0.87rem;
+  color: var(--text-primary);
+  line-height: 1.6;
+  animation: fadeIn 0.15s ease-out;
+}
+
+.footer {
+  margin-top: var(--spacing-md);
+  padding-top: var(--spacing-sm);
+  border-top: 1px solid var(--border-color);
+  font-size: 0.78rem;
+  color: var(--text-tertiary);
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-sm);
+  align-items: center;
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(-2px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}

--- a/eval/app/components/scenario/components/shared/Card.tsx
+++ b/eval/app/components/scenario/components/shared/Card.tsx
@@ -1,0 +1,46 @@
+import { useState } from 'react'
+import type { ReactNode } from 'react'
+import { useResearchData } from '../../contexts/ResearchDataContext'
+import DetailPanel from './DetailPanel'
+import styles from './Card.module.css'
+
+interface CardProps {
+  id: string
+  title: ReactNode
+  badges?: ReactNode
+  summary?: ReactNode
+  children?: ReactNode
+  footer?: ReactNode
+  rawData?: unknown
+  className?: string
+}
+
+export default function Card({
+  id,
+  title,
+  badges,
+  summary,
+  children,
+  footer,
+  rawData,
+  className
+}: CardProps): React.JSX.Element {
+  const [expanded, setExpanded] = useState(false)
+  const { devMode } = useResearchData()
+
+  return (
+    <div id={id} className={`${styles.card} ${className ?? ''}`}>
+      <div className={styles.header} onClick={() => setExpanded(!expanded)}>
+        <div className={styles.title}>{title}</div>
+        <div className={styles.badges}>
+          {badges}
+          <span className={styles.chevron}>{expanded ? '▾' : '▸'}</span>
+        </div>
+      </div>
+      {summary && <div className={styles.summary}>{summary}</div>}
+      {expanded && children && <div className={styles.body}>{children}</div>}
+      {expanded && footer && <div className={styles.footer}>{footer}</div>}
+      {expanded && devMode && rawData != null ? <DetailPanel data={rawData} /> : null}
+    </div>
+  )
+}

--- a/eval/app/components/scenario/components/shared/CrossLink.module.css
+++ b/eval/app/components/scenario/components/shared/CrossLink.module.css
@@ -1,0 +1,18 @@
+.crossLink {
+  display: inline;
+  background: none;
+  border: none;
+  color: var(--text-link);
+  font-family: var(--font-mono);
+  font-size: 0.82em;
+  padding: 0;
+  text-decoration: none;
+  border-bottom: 1px dotted var(--text-link);
+  transition: all 0.15s ease;
+}
+
+.crossLink:hover {
+  color: var(--accent-gold);
+  border-bottom-color: var(--accent-gold);
+  border-bottom-style: solid;
+}

--- a/eval/app/components/scenario/components/shared/CrossLink.tsx
+++ b/eval/app/components/scenario/components/shared/CrossLink.tsx
@@ -1,0 +1,19 @@
+import styles from './CrossLink.module.css'
+
+interface CrossLinkProps {
+  id: string
+  label?: string
+}
+
+// In the desktop app this navigated between sections. In the eval scoring
+// viewer the scenario is shown as one read-only stack, so cross-links are
+// rendered as plain inline references (the id, or a supplied label). Kept
+// as a component so the lifted sections need no edits; re-enabling
+// navigation later only touches this file.
+export default function CrossLink({ id, label }: CrossLinkProps): React.JSX.Element {
+  return (
+    <span className={styles.crossLink} title={id}>
+      {label ?? id}
+    </span>
+  )
+}

--- a/eval/app/components/scenario/components/shared/DetailPanel.module.css
+++ b/eval/app/components/scenario/components/shared/DetailPanel.module.css
@@ -1,0 +1,36 @@
+.panel {
+  margin-top: var(--spacing-md);
+  padding-top: var(--spacing-sm);
+  border-top: 1px dashed var(--border-color);
+  animation: fadeIn 0.15s ease-out;
+}
+
+.label {
+  font-family: var(--font-mono);
+  font-size: 0.65rem;
+  font-weight: 500;
+  color: var(--text-tertiary);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  margin-bottom: var(--spacing-xs);
+}
+
+.code {
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  line-height: 1.5;
+  color: var(--text-secondary);
+  background: var(--bg-code);
+  border: 1px solid var(--border-color);
+  border-radius: var(--border-radius-sm);
+  padding: var(--spacing-sm) var(--spacing-md);
+  overflow-x: auto;
+  max-height: 300px;
+  overflow-y: auto;
+  white-space: pre;
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}

--- a/eval/app/components/scenario/components/shared/DetailPanel.tsx
+++ b/eval/app/components/scenario/components/shared/DetailPanel.tsx
@@ -1,0 +1,14 @@
+import styles from './DetailPanel.module.css'
+
+interface DetailPanelProps {
+  data: unknown
+}
+
+export default function DetailPanel({ data }: DetailPanelProps): React.JSX.Element {
+  return (
+    <div className={styles.panel}>
+      <div className={styles.label}>JSON</div>
+      <pre className={styles.code}>{JSON.stringify(data, null, 2)}</pre>
+    </div>
+  )
+}

--- a/eval/app/components/scenario/components/shared/PersonCard.module.css
+++ b/eval/app/components/scenario/components/shared/PersonCard.module.css
@@ -1,0 +1,57 @@
+.personCard {
+  padding: var(--spacing-lg);
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: var(--border-radius);
+  transition: border-color 0.15s;
+}
+
+.personCard:hover {
+  border-color: var(--border-color-strong);
+}
+
+.name {
+  font-family: var(--font-display);
+  font-weight: 600;
+  font-size: 1.15rem;
+  color: var(--text-primary);
+  letter-spacing: -0.01em;
+}
+
+.relationship {
+  font-size: 0.78rem;
+  color: var(--accent-gold-strong);
+  margin-top: 2px;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.facts {
+  margin-top: var(--spacing-sm);
+  font-size: 0.87rem;
+  color: var(--text-secondary);
+  display: flex;
+  gap: var(--spacing-lg);
+  flex-wrap: wrap;
+}
+
+.fact {
+  white-space: nowrap;
+}
+
+.meta {
+  margin-top: var(--spacing-xs);
+  font-size: 0.72rem;
+  color: var(--text-tertiary);
+  font-variant-numeric: tabular-nums;
+}
+
+.ark {
+  color: var(--accent-gold-strong);
+  text-decoration: none;
+}
+
+.ark:hover {
+  text-decoration: underline;
+}

--- a/eval/app/components/scenario/components/shared/PersonCard.tsx
+++ b/eval/app/components/scenario/components/shared/PersonCard.tsx
@@ -1,0 +1,52 @@
+import type { GedcomxPerson } from '../../lib/schema'
+import { getPreferredName, getPrimaryFact } from '../../lib/schema'
+import styles from './PersonCard.module.css'
+
+interface PersonCardProps {
+  person: GedcomxPerson
+  relationship?: string
+}
+
+export default function PersonCard({ person, relationship }: PersonCardProps): React.JSX.Element {
+  const name = getPreferredName(person)
+  const birth = getPrimaryFact(person, 'Birth')
+  const death = getPrimaryFact(person, 'Death')
+
+  const handleArkClick = (e: React.MouseEvent<HTMLAnchorElement>): void => {
+    e.preventDefault()
+    if (person.ark) window.open(person.ark, '_blank', 'noopener,noreferrer')
+  }
+
+  return (
+    <div className={styles.personCard}>
+      <div className={styles.name}>{name}</div>
+      {relationship && <div className={styles.relationship}>{relationship}</div>}
+      <div className={styles.facts}>
+        {birth && (
+          <span className={styles.fact}>
+            b. {birth.date ?? '?'}
+            {birth.place ? `, ${birth.place}` : ''}
+          </span>
+        )}
+        {death && (
+          <span className={styles.fact}>
+            d. {death.date ?? '?'}
+            {death.place ? `, ${death.place}` : ''}
+          </span>
+        )}
+        {!birth && !death && <span className={styles.fact}>No facts recorded</span>}
+      </div>
+      <div className={styles.meta}>
+        {person.gender} · {person.facts?.length ?? 0} facts
+        {person.ark && (
+          <>
+            {' · '}
+            <a href={person.ark} onClick={handleArkClick} className={styles.ark} title={person.ark}>
+              View on FamilySearch
+            </a>
+          </>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/eval/app/components/scenario/components/shared/StatusBadge.module.css
+++ b/eval/app/components/scenario/components/shared/StatusBadge.module.css
@@ -1,0 +1,41 @@
+.badge {
+  display: inline-block;
+  padding: 1px 8px;
+  border-radius: 3px;
+  font-family: var(--font-body);
+  font-size: 0.7rem;
+  font-weight: 500;
+  text-transform: capitalize;
+  white-space: nowrap;
+  letter-spacing: 0.02em;
+}
+
+.green {
+  background: var(--badge-green-bg);
+  color: var(--badge-green-text);
+}
+
+.amber {
+  background: var(--badge-amber-bg);
+  color: var(--badge-amber-text);
+}
+
+.red {
+  background: var(--badge-red-bg);
+  color: var(--badge-red-text);
+}
+
+.blue {
+  background: var(--badge-blue-bg);
+  color: var(--badge-blue-text);
+}
+
+.gray {
+  background: var(--badge-gray-bg);
+  color: var(--badge-gray-text);
+}
+
+.purple {
+  background: var(--badge-purple-bg);
+  color: var(--badge-purple-text);
+}

--- a/eval/app/components/scenario/components/shared/StatusBadge.tsx
+++ b/eval/app/components/scenario/components/shared/StatusBadge.tsx
@@ -1,0 +1,68 @@
+import styles from './StatusBadge.module.css'
+
+type BadgeColor = 'green' | 'amber' | 'red' | 'blue' | 'gray' | 'purple'
+
+const statusColorMap: Record<string, BadgeColor> = {
+  // Question status
+  open: 'gray',
+  in_progress: 'amber',
+  exhaustive_declared: 'blue',
+  resolved: 'green',
+  // Plan status
+  active: 'amber',
+  completed: 'green',
+  superseded: 'gray',
+  // Plan item status
+  planned: 'gray',
+  skipped: 'gray',
+  // Log outcome
+  positive: 'green',
+  negative: 'red',
+  partial: 'amber',
+  error: 'red',
+  // Source classification
+  original: 'green',
+  derivative: 'amber',
+  authored: 'gray',
+  // Information quality
+  primary: 'green',
+  secondary: 'amber',
+  indeterminate: 'gray',
+  // Evidence type
+  direct: 'green',
+  indirect: 'amber',
+  // Conflict status
+  unresolved: 'red',
+  moot: 'gray',
+  // Hypothesis status
+  supported: 'green',
+  ruled_out: 'red',
+  // Proof tier
+  proved: 'green',
+  probable: 'blue',
+  possible: 'amber',
+  not_proved: 'gray',
+  disproved: 'red',
+  // Person evidence confidence
+  confident: 'green',
+  speculative: 'red',
+  // Conflict type
+  fact: 'purple',
+  identity: 'blue',
+  // Priority
+  high: 'red',
+  medium: 'amber',
+  low: 'gray'
+}
+
+interface StatusBadgeProps {
+  value: string
+  color?: BadgeColor
+}
+
+export default function StatusBadge({ value, color }: StatusBadgeProps): React.JSX.Element {
+  const resolvedColor = color ?? statusColorMap[value] ?? 'gray'
+  return (
+    <span className={`${styles.badge} ${styles[resolvedColor]}`}>{value.replace(/_/g, ' ')}</span>
+  )
+}

--- a/eval/app/components/scenario/contexts/ResearchDataContext.ts
+++ b/eval/app/components/scenario/contexts/ResearchDataContext.ts
@@ -1,0 +1,104 @@
+import { createContext, useContext } from 'react'
+import type { ResearchData, GedcomxData, SidecarFile } from '../lib/schema'
+
+export interface IndexEntry {
+  item: unknown
+  section: string
+}
+
+// Discriminated union — one source of truth for the sidecar drawer's
+// status. SidecarPanel renders via exhaustive switch; no ambiguous nulls.
+export type SidecarState =
+  | { status: 'closed' }
+  | { status: 'loading'; logId: string; focusPersonaId?: string }
+  | {
+      status: 'loaded'
+      logId: string
+      focusPersonaId?: string
+      payload: SidecarFile
+      lastMtime: number
+    }
+  | { status: 'missing'; logId: string }
+  | { status: 'error'; logId: string; error: string }
+
+export interface ResearchDataState {
+  research: ResearchData | null
+  gedcomx: GedcomxData | null
+  error: string | null
+  clearError: () => void
+  lastUpdated: Date | null
+  folderPath: string | null
+  devMode: boolean
+  setDevMode: (v: boolean) => void
+  getById: (id: string) => IndexEntry | null
+  selectFolder: () => Promise<void>
+  activeSection: string
+  setActiveSection: (section: string) => void
+  sidecar: SidecarState
+  openSidecar: (logId: string, focusPersonaId?: string) => void
+  closeSidecar: () => void
+  clearFocusPersona: () => void
+}
+
+export const ResearchDataContext = createContext<ResearchDataState | null>(null)
+
+export function buildIndex(
+  research: ResearchData | null,
+  gedcomx: GedcomxData | null
+): Map<string, IndexEntry> {
+  const map = new Map<string, IndexEntry>()
+  if (!research) return map
+
+  const sections: [string, unknown[]][] = [
+    ['questions', research.questions],
+    ['plans', research.plans],
+    ['log', research.log],
+    ['sources', research.sources],
+    ['assertions', research.assertions],
+    ['person_evidence', research.person_evidence],
+    ['conflicts', research.conflicts],
+    ['hypotheses', research.hypotheses],
+    ['timelines', research.timelines],
+    ['proof_summaries', research.proof_summaries]
+  ]
+
+  for (const [section, items] of sections) {
+    for (const item of items) {
+      const id = (item as { id?: string }).id
+      if (id) map.set(id, { item, section })
+    }
+  }
+
+  // Also index plan items (nested inside plans)
+  for (const plan of research.plans) {
+    for (const planItem of plan.items) {
+      map.set(planItem.id, { item: planItem, section: 'plan_items' })
+    }
+  }
+
+  // Index project
+  if (research.project?.id) {
+    map.set(research.project.id, { item: research.project, section: 'project' })
+  }
+
+  // Index GedcomX entities
+  if (gedcomx) {
+    for (const person of gedcomx.persons) {
+      map.set(person.id, { item: person, section: 'gedcomx_persons' })
+    }
+    for (const rel of gedcomx.relationships) {
+      map.set(rel.id, { item: rel, section: 'gedcomx_relationships' })
+    }
+    for (const src of gedcomx.sources) {
+      map.set(src.id, { item: src, section: 'gedcomx_sources' })
+    }
+  }
+
+  return map
+}
+
+export function useResearchData(): ResearchDataState {
+  const ctx = useContext(ResearchDataContext)
+  if (!ctx) throw new Error('useResearchData must be used within ResearchDataProvider')
+  return ctx
+}

--- a/eval/app/components/scenario/lib/index-by-log-entry.ts
+++ b/eval/app/components/scenario/lib/index-by-log-entry.ts
@@ -1,0 +1,16 @@
+// Reverse-lookup helper: replaces the removed LogEntry.captured_source_ids /
+// produced_assertion_ids fields. Sources and assertions now carry log_entry_id
+// and we derive the per-log groupings from that pointer.
+
+export function indexByLogEntry<T extends { log_entry_id?: string | null }>(
+  items: T[]
+): Map<string, T[]> {
+  const map = new Map<string, T[]>()
+  for (const item of items) {
+    if (!item.log_entry_id) continue
+    const list = map.get(item.log_entry_id) ?? []
+    list.push(item)
+    map.set(item.log_entry_id, list)
+  }
+  return map
+}

--- a/eval/app/components/scenario/lib/relationship-label.ts
+++ b/eval/app/components/scenario/lib/relationship-label.ts
@@ -1,0 +1,231 @@
+import type {
+  GedcomxPerson,
+  GedcomxRelationship,
+  GedcomxParentChildRelationship,
+  GedcomxCoupleRelationship
+} from './schema'
+import { getPreferredName, getPrimaryFact } from './schema'
+
+function capitalize(s: string): string {
+  return s.charAt(0).toUpperCase() + s.slice(1)
+}
+
+// Treat "Biological" as the implicit/default subtype — don't include it in display strings.
+function visibleSubtype(rel: GedcomxParentChildRelationship): string | null {
+  return rel.subtype && rel.subtype !== 'Biological' ? rel.subtype.toLowerCase() : null
+}
+
+export function parentChildLabel(
+  rel: GedcomxParentChildRelationship,
+  relativeName: string,
+  role: 'parent' | 'child'
+): string {
+  const subtype = visibleSubtype(rel)
+  if (role === 'parent') {
+    return subtype
+      ? `${capitalize(subtype)} parent of ${relativeName}`
+      : `Parent of ${relativeName}`
+  }
+  return subtype ? `${capitalize(subtype)} child of ${relativeName}` : `Child of ${relativeName}`
+}
+
+export function describeRelationship(rel: GedcomxRelationship, persons: GedcomxPerson[]): string {
+  const nameOf = (id: string): string => {
+    const p = persons.find((x) => x.id === id)
+    return p ? getPreferredName(p) : id
+  }
+  if (rel.type === 'ParentChild') {
+    const subtype = visibleSubtype(rel)
+    const prefix = subtype ? `${subtype} ` : ''
+    return `${nameOf(rel.parent)} → ${prefix}child ${nameOf(rel.child)}`
+  }
+  return `${nameOf(rel.person1)} ⇔ ${nameOf(rel.person2)}`
+}
+
+// ============================================================
+// Sidecar persons subview — relationship from primary's perspective
+// (used by SidecarResultCard to label each non-primary person)
+// ============================================================
+
+type Gender = 'Male' | 'Female' | 'Unknown' | string | undefined
+
+// GedcomX may emit gender as either a short string ("Male") or a URI form
+// ("http://gedcomx.org/Male"). Normalize to the short form.
+function normalizeGender(gender: Gender): 'Male' | 'Female' | 'Unknown' {
+  if (!gender) return 'Unknown'
+  const tail = gender.includes('/') ? (gender.split('/').pop() ?? '') : gender
+  if (tail === 'Male' || tail === 'Female') return tail
+  return 'Unknown'
+}
+
+function genderedWord(gender: Gender, male: string, female: string, neutral: string): string {
+  const g = normalizeGender(gender)
+  if (g === 'Male') return male
+  if (g === 'Female') return female
+  return neutral
+}
+
+function isParentChild(rel: GedcomxRelationship): rel is GedcomxParentChildRelationship {
+  return rel.type === 'ParentChild'
+}
+
+function isCouple(rel: GedcomxRelationship): rel is GedcomxCoupleRelationship {
+  return rel.type === 'Couple'
+}
+
+/**
+ * Describe `otherId`'s relationship to `primaryId` using the kinship
+ * vocabulary the sidecar viewer uses on person cards.
+ *
+ *   relationshipFromPerspective(primaryId, primaryId, ...) === 'Self'
+ *
+ * Resolves direct (1-hop) ParentChild + Couple, sibling-by-shared-parent,
+ * and 2-hop grandparent/grandchild. Falls back to 'Relative' when present
+ * in the payload but unreachable from the primary via these patterns.
+ *
+ * Gender words use the OTHER person's gender (Father, Wife, Son, ...).
+ * Adoptive / step / foster ParentChild subtypes prefix the gendered word
+ * (e.g. "Adoptive father").
+ */
+export function relationshipFromPerspective(
+  primaryId: string,
+  otherId: string,
+  otherGender: Gender,
+  relationships: GedcomxRelationship[]
+): string {
+  if (otherId === primaryId) return 'Self'
+
+  // 1-hop Couple
+  for (const rel of relationships.filter(isCouple)) {
+    const pair = [rel.person1, rel.person2]
+    if (pair.includes(primaryId) && pair.includes(otherId)) {
+      return genderedWord(otherGender, 'Husband', 'Wife', 'Spouse')
+    }
+  }
+
+  const pcRels = relationships.filter(isParentChild)
+
+  // 1-hop ParentChild: other is parent of primary
+  for (const rel of pcRels) {
+    if (rel.parent === otherId && rel.child === primaryId) {
+      const subtype = visibleSubtype(rel)
+      const word = genderedWord(otherGender, 'Father', 'Mother', 'Parent')
+      return subtype ? `${capitalize(subtype)} ${word.toLowerCase()}` : word
+    }
+  }
+
+  // 1-hop ParentChild: other is child of primary
+  for (const rel of pcRels) {
+    if (rel.parent === primaryId && rel.child === otherId) {
+      const subtype = visibleSubtype(rel)
+      const word = genderedWord(otherGender, 'Son', 'Daughter', 'Child')
+      return subtype ? `${capitalize(subtype)} ${word.toLowerCase()}` : word
+    }
+  }
+
+  // Sibling (shared parent): primary and other both children of same parent
+  const primaryParents = new Set(pcRels.filter((r) => r.child === primaryId).map((r) => r.parent))
+  if (primaryParents.size > 0) {
+    for (const rel of pcRels) {
+      if (rel.child === otherId && primaryParents.has(rel.parent)) {
+        return genderedWord(otherGender, 'Brother', 'Sister', 'Sibling')
+      }
+    }
+  }
+
+  // 2-hop ParentChild: grandparent (other is parent of primary's parent)
+  for (const parentRel of pcRels.filter((r) => r.child === primaryId)) {
+    for (const grandRel of pcRels) {
+      if (grandRel.child === parentRel.parent && grandRel.parent === otherId) {
+        return genderedWord(otherGender, 'Grandfather', 'Grandmother', 'Grandparent')
+      }
+    }
+  }
+
+  // 2-hop ParentChild: grandchild (other is child of primary's child)
+  for (const childRel of pcRels.filter((r) => r.parent === primaryId)) {
+    for (const grandRel of pcRels) {
+      if (grandRel.parent === childRel.child && grandRel.child === otherId) {
+        return genderedWord(otherGender, 'Grandson', 'Granddaughter', 'Grandchild')
+      }
+    }
+  }
+
+  return 'Relative'
+}
+
+// ============================================================
+// Person ordering inside a record-search result
+// ============================================================
+
+type Bucket = 'primary' | 'spouse' | 'child' | 'parent' | 'sibling' | 'other'
+
+function bucketFor(label: string): Bucket {
+  if (label === 'Self') return 'primary'
+  if (label === 'Husband' || label === 'Wife' || label === 'Spouse') return 'spouse'
+  if (label === 'Son' || label === 'Daughter' || label === 'Child') return 'child'
+  if (
+    label === 'Father' ||
+    label === 'Mother' ||
+    label === 'Parent' ||
+    label.endsWith(' father') ||
+    label.endsWith(' mother') ||
+    label.endsWith(' parent')
+  )
+    return 'parent'
+  if (label === 'Brother' || label === 'Sister' || label === 'Sibling') return 'sibling'
+  return 'other'
+}
+
+const BUCKET_ORDER: Bucket[] = ['primary', 'spouse', 'child', 'parent', 'sibling', 'other']
+
+function parseBirthYear(person: GedcomxPerson): number | null {
+  const birth = getPrimaryFact(person, 'Birth')
+  if (!birth?.date) return null
+  // Accept "1840", "~1840", "1840-03-12", "Abt 1840"
+  const m = birth.date.match(/(\d{4})/)
+  return m ? parseInt(m[1], 10) : null
+}
+
+/**
+ * Order a record's persons from the primary's perspective.
+ *
+ *   PRIMARY -> spouse(s) -> children (eldest first by Birth) -> parents
+ *           -> siblings -> other
+ *
+ * Persons without a discoverable relationship are bucketed as "other"
+ * and emitted in payload order. Children with no Birth fact retain
+ * payload order (eldest-first is a hint, not a guarantee).
+ */
+export function orderPersons(
+  persons: GedcomxPerson[],
+  primaryId: string,
+  relationships: GedcomxRelationship[]
+): GedcomxPerson[] {
+  const buckets: Record<Bucket, GedcomxPerson[]> = {
+    primary: [],
+    spouse: [],
+    child: [],
+    parent: [],
+    sibling: [],
+    other: []
+  }
+
+  for (const p of persons) {
+    const label = relationshipFromPerspective(primaryId, p.id, p.gender, relationships)
+    buckets[bucketFor(label)].push(p)
+  }
+
+  // Eldest-first within children. Missing Birth dates sort last,
+  // preserving payload order among them.
+  buckets.child.sort((a, b) => {
+    const ya = parseBirthYear(a)
+    const yb = parseBirthYear(b)
+    if (ya === null && yb === null) return 0
+    if (ya === null) return 1
+    if (yb === null) return -1
+    return ya - yb
+  })
+
+  return BUCKET_ORDER.flatMap((b) => buckets[b])
+}

--- a/eval/app/components/scenario/lib/schema.ts
+++ b/eval/app/components/scenario/lib/schema.ts
@@ -1,0 +1,442 @@
+// TypeScript types mirroring docs/research-schema-spec.md and docs/simplified-gedcomx-spec.md
+
+// ============================================================
+// research.json enums
+// ============================================================
+
+export type QuestionStatus = 'open' | 'in_progress' | 'exhaustive_declared' | 'resolved'
+export type PlanStatus = 'active' | 'completed' | 'superseded'
+export type PlanItemStatus = 'planned' | 'in_progress' | 'completed' | 'skipped'
+export type LogOutcome = 'positive' | 'negative' | 'partial' | 'error'
+export type SourceClassification = 'original' | 'derivative' | 'authored'
+export type InformationQuality = 'primary' | 'secondary' | 'indeterminate'
+export type EvidenceType = 'direct' | 'indirect' | 'negative'
+export type ConflictType = 'fact' | 'identity'
+export type ConflictStatus = 'unresolved' | 'resolved' | 'moot'
+export type HypothesisStatus = 'active' | 'supported' | 'ruled_out'
+export type ProofTier = 'proved' | 'probable' | 'possible' | 'not_proved' | 'disproved'
+export type ProofVehicle = 'statement' | 'summary' | 'argument'
+export type PersonEvidenceConfidence = 'confident' | 'probable' | 'speculative'
+export type ProjectStatus = 'active' | 'paused' | 'completed'
+export type Priority = 'high' | 'medium' | 'low'
+
+export type SelectionBasis =
+  | 'timeline_gap'
+  | 'unresolved_conflict'
+  | 'fan_pivot'
+  | 'hypothesis_test'
+  | 'objective_decomposition'
+  | 'new_evidence'
+  | 'record_found_incidentally'
+  | 'user_directed'
+
+export type InformantProximity =
+  | 'self'
+  | 'witness'
+  | 'household_member'
+  | 'family_not_present'
+  | 'official_duty'
+  | 'unknown'
+
+export type DateCertainty =
+  | 'exact'
+  | 'approximate'
+  | 'estimated'
+  | 'calculated'
+  | 'before'
+  | 'after'
+  | 'between'
+
+export type ExperienceLevel = 'novice' | 'intermediate' | 'experienced' | 'professional'
+
+export type Subscription =
+  | 'Ancestry'
+  | 'MyHeritage'
+  | 'FindMyPast'
+  | 'Newspapers.com'
+  | 'GenealogyBank'
+  | 'FindAGrave-Plus'
+  | 'other'
+  | 'none'
+
+// ============================================================
+// research.json section types
+// ============================================================
+
+export interface Project {
+  id: string
+  objective: string
+  subject_person_ids: string[] | null
+  status: ProjectStatus
+  created: string
+  updated: string
+}
+
+export interface ResearcherProfile {
+  experience_level?: ExperienceLevel
+  subscriptions?: Subscription[]
+  narration_guidance?: string | null
+}
+
+export interface StopCriteria {
+  goal_alignment: string
+  repository_breadth: string
+  original_substitution: string
+  independent_verification: string
+  evidence_class: string
+  conflict_resolution: string
+  overturn_risk: string
+}
+
+export interface ExhaustiveDeclaration {
+  declared: boolean
+  justification: string | null
+  log_entry_ids: string[]
+  stop_criteria: StopCriteria | null
+}
+
+export interface Question {
+  id: string
+  question: string
+  rationale: string
+  selection_basis: SelectionBasis
+  priority: Priority
+  status: QuestionStatus
+  depends_on: string[]
+  unblocks: string[]
+  created: string
+  resolved: string | null
+  resolution_assertion_ids: string[]
+  exhaustive_declaration: ExhaustiveDeclaration
+}
+
+export interface PlanItem {
+  id: string
+  sequence: number
+  record_type: string
+  jurisdiction: string
+  date_range: string
+  repository: string
+  rationale: string
+  fallback_for: string | null
+  status: PlanItemStatus
+}
+
+export interface Plan {
+  id: string
+  question_id: string
+  status: PlanStatus
+  created: string
+  items: PlanItem[]
+}
+
+export interface ExternalSite {
+  site: string
+  url_generated: string
+  capture_received: boolean
+  capture_filename: string | null
+}
+
+export interface LogEntry {
+  id: string
+  plan_item_id: string | null
+  performed: string
+  tool: string
+  query: Record<string, unknown>
+  outcome: LogOutcome
+  results_examined: number
+  results_ref?: string | null
+  results_available?: number | null
+  notes: string | null
+  external_site: ExternalSite | null
+}
+
+export interface CitationDetail {
+  who: string
+  what: string
+  when_created: string
+  when_accessed: string
+  where: string
+  where_within: string
+}
+
+export interface Source {
+  id: string
+  gedcomx_source_description_id: string
+  citation: string
+  citation_detail: CitationDetail
+  source_classification: SourceClassification
+  repository: string
+  access_date: string
+  url: string | null
+  url_archived: string | null
+  notes: string | null
+  log_entry_id?: string | null
+  transcription?: string | null
+}
+
+export interface Assertion {
+  id: string
+  source_id: string
+  record_id: string
+  record_role: string
+  fact_type: string
+  value: string
+  structured_value: Record<string, unknown> | null
+  date: string | null
+  date_certainty: DateCertainty | null
+  place: string | null
+  information_quality: InformationQuality
+  informant: string
+  informant_proximity: InformantProximity
+  informant_bias_notes: string | null
+  evidence_type: EvidenceType
+  log_entry_id: string | null
+  record_persona_id?: string | null
+  extracted_for_question_ids: string[]
+}
+
+export interface PersonEvidence {
+  id: string
+  assertion_id: string
+  person_id: string
+  confidence: PersonEvidenceConfidence
+  rationale: string
+  match_score: number | null
+  created: string
+  superseded_by: string | null
+}
+
+export interface Conflict {
+  id: string
+  conflict_type: ConflictType
+  description: string
+  disputed_attribute: string | null
+  identity_question: string | null
+  competing_assertion_ids: string[]
+  independence_analysis: string | null
+  weighing_analysis: string | null
+  preferred_assertion_id: string | null
+  resolution_rationale: string | null
+  status: ConflictStatus
+  blocks_question_ids: string[]
+}
+
+export interface Hypothesis {
+  id: string
+  claim: string
+  status: HypothesisStatus
+  supporting_assertion_ids: string[]
+  contradicting_assertion_ids: string[]
+  ruled_out: boolean
+  ruled_out_reason: string | null
+  notes: string | null
+  related_question_ids: string[]
+}
+
+export interface TimelineEvent {
+  date: string
+  date_certainty: string
+  event_type: string
+  place: string | null
+  place_id?: string | null
+  description: string
+  assertion_ids: string[]
+  distance_from_previous_km?: number | null
+  conflict_ids?: string[] | null
+  conflict_note?: string | null
+}
+
+export interface TimelineGap {
+  start: string
+  end: string
+  expected_events: string[]
+  severity: 'high' | 'medium' | 'low'
+  notes?: string | null
+}
+
+export interface TimelineImpossibility {
+  description: string
+  event_1_assertion_id: string
+  event_2_assertion_id: string
+}
+
+export interface Timeline {
+  id: string
+  label: string
+  hypothesis_id: string | null
+  person_ids: string[]
+  generated: string
+  events: TimelineEvent[]
+  gaps: TimelineGap[]
+  impossibilities: TimelineImpossibility[]
+}
+
+export interface ProofSummary {
+  id: string
+  question_id: string
+  tier: ProofTier
+  vehicle: ProofVehicle
+  supporting_assertion_ids: string[]
+  resolved_conflict_ids: string[]
+  exhaustive_search_summary: string
+  narrative_markdown: string
+}
+
+export interface ResearchData {
+  project: Project
+  researcher_profile?: ResearcherProfile
+  questions: Question[]
+  plans: Plan[]
+  log: LogEntry[]
+  sources: Source[]
+  assertions: Assertion[]
+  person_evidence: PersonEvidence[]
+  conflicts: Conflict[]
+  hypotheses: Hypothesis[]
+  timelines: Timeline[]
+  proof_summaries: ProofSummary[]
+}
+
+// ============================================================
+// tree.gedcomx.json types (simplified GedcomX)
+// ============================================================
+
+export interface GedcomxSourceRef {
+  ref: string
+  page?: string
+  quality?: number
+}
+
+export interface GedcomxName {
+  id: string
+  preferred?: boolean
+  given: string
+  surname: string
+  type?: string
+  sources?: GedcomxSourceRef[]
+}
+
+export interface GedcomxFact {
+  id: string
+  type: string
+  primary?: boolean
+  date?: string
+  place?: string
+  sources?: GedcomxSourceRef[]
+}
+
+export interface GedcomxPerson {
+  id: string
+  ark?: string
+  gender: 'Male' | 'Female' | 'Unknown'
+  names: GedcomxName[]
+  facts?: GedcomxFact[]
+}
+
+export interface GedcomxParentChildRelationship {
+  id: string
+  type: 'ParentChild'
+  parent: string
+  child: string
+  subtype?: string
+  notes?: string[]
+  sources?: GedcomxSourceRef[]
+}
+
+export interface GedcomxCoupleRelationship {
+  id: string
+  type: 'Couple'
+  person1: string
+  person2: string
+  facts?: GedcomxFact[]
+  notes?: string[]
+  sources?: GedcomxSourceRef[]
+}
+
+export type GedcomxRelationship = GedcomxParentChildRelationship | GedcomxCoupleRelationship
+
+export interface GedcomxSource {
+  id: string
+  title: string
+  citation?: string
+  author?: string
+  url?: string
+}
+
+export interface GedcomxData {
+  persons: GedcomxPerson[]
+  relationships: GedcomxRelationship[]
+  sources: GedcomxSource[]
+}
+
+// ============================================================
+// Sidecar payloads (results/log_NNN.json) — per research-schema-spec §5.4.1
+// ============================================================
+
+export interface TreeMatch {
+  personId: string
+  personName: string
+  treeId?: string
+  ark?: string
+}
+
+export interface RecordSearchResult {
+  primaryId: string
+  personId?: string
+  personName?: string
+  score?: number
+  arkUrl?: string
+  collectionTitle?: string
+  recordTitle?: string
+  birthDate?: string
+  birthPlace?: string
+  events?: Array<{ type?: string; date?: string; place?: string }>
+  gedcomx?: {
+    persons: GedcomxPerson[]
+    relationships: GedcomxRelationship[]
+  }
+  treeMatches?: TreeMatch[]
+}
+
+export interface FulltextSearchResult {
+  id: string
+  collectionTitle?: string
+  recordType?: string
+  recordPlace?: string
+  textDocument?: string
+  names?: string[]
+  places?: string[]
+  highlightTerms?: string[]
+}
+
+export type SidecarTool = 'record_search' | 'fulltext_search' | string
+
+export interface SidecarFile {
+  log_id: string
+  tool: SidecarTool
+  retrieved: string
+  returned_count: number
+  payload: {
+    results?: Array<RecordSearchResult | FulltextSearchResult>
+    [key: string]: unknown
+  }
+}
+
+// ============================================================
+// Helpers
+// ============================================================
+
+export function getPreferredName(person: GedcomxPerson): string {
+  const preferred = person.names.find((n) => n.preferred) ?? person.names[0]
+  if (!preferred) return '(unknown)'
+  const parts = [preferred.given, preferred.surname].filter(Boolean)
+  return parts.length > 0 ? parts.join(' ') : '(unknown)'
+}
+
+export function getPrimaryFact(person: GedcomxPerson, type: string): GedcomxFact | undefined {
+  return (
+    person.facts?.find((f) => f.type === type && f.primary) ??
+    person.facts?.find((f) => f.type === type)
+  )
+}

--- a/eval/app/components/scenario/scenario-tokens.module.css
+++ b/eval/app/components/scenario/scenario-tokens.module.css
@@ -1,0 +1,91 @@
+/*
+ * Design tokens for the lifted scenario viewer, copied from
+ * cowork-genealogy-ui/src/renderer/src/styles/global.css but RE-SCOPED from
+ * :root to `.scenarioViewer` so they cascade only into the scenario subtree
+ * and never leak into the surrounding Mantine scoring UI. Light palette only;
+ * dark mode is deferred. Fonts fall back to the system stack — the desktop
+ * webfonts (Cormorant / IBM Plex) are not loaded here.
+ */
+.scenarioViewer {
+  /* Typography */
+  --font-display: 'Cormorant', 'Georgia', 'Times New Roman', serif;
+  --font-body: 'IBM Plex Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  --font-mono: 'IBM Plex Mono', ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+
+  /* Paper & ink */
+  --bg-primary: #faf8f4;
+  --bg-secondary: #f3efe8;
+  --bg-card: #fefdfb;
+  --bg-hover: #f0ece4;
+  --bg-sidebar: #f5f1eb;
+  --bg-header: #faf8f4;
+  --bg-welcome: #f7f4ee;
+  --bg-code: #f0ece4;
+
+  /* Ink tones */
+  --text-primary: #2c2419;
+  --text-secondary: #6b6055;
+  --text-tertiary: #9a9188;
+  --text-link: #8b5e34;
+
+  /* Warm borders */
+  --border-color: #e2dbd0;
+  --border-color-strong: #cfc6b8;
+  --border-radius: 6px;
+  --border-radius-sm: 3px;
+
+  /* Spacing */
+  --spacing-xs: 4px;
+  --spacing-sm: 8px;
+  --spacing-md: 12px;
+  --spacing-lg: 16px;
+  --spacing-xl: 24px;
+  --spacing-xxl: 32px;
+  --spacing-3xl: 48px;
+
+  /* Status badges */
+  --badge-green-bg: #dce8d4;
+  --badge-green-text: #3d6b2e;
+  --badge-amber-bg: #f0e0c0;
+  --badge-amber-text: #8b6914;
+  --badge-red-bg: #ebd4d0;
+  --badge-red-text: #963b30;
+  --badge-blue-bg: #d4dde8;
+  --badge-blue-text: #3d5f8b;
+  --badge-gray-bg: #e5e0d8;
+  --badge-gray-text: #7a7267;
+  --badge-purple-bg: #ddd4e8;
+  --badge-purple-text: #6b4f8b;
+
+  /* Pipeline */
+  --stage-completed: #6b8f58;
+  --stage-active: #c4943c;
+  --stage-pending: #d4cfc6;
+
+  /* Conflict highlight */
+  --conflict-unresolved-bg: #f5ece8;
+  --conflict-unresolved-border: #d4a898;
+
+  /* Card */
+  --card-shadow: 0 1px 3px rgba(44, 36, 25, 0.06), 0 0 0 1px rgba(44, 36, 25, 0.04);
+  --card-shadow-hover: 0 2px 8px rgba(44, 36, 25, 0.1), 0 0 0 1px rgba(44, 36, 25, 0.06);
+
+  /* Sidebar */
+  --sidebar-width: 240px;
+  --sidebar-active-bg: #ebe5db;
+
+  /* Header */
+  --header-height: 52px;
+
+  /* Decorative */
+  --accent-gold: #b8860b;
+  --accent-gold-soft: rgba(184, 134, 11, 0.12);
+  --accent-gold-strong: #8a6608;
+  --accent-burgundy: #7b2d3b;
+  --divider-ornament: #cfc6b8;
+
+  /* Apply the base paper/ink/typography to the viewer root itself. */
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  font-family: var(--font-body);
+}

--- a/eval/app/lib/scenarioSnapshot.ts
+++ b/eval/app/lib/scenarioSnapshot.ts
@@ -1,0 +1,42 @@
+/**
+ * Pull a scenario's research.json + tree.gedcomx.json out of a run-log
+ * snapshot so the score-review screen can render the scenario offline.
+ *
+ * The run-log snapshot bundles every referenced scenario's files (see
+ * docs/specs/schemas/run-log.schema.json `snapshot`), keyed by repo-relative
+ * path under `eval/fixtures/scenarios/<name>/`. No network/API call is needed.
+ */
+
+export interface ScenarioSnapshotData {
+  research: Record<string, unknown>;
+  /** null when the scenario has no tree.gedcomx.json or it failed to parse. */
+  gedcomx: Record<string, unknown> | null;
+}
+
+function tryParseObject(s: string | undefined): Record<string, unknown> | null {
+  if (!s) return null;
+  try {
+    const parsed = JSON.parse(s);
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Returns the parsed research + gedcomx for `scenarioName`, or null when the
+ * test has no scenario or its research.json is missing/unparseable. A missing
+ * tree.gedcomx.json is tolerated (gedcomx: null) — the viewer degrades to the
+ * research-only sections.
+ */
+export function findScenarioData(
+  snapshot: Record<string, string>,
+  scenarioName: string,
+): ScenarioSnapshotData | null {
+  const base = `eval/fixtures/scenarios/${scenarioName}`;
+  const research = tryParseObject(snapshot[`${base}/research.json`]);
+  if (!research) return null;
+  return { research, gedcomx: tryParseObject(snapshot[`${base}/tree.gedcomx.json`]) };
+}

--- a/eval/app/tests/unit/scenarioSnapshot.test.ts
+++ b/eval/app/tests/unit/scenarioSnapshot.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { findScenarioData } from '@/lib/scenarioSnapshot';
+
+const SCEN = 'mid-research-flynn';
+const research = JSON.stringify({ project: { objective: 'Find Patrick' }, questions: [] });
+const tree = JSON.stringify({ persons: [{ id: 'I1' }], relationships: [] });
+
+function snap(extra: Record<string, string> = {}): Record<string, string> {
+  return {
+    [`eval/fixtures/scenarios/${SCEN}/research.json`]: research,
+    [`eval/fixtures/scenarios/${SCEN}/tree.gedcomx.json`]: tree,
+    'plugin/skills/citation/SKILL.md': '# unrelated',
+    ...extra,
+  };
+}
+
+describe('findScenarioData', () => {
+  it('parses research + gedcomx for a scenario present in the snapshot', () => {
+    const out = findScenarioData(snap(), SCEN);
+    expect(out).not.toBeNull();
+    expect((out!.research.project as { objective: string }).objective).toBe('Find Patrick');
+    expect(Array.isArray((out!.gedcomx as { persons: unknown[] }).persons)).toBe(true);
+  });
+
+  it('returns null when the scenario is not in the snapshot', () => {
+    expect(findScenarioData(snap(), 'no-such-scenario')).toBeNull();
+  });
+
+  it('returns null when research.json is missing (cannot orient without it)', () => {
+    const s = snap();
+    delete s[`eval/fixtures/scenarios/${SCEN}/research.json`];
+    expect(findScenarioData(s, SCEN)).toBeNull();
+  });
+
+  it('tolerates a missing tree.gedcomx.json (gedcomx: null)', () => {
+    const s = snap();
+    delete s[`eval/fixtures/scenarios/${SCEN}/tree.gedcomx.json`];
+    const out = findScenarioData(s, SCEN);
+    expect(out).not.toBeNull();
+    expect(out!.gedcomx).toBeNull();
+  });
+
+  it('returns null on unparseable research.json rather than throwing', () => {
+    const out = findScenarioData(
+      { [`eval/fixtures/scenarios/${SCEN}/research.json`]: '{not json' },
+      SCEN,
+    );
+    expect(out).toBeNull();
+  });
+});


### PR DESCRIPTION
Genealogists correcting LLM scores need to see what was researched (the scenario) and what the mocked tools returned (fixtures) to judge whether a score is right. Both already live in the run-log snapshot, so this is read-only and offline.

- Third pane is now tabbed Trace | Scenario. The Scenario tab renders a read-only research-project viewer (Project Overview + person cards, Questions, Plans, Research Log, Sources, Assertions, Person Evidence, Conflicts, Hypotheses, Timelines, Proof Summaries). The tab appears only when the test references a scenario whose files are in the snapshot. Non-blocking so the grades pane stays visible while reviewing.
- Each tool call's fixture response now renders in the shared JsonViewer (collapsed) instead of a raw pre block.

The viewer is lifted from the cowork-genealogy-ui desktop app (not shared
- the two apps evolve independently). Sections are copied with their CSS Modules; design tokens are re-scoped from :root to .scenarioViewer so they cannot leak into the Mantine chrome. A thin ScenarioDataProvider feeds the lifted sections from snapshot JSON instead of Electron IPC. Cross-links render as plain text, the research-log "view results" sidecar button is dropped (sidecars aren't snapshotted), and ProofSummaries uses the existing MarkdownViewer instead of react-markdown.

Plan: docs/plan/eval-scoring-scenario-context.md
Verified: tsc + eslint clean, 111 unit tests pass, visually checked both tabs via browser (no console errors, tokens scoped correctly).

## Summary

<!-- 1-3 bullets describing what changed and why. -->

## Test plan

- [ ] I ran `scripts/test.sh` and it passed.
- [ ] For every skill whose files I changed (SKILL.md, scenarios, fixtures,
      tests, or supporting MCP/harness code), I ran `RunTests.bat <skill>`
      and committed an all-pass runlog under `eval/runlogs/unit/<skill>/`.
