### PR TITLE
Env-driven DB backend: SQLite locally, Neon Postgres on Fly

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -289,36 +289,39 @@ test suite always runs on SQLite (`conftest` forces `DATABASE_URL=""`).
 `make server-test` only exercises SQLite, so validate Postgres by **booting the
 server against a real Postgres and exercising it**. Two ways:
 
+Prefix any control-plane target with `DATABASE_URL=…` — `make server` then runs
+mock + local + **dev-login** against that Postgres (it pins those dev values so a
+`.env` kept for the oauth/e2b targets doesn't leak in). Pair with `make web` and
+sign in with an allowlisted email (default `dallan@gmail.com`) — that write lands
+in Postgres. Do **not** use a bare `uv run uvicorn …`: it inherits `.env`, so a
+real `GOOGLE_CLIENT_ID` there forces the Google-only login (broken on `:8000`).
+
 **A — throwaway Docker Postgres (offline, no account):**
 ```bash
 docker run -d --name wb-pg -e POSTGRES_PASSWORD=postgres -p 5433:5432 postgres:16-alpine
-
-cd apps/server
-DATABASE_URL="postgresql://postgres:postgres@localhost:5433/postgres" \
-  AGENT_MODE=mock SANDBOX_PROVIDER=local uv run uvicorn app.main:app --port 8000
+DATABASE_URL="postgresql://postgres:postgres@localhost:5433/postgres" make server   # + make web
 # → another terminal:
-curl -s localhost:8000/api/health | jq          # expect "db":"postgres"
+curl -s localhost:8000/api/health | jq          # expect "db":"postgres", "provider":"local"
 docker exec wb-pg psql -U postgres -tAc "\dt"   # 4 tables created by create_all()
-#   …then create/list/delete a session (browser dev-login, or the /v1 API).
+#   …dev-login at http://127.0.0.1:5173 and create/delete a session.
 docker rm -f wb-pg                               # teardown
 ```
-(mock agent + local sandboxes is enough to exercise the DB; `psycopg[binary]` is
-already in `uv.lock`, so no local libpq is needed.)
+(`psycopg[binary]` is already in `uv.lock`, so no local libpq is needed.)
 
 **B — a real Neon dev database (also validates SSL + the real URL):**
 1. Create a free project at neon.tech (region near `iad`); pick/create a database.
 2. Copy the **direct** connection string — the host **without** `-pooler` (it
    already ends with `?sslmode=require`). The pooler endpoint is intentionally
    avoided; see `docs/plan/neon-postgres-plan.md`.
-3. Boot locally against it:
+3. Boot against it (mock + local + dev-login):
    ```bash
-   cd apps/server
-   DATABASE_URL="postgresql://USER:PASS@ep-xxx.REGION.aws.neon.tech/DBNAME?sslmode=require" \
-     uv run uvicorn app.main:app --port 8000
+   DATABASE_URL="postgresql://USER:PASS@ep-xxx.REGION.aws.neon.tech/DBNAME?sslmode=require" make server
+   # + make web
    ```
-4. `curl localhost:8000/api/health` → `"db":"postgres"`; create/list/delete a
-   session; inspect tables in the Neon SQL editor. The first request after idle
-   resumes Neon from scale-to-zero (a few hundred ms–seconds) — expected.
+4. `curl localhost:8000/api/health` → `"db":"postgres"`; dev-login at
+   http://127.0.0.1:5173 and create/delete a session; inspect tables in the Neon
+   SQL editor. The first request after idle resumes Neon from scale-to-zero (a few
+   hundred ms–seconds) — expected.
 
 ### Deploy to Fly.io
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -268,6 +268,91 @@ cd apps/server && uv run pytest -q       # or: make server-test
 `tool` frames), `504` timeout, `409 session_busy`, stale-lock reclamation,
 cross-client isolation, and delete — all on mocks.
 
