### PR TITLE
Spec: place_search rework + place_search_all

### DIFF
--- a/docs/specs/place-search-all-tool-spec.md
+++ b/docs/specs/place-search-all-tool-spec.md
@@ -47,9 +47,11 @@ Identical to `place_search`.
    Primary IDs into a distinct set.
 4. **Describe each rep** — for each distinct rep ID,
    `GET /platform/places/description/{repId}` (Place_Description_resource).
-5. **Enrich + simplify** — for each, fetch the Wikipedia summary for
-   `wikipediaUrl`, then project to `SimplifiedPlaceResult`. Rep IDs whose
-   description lookup 404s are dropped.
+5. **Enrich + simplify** — for each, read the FamilySearch `WIKIPEDIA_LINK`
+   attribute for `wikipediaUrl` (see the place_search spec's
+   [Wikipedia link source](./place-search-tool-spec.md#wikipedia-link-source)),
+   then project to `SimplifiedPlaceResult`. Rep IDs whose description lookup
+   404s are dropped.
 6. Return `{ results: SimplifiedPlaceResult[] }`.
 
 The result set is broader than `place_search`: it includes the temporal/parent
@@ -60,8 +62,8 @@ variants of each matched place, not just the place itself.
 ## Output
 
 `{ results: SimplifiedPlaceResult[] }`, same shape as `place_search` (see the
-sibling spec). No FamilySearch identifiers, score, short name, or `wikipedia`
-object.
+sibling spec) — including `wikipediaUrl`. The internal FamilySearch identifiers,
+relevance score, and short `name` are not exposed.
 
 ```json
 {

--- a/docs/specs/place-search-all-tool-spec.md
+++ b/docs/specs/place-search-all-tool-spec.md
@@ -1,0 +1,170 @@
+# Place Search All Tool — Implementation Spec
+
+## Overview
+
+`place_search_all` is an MCP tool that, for a named place, returns **every
+jurisdiction that place has belonged to over time**. Where `place_search`
+returns the matching place(s), `place_search_all` additionally expands each
+match to all of its FamilySearch place representations — useful when boundaries
+or parent jurisdictions changed across the time period being researched (e.g. a
+town that was in a colonial territory before statehood, or a county whose parent
+changed).
+
+It shares the internal `placeSearch` function and the ID-free
+`SimplifiedPlaceResult` output shape with `place_search`; see
+[`place-search-tool-spec.md`](./place-search-tool-spec.md) for both. **Place IDs
+and rep IDs are never exposed to the LLM.**
+
+No authentication required.
+
+---
+
+## Input
+
+Identical to `place_search`.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `placeName` | string | Yes | Place name to search for. |
+| `contextName` | string | No | Higher-level place to disambiguate by; matched as a case-insensitive substring of each candidate's full name. If nothing matches, unfiltered results are used. |
+
+```json
+{ "placeName": "Schuylkill County", "contextName": "Pennsylvania" }
+```
+
+---
+
+## Behavior
+
+`placeSearchAllTool({ placeName, contextName? })`:
+
+1. **Base search** — run the internal `placeSearch(placeName, contextName)` (same
+   search → context filter → describe → enrich → cache flow as `place_search`).
+2. **Collect Primary IDs** — gather the distinct `placeId` (Primary) values from
+   the base results.
+3. **Expand** — for each Primary ID, `GET /platform/places/{pid}` (Place_resource)
+   to list **all** of its representation (rep) IDs. Union the rep IDs across all
+   Primary IDs into a distinct set.
+4. **Describe each rep** — for each distinct rep ID,
+   `GET /platform/places/description/{repId}` (Place_Description_resource).
+5. **Enrich + simplify** — for each, fetch the Wikipedia summary for
+   `wikipediaUrl`, then project to `SimplifiedPlaceResult`. Rep IDs whose
+   description lookup 404s are dropped.
+6. Return `{ results: SimplifiedPlaceResult[] }`.
+
+The result set is broader than `place_search`: it includes the temporal/parent
+variants of each matched place, not just the place itself.
+
+---
+
+## Output
+
+`{ results: SimplifiedPlaceResult[] }`, same shape as `place_search` (see the
+sibling spec). No FamilySearch identifiers, score, short name, or `wikipedia`
+object.
+
+```json
+{
+  "results": [
+    {
+      "fullName": "Schuylkill, Pennsylvania, United States",
+      "type": "County",
+      "dateRange": "+1811/",
+      "latitude": 40.707,
+      "longitude": -76.185,
+      "familysearchUrl": "https://www.familysearch.org/en/research/places/?text=Schuylkill&focusedId=393167"
+    },
+    {
+      "fullName": "Schuylkill, Philadelphia, Philadelphia, Pennsylvania, British Colonial America",
+      "type": "Neighborhood or suburb",
+      "dateRange": "/+1776",
+      "latitude": 39.9422,
+      "longitude": -75.1875,
+      "familysearchUrl": "https://www.familysearch.org/en/research/places/?text=Schuylkill&focusedId=4982995"
+    }
+  ]
+}
+```
+
+---
+
+## Tool Schema
+
+```typescript
+{
+  name: "place_search_all",
+  description:
+    "Look up a place and return every jurisdiction it has belonged to over " +
+    "time. Takes the same input as place_search (a place name plus an optional " +
+    "higher-level place as context). Where place_search returns the matching " +
+    "place(s), place_search_all additionally expands each match to all of its " +
+    "historical representations — useful when boundaries or parent " +
+    "jurisdictions changed across the time period you're researching. Each " +
+    "result includes the full jurisdictional name, place type, date range, " +
+    "coordinates, a FamilySearch link, and (when available) a Wikipedia link.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      placeName: {
+        type: "string",
+        description: "The place name to search for (e.g., 'Paris', 'Schuylkill County')."
+      },
+      contextName: {
+        type: "string",
+        description:
+          "Optional name of a higher-level place (state, country, etc.) used to " +
+          "disambiguate. Matches places whose full name contains this text. If " +
+          "nothing matches, the unfiltered results are returned instead."
+      }
+    },
+    required: ["placeName"]
+  }
+}
+```
+
+---
+
+## FamilySearch API Reference
+
+In addition to Places_Search_resource and Place_Description_resource (see the
+`place_search` spec), `place_search_all` uses:
+
+### Place_resource
+
+```
+GET https://api.familysearch.org/platform/places/{pid}
+Accept: application/json
+```
+
+Returns `places[]`: a bare place entry (`id === pid`, no `display`) followed by
+representation entries, each with `place.resourceId === pid`. Collect each
+representation's `id` (the rep IDs). Implemented as `getPlaceRepIds(pid)` in
+`place-search.ts` (no auth; parallels the token-bound `placeIdToRepIds` in
+`image-search.ts`).
+
+---
+
+## Error Handling
+
+| Condition | Behavior |
+|-----------|----------|
+| Base search returns no matches | Return `{ results: [] }` |
+| `GET /places/{pid}` 404s | Treat as no rep IDs for that pid (skip it) |
+| `GET /places/{pid}` other non-OK status | Throw `"FamilySearch API error: {status} {statusText}"` |
+| A rep-ID description lookup 404s | Drop that rep ID from the results |
+| Wikipedia API fails | Omit Wikipedia fields (graceful degradation) |
+
+---
+
+## Verification
+
+```bash
+cd mcp-server && npm run build && npm test
+
+# Live smoke (no auth):
+npx tsx dev/try-place-search-all.ts "Schuylkill County" Pennsylvania
+```
+
+Confirm the result set includes temporal/parent variants and that no result
+object contains `placeId`, `placeRepId`, `score`, `name`, or
+`parentPlaceRepId`.

--- a/docs/specs/place-search-all-tool-spec.md
+++ b/docs/specs/place-search-all-tool-spec.md
@@ -74,7 +74,8 @@ relevance score, and short `name` are not exposed.
       "dateRange": "+1811/",
       "latitude": 40.707,
       "longitude": -76.185,
-      "familysearchUrl": "https://www.familysearch.org/en/research/places/?text=Schuylkill&focusedId=393167"
+      "familysearchUrl": "https://www.familysearch.org/en/research/places/?text=Schuylkill&focusedId=393167",
+      "wikipediaUrl": "https://en.wikipedia.org/wiki/Schuylkill_County,_Pennsylvania"
     },
     {
       "fullName": "Schuylkill, Philadelphia, Philadelphia, Pennsylvania, British Colonial America",
@@ -82,7 +83,8 @@ relevance score, and short `name` are not exposed.
       "dateRange": "/+1776",
       "latitude": 39.9422,
       "longitude": -75.1875,
-      "familysearchUrl": "https://www.familysearch.org/en/research/places/?text=Schuylkill&focusedId=4982995"
+      "familysearchUrl": "https://www.familysearch.org/en/research/places/?text=Schuylkill&focusedId=4982995",
+      "wikipediaUrl": "https://en.wikipedia.org/wiki/Schuylkill,_Philadelphia"
     }
   ]
 }

--- a/docs/specs/place-search-tool-spec.md
+++ b/docs/specs/place-search-tool-spec.md
@@ -2,190 +2,176 @@
 
 ## Overview
 
-An MCP tool that returns FamilySearch place data enriched with Wikipedia
-summaries. No authentication required — uses the public FamilySearch places
-endpoints.
+Two MCP tools, `place_search` and `place_search_all`, return FamilySearch
+place data for a named place, enriched with a Wikipedia link. No
+authentication required — both use the public FamilySearch places endpoints.
 
-The tool has two modes determined by the input:
+Both tools are thin wrappers over a single **internal** function,
+`placeSearch(placeName, contextName?)`, and both return arrays of
+`SimplifiedPlaceResult` — a deliberately ID-free shape. **FamilySearch place
+IDs and place representation (rep) IDs are never exposed to the LLM.** They are
+an internal API detail; the model works with place names and the returned
+human-readable fields only. (A later phase will route every tool that needs a
+place ID through `placeSearch` so IDs stay inside the server.)
 
-| Input | Mode | What it does |
-|-------|------|--------------|
-| Place name (e.g., `"Ohio"`) | **Search** | Returns all matching places ranked by relevance |
-| Numeric **rep ID** (e.g., `"267"`) | **Lookup** | Returns the single place with full details + Wikipedia enrichment |
+`place_search_all` is documented in
+[`place-search-all-tool-spec.md`](./place-search-all-tool-spec.md); this file
+covers `place_search` and the shared internal function.
 
-Search mode is for disambiguation — when the user says "Madison," the
-tool returns all places named Madison so Claude can ask which one. Lookup
-mode is for getting the full picture of a known place.
+### The two FamilySearch ID systems (internal only)
 
-### Two ID systems on the FamilySearch Places API
-
-A FamilySearch place carries **two distinct identifiers** that index into
-two different ID systems on the same API. Both appear on every response;
-the tool surfaces both as separate output fields.
-
-| Field | What it is | Where it's used |
-|-------|------------|-----------------|
-| `placeId` | The **Primary** identifier (e.g., `"1927069"` for Nigeria). The canonical place ID. | Pass this to other tools that take a FamilySearch place ID — `place_population`, future `person_read`/`cets`. |
-| `placeRepId` | The **rep** identifier (e.g., `"226"` for Nigeria). FamilySearch's internal sequential index. | Pass this back to `place_search` lookup mode. Used internally to build `familysearchUrl`. |
-
-The two number spaces overlap — Nigeria's Primary is `1927069`, and a
-*different* place's rep is also `1927069`. The number alone is ambiguous;
-which endpoint receives it determines which place comes back. Lookup mode
-(`places({ query: "<digits>" })`) always interprets its argument as a
-**rep ID** because that's the only thing the underlying
-`/platform/places/description/{id}` endpoint accepts. Passing a Primary
-here silently returns a different (often unrelated) place.
+A FamilySearch place carries two distinct identifiers: the **Primary** ID
+(`placeId`, the canonical place ID) and the **rep** ID (`placeRepId`,
+FamilySearch's internal sequential index, accepted by the
+`/places/description/{id}` endpoint). The number spaces overlap, so the same
+number means different places on different endpoints. The internal function
+handles this plumbing privately; neither ID appears in tool output.
 
 ---
 
-## Input
+## ⚠️ Open decision: Wikipedia link accuracy
+
+**Status: needs review — not yet decided. The current implementation ships the
+"as-is" behavior described below; do not treat it as final.**
+
+The enrichment step looks Wikipedia up by the place's **bare name**
+(`/page/summary/{name}`). Wikipedia resolves a bare name to its *primary topic*,
+so the `wikipediaUrl` is **wrong for any place that isn't the famous one with
+that name**:
+
+- `Paris, Idaho` → links to the **Paris, France** article.
+- Every small `Paris` (Idaho, Texas, Ontario, …) gets the same France link.
+- Only the primary-topic place (Paris, France) is correct by luck.
+
+### Options for review
+
+| Option | What it does | Trade-off |
+|--------|--------------|-----------|
+| **A. Drop `wikipediaUrl` for now** | Remove the field until enrichment is done properly. | Simplest; no wrong links, but no Wikipedia links either. |
+| **B. Verify by coordinates** | Only attach the link when the Wikipedia article's coordinates sit near the place's own lat/long. | Most accurate; rejects wrong links and recovers correct ones. More logic; the geosearch action API is rate-limited, so it must lean on the summary endpoint + disambiguated titles. |
+| **C. More-specific lookup** | Query Wikipedia with `name + region` (e.g. `"Paris, Idaho"`) built from `fullName`/type. | Lighter than B; catches most cases but is heuristic/US-centric and can still miss or mismatch. |
+
+---
+
+## Internal function — `placeSearch(placeName, contextName?) -> PlaceResult[]`
+
+The single entry point any tool should call when it needs FamilySearch place
+data or IDs for a named place. Returns the full internal `PlaceResult[]` (which
+still carries IDs for in-server use).
+
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| `placeName` | string | Yes | The place to search for (e.g., `"Paris"`). |
+| `contextName` | string | No | Name of a higher-level place used to disambiguate (e.g., `"Idaho"`, `"France"`). |
+
+Steps:
+
+1. **Search** — `GET /platform/places/search?q=name:{placeName}` (Places_Search_resource).
+2. **Filter by context** — if `contextName` is given, keep only search entries
+   whose `fullName` contains it (case-insensitive substring). **If nothing
+   matches, keep the unfiltered list** — better to return extra results than
+   zero. Filtering happens on the search entries, before any description call.
+3. **Describe** — for each surviving rep ID, `GET /platform/places/description/{repId}`
+   (Place_Description_resource). If a description 404s, fall back to the
+   search-entry data so the place is not dropped.
+4. **Enrich** — for each place, `GET https://en.wikipedia.org/api/rest_v1/page/summary/{name}`
+   to obtain `wikipediaUrl`. Graceful: a non-OK status or network error yields
+   no Wikipedia fields, not an error. ⚠️ This step has a known accuracy problem —
+   see [Open decision: Wikipedia link accuracy](#open-decision-wikipedia-link-accuracy).
+5. **Cache** — memoize the `PlaceResult[]` in a module-level `Map` keyed by the
+   normalized `(placeName, contextName)` pair (trimmed + lowercased). No TTL;
+   lives for the MCP server process. A cache hit returns immediately without
+   re-fetching.
+
+### Context filter examples
+
+- `placeSearch("Paris", "Idaho")` → Paris places in Idaho.
+- `placeSearch("Paris", "France")` → Paris in France.
+- `placeSearch("Paris")` → all Paris matches FamilySearch returns, unfiltered.
+
+---
+
+## `place_search` tool
+
+`placeSearchTool({ placeName, contextName? })` runs `placeSearch`, projects each
+`PlaceResult` to `SimplifiedPlaceResult` via `simplifyPlaceResult`, and returns
+`{ results: SimplifiedPlaceResult[] }`.
+
+### Input
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `query` | string | Yes | A place name to search for, or a numeric FamilySearch place ID to look up directly |
-
-The tool auto-detects the mode: if `query` is all digits, it's treated
-as a place ID lookup; otherwise, it's a name search.
-
-Examples:
+| `placeName` | string | Yes | Place name to search for. |
+| `contextName` | string | No | Higher-level place to disambiguate by; matched as a case-insensitive substring of each candidate's full name. If nothing matches, unfiltered results are returned. |
 
 ```json
-{ "query": "England" }
+{ "placeName": "Paris", "contextName": "Idaho" }
 ```
 
-```json
-{ "query": "267" }
-```
+### Output
 
----
-
-## Output
-
-The tool returns `{ results: PlaceResult[] }`.
-
-Each `PlaceResult`:
+`{ results: SimplifiedPlaceResult[] }`. Each `SimplifiedPlaceResult`:
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `placeId` | string | FamilySearch **Primary** place identifier — the canonical ID accepted by other tools (`place_population`, future `person_read`/`cets`). |
-| `placeRepId` | string | FamilySearch **rep** identifier — the internal sequential ID accepted by `place_search` lookup mode and used to build `familysearchUrl`. |
-| `name` | string | Short place name (e.g., `"England"`) |
-| `fullName` | string | Full jurisdictional name (e.g., `"England, United Kingdom"`) |
-| `type` | string | Place type (e.g., `"Country"`, `"State"`, `"County"`) |
-| `latitude` | number? | Geographic latitude |
-| `longitude` | number? | Geographic longitude |
-| `dateRange` | string? | Temporal description in ISO formal notation (e.g., `"+1801/"`) |
-| `parentPlaceRepId` | string? | Parent jurisdiction's rep ID (lookup mode only; pass back to `place_search` to walk up the hierarchy). |
-| `score` | number? | Relevance score (search mode only) |
-| `wikipedia` | WikipediaData? | Wikipedia enrichment (lookup mode only) |
-| `familysearchUrl` | string | Link to the place on the FamilySearch website |
-| `wikipediaUrl` | string? | Link to the Wikipedia article (when enrichment succeeds) |
+| `fullName` | string | Full jurisdictional name (e.g., `"Paris, Bear Lake, Idaho, United States"`). |
+| `type` | string | Place type (e.g., `"City"`, `"County"`, `"Country"`). |
+| `dateRange` | string? | Temporal description in ISO formal notation (e.g., `"+1875/"`). |
+| `latitude` | number? | Geographic latitude. |
+| `longitude` | number? | Geographic longitude. |
+| `familysearchUrl` | string | Link to the place on the FamilySearch website. |
+| `wikipediaUrl` | string? | Link to the Wikipedia article (when enrichment succeeds). |
 
-`WikipediaData`:
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `title` | string | Wikipedia article title |
-| `description` | string | Short article description |
-| `extract` | string | Article summary (1–2 paragraphs) |
-| `thumbnailUrl` | string? | URL of the article's thumbnail image |
-
-### Search mode example
+No `placeId`, `placeRepId`, `score`, `name`, `parentPlaceRepId`, or `wikipedia`
+object is present — those exist only on the internal `PlaceResult`.
 
 ```json
 {
   "results": [
     {
-      "placeId": "10026773",
-      "placeRepId": "267",
-      "name": "England",
-      "fullName": "England, United Kingdom",
-      "type": "Country",
-      "latitude": 52.0,
-      "longitude": -1.0,
-      "dateRange": "+1801/",
-      "score": 100.0,
-      "familysearchUrl": "https://www.familysearch.org/en/research/places/?text=England&focusedId=267"
-    },
-    {
-      "placeId": "10054321",
-      "placeRepId": "12345",
-      "name": "New England",
-      "fullName": "New England, United States",
-      "type": "Region",
-      "latitude": 43.0,
-      "longitude": -71.0,
-      "score": 64.0,
-      "familysearchUrl": "https://www.familysearch.org/en/research/places/?text=New%20England&focusedId=12345"
+      "fullName": "Paris, Bear Lake, Idaho, United States",
+      "type": "City",
+      "dateRange": "+1875/",
+      "latitude": 42.22722,
+      "longitude": -111.40028,
+      "familysearchUrl": "https://www.familysearch.org/en/research/places/?text=Paris&focusedId=3988097",
+      "wikipediaUrl": "https://en.wikipedia.org/wiki/Paris"
     }
   ]
 }
 ```
 
-### Lookup mode example
-
-```json
-{
-  "results": [
-    {
-      "placeId": "10026773",
-      "placeRepId": "267",
-      "name": "England",
-      "fullName": "England, United Kingdom",
-      "type": "Country",
-      "latitude": 52.0,
-      "longitude": -1.0,
-      "dateRange": "+1801/",
-      "parentPlaceRepId": "10",
-      "wikipedia": {
-        "title": "England",
-        "description": "Country within the United Kingdom",
-        "extract": "England is a country that is part of the United Kingdom. It shares land borders with Wales and Scotland.",
-        "thumbnailUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/england.png"
-      },
-      "familysearchUrl": "https://www.familysearch.org/en/research/places/?text=England&focusedId=267",
-      "wikipediaUrl": "https://en.wikipedia.org/wiki/England"
-    }
-  ]
-}
-```
-
-(The `placeId` values in these examples are illustrative; the real
-Primary IDs are returned in the live API response and may differ.)
-
----
-
-## Tool Schema
+### Tool Schema
 
 ```typescript
 {
   name: "place_search",
   description:
-    "Look up place information for genealogy research. " +
-    "Pass a place name (e.g., 'Ohio', 'Madison') to get all matching places " +
-    "ranked by relevance — useful for disambiguating among places that share " +
-    "a name. Pass a numeric FamilySearch rep ID (the `placeRepId` field from " +
-    "a previous places call) to get the full details for that single place, " +
-    "enriched with a Wikipedia summary. " +
-    "Each result exposes two identifiers: `placeId` (the Primary ID, used by " +
-    "downstream tools like `place_population`) and `placeRepId` (the rep ID, used " +
-    "to re-query `place_search` lookup mode). If you have a `placeId` from another " +
-    "tool's output and want to re-lookup the place, search by name instead — " +
-    "lookup mode does not accept Primary IDs.",
+    "Look up places for genealogy research by name. Pass a place name " +
+    "(e.g., 'Paris', 'Madison') to get all matching places. Optionally pass a " +
+    "higher-level place as context to disambiguate among places that share a " +
+    "name — e.g. placeName 'Paris' with contextName 'Idaho' returns Paris in " +
+    "Idaho, while contextName 'France' returns Paris in France. Each result " +
+    "includes the full jurisdictional name, place type, date range, " +
+    "coordinates, a FamilySearch link, and (when available) a Wikipedia link. " +
+    "Use place_search_all instead when you need every historical jurisdiction " +
+    "a place has belonged to over time.",
   inputSchema: {
     type: "object",
     properties: {
-      query: {
+      placeName: {
+        type: "string",
+        description: "The place name to search for (e.g., 'Paris', 'Schuylkill County')."
+      },
+      contextName: {
         type: "string",
         description:
-          "A place name to search for (returns all matches), or a numeric " +
-          "FamilySearch rep ID (returns one enriched result). The numeric " +
-          "form expects a `placeRepId` from a previous places call — not a " +
-          "`placeId`. Passing a `placeId` (Primary) here will silently return " +
-          "a different place."
+          "Optional name of a higher-level place (state, country, etc.) used to " +
+          "disambiguate. Matches places whose full name contains this text. If " +
+          "nothing matches, the unfiltered results are returned instead."
       }
     },
-    required: ["query"]
+    required: ["placeName"]
   }
 }
 ```
@@ -194,128 +180,50 @@ Primary IDs are returned in the live API response and may differ.)
 
 ## Authentication
 
