### PR TITLE
Add passenger list children guidance to skills and tests (#262)

### DIFF
--- a/eval/fixtures/mcp/wiki-search-great-famine-emigration.json
+++ b/eval/fixtures/mcp/wiki-search-great-famine-emigration.json
@@ -9,7 +9,7 @@
       {
         "rank": 1,
         "relevance_score": 0.91,
-        "chunk_text": "The Great Famine (An Gorta Mór, 1845-1852) drove approximately one million Irish to emigrate, with the largest numbers arriving at New York, Boston, and Philadelphia. Passenger manifests from this period are held at the National Archives (NARA) and are indexed on FamilySearch, Ancestry, and FindMyPast. Castle Garden (New York's pre-Ellis Island immigration station, 1820-1892) processed many Famine-era arrivals; its records are searchable at CastleGarden.org.",
+        "chunk_text": "The Great Famine (An Gorta Mór, 1845-1852) drove approximately one million Irish to emigrate, with the largest numbers arriving at New York, Boston, and Philadelphia. Passenger manifests from this period are held at the National Archives (NARA) and are indexed on FamilySearch, Ancestry, and FindMyPast. These manifests list all passengers aboard a vessel, including infants and young children traveling with their parents — examine the full list to identify complete family groups, not just the named adults. Castle Garden (New York's pre-Ellis Island immigration station, 1820-1892) processed many Famine-era arrivals; its records are searchable at CastleGarden.org.",
         "page_title": "Ireland Emigration and Immigration",
         "section_heading": "Famine-Era Emigration (1845-1852)",
         "source_url": "https://www.familysearch.org/en/wiki/Ireland_Emigration_and_Immigration#Famine-Era_Emigration"

--- a/eval/fixtures/scenarios/flynn-census-exhausted/README.md
+++ b/eval/fixtures/scenarios/flynn-census-exhausted/README.md
@@ -13,7 +13,7 @@ Differs from `mid-research-flynn` in these ways:
 
 ## Used by
 
-- `research-plan` tests where the skill must propose a NEW plan for `q_001` after the existing plan has been completed. Plausible plan items: probate records for Thomas Flynn, 1870/1880/1900 censuses to track Patrick post-1860, FAN research on Schuylkill County neighbors, naturalization records, Irish emigration manifests.
+- `research-plan` tests where the skill must propose a NEW plan for `q_001` after the existing plan has been completed. Plausible plan items: probate records for Thomas Flynn, 1870/1880/1900 censuses to track Patrick post-1860, FAN research on Schuylkill County neighbors, naturalization records, Irish emigration manifests (passenger lists record all passengers including infants and young children — the whole manifest should be examined for the complete family group, not just the parents).
 - `question-selection` tests asking "what should I research next?" when the active question's plan is complete but the question isn't fully resolved.
 - Boundary tests verifying that `research-plan` proposes additional research rather than declaring the question resolved on the strength of three census/vital sources alone.
 

--- a/eval/tests/unit/historical-context/connect-context-to-research.json
+++ b/eval/tests/unit/historical-context/connect-context-to-research.json
@@ -13,6 +13,7 @@
   },
   "judge_context": [
     "Should ground the context in Patrick's actual timeline (Irish-born ~1845, in PA by 1850, died 1908) — not produce generic 19th-century context",
-    "Should suggest specific record classes that follow from the context — e.g., Castle Garden / Ellis Island immigration records (immigration triggered by famine), naturalization records (likely filed in adulthood), mine-worker rosters"
+    "Should suggest specific record classes that follow from the context — e.g., Castle Garden / Ellis Island immigration records (immigration triggered by famine), naturalization records (likely filed in adulthood), mine-worker rosters",
+    "When suggesting passenger lists or arrival manifests, should note that these records list all passengers including infants and young children (ages 0-5) traveling with parents — examine the full manifest for the complete family group, not just the target adult"
   ]
 }

--- a/eval/tests/unit/historical-context/irish-famine-migration.json
+++ b/eval/tests/unit/historical-context/irish-famine-migration.json
@@ -20,6 +20,7 @@
   "judge_context": [
     "Should mention the Great Famine (1845-1852) as the primary driver of Irish emigration in this period — not just 'Irish came to America in the 1800s' generic context",
     "Should note that Schuylkill County's anthracite coal industry was a destination for Irish laborers, particularly through Philadelphia (the main entry port for Pennsylvania-bound Irish)",
-    "Should surface at least two research-actionable consequences: (a) specific record classes (Castle Garden / Famine emigration manifests, Catholic parish baptismal records since most Famine-era Irish were Catholic), (b) FAN-research opportunities (Irish communities tended to migrate in extended-family clusters; neighbors and witnesses in Schuylkill records often share origin parishes)"
+    "Should surface at least two research-actionable consequences: (a) specific record classes (Castle Garden / Famine emigration manifests, Catholic parish baptismal records since most Famine-era Irish were Catholic), (b) FAN-research opportunities (Irish communities tended to migrate in extended-family clusters; neighbors and witnesses in Schuylkill records often share origin parishes)",
+    "When recommending passenger list / arrival manifest research, should note that manifests list all passengers including infants and young children traveling with parents — the whole list should be examined for complete family groups, not just searched for adult names"
   ]
 }

