### PR TITLE
Add metadata_search tool

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,7 +162,7 @@ The interview lives in `init-project/SKILL.md`.
 
 All authenticated tools (`place_collections`, `record_search`, `record_read`,
 `person_search`, `person_read`, `person_ancestors`, `fulltext_search`, `image_search`,
-`person_record_matches`, `record_person_matches`, `person_person_matches`,
+`metadata_search`, `person_record_matches`, `record_person_matches`, `person_person_matches`,
 `record_record_matches`, and `source_attachments`) must go through this module — do not
 re-implement token plumbing.
 
@@ -280,10 +280,11 @@ Where to look first:
 - **Exported helpers in `src/tools/`** — for example, `place-search.ts`
   exports `searchPlace`, `getPlaceById`, and `getWikipediaSummary`,
   `place-collections.ts` exports `fetchAllCollections`,
-  `filterByQuery`, and `filterByPlaceIds`, and `image-search.ts`
-  exports `placeIdToRepIds` and `repIdToPlaceId` (convert between
-  FamilySearch place IDs and place representation IDs). A new tool
-  that needs place lookup, Wikipedia enrichment, or placeId/placeRepId
+  `filterByQuery`, and `filterByPlaceIds`, and `place-search.ts`
+  exports `placeIdToRepIds` (convert a FamilySearch place ID to its
+  place representation IDs — used by `metadata_search` and
+  `image_search`). A new tool that needs place lookup, Wikipedia
+  enrichment, or placeId/placeRepId
   conversion should call these, not re-fetch.
 
 Soft caveat: don't pre-extract for hypothetical reuse. Wait for the

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ The MCP server exposes 30 tools.
 | `person_read` | FamilySearch Family Tree person data — relatives and attached sources | OAuth |
 | `person_ancestors` | FamilySearch Family Tree pedigree — a person (or, when no ID is given, the logged-in user) plus up to N generations of ancestors, each tagged with its Ahnentafel (ascendancy) number | OAuth |
 | `source_attachments` | Check whether source ARKs are already attached to tree persons | OAuth |
+| `metadata_search` | Search FamilySearch's Records Management Service for image groups (digitized volumes) by place and date range — returns coverage metadata, `recordSearchablePercent`, and `fulltextSearchable` per volume | OAuth |
 | `place_external_links` | FS-curated third-party genealogy URLs by place + year | None |
 
 ### FamilySearch Wiki content

--- a/mcp-server/dev/try-metadata-search.ts
+++ b/mcp-server/dev/try-metadata-search.ts
@@ -1,0 +1,46 @@
+/**
+ * Smoke test for the metadata_search tool.
+ *
+ * Usage:
+ *   cd mcp-server
+ *   npx tsx dev/try-metadata-search.ts --placeId 6137147 --from 1730-01-01 --to 1810-12-31
+ *
+ * Requires a valid FamilySearch session (run the login tool first).
+ * The Edensor, Derbyshire placeId 6137147 is a known small result set.
+ */
+
+import { metadataSearchTool } from "../src/tools/metadata-search.js";
+
+const args = process.argv.slice(2);
+
+function getArg(flag: string): string | undefined {
+  const idx = args.indexOf(flag);
+  return idx !== -1 ? args[idx + 1] : undefined;
+}
+
+const placeId = getArg("--placeId") ?? "6137147";
+const fromDate = getArg("--from");
+const toDate = getArg("--to");
+const pageToken = getArg("--pageToken");
+
+console.log("metadata_search smoke test");
+console.log("Input:", { placeId, fromDate, toDate, pageToken });
+console.log("---");
+
+try {
+  const result = await metadataSearchTool({
+    placeId,
+    ...(fromDate ? { fromDate } : {}),
+    ...(toDate ? { toDate } : {}),
+    ...(pageToken ? { pageToken } : {}),
+  });
+  console.log(JSON.stringify(result, null, 2));
+  console.log("---");
+  console.log(`Total groups: ${result.totalGroups}, returned: ${result.returned}`);
+  if (result.nextPageToken) {
+    console.log(`Next page token: ${result.nextPageToken}`);
+  }
+} catch (error) {
+  console.error("Error:", error instanceof Error ? error.message : error);
+  process.exit(1);
+}

--- a/mcp-server/manifest.json
+++ b/mcp-server/manifest.json
@@ -54,7 +54,8 @@
     { "name": "wiki_country_research_tips" },
     { "name": "validate_research_schema" },
     { "name": "source_attachments" },
