### PR TITLE
Add person_ancestors tool spec

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,7 +70,8 @@ instance); end users do not need to set this for normal operation.
   `docs/specs/simplified-gedcomx-spec.md`; implementation spec at
   `docs/specs/gedcomx-convert-spec.md`) and `search-helpers.ts` (shared
   input validators and error parsing used by the search tools
-  `record_search` and `person_search`).
+  `record_search` and `person_search`; `parseUpstreamErrorBody` is also
+  reused by `person_ancestors`).
 - `releases/` — Build output. Gitignored except for `.gitkeep`.
 - `docs/plan/` — Implementation plans for tools (how we intend to build).
 - `docs/specs/` — Finalized specs (what the tool must do). Specs are the
@@ -140,7 +141,7 @@ The interview lives in `init-project/SKILL.md`.
 ## Auth architecture (`mcp-server/src/auth/`)
 
 All authenticated tools (`place_collections`, `record_search`, `record_read`,
-`person_search`, `person_read`, `fulltext_search`, `image_search`,
+`person_search`, `person_read`, `person_ancestors`, `fulltext_search`, `image_search`,
 `person_record_matches`, `record_person_matches`, `person_person_matches`,
 `record_record_matches`, and `source_attachments`) must go through this module — do not
 re-implement token plumbing.

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ The MCP server exposes 30 tools.
 | `person_person_matches` | Possible-duplicate tree-person matches for a tree person | OAuth |
 | `record_record_matches` | Other historical records describing the same individual | OAuth |
 | `person_read` | FamilySearch Family Tree person data — relatives and attached sources | OAuth |
-| `person_ancestors` | FamilySearch Family Tree pedigree — a person plus up to N generations of ancestors, each tagged with its Ahnentafel (ascendancy) number | OAuth |
+| `person_ancestors` | FamilySearch Family Tree pedigree — a person (or, when no ID is given, the logged-in user) plus up to N generations of ancestors, each tagged with its Ahnentafel (ascendancy) number | OAuth |
 | `source_attachments` | Check whether source ARKs are already attached to tree persons | OAuth |
 | `place_external_links` | FS-curated third-party genealogy URLs by place + year | None |
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ the same; the tools just help you meet it faster.
 
 ## MCP tools
 
-The MCP server exposes 29 tools.
+The MCP server exposes 30 tools.
 
 ### FamilySearch records and places
 
@@ -64,6 +64,7 @@ The MCP server exposes 29 tools.
 | `person_person_matches` | Possible-duplicate tree-person matches for a tree person | OAuth |
 | `record_record_matches` | Other historical records describing the same individual | OAuth |
 | `person_read` | FamilySearch Family Tree person data — relatives and attached sources | OAuth |
+| `person_ancestors` | FamilySearch Family Tree pedigree — a person plus up to N generations of ancestors, each tagged with its Ahnentafel (ascendancy) number | OAuth |
 | `source_attachments` | Check whether source ARKs are already attached to tree persons | OAuth |
 | `place_external_links` | FS-curated third-party genealogy URLs by place + year | None |
 
@@ -388,14 +389,14 @@ then narrows the search.
 
 What's shipped:
 
-- **29 MCP tools.** OAuth (`login`, `logout`, `auth_status`); public
+- **30 MCP tools.** OAuth (`login`, `logout`, `auth_status`); public
   reference tools (`wikipedia_search`, `place_search`, `place_population`,
   `place_external_links`, `place_distance`); authenticated search/read
   tools (`place_collections`, `record_search`, `record_read`,
   `person_search`, `fulltext_search`, `image_search`, `image_read`,
   `match_two_examples`, `person_record_matches`, `record_person_matches`,
   `person_person_matches`, `record_record_matches`, `person_read`,
-  `source_attachments`); FamilySearch Wiki tools (`wiki_search`,
+  `person_ancestors`, `source_attachments`); FamilySearch Wiki tools (`wiki_search`,
   `wiki_read`, and four `wiki_country_*` tools); local validation
   (`validate_research_schema`).
 - **24 skills.** Full GPS research cycle from `init-project` through

