### PR TITLE
Integrate person_search into init-project skill

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,7 +92,9 @@ source of truth for the advertised tool list); `src/index.ts` imports that
 list and dispatches calls. Per-tool behavioral contracts are in
 `docs/specs/<tool>-tool-spec.md`. Implementation plans (including for
 tools not yet built, such as `tree_attachments`) are in `docs/plan/`.
-Skills live in `plugin/skills/<skill>/SKILL.md`.
+Skills live in `plugin/skills/<skill>/SKILL.md`. The `init-project`
+skill uses `person_search` to find a person in the FamilySearch tree
+when the user doesn't have a FamilySearch ID to provide.
 
 The host artifact is the `.mcpb` desktop extension, built from
 `mcp-server/` with the `@anthropic-ai/mcpb` CLI. Its `manifest.json` is the

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ are listed in roughly the order you'd use them in a research project.
 
 | Skill | What it does | Say this |
 |-------|-------------|----------|
-| **init-project** | Creates a new project from a FamilySearch person ID. Fetches the person and their relatives to seed the tree. | "Start a new project for person KWCJ-RN4" |
+| **init-project** | Creates a new project from a FamilySearch person ID. If no ID is known, searches the Family Tree by name using `person_search` to find the right person first. Fetches the person and their relatives to seed the tree. | "Start a new project for person KWCJ-RN4" / "Start a project for Patrick Flynn, born 1845 Ireland — I don't have his ID" |
 | **project-status** | Summarizes project progress with GPS state + conversational narrative. Recommends the next step. | "Where are we?" / "What's next?" / "Status" |
 
 ### Planning the research