+## Database backends & deploying to Fly.io
+
+The control plane picks its database from a single env var, **`DATABASE_URL`**:
+
+- **Unset → SQLite** under `DATA_DIR` (`.workbench-data/workbench.db`) — the
+  zero-setup local default. `make server*` and the test suite use this.
+- **Set → Postgres** (Neon in production, supplied as a Fly secret).
+  `config.sqlalchemy_url` normalizes Neon's `postgres://`/`postgresql://` to the
+  `psycopg3` driver.
+
+The schema is pure SQLModel: `init_db()` runs `create_all()` on boot (no Alembic)
+and re-seeds the allowlist from `ALLOWED_EMAILS`. There is **no data migration**
+between backends — switching `DATABASE_URL` just starts a fresh schema.
+`/api/health` reports the live backend (`{"db":"sqlite"|"postgres", …}`). The
+test suite always runs on SQLite (`conftest` forces `DATABASE_URL=""`).
+
+### Test the Postgres / Neon path locally (before deploying)
+
+`make server-test` only exercises SQLite, so validate Postgres by **booting the
+server against a real Postgres and exercising it**. Two ways:
+
+**A — throwaway Docker Postgres (offline, no account):**
+```bash
+docker run -d --name wb-pg -e POSTGRES_PASSWORD=postgres -p 5433:5432 postgres:16-alpine
+
+cd apps/server
+DATABASE_URL="postgresql://postgres:postgres@localhost:5433/postgres" \
+  AGENT_MODE=mock SANDBOX_PROVIDER=local uv run uvicorn app.main:app --port 8000
+# → another terminal:
+curl -s localhost:8000/api/health | jq          # expect "db":"postgres"
+docker exec wb-pg psql -U postgres -tAc "\dt"   # 4 tables created by create_all()
+#   …then create/list/delete a session (browser dev-login, or the /v1 API).
+docker rm -f wb-pg                               # teardown
+```
+(mock agent + local sandboxes is enough to exercise the DB; `psycopg[binary]` is
+already in `uv.lock`, so no local libpq is needed.)
+
+**B — a real Neon dev database (also validates SSL + the real URL):**
+1. Create a free project at neon.tech (region near `iad`); pick/create a database.
+2. Copy the **direct** connection string — the host **without** `-pooler` (it
+   already ends with `?sslmode=require`). The pooler endpoint is intentionally
+   avoided; see `docs/plan/neon-postgres-plan.md`.
+3. Boot locally against it:
+   ```bash
+   cd apps/server
+   DATABASE_URL="postgresql://USER:PASS@ep-xxx.REGION.aws.neon.tech/DBNAME?sslmode=require" \
+     uv run uvicorn app.main:app --port 8000
+   ```
+4. `curl localhost:8000/api/health` → `"db":"postgres"`; create/list/delete a
+   session; inspect tables in the Neon SQL editor. The first request after idle
+   resumes Neon from scale-to-zero (a few hundred ms–seconds) — expected.
+
+### Deploy to Fly.io
+
+One always-on container (`count = 1`) serves the REST + WebSocket API and the
+built web client from a single origin. Full procedure in
+[`docs/plan/fly-deploy-plan.md`](./docs/plan/fly-deploy-plan.md) +
+[`docs/plan/neon-postgres-plan.md`](./docs/plan/neon-postgres-plan.md); short version:
+
+```bash
+# Secrets — NOT in fly.toml (they carry credentials):
+fly secrets set \
+  DATABASE_URL="postgresql://…neon.tech/DBNAME?sslmode=require" \  # direct, non-pooler
+  E2B_API_KEY=… ANTHROPIC_API_KEY=… SESSION_SECRET=… WS_SIGNING_KEY=… \
+  GOOGLE_CLIENT_ID=… GOOGLE_CLIENT_SECRET=… \
+  ALLOWED_EMAILS="you@example.com" API_KEYS="sk_live_…:chatbot@yourco.com"
+
+# Build context is the REPO ROOT (the Dockerfile copies the pnpm workspace):
+fly deploy --config deploy/fly.toml --dockerfile deploy/Dockerfile .
+
+curl -s https://genealogy-workbench.fly.dev/api/health | jq   # expect "db":"postgres"
+fly volumes destroy workbench_data    # if a volume lingers from a pre-Neon deploy
+```
+
+On boot `init_db()` creates the schema on Neon and seeds the allowlist. Non-secret
+config lives in `deploy/fly.toml` `[env]` (`AGENT_MODE=real`, `SANDBOX_PROVIDER=e2b`,
+`PUBLIC_URL`, …); there is **no `[mounts]` block** — nothing persistent remains on
+`DATA_DIR` once the DB is on Neon. The agent runs on **E2B**, not in this container
+(the `genealogy-agent` image is a separate artifact — see `make sandbox-image`).
+
+**Stay at `count = 1`.** `fly scale count > 1` first needs `init_db()` moved to a
+one-time Fly `release_command` (two Machines otherwise race on `create_all` + the
+allowlist seed); tracked in [`docs/TODOs.md`](./docs/TODOs.md). Sticky routing is
+not an option (production is AWS-no-sticky).
+
 ## Troubleshooting
 
 ### `login` doesn't open a browser tab

--- a/Makefile
+++ b/Makefile
@@ -83,13 +83,24 @@ web: $(JS_DEPS) ## Web client; proxies /api+WS to :8000 (use with server / serve
 
 .PHONY: server
 server: ## LOCAL + MOCK agent, dev-login, :8000 — zero setup (web client: make web)
-	cd apps/server && AGENT_MODE=mock uv run uvicorn app.main:app --reload --port 8000
+	# Pin the dev-friendly values so a .env kept for server-oauth/-e2b (real Google
+	# creds, SANDBOX_PROVIDER=e2b, real FS) doesn't leak into this zero-setup target:
+	#  - GOOGLE_CLIENT_ID/SECRET empty → /auth/config offers dev-login (else the UI
+	#    shows only "Sign in with Google", which can't complete on :8000);
+	#  - SANDBOX_PROVIDER=local → sessions run locally, no E2B key needed;
+	#  - FAMILYSEARCH_WEB_ENABLED=false → the FS step uses mock dev-connect.
+	cd apps/server && AGENT_MODE=mock SANDBOX_PROVIDER=local \
+	  GOOGLE_CLIENT_ID= GOOGLE_CLIENT_SECRET= FAMILYSEARCH_WEB_ENABLED=false \
+	  uv run uvicorn app.main:app --reload --port 8000
 
 .PHONY: server-real
 server-real: $(ENGINE_BUILD) ## LOCAL + REAL agent, dev-login, :8000 — needs ANTHROPIC_API_KEY (web client: make web)
 	# engine-build prereq: the real agent forks `node <mcp-server/build/index.js>`.
 	# Key is sourced from $$ANTHROPIC_API_KEY, else the sibling repo's .env (UI_ENV).
