### PR TITLE
Integrate person_search into search-records skill

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,7 +92,10 @@ source of truth for the advertised tool list); `src/index.ts` imports that
 list and dispatches calls. Per-tool behavioral contracts are in
 `docs/specs/<tool>-tool-spec.md`. Implementation plans (including for
 tools not yet built, such as `tree_attachments`) are in `docs/plan/`.
-Skills live in `plugin/skills/<skill>/SKILL.md`.
+Skills live in `plugin/skills/<skill>/SKILL.md`. The `search-records`
+skill routes to either `record_search` (historical records) or
+`person_search` (FamilySearch Family Tree lookup) depending on whether
+the user wants records or a tree person.
 
 The host artifact is the `.mcpb` desktop extension, built from
 `mcp-server/` with the `@anthropic-ai/mcpb` CLI. Its `manifest.json` is the

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ are listed in roughly the order you'd use them in a research project.
 
 | Skill | What it does | Say this |
 |-------|-------------|----------|
-| **search-records** | Searches FamilySearch indexed records (census, vital, probate, etc.). Triages results by match quality. | "Search for Patrick Flynn in the 1850 census" |
+| **search-records** | Searches FamilySearch indexed records (census, vital, probate, etc.) and the FamilySearch Family Tree. Routes to `record_search` for historical records or `person_search` to find a tree person by name, dates, or relatives. Triages results by match quality. | "Search for Patrick Flynn in the 1850 census" / "Find Patrick Flynn in the FamilySearch tree" |
 | **search-full-text** | Full-text search of FS AI-transcribed document images. Finds witnesses, neighbors, heirs, and other non-principal mentions. | "Full-text search for Flynn in Schuylkill County deeds" |
 | **search-external-sites** | Generates search URLs for Ancestry, MyHeritage, FindMyPast, FindAGrave, Newspapers.com. Walks the click-capture-analyze loop. | "Search Ancestry for Thomas Flynn" |
 

