### PR TITLE
Implement place_search rework + place_search_all

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -267,12 +267,13 @@ Where to look first:
   string — `place_collections`, `record_search`, `place_external_links`,
   `image_read`, `image_search`, `record_read`, and `fulltext_search` already do.
 - **Exported helpers in `src/tools/`** — for example, `place-search.ts`
-  exports `searchPlace`, `getPlaceById`, and `getWikipediaSummary`,
+  exports `searchPlace`, `getPlaceById`, and `getPlaceWikipediaUrl`
+  (the place's curated FamilySearch `WIKIPEDIA_LINK` attribute),
   `place-collections.ts` exports `fetchAllCollections`,
   `filterByQuery`, and `filterByPlaceIds`, and `image-search.ts`
   exports `placeIdToRepIds` and `repIdToPlaceId` (convert between
   FamilySearch place IDs and place representation IDs). A new tool
-  that needs place lookup, Wikipedia enrichment, or placeId/placeRepId
+  that needs place lookup, the Wikipedia link, or placeId/placeRepId
   conversion should call these, not re-fetch.
 
 Soft caveat: don't pre-extract for hypothetical reuse. Wait for the

--- a/mcp-server/dev/try-place-search-all.ts
+++ b/mcp-server/dev/try-place-search-all.ts
@@ -1,0 +1,7 @@
+import { placeSearchAllTool } from "../src/tools/place-search.js";
+
+const placeName = process.argv[2] ?? "Schuylkill County";
+const contextName = process.argv[3];
+
+const result = await placeSearchAllTool({ placeName, contextName });
+console.log(JSON.stringify(result, null, 2));

--- a/mcp-server/dev/try-place-search.ts
+++ b/mcp-server/dev/try-place-search.ts
@@ -1,6 +1,7 @@
 import { placeSearchTool } from "../src/tools/place-search.js";
 
-const query = process.argv[2] ?? "Ohio";
+const placeName = process.argv[2] ?? "Paris";
+const contextName = process.argv[3];
 
-const result = await placeSearchTool({ query });
+const result = await placeSearchTool({ placeName, contextName });
 console.log(JSON.stringify(result, null, 2));

--- a/mcp-server/manifest.json
+++ b/mcp-server/manifest.json
@@ -27,6 +27,7 @@
   "tools": [
     { "name": "wikipedia_search" },
     { "name": "place_search" },
+    { "name": "place_search_all" },
     { "name": "login" },
     { "name": "logout" },
     { "name": "auth_status" },

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -5,7 +5,12 @@ import {
   ListToolsRequestSchema
 } from "@modelcontextprotocol/sdk/types.js";
 import { wikipediaSearch, type WikipediaSearchInput } from "./tools/wikipedia.js";
-import { placeSearchTool, type PlaceSearchToolInput } from "./tools/place-search.js";
+import {
+  placeSearchTool,
+  placeSearchAllTool,
+  type PlaceSearchToolInput,
+  type PlaceSearchAllToolInput,
+} from "./tools/place-search.js";
 import { loginTool, type LoginToolInput } from "./tools/login.js";
 import { logoutTool, type LogoutToolInput } from "./tools/logout.js";
 import { authStatusTool, type AuthStatusToolInput } from "./tools/auth-status.js";
@@ -82,6 +87,21 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
     try {
       const args = request.params.arguments as unknown as PlaceSearchToolInput;
       const result = await placeSearchTool(args);
+      return {
+        content: [{ type: "text", text: JSON.stringify(result, null, 2) }]
+      };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Unknown error";
+      return {
+        content: [{ type: "text", text: JSON.stringify({ error: message }) }],
+        isError: true
+      };
+    }
+  }
+  if (request.params.name === "place_search_all") {
+    try {
+      const args = request.params.arguments as unknown as PlaceSearchAllToolInput;
+      const result = await placeSearchAllTool(args);
       return {
         content: [{ type: "text", text: JSON.stringify(result, null, 2) }]
       };

--- a/mcp-server/src/tool-schemas.ts
+++ b/mcp-server/src/tool-schemas.ts
@@ -5,7 +5,10 @@
 // in its own module means the test can read the list without importing
 // index.ts, which connects the stdio transport as a side effect.
 import { wikipediaSearchSchema } from "./tools/wikipedia.js";
-import { placeSearchToolSchema } from "./tools/place-search.js";
+import {
+  placeSearchToolSchema,
+  placeSearchAllToolSchema,
+} from "./tools/place-search.js";
 import { loginToolSchema } from "./tools/login.js";
 import { logoutToolSchema } from "./tools/logout.js";
 import { authStatusToolSchema } from "./tools/auth-status.js";
@@ -42,6 +45,7 @@ import { imageSearchSchema } from "./tools/image-search.js";
 export const allToolSchemas = [
   wikipediaSearchSchema,
   placeSearchToolSchema,
+  placeSearchAllToolSchema,
   loginToolSchema,
   logoutToolSchema,
   authStatusToolSchema,

--- a/mcp-server/src/tools/place-search.ts
+++ b/mcp-server/src/tools/place-search.ts
@@ -1,13 +1,19 @@
 import type {
   FSPlaceSearchResponse,
   FSPlaceDescriptionResponse,
-  WikipediaSummaryResponse,
   PlaceResult,
+  SimplifiedPlaceResult,
   PlaceSearchToolResponse,
 } from "../types/place.js";
+import type { FSPlaceLookupResponse } from "../types/image-search.js";
+import { BROWSER_USER_AGENT } from "../constants.js";
 
 const FS_API_BASE = "https://api.familysearch.org/platform/places";
-const WIKIPEDIA_API_BASE = "https://en.wikipedia.org/api/rest_v1/page/summary";
+// FamilySearch's place service (the one the research-places website uses). It
+// carries curated per-place external links — including the correct Wikipedia
+// link — that the public /platform/places API does not expose.
+const FS_PLACE_WS_UI_BASE =
+  "https://www.familysearch.org/service/standards/place/ws-ui/places/reps";
 const FS_PLACES_PUBLIC_BASE =
   "https://www.familysearch.org/en/research/places";
 const FS_PRIMARY_IDENTIFIER_KEY = "http://gedcomx.org/Primary";
@@ -49,13 +55,6 @@ function buildFamilysearchUrl(name: string, placeRepId: string): string {
   return `${FS_PLACES_PUBLIC_BASE}/?text=${encodeURIComponent(name)}&focusedId=${placeRepId}`;
 }
 
-interface WikipediaResult {
-  title: string;
-  description: string;
-  extract: string;
-  thumbnailUrl?: string;
-  wikipediaUrl?: string;
-}
 
 export async function searchPlace(name: string): Promise<SearchPlaceResult[]> {
   const url = `${FS_API_BASE}/search?q=name:${encodeURIComponent(name)}`;
@@ -181,36 +180,48 @@ export async function getPlaceById(id: string): Promise<GetPlaceResult | null> {
   };
 }
 
+interface FSPlaceAttribute {
+  type?: { code?: string };
+  url?: string;
+}
+interface FSPlaceAttributesResponse {
+  attributes?: FSPlaceAttribute[];
+}
+
 /**
- * Get Wikipedia summary for a place.
- * Returns null if article not found or on any error (graceful degradation).
+ * Get the curated Wikipedia URL FamilySearch stores for a place rep.
+ *
+ * FamilySearch keeps a per-place `WIKIPEDIA_LINK` attribute (e.g. Paris, Idaho
+ * → en.wikipedia.org/wiki/Paris,_Idaho) on its place service — the same one the
+ * research-places website uses. This is correct per-place, unlike a name-based
+ * Wikipedia lookup. Returns null when the place has no such attribute or on any
+ * error (graceful degradation — the Wikipedia link is optional enrichment).
+ *
+ * Note: places may also carry an `FS_WIKI_LINK` attribute (the FamilySearch
+ * research wiki, a different thing); we take only `WIKIPEDIA_LINK`.
  */
-export async function getWikipediaSummary(title: string): Promise<WikipediaResult | null> {
-  const url = `${WIKIPEDIA_API_BASE}/${encodeURIComponent(title)}`;
+export async function getPlaceWikipediaUrl(repId: string): Promise<string | null> {
+  const url = `${FS_PLACE_WS_UI_BASE}/${encodeURIComponent(repId)}/attributes/`;
 
   try {
     const response = await fetch(url, {
       headers: {
         Accept: "application/json",
+        "User-Agent": BROWSER_USER_AGENT,
+        "FS-User-Agent-Chain": "zion-user",
       },
     });
 
     if (!response.ok) {
-      // Graceful degradation: Wikipedia is optional enrichment
       return null;
     }
 
-    const data: WikipediaSummaryResponse = await response.json();
-
-    return {
-      title: data.title,
-      description: data.description || "",
-      extract: data.extract,
-      thumbnailUrl: data.thumbnail?.source,
-      wikipediaUrl: data.content_urls?.desktop.page,
-    };
+    const data = (await response.json()) as FSPlaceAttributesResponse;
+    const wiki = (data.attributes ?? []).find(
+      (a) => a.type?.code === "WIKIPEDIA_LINK" && !!a.url
+    );
+    return wiki?.url ?? null;
   } catch {
-    // Graceful degradation: Wikipedia is optional enrichment
     return null;
   }
 }
@@ -262,20 +273,16 @@ export async function getPlaceCandidateNames(primaryId: string): Promise<string[
   return [...singleWord, ...multiWord];
 }
 
-/**
- * Detect if input looks like a numeric ID
- */
-function isNumericId(query: string): boolean {
-  return /^\d+$/.test(query.trim());
+export interface PlaceSearchToolInput {
+  placeName: string;
+  contextName?: string;
 }
 
-export interface PlaceSearchToolInput {
-  query: string;
-}
+export type PlaceSearchAllToolInput = PlaceSearchToolInput;
 
 function toPlaceResult(
   placeData: SearchPlaceResult | GetPlaceResult,
-  wikiData: WikipediaResult | null
+  wikipediaUrl: string | null
 ): PlaceResult {
   const result: PlaceResult = {
     ...(placeData.placeId ? { placeId: placeData.placeId } : {}),
@@ -297,58 +304,240 @@ function toPlaceResult(
     result.parentPlaceRepId = placeData.parentPlaceRepId;
   }
 
-  if (wikiData) {
-    result.wikipedia = {
-      title: wikiData.title,
-      description: wikiData.description,
-      extract: wikiData.extract,
-      thumbnailUrl: wikiData.thumbnailUrl,
-    };
-    result.wikipediaUrl = wikiData.wikipediaUrl;
+  if (wikipediaUrl) {
+    result.wikipediaUrl = wikipediaUrl;
   }
 
   return result;
 }
 
-export async function placeSearchTool(input: PlaceSearchToolInput): Promise<PlaceSearchToolResponse> {
-  const { query } = input;
-
-  if (isNumericId(query)) {
-    const placeData = await getPlaceById(query);
-    if (!placeData) {
-      throw new Error(`Place not found: ${query}`);
-    }
-    const wikiData = await getWikipediaSummary(placeData.name);
-    return { results: [toPlaceResult(placeData, wikiData)] };
-  }
-
-  const searchResults = await searchPlace(query);
-  return { results: searchResults.map((r) => toPlaceResult(r, null)) };
+/**
+ * Project a full (internal) PlaceResult down to the LLM-facing shape,
+ * dropping all FamilySearch identifiers and the relevance score. Optional
+ * fields are omitted when absent so the JSON stays clean.
+ */
+export function simplifyPlaceResult(r: PlaceResult): SimplifiedPlaceResult {
+  return {
+    fullName: r.fullName,
+    type: r.type,
+    ...(r.dateRange !== undefined ? { dateRange: r.dateRange } : {}),
+    ...(r.latitude !== undefined ? { latitude: r.latitude } : {}),
+    ...(r.longitude !== undefined ? { longitude: r.longitude } : {}),
+    familysearchUrl: r.familysearchUrl,
+    ...(r.wikipediaUrl !== undefined ? { wikipediaUrl: r.wikipediaUrl } : {}),
+  };
 }
 
 /**
- * MCP Tool Schema for places tool
+ * Get every place representation ID for a Primary place ID via the
+ * Place_resource endpoint (GET /platform/places/{pid}). The response lists the
+ * bare place entry (id === pid, no `display`) followed by its representation
+ * entries, each with `place.resourceId === pid`. We collect those rep IDs.
+ *
+ * Public (no auth) — the places endpoints accept anonymous requests. Parallels
+ * `placeIdToRepIds` in image-search.ts, which is token-bound; not consolidated
+ * because the only difference is the Authorization header.
+ */
+export async function getPlaceRepIds(pid: string): Promise<string[]> {
+  const url = `${FS_API_BASE}/${encodeURIComponent(pid)}`;
+
+  const response = await fetch(url, { headers: { Accept: "application/json" } });
+  if (!response.ok) {
+    if (response.status === 404) return [];
+    throw new Error(
+      `FamilySearch API error: ${response.status} ${response.statusText}`
+    );
+  }
+
+  const data = (await response.json()) as FSPlaceLookupResponse;
+  const reps = (data.places ?? []).filter((p) => p.place?.resourceId === pid);
+
+  const ids: string[] = [];
+  const seen = new Set<string>();
+  for (const rep of reps) {
+    if (rep.id && !seen.has(rep.id)) {
+      seen.add(rep.id);
+      ids.push(rep.id);
+    }
+  }
+  return ids;
+}
+
+// In-memory cache of internal place-search results, keyed by the normalized
+// (placeName, contextName) pair. Lives for the life of the MCP server process;
+// no TTL. There is no cross-session host storage (see CLAUDE.md), so this only
+// memoizes within a single running server.
+const placeSearchCache = new Map<string, PlaceResult[]>();
+
+function placeSearchCacheKey(placeName: string, contextName?: string): string {
+  return `${placeName.trim().toLowerCase()} ${(contextName ?? "").trim().toLowerCase()}`;
+}
+
+/** Test-only: empty the in-memory cache so cases don't bleed into each other. */
+export function __clearPlaceSearchCacheForTests(): void {
+  placeSearchCache.clear();
+}
+
+/**
+ * Build a full PlaceResult from a rep ID: fetch its description, enrich with
+ * Wikipedia, and assemble. Falls back to `searchFallback` (the search-entry
+ * data) when the description endpoint 404s, so a place is never dropped.
+ */
+async function buildPlaceResult(
+  repId: string,
+  searchFallback: SearchPlaceResult
+): Promise<PlaceResult> {
+  const placeData = (await getPlaceById(repId)) ?? searchFallback;
+  const wikipediaUrl = await getPlaceWikipediaUrl(placeData.placeRepId);
+  return toPlaceResult(placeData, wikipediaUrl);
+}
+
+/**
+ * Internal place search. The single entry point any tool should call when it
+ * needs FamilySearch place data or IDs for a named place.
+ *
+ * @param placeName   the place to search for (e.g. "Paris")
+ * @param contextName optional name of a higher-level place to disambiguate by
+ *                    (e.g. "Idaho" or "France"); matched as a case-insensitive
+ *                    substring of each candidate's full jurisdictional name
+ *
+ * Steps: search -> filter by context (keep unfiltered if nothing matches) ->
+ * fetch a description per surviving rep ID -> enrich with Wikipedia -> build
+ * PlaceResult[]. Results are cached by (placeName, contextName).
+ */
+export async function placeSearch(
+  placeName: string,
+  contextName?: string
+): Promise<PlaceResult[]> {
+  const key = placeSearchCacheKey(placeName, contextName);
+  const cached = placeSearchCache.get(key);
+  if (cached) return cached;
+
+  let entries = await searchPlace(placeName);
+
+  const context = contextName?.trim().toLowerCase();
+  if (context) {
+    const filtered = entries.filter((e) =>
+      e.fullName.toLowerCase().includes(context)
+    );
+    // Better to return extra results than zero: only narrow if something matched.
+    if (filtered.length > 0) {
+      entries = filtered;
+    }
+  }
+
+  const results = await Promise.all(
+    entries.map((e) => buildPlaceResult(e.placeRepId, e))
+  );
+
+  placeSearchCache.set(key, results);
+  return results;
+}
+
+export async function placeSearchTool(
+  input: PlaceSearchToolInput
+): Promise<PlaceSearchToolResponse> {
+  const results = await placeSearch(input.placeName, input.contextName);
+  return { results: results.map(simplifyPlaceResult) };
+}
+
+/**
+ * place_search_all: every jurisdiction a place has belonged to over time.
+ *
+ * Runs the internal placeSearch, then for each distinct Primary place ID
+ * expands to all of its representations (Place_resource), de-duplicates the rep
+ * IDs across places, fetches a description + Wikipedia for each, and returns the
+ * simplified, ID-free results.
+ */
+export async function placeSearchAllTool(
+  input: PlaceSearchAllToolInput
+): Promise<PlaceSearchToolResponse> {
+  const base = await placeSearch(input.placeName, input.contextName);
+
+  const pids = Array.from(
+    new Set(base.map((r) => r.placeId).filter((p): p is string => !!p))
+  );
+
+  const repIdSets = await Promise.all(pids.map((pid) => getPlaceRepIds(pid)));
+  const repIds = Array.from(new Set(repIdSets.flat()));
+
+  const built = await Promise.all(
+    repIds.map(async (repId) => {
+      const placeData = await getPlaceById(repId);
+      if (!placeData) return null;
+      const wikipediaUrl = await getPlaceWikipediaUrl(repId);
+      return simplifyPlaceResult(toPlaceResult(placeData, wikipediaUrl));
+    })
+  );
+
+  return { results: built.filter((r): r is SimplifiedPlaceResult => r !== null) };
+}
+
+/**
+ * MCP Tool Schema for place_search
  */
 export const placeSearchToolSchema = {
   name: "place_search",
   description:
-    "Look up place information for genealogy research. " +
-    "Pass a place name (e.g., 'Ohio', 'Madison') to get all matching places ranked by relevance — useful for disambiguating among places that share a name. " +
-    "Pass a numeric FamilySearch rep ID (the `placeRepId` field from a previous places call) to get the full details for that single place, enriched with a Wikipedia summary. " +
-    "Each result exposes two identifiers: `placeId` (the Primary ID, used by downstream tools like `place_population`) and `placeRepId` (the rep ID, used to re-query `place_search` lookup mode). " +
-    "If you have a `placeId` from another tool's output and want to re-lookup the place, search by name instead — lookup mode does not accept Primary IDs.",
+    "Look up places for genealogy research by name. " +
+    "Pass a place name (e.g., 'Paris', 'Madison') to get all matching places. " +
+    "Optionally pass a higher-level place as context to disambiguate among places " +
+    "that share a name — e.g. placeName 'Paris' with contextName 'Idaho' returns " +
+    "Paris in Idaho, while contextName 'France' returns Paris in France. " +
+    "Each result includes the full jurisdictional name, place type, date range, " +
+    "coordinates, a FamilySearch link, and (when available) a Wikipedia link. " +
+    "Use place_search_all instead when you need every historical jurisdiction a " +
+    "place has belonged to over time.",
   inputSchema: {
     type: "object",
     properties: {
-      query: {
+      placeName: {
         type: "string",
         description:
-          "A place name to search for (returns all matches), or a numeric FamilySearch rep ID (returns one enriched result). " +
-          "Example name search: { query: \"Schuylkill County, Pennsylvania\" }. " +
-          "The numeric form expects a `placeRepId` from a previous places call — not a `placeId`. " +
-          "Passing a `placeId` (Primary) here will silently return a different place.",
+          "The place name to search for (e.g., 'Paris', 'Schuylkill County').",
+      },
+      contextName: {
+        type: "string",
+        description:
+          "Optional name of a higher-level place (state, country, etc.) used to " +
+          "disambiguate. Matches places whose full name contains this text. If " +
+          "nothing matches, the unfiltered results are returned instead.",
       },
     },
-    required: ["query"],
+    required: ["placeName"],
+  },
+};
+
+/**
+ * MCP Tool Schema for place_search_all
+ */
+export const placeSearchAllToolSchema = {
+  name: "place_search_all",
+  description:
+    "Look up a place and return every jurisdiction it has belonged to over time. " +
+    "Takes the same input as place_search (a place name plus an optional " +
+    "higher-level place as context). Where place_search returns the matching " +
+    "place(s), place_search_all additionally expands each match to all of its " +
+    "historical representations — useful when boundaries or parent jurisdictions " +
+    "changed across the time period you're researching. Each result includes the " +
+    "full jurisdictional name, place type, date range, coordinates, a FamilySearch " +
+    "link, and (when available) a Wikipedia link.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      placeName: {
+        type: "string",
+        description:
+          "The place name to search for (e.g., 'Paris', 'Schuylkill County').",
+      },
+      contextName: {
+        type: "string",
+        description:
+          "Optional name of a higher-level place (state, country, etc.) used to " +
+          "disambiguate. Matches places whose full name contains this text. If " +
+          "nothing matches, the unfiltered results are returned instead.",
+      },
+    },
+    required: ["placeName"],
   },
 };

--- a/mcp-server/src/types/place.ts
+++ b/mcp-server/src/types/place.ts
@@ -67,37 +67,7 @@ export interface FSPlaceDescriptionResponse {
   places?: FSPlace[];
 }
 
-// Wikipedia REST API Response Types
-// GET https://en.wikipedia.org/api/rest_v1/page/summary/{title}
-
-export interface WikipediaSummaryResponse {
-  title: string;
-  description?: string;
-  extract: string;
-  coordinates?: {
-    lat: number;
-    lon: number;
-  };
-  thumbnail?: {
-    source: string;
-    width: number;
-    height: number;
-  };
-  content_urls?: {
-    desktop: {
-      page: string;
-    };
-  };
-}
-
 // Tool Output Types
-
-export interface WikipediaData {
-  title: string;
-  description: string;
-  extract: string;
-  thumbnailUrl?: string;
-}
 
 export interface PlaceResult {
   // FamilySearch data
@@ -112,14 +82,25 @@ export interface PlaceResult {
   parentPlaceRepId?: string;
   score?: number;
 
-  // Wikipedia data (if available)
-  wikipedia?: WikipediaData;
-
   // Links
+  familysearchUrl: string;
+  wikipediaUrl?: string;       // FamilySearch's curated WIKIPEDIA_LINK attribute
+}
+
+// LLM-facing place shape. Deliberately omits the FamilySearch identifiers
+// (`placeId`, `placeRepId`, parent rep IDs) and the relevance `score` — those
+// are internal API details the model never sees. Both `place_search` and
+// `place_search_all` return arrays of these.
+export interface SimplifiedPlaceResult {
+  fullName: string;
+  type: string;
+  dateRange?: string;
+  latitude?: number;
+  longitude?: number;
   familysearchUrl: string;
   wikipediaUrl?: string;
 }
 
 export interface PlaceSearchToolResponse {
-  results: PlaceResult[];
+  results: SimplifiedPlaceResult[];
 }

--- a/mcp-server/tests/tools/place-search.test.ts
+++ b/mcp-server/tests/tools/place-search.test.ts
@@ -2,13 +2,16 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import {
   searchPlace,
   getPlaceById,
-  getWikipediaSummary,
+  getPlaceRepIds,
+  getPlaceWikipediaUrl,
+  placeSearch,
   placeSearchTool,
+  placeSearchAllTool,
+  __clearPlaceSearchCacheForTests,
 } from "../../src/tools/place-search.js";
 import type {
   FSPlaceSearchResponse,
   FSPlaceDescriptionResponse,
-  WikipediaSummaryResponse,
 } from "../../src/types/place.js";
 
 const mockFetch = vi.fn();
@@ -16,18 +19,21 @@ vi.stubGlobal("fetch", mockFetch);
 
 beforeEach(() => {
   mockFetch.mockReset();
+  __clearPlaceSearchCacheForTests();
 });
 
 afterEach(() => {
   vi.restoreAllMocks();
 });
 
-// Test fixtures
+// ---------------------------------------------------------------------------
+// Shared fixtures
 //
 // Real FamilySearch responses carry both a rep ID (echoed at `entry.id` and
-// `place.id`) and a Primary identifier (under `identifiers["http://gedcomx.org/Primary"]`
-// as a URL). The Primary IDs below are illustrative — the real values come
-// from the live API.
+// `place.id`) and a Primary identifier (under
+// `identifiers["http://gedcomx.org/Primary"]` as a URL). The Primary IDs below
+// are illustrative — the real values come from the live API.
+// ---------------------------------------------------------------------------
 
 const mockSearchResponse: FSPlaceSearchResponse = {
   entries: [
@@ -46,9 +52,7 @@ const mockSearchResponse: FSPlaceSearchResponse = {
               },
               latitude: 52.0,
               longitude: -1.0,
-              temporalDescription: {
-                formal: "+1801/",
-              },
+              temporalDescription: { formal: "+1801/" },
               identifiers: {
                 "http://gedcomx.org/Primary": [
                   "https://api.familysearch.org/platform/places/10026773",
@@ -88,11 +92,6 @@ const mockSearchResponse: FSPlaceSearchResponse = {
           ],
         },
       },
-      links: {
-        description: {
-          href: "https://api.familysearch.org/platform/places/description/12345",
-        },
-      },
     },
   ],
 };
@@ -108,12 +107,8 @@ const mockPlaceDescriptionResponse: FSPlaceDescriptionResponse = {
       },
       latitude: 52.0,
       longitude: -1.0,
-      temporalDescription: {
-        formal: "+1801/",
-      },
-      jurisdiction: {
-        resourceId: "10",
-      },
+      temporalDescription: { formal: "+1801/" },
+      jurisdiction: { resourceId: "10" },
       identifiers: {
         "http://gedcomx.org/Primary": [
           "https://api.familysearch.org/platform/places/10026773",
@@ -123,26 +118,127 @@ const mockPlaceDescriptionResponse: FSPlaceDescriptionResponse = {
   ],
 };
 
-const mockWikipediaResponse: WikipediaSummaryResponse = {
-  title: "England",
-  description: "Country within the United Kingdom",
-  extract:
-    "England is a country that is part of the United Kingdom. It shares land borders with Wales and Scotland.",
-  coordinates: {
-    lat: 52.0,
-    lon: -1.0,
-  },
-  thumbnail: {
-    source: "https://upload.wikimedia.org/wikipedia/commons/thumb/england.png",
-    width: 200,
-    height: 200,
-  },
-  content_urls: {
-    desktop: {
-      page: "https://en.wikipedia.org/wiki/England",
+// ---------------------------------------------------------------------------
+// Paris fixtures — used by the multi-call placeSearch / placeSearchAll tests.
+// Routed by URL substring (see `routeByUrl`) so call ordering doesn't matter.
+// ---------------------------------------------------------------------------
+
+const parisSearchResponse: FSPlaceSearchResponse = {
+  entries: [
+    {
+      id: "100",
+      score: 100.0,
+      content: {
+        gedcomx: {
+          places: [
+            {
+              id: "100",
+              display: {
+                name: "Paris",
+                fullName: "Paris, Bear Lake, Idaho, United States",
+                type: "City",
+              },
+              identifiers: {
+                "http://gedcomx.org/Primary": [
+                  "https://api.familysearch.org/platform/places/9001",
+                ],
+              },
+            },
+          ],
+        },
+      },
     },
-  },
+    {
+      id: "200",
+      score: 90.0,
+      content: {
+        gedcomx: {
+          places: [
+            {
+              id: "200",
+              display: {
+                name: "Paris",
+                fullName: "Paris, Île-de-France, France",
+                type: "City",
+              },
+              identifiers: {
+                "http://gedcomx.org/Primary": [
+                  "https://api.familysearch.org/platform/places/9002",
+                ],
+              },
+            },
+          ],
+        },
+      },
+    },
+  ],
 };
+
+function description(
+  id: string,
+  fullName: string,
+  primaryId: string
+): FSPlaceDescriptionResponse {
+  return {
+    places: [
+      {
+        id,
+        display: { name: "Paris", fullName, type: "City" },
+        latitude: 1.0,
+        longitude: 2.0,
+        temporalDescription: { formal: "+1900/" },
+        identifiers: {
+          "http://gedcomx.org/Primary": [
+            `https://api.familysearch.org/platform/places/${primaryId}`,
+          ],
+        },
+      },
+    ],
+  };
+}
+
+/** FamilySearch place attributes response carrying a WIKIPEDIA_LINK attribute. */
+function attributes(wikipediaUrl: string) {
+  return {
+    attributes: [
+      {
+        type: { code: "FS_WIKI_LINK" },
+        url: "https://www.familysearch.org/wiki/en/Idaho,_United_States_Genealogy",
+      },
+      { type: { code: "WIKIPEDIA_LINK" }, url: wikipediaUrl },
+    ],
+  };
+}
+
+interface Route {
+  match: string;
+  ok?: boolean;
+  status?: number;
+  json?: unknown;
+  text?: string;
+}
+
+/** Route fetch calls by URL substring so test order is call-order-independent. */
+function routeByUrl(routes: Route[]): void {
+  mockFetch.mockImplementation(async (url: string) => {
+    const route = routes.find((r) => url.includes(r.match));
+    if (!route) {
+      throw new Error(`Unexpected fetch in test: ${url}`);
+    }
+    if (route.ok === false) {
+      return { ok: false, status: route.status ?? 500, statusText: "Error" };
+    }
+    return {
+      ok: true,
+      json: async () => route.json,
+      text: async () => route.text ?? JSON.stringify(route.json),
+    };
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Helper unit tests
+// ---------------------------------------------------------------------------
 
 describe("searchPlace", () => {
   it("returns Primary as placeId, rep as placeRepId, with all matches and scores preserved", async () => {
@@ -186,59 +282,17 @@ describe("searchPlace", () => {
     ]);
   });
 
-  it("returns placeId as undefined when identifiers.Primary is missing", async () => {
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      text: async () =>
-        JSON.stringify({
-          entries: [
-            {
-              id: "999",
-              score: 50,
-              content: {
-                gedcomx: {
-                  places: [
-                    {
-                      id: "999",
-                      display: {
-                        name: "Mystery",
-                        fullName: "Mystery",
-                        type: "Town",
-                      },
-                    },
-                  ],
-                },
-              },
-            },
-          ],
-        }),
-    });
-
-    const result = await searchPlace("Mystery");
-    expect(result[0].placeId).toBeUndefined();
-    expect(result[0].placeRepId).toBe("999");
-  });
-
   it("returns empty array when no results found (empty entries)", async () => {
     mockFetch.mockResolvedValueOnce({
       ok: true,
       text: async () => JSON.stringify({ entries: [] }),
     });
-
-    const result = await searchPlace("NonexistentPlace12345");
-
-    expect(result).toEqual([]);
+    expect(await searchPlace("NonexistentPlace12345")).toEqual([]);
   });
 
   it("returns empty array when response body is empty", async () => {
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      text: async () => "",
-    });
-
-    const result = await searchPlace("NonexistentPlace12345");
-
-    expect(result).toEqual([]);
+    mockFetch.mockResolvedValueOnce({ ok: true, text: async () => "" });
+    expect(await searchPlace("NonexistentPlace12345")).toEqual([]);
   });
 
   it("throws an error on network failure", async () => {
@@ -247,7 +301,6 @@ describe("searchPlace", () => {
       status: 500,
       statusText: "Internal Server Error",
     });
-
     await expect(searchPlace("England")).rejects.toThrow(
       "FamilySearch API error: 500 Internal Server Error"
     );
@@ -266,9 +319,7 @@ describe("getPlaceById", () => {
     expect(mockFetch).toHaveBeenCalledWith(
       "https://api.familysearch.org/platform/places/description/267",
       expect.objectContaining({
-        headers: expect.objectContaining({
-          Accept: "application/json",
-        }),
+        headers: expect.objectContaining({ Accept: "application/json" }),
       })
     );
     expect(result).toEqual({
@@ -290,10 +341,7 @@ describe("getPlaceById", () => {
       status: 404,
       statusText: "Not Found",
     });
-
-    const result = await getPlaceById("invalid-id");
-
-    expect(result).toBeNull();
+    expect(await getPlaceById("invalid-id")).toBeNull();
   });
 
   it("throws an error on server error", async () => {
@@ -302,200 +350,325 @@ describe("getPlaceById", () => {
       status: 500,
       statusText: "Internal Server Error",
     });
-
     await expect(getPlaceById("267")).rejects.toThrow(
       "FamilySearch API error: 500 Internal Server Error"
     );
   });
 });
 
-describe("getWikipediaSummary", () => {
-  it("returns Wikipedia summary data", async () => {
+describe("getPlaceWikipediaUrl", () => {
+  it("returns the WIKIPEDIA_LINK attribute url (ignoring FS_WIKI_LINK)", async () => {
     mockFetch.mockResolvedValueOnce({
       ok: true,
-      json: async () => mockWikipediaResponse,
+      json: async () => attributes("https://en.wikipedia.org/wiki/Paris,_Idaho"),
     });
 
-    const result = await getWikipediaSummary("England");
+    const result = await getPlaceWikipediaUrl("3988097");
 
     expect(mockFetch).toHaveBeenCalledWith(
-      "https://en.wikipedia.org/api/rest_v1/page/summary/England",
-      expect.any(Object)
+      "https://www.familysearch.org/service/standards/place/ws-ui/places/reps/3988097/attributes/",
+      expect.objectContaining({
+        headers: expect.objectContaining({ Accept: "application/json" }),
+      })
     );
-    expect(result).toEqual({
-      title: "England",
-      description: "Country within the United Kingdom",
-      extract:
-        "England is a country that is part of the United Kingdom. It shares land borders with Wales and Scotland.",
-      thumbnailUrl:
-        "https://upload.wikimedia.org/wikipedia/commons/thumb/england.png",
-      wikipediaUrl: "https://en.wikipedia.org/wiki/England",
-    });
+    expect(result).toBe("https://en.wikipedia.org/wiki/Paris,_Idaho");
   });
 
-  it("returns null when Wikipedia article not found (404)", async () => {
+  it("returns null when the place has no WIKIPEDIA_LINK attribute", async () => {
     mockFetch.mockResolvedValueOnce({
-      ok: false,
-      status: 404,
-      statusText: "Not Found",
+      ok: true,
+      json: async () => ({
+        attributes: [
+          {
+            type: { code: "FS_WIKI_LINK" },
+            url: "https://www.familysearch.org/wiki/en/Whatever",
+          },
+        ],
+      }),
     });
 
-    const result = await getWikipediaSummary("NonexistentPlace12345");
-
-    expect(result).toBeNull();
+    expect(await getPlaceWikipediaUrl("3988097")).toBeNull();
   });
 
-  it("returns null on Wikipedia API errors (graceful degradation)", async () => {
-    mockFetch.mockResolvedValueOnce({
-      ok: false,
-      status: 500,
-      statusText: "Internal Server Error",
-    });
+  it("returns null on a non-OK response (graceful degradation)", async () => {
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 404, statusText: "Not Found" });
+    expect(await getPlaceWikipediaUrl("0000")).toBeNull();
+  });
 
-    const result = await getWikipediaSummary("England");
-
-    expect(result).toBeNull();
+  it("returns null on network error", async () => {
+    mockFetch.mockRejectedValueOnce(new Error("boom"));
+    expect(await getPlaceWikipediaUrl("3988097")).toBeNull();
   });
 });
 
-describe("placeSearchTool", () => {
-  it("returns all name-search matches wrapped in results, without Wikipedia enrichment, with both ID fields and the new familysearchUrl", async () => {
+describe("getPlaceRepIds", () => {
+  it("returns distinct rep IDs whose place.resourceId points back to the pid", async () => {
     mockFetch.mockResolvedValueOnce({
       ok: true,
-      text: async () => JSON.stringify(mockSearchResponse),
+      json: async () => ({
+        places: [
+          { id: "9001", display: undefined },
+          { id: "100", place: { resourceId: "9001" } },
+          { id: "101", place: { resourceId: "9001" } },
+          { id: "999", place: { resourceId: "9999" } },
+          { id: "100", place: { resourceId: "9001" } },
+        ],
+      }),
     });
 
-    const result = await placeSearchTool({ query: "England" });
-
-    expect(mockFetch).toHaveBeenCalledTimes(1);
-    expect(result).toEqual({
-      results: [
-        {
-          placeId: "10026773",
-          placeRepId: "267",
-          name: "England",
-          fullName: "England, United Kingdom",
-          type: "Country",
-          latitude: 52.0,
-          longitude: -1.0,
-          dateRange: "+1801/",
-          score: 100.0,
-          familysearchUrl:
-            "https://www.familysearch.org/en/research/places/?text=England&focusedId=267",
-        },
-        {
-          placeId: "10054321",
-          placeRepId: "12345",
-          name: "New England",
-          fullName: "New England, United States",
-          type: "Region",
-          latitude: 43.0,
-          longitude: -71.0,
-          score: 64.0,
-          familysearchUrl:
-            "https://www.familysearch.org/en/research/places/?text=New%20England&focusedId=12345",
-        },
-      ],
-    });
-  });
-
-  it("returns a single wrapped result with Wikipedia enrichment for numeric (rep) ID input", async () => {
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => mockPlaceDescriptionResponse,
-    });
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => mockWikipediaResponse,
-    });
-
-    const result = await placeSearchTool({ query: "267" });
+    const result = await getPlaceRepIds("9001");
 
     expect(mockFetch).toHaveBeenCalledWith(
-      "https://api.familysearch.org/platform/places/description/267",
-      expect.any(Object)
+      "https://api.familysearch.org/platform/places/9001",
+      expect.objectContaining({
+        headers: expect.objectContaining({ Accept: "application/json" }),
+      })
     );
-    expect(result).toEqual({
-      results: [
-        {
-          placeId: "10026773",
-          placeRepId: "267",
-          name: "England",
-          fullName: "England, United Kingdom",
-          type: "Country",
-          latitude: 52.0,
-          longitude: -1.0,
-          dateRange: "+1801/",
-          parentPlaceRepId: "10",
-          wikipedia: {
-            title: "England",
-            description: "Country within the United Kingdom",
-            extract:
-              "England is a country that is part of the United Kingdom. It shares land borders with Wales and Scotland.",
-            thumbnailUrl:
-              "https://upload.wikimedia.org/wikipedia/commons/thumb/england.png",
-          },
-          familysearchUrl:
-            "https://www.familysearch.org/en/research/places/?text=England&focusedId=267",
-          wikipediaUrl: "https://en.wikipedia.org/wiki/England",
-        },
-      ],
-    });
+    expect(result).toEqual(["100", "101"]);
   });
 
-  it("returns ID result without Wikipedia when Wikipedia fails", async () => {
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => mockPlaceDescriptionResponse,
-    });
-    mockFetch.mockResolvedValueOnce({
-      ok: false,
-      status: 404,
-      statusText: "Not Found",
-    });
-
-    const result = await placeSearchTool({ query: "267" });
-
-    expect(result.results).toHaveLength(1);
-    expect(result.results[0].placeId).toBe("10026773");
-    expect(result.results[0].placeRepId).toBe("267");
-    expect(result.results[0].wikipedia).toBeUndefined();
-    expect(result.results[0].wikipediaUrl).toBeUndefined();
+  it("returns empty array on 404", async () => {
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 404, statusText: "Not Found" });
+    expect(await getPlaceRepIds("0000")).toEqual([]);
   });
 
-  it("returns empty results array for a name search with no matches (no throw)", async () => {
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      text: async () => "",
-    });
-
-    const result = await placeSearchTool({ query: "NonexistentPlace12345" });
-
-    expect(result).toEqual({ results: [] });
-    expect(mockFetch).toHaveBeenCalledTimes(1);
-  });
-
-  it("throws error when numeric ID is not found (404)", async () => {
-    mockFetch.mockResolvedValueOnce({
-      ok: false,
-      status: 404,
-      statusText: "Not Found",
-    });
-
-    await expect(placeSearchTool({ query: "9999999" })).rejects.toThrow(
-      "Place not found: 9999999"
-    );
-  });
-
-  it("throws error on FamilySearch API failure", async () => {
+  it("throws on other non-OK status", async () => {
     mockFetch.mockResolvedValueOnce({
       ok: false,
       status: 500,
       statusText: "Internal Server Error",
     });
-
-    await expect(placeSearchTool({ query: "England" })).rejects.toThrow(
+    await expect(getPlaceRepIds("9001")).rejects.toThrow(
       "FamilySearch API error: 500 Internal Server Error"
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Internal placeSearch
+// ---------------------------------------------------------------------------
+
+describe("placeSearch (internal)", () => {
+  it("narrows to matches whose fullName contains the context name", async () => {
+    routeByUrl([
+      { match: "search?q=name:Paris", json: parisSearchResponse },
+      {
+        match: "description/100",
+        json: description("100", "Paris, Bear Lake, Idaho, United States", "9001"),
+      },
+      { match: "attributes", ok: false, status: 404 },
+    ]);
+
+    const result = await placeSearch("Paris", "Idaho");
+
+    expect(result).toHaveLength(1);
+    expect(result[0].placeId).toBe("9001");
+    expect(result[0].fullName).toBe("Paris, Bear Lake, Idaho, United States");
+    expect(mockFetch).not.toHaveBeenCalledWith(
+      expect.stringContaining("description/200"),
+      expect.anything()
+    );
+  });
+
+  it("keeps the unfiltered list when nothing matches the context name", async () => {
+    routeByUrl([
+      { match: "search?q=name:Paris", json: parisSearchResponse },
+      {
+        match: "description/100",
+        json: description("100", "Paris, Bear Lake, Idaho, United States", "9001"),
+      },
+      {
+        match: "description/200",
+        json: description("200", "Paris, Île-de-France, France", "9002"),
+      },
+      { match: "attributes", ok: false, status: 404 },
+    ]);
+
+    const result = await placeSearch("Paris", "Nowhereland");
+
+    expect(result.map((r) => r.placeId).sort()).toEqual(["9001", "9002"]);
+  });
+
+  it("caches results so a repeat call does not re-fetch", async () => {
+    routeByUrl([
+      { match: "search?q=name:Paris", json: parisSearchResponse },
+      {
+        match: "description/100",
+        json: description("100", "Paris, Bear Lake, Idaho, United States", "9001"),
+      },
+      { match: "attributes", ok: false, status: 404 },
+    ]);
+
+    await placeSearch("Paris", "Idaho");
+    const callsAfterFirst = mockFetch.mock.calls.length;
+    const second = await placeSearch("Paris", "Idaho");
+
+    expect(mockFetch.mock.calls.length).toBe(callsAfterFirst);
+    expect(second[0].placeId).toBe("9001");
+  });
+
+  it("falls back to search-entry data when a description 404s", async () => {
+    routeByUrl([
+      { match: "search?q=name:Paris", json: parisSearchResponse },
+      { match: "description/100", ok: false, status: 404 },
+      { match: "attributes", ok: false, status: 404 },
+    ]);
+
+    const result = await placeSearch("Paris", "Idaho");
+
+    expect(result).toHaveLength(1);
+    expect(result[0].placeId).toBe("9001");
+    expect(result[0].fullName).toBe("Paris, Bear Lake, Idaho, United States");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// place_search tool — simplified, ID-free output
+// ---------------------------------------------------------------------------
+
+describe("placeSearchTool", () => {
+  it("returns simplified fields with the FamilySearch WIKIPEDIA_LINK and no identifiers", async () => {
+    routeByUrl([
+      { match: "search?q=name:Paris", json: parisSearchResponse },
+      {
+        match: "description/100",
+        json: description("100", "Paris, Bear Lake, Idaho, United States", "9001"),
+      },
+      {
+        match: "attributes",
+        json: attributes("https://en.wikipedia.org/wiki/Paris,_Idaho"),
+      },
+    ]);
+
+    const result = await placeSearchTool({
+      placeName: "Paris",
+      contextName: "Idaho",
+    });
+
+    expect(result.results).toHaveLength(1);
+    expect(result.results[0]).toEqual({
+      fullName: "Paris, Bear Lake, Idaho, United States",
+      type: "City",
+      dateRange: "+1900/",
+      latitude: 1.0,
+      longitude: 2.0,
+      familysearchUrl:
+        "https://www.familysearch.org/en/research/places/?text=Paris&focusedId=100",
+      wikipediaUrl: "https://en.wikipedia.org/wiki/Paris,_Idaho",
+    });
+
+    const keys = Object.keys(result.results[0]);
+    for (const banned of [
+      "placeId",
+      "placeRepId",
+      "score",
+      "name",
+      "parentPlaceRepId",
+      "wikipedia",
+    ]) {
+      expect(keys).not.toContain(banned);
+    }
+  });
+
+  it("omits wikipediaUrl when the place has no WIKIPEDIA_LINK attribute", async () => {
+    routeByUrl([
+      { match: "search?q=name:Paris", json: parisSearchResponse },
+      {
+        match: "description/100",
+        json: description("100", "Paris, Bear Lake, Idaho, United States", "9001"),
+      },
+      { match: "attributes", ok: false, status: 404 },
+    ]);
+
+    const result = await placeSearchTool({
+      placeName: "Paris",
+      contextName: "Idaho",
+    });
+
+    expect(result.results[0].wikipediaUrl).toBeUndefined();
+  });
+
+  it("returns an empty results array when the search has no matches", async () => {
+    routeByUrl([{ match: "search?q=name:", json: { entries: [] } }]);
+
+    const result = await placeSearchTool({ placeName: "NonexistentPlace12345" });
+
+    expect(result).toEqual({ results: [] });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// place_search_all tool — all jurisdictions over time
+// ---------------------------------------------------------------------------
+
+describe("placeSearchAllTool", () => {
+  it("expands each pid to all rep IDs and returns simplified, ID-free results", async () => {
+    routeByUrl([
+      { match: "search?q=name:Paris", json: parisSearchResponse },
+      {
+        match: "description/100",
+        json: description("100", "Paris, Bear Lake, Idaho, United States", "9001"),
+      },
+      {
+        match: "places/9001",
+        json: {
+          places: [
+            { id: "9001" },
+            { id: "100", place: { resourceId: "9001" } },
+            { id: "150", place: { resourceId: "9001" } },
+          ],
+        },
+      },
+      {
+        match: "description/150",
+        json: description("150", "Paris, Oneida, Idaho Territory", "9001"),
+      },
+      { match: "attributes", ok: false, status: 404 },
+    ]);
+
+    const result = await placeSearchAllTool({
+      placeName: "Paris",
+      contextName: "Idaho",
+    });
+
+    expect(result.results.map((r) => r.fullName).sort()).toEqual([
+      "Paris, Bear Lake, Idaho, United States",
+      "Paris, Oneida, Idaho Territory",
+    ]);
+    for (const r of result.results) {
+      expect(Object.keys(r)).not.toContain("placeId");
+      expect(Object.keys(r)).not.toContain("placeRepId");
+    }
+  });
+
+  it("drops rep IDs whose description lookup 404s", async () => {
+    routeByUrl([
+      { match: "search?q=name:Paris", json: parisSearchResponse },
+      {
+        match: "description/100",
+        json: description("100", "Paris, Bear Lake, Idaho, United States", "9001"),
+      },
+      {
+        match: "places/9001",
+        json: {
+          places: [
+            { id: "9001" },
+            { id: "100", place: { resourceId: "9001" } },
+            { id: "150", place: { resourceId: "9001" } },
+          ],
+        },
+      },
+      { match: "description/150", ok: false, status: 404 },
+      { match: "attributes", ok: false, status: 404 },
+    ]);
+
+    const result = await placeSearchAllTool({
+      placeName: "Paris",
+      contextName: "Idaho",
+    });
+
+    expect(result.results.map((r) => r.fullName)).toEqual([
+      "Paris, Bear Lake, Idaho, United States",
+    ]);
   });
 });


### PR DESCRIPTION
Implements the place_search rework and `place_search_all`. The spec landed separately in #247 (squash-merged to main); this PR is the implementation.

## Summary
- `place_search` is now a thin wrapper over an internal `placeSearch(placeName, contextName?)`: disambiguates by a higher-level place (Paris + Idaho vs Paris + France), filters candidates by context (keeps the unfiltered list when nothing matches), describes each rep, and caches by (placeName, contextName).
- New `place_search_all` tool: expands each place to every jurisdiction it has belonged to over time.
- Both tools return an ID-free `SimplifiedPlaceResult` — FamilySearch place IDs / rep IDs are never exposed to the LLM.
- `wikipediaUrl` comes from FamilySearch's curated `WIKIPEDIA_LINK` place attribute (the `ws-ui` place service the research-places website uses), per review in #247 — correct per-place (Paris, Idaho → `…/wiki/Paris,_Idaho`). When a place has no such attribute, or FS is unreachable, `wikipediaUrl` is omitted — never a wrong guess.
- Removed the old name-based Wikipedia lookup (`getWikipediaSummary`) and the now-dead Wikipedia types.

## Reviewer notes
- The `WIKIPEDIA_LINK` attribute lives on the `ws-ui` service, which is slower than the `/platform/places` API and can rate-limit under heavy/bulk access — relevant for `place_search_all`.
- FamilySearch's curated links are occasionally imperfect (e.g. England stores a malformed value); the tool passes FS's value through verbatim rather than "fixing" it.

## Test plan
- [x] `npm run build` clean
- [x] Full suite passes (599 tests, incl. the manifest-drift test)
- [x] Live smoke: `paris idaho` → `…/wiki/Paris,_Idaho`; `paris france` → `fr.wikipedia.org/wiki/Paris`; tool `wikipediaUrl` matched FS's raw `WIKIPEDIA_LINK` for the places sampled; no `placeId`/`placeRepId` in output
- [ ] Live `place_search_all` end-to-end — couldn't get a clean run from the dev box (FamilySearch was throttling the IP after testing traffic); it uses the same verified per-rep call. Best confirmed from a fresh IP / Cowork.