-	cd apps/server && AGENT_MODE=real \
+	# Pin the same dev-friendly values as `server` (local provider, dev-login,
+	# mock FS) so .env kept for the oauth/e2b targets doesn't leak in here.
+	cd apps/server && AGENT_MODE=real SANDBOX_PROVIDER=local \
+	  GOOGLE_CLIENT_ID= GOOGLE_CLIENT_SECRET= FAMILYSEARCH_WEB_ENABLED=false \
 	  ANTHROPIC_API_KEY="$${ANTHROPIC_API_KEY:-$$(grep -E '^ANTHROPIC_API_KEY=' $(UI_ENV) | cut -d= -f2-)}" \
 	  uv run uvicorn app.main:app --reload --port 8000
 

--- a/apps/server/app/config.py
+++ b/apps/server/app/config.py
@@ -85,6 +85,12 @@ class Settings(BaseSettings):
     # (Feedback goes to Google Drive; no other local-disk writes.)
     data_dir: Path = REPO_ROOT / ".workbench-data"
 
+    # ── Database ─────────────────────────────────────────────────
+    # Unset → SQLite under DATA_DIR (local dev, zero-setup). Set → Postgres
+    # (Neon on Fly), provided as a Fly secret. Neon hands out postgresql://… ;
+    # sqlalchemy_url pins the psycopg(3) driver. Backend swap = env only.
+    database_url: str | None = None
+
     # ── Dev / serving ────────────────────────────────────────────
     # Web client origin for CORS during local dev (Vite).
     web_origin: str = "http://localhost:5173"
@@ -131,6 +137,24 @@ class Settings(BaseSettings):
     @property
     def db_path(self) -> Path:
         return self.data_dir / "workbench.db"
+
+    @property
+    def is_sqlite(self) -> bool:
+        return not self.database_url
+
+    @property
+    def sqlalchemy_url(self) -> str:
+        """Resolve the SQLAlchemy URL. Unset DATABASE_URL → local SQLite. Set →
+        Postgres, normalizing Neon's postgres://|postgresql:// to the explicit
+        psycopg(3) driver SQLAlchemy needs."""
+        url = self.database_url
+        if not url:
+            return f"sqlite:///{self.db_path}"
+        if url.startswith("postgres://"):
+            url = "postgresql+psycopg://" + url[len("postgres://"):]
+        elif url.startswith("postgresql://"):
+            url = "postgresql+psycopg://" + url[len("postgresql://"):]
+        return url
 
     @property
     def sandboxes_dir(self) -> Path:

--- a/apps/server/app/db.py
+++ b/apps/server/app/db.py
@@ -1,4 +1,9 @@
-"""SQLite engine + schema bootstrap + the allowlist seed."""
+"""DB engine + schema bootstrap + the allowlist seed.
+
+Backend is env-driven (see config.sqlalchemy_url): unset DATABASE_URL → SQLite
+under DATA_DIR (local dev); set → Postgres (Neon on Fly). init_db()/get_session()
+and every SQLModel query are identical across both — the schema is pure SQLModel.
+"""
 from __future__ import annotations
 
 from collections.abc import Iterator
@@ -9,10 +14,20 @@ from .config import get_settings
 from .models import AllowedEmail
 
 _settings = get_settings()
-_engine = create_engine(
-    f"sqlite:///{_settings.db_path}",
-    connect_args={"check_same_thread": False},
-)
+if _settings.is_sqlite:
+    _engine = create_engine(
+        _settings.sqlalchemy_url,
+        connect_args={"check_same_thread": False},
+    )
+else:
+    # Neon auto-suspends idle connections (scale-to-zero); pre_ping discards dead
+    # pooled connections and recycle caps connection age. These keep the pool
+    # correct after a resume; they don't mask the first-query cold-start latency.
+    _engine = create_engine(
+        _settings.sqlalchemy_url,
+        pool_pre_ping=True,
+        pool_recycle=300,
+    )
 
 
 def init_db() -> None:

--- a/apps/server/app/main.py
+++ b/apps/server/app/main.py
@@ -114,6 +114,7 @@ def health() -> dict:
         "ok": True,
         "agentMode": _settings.agent_mode,
         "provider": _settings.sandbox_provider,
+        "db": "sqlite" if _settings.is_sqlite else "postgres",
     }
 
 

--- a/apps/server/app/models.py
+++ b/apps/server/app/models.py
@@ -15,12 +15,18 @@ def utcnow() -> datetime:
     return datetime.now(timezone.utc)
 
 
+# Postgres' default TIMESTAMP strips tzinfo and returns naive datetimes; since the
+# models build tz-aware values (utcnow), declare datetime columns as TIMESTAMP WITH
+# TIME ZONE so read-back stays aware. SQLite round-trips either way. Shared alias.
+_TZ = DateTime(timezone=True)
+
+
 class User(SQLModel, table=True):
     __tablename__ = "users"
     id: str = Field(primary_key=True)
     email: str = Field(index=True, unique=True)
     google_sub: str | None = Field(default=None, index=True)
-    created: datetime = Field(default_factory=utcnow)
+    created: datetime = Field(default_factory=utcnow, sa_type=_TZ)
 
 
 class AllowedEmail(SQLModel, table=True):
