### PR TITLE
Windows harness fixes

### DIFF
--- a/eval/README.md
+++ b/eval/README.md
@@ -34,6 +34,11 @@ eval/
 
 - **Python 3.11+** with [uv](https://github.com/astral-sh/uv) (`pip install uv` or `brew install uv`).
 - **Node.js 20+** with npm.
+- **Claude Code CLI** — required. The harness drives the [Claude Agent SDK](https://github.com/anthropics/claude-agent-sdk-python), which spawns the `claude` CLI as a subprocess. Install once:
+  ```
+  npm install -g @anthropic-ai/claude-code
+  ```
+  Then run `claude` once to authenticate (browser login or paste an API key). `Setup.bat` installs the CLI for you on Windows; macOS/Linux users do this step manually. If `claude --version` returns "not recognized," the harness will fail every test with a misleading "Claude Code returned an error result: success" error even though the SKILL.md, fixtures, and tests are fine.
 - **Anthropic API key** — required. The skill runner and the LLM judge both use it. `Setup.bat` will prompt for the key and save it to `eval/.env`; you can also put it there directly:
   ```
   ANTHROPIC_API_KEY=sk-ant-...

--- a/eval/Setup.bat
+++ b/eval/Setup.bat
@@ -62,6 +62,19 @@ if errorlevel 1 (
 cd ..\..\..\eval
 
 echo.
+echo Installing Claude Code CLI globally (required by the test harness)...
+call npm install -g @anthropic-ai/claude-code
+if errorlevel 1 (
+  echo.
+  echo ERROR: Claude Code CLI install failed. Setup aborted.
+  echo If npm reported a permissions error, re-open cmd as Administrator
+  echo and rerun Setup.bat -- or install manually with:
+  echo   npm install -g @anthropic-ai/claude-code
+  pause
+  exit /b 1
+)
+
+echo.
 echo Installing Python dependencies...
 cd harness
 call uv sync
@@ -80,5 +93,11 @@ echo ANTHROPIC_API_KEY=%APIKEY%> .env
 
 echo.
 echo === Setup complete! ===
-echo Double-click Start.bat to launch the test-creation app.
+echo.
+echo Before your first RunTests.bat run, run this once to authenticate
+echo the Claude Code CLI (browser login or paste an API key):
+echo   claude
+echo.
+echo Then double-click Start.bat to launch the test-creation app, or
+echo RunTests.bat to run the harness.
 pause

--- a/eval/harness/e2e/judge.py
+++ b/eval/harness/e2e/judge.py
@@ -19,7 +19,7 @@ DEFAULT_MAX_TOKENS = 4096
 
 
 def _load_prompt_template() -> str:
-    return (Path(__file__).parent / "judge_prompt.md").read_text()
+    return (Path(__file__).parent / "judge_prompt.md").read_text(encoding="utf-8")
 
 
 def _render_prompt(

--- a/eval/harness/e2e/orchestrator.py
+++ b/eval/harness/e2e/orchestrator.py
@@ -85,8 +85,8 @@ class Fixture:
 def load_fixture(fixture_dir: Path) -> Fixture:
     """Read fixture.json + expected-findings.json from a fixture directory."""
     fixture_dir = Path(fixture_dir)
-    fixture_json = json.loads((fixture_dir / "fixture.json").read_text())
-    expected = json.loads((fixture_dir / "expected-findings.json").read_text())
+    fixture_json = json.loads((fixture_dir / "fixture.json").read_text(encoding="utf-8"))
+    expected = json.loads((fixture_dir / "expected-findings.json").read_text(encoding="utf-8"))
 
     caps_raw = fixture_json.get("caps") or {}
     caps = FixtureCaps(

--- a/eval/harness/e2e/run_e2e.py
+++ b/eval/harness/e2e/run_e2e.py
@@ -41,7 +41,7 @@ def _filter_by_tag(fixture_dirs: Iterable[Path], tag: str) -> list[Path]:
     """Keep fixtures whose tags contain the given tag value (any dimension)."""
     matched = []
     for d in fixture_dirs:
-        meta = json.loads((d / "fixture.json").read_text())
+        meta = json.loads((d / "fixture.json").read_text(encoding="utf-8"))
         tag_values = set((meta.get("tags") or {}).values())
         if tag in tag_values:
             matched.append(d)

--- a/eval/harness/e2e/stop_checker.py
+++ b/eval/harness/e2e/stop_checker.py
@@ -19,7 +19,7 @@ def read_research_json(workspace: Path) -> dict[str, Any] | None:
     if not path.exists():
         return None
     try:
-        return json.loads(path.read_text())
+        return json.loads(path.read_text(encoding="utf-8"))
     except (json.JSONDecodeError, OSError):
         return None
 
@@ -30,7 +30,7 @@ def read_tree_json(workspace: Path) -> dict[str, Any] | None:
     if not path.exists():
         return None
     try:
-        return json.loads(path.read_text())
+        return json.loads(path.read_text(encoding="utf-8"))
     except (json.JSONDecodeError, OSError):
         return None
 

--- a/eval/harness/harness/allowed_tools.py
+++ b/eval/harness/harness/allowed_tools.py
@@ -66,7 +66,7 @@ def load_skill_frontmatter(skill_md: Path) -> dict[str, Any]:
     """
     if not skill_md.exists():
         return {}
-    text = skill_md.read_text()
+    text = skill_md.read_text(encoding="utf-8")
     if not text.startswith("---"):
         return {}
     parts = text.split("---", 2)

--- a/eval/harness/harness/fixtures.py
+++ b/eval/harness/harness/fixtures.py
@@ -36,7 +36,7 @@ def load_fixtures(names: list[str], fixtures_dir: Path) -> list[dict[str, Any]]:
         if not path.exists():
             raise InvalidFixtureError(f"fixture not found: {path}")
         try:
-            fixture = json.loads(path.read_text())
+            fixture = json.loads(path.read_text(encoding="utf-8"))
         except json.JSONDecodeError as e:
             raise InvalidFixtureError(
                 f"fixture is not valid JSON: {path}: {e}"

--- a/eval/harness/harness/judge.py
+++ b/eval/harness/harness/judge.py
@@ -104,7 +104,7 @@ class JudgeOutput:
 
 @lru_cache(maxsize=1)
 def judge_prompt_template() -> str:
-    return JUDGE_PROMPT_PATH.read_text()
+    return JUDGE_PROMPT_PATH.read_text(encoding="utf-8")
 
 
 def judge_prompt_hash() -> str:

--- a/eval/harness/harness/loader.py
+++ b/eval/harness/harness/loader.py
@@ -48,13 +48,13 @@ class TestSpec:
 def _schema() -> dict[str, Any]:
     if not SCHEMA_PATH.exists():
         raise InvalidTestError(f"unit-test schema not found at {SCHEMA_PATH}")
-    return json.loads(SCHEMA_PATH.read_text())
+    return json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
 
 
 def load_test(path: Path) -> TestSpec:
     """Load a unit-test JSON file from disk and return a validated TestSpec."""
     try:
-        raw = json.loads(Path(path).read_text())
+        raw = json.loads(Path(path).read_text(encoding="utf-8"))
     except FileNotFoundError as e:
         raise InvalidTestError(f"test file not found: {path}") from e
     except json.JSONDecodeError as e:

--- a/eval/harness/harness/orchestrator.py
+++ b/eval/harness/harness/orchestrator.py
@@ -77,7 +77,7 @@ def _read_harness_version() -> str:
         except ImportError:  # pragma: no cover — Python < 3.11
             return "unknown"
         try:
-            data = tomllib.loads(pyproject.read_text())
+            data = tomllib.loads(pyproject.read_text(encoding="utf-8"))
             return data.get("project", {}).get("version", "unknown")
         except Exception:  # noqa: BLE001 — best-effort
             return "unknown"
@@ -157,7 +157,7 @@ async def _run_one_test_async(
     rubric_path = paths.tests_dir / spec.skill / "rubric.md"
     rubric = parse_rubric_or_empty(
         spec.skill,
-        rubric_path.read_text() if rubric_path.exists() else None,
+        rubric_path.read_text(encoding="utf-8") if rubric_path.exists() else None,
     )
     skill_frontmatter = load_skill_frontmatter(
         paths.skills_dir / spec.skill / "SKILL.md"
@@ -831,7 +831,7 @@ def _load_scenario_readme(scenarios_dir: Path, scenario: str | None) -> str:
     readme = scenarios_dir / scenario / "README.md"
     if not readme.exists():
         return ""
-    return readme.read_text()
+    return readme.read_text(encoding="utf-8")
 
 
 def _aborted_entry(

--- a/eval/harness/harness/runlog.py
+++ b/eval/harness/harness/runlog.py
@@ -386,13 +386,13 @@ def build_run_log(
 
 @lru_cache(maxsize=1)
 def _validator():
-    schema = json.loads((SCHEMAS_DIR / "run-log.schema.json").read_text())
+    schema = json.loads((SCHEMAS_DIR / "run-log.schema.json").read_text(encoding="utf-8"))
     enums_path = SCHEMAS_DIR / "enums.schema.json"
     registry = Registry()
     if enums_path.exists():
         registry = registry.with_resource(
             uri="enums.schema.json",
-            resource=Resource.from_contents(json.loads(enums_path.read_text())),
+            resource=Resource.from_contents(json.loads(enums_path.read_text(encoding="utf-8"))),
         )
     return jsonschema.Draft202012Validator(schema, registry=registry)
 

--- a/eval/harness/harness/runnability.py
+++ b/eval/harness/harness/runnability.py
@@ -55,7 +55,7 @@ def check_runnable(
             if not f.exists():
                 continue
             try:
-                data = json.loads(f.read_text())
+                data = json.loads(f.read_text(encoding="utf-8"))
             except json.JSONDecodeError as e:
                 return RunnabilityResult(
                     False, f"scenario {fname} is not valid JSON: {e}"
@@ -109,7 +109,7 @@ def check_runnable(
     try:
         parse_rubric_or_empty(
             spec.skill,
-            rubric_path.read_text() if rubric_path.exists() else None,
+            rubric_path.read_text(encoding="utf-8") if rubric_path.exists() else None,
         )
     except InvalidRubricError as e:
         return RunnabilityResult(False, f"rubric.md is malformed: {e}")

--- a/eval/harness/harness/schema_validator.py
+++ b/eval/harness/harness/schema_validator.py
@@ -26,7 +26,7 @@ SCHEMAS_DIR = REPO_ROOT / "docs/specs/schemas"
 def _registry() -> Registry:
     """A registry containing enums.schema.json so the $refs in
     research.schema.json and tree-gedcomx.schema.json resolve."""
-    enums = json.loads((SCHEMAS_DIR / "enums.schema.json").read_text())
+    enums = json.loads((SCHEMAS_DIR / "enums.schema.json").read_text(encoding="utf-8"))
     return Registry().with_resource(
         uri="enums.schema.json",
         resource=Resource.from_contents(enums),
@@ -35,13 +35,13 @@ def _registry() -> Registry:
 
 @lru_cache(maxsize=1)
 def _research_validator() -> jsonschema.Draft202012Validator:
-    schema = json.loads((SCHEMAS_DIR / "research.schema.json").read_text())
+    schema = json.loads((SCHEMAS_DIR / "research.schema.json").read_text(encoding="utf-8"))
     return jsonschema.Draft202012Validator(schema, registry=_registry())
 
 
 @lru_cache(maxsize=1)
 def _tree_gedcomx_validator() -> jsonschema.Draft202012Validator:
-    schema = json.loads((SCHEMAS_DIR / "tree-gedcomx.schema.json").read_text())
+    schema = json.loads((SCHEMAS_DIR / "tree-gedcomx.schema.json").read_text(encoding="utf-8"))
     return jsonschema.Draft202012Validator(schema, registry=_registry())
 
 

--- a/eval/harness/harness/tool_catalog.py
+++ b/eval/harness/harness/tool_catalog.py
@@ -78,7 +78,7 @@ def load_tool_catalog(tools_dir: Path) -> dict[str, str]:
         return catalog
     for path in sorted(tools_dir.glob("*.ts")):
         try:
-            text = path.read_text()
+            text = path.read_text(encoding="utf-8")
         except OSError:
             continue
         catalog.update(parse_tool_file(text))

--- a/eval/harness/harness/workspace.py
+++ b/eval/harness/harness/workspace.py
@@ -121,14 +121,14 @@ def snapshot_files(workspace: Path) -> dict[str, Any]:
     research = workspace / "research.json"
     if research.exists():
         try:
-            snap["research_json"] = json.loads(research.read_text())
+            snap["research_json"] = json.loads(research.read_text(encoding="utf-8"))
         except json.JSONDecodeError:
             snap["research_json"] = None
 
     tree = workspace / "tree.gedcomx.json"
     if tree.exists():
         try:
-            snap["tree_gedcomx_json"] = json.loads(tree.read_text())
+            snap["tree_gedcomx_json"] = json.loads(tree.read_text(encoding="utf-8"))
         except json.JSONDecodeError:
             snap["tree_gedcomx_json"] = None
 
@@ -142,7 +142,7 @@ def snapshot_files(workspace: Path) -> dict[str, Any]:
         if rel in ("research.json", "tree.gedcomx.json"):
             continue
         try:
-            snap["files"][rel] = path.read_text()
+            snap["files"][rel] = path.read_text(encoding="utf-8")
         except UnicodeDecodeError:
             snap["files"][rel] = "<binary>"
 

--- a/eval/harness/scripts/check_runlogs.py
+++ b/eval/harness/scripts/check_runlogs.py
@@ -117,7 +117,7 @@ def latest_full_skill_runlog(skill_dir: Path) -> tuple[str, dict] | None:
         filename = candidates[0][2]
     else:
         return None
-    return filename, json.loads((skill_dir / filename).read_text())
+    return filename, json.loads((skill_dir / filename).read_text(encoding="utf-8"))
 
 
 def rule2_active(skill: str, log: dict, filename: str) -> int:
@@ -160,7 +160,7 @@ def rule3_completeness(skill: str, log: dict, filename: str, skill_dir: Path) ->
             f"the PR.",
         )
         return 1
-    ann = json.loads(ann_path.read_text())
+    ann = json.loads(ann_path.read_text(encoding="utf-8"))
     have = {
         (c["test_id"], c["dimension_source"], c["dimension_name"])
         for c in ann.get("corrections") or []

--- a/eval/harness/scripts/check_tool_coverage.py
+++ b/eval/harness/scripts/check_tool_coverage.py
@@ -86,7 +86,7 @@ def declared_tools(skill_md: Path) -> list[str]:
     """
     if not skill_md.exists():
         return []
-    text = skill_md.read_text()
+    text = skill_md.read_text(encoding="utf-8")
     if not text.startswith("---"):
         return []
     parts = text.split("---", 2)
@@ -122,7 +122,7 @@ def fixture_tool_refs(skill: str) -> dict[str, list[str]]:
         return refs
     for test_path in sorted(skill_tests.glob("*.json")):
         try:
-            test = json.loads(test_path.read_text())
+            test = json.loads(test_path.read_text(encoding="utf-8"))
         except json.JSONDecodeError:
             continue
         for fixture_name in test.get("mcp_fixtures") or []:
@@ -130,7 +130,7 @@ def fixture_tool_refs(skill: str) -> dict[str, list[str]]:
             if not fixture_path.exists():
                 continue
             try:
-                fixture = json.loads(fixture_path.read_text())
+                fixture = json.loads(fixture_path.read_text(encoding="utf-8"))
             except json.JSONDecodeError:
                 continue
             tool = fixture.get("tool")


### PR DESCRIPTION
Two Windows-only fixes the deep-dive surfaced this week. Both
manifested as the same symptom -- the harness aborting every test
with a misleading error -- but had different root causes.

1. Setup.bat installs Claude Code CLI
   The harness drives the Claude Agent SDK, which spawns `claude`
   as a subprocess. Setup.bat didn't install it, so a fresh
   Windows clone left every test aborting with:

       Exception: Claude Code returned an error result: success

   Setup.bat now runs `npm install -g @anthropic-ai/claude-code`
   after the MCP server build, aborts on failure with a permissions
   hint, and reminds the user to run `claude` once at the end.
   README.md adds it under Prerequisites.

2. encoding="utf-8" everywhere we read text
   30 bare Path.read_text() calls across 16 files defaulted to the
   platform codepage. On Windows that's cp1252, which crashes on
   any UTF-8 character (em-dash, arrow, emoji, etc.) with:

       UnicodeDecodeError: 'charmap' codec can't decode byte 0x8f
       in position N

   About 27 of 30+ skills' SKILL.md / references contained at least
   one such character. Adding encoding="utf-8" to every read_text
   call unblocks all of them. No behavior change on macOS/Linux.