--- a/eval/fixtures/mcp/person-search-flynn.json
+++ b/eval/fixtures/mcp/person-search-flynn.json
@@ -1,0 +1,72 @@
+{
+  "tool": "person_search",
+  "description": "FamilySearch Family Tree search for Patrick Flynn — 3 ranked candidates, LZNY-BRF as the top match (born 1845 Ireland, Schuylkill County residence)",
+  "args": { "surname": "Flynn", "givenName": "Patrick" },
+  "response": {
+    "query": { "givenName": "Patrick", "surname": "Flynn" },
+    "totalMatches": 3,
+    "paginationCappedAt": 4999,
+    "returned": 3,
+    "offset": 0,
+    "hasMore": false,
+    "results": [
+      {
+        "personId": "LZNY-BRF",
+        "score": 4.85,
+        "confidence": 3,
+        "gedcomx": {
+          "persons": [
+            {
+              "id": "LZNY-BRF",
+              "ark": "https://familysearch.org/ark:/61903/4:1:LZNY-BRF",
+              "gender": "Male",
+              "names": [{ "given": "Patrick", "surname": "Flynn" }],
+              "facts": [
+                { "type": "Birth", "date": "1845", "place": "Ireland" },
+                { "type": "Residence", "date": "1850", "place": "Branch Township, Schuylkill, Pennsylvania" },
+                { "type": "Death", "date": "1908", "place": "Schuylkill County, Pennsylvania" }
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "personId": "LZNY-QRS",
+        "score": 3.21,
+        "confidence": 2,
+        "gedcomx": {
+          "persons": [
+            {
+              "id": "LZNY-QRS",
+              "ark": "https://familysearch.org/ark:/61903/4:1:LZNY-QRS",
+              "gender": "Male",
+              "names": [{ "given": "Patrick", "surname": "Flynn" }],
+              "facts": [
+                { "type": "Birth", "date": "1847", "place": "Ireland" },
+                { "type": "Death", "date": "1908", "place": "Schuylkill County, Pennsylvania" }
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "personId": "KWCJ-PAT",
+        "score": 2.10,
+        "confidence": 1,
+        "gedcomx": {
+          "persons": [
+            {
+              "id": "KWCJ-PAT",
+              "ark": "https://familysearch.org/ark:/61903/4:1:KWCJ-PAT",
+              "gender": "Male",
+              "names": [{ "given": "Patrick", "surname": "Flynn" }],
+              "facts": [
+                { "type": "Birth", "date": "1840", "place": "County Cork, Ireland" }
+              ]
+            }
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/eval/harness/validators/test_search_records.py
+++ b/eval/harness/validators/test_search_records.py
@@ -40,6 +40,8 @@ def test_positive_appends_log_entry(before_state, after_state, test):
     exhaustive-search declaration."""
     if test.get("type") != "positive":
         pytest.skip("only positive tests record searches")
+    if "person-search" in test.get("tags", []):
+        pytest.skip("person_search is a tree navigation step — no log entry required")
     if before_state.get("research_json") is None:
         pytest.skip("no research.json in scenario")
     new_entries = _new_log_entries(before_state, after_state)

--- a/eval/tests/unit/search-records/person-search-tree.json
+++ b/eval/tests/unit/search-records/person-search-tree.json
@@ -1,0 +1,25 @@
+{
+  "test": {
+    "id": "ut_search_records_012",
+    "skill": "search-records",
+    "name": "Search FamilySearch Family Tree for Patrick Flynn using person_search",
+    "type": "positive",
+    "description": "User asks to find Patrick Flynn in the FamilySearch Family Tree. Tests that search-records routes to person_search (not record_search), presents all ranked candidates with personIds and key facts, and identifies LZNY-BRF as the strongest match based on its birth place and Schuylkill County residence aligning with the research context.",
+    "tags": ["search", "person-search", "tree-search", "candidate-ranking"]
+  },
+  "input": {
+    "user_message": "search-records: Find Patrick Flynn (born about 1845 in Ireland, lived in Schuylkill County Pennsylvania) in the FamilySearch Family Tree and show me the candidates.",
+    "scenario": "mid-research-flynn"
+  },
+  "mcp_fixtures": ["person-search-flynn"],
+  "judge_context": [
+    "Should call person_search (not record_search) — this is a tree person lookup, not a historical record search",
+    "Should include surname 'Flynn' and given name 'Patrick' in the call arguments",
+    "Should present all 3 candidates with their personIds (LZNY-BRF, LZNY-QRS, KWCJ-PAT), confidence scores, and key facts",
+    "Should identify LZNY-BRF as the top match (score 4.85, confidence 3) given its 1845 Ireland birth and Schuylkill County residence matching the research context",
+    "Should NOT write a log entry to research.json — tree person lookup is a navigation step, not a GPS research search"
+  ],
+  "execution": {
+    "max_wall_clock_seconds": 120
+  }
+}

--- a/plugin/skills/search-records/SKILL.md
+++ b/plugin/skills/search-records/SKILL.md
@@ -1,21 +1,24 @@
 ---
 name: search-records
 model: claude-sonnet-4-6
-description: Executes searches against FamilySearch historical records per
-  the research plan. Routes to the correct MCP search tool based on record
-  type, triages results using match scoring, logs every search including nil
-  results, and passes promising records to record-extraction. GPS Step 1 —
+description: Searches FamilySearch historical records and the FamilySearch
+  Family Tree. Routes to record_search for indexed records (census, vital,
+  probate, etc.) or to person_search to find a tree person by name, dates,
+  or relatives. Triages results using match scoring, logs record searches,
+  and passes promising records to record-extraction. GPS Step 1 —
   Reasonably Exhaustive Research (execution phase). Use when the user says
-  "search for [person]", "find [person] in [record type]", "execute the
-  plan", "run the next search", "search FamilySearch", or when a plan item
-  targets a FamilySearch repository. Do NOT use when the target is
-  Ancestry, MyHeritage, FindMyPast, FindAGrave, or Newspapers.com (use
-  search-external-sites), when the user wants to plan what to search (use
-  research-plan), or when the user wants to analyze a record already found
-  (use record-extraction).
+  "search for [person]", "find [person] in [record type]", "find [person]
+  in the FamilySearch tree", "search the tree for", "look up [person] in
+  the tree", "execute the plan", "run the next search", "search
+  FamilySearch", or when a plan item targets a FamilySearch repository.
+  Do NOT use when the target is Ancestry, MyHeritage, FindMyPast,
+  FindAGrave, or Newspapers.com (use search-external-sites), when the user
+  wants to plan what to search (use research-plan), or when the user wants
+  to analyze a record already found (use record-extraction).
 allowed-tools:
   - record_search
   - match_two_examples
+  - person_search
 ---
 
 # Search Records
@@ -59,9 +62,40 @@ This skill uses two search tools. Route based on the plan item's
 | `census`, `vital_record`, `probate`, `land`, `church`, `military`, `immigration`, `court`, `tax` | `record_search` | Structured searches by person attributes (name, dates, places, relationships). The primary search tool for most record types |
 | `newspaper`, or any witness/FAN mention search | — | **Delegate to search-full-text skill.** FTS has different query syntax and strategies. Use full-text-search when: searching for obituaries/marriage announcements, searching for a person mentioned as witness/neighbor/heir/surety/appraiser, pre-1850 US research with thin indexed coverage, Latin American notarial records, or narrative paragraph records (court minutes, meetings) |
 | `cemetery` | `record_search` | FamilySearch indexes some cemetery records. Also consider suggesting search-external-sites for FindAGrave |
+| Tree person lookup | `person_search` | Finding a named person in the FamilySearch Family Tree by name, dates, or relatives. Returns ranked candidates (personId + key facts) for the user to pick their subject. Chains into person_read for relatives and attached sources |
 
 Additional tool:
 | `match_two_examples` | Results triage — scoring how well a search result matches the research subject |
+
+## Tree person lookup
+
+When the user wants to find a person in the FamilySearch Family Tree
+(not a historical record), call `person_search`:
+
+```
+person_search({
+  surname: "Flynn",
+  givenName: "Patrick",
+  birthYearFrom: 1843,
+  birthYearTo: 1847,
+  birthPlace: "Ireland"
+})
+```
+
+**Surname-plus-one rule:** `surname` is always required plus at least
+one other qualifying field (given name, date, place, or relative name).
+Sex and `*Exact` toggle fields don't count as the qualifying field.
+
+This returns a ranked list of candidate tree persons. Present all
+candidates to the user with their `personId`, confidence, and key
+facts. Let the user confirm which person is their subject. The
+selected `personId` passes to `person_read` to expand relatives and
+attached sources.
+
+**Do not write a log entry** for `person_search` calls — tree person
+lookup is a navigation step to identify the subject, not a GPS
+research search. Only `record_search` and `fulltext_search` calls get
+log entries in `research.json`.
 
 ## Steps
 


### PR DESCRIPTION
## Summary

- **search-records SKILL.md**: adds `person_search` to `allowed-tools`, extends description trigger phrases to include tree-person lookup ("find [person] in the FamilySearch tree", "search the tree for"), adds a routing table row, and adds a new **Tree person lookup** section with the surname-plus-one rule and guidance that tree lookups don't write log entries
- **README.md**: updates search-records skill description to mention tree searching via `person_search`
- **CLAUDE.md**: notes that search-records routes to `person_search` for tree lookups in addition to `record_search` for historical records
- **eval/fixtures/mcp/person-search-flynn.json**: new MCP fixture returning 3 ranked Patrick Flynn tree candidates (LZNY-BRF as top match)
- **eval/tests/unit/search-records/person-search-tree.json**: new test `ut_search_records_012` — verified passing
- **eval/harness/validators/test_search_records.py**: skip log-entry check for `person-search` tagged tests (tree lookup is navigation, not a GPS research search)

## Test plan

- [x] `ut_search_records_012` passes — skill routes to `person_search`, presents all 3 candidates, identifies LZNY-BRF as top match, no log entry written