### PR TITLE
/v1: accept a FamilySearch token at session create

### DIFF
--- a/apps/server/app/sessions.py
+++ b/apps/server/app/sessions.py
@@ -9,7 +9,7 @@ import re
 from datetime import datetime
 
 from fastapi import APIRouter, Depends, HTTPException, Request, Response
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from sqlmodel import Session, select
 
 from . import fs_oauth
@@ -53,6 +53,21 @@ class ProjectOut(BaseModel):
         )
 
 
+class FsTokenIn(BaseModel):
+    """A FamilySearch token bundle a `/v1` client supplies at session create. Unlike
+    the browser path (whose token comes from the FS app-login row), `/v1` clients never
+    run FS OAuth, so they pass the token here; it is injected straight into the sandbox
+    and **never persisted** to the control-plane DB.
+
+    Include `refresh_token` (OAuth `offline_access`) so the in-sandbox MCP can
+    self-refresh: with it the session lasts as long as the sandbox; without it the
+    session works only until the access token expires (FS access tokens last ~1h, so a
+    multi-hour session needs the refresh token)."""
+    access_token: str = Field(min_length=1)
+    refresh_token: str | None = None
+    expires_in: int | None = None  # seconds from now; defaults to 3600 (FS default)
+
+
 class CreateSessionBody(BaseModel):
     title: str | None = None
     model: str | None = None