--- a/eval/tests/unit/locality-guide/different-jurisdiction-ireland.json
+++ b/eval/tests/unit/locality-guide/different-jurisdiction-ireland.json
@@ -14,6 +14,7 @@
   "judge_context": [
     "Should identify that Irish civil registration didn't exist for births/deaths in the 1830s-1840s (it began 1864) — research must rely on church (Catholic parish) records, surviving estate records, and emigrant lists",
     "Should name specific record classes available for 1830s-1840s Ireland: Catholic parish baptismal/marriage/burial registers (variable survival), Tithe Applotment Books (1823-1837, tax records), Griffith's Valuation (begins 1847, just after), Famine-era emigration manifests for departures from Cork ports",
+    "When mentioning emigration manifests or passenger lists, should note that these records list all passengers including infants and young children (ages 0-5) traveling with parents — the whole manifest should be examined for complete family groups, not just individual adult names",
     "Should warn about specific pitfalls: parish boundary changes, Catholic parish registers held by the National Library of Ireland (microfilm) rather than local courthouses, and that pre-Famine records often perished in the 1922 Four Courts fire for civil/estate documents",
     "Should NOT recommend American-style record classes (county courthouse vital records, statewide vital registration) — those don't apply to 1840s Ireland; using them as the answer would indicate jurisdiction-blindness"
   ]

--- a/plugin/skills/locality-guide/references/output-format.md
+++ b/plugin/skills/locality-guide/references/output-format.md
@@ -74,6 +74,10 @@ records for an inland area with no immigration activity).
 - **Relevant ports:** [nearest ports of entry]
 - **Record types:** [passenger lists, naturalization, border crossing]
 - **Where held:** [NARA, online databases]
+- **Content note:** Passenger lists (arrival manifests) record every
+  person aboard, including infants and young children traveling with
+  parents. When researching a family, examine the full manifest for
+  all family members — children as young as newborns are listed.
 
 ### Tax records
 - **Types:** [property tax, poll tax, personal property]

--- a/plugin/skills/record-extraction/SKILL.md
+++ b/plugin/skills/record-extraction/SKILL.md
@@ -458,6 +458,12 @@ calling `image_read`.
 - For FAN (Family, Associates, Neighbors): extract identifying facts
   (name, age/birth, birthplace) plus any facts bearing on open questions
 - For unrelated individuals: skip unless a research question targets them
+- **For passenger lists (arrival manifests):** Passenger lists record
+  every person aboard, including infants and children (ages 0–5)
+  traveling with parents. Always examine the full manifest and extract
+  facts for all family members listed — not just the adult target.
+  Children's names, ages, and birthplaces on a manifest confirm family
+  composition and can resolve parentage questions.
 
 **Partial or damaged records:**
 - Extract whatever is legible. Annotate gaps with `[illegible]`,

--- a/plugin/skills/search-records/SKILL.md
+++ b/plugin/skills/search-records/SKILL.md
@@ -326,6 +326,13 @@ Never treat an index entry as equivalent to examining the original
 record. Indexes may contain transcription errors, omit context, or
 misattribute relationships.
 
+**Passenger lists (arrival manifests):** When searching for immigration
+records, remember that passenger lists record every person aboard —
+including infants and young children (ages 0–5) traveling with parents.
+When a result matches a parent, examine the full manifest for all
+family members listed together. Children's names, ages, and birthplaces
+confirm family composition and can resolve parentage questions.
+
 ### 8. Handle nil results
 
 When a search returns no results:


### PR DESCRIPTION
## Summary
- Updates skill docs, eval tests, MCP fixtures, and scenario descriptions so Claude knows passenger lists (arrival manifests) record all passengers — including infants and young children — not just adults
- Teaches the principle in 3 skill reference docs (record-extraction, search-records, locality-guide output format), grades it in 3 eval test judge contexts, reinforces it in the MCP wiki fixture and Flynn scenario README

## Test plan
- [x] No TypeScript or runtime code changed — no vitest/tsc needed
- [x] All changes are additive (new judge context items appended, not replacing existing ones)
- [x] Verified 8 files changed, 24 insertions, 4 deletions — all passenger-list-related content only
- [ ] Re-run affected eval skills (historical-context, locality-guide) to verify updated judge context grades correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)