### PR TITLE
Batch script fixes

### DIFF
--- a/eval/JUNIOR-WALKTHROUGH.md
+++ b/eval/JUNIOR-WALKTHROUGH.md
@@ -70,8 +70,35 @@ You'll install three things outside the repo, then run a single batch file insid
    Either way, the script will:
    - Install `uv` (the Python package manager) via PowerShell.
    - Run `npm install` in `eval/app/` (installs the CRUD UI's dependencies).
+   - Run `npm install` and `npm run build` in `mcp-server/` (compiles the MCP server the harness loads).
    - Run `uv sync` in `eval/harness/` (installs Python dependencies and Python itself if needed).
    - Prompt you for your **Anthropic API key** — paste it in when asked. It gets saved to `eval/.env`.
+
+   ### If Setup.bat stops with `'uv' is not recognized`
+
+   You may see output like this near the end:
+
+   ```
+   Installing Python dependencies...
+   'uv' is not recognized as an internal or external command,
+   operable program or batch file.
+   ERROR: uv sync failed. Setup aborted.
+   Press any key to continue . . .
+   Terminate batch job (Y/N)?
+   ```
+
+   This is a known Windows quirk: the installer just added `uv` to your user `PATH`, but the current Command Prompt window started *before* that change, so it can't see `uv` yet. The fix is two steps:
+
+   1. Press any key to dismiss the prompt, then type `Y` and press Enter to terminate the batch job.
+   2. **Close the Command Prompt window entirely.** Open a fresh Command Prompt (or just double-click `Setup.bat` again from Explorer) and re-run Setup. The previously-completed steps (uv install, `npm install`) are no-ops the second time, and `uv sync` will now find `uv` and finish the job.
+
+   If a fresh window still says "not recognized," the installer didn't update your user PATH for some reason. Run this in the new window before re-running Setup:
+
+   ```
+   set Path=%USERPROFILE%\.local\bin;%Path%
+   ```
+
+   That prepends uv's install location for this one session. Then re-run Setup.bat.
 
 You only do all this once per machine. After this point, daily work uses `Start.bat` and `RunTests.bat` — see below.
 

--- a/eval/JUNIOR-WALKTHROUGH.md
+++ b/eval/JUNIOR-WALKTHROUGH.md
@@ -54,6 +54,8 @@ You'll install three things outside the repo, then run a single batch file insid
 
    **First — get your Anthropic API key.** `Setup.bat` asks for it partway through, so have it ready before you start. Get it from <https://console.anthropic.com/settings/keys> — use an existing key, or create a new one. It looks like `sk-ant-...`. ⚠️ A newly created key is shown **only once** — copy it right away and save it somewhere private (a password manager is ideal). If you lose it, you'll have to create another.
 
+   > **For your current assessment, you don't need a real API key.** When Setup gets to the "Paste your Anthropic API key" prompt, you can simply close the Command Prompt window — everything you need for the assessment was installed in the earlier steps.
+
    **Then — run the script.** Use **either** Option A (clickable) **or** Option B (terminal) — not both.
 
    **Option A — Explorer** (recommended if you don't use a terminal)

--- a/eval/RunTests.bat
+++ b/eval/RunTests.bat
@@ -13,6 +13,19 @@ if "%SKILL%"=="" (
 )
 
 echo.
+echo Building MCP server (picks up any code changes from the last git pull)...
+cd ..\mcp-server
+call npm run build
+if errorlevel 1 (
+  echo.
+  echo ERROR: MCP server build failed. Aborting test run.
+  cd ..\eval
+  pause
+  exit /b 1
+)
+cd ..\eval
+
+echo.
 echo Running tests for %SKILL%...
 echo.
 

--- a/eval/RunTests.bat
+++ b/eval/RunTests.bat
@@ -12,6 +12,15 @@ if "%SKILL%"=="" (
   exit /b 1
 )
 
+if not exist ..\mcp-server\node_modules\ (
+  echo.
+  echo ERROR: mcp-server dependencies are not installed.
+  echo The build step needs ..\mcp-server\node_modules to exist.
+  echo Please run Setup.bat once to install everything, then retry.
+  pause
+  exit /b 1
+)
+
 echo.
 echo Building MCP server (picks up any code changes from the last git pull)...
 cd ..\mcp-server

--- a/eval/Setup.bat
+++ b/eval/Setup.bat
@@ -38,6 +38,30 @@ if errorlevel 1 (
 cd ..
 
 echo.
+echo Installing MCP server dependencies...
+cd ..\mcp-server
+call npm install
+if errorlevel 1 (
+  echo.
+  echo ERROR: npm install in mcp-server failed. Setup aborted.
+  cd ..\eval
+  pause
+  exit /b 1
+)
+
+echo.
+echo Building MCP server...
+call npm run build
+if errorlevel 1 (
+  echo.
+  echo ERROR: MCP server build failed. Setup aborted.
+  cd ..\eval
+  pause
+  exit /b 1
+)
+cd ..\eval
+
+echo.
 echo Installing Python dependencies...
 cd harness
 call uv sync


### PR DESCRIPTION
## Summary
- Setup.bat now installs + builds `mcp-server/` so a fresh clone can run RunTests.bat without manually building. Previously the harness loaded `mcp-server/build/` which only exists if you happened to build separately.
- RunTests.bat now does an incremental `npm run build` in `mcp-server/` before invoking the harness, so a daily `git pull` that touches `mcp-server/src/` "just works." When nothing changed, `tsc` is a near-no-op.
- RunTests.bat also pre-checks that `mcp-server/node_modules` exists and aborts with a one-line "run Setup.bat first" message if it doesn't. Replaces a confusing 22-error tsc wall with a clear next step.
- JUNIOR-WALKTHROUGH.md documents the Windows `'uv' is not recognized` failure mode (uv updates user PATH but the running cmd shell doesn't see it) and how to recover: close cmd, reopen, re-run Setup. Includes a manual PATH fallback.
- JUNIOR-WALKTHROUGH.md also notes that genealogists doing the current assessment don't need a real Anthropic API key — they can close the Command Prompt at the key prompt.

## Why
Every new genealogist hits two cliffs in a row on a fresh Windows clone:
1. Setup.bat crashes on `uv sync` because the cmd shell that started before the uv install can't see the new PATH entry.
2. Even after that, RunTests.bat aborts with "mcp-server build is stale or missing" because Setup.bat never touched `mcp-server/` and `build/` is gitignored.

And a third cliff for anyone who tries RunTests.bat before Setup.bat finishes successfully or if someone cleans mcp-server/node_modules: a 22-error TypeScript wall about missing `@types/node` and `@modelcontextprotocol/sdk`, with no hint that the real fix is "run Setup.bat once."



## Verification (tested on a fresh Windows clone)

- [x] **Pre-Setup RunTests guard fires correctly.** Ran `RunTests.bat` before `Setup.bat` on a fresh clone. Got the new one-line message ("mcp-server dependencies are not installed. Please run Setup.bat once") instead of the previous 22-error TypeScript wall.

- [x] **uv-PATH workaround is documented and works.** Ran `Setup.bat` on the fresh clone and hit the `'uv' is not recognized` failure during `uv sync`. Followed the JUNIOR-WALKTHROUGH recovery steps — closed the Command Prompt, reopened a new one, re-ran `Setup.bat`. The second run picked up the new PATH and finished cleanly.

- [x] **mcp-server build step is required and now works.** Before the fix, RunTests.bat on a fresh clone failed with "mcp-server build is stale or missing" because Setup.bat never built it. After the fix, Setup.bat installs + builds mcp-server, and RunTests.bat picks up the build artifacts and runs the harness end-to-end.
