### PR TITLE
Add public /v1 REST chat API (bearer auth, sync + SSE)

### DIFF
--- a/apps/server/app/auth.py
+++ b/apps/server/app/auth.py
@@ -9,11 +9,13 @@ Data access (FamilySearch per-user OAuth) lives in familysearch.py.
 """
 from __future__ import annotations
 
+import hmac
 import uuid
 
 from authlib.integrations.starlette_client import OAuth, OAuthError
-from fastapi import APIRouter, Depends, HTTPException, Request, Response
+from fastapi import APIRouter, Depends, HTTPException, Request, Response, Security
 from fastapi.responses import HTMLResponse, RedirectResponse
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from itsdangerous import BadSignature, URLSafeTimedSerializer
 from pydantic import BaseModel
 from sqlmodel import Session, select
@@ -100,6 +102,41 @@ def get_current_user(
     if user is None:
         raise HTTPException(status_code=401, detail="Unknown user")
     return user
+
+
+# ── Public /v1 bearer-key auth ───────────────────────────────────
+_bearer = HTTPBearer(auto_error=False)
+
+
+def get_api_client(
+    creds: HTTPAuthorizationCredentials | None = Security(_bearer),
+    session: Session = Depends(get_session),
+) -> User:
+    """Bearer-key dependency for the public /v1 surface. Resolves the presented
+    key to its configured email (constant-time) and returns the SAME User row
+    the browser path would create for that email.
+
+    Authz note (deliberate): unlike the browser login path, this does NOT gate on
+    the Gmail allowlist. API keys are operator-granted (set in `api_keys` env), so
+    presence in api_key_map IS the grant; the allowlist governs self-service login
+    only. A key can therefore mint a User for an email the allowlist would reject.
+    """
+    if creds is None or (creds.scheme or "").lower() != "bearer" or not creds.credentials:
+        raise HTTPException(
+            status_code=401, detail="Missing bearer token",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+    email: str | None = None
+    for key, mapped in get_settings().api_key_map.items():
+        if hmac.compare_digest(key, creds.credentials):
+            email = mapped
+            break
+    if email is None:
+        raise HTTPException(
+            status_code=401, detail="Invalid API key",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+    return _upsert_user(session, email)
 
 
 # ── endpoints ────────────────────────────────────────────────────

--- a/apps/server/app/config.py
+++ b/apps/server/app/config.py
@@ -64,6 +64,22 @@ class Settings(BaseSettings):
     # Public base URL (Tailscale Funnel in prod) for OAuth redirects.
     public_url: str = "http://localhost:8000"
 
+    # ── Public /v1 REST API (bearer keys for an external chatbot team) ───
+    # Comma-separated `key:email` pairs. Operator-granted: presence here IS the
+    # grant (NOT subject to the Gmail allowlist — see auth.get_api_client). Each
+    # key maps to the same User row its email would create on the browser path,
+    # so ownership (_owned) isolates one client's sessions from another's. Give
+    # each distinct client a distinct email; two keys sharing an email share a
+    # User (and therefore its sessions).
+    api_keys: str = ""
+    # Sync turn cap. A turn that runs longer ends in 504 turn_timeout; streaming
+    # (stream:true) relies on heartbeats instead of a hard cap.
+    v1_turn_timeout_seconds: int = 120
+    # Staleness TTL for the per-session turn lock (Project.turn_locked_at). A lock
+    # older than this is reclaimed by the next caller, so a crashed/killed instance
+    # can't wedge a session forever. Must exceed the longest expected turn.
+    v1_turn_lock_stale_seconds: int = 600
+
     # ── Storage ──────────────────────────────────────────────────
     # LocalProvider per-session sandbox dirs + the SQLite DB live here.
     # (Feedback goes to Google Drive; no other local-disk writes.)
@@ -79,6 +95,20 @@ class Settings(BaseSettings):
     @property
     def allowlist(self) -> set[str]:
         return {e.strip().lower() for e in self.allowed_emails.split(",") if e.strip()}
+
+    @property
+    def api_key_map(self) -> dict[str, str]:
+        """Parse `api_keys` into {key: email}. Malformed pairs are skipped."""
+        out: dict[str, str] = {}
+        for pair in self.api_keys.split(","):
+            pair = pair.strip()
+            if not pair or ":" not in pair:
+                continue
+            key, email = pair.split(":", 1)
+            key, email = key.strip(), email.strip().lower()
+            if key and email:
+                out[key] = email
+        return out
 
     @property
     def familysearch_client_id(self) -> str | None:

--- a/apps/server/app/main.py
+++ b/apps/server/app/main.py
@@ -11,10 +11,17 @@ from __future__ import annotations
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
+from fastapi.exception_handlers import (
+    http_exception_handler,
+    request_validation_exception_handler,
+)
+from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
+from starlette.exceptions import HTTPException as StarletteHTTPException
 from starlette.middleware.sessions import SessionMiddleware
 
-from . import auth, familysearch, feedback, image_proxy, sessions
+from . import auth, familysearch, feedback, image_proxy, sessions, v1
 from .config import get_settings
 from .db import init_db
 from .obs import setup_logging
@@ -56,6 +63,49 @@ app.include_router(familysearch.router)
 app.include_router(familysearch.callback_router)  # top-level /callback (reuses the FS desktop registration)
 app.include_router(image_proxy.router)
 app.include_router(feedback.router)
+app.include_router(v1.router)
+
+
+# ── /v1 error envelope ───────────────────────────────────────────
+# The public API speaks one shape for every error: {"error":{code,message}}.
+# These must be APP-level (not router-scoped): the 401 is raised inside the bearer
+# dependency and the 422 is FastAPI's RequestValidationError — both fire before/
+# outside a router's handlers. Key on the /v1 path prefix so /api/* shapes are
+# untouched (fall through to FastAPI's defaults).
+_V1_CODE_BY_STATUS = {
+    400: "validation_error", 401: "unauthorized", 403: "forbidden",
+    404: "session_not_found", 409: "session_busy", 422: "validation_error",
+    500: "internal_error", 504: "turn_timeout",
+}
+
+
+@app.exception_handler(StarletteHTTPException)
+async def _v1_http_exception_handler(request, exc: StarletteHTTPException):
+    if not request.url.path.startswith("/v1"):
+        return await http_exception_handler(request, exc)
+    detail = exc.detail
+    if isinstance(detail, dict) and "code" in detail:
+        error = {"code": detail["code"], "message": detail.get("message", "")}
+    else:
+        error = {
+            "code": _V1_CODE_BY_STATUS.get(exc.status_code, "internal_error"),
+            "message": detail if isinstance(detail, str) else "Request failed",
+        }
+    return JSONResponse(
+        status_code=exc.status_code, content={"error": error},
+        headers=getattr(exc, "headers", None),
+    )
+
+
+@app.exception_handler(RequestValidationError)
+async def _v1_validation_exception_handler(request, exc: RequestValidationError):
+    if not request.url.path.startswith("/v1"):
+        return await request_validation_exception_handler(request, exc)
+    errors = exc.errors()
+    message = errors[0].get("msg", "Invalid request") if errors else "Invalid request"
+    return JSONResponse(
+        status_code=422, content={"error": {"code": "validation_error", "message": message}},
+    )
 
 
 @app.get("/api/health")

--- a/apps/server/app/models.py
+++ b/apps/server/app/models.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 
+from sqlalchemy import DateTime
 from sqlmodel import Field, SQLModel
 
 
@@ -50,3 +51,11 @@ class Project(SQLModel, table=True):
     created: datetime = Field(default_factory=utcnow)
     updated: datetime = Field(default_factory=utcnow)
     last_active: datetime = Field(default_factory=utcnow)
+    # Per-session turn lock for the public /v1 API (one turn at a time). Holds the
+    # timestamp of the in-flight turn, NULL when idle. A guarded UPDATE on this
+    # column is the atomic, cross-instance lock (correct on SQLite + Postgres) —
+    # see app/v1.py. tz-aware so it stays correct once the Neon migration applies
+    # the same DateTime(timezone=True) hardening to the other datetime columns.
+    turn_locked_at: datetime | None = Field(
+        default=None, sa_type=DateTime(timezone=True), nullable=True
+    )

--- a/apps/server/app/sessions.py
+++ b/apps/server/app/sessions.py
@@ -72,6 +72,40 @@ def _owned(session: Session, user: User, session_id: str) -> Project:
     return project
 
 
+async def create_project(
+    *,
+    session: Session,
+    provider: SandboxProvider,
+    user: User,
+    title: str | None = None,
+    model: str | None = None,
+    sample: bool = False,
+) -> Project:
+    """Provision a sandbox + record the user→sandbox map. Shared by the browser
+    `create_session` route and the public `/v1` create route."""
+    import uuid
+
+    settings = get_settings()
+    model = model or settings.default_model
+    sandbox = await provider.create(
+        SandboxSpec(template=settings.e2b_template, labels={"user_id": user.id}, model=model)
+    )
+    if sample:
+        await seed_sample_project(sandbox)
+
+    project = Project(
+        id="prj_" + uuid.uuid4().hex[:16],
+        user_id=user.id,
+        sandbox_id=sandbox.id,
+        title=title or ("Sample research project" if sample else "New research session"),
+        model=model,
+    )
+    session.add(project)
+    session.commit()
+    session.refresh(project)
+    return project
+
+
 @router.get("", response_model=list[ProjectOut])
 def list_sessions(
     user: User = Depends(get_current_user), session: Session = Depends(get_session)
@@ -90,26 +124,10 @@ async def create_session(
     session: Session = Depends(get_session),
     provider: SandboxProvider = Depends(get_provider),
 ) -> ProjectOut:
-    import uuid
-
-    settings = get_settings()
-    model = body.model or settings.default_model
-    sandbox = await provider.create(
-        SandboxSpec(template=settings.e2b_template, labels={"user_id": user.id}, model=model)
+    project = await create_project(
+        session=session, provider=provider, user=user,
+        title=body.title, model=body.model, sample=body.sample,
     )
-    if body.sample:
-        await seed_sample_project(sandbox)
-
-    project = Project(
-        id="prj_" + uuid.uuid4().hex[:16],
-        user_id=user.id,
-        sandbox_id=sandbox.id,
-        title=body.title or ("Sample research project" if body.sample else "New research session"),
-        model=model,
-    )
-    session.add(project)
-    session.commit()
-    session.refresh(project)
     return ProjectOut.of(project)
 
 

--- a/apps/server/app/v1.py
+++ b/apps/server/app/v1.py
@@ -1,0 +1,351 @@
+"""Public `/v1` REST chat API for an external chatbot team (bearer-only).
+
+Three endpoints: create a session, send a message (sync JSON or, with stream:true,
+SSE), and delete a session. Lean shapes that hide internal fields.
+
+How a turn is observed
+----------------------
+The realtime re-architecture moved the agent stream INTO the sandbox: the browser
+connects a WebSocket straight to the in-sandbox WS server (app/sandbox_server.py)
+and the control plane is otherwise out of the streaming path. So to "send a message
+and get the reply," this router does what the browser does — it becomes a WS client
+of the sandbox: reuse the `/connect` plumbing (resume + expose_port + mint_token),
+open a socket, send `{type:"user_msg"}`, and read `agent_event` frames until
+`turn_done`, assembling the reply (sync) or relaying it as SSE (stream).
+
+Concurrency (one turn at a time per session)
+--------------------------------------------
+Enforced by a DB-backed lock — a guarded UPDATE on `Project.turn_locked_at`. The DB
+serializes the conditional write, so exactly one caller wins regardless of how many
+control-plane instances are running (the affinity-free property the realtime re-arch
+was built for). Correct on SQLite today and on Postgres after the Neon migration; no
+in-memory/per-instance state. A second concurrent message → 409. A lock older than
+`v1_turn_lock_stale_seconds` is reclaimed, so a crashed instance can't wedge a
+session. On a fresh WS connection the Hub replays its snapshot + transcript history
+before live frames, so we first drain that burst (read until the socket goes idle)
+before sending.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+from datetime import timedelta
+
+import websockets
+from fastapi import APIRouter, Depends, HTTPException
+from fastapi.responses import StreamingResponse
+from pydantic import BaseModel, Field
+from sqlalchemy import update as sa_update
+from sqlmodel import Session
+
+from .auth import get_api_client
+from .config import get_settings
+from .db import get_engine, get_session
+from .models import Project, User, utcnow
+from .sandbox import SandboxProvider
+from .sandbox.base import SANDBOX_WS_PORT
+from .sessions import _owned, create_project, get_provider
+from .ws_token import mint_token
+
+router = APIRouter(prefix="/v1", tags=["public-api"])
+
+# Seconds of silence that marks the end of the in-sandbox snapshot/history replay
+# burst (so we don't read replayed frames as the new turn's reply).
+_DRAIN_IDLE = 0.5
+# SSE heartbeat interval: emit a comment if no frame arrives within this window so
+# proxies don't drop a long-running stream.
+_HEARTBEAT_S = 15.0
+# Retry the in-process connect to the freshly-launched sandbox WS server until it
+# is listening (~5s budget).
+_CONNECT_ATTEMPTS = 50
+_CONNECT_RETRY_S = 0.1
+
+
+class _TurnTimeout(Exception):
+    """Sync turn exceeded v1_turn_timeout_seconds."""
+
+
+# ── request/response models ──────────────────────────────────────
+class SessionOut(BaseModel):
+    session_id: str
+    title: str
+    model: str
+    created_at: object  # datetime; serialized to ISO-8601 by FastAPI
+
+
+class CreateBody(BaseModel):
+    title: str | None = None
+    model: str | None = None
+
+
+class MessageBody(BaseModel):
+    message: str = Field(min_length=1)
+    stream: bool = False
+
+
+# ── turn lock (DB-backed, cross-instance) ────────────────────────
+def _acquire_turn(session: Session, session_id: str):
+    """Atomically claim the per-session turn lock via a guarded UPDATE on the
+    Project row (also bumps last_active in the same write). Returns the lock token
+    (the timestamp set) on success, or None if a non-stale turn already holds it.
+
+    The DB applies the WHERE at write time under its write lock, so this is a true
+    test-and-set — no check-then-act race across instances. Stale locks (older than
+    v1_turn_lock_stale_seconds) are reclaimed."""
+    now = utcnow()
+    stale_before = now - timedelta(seconds=get_settings().v1_turn_lock_stale_seconds)
+    stmt = (
+        sa_update(Project)
+        .where(
+            Project.id == session_id,
+            (Project.turn_locked_at.is_(None)) | (Project.turn_locked_at < stale_before),
+        )
+        .values(turn_locked_at=now, last_active=now)
+        # Skip the Python-side WHERE re-evaluation against loaded objects: SQLite
+        # reads tz-aware columns back naive, which would TypeError against our aware
+        # param. We don't reuse the in-session Project after this, so SQL-only is fine.
+        .execution_options(synchronize_session=False)
+    )
+    result = session.execute(stmt)
+    session.commit()
+    return now if result.rowcount == 1 else None
+
+
+def _release_turn(session_id: str, token) -> None:
+    """Release the lock IFF we still hold it (turn_locked_at == the token we set),
+    so a staleness takeover by another instance isn't clobbered. Uses a fresh DB
+    session — a streaming turn releases after the request-scoped session has closed.
+    If we no longer hold it this is a harmless no-op (the lock self-heals via TTL)."""
+    stmt = (
+        sa_update(Project)
+        .where(Project.id == session_id, Project.turn_locked_at == token)
+        .values(turn_locked_at=None)
+        .execution_options(synchronize_session=False)
+    )
+    with Session(get_engine()) as s:
+        s.execute(stmt)
+        s.commit()
+
+
+# ── in-sandbox WS client ─────────────────────────────────────────
+async def _open_ws(provider: SandboxProvider, sandbox_id: str):
+    """Open a WS to the in-sandbox server, the same way /connect hands the browser
+    a URL: resume → expose_port → mint a handshake token.
+
+    expose_port has just (re)launched the WS server, which may not be listening
+    yet — the browser path connects a moment later over the network, but we connect
+    in-process immediately — so retry the TCP connect briefly until it is up."""
+    sandbox = await provider.resume(sandbox_id)
+    conn = await sandbox.expose_port(SANDBOX_WS_PORT)
+    token = mint_token(sandbox_id)
+    url = f"{conn.url}/?token={token}"
+    # max_size=None: viewer-delta frames (whole research.json) can exceed the 1 MiB
+    # default; we ignore those but must not let one crash the connection.
+    extra = {"additional_headers": conn.headers} if conn.headers else {}
+    last: Exception | None = None
+    for _ in range(_CONNECT_ATTEMPTS):
+        try:
+            return await websockets.connect(url, open_timeout=20, max_size=None, **extra)
+        except OSError as exc:  # server not listening yet (ECONNREFUSED, etc.)
+            last = exc
+            await asyncio.sleep(_CONNECT_RETRY_S)
+    raise last if last is not None else RuntimeError("could not connect to sandbox WS server")
+
+
+def _normalize(raw: str):
+    """Map an in-sandbox frame to a public ('kind', payload) tuple, or None to
+    ignore. kind ∈ {text, tool, error, done}. thinking/status/viewer deltas drop."""
+    try:
+        msg = json.loads(raw)
+    except json.JSONDecodeError:
+        return None
+    if msg.get("type") != "agent_event":
+        return None
+    ev = msg.get("event") or {}
+    kind = ev.get("kind")
+    if kind == "turn_done":
+        return ("done", None)
+    if kind == "text":
+        return ("text", ev.get("text", ""))
+    if kind in ("tool_use", "tool_result"):
+        return ("tool", {"type": kind, "tool": ev.get("tool", ""), "summary": ev.get("summary", "")})
+    if kind == "error":
+        return ("error", ev.get("text", ""))
+    return None
+
+
+async def _drain_replay(ws) -> None:
+    """Consume the snapshot/history replay burst, stopping once the socket has been
+    idle for _DRAIN_IDLE. A cancelled recv leaves any buffered frame for the next
+    recv, so no live-turn frame is lost."""
+    while True:
+        try:
+            await asyncio.wait_for(ws.recv(), timeout=_DRAIN_IDLE)
+        except asyncio.TimeoutError:
+            return
+        except websockets.ConnectionClosed:
+            return
+
+
+# ── sync path ────────────────────────────────────────────────────
+async def _collect_sync(ws, message: str, timeout_s: int) -> dict:
+    await _drain_replay(ws)
+    await ws.send(json.dumps({"type": "user_msg", "text": message}))
+    deadline = time.monotonic() + timeout_s
+    text_parts: list[str] = []
+    tool_calls: list[dict] = []
+    finish, error = "stop", None
+    while True:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise _TurnTimeout()
+        try:
+            raw = await asyncio.wait_for(ws.recv(), timeout=remaining)
+        except asyncio.TimeoutError:
+            raise _TurnTimeout()
+        ev = _normalize(raw)
+        if ev is None:
+            continue
+        kind, payload = ev
+        if kind == "done":
+            break
+        if kind == "text":
+            text_parts.append(payload)
+        elif kind == "tool":
+            tool_calls.append({"tool": payload["tool"], "summary": payload["summary"]})
+        elif kind == "error":
+            finish, error = "error", payload
+    return {"text": "".join(text_parts), "tool_calls": tool_calls,
+            "finish_reason": finish, "error": error}
+
+
+async def _handle_sync(provider, sandbox_id: str, message: str, session_id: str, token):
+    try:
+        ws = await _open_ws(provider, sandbox_id)
+        try:
+            result = await _collect_sync(ws, message, get_settings().v1_turn_timeout_seconds)
+        finally:
+            await ws.close()
+    except _TurnTimeout:
+        raise HTTPException(status_code=504, detail={
+            "code": "turn_timeout",
+            "message": "The turn did not complete in time; use stream=true for long turns.",
+        })
+    except HTTPException:
+        raise
+    except Exception as exc:  # noqa: BLE001 — surface as a stable envelope
+        raise HTTPException(status_code=500, detail={"code": "internal_error", "message": str(exc)})
+    finally:
+        _release_turn(session_id, token)
+    resp = {
+        "session_id": session_id, "role": "assistant", "text": result["text"],
+        "tool_calls": result["tool_calls"], "finish_reason": result["finish_reason"],
+    }
+    if result["error"] is not None:
+        resp["error"] = result["error"]
+    return resp
+
+
+# ── stream (SSE) path ────────────────────────────────────────────
+def _sse(event: str, data: dict) -> str:
+    return f"event: {event}\ndata: {json.dumps(data)}\n\n"
+
+
+async def _handle_stream(provider, sandbox_id: str, message: str, session_id: str, token):
+    try:
+        ws = await _open_ws(provider, sandbox_id)
+    except Exception as exc:  # noqa: BLE001
+        _release_turn(session_id, token)
+        raise HTTPException(status_code=500, detail={"code": "internal_error", "message": str(exc)})
+
+    async def gen():
+        text_parts: list[str] = []
+        finish = "stop"
+        try:
+            await _drain_replay(ws)
+            await ws.send(json.dumps({"type": "user_msg", "text": message}))
+            while True:
+                try:
+                    raw = await asyncio.wait_for(ws.recv(), timeout=_HEARTBEAT_S)
+                except asyncio.TimeoutError:
+                    yield ": keep-alive\n\n"
+                    continue
+                except websockets.ConnectionClosed:
+                    break
+                ev = _normalize(raw)
+                if ev is None:
+                    continue
+                kind, payload = ev
+                if kind == "done":
+                    break
+                if kind == "text":
+                    text_parts.append(payload)
+                    yield _sse("delta", {"type": "text", "text": payload})
+                elif kind == "tool":
+                    yield _sse("tool", payload)
+                elif kind == "error":
+                    finish = "error"
+                    yield _sse("error", {"type": "error", "text": payload})
+            yield _sse("done", {
+                "session_id": session_id, "text": "".join(text_parts), "finish_reason": finish,
+            })
+        finally:
+            await ws.close()
+            _release_turn(session_id, token)
+
+    return StreamingResponse(
+        gen(), media_type="text/event-stream",
+        headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
+    )
+
+
+# ── routes ───────────────────────────────────────────────────────
+@router.post("/sessions", status_code=201, response_model=SessionOut)
+async def create_v1_session(
+    body: CreateBody,
+    user: User = Depends(get_api_client),
+    session: Session = Depends(get_session),
+    provider: SandboxProvider = Depends(get_provider),
+) -> SessionOut:
+    project = await create_project(
+        session=session, provider=provider, user=user, title=body.title, model=body.model,
+    )
+    return SessionOut(
+        session_id=project.id, title=project.title, model=project.model, created_at=project.created,
+    )
+
+
+@router.post("/sessions/{session_id}/messages")
+async def send_v1_message(
+    session_id: str,
+    body: MessageBody,
+    user: User = Depends(get_api_client),
+    session: Session = Depends(get_session),
+    provider: SandboxProvider = Depends(get_provider),
+):
+    project = _owned(session, user, session_id)  # ownership/isolation → 404
+    sandbox_id = project.sandbox_id  # capture before the lock write expires the ORM object
+    token = _acquire_turn(session, session_id)
+    if token is None:
+        raise HTTPException(status_code=409, detail={
+            "code": "session_busy",
+            "message": "A turn is already in progress for this session; retry after a short backoff.",
+        })
+    if body.stream:
+        return await _handle_stream(provider, sandbox_id, body.message, session_id, token)
+    return await _handle_sync(provider, sandbox_id, body.message, session_id, token)
+
+
+@router.delete("/sessions/{session_id}")
+async def delete_v1_session(
+    session_id: str,
+    user: User = Depends(get_api_client),
+    session: Session = Depends(get_session),
+    provider: SandboxProvider = Depends(get_provider),
+) -> dict:
+    project = _owned(session, user, session_id)
+    await provider.delete(project.sandbox_id)
+    session.delete(project)  # the turn lock is a column on this row → gone with it
+    session.commit()
+    return {"deleted": True, "session_id": session_id}

