### PR TITLE
Integrate record_read into skills, evals, README, and CLAUDE.md (#222)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,7 +137,7 @@ The interview lives in `init-project/SKILL.md`.
 
 ## Auth architecture (`mcp-server/src/auth/`)
 
-All authenticated tools (`place_collections`, `record_search`,
+All authenticated tools (`place_collections`, `record_search`, `record_read`,
 `person_search`, `person_read`, and `fulltext_search`) must go through this
 module — do not re-implement token plumbing.
 
@@ -251,7 +251,7 @@ Where to look first:
   (including `fs-search-agent` from the FS-internal API
   examples). Import this constant instead of hardcoding the
   string — `place_collections`, `record_search`, `place_external_links`,
-  `image_read`, and `fulltext_search` already do.
+  `image_read`, `record_read`, and `fulltext_search` already do.
 - **Exported helpers in `src/tools/`** — for example, `place-search.ts`
   exports `searchPlace`, `getPlaceById`, and `getWikipediaSummary`,
   and `place-collections.ts` exports `fetchAllCollections`,

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ The MCP server exposes 21 tools.
 | `place_search` | FamilySearch place data + Wikipedia enrichment | None |
 | `place_collections` | FamilySearch record collections for a place (list mode) or details for a single collection (detail mode) | OAuth |
 | `record_search` | FamilySearch historical-record search for a person | OAuth |
+| `record_read` | Fetch a FamilySearch historical record by ARK or entity ID — returns full simplified GEDCOMX | OAuth |
 | `person_search` | FamilySearch Family Tree search for a person — ranked candidate tree persons to pick and research (chains into `person_read`) | OAuth |
 | `fulltext_search` | Full-text search of FS AI-transcribed document images — finds non-principal mentions (witnesses, neighbors, heirs) | OAuth |
 | `match_two_examples` | Asks FamilySearch whether two record extractions describe the same person — match confidence + score | OAuth |
@@ -382,10 +383,10 @@ then narrows the search.
 
 What's shipped:
 
-- **21 MCP tools.** OAuth (`login`, `logout`, `auth_status`); public
+- **22 MCP tools.** OAuth (`login`, `logout`, `auth_status`); public
   reference tools (`wikipedia_search`, `place_search`, `place_population`,
   `place_external_links`, `place_distance`, `image_read`); authenticated
-  read tools (`place_collections`, `record_search`, `person_search`,
+  read tools (`place_collections`, `record_search`, `record_read`, `person_search`,
   `fulltext_search`, `match_two_examples`, `person_record_matches`,
   `record_person_matches`, `person_person_matches`, `record_record_matches`,
   `person_read`); FamilySearch Wiki tools (`wiki_search`, `wiki_read`, and

--- a/eval/fixtures/mcp/record-read-68Q9-K34P.json
+++ b/eval/fixtures/mcp/record-read-68Q9-K34P.json
@@ -1,0 +1,66 @@
+{
+  "tool": "record_read",
+  "description": "FamilySearch record_read response for record 68Q9-K34P — a 1850 U.S. Census index entry for Patrick Flynn. Returns simplified GEDCOMX with the primary person, household relationships, and source attachment.",
+  "args": {
+    "recordId": "68Q9-K34P"
+  },
+  "response": {
+    "persons": [
+      {
+        "id": "68Q9-K34P",
+        "ark": "ark:/61903/1:1:68Q9-K34P",
+        "gender": "Male",
+        "names": [
+          {
+            "id": "N1",
+            "type": "BirthName",
+            "given": "Patrick",
+            "surname": "Flynn"
+          }
+        ],
+        "facts": [
+          { "type": "Birth", "date": "1845", "place": "Ireland" },
+          { "type": "Residence", "date": "1850", "place": "Branch Township, Schuylkill, Pennsylvania, United States" }
+        ],
+        "sources": [
+          { "id": "S1", "title": "United States Census, 1850" }
+        ]
+      },
+      {
+        "id": "68Q9-K34Q",
+        "ark": "ark:/61903/1:1:68Q9-K34Q",
+        "gender": "Male",
+        "names": [
+          {
+            "id": "N2",
+            "type": "BirthName",
+            "given": "Thomas",
+            "surname": "Flynn"
+          }
+        ],
+        "facts": [
+          { "type": "Residence", "date": "1850", "place": "Branch Township, Schuylkill, Pennsylvania, United States" }
+        ],
+        "sources": [
+          { "id": "S1", "title": "United States Census, 1850" }
+        ]
+      }
+    ],
+    "relationships": [
+      {
+        "id": "R1",
+        "type": "ParentChild",
+        "parent": "68Q9-K34Q",
+        "child": "68Q9-K34P"
+      }
+    ],
+    "sources": [
+      {
+        "id": "S1",
+        "title": "United States Census, 1850",
+        "url": "https://www.familysearch.org/ark:/61903/1:1:68Q9-K34P"
+      }
+    ],
+    "places": []
+  }
+}

--- a/eval/tests/unit/record-extraction/record-read-via-ark.json
+++ b/eval/tests/unit/record-extraction/record-read-via-ark.json
@@ -1,0 +1,26 @@
+{
+  "test": {
+    "id": "ut_record_extraction_006",
+    "skill": "record-extraction",
+    "name": "Extract assertions by fetching record via ARK using record_read",
+    "type": "positive",
+    "description": "When the user provides a FamilySearch record ARK, the skill should call record_read to fetch the full simplified GEDCOMX, then extract assertions from the returned data. Tests that the skill uses record_read as the data-fetch path when given a bare record ID or ARK rather than inline record text.",
+    "tags": ["record-read", "ark", "gedcomx", "1850-census"]
+  },
+  "input": {
+    "user_message": "Extract the assertions from FamilySearch record ark:/61903/1:1:68Q9-K34P.",
+    "scenario": "empty-project-just-created"
+  },
+  "mcp_fixtures": ["record-read-68Q9-K34P"],
+  "judge_context": [
+    "The skill MUST call record_read with recordId '68Q9-K34P' (or the full ARK) — not hallucinate record contents",
+    "Should extract assertions for Patrick Flynn (primary person): name, birth date ~1845, birthplace Ireland, residence 1850 Branch Township Schuylkill Pennsylvania",
+    "Should extract the ParentChild relationship between Thomas Flynn (parent) and Patrick Flynn (child) as an indirect-evidence assertion — the census doesn't explicitly state relationships",
+    "Should create a source entry pointing to the United States Census 1850 collection",
+    "Should NOT invent facts not present in the record_read response"
+  ],
+  "execution": {
+    "max_wall_clock_seconds": 600,
+    "sdk_message_silence_seconds": 300
+  }
+}

--- a/eval/tests/unit/search-records/fetch-full-record-via-record-read.json
+++ b/eval/tests/unit/search-records/fetch-full-record-via-record-read.json
@@ -1,0 +1,25 @@
+{
+  "test": {
+    "id": "ut_search_records_006",
+    "skill": "search-records",
+    "name": "Fetch full record details via record_read after finding a census match",
+    "type": "positive",
+    "description": "After record_search returns an index entry with a record ID, the skill should call record_read to fetch the full simplified GEDCOMX before passing the record to record-extraction. Tests that the skill uses record_read as a follow-up call to enrich index results with full record detail.",
+    "tags": ["record-read", "census", "1850", "full-record", "index-entry"]
+  },
+  "input": {
+    "user_message": "Search the 1850 census for Patrick Flynn in Schuylkill County and fetch the full record details.",
+    "scenario": "flynn-record-matching"
+  },
+  "mcp_fixtures": ["record-search-1850-census-flynn", "record-read-68Q9-K34P"],
+  "judge_context": [
+    "Should call record_search first to find the census entry",
+    "Should then call record_read with the record ID from the search result (e.g., 'MXHY-TP4' or '68Q9-K34P') to fetch the full GEDCOMX",
+    "The log entry should reflect that the full record was fetched, not just the index entry",
+    "Should note that index entries are derivative — record_read provides the richer data for extraction"
+  ],
+  "execution": {
+    "max_wall_clock_seconds": 600,
+    "sdk_message_silence_seconds": 300
+  }
+}

--- a/plugin/skills/record-extraction/SKILL.md
+++ b/plugin/skills/record-extraction/SKILL.md
@@ -15,6 +15,7 @@ description: Extracts atomic GPS-conformant assertions from genealogical
   classifications (use assertion-classification), or wants to format
   citations (use citation).
 allowed-tools:
+  - record_read
   - image_read
   - validate_research_schema
 ---
@@ -53,19 +54,25 @@ The governing principles:
 
 ## Inputs
 
-Record data arrives in one of three ways:
+Record data arrives in one of four ways:
 
 1. **MCP tool response in context** — search-records called `record_search`
    and Claude holds the structured data in context.
    This is the most common path.
 
-2. **PDF capture** — the user uploaded a PDF from an external site
+2. **Record ARK or entity ID** — the user provides a FamilySearch record
+   ARK (e.g., `ark:/61903/1:1:QVS9-DHDB`) or bare entity ID (e.g.,
+   `QVS9-DHDB`). Call `record_read` to fetch the full simplified GEDCOMX,
+   then extract assertions from the returned persons, relationships, and
+   facts.
+
+3. **PDF capture** — the user uploaded a PDF from an external site
    (Ancestry, MyHeritage, FindMyPast, FindAGrave). Claude reads the
    PDF directly. This comes via search-external-sites or a direct
    user upload.
 
-3. **Image** — the user provides a FamilySearch image URL (image ARK
-   `3:1:.../$dist` or DGS URL `dgs:.../dist.jpg`). The skill calls
+4. **Image** — the user provides a FamilySearch image URL (image ARK
+   `3:1:.../$dist` or Image Group Number URL `dgs:.../dist.jpg`). The skill calls
    `image_read` to fetch the image bytes. Claude reads the image
    natively (multimodal) and produces a transcription. **Transcription
    review is mandatory** — see the transcription review section below.

--- a/plugin/skills/search-records/SKILL.md
+++ b/plugin/skills/search-records/SKILL.md
@@ -15,6 +15,7 @@ description: Executes searches against FamilySearch historical records per
   (use record-extraction).
 allowed-tools:
   - record_search
+  - record_read
   - match_two_examples
 ---
 
@@ -290,10 +291,14 @@ not the records themselves. Before extraction:
    Index entries typically contain only name, date, place, and a
    record identifier. Full records contain additional detail
    (household members, witnesses, document text, etc.).
-2. If the full record is unavailable but an image exists, record the
+2. If a record ID or ARK is available, call `record_read` to fetch
+   the full simplified GEDCOMX before passing to record-extraction.
+   This surfaces relationships, additional persons, and fact details
+   that the index entry may not include.
+3. If the full record is unavailable but an image exists, record the
    image's URL or identifier in the log and pass the record to
    record-extraction, which fetches and transcribes the image.
-3. If only the index entry is available (no image, no full record),
+4. If only the index entry is available (no image, no full record),
    flag it in the log notes as "derivative only — original not
    located" so the researcher knows the data has not been verified
    against the original source.


### PR DESCRIPTION
**Wire the record_read tool into the two skills that benefit from it: record-extraction now calls it when given a bare ARK or entity ID, and search-records now calls it to enrich index entries before extraction. Add two eval tests and an MCP fixture covering both paths.**


### **Summary**

__Added_ record_read to record-extraction skill: new input path lets Claude call record_read when the user provides a FamilySearch ARK or bare entity ID, instead of requiring inline record text
Added record_read to search-records skill: after finding an index entry via record_search, Claude now calls record_read to fetch the full simplified GEDCOMX before passing to extraction — surfacing household members, relationships, and facts that index entries omit
Added MCP fixture record-read-68Q9-K34P.json (1850 census, Patrick Flynn) for use in eval tests
Added eval test ut_record_extraction_006 — verifies skill calls record_read given a bare ARK
Added eval test ut_search_records_006 — verifies skill enriches index results with record_read before extraction
Updated README.md (tool count 21 → 22, added record_read row) and CLAUDE.md (auth architecture list, BROWSER_USER_AGENT note)_

