### PR TITLE
Add imageGroupNumber param to record_search (#25)

### DIFF
--- a/docs/specs/record-search-tool-spec-v2.md
+++ b/docs/specs/record-search-tool-spec-v2.md
@@ -132,6 +132,7 @@ together in a record but doesn't know the formal relationship.
 | Field | Type | Description |
 |-------|------|-------------|
 | `collectionId` | number | A FamilySearch collection ID (from the `place_collections` tool). |
+| `imageGroupNumber` | string | Image group number of a specific digitized volume (e.g., `"004010852"`). Also accepts split DGS format (e.g., `"004010852_001_M9QY-X6Y"`). Use the `image_search` tool first to find the image group number. |
 | `recordCountry` | string | Country where the record was created (e.g., `"United States"`, `"England"`). |
 | `recordSubdivision` | string | State or province within the country (e.g., `"Alabama"`). Requires `recordCountry`. |
 | `recordType` | `"birth"` \| `"marriage"` \| `"death"` \| `"census"` \| `"immigration"` \| `"military"` \| `"probate"` \| `"other"` | Type of record. |
@@ -435,6 +436,7 @@ Example:
 
       // Record-source
       collectionId:          { type: "number", description: "A single FamilySearch collection ID. Call the `place_collections` tool first to find the right ID for a place or topic. Note: this is a different ID system from the `place_search` tool's IDs — pass a place *name* to `place_collections`, not a place ID." },
+      imageGroupNumber:      { type: "string", description: "Filter to a specific digitized volume by image group number (e.g., `'004010852'`). Also accepts split DGS format (e.g., `'004010852_001_M9QY-X6Y'`). Use the `image_search` tool first to find the image group number for a place and date range." },
       recordCountry:         { type: "string", description: "Country where the record was created (e.g., `'United States'`, `'England'`). Acts as an anchor — at least one of `surname` or `recordCountry` must be supplied." },
       recordSubdivision:     { type: "string", description: "State, province, or first-level subdivision within the country (e.g., `'Alabama'`). Requires `recordCountry` to be supplied alongside it." },
       recordType:            { type: "string", enum: ["birth", "marriage", "death", "census", "immigration", "military", "probate", "other"], description: "Type of record. Mapped to the upstream's integer recordType encoding by the tool." },
@@ -555,6 +557,7 @@ User-Agent: <browser-like user agent string>
 | `otherGivenNameExact=true` | `q.otherGivenName.exact=on` |
 | `otherSurnameExact=true` | `q.otherSurname.exact=on` |
 | `collectionId` | `f.collectionId` |
+| `imageGroupNumber` | `q.filmNumber` |
 | `recordCountry` | `q.recordCountry` |
 | `recordSubdivision` | `q.recordSubcountry=<recordCountry>,<recordSubdivision>` (joined with a comma, no space) |
 | `recordType` | `f.recordType=N` (`"birth"`=0, `"marriage"`=1, `"death"`=2, `"census"`=3, `"immigration"`=4, `"military"`=5, `"probate"`=6, `"other"`=7) |
@@ -819,6 +822,8 @@ ListTools, CallTool — same as `place_search`, `place_collections`).
 | 18 | `recordSubdivision` is composed into `q.recordSubcountry=<country>,<subdivision>` | Subdivision composition |
 | 19 | `recordType="marriage"` maps to `f.recordType=1` | Record-type enum mapping |
 | 20 | Default flags `m.queryRequireDefault=on` and `m.defaultFacets=off` are sent on every request | Default flag enforcement |
+| 21b | `imageGroupNumber` maps to `q.filmNumber` | Film-number param mapping |
+| 21c | `imageGroupNumber` accepts split DGS format | Split DGS format passthrough |
 | 21 | Throws auth error when not authenticated | Auth propagation |
 | 22 | Throws on 400 with extracted error-body detail | API validation errors |
 | 23 | Falls back to generic 400 message when body isn't parseable | Defensive parsing |
@@ -840,6 +845,8 @@ npx tsx dev/try-record-search.ts Lincoln Abraham --birth-year 1809
 npx tsx dev/try-record-search.ts Smith --collection 1743384 --marriage-year 1830 1850
 npx tsx dev/try-record-search.ts --given Mary --country "United States"  # surname-less + country anchor
 npx tsx dev/try-record-search.ts Lincoln --alt Todd --given Mary    # maiden+married name
