### PR TITLE
image_read: accept only an imageId, drop the URL input

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ The MCP server exposes 30 tools.
 | `wikipedia_search` | Wikipedia article summary lookup | None |
 | `place_population` | Historical population data + indexed record counts | None |
 | `place_distance` | Distance between two FamilySearch places | None |
-| `image_read` | Read a FamilySearch image by URL and return bytes + metadata | OAuth |
+| `image_read` | Read a FamilySearch image by imageId (NUMBER_NUMBER) and return bytes + metadata | OAuth |
 | `validate_research_schema` | Validate research.json and tree.gedcomx.json against published schemas | None |
 
 ### Auth (FamilySearch OAuth 2.0 + PKCE)

--- a/docs/specs/image-read-spec.md
+++ b/docs/specs/image-read-spec.md
@@ -2,31 +2,33 @@
 
 ## What it does
 
-Fetches a FamilySearch distribution image (≥200 DPI) by URL and returns
-the image data so Claude can display it or pass it to OCR models.
-Requires FamilySearch authentication.
+Fetches a FamilySearch distribution image (≥200 DPI) by imageId and
+returns the image data so Claude can display it or pass it to OCR
+models. Requires FamilySearch authentication.
 
 ## Input
 
 ```typescript
 {
-  url: string   // A FamilySearch image URL in one of the two supported formats
+  imageId: string   // An Image Group Number of the form NUMBER_NUMBER
 }
 ```
 
-### Supported URL formats
+### imageId format
 
-**ARK format** (DeepZoom cloud endpoint):
+An `imageId` is an Image Group Number of the form `NUMBER_NUMBER` — an
+image group number, an underscore, and an image sequence number (e.g.
+`004884748_02613`). It matches `/^\d+_\d+$/`. An `imageId` returned by
+`image_search` feeds this tool directly.
+
+The tool builds the distribution-image URL internally:
+
 ```
-https://sg30p0.familysearch.org/service/records/storage/deepzoomcloud/dz/v1/{ARK_ID}/$dist
+https://familysearch.org/das/v2/dgs:{imageId}/dist.jpg
 ```
 
-**DGS format** (direct JPEG endpoint):
-```
-https://familysearch.org/das/v2/dgs:{DGS_NUMBER}_{IMAGE_NUMBER}/dist.jpg
-```
-
-Both formats require a valid FamilySearch bearer token.
+The caller never constructs the URL. Fetching requires a valid
+FamilySearch bearer token.
 
 ## Output
 