--- a/apps/server/tests/conftest.py
+++ b/apps/server/tests/conftest.py
@@ -19,3 +19,8 @@ os.environ["GOOGLE_CLIENT_ID"] = ""          # keep dev-login enabled in tests
 os.environ["GOOGLE_CLIENT_SECRET"] = ""
 os.environ["FAMILYSEARCH_WEB_ENABLED"] = "false"
 os.environ["ANTHROPIC_API_KEY"] = ""         # keep the real key out of test assertions
+
+# Public /v1 bearer keys. `api-bot@…` is deliberately NOT on the allowlist (above)
+# — it proves an operator-granted key mints a User the allowlist would reject.
+# `other-bot@…` is a second client used to test cross-client session isolation.
+os.environ.setdefault("API_KEYS", "sk_test:api-bot@example.com,sk_other:other-bot@example.com")

--- a/apps/server/tests/test_v1_api.py
+++ b/apps/server/tests/test_v1_api.py
@@ -1,0 +1,228 @@
+"""Public /v1 REST API over the real LocalProvider + the in-sandbox WS server +
+the mock agent. Mirrors test_sandbox_server.py: a turn drives a real subprocess
+WS server, no E2B/Anthropic needed.
+
+Keys come from conftest's API_KEYS:
+  sk_test  → api-bot@example.com   (NOT on the allowlist — operator-granted)
+  sk_other → other-bot@example.com (a second client, for isolation)
+"""
+import json
+from datetime import timedelta
+
+from fastapi.testclient import TestClient
+from sqlmodel import Session
+
+from app.db import get_engine
+from app.main import app
+from app.models import Project, utcnow
+
+
+def _set_lock(sid: str, when):
+    """Force Project.turn_locked_at directly in the DB (simulates an in-flight or
+    stale turn held by another instance, without racing a real concurrent turn)."""
+    with Session(get_engine()) as s:
+        p = s.get(Project, sid)
+        p.turn_locked_at = when
+        s.add(p)
+        s.commit()
+
+
+def _seed_active(sid: str):
+    """Pre-write research.json into the sandbox project dir so the mock agent boots
+    straight into 'active' phase (skips the onboarding interview) — then a "search"
+    turn runs the record_search tool. Must be called after create, before the first
+    message (the agent reads phase from the FS when it spawns on first connect).
+    Reaches into LocalProvider internals, same as test_sessions.py."""
+    with Session(get_engine()) as s:
+        sandbox_id = s.get(Project, sid).sandbox_id
+    proj = app.state.provider._root(sandbox_id) / "project"  # LocalProvider
+    proj.mkdir(parents=True, exist_ok=True)
+    (proj / "research.json").write_text('{"project":{"id":"seed"}}')
+
+K = {"Authorization": "Bearer sk_test"}
+K_OTHER = {"Authorization": "Bearer sk_other"}
+
+
+def _create(client, headers=K) -> str:
+    r = client.post("/v1/sessions", json={"title": "t"}, headers=headers)
+    assert r.status_code == 201, r.text
+    body = r.json()
+    assert body["session_id"].startswith("prj_")
+    assert body["title"] == "t" and body["model"] and body["created_at"]
+    # Lean shape: no internal fields leak.
+    assert not (set(body) & {"sandbox_id", "agent_session_id", "status", "sample"})
+    return body["session_id"]
+
+
+# ── auth + error envelope ────────────────────────────────────────
+def test_missing_bearer_is_unauthorized_envelope():
+    with TestClient(app) as client:
+        r = client.post("/v1/sessions", json={})
+        assert r.status_code == 401
+        assert r.json() == {"error": {"code": "unauthorized", "message": "Missing bearer token"}}
+
+
+def test_invalid_key_is_unauthorized():
+    with TestClient(app) as client:
+        r = client.post("/v1/sessions", json={}, headers={"Authorization": "Bearer nope"})
+        assert r.status_code == 401
+        assert r.json()["error"]["code"] == "unauthorized"
+
+
+def test_operator_granted_key_bypasses_allowlist():
+    # api-bot@example.com is NOT allowlisted, yet the key mints it a session.
+    with TestClient(app) as client:
+        sid = _create(client)
+        assert sid
+        client.delete(f"/v1/sessions/{sid}", headers=K)
+
+
+def test_validation_error_envelope():
+    with TestClient(app) as client:
+        r = client.post("/v1/sessions/prj_x/messages", json={}, headers=K)  # missing message
+        assert r.status_code == 422
+        assert r.json()["error"]["code"] == "validation_error"
+
+
+# ── sync turn ────────────────────────────────────────────────────
+def test_sync_message_returns_assembled_reply():
+    with TestClient(app) as client:
+        sid = _create(client)
+        r = client.post(f"/v1/sessions/{sid}/messages",
+                         json={"message": "let's start"}, headers=K)
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["session_id"] == sid
+        assert body["role"] == "assistant"
+        assert body["finish_reason"] == "stop"
+        assert isinstance(body["tool_calls"], list)
+        # First turn of a fresh project → the mock greets.
+        assert "Welcome" in body["text"]
+        client.delete(f"/v1/sessions/{sid}", headers=K)
+
+
+# ── tool-using turn ──────────────────────────────────────────────
+def test_sync_turn_reports_tool_calls():
+    with TestClient(app) as client:
+        sid = _create(client)
+        _seed_active(sid)  # skip onboarding → a search turn runs record_search
+        r = client.post(f"/v1/sessions/{sid}/messages",
+                        json={"message": "search for census records"}, headers=K)
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["finish_reason"] == "stop"
+        # tool_use + tool_result are flattened into tool_calls.
+        assert any(tc["tool"] == "record_search" for tc in body["tool_calls"]), body["tool_calls"]
+        assert "census match" in body["text"]  # trailing text still assembled
+        client.delete(f"/v1/sessions/{sid}", headers=K)
+
+
+def test_stream_emits_tool_event():
+    with TestClient(app) as client:
+        sid = _create(client)
+        _seed_active(sid)
+        r = client.post(f"/v1/sessions/{sid}/messages",
+                        json={"message": "search for census records", "stream": True}, headers=K)
+        assert r.status_code == 200, r.text
+        tool_payloads, saw_done = [], False
+        for block in r.text.split("\n\n"):
+            if block.startswith("event: tool"):
+                tool_payloads.append(json.loads(block.split("data: ", 1)[1]))
+            elif block.startswith("event: done"):
+                saw_done = True
+        assert saw_done, r.text
+        assert any(p.get("tool") == "record_search" for p in tool_payloads), r.text
+        client.delete(f"/v1/sessions/{sid}", headers=K)
+
+
+# ── streaming turn ───────────────────────────────────────────────
+def test_stream_message_done_text_equals_sync():
+    with TestClient(app) as client:
+        sid = _create(client)
+        r = client.post(f"/v1/sessions/{sid}/messages",
+                        json={"message": "let's start", "stream": True}, headers=K)
+        assert r.status_code == 200, r.text
+        assert r.headers["content-type"].startswith("text/event-stream")
+        # Parse SSE: find the terminal `done` event payload.
+        done = None
+        for block in r.text.split("\n\n"):
+            if block.startswith("event: done"):
+                data = block.split("data: ", 1)[1]
+                done = json.loads(data)
+        assert done is not None, r.text
+        assert done["session_id"] == sid
+        assert done["finish_reason"] == "stop"
+        assert "Welcome" in done["text"]
+        client.delete(f"/v1/sessions/{sid}", headers=K)
+
+
+# ── sync timeout ─────────────────────────────────────────────────
+def test_sync_turn_timeout_returns_504(monkeypatch):
+    """A sync turn capped at 0s ends in 504 turn_timeout (no partial text). The
+    agent keeps running in the sandbox; the lock is released so a retry isn't 409'd
+    forever."""
+    from app.config import get_settings
+
+    monkeypatch.setattr(get_settings(), "v1_turn_timeout_seconds", 0)
+    with TestClient(app) as client:
+        sid = _create(client)
+        r = client.post(f"/v1/sessions/{sid}/messages",
+                        json={"message": "let's start"}, headers=K)
+        assert r.status_code == 504, r.text
+        assert r.json()["error"]["code"] == "turn_timeout"
+        client.delete(f"/v1/sessions/{sid}", headers=K)
+
+
+# ── 409 session_busy (DB-backed lock) ────────────────────────────
+def test_concurrent_turn_is_session_busy():
+    with TestClient(app) as client:
+        sid = _create(client)
+        # A fresh (non-stale) lock held by "another instance" → 409.
+        _set_lock(sid, utcnow())
+        r = client.post(f"/v1/sessions/{sid}/messages",
+                        json={"message": "second"}, headers=K)
+        assert r.status_code == 409
+        assert r.json()["error"]["code"] == "session_busy"
+        client.delete(f"/v1/sessions/{sid}", headers=K)
+
+
+def test_stale_lock_is_reclaimed():
+    """A lock older than v1_turn_lock_stale_seconds must not wedge the session — a
+    new turn reclaims it (guards against a crashed instance holding it forever)."""
+    with TestClient(app) as client:
+        sid = _create(client)
+        _set_lock(sid, utcnow() - timedelta(hours=1))  # well past the staleness TTL
+        r = client.post(f"/v1/sessions/{sid}/messages",
+                        json={"message": "let's start"}, headers=K)
+        assert r.status_code == 200, r.text
+        assert "Welcome" in r.json()["text"]
+        client.delete(f"/v1/sessions/{sid}", headers=K)
+
+
+# ── ownership isolation ──────────────────────────────────────────
+def test_another_client_cannot_reach_the_session():
+    with TestClient(app) as client:
+        sid = _create(client, headers=K)  # owned by api-bot
+        # other-bot presents a valid key but does not own the session → 404.
+        r = client.post(f"/v1/sessions/{sid}/messages",
+                        json={"message": "hi"}, headers=K_OTHER)
+        assert r.status_code == 404
+        assert r.json()["error"]["code"] == "session_not_found"
+        client.delete(f"/v1/sessions/{sid}", headers=K)
+
+
+# ── delete ───────────────────────────────────────────────────────
+def test_delete_releases_sandbox_and_404s_after():
+    with TestClient(app) as client:
+        r = client.post("/v1/sessions", json={}, headers=K)
+        sid = r.json()["session_id"]
+        # Drive one turn so the in-sandbox WS server is actually running.
+        client.post(f"/v1/sessions/{sid}/messages", json={"message": "hi"}, headers=K)
+
+        d = client.delete(f"/v1/sessions/{sid}", headers=K)
+        assert d.status_code == 200
+        assert d.json() == {"deleted": True, "session_id": sid}
+
+        # Gone: a follow-up message 404s.
+        r2 = client.post(f"/v1/sessions/{sid}/messages", json={"message": "again"}, headers=K)
+        assert r2.status_code == 404

