### PR TITLE
Standardize on standardPlace above the tool layer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -285,15 +285,16 @@ Where to look first:
   take a `standardPlace` at the LLM boundary resolve IDs through this module
   (e.g. `metadata_search`, `place_population`, `place_external_links`,
   `place_distance`, `wiki_country_*`); skills/persisted artifacts use only the
-  name. It builds on the low-level fetchers in `place-search.ts`.
-- **Exported helpers in `src/tools/`** — for example, `place-search.ts`
-  exports `searchPlace`, `getPlaceById`, `getPlaceByPrimaryId`,
-  `getPlaceRepIds`, `getPlaceCandidateNames`, and `getPlaceWikipediaUrl`
-  (the place's curated FamilySearch `WIKIPEDIA_LINK` attribute), and
-  `place-collections.ts` exports `fetchAllCollections` and `filterByQuery`.
-  A new tool that needs place lookup, the Wikipedia link, or
-  standardPlace↔ID conversion should call these (or the resolver above),
-  not re-fetch.
+  name. It builds on the low-level fetchers in `src/utils/place-api.ts`.
+- **`src/utils/place-api.ts`** — the low-level FamilySearch Places API
+  fetchers (raw HTTP, no caching): `searchPlace`, `getPlaceById`,
+  `getPlaceByPrimaryId`, `getPlaceRepIds`, `getPlaceCandidateNames`,
+  `getPlaceWikipediaUrl` (the place's curated `WIKIPEDIA_LINK` attribute),
+  `extractPrimaryId`. Both `place-resolver.ts` and `place-search.ts` build on
+  these (no util→tool dependency). A new tool needing a place fetcher imports
+  from here (or, for resolution, from the resolver above) — don't re-fetch.
+  `place-search.ts` re-exports them for back-compat; `place-collections.ts`
+  exports `fetchAllCollections` and `filterByQuery`.
 
 Soft caveat: don't pre-extract for hypothetical reuse. Wait for the
 second concrete need before factoring code into a shared module —

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -277,15 +277,23 @@ Where to look first:
   examples). Import this constant instead of hardcoding the
   string — `place_collections`, `record_search`, `place_external_links`,
   `image_read`, `image_search`, `record_read`, and `fulltext_search` already do.
+- **`src/utils/place-resolver.ts`** — the shared resolver between a
+  `standardPlace` name and FamilySearch IDs: `resolveStandardPlace`,
+  `standardPlaceToRepId`, `repIdToStandardPlace`, `standardPlaceToPlaceId`
+  (null when candidates disagree), `placeIdToRepIds` (anonymous, `string[]`),
+  `standardPlaceToCoords`, plus `withRetry` / `mapWithConcurrency`. Tools that
+  take a `standardPlace` at the LLM boundary resolve IDs through this module
+  (e.g. `metadata_search`, `place_population`, `place_external_links`,
+  `place_distance`, `wiki_country_*`); skills/persisted artifacts use only the
+  name. It builds on the low-level fetchers in `place-search.ts`.
 - **Exported helpers in `src/tools/`** — for example, `place-search.ts`
-  exports `searchPlace`, `getPlaceById`, `getPlaceWikipediaUrl`
+  exports `searchPlace`, `getPlaceById`, `getPlaceByPrimaryId`,
+  `getPlaceRepIds`, `getPlaceCandidateNames`, and `getPlaceWikipediaUrl`
   (the place's curated FamilySearch `WIKIPEDIA_LINK` attribute), and
-  `placeIdToRepIds` (authenticated; converts a placeId to numeric placeRepIds —
-  used by `metadata_search`), and
-  `place-collections.ts` exports `fetchAllCollections`,
-  `filterByQuery`, and `filterByPlaceIds`. A new tool that needs place
-  lookup, the Wikipedia link, or placeId/placeRepId conversion should
-  call these, not re-fetch.
+  `place-collections.ts` exports `fetchAllCollections` and `filterByQuery`.
+  A new tool that needs place lookup, the Wikipedia link, or
+  standardPlace↔ID conversion should call these (or the resolver above),
+  not re-fetch.
 
 Soft caveat: don't pre-extract for hypothetical reuse. Wait for the
 second concrete need before factoring code into a shared module —

--- a/docs/plan/standard-place-standardization.md
+++ b/docs/plan/standard-place-standardization.md
@@ -539,8 +539,24 @@ the key + date as a resolution hint.
      Types + test (11) updated. Skills `locality-guide` + `research-plan`
      wiki_country calls → `standardPlace` (+ their `place_search` `query`→
      `placeName` drift fixed). No dedicated wiki_country spec/testing guide.
-   - ⬜ Remaining: `metadata_search`, `place_population`,
-     `place_external_links`, `place_collections` (deprecate `placeIds`).
+   - ✅ **`place_population`** DONE — `standardPlace` → `standardPlaceToPlaceId`
+     → Pop Stats `place_id`; new test; skills (locality-guide, historical-context).
+   - ✅ **`place_external_links`** DONE — `standardPlace` → `standardPlaceToPlaceId`
+     → `q.placeId` (resolve after the cheap guards); output echoes `standardPlace`;
+     skills (locality-guide, research-plan, search-external-sites + its `query`→`placeName` drift).
+   - ✅ **`place_collections`** DONE — deprecated/removed the `placeIds` input +
+     curated `Collection.placeIds`/`CollectionsResult.placeIds` output + dead
+     helpers (`getPlaceIds`/`filterByPlaceIds`); kept the upstream
+     `FSSearchMetadata.placeIds` detail pass-through.
+   - ✅ **`metadata_search`** DONE — `standardPlace` → `standardPlaceToPlaceId`
+     (null-on-disagreement) → `placeIdToRepIds` (anonymous, `string[]`) →
+     `coverage.placeRepIds` (type widened to `string[]`); query echo →
+     `standardPlace`; getValidToken stays for the RMS/fulltext calls; test
+     re-indexed to the 2-call (search, fulltext) sequence + resolver mocks.
+   - **Step 4 tool migration complete.** Remaining doc cleanup (batched):
+     full testing-guide sweeps + residual spec prose/examples for the four
+     tools; the old `placeIdToRepIds` in `place-search.ts` is now dead code
+     (resolver's version is used) — leave or remove with a CLAUDE.md note.
 5. **Schema** — research.json `place_id` → `standard_place` (§8): schema +
    spec + validator + eval TS mirror + Python stubs.
 6. **Sweep** — repo-wide grep for residual `placeId`/`placeRepId`/`place_id`

--- a/docs/plan/standard-place-standardization.md
+++ b/docs/plan/standard-place-standardization.md
@@ -557,8 +557,16 @@ the key + date as a resolution hint.
      full testing-guide sweeps + residual spec prose/examples for the four
      tools; the old `placeIdToRepIds` in `place-search.ts` is now dead code
      (resolver's version is used) — leave or remove with a CLAUDE.md note.
-5. **Schema** — research.json `place_id` → `standard_place` (§8): schema +
-   spec + validator + eval TS mirror + Python stubs.
+5. **Schema** — ✅ **DONE**. research.json `timelines[].events[].place_id` →
+   `standard_place`: `research.schema.json`, `validator.ts` (NULLABLE_FIELDS),
+   `eval/app/.../schema.ts` (TS mirror), `research-schema-spec.md` +
+   `2026-05-07-timeline-distances-design.md` (rows + derivation), and the
+   `timeline` skill now persists `standard_place` on events (distance keys off
+   `standard_place` equality). No Python stubs / scenario fixtures carried
+   `place_id` (verified — no-op). Also fixed a step-4 leftover: `try-place-distance.ts`
+   still passed `placeId1/2`. Note: the eval run-log snapshot tracks
+   `mcp-server/src/**`, so the validator change invalidates existing snapshots
+   (eval re-record is a separate eval-team task).
 6. **Sweep** — repo-wide grep for residual `placeId`/`placeRepId`/`place_id`
    in skills, specs, fixtures; run `spec-review` on every touched tool;
    manifest drift test. Leave the documented out-of-scope id-spaces alone

--- a/docs/plan/standard-place-standardization.md
+++ b/docs/plan/standard-place-standardization.md
@@ -274,7 +274,7 @@ facts at once ("Ky" ×10 → one resolution), which a per-fact function can't.
    ambiguous / error the fact keeps an empty `standard_place` (snake — it is
    the `SimplifiedFact` field) and the other places proceed. **Negative-cache only definitive 0-candidate results —
    never transient failures** (so a network blip doesn't poison the cache).
-   **Soft cap** distinct places per call (~50) and `log()` overflow — no
+   **Soft cap** distinct places per call (100) and `log()` overflow — no
    silent truncation. The process cache + persisted names keep steady-state
    well under the cap. Idempotent: only fills empty values.
 7. **`expandFact`** (`gedcomx-convert.ts:506`): `standard_place` is a
@@ -522,7 +522,7 @@ the key + date as a resolution hint.
 3. **Converter + standardization pass** — ✅ **DONE**.
    `types/gedcomx.ts`: `GedcomXFact.place.normalized` + `SimplifiedFact.standard_place`.
    `gedcomx-convert.ts`: `simplifyFact` reads `normalized` (pure, prefer en);
-   `standardizePlaces` (dedup + ≤8 parallel + soft-cap-50 + best-effort) +
+   `standardizePlaces` (dedup + ≤8 parallel + soft-cap-100 + best-effort) +
    `collectFacts` + async `toSimplifiedStandardized`. Wired: `person_read`,
    `record_read`, `person_ancestors` → `toSimplifiedStandardized`;
    `record_search`/`person_search` → one `standardizePlaces` over all entries

--- a/docs/plan/standard-place-standardization.md
+++ b/docs/plan/standard-place-standardization.md
@@ -527,6 +527,14 @@ the key + date as a resolution hint.
    tool's spec + testing guide + tests. This is the unit that keeps the
    system runnable at every commit. (Fixing the `place_search({ query })`
    drift happens here too, per tool's callers.)
+   - ✅ **`place_distance`** DONE — input `placeId1/2` → `standardPlace1/2`
+     (resolves via `standardPlaceToCoords`); output echoes the names; tool +
+     test + dispatch unaffected. Skills/agent updated: `timeline` (resolves to
+     `standardPlace` transiently, no `place_id` persistence — that field moves
+     in Step 5; also fixed `query`→`placeName`), `conflict-resolution`,
+     `gps-mentor`. Spec note added to the timeline-distances design doc.
+   - ⬜ Remaining: `wiki_country_*`, `metadata_search`, `place_population`,
+     `place_external_links`, `place_collections` (deprecate `placeIds`).
 5. **Schema** — research.json `place_id` → `standard_place` (§8): schema +
    spec + validator + eval TS mirror + Python stubs.
 6. **Sweep** — repo-wide grep for residual `placeId`/`placeRepId`/`place_id`

--- a/docs/plan/standard-place-standardization.md
+++ b/docs/plan/standard-place-standardization.md
@@ -533,7 +533,13 @@ the key + date as a resolution hint.
      `standardPlace` transiently, no `place_id` persistence — that field moves
      in Step 5; also fixed `query`→`placeName`), `conflict-resolution`,
      `gps-mentor`. Spec note added to the timeline-distances design doc.
-   - ⬜ Remaining: `wiki_country_*`, `metadata_search`, `place_population`,
+   - ✅ **`wiki_country_*`** (×4) DONE — input `placeId` → `standardPlace`;
+     resolves the standard place's leaf name + `standardPlaceToPlaceId` →
+     `getPlaceCandidateNames` for slug variants. Output echoes `standardPlace`.
+     Types + test (11) updated. Skills `locality-guide` + `research-plan`
+     wiki_country calls → `standardPlace` (+ their `place_search` `query`→
+     `placeName` drift fixed). No dedicated wiki_country spec/testing guide.
+   - ⬜ Remaining: `metadata_search`, `place_population`,
      `place_external_links`, `place_collections` (deprecate `placeIds`).
 5. **Schema** — research.json `place_id` → `standard_place` (§8): schema +
    spec + validator + eval TS mirror + Python stubs.

--- a/docs/plan/standard-place-standardization.md
+++ b/docs/plan/standard-place-standardization.md
@@ -3,10 +3,12 @@
 **Status:** ✅ **IMPLEMENTED** (2026-06-05) — Steps 1–6 complete on branch
 `standard-place-resolver` (12 commits), plus spec-review + a multi-agent
 code-review (all CONFIRMED findings fixed) and the residual-prose doc cleanup.
-tsc clean; 806 tests green; no LLM-facing `placeId` remains. Remaining:
-eval-corpus re-record (mock fixtures + runlog snapshots — eval-team), and the
-optional `place-search.ts` fetcher consolidation (Step 1 deferral). History
-below was the design trail (v1 → v5).
+tsc clean; 806 tests green; no LLM-facing `placeId` remains. The Step-1 fetcher
+consolidation is now done — the low-level FS Places fetchers live in
+`src/utils/place-api.ts`, which both `place-resolver.ts` and `place-search.ts`
+build on (no util→tool dependency). Remaining: eval-corpus re-record (mock
+fixtures + runlog snapshots — eval-team). History below was the design trail
+(v1 → v5).
 
 **Status (design trail):** Draft v5 (2026-06-05) — added retry/backoff for
 standardization; locked the `standardPlace`(code) / `standard_place`(data)

--- a/docs/plan/standard-place-standardization.md
+++ b/docs/plan/standard-place-standardization.md
@@ -1,0 +1,559 @@
+# Standard-place standardization — implementation plan
+
+**Status:** Draft v5 (2026-06-05) — added retry/backoff for standardization;
+locked the `standardPlace`(code) / `standard_place`(data) naming split.
+**Scope:** Make `standard_place` (a fully-qualified standardized place
+NAME) the only place vocabulary above the MCP tool layer — in skills, in
+SimplifiedGedcomX, and in persisted research artifacts. Keep `placeId` /
+`placeRepId` as private, cached, in-server plumbing.
+**Related:** `docs/plan/id-vocabulary-standardization-progress.md` (which
+explicitly scoped the placeId chain OUT as "a separate task" — this is
+that task), and the `place-search`/`place-search-all` specs, which already
+promise "a later phase will route every tool that needs a place ID through
+placeSearch so IDs stay inside the server."
+
+> **v2 changes (review-incorporated):** decision #1 (pure converter) is now
+> **contingent on a verification probe** + `Accept-Language: en` because
+> `place.normalized` is unconfirmed at the read endpoints and is
+> locale-sensitive; rollout re-sequenced to **tool+its-skills atomic units**;
+> `place_search` gains an explicit `standard_place` field + selection rule;
+> `metadata_search` gets a placeId tie-break; added missing update sites
+> (eval app TS schema, 3 testing guides, place-collections & gps-mentor specs,
+> `types/place.ts`); corrected two false claims (no fixtures carry `place_id`;
+> no "wiki country specs" exist).
+>
+> **v3 change:** populate strategy is now **hybrid** — use `place.normalized`
+> when present (locale fragility accepted by the user), and **standardize via
+> `place_search` otherwise** (as a network enrichment step in the read tools).
+> The §0 probe is downgraded from a go/no-go gate to an optional shape check,
+> since the design no longer depends on normalized being present.
+>
+> **v4 change:** standardization moved **into the converter path** (not the
+> read tools) as an async document-level pass (`toSimplifiedStandardized`)
+> with **dedup + ≤8-way parallelism**, so the workhorse `record_search` gets
+> standardized places too. `place_search` now **always and only returns
+> standard places** (`standard_place` is its canonical field). Network in the
+> converter path is accepted; the pass is best-effort (never throws) with
+> negative-caching + a soft cap.
+>
+> **v5 change:** place standardization **retries transient failures (≤3,
+> backoff + jitter)**; only definitive 0-candidate nulls are cached (transient
+> blips are not). Naming locked: **camelCase `standardPlace`** in code surfaces
+> (place_search struct, tool inputs, internal TS), **snake_case
+> `standard_place`** in the data formats (`SimplifiedFact`, research.json) —
+> see §2. The `place_search` result struct is
+> `{ standardPlace, type, dateRange?, coords, links }`.
+
+---
+
+## 0. Shape probe (informational — no longer a gate)
+
+The hybrid populate strategy (§1.1) does **not** depend on `normalized`
+being present: when it's missing we standardize via `place_search`. So this
+is a quick shape check, not a go/no-go gate.
+
+- Write `mcp-server/dev/probe-place-normalized.ts`: call live `person_read`
+  and `record_read` for a record with a standardized place and capture the
+  **raw** fact `place` block. Confirm the field shape we'll read —
+  `place.normalized` as `[{ value, lang? }]` (GedcomX `TextValue[]`) — and
+  note how often it's present and in what locale.
+- Regardless of the result, add `Accept-Language: en` to the
+  person_read/record_read fetch headers as cheap insurance so the normalized
+  values trend English (the user has accepted residual locale fragility).
+
+Context: `person-read-tool-spec.md:291,310,509` models `fact.place` as only
+`{ original }` and `gedcomx-convert-spec.md:84` as `{ original?, description? }`
+— neither models `normalized`, so the type widening in §5.1 is required
+regardless. The only repo mention of `.normalized`
+(`person-search-tool-spec.md:370-376`, a different endpoint) flags locale
+sensitivity, which the user has accepted.
+
+---
+
+## 1. Decisions locked (user, 2026-06-05)
+
+1. **Populate source — in the converter path, dedup + parallelism.**
+   `standard_place` = `place.normalized` when present (pure, in
+   `toSimplified`; locale accepted, `Accept-Language: en` insurance), **else
+   resolved via `place_search`** in an async document-level standardization
+   pass (`toSimplifiedStandardized`) that **dedups** distinct place strings
+   and resolves them **≤8 in parallel**, best-effort. This runs on *every*
+   converter path — including the workhorse `record_search` — so the LLM
+   always sees a `standard_place`. Network calls in the converter path are
+   explicitly accepted (the converter module owns them; `simplifyFact` stays
+   pure). Unresolvable → omit (never guess). See §5.
+2. **Rollout — one coordinated effort.** Shared name↔ID resolver + tool
+   input migration + converter change + skill rewrites + schema change land
+   together, fixing the pre-existing `place_search` drift in the same pass.
+   **Unit of change = each place tool *plus* the skills that call it,
+   migrated atomically** (see §12) — so no intermediate commit strands a
+   skill against a changed tool contract.
+3. **research.json — replace `place_id` with `standard_place`.** Drop
+   `timelines[].events[].place_id`; store `standard_place`. `place_distance`
+   accepts `standard_place` names and resolves to lat/long internally.
+   Matches the prior `jurisdiction_place_id → jurisdiction` decision
+   (`research-schema-spec.md:1438`); the schema is unversioned, so the
+   break is acceptable.
+
+---
+
+## 2. The place model (ground truth)
+
+| Term | Meaning | FS identity | Resolves via |
+|------|---------|-------------|--------------|
+| **`standard_place`** | Fully-qualified standardized place NAME, e.g. `"Branch Township, Schuylkill, Pennsylvania, United States"` | == `SimplifiedPlaceResult.fullName` | 1:1 with a **placeRepId** |
+| **`placeRepId`** | One time-qualified representation | FS "rep" id | `getPlaceById(repId)` → `/platform/places/description/{repId}` → fullName + coords |
+| **`placeId`** | A spot on earth (FS "Primary" id) | `extractPrimaryId(...)` | `getPlaceByPrimaryId(placeId)` → `/platform/places/{placeId}` → coords; `getPlaceRepIds(placeId)` → all repIds |
+
+Two endpoints, two id-types — do **not** conflate: `getPlaceById` takes a
+**repId** (`/description/{id}`), `getPlaceByPrimaryId` takes a **placeId**
+(`/{id}`). Both return coords. `searchPlace(name)` also returns coords per
+entry, so a name→coords path needs no second fetch.
+
+Key consequence: **`standard_place` is the 1:1 partner of `placeRepId`, not
+`placeId`.** `placeId` only matters when a tool must enumerate *all* of a
+spot's representations over time.
+
+Uniqueness caveat: `fullName` is **not guaranteed globally unique** — two
+reps at different dates can share a `fullName` (differ only by `dateRange`),
+and in principle two distinct `placeId`s could too. See §11 (resolution
+policy + null-on-ambiguity).
+
+**Naming convention (`standardPlace` vs `standard_place`).** The string
+value is identical; only the key casing differs by surface:
+- **camelCase `standardPlace`** in all *code* surfaces — the `place_search`
+  output struct (cf. `fullName`/`dateRange`), every tool **input** param
+  (cf. `placeName`/`placeId`/`birthPlace`), and internal TS (resolver fns,
+  helpers).
+- **snake_case `standard_place`** only in the two snake_case *data formats* —
+  the `SimplifiedFact` field (cf. its sibling `standard_date`) and
+  research.json (cf. `place_id`/`distance_from_previous_km`).
+(The per-skill table in §7 uses the concept loosely; map each mention to
+the surface above.)
+
+---
+
+## 3. Answer: "do we still need placeIds at all?"
+
+**Above the tool layer (skills, SimplifiedGedcomX, research.json): No.**
+Everything becomes `standard_place` names.
+
+**Inside the server: yes, but only as private plumbing behind the shared
+resolver.** Two irreducible survivors for `placeId` itself:
+
+- **`place_search_all`** — `placeId` groups the many `placeRepId`s one spot
+  has had over time; no FS endpoint maps a name/repId → all sibling reps
+  directly (`place-search.ts:507-512`, `getPlaceRepIds`).
+- **`place_population`** — the **external** Pop Stats sidecar is
+  `place_id`-keyed and re-emits `place_id` in its response
+  (`types/place-population.ts:36,43`; the outbound param is built at
+  `place-population.ts:19`).
+
+`placeRepId` also survives internally as the key for `metadata_search`'s
+RMS coverage query (`placeIdToRepIds` → `coverage.placeRepIds`),
+`getPlaceWikipediaUrl`'s ws-ui attributes endpoint
+(`place-search.ts:256`), and `getPlaceById`.
+
+`place_distance` and `wiki_country_*` currently take an ID but do **not**
+need one — distance needs only lat/long (already in `place_search` output),
+and the wiki tools use the ID only to derive a NAME, which `standard_place`
+already is.
+
+---
+
+## 4. Architecture — the shared place resolver (bidirectional cache)
+
+Create `mcp-server/src/utils/place-resolver.ts`, the single home for
+name↔ID conversion, **consolidating** today's scattered + duplicated
+helpers (all currently in `place-search.ts`):
+
+- `placeIdToRepIds(placeId, token)` → `number[]` (auth) — `:33-68`
+- `getPlaceRepIds(pid)` → `string[]` (no-auth) — `:391-414`
+- `getPlaceById(repId)` (repId; `/description/{id}`) — `:198-233`
+- `getPlaceByPrimaryId(placeId)` (placeId; `/{id}`) — `:156-192`
+- `extractPrimaryId(identifiers)` — `:96-104`
+- `searchPlace(name)` (returns placeId + repId + fullName + coords) — `:111-149`
+
+The two `…ToRepIds` functions hit the **identical** endpoint and differ
+only in auth + return type. **Cache-safety / auth note (verified):** every
+`/platform/places` endpoint is anonymous (`place-search.ts:389`), so the
+merged resolver can drop the token; this does **not** weaken
+`metadata_search`'s own `getValidToken()` gate, which stays at the tool
+boundary (`metadata-search.ts:167`). Because all cached results come from
+anonymous endpoints, process-wide `Map`s carry **no** user-scoped data and
+are safe to share across users (same as today's `placeSearchCache`).
+
+Public API (memoized in-process `Map`s, no TTL — mirrors `placeSearchCache`):
+
+```
+standardPlaceToRepId(name, {date?, contextName?}): Promise<string | null>   // 1:1
+repIdToStandardPlace(repId): Promise<string | null>                         // 1:1, cheap
+standardPlaceToPlaceId(name, {date?, contextName?}): Promise<string | null> // null if candidates disagree on placeId (§11)
+placeIdToRepIds(placeId): Promise<string[]>                                 // 1:N, anonymous
+standardPlaceToCoords(name, {...}): Promise<{lat,long} | null>              // straight from the search entry — no 2nd fetch
+resolveStandardPlace(originalText, {contextName?}): Promise<string | null>  // free text → standardPlace; transient failures retried ≤3× (backoff+jitter); only definitive 0-candidate nulls cached
+```
+
+(The document-level dedup + ≤8-way parallel standardization pass that calls
+`resolveStandardPlace` lives in the **converter module**, §5 — not here. A
+small `mapWithConcurrency(items, 8, fn)` helper in `utils/` bounds it.)
+
+Cache shape — four `Map`s, filled opportunistically:
+- `originalText → standardPlace | null` (standardization cache; caches **definitive 0-candidate negatives** only — transient retry-exhausted failures are NOT cached, so they retry on a later call)
+- `name → repId` (1:1, with the §11 tie-break)
+- `repId → {standardPlace, placeId, lat, long}` (from `getPlaceById`)
+- `placeId → repId[]` (1:N, from `getPlaceRepIds`)
+
+The **persisted `standard_place` strings** in `research.json` /
+`tree.gedcomx.json` are the real cross-session "cache": skills never
+re-resolve because the name is already stored.
+
+`place-search.ts` keeps the tool entry points (`placeSearchTool`,
+`placeSearchAllTool`) but delegates the raw fetchers to `place-resolver.ts`
+(CLAUDE.md: extend, don't parallel-copy). Update CLAUDE.md's place-helper
+note accordingly (it currently locates these in `place-search.ts`).
+
+---
+
+## 5. Populating `standard_place` — in the converter path, dedup + ≤8 parallel
+
+Standardization happens **in the converter path** so *every* tool that runs
+GedcomX through it returns standardized places automatically — the workhorse
+`record_search`/`person_search` plus `person_read`/`record_read`/
+`person_ancestors`. The LLM can then always reason about a `standard_place`,
+exactly as it does about `standard_date`. Network calls in the converter
+path are accepted (the user's call).
+
+**Why a document-level pass, not inside `simplifyFact`:** dedup must see all
+facts at once ("Ky" ×10 → one resolution), which a per-fact function can't.
+
+1. **Type** — extend the raw model (`types/gedcomx.ts:45`) with
+   `normalized?: { value: string; lang? }[]`; add `standard_place?: string`
+   to `SimplifiedFact` (`types/gedcomx.ts:120-129`). (Raw type lacks
+   `normalized` today — compile-time only; it survives at runtime because
+   `person-read.ts:215-219` / `record-read.ts:94` pass un-whitelisted bodies.)
+2. **Cheap path — pure `toSimplified` (purity unchanged).** In `simplifyFact`
+   (`gedcomx-convert.ts:264-266`), after `out.place = fact.place.original`,
+   set `out.standard_place` from `place.normalized` when present (prefer
+   `lang === "en"`, else first). No network. `Accept-Language: en` on reads
+   as insurance. **Existing pure-converter tests stay green.**
+3. **`toSimplifiedStandardized(gedcomx)` (async, same module).** Calls
+   `toSimplified`, then runs **one document-level standardization pass**, and
+   returns the result. Tools call this instead of bare `toSimplified`; the
+   pure version remains for callers that want no I/O (`merge_gedcomx`,
+   validation).
+4. **The pass — `standardizePlaces(facts[])`:**
+   - Collect every fact with `place` but no `standard_place` — for the search
+     tools, pass the **flattened** fact set across the whole response so
+     dedup spans records.
+   - **Dedup** by normalized key (`original.trim().toLowerCase()`,
+     whitespace-collapsed); map one resolution back to all facts sharing it.
+   - Resolve distinct keys **≤8 at a time** (`mapWithConcurrency`, §4) via
+     `resolveStandardPlace`.
+   - Write `standard_place` back; on null/ambiguous/error **leave it empty**.
+5. **Date isn't needed here.** We populate the *name* (stable), not a repId,
+   so dedup-by-name is safe even across facts with different dates.
+   Date-aware repId resolution stays in the consuming tools (§11). (v1
+   simplification: bulk standardization is date-agnostic.)
+6. **Robustness — network is now in the search hot path:** the pass is
+   strictly **best-effort and never throws**. Each `resolveStandardPlace`
+   call **retries transient failures (network / 429 / 5xx) with exponential
+   backoff + jitter, up to 3 attempts** (a shared `fetchWithRetry`); a
+   0-candidate result is definitive (no retry). On retry-exhaustion /
+   ambiguous / error the fact keeps an empty `standard_place` (snake — it is
+   the `SimplifiedFact` field) and the other places proceed. **Negative-cache only definitive 0-candidate results —
+   never transient failures** (so a network blip doesn't poison the cache).
+   **Soft cap** distinct places per call (~50) and `log()` overflow — no
+   silent truncation. The process cache + persisted names keep steady-state
+   well under the cap. Idempotent: only fills empty values.
+7. **`expandFact`** (`gedcomx-convert.ts:506`): `standard_place` is a
+   simplified-only sidecar — **dropped on `toGedcomX`**, like `standard_date`
+   (`gedcomx-convert.ts:505`).
+8. **Locally-authored facts** (init-project, record-extraction, tree-edit,
+   timeline) bypass the converter — skills fill `standard_place` via the
+   `place_search` tool at author time (§7). Cross-session: once written into
+   `tree.gedcomx.json` / results sidecars, names are never re-resolved.
+
+Spec updates: `simplified-gedcomx-spec.md` (facts table + sidecar rule),
+`gedcomx-convert-spec.md` (Rule 7 + `SimplifiedFact` type + the new async
+`toSimplifiedStandardized` contract + test 13).
+
+---
+
+## 6. Tool input migrations (LLM boundary → `standard_place` names)
+
+Every tool below changes its **LLM-facing** input from an ID to a
+`standard_place` name, resolving internally via §4. Internal/upstream IDs
+are unchanged.
+
+| Tool | Today (LLM input) | After | Internal resolution | placeId still needed? |
+|------|-------------------|-------|---------------------|-----------------------|
+| `metadata_search` | `placeId` (required) | `standardPlace` | `standardPlaceToPlaceId` (null-on-disagreement, §11) → `placeIdToRepIds` → `coverage.placeRepIds` | placeId internal only |
+| `place_population` | `placeId` | `standardPlace` | `standardPlaceToPlaceId` → Pop Stats `place_id` | **yes** (external sidecar) |
+| `place_external_links` | `placeId` | `standardPlace` | `standardPlaceToPlaceId` → `q.placeId` | yes (FS external endpoint) |
+| `place_distance` | `placeId1`,`placeId2` | `standardPlace1`,`standardPlace2` | `standardPlaceToCoords` (coords straight from search entry) → haversine | no |
+| `wiki_country_*` (×4) | `placeId` | `standardPlace` (or simple place name) | name → candidate wiki slugs (keep multi-variant slug search) | no |
+| `place_collections` | `query` (name) ✓ + `placeIds` | `query` unchanged; **deprecate `placeIds`** | n/a (already name-based) | n/a — different id space |
+
+Plus an **output** change: `place_search` / `place_search_all` **always and
+only return standard places**. Each result is the struct
+`{ standardPlace, type, dateRange?, latitude?, longitude?, familysearchUrl, wikipediaUrl? }`
+— `standardPlace` (camel) is the canonical handle (== today's `fullName`);
+the rest is metadata. `place_search` is the **single standardizer** that both
+the converter pass (§5) and the skills call.
+
+Notes:
+- **`metadata_search`** keeps today's "coverage across all temporal reps"
+  behavior: skills pass **one** `standardPlace`; the tool recovers the
+  parent `placeId` and fans out to **all** repIds. The risk (review): if a
+  fullName re-resolves to a *different* placeId than the user meant, fan-out
+  shifts silently. Mitigation: `standardPlaceToPlaceId` returns **null when
+  surviving candidates disagree on `placeId`** (§11), and the tool surfaces
+  an LLM-actionable error rather than guessing. Query echo changes
+  `{ placeId }` → `{ standardPlace }` (`metadata-search.ts:200-202`,
+  `types/metadata-search.ts:87-97`).
+- **`place_distance`**: coords come straight from the resolved search entry
+  (`searchPlace` returns `latitude`/`longitude` per entry,
+  `place-search.ts:142-143`) — no second description fetch. Failure mode the
+  schema requires: if **either** `standardPlace` is unresolvable or lacks
+  coords, return `null` (`distance_from_previous_km` null,
+  `research-schema-spec.md:464`).
+- **`place_collections.placeIds`** is a **third** id space (Alabama=33, not
+  the Places API placeId — `place-collections.ts:305`). No skill passes it
+  (verified: grep of `plugin/` for `placeIds` is empty), so removing it from
+  the LLM schema is safe; also drop the opaque `Collection.placeIds` from
+  output. Primary path already takes `query` = a name.
+- Tools that re-emit an ID in output (`place_population`'s `place.place_id`,
+  `distance`'s `placeId1/2` echo) drop or translate it to the
+  `standard_place` name.
+- **`types/place.ts:74-75`** comments ("pass to downstream tools") go stale —
+  update them.
+
+---
+
+## 7. Skill rewrites (fix drift + adopt standard_place)
+
+The skills are **already broken** and must be repaired in this pass:
+- Every skill calls `place_search({ query })` — the real param is
+  `{ placeName, contextName }`. Fix all call sites.
+- 6 skills tell Claude to pull a `placeId` out of `place_search` and pass it
+  downstream — impossible since the tool returns ID-free output.
+- No skill knows `place_search_all` exists.
+
+**The handle + selection rule (review blocker fix).** `place_search`
+returns an **array**, and two results can share a name. So skills get an
+explicit rule, stated once in the canonical reference block and the
+place_search spec: *"`place_search` returns a `standardPlace` field on each
+result. Pick the best/first matching result and pass its `standardPlace`
+verbatim to every downstream tool."* This requires the §6 output change (add
+`standardPlace` to `SimplifiedPlaceResult`).
+
+Per-skill work:
+
+| Skill | Changes |
+|-------|---------|
+| `locality-guide` | `query`→`placeName`; placeId→`standard_place` for place_population / wiki_country_* / place_external_links; add `place_search_all` |
+| `research-plan` | `query`→`placeName`; placeId→`standard_place`; **fix stale `image_search({ placeId })`** (now takes `imageGroupNumber`); add `place_search_all` |
+| `search-external-sites` | rewrite "placeId … get it from place_search" → "pass the `standard_place` from place_search" |
+| `historical-context` | add `place_search`/`place_search_all` to allowed-tools; placeId→`standard_place` for place_population |
+| `timeline` | `place_search`→`standard_place` on events (replaces `place_id`); `place_distance` with two `standard_place` names |
+| `conflict-resolution` | resolve location → `standard_place` (not placeId) → `place_distance` |
+| `record-extraction` | optionally write `standard_place` companion alongside free-text `place` |
+| `tree-edit` | when correcting `facts[].place`, optionally fill `standard_place` |
+| `init-project` | seeds `facts[].place` — leave free-text; standard_place optional |
+| `gps-mentor` (agent) | geographic-plausibility path: `place_search`→`standard_place`→`place_distance` |
+
+**Out of scope (don't let the §12 sweep rewrite these):**
+`search-records/references/place-date-mechanics.md:40` documents the raw FS
+`f.*Place` filter format `{parent_place_id},{place_name}` — a separate,
+currently-unexposed API id-space, **not** a `standard_place` handle. Leave
+as-is.
+
+**Reference-doc rule:** per CLAUDE.md, shared guidance is **duplicated**,
+not linked. Author one canonical "places & standard_place" guidance block
+(the handle + selection rule + place_search vs place_search_all) and copy it
+into each skill's `references/`. Add a drift lint (like the manifest test).
+Model the write-companion pattern on `convert-dates`.
+
+---
+
+## 8. Persisted schema (research.json) — narrow blast radius
+
+The only persisted `place_id` is the schema definition itself + its mirrors.
+**No scenario or tree fixture currently contains `place_id` or
+`standard_place`** (verified: grep of `eval/fixtures/` and all
+`tree.gedcomx.json` is empty) — so there is **no fixture data migration**;
+new `standard_place` fixtures are authored only for new tests.
+
+Update sites:
+- `docs/specs/schemas/research.schema.json` — `timeline_event`: remove
+  `place_id` (line 586), add `standard_place` (string|null) next to `place`
+  (585).
+- `docs/specs/research-schema-spec.md` — replace the `place_id` row (461)
+  with `standard_place`; update `distance_from_previous_km` derivation (464)
+  to key off `standard_place` equality + name resolution.
+- `mcp-server/src/validation/validator.ts` — `NULLABLE_FIELDS` (225-226):
+  add `standard_place`, drop `place_id`.
+- **`eval/app/components/scenario/lib/schema.ts:242`** — `TimelineEvent.place_id`
+  → `standard_place` (the eval CRUD app's independent TS schema mirror; the
+  renderer `TimelinesSection.tsx:115` only reads `event.place`, so it's
+  safe, but the interface must change). *(This is the 4th mirror the memory
+  note `research-schema-required-field-update-sites` warns about.)*
+- eval-side Python stubs that declare the timeline-event shape — migrate
+  `place_id` → `standard_place`.
+
+Note: existing eval run-log snapshots will be invalidated by the
+converter/tool changes (expected; `eval/CLAUDE.md` snapshot model tracks
+`mcp-server/src/**`). Re-record as part of §10.
+
+---
+
+## 9. Specs & docs to update (source of truth for spec-review)
+
+- `place-search-tool-spec.md`, `place-search-all-tool-spec.md` — fulfill the
+  "later phase" promise; document the `standardPlace` output struct (==
+  `fullName`) + selection rule.
+- `simplified-gedcomx-spec.md`, `gedcomx-convert-spec.md` — `standard_place`
+  field + sidecar rule + test 13.
+- `metadata-search-tool-spec.md`, `place-population-tool-spec.md`,
+  `place-external-links-tool-spec.md`, `place-collections-tool-spec.md`
+  (documents `placeIds` across ~15 sites), `2026-05-07-timeline-distances-design.md`
+  (distance) — input-contract changes.
+- `gps-mentor-agent-spec.md` (lists `place_search`/`place_distance` in
+  allowed-tools + usage, `:108-109,222,616`) — tool-usage guidance.
+- **Testing guides** (CLAUDE.md verify-before-ship playbooks):
+  `docs/testing-guides/place-population-tool-testing-guide.md`,
+  `place-external-links-tool-testing-guide.md`,
+  `place-collections-tool-testing-guide.md` all teach passing a `placeId` —
+  rewrite to `standard_place`.
+- `research-schema-spec.md` (+ schema + validator + eval TS schema) — §8.
+- `types/place.ts` (stale `:74-75` comments), `CLAUDE.md` (place-helper
+  location).
+- **There is no `wiki_country` tool spec** (only the source
+  `wiki-country-page.ts` + its test) — do not list one.
+
+---
+
+## 10. Tests
+
+- `gedcomx-convert.test.ts` — `normalized` present → `standard_place` (prefer
+  en, else first); absent → left empty by pure `toSimplified`; dropped on
+  `toGedcomX`.
+- New `place-resolver.test.ts` — `resolveStandardPlace` (free text →
+  standard_place), result + **negative caching**, bidirectional cache hits,
+  §11 tie-break, ambiguous/0/many, **null-on-placeId-disagreement**, 404 → null.
+- Converter standardization pass (`toSimplifiedStandardized`) — **dedups**
+  duplicate place strings to one resolution, resolves **≤8 in parallel** (mock
+  resolver), fills empties, leaves unresolved empty, **never throws** on
+  resolver error, honors the soft cap + logs overflow. Assert a multi-record
+  `record_search` response standardizes each distinct place exactly once.
+- Per-tool tests (`metadata-search`, `place-population`,
+  `place-external-links`, `distance`, `wiki-country-page`,
+  `place-collections`) — name input → internal resolution; update fixtures.
+  Add a `metadata_search` test for a name that resolves to **multiple
+  placeIds** to prove coverage equals the old placeId path (or errors).
+- `manifest.test.ts` / tool-schemas drift.
+- **Fixture cleanup:** remove/replace
+  `eval/fixtures/mcp/image-search-edensor-place.json` (its `placeId` arg
+  predicate no longer matches the rewritten `image_search`) and re-record
+  invalidated run-log snapshots.
+
+---
+
+## 11. Resolution policy (the genuine design risk)
+
+`standardPlaceToRepId` / `standardPlaceToPlaceId` are inherently
+**ambiguous** searches. v1 policy:
+
+1. Exact case-insensitive `fullName` match among `searchPlace` candidates;
+   if multiple, take the highest `score`.
+2. **Date hint** (facts/events carry dates): when provided, prefer the rep
+   whose `temporalDescription.formal` covers the date — the
+   genealogically-correct tie-break (boundaries change). Thread the date
+   through from the start.
+3. **Null on disagreement:** for `standardPlaceToPlaceId`, if surviving
+   candidates disagree on `placeId`, return `null` (don't silently pick one)
+   — this guards `metadata_search` / `place_population` fan-out. 0 candidates
+   → `null`. The tool surfaces an LLM-actionable "couldn't resolve
+   <standard_place>; try place_search" error.
+4. **Locale:** the resolver searches by English fullName, so a non-en
+   `standard_place` (from a non-en `normalized` value the user opted to
+   accept) may resolve to `null` when a tool later needs its repId. Mitigated
+   by `Accept-Language: en` on reads (§5.2) so normalized trends English; not
+   treated as a hard error.
+
+Deferred (note, don't build): encoding date/dateRange into the
+`standard_place` token to make name↔repId provably 1:1. v1 keeps the name as
+the key + date as a resolution hint.
+
+---
+
+## 12. Sequenced work (one coordinated effort, atomic units)
+
+0. **Shape probe (§0, informational).** Confirm `place.normalized` shape +
+   add `Accept-Language: en`. Does **not** block §5 (the hybrid standardizes
+   via `place_search` when normalized is absent).
+1. **Resolver foundation** — ✅ **DONE** (`mcp-server/src/utils/place-resolver.ts`
+   + `tests/utils/place-resolver.test.ts`, 18 tests; full suite 789 green,
+   tsc clean). Public fns (`resolveStandardPlace`, `standardPlaceToRepId`,
+   `repIdToStandardPlace`, `standardPlaceToPlaceId`, `standardPlaceToCoords`,
+   `placeIdToRepIds`) + `withRetry` (≤3, backoff+jitter) + `mapWithConcurrency`
+   + caches (4 + an internal search memo) + §11 tie-break + null-on-disagreement
+   + negative-cache (definitive-0 only). *Deviation:* kept it a pure addition —
+   it **imports** the existing `searchPlace`/`getPlaceById`/`getPlaceRepIds`
+   from `place-search.ts` rather than moving them; the fetcher consolidation
+   (move down + place-search delegation, incl. `getPlaceByPrimaryId`) is a
+   later step (TODO noted in the module header). No contract changes.
+2. **`place_search` output** — ✅ **DONE**. `SimplifiedPlaceResult.fullName`
+   renamed → `standardPlace` (`types/place.ts`, `simplifyPlaceResult`,
+   schema descriptions, tests). `place_search`/`place_search_all` now return
+   `{ standardPlace, type, dateRange?, lat?, long?, links }`.
+3. **Converter + standardization pass** — ✅ **DONE**.
+   `types/gedcomx.ts`: `GedcomXFact.place.normalized` + `SimplifiedFact.standard_place`.
+   `gedcomx-convert.ts`: `simplifyFact` reads `normalized` (pure, prefer en);
+   `standardizePlaces` (dedup + ≤8 parallel + soft-cap-50 + best-effort) +
+   `collectFacts` + async `toSimplifiedStandardized`. Wired: `person_read`,
+   `record_read`, `person_ancestors` → `toSimplifiedStandardized`;
+   `record_search`/`person_search` → one `standardizePlaces` over all entries
+   (cross-record dedup). `Accept-Language: en` on `person_read`/`record_read`.
+   Tests: `gedcomx-standardize.test.ts` (10) + resolver stub in the 5 tool
+   tests. Full suite 799 green. *Follow-ups:* `Accept-Language: en` on
+   `person_ancestors`/search fetches (optional; locale fragility accepted);
+   spec sync (below).
+4. **Per place tool, ATOMIC with its skills:** for each of `metadata_search`,
+   `place_population`, `place_external_links`, `place_distance`,
+   `wiki_country_*`, `place_collections` — migrate the tool schema **and**
+   rewrite every skill/agent that calls it **in the same commit**, plus that
+   tool's spec + testing guide + tests. This is the unit that keeps the
+   system runnable at every commit. (Fixing the `place_search({ query })`
+   drift happens here too, per tool's callers.)
+5. **Schema** — research.json `place_id` → `standard_place` (§8): schema +
+   spec + validator + eval TS mirror + Python stubs.
+6. **Sweep** — repo-wide grep for residual `placeId`/`placeRepId`/`place_id`
+   in skills, specs, fixtures; run `spec-review` on every touched tool;
+   manifest drift test. Leave the documented out-of-scope id-spaces alone
+   (`place-date-mechanics.md` `{parent_place_id}`, `place_collections`
+   internal placeIds).
+
+---
+
+## Appendix — primary evidence (file:line)
+
+- Converter drops `description`, keeps only `original`: `gedcomx-convert.ts:264-266,506`
+- `standard_date` sidecar precedent: `gedcomx-convert.ts:505`, `simplified-gedcomx-spec.md:183`
+- Read-endpoint place modeled as `{original}` only (premise risk): `person-read-tool-spec.md:291,310,509`, `gedcomx-convert-spec.md:84`
+- `.normalized` is locale-sensitive, wrong-endpoint cite corrected: `person-search-tool-spec.md:370-376` (person *search*, not read)
+- Raw bodies un-whitelisted into converter (field survives at runtime if sent): `person-read.ts:215-219`, `record-read.ts:94`
+- `metadata_search` requires `placeId`, no reverse repId→placeId: `metadata-search.ts:169,235-259`, `metadata-search-tool-spec.md:134-137`
+- ID-free LLM output already shipped: `types/place.ts:90-106`, `place-search.ts:371-381`
+- `place_search_all` needs placeId to group reps: `place-search.ts:507-512`
+- Pop Stats is `place_id`-keyed (external) + re-emits it: outbound `place-population.ts:19`; response `types/place-population.ts:36,43`
+- distance uses `getPlaceByPrimaryId` (placeId), not `getPlaceById` (repId): `distance.ts:1,49-50`; endpoints `place-search.ts:157` vs `:199`
+- `searchPlace` returns coords per entry: `place-search.ts:142-143`
+- `/platform/places` is anonymous (auth-drop safe): `place-search.ts:389`
+- Persisted `place_id` (sole stored ID) + eval mirror: `research.schema.json:585-586`, `research-schema-spec.md:461,464`, `validator.ts:225`, `eval/app/components/scenario/lib/schema.ts:242`
+- No fixtures carry `place_id` (migration is a no-op): grep `eval/fixtures/` empty
+- Skills broken (`query` param + expect stripped placeId): `locality-guide:84`, `research-plan:124,127`, `timeline:129`, `search-external-sites:125`, `historical-context:90`
+- `place_collections.placeIds` separate id-space, unused by skills: `place-collections.ts:305`, grep `plugin/` empty
+- Prior "drop place IDs for human-readable" decision: `research-schema-spec.md:1438`
+- This task scoped out of id-vocabulary effort: `id-vocabulary-standardization-progress.md:6`

--- a/docs/plan/standard-place-standardization.md
+++ b/docs/plan/standard-place-standardization.md
@@ -567,11 +567,20 @@ the key + date as a resolution hint.
    still passed `placeId1/2`. Note: the eval run-log snapshot tracks
    `mcp-server/src/**`, so the validator change invalidates existing snapshots
    (eval re-record is a separate eval-team task).
-6. **Sweep** — repo-wide grep for residual `placeId`/`placeRepId`/`place_id`
-   in skills, specs, fixtures; run `spec-review` on every touched tool;
-   manifest drift test. Leave the documented out-of-scope id-spaces alone
-   (`place-date-mechanics.md` `{parent_place_id}`, `place_collections`
-   internal placeIds).
+6. **Sweep** — ✅ **DONE**. Verified **no LLM-facing `placeId` input remains**
+   in any tool schema (the lone hit is prose in `metadata_search`'s
+   description). Fixed the last stale skill call (`research-plan`'s
+   `image_search({ placeId })` → `imageGroupNumber`). Manifest drift test
+   green; `spec-review` run on the 4 specced tools. Confirmed out-of-scope
+   id-spaces left alone: `place-date-mechanics.md` / `docs/gps/record-search.md`
+   `{parent_place_id}` (record_search `f.*Place` filter), `place_collections`
+   upstream `searchMetadata.placeIds`, and Pop Stats / `q.placeId` internals.
+   **Eval re-record needed (eval-team):** `eval/fixtures/mcp/place-search-*.json`
+   mock the old place_search shape (`fullName` → should be `standardPlace`,
+   plus pre-existing `name`-arg / `placeId` staleness) and
+   `image-search-*.json` carry stale `placeId` arg predicates; and the
+   `validator.ts` change already invalidated runlog snapshots (mcp-server/src/**
+   is snapshotted). These are eval-corpus items, not code.
 
 ---
 

--- a/docs/plan/standard-place-standardization.md
+++ b/docs/plan/standard-place-standardization.md
@@ -1,7 +1,16 @@
 # Standard-place standardization — implementation plan
 
-**Status:** Draft v5 (2026-06-05) — added retry/backoff for standardization;
-locked the `standardPlace`(code) / `standard_place`(data) naming split.
+**Status:** ✅ **IMPLEMENTED** (2026-06-05) — Steps 1–6 complete on branch
+`standard-place-resolver` (12 commits), plus spec-review + a multi-agent
+code-review (all CONFIRMED findings fixed) and the residual-prose doc cleanup.
+tsc clean; 806 tests green; no LLM-facing `placeId` remains. Remaining:
+eval-corpus re-record (mock fixtures + runlog snapshots — eval-team), and the
+optional `place-search.ts` fetcher consolidation (Step 1 deferral). History
+below was the design trail (v1 → v5).
+
+**Status (design trail):** Draft v5 (2026-06-05) — added retry/backoff for
+standardization; locked the `standardPlace`(code) / `standard_place`(data)
+naming split.
 **Scope:** Make `standard_place` (a fully-qualified standardized place
 NAME) the only place vocabulary above the MCP tool layer — in skills, in
 SimplifiedGedcomX, and in persisted research artifacts. Keep `placeId` /

--- a/docs/specs/2026-05-07-timeline-distances-design.md
+++ b/docs/specs/2026-05-07-timeline-distances-design.md
@@ -52,12 +52,19 @@ gaps).
 **Phase 2 — Compute distances:**
 
 1. Walk events in chronological order as consecutive pairs.
-2. For each pair where both events have a non-null `place_id`:
-   - If the two `place_id` values are the same, set
-     `distance_from_previous_km` to `0` (no API call needed).
-   - If they differ, call `place_distance` with the two IDs and write
-     the result onto the later event's `distance_from_previous_km`.
-3. Skip (leave null) when either event lacks a `place_id`.
+2. For each pair where both events have a non-null place:
+   - If both resolve to the same standard place (or the raw `place`
+     strings match), set `distance_from_previous_km` to `0` (no API call).
+   - Otherwise call `place_distance({ standardPlace1, standardPlace2 })`
+     with the two standard place names and write its `kilometers` onto the
+     later event's `distance_from_previous_km`.
+3. Skip (leave null) when either event's place is missing or unresolved.
+
+> **Note (standard-place standardization):** `place_distance` now takes
+> `standardPlace` names, not place IDs, and the timeline skill resolves
+> places to `standardPlace` transiently rather than persisting a `place_id`.
+> Replacing the persisted `place_id` event field with `standard_place` is
+> tracked as Step 5 of `docs/plan/standard-place-standardization.md`.
 
 **MCP call count:** at most (number of unique place strings) +
 (number of consecutive pairs with two distinct resolved place IDs).

--- a/docs/specs/2026-05-07-timeline-distances-design.md
+++ b/docs/specs/2026-05-07-timeline-distances-design.md
@@ -21,11 +21,12 @@ Two new optional fields on timeline events in `research.json`
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `place_id` | string or null | no | FamilySearch place ID resolved from `place` via the `place_search` tool. Null if unresolvable or `place` is null. |
-| `distance_from_previous_km` | number or null | no | Great-circle distance in km from the previous event's place. Null for the first event, or when either event lacks a resolved `place_id`. |
+| `standard_place` | string or null | no | Standardized place name (the `standardPlace` from `place_search`) for `place`. Null if unresolvable or `place` is null. |
+| `distance_from_previous_km` | number or null | no | Great-circle distance in km from the previous event's place, via `place_distance` on the two `standard_place` names. Null for the first event, or when either event lacks a resolved `standard_place`. |
 
 Both fields are additive and optional. Existing timelines without these
-fields remain valid.
+fields remain valid. (The earlier `place_id` field was replaced by
+`standard_place` in step 5 of the standard-place standardization.)
 
 ## SKILL.md Changes
 
@@ -42,11 +43,12 @@ gaps).
 **Phase 1 — Resolve places:**
 
 1. Collect all unique non-null `place` strings from the built events.
-2. For each unique place string, call the `place_search` MCP tool to resolve
-   it to a place ID.
-3. If the tool returns one or more results, use the first (best) match
-   and write its `place_id` onto all events sharing that place string.
-4. If it returns no results, leave `place_id` null. Do not retry or
+2. For each unique place string, call the `place_search` MCP tool to
+   standardize it.
+3. If the tool returns one or more results, use the first (best) match's
+   `standardPlace` field and write it as `standard_place` onto all events
+   sharing that place string.
+4. If it returns no results, leave `standard_place` null. Do not retry or
    error.
 
 **Phase 2 — Compute distances:**

--- a/docs/specs/gedcomx-convert-spec.md
+++ b/docs/specs/gedcomx-convert-spec.md
@@ -164,7 +164,8 @@ export type SimplifiedFact = {
   primary?: boolean;         // Present only when GedcomX set it to true
   date?: string;             // Verbatim from GedcomX date.original
   standard_date?: string;    // GEDCOM-canonical form of `date` (set by toSimplified when parseable)
-  place?: string;
+  place?: string;            // Verbatim from GedcomX place.original
+  standard_place?: string;   // Standardized place name (snake_case form of standardPlace). See Rule 7.
   sources?: SimplifiedSourceReference[];
 };
 
@@ -351,12 +352,29 @@ equivalent.
 ### 7. Places on facts
 
 ```
-{ "original": "Denver, Colorado, USA", "description": "#place1" }  →  "Denver, Colorado, USA"
+{ "original": "Denver, Colorado, USA", "description": "#place1" }  →  place: "Denver, Colorado, USA"
+{ "original": "Denver", "normalized": [{ "value": "Denver, Colorado, United States", "lang": "en" }] }
+                                                  →  place: "Denver", standard_place: "Denver, Colorado, United States"
 ```
 
-The `description` reference is dropped; richer place data lives in the
-top-level `places[]` array (Rule 12). `toGedcomX` writes
-`{ original: placeString }` with no `description`.
+`place` is `place.original` verbatim. `standard_place` is the standardized
+name: `toSimplified` (pure) takes it from `place.normalized` — preferring the
+`lang === "en"` entry, else the first. The `description` reference is dropped;
+richer place data lives in the top-level `places[]` array (Rule 12).
+
+`standard_place` is a simplified-format-only sidecar (like `standard_date`):
+`toGedcomX` writes only `{ original: placeString }` and ignores
+`standard_place` on the reverse path.
+
+Free-text places with no `normalized` value are left without a
+`standard_place` by the pure converter. The async wrapper
+`toSimplifiedStandardized` fills them by resolving `place` through
+`place_search` (network) — deduping identical strings, resolving ≤8 in
+parallel, best-effort (never throws, leaves the field empty on failure). Tools
+that return facts to the model call `toSimplifiedStandardized` (single doc) or
+run `standardizePlaces` over the flattened facts of a multi-result response
+(`record_search` / `person_search`). The pure `toSimplified` remains for
+callers that want no I/O.
 
 ### 7.5 `value` on facts
 

--- a/docs/specs/metadata-search-tool-spec.md
+++ b/docs/specs/metadata-search-tool-spec.md
@@ -100,7 +100,7 @@ in the existing `placeIdToRepIds` helper.
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `placeId` | string | **Yes** | FamilySearch place ID — the same `placeId` returned by `place_search`. The tool internally converts it to one or more `placeRepId`s via the places API. |
+| `standardPlace` | string | **Yes** | Standard place name (the `standardPlace` field from `place_search`). The tool resolves it to a `placeId` and then to one or more `placeRepId`s internally (via `standardPlaceToPlaceId` → `placeIdToRepIds`). |
 | `fromDate` | string | No | Start of date range, `YYYY-MM-DD` (e.g., `"1730-01-01"`). |
 | `toDate` | string | No | End of date range, `YYYY-MM-DD` (e.g., `"1810-12-31"`). |
 | `pageToken` | string | No | Opaque pagination cursor. Pass back the `nextPageToken` from a previous response to fetch the next page. **Must be sent together with the same `placeId`/`fromDate`/`toDate`** that produced it (see [Pagination](#pagination)). |
@@ -285,7 +285,7 @@ on the full `groupName` is exact — no prefix fallback is needed.
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `query` | object | Echo of input (`placeId`, `fromDate?`, `toDate?`) |
+| `query` | object | Echo of input (`standardPlace`, `fromDate?`, `toDate?`) |
 | `totalGroups` | number | `totalCount` from the API (across all pages) |
 | `returned` | number | Groups in this page (`numberReturned`) |
 | `nextPageToken` | string? | Present only when more pages remain; pass back as `pageToken` |
@@ -318,7 +318,7 @@ on the full `groupName` is exact — no prefix fallback is needed.
 ```json
 {
   "query": {
-    "placeId": "6137147",
+    "standardPlace": "Edensor, Derbyshire, England, United Kingdom",
     "fromDate": "1730-01-01",
     "toDate": "1810-12-31"
   },
@@ -354,23 +354,24 @@ on the full `groupName` is exact — no prefix fallback is needed.
   description:
     "Search FamilySearch's Records Management Service for image groups — " +
     "digitized volumes of historical documents (microfilm rolls, book scans) — " +
-    "covering a place and date range. Provide a placeId from place_search and an " +
+    "covering a place and date range. Provide a standardPlace from place_search and an " +
     "optional date range. For each volume it returns coverage (places, dates, " +
     "record types), how much of the volume is indexed for record_search " +
     "(recordSearchablePercent), and whether it is full-text searchable " +
     "(fulltextSearchable). Use the returned imageGroupNumber with image_search to " +
     "list the volume's images, or with fulltext_search to search its text. " +
-    "Results are paginated — pass back nextPageToken (with the same placeId and " +
+    "Results are paginated — pass back nextPageToken (with the same standardPlace and " +
     "dates) as pageToken to get the next page. " +
     "Requires authentication — call the login tool first if not logged in.",
   inputSchema: {
     type: "object",
     properties: {
-      placeId: {
+      standardPlace: {
         type: "string",
         description:
-          "FamilySearch place ID from place_search. Required. The tool " +
-          "internally converts it to place representation IDs for the query.",
+          "Standard place name (the `standardPlace` field from place_search). " +
+          "Required. The tool resolves it to a placeId and its place " +
+          "representation IDs for the query.",
       },
       fromDate: {
         type: "string",
@@ -386,11 +387,11 @@ on the full `groupName` is exact — no prefix fallback is needed.
         type: "string",
         description:
           "Pagination cursor. Pass the nextPageToken from a previous " +
-          "response, together with the same placeId/fromDate/toDate, to " +
+          "response, together with the same standardPlace/fromDate/toDate, to " +
           "fetch the next page.",
       },
     },
-    required: ["placeId"],
+    required: ["standardPlace"],
   },
 }
 ```
@@ -408,9 +409,10 @@ all other authenticated tools. Do not re-implement token plumbing.
 
 | Condition | Behavior |
 |-----------|----------|
-| `placeId` not provided | Throw: `"metadata_search requires a placeId."` |
+| `standardPlace` not provided | Throw: `"metadata_search requires a standardPlace."` |
+| `standardPlace` unresolvable / ambiguous | Throw: `"Could not resolve \"<name>\" to a single place; use place_search ..."` |
 | `fromDate` or `toDate` not in `YYYY-MM-DD` format | Throw: `"fromDate must be in YYYY-MM-DD format (e.g., '1730-01-01')."` (and the `toDate` analogue) |
-| Places API returns no placeRepIds | Throw: `"No place representations found for placeId {placeId}."` |
+| Resolved place has no placeRepIds | Throw: `"No place representations found for \"{standardPlace}\"."` |
 | Not authenticated | Let `getValidToken()` throw its LLM-instruction error |
 | Group-search API returns 401 | Throw: `"FamilySearch session not accepted; call the login tool to re-authenticate."` |
 | Group-search API returns 403 | Throw: `"FamilySearch metadata search API error: 403 Forbidden."` |

--- a/docs/specs/metadata-search-tool-spec.md
+++ b/docs/specs/metadata-search-tool-spec.md
@@ -472,9 +472,20 @@ docs):
 - `nextPageToken` is **only valid with the exact same searchSpec** — the
   tool must rebuild a byte-for-byte identical body and append the token.
   Therefore the caller passes `pageToken` **together with the same
-  `placeId`/`fromDate`/`toDate`**.
+  `standardPlace`/`fromDate`/`toDate`**.
 - The token is a client-side cursor with a **~9-day TTL** (the database
   is repaired every 9 days); stale tokens may skip or duplicate rows.
+
+> **`standardPlace` re-resolution caveat (since the input is now a name, not a
+> placeId).** Each page re-resolves `standardPlace` → `placeId` → `placeRepIds`
+> to rebuild the coverage body. Within one server process this is deterministic
+> (the resolver's in-process caches memoize the lookups), so pagination is
+> byte-stable for the lifetime of a session. The only way the rebuilt body can
+> differ from the token-minting body is if the **process restarts** between
+> pages *and* the underlying FamilySearch place data shifts within the same
+> 9-day window — a rare edge. Because `standardPlace` is a canonical
+> fully-qualified name, resolution is exact-match and stable in practice; if a
+> stale cursor is ever rejected, the caller simply re-issues page 1.
 
 The tool returns **one page (≤ 100 groups) per call** plus
 `nextPageToken` when more remain. It does **not** auto-aggregate all

--- a/docs/specs/metadata-search-tool-spec.md
+++ b/docs/specs/metadata-search-tool-spec.md
@@ -68,7 +68,7 @@ groups**:
 | **Group search** | `PUT https://sg30p0.familysearch.org/service/records/rms/group-service/group/search` |
 | **Per-group child counts** | `GET https://sg30p0.familysearch.org/service/records/rms/group-service/group/{id}?include-child-count=true` |
 | **Full-text searchability** | `GET https://sg30p0.familysearch.org/service/search/fulltext/search/groupNumber?ids={comma-separated}` |
-| **placeId → placeRepIds (input conversion)** | `GET https://api.familysearch.org/platform/places/{placeId}` |
+| **standardPlace → placeId → placeRepIds (input conversion)** | Anonymous FamilySearch place lookups (place search + `GET https://api.familysearch.org/platform/places/{placeId}`), via the resolver in `src/utils/place-resolver.ts` |
 
 Note: the group search is a **PUT** request (not GET or POST).
 
@@ -85,9 +85,11 @@ full-text searchability):
 | `User-Agent` | `BROWSER_USER_AGENT` | From `src/constants.ts` — FS sits behind Imperva, which 403s non-browser UAs |
 | `FS-User-Agent-Chain` | `chesworth` | Hard-coded identifier so the FamilySearch team knows who to contact |
 
-The places API call (`api.familysearch.org`) sends only `Authorization`
-and `Accept: application/json` (it does not require the browser UA), as
-in the existing `placeIdToRepIds` helper.
+The place-resolution calls (the place search and `api.familysearch.org`
+lookups behind `standardPlaceToPlaceId` → `placeIdToRepIds`) are
+**anonymous** — they send no `Authorization` header. They run inside the
+resolver in `src/utils/place-resolver.ts`, whose underlying FamilySearch
+place fetchers all hit anonymous endpoints.
 
 > **Verify during implementation:** that the full-text searchability
 > endpoint accepts the same headers. It requires authentication; the
@@ -103,7 +105,7 @@ in the existing `placeIdToRepIds` helper.
 | `standardPlace` | string | **Yes** | Standard place name (the `standardPlace` field from `place_search`). The tool resolves it to a `placeId` and then to one or more `placeRepId`s internally (via `standardPlaceToPlaceId` → `placeIdToRepIds`). |
 | `fromDate` | string | No | Start of date range, `YYYY-MM-DD` (e.g., `"1730-01-01"`). |
 | `toDate` | string | No | End of date range, `YYYY-MM-DD` (e.g., `"1810-12-31"`). |
-| `pageToken` | string | No | Opaque pagination cursor. Pass back the `nextPageToken` from a previous response to fetch the next page. **Must be sent together with the same `placeId`/`fromDate`/`toDate`** that produced it (see [Pagination](#pagination)). |
+| `pageToken` | string | No | Opaque pagination cursor. Pass back the `nextPageToken` from a previous response to fetch the next page. **Must be sent together with the same `standardPlace`/`fromDate`/`toDate`** that produced it (see [Pagination](#pagination)). |
 
 ### Fixed fields (always sent in the group-search request body)
 
@@ -117,19 +119,26 @@ in the existing `placeIdToRepIds` helper.
 search response. Counts are fetched per group instead (see
 [Child counts sub-fetch](#child-counts-sub-fetch)).
 
-### Internal conversion: placeId → placeRepIds
+### Internal conversion: standardPlace → placeId → placeRepIds
 
-When the LLM provides a `placeId`, the tool:
+When the LLM provides a `standardPlace` name, the tool resolves it in two
+steps (both **anonymous** — no auth token is sent on these calls):
 
-1. Calls `GET https://api.familysearch.org/platform/places/{placeId}`.
-2. Extracts all `placeRepId`s (one placeId can map to multiple
+1. `standardPlaceToPlaceId(standardPlace)` resolves the name to a single
+   `placeId` via FamilySearch place search. It returns `null` when the
+   name is unresolvable or maps to multiple distinct spots (guarding the
+   fan-out).
+2. `placeIdToRepIds(placeId)` calls
+   `GET https://api.familysearch.org/platform/places/{placeId}` and
+   extracts all `placeRepId`s (one placeId can map to multiple
    placeRepIds).
-3. Passes them in a single search call via `coverage.placeRepIds` — the
-   API accepts the array natively (no fan-out or dedup needed).
+3. The tool passes them in a single search call via
+   `coverage.placeRepIds` — the API accepts the array natively (no
+   fan-out or dedup needed).
 
-This is invisible to the LLM, which only sees `placeId`. The
-`placeIdToRepIds` helper (relocated from the old `image-search.ts` to
-`src/tools/place-search.ts`, see [Files](#files)) performs this.
+This is invisible to the LLM, which only ever provides a
+`standardPlace`. Both helpers live in the shared resolver
+`src/utils/place-resolver.ts` (see [Files](#files)).
 
 > There is **no reverse `placeRepId` → `placeId` conversion** in this
 > tool. The old tool did this to populate a `placeId` in coverage
@@ -430,8 +439,9 @@ signals is more useful than a hard error.
 
 ### Pre-request
 
-1. Validate `placeId` (required) and date formats.
-2. Convert `placeId` → `placeRepIds` via `placeIdToRepIds`.
+1. Validate `standardPlace` (required) and date formats.
+2. Resolve `standardPlace` → `placeId` via `standardPlaceToPlaceId`,
+   then `placeId` → `placeRepIds` via `placeIdToRepIds` (both anonymous).
 3. Build the group-search body (fixed fields + coverage + optional
    `nextPageToken`).
 
@@ -507,14 +517,14 @@ images are digitized, indexed, or full-text processed.
 |------|--------|
 | `src/types/metadata-search.ts` | Create — input, output, and API response types |
 | `src/tools/metadata-search.ts` | Create — tool function, validation, request building, counts/full-text sub-fetches, mapping, schema export |
-| `src/tools/place-search.ts` | Modify — relocate `placeIdToRepIds` (and its `FSPlaceLookup*` types) here from the old `image-search.ts`, since `metadata_search` is now its sole consumer |
+| `src/utils/place-resolver.ts` | Use — `standardPlaceToPlaceId` and `placeIdToRepIds` (the place-name → placeId → placeRepIds resolution) live here, anonymous. The old `place-search.ts` copy of `placeIdToRepIds` was deleted; the resolver is the single home |
 | `src/tool-schemas.ts` | Add `metadataSearchSchema` to `allToolSchemas` |
 | `src/index.ts` | Wire `metadata_search` handler in `CallToolRequestSchema` |
 | `manifest.json` | Add `{ "name": "metadata_search" }` to the `tools` array |
 | `dev/try-metadata-search.ts` | Create — one-shot smoke test |
 | `tests/tools/metadata-search.test.ts` | Create — unit tests |
 | `README.md` | Add `metadata_search` to the tool catalog |
-| `CLAUDE.md` | Add `metadata_search` to the authenticated-tools list; update the code-reuse note that currently says `image-search.ts` exports `placeIdToRepIds`/`repIdToPlaceId` |
+| `CLAUDE.md` | Add `metadata_search` to the authenticated-tools list; ensure the code-reuse note points at `src/utils/place-resolver.ts` as the home of `standardPlaceToPlaceId`/`placeIdToRepIds` (not the old `image-search.ts`) |
 
 ---
 
@@ -524,10 +534,10 @@ images are digitized, indexed, or full-text processed.
 
 | # | Test case | What it verifies |
 |---|-----------|------------------|
-| 1 | Returns groups for placeId + date range | Happy path |
-| 2 | Throws when placeId is missing | Required-input validation |
+| 1 | Returns groups for standardPlace + date range | Happy path |
+| 2 | Throws when standardPlace is missing | Required-input validation |
 | 3 | Throws when fromDate/toDate is malformed | Date validation |
-| 4 | Converts placeId → placeRepIds and passes them in `coverage.placeRepIds` | Input conversion |
+| 4 | Resolves standardPlace → placeId → placeRepIds and passes them in `coverage.placeRepIds` | Input conversion |
 | 5 | Sends fixed fields `types:["NATURAL"]`, `active:true`, `pageSize:100`; omits `returnChildCounts` | Request construction |
 | 6 | Derives `imageGroupPrefix` for both bare and 3-segment `groupName`s | Prefix rule |
 | 7 | Computes `recordSearchablePercent` = round(indexed / (total − nonIndexable) × 100) | Counts math |
@@ -548,14 +558,15 @@ images are digitized, indexed, or full-text processed.
 
 ```bash
 cd mcp-server
-npx tsx dev/try-metadata-search.ts --placeId 6137147 --from 1730-01-01 --to 1810-12-31
+npx tsx dev/try-metadata-search.ts --standardPlace "Edensor, Derbyshire, England, United Kingdom" --from 1730-01-01 --to 1810-12-31
 ```
 
 > No confirmed live examples yet — verifying the live request/response
 > (including that `include-child-count` and the full-text `groupNumber`
-> endpoints behave as specced) is part of implementation. The Edensor
-> `placeId 6137147` / `1730-01-01`..`1810-12-31` query is a reasonable
-> starting fixture (it appears in `metadata-search-documentation.txt`).
+> endpoints behave as specced) is part of implementation. The
+> `standardPlace "Edensor, Derbyshire, England, United Kingdom"` /
+> `1730-01-01`..`1810-12-31` query is a reasonable starting fixture (it
+> appears in `metadata-search-documentation.txt`).
 
 ---
 

--- a/docs/specs/metadata-search-tool-spec.md
+++ b/docs/specs/metadata-search-tool-spec.md
@@ -65,8 +65,7 @@ groups**:
 
 | Purpose | Method + URL |
 |---------|--------------|
-| **Group search** | `PUT https://sg30p0.familysearch.org/service/records/rms/group-service/group/search` |
-| **Per-group child counts** | `GET https://sg30p0.familysearch.org/service/records/rms/group-service/group/{id}?include-child-count=true` |
+| **Group search** | `PUT https://sg30p0.familysearch.org/service/records/rms/group-service/group/search` (with `returnChildCounts: true`, child counts come back inline) |
 | **Full-text searchability** | `GET https://sg30p0.familysearch.org/service/search/fulltext/search/groupNumber?ids={comma-separated}` |
 | **standardPlace → placeId → placeRepIds (input conversion)** | Anonymous FamilySearch place lookups (place search + `GET https://api.familysearch.org/platform/places/{placeId}`), via the resolver in `src/utils/place-resolver.ts` |
 
@@ -74,8 +73,7 @@ Note: the group search is a **PUT** request (not GET or POST).
 
 ### Headers
 
-All `sg30p0.familysearch.org` calls (group search, child counts,
-full-text searchability):
+All `sg30p0.familysearch.org` calls (group search, full-text searchability):
 
 | Header | Value | Notes |
 |--------|-------|-------|
@@ -114,10 +112,12 @@ place fetchers all hit anonymous endpoints.
 | `types` | `["NATURAL"]` | Only query Natural Groups, for correct granularity |
 | `active` | `true` | Only return available groups |
 | `pageSize` | `100` | One page per call (see Pagination) |
+| `returnChildCounts` | `true` | Populates `childCount` / `indexedChildCount` / `noIndexableDataChildCount` **inline** on each group in the search response |
 
-`returnChildCounts` is **not** sent — it does not populate counts in the
-search response. Counts are fetched per group instead (see
-[Child counts sub-fetch](#child-counts-sub-fetch)).
+`returnChildCounts: true` is sent, and the group-search response returns the
+child counts **inline** on each group — no per-group sub-fetch is needed.
+(Confirmed against the live API: the search response carries `childCount`,
+`indexedChildCount`, and `noIndexableDataChildCount` directly.)
 
 ### Internal conversion: standardPlace → placeId → placeRepIds
 
@@ -191,7 +191,10 @@ Probed against the live endpoint (see `metadata-search-documentation.txt`).
 | API field | Type | Used for |
 |-----------|------|----------|
 | `groupName` | string | `imageGroupNumber` and (derived) `imageGroupPrefix` |
-| `id` | string | Internal key for the per-group counts fetch (not output) |
+| `childCount` | number? | `imageCount` and the `recordSearchablePercent` numerator base |
+| `indexedChildCount` | number? | `recordSearchablePercent` numerator |
+| `noIndexableDataChildCount` | number? | excluded from the `recordSearchablePercent` denominator |
+| `id` | string | Group identifier (not output) |
 | `coverages` | Coverage[] | `coverages` output array |
 | `languages` | string[] | `languages` output |
 | `title` | string? | `title` output (when present) |
@@ -219,18 +222,11 @@ Coverage fields intentionally **ignored**: `placeRepId`,
 
 ---
 
-## Child counts sub-fetch
+## Child counts (inline)
 
-The search response does **not** include child counts
-(`returnChildCounts: true` does not work). For each group in the page,
-the tool fetches counts individually:
-
-```
-GET https://sg30p0.familysearch.org/service/records/rms/group-service/group/{id}?include-child-count=true
-```
-
-using the group's `id` from the search response. The response includes
-(see `metadata-group-id-lookup.txt`):
+The group-search request sends `returnChildCounts: true`, and the search
+response returns the child counts **inline on each group** — there is **no
+per-group sub-fetch**. Each group carries:
 
 | API field | Meaning |
 |-----------|---------|
@@ -249,11 +245,8 @@ the fraction of *indexable* images that have actually been indexed.
 **Edge cases:**
 - If the denominator (`childCount − noIndexableDataChildCount`) is `≤ 0`,
   set `recordSearchablePercent` to `null`.
-- These fetches run **in parallel** with bounded concurrency (a pool of
-  ~10 — do not fire all 100 at once). Each fetch is **retried up to 3
-  times** on failure. If it still fails, set both `imageCount` and
-  `recordSearchablePercent` to `null` for that group and continue — do
-  not fail the whole search.
+- If a group omits the count fields entirely, set both `imageCount` and
+  `recordSearchablePercent` to `null` for that group.
 
 ---
 
@@ -427,11 +420,11 @@ all other authenticated tools. Do not re-implement token plumbing.
 | Group-search API returns 403 | Throw: `"FamilySearch metadata search API error: 403 Forbidden."` |
 | Group-search API other non-OK | Throw: `"FamilySearch metadata search API error: {status} {statusText}."` |
 | Group-search network error | Throw: `"Could not reach FamilySearch metadata search API: {message}."` |
-| **Per-group counts** fetch fails (after 3 retries) | Set `imageCount` and `recordSearchablePercent` to `null` for that group; continue |
+| Group missing inline count fields | Set `imageCount` and `recordSearchablePercent` to `null` for that group; continue |
 | **Full-text** check fails (after 3 retries) | Set `fulltextSearchable` to `null` for the batch; continue |
 
-The sub-fetch failures are **non-fatal** — a partial result with `null`
-signals is more useful than a hard error.
+The full-text sub-fetch failure is **non-fatal** — a partial result with
+`null` signals is more useful than a hard error.
 
 ---
 
@@ -445,13 +438,12 @@ signals is more useful than a hard error.
 3. Build the group-search body (fixed fields + coverage + optional
    `nextPageToken`).
 
-### Group search → counts → full-text
+### Group search → full-text
 
-1. PUT the group search; read `groups`, `totalCount`,
-   `numberReturned`, `nextPageToken`.
-2. In parallel (bounded concurrency, 3 retries each): fetch child
-   counts per group by `id`.
-3. In one or more batches of ≤ 100 `groupName`s (3 retries): fetch the
+1. PUT the group search (`returnChildCounts: true`); read `groups`,
+   `totalCount`, `numberReturned`, `nextPageToken`. Child counts arrive
+   **inline** on each group — no per-group fetch.
+2. In one or more batches of ≤ 100 `groupName`s (3 retries): fetch the
    full-text-searchable set.
 
 ### Per-group mapping
@@ -499,8 +491,9 @@ docs):
 
 The tool returns **one page (≤ 100 groups) per call** plus
 `nextPageToken` when more remain. It does **not** auto-aggregate all
-pages — that would fan out to thousands of per-group counts fetches.
-`totalGroups` tells the caller how many groups exist in total.
+pages — that would walk every page (and full-text batch) for what is
+usually just a scoping question. `totalGroups` tells the caller how many
+groups exist in total.
 
 ---
 
@@ -516,7 +509,7 @@ images are digitized, indexed, or full-text processed.
 | File | Action |
 |------|--------|
 | `src/types/metadata-search.ts` | Create — input, output, and API response types |
-| `src/tools/metadata-search.ts` | Create — tool function, validation, request building, counts/full-text sub-fetches, mapping, schema export |
+| `src/tools/metadata-search.ts` | Create — tool function, validation, request building, full-text sub-fetch, mapping, schema export |
 | `src/utils/place-resolver.ts` | Use — `standardPlaceToPlaceId` and `placeIdToRepIds` (the place-name → placeId → placeRepIds resolution) live here, anonymous. The old `place-search.ts` copy of `placeIdToRepIds` was deleted; the resolver is the single home |
 | `src/tool-schemas.ts` | Add `metadataSearchSchema` to `allToolSchemas` |
 | `src/index.ts` | Wire `metadata_search` handler in `CallToolRequestSchema` |
@@ -538,11 +531,11 @@ images are digitized, indexed, or full-text processed.
 | 2 | Throws when standardPlace is missing | Required-input validation |
 | 3 | Throws when fromDate/toDate is malformed | Date validation |
 | 4 | Resolves standardPlace → placeId → placeRepIds and passes them in `coverage.placeRepIds` | Input conversion |
-| 5 | Sends fixed fields `types:["NATURAL"]`, `active:true`, `pageSize:100`; omits `returnChildCounts` | Request construction |
+| 5 | Sends fixed fields `types:["NATURAL"]`, `active:true`, `pageSize:100`, `returnChildCounts:true` | Request construction |
 | 6 | Derives `imageGroupPrefix` for both bare and 3-segment `groupName`s | Prefix rule |
 | 7 | Computes `recordSearchablePercent` = round(indexed / (total − nonIndexable) × 100) | Counts math |
 | 8 | Sets `recordSearchablePercent: null` when denominator ≤ 0 | Zero-denominator edge |
-| 9 | Sets `imageCount`/`recordSearchablePercent: null` after counts fetch fails 3× | Counts failure path |
+| 9 | Sets `imageCount`/`recordSearchablePercent: null` when a group omits inline count fields | Missing-counts path |
 | 10 | Sets `fulltextSearchable: true/false` from the groupNumber endpoint | Full-text mapping |
 | 11 | Sets `fulltextSearchable: null` after the full-text call fails 3× | Full-text failure path |
 | 12 | Batches `groupName`s in chunks of ≤ 100 | Batch sizing |
@@ -561,12 +554,12 @@ cd mcp-server
 npx tsx dev/try-metadata-search.ts --standardPlace "Edensor, Derbyshire, England, United Kingdom" --from 1730-01-01 --to 1810-12-31
 ```
 
-> No confirmed live examples yet — verifying the live request/response
-> (including that `include-child-count` and the full-text `groupNumber`
-> endpoints behave as specced) is part of implementation. The
-> `standardPlace "Edensor, Derbyshire, England, United Kingdom"` /
+> The `standardPlace "Edensor, Derbyshire, England, United Kingdom"` /
 > `1730-01-01`..`1810-12-31` query is a reasonable starting fixture (it
-> appears in `metadata-search-documentation.txt`).
+> appears in `metadata-search-documentation.txt`). The live request/response
+> behavior has been confirmed: the group search with `returnChildCounts:
+> true` returns child counts inline, and the full-text `groupNumber`
+> endpoint behaves as specced.
 
 ---
 
@@ -577,9 +570,10 @@ npx tsx dev/try-metadata-search.ts --standardPlace "Edensor, Derbyshire, England
 `recordSearchablePercent` and `fulltextSearchable` describe **different
 search systems** and are sourced differently:
 
-- `recordSearchablePercent` comes from per-group **child counts**
-  (`indexedChildCount` vs. indexable images). It tells the LLM how much
-  of the volume is reachable through the indexed `record_search`.
+- `recordSearchablePercent` comes from the **inline child counts**
+  (`indexedChildCount` vs. indexable images) returned on each group. It
+  tells the LLM how much of the volume is reachable through the indexed
+  `record_search`.
 - `fulltextSearchable` comes from the dedicated **full-text groupNumber
   endpoint**. It tells the LLM whether `fulltext_search` (which accepts
   an `imageGroupNumber`) will find anything in this volume.
@@ -588,13 +582,16 @@ A volume can be one, both, or neither. Both being low/false is the
 signal that the only way into the volume is to browse it image by image
 (`image_search` → `image_read`).
 
-### Why per-group count fetches
+### Child counts come back inline
 
-`returnChildCounts: true` on the search does not populate counts in the
-response. The reliable source is the single-group GET
-(`?include-child-count=true`), so the tool fans out one fetch per group
-with bounded concurrency. This is the dominant cost of the tool and the
-reason it returns a single page rather than auto-aggregating.
+`returnChildCounts: true` on the group search **does** populate
+`childCount` / `indexedChildCount` / `noIndexableDataChildCount` inline on
+each returned group — confirmed against the live API. There is no
+per-group sub-fetch; the tool reads the counts straight off the search
+response. (An earlier draft of this spec assumed `returnChildCounts` was
+ineffective and required a single-group `?include-child-count=true` fetch
+per group; that turned out to be wrong and the inline approach is what
+ships.)
 
 ### Terminology
 

--- a/docs/specs/place-collections-tool-spec.md
+++ b/docs/specs/place-collections-tool-spec.md
@@ -9,9 +9,11 @@ tool).
 
 The tool has two input modes:
 
-- **List mode** — Pass `query` (a place name string like `"Alabama"`).
-  Returns the matching collections with record, person, and image
-  counts.
+- **List mode** — Pass `standardPlace` (preferably the standardized place
+  name from `place_search`, e.g. `"Schuylkill, Pennsylvania, United States"`;
+  a plain place name also works). The tool derives the right collection scope
+  (see [Place → collection scope](#place--collection-scope)) and returns the
+  matching collections with record, person, and image counts.
 - **Detail mode** — Pass `id` (a FamilySearch collection ID like
   `"1473181"`). Returns the FamilySearch search API response for that
   collection **as-is**, with HTML-bearing string fields converted to
@@ -28,11 +30,30 @@ API (`/service/search/hr/v2/collections`) use **different place ID
 systems**. Alabama is 351 in the Places API but 33 in the Collections
 API. These IDs are not interchangeable.
 
-The `query` parameter was added to work around this — Claude passes
-the place name (e.g., `"Alabama"`) directly to the collections tool
-and filters by collection title. The `place_search` tool is still
-useful for disambiguation (e.g., which "Madison"?) but its IDs are
-not passed to `place_collections`.
+The `standardPlace` input works around this — Claude passes the place
+**name** (the `standardPlace` from `place_search`, e.g. `"Schuylkill,
+Pennsylvania, United States"`), and the tool derives a title-match term
+and filters by collection title. `place_search` IDs are never passed to
+`place_collections`.
+
+### Place → collection scope
+
+FamilySearch organizes record collections at the **state/province level**
+for the United States, Canada, and Mexico, and at the **country level**
+everywhere else. The tool derives the title-match term from the
+`standardPlace` accordingly (`standardPlaceToCollectionsQuery`):
+
+| Country (last component) | Term used | Example input → term |
+|--------------------------|-----------|----------------------|
+| United States | the state (second-to-last component) | `"Schuylkill, Pennsylvania, United States"` → `"Pennsylvania"` |
+| Canada / Mexico | `"Country, State"` | `"Toronto, Ontario, Canada"` → `"Canada, Ontario"` |
+| any other country | the country (last component) | `"Paris, France"` → `"France"` |
+
+A free-text query that isn't a standardPlace (no recognized country tail,
+e.g. `"Census"`) passes through unchanged, so an arbitrary place query
+still works — but a `standardPlace` is preferred. This conversion is
+**internal**: the LLM always passes the full place; it never picks
+"country vs state."
 
 ### Detail-mode design rationale (stakeholder transcript, 2026-05-12)
 
@@ -49,25 +70,25 @@ pre-parsing of GEDCOMX timestamps.
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `query` | string | No* | Place name to search collection titles (list mode) |
+| `standardPlace` | string | No* | Place to list collections for — preferably the `standardPlace` from `place_search` (list mode). The tool derives the collection scope from it (see [Place → collection scope](#place--collection-scope)). A plain place name also works. |
 | `id` | string | No* | FamilySearch collection ID for single-collection detail (detail mode) |
 
-*Exactly one of `query` or `id` must be provided. (The former `placeIds`
-list-mode input — a separate collections-internal id-space — has been removed;
-use `query` with a place name.)
+*Exactly one of `standardPlace` or `id` must be provided. (The former
+`placeIds` list-mode input — a separate collections-internal id-space — has
+been removed.)
 
 ### Input precedence
 
-1. `id` — takes precedence; runs detail mode, silently ignores `query`.
-2. `query` — used when `id` is not set; runs list mode.
+1. `id` — takes precedence; runs detail mode, silently ignores `standardPlace`.
+2. `standardPlace` — used when `id` is not set; runs list mode.
 
-`query` is the only list-mode input.
+`standardPlace` is the only list-mode input.
 
 Examples:
 
 ```json
-{ "query": "Alabama" }        // list mode
-{ "id": "1473181" }           // detail mode
+{ "standardPlace": "Schuylkill, Pennsylvania, United States" }  // list mode
+{ "id": "1473181" }                                             // detail mode
 ```
 
 ---
@@ -80,7 +101,8 @@ When `id` is absent:
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `query` | string? | Echo of the query input (present when supplied) |
+| `standardPlace` | string? | Echo of the `standardPlace` input (present when supplied) |
+| `query` | string? | The title-match term actually used (the derived scope, e.g. `"Pennsylvania"` for a US place) |
 | `matchingCollections` | number | Total count of matching collections |
 | `collections` | Collection[] | The matching collection objects |
 
@@ -99,6 +121,7 @@ Each `Collection` object:
 Example:
 ```json
 {
+  "standardPlace": "Birmingham, Jefferson, Alabama, United States",
   "query": "Alabama",
   "matchingCollections": 29,
   "collections": [
@@ -214,17 +237,22 @@ themselves when needed.
   name: "place_collections",
   description:
     "List FamilySearch record collections for a place, OR get detailed " +
-    "information about a single collection. Pass `query` (a place name) to " +
-    "list, or `id` (a collection ID like \"1743384\") to get the FS API " +
-    "response for that collection, with HTML strings (citations, Research " +
+    "information about a single collection. For list mode, pass `standardPlace` " +
+    "— preferably the standardized place name from place_search (e.g. " +
+    "\"Schuylkill, Pennsylvania, United States\"); a plain place name also works. " +
+    "FamilySearch organizes collections at the state/province level for the " +
+    "United States, Canada, and Mexico, and at the country level everywhere else, " +
+    "so results come back at that scope (the tool derives it from the place). " +
+    "For detail mode, pass `id` (a collection ID like \"1743384\") to get the FS " +
+    "API response for that collection, with HTML strings (citations, Research " +
     "Wiki page) converted to markdown. Requires authentication — call the " +
     "login tool first if not logged in.",
   inputSchema: {
     type: "object",
     properties: {
-      query: {
+      standardPlace: {
         type: "string",
-        description: "Place name to search for in collection titles (e.g., \"Alabama\", \"England\"). Use the place_search tool first to disambiguate if needed."
+        description: "The place to list collections for — preferably the `standardPlace` from place_search (e.g. \"Schuylkill, Pennsylvania, United States\"). The tool derives the right collection scope (the US state, \"Country, State\" for Canada/Mexico, or the country) and matches it against collection titles. A plain place name works too."
       },
       id: {
         type: "string",
@@ -373,7 +401,7 @@ Walks the response and produces a new object with:
 
 | Condition | Behavior |
 |-----------|----------|
-| Neither `query` nor `id` provided | Throw error with usage instructions |
+| Neither `standardPlace` nor `id` provided | Throw error with usage instructions |
 | Not authenticated | Let `getValidToken()` throw its LLM-instruction error ("User is not logged in to FamilySearch. Call the login tool to authenticate.") |
 | API returns non-OK status | Throw error: `"FamilySearch collections API error: {status} {statusText}"` |
 | API returns empty/malformed response | Return `{ matchingCollections: 0, collections: [] }` |
@@ -383,7 +411,7 @@ Walks the response and produces a new object with:
 | Condition | Behavior |
 |-----------|----------|
 | Not authenticated | Let `getValidToken()` throw |
-| 404 from upstream | Throw: `"No FamilySearch collection found with id \"{id}\". Use place_collections({ query: ... }) to list available collections."` |
+| 404 from upstream | Throw: `"No FamilySearch collection found with id \"{id}\". Use place_collections({ standardPlace: ... }) to list available collections."` |
 | Non-OK status other than 404 | Throw: `"FamilySearch collection detail API error: {status} {statusText}"` |
 | Upstream 200 but malformed JSON | Throw: `"FamilySearch collection detail API returned malformed response."` |
 
@@ -418,6 +446,7 @@ is a type alias for `FSCollectionDetailResponse` — no curated shape.
 
 - `placeCollectionsToolSchema` — MCP tool schema (with `id` property)
 - `placeCollectionsTool(input)` — main function (routes by input mode)
+- `standardPlaceToCollectionsQuery(value)` — derive the title-match term from a `standardPlace` (US → state, Canada/Mexico → `"Country, State"`, else → country; free text passes through)
 - `fetchAllCollections(token)` — cached list-mode API call
 - `fetchCollectionDetail(token, id)` — detail-mode API call (with the embed flag)
 - `filterByQuery(entries, query)` — case-insensitive title matching
@@ -458,15 +487,20 @@ Documents the endpoint investigation and the RESULTS table for detail mode.
 
 | # | Test case | What it verifies |
 |---|-----------|------------------|
-| 1 | Returns collections matching a place name query | Query happy path |
-| 2 | Query matching is case-insensitive | Case handling |
-| 3 | Returns empty array when query matches no titles | Query zero-match |
-| 4 | Query matches anywhere in the title | Substring matching |
-| 5 | Throws auth error when not authenticated | Auth propagation |
-| 6 | Throws on non-OK API response | HTTP error handling |
-| 7 | Handles malformed API response gracefully | Empty/null response |
-| 8 | Throws when neither query nor id provided | Input validation |
-| 9 | Maps API response fields to Collection shape | Field mapping |
+| 1 | Returns collections matching a place; echoes `standardPlace` | List happy path |
+| 2 | Converts a US standardPlace to its state before matching | Conversion wired into the tool |
+| 3 | Matching is case-insensitive | Case handling |
+| 4 | Returns empty array when nothing matches | Zero-match |
+| 5 | Matches anywhere in the title | Substring matching |
+| 6 | Throws auth error when not authenticated | Auth propagation |
+| 7 | Throws on non-OK API response | HTTP error handling |
+| 8 | Handles malformed API response gracefully | Empty/null response |
+| 9 | Throws when neither `standardPlace` nor `id` provided | Input validation |
+| 10 | Maps API response fields to Collection shape | Field mapping |
+
+**`standardPlaceToCollectionsQuery` unit tests:** US → state (any nesting
+depth); Canada/Mexico → `"Country, State"`; other countries → country;
+free-text passes through; country-only US/Canada falls back to the country.
 
 **Detail-mode helper tests:**
 
@@ -514,17 +548,17 @@ cd mcp-server && npm run build && npm test
 npx @modelcontextprotocol/inspector node build/index.js
 ```
 
-- `place_collections({ query: "Alabama" })` — returns 29 Alabama collections
-- `place_collections({ query: "England" })` — returns England collections
-- `place_collections({ query: "xyznonexistent" })` — returns empty list
+- `place_collections({ standardPlace: "Birmingham, Jefferson, Alabama, United States" })` — derives `"Alabama"`, returns 29 Alabama collections
+- `place_collections({ standardPlace: "London, England, United Kingdom" })` — derives `"United Kingdom"`, returns UK collections
+- `place_collections({ standardPlace: "Nowhere" })` — returns empty list
 - `place_collections({ id: "1473181" })` — returns FS pass-through with markdown wiki
 - `place_collections({ id: "9999999" })` — friendly 404
-- `place_collections({ id, query })` — detail returned, query dropped
+- `place_collections({ id, standardPlace })` — detail returned, `standardPlace` dropped
 - `place_collections` without logging in — returns auth error message
 
 ### Manual Layer 2 (Claude Code / Cowork)
 
-- "What FamilySearch collections cover Alabama?" — Claude should call `place_collections` with query `"Alabama"` and present the results.
+- "What FamilySearch collections cover Alabama?" — Claude should call `place_collections` with the `standardPlace` for Alabama (e.g. from `place_search`) and present the results.
 - "Tell me more about FamilySearch collection 1473181" — Claude should call `place_collections` with `id: "1473181"` and present the wiki + citation.
 - "What's the citation for collection 1743384?" — same pattern with the citation field highlighted.
 - "Show me the wiki page for collection 1473181" — Claude should call `place_collections` with `id` and present `documents[0].text`.

--- a/docs/specs/place-collections-tool-spec.md
+++ b/docs/specs/place-collections-tool-spec.md
@@ -9,9 +9,9 @@ tool).
 
 The tool has two input modes:
 
-- **List mode** — Pass `query` (a place name string like `"Alabama"`)
-  or `placeIds` (internal collection place IDs). Returns the matching
-  collections with record, person, and image counts.
+- **List mode** — Pass `query` (a place name string like `"Alabama"`).
+  Returns the matching collections with record, person, and image
+  counts.
 - **Detail mode** — Pass `id` (a FamilySearch collection ID like
   `"1473181"`). Returns the FamilySearch search API response for that
   collection **as-is**, with HTML-bearing string fields converted to
@@ -58,19 +58,15 @@ use `query` with a place name.)
 
 ### Input precedence
 
-1. `id` — takes precedence; runs detail mode, silently ignores `query`/`placeIds`.
-2. `query` — takes precedence over `placeIds` (existing behavior).
-3. `placeIds` — used when neither `id` nor `query` is set.
+1. `id` — takes precedence; runs detail mode, silently ignores `query`.
+2. `query` — used when `id` is not set; runs list mode.
 
-`query` is the recommended parameter for list-mode LLM workflow.
-`placeIds` is for advanced use when internal collection IDs are
-already known.
+`query` is the only list-mode input.
 
 Examples:
 
 ```json
-{ "query": "Alabama" }        // list mode (recommended)
-{ "placeIds": [33] }          // list mode (advanced)
+{ "query": "Alabama" }        // list mode
 { "id": "1473181" }           // detail mode
 ```
 
@@ -320,14 +316,9 @@ embed the FamilySearch Research Wiki "about" page as HTML in
 
 ## Filtering Logic (list mode)
 
-**Query mode (recommended):** Case-insensitive substring match against
-collection titles. `"Alabama"` matches any collection whose title
-contains "Alabama" (e.g., `"Alabama, County Marriages, 1711-1992"`).
-
-**PlaceIds mode:** Filter collections where any of the requested place
-IDs appear in the collection's `searchMetadata[0].placeIds` array.
-
-When `query` is provided, it takes precedence over `placeIds`.
+**Query mode:** Case-insensitive substring match against collection
+titles. `"Alabama"` matches any collection whose title contains
+"Alabama" (e.g., `"Alabama, County Marriages, 1711-1992"`).
 
 ---
 
@@ -382,7 +373,7 @@ Walks the response and produces a new object with:
 
 | Condition | Behavior |
 |-----------|----------|
-| Neither `query` nor `placeIds` (and no `id`) provided | Throw error with usage instructions |
+| Neither `query` nor `id` provided | Throw error with usage instructions |
 | Not authenticated | Let `getValidToken()` throw its LLM-instruction error ("User is not logged in to FamilySearch. Call the login tool to authenticate.") |
 | API returns non-OK status | Throw error: `"FamilySearch collections API error: {status} {statusText}"` |
 | API returns empty/malformed response | Return `{ matchingCollections: 0, collections: [] }` |
@@ -430,7 +421,6 @@ is a type alias for `FSCollectionDetailResponse` — no curated shape.
 - `fetchAllCollections(token)` — cached list-mode API call
 - `fetchCollectionDetail(token, id)` — detail-mode API call (with the embed flag)
 - `filterByQuery(entries, query)` — case-insensitive title matching
-- `filterByPlaceIds(entries, placeIds)` — internal placeId matching
 - `htmlToMarkdown(html)` — single-string HTML→markdown conversion
 - `convertHtmlToMarkdown(response)` — walks the detail response per the rules
 - Module-level `turndown` instance with the rules above
@@ -472,15 +462,11 @@ Documents the endpoint investigation and the RESULTS table for detail mode.
 | 2 | Query matching is case-insensitive | Case handling |
 | 3 | Returns empty array when query matches no titles | Query zero-match |
 | 4 | Query matches anywhere in the title | Substring matching |
-| 5 | Returns collections matching a single place ID | PlaceIds happy path |
-| 6 | Returns collections matching multiple place IDs | Union filtering |
-| 7 | Returns empty array when no place IDs match | PlaceIds zero-match |
-| 8 | Filters correctly against placeIds in searchMetadata | PlaceIds logic |
-| 9 | Throws auth error when not authenticated | Auth propagation |
-| 10 | Throws on non-OK API response | HTTP error handling |
-| 11 | Handles malformed API response gracefully | Empty/null response |
-| 12 | Throws when neither query nor placeIds provided | Input validation |
-| 13 | Maps API response fields to Collection shape | Field mapping |
+| 5 | Throws auth error when not authenticated | Auth propagation |
+| 6 | Throws on non-OK API response | HTTP error handling |
+| 7 | Handles malformed API response gracefully | Empty/null response |
+| 8 | Throws when neither query nor id provided | Input validation |
+| 9 | Maps API response fields to Collection shape | Field mapping |
 
 **Detail-mode helper tests:**
 
@@ -509,8 +495,6 @@ Documents the endpoint investigation and the RESULTS table for detail mode.
 cd mcp-server
 npx tsx dev/try-place-collections.ts Alabama
 npx tsx dev/try-place-collections.ts England
-npx tsx dev/try-place-collections.ts --ids 33
-npx tsx dev/try-place-collections.ts --ids 33,325
 npx tsx dev/try-collection-detail.ts 1473181
 npx tsx dev/try-collection-detail.ts 1743384
 npx tsx dev/try-collection-detail.ts 9999999

--- a/docs/specs/place-collections-tool-spec.md
+++ b/docs/specs/place-collections-tool-spec.md
@@ -50,10 +50,11 @@ pre-parsing of GEDCOMX timestamps.
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `query` | string | No* | Place name to search collection titles (list mode) |
-| `placeIds` | number[] | No* | Internal FamilySearch collection place IDs (list mode; NOT from the `place_search` tool) |
 | `id` | string | No* | FamilySearch collection ID for single-collection detail (detail mode) |
 
-*Exactly one of `query`, `placeIds`, or `id` must be provided.
+*Exactly one of `query` or `id` must be provided. (The former `placeIds`
+list-mode input — a separate collections-internal id-space — has been removed;
+use `query` with a place name.)
 
 ### Input precedence
 
@@ -84,7 +85,6 @@ When `id` is absent:
 | Field | Type | Description |
 |-------|------|-------------|
 | `query` | string? | Echo of the query input (present when supplied) |
-| `placeIds` | number[]? | Echo of the placeIds input (present when supplied) |
 | `matchingCollections` | number | Total count of matching collections |
 | `collections` | Collection[] | The matching collection objects |
 
@@ -95,7 +95,6 @@ Each `Collection` object:
 | `id` | string | FamilySearch collection identifier |
 | `title` | string | Human-readable collection name |
 | `dateRange` | string | Time period the collection covers (e.g., `"1809-1950"`) |
-| `placeIds` | number[] | Internal place IDs from the collection's spatial coverage |
 | `recordCount` | number | Number of records in the collection |
 | `personCount` | number | Number of persons in the collection |
 | `imageCount` | number | Number of images in the collection |
@@ -111,7 +110,6 @@ Example:
       "id": "1743384",
       "title": "Alabama County Marriages, 1711-1992",
       "dateRange": "1711-1992",
-      "placeIds": [33],
       "recordCount": 6049744,
       "personCount": 22361103,
       "imageCount": 1231203,
@@ -231,11 +229,6 @@ themselves when needed.
       query: {
         type: "string",
         description: "Place name to search for in collection titles (e.g., \"Alabama\", \"England\"). Use the place_search tool first to disambiguate if needed."
-      },
-      placeIds: {
-        type: "array",
-        items: { type: "number" },
-        description: "Internal FamilySearch collection place IDs. These are NOT the same as place IDs from the place_search tool. Only use if you know the internal IDs."
       },
       id: {
         type: "string",

--- a/docs/specs/place-external-links-tool-spec.md
+++ b/docs/specs/place-external-links-tool-spec.md
@@ -49,13 +49,13 @@ window," not "URLs of a specific record category."
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `placeId` | string | Yes | FamilySearch place ID (numeric string), e.g. `"1927089"` for France. Sourced from the `place_search` tool. |
+| `standardPlace` | string | Yes | Standard place name (the `standardPlace` field from `place_search`, e.g. `"France"`). Resolved to a FamilySearch place ID internally. |
 | `startYear` | number (integer, 1500–2100) | Yes | Earliest year of interest (inclusive). |
 | `endYear` | number (integer, 1500–2100) | Yes | Latest year of interest (inclusive). Must be `>= startYear`. |
 
 Validation:
 
-- `placeId` must be a non-empty string.
+- `standardPlace` must be a non-empty string; the tool resolves it to a place ID via `standardPlaceToPlaceId` and throws `Could not resolve "<name>" ...` when it cannot (unresolvable or ambiguous).
 - `startYear` and `endYear` must be integers in `[1500, 2100]`.
 - `endYear >= startYear` is enforced inside the handler — the JSON
   Schema reports the range constraints, and the handler throws a
@@ -126,19 +126,18 @@ default is to preserve API truth.
   description:
     "Return FamilySearch-curated third-party genealogy resource URLs for a place and year range. " +
     "Use when the user wants links to external record collections (Ancestry, MyHeritage, FindMyPast, " +
-    "national archives, etc.) covering a specific place by FamilySearch place ID and time period. " +
+    "national archives, etc.) covering a specific place by standard place name and time period. " +
     "Returns every collection whose date range overlaps [startYear, endYear], plus undated wiki/website " +
-    "resources for that place. Requires a place ID — do not guess; obtain it from the places tool " +
-    "or the user.",
+    "resources for that place. Pass the standard place name (the `standardPlace` field from place_search).",
   inputSchema: {
     type: "object",
-    required: ["placeId", "startYear", "endYear"],
+    required: ["standardPlace", "startYear", "endYear"],
     properties: {
-      placeId: {
+      standardPlace: {
         type: "string",
         description:
-          "FamilySearch place ID (numeric string), e.g. '1927089' for France. " +
-          "Get this from the places tool, not by guessing."
+          "The standard place name (the `standardPlace` field from place_search, e.g. 'France'). " +
+          "The tool resolves it to a FamilySearch place ID internally."
       },
       startYear: {
         type: "integer",

--- a/docs/specs/place-external-links-tool-spec.md
+++ b/docs/specs/place-external-links-tool-spec.md
@@ -22,16 +22,17 @@ user at the third-party genealogy resources FS curates on its wiki.
 A near-term workflow this tool participates in:
 
 ```
-place_population({ place_id })  → place_id, place name, population data
+place_search({ query })  → standardPlace name, place data
         ↓
-place_external_links({ placeId, startYear, endYear })
+place_external_links({ standardPlace, startYear, endYear })
         → curated third-party URLs covering that place + year window
 ```
 
-The `place_population` tool (sibling in this server) is the upstream source
-of place IDs. `place_external_links` does not resolve place names to IDs;
-the place ID must come from the caller. **The LLM should not guess
-place IDs.**
+The `place_search` tool (sibling in this server) is the upstream source
+of standard place names. `place_external_links` resolves the `standardPlace`
+name to a place ID internally; the caller passes the name, not an ID.
+**The LLM should pass the `standardPlace` name from `place_search`, not a
+guessed place ID.**
 
 ### Why no `recordType` filter
 
@@ -65,7 +66,7 @@ Validation:
 Example:
 
 ```json
-{ "placeId": "1927089", "startYear": 1880, "endYear": 1950 }
+{ "standardPlace": "France", "startYear": 1880, "endYear": 1950 }
 ```
 
 ---
@@ -74,8 +75,9 @@ Example:
 
 | Field | Type | Description |
 |-------|------|-------------|
+| `standardPlace` | string | Echo of the `standardPlace` name that was passed in (e.g. `"France"`). |
 | `place` | string \| null | Place name resolved by FS (e.g. `"France"`). `null` if no collections were returned. |
-| `totalResults` | number | Raw total reported by the FS API for this `placeId` (before overlap filter). |
+| `totalResults` | number | Raw total reported by the FS API for the resolved place (before overlap filter). |
 | `matchedCount` | number | Number of items in `results[]` after overlap filter. |
 | `results` | `{ url, linkText }[]` | URLs FS curates for this place that overlap the requested year range. |
 
@@ -90,6 +92,7 @@ Example:
 
 ```json
 {
+  "standardPlace": "France",
   "place": "France",
   "totalResults": 221,
   "matchedCount": 178,
@@ -319,22 +322,22 @@ API. Bypasses the MCP harness for fast debugging. Modeled on
 | 2 | Includes collections with empty start/end years | Permissive empty-year inclusion |
 | 3 | Fetches every page until totalResults is exhausted | Multi-page pagination loop |
 | 4 | Stops looping when an empty page is returned | Defensive bail on bad API state |
-| 5 | Returns empty results cleanly for unknown placeId | Empty-data path |
+| 5 | Returns empty results cleanly for a place that resolves but has no collections | Empty-data path |
 | 6 | Throws an instructional error on 403 | Rate-limit / WAF error wording |
 | 7 | Throws an instructional error on 429 | Rate-limit error wording |
 | 8 | Throws a retry-once error on generic 5xx | Transient-error wording |
 | 9 | Throws an instructional error on malformed JSON | Parse-failure handling |
 | 10 | Rejects endYear < startYear without hitting the network | Handler-level guard + no fetch |
 | 11 | Accepts endYear === startYear (single-year query) | Boundary case |
-| 12 | Rejects empty placeId without hitting the network | Handler-level guard + no fetch |
+| 12 | Rejects empty standardPlace without hitting the network | Handler-level guard + no fetch |
 
 ### Smoke-test script
 
 ```bash
 cd mcp-server
-npx tsx dev/try-place-external-links.ts 1927089 1880 1950   # France, populated
-npx tsx dev/try-place-external-links.ts 1927089 1700 1750   # France, sparse
-npx tsx dev/try-place-external-links.ts 1927164 1880 1950   # Canada
+npx tsx dev/try-place-external-links.ts "France" 1880 1950   # France, populated
+npx tsx dev/try-place-external-links.ts "France" 1700 1750   # France, sparse
+npx tsx dev/try-place-external-links.ts "Canada" 1880 1950   # Canada
 ```
 
 ---
@@ -354,14 +357,14 @@ cd mcp-server
 npx @modelcontextprotocol/inspector node build/index.js
 ```
 
-- Call `place_external_links({ placeId: "1927089", startYear: 1880, endYear: 1950 })` → `~178` results, `totalResults: 221`.
+- Call `place_external_links({ standardPlace: "France", startYear: 1880, endYear: 1950 })` → `~178` results, `totalResults: 221`.
 - Call with `startYear: 1700, endYear: 1750` → far fewer matches (proves the filter works).
 - Call with `startYear: 1950, endYear: 1880` → handler error mentioning `endYear must be greater than or equal to startYear`.
-- Call with `placeId: "999999999"` → `place: null`, `totalResults: 0`, `matchedCount: 0`, `results: []`.
+- Call with `standardPlace: "Nowhere"` → resolution error mentioning `Could not resolve "Nowhere"`.
 
 ### Manual Layer 2 (Claude Code)
 
-- "Find FamilySearch resources for placeId 1927089 between 1880 and 1950." — Claude should call `place_external_links` with those inputs and present the URLs.
+- "Find FamilySearch resources for France between 1880 and 1950." — Claude should call `place_external_links` with `standardPlace: "France"` and those years and present the URLs.
 
 ---
 

--- a/docs/specs/place-population-tool-spec.md
+++ b/docs/specs/place-population-tool-spec.md
@@ -27,12 +27,12 @@ data point if no exact match exists.
 
 Example (single year):
 ```json
-{ "placeId": "1927069", "year": 1960 }
+{ "standardPlace": "Nigeria", "year": 1960 }
 ```
 
 Example (year range):
 ```json
-{ "placeId": "1927069", "year_start": 1900, "year_end": 1950 }
+{ "standardPlace": "Nigeria", "year_start": 1900, "year_end": 1950 }
 ```
 
 ---
@@ -146,17 +146,19 @@ None required. The Pop Stats API is an internal service with no auth.
 
 **Endpoint:**
 ```
-GET {POP_STATS_BASE_URL}/population
+GET {popStatsUrl}/population
 ```
 
-The base URL defaults to `http://localhost:8000` and can be overridden via
-the `POP_STATS_BASE_URL` environment variable.
+The base URL is read from `loadConfig().popStatsUrl` and defaults to the
+hosted Pop Stats service (`https://malachi.taild68f1b.ts.net/pop-stats`). It
+can be overridden per-user via the `popStatsUrl` field in
+`~/.familysearch-mcp/config.json`.
 
 **Query parameters:**
 
 | Parameter | Type | Required | Purpose |
 |-----------|------|----------|---------|
-| `place_id` | string | Yes | FamilySearch place ID |
+| `place_id` | string | Yes | FamilySearch place ID (upstream Pop Stats id-space; the tool resolves `standardPlace` to this via place_search internally) |
 | `year` | number | No | Specific year |
 | `year_start` | number | No | Start of range |
 | `year_end` | number | No | End of range |
@@ -188,24 +190,26 @@ the `POP_STATS_BASE_URL` environment variable.
 
 ## Configuration
 
-The Pop Stats API base URL is read from the `POP_STATS_BASE_URL` environment
-variable, defaulting to `http://localhost:8000`. This allows deployment
-flexibility — the API may run on the same host or a remote server.
+The Pop Stats API base URL is read from `loadConfig().popStatsUrl` (the
+`popStatsUrl` field in `~/.familysearch-mcp/config.json`), defaulting to the
+hosted Pop Stats service `https://malachi.taild68f1b.ts.net/pop-stats`. This
+allows deployment flexibility — the API may run on the same host or a remote
+server.
 
 ---
 
 ## Files
 
-### `mcp-server/src/types/population.ts`
+### `mcp-server/src/types/place-population.ts`
 
 Input and output types for the population tool:
 - `PopulationToolInput` — tool input shape
 - `PopulationResponse` — API response shape (place, population, indexed_records)
 
-### `mcp-server/src/tools/population.ts`
+### `mcp-server/src/tools/place-population.ts`
 
 - `populationToolSchema` — MCP tool schema
-- `populationTool(input)` — main function (builds query string, fetches, returns)
+- `populationTool(input)` — main function (resolves `standardPlace` to a placeId, builds query string, fetches, returns)
 
 ### `mcp-server/src/index.ts`
 
@@ -215,16 +219,16 @@ Registered following the existing tool pattern (import, ListTools, CallTool).
 
 ## Testing
 
-### `tests/tools/population.test.ts`
+### `tests/tools/place-population.test.ts`
 
 | # | Test case | What it verifies |
 |---|-----------|------------------|
-| 1 | Returns population data for a valid placeId | Happy path |
+| 1 | Returns population data for a valid standardPlace | Happy path |
 | 2 | Returns data filtered by specific year | Year filter |
 | 3 | Returns data filtered by year range | Year range filter |
 | 4 | Returns nearest-year data when exact year has no match | Fallback behavior |
 | 5 | Returns parent-level data for province/town queries | Parent resolution |
-| 6 | Throws error when placeId is missing | Input validation |
+| 6 | Throws error when standardPlace is missing | Input validation |
 | 7 | Throws error when API is unreachable | Service availability |
 | 8 | Handles API error responses | HTTP error handling |
 | 9 | Omits empty sections from response | Response structure |
@@ -233,9 +237,9 @@ Registered following the existing tool pattern (import, ListTools, CallTool).
 
 ```bash
 cd mcp-server
-npx tsx dev/try-population.ts 1927069              # Nigeria (country)
-npx tsx dev/try-population.ts 1927069 --year 1960  # Nigeria, specific year
-npx tsx dev/try-population.ts 399 --year 1900      # Abia (province), parent resolution
+npx tsx dev/try-population.ts "Nigeria"              # Nigeria (country)
+npx tsx dev/try-population.ts "Nigeria" --year 1960  # Nigeria, specific year
+npx tsx dev/try-population.ts "Abia, Nigeria" --year 1900  # province, parent resolution
 ```
 
 ---
@@ -251,11 +255,12 @@ cd mcp-server && npm run build && npm test
 ```bash
 npx @modelcontextprotocol/inspector node build/index.js
 ```
-- Call `population({ placeId: "1927069" })` — returns Nigeria population data
-- Call `population({ placeId: "1927069", year: 1960 })` — returns 1960 data
-- Call `population({ placeId: "399" })` — returns Abia data with parent resolution
-- Call `population({})` — returns validation error
+- Call `place_population({ standardPlace: "Nigeria" })` — returns Nigeria population data
+- Call `place_population({ standardPlace: "Nigeria", year: 1960 })` — returns 1960 data
+- Call `place_population({ standardPlace: "Abia, Nigeria" })` — returns Abia data with parent resolution
+- Call `place_population({})` — returns validation error
 
 ### Manual Layer 2 (Claude Code)
 - "What was the population of Nigeria in 1960?" — Claude should call `place_search`
-  to find Nigeria's place ID, then call `place_population` with that ID and year
+  to get Nigeria's standard place name, then call `place_population` with that
+  `standardPlace` and year

--- a/docs/specs/place-population-tool-spec.md
+++ b/docs/specs/place-population-tool-spec.md
@@ -6,7 +6,7 @@ An MCP tool that returns historical population data and indexed record counts
 for a FamilySearch place. No authentication required — it calls the Pop Stats
 API, which is a separate service running on the host.
 
-The tool takes a FamilySearch `placeId` and optional year filters, and returns
+The tool takes a standard place name (`standardPlace`, from place_search) and optional year filters, and returns
 population data from multiple sources (populstat, gapminder) and FamilySearch
 indexed birth record counts.
 
@@ -16,7 +16,7 @@ indexed birth record counts.
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `placeId` | string | Yes | FamilySearch place ID (e.g., `"1927069"` for Nigeria) |
+| `standardPlace` | string | Yes | Standard place name from place_search (e.g., `"Nigeria"`) |
 | `year` | number | No | Specific year to query |
 | `year_start` | number | No | Start of year range |
 | `year_end` | number | No | End of year range |
@@ -108,13 +108,13 @@ Example:
 ```typescript
 {
   name: "place_population",
-  description: "Get historical population data and indexed record counts for a FamilySearch place. Pass a FamilySearch place ID (from the places tool) and optionally filter by year or year range. Returns population data from multiple sources and FamilySearch indexed birth record coverage. No authentication required.",
+  description: "Get historical population data and indexed record counts for a FamilySearch place. Pass a standard place name (the `standardPlace` field from place_search) and optionally filter by year or year range. Returns population data from multiple sources and FamilySearch indexed birth record coverage. No authentication required.",
   inputSchema: {
     type: "object",
     properties: {
-      placeId: {
+      standardPlace: {
         type: "string",
-        description: "FamilySearch place ID (e.g., \"1927069\" for Nigeria). Use the places tool first to find the place ID."
+        description: "The standard place name (the `standardPlace` field from place_search, e.g. \"Nigeria\"). Call place_search first to get this name."
       },
       year: {
         type: "number",
@@ -129,7 +129,7 @@ Example:
         description: "End of year range filter."
       }
     },
-    required: ["placeId"]
+    required: ["standardPlace"]
   }
 }
 ```
@@ -178,7 +178,8 @@ the `POP_STATS_BASE_URL` environment variable.
 
 | Condition | Behavior |
 |-----------|----------|
-| `placeId` not provided | Throw error: `"placeId is required"` |
+| `standardPlace` not provided | Throw error: `"standardPlace is required"` |
+| `standardPlace` unresolvable / ambiguous | Throw error: `"Could not resolve \"<name>\" to a single FamilySearch place. Use place_search ..."` |
 | Pop Stats API unreachable | Throw error: `"Population data service is unavailable. Is the Pop Stats API running?"` |
 | API returns non-OK status | Throw error: `"Population API error: {status} {statusText}"` |
 | API returns 404 / no data | Return the API's response as-is (place info with no population/indexed_records sections) |

--- a/docs/specs/place-search-all-tool-spec.md
+++ b/docs/specs/place-search-all-tool-spec.md
@@ -69,7 +69,7 @@ relevance score, and short `name` are not exposed.
 {
   "results": [
     {
-      "fullName": "Schuylkill, Pennsylvania, United States",
+      "standardPlace": "Schuylkill, Pennsylvania, United States",
       "type": "County",
       "dateRange": "+1811/",
       "latitude": 40.707,
@@ -78,7 +78,7 @@ relevance score, and short `name` are not exposed.
       "wikipediaUrl": "https://en.wikipedia.org/wiki/Schuylkill_County,_Pennsylvania"
     },
     {
-      "fullName": "Schuylkill, Philadelphia, Philadelphia, Pennsylvania, British Colonial America",
+      "standardPlace": "Schuylkill, Philadelphia, Philadelphia, Pennsylvania, British Colonial America",
       "type": "Neighborhood or suburb",
       "dateRange": "/+1776",
       "latitude": 39.9422,

--- a/docs/specs/place-search-tool-spec.md
+++ b/docs/specs/place-search-tool-spec.md
@@ -120,7 +120,7 @@ Steps:
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `fullName` | string | Full jurisdictional name (e.g., `"Paris, Bear Lake, Idaho, United States"`). |
+| `standardPlace` | string | The standardized place name — full jurisdictional name (e.g., `"Paris, Bear Lake, Idaho, United States"`). The canonical handle skills pass to downstream tools. |
 | `type` | string | Place type (e.g., `"City"`, `"County"`, `"Country"`). |
 | `dateRange` | string? | Temporal description in ISO formal notation (e.g., `"+1875/"`). |
 | `latitude` | number? | Geographic latitude. |
@@ -135,7 +135,7 @@ object is present — those exist only on the internal `PlaceResult`.
 {
   "results": [
     {
-      "fullName": "Paris, Bear Lake, Idaho, United States",
+      "standardPlace": "Paris, Bear Lake, Idaho, United States",
       "type": "City",
       "dateRange": "+1875/",
       "latitude": 42.22722,

--- a/docs/specs/research-schema-spec.md
+++ b/docs/specs/research-schema-spec.md
@@ -458,10 +458,10 @@ Array of timeline objects. Timelines are keyed by a unique ID with a human-reada
 | `date_certainty` | string | yes | `exact`, `approximate`, `estimated`, or `calculated` |
 | `event_type` | string | yes | `birth`, `baptism`, `marriage`, `death`, `burial`, `residence`, `census`, `military`, `immigration`, `emigration`, `land_transaction`, `probate`, `other` |
 | `place` | string or null | no | Place description |
-| `place_id` | string or null | no | FamilySearch place ID resolved from `place` via the `place_search` tool. Null if unresolvable or `place` is null. |
+| `standard_place` | string or null | no | Standardized place name (the `standardPlace` field from the `place_search` tool) for `place`. Null if unresolvable or `place` is null. |
 | `description` | string | yes | Human-readable event description |
 | `assertion_ids` | string[] | yes | `a_` references backing this event |
-| `distance_from_previous_km` | number or null | no | Great-circle distance in km from the previous event's place. Null for the first event, or when either event lacks a resolved `place_id`. |
+| `distance_from_previous_km` | number or null | no | Great-circle distance in km from the previous event's place, via `place_distance` on the two `standard_place` names. Null for the first event, or when either event lacks a resolved `standard_place`. |
 | `conflict_ids` | string[] or null | no | `c_` references to open conflicts this event relates to. Provides bidirectional traceability between timeline events and conflict entries. |
 | `conflict_note` | string or null | no | Brief note about how this event relates to the conflicts (e.g., "contradicts birth year in c_002"). |
 

--- a/docs/specs/research-schema-spec.md
+++ b/docs/specs/research-schema-spec.md
@@ -346,7 +346,8 @@ Array of assertion objects. Each assertion is an atomic claim extracted from a r
 | `structured_value` | object or null | no | Machine-readable structured form of the value. Shape depends on `fact_type`. See below |
 | `date` | string or null | no | Date of the event/fact |
 | `date_certainty` | string or null | no | `exact`, `approximate`, `estimated`, `calculated`, `before`, `after`, or `between` |
-| `place` | string or null | no | Place description |
+| `place` | string or null | no | Place description (as recorded) |
+| `standard_place` | string or null | no | Standardized place name (the `standardPlace` from `place_search`) for `place`. Copied from the source record's fact when available, else resolved via `place_search`; null if unresolvable or `place` is null. |
 | `information_quality` | `information_quality` | yes | Primary, Secondary, or Indeterminate — classified at the assertion level |
 | `informant` | string | yes | Who provided this specific information (e.g., "census enumerator", "attending physician", "son-in-law James Brown", "unknown household member") |
 | `informant_proximity` | string | yes | `self`, `witness`, `household_member`, `family_not_present`, `official_duty`, or `unknown` |

--- a/docs/specs/schemas/research.schema.json
+++ b/docs/specs/schemas/research.schema.json
@@ -399,6 +399,7 @@
           ]
         },
         "place": { "type": ["string", "null"] },
+        "standard_place": { "type": ["string", "null"] },
         "information_quality": { "$ref": "enums.schema.json#/$defs/information_quality" },
         "informant": { "type": "string" },
         "informant_proximity": { "$ref": "enums.schema.json#/$defs/informant_proximity" },

--- a/docs/specs/schemas/research.schema.json
+++ b/docs/specs/schemas/research.schema.json
@@ -583,7 +583,7 @@
         "date_certainty": { "$ref": "enums.schema.json#/$defs/date_certainty_timeline" },
         "event_type": { "$ref": "enums.schema.json#/$defs/event_type_recommended" },
         "place": { "type": ["string", "null"] },
-        "place_id": { "type": ["string", "null"] },
+        "standard_place": { "type": ["string", "null"] },
         "description": { "type": "string" },
         "assertion_ids": {
           "type": "array",

--- a/docs/specs/simplified-gedcomx-spec.md
+++ b/docs/specs/simplified-gedcomx-spec.md
@@ -106,7 +106,8 @@ Array of person objects.
 | `primary` | boolean | no | True if this is the primary fact of its type. Omit rather than setting false |
 | `date` | string | no | Date string as originally written (e.g. `2 October 1876`). See Section 4.5 for recognized patterns |
 | `standard_date` | string | no | GEDCOM-canonical form of `date` (e.g. `2 Oct 1876`, `Abt 1850`, `Bef Oct 1855`). Populated by the converter when reading raw GedcomX; LLM-authored facts may omit it. See Section 4.5 |
-| `place` | string | no | Place description as a human-readable string |
+| `place` | string | no | Place description as a human-readable string (the verbatim original text) |
+| `standard_place` | string | no | Standardized place name (the snake_case data-format spelling of `standardPlace` from `place_search`). Populated by the converter from raw `place.normalized`, or resolved from `place` via `place_search` by `toSimplifiedStandardized`. Dropped on reverse conversion, like `standard_date` |
 | `value` | string | no | A qualifier carrying the meaning of the fact when `type + date + place` isn't enough — e.g. `"Newpaper Editor"` for an Occupation fact, `"United States"` for a Citizenship fact, `"Continental Congress"` for a `data:,Elected` fact. Preserved verbatim from raw GedcomX |
 | `sources` | object[] | no | Source references for this fact |
 

--- a/docs/testing-guides/place-collections-tool-testing-guide.md
+++ b/docs/testing-guides/place-collections-tool-testing-guide.md
@@ -31,12 +31,6 @@ Claude: places("Madison") → multiple results → ask user which one
 Claude: collections({ query: "Alabama" }) → Alabama collections
 ```
 
-**Note:** The `place_search` tool and `place_collections` tool use different
-place ID systems. The `query` parameter (place name) is the primary
-way to search collections. A `placeIds` parameter exists for internal
-collection IDs, but these are NOT the same IDs the `place_search` tool
-returns.
-
 ## Before You Start
 
 ### 1. Make sure the server builds and all tests pass
@@ -117,14 +111,6 @@ directly. It's the fastest way to catch API response shape mismatches.
 
    Should return `matchingCollections: 0` and an empty `collections`
    array — no crash.
-
-6. (Optional) Try the placeIds mode with internal IDs:
-
-   ```bash
-   npx tsx scripts/try-place-collections.ts --ids 33
-   ```
-
-   Should return the same Alabama collections.
 
 ### What success looks like
 
@@ -513,7 +499,6 @@ The collections workflow works in Cowork on native Windows.
 | Run tests | `cd mcp-server && npm test` |
 | Smoke test (Alabama) | `cd mcp-server && npx tsx scripts/try-place-collections.ts Alabama` |
 | Smoke test (England) | `cd mcp-server && npx tsx scripts/try-place-collections.ts England` |
-| Smoke test (internal IDs) | `cd mcp-server && npx tsx scripts/try-place-collections.ts --ids 33` |
 | Run Inspector | `cd mcp-server && npx @modelcontextprotocol/inspector node build/index.js` |
 | Wipe session (Linux/WSL) | `rm -f ~/.familysearch-mcp/tokens.json` |
 | Wipe session (PowerShell) | `Remove-Item $env:USERPROFILE\.familysearch-mcp\tokens.json` |

--- a/docs/testing-guides/place-external-links-tool-testing-guide.md
+++ b/docs/testing-guides/place-external-links-tool-testing-guide.md
@@ -8,7 +8,7 @@ catches different problems.
 
 The `place_external_links` tool returns FamilySearch-curated third-party
 genealogy resource URLs for a place and year range. You pass it a
-FamilySearch place ID plus a `[startYear, endYear]` window, and it
+standard place name plus a `[startYear, endYear]` window, and it
 returns every collection FS knows about whose date range overlaps that
 window — plus undated wiki/website resources for that place.
 
@@ -16,8 +16,8 @@ Compared to the existing `place_collections` tool:
 
 - `place_external_links` calls the **public** `/external/collections/search`
   endpoint — no OAuth required.
-- Its primary input is a **place ID** (numeric string, e.g. `"1927089"`
-  for France), not a place name.
+- Its primary input is a **standard place name** (the `standardPlace`
+  field from `place_search`, e.g. `"France"`), not a place ID.
 - Output is `{ url, linkText }[]` plus paging metadata — no record
   counts, because the external endpoint doesn't expose them.
 
@@ -26,15 +26,15 @@ The typical workflow is:
 ```
 [user request: "find me genealogy resources for France 1880-1950"]
         ↓
-places({ query: "France" })  → placeId, place name, etc.
+places({ query: "France" })  → standardPlace, place name, etc.
         ↓
-place_external_links({ placeId, startYear, endYear })
+place_external_links({ standardPlace, startYear, endYear })
                               → list of curated third-party URLs
 ```
 
 The `place_search` tool (sibling in this server) is the upstream source of
-place IDs. Claude should not guess place IDs — it should obtain them
-from `place_search` or from the user.
+standard place names. Claude should not guess place IDs — it should use
+the standard place name from `place_search`, or get it from the user.
 
 ## Before you start
 
@@ -54,15 +54,15 @@ anything is red, fix it first.
 The endpoint is public. Unlike `place_collections`, this tool does not call
 `getValidToken()` and does not require an OAuth session.
 
-### 3. You'll need a real FamilySearch place ID
+### 3. You'll need a real standard place name
 
-For manual testing, the IDs below are stable:
+For manual testing, the place names below are stable:
 
-| Place | Place ID |
-|-------|----------|
-| France | `1927089` |
-| Canada | `1927164` |
-| Iceland | `1927031` |
+| Place | Standard place name |
+|-------|---------------------|
+| France | `France` |
+| Canada | `Canada` |
+| Nigeria | `Nigeria` |
 
 In production these come from the `place_search` tool.
 
@@ -81,7 +81,7 @@ Fastest way to catch API-shape regressions or pagination bugs.
 
    ```bash
    cd mcp-server
-   npx tsx dev/try-place-external-links.ts 1927089 1880 1950
+   npx tsx dev/try-place-external-links.ts "France" 1880 1950
    ```
 
 2. You should see JSON with:
@@ -95,7 +95,7 @@ Fastest way to catch API-shape regressions or pagination bugs.
 3. Try a different country:
 
    ```bash
-   npx tsx dev/try-place-external-links.ts 1927164 1880 1950
+   npx tsx dev/try-place-external-links.ts "Canada" 1880 1950
    ```
 
    Should return `place: "Canada"` and `totalResults` ~470.
@@ -103,7 +103,7 @@ Fastest way to catch API-shape regressions or pagination bugs.
 4. Try the validation guard:
 
    ```bash
-   npx tsx dev/try-place-external-links.ts 1927089 1950 1880
+   npx tsx dev/try-place-external-links.ts "France" 1950 1880
    ```
 
    The script should fail loudly with an error mentioning `endYear must
@@ -126,7 +126,7 @@ in your browser to confirm they're not 404s.
 
 ### When to move on
 
-Move to Layer 1 once two different placeIds return real data and the
+Move to Layer 1 once two different place names return real data and the
 validation guard fires.
 
 ---
@@ -161,7 +161,7 @@ If `place_external_links` is missing, check `src/index.ts` registration
 Call `place_external_links` with:
 
 ```json
-{ "placeId": "1927089", "startYear": 1880, "endYear": 1950 }
+{ "standardPlace": "France", "startYear": 1880, "endYear": 1950 }
 ```
 
 Expected: JSON with `place: "France"`, `totalResults: ~221`,
@@ -170,7 +170,7 @@ Expected: JSON with `place: "France"`, `totalResults: ~221`,
 ### Part B — Sparse window
 
 ```json
-{ "placeId": "1927089", "startYear": 1700, "endYear": 1750 }
+{ "standardPlace": "France", "startYear": 1700, "endYear": 1750 }
 ```
 
 Expected: smaller `matchedCount`. Mostly undated wiki entries plus a
@@ -179,20 +179,20 @@ handful of pre-1750 collections.
 ### Part C — Validation error
 
 ```json
-{ "placeId": "1927089", "startYear": 1950, "endYear": 1880 }
+{ "standardPlace": "France", "startYear": 1950, "endYear": 1880 }
 ```
 
 Expected: a tool error with `isError: true` and a message containing
 `endYear must be greater than or equal to startYear`.
 
-### Part D — Empty result for unknown placeId
+### Part D — Empty result for unresolvable place name
 
 ```json
-{ "placeId": "999999999", "startYear": 1880, "endYear": 1950 }
+{ "standardPlace": "Nowhere", "startYear": 1880, "endYear": 1950 }
 ```
 
-Expected: a *successful* response (not an error) containing
-`place: null, totalResults: 0, matchedCount: 0, results: []`.
+Expected: a tool error with `isError: true` and a message containing
+`Could not resolve "Nowhere" to a FamilySearch place`.
 
 ### What success looks like (Layer 1)
 
@@ -245,34 +245,35 @@ tool from natural language?
 
 4. Test with a natural-language prompt:
 
-   > "Find FamilySearch resource links for place ID 1927089 between
-   > 1880 and 1950."
+   > "Find FamilySearch resource links for France between 1880 and
+   > 1950."
 
 5. Watch what Claude does:
    - Claude should call `place_external_links` with the three fields.
    - Claude should present the URLs (probably summarized or grouped),
      not dump raw JSON.
-   - Claude should not invent a place ID.
+   - Claude should pass the standard place name, not invent a place ID.
 
 6. Test a less explicit prompt:
 
-   > "I'm researching France from 1880 to 1950. The FamilySearch place
-   > ID is 1927089. What external genealogy resources are available?"
+   > "I'm researching France from 1880 to 1950. What external genealogy
+   > resources are available?"
 
    Claude should still pick `place_external_links` — the description mentions
-   place ID and year range explicitly.
+   standard place name and year range explicitly.
 
 ### What success looks like
 
-Claude calls the tool with correct inputs, doesn't try to guess place
-IDs, and presents the URLs in a way the user can act on.
+Claude calls the tool with correct inputs, passes the standard place
+name rather than guessing a place ID, and presents the URLs in a way
+the user can act on.
 
 ### What failure looks like
 
 - Claude doesn't pick the tool → the description doesn't match the
   user's natural language. **Fix the description, not the user.**
-- Claude tries to invent a place ID → strengthen the "do not guess"
-  wording in the schema.
+- Claude tries to invent a place ID → strengthen the "use the standard
+  place name from place_search" wording in the schema.
 - Claude confuses `place_external_links` with `place_collections` → tighten the
   description to clarify they return different things (collections are
   FS's own collections; place_external_links are third-party URLs FS curates).
@@ -288,7 +289,7 @@ If you change the server code:
 ### When to move on
 
 Move to Layer 3 when Claude consistently uses the tool from
-natural-language prompts that mention a place ID and year range.
+natural-language prompts that mention a place name and year range.
 
 ---
 
@@ -393,8 +394,8 @@ mount.
 
 6. Test:
 
-   > "Find FamilySearch external links for place ID 1927089 between
-   > 1880 and 1950."
+   > "Find FamilySearch external links for France between 1880 and
+   > 1950."
 
 7. Verify Claude calls `place_external_links` and presents the URLs.
 
@@ -411,7 +412,7 @@ Cowork → Claude Desktop → WSL2 → MCP server.
 | Server doesn't appear in Settings → Developer | Config edit landed in the unredirected `%APPDATA%\Claude\` path that MSIX Desktop ignores | Use the Edit Config button to open the right file |
 | `wsl.exe: command not found` in log | Desktop's MSIX sandbox can't find wsl.exe on PATH | Use full path: `"command": "C:\\Windows\\System32\\wsl.exe"` (note doubled backslashes for JSON) |
 | `Cannot find module ... build/index.js` | `--cd` path wrong, or `mcp-server/build/` doesn't exist | From WSL2: `ls /home/<you>/cowork-genealogy/mcp-server/build/index.js` |
-| `ETIMEDOUT` / `fetch failed` from the server itself | WSL2 networking issue | Verify the smoke-test script (`npx tsx dev/try-place-external-links.ts ...`) works inside WSL2 first |
+| `ETIMEDOUT` / `fetch failed` from the server itself | WSL2 networking issue | Verify the smoke-test script (`npx tsx dev/try-place-external-links.ts "France" 1880 1950`) works inside WSL2 first |
 
 ### When to move on
 
@@ -499,8 +500,8 @@ The same prompt returns curated URLs in Cowork on native Windows.
 |------|---------|
 | Build server | `cd mcp-server && npm run build` |
 | Run all tests | `cd mcp-server && npm test` |
-| Smoke test (France) | `cd mcp-server && npx tsx dev/try-place-external-links.ts 1927089 1880 1950` |
-| Smoke test (Canada) | `cd mcp-server && npx tsx dev/try-place-external-links.ts 1927164 1880 1950` |
+| Smoke test (France) | `cd mcp-server && npx tsx dev/try-place-external-links.ts "France" 1880 1950` |
+| Smoke test (Canada) | `cd mcp-server && npx tsx dev/try-place-external-links.ts "Canada" 1880 1950` |
 | Run Inspector | `cd mcp-server && npx @modelcontextprotocol/inspector node build/index.js` |
 | Reconnect in Claude Code | `/mcp` |
 | Claude Desktop config | Settings → Developer → Edit Config |

--- a/docs/testing-guides/place-population-tool-testing-guide.md
+++ b/docs/testing-guides/place-population-tool-testing-guide.md
@@ -7,10 +7,10 @@ catches different problems.
 ## What the population tool does (30 seconds)
 
 The `place_population` tool returns historical population data and indexed
-record counts for a FamilySearch place. You pass it a `place_id` like
-`"1927069"` (Nigeria) and optionally a year or year range, and it
-returns population data from multiple sources (populstat, gapminder)
-and FamilySearch indexed birth record counts.
+record counts for a FamilySearch place. You pass it a `standardPlace` name like
+`"Nigeria"` (the `standardPlace` field from `place_search`) and optionally
+a year or year range, and it returns population data from multiple sources
+(populstat, gapminder) and FamilySearch indexed birth record counts.
 
 This is a **no-auth** tool — it calls the Pop Stats API, a separate
 service that must be running on the host. No FamilySearch login needed.
@@ -18,16 +18,16 @@ service that must be running on the host. No FamilySearch login needed.
 The typical user workflow is:
 ```
 User: "What was the population of Nigeria in 1960?"
-Claude: places("Nigeria") → place_id 1927069
-Claude: population({ place_id: "1927069", year: 1960 }) → population data
+Claude: place_search("Nigeria") → standardPlace "Nigeria"
+Claude: place_population({ standardPlace: "Nigeria", year: 1960 }) → population data
 ```
 
 For provinces/towns, the tool automatically resolves country-level data
 (gapminder, indexed records) from the parent country:
 ```
 User: "What's the population data for Badakhshan?"
-Claude: places("Badakhshan") → place_id 1927318
-Claude: population({ place_id: "1927318" }) → province data + parent country data
+Claude: place_search("Badakhshan") → standardPlace "Badakhshan, Afghanistan"
+Claude: place_population({ standardPlace: "Badakhshan, Afghanistan" }) → province data + parent country data
 ```
 
 **Important:** The Pop Stats API must be running for this tool to work.
@@ -82,10 +82,10 @@ directly. It's the fastest way to catch API response shape mismatches.
 
    ```bash
    cd mcp-server
-   npx tsx dev/try-population.ts 1927069
+   npx tsx dev/try-population.ts "Nigeria"
    ```
 
-   This calls `populationTool({ place_id: "1927069" })` — all data
+   This calls `populationTool({ standardPlace: "Nigeria" })` — all data
    for Nigeria.
 
 3. You should see JSON output with:
@@ -96,7 +96,7 @@ directly. It's the fastest way to catch API response shape mismatches.
 4. Try with a specific year:
 
    ```bash
-   npx tsx dev/try-population.ts 1927069 --year 1960
+   npx tsx dev/try-population.ts "Nigeria" --year 1960
    ```
 
    Should return 1960 data for Nigeria.
@@ -104,7 +104,7 @@ directly. It's the fastest way to catch API response shape mismatches.
 5. Try a province (parent resolution):
 
    ```bash
-   npx tsx dev/try-population.ts 1927318 --year 1900
+   npx tsx dev/try-population.ts "Badakhshan, Afghanistan" --year 1900
    ```
 
    This is Badakhshan, Afghanistan. Should return:
@@ -116,7 +116,7 @@ directly. It's the fastest way to catch API response shape mismatches.
 6. Try a year range:
 
    ```bash
-   npx tsx dev/try-population.ts 1927069 --year-start 1900 --year-end 1950
+   npx tsx dev/try-population.ts "Nigeria" --year-start 1900 --year-end 1950
    ```
 
    Should return multiple data points within that range.
@@ -131,8 +131,8 @@ fields should be valid URLs (try opening one in your browser).
 | Symptom | Likely cause | Fix |
 |---------|--------------|-----|
 | "Population data service is unavailable" | Pop Stats API not running | Start it: `uv run uvicorn api.app:app --port 8000` |
-| "Population API error: 404" | Invalid place_id | Use a valid ID from the matched data |
-| Empty population/indexed_records | Place not in the database | Check `data/matches/` for valid place IDs |
+| "Population API error: 404" | `standardPlace` resolved to a place not in the Pop Stats database | Use a place name that matches the indexed data |
+| Empty population/indexed_records | Place not in the database | Check `data/matches/` for places with data |
 | Connection refused | Wrong port or API not running | Check the API is on port 8000 |
 
 ### When to move on
@@ -173,7 +173,7 @@ registers it.
 2. In the Inspector, call **`place_population`** with:
 
    ```json
-   { "place_id": "1927069" }
+   { "standardPlace": "Nigeria" }
    ```
 
 3. Expected response: an error with `isError: true` and a message like:
@@ -191,7 +191,7 @@ registers it.
 2. In the Inspector, call **`place_population`** with:
 
    ```json
-   { "place_id": "1927069" }
+   { "standardPlace": "Nigeria" }
    ```
 
 3. Expected response: JSON with `place`, `population`, and
@@ -200,7 +200,7 @@ registers it.
 4. Try with a year filter:
 
    ```json
-   { "place_id": "1927069", "year": 1960 }
+   { "standardPlace": "Nigeria", "year": 1960 }
    ```
 
    Should return 1960-specific data.
@@ -208,26 +208,26 @@ registers it.
 5. Try a province:
 
    ```json
-   { "place_id": "1927318" }
+   { "standardPlace": "Badakhshan, Afghanistan" }
    ```
 
    Should return Badakhshan data with parent resolution for gapminder
    and indexed records.
 
-6. Try with no place_id:
+6. Try with no standardPlace:
 
    ```json
    {}
    ```
 
-   Should return an error: `"place_id is required"`.
+   Should return an error: `"standardPlace is required"`.
 
 ### What success looks like (Layer 1)
 
 - Tool shows up in the Inspector.
 - Without API: clear error about the service being unavailable.
 - With API: structured population data returned.
-- Missing place_id: validation error, no crash.
+- Missing standardPlace: validation error, no crash.
 
 ### What failure looks like
 
@@ -301,7 +301,7 @@ citing sources and noting when data comes from a parent country.
 - Claude doesn't use `place_population` at all → the tool description
   doesn't match the user's natural language.
 - Claude tries to call `place_population` without calling `place_search` first →
-  it guessed a place_id instead of looking it up.
+  it guessed a `standardPlace` name instead of looking it up.
 - Claude gets "service unavailable" → Pop Stats API isn't running.
 
 ### Troubleshooting
@@ -418,7 +418,7 @@ through the WSL2 bridge?
 
 ### What success looks like
 
-Claude calls `population({ place_id: "1927069", year: 1960 })` and
+Claude calls `place_population({ standardPlace: "Nigeria", year: 1960 })` and
 returns Nigeria's population data, running through the full Cowork →
 Claude Desktop → WSL2 → MCP server → Pop Stats API pipeline.
 
@@ -540,9 +540,9 @@ The population workflow works in Cowork on native Windows.
 | Build server | `cd mcp-server && npm run build` |
 | Run tests | `cd mcp-server && npm test` |
 | Start Pop Stats API | `cd pop-stats-api && uv run uvicorn api.app:app --port 8000` |
-| Smoke test (Nigeria) | `cd mcp-server && npx tsx dev/try-population.ts 1927069` |
-| Smoke test (year) | `cd mcp-server && npx tsx dev/try-population.ts 1927069 --year 1960` |
-| Smoke test (province) | `cd mcp-server && npx tsx dev/try-population.ts 1927318 --year 1900` |
+| Smoke test (Nigeria) | `cd mcp-server && npx tsx dev/try-population.ts "Nigeria"` |
+| Smoke test (year) | `cd mcp-server && npx tsx dev/try-population.ts "Nigeria" --year 1960` |
+| Smoke test (province) | `cd mcp-server && npx tsx dev/try-population.ts "Badakhshan, Afghanistan" --year 1900` |
 | Run Inspector | `cd mcp-server && npx @modelcontextprotocol/inspector node build/index.js` |
 | Reconnect in Claude Code | `/mcp` |
 | Claude Desktop config | Settings → Developer → Edit Config |

--- a/eval/app/components/scenario/lib/schema.ts
+++ b/eval/app/components/scenario/lib/schema.ts
@@ -186,6 +186,7 @@ export interface Assertion {
   date: string | null
   date_certainty: DateCertainty | null
   place: string | null
+  standard_place?: string | null
   information_quality: InformationQuality
   informant: string
   informant_proximity: InformantProximity

--- a/eval/app/components/scenario/lib/schema.ts
+++ b/eval/app/components/scenario/lib/schema.ts
@@ -239,7 +239,7 @@ export interface TimelineEvent {
   date_certainty: string
   event_type: string
   place: string | null
-  place_id?: string | null
+  standard_place?: string | null
   description: string
   assertion_ids: string[]
   distance_from_previous_km?: number | null

--- a/eval/fixtures/mcp/place-collections-pennsylvania.json
+++ b/eval/fixtures/mcp/place-collections-pennsylvania.json
@@ -1,8 +1,11 @@
 {
   "tool": "place_collections",
   "description": "FamilySearch collections for Pennsylvania (state-level query). SKILL.md guidance tells locality-guide and similar skills to query the enclosing state, not the county; this fixture returns the collections a Pennsylvania researcher would actually see.",
-  "args": { "query": "~Pennsylvania" },
+  "args": {
+    "standardPlace": "~Pennsylvania"
+  },
   "response": {
+    "standardPlace": "Pennsylvania, United States",
     "query": "Pennsylvania",
     "matchingCollections": 6,
     "collections": [

--- a/eval/fixtures/mcp/place-collections-schuylkill.json
+++ b/eval/fixtures/mcp/place-collections-schuylkill.json
@@ -1,9 +1,12 @@
 {
   "tool": "place_collections",
   "description": "FamilySearch collections for Schuylkill County, Pennsylvania",
-  "args": { "query": "~Schuylkill" },
+  "args": {
+    "standardPlace": "~Schuylkill"
+  },
   "response": {
-    "query": "Schuylkill",
+    "standardPlace": "Schuylkill, Pennsylvania, United States",
+    "query": "Pennsylvania",
     "matchingCollections": 1,
     "collections": [
       {

--- a/eval/fixtures/mcp/place-external-links-schuylkill.json
+++ b/eval/fixtures/mcp/place-external-links-schuylkill.json
@@ -1,8 +1,11 @@
 {
   "tool": "place_external_links",
   "description": "External genealogy links for Schuylkill County, 1840-1860",
-  "args": { "placeId": "~" },
+  "args": {
+    "standardPlace": "~"
+  },
   "response": {
+    "standardPlace": "Schuylkill, Pennsylvania, United States",
     "place": "Schuylkill, Pennsylvania, United States",
     "totalResults": 2,
     "matchedCount": 2,

--- a/eval/fixtures/mcp/place-search-ireland-by-name.json
+++ b/eval/fixtures/mcp/place-search-ireland-by-name.json
@@ -1,19 +1,17 @@
 {
   "tool": "place_search",
-  "description": "Fallback variant: catches place_search calls that use the non-canonical 'name' arg instead of 'query'. Same response payload as place-search-ireland.",
-  "args": { "name": "~Ireland" },
+  "description": "Fallback variant: catches place_search calls that use the non-canonical 'name' arg instead of 'placeName'. Same response payload as place-search-ireland.",
+  "args": {
+    "name": "~Ireland"
+  },
   "response": {
     "results": [
       {
-        "placeId": "296",
-        "placeRepId": "10",
-        "name": "Ireland",
-        "fullName": "Ireland",
+        "standardPlace": "Ireland",
         "type": "Country",
+        "dateRange": "+1801/",
         "latitude": 53.0,
         "longitude": -8.0,
-        "dateRange": "+1801/",
-        "score": 100.0,
         "familysearchUrl": "https://www.familysearch.org/en/research/places/?text=Ireland&focusedId=10"
       }
     ]

--- a/eval/fixtures/mcp/place-search-ireland-by-place.json
+++ b/eval/fixtures/mcp/place-search-ireland-by-place.json
@@ -1,19 +1,17 @@
 {
   "tool": "place_search",
-  "description": "Fallback variant: catches place_search calls that use the non-canonical 'place' arg instead of 'query'. Same response payload as place-search-ireland.",
-  "args": { "place": "~Ireland" },
+  "description": "Fallback variant: catches place_search calls that use the non-canonical 'place' arg instead of 'placeName'. Same response payload as place-search-ireland.",
+  "args": {
+    "place": "~Ireland"
+  },
   "response": {
     "results": [
       {
-        "placeId": "296",
-        "placeRepId": "10",
-        "name": "Ireland",
-        "fullName": "Ireland",
+        "standardPlace": "Ireland",
         "type": "Country",
+        "dateRange": "+1801/",
         "latitude": 53.0,
         "longitude": -8.0,
-        "dateRange": "+1801/",
-        "score": 100.0,
         "familysearchUrl": "https://www.familysearch.org/en/research/places/?text=Ireland&focusedId=10"
       }
     ]

--- a/eval/fixtures/mcp/place-search-ireland.json
+++ b/eval/fixtures/mcp/place-search-ireland.json
@@ -1,19 +1,17 @@
 {
   "tool": "place_search",
   "description": "FamilySearch place data for Ireland",
-  "args": { "query": "~Ireland" },
+  "args": {
+    "placeName": "~Ireland"
+  },
   "response": {
     "results": [
       {
-        "placeId": "296",
-        "placeRepId": "10",
-        "name": "Ireland",
-        "fullName": "Ireland",
+        "standardPlace": "Ireland",
         "type": "Country",
+        "dateRange": "+1801/",
         "latitude": 53.0,
         "longitude": -8.0,
-        "dateRange": "+1801/",
-        "score": 100.0,
         "familysearchUrl": "https://www.familysearch.org/en/research/places/?text=Ireland&focusedId=10"
       }
     ]

--- a/eval/fixtures/mcp/place-search-pennsylvania-by-name.json
+++ b/eval/fixtures/mcp/place-search-pennsylvania-by-name.json
@@ -1,19 +1,17 @@
 {
   "tool": "place_search",
-  "description": "Fallback variant: catches place_search calls that use the non-canonical 'name' arg instead of 'query'. Same response payload as place-search-pennsylvania.",
-  "args": { "name": "~Pennsylvania" },
+  "description": "Fallback variant: catches place_search calls that use the non-canonical 'name' arg instead of 'placeName'. Same response payload as place-search-pennsylvania.",
+  "args": {
+    "name": "~Pennsylvania"
+  },
   "response": {
     "results": [
       {
-        "placeId": "335",
-        "placeRepId": "39",
-        "name": "Pennsylvania",
-        "fullName": "Pennsylvania, United States",
+        "standardPlace": "Pennsylvania, United States",
         "type": "State",
+        "dateRange": "+1787/",
         "latitude": 40.5,
         "longitude": -77.5,
-        "dateRange": "+1787/",
-        "score": 100.0,
         "familysearchUrl": "https://www.familysearch.org/en/research/places/?text=Pennsylvania&focusedId=39"
       }
     ]

--- a/eval/fixtures/mcp/place-search-pennsylvania-by-place.json
+++ b/eval/fixtures/mcp/place-search-pennsylvania-by-place.json
@@ -1,19 +1,17 @@
 {
   "tool": "place_search",
-  "description": "Fallback variant: catches place_search calls that use the non-canonical 'place' arg instead of 'query'. Same response payload as place-search-pennsylvania.",
-  "args": { "place": "~Pennsylvania" },
+  "description": "Fallback variant: catches place_search calls that use the non-canonical 'place' arg instead of 'placeName'. Same response payload as place-search-pennsylvania.",
+  "args": {
+    "place": "~Pennsylvania"
+  },
   "response": {
     "results": [
       {
-        "placeId": "335",
-        "placeRepId": "39",
-        "name": "Pennsylvania",
-        "fullName": "Pennsylvania, United States",
+        "standardPlace": "Pennsylvania, United States",
         "type": "State",
+        "dateRange": "+1787/",
         "latitude": 40.5,
         "longitude": -77.5,
-        "dateRange": "+1787/",
-        "score": 100.0,
         "familysearchUrl": "https://www.familysearch.org/en/research/places/?text=Pennsylvania&focusedId=39"
       }
     ]

--- a/eval/fixtures/mcp/place-search-pennsylvania.json
+++ b/eval/fixtures/mcp/place-search-pennsylvania.json
@@ -1,19 +1,17 @@
 {
   "tool": "place_search",
   "description": "FamilySearch place data for Pennsylvania (state-level lookup, used when an assertion's birthplace is just 'Pennsylvania' without a county)",
-  "args": { "query": "~Pennsylvania" },
+  "args": {
+    "placeName": "~Pennsylvania"
+  },
   "response": {
     "results": [
       {
-        "placeId": "335",
-        "placeRepId": "39",
-        "name": "Pennsylvania",
-        "fullName": "Pennsylvania, United States",
+        "standardPlace": "Pennsylvania, United States",
         "type": "State",
+        "dateRange": "+1787/",
         "latitude": 40.5,
         "longitude": -77.5,
-        "dateRange": "+1787/",
-        "score": 100.0,
         "familysearchUrl": "https://www.familysearch.org/en/research/places/?text=Pennsylvania&focusedId=39"
       }
     ]

--- a/eval/fixtures/mcp/place-search-schuylkill-by-id.json
+++ b/eval/fixtures/mcp/place-search-schuylkill-by-id.json
@@ -1,23 +1,20 @@
 {
   "tool": "place_search",
-  "description": "FamilySearch place lookup by placeRepId (catch-all for any ID-based place lookup in this test)",
-  "args": { "placeRepId": "~" },
+  "description": "FamilySearch place data for Schuylkill County — variant matching an ID-based `placeRepId` arg (non-canonical; the real parameter is `placeName`). Same response shape as place-search-schuylkill-county so the run grades rather than aborts; the Tool Arguments dimension surfaces the wrong arg name.",
+  "args": {
+    "placeRepId": "~"
+  },
   "response": {
-    "placeId": "326",
-    "name": "Schuylkill",
-    "fullName": "Schuylkill, Pennsylvania, United States",
-    "type": "County",
-    "latitude": 40.7,
-    "longitude": -76.2,
-    "dateRange": "1811-01-01 to present",
-    "parentPlaceId": "50",
-    "wikipedia": {
-      "title": "Schuylkill County, Pennsylvania",
-      "extract": "Schuylkill County is a county in the U.S. state of Pennsylvania, known historically as a center of anthracite coal mining.",
-      "url": "https://en.wikipedia.org/wiki/Schuylkill_County,_Pennsylvania"
-    },
-    "urls": {
-      "familysearch": "https://www.familysearch.org/en/wiki/Schuylkill_County,_Pennsylvania_Genealogy"
-    }
+    "results": [
+      {
+        "standardPlace": "Schuylkill, Pennsylvania, United States",
+        "type": "County",
+        "dateRange": "+1811/",
+        "latitude": 40.7,
+        "longitude": -76.2,
+        "familysearchUrl": "https://www.familysearch.org/en/research/places/?text=Schuylkill&focusedId=7042",
+        "wikipediaUrl": "https://en.wikipedia.org/wiki/Schuylkill_County,_Pennsylvania"
+      }
+    ]
   }
 }

--- a/eval/fixtures/mcp/place-search-schuylkill-by-name.json
+++ b/eval/fixtures/mcp/place-search-schuylkill-by-name.json
@@ -1,19 +1,17 @@
 {
   "tool": "place_search",
-  "description": "FamilySearch place data for Schuylkill County — variant matching `name` arg (non-canonical; the real tool parameter is `query`). Same response payload as place-search-schuylkill-county so the run grades rather than aborts; the Tool Arguments dimension surfaces the wrong arg name.",
-  "args": { "name": "~Schuylkill" },
+  "description": "FamilySearch place data for Schuylkill County — variant matching `name` arg (non-canonical; the real tool parameter is `placeName`). Same response payload as place-search-schuylkill-county so the run grades rather than aborts; the Tool Arguments dimension surfaces the wrong arg name.",
+  "args": {
+    "name": "~Schuylkill"
+  },
   "response": {
     "results": [
       {
-        "placeId": "326",
-        "placeRepId": "7042",
-        "name": "Schuylkill",
-        "fullName": "Schuylkill, Pennsylvania, United States",
+        "standardPlace": "Schuylkill, Pennsylvania, United States",
         "type": "County",
+        "dateRange": "+1811/",
         "latitude": 40.7,
         "longitude": -76.2,
-        "dateRange": "+1811/",
-        "score": 100.0,
         "familysearchUrl": "https://www.familysearch.org/en/research/places/?text=Schuylkill&focusedId=7042"
       }
     ]

--- a/eval/fixtures/mcp/place-search-schuylkill-by-place.json
+++ b/eval/fixtures/mcp/place-search-schuylkill-by-place.json
@@ -1,19 +1,17 @@
 {
   "tool": "place_search",
-  "description": "FamilySearch place data for Schuylkill County — variant matching `place` arg (non-canonical; real parameter is `query`). Same response payload as place-search-schuylkill-county so the run grades rather than aborts.",
-  "args": { "place": "~Schuylkill" },
+  "description": "FamilySearch place data for Schuylkill County — variant matching `place` arg (non-canonical; real parameter is `placeName`). Same response payload as place-search-schuylkill-county so the run grades rather than aborts.",
+  "args": {
+    "place": "~Schuylkill"
+  },
   "response": {
     "results": [
       {
-        "placeId": "326",
-        "placeRepId": "7042",
-        "name": "Schuylkill",
-        "fullName": "Schuylkill, Pennsylvania, United States",
+        "standardPlace": "Schuylkill, Pennsylvania, United States",
         "type": "County",
+        "dateRange": "+1811/",
         "latitude": 40.7,
         "longitude": -76.2,
-        "dateRange": "+1811/",
-        "score": 100.0,
         "familysearchUrl": "https://www.familysearch.org/en/research/places/?text=Schuylkill&focusedId=7042"
       }
     ]

--- a/eval/fixtures/mcp/place-search-schuylkill-county.json
+++ b/eval/fixtures/mcp/place-search-schuylkill-county.json
@@ -1,19 +1,17 @@
 {
   "tool": "place_search",
   "description": "FamilySearch place data for Schuylkill County, Pennsylvania",
-  "args": { "query": "~Schuylkill" },
+  "args": {
+    "placeName": "~Schuylkill"
+  },
   "response": {
     "results": [
       {
-        "placeId": "326",
-        "placeRepId": "7042",
-        "name": "Schuylkill",
-        "fullName": "Schuylkill, Pennsylvania, United States",
+        "standardPlace": "Schuylkill, Pennsylvania, United States",
         "type": "County",
+        "dateRange": "+1811/",
         "latitude": 40.7,
         "longitude": -76.2,
-        "dateRange": "+1811/",
-        "score": 100.0,
         "familysearchUrl": "https://www.familysearch.org/en/research/places/?text=Schuylkill&focusedId=7042"
       }
     ]

--- a/mcp-server/dev/try-metadata-search.ts
+++ b/mcp-server/dev/try-metadata-search.ts
@@ -3,10 +3,10 @@
  *
  * Usage:
  *   cd mcp-server
- *   npx tsx dev/try-metadata-search.ts --placeId 6137147 --from 1730-01-01 --to 1810-12-31
+ *   npx tsx dev/try-metadata-search.ts --standardPlace "Edensor, Derbyshire, England, United Kingdom" --from 1730-01-01 --to 1810-12-31
  *
  * Requires a valid FamilySearch session (run the login tool first).
- * The Edensor, Derbyshire placeId 6137147 is a known small result set.
+ * Edensor, Derbyshire is a known small result set.
  */
 
 import { metadataSearchTool } from "../src/tools/metadata-search.js";
@@ -18,18 +18,19 @@ function getArg(flag: string): string | undefined {
   return idx !== -1 ? args[idx + 1] : undefined;
 }
 
-const placeId = getArg("--placeId") ?? "6137147";
+const standardPlace =
+  getArg("--standardPlace") ?? "Edensor, Derbyshire, England, United Kingdom";
 const fromDate = getArg("--from");
 const toDate = getArg("--to");
 const pageToken = getArg("--pageToken");
 
 console.log("metadata_search smoke test");
-console.log("Input:", { placeId, fromDate, toDate, pageToken });
+console.log("Input:", { standardPlace, fromDate, toDate, pageToken });
 console.log("---");
 
 try {
   const result = await metadataSearchTool({
-    placeId,
+    standardPlace,
     ...(fromDate ? { fromDate } : {}),
     ...(toDate ? { toDate } : {}),
     ...(pageToken ? { pageToken } : {}),

--- a/mcp-server/dev/try-place-collections.ts
+++ b/mcp-server/dev/try-place-collections.ts
@@ -3,15 +3,15 @@ import { placeCollectionsTool } from "../src/tools/place-collections.js";
 const arg = process.argv[2];
 if (!arg) {
   console.error("Usage:");
-  console.error('  npx tsx dev/try-place-collections.ts Alabama   # Search by place name');
+  console.error('  npx tsx dev/try-place-collections.ts "Schuylkill, Pennsylvania, United States"   # list by standardPlace');
   console.error('  npx tsx dev/try-place-collections.ts 1743384   # (a collection id triggers detail mode)');
   process.exit(1);
 }
 
 // A numeric-looking arg is treated as a collection id (detail mode); otherwise
-// it is a place-name query.
+// it is a standardPlace (or plain place query).
 const result = /^\d+$/.test(arg)
   ? await placeCollectionsTool({ id: arg })
-  : await placeCollectionsTool({ query: arg });
+  : await placeCollectionsTool({ standardPlace: arg });
 
 console.log(JSON.stringify(result, null, 2));

--- a/mcp-server/dev/try-place-collections.ts
+++ b/mcp-server/dev/try-place-collections.ts
@@ -3,23 +3,15 @@ import { placeCollectionsTool } from "../src/tools/place-collections.js";
 const arg = process.argv[2];
 if (!arg) {
   console.error("Usage:");
-  console.error("  npx tsx scripts/try-collections.ts Alabama          # Search by place name");
-  console.error("  npx tsx scripts/try-collections.ts --ids 33         # Filter by internal place IDs");
-  console.error("  npx tsx scripts/try-collections.ts --ids 33,325     # Multiple internal IDs");
+  console.error('  npx tsx dev/try-place-collections.ts Alabama   # Search by place name');
+  console.error('  npx tsx dev/try-place-collections.ts 1743384   # (a collection id triggers detail mode)');
   process.exit(1);
 }
 
-let result;
-if (arg === "--ids") {
-  const idsArg = process.argv[3];
-  if (!idsArg) {
-    console.error("Provide comma-separated place IDs after --ids");
-    process.exit(1);
-  }
-  const placeIds = idsArg.split(",").map((s) => parseInt(s.trim(), 10));
-  result = await placeCollectionsTool({ placeIds });
-} else {
-  result = await placeCollectionsTool({ query: arg });
-}
+// A numeric-looking arg is treated as a collection id (detail mode); otherwise
+// it is a place-name query.
+const result = /^\d+$/.test(arg)
+  ? await placeCollectionsTool({ id: arg })
+  : await placeCollectionsTool({ query: arg });
 
 console.log(JSON.stringify(result, null, 2));

--- a/mcp-server/dev/try-place-distance.ts
+++ b/mcp-server/dev/try-place-distance.ts
@@ -1,14 +1,14 @@
 import { placeDistanceTool } from "../src/tools/distance.js";
 
-const [place_id1, place_id2] = process.argv.slice(2);
+const [standardPlace1, standardPlace2] = process.argv.slice(2);
 
-if (!place_id1 || !place_id2) {
-  console.error("Usage: npx tsx dev/try-place-distance.ts <place_id1> <place_id2>");
-  console.error("Example: npx tsx dev/try-place-distance.ts 267 456");
+if (!standardPlace1 || !standardPlace2) {
+  console.error('Usage: npx tsx dev/try-place-distance.ts "<standardPlace1>" "<standardPlace2>"');
+  console.error('Example: npx tsx dev/try-place-distance.ts "England, United Kingdom" "Ohio, United States"');
   process.exit(1);
 }
 
-const result = await placeDistanceTool({ placeId1: place_id1, placeId2: place_id2 });
-console.log(`Distance from ${result.place1Name} to ${result.place2Name}:`);
+const result = await placeDistanceTool({ standardPlace1, standardPlace2 });
+console.log(`Distance from ${result.standardPlace1} to ${result.standardPlace2}:`);
 console.log(`  ${result.miles.toLocaleString()} miles`);
 console.log(`  ${result.kilometers.toLocaleString()} km`);

--- a/mcp-server/dev/try-place-external-links.ts
+++ b/mcp-server/dev/try-place-external-links.ts
@@ -1,27 +1,27 @@
 import { placeExternalLinksTool } from "../src/tools/place-external-links.js";
 
-const placeId = process.argv[2];
+const standardPlace = process.argv[2];
 const startYear = process.argv[3];
 const endYear = process.argv[4];
 
-if (!placeId || !startYear || !endYear) {
+if (!standardPlace || !startYear || !endYear) {
   console.error("Usage:");
   console.error(
-    "  npx tsx dev/try-place-external-links.ts <placeId> <startYear> <endYear>"
+    '  npx tsx dev/try-place-external-links.ts "<standardPlace>" <startYear> <endYear>'
   );
   console.error("");
   console.error("Examples:");
   console.error(
-    "  npx tsx dev/try-place-external-links.ts 1927089 1880 1950   # France"
+    '  npx tsx dev/try-place-external-links.ts "France" 1880 1950'
   );
   console.error(
-    "  npx tsx dev/try-place-external-links.ts 1927164 1880 1950   # Canada"
+    '  npx tsx dev/try-place-external-links.ts "Canada" 1880 1950'
   );
   process.exit(1);
 }
 
 const result = await placeExternalLinksTool({
-  placeId,
+  standardPlace,
   startYear: Number.parseInt(startYear, 10),
   endYear: Number.parseInt(endYear, 10),
 });

--- a/mcp-server/dev/try-population.ts
+++ b/mcp-server/dev/try-population.ts
@@ -1,6 +1,6 @@
-import { populationTool } from "../src/tools/population.js";
+import { populationTool } from "../src/tools/place-population.js";
 
-const place_id = process.argv[2] ?? "1927069";
+const standardPlace = process.argv[2] ?? "Nigeria";
 
 const yearFlag = process.argv.indexOf("--year");
 const startFlag = process.argv.indexOf("--year-start");
@@ -10,5 +10,5 @@ const year = yearFlag !== -1 ? Number(process.argv[yearFlag + 1]) : undefined;
 const year_start = startFlag !== -1 ? Number(process.argv[startFlag + 1]) : undefined;
 const year_end = endFlag !== -1 ? Number(process.argv[endFlag + 1]) : undefined;
 
-const result = await populationTool({ placeId: place_id, year, year_start, year_end });
+const result = await populationTool({ standardPlace, year, year_start, year_end });
 console.log(JSON.stringify(result, null, 2));

--- a/mcp-server/src/tools/distance.ts
+++ b/mcp-server/src/tools/distance.ts
@@ -1,4 +1,4 @@
-import { getPlaceByPrimaryId } from "./place-search.js";
+import { standardPlaceToCoords } from "../utils/place-resolver.js";
 
 const EARTH_RADIUS_KM = 6371;
 const KM_TO_MILES = 0.621371;
@@ -29,15 +29,13 @@ export function haversineDistance(
 }
 
 export interface PlaceDistanceInput {
-  placeId1: string;
-  placeId2: string;
+  standardPlace1: string;
+  standardPlace2: string;
 }
 
 export interface PlaceDistanceResult {
-  placeId1: string;
-  placeId2: string;
-  place1Name: string;
-  place2Name: string;
+  standardPlace1: string;
+  standardPlace2: string;
   miles: number;
   kilometers: number;
 }
@@ -45,40 +43,34 @@ export interface PlaceDistanceResult {
 export async function placeDistanceTool(
   input: PlaceDistanceInput
 ): Promise<PlaceDistanceResult> {
-  const [place1, place2] = await Promise.all([
-    getPlaceByPrimaryId(input.placeId1),
-    getPlaceByPrimaryId(input.placeId2),
+  const [coords1, coords2] = await Promise.all([
+    standardPlaceToCoords(input.standardPlace1),
+    standardPlaceToCoords(input.standardPlace2),
   ]);
 
-  if (!place1) {
-    throw new Error(`Place not found: ${input.placeId1}`);
-  }
-  if (!place2) {
-    throw new Error(`Place not found: ${input.placeId2}`);
-  }
-  if (place1.latitude === undefined || place1.longitude === undefined) {
+  if (!coords1) {
     throw new Error(
-      `Place "${place1.name}" (ID ${input.placeId1}) has no coordinates.`
+      `Could not resolve coordinates for "${input.standardPlace1}". ` +
+        `Use place_search to get a standard place name first.`
     );
   }
-  if (place2.latitude === undefined || place2.longitude === undefined) {
+  if (!coords2) {
     throw new Error(
-      `Place "${place2.name}" (ID ${input.placeId2}) has no coordinates.`
+      `Could not resolve coordinates for "${input.standardPlace2}". ` +
+        `Use place_search to get a standard place name first.`
     );
   }
 
   const { miles, kilometers } = haversineDistance(
-    place1.latitude,
-    place1.longitude,
-    place2.latitude,
-    place2.longitude
+    coords1.latitude,
+    coords1.longitude,
+    coords2.latitude,
+    coords2.longitude
   );
 
   return {
-    placeId1: input.placeId1,
-    placeId2: input.placeId2,
-    place1Name: place1.fullName,
-    place2Name: place2.fullName,
+    standardPlace1: input.standardPlace1,
+    standardPlace2: input.standardPlace2,
     miles,
     kilometers,
   };
@@ -87,20 +79,25 @@ export async function placeDistanceTool(
 export const placeDistanceToolSchema = {
   name: "place_distance",
   description:
-    "Calculate the approximate straight-line distance in miles and kilometers between two FamilySearch places. " +
-    "Pass two numeric FamilySearch place IDs. Use the places tool first if you only have place names and need their IDs.",
+    "Calculate the approximate straight-line distance in miles and kilometers " +
+    "between two places. Pass two standard place names (the `standardPlace` " +
+    "field from place_search); the tool resolves each to coordinates internally.",
   inputSchema: {
     type: "object" as const,
     properties: {
-      placeId1: {
+      standardPlace1: {
         type: "string",
-        description: "The FamilySearch place ID of the first place.",
+        description:
+          'The standard place name of the first place (the `standardPlace` ' +
+          'field from place_search, e.g. "Paris, Bear Lake, Idaho, United States").',
       },
-      placeId2: {
+      standardPlace2: {
         type: "string",
-        description: "The FamilySearch place ID of the second place.",
+        description:
+          "The standard place name of the second place (the `standardPlace` " +
+          "field from place_search).",
       },
     },
-    required: ["placeId1", "placeId2"],
+    required: ["standardPlace1", "standardPlace2"],
   },
 };

--- a/mcp-server/src/tools/metadata-search.ts
+++ b/mcp-server/src/tools/metadata-search.ts
@@ -164,10 +164,13 @@ export async function metadataSearchTool(
 ): Promise<MetadataSearchResult> {
   validate(input);
 
+  // Auth first, so an unauthenticated user always gets the login-instruction
+  // error (rather than a "could not resolve" message) regardless of the place.
+  const token = await getValidToken();
+
   // Resolve the standard place name -> placeId -> all of its representation
   // IDs. standardPlaceToPlaceId returns null when the name is unresolvable or
-  // resolves to multiple distinct spots (guards the fan-out). Done before
-  // getValidToken so an unresolvable place fails fast without an auth call.
+  // resolves to multiple distinct spots (guards the fan-out).
   const placeId = await standardPlaceToPlaceId(input.standardPlace);
   if (!placeId) {
     throw new Error(
@@ -183,11 +186,11 @@ export async function metadataSearchTool(
     );
   }
 
-  const token = await getValidToken();
-
   const body: MetadataRmsSearchRequest = {
     coverage: {
-      placeRepIds,
+      // RMS expects numeric rep IDs; the resolver returns them as strings.
+      // Drop any non-numeric id rather than emitting NaN (-> null) into the body.
+      placeRepIds: placeRepIds.map(Number).filter((n) => !Number.isNaN(n)),
       ...(input.fromDate ? { fromDateString: input.fromDate } : {}),
       ...(input.toDate ? { toDateString: input.toDate } : {}),
     },

--- a/mcp-server/src/tools/metadata-search.ts
+++ b/mcp-server/src/tools/metadata-search.ts
@@ -1,6 +1,6 @@
 import { getValidToken } from "../auth/refresh.js";
 import { BROWSER_USER_AGENT } from "../constants.js";
-import { placeIdToRepIds } from "./place-search.js";
+import { standardPlaceToPlaceId, placeIdToRepIds } from "../utils/place-resolver.js";
 import type {
   MetadataSearchInput,
   MetadataSearchResult,
@@ -22,8 +22,8 @@ const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
 const RECORD_TYPE_PLACEHOLDER_RE = /^(concept-id|title):/;
 
 function validate(input: MetadataSearchInput): void {
-  if (!input.placeId) {
-    throw new Error("metadata_search requires a placeId.");
+  if (!input.standardPlace) {
+    throw new Error("metadata_search requires a standardPlace.");
   }
   if (input.fromDate && !DATE_RE.test(input.fromDate)) {
     throw new Error(
@@ -164,14 +164,26 @@ export async function metadataSearchTool(
 ): Promise<MetadataSearchResult> {
   validate(input);
 
-  const token = await getValidToken();
-
-  const placeRepIds = await placeIdToRepIds(input.placeId, token);
-  if (placeRepIds.length === 0) {
+  // Resolve the standard place name -> placeId -> all of its representation
+  // IDs. standardPlaceToPlaceId returns null when the name is unresolvable or
+  // resolves to multiple distinct spots (guards the fan-out). Done before
+  // getValidToken so an unresolvable place fails fast without an auth call.
+  const placeId = await standardPlaceToPlaceId(input.standardPlace);
+  if (!placeId) {
     throw new Error(
-      `No place representations found for placeId ${input.placeId}.`
+      `Could not resolve "${input.standardPlace}" to a single place; ` +
+        "use place_search to get a standard place name first."
     );
   }
+
+  const placeRepIds = await placeIdToRepIds(placeId);
+  if (placeRepIds.length === 0) {
+    throw new Error(
+      `No place representations found for "${input.standardPlace}".`
+    );
+  }
+
+  const token = await getValidToken();
 
   const body: MetadataRmsSearchRequest = {
     coverage: {
@@ -197,7 +209,7 @@ export async function metadataSearchTool(
 
   const mappedGroups = groups.map((g) => mapGroup(g, fulltextSet));
 
-  const query: MetadataSearchResult["query"] = { placeId: input.placeId };
+  const query: MetadataSearchResult["query"] = { standardPlace: input.standardPlace };
   if (input.fromDate) query.fromDate = input.fromDate;
   if (input.toDate) query.toDate = input.toDate;
 
@@ -220,23 +232,24 @@ export const metadataSearchSchema = {
   description:
     "Search FamilySearch's Records Management Service for image groups — " +
     "digitized volumes of historical documents (microfilm rolls, book scans) — " +
-    "covering a place and date range. Provide a placeId from place_search and an " +
+    "covering a place and date range. Provide a standardPlace from place_search and an " +
     "optional date range. For each volume it returns coverage (places, dates, " +
     "record types), how much of the volume is indexed for record_search " +
     "(recordSearchablePercent), and whether it is full-text searchable " +
     "(fulltextSearchable). Use the returned imageGroupNumber with image_search to " +
     "list the volume's images, or with fulltext_search to search its text. " +
-    "Results are paginated — pass back nextPageToken (with the same placeId and " +
+    "Results are paginated — pass back nextPageToken (with the same standardPlace and " +
     "dates) as pageToken to get the next page. " +
     "Requires authentication — call the login tool first if not logged in.",
   inputSchema: {
     type: "object",
     properties: {
-      placeId: {
+      standardPlace: {
         type: "string",
         description:
-          "FamilySearch place ID from place_search. Required. The tool " +
-          "internally converts it to place representation IDs for the query.",
+          "Standard place name (the `standardPlace` field from place_search). " +
+          "Required. The tool resolves it to a placeId and its place " +
+          "representation IDs for the query.",
       },
       fromDate: {
         type: "string",
@@ -252,10 +265,10 @@ export const metadataSearchSchema = {
         type: "string",
         description:
           "Pagination cursor. Pass the nextPageToken from a previous " +
-          "response, together with the same placeId/fromDate/toDate, to " +
+          "response, together with the same standardPlace/fromDate/toDate, to " +
           "fetch the next page.",
       },
     },
-    required: ["placeId"],
+    required: ["standardPlace"],
   },
 };

--- a/mcp-server/src/tools/person-ancestors.ts
+++ b/mcp-server/src/tools/person-ancestors.ts
@@ -1,5 +1,5 @@
 import { getValidToken } from "../auth/refresh.js";
-import { toSimplified } from "../utils/gedcomx-convert.js";
+import { toSimplifiedStandardized } from "../utils/gedcomx-convert.js";
 import { parseUpstreamErrorBody } from "../utils/search-helpers.js";
 import type { GedcomX, SimplifiedRelationship } from "../types/gedcomx.js";
 import type {
@@ -218,7 +218,7 @@ async function fetchAndMap(
   }
 
   const body = (await res.json()) as FSAncestryResponse;
-  return mapResponse(body, input.marriageDetails === true);
+  return await mapResponse(body, input.marriageDetails === true);
 }
 
 // ─── URL builder ────────────────────────────────────────────────────────────
@@ -236,14 +236,14 @@ function buildUrl(input: PersonAncestorsInput, pid: string): string {
 
 // ─── Mapping: FS ancestry → simplified graph + ascendancyNumber ────────────
 
-function mapResponse(
+async function mapResponse(
   body: FSAncestryResponse,
   marriageDetails: boolean,
-): PersonAncestorsResult {
+): Promise<PersonAncestorsResult> {
   const rawPersons = body.persons ?? [];
 
   // Convert persons (and couples, when requested) in one pass.
-  const simplified = toSimplified({
+  const simplified = await toSimplifiedStandardized({
     persons: rawPersons,
     relationships: marriageDetails ? (body.relationships ?? []) : [],
   } as unknown as GedcomX);

--- a/mcp-server/src/tools/person-read.ts
+++ b/mcp-server/src/tools/person-read.ts
@@ -1,5 +1,5 @@
 import { getValidToken } from "../auth/refresh.js";
-import { toSimplified } from "../utils/gedcomx-convert.js";
+import { toSimplifiedStandardized } from "../utils/gedcomx-convert.js";
 import type {
   GedcomX,
   GedcomXFact,
@@ -90,6 +90,7 @@ async function fetchAndConvert(
     headers: {
       Authorization: `Bearer ${token}`,
       Accept: ACCEPT_HEADER,
+      "Accept-Language": "en",
     },
     redirect: "manual",
   });
@@ -149,7 +150,7 @@ async function fetchAndConvert(
   }
 
   const body = (await res.json()) as FSTreeResponse;
-  return convertResponse(body, relatives, sourceDescriptions);
+  return await convertResponse(body, relatives, sourceDescriptions);
 }
 
 // ─── URL + helpers ────────────────────────────────────────────────────────
@@ -188,11 +189,11 @@ function livingPersonStub(pid: string): PersonReadResult {
 
 // ─── Conversion: FS-extended GEDCOMX → simplified → tree-spec shape ──────
 
-function convertResponse(
+async function convertResponse(
   body: FSTreeResponse,
   relatives: boolean,
   sourceDescriptions: boolean,
-): PersonReadResult {
+): Promise<PersonReadResult> {
   // Pre-process relationships:
   //
   // FamilySearch returns the same parent-child links in two places —
@@ -218,7 +219,7 @@ function convertResponse(
     sourceDescriptions: body.sourceDescriptions,
   };
 
-  const simplified = toSimplified(gedcomxInput);
+  const simplified = await toSimplifiedStandardized(gedcomxInput);
 
   // Post-process: shape the simplified output into the tree-spec types
   // (add `living` from raw, narrow names, filter SD_* metadata sources).

--- a/mcp-server/src/tools/person-search.ts
+++ b/mcp-server/src/tools/person-search.ts
@@ -1,5 +1,9 @@
 import { getValidToken } from "../auth/refresh.js";
-import { toSimplified } from "../utils/gedcomx-convert.js";
+import {
+  toSimplified,
+  standardizePlaces,
+  collectFacts,
+} from "../utils/gedcomx-convert.js";
 import {
   isFourDigitYear,
   normalizeSex,
@@ -317,6 +321,11 @@ export async function personSearchTool(
   const results = entries
     .map(mapEntry)
     .filter((r): r is PersonSearchResult => r !== null);
+
+  // Standardize places across the whole response in one pass. Best-effort.
+  await standardizePlaces(
+    results.flatMap((r) => (r.gedcomx ? collectFacts(r.gedcomx) : [])),
+  );
 
   return {
     query: echoQuery(input),

--- a/mcp-server/src/tools/place-collections.ts
+++ b/mcp-server/src/tools/place-collections.ts
@@ -55,6 +55,38 @@ export function filterByQuery(
 }
 
 /**
+ * Derive the collection-title search term from a place. FamilySearch organizes
+ * record collections at the state/province level for the United States, Canada,
+ * and Mexico, and at the country level everywhere else. Given a `standardPlace`
+ * (the fully-qualified name from place_search, e.g.
+ * "Schuylkill, Pennsylvania, United States"), return the right title-match term:
+ *   - United States   -> the state            ("Pennsylvania")
+ *   - Canada / Mexico  -> "Country, State"      ("Canada, Ontario")
+ *   - everywhere else  -> the country          ("France")
+ *
+ * The standardPlace format is comma-separated with the country last and the
+ * state/province second-to-last. A free-text query that isn't a standardPlace
+ * (no recognized country tail, e.g. "Census" or "Schuylkill County Pennsylvania")
+ * passes through unchanged, so the tool still accepts an arbitrary place query.
+ */
+export function standardPlaceToCollectionsQuery(value: string): string {
+  const parts = value
+    .split(",")
+    .map((p) => p.trim())
+    .filter(Boolean);
+  if (parts.length === 0) return value.trim();
+
+  const country = parts[parts.length - 1];
+  const state = parts.length >= 2 ? parts[parts.length - 2] : undefined;
+
+  if (country === "United States") return state ?? country;
+  if (country === "Canada" || country === "Mexico") {
+    return state ? `${country}, ${state}` : country;
+  }
+  return country;
+}
+
+/**
  * Fetch all collections from FamilySearch (cached for 1 hour per token).
  */
 export async function fetchAllCollections(
@@ -167,7 +199,7 @@ export async function fetchCollectionDetail(
 
   if (response.status === 404) {
     throw new Error(
-      `No FamilySearch collection found with id "${id}". Use collections({ query: ... }) to list available collections.`
+      `No FamilySearch collection found with id "${id}". Use place_collections({ standardPlace: ... }) to list available collections.`
     );
   }
   if (!response.ok) {
@@ -207,7 +239,7 @@ async function getCollectionDetail(id: string): Promise<CollectionDetailResult> 
 // ---------- Tool entry point ----------
 
 export interface PlaceCollectionsToolInput {
-  query?: string;
+  standardPlace?: string;
   id?: string;
 }
 
@@ -219,21 +251,26 @@ export async function placeCollectionsTool(
     return await getCollectionDetail(input.id);
   }
 
-  if (!input.query) {
+  if (!input.standardPlace) {
     throw new Error(
-      "Provide one of: id (single-collection detail) or query (place name like \"Alabama\")."
+      "Provide one of: id (single-collection detail) or standardPlace (a place to list collections for, preferably the standardPlace from place_search)."
     );
   }
+
+  // Derive the right collection scope (US state, "Country, State" for
+  // Canada/Mexico, country otherwise). Free-text queries pass through.
+  const query = standardPlaceToCollectionsQuery(input.standardPlace);
 
   const token = await getValidToken();
   const data = await fetchAllCollections(token);
   const entries = data.entries ?? [];
 
-  const filtered = filterByQuery(entries, input.query);
+  const filtered = filterByQuery(entries, query);
   const collections = filtered.map(toCollection);
 
   return {
-    query: input.query,
+    standardPlace: input.standardPlace,
+    query,
     matchingCollections: collections.length,
     collections,
   };
@@ -246,19 +283,27 @@ export const placeCollectionsToolSchema = {
   name: "place_collections",
   description:
     "List FamilySearch record collections for a place, OR get detailed " +
-    "information about a single collection. Pass `query` (a place name like " +
-    "\"Alabama\") to list collections, or `id` (a collection ID like \"1743384\") " +
-    "to get the FamilySearch API response for that collection, with HTML " +
-    "content (formal citation, FS Research Wiki page) converted to markdown. " +
+    "information about a single collection. For list mode, pass `standardPlace` " +
+    "— preferably the standardized place name from place_search (e.g. " +
+    "\"Schuylkill, Pennsylvania, United States\"); a plain place name also works. " +
+    "FamilySearch organizes collections at the state/province level for the " +
+    "United States, Canada, and Mexico, and at the country level everywhere else, " +
+    "so results come back at that scope (the tool derives it from the place). " +
+    "For detail mode, pass `id` (a collection ID like \"1743384\") to get the " +
+    "FamilySearch API response for that collection, with HTML content (formal " +
+    "citation, FS Research Wiki page) converted to markdown. " +
     "Requires authentication — call the login tool first if not logged in.",
   inputSchema: {
     type: "object",
     properties: {
-      query: {
+      standardPlace: {
         type: "string",
         description:
-          "Place name to search for in collection titles (e.g., \"Alabama\", \"England\"). " +
-          "This is the recommended list-mode parameter — use the places tool first to disambiguate if needed.",
+          "The place to list collections for — preferably the `standardPlace` " +
+          "from place_search (e.g. \"Schuylkill, Pennsylvania, United States\"). " +
+          "The tool derives the right collection scope (the US state, " +
+          "\"Country, State\" for Canada/Mexico, or the country) and matches it " +
+          "against collection titles. A plain place name works too.",
       },
       id: {
         type: "string",
@@ -266,7 +311,7 @@ export const placeCollectionsToolSchema = {
           "FamilySearch collection ID (e.g., \"1743384\"). When set, returns the " +
           "FS API response for that collection (sourceDescriptions, documents, " +
           "collections), with HTML strings (citations, Research Wiki page) " +
-          "converted to markdown. Use list mode (query) first to discover the ID.",
+          "converted to markdown. Use list mode (standardPlace) first to discover the ID.",
       },
     },
   },

--- a/mcp-server/src/tools/place-collections.ts
+++ b/mcp-server/src/tools/place-collections.ts
@@ -34,35 +34,6 @@ function unwrapEntry(entry: FSCollectionEntry): FSCollectionData | null {
 }
 
 /**
- * Get the place IDs from a collection's searchMetadata.
- */
-function getPlaceIds(data: FSCollectionData): number[] {
-  return data.searchMetadata?.[0]?.placeIds ?? [];
-}
-
-/**
- * Filter entries to those whose searchMetadata placeIds overlap with the requested set.
- */
-export function filterByPlaceIds(
-  entries: FSCollectionEntry[],
-  placeIds: number[]
-): FSCollectionData[] {
-  const requested = new Set(placeIds);
-  const results: FSCollectionData[] = [];
-
-  for (const entry of entries) {
-    const data = unwrapEntry(entry);
-    if (!data) continue;
-    const entryPlaceIds = getPlaceIds(data);
-    if (entryPlaceIds.some((id) => requested.has(id))) {
-      results.push(data);
-    }
-  }
-
-  return results;
-}
-
-/**
  * Filter entries whose title contains the query string (case-insensitive).
  */
 export function filterByQuery(
@@ -152,7 +123,6 @@ function toCollection(data: FSCollectionData): Collection {
     id: data.id,
     title: data.title,
     dateRange,
-    placeIds: getPlaceIds(data),
     recordCount: getCount(data.content, "/Record"),
     personCount: getCount(data.content, "/Person"),
     imageCount: meta?.imageCount ?? 0,
@@ -238,7 +208,6 @@ async function getCollectionDetail(id: string): Promise<CollectionDetailResult> 
 
 export interface PlaceCollectionsToolInput {
   query?: string;
-  placeIds?: number[];
   id?: string;
 }
 
@@ -250,9 +219,9 @@ export async function placeCollectionsTool(
     return await getCollectionDetail(input.id);
   }
 
-  if (!input.query && (!input.placeIds || input.placeIds.length === 0)) {
+  if (!input.query) {
     throw new Error(
-      "Provide one of: id (single-collection detail), query (place name like \"Alabama\"), or placeIds (internal collection IDs like [33])."
+      "Provide one of: id (single-collection detail) or query (place name like \"Alabama\")."
     );
   }
 
@@ -260,18 +229,11 @@ export async function placeCollectionsTool(
   const data = await fetchAllCollections(token);
   const entries = data.entries ?? [];
 
-  let filtered: FSCollectionData[];
-  if (input.query) {
-    filtered = filterByQuery(entries, input.query);
-  } else {
-    filtered = filterByPlaceIds(entries, input.placeIds!);
-  }
-
+  const filtered = filterByQuery(entries, input.query);
   const collections = filtered.map(toCollection);
 
   return {
-    ...(input.query ? { query: input.query } : {}),
-    ...(input.placeIds ? { placeIds: input.placeIds } : {}),
+    query: input.query,
     matchingCollections: collections.length,
     collections,
   };
@@ -297,13 +259,6 @@ export const placeCollectionsToolSchema = {
         description:
           "Place name to search for in collection titles (e.g., \"Alabama\", \"England\"). " +
           "This is the recommended list-mode parameter — use the places tool first to disambiguate if needed.",
-      },
-      placeIds: {
-        type: "array",
-        items: { type: "number" },
-        description:
-          "Internal FamilySearch collection place IDs. These are NOT the same as " +
-          "place IDs from the places tool. Only use if you know the internal IDs.",
       },
       id: {
         type: "string",

--- a/mcp-server/src/tools/place-external-links.ts
+++ b/mcp-server/src/tools/place-external-links.ts
@@ -1,4 +1,5 @@
 import { BROWSER_USER_AGENT } from "../constants.js";
+import { standardPlaceToPlaceId } from "../utils/place-resolver.js";
 import type {
   PlaceExternalLink,
   PlaceExternalLinksResult,
@@ -7,7 +8,7 @@ import type {
 } from "../types/place-external-links.js";
 
 export interface PlaceExternalLinksToolInput {
-  placeId: string;
+  standardPlace: string;
   startYear: number;
   endYear: number;
 }
@@ -80,16 +81,16 @@ async function fetchPage(
 export async function placeExternalLinksTool(
   input: PlaceExternalLinksToolInput
 ): Promise<PlaceExternalLinksResult> {
-  const { placeId } = input;
+  const { standardPlace } = input;
   // The MCP SDK does not validate arguments against inputSchema, and the
   // LLM sometimes passes year values as strings despite the integer
   // schema. Coerce defensively so the comparisons below stay numeric.
   const startYear = Number(input.startYear);
   const endYear = Number(input.endYear);
 
-  if (!placeId || typeof placeId !== "string") {
+  if (!standardPlace || typeof standardPlace !== "string") {
     throw new Error(
-      "placeId is required and must be a non-empty string. " +
+      "standardPlace is required and must be a non-empty string. " +
         "Re-read the tool's input schema and retry with corrected arguments."
     );
   }
@@ -103,6 +104,16 @@ export async function placeExternalLinksTool(
     throw new Error(
       "endYear must be greater than or equal to startYear. " +
         "Re-read the tool's input schema and retry with corrected arguments."
+    );
+  }
+
+  // Resolve the standard place name to a FamilySearch placeId only after the
+  // cheap guards, so malformed input never hits the network.
+  const placeId = await standardPlaceToPlaceId(standardPlace);
+  if (!placeId) {
+    throw new Error(
+      `Could not resolve "${standardPlace}" to a FamilySearch place. ` +
+        "Use place_search to get a standard place name first."
     );
   }
 
@@ -142,6 +153,7 @@ export async function placeExternalLinksTool(
     }));
 
   return {
+    standardPlace,
     place,
     totalResults,
     matchedCount: results.length,
@@ -154,18 +166,17 @@ export const placeExternalLinksToolSchema = {
   description:
     "Return FamilySearch-curated third-party genealogy resource URLs for a place and year range. " +
     "Use when the user wants links to external record collections (Ancestry, MyHeritage, FindMyPast, " +
-    "national archives, etc.) covering a specific place by FamilySearch place ID and time period. " +
+    "national archives, etc.) covering a specific place by standard place name and time period. " +
     "Returns every collection whose date range overlaps [startYear, endYear], plus undated wiki/website " +
-    "resources for that place. Requires a place ID — do not guess; obtain it from the places tool " +
-    "or the user.",
+    "resources for that place. Pass the standard place name (the `standardPlace` field from place_search).",
   inputSchema: {
     type: "object" as const,
     properties: {
-      placeId: {
+      standardPlace: {
         type: "string",
         description:
-          "FamilySearch place ID (numeric string), e.g. '1927089' for France. " +
-          "Get this from the places tool, not by guessing.",
+          "The standard place name (the `standardPlace` field from place_search, e.g. 'France'). " +
+          "The tool resolves it to a FamilySearch place ID internally.",
       },
       startYear: {
         type: "integer",
@@ -181,6 +192,6 @@ export const placeExternalLinksToolSchema = {
           "Latest year of interest (inclusive). Must be >= startYear.",
       },
     },
-    required: ["placeId", "startYear", "endYear"],
+    required: ["standardPlace", "startYear", "endYear"],
   },
 };

--- a/mcp-server/src/tools/place-population.ts
+++ b/mcp-server/src/tools/place-population.ts
@@ -1,22 +1,30 @@
 import type { PopulationResponse, PopulationToolInput } from "../types/place-population.js";
 export type { PopulationToolInput } from "../types/place-population.js";
 import { loadConfig } from "../auth/config.js";
+import { standardPlaceToPlaceId } from "../utils/place-resolver.js";
 
 const DEFAULT_POP_STATS_URL = "https://malachi.taild68f1b.ts.net/pop-stats";
 
 export async function populationTool(
   input: PopulationToolInput
 ): Promise<PopulationResponse> {
-  if (!input.placeId) {
-    throw new Error("placeId is required");
+  if (!input.standardPlace) {
+    throw new Error("standardPlace is required");
+  }
+
+  const placeId = await standardPlaceToPlaceId(input.standardPlace);
+  if (!placeId) {
+    throw new Error(
+      `Could not resolve "${input.standardPlace}" to a single FamilySearch place. ` +
+        "Use place_search to get a standard place name first."
+    );
   }
 
   const config = await loadConfig();
   const baseUrl = config.popStatsUrl ?? DEFAULT_POP_STATS_URL;
 
-  // The upstream Pop Stats API expects the query param `place_id`; only the
-  // MCP tool's input field is named `placeId` (standardized casing).
-  const params = new URLSearchParams({ place_id: input.placeId });
+  // The upstream Pop Stats API expects the query param `place_id`.
+  const params = new URLSearchParams({ place_id: placeId });
   if (input.year != null) params.set("year", String(input.year));
   if (input.year_start != null) params.set("year_start", String(input.year_start));
   if (input.year_end != null) params.set("year_end", String(input.year_end));
@@ -45,17 +53,18 @@ export const populationToolSchema = {
   name: "place_population",
   description:
     "Get historical population data and indexed record counts for a FamilySearch place. " +
-    "Pass a FamilySearch place ID (from the places tool) and optionally filter by year or year range. " +
+    "Pass a standard place name (the `standardPlace` field from place_search) and optionally filter by year or year range. " +
     "Returns population data from multiple sources and FamilySearch indexed birth record coverage. " +
     "No authentication required.",
   inputSchema: {
     type: "object",
     properties: {
-      placeId: {
+      standardPlace: {
         type: "string",
         description:
-          'FamilySearch place ID (e.g., "1927069" for Nigeria). ' +
-          "Use the places tool first to find the place ID.",
+          'The standard place name (the `standardPlace` field from place_search, ' +
+          'e.g. "Nigeria" or "Schuylkill, Pennsylvania, United States"). ' +
+          "Call place_search first to get this name.",
       },
       year: {
         type: "number",
@@ -71,6 +80,6 @@ export const populationToolSchema = {
         description: "End of year range filter.",
       },
     },
-    required: ["placeId"],
+    required: ["standardPlace"],
   },
 };

--- a/mcp-server/src/tools/place-search.ts
+++ b/mcp-server/src/tools/place-search.ts
@@ -370,7 +370,7 @@ function toPlaceResult(
  */
 export function simplifyPlaceResult(r: PlaceResult): SimplifiedPlaceResult {
   return {
-    fullName: r.fullName,
+    standardPlace: r.fullName,
     type: r.type,
     ...(r.dateRange !== undefined ? { dateRange: r.dateRange } : {}),
     ...(r.latitude !== undefined ? { latitude: r.latitude } : {}),
@@ -534,7 +534,7 @@ export const placeSearchToolSchema = {
     "Optionally pass a higher-level place as context to disambiguate among places " +
     "that share a name — e.g. placeName 'Paris' with contextName 'Idaho' returns " +
     "Paris in Idaho, while contextName 'France' returns Paris in France. " +
-    "Each result includes the full jurisdictional name, place type, date range, " +
+    "Each result includes the standardized place name (standardPlace), place type, date range," +
     "coordinates, a FamilySearch link, and (when available) a Wikipedia link. " +
     "Use place_search_all instead when you need every historical jurisdiction a " +
     "place has belonged to over time.",

--- a/mcp-server/src/tools/place-search.ts
+++ b/mcp-server/src/tools/place-search.ts
@@ -26,46 +26,6 @@ interface FSPlaceLookupResponse {
   places?: FSPlaceLookupEntry[];
 }
 
-/**
- * Convert a placeId to its placeRepIds via the places API.
- * Relocated here from image-search.ts for use by metadata_search.
- */
-export async function placeIdToRepIds(
-  placeId: string,
-  token: string
-): Promise<number[]> {
-  const response = await fetch(
-    `${FS_API_BASE}/${encodeURIComponent(placeId)}`,
-    {
-      headers: {
-        Authorization: `Bearer ${token}`,
-        Accept: "application/json",
-      },
-    }
-  );
-
-  if (!response.ok) {
-    throw new Error(
-      `FamilySearch places API error: ${response.status} ${response.statusText}`
-    );
-  }
-
-  const data = (await response.json()) as FSPlaceLookupResponse;
-  const reps = (data.places ?? []).filter(
-    (p) => p.place?.resourceId === placeId
-  );
-
-  const ids: number[] = [];
-  const seen = new Set<number>();
-  for (const rep of reps) {
-    const n = Number(rep.id);
-    if (!Number.isNaN(n) && !seen.has(n)) {
-      seen.add(n);
-      ids.push(n);
-    }
-  }
-  return ids;
-}
 const FS_PLACES_PUBLIC_BASE =
   "https://www.familysearch.org/en/research/places";
 const FS_PRIMARY_IDENTIFIER_KEY = "http://gedcomx.org/Primary";

--- a/mcp-server/src/tools/place-search.ts
+++ b/mcp-server/src/tools/place-search.ts
@@ -1,288 +1,38 @@
 import type {
-  FSPlaceSearchResponse,
-  FSPlaceDescriptionResponse,
   PlaceResult,
   SimplifiedPlaceResult,
   PlaceSearchToolResponse,
 } from "../types/place.js";
-import { BROWSER_USER_AGENT } from "../constants.js";
+import {
+  searchPlace,
+  getPlaceById,
+  getPlaceByPrimaryId,
+  getPlaceRepIds,
+  getPlaceWikipediaUrl,
+  getPlaceCandidateNames,
+  extractPrimaryId,
+  type SearchPlaceResult,
+  type GetPlaceResult,
+} from "../utils/place-api.js";
 
-const FS_API_BASE = "https://api.familysearch.org/platform/places";
-// FamilySearch's place service (the one the research-places website uses). It
-// carries curated per-place external links — including the correct Wikipedia
-// link — that the public /platform/places API does not expose.
-const FS_PLACE_WS_UI_BASE =
-  "https://www.familysearch.org/service/standards/place/ws-ui/places/reps";
-const WIKIPEDIA_API_BASE = "https://en.wikipedia.org/api/rest_v1/page/summary";
-
-interface FSPlaceLookupEntry {
-  id: string;
-  place?: { resource?: string; resourceId?: string };
-  identifiers?: Record<string, string[]>;
-  display?: { name: string; fullName: string; type: string };
-}
-
-interface FSPlaceLookupResponse {
-  places?: FSPlaceLookupEntry[];
-}
+// Re-export the low-level FamilySearch places fetchers so existing tool/test
+// imports keep resolving from here. Their implementations live in
+// `utils/place-api.ts` — the low-level layer the resolver also builds on.
+export {
+  searchPlace,
+  getPlaceById,
+  getPlaceByPrimaryId,
+  getPlaceRepIds,
+  getPlaceWikipediaUrl,
+  getPlaceCandidateNames,
+  extractPrimaryId,
+};
 
 const FS_PLACES_PUBLIC_BASE =
   "https://www.familysearch.org/en/research/places";
-const FS_PRIMARY_IDENTIFIER_KEY = "http://gedcomx.org/Primary";
-
-interface SearchPlaceResult {
-  placeId?: string;     // Primary
-  placeRepId: string;   // rep
-  name: string;
-  fullName: string;
-  type: string;
-  latitude?: number;
-  longitude?: number;
-  dateRange?: string;
-  score?: number;
-}
-
-interface GetPlaceResult extends SearchPlaceResult {
-  parentPlaceRepId?: string;
-}
-
-/**
- * Extract the bare Primary place ID from the identifiers map.
- * The Primary value is a URL of the form
- * "https://api.familysearch.org/platform/places/{primaryId}"; the bare ID
- * is the last path segment. Returns undefined if the Primary identifier
- * is missing or malformed.
- */
-export function extractPrimaryId(
-  identifiers: Record<string, string[]> | undefined
-): string | undefined {
-  const url = identifiers?.[FS_PRIMARY_IDENTIFIER_KEY]?.[0];
-  if (!url) return undefined;
-  const segments = url.split("/");
-  const last = segments[segments.length - 1];
-  return last || undefined;
-}
 
 function buildFamilysearchUrl(name: string, placeRepId: string): string {
   return `${FS_PLACES_PUBLIC_BASE}/?text=${encodeURIComponent(name)}&focusedId=${placeRepId}`;
-}
-
-
-export async function searchPlace(name: string): Promise<SearchPlaceResult[]> {
-  const url = `${FS_API_BASE}/search?q=name:${encodeURIComponent(name)}`;
-
-  const response = await fetch(url, {
-    headers: {
-      Accept: "application/x-gedcomx-atom+json",
-    },
-  });
-
-  if (!response.ok) {
-    throw new Error(`FamilySearch API error: ${response.status} ${response.statusText}`);
-  }
-
-  const text = await response.text();
-  if (!text || text.trim() === "") {
-    return [];
-  }
-
-  const data: FSPlaceSearchResponse = JSON.parse(text);
-
-  if (!data.entries || data.entries.length === 0) {
-    return [];
-  }
-
-  return data.entries.map((entry) => {
-    const place = entry.content.gedcomx.places[0];
-    return {
-      placeId: extractPrimaryId(place.identifiers),
-      placeRepId: entry.id,
-      name: place.display.name,
-      fullName: place.display.fullName,
-      type: place.display.type,
-      latitude: place.latitude,
-      longitude: place.longitude,
-      dateRange: place.temporalDescription?.formal,
-      score: entry.score,
-    };
-  });
-}
-
-/**
- * Get place details by Primary ID using FamilySearch API.
- * The Primary ID is the canonical place ID (placeId) returned by the places tool.
- * Returns null for 404 (invalid ID), throws for other errors.
- */
-export async function getPlaceByPrimaryId(primaryId: string): Promise<GetPlaceResult | null> {
-  const url = `${FS_API_BASE}/${primaryId}`;
-
-  const response = await fetch(url, {
-    headers: {
-      Accept: "application/json",
-    },
-  });
-
-  if (!response.ok) {
-    if (response.status === 404) {
-      return null;
-    }
-    throw new Error(`FamilySearch API error: ${response.status} ${response.statusText}`);
-  }
-
-  const data: FSPlaceDescriptionResponse = await response.json();
-
-  // The response contains two objects: the place (names only, no display/coords)
-  // and the place description (has display, latitude, longitude). Use the latter.
-  const place = data.places?.find((p) => p.display != null);
-  if (!place) {
-    return null;
-  }
-
-  return {
-    placeId: extractPrimaryId(place.identifiers),
-    placeRepId: place.id,
-    name: place.display.name,
-    fullName: place.display.fullName,
-    type: place.display.type,
-    latitude: place.latitude,
-    longitude: place.longitude,
-    dateRange: place.temporalDescription?.formal,
-    parentPlaceRepId: place.jurisdiction?.resourceId,
-  };
-}
-
-/**
- * Get place details by ID using FamilySearch API.
- * Returns null for 404 (invalid ID), throws for other errors.
- */
-export async function getPlaceById(id: string): Promise<GetPlaceResult | null> {
-  const url = `${FS_API_BASE}/description/${id}`;
-
-  const response = await fetch(url, {
-    headers: {
-      Accept: "application/json",
-    },
-  });
-
-  if (!response.ok) {
-    if (response.status === 404) {
-      return null;
-    }
-    throw new Error(`FamilySearch API error: ${response.status} ${response.statusText}`);
-  }
-
-  const data: FSPlaceDescriptionResponse = await response.json();
-
-  if (!data.places || data.places.length === 0) {
-    return null;
-  }
-
-  const place = data.places[0];
-
-  return {
-    placeId: extractPrimaryId(place.identifiers),
-    placeRepId: place.id,
-    name: place.display.name,
-    fullName: place.display.fullName,
-    type: place.display.type,
-    latitude: place.latitude,
-    longitude: place.longitude,
-    dateRange: place.temporalDescription?.formal,
-    parentPlaceRepId: place.jurisdiction?.resourceId,
-  };
-}
-
-interface FSPlaceAttribute {
-  type?: { code?: string };
-  url?: string;
-}
-interface FSPlaceAttributesResponse {
-  attributes?: FSPlaceAttribute[];
-}
-
-/**
- * Get the curated Wikipedia URL FamilySearch stores for a place rep.
- *
- * FamilySearch keeps a per-place `WIKIPEDIA_LINK` attribute (e.g. Paris, Idaho
- * → en.wikipedia.org/wiki/Paris,_Idaho) on its place service — the same one the
- * research-places website uses. This is correct per-place, unlike a name-based
- * Wikipedia lookup. Returns null when the place has no such attribute or on any
- * error (graceful degradation — the Wikipedia link is optional enrichment).
- *
- * Note: places may also carry an `FS_WIKI_LINK` attribute (the FamilySearch
- * research wiki, a different thing); we take only `WIKIPEDIA_LINK`.
- */
-export async function getPlaceWikipediaUrl(repId: string): Promise<string | null> {
-  const url = `${FS_PLACE_WS_UI_BASE}/${encodeURIComponent(repId)}/attributes/`;
-
-  try {
-    const response = await fetch(url, {
-      headers: {
-        Accept: "application/json",
-        "User-Agent": BROWSER_USER_AGENT,
-        "FS-User-Agent-Chain": "zion-user",
-      },
-    });
-
-    if (!response.ok) {
-      return null;
-    }
-
-    const data = (await response.json()) as FSPlaceAttributesResponse;
-    const wiki = (data.attributes ?? []).find(
-      (a) => a.type?.code === "WIKIPEDIA_LINK" && !!a.url
-    );
-    return wiki?.url ?? null;
-  } catch {
-    return null;
-  }
-}
-
-/**
- * Get place details by Primary (canonical) place ID.
- * Returns null for 404 (invalid ID), throws for other errors.
- */
-type PrimaryIdResponse = {
-  places?: Array<{ id: string; names?: Array<{ lang: string; value: string }> }>;
-};
-
-async function fetchPrimaryIdResponse(primaryId: string): Promise<PrimaryIdResponse> {
-  const url = `${FS_API_BASE}/${primaryId}`;
-  const response = await fetch(url, { headers: { Accept: "application/json" } });
-  if (!response.ok) {
-    if (response.status === 404) return {};
-    throw new Error(`FamilySearch API error: ${response.status} ${response.statusText}`);
-  }
-  return (await response.json()) as PrimaryIdResponse;
-}
-
-export async function getPlaceCandidateNames(primaryId: string): Promise<string[]> {
-  const data = await fetchPrimaryIdResponse(primaryId);
-  if (!data.places?.length) return [];
-
-  const allNames = data.places[0].names ?? [];
-
-  // Keep proper-case English names: starts uppercase, not all-caps (filters abbreviations like PRT, MN)
-  const properEnglish = allNames
-    .filter(
-      (n) =>
-        n.lang === "en" &&
-        n.value.length > 0 &&
-        n.value[0] === n.value[0].toUpperCase() &&
-        n.value !== n.value.toUpperCase()
-    )
-    .map((n) => n.value);
-
-  // Deduplicate; single-word names first (more likely to be the canonical wiki page name)
-  const seen = new Set<string>();
-  const singleWord: string[] = [];
-  const multiWord: string[] = [];
-  for (const name of properEnglish) {
-    if (seen.has(name)) continue;
-    seen.add(name);
-    (name.includes(" ") ? multiWord : singleWord).push(name);
-  }
-  return [...singleWord, ...multiWord];
 }
 
 export interface PlaceSearchToolInput {
@@ -340,39 +90,6 @@ export function simplifyPlaceResult(r: PlaceResult): SimplifiedPlaceResult {
   };
 }
 
-/**
- * Get every place representation ID for a Primary place ID via the
- * Place_resource endpoint (GET /platform/places/{pid}). The response lists the
- * bare place entry (id === pid, no `display`) followed by its representation
- * entries, each with `place.resourceId === pid`. We collect those rep IDs.
- *
- * Public (no auth) — the places endpoints accept anonymous requests.
- */
-export async function getPlaceRepIds(pid: string): Promise<string[]> {
-  const url = `${FS_API_BASE}/${encodeURIComponent(pid)}`;
-
-  const response = await fetch(url, { headers: { Accept: "application/json" } });
-  if (!response.ok) {
-    if (response.status === 404) return [];
-    throw new Error(
-      `FamilySearch API error: ${response.status} ${response.statusText}`
-    );
-  }
-
-  const data = (await response.json()) as FSPlaceLookupResponse;
-  const reps = (data.places ?? []).filter((p) => p.place?.resourceId === pid);
-
-  const ids: string[] = [];
-  const seen = new Set<string>();
-  for (const rep of reps) {
-    if (rep.id && !seen.has(rep.id)) {
-      seen.add(rep.id);
-      ids.push(rep.id);
-    }
-  }
-  return ids;
-}
-
 // In-memory cache of internal place-search results, keyed by the normalized
 // (placeName, contextName) pair. Lives for the life of the MCP server process;
 // no TTL. There is no cross-session host storage (see CLAUDE.md), so this only
@@ -380,7 +97,7 @@ export async function getPlaceRepIds(pid: string): Promise<string[]> {
 const placeSearchCache = new Map<string, PlaceResult[]>();
 
 function placeSearchCacheKey(placeName: string, contextName?: string): string {
-  return `${placeName.trim().toLowerCase()} ${(contextName ?? "").trim().toLowerCase()}`;
+  return `${placeName.trim().toLowerCase()} ${(contextName ?? "").trim().toLowerCase()}`;
 }
 
 /** Test-only: empty the in-memory cache so cases don't bleed into each other. */
@@ -530,8 +247,8 @@ export const placeSearchAllToolSchema = {
     "place(s), place_search_all additionally expands each match to all of its " +
     "historical representations — useful when boundaries or parent jurisdictions " +
     "changed across the time period you're researching. Each result includes the " +
-    "full jurisdictional name, place type, date range, coordinates, a FamilySearch " +
-    "link, and (when available) a Wikipedia link.",
+    "standardized place name (standardPlace), place type, date range, coordinates, a " +
+    "FamilySearch link, and (when available) a Wikipedia link.",
   inputSchema: {
     type: "object",
     properties: {

--- a/mcp-server/src/tools/record-read.ts
+++ b/mcp-server/src/tools/record-read.ts
@@ -1,6 +1,6 @@
 import { getValidToken } from "../auth/refresh.js";
 import { BROWSER_USER_AGENT } from "../constants.js";
-import { toSimplified } from "../utils/gedcomx-convert.js";
+import { toSimplifiedStandardized } from "../utils/gedcomx-convert.js";
 import type { GedcomX } from "../types/gedcomx.js";
 import type { RecordReadInput, RecordReadResult } from "../types/record-read.js";
 
@@ -61,6 +61,7 @@ export async function recordReadTool(
     headers: {
       Authorization: `Bearer ${token}`,
       Accept: "application/json",
+      "Accept-Language": "en",
       "User-Agent": BROWSER_USER_AGENT,
     },
   });
@@ -91,7 +92,7 @@ export async function recordReadTool(
   }
 
   const body = (await res.json()) as GedcomX;
-  return toSimplified(body);
+  return await toSimplifiedStandardized(body);
 }
 
 // ─── Helpers ──────────────────────────────────────────────────────────────

--- a/mcp-server/src/tools/record-search.ts
+++ b/mcp-server/src/tools/record-search.ts
@@ -1,6 +1,10 @@
 import { getValidToken } from "../auth/refresh.js";
 import { BROWSER_USER_AGENT } from "../constants.js";
-import { toSimplified } from "../utils/gedcomx-convert.js";
+import {
+  toSimplified,
+  standardizePlaces,
+  collectFacts,
+} from "../utils/gedcomx-convert.js";
 import type { GedcomX } from "../types/gedcomx.js";
 import type {
   FSSearchResponse,
@@ -497,6 +501,12 @@ export async function recordSearchTool(
   const results = entries
     .map(mapEntry)
     .filter((r): r is RecordSearchResult => r !== null);
+
+  // Standardize places across the whole response in one pass (dedup spans all
+  // entries; the resolver caches identical strings). Best-effort — never throws.
+  await standardizePlaces(
+    results.flatMap((r) => (r.gedcomx ? collectFacts(r.gedcomx) : [])),
+  );
 
   return {
     query: echoQuery(input),

--- a/mcp-server/src/tools/wiki-country-page.ts
+++ b/mcp-server/src/tools/wiki-country-page.ts
@@ -20,58 +20,61 @@ async function tryReadFile(filePath: string): Promise<string | null> {
 }
 
 /**
- * Build the candidate English names to try as wiki-slug bases for a standard
- * place. The standard place's own leaf segment (e.g. "Minnesota" from
- * "Minnesota, United States") is always tried first; resolving the name to a
- * placeId yields additional variants from the places API (which handles places
- * whose canonical wiki name differs from the leaf, plus alternate spellings).
+ * Try a list of candidate place names against the local pre-crawled wiki
+ * corpus, returning the first matching page or null. Pure file reads — the
+ * file-existence check is the reliable filter (only the canonical name has a
+ * matching file). No network.
  */
-async function candidateNamesFor(standardPlace: string): Promise<string[]> {
-  const names: string[] = [];
-  const leaf = standardPlace.split(",")[0].trim();
-  if (leaf) names.push(leaf);
-
-  const placeId = await standardPlaceToPlaceId(standardPlace);
-  if (placeId) {
-    for (const name of await getPlaceCandidateNames(placeId)) {
-      if (!names.includes(name)) names.push(name);
+async function tryNames(
+  names: string[],
+  getCandidateSlugs: (nameSlug: string) => string[],
+  wikiDir: string,
+  standardPlace: string
+): Promise<WikiCountryResult | null> {
+  for (const name of names) {
+    const nameSlug = nameToSlug(name);
+    for (const slug of getCandidateSlugs(nameSlug)) {
+      const content = await tryReadFile(join(wikiDir, `${slug}.md`));
+      if (content !== null) {
+        return { url: `${FS_WIKI_BASE}/${slug}`, content, standardPlace, placeName: name };
+      }
     }
   }
-  return names;
+  return null;
 }
 
 async function readCountryPage(
   standardPlace: string,
   getCandidateSlugs: (nameSlug: string) => string[]
 ): Promise<WikiCountryResult> {
-  const candidateNames = await candidateNamesFor(standardPlace);
-  if (candidateNames.length === 0) {
-    throw new Error(`No place found for: ${standardPlace}`);
+  if (!standardPlace || typeof standardPlace !== "string" || !standardPlace.trim()) {
+    throw new Error(
+      "standardPlace is required and must be a non-empty string. " +
+        "Pass the standardPlace name (from place_search)."
+    );
   }
 
   const wikiDir = await getWikiMarkdownDir();
+  const leaf = standardPlace.split(",")[0].trim();
 
-  // Try every candidate name. The file-existence check is the reliable filter —
-  // only the canonical name has a matching pre-crawled wiki file.
-  for (const name of candidateNames) {
-    const nameSlug = nameToSlug(name);
-    for (const slug of getCandidateSlugs(nameSlug)) {
-      const content = await tryReadFile(join(wikiDir, `${slug}.md`));
-      if (content !== null) {
-        return {
-          url: `${FS_WIKI_BASE}/${slug}`,
-          content,
-          standardPlace,
-          placeName: name,
-        };
-      }
-    }
+  // 1) Common case: try the standard place's own leaf name against the local
+  //    wiki files first — no network (e.g. "Portugal" -> Portugal_Genealogy.md).
+  if (leaf) {
+    const hit = await tryNames([leaf], getCandidateSlugs, wikiDir, standardPlace);
+    if (hit) return hit;
   }
 
-  const tried = candidateNames.slice(0, 5).join(", ");
-  throw new Error(
-    `No wiki page found for "${standardPlace}". Tried names: ${tried}${candidateNames.length > 5 ? " (and more)" : ""}`
-  );
+  // 2) Fallback: only when every leaf slug misses, resolve to a placeId and try
+  //    the places API's alternate name variants (handles places whose canonical
+  //    wiki name differs from the leaf). Two network round-trips, paid rarely.
+  const placeId = await standardPlaceToPlaceId(standardPlace);
+  if (placeId) {
+    const variants = (await getPlaceCandidateNames(placeId)).filter((n) => n !== leaf);
+    const hit = await tryNames(variants, getCandidateSlugs, wikiDir, standardPlace);
+    if (hit) return hit;
+  }
+
+  throw new Error(`No wiki page found for "${standardPlace}".`);
 }
 
 const STANDARD_PLACE_SCHEMA = {

--- a/mcp-server/src/tools/wiki-country-page.ts
+++ b/mcp-server/src/tools/wiki-country-page.ts
@@ -1,6 +1,7 @@
 import { readFile } from "fs/promises";
 import { join } from "path";
 import { getPlaceCandidateNames } from "./place-search.js";
+import { standardPlaceToPlaceId } from "../utils/place-resolver.js";
 import { getWikiMarkdownDir } from "../auth/config.js";
 import type { WikiCountryInput, WikiCountryResult } from "../types/wikiPage.js";
 
@@ -18,48 +19,77 @@ async function tryReadFile(filePath: string): Promise<string | null> {
   }
 }
 
+/**
+ * Build the candidate English names to try as wiki-slug bases for a standard
+ * place. The standard place's own leaf segment (e.g. "Minnesota" from
+ * "Minnesota, United States") is always tried first; resolving the name to a
+ * placeId yields additional variants from the places API (which handles places
+ * whose canonical wiki name differs from the leaf, plus alternate spellings).
+ */
+async function candidateNamesFor(standardPlace: string): Promise<string[]> {
+  const names: string[] = [];
+  const leaf = standardPlace.split(",")[0].trim();
+  if (leaf) names.push(leaf);
+
+  const placeId = await standardPlaceToPlaceId(standardPlace);
+  if (placeId) {
+    for (const name of await getPlaceCandidateNames(placeId)) {
+      if (!names.includes(name)) names.push(name);
+    }
+  }
+  return names;
+}
+
 async function readCountryPage(
-  placeId: string,
+  standardPlace: string,
   getCandidateSlugs: (nameSlug: string) => string[]
 ): Promise<WikiCountryResult> {
-  const candidateNames = await getPlaceCandidateNames(placeId);
+  const candidateNames = await candidateNamesFor(standardPlace);
   if (candidateNames.length === 0) {
-    throw new Error(`No place found for placeId: ${placeId}`);
+    throw new Error(`No place found for: ${standardPlace}`);
   }
 
   const wikiDir = await getWikiMarkdownDir();
 
-  // Try every candidate name (the API returns many variants including typos).
-  // The file-existence check is the reliable filter — only the canonical name has a matching file.
+  // Try every candidate name. The file-existence check is the reliable filter —
+  // only the canonical name has a matching pre-crawled wiki file.
   for (const name of candidateNames) {
     const nameSlug = nameToSlug(name);
     for (const slug of getCandidateSlugs(nameSlug)) {
       const content = await tryReadFile(join(wikiDir, `${slug}.md`));
       if (content !== null) {
-        return { url: `${FS_WIKI_BASE}/${slug}`, content, placeId, placeName: name };
+        return {
+          url: `${FS_WIKI_BASE}/${slug}`,
+          content,
+          standardPlace,
+          placeName: name,
+        };
       }
     }
   }
 
   const tried = candidateNames.slice(0, 5).join(", ");
   throw new Error(
-    `No wiki page found for place "${placeId}". Tried names: ${tried}${candidateNames.length > 5 ? " (and more)" : ""}`
+    `No wiki page found for "${standardPlace}". Tried names: ${tried}${candidateNames.length > 5 ? " (and more)" : ""}`
   );
 }
 
-const PLACE_ID_SCHEMA = {
+const STANDARD_PLACE_SCHEMA = {
   type: "object" as const,
   properties: {
-    placeId: {
+    standardPlace: {
       type: "string",
-      description: "The FamilySearch place ID (the `placeId` field from the places tool output)",
+      description:
+        'The standard place name (the `standardPlace` field from place_search), ' +
+        'e.g. "Portugal" or "Minnesota, United States". Works for countries, ' +
+        "US states, and Canadian provinces.",
     },
   },
-  required: ["placeId"],
+  required: ["standardPlace"],
 };
 
 export async function wikiCountryHomeTool(input: WikiCountryInput): Promise<WikiCountryResult> {
-  return readCountryPage(input.placeId, (nameSlug) => [
+  return readCountryPage(input.standardPlace, (nameSlug) => [
     `${nameSlug}_Genealogy`,                    // countries: Portugal_Genealogy
     `${nameSlug},_Canada_Genealogy`,            // Canadian provinces: Manitoba,_Canada_Genealogy
     `${nameSlug},_United_States_Genealogy`,     // US states: Minnesota,_United_States_Genealogy
@@ -70,45 +100,45 @@ export const wikiCountryHomeSchema = {
   name: "wiki_country_home",
   description:
     "Return the FamilySearch wiki homepage for a country, US state, or Canadian province. " +
-    "Given a place ID (from the places tool), reads the main Genealogy overview page " +
+    "Given a standard place name (from place_search), reads the main Genealogy overview page " +
     "(e.g. Portugal_Genealogy) from the pre-crawled wiki files and returns it as markdown.",
-  inputSchema: PLACE_ID_SCHEMA,
+  inputSchema: STANDARD_PLACE_SCHEMA,
 };
 
 export async function wikiCountryGettingStartedTool(
   input: WikiCountryInput
 ): Promise<WikiCountryResult> {
-  return readCountryPage(input.placeId, (nameSlug) => [`${nameSlug}_Getting_Started`]);
+  return readCountryPage(input.standardPlace, (nameSlug) => [`${nameSlug}_Getting_Started`]);
 }
 
 export const wikiCountryGettingStartedSchema = {
   name: "wiki_country_getting_started",
   description:
     "Return the FamilySearch wiki Getting Started guide for a country, US state, or Canadian province. " +
-    "Given a place ID (from the places tool), reads the Getting Started page " +
+    "Given a standard place name (from place_search), reads the Getting Started page " +
     "(e.g. Portugal_Getting_Started) from the pre-crawled wiki files and returns it as markdown.",
-  inputSchema: PLACE_ID_SCHEMA,
+  inputSchema: STANDARD_PLACE_SCHEMA,
 };
 
 export async function wikiCountryOnlineRecordsTool(
   input: WikiCountryInput
 ): Promise<WikiCountryResult> {
-  return readCountryPage(input.placeId, (nameSlug) => [`${nameSlug}_Online_Genealogy_Records`]);
+  return readCountryPage(input.standardPlace, (nameSlug) => [`${nameSlug}_Online_Genealogy_Records`]);
 }
 
 export const wikiCountryOnlineRecordsSchema = {
   name: "wiki_country_online_records",
   description:
     "Return the FamilySearch wiki Online Genealogy Records page for a country, US state, or Canadian province. " +
-    "Given a place ID (from the places tool), reads the Online Genealogy Records page " +
+    "Given a standard place name (from place_search), reads the Online Genealogy Records page " +
     "(e.g. Portugal_Online_Genealogy_Records) from the pre-crawled wiki files and returns it as markdown.",
-  inputSchema: PLACE_ID_SCHEMA,
+  inputSchema: STANDARD_PLACE_SCHEMA,
 };
 
 export async function wikiCountryResearchTipsTool(
   input: WikiCountryInput
 ): Promise<WikiCountryResult> {
-  return readCountryPage(input.placeId, (nameSlug) => [
+  return readCountryPage(input.standardPlace, (nameSlug) => [
     `${nameSlug}_Research_Tips_and_Strategies`,
   ]);
 }
@@ -117,9 +147,9 @@ export const wikiCountryResearchTipsSchema = {
   name: "wiki_country_research_tips",
   description:
     "Return the FamilySearch wiki Research Tips and Strategies page for a country, US state, or Canadian province. " +
-    "Given a place ID (from the places tool), reads the Research Tips and Strategies page " +
+    "Given a standard place name (from place_search), reads the Research Tips and Strategies page " +
     "(e.g. Portugal_Research_Tips_and_Strategies) from the pre-crawled wiki files and returns it as markdown.",
-  inputSchema: PLACE_ID_SCHEMA,
+  inputSchema: STANDARD_PLACE_SCHEMA,
 };
 
 export type { WikiCountryInput };

--- a/mcp-server/src/types/collection.ts
+++ b/mcp-server/src/types/collection.ts
@@ -77,7 +77,6 @@ export interface Collection {
   id: string;
   title: string;
   dateRange: string;
-  placeIds: number[];
   recordCount: number;
   personCount: number;
   imageCount: number;
@@ -86,7 +85,6 @@ export interface Collection {
 
 export interface CollectionsResult {
   query?: string;
-  placeIds?: number[];
   matchingCollections: number;
   collections: Collection[];
 }

--- a/mcp-server/src/types/collection.ts
+++ b/mcp-server/src/types/collection.ts
@@ -84,6 +84,7 @@ export interface Collection {
 }
 
 export interface CollectionsResult {
+  standardPlace?: string;
   query?: string;
   matchingCollections: number;
   collections: Collection[];

--- a/mcp-server/src/types/gedcomx.ts
+++ b/mcp-server/src/types/gedcomx.ts
@@ -42,7 +42,11 @@ export interface GedcomXFact {
   type?: string;
   primary?: boolean;
   date?: { original?: string; formal?: string };
-  place?: { original?: string; description?: string };
+  place?: {
+    original?: string;
+    normalized?: { value: string; lang?: string }[];
+    description?: string;
+  };
   value?: string;
   sources?: GedcomXSourceReference[];
 }
@@ -124,6 +128,11 @@ export interface SimplifiedFact {
   date?: string;
   standard_date?: string;
   place?: string;
+  // Standardized place name (the snake_case data-format spelling of
+  // `standardPlace`). Populated from raw `place.normalized` by `toSimplified`,
+  // or by the network standardization pass (`toSimplifiedStandardized`) for
+  // free-text places. Dropped on `toGedcomX`, like `standard_date`.
+  standard_place?: string;
   value?: string;
   sources?: SimplifiedSourceReference[];
 }

--- a/mcp-server/src/types/metadata-search.ts
+++ b/mcp-server/src/types/metadata-search.ts
@@ -17,9 +17,9 @@ export interface MetadataSearchInput {
 // ---------- RMS request ----------
 
 export interface MetadataRmsCoverageRequest {
-  // placeRepIds come from the shared resolver as strings; the RMS API accepts
-  // them JSON-serialized.
-  placeRepIds: string[];
+  // Numeric rep IDs — the RMS API's expected wire format. The resolver returns
+  // them as strings; the tool maps them to numbers for the request body.
+  placeRepIds: number[];
   fromDateString?: string;
   toDateString?: string;
 }

--- a/mcp-server/src/types/metadata-search.ts
+++ b/mcp-server/src/types/metadata-search.ts
@@ -8,7 +8,7 @@
 // ---------- Tool input ----------
 
 export interface MetadataSearchInput {
-  placeId: string;
+  standardPlace: string;
   fromDate?: string;
   toDate?: string;
   pageToken?: string;
@@ -17,7 +17,9 @@ export interface MetadataSearchInput {
 // ---------- RMS request ----------
 
 export interface MetadataRmsCoverageRequest {
-  placeRepIds: number[];
+  // placeRepIds come from the shared resolver as strings; the RMS API accepts
+  // them JSON-serialized.
+  placeRepIds: string[];
   fromDateString?: string;
   toDateString?: string;
 }
@@ -86,7 +88,7 @@ export interface MetadataGroup {
 
 export interface MetadataSearchResult {
   query: {
-    placeId: string;
+    standardPlace: string;
     fromDate?: string;
     toDate?: string;
   };

--- a/mcp-server/src/types/place-external-links.ts
+++ b/mcp-server/src/types/place-external-links.ts
@@ -28,6 +28,7 @@ export interface PlaceExternalLink {
 }
 
 export interface PlaceExternalLinksResult {
+  standardPlace: string;
   place: string | null;
   totalResults: number;
   matchedCount: number;

--- a/mcp-server/src/types/place-population.ts
+++ b/mcp-server/src/types/place-population.ts
@@ -48,7 +48,7 @@ export interface PopulationResponse {
 // Tool Input Type
 
 export interface PopulationToolInput {
-  placeId: string;
+  standardPlace: string;
   year?: number;
   year_start?: number;
   year_end?: number;

--- a/mcp-server/src/types/place.ts
+++ b/mcp-server/src/types/place.ts
@@ -87,12 +87,14 @@ export interface PlaceResult {
   wikipediaUrl?: string;       // FamilySearch's curated WIKIPEDIA_LINK attribute
 }
 
-// LLM-facing place shape. Deliberately omits the FamilySearch identifiers
-// (`placeId`, `placeRepId`, parent rep IDs) and the relevance `score` — those
-// are internal API details the model never sees. Both `place_search` and
-// `place_search_all` return arrays of these.
+// LLM-facing place shape: `place_search` / `place_search_all` always and only
+// return standard places. `standardPlace` (the fully-qualified standardized
+// name) is the canonical handle skills pass to every downstream tool; the rest
+// is metadata. Deliberately omits the FamilySearch identifiers (`placeId`,
+// `placeRepId`, parent rep IDs) and the relevance `score` — internal API
+// details the model never sees.
 export interface SimplifiedPlaceResult {
-  fullName: string;
+  standardPlace: string;
   type: string;
   dateRange?: string;
   latitude?: number;

--- a/mcp-server/src/types/wikiPage.ts
+++ b/mcp-server/src/types/wikiPage.ts
@@ -8,10 +8,10 @@ export interface WikiPageResult {
 }
 
 export interface WikiCountryInput {
-  placeId: string;
+  standardPlace: string;
 }
 
 export interface WikiCountryResult extends WikiPageResult {
-  placeId: string;
+  standardPlace: string;
   placeName: string;
 }

--- a/mcp-server/src/utils/gedcomx-convert.ts
+++ b/mcp-server/src/utils/gedcomx-convert.ts
@@ -633,7 +633,7 @@ function expandPlaceDescription(
 // part of the converter that touches the network; it is best-effort.
 
 const STANDARDIZE_CONCURRENCY = 8;
-const STANDARDIZE_SOFT_CAP = 50;
+const STANDARDIZE_SOFT_CAP = 100;
 
 /** Gather every fact (person + relationship) from a simplified document. */
 export function collectFacts(doc: SimplifiedGedcomX): SimplifiedFact[] {

--- a/mcp-server/src/utils/gedcomx-convert.ts
+++ b/mcp-server/src/utils/gedcomx-convert.ts
@@ -21,6 +21,7 @@ import type {
 } from "../types/gedcomx.js";
 import { stdDate } from "./date-standardize.js";
 import { toArk, arkToBareId } from "./ark.js";
+import { resolveStandardPlace, mapWithConcurrency } from "./place-resolver.js";
 
 const URI_PREFIX = "http://gedcomx.org/";
 const CITATION_DETAIL = "http://gedcomx.org/CitationDetail";
@@ -243,6 +244,21 @@ function isKnownNamePart(kind: string): kind is NamePartKind {
   return (KNOWN_NAME_PARTS as readonly string[]).includes(kind);
 }
 
+/**
+ * Pick the standardized place name from a raw GedcomX `place.normalized` array.
+ * Prefers the English entry; falls back to the first non-empty value (locale
+ * fragility accepted — the read tools send `Accept-Language: en`). Returns
+ * undefined when there is no normalized value.
+ */
+function pickNormalizedPlace(
+  normalized?: { value: string; lang?: string }[],
+): string | undefined {
+  if (!normalized || normalized.length === 0) return undefined;
+  const en = normalized.find((n) => n.lang === "en" && n.value);
+  if (en) return en.value;
+  return normalized.find((n) => n.value)?.value;
+}
+
 function simplifyFact(fact: GedcomXFact): SimplifiedFact {
   const out: SimplifiedFact = {};
   if (fact.id !== undefined) out.id = fact.id;
@@ -261,8 +277,16 @@ function simplifyFact(fact: GedcomXFact): SimplifiedFact {
     if (standardized.length > 0) out.standard_date = standardized;
   }
 
-  if (fact.place && typeof fact.place.original === "string") {
-    out.place = fact.place.original;
+  if (fact.place) {
+    if (typeof fact.place.original === "string") {
+      out.place = fact.place.original;
+    }
+    // Standardized-place sidecar (cf. standard_date): take the canonical name
+    // straight from the raw GedcomX `normalized` values when present — pure, no
+    // network. Free-text places that lack a normalized value are filled later
+    // by the document-level standardization pass (toSimplifiedStandardized).
+    const standard = pickNormalizedPlace(fact.place.normalized);
+    if (standard) out.standard_place = standard;
   }
 
   // Preserve the fact-level value (the qualifier carrying the meaning of
@@ -600,4 +624,96 @@ function expandPlaceDescription(
   if (typeof place.longitude === "number") out.longitude = place.longitude;
 
   return out;
+}
+
+// ─── Place standardization (network) ─────────────────────────────────────────
+// `toSimplified` populates `standard_place` from raw `place.normalized` (pure).
+// Free-text places that lack a normalized value are standardized here, by
+// resolving the place name through the shared place resolver. This is the only
+// part of the converter that touches the network; it is best-effort.
+
+const STANDARDIZE_CONCURRENCY = 8;
+const STANDARDIZE_SOFT_CAP = 50;
+
+/** Gather every fact (person + relationship) from a simplified document. */
+export function collectFacts(doc: SimplifiedGedcomX): SimplifiedFact[] {
+  const facts: SimplifiedFact[] = [];
+  for (const p of doc.persons ?? []) {
+    for (const f of p.facts ?? []) facts.push(f);
+  }
+  for (const r of doc.relationships ?? []) {
+    for (const f of r.facts ?? []) facts.push(f);
+  }
+  return facts;
+}
+
+/**
+ * Fill `standard_place` on any fact that has a free-text `place` but no
+ * standardized form yet, resolving the place name through the shared resolver.
+ * Operates in place. Best-effort:
+ *  - dedups identical place strings so each is resolved once ("Ky" ×10 → 1),
+ *  - resolves up to 8 distinct places in parallel,
+ *  - never throws (a resolver failure just leaves `standard_place` empty),
+ *  - caps the distinct places resolved per call and logs the overflow.
+ * Pass the facts from across a whole tool response (e.g. all of record_search's
+ * entries) so the dedup spans the entire response.
+ */
+export async function standardizePlaces(
+  facts: SimplifiedFact[],
+): Promise<void> {
+  const needing = facts.filter((f) => f.place && !f.standard_place);
+  if (needing.length === 0) return;
+
+  // Dedup by normalized place string -> the facts that share it.
+  const groups = new Map<
+    string,
+    { original: string; facts: SimplifiedFact[] }
+  >();
+  for (const f of needing) {
+    const key = f.place!.trim().toLowerCase().replace(/\s+/g, " ");
+    const group = groups.get(key);
+    if (group) group.facts.push(f);
+    else groups.set(key, { original: f.place!, facts: [f] });
+  }
+
+  let distinct = [...groups.values()];
+  if (distinct.length > STANDARDIZE_SOFT_CAP) {
+    const dropped = distinct.length - STANDARDIZE_SOFT_CAP;
+    distinct = distinct.slice(0, STANDARDIZE_SOFT_CAP);
+    console.error(
+      `[standardizePlaces] ${dropped} distinct place(s) over the soft cap of ` +
+        `${STANDARDIZE_SOFT_CAP} left unstandardized`,
+    );
+  }
+
+  await mapWithConcurrency(
+    distinct,
+    STANDARDIZE_CONCURRENCY,
+    async (group) => {
+      let standard: string | null = null;
+      try {
+        standard = await resolveStandardPlace(group.original);
+      } catch {
+        standard = null; // resolver is best-effort; never fail the conversion
+      }
+      if (standard) {
+        for (const f of group.facts) f.standard_place = standard;
+      }
+    },
+  );
+}
+
+/**
+ * `toSimplified` plus a document-level place-standardization pass. Tools that
+ * return facts to the model call this (instead of bare `toSimplified`) so the
+ * LLM always sees a `standard_place`. Search tools that produce many documents
+ * should instead run `standardizePlaces` once over the flattened fact set
+ * (`collectFacts` per doc) so dedup spans the whole response.
+ */
+export async function toSimplifiedStandardized(
+  gedcomx: GedcomX,
+): Promise<SimplifiedGedcomX> {
+  const simplified = toSimplified(gedcomx);
+  await standardizePlaces(collectFacts(simplified));
+  return simplified;
 }

--- a/mcp-server/src/utils/place-api.ts
+++ b/mcp-server/src/utils/place-api.ts
@@ -1,0 +1,310 @@
+// Low-level FamilySearch Places API access — the raw HTTP fetchers that sit
+// below the tool layer. Both `utils/place-resolver.ts` (the standardPlace↔ID
+// resolution + caching layer) and `tools/place-search.ts` (the place_search /
+// place_search_all tool logic) build on these. Keeping them here, rather than
+// inside place-search.ts, avoids the resolver (a util) having to import from a
+// tool. No caching, no resolution policy — just fetch + parse.
+
+import type {
+  FSPlaceSearchResponse,
+  FSPlaceDescriptionResponse,
+} from "../types/place.js";
+import { BROWSER_USER_AGENT } from "../constants.js";
+
+const FS_API_BASE = "https://api.familysearch.org/platform/places";
+// FamilySearch's place service (the one the research-places website uses). It
+// carries curated per-place external links — including the correct Wikipedia
+// link — that the public /platform/places API does not expose.
+const FS_PLACE_WS_UI_BASE =
+  "https://www.familysearch.org/service/standards/place/ws-ui/places/reps";
+const FS_PRIMARY_IDENTIFIER_KEY = "http://gedcomx.org/Primary";
+
+interface FSPlaceLookupEntry {
+  id: string;
+  place?: { resource?: string; resourceId?: string };
+  identifiers?: Record<string, string[]>;
+  display?: { name: string; fullName: string; type: string };
+}
+
+interface FSPlaceLookupResponse {
+  places?: FSPlaceLookupEntry[];
+}
+
+export interface SearchPlaceResult {
+  placeId?: string;     // Primary
+  placeRepId: string;   // rep
+  name: string;
+  fullName: string;
+  type: string;
+  latitude?: number;
+  longitude?: number;
+  dateRange?: string;
+  score?: number;
+}
+
+export interface GetPlaceResult extends SearchPlaceResult {
+  parentPlaceRepId?: string;
+}
+
+/**
+ * Extract the bare Primary place ID from the identifiers map.
+ * The Primary value is a URL of the form
+ * "https://api.familysearch.org/platform/places/{primaryId}"; the bare ID
+ * is the last path segment. Returns undefined if the Primary identifier
+ * is missing or malformed.
+ */
+export function extractPrimaryId(
+  identifiers: Record<string, string[]> | undefined
+): string | undefined {
+  const url = identifiers?.[FS_PRIMARY_IDENTIFIER_KEY]?.[0];
+  if (!url) return undefined;
+  const segments = url.split("/");
+  const last = segments[segments.length - 1];
+  return last || undefined;
+}
+
+export async function searchPlace(name: string): Promise<SearchPlaceResult[]> {
+  const url = `${FS_API_BASE}/search?q=name:${encodeURIComponent(name)}`;
+
+  const response = await fetch(url, {
+    headers: {
+      Accept: "application/x-gedcomx-atom+json",
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`FamilySearch API error: ${response.status} ${response.statusText}`);
+  }
+
+  const text = await response.text();
+  if (!text || text.trim() === "") {
+    return [];
+  }
+
+  const data: FSPlaceSearchResponse = JSON.parse(text);
+
+  if (!data.entries || data.entries.length === 0) {
+    return [];
+  }
+
+  return data.entries.map((entry) => {
+    const place = entry.content.gedcomx.places[0];
+    return {
+      placeId: extractPrimaryId(place.identifiers),
+      placeRepId: entry.id,
+      name: place.display.name,
+      fullName: place.display.fullName,
+      type: place.display.type,
+      latitude: place.latitude,
+      longitude: place.longitude,
+      dateRange: place.temporalDescription?.formal,
+      score: entry.score,
+    };
+  });
+}
+
+/**
+ * Get place details by Primary ID using FamilySearch API.
+ * The Primary ID is the canonical place ID (placeId) returned by the places tool.
+ * Returns null for 404 (invalid ID), throws for other errors.
+ */
+export async function getPlaceByPrimaryId(primaryId: string): Promise<GetPlaceResult | null> {
+  const url = `${FS_API_BASE}/${primaryId}`;
+
+  const response = await fetch(url, {
+    headers: {
+      Accept: "application/json",
+    },
+  });
+
+  if (!response.ok) {
+    if (response.status === 404) {
+      return null;
+    }
+    throw new Error(`FamilySearch API error: ${response.status} ${response.statusText}`);
+  }
+
+  const data: FSPlaceDescriptionResponse = await response.json();
+
+  // The response contains two objects: the place (names only, no display/coords)
+  // and the place description (has display, latitude, longitude). Use the latter.
+  const place = data.places?.find((p) => p.display != null);
+  if (!place) {
+    return null;
+  }
+
+  return {
+    placeId: extractPrimaryId(place.identifiers),
+    placeRepId: place.id,
+    name: place.display.name,
+    fullName: place.display.fullName,
+    type: place.display.type,
+    latitude: place.latitude,
+    longitude: place.longitude,
+    dateRange: place.temporalDescription?.formal,
+    parentPlaceRepId: place.jurisdiction?.resourceId,
+  };
+}
+
+/**
+ * Get place details by ID using FamilySearch API.
+ * Returns null for 404 (invalid ID), throws for other errors.
+ */
+export async function getPlaceById(id: string): Promise<GetPlaceResult | null> {
+  const url = `${FS_API_BASE}/description/${id}`;
+
+  const response = await fetch(url, {
+    headers: {
+      Accept: "application/json",
+    },
+  });
+
+  if (!response.ok) {
+    if (response.status === 404) {
+      return null;
+    }
+    throw new Error(`FamilySearch API error: ${response.status} ${response.statusText}`);
+  }
+
+  const data: FSPlaceDescriptionResponse = await response.json();
+
+  if (!data.places || data.places.length === 0) {
+    return null;
+  }
+
+  const place = data.places[0];
+
+  return {
+    placeId: extractPrimaryId(place.identifiers),
+    placeRepId: place.id,
+    name: place.display.name,
+    fullName: place.display.fullName,
+    type: place.display.type,
+    latitude: place.latitude,
+    longitude: place.longitude,
+    dateRange: place.temporalDescription?.formal,
+    parentPlaceRepId: place.jurisdiction?.resourceId,
+  };
+}
+
+interface FSPlaceAttribute {
+  type?: { code?: string };
+  url?: string;
+}
+interface FSPlaceAttributesResponse {
+  attributes?: FSPlaceAttribute[];
+}
+
+/**
+ * Get the curated Wikipedia URL FamilySearch stores for a place rep.
+ *
+ * FamilySearch keeps a per-place `WIKIPEDIA_LINK` attribute (e.g. Paris, Idaho
+ * → en.wikipedia.org/wiki/Paris,_Idaho) on its place service — the same one the
+ * research-places website uses. This is correct per-place, unlike a name-based
+ * Wikipedia lookup. Returns null when the place has no such attribute or on any
+ * error (graceful degradation — the Wikipedia link is optional enrichment).
+ *
+ * Note: places may also carry an `FS_WIKI_LINK` attribute (the FamilySearch
+ * research wiki, a different thing); we take only `WIKIPEDIA_LINK`.
+ */
+export async function getPlaceWikipediaUrl(repId: string): Promise<string | null> {
+  const url = `${FS_PLACE_WS_UI_BASE}/${encodeURIComponent(repId)}/attributes/`;
+
+  try {
+    const response = await fetch(url, {
+      headers: {
+        Accept: "application/json",
+        "User-Agent": BROWSER_USER_AGENT,
+        "FS-User-Agent-Chain": "zion-user",
+      },
+    });
+
+    if (!response.ok) {
+      return null;
+    }
+
+    const data = (await response.json()) as FSPlaceAttributesResponse;
+    const wiki = (data.attributes ?? []).find(
+      (a) => a.type?.code === "WIKIPEDIA_LINK" && !!a.url
+    );
+    return wiki?.url ?? null;
+  } catch {
+    return null;
+  }
+}
+
+type PrimaryIdResponse = {
+  places?: Array<{ id: string; names?: Array<{ lang: string; value: string }> }>;
+};
+
+async function fetchPrimaryIdResponse(primaryId: string): Promise<PrimaryIdResponse> {
+  const url = `${FS_API_BASE}/${primaryId}`;
+  const response = await fetch(url, { headers: { Accept: "application/json" } });
+  if (!response.ok) {
+    if (response.status === 404) return {};
+    throw new Error(`FamilySearch API error: ${response.status} ${response.statusText}`);
+  }
+  return (await response.json()) as PrimaryIdResponse;
+}
+
+export async function getPlaceCandidateNames(primaryId: string): Promise<string[]> {
+  const data = await fetchPrimaryIdResponse(primaryId);
+  if (!data.places?.length) return [];
+
+  const allNames = data.places[0].names ?? [];
+
+  // Keep proper-case English names: starts uppercase, not all-caps (filters abbreviations like PRT, MN)
+  const properEnglish = allNames
+    .filter(
+      (n) =>
+        n.lang === "en" &&
+        n.value.length > 0 &&
+        n.value[0] === n.value[0].toUpperCase() &&
+        n.value !== n.value.toUpperCase()
+    )
+    .map((n) => n.value);
+
+  // Deduplicate; single-word names first (more likely to be the canonical wiki page name)
+  const seen = new Set<string>();
+  const singleWord: string[] = [];
+  const multiWord: string[] = [];
+  for (const name of properEnglish) {
+    if (seen.has(name)) continue;
+    seen.add(name);
+    (name.includes(" ") ? multiWord : singleWord).push(name);
+  }
+  return [...singleWord, ...multiWord];
+}
+
+/**
+ * Get every place representation ID for a Primary place ID via the
+ * Place_resource endpoint (GET /platform/places/{pid}). The response lists the
+ * bare place entry (id === pid, no `display`) followed by its representation
+ * entries, each with `place.resourceId === pid`. We collect those rep IDs.
+ *
+ * Public (no auth) — the places endpoints accept anonymous requests.
+ */
+export async function getPlaceRepIds(pid: string): Promise<string[]> {
+  const url = `${FS_API_BASE}/${encodeURIComponent(pid)}`;
+
+  const response = await fetch(url, { headers: { Accept: "application/json" } });
+  if (!response.ok) {
+    if (response.status === 404) return [];
+    throw new Error(
+      `FamilySearch API error: ${response.status} ${response.statusText}`
+    );
+  }
+
+  const data = (await response.json()) as FSPlaceLookupResponse;
+  const reps = (data.places ?? []).filter((p) => p.place?.resourceId === pid);
+
+  const ids: string[] = [];
+  const seen = new Set<string>();
+  for (const rep of reps) {
+    if (rep.id && !seen.has(rep.id)) {
+      seen.add(rep.id);
+      ids.push(rep.id);
+    }
+  }
+  return ids;
+}

--- a/mcp-server/src/utils/place-resolver.ts
+++ b/mcp-server/src/utils/place-resolver.ts
@@ -1,0 +1,365 @@
+/**
+ * Shared place resolver — the single home for converting between a
+ * `standardPlace` (a fully-qualified standardized place NAME) and the
+ * FamilySearch identifiers it maps to (placeRepId, placeId).
+ *
+ * Above the MCP tool layer everything is a `standardPlace` name; the raw
+ * `placeId` / `placeRepId` identifiers live only here, behind a bidirectional
+ * in-process cache so repeated lookups don't re-hit FamilySearch.
+ *
+ * Naming (see docs/plan/standard-place-standardization.md §2): camelCase
+ * `standardPlace` is the code-surface spelling (this module, tool inputs, the
+ * place_search struct). The snake_case `standard_place` form appears only in
+ * the SimplifiedGedcomX / research.json data formats.
+ *
+ * This module builds on the low-level FamilySearch places fetchers already
+ * exported by `../tools/place-search.ts` (`searchPlace`, `getPlaceById`,
+ * `getPlaceRepIds`). All of those endpoints are anonymous (no auth), so the
+ * process-wide caches here carry no user-scoped data and are safe to share.
+ *
+ * TODO(consolidation, plan §4/§12): later steps move the low-level fetchers
+ * down into this module and have place-search.ts delegate to it, so the raw
+ * HTTP lives below the tool layer. For now this is a pure addition that reuses
+ * the existing exports — no contract changes.
+ */
+import {
+  searchPlace,
+  getPlaceById,
+  getPlaceRepIds,
+} from "../tools/place-search.js";
+
+// Element types of the existing fetchers, without needing their (unexported)
+// interfaces — keeps this module in lockstep with place-search.ts.
+type SearchEntry = Awaited<ReturnType<typeof searchPlace>>[number];
+
+interface RepInfo {
+  standardPlace: string;
+  placeId?: string;
+  latitude?: number;
+  longitude?: number;
+}
+
+export interface ResolveOpts {
+  /**
+   * Higher-level place used to disambiguate (e.g. "Idaho"), matched as a
+   * case-insensitive substring of each candidate's full name.
+   */
+  contextName?: string;
+  /**
+   * The date of the fact/event, for forward-compat. NOT yet used: v1 bulk
+   * standardization is date-agnostic (we populate the stable NAME; date-aware
+   * placeRepId disambiguation lives in the consuming tools). See plan §11.
+   */
+  date?: string;
+}
+
+// ─── Caches ────────────────────────────────────────────────────────────────
+// In-process Maps, no TTL — mirrors place-search.ts's placeSearchCache and
+// respects "no cross-session host storage" (CLAUDE.md). The persisted
+// standardPlace strings in research.json / tree.gedcomx.json are the real
+// cross-session cache.
+
+/** originalText (normalized) -> standardPlace | null. Caches DEFINITIVE
+ *  0-candidate negatives only; transient (retry-exhausted) failures are never
+ *  cached, so a network blip doesn't poison the cache. */
+const standardizeCache = new Map<string, string | null>();
+/** standardPlace name (normalized) -> placeRepId | null. */
+const nameToRepIdCache = new Map<string, string | null>();
+/** placeRepId -> resolved info (standardPlace, placeId, coords). */
+const repInfoCache = new Map<string, RepInfo | null>();
+/** placeId -> all placeRepIds for that spot over time. */
+const placeIdRepsCache = new Map<string, string[]>();
+/** Internal memo of raw search results, so the resolver fns above don't
+ *  re-issue the same search. Key: `${name}|${contextName}` (normalized). */
+const searchEntriesCache = new Map<string, SearchEntry[]>();
+
+/** Test-only: clear every cache so cases don't bleed into each other. */
+export function __clearPlaceResolverCachesForTests(): void {
+  standardizeCache.clear();
+  nameToRepIdCache.clear();
+  repInfoCache.clear();
+  placeIdRepsCache.clear();
+  searchEntriesCache.clear();
+}
+
+// ─── Generic helpers ─────────────────────────────────────────────────────────
+
+function normalizeKey(s: string): string {
+  return s.trim().toLowerCase().replace(/\s+/g, " ");
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Retry an idempotent async call with exponential backoff + jitter. Used for
+ * place standardization, where a transient network / 429 / 5xx blip shouldn't
+ * drop a place. Re-throws the last error after `attempts` tries so the caller
+ * can decide (the resolver fns swallow it and return null WITHOUT caching, so
+ * the failed lookup retries on a later call).
+ *
+ * NOTE: the underlying fetchers throw a generic Error on any non-2xx, so this
+ * retries all thrown errors (not just 5xx). That is harmless for these
+ * idempotent GETs; finer transient-only classification will land when the raw
+ * fetch moves into this module (see file header TODO).
+ */
+export async function withRetry<T>(
+  fn: () => Promise<T>,
+  opts?: { attempts?: number; baseMs?: number },
+): Promise<T> {
+  const attempts = opts?.attempts ?? 3;
+  const baseMs = opts?.baseMs ?? 200;
+  let lastErr: unknown;
+  for (let attempt = 0; attempt < attempts; attempt++) {
+    try {
+      return await fn();
+    } catch (err) {
+      lastErr = err;
+      if (attempt < attempts - 1) {
+        const backoff = baseMs * 2 ** attempt;
+        const jitter = backoff * 0.5 * Math.random();
+        await sleep(backoff + jitter);
+      }
+    }
+  }
+  throw lastErr;
+}
+
+/**
+ * Map over items with bounded concurrency (default 8). Order-preserving. Used
+ * by the converter's document-level standardization pass so a search result
+ * with many places resolves in parallel without flooding FamilySearch.
+ */
+export async function mapWithConcurrency<T, R>(
+  items: T[],
+  limit: number,
+  fn: (item: T, index: number) => Promise<R>,
+): Promise<R[]> {
+  const results: R[] = new Array(items.length);
+  let cursor = 0;
+  async function worker(): Promise<void> {
+    for (;;) {
+      const index = cursor++;
+      if (index >= items.length) return;
+      results[index] = await fn(items[index], index);
+    }
+  }
+  const workerCount = Math.max(1, Math.min(limit, items.length));
+  await Promise.all(Array.from({ length: workerCount }, () => worker()));
+  return results;
+}
+
+// ─── Internal search + selection ─────────────────────────────────────────────
+
+/**
+ * Run (and memoize) a name search. Applies the same context-name filter as
+ * place_search: narrow by substring, but keep the unfiltered set if nothing
+ * matches (better to return extra candidates than zero). Wrapped in withRetry;
+ * a successful empty result IS cached (definitive), a thrown error is not.
+ */
+async function getSearchEntries(
+  name: string,
+  contextName?: string,
+): Promise<SearchEntry[]> {
+  const key = `${normalizeKey(name)}|${normalizeKey(contextName ?? "")}`;
+  const cached = searchEntriesCache.get(key);
+  if (cached) return cached;
+
+  let entries = await withRetry(() => searchPlace(name));
+
+  const context = contextName?.trim().toLowerCase();
+  if (context) {
+    const filtered = entries.filter((e) =>
+      e.fullName.toLowerCase().includes(context),
+    );
+    if (filtered.length > 0) entries = filtered;
+  }
+
+  searchEntriesCache.set(key, entries);
+  return entries;
+}
+
+/** Highest-scoring entry (FamilySearch ranks by relevance), else first. */
+function pickBest(entries: SearchEntry[]): SearchEntry | undefined {
+  if (entries.length === 0) return undefined;
+  return entries.reduce((best, e) =>
+    (e.score ?? 0) > (best.score ?? 0) ? e : best,
+  );
+}
+
+/**
+ * When the input IS already a standard fullName, prefer an exact
+ * (case-insensitive) fullName match; fall back to best-scored otherwise.
+ */
+function pickExactOrBest(
+  entries: SearchEntry[],
+  name: string,
+): SearchEntry | undefined {
+  const target = normalizeKey(name);
+  const exact = entries.filter((e) => normalizeKey(e.fullName) === target);
+  return pickBest(exact.length > 0 ? exact : entries);
+}
+
+// ─── Public API ───────────────────────────────────────────────────────────
+
+/**
+ * Free-text place ("Ky", "Branch Twp., Schuylkill Co., PA") -> the canonical
+ * `standardPlace` name, or null if nothing matches. This is the "standardize
+ * otherwise" path the converter uses when raw GedcomX carries no normalized
+ * value. Definitive 0-candidate results are negative-cached; transient
+ * failures are not (they retry on a later call).
+ */
+export async function resolveStandardPlace(
+  originalText: string,
+  opts: ResolveOpts = {},
+): Promise<string | null> {
+  const key = normalizeKey(originalText);
+  if (!key) return null;
+  if (standardizeCache.has(key)) return standardizeCache.get(key) ?? null;
+
+  let entries: SearchEntry[];
+  try {
+    entries = await getSearchEntries(originalText, opts.contextName);
+  } catch {
+    return null; // transient failure after retries — do not cache
+  }
+
+  const best = pickBest(entries);
+  const standardPlace = best?.fullName ?? null;
+  standardizeCache.set(key, standardPlace); // definitive (incl. null for 0 hits)
+  return standardPlace;
+}
+
+/**
+ * A `standardPlace` name -> its placeRepId (1:1), or null. Prefers an exact
+ * fullName match among candidates.
+ */
+export async function standardPlaceToRepId(
+  standardPlace: string,
+  opts: ResolveOpts = {},
+): Promise<string | null> {
+  const key = normalizeKey(standardPlace);
+  if (!key) return null;
+  if (nameToRepIdCache.has(key)) return nameToRepIdCache.get(key) ?? null;
+
+  let entries: SearchEntry[];
+  try {
+    entries = await getSearchEntries(standardPlace, opts.contextName);
+  } catch {
+    return null;
+  }
+
+  const match = pickExactOrBest(entries, standardPlace);
+  const repId = match?.placeRepId ?? null;
+  nameToRepIdCache.set(key, repId);
+  return repId;
+}
+
+/**
+ * A placeRepId -> its `standardPlace` name (1:1, cheap), or null. Uses the
+ * description endpoint via getPlaceById.
+ */
+export async function repIdToStandardPlace(
+  repId: string,
+): Promise<string | null> {
+  const info = await getRepInfo(repId);
+  return info?.standardPlace ?? null;
+}
+
+async function getRepInfo(repId: string): Promise<RepInfo | null> {
+  if (repInfoCache.has(repId)) return repInfoCache.get(repId) ?? null;
+  let place: Awaited<ReturnType<typeof getPlaceById>>;
+  try {
+    place = await withRetry(() => getPlaceById(repId));
+  } catch {
+    return null; // transient — do not cache
+  }
+  const info: RepInfo | null = place
+    ? {
+        standardPlace: place.fullName,
+        placeId: place.placeId,
+        latitude: place.latitude,
+        longitude: place.longitude,
+      }
+    : null;
+  repInfoCache.set(repId, info);
+  return info;
+}
+
+/**
+ * A `standardPlace` name -> its parent placeId ("spot on earth"), or null.
+ * Returns null when the surviving candidates DISAGREE on placeId, so callers
+ * that fan out over all reps (metadata_search, place_population) never silently
+ * query the wrong spot. See plan §11.
+ */
+export async function standardPlaceToPlaceId(
+  standardPlace: string,
+  opts: ResolveOpts = {},
+): Promise<string | null> {
+  let entries: SearchEntry[];
+  try {
+    entries = await getSearchEntries(standardPlace, opts.contextName);
+  } catch {
+    return null;
+  }
+
+  const target = normalizeKey(standardPlace);
+  const exact = entries.filter(
+    (e) => normalizeKey(e.fullName) === target && e.placeId,
+  );
+  const pool = exact.length > 0 ? exact : entries.filter((e) => e.placeId);
+  if (pool.length === 0) return null;
+
+  const distinct = new Set(pool.map((e) => e.placeId as string));
+  if (distinct.size > 1) return null; // ambiguous spot — guard the fan-out
+  return pool[0].placeId ?? null;
+}
+
+/**
+ * All placeRepIds a placeId has had over time (1:N). The only FS path that
+ * enumerates a spot's representations — used by place_search_all and the
+ * metadata_search fan-out. Empty array on failure (not cached).
+ */
+export async function placeIdToRepIds(placeId: string): Promise<string[]> {
+  const cached = placeIdRepsCache.get(placeId);
+  if (cached) return cached;
+  let reps: string[];
+  try {
+    reps = await withRetry(() => getPlaceRepIds(placeId));
+  } catch {
+    return [];
+  }
+  placeIdRepsCache.set(placeId, reps);
+  return reps;
+}
+
+/**
+ * A `standardPlace` name -> its coordinates, or null. Coords come straight
+ * from the search entry when present (no second fetch); otherwise falls back
+ * to the description endpoint. Used by place_distance.
+ */
+export async function standardPlaceToCoords(
+  standardPlace: string,
+  opts: ResolveOpts = {},
+): Promise<{ latitude: number; longitude: number } | null> {
+  let entries: SearchEntry[];
+  try {
+    entries = await getSearchEntries(standardPlace, opts.contextName);
+  } catch {
+    return null;
+  }
+
+  const match = pickExactOrBest(entries, standardPlace);
+  if (!match) return null;
+
+  if (match.latitude != null && match.longitude != null) {
+    return { latitude: match.latitude, longitude: match.longitude };
+  }
+
+  const info = await getRepInfo(match.placeRepId);
+  if (info && info.latitude != null && info.longitude != null) {
+    return { latitude: info.latitude, longitude: info.longitude };
+  }
+  return null;
+}

--- a/mcp-server/src/utils/place-resolver.ts
+++ b/mcp-server/src/utils/place-resolver.ts
@@ -162,6 +162,10 @@ async function getSearchEntries(
   name: string,
   contextName?: string,
 ): Promise<SearchEntry[]> {
+  // Empty / whitespace-only name has nothing to search — short-circuit before
+  // any network call. This is the single choke point all resolver fns go
+  // through, so every public fn inherits the empty-input guard here.
+  if (!normalizeKey(name)) return [];
   const key = `${normalizeKey(name)}|${normalizeKey(contextName ?? "")}`;
   const cached = searchEntriesCache.get(key);
   if (cached) return cached;

--- a/mcp-server/src/utils/place-resolver.ts
+++ b/mcp-server/src/utils/place-resolver.ts
@@ -12,21 +12,18 @@
  * place_search struct). The snake_case `standard_place` form appears only in
  * the SimplifiedGedcomX / research.json data formats.
  *
- * This module builds on the low-level FamilySearch places fetchers already
- * exported by `../tools/place-search.ts` (`searchPlace`, `getPlaceById`,
- * `getPlaceRepIds`). All of those endpoints are anonymous (no auth), so the
+ * This module builds on the low-level FamilySearch places fetchers in
+ * `./place-api.ts` (`searchPlace`, `getPlaceById`, `getPlaceRepIds`) — a
+ * dedicated low-level layer that both this resolver and `tools/place-search.ts`
+ * import from, so the raw HTTP lives below the tool layer (no util→tool
+ * dependency). All of those endpoints are anonymous (no auth), so the
  * process-wide caches here carry no user-scoped data and are safe to share.
- *
- * TODO(consolidation, plan §4/§12): later steps move the low-level fetchers
- * down into this module and have place-search.ts delegate to it, so the raw
- * HTTP lives below the tool layer. For now this is a pure addition that reuses
- * the existing exports — no contract changes.
  */
 import {
   searchPlace,
   getPlaceById,
   getPlaceRepIds,
-} from "../tools/place-search.js";
+} from "./place-api.js";
 
 // Element types of the existing fetchers, without needing their (unexported)
 // interfaces — keeps this module in lockstep with place-search.ts.

--- a/mcp-server/src/validation/validator.ts
+++ b/mcp-server/src/validation/validator.ts
@@ -222,7 +222,7 @@ const NULLABLE_FIELDS = new Set([
   "date", "date_certainty", "place", "informant_bias_notes",
   "plan_item_id", "notes", "url", "url_archived", "log_entry_id",
   "structured_value", "fallback_for", "capture_filename", "record_persona_id",
-  "results_ref", "results_available", "place_id", "distance_from_previous_km",
+  "results_ref", "results_available", "standard_place", "distance_from_previous_km",
   "conflict_ids", "conflict_note", "justification",
 ]);
 

--- a/mcp-server/tests/packaging/skill-guidance.test.ts
+++ b/mcp-server/tests/packaging/skill-guidance.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync, existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+// Drift lint for shared skill guidance. Claude Code can't reliably load a
+// reference doc across skills (issue #17741), so the canonical places guidance
+// is duplicated into each place-using skill's references/ folder. This test
+// fails if any copy drifts from the canonical source — keeping the duplicates
+// in sync the same way the manifest test keeps the tool list in sync.
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(here, "..", "..", "..");
+const canonicalPath = join(repoRoot, "plugin", "references", "places-guidance.md");
+
+// Skills that carry a copy of the canonical places guidance. Add a skill here
+// (and copy the file) when it starts using place tools or writing places.
+const SKILLS_WITH_PLACES_GUIDANCE = [
+  "locality-guide",
+  "research-plan",
+  "historical-context",
+  "search-external-sites",
+  "timeline",
+  "conflict-resolution",
+  "record-extraction",
+  "tree-edit",
+  "init-project",
+];
+
+describe("places-guidance drift lint", () => {
+  const canonical = readFileSync(canonicalPath, "utf8");
+
+  it("canonical source exists and is non-empty", () => {
+    expect(canonical.trim().length).toBeGreaterThan(0);
+  });
+
+  for (const skill of SKILLS_WITH_PLACES_GUIDANCE) {
+    it(`${skill} carries an in-sync copy of places-guidance.md`, () => {
+      const copyPath = join(
+        repoRoot,
+        "plugin",
+        "skills",
+        skill,
+        "references",
+        "places-guidance.md"
+      );
+      expect(existsSync(copyPath), `missing copy: ${copyPath}`).toBe(true);
+      const copy = readFileSync(copyPath, "utf8");
+      // Byte-identical: edit the canonical, then re-copy into every skill.
+      expect(copy).toBe(canonical);
+    });
+  }
+});

--- a/mcp-server/tests/tools/distance.test.ts
+++ b/mcp-server/tests/tools/distance.test.ts
@@ -1,34 +1,19 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { haversineDistance, placeDistanceTool } from "../../src/tools/distance.js";
 
-vi.mock("../../src/tools/place-search.js", () => ({
-  getPlaceByPrimaryId: vi.fn(),
+vi.mock("../../src/utils/place-resolver.js", () => ({
+  standardPlaceToCoords: vi.fn(),
 }));
 
-import { getPlaceByPrimaryId } from "../../src/tools/place-search.js";
-const mockGetPlaceById = vi.mocked(getPlaceByPrimaryId);
+import { standardPlaceToCoords } from "../../src/utils/place-resolver.js";
+const mockCoords = vi.mocked(standardPlaceToCoords);
 
 beforeEach(() => {
-  mockGetPlaceById.mockReset();
+  mockCoords.mockReset();
 });
 
-const englandPlace = {
-  placeId: "267",
-  name: "England",
-  fullName: "England, United Kingdom",
-  type: "Country",
-  latitude: 52.0,
-  longitude: -1.0,
-};
-
-const ohioPlace = {
-  placeId: "456",
-  name: "Ohio",
-  fullName: "Ohio, United States",
-  type: "State",
-  latitude: 40.4,
-  longitude: -82.9,
-};
+const englandCoords = { latitude: 52.0, longitude: -1.0 };
+const ohioCoords = { latitude: 40.4, longitude: -82.9 };
 
 describe("haversineDistance", () => {
   it("returns a reasonable distance between London and New York", () => {
@@ -54,55 +39,44 @@ describe("haversineDistance", () => {
 });
 
 describe("placeDistanceTool", () => {
-  it("returns distance between two valid places", async () => {
-    mockGetPlaceById.mockResolvedValueOnce(englandPlace);
-    mockGetPlaceById.mockResolvedValueOnce(ohioPlace);
+  it("returns distance between two standard places", async () => {
+    mockCoords.mockResolvedValueOnce(englandCoords);
+    mockCoords.mockResolvedValueOnce(ohioCoords);
 
-    const result = await placeDistanceTool({ placeId1: "267", placeId2: "456" });
+    const result = await placeDistanceTool({
+      standardPlace1: "England, United Kingdom",
+      standardPlace2: "Ohio, United States",
+    });
 
-    expect(result.placeId1).toBe("267");
-    expect(result.placeId2).toBe("456");
-    expect(result.place1Name).toBe("England, United Kingdom");
-    expect(result.place2Name).toBe("Ohio, United States");
+    expect(result.standardPlace1).toBe("England, United Kingdom");
+    expect(result.standardPlace2).toBe("Ohio, United States");
     expect(result.miles).toBeGreaterThan(0);
     expect(result.kilometers).toBeGreaterThan(0);
+    expect(mockCoords).toHaveBeenNthCalledWith(1, "England, United Kingdom");
+    expect(mockCoords).toHaveBeenNthCalledWith(2, "Ohio, United States");
   });
 
-  it("throws when the first place ID is not found", async () => {
-    mockGetPlaceById.mockResolvedValueOnce(null);
-    mockGetPlaceById.mockResolvedValueOnce(ohioPlace);
+  it("throws when the first place cannot be resolved", async () => {
+    mockCoords.mockResolvedValueOnce(null);
+    mockCoords.mockResolvedValueOnce(ohioCoords);
 
     await expect(
-      placeDistanceTool({ placeId1: "999", placeId2: "456" })
-    ).rejects.toThrow("Place not found: 999");
+      placeDistanceTool({
+        standardPlace1: "Nowhere, Nowhere",
+        standardPlace2: "Ohio, United States",
+      })
+    ).rejects.toThrow('Could not resolve coordinates for "Nowhere, Nowhere"');
   });
 
-  it("throws when the second place ID is not found", async () => {
-    mockGetPlaceById.mockResolvedValueOnce(englandPlace);
-    mockGetPlaceById.mockResolvedValueOnce(null);
+  it("throws when the second place cannot be resolved", async () => {
+    mockCoords.mockResolvedValueOnce(englandCoords);
+    mockCoords.mockResolvedValueOnce(null);
 
     await expect(
-      placeDistanceTool({ placeId1: "267", placeId2: "999" })
-    ).rejects.toThrow("Place not found: 999");
-  });
-
-  it("throws when the first place has no coordinates", async () => {
-    const noCoords = { ...englandPlace, latitude: undefined, longitude: undefined };
-    mockGetPlaceById.mockResolvedValueOnce(noCoords);
-    mockGetPlaceById.mockResolvedValueOnce(ohioPlace);
-
-    await expect(
-      placeDistanceTool({ placeId1: "267", placeId2: "456" })
-    ).rejects.toThrow('Place "England" (ID 267) has no coordinates.');
-  });
-
-  it("throws when the second place has no coordinates", async () => {
-    const noCoords = { ...ohioPlace, latitude: undefined, longitude: undefined };
-    mockGetPlaceById.mockResolvedValueOnce(englandPlace);
-    mockGetPlaceById.mockResolvedValueOnce(noCoords);
-
-    await expect(
-      placeDistanceTool({ placeId1: "267", placeId2: "456" })
-    ).rejects.toThrow('Place "Ohio" (ID 456) has no coordinates.');
+      placeDistanceTool({
+        standardPlace1: "England, United Kingdom",
+        standardPlace2: "Nowhere, Nowhere",
+      })
+    ).rejects.toThrow('Could not resolve coordinates for "Nowhere, Nowhere"');
   });
 });

--- a/mcp-server/tests/tools/metadata-search.test.ts
+++ b/mcp-server/tests/tools/metadata-search.test.ts
@@ -4,6 +4,15 @@ vi.mock("../../src/auth/refresh.js", () => ({
   getValidToken: vi.fn(),
 }));
 
+// The places-API conversion now lives in the shared resolver; mock it so the
+// tool no longer fetches the places API (the fetch sequence is search,fulltext).
+const mockStandardPlaceToPlaceId = vi.hoisted(() => vi.fn());
+const mockPlaceIdToRepIds = vi.hoisted(() => vi.fn());
+vi.mock("../../src/utils/place-resolver.js", () => ({
+  standardPlaceToPlaceId: mockStandardPlaceToPlaceId,
+  placeIdToRepIds: mockPlaceIdToRepIds,
+}));
+
 import { metadataSearchTool } from "../../src/tools/metadata-search.js";
 import { getValidToken } from "../../src/auth/refresh.js";
 import { BROWSER_USER_AGENT } from "../../src/constants.js";
@@ -20,6 +29,10 @@ beforeEach(() => {
   mockFetch.mockReset();
   mockedGetValidToken.mockReset();
   mockedGetValidToken.mockResolvedValue("test-token");
+  mockStandardPlaceToPlaceId.mockReset();
+  mockStandardPlaceToPlaceId.mockResolvedValue("6137147");
+  mockPlaceIdToRepIds.mockReset();
+  mockPlaceIdToRepIds.mockResolvedValue(["2968392"]);
 });
 
 afterEach(() => {
@@ -27,24 +40,6 @@ afterEach(() => {
 });
 
 // ─── Fixtures ───────────────────────────────────────────────────────────
-
-function makePlacesResponse(placeRepIds: number[]) {
-  return {
-    ok: true,
-    status: 200,
-    json: async () => ({
-      places: [
-        // bare place entry — has no place.resourceId pointing back
-        { id: "6137147", display: { name: "Edensor", fullName: "Edensor, England", type: "Place" } },
-        // representation entries — each has place.resourceId === placeId
-        ...placeRepIds.map((id) => ({
-          id: String(id),
-          place: { resourceId: "6137147" },
-        })),
-      ],
-    }),
-  };
-}
 
 function makeGroup(overrides: Partial<MetadataRmsGroup> = {}): MetadataRmsGroup {
   return {
@@ -96,8 +91,8 @@ function setupCalls(
   searchBody: MetadataRmsSearchResponse,
   fulltextIds: string[]
 ) {
+  mockPlaceIdToRepIds.mockResolvedValueOnce(placeRepIds.map(String));
   mockFetch
-    .mockResolvedValueOnce(makePlacesResponse(placeRepIds))
     .mockResolvedValueOnce(makeOkResponse(searchBody))
     .mockResolvedValueOnce(makeFulltextResponse(fulltextIds));
 }
@@ -114,13 +109,13 @@ describe("metadataSearchTool", () => {
     );
 
     const result = await metadataSearchTool({
-      placeId: "6137147",
+      standardPlace: "Edensor, Derbyshire, England, United Kingdom",
       fromDate: "1730-01-01",
       toDate: "1810-12-31",
     });
 
     expect(result.query).toEqual({
-      placeId: "6137147",
+      standardPlace: "Edensor, Derbyshire, England, United Kingdom",
       fromDate: "1730-01-01",
       toDate: "1810-12-31",
     });
@@ -145,20 +140,20 @@ describe("metadataSearchTool", () => {
   // 2. Missing placeId
   it("throws when placeId is missing", async () => {
     await expect(
-      metadataSearchTool({ placeId: "" })
-    ).rejects.toThrow("metadata_search requires a placeId.");
+      metadataSearchTool({ standardPlace: "" })
+    ).rejects.toThrow("metadata_search requires a standardPlace.");
   });
 
   // 3. Malformed date
   it("throws when fromDate is malformed", async () => {
     await expect(
-      metadataSearchTool({ placeId: "6137147", fromDate: "1730/01/01" })
+      metadataSearchTool({ standardPlace: "Edensor, Derbyshire, England, United Kingdom", fromDate: "1730/01/01" })
     ).rejects.toThrow("fromDate must be in YYYY-MM-DD format");
   });
 
   it("throws when toDate is malformed", async () => {
     await expect(
-      metadataSearchTool({ placeId: "6137147", toDate: "bad-date" })
+      metadataSearchTool({ standardPlace: "Edensor, Derbyshire, England, United Kingdom", toDate: "bad-date" })
     ).rejects.toThrow("toDate must be in YYYY-MM-DD format");
   });
 
@@ -166,20 +161,23 @@ describe("metadataSearchTool", () => {
   it("converts placeId to placeRepIds in coverage.placeRepIds", async () => {
     setupCalls([2968392, 10609408], makeSearchResponse([makeGroup()]), []);
 
-    await metadataSearchTool({ placeId: "6137147" });
+    await metadataSearchTool({ standardPlace: "Edensor, Derbyshire, England, United Kingdom" });
 
-    const searchCall = mockFetch.mock.calls[1];
+    expect(mockStandardPlaceToPlaceId).toHaveBeenCalledWith(
+      "Edensor, Derbyshire, England, United Kingdom"
+    );
+    const searchCall = mockFetch.mock.calls[0];
     const body = JSON.parse(searchCall[1].body);
-    expect(body.coverage.placeRepIds).toEqual([2968392, 10609408]);
+    expect(body.coverage.placeRepIds).toEqual(["2968392", "10609408"]);
   });
 
   // 5. Fixed fields
   it("sends types NATURAL, active true, pageSize 100, returnChildCounts true", async () => {
     setupCalls([2968392], makeSearchResponse([makeGroup()]), []);
 
-    await metadataSearchTool({ placeId: "6137147" });
+    await metadataSearchTool({ standardPlace: "Edensor, Derbyshire, England, United Kingdom" });
 
-    const body = JSON.parse(mockFetch.mock.calls[1][1].body);
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body);
     expect(body.types).toEqual(["NATURAL"]);
     expect(body.active).toBe(true);
     expect(body.pageSize).toBe(100);
@@ -189,7 +187,7 @@ describe("metadataSearchTool", () => {
   // 6. imageGroupPrefix derivation
   it("derives imageGroupPrefix for bare groupName", async () => {
     setupCalls([2968392], makeSearchResponse([makeGroup({ groupName: "004452257" })]), []);
-    const result = await metadataSearchTool({ placeId: "6137147" });
+    const result = await metadataSearchTool({ standardPlace: "Edensor, Derbyshire, England, United Kingdom" });
     expect(result.groups[0].imageGroupPrefix).toBe("004452257");
   });
 
@@ -199,7 +197,7 @@ describe("metadataSearchTool", () => {
       makeSearchResponse([makeGroup({ groupName: "007621224_005_M99P-2TQ" })]),
       []
     );
-    const result = await metadataSearchTool({ placeId: "6137147" });
+    const result = await metadataSearchTool({ standardPlace: "Edensor, Derbyshire, England, United Kingdom" });
     expect(result.groups[0].imageGroupNumber).toBe("007621224_005_M99P-2TQ");
     expect(result.groups[0].imageGroupPrefix).toBe("007621224");
   });
@@ -212,7 +210,7 @@ describe("metadataSearchTool", () => {
       makeSearchResponse([makeGroup({ childCount: 412, indexedChildCount: 366, noIndexableDataChildCount: 0 })]),
       []
     );
-    const result = await metadataSearchTool({ placeId: "6137147" });
+    const result = await metadataSearchTool({ standardPlace: "Edensor, Derbyshire, England, United Kingdom" });
     expect(result.groups[0].recordSearchablePercent).toBe(89);
   });
 
@@ -223,7 +221,7 @@ describe("metadataSearchTool", () => {
       makeSearchResponse([makeGroup({ childCount: 100, indexedChildCount: 80, noIndexableDataChildCount: 20 })]),
       []
     );
-    const result = await metadataSearchTool({ placeId: "6137147" });
+    const result = await metadataSearchTool({ standardPlace: "Edensor, Derbyshire, England, United Kingdom" });
     expect(result.groups[0].recordSearchablePercent).toBe(100);
   });
 
@@ -234,7 +232,7 @@ describe("metadataSearchTool", () => {
       makeSearchResponse([makeGroup({ childCount: 10, indexedChildCount: 0, noIndexableDataChildCount: 10 })]),
       []
     );
-    const result = await metadataSearchTool({ placeId: "6137147" });
+    const result = await metadataSearchTool({ standardPlace: "Edensor, Derbyshire, England, United Kingdom" });
     expect(result.groups[0].recordSearchablePercent).toBeNull();
   });
 
@@ -245,7 +243,7 @@ describe("metadataSearchTool", () => {
     delete (groupNoCount as Partial<MetadataRmsGroup>).indexedChildCount;
     setupCalls([2968392], makeSearchResponse([groupNoCount]), []);
 
-    const result = await metadataSearchTool({ placeId: "6137147" });
+    const result = await metadataSearchTool({ standardPlace: "Edensor, Derbyshire, England, United Kingdom" });
     expect(result.groups[0].imageCount).toBeNull();
     expect(result.groups[0].recordSearchablePercent).toBeNull();
   });
@@ -257,7 +255,7 @@ describe("metadataSearchTool", () => {
       makeSearchResponse([makeGroup({ groupName: "004452257" })]),
       ["004452257"]
     );
-    const result = await metadataSearchTool({ placeId: "6137147" });
+    const result = await metadataSearchTool({ standardPlace: "Edensor, Derbyshire, England, United Kingdom" });
     expect(result.groups[0].fulltextSearchable).toBe(true);
   });
 
@@ -267,20 +265,19 @@ describe("metadataSearchTool", () => {
       makeSearchResponse([makeGroup({ groupName: "004452257" })]),
       []
     );
-    const result = await metadataSearchTool({ placeId: "6137147" });
+    const result = await metadataSearchTool({ standardPlace: "Edensor, Derbyshire, England, United Kingdom" });
     expect(result.groups[0].fulltextSearchable).toBe(false);
   });
 
   // 11. fulltextSearchable null on fulltext call failure
   it("sets fulltextSearchable to null when fulltext call fails 3 times", async () => {
     mockFetch
-      .mockResolvedValueOnce(makePlacesResponse([2968392]))
       .mockResolvedValueOnce(makeOkResponse(makeSearchResponse([makeGroup()])))
       .mockRejectedValueOnce(new Error("network error"))
       .mockRejectedValueOnce(new Error("network error"))
       .mockRejectedValueOnce(new Error("network error"));
 
-    const result = await metadataSearchTool({ placeId: "6137147" });
+    const result = await metadataSearchTool({ standardPlace: "Edensor, Derbyshire, England, United Kingdom" });
     expect(result.groups[0].fulltextSearchable).toBeNull();
   });
 
@@ -292,10 +289,10 @@ describe("metadataSearchTool", () => {
     ];
     setupCalls([2968392], makeSearchResponse(groups), []);
 
-    await metadataSearchTool({ placeId: "6137147" });
+    await metadataSearchTool({ standardPlace: "Edensor, Derbyshire, England, United Kingdom" });
 
     // calls: [0] places, [1] search, [2] fulltext
-    const fulltextCall = mockFetch.mock.calls[2];
+    const fulltextCall = mockFetch.mock.calls[1];
     expect(fulltextCall[0]).toContain("111111111");
     expect(fulltextCall[0]).toContain("222222222");
   });
@@ -313,7 +310,7 @@ describe("metadataSearchTool", () => {
       ]),
       []
     );
-    const result = await metadataSearchTool({ placeId: "6137147" });
+    const result = await metadataSearchTool({ standardPlace: "Edensor, Derbyshire, England, United Kingdom" });
     expect(result.groups[0].coverages[0]).toEqual({
       place: "Edensor",
       dateRange: "1726–1812",
@@ -335,7 +332,7 @@ describe("metadataSearchTool", () => {
       ]),
       []
     );
-    const result = await metadataSearchTool({ placeId: "6137147" });
+    const result = await metadataSearchTool({ standardPlace: "Edensor, Derbyshire, England, United Kingdom" });
     expect(result.groups[0].coverages[0].recordType).toBeUndefined();
     expect(result.groups[0].coverages[1].recordType).toBeUndefined();
   });
@@ -343,10 +340,9 @@ describe("metadataSearchTool", () => {
   // 15. Empty result set
   it("handles empty totalCount:0 response", async () => {
     mockFetch
-      .mockResolvedValueOnce(makePlacesResponse([2968392]))
       .mockResolvedValueOnce(makeOkResponse({ totalCount: 0 }));
 
-    const result = await metadataSearchTool({ placeId: "6137147" });
+    const result = await metadataSearchTool({ standardPlace: "Edensor, Derbyshire, England, United Kingdom" });
     expect(result.totalGroups).toBe(0);
     expect(result.returned).toBe(0);
     expect(result.groups).toHaveLength(0);
@@ -359,26 +355,25 @@ describe("metadataSearchTool", () => {
       makeSearchResponse([makeGroup()], { nextPageToken: "abc123" }),
       []
     );
-    const result = await metadataSearchTool({ placeId: "6137147" });
+    const result = await metadataSearchTool({ standardPlace: "Edensor, Derbyshire, England, United Kingdom" });
     expect(result.nextPageToken).toBe("abc123");
   });
 
   it("sends pageToken as nextPageToken in the request body", async () => {
     setupCalls([2968392], makeSearchResponse([makeGroup()]), []);
 
-    await metadataSearchTool({ placeId: "6137147", pageToken: "cursor-xyz" });
+    await metadataSearchTool({ standardPlace: "Edensor, Derbyshire, England, United Kingdom", pageToken: "cursor-xyz" });
 
-    const body = JSON.parse(mockFetch.mock.calls[1][1].body);
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body);
     expect(body.nextPageToken).toBe("cursor-xyz");
   });
 
   // 17. 401 error
   it("throws re-login guidance on 401", async () => {
     mockFetch
-      .mockResolvedValueOnce(makePlacesResponse([2968392]))
       .mockResolvedValueOnce(makeErrorResponse(401, "Unauthorized"));
 
-    await expect(metadataSearchTool({ placeId: "6137147" })).rejects.toThrow(
+    await expect(metadataSearchTool({ standardPlace: "Edensor, Derbyshire, England, United Kingdom" })).rejects.toThrow(
       "FamilySearch session not accepted; call the login tool to re-authenticate."
     );
   });
@@ -386,10 +381,9 @@ describe("metadataSearchTool", () => {
   // 18. Network error
   it("throws on network error", async () => {
     mockFetch
-      .mockResolvedValueOnce(makePlacesResponse([2968392]))
       .mockRejectedValueOnce(new Error("ECONNREFUSED"));
 
-    await expect(metadataSearchTool({ placeId: "6137147" })).rejects.toThrow(
+    await expect(metadataSearchTool({ standardPlace: "Edensor, Derbyshire, England, United Kingdom" })).rejects.toThrow(
       "Could not reach FamilySearch metadata search API: ECONNREFUSED."
     );
   });
@@ -398,9 +392,9 @@ describe("metadataSearchTool", () => {
   it("sends Authorization, Content-Type, User-Agent, and FS-User-Agent-Chain headers", async () => {
     setupCalls([2968392], makeSearchResponse([makeGroup()]), []);
 
-    await metadataSearchTool({ placeId: "6137147" });
+    await metadataSearchTool({ standardPlace: "Edensor, Derbyshire, England, United Kingdom" });
 
-    const searchCall = mockFetch.mock.calls[1];
+    const searchCall = mockFetch.mock.calls[0];
     const headers = searchCall[1].headers;
     expect(headers["Authorization"]).toBe("Bearer test-token");
     expect(headers["Content-Type"]).toBe("application/json");
@@ -408,16 +402,24 @@ describe("metadataSearchTool", () => {
     expect(headers["FS-User-Agent-Chain"]).toBe("chesworth");
   });
 
-  // Bonus: no placeRepIds found
-  it("throws when places API returns no placeRepIds", async () => {
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      status: 200,
-      json: async () => ({ places: [] }),
-    });
+  // Bonus: unresolvable place
+  it("throws when the standard place cannot be resolved", async () => {
+    mockStandardPlaceToPlaceId.mockResolvedValueOnce(null);
 
-    await expect(metadataSearchTool({ placeId: "9999999" })).rejects.toThrow(
-      "No place representations found for placeId 9999999."
+    await expect(
+      metadataSearchTool({ standardPlace: "Nowhere" })
+    ).rejects.toThrow(/Could not resolve "Nowhere"/);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  // Bonus: resolved place has no representations
+  it("throws when the place has no representations", async () => {
+    mockPlaceIdToRepIds.mockResolvedValueOnce([]);
+
+    await expect(
+      metadataSearchTool({ standardPlace: "Edensor, Derbyshire, England, United Kingdom" })
+    ).rejects.toThrow(
+      'No place representations found for "Edensor, Derbyshire, England, United Kingdom".'
     );
   });
 });

--- a/mcp-server/tests/tools/metadata-search.test.ts
+++ b/mcp-server/tests/tools/metadata-search.test.ts
@@ -168,7 +168,7 @@ describe("metadataSearchTool", () => {
     );
     const searchCall = mockFetch.mock.calls[0];
     const body = JSON.parse(searchCall[1].body);
-    expect(body.coverage.placeRepIds).toEqual(["2968392", "10609408"]);
+    expect(body.coverage.placeRepIds).toEqual([2968392, 10609408]);
   });
 
   // 5. Fixed fields

--- a/mcp-server/tests/tools/person-ancestors.test.ts
+++ b/mcp-server/tests/tools/person-ancestors.test.ts
@@ -4,6 +4,15 @@ vi.mock("../../src/auth/refresh.js", () => ({
   getValidToken: vi.fn(),
 }));
 
+// Place standardization runs inside the converter now; stub the network
+// resolver so these tool tests stay offline and deterministic (no standard_place
+// is added — that behavior is covered in gedcomx-standardize.test.ts).
+vi.mock("../../src/utils/place-resolver.js", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../../src/utils/place-resolver.js")>();
+  return { ...actual, resolveStandardPlace: vi.fn().mockResolvedValue(null) };
+});
+
 import { personAncestorsTool } from "../../src/tools/person-ancestors.js";
 import { getValidToken } from "../../src/auth/refresh.js";
 import type { FSAncestryResponse } from "../../src/types/person-ancestors.js";

--- a/mcp-server/tests/tools/person-read.test.ts
+++ b/mcp-server/tests/tools/person-read.test.ts
@@ -4,6 +4,15 @@ vi.mock("../../src/auth/refresh.js", () => ({
   getValidToken: vi.fn(),
 }));
 
+// Place standardization runs inside the converter now; stub the network
+// resolver so these tool tests stay offline and deterministic (no standard_place
+// is added — that behavior is covered in gedcomx-standardize.test.ts).
+vi.mock("../../src/utils/place-resolver.js", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../../src/utils/place-resolver.js")>();
+  return { ...actual, resolveStandardPlace: vi.fn().mockResolvedValue(null) };
+});
+
 import { personReadTool } from "../../src/tools/person-read.js";
 import { getValidToken } from "../../src/auth/refresh.js";
 import type { FSTreeResponse } from "../../src/types/person-read.js";

--- a/mcp-server/tests/tools/person-search.test.ts
+++ b/mcp-server/tests/tools/person-search.test.ts
@@ -4,6 +4,15 @@ vi.mock("../../src/auth/refresh.js", () => ({
   getValidToken: vi.fn(),
 }));
 
+// Place standardization runs inside the converter now; stub the network
+// resolver so these tool tests stay offline and deterministic (no standard_place
+// is added — that behavior is covered in gedcomx-standardize.test.ts).
+vi.mock("../../src/utils/place-resolver.js", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../../src/utils/place-resolver.js")>();
+  return { ...actual, resolveStandardPlace: vi.fn().mockResolvedValue(null) };
+});
+
 import {
   personSearchTool,
   buildSearchUrl,

--- a/mcp-server/tests/tools/place-collections.test.ts
+++ b/mcp-server/tests/tools/place-collections.test.ts
@@ -7,6 +7,7 @@ vi.mock("../../src/auth/refresh.js", () => ({
 import {
   placeCollectionsTool,
   filterByQuery,
+  standardPlaceToCollectionsQuery,
   fetchAllCollections,
   clearCollectionsCache,
   htmlToMarkdown,
@@ -113,7 +114,7 @@ const mockApiResponse: FSCollectionsResponse = {
   ],
 };
 
-describe("placeCollectionsTool with query", () => {
+describe("placeCollectionsTool with standardPlace", () => {
   it("returns collections matching a place name query", async () => {
     mockedGetValidToken.mockResolvedValueOnce("test-token");
     mockFetch.mockResolvedValueOnce({
@@ -121,8 +122,28 @@ describe("placeCollectionsTool with query", () => {
       json: async () => mockApiResponse,
     });
 
-    const result = await placeCollectionsTool({ query: "Alabama" });
+    const result = await placeCollectionsTool({ standardPlace: "Alabama" });
 
+    expect(result.standardPlace).toBe("Alabama");
+    expect(result.query).toBe("Alabama");
+    expect(result.matchingCollections).toBe(1);
+    expect(result.collections[0].id).toBe("1234");
+  });
+
+  it("converts a US standardPlace to its state before matching titles", async () => {
+    mockedGetValidToken.mockResolvedValueOnce("test-token");
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockApiResponse,
+    });
+
+    const result = await placeCollectionsTool({
+      standardPlace: "Birmingham, Jefferson, Alabama, United States",
+    });
+
+    // The tool derived "Alabama" (the state) from the full standardPlace and
+    // matched the Alabama collection; the input is echoed unchanged.
+    expect(result.standardPlace).toBe("Birmingham, Jefferson, Alabama, United States");
     expect(result.query).toBe("Alabama");
     expect(result.matchingCollections).toBe(1);
     expect(result.collections[0].id).toBe("1234");
@@ -135,7 +156,7 @@ describe("placeCollectionsTool with query", () => {
       json: async () => mockApiResponse,
     });
 
-    const result = await placeCollectionsTool({ query: "alabama" });
+    const result = await placeCollectionsTool({ standardPlace: "alabama" });
 
     expect(result.matchingCollections).toBe(1);
     expect(result.collections[0].id).toBe("1234");
@@ -148,7 +169,7 @@ describe("placeCollectionsTool with query", () => {
       json: async () => mockApiResponse,
     });
 
-    const result = await placeCollectionsTool({ query: "Narnia" });
+    const result = await placeCollectionsTool({ standardPlace: "Narnia" });
 
     expect(result.matchingCollections).toBe(0);
     expect(result.collections).toEqual([]);
@@ -161,10 +182,44 @@ describe("placeCollectionsTool with query", () => {
       json: async () => mockApiResponse,
     });
 
-    const result = await placeCollectionsTool({ query: "Census" });
+    const result = await placeCollectionsTool({ standardPlace: "Census" });
 
     expect(result.matchingCollections).toBe(1);
     expect(result.collections[0].id).toBe("9999");
+  });
+});
+
+describe("standardPlaceToCollectionsQuery", () => {
+  it("US standardPlace -> state only (regardless of nesting depth)", () => {
+    expect(standardPlaceToCollectionsQuery("Pennsylvania, United States")).toBe("Pennsylvania");
+    expect(standardPlaceToCollectionsQuery("Schuylkill, Pennsylvania, United States")).toBe("Pennsylvania");
+    expect(
+      standardPlaceToCollectionsQuery("Pottsville, Schuylkill, Pennsylvania, United States")
+    ).toBe("Pennsylvania");
+  });
+
+  it('Canada / Mexico -> "Country, State"', () => {
+    expect(standardPlaceToCollectionsQuery("Ontario, Canada")).toBe("Canada, Ontario");
+    expect(standardPlaceToCollectionsQuery("Toronto, Ontario, Canada")).toBe("Canada, Ontario");
+    expect(standardPlaceToCollectionsQuery("Mérida, Yucatán, Mexico")).toBe("Mexico, Yucatán");
+  });
+
+  it("all other countries -> country only", () => {
+    expect(standardPlaceToCollectionsQuery("Paris, France")).toBe("France");
+    expect(standardPlaceToCollectionsQuery("London, England, United Kingdom")).toBe("United Kingdom");
+    expect(standardPlaceToCollectionsQuery("France")).toBe("France");
+  });
+
+  it("free-text (non-standardPlace) passes through unchanged", () => {
+    expect(standardPlaceToCollectionsQuery("Census")).toBe("Census");
+    expect(standardPlaceToCollectionsQuery("Schuylkill County Pennsylvania")).toBe(
+      "Schuylkill County Pennsylvania"
+    );
+  });
+
+  it("country-only US / Canada falls back to the country", () => {
+    expect(standardPlaceToCollectionsQuery("United States")).toBe("United States");
+    expect(standardPlaceToCollectionsQuery("Canada")).toBe("Canada");
   });
 });
 
@@ -174,7 +229,7 @@ describe("placeCollectionsTool error handling", () => {
       new Error("User is not logged in to FamilySearch. Call the login tool to authenticate.")
     );
 
-    await expect(placeCollectionsTool({ query: "Alabama" })).rejects.toThrow(
+    await expect(placeCollectionsTool({ standardPlace: "Alabama" })).rejects.toThrow(
       "User is not logged in to FamilySearch. Call the login tool to authenticate."
     );
     expect(mockFetch).not.toHaveBeenCalled();
@@ -188,7 +243,7 @@ describe("placeCollectionsTool error handling", () => {
       statusText: "Internal Server Error",
     });
 
-    await expect(placeCollectionsTool({ query: "Alabama" })).rejects.toThrow(
+    await expect(placeCollectionsTool({ standardPlace: "Alabama" })).rejects.toThrow(
       "FamilySearch collections API error: 500 Internal Server Error"
     );
   });
@@ -200,13 +255,13 @@ describe("placeCollectionsTool error handling", () => {
       json: async () => ({}),
     });
 
-    const result = await placeCollectionsTool({ query: "Alabama" });
+    const result = await placeCollectionsTool({ standardPlace: "Alabama" });
 
     expect(result.matchingCollections).toBe(0);
     expect(result.collections).toEqual([]);
   });
 
-  it("throws when neither id nor query is provided", async () => {
+  it("throws when neither id nor standardPlace is provided", async () => {
     await expect(placeCollectionsTool({})).rejects.toThrow(/Provide one of/);
   });
 });
@@ -233,7 +288,7 @@ describe("placeCollectionsTool field mapping", () => {
       }),
     });
 
-    const result = await placeCollectionsTool({ query: "Alabama" });
+    const result = await placeCollectionsTool({ standardPlace: "Alabama" });
 
     expect(result.collections[0]).toEqual({
       id: "1234",
@@ -255,7 +310,7 @@ describe("placeCollectionsTool — User-Agent contract", () => {
       json: async () => mockApiResponse,
     });
 
-    await placeCollectionsTool({ query: "Alabama" });
+    await placeCollectionsTool({ standardPlace: "Alabama" });
 
     expect(mockFetch).toHaveBeenCalledTimes(1);
     const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
@@ -611,13 +666,13 @@ describe("placeCollectionsTool detail mode (pass-through)", () => {
     );
   });
 
-  it("id wins when both id and query are passed", async () => {
+  it("id wins when both id and standardPlace are passed", async () => {
     mockedGetValidToken.mockResolvedValue("test-token");
     routeFetchMocks({});
 
     const result = (await placeCollectionsTool({
       id: "1743384",
-      query: "ignored",
+      standardPlace: "ignored",
     })) as CollectionDetailResult;
 
     // Detail-mode shape (sourceDescriptions present), not list-mode (collections array of summaries).

--- a/mcp-server/tests/tools/place-collections.test.ts
+++ b/mcp-server/tests/tools/place-collections.test.ts
@@ -6,7 +6,6 @@ vi.mock("../../src/auth/refresh.js", () => ({
 
 import {
   placeCollectionsTool,
-  filterByPlaceIds,
   filterByQuery,
   fetchAllCollections,
   clearCollectionsCache,
@@ -125,7 +124,6 @@ describe("placeCollectionsTool with query", () => {
     const result = await placeCollectionsTool({ query: "Alabama" });
 
     expect(result.query).toBe("Alabama");
-    expect(result.placeIds).toBeUndefined();
     expect(result.matchingCollections).toBe(1);
     expect(result.collections[0].id).toBe("1234");
   });
@@ -170,75 +168,6 @@ describe("placeCollectionsTool with query", () => {
   });
 });
 
-describe("placeCollectionsTool with placeIds", () => {
-  it("returns collections matching a single place ID", async () => {
-    mockedGetValidToken.mockResolvedValueOnce("test-token");
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => mockApiResponse,
-    });
-
-    const result = await placeCollectionsTool({ placeIds: [33] });
-
-    expect(result.placeIds).toEqual([33]);
-    expect(result.query).toBeUndefined();
-    expect(result.matchingCollections).toBe(1);
-    expect(result.collections[0].id).toBe("1234");
-  });
-
-  it("returns collections matching multiple place IDs", async () => {
-    mockedGetValidToken.mockResolvedValueOnce("test-token");
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => mockApiResponse,
-    });
-
-    const result = await placeCollectionsTool({ placeIds: [33, 325] });
-
-    expect(result.placeIds).toEqual([33, 325]);
-    expect(result.matchingCollections).toBe(2);
-    const ids = result.collections.map((c) => c.id);
-    expect(ids).toContain("1234");
-    expect(ids).toContain("5678");
-  });
-
-  it("returns empty array when no collections match", async () => {
-    mockedGetValidToken.mockResolvedValueOnce("test-token");
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => mockApiResponse,
-    });
-
-    const result = await placeCollectionsTool({ placeIds: [999999] });
-
-    expect(result.matchingCollections).toBe(0);
-    expect(result.collections).toEqual([]);
-  });
-
-  it("filters correctly against placeIds in searchMetadata", async () => {
-    mockedGetValidToken.mockResolvedValueOnce("test-token");
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({
-        results: 3,
-        entries: [
-          makeEntry({ id: "a", title: "A", placeIds: [1, 33, 500] }),
-          makeEntry({ id: "b", title: "B", placeIds: [1, 44] }),
-          makeEntry({ id: "c", title: "C", placeIds: [33] }),
-        ],
-      }),
-    });
-
-    const result = await placeCollectionsTool({ placeIds: [33] });
-
-    expect(result.matchingCollections).toBe(2);
-    const ids = result.collections.map((c) => c.id);
-    expect(ids).toContain("a");
-    expect(ids).toContain("c");
-    expect(ids).not.toContain("b");
-  });
-});
-
 describe("placeCollectionsTool error handling", () => {
   it("throws auth error when not authenticated", async () => {
     mockedGetValidToken.mockRejectedValueOnce(
@@ -277,7 +206,7 @@ describe("placeCollectionsTool error handling", () => {
     expect(result.collections).toEqual([]);
   });
 
-  it("throws when none of id, query, or placeIds is provided", async () => {
+  it("throws when neither id nor query is provided", async () => {
     await expect(placeCollectionsTool({})).rejects.toThrow(/Provide one of/);
   });
 });
@@ -310,7 +239,6 @@ describe("placeCollectionsTool field mapping", () => {
       id: "1234",
       title: "Alabama, County Marriages, 1809-1950",
       dateRange: "1809-1950",
-      placeIds: [1, 33],
       recordCount: 524000,
       personCount: 1048000,
       imageCount: 120000,

--- a/mcp-server/tests/tools/place-external-links.test.ts
+++ b/mcp-server/tests/tools/place-external-links.test.ts
@@ -5,6 +5,18 @@ import { BROWSER_USER_AGENT } from "../../src/constants.js";
 const mockFetch = vi.fn();
 vi.stubGlobal("fetch", mockFetch);
 
+const mockStandardPlaceToPlaceId = vi.hoisted(() => vi.fn());
+vi.mock("../../src/utils/place-resolver.js", () => ({
+  standardPlaceToPlaceId: mockStandardPlaceToPlaceId,
+}));
+
+// Runs before every test (in addition to the per-describe fetch resets);
+// default the resolver to a successful placeId so existing cases reach fetch.
+beforeEach(() => {
+  mockStandardPlaceToPlaceId.mockReset();
+  mockStandardPlaceToPlaceId.mockResolvedValue("1927089");
+});
+
 function jsonResponse(body: unknown, status = 200): Response {
   return {
     ok: status >= 200 && status < 300,
@@ -68,11 +80,12 @@ describe("placeExternalLinksTool — happy path", () => {
     mockFetch.mockResolvedValueOnce(singlePage(collections));
 
     const result = await placeExternalLinksTool({
-      placeId: "1927089",
+      standardPlace: "France",
       startYear: 1880,
       endYear: 1950,
     });
 
+    expect(result.standardPlace).toBe("France");
     expect(result.place).toBe("France");
     expect(result.totalResults).toBe(2);
     expect(result.matchedCount).toBe(1);
@@ -101,7 +114,7 @@ describe("placeExternalLinksTool — happy path", () => {
     mockFetch.mockResolvedValueOnce(singlePage(collections));
 
     const result = await placeExternalLinksTool({
-      placeId: "1927089",
+      standardPlace: "France",
       startYear: 1880,
       endYear: 1950,
     });
@@ -132,7 +145,7 @@ describe("placeExternalLinksTool — pagination", () => {
       .mockResolvedValueOnce(pageAt(makePage(200, 50), 200, 250));
 
     const result = await placeExternalLinksTool({
-      placeId: "1927089",
+      standardPlace: "France",
       startYear: 1880,
       endYear: 1950,
     });
@@ -150,7 +163,7 @@ describe("placeExternalLinksTool — pagination", () => {
     );
 
     const result = await placeExternalLinksTool({
-      placeId: "1927089",
+      standardPlace: "France",
       startYear: 1880,
       endYear: 1950,
     });
@@ -159,13 +172,13 @@ describe("placeExternalLinksTool — pagination", () => {
     expect(result.matchedCount).toBe(0);
   });
 
-  it("returns empty results cleanly for an unknown placeId", async () => {
+  it("returns empty results cleanly for a place with no collections", async () => {
     mockFetch.mockResolvedValueOnce(
       jsonResponse({ count: 0, offset: 0, totalResults: 0, collections: [] })
     );
 
     const result = await placeExternalLinksTool({
-      placeId: "999999999",
+      standardPlace: "France",
       startYear: 1880,
       endYear: 1950,
     });
@@ -191,7 +204,7 @@ describe("placeExternalLinksTool — error handling", () => {
     mockFetch.mockResolvedValueOnce(mock());
 
     await expect(
-      placeExternalLinksTool({ placeId: "x", startYear: 1900, endYear: 1950 })
+      placeExternalLinksTool({ standardPlace: "France", startYear: 1900, endYear: 1950 })
     ).rejects.toThrow(pattern);
   });
 });
@@ -203,16 +216,17 @@ describe("placeExternalLinksTool — handler-level guards", () => {
 
   it("rejects endYear < startYear without hitting the network", async () => {
     await expect(
-      placeExternalLinksTool({ placeId: "1927089", startYear: 1950, endYear: 1880 })
+      placeExternalLinksTool({ standardPlace: "France", startYear: 1950, endYear: 1880 })
     ).rejects.toThrow(/endYear must be greater than or equal to startYear/i);
     expect(mockFetch).not.toHaveBeenCalled();
+    expect(mockStandardPlaceToPlaceId).not.toHaveBeenCalled();
   });
 
   it("accepts endYear === startYear (single-year query)", async () => {
     mockFetch.mockResolvedValueOnce(singlePage([]));
 
     const result = await placeExternalLinksTool({
-      placeId: "1927089",
+      standardPlace: "France",
       startYear: 1900,
       endYear: 1900,
     });
@@ -221,10 +235,19 @@ describe("placeExternalLinksTool — handler-level guards", () => {
     expect(mockFetch).toHaveBeenCalledTimes(1);
   });
 
-  it("rejects empty placeId without hitting the network", async () => {
+  it("rejects empty standardPlace without hitting the network", async () => {
     await expect(
-      placeExternalLinksTool({ placeId: "", startYear: 1900, endYear: 1950 })
-    ).rejects.toThrow(/placeId is required/i);
+      placeExternalLinksTool({ standardPlace: "", startYear: 1900, endYear: 1950 })
+    ).rejects.toThrow(/standardPlace is required/i);
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(mockStandardPlaceToPlaceId).not.toHaveBeenCalled();
+  });
+
+  it("rejects an unresolvable standardPlace without hitting the network", async () => {
+    mockStandardPlaceToPlaceId.mockResolvedValueOnce(null);
+    await expect(
+      placeExternalLinksTool({ standardPlace: "Nowhere", startYear: 1900, endYear: 1950 })
+    ).rejects.toThrow(/Could not resolve "Nowhere"/i);
     expect(mockFetch).not.toHaveBeenCalled();
   });
 });
@@ -238,7 +261,7 @@ describe("placeExternalLinksTool — User-Agent contract", () => {
     mockFetch.mockResolvedValueOnce(singlePage([]));
 
     await placeExternalLinksTool({
-      placeId: "1927089",
+      standardPlace: "France",
       startYear: 1880,
       endYear: 1950,
     });

--- a/mcp-server/tests/tools/place-population.test.ts
+++ b/mcp-server/tests/tools/place-population.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockStandardPlaceToPlaceId = vi.hoisted(() => vi.fn());
+vi.mock("../../src/utils/place-resolver.js", () => ({
+  standardPlaceToPlaceId: mockStandardPlaceToPlaceId,
+}));
+
+const mockLoadConfig = vi.hoisted(() => vi.fn());
+vi.mock("../../src/auth/config.js", () => ({
+  loadConfig: mockLoadConfig,
+}));
+
+import { populationTool } from "../../src/tools/place-population.js";
+import type { PopulationToolInput } from "../../src/types/place-population.js";
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+const SAMPLE = { place: { place_id: "1927069", name: "Nigeria" }, population: {} };
+
+function okJson(body: unknown) {
+  return { ok: true, status: 200, statusText: "OK", json: () => Promise.resolve(body) };
+}
+
+beforeEach(() => {
+  mockStandardPlaceToPlaceId.mockReset();
+  mockStandardPlaceToPlaceId.mockResolvedValue("1927069");
+  mockLoadConfig.mockReset();
+  mockLoadConfig.mockResolvedValue({ popStatsUrl: "https://pop.example/api" });
+  mockFetch.mockReset();
+});
+
+describe("populationTool", () => {
+  it("resolves the standard place to a placeId and queries Pop Stats", async () => {
+    mockFetch.mockResolvedValueOnce(okJson(SAMPLE));
+
+    const result = await populationTool({ standardPlace: "Nigeria" });
+
+    expect(mockStandardPlaceToPlaceId).toHaveBeenCalledWith("Nigeria");
+    const url = mockFetch.mock.calls[0][0] as string;
+    expect(url).toContain("place_id=1927069");
+    expect(result).toEqual(SAMPLE);
+  });
+
+  it("passes year and year-range filters through", async () => {
+    mockFetch.mockResolvedValueOnce(okJson(SAMPLE));
+
+    await populationTool({
+      standardPlace: "Nigeria",
+      year: 1960,
+      year_start: 1900,
+      year_end: 2000,
+    });
+
+    const url = mockFetch.mock.calls[0][0] as string;
+    expect(url).toContain("year=1960");
+    expect(url).toContain("year_start=1900");
+    expect(url).toContain("year_end=2000");
+  });
+
+  it("throws and does not fetch when the place cannot be resolved", async () => {
+    mockStandardPlaceToPlaceId.mockResolvedValueOnce(null);
+
+    await expect(populationTool({ standardPlace: "Nowhere" })).rejects.toThrow(
+      /Could not resolve "Nowhere"/
+    );
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("throws when standardPlace is missing", async () => {
+    await expect(
+      populationTool({ standardPlace: "" } as PopulationToolInput)
+    ).rejects.toThrow(/standardPlace is required/);
+  });
+
+  it("throws a friendly error when the service is unreachable", async () => {
+    mockFetch.mockRejectedValueOnce(new Error("ECONNREFUSED"));
+
+    await expect(populationTool({ standardPlace: "Nigeria" })).rejects.toThrow(
+      /Population data service is unavailable/
+    );
+  });
+
+  it("throws on a non-OK response", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 404,
+      statusText: "Not Found",
+      json: () => Promise.resolve({}),
+    });
+
+    await expect(populationTool({ standardPlace: "Nigeria" })).rejects.toThrow(
+      /Population API error: 404/
+    );
+  });
+});

--- a/mcp-server/tests/tools/place-search.test.ts
+++ b/mcp-server/tests/tools/place-search.test.ts
@@ -547,7 +547,7 @@ describe("placeSearchTool", () => {
 
     expect(result.results).toHaveLength(1);
     expect(result.results[0]).toEqual({
-      fullName: "Paris, Bear Lake, Idaho, United States",
+      standardPlace: "Paris, Bear Lake, Idaho, United States",
       type: "City",
       dateRange: "+1900/",
       latitude: 1.0,
@@ -631,7 +631,7 @@ describe("placeSearchAllTool", () => {
       contextName: "Idaho",
     });
 
-    expect(result.results.map((r) => r.fullName).sort()).toEqual([
+    expect(result.results.map((r) => r.standardPlace).sort()).toEqual([
       "Paris, Bear Lake, Idaho, United States",
       "Paris, Oneida, Idaho Territory",
     ]);
@@ -667,7 +667,7 @@ describe("placeSearchAllTool", () => {
       contextName: "Idaho",
     });
 
-    expect(result.results.map((r) => r.fullName)).toEqual([
+    expect(result.results.map((r) => r.standardPlace)).toEqual([
       "Paris, Bear Lake, Idaho, United States",
     ]);
   });

--- a/mcp-server/tests/tools/record-read.test.ts
+++ b/mcp-server/tests/tools/record-read.test.ts
@@ -4,6 +4,15 @@ vi.mock("../../src/auth/refresh.js", () => ({
   getValidToken: vi.fn(),
 }));
 
+// Place standardization runs inside the converter now; stub the network
+// resolver so these tool tests stay offline and deterministic (no standard_place
+// is added — that behavior is covered in gedcomx-standardize.test.ts).
+vi.mock("../../src/utils/place-resolver.js", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../../src/utils/place-resolver.js")>();
+  return { ...actual, resolveStandardPlace: vi.fn().mockResolvedValue(null) };
+});
+
 import { recordReadTool, extractEntityId } from "../../src/tools/record-read.js";
 import { getValidToken } from "../../src/auth/refresh.js";
 import type { GedcomX } from "../../src/types/gedcomx.js";

--- a/mcp-server/tests/tools/record-search.test.ts
+++ b/mcp-server/tests/tools/record-search.test.ts
@@ -4,6 +4,15 @@ vi.mock("../../src/auth/refresh.js", () => ({
   getValidToken: vi.fn(),
 }));
 
+// Place standardization runs inside the converter now; stub the network
+// resolver so these tool tests stay offline and deterministic (no standard_place
+// is added — that behavior is covered in gedcomx-standardize.test.ts).
+vi.mock("../../src/utils/place-resolver.js", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../../src/utils/place-resolver.js")>();
+  return { ...actual, resolveStandardPlace: vi.fn().mockResolvedValue(null) };
+});
+
 import {
   recordSearchTool,
   buildSearchUrl,

--- a/mcp-server/tests/tools/wiki-country-page.test.ts
+++ b/mcp-server/tests/tools/wiki-country-page.test.ts
@@ -120,6 +120,14 @@ describe("wikiCountryHomeTool", () => {
       /No wiki page found for "Nowhere"/
     );
   });
+
+  it("rejects an empty/whitespace standardPlace without touching the filesystem", async () => {
+    await expect(
+      wikiCountryHomeTool({ standardPlace: "  " })
+    ).rejects.toThrow(/standardPlace is required/);
+    expect(mockReadFile).not.toHaveBeenCalled();
+    expect(mockStandardPlaceToPlaceId).not.toHaveBeenCalled();
+  });
 });
 
 describe("wikiCountryGettingStartedTool", () => {

--- a/mcp-server/tests/tools/wiki-country-page.test.ts
+++ b/mcp-server/tests/tools/wiki-country-page.test.ts
@@ -10,6 +10,11 @@ vi.mock("../../src/tools/place-search.js", () => ({
   placeSearchTool: vi.fn(),
 }));
 
+const mockStandardPlaceToPlaceId = vi.hoisted(() => vi.fn());
+vi.mock("../../src/utils/place-resolver.js", () => ({
+  standardPlaceToPlaceId: mockStandardPlaceToPlaceId,
+}));
+
 const mockReadFile = vi.hoisted(() => vi.fn());
 vi.mock("fs/promises", () => ({
   readFile: mockReadFile,
@@ -29,69 +34,62 @@ import {
 } from "../../src/tools/wiki-country-page.js";
 
 const WIKI_DIR = "/test/wiki/dir";
-const PORTUGAL = { name: "Portugal", placeId: "1927089" };
-const MANITOBA = { name: "Manitoba", placeId: "1927456" };
-const BRITISH_COLUMBIA = { name: "British Columbia", placeId: "1927123" };
 
 beforeEach(() => {
   mockGetPlaceCandidateNames.mockReset();
+  mockStandardPlaceToPlaceId.mockReset();
+  mockStandardPlaceToPlaceId.mockResolvedValue(null); // default: rely on the leaf name
   mockReadFile.mockReset();
   mockGetWikiMarkdownDir.mockResolvedValue(WIKI_DIR);
 });
 
 describe("wikiCountryHomeTool", () => {
-  it("reads Portugal_Genealogy.md when it exists", async () => {
-    mockGetPlaceCandidateNames.mockResolvedValueOnce([PORTUGAL.name]);
+  it("reads Portugal_Genealogy.md from the standard place's leaf name", async () => {
     mockReadFile.mockResolvedValueOnce("# Portugal");
 
-    const result = await wikiCountryHomeTool({ placeId: "1927089" });
+    const result = await wikiCountryHomeTool({ standardPlace: "Portugal" });
 
     expect(mockReadFile).toHaveBeenCalledWith(`${WIKI_DIR}/Portugal_Genealogy.md`, "utf8");
-    expect(result.placeId).toBe("1927089");
+    expect(result.standardPlace).toBe("Portugal");
     expect(result.placeName).toBe("Portugal");
     expect(result.url).toBe("https://www.familysearch.org/en/wiki/Portugal_Genealogy");
-    expect(result).not.toHaveProperty("placeRepId");
-    expect(result).not.toHaveProperty("cached");
+    expect(result).not.toHaveProperty("placeId");
+  });
+
+  it("derives the leaf from a fully-qualified standard place", async () => {
+    mockReadFile.mockResolvedValueOnce("# Minnesota");
+
+    const result = await wikiCountryHomeTool({
+      standardPlace: "Minnesota, United States",
+    });
+
+    // leaf "Minnesota" -> tries _Genealogy first (succeeds here)
+    expect(mockReadFile).toHaveBeenCalledWith(`${WIKI_DIR}/Minnesota_Genealogy.md`, "utf8");
+    expect(result.standardPlace).toBe("Minnesota, United States");
+    expect(result.placeName).toBe("Minnesota");
   });
 
   it("falls back to Manitoba,_Canada_Genealogy.md when plain _Genealogy is missing", async () => {
-    mockGetPlaceCandidateNames.mockResolvedValueOnce([MANITOBA.name]);
     mockReadFile
       .mockRejectedValueOnce(new Error("ENOENT"))
       .mockResolvedValueOnce("# Manitoba Genealogy");
 
-    const result = await wikiCountryHomeTool({ placeId: "1927456" });
+    const result = await wikiCountryHomeTool({ standardPlace: "Manitoba, Canada" });
 
-    expect(mockReadFile).toHaveBeenNthCalledWith(
-      1,
-      `${WIKI_DIR}/Manitoba_Genealogy.md`,
-      "utf8"
-    );
+    expect(mockReadFile).toHaveBeenNthCalledWith(1, `${WIKI_DIR}/Manitoba_Genealogy.md`, "utf8");
     expect(mockReadFile).toHaveBeenNthCalledWith(
       2,
       `${WIKI_DIR}/Manitoba,_Canada_Genealogy.md`,
       "utf8"
     );
-    expect(result.url).toBe(
-      "https://www.familysearch.org/en/wiki/Manitoba,_Canada_Genealogy"
-    );
-    expect(result.placeId).toBe("1927456");
-  });
-
-  it("throws when neither file candidate exists", async () => {
-    mockGetPlaceCandidateNames.mockResolvedValueOnce([MANITOBA.name]);
-    mockReadFile.mockRejectedValue(new Error("ENOENT"));
-
-    await expect(wikiCountryHomeTool({ placeId: "1927456" })).rejects.toThrow(
-      /No wiki page found for place "1927456"/
-    );
+    expect(result.url).toBe("https://www.familysearch.org/en/wiki/Manitoba,_Canada_Genealogy");
+    expect(result.standardPlace).toBe("Manitoba, Canada");
   });
 
   it("handles multi-word place names with underscores", async () => {
-    mockGetPlaceCandidateNames.mockResolvedValueOnce([BRITISH_COLUMBIA.name]);
     mockReadFile.mockResolvedValueOnce("# BC");
 
-    await wikiCountryHomeTool({ placeId: "1927123" });
+    await wikiCountryHomeTool({ standardPlace: "British Columbia, Canada" });
 
     expect(mockReadFile).toHaveBeenCalledWith(
       `${WIKI_DIR}/British_Columbia_Genealogy.md`,
@@ -99,21 +97,36 @@ describe("wikiCountryHomeTool", () => {
     );
   });
 
-  it("throws when place is not found", async () => {
-    mockGetPlaceCandidateNames.mockResolvedValueOnce([]);
+  it("tries additional name variants from the places API when the leaf misses", async () => {
+    // Leaf "Old Name" has no file; resolving yields the canonical wiki name.
+    mockStandardPlaceToPlaceId.mockResolvedValueOnce("1927089");
+    mockGetPlaceCandidateNames.mockResolvedValueOnce(["Czechia"]);
+    mockReadFile
+      .mockRejectedValueOnce(new Error("ENOENT")) // Old_Name_Genealogy
+      .mockRejectedValueOnce(new Error("ENOENT")) // Old_Name,_Canada_Genealogy
+      .mockRejectedValueOnce(new Error("ENOENT")) // Old_Name,_United_States_Genealogy
+      .mockResolvedValueOnce("# Czechia"); // Czechia_Genealogy
 
-    await expect(wikiCountryHomeTool({ placeId: "999" })).rejects.toThrow(
-      /No place found for placeId: 999/
+    const result = await wikiCountryHomeTool({ standardPlace: "Old Name" });
+
+    expect(result.placeName).toBe("Czechia");
+    expect(result.url).toBe("https://www.familysearch.org/en/wiki/Czechia_Genealogy");
+  });
+
+  it("throws when no candidate file exists", async () => {
+    mockReadFile.mockRejectedValue(new Error("ENOENT"));
+
+    await expect(wikiCountryHomeTool({ standardPlace: "Nowhere" })).rejects.toThrow(
+      /No wiki page found for "Nowhere"/
     );
   });
 });
 
 describe("wikiCountryGettingStartedTool", () => {
   it("reads the correct _Getting_Started file", async () => {
-    mockGetPlaceCandidateNames.mockResolvedValueOnce([PORTUGAL.name]);
     mockReadFile.mockResolvedValueOnce("# Getting Started");
 
-    await wikiCountryGettingStartedTool({ placeId: "1927089" });
+    await wikiCountryGettingStartedTool({ standardPlace: "Portugal" });
 
     expect(mockReadFile).toHaveBeenCalledWith(
       `${WIKI_DIR}/Portugal_Getting_Started.md`,
@@ -122,22 +135,20 @@ describe("wikiCountryGettingStartedTool", () => {
   });
 
   it("does not try a Canada variant (no fallback for non-home pages)", async () => {
-    mockGetPlaceCandidateNames.mockResolvedValueOnce([MANITOBA.name]);
     mockReadFile.mockRejectedValueOnce(new Error("ENOENT"));
 
-    await expect(wikiCountryGettingStartedTool({ placeId: "1927456" })).rejects.toThrow(
-      /No wiki page found for place "1927456"/
-    );
+    await expect(
+      wikiCountryGettingStartedTool({ standardPlace: "Manitoba, Canada" })
+    ).rejects.toThrow(/No wiki page found for "Manitoba, Canada"/);
     expect(mockReadFile).toHaveBeenCalledTimes(1);
   });
 });
 
 describe("wikiCountryOnlineRecordsTool", () => {
   it("reads the correct _Online_Genealogy_Records file", async () => {
-    mockGetPlaceCandidateNames.mockResolvedValueOnce([PORTUGAL.name]);
     mockReadFile.mockResolvedValueOnce("# Records");
 
-    await wikiCountryOnlineRecordsTool({ placeId: "1927089" });
+    await wikiCountryOnlineRecordsTool({ standardPlace: "Portugal" });
 
     expect(mockReadFile).toHaveBeenCalledWith(
       `${WIKI_DIR}/Portugal_Online_Genealogy_Records.md`,
@@ -148,10 +159,9 @@ describe("wikiCountryOnlineRecordsTool", () => {
 
 describe("wikiCountryResearchTipsTool", () => {
   it("reads the correct _Research_Tips_and_Strategies file", async () => {
-    mockGetPlaceCandidateNames.mockResolvedValueOnce([PORTUGAL.name]);
     mockReadFile.mockResolvedValueOnce("# Research Tips");
 
-    await wikiCountryResearchTipsTool({ placeId: "1927089" });
+    await wikiCountryResearchTipsTool({ standardPlace: "Portugal" });
 
     expect(mockReadFile).toHaveBeenCalledWith(
       `${WIKI_DIR}/Portugal_Research_Tips_and_Strategies.md`,
@@ -161,13 +171,12 @@ describe("wikiCountryResearchTipsTool", () => {
 });
 
 describe("shared behaviour across all 4 tools", () => {
-  it("includes placeId and placeName in the result", async () => {
-    mockGetPlaceCandidateNames.mockResolvedValueOnce([PORTUGAL.name]);
+  it("includes standardPlace and placeName in the result", async () => {
     mockReadFile.mockResolvedValueOnce("# Portugal");
 
-    const result = await wikiCountryHomeTool({ placeId: "1927089" });
+    const result = await wikiCountryHomeTool({ standardPlace: "Portugal" });
 
-    expect(result.placeId).toBe("1927089");
+    expect(result.standardPlace).toBe("Portugal");
     expect(result.placeName).toBe("Portugal");
     expect(result.content).toBe("# Portugal");
   });

--- a/mcp-server/tests/utils/gedcomx-standardize.test.ts
+++ b/mcp-server/tests/utils/gedcomx-standardize.test.ts
@@ -131,12 +131,12 @@ describe("standardizePlaces", () => {
   it("caps distinct places at the soft cap and logs the overflow", async () => {
     mockResolve.mockImplementation(async (t: string) => `STD:${t}`);
     const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-    const facts: SimplifiedFact[] = Array.from({ length: 60 }, (_, i) => ({
+    const facts: SimplifiedFact[] = Array.from({ length: 110 }, (_, i) => ({
       place: `place-${i}`,
     }));
     await standardizePlaces(facts);
     const resolved = facts.filter((f) => f.standard_place).length;
-    expect(resolved).toBe(50);
+    expect(resolved).toBe(100);
     expect(errSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/mcp-server/tests/utils/gedcomx-standardize.test.ts
+++ b/mcp-server/tests/utils/gedcomx-standardize.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// Stub the network resolver; keep the real mapWithConcurrency.
+vi.mock("../../src/utils/place-resolver.js", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../../src/utils/place-resolver.js")>();
+  return { ...actual, resolveStandardPlace: vi.fn() };
+});
+
+import {
+  toSimplified,
+  toGedcomX,
+  standardizePlaces,
+  toSimplifiedStandardized,
+} from "../../src/utils/gedcomx-convert.js";
+import { resolveStandardPlace } from "../../src/utils/place-resolver.js";
+import type {
+  GedcomX,
+  SimplifiedFact,
+  SimplifiedGedcomX,
+} from "../../src/types/gedcomx.js";
+
+const mockResolve = vi.mocked(resolveStandardPlace);
+
+beforeEach(() => {
+  mockResolve.mockReset();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("toSimplified — standard_place from raw normalized (pure)", () => {
+  function simplifyOneFact(place: {
+    original?: string;
+    normalized?: { value: string; lang?: string }[];
+  }): SimplifiedFact {
+    const doc = toSimplified({
+      persons: [
+        { id: "I1", facts: [{ type: "http://gedcomx.org/Birth", place }] },
+      ],
+    } as GedcomX);
+    return doc.persons![0]!.facts![0]!;
+  }
+
+  it("prefers the English normalized value", () => {
+    const fact = simplifyOneFact({
+      original: "Paris",
+      normalized: [
+        { value: "Paris, Frankreich", lang: "de" },
+        { value: "Paris, France", lang: "en" },
+      ],
+    });
+    expect(fact.place).toBe("Paris");
+    expect(fact.standard_place).toBe("Paris, France");
+  });
+
+  it("falls back to the first value when no English entry exists", () => {
+    const fact = simplifyOneFact({
+      original: "Köln",
+      normalized: [{ value: "Köln, Deutschland", lang: "de" }],
+    });
+    expect(fact.standard_place).toBe("Köln, Deutschland");
+  });
+
+  it("omits standard_place when there is no normalized value", () => {
+    const fact = simplifyOneFact({ original: "Some Farm" });
+    expect(fact.place).toBe("Some Farm");
+    expect(fact.standard_place).toBeUndefined();
+  });
+});
+
+describe("toGedcomX — standard_place is a dropped sidecar", () => {
+  it("does not round-trip standard_place back into raw GedcomX", () => {
+    const simplified: SimplifiedGedcomX = {
+      persons: [
+        {
+          id: "I1",
+          facts: [
+            { type: "Birth", place: "Paris", standard_place: "Paris, France" },
+          ],
+        },
+      ],
+    };
+    const full = toGedcomX(simplified);
+    expect(full.persons![0]!.facts![0]!.place).toEqual({ original: "Paris" });
+    expect(JSON.stringify(full)).not.toContain("standard_place");
+  });
+});
+
+describe("standardizePlaces", () => {
+  it("dedups identical place strings to a single resolution", async () => {
+    mockResolve.mockResolvedValue("Kentucky, United States");
+    const facts: SimplifiedFact[] = [
+      { place: "Ky" },
+      { place: "ky" }, // normalized key dedups with "Ky"
+      { place: "Ky" },
+    ];
+    await standardizePlaces(facts);
+    expect(facts.every((f) => f.standard_place === "Kentucky, United States")).toBe(
+      true,
+    );
+    expect(mockResolve).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips facts with no place or an existing standard_place", async () => {
+    mockResolve.mockResolvedValue("X");
+    const facts: SimplifiedFact[] = [
+      { place: "A", standard_place: "Already standardized" },
+      { value: "no place at all" },
+    ];
+    await standardizePlaces(facts);
+    expect(mockResolve).not.toHaveBeenCalled();
+    expect(facts[0]!.standard_place).toBe("Already standardized");
+  });
+
+  it("leaves standard_place empty when the resolver returns null", async () => {
+    mockResolve.mockResolvedValue(null);
+    const facts: SimplifiedFact[] = [{ place: "Nowhere in particular" }];
+    await standardizePlaces(facts);
+    expect(facts[0]!.standard_place).toBeUndefined();
+  });
+
+  it("never throws when the resolver rejects (best-effort)", async () => {
+    mockResolve.mockRejectedValue(new Error("network down"));
+    const facts: SimplifiedFact[] = [{ place: "Paris" }];
+    await expect(standardizePlaces(facts)).resolves.toBeUndefined();
+    expect(facts[0]!.standard_place).toBeUndefined();
+  });
+
+  it("caps distinct places at the soft cap and logs the overflow", async () => {
+    mockResolve.mockImplementation(async (t: string) => `STD:${t}`);
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const facts: SimplifiedFact[] = Array.from({ length: 60 }, (_, i) => ({
+      place: `place-${i}`,
+    }));
+    await standardizePlaces(facts);
+    const resolved = facts.filter((f) => f.standard_place).length;
+    expect(resolved).toBe(50);
+    expect(errSpy).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("toSimplifiedStandardized — hybrid", () => {
+  it("uses normalized when present and only resolves free-text places", async () => {
+    mockResolve.mockResolvedValue("RESOLVED PLACE");
+    const gx: GedcomX = {
+      persons: [
+        {
+          id: "I1",
+          facts: [
+            {
+              type: "http://gedcomx.org/Birth",
+              place: {
+                original: "Paris",
+                normalized: [{ value: "Paris, France", lang: "en" }],
+              },
+            },
+            { type: "http://gedcomx.org/Death", place: { original: "Freetext" } },
+          ],
+        },
+      ],
+    };
+    const doc = await toSimplifiedStandardized(gx);
+    const facts = doc.persons![0]!.facts!;
+    expect(facts[0]!.standard_place).toBe("Paris, France"); // from normalized
+    expect(facts[1]!.standard_place).toBe("RESOLVED PLACE"); // from resolver
+    expect(mockResolve).toHaveBeenCalledTimes(1);
+    expect(mockResolve).toHaveBeenCalledWith("Freetext");
+  });
+});

--- a/mcp-server/tests/utils/place-resolver.test.ts
+++ b/mcp-server/tests/utils/place-resolver.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
-// The resolver builds on the low-level FamilySearch places fetchers exported by
-// place-search.ts. Mock just those three so no network is touched.
-vi.mock("../../src/tools/place-search.js", () => ({
+// The resolver builds on the low-level FamilySearch places fetchers in
+// utils/place-api.ts. Mock just those three so no network is touched.
+vi.mock("../../src/utils/place-api.js", () => ({
   searchPlace: vi.fn(),
   getPlaceById: vi.fn(),
   getPlaceRepIds: vi.fn(),
@@ -12,7 +12,7 @@ import {
   searchPlace,
   getPlaceById,
   getPlaceRepIds,
-} from "../../src/tools/place-search.js";
+} from "../../src/utils/place-api.js";
 import {
   resolveStandardPlace,
   standardPlaceToRepId,

--- a/mcp-server/tests/utils/place-resolver.test.ts
+++ b/mcp-server/tests/utils/place-resolver.test.ts
@@ -1,0 +1,248 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// The resolver builds on the low-level FamilySearch places fetchers exported by
+// place-search.ts. Mock just those three so no network is touched.
+vi.mock("../../src/tools/place-search.js", () => ({
+  searchPlace: vi.fn(),
+  getPlaceById: vi.fn(),
+  getPlaceRepIds: vi.fn(),
+}));
+
+import {
+  searchPlace,
+  getPlaceById,
+  getPlaceRepIds,
+} from "../../src/tools/place-search.js";
+import {
+  resolveStandardPlace,
+  standardPlaceToRepId,
+  standardPlaceToPlaceId,
+  repIdToStandardPlace,
+  standardPlaceToCoords,
+  placeIdToRepIds,
+  withRetry,
+  mapWithConcurrency,
+  __clearPlaceResolverCachesForTests,
+} from "../../src/utils/place-resolver.js";
+
+const mockSearchPlace = vi.mocked(searchPlace);
+const mockGetPlaceById = vi.mocked(getPlaceById);
+const mockGetPlaceRepIds = vi.mocked(getPlaceRepIds);
+
+type Entry = Awaited<ReturnType<typeof searchPlace>>[number];
+
+function entry(over: Partial<Entry> & { placeRepId: string; fullName: string }): Entry {
+  return {
+    name: over.fullName.split(",")[0]!.trim(),
+    type: "City",
+    ...over,
+  } as Entry;
+}
+
+beforeEach(() => {
+  mockSearchPlace.mockReset();
+  mockGetPlaceById.mockReset();
+  mockGetPlaceRepIds.mockReset();
+  __clearPlaceResolverCachesForTests();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("resolveStandardPlace", () => {
+  it("returns the best-scored candidate's fullName for free text", async () => {
+    mockSearchPlace.mockResolvedValue([
+      entry({ placeRepId: "1", placeId: "p1", fullName: "Kentucky, United States", score: 0.4 }),
+      entry({ placeRepId: "2", placeId: "p2", fullName: "Kent, England, United Kingdom", score: 0.9 }),
+    ]);
+    expect(await resolveStandardPlace("Ky")).toBe("Kent, England, United Kingdom");
+  });
+
+  it("caches a resolved value (second call does not re-search)", async () => {
+    mockSearchPlace.mockResolvedValue([
+      entry({ placeRepId: "1", fullName: "Ohio, United States", score: 1 }),
+    ]);
+    expect(await resolveStandardPlace("Ohio")).toBe("Ohio, United States");
+    expect(await resolveStandardPlace("ohio")).toBe("Ohio, United States"); // normalized key
+    expect(mockSearchPlace).toHaveBeenCalledTimes(1);
+  });
+
+  it("negative-caches a definitive 0-candidate result", async () => {
+    mockSearchPlace.mockResolvedValue([]);
+    expect(await resolveStandardPlace("Mrs. John's farm")).toBeNull();
+    expect(await resolveStandardPlace("Mrs. John's farm")).toBeNull();
+    expect(mockSearchPlace).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT cache a transient failure (retries on the next call)", async () => {
+    vi.useFakeTimers();
+    mockSearchPlace.mockRejectedValue(new Error("network"));
+
+    const first = resolveStandardPlace("Paris");
+    await vi.runAllTimersAsync();
+    expect(await first).toBeNull();
+
+    // Now the API recovers — because the failure wasn't cached, it re-searches.
+    mockSearchPlace.mockResolvedValueOnce([
+      entry({ placeRepId: "9", fullName: "Paris, France", score: 1 }),
+    ]);
+    const second = resolveStandardPlace("Paris");
+    await vi.runAllTimersAsync();
+    expect(await second).toBe("Paris, France");
+  });
+});
+
+describe("standardPlaceToRepId", () => {
+  it("prefers an exact fullName match over a higher-scored other", async () => {
+    mockSearchPlace.mockResolvedValue([
+      entry({ placeRepId: "exact", fullName: "Paris, Bear Lake, Idaho, United States", score: 0.3 }),
+      entry({ placeRepId: "other", fullName: "Paris, France", score: 0.99 }),
+    ]);
+    expect(
+      await standardPlaceToRepId("Paris, Bear Lake, Idaho, United States"),
+    ).toBe("exact");
+  });
+
+  it("falls back to best-scored when no exact match", async () => {
+    mockSearchPlace.mockResolvedValue([
+      entry({ placeRepId: "a", fullName: "Springfield, Illinois, United States", score: 0.2 }),
+      entry({ placeRepId: "b", fullName: "Springfield, Missouri, United States", score: 0.8 }),
+    ]);
+    expect(await standardPlaceToRepId("Springfield")).toBe("b");
+  });
+});
+
+describe("standardPlaceToPlaceId", () => {
+  it("returns the placeId when exact matches agree", async () => {
+    mockSearchPlace.mockResolvedValue([
+      entry({ placeRepId: "1", placeId: "P", fullName: "Berlin, Germany", score: 0.9 }),
+      entry({ placeRepId: "2", placeId: "P", fullName: "Berlin, Germany", score: 0.5 }),
+    ]);
+    expect(await standardPlaceToPlaceId("Berlin, Germany")).toBe("P");
+  });
+
+  it("returns null when candidates disagree on placeId (guards fan-out)", async () => {
+    mockSearchPlace.mockResolvedValue([
+      entry({ placeRepId: "1", placeId: "P1", fullName: "Berlin, Germany", score: 0.9 }),
+      entry({ placeRepId: "2", placeId: "P2", fullName: "Berlin, Germany", score: 0.9 }),
+    ]);
+    expect(await standardPlaceToPlaceId("Berlin, Germany")).toBeNull();
+  });
+});
+
+describe("repIdToStandardPlace", () => {
+  it("returns the fullName from the description endpoint", async () => {
+    mockGetPlaceById.mockResolvedValue({
+      placeRepId: "42",
+      placeId: "p",
+      name: "Cork",
+      fullName: "Cork, Munster, Ireland",
+      type: "County",
+    } as Awaited<ReturnType<typeof getPlaceById>>);
+    expect(await repIdToStandardPlace("42")).toBe("Cork, Munster, Ireland");
+  });
+
+  it("returns null when the rep is not found (404)", async () => {
+    mockGetPlaceById.mockResolvedValue(null);
+    expect(await repIdToStandardPlace("nope")).toBeNull();
+  });
+});
+
+describe("standardPlaceToCoords", () => {
+  it("returns coords straight from the search entry (no description fetch)", async () => {
+    mockSearchPlace.mockResolvedValue([
+      entry({ placeRepId: "1", fullName: "Rome, Italy", latitude: 41.9, longitude: 12.5, score: 1 }),
+    ]);
+    expect(await standardPlaceToCoords("Rome, Italy")).toEqual({
+      latitude: 41.9,
+      longitude: 12.5,
+    });
+    expect(mockGetPlaceById).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the description endpoint when the entry lacks coords", async () => {
+    mockSearchPlace.mockResolvedValue([
+      entry({ placeRepId: "7", fullName: "Atlantis", score: 1 }),
+    ]);
+    mockGetPlaceById.mockResolvedValue({
+      placeRepId: "7",
+      name: "Atlantis",
+      fullName: "Atlantis",
+      type: "City",
+      latitude: 1.1,
+      longitude: 2.2,
+    } as Awaited<ReturnType<typeof getPlaceById>>);
+    expect(await standardPlaceToCoords("Atlantis")).toEqual({
+      latitude: 1.1,
+      longitude: 2.2,
+    });
+  });
+});
+
+describe("placeIdToRepIds", () => {
+  it("returns and caches the rep ids for a placeId", async () => {
+    mockGetPlaceRepIds.mockResolvedValue(["10", "20", "30"]);
+    expect(await placeIdToRepIds("P")).toEqual(["10", "20", "30"]);
+    expect(await placeIdToRepIds("P")).toEqual(["10", "20", "30"]);
+    expect(mockGetPlaceRepIds).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns [] on failure without caching", async () => {
+    vi.useFakeTimers();
+    mockGetPlaceRepIds.mockRejectedValue(new Error("boom"));
+    const p = placeIdToRepIds("P");
+    await vi.runAllTimersAsync();
+    expect(await p).toEqual([]);
+
+    mockGetPlaceRepIds.mockResolvedValueOnce(["1"]);
+    const p2 = placeIdToRepIds("P");
+    await vi.runAllTimersAsync();
+    expect(await p2).toEqual(["1"]);
+  });
+});
+
+describe("withRetry", () => {
+  it("succeeds after transient failures, backing off between attempts", async () => {
+    vi.useFakeTimers();
+    const fn = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("a"))
+      .mockRejectedValueOnce(new Error("b"))
+      .mockResolvedValueOnce("ok");
+    const p = withRetry(fn, { attempts: 3, baseMs: 10 });
+    await vi.runAllTimersAsync();
+    await expect(p).resolves.toBe("ok");
+    expect(fn).toHaveBeenCalledTimes(3);
+  });
+
+  it("rethrows after exhausting all attempts", async () => {
+    vi.useFakeTimers();
+    const fn = vi.fn().mockRejectedValue(new Error("nope"));
+    const p = withRetry(fn, { attempts: 3, baseMs: 10 });
+    const assertion = expect(p).rejects.toThrow("nope");
+    await vi.runAllTimersAsync();
+    await assertion;
+    expect(fn).toHaveBeenCalledTimes(3);
+  });
+});
+
+describe("mapWithConcurrency", () => {
+  it("preserves order and caps in-flight work at the limit", async () => {
+    let active = 0;
+    let maxActive = 0;
+    const out = await mapWithConcurrency([1, 2, 3, 4, 5], 2, async (x) => {
+      active++;
+      maxActive = Math.max(maxActive, active);
+      await new Promise((r) => setTimeout(r, 5));
+      active--;
+      return x * 2;
+    });
+    expect(out).toEqual([2, 4, 6, 8, 10]);
+    expect(maxActive).toBe(2);
+  });
+
+  it("handles an empty list", async () => {
+    expect(await mapWithConcurrency([], 8, async (x) => x)).toEqual([]);
+  });
+});

--- a/mcp-server/tests/utils/place-resolver.test.ts
+++ b/mcp-server/tests/utils/place-resolver.test.ts
@@ -131,6 +131,23 @@ describe("standardPlaceToPlaceId", () => {
   });
 });
 
+describe("empty / whitespace input short-circuits without a network search", () => {
+  it("standardPlaceToPlaceId returns null and never searches", async () => {
+    expect(await standardPlaceToPlaceId("   ")).toBeNull();
+    expect(mockSearchPlace).not.toHaveBeenCalled();
+  });
+
+  it("standardPlaceToCoords returns null and never searches", async () => {
+    expect(await standardPlaceToCoords("")).toBeNull();
+    expect(mockSearchPlace).not.toHaveBeenCalled();
+  });
+
+  it("resolveStandardPlace returns null and never searches", async () => {
+    expect(await resolveStandardPlace("  ")).toBeNull();
+    expect(mockSearchPlace).not.toHaveBeenCalled();
+  });
+});
+
 describe("repIdToStandardPlace", () => {
   it("returns the fullName from the description endpoint", async () => {
     mockGetPlaceById.mockResolvedValue({

--- a/plugin/agents/gps-mentor.md
+++ b/plugin/agents/gps-mentor.md
@@ -365,9 +365,11 @@ the analytical work underneath is sound.
    no matter how nicely typeset).
 
 5. **Geographic plausibility.** Where assertions involve travel or
-   residence, call `place_distance` and `place_search` to
-   sanity-check the implied travel against era norms. Flag
-   impossibilities — they're often missed identity conflicts.
+   residence, resolve each place with `place_search` (use its
+   `standardPlace` field), then call
+   `place_distance({ standardPlace1, standardPlace2 })` to sanity-check
+   the implied travel against era norms. Flag impossibilities — they're
+   often missed identity conflicts.
 
 ### proof-critique
 
@@ -440,8 +442,9 @@ not abstract.
   diversity gaps. Name the specific third-party site.
 - **`place_distance`** + **`place_search`** — Use whenever an
   assertion or proof implies the same person traveled between two
-  named places. Quote the distance and era travel norms in the
-  feedback.
+  named places. Resolve each via `place_search` and pass the two
+  `standardPlace` names to `place_distance`. Quote the distance and
+  era travel norms in the feedback.
 - **`wiki_search`** — Last-resort for finding published guidance
   on a specific record-type or strategy question.
 - **`validate_research_schema`** — Anchor for mechanical

--- a/plugin/references/places-guidance.md
+++ b/plugin/references/places-guidance.md
@@ -39,6 +39,7 @@ internally — pass the `standardPlace` you got from `place_search`:
 
 - `place_population({ standardPlace, ... })`
 - `place_external_links({ standardPlace, ... })`
+- `place_collections({ standardPlace })` — lists record collections; it matches at the state level for the US/Canada/Mexico and the country level elsewhere (derived internally)
 - `place_distance({ standardPlace1, standardPlace2 })`
 - `wiki_country_home` / `_getting_started` / `_online_records` / `_research_tips`({ standardPlace })
 - `metadata_search({ standardPlace, ... })`

--- a/plugin/references/places-guidance.md
+++ b/plugin/references/places-guidance.md
@@ -1,0 +1,60 @@
+<!--
+  CANONICAL SOURCE — do not edit a copy in isolation.
+  This block is duplicated, byte-for-byte, into each place-using skill's
+  references/places-guidance.md (Claude Code can't reliably load a shared
+  reference across skills — issue #17741 — so each skill carries its own copy).
+  A drift lint (mcp-server/tests/packaging/skill-guidance.test.ts) fails if any
+  copy diverges from this source. To change the guidance: edit this file, then
+  re-copy it into every skill listed in that test.
+-->
+
+# Working with places (standard places)
+
+Above the tool layer, places are always **names**, never IDs. The canonical
+name is the `standardPlace` from `place_search`.
+
+## Resolving a place
+
+Call `place_search` with the place name as `placeName` (optionally a
+higher-level `contextName` to disambiguate):
+
+```
+place_search({ placeName: "Schuylkill County, Pennsylvania" })
+```
+
+It returns an array of matches; each match has a **`standardPlace`** field (the
+fully-qualified standardized name) plus `type`, `dateRange`, coordinates, and
+links. **Pick the best/first match and use its `standardPlace` verbatim** as the
+handle for everything downstream. There are no place IDs in the output.
+
+Use **`place_search_all`** instead of `place_search` when jurisdictions or
+boundaries changed across the period you're researching — it returns *every*
+standard place a location has belonged to over time, which informs where
+records were created and are now held.
+
+## Passing places to other tools
+
+The place tools all take a `standardPlace` name (not an ID) and resolve it
+internally — pass the `standardPlace` you got from `place_search`:
+
+- `place_population({ standardPlace, ... })`
+- `place_external_links({ standardPlace, ... })`
+- `place_distance({ standardPlace1, standardPlace2 })`
+- `wiki_country_home` / `_getting_started` / `_online_records` / `_research_tips`({ standardPlace })
+- `metadata_search({ standardPlace, ... })`
+
+For `place_distance`, two events at the **same** `standard_place` are distance 0
+(no call needed); otherwise pass the two names.
+
+## Writing places to research.json / tree.gedcomx.json
+
+Whenever you persist a place on a fact, assertion, or timeline event, also set
+its **`standard_place`** companion (snake_case in the data formats) when one can
+be found:
+
+- If the place came from a `record_read` / `record_search` / `person_read`
+  result, that fact already carries a converter-resolved `standard_place` —
+  **copy it** (no tool call).
+- Otherwise call `place_search({ placeName: "<place>" })` and use the first
+  result's `standardPlace`. Resolve each distinct place once.
+- Leave `standard_place` null when `place` is null or nothing resolves.

--- a/plugin/skills/conflict-resolution/SKILL.md
+++ b/plugin/skills/conflict-resolution/SKILL.md
@@ -177,9 +177,10 @@ explanation, not a point total.
 
 **For identity conflicts involving location-based evidence:** when
 evaluating whether two events could belong to the same person, use
-`place_search` to resolve each event's location to a FamilySearch place ID,
-then call `place_distance` with those two IDs to get the actual
-distance in kilometers. Compare the result against era travel norms
+`place_search` to resolve each event's location to a standard place name
+(the `standardPlace` field), then call
+`place_distance({ standardPlace1, standardPlace2 })` with those two names
+to get the actual distance in kilometers. Compare the result against era travel norms
 (pre-1830: ~30-50 km/day; 1830-1870: rail where available; 1870+:
 extensive rail networks). A quantified distance strengthens or
 eliminates a travel-impossibility argument far more than a subjective

--- a/plugin/skills/conflict-resolution/SKILL.md
+++ b/plugin/skills/conflict-resolution/SKILL.md
@@ -29,6 +29,8 @@ description: Identifies and resolves conflicting genealogical evidence —
 
 **Narration:** Read `researcher_profile.narration_guidance` from `research.json` and apply it as your narration style for this invocation. If absent, default to a one-line preamble per action.
 
+**Places:** When resolving or writing places, follow `references/places-guidance.md` — resolve with `place_search` / `place_search_all` and record the `standardPlace` (and `standard_place` on persisted facts/assertions/events).
+
 Identifies, analyzes, and resolves conflicts in the evidence. GPS
 Element 4 requires ALL conflicting evidence to be resolved before a
 conclusion can be proved. An unresolved conflict acknowledged honestly

--- a/plugin/skills/conflict-resolution/references/places-guidance.md
+++ b/plugin/skills/conflict-resolution/references/places-guidance.md
@@ -39,6 +39,7 @@ internally — pass the `standardPlace` you got from `place_search`:
 
 - `place_population({ standardPlace, ... })`
 - `place_external_links({ standardPlace, ... })`
+- `place_collections({ standardPlace })` — lists record collections; it matches at the state level for the US/Canada/Mexico and the country level elsewhere (derived internally)
 - `place_distance({ standardPlace1, standardPlace2 })`
 - `wiki_country_home` / `_getting_started` / `_online_records` / `_research_tips`({ standardPlace })
 - `metadata_search({ standardPlace, ... })`

--- a/plugin/skills/conflict-resolution/references/places-guidance.md
+++ b/plugin/skills/conflict-resolution/references/places-guidance.md
@@ -1,0 +1,60 @@
+<!--
+  CANONICAL SOURCE — do not edit a copy in isolation.
+  This block is duplicated, byte-for-byte, into each place-using skill's
+  references/places-guidance.md (Claude Code can't reliably load a shared
+  reference across skills — issue #17741 — so each skill carries its own copy).
+  A drift lint (mcp-server/tests/packaging/skill-guidance.test.ts) fails if any
+  copy diverges from this source. To change the guidance: edit this file, then
+  re-copy it into every skill listed in that test.
+-->
+
+# Working with places (standard places)
+
+Above the tool layer, places are always **names**, never IDs. The canonical
+name is the `standardPlace` from `place_search`.
+
+## Resolving a place
+
+Call `place_search` with the place name as `placeName` (optionally a
+higher-level `contextName` to disambiguate):
+
+```
+place_search({ placeName: "Schuylkill County, Pennsylvania" })
+```
+
+It returns an array of matches; each match has a **`standardPlace`** field (the
+fully-qualified standardized name) plus `type`, `dateRange`, coordinates, and
+links. **Pick the best/first match and use its `standardPlace` verbatim** as the
+handle for everything downstream. There are no place IDs in the output.
+
+Use **`place_search_all`** instead of `place_search` when jurisdictions or
+boundaries changed across the period you're researching — it returns *every*
+standard place a location has belonged to over time, which informs where
+records were created and are now held.
+
+## Passing places to other tools
+
+The place tools all take a `standardPlace` name (not an ID) and resolve it
+internally — pass the `standardPlace` you got from `place_search`:
+
+- `place_population({ standardPlace, ... })`
+- `place_external_links({ standardPlace, ... })`
+- `place_distance({ standardPlace1, standardPlace2 })`
+- `wiki_country_home` / `_getting_started` / `_online_records` / `_research_tips`({ standardPlace })
+- `metadata_search({ standardPlace, ... })`
+
+For `place_distance`, two events at the **same** `standard_place` are distance 0
+(no call needed); otherwise pass the two names.
+
+## Writing places to research.json / tree.gedcomx.json
+
+Whenever you persist a place on a fact, assertion, or timeline event, also set
+its **`standard_place`** companion (snake_case in the data formats) when one can
+be found:
+
+- If the place came from a `record_read` / `record_search` / `person_read`
+  result, that fact already carries a converter-resolved `standard_place` —
+  **copy it** (no tool call).
+- Otherwise call `place_search({ placeName: "<place>" })` and use the first
+  result's `standardPlace`. Resolve each distinct place once.
+- Leave `standard_place` null when `place` is null or nothing resolves.

--- a/plugin/skills/historical-context/SKILL.md
+++ b/plugin/skills/historical-context/SKILL.md
@@ -28,6 +28,8 @@ allowed-tools:
 
 **Narration:** Read `researcher_profile.narration_guidance` from `research.json` and apply it as your narration style for this invocation. If absent, default to a one-line preamble per action.
 
+**Places:** When resolving or writing places, follow `references/places-guidance.md` — resolve with `place_search` / `place_search_all` and record the `standardPlace` (and `standard_place` on persisted facts/assertions/events).
+
 Provides the historical background needed to correctly interpret
 genealogical records. Records were created by specific institutions,
 in specific political contexts, with specific social conventions.

--- a/plugin/skills/historical-context/SKILL.md
+++ b/plugin/skills/historical-context/SKILL.md
@@ -19,6 +19,8 @@ allowed-tools:
   - wiki_search
   - wiki_read
   - wikipedia_search
+  - place_search
+  - place_search_all
   - place_population
 ---
 
@@ -87,8 +89,15 @@ Call MCP tools for relevant information:
 wiki_search({ query: "German immigration Pennsylvania 1840s" })
 wiki_read({ url: "<specific FamilySearch wiki page URL>" })
 wikipedia_search({ query: "History of Schuylkill County Pennsylvania" })
+place_search({ placeName: "Schuylkill County, Pennsylvania" })
 place_population({ standardPlace: "Schuylkill, Pennsylvania, United States", year_start: 1840, year_end: 1880 })
 ```
+
+Resolve the place with `place_search` first and pass the result's
+`standardPlace` field to `place_population`. When the place's jurisdiction
+or boundaries changed across the period you're researching, use
+`place_search_all` instead — it returns every standard place a location has
+belonged to over time, which can explain where records ended up.
 
 Use the `place_population` tool when community size matters for
 interpreting the research context — a small rural community will

--- a/plugin/skills/historical-context/SKILL.md
+++ b/plugin/skills/historical-context/SKILL.md
@@ -87,7 +87,7 @@ Call MCP tools for relevant information:
 wiki_search({ query: "German immigration Pennsylvania 1840s" })
 wiki_read({ url: "<specific FamilySearch wiki page URL>" })
 wikipedia_search({ query: "History of Schuylkill County Pennsylvania" })
-place_population({ placeId: "<id>", year_start: 1840, year_end: 1880 })
+place_population({ standardPlace: "Schuylkill, Pennsylvania, United States", year_start: 1840, year_end: 1880 })
 ```
 
 Use the `place_population` tool when community size matters for

--- a/plugin/skills/historical-context/references/places-guidance.md
+++ b/plugin/skills/historical-context/references/places-guidance.md
@@ -39,6 +39,7 @@ internally — pass the `standardPlace` you got from `place_search`:
 
 - `place_population({ standardPlace, ... })`
 - `place_external_links({ standardPlace, ... })`
+- `place_collections({ standardPlace })` — lists record collections; it matches at the state level for the US/Canada/Mexico and the country level elsewhere (derived internally)
 - `place_distance({ standardPlace1, standardPlace2 })`
 - `wiki_country_home` / `_getting_started` / `_online_records` / `_research_tips`({ standardPlace })
 - `metadata_search({ standardPlace, ... })`

--- a/plugin/skills/historical-context/references/places-guidance.md
+++ b/plugin/skills/historical-context/references/places-guidance.md
@@ -1,0 +1,60 @@
+<!--
+  CANONICAL SOURCE — do not edit a copy in isolation.
+  This block is duplicated, byte-for-byte, into each place-using skill's
+  references/places-guidance.md (Claude Code can't reliably load a shared
+  reference across skills — issue #17741 — so each skill carries its own copy).
+  A drift lint (mcp-server/tests/packaging/skill-guidance.test.ts) fails if any
+  copy diverges from this source. To change the guidance: edit this file, then
+  re-copy it into every skill listed in that test.
+-->
+
+# Working with places (standard places)
+
+Above the tool layer, places are always **names**, never IDs. The canonical
+name is the `standardPlace` from `place_search`.
+
+## Resolving a place
+
+Call `place_search` with the place name as `placeName` (optionally a
+higher-level `contextName` to disambiguate):
+
+```
+place_search({ placeName: "Schuylkill County, Pennsylvania" })
+```
+
+It returns an array of matches; each match has a **`standardPlace`** field (the
+fully-qualified standardized name) plus `type`, `dateRange`, coordinates, and
+links. **Pick the best/first match and use its `standardPlace` verbatim** as the
+handle for everything downstream. There are no place IDs in the output.
+
+Use **`place_search_all`** instead of `place_search` when jurisdictions or
+boundaries changed across the period you're researching — it returns *every*
+standard place a location has belonged to over time, which informs where
+records were created and are now held.
+
+## Passing places to other tools
+
+The place tools all take a `standardPlace` name (not an ID) and resolve it
+internally — pass the `standardPlace` you got from `place_search`:
+
+- `place_population({ standardPlace, ... })`
+- `place_external_links({ standardPlace, ... })`
+- `place_distance({ standardPlace1, standardPlace2 })`
+- `wiki_country_home` / `_getting_started` / `_online_records` / `_research_tips`({ standardPlace })
+- `metadata_search({ standardPlace, ... })`
+
+For `place_distance`, two events at the **same** `standard_place` are distance 0
+(no call needed); otherwise pass the two names.
+
+## Writing places to research.json / tree.gedcomx.json
+
+Whenever you persist a place on a fact, assertion, or timeline event, also set
+its **`standard_place`** companion (snake_case in the data formats) when one can
+be found:
+
+- If the place came from a `record_read` / `record_search` / `person_read`
+  result, that fact already carries a converter-resolved `standard_place` —
+  **copy it** (no tool call).
+- Otherwise call `place_search({ placeName: "<place>" })` and use the first
+  result's `standardPlace`. Resolve each distinct place once.
+- Leave `standard_place` null when `place` is null or nothing resolves.

--- a/plugin/skills/init-project/SKILL.md
+++ b/plugin/skills/init-project/SKILL.md
@@ -28,6 +28,8 @@ Do NOT call `validate_research_schema`, `person_read`, or any other tool. Do NOT
 
 **Narration (new projects only):** Read `researcher_profile.narration_guidance` from `research.json` and apply it as your narration style for this invocation. If absent (e.g. this is a brand-new project still being initialized), default to a one-line preamble per action — the profile gets written in Step 4 and takes effect on the next skill invocation.
 
+**Places:** When resolving or writing places, follow `references/places-guidance.md` — facts from `person_read` already carry `standard_place`; for places you enter by hand, resolve with `place_search` and record the `standardPlace`.
+
 Creates a new genealogy research project by fetching a person from the
 FamilySearch tree and initializing the two project files:
 

--- a/plugin/skills/init-project/SKILL.md
+++ b/plugin/skills/init-project/SKILL.md
@@ -16,6 +16,7 @@ description: Initializes a new genealogy research project with GPS-conformant
 allowed-tools:
   - person_read
   - person_search
+  - place_search
 ---
 
 # Init Project
@@ -262,8 +263,14 @@ Create one source description entry (e.g., `S1`) for the FamilySearch tree using
 
 And on each fact:
 ```json
-{ "id": "F1", "type": "Birth", "date": "~1845", "place": "Ireland", "sources": [{ "ref": "S1", "quality": 1 }] }
+{ "id": "F1", "type": "Birth", "date": "~1845", "place": "Ireland", "standard_place": "Ireland", "sources": [{ "ref": "S1", "quality": 1 }] }
 ```
+
+Facts that come straight from `person_read` already carry a
+`standard_place` (the read tool resolves it) — keep it. For any fact whose
+`place` you enter or adjust by hand, set `standard_place` by calling
+`place_search({ placeName: "<place>" })` and using the first result's
+`standardPlace` field (null if nothing resolves).
 
 Do NOT describe the data as "unsourced" — it IS sourced to the FamilySearch tree. What matters is that it is an unverified compiled source, not a primary record. Use `quality: 1` (questionable) to signal this in the GedcomX data itself.
 

--- a/plugin/skills/init-project/references/places-guidance.md
+++ b/plugin/skills/init-project/references/places-guidance.md
@@ -39,6 +39,7 @@ internally — pass the `standardPlace` you got from `place_search`:
 
 - `place_population({ standardPlace, ... })`
 - `place_external_links({ standardPlace, ... })`
+- `place_collections({ standardPlace })` — lists record collections; it matches at the state level for the US/Canada/Mexico and the country level elsewhere (derived internally)
 - `place_distance({ standardPlace1, standardPlace2 })`
 - `wiki_country_home` / `_getting_started` / `_online_records` / `_research_tips`({ standardPlace })
 - `metadata_search({ standardPlace, ... })`

--- a/plugin/skills/init-project/references/places-guidance.md
+++ b/plugin/skills/init-project/references/places-guidance.md
@@ -1,0 +1,60 @@
+<!--
+  CANONICAL SOURCE — do not edit a copy in isolation.
+  This block is duplicated, byte-for-byte, into each place-using skill's
+  references/places-guidance.md (Claude Code can't reliably load a shared
+  reference across skills — issue #17741 — so each skill carries its own copy).
+  A drift lint (mcp-server/tests/packaging/skill-guidance.test.ts) fails if any
+  copy diverges from this source. To change the guidance: edit this file, then
+  re-copy it into every skill listed in that test.
+-->
+
+# Working with places (standard places)
+
+Above the tool layer, places are always **names**, never IDs. The canonical
+name is the `standardPlace` from `place_search`.
+
+## Resolving a place
+
+Call `place_search` with the place name as `placeName` (optionally a
+higher-level `contextName` to disambiguate):
+
+```
+place_search({ placeName: "Schuylkill County, Pennsylvania" })
+```
+
+It returns an array of matches; each match has a **`standardPlace`** field (the
+fully-qualified standardized name) plus `type`, `dateRange`, coordinates, and
+links. **Pick the best/first match and use its `standardPlace` verbatim** as the
+handle for everything downstream. There are no place IDs in the output.
+
+Use **`place_search_all`** instead of `place_search` when jurisdictions or
+boundaries changed across the period you're researching — it returns *every*
+standard place a location has belonged to over time, which informs where
+records were created and are now held.
+
+## Passing places to other tools
+
+The place tools all take a `standardPlace` name (not an ID) and resolve it
+internally — pass the `standardPlace` you got from `place_search`:
+
+- `place_population({ standardPlace, ... })`
+- `place_external_links({ standardPlace, ... })`
+- `place_distance({ standardPlace1, standardPlace2 })`
+- `wiki_country_home` / `_getting_started` / `_online_records` / `_research_tips`({ standardPlace })
+- `metadata_search({ standardPlace, ... })`
+
+For `place_distance`, two events at the **same** `standard_place` are distance 0
+(no call needed); otherwise pass the two names.
+
+## Writing places to research.json / tree.gedcomx.json
+
+Whenever you persist a place on a fact, assertion, or timeline event, also set
+its **`standard_place`** companion (snake_case in the data formats) when one can
+be found:
+
+- If the place came from a `record_read` / `record_search` / `person_read`
+  result, that fact already carries a converter-resolved `standard_place` —
+  **copy it** (no tool call).
+- Otherwise call `place_search({ placeName: "<place>" })` and use the first
+  result's `standardPlace`. Resolve each distinct place once.
+- Leave `standard_place` null when `place` is null or nothing resolves.

--- a/plugin/skills/locality-guide/SKILL.md
+++ b/plugin/skills/locality-guide/SKILL.md
@@ -31,6 +31,8 @@ allowed-tools:
 
 **Narration:** Read `researcher_profile.narration_guidance` from `research.json` and apply it as your narration style for this invocation. If absent, default to a one-line preamble per action.
 
+**Places:** When resolving or writing places, follow `references/places-guidance.md` — resolve with `place_search` / `place_search_all` and record the `standardPlace` (and `standard_place` on persisted facts/assertions/events).
+
 Produces a locality research guide — a structured survey of what
 records exist for a specific place and time period, where they are
 held, and how to access them. This is the prerequisite step before

--- a/plugin/skills/locality-guide/SKILL.md
+++ b/plugin/skills/locality-guide/SKILL.md
@@ -81,7 +81,7 @@ A guide without a time period cannot assess which records apply.
 Call MCP tools to establish the jurisdiction:
 
 ```
-place_search({ query: "Schuylkill County, Pennsylvania" })
+place_search({ placeName: "Schuylkill County, Pennsylvania" })
 place_population({ placeId: "<id>", year_start: 1840, year_end: 1880 })
 wikipedia_search({ query: "Schuylkill County Pennsylvania history" })
 ```
@@ -102,10 +102,10 @@ records exist and where they are held.
 ```
 wiki_search({ query: "Schuylkill County Pennsylvania genealogy records" })
 wiki_read({ url: "<relevant wiki page URL>" })
-wiki_country_home({ placeId: "<id>" })
-wiki_country_getting_started({ placeId: "<id>" })
-wiki_country_online_records({ placeId: "<id>" })
-wiki_country_research_tips({ placeId: "<id>" })
+wiki_country_home({ standardPlace: "Pennsylvania, United States" })
+wiki_country_getting_started({ standardPlace: "Pennsylvania, United States" })
+wiki_country_online_records({ standardPlace: "Pennsylvania, United States" })
+wiki_country_research_tips({ standardPlace: "Pennsylvania, United States" })
 place_collections({ query: "Pennsylvania" })
 place_external_links({ placeId: "<id>", startYear: 1840, endYear: 1880 })
 ```

--- a/plugin/skills/locality-guide/SKILL.md
+++ b/plugin/skills/locality-guide/SKILL.md
@@ -107,7 +107,7 @@ wiki_country_getting_started({ standardPlace: "Pennsylvania, United States" })
 wiki_country_online_records({ standardPlace: "Pennsylvania, United States" })
 wiki_country_research_tips({ standardPlace: "Pennsylvania, United States" })
 place_collections({ query: "Pennsylvania" })
-place_external_links({ placeId: "<id>", startYear: 1840, endYear: 1880 })
+place_external_links({ standardPlace: "Schuylkill, Pennsylvania, United States", startYear: 1840, endYear: 1880 })
 ```
 
 `place_collections` matches your query as a substring of FamilySearch

--- a/plugin/skills/locality-guide/SKILL.md
+++ b/plugin/skills/locality-guide/SKILL.md
@@ -115,7 +115,7 @@ wiki_country_home({ standardPlace: "Pennsylvania, United States" })
 wiki_country_getting_started({ standardPlace: "Pennsylvania, United States" })
 wiki_country_online_records({ standardPlace: "Pennsylvania, United States" })
 wiki_country_research_tips({ standardPlace: "Pennsylvania, United States" })
-place_collections({ query: "Pennsylvania" })
+place_collections({ standardPlace: "Pennsylvania, United States" })
 place_external_links({ standardPlace: "Schuylkill, Pennsylvania, United States", startYear: 1840, endYear: 1880 })
 ```
 

--- a/plugin/skills/locality-guide/SKILL.md
+++ b/plugin/skills/locality-guide/SKILL.md
@@ -82,7 +82,7 @@ Call MCP tools to establish the jurisdiction:
 
 ```
 place_search({ placeName: "Schuylkill County, Pennsylvania" })
-place_population({ placeId: "<id>", year_start: 1840, year_end: 1880 })
+place_population({ standardPlace: "Schuylkill, Pennsylvania, United States", year_start: 1840, year_end: 1880 })
 wikipedia_search({ query: "Schuylkill County Pennsylvania history" })
 ```
 

--- a/plugin/skills/locality-guide/SKILL.md
+++ b/plugin/skills/locality-guide/SKILL.md
@@ -20,6 +20,7 @@ allowed-tools:
   - wiki_country_online_records
   - wiki_country_research_tips
   - place_search
+  - place_search_all
   - place_population
   - place_collections
   - place_external_links
@@ -85,6 +86,12 @@ place_search({ placeName: "Schuylkill County, Pennsylvania" })
 place_population({ standardPlace: "Schuylkill, Pennsylvania, United States", year_start: 1840, year_end: 1880 })
 wikipedia_search({ query: "Schuylkill County Pennsylvania history" })
 ```
+
+`place_search` returns each match's `standardPlace` (the canonical name) —
+pass that to `place_population` and the other place tools. When jurisdictions
+or boundaries changed across the target period, call `place_search_all`
+instead: it returns every standard place a location has belonged to over time,
+which directly informs where records were created and are now held.
 
 From the results, determine:
 - When the jurisdiction was formed and from what parent

--- a/plugin/skills/locality-guide/references/places-guidance.md
+++ b/plugin/skills/locality-guide/references/places-guidance.md
@@ -39,6 +39,7 @@ internally — pass the `standardPlace` you got from `place_search`:
 
 - `place_population({ standardPlace, ... })`
 - `place_external_links({ standardPlace, ... })`
+- `place_collections({ standardPlace })` — lists record collections; it matches at the state level for the US/Canada/Mexico and the country level elsewhere (derived internally)
 - `place_distance({ standardPlace1, standardPlace2 })`
 - `wiki_country_home` / `_getting_started` / `_online_records` / `_research_tips`({ standardPlace })
 - `metadata_search({ standardPlace, ... })`

--- a/plugin/skills/locality-guide/references/places-guidance.md
+++ b/plugin/skills/locality-guide/references/places-guidance.md
@@ -1,0 +1,60 @@
+<!--
+  CANONICAL SOURCE — do not edit a copy in isolation.
+  This block is duplicated, byte-for-byte, into each place-using skill's
+  references/places-guidance.md (Claude Code can't reliably load a shared
+  reference across skills — issue #17741 — so each skill carries its own copy).
+  A drift lint (mcp-server/tests/packaging/skill-guidance.test.ts) fails if any
+  copy diverges from this source. To change the guidance: edit this file, then
+  re-copy it into every skill listed in that test.
+-->
+
+# Working with places (standard places)
+
+Above the tool layer, places are always **names**, never IDs. The canonical
+name is the `standardPlace` from `place_search`.
+
+## Resolving a place
+
+Call `place_search` with the place name as `placeName` (optionally a
+higher-level `contextName` to disambiguate):
+
+```
+place_search({ placeName: "Schuylkill County, Pennsylvania" })
+```
+
+It returns an array of matches; each match has a **`standardPlace`** field (the
+fully-qualified standardized name) plus `type`, `dateRange`, coordinates, and
+links. **Pick the best/first match and use its `standardPlace` verbatim** as the
+handle for everything downstream. There are no place IDs in the output.
+
+Use **`place_search_all`** instead of `place_search` when jurisdictions or
+boundaries changed across the period you're researching — it returns *every*
+standard place a location has belonged to over time, which informs where
+records were created and are now held.
+
+## Passing places to other tools
+
+The place tools all take a `standardPlace` name (not an ID) and resolve it
+internally — pass the `standardPlace` you got from `place_search`:
+
+- `place_population({ standardPlace, ... })`
+- `place_external_links({ standardPlace, ... })`
+- `place_distance({ standardPlace1, standardPlace2 })`
+- `wiki_country_home` / `_getting_started` / `_online_records` / `_research_tips`({ standardPlace })
+- `metadata_search({ standardPlace, ... })`
+
+For `place_distance`, two events at the **same** `standard_place` are distance 0
+(no call needed); otherwise pass the two names.
+
+## Writing places to research.json / tree.gedcomx.json
+
+Whenever you persist a place on a fact, assertion, or timeline event, also set
+its **`standard_place`** companion (snake_case in the data formats) when one can
+be found:
+
+- If the place came from a `record_read` / `record_search` / `person_read`
+  result, that fact already carries a converter-resolved `standard_place` —
+  **copy it** (no tool call).
+- Otherwise call `place_search({ placeName: "<place>" })` and use the first
+  result's `standardPlace`. Resolve each distinct place once.
+- Leave `standard_place` null when `place` is null or nothing resolves.

--- a/plugin/skills/record-extraction/SKILL.md
+++ b/plugin/skills/record-extraction/SKILL.md
@@ -18,6 +18,7 @@ allowed-tools:
   - record_read
   - image_read
   - image_search
+  - place_search
   - validate_research_schema
   - record_person_matches
   - record_record_matches
@@ -223,6 +224,7 @@ after correlation.
   "date": "<date or null>",
   "date_certainty": "<exact|approximate|estimated|...>",
   "place": "<place or null>",
+  "standard_place": "<standardized place name or null — see Standardizing places>",
   "information_quality": "<primary|secondary|indeterminate>",
   "informant": "<who provided this fact>",
   "informant_proximity": "<self|witness|household_member|...>",
@@ -232,6 +234,16 @@ after correlation.
   "extracted_for_question_ids": ["<question IDs or empty>"]
 }
 ```
+
+**Standardizing places (`standard_place`):** every assertion with a
+non-null `place` should carry a `standard_place` when one can be found.
+- If the source record came from `record_read` / `record_search`, its facts
+  already carry a converter-resolved `standard_place` — **copy that value**
+  for the matching place (no tool call needed).
+- Otherwise (image/PDF/full-text records, or a place not present on the
+  source fact), call `place_search({ placeName: "<place>" })` and use the
+  first result's `standardPlace` field. Resolve each distinct place once.
+- Leave `standard_place` null when `place` is null or nothing resolves.
 
 **Critical rules for each field:**
 

--- a/plugin/skills/record-extraction/SKILL.md
+++ b/plugin/skills/record-extraction/SKILL.md
@@ -28,6 +28,8 @@ allowed-tools:
 
 **Narration:** Read `researcher_profile.narration_guidance` from `research.json` and apply it as your narration style for this invocation. If absent, default to a one-line preamble per action.
 
+**Places:** When resolving or writing places, follow `references/places-guidance.md` — resolve with `place_search` / `place_search_all` and record the `standardPlace` (and `standard_place` on persisted facts/assertions/events).
+
 Reads a genealogical record and extracts every relevant fact as an
 atomic assertion. This is the core data-ingestion skill — it transforms
 raw records into the structured assertions that every downstream skill

--- a/plugin/skills/record-extraction/references/places-guidance.md
+++ b/plugin/skills/record-extraction/references/places-guidance.md
@@ -39,6 +39,7 @@ internally — pass the `standardPlace` you got from `place_search`:
 
 - `place_population({ standardPlace, ... })`
 - `place_external_links({ standardPlace, ... })`
+- `place_collections({ standardPlace })` — lists record collections; it matches at the state level for the US/Canada/Mexico and the country level elsewhere (derived internally)
 - `place_distance({ standardPlace1, standardPlace2 })`
 - `wiki_country_home` / `_getting_started` / `_online_records` / `_research_tips`({ standardPlace })
 - `metadata_search({ standardPlace, ... })`

--- a/plugin/skills/record-extraction/references/places-guidance.md
+++ b/plugin/skills/record-extraction/references/places-guidance.md
@@ -1,0 +1,60 @@
+<!--
+  CANONICAL SOURCE — do not edit a copy in isolation.
+  This block is duplicated, byte-for-byte, into each place-using skill's
+  references/places-guidance.md (Claude Code can't reliably load a shared
+  reference across skills — issue #17741 — so each skill carries its own copy).
+  A drift lint (mcp-server/tests/packaging/skill-guidance.test.ts) fails if any
+  copy diverges from this source. To change the guidance: edit this file, then
+  re-copy it into every skill listed in that test.
+-->
+
+# Working with places (standard places)
+
+Above the tool layer, places are always **names**, never IDs. The canonical
+name is the `standardPlace` from `place_search`.
+
+## Resolving a place
+
+Call `place_search` with the place name as `placeName` (optionally a
+higher-level `contextName` to disambiguate):
+
+```
+place_search({ placeName: "Schuylkill County, Pennsylvania" })
+```
+
+It returns an array of matches; each match has a **`standardPlace`** field (the
+fully-qualified standardized name) plus `type`, `dateRange`, coordinates, and
+links. **Pick the best/first match and use its `standardPlace` verbatim** as the
+handle for everything downstream. There are no place IDs in the output.
+
+Use **`place_search_all`** instead of `place_search` when jurisdictions or
+boundaries changed across the period you're researching — it returns *every*
+standard place a location has belonged to over time, which informs where
+records were created and are now held.
+
+## Passing places to other tools
+
+The place tools all take a `standardPlace` name (not an ID) and resolve it
+internally — pass the `standardPlace` you got from `place_search`:
+
+- `place_population({ standardPlace, ... })`
+- `place_external_links({ standardPlace, ... })`
+- `place_distance({ standardPlace1, standardPlace2 })`
+- `wiki_country_home` / `_getting_started` / `_online_records` / `_research_tips`({ standardPlace })
+- `metadata_search({ standardPlace, ... })`
+
+For `place_distance`, two events at the **same** `standard_place` are distance 0
+(no call needed); otherwise pass the two names.
+
+## Writing places to research.json / tree.gedcomx.json
+
+Whenever you persist a place on a fact, assertion, or timeline event, also set
+its **`standard_place`** companion (snake_case in the data formats) when one can
+be found:
+
+- If the place came from a `record_read` / `record_search` / `person_read`
+  result, that fact already carries a converter-resolved `standard_place` —
+  **copy it** (no tool call).
+- Otherwise call `place_search({ placeName: "<place>" })` and use the first
+  result's `standardPlace`. Resolve each distinct place once.
+- Leave `standard_place` null when `place` is null or nothing resolves.

--- a/plugin/skills/research-plan/SKILL.md
+++ b/plugin/skills/research-plan/SKILL.md
@@ -15,6 +15,7 @@ description: Creates a sequenced research plan (written to research.json) for an
 allowed-tools:
   - wiki_search
   - place_search
+  - place_search_all
   - place_collections
   - place_population
   - place_external_links

--- a/plugin/skills/research-plan/SKILL.md
+++ b/plugin/skills/research-plan/SKILL.md
@@ -123,7 +123,7 @@ period. This is the foundation of sound planning.
 ```
 place_search({ placeName: "Schuylkill County, Pennsylvania" })
 place_collections({ query: "Schuylkill County Pennsylvania" })
-place_external_links({ placeId: "<place_id>", startYear: 1875, endYear: 1890 })
+place_external_links({ standardPlace: "<standardPlace from place_search>", startYear: 1875, endYear: 1890 })
 image_search({ placeId: "<place_id>", fromDate: "1875-01-01", toDate: "1890-12-31" })
 wiki_search({ query: "Pennsylvania probate records genealogy" })
 wiki_country_research_tips({ standardPlace: "Pennsylvania, United States" })

--- a/plugin/skills/research-plan/SKILL.md
+++ b/plugin/skills/research-plan/SKILL.md
@@ -121,13 +121,13 @@ period. This is the foundation of sound planning.
   call MCP tools directly:
 
 ```
-place_search({ query: "Schuylkill County, Pennsylvania" })
+place_search({ placeName: "Schuylkill County, Pennsylvania" })
 place_collections({ query: "Schuylkill County Pennsylvania" })
 place_external_links({ placeId: "<place_id>", startYear: 1875, endYear: 1890 })
 image_search({ placeId: "<place_id>", fromDate: "1875-01-01", toDate: "1890-12-31" })
 wiki_search({ query: "Pennsylvania probate records genealogy" })
-wiki_country_research_tips({ placeId: "<place_id>" })
-wiki_country_online_records({ placeId: "<place_id>" })
+wiki_country_research_tips({ standardPlace: "Pennsylvania, United States" })
+wiki_country_online_records({ standardPlace: "Pennsylvania, United States" })
 ```
 
 Pass the question's target period to `place_external_links` as `startYear`

--- a/plugin/skills/research-plan/SKILL.md
+++ b/plugin/skills/research-plan/SKILL.md
@@ -29,6 +29,8 @@ allowed-tools:
 
 **Narration:** Read `researcher_profile.narration_guidance` from `research.json` and apply it as your narration style for this invocation. If absent, default to a one-line preamble per action.
 
+**Places:** When resolving or writing places, follow `references/places-guidance.md` — resolve with `place_search` / `place_search_all` and record the `standardPlace` (and `standard_place` on persisted facts/assertions/events).
+
 Given a specific research question, produces a concrete plan to answer
 it: which record sets to search, in what order, from which repositories,
 with rationale for each step and fallbacks when primary sources yield

--- a/plugin/skills/research-plan/SKILL.md
+++ b/plugin/skills/research-plan/SKILL.md
@@ -124,7 +124,7 @@ period. This is the foundation of sound planning.
 place_search({ placeName: "Schuylkill County, Pennsylvania" })
 place_collections({ query: "Schuylkill County Pennsylvania" })
 place_external_links({ standardPlace: "<standardPlace from place_search>", startYear: 1875, endYear: 1890 })
-image_search({ placeId: "<place_id>", fromDate: "1875-01-01", toDate: "1890-12-31" })
+image_search({ imageGroupNumber: "<imageGroupNumber from metadata_search>" })
 wiki_search({ query: "Pennsylvania probate records genealogy" })
 wiki_country_research_tips({ standardPlace: "Pennsylvania, United States" })
 wiki_country_online_records({ standardPlace: "Pennsylvania, United States" })

--- a/plugin/skills/research-plan/SKILL.md
+++ b/plugin/skills/research-plan/SKILL.md
@@ -125,7 +125,7 @@ period. This is the foundation of sound planning.
 
 ```
 place_search({ placeName: "Schuylkill County, Pennsylvania" })
-place_collections({ query: "Schuylkill County Pennsylvania" })
+place_collections({ standardPlace: "Schuylkill, Pennsylvania, United States" })
 place_external_links({ standardPlace: "<standardPlace from place_search>", startYear: 1875, endYear: 1890 })
 image_search({ imageGroupNumber: "<imageGroupNumber from metadata_search>" })
 wiki_search({ query: "Pennsylvania probate records genealogy" })
@@ -293,7 +293,7 @@ in Schuylkill County naming Patrick as a son?"
 **Locality survey:**
 - `place_search("Schuylkill County, Pennsylvania")` → County formed
   1811, seat at Pottsville, part of Pennsylvania throughout
-- `place_collections("Schuylkill County Pennsylvania")` → FamilySearch
+- `place_collections({ standardPlace: "Schuylkill, Pennsylvania, United States" })` → FamilySearch
   has "Pennsylvania Probate Records, 1683-1994" (indexed, 2.3M records)
   and "Pennsylvania Land Records, 1687-1940" (images, not indexed)
 - `place_external_links(...)` → URL to Ancestry's "Pennsylvania Wills and

--- a/plugin/skills/research-plan/references/places-guidance.md
+++ b/plugin/skills/research-plan/references/places-guidance.md
@@ -39,6 +39,7 @@ internally — pass the `standardPlace` you got from `place_search`:
 
 - `place_population({ standardPlace, ... })`
 - `place_external_links({ standardPlace, ... })`
+- `place_collections({ standardPlace })` — lists record collections; it matches at the state level for the US/Canada/Mexico and the country level elsewhere (derived internally)
 - `place_distance({ standardPlace1, standardPlace2 })`
 - `wiki_country_home` / `_getting_started` / `_online_records` / `_research_tips`({ standardPlace })
 - `metadata_search({ standardPlace, ... })`

--- a/plugin/skills/research-plan/references/places-guidance.md
+++ b/plugin/skills/research-plan/references/places-guidance.md
@@ -1,0 +1,60 @@
+<!--
+  CANONICAL SOURCE — do not edit a copy in isolation.
+  This block is duplicated, byte-for-byte, into each place-using skill's
+  references/places-guidance.md (Claude Code can't reliably load a shared
+  reference across skills — issue #17741 — so each skill carries its own copy).
+  A drift lint (mcp-server/tests/packaging/skill-guidance.test.ts) fails if any
+  copy diverges from this source. To change the guidance: edit this file, then
+  re-copy it into every skill listed in that test.
+-->
+
+# Working with places (standard places)
+
+Above the tool layer, places are always **names**, never IDs. The canonical
+name is the `standardPlace` from `place_search`.
+
+## Resolving a place
+
+Call `place_search` with the place name as `placeName` (optionally a
+higher-level `contextName` to disambiguate):
+
+```
+place_search({ placeName: "Schuylkill County, Pennsylvania" })
+```
+
+It returns an array of matches; each match has a **`standardPlace`** field (the
+fully-qualified standardized name) plus `type`, `dateRange`, coordinates, and
+links. **Pick the best/first match and use its `standardPlace` verbatim** as the
+handle for everything downstream. There are no place IDs in the output.
+
+Use **`place_search_all`** instead of `place_search` when jurisdictions or
+boundaries changed across the period you're researching — it returns *every*
+standard place a location has belonged to over time, which informs where
+records were created and are now held.
+
+## Passing places to other tools
+
+The place tools all take a `standardPlace` name (not an ID) and resolve it
+internally — pass the `standardPlace` you got from `place_search`:
+
+- `place_population({ standardPlace, ... })`
+- `place_external_links({ standardPlace, ... })`
+- `place_distance({ standardPlace1, standardPlace2 })`
+- `wiki_country_home` / `_getting_started` / `_online_records` / `_research_tips`({ standardPlace })
+- `metadata_search({ standardPlace, ... })`
+
+For `place_distance`, two events at the **same** `standard_place` are distance 0
+(no call needed); otherwise pass the two names.
+
+## Writing places to research.json / tree.gedcomx.json
+
+Whenever you persist a place on a fact, assertion, or timeline event, also set
+its **`standard_place`** companion (snake_case in the data formats) when one can
+be found:
+
+- If the place came from a `record_read` / `record_search` / `person_read`
+  result, that fact already carries a converter-resolved `standard_place` —
+  **copy it** (no tool call).
+- Otherwise call `place_search({ placeName: "<place>" })` and use the first
+  result's `standardPlace`. Resolve each distinct place once.
+- Leave `standard_place` null when `place` is null or nothing resolves.

--- a/plugin/skills/search-external-sites/SKILL.md
+++ b/plugin/skills/search-external-sites/SKILL.md
@@ -22,6 +22,8 @@ allowed-tools:
 
 **Narration:** Read `researcher_profile.narration_guidance` from `research.json` and apply it as your narration style for this invocation. If absent, default to a one-line preamble per action.
 
+**Places:** When resolving or writing places, follow `references/places-guidance.md` — resolve with `place_search` / `place_search_all` and record the `standardPlace` (and `standard_place` on persisted facts/assertions/events).
+
 Generates search URLs for commercial and external genealogy sites,
 instructs the user on the click-capture workflow, and analyzes
 returned PDF captures. This skill exists because these sites have

--- a/plugin/skills/search-external-sites/SKILL.md
+++ b/plugin/skills/search-external-sites/SKILL.md
@@ -114,15 +114,15 @@ Call the `place_external_links` MCP tool to fetch FamilySearch-curated
 third-party URLs for the target place and time period:
 
 ```
-place_external_links({ placeId: <place_id>, startYear: <year>, endYear: <year> })
+place_external_links({ standardPlace: "<standard place name>", startYear: <year>, endYear: <year> })
 ```
 
-`placeId` is the FamilySearch place ID — get it from the `place_search`
-tool, do not guess. Call it like this (the parameter name is `query`,
-not `name` or `place`):
+`standardPlace` is the standard place name — get it from the `place_search`
+tool's `standardPlace` output field, do not guess. Call place_search like
+this (the parameter name is `placeName`):
 
 ```
-place_search({ query: "<place name>" })
+place_search({ placeName: "<place name>" })
 ```
 
 `startYear` and `endYear` come from the plan item's target period.

--- a/plugin/skills/search-external-sites/references/places-guidance.md
+++ b/plugin/skills/search-external-sites/references/places-guidance.md
@@ -39,6 +39,7 @@ internally — pass the `standardPlace` you got from `place_search`:
 
 - `place_population({ standardPlace, ... })`
 - `place_external_links({ standardPlace, ... })`
+- `place_collections({ standardPlace })` — lists record collections; it matches at the state level for the US/Canada/Mexico and the country level elsewhere (derived internally)
 - `place_distance({ standardPlace1, standardPlace2 })`
 - `wiki_country_home` / `_getting_started` / `_online_records` / `_research_tips`({ standardPlace })
 - `metadata_search({ standardPlace, ... })`

--- a/plugin/skills/search-external-sites/references/places-guidance.md
+++ b/plugin/skills/search-external-sites/references/places-guidance.md
@@ -1,0 +1,60 @@
+<!--
+  CANONICAL SOURCE — do not edit a copy in isolation.
+  This block is duplicated, byte-for-byte, into each place-using skill's
+  references/places-guidance.md (Claude Code can't reliably load a shared
+  reference across skills — issue #17741 — so each skill carries its own copy).
+  A drift lint (mcp-server/tests/packaging/skill-guidance.test.ts) fails if any
+  copy diverges from this source. To change the guidance: edit this file, then
+  re-copy it into every skill listed in that test.
+-->
+
+# Working with places (standard places)
+
+Above the tool layer, places are always **names**, never IDs. The canonical
+name is the `standardPlace` from `place_search`.
+
+## Resolving a place
+
+Call `place_search` with the place name as `placeName` (optionally a
+higher-level `contextName` to disambiguate):
+
+```
+place_search({ placeName: "Schuylkill County, Pennsylvania" })
+```
+
+It returns an array of matches; each match has a **`standardPlace`** field (the
+fully-qualified standardized name) plus `type`, `dateRange`, coordinates, and
+links. **Pick the best/first match and use its `standardPlace` verbatim** as the
+handle for everything downstream. There are no place IDs in the output.
+
+Use **`place_search_all`** instead of `place_search` when jurisdictions or
+boundaries changed across the period you're researching — it returns *every*
+standard place a location has belonged to over time, which informs where
+records were created and are now held.
+
+## Passing places to other tools
+
+The place tools all take a `standardPlace` name (not an ID) and resolve it
+internally — pass the `standardPlace` you got from `place_search`:
+
+- `place_population({ standardPlace, ... })`
+- `place_external_links({ standardPlace, ... })`
+- `place_distance({ standardPlace1, standardPlace2 })`
+- `wiki_country_home` / `_getting_started` / `_online_records` / `_research_tips`({ standardPlace })
+- `metadata_search({ standardPlace, ... })`
+
+For `place_distance`, two events at the **same** `standard_place` are distance 0
+(no call needed); otherwise pass the two names.
+
+## Writing places to research.json / tree.gedcomx.json
+
+Whenever you persist a place on a fact, assertion, or timeline event, also set
+its **`standard_place`** companion (snake_case in the data formats) when one can
+be found:
+
+- If the place came from a `record_read` / `record_search` / `person_read`
+  result, that fact already carries a converter-resolved `standard_place` —
+  **copy it** (no tool call).
+- Otherwise call `place_search({ placeName: "<place>" })` and use the first
+  result's `standardPlace`. Resolve each distinct place once.
+- Leave `standard_place` null when `place` is null or nothing resolves.

--- a/plugin/skills/timeline/SKILL.md
+++ b/plugin/skills/timeline/SKILL.md
@@ -128,24 +128,23 @@ events.
    standardize it. Pass the place string as `placeName` —
    e.g. `place_search({ placeName: "Schuylkill County, Pennsylvania" })`.
 3. If the tool returns one or more results, take the first (best)
-   match's `standardPlace` field and keep an in-memory map from the
-   place string to that `standardPlace` (you do not persist it on the
-   event — `place_distance` resolves names itself).
-4. If it returns no results, treat that place as unresolved.
+   match's `standardPlace` field and write it as `standard_place` onto
+   all events sharing that place string.
+4. If it returns no results, leave `standard_place` null. Do not retry
+   or error.
 
 **Phase 2 — Compute distances:**
 
 1. Walk events in chronological order as consecutive pairs.
-2. For each pair where both events have a non-null `place`:
-   - If both resolved to the **same** `standardPlace` (or the two raw
-     `place` strings are identical), set `distance_from_previous_km` to
-     `0` (no API call needed).
+2. For each pair where both events have a non-null `standard_place`:
+   - If the two `standard_place` values are the same, set
+     `distance_from_previous_km` to `0` (no API call needed).
    - Otherwise call
      `place_distance({ standardPlace1, standardPlace2 })` with the two
-     standard place names and write its `kilometers` onto the later
+     `standard_place` names and write its `kilometers` onto the later
      event's `distance_from_previous_km`.
-3. Skip (leave `distance_from_previous_km` null) when either event's
-   place is missing or unresolved.
+3. Skip (leave `distance_from_previous_km` null) when either event lacks
+   a `standard_place`.
 
 **Example enriched event:**
 
@@ -155,6 +154,7 @@ events.
   "date_certainty": "exact",
   "event_type": "census",
   "place": "Schuylkill County, Pennsylvania",
+  "standard_place": "Schuylkill, Pennsylvania, United States",
   "description": "Enumerated age 5 in Thomas Flynn household, dwelling 84",
   "assertion_ids": ["a_003", "a_004"],
   "distance_from_previous_km": 5400

--- a/plugin/skills/timeline/SKILL.md
+++ b/plugin/skills/timeline/SKILL.md
@@ -24,6 +24,8 @@ allowed-tools:
 
 **Narration:** Read `researcher_profile.narration_guidance` from `research.json` and apply it as your narration style for this invocation. If absent, default to a one-line preamble per action.
 
+**Places:** When resolving or writing places, follow `references/places-guidance.md` — resolve with `place_search` / `place_search_all` and record the `standardPlace` (and `standard_place` on persisted facts/assertions/events).
+
 Builds chronological timelines from assertions linked to persons.
 A timeline is the primary **correlation tool** — it arranges events
 from multiple independent sources in chronological order to:

--- a/plugin/skills/timeline/SKILL.md
+++ b/plugin/skills/timeline/SKILL.md
@@ -121,29 +121,31 @@ After building and sorting events, resolve place strings to
 FamilySearch place IDs and compute distances between consecutive
 events.
 
-**Phase 1 — Resolve places:**
+**Phase 1 — Resolve places to standard place names:**
 
 1. Collect all unique non-null `place` strings from the built events.
 2. For each unique place string, call the `place_search` MCP tool to
-   resolve it to a place ID. Pass the place string as `query` —
-   e.g. `place_search({ query: "Schuylkill County, Pennsylvania" })`.
-3. If the tool returns one or more results, use the first (best)
-   match and write its `place_id` onto all events sharing that
-   place string.
-4. If it returns no results, leave `place_id` null. Do not retry
-   or error.
+   standardize it. Pass the place string as `placeName` —
+   e.g. `place_search({ placeName: "Schuylkill County, Pennsylvania" })`.
+3. If the tool returns one or more results, take the first (best)
+   match's `standardPlace` field and keep an in-memory map from the
+   place string to that `standardPlace` (you do not persist it on the
+   event — `place_distance` resolves names itself).
+4. If it returns no results, treat that place as unresolved.
 
 **Phase 2 — Compute distances:**
 
 1. Walk events in chronological order as consecutive pairs.
-2. For each pair where both events have a non-null `place_id`:
-   - If the two `place_id` values are the same, set
-     `distance_from_previous_km` to `0` (no API call needed).
-   - If they differ, call `place_distance` with the two IDs and
-     write the result onto the later event's
-     `distance_from_previous_km`.
-3. Skip (leave `distance_from_previous_km` null) when either event
-   lacks a `place_id`.
+2. For each pair where both events have a non-null `place`:
+   - If both resolved to the **same** `standardPlace` (or the two raw
+     `place` strings are identical), set `distance_from_previous_km` to
+     `0` (no API call needed).
+   - Otherwise call
+     `place_distance({ standardPlace1, standardPlace2 })` with the two
+     standard place names and write its `kilometers` onto the later
+     event's `distance_from_previous_km`.
+3. Skip (leave `distance_from_previous_km` null) when either event's
+   place is missing or unresolved.
 
 **Example enriched event:**
 
@@ -153,7 +155,6 @@ events.
   "date_certainty": "exact",
   "event_type": "census",
   "place": "Schuylkill County, Pennsylvania",
-  "place_id": "325",
   "description": "Enumerated age 5 in Thomas Flynn household, dwelling 84",
   "assertion_ids": ["a_003", "a_004"],
   "distance_from_previous_km": 5400

--- a/plugin/skills/timeline/references/places-guidance.md
+++ b/plugin/skills/timeline/references/places-guidance.md
@@ -39,6 +39,7 @@ internally — pass the `standardPlace` you got from `place_search`:
 
 - `place_population({ standardPlace, ... })`
 - `place_external_links({ standardPlace, ... })`
+- `place_collections({ standardPlace })` — lists record collections; it matches at the state level for the US/Canada/Mexico and the country level elsewhere (derived internally)
 - `place_distance({ standardPlace1, standardPlace2 })`
 - `wiki_country_home` / `_getting_started` / `_online_records` / `_research_tips`({ standardPlace })
 - `metadata_search({ standardPlace, ... })`

--- a/plugin/skills/timeline/references/places-guidance.md
+++ b/plugin/skills/timeline/references/places-guidance.md
@@ -1,0 +1,60 @@
+<!--
+  CANONICAL SOURCE — do not edit a copy in isolation.
+  This block is duplicated, byte-for-byte, into each place-using skill's
+  references/places-guidance.md (Claude Code can't reliably load a shared
+  reference across skills — issue #17741 — so each skill carries its own copy).
+  A drift lint (mcp-server/tests/packaging/skill-guidance.test.ts) fails if any
+  copy diverges from this source. To change the guidance: edit this file, then
+  re-copy it into every skill listed in that test.
+-->
+
+# Working with places (standard places)
+
+Above the tool layer, places are always **names**, never IDs. The canonical
+name is the `standardPlace` from `place_search`.
+
+## Resolving a place
+
+Call `place_search` with the place name as `placeName` (optionally a
+higher-level `contextName` to disambiguate):
+
+```
+place_search({ placeName: "Schuylkill County, Pennsylvania" })
+```
+
+It returns an array of matches; each match has a **`standardPlace`** field (the
+fully-qualified standardized name) plus `type`, `dateRange`, coordinates, and
+links. **Pick the best/first match and use its `standardPlace` verbatim** as the
+handle for everything downstream. There are no place IDs in the output.
+
+Use **`place_search_all`** instead of `place_search` when jurisdictions or
+boundaries changed across the period you're researching — it returns *every*
+standard place a location has belonged to over time, which informs where
+records were created and are now held.
+
+## Passing places to other tools
+
+The place tools all take a `standardPlace` name (not an ID) and resolve it
+internally — pass the `standardPlace` you got from `place_search`:
+
+- `place_population({ standardPlace, ... })`
+- `place_external_links({ standardPlace, ... })`
+- `place_distance({ standardPlace1, standardPlace2 })`
+- `wiki_country_home` / `_getting_started` / `_online_records` / `_research_tips`({ standardPlace })
+- `metadata_search({ standardPlace, ... })`
+
+For `place_distance`, two events at the **same** `standard_place` are distance 0
+(no call needed); otherwise pass the two names.
+
+## Writing places to research.json / tree.gedcomx.json
+
+Whenever you persist a place on a fact, assertion, or timeline event, also set
+its **`standard_place`** companion (snake_case in the data formats) when one can
+be found:
+
+- If the place came from a `record_read` / `record_search` / `person_read`
+  result, that fact already carries a converter-resolved `standard_place` —
+  **copy it** (no tool call).
+- Otherwise call `place_search({ placeName: "<place>" })` and use the first
+  result's `standardPlace`. Resolve each distinct place once.
+- Leave `standard_place` null when `place` is null or nothing resolves.

--- a/plugin/skills/tree-edit/SKILL.md
+++ b/plugin/skills/tree-edit/SKILL.md
@@ -22,6 +22,7 @@ description: Handles direct edits to tree.gedcomx.json — adding facts,
   search-records), wants to write a conclusion (use proof-conclusion),
   or wants to link assertions to persons (use person-evidence).
 allowed-tools:
+  - place_search
   - validate_research_schema
   - person_record_matches
   - person_person_matches
@@ -60,12 +61,15 @@ Load these for detailed guidance on specific topics:
   "type": "Occupation",
   "date": "1870",
   "place": "Schuylkill County, Pennsylvania",
+  "standard_place": "Schuylkill, Pennsylvania, United States",
   "sources": [{ "ref": "S2", "page": "1870 Census, dwelling 201" }]
 }
 ```
 
 Add to the person's `facts` array. Generate the next available `F`
-prefix ID. If the fact should be the primary of its type, add
+prefix ID. Whenever you set a fact's `place`, also set `standard_place`:
+call `place_search({ placeName: "<place>" })` and use the first result's
+`standardPlace` field (leave it null if nothing resolves). If the fact should be the primary of its type, add
 `"primary": true` (and remove `primary` from any existing fact of
 the same type on this person).
 
@@ -74,7 +78,9 @@ the same type on this person).
 Find the field to correct and update it. Examples:
 - Change given name: update `names[].given`
 - Fix birth year: update `facts[].date` where `type: "Birth"`
-- Correct a place: update `facts[].place`
+- Correct a place: update `facts[].place` **and** re-resolve
+  `facts[].standard_place` via `place_search` (or set it null if the new
+  place doesn't resolve)
 
 ### Adding a person
 

--- a/plugin/skills/tree-edit/SKILL.md
+++ b/plugin/skills/tree-edit/SKILL.md
@@ -32,6 +32,8 @@ allowed-tools:
 
 **Narration:** Read `researcher_profile.narration_guidance` from `research.json` and apply it as your narration style for this invocation. If absent, default to a one-line preamble per action.
 
+**Places:** When resolving or writing places, follow `references/places-guidance.md` — resolve with `place_search` / `place_search_all` and record the `standardPlace` (and `standard_place` on persisted facts/assertions/events).
+
 Handles direct modifications to `tree.gedcomx.json` — the simplified
 GedcomX deliverable. This skill covers two main use cases:
 

--- a/plugin/skills/tree-edit/references/places-guidance.md
+++ b/plugin/skills/tree-edit/references/places-guidance.md
@@ -39,6 +39,7 @@ internally — pass the `standardPlace` you got from `place_search`:
 
 - `place_population({ standardPlace, ... })`
 - `place_external_links({ standardPlace, ... })`
+- `place_collections({ standardPlace })` — lists record collections; it matches at the state level for the US/Canada/Mexico and the country level elsewhere (derived internally)
 - `place_distance({ standardPlace1, standardPlace2 })`
 - `wiki_country_home` / `_getting_started` / `_online_records` / `_research_tips`({ standardPlace })
 - `metadata_search({ standardPlace, ... })`

--- a/plugin/skills/tree-edit/references/places-guidance.md
+++ b/plugin/skills/tree-edit/references/places-guidance.md
@@ -1,0 +1,60 @@
+<!--
+  CANONICAL SOURCE — do not edit a copy in isolation.
+  This block is duplicated, byte-for-byte, into each place-using skill's
+  references/places-guidance.md (Claude Code can't reliably load a shared
+  reference across skills — issue #17741 — so each skill carries its own copy).
+  A drift lint (mcp-server/tests/packaging/skill-guidance.test.ts) fails if any
+  copy diverges from this source. To change the guidance: edit this file, then
+  re-copy it into every skill listed in that test.
+-->
+
+# Working with places (standard places)
+
+Above the tool layer, places are always **names**, never IDs. The canonical
+name is the `standardPlace` from `place_search`.
+
+## Resolving a place
+
+Call `place_search` with the place name as `placeName` (optionally a
+higher-level `contextName` to disambiguate):
+
+```
+place_search({ placeName: "Schuylkill County, Pennsylvania" })
+```
+
+It returns an array of matches; each match has a **`standardPlace`** field (the
+fully-qualified standardized name) plus `type`, `dateRange`, coordinates, and
+links. **Pick the best/first match and use its `standardPlace` verbatim** as the
+handle for everything downstream. There are no place IDs in the output.
+
+Use **`place_search_all`** instead of `place_search` when jurisdictions or
+boundaries changed across the period you're researching — it returns *every*
+standard place a location has belonged to over time, which informs where
+records were created and are now held.
+
+## Passing places to other tools
+
+The place tools all take a `standardPlace` name (not an ID) and resolve it
+internally — pass the `standardPlace` you got from `place_search`:
+
+- `place_population({ standardPlace, ... })`
+- `place_external_links({ standardPlace, ... })`
+- `place_distance({ standardPlace1, standardPlace2 })`
+- `wiki_country_home` / `_getting_started` / `_online_records` / `_research_tips`({ standardPlace })
+- `metadata_search({ standardPlace, ... })`
+
+For `place_distance`, two events at the **same** `standard_place` are distance 0
+(no call needed); otherwise pass the two names.
+
+## Writing places to research.json / tree.gedcomx.json
+
+Whenever you persist a place on a fact, assertion, or timeline event, also set
+its **`standard_place`** companion (snake_case in the data formats) when one can
+be found:
+
+- If the place came from a `record_read` / `record_search` / `person_read`
+  result, that fact already carries a converter-resolved `standard_place` —
+  **copy it** (no tool call).
+- Otherwise call `place_search({ placeName: "<place>" })` and use the first
+  result's `standardPlace`. Resolve each distinct place once.
+- Leave `standard_place` null when `place` is null or nothing resolves.


### PR DESCRIPTION
## Summary

Standardizes on a **`standardPlace`** (a fully-qualified standardized place name) everywhere above the MCP tool layer — in skills, in SimplifiedGedcomX, and in persisted research artifacts. Raw FamilySearch `placeId` / `placeRepId` identifiers now live **only** as private, cached, in-server plumbing.

The headline result: **above the tool layer, `placeId` is gone.** Skills and persisted artifacts deal only with names; tools that need an ID resolve it internally through a shared resolver.

Full design + decision trail: `docs/plan/standard-place-standardization.md`.

## What changed (by plan step)

| Step | Change |
|---|---|
| **1. Resolver** | New `utils/place-resolver.ts` — bidirectional `standardPlace`↔ID conversion with in-process caching, retry/backoff (transient-only), bounded-concurrency map, `null`-on-ambiguity tie-break, and definitive-only negative caching. |
| **2. `place_search`** | Returns a `standardPlace` field (renamed from `fullName`) as the single canonical handle. |
| **3. Converter** | `SimplifiedFact.standard_place`, populated by the pure converter from raw `place.normalized`; `toSimplifiedStandardized` adds a document-level network pass (dedup + ≤8 parallel, best-effort) for free-text places. Wired into `person_read`, `record_read`, `person_ancestors`, and the `record_search` / `person_search` workhorses (one pass over all entries, cross-record dedup). |
| **4. Tool inputs** | All six ID-taking tools now take `standardPlace`, atomic with their skills: `place_distance`, `wiki_country_*` (×4), `place_population`, `place_external_links`, `place_collections` (`placeIds` removed; list mode now takes `standardPlace` and derives the FS collection scope internally — US→state, Canada/Mexico→"Country, State", else→country), `metadata_search`. |
| **5. Schema** | research.json `timelines[].events[].place_id` → `standard_place`; `standard_place` also added to assertions. Schema + validator + eval-app TS mirror + specs + skills. |
| **6. Sweep** | Verified zero LLM-facing `placeId` remains; documented out-of-scope id-spaces (Pop Stats `place_id`, `q.placeId`, collections `searchMetadata.placeIds`, record_search `{parent_place_id}`) left intact. |

Plus, per follow-up requests:
- **`standard_place` on every authored place field** — `record-extraction`, `tree-edit`, `init-project` now fill it (copying from the source record's converter-resolved fact when available, else `place_search`).
- **`metadata_search` spec correction** — the spec described a per-group child-counts sub-fetch the code doesn't do; rewritten to match the shipped (and live-confirmed) inline `returnChildCounts: true` behavior.
- **Fetcher consolidation** — raw FS Places fetchers extracted into a low-level `utils/place-api.ts` that both the resolver and `place-search` build on (removes the util→tool dependency); pure refactor.
- **Shared `places-guidance.md`** — one canonical reference duplicated into all 9 place-using skills, with a **drift lint** (`tests/packaging/skill-guidance.test.ts`) and a per-skill pointer.
- **Soft cap 50 → 100** distinct places per standardization pass.

## Naming convention

`standardPlace` (camelCase) in all code surfaces — the `place_search` output struct, tool input params, and internal TS. `standard_place` (snake_case) only in the data formats (`SimplifiedFact`, research.json), matching the existing `standard_date` / `place_id`.

## Reviews

- **spec-review** on all four specced tools → 3 genuine code fixes (numeric `coverage.placeRepIds` wire format, broken smoke script, dead code).
- **Multi-agent code-review** (7 finder angles + adversarial verification) → all 5 CONFIRMED issues fixed, notably a real efficiency regression (`wiki_country_*` did 2 network round-trips before the local file the leaf name finds — now leaf-first, zero network in the common case), plus empty-input/NaN guards and auth-error ordering.

## Testing

`tsc` clean. **816 tests** across 38 files (new: resolver, converter standardization, every migrated tool, the guidance drift lint). No behavior change in the fetcher consolidation refactor.

## Eval corpus

**Done here:** the place-tool mock fixtures (`eval/fixtures/mcp/place-search-*`, `place-external-links-*`) are updated to the new contracts — `place_search` responses use the `standardPlace`-shaped `SimplifiedPlaceResult`, and the canonical `args` are `placeName` (this also fixes a pre-existing eval bug where the fixtures assumed the real param was `query`).

**Remaining (eval-team):** the runlog **re-record + re-grade** — the `plugin/skills/**` and `mcp-server/src/**` changes invalidate the snapshot of every touched skill's runlog, so the check-runlogs action will require a re-record regardless of the fixture edits. Also out of scope here: the `image_search` fixtures (their `placeId` predicate is stale from the separate `image_search`→`imageGroupNumber` migration) and enriching `record`/`person` fixture facts with `standard_place` to mirror the converter output. Tracked in the plan doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