-None. Both FamilySearch places endpoints and the Wikipedia API are public.
+None. The FamilySearch places endpoints and the Wikipedia API are all public.
 
 ---
 
 ## FamilySearch API Reference
 
-### Endpoint: Place search
+### Places_Search_resource
 
 ```
 GET https://api.familysearch.org/platform/places/search?q=name:{query}
 Accept: application/x-gedcomx-atom+json
 ```
 
-No authentication or User-Agent header required.
+Response: `entries[]`, each with `id` (rep ID), `score`, and
+`content.gedcomx.places[0]` carrying `display.{name,fullName,type}`,
+`latitude`/`longitude`, `temporalDescription.formal`, and
+`identifiers["http://gedcomx.org/Primary"][0]` (a URL whose last path segment is
+the Primary `placeId`).
 
-**Response shape (GEDCOMX Atom):**
-
-```
-response.entries[]
-  .id                                    -> string, rep ID (same as place.id below)
-  .score                                 -> number, relevance score
-  .content.gedcomx.places[0]
-    .id                                  -> string, rep ID
-    .identifiers["http://gedcomx.org/Primary"][0]
-                                         -> string URL of the form
-                                            "https://api.familysearch.org/platform/places/{primaryId}".
-                                            The bare Primary ID is the last path segment.
-    .display.name                        -> string, short name
-    .display.fullName                    -> string, full jurisdictional name
-    .display.type                        -> string, place type
-    .latitude                            -> number (optional)
-    .longitude                           -> number (optional)
-    .temporalDescription.formal          -> string (optional), ISO date range
-```
-
-Returns multiple matches ranked by relevance. The query uses
-FamilySearch's built-in fuzzy matching — `"England"` also returns
-`"New England"`, `"England, Arkansas"`, etc.
-
-### Endpoint: Place description (by ID)
+### Place_Description_resource
 
 ```
-GET https://api.familysearch.org/platform/places/description/{id}
+GET https://api.familysearch.org/platform/places/description/{repId}
 Accept: application/json
 ```
 