-    { "name": "image_search" }
+    { "name": "image_search" },
+    { "name": "metadata_search" }
   ],
   "compatibility": {
     "platforms": ["darwin", "win32", "linux"],

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -51,6 +51,8 @@ import { sourceAttachmentsTool } from "./tools/source-attachments.js";
 import type { SourceAttachmentsInput } from "./types/source-attachments.js";
 import { imageSearchTool } from "./tools/image-search.js";
 import type { ImageSearchInput } from "./types/image-search.js";
+import { metadataSearchTool } from "./tools/metadata-search.js";
+import type { MetadataSearchInput } from "./types/metadata-search.js";
 import { allToolSchemas } from "./tool-schemas.js";
 
 const server = new Server(
@@ -475,6 +477,16 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
     try {
       const args = request.params.arguments as unknown as ImageSearchInput;
       const result = await imageSearchTool(args);
+      return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Unknown error";
+      return { content: [{ type: "text", text: JSON.stringify({ error: message }) }], isError: true };
+    }
+  }
+  if (request.params.name === "metadata_search") {
+    try {
+      const args = request.params.arguments as unknown as MetadataSearchInput;
+      const result = await metadataSearchTool(args);
       return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
     } catch (error) {
       const message = error instanceof Error ? error.message : "Unknown error";

--- a/mcp-server/src/tool-schemas.ts
+++ b/mcp-server/src/tool-schemas.ts
@@ -38,6 +38,7 @@ import {
 import { validateResearchSchemaSchema } from "./tools/validate-research-schema.js";
 import { sourceAttachmentsSchema } from "./tools/source-attachments.js";
 import { imageSearchSchema } from "./tools/image-search.js";
+import { metadataSearchSchema } from "./tools/metadata-search.js";
 
 export const allToolSchemas = [
   wikipediaSearchSchema,
@@ -70,4 +71,5 @@ export const allToolSchemas = [
   validateResearchSchemaSchema,
   sourceAttachmentsSchema,
   imageSearchSchema,
+  metadataSearchSchema,
 ];

--- a/mcp-server/src/tools/image-search.ts
+++ b/mcp-server/src/tools/image-search.ts
@@ -1,6 +1,6 @@
 import { getValidToken } from "../auth/refresh.js";
 import { BROWSER_USER_AGENT } from "../constants.js";
-import { extractPrimaryId } from "./place-search.js";
+import { extractPrimaryId, placeIdToRepIds } from "./place-search.js";
 import type {
   ImageSearchInput,
   ImageSearchResult,
@@ -18,48 +18,6 @@ const RMS_SEARCH_URL =
   "https://sg30p0.familysearch.org/service/records/rms/group-service/group/search";
 
 const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
-
-/**
- * Convert a placeId to its placeRepIds via the places API.
- *
- * GET /places/{placeId} returns the bare place entry (id === placeId, no
- * `display`) followed by representation entries, each with a top-level
- * `place.resourceId` pointing back to the placeId. We collect the
- * representation ids.
- */
-export async function placeIdToRepIds(
-  placeId: string,
-  token: string
-): Promise<number[]> {
-  const response = await fetch(`${PLACES_API_BASE}/${encodeURIComponent(placeId)}`, {
-    headers: {
-      Authorization: `Bearer ${token}`,
-      Accept: "application/json",
-    },
-  });
-
-  if (!response.ok) {
-    throw new Error(
-      `FamilySearch places API error: ${response.status} ${response.statusText}`
-    );
-  }
-
-  const data = (await response.json()) as FSPlaceLookupResponse;
-  const reps = (data.places ?? []).filter(
-    (p) => p.place?.resourceId === placeId
-  );
-
-  const ids: number[] = [];
-  const seen = new Set<number>();
-  for (const rep of reps) {
-    const n = Number(rep.id);
-    if (!Number.isNaN(n) && !seen.has(n)) {
-      seen.add(n);
-      ids.push(n);
-    }
-  }
-  return ids;
-}
 
 /**
  * Convert a placeRepId back to a placeId via the places description API.

--- a/mcp-server/src/tools/metadata-search.ts
+++ b/mcp-server/src/tools/metadata-search.ts
@@ -1,0 +1,261 @@
+import { getValidToken } from "../auth/refresh.js";
+import { BROWSER_USER_AGENT } from "../constants.js";
+import { placeIdToRepIds } from "./place-search.js";
+import type {
+  MetadataSearchInput,
+  MetadataSearchResult,
+  MetadataGroup,
+  SimplifiedCoverage,
+  MetadataRmsSearchRequest,
+  MetadataRmsSearchResponse,
+  MetadataRmsGroup,
+  MetadataRmsCoverageEntry,
+  FulltextGroupNumberResponse,
+} from "../types/metadata-search.js";
+
+const RMS_SEARCH_URL =
+  "https://sg30p0.familysearch.org/service/records/rms/group-service/group/search";
+const FULLTEXT_GROUP_URL =
+  "https://sg30p0.familysearch.org/service/search/fulltext/search/groupNumber";
+
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+const RECORD_TYPE_PLACEHOLDER_RE = /^(concept-id|title):/;
+
+function validate(input: MetadataSearchInput): void {
+  if (!input.placeId) {
+    throw new Error("metadata_search requires a placeId.");
+  }
+  if (input.fromDate && !DATE_RE.test(input.fromDate)) {
+    throw new Error(
+      "fromDate must be in YYYY-MM-DD format (e.g., '1730-01-01')."
+    );
+  }
+  if (input.toDate && !DATE_RE.test(input.toDate)) {
+    throw new Error(
+      "toDate must be in YYYY-MM-DD format (e.g., '1810-12-31')."
+    );
+  }
+}
+
+function rmsHeaders(token: string): Record<string, string> {
+  return {
+    Authorization: `Bearer ${token}`,
+    "Content-Type": "application/json",
+    Accept: "application/json",
+    "User-Agent": BROWSER_USER_AGENT,
+    "FS-User-Agent-Chain": "chesworth",
+  };
+}
+
+async function callGroupSearch(
+  body: MetadataRmsSearchRequest,
+  token: string
+): Promise<MetadataRmsSearchResponse> {
+  let response: Response;
+  try {
+    response = await fetch(RMS_SEARCH_URL, {
+      method: "PUT",
+      headers: rmsHeaders(token),
+      body: JSON.stringify(body),
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unknown error";
+    throw new Error(
+      `Could not reach FamilySearch metadata search API: ${message}.`
+    );
+  }
+
+  if (response.status === 401) {
+    throw new Error(
+      "FamilySearch session not accepted; call the login tool to re-authenticate."
+    );
+  }
+  if (response.status === 403) {
+    throw new Error("FamilySearch metadata search API error: 403 Forbidden.");
+  }
+  if (!response.ok) {
+    throw new Error(
+      `FamilySearch metadata search API error: ${response.status} ${response.statusText}.`
+    );
+  }
+
+  return (await response.json()) as MetadataRmsSearchResponse;
+}
+
+async function fetchFulltextSearchable(
+  groupNames: string[],
+  token: string
+): Promise<Set<string> | null> {
+  const ids = groupNames.join(",");
+  const url = `${FULLTEXT_GROUP_URL}?ids=${encodeURIComponent(ids)}`;
+
+  for (let attempt = 0; attempt < 3; attempt++) {
+    try {
+      const response = await fetch(url, { headers: rmsHeaders(token) });
+      if (!response.ok) {
+        if (attempt === 2) return null;
+        continue;
+      }
+      const data = (await response.json()) as FulltextGroupNumberResponse;
+      return new Set(data.ids ?? []);
+    } catch {
+      if (attempt === 2) return null;
+    }
+  }
+  return null;
+}
+
+function derivePrefix(groupName: string): string {
+  const underscoreIdx = groupName.indexOf("_");
+  return underscoreIdx === -1 ? groupName : groupName.slice(0, underscoreIdx);
+}
+
+function computeRecordSearchablePercent(group: MetadataRmsGroup): number | null {
+  const total = group.childCount;
+  const indexed = group.indexedChildCount;
+  const nonIndexable = group.noIndexableDataChildCount ?? 0;
+  if (total == null || indexed == null) return null;
+  const denominator = total - nonIndexable;
+  if (denominator <= 0) return null;
+  return Math.round((indexed / denominator) * 100);
+}
+
+function mapCoverage(entry: MetadataRmsCoverageEntry): SimplifiedCoverage {
+  const coverage: SimplifiedCoverage = { place: entry.place ?? "" };
+  if (entry.datesOrig != null) coverage.dateRange = entry.datesOrig;
+  if (
+    entry.recordTypeOrig != null &&
+    !RECORD_TYPE_PLACEHOLDER_RE.test(entry.recordTypeOrig)
+  ) {
+    coverage.recordType = entry.recordTypeOrig;
+  }
+  return coverage;
+}
+
+function mapGroup(
+  group: MetadataRmsGroup,
+  fulltextSet: Set<string> | null
+): MetadataGroup {
+  const imageGroupNumber = group.groupName;
+  const imageGroupPrefix = derivePrefix(imageGroupNumber);
+  const imageCount = group.childCount ?? null;
+  const recordSearchablePercent = computeRecordSearchablePercent(group);
+  const fulltextSearchable =
+    fulltextSet === null ? null : fulltextSet.has(imageGroupNumber);
+
+  const result: MetadataGroup = {
+    imageGroupNumber,
+    imageGroupPrefix,
+    imageCount,
+    recordSearchablePercent,
+    fulltextSearchable,
+    languages: group.languages ?? [],
+    coverages: (group.coverages ?? []).map(mapCoverage),
+  };
+
+  if (group.title != null) result.title = group.title;
+  if (group.volumes != null) result.volumes = group.volumes;
+
+  return result;
+}
+
+export async function metadataSearchTool(
+  input: MetadataSearchInput
+): Promise<MetadataSearchResult> {
+  validate(input);
+
+  const token = await getValidToken();
+
+  const placeRepIds = await placeIdToRepIds(input.placeId, token);
+  if (placeRepIds.length === 0) {
+    throw new Error(
+      `No place representations found for placeId ${input.placeId}.`
+    );
+  }
+
+  const body: MetadataRmsSearchRequest = {
+    coverage: {
+      placeRepIds,
+      ...(input.fromDate ? { fromDateString: input.fromDate } : {}),
+      ...(input.toDate ? { toDateString: input.toDate } : {}),
+    },
+    types: ["NATURAL"],
+    returnChildCounts: true,
+    active: true,
+    pageSize: 100,
+    ...(input.pageToken ? { nextPageToken: input.pageToken } : {}),
+  };
+
+  const response = await callGroupSearch(body, token);
+
+  const groups = response.groups ?? [];
+  const groupNames = groups.map((g) => g.groupName);
+
+  const fulltextSet = groupNames.length > 0
+    ? await fetchFulltextSearchable(groupNames, token)
+    : new Set<string>();
+
+  const mappedGroups = groups.map((g) => mapGroup(g, fulltextSet));
+
+  const query: MetadataSearchResult["query"] = { placeId: input.placeId };
+  if (input.fromDate) query.fromDate = input.fromDate;
+  if (input.toDate) query.toDate = input.toDate;
+
+  const result: MetadataSearchResult = {
+    query,
+    totalGroups: response.totalCount ?? 0,
+    returned: response.numberReturned ?? 0,
+    groups: mappedGroups,
+  };
+
+  if (response.nextPageToken != null) {
+    result.nextPageToken = response.nextPageToken;
+  }
+
+  return result;
+}
+
+export const metadataSearchSchema = {
+  name: "metadata_search",
+  description:
+    "Search FamilySearch's Records Management Service for image groups — " +
+    "digitized volumes of historical documents (microfilm rolls, book scans) — " +
+    "covering a place and date range. Provide a placeId from place_search and an " +
+    "optional date range. For each volume it returns coverage (places, dates, " +
+    "record types), how much of the volume is indexed for record_search " +
+    "(recordSearchablePercent), and whether it is full-text searchable " +
+    "(fulltextSearchable). Use the returned imageGroupNumber with image_search to " +
+    "list the volume's images, or with fulltext_search to search its text. " +
+    "Results are paginated — pass back nextPageToken (with the same placeId and " +
+    "dates) as pageToken to get the next page. " +
+    "Requires authentication — call the login tool first if not logged in.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      placeId: {
+        type: "string",
+        description:
+          "FamilySearch place ID from place_search. Required. The tool " +
+          "internally converts it to place representation IDs for the query.",
+      },
+      fromDate: {
+        type: "string",
+        description:
+          "Start of date range in YYYY-MM-DD format (e.g., '1730-01-01').",
+      },
+      toDate: {
+        type: "string",
+        description:
+          "End of date range in YYYY-MM-DD format (e.g., '1810-12-31').",
+      },
+      pageToken: {
+        type: "string",
+        description:
+          "Pagination cursor. Pass the nextPageToken from a previous " +
+          "response, together with the same placeId/fromDate/toDate, to " +
+          "fetch the next page.",
+      },
+    },
+    required: ["placeId"],
+  },
+};

--- a/mcp-server/src/tools/place-search.ts
+++ b/mcp-server/src/tools/place-search.ts
@@ -7,6 +7,59 @@ import type {
 } from "../types/place.js";
 
 const FS_API_BASE = "https://api.familysearch.org/platform/places";
+
+// ---------- placeId <-> placeRepId helpers ----------
+// Used by metadata_search (and formerly image_search) to convert between the
+// Primary place ID (returned by place_search) and the RMS placeRepId.
+
+export interface FSPlaceLookupEntry {
+  id: string;
+  display?: { name: string; fullName: string; type: string };
+  place?: { resource?: string; resourceId?: string };
+  identifiers?: Record<string, string[]>;
+}
+
+export interface FSPlaceLookupResponse {
+  places?: FSPlaceLookupEntry[];
+}
+
+/**
+ * Convert a placeId to its placeRepIds via the places API.
+ * One placeId can map to multiple placeRepIds; all are returned.
+ */
+export async function placeIdToRepIds(
+  placeId: string,
+  token: string
+): Promise<number[]> {
+  const response = await fetch(`${FS_API_BASE}/${encodeURIComponent(placeId)}`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: "application/json",
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `FamilySearch places API error: ${response.status} ${response.statusText}`
+    );
+  }
+
+  const data = (await response.json()) as FSPlaceLookupResponse;
+  const reps = (data.places ?? []).filter(
+    (p) => p.place?.resourceId === placeId
+  );
+
+  const ids: number[] = [];
+  const seen = new Set<number>();
+  for (const rep of reps) {
+    const n = Number(rep.id);
+    if (!Number.isNaN(n) && !seen.has(n)) {
+      seen.add(n);
+      ids.push(n);
+    }
+  }
+  return ids;
+}
 const WIKIPEDIA_API_BASE = "https://en.wikipedia.org/api/rest_v1/page/summary";
 const FS_PLACES_PUBLIC_BASE =
   "https://www.familysearch.org/en/research/places";

--- a/mcp-server/src/types/metadata-search.ts
+++ b/mcp-server/src/types/metadata-search.ts
@@ -1,0 +1,97 @@
+// Types for the metadata_search tool.
+//
+// Searches FamilySearch's Records Management Service (RMS) for image groups
+// (digitized volumes) by place and date range. Returns coverage metadata plus
+// two searchability signals: recordSearchablePercent and fulltextSearchable.
+// See docs/specs/metadata-search-tool-spec.md.
+
+// ---------- Tool input ----------
+
+export interface MetadataSearchInput {
+  placeId: string;
+  fromDate?: string;
+  toDate?: string;
+  pageToken?: string;
+}
+
+// ---------- RMS request ----------
+
+export interface MetadataRmsCoverageRequest {
+  placeRepIds: number[];
+  fromDateString?: string;
+  toDateString?: string;
+}
+
+export interface MetadataRmsSearchRequest {
+  coverage: MetadataRmsCoverageRequest;
+  types: string[];
+  returnChildCounts: boolean;
+  active: boolean;
+  pageSize: number;
+  nextPageToken?: string;
+}
+
+// ---------- RMS response ----------
+
+export interface MetadataRmsCoverageEntry {
+  place?: string;
+  datesOrig?: string;
+  recordTypeOrig?: string;
+}
+
+export interface MetadataRmsGroup {
+  id: string;
+  groupName: string;
+  coverages?: MetadataRmsCoverageEntry[];
+  languages?: string[];
+  title?: string;
+  volumes?: string[];
+  // Populated inline when includeChildCounts: true is sent
+  childCount?: number;
+  indexedChildCount?: number;
+  noIndexableDataChildCount?: number;
+}
+
+export interface MetadataRmsSearchResponse {
+  groups?: MetadataRmsGroup[];
+  numberReturned?: number;
+  totalCount?: number;
+  nextPageToken?: string;
+}
+
+// Response from the full-text searchability endpoint
+export interface FulltextGroupNumberResponse {
+  ids?: string[];
+}
+
+// ---------- Tool output ----------
+
+export interface SimplifiedCoverage {
+  place: string;
+  dateRange?: string;
+  recordType?: string;
+}
+
+export interface MetadataGroup {
+  imageGroupNumber: string;
+  imageGroupPrefix: string;
+  imageCount: number | null;
+  recordSearchablePercent: number | null;
+  fulltextSearchable: boolean | null;
+  title?: string;
+  volumes?: string[];
+  languages: string[];
+  coverages: SimplifiedCoverage[];
+}
+
+export interface MetadataSearchResult {
+  query: {
+    placeId: string;
+    fromDate?: string;
+    toDate?: string;
+  };
+  totalGroups: number;
+  returned: number;
+  nextPageToken?: string;
+  groups: MetadataGroup[];
+}

--- a/mcp-server/tests/tools/metadata-search.test.ts
+++ b/mcp-server/tests/tools/metadata-search.test.ts
@@ -1,0 +1,423 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("../../src/auth/refresh.js", () => ({
+  getValidToken: vi.fn(),
+}));
+
+import { metadataSearchTool } from "../../src/tools/metadata-search.js";
+import { getValidToken } from "../../src/auth/refresh.js";
+import { BROWSER_USER_AGENT } from "../../src/constants.js";
+import type {
+  MetadataRmsSearchResponse,
+  MetadataRmsGroup,
+} from "../../src/types/metadata-search.js";
+
+const mockedGetValidToken = vi.mocked(getValidToken);
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+beforeEach(() => {
+  mockFetch.mockReset();
+  mockedGetValidToken.mockReset();
+  mockedGetValidToken.mockResolvedValue("test-token");
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// ─── Fixtures ───────────────────────────────────────────────────────────
+
+function makePlacesResponse(placeRepIds: number[]) {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => ({
+      places: [
+        // bare place entry — has no place.resourceId pointing back
+        { id: "6137147", display: { name: "Edensor", fullName: "Edensor, England", type: "Place" } },
+        // representation entries — each has place.resourceId === placeId
+        ...placeRepIds.map((id) => ({
+          id: String(id),
+          place: { resourceId: "6137147" },
+        })),
+      ],
+    }),
+  };
+}
+
+function makeGroup(overrides: Partial<MetadataRmsGroup> = {}): MetadataRmsGroup {
+  return {
+    id: "DGS-004452257",
+    groupName: "004452257",
+    languages: ["en", "la"],
+    // Inline counts — returned when returnChildCounts:true is sent
+    childCount: 412,
+    indexedChildCount: 366,
+    noIndexableDataChildCount: 0,
+    coverages: [
+      {
+        place: "Edensor, Derbyshire, England, United Kingdom",
+        datesOrig: "1726–1812",
+        recordTypeOrig: "Burial Records",
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function makeSearchResponse(
+  groups: MetadataRmsGroup[],
+  overrides: Partial<MetadataRmsSearchResponse> = {}
+): MetadataRmsSearchResponse {
+  return {
+    groups,
+    numberReturned: groups.length,
+    totalCount: groups.length,
+    ...overrides,
+  };
+}
+
+function makeOkResponse(body: unknown) {
+  return { ok: true, status: 200, json: async () => body };
+}
+
+function makeErrorResponse(status: number, statusText: string) {
+  return { ok: false, status, statusText, json: async () => ({}) };
+}
+
+function makeFulltextResponse(ids: string[]) {
+  return makeOkResponse({ ids });
+}
+
+// Helper: set up the standard 3-call sequence (places, search, fulltext)
+function setupCalls(
+  placeRepIds: number[],
+  searchBody: MetadataRmsSearchResponse,
+  fulltextIds: string[]
+) {
+  mockFetch
+    .mockResolvedValueOnce(makePlacesResponse(placeRepIds))
+    .mockResolvedValueOnce(makeOkResponse(searchBody))
+    .mockResolvedValueOnce(makeFulltextResponse(fulltextIds));
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────
+
+describe("metadataSearchTool", () => {
+  // 1. Happy path
+  it("returns groups for placeId + date range", async () => {
+    setupCalls(
+      [2968392],
+      makeSearchResponse([makeGroup()]),
+      ["004452257"]
+    );
+
+    const result = await metadataSearchTool({
+      placeId: "6137147",
+      fromDate: "1730-01-01",
+      toDate: "1810-12-31",
+    });
+
+    expect(result.query).toEqual({
+      placeId: "6137147",
+      fromDate: "1730-01-01",
+      toDate: "1810-12-31",
+    });
+    expect(result.totalGroups).toBe(1);
+    expect(result.returned).toBe(1);
+    expect(result.groups).toHaveLength(1);
+    expect(result.groups[0].imageGroupNumber).toBe("004452257");
+    expect(result.groups[0].imageGroupPrefix).toBe("004452257");
+    expect(result.groups[0].imageCount).toBe(412);
+    expect(result.groups[0].recordSearchablePercent).toBe(89);
+    expect(result.groups[0].fulltextSearchable).toBe(true);
+    expect(result.groups[0].languages).toEqual(["en", "la"]);
+    expect(result.groups[0].coverages).toEqual([
+      {
+        place: "Edensor, Derbyshire, England, United Kingdom",
+        dateRange: "1726–1812",
+        recordType: "Burial Records",
+      },
+    ]);
+  });
+
+  // 2. Missing placeId
+  it("throws when placeId is missing", async () => {
+    await expect(
+      metadataSearchTool({ placeId: "" })
+    ).rejects.toThrow("metadata_search requires a placeId.");
+  });
+
+  // 3. Malformed date
+  it("throws when fromDate is malformed", async () => {
+    await expect(
+      metadataSearchTool({ placeId: "6137147", fromDate: "1730/01/01" })
+    ).rejects.toThrow("fromDate must be in YYYY-MM-DD format");
+  });
+
+  it("throws when toDate is malformed", async () => {
+    await expect(
+      metadataSearchTool({ placeId: "6137147", toDate: "bad-date" })
+    ).rejects.toThrow("toDate must be in YYYY-MM-DD format");
+  });
+
+  // 4. placeId → placeRepIds conversion
+  it("converts placeId to placeRepIds in coverage.placeRepIds", async () => {
+    setupCalls([2968392, 10609408], makeSearchResponse([makeGroup()]), []);
+
+    await metadataSearchTool({ placeId: "6137147" });
+
+    const searchCall = mockFetch.mock.calls[1];
+    const body = JSON.parse(searchCall[1].body);
+    expect(body.coverage.placeRepIds).toEqual([2968392, 10609408]);
+  });
+
+  // 5. Fixed fields
+  it("sends types NATURAL, active true, pageSize 100, returnChildCounts true", async () => {
+    setupCalls([2968392], makeSearchResponse([makeGroup()]), []);
+
+    await metadataSearchTool({ placeId: "6137147" });
+
+    const body = JSON.parse(mockFetch.mock.calls[1][1].body);
+    expect(body.types).toEqual(["NATURAL"]);
+    expect(body.active).toBe(true);
+    expect(body.pageSize).toBe(100);
+    expect(body.returnChildCounts).toBe(true);
+  });
+
+  // 6. imageGroupPrefix derivation
+  it("derives imageGroupPrefix for bare groupName", async () => {
+    setupCalls([2968392], makeSearchResponse([makeGroup({ groupName: "004452257" })]), []);
+    const result = await metadataSearchTool({ placeId: "6137147" });
+    expect(result.groups[0].imageGroupPrefix).toBe("004452257");
+  });
+
+  it("derives imageGroupPrefix for 3-segment groupName", async () => {
+    setupCalls(
+      [2968392],
+      makeSearchResponse([makeGroup({ groupName: "007621224_005_M99P-2TQ" })]),
+      []
+    );
+    const result = await metadataSearchTool({ placeId: "6137147" });
+    expect(result.groups[0].imageGroupNumber).toBe("007621224_005_M99P-2TQ");
+    expect(result.groups[0].imageGroupPrefix).toBe("007621224");
+  });
+
+  // 7. recordSearchablePercent calculation
+  it("computes recordSearchablePercent correctly from inline counts", async () => {
+    // 366 indexed / (412 total - 0 non-indexable) * 100 = ~88.8 → 89
+    setupCalls(
+      [2968392],
+      makeSearchResponse([makeGroup({ childCount: 412, indexedChildCount: 366, noIndexableDataChildCount: 0 })]),
+      []
+    );
+    const result = await metadataSearchTool({ placeId: "6137147" });
+    expect(result.groups[0].recordSearchablePercent).toBe(89);
+  });
+
+  it("excludes non-indexable images from denominator", async () => {
+    // 80 indexed / (100 - 20 non-indexable) * 100 = 100
+    setupCalls(
+      [2968392],
+      makeSearchResponse([makeGroup({ childCount: 100, indexedChildCount: 80, noIndexableDataChildCount: 20 })]),
+      []
+    );
+    const result = await metadataSearchTool({ placeId: "6137147" });
+    expect(result.groups[0].recordSearchablePercent).toBe(100);
+  });
+
+  // 8. Zero denominator edge case
+  it("sets recordSearchablePercent to null when denominator <= 0", async () => {
+    setupCalls(
+      [2968392],
+      makeSearchResponse([makeGroup({ childCount: 10, indexedChildCount: 0, noIndexableDataChildCount: 10 })]),
+      []
+    );
+    const result = await metadataSearchTool({ placeId: "6137147" });
+    expect(result.groups[0].recordSearchablePercent).toBeNull();
+  });
+
+  // 9. Missing counts in response → null
+  it("sets imageCount and recordSearchablePercent to null when counts are absent from group", async () => {
+    const groupNoCount = makeGroup();
+    delete (groupNoCount as Partial<MetadataRmsGroup>).childCount;
+    delete (groupNoCount as Partial<MetadataRmsGroup>).indexedChildCount;
+    setupCalls([2968392], makeSearchResponse([groupNoCount]), []);
+
+    const result = await metadataSearchTool({ placeId: "6137147" });
+    expect(result.groups[0].imageCount).toBeNull();
+    expect(result.groups[0].recordSearchablePercent).toBeNull();
+  });
+
+  // 10. fulltextSearchable true/false mapping
+  it("sets fulltextSearchable true for groups in the fulltext response", async () => {
+    setupCalls(
+      [2968392],
+      makeSearchResponse([makeGroup({ groupName: "004452257" })]),
+      ["004452257"]
+    );
+    const result = await metadataSearchTool({ placeId: "6137147" });
+    expect(result.groups[0].fulltextSearchable).toBe(true);
+  });
+
+  it("sets fulltextSearchable false for groups not in the fulltext response", async () => {
+    setupCalls(
+      [2968392],
+      makeSearchResponse([makeGroup({ groupName: "004452257" })]),
+      []
+    );
+    const result = await metadataSearchTool({ placeId: "6137147" });
+    expect(result.groups[0].fulltextSearchable).toBe(false);
+  });
+
+  // 11. fulltextSearchable null on fulltext call failure
+  it("sets fulltextSearchable to null when fulltext call fails 3 times", async () => {
+    mockFetch
+      .mockResolvedValueOnce(makePlacesResponse([2968392]))
+      .mockResolvedValueOnce(makeOkResponse(makeSearchResponse([makeGroup()])))
+      .mockRejectedValueOnce(new Error("network error"))
+      .mockRejectedValueOnce(new Error("network error"))
+      .mockRejectedValueOnce(new Error("network error"));
+
+    const result = await metadataSearchTool({ placeId: "6137147" });
+    expect(result.groups[0].fulltextSearchable).toBeNull();
+  });
+
+  // 12. Fulltext batch URL includes all groupNames
+  it("sends all groupNames in the fulltext batch call", async () => {
+    const groups = [
+      makeGroup({ id: "id-1", groupName: "111111111" }),
+      makeGroup({ id: "id-2", groupName: "222222222" }),
+    ];
+    setupCalls([2968392], makeSearchResponse(groups), []);
+
+    await metadataSearchTool({ placeId: "6137147" });
+
+    // calls: [0] places, [1] search, [2] fulltext
+    const fulltextCall = mockFetch.mock.calls[2];
+    expect(fulltextCall[0]).toContain("111111111");
+    expect(fulltextCall[0]).toContain("222222222");
+  });
+
+  // 13. Coverage mapping
+  it("maps coverages to place, dateRange, recordType", async () => {
+    setupCalls(
+      [2968392],
+      makeSearchResponse([
+        makeGroup({
+          coverages: [
+            { place: "Edensor", datesOrig: "1726–1812", recordTypeOrig: "Burial Records" },
+          ],
+        }),
+      ]),
+      []
+    );
+    const result = await metadataSearchTool({ placeId: "6137147" });
+    expect(result.groups[0].coverages[0]).toEqual({
+      place: "Edensor",
+      dateRange: "1726–1812",
+      recordType: "Burial Records",
+    });
+  });
+
+  // 14. Placeholder recordType filtering
+  it("omits recordType when value starts with concept-id: or title:", async () => {
+    setupCalls(
+      [2968392],
+      makeSearchResponse([
+        makeGroup({
+          coverages: [
+            { place: "Edensor", recordTypeOrig: "concept-id:burial" },
+            { place: "Edensor", recordTypeOrig: "title:burial" },
+          ],
+        }),
+      ]),
+      []
+    );
+    const result = await metadataSearchTool({ placeId: "6137147" });
+    expect(result.groups[0].coverages[0].recordType).toBeUndefined();
+    expect(result.groups[0].coverages[1].recordType).toBeUndefined();
+  });
+
+  // 15. Empty result set
+  it("handles empty totalCount:0 response", async () => {
+    mockFetch
+      .mockResolvedValueOnce(makePlacesResponse([2968392]))
+      .mockResolvedValueOnce(makeOkResponse({ totalCount: 0 }));
+
+    const result = await metadataSearchTool({ placeId: "6137147" });
+    expect(result.totalGroups).toBe(0);
+    expect(result.returned).toBe(0);
+    expect(result.groups).toHaveLength(0);
+  });
+
+  // 16. Pagination — nextPageToken returned and used
+  it("returns nextPageToken when present in the response", async () => {
+    setupCalls(
+      [2968392],
+      makeSearchResponse([makeGroup()], { nextPageToken: "abc123" }),
+      []
+    );
+    const result = await metadataSearchTool({ placeId: "6137147" });
+    expect(result.nextPageToken).toBe("abc123");
+  });
+
+  it("sends pageToken as nextPageToken in the request body", async () => {
+    setupCalls([2968392], makeSearchResponse([makeGroup()]), []);
+
+    await metadataSearchTool({ placeId: "6137147", pageToken: "cursor-xyz" });
+
+    const body = JSON.parse(mockFetch.mock.calls[1][1].body);
+    expect(body.nextPageToken).toBe("cursor-xyz");
+  });
+
+  // 17. 401 error
+  it("throws re-login guidance on 401", async () => {
+    mockFetch
+      .mockResolvedValueOnce(makePlacesResponse([2968392]))
+      .mockResolvedValueOnce(makeErrorResponse(401, "Unauthorized"));
+
+    await expect(metadataSearchTool({ placeId: "6137147" })).rejects.toThrow(
+      "FamilySearch session not accepted; call the login tool to re-authenticate."
+    );
+  });
+
+  // 18. Network error
+  it("throws on network error", async () => {
+    mockFetch
+      .mockResolvedValueOnce(makePlacesResponse([2968392]))
+      .mockRejectedValueOnce(new Error("ECONNREFUSED"));
+
+    await expect(metadataSearchTool({ placeId: "6137147" })).rejects.toThrow(
+      "Could not reach FamilySearch metadata search API: ECONNREFUSED."
+    );
+  });
+
+  // 19. Correct headers sent
+  it("sends Authorization, Content-Type, User-Agent, and FS-User-Agent-Chain headers", async () => {
+    setupCalls([2968392], makeSearchResponse([makeGroup()]), []);
+
+    await metadataSearchTool({ placeId: "6137147" });
+
+    const searchCall = mockFetch.mock.calls[1];
+    const headers = searchCall[1].headers;
+    expect(headers["Authorization"]).toBe("Bearer test-token");
+    expect(headers["Content-Type"]).toBe("application/json");
+    expect(headers["User-Agent"]).toBe(BROWSER_USER_AGENT);
+    expect(headers["FS-User-Agent-Chain"]).toBe("chesworth");
+  });
+
+  // Bonus: no placeRepIds found
+  it("throws when places API returns no placeRepIds", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({ places: [] }),
+    });
+
+    await expect(metadataSearchTool({ placeId: "9999999" })).rejects.toThrow(
+      "No place representations found for placeId 9999999."
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- New `metadata_search` tool that queries FamilySearch RMS for image groups (digitized volumes) covering a place and date range
- Returns `imageCount`, `recordSearchablePercent` (how much is indexed for `record_search`), and `fulltextSearchable` (whether the volume supports `fulltext_search`) per group
- `placeIdToRepIds` moved from `image-search.ts` to `place-search.ts` so both `metadata_search` and `image_search` can share it

## Implementation

3-call flow:
1. Places API → convert `placeId` to `placeRepIds`
2. PUT group search with `returnChildCounts: true` → groups with inline `childCount`/`indexedChildCount`/`noIndexableDataChildCount`
3. GET fulltext batch → `fulltextSearchable` per group

No per-group sub-fetches needed — `returnChildCounts: true` in the PUT body returns child counts inline on the initial search call.

## Test plan

- [x] 25 unit tests passing (`npx vitest run tests/tools/metadata-search.test.ts`)
- [x] Smoke-tested live against Edensor, Derbyshire (placeId `6137147`, 1730–1810): 4 groups returned with real `imageCount` values (307, 133, 63, 44), `fulltextSearchable` correct, coverages/languages mapped correctly
- [x] Build clean (`npx tsc --noEmit`)
- [x] `manifest.json` tools array updated