### PR TITLE
Web workbench: agent-derived session titles, cost meter, theming, URL resume, clickable pipeline

### DIFF
--- a/apps/server/app/agent/mock_agent.py
+++ b/apps/server/app/agent/mock_agent.py
@@ -85,6 +85,16 @@ class MockAgent:
         }.get(phase, self._active)
         async for ev in handler(text):
             yield ev
+        # Synthetic per-turn usage so the alpha-mode cost meter is demonstrable
+        # in the offline mock (real cost only accrues in AGENT_MODE=real).
+        # `estimated` tells the client to show a "~" + "mock estimate" hint.
+        yield _event(
+            "usage",
+            cost_usd=round(0.004 + 0.00003 * len(text), 5),
+            input_tokens=420 + len(text) // 4,
+            output_tokens=260,
+            estimated=True,
+        )
         # turn_done is emitted by the runner (uniform for mock + real).
 
     async def _greet(self, text: str) -> AsyncIterator[dict]:

--- a/apps/server/app/agent/mock_agent.py
+++ b/apps/server/app/agent/mock_agent.py
@@ -37,6 +37,13 @@ def _event(kind: str, **kw) -> dict:
     return {"kind": kind, **kw}
 
 
+def _title_from_objective(objective: str) -> str:
+    """A concise session name from the objective — the mock's stand-in for the
+    real agent naming the project (a Claude-style chat title)."""
+    head = objective.strip().split(",", 1)[0].strip()
+    return head[:57].rsplit(" ", 1)[0] + "…" if len(head) > 60 else head
+
+
 class MockAgent:
     def __init__(self, project_dir: Path):
         self.dir = project_dir
@@ -151,6 +158,7 @@ class MockAgent:
                 "status": "active",
                 "created": "2026-06-06",
                 "updated": "2026-06-06",