--- a/docs/specs/person-ancestors-tool-spec.md
+++ b/docs/specs/person-ancestors-tool-spec.md
@@ -62,19 +62,44 @@ envelope, no derived summary fields.
 
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
-| `personId` | string | **Yes** | — | The starting tree-person ID (e.g. `"LZJW-C31"`). The root of the pedigree (ascendancy number `1`). Maps to the endpoint's `person` parameter. |
+| `personId` | string | No | *current user* | The starting tree-person ID (e.g. `"LZJW-C31"`). The root of the pedigree (ascendancy number `1`). Maps to the endpoint's `person` parameter. **Optional** — when omitted (or empty), the tool resolves the logged-in user's own tree person and returns the user plus their ancestors (see *Defaulting to the current user*). |
 | `generations` | number | No | `3` | How many generations of ancestors to return above the root. Integer **1–8** (FamilySearch's hard maximum). |
 | `spouse` | string | No | — | Also include this spouse's ancestry. A spouse tree-person ID, or the literal `"UNKNOWN"` to let FamilySearch choose the spouse. |
 | `personDetails` | boolean | No | `false` | When `true`, each person carries a full `facts` array (Birth, Death, …). When `false` (the API default), persons have only name, gender, and `ascendancyNumber` — **no facts, no dates**. The LLM sets this when the user asks for dates/vitals. |
 | `marriageDetails` | boolean | No | `false` | When `true`, the response includes `relationships` — `Couple` entries with marriage facts between the ancestral couples. When `false`, no `relationships` are returned. |
 | `descendants` | boolean | No | `false` | When `true`, additional descendant detail is returned for persons in the pedigree. |
 
-`personId` is the only required field; the other five map one-to-one to
-the endpoint's optional parameters (the task is to "expose the
-parameters of that call"). `personDetails`, `marriageDetails`, and
-`descendants` are independent per-call toggles the LLM flips based on the
-user's request; their schema descriptions state exactly what each adds so
-the model can choose correctly.
+No field is strictly required: omitting `personId` defaults to the
+current user (below). The other five map one-to-one to the endpoint's
+optional parameters (the task is to "expose the parameters of that
+call"). `personDetails`, `marriageDetails`, and `descendants` are
+independent per-call toggles the LLM flips based on the user's request;
+their schema descriptions state exactly what each adds so the model can
+choose correctly.
+
+### Defaulting to the current user
+
+When `personId` is omitted (or an empty/whitespace string), the tool
+first resolves the **logged-in user's own tree person** and uses it as
+the root. So `person_ancestors({})` returns *you and your ancestors* — a
+convenient "me" shortcut.
+
+Resolution calls `GET /platform/users/current` ("Read Current User") and
+reads **`users[0].personId`** *(probe-confirmed 2026-06-04)*. That
+response also carries account PII (`helperAccessPin`, `birthDate`, names,
+…) — the tool reads **only** `personId` and never surfaces or logs the
+rest. The user's own person is typically `living`; running ancestry on it
+is fine (it returns `persons: [self]` when no ancestors are entered — not
+an error).
+
+**Footgun — the LLM must not omit `personId` for a *named* person.**
+Omitting it always means "the current user," so a request like *"show me
+Abraham Lincoln's ancestors"* must **not** be answered by calling
+`person_ancestors({})` (that would return the *user's* ancestors). For
+any person other than the user, the LLM resolves the name to a tree ID
+via `person_search` first, then passes that `personId`. The tool
+description states this explicitly. Omit `personId` **only** for
+self-requests (*"my ancestors,"* *"my great-grandparents"*).
 
 ### Examples
 
@@ -92,6 +117,11 @@ Full vitals on each ancestor, with marriage facts between couples:
 Include a chosen spouse's ancestry too:
 ```json
 { "personId": "LZJW-C31", "generations": 4, "spouse": "LCHV-P5R" }
+```
+
+The current user's own ancestors (no `personId`):
+```json
+{ "generations": 4 }
 ```
 
 ---
@@ -206,26 +236,29 @@ dates** — to get them, the LLM sets `personDetails: true`.
     "that person's parents; the -S suffix marks a spouse). Set generations " +
     "(1-8, default 3) for depth, personDetails: true for full birth/death " +
     "facts on each ancestor, marriageDetails: true for marriage facts between " +
-    "couples. Requires authentication — call the login tool first if not " +
+    "couples. If personId is omitted, returns the CURRENT logged-in user's " +
+    "own ancestors. For any OTHER (named) person, first call person_search " +
+    "to get their personId — do NOT omit personId for someone other than the " +
+    "user. Requires authentication — call the login tool first if not " +
     "logged in.",
   inputSchema: {
     type: "object",
     properties: {
-      personId:        { type: "string",  description: "FamilySearch tree-person ID of the root person (e.g. \"LZJW-C31\"). Required." },
+      personId:        { type: "string",  description: "FamilySearch tree-person ID of the root person (e.g. \"LZJW-C31\"). Optional — omit to use the logged-in user's own tree person (returns the user and their ancestors). Omit ONLY for self-requests; for a named person, resolve their ID with person_search first." },
       generations:     { type: "number",  description: "Generations of ancestors to return above the root. Integer 1-8. Defaults to 3." },
       spouse:          { type: "string",  description: "Also include this spouse's ancestry. A spouse tree-person ID, or \"UNKNOWN\" to let FamilySearch choose the spouse." },
       personDetails:   { type: "boolean", description: "When true, include a full facts array (Birth, Death, ...) on each person. Defaults to false (name, gender, and ascendancyNumber only — no dates)." },
       marriageDetails: { type: "boolean", description: "When true, include relationships (Couple entries with marriage facts) between the ancestral couples. Defaults to false." },
       descendants:     { type: "boolean", description: "When true, include additional descendant detail for persons in the pedigree. Defaults to false." }
-    },
-    required: ["personId"]
+    }
   }
 }
 ```
 
-`personId` is required via JSON Schema. `generations` range (1–8) is
-checked in `validateInput` for a clear error message before the call
-(the server also enforces it — see Error Handling).
+No field is required via JSON Schema — omitting `personId` triggers the
+current-user lookup. `generations` range (1–8) is checked in
+`validateInput` for a clear error message before the call (the server
+also enforces it — see Error Handling).
 
 ---
 
@@ -263,7 +296,7 @@ Accept: application/x-fs-v1+json
 
 | Tool input | API parameter | Notes |
 |------------|---------------|-------|
-| `personId` | `person` | Required. |
+| `personId` | `person` | The resolved root ID — the supplied `personId`, or the current user's `personId` when omitted. |
 | `generations` | `generations` | Sent as the resolved value (default `3`). |
 | `spouse` | `spouse` | ID or `"UNKNOWN"`. Omitted when absent. |
 | `personDetails=true` | `personDetails=true` | Omitted when false/absent. |
@@ -297,9 +330,34 @@ clarity):** `generations > 8` → `400 "readAncestry.generations: must be
 less than or equal to 8"`; `generations < 1` → `400 "... greater than or
 equal to 1"`. Unknown `person` → `404`.
 
+**Current-user resolution endpoint (only when `personId` is omitted):**
+
+```
+GET https://api.familysearch.org/platform/users/current
+Authorization: Bearer <access_token>
+Accept: application/x-fs-v1+json
+```
+
+Response *(probe-confirmed 2026-06-04)*:
+
+```
+response.users[0].personId   -> the user's tree person ID (e.g. "P8M8-S2C")  [the only field read]
+response.users[0].(helperAccessPin, birthDate, givenName, familyName, ...)  -> account PII; NOT read or surfaced
+```
+
+A bad token returns `401` with the standard `{ errors: [{ code, message }] }`
+body. Per the FS docs, the endpoint "returns partial user data when Tree
+Data is unavailable," so `users[0].personId` may be **absent** — handled
+as an error (below). No browser User-Agent needed (same host).
+
 ---
 
 ## Mapping Logic
+
+**Step 0 — resolve the root personId.** If `personId` is a non-empty
+string, trim and use it. Otherwise call `getCurrentUserPersonId(token)`
+(`GET /platform/users/current`) and use `users[0].personId`. Everything
+below operates on the resolved ID.
 
 1. **Convert once.** Build
    `toSimplified({ persons: body.persons, relationships: marriageDetails ? body.relationships : [] })`.
@@ -331,9 +389,12 @@ Mirrors `person_read`'s status handling (shared host contract).
 
 | Condition | Behavior |
 |-----------|----------|
-| `personId` missing / not a non-empty string | Throw: `"person_ancestors requires a non-empty personId string (e.g., \"LZJW-C31\")."` |
+| `personId` omitted / empty | Resolve the current user (see *current-user lookup* rows below); not an error. |
 | `generations` supplied but not an integer in `[1, 8]` | Throw: `"generations must be an integer between 1 and 8."` |
 | Not authenticated | Let `getValidToken()` throw its LLM-instruction error. |
+| **Current-user lookup** 401 | Throw the same re-auth message as the ancestry 401 below. |
+| **Current-user lookup** 200 but `users[0].personId` absent | Throw: `"Could not determine your FamilySearch tree person (your account may not be linked to one). Pass a personId explicitly."` |
+| **Current-user lookup** other non-OK | Throw: `"FamilySearch could not read your current user: HTTP ${status}."` |
 | API returns 204 (no body) | Return `{ persons: [] }`. |
 | API returns 301 (person merged) | Follow the `Location` header to the new ID and re-fetch, capped at **1** redirect. Missing `Location` or a second redirect → throw a `"redirect loop"` / `"missing Location"` error. |
 | API returns 401 | Throw: `"FamilySearch rejected the access token (401). The session may have expired or been revoked — call the login tool to re-authenticate."` |
@@ -357,8 +418,10 @@ for little benefit.
 
 ### `mcp-server/src/types/person-ancestors.ts`
 FS response types (`FSAncestryPerson`, `FSAncestryDisplay`,
-`FSAncestryRelationship`, `FSAncestryResponse`) and tool I/O types
-(`PersonAncestorsInput`, `AncestorPerson`, `PersonAncestorsResult` =
+`FSAncestryRelationship`, `FSAncestryResponse`, `FSCurrentUserResponse` =
+`{ users?: Array<{ personId?: string }> }`) and tool I/O types
+(`PersonAncestorsInput` with `personId` **optional**, `AncestorPerson`,
+`PersonAncestorsResult` =
 `{ persons: AncestorPerson[]; relationships?: SimplifiedRelationship[] }`).
 Reuse shared GedcomX types from `src/types/gedcomx.ts`
 (`SimplifiedPerson`, `SimplifiedName`, `SimplifiedFact`,
@@ -367,10 +430,16 @@ Reuse shared GedcomX types from `src/types/gedcomx.ts`
 ### `mcp-server/src/tools/person-ancestors.ts`
 - `personAncestorsToolSchema` — the MCP schema above.
 - `personAncestorsTool(input)` — entry point: validate, authenticate,
-  fetch (with `redirect: "manual"`), map.
-- `validateInput(input)` — `personId` + `generations` range checks.
-- `buildUrl(input)` — `person`/`generations`/`spouse`/`*Details` builder
-  with `encodeURIComponent`.
+  resolve root pid (provided or current-user), fetch (with
+  `redirect: "manual"`), map.
+- `validateInput(input)` — `generations` range check (personId is
+  optional; no required check).
+- `getCurrentUserPersonId(token)` — `GET /platform/users/current` →
+  `users[0].personId`; reuses the 401 message and `parseUpstreamErrorBody`;
+  throws the "no tree person" error when absent. Inline here for now
+  (single caller); promote to `src/auth/` if a second tool needs it.
+- `buildUrl(input, pid)` — `person`/`generations`/`spouse`/`*Details`
+  builder with `encodeURIComponent`.
 - `mapResponse(body, marriageDetails)` — the 4-step mapping above.
 - `extractPersonId(location)` — bare-ID parse from a `…/persons/<id>`
   redirect/ref (same shape as `person_read`).
@@ -406,7 +475,9 @@ a trimmed Lincoln ancestry response (root `1`, spouse `1-S`, parents
 | 1 | Returns `{ persons }` for a valid `personId` (default generations) | Happy path |
 | 2 | Each person carries `ascendancyNumber` (`"1"`, `"2"`, `"1-S"`) | Ancestry-field re-attach |
 | 3 | No envelope: result is the graph directly; `persons.length` matches | Output shape |
-| 4 | Throws when `personId` is missing/empty | Input validation |
+| 4 | No `personId` → first fetch is `/platform/users/current`, second is ancestry on `users[0].personId`; result is the pedigree. Empty/whitespace `personId` behaves the same | Current-user default |
+| 4b | Provided `personId` makes a single fetch (ancestry only — no `/users/current` lookup) | No needless lookup |
+| 4c | Current-user lookup 401 → re-auth error; 200 without `users[0].personId` → "Pass a personId explicitly"; other non-OK → generic | Lookup error handling |
 | 5 | Throws when `generations` is 0, 9, or non-integer | Range validation |
 | 6 | `buildUrl` maps `personId→person`, `generations`, `spouse`, `personDetails`, `marriageDetails`, `descendants`; omits absent params | Param mapping |
 | 7 | `generations` defaults to 3 in the URL when not supplied | Default |
@@ -425,6 +496,7 @@ a trimmed Lincoln ancestry response (root `1`, spouse `1-S`, parents
 
 ```bash
 cd mcp-server
+npx tsx dev/try-person-ancestors.ts                 # no id → the logged-in user + ancestors
 npx tsx dev/try-person-ancestors.ts LZJW-C31
 npx tsx dev/try-person-ancestors.ts LZJW-C31 --generations 4 --person-details
 npx tsx dev/try-person-ancestors.ts LZJW-C31 --generations 2 --marriage-details
@@ -468,6 +540,7 @@ per `docs/testing-guides/oauth-tool-testing-guide.md`).
 ## References
 
 - Read Ancestry (endpoint reference): https://developers.familysearch.org/main/reference/readancestry *(verified live 2026-06-02)*
+- Read Current User (self-default lookup): https://developers.familysearch.org/main/reference/readcurrentuser *(verified live 2026-06-04)*
 - `docs/specs/simplified-gedcomx-spec.md` — output format for the persons/relationships.
 - `docs/specs/person-read-tool-spec.md` — sibling tree-read tool; shared
   host contract, status handling, `personId` naming, and the
@@ -477,4 +550,5 @@ per `docs/testing-guides/oauth-tool-testing-guide.md`).
 
 Evidence trail: `mcp-server/dev/probe-ancestry.ts`,
 `probe-ancestry-numbering.ts`, `probe-ancestry-rels-sources.ts`
-(run 2026-06-02).
+(run 2026-06-02); `probe-current-user.ts`, `probe-self-ancestry.ts`
+(self-default, run 2026-06-04).

--- a/docs/specs/person-ancestors-tool-spec.md
+++ b/docs/specs/person-ancestors-tool-spec.md
@@ -1,0 +1,480 @@
+# Person Ancestors Tool — Implementation Spec
+
+## Overview
+
+An MCP tool that reads a person's **pedigree** from the FamilySearch
+Family Tree: given one tree-person ID, it returns that person plus up to
+N generations of ancestors, each tagged with its **Ahnentafel
+(ascendancy) number** so the caller can reconstruct the tree. Results
+are returned as simplified GedcomX.
+
+Requires authentication (OAuth tokens from the `login` tool). Wraps the
+documented FamilySearch platform endpoint
+`GET /platform/tree/ancestry` ("Read Ancestry").
+
+This is the **walk-up-the-tree** primitive. It complements:
+
+- `person_search` — find a candidate person in the tree (returns a
+  tree-person ID).
+- `person_read` — read one person plus immediate relatives (parents,
+  spouses, children).
+- **`person_ancestors`** (this tool) — read many generations upward in
+  one call, as a numbered pedigree.
+
+```
+person_search({ surname, givenName, ... })   // find the starting person
+  ↓  user picks one → personId (e.g. "LZJW-C31")
+person_ancestors({ personId, generations: 4 })   // walk up 4 generations
+```
+
+### The ascendancy number (the one field we add — and why)
+
+The endpoint returns a flat list of persons (up to 215 at
+`generations=8`) and — confirmed by probe — **no parent-child
+relationships at all**. The *only* thing encoding the tree structure is
+the **ascendancy number** FamilySearch puts on each person
+(`display.ascendancyNumber`). It is the classic Ahnentafel numbering:
+
+- `1` = the starting person (the root).
+- `1-S` = the root's spouse. The `-S` suffix marks a spouse; the root's
+  spouse is returned by default.
+- `2` = father, `3` = mother.
+- Rule: a person numbered *n* has father *2n* and mother *2n + 1*.
+
+So `4`/`5` are the father's parents, `6`/`7` are the mother's parents,
+and so on. **`ascendancyNumber` is a string** (`"1"`, `"2"`, `"1-S"`),
+not an integer — the `-S` suffix and future variants require it.
+
+`toSimplified` reads only `names`, `gender`, `facts`, and `identifiers`
+— it never looks at the `display` block, so the ascendancy number is
+**not carried through conversion**. Because simplified GedcomX has no
+slot for a pedigree position, this tool **re-attaches the number onto
+each converted person afterward** (read from the raw person still in
+hand). This is the identical move `person_read` makes to re-attach
+`living`. Without it the output would be a meaningless flat list, so this
+one addition is what makes "convert the results" preserve the result's
+meaning — it is not optional enrichment. Nothing else is added: no
+envelope, no derived summary fields.
+
+---
+
+## Input
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `personId` | string | **Yes** | — | The starting tree-person ID (e.g. `"LZJW-C31"`). The root of the pedigree (ascendancy number `1`). Maps to the endpoint's `person` parameter. |
+| `generations` | number | No | `3` | How many generations of ancestors to return above the root. Integer **1–8** (FamilySearch's hard maximum). |
+| `spouse` | string | No | — | Also include this spouse's ancestry. A spouse tree-person ID, or the literal `"UNKNOWN"` to let FamilySearch choose the spouse. |
+| `personDetails` | boolean | No | `false` | When `true`, each person carries a full `facts` array (Birth, Death, …). When `false` (the API default), persons have only name, gender, and `ascendancyNumber` — **no facts, no dates**. The LLM sets this when the user asks for dates/vitals. |
+| `marriageDetails` | boolean | No | `false` | When `true`, the response includes `relationships` — `Couple` entries with marriage facts between the ancestral couples. When `false`, no `relationships` are returned. |
+| `descendants` | boolean | No | `false` | When `true`, additional descendant detail is returned for persons in the pedigree. |
+
+`personId` is the only required field; the other five map one-to-one to
+the endpoint's optional parameters (the task is to "expose the
+parameters of that call"). `personDetails`, `marriageDetails`, and
+`descendants` are independent per-call toggles the LLM flips based on the
+user's request; their schema descriptions state exactly what each adds so
+the model can choose correctly.
+
+### Examples
+
+Four generations of Abraham Lincoln's ancestors (lean):
+```json
+{ "personId": "LZJW-C31", "generations": 4 }
+```
+
+Full vitals on each ancestor, with marriage facts between couples:
+```json
+{ "personId": "LZJW-C31", "generations": 3,
+  "personDetails": true, "marriageDetails": true }
+```
+
+Include a chosen spouse's ancestry too:
+```json
+{ "personId": "LZJW-C31", "generations": 4, "spouse": "LCHV-P5R" }
+```
+
+---
+
+## Output
+
+The tool returns the pedigree **as a simplified GedcomX graph, directly**
+— the same shape `person_read` returns, with no wrapping envelope:
+
+```typescript
+{
+  persons: AncestorPerson[];
+  relationships?: SimplifiedRelationship[];  // present ONLY with marriageDetails
+}
+```
+
+There is intentionally **no** `personId` / `generations` / `ancestorCount`
+envelope: the count is `persons.length`, the generation depth is what the
+caller passed, and the root is the person whose `ascendancyNumber` is
+`"1"`. Adding those would be redundant metadata the task did not ask for.
+
+Each **`AncestorPerson`** is a standard simplified person extended with
+exactly one ancestry-specific field:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `ascendancyNumber` | string | Ahnentafel position (`"1"`, `"2"`, `"1-S"`, …). Re-attached from the raw `display.ascendancyNumber`. **The field that encodes the tree.** |
+| `id` | string | FamilySearch tree-person ID (e.g. `"9VMF-H1F"`). Preserved by `toSimplified` — **not** renumbered to `I1`/`N1` (see ID note). |
+| `ark` | string \| undefined | Persistent ark URL, from the person's `identifiers`. |
+| `gender` | string \| undefined | `"Male"` / `"Female"` / `"Unknown"`. |
+| `names` | SimplifiedName[] | **All** name forms FamilySearch returns, each with its `preferred`/`type` flags — `given`/`surname` plus `prefix`/`suffix` when those parts exist (e.g. `prefix: "President"`, `prefix: "Capt"`). Under `personDetails` this includes alternate names (`BirthName`/`AlsoKnownAs`/`MarriedName`), kept as genealogical research clues. Unlike `person_read`, the tool does **not** narrow to a single preferred name; consumers should honor `preferred: true` to pick the display name. |
+| `facts` | SimplifiedFact[] \| undefined | Present **only** when `personDetails: true`. Birth/Death/etc. with `date`/`place`. |
+
+`gedcomx.relationships` (present **only** when `marriageDetails: true`)
+is an array of simplified `Couple` relationships, each with `person1`
+and `person2` as **bare tree IDs** and the marriage `facts`. When
+`marriageDetails` is off, the `relationships` key is omitted.
+
+**Per-person `sources` are stripped.** With `personDetails: true` the raw
+persons carry `sources`, but the ancestry response includes **no**
+top-level `sourceDescriptions`, so those refs would be dangling. They
+are removed from this tool's output only; `toSimplified` is unchanged, so
+other callers keep their sources. (Same rationale as `person_search`.)
+
+**ID note (don't "fix" this):** `toSimplified` preserves the source
+person's FamilySearch ID, so `persons[*].id` are real tree IDs (e.g.
+`"9VMF-H1F"`), **not** the abstract `I1`/`N1`/`F1` IDs that
+`simplified-gedcomx-spec.md` §3 assigns only when curating the
+`tree.gedcomx.json` deliverable. Emitting FS IDs here is correct and
+matches `person_read` / `person_search`.
+
+### Example — `person_ancestors({ personId: "LZJW-C31", generations: 2 })`
+
+```jsonc
+{
+  "persons": [
+    { "id": "LZJW-C31", "ascendancyNumber": "1",   "gender": "Male",
+      "names": [{ "prefix": "President", "given": "Abraham", "surname": "Lincoln" }] },
+    { "id": "LCHV-P5R", "ascendancyNumber": "1-S", "gender": "Female",
+      "names": [{ "given": "Mary Ann", "surname": "Todd" }] },
+    { "id": "9VMF-H1F", "ascendancyNumber": "2",   "gender": "Male",
+      "names": [{ "given": "Thomas Herring", "surname": "Lincoln" }] },
+    { "id": "KN6W-CSY", "ascendancyNumber": "3",   "gender": "Female",
+      "names": [{ "given": "Nancy Elizabeth", "surname": "Hanks" }] },
+    { "id": "LKBG-8W2", "ascendancyNumber": "4", "gender": "Male",   "names": [{ "prefix": "Capt", "given": "Abraham", "surname": "Lincoln" }] },
+    { "id": "LXQL-TV6", "ascendancyNumber": "5", "gender": "Female", "names": [{ "given": "Bathsheba", "surname": "Herring" }] },
+    { "id": "L1H7-RXW", "ascendancyNumber": "6", "gender": "Male",   "names": [{ "given": "Joseph",    "surname": "Hanks" }] },
+    { "id": "PSPQ-97W", "ascendancyNumber": "7", "gender": "Female", "names": [{ "given": "Ann Nanny", "surname": "Lee" }] }
+  ]
+}
+```
+
+How to read it: walk `persons`; `ascendancyNumber` tells you the tree —
+`2` and `3` are person `1`'s parents; `4`/`5` are `2`'s parents; `6`/`7`
+are `3`'s parents. No nesting needed. Persons are emitted in the order
+FamilySearch returns them (root, root's spouse, then ascending Ahnentafel
+order); the tool does not re-sort. In this lean default there are **no
+dates** — to get them, the LLM sets `personDetails: true`.
+
+### Example — with `personDetails: true, marriageDetails: true`
+
+```jsonc
+{
+  "persons": [
+    { "id": "LZJW-C31", "ascendancyNumber": "1", "gender": "Male",
+      "names": [{ "prefix": "President", "given": "Abraham", "surname": "Lincoln" }],
+      "facts": [
+        { "type": "Birth", "date": "12 February 1809", "place": "Sinking Spring Farm, Hardin, Kentucky, United States" },
+        { "type": "Death", "date": "15 April 1865",    "place": "Washington, District of Columbia, United States" }
+      ] }
+    // ... the other persons, each now carrying facts ...
+  ],
+  "relationships": [
+    { "type": "Couple", "person1": "9VMF-H1F", "person2": "KN6W-CSY",
+      "facts": [{ "type": "Marriage", "date": "12 June 1806", "place": "Washington, Kentucky, United States" }] }
+  ]
+}
+```
+
+---
+
+## Tool Schema
+
+```typescript
+{
+  name: "person_ancestors",
+  description:
+    "Read a person's ancestors (pedigree) from the FamilySearch Family Tree. " +
+    "Given a tree-person ID, returns that person plus up to N generations of " +
+    "ancestors as simplified GEDCOMX, each tagged with an ascendancyNumber " +
+    "(Ahnentafel position: 1 = the person, 2 = father, 3 = mother, 2n/2n+1 = " +
+    "that person's parents; the -S suffix marks a spouse). Set generations " +
+    "(1-8, default 3) for depth, personDetails: true for full birth/death " +
+    "facts on each ancestor, marriageDetails: true for marriage facts between " +
+    "couples. Requires authentication — call the login tool first if not " +
+    "logged in.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      personId:        { type: "string",  description: "FamilySearch tree-person ID of the root person (e.g. \"LZJW-C31\"). Required." },
+      generations:     { type: "number",  description: "Generations of ancestors to return above the root. Integer 1-8. Defaults to 3." },
+      spouse:          { type: "string",  description: "Also include this spouse's ancestry. A spouse tree-person ID, or \"UNKNOWN\" to let FamilySearch choose the spouse." },
+      personDetails:   { type: "boolean", description: "When true, include a full facts array (Birth, Death, ...) on each person. Defaults to false (name, gender, and ascendancyNumber only — no dates)." },
+      marriageDetails: { type: "boolean", description: "When true, include relationships (Couple entries with marriage facts) between the ancestral couples. Defaults to false." },
+      descendants:     { type: "boolean", description: "When true, include additional descendant detail for persons in the pedigree. Defaults to false." }
+    },
+    required: ["personId"]
+  }
+}
+```
+
+`personId` is required via JSON Schema. `generations` range (1–8) is
+checked in `validateInput` for a clear error message before the call
+(the server also enforces it — see Error Handling).
+
+---
+
+## Authentication
+
+Requires a valid FamilySearch access token. Calls `getValidToken()` from
+`src/auth/refresh.ts` — the single entry point for authenticated tools.
+Do not re-implement token plumbing. If the user is not authenticated,
+`getValidToken()` throws an LLM-instruction error directing them to the
+`login` tool; the handler lets it propagate.
+
+**No browser User-Agent is required.** *(Empirical, probe 2026-06-02:
+the platform host `api.familysearch.org` is not behind the Imperva WAF —
+requests succeed with and without a UA. Same host contract as
+`person_read` / `person_search`.)*
+
+No `Accept-Language` header is sent. The tool reads only
+locale-independent fields — `fact.*.original` (via `toSimplified`) and
+`display.ascendancyNumber` (a numbering token) — so the session locale
+does not affect output. (Matches `person_read`.)
+
+---
+
+## FamilySearch API Reference
+
+**Endpoint (auth required):**
+
+```
+GET https://api.familysearch.org/platform/tree/ancestry
+Authorization: Bearer <access_token>
+Accept: application/x-fs-v1+json
+```
+
+**Tool input → API parameter mapping:**
+
+| Tool input | API parameter | Notes |
+|------------|---------------|-------|
+| `personId` | `person` | Required. |
+| `generations` | `generations` | Sent as the resolved value (default `3`). |
+| `spouse` | `spouse` | ID or `"UNKNOWN"`. Omitted when absent. |
+| `personDetails=true` | `personDetails=true` | Omitted when false/absent. |
+| `marriageDetails=true` | `marriageDetails=true` | Omitted when false/absent. |
+| `descendants=true` | `descendants=true` | Omitted when false/absent. |
+
+URL-encode every value with `encodeURIComponent`.
+
+**Response shape** *(confirmed by probe 2026-06-02):*
+
+```
+response.persons[]
+  .id                                  -> bare tree-person ID
+  .living                              -> boolean
+  .gender.type                         -> URL form (e.g. "http://gedcomx.org/Male")
+  .names[].nameForms[].fullText/.parts -> name (read by toSimplified)
+  .identifiers["http://gedcomx.org/Persistent"][0] -> ark URL
+  .display.ascendancyNumber            -> STRING Ahnentafel number ("1", "2", "1-S")  [re-attached]
+  .display.name/.gender/.lifespan      -> normalized summary (NOT read by this tool)
+  .facts[]                             -> present ONLY with personDetails=true
+  .sources[]                           -> present with personDetails; dangling (no sourceDescriptions) -> STRIPPED
+response.relationships[]               -> present ONLY with marriageDetails=true
+  .type = "http://gedcomx.org/Couple"
+  .person1/.person2 { resource (URL), resourceId }   -> resource is read by toSimplified; strip URL -> bare ID
+  .facts[] (Marriage)
+response.sourceDescriptions            -> NOT returned by this endpoint (so per-person sources are dangling)
+```
+
+**Server-side validation (relied upon, mirrored client-side for
+clarity):** `generations > 8` → `400 "readAncestry.generations: must be
+less than or equal to 8"`; `generations < 1` → `400 "... greater than or
+equal to 1"`. Unknown `person` → `404`.
+
+---
+
+## Mapping Logic
+
+1. **Convert once.** Build
+   `toSimplified({ persons: body.persons, relationships: marriageDetails ? body.relationships : [] })`.
+   This yields simplified persons (id, ark, gender, names, facts) and,
+   when requested, simplified `Couple` relationships.
+2. **Re-attach the ascendancy number.** Index the raw persons by `id`.
+   For each simplified person, set `ascendancyNumber` ←
+   `raw.display.ascendancyNumber`. A person with no
+   `display.ascendancyNumber` is skipped (defensive — every real ancestry
+   person has one).
+3. **Strip dangling sources.** Delete `sources` from every output person
+   (they have no matching `sourceDescriptions`). Mutates this tool's
+   result only.
+4. **Shape relationships** (only when `marriageDetails`): for each
+   simplified `Couple`, strip `person1`/`person2` to bare tree IDs
+   (drop any `…/persons/<id>` URL prefix, same as `person_read`'s
+   `extractPersonRef`) and keep the marriage `facts`.
+
+**Assembled result:**
+`{ persons, ...(marriageDetails ? { relationships } : {}) }`. After a
+`301` merge the persons come from the merged-to person; the root is
+identifiable as `ascendancyNumber === "1"`.
+
+---
+
+## Error Handling
+
+Mirrors `person_read`'s status handling (shared host contract).
+
+| Condition | Behavior |
+|-----------|----------|
+| `personId` missing / not a non-empty string | Throw: `"person_ancestors requires a non-empty personId string (e.g., \"LZJW-C31\")."` |
+| `generations` supplied but not an integer in `[1, 8]` | Throw: `"generations must be an integer between 1 and 8."` |
+| Not authenticated | Let `getValidToken()` throw its LLM-instruction error. |
+| API returns 204 (no body) | Return `{ persons: [] }`. |
+| API returns 301 (person merged) | Follow the `Location` header to the new ID and re-fetch, capped at **1** redirect. Missing `Location` or a second redirect → throw a `"redirect loop"` / `"missing Location"` error. |
+| API returns 401 | Throw: `"FamilySearch rejected the access token (401). The session may have expired or been revoked — call the login tool to re-authenticate."` |
+| API returns 403 | Throw: `"Person ${personId} is restricted and cannot be viewed."` |
+| API returns 404 | Throw: `"Person ${personId} not found in the FamilySearch Family Tree."` |
+| API returns 410 (deleted) | Throw: `"Person ${personId} has been deleted from the FamilySearch Family Tree."` |
+| API returns 400 | Read body JSON, extract `errors[0].message`, throw: `"FamilySearch ancestry request rejected: ${detail}."` Fall back to a generic message if unparseable. |
+| API returns 429 | Throw: `"FamilySearch rate limit reached. Wait a moment and try again."` |
+| API returns other non-OK status | Throw: `"FamilySearch ancestry API error: ${status}."` |
+
+---
+
+## Caching
+
+None. The tree changes as users edit it; caching would risk staleness
+for little benefit.
+
+---
+
+## Files
+
+### `mcp-server/src/types/person-ancestors.ts`
+FS response types (`FSAncestryPerson`, `FSAncestryDisplay`,
+`FSAncestryRelationship`, `FSAncestryResponse`) and tool I/O types
+(`PersonAncestorsInput`, `AncestorPerson`, `PersonAncestorsResult` =
+`{ persons: AncestorPerson[]; relationships?: SimplifiedRelationship[] }`).
+Reuse shared GedcomX types from `src/types/gedcomx.ts`
+(`SimplifiedPerson`, `SimplifiedName`, `SimplifiedFact`,
+`SimplifiedRelationship`).
+
+### `mcp-server/src/tools/person-ancestors.ts`
+- `personAncestorsToolSchema` — the MCP schema above.
+- `personAncestorsTool(input)` — entry point: validate, authenticate,
+  fetch (with `redirect: "manual"`), map.
+- `validateInput(input)` — `personId` + `generations` range checks.
+- `buildUrl(input)` — `person`/`generations`/`spouse`/`*Details` builder
+  with `encodeURIComponent`.
+- `mapResponse(body, marriageDetails)` — the 4-step mapping above.
+- `extractPersonId(location)` — bare-ID parse from a `…/persons/<id>`
+  redirect/ref (same shape as `person_read`).
+
+### `mcp-server/src/tool-schemas.ts`
+Add `personAncestorsToolSchema` to `allToolSchemas`.
+
+### `mcp-server/src/index.ts`
+Add the `person_ancestors` dispatch branch (import tool + input type,
+call within the existing try/catch pattern).
+
+### `mcp-server/manifest.json`
+Add `{ "name": "person_ancestors" }` to `tools`.
+
+### `mcp-server/dev/try-person-ancestors.ts`
+Live smoke-test CLI, e.g.
+`npx tsx dev/try-person-ancestors.ts LZJW-C31 --generations 4 --person-details`.
+
+---
+
+## Testing
+
+### `tests/tools/person-ancestors.test.ts`
+
+Mocks `fetch` and `getValidToken`; uses the real `toSimplified`. Fixture:
+a trimmed Lincoln ancestry response (root `1`, spouse `1-S`, parents
+`2`/`3`, each with `display.ascendancyNumber`, plus one person carrying
+`facts` and dangling `sources` for the personDetails cases, and one
+`Couple` relationship with a Marriage fact).
+
+| # | Test case | Verifies |
+|---|-----------|----------|
+| 1 | Returns `{ persons }` for a valid `personId` (default generations) | Happy path |
+| 2 | Each person carries `ascendancyNumber` (`"1"`, `"2"`, `"1-S"`) | Ancestry-field re-attach |
+| 3 | No envelope: result is the graph directly; `persons.length` matches | Output shape |
+| 4 | Throws when `personId` is missing/empty | Input validation |
+| 5 | Throws when `generations` is 0, 9, or non-integer | Range validation |
+| 6 | `buildUrl` maps `personId→person`, `generations`, `spouse`, `personDetails`, `marriageDetails`, `descendants`; omits absent params | Param mapping |
+| 7 | `generations` defaults to 3 in the URL when not supplied | Default |
+| 8 | No `User-Agent` / no `Accept-Language` header sent; `Accept: application/x-fs-v1+json` is | Host contract |
+| 9 | Without `personDetails`, persons have no `facts`; with it, facts come through | personDetails switch |
+| 10 | Per-person `sources` are stripped even when present in the raw person | Dangling-source strip |
+| 11 | With `marriageDetails`, `relationships` has a `Couple` with bare-ID `person1`/`person2` and the Marriage fact; without it, no `relationships` key | Relationship shaping |
+| 12 | Person IDs are real FS IDs (e.g. `"9VMF-H1F"`), not renumbered | ID preservation |
+| 13 | 204 returns `{ persons: [] }` | Empty handling |
+| 14 | 301 follows `Location` and reads the merged-to person; second redirect throws | Merge redirect |
+| 15 | Throws auth error when not authenticated | Auth propagation |
+| 16 | 401 / 403 / 404 / 410 / 429 each throw their specific message | Status handling |
+| 17 | 400 throws with the extracted `errors[0].message` detail | Upstream-error surfacing |
+
+### Smoke test
+
+```bash
+cd mcp-server
+npx tsx dev/try-person-ancestors.ts LZJW-C31
+npx tsx dev/try-person-ancestors.ts LZJW-C31 --generations 4 --person-details
+npx tsx dev/try-person-ancestors.ts LZJW-C31 --generations 2 --marriage-details
+```
+
+---
+
+## Verification
+
+### Automated
+```bash
+cd mcp-server && npm run build && npm test
+```
+
+### Manual Layer 1 (MCP Inspector)
+```bash
+npx @modelcontextprotocol/inspector node build/index.js
+```
+- `person_ancestors({ personId: "LZJW-C31", generations: 2 })` — returns
+  8 persons; ascendancy `1` is President Abraham Lincoln, `2`/`3` his
+  parents, `1-S` Mary Ann Todd.
+- `person_ancestors({ personId: "LZJW-C31", generations: 9 })` — fails
+  with the generations range error.
+- `person_ancestors({ personId: "XXXX-XXX" })` — fails with not-found.
+- `person_ancestors` without logging in — returns the auth error.
+
+### Manual Layer 2 (Claude Code)
+- *"Show me four generations of Abraham Lincoln's ancestors."* — Claude
+  calls `person_ancestors({ personId: "LZJW-C31", generations: 4 })` and
+  renders the pedigree from the ascendancy numbers.
+- *"…include their birth and death dates."* — Claude re-calls with
+  `personDetails: true`.
+
+### Manual Layers 0–3 (smoke → Inspector → Claude Code → Cowork)
+Full layered playbook in
+`docs/testing-guides/person-ancestors-tool-testing-guide.md` (OAuth setup
+per `docs/testing-guides/oauth-tool-testing-guide.md`).
+
+---
+
+## References
+
+- Read Ancestry (endpoint reference): https://developers.familysearch.org/main/reference/readancestry *(verified live 2026-06-02)*
+- `docs/specs/simplified-gedcomx-spec.md` — output format for the persons/relationships.
+- `docs/specs/person-read-tool-spec.md` — sibling tree-read tool; shared
+  host contract, status handling, `personId` naming, and the
+  envelope-free graph output this tool mirrors.
+- `docs/specs/person-search-tool-spec.md` — sibling; dangling-source-strip
+  rationale and the find→read→walk chain.
+
+Evidence trail: `mcp-server/dev/probe-ancestry.ts`,
+`probe-ancestry-numbering.ts`, `probe-ancestry-rels-sources.ts`
+(run 2026-06-02).

--- a/docs/testing-guides/person-ancestors-tool-testing-guide.md
+++ b/docs/testing-guides/person-ancestors-tool-testing-guide.md
@@ -40,7 +40,7 @@ Claude: person_ancestors({ personId: "LZJW-C31", generations: 4,
 
 | Parameter | Default | What it does |
 |-----------|---------|--------------|
-| `personId` (required) | — | The root tree-person ID |
+| `personId` (optional) | the logged-in user | The root tree-person ID. **Omit it to get your own ancestors** |
 | `generations` | `3` | How many generations up (integer **1–8**) |
 | `spouse` | — | Also include this spouse's ancestry (an ID or `"UNKNOWN"`) |
 | `personDetails` | `false` | Add a full `facts` array (Birth/Death/…) to each person |
@@ -50,6 +50,13 @@ Claude: person_ancestors({ personId: "LZJW-C31", generations: 4,
 With `personDetails` off (the default), persons have only name, gender,
 and `ascendancyNumber` — **no dates**. That's intentional: the endpoint
 returns no facts unless asked.
+
+**`personId` is optional.** When omitted, the tool looks up the logged-in
+user's own tree person (via `GET /platform/users/current`) and returns
+*you and your ancestors*. **Important:** omit `personId` only for
+self-requests ("my ancestors"). For a *named* person ("Lincoln's
+ancestors"), the LLM must resolve the name with `person_search` first and
+pass the ID — omitting it would wrongly return the user's own ancestors.
 
 ## Before You Start
 
@@ -164,6 +171,17 @@ directly. It's the fastest way to catch API response shape mismatches.
    Should error with *"Person XXXX-XXX not found in the FamilySearch
    Family Tree."* — no crash.
 
+7. Verify the current-user default (no `personId`):
+
+   ```bash
+   npx tsx dev/try-person-ancestors.ts --generations 2
+   ```
+
+   With no ID, the tool first calls `GET /platform/users/current`, then
+   runs ancestry on **your own** tree person. Ascendancy `1` should be
+   **you** (your name). If your tree has no ancestors entered, you'll see
+   just yourself (`persons: 1`) — that's correct, not an error.
+
 ### What success looks like
 
 You get back a numbered pedigree. The Lincoln query returns 8 persons at
@@ -264,6 +282,16 @@ listed in `src/tool-schemas.ts`, and named in `manifest.json`.
    Should return a `relationships` array of `Couple` entries with
    bare-ID participants and Marriage facts.
 
+6. Verify the current-user default. Call **`person_ancestors`** with no
+   `personId`:
+
+   ```json
+   { "generations": 2 }
+   ```
+
+   Expected: a pedigree rooted at **your own** person — ascendancy `1` is
+   you. (Just yourself if your tree has no ancestors entered.)
+
 ### What success looks like (Layer 1)
 
 - Tool shows up in the Inspector.
@@ -351,11 +379,27 @@ person_ancestors tool from natural language — and does it toggle
    Claude should re-call with `marriageDetails: true` and read the
    marriage facts from the relationships.
 
+9. **Test the self-default vs. named-person distinction (the footgun).**
+
+   > "Show me my own ancestors."
+
+   Claude should call `person_ancestors` **without** a `personId` (the
+   root should come back as *you*). Then, in contrast:
+
+   > "Now show me Abraham Lincoln's ancestors."
+
+   Claude should **resolve Lincoln via `person_search` first** and pass
+   his `personId` — it must **not** omit `personId` here (that would
+   return *your* ancestors, not Lincoln's). Confirm the root of the second
+   result is Lincoln, not you.
+
 ### What success looks like
 
 Claude calls `person_ancestors`, renders the pedigree from the ascendancy
-numbers, and flips `personDetails` / `marriageDetails` on when the user
-asks for dates or marriages.
+numbers, flips `personDetails` / `marriageDetails` on when asked, omits
+`personId` for "my ancestors", and resolves a named person via
+`person_search` before calling (never omitting `personId` for someone
+other than the user).
 
 ### What failure looks like
 
@@ -365,6 +409,9 @@ asks for dates or marriages.
   in the description isn't landing.
 - Claude calls `person_read` repeatedly to walk up the tree instead of
   `person_ancestors` once → the tools' roles aren't distinct enough.
+- **Claude omits `personId` for a named person** (e.g. returns *your*
+  ancestors when asked for Lincoln's) → the self-only guidance in the
+  description isn't landing; this is the key regression to watch for.
 
 ### Troubleshooting
 
@@ -553,6 +600,7 @@ request) works in Cowork on native Windows.
 | Build server | `cd mcp-server && npm run build` |
 | Run tests | `cd mcp-server && npm test` |
 | Log in (dev) | `cd mcp-server && npx tsx dev/try-login.ts unused` |
+| Smoke test (self / current user) | `cd mcp-server && npx tsx dev/try-person-ancestors.ts --generations 2` |
 | Smoke test (Lincoln, lean) | `cd mcp-server && npx tsx dev/try-person-ancestors.ts LZJW-C31 --generations 2` |
 | Smoke test (facts + marriages) | `cd mcp-server && npx tsx dev/try-person-ancestors.ts LZJW-C31 --generations 2 --person-details --marriage-details` |
 | Smoke test (range rejection) | `cd mcp-server && npx tsx dev/try-person-ancestors.ts LZJW-C31 --generations 9` |
@@ -569,10 +617,10 @@ request) works in Cowork on native Windows.
 
 | Layer | What it tests | Bugs it catches |
 |-------|---------------|-----------------|
-| 0 - Smoke test | Direct function call vs live API | API shape mismatches, ascendancy re-attach, envelope/source-strip regressions, range validation |
+| 0 - Smoke test | Direct function call vs live API | API shape mismatches, ascendancy re-attach, envelope/source-strip regressions, range validation, current-user default |
 | 1 - Inspector (no auth) | Auth error propagation | Missing/wrong error messages |
-| 1 - Inspector (with auth) | Tool through MCP protocol | Schema errors, validation enforcement, serialization bugs |
-| 2 - Claude Code | LLM tool selection + detail toggles | Wrong tool, missing `personDetails`/`marriageDetails`, bad descriptions |
+| 1 - Inspector (with auth) | Tool through MCP protocol | Schema errors, validation enforcement, serialization bugs, self-default |
+| 2 - Claude Code | LLM tool selection + detail toggles | Wrong tool, missing `personDetails`/`marriageDetails`, bad descriptions, **omitting personId for a named person** |
 | 3a - Cowork WSL2 | Full path through WSL2 | WSL2 bridge + token path issues |
 | 3b - Cowork Native | Full path on native Windows | Cross-platform bugs |
 

--- a/docs/testing-guides/person-ancestors-tool-testing-guide.md
+++ b/docs/testing-guides/person-ancestors-tool-testing-guide.md
@@ -1,0 +1,579 @@
+# Person Ancestors Tool Testing Guide
+
+This guide walks you through testing the `person_ancestors` tool after
+it's built. Follow each layer in order. Don't skip ahead — each layer
+catches different problems.
+
+## What the person_ancestors tool does (30 seconds)
+
+The `person_ancestors` tool reads a person's **pedigree** from the
+**FamilySearch Family Tree**. You pass one tree-person ID and it returns
+that person plus up to N generations of ancestors as simplified GedcomX.
+
+The key field is **`ascendancyNumber`** on each person — the classic
+Ahnentafel numbering that encodes the tree: `1` is the starting person,
+`2` is the father, `3` is the mother, and a person numbered *n* has
+father *2n* and mother *2n + 1*. The `-S` suffix marks a spouse (the
+root's spouse, `1-S`, comes back by default). The raw API returns **no
+parent-child relationships**, so this number is the only thing that tells
+you who descends from whom.
+
+This is an **authenticated** tool — it requires a valid FamilySearch
+login session (via the `login` tool). Under the hood it calls the
+documented FamilySearch platform endpoint `GET /platform/tree/ancestry`
+("Read Ancestry"). Like the other tree tools, this endpoint is **not**
+behind the Imperva WAF, so it needs **no** browser User-Agent header.
+
+The output is the simplified graph **directly** — `{ persons }` (plus
+`relationships` only when you ask for marriage details), with **no
+envelope**. The five optional parameters are LLM-toggleable:
+
+```
+User: "Show me four generations of Abraham Lincoln's ancestors."
+Claude: person_ancestors({ personId: "LZJW-C31", generations: 4 })
+        → a numbered pedigree (lean: names + ascendancy numbers, no dates)
+
+User: "Include their birth and death dates."
+Claude: person_ancestors({ personId: "LZJW-C31", generations: 4,
+                           personDetails: true })  → each person now carries facts
+```
+
+| Parameter | Default | What it does |
+|-----------|---------|--------------|
+| `personId` (required) | — | The root tree-person ID |
+| `generations` | `3` | How many generations up (integer **1–8**) |
+| `spouse` | — | Also include this spouse's ancestry (an ID or `"UNKNOWN"`) |
+| `personDetails` | `false` | Add a full `facts` array (Birth/Death/…) to each person |
+| `marriageDetails` | `false` | Add `relationships` (Couple entries with marriage facts) |
+| `descendants` | `false` | Add descendant detail for persons in the pedigree |
+
+With `personDetails` off (the default), persons have only name, gender,
+and `ascendancyNumber` — **no dates**. That's intentional: the endpoint
+returns no facts unless asked.
+
+## Before You Start
+
+### 1. Make sure the server builds and all tests pass
+
+```bash
+cd mcp-server
+npm run build
+npm test
+```
+
+All tests should pass (including the `person_ancestors` suite). If
+anything is red, fix it first.
+
+### 2. You need a valid FamilySearch session
+
+The `person_ancestors` tool requires authentication. You must be able to
+log in via the `login` tool first. If you haven't tested OAuth yet,
+complete the [OAuth Testing Guide](./oauth-tool-testing-guide.md)
+through at least Layer 1 Part C before continuing.
+
+You'll need:
+- A FamilySearch developer app with a registered client ID
+- The redirect URI `http://127.0.0.1:1837/callback` registered on
+  your FS app
+- A FamilySearch account you can log in with
+
+---
+
+## Layer 0: Smoke-Test Script
+
+**What this tests:** Does the tool function work against the live API?
+
+This bypasses the MCP harness entirely and calls the tool function
+directly. It's the fastest way to catch API response shape mismatches.
+
+### Steps
+
+1. Make sure you're logged in (you should have
+   `~/.familysearch-mcp/tokens.json` from a previous `login` call). If
+   not, log in via the dev helper (run it through `tsx` — the `.ts` file
+   isn't executable; the `unused` arg is a throwaway the login tool
+   ignores in favor of the bundled client ID):
+
+   ```bash
+   cd mcp-server
+   npx tsx dev/try-login.ts unused
+   ```
+
+   Complete the browser flow.
+
+2. Run the smoke test:
+
+   ```bash
+   cd mcp-server
+   npx tsx dev/try-person-ancestors.ts LZJW-C31 --generations 2
+   ```
+
+   This calls `personAncestorsTool({ personId: "LZJW-C31", generations: 2 })`.
+
+3. You should see **8 persons**, each line showing its ascendancy number,
+   ID, and name:
+
+   ```
+        1  LZJW-C31  President Abraham Lincoln
+      1-S  LCHV-P5R  Mary Ann Todd
+        2  9VMF-H1F  Thomas Herring Lincoln
+        3  KN6W-CSY  Nancy Elizabeth Hanks
+        4  LKBG-8W2  Capt Abraham Lincoln
+        5  LXQL-TV6  Bathsheba Herring
+        6  L1H7-RXW  Joseph Hanks
+        7  PSPQ-97W  Ann Nanny Lee
+   ```
+
+   Confirm:
+   - `1` is **President** Abraham Lincoln and `4` is **Capt** Abraham
+     Lincoln — those titles are real `prefix` parts (check the full JSON:
+     `names[0].prefix` should be `"President"` / `"Capt"`, with `given`
+     `"Abraham"`).
+   - `2`/`3` are the parents, `4`/`5` and `6`/`7` the grandparents.
+   - In the full JSON the top-level keys are just `persons` — **no**
+     `personId` / `generations` / `ancestorCount` envelope, and **no**
+     `relationships` key (you didn't ask for marriage details).
+   - With `--generations 2` and no `--person-details`, persons have
+     **no** `facts`.
+
+4. Add facts and marriage details:
+
+   ```bash
+   npx tsx dev/try-person-ancestors.ts LZJW-C31 --generations 2 --person-details --marriage-details
+   ```
+
+   Now each person should carry a `facts` array (Birth/Death), and a
+   `relationships` list should appear with `Couple` entries — `person1`
+   and `person2` are **bare tree IDs** (e.g. `9VMF-H1F`, not a URL) and
+   each carries a Marriage fact.
+
+5. Verify the generations range is enforced (no API call):
+
+   ```bash
+   npx tsx dev/try-person-ancestors.ts LZJW-C31 --generations 9
+   ```
+
+   Should error with *"generations must be an integer between 1 and 8."*
+
+6. Verify a bad ID is handled:
+
+   ```bash
+   npx tsx dev/try-person-ancestors.ts XXXX-XXX
+   ```
+
+   Should error with *"Person XXXX-XXX not found in the FamilySearch
+   Family Tree."* — no crash.
+
+### What success looks like
+
+You get back a numbered pedigree. The Lincoln query returns 8 persons at
+`generations=2` with correct ascendancy numbers and prefixes, the lean
+default has no dates, and `--person-details` / `--marriage-details` add
+facts and couple relationships.
+
+### What failure looks like
+
+| Symptom | Likely cause | Fix |
+|---------|--------------|-----|
+| Auth error ("call the login tool") | No valid session | Run `npx tsx dev/try-login.ts unused` first |
+| "generations must be an integer between 1 and 8" on a valid number | Off-by-one or non-integer slipped through | Check `validateInput` in `src/tools/person-ancestors.ts` |
+| Persons missing `ascendancyNumber` | Re-attach broken | Confirm `mapResponse` reads raw `display.ascendancyNumber` |
+| An envelope appears (`personId`/`ancestorCount`) | Output shape regressed | Result must be `{ persons, relationships? }` only |
+| Per-person `sources` present | Dangling-source strip removed | `delete sp.sources` in `mapResponse` |
+| Couple `person1`/`person2` are URLs | Bare-ID strip missing | Check `shapeRelationship` / `bareId` |
+| API returns unexpected shape | Types don't match reality | Compare raw response to `src/types/person-ancestors.ts` |
+
+### When to move on
+
+Move to Layer 1 once the smoke test returns the 8-person Lincoln pedigree
+with correct ascendancy numbers and rejects `--generations 9`.
+
+---
+
+## Layer 1: MCP Inspector
+
+**What this tests:** Does the tool register correctly? Does it work
+through the MCP protocol?
+
+### Start the Inspector
+
+```bash
+cd mcp-server
+npx @modelcontextprotocol/inspector node build/index.js
+```
+
+Look at the tools list and confirm **`person_ancestors`** is present. If
+it is missing, check that it's imported and dispatched in `src/index.ts`,
+listed in `src/tool-schemas.ts`, and named in `manifest.json`.
+
+### Part A — Not authenticated (error message)
+
+1. Wipe any existing session:
+
+   ```bash
+   rm -f ~/.familysearch-mcp/tokens.json
+   ```
+
+   On Windows PowerShell:
+
+   ```powershell
+   Remove-Item $env:USERPROFILE\.familysearch-mcp\tokens.json
+   ```
+
+2. In the Inspector, call **`person_ancestors`** with:
+
+   ```json
+   { "personId": "LZJW-C31" }
+   ```
+
+3. Expected response: an error with `isError: true` and a message
+   directing you to call the `login` tool. This confirms auth error
+   propagation works.
+
+### Part B — Authenticated (happy path + validation)
+
+1. In the Inspector, call **`login`** with your client ID. Complete the
+   browser flow.
+
+2. Call **`person_ancestors`** with:
+
+   ```json
+   { "personId": "LZJW-C31", "generations": 2 }
+   ```
+
+3. Expected response: JSON with a `persons` array of 8 entries. Ascendancy
+   `1` is President Abraham Lincoln (with `names[0].prefix: "President"`),
+   `1-S` is Mary Ann Todd, `2`/`3` are his parents. No envelope, no
+   `relationships` key.
+
+4. Verify the generations range. Call:
+
+   ```json
+   { "personId": "LZJW-C31", "generations": 9 }
+   ```
+
+   Expected: an error with the *"generations must be an integer between 1
+   and 8"* message. Same for `"generations": 0`.
+
+5. Add marriage details:
+
+   ```json
+   { "personId": "LZJW-C31", "generations": 2, "marriageDetails": true }
+   ```
+
+   Should return a `relationships` array of `Couple` entries with
+   bare-ID participants and Marriage facts.
+
+### What success looks like (Layer 1)
+
+- Tool shows up in the Inspector.
+- Without auth: clear error message directing to login.
+- With auth + a valid query: a numbered pedigree.
+- Out-of-range generations: rejected with the range message, no crash.
+
+### What failure looks like
+
+| Symptom | Likely cause | Fix |
+|---------|--------------|-----|
+| Tool missing from Inspector | Not registered | Check `index.ts`, `tool-schemas.ts`, `manifest.json` |
+| Auth error despite being logged in | Token expired, cache issue | Log out and log in again |
+| `generations: 9` returns data instead of erroring | Validation not enforced | Check `validateInput` |
+| Unexpected error shape | API response doesn't match types | Check the smoke test output and adjust types |
+
+### When to move on
+
+Move to Layer 2 when Part B works — you can get a pedigree for a valid
+query through the Inspector, and out-of-range queries are rejected.
+
+---
+
+## Layer 2: Claude Code as Client
+
+**What this tests:** Does Claude understand when and how to use the
+person_ancestors tool from natural language — and does it toggle
+`personDetails` / `marriageDetails` based on the request?
+
+### Steps
+
+1. Open a terminal and create a scratch folder:
+
+   ```bash
+   mkdir -p ~/mcp-test-scratch
+   cd ~/mcp-test-scratch
+   ```
+
+   On Windows PowerShell:
+
+   ```powershell
+   mkdir -Force $env:USERPROFILE\mcp-test-scratch
+   cd $env:USERPROFILE\mcp-test-scratch
+   ```
+
+2. Register the server with Claude Code (if not already):
+
+   ```bash
+   claude mcp add --transport stdio genealogy-dev -- node /path/to/cowork-genealogy/mcp-server/build/index.js
+   ```
+
+3. Start Claude Code:
+
+   ```bash
+   claude
+   ```
+
+4. Make sure you have a valid session. If needed:
+
+   > "Log me in to FamilySearch. My client ID is YOUR-KEY."
+
+5. Test the pedigree query:
+
+   > "Show me four generations of Abraham Lincoln's ancestors."
+   > (If Claude needs the ID first, it may call `person_search`; or give
+   > it `LZJW-C31` directly.)
+
+6. Watch what Claude does:
+   - Claude should call `person_ancestors` with `personId` and
+     `generations: 4`.
+   - Claude should present the pedigree using the ascendancy numbers
+     (e.g. as a tree or a numbered list).
+
+7. Test the `personDetails` toggle:
+
+   > "Include their birth and death dates."
+
+   Claude should re-call with `personDetails: true`, and the dates should
+   now appear.
+
+8. Test the `marriageDetails` toggle:
+
+   > "When did each couple marry?"
+
+   Claude should re-call with `marriageDetails: true` and read the
+   marriage facts from the relationships.
+
+### What success looks like
+
+Claude calls `person_ancestors`, renders the pedigree from the ascendancy
+numbers, and flips `personDetails` / `marriageDetails` on when the user
+asks for dates or marriages.
+
+### What failure looks like
+
+- Claude asks for dates but doesn't set `personDetails` → the description
+  isn't teaching the toggle clearly.
+- Claude can't reconstruct the tree → the `ascendancyNumber` explanation
+  in the description isn't landing.
+- Claude calls `person_read` repeatedly to walk up the tree instead of
+  `person_ancestors` once → the tools' roles aren't distinct enough.
+
+### Troubleshooting
+
+If you change the server code:
+
+1. Rebuild: `cd mcp-server && npm run build`
+2. In Claude Code, type `/mcp` to reconnect.
+3. Try again.
+
+### When to move on
+
+Move to Layer 3 when Claude successfully uses `person_ancestors` from
+natural language and toggles the detail flags appropriately.
+
+---
+
+## Choose Your Layer 3 Order
+
+Layers 1 and 2 are platform-agnostic — everyone runs them. Layer 3
+splits by where Cowork's MCP server runs, and **both sub-layers are
+required**:
+
+| Your dev environment | Run first | Then |
+|----------------------|-----------|------|
+| WSL2 | Layer 3a (WSL2) | Layer 3b (Native Windows) |
+| Native Windows | Layer 3b (Native Windows) | Layer 3a (WSL2) |
+
+---
+
+## Layer 3a: Cowork via WSL2
+
+**What this tests:** Does the full pipeline work in Cowork, talking
+through the WSL2 bridge?
+
+**Prerequisite:** Claude Desktop installed with a WSL2 MCP server
+entry. Example `claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "genealogy-wsl": {
+      "command": "wsl.exe",
+      "args": [
+        "-d", "Ubuntu-22.04",
+        "--cd", "/mnt/c/path/to/cowork-genealogy/mcp-server",
+        "--",
+        "/usr/bin/node",
+        "build/index.js"
+      ]
+    }
+  }
+}
+```
+
+Adjust the distro name, path, and node path for your setup. Use
+`wsl.exe -l` to find your distro name and `wsl.exe -- which node`
+to find the node path.
+
+**Important:** Remove or rename any native Windows MCP server entry
+while testing this layer, so you know the WSL2 bridge is being used.
+
+### Steps
+
+1. FULLY restart Claude Desktop if you changed the server config
+   or rebuilt (system tray → right-click → Quit → reopen).
+
+2. Open a Cowork session.
+
+3. Make sure you're logged in:
+
+   > "What's my FamilySearch auth status?"
+
+   If not logged in:
+
+   > "Log me in to FamilySearch. My client ID is YOUR-KEY."
+
+4. Test the pedigree workflow:
+
+   > "Show me four generations of Abraham Lincoln's ancestors."
+
+5. Verify Claude calls `person_ancestors` and presents the numbered
+   pedigree.
+
+6. Test a toggle:
+
+   > "Add their birth and death dates."
+
+   Verify Claude re-calls with `personDetails: true`.
+
+### What success looks like
+
+Claude calls `person_ancestors`, returns the Lincoln pedigree with
+ascendancy numbers, and adds facts on request — all through the full
+Cowork → Claude Desktop → WSL2 → MCP server pipeline.
+
+### What failure looks like
+
+- Claude doesn't see the tools → config typo or Claude Desktop
+  wasn't fully restarted.
+- Server error `ETIMEDOUT` or `fetch failed` → Node 22 networking
+  bug; switch to Node 20.
+- Auth error despite logging in → token file path mismatch between
+  WSL2 and Windows.
+
+### When to move on
+
+Move to Layer 3b once the WSL2 bridge handles the pedigree workflow.
+
+---
+
+## Layer 3b: Cowork via Native Windows
+
+**What this tests:** Does the full pipeline work running natively
+on Windows?
+
+**Prerequisite:** Claude Desktop configured with a native Windows
+MCP server entry:
+
+```json
+{
+  "mcpServers": {
+    "genealogy-native": {
+      "command": "node",
+      "args": [
+        "C:\\path\\to\\cowork-genealogy\\mcp-server\\build\\index.js"
+      ]
+    }
+  }
+}
+```
+
+**Important:** Remove or rename any WSL2 MCP server entry while
+testing this layer.
+
+### Steps
+
+1. Make sure the native Windows build is up to date:
+
+   ```powershell
+   cd C:\path\to\cowork-genealogy\mcp-server
+   npm run build
+   ```
+
+2. FULLY restart Claude Desktop.
+
+3. Open Cowork and test:
+
+   > "What's my FamilySearch auth status?"
+
+   If not logged in:
+
+   > "Log me in to FamilySearch. My client ID is YOUR-KEY."
+
+   Then:
+
+   > "Show me four generations of Abraham Lincoln's ancestors."
+
+4. Verify the same results as Layer 3a, including the `personDetails`
+   follow-up.
+
+### What success looks like
+
+Same results as Layer 3a, but running natively on Windows.
+
+### What failure looks like
+
+Same issues as Layer 3a, plus potential cross-platform problems:
+
+| Problem | Fix |
+|---------|-----|
+| Build fails on Windows | Check for Linux-specific code |
+| Server crashes on startup | Check for hardcoded paths |
+| `npx` not found in config | Use `npx.cmd` on Windows |
+
+### You're done when
+
+The pedigree workflow (walk up N generations → add dates/marriages on
+request) works in Cowork on native Windows.
+
+---
+
+## Quick Reference: Commands
+
+| What | Command |
+|------|---------|
+| Build server | `cd mcp-server && npm run build` |
+| Run tests | `cd mcp-server && npm test` |
+| Log in (dev) | `cd mcp-server && npx tsx dev/try-login.ts unused` |
+| Smoke test (Lincoln, lean) | `cd mcp-server && npx tsx dev/try-person-ancestors.ts LZJW-C31 --generations 2` |
+| Smoke test (facts + marriages) | `cd mcp-server && npx tsx dev/try-person-ancestors.ts LZJW-C31 --generations 2 --person-details --marriage-details` |
+| Smoke test (range rejection) | `cd mcp-server && npx tsx dev/try-person-ancestors.ts LZJW-C31 --generations 9` |
+| Run Inspector | `cd mcp-server && npx @modelcontextprotocol/inspector node build/index.js` |
+| Wipe session (Linux/WSL) | `rm -f ~/.familysearch-mcp/tokens.json` |
+| Wipe session (PowerShell) | `Remove-Item $env:USERPROFILE\.familysearch-mcp\tokens.json` |
+| Reconnect in Claude Code | `/mcp` |
+| Claude Desktop config | Settings → Developer → Edit Config |
+| Claude Desktop logs | Settings → Developer → View Logs |
+
+---
+
+## Summary: What Each Layer Catches
+
+| Layer | What it tests | Bugs it catches |
+|-------|---------------|-----------------|
+| 0 - Smoke test | Direct function call vs live API | API shape mismatches, ascendancy re-attach, envelope/source-strip regressions, range validation |
+| 1 - Inspector (no auth) | Auth error propagation | Missing/wrong error messages |
+| 1 - Inspector (with auth) | Tool through MCP protocol | Schema errors, validation enforcement, serialization bugs |
+| 2 - Claude Code | LLM tool selection + detail toggles | Wrong tool, missing `personDetails`/`marriageDetails`, bad descriptions |
+| 3a - Cowork WSL2 | Full path through WSL2 | WSL2 bridge + token path issues |
+| 3b - Cowork Native | Full path on native Windows | Cross-platform bugs |
+
+**Don't skip layers.** Each one catches bugs the others miss.

--- a/mcp-server/dev/try-person-ancestors.ts
+++ b/mcp-server/dev/try-person-ancestors.ts
@@ -1,0 +1,63 @@
+/**
+ * One-shot smoke test for the person_ancestors tool against the live FS API.
+ * No MCP harness — calls the tool function directly.
+ *
+ * Requires a valid session (run `npx tsx dev/try-login.ts unused` first).
+ *
+ * Usage:
+ *   cd mcp-server
+ *   npx tsx dev/try-person-ancestors.ts LZJW-C31
+ *   npx tsx dev/try-person-ancestors.ts LZJW-C31 --generations 4 --person-details
+ *   npx tsx dev/try-person-ancestors.ts LZJW-C31 --generations 2 --marriage-details
+ */
+import { personAncestorsTool } from "../src/tools/person-ancestors.js";
+import type { PersonAncestorsInput } from "../src/types/person-ancestors.js";
+
+const args = process.argv.slice(2);
+const personId = args.find((a) => !a.startsWith("--"));
+if (!personId) {
+  console.error("Usage: npx tsx dev/try-person-ancestors.ts <personId> [--generations N] [--spouse <id|UNKNOWN>] [--person-details] [--marriage-details] [--descendants]");
+  process.exit(1);
+}
+
+function flagValue(name: string): string | undefined {
+  const i = args.indexOf(name);
+  return i >= 0 ? args[i + 1] : undefined;
+}
+
+const input: PersonAncestorsInput = { personId };
+const gen = flagValue("--generations");
+if (gen) input.generations = Number(gen);
+const spouse = flagValue("--spouse");
+if (spouse) input.spouse = spouse;
+if (args.includes("--person-details")) input.personDetails = true;
+if (args.includes("--marriage-details")) input.marriageDetails = true;
+if (args.includes("--descendants")) input.descendants = true;
+
+console.log("Input:", JSON.stringify(input));
+console.log("---");
+
+try {
+  const result = await personAncestorsTool(input);
+  console.log(`persons: ${result.persons.length}`);
+  for (const p of result.persons) {
+    // Persons can carry several name variants (BirthName/AlsoKnownAs/...);
+    // show the preferred one for the summary, not whatever is first.
+    const n = p.names?.find((nm) => nm.preferred) ?? p.names?.[0];
+    const name = [n?.prefix, n?.given, n?.surname, n?.suffix].filter(Boolean).join(" ");
+    console.log(`  ${String(p.ascendancyNumber).padStart(4)}  ${p.id}  ${name}`);
+  }
+  if (result.relationships) {
+    console.log(`relationships: ${result.relationships.length}`);
+    for (const r of result.relationships) {
+      const m = r.facts?.find((f) => f.type === "Marriage");
+      console.log(`  ${r.person1} × ${r.person2}${m ? `  m. ${m.date ?? ""} ${m.place ?? ""}` : ""}`);
+    }
+  }
+  console.log("---");
+  console.log("Full JSON:");
+  console.log(JSON.stringify(result, null, 2));
+} catch (e) {
+  console.error("ERROR:", (e as Error).message);
+  process.exit(1);
+}

--- a/mcp-server/dev/try-person-ancestors.ts
+++ b/mcp-server/dev/try-person-ancestors.ts
@@ -6,6 +6,7 @@
  *
  * Usage:
  *   cd mcp-server
+ *   npx tsx dev/try-person-ancestors.ts                 # no id -> logged-in user + ancestors
  *   npx tsx dev/try-person-ancestors.ts LZJW-C31
  *   npx tsx dev/try-person-ancestors.ts LZJW-C31 --generations 4 --person-details
  *   npx tsx dev/try-person-ancestors.ts LZJW-C31 --generations 2 --marriage-details
@@ -14,18 +15,29 @@ import { personAncestorsTool } from "../src/tools/person-ancestors.js";
 import type { PersonAncestorsInput } from "../src/types/person-ancestors.js";
 
 const args = process.argv.slice(2);
-const personId = args.find((a) => !a.startsWith("--"));
-if (!personId) {
-  console.error("Usage: npx tsx dev/try-person-ancestors.ts <personId> [--generations N] [--spouse <id|UNKNOWN>] [--person-details] [--marriage-details] [--descendants]");
-  process.exit(1);
-}
+const VALUE_FLAGS = new Set(["--generations", "--spouse"]);
 
 function flagValue(name: string): string | undefined {
   const i = args.indexOf(name);
   return i >= 0 ? args[i + 1] : undefined;
 }
 
-const input: PersonAncestorsInput = { personId };
+// personId is the first positional arg — skip --flags AND the values that
+// belong to value-taking flags (so `--generations 2` isn't read as the id).
+// Optional: omit it to read the logged-in user's own ancestry.
+let personId: string | undefined;
+for (let i = 0; i < args.length; i++) {
+  const a = args[i];
+  if (a.startsWith("--")) {
+    if (VALUE_FLAGS.has(a)) i++; // skip this flag's value
+    continue;
+  }
+  personId = a;
+  break;
+}
+
+const input: PersonAncestorsInput = {};
+if (personId) input.personId = personId;
 const gen = flagValue("--generations");
 if (gen) input.generations = Number(gen);
 const spouse = flagValue("--spouse");

--- a/mcp-server/manifest.json
+++ b/mcp-server/manifest.json
@@ -38,6 +38,7 @@
     { "name": "image_read" },
     { "name": "record_search" },
     { "name": "person_search" },
+    { "name": "person_ancestors" },
     { "name": "match_two_examples" },
     { "name": "person_record_matches" },
     { "name": "record_person_matches" },

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -21,6 +21,10 @@ import { personSearchTool, type PersonSearchInput } from "./tools/person-search.
 import { matchTwoExamples } from "./tools/match-two-examples.js";
 import type { MatchTwoExamplesInput } from "./types/match-two-examples.js";
 import { personReadTool, type PersonReadToolInput } from "./tools/person-read.js";
+import {
+  personAncestorsTool,
+  type PersonAncestorsInput,
+} from "./tools/person-ancestors.js";
 import { recordReadTool, type RecordReadInput } from "./tools/record-read.js";
 import { fulltextSearchTool } from "./tools/fulltext-search.js";
 import type { FulltextSearchInput } from "./types/fulltext-search.js";
@@ -336,6 +340,21 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
     try {
       const args = request.params.arguments as unknown as PersonReadToolInput;
       const result = await personReadTool(args);
+      return {
+        content: [{ type: "text", text: JSON.stringify(result, null, 2) }]
+      };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Unknown error";
+      return {
+        content: [{ type: "text", text: JSON.stringify({ error: message }) }],
+        isError: true
+      };
+    }
+  }
+  if (request.params.name === "person_ancestors") {
+    try {
+      const args = request.params.arguments as unknown as PersonAncestorsInput;
+      const result = await personAncestorsTool(args);
       return {
         content: [{ type: "text", text: JSON.stringify(result, null, 2) }]
       };

--- a/mcp-server/src/tool-schemas.ts
+++ b/mcp-server/src/tool-schemas.ts
@@ -17,6 +17,7 @@ import { placeExternalLinksToolSchema } from "./tools/place-external-links.js";
 import { imageReadToolSchema } from "./tools/image-read.js";
 import { recordSearchToolSchema } from "./tools/record-search.js";
 import { personSearchToolSchema } from "./tools/person-search.js";
+import { personAncestorsToolSchema } from "./tools/person-ancestors.js";
 import { matchTwoExamplesSchema } from "./tools/match-two-examples.js";
 import {
   personRecordMatchesSchema,
@@ -52,6 +53,7 @@ export const allToolSchemas = [
   imageReadToolSchema,
   recordSearchToolSchema,
   personSearchToolSchema,
+  personAncestorsToolSchema,
   matchTwoExamplesSchema,
   personRecordMatchesSchema,
   recordPersonMatchesSchema,

--- a/mcp-server/src/tools/person-ancestors.ts
+++ b/mcp-server/src/tools/person-ancestors.ts
@@ -1,0 +1,261 @@
+import { getValidToken } from "../auth/refresh.js";
+import { toSimplified } from "../utils/gedcomx-convert.js";
+import { parseUpstreamErrorBody } from "../utils/search-helpers.js";
+import type { GedcomX, SimplifiedRelationship } from "../types/gedcomx.js";
+import type {
+  AncestorPerson,
+  FSAncestryResponse,
+  PersonAncestorsInput,
+  PersonAncestorsResult,
+} from "../types/person-ancestors.js";
+
+const API_BASE = "https://api.familysearch.org/platform/tree/ancestry";
+const ACCEPT_HEADER = "application/x-fs-v1+json";
+const MAX_REDIRECTS = 1;
+const DEFAULT_GENERATIONS = 3;
+const MIN_GENERATIONS = 1;
+const MAX_GENERATIONS = 8;
+
+// ─── MCP schema ───────────────────────────────────────────────────────────
+
+export const personAncestorsToolSchema = {
+  name: "person_ancestors",
+  description:
+    "Read a person's ancestors (pedigree) from the FamilySearch Family Tree. " +
+    "Given a tree-person ID, returns that person plus up to N generations of " +
+    "ancestors as simplified GEDCOMX, each tagged with an ascendancyNumber " +
+    "(Ahnentafel position: 1 = the person, 2 = father, 3 = mother, 2n/2n+1 = " +
+    "that person's parents; the -S suffix marks a spouse). Set generations " +
+    "(1-8, default 3) for depth, personDetails: true for full birth/death " +
+    "facts on each ancestor, marriageDetails: true for marriage facts between " +
+    "couples. Requires authentication — call the login tool first if not " +
+    "logged in.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      personId: {
+        type: "string",
+        description:
+          'FamilySearch tree-person ID of the root person (e.g. "LZJW-C31"). Required.',
+      },
+      generations: {
+        type: "number",
+        description:
+          "Generations of ancestors to return above the root. Integer 1-8. Defaults to 3.",
+      },
+      spouse: {
+        type: "string",
+        description:
+          'Also include this spouse\'s ancestry. A spouse tree-person ID, or "UNKNOWN" to let FamilySearch choose the spouse.',
+      },
+      personDetails: {
+        type: "boolean",
+        description:
+          "When true, include a full facts array (Birth, Death, ...) on each person. Defaults to false (name, gender, and ascendancyNumber only — no dates).",
+      },
+      marriageDetails: {
+        type: "boolean",
+        description:
+          "When true, include relationships (Couple entries with marriage facts) between the ancestral couples. Defaults to false.",
+      },
+      descendants: {
+        type: "boolean",
+        description:
+          "When true, include additional descendant detail for persons in the pedigree. Defaults to false.",
+      },
+    },
+    required: ["personId"],
+  },
+} as const;
+
+// ─── Entry point ──────────────────────────────────────────────────────────
+
+export async function personAncestorsTool(
+  input: PersonAncestorsInput,
+): Promise<PersonAncestorsResult> {
+  validateInput(input);
+  const token = await getValidToken();
+  return fetchAndMap(token, input, input.personId.trim(), 0);
+}
+
+function validateInput(input: PersonAncestorsInput): void {
+  const { personId, generations } = input;
+  if (typeof personId !== "string" || personId.trim() === "") {
+    throw new Error(
+      'person_ancestors requires a non-empty personId string (e.g., "LZJW-C31").',
+    );
+  }
+  if (generations !== undefined) {
+    if (
+      !Number.isInteger(generations) ||
+      generations < MIN_GENERATIONS ||
+      generations > MAX_GENERATIONS
+    ) {
+      throw new Error("generations must be an integer between 1 and 8.");
+    }
+  }
+}
+
+// ─── Fetch + status handling (mirrors person_read's host contract) ─────────
+
+async function fetchAndMap(
+  token: string,
+  input: PersonAncestorsInput,
+  pid: string,
+  redirectsFollowed: number,
+): Promise<PersonAncestorsResult> {
+  const url = buildUrl(input, pid);
+  const res = await fetch(url, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: ACCEPT_HEADER,
+    },
+    redirect: "manual",
+  });
+
+  // 204: no pedigree available — return an empty graph.
+  if (res.status === 204) {
+    return { persons: [] };
+  }
+
+  // 301: person merged. Follow the Location header to the new ID (capped).
+  if (res.status === 301) {
+    if (redirectsFollowed >= MAX_REDIRECTS) {
+      throw new Error(
+        `FamilySearch ancestry API error: redirect loop while resolving ${pid}.`,
+      );
+    }
+    const location = res.headers.get("location");
+    const newId = location ? extractPersonId(location) : null;
+    if (!newId) {
+      throw new Error(
+        `FamilySearch ancestry API error: 301 redirect missing Location header for ${pid}.`,
+      );
+    }
+    return fetchAndMap(token, input, newId, redirectsFollowed + 1);
+  }
+
+  if (res.status === 401) {
+    throw new Error(
+      "FamilySearch rejected the access token (401). The session may have " +
+        "expired or been revoked — call the login tool to re-authenticate.",
+    );
+  }
+  if (res.status === 403) {
+    throw new Error(`Person ${pid} is restricted and cannot be viewed.`);
+  }
+  if (res.status === 404) {
+    throw new Error(`Person ${pid} not found in the FamilySearch Family Tree.`);
+  }
+  if (res.status === 410) {
+    throw new Error(
+      `Person ${pid} has been deleted from the FamilySearch Family Tree.`,
+    );
+  }
+  if (res.status === 400) {
+    let detail: string | null = null;
+    try {
+      detail = parseUpstreamErrorBody(await res.json());
+    } catch {
+      detail = null;
+    }
+    throw new Error(
+      `FamilySearch ancestry request rejected: ${detail ?? "HTTP 400"}.`,
+    );
+  }
+  if (res.status === 429) {
+    throw new Error(
+      "FamilySearch rate limit reached. Wait a moment and try again.",
+    );
+  }
+  if (!res.ok) {
+    throw new Error(`FamilySearch ancestry API error: ${res.status}.`);
+  }
+
+  const body = (await res.json()) as FSAncestryResponse;
+  return mapResponse(body, input.marriageDetails === true);
+}
+
+// ─── URL builder ────────────────────────────────────────────────────────────
+
+function buildUrl(input: PersonAncestorsInput, pid: string): string {
+  const params: string[] = [`person=${encodeURIComponent(pid)}`];
+  const generations = input.generations ?? DEFAULT_GENERATIONS;
+  params.push(`generations=${generations}`);
+  if (input.spouse) params.push(`spouse=${encodeURIComponent(input.spouse)}`);
+  if (input.personDetails) params.push("personDetails=true");
+  if (input.marriageDetails) params.push("marriageDetails=true");
+  if (input.descendants) params.push("descendants=true");
+  return `${API_BASE}?${params.join("&")}`;
+}
+
+// ─── Mapping: FS ancestry → simplified graph + ascendancyNumber ────────────
+
+function mapResponse(
+  body: FSAncestryResponse,
+  marriageDetails: boolean,
+): PersonAncestorsResult {
+  const rawPersons = body.persons ?? [];
+
+  // Convert persons (and couples, when requested) in one pass.
+  const simplified = toSimplified({
+    persons: rawPersons,
+    relationships: marriageDetails ? (body.relationships ?? []) : [],
+  } as unknown as GedcomX);
+
+  // Index raw ascendancy numbers by person id (toSimplified drops `display`).
+  const ascById = new Map<string, string>();
+  for (const p of rawPersons) {
+    if (p.id && typeof p.display?.ascendancyNumber === "string") {
+      ascById.set(p.id, p.display.ascendancyNumber);
+    }
+  }
+
+  const persons: AncestorPerson[] = [];
+  for (const sp of simplified.persons ?? []) {
+    if (!sp.id) continue;
+    const ascendancyNumber = ascById.get(sp.id);
+    if (ascendancyNumber === undefined) continue; // defensive — every ancestry person has one
+    // Drop per-person source references: the ancestry response carries no
+    // sourceDescriptions, so these would be dangling. Mutates this result
+    // only — toSimplified is untouched, so other callers keep their sources.
+    delete sp.sources;
+    persons.push({ ...sp, ascendancyNumber });
+  }
+
+  const result: PersonAncestorsResult = { persons };
+  if (marriageDetails) {
+    result.relationships = (simplified.relationships ?? []).map(
+      shapeRelationship,
+    );
+  }
+  return result;
+}
+
+// Couple person refs come out of toSimplified as absolute URLs
+// (…/persons/<id>); strip to the bare tree ID, same as person_read.
+function shapeRelationship(r: SimplifiedRelationship): SimplifiedRelationship {
+  const out: SimplifiedRelationship = { ...r };
+  if (out.person1) out.person1 = bareId(out.person1);
+  if (out.person2) out.person2 = bareId(out.person2);
+  return out;
+}
+
+function bareId(ref: string): string {
+  const slash = ref.lastIndexOf("/");
+  return slash >= 0 ? ref.slice(slash + 1) : ref;
+}
+
+// The ancestry 301 (merged person) Location format is not probe-confirmed (no
+// merged test ID was on hand); handle both FamilySearch redirect shapes — a
+// `person=<id>` query param and a `…/persons/<id>` path segment.
+function extractPersonId(location: string): string | null {
+  const query = location.match(/[?&]person=([^&]+)/);
+  if (query) return decodeURIComponent(query[1]);
+  const path = location.match(/\/persons\/([^/?#]+)/);
+  if (path) return path[1];
+  return null;
+}
+
+// Re-export tool input type for index.ts wiring.
+export type { PersonAncestorsInput };

--- a/mcp-server/src/tools/person-ancestors.ts
+++ b/mcp-server/src/tools/person-ancestors.ts
@@ -5,11 +5,14 @@ import type { GedcomX, SimplifiedRelationship } from "../types/gedcomx.js";
 import type {
   AncestorPerson,
   FSAncestryResponse,
+  FSCurrentUserResponse,
   PersonAncestorsInput,
   PersonAncestorsResult,
 } from "../types/person-ancestors.js";
 
 const API_BASE = "https://api.familysearch.org/platform/tree/ancestry";
+const FS_CURRENT_USER_URL =
+  "https://api.familysearch.org/platform/users/current";
 const ACCEPT_HEADER = "application/x-fs-v1+json";
 const MAX_REDIRECTS = 1;
 const DEFAULT_GENERATIONS = 3;
@@ -28,7 +31,10 @@ export const personAncestorsToolSchema = {
     "that person's parents; the -S suffix marks a spouse). Set generations " +
     "(1-8, default 3) for depth, personDetails: true for full birth/death " +
     "facts on each ancestor, marriageDetails: true for marriage facts between " +
-    "couples. Requires authentication — call the login tool first if not " +
+    "couples. If personId is omitted, returns the CURRENT logged-in user's " +
+    "own ancestors. For any OTHER (named) person, first call person_search " +
+    "to get their personId — do NOT omit personId for someone other than " +
+    "the user. Requires authentication — call the login tool first if not " +
     "logged in.",
   inputSchema: {
     type: "object",
@@ -36,7 +42,11 @@ export const personAncestorsToolSchema = {
       personId: {
         type: "string",
         description:
-          'FamilySearch tree-person ID of the root person (e.g. "LZJW-C31"). Required.',
+          'FamilySearch tree-person ID of the root person (e.g. "LZJW-C31"). ' +
+          "Optional — omit to use the logged-in user's own tree person " +
+          "(returns the user and their ancestors). Omit ONLY for " +
+          "self-requests; for a named person, resolve their ID with " +
+          "person_search first.",
       },
       generations: {
         type: "number",
@@ -64,7 +74,6 @@ export const personAncestorsToolSchema = {
           "When true, include additional descendant detail for persons in the pedigree. Defaults to false.",
       },
     },
-    required: ["personId"],
   },
 } as const;
 
@@ -75,16 +84,17 @@ export async function personAncestorsTool(
 ): Promise<PersonAncestorsResult> {
   validateInput(input);
   const token = await getValidToken();
-  return fetchAndMap(token, input, input.personId.trim(), 0);
+  // Resolve the root: the supplied personId, or the logged-in user's own
+  // tree person when it's omitted/empty.
+  const provided =
+    typeof input.personId === "string" ? input.personId.trim() : "";
+  const pid = provided !== "" ? provided : await getCurrentUserPersonId(token);
+  return fetchAndMap(token, input, pid, 0);
 }
 
 function validateInput(input: PersonAncestorsInput): void {
-  const { personId, generations } = input;
-  if (typeof personId !== "string" || personId.trim() === "") {
-    throw new Error(
-      'person_ancestors requires a non-empty personId string (e.g., "LZJW-C31").',
-    );
-  }
+  // personId is optional (omit → current user); only generations is checked.
+  const { generations } = input;
   if (generations !== undefined) {
     if (
       !Number.isInteger(generations) ||
@@ -94,6 +104,41 @@ function validateInput(input: PersonAncestorsInput): void {
       throw new Error("generations must be an integer between 1 and 8.");
     }
   }
+}
+
+// Resolve the logged-in user's own tree person when no personId is given.
+// Reads ONLY users[0].personId from /platform/users/current — never the
+// account PII (helperAccessPin, birthDate, ...) the endpoint also returns.
+// Inline here for the single caller; promote to src/auth/ if a second tool
+// needs it.
+async function getCurrentUserPersonId(token: string): Promise<string> {
+  const res = await fetch(FS_CURRENT_USER_URL, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: ACCEPT_HEADER,
+    },
+  });
+  if (res.status === 401) {
+    throw new Error(
+      "FamilySearch rejected the access token (401). The session may have " +
+        "expired or been revoked — call the login tool to re-authenticate.",
+    );
+  }
+  if (!res.ok) {
+    throw new Error(
+      `FamilySearch could not read your current user: HTTP ${res.status}.`,
+    );
+  }
+  const body = (await res.json()) as FSCurrentUserResponse;
+  const personId = body.users?.[0]?.personId;
+  if (typeof personId !== "string" || personId.trim() === "") {
+    // "Partial user data when Tree Data is unavailable" — no linked person.
+    throw new Error(
+      "Could not determine your FamilySearch tree person (your account may " +
+        "not be linked to one). Pass a personId explicitly.",
+    );
+  }
+  return personId.trim();
 }
 
 // ─── Fetch + status handling (mirrors person_read's host contract) ─────────

--- a/mcp-server/src/types/person-ancestors.ts
+++ b/mcp-server/src/types/person-ancestors.ts
@@ -34,10 +34,17 @@ export interface FSAncestryResponse {
   relationships?: unknown[];
 }
 
+// GET /platform/users/current — only the field the self-default reads.
+export interface FSCurrentUserResponse {
+  users?: Array<{ personId?: string }>;
+}
+
 // ─── Tool I/O ───────────────────────────────────────────────────────────────
 
 export interface PersonAncestorsInput {
-  personId: string;
+  // Optional: when omitted/empty, the tool resolves the logged-in user's
+  // own tree person (returns the user and their ancestors).
+  personId?: string;
   generations?: number;
   spouse?: string;
   personDetails?: boolean;

--- a/mcp-server/src/types/person-ancestors.ts
+++ b/mcp-server/src/types/person-ancestors.ts
@@ -1,0 +1,60 @@
+// FamilySearch Read Ancestry API response + tool I/O types.
+// GET https://api.familysearch.org/platform/tree/ancestry
+//
+// Only the fields the tool reads directly are declared with precision; the
+// names/gender/facts/sources/identifiers are otherwise passed straight to
+// `toSimplified` (cast to GedcomX), which reads the full runtime structure.
+
+import type { SimplifiedPerson, SimplifiedRelationship } from "./gedcomx.js";
+
+// ─── Upstream (FS) response shapes ──────────────────────────────────────────
+
+export interface FSAncestryDisplay {
+  // Ahnentafel position — a STRING ("1", "2", "1-S"); the only field that
+  // encodes the pedigree. `toSimplified` ignores the whole display block, so
+  // the tool re-attaches this onto each converted person.
+  ascendancyNumber?: string;
+  name?: string;
+  lifespan?: string;
+}
+
+export interface FSAncestryPerson {
+  id?: string;
+  living?: boolean;
+  gender?: { type?: string };
+  names?: unknown[];
+  facts?: unknown[];
+  sources?: unknown[];
+  identifiers?: Record<string, string[]>;
+  display?: FSAncestryDisplay;
+}
+
+export interface FSAncestryResponse {
+  persons?: FSAncestryPerson[];
+  relationships?: unknown[];
+}
+
+// ─── Tool I/O ───────────────────────────────────────────────────────────────
+
+export interface PersonAncestorsInput {
+  personId: string;
+  generations?: number;
+  spouse?: string;
+  personDetails?: boolean;
+  marriageDetails?: boolean;
+  descendants?: boolean;
+}
+
+// A simplified person plus the one ancestry-specific field. `ascendancyNumber`
+// has no slot in standard simplified GedcomX, so it is added here.
+export interface AncestorPerson extends SimplifiedPerson {
+  ascendancyNumber: string;
+}
+
+// The pedigree as a simplified GedcomX graph, returned directly (no envelope),
+// the same shape `person_read` returns. `relationships` is present only when
+// `marriageDetails` is requested.
+export interface PersonAncestorsResult {
+  persons: AncestorPerson[];
+  relationships?: SimplifiedRelationship[];
+}

--- a/mcp-server/tests/tools/person-ancestors.test.ts
+++ b/mcp-server/tests/tools/person-ancestors.test.ts
@@ -45,6 +45,15 @@ function mockStatus(status: number, location?: string, body: unknown = {}): void
   });
 }
 
+function mockCurrentUser(personId?: string): void {
+  mockFetch.mockResolvedValueOnce({
+    ok: true,
+    status: 200,
+    json: () => Promise.resolve({ users: [personId ? { personId } : {}] }),
+    headers: new Headers(),
+  });
+}
+
 function lastCall(): [string, { headers: Record<string, string> }] {
   const call = mockFetch.mock.calls.at(-1);
   return call as [string, { headers: Record<string, string> }];
@@ -181,15 +190,55 @@ describe("person_ancestors", () => {
     expect(r.persons.length).toBe(4);
   });
 
-  // 4
-  it("throws when personId is missing or empty (no fetch)", async () => {
-    await expect(
-      personAncestorsTool({ personId: "" } as never),
-    ).rejects.toThrow(/non-empty personId/);
-    await expect(personAncestorsTool({} as never)).rejects.toThrow(
-      /non-empty personId/,
+  // 4 — current-user default
+  it("with no personId, looks up the current user then fetches their ancestry", async () => {
+    mockCurrentUser("LZJW-C31"); // GET /platform/users/current
+    mockOk(leanResponse()); // ancestry on the resolved id
+    const r = await personAncestorsTool({});
+    expect(r.persons.length).toBe(4);
+    expect(mockFetch.mock.calls[0][0] as string).toContain(
+      "/platform/users/current",
     );
-    expect(mockFetch).not.toHaveBeenCalled();
+    expect(mockFetch.mock.calls[1][0] as string).toContain(
+      "/platform/tree/ancestry",
+    );
+    expect(mockFetch.mock.calls[1][0] as string).toContain("person=LZJW-C31");
+  });
+
+  it("treats empty/whitespace personId as 'use current user'", async () => {
+    mockCurrentUser("LZJW-C31");
+    mockOk(leanResponse());
+    await personAncestorsTool({ personId: "   " });
+    expect(mockFetch.mock.calls[0][0] as string).toContain(
+      "/platform/users/current",
+    );
+  });
+
+  // 4b — no needless lookup
+  it("with a provided personId, makes a single ancestry fetch (no current-user lookup)", async () => {
+    mockOk(leanResponse());
+    await personAncestorsTool({ personId: "LZJW-C31" });
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(mockFetch.mock.calls[0][0] as string).toContain(
+      "/platform/tree/ancestry",
+    );
+    expect(mockFetch.mock.calls[0][0] as string).not.toContain("users/current");
+  });
+
+  // 4c — lookup error handling
+  it("surfaces current-user lookup errors", async () => {
+    mockStatus(401);
+    await expect(personAncestorsTool({})).rejects.toThrow(/401|re-authenticate/i);
+
+    mockCurrentUser(undefined); // 200 but no users[0].personId
+    await expect(personAncestorsTool({})).rejects.toThrow(
+      /pass a personId explicitly/i,
+    );
+
+    mockStatus(500);
+    await expect(personAncestorsTool({})).rejects.toThrow(
+      /could not read your current user/i,
+    );
   });
 
   // 5

--- a/mcp-server/tests/tools/person-ancestors.test.ts
+++ b/mcp-server/tests/tools/person-ancestors.test.ts
@@ -1,0 +1,374 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("../../src/auth/refresh.js", () => ({
+  getValidToken: vi.fn(),
+}));
+
+import { personAncestorsTool } from "../../src/tools/person-ancestors.js";
+import { getValidToken } from "../../src/auth/refresh.js";
+import type { FSAncestryResponse } from "../../src/types/person-ancestors.js";
+
+const mockedGetValidToken = vi.mocked(getValidToken);
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+beforeEach(() => {
+  mockFetch.mockReset();
+  mockedGetValidToken.mockReset();
+  mockedGetValidToken.mockResolvedValue("test-token");
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// ─── Response mocks ─────────────────────────────────────────────────────────
+
+function mockOk(body: FSAncestryResponse): void {
+  mockFetch.mockResolvedValueOnce({
+    ok: true,
+    status: 200,
+    json: () => Promise.resolve(body),
+    headers: new Headers(),
+  });
+}
+
+function mockStatus(status: number, location?: string, body: unknown = {}): void {
+  const headers = new Headers();
+  if (location) headers.set("location", location);
+  mockFetch.mockResolvedValueOnce({
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: "",
+    json: () => Promise.resolve(body),
+    headers,
+  });
+}
+
+function lastCall(): [string, { headers: Record<string, string> }] {
+  const call = mockFetch.mock.calls.at(-1);
+  return call as [string, { headers: Record<string, string> }];
+}
+function lastUrl(): string {
+  return lastCall()[0];
+}
+function lastHeaders(): Record<string, string> {
+  return lastCall()[1].headers;
+}
+
+// ─── Fixtures (verified against the live LZJW-C31 ancestry, probe 2026-06-02) ─
+
+const G = "http://gedcomx.org/";
+
+function names(prefix: string | null, given: string, surname: string) {
+  const parts: { type: string; value: string }[] = [];
+  if (prefix) parts.push({ type: G + "Prefix", value: prefix });
+  parts.push({ type: G + "Given", value: given });
+  parts.push({ type: G + "Surname", value: surname });
+  return [{ preferred: true, nameForms: [{ parts }] }];
+}
+
+function rawPerson(
+  id: string,
+  asc: string,
+  prefix: string | null,
+  given: string,
+  surname: string,
+  genderType: string,
+  extra: Record<string, unknown> = {},
+): FSAncestryResponse["persons"] extends (infer P)[] ? P : never {
+  return {
+    id,
+    living: false,
+    gender: { type: genderType },
+    names: names(prefix, given, surname),
+    display: { ascendancyNumber: asc, name: `${given} ${surname}` },
+    ...extra,
+  };
+}
+
+function leanResponse(): FSAncestryResponse {
+  return {
+    persons: [
+      rawPerson("LZJW-C31", "1", "President", "Abraham", "Lincoln", G + "Male"),
+      rawPerson("LCHV-P5R", "1-S", null, "Mary Ann", "Todd", G + "Female"),
+      rawPerson("9VMF-H1F", "2", null, "Thomas Herring", "Lincoln", G + "Male"),
+      rawPerson("KN6W-CSY", "3", null, "Nancy Elizabeth", "Hanks", G + "Female"),
+    ],
+  };
+}
+
+const THOMAS_FACTS = [
+  {
+    type: G + "Birth",
+    date: { original: "6 January 1778" },
+    place: { original: "Rockingham, Virginia, United States" },
+  },
+];
+// Dangling source refs (no top-level sourceDescriptions in an ancestry response).
+const THOMAS_SOURCES = [
+  {
+    id: "feaaf802-7bd2-4745-ab37-e39abf488271",
+    description:
+      "https://api.familysearch.org/platform/sources/descriptions/7SDM-WXR",
+    descriptionId: "7SDM-WXR",
+  },
+];
+
+function detailedResponse(): FSAncestryResponse {
+  const r = leanResponse();
+  const thomas = r.persons!.find((p) => p.id === "9VMF-H1F")!;
+  (thomas as Record<string, unknown>).facts = THOMAS_FACTS;
+  (thomas as Record<string, unknown>).sources = THOMAS_SOURCES;
+  return r;
+}
+
+const RELATIONSHIPS = [
+  {
+    id: "93NL-RJ2",
+    type: G + "Couple",
+    person1: {
+      resource: "https://api.familysearch.org/platform/tree/persons/9VMF-H1F",
+      resourceId: "9VMF-H1F",
+    },
+    person2: {
+      resource: "https://api.familysearch.org/platform/tree/persons/KN6W-CSY",
+      resourceId: "KN6W-CSY",
+    },
+    facts: [
+      {
+        type: G + "Marriage",
+        date: { original: "12 June 1806" },
+        place: { original: "Washington, Kentucky, United States" },
+      },
+    ],
+  },
+];
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe("person_ancestors", () => {
+  // 1
+  it("returns { persons } for a valid personId (default generations)", async () => {
+    mockOk(leanResponse());
+    const r = await personAncestorsTool({ personId: "LZJW-C31" });
+    expect(Array.isArray(r.persons)).toBe(true);
+    expect(r.persons.length).toBe(4);
+  });
+
+  // 2
+  it("re-attaches ascendancyNumber and carries name prefixes", async () => {
+    mockOk(leanResponse());
+    const r = await personAncestorsTool({ personId: "LZJW-C31" });
+    const byId = Object.fromEntries(r.persons.map((p) => [p.id, p.ascendancyNumber]));
+    expect(byId["LZJW-C31"]).toBe("1");
+    expect(byId["LCHV-P5R"]).toBe("1-S");
+    expect(byId["9VMF-H1F"]).toBe("2");
+    expect(byId["KN6W-CSY"]).toBe("3");
+    const root = r.persons.find((p) => p.id === "LZJW-C31");
+    expect(root?.names?.[0]?.prefix).toBe("President");
+    expect(root?.names?.[0]?.given).toBe("Abraham");
+  });
+
+  // 3
+  it("returns the simplified graph directly with no envelope", async () => {
+    mockOk(leanResponse());
+    const r = await personAncestorsTool({ personId: "LZJW-C31" });
+    expect(Object.keys(r)).toEqual(["persons"]);
+    expect(r).not.toHaveProperty("personId");
+    expect(r).not.toHaveProperty("generations");
+    expect(r).not.toHaveProperty("ancestorCount");
+    expect(r.persons.length).toBe(4);
+  });
+
+  // 4
+  it("throws when personId is missing or empty (no fetch)", async () => {
+    await expect(
+      personAncestorsTool({ personId: "" } as never),
+    ).rejects.toThrow(/non-empty personId/);
+    await expect(personAncestorsTool({} as never)).rejects.toThrow(
+      /non-empty personId/,
+    );
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  // 5
+  it("throws when generations is 0, 9, or non-integer (no fetch)", async () => {
+    for (const g of [0, 9, 3.5]) {
+      await expect(
+        personAncestorsTool({ personId: "LZJW-C31", generations: g }),
+      ).rejects.toThrow(/between 1 and 8/);
+    }
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  // 6
+  it("maps every input to its API parameter, omitting absent ones", async () => {
+    mockOk(leanResponse());
+    await personAncestorsTool({
+      personId: "LZJW-C31",
+      generations: 4,
+      spouse: "LCHV-P5R",
+      personDetails: true,
+      marriageDetails: true,
+      descendants: true,
+    });
+    const url = lastUrl();
+    expect(url).toContain("person=LZJW-C31");
+    expect(url).toContain("generations=4");
+    expect(url).toContain("spouse=LCHV-P5R");
+    expect(url).toContain("personDetails=true");
+    expect(url).toContain("marriageDetails=true");
+    expect(url).toContain("descendants=true");
+
+    mockOk(leanResponse());
+    await personAncestorsTool({ personId: "LZJW-C31" });
+    const lean = lastUrl();
+    expect(lean).not.toContain("spouse=");
+    expect(lean).not.toContain("personDetails=");
+    expect(lean).not.toContain("marriageDetails=");
+    expect(lean).not.toContain("descendants=");
+  });
+
+  // 7
+  it("defaults generations to 3 in the URL when not supplied", async () => {
+    mockOk(leanResponse());
+    await personAncestorsTool({ personId: "LZJW-C31" });
+    expect(lastUrl()).toContain("generations=3");
+  });
+
+  // 8
+  it("sends Accept fs-v1 + Authorization, and no User-Agent / Accept-Language", async () => {
+    mockOk(leanResponse());
+    await personAncestorsTool({ personId: "LZJW-C31" });
+    const headers = lastHeaders();
+    expect(headers.Accept).toBe("application/x-fs-v1+json");
+    expect(headers.Authorization).toBe("Bearer test-token");
+    expect("User-Agent" in headers).toBe(false);
+    expect("Accept-Language" in headers).toBe(false);
+  });
+
+  // 9
+  it("includes facts only when the response carries them (personDetails)", async () => {
+    mockOk(leanResponse());
+    const lean = await personAncestorsTool({ personId: "LZJW-C31" });
+    expect(lean.persons.find((p) => p.id === "9VMF-H1F")?.facts).toBeUndefined();
+
+    mockOk(detailedResponse());
+    const rich = await personAncestorsTool({
+      personId: "LZJW-C31",
+      personDetails: true,
+    });
+    const thomas = rich.persons.find((p) => p.id === "9VMF-H1F");
+    expect(thomas?.facts?.some((f) => f.type === "Birth")).toBe(true);
+  });
+
+  // 10
+  it("strips dangling per-person sources", async () => {
+    mockOk(detailedResponse());
+    const r = await personAncestorsTool({
+      personId: "LZJW-C31",
+      personDetails: true,
+    });
+    for (const p of r.persons) expect(p.sources).toBeUndefined();
+  });
+
+  // 11
+  it("shapes Couple relationships with bare IDs under marriageDetails; omits otherwise", async () => {
+    mockOk({ ...detailedResponse(), relationships: RELATIONSHIPS });
+    const r = await personAncestorsTool({
+      personId: "LZJW-C31",
+      marriageDetails: true,
+    });
+    expect(r.relationships?.length).toBe(1);
+    const rel = r.relationships![0];
+    expect(rel.type).toBe("Couple");
+    expect(rel.person1).toBe("9VMF-H1F");
+    expect(rel.person2).toBe("KN6W-CSY");
+    expect(rel.facts?.some((f) => f.type === "Marriage")).toBe(true);
+
+    mockOk(leanResponse());
+    const r2 = await personAncestorsTool({ personId: "LZJW-C31" });
+    expect(r2).not.toHaveProperty("relationships");
+  });
+
+  // 12
+  it("preserves real FamilySearch IDs (no I1/N1 renumbering)", async () => {
+    mockOk(leanResponse());
+    const r = await personAncestorsTool({ personId: "LZJW-C31" });
+    expect(r.persons.map((p) => p.id)).toContain("9VMF-H1F");
+    expect(r.persons.every((p) => !/^[INF]\d+$/.test(p.id!))).toBe(true);
+  });
+
+  // 13
+  it("returns { persons: [] } on 204", async () => {
+    mockStatus(204);
+    const r = await personAncestorsTool({ personId: "LZJW-C31" });
+    expect(r).toEqual({ persons: [] });
+  });
+
+  // 14a
+  it("follows a 301 to the merged-to person", async () => {
+    mockStatus(
+      301,
+      "https://api.familysearch.org/platform/tree/ancestry?person=WXYZ-789&generations=3",
+    );
+    mockOk(leanResponse());
+    const r = await personAncestorsTool({ personId: "ABCD-123" });
+    expect(r.persons.length).toBe(4);
+    expect(mockFetch.mock.calls[1][0] as string).toContain("person=WXYZ-789");
+  });
+
+  // 14b
+  it("throws on a redirect loop (second 301)", async () => {
+    mockStatus(301, "https://x/platform/tree/ancestry?person=A-1");
+    mockStatus(301, "https://x/platform/tree/ancestry?person=B-2");
+    await expect(
+      personAncestorsTool({ personId: "ABCD-123" }),
+    ).rejects.toThrow(/redirect loop/);
+  });
+
+  // 15
+  it("propagates the auth error when not authenticated (no fetch)", async () => {
+    mockedGetValidToken.mockReset();
+    mockedGetValidToken.mockRejectedValueOnce(
+      new Error("Call the login tool to authenticate."),
+    );
+    await expect(
+      personAncestorsTool({ personId: "LZJW-C31" }),
+    ).rejects.toThrow(/login tool/);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  // 16
+  it("throws specific messages for 401/403/404/410/429", async () => {
+    const cases: [number, RegExp][] = [
+      [401, /401|re-authenticate/i],
+      [403, /restricted/i],
+      [404, /not found/i],
+      [410, /deleted/i],
+      [429, /rate limit/i],
+    ];
+    for (const [status, re] of cases) {
+      mockStatus(status);
+      await expect(
+        personAncestorsTool({ personId: "LZJW-C31" }),
+      ).rejects.toThrow(re);
+    }
+  });
+
+  // 17
+  it("surfaces the upstream 400 errors[0].message", async () => {
+    mockStatus(400, undefined, {
+      errors: [
+        {
+          code: 400,
+          message: "readAncestry.generations: must be less than or equal to 8",
+        },
+      ],
+    });
+    await expect(
+      personAncestorsTool({ personId: "LZJW-C31", generations: 8 }),
+    ).rejects.toThrow(/must be less than or equal to 8/);
+  });
+});


### PR DESCRIPTION
Closes #191 

Adds person_ancestors, an authenticated MCP tool wrapping the documented GET /platform/tree/ancestry ("Read Ancestry") endpoint. Given a tree-person ID it returns that person plus up to N generations of ancestors as simplified GedcomX, exposing the endpoint's parameters (generations 1–8 default 3, spouse, personDetails, marriageDetails, descendants). The raw response has no parent-child links, so the pedigree structure is carried by FamilySearch's Ahnentafel ascendancyNumber, which toSimplified drops with the display block — the tool re-attaches it onto each person (the pattern person_read uses for living). Output is the simplified graph directly (no envelope), { persons, relationships? }; relationships (Couple + marriage facts, bare IDs) appear only under marriageDetails; dangling per-person sources are stripped; all name variants (incl. prefix/suffix) are preserved.

- personId is optional. When omitted, the tool resolves the logged-in user's own tree person via GET /platform/users/current (reading only users[0].personId, never the account PII the endpoint also returns) and returns the user plus their ancestors. The tool description steers the model to omit personId only for self-requests and to resolve a named person via person_search first, so a named request can't silently return the user's own ancestors. Lookup errors are handled (401 → re-auth, no linked person → "pass a personId explicitly", other non-OK → generic).

- Reuses getValidToken, toSimplified, and parseUpstreamErrorBody; wires into tool-schemas.ts, index.ts, and manifest.json (tool count 29 → 30). Ships the spec, a layered testing guide, a dev smoke CLI, and README/CLAUDE updates.

Test plan
- [x] cd mcp-server && npm test — full suite passes (593 tests, 29 files), including the manifest drift test and the unchanged person_read / person_search suites.
- [x] Spec-reviewed against docs/specs/person-ancestors-tool-spec.md — compliant, no material drift (base tool + the optional-personId feature).
- [x] Manual layers per docs/testing-guides/person-ancestors-tool-testing-guide.md — Layer 0 (live smoke: Lincoln pedigree, personDetails/marriageDetails, range + bad-ID rejection, self-default with no ID), Layer 1 (Inspector), Layer 2 (Claude Code, incl. the named-vs-self distinction), Layer 3 (Cowork WSL2  + native) — all verified.