@@ -34,8 +40,8 @@ class FamilySearchToken(SQLModel, table=True):
     # POC: plaintext. TODO encrypt at rest before any real PII (spec §13).
     access_token: str
     refresh_token: str | None = None
-    expires_at: datetime
-    updated: datetime = Field(default_factory=utcnow)
+    expires_at: datetime = Field(sa_type=_TZ)
+    updated: datetime = Field(default_factory=utcnow, sa_type=_TZ)
 
 
 class Project(SQLModel, table=True):
@@ -48,14 +54,11 @@ class Project(SQLModel, table=True):
     title: str = "New research session"
     model: str = "claude-sonnet-4-6"
     status: str = "active"  # active | archived
-    created: datetime = Field(default_factory=utcnow)
-    updated: datetime = Field(default_factory=utcnow)
-    last_active: datetime = Field(default_factory=utcnow)
+    created: datetime = Field(default_factory=utcnow, sa_type=_TZ)
+    updated: datetime = Field(default_factory=utcnow, sa_type=_TZ)
+    last_active: datetime = Field(default_factory=utcnow, sa_type=_TZ)
     # Per-session turn lock for the public /v1 API (one turn at a time). Holds the
     # timestamp of the in-flight turn, NULL when idle. A guarded UPDATE on this
     # column is the atomic, cross-instance lock (correct on SQLite + Postgres) —
-    # see app/v1.py. tz-aware so it stays correct once the Neon migration applies
-    # the same DateTime(timezone=True) hardening to the other datetime columns.
-    turn_locked_at: datetime | None = Field(
-        default=None, sa_type=DateTime(timezone=True), nullable=True
-    )
+    # see app/v1.py.
+    turn_locked_at: datetime | None = Field(default=None, sa_type=_TZ, nullable=True)

--- a/apps/server/pyproject.toml
+++ b/apps/server/pyproject.toml
@@ -16,6 +16,9 @@ dependencies = [
     "claude-agent-sdk>=0.2.93",
     "ably>=3.1.2",
     "e2b>=2.26.0",
+    # Postgres driver (Neon on Fly); SQLite remains the local default. The
+    # [binary] extra bundles libpq → no Dockerfile/apt change on python:3.12-slim.
+    "psycopg[binary]>=3.2",
 ]
 
 [dependency-groups]

--- a/apps/server/tests/conftest.py
+++ b/apps/server/tests/conftest.py
@@ -19,6 +19,7 @@ os.environ["GOOGLE_CLIENT_ID"] = ""          # keep dev-login enabled in tests
 os.environ["GOOGLE_CLIENT_SECRET"] = ""
 os.environ["FAMILYSEARCH_WEB_ENABLED"] = "false"
 os.environ["ANTHROPIC_API_KEY"] = ""         # keep the real key out of test assertions
+os.environ["DATABASE_URL"] = ""              # tests always run on SQLite, never a dev .env Postgres
 
 # Public /v1 bearer keys. `api-bot@…` is deliberately NOT on the allowlist (above)
 # — it proves an operator-granted key mints a User the allowlist would reject.

