### PR TITLE
docs: hosted web genealogy workbench spec (POC)

### DIFF
--- a/docs/plan/hosted-web-workbench-implementation-plan.md
+++ b/docs/plan/hosted-web-workbench-implementation-plan.md
@@ -1,0 +1,200 @@
+# Hosted Genealogy Workbench — Implementation Plan (POC / Alpha)
+
+**Audience:** the dev team. **Read with:** `hosted-web-workbench-spec.md` (system
+spec; §0.5 is the POC scope) and `sandbox-provider-interface.md` (sandbox layer).
+**Date:** 2026-06-05.
+
+This plan turns the spec into an ordered, task-level build for the alpha POC.
+Each milestone lists **goal → tasks → acceptance criteria → packages touched**.
+Milestones are sequenced so something runnable exists early and risk is front-loaded.
+
+---
+
+## A. POC scope recap (what we are building)
+
+A single web app — **a project viewer with a chat sidebar** — for a handful of
+allowlisted alpha users (no living-person data; PII work deferred). Landing screen
+is a **session list**; each session is a hibernated **E2B microVM** holding one
+Agent SDK session + one project. The user picks a session (resume) or starts a new
+one (create + conversational `init-project`). The agent = the **existing 28 skills
++ 30-tool stdio MCP server**, run under the **Claude Agent SDK inside the sandbox**.
+Everything except the sandboxes runs on **Dallan's local server**, exposed via
+**Tailscale Funnel**.
+
+**`session == project == sandbox`, 1:1.** Many sessions per user.
+
+---
+
+## B. Tech stack & conventions
+
+| Layer | Choice |
+|---|---|
+| Monorepo | pnpm workspaces + turborepo |
+| Shared UI | `packages/viewer-ui` (React 19, the extracted renderer) |
+| Web app | `apps/web` (React 19 + Vite) |
+| Electron | `apps/electron` (existing app, consumes `viewer-ui`) |
+| Control plane | `apps/server` — **FastAPI (Python)** |
+| Agent runtime | `agent_runner.py` (Python Agent SDK) inside the E2B sandbox |
+| DB | **SQLite** (local file) via SQLModel/SQLAlchemy |
+| Sandbox SDK | `e2b` Python SDK (`AsyncSandbox`) behind `SandboxProvider` (E2BProvider only for POC) |
+| Auth | Google OIDC (app access) + per-user FamilySearch OAuth (data access) |
+| Transport | Browser ↔ server **WebSocket** (chat + viewer deltas) + HTTP (REST) |
+| Ingress | Tailscale Funnel (public HTTPS) |
+
+Casing: web/wire = camelCase; persisted research.json/tree.gedcomx = snake_case
+(unchanged from the engine).
+
+---
+
+## C. Environment / secrets / config (provision before M2)
+
+- `E2B_API_KEY` (+ `E2B_DOMAIN` if self-host later) — control plane.
+- `ANTHROPIC_API_KEY` (operator) — injected into each sandbox; `MODEL` per-session
+  (`claude-sonnet-4-6` / `claude-opus-4-8`).
+- Google OAuth client id/secret + redirect `https://<funnel>/auth/google/callback`.
+- FamilySearch: bundled client id; **add redirect `https://<funnel>/familysearch/callback`**
+  to the FS app; confirm dev-key allows external alpha users + web flow.
+- `ALLOWED_EMAILS` seed (allowlist).
+- Tailscale Funnel enabled for: the control plane (443) **and** the two sidecar
+  endpoints (`/wiki`, `/pop-stats`).
+- Sandbox image carries: Node + Python + `claude-agent-sdk`, the genealogy MCP
+  `build/`, the 28 `.claude/skills/`, `agent_runner.py`, and the pre-crawled wiki
+  markdown corpus (for `wiki_read`/`wiki_place_page`).
+
+---
+
+## D. Key contracts (freeze these early; everything else codes against them)
+
+**1. `ResearchTransport`** (shared by Electron + web) — see spec §4.1.
+**2. `SandboxProvider` / `Sandbox` / `Process`** — see `sandbox-provider-interface.md` §4.
+**3. Browser ↔ server WebSocket** (per active session) — see spec §6.2:
+```
+client → server : {type:"user_msg", text} | {type:"interrupt"}
+server → client : {type:"agent_event", event}            # streamed Agent SDK output
+                  {type:"research_updated", data}         # from E2B files.watch_dir
+                  {type:"gedcomx_updated", data}
+                  {type:"sidecar_updated", logId, mtime}
+                  {type:"status", state}                  # starting|ready|suspended|error
+                  {type:"auth_required", provider:"familysearch"}
+```
+**4. SQLite tables:** `users`, `allowed_emails`, `familysearch_tokens`,
+`projects(id,user_id,sandbox_id,agent_session_id,title,created,updated,last_active)`,
+optional `usage`. (FS token may also live only on the sandbox FS per §0.5; keep a
+DB copy if you want central refresh — decide in M4.)
+
+---
+
+## Milestone 0 — Monorepo bootstrap
+**Goal:** one repo, both existing artifacts still build.
+**Tasks:**
+- Create pnpm/turborepo monorepo; move `mcp-server` + `plugin` into
+  `packages/engine`; keep `scripts/build-mcpb.sh` + `scripts/package-plugin.sh`
+  working (they still produce `genealogy-mcp.mcpb` + `genealogy-plugin.zip`).
+- Move the Electron app in as `apps/electron`.
+- Add empty `packages/viewer-ui`, `packages/schema`, `apps/web`, `apps/server`.
+**Acceptance:** `.mcpb` + plugin `.zip` still build; Electron app still runs; CI
+(`tests/packaging/*`) green.
+**Packages:** all (scaffolding).
+
+## Milestone 1 — Extract `viewer-ui` (transport-agnostic)
+**Goal:** the renderer runs in Electron via an injected transport (no behavior change).
+**Tasks:**
+- Move renderer (`App`, 11 sections, shared components, `lib/*`) into
+  `packages/viewer-ui`; move research/GedcomX TS types into `packages/schema`.
+- Define `ResearchTransport` (contract D.1). Refactor `ResearchDataProvider` to take
+  a transport prop instead of calling `window.api` directly.
+- `apps/electron`: implement `IpcResearchTransport` wrapping the existing
+  `window.api`; render `viewer-ui`. Keep `main/`, `preload/`, watcher, sidecar,
+  feedback as-is.
+**Acceptance:** Electron app behaves identically to today, but its UI is the shared
+package. A `ResearchTransport` contract test passes against the IPC adapter.
+**Packages:** `viewer-ui`, `schema`, `apps/electron`.
+
+## Milestone 2 — Control-plane skeleton + auth + session list
+**Goal:** a user can log in (Google + allowlist) and see/create sessions (no agent yet).
+**Tasks:**
+- FastAPI app; SQLite (contract D.4); Tailscale Funnel ingress.
+- Google OIDC login + allowlist check → signed session cookie.
+- `SandboxProvider` → **`E2BProvider`** (implement `create/get/resume/suspend/
+  delete/list` + `Sandbox.read_file/write_file/list_dir/exec/start_process/
+  expose_port` per the interface doc, E2B side only).
+- Build the **sandbox image** (E2B template) per §C.
+- REST: `GET /api/sessions` (list `projects`), `POST /api/sessions` (create sandbox
+  + project row), `POST /api/sessions/{id}/resume`, `DELETE`.
+- `apps/web` shell: Google login screen → **session list** landing → "new"/"open".
+**Acceptance:** login gated by allowlist; create a session → a real E2B sandbox
+exists; list/resume/delete work; suspend on disconnect.
+**Packages:** `apps/server`, `apps/web`.
+
+## Milestone 3 — Viewer path (read-only, live)
+**Goal:** opening a session shows its live project state and updates in real time —
+**no chat yet.**
+**Tasks:**
+- On resume: control plane reads `/project` from the sandbox (`files.read`/`list`),
+  sends a snapshot; subscribe via **E2B `files.watch_dir("/project")`** and push
+  `research_updated`/`gedcomx_updated`/`sidecar_updated` over the browser WS.
+- `apps/web`: implement `WsResearchTransport` (contract D.1 over the WS + REST);
+  mount `viewer-ui`.
+- Seed a sandbox with a sample `research.json`/`tree.gedcomx.json` to verify
+  rendering end-to-end.
+**Acceptance:** the web viewer renders the same sections as Electron from a live
+sandbox; editing a file in the sandbox updates the web UI within ~1s. Same
+`ResearchTransport` contract test passes against the WS adapter.
+**Packages:** `apps/server`, `apps/web`, `viewer-ui`.
+
+## Milestone 4 — Agent path (chat + FamilySearch) ← highest risk, do carefully
+**Goal:** a full research session: connect FamilySearch, chat, tools run, files update.
+**Tasks:**
+- `agent_runner.py`: Agent SDK (`ClaudeSDKClient`) loading `.claude/skills` +
+  the stdio MCP server; WS server on a port; `resume=session_id`; streams
+  `agent_event`s. (Spec §7 / sandbox doc §6.)
+- Control plane: launch `agent_runner` via `start_process`, get its address via
+  `expose_port`, and **proxy** the browser WS ↔ in-sandbox WS for chat; multiplex
+  with the viewer deltas from M3 on the one browser socket.
+- **FamilySearch web OAuth:** `/familysearch/login` + `/familysearch/callback`
+  (reuse PKCE/token-exchange/refresh from `engine/.../auth`; drop the localhost
+  server/`open()`); write tokens to `~/.familysearch-mcp/tokens.json` **inside the
+  sandbox** (option a); emit `auth_required` when not connected.
+- **New session** auto-sends the opening turn → `init-project` runs conversationally.
+- Model config knob (Sonnet/Opus) per session.
+- **Watch the two unverified risks here:** the in-sandbox WS-port round-trip, and
+  pause/resume with a live session (re-launch `agent_runner`, restore via
+  `resume=session_id`). If resume misbehaves, add reconnect/checkpoint handling.
+**Acceptance:** from a clean login: new session → init-project interview → connect
+FamilySearch → run a real `record_search`/`person_read` → assertions appear in the
+viewer live → suspend → resume → continue the same conversation.
+**Packages:** `apps/server` (+ `agent_runner.py`), `engine` (FS web-OAuth), `apps/web` (chat UI).
+
+## Milestone 5 — POC polish
+**Goal:** durable enough + observable enough for alpha.
+**Tasks:**
+- **Local backup dir:** mirror `research.json`/`tree.gedcomx.json`/`results/` to a
+  per-session folder on the server as deltas stream (insurance vs sandbox loss).
+- **Feedback:** read the in-sandbox `~/.claude/.../*.jsonl` + `/project` via
+  `files.read`, bundle (port `feedback.ts` logic); add `POST /api/feedback`.
+- **Sidecars:** verify Funnel reachability for `wiki_search`/`place_population`
+  from inside a sandbox; confirm wiki markdown corpus is in the image.
+- **Cost/idle:** aggressive idle suspend (E2B pause) + optional per-session token
+  budget; log token + sandbox-second usage.
+- **Image proxy:** `GET /api/image/{imageId}` → `image_read` for FamilySearch images.
+- **Observability:** structured logs (no record/tree contents); basic error tracking.
+**Acceptance:** a killed sandbox can be re-hydrated from the backup; feedback zip
+contains the transcript; wiki/place tools work; idle sessions suspend; images render.
+**Packages:** `apps/server`, `apps/web`.
+
+---
+
+## E. Risks / watch-items
+- **WS-port + pause/resume** (M4) — the one genuinely unproven path; surface early
+  in M4, not at the end.
+- **FamilySearch dev-key** limits on external users / web redirect (confirm in C).
+- **Funnel** reachability + throughput for sidecars and per-user browsers (handful
+  of users → fine; don't assume it scales past alpha).
+- **Single copy of project data on E2B** — mitigated by the M5 local backup.
+- **Agent SDK skill/MCP loading inside the image** — verify `setting_sources`/
+  `skills` discovery + the stdio MCP fork work in the sandbox during M4.
+
+## F. Out of scope for the POC
+PII/compliance hardening, cloud/object-store, Postgres, multi-region, collaboration,
+public signup, billing, self-hosted E2B (the FamilySearch endgame). The
+vendor-neutral `SandboxProvider` is kept so that endgame stays cheap later.

--- a/docs/plan/hosted-web-workbench-spec.md
+++ b/docs/plan/hosted-web-workbench-spec.md
@@ -1,0 +1,483 @@
+# Hosted Genealogy Workbench — Developer Spec
+
+**Status:** draft spec for implementation. **Date:** 2026-06-05.
+**Companion docs:** sandbox layer = `docs/plan/sandbox-provider-interface.md`
+(the per-user E2B sandbox abstraction); architecture/decision record = project
+memory `client-server-workbench-direction.md`.
+
+---
+
+## 0. TL;DR of the decisions already made
+
+- **Re-host, don't rewrite.** The hosted product runs the **existing** SKILL.md
+  skills + stdio MCP server under the **Claude Agent SDK**, inside a **per-user
+  E2B microVM** (chosen platform; FamilySearch will require microVM isolation).
+  See `sandbox-provider-interface.md`.
+- **Operator pays** for Claude (our Anthropic key). **Hosted multi-user SaaS.**
+- **Three artifacts ship from one monorepo:** (1) the existing Cowork plugin +
+  `.mcpb` MCP extension (unchanged in purpose), (2) the existing Electron viewer
+  (adapted to share code), (3) the **new** hosted web workbench (chat + viewer).
+- **The viewer is shared code**; the chat is net-new.
+
+---
+
+## 0.5 POC scope (alpha) — decisions & overrides (2026-06-05)
+
+This section records the **alpha/POC** decisions and **overrides** the
+correspondingly-numbered general sections below. The general spec remains the
+"eventual" design; build the POC per this section.
+
+- **Why a POC:** let alpha users who *can't install Claude Cowork* help test the
+  system. Handful of users. **PII deferred** — users are instructed to enter **no
+  living-person data**; §13's residency/retention/compliance work is out of scope
+  for now.
+- **Deployment — everything on Dallan's local server** except the E2B sandboxes:
+  the FastAPI control plane, the web app, and the DB all run locally; the control
+  plane calls E2B (outbound) for per-user sandboxes. The server is exposed via
+  **Tailscale Funnel** (public HTTPS at `https://<machine>.<tailnet>.ts.net`),
+  which is both how alpha users' browsers reach it and the **OAuth redirect
+  target** for Google + FamilySearch. The Funnel URL is registered as an allowed
+  redirect URI on the FamilySearch OAuth client (Dallan controls this) and the
+  Google OAuth client.
+- **Database = SQLite** on the local server (not Postgres yet). Same logical
+  tables as §6.3.
+- **No cloud object store** (overrides §6.4). Project files (`research.json`,
+  `tree.gedcomx.json`, `results/`) live on the **E2B sandbox filesystem** and
+  persist across hibernation (E2B pause snapshots the FS). **Recommended cheap
+  insurance:** the control plane mirrors the small JSON files to a **local backup
+  dir per session** as deltas stream through for the viewer (protects against
+  sandbox loss; risk if skipped = deleted/corrupted sandbox loses that project).
+- **Session-centric model — `session == project == sandbox`, 1:1.** A "session" is
+  a hibernated E2B sandbox holding **one** Agent SDK session and **one** project
+  at `/project`. **Many sessions per user.** App landing screen = a **session list**
+  (from SQLite: user_id, sandbox_id, agent_session_id, title, last_active).
+  Select → resume that sandbox; New → create a sandbox + run `init-project`.
+- **Combined client (overrides the "two-pane" framing in §8):** ONE app = a viewer
+  **with a chat sidebar**. The session list is the landing view. The viewer only
+  ever renders a **live (resumed)** session — never hibernated state, no object
+  store read.
+- **Viewer data path (the "trick"):** on resume, the control plane reads `/project`
+  from the sandbox FS via E2B `files.read`/`files.list` and sends a snapshot to the
+  client; then it streams live updates by watching the sandbox FS with E2B
+  **`files.watch_dir("/project", on_event)`** + `files.read`, pushing
+  `research_updated` / `gedcomx_updated` / `sidecar_updated` over the WS. This
+  viewer path is control-plane↔E2B and is independent of the chat channel.
+- **FamilySearch token (overrides §5.2 option choice):** option **(a)** — the
+  control plane writes the token to `~/.familysearch-mcp/tokens.json` **inside the
+  sandbox** after OAuth (zero MCP code change); the in-sandbox MCP server refreshes
+  it; it persists across hibernation. *Initial* OAuth still needs a hosted/tunneled
+  redirect URI registered with FamilySearch.
+- **Feedback (refines §11):** the control plane reads the in-sandbox Agent SDK
+  transcript (`~/.claude/projects/<…>/*.jsonl`) + `/project` files via E2B
+  `files.read` and bundles them — the existing `feedback.ts` logic, repointed at
+  the sandbox FS.
+- **Sidecars:** `wiki_search`/`place_population` call `malachi.taild68f1b.ts.net`.
+  A `*.ts.net` host is reachable from an E2B sandbox **iff it is exposed via
+  Tailscale Funnel** (public ingress) — *not* if it is a plain private-tailnet
+  MagicDNS name. Action: confirm those two endpoints are Funnel-exposed (expected);
+  then E2B sandboxes reach them with no relocation. Separately, the pre-crawled
+  wiki markdown (`wikiMarkdownDir`) for `wiki_read`/`wiki_place_page` is read from
+  **disk**, so that corpus must be **baked into the sandbox image** (or those two
+  tools disabled for the POC).
+- **Models:** Dallan provides the Anthropic key. Model is a **per-session config
+  knob**; alpha will A/B **Sonnet vs Opus** for cost/performance (Opus ≈ 5× Sonnet
+  token cost — fine for comparison, watch the bill).
+- **New-session onboarding = conversational.** "New session" creates a fresh
+  sandbox with an empty `/project`, starts `agent_runner`, and the client
+  **auto-sends an opening turn** ("start a new genealogy research project") that
+  triggers the existing **`init-project`** skill — researcher-profile interview +
+  FamilySearch-person seeding, in chat, reusing the skill as-is (no new onboarding
+  UI). The session is titled provisionally and renamed once the objective is set.
+
+---
+
+## 1. Goals / non-goals
+
+**Goals**
+- A browser workbench where a whitelisted user logs in (Google), connects their
+  FamilySearch account, and does GPS-conformant research by **chatting with an
+  agent** while a **live project viewer** updates beside the chat.
+- Maximum reuse: the agent = today's skills + MCP server; the viewer = today's
+  Electron renderer; both shared, not forked.
+- Keep shipping the Cowork plugin + `.mcpb` for existing Cowork users.
+
+**Non-goals (v1)**
+- Collaboration / multi-user shared projects, org accounts, billing UI, mobile.
+- Replacing Cowork for existing users (it continues unchanged).
+- Public signup (access is gated to a Gmail allowlist).
+
+---
+
+## 2. The three products and what they share
+
+| Product | Runtime | Status | Shares |
+|---|---|---|---|
+| **Cowork plugin + `.mcpb`** | Claude Cowork VM + host | exists, continues | the **engine** (skills + MCP server) |
+| **Electron viewer** | desktop | exists, adapted | the **viewer-ui** + **schema** packages |
+| **Hosted web workbench** (new) | browser + our cloud + E2B | new | **engine** (server-side) + **viewer-ui** + **schema** |
+
+**The engine (skills + MCP server) is the single source of truth** consumed two
+ways: Cowork loads it as a plugin; the web backend loads it via the Agent SDK
+inside the sandbox. The viewer-ui is consumed two ways: Electron (IPC transport)
+and web (WebSocket transport).
+
+---
+
+## 3. System architecture & topology — *where each piece runs*
+
+> **Important correction to "server deployment on E2B":** E2B hosts the
+> **per-user agent sandboxes only**. E2B is sandbox infrastructure, not a general
+> app host — it cannot run our always-on control plane or serve the web app. The
+> **control plane (FastAPI), web app, database, and object store run on
+> conventional always-on infra** (Fly.io / Render / Cloud Run / a VM). The
+> control plane *calls* E2B to create/resume per-user sandboxes.
+
+```
+                         ┌────────────────────────── our cloud (always-on) ──────────────────────────┐
+  Browser ── HTTPS ────► │  Web app (static)   FastAPI control plane            Postgres   Object store │
+  (React: chat+viewer)   │                     ├─ Google auth + allowlist        (users,     (S3/GCS:    │
+        ▲   │            │                     ├─ FamilySearch OAuth (per-user)   sessions,   per-user   │
+        │   └── WS ──────┼───────────────────► ├─ session/sandbox orchestrator    FS tokens,  project    │
+        │  (chat +       │                     │   (SandboxProvider → E2B)         sandbox     folders)   │
+        │   live deltas) │                     ├─ viewer read API (durable state)  map)                   │
+        │                │                     └─ feedback, sidecar-image proxy                           │
+        │                └───────────────────────────────────┬───────────────────────────────────────────┘
+        │                                                     │ create / resume / suspend / write-secrets / expose-port
+        │                                                     ▼
+        │                                      ┌──────────── E2B (per user) ────────────┐
+        └──────── proxied WS ──────────────────┤ agent_runner.py (Agent SDK, WS server) │
+                                               │   └─ node CLI → node stdio MCP → FamilySearch / sidecars
+                                               │ /project (research.json, tree.gedcomx.json, results/) ──► object store
+                                               └─────────────────────────────────────────┘
+```
+
+**Two decoupled paths (key design rule):**
+- **Read/viewer path** — always available, even when the user's sandbox is
+  suspended. The control plane serves the latest project state from the
+  **object store / DB** (synced out of the sandbox on every change) and pushes
+  live deltas over WS *when a session is active*. Viewing never requires waking
+  a sandbox.
+- **Write/chat path** — requires a **live sandbox**. The control plane
+  resumes/creates the user's sandbox, injects secrets, launches `agent_runner`,
+  and proxies the browser↔sandbox WebSocket.
+
+---
+
+## 4. Monorepo & code-sharing
+
+Bring everything into one monorepo (pnpm + turborepo). The Electron app moves in
+as an app package so it can consume the shared `viewer-ui` (this is what "client
+and electron share code" requires).
+
+```
+/packages
+  /engine       skills (SKILL.md ×28) + MCP server (TS, 30 tools)  ← source of truth for Cowork AND web
+  /schema       research.json + simplified-GedcomX TS types + JSON Schemas (single source; used by
+                viewer-ui, the validate_research_schema tool, and the server)
+  /viewer-ui    the renderer: App, 11 sections, shared components, lib/, ResearchDataProvider —
+                refactored to take a **ResearchTransport** (no direct window.api)
+/apps
+  /cowork-plugin  packages engine skills → genealogy-plugin.zip   (scripts/package-plugin.sh)
+  /mcpb           packages engine MCP server → genealogy-mcp.mcpb (scripts/build-mcpb.sh)
+  /electron       thin shell: injects an **IPC** ResearchTransport (wraps today's window.api + main/preload)
+  /web            React app: chat UI + viewer-ui with a **WebSocket** ResearchTransport
+  /server         FastAPI control plane (Python) + agent_runner.py (ships into the sandbox image)
+```
+
+### 4.1 The shared seam: `ResearchTransport`
+
+Today `ResearchDataProvider` calls `window.api.*` directly. Refactor it to accept
+a transport object so the *same* provider + components run in both apps:
+
+```ts
+interface ResearchTransport {
+  getProjectState(): Promise<{ research: ResearchData | null; gedcomx: GedcomxData | null }>;
+  subscribe(handlers: {
+    onResearch(d: ResearchData): void;
+    onGedcomx(d: GedcomxData): void;
+    onSidecar(e: { logId: string; mtime: number }): void;
+    onError(msg: string): void;
+  }): () => void;                                   // returns unsubscribe
+  readSidecar(logId: string): Promise<{ raw: string; mtime: number } | null>;
+  openExternal(url: string): void;                  // electron: window.api.openExternal; web: window.open
+  submitFeedback(payload: FeedbackPayload): Promise<{ ok: true; filename?: string }>;
+}
+```
+
+- **Electron adapter** wraps the existing `window.api` (no behavior change).
+- **Web adapter** maps `subscribe` → WebSocket messages, `getProjectState`/
+  `readSidecar`/`submitFeedback` → HTTP, `openExternal` → `window.open`.
+- **Electron-only `window.api` methods drop out of the shared interface**:
+  `selectFolder`, `openFile`, `listProjectFiles`, `getSessionLog`, `getVersion`
+  are desktop "open a local folder" concepts. The web app replaces folder
+  selection with **server-side project selection** (§7.4) and a different
+  feedback/session-capture model (§11).
+
+~90% of the renderer (App, 11 sections, shared components, `lib/schema.ts`,
+`progress.ts`, `relationship-label.ts`) moves into `viewer-ui` unchanged.
+
+---
+
+## 5. Authentication & authorization — **two distinct layers**
+
+> **Gap the original list misses:** Google login only controls *app access*. The
+> product also needs **per-user FamilySearch OAuth** for the MCP tools to work at
+> all. These are two separate flows.
+
+### 5.1 App login: Google OAuth + Gmail allowlist (the "simple auth")
+- Google OIDC (Authorization Code + PKCE). On callback, verify the email, check
+  it against an **allowlist** (DB table `allowed_emails`, seedable from env).
+  Non-allowlisted → 403.
+- Issue a signed session (HTTP-only secure cookie or short-lived JWT + refresh).
+- This is the only thing the user's *Google* identity does. It is **not** used by
+  any genealogy tool.
+
+### 5.2 Data auth: per-user FamilySearch OAuth (the big refactor)
+The current MCP auth (`mcp-server/src/auth/`) is **single-user, single-machine**:
+`login.ts` runs a **localhost:1837** callback and writes one
+`~/.familysearch-mcp/tokens.json`; every tool calls `getValidToken()` which reads
+that **one global file** — there is **no per-request/per-env token path**. For
+multi-tenant web this must change:
+
+1. **Web OAuth redirect flow** — replace the localhost callback with a hosted
+   redirect URI (`https://<app>/familysearch/callback`). Reuse the existing PKCE
+   + token-exchange + refresh logic; replace only the transport (no `open()`/
+   localhost server).
+2. **Per-user token storage** — store `{access, refresh, expiresAt}` per user in
+   the DB (encrypted at rest), keyed by user id. Auto-refresh server-side.
+3. **Token injection into the sandbox** — on each session connect, the control
+   plane writes a fresh token into the user's sandbox; `agent_runner` passes it
+   to the MCP server. Two implementation options:
+   - **(a) Minimal:** write `~/.familysearch-mcp/tokens.json` inside the sandbox
+     (matches today's MCP server exactly — zero MCP code change). Simple, works,
+     but couples to the file format.
+   - **(b) Clean:** refactor `getValidToken()` to accept a token from an env var
+     / per-session config the MCP server reads (`FAMILYSEARCH_ACCESS_TOKEN`),
+     and the control plane refreshes centrally. Preferred long-term.
+   Recommendation: ship (a) for v1 speed, plan (b).
+4. **Onboarding gate** — a user who hasn't connected FamilySearch is prompted to
+   before any research tool runs.
+
+---
+
+## 6. The server (FastAPI control plane)
+
+### 6.1 Responsibilities
+- Google auth + allowlist; FamilySearch OAuth redirect + per-user token store.
+- **Session/sandbox orchestration** via the `SandboxProvider` interface
+  (E2BProvider) — create / resume / suspend / write-secrets / expose-port.
+  See `sandbox-provider-interface.md` §6–7 for the exact flow.
+- **WebSocket endpoint** (`/ws/{project_id}`) that (a) proxies chat to/from the
+  in-sandbox `agent_runner`, and (b) streams project-state deltas to the viewer.
+- **Viewer read API** — serve the latest `research.json` / `tree.gedcomx.json` /
+  `results/<logId>.json` from durable storage (so the viewer works while the
+  sandbox is suspended).
+- **Sidecar image proxy** — `image_read` returns FamilySearch image bytes; the
+  browser can't fetch FS directly (CSP/no token). Proxy through the server.
+- Feedback intake (§11); cost controls (§13); observability (§14).
+
+### 6.2 WebSocket protocol (browser ↔ control plane)
+JSON messages. The control plane multiplexes chat (proxied to the sandbox) and
+viewer deltas (from sync) over one socket:
+```
+client → server:  {type:"user_msg", text}            {type:"interrupt"}
+server → client:  {type:"agent_event", event}        # streamed Agent SDK messages/tool-calls/thinking
+                  {type:"research_updated", data}     # full or patch of research.json
+                  {type:"gedcomx_updated", data}
+                  {type:"sidecar_updated", logId, mtime}
+                  {type:"status", state}              # sandbox: starting|ready|suspended|error
+                  {type:"auth_required", provider:"familysearch"}
+```
+
+### 6.3 Database (Postgres) — minimum tables
+- `users` (id, google_sub, email, created)
+- `allowed_emails` (email) — the allowlist
+- `familysearch_tokens` (user_id, access_enc, refresh_enc, expires_at)
+- `projects` (id, user_id, sandbox_id, agent_session_id, objstore_prefix,
+  title, created, updated, last_active) — **the user→sandbox map + project list**
+- `sessions` (app login sessions) — or stateless JWT
+- (optional) `usage` (user_id, tokens, sandbox_seconds) for cost controls
+
+### 6.4 Durable project storage (object store)
+- One prefix per project (`projects/<project_id>/`) holding `research.json`,
+  `tree.gedcomx.json`, `results/<logId>.json`.
+- `agent_runner` syncs the sandbox `/project` → object store on every change
+  (decision #5 in the sandbox doc). The control plane reads from here for the
+  viewer and can re-hydrate a fresh sandbox from it.
+
+---
+
+## 7. The agent runtime (inside the E2B sandbox)
+
+Per `sandbox-provider-interface.md`. Key points for this spec:
+- `agent_runner.py` runs the **Agent SDK**, loading the project's `.claude/skills`
+  (the 28 skills) via `setting_sources=["project"], skills="all"`, and the
+  genealogy **stdio MCP server** via `mcp_servers={genealogy: {command:"node",
+  args:[build/index.js], env:{FAMILYSEARCH_ACCESS_TOKEN…}}}`.
+- It exposes a WS server on a port; the control plane reaches it via E2B
+  `get_host(port)` and proxies the browser socket.
+- It restores conversation context with the Agent SDK's `resume=session_id`
+  (we never depend on microVM memory snapshots).
+- After each turn it pushes file deltas over WS **and** syncs `/project` to the
+  object store.
+
+### 7.1 Sandbox image (`apps/server` build target)
+A template/image bundling: Node + Python + `claude-agent-sdk`, the genealogy MCP
+`build/`, the 28 `.claude/skills/`, `agent_runner.py`. Built via E2B template
+(`e2b.Dockerfile`). The engine package supplies the skills + MCP build at image
+build time.
+
+---
+
+## 8. The web client
+
+- **Layout:** two panes — **chat** (left, net-new) + **viewer** (right, shared
+  `viewer-ui`). Plus the existing Sidebar/section nav and SidecarPanel.
+- **Chat UI (net-new — neither repo has one):** message thread, streaming
+  assistant output, tool-call/skill-invocation/progress rendering, interrupt,
+  "connect FamilySearch" and "create project" affordances, the researcher-profile
+  onboarding (§7.4 below). Renders the `agent_event` stream.
+- **Viewer:** `viewer-ui` with the **WebSocket ResearchTransport**. Reads initial
+  state from the read API, then live deltas over WS. Identical components to
+  Electron.
+- **Project selection** replaces "open folder": a project list (from `projects`)
+  + "new project" flow.
+- **Images:** display via the server's image proxy.
+
+---
+
+## 9. The Electron app (adapted)
+
+- Renderer is replaced by an import of `viewer-ui` + an **IPC ResearchTransport**
+  that wraps today's `window.api`. `main/`, `preload/`, watcher, sidecar reader,
+  feedback bundling stay as-is.
+- Net effect: the Electron app keeps working exactly as today, but its UI now
+  comes from the shared package, so any viewer improvement lands in both. No chat
+  in Electron (it remains the Cowork companion viewer).
+
+---
+
+## 10. Continued Cowork plugin + MCP `.mcpb`
+
+- Unchanged in purpose. Built from `packages/engine` via the existing
+  `scripts/build-mcpb.sh` (→ `genealogy-mcp.mcpb`) and `scripts/package-plugin.sh`
+  (→ `genealogy-plugin.zip`). The packaging drift tests
+  (`tests/packaging/*.test.ts`) continue to guard manifest/skill sync.
+- The web product reuses this same engine; do **not** fork the skills or tools.
+
+---
+
+## 11. Data model, feedback, migration
+
+- `research.json` sections (current): `project, researcher_profile, questions,
+  plans, log, sources, assertions, person_evidence, conflicts, hypotheses,
+  timelines, proof_summaries, evaluations`. `tree.gedcomx.json`: `persons,
+  relationships, sources`. `results/<logId>.json` sidecars. The `schema` package
+  is the single TS-types + JSON-Schema source for all consumers.
+- **Schema versioning:** stamp a `schema_version`; the web/electron/cowork
+  consumers and `validate_research_schema` must tolerate version skew (the schema
+  package owns migration helpers).
+- **Feedback:** the Electron flow bundles the local `~/.claude` session log; in
+  the web app there is no local Claude session — the "session log" is the agent
+  transcript held server-side / in the sandbox. Spec a web feedback endpoint that
+  captures the server-side transcript + project files instead.
+
+---
+
+## 12. Sidecar services — productionize (currently broken for hosting)
+
+> **Gap:** `wiki_search` and `place_population` call
+> `https://malachi.taild68f1b.ts.net/...` — a **personal Tailscale domain**, not
+> production. In a hosted product these two tools fail for end users.
+
+Action: host `wiki-query-api` and the Pop-Stats API on production infra and point
+`wikiApiUrl` / `popStatsUrl` at them (per-deployment config, not per-user).
+`wiki_read`/`wiki_place_page` also read **pre-crawled markdown from disk**
+(`wikiMarkdownDir`) — that corpus must be baked into the sandbox image or served.
+
+---
+
+## 13. Security, PII, cost
+
+- **Isolation:** one E2B microVM per user (own guest kernel) — the reason E2B was
+  chosen. One sandbox = one tenant; never share.
+- **Secrets:** operator Anthropic key + per-user FS token are written into the
+  sandbox as a secrets file on connect (not build-time env); never surfaced to
+  the browser; rotate FS tokens via central refresh. Keep the Anthropic key out
+  of user-readable space where feasible.
+- **`validate_research_schema` path-traversal:** the tool takes a user-influenced
+  `projectPath` and reads files — in multi-tenant it must be constrained to the
+  user's project dir (no `..`/absolute escapes).
+- **Data residency / retention (family PII):** confirm E2B's compliance posture
+  for the **interim managed** phase (SOC2/HIPAA/DPA — currently unverified via
+  `trust.e2b.dev`); the **self-hosted-E2B endgame** removes third-party custody.
+  Publish a privacy policy; support project deletion (sandbox kill + object-store
+  purge + token revoke).
+- **Cost controls (operator-pays):** per-user token budgets + sandbox-second
+  budgets; aggressive **idle suspension** (E2B pause) and auto-archive; rate
+  limits; the allowlist already caps the blast radius for v1.
+
+---
+
+## 14. Observability, testing
+
+- **Logging:** structured logs **without PII** (never log research/tree contents
+  or FS records). Error tracking (Sentry-style) with PII scrubbing.
+- **Testing:** keep the engine's existing eval harness (`eval/`) + packaging
+  drift tests. Add: control-plane unit/integration tests, a transport-contract
+  test shared by both ResearchTransport adapters, and an end-to-end
+  "create→chat→file-delta→suspend→resume" test against a real E2B sandbox.
+
+---
+
+## 15. Suggested phasing
+
+1. **Monorepo + `viewer-ui` extraction** (transport-agnostic) — Electron keeps
+   working via the IPC adapter. (Lowest risk, unblocks sharing.)
+2. **Control plane skeleton:** Google auth + allowlist, project/DB, E2BProvider,
+   WS, read API, viewer over WS (read-only web viewer, no chat yet).
+3. **Agent path:** `agent_runner` + sandbox image + FamilySearch web OAuth +
+   token injection + chat UI → first end-to-end research session.
+4. **Productionize:** sidecar services, image proxy, cost controls, feedback,
+   privacy/retention, observability.
+5. **Harden / endgame:** E2B compliance verification; later, self-hosted E2B for
+   FamilySearch.
+
+---
+
+## 16. Decisions — RESOLVED for the POC (see §0.5)
+- **Many** projects per user; **`session == project == sandbox`, 1:1**.
+- **PII deferred** — POC only, users instructed to enter no living-person data;
+  residency/retention/compliance out of scope for now.
+- FamilySearch token injection = **(a) file on the sandbox FS** (no MCP change).
+- Control plane hosted on **Dallan's local server, exposed via Tailscale Funnel**.
+- Onboarding = **conversational** (`init-project` skill), not a custom form.
+- **Still to confirm (not blocking):** FamilySearch dev-key supports the web
+  redirect flow + a handful of external alpha users; Funnel is enabled for the two
+  sidecar endpoints.
+
+---
+
+## 17. What the original list was missing (read this)
+1. **Per-user FamilySearch OAuth** (web redirect + per-user token store + sandbox
+   injection) — Google login ≠ FamilySearch auth; the product is inert without it.
+2. **The control plane is NOT on E2B** — E2B runs per-user sandboxes; the
+   always-on FastAPI/web/DB/object-store run on conventional infra.
+3. **Per-user durable storage + a database** (object store for project files;
+   Postgres for users/allowlist/tokens/sandbox-map/projects).
+4. **Decouple viewer reads from the sandbox** — viewer serves from durable
+   storage so it works while the sandbox is suspended.
+5. **The chat UI is net-new** (streaming, tool/skill progress, interrupt,
+   onboarding) — neither repo has one.
+6. **MCP per-session token refactor** (today: one global token file, no per-request
+   path).
+7. **Sidecar services productionization** (`.ts.net` → prod) + the pre-crawled
+   wiki markdown corpus.
+8. **Operator-pays cost controls** (token + sandbox-second budgets, idle suspend).
+9. **Secrets handling & rotation**; **`validate_research_schema` path-traversal**.
+10. **Data residency / retention / privacy policy / deletion** for family PII.
+11. **Image proxy** (FamilySearch images to the browser).
+12. **Schema versioning** across web/electron/cowork; **web feedback** model
+    (no local `~/.claude` session log).
+13. **Project/onboarding model** (project creation, researcher profile, FS-person
+    seeding) — `init-project` is a Cowork skill that needs a web equivalent.

--- a/docs/plan/sandbox-provider-interface.md
+++ b/docs/plan/sandbox-provider-interface.md
@@ -1,0 +1,426 @@
+# Sandbox Provider Interface — design + stubs
+
+**Status:** design (not yet implemented). **Scope:** the per-user execution
+sandbox layer for the hosted multi-user "genealogy workbench" (the
+client-server product), kept vendor-neutral across **Daytona** and **E2B**
+(and a future provider) so the partner (FamilySearch) can self-host later.
+
+This is the implementation plan for the sandbox abstraction only. For the
+broader product direction (re-host skills+MCP under the Agent SDK; monorepo +
+transport-agnostic viewer; operator-pays SaaS) see the conversation record /
+project memory.
+
+---
+
+## 1. Why this layer exists (platform decision context)
+
+Multi-user means **one isolated execution sandbox per user** — not just a
+directory — because each session must fork the full agent tree
+(`Python Agent SDK → Node Claude Code CLI → Node stdio MCP server`), reach
+FamilySearch over open egress, hold that user's project folder durably, and
+carry that user's FamilySearch OAuth token. A serverless function / V8 isolate
+that cannot fork subprocesses is disqualified.
+
+The endgame requirement is that **FamilySearch will self-host the whole thing**,
+so the sandbox platform must be self-hostable. That eliminates Fly.io
+(managed-only) as an endgame and narrows the real choice to **Daytona vs E2B**.
+Both are full-Linux, self-hostable, and clear every hard constraint; they
+differ on the axes below.
+
+| Dimension | E2B | Daytona | Winner |
+|---|---|---|---|
+| Isolation primitive (PII) | Firecracker microVM, own guest kernel/tenant | Sysbox container, shared host kernel (+ `Privileged:true`) | **E2B** |
+| Network egress | open by default, no gate | gated behind Tier-3 $500 prepaid top-up | **E2B** |
+| Persistence / resume | pause = FS+memory, indefinite; resume ~1s (bugs #884/#987 closed) | stop/archive + S3 volumes, FS-only; resume-by-id | **E2B** |
+| Self-host license | Apache-2.0 | AGPL-3.0 (copyleft) | **E2B** |
+| Self-host isolation | keeps Firecracker microVM | stays Sysbox shared-kernel | **E2B** |
+| Compliance **documented today** | contested/unverified (DPA/SOC2/HIPAA not on E2B's own pages) | DPA + HIPAA BAA + SOC2 Type I documented | **Daytona** |
+| Ops to self-host | heavier (Nomad+Firecracker+nested-virt, GCP/AWS only) | lighter (Docker-Compose/Nomad) | **Daytona** |
+| subprocess / SDK fit / pricing / scaling | tie (both run the fork-tree, official Claude guides, ~$0.067/hr 1vCPU/1GiB, idle=storage) | tie | — |
+
+**Pivotal open question (decides Daytona vs E2B endgame):** does FamilySearch's
+security review **require hardware/microVM isolation per tenant**, or is
+**hardened shared-kernel (Sysbox) acceptable**? microVM-required → **E2B**;
+shared-kernel-OK → **Daytona** (lighter ops + documented compliance).
+
+**Resolve before committing:** (1) E2B's real SOC2/HIPAA/DPA status via
+`trust.e2b.dev` (governs whether the interim *managed* phase can legally hold
+family PII); (2) the WS-port-exposure recipe for the Agent SDK inside E2B.
+
+Because the choice is genuinely undecided, the rest of this doc defines a
+**provider-neutral interface** so the product is built once and the platform
+stays swappable.
+
+---
+
+## 2. Architecture placement
+
+The per-user **agent runs inside the sandbox**, not on the FastAPI host —
+because the Agent SDK forks its MCP server as a local **stdio** child, the whole
+tree must live together with the project folder, the FamilySearch token, and
+egress. FastAPI is a thin **control plane + WebSocket proxy** in front of N
+sandboxes.
+
+```
+Browser ──WS──► FastAPI orchestrator ──(SandboxProvider)──► Sandbox[user]
+                  │  create/resume/suspend                   ├─ agent_runner.py (Python Agent SDK, WS server)
+                  │  write secrets file                      │    └─ node CLI → node stdio MCP → FamilySearch
+                  │  expose_port → proxy WS ◄──in-sbx WS──────┤
+                  └─ session_id ↔ sandbox_id (DB)            └─ /project (research.json, tree.gedcomx.json, results/)
+                                                                  └─ object-store sync (S3/GCS)
+```
+
+---
+
+## 3. Design decisions baked into the interface
+
+1. **Resume = filesystem only, never memory.** Daytona stop/archive preserves
+   FS but kills the process; E2B pause snapshots memory too. The portable
+   contract is the weaker one: `SUSPENDED` preserves only the project folder;
+   on resume the orchestrator **re-launches `agent_runner`**, which restores
+   conversation via the Agent SDK's own `resume=session_id`. Works identically
+   on both and on any future provider; never depends on a memory snapshot.
+2. **Per-user secrets go in a file, written on every (re)connect** — not
+   create-time env. Neither SDK can mutate env on a running/resumed sandbox,
+   and FamilySearch tokens rotate. `write_file("/run/secrets/session.json", …)`
+   each connect; `agent_runner` reads creds per turn.
+3. **Streaming via an exposed in-sandbox port**, not stdio piping. `agent_runner`
+   runs a tiny WS server inside the sandbox; the orchestrator gets its address
+   via `expose_port()` (Daytona `get_preview_link` / E2B `get_host`) and proxies
+   the browser WS to it.
+4. **Project-file change events come from the agent**, not sandbox file-watch
+   (Daytona has none). `agent_runner` knows when it writes `research.json` /
+   `tree.gedcomx.json` and pushes deltas over the same WS.
+5. **Object-store sync runs inside the sandbox** (it has the files + egress),
+   giving durability independent of any vendor's snapshot subsystem.
+
+---
+
+## 4. The interface — `sandbox/base.py`
+
+Six control-plane + six sandbox methods. Deliberately minimal so Daytona, E2B,
+and a future Fly/raw-Firecracker/self-hosted provider all implement the same
+contract.
+
+```python
+from __future__ import annotations
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import AsyncIterator, Protocol, runtime_checkable
+
+
+class SandboxState(str, Enum):
+    RUNNING = "running"
+    SUSPENDED = "suspended"   # FS preserved, process gone (Daytona stop/archive | E2B pause)
+    MISSING = "missing"       # not found / deleted
+
+
+@dataclass(frozen=True)
+class Resources:
+    cpu: int = 1              # vCPUs   — honored by Daytona (image path); on E2B comes from the
+    memory_gb: int = 2        #            template, so advisory there (see E2BProvider docstring)
+    disk_gb: int = 5
+
+
+@dataclass(frozen=True)
+class SandboxSpec:
+    template: str                                          # Daytona snapshot/image | E2B template id
+    env: dict[str, str] = field(default_factory=dict)      # boot-time, NON-secret only (decision #2)
+    labels: dict[str, str] = field(default_factory=dict)   # Daytona labels | E2B metadata (user_id, etc.)
+    resources: Resources | None = None
+    auto_suspend_seconds: int = 900                        # idle → suspend
+    persistent: bool = True                                # False → ephemeral (delete on stop)
+
+
+@dataclass(frozen=True)
+class ConnectURL:
+    url: str                                               # reach an in-sandbox server port
+    headers: dict[str, str] = field(default_factory=dict)  # auth header(s), provider-specific
+
+
+@dataclass(frozen=True)
+class ExecResult:
+    exit_code: int
+    stdout: str
+    stderr: str
+
+
+@dataclass(frozen=True)
+class DirEntry:
+    name: str
+    path: str
+    is_dir: bool
+
+
+@runtime_checkable
+class Process(Protocol):
+    """A long-lived process inside the sandbox (the per-user agent_runner)."""
+    @property
+    def pid(self) -> str: ...
+    def stdout(self) -> AsyncIterator[bytes]: ...
+    def stderr(self) -> AsyncIterator[bytes]: ...
+    async def write_stdin(self, data: bytes) -> None: ...
+    async def wait(self) -> int: ...
+    async def kill(self) -> None: ...
+
+
+@runtime_checkable
+class Sandbox(Protocol):
+    @property
+    def id(self) -> str: ...
+    @property
+    def state(self) -> SandboxState: ...
+
+    # process / exec
+    async def exec(self, cmd: str, *, cwd: str | None = None,
+                   env: dict[str, str] | None = None, timeout: int | None = None) -> ExecResult: ...
+    async def start_process(self, cmd: str, *, cwd: str | None = None,
+                            env: dict[str, str] | None = None) -> Process: ...
+
+    # networking
+    async def expose_port(self, port: int) -> ConnectURL: ...
+
+    # filesystem (secrets file, project-folder I/O, object-store sync)
+    async def read_file(self, path: str) -> bytes: ...
+    async def write_file(self, path: str, data: bytes) -> None: ...
+    async def list_dir(self, path: str) -> list[DirEntry]: ...
+
+
+class SandboxProvider(ABC):
+    """Vendor-neutral control plane. Implemented by DaytonaProvider / E2BProvider / (future) FlyProvider."""
+    @abstractmethod
+    async def create(self, spec: SandboxSpec) -> Sandbox: ...
+    @abstractmethod
+    async def get(self, sandbox_id: str) -> Sandbox: ...        # MISSING state if gone
+    @abstractmethod
+    async def resume(self, sandbox_id: str) -> Sandbox: ...     # suspended → running (FS rewarmed)
+    @abstractmethod
+    async def suspend(self, sandbox_id: str) -> None: ...       # running → suspended (FS preserved)
+    @abstractmethod
+    async def delete(self, sandbox_id: str) -> None: ...
+    @abstractmethod
+    async def list(self, labels: dict[str, str] | None = None) -> list[Sandbox]: ...
+```
+
+---
+
+## 5. Provider mapping (verified SDK calls, 2026)
+
+| Neutral op | Daytona (`AsyncDaytona`) | E2B (`AsyncSandbox`, SDK v2.5.0) |
+|---|---|---|
+| `create(spec)` | `daytona.create(CreateSandboxFromImageParams(image, env_vars, labels, ephemeral, auto_stop_interval=secs//60, resources=Resources(cpu,memory,disk)))` | `AsyncSandbox.create(template, envs, metadata, timeout, allow_internet_access=True)` |
+| `get` / `resume` | `daytona.get(id)` → `sandbox.start()` | `AsyncSandbox.connect(id)` (auto-resumes if paused) |
+| `suspend` | `sandbox.stop()` (or `.archive()` for cheap long idle) | `sandbox.pause()` |
+| `delete` | `sandbox.delete()` | `sandbox.kill()` |
+| `list(labels)` | `daytona.list(ListSandboxesQuery(labels=…))` | `AsyncSandbox.list(SandboxQuery(metadata=…))` |
+| `exec` | `sandbox.process.exec(cmd, cwd, env, timeout)` | `sandbox.commands.run(cmd, envs, cwd, timeout)` |
+| `start_process` | `process.create_session(sid)` → `execute_session_command(sid, SessionExecuteRequest(cmd, run_async=True))` → `.cmd_id` | `commands.run(cmd, background=True, stdin=True, on_stdout=…)` → `CommandHandle` |
+| `Process.write_stdin` | `process.send_session_command_input(sid, cmd_id, data)` | `commands.send_stdin(pid, data)` |
+| `Process.stdout` | `process.get_session_command_logs_async(sid, cmd_id, on_stdout, on_stderr)` | `CommandHandle` iteration / `on_stdout` |
+| `expose_port` | `sandbox.get_preview_link(port)` → `{url, token}`; header `x-daytona-preview-token` | `sandbox.get_host(port)` → `https://{host}` (+ optional `e2b-traffic-access-token`) |
+| `read/write/list` | `fs.download_file` / `fs.upload_file(bytes, path)` / `fs.list_files(path)` | `files.read` / `files.write` / `files.list(path, depth)` |
+| self-host config | `DaytonaConfig(api_url, target, api_key)` | `domain` / `api_url` / `api_key` params |
+
+The long-lived process is where the abstraction earns its keep — both bridge
+into one `asyncio.Queue` exposed as the neutral `Process.stdout`:
+
+```python
+# DaytonaProcess: session command + log callback → queue
+async def start_process(self, cmd, *, cwd=None, env=None) -> Process:
+    sid = f"agent-{uuid4().hex}"
+    await self._sb.process.create_session(sid)
+    resp = await self._sb.process.execute_session_command(
+        sid, SessionExecuteRequest(command=cmd, run_async=True))       # → resp.cmd_id
+    q: asyncio.Queue[bytes | None] = asyncio.Queue()
+    asyncio.create_task(self._sb.process.get_session_command_logs_async(
+        sid, resp.cmd_id, on_stdout=lambda l: q.put_nowait(l.encode()), on_stderr=...))
+    return _DaytonaProcess(self._sb, sid, resp.cmd_id, q)              # write_stdin → send_session_command_input
+
+# E2BProcess: background command handle + on_stdout → queue
+async def start_process(self, cmd, *, cwd=None, env=None) -> Process:
+    q: asyncio.Queue[bytes | None] = asyncio.Queue()
+    handle = await self._sb.commands.run(
+        cmd, background=True, cwd=cwd, envs=env, stdin=True,
+        on_stdout=lambda d: q.put_nowait(d.encode()), on_stderr=...)    # → CommandHandle, handle.pid
+    return _E2BProcess(self._sb, handle, q)                            # write_stdin → commands.send_stdin(pid)
+```
+
+---
+
+## 6. Stub — `agent_runner.py` (runs INSIDE the sandbox)
+
+A tiny WS server that owns one user's agent. Streams chat + project-file deltas
+over a single WS; restores context via the Agent SDK's own session resume; syncs
+the project folder to object storage. **Sketch — verify API names against the
+installed `claude-agent-sdk` version.**
+
+```python
+"""agent_runner.py — one per user sandbox. Listens on :8080.
+
+Protocol (JSON over WS):
+  in : {"type":"user_msg","text": "..."}
+  out: {"type":"agent_event", ...}      # streamed Agent SDK messages/tool calls
+       {"type":"file_delta","file":"research.json","data":{...}}
+"""
+import asyncio, json, pathlib
+import websockets
+from claude_agent_sdk import ClaudeSDKClient, ClaudeAgentOptions
+
+PROJECT_DIR = pathlib.Path("/project")
+SECRETS = pathlib.Path("/run/secrets/session.json")     # written by orchestrator each connect
+MCP_BUILD = "/opt/genealogy-mcp/build/index.js"
+WATCHED = ["research.json", "tree.gedcomx.json"]
+
+def load_creds() -> dict:
+    return json.loads(SECRETS.read_text())              # fs_token, anthropic_key, session_id, objstore_*
+
+def build_options(creds: dict) -> ClaudeAgentOptions:
+    return ClaudeAgentOptions(
+        cwd=str(PROJECT_DIR),
+        resume=creds.get("session_id"),                 # restore prior conversation (decision #1)
+        setting_sources=["project"],                    # load .claude/skills/ from the project
+        skills="all",
+        permission_mode="bypassPermissions",            # operator-controlled, headless
+        env={"ANTHROPIC_API_KEY": creds["anthropic_key"]},
+        mcp_servers={
+            "genealogy": {                              # the existing stdio MCP server, unchanged
+                "command": "node",
+                "args": [MCP_BUILD],
+                # NOTE: the MCP server must accept a per-session FS token via env/config
+                # rather than the global ~/.familysearch-mcp/tokens.json (auth refactor).
+                "env": {"FAMILYSEARCH_ACCESS_TOKEN": creds["fs_token"]},
+            }
+        },
+    )
+
+async def snapshot_files() -> dict:
+    out = {}
+    for name in WATCHED:
+        p = PROJECT_DIR / name
+        out[name] = p.read_text() if p.exists() else None
+    return out
+
+async def handle(ws):
+    creds = load_creds()
+    async with ClaudeSDKClient(options=build_options(creds)) as client:
+        async for raw in ws:
+            msg = json.loads(raw)
+            if msg.get("type") != "user_msg":
+                continue
+            before = await snapshot_files()
+            await client.query(msg["text"])
+            async for event in client.receive_response():
+                await ws.send(json.dumps({"type": "agent_event", "event": _serialize(event)}))
+            after = await snapshot_files()
+            for name, data in after.items():            # decision #4: agent emits file deltas
+                if data != before.get(name):
+                    await ws.send(json.dumps({"type": "file_delta", "file": name, "data": data}))
+            await sync_to_object_store(creds)           # decision #5: durability from inside
+
+async def main():
+    async with websockets.serve(handle, "0.0.0.0", 8080):
+        await asyncio.Future()
+
+# _serialize(), sync_to_object_store() omitted — push PROJECT_DIR to S3/GCS using objstore_* creds.
+if __name__ == "__main__":
+    asyncio.run(main())
+```
+
+---
+
+## 7. Sketch — FastAPI session orchestrator (runs on the always-on host)
+
+`create → inject-secrets → start agent_runner → expose port → proxy WS → suspend
+on idle`. Provider is config-selected (`SANDBOX_PROVIDER=e2b|daytona`); the rest
+is identical. **Sketch.**
+
+```python
+import json, asyncio, websockets
+from fastapi import FastAPI, WebSocket
+from sandbox.base import SandboxProvider, SandboxSpec, SandboxState
+
+app = FastAPI()
+provider: SandboxProvider = make_provider()             # E2BProvider(...) | DaytonaProvider(...)
+AGENT_PORT = 8080
+SPEC = SandboxSpec(template="genealogy-agent:latest", auto_suspend_seconds=900)
+
+async def ensure_sandbox(user_id: str):
+    sandbox_id = await db_lookup_sandbox(user_id)       # user → sandbox_id map
+    if sandbox_id is None:
+        sb = await provider.create(SandboxSpec(**{**SPEC.__dict__, "labels": {"user_id": user_id}}))
+        await db_store_sandbox(user_id, sb.id)
+    else:
+        sb = await provider.get(sandbox_id)
+        if sb.state is SandboxState.SUSPENDED:
+            sb = await provider.resume(sandbox_id)      # FS rewarmed; process re-launched below
+        elif sb.state is SandboxState.MISSING:
+            sb = await provider.create(SPEC); await db_store_sandbox(user_id, sb.id)
+    return sb
+
+@app.websocket("/ws/{user_id}")
+async def session_ws(browser_ws: WebSocket, user_id: str):
+    await browser_ws.accept()
+    sb = await ensure_sandbox(user_id)
+
+    # decision #2: fresh per-user secrets as a file (env can't be mutated on a live sandbox)
+    creds = {
+        "fs_token": await get_fresh_familysearch_token(user_id),
+        "anthropic_key": OPERATOR_ANTHROPIC_KEY,
+        "session_id": await db_lookup_agent_session(user_id),   # None on first run
+        **object_store_creds(user_id),
+    }
+    await sb.write_file("/run/secrets/session.json", json.dumps(creds).encode())
+
+    # (re)launch the in-sandbox agent server (decision #1: never assume it survived suspend)
+    await sb.start_process("python /opt/agent_runner.py")
+    conn = await sb.expose_port(AGENT_PORT)             # ConnectURL{url, headers}
+
+    # proxy browser WS <-> in-sandbox agent WS
+    async with websockets.connect(conn.url.replace("https", "wss"), extra_headers=conn.headers) as agent_ws:
+        await _pump(browser_ws, agent_ws)              # bidirectional until either closes
+
+    await provider.suspend(sb.id)                       # idle → suspend (FS preserved)
+
+async def _pump(a, b):
+    async def fwd(src, dst): 
+        try:
+            while True: await dst.send(await src.receive_text())
+        except Exception: pass
+    await asyncio.gather(fwd(a, b), fwd(b, a))
+```
+
+---
+
+## 8. Documented abstraction leaks (known, bounded)
+
+- **`Resources` is advisory on E2B** — CPU/RAM come from the template; bake sizes
+  into the template. Honored on Daytona's image path.
+- **`auto_suspend` units differ** — Daytona wants minutes (`auto_stop_interval`);
+  adapter converts. E2B uses `timeout` seconds + `set_timeout` to extend.
+- **No env mutation on a running sandbox** on either platform → secrets are
+  file-based (decision #2), not an interface method.
+- **No native whole-directory sync** on either → object-store sync runs inside
+  the sandbox; an orchestrator-side pull would be `exec("tar …")` + `read_file`.
+- **`expose_port` auth differs** (Daytona token header vs E2B optional traffic
+  token) → absorbed into `ConnectURL.headers`, callers stay uniform.
+- **MCP-server token sourcing** — the existing genealogy MCP server reads the FS
+  token from `~/.familysearch-mcp/tokens.json`. For per-session multi-tenancy it
+  must accept the token via env/config (the auth refactor noted in project
+  direction). `agent_runner` injects it via `mcp_servers[...].env`.
+
+---
+
+## 9. Open questions / next steps
+
+1. **Pivotal platform question** → put to FamilySearch security: hardware/microVM
+   isolation required, or hardened shared-kernel (Sysbox) acceptable? Decides
+   E2B vs Daytona endgame.
+2. **Verify E2B compliance** (SOC2/HIPAA/DPA) via `trust.e2b.dev` — governs the
+   interim managed phase for family PII.
+3. **Spike the WS-port pattern** + microVM pause/resume with live FamilySearch
+   sockets + WebSocket re-attach (highest-risk unknown; prototype on E2B).
+4. **Flesh out the two adapters** (`DaytonaProvider`, `E2BProvider`) into runnable
+   modules; add the `agent_runner` object-store sync and the MCP token refactor.
+5. **Build-time:** a sandbox image/template bundling Node + Python + the Agent
+   SDK + the genealogy MCP `build/` + the `.claude/skills/`.


### PR DESCRIPTION
## What this is

Three planning docs (under `docs/plan/`) specifying a hosted multi-user web **genealogy workbench** for alpha testing — a combined **project viewer + chat** client backed by the **existing skills + MCP server** re-hosted under the **Claude Agent SDK** in per-user **E2B microVM** sandboxes. The Cowork plugin + `.mcpb` continue unchanged from the same engine source.

**Docs only — no code changes.**

## Files

- **`hosted-web-workbench-spec.md`** — system spec. Read **§0.5 (POC scope & overrides)** first; §16 = resolved decisions; §17 = gaps the original ask missed.
- **`hosted-web-workbench-implementation-plan.md`** — the dev build order: **Milestones 0–5** (monorepo → transport-agnostic `viewer-ui` → control plane + auth + session list → live viewer path → agent + chat + FamilySearch → polish), each with tasks + acceptance criteria, plus frozen contracts and an env/secrets checklist.
- **`sandbox-provider-interface.md`** — the per-user sandbox abstraction (E2BProvider for the POC; vendor-neutral so the FamilySearch self-host endgame stays cheap).

## Key decisions baked in

- **E2B** chosen for per-user microVM isolation (FamilySearch will require it). Endgame = self-hosted E2B.
- POC runs on **Dallan's local server via Tailscale Funnel** (also the Google + FamilySearch OAuth redirect); **SQLite**; no cloud object store (files live on the sandbox FS + a local backup of the small JSONs).
- **`session == project == sandbox`, 1:1**; landing screen is a **session list** of hibernated sandboxes; viewer updates via E2B `files.watch_dir`.
- **PII deferred** (alpha, no living-person data).

## Out of scope (POC)

PII/compliance hardening, Postgres/object-store, multi-region, collaboration, public signup, billing, self-hosted E2B.

## Non-blocking confirmations still open

- FamilySearch dev-key allows external alpha users + the web redirect flow.
- Tailscale Funnel enabled for the two sidecar endpoints (`wiki_search`, `place_population`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)