### PR TITLE
Fix Fly.io control-plane deploy (FS client id in image, .env autoload, drift cleanup)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,25 @@
+# Build-context hygiene for deploy/Dockerfile (context = repo root) and the E2B
+# sandbox image. The multi-stage builds install deps and compile fresh, so local
+# installs and build outputs are noise — excluding them shrinks the context that
+# gets uploaded to the (remote) builder from ~1.5 GB to a few MB.
+#
+# NOTE: dist/ is built INSIDE the image (stage `web`) and copied via --from=web,
+# so excluding the host's local dist/ is correct — it is never the source.
+
+**/node_modules
+.git
+**/.venv
+**/__pycache__
+**/*.pyc
+**/dist
+**/.turbo
+**/.next
+releases
+.workbench-data
+eval
+*.log
+.DS_Store
+
+# NB: do NOT add **/build — the E2B sandbox image (apps/server/sandbox/
+# e2b.Dockerfile) shares this context and COPYs packages/engine/mcp-server/build.
+# Excluding it would bake a broken template. The deploy image copies no build/.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -339,8 +339,10 @@ fly secrets set \
   FAMILYSEARCH_WEB_ENABLED=true \
   ALLOWED_EMAILS="you@familysearch-account-email" API_KEYS="sk_live_…:chatbot@yourco.com"
 
-# Build context is the REPO ROOT (the Dockerfile copies the pnpm workspace):
-fly deploy --config deploy/fly.toml --dockerfile deploy/Dockerfile .
+# Build context is the REPO ROOT (the Dockerfile copies the pnpm workspace).
+# --ha=false: fly deploy otherwise provisions TWO machines (HA), which violates
+# the count = 1 invariant below until init_db moves to a release_command.
+fly deploy --config deploy/fly.toml --dockerfile deploy/Dockerfile . --ha=false
 
 curl -s https://genealogy-workbench.fly.dev/api/health | jq   # expect "db":"postgres"
 fly volumes destroy workbench_data    # if a volume lingers from a pre-Neon deploy