+                "title": _title_from_objective(objective),
             },
             "researcher_profile": {
                 "experience_level": lvl,

--- a/apps/server/app/agent/real_agent.py
+++ b/apps/server/app/agent/real_agent.py
@@ -163,6 +163,23 @@ class RealAgent:
                     yield ev
                 if isinstance(message, ResultMessage):
                     self._remember_session(message)  # persist for resume on relaunch
+                    # Per-turn cost/usage for the operator cost meter (alpha
+                    # mode, web only). The SDK's ResultMessage carries
+                    # total_cost_usd + a usage dict that was otherwise discarded;
+                    # emit one event the client sums. Defensive: fields may be
+                    # absent on older SDKs or partial results.
+                    usage = getattr(message, "usage", None)
+                    if isinstance(usage, dict):
+                        in_tok, out_tok = usage.get("input_tokens"), usage.get("output_tokens")
+                    else:
+                        in_tok = getattr(usage, "input_tokens", None)
+                        out_tok = getattr(usage, "output_tokens", None)
+                    yield _event(
+                        "usage",
+                        cost_usd=getattr(message, "total_cost_usd", None),
+                        input_tokens=in_tok,
+                        output_tokens=out_tok,
+                    )
                     break  # turn complete; the runner emits turn_done
         except Exception as exc:
             yield _event("error", text=f"Agent error: {exc}")

--- a/apps/server/app/seed/sample_project/research.json
+++ b/apps/server/app/seed/sample_project/research.json
@@ -5,7 +5,8 @@
     "subject_person_ids": ["I1"],
     "status": "active",
     "created": "2026-05-01",
-    "updated": "2026-05-04"
+    "updated": "2026-05-04",
+    "title": "Patrick Flynn's parents"
   },
 
   "researcher_profile": {

--- a/apps/server/app/sessions.py
+++ b/apps/server/app/sessions.py
@@ -73,6 +73,42 @@ def _owned(session: Session, user: User, session_id: str) -> Project:
     return project
 
 
+_DEFAULT_TITLE = "New research session"
+
+
+def _derive_title_from_objective(objective: str | None) -> str | None:
+    """A concise, Claude-style session title from the agent's research objective.
+    Genealogy objectives lead with the subject clause ("Identify the parents of
+    Mary Sullivan, born ca. 1860 …"), so take the text before the first comma,
+    then cap at a word boundary."""
+    if not objective:
+        return None
+    head = objective.strip().split(",", 1)[0].strip()
+    if not head:
+        return None
+    if len(head) > 60:
+        head = head[:60].rsplit(" ", 1)[0].rstrip() + "…"
+    return head
+
+
+def _maybe_backfill_title(session: Session, project: Project, research: object) -> None:
+    """Fallback session naming for a still-default session. The browser relays
+    the agent-written project.title live (the primary path); this backstops the
+    cases with no browser relaying (e.g. the /v1 API). Prefer the agent's title;
+    derive from the objective only for legacy projects without one. One-time,
+    persisted — keeps the list from being a wall of 'New research session'."""
+    if project.title != _DEFAULT_TITLE or not isinstance(research, dict):
+        return
+    proj = research.get("project") if isinstance(research.get("project"), dict) else {}
+    title = proj.get("title") or _derive_title_from_objective(proj.get("objective"))
+    if title and title != project.title:
+        project.title = title
+        project.updated = utcnow()
+        session.add(project)
+        session.commit()
+        session.refresh(project)
+
+
 async def create_project(
     *,
     session: Session,
@@ -121,6 +157,9 @@ async def create_project(
 def list_sessions(
     user: User = Depends(get_current_user), session: Session = Depends(get_session)
 ) -> list[ProjectOut]:
+    # Titles are kept current by the client relay (browser → patchSession the
+    # moment the agent names the project) with a free backfill in /state as a
+    # fallback, so the list just reads the DB — no per-row sandbox reads here.
     rows = session.exec(
         select(Project).where(Project.user_id == user.id, Project.status == "active")
         .order_by(Project.last_active.desc())
@@ -208,9 +247,11 @@ async def session_state(
     project = _owned(session, user, session_id)
     sandbox = await provider.resume(project.sandbox_id)
     snap = await sandbox.read_project_snapshot()
+    research = _safe_parse(snap["research"])
+    _maybe_backfill_title(session, project, research)  # name the session from its objective
     return {
         "label": project.title,
-        "research": _safe_parse(snap["research"]),
+        "research": research,
         "gedcomx": _safe_parse(snap["gedcomx"]),
         "sidecars": snap["sidecars"],
     }

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -4,6 +4,17 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Genealogy Workbench</title>
+    <!-- The "Warm Scholarly" design system (packages/viewer-ui global.css) names
+         Cormorant + IBM Plex but the WEB host never loaded the webfonts — so the
+         shell alone rendered in Georgia/system fallback. This is the exact same
+         font request the Electron renderer makes (apps/electron .../index.html),
+         so the shared viewer renders identically in both apps. -->
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Cormorant:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&family=IBM+Plex+Sans:ital,wght@0,300;0,400;0,500;0,600;1,400&family=IBM+Plex+Mono:wght@400;500&display=swap"
+    />
   </head>
   <body>
     <div id="root"></div>

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,12 +1,55 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useAuth } from './auth'
 import LoginScreen from './components/LoginScreen'
 import SessionList from './components/SessionList'
 import SessionView from './components/SessionView'
 
+// The open session lives in the URL hash (`#/s/:id`) so a browser refresh —
+// or a shared link — restores it instead of dropping back to the list. The
+// hash is inert: it never triggers a top-level navigation, so it can't disturb
+// the FamilySearch OAuth popup flow (the reason SessionView avoids a router).
+function readRoute(): string | null {
+  // hash looks like "#/s/<id>" — capture only the id, stopping at a trailing
+  // slash, an in-hash query (e.g. an operator appending "?alpha=1"), or another
+  // "#". A trailing segment must never get folded into the session id.
+  const m = window.location.hash.match(/^#\/s\/([^/?#]+)/)
+  return m ? decodeURIComponent(m[1]) : null
+}
+
+interface OpenSession {
+  id: string
+  isNew: boolean
+}
+
 export default function App(): React.JSX.Element {
   const { user, loading } = useAuth()
-  const [open, setOpen] = useState<{ id: string; isNew: boolean } | null>(null)
+  // Seed from the URL on first load. A restored session is never "new" — only
+  // the +New button below opens with isNew:true (which auto-sends the opening
+  // turn); a refresh must not re-fire that.
+  const [open, setOpen] = useState<OpenSession | null>(() => {
+    const id = readRoute()
+    return id ? { id, isNew: false } : null
+  })
+
+  // Track browser back/forward (and the back button below, which clears the hash).
+  useEffect(() => {
+    const onHashChange = (): void => {
+      const id = readRoute()
+      setOpen((cur) => (id ? (cur?.id === id ? cur : { id, isNew: false }) : null))
+    }
+    window.addEventListener('hashchange', onHashChange)
+    return () => window.removeEventListener('hashchange', onHashChange)
+  }, [])
+
+  const openSession = (id: string, isNew: boolean): void => {
+    window.location.hash = `#/s/${encodeURIComponent(id)}`
+    setOpen({ id, isNew })
+  }
+
+  const back = (): void => {
+    window.location.hash = ''
+    setOpen(null)
+  }
 
   if (loading) {
     return <div className="centerScreen">Loading…</div>
@@ -15,14 +58,7 @@ export default function App(): React.JSX.Element {
     return <LoginScreen />
   }
   if (open) {
-    return (
-      <SessionView
-        key={open.id}
-        sessionId={open.id}
-        isNew={open.isNew}
-        onBack={() => setOpen(null)}
-      />
-    )
+    return <SessionView key={open.id} sessionId={open.id} isNew={open.isNew} onBack={back} />
   }
-  return <SessionList onOpen={(id, isNew) => setOpen({ id, isNew: Boolean(isNew) })} />
+  return <SessionList onOpen={(id, isNew) => openSession(id, Boolean(isNew))} />
 }

--- a/apps/web/src/components/ChatPane.tsx
+++ b/apps/web/src/components/ChatPane.tsx
@@ -18,12 +18,21 @@ interface ChatMessage {
   error?: boolean
 }
 
+export interface UsageDelta {
+  costUsd: number
+  inputTokens: number
+  outputTokens: number
+  estimated: boolean
+}
+
 export default function ChatPane({
   conn,
-  isNew
+  isNew,
+  onUsage
 }: {
   conn: SessionConnection
   isNew: boolean
+  onUsage?: (delta: UsageDelta) => void
 }): React.JSX.Element {
   const [messages, setMessages] = useState<ChatMessage[]>([])
   const [input, setInput] = useState('')
@@ -39,6 +48,17 @@ export default function ChatPane({
     const kind = ev.kind as string
     if (kind === 'turn_done') {
       setBusy(false)
+      return
+    }
+    if (kind === 'usage') {
+      // Per-turn cost/tokens, emitted once just before turn_done. Not a chat
+      // message — bubble it up to the (alpha-gated) session cost meter.
+      onUsage?.({
+        costUsd: typeof ev.cost_usd === 'number' ? ev.cost_usd : 0,
+        inputTokens: typeof ev.input_tokens === 'number' ? ev.input_tokens : 0,
+        outputTokens: typeof ev.output_tokens === 'number' ? ev.output_tokens : 0,
+        estimated: Boolean(ev.estimated)
+      })
       return
     }
     setMessages((prev) => {

--- a/apps/web/src/components/LoginScreen.tsx
+++ b/apps/web/src/components/LoginScreen.tsx
@@ -67,7 +67,11 @@ export default function LoginScreen(): React.JSX.Element {
         )}
 
         {error && <div className="loginError">{error}</div>}
-        <p className="loginHint">Access is limited to allowlisted accounts (alpha).</p>
+        <p className="loginHint">
+          {config?.familysearch
+            ? 'Access is limited to allowlisted accounts (alpha).'
+            : 'Developer sign-in — alpha build.'}
+        </p>
       </div>
     </div>
   )

--- a/apps/web/src/components/SessionList.tsx
+++ b/apps/web/src/components/SessionList.tsx
@@ -25,7 +25,6 @@ export default function SessionList({
   const { user, logout } = useAuth()
   const [sessions, setSessions] = useState<SessionSummary[]>([])
   const [loading, setLoading] = useState(true)
-  const [title, setTitle] = useState('')
   const [model, setModel] = useState(MODELS[0].id)
   const [busy, setBusy] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -48,11 +47,10 @@ export default function SessionList({
     setBusy(true)
     setError(null)
     try {
-      // The user-given name is for their own research sessions; the sample
-      // project keeps its seeded title. Empty falls back to the server default.
-      const named = !sample && title.trim() ? title.trim() : undefined
-      const s = await api.createSession({ sample, model, title: named })
+      const s = await api.createSession({ sample, model })
       // A fresh (non-sample) session auto-starts the init-project onboarding.
+      // We don't ask for a name up front — the title is derived server-side from
+      // the research objective the agent captures (like Claude naming a chat).
       onOpen(s.id, !sample)
     } catch (err) {
       setError(err instanceof ApiError ? err.message : 'Failed to create session')
@@ -85,42 +83,23 @@ export default function SessionList({
 
       <main className="listMain">
         <section className="newSessionBar">
-          <div className="newSessionMain">
-            <div className="newSessionField newSessionFieldGrow">
-              <label className="fieldLabel" htmlFor="title">
-                Project name
-              </label>
-              <input
-                id="title"
-                className="textInput"
-                type="text"
-                placeholder="e.g. Find Mary Sullivan's parents  (optional — you can rename later)"
-                value={title}
-                disabled={busy}
-                onChange={(e) => setTitle(e.target.value)}
-                onKeyDown={(e) => {
-                  if (e.key === 'Enter' && !busy) void create(false)
-                }}
-              />
-            </div>
-            <div className="newSessionField">
-              <label className="fieldLabel" htmlFor="model">
-                Model
-              </label>
-              <select
-                id="model"
-                className="select"
-                value={model}
-                disabled={busy}
-                onChange={(e) => setModel(e.target.value)}
-              >
-                {MODELS.map((m) => (
-                  <option key={m.id} value={m.id}>
-                    {m.label}
-                  </option>
-                ))}
-              </select>
-            </div>
+          <div className="newSessionField">
+            <label className="fieldLabel" htmlFor="model">
+              Model
+            </label>
+            <select
+              id="model"
+              className="select"
+              value={model}
+              disabled={busy}
+              onChange={(e) => setModel(e.target.value)}
+            >
+              {MODELS.map((m) => (
+                <option key={m.id} value={m.id}>
+                  {m.label}
+                </option>
+              ))}
+            </select>
           </div>
           <div className="newSessionActions">
             <button className="btnPrimary" disabled={busy} onClick={() => void create(false)}>

--- a/apps/web/src/components/SessionList.tsx
+++ b/apps/web/src/components/SessionList.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from 'react'
 import { api, ApiError, type SessionSummary } from '../api'
 import { useAuth } from '../auth'
+import ThemeToggle from './ThemeToggle'
 
 const MODELS = [
   { id: 'claude-sonnet-4-6', label: 'Sonnet 4.6 — fast & economical' },
@@ -24,6 +25,7 @@ export default function SessionList({
   const { user, logout } = useAuth()
   const [sessions, setSessions] = useState<SessionSummary[]>([])
   const [loading, setLoading] = useState(true)
+  const [title, setTitle] = useState('')
   const [model, setModel] = useState(MODELS[0].id)
   const [busy, setBusy] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -46,7 +48,10 @@ export default function SessionList({
     setBusy(true)
     setError(null)
     try {
-      const s = await api.createSession({ sample, model })
+      // The user-given name is for their own research sessions; the sample
+      // project keeps its seeded title. Empty falls back to the server default.
+      const named = !sample && title.trim() ? title.trim() : undefined
+      const s = await api.createSession({ sample, model, title: named })
       // A fresh (non-sample) session auto-starts the init-project onboarding.
       onOpen(s.id, !sample)
     } catch (err) {
@@ -70,6 +75,7 @@ export default function SessionList({
           <span className="brandTitle">Genealogy Workbench</span>
         </div>
         <div className="topBarRight">
+          <ThemeToggle />
           <span className="userEmail">{user?.email}</span>
           <button className="btnGhost" onClick={() => void logout()}>
             Sign out
@@ -79,22 +85,42 @@ export default function SessionList({
 
       <main className="listMain">
         <section className="newSessionBar">
-          <div className="newSessionControls">
-            <label className="fieldLabel" htmlFor="model">
-              Model
-            </label>
-            <select
-              id="model"
-              className="select"
-              value={model}
-              onChange={(e) => setModel(e.target.value)}
-            >
-              {MODELS.map((m) => (
-                <option key={m.id} value={m.id}>
-                  {m.label}
-                </option>
-              ))}
-            </select>
+          <div className="newSessionMain">
+            <div className="newSessionField newSessionFieldGrow">
+              <label className="fieldLabel" htmlFor="title">
+                Project name
+              </label>
+              <input
+                id="title"
+                className="textInput"
+                type="text"
+                placeholder="e.g. Find Mary Sullivan's parents  (optional — you can rename later)"
+                value={title}
+                disabled={busy}
+                onChange={(e) => setTitle(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' && !busy) void create(false)
+                }}
+              />
+            </div>
+            <div className="newSessionField">
+              <label className="fieldLabel" htmlFor="model">
+                Model
+              </label>
+              <select
+                id="model"
+                className="select"
+                value={model}
+                disabled={busy}
+                onChange={(e) => setModel(e.target.value)}
+              >
+                {MODELS.map((m) => (
+                  <option key={m.id} value={m.id}>
+                    {m.label}
+                  </option>
+                ))}
+              </select>
+            </div>
           </div>
           <div className="newSessionActions">
             <button className="btnPrimary" disabled={busy} onClick={() => void create(false)}>

--- a/apps/web/src/components/SessionView.tsx
+++ b/apps/web/src/components/SessionView.tsx
@@ -1,14 +1,19 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { App as ViewerApp } from '@genealogy/viewer-ui'
 import { api, type SessionSummary } from '../api'
+import { useAlpha } from '../lib/alpha'
 import { makeSessionConnection } from '../transport/makeSessionConnection'
 import type { SessionConnection } from '../transport/SessionConnection'
 import { WsResearchTransport } from '../transport/WsResearchTransport'
-import ChatPane from './ChatPane'
+import ChatPane, { type UsageDelta } from './ChatPane'
+import ThemeToggle from './ThemeToggle'
 
-// Two-pane: chat (left) + the shared viewer (right). The realtime backend
-// (local_ws WebSocket or Ably) is chosen by the server's minted token via
-// makeSessionConnection — this component is backend-agnostic.
+// Two-pane: chat (left) + the shared viewer (right). The viewer is the SAME
+// component Electron mounts as its whole UI — everything session-specific that
+// can be shared lives there; this file is the web-only chrome around it (chat,
+// the cost meter, sandbox logs), none of which Electron has an event source for.
+// (FamilySearch is now the app front-door login, #300, so there is no per-session
+// connect button here anymore.)
 export default function SessionView({
   sessionId,
   isNew,
@@ -21,6 +26,21 @@ export default function SessionView({
   const [session, setSession] = useState<SessionSummary | null>(null)
   const [conn, setConn] = useState<SessionConnection | null>(null)
   const [logs, setLogs] = useState<{ ws: string; agent: string } | null>(null)
+  const { alpha, setAlpha } = useAlpha()
+
+  // Running cost for this session connection — operator/sponsor signal during
+  // alpha (per-turn usage summed from the agent event stream). Resets on
+  // refresh for now; persisting it is a server follow-up (a Project.cost column).
+  const [cost, setCost] = useState({ usd: 0, turns: 0, inTok: 0, outTok: 0, estimated: false })
+  const onUsage = useCallback((u: UsageDelta) => {
+    setCost((c) => ({
+      usd: c.usd + u.costUsd,
+      turns: c.turns + 1,
+      inTok: c.inTok + u.inputTokens,
+      outTok: c.outTok + u.outputTokens,
+      estimated: c.estimated || u.estimated
+    }))
+  }, [])
 
   const transport = useMemo(
     () => (conn ? new WsResearchTransport(sessionId, conn) : null),
@@ -31,7 +51,9 @@ export default function SessionView({
     let cancelled = false
     let live: SessionConnection | null = null
 
-    void api.resumeSession(sessionId).then(setSession)
+    // A stale/shared `#/s/:id` link can point at a session that no longer
+    // exists — fall back to the list rather than hang on "Loading…".
+    void api.resumeSession(sessionId).then(setSession).catch(() => onBack())
     void makeSessionConnection(sessionId).then((c) => {
       if (cancelled) {
         c.close()
@@ -46,7 +68,7 @@ export default function SessionView({
       cancelled = true
       live?.close()
     }
-  }, [sessionId])
+  }, [sessionId, onBack])
 
   const viewLogs = async (): Promise<void> => {
     try {
@@ -56,6 +78,8 @@ export default function SessionView({
     }
   }
 
+  const costLabel = `${cost.estimated ? '~' : ''}$${cost.usd.toFixed(cost.usd >= 1 ? 2 : 4)}`
+
   return (
     <div className="sessionShell">
       <aside className="chatPane">
@@ -64,12 +88,34 @@ export default function SessionView({
             ← Sessions
           </button>
           <span className="chatTitle">{session?.title ?? 'Loading…'}</span>
-          <button className="btnGhost" onClick={() => void viewLogs()} title="Sandbox WS + agent logs">
-            Logs
-          </button>
+
+          {/* Operator/dev affordances — hidden for normal users, shown only when
+              alpha mode is on (visit /?alpha=1). Removable after the alpha test. */}
+          {alpha && (
+            <span className="alphaCluster">
+              <button
+                className="alphaTag"
+                onClick={() => setAlpha(false)}
+                title="Alpha tools are on — click to hide"
+              >
+                ALPHA
+              </button>
+              <span
+                className="costChip"
+                title={`${cost.turns} turn${cost.turns === 1 ? '' : 's'} · ${cost.inTok.toLocaleString()} in / ${cost.outTok.toLocaleString()} out tokens${cost.estimated ? ' · mock estimate' : ''}`}
+              >
+                {costLabel}
+              </span>
+              <button className="btnGhost" onClick={() => void viewLogs()} title="Sandbox WS + agent logs">
+                Logs
+              </button>
+            </span>
+          )}
+
+          <ThemeToggle />
         </header>
         {conn ? (
-          <ChatPane conn={conn} isNew={isNew} />
+          <ChatPane conn={conn} isNew={isNew} onUsage={onUsage} />
         ) : (
           <div className="chatBody">
             <div className="chatPlaceholder muted">Connecting…</div>
@@ -90,8 +136,8 @@ export default function SessionView({
           <div
             onClick={(e) => e.stopPropagation()}
             style={{
-              background: '#fff', width: '80%', maxWidth: 920, maxHeight: '82vh',
-              overflow: 'auto', borderRadius: 8, padding: 16
+              background: 'var(--bg-card)', color: 'var(--text-primary)', width: '80%',
+              maxWidth: 920, maxHeight: '82vh', overflow: 'auto', borderRadius: 8, padding: 16
             }}
           >
             <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 8 }}>

--- a/apps/web/src/components/SessionView.tsx
+++ b/apps/web/src/components/SessionView.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { App as ViewerApp } from '@genealogy/viewer-ui'
 import { api, type SessionSummary } from '../api'
 import { useAlpha } from '../lib/alpha'
@@ -47,6 +47,25 @@ export default function SessionView({
     [conn, sessionId]
   )
 
+  // Live session naming: the viewer reports the agent-written project.title;
+  // relay it to the control plane ONCE, the moment the agent names a session
+  // that's still on the default title (like Claude naming a chat). The /state
+  // backfill is the fallback for sessions with no browser relaying.
+  const [agentTitle, setAgentTitle] = useState<string | null>(null)
+  const titledRef = useRef(false)
+  useEffect(() => {
+    if (titledRef.current || !agentTitle || !session) return
+    titledRef.current = true
+    if (session.title === 'New research session') {
+      void api
+        .patchSession(sessionId, { title: agentTitle })
+        .then(setSession)
+        .catch(() => {
+          titledRef.current = false // let a later research delta retry
+        })
+    }
+  }, [agentTitle, session, sessionId])
+
   useEffect(() => {
     let cancelled = false
     let live: SessionConnection | null = null
@@ -84,8 +103,8 @@ export default function SessionView({
     <div className="sessionShell">
       <aside className="chatPane">
         <header className="chatHeader">
-          <button className="btnGhost" onClick={onBack}>
-            ← Sessions
+          <button className="btnGhost" onClick={onBack} title="Back to sessions" aria-label="Back to sessions">
+            ←
           </button>
           <span className="chatTitle">{session?.title ?? 'Loading…'}</span>
 
@@ -123,7 +142,12 @@ export default function SessionView({
         )}
       </aside>
       <section className="viewerPane">
-        {transport && <ViewerApp transport={transport} />}
+        {/* The web shell provides its own theme toggle in the chat header, so
+            tell the embedded viewer to hide its (redundant) sidebar one.
+            Electron passes nothing → keeps its toggle (its only one). */}
+        {transport && (
+          <ViewerApp transport={transport} showThemeToggle={false} onProjectTitle={setAgentTitle} />
+        )}
       </section>
       {logs && (
         <div

--- a/apps/web/src/components/ThemeToggle.tsx
+++ b/apps/web/src/components/ThemeToggle.tsx
@@ -1,0 +1,29 @@
+import { useTheme } from '../lib/theme'
+
+// A quiet icon button that flips the global light/dark theme (shell + viewer).
+// Shows the icon of the theme you'd switch TO, the common affordance pattern.
+export default function ThemeToggle(): React.JSX.Element {
+  const { theme, toggleTheme } = useTheme()
+  const dark = theme === 'dark'
+  return (
+    <button
+      className="iconBtn"
+      onClick={toggleTheme}
+      title={dark ? 'Switch to light theme' : 'Switch to dark theme'}
+      aria-label={dark ? 'Switch to light theme' : 'Switch to dark theme'}
+    >
+      {dark ? (
+        // Sun
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round">
+          <circle cx="12" cy="12" r="4" />
+          <path d="M12 2v2M12 20v2M2 12h2M20 12h2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M19.1 4.9l-1.4 1.4M6.3 17.7l-1.4 1.4" />
+        </svg>
+      ) : (
+        // Moon
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round">
+          <path d="M21 12.8A9 9 0 1 1 11.2 3a7 7 0 0 0 9.8 9.8z" />
+        </svg>
+      )}
+    </button>
+  )
+}

--- a/apps/web/src/lib/alpha.ts
+++ b/apps/web/src/lib/alpha.ts
@@ -1,0 +1,34 @@
+// Alpha-mode flag — gates the operator/developer affordances (cost meter,
+// sandbox Logs, raw-JSON peeks) that ship during the alpha test and can be
+// removed after. OFF by default, so normal users never see them.
+//
+// Operators turn it on by visiting `/?alpha=1` once (the flag is then sticky in
+// localStorage); `/?alpha=0` or clicking the alpha badge turns it back off.
+import { useCallback, useState } from 'react'
+
+const KEY = 'alpha'
+
+function compute(): boolean {
+  // An `?alpha=` param flips the sticky flag, then it persists across reloads.
+  // Accept it in the real query string OR inside the hash — with a `#/s/:id`
+  // route, operators tend to append "?alpha=1" to the end of the URL, which
+  // lands it in the fragment, not in window.location.search.
+  const hash = window.location.hash
+  const hashQuery = hash.includes('?') ? hash.slice(hash.indexOf('?') + 1) : ''
+  const param =
+    new URLSearchParams(window.location.search).get('alpha') ??
+    new URLSearchParams(hashQuery).get('alpha')
+  if (param === '1') localStorage.setItem(KEY, '1')
+  else if (param === '0') localStorage.removeItem(KEY)
+  return localStorage.getItem(KEY) === '1'
+}
+
+export function useAlpha(): { alpha: boolean; setAlpha: (on: boolean) => void } {
+  const [alpha, setOn] = useState(compute)
+  const setAlpha = useCallback((on: boolean) => {
+    if (on) localStorage.setItem(KEY, '1')
+    else localStorage.removeItem(KEY)
+    setOn(on)
+  }, [])
+  return { alpha, setAlpha }
+}

--- a/apps/web/src/lib/theme.ts
+++ b/apps/web/src/lib/theme.ts
@@ -1,0 +1,25 @@
+// Light/dark theme for the web shell. Deliberately mirrors the viewer's own
+// toggle (packages/viewer-ui Sidebar.tsx): same localStorage key (`theme`) and
+// same global attribute (`document.documentElement.dataset.theme`), so toggling
+// from the shell or from inside the viewer always switches BOTH panes together
+// — there is one source of truth for the rendered theme (the <html> attribute).
+import { useCallback, useState } from 'react'
+
+function initTheme(): string {
+  const stored = localStorage.getItem('theme') || 'light'
+  if (document.documentElement.dataset.theme == null) {
+    document.documentElement.dataset.theme = stored
+  }
+  return stored
+}
+
+export function useTheme(): { theme: string; toggleTheme: () => void } {
+  const [theme, setTheme] = useState(initTheme)
+  const toggleTheme = useCallback(() => {
+    const next = theme === 'dark' ? 'light' : 'dark'
+    document.documentElement.dataset.theme = next
+    localStorage.setItem('theme', next)
+    setTheme(next)
+  }, [theme])
+  return { theme, toggleTheme }
+}

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -33,6 +33,16 @@ body,
   min-height: 100vh;
 }
 
+/* viewer-ui's global.css also sets #root{display:flex} for Electron, where the
+   viewer IS the whole UI. In the web app #root wraps our OWN shell, and that
+   flex makes the shell shrink-wrap to its content and pin left (the session
+   list, login, and an empty viewer all stranded at ~920px on a wide screen).
+   Reset to block so .appShell / .centerScreen / .sessionShell fill the width
+   and center their own content. */
+#root {
+  display: block;
+}
+
 body {
   margin: 0;
   font-family: var(--sans);
@@ -48,8 +58,9 @@ button {
 
 .centerScreen {
   min-height: 100vh;
-  display: grid;
-  place-items: center;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   padding: 24px;
   color: var(--ink-soft);
 }
@@ -382,6 +393,7 @@ button {
   font-size: 17px;
   font-weight: 600;
   flex: 1;
+  min-width: 0; /* let the title ellipsize instead of getting crushed to "S." when the alpha cluster is present */
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1,15 +1,22 @@
+/* The web shell inherits the viewer's "Warm Scholarly" design system
+   (packages/viewer-ui/src/styles/global.css, imported first in main.tsx), which
+   is the single source of truth for the palette, light/dark themes, and fonts —
+   the same system Electron renders. These aliases map the shell's existing
+   semantic names onto that system, so the shell follows the viewer in BOTH
+   themes (custom properties resolve lazily, so var(--bg) picks up the dark value
+   when [data-theme='dark'] is set on <html>). */
 :root {
-  --bg: #f6f1e7;
-  --bg-elev: #fffdf8;
-  --ink: #2b2724;
-  --ink-soft: #6b6157;
-  --line: #e3d9c6;
-  --accent: #7a5230;
-  --accent-soft: #9a7048;
-  --danger: #a33b2a;
-  --shadow: 0 1px 3px rgba(60, 45, 25, 0.08), 0 6px 24px rgba(60, 45, 25, 0.06);
-  --serif: 'Iowan Old Style', 'Palatino Linotype', Palatino, Georgia, serif;
-  --sans: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  --bg: var(--bg-primary);
+  --bg-elev: var(--bg-card);
+  --ink: var(--text-primary);
+  --ink-soft: var(--text-secondary);
+  --line: var(--border-color);
+  --accent: var(--text-link);
+  --accent-soft: var(--accent-gold-strong);
+  --danger: var(--badge-red-text);
+  --shadow: var(--card-shadow);
+  --serif: var(--font-display);
+  --sans: var(--font-body);
 }
 
 * {
@@ -62,7 +69,7 @@ button {
 }
 .btnPrimary {
   background: var(--accent);
-  color: #fff;
+  color: var(--bg-primary);
 }
 .btnPrimary:hover {
   background: var(--accent-soft);
@@ -83,7 +90,7 @@ button {
 }
 .btnGhost:hover {
   color: var(--ink);
-  background: rgba(122, 82, 48, 0.06);
+  background: var(--bg-hover);
 }
 .btnPrimary:disabled,
 .btnSecondary:disabled {
@@ -95,6 +102,24 @@ button {
   width: 100%;
   text-align: center;
   margin-top: 12px;
+}
+
+/* Quiet square icon button (theme toggle, etc.) */
+.iconBtn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 34px;
+  height: 34px;
+  border-radius: 8px;
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--ink-soft);
+  transition: background 0.12s, color 0.12s, border-color 0.12s;
+}
+.iconBtn:hover {
+  color: var(--ink);
+  background: var(--bg-hover);
 }
 
 /* ── Login ───────────────────────────────────────────── */
@@ -116,7 +141,8 @@ button {
 }
 .loginTitle {
   font-family: var(--serif);
-  font-size: 30px;
+  font-size: 34px;
+  font-weight: 600;
   margin: 6px 0 12px;
 }
 .loginSubtitle {
@@ -143,7 +169,8 @@ button {
   border: 1px solid var(--line);
   border-radius: 8px;
   font-size: 14px;
-  background: #fff;
+  font-family: inherit;
+  background: var(--bg-card);
   color: var(--ink);
 }
 .textInput:focus,
@@ -185,11 +212,11 @@ button {
   font-family: var(--serif);
   font-style: italic;
   color: var(--accent-soft);
-  font-size: 14px;
+  font-size: 15px;
 }
 .brandTitle {
   font-family: var(--serif);
-  font-size: 19px;
+  font-size: 21px;
   font-weight: 600;
 }
 .topBarRight {
@@ -216,14 +243,29 @@ button {
   gap: 18px;
   background: var(--bg-elev);
   border: 1px solid var(--line);
-  border-radius: 12px;
-  padding: 18px;
+  border-radius: 14px;
+  padding: 20px;
   box-shadow: var(--shadow);
   flex-wrap: wrap;
 }
-.newSessionControls {
-  min-width: 260px;
+.newSessionMain {
+  display: flex;
+  align-items: flex-end;
+  gap: 14px;
   flex: 1;
+  min-width: 280px;
+  flex-wrap: wrap;
+}
+.newSessionField {
+  display: flex;
+  flex-direction: column;
+}
+.newSessionField:not(.newSessionFieldGrow) {
+  width: 220px;
+}
+.newSessionFieldGrow {
+  flex: 1;
+  min-width: 240px;
 }
 .newSessionActions {
   display: flex;
@@ -231,7 +273,8 @@ button {
 }
 .sectionHeading {
   font-family: var(--serif);
-  font-size: 18px;
+  font-size: 20px;
+  font-weight: 600;
   margin: 30px 0 14px;
 }
 .muted {
@@ -240,10 +283,10 @@ button {
 .bannerError {
   margin-top: 14px;
   padding: 10px 14px;
-  background: #f8e6e1;
-  border: 1px solid #e6c3b9;
+  background: var(--badge-red-bg);
+  border: 1px solid var(--badge-red-bg);
   border-radius: 8px;
-  color: var(--danger);
+  color: var(--badge-red-text);
   font-size: 14px;
 }
 .emptyState {
@@ -267,19 +310,21 @@ button {
   border-radius: 12px;
   padding: 16px;
   cursor: pointer;
-  transition: border-color 0.12s, transform 0.08s;
+  transition: border-color 0.12s, transform 0.08s, box-shadow 0.12s;
   box-shadow: var(--shadow);
 }
 .sessionCard:hover {
   border-color: var(--accent-soft);
   transform: translateY(-1px);
+  box-shadow: var(--card-shadow-hover);
 }
 .sessionCardTitle {
   font-family: var(--serif);
-  font-size: 16px;
+  font-size: 18px;
+  font-weight: 600;
   margin-bottom: 12px;
   padding-right: 18px;
-  line-height: 1.35;
+  line-height: 1.3;
 }
 .sessionCardMeta {
   display: flex;
@@ -288,8 +333,8 @@ button {
   font-size: 12px;
 }
 .pill {
-  background: rgba(122, 82, 48, 0.1);
-  color: var(--accent);
+  background: var(--accent-gold-soft);
+  color: var(--accent-gold-strong);
   border-radius: 999px;
   padding: 2px 9px;
   font-weight: 600;
@@ -334,7 +379,7 @@ button {
 }
 .chatTitle {
   font-family: var(--serif);
-  font-size: 15px;
+  font-size: 17px;
   font-weight: 600;
   flex: 1;
   white-space: nowrap;
@@ -346,6 +391,43 @@ button {
   min-height: 0;
   display: flex;
   flex-direction: column;
+}
+
+/* Operator/dev affordances grouped behind alpha mode (off for normal users) */
+.alphaCluster {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 2px 8px;
+  border: 1px dashed var(--border-color-strong);
+  border-radius: 999px;
+}
+.alphaTag {
+  font-family: var(--font-mono);
+  font-size: 9.5px;
+  letter-spacing: 0.12em;
+  font-weight: 600;
+  color: var(--accent-gold-strong);
+  background: var(--accent-gold-soft);
+  border: none;
+  border-radius: 999px;
+  padding: 2px 7px;
+  transition: background 0.12s, color 0.12s;
+}
+.alphaTag:hover {
+  background: var(--accent-gold-strong);
+  color: var(--bg-primary);
+}
+.costChip {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--ink);
+  white-space: nowrap;
+}
+.alphaCluster .btnGhost {
+  padding: 3px 8px;
+  font-size: 12px;
 }
 .chatPlaceholder {
   margin: auto;
@@ -385,12 +467,12 @@ button {
 }
 .msgUser .msgText {
   background: var(--accent);
-  color: #fff;
+  color: var(--bg-primary);
   border-radius: 12px 12px 2px 12px;
   padding: 8px 12px;
 }
 .msgAssistant .msgText {
-  background: #fff;
+  background: var(--bg-card);
   border: 1px solid var(--line);
   border-radius: 12px 12px 12px 2px;
   padding: 8px 12px;
@@ -405,9 +487,10 @@ button {
   color: var(--danger);
 }
 .msgText code {
-  background: rgba(122, 82, 48, 0.1);
+  background: var(--bg-code);
   padding: 1px 4px;
   border-radius: 4px;
+  font-family: var(--font-mono);
   font-size: 0.9em;
 }
 .toolChips {
@@ -423,12 +506,12 @@ button {
   align-self: flex-start;
 }
 .toolRunning {
-  background: #f3ecd9;
-  color: var(--accent);
+  background: var(--badge-amber-bg);
+  color: var(--badge-amber-text);
 }
 .toolDone {
-  background: #e7f0e3;
-  color: #3f6b3a;
+  background: var(--badge-green-bg);
+  color: var(--badge-green-text);
 }
 .typing {
   align-self: flex-start;
@@ -456,6 +539,7 @@ button {
   padding: 8px 10px;
   font-family: inherit;
   font-size: 13px;
+  background: var(--bg-card);
   color: var(--ink);
 }
 .chatTextarea:focus {
@@ -465,7 +549,7 @@ button {
 .chatSend {
   align-self: stretch;
   background: var(--accent);
-  color: #fff;
+  color: var(--bg-primary);
   border: none;
   border-radius: 8px;
   padding: 0 16px;

--- a/docs/specs/research-schema-spec.md
+++ b/docs/specs/research-schema-spec.md
@@ -168,6 +168,7 @@ Single object (not an array).
 | `status` | `project_status` | yes | Current status |
 | `created` | string | yes | ISO 8601 date |
 | `updated` | string | yes | ISO 8601 date |
+| `title` | string | no | Agent-written concise session name (3-6 words), like a Claude chat title — summarizes the objective for the session list. Absent on legacy projects, where the control plane derives one from `objective`. |
 
 ### 5.1.1 `researcher_profile`
 

--- a/docs/specs/schemas/research.schema.json
+++ b/docs/specs/schemas/research.schema.json
@@ -81,7 +81,8 @@
         },
         "status": { "$ref": "enums.schema.json#/$defs/project_status" },
         "created": { "$ref": "enums.schema.json#/$defs/iso_date" },
-        "updated": { "$ref": "enums.schema.json#/$defs/iso_date" }
+        "updated": { "$ref": "enums.schema.json#/$defs/iso_date" },
+        "title": { "type": "string" }
       }
     },
     "researcher_profile": {

--- a/eval/app/components/scenario/lib/schema.ts
+++ b/eval/app/components/scenario/lib/schema.ts
@@ -70,6 +70,9 @@ export interface Project {
   status: ProjectStatus
   created: string
   updated: string
+  /** Agent-written concise session name (3-6 words), like a Claude chat title.
+   *  Optional: absent on legacy projects. Keep in sync with @genealogy/schema. */
+  title?: string
 }
 
 export interface ResearcherProfile {

--- a/packages/engine/plugin/skills/init-project/SKILL.md
+++ b/packages/engine/plugin/skills/init-project/SKILL.md
@@ -298,6 +298,11 @@ Fill in the project section:
 - `status`: `active`
 - `created`: today's date in ISO 8601 format
 - `updated`: same as created
+- `title`: a concise session name (3-6 words) summarizing the
+  objective, like a Claude chat title (e.g. "Patrick Flynn's parents",
+  "Mary Sullivan's origins"). This is the label the user sees for this
+  project in their session list — make it specific and human, not a
+  restatement of the full objective sentence.
 
 Fill in the `researcher_profile` section using the answers from the
 researcher-profile interview (see the section above):
@@ -380,7 +385,8 @@ identify his parents."
        "subject_person_ids": ["KWCJ-RN4"],
        "status": "active",
        "created": "2026-05-19",
-       "updated": "2026-05-19"
+       "updated": "2026-05-19",
+       "title": "Patrick Flynn's parents"
      },
      "researcher_profile": {
        "experience_level": "intermediate",

--- a/packages/engine/plugin/skills/init-project/templates/research.json
+++ b/packages/engine/plugin/skills/init-project/templates/research.json
@@ -5,7 +5,8 @@
     "subject_person_ids": {{subject_person_ids}},
     "status": "active",
     "created": "{{today}}",
-    "updated": "{{today}}"
+    "updated": "{{today}}",
+    "title": "{{title}}"
   },
   "researcher_profile": {
     "experience_level": "{{experience_level}}",

--- a/packages/schema/schemas/research.schema.json
+++ b/packages/schema/schemas/research.schema.json
@@ -81,7 +81,8 @@
         },
         "status": { "$ref": "enums.schema.json#/$defs/project_status" },
         "created": { "$ref": "enums.schema.json#/$defs/iso_date" },
-        "updated": { "$ref": "enums.schema.json#/$defs/iso_date" }
+        "updated": { "$ref": "enums.schema.json#/$defs/iso_date" },
+        "title": { "type": "string" }
       }
     },
     "researcher_profile": {

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -70,6 +70,10 @@ export interface Project {
   status: ProjectStatus
   created: string
   updated: string
+  /** Agent-written concise session name (3-6 words), like a Claude chat title.
+   *  Optional: absent on legacy projects, where the control plane falls back to
+   *  deriving one from `objective`. */
+  title?: string
 }
 
 export interface ResearcherProfile {

--- a/packages/viewer-ui/src/App.tsx
+++ b/packages/viewer-ui/src/App.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react'
 import type { ResearchTransport } from './transport'
 import { useResearchData } from './contexts/ResearchDataContext'
 import { ResearchDataProvider } from './contexts/ResearchDataProvider'
@@ -69,8 +70,22 @@ function WaitingScreen(): React.JSX.Element {
   )
 }
 
-function AppContent(): React.JSX.Element {
+function AppContent({
+  showThemeToggle,
+  onProjectTitle
+}: {
+  showThemeToggle: boolean
+  onProjectTitle?: (title: string | null) => void
+}): React.JSX.Element {
   const { research, folderPath, activeSection } = useResearchData()
+
+  // Relay the agent-written project.title up to the host shell, which patches it
+  // to the control plane (live session naming). Hook runs before the early
+  // returns below to satisfy the rules of hooks.
+  const projectTitle = research?.project?.title ?? null
+  useEffect(() => {
+    onProjectTitle?.(projectTitle)
+  }, [projectTitle, onProjectTitle])
 
   if (!folderPath) {
     return <WelcomeScreen />
@@ -79,7 +94,7 @@ function AppContent(): React.JSX.Element {
   if (!research) {
     return (
       <div className={styles.layout}>
-        <Sidebar />
+        <Sidebar showThemeToggle={showThemeToggle} />
         <div className={styles.main}>
           <Header />
           <WaitingScreen />
@@ -92,7 +107,7 @@ function AppContent(): React.JSX.Element {
 
   return (
     <div className={styles.layout}>
-      <Sidebar />
+      <Sidebar showThemeToggle={showThemeToggle} />
       <div className={styles.main}>
         <Header />
         <ProgressPipeline />
@@ -105,10 +120,24 @@ function AppContent(): React.JSX.Element {
   )
 }
 
-export default function App({ transport }: { transport: ResearchTransport }): React.JSX.Element {
+export default function App({
+  transport,
+  // Whether the viewer renders its own theme toggle (Sidebar footer). The web
+  // shell sets this false because it provides one in its chat header; Electron
+  // omits it (defaults true) since the viewer's is the only one.
+  showThemeToggle = true,
+  // Called with the agent-written project.title (or null) whenever research
+  // changes — the web shell uses it to name the session in the control plane.
+  // Electron omits it (it has no session-list concept).
+  onProjectTitle
+}: {
+  transport: ResearchTransport
+  showThemeToggle?: boolean
+  onProjectTitle?: (title: string | null) => void
+}): React.JSX.Element {
   return (
     <ResearchDataProvider transport={transport}>
-      <AppContent />
+      <AppContent showThemeToggle={showThemeToggle} onProjectTitle={onProjectTitle} />
     </ResearchDataProvider>
   )
 }

--- a/packages/viewer-ui/src/components/layout/ProgressPipeline.module.css
+++ b/packages/viewer-ui/src/components/layout/ProgressPipeline.module.css
@@ -34,12 +34,38 @@
   align-items: center;
   gap: 5px;
   padding: 4px 10px;
+  border: none;
+  background: transparent;
   border-radius: 20px;
   font-size: 0.75rem;
   white-space: nowrap;
   transition: all 0.3s ease;
   font-family: var(--font-body);
   letter-spacing: 0.01em;
+  cursor: pointer;
+}
+
+/* Pending stages have no artifacts yet — not navigable. */
+.stage:disabled {
+  cursor: default;
+}
+
+.stage:not(:disabled):not(.active):hover {
+  background: var(--bg-hover);
+}
+
+.stage:not(:disabled):not(.active):hover .label {
+  color: var(--text-primary);
+}
+
+.stage:focus-visible {
+  outline: 2px solid var(--accent-gold);
+  outline-offset: 2px;
+}
+
+/* The stage whose section is currently shown in the rail. */
+.stage.current {
+  box-shadow: inset 0 0 0 1px var(--border-color-strong);
 }
 
 .dot {

--- a/packages/viewer-ui/src/components/layout/ProgressPipeline.tsx
+++ b/packages/viewer-ui/src/components/layout/ProgressPipeline.tsx
@@ -4,7 +4,7 @@ import { inferProgress } from '../../lib/progress'
 import styles from './ProgressPipeline.module.css'
 
 export default function ProgressPipeline(): React.JSX.Element | null {
-  const { research } = useResearchData()
+  const { research, activeSection, setActiveSection } = useResearchData()
 
   const stages = useMemo(() => {
     if (!research) return null
@@ -14,16 +14,31 @@ export default function ProgressPipeline(): React.JSX.Element | null {
   if (!stages) return null
 
   return (
-    <div className={styles.pipeline}>
-      {stages.map((stage, i) => (
-        <div key={stage.name} className={styles.stageWrapper}>
-          {i > 0 && <div className={`${styles.connector} ${styles[stage.status]}`} />}
-          <div className={`${styles.stage} ${styles[stage.status]}`} title={stage.label}>
-            <div className={styles.dot} />
-            <span className={styles.label}>{stage.label}</span>
+    <nav className={styles.pipeline} aria-label="Research progress — jump to a stage">
+      {stages.map((stage, i) => {
+        // Status, not control: a click NAVIGATES the rail to the section that
+        // stage produced — it never re-runs the agent. Pending stages have no
+        // artifacts yet, so they're disabled rather than landing on an empty view.
+        const navigable = stage.status !== 'pending'
+        const current = activeSection === stage.section
+        return (
+          <div key={stage.name} className={styles.stageWrapper}>
+            {i > 0 && <div className={`${styles.connector} ${styles[stage.status]}`} />}
+            <button
+              type="button"
+              className={`${styles.stage} ${styles[stage.status]} ${current ? styles.current : ''}`}
+              disabled={!navigable}
+              aria-current={current ? 'page' : undefined}
+              onClick={navigable ? () => setActiveSection(stage.section) : undefined}
+              title={navigable ? `Go to ${stage.label}` : `${stage.label} — not started yet`}
+              aria-label={navigable ? `Go to ${stage.label}` : `${stage.label}, not started yet`}
+            >
+              <span className={styles.dot} />
+              <span className={styles.label}>{stage.label}</span>
+            </button>
           </div>
-        </div>
-      ))}
-    </div>
+        )
+      })}
+    </nav>
   )
 }

--- a/packages/viewer-ui/src/components/layout/Sidebar.tsx
+++ b/packages/viewer-ui/src/components/layout/Sidebar.tsx
@@ -16,7 +16,11 @@ function getInitialTheme(): string {
   return stored
 }
 
-export default function Sidebar(): React.JSX.Element {
+export default function Sidebar({
+  showThemeToggle = true
+}: {
+  showThemeToggle?: boolean
+} = {}): React.JSX.Element {
   const {
     research,
     folderPath,
@@ -91,13 +95,15 @@ export default function Sidebar(): React.JSX.Element {
           >
             {'</>'}
           </button>
-          <button
-            className={styles.footerToggle}
-            onClick={toggleTheme}
-            title={`Switch to ${theme === 'dark' ? 'light' : 'dark'} mode`}
-          >
-            {theme === 'dark' ? '☀' : '☽'}
-          </button>
+          {showThemeToggle && (
+            <button
+              className={styles.footerToggle}
+              onClick={toggleTheme}
+              title={`Switch to ${theme === 'dark' ? 'light' : 'dark'} mode`}
+            >
+              {theme === 'dark' ? '☀' : '☽'}
+            </button>
+          )}
         </div>
         <div className={styles.watchStatus}>
           {folderPath ? (

--- a/packages/viewer-ui/src/lib/progress.ts
+++ b/packages/viewer-ui/src/lib/progress.ts
@@ -6,16 +6,19 @@ export interface StageInfo {
   name: string
   label: string
   status: StageStatus
+  /** Rail section this stage's artifacts live in — the click target in the
+   *  ProgressPipeline. `analysis` spans three sections; we default to conflicts. */
+  section: string
 }
 
 const stages = [
-  { name: 'init', label: 'Init' },
-  { name: 'question_selection', label: 'Question Selection' },
-  { name: 'research_plan', label: 'Research Plan' },
-  { name: 'search_records', label: 'Search Records' },
-  { name: 'extraction', label: 'Extraction' },
-  { name: 'analysis', label: 'Analysis' },
-  { name: 'proof_summary', label: 'Proof Summary' }
+  { name: 'init', label: 'Init', section: 'project_overview' },
+  { name: 'question_selection', label: 'Question Selection', section: 'questions' },
+  { name: 'research_plan', label: 'Research Plan', section: 'plans' },
+  { name: 'search_records', label: 'Search Records', section: 'log' },
+  { name: 'extraction', label: 'Extraction', section: 'assertions' },
+  { name: 'analysis', label: 'Analysis', section: 'conflicts' },
+  { name: 'proof_summary', label: 'Proof Summary', section: 'proof_summaries' }
 ] as const
 
 function isStageCompleted(name: string, data: ResearchData): boolean {
@@ -57,7 +60,7 @@ export function inferProgress(data: ResearchData): StageInfo[] {
       status = 'pending'
     }
 
-    result.push({ name: stage.name, label: stage.label, status })
+    result.push({ name: stage.name, label: stage.label, status, section: stage.section })
 
     if (!completed) {
       allPriorComplete = false


### PR DESCRIPTION
The first-impression + operator foundation for the hosted web workbench, plus a live design-QA polish pass. Most session-open functionality lives in the shared `viewer-ui` so **Electron benefits too**; only the chat / session-management chrome is web-only.

## Highlights
- **Session titles, agent-derived** — the agent names each project from its research objective (like Claude naming a chat); the title appears live in the session list + header. Schema change: optional `project.title` added across every schema-of-record (both JSON Schemas, prose spec, `@genealogy/schema` type, eval dup); written by `init-project` (real) + mock + seed; relayed browser → `patchSession` with a `session_state` server fallback. Done now, pre-alpha, while data is disposable.
- **URL resume** — the open session lives in `#/s/:id`; refresh / shared links restore it; back-forward works; a stale id falls back to the list.
- **Cost meter (operator/alpha)** — a per-turn `usage` agent event (real cost off the SDK `ResultMessage`, mock synthetic) shown behind a sticky `/?alpha=1` flag, alongside the sandbox Logs button. Off for normal users; removable post-alpha.
- **Design unification + dark mode** — load the named-but-never-loaded Cormorant/IBM Plex webfonts in the web host (parity with Electron); alias the shell tokens onto the viewer's "Warm Scholarly" system so it inherits light/dark; add a shell theme toggle. Fixed the shell being left-pinned at ~920px on wide screens.
- **Clickable ProgressPipeline** (shared) — completed/active stages navigate the rail to their section; pending disabled; status-not-control.

## Electron
The shared `viewer-ui` upgrades (clickable pipeline, fonts, tokens) reach Electron for free. The new `App` props (`showThemeToggle`, `onProjectTitle`) are optional with defaults, so Electron compiles and behaves unchanged.

## Verification
`make test` green: viewer-ui 99, server 38, web tsc + vite build, mcp-server tsc + 35 validation tests. Title relay + centering + alpha cost meter + clickable pipeline verified end-to-end in the browser (mock mode).

## ⚠️ Action before merge
Editing `init-project/SKILL.md` + its template makes the **init-project eval run log stale**. Per the runlog CI rule it needs a re-run + release (`run_tests.py --skill init-project`) — a genealogist task. The change is additive/optional so it shouldn't fail the eval, but the snapshot must refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)