-**Response shape:**
-
-```
-response.places[0]
-  .id                                    -> string, rep ID (echoes the {id} you passed)
-  .identifiers["http://gedcomx.org/Primary"][0]
-                                         -> string URL of the form
-                                            "https://api.familysearch.org/platform/places/{primaryId}".
-                                            The bare Primary ID is the last path segment.
-  .display.name                          -> string
-  .display.fullName                      -> string
-  .display.type                          -> string
-  .latitude                              -> number (optional)
-  .longitude                             -> number (optional)
-  .temporalDescription.formal            -> string (optional)
-  .jurisdiction.resourceId               -> string, parent rep ID
-                                            (the resource URL is the
-                                            description endpoint, which
-                                            takes rep IDs only)
-```
-
-Returns a single place with additional fields not available in search
-results: `jurisdiction.resourceId` (the parent place's rep ID) and
-`names[]` (multilingual name variants).
-
-**Important:** the description endpoint accepts **only rep IDs**.
-Passing a Primary identifier silently returns a different place (the
-place whose rep ID happens to numerically match the Primary you sent).
-This is why `place_search` lookup mode requires `placeRepId`, not `placeId`.
+Response: `places[0]` with the same display/coord/temporal fields plus
+`jurisdiction.resourceId` (parent rep ID). Accepts **rep IDs only**.
 
 ---
 
 ## Wikipedia API Reference
 
-### Endpoint: Page summary
-
 ```
-GET https://en.wikipedia.org/api/rest_v1/page/summary/{title}
+GET https://en.wikipedia.org/api/rest_v1/page/summary/{name}
 Accept: application/json
 ```
 
-Used for enrichment in lookup mode only. The place's `name` field is
-passed directly as the Wikipedia title.
+Used to populate `wikipediaUrl` (from `content_urls.desktop.page`). Optional
+enrichment — any non-OK status or error degrades gracefully to no Wikipedia URL.
 
-**Response shape (relevant fields):**
-
-```
-response.title                           -> string
-response.description                     -> string (optional)
-response.extract                         -> string, summary text
-response.thumbnail.source                -> string, thumbnail URL
-response.content_urls.desktop.page       -> string, article URL
-```
-
-Wikipedia enrichment is **optional** — if the API returns a non-OK
-status or throws, the tool returns the place data without Wikipedia
-fields. This is graceful degradation, not an error.
-
----
-
-## Mode detection
-
-The tool detects mode by checking whether `query` is all digits:
-
-```typescript
-function isNumericId(query: string): boolean {
-  return /^\d+$/.test(query.trim());
-}
-```
-
-- All digits → **lookup mode** (calls place description endpoint + Wikipedia)
-- Otherwise → **search mode** (calls place search endpoint, no Wikipedia)
-
-Wikipedia enrichment is only performed in lookup mode because search
-mode may return many results and enriching each one would be slow and
-wasteful.
+⚠️ The bare-name lookup shown here is the current behavior, **pending the
+[Open decision: Wikipedia link accuracy](#open-decision-wikipedia-link-accuracy)** —
+it returns the wrong article for non-primary-topic places.
 
 ---
 
@@ -324,97 +232,34 @@ wasteful.
 | Condition | Behavior |
 |-----------|----------|
 | Search returns no results (empty body or empty entries) | Return `{ results: [] }` |
-| Lookup returns 404 (invalid place ID) | Throw: `"Place not found: {id}"` |
-| FamilySearch API returns other non-OK status | Throw: `"FamilySearch API error: {status} {statusText}"` |
-| Wikipedia API fails (any status or network error) | Return place data without Wikipedia fields (graceful degradation) |
+| A description lookup 404s | Fall back to the search-entry data; do not drop the place |
+| FamilySearch search/description returns other non-OK status | Throw `"FamilySearch API error: {status} {statusText}"` |
+| Wikipedia API fails (any status or network error) | Omit Wikipedia fields (graceful degradation) |
 
 ---
 
 ## Files
 
-### `mcp-server/src/types/place.ts`
-
-API response types (`FSPlaceSearchEntry`, `FSPlaceSearchResponse`,
-`FSPlace`, `FSPlaceDescriptionResponse`, `WikipediaSummaryResponse`)
-and output types (`WikipediaData`, `PlaceResult`, `PlaceSearchToolResponse`).
-
-### `mcp-server/src/tools/place-search.ts`
-
-- `placeSearchToolSchema` — MCP tool schema
-- `placeSearchTool(input)` — main entry point (detects mode, routes accordingly)
-- `searchPlace(name)` — calls the search endpoint, returns array of results
-- `getPlaceById(id)` — calls the description endpoint, returns single result or null
-- `getWikipediaSummary(title)` — calls Wikipedia, returns enrichment or null
-- `isNumericId(query)` — mode detection
-- `toPlaceResult(placeData, wikiData)` — maps internal types to output shape
-
-### `mcp-server/src/index.ts`
-
-Registered following the existing tool pattern (import, ListTools, CallTool).
-
----
-
-## Testing
-
-### `tests/tools/place-search.test.ts` (10 cases)
-
-| # | Test case | What it verifies |
-|---|-----------|------------------|
-| 1 | Returns all matching entries with scores preserved | Search happy path |
-| 2 | Returns empty array when no results (empty entries) | Search zero-match |
-| 3 | Returns empty array when response body is empty | Empty body handling |
-| 4 | Throws on FamilySearch API network failure | HTTP error propagation |
-| 5 | Returns place data for valid ID | Lookup happy path |
-| 6 | Returns null for invalid ID (404) | Lookup 404 handling |
-| 7 | Throws on server error for ID lookup | HTTP error propagation |
-| 8 | Returns Wikipedia summary data | Wikipedia enrichment |
-| 9 | Returns null when Wikipedia article not found | Wikipedia 404 |
-| 10 | Returns null on Wikipedia API errors | Wikipedia graceful degradation |
-
-**Integration tests (via `placeSearchTool`):**
-
-| # | Test case | What it verifies |
-|---|-----------|------------------|
-| 11 | Name search returns all matches without Wikipedia | Search mode routing |
-| 12 | Numeric ID returns single result with Wikipedia | Lookup mode routing |
-| 13 | Numeric ID returns result without Wikipedia when Wikipedia fails | Graceful degradation |
-| 14 | Name search with no matches returns empty results | Zero-match end-to-end |
-| 15 | Numeric ID not found throws error | Lookup 404 end-to-end |
-| 16 | FamilySearch API failure throws error | Error propagation |
-
-### Smoke-test script
-
-```bash
-cd mcp-server
-npx tsx dev/try-place-search.ts Ohio            # Search by name
-npx tsx dev/try-place-search.ts 267             # Lookup by rep ID (England)
-npx tsx dev/try-place-search.ts Madison         # Disambiguation (multiple matches)
-```
+| File | Contents |
+|------|----------|
+| `mcp-server/src/types/place.ts` | `SimplifiedPlaceResult`, `PlaceResult` (internal), `PlaceSearchToolResponse = { results: SimplifiedPlaceResult[] }`, and the FS/Wikipedia response types. |
+| `mcp-server/src/tools/place-search.ts` | Internal `placeSearch` + module cache, `getPlaceRepIds`, `simplifyPlaceResult`, `placeSearchTool` + `placeSearchToolSchema`, `placeSearchAllTool` + `placeSearchAllToolSchema`. Plus the reusable helpers `searchPlace`, `getPlaceById`, `getPlaceByPrimaryId`, `getWikipediaSummary`, `getPlaceCandidateNames`, `extractPrimaryId`, `toPlaceResult`. |
+| `mcp-server/src/tool-schemas.ts`, `src/index.ts`, `manifest.json` | Registration for both tools. |
+| `mcp-server/tests/tools/place-search.test.ts` | Unit + integration coverage. |
+| `mcp-server/dev/try-place-search.ts`, `dev/try-place-search-all.ts` | Live smoke scripts. |
 
 ---
 
 ## Verification
 
-### Automated
-
 ```bash
 cd mcp-server && npm run build && npm test
+
+# Live smoke (no auth):
+npx tsx dev/try-place-search.ts Paris Idaho     # Paris in Idaho
+npx tsx dev/try-place-search.ts Paris France    # Paris in France
+npx tsx dev/try-place-search.ts Paris           # all Paris matches, unfiltered
 ```
 
-### Manual Layer 1 (MCP Inspector)
-
-```bash
-npx @modelcontextprotocol/inspector node build/index.js
-```
-
-- Call `places({ query: "Ohio" })` — returns Ohio and similar matches with scores
-- Call `places({ query: "267" })` — returns England with Wikipedia enrichment
-- Call `places({ query: "Madison" })` — returns multiple Madisons for disambiguation
-- Call `places({ query: "9999999" })` — returns "Place not found" error
-
-### Manual Layer 2 (Claude Code)
-
-- "Tell me about Ohio for genealogy research" — Claude should call
-  `place_search` with query `"Ohio"` and present the results
-- "What FamilySearch place is ID 267?" — Claude should call `place_search`
-  with query `"267"` and present the enriched result
+Confirm no result object contains `placeId`, `placeRepId`, `score`, `name`, or
+`parentPlaceRepId`.

--- a/docs/specs/place-search-tool-spec.md
+++ b/docs/specs/place-search-tool-spec.md
@@ -29,27 +29,33 @@ handles this plumbing privately; neither ID appears in tool output.
 
 ---
 
-## ⚠️ Open decision: Wikipedia link accuracy
+## Wikipedia link source
 
-**Status: needs review — not yet decided. The current implementation ships the
-"as-is" behavior described below; do not treat it as final.**
+`wikipediaUrl` comes from **FamilySearch's own curated per-place link**, not from
+a Wikipedia name lookup. FamilySearch stores a `WIKIPEDIA_LINK` attribute on each
+place rep, exposed by the same place service the FS research-places website uses:
 
-The enrichment step looks Wikipedia up by the place's **bare name**
-(`/page/summary/{name}`). Wikipedia resolves a bare name to its *primary topic*,
-so the `wikipediaUrl` is **wrong for any place that isn't the famous one with
-that name**:
+```
+GET https://www.familysearch.org/service/standards/place/ws-ui/places/reps/{placeRepId}/attributes/
+```
 
-- `Paris, Idaho` → links to the **Paris, France** article.
-- Every small `Paris` (Idaho, Texas, Ontario, …) gets the same France link.
-- Only the primary-topic place (Paris, France) is correct by luck.
+Take the attribute whose `type.code == "WIKIPEDIA_LINK"` and use its `url`. These
+links are correct per-place (verified live):
 
-### Options for review
+| Place | `placeRepId` | FS `WIKIPEDIA_LINK` url |
+|-------|--------------|-------------------------|
+| Paris, Idaho | `3988097` | `https://en.wikipedia.org/wiki/Paris,_Idaho` |
+| Paris, France | `442102` | `https://fr.wikipedia.org/wiki/Paris` |
+| Paris, Texas | `5021746` | `https://en.wikipedia.org/wiki/Paris,_Texas` |
+| Paris, Ontario | `11783786` | `https://en.wikipedia.org/wiki/Paris,_Ontario` |
 
-| Option | What it does | Trade-off |
-|--------|--------------|-----------|
-| **A. Drop `wikipediaUrl` for now** | Remove the field until enrichment is done properly. | Simplest; no wrong links, but no Wikipedia links either. |
-| **B. Verify by coordinates** | Only attach the link when the Wikipedia article's coordinates sit near the place's own lat/long. | Most accurate; rejects wrong links and recovers correct ones. More logic; the geosearch action API is rate-limited, so it must lean on the summary endpoint + disambiguated titles. |
-| **C. More-specific lookup** | Query Wikipedia with `name + region` (e.g. `"Paris, Idaho"`) built from `fullName`/type. | Lighter than B; catches most cases but is heuristic/US-centric and can still miss or mismatch. |
+When a place has no `WIKIPEDIA_LINK` attribute, `wikipediaUrl` is omitted. The
+`/platform/places` search and description endpoints do **not** carry this link —
+it lives only on this `ws-ui` attributes endpoint.
+
+> Earlier drafts of this spec described enriching via a Wikipedia name lookup
+> (`/page/summary/{name}`), which produced wrong links for non-primary-topic
+> places. That was a mistake — superseded by the FamilySearch attribute above.
 
 ---
 
@@ -74,10 +80,10 @@ Steps:
 3. **Describe** — for each surviving rep ID, `GET /platform/places/description/{repId}`
    (Place_Description_resource). If a description 404s, fall back to the
    search-entry data so the place is not dropped.
-4. **Enrich** — for each place, `GET https://en.wikipedia.org/api/rest_v1/page/summary/{name}`
-   to obtain `wikipediaUrl`. Graceful: a non-OK status or network error yields
-   no Wikipedia fields, not an error. ⚠️ This step has a known accuracy problem —
-   see [Open decision: Wikipedia link accuracy](#open-decision-wikipedia-link-accuracy).
+4. **Enrich** — for each place, `GET …/service/standards/place/ws-ui/places/reps/{placeRepId}/attributes/`
+   and take the `WIKIPEDIA_LINK` attribute's `url` as `wikipediaUrl` (see
+   [Wikipedia link source](#wikipedia-link-source)). Graceful: a non-OK status,
+   network error, or absent attribute yields no `wikipediaUrl`, not an error.
 5. **Cache** — memoize the `PlaceResult[]` in a module-level `Map` keyed by the
    normalized `(placeName, contextName)` pair (trimmed + lowercased). No TTL;
    lives for the MCP server process. A cache hit returns immediately without
@@ -135,7 +141,7 @@ object is present — those exist only on the internal `PlaceResult`.
       "latitude": 42.22722,
       "longitude": -111.40028,
       "familysearchUrl": "https://www.familysearch.org/en/research/places/?text=Paris&focusedId=3988097",
-      "wikipediaUrl": "https://en.wikipedia.org/wiki/Paris"
+      "wikipediaUrl": "https://en.wikipedia.org/wiki/Paris,_Idaho"
     }
   ]
 }
@@ -211,19 +217,23 @@ Response: `places[0]` with the same display/coord/temporal fields plus
 
 ---
 
-## Wikipedia API Reference
+## Wikipedia link API Reference
 
 ```
-GET https://en.wikipedia.org/api/rest_v1/page/summary/{name}
+GET https://www.familysearch.org/service/standards/place/ws-ui/places/reps/{placeRepId}/attributes/
 Accept: application/json
 ```
 
-Used to populate `wikipediaUrl` (from `content_urls.desktop.page`). Optional
-enrichment — any non-OK status or error degrades gracefully to no Wikipedia URL.
+(This is the place service the FS research-places website uses, not the
+`api.familysearch.org/platform` API. Send a browser `User-Agent`; the request
+succeeds unauthenticated.)
 
-⚠️ The bare-name lookup shown here is the current behavior, **pending the
-[Open decision: Wikipedia link accuracy](#open-decision-wikipedia-link-accuracy)** —
-it returns the wrong article for non-primary-topic places.
+Response: `attributes[]`. Take the entry whose `type.code == "WIKIPEDIA_LINK"`
+and use its `url` (its `urlTitle` is the article title, e.g. `"Paris, Idaho -
+Wikipedia"`). Optional enrichment — any non-OK status, error, or missing
+attribute degrades gracefully to no `wikipediaUrl`. (Places may also carry an
+`FS_WIKI_LINK` attribute — the FamilySearch research wiki, a different thing;
+ignore it for `wikipediaUrl`.)
 
 ---
 
@@ -243,7 +253,7 @@ it returns the wrong article for non-primary-topic places.
 | File | Contents |
 |------|----------|
 | `mcp-server/src/types/place.ts` | `SimplifiedPlaceResult`, `PlaceResult` (internal), `PlaceSearchToolResponse = { results: SimplifiedPlaceResult[] }`, and the FS/Wikipedia response types. |
-| `mcp-server/src/tools/place-search.ts` | Internal `placeSearch` + module cache, `getPlaceRepIds`, `simplifyPlaceResult`, `placeSearchTool` + `placeSearchToolSchema`, `placeSearchAllTool` + `placeSearchAllToolSchema`. Plus the reusable helpers `searchPlace`, `getPlaceById`, `getPlaceByPrimaryId`, `getWikipediaSummary`, `getPlaceCandidateNames`, `extractPrimaryId`, `toPlaceResult`. |
+| `mcp-server/src/tools/place-search.ts` | Internal `placeSearch` + module cache, `getPlaceRepIds`, `getPlaceWikipediaUrl` (reads the `WIKIPEDIA_LINK` attribute), `simplifyPlaceResult`, `placeSearchTool` + `placeSearchToolSchema`, `placeSearchAllTool` + `placeSearchAllToolSchema`. Plus the reusable helpers `searchPlace`, `getPlaceById`, `getPlaceByPrimaryId`, `getPlaceCandidateNames`, `extractPrimaryId`, `toPlaceResult`. |
 | `mcp-server/src/tool-schemas.ts`, `src/index.ts`, `manifest.json` | Registration for both tools. |
 | `mcp-server/tests/tools/place-search.test.ts` | Unit + integration coverage. |
 | `mcp-server/dev/try-place-search.ts`, `dev/try-place-search-all.ts` | Live smoke scripts. |


### PR DESCRIPTION
## Summary
- Spec-first PR for reworking `place_search`  and adding `place_search_all`. 
- `place_search` becomes a thin wrapper over an internal `placeSearch(placeName, contextName?)`: disambiguates by a higher-level place (Paris + Idaho vs Paris + France), filters candidates by context (keeps the unfiltered list when nothing matches), describes each rep, and caches by (placeName, contextName).
- New `place_search_all` tool: expands each place to every jurisdiction it has belonged to over time.
- Both tools return an ID-free `SimplifiedPlaceResult` — FamilySearch place IDs and rep IDs are never exposed to the LLM
