### PR TITLE
Add merge_gedcomx util (#250)

### DIFF
--- a/docs/specs/merge-gedcomx-spec.md
+++ b/docs/specs/merge-gedcomx-spec.md
@@ -64,7 +64,7 @@ and child↔child. Whatever isn't paired is simply **carried in as a new relativ
 |------|------------------------|
 | Closest sibling tool operates on **SimplifiedGedcomX** | `packages/engine/mcp-server/src/tools/same-person.ts` |
 | `SimplifiedFact` has `primary?: boolean`; `SimplifiedName` has `preferred?: boolean` (so "keep both, mark 1 preferred" is representable) | `packages/engine/mcp-server/src/types/gedcomx.ts:112,123` |
-| `SimplifiedFact = { id, type, primary?, date?, standard_date?, place?, value?, sources? }` — **`place` is a plain string** (no standardized place-id chain) | `packages/engine/mcp-server/src/types/gedcomx.ts:120` |
+| `SimplifiedFact = { id, type, primary?, date?, standard_date?, place?, standard_place?, value?, sources? }` — `standard_place` is the standardized hierarchical place name (added 2026-06-05); equivalence uses it, falling back to free-text `place` | `packages/engine/mcp-server/src/types/gedcomx.ts:120` |
 | Marriage/couple facts live on the **relationship** (`SimplifiedRelationship.facts`), not the person | `packages/engine/mcp-server/src/types/gedcomx.ts:139` |
 | IDs `I/N/F/R/S` unique within their array (restart at 1 per doc → collisions on merge) | `docs/specs/simplified-gedcomx-spec.md` |
 | Convert util exposes only `toSimplified`/`toGedcomX` — **no existing ID-remap or dedup helper** | `packages/engine/mcp-server/src/utils/gedcomx-convert.ts` |
@@ -175,10 +175,11 @@ Every candidate relationship is carried over (Mode 1) / retained (Mode 2) with:
   ids → survivor ids; others → remapped),
 - relationship-level `facts` and `sources` ref-rewritten; couple/marriage facts
   merged per §7.2 when the same couple appears on both sides.
-Then **dedup**: drop a relationship whose `type` + endpoint pair already exists
-(e.g. the same ParentChild pair contributed by both documents). A
-self-referential relationship produced by a collapse (parent == child) is
-dropped.
+Then **dedup**: collapse duplicate `type` + endpoint relationships into one,
+**folding the duplicate's facts and source refs into the kept relationship**
+(so e.g. a candidate couple's Marriage fact is not lost when the same couple
+already exists on the target). A self-referential relationship produced by a
+collapse (parent == child / person1 == person2) is dropped.
 
 ### 6.6 Sources
 Candidate `sources[]` merged into target `sources[]`:
@@ -188,14 +189,17 @@ Candidate `sources[]` merged into target `sources[]`:
   to the resulting source ids.
 
 ### 6.7 `places[]`
-Candidate `places[]` carried over with remapped ids (Mode 1); referenced place
-ids rewritten. (Simplified places are referenced by id from `place` strings only
-indirectly; v1 carries them through without dedup.)
+Candidate `places[]` are carried into the result; a candidate place id that
+collides with a target place id is given a fresh unique id. Nothing references
+place ids in the simplified format (facts carry place **names**), so no ref
+rewriting is needed and v1 does not dedup places by content.
 
 ### 6.8 Result
 `{ persons, relationships, sources, places }` where every merged pair's survivor
 id is preserved, all candidate ids are collision-free, every cross-reference
-resolves, and no names/facts were discarded.
+resolves, and no names/facts were discarded. Because fact/name ids are unique
+only *within their source array*, a final pass re-ids any duplicate fact/name id
+so the result is globally unique (safe — nothing references fact/name ids).
 
 ---
 
@@ -223,11 +227,12 @@ distinct entry.**
   - *Dates compatible* (`datesMatch` 1159): parse `standard_date` into Y/M/D;
     for each field present on both sides the values must be equal; a field
     missing on either side is compatible. So `1900` ≈ `1900-01-10`.