--- a/apps/server/uv.lock
+++ b/apps/server/uv.lock
@@ -297,6 +297,7 @@ dependencies = [
     { name = "fastapi" },
     { name = "httpx" },
     { name = "itsdangerous" },
+    { name = "psycopg", extra = ["binary"] },
     { name = "pydantic-settings" },
     { name = "python-multipart" },
     { name = "sqlmodel" },
@@ -320,6 +321,7 @@ requires-dist = [
     { name = "fastapi", specifier = ">=0.115" },
     { name = "httpx", specifier = ">=0.27" },
     { name = "itsdangerous", specifier = ">=2.2" },
+    { name = "psycopg", extras = ["binary"], specifier = ">=3.2" },
     { name = "pydantic-settings", specifier = ">=2.6" },
     { name = "python-multipart", specifier = ">=0.0.12" },
     { name = "sqlmodel", specifier = ">=0.0.22" },
@@ -689,6 +691,64 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/8e/e5/e46adb0badc388bfb84877a5f9f026aff63f60e611016cf64dbe77e05446/protobuf-7.35.0-cp310-abi3-win32.whl", hash = "sha256:4c4617b83ade0e279d1d2bfe04025a1adb87f9ed657de038620dc0ff959357f6", size = 428946, upload-time = "2026-05-19T23:02:25.741Z" },
     { url = "https://files.pythonhosted.org/packages/a7/ab/547fbd9e16d879dd13c167478f8ae0a83a428008ca07a5e06acdc23ad473/protobuf-7.35.0-cp310-abi3-win_amd64.whl", hash = "sha256:f05bcadf9a2a6b8dda047007075135fb7d08c73d9177aabc067e1be46881a201", size = 439996, upload-time = "2026-05-19T23:02:26.808Z" },
     { url = "https://files.pythonhosted.org/packages/b8/ef/50433d346c56657a70d27f156c7b349ac59a068b01de4eb796e747eecc43/protobuf-7.35.0-py3-none-any.whl", hash = "sha256:c13f325cf242bad135c350629eeb5d54b24228eb472fb3e2e9ebbd4c5dc20ca0", size = 171659, upload-time = "2026-05-19T23:02:27.842Z" },
+]
+
+[[package]]
+name = "psycopg"
+version = "3.3.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/db/2f/cb91e5502ec9de1de6f1b76cfbf69531932725361168bb06963620c77e2e/psycopg-3.3.4.tar.gz", hash = "sha256:e21207764952cff81b6b8bdacad9a3939f2793367fdac2987b3aac36a651b5bc", size = 165799, upload-time = "2026-05-01T23:31:55.179Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/e0/7b3dee031daae7743609ce3c746565d4a3ed7c2c186479eb48e34e838c64/psycopg-3.3.4-py3-none-any.whl", hash = "sha256:b6bbc25ccf05c8fad3b061d9db2ef0909a555171b84b07f29458a447253d679a", size = 213001, upload-time = "2026-05-01T23:20:50.816Z" },
+]
+
+[package.optional-dependencies]
+binary = [
+    { name = "psycopg-binary", marker = "implementation_name != 'pypy'" },
+]
+
+[[package]]
+name = "psycopg-binary"
+version = "3.3.4"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/95/7d/03818e13ba7f36de93573c93ee3482006d3dfa8b0f8d28df511bad0a1a92/psycopg_binary-3.3.4-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:5ab28a2a7649df3b72e6b674b4c190e448e8e77cf496a65bd846472048de2089", size = 4591122, upload-time = "2026-05-01T23:27:56.162Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/b9/11b341edf8d54e2694726b273fe9652b254d989f4f63e3ac6816ad6b55f4/psycopg_binary-3.3.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6402a9d8146cf4b3974ded3fd28a971e83dc6a0333eb7822524a3aa20b546578", size = 4669943, upload-time = "2026-05-01T23:28:04.522Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/18/4665bacd65e7865b4372fcd8abb8b9186ada4b0025f8c2ca691b364a556c/psycopg_binary-3.3.4-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:580ae30a5f95ccd90008ec697d3ed6a4a2047a516407ad904283fa42086936e9", size = 5469697, upload-time = "2026-05-01T23:28:11.337Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/b1/b83136c6e510593d9b0c759ba5384337bc4ad82d19fda675adc4b2703c84/psycopg_binary-3.3.4-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e7510c37550f91a187e3660a8cc50d4b760f8c3b8b2f89ebc5698cd2c7f2c85d", size = 5152995, upload-time = "2026-05-01T23:28:20.529Z" },
+    { url = "https://files.pythonhosted.org/packages/67/8d/a9821e2a648afe6091989929982a3b0f00b2631a859cb81379728f08fb75/psycopg_binary-3.3.4-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:77df19583501ea288eaf15ac0fe7ad01e6d8091a91d5c41df5c718f307d8e31b", size = 6738180, upload-time = "2026-05-01T23:28:30.654Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/58/2e349e8d23905dc2317b80ac65f48fb6f821a4777a4e994a60da91c4850f/psycopg_binary-3.3.4-cp312-cp312-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:018fbed325936da502feb546642c982dcc4b9ffdea32dfef78dbf3b7f7ad4070", size = 4978828, upload-time = "2026-05-01T23:28:37.277Z" },
+    { url = "https://files.pythonhosted.org/packages/45/48/57b00d03b4721878326122a1f1e6b0a90b85bcaec56b5b2f8ea6cfa45235/psycopg_binary-3.3.4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:17a21953a9e5ff3a16dab692625a3676e2f101db5e40072f39dbee2250194d68", size = 4509757, upload-time = "2026-05-01T23:28:43.078Z" },
+    { url = "https://files.pythonhosted.org/packages/25/37/33b47d8c007df69aec500df5889767c4d313748e8e9e27a2fef8a6dabcee/psycopg_binary-3.3.4-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:eb05ee1c2b817d27c537333224c9e83c7afb86fe7296ba970990068baf819b16", size = 4190546, upload-time = "2026-05-01T23:28:50.016Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/c6/32b0835dbc2122617902b649d76a91c1e75406e76bf3d595b0c3bb5ffad6/psycopg_binary-3.3.4-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:773d573e11f437ce0bdb95b7c18dc58390494f96d43f8b45b9760436114f7652", size = 3926197, upload-time = "2026-05-01T23:28:55.55Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/68/d190ef0c0c5b16ded07831dabc8ddd412f4cdab07ec6e30ed38d9bda0e1f/psycopg_binary-3.3.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:71e55ccbdfae79a2ed9c6369c3008a3025817ff9d7e27b32a2d84e2a4267e66e", size = 4236627, upload-time = "2026-05-01T23:29:05.336Z" },
+    { url = "https://files.pythonhosted.org/packages/25/8f/81dcbc2e8454b74d14881275ea45f00791052dac531a9fa8be1730d1685b/psycopg_binary-3.3.4-cp312-cp312-win_amd64.whl", hash = "sha256:494ca54901be8cf9eb7e02c25b731f2317c378efa44f43e8f9bd0e1184ae7be4", size = 3560782, upload-time = "2026-05-01T23:29:11.967Z" },
+    { url = "https://files.pythonhosted.org/packages/09/43/13e9c406fbbf354580476e248a16b64802a376873ebe6339e30bb655572d/psycopg_binary-3.3.4-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:fbd1d4ed566895ad2d3bf4ddfd8bae90026930ddf29df3b9d91d32c8c47866a7", size = 4590377, upload-time = "2026-05-01T23:29:18.782Z" },
+    { url = "https://files.pythonhosted.org/packages/22/be/2923cd7c3683e7afdecf4f10796a18de02f5c5ddc0969aa2ad0a8cdd3bbd/psycopg_binary-3.3.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:75a9067e236f9b9ae3535b66fe99bddb33d39c0de10112e49b9ab11eee53dc31", size = 4669023, upload-time = "2026-05-01T23:29:25.884Z" },
+    { url = "https://files.pythonhosted.org/packages/96/a0/2c913d6fe13d6a8bd13597d36739bf47af063ad9399e402cfecab16f3c1e/psycopg_binary-3.3.4-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:b56b603ebcea8aa10b46228b8410ba7f13e7c2ee54389d4d9be0927fd8ce2a70", size = 5467423, upload-time = "2026-05-01T23:29:33.416Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/38/205d10bc1ad0df4a21c5c51659126bd3ea0ef98fcad1e852f78c249bb9c3/psycopg_binary-3.3.4-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c677c4ad433cb7150c8cd304a0769ae3bcfbe5ea0676eb53faa7b1443b16d0d3", size = 5151137, upload-time = "2026-05-01T23:29:42.013Z" },
+    { url = "https://files.pythonhosted.org/packages/36/fc/f0381ddcd45eff3bb70dbca6823a996048d7f507b2ec3fc92c6fabc0fe87/psycopg_binary-3.3.4-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:26df2717e59c0473e4465a97dfb1b7afebaa479277870fd5784d1436470db47c", size = 6736671, upload-time = "2026-05-01T23:29:51.626Z" },
+    { url = "https://files.pythonhosted.org/packages/95/40/fa545ae152c24327651e5624e4902121e808270be36c10b12e9939be09bc/psycopg_binary-3.3.4-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:1dc1f79fd16bb1f3f4421417a514607539f17804d95c7ed617265369d1981cae", size = 4979601, upload-time = "2026-05-01T23:29:56.961Z" },
+    { url = "https://files.pythonhosted.org/packages/86/e4/2f8a47ee97f90cd2b933d0463081d35631ff419de2b8c984a5f369857de0/psycopg_binary-3.3.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:136f199a407b5348b9b857c504aff60c77622a28482e7195839ce1b51238c4cc", size = 4510513, upload-time = "2026-05-01T23:30:07.243Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/0e/94e842ff4a7f98ed162580ca2e8b8864b28c1e0350f2443f8ee47f821167/psycopg_binary-3.3.4-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:b6f5a29e9c775b9f12a1a717aa7a2c80f9e1db6f27ba44a5b59c80ac61d2ffcf", size = 4187243, upload-time = "2026-05-01T23:30:15.352Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/83/fc6c174b672e29b7de996ea77b6cbddf46c891751c3355f6974292baa6b4/psycopg_binary-3.3.4-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:ee17a2cf4943cde261adfad1bbc5bf38d6b3776d7afff74c7cabcbeaeb08c260", size = 3927347, upload-time = "2026-05-01T23:30:21.186Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/65/768364d4a97a15b1a7f47ba52688c1686f22941d8332a8398cefc468e25f/psycopg_binary-3.3.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5c4ab71be17bdca30cb34c34c4e1496e2f5d6f20c199c12bad226070b22ef9bf", size = 4236393, upload-time = "2026-05-01T23:30:26.211Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/3b/218efbc9e645becd80cdf651acda05f85cfe546b7a9c0458c7cbc8fe1f74/psycopg_binary-3.3.4-cp313-cp313-win_amd64.whl", hash = "sha256:dbfdb9b6cc79f31104a7b162a2b921b765fcc62af6c00540a167a8de47e4ed38", size = 3564592, upload-time = "2026-05-01T23:30:31.764Z" },
+    { url = "https://files.pythonhosted.org/packages/48/a6/828c9185701dab71b234c2a76c38a08b098ebfec5020716b4e93807492b5/psycopg_binary-3.3.4-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:28b7398fdd19db3232c884fb24550bdfe951221f510e195e233299e4c9b78f97", size = 4607292, upload-time = "2026-05-01T23:30:38.962Z" },
+    { url = "https://files.pythonhosted.org/packages/92/58/5b40dbc9d839045c9dae956960e4fb6d20bcabe6c59a2aa34fc3a371913f/psycopg_binary-3.3.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1fbaa292a3c8bb61b45df1ad3da1908ccee7cb889db9425e3557d9e34e2a4829", size = 4687023, upload-time = "2026-05-01T23:30:47.227Z" },
+    { url = "https://files.pythonhosted.org/packages/85/a9/793f0ac107a9003b48441d0d1f9f616d96e0f37458dd8dc12528ceff55fb/psycopg_binary-3.3.4-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:94596f9e7633ee3f6440711d43bb70aa31cc0a46a900ab8b4201a366ace5c9e7", size = 5486985, upload-time = "2026-05-01T23:30:55.517Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/26/42e8533497e2592334f68ec529cf5f840f7fa4e99575a4bb61aa184dbfbf/psycopg_binary-3.3.4-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8c0056529e68dbe9184cd4019a1f3d8f3a4ead2f6fc7a5afcf27d3314edd1277", size = 5168745, upload-time = "2026-05-01T23:31:01.904Z" },
+    { url = "https://files.pythonhosted.org/packages/15/af/b7151776cc08d5935d45c833ec818a9beb417cf7c08239af1aafbdae78ee/psycopg_binary-3.3.4-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2c09aad7051326e7603c14e50636db9c01f78272dc54b3accff03d46370461e6", size = 6761486, upload-time = "2026-05-01T23:31:14.511Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/ed/c92533b9124712d592cbf1cd6c76da933a2e0acea81dfe1fbe7e735f0cff/psycopg_binary-3.3.4-cp314-cp314-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:514404ed543efd620c85602b747df2a23cf1241b4067199e1a66f2d2757aaa41", size = 4997427, upload-time = "2026-05-01T23:31:20.901Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/23/ccadfd0de416aa188356daa199453af24087b042e296088706d190ae0295/psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:46893c26858be12cc49ca4226ed6a60b4bfccadd946b3bebb783a60b38788228", size = 4533549, upload-time = "2026-05-01T23:31:26.204Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/a0/c8f43cee36386f7bc891ab41a9d31ea07cf9826038e732da79f26b1e5f34/psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:df1d567fc430f6df15c9fcf67d87685fc49bdb325adc0db5af1adfb2f44eb5c9", size = 4210256, upload-time = "2026-05-01T23:31:33.884Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/2c/c1547871be3790676e8868b38655496422f94f0978dfb66b74bdba2f1676/psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:6b9016b1714da4dd5ecaaa75b82098aa5a0b87854ce9b092e21c27c4ae23e014", size = 3946204, upload-time = "2026-05-01T23:31:39.626Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/b1/f6670f00fa7ea601584623f6c11602ab92117d83eaff885e0210f6de7418/psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:47c656a8a7ba6eb0cff1801a4caaa9c8bdc12d03080e273aff1c8ac39971a77e", size = 4255811, upload-time = "2026-05-01T23:31:44.986Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/e6/5fff07a70d1f945ed90ae131c3bd76cab32beff7c58c6db15ad5820b6d1f/psycopg_binary-3.3.4-cp314-cp314-win_amd64.whl", hash = "sha256:c37e024c07308cd06cf3ec51bfd0e7f6157585a4d84d1bce4a7f5f7913719bf8", size = 3666849, upload-time = "2026-05-01T23:31:51.165Z" },
 ]
 
 [[package]]