@@ -355,7 +357,9 @@ config lives in `deploy/fly.toml` `[env]` (`AGENT_MODE=real`, `SANDBOX_PROVIDER=
 **Stay at `count = 1`.** `fly scale count > 1` first needs `init_db()` moved to a
 one-time Fly `release_command` (two Machines otherwise race on `create_all` + the
 allowlist seed); tracked in [`docs/TODOs.md`](./docs/TODOs.md). Sticky routing is
-not an option (production is AWS-no-sticky).
+not an option (production is AWS-no-sticky). Because `fly deploy` provisions two
+machines by default, always pass `--ha=false` (above); if a deploy ever leaves
+two, run `fly scale count 1` to drop back to one.
 
 ## Troubleshooting
 

--- a/apps/server/sandbox/build-image.sh
+++ b/apps/server/sandbox/build-image.sh
@@ -21,6 +21,18 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
 cd "${ROOT}"
 
+# Auto-load apps/server/.env — the established home for these keys (the same file
+# e2b-preflight checks and pydantic reads for `make server-e2b`). Saves a manual
+# `export`/`source`. The e2b CLI authenticates the build with E2B_ACCESS_TOKEN;
+# E2B_API_KEY is what the control plane uses at runtime — both live there.
+ENV_FILE="${ROOT}/apps/server/.env"
+if [[ -f "${ENV_FILE}" ]]; then
+  set -a
+  # shellcheck source=/dev/null
+  source "${ENV_FILE}"
+  set +a
+fi
+
 echo "==> [1/2] Building the genealogy engine (mcp-server)..."
 ( cd "${ROOT}/packages/engine/mcp-server" && npm install && npm run build )
 test -f "${ROOT}/packages/engine/mcp-server/build/index.js" \

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -57,10 +57,21 @@ COPY --from=pydeps /app/server/.venv /app/server/.venv
 COPY apps/server/app /app/server/app
 # Built web client, served by the control plane (StaticFiles mount in main.py).
 COPY --from=web /repo/apps/web/dist /app/server/web-dist
+# Bundled FamilySearch OAuth client id. config.py reads it from
+# REPO_ROOT/packages/engine/mcp-server/config/familysearch.json, and REPO_ROOT
+# resolves to "/" in this image (the server lives at /app/server/app, so
+# config.py's parents[3] is "/"). The file must therefore land at this absolute
+# path. Without it familysearch_configured is False → the FS login route 501s
+# AND https disables dev-login, i.e. NO login works. (The rest of the engine is
+# NOT baked into this control-plane image — only this one config file is.)
+COPY packages/engine/mcp-server/config/familysearch.json /packages/engine/mcp-server/config/familysearch.json
 
 # Where the StaticFiles mount looks for the built client.
 ENV WEB_DIST_DIR=/app/server/web-dist
-# SQLite + the local viewer backup mirror live under DATA_DIR (the Fly volume).
+# get_settings() mkdirs its work dir under DATA_DIR. With the DB on Neon
+# (DATABASE_URL secret) and feedback + viewer-mirror already off-disk, nothing
+# persistent lives here, so there is NO Fly volume — DATA_DIR just needs to be a
+# writable path in the ephemeral container fs.
 ENV DATA_DIR=/data
 
 EXPOSE 8000

--- a/deploy/fly.toml
+++ b/deploy/fly.toml
@@ -3,9 +3,10 @@
 # control plane serves the REST + /ws WebSocket API AND the static web client
 # from the same origin.
 #
-# Secrets (E2B_API_KEY, ANTHROPIC_API_KEY, SESSION_SECRET, GOOGLE_CLIENT_ID,
-# GOOGLE_CLIENT_SECRET, DATABASE_URL, API_KEYS) are NOT in this file — set them
-# with `fly secrets set`. Only non-secret config lives in [env] below.
+# Secrets (E2B_API_KEY, ANTHROPIC_API_KEY, SESSION_SECRET, WS_SIGNING_KEY,
+# DATABASE_URL, ALLOWED_EMAILS, API_KEYS) are NOT in this file — set them with
+# `fly secrets set`. Only non-secret config lives in [env] below. (Login is
+# unified FamilySearch OAuth — there is no Google client.)
 #
 # DB: with DATABASE_URL set to a Neon Postgres URL (a secret), the control plane
 # uses Postgres and nothing persistent remains on DATA_DIR — so there is no Fly
@@ -22,7 +23,9 @@ primary_region = "iad"
   WEB_DIST_DIR = "/app/server/web-dist"
   AGENT_MODE = "real"
   SANDBOX_PROVIDER = "e2b"
-  REALTIME = "local_ws"           # alpha relays /ws on this container; flip to "ably" later
+  # No REALTIME var: the realtime path is the in-sandbox WS server the browser
+  # connects to directly via /connect (sandbox-as-server; config.py has no such
+  # field). Ably was dropped. See docs/plan/ably-realtime-migration.md.
   FAMILYSEARCH_WEB_ENABLED = "true"
   DEFAULT_MODEL = "claude-sonnet-4-6"
   # PUBLIC_URL must match the public hostname Fly assigns / you map. Used for

--- a/docs/plan/fly-deploy-plan.md
+++ b/docs/plan/fly-deploy-plan.md
@@ -8,7 +8,28 @@
 This is the first hosted deploy of the POC. It replaces the local-server +
 Tailscale-Funnel trick with a public Fly URL as the OAuth-redirect target and
 browser ingress. E2B runs the per-user sandboxes (outbound from the container).
-SQLite + the local backup dir stay; Postgres/S3 are later.
+
+> **Status (2026-06-08): partially shipped + amended. Read the deltas before
+> following the body below.** Since this plan was written, three things landed on
+> `main` that change it:
+> - **DB is Neon Postgres, not SQLite-on-a-volume.** The `neon-postgres-plan.md`
+>   migration (#296) made the backend env-driven via `DATABASE_URL`. **There is no
+>   Fly volume** — the `[mounts]` block is gone from `deploy/fly.toml`, and the
+>   "SQLite + Fly volume" Decision, the **Volume** section, and the
+>   `fly volumes create` step below are **superseded**. `DATABASE_URL` (a secret)
+>   is now required; `WS_SIGNING_KEY` is too (per-sandbox WS tokens). The
+>   authoritative deploy procedure is **DEVELOPMENT.md § "Deploy to Fly.io"**.
+> - **`REALTIME` is gone.** The realtime path is the in-sandbox WS server the
+>   browser connects to directly (`/connect`); `config.py` has no `realtime`
+>   field, so the `REALTIME=local_ws` env was dead and has been removed from
+>   `fly.toml`. Ably was dropped (`ably-realtime-migration.md`). The
+>   "Architecture" / smoke-test mentions of a `/ws` relay on this container are
+>   historical.
+> - **The code is already committed.** The "Server change required" (StaticFiles
+>   mount) is done (`main.py`), `deploy/Dockerfile` + `deploy/fly.toml` exist, and
+>   `E2BProvider` is fully implemented (not the stub the Caveats imply). What
+>   remains is operational: create the app, set secrets, register the FS redirect,
+>   build the E2B template image, deploy.
 
 ---
 
@@ -22,8 +43,10 @@ SQLite + the local backup dir stay; Postgres/S3 are later.
   socket per session (`apps/web/src/transport/SessionConnection.ts`). A
   long-lived socket rules out Lambda/serverless for now, so this is a single
   always-on Fly Machine.
-- **SQLite + local backup mirror on a Fly persistent volume.** One volume,
-  mounted at `DATA_DIR`. Postgres + an object store come post-alpha.
+- ~~**SQLite + local backup mirror on a Fly persistent volume.**~~ **Superseded
+  by `neon-postgres-plan.md` (#296):** the DB is Neon Postgres via the
+  `DATABASE_URL` secret; there is **no Fly volume**. An object store is still
+  post-alpha.
 - **E2B runs the sandboxes.** `SANDBOX_PROVIDER=e2b`; the container reaches E2B
   outbound. The agent does **not** run in this container.
 - **Funnel is still needed for the sidecars the *sandbox* calls.** The public
@@ -142,10 +165,15 @@ the alpha tester list is not committed. **Use each tester's FamilySearch-account
 email** — that is what the allowlist gate compares against at login.
 
 ```bash
+# DATABASE_URL + WS_SIGNING_KEY are required now (Neon migration + per-sandbox WS
+# tokens); they were not in this plan's original table. DATABASE_URL is the Neon
+# DIRECT (non-pooler) URL. See neon-postgres-plan.md and DEVELOPMENT.md § Deploy.
 fly secrets set \
   E2B_API_KEY=... \
   ANTHROPIC_API_KEY=... \
   SESSION_SECRET="$(openssl rand -hex 32)" \
+  WS_SIGNING_KEY="$(openssl rand -hex 32)" \
+  DATABASE_URL="postgresql://USER:PASS@ep-xxx.REGION.aws.neon.tech/DBNAME?sslmode=require" \
   ALLOWED_EMAILS="dallan@quass.org"
 ```
 
@@ -158,15 +186,18 @@ The Dockerfile build context is the **repo root** (it copies `pnpm-workspace.yam
 the repo-root context:
 
 ```bash
-# 1. First time only: create the app (no deploy yet) and the volume.
+# 1. First time only: create the app (no deploy yet). NO volume — the DB is on
+#    Neon (neon-postgres-plan.md); the old `fly volumes create workbench_data`
+#    step is removed.
 fly launch --no-deploy --copy-config --name genealogy-workbench \
   --config deploy/fly.toml --dockerfile deploy/Dockerfile
-fly volumes create workbench_data --region iad --size 1   # matches [mounts].source
 
-# 2. Set secrets (see above).
+# 2. Set secrets (see above) — including DATABASE_URL + WS_SIGNING_KEY.
 
 # 3. Deploy (build context = repo root, config + Dockerfile under deploy/).
-fly deploy --config deploy/fly.toml --dockerfile deploy/Dockerfile .
+#    --ha=false: fly deploy provisions TWO machines by default; we must stay at
+#    count = 1 until init_db moves to a release_command (see Horizontal-scaling).
+fly deploy --config deploy/fly.toml --dockerfile deploy/Dockerfile . --ha=false
 ```
 
 Local sanity-check of the image before deploying:
@@ -178,16 +209,14 @@ docker build -f deploy/Dockerfile -t workbench .   # confirm the multi-stage bui
 
 ---
 
-## Volume
+## Volume — **superseded (no volume)**
 
-- One volume `workbench_data`, size 1 GB to start (SQLite + JSON backups are
-  small; alpha is a handful of users). Mounted at `/data` (= `DATA_DIR`).
-- `config.py` derives `workbench.db`, `sandboxes/`, and `backup/` under
-  `DATA_DIR`. On a fresh volume those dirs are created on boot (`get_settings()`
-  mkdirs them) and `init_db()` creates the SQLite schema.
-- The `sandboxes/` dir under `DATA_DIR` is only used by `LocalProvider`; under
-  `SANDBOX_PROVIDER=e2b` the project filesystem lives in the E2B microVM, and
-  the volume holds only the DB + the backup mirror.
+`neon-postgres-plan.md` (#296) moved the DB to Neon Postgres and removed the
+`[mounts]` block, so **there is no Fly volume**. `DATA_DIR` is still set (to
+`/data`) because `get_settings()` mkdirs a work dir there, but nothing persistent
+lives on it — the DB is on Neon and feedback + the viewer mirror are off-disk. If
+a `workbench_data` volume lingers from a pre-Neon deploy, destroy it after a clean
+deploy: `fly volumes destroy workbench_data`.
 
 ---
 
@@ -241,7 +270,8 @@ affinity-free. Ably is dropped (it would unpin only the *fanout*, not the
 ## Smoke-test checklist (after deploy)
 
 1. `fly status` — one Machine, `started`; volume attached.
-2. `curl https://<host>/api/health` → `{"ok":true,"agentMode":"real","provider":"e2b","realtime":"local_ws"}`.
+2. `curl https://<host>/api/health` → `{"ok":true,"agentMode":"real","provider":"e2b","db":"postgres"}`
+   (the health payload reports `db`, not `realtime` — that field was removed).
 3. `https://<host>/` loads the web client (StaticFiles mount serving `dist`).
 4. **Sign in with FamilySearch** completes and returns to the app: the FS OAuth
    round-trip lands on `/callback` (redirect URI matches), the allowlist check
@@ -259,10 +289,10 @@ affinity-free. Ably is dropped (it would unpin only the *fanout*, not the
    confirms the injected token works **and** the sandbox can reach FS + the
    Funnel sidecars. (If it 401s, the injected access token's refresh succeeded
    in-sandbox via `getValidToken()`.)
-8. Reopen the session after idle → resumes (DB persisted on the volume; sandbox
+8. Reopen the session after idle → resumes (DB persisted on Neon; sandbox
    resumes or re-creates).
 9. `fly machine restart` (or redeploy) → after boot, the session list and DB are
-   intact (volume persistence).
+   intact (Neon persistence — no volume).
 
 ---
 


### PR DESCRIPTION
## Summary

Implements the operational half of `docs/plan/fly-deploy-plan.md`. The plan's code was largely already merged (Neon migration #296, FamilySearch login #300, deploy artifacts), so this PR is the two **deploy blockers** found while actually deploying, plus drift cleanup and shared build-context hygiene. Validated by a live deploy to **https://genealogy-workbench.fly.dev** (`/api/health` → `db:postgres`; `/auth/config` → `familysearch:true`).

## Blockers fixed

- **FamilySearch client id missing from the control-plane image.** `config.py`'s `REPO_ROOT` resolves to `/` in the container (server at `/app/server/app`), so `familysearch_client_id` looked for `/packages/engine/mcp-server/config/familysearch.json`, which the Dockerfile never copied → `familysearch_configured=False` → the FS login route **501s** *and* https disables dev-login = **no login at all**. The Dockerfile now bakes that one config file in. Verified `/auth/config → {"familysearch":true,"devLogin":false}` and `/auth/familysearch/login → 307` to FamilySearch on the live host.
- **`make sandbox-image` couldn't see `E2B_API_KEY`.** `build-image.sh` only read the process env; it now auto-loads `apps/server/.env` (where the keys already live, same file `e2b-preflight` checks).

## Other changes

- **`.dockerignore` (new):** shrinks the shared repo-root build context (~1.5 GB → a few MB). Guarded to **not** exclude `**/build` — the E2B sandbox image (`e2b.Dockerfile`) shares this context and COPYs `packages/engine/mcp-server/build`.
- **`deploy/fly.toml`:** drop stale `GOOGLE_*` secrets from the comment header; remove the dead `REALTIME=local_ws` env (no `config.py` field — realtime is the in-sandbox WS server; Ably was dropped).
- **`DEVELOPMENT.md` + `docs/plan/fly-deploy-plan.md`:** add `--ha=false` (a `fly deploy` provisions **2** machines by default; we must stay at `count=1` until `init_db` moves to a `release_command`), and reconcile the SQLite/volume/`REALTIME` prose to the shipped Neon + FamilySearch reality.

## Deploy state (not part of this PR)

- App `genealogy-workbench` is live, **1 machine** (iad), health passing, DB on Neon.
- Still operator steps: register the FS redirect `https://genealogy-workbench.fly.dev/callback`, and build/push the E2B `genealogy-agent` template for real agent turns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)