--- a/docs/plan/public-rest-api.md
+++ b/docs/plan/public-rest-api.md
@@ -1,84 +1,140 @@
 # Plan: Public `/v1` REST chat API for an external chatbot team
 
-> **Status:** Proposed — for review.
-> **Scope:** `apps/server/` only. The engine (`packages/engine/mcp-server/` + `packages/engine/plugin/`) and its
-> `.mcpb`/plugin CI are untouched.
+> **Status:** Implemented in `apps/server/app/v1.py` (+ small hooks in
+> `config.py`, `auth.py`, `sessions.py`, `main.py`). Server-only; the engine
+> (`packages/engine/`) and its `.mcpb`/plugin CI are untouched.
+>
+> **History:** the original proposal targeted a control-plane `LiveSession`
+> with an in-process `_publish` listener fanout over pluggable `realtime`
+> backends. That architecture was removed by the realtime re-architecture
+> (`ably-realtime-migration.md` / `realtime-rearch-status.md`): **the agent
+> stream now lives inside the sandbox** (`app/sandbox_server.py`'s `Hub`), and
+> the browser connects a WebSocket straight to it — the control plane is out of
+> the streaming path. This doc has been rewritten to match what shipped.
 
 ## Context
 
-Another team wants to drive our server from a simple chatbot over plain REST.
-They asked for three things: create a session, send a message and get the reply
-back, and (later) send a message and stream the reply. They do **not** want our
-browser machinery — WebSockets, Ably tokens, subscribe-only channels, viewer
-state, sidecars.
+Another team wanted to drive our server from a simple chatbot over plain REST:
+create a session, send a message and get the reply, and (later) stream the reply.
+They do **not** want our browser machinery (WebSockets, viewer state, sidecars).
 
-The blocker is architectural: today chat is **fire-and-forget**. The browser
-sends `{type:"user_msg"}` over a WebSocket (or `POST /api/sessions/{id}/message`
-→ `202` for the Ably backend), and the agent's reply streams back *out of band*
-as `agent_event` frames over a realtime channel (`apps/server/app/live_session.py`
-→ `realtime.publish`), terminated by `{"kind":"turn_done"}`. **There is no
-synchronous "send and get the reply in the HTTP response" path.** This plan adds
-one cleanly, plus an SSE variant, behind a dedicated, versioned, bearer-auth
-public surface — reusing the existing per-session agent process (and therefore
-its cross-turn memory) untouched.
+The relevant architectural fact: there is no synchronous "send and get the reply
+in the HTTP response" path for the browser, because the agent's reply streams over
+a WebSocket **from inside the sandbox** to the browser; the control plane never
+sees an `agent_event`. So a sync/SSE REST endpoint must observe one turn's stream
+some other way.
 
-Design decisions (confirmed):
+Design decisions (confirmed with the requester):
 - **One message endpoint** with an OpenAI-style `stream` flag (sync → JSON,
   stream → SSE), not two endpoints.
 - **Dedicated `/v1/*` surface** with lean shapes that hide internal fields.
 - **Bearer API keys** (env-configured), not the browser cookie.
+- **Isolated bearer-only sessions, horizontally-scalable control plane:** one turn
+  at a time per session, enforced by a **DB-backed lock** (correct across instances),
+  not in-process state.
 
-## Recommended design (the short version)
+## As-built design (the short version)
 
-The reply isn't in the HTTP response today, so a sync endpoint must *observe one
-turn's agent-event stream and detect `turn_done`*. The clean seam is an
-**in-process listener fanout on `LiveSession`**, added at the single `_publish`
-chokepoint (`LiveSession._publish`). It feeds the existing browser path
-(`realtime.publish`) and a new REST consumer from the same call — and crucially
-**touches none of the realtime backends** (`realtime/base.py`, `local_ws.py`,
-`ably.py`), so the new API works regardless of which backend is deployed. On top
-of that: a per-session **turn lock** for correctness, a thin **`/v1` router**,
-**bearer-key auth** reusing the existing user model, and a shared
-**`create_project(...)`** service so session creation isn't duplicated.
+To "send a message and get the reply," the `/v1` handler **becomes a WebSocket
+client of the sandbox** — it does exactly what the browser does:
+
+1. Reuse the `/connect` plumbing: `provider.resume(sandbox_id)` +
+   `sandbox.expose_port(SANDBOX_WS_PORT)` + `mint_token(sandbox_id)` →
+   a `ws(s)://…/?token=…` URL (Local → `ws://127.0.0.1:port`, E2B → `wss://…e2b.app`).
+2. Open the socket, **drain the snapshot/history replay burst** the `Hub` sends on
+   connect (read until the socket goes idle), then `send({type:"user_msg"})`.
+3. Read `agent_event` frames until `kind:"turn_done"`, assembling the reply (sync)
+   or relaying it as SSE (stream).
+
+This touches none of the in-sandbox protocol and works for both providers (the CP
+already ships the `websockets` client). A per-session **DB-backed turn lock** (a
+guarded `UPDATE` on `Project.turn_locked_at`) gives `409 session_busy` for overlapping
+turns and stays correct across control-plane instances; **ownership** (`_owned`)
+isolates one client's sessions from another's; a **bearer-key dependency** maps a key
+to the same `User` the browser path would create.
+
+### Why the turn lock is in the DB (horizontal scaling)
+
+The control plane runs **N instances** (Fly `count > 1`, AWS-no-sticky), so requests
+for one session land on any instance — an in-memory lock wouldn't be shared. The
+sandbox-as-server re-arch already removed all *other* per-session state from the
+control plane; this lock was the last piece. It lives as one nullable, tz-aware
+column on the `Project` row, claimed by an atomic guarded write:
+
+```sql
+UPDATE projects SET turn_locked_at = :now, last_active = :now
+WHERE id = :sid AND (turn_locked_at IS NULL OR turn_locked_at < :stale_before)
+-- rowcount == 1 → acquired;  rowcount == 0 → 409 session_busy
+```
+
+The DB serializes the conditional write, so exactly one caller wins (a true
+test-and-set, not check-then-act). It is **pooler-safe** (no session-level state —
+Postgres advisory locks would break behind Neon's pooler), **self-heals** via the
+`stale_before` clause (`v1_turn_lock_stale_seconds`, default 600s — a crashed
+instance's lock is reclaimed), and uses only portable SQLModel/SQLAlchemy. It is
+correct on **SQLite today** (SQLite serializes writes globally) and on **Neon
+Postgres later** with zero changes, riding the `neon-postgres-plan.md` migration
+cleanly: `create_all()` auto-adds the column (no Alembic, per that plan's decision),
+and the column is declared `DateTime(timezone=True)` to match the datetime-hardening
+that plan applies to the other columns. Release is a guarded `UPDATE … SET
+turn_locked_at = NULL WHERE turn_locked_at = :token` (only if we still hold it, so a
+staleness takeover isn't clobbered), run on a fresh session since a streaming turn
+releases after the request-scoped session closes.
+
+> The bulk `UPDATE` is issued with `synchronize_session=False`: the comparison must
+> happen in SQL only. SQLite reads a tz-aware column back **naive**, so the default
+> Python-side WHERE re-evaluation against the loaded `Project` would compare naive vs
+> aware and `TypeError`. We capture `sandbox_id` before acquiring and never reuse the
+> in-session object, so SQL-only sync is correct.
+
+**Prerequisite for `count > 1` (not this PR):** the shared-DB migration
+(`neon-postgres-plan.md`) must land first — today's SQLite-on-a-Fly-volume is
+per-machine, so at `count > 1` *all* control-plane state (users, allowlist, sessions,
+ownership) diverges, not just this lock. That plan also calls out moving `init_db()`
+to a one-time Fly `release_command` (two Machines booting otherwise race on
+`create_all` + the allowlist seed). The `LiveSession` pin that plan names as the other
+blocker is already resolved (it's the sandbox-as-server architecture this API builds
+on).
 
 ```
-external client                          our server (apps/server)
-───────────────                          ────────────────────────
-POST /v1/sessions ───────────────────▶  create_project()  →  Project + sandbox
-POST /v1/.../messages {stream?} ─────▶  ┌─ acquire per-session turn lock
-                                         ├─ SessionManager.ensure()  (resume + agent)
-                                         ├─ LiveSession.run_turn():
-   (sync)  ◀── JSON {text,…} ───────────┤    add_listener() BEFORE send_input
-   (stream) ◀── SSE delta…done ─────────┤    yield agent_events until turn_done
-                                         └─ release lock
-                          (browser viewers, if any, keep getting the same frames
-                           via realtime.publish — unchanged)
+external client                          control plane (apps/server)            sandbox (sandbox_server.Hub)
+───────────────                          ──────────────────────────            ───────────────────────────
+POST /v1/sessions ───────────────────▶  create_project() → Project + sandbox
+POST /v1/.../messages {stream?} ─────▶  acquire per-session turn lock (409 if held)
+                                         resume + expose_port + mint_token ──▶  (WS server listening)
+                                         open WS ───────────────────────────▶  replay snapshot+history
+                                         drain replay until idle
+                                         send {user_msg} ───────────────────▶  spawn/feed agent_runner
+   (sync)  ◀── JSON {text,…} ───────────  read agent_event … turn_done  ◀────  broadcast agent_event…turn_done
+   (stream)◀── SSE delta…done ──────────  (same frames, formatted as SSE)
+                                         close WS; release lock
 ```
+
+**Why this is correct on retry without a "drain-owns-the-lock" task:** the in-sandbox
+runner is sequential (it won't read the next `user_msg` until the current turn emits
+`turn_done`). If a sync turn times out (504) and the lock releases, a retry opens a
+*fresh* WS and drains-until-idle — but the prior turn is still emitting frames, so
+there is no idle gap and the drain simply waits the prior turn out before sending.
+The retry therefore never mis-reads the prior turn's trailing frames as its own reply.
 
 ## API contract (`/v1`, bearer-only)
 
 All requests carry `Authorization: Bearer <key>`. All errors use one envelope:
 `{"error": {"code": "...", "message": "..."}}` with stable codes (`unauthorized`
 401, `session_not_found` 404, `session_busy` 409, `validation_error` 422,
-`turn_timeout` 504, `internal_error` 500). Every response echoes `session_id`.
-
-Delivering this envelope for **every** code requires an **app-level** handler, not
-a router-scoped one: `401 unauthorized` is raised inside the bearer dependency and
-`422 validation_error` is FastAPI's `RequestValidationError` — both fire before or
-outside a router's `exception_handlers` and would otherwise return FastAPI's
-default `{"detail": …}`. The handler keys on `request.url.path.startswith("/v1")`
-so `/api/*` error shapes are untouched (see §5).
+`turn_timeout` 504, `internal_error` 500). Delivered by **app-level** handlers
+(`main.py`) keyed on `request.url.path.startswith("/v1")` — a router-scoped handler
+can't catch the dependency-raised 401 or the framework-level 422; `/api/*` shapes
+fall through to FastAPI's defaults.
 
 ### `POST /v1/sessions` → create — `201`
 ```jsonc
-// req
-{ "title": "Cork research", "model": "claude-sonnet-4-6" }   // both optional
-// res 201
+// req  (both optional)
+{ "title": "Cork research", "model": "claude-sonnet-4-6" }
+// res 201  — lean SessionOut: no sandbox_id / agent_session_id / status / sample
 { "session_id": "prj_…", "title": "Cork research",
-  "model": "claude-sonnet-4-6", "created_at": "2026-06-06T18:30:00Z" }
+  "model": "claude-sonnet-4-6", "created_at": "2026-06-07T23:18:14Z" }
 ```
-Lean `SessionOut` — no `sandbox_id`, `agent_session_id`, or `status`. (The
-internal `sample` seed flag is **not** exposed.)
 
 ### `POST /v1/sessions/{session_id}/messages` → send + reply
 ```jsonc
@@ -90,14 +146,11 @@ internal `sample` seed flag is **not** exposed.)
   "finish_reason": "stop" }        // "stop" | "error"
 ```
 - `text` = all `kind:"text"` events concatenated. `tool_calls` = flattened
-  `tool_use`/`tool_result` summaries (secondary; a simple chatbot ignores them).
-  `thinking` events are dropped from the public surface.
-- On an agent `error` event: `finish_reason:"error"`, include the message in an
-  `error` field, still `200` (the turn completed). Sync turns are capped by a
-  timeout → `504 turn_timeout` as a plain error envelope (**no** partial text: the
-  agent keeps running, so the turn isn't actually done — steer long turns to
-  streaming). The cap is the only way a sync call ends without a `turn_done`, since
-  the runner emits `turn_done` even on agent error.
+  `tool_use`/`tool_result` summaries (secondary). `thinking` is dropped.
+- On an agent `error` event: `finish_reason:"error"` + an `error` field, still `200`
+  (the runner emits `turn_done` even on agent error). The only way a sync call ends
+  without `turn_done` is the timeout → `504 turn_timeout` (no partial text; steer
+  long turns to streaming).
 
 ```jsonc
 // stream (stream:true) → 200 text/event-stream
@@ -114,214 +167,86 @@ event: done
 data: {"session_id":"prj_…","text":"Found a strong census match. …","finish_reason":"stop"}
 ```
 Public taxonomy: `text→delta`, `tool_use`/`tool_result→tool`, `error→error`,
-`turn_done→done`. The terminal `done` carries the full assembled text, so a
-client that ignores deltas still gets the whole answer — making sync and stream
-genuinely equivalent. Emit a `: keep-alive` SSE comment every ~15s during long
-tool runs so proxies don't drop the connection.
+`turn_done→done`. The terminal `done` carries the full assembled text (sync ≡ stream).
+A `: keep-alive` comment is emitted every ~15s so proxies don't drop a long stream.
 
 ### `DELETE /v1/sessions/{session_id}` → cleanup — `200`
 ```jsonc
 { "deleted": true, "session_id": "prj_…" }
 ```
-Thin wrapper over the existing delete logic (`provider.delete` + row delete).
-Lets the team release sandbox resources promptly instead of waiting on the
-30-min idle-suspend reaper.
+`provider.delete` + row delete (the turn lock is a column on that row → gone with it).
+Lets the team release sandbox resources promptly.
 
-## Implementation
+## Implementation (as shipped)
 
-Smallest clean change set. New file: `apps/server/app/v1.py`.
+- **`config.py`** — `api_keys: str` (comma-separated `key:email`) + `api_key_map`
+  property; `v1_turn_timeout_seconds: int = 120` (sync cap; streaming uses heartbeats);
+  `v1_turn_lock_stale_seconds: int = 600` (turn-lock staleness TTL).
+- **`auth.py`** — `get_api_client(Security(HTTPBearer(auto_error=False)), …)`:
+  reject non-bearer (`401`), `hmac.compare_digest` against each configured key,
+  resolve email → `_upsert_user`. **Deliberately NOT gated on `_is_allowed`**: API
+  keys are operator-granted, so presence in `api_key_map` *is* the grant; the Gmail
+  allowlist governs self-service login only.
+- **`models.py`** — `Project.turn_locked_at: datetime | None` (nullable,
+  `DateTime(timezone=True)`) — the DB-backed turn lock (see above).
+- **`sessions.py`** — `create_project(*, session, provider, user, title, model, sample)`
+  factored out of `create_session`; `_owned` reused for ownership/isolation.
+- **`app/v1.py`** — `APIRouter(prefix="/v1")`, all routes `Depends(get_api_client)`.
+  `_acquire_turn` / `_release_turn` (the guarded-UPDATE lock), `_open_ws` (resume+
+  expose+mint, with a brief connect-retry since we connect to the freshly-launched WS
+  server in-process), `_drain_replay`, `_normalize`, `_collect_sync`, `_handle_sync`,
+  `_handle_stream` (SSE), and the three routes.
+- **`main.py`** — `include_router(v1.router)`; the two app-level `/v1` exception
+  handlers.
 
-### 1. `apps/server/app/live_session.py` — in-process turn observation
-- `LiveSession.__init__`: add `self._listeners: set[asyncio.Queue[dict]] = set()`.
-- Add `add_listener() -> asyncio.Queue` / `remove_listener(q)`.
-- `LiveSession._publish`: fan out to listeners **before** the realtime publish,
-  using `put_nowait` so the browser path is never blocked or starved by a slow REST
-  consumer:
-  ```python
-  async def _publish(self, msg: dict) -> None:
-      for q in self._listeners:
-          try:
-              q.put_nowait(msg)
-          except asyncio.QueueFull:
-              pass  # stalled consumer: drop rather than grow unbounded
-      await self.realtime.publish(self.session_id, msg)
-  ```
-  Use a **bounded** queue (`maxsize`, e.g. 256), not an unbounded one. A client that
-  opens an SSE stream and stops reading otherwise stalls `StreamingResponse` writes
-  and lets its queue grow without bound — a memory-exhaustion vector on a public
-  surface. On overflow, drop frames (the terminal `done` still carries the full
-  assembled text) or, stricter, drop the listener and close the stream.
-- Add `run_turn(msg_type, text, timeout_s)` async generator — register the
-  listener **before** `send_input` (so the first frame can't be lost), then yield
-  inner `event` dicts of `type=="agent_event"` frames until `kind=="turn_done"`,
-  with a shrinking per-`get` deadline; `finally: remove_listener(q)` (leak-proof
-  on timeout *and* client disconnect). Frames that aren't `agent_event` (status,
-  viewer deltas) are skipped.
-- **Turn integrity (drain-owns-the-lock).** The turn lock must stay held until the
-  agent emits `turn_done`, *independent of the client*. The runner is sequential —
-  it won't read the next stdin message until the current `handle_turn` finishes — so
-  if the client times out or disconnects, the agent is still mid-turn. Run the drain
-  in a task that owns the lock and consumes `run_turn` to `turn_done`; the HTTP
-  handler tees frames off a queue the drain feeds. On disconnect/timeout the drain
-  keeps going to `turn_done`, *then* releases. Without this the lock releases early
-  (the `async with` unwinds on raise/cancel), a retry's `send_input` buffers behind
-  the unfinished turn, and the old turn's trailing frames — *and its `turn_done`* —
-  are mis-read as the new turn's reply. Full trace under Lifecycle → Turn integrity.
-- `SessionManager.__init__`: add `self._turn_locks: dict[str, asyncio.Lock] = defaultdict(asyncio.Lock)` and `def turn_lock(self, sid) -> asyncio.Lock`.
-  This is **separate** from the existing `_locks` — reusing those would block
-  `ensure`/`dispose`/idle-suspend for the whole minutes-long turn. Clean up
-  `_turn_locks.pop(session_id, None)` in `dispose`/delete so the dict doesn't grow
-  unbounded under a high-volume API caller (the existing `_locks` has the same
-  latent leak).
+### Concurrency / lifecycle
+- **One turn at a time per session.** `_acquire_turn` (guarded `UPDATE` on
+  `Project.turn_locked_at`) → `409 session_busy` on `rowcount == 0`; held until the
+  turn ends (`_release_turn`), correct across control-plane instances. See "Why the
+  turn lock is in the DB" above. The drain-until-idle property also keeps a retry after
+  a timeout correct (it waits out a still-running prior turn).
+- **Cross-turn memory** survives because the agent process stays up in the sandbox
+  between turns as long as the team reuses `session_id`. Idle reclamation is the
+  provider's job now (E2B auto-suspend; LocalProvider no-op) — the next message
+  re-launches the server and resumes the agent.
+- **Isolation.** `get_api_client` maps each key → a distinct `User`; `_owned` returns
+  the same `404` for "not found" and "not yours," so a client cannot reach (or probe)
+  another client's sessions even with the exact id. Session ids are already 64-bit
+  random (`prj_` + `uuid4().hex[:16]`) — defense-in-depth, not the load-bearing gate.
+  Operator practice: give each distinct client a distinct email in `api_keys`.
 
-### 2. `apps/server/app/config.py` — settings
-- `api_keys: str = ""` (comma-separated `key:email` pairs) + an `api_key_map`
-  property that parses to `{key: email}`.
-- `v1_turn_timeout_seconds: int = 120` (sync timeout; streaming relies on
-  heartbeats instead of a hard cap).
+## Suggested changes to their request (kept)
 
-### 3. `apps/server/app/auth.py` — bearer dependency
-- Add `get_api_client(creds = Security(HTTPBearer(auto_error=False)), session = Depends(get_session)) -> User`:
-  reject non-bearer (`401 unauthorized`), `hmac.compare_digest` the credential
-  against each configured key (constant-time), resolve to its email, and return
-  `_upsert_user(session, email)` — so a key maps to the **same** `User` row the
-  browser path would create. `/v1` is bearer-**only**; the browser keeps `/api/*`.
-- **Authz decision (explicit):** the browser login path gates on `_is_allowed(email)`
-  *before* `_upsert_user`; `get_api_client` deliberately does **not**. API keys are
-  operator-granted (set in env), so presence in `api_key_map` *is* the grant; the
-  `_is_allowed` allowlist governs self-service login only. A key can therefore mint a
-  `User` for an email the allowlist would reject — intended, but state it so a
-  reviewer doesn't read it as an accidental bypass.
+1. Two send-endpoints → one with `stream:true`. 2. Don't return our session object —
+lean `{session_id,title,model,created_at}`. 3. Bearer keys, not cookies. 4. Steer to
+streaming for real (tool-running) turns; sync is capped (`504`). 5. One message at a
+time per session (`409` → retry after a short backoff). 6. We add `DELETE`. 7.
+Consistent `{error:{code,message}}` envelope.
 
-### 4. `apps/server/app/sessions.py` — extract shared service
-- Factor the body of `create_session` into
-  `async def create_project(*, session, provider, user, title=None, model=None, sample=False) -> Project`.
-- Repoint `create_session` at it; `/v1` calls it with `sample` defaulted off.
-- Reuse `_owned(session, user, session_id)` for ownership in `/v1`.
+Explicitly **not** built (over-engineering for a POC): DB-backed key table / hashing /
+rotation / scopes / rate limits, message-history endpoints, idempotency keys,
+`include_thinking`, a WebSocket streaming transport. (The turn lock *is*
+multi-instance-correct — it's DB-backed.)
 
-### 5. `apps/server/app/v1.py` — NEW router
-- `APIRouter(prefix="/v1", tags=["public-api"])`, all routes
-  `Depends(get_api_client)`.
-- Models: `SessionOut`, `CreateBody {title?, model?}`, `MessageBody {message, stream=False}`.
-- A shared `_drive_turn(manager, session_id, project, body)` that:
-  1. acquires the turn lock **non-blocking** and returns `409 session_busy` on
-     failure — `acquired = await asyncio.wait_for(lock.acquire(), 0)` (or an
-     equivalent try-acquire). Do **not** check `.locked()` then `async with`: that is
-     check-then-act, and a concurrent caller would silently *queue* on the
-     `async with` instead of getting `409`, contradicting the contract;
-  2. with the lock held, `live = await manager.ensure(session_id, project)` (ensure
-     **inside** the lock so the session can't be disposed mid-turn), and hold the
-     lock until the agent's `turn_done` (drain-owns-the-lock, §1);
-  3. bumps `project.last_active` (so idle-suspend won't reap an active session);
-  4. `async for ev in live.run_turn(...)`: collect (sync) or format SSE (stream).
-- Sync handler returns `SessionOut`-style JSON; stream handler returns
-  `StreamingResponse(gen(), media_type="text/event-stream", headers={"Cache-Control":"no-cache","X-Accel-Buffering":"no"})`.
-  **Bump `last_active` before streaming starts** (the request-scoped DB session
-  may close before a long stream ends — don't touch it inside the generator).
-- Register **app-level** exception handlers (in `main.py`) for `HTTPException` and
-  `RequestValidationError` that emit the `{"error":{code,message}}` envelope when
-  `request.url.path.startswith("/v1")` and otherwise fall through to FastAPI's
-  default — a router-scoped handler can't catch the dependency-raised `401` or the
-  framework-level `422` (see API contract above).
+## Verification (done)
 
-### 6. `apps/server/app/main.py` — wire it
-- `from . import v1` and `app.include_router(v1.router)` after the existing
-  `include_router` calls. Add the app-level `/v1` exception handlers here (§5).
+Runs fully on mocks (`agent_mode=mock`, `sandbox=local`).
 
-### Lifecycle / edge cases
-- **Keep-alive after a turn**: the `LiveSession` (and its long-lived agent
-  process) stays up → cross-turn memory works for the team automatically as long
-  as they reuse the `session_id`. Idle-suspend reclaims REST-only sessions:
-  `has_local_subscribers` is `False` for them, so after `idle_suspend_seconds` it
-  disposes + suspends; the next message re-`ensure`s (resumes the sandbox + agent).
-  The headline promise is that memory survives this dispose/resume cycle — that
-  path must be **tested**, not assumed (see Verification).
-- **Client disconnect mid-stream / sync timeout**: `run_turn`'s `finally` removes
-  the listener (no leak), but the drain task keeps consuming to `turn_done` while
-  holding the turn lock (drain-owns-the-lock, §1). The agent finishes its turn; its
-  frames are dropped for the gone client and still reach any browser viewer. Memory
-  is preserved.
-- **Turn integrity (was "known limitation").** This is a correctness requirement,
-  not a follow-up. If the lock released when `run_turn` exits (on raise/cancel)
-  rather than at `turn_done`: (1) turn A times out at 120s but the agent runs to
-  ~180s; (2) the client retries with B at ~130s — the lock is free, so
-  `send_input(B)` buffers behind A (the runner hasn't read it yet); (3) at ~180s A
-  finishes and its trailing frames **plus `turn_done(A)`** flow to B's listener, so
-  B returns A's leftover text and B's real answer is lost. Drain-owns-the-lock fixes
-  it: the lock is held until `turn_done(A)`, so the retry correctly gets `409` until
-  A truly finishes. Implementing `interrupt` in the runner (`agent/runner.py`
-  currently ignores non-`user_msg`) is an alternative that *aborts* A on timeout
-  instead of waiting it out — cleaner, larger, optional.
-
-## Suggested changes to their request
-
-What we'd push back on or improve vs. their stated 3-endpoint design, to keep the
-architecture clean and the DX excellent:
-
-1. **Two send-endpoints → one** `POST /v1/sessions/{id}/messages` with
-   `stream:true`. Same OpenAI mental model, half the surface, no handler drift.
-2. **Don't return our session object.** Create returns `{session_id, title,
-   model, created_at}`; their client depends only on `session_id`. We hide
-   `sandbox_id`/`agent_session_id`/`status` behind `/v1`.
-3. **Bearer keys, not cookies** — the right fit for a server-to-server caller
-   (no login flow, no CSRF surface).
-4. **Steer to streaming for real turns.** Genealogy turns invoke tools and can
-   run tens of seconds; sync is capped (`504`) and best for short Q&A. Streaming
-   (continuous bytes + heartbeat) sidesteps client/proxy idle timeouts.
-5. **One message at a time per session** (single long-lived agent process):
-   overlapping turns get `409 session_busy`. The natural chatbot pattern
-   (await the reply, then send the next) already satisfies this; tell the team to
-   treat `409` as "retry after a short backoff" — it can also appear briefly after a
-   timed-out turn while the prior turn drains (see Turn integrity).
-6. **We add `DELETE /v1/sessions/{id}`** (not in their list) for prompt resource
-   cleanup.
-7. **Consistent `{error:{code,message}}` envelope** so their client branches on
-   `error.code`, not prose.
-
-Explicitly **not** building now (over-engineering for a POC): DB-backed key table
-/ hashing / rotation / scopes / rate limits, message-history endpoints,
-idempotency keys, `include_thinking`, a second (WebSocket) streaming transport.
-
-## Verification
-
-Runs fully on mocks (`agent_mode=mock`, `realtime=local_ws`, `sandbox=local`) —
-no Anthropic/Ably/E2B needed.
-
-1. **Unit/integration tests** (pytest, `apps/server/`), using `MockRealtime` +
-   the mock agent — mirror the existing `test_ably_flow.py` style:
-   - sync: assembled `text` equals concatenated mock `text` events; `finish_reason:"stop"`.
-   - stream: SSE frames parse; the terminal `done` payload's `text` equals the sync text.
-   - `409 session_busy` when a second turn starts while one holds the turn lock.
-   - **turn integrity**: time out (or disconnect) turn A while the mock agent is
-     mid-turn, immediately send turn B, and assert B's reply is B's — not A's
-     trailing text. Guards the drain-owns-the-lock fix (§1); the test most likely to
-     fail without it.
-   - **memory across idle-suspend**: with a short `idle_suspend_seconds`, send a
-     turn, let the session dispose + suspend, then send a follow-up that references
-     the first and assert the resumed agent still has context. This is the doc's
-     headline DX promise.
-   - auth: missing/invalid bearer → `401`; valid key → `200` and a `Project`
-     owned by the mapped user. Error bodies use the `{"error":{code,message}}`
-     envelope (assert it for `401` and for a `422` from a malformed body).
-   - `DELETE` removes the row and calls `provider.delete`.
-2. **Live smoke** with `API_KEYS=sk_dev:dallan@gmail.com make server`:
-   ```bash
-   K="Authorization: Bearer sk_dev"
-   SID=$(curl -s -H "$K" -XPOST localhost:8000/v1/sessions \
-         -d '{"title":"t"}' | jq -r .session_id)
-   curl -s -H "$K" -XPOST localhost:8000/v1/sessions/$SID/messages \
-        -d '{"message":"hello"}' | jq          # sync JSON
-   curl -N -H "$K" -XPOST localhost:8000/v1/sessions/$SID/messages \
-        -d '{"message":"hello","stream":true}' # SSE stream
-   ```
-   Confirm cross-turn memory by sending a second message that references the
-   first. Confirm `make test` passes (server-only changes).
+- **`apps/server/tests/test_v1_api.py`** (10 tests, green; full suite 27 green): sync
+  assembled text; SSE `done` text equals sync; `409 session_busy` (a held DB lock);
+  **stale lock reclaimed** (a lock past the TTL doesn't wedge the session);
+  `422`/`401`/`404` envelopes; operator-granted key bypasses the allowlist; cross-client
+  `404` isolation; delete releases the sandbox and `404`s after.
+- **Live smoke** (`API_KEYS=sk_dev:… uvicorn app.main:app`): create → two sequential
+  sync turns on the same session that **advance the agent's conversation state** (greet
+  → experience acknowledged), confirming both the long-lived agent process / cross-turn
+  memory *and* that the DB lock is released between turns; SSE turn; bad key → `401`
+  envelope; delete → `{deleted:true}`.
 
 ### Critical files
-- `apps/server/app/live_session.py` — listener fanout + `run_turn` + turn lock
-- `apps/server/app/v1.py` — NEW router (create / messages / delete, SSE)
+- `apps/server/app/v1.py` — the router + WS-client turn driver + DB turn lock (create / messages / delete, SSE)
 - `apps/server/app/auth.py` — `get_api_client` bearer dependency
-- `apps/server/app/sessions.py` — extract `create_project(...)`
-- `apps/server/app/config.py` — `api_keys` / `api_key_map` / `v1_turn_timeout_seconds`
-- `apps/server/app/main.py` — register `v1.router`
-```
+- `apps/server/app/sessions.py` — `create_project(...)` + `_owned`
+- `apps/server/app/models.py` — `Project.turn_locked_at` (the DB lock column)
+- `apps/server/app/config.py` — `api_keys` / `api_key_map` / `v1_turn_timeout_seconds` / `v1_turn_lock_stale_seconds`
+- `apps/server/app/main.py` — register `v1.router` + the `/v1` error envelope handlers


### PR DESCRIPTION
## What

A dedicated, versioned, **bearer-only `/v1` surface** for an external chatbot team to drive the server over plain REST:

- `POST /v1/sessions` — create (lean shape: `{session_id, title, model, created_at}`)
- `POST /v1/sessions/{id}/messages` — send a message; `{message, stream?}` → JSON when `stream` is false/omitted, **SSE** when true
- `DELETE /v1/sessions/{id}` — release the sandbox

Server-only (`apps/server/`); the engine (`packages/engine/`) and its `.mcpb`/plugin CI are untouched.

## How a turn is observed

The realtime re-architecture moved the agent stream **into the sandbox** (the browser connects a WS straight to `sandbox_server.py`; the control plane is out of the streaming path). So the `/v1` handler does what the browser does — it becomes a **WS client of the sandbox**, reusing the `/connect` plumbing (`resume` + `expose_port` + `mint_token`), sends `{type:"user_msg"}`, and reads `agent_event` frames until `turn_done`, assembling the reply (sync) or relaying it as SSE.

## Key decisions

- **Auth:** `get_api_client` bearer dependency — constant-time key check, maps a key to the same `User` the browser path would create. Operator-granted (presence in `api_keys` *is* the grant; deliberately **not** gated on the Gmail allowlist).
- **Isolation:** reuses `_owned` — a different key → `404` even with the exact `session_id` (same `404` for "not yours"/"not found", so existence can't be probed). Ownership is the gate; the 64-bit-random ids are defense-in-depth.
- **One turn at a time per session:** a **DB-backed lock** (guarded `UPDATE` on a new `Project.turn_locked_at` column) → `409 session_busy`. Correct across **horizontally-scaled** control-plane instances (the DB serializes the conditional write — no in-memory/per-instance state), self-heals via a staleness TTL. Works on **SQLite today** and on **Postgres after the Neon migration** (rides `create_all`; tz-aware column, no Alembic).
- **Errors:** one `{"error":{"code","message"}}` envelope via app-level handlers scoped to `/v1` (`/api/*` shapes untouched).

> **Prerequisite for `count > 1` (not this PR):** the shared-DB (Neon) migration must land first — today's SQLite-on-a-volume is per-machine. This lock is built to ride that PR cleanly.

## Tests

13 `/v1` tests (integration over LocalProvider + the real in-sandbox WS server + mock agent — no E2B/Anthropic): auth + error envelopes, sync assembled text, SSE `done` ≡ sync, `tool_calls` + SSE `tool` frames, `504 turn_timeout`, `409 session_busy`, **stale-lock reclamation**, cross-client `404` isolation, delete. Full `apps/server` suite green (**30**). Live-smoke verified (real `uvicorn` + `curl -N`): sequential turns advance agent state (cross-turn memory + lock release between turns).

See `docs/plan/public-rest-api.md` (rewritten to match the as-built architecture).

🤖 Generated with [Claude Code](https://claude.com/claude-code)