### PR TITLE
Rewrite image_search to return imageIds for an imageGroupNumber (#261)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -278,13 +278,14 @@ Where to look first:
   string — `place_collections`, `record_search`, `place_external_links`,
   `image_read`, `image_search`, `record_read`, and `fulltext_search` already do.
 - **Exported helpers in `src/tools/`** — for example, `place-search.ts`
-  exports `searchPlace`, `getPlaceById`, and `getWikipediaSummary`,
+  exports `searchPlace`, `getPlaceById`, `getWikipediaSummary`, and
+  `placeIdToRepIds` (converts a FamilySearch place ID to its place
+  representation IDs — use this for any tool that needs the placeId →
+  placeRepIds conversion, rather than re-fetching), and
   `place-collections.ts` exports `fetchAllCollections`,
-  `filterByQuery`, and `filterByPlaceIds`, and `image-search.ts`
-  exports `placeIdToRepIds` and `repIdToPlaceId` (convert between
-  FamilySearch place IDs and place representation IDs). A new tool
-  that needs place lookup, Wikipedia enrichment, or placeId/placeRepId
-  conversion should call these, not re-fetch.
+  `filterByQuery`, and `filterByPlaceIds`. A new tool that needs place
+  lookup, Wikipedia enrichment, or placeId/placeRepId conversion should
+  call these, not re-fetch.
 
 Soft caveat: don't pre-extract for hypothetical reuse. Wait for the
 second concrete need before factoring code into a shared module —

--- a/mcp-server/dev/try-image-search.ts
+++ b/mcp-server/dev/try-image-search.ts
@@ -1,34 +1,24 @@
 /**
- * Smoke-test the image_search tool against the live FS RMS API.
+ * Smoke-test the image_search tool against the live FS API.
  *
  * Usage:
- *   npx tsx dev/try-image-search.ts --placeId 6137147 --from 1730-01-01 --to 1810-12-31
- *   npx tsx dev/try-image-search.ts --imageGroupNumber "007621224"
+ *   cd mcp-server
+ *   npx tsx dev/try-image-search.ts 007621224_005_M99P-2TQ   # split form
+ *   npx tsx dev/try-image-search.ts 007621224                # bare form (apid path)
  */
 import { imageSearchTool } from "../src/tools/image-search.js";
 
-function flag(name: string): string | undefined {
-  const i = process.argv.indexOf(name);
-  return i >= 0 ? process.argv[i + 1] : undefined;
-}
-
-const placeId = flag("--placeId");
-const fromDate = flag("--from");
-const toDate = flag("--to");
-const imageGroupNumber = flag("--imageGroupNumber");
-
-if (!placeId && !imageGroupNumber) {
+const imageGroupNumber = process.argv[2];
+if (!imageGroupNumber) {
+  console.error("Usage: npx tsx dev/try-image-search.ts <imageGroupNumber>");
   console.error(
-    "Usage: npx tsx dev/try-image-search.ts --placeId <id> [--from YYYY-MM-DD] [--to YYYY-MM-DD]"
+    "  Split form: npx tsx dev/try-image-search.ts 007621224_005_M99P-2TQ"
   );
-  console.error('   or: npx tsx dev/try-image-search.ts --imageGroupNumber "007621224"');
+  console.error(
+    "  Bare form:  npx tsx dev/try-image-search.ts 007621224"
+  );
   process.exit(1);
 }
 
-const result = await imageSearchTool({
-  ...(placeId ? { placeId } : {}),
-  ...(fromDate ? { fromDate } : {}),
-  ...(toDate ? { toDate } : {}),
-  ...(imageGroupNumber ? { imageGroupNumber } : {}),
-});
+const result = await imageSearchTool({ imageGroupNumber });
 console.log(JSON.stringify(result, null, 2));

--- a/mcp-server/src/tools/image-search.ts
+++ b/mcp-server/src/tools/image-search.ts
@@ -1,173 +1,66 @@
 import { getValidToken } from "../auth/refresh.js";
 import { BROWSER_USER_AGENT } from "../constants.js";
-import { extractPrimaryId } from "./place-search.js";
 import type {
   ImageSearchInput,
   ImageSearchResult,
-  ImageGroup,
-  SimplifiedCoverage,
-  FSPlaceLookupResponse,
-  RmsSearchRequest,
-  RmsSearchResponse,
-  RmsGroup,
-  RmsCoverageEntry,
+  ChildrenNamesResponse,
 } from "../types/image-search.js";
 
-const PLACES_API_BASE = "https://api.familysearch.org/platform/places";
-const RMS_SEARCH_URL =
-  "https://sg30p0.familysearch.org/service/records/rms/group-service/group/search";
+const GROUP_SERVICE_BASE =
+  "https://sg30p0.familysearch.org/service/records/rms/group-service";
+const ARTIFACT_BASE =
+  "https://sg30p0.familysearch.org/service/records/rms";
 
-const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
-
-/**
- * Convert a placeId to its placeRepIds via the places API.
- *
- * GET /places/{placeId} returns the bare place entry (id === placeId, no
- * `display`) followed by representation entries, each with a top-level
- * `place.resourceId` pointing back to the placeId. We collect the
- * representation ids.
- */
-export async function placeIdToRepIds(
-  placeId: string,
-  token: string
-): Promise<number[]> {
-  const response = await fetch(`${PLACES_API_BASE}/${encodeURIComponent(placeId)}`, {
-    headers: {
-      Authorization: `Bearer ${token}`,
-      Accept: "application/json",
-    },
-  });
-
-  if (!response.ok) {
-    throw new Error(
-      `FamilySearch places API error: ${response.status} ${response.statusText}`
-    );
-  }
-
-  const data = (await response.json()) as FSPlaceLookupResponse;
-  const reps = (data.places ?? []).filter(
-    (p) => p.place?.resourceId === placeId
-  );
-
-  const ids: number[] = [];
-  const seen = new Set<number>();
-  for (const rep of reps) {
-    const n = Number(rep.id);
-    if (!Number.isNaN(n) && !seen.has(n)) {
-      seen.add(n);
-      ids.push(n);
-    }
-  }
-  return ids;
-}
-
-/**
- * Convert a placeRepId back to a placeId via the places description API.
- *
- * GET /places/description/{placeRepId} returns the representation with its
- * `Primary` identifier, whose last path segment is the placeId. Returns null
- * if the placeId cannot be resolved.
- */
-export async function repIdToPlaceId(
-  placeRepId: number,
-  token: string
-): Promise<string | null> {
-  const response = await fetch(
-    `${PLACES_API_BASE}/description/${placeRepId}`,
-    {
-      headers: {
-        Authorization: `Bearer ${token}`,
-        Accept: "application/json",
-      },
-    }
-  );
-
-  if (!response.ok) {
-    return null;
-  }
-
-  const data = (await response.json()) as FSPlaceLookupResponse;
-  const entry =
-    data.places?.find(
-      (p) => p.identifiers?.["http://gedcomx.org/Primary"] != null
-    ) ?? data.places?.find((p) => p.display != null);
-
-  return extractPrimaryId(entry?.identifiers) ?? null;
-}
-
-function validate(input: ImageSearchInput): void {
-  const { placeId, imageGroupNumber, fromDate, toDate } = input;
-
-  if (!placeId && !imageGroupNumber) {
-    throw new Error(
-      "image_search requires either placeId or imageGroupNumber."
-    );
-  }
-  if (placeId && imageGroupNumber) {
-    throw new Error("Provide either placeId or imageGroupNumber, not both.");
-  }
-  if ((fromDate || toDate) && !placeId) {
-    throw new Error("fromDate and toDate require placeId.");
-  }
-  if (fromDate && !DATE_RE.test(fromDate)) {
-    throw new Error(
-      "fromDate must be in YYYY-MM-DD format (e.g., '1730-01-01')."
-    );
-  }
-  if (toDate && !DATE_RE.test(toDate)) {
-    throw new Error(
-      "toDate must be in YYYY-MM-DD format (e.g., '1810-12-31')."
-    );
-  }
-}
-
-async function buildRequestBody(
-  input: ImageSearchInput,
-  token: string
-): Promise<RmsSearchRequest> {
-  const base = {
-    types: ["NATURAL"],
-    returnChildCounts: false,
-    active: true,
-  };
-
-  if (input.imageGroupNumber) {
-    return { ...base, name: `${input.imageGroupNumber}*` };
-  }
-
-  const placeRepIds = await placeIdToRepIds(input.placeId!, token);
-  if (placeRepIds.length === 0) {
-    throw new Error(
-      `No place representations found for placeId ${input.placeId}.`
-    );
-  }
-
+function headers(token: string): Record<string, string> {
   return {
-    ...base,
-    coverage: {
-      placeRepIds,
-      ...(input.fromDate ? { fromDateString: input.fromDate } : {}),
-      ...(input.toDate ? { toDateString: input.toDate } : {}),
-    },
+    Authorization: `Bearer ${token}`,
+    Accept: "application/json",
+    "User-Agent": BROWSER_USER_AGENT,
+    "FS-User-Agent-Chain": "chesworth",
   };
 }
 
-async function callRms(
-  body: RmsSearchRequest,
+async function resolveGroupId(
+  imageGroupNumber: string,
   token: string
-): Promise<RmsSearchResponse> {
+): Promise<string> {
+  if (imageGroupNumber.includes("_")) {
+    const parts = imageGroupNumber.split("_");
+    return parts[parts.length - 1];
+  }
+
   let response: Response;
   try {
-    response = await fetch(RMS_SEARCH_URL, {
-      method: "PUT",
-      headers: {
-        Authorization: `Bearer ${token}`,
-        "Content-Type": "application/json",
-        "User-Agent": BROWSER_USER_AGENT,
-        "FS-User-Agent-Chain": "chesworth",
-      },
-      body: JSON.stringify(body),
-    });
+    response = await fetch(
+      `${GROUP_SERVICE_BASE}/group/${encodeURIComponent(imageGroupNumber)}/apid`,
+      { headers: headers(token) }
+    );
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unknown error";
+    throw new Error(
+      `Could not reach FamilySearch image search API: ${message}.`
+    );
+  }
+
+  if (!response.ok) {
+    throw new Error(
+      `Could not resolve image group number ${imageGroupNumber} to an image group.`
+    );
+  }
+
+  return (await response.text()).trim();
+}
+
+async function fetchChildren(
+  groupId: string,
+  token: string
+): Promise<ChildrenNamesResponse> {
+  let response: Response;
+  try {
+    response = await fetch(
+      `${ARTIFACT_BASE}/artifact/group/${encodeURIComponent(groupId)}/children/names`,
+      { headers: headers(token) }
+    );
   } catch (error) {
     const message = error instanceof Error ? error.message : "Unknown error";
     throw new Error(
@@ -189,123 +82,44 @@ async function callRms(
     );
   }
 
-  return (await response.json()) as RmsSearchResponse;
-}
-
-async function mapCoverage(
-  coverage: RmsCoverageEntry,
-  token: string,
-  cache: Map<number, string | null>
-): Promise<SimplifiedCoverage> {
-  let placeId = "";
-  if (coverage.placeRepId != null) {
-    if (!cache.has(coverage.placeRepId)) {
-      cache.set(coverage.placeRepId, await repIdToPlaceId(coverage.placeRepId, token));
-    }
-    placeId = cache.get(coverage.placeRepId) ?? "";
-  }
-
-  return {
-    place: coverage.place ?? "",
-    placeId,
-    ...(coverage.datesOrig != null ? { dateRange: coverage.datesOrig } : {}),
-    ...(coverage.recordTypeOrig != null
-      ? { recordType: coverage.recordTypeOrig }
-      : {}),
-    placeRelevance: coverage.placeRelevance ?? 0,
-  };
-}
-
-async function mapGroup(
-  group: RmsGroup,
-  token: string,
-  cache: Map<number, string | null>
-): Promise<ImageGroup> {
-  const coverages = await Promise.all(
-    (group.coverages ?? []).map((c) => mapCoverage(c, token, cache))
-  );
-
-  return {
-    id: group.id,
-    imageGroupNumber: group.groupName,
-    ...(group.title != null ? { title: group.title } : {}),
-    types: group.types ?? [],
-    creators: group.creators ?? [],
-    languages: group.languages ?? [],
-    ...(group.custodians != null ? { custodians: group.custodians } : {}),
-    ...(group.volumes != null ? { volumes: group.volumes } : {}),
-    coverages,
-  };
+  return (await response.json()) as ChildrenNamesResponse;
 }
 
 export async function imageSearchTool(
   input: ImageSearchInput
 ): Promise<ImageSearchResult> {
-  validate(input);
+  if (!input.imageGroupNumber) {
+    throw new Error("image_search requires an imageGroupNumber.");
+  }
 
   const token = await getValidToken();
-  const body = await buildRequestBody(input, token);
-  const response = await callRms(body, token);
-
-  const groups = response.groups ?? [];
-  const cache = new Map<number, string | null>();
-  const mapped = await Promise.all(
-    groups.map((g) => mapGroup(g, token, cache))
-  );
-
-  return {
-    query: {
-      ...(input.placeId ? { placeId: input.placeId } : {}),
-      ...(input.fromDate ? { fromDate: input.fromDate } : {}),
-      ...(input.toDate ? { toDate: input.toDate } : {}),
-      ...(input.imageGroupNumber
-        ? { imageGroupNumber: input.imageGroupNumber }
-        : {}),
-    },
-    totalGroups: response.totalCount ?? 0,
-    returned: response.numberReturned ?? 0,
-    groups: mapped,
-  };
+  const groupId = await resolveGroupId(input.imageGroupNumber, token);
+  const data = await fetchChildren(groupId, token);
+  const imageIds = Object.values(data).sort();
+  return { imageIds };
 }
 
 export const imageSearchSchema = {
   name: "image_search",
   description:
-    "Search FamilySearch's Records Management Service for image groups — " +
-    "digitized volumes of historical documents (microfilm rolls, book scans). " +
-    "Two query modes: (1) search by place + date range using a placeId from " +
-    "place_search, or (2) look up a specific volume by image group number. " +
-    "Returns image group metadata including coverage (places, dates, record " +
-    "types) and creators. Use the results with image_read to view individual " +
-    "images from a group. " +
+    "List the images in a single FamilySearch image group (a digitized " +
+    "volume — one microfilm roll or book scan). Provide an imageGroupNumber " +
+    "(from metadata_search) and get back the sorted list of image IDs in that " +
+    "volume, each of the form '004884748_02613'. To view an image, pass its ID " +
+    "to image_read. Use metadata_search " +
+    "first to find which image groups cover a place and date range. " +
     "Requires authentication — call the login tool first if not logged in.",
   inputSchema: {
     type: "object",
     properties: {
-      placeId: {
-        type: "string",
-        description:
-          "FamilySearch place ID from place_search. The tool internally " +
-          "converts this to place representation IDs for the RMS query.",
-      },
-      fromDate: {
-        type: "string",
-        description:
-          "Start of date range in YYYY-MM-DD format (e.g., '1730-01-01'). " +
-          "Only used with placeId.",
-      },
-      toDate: {
-        type: "string",
-        description:
-          "End of date range in YYYY-MM-DD format (e.g., '1810-12-31'). " +
-          "Only used with placeId.",
-      },
       imageGroupNumber: {
         type: "string",
         description:
-          "Image group number (e.g., '007621224'). Image group numbers " +
-          "come from catalog search results.",
+          "The image group number to list, from metadata_search — either a " +
+          "split Natural Group name like '007621224_005_M99P-2TQ' or a bare " +
+          "number like '007621224'.",
       },
     },
+    required: ["imageGroupNumber"],
   },
 };

--- a/mcp-server/src/tools/place-search.ts
+++ b/mcp-server/src/tools/place-search.ts
@@ -7,6 +7,58 @@ import type {
 } from "../types/place.js";
 
 const FS_API_BASE = "https://api.familysearch.org/platform/places";
+
+interface FSPlaceLookupEntry {
+  id: string;
+  place?: { resource?: string; resourceId?: string };
+  identifiers?: Record<string, string[]>;
+  display?: { name: string; fullName: string; type: string };
+}
+
+interface FSPlaceLookupResponse {
+  places?: FSPlaceLookupEntry[];
+}
+
+/**
+ * Convert a placeId to its placeRepIds via the places API.
+ * Relocated here from image-search.ts for use by metadata_search.
+ */
+export async function placeIdToRepIds(
+  placeId: string,
+  token: string
+): Promise<number[]> {
+  const response = await fetch(
+    `${FS_API_BASE}/${encodeURIComponent(placeId)}`,
+    {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: "application/json",
+      },
+    }
+  );
+
+  if (!response.ok) {
+    throw new Error(
+      `FamilySearch places API error: ${response.status} ${response.statusText}`
+    );
+  }
+
+  const data = (await response.json()) as FSPlaceLookupResponse;
+  const reps = (data.places ?? []).filter(
+    (p) => p.place?.resourceId === placeId
+  );
+
+  const ids: number[] = [];
+  const seen = new Set<number>();
+  for (const rep of reps) {
+    const n = Number(rep.id);
+    if (!Number.isNaN(n) && !seen.has(n)) {
+      seen.add(n);
+      ids.push(n);
+    }
+  }
+  return ids;
+}
 const WIKIPEDIA_API_BASE = "https://en.wikipedia.org/api/rest_v1/page/summary";
 const FS_PLACES_PUBLIC_BASE =
   "https://www.familysearch.org/en/research/places";

--- a/mcp-server/src/types/image-search.ts
+++ b/mcp-server/src/types/image-search.ts
@@ -1,106 +1,15 @@
 // Types for the image_search tool.
 //
-// Searches FamilySearch's Records Management Service (RMS) for image groups
-// (digitized volumes). Two query modes: place + date range, or image group
-// number. See docs/specs/image-search-tool-spec.md.
-
-// ---------- Tool input ----------
+// Given an imageGroupNumber, the tool resolves it to a group and returns
+// all image IDs in that group. See docs/specs/image-search-tool-spec.md.
 
 export interface ImageSearchInput {
-  placeId?: string;
-  fromDate?: string;
-  toDate?: string;
-  imageGroupNumber?: string;
-}
-
-// ---------- Places API lookup (placeId <-> placeRepId conversion) ----------
-
-// GET https://api.familysearch.org/platform/places/{placeId} returns a list
-// where the bare place entry (id === placeId, no `display`) is followed by its
-// representation entries. Each representation has a top-level `place` pointing
-// back to the parent placeId and a `Primary` identifier.
-export interface FSPlaceLookupEntry {
-  id: string;
-  display?: { name: string; fullName: string; type: string };
-  place?: { resource?: string; resourceId?: string };
-  identifiers?: Record<string, string[]>;
-}
-
-export interface FSPlaceLookupResponse {
-  places?: FSPlaceLookupEntry[];
-}
-
-// ---------- RMS request ----------
-
-export interface RmsCoverageRequest {
-  placeRepIds: number[];
-  fromDateString?: string;
-  toDateString?: string;
-}
-
-export interface RmsSearchRequest {
-  coverage?: RmsCoverageRequest;
-  name?: string;
-  types: string[];
-  returnChildCounts: boolean;
-  active: boolean;
-}
-
-// ---------- RMS response ----------
-
-export interface RmsCoverageEntry {
-  place?: string;
-  placeRepId?: number;
-  datesOrig?: string;
-  recordTypeOrig?: string;
-  placeRelevance?: number;
-}
-
-export interface RmsGroup {
-  id: string;
-  groupName: string;
-  active?: boolean;
-  types?: string[];
-  coverages?: RmsCoverageEntry[];
-  creators?: string[];
-  languages?: string[];
-  title?: string;
-  volumes?: string[];
-  custodians?: string[];
-}
-
-export interface RmsSearchResponse {
-  groups?: RmsGroup[];
-  numberReturned?: number;
-  totalCount?: number;
-  nextPageToken?: string;
-}
-
-// ---------- Tool output ----------
-
-export interface SimplifiedCoverage {
-  place: string;
-  placeId: string;
-  dateRange?: string;
-  recordType?: string;
-  placeRelevance: number;
-}
-
-export interface ImageGroup {
-  id: string;
   imageGroupNumber: string;
-  title?: string;
-  types: string[];
-  creators: string[];
-  languages: string[];
-  custodians?: string[];
-  volumes?: string[];
-  coverages: SimplifiedCoverage[];
 }
+
+// children/names endpoint returns a flat object mapping apid → imageId.
+export type ChildrenNamesResponse = Record<string, string>;
 
 export interface ImageSearchResult {
-  query: ImageSearchInput;
-  totalGroups: number;
-  returned: number;
-  groups: ImageGroup[];
+  imageIds: string[];
 }

--- a/mcp-server/tests/tools/image-search.test.ts
+++ b/mcp-server/tests/tools/image-search.test.ts
@@ -7,126 +7,23 @@ vi.mock("../../src/auth/refresh.js", () => ({
 import { imageSearchTool } from "../../src/tools/image-search.js";
 import { getValidToken } from "../../src/auth/refresh.js";
 import { BROWSER_USER_AGENT } from "../../src/constants.js";
-import type {
-  FSPlaceLookupResponse,
-  RmsSearchResponse,
-  RmsGroup,
-} from "../../src/types/image-search.js";
 
 const mockedGetValidToken = vi.mocked(getValidToken);
 const mockFetch = vi.fn();
 vi.stubGlobal("fetch", mockFetch);
 
-// ---------- fixtures ----------
-
-// Shape of GET /places/{placeId}: bare place entry (no display) followed by
-// representations whose top-level `place.resourceId` points back to the placeId.
-function forwardPlacesResponse(
-  placeId: string,
-  repIds: string[]
-): FSPlaceLookupResponse {
-  return {
-    places: [
-      { id: placeId, names: [{ lang: "en", value: "Edensor" }] } as never,
-      ...repIds.map((id) => ({
-        id,
-        place: {
-          resource: `https://api.familysearch.org/platform/places/${placeId}`,
-          resourceId: placeId,
-        },
-        identifiers: {
-          "http://gedcomx.org/Primary": [
-            `https://api.familysearch.org/platform/places/${placeId}`,
-          ],
-        },
-        display: { name: "Edensor", fullName: "Edensor, Derbyshire", type: "Village" },
-      })),
-    ],
-  };
-}
-
-// Shape of GET /places/description/{repId}: the representation with its Primary
-// identifier resolving to the placeId.
-function descriptionResponse(repId: string, placeId: string): FSPlaceLookupResponse {
-  return {
-    places: [
-      {
-        id: repId,
-        identifiers: {
-          "http://gedcomx.org/Primary": [
-            `https://api.familysearch.org/platform/places/${placeId}`,
-          ],
-        },
-        display: { name: "Edensor", fullName: "Edensor, Derbyshire", type: "Village" },
-      },
-    ],
-  };
-}
-
-const sampleGroup: RmsGroup = {
-  id: "DGS-004452257",
-  groupName: "004452257",
-  active: true,
-  types: ["NATURAL", "DGS"],
-  creators: ["Church of England. Parish Church of Edensor (Derbyshire)"],
-  languages: ["en", "la"],
-  coverages: [
-    {
-      place: "Edensor, Derbyshire, England, United Kingdom",
-      placeRepId: 2968392,
-      datesOrig: "1726–1812",
-      recordTypeOrig: "Burial Records",
-      placeRelevance: 94,
-    },
-  ],
+const SAMPLE_CHILDREN: Record<string, string> = {
+  "TH-1951-22159-52423-62": "004884748_02613",
+  "TH-1951-22159-52571-81": "004884748_02614",
+  "TH-1942-22159-53144-63": "004884748_02615",
 };
 
-// Routes mock fetch by URL so place mode (forward lookup + RMS + reverse
-// lookups) works in one configuration.
-function routeFetch(opts: {
-  reps?: string[]; // placeRepIds returned by the forward lookup
-  placeId?: string;
-  rms?: RmsSearchResponse | { status: number; statusText?: string };
-  rmsReject?: Error;
-  repToPlaceId?: Record<string, string>;
-}) {
-  mockFetch.mockImplementation((url: string, init?: RequestInit) => {
-    if (url.includes("/places/description/")) {
-      const repId = url.split("/places/description/")[1].split("?")[0];
-      const placeId = opts.repToPlaceId?.[repId];
-      if (placeId == null) {
-        return Promise.resolve({ ok: false, status: 404, statusText: "Not Found" });
-      }
-      return Promise.resolve({
-        ok: true,
-        status: 200,
-        json: async () => descriptionResponse(repId, placeId),
-      });
-    }
-    if (url.includes("/group/search")) {
-      if (opts.rmsReject) return Promise.reject(opts.rmsReject);
-      const rms = opts.rms;
-      if (rms && "status" in rms) {
-        return Promise.resolve({
-          ok: false,
-          status: rms.status,
-          statusText: rms.statusText ?? "Error",
-        });
-      }
-      return Promise.resolve({
-        ok: true,
-        status: 200,
-        json: async () => rms ?? { groups: [], numberReturned: 0, totalCount: 0 },
-      });
-    }
-    // forward /places/{placeId}
-    return Promise.resolve({
-      ok: true,
-      status: 200,
-      json: async () =>
-        forwardPlacesResponse(opts.placeId ?? "6137147", opts.reps ?? []),
-    });
-  });
+function okChildren(data: Record<string, string> = SAMPLE_CHILDREN) {
+  return Promise.resolve({ ok: true, status: 200, json: async () => data });
+}
+
+function okApid(apid: string) {
+  return Promise.resolve({ ok: true, status: 200, text: async () => apid });
 }
 
 beforeEach(() => {
@@ -139,294 +36,155 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
-describe("imageSearchTool — happy paths", () => {
-  it("returns groups for placeId + date range query", async () => {
-    routeFetch({
-      placeId: "6137147",
-      reps: ["2968392", "10609408"],
-      rms: { groups: [sampleGroup], numberReturned: 1, totalCount: 1 },
-      repToPlaceId: { "2968392": "6137147" },
-    });
+// Test 1 — split form uses last segment, calls children/names directly
+it("split form: uses last _ segment as groupId, skips apid lookup", async () => {
+  mockFetch.mockResolvedValueOnce(okChildren());
 
-    const result = await imageSearchTool({
-      placeId: "6137147",
-      fromDate: "1730-01-01",
-      toDate: "1810-12-31",
-    });
+  await imageSearchTool({ imageGroupNumber: "007621224_005_M99P-2TQ" });
 
-    expect(result.totalGroups).toBe(1);
-    expect(result.returned).toBe(1);
-    expect(result.groups[0].imageGroupNumber).toBe("004452257");
-    expect(result.query).toEqual({
-      placeId: "6137147",
-      fromDate: "1730-01-01",
-      toDate: "1810-12-31",
-    });
-  });
-
-  it("returns groups for image group number query", async () => {
-    routeFetch({ rms: { groups: [sampleGroup], numberReturned: 1, totalCount: 1 } });
-
-    const result = await imageSearchTool({ imageGroupNumber: "004452257" });
-
-    expect(result.totalGroups).toBe(1);
-    expect(result.groups[0].id).toBe("DGS-004452257");
-    expect(result.query).toEqual({ imageGroupNumber: "004452257" });
-  });
+  expect(mockFetch).toHaveBeenCalledTimes(1);
+  const url = mockFetch.mock.calls[0][0] as string;
+  expect(url).toContain("/artifact/group/M99P-2TQ/children/names");
 });
 
-describe("imageSearchTool — input validation", () => {
-  it("throws when neither placeId nor imageGroupNumber provided", async () => {
-    await expect(imageSearchTool({})).rejects.toThrow(
-      "image_search requires either placeId or imageGroupNumber."
-    );
-    expect(mockFetch).not.toHaveBeenCalled();
-  });
+// Test 2 — bare form calls apid then children/names
+it("bare form: calls apid endpoint, then children/names with the apid", async () => {
+  mockFetch
+    .mockResolvedValueOnce(okApid("TH-1942-27199-5790-22"))
+    .mockResolvedValueOnce(okChildren());
 
-  it("throws when both placeId and imageGroupNumber provided", async () => {
-    await expect(
-      imageSearchTool({ placeId: "6137147", imageGroupNumber: "004452257" })
-    ).rejects.toThrow("Provide either placeId or imageGroupNumber, not both.");
-    expect(mockFetch).not.toHaveBeenCalled();
-  });
+  await imageSearchTool({ imageGroupNumber: "007621224" });
 
-  it("throws when fromDate is invalid format", async () => {
-    await expect(
-      imageSearchTool({ placeId: "6137147", fromDate: "1730" })
-    ).rejects.toThrow("fromDate must be in YYYY-MM-DD format");
-    expect(mockFetch).not.toHaveBeenCalled();
-  });
-
-  it("throws when fromDate/toDate provided without placeId", async () => {
-    await expect(
-      imageSearchTool({ imageGroupNumber: "004452257", fromDate: "1730-01-01" })
-    ).rejects.toThrow("fromDate and toDate require placeId.");
-    expect(mockFetch).not.toHaveBeenCalled();
-  });
-
-  it("throws when places API returns no placeRepIds", async () => {
-    routeFetch({ placeId: "6137147", reps: [] });
-    await expect(imageSearchTool({ placeId: "6137147" })).rejects.toThrow(
-      "No place representations found for placeId 6137147."
-    );
-  });
+  expect(mockFetch).toHaveBeenCalledTimes(2);
+  const apidUrl = mockFetch.mock.calls[0][0] as string;
+  const childrenUrl = mockFetch.mock.calls[1][0] as string;
+  expect(apidUrl).toContain("/group/007621224/apid");
+  expect(childrenUrl).toContain(
+    "/artifact/group/TH-1942-27199-5790-22/children/names"
+  );
 });
 
-describe("imageSearchTool — placeId conversion", () => {
-  it("converts placeId to placeRepIds via the places API", async () => {
-    routeFetch({
-      placeId: "6137147",
-      reps: ["2968392", "10609408"],
-      rms: { groups: [], numberReturned: 0, totalCount: 0 },
-    });
+// Test 3 — apid body is plain text, whitespace is trimmed
+it("reads apid body as plain text and trims whitespace", async () => {
+  mockFetch
+    .mockResolvedValueOnce(
+      okApid("  TH-1942-27199-5790-22  \n")
+    )
+    .mockResolvedValueOnce(okChildren());
 
-    await imageSearchTool({ placeId: "6137147" });
+  await imageSearchTool({ imageGroupNumber: "007621224" });
 
-    const forwardCall = mockFetch.mock.calls.find(
-      (c) => (c[0] as string).endsWith("/platform/places/6137147")
-    );
-    expect(forwardCall).toBeDefined();
-  });
-
-  it("passes all placeRepIds in a single RMS call via coverage.placeRepIds", async () => {
-    routeFetch({
-      placeId: "6137147",
-      reps: ["2968392", "10609408"],
-      rms: { groups: [], numberReturned: 0, totalCount: 0 },
-    });
-
-    await imageSearchTool({
-      placeId: "6137147",
-      fromDate: "1730-01-01",
-      toDate: "1810-12-31",
-    });
-
-    const rmsCall = mockFetch.mock.calls.find((c) =>
-      (c[0] as string).includes("/group/search")
-    );
-    const body = JSON.parse((rmsCall![1] as RequestInit).body as string);
-    expect(body.coverage.placeRepIds).toEqual([2968392, 10609408]);
-    expect(body.coverage.fromDateString).toBe("1730-01-01");
-    expect(body.coverage.toDateString).toBe("1810-12-31");
-    expect(body.types).toEqual(["NATURAL"]);
-    expect(body.returnChildCounts).toBe(false);
-    expect(body.active).toBe(true);
-    // single RMS call
-    const rmsCalls = mockFetch.mock.calls.filter((c) =>
-      (c[0] as string).includes("/group/search")
-    );
-    expect(rmsCalls).toHaveLength(1);
-  });
+  const childrenUrl = mockFetch.mock.calls[1][0] as string;
+  expect(childrenUrl).toContain(
+    "/artifact/group/TH-1942-27199-5790-22/children/names"
+  );
 });
 
-describe("imageSearchTool — request construction", () => {
-  it("builds correct request body for place mode", async () => {
-    routeFetch({
-      placeId: "6137147",
-      reps: ["2968392"],
-      rms: { groups: [], numberReturned: 0, totalCount: 0 },
-    });
+// Test 4 — returns imageId values (not apid keys), sorted ascending
+it("returns imageId values sorted ascending", async () => {
+  mockFetch.mockResolvedValueOnce(
+    okChildren({
+      "TH-A": "004884748_02615",
+      "TH-B": "004884748_02613",
+      "TH-C": "004884748_02614",
+    })
+  );
 
-    await imageSearchTool({ placeId: "6137147" });
-
-    const rmsCall = mockFetch.mock.calls.find((c) =>
-      (c[0] as string).includes("/group/search")
-    );
-    const body = JSON.parse((rmsCall![1] as RequestInit).body as string);
-    expect(body).toEqual({
-      coverage: { placeRepIds: [2968392] },
-      types: ["NATURAL"],
-      returnChildCounts: false,
-      active: true,
-    });
+  const result = await imageSearchTool({
+    imageGroupNumber: "007621224_005_M99P-2TQ",
   });
 
-  it("builds correct request body for image group number mode (appends wildcard)", async () => {
-    routeFetch({ rms: { groups: [], numberReturned: 0, totalCount: 0 } });
-
-    await imageSearchTool({ imageGroupNumber: "007621224" });
-
-    const rmsCall = mockFetch.mock.calls.find((c) =>
-      (c[0] as string).includes("/group/search")
-    );
-    const body = JSON.parse((rmsCall![1] as RequestInit).body as string);
-    expect(body).toEqual({
-      name: "007621224*",
-      types: ["NATURAL"],
-      returnChildCounts: false,
-      active: true,
-    });
-  });
+  expect(result.imageIds).toEqual([
+    "004884748_02613",
+    "004884748_02614",
+    "004884748_02615",
+  ]);
 });
 
-describe("imageSearchTool — response mapping", () => {
-  it("maps API response to simplified output", async () => {
-    routeFetch({
-      placeId: "6137147",
-      reps: ["2968392"],
-      rms: { groups: [sampleGroup], numberReturned: 1, totalCount: 1 },
-      repToPlaceId: { "2968392": "6137147" },
-    });
-
-    const result = await imageSearchTool({ placeId: "6137147" });
-
-    expect(result.groups[0]).toEqual({
-      id: "DGS-004452257",
-      imageGroupNumber: "004452257",
-      types: ["NATURAL", "DGS"],
-      creators: ["Church of England. Parish Church of Edensor (Derbyshire)"],
-      languages: ["en", "la"],
-      coverages: [
-        {
-          place: "Edensor, Derbyshire, England, United Kingdom",
-          placeId: "6137147",
-          dateRange: "1726–1812",
-          recordType: "Burial Records",
-          placeRelevance: 94,
-        },
-      ],
-    });
-  });
-
-  it("handles groups with multiple coverages", async () => {
-    const multi: RmsGroup = {
-      id: "DGS-1",
-      groupName: "1",
-      types: ["NATURAL"],
-      creators: [],
-      languages: ["en"],
-      coverages: [
-        { place: "A", placeRepId: 100, placeRelevance: 90 },
-        { place: "B", placeRepId: 200, placeRelevance: 80 },
-      ],
-    };
-    routeFetch({
-      placeId: "6137147",
-      reps: ["2968392"],
-      rms: { groups: [multi], numberReturned: 1, totalCount: 1 },
-      repToPlaceId: { "100": "111", "200": "222" },
-    });
-
-    const result = await imageSearchTool({ placeId: "6137147" });
-
-    expect(result.groups[0].coverages).toHaveLength(2);
-    expect(result.groups[0].coverages[0].placeId).toBe("111");
-    expect(result.groups[0].coverages[1].placeId).toBe("222");
-  });
-
-  it("converts placeRepId in coverage to placeId in output", async () => {
-    routeFetch({
-      placeId: "6137147",
-      reps: ["2968392"],
-      rms: { groups: [sampleGroup], numberReturned: 1, totalCount: 1 },
-      repToPlaceId: { "2968392": "6137147" },
-    });
-
-    const result = await imageSearchTool({ placeId: "6137147" });
-
-    expect(result.groups[0].coverages[0].placeId).toBe("6137147");
-    const reverseCall = mockFetch.mock.calls.find((c) =>
-      (c[0] as string).includes("/places/description/2968392")
-    );
-    expect(reverseCall).toBeDefined();
-  });
-
-  it("handles empty groups response", async () => {
-    // API returns {"totalCount": 0} with no groups/numberReturned keys.
-    routeFetch({ rms: { totalCount: 0 } });
-
-    const result = await imageSearchTool({ imageGroupNumber: "nope" });
-
-    expect(result.totalGroups).toBe(0);
-    expect(result.returned).toBe(0);
-    expect(result.groups).toEqual([]);
-  });
+// Test 5 — throws when imageGroupNumber is missing
+it("throws when imageGroupNumber is missing", async () => {
+  await expect(
+    imageSearchTool({ imageGroupNumber: "" })
+  ).rejects.toThrow("image_search requires an imageGroupNumber.");
+  expect(mockFetch).not.toHaveBeenCalled();
 });
 
-describe("imageSearchTool — error handling", () => {
-  it("throws auth error when not authenticated", async () => {
-    mockedGetValidToken.mockRejectedValueOnce(
-      new Error("User is not logged in to FamilySearch. Call the login tool to authenticate.")
-    );
-
-    await expect(imageSearchTool({ imageGroupNumber: "004452257" })).rejects.toThrow(
-      /not logged in/
-    );
-    expect(mockFetch).not.toHaveBeenCalled();
+// Test 6 — throws when apid lookup fails
+it("throws when apid lookup returns non-OK", async () => {
+  mockFetch.mockResolvedValueOnce({
+    ok: false,
+    status: 404,
+    statusText: "Not Found",
   });
 
-  it("throws on 401 with re-login guidance", async () => {
-    routeFetch({ rms: { status: 401, statusText: "Unauthorized" } });
-
-    await expect(imageSearchTool({ imageGroupNumber: "004452257" })).rejects.toThrow(
-      "FamilySearch session not accepted; call the login tool to re-authenticate."
-    );
-  });
-
-  it("throws on network error", async () => {
-    routeFetch({ rmsReject: new Error("ECONNREFUSED") });
-
-    await expect(imageSearchTool({ imageGroupNumber: "004452257" })).rejects.toThrow(
-      "Could not reach FamilySearch image search API: ECONNREFUSED."
-    );
-  });
+  await expect(
+    imageSearchTool({ imageGroupNumber: "007621224" })
+  ).rejects.toThrow(
+    "Could not resolve image group number 007621224 to an image group."
+  );
 });
 
-describe("imageSearchTool — header contract", () => {
-  it("sends Authorization, Content-Type, User-Agent, FS-User-Agent-Chain on the RMS call", async () => {
-    routeFetch({ rms: { groups: [], numberReturned: 0, totalCount: 0 } });
+// Test 7 — empty response returns { imageIds: [] }
+it("returns empty imageIds for an empty {} response", async () => {
+  mockFetch.mockResolvedValueOnce(okChildren({}));
 
-    await imageSearchTool({ imageGroupNumber: "004452257" });
-
-    const rmsCall = mockFetch.mock.calls.find((c) =>
-      (c[0] as string).includes("/group/search")
-    );
-    const init = rmsCall![1] as RequestInit;
-    const headers = init.headers as Record<string, string>;
-    expect(init.method).toBe("PUT");
-    expect(headers["Authorization"]).toBe("Bearer test-token");
-    expect(headers["Content-Type"]).toBe("application/json");
-    expect(headers["User-Agent"]).toBe(BROWSER_USER_AGENT);
-    expect(headers["FS-User-Agent-Chain"]).toBe("chesworth");
+  const result = await imageSearchTool({
+    imageGroupNumber: "007621224_005_M99P-2TQ",
   });
+
+  expect(result.imageIds).toEqual([]);
+});
+
+// Test 8 — auth error propagates
+it("throws auth error when not authenticated", async () => {
+  mockedGetValidToken.mockRejectedValueOnce(
+    new Error(
+      "User is not logged in to FamilySearch. Call the login tool to authenticate."
+    )
+  );
+
+  await expect(
+    imageSearchTool({ imageGroupNumber: "007621224" })
+  ).rejects.toThrow(/not logged in/);
+  expect(mockFetch).not.toHaveBeenCalled();
+});
+
+// Test 9 — 401 on children/names
+it("throws on 401 with re-login guidance", async () => {
+  mockFetch.mockResolvedValueOnce({
+    ok: false,
+    status: 401,
+    statusText: "Unauthorized",
+  });
+
+  await expect(
+    imageSearchTool({ imageGroupNumber: "007621224_005_M99P-2TQ" })
+  ).rejects.toThrow(
+    "FamilySearch session not accepted; call the login tool to re-authenticate."
+  );
+});
+
+// Test 10 — network error
+it("throws on network error", async () => {
+  mockFetch.mockRejectedValueOnce(new Error("ECONNREFUSED"));
+
+  await expect(
+    imageSearchTool({ imageGroupNumber: "007621224_005_M99P-2TQ" })
+  ).rejects.toThrow(
+    "Could not reach FamilySearch image search API: ECONNREFUSED."
+  );
+});
+
+// Test 11 — header contract on children/names call
+it("sends correct headers on children/names call", async () => {
+  mockFetch.mockResolvedValueOnce(okChildren());
+
+  await imageSearchTool({ imageGroupNumber: "007621224_005_M99P-2TQ" });
+
+  const init = mockFetch.mock.calls[0][1] as RequestInit;
+  const hdrs = init.headers as Record<string, string>;
+  expect(hdrs["Authorization"]).toBe("Bearer test-token");
+  expect(hdrs["Accept"]).toBe("application/json");
+  expect(hdrs["User-Agent"]).toBe(BROWSER_USER_AGENT);
+  expect(hdrs["FS-User-Agent-Chain"]).toBe("chesworth");
 });


### PR DESCRIPTION
Replace the old RMS group search (place+date → image groups) with a focused tool that lists all image IDs in a single group. Supports split Natural Group form (007621224_005_M99P-2TQ) and bare number form (007621224). Relocate placeIdToRepIds to place-search.ts for future metadata_search use.

Rewrote image_search tool to accept a single imageGroupNumber and return all image IDs in that group as a sorted list (imageIds: string[])
Supports two input forms: split Natural Group (007621224_005_M99P-2TQ) and bare number (007621224)
Split form: uses the last underscore-separated segment as the group ID directly
Bare form: calls the apid endpoint first, then fetches image IDs
Fixed the image-listing endpoint URL — correct path is .../rms/artifact/group/{id}/children/names (not .../rms/group-service/artifact/...)
Relocated placeIdToRepIds from image-search.ts to place-search.ts for use by the future metadata_search tool
Rewrote all 11 Vitest tests to cover the new behavior
Verified against the live FamilySearch API — returns 322 image IDs for 007621224_005_M99P-2TQ

