### PR TITLE
Convert DGS to imageGroupNumber for consistency

### DIFF
--- a/docs/specs/fulltext-search-tool-spec.md
+++ b/docs/specs/fulltext-search-tool-spec.md
@@ -51,9 +51,9 @@ descriptions distinct so Claude picks the right one.
       "type": "string",
       "description": "Filter to a specific FamilySearch collection by ID."
     },
-    "dgsNumber": {
+    "imageGroupNumber": {
       "type": "string",
-      "description": "Filter to a specific digitized volume by DGS (Image Group Number)."
+      "description": "Filter to a specific digitized volume by Image Group Number."
     },
     "yearFrom": {
       "type": "number",
@@ -112,7 +112,7 @@ The tool maps its input to the upstream API query parameters:
 | `name` | `q.fullName` |
 | `place` | `q.recordPlace` |
 | `collectionId` | `f.collectionId` |
-| `dgsNumber` | `q.groupName` |
+| `imageGroupNumber` | `q.groupName` |
 | `yearFrom` | `f.recordYear0` |
 | `yearTo` | `f.recordYear1` |
 | `recordType` | `f.recordType0` |

--- a/eval/fixtures/mcp/fulltext-search-flynn-flinn-variant.json
+++ b/eval/fixtures/mcp/fulltext-search-flynn-flinn-variant.json
@@ -25,9 +25,9 @@
         "type": "string",
         "description": "Filter to a specific FamilySearch collection by ID."
       },
-      "dgsNumber": {
+      "imageGroupNumber": {
         "type": "string",
-        "description": "Filter to a specific digitized volume by DGS (Image Group Number)."
+        "description": "Filter to a specific digitized volume by Image Group Number."
       },
       "yearFrom": {
         "type": "number",

--- a/eval/fixtures/mcp/fulltext-search-flynn-probate-empty.json
+++ b/eval/fixtures/mcp/fulltext-search-flynn-probate-empty.json
@@ -25,9 +25,9 @@
         "type": "string",
         "description": "Filter to a specific FamilySearch collection by ID."
       },
-      "dgsNumber": {
+      "imageGroupNumber": {
         "type": "string",
-        "description": "Filter to a specific digitized volume by DGS (Image Group Number)."
+        "description": "Filter to a specific digitized volume by Image Group Number."
       },
       "yearFrom": {
         "type": "number",

--- a/eval/fixtures/mcp/fulltext-search-flynn-witnesses.json
+++ b/eval/fixtures/mcp/fulltext-search-flynn-witnesses.json
@@ -25,9 +25,9 @@
         "type": "string",
         "description": "Filter to a specific FamilySearch collection by ID."
       },
-      "dgsNumber": {
+      "imageGroupNumber": {
         "type": "string",
-        "description": "Filter to a specific digitized volume by DGS (Image Group Number)."
+        "description": "Filter to a specific digitized volume by Image Group Number."
       },
       "yearFrom": {
         "type": "number",

--- a/mcp-server/dev/try-fulltext-search.ts
+++ b/mcp-server/dev/try-fulltext-search.ts
@@ -37,8 +37,8 @@ while (i < args.length) {
     input.place = args[++i];
   } else if (flag === "--collection" && args[i + 1]) {
     input.collectionId = args[++i];
-  } else if (flag === "--dgs" && args[i + 1]) {
-    input.dgsNumber = args[++i];
+  } else if (flag === "--image-group-number" && args[i + 1]) {
+    input.imageGroupNumber = args[++i];
   } else if (flag === "--year-from" && args[i + 1]) {
     input.yearFrom = Number(args[++i]);
   } else if (flag === "--year-to" && args[i + 1]) {

--- a/mcp-server/src/tools/fulltext-search.ts
+++ b/mcp-server/src/tools/fulltext-search.ts
@@ -16,9 +16,9 @@ const FS_FULLTEXT_URL =
   "https://www.familysearch.org/service/search/fulltext/search";
 
 function validateInput(input: FulltextSearchInput): void {
-  if (!input.keywords && !input.name && !input.place && !input.nlQuery && !input.dgsNumber) {
+  if (!input.keywords && !input.name && !input.place && !input.nlQuery && !input.imageGroupNumber) {
     throw new Error(
-      "At least one of keywords, name, place, nlQuery, or dgsNumber is required."
+      "At least one of keywords, name, place, nlQuery, or imageGroupNumber is required."
     );
   }
   if (input.count !== undefined) {
@@ -56,7 +56,7 @@ function buildUrl(input: FulltextSearchInput): string {
   if (input.place) add("q.recordPlace", input.place);
   if (input.nlQuery) add("nlQuery", input.nlQuery);
   if (input.collectionId) add("f.collectionId", input.collectionId);
-  if (input.dgsNumber) add("q.groupName", input.dgsNumber);
+  if (input.imageGroupNumber) add("q.groupName", input.imageGroupNumber);
   if (input.yearFrom !== undefined) add("f.recordYear0", input.yearFrom);
   if (input.yearTo !== undefined) add("f.recordYear1", input.yearTo);
   if (input.recordType) add("f.recordType0", input.recordType);
@@ -253,10 +253,10 @@ export const fulltextSearchToolSchema = {
         type: "string",
         description: "Filter to a specific FamilySearch collection by ID.",
       },
-      dgsNumber: {
+      imageGroupNumber: {
         type: "string",
         description:
-          "Filter to a specific digitized volume by DGS (Image Group Number).",
+          "Filter to a specific digitized volume by Image Group Number.",
       },
       yearFrom: {
         type: "number",

--- a/mcp-server/src/tools/image-read.ts
+++ b/mcp-server/src/tools/image-read.ts
@@ -20,7 +20,7 @@ function validateUrl(url: string): void {
   if (!ARK_PATTERN.test(url) && !DGS_PATTERN.test(url)) {
     throw new Error(
       "Unrecognized FamilySearch image URL. Expected an ARK URL " +
-        "(ending in /$dist) or a DGS URL (dgs:NUMBER_NUMBER/dist.jpg)."
+        "(ending in /$dist) or an Image Group Number URL (dgs:NUMBER_NUMBER/dist.jpg)."
     );
   }
 }
@@ -78,7 +78,7 @@ export const imageReadToolSchema = {
   name: "image_read",
   description:
     "Fetch a FamilySearch distribution image by URL and return it as image data. " +
-    "Accepts ARK URLs (ending in /$dist) or DGS URLs (dgs:NUMBER_NUMBER/dist.jpg). " +
+    "Accepts ARK URLs (ending in /$dist) or Image Group Number URLs (dgs:NUMBER_NUMBER/dist.jpg). " +
     "Requires authentication — call the login tool first if not logged in.",
   inputSchema: {
     type: "object",
@@ -88,7 +88,7 @@ export const imageReadToolSchema = {
         description:
           "FamilySearch image URL. Two formats supported:\n" +
           "ARK: https://sg30p0.familysearch.org/service/records/storage/deepzoomcloud/dz/v1/{ARK_ID}/$dist\n" +
-          "DGS: https://familysearch.org/das/v2/dgs:{DGS}_{IMAGE}/dist.jpg",
+          "Image Group Number: https://familysearch.org/das/v2/dgs:{IMAGE_GROUP_NUMBER}_{IMAGE}/dist.jpg",
       },
     },
     required: ["url"],

--- a/mcp-server/src/types/fulltext-search.ts
+++ b/mcp-server/src/types/fulltext-search.ts
@@ -48,7 +48,7 @@ export interface FulltextSearchInput {
   place?: string;
   nlQuery?: string;
   collectionId?: string;
-  dgsNumber?: string;
+  imageGroupNumber?: string;
   yearFrom?: number;
   yearTo?: number;
   recordType?: string;

--- a/plugin/skills/record-extraction/SKILL.md
+++ b/plugin/skills/record-extraction/SKILL.md
@@ -65,7 +65,7 @@ Record data arrives in one of three ways:
    user upload.
 
 3. **Image** — the user provides a FamilySearch image URL (image ARK
-   `3:1:.../$dist` or DGS URL `dgs:.../dist.jpg`). The skill calls
+   `3:1:.../$dist` or Image Group Number URL `dgs:.../dist.jpg`). The skill calls
    `image_read` to fetch the image bytes. Claude reads the image
    natively (multimodal) and produces a transcription. **Transcription
    review is mandatory** — see the transcription review section below.
@@ -390,7 +390,7 @@ When processing image-based records (via `image_read`):
 1. Call `image_read` with the image URL. Only two URL formats are
    accepted by the tool — anything else is rejected:
    - Image ARK: `https://sg30p0.familysearch.org/service/records/storage/deepzoomcloud/dz/v1/3:1:{ID}/$dist`
-   - DGS: `https://familysearch.org/das/v2/dgs:{DGS}_{IMAGE}/dist.jpg`
+   - Image Group Number: `https://familysearch.org/das/v2/dgs:{IMAGE_GROUP_NUMBER}_{IMAGE}/dist.jpg`
 
    The tool returns the image as a multimodal content block — you
    (Claude) see the image directly.
@@ -418,7 +418,7 @@ that propagate silently into the research file.
 
 **If the user provides a persona ARK (`1:1:...`) or record ARK
 (`1:2:...`), `image_read` will reject the URL** — the tool only
-accepts image ARKs (`3:1:...`) and DGS URLs. Ask the user for the
+accepts image ARKs (`3:1:...`) and Image Group Number URLs. Ask the user for the
 image URL from the FamilySearch record viewer's "View Image" link.
 If the user only has a persona or record ARK, the image URL must be
 looked up separately (e.g., from the FS record-detail page) before

--- a/plugin/skills/search-full-text/SKILL.md
+++ b/plugin/skills/search-full-text/SKILL.md
@@ -163,12 +163,11 @@ fulltext_search({ nlQuery: "Search for John Doe born in Austria" })
 # Search by tree person ID
 fulltext_search({ nlQuery: "KD96-TV2" })
 
-# Search within a specific DGS volume
-fulltext_search({ dgsNumber: "4057677" })
+# Search within a specific volume
+fulltext_search({ imageGroupNumber: "4057677" })
 ```
 
-**When searching a specific volume:** Use the DGS (Image Group
-Number) field to restrict to one digitized volume, then add keywords.
+**When searching a specific volume:** Use the Image Group Number field to restrict to one digitized volume, then add keywords.
 
 ### 6. Execute and iterate
 

--- a/plugin/skills/search-full-text/references/query-syntax.md
+++ b/plugin/skills/search-full-text/references/query-syntax.md
@@ -12,7 +12,7 @@ Behavior differs fundamentally from indexed Records search.
 | Name | NLP-recognized person names only | Auto-handles last-name-first inversions ("Mills Alexander" matches "Alexander Mills"). Keywords field does NOT auto-invert. |
 | Place | Place name | Matches BOTH transcript content AND collection metadata — major source of false positives. **Prefer filtering by place after search rather than including place in the query.** |
 | Year Range | Numeric range | Matches AI-recognized years in transcript and/or collection metadata. Documents often contain multiple dates. |
-| DGS (Image Group Number) | Restrict to one digitized volume | Enter without leading zeros. Combine with keywords to scan one volume. |
+| Image Group Number | Restrict to one digitized volume | Enter without leading zeros. Combine with keywords to scan one volume. |
 
 **Cross-field semantics:** If multiple fields are specified, results
 must match ALL fields. Within a field, operators control which terms


### PR DESCRIPTION
Rename dgsNumber to imageGroupNumber in the fulltext_search tool and update all user-facing references from 'DGS' to 'Image Group Number' across skills, specs, and eval fixtures.

**Summary**
FamilySearch has been transitioning from the legacy term "DGS" (Digital Group Sheet) to the newer canonical term "Image Group Number." Having both names scattered across the codebase was inconsistent and could confuse the LLM into treating them as different concepts when they refer to the same thing.

**What** changed
fulltext_search tool — renamed the dgsNumber input parameter to imageGroupNumber in the type definition, validation logic, query mapping, and MCP schema description
image_read tool — updated error messages and tool description to say "Image Group Number URL" instead of "DGS URL"
search-full-text skill — updated the example call (dgsNumber → imageGroupNumber) and the query-syntax reference doc
record-extraction skill — updated URL format description to say "Image Group Number URL"
Fulltext search spec — updated dgsNumber → imageGroupNumber in the input schema and query parameter mapping table
Eval fixtures — updated 3 fulltext search MCP fixture files to reflect the renamed parameter
Dev smoke test — renamed --dgs CLI flag to --image-group-number

**What** did NOT change
The actual dgs: prefix inside FamilySearch image URLs (e.g. dgs:007621224_001/dist.jpg) was left unchanged — that is FamilySearch's server-side URL format and is outside our control.

