### PR TITLE
Local dev-login: drop the allowlist, optional email, https backstop

### DIFF
--- a/apps/server/app/auth.py
+++ b/apps/server/app/auth.py
@@ -141,7 +141,7 @@ def get_api_client(
 
 # ── endpoints ────────────────────────────────────────────────────
 class DevLoginBody(BaseModel):
-    email: str
+    email: str = ""  # optional in dev-login: blank → a default local identity
 
 
 class MeResponse(BaseModel):
@@ -154,22 +154,32 @@ def me(user: User = Depends(get_current_user)) -> MeResponse:
     return MeResponse(id=user.id, email=user.email)
 
 
+def _dev_login_enabled(s) -> bool:
+    """Dev-login is a LOCAL convenience only: offered when Google isn't configured
+    AND we're not on a deployed (https) host. The https guard is a backstop so a
+    deploy that forgot to set GOOGLE_CLIENT_ID can't expose an allowlist-free,
+    open-signup endpoint — dev-login is never deployed (see DEVELOPMENT.md)."""
+    return not s.google_client_id and not s.public_url.startswith("https")
+
+
 @router.get("/config")
 def auth_config() -> dict:
     """Tells the client which login methods are available."""
     s = get_settings()
-    return {"google": bool(s.google_client_id), "devLogin": not bool(s.google_client_id)}
+    return {"google": bool(s.google_client_id), "devLogin": _dev_login_enabled(s)}
 
 
 @router.post("/dev-login", response_model=MeResponse)
 def dev_login(
     body: DevLoginBody, response: Response, session: Session = Depends(get_session)
 ) -> MeResponse:
-    if get_settings().google_client_id:
+    if not _dev_login_enabled(get_settings()):
         raise HTTPException(status_code=403, detail="Dev-login disabled; use Google sign-in")
-    email = body.email.strip().lower()
-    if not _is_allowed(session, email):
-        raise HTTPException(status_code=403, detail="Email not on the allowlist")
+    # No allowlist locally — any email signs in, so you can simulate distinct users
+    # (per-user session lists, ownership, /v1 cross-client isolation). The prod
+    # access gate is the Google callback's allowlist, which is unaffected. A blank
+    # email gets a default identity for one-click sign-in.
+    email = body.email.strip().lower() or "dev@localhost"
     user = _upsert_user(session, email)
     set_session_cookie(response, user.id)
     return MeResponse(id=user.id, email=user.email)

--- a/apps/server/tests/test_sessions.py
+++ b/apps/server/tests/test_sessions.py
@@ -1,9 +1,10 @@
 """Session lifecycle over the real REST surface + LocalProvider:
-dev-login (with allowlist gate) → create sample session → list → resume →
+dev-login (local, no allowlist) → create sample session → list → resume →
 delete. Also asserts the sample seed lands real project files on the sandbox FS.
 """
 from fastapi.testclient import TestClient
 
+from app.config import get_settings
 from app.main import app
 
 
@@ -12,15 +13,35 @@ def test_unauthenticated_is_rejected():
         assert client.get("/api/sessions").status_code == 401
 
 
-def test_allowlist_blocks_unknown_email():
+def test_dev_login_accepts_any_email_locally():
+    # No allowlist on the local dev-login path — any email signs in (the prod gate
+    # is the Google callback's allowlist, exercised separately).
     with TestClient(app) as client:
         r = client.post("/auth/dev-login", json={"email": "stranger@example.com"})
+        assert r.status_code == 200, r.text
+        assert r.json()["email"] == "stranger@example.com"
+
+
+def test_dev_login_blank_email_defaults():
+    with TestClient(app) as client:
+        r = client.post("/auth/dev-login", json={})  # email omitted
+        assert r.status_code == 200, r.text
+        assert r.json()["email"] == "dev@localhost"
+
+
+def test_dev_login_refused_when_deployed(monkeypatch):
+    # Backstop: on an https (deployed) host, dev-login is off even if Google was
+    # never configured — so a misconfigured deploy can't become open signup.
+    monkeypatch.setattr(get_settings(), "public_url", "https://example.com")
+    with TestClient(app) as client:
+        assert client.get("/auth/config").json()["devLogin"] is False
+        r = client.post("/auth/dev-login", json={"email": "anyone@example.com"})
         assert r.status_code == 403
 
 
 def test_session_lifecycle_and_sample_seed():
     with TestClient(app) as client:
-        # Login (allowlisted).
+        # Login (any email; no allowlist locally).
         r = client.post("/auth/dev-login", json={"email": "tester@example.com"})
         assert r.status_code == 200, r.text
         assert r.json()["email"] == "tester@example.com"

--- a/apps/web/src/components/LoginScreen.tsx
+++ b/apps/web/src/components/LoginScreen.tsx
@@ -46,19 +46,18 @@ export default function LoginScreen(): React.JSX.Element {
         {config?.devLogin && (
           <form onSubmit={handleDevLogin} className="loginForm">
             <label className="fieldLabel" htmlFor="email">
-              Email (dev sign-in — must be allowlisted)
+              Email (dev sign-in — any email; blank signs in as a default user)
             </label>
             <input
               id="email"
               type="email"
               className="textInput"
-              placeholder="you@example.com"
+              placeholder="you@example.com (optional)"
               value={email}
               onChange={(e) => setEmail(e.target.value)}
               autoComplete="email"
-              required
             />
-            <button className="btnPrimary block" type="submit" disabled={busy || !email.trim()}>
+            <button className="btnPrimary block" type="submit" disabled={busy}>
               {busy ? 'Signing in…' : 'Continue'}
             </button>
           </form>


### PR DESCRIPTION
You asked: in non-OAuth (dev-login) mode, why require allowlisted emails — anyone should be able to sign in locally, and maybe we don't even need the email.

**Agreed, and implemented.** Dev-login is a local-only convenience — it's offered only when Google OAuth isn't configured. Requiring the email to be on `ALLOWED_EMAILS` was pure local friction; it never gates production (where the access control is the **Google callback's allowlist**, untouched here).

## Changes
- **No allowlist on `/auth/dev-login`** — any email signs in. This keeps local multi-user testing possible (per-user session lists, `_owned` ownership, `/v1` cross-client isolation), which a single fixed identity would collapse.
- **Email is optional** — blank → `dev@localhost` (one-click sign-in). `LoginScreen` field no longer `required`, relabeled.
- **https backstop** — `_dev_login_enabled()` also refuses dev-login when `public_url` is `https` (a deployed posture). So a deploy that forgot to set `GOOGLE_CLIENT_ID` can't turn into an allowlist-free, open-signup endpoint — we don't rely on the "never deployed" promise. `/auth/config` reports `devLogin` accordingly so the UI hides the form there too.

## Not changed
The Google OIDC path and its allowlist (`google_callback` → `_is_allowed`) — production access control is unaffected.

## Tests
Replaced `test_allowlist_blocks_unknown_email` with: any-email-accepted, blank-email-defaults-to-`dev@localhost`, and refused-when-deployed (https). Server suite green (33); web typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)