+npx tsx dev/try-record-search-film.ts Smith --film 004010852       # film-number filter
+npx tsx dev/try-record-search-film.ts Smith --film 004010852 --given John --birth-year 1850
 ```
 
 ---

--- a/mcp-server/dev/try-record-search-film.ts
+++ b/mcp-server/dev/try-record-search-film.ts
@@ -1,0 +1,69 @@
+import { recordSearchTool } from "../src/tools/record-search.js";
+import type { RecordSearchInput } from "../src/types/record-search.js";
+
+function usage(): never {
+  console.error("Usage:");
+  console.error("  npx tsx dev/try-record-search-film.ts <surname> --film <imageGroupNumber> [options]");
+  console.error("");
+  console.error("Options:");
+  console.error("  --film <number>           Image group number (required)");
+  console.error("  --given <name>            Given name");
+  console.error("  --country <name>          recordCountry anchor");
+  console.error("  --birth-year <yyyy>       Birth year (single year => from=to)");
+  console.error("  --count <n>               Default 20");
+  console.error("");
+  console.error("Examples:");
+  console.error("  npx tsx dev/try-record-search-film.ts Smith --film 004010852");
+  console.error("  npx tsx dev/try-record-search-film.ts Smith --film 004010852 --given John --birth-year 1850");
+  console.error("  npx tsx dev/try-record-search-film.ts --country \"United States\" --film 004010852");
+  process.exit(1);
+}
+
+const argv = process.argv.slice(2);
+if (argv.length === 0) usage();
+
+const input: RecordSearchInput = {};
+const positional: string[] = [];
+
+for (let i = 0; i < argv.length; i++) {
+  const a = argv[i];
+  switch (a) {
+    case "--film":
+      input.imageGroupNumber = argv[++i];
+      break;
+    case "--given":
+      input.givenName = argv[++i];
+      break;
+    case "--country":
+      input.recordCountry = argv[++i];
+      break;
+    case "--birth-year": {
+      const y = parseInt(argv[++i], 10);
+      input.birthYearFrom = y;
+      input.birthYearTo = y;
+      break;
+    }
+    case "--count":
+      input.count = parseInt(argv[++i], 10);
+      break;
+    case "--help":
+    case "-h":
+      usage();
+    default:
+      if (a.startsWith("--")) {
+        console.error(`Unknown flag: ${a}`);
+        usage();
+      }
+      positional.push(a);
+  }
+}
+
+if (positional[0]) input.surname = positional[0];
+
+if (!input.imageGroupNumber) {
+  console.error("Error: --film is required for this smoke test.");
+  usage();
+}
+
+const result = await recordSearchTool(input);
+console.log(JSON.stringify(result, null, 2));

--- a/mcp-server/src/tools/record-search.ts
+++ b/mcp-server/src/tools/record-search.ts
@@ -238,6 +238,7 @@ export function buildSearchUrl(input: RecordSearchInput): string {
   }
 
   if (input.collectionId !== undefined) add("f.collectionId", input.collectionId);
+  if (input.imageGroupNumber) add("q.filmNumber", input.imageGroupNumber);
   if (input.recordCountry) add("q.recordCountry", input.recordCountry);
   if (input.recordSubdivision && input.recordCountry) {
     add(
@@ -574,6 +575,7 @@ export const recordSearchToolSchema = {
       otherSurnameExact: { type: "boolean", description: "When `true`, requires an exact match on the other family name." },
 
       collectionId: { type: "number", description: "A single FamilySearch collection ID. Call the `place_collections` tool first to find the right ID for a place or topic. Note: this is a different ID system from the `place_search` tool's IDs — pass a place *name* to `place_collections`, not a place ID." },
+      imageGroupNumber: { type: "string", description: "Filter to a specific digitized volume by image group number (e.g., `'004010852'`). Also accepts split DGS format (e.g., `'004010852_001_M9QY-X6Y'`). Use the `image_search` tool first to find the image group number for a place and date range." },
       recordCountry: { type: "string", description: "Country where the record was created (e.g., `'United States'`, `'England'`). Acts as an anchor — at least one of `surname` or `recordCountry` must be supplied." },
       recordSubdivision: { type: "string", description: "State, province, or first-level subdivision within the country (e.g., `'Alabama'`). Requires `recordCountry` to be supplied alongside it." },
       recordType: { type: "string", enum: ["birth", "marriage", "death", "census", "immigration", "military", "probate", "other"], description: "Type of record. Mapped to the upstream's integer recordType encoding by the tool." },

--- a/mcp-server/src/types/record-search.ts
+++ b/mcp-server/src/types/record-search.ts
@@ -159,6 +159,7 @@ export interface RecordSearchInput {
   otherSurnameExact?: boolean;
 
   collectionId?: number;
+  imageGroupNumber?: string;
   recordCountry?: string;
   recordSubdivision?: string;
   recordType?: string;

--- a/mcp-server/tests/tools/record-search.test.ts
+++ b/mcp-server/tests/tools/record-search.test.ts
@@ -314,6 +314,16 @@ describe("buildSearchUrl param mapping", () => {
     expect(url).toContain("m.queryRequireDefault=on");
     expect(url).toContain("m.defaultFacets=off");
   });
+
+  it("21b. imageGroupNumber maps to q.filmNumber", () => {
+    const url = buildSearchUrl({ surname: "Smith", imageGroupNumber: "004010852" });
+    expect(url).toContain("q.filmNumber=004010852");
+  });
+
+  it("21c. imageGroupNumber accepts split DGS format", () => {
+    const url = buildSearchUrl({ surname: "Smith", imageGroupNumber: "004010852_001_M9QY-X6Y" });
+    expect(url).toContain("q.filmNumber=004010852_001_M9QY-X6Y");
+  });
 });
 
 describe("recordSearchTool error propagation", () => {


### PR DESCRIPTION
## Summary
- Adds `imageGroupNumber` input to `record_search`, mapped to FamilySearch's `q.filmNumber` API parameter, so users can scope indexed record searches to a specific digitized volume (microfilm roll)
- Includes two unit tests (plain and split DGS format), a smoke script (`try-record-search-film.ts`), and spec updates across all five relevant sections
- Follows the existing passthrough pattern used by `collectionId` — no validation beyond presence, not an anchor

## Test plan
- [x] `npx tsc --noEmit` passes clean
- [x] `npx vitest run mcp-server/tests/tools/record-search.test.ts` — 47/47 pass (includes 2 new tests)
- [x] `npx vitest run mcp-server/tests/packaging/manifest.test.ts` — 8/8 pass
- [ ] `npx tsx mcp-server/dev/try-record-search-film.ts Smith --film 004010852` — manual smoke test against live API (requires auth)

🤖 Generated with [Claude Code](https://claude.com/claude-code)