### PR TITLE
project-status: fix 1860 census relationship as inferred, not direct

### DIFF
--- a/packages/engine/plugin/skills/project-status/SKILL.md
+++ b/packages/engine/plugin/skills/project-status/SKILL.md
@@ -74,11 +74,15 @@ Tells the story of the research so far:
 - What the recommended next step is
 
 Example: "We're looking for Patrick Flynn's parents. We've found
-strong evidence that his father was Thomas Flynn — Patrick appears
-in Thomas's household in 1850 and 1860, and his death certificate
-names Thomas as his father. The main gap is that we haven't found
-records between 1860 and 1908. Our next step should be searching
-for Patrick in the 1870 census."
+strong evidence that his father was Thomas Flynn — Patrick is
+listed in Thomas's household in both the 1850 and 1860 censuses
+(those censuses don't actually state relationships, so we infer
+Patrick is Thomas's son from his age and place in the household;
+the relationship column wasn't added until the 1880 census), and
+his 1908 death certificate names Thomas as his father directly.
+The main gap is that we haven't found records between 1860 and
+1908. Our next step should be searching for Patrick in the 1870
+census."
 
 ## Steps
 
@@ -288,9 +292,9 @@ We're trying to identify Patrick's parents. The strongest
 evidence points to Thomas Flynn of Schuylkill County as his
 father — three different records support this:
 
-• The 1850 census shows 5-year-old Patrick in Thomas's household
-• The 1860 census shows 15-year-old Patrick in Thomas's household (relationship inferred from position, not stated explicitly until 1880 census)
-• Patrick's 1908 death certificate names Thomas as his father
+• The 1850 census shows 5-year-old Patrick in Thomas's household (relationship inferred from position — the relationship column wasn't introduced until the 1880 census)
+• The 1860 census shows 15-year-old Patrick in Thomas's household (relationship also inferred — same reason)
+• Patrick's 1908 death certificate names Thomas as his father directly
 
 We resolved one conflict: the death certificate says Patrick was
 born in Pennsylvania, but the census records say Ireland. We


### PR DESCRIPTION
## Summary

Fixes the two `SKILL.md` examples in the `project-status` skill where the 1860 U.S. Census was described as if it stated Patrick's relationship to Thomas Flynn directly. The 1860 census does not list relationships — the relationship-to-head-of-household column wasn't introduced until the 1880 census.

- **Novice example** (lines 76–85): now explicitly says we *infer* Patrick is Thomas's son from his age and position in the 1850 and 1860 censuses, while the 1908 death certificate names Thomas as his father directly.
- **Experienced example** (lines 295–297): both 1850 and 1860 census bullets now carry the "relationship inferred" caveat (previously only the 1860 bullet did, which was inconsistent).

The underlying scenarios (`flynn-resolved`, `flynn-multi-conflict`, `mid-research-flynn`, and the others) already mark the 1860 relationship assertion as `child_inferred` / `evidence_type: indirect` — no scenario changes needed.

## Test plan

- [x] All 1850/1860 references in `SKILL.md` audited; only the two example blocks needed fixing.
- [x] YAML frontmatter still valid.
- [x] Verified locally by running the eval harness against `project-status`: 3/4 tests pass, Claude's new output consistently treats the 1850/1860 censuses as inferred and the 1908 death certificate as direct. (1 test aborted due to an unrelated upstream API stall.)