@@ -1218,6 +1278,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "tzdata"
+version = "2026.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/19/1b9b0e29f30c6d35cb345486df41110984ea67ae69dddbc0e8a100999493/tzdata-2026.2.tar.gz", hash = "sha256:9173fde7d80d9018e02a662e168e5a2d04f87c41ea174b139fbef642eda62d10", size = 198254, upload-time = "2026-04-24T15:22:08.651Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl", hash = "sha256:bbe9af844f658da81a5f95019480da3a89415801f6cc966806612cc7169bffe7", size = 349321, upload-time = "2026-04-24T15:22:05.876Z" },
 ]
 
 [[package]]

--- a/deploy/fly.toml
+++ b/deploy/fly.toml
@@ -4,8 +4,12 @@
 # from the same origin.
 #
 # Secrets (E2B_API_KEY, ANTHROPIC_API_KEY, SESSION_SECRET, GOOGLE_CLIENT_ID,
-# GOOGLE_CLIENT_SECRET, ABLY_API_KEY) are NOT in this file — set them with
-# `fly secrets set`. Only non-secret config lives in [env] below.
+# GOOGLE_CLIENT_SECRET, DATABASE_URL, API_KEYS) are NOT in this file — set them
+# with `fly secrets set`. Only non-secret config lives in [env] below.
+#
+# DB: with DATABASE_URL set to a Neon Postgres URL (a secret), the control plane
+# uses Postgres and nothing persistent remains on DATA_DIR — so there is no Fly
+# volume (see docs/plan/neon-postgres-plan.md). Unset → SQLite (local dev only).
 
 app = "genealogy-workbench"
 primary_region = "iad"