@@ -39,7 +41,7 @@ The tool returns two content blocks:
 
 ```typescript
 {
-  url: string         // The URL that was fetched
+  url: string         // The distribution URL that was built and fetched
   mimeType: string    // e.g. "image/jpeg"
   sizeBytes: number   // Size of the image in bytes
 }
@@ -50,7 +52,7 @@ The tool returns two content blocks:
 | Condition | Message |
 |-----------|---------|
 | Not logged in | "Not authenticated. Call the login tool first." |
-| Invalid URL format | "Unrecognized FamilySearch image URL. Expected an ARK or DGS URL." |
+| Invalid imageId format | "Unrecognized imageId. Expected an Image Group Number of the form NUMBER_NUMBER (e.g. 004884748_02613)." |
 | FamilySearch returns non-2xx | "FamilySearch image fetch failed: {status} {statusText}" |
 | Response is not an image | "Expected an image response but got content-type: {type}" |
 
@@ -62,7 +64,7 @@ Uses `getValidToken()` from `src/auth/refresh.ts`. Passes the token as
 ## What NOT to return
 
 - Do not return the preservation image — those are multi-gigabyte TIFFs.
-  The `/$dist` suffix and `dist.jpg` path are the distribution copies.
+  The `dist.jpg` path is the distribution copy.
 - Do not cache images — they are per-user and potentially large.
 
 ## Downstream use

--- a/mcp-server/dev/try-image-read.ts
+++ b/mcp-server/dev/try-image-read.ts
@@ -2,18 +2,18 @@
  * Smoke test for the image_read tool.
  *
  * Usage:
- *   npx tsx dev/try-image-read.ts "<image-url>"
+ *   npx tsx dev/try-image-read.ts "<imageId>"   # e.g. 004884748_02613
  */
 
 import { imageReadTool } from "../src/tools/image-read.js";
 
-const url = process.argv[2];
-if (!url) {
-  console.error("Usage: npx tsx dev/try-image-read.ts <image-url>");
+const imageId = process.argv[2];
+if (!imageId) {
+  console.error("Usage: npx tsx dev/try-image-read.ts <imageId>");
   process.exit(1);
 }
 
-const result = await imageReadTool({ url });
+const result = await imageReadTool({ imageId });
 
 // Print metadata only — printing base64 would flood the terminal
 console.log("Metadata:", JSON.stringify(result.metadata, null, 2));

--- a/mcp-server/src/tools/image-read.ts
+++ b/mcp-server/src/tools/image-read.ts
@@ -1,13 +1,13 @@
 import { getValidToken } from "../auth/refresh.js";
 import { BROWSER_USER_AGENT } from "../constants.js";
 
-const ARK_PATTERN =
-  /^https:\/\/sg30p0\.familysearch\.org\/.+\/\$dist$/;
-const DGS_PATTERN =
-  /^https:\/\/(www\.)?familysearch\.org\/das\/v2\/dgs:[^/]+\/dist\.jpg$/;
+// An imageId is a digitized-image identifier of the form NUMBER_NUMBER
+// (an image group number, an underscore, and an image sequence number,
+// e.g. "004884748_02613").
+const IMAGE_ID_PATTERN = /^\d+_\d+$/;
 
 export interface ImageReadInput {
-  url: string;
+  imageId: string;
 }
 
 export interface ImageReadResult {
@@ -16,24 +16,25 @@ export interface ImageReadResult {
   sizeBytes: number;
 }
 
-function validateUrl(url: string): void {
-  if (!ARK_PATTERN.test(url) && !DGS_PATTERN.test(url)) {
+function imageIdToUrl(imageId: string): string {
+  if (!IMAGE_ID_PATTERN.test(imageId)) {
     throw new Error(
-      "Unrecognized FamilySearch image URL. Expected an ARK URL " +
-        "(ending in /$dist) or an Image Group Number URL (dgs:NUMBER_NUMBER/dist.jpg)."
+      "Unrecognized imageId. Expected an Image Group Number of the form " +
+        "NUMBER_NUMBER (e.g. 004884748_02613)."
     );
   }
+  return `https://familysearch.org/das/v2/dgs:${imageId}/dist.jpg`;
 }
 
 export async function imageReadTool(input: ImageReadInput): Promise<{
   imageData: string;
   metadata: ImageReadResult;
 }> {
-  validateUrl(input.url);
+  const url = imageIdToUrl(input.imageId);
 
   const token = await getValidToken();
 
-  const response = await fetch(input.url, {
+  const response = await fetch(url, {
     headers: {
       Authorization: `Bearer ${token}`,
       Accept: "image/*,*/*",
@@ -67,7 +68,7 @@ export async function imageReadTool(input: ImageReadInput): Promise<{
   return {
     imageData,
     metadata: {
-      url: input.url,
+      url,
       mimeType: contentType.split(";")[0].trim(),
       sizeBytes: buffer.byteLength,
     },
@@ -77,20 +78,21 @@ export async function imageReadTool(input: ImageReadInput): Promise<{
 export const imageReadToolSchema = {
   name: "image_read",
   description:
-    "Fetch a FamilySearch distribution image by URL and return it as image data. " +
-    "Accepts ARK URLs (ending in /$dist) or Image Group Number URLs (dgs:NUMBER_NUMBER/dist.jpg). " +
+    "Fetch a FamilySearch distribution image by imageId and return it as image data. " +
+    "Takes an Image Group Number of the form NUMBER_NUMBER (e.g. 004884748_02613), " +
+    "such as an imageId returned by image_search, and builds the distribution URL internally. " +
     "Requires authentication — call the login tool first if not logged in.",
   inputSchema: {
     type: "object",
     properties: {
-      url: {
+      imageId: {
         type: "string",
         description:
-          "FamilySearch image URL. Two formats supported:\n" +
-          "ARK: https://sg30p0.familysearch.org/service/records/storage/deepzoomcloud/dz/v1/{ARK_ID}/$dist\n" +
-          "Image Group Number: https://familysearch.org/das/v2/dgs:{IMAGE_GROUP_NUMBER}_{IMAGE}/dist.jpg",
+          "FamilySearch Image Group Number of the form NUMBER_NUMBER " +
+          "(an image group number, an underscore, and an image sequence " +
+          "number), e.g. 004884748_02613. Feed an imageId from image_search directly.",
       },
     },
-    required: ["url"],
+    required: ["imageId"],
   },
 };

--- a/mcp-server/tests/tools/image-read.test.ts
+++ b/mcp-server/tests/tools/image-read.test.ts
@@ -12,6 +12,20 @@ const mockedGetValidToken = vi.mocked(getValidToken);
 const mockFetch = vi.fn();
 vi.stubGlobal("fetch", mockFetch);
 
+function mockImageResponse() {
+  const pixel = new Uint8Array([0xff, 0xd8, 0xff, 0xd9]);
+  mockFetch.mockResolvedValueOnce({
+    ok: true,
+    status: 200,
+    statusText: "OK",
+    headers: {
+      get: (name: string) =>
+        name.toLowerCase() === "content-type" ? "image/jpeg" : null,
+    },
+    arrayBuffer: async () => pixel.buffer,
+  });
+}
+
 beforeEach(() => {
   mockFetch.mockReset();
   mockedGetValidToken.mockReset();
@@ -22,27 +36,51 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
-describe("imageReadTool — User-Agent contract", () => {
-  it("sends the shared BROWSER_USER_AGENT header", async () => {
-    const pixel = new Uint8Array([0xff, 0xd8, 0xff, 0xd9]);
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      status: 200,
-      statusText: "OK",
-      headers: {
-        get: (name: string) =>
-          name.toLowerCase() === "content-type" ? "image/jpeg" : null,
-      },
-      arrayBuffer: async () => pixel.buffer,
-    });
+describe("imageReadTool — imageId input", () => {
+  it("builds the DGS URL from imageId and fetches it", async () => {
+    mockImageResponse();
 
-    await imageReadTool({
-      url: "https://sg30p0.familysearch.org/service/records/storage/deepzoomcloud/dz/v1/abc/$dist",
-    });
+    const result = await imageReadTool({ imageId: "004884748_02613" });
 
     expect(mockFetch).toHaveBeenCalledTimes(1);
+    const [url] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe(
+      "https://familysearch.org/das/v2/dgs:004884748_02613/dist.jpg"
+    );
+    expect(result.metadata.url).toBe(
+      "https://familysearch.org/das/v2/dgs:004884748_02613/dist.jpg"
+    );
+    expect(result.metadata.mimeType).toBe("image/jpeg");
+  });
+
+  it("sends the shared BROWSER_USER_AGENT header", async () => {
+    mockImageResponse();
+
+    await imageReadTool({ imageId: "004884748_02613" });
+
     const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
     const headers = init.headers as Record<string, string>;
     expect(headers["User-Agent"]).toBe(BROWSER_USER_AGENT);
+  });
+
+  it.each([
+    ["abc", "non-numeric"],
+    ["123", "missing underscore"],
+    ["123_", "missing second number"],
+    ["_456", "missing first number"],
+    ["123_456_789", "extra segment"],
+    [
+      "https://familysearch.org/das/v2/dgs:004884748_02613/dist.jpg",
+      "a full URL",
+    ],
+    [
+      "https://sg30p0.familysearch.org/service/records/storage/deepzoomcloud/dz/v1/abc/$dist",
+      "an ARK URL",
+    ],
+  ])("rejects %j (%s) without fetching", async (imageId) => {
+    await expect(imageReadTool({ imageId })).rejects.toThrow(
+      /Unrecognized.*imageId/i
+    );
+    expect(mockFetch).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Closes #259

## Summary

`image_read` now takes a single `imageId` of the form NUMBER_NUMBER (e.g. 004884748_02613) and builds the distribution URL internally:
`https://familysearch.org/das/v2/dgs:{imageId}/dist.jpg`. The previous `url` input (ARK `…/$dist` or full DGS `dist.jpg`) is removed.

## Changes
- `mcp-server/src/tools/image-read.ts` — `ImageReadInput { imageId }`; dropped ARK/DGS URL patterns; added `IMAGE_ID_PATTERN = /^\d+_\d+$/`; `imageIdToUrl()` validates + builds the DGS URL; schema/description updated.
- `mcp-server/tests/tools/image-read.test.ts` — URL construction, BROWSER_USER_AGENT header, 7 rejection cases that never call fetch.
- `mcp-server/dev/try-image-read.ts` — takes an `imageId` arg.
- `docs/specs/image-read-spec.md`, `README.md` — updated to the imageId contract.

## Verification
- `npx vitest run` — 611/611 pass.
- `npx tsc --noEmit` — clean.