--- a/eval/fixtures/mcp/person-search-flynn.json
+++ b/eval/fixtures/mcp/person-search-flynn.json
@@ -1,0 +1,72 @@
+{
+  "tool": "person_search",
+  "description": "FamilySearch Family Tree search for Patrick Flynn — 3 ranked candidates, LZNY-BRF as the top match (born 1845 Ireland, Schuylkill County residence)",
+  "args": { "surname": "Flynn", "givenName": "Patrick" },
+  "response": {
+    "query": { "givenName": "Patrick", "surname": "Flynn" },
+    "totalMatches": 3,
+    "paginationCappedAt": 4999,
+    "returned": 3,
+    "offset": 0,
+    "hasMore": false,
+    "results": [
+      {
+        "personId": "LZNY-BRF",
+        "score": 4.85,
+        "confidence": 3,
+        "gedcomx": {
+          "persons": [
+            {
+              "id": "LZNY-BRF",
+              "ark": "https://familysearch.org/ark:/61903/4:1:LZNY-BRF",
+              "gender": "Male",
+              "names": [{ "given": "Patrick", "surname": "Flynn" }],
+              "facts": [
+                { "type": "Birth", "date": "1845", "place": "Ireland" },
+                { "type": "Residence", "date": "1850", "place": "Branch Township, Schuylkill, Pennsylvania" },
+                { "type": "Death", "date": "1908", "place": "Schuylkill County, Pennsylvania" }
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "personId": "LZNY-QRS",
+        "score": 3.21,
+        "confidence": 2,
+        "gedcomx": {
+          "persons": [
+            {
+              "id": "LZNY-QRS",
+              "ark": "https://familysearch.org/ark:/61903/4:1:LZNY-QRS",
+              "gender": "Male",
+              "names": [{ "given": "Patrick", "surname": "Flynn" }],
+              "facts": [
+                { "type": "Birth", "date": "1847", "place": "Ireland" },
+                { "type": "Death", "date": "1908", "place": "Schuylkill County, Pennsylvania" }
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "personId": "KWCJ-PAT",
+        "score": 2.10,
+        "confidence": 1,
+        "gedcomx": {
+          "persons": [
+            {
+              "id": "KWCJ-PAT",
+              "ark": "https://familysearch.org/ark:/61903/4:1:KWCJ-PAT",
+              "gender": "Male",
+              "names": [{ "given": "Patrick", "surname": "Flynn" }],
+              "facts": [
+                { "type": "Birth", "date": "1840", "place": "County Cork, Ireland" }
+              ]
+            }
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/eval/tests/unit/init-project/new-project-from-search.json
+++ b/eval/tests/unit/init-project/new-project-from-search.json
@@ -1,0 +1,25 @@
+{
+  "test": {
+    "id": "ut_init_project_004",
+    "skill": "init-project",
+    "name": "Initialize project by searching FamilySearch tree when no person ID provided",
+    "type": "positive",
+    "description": "User wants to start a project for Patrick Flynn but does not have his FamilySearch ID. The skill should call person_search to find candidates, select the top match (LZNY-BRF), call person_read with that ID, then create both project files normally.",
+    "tags": ["initialization", "person-search", "no-id", "single-turn-decomposition"]
+  },
+  "input": {
+    "user_message": "init-project: Start a new research project. I want to find the parents of Patrick Flynn, born around 1845 in Ireland, who lived in Schuylkill County, Pennsylvania. I don't have his FamilySearch ID.",
+    "scenario": null
+  },
+  "mcp_fixtures": ["person-search-flynn", "person-read-flynn"],
+  "judge_context": [
+    "Should call person_search (not person_read) first — no FamilySearch ID was provided",
+    "Should include surname 'Flynn' and given name 'Patrick' in the person_search arguments",
+    "Should select LZNY-BRF as the top candidate (score 4.85, confidence 3, birth 1845 Ireland matching the user's description) and then call person_read with LZNY-BRF",
+    "Should create both research.json and tree.gedcomx.json using the person_read data",
+    "Should set the project objective to something like 'Identify the parents of Patrick Flynn'"
+  ],
+  "execution": {
+    "max_wall_clock_seconds": 180
+  }
+}

--- a/plugin/skills/init-project/SKILL.md
+++ b/plugin/skills/init-project/SKILL.md
@@ -4,14 +4,18 @@ model: claude-sonnet-4-6
 description: Initializes a new genealogy research project with GPS-conformant
   file structures. Creates research.json (GPS audit trail) and
   tree.gedcomx.json (simplified GedcomX deliverable) from a FamilySearch
-  person ID. Implements Steps 1-2 of the genealogical research process
-  (define the problem and survey known information). Use when the user says
-  "new project", "start research", "research [person]", "find parents of",
-  "begin researching", or provides a FamilySearch person ID to start working
-  with. Do NOT use when a research.json file already exists in the folder —
-  use project-status instead to resume an existing project.
+  person ID. If the user does not have a FamilySearch ID, searches the
+  Family Tree by name using person_search to find the right person.
+  Implements Steps 1-2 of the genealogical research process (define the
+  problem and survey known information). Use when the user says "new
+  project", "start research", "research [person]", "find parents of",
+  "begin researching", "I don't have their FamilySearch ID", or provides
+  a FamilySearch person ID to start working with. Do NOT use when a
+  research.json file already exists in the folder — use project-status
+  instead to resume an existing project.
 allowed-tools:
   - person_read
+  - person_search
 ---
 
 # Init Project
@@ -54,8 +58,10 @@ Example decline response:
 
 - A FamilySearch person ID is preferred but not required. If an ID is
   provided, use `person_read` to seed known information. If no ID is
-  available, initialize from the objective text only using local stub
-  persons and continue.
+  available, call `person_search` to find the person by name and known
+  facts, let the user pick the right candidate, then call `person_read`
+  with the selected person ID. Fall back to local stub persons only if
+  `person_search` returns no usable candidates.
 
 ## Researcher profile interview
 
@@ -133,7 +139,8 @@ special update flow.
 ### 1. Get the research objective
 
 Ask the user for:
-- The FamilySearch person ID of the research subject
+- The FamilySearch person ID of the research subject (preferred), or
+  their name and any known facts so you can find them via `person_search`
 - The research objective in one sentence (e.g., "Identify the parents
   of Patrick Flynn, born ~1845 in Pennsylvania")
 
@@ -152,10 +159,43 @@ data and formulate a default objective based on what's missing (e.g.,
 if the person has no parents in the tree, the objective is "Identify
 the parents of [person name]").
 
+**If no FamilySearch ID is provided**, search for the person by name
+using `person_search` (see "Searching by name" below). Let the user
+pick the right candidate before proceeding to `person_read`.
+
 If the user's stated objective is too vague to be actionable (no named
 individual, no distinguishing details), ask clarifying questions. But
 do not require the precision of a research question — objectives are
 allowed to be broader.
+
+## Searching by name
+
+When the user does not have a FamilySearch person ID, call
+`person_search` with the name and any known facts:
+
+```
+person_search({
+  surname: "Flynn",
+  givenName: "Patrick",
+  birthYearFrom: 1843,
+  birthYearTo: 1847,
+  birthPlace: "Ireland"
+})
+```
+
+**Surname-plus-one rule:** `surname` is always required plus at least
+one other qualifying field (given name, date, place, or relative name).
+
+Present the ranked candidates to the user with their `personId`,
+confidence, and key facts. In single-turn evaluation mode (no follow-up
+available), select the top-scoring candidate and proceed. Once the user
+confirms the right person (or the top candidate is selected), call
+`person_read` with that `personId` and continue with the normal
+initialization steps.
+
+If `person_search` returns no candidates, or the user confirms none of
+the candidates match, initialize from objective text only using local
+stub persons (no `person_read` call).
 
 ### 2. Fetch person data from FamilySearch
 
@@ -382,9 +422,10 @@ identify his parents."
   with no parents, spouse, or children, still create the project. Note
   the isolation in the summary — a person with no linked relatives makes
   FAN research harder and increases reliance on direct records.
-- **No FamilySearch ID fallback.** If no FamilySearch ID is provided,
-  initialize from objective text only with local stubs. Do not block
-  project creation.
+- **No FamilySearch ID — search first.** If no FamilySearch ID is
+  provided, call `person_search` by name before falling back to local
+  stubs. Only create stub-only projects when `person_search` returns
+  nothing useful or the user confirms no candidate matches.
 - **No placeholder unknown-person stubs.** If a target person is
   entirely unknown (for example "unknown maternal grandmother" with no
   name), do not create a placeholder person entry with empty name/date/


### PR DESCRIPTION
## Summary

When a user starts a project without a FamilySearch ID, `init-project` now calls `person_search` to find the person by name first — instead of immediately falling back to local stubs.

- **init-project SKILL.md**: adds `person_search` to `allowed-tools`, extends description to mention the no-ID search flow, adds a **Searching by name** section with the surname-plus-one rule and single-turn guidance (pick the top candidate and proceed), updates the "No FamilySearch ID fallback" rule
- **README.md**: updates init-project skill description with no-ID example trigger
- **CLAUDE.md**: notes that init-project uses `person_search` when no ID is provided
- **eval/fixtures/mcp/person-search-flynn.json**: fixture returning 3 ranked Patrick Flynn candidates (LZNY-BRF top match)
- **eval/tests/unit/init-project/new-project-from-search.json**: new test `ut_init_project_004` — verified passing

## Test plan

- [x] `ut_init_project_004` passes — skill calls `person_search`, selects LZNY-BRF as top match, calls `person_read`, creates both project files with correct objective