@@ -25,11 +29,10 @@ primary_region = "iad"
   # OAuth redirect_uri and the `secure` cookie flag (it starts with https).
   PUBLIC_URL = "https://genealogy-workbench.fly.dev"
 
-# SQLite DB + local viewer backup mirror persist on a Fly volume mounted at
-# DATA_DIR. Single volume => single instance until Postgres (see plan).
-[mounts]
-  source = "workbench_data"
-  destination = "/data"
+# No [mounts]: the DB lives on Neon Postgres (DATABASE_URL secret) and the
+# feedback + viewer-mirror writers are already off DATA_DIR, so nothing
+# persistent remains on disk. Destroy the old `workbench_data` volume after a
+# clean deploy (`fly volumes destroy …`). See docs/plan/neon-postgres-plan.md.
 
 [http_service]
   internal_port = 8000

--- a/docs/TODOs.md
+++ b/docs/TODOs.md
@@ -15,6 +15,19 @@ Deferred items to revisit. Not blocking the alpha. Architecture context:
   it's still the dev default, so a deploy can't silently mint forgeable
   per-sandbox WS tokens.
 
+## Before horizontal scaling (`count > 1`)
+- [ ] **`init_db` → Fly `release_command`** — move `init_db()` (`create_all()` +
+  the allowlist seed) off the per-boot path into a one-time Fly `release_command`
+  that runs once before any Machine starts. At `count > 1`, two Machines booting
+  together race: both pass `create_all`'s existence check then both `CREATE TABLE`,
+  and both see an allowlist email absent then both `INSERT` the same PK
+  (`IntegrityError`) — crashing a boot. **Not needed at `count = 1`** (single
+  always-on Machine; no concurrent boot — harmless). Required before
+  `fly scale count > 1`. See `docs/plan/neon-postgres-plan.md` § "Also before
+  count > 1". (The other former `count > 1` blockers are already cleared: the DB
+  pin by the Neon migration, and the `LiveSession` pin by the shipped
+  sandbox-as-server arch; the `/v1` turn lock is already DB-backed.)
+
 ## Depends on other work
 - [ ] **Wiki page tools corpus** — `wiki_read` / `wiki_place_page` need the
   pre-crawled wiki markdown (`wikiMarkdownDir`). Being handled by baking the