-  - *Places compatible* (`placesMatch` 1195, **simplified**): we only have a
-    `place` **string** (no id-chain), so v1 uses normalized **chain
-    containment** — one place is a tail/superset of the other
-    (`Utah` ≈ `Provo, Utah, United States`) or equal after normalization. This
-    is weaker than MobMergeUtil's standardized-place-id check (§12 limitation).
+  - *Places compatible* (`placesMatch` 1195): compares the **`standard_place`**
+    hierarchical name (falling back to free-text `place`) by normalized **chain
+    containment** — one place is a prefix of the other root-first
+    (`Utah, United States` ≈ `Provo, Utah, United States`) or equal after
+    normalization. Weaker than MobMergeUtil's standardized-place-**id** check
+    (§12), but the standardized *name* is what skills now pass everywhere.
 - **Merge** equivalents → take the **most-complete date** (completeness score
   from `standard_date`: year=100, month=10, day=1; then most common; then
   longest display text) and the **most-specific place** (longest normalized
@@ -331,8 +336,9 @@ Adopted (ideas, not a port — Richard's guidance):
   `containsAllOrInitials` (844) / `scoreName` (959) / `findLongestName` (971).
 
 Deliberately simplified for v1 (note as limitations):
-- **Place comparison** is string/normalized-chain based — we lack MobMergeUtil's
-  standardized place-id database and `MStandardPlace` chains.
+- **Place comparison** uses the standardized place **name** chain
+  (`standard_place`), not MobMergeUtil's place-**id** database / `MStandardPlace`
+  chains — but the standardized name is what the skills now pass everywhere.
 - **Name matching** uses normalized subset + initials; we omit the Jaro-Winkler
   scorer and the `std_given.txt`/`std_surname.txt` lookup tables (nickname/
   spelling-variant maps) — exact/normalized compare for v1, extendable later.

--- a/packages/engine/mcp-server/src/utils/merge-gedcomx.ts
+++ b/packages/engine/mcp-server/src/utils/merge-gedcomx.ts
@@ -1,0 +1,728 @@
+// merge-gedcomx — deterministically merge SimplifiedGedcomX documents.
+//
+// Issue #250 / spec `docs/specs/merge-gedcomx-spec.md` (rev. 2). The function
+// does NOT decide which people are the same — the caller supplies a list of
+// `[survivorId, collapsedId]` pairs. For each pair the survivor id is kept and
+// the collapsed person is folded into it.
+//
+//   Mode 1 (cross-document): mergeGedcomx(target, candidate, merges)
+//     each pair = [targetId, candidateId]; candidate folds into target,
+//     unpaired candidate persons are carried in as new relatives.
+//   Mode 2 (same-document):  mergeGedcomx(target, null, merges)
+//     each pair = [targetIdA, targetIdB]; B folds into A within the target.
+//
+// Pure: inputs are never mutated; a fresh document is returned.
+
+import type {
+  SimplifiedFact,
+  SimplifiedGedcomX,
+  SimplifiedName,
+  SimplifiedPerson,
+  SimplifiedRelationship,
+  SimplifiedSourceDescription,
+  SimplifiedSourceReference,
+} from "../types/gedcomx.js";
+import { getDayRange } from "./date-helpers.js";
+import { getStandardDate } from "./fact-helpers.js";
+
+/**
+ * Merge `candidate` into `target` (or persons within `target` when
+ * `candidate` is null), collapsing each `[survivorId, collapsedId]` pair.
+ *
+ * @throws on empty/duplicate/chained merges, or unknown ids (see spec §8).
+ */
+export function mergeGedcomx(
+  target: SimplifiedGedcomX,
+  candidate: SimplifiedGedcomX | null,
+  merges: Array<[string, string]>,
+): SimplifiedGedcomX {
+  validateMerges(target, candidate, merges);
+
+  if (candidate === null) {
+    return mergeSameDocument(target, merges);
+  }
+  return mergeCrossDocument(target, candidate, merges);
+}
+
+// ─── Mode 1: cross-document merge ───────────────────────────────────────────
+
+/** Per-prefix id counters, seeded from the target's current maxima. */
+interface IdCounters {
+  I: number;
+  N: number;
+  F: number;
+  R: number;
+  S: number;
+}
+
+function mergeCrossDocument(
+  target: SimplifiedGedcomX,
+  candidate: SimplifiedGedcomX,
+  merges: Array<[string, string]>,
+): SimplifiedGedcomX {
+  const result = structuredClone(target);
+  result.persons ??= [];
+  const counters: IdCounters = {
+    I: maxIdNum(result, "I"),
+    N: maxIdNum(result, "N"),
+    F: maxIdNum(result, "F"),
+    R: maxIdNum(result, "R"),
+    S: maxIdNum(result, "S"),
+  };
+
+  // candidate person id → survivor id (collapsed) or fresh I id (carried).
+  const collapseMap = new Map<string, string>();
+  for (const [s, c] of merges) collapseMap.set(c, s);
+  const personIdMap = new Map<string, string>();
+  for (const p of candidate.persons ?? []) {
+    if (p.id === undefined) continue;
+    personIdMap.set(p.id, collapseMap.get(p.id) ?? `I${++counters.I}`);
+  }
+
+  // candidate source id → deduped target id (by title) or fresh S id.
+  const sourceIdMap = buildSourceIdMap(result, candidate.sources ?? [], counters);
+
+  for (const person of candidate.persons ?? []) {
+    if (person.id === undefined) continue;
+    const content = remapPersonContent(person, counters, sourceIdMap);
+    const survivorId = collapseMap.get(person.id);
+    if (survivorId !== undefined) {
+      const surv = result.persons.find((p) => p.id === survivorId)!;
+      if (!surv.ark && content.ark) surv.ark = content.ark;
+      if (!surv.gender && content.gender) surv.gender = content.gender;
+      if (content.names.length) (surv.names ??= []).push(...content.names);
+      if (content.facts.length) (surv.facts ??= []).push(...content.facts);
+      if (content.sources.length) (surv.sources ??= []).push(...content.sources);
+    } else {
+      const carried: SimplifiedPerson = { id: personIdMap.get(person.id) };
+      if (content.ark !== undefined) carried.ark = content.ark;
+      if (content.gender !== undefined) carried.gender = content.gender;
+      if (content.names.length) carried.names = content.names;
+      if (content.facts.length) carried.facts = content.facts;
+      if (content.sources.length) carried.sources = content.sources;
+      result.persons.push(carried);
+    }
+  }
+
+  // Equivalence-merge names and facts on each survivor (spec §7.1, §7.2).
+  for (const survivorId of new Set(merges.map(([s]) => s))) {
+    const surv = result.persons.find((p) => p.id === survivorId);
+    if (surv?.names) surv.names = mergeNames(surv.names);
+    if (surv?.facts) surv.facts = mergeFacts(surv.facts);
+    if (surv?.sources) surv.sources = dedupSourceRefs(surv.sources);
+  }
+
+  const remappedRels = (candidate.relationships ?? []).map((rel) =>
+    remapRelationship(rel, personIdMap, sourceIdMap, counters),
+  );
+  const combinedRels = [...(result.relationships ?? []), ...remappedRels];
+  if (combinedRels.length > 0) {
+    result.relationships = dedupRelationships(combinedRels);
+  }
+
+  // Carry candidate places, keeping ids unique (places aren't referenced).
+  const candidatePlaces = candidate.places ?? [];
+  if (candidatePlaces.length > 0) {
+    const usedPlaceIds = new Set(
+      (result.places ?? [])
+        .map((p) => p.id)
+        .filter((id): id is string => id !== undefined),
+    );
+    for (const pl of candidatePlaces) {
+      const cloned = structuredClone(pl);
+      if (cloned.id !== undefined && usedPlaceIds.has(cloned.id)) {
+        cloned.id = freshPlaceId(cloned.id, usedPlaceIds);
+      }
+      if (cloned.id !== undefined) usedPlaceIds.add(cloned.id);
+      (result.places ??= []).push(cloned);
+    }
+  }
+
+  ensureUniqueFactAndNameIds(result);
+  return result;
+}
+
+/** A unique place id derived from `base` (places aren't referenced by id). */
+function freshPlaceId(base: string, used: Set<string>): string {
+  let n = 2;
+  let id = `${base}-${n}`;
+  while (used.has(id)) {
+    n += 1;
+    id = `${base}-${n}`;
+  }
+  return id;
+}
+
+// ─── Mode 2: same-document merge ────────────────────────────────────────────
+
+/**
+ * Merge persons within a single document. Each `[survivorId, collapsedId]` pair
+ * folds the collapsed person into the survivor, removes the collapsed person,
+ * and repoints every relationship endpoint. No id remap is needed — the ids
+ * already live in one namespace.
+ */
+function mergeSameDocument(
+  target: SimplifiedGedcomX,
+  merges: Array<[string, string]>,
+): SimplifiedGedcomX {
+  const result = structuredClone(target);
+  result.persons ??= [];
+
+  const collapseMap = new Map<string, string>();
+  for (const [s, c] of merges) collapseMap.set(c, s);
+
+  for (const [survivorId, collapsedId] of merges) {
+    const surv = result.persons.find((p) => p.id === survivorId)!;
+    const coll = result.persons.find((p) => p.id === collapsedId)!;
+    if (!surv.ark && coll.ark) surv.ark = coll.ark;
+    if (!surv.gender && coll.gender) surv.gender = coll.gender;
+    if (coll.names?.length) (surv.names ??= []).push(...structuredClone(coll.names));
+    if (coll.facts?.length) (surv.facts ??= []).push(...structuredClone(coll.facts));
+    if (coll.sources?.length) (surv.sources ??= []).push(...structuredClone(coll.sources));
+  }
+
+  const collapsedIds = new Set(merges.map(([, c]) => c));
+  result.persons = result.persons.filter(
+    (p) => p.id === undefined || !collapsedIds.has(p.id),
+  );
+
+  for (const rel of result.relationships ?? []) {
+    const mapPerson = (id?: string): string | undefined =>
+      id !== undefined ? (collapseMap.get(id) ?? id) : id;
+    if (rel.parent !== undefined) rel.parent = mapPerson(rel.parent);
+    if (rel.child !== undefined) rel.child = mapPerson(rel.child);
+    if (rel.person1 !== undefined) rel.person1 = mapPerson(rel.person1);
+    if (rel.person2 !== undefined) rel.person2 = mapPerson(rel.person2);
+  }
+  if (result.relationships?.length) {
+    result.relationships = dedupRelationships(result.relationships);
+  }
+
+  for (const survivorId of new Set(merges.map(([s]) => s))) {
+    const surv = result.persons.find((p) => p.id === survivorId);
+    if (surv?.names) surv.names = mergeNames(surv.names);
+    if (surv?.facts) surv.facts = mergeFacts(surv.facts);
+    if (surv?.sources) surv.sources = dedupSourceRefs(surv.sources);
+  }
+
+  ensureUniqueFactAndNameIds(result);
+  return result;
+}
+
+/** A candidate person's content after id remap, ready to fold or carry. */
+interface PersonContent {
+  ark?: string;
+  gender?: string;
+  names: SimplifiedName[];
+  facts: SimplifiedFact[];
+  sources: SimplifiedSourceReference[];
+}
+
+/**
+ * Clone a candidate person's names/facts/source-refs with fresh N/F ids and
+ * source refs rewritten through `sourceIdMap`. The id itself is assigned by
+ * the caller (survivor id for a collapse, fresh I id for a carry).
+ */
+function remapPersonContent(
+  person: SimplifiedPerson,
+  counters: IdCounters,
+  sourceIdMap: Map<string, string>,
+): PersonContent {
+  const names = (person.names ?? []).map((n) => {
+    const c = structuredClone(n);
+    c.id = `N${++counters.N}`;
+    if (c.sources) c.sources = remapSourceRefs(c.sources, sourceIdMap);
+    return c;
+  });
+  const facts = (person.facts ?? []).map((f) => {
+    const c = structuredClone(f);
+    c.id = `F${++counters.F}`;
+    if (c.sources) c.sources = remapSourceRefs(c.sources, sourceIdMap);
+    return c;
+  });
+  const sources = person.sources
+    ? remapSourceRefs(person.sources, sourceIdMap)
+    : [];
+  return { ark: person.ark, gender: person.gender, names, facts, sources };
+}
+
+/** Clone a candidate relationship with a fresh R id and all refs repointed. */
+function remapRelationship(
+  rel: SimplifiedRelationship,
+  personIdMap: Map<string, string>,
+  sourceIdMap: Map<string, string>,
+  counters: IdCounters,
+): SimplifiedRelationship {
+  const c = structuredClone(rel);
+  c.id = `R${++counters.R}`;
+  const mapPerson = (id?: string): string | undefined =>
+    id !== undefined ? (personIdMap.get(id) ?? id) : id;
+  if (c.parent !== undefined) c.parent = mapPerson(c.parent);
+  if (c.child !== undefined) c.child = mapPerson(c.child);
+  if (c.person1 !== undefined) c.person1 = mapPerson(c.person1);
+  if (c.person2 !== undefined) c.person2 = mapPerson(c.person2);
+  if (c.facts) {
+    c.facts = c.facts.map((f) => {
+      const fc = structuredClone(f);
+      fc.id = `F${++counters.F}`;
+      if (fc.sources) fc.sources = remapSourceRefs(fc.sources, sourceIdMap);
+      return fc;
+    });
+  }
+  if (c.sources) c.sources = remapSourceRefs(c.sources, sourceIdMap);
+  return c;
+}
+
+function remapSourceRefs(
+  refs: SimplifiedSourceReference[],
+  sourceIdMap: Map<string, string>,
+): SimplifiedSourceReference[] {
+  return refs.map((r) => {
+    const c = structuredClone(r);
+    if (c.ref !== undefined) c.ref = sourceIdMap.get(c.ref) ?? c.ref;
+    return c;
+  });
+}
+
+/**
+ * Merge candidate sources into `result.sources`, deduping by `title`. Returns a
+ * map from candidate source id → resulting id (an existing target id when a
+ * title matches, else a fresh S id). Mutates `result.sources`.
+ */
+function buildSourceIdMap(
+  result: SimplifiedGedcomX,
+  candidateSources: SimplifiedSourceDescription[],
+  counters: IdCounters,
+): Map<string, string> {
+  const map = new Map<string, string>();
+  const titleToId = new Map<string, string>();
+  for (const s of result.sources ?? []) {
+    if (s.id !== undefined && s.title !== undefined && !titleToId.has(s.title)) {
+      titleToId.set(s.title, s.id);
+    }
+  }
+  for (const s of candidateSources) {
+    if (s.id === undefined) continue;
+    const existing = s.title !== undefined ? titleToId.get(s.title) : undefined;
+    if (existing !== undefined) {
+      map.set(s.id, existing);
+      continue;
+    }
+    const newId = `S${++counters.S}`;
+    map.set(s.id, newId);
+    const cloned = structuredClone(s);
+    cloned.id = newId;
+    (result.sources ??= []).push(cloned);
+    if (s.title !== undefined) titleToId.set(s.title, newId);
+  }
+  return map;
+}
+
+/**
+ * Drop self-referential relationships, and collapse exact `type`+endpoint
+ * duplicates into one — folding the duplicate's facts and source refs into the
+ * kept relationship rather than discarding them (never throw facts away).
+ */
+function dedupRelationships(
+  rels: SimplifiedRelationship[],
+): SimplifiedRelationship[] {
+  const byKey = new Map<string, SimplifiedRelationship>();
+  const out: SimplifiedRelationship[] = [];
+  for (const r of rels) {
+    if (isSelfRelationship(r)) continue;
+    const key = relationshipKey(r);
+    const kept = byKey.get(key);
+    if (kept) {
+      if (r.facts?.length) {
+        kept.facts = mergeFacts([...(kept.facts ?? []), ...r.facts]);
+      }
+      if (r.sources?.length) {
+        kept.sources = dedupSourceRefs([...(kept.sources ?? []), ...r.sources]);
+      }
+      continue;
+    }
+    byKey.set(key, r);
+    out.push(r);
+  }
+  return out;
+}
+
+function isSelfRelationship(r: SimplifiedRelationship): boolean {
+  if (r.parent !== undefined && r.parent === r.child) return true;
+  if (r.person1 !== undefined && r.person1 === r.person2) return true;
+  return false;
+}
+
+function relationshipKey(r: SimplifiedRelationship): string {
+  const type = r.type ?? "?";
+  // Couple endpoints are unordered; ParentChild is directional.
+  if (r.person1 !== undefined || r.person2 !== undefined) {
+    const ends = [r.person1 ?? "", r.person2 ?? ""].sort();
+    return `${type}|couple|${ends[0]}|${ends[1]}`;
+  }
+  return `${type}|pc|${r.parent ?? ""}|${r.child ?? ""}`;
+}
+
+// ─── Name equivalence (spec §7.1) ───────────────────────────────────────────
+
+/**
+ * Collapse equivalent names (a less-specific form merges into the fuller one)
+ * and keep genuinely distinct names. Exactly one resulting name is preferred —
+ * the most frequent across inputs, tie-broken by completeness.
+ */
+function mergeNames(names: SimplifiedName[]): SimplifiedName[] {
+  if (names.length === 0) return names;
+  if (names.length === 1) {
+    const only = structuredClone(names[0]);
+    only.preferred = true;
+    return [only];
+  }
+
+  const classes: SimplifiedName[][] = [];
+  for (const n of names) {
+    const cls = classes.find((c) => c.some((m) => namesEquivalent(m, n)));
+    if (cls) cls.push(n);
+    else classes.push([n]);
+  }
+
+  const reps = classes.map((members) => {
+    const best = members.reduce((a, b) => (scoreName(b) > scoreName(a) ? b : a));
+    const rep = structuredClone(best);
+    const sources = dedupSourceRefs(members.flatMap((m) => m.sources ?? []));
+    if (sources.length > 0) rep.sources = sources;
+    else delete rep.sources;
+    rep.preferred = false;
+    return { rep, size: members.length };
+  });
+
+  let best = 0;
+  for (let i = 1; i < reps.length; i++) {
+    const bigger = reps[i].size > reps[best].size;
+    const tie = reps[i].size === reps[best].size;
+    if (bigger || (tie && scoreName(reps[i].rep) > scoreName(reps[best].rep))) {
+      best = i;
+    }
+  }
+  reps[best].rep.preferred = true;
+  return reps.map((r) => r.rep);
+}
+
+function namesEquivalent(a: SimplifiedName, b: SimplifiedName): boolean {
+  return (
+    tokensCompatible(nameTokens(a.given), nameTokens(b.given)) &&
+    tokensCompatible(nameTokens(a.surname), nameTokens(b.surname))
+  );
+}
+
+function nameTokens(part: string | undefined): string[] {
+  return (part ?? "")
+    .normalize("NFD")
+    .replace(/\p{Mn}/gu, "")
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter(Boolean);
+}
+
+/**
+ * True when one token list is a subset of the other, treating a single-letter
+ * initial as matching any token that starts with it (`j` ~ `john`).
+ */
+function tokensCompatible(a: string[], b: string[]): boolean {
+  return coversAll(a, b) || coversAll(b, a);
+}
+
+function coversAll(big: string[], small: string[]): boolean {
+  return small.every((s) => big.some((b) => tokenMatch(b, s)));
+}
+
+function tokenMatch(x: string, y: string): boolean {
+  if (x === y) return true;
+  if (x.length === 1 && y.startsWith(x)) return true;
+  if (y.length === 1 && x.startsWith(y)) return true;
+  return false;
+}
+
+/** Completeness score: more letters and diacritics = more complete. */
+function scoreName(n: SimplifiedName): number {
+  const text = `${n.given ?? ""} ${n.surname ?? ""}`.trim();
+  const letters = text.replace(/\s/g, "").length;
+  const diacritics =
+    text.normalize("NFD").match(/\p{Mn}/gu)?.length ?? 0;
+  return letters * 10 + diacritics;
+}
+
+function dedupSourceRefs(
+  refs: SimplifiedSourceReference[],
+): SimplifiedSourceReference[] {
+  const seen = new Set<string>();
+  const out: SimplifiedSourceReference[] = [];
+  for (const r of refs) {
+    const key = `${r.ref ?? ""}|${r.page ?? ""}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(structuredClone(r));
+  }
+  return out;
+}
+
+/** Highest numeric suffix used by any `<prefix><n>` id of `prefix` in `doc`. */
+function maxIdNum(doc: SimplifiedGedcomX, prefix: string): number {
+  let max = 0;
+  const consider = (id: string | undefined): void => {
+    if (!id) return;
+    const m = id.match(/^([A-Za-z]+)(\d+)$/);
+    if (m && m[1] === prefix) {
+      const n = Number(m[2]);
+      if (n > max) max = n;
+    }
+  };
+  for (const p of doc.persons ?? []) {
+    consider(p.id);
+    for (const n of p.names ?? []) consider(n.id);
+    for (const f of p.facts ?? []) consider(f.id);
+  }
+  for (const r of doc.relationships ?? []) {
+    consider(r.id);
+    for (const f of r.facts ?? []) consider(f.id);
+  }
+  for (const s of doc.sources ?? []) consider(s.id);
+  for (const pl of doc.places ?? []) consider(pl.id);
+  return max;
+}
+
+/**
+ * Final safety pass. Fact and name ids are only unique *within their own array*
+ * in SimplifiedGedcomX, so merging arrays (mode-2 person collapse, relationship
+ * fact-fold) can yield two facts/names sharing an id. Re-id any duplicate or
+ * missing fact/name id with a fresh value above the current maximum. Safe
+ * because nothing in the format references a fact or name id.
+ */
+function ensureUniqueFactAndNameIds(result: SimplifiedGedcomX): void {
+  let fMax = maxIdNum(result, "F");
+  const seenF = new Set<string>();
+  const reidFacts = (facts?: SimplifiedFact[]): void => {
+    for (const f of facts ?? []) {
+      if (f.id === undefined || seenF.has(f.id)) f.id = `F${++fMax}`;
+      seenF.add(f.id);
+    }
+  };
+  for (const p of result.persons ?? []) reidFacts(p.facts);
+  for (const r of result.relationships ?? []) reidFacts(r.facts);
+
+  let nMax = maxIdNum(result, "N");
+  const seenN = new Set<string>();
+  for (const p of result.persons ?? []) {
+    for (const n of p.names ?? []) {
+      if (n.id === undefined || seenN.has(n.id)) n.id = `N${++nMax}`;
+      seenN.add(n.id);
+    }
+  }
+}
+
+// ─── Validation (spec §6.1, §8) ─────────────────────────────────────────────
+
+function validateMerges(
+  target: SimplifiedGedcomX,
+  candidate: SimplifiedGedcomX | null,
+  merges: Array<[string, string]>,
+): void {
+  const targetPersons = target.persons ?? [];
+  if (targetPersons.length === 0) {
+    throw new Error("target_gedcomx has no persons");
+  }
+  if (merges.length === 0) {
+    throw new Error("merges must not be empty — nothing to merge");
+  }
+
+  const survivors = merges.map((m) => m[0]);
+  const collapsed = merges.map((m) => m[1]);
+
+  const dupSurvivor = firstDuplicate(survivors);
+  if (dupSurvivor !== undefined) {
+    throw new Error(`invalid merges: ${dupSurvivor} appears in multiple pairs`);
+  }
+  const dupCollapsed = firstDuplicate(collapsed);
+  if (dupCollapsed !== undefined) {
+    throw new Error(`invalid merges: ${dupCollapsed} appears in multiple pairs`);
+  }
+
+  // Mode 2 only: survivor and collapsed share one namespace, so an id that is
+  // both a survivor and a collapsed id is an ambiguous chain (a→b, b→c).
+  if (candidate === null) {
+    const survivorSet = new Set(survivors);
+    const chained = collapsed.find((id) => survivorSet.has(id));
+    if (chained !== undefined) {
+      throw new Error(
+        `invalid merges: ${chained} appears as both a survivor and a collapsed id (chains are not supported)`,
+      );
+    }
+  }
+
+  const targetIds = new Set(targetPersons.map((p) => p.id));
+  for (const id of survivors) {
+    if (!targetIds.has(id)) {
+      throw new Error(`merge survivor id ${id} not found in target_gedcomx`);
+    }
+  }
+
+  const collapsedSourceIds =
+    candidate === null
+      ? targetIds
+      : new Set((candidate.persons ?? []).map((p) => p.id));
+  for (const id of collapsed) {
+    if (!collapsedSourceIds.has(id)) {
+      throw new Error(`merge id ${id} not found`);
+    }
+  }
+}
+
+function firstDuplicate(ids: string[]): string | undefined {
+  const seen = new Set<string>();
+  for (const id of ids) {
+    if (seen.has(id)) return id;
+    seen.add(id);
+  }
+  return undefined;
+}
+
+// ─── Fact equivalence (spec §7.2) ───────────────────────────────────────────
+
+/** Single-occurrence vital types: exactly one of each is marked `primary`. */
+const VITAL_PRIMARY_TYPES: ReadonlySet<string> = new Set([
+  "Birth",
+  "Death",
+  "Christening",
+  "Burial",
+]);
+
+/**
+ * Collapse equivalent facts (same type + compatible date + compatible place),
+ * taking the most-specific date and place; keep genuinely distinct facts. For
+ * each single-occurrence vital type the most-complete surviving fact is marked
+ * `primary`. Other types keep an input `primary` if one was set.
+ */
+function mergeFacts(facts: SimplifiedFact[]): SimplifiedFact[] {
+  if (facts.length === 0) return facts;
+
+  const classes: SimplifiedFact[][] = [];
+  for (const f of facts) {
+    const cls = classes.find((c) => c.some((m) => factsEquivalent(m, f)));
+    if (cls) cls.push(f);
+    else classes.push([f]);
+  }
+  const reps = classes.map(mergeFactGroup);
+
+  for (const type of VITAL_PRIMARY_TYPES) {
+    const group = reps.filter((r) => r.type === type);
+    if (group.length === 0) continue;
+    for (const r of group) delete r.primary;
+    const best = group.reduce((a, b) => (factMoreComplete(b, a) ? b : a));
+    best.primary = true;
+  }
+  return reps;
+}
+
+/** Merge a class of equivalent facts into one, taking best date + best place. */
+function mergeFactGroup(members: SimplifiedFact[]): SimplifiedFact {
+  const rep = structuredClone(members[0]); // keep the first (target) id + type
+
+  const bestDate = members.reduce((a, b) =>
+    factDateWidth(b) < factDateWidth(a) ? b : a,
+  );
+  setOrDelete(rep, "date", bestDate.date);
+  setOrDelete(rep, "standard_date", bestDate.standard_date);
+
+  const bestPlace = members.reduce((a, b) =>
+    placeChainLength(b) > placeChainLength(a) ? b : a,
+  );
+  setOrDelete(rep, "place", bestPlace.place);
+  setOrDelete(rep, "standard_place", bestPlace.standard_place);
+
+  const valued = members.find((m) => m.value !== undefined && m.value !== "");
+  setOrDelete(rep, "value", valued?.value);
+
+  if (members.some((m) => m.primary === true)) rep.primary = true;
+  else delete rep.primary;
+
+  const sources = dedupSourceRefs(members.flatMap((m) => m.sources ?? []));
+  if (sources.length > 0) rep.sources = sources;
+  else delete rep.sources;
+
+  return rep;
+}
+
+function setOrDelete<K extends keyof SimplifiedFact>(
+  fact: SimplifiedFact,
+  key: K,
+  value: SimplifiedFact[K] | undefined,
+): void {
+  if (value !== undefined) fact[key] = value;
+  else delete fact[key];
+}
+
+function factsEquivalent(a: SimplifiedFact, b: SimplifiedFact): boolean {
+  if (a.type !== b.type) return false;
+  return datesCompatible(a, b) && placesCompatible(a, b);
+}
+
+/** Compatible when one date's day-range contains the other (or either is absent). */
+function datesCompatible(a: SimplifiedFact, b: SimplifiedFact): boolean {
+  const sa = getStandardDate(a);
+  const sb = getStandardDate(b);
+  if (sa === null || sb === null) return true;
+  const ra = getDayRange(sa);
+  const rb = getDayRange(sb);
+  if (!ra || !rb) return true;
+  return rangeContains(ra, rb) || rangeContains(rb, ra);
+}
+
+function rangeContains(
+  outer: { min: number; max: number },
+  inner: { min: number; max: number },
+): boolean {
+  return outer.min <= inner.min && inner.max <= outer.max;
+}
+
+/** Compatible when one place chain is a prefix of the other (or either is absent). */
+function placesCompatible(a: SimplifiedFact, b: SimplifiedFact): boolean {
+  const pa = placeChain(a);
+  const pb = placeChain(b);
+  if (pa.length === 0 || pb.length === 0) return true;
+  return chainIsPrefix(pa, pb) || chainIsPrefix(pb, pa);
+}
+
+/** Root-first, normalized components of a fact's place (standard_place ∨ place). */
+function placeChain(f: SimplifiedFact): string[] {
+  const raw = f.standard_place ?? f.place;
+  if (!raw) return [];
+  return raw
+    .split(",")
+    .map((t) => t.trim().toLowerCase())
+    .filter(Boolean)
+    .reverse();
+}
+
+function placeChainLength(f: SimplifiedFact): number {
+  return placeChain(f).length;
+}
+
+function chainIsPrefix(short: string[], long: string[]): boolean {
+  return short.length <= long.length && short.every((t, i) => long[i] === t);
+}
+
+/** Day-span of a fact's date (smaller = more specific); Infinity when undated. */
+function factDateWidth(f: SimplifiedFact): number {
+  const s = getStandardDate(f);
+  if (s === null) return Infinity;
+  const r = getDayRange(s);
+  if (!r) return Infinity;
+  return r.max - r.min;
+}
+
+/** True when `a` is strictly more complete than `b` (date first, then place). */
+function factMoreComplete(a: SimplifiedFact, b: SimplifiedFact): boolean {
+  const da = factDateWidth(a);
+  const db = factDateWidth(b);
+  if (da !== db) return da < db;
+  return placeChainLength(a) > placeChainLength(b);
+}

--- a/packages/engine/mcp-server/tests/utils/merge-gedcomx.test.ts
+++ b/packages/engine/mcp-server/tests/utils/merge-gedcomx.test.ts
@@ -1,0 +1,768 @@
+import { describe, it, expect } from "vitest";
+
+import { mergeGedcomx } from "../../src/utils/merge-gedcomx.js";
+import type { SimplifiedGedcomX } from "../../src/types/gedcomx.js";
+
+/**
+ * Assert the document is internally consistent: every relationship endpoint
+ * resolves to a person, every source `ref` resolves to a source, and ids are
+ * unique within each kind (person, source, fact, name).
+ */
+function assertIntegrity(doc: SimplifiedGedcomX): void {
+  const personIds = new Set((doc.persons ?? []).map((p) => p.id));
+  const sourceIds = new Set((doc.sources ?? []).map((s) => s.id));
+
+  for (const rel of doc.relationships ?? []) {
+    for (const ep of [rel.parent, rel.child, rel.person1, rel.person2]) {
+      if (ep !== undefined) expect(personIds.has(ep)).toBe(true);
+    }
+    for (const sr of rel.sources ?? []) {
+      if (sr.ref !== undefined) expect(sourceIds.has(sr.ref)).toBe(true);
+    }
+  }
+
+  const factIds: (string | undefined)[] = [];
+  const nameIds: (string | undefined)[] = [];
+  const checkRefs = (srs?: { ref?: string }[]) => {
+    for (const sr of srs ?? []) {
+      if (sr.ref !== undefined) expect(sourceIds.has(sr.ref)).toBe(true);
+    }
+  };
+  for (const p of doc.persons ?? []) {
+    checkRefs(p.sources);
+    for (const n of p.names ?? []) {
+      nameIds.push(n.id);
+      checkRefs(n.sources);
+    }
+    for (const f of p.facts ?? []) {
+      factIds.push(f.id);
+      checkRefs(f.sources);
+    }
+  }
+  for (const r of doc.relationships ?? []) {
+    for (const f of r.facts ?? []) factIds.push(f.id);
+  }
+
+  const personIdList = (doc.persons ?? []).map((p) => p.id);
+  expect(new Set(personIdList).size).toBe(personIdList.length);
+  const sourceIdList = (doc.sources ?? []).map((s) => s.id);
+  expect(new Set(sourceIdList).size).toBe(sourceIdList.length);
+  expect(new Set(factIds).size).toBe(factIds.length);
+  expect(new Set(nameIds).size).toBe(nameIds.length);
+}
+
+// ────────────────────────────────────────────────────────────────────
+// Block A: validation (spec §6.1, §8)
+// ────────────────────────────────────────────────────────────────────
+
+describe("mergeGedcomx — validation", () => {
+  const target: SimplifiedGedcomX = {
+    persons: [{ id: "I1", names: [{ id: "N1", given: "Ann" }] }],
+  };
+  const candidate: SimplifiedGedcomX = {
+    persons: [{ id: "I1", names: [{ id: "N1", given: "Ann" }] }],
+  };
+
+  it("throws when merges is empty", () => {
+    expect(() => mergeGedcomx(target, candidate, [])).toThrow(/merges/i);
+  });
+
+  it("throws when a survivor id is not in the target", () => {
+    expect(() => mergeGedcomx(target, candidate, [["I9", "I1"]])).toThrow(/I9/);
+  });
+
+  it("throws when a collapsed id is not in the candidate (mode 1)", () => {
+    expect(() => mergeGedcomx(target, candidate, [["I1", "I9"]])).toThrow(/I9/);
+  });
+
+  it("throws when a survivor id appears in more than one pair (mode 2)", () => {
+    const t: SimplifiedGedcomX = {
+      persons: [{ id: "I1" }, { id: "I2" }, { id: "I3" }],
+    };
+    expect(() =>
+      mergeGedcomx(t, null, [
+        ["I1", "I2"],
+        ["I1", "I3"],
+      ]),
+    ).toThrow(/I1/);
+  });
+
+  it("throws on a merge chain — an id that is both survivor and collapsed (mode 2)", () => {
+    const t: SimplifiedGedcomX = {
+      persons: [{ id: "I1" }, { id: "I2" }, { id: "I3" }],
+    };
+    expect(() =>
+      mergeGedcomx(t, null, [
+        ["I1", "I2"],
+        ["I2", "I3"],
+      ]),
+    ).toThrow(/I2/);
+  });
+
+  it("throws when the target has no persons", () => {
+    expect(() => mergeGedcomx({ persons: [] }, candidate, [["I1", "I1"]])).toThrow();
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────
+// Block B: mode-1 core — collapse, id remap, ark/gender, purity
+// ────────────────────────────────────────────────────────────────────
+
+describe("mergeGedcomx — mode 1 core", () => {
+  it("collapses one pair: survivor id kept, facts unioned, colliding candidate fact id remapped", () => {
+    const target: SimplifiedGedcomX = {
+      persons: [{ id: "I1", facts: [{ id: "F1", type: "Birth", standard_date: "1845" }] }],
+    };
+    const candidate: SimplifiedGedcomX = {
+      persons: [{ id: "I1", facts: [{ id: "F1", type: "Residence", standard_date: "1880" }] }],
+    };
+
+    const out = mergeGedcomx(target, candidate, [["I1", "I1"]]);
+
+    expect(out.persons).toHaveLength(1);
+    const p = out.persons![0];
+    expect(p.id).toBe("I1");
+    expect((p.facts ?? []).map((f) => f.type).sort()).toEqual(["Birth", "Residence"]);
+    const factIds = (p.facts ?? []).map((f) => f.id);
+    expect(new Set(factIds).size).toBe(2); // no id collision
+    const residence = p.facts!.find((f) => f.type === "Residence")!;
+    expect(residence.id).not.toBe("F1"); // remapped off the target's F1
+  });
+
+  it("keeps the survivor's ark/gender on conflict, adopts the candidate's when the survivor has none", () => {
+    const conflict = mergeGedcomx(
+      { persons: [{ id: "I1", ark: "T-ARK", gender: "Male" }] },
+      { persons: [{ id: "I1", ark: "C-ARK", gender: "Female" }] },
+      [["I1", "I1"]],
+    );
+    expect(conflict.persons![0].ark).toBe("T-ARK");
+    expect(conflict.persons![0].gender).toBe("Male");
+
+    const adopt = mergeGedcomx(
+      { persons: [{ id: "I1" }] },
+      { persons: [{ id: "I1", ark: "C-ARK", gender: "Female" }] },
+      [["I1", "I1"]],
+    );
+    expect(adopt.persons![0].ark).toBe("C-ARK");
+    expect(adopt.persons![0].gender).toBe("Female");
+  });
+
+  it("does not mutate either input document (purity)", () => {
+    const target: SimplifiedGedcomX = {
+      persons: [{ id: "I1", facts: [{ id: "F1", type: "Birth", standard_date: "1845" }] }],
+    };
+    const candidate: SimplifiedGedcomX = {
+      persons: [{ id: "I1", facts: [{ id: "F1", type: "Residence", standard_date: "1880" }] }],
+    };
+    const targetBefore = structuredClone(target);
+    const candidateBefore = structuredClone(candidate);
+
+    mergeGedcomx(target, candidate, [["I1", "I1"]]);
+
+    expect(target).toEqual(targetBefore);
+    expect(candidate).toEqual(candidateBefore);
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────
+// Block C: mode-1 relationships, sources, carry-over, integrity
+// ────────────────────────────────────────────────────────────────────
+
+describe("mergeGedcomx — mode 1 relationships / sources / carry-over", () => {
+  it("repoints candidate relationships to survivors and drops exact duplicates", () => {
+    const target: SimplifiedGedcomX = {
+      persons: [{ id: "I1" }, { id: "I2" }],
+      relationships: [{ id: "R1", type: "ParentChild", parent: "I2", child: "I1" }],
+    };
+    const candidate: SimplifiedGedcomX = {
+      persons: [{ id: "I1" }, { id: "I2" }],
+      relationships: [{ id: "R1", type: "ParentChild", parent: "I2", child: "I1" }],
+    };
+
+    const out = mergeGedcomx(target, candidate, [
+      ["I1", "I1"],
+      ["I2", "I2"],
+    ]);
+
+    const pc = (out.relationships ?? []).filter((r) => r.type === "ParentChild");
+    expect(pc).toHaveLength(1);
+    expect(pc[0]).toMatchObject({ parent: "I2", child: "I1" });
+    assertIntegrity(out);
+  });
+
+  it("carries an unpaired candidate person in as a new relative with a fresh id", () => {
+    const target: SimplifiedGedcomX = { persons: [{ id: "I1" }] };
+    const candidate: SimplifiedGedcomX = {
+      persons: [
+        { id: "I1" },
+        { id: "I2", names: [{ id: "N1", given: "Mary", surname: "Flynn" }] },
+      ],
+      relationships: [{ id: "R1", type: "ParentChild", parent: "I2", child: "I1" }],
+    };
+
+    const out = mergeGedcomx(target, candidate, [["I1", "I1"]]);
+
+    expect(out.persons).toHaveLength(2);
+    const mary = out.persons!.find((p) =>
+      (p.names ?? []).some((n) => n.given === "Mary"),
+    )!;
+    expect(mary).toBeDefined();
+    expect(mary.id).not.toBe("I1");
+    // the relationship now points parent → the carried person's fresh id
+    const pc = (out.relationships ?? []).find((r) => r.type === "ParentChild")!;
+    expect(pc.parent).toBe(mary.id);
+    expect(pc.child).toBe("I1");
+    assertIntegrity(out);
+  });
+
+  it("dedups sources by title and rewrites every source ref to the surviving id", () => {
+    const target: SimplifiedGedcomX = {
+      persons: [{ id: "I1", sources: [{ ref: "S1" }] }],
+      sources: [{ id: "S1", title: "1850 Census" }],
+    };
+    const candidate: SimplifiedGedcomX = {
+      persons: [
+        {
+          id: "I1",
+          facts: [
+            { id: "F1", type: "Residence", standard_date: "1880", sources: [{ ref: "S1" }] },
+            { id: "F2", type: "Census", standard_date: "1885", sources: [{ ref: "S2" }] },
+          ],
+        },
+      ],
+      sources: [
+        { id: "S1", title: "1850 Census" }, // same title → dedups to target's S1
+        { id: "S2", title: "1880 Census" }, // distinct → carried with a fresh id
+      ],
+    };
+
+    const out = mergeGedcomx(target, candidate, [["I1", "I1"]]);
+
+    expect((out.sources ?? []).map((s) => s.title).sort()).toEqual([
+      "1850 Census",
+      "1880 Census",
+    ]);
+    const byId = new Map((out.sources ?? []).map((s) => [s.id, s.title]));
+    const p = out.persons![0];
+    const residence = p.facts!.find((f) => f.type === "Residence")!;
+    const census = p.facts!.find((f) => f.type === "Census")!;
+    // refs resolve to the correct source (Residence → deduped 1850, Census → 1880)
+    expect(byId.get(residence.sources![0].ref!)).toBe("1850 Census");
+    expect(byId.get(census.sources![0].ref!)).toBe("1880 Census");
+    assertIntegrity(out);
+  });
+
+  it("handles a full id collision across persons/names/facts/rels/sources with no dangling refs", () => {
+    const target: SimplifiedGedcomX = {
+      persons: [
+        {
+          id: "I1",
+          ark: "T",
+          gender: "Male",
+          names: [{ id: "N1", preferred: true, given: "Patrick", surname: "Flynn" }],
+          facts: [{ id: "F1", type: "Birth", standard_date: "1845", sources: [{ ref: "S1" }] }],
+          sources: [{ ref: "S1" }],
+        },
+        { id: "I2", gender: "Male", names: [{ id: "N2", given: "Michael", surname: "Flynn" }] },
+      ],
+      relationships: [
+        { id: "R1", type: "ParentChild", parent: "I2", child: "I1", sources: [{ ref: "S1" }] },
+      ],
+      sources: [{ id: "S1", title: "1850 Census" }],
+    };
+    const candidate: SimplifiedGedcomX = {
+      persons: [
+        {
+          id: "I1",
+          gender: "Male",
+          names: [{ id: "N1", given: "Patrick", surname: "Flynn" }],
+          facts: [{ id: "F1", type: "Residence", standard_date: "1880", sources: [{ ref: "S1" }] }],
+          sources: [{ ref: "S1" }],
+        },
+        { id: "I2", gender: "Male", names: [{ id: "N1", given: "Michael", surname: "Flynn" }] },
+        { id: "I3", gender: "Female", names: [{ id: "N2", given: "Mary", surname: "Flynn" }] },
+      ],
+      relationships: [
+        { id: "R1", type: "ParentChild", parent: "I2", child: "I1", sources: [{ ref: "S1" }] }, // dup
+        { id: "R2", type: "ParentChild", parent: "I3", child: "I1" }, // new (mother)
+        { id: "R3", type: "Couple", person1: "I2", person2: "I3" }, // new (parents)
+      ],
+      sources: [
+        { id: "S1", title: "1850 Census" },
+        { id: "S2", title: "1880 Census" },
+      ],
+    };
+
+    const out = mergeGedcomx(target, candidate, [
+      ["I1", "I1"],
+      ["I2", "I2"],
+    ]);
+
+    assertIntegrity(out);
+    expect(out.persons).toHaveLength(3); // I1, I2, carried Mary
+    expect(out.relationships).toHaveLength(3); // PC(I2→I1), PC(Mary→I1), Couple(I2,Mary)
+    expect((out.sources ?? []).map((s) => s.title).sort()).toEqual([
+      "1850 Census",
+      "1880 Census",
+    ]);
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────
+// Block D: name equivalence (spec §7.1)
+// ────────────────────────────────────────────────────────────────────
+
+describe("mergeGedcomx — name equivalence", () => {
+  function preferred(p: { names?: { preferred?: boolean }[] }) {
+    return (p.names ?? []).filter((n) => n.preferred === true);
+  }
+
+  it("merges an initials/subset name into the fuller one and marks it preferred", () => {
+    const out = mergeGedcomx(
+      { persons: [{ id: "I1", names: [{ id: "N1", preferred: true, given: "J", surname: "Flynn" }] }] },
+      { persons: [{ id: "I1", names: [{ id: "N1", given: "James", surname: "Flynn" }] }] },
+      [["I1", "I1"]],
+    );
+
+    const p = out.persons![0];
+    expect(p.names).toHaveLength(1);
+    expect(p.names![0]).toMatchObject({ given: "James", surname: "Flynn", preferred: true });
+  });
+
+  it("keeps a genuinely different name as a distinct entry, with exactly one preferred", () => {
+    const out = mergeGedcomx(
+      { persons: [{ id: "I1", names: [{ id: "N1", preferred: true, given: "James", surname: "Flynn" }] }] },
+      { persons: [{ id: "I1", names: [{ id: "N1", given: "Patrick", surname: "Murphy" }] }] },
+      [["I1", "I1"]],
+    );
+
+    const p = out.persons![0];
+    expect(p.names).toHaveLength(2);
+    expect((p.names ?? []).map((n) => n.given).sort()).toEqual(["James", "Patrick"]);
+    expect(preferred(p)).toHaveLength(1);
+  });
+
+  it("marks the most frequent name as preferred when one repeats across inputs", () => {
+    const out = mergeGedcomx(
+      {
+        persons: [
+          {
+            id: "I1",
+            names: [
+              { id: "N1", given: "James", surname: "Flynn" },
+              { id: "N2", given: "Jim", surname: "Flynn" },
+            ],
+          },
+        ],
+      },
+      { persons: [{ id: "I1", names: [{ id: "N1", given: "James", surname: "Flynn" }] }] },
+      [["I1", "I1"]],
+    );
+
+    const p = out.persons![0];
+    expect(p.names).toHaveLength(2); // {James Flynn} ×2 collapse to one; {Jim Flynn} distinct
+    const pref = preferred(p);
+    expect(pref).toHaveLength(1);
+    expect(pref[0].given).toBe("James");
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────
+// Block E: fact equivalence + primary marking (spec §7.2)
+// ────────────────────────────────────────────────────────────────────
+
+describe("mergeGedcomx — fact equivalence", () => {
+  it("merges a less-specific birth into the more specific one, taking date+place, marked primary", () => {
+    const out = mergeGedcomx(
+      {
+        persons: [
+          {
+            id: "I1",
+            facts: [
+              {
+                id: "F1",
+                type: "Birth",
+                date: "1900",
+                standard_date: "1900",
+                place: "Utah",
+                standard_place: "Utah, United States",
+              },
+            ],
+          },
+        ],
+      },
+      {
+        persons: [
+          {
+            id: "I1",
+            facts: [
+              {
+                id: "F1",
+                type: "Birth",
+                date: "10 Jan 1900",
+                standard_date: "10 Jan 1900",
+                place: "Provo, Utah",
+                standard_place: "Provo, Utah, United States",
+              },
+            ],
+          },
+        ],
+      },
+      [["I1", "I1"]],
+    );
+
+    const births = (out.persons![0].facts ?? []).filter((f) => f.type === "Birth");
+    expect(births).toHaveLength(1);
+    expect(births[0].standard_date).toBe("10 Jan 1900"); // most complete date
+    expect(births[0].standard_place).toBe("Provo, Utah, United States"); // most specific place
+    expect(births[0].primary).toBe(true);
+  });
+
+  it("keeps two conflicting births and marks exactly one (the better) as primary", () => {
+    const out = mergeGedcomx(
+      {
+        persons: [
+          { id: "I1", facts: [{ id: "F1", type: "Birth", standard_date: "1900", standard_place: "Utah, United States" }] },
+        ],
+      },
+      {
+        persons: [
+          { id: "I1", facts: [{ id: "F1", type: "Birth", standard_date: "1888", standard_place: "Ohio, United States" }] },
+        ],
+      },
+      [["I1", "I1"]],
+    );
+
+    const births = (out.persons![0].facts ?? []).filter((f) => f.type === "Birth");
+    expect(births).toHaveLength(2);
+    expect(births.filter((f) => f.primary === true)).toHaveLength(1);
+  });
+
+  it("merges compatible residences, keeps distinct ones, and marks none primary (non-vital type)", () => {
+    const out = mergeGedcomx(
+      {
+        persons: [
+          { id: "I1", facts: [{ id: "F1", type: "Residence", standard_date: "1880", standard_place: "New York, United States" }] },
+        ],
+      },
+      {
+        persons: [
+          {
+            id: "I1",
+            facts: [
+              { id: "F1", type: "Residence", standard_date: "1880", standard_place: "Manhattan, New York, United States" },
+              { id: "F2", type: "Residence", standard_date: "1900", standard_place: "Boston, Massachusetts, United States" },
+            ],
+          },
+        ],
+      },
+      [["I1", "I1"]],
+    );
+
+    const res = (out.persons![0].facts ?? []).filter((f) => f.type === "Residence");
+    expect(res).toHaveLength(2); // 1880 (merged, more specific place) + distinct 1900
+    expect(res.some((f) => f.standard_place === "Manhattan, New York, United States")).toBe(true);
+    expect(res.every((f) => f.primary !== true)).toBe(true);
+  });
+
+  it("preserves an existing primary when merging a non-vital group", () => {
+    const out = mergeGedcomx(
+      {
+        persons: [
+          { id: "I1", facts: [{ id: "F1", type: "Census", primary: true, standard_date: "1880", standard_place: "New York, United States" }] },
+        ],
+      },
+      {
+        persons: [
+          { id: "I1", facts: [{ id: "F1", type: "Census", standard_date: "1880", standard_place: "Manhattan, New York, United States" }] },
+        ],
+      },
+      [["I1", "I1"]],
+    );
+
+    const census = (out.persons![0].facts ?? []).filter((f) => f.type === "Census");
+    expect(census).toHaveLength(1);
+    expect(census[0].primary).toBe(true);
+    expect(census[0].standard_place).toBe("Manhattan, New York, United States");
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────
+// Block F: mode 2 — same-document merge (candidate = null)
+// ────────────────────────────────────────────────────────────────────
+
+describe("mergeGedcomx — mode 2 (same document)", () => {
+  it("folds one target person into another, removes it, and repoints relationships", () => {
+    const target: SimplifiedGedcomX = {
+      persons: [
+        { id: "I1", names: [{ id: "N1", given: "John", surname: "Doe" }], facts: [{ id: "F1", type: "Birth", standard_date: "1900" }] },
+        { id: "I2", names: [{ id: "N2", given: "J", surname: "Doe" }], facts: [{ id: "F2", type: "Residence", standard_date: "1920" }] },
+        { id: "I3" },
+      ],
+      relationships: [{ id: "R1", type: "ParentChild", parent: "I2", child: "I3" }],
+    };
+
+    const out = mergeGedcomx(target, null, [["I1", "I2"]]);
+
+    expect(out.persons).toHaveLength(2);
+    expect(out.persons!.some((p) => p.id === "I2")).toBe(false);
+    const i1 = out.persons!.find((p) => p.id === "I1")!;
+    expect((i1.facts ?? []).map((f) => f.type).sort()).toEqual(["Birth", "Residence"]);
+    expect(i1.names).toHaveLength(1); // "J Doe" merged into "John Doe"
+    const pc = out.relationships!.find((r) => r.type === "ParentChild")!;
+    expect(pc.parent).toBe("I1");
+    expect(pc.child).toBe("I3");
+    assertIntegrity(out);
+  });
+
+  it("drops a relationship that becomes self-referential after the collapse", () => {
+    const target: SimplifiedGedcomX = {
+      persons: [{ id: "I1" }, { id: "I2" }],
+      relationships: [{ id: "R1", type: "Couple", person1: "I1", person2: "I2" }],
+    };
+
+    const out = mergeGedcomx(target, null, [["I1", "I2"]]);
+
+    expect(out.persons).toHaveLength(1);
+    expect(out.relationships ?? []).toHaveLength(0);
+    assertIntegrity(out);
+  });
+
+  it("does not mutate the input document (mode 2 purity)", () => {
+    const target: SimplifiedGedcomX = {
+      persons: [
+        { id: "I1", facts: [{ id: "F1", type: "Birth", standard_date: "1900" }] },
+        { id: "I2", facts: [{ id: "F2", type: "Death", standard_date: "1970" }] },
+      ],
+      relationships: [{ id: "R1", type: "Couple", person1: "I1", person2: "I2" }],
+    };
+    const before = structuredClone(target);
+
+    mergeGedcomx(target, null, [["I1", "I2"]]);
+
+    expect(target).toEqual(before);
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────
+// Block G: robustness — source-ref dedup, rel-fact merge, places, disjoint ids
+// ────────────────────────────────────────────────────────────────────
+
+describe("mergeGedcomx — robustness", () => {
+  it("dedups a survivor's person-level source refs (spec §6.3)", () => {
+    const target: SimplifiedGedcomX = {
+      persons: [{ id: "I1", sources: [{ ref: "S1" }] }],
+      sources: [{ id: "S1", title: "Census" }],
+    };
+    const candidate: SimplifiedGedcomX = {
+      persons: [{ id: "I1", sources: [{ ref: "S1" }] }],
+      sources: [{ id: "S1", title: "Census" }], // same title → same source
+    };
+
+    const out = mergeGedcomx(target, candidate, [["I1", "I1"]]);
+
+    expect(out.persons![0].sources).toHaveLength(1);
+    assertIntegrity(out);
+  });
+
+  it("merges a duplicate couple's marriage fact into the kept relationship (never drops facts)", () => {
+    const target: SimplifiedGedcomX = {
+      persons: [{ id: "I1" }, { id: "I2" }],
+      relationships: [{ id: "R1", type: "Couple", person1: "I1", person2: "I2" }],
+    };
+    const candidate: SimplifiedGedcomX = {
+      persons: [{ id: "I1" }, { id: "I2" }],
+      relationships: [
+        {
+          id: "R1",
+          type: "Couple",
+          person1: "I1",
+          person2: "I2",
+          facts: [{ id: "F1", type: "Marriage", standard_date: "1870" }],
+        },
+      ],
+    };
+
+    const out = mergeGedcomx(target, candidate, [
+      ["I1", "I1"],
+      ["I2", "I2"],
+    ]);
+
+    const couples = (out.relationships ?? []).filter((r) => r.type === "Couple");
+    expect(couples).toHaveLength(1);
+    expect((couples[0].facts ?? []).some((f) => f.type === "Marriage")).toBe(true);
+    assertIntegrity(out);
+  });
+
+  it("carries candidate places over, keeping place ids unique on collision (spec §6.7)", () => {
+    const target: SimplifiedGedcomX = {
+      persons: [{ id: "I1" }],
+      places: [{ id: "PL1", name: "Ireland" }],
+    };
+    const candidate: SimplifiedGedcomX = {
+      persons: [{ id: "I1" }],
+      places: [{ id: "PL1", name: "New York" }],
+    };
+
+    const out = mergeGedcomx(target, candidate, [["I1", "I1"]]);
+
+    expect((out.places ?? []).map((p) => p.name).sort()).toEqual(["Ireland", "New York"]);
+    const ids = (out.places ?? []).map((p) => p.id);
+    expect(new Set(ids).size).toBe(ids.length); // unique
+  });
+
+  it("handles disjoint ids (no collision) with full referential integrity (spec §9)", () => {
+    const target: SimplifiedGedcomX = {
+      persons: [
+        {
+          id: "I1",
+          names: [{ id: "N1", given: "Pat", surname: "Flynn" }],
+          facts: [{ id: "F1", type: "Birth", standard_date: "1845" }],
+          sources: [{ ref: "S1" }],
+        },
+      ],
+      sources: [{ id: "S1", title: "A" }],
+    };
+    const candidate: SimplifiedGedcomX = {
+      persons: [
+        {
+          id: "I5",
+          facts: [{ id: "F5", type: "Death", standard_date: "1910", sources: [{ ref: "S5" }] }],
+          sources: [{ ref: "S5" }],
+        },
+      ],
+      sources: [{ id: "S5", title: "B" }],
+    };
+
+    const out = mergeGedcomx(target, candidate, [["I1", "I5"]]);
+
+    assertIntegrity(out);
+    expect(out.persons).toHaveLength(1);
+    expect((out.persons![0].facts ?? []).map((f) => f.type).sort()).toEqual(["Birth", "Death"]);
+    expect((out.sources ?? []).map((s) => s.title).sort()).toEqual(["A", "B"]);
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────
+// Block H: adversarial edge cases (probe the riskiest paths)
+// ────────────────────────────────────────────────────────────────────
+
+describe("mergeGedcomx — adversarial edge cases", () => {
+  it("merges focus + father + mother in one call (3 pairs, spec §9 multi-pair)", () => {
+    const tree = (): SimplifiedGedcomX => ({
+      persons: [
+        { id: "I1", names: [{ id: "N1", given: "Pat", surname: "Flynn" }] },
+        { id: "I2", gender: "Male", names: [{ id: "N2", given: "Mike", surname: "Flynn" }] },
+        { id: "I3", gender: "Female", names: [{ id: "N3", given: "Mary", surname: "Flynn" }] },
+      ],
+      relationships: [
+        { id: "R1", type: "ParentChild", parent: "I2", child: "I1" },
+        { id: "R2", type: "ParentChild", parent: "I3", child: "I1" },
+        { id: "R3", type: "Couple", person1: "I2", person2: "I3" },
+      ],
+    });
+
+    const out = mergeGedcomx(tree(), tree(), [
+      ["I1", "I1"],
+      ["I2", "I2"],
+      ["I3", "I3"],
+    ]);
+
+    expect(out.persons).toHaveLength(3); // nobody carried — all three paired
+    expect(out.relationships).toHaveLength(3); // duplicates collapsed
+    assertIntegrity(out);
+  });
+
+  it("never leaves two primaries of the same vital type, even when both inputs were primary", () => {
+    const out = mergeGedcomx(
+      { persons: [{ id: "I1", facts: [{ id: "F1", type: "Birth", primary: true, standard_date: "1900" }] }] },
+      { persons: [{ id: "I1", facts: [{ id: "F1", type: "Birth", primary: true, standard_date: "1888" }] }] },
+      [["I1", "I1"]],
+    );
+    const births = (out.persons![0].facts ?? []).filter((f) => f.type === "Birth");
+    expect(births).toHaveLength(2); // distinct → both kept
+    expect(births.filter((f) => f.primary === true)).toHaveLength(1); // exactly one
+  });
+
+  it("marks a lone vital fact primary even when nothing was merged into it", () => {
+    const out = mergeGedcomx(
+      { persons: [{ id: "I1", facts: [{ id: "F1", type: "Birth", standard_date: "1900" }] }] },
+      { persons: [{ id: "I1", names: [{ id: "N1", given: "Pat", surname: "Flynn" }] }] },
+      [["I1", "I1"]],
+    );
+    const births = (out.persons![0].facts ?? []).filter((f) => f.type === "Birth");
+    expect(births).toHaveLength(1);
+    expect(births[0].primary).toBe(true);
+  });
+
+  it("does NOT merge births that differ at month precision (Jan vs Feb)", () => {
+    const out = mergeGedcomx(
+      { persons: [{ id: "I1", facts: [{ id: "F1", type: "Birth", standard_date: "Jan 1900" }] }] },
+      { persons: [{ id: "I1", facts: [{ id: "F1", type: "Birth", standard_date: "Feb 1900" }] }] },
+      [["I1", "I1"]],
+    );
+    expect((out.persons![0].facts ?? []).filter((f) => f.type === "Birth")).toHaveLength(2);
+  });
+
+  it("does NOT merge facts whose places share only the country", () => {
+    const out = mergeGedcomx(
+      { persons: [{ id: "I1", facts: [{ id: "F1", type: "Residence", standard_date: "1880", standard_place: "Ohio, United States" }] }] },
+      { persons: [{ id: "I1", facts: [{ id: "F1", type: "Residence", standard_date: "1880", standard_place: "Utah, United States" }] }] },
+      [["I1", "I1"]],
+    );
+    expect((out.persons![0].facts ?? []).filter((f) => f.type === "Residence")).toHaveLength(2);
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────
+// Block I: id uniqueness when source arrays reuse ids ("unique within
+// their array" → two arrays can both hold F1/N1; merging must not collide)
+// ────────────────────────────────────────────────────────────────────
+
+describe("mergeGedcomx — id uniqueness under same-id arrays", () => {
+  it("mode 2: collapsing two persons that each have a fact 'F1' yields unique fact ids", () => {
+    const target: SimplifiedGedcomX = {
+      persons: [
+        { id: "I1", facts: [{ id: "F1", type: "Birth", standard_date: "1900" }] },
+        { id: "I2", facts: [{ id: "F1", type: "Death", standard_date: "1970" }] },
+      ],
+    };
+
+    const out = mergeGedcomx(target, null, [["I1", "I2"]]);
+
+    expect((out.persons![0].facts ?? []).map((f) => f.type).sort()).toEqual(["Birth", "Death"]);
+    assertIntegrity(out); // would fail if both kept id "F1"
+  });
+
+  it("mode 2: collapsing two persons that each have a name 'N1' yields unique name ids", () => {
+    const target: SimplifiedGedcomX = {
+      persons: [
+        { id: "I1", names: [{ id: "N1", given: "John", surname: "Doe" }] },
+        { id: "I2", names: [{ id: "N1", given: "Jane", surname: "Roe" }] },
+      ],
+    };
+
+    const out = mergeGedcomx(target, null, [["I1", "I2"]]);
+
+    expect(out.persons![0].names).toHaveLength(2);
+    assertIntegrity(out); // would fail if both kept id "N1"
+  });
+
+  it("dedup fold: two duplicate couples whose marriage facts share id 'F9' stay unique", () => {
+    const target: SimplifiedGedcomX = {
+      persons: [{ id: "I1" }, { id: "I2" }, { id: "I3" }],
+      relationships: [
+        { id: "R1", type: "Couple", person1: "I1", person2: "I2", facts: [{ id: "F9", type: "Marriage", standard_date: "1870", standard_place: "Utah, United States" }] },
+        { id: "R2", type: "Couple", person1: "I1", person2: "I3", facts: [{ id: "F9", type: "Marriage", standard_date: "1888", standard_place: "Ohio, United States" }] },
+      ],
+    };
+
+    // collapse I3 into I2 → R2 becomes Couple(I1,I2) == R1 → its marriage fact folds in
+    const out = mergeGedcomx(target, null, [["I2", "I3"]]);
+
+    const couples = (out.relationships ?? []).filter((r) => r.type === "Couple");
+    expect(couples).toHaveLength(1);
+    expect((couples[0].facts ?? []).filter((f) => f.type === "Marriage")).toHaveLength(2); // non-equivalent → both kept
+    assertIntegrity(out); // would fail if both kept id "F9"
+  });
+});


### PR DESCRIPTION
Implements merge_gedcomx (#250) — a pure function that merges two SimplifiedGedcomX documents given caller-supplied [survivorId, collapsedId] pairs (it does not decide who merges).

  - Renumbers candidate ids so nothing collides; every relationship/source ref rewritten.
  - Names: merges initials/subset into the fullest; keeps distinct names; one preferred.
  - Facts: merges compatible date + place into the most specific; keeps genuinely
    distinct facts; marks one primary for Birth/Death/Christening/Burial.
  - Relationships: repoint + dedup, folding a duplicate's facts (marriage facts
    aren't dropped); sources dedup by title. Inputs never mutated.

  Util only, no separate MCP tool (per review on #254).

  Tests: 35 vitest cases; full engine suite green; tsc clean.
  Spec [docs/specs/merge-gedcomx-spec.md](https://github.com/PioneerAIAcademy/cowork-genealogy/blob/main/docs/specs/merge-gedcomx-spec.md) refined to match.