@@ -81,9 +96,14 @@ async def create_project(
     title: str | None = None,
     model: str | None = None,
     sample: bool = False,
+    fs_token: FsTokenIn | None = None,
 ) -> Project:
     """Provision a sandbox + record the user→sandbox map. Shared by the browser
-    `create_session` route and the public `/v1` create route."""
+    `create_session` route and the public `/v1` create route.
+
+    `fs_token`, when given, is a caller-supplied FamilySearch token (the `/v1` path)
+    that takes precedence over the user's stored row and is injected but not persisted.
+    """
     import uuid
 
     settings = get_settings()
@@ -91,16 +111,25 @@ async def create_project(
     sandbox = await provider.create(
         SandboxSpec(template=settings.e2b_template, labels={"user_id": user.id}, model=model)
     )
-    # Inject the user's FamilySearch token so the in-sandbox MCP is authenticated
-    # without an interactive login (which it cannot run). FS login is the app front
-    # door, so a real token exists for every real-FS user; the offline/dev-login
-    # (mock-agent) path has no row and needs none — mock mode never reads it. In
-    # create_project (not the route) so the /v1 create path injects it too.
-    fs_token = session.get(FamilySearchToken, user.id)
+    # Inject the FamilySearch token so the in-sandbox MCP is authenticated without an
+    # interactive login (which it cannot run). Two sources, explicit wins:
+    #   • /v1: the caller supplies the token in the create request (no DB row exists —
+    #     /v1 clients authenticate by bearer key, never via FS OAuth).
+    #   • browser: the user's row, persisted at FS app login (the front door).
+    # The offline/dev-login (mock-agent) path has neither and needs none — mock mode
+    # never reads it. In create_project (not the route) so the /v1 path injects too.
     if fs_token is not None:
+        token_json = {"expires_in": fs_token.expires_in} if fs_token.expires_in is not None else {}
         await fs_oauth.write_tokens(
-            sandbox, fs_token.access_token, fs_token.refresh_token, fs_token.expires_at
+            sandbox, fs_token.access_token, fs_token.refresh_token,
+            fs_oauth.expires_at_from(token_json),
         )
+    else:
+        row = session.get(FamilySearchToken, user.id)
+        if row is not None:
+            await fs_oauth.write_tokens(
+                sandbox, row.access_token, row.refresh_token, row.expires_at
+            )
     if sample:
         await seed_sample_project(sandbox)
 

--- a/apps/server/app/v1.py
+++ b/apps/server/app/v1.py
@@ -45,7 +45,7 @@ from .db import get_engine, get_session
 from .models import Project, User, utcnow
 from .sandbox import SandboxProvider
 from .sandbox.base import SANDBOX_WS_PORT
-from .sessions import _owned, create_project, get_provider
+from .sessions import FsTokenIn, _owned, create_project, get_provider
 from .ws_token import mint_token
 
 router = APIRouter(prefix="/v1", tags=["public-api"])
@@ -77,6 +77,11 @@ class SessionOut(BaseModel):
 class CreateBody(BaseModel):
     title: str | None = None
     model: str | None = None
+    # Optional FamilySearch token to authenticate the in-sandbox MCP for this session.
+    # /v1 clients have no FS app-login row, so they pass it here; it is injected into
+    # the sandbox at create and never persisted. Include refresh_token for sessions
+    # that outlive the ~1h access-token TTL (see FsTokenIn). Omit → FS-tool-less session.
+    familysearch_token: FsTokenIn | None = None
 
 
 class MessageBody(BaseModel):
@@ -310,6 +315,7 @@ async def create_v1_session(
 ) -> SessionOut:
     project = await create_project(
         session=session, provider=provider, user=user, title=body.title, model=body.model,
+        fs_token=body.familysearch_token,
     )
     return SessionOut(
         session_id=project.id, title=project.title, model=project.model, created_at=project.created,

--- a/apps/server/tests/test_v1_api.py
+++ b/apps/server/tests/test_v1_api.py
@@ -39,6 +39,17 @@ def _seed_active(sid: str):
     proj.mkdir(parents=True, exist_ok=True)
     (proj / "research.json").write_text('{"project":{"id":"seed"}}')
 
+def _tokens_path(sid: str):
+    """Path to the FS tokens.json injected for a /v1 session's sandbox (LocalProvider),
+    mirroring where the in-sandbox MCP reads it (HOME_DIR/.familysearch-mcp)."""
+    with Session(get_engine()) as s:
+        sandbox_id = s.get(Project, sid).sandbox_id
+    return (
+        app.state.provider._root(sandbox_id)
+        / "home" / "user" / ".familysearch-mcp" / "tokens.json"
+    )
+
+
 K = {"Authorization": "Bearer sk_test"}
 K_OTHER = {"Authorization": "Bearer sk_other"}
 
@@ -80,6 +91,66 @@ def test_operator_granted_key_bypasses_allowlist():
 def test_validation_error_envelope():
     with TestClient(app) as client:
         r = client.post("/v1/sessions/prj_x/messages", json={}, headers=K)  # missing message
+        assert r.status_code == 422
+        assert r.json()["error"]["code"] == "validation_error"
+
+
+# ── FamilySearch token injection at create ───────────────────────
+def test_create_injects_supplied_familysearch_token():
+    """A /v1 client with no FS app-login row supplies the token in the create body;
+    it lands in the sandbox in the engine's tokens.json shape, ready for the in-sandbox
+    MCP to self-refresh."""
+    with TestClient(app) as client:
+        r = client.post("/v1/sessions", json={
+            "title": "t",
+            "familysearch_token": {
+                "access_token": "v1-access",
+                "refresh_token": "v1-refresh",
+                "expires_in": 3600,
+            },
+        }, headers=K)
+        assert r.status_code == 201, r.text
+        sid = r.json()["session_id"]
+        assert "familysearch_token" not in r.json()  # not echoed back
+
+        tok = json.loads(_tokens_path(sid).read_text())
+        assert tok["accessToken"] == "v1-access"
+        assert tok["refreshToken"] == "v1-refresh"
+        assert isinstance(tok["expiresAt"], int) and tok["expiresAt"] > 0
+        client.delete(f"/v1/sessions/{sid}", headers=K)
+
+
+def test_create_token_not_persisted_to_db():
+    """The supplied token is injected into the sandbox only — never written to the
+    control-plane familysearch_tokens table (sidesteps encrypt-at-rest for /v1)."""
+    from app.models import FamilySearchToken
+
+    with TestClient(app) as client:
+        r = client.post("/v1/sessions", json={
+            "familysearch_token": {"access_token": "v1-access", "refresh_token": "v1-refresh"},
+        }, headers=K)
+        sid = r.json()["session_id"]
+        with Session(get_engine()) as s:
+            user_id = s.get(Project, sid).user_id
+            assert s.get(FamilySearchToken, user_id) is None
+        client.delete(f"/v1/sessions/{sid}", headers=K)
+
+
+def test_create_without_token_injects_nothing():
+    """No token supplied → no tokens.json (the FS-tool-less /v1 path; mock mode here
+    never reads it)."""
+    with TestClient(app) as client:
+        sid = _create(client)
+        assert not _tokens_path(sid).exists()
+        client.delete(f"/v1/sessions/{sid}", headers=K)
+
+
+def test_create_rejects_blank_access_token():
+    """An empty access_token fails validation with the public envelope (min_length=1)."""
+    with TestClient(app) as client:
+        r = client.post("/v1/sessions", json={
+            "familysearch_token": {"access_token": ""},
+        }, headers=K)
         assert r.status_code == 422
         assert r.json()["error"]["code"] == "validation_error"
 

--- a/docs/TODOs.md
+++ b/docs/TODOs.md
@@ -44,12 +44,6 @@ create. Google is gone. Follow-ups (`docs/plan/familysearch-login-plan.md`):
   for the bundled client id before the Fly deploy's login works. Locally it rides
   the desktop loopback registration. See `docs/plan/fly-deploy-plan.md` §
   OAuth-redirect.
-- [ ] **`/v1` sessions have no FamilySearch token** — `/v1` clients authenticate
-  by bearer key (no FS OAuth), so they have no `familysearch_tokens` row and
-  `create_project` injects nothing; a real-agent FS tool call in a `/v1` session
-  fails with "not logged in." `/v1` calls will need to supply a token somehow —
-  operator-provisioned per key, a shared service token, or a per-request token.
-  Decide the mechanism, or document `/v1` as FS-tool-less.
 - [ ] **Encrypt FS tokens at rest** — `familysearch_tokens.access_token` /
   `refresh_token` are plaintext (`models.py` TODO). Encrypt before any real PII /
   wider alpha.
@@ -64,6 +58,14 @@ create. Google is gone. Follow-ups (`docs/plan/familysearch-login-plan.md`):
   use) so an allowlisted email can't be claimed on a throwaway FS account.
 
 ## Done
+- ~~`/v1` FamilySearch token mechanism~~ — **shipped**: `POST /v1/sessions` accepts an
+  optional `familysearch_token` ({`access_token`, `refresh_token?`, `expires_in?`}),
+  injected straight into the sandbox at create and **not** persisted. Include the
+  refresh token for sessions that outlive the ~1h access-token TTL — the in-sandbox
+  `getValidToken()` self-refreshes, so one create-time injection covers the sandbox's
+  life (same as the browser path). Omit it for an FS-tool-less session. Mechanism chosen:
+  per-request token at create (caller may pass a per-client or shared service token).
+  See `docs/plan/public-rest-api.md` § `POST /v1/sessions`.
 - ~~`/v1` public REST chat API~~ — **shipped** (#294) as a control-plane
   WS-client to the in-sandbox server; bearer auth, sync + SSE, DB-backed turn
   lock. Spec: `docs/plan/public-rest-api.md`.

--- a/docs/plan/public-rest-api.md
+++ b/docs/plan/public-rest-api.md
@@ -129,12 +129,25 @@ fall through to FastAPI's defaults.
 
 ### `POST /v1/sessions` → create — `201`
 ```jsonc
-// req  (both optional)
-{ "title": "Cork research", "model": "claude-sonnet-4-6" }
+// req  (all optional)
+{ "title": "Cork research", "model": "claude-sonnet-4-6",
+  // FamilySearch token for the in-sandbox MCP. /v1 clients have no FS app-login row,
+  // so they pass it here; injected into the sandbox at create, never persisted.
+  "familysearch_token": { "access_token": "…", "refresh_token": "…", "expires_in": 3600 } }
 // res 201  — lean SessionOut: no sandbox_id / agent_session_id / status / sample
 { "session_id": "prj_…", "title": "Cork research",
   "model": "claude-sonnet-4-6", "created_at": "2026-06-07T23:18:14Z" }
 ```
+- `familysearch_token` is **optional**. Omit it for an FS-tool-less session (the agent
+  runs but FS-authenticated tools fail with "not logged in"). Supply it to authenticate
+  FS tools. Only `access_token` is required; `expires_in` defaults to 3600s.
+- **Include `refresh_token`** (OAuth `offline_access`) for any session that may outlive
+  the access token: FS access tokens last ~1h, so a multi-hour session needs it. The
+  token is self-refreshed **in-sandbox** by the engine's `getValidToken()` — the same
+  mechanism the browser path relies on — so a single create-time injection suffices for
+  the life of the sandbox. Without a refresh token the session works only until the
+  access token expires. The token is injected straight into the sandbox and is **not**
+  written to the `familysearch_tokens` table (so /v1 sidesteps encrypt-at-rest).
 
 ### `POST /v1/sessions/{session_id}/messages` → send + reply
 ```jsonc
@@ -189,8 +202,11 @@ Lets the team release sandbox resources promptly.
   allowlist governs self-service login only.
 - **`models.py`** — `Project.turn_locked_at: datetime | None` (nullable,
   `DateTime(timezone=True)`) — the DB-backed turn lock (see above).
-- **`sessions.py`** — `create_project(*, session, provider, user, title, model, sample)`
-  factored out of `create_session`; `_owned` reused for ownership/isolation.
+- **`sessions.py`** — `create_project(*, session, provider, user, title, model, sample,
+  fs_token)` factored out of `create_session`; `_owned` reused for ownership/isolation.
+  `fs_token` (a `FsTokenIn`) is the optional caller-supplied FamilySearch token: when
+  present it is injected into the sandbox and takes precedence over the user's stored
+  row (and is never persisted); when absent the browser path's DB-row lookup runs.
 - **`app/v1.py`** — `APIRouter(prefix="/v1")`, all routes `Depends(get_api_client)`.
   `_acquire_turn` / `_release_turn` (the guarded-UPDATE lock), `_open_ws` (resume+
   expose+mint, with a brief connect-retry since we connect to the freshly-launched WS
@@ -232,11 +248,13 @@ multi-instance-correct — it's DB-backed.)
 
 Runs fully on mocks (`agent_mode=mock`, `sandbox=local`).
 
-- **`apps/server/tests/test_v1_api.py`** (10 tests, green; full suite 27 green): sync
-  assembled text; SSE `done` text equals sync; `409 session_busy` (a held DB lock);
-  **stale lock reclaimed** (a lock past the TTL doesn't wedge the session);
-  `422`/`401`/`404` envelopes; operator-granted key bypasses the allowlist; cross-client
-  `404` isolation; delete releases the sandbox and `404`s after.
+- **`apps/server/tests/test_v1_api.py`** (green): sync assembled text; SSE `done` text
+  equals sync; `409 session_busy` (a held DB lock); **stale lock reclaimed** (a lock
+  past the TTL doesn't wedge the session); `422`/`401`/`404` envelopes; operator-granted
+  key bypasses the allowlist; cross-client `404` isolation; delete releases the sandbox
+  and `404`s after; **create-time FamilySearch token injection** (a supplied token lands
+  in the sandbox tokens.json, is not persisted to the DB, is absent when omitted, and a
+  blank `access_token` is a `422`).
 - **Live smoke** (`API_KEYS=sk_dev:… uvicorn app.main:app`): create → two sequential
   sync turns on the same session that **advance the agent's conversation state** (greet
   → experience acknowledged), confirming both the long-lived agent process / cross-turn


### PR DESCRIPTION
## What

Resolves the open `docs/TODOs.md` item **"`/v1` sessions have no FamilySearch token."** `/v1` clients authenticate by bearer key (no FS OAuth), so they have no `familysearch_tokens` row and `create_project` injected nothing — any FS-authenticated tool call in a `/v1` session failed with *"not logged in."*

`POST /v1/sessions` now accepts an **optional** `familysearch_token`:

```jsonc
{ "title": "Cork research",
  "familysearch_token": { "access_token": "…", "refresh_token": "…", "expires_in": 3600 } }
```

## Mechanism (and why)

- **Per-request token at create**, injected straight into the sandbox's `tokens.json` via the existing `fs_oauth.write_tokens`, and **not persisted** to the DB — so `/v1` sidesteps the separate encrypt-FS-tokens-at-rest follow-up.
- **Create-time injection is sufficient** because the engine's in-sandbox `getValidToken()` self-refreshes from the `refresh_token` — the exact mechanism the browser path already relies on. One injection covers the life of the sandbox, which is enough for the multi-hour sessions `/v1` targets.
- The crux: **include a `refresh_token`** for any session that may outlive the ~1h FS access-token TTL. Only `access_token` is required (`expires_in` defaults to 3600s). Omit the whole field for an FS-tool-less session.
- The caller can pass a per-client token or an operator-provisioned shared service token — both are just "a token at create."

Threaded through `create_project(..., fs_token=...)`: an explicit token wins; otherwise the browser path's DB-row lookup runs unchanged. No change to the browser create path.

## Tests

Added to `apps/server/tests/test_v1_api.py` (server suite green, 38 → 42):
- supplied token lands in the sandbox `tokens.json` in the engine shape (`accessToken`/`refreshToken`/`expiresAt`)
- token is **never** written to `familysearch_tokens`
- no token supplied → no `tokens.json`
- blank `access_token` → `422` validation envelope

## Docs
- `docs/plan/public-rest-api.md` — create-body contract + implementation notes
- `docs/TODOs.md` — moved the item to **Done** with the chosen mechanism

🤖 Generated with [Claude Code](https://claude.com/claude-code)