@@ -22,6 +35,7 @@ Deferred items to revisit. Not blocking the alpha. Architecture context:
   point those tools at it (or move them to the networked API like `wiki_search`).
   Until then they error; everything else works.
 
-## Dropped (revisit only if needed)
-- `/v1` public REST chat API (`docs/plan/public-rest-api.md`) — deferred; would
-  re-base onto a server-side WSS-to-sandbox proxy.
+## Done
+- ~~`/v1` public REST chat API~~ — **shipped** (#294) as a control-plane
+  WS-client to the in-sandbox server; bearer auth, sync + SSE, DB-backed turn
+  lock. Spec: `docs/plan/public-rest-api.md`.

--- a/docs/plan/neon-postgres-plan.md
+++ b/docs/plan/neon-postgres-plan.md
@@ -5,6 +5,21 @@
 (current state). **Touches:** `apps/server/app/{config,db,models,main}.py`,
 `apps/server/pyproject.toml`, `deploy/fly.toml`.
 
+> **Status: implemented** (the code changes below + `apps/server/uv.lock`,
+> `apps/server/tests/conftest.py`). Verified locally on **SQLite** (`make
+> server-test`, 30 green) and against a **live Postgres** (throwaway Docker pg):
+> `/api/health` → `db:"postgres"`, `create_all()` builds all four tables, and a
+> `/v1` create → message → delete round-trip works (the message exercises the
+> turn-lock guarded `UPDATE` on native `timestamptz`). **Still manual** (deploy
+> ops, no code): create the Neon project, `fly secrets set DATABASE_URL=…`,
+> deploy, then `fly volumes destroy workbench_data`. The Docker image build
+> (verification §4) was not run — low risk (psycopg ships a manylinux wheel and
+> `uv lock` resolved it). The "What this does and doesn't unblock" section below
+> is **superseded**: the `LiveSession`/`session_manager` pin it describes is gone
+> (sandbox-as-server already shipped), and the `/v1` turn lock is already
+> DB-backed — so the only remaining `count > 1` prerequisite in code terms is the
+> `init_db` `release_command` (still out of scope here).
+
 ---
 
 ## Context


### PR DESCRIPTION
Implements [`docs/plan/neon-postgres-plan.md`](../blob/main/docs/plan/neon-postgres-plan.md). The DB backend is selected by a single env var, **`DATABASE_URL`**:

- **Unset** → SQLite under `DATA_DIR` (local dev, zero-setup — unchanged).
- **Set** → Postgres (Neon on Fly, provided as a Fly secret).

The schema is pure SQLModel, so every query and `create_all()` work identically on both — the change is engine wiring, one dependency, and a datetime-type hardening.

## Changes
- **`config.py`** — `database_url` + `sqlalchemy_url` (normalizes `postgres://`/`postgresql://` to the explicit `psycopg3` driver) + `is_sqlite`.
- **`db.py`** — branch the engine: SQLite `check_same_thread` arg for SQLite; `pool_pre_ping` + `pool_recycle=300` for Postgres (keeps the pool correct across Neon scale-to-zero resumes).
- **`models.py`** — declare all datetime columns `TIMESTAMP WITH TIME ZONE` (shared `_TZ` alias) so Postgres read-back stays tz-aware; SQLite round-trips either way.
- **`main.py`** — `/api/health` now reports `db: "sqlite" | "postgres"`.
- **`pyproject.toml` + `uv.lock`** — add `psycopg[binary]>=3.2` (manylinux wheel; no Dockerfile/apt change on `python:3.12-slim`).
- **`tests/conftest.py`** — force `DATABASE_URL=""` so the suite always runs on SQLite, even if a dev `.env` points at Postgres.
- **`deploy/fly.toml`** — drop the `[mounts]` volume; nothing persistent remains on `DATA_DIR` once the DB is on Neon.

## Verification
- `make server-test` green on the **SQLite** default (30).
- **Live Postgres** (throwaway Docker pg): `/api/health` → `db:"postgres"`, `create_all()` builds all 4 tables, and a `/v1` create → message → delete round-trips — the message exercises the turn-lock guarded `UPDATE` on native `timestamptz`.

## Deploy (manual — not in this PR)
Create the Neon project, `fly secrets set DATABASE_URL=…` (direct, non-pooler endpoint), deploy, then `fly volumes destroy workbench_data`. **Stay at `count = 1`** — `count > 1` still needs the `init_db` `release_command` (out of scope here; the `LiveSession` pin the plan named is already resolved by the shipped sandbox-as-server arch, and the `/v1` turn lock is already DB-backed).

## Out of scope (per the plan)
Alembic/migrations, SQLite→Postgres data migration, the `init_db` `release_command` + multi-Machine `fly.toml` tuning, the `REALTIME` cutover, and the eventual Neon→RDS move (a `DATABASE_URL` swap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)