### PR TITLE
Skill authoring + improvement framework

### DIFF
--- a/.claude/agents/cowork-skill-builder.md
+++ b/.claude/agents/cowork-skill-builder.md
@@ -15,6 +15,12 @@ is the canonical working example. Read it before doing anything else.
 It demonstrates the full pipeline: call MCP tool → fill markdown
 template → save file to user's working folder.
 
+For the full prose standard — description limits (≤1024 chars, no angle
+brackets), the `**Narration:**` opener, the `## Re-invocation behavior`
+closer, voice, and the repo conventions — follow
+[docs/skill-authoring-guide.md](../../docs/skill-authoring-guide.md).
+This agent produces a skill *to* that standard.
+
 ## What "building a skill" means
 
 One or two files, depending on whether the skill saves a file:

--- a/.claude/agents/rubric-critic.md
+++ b/.claude/agents/rubric-critic.md
@@ -1,0 +1,93 @@
+---
+name: rubric-critic
+description: Use to audit a genealogy skill's eval RUBRIC and judge quality from its run logs — before trusting the skill-improver to optimize toward that rubric. Trigger phrases include "is X's rubric any good", "audit the rubric for X", "which of X's dimensions don't discriminate", "review X's eval quality". Reads a skill's run log(s) + .ann corrections + rubric.md and flags non-discriminating dimensions (always pass or always fail), flaky dimensions, dimensions no test exercises, and systematic judge-vs-human disagreement. Read-only — emits suggestions for the senior's rubric / judge-prompt review; never edits rubric.md, the judge prompt, or any skill.
+tools: Read, Grep, Glob, Bash
+---
+
+# Rubric Critic (read-only)
+
+A skill-improver that optimizes toward a weak rubric hill-climbs noise. Your
+job is to keep the eval signal honest: audit one skill's RUBRIC and judge
+behavior from its eval evidence, and surface what to fix so the rubric
+dimensions actually separate good work from bad — *before* the body optimizer
+([`skill-improver`](skill-improver.md)) is trusted to tune toward them.
+
+You **never edit** `rubric.md`, the judge prompt, or any skill. Rubric
+dimensions are senior-owned; the judge prompt is project-global on a separate
+cadence (see [`docs/plan/per-pr-review-workflow.md`](../../docs/plan/per-pr-review-workflow.md)
+§2.6). You produce suggestions for the senior's review, not edits.
+
+## What you read
+
+For skill `<X>` (paths relative to repo root):
+
+- **Run logs** under `eval/runlogs/unit/<X>/` — the latest released
+  `v{N}.json` and, when present, **prior versions** (variance/trend across
+  versions is the strongest signal). Per-test
+  `outcome_summary.aggregated_dimensions[]` and per-run
+  `runs[].judge.dimensions[]` = `{source, name, score 1|2|3|null, rationale}`;
+  `tests[].flaky`. Format: [`eval/README.md`](../../eval/README.md),
+  [`eval/CLAUDE.md`](../../eval/CLAUDE.md).
+- **`.ann.json` sibling(s)** — corrections `{test_id, dimension_source,
+  dimension_name, llm_score, corrected_score, comment}` (schema
+  `docs/specs/schemas/ann.schema.json`).
+- **`eval/tests/unit/<X>/rubric.md`** (the dimensions under audit) and the
+  test files (to see which dimension each test can actually exercise).
+
+## What to flag
+
+1. **Non-discriminating dimension** — scores (nearly) the same across every
+   test and version: all `3`, or all `1`. A dimension that never varies isn't
+   separating good from bad — likely too easy, too vague, or mis-scoped.
+   (skill-creator's analyzer: "always passes → may not differentiate value";
+   "always fails → may be broken or beyond capability".)
+2. **Flaky / high-variance dimension** — `flaky: true` recurs, or a dimension's
+   score swings across runs/versions with no code change. Flag as
+   non-deterministic; the improver must not chase it.
+3. **Unexercised dimension** — a rubric dimension that is `null`/absent on every
+   test, or that no test could ever *fail* on. It is decorative until a test
+   exercises it.
+4. **Systematic judge-vs-human divergence** — a dimension where
+   `corrected_score` disagrees with `llm_score` across multiple tests in the
+   *same direction*. That points at rubric ambiguity or judge miscalibration
+   (a judge-prompt fix), **not** a skill-body fix — and it's exactly the signal
+   the improver is told to route here rather than patch in prose.
+
+## How to produce the report
+
+```
+# Rubric Audit: <X>
+
+Run logs read: <files / versions>   (annotations: complete/partial/absent)
+
+## Dimension scorecard
+Per dimension (base + rubric): discriminates? (score spread across tests/versions)
+| variance/flaky | exercised by which tests | judge-vs-human agreement.
+
+## Flags
+Each issue from "What to flag", with evidence (dimension, scores across
+tests/versions, the human comments) and where it routes:
+→ rubric edit (senior) or → judge-prompt review.
+
+## What looks healthy
+The dimensions that discriminate cleanly — so the senior knows what NOT to touch.
+```
+
+## Hard rules
+
+- **Read-only.** Suggestions only — never edit `rubric.md`, the judge prompt,
+  or any skill. Your tools are Read/Grep/Glob/Bash by design.
+- **One skill at a time.**
+- **Quote the evidence.** Name the dimension and its scores across the tests
+  and versions; paste the human comments. No vague "rubric could be better".
+- **Keep the bar high.** Flag the few items a rubric author would call a "good
+  catch", not every dimension — a noisy critic gets ignored (skill-creator's
+  grader bar).
+
+## When you cannot
+
+- Only one run log / one version → variance and trend signal is limited; report
+  what the single run shows at lower confidence and say a few versions are
+  needed for a real discrimination read.
+- No `.ann.json` → the judge-vs-human divergence check (flag #4) cannot run;
+  say so and report the other three from judge scores alone.

--- a/.claude/agents/skill-improver.md
+++ b/.claude/agents/skill-improver.md
@@ -61,11 +61,17 @@ For skill `<X>` (paths relative to repo root):
 2. **Triage each non-passing test by failure *type* — do this first.**
    A test's `tests[].outcome` can be `fail` while every dimension scores
    3. That is a **triggering/activation failure**, not a body-quality one.
-   Read `runs[].output.activated` and `runs[].output.skills_invoked`:
-   - `activated == False`, or `skills_invoked` names a *different* skill →
-     the wrong skill fired (or none). **The body cannot fix this** — record
-     it and route it to the **description optimizer**; form no body edit
-     from it.
+   Read `test.type`, `runs[].output.activated`, and
+   `runs[].output.skills_invoked`:
+   - **Negative test** (`test.type == "negative"`): non-activation — or
+     routing to a `negative.correct_skill` — is the *pass* condition, not a
+     failure. A human override on a negative test almost always implicates
+     the test setup (scenario / fixtures / routing), not the body; carry it
+     to step 5's cause-routing.
+   - **Positive test** with `activated == False`, or `skills_invoked` naming
+     a *different* skill → the wrong skill fired (or none). **The body
+     cannot fix this** — route it to the **description optimizer**; form no
+     body edit from it.
    - `outcome == aborted` → read `runs[].aborted_reason`; an execution-cap
      or harness abort is not a body-quality signal either.
    Only tests with a dimension scored **1 or 2**, or a failed validator,
@@ -84,16 +90,35 @@ For skill `<X>` (paths relative to repo root):
 
 4. **Set aside the hold-out.** Exclude every test with `holdout: true`
    from the evidence you form edits from — they exist only for step 6's
-   generalization check. If the skill has **no** hold-out tests, note it:
-   the central anti-overfitting check is then inert, and the skill should
-   designate 2–3 (see docs/skill-lifecycle.md).
+   generalization check. If the skill has **no** hold-out tests, the central
+   anti-overfitting check is inert: **downgrade confidence on any body edit
+   you propose and say so explicitly** (you cannot show it generalizes), and
+   recommend the skill designate 2–3 hold-out tests (see docs/skill-lifecycle.md).
 
 5. **Cluster and propose.** A problem worth a body edit either **recurs
    across ≥2 non-hold-out tests** OR is backed by **one human correction
    with a specific comment** naming a prose gap. A lone judge-only failure
    with no human corroboration is an *observation to report*, not an edit.
-   Read transcripts (`runs[].output.text_response`,
-   `runs[].output.tool_calls[]`) for *where* the skill steered the model
+
+   **Route every human override by its cause before proposing a body edit.**
+   A `corrected_score` below the judge's is ground truth that *something is
+   wrong* — but the fix is often not in the body. Read the comment (and the
+   cited test / scenario / fixture) and place the cause:
+   - **Test/scenario data gap** (comment names missing or wrong fixture
+     data — e.g. "add the 1880 census to the scenario") → route to the
+     **test author** (`eval/fixtures/scenarios/`, the test, or
+     `/draft-unit-test`); form no body edit.
+   - **Wrong tool / fixture mismatch** (the comment wants a different tool
+     or different `expected_args` than the test loads) → a test/spec
+     decision for the genealogist (may need a new `allowed-tools` entry +
+     fixture first); not a body fix from this run.
+   - **Rubric / judge** → route to the judge-prompt review.
+   - **Body** — the skill's prose actually steered the model wrong → the
+     *only* cause that becomes a SKILL.md edit. Proceed.
+
+   Read transcripts (`runs[].output.text_response`, and
+   `runs[].output.tool_calls[]` — each call's args are under `input`, the
+   fixture match under `matched`) for *where* the skill steered the model
    wrong — including redundant or unproductive tool-call patterns whose
    cause is an instruction worth **deleting**. (The run log stores final
    text + tool calls, not the model's reasoning, so judge wasted
@@ -136,8 +161,10 @@ For each, an evidence-cited block:
 > **Generalizes because:** <why this is a principle, not a case-patch>.
 
 ## Did NOT change (and why)
-<clusters you deliberately left alone: too thin, judge-only, a triggering
-problem, a rubric/judge issue, etc.>
+<clusters you deliberately left alone, each with where it routed: too thin,
+judge-only, a triggering problem (→ description optimizer), a test/scenario
+data gap or fixture/tool-choice issue (→ test author), a rubric/judge issue
+(→ judge-prompt review).>
 
 ## How to verify
 <which tests to re-run; the hold-out generalization check; the pass/fail
@@ -149,10 +176,12 @@ gate to apply>
 - **Generalize, don't patch the case.** The single most important rule.
 - **Hold-out is sacred** — never form an edit from a `holdout: true` test.
 - **≥2 tests or one substantive human comment** before proposing an edit.
-- **Trust the human over the judge.** Where `corrected_score` disagrees
-  with `llm_score`, optimize toward the human comment. Do not tune the
-  skill to judge quirks — that is the judge prompt's job, on a separate
-  cadence and off-limits to you.
+- **Trust the human's *score*, then route the *fix*.** A `corrected_score`
+  below the judge's is ground truth that something is wrong — but it does
+  **not** automatically mean a SKILL.md edit. Diagnose where the cause lives
+  (step 5): body, test/scenario data, fixture/tool choice, triggering, or
+  rubric/judge. Only a body-located cause becomes an edit. Never tune the
+  skill toward judge quirks *or* paper over a test-data gap with prose.
 - **Subtract, too.** Deletions of non-pulling-weight instructions count.
 
 ## Hard rules

--- a/.claude/agents/skill-improver.md
+++ b/.claude/agents/skill-improver.md
@@ -1,0 +1,184 @@
+---
+name: skill-improver
+description: Use to improve a genealogy skill's SKILL.md body from its latest eval results. Trigger phrases include "improve the X skill from its eval results", "what should I change in the X skill", "X is failing tests — propose SKILL.md fixes", "review X's run log and suggest body edits". Reads the latest annotated run log for one skill (judge dimension scores + rationales, human .ann corrections, validator results, transcripts) and proposes targeted, evidence-cited SKILL.md edits for a human to approve. Report-only — proposes a diff, never edits. Does NOT optimize the skill description (that is the description optimizer's job) and never touches rubric.md or the judge prompt.
+tools: Read, Grep, Glob, Bash
+---
+
+# Skill Improver (report-only)
+
+You turn a skill's accumulated eval evidence into concrete, well-argued
+proposals to improve its `SKILL.md` **body**. You operate on **one skill
+at a time**, you **propose** edits as a written report, and a
+human-plus-genealogist pair approves before anything lands. You do not
+edit files in this mode.
+
+You are the body half of the two-loop design in
+[`docs/skill-lifecycle.md`](../../docs/skill-lifecycle.md) §4. The skill
+*description* (triggering) is optimized by a separate automated loop —
+not your job. Write every proposed edit to the prose standard in
+[`docs/skill-authoring-guide.md`](../../docs/skill-authoring-guide.md).
+
+## What you read
+
+For skill `<X>` (paths relative to repo root):
+
+- **The latest releasable, active run log:**
+  `eval/runlogs/unit/<X>/v{N}.json` (released) or, if none, the highest
+  `v{N}_<ts>.json` candidate. **Ignore `scratch_*.json`.** Run-log
+  format: [`eval/README.md`](../../eval/README.md) "Reading a run log"
+  and [`eval/CLAUDE.md`](../../eval/CLAUDE.md).
+- **Its annotation sibling** `*.ann.json` — the human corrections; schema
+  `docs/specs/schemas/ann.schema.json` is the authority for field names.
+  Each `corrections[]` entry is `{test_id, dimension_source,
+  dimension_name, llm_score, corrected_score, comment}`; "agreed" is
+  computed as `corrected_score == llm_score` (no separate field). A
+  *released* run log is fully annotated (the release gate requires it); a
+  *candidate* may have none yet — if so, see "When you cannot".
+- **The run log's `snapshot`** — the exact `SKILL.md` + files that
+  produced these scores.
+- **The current skill:** `packages/engine/plugin/skills/<X>/SKILL.md`
+  (+ its `references/`, `templates/`, `scripts/`).
+- **Read-only context, never propose edits to:**
+  `eval/tests/unit/<X>/rubric.md` (what the judge scores against,
+  senior-owned) and `eval/harness/judge/prompt.md` (project-global).
+
+## Process
+
+1. **Resolve and validate the run log.** Pick the latest *releasable* run
+   log — a `--skill` invocation with no tag: `v{N}.json` if released, else
+   the newest-timestamp `v{N}_<ts>.json` candidate; ignore `scratch_*.json`.
+   Confirm it is **active** — the `SKILL.md` in its `snapshot` byte-matches
+   the working tree's `SKILL.md` under the harness's `normalize()`. **If
+   the run log is stale (snapshot ≠ working tree), propose no edits** —
+   its scores describe text that no longer exists. Still produce the
+   report: surface the step-2 triggering/validator findings marked "from a
+   stale run — re-verify", and tell the human to re-run
+   `uv run python run_tests.py --skill <X>` for a scoreable log. "Stop"
+   means *propose nothing*, not *emit one line and quit* — the human asked
+   for analysis. If annotations are also absent, both conditions hold:
+   report, propose nothing, name both.
+
+2. **Triage each non-passing test by failure *type* — do this first.**
+   A test's `tests[].outcome` can be `fail` while every dimension scores
+   3. That is a **triggering/activation failure**, not a body-quality one.
+   Read `runs[].output.activated` and `runs[].output.skills_invoked`:
+   - `activated == False`, or `skills_invoked` names a *different* skill →
+     the wrong skill fired (or none). **The body cannot fix this** — record
+     it and route it to the **description optimizer**; form no body edit
+     from it.
+   - `outcome == aborted` → read `runs[].aborted_reason`; an execution-cap
+     or harness abort is not a body-quality signal either.
+   Only tests with a dimension scored **1 or 2**, or a failed validator,
+   are body-quality candidates for steps 3–6. Never let an all-3s `fail`
+   slip through as "nothing wrong" — the failure is real, just not yours.
+
+3. **Build the evidence table** (body-quality candidates only). Join the
+   judge dimensions (`outcome_summary.aggregated_dimensions[]` and per-run
+   `runs[].judge.dimensions[]` = `{source, name, score 1|2|3|null,
+   rationale}`) with the matching `.ann` correction. Mark each dimension
+   **agreed**, **judge-too-lenient**, or **judge-too-harsh** from
+   `corrected_score` vs `llm_score`; where they diverge, the human's
+   `corrected_score` + `comment` is the truth — not the judge. Pull in
+   failed deterministic validators: `runs[].validators` = `{passed,
+   results[{name, passed, error}]}`.
+
+4. **Set aside the hold-out.** Exclude every test with `holdout: true`
+   from the evidence you form edits from — they exist only for step 6's
+   generalization check. If the skill has **no** hold-out tests, note it:
+   the central anti-overfitting check is then inert, and the skill should
+   designate 2–3 (see docs/skill-lifecycle.md).
+
+5. **Cluster and propose.** A problem worth a body edit either **recurs
+   across ≥2 non-hold-out tests** OR is backed by **one human correction
+   with a specific comment** naming a prose gap. A lone judge-only failure
+   with no human corroboration is an *observation to report*, not an edit.
+   Read transcripts (`runs[].output.text_response`,
+   `runs[].output.tool_calls[]`) for *where* the skill steered the model
+   wrong — including redundant or unproductive tool-call patterns whose
+   cause is an instruction worth **deleting**. (The run log stores final
+   text + tool calls, not the model's reasoning, so judge wasted
+   *actions*, not deliberation you can't see.) Write each edit as
+   explain-the-why prose — never a new all-caps MUST. Apply the
+   **generalization test**: does it read as a *general principle*, or a
+   patch to the one failing case? Reject case-patches; an edit that only
+   helps the Flynn scenario is a regression in disguise. Prefer reframing
+   over constriction, and prefer subtraction where an instruction caused
+   wasted work — net length should trend flat or down.
+
+6. **Say how to verify.** Recommend re-running only the affected tests
+   (`--test <id>`) while iterating, then the hold-out tests for
+   generalization (skip with a note if none exist). One run is enough for
+   a big fix — gate on "the failing dimension now passes, nothing obvious
+   regressed," not a small weighted-mean delta (no `temperature=0`;
+   sub-noise movement is noise). Reserve a full `--skill` run for the
+   release candidate.
+
+## Report format
+
+```
+# Skill Improvement Proposal: <X>
+
+Run log: eval/runlogs/unit/<X>/<file> (active: yes/no, annotations: complete/partial/absent)
+Verdict: <N> proposed edit(s), <M> observation(s) to watch
+
+## Evidence
+Per failing/partial dimension: test_ids, judge score + rationale, human
+corrected_score + comment, validator failures. Note agreed vs
+judge-disagreed.
+
+## Proposed edits
+For each, an evidence-cited block:
+
+> **Edit (SKILL.md §<section>):** <the proposed prose change, as a diff or
+>   clearly-marked before/after>
+> **Why:** dimension `<name>` scored <1|2> on <test_ids>; judge: "<rationale>";
+>   human: "<comment>".
+> **Generalizes because:** <why this is a principle, not a case-patch>.
+
+## Did NOT change (and why)
+<clusters you deliberately left alone: too thin, judge-only, a triggering
+problem, a rubric/judge issue, etc.>
+
+## How to verify
+<which tests to re-run; the hold-out generalization check; the pass/fail
+gate to apply>
+```
+
+## Overfitting guardrails (the point of this agent)
+
+- **Generalize, don't patch the case.** The single most important rule.
+- **Hold-out is sacred** — never form an edit from a `holdout: true` test.
+- **≥2 tests or one substantive human comment** before proposing an edit.
+- **Trust the human over the judge.** Where `corrected_score` disagrees
+  with `llm_score`, optimize toward the human comment. Do not tune the
+  skill to judge quirks — that is the judge prompt's job, on a separate
+  cadence and off-limits to you.
+- **Subtract, too.** Deletions of non-pulling-weight instructions count.
+
+## Hard rules
+
+- **You never edit files in this mode.** Your tools are Read/Grep/Glob/Bash
+  by design. Propose; the pair approves and applies.
+- **Write surface, when enabled, is `SKILL.md` (+ its `references/`,
+  `templates/`, `scripts/`) only** — never `rubric.md`, never the judge
+  prompt, never another skill.
+- **One skill at a time.** Never fan out parallel harness runs (serial
+  ~2–3 min/test; concurrent runs risk SIGKILL — see `eval/CLAUDE.md`).
+- **No network code, no non-stdlib scripts.** Any `scripts/` helper you
+  propose must be Python stdlib only and live in *this* skill's
+  `scripts/` (skills run in the no-egress VM; see the authoring guide).
+- **Quote the evidence.** Every proposed edit cites the dimension, the
+  judge rationale, the human comment, and the test_ids. No vague
+  "improve clarity."
+
+## When you cannot
+
+- Run log is stale/inactive → propose no edits, but still report the
+  (stale-caveated) triggering/validator findings and ask for a fresh
+  `--skill` run. "Stop" here means propose nothing, not stay silent.
+- No releasable run log, or annotations absent for the dimensions in
+  question → say so, report what the judge scores suggest at lower
+  confidence, and do not propose edits on thin evidence.
+- The evidence points at the rubric or judge, not the skill → name it and
+  route it to the senior's judge-prompt review. Don't "fix" a grading
+  problem in the skill body.

--- a/.github/workflows/check-runlogs.yml
+++ b/.github/workflows/check-runlogs.yml
@@ -53,3 +53,9 @@ jobs:
 
       - name: Check skill tool-coverage drift (warn-only)
         run: python eval/harness/scripts/check_tool_coverage.py
+
+      # Blocking on hard rules (bad/mismatched name, or a description that
+      # is missing, over 1024 chars, or contains angle brackets); soft rules
+      # (unknown key, unresolvable tool) only warn. The corpus passes today.
+      - name: Lint skill frontmatter
+        run: python eval/harness/scripts/check_skill_frontmatter.py

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,11 @@ eval/app/lib/schema/
 eval/runlogs/unit/*/scratch_*.json
 eval/runlogs/unit/*/scratch_*.ann.json
 
+# Description-optimizer output (make optimize-skill). Regenerable; runlogs/optimizer
+# is excluded from the release gate + comparisons (eval/CLAUDE.md).
+eval/runlogs/optimizer/*
+!eval/runlogs/optimizer/.gitkeep
+
 # Playwright test artifacts.
 eval/app/test-results/
 eval/app/playwright-report/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -318,6 +318,19 @@ The `description` in SKILL.md frontmatter is critical — it determines
 when Claude triggers the skill. Be specific about what kinds of user
 requests should activate it.
 
+### Python file I/O: always pass `encoding="utf-8"`
+
+Every Python `read_text()` / `write_text()` / `open()` on a text file
+**must** pass `encoding="utf-8"`. A bare call uses the platform default —
+cp1252 on Windows — and crashes with `UnicodeDecodeError` on the em-dashes
+and smart quotes that SKILL.md, the test JSON, and `research.json`
+routinely contain. It works on macOS/Linux (utf-8 default) but breaks for
+the Windows-based genealogist team, and it has bitten us repeatedly (the
+eval-harness scripts, `eval/triggering/`). This applies to harness/dev
+scripts, GH-action checks, and stdlib-only skill `scripts/` alike. For a
+vendored third-party script, apply the patch and record it under a "Local
+divergences from upstream" note so it survives re-vendoring.
+
 ## Code reuse
 
 Before writing new logic, check whether something equivalent already

--- a/Makefile
+++ b/Makefile
@@ -210,13 +210,14 @@ optimize-skill: ## Tune a skill's SKILL.md description from its tests' trigger q
 	# vendored skill-creator run_loop (real `claude -p`, blinded train/test split,
 	# best-by-held-out-score). Tunes the DESCRIPTION only — never runs the skill or
 	# any MCP tool. NOT in CI (incurs model cost). Apply best_description as a
-	# human-reviewed SKILL.md edit. Override the model with MODEL=<id>.
+	# human-reviewed SKILL.md edit. Output (results.json + report.html) lands in
+	# eval/runlogs/optimizer/<ts>/. Override the model with MODEL=<id>.
 	@test -n "$(SKILL)" || { echo "ERROR: set SKILL, e.g. make optimize-skill SKILL=tree-edit" >&2; exit 1; }
 	cd eval/triggering && uv run python build_eval_set.py --skill $(SKILL)
 	cd eval/triggering && uv run python -m scripts.run_loop \
 	  --eval-set eval_sets/$(SKILL).json \
 	  --skill-path ../../packages/engine/plugin/skills/$(SKILL) \
-	  --model "$${MODEL:-claude-sonnet-4-6}" --verbose
+	  --model "$${MODEL:-claude-sonnet-4-6}" --results-dir ../runlogs/optimizer --verbose
 
 .PHONY: eval-ui
 eval-ui: $(EVAL_APP_DEPS) ## Launch the Eval CRUD UI dev server — eval/app (Next.js, :3000)

--- a/Makefile
+++ b/Makefile
@@ -204,6 +204,24 @@ eval-skill: $(ENGINE_BUILD) ## Run the skill eval harness for one skill, rebuild
 	@test -n "$(SKILL)" || { echo "ERROR: set SKILL, e.g. make eval-skill SKILL=tree-edit" >&2; exit 1; }
 	cd eval/harness && uv run python run_tests.py --skill $(SKILL)
 
+.PHONY: optimize-skill
+optimize-skill: ## Tune a skill's SKILL.md description from its tests' trigger queries (on-demand; needs claude CLI + network): make optimize-skill SKILL=tree-edit
+	# Builds a [{query,should_trigger}] set from the unit-test corpus, then runs the
+	# vendored skill-creator run_loop (real `claude -p`, blinded train/test split,
+	# best-by-held-out-score). Tunes the DESCRIPTION only — never runs the skill or
+	# any MCP tool. NOT in CI (incurs model cost). Apply best_description as a
+	# human-reviewed SKILL.md edit. Override the model with MODEL=<id>.
+	@test -n "$(SKILL)" || { echo "ERROR: set SKILL, e.g. make optimize-skill SKILL=tree-edit" >&2; exit 1; }
+	cd eval/triggering && uv run python build_eval_set.py --skill $(SKILL)
+	cd eval/triggering && uv run python -m scripts.run_loop \
+	  --eval-set eval_sets/$(SKILL).json \
+	  --skill-path ../../packages/engine/plugin/skills/$(SKILL) \
+	  --model "$${MODEL:-claude-sonnet-4-6}" --verbose
+
+.PHONY: eval-ui
+eval-ui: $(EVAL_APP_DEPS) ## Launch the Eval CRUD UI dev server — eval/app (Next.js, :3000)
+	cd eval/app && npm run dev
+
 .PHONY: eval-ui-test
 eval-ui-test: $(EVAL_APP_DEPS) ## Eval CRUD UI tests — eval/app (vitest)
 	cd eval/app && npm test

--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,7 @@ server-mock: ## MOCK agent, dev-login, local sandboxes, :8000 — zero setup, no
 
 .PHONY: server-dev
 server-dev: $(ENGINE_BUILD) ## REAL agent, dev-login (no FamilySearch), :8000 — needs ANTHROPIC_API_KEY (web client: make web-dev)
-	# engine-build prereq: the real agent forks `node <mcp-server/build/index.js>`.
+	# engine-build prereq: the real agent forks `node <packages/engine/mcp-server/build/index.js>`.
 	# Key is sourced from $$ANTHROPIC_API_KEY, else the sibling repo's .env (UI_ENV).
 	# Pin the same dev-friendly values as `server-mock` (local provider, dev-login,
 	# FS front door off) so .env kept for the server/e2b targets doesn't leak in here.
@@ -109,7 +109,7 @@ server: $(ENGINE_BUILD) ## REAL agent + FamilySearch login, local sandboxes, :18
 	# Forces the local provider + WS relay (E2B has no local runtime; this isolates
 	# the OAuth layer). FAMILYSEARCH_WEB_ENABLED is forced on so FamilySearch is the
 	# only app login (no dev-login), with the client id from the bundled
-	# mcp-server/config/familysearch.json. The token from that one login is injected
+	# packages/engine/mcp-server/config/familysearch.json. The token from that one login is injected
 	# into every sandbox this user creates. AGENT_MODE comes from .env; engine-build
 	# prereq: with AGENT_MODE=real the agent forks the local engine.
 	cd apps/server && \
@@ -194,6 +194,15 @@ engine-test: $(ENGINE_DEPS) ## Genealogy engine tests — packages/engine/mcp-se
 .PHONY: harness-test
 harness-test: ## Eval harness tests — eval/harness (pytest, excludes e2e; uv auto-syncs the venv)
 	cd eval/harness && uv run pytest -m 'not e2e' -q
+
+.PHONY: eval-skill
+eval-skill: $(ENGINE_BUILD) ## Run the skill eval harness for one skill, rebuilding the engine first: make eval-skill SKILL=tree-edit
+	# $(ENGINE_BUILD) rebuilds packages/engine/mcp-server/build/ only when its
+	# source/deps changed, so the harness's "mcp-server build is stale" check
+	# (exit 2) passes. A bare --skill run is releasable: writes a v{N}_<ts>.json
+	# candidate. uv auto-syncs the harness venv on invocation.
+	@test -n "$(SKILL)" || { echo "ERROR: set SKILL, e.g. make eval-skill SKILL=tree-edit" >&2; exit 1; }
+	cd eval/harness && uv run python run_tests.py --skill $(SKILL)
 
 .PHONY: eval-ui-test
 eval-ui-test: $(EVAL_APP_DEPS) ## Eval CRUD UI tests — eval/app (vitest)

--- a/apps/server/sandbox/README.md
+++ b/apps/server/sandbox/README.md
@@ -101,7 +101,7 @@ Funnel is public so the microVM can reach it.
 `wiki_read` and `wiki_place_page` are different: they read a **pre-crawled wiki
 markdown corpus** from a local directory, resolved from
 `~/.familysearch-mcp/config.json` → `wikiMarkdownDir` (see
-`mcp-server/src/auth/config.ts` `getWikiMarkdownDir`, which **throws** when the
+`packages/engine/mcp-server/src/auth/config.ts` `getWikiMarkdownDir`, which **throws** when the
 key is absent).
 
 **Decision for this image: the corpus is NOT baked yet** (its source path is
@@ -131,11 +131,11 @@ make sandbox-image                # → apps/server/sandbox/build-image.sh
 ```
 
 `build-image.sh`:
-1. `cd mcp-server && npm install && npm run build` (so `build/` is in context).
+1. `cd packages/engine/mcp-server && npm install && npm run build` (so `build/` is in context).
 2. `e2b template build --config apps/server/sandbox/e2b.toml --path <repo root>`.
 
 The build context is the **repo root** — that is why the Dockerfile's `COPY`
-paths are repo-root-relative (`apps/server/app`, `mcp-server/build`, `plugin`).
+paths are repo-root-relative (`apps/server/app`, `packages/engine/mcp-server/build`, `packages/engine/plugin`).
 
 After the first build, the e2b CLI writes a generated `template_id` back into
 `e2b.toml`; commit it. The control plane references the template by name

--- a/apps/server/sandbox/e2b.Dockerfile
+++ b/apps/server/sandbox/e2b.Dockerfile
@@ -15,8 +15,8 @@
 #
 # Build context is the REPO ROOT (see build-image.sh / e2b.toml dockerfile path).
 # The engine MUST already be compiled before this builds: build-image.sh runs
-# `cd mcp-server && npm install && npm run build` first, so mcp-server/build/
-# exists in the context.
+# `cd packages/engine/mcp-server && npm install && npm run build` first, so
+# packages/engine/mcp-server/build/ exists in the context.
 FROM ubuntu:24.04
 
 # NOTE: one ENV per line — the E2B v2 Dockerfile parser appends a trailing space

--- a/docs/feedback-workflow.md
+++ b/docs/feedback-workflow.md
@@ -1,5 +1,14 @@
 # Feedback case workflow — how to triage a submission
 
+> **Superseded by [`docs/skill-lifecycle.md`](skill-lifecycle.md)** as the
+> canonical create → test → improve flow. This page remains the detailed
+> click-path for one specific on-ramp: triaging a **user-submitted feedback
+> zip** end to end (the per-platform setup, state reset, and commit steps).
+> The *discipline* it teaches — reproduce the bug live first, reset both the
+> conversation and the case data between attempts, and promote the fix into
+> a regression test — is summarized in the lifecycle doc's step 5; come here
+> for the actual zip-triage mechanics.
+
 You have a user feedback zip and you need to fix the bug and lock the
 fix in with a regression test. This page is the step-by-step. The
 spec at `docs/specs/feedback-case-spec.md` carries the rationale and

--- a/docs/feedback-workflow.md
+++ b/docs/feedback-workflow.md
@@ -114,7 +114,9 @@ Repeat until `/compare-state --against=desired` says `matches`:
 
 1. **Edit** the relevant `packages/engine/plugin/skills/<name>/SKILL.md` in your
    repo checkout. (Or an MCP tool source, or a skill template — most
-   bugs are SKILL.md prose.)
+   bugs are SKILL.md prose.) Write to the prose standard in
+   [`skill-authoring-guide.md`](skill-authoring-guide.md) — explain the
+   *why* behind a fix rather than bolting on another rule.
 2. **Reset case state** — discard every change in the case directory
    so it's back at the `imported` baseline the setup script created.
 

--- a/docs/gps/eval-setup-guide.md
+++ b/docs/gps/eval-setup-guide.md
@@ -112,6 +112,9 @@ cd eval/harness
 uv run python run_tests.py --skill <skill-name>
 ```
 
+On macOS/Linux you can instead run `make eval-skill SKILL=<skill-name>` from the
+repo root, which rebuilds the engine first (Windows juniors use `RunTests.bat`).
+
 When the harness finishes, switch back to the browser tab. The Results section will auto-refresh and your new run log will appear in the "Recent run logs" widget.
 
 ---

--- a/docs/plan/per-pr-review-workflow.md
+++ b/docs/plan/per-pr-review-workflow.md
@@ -228,7 +228,8 @@ When body-optimizer runs produce a candidate SKILL.md edit, that edit goes throu
 > 1. Pull latest main. Edit `packages/engine/plugin/skills/<skill>/SKILL.md` and/or tests via the CRUD UI.
 > 2. Run the harness for the skill:
 >    ```bash
->    cd eval/harness && uv run python run_tests.py --skill <name>
+>    make eval-skill SKILL=<name>   # rebuilds the engine if stale, then runs
+>    # or: cd eval/harness && uv run python run_tests.py --skill <name>
 >    ```
 >    The harness writes the run log to `eval/runlogs/unit/<skill>/<model>/<timestamp>.json`.
 > 3. Open the CRUD UI Results section. Pick the new run log. Review LLM scores per dimension per test.

--- a/docs/skill-authoring-guide.md
+++ b/docs/skill-authoring-guide.md
@@ -1,0 +1,174 @@
+# Skill authoring guide — how to write a good SKILL.md
+
+This is the prose standard for the genealogy skills in
+`packages/engine/plugin/skills/*/`. It covers **how to write the
+instructions** — structure, the description, voice, examples. It does
+*not* cover skill *architecture* (workflow vs reference vs guardrail
+skills, the file-handoff model, why a skill exists); that's
+[`docs/specs/skill-architecture-spec.md`](specs/skill-architecture-spec.md).
+Read the architecture spec for *why*, this guide for *how to write*.
+
+Two other things write toward this guide, so keep it current:
+
+- The `cowork-skill-builder` agent (`.claude/agents/`) scaffolds a new
+  skill — point it here for body style and frontmatter limits.
+- The skill-improver loop (see [`docs/skill-lifecycle.md`](skill-lifecycle.md))
+  proposes edits to existing skills and is told to write toward this
+  standard.
+
+**Read the exemplars first.** `search-wikipedia/SKILL.md` is the
+deliberately minimal reference — copy its shape for a simple
+tool-wrapping skill. `citation/SKILL.md` and `record-extraction/SKILL.md`
+are the richer pattern with positive triggers, negative guards, and
+worked examples. When in doubt, match how those read.
+
+---
+
+## 1. Anatomy
+
+A skill is a directory under `packages/engine/plugin/skills/<name>/`:
+
+```
+<name>/
+├── SKILL.md          (required) YAML frontmatter + markdown instructions
+├── references/       (optional) docs loaded on demand
+├── templates/        (optional) markdown files the skill fills in
+└── scripts/          (optional) Python (stdlib only) for deterministic work
+```
+
+Frontmatter requires `name` and `description`. `model:` pins a model
+for the harness; `allowed-tools:` lists the MCP tools the skill may
+call (the eval harness enforces this allowlist — anything not listed is
+blocked during tests).
+
+## 2. Progressive disclosure — and the no-shared-references rule
+
+Skills load in three levels. Keep cheap things resident and push depth
+behind pointers:
+
+1. **`name` + `description`** — always in the orchestrator's context for
+   every session. Treat this as a scarce budget (see §3).
+2. **SKILL.md body** — loaded whenever the skill triggers. Aim **under
+   ~500 lines**. If you're approaching that, add a layer of hierarchy
+   and point to a `references/` file rather than inlining everything.
+3. **`references/`, `templates/`, `scripts/`** — loaded or executed only
+   when the body tells the model to.
+
+When you reference a file, say **when** to read it. For a reference over
+~300 lines, give it a table of contents.
+
+**The adaptation you must respect:** Claude Code can't reliably resolve
+a shared reference path across skills (issue #17741), so shared guidance
+is **duplicated into each skill's own `references/`, never linked to a
+single shared copy.** The skill-creator advice to "factor shared
+guidance into one file" does *not* apply here — if two skills need the
+same rule, both carry their own copy, and "update the shared guidance"
+means editing every copy. (This is also why there is no plugin-level
+`CLAUDE.md`: it wouldn't be auto-loaded.)
+
+## 3. The description is the trigger — write it deliberately
+
+Cowork's orchestrator decides whether to invoke a skill from its
+`name` + `description` alone. So:
+
+- **Put all "when to use" information in the description**, not the body.
+  Name the phrasings and contexts that should activate it — including
+  ones where the user doesn't say the skill's name. Claude tends to
+  *under*-trigger, so lean slightly pushy.
+- **Name the confusable skills in a "Do NOT use when …" clause.**
+  `search-wikipedia`'s description is the model: it names
+  search-familysearch-wiki, locality-guide, and historical-context as
+  the skills to defer to. Every such clause is also a free source of
+  negative tests (see the lifecycle doc).
+- **Stay within 1024 characters.** Not because a packager rejects longer
+  — because every skill's description is *always resident* and the ~28
+  descriptions compete for the orchestrator's attention on every turn. A
+  tight description triggers more precisely than a rambling one. If you
+  can't fit it, the skill is probably doing too much. (Trim over-long
+  descriptions through the description optimizer, not by eye — see the
+  lifecycle doc — because blind cuts drop activations.)
+- **Avoid angle brackets in the description.** Write "before 1850," not
+  "`<1850`"; `<…>` can collide with prompt scaffolding. In the body,
+  `<1850` is fine.
+
+## 4. Repo conventions every SKILL.md follows
+
+- **Open with the Narration line.** Every skill starts with:
+  `**Narration:** Read research.json's researcher_profile.narration_guidance
+  and apply it as your narration style for this invocation.` Copy it
+  verbatim from an existing skill.
+- **End with `## Re-invocation behavior`.** State what the skill
+  **Writes**, what happens **On repeat invocation**, and a **Do not
+  duplicate** rule. See `search-wikipedia/SKILL.md`.
+- **Network code never lives in a skill.** Skills run in the Cowork VM
+  with no reliable egress. Anything that hits the network is an MCP tool
+  on the host; the skill calls it. If you find yourself wanting `fetch`
+  in a skill, you want an MCP tool instead.
+- **Bundled scripts are Python, standard library only.** They run in the
+  VM; no `pip` deps, no network. Move deterministic, repetitive work
+  (date math, GEDCOM munging, formatting) into a `scripts/` helper
+  rather than re-deriving it in prose on every run — and put it in *this*
+  skill's `scripts/`, not a shared location.
+- **Mind the casing seam.** MCP tool parameters are camelCase
+  (`personId`, `birthPlace`); the persisted documents the skill edits —
+  `research.json`, `tree.gedcomx.json` — are snake_case (`assertion_id`,
+  `couple_relationship`). Keep each on its own side.
+- **No skill invokes another skill.** Orchestration is Claude reading
+  descriptions and file state. If skill A produces data B needs, A leaves
+  it in `research.json`/`tree.gedcomx.json` (or Claude's context), and
+  B's description tells Claude when to fire. A guardrail like
+  validate-schema is invoked by a prose instruction in the writing
+  skill, not a programmatic call.
+- **Extending the schema is a three-place change.** A new `research.json`
+  or simplified-GedcomX field requires updating
+  `docs/specs/schemas/research.schema.json`, the prose table in
+  `docs/specs/research-schema-spec.md`, and the `validate_research_schema`
+  validator. Don't add a field in a skill alone.
+
+## 5. Writing style
+
+- **Imperative voice.** "Call `record_search` with the plan item's
+  parameters," not "the skill should call…".
+- **Explain the why; treat all-caps MUSTs as a yellow flag.** Today's
+  models follow reasoning better than rote commands, and a "why"
+  generalizes to cases your examples didn't cover. If you're reaching for
+  `ALWAYS`/`NEVER`, reframe it as the reason the rule matters. Reserve
+  hard mandates for genuine invariants (schema conformance, the research
+  log protocol).
+- **Define fixed output shapes with a template.** If the output has a
+  required structure, show the literal skeleton (a `templates/` file or
+  an inline block) for the model to fill in.
+- **Show worked examples.** A concrete input→output pair teaches the
+  mapping better than description. See the `## Example` section in
+  `search-wikipedia/SKILL.md`.
+- **Keep it general, not overfit.** You'll often write a skill against a
+  few example records. Resist tuning the prose to those specific cases —
+  a skill that only works for the Flynn scenario is useless. State the
+  principle; let the model apply it.
+- **Draft, then read it cold.** Write a first version, then re-read it
+  against this guide with fresh eyes — is it lean, are the MUSTs
+  justified, did the body stay under 500 lines? This pass is cheap and
+  catches the most.
+
+## 6. Lack of surprise
+
+A skill's behavior must not surprise a user who read its description. No
+hidden side effects, no data exfiltration, no network code smuggled past
+the VM boundary. If a proposed skill's intent and its contents diverge,
+fix the divergence before shipping.
+
+---
+
+## Checklist before you commit
+
+- [ ] `description` ≤ 1024 chars, no angle brackets, names the
+      confusable skills it defers to.
+- [ ] Opens with the `**Narration:**` line; ends with
+      `## Re-invocation behavior`.
+- [ ] Body under ~500 lines; depth pushed into this skill's own
+      `references/`.
+- [ ] No network code; any bundled script is Python stdlib only.
+- [ ] camelCase tool params, snake_case persisted fields.
+- [ ] MUSTs are real invariants; everything else explains its why.
+- [ ] Has unit tests under `eval/tests/unit/<name>/` (see the lifecycle
+      doc for the test taxonomy and holdout convention).

--- a/docs/skill-authoring-guide.md
+++ b/docs/skill-authoring-guide.md
@@ -2,11 +2,10 @@
 
 This is the prose standard for the genealogy skills in
 `packages/engine/plugin/skills/*/`. It covers **how to write the
-instructions** — structure, the description, voice, examples. It does
-*not* cover skill *architecture* (workflow vs reference vs guardrail
-skills, the file-handoff model, why a skill exists); that's
-[`docs/specs/skill-architecture-spec.md`](specs/skill-architecture-spec.md).
-Read the architecture spec for *why*, this guide for *how to write*.
+instructions** — structure, the description, voice, examples — plus the
+handful of architecture facts you need to make the right calls. You don't
+need to read anything else to write a good skill; deeper rationale is in
+the doc index at the end.
 
 Two other things write toward this guide, so keep it current:
 
@@ -16,11 +15,27 @@ Two other things write toward this guide, so keep it current:
   proposes edits to existing skills and is told to write toward this
   standard.
 
-**Read the exemplars first.** `search-wikipedia/SKILL.md` is the
-deliberately minimal reference — copy its shape for a simple
-tool-wrapping skill. `citation/SKILL.md` and `record-extraction/SKILL.md`
-are the richer pattern with positive triggers, negative guards, and
-worked examples. When in doubt, match how those read.
+## What kind of skill are you writing?
+
+Three kinds, and it changes how you write it:
+
+- **Workflow skill** — triggered by a user request (most skills). It maps
+  to a step in the research process and reads from and writes to the two
+  project files, `research.json` and `tree.gedcomx.json`.
+- **Reference document** — not triggered on its own. It's a rules doc
+  (like the research-log protocol) that several skills must follow
+  identically, so a copy lives in each of their `references/` folders.
+- **Guardrail** — enforces a check, e.g. schema validity. Cowork has no
+  automatic post-write hooks, so a guardrail runs only because a writing
+  skill's prose tells Claude to: "After writing to research.json, invoke
+  validate-schema."
+
+**Skills never call each other.** There is no programmatic skill-to-skill
+invocation in Cowork — orchestration is Claude reading the skill
+descriptions and the current file state and deciding what to do next. If
+skill A produces something skill B needs, A leaves it in `research.json` /
+`tree.gedcomx.json` (or in Claude's context within the session), and B's
+*description* is what tells Claude when to fire.
 
 ---
 
@@ -75,11 +90,11 @@ Cowork's orchestrator decides whether to invoke a skill from its
   Name the phrasings and contexts that should activate it — including
   ones where the user doesn't say the skill's name. Claude tends to
   *under*-trigger, so lean slightly pushy.
-- **Name the confusable skills in a "Do NOT use when …" clause.**
-  `search-wikipedia`'s description is the model: it names
-  search-familysearch-wiki, locality-guide, and historical-context as
-  the skills to defer to. Every such clause is also a free source of
-  negative tests (see the lifecycle doc).
+- **Name the confusable skills in a "Do NOT use when …" clause.** List
+  the skills this one should defer to (for example, a Wikipedia-lookup
+  skill defers to search-familysearch-wiki, locality-guide, and
+  historical-context). Every such clause is also a free source of negative
+  tests (see the lifecycle doc).
 - **Stay within 1024 characters.** Not because a packager rejects longer
   — because every skill's description is *always resident* and the ~28
   descriptions compete for the orchestrator's attention on every turn. A
@@ -99,7 +114,7 @@ Cowork's orchestrator decides whether to invoke a skill from its
   verbatim from an existing skill.
 - **End with `## Re-invocation behavior`.** State what the skill
   **Writes**, what happens **On repeat invocation**, and a **Do not
-  duplicate** rule. See `search-wikipedia/SKILL.md`.
+  duplicate** rule.
 - **Network code never lives in a skill.** Skills run in the Cowork VM
   with no reliable egress. Anything that hits the network is an MCP tool
   on the host; the skill calls it. If you find yourself wanting `fetch`
@@ -119,11 +134,6 @@ Cowork's orchestrator decides whether to invoke a skill from its
   B's description tells Claude when to fire. A guardrail like
   validate-schema is invoked by a prose instruction in the writing
   skill, not a programmatic call.
-- **Extending the schema is a three-place change.** A new `research.json`
-  or simplified-GedcomX field requires updating
-  `docs/specs/schemas/research.schema.json`, the prose table in
-  `docs/specs/research-schema-spec.md`, and the `validate_research_schema`
-  validator. Don't add a field in a skill alone.
 
 ## 5. Writing style
 
@@ -139,8 +149,8 @@ Cowork's orchestrator decides whether to invoke a skill from its
   required structure, show the literal skeleton (a `templates/` file or
   an inline block) for the model to fill in.
 - **Show worked examples.** A concrete input→output pair teaches the
-  mapping better than description. See the `## Example` section in
-  `search-wikipedia/SKILL.md`.
+  mapping better than description — include a short "Example" section
+  showing one full interaction.
 - **Keep it general, not overfit.** You'll often write a skill against a
   few example records. Resist tuning the prose to those specific cases —
   a skill that only works for the Flynn scenario is useless. State the
@@ -172,3 +182,16 @@ fix the divergence before shipping.
 - [ ] MUSTs are real invariants; everything else explains its why.
 - [ ] Has unit tests under `eval/tests/unit/<name>/` (see the lifecycle
       doc for the test taxonomy and holdout convention).
+
+## Doc index
+
+- [`docs/skill-lifecycle.md`](skill-lifecycle.md) — the full create → test
+  → improve flow this guide is step 1 of.
+- [`docs/specs/skill-architecture-spec.md`](specs/skill-architecture-spec.md)
+  — the architecture rationale behind the skill kinds and the file-handoff
+  model. You don't need it to write a skill; read it only if you're curious
+  or changing the architecture itself.
+- [`docs/specs/research-schema-spec.md`](specs/research-schema-spec.md) —
+  only if you're adding a new `research.json` / GedcomX field: that's a
+  three-place change (the schema JSON + the prose table + the
+  `validate_research_schema` validator), not something a skill does alone.

--- a/docs/skill-lifecycle.md
+++ b/docs/skill-lifecycle.md
@@ -2,8 +2,9 @@
 
 This is the **start-here map** for the people who build and improve the
 genealogy skills: how a skill goes from an idea to a tested, released,
-continually-improved artifact. It orients you and points at the detailed
-docs — it does not restate them.
+continually-improved artifact. It is the **complete flow** end to end and the
+entry point; it points at the detailed docs for each step rather than
+restating them.
 
 The work is done by a **genealogist and a developer pairing.**
 Genealogists are learning to run tests; developers are learning
@@ -12,9 +13,14 @@ genealogy. Neither role does the whole loop alone — the genealogist owns
 work*, and they decide together at the points that matter.
 
 ```
-        create ──► test ──► review & annotate ──► improve ──► release
-          ▲                                          │
-          └──────────────── (description optimize) ◄─┘
+  1 create → 2 test → 3 review+annotate → 4 audit rubric → 5 improve body → 6 verify → 7 release
+                                                                 │
+                       8 optimize description  ◄── co-tune ──────┘
+
+  One skill at a time. Body loop (5) = skill-improver, which proposes SKILL.md
+  edits and routes test-data / triggering / rubric causes elsewhere.
+  Description loop (8) = the vendored run_loop. Rubric audit (4) keeps the
+  signal honest so (5) doesn't optimize toward a weak rubric.
 ```
 
 | Role | Owns | Across the lifecycle |
@@ -83,15 +89,31 @@ Should: a hard conflict — two primary informants disagree. Gap: the
 skill body never says primary-vs-primary disagreement is hard."* That
 comment is an edit waiting to happen; the first one isn't.
 
-### 4. Improve the skill body
+### 4. Audit the rubric (periodic; before a body-optimization push)
+
+**Pair.** Before trusting the improver to optimize toward a rubric, make sure
+the rubric *discriminates*. The **rubric-critic** agent (read-only) reads a
+skill's run logs (best across versions) + `.ann` corrections + `rubric.md` and
+flags non-discriminating dimensions (always 3 or always 1), flaky dimensions,
+dimensions no test exercises, and systematic judge-vs-human disagreement.
+Invoke it in Claude Code: *"audit the rubric for `<skill>`"*. It only
+*suggests* — rubric edits are the senior's, judge-prompt edits a separate
+cadence. A skill-improver that hill-climbs a weak rubric optimizes noise, so
+run this periodically and whenever a dimension looks off.
+
+### 5. Improve the skill body
 
 **Pair.** Cluster the failures across the skill's tests and revise the
 SKILL.md prose to fix them — explaining the *why*, not bolting on
-another MUST (see the authoring guide). Today this is the manual edit
-step in [`docs/feedback-workflow.md`](feedback-workflow.md); the
-**skill-improver** agent (report-only; see Status) assists by reading
-the latest annotated run-log, clustering, and proposing an evidence-cited
-diff for the pair to approve. Either way the discipline is the same:
+another MUST (see the authoring guide). The legacy single-case path is
+[`docs/feedback-workflow.md`](feedback-workflow.md); the **skill-improver**
+agent (report-only) assists by reading the latest annotated run-log,
+clustering, and proposing an evidence-cited diff for the pair to approve.
+Invoke it in Claude Code: *"improve `<skill>` from its eval results"*. It
+**routes by cause** — a correction that actually points at a test-data gap, a
+triggering miss, or a rubric problem goes to the test author / description
+optimizer (step 8) / rubric review (step 4), not into a body edit; only a
+body-located cause becomes SKILL.md prose. Either way the discipline is the same:
 
 - **Generalize, don't patch the case.** The test is the question, not the
   answer key. Ask "does this edit read as a general principle?" An edit
@@ -110,7 +132,7 @@ diff for the pair to approve. Either way the discipline is the same:
   unproductive paths, delete the offending instruction. Net SKILL.md
   length should trend flat or down, not always up.
 
-### 5. Verify the fix
+### 6. Verify the fix
 
 **Pair.** We are early in the cycle — **catching big problems, not
 polishing small ones** — so verification is cheap and qualitative, not a
@@ -129,24 +151,32 @@ statistical bake-off:
   — a binary a single run answers — not "did the weighted mean rise by
   X."
 
-### 6. Release
+### 7. Release
 
 **Genealogist blesses, developer ships.** The GitHub Action requires the
 latest full-skill run-log to be active and fully annotated before the
 senior clicks Release. Mechanics: `eval/README.md` → "Run log naming"
 and the versioning plan.
 
-### 7. Optimize the description (separate, automated loop)
+### 8. Optimize the description (separate, automated loop)
 
-**Developer.** The skill body (steps 4–6) and the skill *description* are
-two different loops. The description drives Cowork's auto-delegation and
-is tuned automatically by the description optimizer (a port of
-skill-creator's `run_loop`) against should-trigger / should-not-trigger
-query sets — which it can derive for free from the positive and negative
-tests you already wrote. Plan:
-[`docs/plan/skill-mcp-optimization-plan.md`](plan/skill-mcp-optimization-plan.md).
-Optimizer run-logs land in `eval/runlogs/optimizer/` (excluded from the
-release gate and comparisons).
+**Developer.** The skill body (steps 5–7) and the skill *description* are
+two different loops. The description drives Cowork's auto-delegation and is
+tuned by the description optimizer (skill-creator's `run_loop`, vendored under
+`eval/triggering/`) against should-trigger / should-not-trigger query sets —
+derived for free from your positive and negative tests. Run it on demand (real
+`claude -p` calls — network + model cost, **not** CI):
+
+```bash
+make optimize-skill SKILL=<skill>   # build the query set from the tests, then run the optimizer
+```
+
+It tunes the **description only** — it never runs the skill or an MCP tool.
+Apply the proposed `best_description` as a human-reviewed SKILL.md edit. Plan:
+[`docs/plan/skill-mcp-optimization-plan.md`](plan/skill-mcp-optimization-plan.md);
+vendoring notes: `eval/triggering/VENDORED.md`. (Folding the optimizer's output
+into `eval/runlogs/optimizer/` is a planned fast-follow; today it prints
+`best_description` + an HTML report.)
 
 **Co-tune the two.** A body change can invalidate the old description's
 triggers, and a skill that never activates can't be body-improved. After
@@ -197,12 +227,17 @@ promotion criteria.)
 
 ## Status
 
-In place: the authoring guide; the harness + CRUD-UI review loop; the
-`holdout` test flag; a blocking frontmatter lint in CI; and the
-**skill-improver** agent — a report-only proposer that reads a skill's
-latest active, annotated run log and returns evidence-cited SKILL.md edits
-for the pairing developer to apply in-session, re-verify, and commit. It
-does not edit files itself.
+Every step in the flow above is built and on the
+`skill-authoring-and-improvement-framework` branch:
+
+- **Author** — the authoring guide + a blocking frontmatter lint (CI).
+- **Test** — `make eval-skill SKILL=<name>` (rebuilds the engine, then runs the harness).
+- **Review** — the CRUD-UI annotation loop + the `holdout` test flag.
+- **Audit** — the `rubric-critic` agent.
+- **Improve** — the `skill-improver` agent (report-only; proposes evidence-cited
+  SKILL.md edits and routes non-body causes elsewhere; the pair applies,
+  re-runs, commits — it never edits files itself).
+- **Optimize** — `make optimize-skill SKILL=<name>` (vendored `run_loop`, on-demand).
 
 **To try the skill-improver on skill `X`:** it needs an *active* run log
 (its snapshot matches the working tree) that is *annotated*. So first
@@ -213,8 +248,9 @@ returns no edits and asks you to re-run — that is correct behavior, not a
 failure. The developer applies the approved diffs, re-runs the affected
 tests, and the pair decides whether to keep them.
 
-Still to come: a rubric-quality critic, and the body↔description co-tune
-with the description optimizer. The manual edit path is
+Fast-follows (not blockers for team testing): folding the optimizer's output
+into `eval/runlogs/optimizer/`. The real next phase is the teams exercising all
+of this on real skills. The legacy single-case path is
 [`docs/feedback-workflow.md`](feedback-workflow.md).
 
 ## Doc index
@@ -225,6 +261,9 @@ with the description optimizer. The manual edit path is
 | Understand skill architecture / categories | [`docs/specs/skill-architecture-spec.md`](specs/skill-architecture-spec.md) |
 | Run the harness / read a run-log | [`eval/README.md`](../eval/README.md) |
 | Write a test | [`docs/specs/unit-test-spec.md`](specs/unit-test-spec.md) |
+| Audit a skill's rubric quality | the `rubric-critic` agent — `.claude/agents/rubric-critic.md` |
+| Improve a SKILL.md body from eval results | the `skill-improver` agent — `.claude/agents/skill-improver.md` |
+| Optimize a skill's description | `make optimize-skill SKILL=<name>`; `eval/triggering/` + `VENDORED.md` |
 | Triage a user feedback report | [`docs/feedback-workflow.md`](feedback-workflow.md) |
 | Know the per-PR + release cadence | [`docs/plan/per-pr-review-workflow.md`](plan/per-pr-review-workflow.md), [`docs/plan/eval-runlog-versioning.md`](plan/eval-runlog-versioning.md) |
 | Understand the optimizers | [`docs/plan/skill-mcp-optimization-plan.md`](plan/skill-mcp-optimization-plan.md) |

--- a/docs/skill-lifecycle.md
+++ b/docs/skill-lifecycle.md
@@ -41,10 +41,11 @@ and [`eval/SENIOR-WALKTHROUGH.md`](../eval/SENIOR-WALKTHROUGH.md).
 **Pair.** Write the SKILL.md to the prose standard in
 [`docs/skill-authoring-guide.md`](skill-authoring-guide.md); for a new
 tool-wrapping skill, scaffold it with the `cowork-skill-builder` agent
-first. Architecture questions (should this even be a skill? which
-category?) → [`docs/specs/skill-architecture-spec.md`](specs/skill-architecture-spec.md).
-The genealogist drives the domain content; the developer drives shape,
-frontmatter limits, and any `scripts/` helper.
+first. (The authoring guide's "What kind of skill are you writing?"
+section covers whether it should be a skill at all and which of the three
+kinds — workflow, reference, or guardrail — it is.) The genealogist drives
+the domain content; the developer drives shape, frontmatter limits, and
+any `scripts/` helper.
 
 ### 2. Test
 
@@ -55,26 +56,36 @@ make eval-skill SKILL=<skill>     # from repo root: rebuilds the engine if stale
 # manual equivalent: cd eval/harness && uv run python run_tests.py --skill <skill>
 ```
 
-The harness drives the skill against mocked MCP tools in a seeded
-scenario, an LLM judge grades each run, and it writes a candidate
-run-log. Format, fixtures, scenarios, exit codes: [`eval/README.md`](../eval/README.md)
-and [`docs/specs/unit-test-spec.md`](specs/unit-test-spec.md). Tests are
-**slow (~2–3 min each) and cost money** — scope every run to one skill,
-never run several invocations at once (they fight for memory and get
-killed).
+The harness drives the skill against mocked tool responses in a seeded
+starting state (a *scenario*), an LLM judge grades each run, and it saves
+a **run-log** — the scores plus a snapshot of the exact skill, tests,
+scenario, and fixtures used, so the run can be reproduced. Each full
+`--skill` run writes a new run-log; running a single test (`--test`)
+makes a throwaway "scratch" run that isn't saved. Tests are **slow
+(~2–3 min each) and cost money** — scope every run to one skill, never run
+several invocations at once (they fight for memory and get killed).
 
 How to author a *good* test corpus is its own section below — it's the
 single biggest lever on whether the rest of the loop works.
 
 ### 3. Review & annotate
 
-**Genealogist.** Open the CRUD UI (`cd eval/app && npm run dev`), read
-each run, and correct the judge's per-dimension scores into the
-`.ann.json` sibling. This is where human judgment enters the system, and
-it's what every later step trusts more than the raw judge score. The
-per-PR cadence is [`docs/plan/per-pr-review-workflow.md`](plan/per-pr-review-workflow.md);
-release/active/candidate mechanics are
-[`docs/plan/eval-runlog-versioning.md`](plan/eval-runlog-versioning.md).
+**Genealogist.** Open the CRUD UI (`make eval-ui`, or `cd eval/app && npm
+run dev`), read each run, and correct the judge's grades. The UI pre-fills
+every dimension with the judge's score, so you only change the ones you
+**disagree with** and add a comment on those (matching dimensions need no
+comment). This is where human judgment enters the system — it's what every
+later step trusts more than the raw judge score.
+
+**One skill per PR, and you own the loop:** edit the skill and/or tests,
+run the harness, correct the grades, commit all of it (skill edits + test
+changes + run-log + your corrections), and open the PR. A senior reviews it
+via the GitHub diff + the CRUD UI and leaves feedback as **PR comments** —
+respond by re-running and pushing a *new commit per round* (don't amend).
+The senior is the gate: they release when the corrected grades show a real
+improvement and the skill + tests look right — a holistic judgment, not a
+number. Most PRs land in 1–2 rounds; 3+ is a signal to flag a senior
+engineer rather than grind.
 
 **Write correction comments a machine can act on.** A comment is the
 highest-signal input the improver gets, and "judge over-credited" is
@@ -105,9 +116,8 @@ run this periodically and whenever a dimension looks off.
 
 **Pair.** Cluster the failures across the skill's tests and revise the
 SKILL.md prose to fix them — explaining the *why*, not bolting on
-another MUST (see the authoring guide). The legacy single-case path is
-[`docs/feedback-workflow.md`](feedback-workflow.md); the **skill-improver**
-agent (report-only) assists by reading the latest annotated run-log,
+another MUST (see the authoring guide). The **skill-improver** agent
+(report-only) assists by reading the latest annotated run-log,
 clustering, and proposing an evidence-cited diff for the pair to approve.
 Invoke it in Claude Code: *"improve `<skill>` from its eval results"*. It
 **routes by cause** — a correction that actually points at a test-data gap, a
@@ -134,6 +144,17 @@ body-located cause becomes SKILL.md prose. Either way the discipline is the same
   unproductive paths, delete the offending instruction. Net SKILL.md
   length should trend flat or down, not always up.
 
+**When the trigger is a real user bug** (a feedback report) instead of an
+annotated run-log, the on-ramp differs but the machinery is the same.
+First **reproduce it live** — replay the user's exact prompt against the
+real skill and watch the bug happen before you change anything; live APIs
+are noisy, so re-run once if it doesn't show. Between fix attempts, reset
+*two* things: start a fresh conversation (so the agent isn't anchored on
+its earlier bad reasoning) and reset the case's data to its starting state
+(leftover changes contaminate the next run). Once it's fixed, **promote
+the case into a regression test** so it can't silently come back, and let
+the commit message be the lesson — what went wrong and why the fix works.
+
 ### 6. Verify the fix
 
 **Pair.** We are early in the cycle — **catching big problems, not
@@ -155,52 +176,72 @@ statistical bake-off:
 
 ### 7. Release
 
-**Genealogist blesses, developer ships.** The GitHub Action requires the
-latest full-skill run-log to be active and fully annotated before the
-senior clicks Release. Mechanics: `eval/README.md` → "Run log naming"
-and the versioning plan.
+**Senior blesses, developer ships.** Each full run you commit is a
+**candidate**; a senior reviews the corrected grades and clicks **Release**
+on the good one, which makes it the official version (v1, v2, … — one
+released run-log per version). Before they can, the run-log must be
+**active** — its snapshot still matches the skill files in the repo. Edit
+SKILL.md or a test and the UI shows "no active version" until you re-run
+the harness; that's your signal the latest results are stale. It must also
+be fully annotated. CI enforces both.
 
 ### 8. Optimize the description (separate, automated loop)
 
-**Developer.** The skill body (steps 5–7) and the skill *description* are
-two different loops. The description drives Cowork's auto-delegation and is
-tuned by the description optimizer (skill-creator's `run_loop`, vendored under
-`eval/triggering/`) against should-trigger / should-not-trigger query sets —
-derived for free from your positive and negative tests. Run it on demand (real
-`claude -p` calls — network + model cost, **not** CI):
+**Developer.** A skill has two parts that are tuned separately: the
+one-line **description** controls *when* the skill fires; the **body**
+(steps 5–7) teaches Claude *how* to do the task. A *triggering* problem —
+the skill fires when it shouldn't, or doesn't when it should — is a
+**description** fix; an "it did the task wrong" problem is a **body** fix.
+Don't conflate them.
+
+The description optimizer builds should-trigger / should-not-trigger query
+sets for free from your positive and negative tests, then tunes the
+description against them. Run it on demand (it makes real `claude -p` calls
+— network + model cost, **not** CI):
 
 ```bash
-make optimize-skill SKILL=<skill>   # build the query set from the tests, then run the optimizer
+make optimize-skill SKILL=<skill>   # build the trigger query set, then run the optimizer
+# no make? cd eval/triggering, then run these two:
+#   uv run python build_eval_set.py --skill <skill>
+#   uv run python -m scripts.run_loop --eval-set eval_sets/<skill>.json \
+#     --skill-path ../../packages/engine/plugin/skills/<skill> --model <session-model>
 ```
 
-It tunes the **description only** — it never runs the skill or an MCP tool.
-Apply the proposed `best_description` as a human-reviewed SKILL.md edit. Plan:
-[`docs/plan/skill-mcp-optimization-plan.md`](plan/skill-mcp-optimization-plan.md);
-vendoring notes: `eval/triggering/VENDORED.md`. Output (`results.json` + an HTML
-report) lands in `eval/runlogs/optimizer/<ts>/`, which is excluded from the
-release gate and comparisons.
+It tunes the **description only** — it never runs the skill or a tool.
+Apply the proposed new description as a human-reviewed SKILL.md edit; the
+optimizer's report lands in `eval/runlogs/optimizer/`, separate from your
+test run-logs.
 
-**Co-tune the two.** A body change can invalidate the old description's
-triggers, and a skill that never activates can't be body-improved. After
-a body edit lands, re-run the description optimizer; after a description
-change, re-run the body suite to confirm no behavioral regression. Do
-body first, then description.
+**The two loops interact, so sequence them.** Fix the body first — a skill
+that never fires can't be body-improved. After a body change that alters
+*what the skill does*, re-run the description optimizer (the old triggers
+may no longer fit). After a description change, re-run the skill's tests to
+confirm its behavior didn't move. Body first, then description.
 
 ---
 
 ## Authoring a test corpus that the loop can actually use
 
-Test *count* is a floor, not the goal — aim for **8–12 tests per skill**,
-but spend them on **coverage, not repetition**. Eight easy happy-path
-tests can't tell a good skill from a bad one. Each skill's set should
-span:
+A test is four things you fill in the CRUD UI — no JSON: the **user
+message**, a starting **scenario** (project state) from a dropdown,
+optional **fixtures** (canned tool responses so the skill doesn't hit a
+live API), and plain-English **criteria**. You can ship a useful test with
+just a message and a scenario — the skill's shared rubric does the heavy
+grading; your criteria only add what's unique to *this* case. (If no
+scenario fits, pick the closest and note the gap — the test saves but
+won't run until a developer builds the matching scenario.)
+
+Aim for **at least 8 tests per skill** — no upper bound; we don't yet know
+enough to set one. Spend them on **coverage, not repetition**: eight easy
+happy-path tests can't tell a good skill from a bad one. Each skill's set
+should span:
 
 - **Positive** — the skill should fire and do the task well (happy path
   *and* messier variants).
 - **Negative / routing** — a near-miss that should go to a *different*
-  skill. Mine these from the "Do NOT use when…" clauses in the
-  description (see the authoring guide); build them from both directions
-  of each confusable pair.
+  skill (you name which one, or "none"). Mine these from the "Do NOT use
+  when…" clauses in the description (see the authoring guide); build them
+  from both directions of each confusable pair.
 - **Edge cases** — the messy genealogy realities: conflicting records,
   missing data, ambiguous places, multi-person households.
 - **At least one hard case** — something the skill currently gets wrong.
@@ -211,63 +252,67 @@ toggle the "Hold out from the skill-improver" switch on each in the CRUD
 UI. Authoring the hold-out into the corpus now is far cheaper than carving
 it out after the improver has already been trained against everything.
 
-Keep `judge_context` / criteria **neutral** — grade the reasoning, not a
-preferred verdict (see `unit-test-spec.md` §5.4). A criterion the test's
-own author would only endorse if they reached one particular conclusion
-is leakage, and it's the biggest validity threat to LLM-as-judge.
+Keep your criteria **neutral** — grade the *reasoning*, never a preferred
+answer. "Should resolve in favor of the Irish birthplace" is leakage: the
+judge then just agrees with you. Rewrite it to "resolution should weigh
+informant proximity as a factor, regardless of which birthplace it picks."
+The test: would a genealogist who reached the *opposite* conclusion still
+call your criterion fair? If not, it's leaking — the biggest validity
+threat to LLM-as-judge grading.
 
 ---
 
 ## Is the loop working?
 
 The real metric isn't pass rate — it's whether the system **compounds.**
-If the pair keeps catching the *same class* of issue ten iterations in,
-the loop isn't learning: the fix belongs further upstream (a rubric
-dimension, a validator, the authoring guide), not in yet another
-case-specific prose patch. Promote recurring findings down a tier rather
-than re-fixing them. (`skill-mcp-optimization-plan.md` carries the
-promotion criteria.)
+When you catch the *same kind of mistake* across several tests, stop fixing
+it by hand: push it down into something that catches it automatically. A
+yes/no check on a single output (e.g. "citation missing") becomes an
+automated test; something you only see by reading the whole output and
+weighing it (e.g. "overconfident conclusion") becomes a **rubric**
+dimension. If you're still hand-catching the same class of issue ten rounds
+in, the loop isn't learning.
 
 ## Status
 
-Every step in the flow above is built and on the
-`skill-authoring-and-improvement-framework` branch:
+Every step has tooling in place:
 
-- **Author** — the authoring guide + a blocking frontmatter lint (CI).
-- **Test** — `make eval-skill SKILL=<name>` (rebuilds the engine, then runs the harness).
-- **Review** — the CRUD-UI annotation loop + the `holdout` test flag.
+- **Author** — the authoring guide + a blocking frontmatter lint in CI.
+- **Test** — `make eval-skill SKILL=<name>` (or `cd eval/harness && uv run python run_tests.py --skill <name>`).
+- **Review** — the CRUD UI (`make eval-ui`, or `cd eval/app && npm run dev`) + the holdout toggle.
 - **Audit** — the `rubric-critic` agent.
-- **Improve** — the `skill-improver` agent (report-only; proposes evidence-cited
-  SKILL.md edits and routes non-body causes elsewhere; the pair applies,
-  re-runs, commits — it never edits files itself).
-- **Optimize** — `make optimize-skill SKILL=<name>` (vendored `run_loop`, on-demand).
+- **Improve** — the `skill-improver` agent (report-only: it proposes
+  evidence-cited SKILL.md edits and routes non-body causes elsewhere; the
+  pair applies, re-runs, and commits — it never edits files itself).
+- **Optimize** — `make optimize-skill SKILL=<name>` (on-demand; manual commands in step 8).
 
-**To try the skill-improver on skill `X`:** it needs an *active* run log
-(its snapshot matches the working tree) that is *annotated*. So first
-`make eval-skill SKILL=X` (it rebuilds the engine first) on current code, annotate that
-candidate in the CRUD UI, then in Claude Code ask to "use the
-skill-improver agent on X". Against a stale or unannotated run log it
-returns no edits and asks you to re-run — that is correct behavior, not a
-failure. The developer applies the approved diffs, re-runs the affected
-tests, and the pair decides whether to keep them.
-
-Fast-follows (not blockers for team testing): folding the optimizer's output
-into `eval/runlogs/optimizer/`. The real next phase is the teams exercising all
-of this on real skills. The legacy single-case path is
-[`docs/feedback-workflow.md`](feedback-workflow.md).
+**To run the skill-improver on skill `X`:** it needs an *active*,
+*annotated* run-log. So run the harness on current code (`make eval-skill
+SKILL=X`, or `cd eval/harness && uv run python run_tests.py --skill X`),
+annotate the candidate in the CRUD UI, then ask Claude Code to "improve `X`
+from its eval results". Against a stale or unannotated run-log it proposes
+nothing and asks you to re-run — that's correct, not a failure.
 
 ## Doc index
 
-| You want to… | Read |
+Everyday docs:
+
+| You want to… | Go to |
 |---|---|
 | Write a SKILL.md well | [`docs/skill-authoring-guide.md`](skill-authoring-guide.md) |
-| Understand skill architecture / categories | [`docs/specs/skill-architecture-spec.md`](specs/skill-architecture-spec.md) |
 | Run the harness / read a run-log | [`eval/README.md`](../eval/README.md) |
-| Write a test | [`docs/specs/unit-test-spec.md`](specs/unit-test-spec.md) |
 | Audit a skill's rubric quality | the `rubric-critic` agent — `.claude/agents/rubric-critic.md` |
 | Improve a SKILL.md body from eval results | the `skill-improver` agent — `.claude/agents/skill-improver.md` |
-| Optimize a skill's description | `make optimize-skill SKILL=<name>`; `eval/triggering/` + `VENDORED.md` |
-| Triage a user feedback report | [`docs/feedback-workflow.md`](feedback-workflow.md) |
-| Know the per-PR + release cadence | [`docs/plan/per-pr-review-workflow.md`](plan/per-pr-review-workflow.md), [`docs/plan/eval-runlog-versioning.md`](plan/eval-runlog-versioning.md) |
-| Understand the optimizers | [`docs/plan/skill-mcp-optimization-plan.md`](plan/skill-mcp-optimization-plan.md) |
 | Do your first PR (genealogist / senior) | [`eval/JUNIOR-WALKTHROUGH.md`](../eval/JUNIOR-WALKTHROUGH.md), [`eval/SENIOR-WALKTHROUGH.md`](../eval/SENIOR-WALKTHROUGH.md) |
+
+**Go deeper only if you're changing the machinery itself** — you don't need
+these to follow the flow above:
+
+| Topic | Spec / plan |
+|---|---|
+| Skill architecture & the three skill kinds | [`docs/specs/skill-architecture-spec.md`](specs/skill-architecture-spec.md) |
+| Test JSON format, fixtures, validators | [`docs/specs/unit-test-spec.md`](specs/unit-test-spec.md) |
+| Per-PR review + run-log release/active/candidate mechanics | [`docs/plan/per-pr-review-workflow.md`](plan/per-pr-review-workflow.md), [`docs/plan/eval-runlog-versioning.md`](plan/eval-runlog-versioning.md) |
+| The full evaluation + optimizer design | [`docs/plan/skill-mcp-optimization-plan.md`](plan/skill-mcp-optimization-plan.md) |
+| The vendored description optimizer | `eval/triggering/` (vendoring notes in `VENDORED.md`) |
+| Triaging an actual user feedback zip (per-platform setup + click-paths) | [`docs/feedback-workflow.md`](feedback-workflow.md) — superseded as the canonical flow by this doc |

--- a/docs/skill-lifecycle.md
+++ b/docs/skill-lifecycle.md
@@ -45,8 +45,8 @@ frontmatter limits, and any `scripts/` helper.
 **Pair, genealogist-led.** Run the harness one skill at a time:
 
 ```bash
-cd eval/harness
-uv run python run_tests.py --skill <skill>
+make eval-skill SKILL=<skill>     # from repo root: rebuilds the engine if stale, then runs
+# manual equivalent: cd eval/harness && uv run python run_tests.py --skill <skill>
 ```
 
 The harness drives the skill against mocked MCP tools in a seeded
@@ -206,7 +206,7 @@ does not edit files itself.
 
 **To try the skill-improver on skill `X`:** it needs an *active* run log
 (its snapshot matches the working tree) that is *annotated*. So first
-`uv run python run_tests.py --skill X` on current code, annotate that
+`make eval-skill SKILL=X` (it rebuilds the engine first) on current code, annotate that
 candidate in the CRUD UI, then in Claude Code ask to "use the
 skill-improver agent on X". Against a stale or unannotated run log it
 returns no edits and asks you to re-run — that is correct behavior, not a

--- a/docs/skill-lifecycle.md
+++ b/docs/skill-lifecycle.md
@@ -176,9 +176,9 @@ make optimize-skill SKILL=<skill>   # build the query set from the tests, then r
 It tunes the **description only** — it never runs the skill or an MCP tool.
 Apply the proposed `best_description` as a human-reviewed SKILL.md edit. Plan:
 [`docs/plan/skill-mcp-optimization-plan.md`](plan/skill-mcp-optimization-plan.md);
-vendoring notes: `eval/triggering/VENDORED.md`. (Folding the optimizer's output
-into `eval/runlogs/optimizer/` is a planned fast-follow; today it prints
-`best_description` + an HTML report.)
+vendoring notes: `eval/triggering/VENDORED.md`. Output (`results.json` + an HTML
+report) lands in `eval/runlogs/optimizer/<ts>/`, which is excluded from the
+release gate and comparisons.
 
 **Co-tune the two.** A body change can invalidate the old description's
 triggers, and a skill that never activates can't be body-improved. After

--- a/docs/skill-lifecycle.md
+++ b/docs/skill-lifecycle.md
@@ -120,10 +120,12 @@ body-located cause becomes SKILL.md prose. Either way the discipline is the same
   that only helps the Flynn scenario is a regression in disguise. This —
   not a statistical hold-out — is the primary overfitting guard at our
   test counts.
-- **Hold out a few tests.** Mark ~2–3 of the skill's tests `holdout: true`
-  (see the test schema). The improver never reads them while forming an
-  edit; they exist only to check the edit helped cases it wasn't written
-  from. Keep them stable — don't rewrite a holdout test to make it pass.
+- **Hold out a few tests.** Mark ~2–3 of the skill's tests as holdout —
+  flip the **"Hold out from the skill-improver"** switch on each test in
+  the CRUD UI (it sets `holdout: true`; no need to hand-edit JSON). The
+  improver never reads them while forming an edit; they exist only to
+  check the edit helped cases it wasn't written from. Keep them stable —
+  don't rewrite a holdout test to make it pass.
 - **Trust the human over the judge.** Where a correction comment
   disagrees with the judge, the comment governs the edit. Don't tune the
   skill toward judge quirks — that's the judge prompt's problem, on a
@@ -204,9 +206,10 @@ span:
 - **At least one hard case** — something the skill currently gets wrong.
   A corpus with no failures has nothing to improve against.
 
-Then mark **2–3 diverse, representative tests `holdout: true`** up front.
-Authoring the hold-out into the corpus now is far cheaper than carving it
-out after the improver has already been trained against everything.
+Then mark **2–3 diverse, representative tests as holdout** up front —
+toggle the "Hold out from the skill-improver" switch on each in the CRUD
+UI. Authoring the hold-out into the corpus now is far cheaper than carving
+it out after the improver has already been trained against everything.
 
 Keep `judge_context` / criteria **neutral** — grade the reasoning, not a
 preferred verdict (see `unit-test-spec.md` §5.4). A criterion the test's

--- a/docs/skill-lifecycle.md
+++ b/docs/skill-lifecycle.md
@@ -1,0 +1,231 @@
+# The skill lifecycle — authoring, testing, and improving genealogy skills
+
+This is the **start-here map** for the people who build and improve the
+genealogy skills: how a skill goes from an idea to a tested, released,
+continually-improved artifact. It orients you and points at the detailed
+docs — it does not restate them.
+
+The work is done by a **genealogist and a developer pairing.**
+Genealogists are learning to run tests; developers are learning
+genealogy. Neither role does the whole loop alone — the genealogist owns
+*what good looks like*, the developer owns *how the skill and harness
+work*, and they decide together at the points that matter.
+
+```
+        create ──► test ──► review & annotate ──► improve ──► release
+          ▲                                          │
+          └──────────────── (description optimize) ◄─┘
+```
+
+| Role | Owns | Across the lifecycle |
+|---|---|---|
+| **Genealogist** | Correctness — does the skill do genealogy right? | Writes tests + rubric, runs the harness, annotates grades, judges whether a proposed edit is *genealogically* correct, blesses releases. |
+| **Developer** | Mechanics — skills, scripts, harness, the loop. | Pairs on skill prose and scripts, runs the improver and the optimizer, builds the plugin, opens PRs, keeps the harness honest. |
+
+If you're brand new, read the two walkthroughs first:
+[`eval/JUNIOR-WALKTHROUGH.md`](../eval/JUNIOR-WALKTHROUGH.md) (genealogist)
+and [`eval/SENIOR-WALKTHROUGH.md`](../eval/SENIOR-WALKTHROUGH.md).
+
+---
+
+## The stages
+
+### 1. Create / edit a skill
+
+**Pair.** Write the SKILL.md to the prose standard in
+[`docs/skill-authoring-guide.md`](skill-authoring-guide.md); for a new
+tool-wrapping skill, scaffold it with the `cowork-skill-builder` agent
+first. Architecture questions (should this even be a skill? which
+category?) → [`docs/specs/skill-architecture-spec.md`](specs/skill-architecture-spec.md).
+The genealogist drives the domain content; the developer drives shape,
+frontmatter limits, and any `scripts/` helper.
+
+### 2. Test
+
+**Pair, genealogist-led.** Run the harness one skill at a time:
+
+```bash
+cd eval/harness
+uv run python run_tests.py --skill <skill>
+```
+
+The harness drives the skill against mocked MCP tools in a seeded
+scenario, an LLM judge grades each run, and it writes a candidate
+run-log. Format, fixtures, scenarios, exit codes: [`eval/README.md`](../eval/README.md)
+and [`docs/specs/unit-test-spec.md`](specs/unit-test-spec.md). Tests are
+**slow (~2–3 min each) and cost money** — scope every run to one skill,
+never run several invocations at once (they fight for memory and get
+killed).
+
+How to author a *good* test corpus is its own section below — it's the
+single biggest lever on whether the rest of the loop works.
+
+### 3. Review & annotate
+
+**Genealogist.** Open the CRUD UI (`cd eval/app && npm run dev`), read
+each run, and correct the judge's per-dimension scores into the
+`.ann.json` sibling. This is where human judgment enters the system, and
+it's what every later step trusts more than the raw judge score. The
+per-PR cadence is [`docs/plan/per-pr-review-workflow.md`](plan/per-pr-review-workflow.md);
+release/active/candidate mechanics are
+[`docs/plan/eval-runlog-versioning.md`](plan/eval-runlog-versioning.md).
+
+**Write correction comments a machine can act on.** A comment is the
+highest-signal input the improver gets, and "judge over-credited" is
+useless to it. Use three parts:
+
+> **Did:** what the skill actually did.
+> **Should:** what it should have done.
+> **Gap:** which SKILL.md guidance is missing, wrong, or being ignored.
+
+Example: *"Did: labeled the conflicting birthplaces a soft conflict.
+Should: a hard conflict — two primary informants disagree. Gap: the
+skill body never says primary-vs-primary disagreement is hard."* That
+comment is an edit waiting to happen; the first one isn't.
+
+### 4. Improve the skill body
+
+**Pair.** Cluster the failures across the skill's tests and revise the
+SKILL.md prose to fix them — explaining the *why*, not bolting on
+another MUST (see the authoring guide). Today this is the manual edit
+step in [`docs/feedback-workflow.md`](feedback-workflow.md); the
+**skill-improver** agent (report-only; see Status) assists by reading
+the latest annotated run-log, clustering, and proposing an evidence-cited
+diff for the pair to approve. Either way the discipline is the same:
+
+- **Generalize, don't patch the case.** The test is the question, not the
+  answer key. Ask "does this edit read as a general principle?" An edit
+  that only helps the Flynn scenario is a regression in disguise. This —
+  not a statistical hold-out — is the primary overfitting guard at our
+  test counts.
+- **Hold out a few tests.** Mark ~2–3 of the skill's tests `holdout: true`
+  (see the test schema). The improver never reads them while forming an
+  edit; they exist only to check the edit helped cases it wasn't written
+  from. Keep them stable — don't rewrite a holdout test to make it pass.
+- **Trust the human over the judge.** Where a correction comment
+  disagrees with the judge, the comment governs the edit. Don't tune the
+  skill toward judge quirks — that's the judge prompt's problem, on a
+  separate cadence.
+- **Subtract, too.** If a run shows the skill sending the model down
+  unproductive paths, delete the offending instruction. Net SKILL.md
+  length should trend flat or down, not always up.
+
+### 5. Verify the fix
+
+**Pair.** We are early in the cycle — **catching big problems, not
+polishing small ones** — so verification is cheap and qualitative, not a
+statistical bake-off:
+
+- **Re-run only the affected tests** while iterating (`--test <id>`);
+  reserve the full `--skill` run for the release candidate.
+- **One run is enough for a big fix.** A real problem is a dimension that
+  fails *consistently* (a 1, not a flicker); a single run sees that.
+  Don't require multiple runs to chase small score deltas you can't trust
+  — the harness has no `temperature=0`, so treat a sub-noise movement as
+  noise, not victory. (Bump `runs_per_test` only when you genuinely need
+  to measure a marginal change later.)
+- **Gate on the named problem, not the mean.** The question is "did the
+  dimension that was failing now pass, with nothing obvious regressing?"
+  — a binary a single run answers — not "did the weighted mean rise by
+  X."
+
+### 6. Release
+
+**Genealogist blesses, developer ships.** The GitHub Action requires the
+latest full-skill run-log to be active and fully annotated before the
+senior clicks Release. Mechanics: `eval/README.md` → "Run log naming"
+and the versioning plan.
+
+### 7. Optimize the description (separate, automated loop)
+
+**Developer.** The skill body (steps 4–6) and the skill *description* are
+two different loops. The description drives Cowork's auto-delegation and
+is tuned automatically by the description optimizer (a port of
+skill-creator's `run_loop`) against should-trigger / should-not-trigger
+query sets — which it can derive for free from the positive and negative
+tests you already wrote. Plan:
+[`docs/plan/skill-mcp-optimization-plan.md`](plan/skill-mcp-optimization-plan.md).
+Optimizer run-logs land in `eval/runlogs/optimizer/` (excluded from the
+release gate and comparisons).
+
+**Co-tune the two.** A body change can invalidate the old description's
+triggers, and a skill that never activates can't be body-improved. After
+a body edit lands, re-run the description optimizer; after a description
+change, re-run the body suite to confirm no behavioral regression. Do
+body first, then description.
+
+---
+
+## Authoring a test corpus that the loop can actually use
+
+Test *count* is a floor, not the goal — aim for **8–12 tests per skill**,
+but spend them on **coverage, not repetition**. Eight easy happy-path
+tests can't tell a good skill from a bad one. Each skill's set should
+span:
+
+- **Positive** — the skill should fire and do the task well (happy path
+  *and* messier variants).
+- **Negative / routing** — a near-miss that should go to a *different*
+  skill. Mine these from the "Do NOT use when…" clauses in the
+  description (see the authoring guide); build them from both directions
+  of each confusable pair.
+- **Edge cases** — the messy genealogy realities: conflicting records,
+  missing data, ambiguous places, multi-person households.
+- **At least one hard case** — something the skill currently gets wrong.
+  A corpus with no failures has nothing to improve against.
+
+Then mark **2–3 diverse, representative tests `holdout: true`** up front.
+Authoring the hold-out into the corpus now is far cheaper than carving it
+out after the improver has already been trained against everything.
+
+Keep `judge_context` / criteria **neutral** — grade the reasoning, not a
+preferred verdict (see `unit-test-spec.md` §5.4). A criterion the test's
+own author would only endorse if they reached one particular conclusion
+is leakage, and it's the biggest validity threat to LLM-as-judge.
+
+---
+
+## Is the loop working?
+
+The real metric isn't pass rate — it's whether the system **compounds.**
+If the pair keeps catching the *same class* of issue ten iterations in,
+the loop isn't learning: the fix belongs further upstream (a rubric
+dimension, a validator, the authoring guide), not in yet another
+case-specific prose patch. Promote recurring findings down a tier rather
+than re-fixing them. (`skill-mcp-optimization-plan.md` carries the
+promotion criteria.)
+
+## Status
+
+In place: the authoring guide; the harness + CRUD-UI review loop; the
+`holdout` test flag; a blocking frontmatter lint in CI; and the
+**skill-improver** agent — a report-only proposer that reads a skill's
+latest active, annotated run log and returns evidence-cited SKILL.md edits
+for the pairing developer to apply in-session, re-verify, and commit. It
+does not edit files itself.
+
+**To try the skill-improver on skill `X`:** it needs an *active* run log
+(its snapshot matches the working tree) that is *annotated*. So first
+`uv run python run_tests.py --skill X` on current code, annotate that
+candidate in the CRUD UI, then in Claude Code ask to "use the
+skill-improver agent on X". Against a stale or unannotated run log it
+returns no edits and asks you to re-run — that is correct behavior, not a
+failure. The developer applies the approved diffs, re-runs the affected
+tests, and the pair decides whether to keep them.
+
+Still to come: a rubric-quality critic, and the body↔description co-tune
+with the description optimizer. The manual edit path is
+[`docs/feedback-workflow.md`](feedback-workflow.md).
+
+## Doc index
+
+| You want to… | Read |
+|---|---|
+| Write a SKILL.md well | [`docs/skill-authoring-guide.md`](skill-authoring-guide.md) |
+| Understand skill architecture / categories | [`docs/specs/skill-architecture-spec.md`](specs/skill-architecture-spec.md) |
+| Run the harness / read a run-log | [`eval/README.md`](../eval/README.md) |
+| Write a test | [`docs/specs/unit-test-spec.md`](specs/unit-test-spec.md) |
+| Triage a user feedback report | [`docs/feedback-workflow.md`](feedback-workflow.md) |
+| Know the per-PR + release cadence | [`docs/plan/per-pr-review-workflow.md`](plan/per-pr-review-workflow.md), [`docs/plan/eval-runlog-versioning.md`](plan/eval-runlog-versioning.md) |
+| Understand the optimizers | [`docs/plan/skill-mcp-optimization-plan.md`](plan/skill-mcp-optimization-plan.md) |
+| Do your first PR (genealogist / senior) | [`eval/JUNIOR-WALKTHROUGH.md`](../eval/JUNIOR-WALKTHROUGH.md), [`eval/SENIOR-WALKTHROUGH.md`](../eval/SENIOR-WALKTHROUGH.md) |

--- a/docs/specs/eval-crud-ui-spec.md
+++ b/docs/specs/eval-crud-ui-spec.md
@@ -92,6 +92,7 @@ Form fields mapped to the unit test JSON schema (see `docs/specs/unit-test-spec.
 | type | Toggle: positive / negative | Controls which fields are shown |
 | description | Text area | |
 | tags | Tag input (autocomplete from existing tags) | |
+| holdout | Switch | Reserves the test as a skill-improver generalization check (schema default `false`). Off by default; only persisted when on. See `docs/skill-lifecycle.md`. |
 | user_message | Text area | |
 | scenario | Dropdown + "Create new" button | Shows scenario README description on hover/select |
 | scenario_notes | Text area (collapsible) | Shown when scenario doesn't exactly match |
@@ -102,7 +103,7 @@ Form fields mapped to the unit test JSON schema (see `docs/specs/unit-test-spec.
 
 The form displays the skill's rubric dimensions (from rubric.md) in a sidebar or info panel so the genealogist knows what's already covered and can write additional_criteria that don't duplicate the rubric.
 
-**Hash-change warning on edit.** When the junior edits an existing test and changes a grading-relevant field (`user_message`, `scenario`, `mcp_fixtures`, `additional_criteria`, `negative`), the UI shows an inline warning: "This edit changes the test's content hash — it will be excluded from cross-PR comparison for one PR. Continue?" Cosmetic edits (`name`, `description`, `tags`) don't trigger the warning. The warning is advisory only — the junior may proceed. The senior reviewing the PR sees the diff and decides whether to ask for a revert. Per plan §2.4.
+**Hash-change warning on edit.** When the junior edits an existing test and changes a grading-relevant field (`user_message`, `scenario`, `mcp_fixtures`, `additional_criteria`, `negative`, `holdout`), the UI shows an inline warning: "This edit changes the test's content hash — it will be excluded from cross-PR comparison for one PR. Continue?" Cosmetic edits (`name`, `description`, `tags`) don't trigger the warning. The warning is advisory only — the junior may proceed. The senior reviewing the PR sees the diff and decides whether to ask for a revert. Per plan §2.4.
 
 ### Validation
 

--- a/docs/specs/schemas/unit-test.schema.json
+++ b/docs/specs/schemas/unit-test.schema.json
@@ -39,6 +39,11 @@
           "items": { "type": "string" },
           "description": "Freeform tags for filtering and grouping. May be empty."
         },
+        "holdout": {
+          "type": "boolean",
+          "default": false,
+          "description": "Reserves this test as a generalization check for the skill-improvement loop. When true, the body-optimizer must not read or tune against this test when proposing SKILL.md edits — it consults holdout tests only to measure whether an edit generalized beyond the cases it was written from. The harness runs holdout tests like any other (they are still graded, annotated, and released); the flag governs only the improver's behavior. See docs/skill-lifecycle.md."
+        },
         "expected_outcome": {
           "type": "string",
           "enum": ["pass", "xfail"],

--- a/docs/specs/unit-test-spec.md
+++ b/docs/specs/unit-test-spec.md
@@ -321,6 +321,11 @@ The machine-readable schema lives at [`docs/specs/schemas/unit-test.schema.json`
           "items": { "type": "string" },
           "description": "Freeform tags for filtering and grouping. May be empty."
         },
+        "holdout": {
+          "type": "boolean",
+          "default": false,
+          "description": "Reserves this test as a generalization check for the skill-improvement loop. The body-optimizer must not read or tune against it; it is consulted only to measure whether an edit generalized. The harness runs holdout tests like any other. See docs/skill-lifecycle.md."
+        },
         "expected_outcome": {
           "type": "string",
           "enum": ["pass", "xfail"],
@@ -442,6 +447,7 @@ The machine-readable schema lives at [`docs/specs/schemas/unit-test.schema.json`
 | `type` | string | yes | `"positive"` or `"negative"`. Determines which other fields are present |
 | `description` | string | yes | 1-2 sentences explaining what this test verifies and why it matters |
 | `tags` | string[] | yes | Freeform tags for filtering and grouping. May be empty. The UI uses these for filtering the test list. Useful tag dimensions: record type (`census`, `vital-record`, `probate`), time period (`1850`, `1860`), GPS concept (`informant-weighting`, `independence`, `negative-evidence`), test pattern (`near-miss`, `multi-person`, `stateless`) |
+| `holdout` | boolean | no | `false` (default) or `true`. Reserves this test as a generalization check for the skill-improvement loop. The body-optimizer never reads a holdout test when proposing a SKILL.md edit — it consults holdout tests only afterward, to confirm the edit helped cases it was not written from. The harness runs holdout tests like any other; the flag governs only the improver. Mark ~2-3 of a skill's tests holdout (diverse, representative ones — not the easy ones), and keep them stable across iterations. See `docs/skill-lifecycle.md` |
 | `expected_outcome` | string | no | `"pass"` (default) or `"xfail"`. Marks a known-failing test. xfail tests still run; their failures aggregate to `outcome: xfail` (expected, not a regression). If an xfail test starts passing, the run reports `outcome: xpass` so the marker can be removed |
 | `xfail_reason` | string | conditional | Required when `expected_outcome` is `"xfail"`. Brief explanation, ideally with an issue link and a removal condition (e.g., "blocked on #312; remove when fixed") |
 

--- a/eval/CLAUDE.md
+++ b/eval/CLAUDE.md
@@ -105,6 +105,8 @@ Every run log embeds a `snapshot: {repo-relative-path: normalized content}` bloc
 - referenced `eval/fixtures/mcp/<name>.json`
 - `packages/engine/mcp-server/src/**` (all MCP tool source — conservative: changes to any shared util can affect any tool's behavior, so the whole tree is tracked rather than a per-skill subset)
 
+By design this is conservative: editing **any** file under the skill dir — including a `references/` doc or even a comment — flips prior run logs inactive and forces a re-run. That is intentional (decided 2026-06): a reference-doc change can change behavior, and a cheap re-run is the price of a trustworthy active-state check; docs and comments are **not** excluded from the snapshot.
+
 `eval/harness/judge/prompt.md` is **not** in the snapshot — it's project-global and gets a separate `judge_prompt_hash` field. This keeps "activate this run log" a per-skill operation; activating skill A's v1 doesn't clobber skill B's judge calibration.
 
 Normalization rules (shared with `eval/app/lib/snapshot.ts`):

--- a/eval/README.md
+++ b/eval/README.md
@@ -57,6 +57,10 @@ or missing":
 cd packages/engine/mcp-server && npm install && npm run build
 ```
 
+Or skip the manual build: from the repo root, **`make eval-skill SKILL=<name>`**
+rebuilds the engine only when its source changed, then runs the harness for that
+skill (a releasable full-skill run). The steps below are the manual equivalent.
+
 ```bash
 cd eval/harness
 
@@ -175,7 +179,7 @@ The CRUD UI's run-log detail page (`/results/<skill>/<filename-without-ext>`) is
 See [`docs/plan/eval-runlog-versioning.md`](../docs/plan/eval-runlog-versioning.md) for the canonical release/active/candidate workflow and [`docs/plan/per-pr-review-workflow.md`](../docs/plan/per-pr-review-workflow.md) for the per-PR cadence. Short version:
 
 1. Junior edits a skill / tests / scenarios / fixtures.
-2. Junior runs `uv run python run_tests.py --skill <skill>` → harness writes a `v{N}_<ts>.json` candidate.
+2. Junior runs `make eval-skill SKILL=<skill>` (or `cd eval/harness && uv run python run_tests.py --skill <skill>`) → harness writes a `v{N}_<ts>.json` candidate.
 3. Junior opens the CRUD UI, reviews every dimension on the latest candidate (sparse `.ann.json` becomes complete).
 4. Junior commits the candidate + annotation, pushes the PR.
 5. GH Action enforces (blocking): ≤1 added released file, latest full-skill run log is active on skill-side files (snapshot matches working tree), and its `.ann.json` is complete. Two warn-only checks also run and do not block merge: tool-coverage drift (`check_tool_coverage.py` — a skill declaring a tool with no fixture) and a judge-prompt-hash match (rule 2b).

--- a/eval/README.md
+++ b/eval/README.md
@@ -2,6 +2,8 @@
 
 Systematic evaluation of Cowork Genealogy skills. Tests live as version-controlled JSON; the harness runs them against the Claude Agent SDK; an LLM judge grades each run; humans verify the grades through the CRUD UI. See [`docs/gps/skill-mcp-testing-plan.md`](../docs/gps/skill-mcp-testing-plan.md) for the strategic plan, [`docs/specs/unit-test-spec.md`](../docs/specs/unit-test-spec.md) for the test format, and [`docs/plan/eval-runlog-versioning.md`](../docs/plan/eval-runlog-versioning.md) for the run-log versioning and release workflow.
 
+New to how skills are built, tested, and improved? Start with the lifecycle map: [`docs/skill-lifecycle.md`](../docs/skill-lifecycle.md).
+
 ## Directory layout
 
 ```

--- a/eval/app/app/tests/page.tsx
+++ b/eval/app/app/tests/page.tsx
@@ -196,9 +196,18 @@ function TestsListInner() {
                     </Text>
                   </Table.Td>
                   <Table.Td>
-                    <Badge variant="outline" color={t.type === 'positive' ? 'blue' : 'gray'}>
-                      {t.type}
-                    </Badge>
+                    <Group gap={4} wrap="wrap">
+                      <Badge variant="outline" color={t.type === 'positive' ? 'blue' : 'gray'}>
+                        {t.type}
+                      </Badge>
+                      {t.holdout ? (
+                        <Tooltip label="Reserved as a skill-improver generalization check" withArrow>
+                          <Badge variant="outline" color="grape">
+                            holdout
+                          </Badge>
+                        </Tooltip>
+                      ) : null}
+                    </Group>
                   </Table.Td>
                   <Table.Td>
                     <Text size="sm">{t.scenario ?? <Text component="span" c="dimmed">—</Text>}</Text>

--- a/eval/app/components/forms/TestForm.tsx
+++ b/eval/app/components/forms/TestForm.tsx
@@ -31,6 +31,7 @@ import {
   MultiSelect,
   Select,
   Stack,
+  Switch,
   TagsInput,
   Text,
   TextInput,
@@ -77,6 +78,10 @@ function hasGradingRelevantChange(before: UnitTestFile, after: UnitTestFile): bo
   if (JSON.stringify(before.mcp_fixtures ?? []) !== JSON.stringify(after.mcp_fixtures ?? [])) return true;
   if (JSON.stringify(before.judge_context) !== JSON.stringify(after.judge_context)) return true;
   if (JSON.stringify(before.negative ?? null) !== JSON.stringify(after.negative ?? null)) return true;
+  // holdout survives snapshot normalization (only name/description/tags are
+  // stripped), so toggling it changes the content hash. Keep this in sync with
+  // GRADING_RELEVANT_FIELDS in lib/fs/tests.ts.
+  if ((before.test.holdout ?? false) !== (after.test.holdout ?? false)) return true;
   return false;
 }
 
@@ -192,6 +197,10 @@ export function TestForm({ mode, initialValues, onSaved }: TestFormProps) {
     } else {
       delete payload.negative;
     }
+    // holdout defaults to false (schema default) — only persist the key when
+    // true, so existing tests that never opted in keep their content hash.
+    if (payload.test.holdout) payload.test.holdout = true;
+    else delete payload.test.holdout;
     // Empty string scenarios → null so the API/file shape matches the schema.
     if (payload.input.scenario === '') payload.input.scenario = null;
     if (payload.input.scenario_notes === '') payload.input.scenario_notes = null;
@@ -273,6 +282,12 @@ export function TestForm({ mode, initialValues, onSaved }: TestFormProps) {
                   acceptValueOnBlur
                   clearable
                   splitChars={[',']}
+                />
+                <Switch
+                  label="Hold out from the skill-improver"
+                  description="Reserve this test as a generalization check. The body-optimizer won't read or tune against it when proposing SKILL.md edits — it only checks afterward whether the edit helped. The harness still runs, grades, and releases it like any other test. Mark ~2–3 diverse, representative tests and keep them stable."
+                  checked={!!form.values.test.holdout}
+                  onChange={(e) => form.setFieldValue('test.holdout', e.currentTarget.checked)}
                 />
               </Stack>
             </Card>

--- a/eval/app/lib/fs/tests.ts
+++ b/eval/app/lib/fs/tests.ts
@@ -56,6 +56,7 @@ function toListEntry(test: UnitTestFile, filePath: string, blocked: BlockedReaso
     type: test.test.type,
     description: test.test.description,
     tags: test.test.tags,
+    holdout: test.test.holdout ?? false,
     scenario: test.input.scenario ?? null,
     mcpFixtures: test.mcp_fixtures ?? [],
     filePath,
@@ -207,6 +208,13 @@ export async function nextTestId(skill: string): Promise<string> {
  * Fields whose change invalidates the content hash (per spec §3 and
  * plan §2.4). Used by the edit form to decide whether to show the
  * "content-changed" warning.
+ *
+ * `test.holdout` is included because the snapshot normalization strips
+ * only the cosmetic `test.{name,description,tags}` — holdout survives
+ * into the snapshot, so flipping it changes the content hash and flips
+ * the active run log inactive (forces a re-run), even though it never
+ * changes grading. (It governs only the skill-improver's behavior; see
+ * docs/skill-lifecycle.md.)
  */
 export const GRADING_RELEVANT_FIELDS = [
   'input.user_message',
@@ -214,6 +222,7 @@ export const GRADING_RELEVANT_FIELDS = [
   'mcp_fixtures',
   'judge_context',
   'negative',
+  'test.holdout',
 ] as const;
 
 /** True if any grading-relevant field differs between `before` and `after`. */
@@ -223,5 +232,6 @@ export function hasGradingRelevantChange(before: UnitTestFile, after: UnitTestFi
   if (JSON.stringify(before.mcp_fixtures ?? []) !== JSON.stringify(after.mcp_fixtures ?? [])) return true;
   if (JSON.stringify(before.judge_context) !== JSON.stringify(after.judge_context)) return true;
   if (JSON.stringify(before.negative ?? null) !== JSON.stringify(after.negative ?? null)) return true;
+  if ((before.test.holdout ?? false) !== (after.test.holdout ?? false)) return true;
   return false;
 }

--- a/eval/app/lib/types.ts
+++ b/eval/app/lib/types.ts
@@ -20,6 +20,7 @@ export interface UnitTestFile {
     type: UnitTestType;
     description: string;
     tags: string[];
+    holdout?: boolean;
     expected_outcome?: ExpectedOutcome;
     xfail_reason?: string;
   };
@@ -249,6 +250,7 @@ export interface UnitTestListEntry {
   type: UnitTestType;
   description: string;
   tags: string[];
+  holdout: boolean;
   scenario: string | null;
   mcpFixtures: string[];
   filePath: string;

--- a/eval/app/tests/fs/tests.test.ts
+++ b/eval/app/tests/fs/tests.test.ts
@@ -88,6 +88,20 @@ describe('tests — listTests', () => {
     await handle2.cleanup();
   });
 
+  it('surfaces holdout on the list entry (default false, true when set)', async () => {
+    const handle2 = await makeFixtureTree({
+      tests: [
+        { skill: 'locality-guide', filename: 'plain.json', body: makeTest({ id: 'ut_locality_guide_001', skill: 'locality-guide' }) },
+        { skill: 'locality-guide', filename: 'held.json', body: makeTest({ id: 'ut_locality_guide_002', skill: 'locality-guide', test: { id: 'ut_locality_guide_002', skill: 'locality-guide', name: 'held', type: 'positive', description: 'd', tags: [], holdout: true } }) },
+      ],
+    });
+    process.env.EVAL_DIR = handle2.root;
+    const { tests } = await listTests();
+    expect(tests.find((t) => t.id === 'ut_locality_guide_001')?.holdout).toBe(false);
+    expect(tests.find((t) => t.id === 'ut_locality_guide_002')?.holdout).toBe(true);
+    await handle2.cleanup();
+  });
+
   it('flags blocked when scenario_notes present', async () => {
     const handle2 = await makeFixtureTree({
       tests: [
@@ -175,5 +189,19 @@ describe('tests — hasGradingRelevantChange', () => {
     const a = makeTest({ judge_context: ['a'] });
     const b = makeTest({ judge_context: ['a', 'b'] });
     expect(hasGradingRelevantChange(a, b)).toBe(true);
+  });
+
+  it('detects holdout toggle (it survives snapshot normalization)', () => {
+    const a = makeTest({});
+    const b = JSON.parse(JSON.stringify(a)) as UnitTestFile;
+    b.test.holdout = true;
+    expect(hasGradingRelevantChange(a, b)).toBe(true);
+  });
+
+  it('treats absent holdout and explicit false as equivalent', () => {
+    const a = makeTest({});
+    const b = JSON.parse(JSON.stringify(a)) as UnitTestFile;
+    b.test.holdout = false;
+    expect(hasGradingRelevantChange(a, b)).toBe(false);
   });
 });

--- a/eval/fixtures/scenarios/mid-research-flynn-1880-found/README.md
+++ b/eval/fixtures/scenarios/mid-research-flynn-1880-found/README.md
@@ -1,0 +1,32 @@
+# mid-research-flynn-1880-found
+
+**DRAFT variant of `mid-research-flynn` — genealogist review needed.**
+
+Same mid-project Patrick Flynn parentage research as `mid-research-flynn`, with one
+difference: the **1880 census has just been located and logged (plan item `pli_007`,
+log entry `log_006`) but NOT yet extracted** — there are no 1880 assertions, sources,
+or tree facts. It encodes the "found, awaiting extraction" state.
+
+Used by `ut_tree_edit_003` (negative test): the user says *"I just found the 1880
+census… add the facts to the tree,"* and tree-edit should **decline** and route to
+record-extraction (facts flow extraction → proof-conclusion → tree, never directly
+from a raw record).
+
+> ⚠️ **Placeholder.** The 1880 household in `log_006`'s notes (Patrick as head of
+> household, ~35, Schuylkill County) is invented scaffolding. A genealogist should
+> set the real household composition, ages, and 1880 relationship-column detail —
+> then re-run `--skill tree-edit` and re-annotate — before this is released.
+
+- **Objective:** Identify the parents of Patrick Flynn (b. ~1845, d. 1908)
+- **Questions:** q_001 (parentage, in_progress), q_002 (1850 census placement, resolved)
+- **Plans:** pl_001 (1850 census, completed), pl_002 (parentage evidence, active — now incl. `pli_007`, 1880 census)
+- **Log:** 6 entries — 1850 (FS/Ancestry/MyHeritage), 1860, death cert, **1880 census found (`log_006`, unextracted)**
+- **Sources:** 4 (no 1880 source yet — created at extraction)
+- **Assertions:** 13 (no 1880 assertions yet — extraction pending)
+- **Person evidence:** 6 links (Patrick → I1, Thomas → I2)
+- **Conflicts:** 1 resolved (birthplace: Ireland vs Pennsylvania)
+- **Hypotheses:** h_001 (Thomas is Patrick's father, supported)
+- **Timelines:** t_001 (Patrick, 4 events, 1 gap)
+- **Proof summaries:** ps_001 (parentage, probable; note updated: 1880 located, extraction pending)
+- **GedcomX persons:** I1 (Patrick Flynn), I2 (Thomas Flynn)
+- **GedcomX relationships:** R1 (ParentChild, Thomas → Patrick)

--- a/eval/fixtures/scenarios/mid-research-flynn-1880-found/research.json
+++ b/eval/fixtures/scenarios/mid-research-flynn-1880-found/research.json
@@ -1,0 +1,836 @@
+{
+  "project": {
+    "id": "rp_001",
+    "objective": "Identify the parents of Patrick Flynn, born ca. 1845 in Pennsylvania, died 1908 in Schuylkill County, PA",
+    "subject_person_ids": [
+      "I1"
+    ],
+    "status": "active",
+    "created": "2026-05-01",
+    "updated": "2026-05-04"
+  },
+  "questions": [
+    {
+      "id": "q_001",
+      "question": "Who were the parents of Patrick Flynn (b. ~1845, PA, d. 1908)?",
+      "rationale": "This is the primary research objective.",
+      "selection_basis": "objective_decomposition",
+      "priority": "high",
+      "status": "in_progress",
+      "depends_on": [],
+      "unblocks": [],
+      "created": "2026-05-01",
+      "resolved": null,
+      "resolution_assertion_ids": [],
+      "exhaustive_declaration": {
+        "declared": false,
+        "justification": null,
+        "log_entry_ids": [],
+        "stop_criteria": null
+      }
+    },
+    {
+      "id": "q_002",
+      "question": "Where was Patrick Flynn in the 1850 census?",
+      "rationale": "The 1850 census is the earliest enumeration where Patrick would appear by name (age ~5). Locating him in a household identifies candidate parents.",
+      "selection_basis": "objective_decomposition",
+      "priority": "high",
+      "status": "resolved",
+      "depends_on": [],
+      "unblocks": [
+        "q_001"
+      ],
+      "created": "2026-05-01",
+      "resolved": "2026-05-02",
+      "resolution_assertion_ids": [
+        "a_001",
+        "a_002",
+        "a_003"
+      ],
+      "exhaustive_declaration": {
+        "declared": true,
+        "justification": "Searched 1850 census for Schuylkill County on FamilySearch (indexed and browse), Ancestry (indexed), and MyHeritage (indexed). All three returned the same household. No other Patrick Flynn of matching age found in the county.",
+        "log_entry_ids": [
+          "log_001",
+          "log_002",
+          "log_003"
+        ],
+        "stop_criteria": {
+          "goal_alignment": "Yes \u2014 Patrick Flynn located in a specific 1850 household, answering the question.",
+          "repository_breadth": "Three major repositories searched (FamilySearch, Ancestry, MyHeritage). No additional known indexes of the 1850 Schuylkill County census exist.",
+          "original_substitution": "FamilySearch provides the original census image; Ancestry index is derivative but confirmed consistent.",
+          "independent_verification": "FamilySearch (original) and Ancestry (derivative) both return the same household. Two access paths, one underlying original.",
+          "evidence_class": "Yes \u2014 FamilySearch provides original census image with indeterminate-quality information.",
+          "conflict_resolution": "No conflicts on the 1850 census placement question.",
+          "overturn_risk": "Low \u2014 all three repositories agree, and no competing Patrick Flynn of matching age exists in the county."
+        }
+      }
+    }
+  ],
+  "plans": [
+    {
+      "id": "pl_001",
+      "question_id": "q_002",
+      "status": "completed",
+      "created": "2026-05-01",
+      "items": [
+        {
+          "id": "pli_001",
+          "sequence": 1,
+          "record_type": "census",
+          "jurisdiction": "Schuylkill County, Pennsylvania",
+          "date_range": "1850",
+          "repository": "FamilySearch",
+          "rationale": "1850 census fully indexed on FamilySearch. Free access, start here.",
+          "fallback_for": null,
+          "status": "completed"
+        },
+        {
+          "id": "pli_002",
+          "sequence": 2,
+          "record_type": "census",
+          "jurisdiction": "Schuylkill County, Pennsylvania",
+          "date_range": "1850",
+          "repository": "Ancestry",
+          "rationale": "Ancestry has independent indexing; cross-check for transcription errors.",
+          "fallback_for": null,
+          "status": "completed"
+        },
+        {
+          "id": "pli_003",
+          "sequence": 3,
+          "record_type": "census",
+          "jurisdiction": "Schuylkill County, Pennsylvania",
+          "date_range": "1850",
+          "repository": "MyHeritage",
+          "rationale": "Third independent index for coverage confirmation.",
+          "fallback_for": null,
+          "status": "completed"
+        }
+      ]
+    },
+    {
+      "id": "pl_002",
+      "question_id": "q_001",
+      "status": "active",
+      "created": "2026-05-02",
+      "items": [
+        {
+          "id": "pli_004",
+          "sequence": 1,
+          "record_type": "census",
+          "jurisdiction": "Schuylkill County, Pennsylvania",
+          "date_range": "1860",
+          "repository": "FamilySearch",
+          "rationale": "Confirm Patrick still in Thomas Flynn household in 1860. Strengthens parent-child identification.",
+          "fallback_for": null,
+          "status": "completed"
+        },
+        {
+          "id": "pli_005",
+          "sequence": 2,
+          "record_type": "vital_record",
+          "jurisdiction": "Schuylkill County, Pennsylvania",
+          "date_range": "1908",
+          "repository": "FamilySearch",
+          "rationale": "Death certificate may name parents directly.",
+          "fallback_for": null,
+          "status": "completed"
+        },
+        {
+          "id": "pli_006",
+          "sequence": 3,
+          "record_type": "probate",
+          "jurisdiction": "Schuylkill County, Pennsylvania",
+          "date_range": "1870-1890",
+          "repository": "FamilySearch",
+          "rationale": "Thomas Flynn probate/will may name Patrick as son.",
+          "fallback_for": null,
+          "status": "in_progress"
+        },
+        {
+          "id": "pli_007",
+          "sequence": 4,
+          "record_type": "census",
+          "jurisdiction": "Schuylkill County, Pennsylvania",
+          "date_range": "1880",
+          "repository": "FamilySearch",
+          "rationale": "1880 census introduces an explicit relationship column; may state Patrick's household relationships directly. [DRAFT variant \u2014 genealogist review]",
+          "fallback_for": null,
+          "status": "completed"
+        }
+      ]
+    }
+  ],
+  "log": [
+    {
+      "id": "log_001",
+      "plan_item_id": "pli_001",
+      "performed": "2026-05-01T10:15:00Z",
+      "tool": "record_search",
+      "query": {
+        "surname": "Flynn",
+        "given": "Patrick",
+        "birth_year": 1845,
+        "birth_place": "Pennsylvania",
+        "collection": "1850 Census"
+      },
+      "outcome": "positive",
+      "results_examined": 8,
+      "notes": "Found Patrick Flynn age 5 in household of Thomas Flynn, dwelling 84, Schuylkill Co. Three other Flynn results examined \u2014 ages and locations don't match.",
+      "external_site": null
+    },
+    {
+      "id": "log_002",
+      "plan_item_id": "pli_002",
+      "performed": "2026-05-01T11:30:00Z",
+      "tool": "external_site",
+      "query": {
+        "surname": "Flynn",
+        "given": "Patrick",
+        "birth_year": 1845,
+        "birth_place": "Pennsylvania"
+      },
+      "outcome": "positive",
+      "results_examined": 12,
+      "notes": "Ancestry index confirms same household. Transcription matches FamilySearch except Ancestry reads dwelling as 84, FamilySearch as 84 \u2014 consistent.",
+      "external_site": {
+        "site": "ancestry",
+        "url_generated": "https://www.ancestry.com/search/collections/8054/?name=Patrick_Flynn&birth=1845&birthplace=Pennsylvania",
+        "capture_received": true,
+        "capture_filename": "ancestry-1850-flynn-results.pdf"
+      }
+    },
+    {
+      "id": "log_003",
+      "plan_item_id": "pli_003",
+      "performed": "2026-05-01T14:00:00Z",
+      "tool": "external_site",
+      "query": {
+        "surname": "Flynn",
+        "given": "Patrick",
+        "birth_year": 1845,
+        "birth_place": "Pennsylvania"
+      },
+      "outcome": "negative",
+      "results_examined": 0,
+      "notes": "MyHeritage returned no results for Patrick Flynn in 1850 Schuylkill County. Site may not have this collection indexed. Searched broader Pennsylvania \u2014 still no match.",
+      "external_site": {
+        "site": "myheritage",
+        "url_generated": "https://www.myheritage.com/research?action=query&first=Patrick&last=Flynn&birth_year=1845&birth_place=Pennsylvania",
+        "capture_received": true,
+        "capture_filename": "myheritage-1850-flynn-nil.pdf"
+      }
+    },
+    {
+      "id": "log_004",
+      "plan_item_id": "pli_004",
+      "performed": "2026-05-02T09:00:00Z",
+      "tool": "record_search",
+      "query": {
+        "surname": "Flynn",
+        "given": "Patrick",
+        "birth_year": 1845,
+        "birth_place": "Pennsylvania",
+        "collection": "1860 Census"
+      },
+      "outcome": "positive",
+      "results_examined": 5,
+      "notes": "Patrick Flynn age 15 in household of Thomas Flynn, Schuylkill Co. Consistent with 1850 placement.",
+      "external_site": null
+    },
+    {
+      "id": "log_005",
+      "plan_item_id": "pli_005",
+      "performed": "2026-05-03T10:00:00Z",
+      "tool": "record_search",
+      "query": {
+        "surname": "Flynn",
+        "given": "Patrick",
+        "death_year": 1908,
+        "death_place": "Schuylkill County, Pennsylvania"
+      },
+      "outcome": "positive",
+      "results_examined": 2,
+      "notes": "Death certificate found. Names Thomas Flynn as father. Informant was son-in-law James Brown.",
+      "external_site": null
+    },
+    {
+      "id": "log_006",
+      "plan_item_id": "pli_007",
+      "performed": "2026-05-04T09:00:00Z",
+      "tool": "record_search",
+      "query": {
+        "surname": "Flynn",
+        "given": "Patrick",
+        "birth_year": 1845,
+        "birth_place": "Ireland",
+        "collection": "1880 Census"
+      },
+      "outcome": "positive",
+      "results_examined": 3,
+      "notes": "DRAFT (genealogist review). Found Patrick Flynn, age ~35, head of household in Schuylkill County, PA (1880 census states relationships explicitly). Record LOCATED but NOT yet extracted \u2014 facts pending record-extraction. Household composition is a placeholder pending genealogist verification.",
+      "external_site": null
+    }
+  ],
+  "sources": [
+    {
+      "id": "src_001",
+      "gedcomx_source_description_id": "S1",
+      "citation": "1850 U.S. Census, Schuylkill County, Pennsylvania, population schedule, dwelling 84, family 91, Thomas Flynn household; NARA microfilm publication M432, roll 810; digital image, FamilySearch.org, accessed 1 May 2026.",
+      "citation_detail": {
+        "who": "U.S. Census Bureau",
+        "what": "1850 U.S. Federal Census, population schedule",
+        "when_created": "1850",
+        "when_accessed": "2026-05-01",
+        "where": "FamilySearch.org (NARA microfilm M432, roll 810)",
+        "where_within": "Schuylkill County, dwelling 84, family 91"
+      },
+      "source_classification": "original",
+      "repository": "FamilySearch",
+      "access_date": "2026-05-01",
+      "url": "https://www.familysearch.org/ark:/61903/1:1:MXYZ",
+      "url_archived": null,
+      "notes": "Image quality good. Enumerator handwriting clear.",
+      "log_entry_id": "log_001"
+    },
+    {
+      "id": "src_002",
+      "gedcomx_source_description_id": "S1",
+      "citation": "1850 U.S. Census, Schuylkill County, Pennsylvania, population schedule, dwelling 84, Thomas Flynn household; digital image, Ancestry.com, accessed 1 May 2026.",
+      "citation_detail": {
+        "who": "U.S. Census Bureau",
+        "what": "1850 U.S. Federal Census, population schedule (Ancestry index)",
+        "when_created": "1850",
+        "when_accessed": "2026-05-01",
+        "where": "Ancestry.com",
+        "where_within": "Schuylkill County, dwelling 84"
+      },
+      "source_classification": "derivative",
+      "repository": "Ancestry",
+      "access_date": "2026-05-01",
+      "url": null,
+      "url_archived": null,
+      "notes": "Ancestry's index of the same original census. Transcription consistent with FamilySearch.",
+      "log_entry_id": "log_002"
+    },
+    {
+      "id": "src_003",
+      "gedcomx_source_description_id": "S2",
+      "citation": "1860 U.S. Census, Schuylkill County, Pennsylvania, population schedule, dwelling 112, family 119, Thomas Flynn household; NARA microfilm publication M653, roll 1141; digital image, FamilySearch.org, accessed 2 May 2026.",
+      "citation_detail": {
+        "who": "U.S. Census Bureau",
+        "what": "1860 U.S. Federal Census, population schedule",
+        "when_created": "1860",
+        "when_accessed": "2026-05-02",
+        "where": "FamilySearch.org (NARA microfilm M653, roll 1141)",
+        "where_within": "Schuylkill County, dwelling 112, family 119"
+      },
+      "source_classification": "original",
+      "repository": "FamilySearch",
+      "access_date": "2026-05-02",
+      "url": "https://www.familysearch.org/ark:/61903/1:1:MABC",
+      "url_archived": null,
+      "notes": null,
+      "log_entry_id": "log_004"
+    },
+    {
+      "id": "src_004",
+      "gedcomx_source_description_id": "S3",
+      "citation": "Pennsylvania Department of Health, death certificate no. 4521 (1908), Patrick Flynn; Pennsylvania State Archives, Harrisburg; digital image, FamilySearch.org, accessed 3 May 2026.",
+      "citation_detail": {
+        "who": "Pennsylvania Department of Health; informant: James Brown (son-in-law)",
+        "what": "Death certificate no. 4521",
+        "when_created": "1908-03-14",
+        "when_accessed": "2026-05-03",
+        "where": "FamilySearch.org (Pennsylvania State Archives, Harrisburg)",
+        "where_within": "Certificate no. 4521"
+      },
+      "source_classification": "original",
+      "repository": "FamilySearch",
+      "access_date": "2026-05-03",
+      "url": "https://www.familysearch.org/ark:/61903/1:1:MDEF",
+      "url_archived": null,
+      "notes": "Informant is son-in-law James Brown. Primary for death facts, secondary for birth facts.",
+      "log_entry_id": "log_005"
+    }
+  ],
+  "assertions": [
+    {
+      "id": "a_001",
+      "source_id": "src_001",
+      "record_id": "ark:/61903/1:1:MXYZ",
+      "record_role": "child_1",
+      "fact_type": "name",
+      "value": "Patrick Flynn",
+      "structured_value": {
+        "given": "Patrick",
+        "surname": "Flynn"
+      },
+      "date": null,
+      "date_certainty": null,
+      "place": null,
+      "information_quality": "indeterminate",
+      "informant": "Unknown household member reporting to census enumerator",
+      "informant_proximity": "unknown",
+      "informant_bias_notes": "Census enumerator is the recorder, not the informant. The household member who provided the name is unknown. Proximity is 'unknown' rather than 'household_member' because for names specifically, the enumerator may have read a sign, heard a neighbor, or made an assumption \u2014 the name fact doesn't necessarily require active reporting the way age/birthplace does.",
+      "evidence_type": "direct",
+      "log_entry_id": "log_001",
+      "extracted_for_question_ids": [
+        "q_002"
+      ]
+    },
+    {
+      "id": "a_002",
+      "source_id": "src_001",
+      "record_id": "ark:/61903/1:1:MXYZ",
+      "record_role": "child_1",
+      "fact_type": "birth",
+      "value": "age 5",
+      "structured_value": {
+        "year": 1845,
+        "place": "Ireland"
+      },
+      "date": "~1845",
+      "date_certainty": "estimated",
+      "place": "Ireland",
+      "information_quality": "indeterminate",
+      "informant": "Unknown household member (likely Thomas Flynn or wife)",
+      "informant_proximity": "household_member",
+      "informant_bias_notes": "Age and birthplace require active reporting by a household member \u2014 someone had to tell the enumerator these facts. Proximity is 'household_member' rather than 'unknown' because these facts could only come from someone in the household.",
+      "evidence_type": "indirect",
+      "log_entry_id": "log_001",
+      "extracted_for_question_ids": [
+        "q_002"
+      ]
+    },
+    {
+      "id": "a_003",
+      "source_id": "src_001",
+      "record_id": "ark:/61903/1:1:MXYZ",
+      "record_role": "child_1",
+      "fact_type": "residence",
+      "value": "Schuylkill County, Pennsylvania",
+      "date": "1850",
+      "date_certainty": "exact",
+      "place": "Schuylkill County, Pennsylvania",
+      "information_quality": "primary",
+      "informant": "Census enumerator (witness to residence by visiting the dwelling)",
+      "informant_proximity": "witness",
+      "informant_bias_notes": "For residence facts specifically, the enumerator is a direct witness \u2014 they physically visited the dwelling and recorded who lived there. This distinguishes residence from other census facts where the household member is the true informant.",
+      "evidence_type": "direct",
+      "log_entry_id": "log_001",
+      "extracted_for_question_ids": [
+        "q_002"
+      ]
+    },
+    {
+      "id": "a_004",
+      "source_id": "src_001",
+      "record_id": "ark:/61903/1:1:MXYZ",
+      "record_role": "child_1",
+      "fact_type": "relationship",
+      "value": "Listed in household of Thomas Flynn (head), position consistent with child",
+      "structured_value": {
+        "relationship_type": "child_inferred",
+        "related_person_role": "head_of_household"
+      },
+      "date": "1850",
+      "date_certainty": "exact",
+      "place": "Schuylkill County, Pennsylvania",
+      "information_quality": "indeterminate",
+      "informant": "Inferred from household structure \u2014 no explicit informant for relationships in 1850 census",
+      "informant_proximity": "unknown",
+      "informant_bias_notes": "1850 census does not state relationships; this assertion is inferred from household position and shared surname, not directly reported by any informant. The relationship is indirect evidence constructed by the researcher, not information provided by a census informant.",
+      "evidence_type": "indirect",
+      "log_entry_id": "log_001",
+      "extracted_for_question_ids": [
+        "q_001"
+      ]
+    },
+    {
+      "id": "a_005",
+      "source_id": "src_001",
+      "record_id": "ark:/61903/1:1:MXYZ",
+      "record_role": "head_of_household",
+      "fact_type": "name",
+      "value": "Thomas Flynn",
+      "date": null,
+      "date_certainty": null,
+      "place": null,
+      "information_quality": "indeterminate",
+      "informant": "Unknown household member (likely Thomas Flynn himself) reporting to census enumerator",
+      "informant_proximity": "unknown",
+      "informant_bias_notes": "Census enumerator is the recorder, not the informant. As head of household, Thomas likely provided his own name, but the 1850 census does not identify the informant.",
+      "evidence_type": "indirect",
+      "log_entry_id": "log_001",
+      "extracted_for_question_ids": [
+        "q_001"
+      ]
+    },
+    {
+      "id": "a_006",
+      "source_id": "src_002",
+      "record_id": "ancestry:8054:patrick-flynn-1850",
+      "record_role": "child_1",
+      "fact_type": "name",
+      "value": "Patrick Flynn",
+      "date": null,
+      "date_certainty": null,
+      "place": null,
+      "information_quality": "indeterminate",
+      "informant": "Ancestry transcriber (derivative of census enumerator)",
+      "informant_proximity": "unknown",
+      "informant_bias_notes": "Derivative index \u2014 transcription errors possible",
+      "evidence_type": "direct",
+      "log_entry_id": "log_002",
+      "extracted_for_question_ids": [
+        "q_002"
+      ]
+    },
+    {
+      "id": "a_007",
+      "source_id": "src_002",
+      "record_id": "ancestry:8054:patrick-flynn-1850",
+      "record_role": "child_1",
+      "fact_type": "birth",
+      "value": "age 5",
+      "date": "~1845",
+      "date_certainty": "estimated",
+      "place": "Ireland",
+      "information_quality": "indeterminate",
+      "informant": "Ancestry transcriber (derivative)",
+      "informant_proximity": "unknown",
+      "informant_bias_notes": null,
+      "evidence_type": "indirect",
+      "log_entry_id": "log_002",
+      "extracted_for_question_ids": [
+        "q_002"
+      ]
+    },
+    {
+      "id": "a_008",
+      "source_id": "src_003",
+      "record_id": "ark:/61903/1:1:MABC",
+      "record_role": "child_2",
+      "fact_type": "name",
+      "value": "Patrick Flynn",
+      "date": null,
+      "date_certainty": null,
+      "place": null,
+      "information_quality": "indeterminate",
+      "informant": "Unknown household member reporting to census enumerator",
+      "informant_proximity": "unknown",
+      "informant_bias_notes": "Census enumerator is the recorder, not the informant. Proximity is 'unknown' for names (same reasoning as a_001 \u2014 name facts don't necessarily require active reporting).",
+      "evidence_type": "direct",
+      "log_entry_id": "log_004",
+      "extracted_for_question_ids": [
+        "q_001"
+      ]
+    },
+    {
+      "id": "a_009",
+      "source_id": "src_003",
+      "record_id": "ark:/61903/1:1:MABC",
+      "record_role": "child_2",
+      "fact_type": "birth",
+      "value": "age 15",
+      "date": "~1845",
+      "date_certainty": "estimated",
+      "place": "Ireland",
+      "information_quality": "indeterminate",
+      "informant": "Unknown household member (likely Thomas Flynn or wife)",
+      "informant_proximity": "household_member",
+      "informant_bias_notes": "Age and birthplace require active reporting by a household member (same reasoning as a_002).",
+      "evidence_type": "indirect",
+      "log_entry_id": "log_004",
+      "extracted_for_question_ids": [
+        "q_001"
+      ]
+    },
+    {
+      "id": "a_010",
+      "source_id": "src_003",
+      "record_id": "ark:/61903/1:1:MABC",
+      "record_role": "child_2",
+      "fact_type": "relationship",
+      "value": "Listed in household of Thomas Flynn (head), position and age consistent with son",
+      "structured_value": {
+        "relationship_type": "child_inferred",
+        "related_person_role": "head_of_household"
+      },
+      "date": "1860",
+      "date_certainty": "exact",
+      "place": "Schuylkill County, Pennsylvania",
+      "information_quality": "indeterminate",
+      "informant": "Inferred from household structure \u2014 no explicit informant for relationships in 1860 census",
+      "informant_proximity": "unknown",
+      "informant_bias_notes": "1860 census does not state relationships; like the 1850 census, this assertion is inferred from household position, age, and shared surname. The relationship column was not introduced until the 1880 census.",
+      "evidence_type": "indirect",
+      "log_entry_id": "log_004",
+      "extracted_for_question_ids": [
+        "q_001"
+      ]
+    },
+    {
+      "id": "a_011",
+      "source_id": "src_004",
+      "record_id": "ark:/61903/1:1:MDEF",
+      "record_role": "deceased",
+      "fact_type": "death",
+      "value": "Died 12 March 1908",
+      "date": "1908-03-12",
+      "date_certainty": "exact",
+      "place": "Schuylkill County, Pennsylvania",
+      "information_quality": "primary",
+      "informant": "Attending physician (signature on certificate)",
+      "informant_proximity": "witness",
+      "informant_bias_notes": null,
+      "evidence_type": "direct",
+      "log_entry_id": "log_005",
+      "extracted_for_question_ids": []
+    },
+    {
+      "id": "a_012",
+      "source_id": "src_004",
+      "record_id": "ark:/61903/1:1:MDEF",
+      "record_role": "deceased",
+      "fact_type": "birth",
+      "value": "Born 1845, Pennsylvania",
+      "structured_value": {
+        "year": 1845,
+        "place": "Pennsylvania"
+      },
+      "date": "1845",
+      "date_certainty": "approximate",
+      "place": "Pennsylvania",
+      "information_quality": "secondary",
+      "informant": "James Brown (son-in-law)",
+      "informant_proximity": "family_not_present",
+      "informant_bias_notes": "Son-in-law reporting birth facts decades after the event. Note: death cert says Pennsylvania, but census records say Ireland. Son-in-law may not have known Patrick was born in Ireland.",
+      "evidence_type": "direct",
+      "log_entry_id": "log_005",
+      "extracted_for_question_ids": [
+        "q_001"
+      ]
+    },
+    {
+      "id": "a_013",
+      "source_id": "src_004",
+      "record_id": "ark:/61903/1:1:MDEF",
+      "record_role": "deceased",
+      "fact_type": "relationship",
+      "value": "Father: Thomas Flynn",
+      "structured_value": {
+        "relationship_type": "father",
+        "related_person_role": "deceased"
+      },
+      "date": null,
+      "date_certainty": null,
+      "place": null,
+      "information_quality": "secondary",
+      "informant": "James Brown (son-in-law)",
+      "informant_proximity": "family_not_present",
+      "informant_bias_notes": "Secondary information \u2014 son-in-law reporting what he was told about father-in-law's parentage",
+      "evidence_type": "direct",
+      "log_entry_id": "log_005",
+      "extracted_for_question_ids": [
+        "q_001"
+      ]
+    }
+  ],
+  "person_evidence": [
+    {
+      "id": "pe_001",
+      "assertion_id": "a_001",
+      "person_id": "I1",
+      "confidence": "confident",
+      "rationale": "Name matches (Patrick Flynn), age consistent with ~1845 birth, located in Schuylkill County where subject is known to have lived. Only Patrick Flynn of this age in the county in 1850.",
+      "match_score": null,
+      "created": "2026-05-01",
+      "superseded_by": null
+    },
+    {
+      "id": "pe_002",
+      "assertion_id": "a_004",
+      "person_id": "I1",
+      "confidence": "probable",
+      "rationale": "Same record as pe_001, same person. Household position and shared surname with head Thomas Flynn suggest parent-child relationship, but 1850 census does not state relationships explicitly.",
+      "match_score": null,
+      "created": "2026-05-01",
+      "superseded_by": null
+    },
+    {
+      "id": "pe_006",
+      "assertion_id": "a_004",
+      "person_id": "I2",
+      "confidence": "probable",
+      "rationale": "Same assertion as pe_002 but linked to Thomas Flynn (I2). The relationship assertion ('position consistent with child') equally bears on the head of household. Thomas Flynn is the other party in the implied parent-child relationship.",
+      "match_score": null,
+      "created": "2026-05-01",
+      "superseded_by": null
+    },
+    {
+      "id": "pe_003",
+      "assertion_id": "a_005",
+      "person_id": "I2",
+      "confidence": "probable",
+      "rationale": "Thomas Flynn, head of household where Patrick was found. Age (~32 in 1850, born ~1818) is consistent with being Patrick's father. Name matches candidate father.",
+      "match_score": 0.82,
+      "created": "2026-05-01",
+      "superseded_by": null
+    },
+    {
+      "id": "pe_004",
+      "assertion_id": "a_010",
+      "person_id": "I1",
+      "confidence": "confident",
+      "rationale": "Patrick Flynn age 15 in Thomas Flynn household, 1860 census. Same county, age consistent with 1850 enumeration. Relationship inferred from household position and shared surname (1860 census does not state relationships explicitly).",
+      "match_score": null,
+      "created": "2026-05-02",
+      "superseded_by": null
+    },
+    {
+      "id": "pe_005",
+      "assertion_id": "a_013",
+      "person_id": "I1",
+      "confidence": "confident",
+      "rationale": "Death certificate for Patrick Flynn, d. 1908, Schuylkill County. Names match, death location matches known residence. Names Thomas Flynn as father.",
+      "match_score": null,
+      "created": "2026-05-03",
+      "superseded_by": null
+    }
+  ],
+  "conflicts": [
+    {
+      "id": "c_001",
+      "conflict_type": "fact",
+      "description": "Patrick Flynn's birthplace: Ireland (1850 and 1860 censuses) vs. Pennsylvania (1908 death certificate)",
+      "disputed_attribute": "birthplace",
+      "identity_question": null,
+      "competing_assertion_ids": [
+        "a_002",
+        "a_009",
+        "a_012"
+      ],
+      "independence_analysis": "The two census records (1850, 1860) are independent original sources with different enumerators. The death certificate is a third independent original source. However, the census informants are likely the same household member (Thomas Flynn or wife), so the two census assertions may share a single informant \u2014 potentially not fully independent for this fact.",
+      "weighing_analysis": "The census records are contemporary recordings made near the time of Patrick's birth, while the death certificate was created 63 years later. The census informant was likely a household member with firsthand knowledge (primary or indeterminate), while the death certificate informant (son-in-law) is clearly secondary for birth facts. Two contemporary sources outweigh one later recollection by a secondary informant.",
+      "preferred_assertion_id": "a_002",
+      "resolution_rationale": "Ireland is accepted as the birthplace. The 1908 death certificate birthplace of 'Pennsylvania' is rejected as a likely error by the son-in-law informant, who may have confused Patrick's place of residence with his place of birth, or may not have known Patrick was born in Ireland before immigrating as a young child.",
+      "status": "resolved",
+      "blocks_question_ids": []
+    }
+  ],
+  "hypotheses": [
+    {
+      "id": "h_001",
+      "claim": "Patrick Flynn's father was Thomas Flynn of Schuylkill County, Pennsylvania",
+      "status": "supported",
+      "supporting_assertion_ids": [
+        "a_004",
+        "a_010",
+        "a_013"
+      ],
+      "contradicting_assertion_ids": [],
+      "ruled_out": false,
+      "ruled_out_reason": null,
+      "notes": "Three independent pieces of evidence: 1850 census co-enumeration (indirect), 1860 census co-enumeration (indirect \u2014 relationship inferred from household position), death certificate naming Thomas as father (direct, secondary informant). Awaiting probate records for additional confirmation.",
+      "related_question_ids": [
+        "q_001"
+      ]
+    }
+  ],
+  "timelines": [
+    {
+      "id": "t_001",
+      "label": "Patrick Flynn \u2014 assuming Thomas Flynn parentage",
+      "hypothesis_id": "h_001",
+      "person_ids": [
+        "I1"
+      ],
+      "generated": "2026-05-03T12:00:00Z",
+      "events": [
+        {
+          "date": "~1845",
+          "date_certainty": "estimated",
+          "event_type": "birth",
+          "place": "Ireland",
+          "description": "Born in Ireland, estimated from census ages",
+          "assertion_ids": [
+            "a_002",
+            "a_009"
+          ]
+        },
+        {
+          "date": "1850",
+          "date_certainty": "exact",
+          "event_type": "census",
+          "place": "Schuylkill County, Pennsylvania",
+          "description": "Enumerated age 5 in Thomas Flynn household, dwelling 84",
+          "assertion_ids": [
+            "a_003",
+            "a_004"
+          ]
+        },
+        {
+          "date": "1860",
+          "date_certainty": "exact",
+          "event_type": "census",
+          "place": "Schuylkill County, Pennsylvania",
+          "description": "Enumerated age 15 in Thomas Flynn household, dwelling 112",
+          "assertion_ids": [
+            "a_008",
+            "a_009",
+            "a_010"
+          ]
+        },
+        {
+          "date": "1908-03-12",
+          "date_certainty": "exact",
+          "event_type": "death",
+          "place": "Schuylkill County, Pennsylvania",
+          "description": "Died, death certificate names Thomas Flynn as father",
+          "assertion_ids": [
+            "a_011",
+            "a_013"
+          ]
+        }
+      ],
+      "gaps": [
+        {
+          "start": "1860-01-01",
+          "end": "1908-03-12",
+          "expected_events": [
+            "marriage",
+            "1870_census",
+            "1880_census",
+            "1900_census",
+            "residence",
+            "occupation"
+          ],
+          "severity": "high"
+        }
+      ],
+      "impossibilities": []
+    }
+  ],
+  "proof_summaries": [
+    {
+      "id": "ps_001",
+      "question_id": "q_001",
+      "tier": "probable",
+      "vehicle": "summary",
+      "supporting_assertion_ids": [
+        "a_004",
+        "a_010",
+        "a_013"
+      ],
+      "resolved_conflict_ids": [
+        "c_001"
+      ],
+      "exhaustive_search_summary": "Searched 1850 census (FamilySearch, Ancestry, MyHeritage \u2014 log_001, log_002, log_003), 1860 census (FamilySearch \u2014 log_004), and death certificate (FamilySearch \u2014 log_005). Probate search in progress. 1880 census located (log_006), extraction pending; 1870 and 1900 censuses not yet searched.",
+      "narrative_markdown": "## Parentage of Patrick Flynn (ca. 1845\u20131908)\n\nPatrick Flynn is **Probably** the son of Thomas Flynn of Schuylkill County, Pennsylvania.\n\n### Evidence Summary\n\nThree independent lines of evidence support this conclusion:\n\n1. **1850 U.S. Census** (Original Source). Patrick Flynn, age 5, born Ireland, appears in the household of Thomas Flynn, age 32, born Ireland, in Schuylkill County, Pennsylvania (dwelling 84, family 91). The 1850 census does not state relationships, but Patrick's position in the household and shared surname are consistent with a parent-child relationship. The informant is indeterminate but likely a household member. This constitutes indirect evidence of parentage.\n\n2. **1860 U.S. Census** (Original Source). Patrick Flynn, age 15, born Ireland, appears in the household of Thomas Flynn in Schuylkill County (dwelling 112, family 119). Like the 1850 census, the 1860 census does not state relationships explicitly (the relationship column was not introduced until 1880). Patrick's position in the household, shared surname, and age consistent with the 1850 enumeration support a parent-child relationship. This constitutes indirect evidence of parentage.\n\n3. **1908 Death Certificate** (Original Source). Patrick Flynn's death certificate (no. 4521, Pennsylvania Department of Health) names \"Thomas Flynn\" as his father. The informant was James Brown, identified as Patrick's son-in-law. As a son-in-law reporting his father-in-law's parentage, Brown is a secondary informant for this fact \u2014 he was not a witness to Patrick's birth and is reporting what he was told. Nevertheless, this is direct evidence naming the father.\n\n### Conflict Resolution\n\nA birthplace conflict exists: the 1850 and 1860 censuses list Patrick's birthplace as Ireland, while the 1908 death certificate states Pennsylvania. The two census records are contemporary recordings with informants likely present in the household, while the death certificate was created 63 years after Patrick's birth by a son-in-law with no firsthand knowledge of the event. Per the GPS preponderance hierarchy, contemporary recordings by closer informants outweigh later recollections by secondary informants. Ireland is accepted as the birthplace; the death certificate entry is attributed to informant error.\n\n### Assessment\n\nThe conclusion is rated **Probable** rather than **Proved** because: (a) both census sources (1850 and 1860) provide only indirect evidence of parentage (relationships not stated \u2014 the relationship column was not introduced until 1880), (b) the death certificate informant is secondary, and (c) research is not yet exhaustive \u2014 the 1880 census was just located and awaits extraction, while the 1870 and 1900 censuses have not been searched, and Thomas Flynn's probate records have not been located. If Thomas Flynn's will names Patrick as a son, or if additional census records confirm the relationship, the conclusion would advance to **Proved**.\n\n### Citations\n\n1. 1850 U.S. Census, Schuylkill County, Pennsylvania, population schedule, dwelling 84, family 91, Thomas Flynn household; NARA microfilm publication M432, roll 810; digital image, FamilySearch.org, accessed 1 May 2026.\n2. 1860 U.S. Census, Schuylkill County, Pennsylvania, population schedule, dwelling 112, family 119, Thomas Flynn household; NARA microfilm publication M653, roll 1141; digital image, FamilySearch.org, accessed 2 May 2026.\n3. Pennsylvania Department of Health, death certificate no. 4521 (1908), Patrick Flynn; Pennsylvania State Archives, Harrisburg; digital image, FamilySearch.org, accessed 3 May 2026."
+    }
+  ],
+  "evaluations": []
+}

--- a/eval/fixtures/scenarios/mid-research-flynn-1880-found/tree.gedcomx.json
+++ b/eval/fixtures/scenarios/mid-research-flynn-1880-found/tree.gedcomx.json
@@ -1,0 +1,75 @@
+{
+  "persons": [
+    {
+      "id": "I1",
+      "gender": "Male",
+      "names": [
+        {
+          "id": "N1",
+          "preferred": true,
+          "given": "Patrick",
+          "surname": "Flynn",
+          "type": "BirthName"
+        }
+      ],
+      "facts": [
+        {
+          "id": "F1",
+          "type": "Birth",
+          "primary": true,
+          "date": "~1845",
+          "place": "Ireland",
+          "sources": [{ "ref": "S1", "page": "1850 Census, Schuylkill Co., dwelling 84" }]
+        },
+        {
+          "id": "F2",
+          "type": "Death",
+          "date": "1908-03-12",
+          "place": "Schuylkill County, Pennsylvania",
+          "sources": [{ "ref": "S3", "page": "Death cert. no. 4521" }]
+        }
+      ]
+    },
+    {
+      "id": "I2",
+      "gender": "Male",
+      "names": [
+        {
+          "id": "N2",
+          "preferred": true,
+          "given": "Thomas",
+          "surname": "Flynn",
+          "type": "BirthName"
+        }
+      ],
+      "facts": [
+        {
+          "id": "F3",
+          "type": "Birth",
+          "primary": true,
+          "date": "~1818",
+          "place": "Ireland"
+        }
+      ]
+    }
+  ],
+  "relationships": [
+    {
+      "id": "R1",
+      "type": "ParentChild",
+      "parent": "I2",
+      "child": "I1",
+      "sources": [
+        { "ref": "S1", "page": "1850 Census, Schuylkill Co., dwelling 84", "quality": 2 },
+        { "ref": "S2", "page": "1860 Census, Schuylkill Co., dwelling 112", "quality": 2 },
+        { "ref": "S3", "page": "Death cert. no. 4521", "quality": 2 }
+      ]
+    }
+  ],
+  "sources": [
+    { "id": "S1", "title": "1850 U.S. Federal Census", "author": "U.S. Census Bureau" },
+    { "id": "S2", "title": "1860 U.S. Federal Census", "author": "U.S. Census Bureau" },
+    { "id": "S3", "title": "Pennsylvania Death Certificates", "author": "Pennsylvania Dept. of Health" },
+    { "id": "S4", "title": "Schuylkill County Probate Records", "author": "Schuylkill County Register of Wills" }
+  ]
+}

--- a/eval/harness/run_tests.py
+++ b/eval/harness/run_tests.py
@@ -289,7 +289,8 @@ def main(argv: list[str] | None = None) -> int:
         if len(stale) > 5:
             print(f"  ... and {len(stale) - 5} more", file=sys.stderr)
         print(
-            "\nFix: cd mcp-server && npm run build",
+            "\nFix: cd packages/engine/mcp-server && npm run build\n"
+            "     (or: make eval-skill SKILL=<name>, which rebuilds first)",
             file=sys.stderr,
         )
         return 2

--- a/eval/harness/scripts/check_skill_frontmatter.py
+++ b/eval/harness/scripts/check_skill_frontmatter.py
@@ -94,7 +94,7 @@ def parse_frontmatter(skill_md: Path) -> dict | None:
     """
     if not skill_md.exists():
         return None
-    text = skill_md.read_text()
+    text = skill_md.read_text(encoding="utf-8")
     if not text.startswith("---"):
         return None
     parts = text.split("---", 2)
@@ -150,7 +150,7 @@ def load_manifest_tools() -> set[str] | None:
     if not MANIFEST.exists():
         return None
     try:
-        data = json.loads(MANIFEST.read_text())
+        data = json.loads(MANIFEST.read_text(encoding="utf-8"))
     except json.JSONDecodeError:
         return None
     names = {t.get("name") for t in data.get("tools", []) if isinstance(t, dict)}

--- a/eval/harness/scripts/check_skill_frontmatter.py
+++ b/eval/harness/scripts/check_skill_frontmatter.py
@@ -1,0 +1,284 @@
+#!/usr/bin/env python3
+"""GH Action: lint every skill's SKILL.md frontmatter.
+
+Checks the parts of a skill's frontmatter that, if wrong, break the skill
+before it can run or quietly degrade how Cowork's orchestrator triggers it.
+
+Hard rules (fail the build, exit 1):
+  - `name` present, kebab-case, <=64 chars, and equal to the directory name.
+  - `description` present, non-empty, <=1024 chars, and free of angle
+    brackets (`<` / `>`). The 1024 cap is a self-imposed standard, not a
+    Cowork limit: every skill's description is always resident in the
+    orchestrator's context and the ~28 descriptions compete for its
+    attention on every turn, so a tight description triggers more
+    precisely. Angle brackets can collide with prompt scaffolding — write
+    "before 1850" in the description, not "<1850" (the body may use `<`).
+    See docs/skill-authoring-guide.md §3.
+
+Soft rules (warning annotation only, never block):
+  - Unrecognized top-level frontmatter key (catches typos like
+    `descrption:` or `allowed_tools:` with an underscore).
+  - An `allowed-tools` entry that doesn't resolve to a real MCP tool
+    (sourced from packages/engine/mcp-server/manifest.json). The skill
+    could not call it — it would be denied at runtime. (The fixture side
+    of allowed-tools drift is covered by check_tool_coverage.py.)
+  - A `description` that isn't a single-line scalar, so its length can't
+    be measured here — keep descriptions single-line.
+
+The gate is on from the start: the corpus passes today, so there's no
+backlog to grandfather in. A PR that introduces a hard violation fails.
+
+Run by .github/workflows/check-runlogs.yml. Self-contained: stdlib only
+(the workflow installs no dependencies — same reason check_tool_coverage.py
+hand-parses frontmatter instead of importing yaml).
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+HARNESS_DIR = HERE.parent
+REPO_ROOT = HARNESS_DIR.parents[1]
+
+SKILLS_DIR = REPO_ROOT / "packages" / "engine" / "plugin" / "skills"
+MANIFEST = REPO_ROOT / "packages" / "engine" / "mcp-server" / "manifest.json"
+
+DESCRIPTION_MAX = 1024
+NAME_MAX = 64
+KEBAB_RE = re.compile(r"^[a-z0-9]+(-[a-z0-9]+)*$")
+# Keys a SKILL.md frontmatter may carry. The four in active use plus the
+# optional ones the skill format allows; anything else is likely a typo.
+KNOWN_KEYS = {
+    "name",
+    "description",
+    "model",
+    "allowed-tools",
+    "license",
+    "metadata",
+    "compatibility",
+}
+# Block-scalar / empty markers that mean "description isn't a single line".
+_BLOCK_MARKERS = {"", "|", ">", "|-", ">-", "|+", ">+"}
+
+
+def gh_warning(message: str, *, file: str | None = None) -> None:
+    """Emit a GitHub warning annotation (visible on the PR; non-blocking)."""
+    prefix = f"::warning file={file}::" if file else "::warning::"
+    print(f"{prefix}{message}")
+
+
+def gh_error(message: str, *, file: str | None = None) -> None:
+    """Emit a GitHub error annotation for a hard-rule violation. The build
+    fails because main() returns 1 when any hard violation is found."""
+    prefix = f"::error file={file}::" if file else "::error::"
+    print(f"{prefix}{message}")
+
+
+def _unquote(value: str) -> str:
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in "\"'":
+        return value[1:-1]
+    return value
+
+
+def parse_frontmatter(skill_md: Path) -> dict | None:
+    """Parse the YAML frontmatter into the fields the lint needs.
+
+    Stdlib only — no yaml dependency. Relies on the convention that these
+    skills keep `name`/`description`/`model` as single-line scalars and
+    `allowed-tools` as a `  - name` block list (verified across the
+    corpus). Returns None when there is no frontmatter block at all.
+    """
+    if not skill_md.exists():
+        return None
+    text = skill_md.read_text()
+    if not text.startswith("---"):
+        return None
+    parts = text.split("---", 2)
+    if len(parts) < 3:
+        return None
+
+    keys: list[str] = []
+    name: str | None = None
+    description: str | None = None
+    description_block = False
+    allowed: list[str] = []
+    in_allowed = False
+
+    for line in parts[1].splitlines():
+        if re.match(r"^[A-Za-z]", line):  # a top-level key
+            in_allowed = False
+            m = re.match(r"^([A-Za-z0-9_-]+):(.*)$", line)
+            if not m:
+                continue
+            key, raw = m.group(1), m.group(2).strip()
+            keys.append(key)
+            if key == "name":
+                name = _unquote(raw)
+            elif key == "description":
+                if raw in _BLOCK_MARKERS:
+                    description_block = True
+                else:
+                    description = _unquote(raw)
+            elif key == "allowed-tools":
+                in_allowed = True
+        elif in_allowed:
+            stripped = line.strip()
+            if stripped.startswith("- "):
+                allowed.append(stripped[2:].strip().split("__")[-1])
+            elif stripped == "":
+                continue
+            else:
+                in_allowed = False
+
+    return {
+        "keys": keys,
+        "name": name,
+        "description": description,
+        "description_block": description_block,
+        "allowed_tools": allowed,
+    }
+
+
+def load_manifest_tools() -> set[str] | None:
+    """Valid MCP tool names from the mcpb manifest (the install contract,
+    kept in sync with allToolSchemas). None if absent/unreadable, in which
+    case the allowed-tools resolution check is skipped with a note."""
+    if not MANIFEST.exists():
+        return None
+    try:
+        data = json.loads(MANIFEST.read_text())
+    except json.JSONDecodeError:
+        return None
+    names = {t.get("name") for t in data.get("tools", []) if isinstance(t, dict)}
+    return {n for n in names if isinstance(n, str)}
+
+
+def main() -> int:
+    if not SKILLS_DIR.is_dir():
+        print(f"No skills directory at {SKILLS_DIR}; nothing to check.")
+        return 0
+
+    manifest_tools = load_manifest_tools()
+    hard = 0
+    soft = 0
+    skills_checked = 0
+
+    for skill_dir in sorted(SKILLS_DIR.iterdir()):
+        skill_md = skill_dir / "SKILL.md"
+        if not skill_dir.is_dir() or not skill_md.exists():
+            continue
+        skill = skill_dir.name
+        rel = f"packages/engine/plugin/skills/{skill}/SKILL.md"
+        skills_checked += 1
+
+        fm = parse_frontmatter(skill_md)
+        if fm is None:
+            hard += 1
+            gh_error(f"skill `{skill}` has no YAML frontmatter block.", file=rel)
+            continue
+
+        # name --------------------------------------------------------------
+        name = fm["name"]
+        if not name:
+            hard += 1
+            gh_error(f"skill `{skill}` is missing a `name`.", file=rel)
+        else:
+            if not KEBAB_RE.match(name):
+                hard += 1
+                gh_error(
+                    f"skill `{skill}` name `{name}` is not kebab-case "
+                    f"(lowercase letters/digits, single hyphens, no leading/"
+                    f"trailing/double hyphen).",
+                    file=rel,
+                )
+            if len(name) > NAME_MAX:
+                hard += 1
+                gh_error(
+                    f"skill `{skill}` name is {len(name)} chars; max is {NAME_MAX}.",
+                    file=rel,
+                )
+            if name != skill:
+                hard += 1
+                gh_error(
+                    f"skill `{skill}` frontmatter name is `{name}` but must "
+                    f"equal the directory name `{skill}`.",
+                    file=rel,
+                )
+
+        # description -------------------------------------------------------
+        if fm["description_block"]:
+            soft += 1
+            gh_warning(
+                f"skill `{skill}` description is not a single-line scalar; "
+                f"its length can't be checked. Keep descriptions single-line.",
+                file=rel,
+            )
+        else:
+            desc = fm["description"]
+            if not desc:
+                hard += 1
+                gh_error(f"skill `{skill}` is missing a `description`.", file=rel)
+            else:
+                if len(desc) > DESCRIPTION_MAX:
+                    hard += 1
+                    gh_error(
+                        f"skill `{skill}` description is {len(desc)} chars; max "
+                        f"is {DESCRIPTION_MAX}. Trim via the description "
+                        f"optimizer (docs/skill-lifecycle.md), not by hand — "
+                        f"blind cuts drop triggers.",
+                        file=rel,
+                    )
+                if "<" in desc or ">" in desc:
+                    hard += 1
+                    gh_error(
+                        f"skill `{skill}` description contains an angle bracket "
+                        f"(`<` or `>`). Write 'before 1850', not '<1850', in the "
+                        f"description (the body may use `<`).",
+                        file=rel,
+                    )
+
+        # unknown keys ------------------------------------------------------
+        for key in fm["keys"]:
+            if key not in KNOWN_KEYS:
+                soft += 1
+                gh_warning(
+                    f"skill `{skill}` has unrecognized frontmatter key "
+                    f"`{key}` (typo? known keys: {sorted(KNOWN_KEYS)}).",
+                    file=rel,
+                )
+
+        # allowed-tools resolution -----------------------------------------
+        if manifest_tools is not None:
+            for tool in fm["allowed_tools"]:
+                if tool not in manifest_tools:
+                    soft += 1
+                    gh_warning(
+                        f"skill `{skill}` allowed-tools lists `{tool}`, which is "
+                        f"not a known MCP tool (manifest.json). The skill could "
+                        f"not call it — it would be denied at runtime. Typo?",
+                        file=rel,
+                    )
+
+    print()
+    if manifest_tools is None:
+        print(
+            "Note: manifest.json not found — skipped the allowed-tools "
+            "resolution check."
+        )
+    if hard or soft:
+        print(
+            f"Frontmatter lint: {hard} hard violation(s) (fail the build), "
+            f"{soft} warning(s) across {skills_checked} skill(s). See above."
+        )
+    else:
+        print(f"All {skills_checked} skill(s) have clean frontmatter.")
+
+    return 1 if hard else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/eval/tests/unit/tree-edit/negative-record-extraction.json
+++ b/eval/tests/unit/tree-edit/negative-record-extraction.json
@@ -9,7 +9,8 @@
   },
   "input": {
     "user_message": "I just found the 1880 census for Patrick Flynn. Add the facts from that record to the tree.",
-    "scenario": "mid-research-flynn"
+    "scenario": "mid-research-flynn-1880-found",
+    "scenario_notes": "DRAFT variant of mid-research-flynn where the 1880 census is found-but-unextracted (log_006). See the scenario README; the 1880 household is a placeholder pending genealogist review."
   },
   "negative": {
     "correct_skill": ["record-extraction"],

--- a/eval/triggering/.gitignore
+++ b/eval/triggering/.gitignore
@@ -1,0 +1,7 @@
+# Generated trigger eval sets — regenerate with build_eval_set.py / make optimize-skill.
+eval_sets/*.json
+!eval_sets/.gitkeep
+
+# uv environment for the vendored optimizer (stdlib only — nothing to commit).
+.venv/
+uv.lock

--- a/eval/triggering/VENDORED.md
+++ b/eval/triggering/VENDORED.md
@@ -31,6 +31,8 @@ Driven in this repo by:
 cost (real `claude -p` calls). It is **not** part of CI and has not been run
 end-to-end in this repo yet — the first team use validates it; treat its output
 as advisory and apply the proposed description as a human-reviewed SKILL.md edit.
+`make optimize-skill` writes `results.json` + the HTML report to
+`eval/runlogs/optimizer/<ts>/` (excluded from the release gate + comparisons).
 
 Spec / rationale: `docs/plan/skill-mcp-optimization-plan.md`; lifecycle: `docs/skill-lifecycle.md` §7.
 

--- a/eval/triggering/VENDORED.md
+++ b/eval/triggering/VENDORED.md
@@ -38,3 +38,11 @@ Spec / rationale: `docs/plan/skill-mcp-optimization-plan.md`; lifecycle: `docs/s
 
 Provenance: copied from the local skill-creator cache on 2026-06-10. Record the
 upstream commit here when re-vendoring.
+
+## Local divergences from upstream
+
+- **`encoding="utf-8"`** added to all `read_text()` calls (utils.py,
+  run_loop.py, run_eval.py, improve_description.py, generate_report.py).
+  Without this, `read_text()` defaults to cp1252 on Windows and crashes on
+  SKILL.md files containing em dashes or smart quotes. Re-apply after
+  re-vendoring.

--- a/eval/triggering/VENDORED.md
+++ b/eval/triggering/VENDORED.md
@@ -1,0 +1,38 @@
+# Vendored: the description / trigger optimizer (from Anthropic's skill-creator)
+
+`scripts/` here is vendored **verbatim** from Anthropic's `skill-creator` skill
+(`anthropics/skills`, `skills/skill-creator/scripts/`) — the
+description/trigger-optimization half of it:
+
+- `run_loop.py` — train/test split + iterate a blinded description improver,
+  best-by-held-out-score
+- `run_eval.py` — fakes the skill as a throwaway `.claude/commands/<name>.md`
+  and runs real `claude -p`, detecting whether Claude consults the skill
+- `improve_description.py` — the blinded improver (≤1024-char descriptions)
+- `generate_report.py` — the per-iteration HTML report
+- `utils.py`, `__init__.py`
+
+**Do not edit these files.** They are kept byte-identical so upstream drift is
+easy to track; if upstream changes, re-copy. The package name `scripts` is
+preserved because the modules import each other as `from scripts.X import ...`;
+run them as `python -m scripts.run_loop` from this directory (`eval/triggering/`).
+
+What it does: tunes a skill's SKILL.md `description` (the trigger surface the
+Cowork orchestrator reads) against a `[{query, should_trigger}]` set. It does
+**not** execute the skill or any MCP tool — only measures whether Claude decides
+to consult the skill. This is the *description* loop; the *body* loop is the
+`skill-improver` agent.
+
+Driven in this repo by:
+- `build_eval_set.py` — derives the query set from the unit-test corpus
+- `make optimize-skill SKILL=<name>` — build the set, then run the loop
+
+**On-demand only.** It needs the `claude` CLI, network access, and incurs model
+cost (real `claude -p` calls). It is **not** part of CI and has not been run
+end-to-end in this repo yet — the first team use validates it; treat its output
+as advisory and apply the proposed description as a human-reviewed SKILL.md edit.
+
+Spec / rationale: `docs/plan/skill-mcp-optimization-plan.md`; lifecycle: `docs/skill-lifecycle.md` §7.
+
+Provenance: copied from the local skill-creator cache on 2026-06-10. Record the
+upstream commit here when re-vendoring.

--- a/eval/triggering/build_eval_set.py
+++ b/eval/triggering/build_eval_set.py
@@ -40,7 +40,7 @@ def load_tests() -> list[tuple[Path, dict]]:
     out = []
     for tj in sorted(TESTS_DIR.glob("*/*.json")):
         try:
-            out.append((tj, json.loads(tj.read_text())))
+            out.append((tj, json.loads(tj.read_text(encoding="utf-8"))))
         except json.JSONDecodeError:
             print(f"  warning: skipping unparseable {tj.relative_to(REPO_ROOT)}", file=sys.stderr)
     return out
@@ -89,7 +89,7 @@ def main() -> int:
 
     out = Path(args.out) if args.out else (OUT_DIR / f"{args.skill}.json")
     out.parent.mkdir(parents=True, exist_ok=True)
-    out.write_text(json.dumps(items, indent=2) + "\n")
+    out.write_text(json.dumps(items, indent=2) + "\n", encoding="utf-8")
     print(f"{args.skill}: {len(items)} queries ({pos} should-trigger, {neg} should-not) "
           f"-> {out.relative_to(REPO_ROOT) if out.is_relative_to(REPO_ROOT) else out}")
 

--- a/eval/triggering/build_eval_set.py
+++ b/eval/triggering/build_eval_set.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Derive a description/trigger eval set for one skill from the unit-test corpus.
+
+The description optimizer (eval/triggering/scripts/run_loop.py, vendored from
+Anthropic's skill-creator) tunes a skill's SKILL.md `description` against a list
+of [{query, should_trigger}] items. This script builds that list for free from
+the genealogist-authored unit tests, so the optimizer trains on real,
+domain-expert phrasings instead of hand-written queries.
+
+Mapping (see docs/plan/skill-mcp-optimization-plan.md):
+  - every POSITIVE test for skill X            -> {query, should_trigger: true}
+  - every NEGATIVE test for skill X            -> {query, should_trigger: false}
+  - every NEGATIVE test in ANOTHER skill whose
+    `negative.correct_skill` names X           -> {query, should_trigger: true}
+        (the author already asserted X is the right route, so it is a free,
+         domain-expert-labeled positive trigger for X)
+
+Output: eval/triggering/eval_sets/<skill>.json — a JSON array of
+{query, should_trigger, _provenance}. Regenerable; gitignored. The optimizer
+reads only `query` + `should_trigger`; `_provenance` is for human review.
+
+Stdlib only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent  # eval/triggering
+REPO_ROOT = HERE.parents[1]
+TESTS_DIR = REPO_ROOT / "eval" / "tests" / "unit"
+SKILLS_DIR = REPO_ROOT / "packages" / "engine" / "plugin" / "skills"
+OUT_DIR = HERE / "eval_sets"
+
+
+def load_tests() -> list[tuple[Path, dict]]:
+    out = []
+    for tj in sorted(TESTS_DIR.glob("*/*.json")):
+        try:
+            out.append((tj, json.loads(tj.read_text())))
+        except json.JSONDecodeError:
+            print(f"  warning: skipping unparseable {tj.relative_to(REPO_ROOT)}", file=sys.stderr)
+    return out
+
+
+def build_for_skill(skill: str, tests: list[tuple[Path, dict]]) -> list[dict]:
+    items: list[dict] = []
+    for _tj, t in tests:
+        meta = t.get("test", {})
+        ttype = meta.get("type")
+        tid = meta.get("id")
+        owner = meta.get("skill")
+        msg = (t.get("input") or {}).get("user_message")
+        if not msg:
+            continue
+        if owner == skill and ttype == "positive":
+            items.append({"query": msg, "should_trigger": True,
+                          "_provenance": {"test_id": tid, "reason": "positive test for this skill"}})
+        elif owner == skill and ttype == "negative":
+            items.append({"query": msg, "should_trigger": False,
+                          "_provenance": {"test_id": tid, "reason": "negative test for this skill"}})
+        elif ttype == "negative":
+            correct = (t.get("negative") or {}).get("correct_skill") or []
+            if skill in correct:
+                items.append({"query": msg, "should_trigger": True,
+                              "_provenance": {"test_id": tid,
+                                              "reason": f"negative test in '{owner}' routes here (correct_skill)"}})
+    return items
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--skill", required=True,
+                    help="skill directory name under packages/engine/plugin/skills/")
+    ap.add_argument("--out", default=None,
+                    help="output path (default eval/triggering/eval_sets/<skill>.json)")
+    args = ap.parse_args()
+
+    if not (SKILLS_DIR / args.skill).is_dir():
+        print(f"ERROR: no skill '{args.skill}' under {SKILLS_DIR}", file=sys.stderr)
+        return 1
+
+    items = build_for_skill(args.skill, load_tests())
+    pos = sum(1 for i in items if i["should_trigger"])
+    neg = len(items) - pos
+
+    out = Path(args.out) if args.out else (OUT_DIR / f"{args.skill}.json")
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(items, indent=2) + "\n")
+    print(f"{args.skill}: {len(items)} queries ({pos} should-trigger, {neg} should-not) "
+          f"-> {out.relative_to(REPO_ROOT) if out.is_relative_to(REPO_ROOT) else out}")
+
+    if pos < 3 or neg < 3:
+        print(f"  NOTE: thin set ({pos} positive / {neg} negative). run_loop holds out ~40% "
+              f"stratified by polarity and needs a few of each class; add tests (or hand-add "
+              f"near-miss negatives) before trusting the optimizer's scores.", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/eval/triggering/pyproject.toml
+++ b/eval/triggering/pyproject.toml
@@ -1,0 +1,11 @@
+[project]
+name = "genealogy-triggering"
+version = "0.0.0"
+description = "Corpus-derived description/trigger optimizer for genealogy skills (vendored skill-creator run_loop + build_eval_set)."
+requires-python = ">=3.10"
+
+# Stdlib only — no dependencies. The vendored scripts/ modules use 3.10+ syntax
+# (e.g. `str | None` evaluated at runtime), so this pins the interpreter; `uv run`
+# provides it without touching the system python3. Not an installable package.
+[tool.uv]
+package = false

--- a/eval/triggering/scripts/generate_report.py
+++ b/eval/triggering/scripts/generate_report.py
@@ -1,0 +1,326 @@
+#!/usr/bin/env python3
+"""Generate an HTML report from run_loop.py output.
+
+Takes the JSON output from run_loop.py and generates a visual HTML report
+showing each description attempt with check/x for each test case.
+Distinguishes between train and test queries.
+"""
+
+import argparse
+import html
+import json
+import sys
+from pathlib import Path
+
+
+def generate_html(data: dict, auto_refresh: bool = False, skill_name: str = "") -> str:
+    """Generate HTML report from loop output data. If auto_refresh is True, adds a meta refresh tag."""
+    history = data.get("history", [])
+    holdout = data.get("holdout", 0)
+    title_prefix = html.escape(skill_name + " \u2014 ") if skill_name else ""
+
+    # Get all unique queries from train and test sets, with should_trigger info
+    train_queries: list[dict] = []
+    test_queries: list[dict] = []
+    if history:
+        for r in history[0].get("train_results", history[0].get("results", [])):
+            train_queries.append({"query": r["query"], "should_trigger": r.get("should_trigger", True)})
+        if history[0].get("test_results"):
+            for r in history[0].get("test_results", []):
+                test_queries.append({"query": r["query"], "should_trigger": r.get("should_trigger", True)})
+
+    refresh_tag = '    <meta http-equiv="refresh" content="5">\n' if auto_refresh else ""
+
+    html_parts = ["""<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+""" + refresh_tag + """    <title>""" + title_prefix + """Skill Description Optimization</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@500;600&family=Lora:wght@400;500&display=swap" rel="stylesheet">
+    <style>
+        body {
+            font-family: 'Lora', Georgia, serif;
+            max-width: 100%;
+            margin: 0 auto;
+            padding: 20px;
+            background: #faf9f5;
+            color: #141413;
+        }
+        h1 { font-family: 'Poppins', sans-serif; color: #141413; }
+        .explainer {
+            background: white;
+            padding: 15px;
+            border-radius: 6px;
+            margin-bottom: 20px;
+            border: 1px solid #e8e6dc;
+            color: #b0aea5;
+            font-size: 0.875rem;
+            line-height: 1.6;
+        }
+        .summary {
+            background: white;
+            padding: 15px;
+            border-radius: 6px;
+            margin-bottom: 20px;
+            border: 1px solid #e8e6dc;
+        }
+        .summary p { margin: 5px 0; }
+        .best { color: #788c5d; font-weight: bold; }
+        .table-container {
+            overflow-x: auto;
+            width: 100%;
+        }
+        table {
+            border-collapse: collapse;
+            background: white;
+            border: 1px solid #e8e6dc;
+            border-radius: 6px;
+            font-size: 12px;
+            min-width: 100%;
+        }
+        th, td {
+            padding: 8px;
+            text-align: left;
+            border: 1px solid #e8e6dc;
+            white-space: normal;
+            word-wrap: break-word;
+        }
+        th {
+            font-family: 'Poppins', sans-serif;
+            background: #141413;
+            color: #faf9f5;
+            font-weight: 500;
+        }
+        th.test-col {
+            background: #6a9bcc;
+        }
+        th.query-col { min-width: 200px; }
+        td.description {
+            font-family: monospace;
+            font-size: 11px;
+            word-wrap: break-word;
+            max-width: 400px;
+        }
+        td.result {
+            text-align: center;
+            font-size: 16px;
+            min-width: 40px;
+        }
+        td.test-result {
+            background: #f0f6fc;
+        }
+        .pass { color: #788c5d; }
+        .fail { color: #c44; }
+        .rate {
+            font-size: 9px;
+            color: #b0aea5;
+            display: block;
+        }
+        tr:hover { background: #faf9f5; }
+        .score {
+            display: inline-block;
+            padding: 2px 6px;
+            border-radius: 4px;
+            font-weight: bold;
+            font-size: 11px;
+        }
+        .score-good { background: #eef2e8; color: #788c5d; }
+        .score-ok { background: #fef3c7; color: #d97706; }
+        .score-bad { background: #fceaea; color: #c44; }
+        .train-label { color: #b0aea5; font-size: 10px; }
+        .test-label { color: #6a9bcc; font-size: 10px; font-weight: bold; }
+        .best-row { background: #f5f8f2; }
+        th.positive-col { border-bottom: 3px solid #788c5d; }
+        th.negative-col { border-bottom: 3px solid #c44; }
+        th.test-col.positive-col { border-bottom: 3px solid #788c5d; }
+        th.test-col.negative-col { border-bottom: 3px solid #c44; }
+        .legend { font-family: 'Poppins', sans-serif; display: flex; gap: 20px; margin-bottom: 10px; font-size: 13px; align-items: center; }
+        .legend-item { display: flex; align-items: center; gap: 6px; }
+        .legend-swatch { width: 16px; height: 16px; border-radius: 3px; display: inline-block; }
+        .swatch-positive { background: #141413; border-bottom: 3px solid #788c5d; }
+        .swatch-negative { background: #141413; border-bottom: 3px solid #c44; }
+        .swatch-test { background: #6a9bcc; }
+        .swatch-train { background: #141413; }
+    </style>
+</head>
+<body>
+    <h1>""" + title_prefix + """Skill Description Optimization</h1>
+    <div class="explainer">
+        <strong>Optimizing your skill's description.</strong> This page updates automatically as Claude tests different versions of your skill's description. Each row is an iteration — a new description attempt. The columns show test queries: green checkmarks mean the skill triggered correctly (or correctly didn't trigger), red crosses mean it got it wrong. The "Train" score shows performance on queries used to improve the description; the "Test" score shows performance on held-out queries the optimizer hasn't seen. When it's done, Claude will apply the best-performing description to your skill.
+    </div>
+"""]
+
+    # Summary section
+    best_test_score = data.get('best_test_score')
+    best_train_score = data.get('best_train_score')
+    html_parts.append(f"""
+    <div class="summary">
+        <p><strong>Original:</strong> {html.escape(data.get('original_description', 'N/A'))}</p>
+        <p class="best"><strong>Best:</strong> {html.escape(data.get('best_description', 'N/A'))}</p>
+        <p><strong>Best Score:</strong> {data.get('best_score', 'N/A')} {'(test)' if best_test_score else '(train)'}</p>
+        <p><strong>Iterations:</strong> {data.get('iterations_run', 0)} | <strong>Train:</strong> {data.get('train_size', '?')} | <strong>Test:</strong> {data.get('test_size', '?')}</p>
+    </div>
+""")
+
+    # Legend
+    html_parts.append("""
+    <div class="legend">
+        <span style="font-weight:600">Query columns:</span>
+        <span class="legend-item"><span class="legend-swatch swatch-positive"></span> Should trigger</span>
+        <span class="legend-item"><span class="legend-swatch swatch-negative"></span> Should NOT trigger</span>
+        <span class="legend-item"><span class="legend-swatch swatch-train"></span> Train</span>
+        <span class="legend-item"><span class="legend-swatch swatch-test"></span> Test</span>
+    </div>
+""")
+
+    # Table header
+    html_parts.append("""
+    <div class="table-container">
+    <table>
+        <thead>
+            <tr>
+                <th>Iter</th>
+                <th>Train</th>
+                <th>Test</th>
+                <th class="query-col">Description</th>
+""")
+
+    # Add column headers for train queries
+    for qinfo in train_queries:
+        polarity = "positive-col" if qinfo["should_trigger"] else "negative-col"
+        html_parts.append(f'                <th class="{polarity}">{html.escape(qinfo["query"])}</th>\n')
+
+    # Add column headers for test queries (different color)
+    for qinfo in test_queries:
+        polarity = "positive-col" if qinfo["should_trigger"] else "negative-col"
+        html_parts.append(f'                <th class="test-col {polarity}">{html.escape(qinfo["query"])}</th>\n')
+
+    html_parts.append("""            </tr>
+        </thead>
+        <tbody>
+""")
+
+    # Find best iteration for highlighting
+    if test_queries:
+        best_iter = max(history, key=lambda h: h.get("test_passed") or 0).get("iteration")
+    else:
+        best_iter = max(history, key=lambda h: h.get("train_passed", h.get("passed", 0))).get("iteration")
+
+    # Add rows for each iteration
+    for h in history:
+        iteration = h.get("iteration", "?")
+        train_passed = h.get("train_passed", h.get("passed", 0))
+        train_total = h.get("train_total", h.get("total", 0))
+        test_passed = h.get("test_passed")
+        test_total = h.get("test_total")
+        description = h.get("description", "")
+        train_results = h.get("train_results", h.get("results", []))
+        test_results = h.get("test_results", [])
+
+        # Create lookups for results by query
+        train_by_query = {r["query"]: r for r in train_results}
+        test_by_query = {r["query"]: r for r in test_results} if test_results else {}
+
+        # Compute aggregate correct/total runs across all retries
+        def aggregate_runs(results: list[dict]) -> tuple[int, int]:
+            correct = 0
+            total = 0
+            for r in results:
+                runs = r.get("runs", 0)
+                triggers = r.get("triggers", 0)
+                total += runs
+                if r.get("should_trigger", True):
+                    correct += triggers
+                else:
+                    correct += runs - triggers
+            return correct, total
+
+        train_correct, train_runs = aggregate_runs(train_results)
+        test_correct, test_runs = aggregate_runs(test_results)
+
+        # Determine score classes
+        def score_class(correct: int, total: int) -> str:
+            if total > 0:
+                ratio = correct / total
+                if ratio >= 0.8:
+                    return "score-good"
+                elif ratio >= 0.5:
+                    return "score-ok"
+            return "score-bad"
+
+        train_class = score_class(train_correct, train_runs)
+        test_class = score_class(test_correct, test_runs)
+
+        row_class = "best-row" if iteration == best_iter else ""
+
+        html_parts.append(f"""            <tr class="{row_class}">
+                <td>{iteration}</td>
+                <td><span class="score {train_class}">{train_correct}/{train_runs}</span></td>
+                <td><span class="score {test_class}">{test_correct}/{test_runs}</span></td>
+                <td class="description">{html.escape(description)}</td>
+""")
+
+        # Add result for each train query
+        for qinfo in train_queries:
+            r = train_by_query.get(qinfo["query"], {})
+            did_pass = r.get("pass", False)
+            triggers = r.get("triggers", 0)
+            runs = r.get("runs", 0)
+
+            icon = "✓" if did_pass else "✗"
+            css_class = "pass" if did_pass else "fail"
+
+            html_parts.append(f'                <td class="result {css_class}">{icon}<span class="rate">{triggers}/{runs}</span></td>\n')
+
+        # Add result for each test query (with different background)
+        for qinfo in test_queries:
+            r = test_by_query.get(qinfo["query"], {})
+            did_pass = r.get("pass", False)
+            triggers = r.get("triggers", 0)
+            runs = r.get("runs", 0)
+
+            icon = "✓" if did_pass else "✗"
+            css_class = "pass" if did_pass else "fail"
+
+            html_parts.append(f'                <td class="result test-result {css_class}">{icon}<span class="rate">{triggers}/{runs}</span></td>\n')
+
+        html_parts.append("            </tr>\n")
+
+    html_parts.append("""        </tbody>
+    </table>
+    </div>
+""")
+
+    html_parts.append("""
+</body>
+</html>
+""")
+
+    return "".join(html_parts)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Generate HTML report from run_loop output")
+    parser.add_argument("input", help="Path to JSON output from run_loop.py (or - for stdin)")
+    parser.add_argument("-o", "--output", default=None, help="Output HTML file (default: stdout)")
+    parser.add_argument("--skill-name", default="", help="Skill name to include in the report title")
+    args = parser.parse_args()
+
+    if args.input == "-":
+        data = json.load(sys.stdin)
+    else:
+        data = json.loads(Path(args.input).read_text())
+
+    html_output = generate_html(data, skill_name=args.skill_name)
+
+    if args.output:
+        Path(args.output).write_text(html_output)
+        print(f"Report written to {args.output}", file=sys.stderr)
+    else:
+        print(html_output)
+
+
+if __name__ == "__main__":
+    main()

--- a/eval/triggering/scripts/generate_report.py
+++ b/eval/triggering/scripts/generate_report.py
@@ -311,7 +311,7 @@ def main():
     if args.input == "-":
         data = json.load(sys.stdin)
     else:
-        data = json.loads(Path(args.input).read_text())
+        data = json.loads(Path(args.input).read_text(encoding="utf-8"))
 
     html_output = generate_html(data, skill_name=args.skill_name)
 

--- a/eval/triggering/scripts/improve_description.py
+++ b/eval/triggering/scripts/improve_description.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env python3
+"""Improve a skill description based on eval results.
+
+Takes eval results (from run_eval.py) and generates an improved description
+by calling `claude -p` as a subprocess (same auth pattern as run_eval.py —
+uses the session's Claude Code auth, no separate ANTHROPIC_API_KEY needed).
+"""
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+from scripts.utils import parse_skill_md
+
+
+def _call_claude(prompt: str, model: str | None, timeout: int = 300) -> str:
+    """Run `claude -p` with the prompt on stdin and return the text response.
+
+    Prompt goes over stdin (not argv) because it embeds the full SKILL.md
+    body and can easily exceed comfortable argv length.
+    """
+    cmd = ["claude", "-p", "--output-format", "text"]
+    if model:
+        cmd.extend(["--model", model])
+
+    # Remove CLAUDECODE env var to allow nesting claude -p inside a
+    # Claude Code session. The guard is for interactive terminal conflicts;
+    # programmatic subprocess usage is safe. Same pattern as run_eval.py.
+    env = {k: v for k, v in os.environ.items() if k != "CLAUDECODE"}
+
+    result = subprocess.run(
+        cmd,
+        input=prompt,
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=timeout,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"claude -p exited {result.returncode}\nstderr: {result.stderr}"
+        )
+    return result.stdout
+
+
+def improve_description(
+    skill_name: str,
+    skill_content: str,
+    current_description: str,
+    eval_results: dict,
+    history: list[dict],
+    model: str,
+    test_results: dict | None = None,
+    log_dir: Path | None = None,
+    iteration: int | None = None,
+) -> str:
+    """Call Claude to improve the description based on eval results."""
+    failed_triggers = [
+        r for r in eval_results["results"]
+        if r["should_trigger"] and not r["pass"]
+    ]
+    false_triggers = [
+        r for r in eval_results["results"]
+        if not r["should_trigger"] and not r["pass"]
+    ]
+
+    # Build scores summary
+    train_score = f"{eval_results['summary']['passed']}/{eval_results['summary']['total']}"
+    if test_results:
+        test_score = f"{test_results['summary']['passed']}/{test_results['summary']['total']}"
+        scores_summary = f"Train: {train_score}, Test: {test_score}"
+    else:
+        scores_summary = f"Train: {train_score}"
+
+    prompt = f"""You are optimizing a skill description for a Claude Code skill called "{skill_name}". A "skill" is sort of like a prompt, but with progressive disclosure -- there's a title and description that Claude sees when deciding whether to use the skill, and then if it does use the skill, it reads the .md file which has lots more details and potentially links to other resources in the skill folder like helper files and scripts and additional documentation or examples.
+
+The description appears in Claude's "available_skills" list. When a user sends a query, Claude decides whether to invoke the skill based solely on the title and on this description. Your goal is to write a description that triggers for relevant queries, and doesn't trigger for irrelevant ones.
+
+Here's the current description:
+<current_description>
+"{current_description}"
+</current_description>
+
+Current scores ({scores_summary}):
+<scores_summary>
+"""
+    if failed_triggers:
+        prompt += "FAILED TO TRIGGER (should have triggered but didn't):\n"
+        for r in failed_triggers:
+            prompt += f'  - "{r["query"]}" (triggered {r["triggers"]}/{r["runs"]} times)\n'
+        prompt += "\n"
+
+    if false_triggers:
+        prompt += "FALSE TRIGGERS (triggered but shouldn't have):\n"
+        for r in false_triggers:
+            prompt += f'  - "{r["query"]}" (triggered {r["triggers"]}/{r["runs"]} times)\n'
+        prompt += "\n"
+
+    if history:
+        prompt += "PREVIOUS ATTEMPTS (do NOT repeat these — try something structurally different):\n\n"
+        for h in history:
+            train_s = f"{h.get('train_passed', h.get('passed', 0))}/{h.get('train_total', h.get('total', 0))}"
+            test_s = f"{h.get('test_passed', '?')}/{h.get('test_total', '?')}" if h.get('test_passed') is not None else None
+            score_str = f"train={train_s}" + (f", test={test_s}" if test_s else "")
+            prompt += f'<attempt {score_str}>\n'
+            prompt += f'Description: "{h["description"]}"\n'
+            if "results" in h:
+                prompt += "Train results:\n"
+                for r in h["results"]:
+                    status = "PASS" if r["pass"] else "FAIL"
+                    prompt += f'  [{status}] "{r["query"][:80]}" (triggered {r["triggers"]}/{r["runs"]})\n'
+            if h.get("note"):
+                prompt += f'Note: {h["note"]}\n'
+            prompt += "</attempt>\n\n"
+
+    prompt += f"""</scores_summary>
+
+Skill content (for context on what the skill does):
+<skill_content>
+{skill_content}
+</skill_content>
+
+Based on the failures, write a new and improved description that is more likely to trigger correctly. When I say "based on the failures", it's a bit of a tricky line to walk because we don't want to overfit to the specific cases you're seeing. So what I DON'T want you to do is produce an ever-expanding list of specific queries that this skill should or shouldn't trigger for. Instead, try to generalize from the failures to broader categories of user intent and situations where this skill would be useful or not useful. The reason for this is twofold:
+
+1. Avoid overfitting
+2. The list might get loooong and it's injected into ALL queries and there might be a lot of skills, so we don't want to blow too much space on any given description.
+
+Concretely, your description should not be more than about 100-200 words, even if that comes at the cost of accuracy. There is a hard limit of 1024 characters — descriptions over that will be truncated, so stay comfortably under it.
+
+Here are some tips that we've found to work well in writing these descriptions:
+- The skill should be phrased in the imperative -- "Use this skill for" rather than "this skill does"
+- The skill description should focus on the user's intent, what they are trying to achieve, vs. the implementation details of how the skill works.
+- The description competes with other skills for Claude's attention — make it distinctive and immediately recognizable.
+- If you're getting lots of failures after repeated attempts, change things up. Try different sentence structures or wordings.
+
+I'd encourage you to be creative and mix up the style in different iterations since you'll have multiple opportunities to try different approaches and we'll just grab the highest-scoring one at the end. 
+
+Please respond with only the new description text in <new_description> tags, nothing else."""
+
+    text = _call_claude(prompt, model)
+
+    match = re.search(r"<new_description>(.*?)</new_description>", text, re.DOTALL)
+    description = match.group(1).strip().strip('"') if match else text.strip().strip('"')
+
+    transcript: dict = {
+        "iteration": iteration,
+        "prompt": prompt,
+        "response": text,
+        "parsed_description": description,
+        "char_count": len(description),
+        "over_limit": len(description) > 1024,
+    }
+
+    # Safety net: the prompt already states the 1024-char hard limit, but if
+    # the model blew past it anyway, make one fresh single-turn call that
+    # quotes the too-long version and asks for a shorter rewrite. (The old
+    # SDK path did this as a true multi-turn; `claude -p` is one-shot, so we
+    # inline the prior output into the new prompt instead.)
+    if len(description) > 1024:
+        shorten_prompt = (
+            f"{prompt}\n\n"
+            f"---\n\n"
+            f"A previous attempt produced this description, which at "
+            f"{len(description)} characters is over the 1024-character hard limit:\n\n"
+            f'"{description}"\n\n'
+            f"Rewrite it to be under 1024 characters while keeping the most "
+            f"important trigger words and intent coverage. Respond with only "
+            f"the new description in <new_description> tags."
+        )
+        shorten_text = _call_claude(shorten_prompt, model)
+        match = re.search(r"<new_description>(.*?)</new_description>", shorten_text, re.DOTALL)
+        shortened = match.group(1).strip().strip('"') if match else shorten_text.strip().strip('"')
+
+        transcript["rewrite_prompt"] = shorten_prompt
+        transcript["rewrite_response"] = shorten_text
+        transcript["rewrite_description"] = shortened
+        transcript["rewrite_char_count"] = len(shortened)
+        description = shortened
+
+    transcript["final_description"] = description
+
+    if log_dir:
+        log_dir.mkdir(parents=True, exist_ok=True)
+        log_file = log_dir / f"improve_iter_{iteration or 'unknown'}.json"
+        log_file.write_text(json.dumps(transcript, indent=2))
+
+    return description
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Improve a skill description based on eval results")
+    parser.add_argument("--eval-results", required=True, help="Path to eval results JSON (from run_eval.py)")
+    parser.add_argument("--skill-path", required=True, help="Path to skill directory")
+    parser.add_argument("--history", default=None, help="Path to history JSON (previous attempts)")
+    parser.add_argument("--model", required=True, help="Model for improvement")
+    parser.add_argument("--verbose", action="store_true", help="Print thinking to stderr")
+    args = parser.parse_args()
+
+    skill_path = Path(args.skill_path)
+    if not (skill_path / "SKILL.md").exists():
+        print(f"Error: No SKILL.md found at {skill_path}", file=sys.stderr)
+        sys.exit(1)
+
+    eval_results = json.loads(Path(args.eval_results).read_text())
+    history = []
+    if args.history:
+        history = json.loads(Path(args.history).read_text())
+
+    name, _, content = parse_skill_md(skill_path)
+    current_description = eval_results["description"]
+
+    if args.verbose:
+        print(f"Current: {current_description}", file=sys.stderr)
+        print(f"Score: {eval_results['summary']['passed']}/{eval_results['summary']['total']}", file=sys.stderr)
+
+    new_description = improve_description(
+        skill_name=name,
+        skill_content=content,
+        current_description=current_description,
+        eval_results=eval_results,
+        history=history,
+        model=args.model,
+    )
+
+    if args.verbose:
+        print(f"Improved: {new_description}", file=sys.stderr)
+
+    # Output as JSON with both the new description and updated history
+    output = {
+        "description": new_description,
+        "history": history + [{
+            "description": current_description,
+            "passed": eval_results["summary"]["passed"],
+            "failed": eval_results["summary"]["failed"],
+            "total": eval_results["summary"]["total"],
+            "results": eval_results["results"],
+        }],
+    }
+    print(json.dumps(output, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/eval/triggering/scripts/improve_description.py
+++ b/eval/triggering/scripts/improve_description.py
@@ -205,10 +205,10 @@ def main():
         print(f"Error: No SKILL.md found at {skill_path}", file=sys.stderr)
         sys.exit(1)
 
-    eval_results = json.loads(Path(args.eval_results).read_text())
+    eval_results = json.loads(Path(args.eval_results).read_text(encoding="utf-8"))
     history = []
     if args.history:
-        history = json.loads(Path(args.history).read_text())
+        history = json.loads(Path(args.history).read_text(encoding="utf-8"))
 
     name, _, content = parse_skill_md(skill_path)
     current_description = eval_results["description"]

--- a/eval/triggering/scripts/run_eval.py
+++ b/eval/triggering/scripts/run_eval.py
@@ -1,0 +1,310 @@
+#!/usr/bin/env python3
+"""Run trigger evaluation for a skill description.
+
+Tests whether a skill's description causes Claude to trigger (read the skill)
+for a set of queries. Outputs results as JSON.
+"""
+
+import argparse
+import json
+import os
+import select
+import subprocess
+import sys
+import time
+import uuid
+from concurrent.futures import ProcessPoolExecutor, as_completed
+from pathlib import Path
+
+from scripts.utils import parse_skill_md
+
+
+def find_project_root() -> Path:
+    """Find the project root by walking up from cwd looking for .claude/.
+
+    Mimics how Claude Code discovers its project root, so the command file
+    we create ends up where claude -p will look for it.
+    """
+    current = Path.cwd()
+    for parent in [current, *current.parents]:
+        if (parent / ".claude").is_dir():
+            return parent
+    return current
+
+
+def run_single_query(
+    query: str,
+    skill_name: str,
+    skill_description: str,
+    timeout: int,
+    project_root: str,
+    model: str | None = None,
+) -> bool:
+    """Run a single query and return whether the skill was triggered.
+
+    Creates a command file in .claude/commands/ so it appears in Claude's
+    available_skills list, then runs `claude -p` with the raw query.
+    Uses --include-partial-messages to detect triggering early from
+    stream events (content_block_start) rather than waiting for the
+    full assistant message, which only arrives after tool execution.
+    """
+    unique_id = uuid.uuid4().hex[:8]
+    clean_name = f"{skill_name}-skill-{unique_id}"
+    project_commands_dir = Path(project_root) / ".claude" / "commands"
+    command_file = project_commands_dir / f"{clean_name}.md"
+
+    try:
+        project_commands_dir.mkdir(parents=True, exist_ok=True)
+        # Use YAML block scalar to avoid breaking on quotes in description
+        indented_desc = "\n  ".join(skill_description.split("\n"))
+        command_content = (
+            f"---\n"
+            f"description: |\n"
+            f"  {indented_desc}\n"
+            f"---\n\n"
+            f"# {skill_name}\n\n"
+            f"This skill handles: {skill_description}\n"
+        )
+        command_file.write_text(command_content)
+
+        cmd = [
+            "claude",
+            "-p", query,
+            "--output-format", "stream-json",
+            "--verbose",
+            "--include-partial-messages",
+        ]
+        if model:
+            cmd.extend(["--model", model])
+
+        # Remove CLAUDECODE env var to allow nesting claude -p inside a
+        # Claude Code session. The guard is for interactive terminal conflicts;
+        # programmatic subprocess usage is safe.
+        env = {k: v for k, v in os.environ.items() if k != "CLAUDECODE"}
+
+        process = subprocess.Popen(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            cwd=project_root,
+            env=env,
+        )
+
+        triggered = False
+        start_time = time.time()
+        buffer = ""
+        # Track state for stream event detection
+        pending_tool_name = None
+        accumulated_json = ""
+
+        try:
+            while time.time() - start_time < timeout:
+                if process.poll() is not None:
+                    remaining = process.stdout.read()
+                    if remaining:
+                        buffer += remaining.decode("utf-8", errors="replace")
+                    break
+
+                ready, _, _ = select.select([process.stdout], [], [], 1.0)
+                if not ready:
+                    continue
+
+                chunk = os.read(process.stdout.fileno(), 8192)
+                if not chunk:
+                    break
+                buffer += chunk.decode("utf-8", errors="replace")
+
+                while "\n" in buffer:
+                    line, buffer = buffer.split("\n", 1)
+                    line = line.strip()
+                    if not line:
+                        continue
+
+                    try:
+                        event = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+
+                    # Early detection via stream events
+                    if event.get("type") == "stream_event":
+                        se = event.get("event", {})
+                        se_type = se.get("type", "")
+
+                        if se_type == "content_block_start":
+                            cb = se.get("content_block", {})
+                            if cb.get("type") == "tool_use":
+                                tool_name = cb.get("name", "")
+                                if tool_name in ("Skill", "Read"):
+                                    pending_tool_name = tool_name
+                                    accumulated_json = ""
+                                else:
+                                    return False
+
+                        elif se_type == "content_block_delta" and pending_tool_name:
+                            delta = se.get("delta", {})
+                            if delta.get("type") == "input_json_delta":
+                                accumulated_json += delta.get("partial_json", "")
+                                if clean_name in accumulated_json:
+                                    return True
+
+                        elif se_type in ("content_block_stop", "message_stop"):
+                            if pending_tool_name:
+                                return clean_name in accumulated_json
+                            if se_type == "message_stop":
+                                return False
+
+                    # Fallback: full assistant message
+                    elif event.get("type") == "assistant":
+                        message = event.get("message", {})
+                        for content_item in message.get("content", []):
+                            if content_item.get("type") != "tool_use":
+                                continue
+                            tool_name = content_item.get("name", "")
+                            tool_input = content_item.get("input", {})
+                            if tool_name == "Skill" and clean_name in tool_input.get("skill", ""):
+                                triggered = True
+                            elif tool_name == "Read" and clean_name in tool_input.get("file_path", ""):
+                                triggered = True
+                            return triggered
+
+                    elif event.get("type") == "result":
+                        return triggered
+        finally:
+            # Clean up process on any exit path (return, exception, timeout)
+            if process.poll() is None:
+                process.kill()
+                process.wait()
+
+        return triggered
+    finally:
+        if command_file.exists():
+            command_file.unlink()
+
+
+def run_eval(
+    eval_set: list[dict],
+    skill_name: str,
+    description: str,
+    num_workers: int,
+    timeout: int,
+    project_root: Path,
+    runs_per_query: int = 1,
+    trigger_threshold: float = 0.5,
+    model: str | None = None,
+) -> dict:
+    """Run the full eval set and return results."""
+    results = []
+
+    with ProcessPoolExecutor(max_workers=num_workers) as executor:
+        future_to_info = {}
+        for item in eval_set:
+            for run_idx in range(runs_per_query):
+                future = executor.submit(
+                    run_single_query,
+                    item["query"],
+                    skill_name,
+                    description,
+                    timeout,
+                    str(project_root),
+                    model,
+                )
+                future_to_info[future] = (item, run_idx)
+
+        query_triggers: dict[str, list[bool]] = {}
+        query_items: dict[str, dict] = {}
+        for future in as_completed(future_to_info):
+            item, _ = future_to_info[future]
+            query = item["query"]
+            query_items[query] = item
+            if query not in query_triggers:
+                query_triggers[query] = []
+            try:
+                query_triggers[query].append(future.result())
+            except Exception as e:
+                print(f"Warning: query failed: {e}", file=sys.stderr)
+                query_triggers[query].append(False)
+
+    for query, triggers in query_triggers.items():
+        item = query_items[query]
+        trigger_rate = sum(triggers) / len(triggers)
+        should_trigger = item["should_trigger"]
+        if should_trigger:
+            did_pass = trigger_rate >= trigger_threshold
+        else:
+            did_pass = trigger_rate < trigger_threshold
+        results.append({
+            "query": query,
+            "should_trigger": should_trigger,
+            "trigger_rate": trigger_rate,
+            "triggers": sum(triggers),
+            "runs": len(triggers),
+            "pass": did_pass,
+        })
+
+    passed = sum(1 for r in results if r["pass"])
+    total = len(results)
+
+    return {
+        "skill_name": skill_name,
+        "description": description,
+        "results": results,
+        "summary": {
+            "total": total,
+            "passed": passed,
+            "failed": total - passed,
+        },
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Run trigger evaluation for a skill description")
+    parser.add_argument("--eval-set", required=True, help="Path to eval set JSON file")
+    parser.add_argument("--skill-path", required=True, help="Path to skill directory")
+    parser.add_argument("--description", default=None, help="Override description to test")
+    parser.add_argument("--num-workers", type=int, default=10, help="Number of parallel workers")
+    parser.add_argument("--timeout", type=int, default=30, help="Timeout per query in seconds")
+    parser.add_argument("--runs-per-query", type=int, default=3, help="Number of runs per query")
+    parser.add_argument("--trigger-threshold", type=float, default=0.5, help="Trigger rate threshold")
+    parser.add_argument("--model", default=None, help="Model to use for claude -p (default: user's configured model)")
+    parser.add_argument("--verbose", action="store_true", help="Print progress to stderr")
+    args = parser.parse_args()
+
+    eval_set = json.loads(Path(args.eval_set).read_text())
+    skill_path = Path(args.skill_path)
+
+    if not (skill_path / "SKILL.md").exists():
+        print(f"Error: No SKILL.md found at {skill_path}", file=sys.stderr)
+        sys.exit(1)
+
+    name, original_description, content = parse_skill_md(skill_path)
+    description = args.description or original_description
+    project_root = find_project_root()
+
+    if args.verbose:
+        print(f"Evaluating: {description}", file=sys.stderr)
+
+    output = run_eval(
+        eval_set=eval_set,
+        skill_name=name,
+        description=description,
+        num_workers=args.num_workers,
+        timeout=args.timeout,
+        project_root=project_root,
+        runs_per_query=args.runs_per_query,
+        trigger_threshold=args.trigger_threshold,
+        model=args.model,
+    )
+
+    if args.verbose:
+        summary = output["summary"]
+        print(f"Results: {summary['passed']}/{summary['total']} passed", file=sys.stderr)
+        for r in output["results"]:
+            status = "PASS" if r["pass"] else "FAIL"
+            rate_str = f"{r['triggers']}/{r['runs']}"
+            print(f"  [{status}] rate={rate_str} expected={r['should_trigger']}: {r['query'][:70]}", file=sys.stderr)
+
+    print(json.dumps(output, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/eval/triggering/scripts/run_eval.py
+++ b/eval/triggering/scripts/run_eval.py
@@ -269,7 +269,7 @@ def main():
     parser.add_argument("--verbose", action="store_true", help="Print progress to stderr")
     args = parser.parse_args()
 
-    eval_set = json.loads(Path(args.eval_set).read_text())
+    eval_set = json.loads(Path(args.eval_set).read_text(encoding="utf-8"))
     skill_path = Path(args.skill_path)
 
     if not (skill_path / "SKILL.md").exists():

--- a/eval/triggering/scripts/run_loop.py
+++ b/eval/triggering/scripts/run_loop.py
@@ -1,0 +1,328 @@
+#!/usr/bin/env python3
+"""Run the eval + improve loop until all pass or max iterations reached.
+
+Combines run_eval.py and improve_description.py in a loop, tracking history
+and returning the best description found. Supports train/test split to prevent
+overfitting.
+"""
+
+import argparse
+import json
+import random
+import sys
+import tempfile
+import time
+import webbrowser
+from pathlib import Path
+
+from scripts.generate_report import generate_html
+from scripts.improve_description import improve_description
+from scripts.run_eval import find_project_root, run_eval
+from scripts.utils import parse_skill_md
+
+
+def split_eval_set(eval_set: list[dict], holdout: float, seed: int = 42) -> tuple[list[dict], list[dict]]:
+    """Split eval set into train and test sets, stratified by should_trigger."""
+    random.seed(seed)
+
+    # Separate by should_trigger
+    trigger = [e for e in eval_set if e["should_trigger"]]
+    no_trigger = [e for e in eval_set if not e["should_trigger"]]
+
+    # Shuffle each group
+    random.shuffle(trigger)
+    random.shuffle(no_trigger)
+
+    # Calculate split points
+    n_trigger_test = max(1, int(len(trigger) * holdout))
+    n_no_trigger_test = max(1, int(len(no_trigger) * holdout))
+
+    # Split
+    test_set = trigger[:n_trigger_test] + no_trigger[:n_no_trigger_test]
+    train_set = trigger[n_trigger_test:] + no_trigger[n_no_trigger_test:]
+
+    return train_set, test_set
+
+
+def run_loop(
+    eval_set: list[dict],
+    skill_path: Path,
+    description_override: str | None,
+    num_workers: int,
+    timeout: int,
+    max_iterations: int,
+    runs_per_query: int,
+    trigger_threshold: float,
+    holdout: float,
+    model: str,
+    verbose: bool,
+    live_report_path: Path | None = None,
+    log_dir: Path | None = None,
+) -> dict:
+    """Run the eval + improvement loop."""
+    project_root = find_project_root()
+    name, original_description, content = parse_skill_md(skill_path)
+    current_description = description_override or original_description
+
+    # Split into train/test if holdout > 0
+    if holdout > 0:
+        train_set, test_set = split_eval_set(eval_set, holdout)
+        if verbose:
+            print(f"Split: {len(train_set)} train, {len(test_set)} test (holdout={holdout})", file=sys.stderr)
+    else:
+        train_set = eval_set
+        test_set = []
+
+    history = []
+    exit_reason = "unknown"
+
+    for iteration in range(1, max_iterations + 1):
+        if verbose:
+            print(f"\n{'='*60}", file=sys.stderr)
+            print(f"Iteration {iteration}/{max_iterations}", file=sys.stderr)
+            print(f"Description: {current_description}", file=sys.stderr)
+            print(f"{'='*60}", file=sys.stderr)
+
+        # Evaluate train + test together in one batch for parallelism
+        all_queries = train_set + test_set
+        t0 = time.time()
+        all_results = run_eval(
+            eval_set=all_queries,
+            skill_name=name,
+            description=current_description,
+            num_workers=num_workers,
+            timeout=timeout,
+            project_root=project_root,
+            runs_per_query=runs_per_query,
+            trigger_threshold=trigger_threshold,
+            model=model,
+        )
+        eval_elapsed = time.time() - t0
+
+        # Split results back into train/test by matching queries
+        train_queries_set = {q["query"] for q in train_set}
+        train_result_list = [r for r in all_results["results"] if r["query"] in train_queries_set]
+        test_result_list = [r for r in all_results["results"] if r["query"] not in train_queries_set]
+
+        train_passed = sum(1 for r in train_result_list if r["pass"])
+        train_total = len(train_result_list)
+        train_summary = {"passed": train_passed, "failed": train_total - train_passed, "total": train_total}
+        train_results = {"results": train_result_list, "summary": train_summary}
+
+        if test_set:
+            test_passed = sum(1 for r in test_result_list if r["pass"])
+            test_total = len(test_result_list)
+            test_summary = {"passed": test_passed, "failed": test_total - test_passed, "total": test_total}
+            test_results = {"results": test_result_list, "summary": test_summary}
+        else:
+            test_results = None
+            test_summary = None
+
+        history.append({
+            "iteration": iteration,
+            "description": current_description,
+            "train_passed": train_summary["passed"],
+            "train_failed": train_summary["failed"],
+            "train_total": train_summary["total"],
+            "train_results": train_results["results"],
+            "test_passed": test_summary["passed"] if test_summary else None,
+            "test_failed": test_summary["failed"] if test_summary else None,
+            "test_total": test_summary["total"] if test_summary else None,
+            "test_results": test_results["results"] if test_results else None,
+            # For backward compat with report generator
+            "passed": train_summary["passed"],
+            "failed": train_summary["failed"],
+            "total": train_summary["total"],
+            "results": train_results["results"],
+        })
+
+        # Write live report if path provided
+        if live_report_path:
+            partial_output = {
+                "original_description": original_description,
+                "best_description": current_description,
+                "best_score": "in progress",
+                "iterations_run": len(history),
+                "holdout": holdout,
+                "train_size": len(train_set),
+                "test_size": len(test_set),
+                "history": history,
+            }
+            live_report_path.write_text(generate_html(partial_output, auto_refresh=True, skill_name=name))
+
+        if verbose:
+            def print_eval_stats(label, results, elapsed):
+                pos = [r for r in results if r["should_trigger"]]
+                neg = [r for r in results if not r["should_trigger"]]
+                tp = sum(r["triggers"] for r in pos)
+                pos_runs = sum(r["runs"] for r in pos)
+                fn = pos_runs - tp
+                fp = sum(r["triggers"] for r in neg)
+                neg_runs = sum(r["runs"] for r in neg)
+                tn = neg_runs - fp
+                total = tp + tn + fp + fn
+                precision = tp / (tp + fp) if (tp + fp) > 0 else 1.0
+                recall = tp / (tp + fn) if (tp + fn) > 0 else 1.0
+                accuracy = (tp + tn) / total if total > 0 else 0.0
+                print(f"{label}: {tp+tn}/{total} correct, precision={precision:.0%} recall={recall:.0%} accuracy={accuracy:.0%} ({elapsed:.1f}s)", file=sys.stderr)
+                for r in results:
+                    status = "PASS" if r["pass"] else "FAIL"
+                    rate_str = f"{r['triggers']}/{r['runs']}"
+                    print(f"  [{status}] rate={rate_str} expected={r['should_trigger']}: {r['query'][:60]}", file=sys.stderr)
+
+            print_eval_stats("Train", train_results["results"], eval_elapsed)
+            if test_summary:
+                print_eval_stats("Test ", test_results["results"], 0)
+
+        if train_summary["failed"] == 0:
+            exit_reason = f"all_passed (iteration {iteration})"
+            if verbose:
+                print(f"\nAll train queries passed on iteration {iteration}!", file=sys.stderr)
+            break
+
+        if iteration == max_iterations:
+            exit_reason = f"max_iterations ({max_iterations})"
+            if verbose:
+                print(f"\nMax iterations reached ({max_iterations}).", file=sys.stderr)
+            break
+
+        # Improve the description based on train results
+        if verbose:
+            print(f"\nImproving description...", file=sys.stderr)
+
+        t0 = time.time()
+        # Strip test scores from history so improvement model can't see them
+        blinded_history = [
+            {k: v for k, v in h.items() if not k.startswith("test_")}
+            for h in history
+        ]
+        new_description = improve_description(
+            skill_name=name,
+            skill_content=content,
+            current_description=current_description,
+            eval_results=train_results,
+            history=blinded_history,
+            model=model,
+            log_dir=log_dir,
+            iteration=iteration,
+        )
+        improve_elapsed = time.time() - t0
+
+        if verbose:
+            print(f"Proposed ({improve_elapsed:.1f}s): {new_description}", file=sys.stderr)
+
+        current_description = new_description
+
+    # Find the best iteration by TEST score (or train if no test set)
+    if test_set:
+        best = max(history, key=lambda h: h["test_passed"] or 0)
+        best_score = f"{best['test_passed']}/{best['test_total']}"
+    else:
+        best = max(history, key=lambda h: h["train_passed"])
+        best_score = f"{best['train_passed']}/{best['train_total']}"
+
+    if verbose:
+        print(f"\nExit reason: {exit_reason}", file=sys.stderr)
+        print(f"Best score: {best_score} (iteration {best['iteration']})", file=sys.stderr)
+
+    return {
+        "exit_reason": exit_reason,
+        "original_description": original_description,
+        "best_description": best["description"],
+        "best_score": best_score,
+        "best_train_score": f"{best['train_passed']}/{best['train_total']}",
+        "best_test_score": f"{best['test_passed']}/{best['test_total']}" if test_set else None,
+        "final_description": current_description,
+        "iterations_run": len(history),
+        "holdout": holdout,
+        "train_size": len(train_set),
+        "test_size": len(test_set),
+        "history": history,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Run eval + improve loop")
+    parser.add_argument("--eval-set", required=True, help="Path to eval set JSON file")
+    parser.add_argument("--skill-path", required=True, help="Path to skill directory")
+    parser.add_argument("--description", default=None, help="Override starting description")
+    parser.add_argument("--num-workers", type=int, default=10, help="Number of parallel workers")
+    parser.add_argument("--timeout", type=int, default=30, help="Timeout per query in seconds")
+    parser.add_argument("--max-iterations", type=int, default=5, help="Max improvement iterations")
+    parser.add_argument("--runs-per-query", type=int, default=3, help="Number of runs per query")
+    parser.add_argument("--trigger-threshold", type=float, default=0.5, help="Trigger rate threshold")
+    parser.add_argument("--holdout", type=float, default=0.4, help="Fraction of eval set to hold out for testing (0 to disable)")
+    parser.add_argument("--model", required=True, help="Model for improvement")
+    parser.add_argument("--verbose", action="store_true", help="Print progress to stderr")
+    parser.add_argument("--report", default="auto", help="Generate HTML report at this path (default: 'auto' for temp file, 'none' to disable)")
+    parser.add_argument("--results-dir", default=None, help="Save all outputs (results.json, report.html, log.txt) to a timestamped subdirectory here")
+    args = parser.parse_args()
+
+    eval_set = json.loads(Path(args.eval_set).read_text())
+    skill_path = Path(args.skill_path)
+
+    if not (skill_path / "SKILL.md").exists():
+        print(f"Error: No SKILL.md found at {skill_path}", file=sys.stderr)
+        sys.exit(1)
+
+    name, _, _ = parse_skill_md(skill_path)
+
+    # Set up live report path
+    if args.report != "none":
+        if args.report == "auto":
+            timestamp = time.strftime("%Y%m%d_%H%M%S")
+            live_report_path = Path(tempfile.gettempdir()) / f"skill_description_report_{skill_path.name}_{timestamp}.html"
+        else:
+            live_report_path = Path(args.report)
+        # Open the report immediately so the user can watch
+        live_report_path.write_text("<html><body><h1>Starting optimization loop...</h1><meta http-equiv='refresh' content='5'></body></html>")
+        webbrowser.open(str(live_report_path))
+    else:
+        live_report_path = None
+
+    # Determine output directory (create before run_loop so logs can be written)
+    if args.results_dir:
+        timestamp = time.strftime("%Y-%m-%d_%H%M%S")
+        results_dir = Path(args.results_dir) / timestamp
+        results_dir.mkdir(parents=True, exist_ok=True)
+    else:
+        results_dir = None
+
+    log_dir = results_dir / "logs" if results_dir else None
+
+    output = run_loop(
+        eval_set=eval_set,
+        skill_path=skill_path,
+        description_override=args.description,
+        num_workers=args.num_workers,
+        timeout=args.timeout,
+        max_iterations=args.max_iterations,
+        runs_per_query=args.runs_per_query,
+        trigger_threshold=args.trigger_threshold,
+        holdout=args.holdout,
+        model=args.model,
+        verbose=args.verbose,
+        live_report_path=live_report_path,
+        log_dir=log_dir,
+    )
+
+    # Save JSON output
+    json_output = json.dumps(output, indent=2)
+    print(json_output)
+    if results_dir:
+        (results_dir / "results.json").write_text(json_output)
+
+    # Write final HTML report (without auto-refresh)
+    if live_report_path:
+        live_report_path.write_text(generate_html(output, auto_refresh=False, skill_name=name))
+        print(f"\nReport: {live_report_path}", file=sys.stderr)
+
+    if results_dir and live_report_path:
+        (results_dir / "report.html").write_text(generate_html(output, auto_refresh=False, skill_name=name))
+
+    if results_dir:
+        print(f"Results saved to: {results_dir}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/eval/triggering/scripts/run_loop.py
+++ b/eval/triggering/scripts/run_loop.py
@@ -258,7 +258,7 @@ def main():
     parser.add_argument("--results-dir", default=None, help="Save all outputs (results.json, report.html, log.txt) to a timestamped subdirectory here")
     args = parser.parse_args()
 
-    eval_set = json.loads(Path(args.eval_set).read_text())
+    eval_set = json.loads(Path(args.eval_set).read_text(encoding="utf-8"))
     skill_path = Path(args.skill_path)
 
     if not (skill_path / "SKILL.md").exists():

--- a/eval/triggering/scripts/utils.py
+++ b/eval/triggering/scripts/utils.py
@@ -1,0 +1,47 @@
+"""Shared utilities for skill-creator scripts."""
+
+from pathlib import Path
+
+
+
+def parse_skill_md(skill_path: Path) -> tuple[str, str, str]:
+    """Parse a SKILL.md file, returning (name, description, full_content)."""
+    content = (skill_path / "SKILL.md").read_text()
+    lines = content.split("\n")
+
+    if lines[0].strip() != "---":
+        raise ValueError("SKILL.md missing frontmatter (no opening ---)")
+
+    end_idx = None
+    for i, line in enumerate(lines[1:], start=1):
+        if line.strip() == "---":
+            end_idx = i
+            break
+
+    if end_idx is None:
+        raise ValueError("SKILL.md missing frontmatter (no closing ---)")
+
+    name = ""
+    description = ""
+    frontmatter_lines = lines[1:end_idx]
+    i = 0
+    while i < len(frontmatter_lines):
+        line = frontmatter_lines[i]
+        if line.startswith("name:"):
+            name = line[len("name:"):].strip().strip('"').strip("'")
+        elif line.startswith("description:"):
+            value = line[len("description:"):].strip()
+            # Handle YAML multiline indicators (>, |, >-, |-)
+            if value in (">", "|", ">-", "|-"):
+                continuation_lines: list[str] = []
+                i += 1
+                while i < len(frontmatter_lines) and (frontmatter_lines[i].startswith("  ") or frontmatter_lines[i].startswith("\t")):
+                    continuation_lines.append(frontmatter_lines[i].strip())
+                    i += 1
+                description = " ".join(continuation_lines)
+                continue
+            else:
+                description = value.strip('"').strip("'")
+        i += 1
+
+    return name, description, content

--- a/eval/triggering/scripts/utils.py
+++ b/eval/triggering/scripts/utils.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 def parse_skill_md(skill_path: Path) -> tuple[str, str, str]:
     """Parse a SKILL.md file, returning (name, description, full_content)."""
-    content = (skill_path / "SKILL.md").read_text()
+    content = (skill_path / "SKILL.md").read_text(encoding="utf-8")
     lines = content.split("\n")
 
     if lines[0].strip() != "---":

--- a/packages/engine/plugin/references/places-guidance.md
+++ b/packages/engine/plugin/references/places-guidance.md
@@ -3,7 +3,7 @@
   This block is duplicated, byte-for-byte, into each place-using skill's
   references/places-guidance.md (Claude Code can't reliably load a shared
   reference across skills — issue #17741 — so each skill carries its own copy).
-  A drift lint (mcp-server/tests/packaging/skill-guidance.test.ts) fails if any
+  A drift lint (packages/engine/mcp-server/tests/packaging/skill-guidance.test.ts) fails if any
   copy diverges from this source. To change the guidance: edit this file, then
   re-copy it into every skill listed in that test.
 -->

--- a/packages/engine/plugin/skills/author-e2e-fixture/SKILL.md
+++ b/packages/engine/plugin/skills/author-e2e-fixture/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: author-e2e-fixture
 model: claude-sonnet-4-6
-description: Authors an end-to-end test fixture for the GPS research benchmark. Produces the five files an e2e fixture needs (fixture.json, starting-research.json, starting-tree.gedcomx.json, expected-findings.json, README.md) in the user's working folder, ready to be moved into eval/tests/e2e/<slug>/. Primary path converts a just-completed research project into a fixture by stripping the answer from the tree and recording it as expected findings. Use when the user says "save this as an e2e test", "make a benchmark from this research", "create an e2e fixture", or "author an e2e test". Do NOT use to interpret the result of an e2e run (use interpret-e2e-result), to run a new research project (use init-project), or to interpret the result of a unit-test run (those are developer-facing JSON files).
+description: Authors an end-to-end test fixture for the GPS research benchmark. Produces the five files an e2e fixture needs (fixture.json, starting-research.json, starting-tree.gedcomx.json, expected-findings.json, README.md) in the user's working folder, ready to be moved into a per-test directory under eval/tests/e2e/. Primary path converts a just-completed research project into a fixture by stripping the answer from the tree and recording it as expected findings. Use when the user says "save this as an e2e test", "make a benchmark from this research", "create an e2e fixture", or "author an e2e test". Do NOT use to interpret the result of an e2e run (use interpret-e2e-result), to run a new research project (use init-project), or to interpret the result of a unit-test run (those are developer-facing JSON files).
 allowed-tools:
   - validate_research_schema
 ---

--- a/packages/engine/plugin/skills/conflict-resolution/references/places-guidance.md
+++ b/packages/engine/plugin/skills/conflict-resolution/references/places-guidance.md
@@ -3,7 +3,7 @@
   This block is duplicated, byte-for-byte, into each place-using skill's
   references/places-guidance.md (Claude Code can't reliably load a shared
   reference across skills — issue #17741 — so each skill carries its own copy).
-  A drift lint (mcp-server/tests/packaging/skill-guidance.test.ts) fails if any
+  A drift lint (packages/engine/mcp-server/tests/packaging/skill-guidance.test.ts) fails if any
   copy diverges from this source. To change the guidance: edit this file, then
   re-copy it into every skill listed in that test.
 -->

--- a/packages/engine/plugin/skills/historical-context/references/places-guidance.md
+++ b/packages/engine/plugin/skills/historical-context/references/places-guidance.md
@@ -3,7 +3,7 @@
   This block is duplicated, byte-for-byte, into each place-using skill's
   references/places-guidance.md (Claude Code can't reliably load a shared
   reference across skills — issue #17741 — so each skill carries its own copy).
-  A drift lint (mcp-server/tests/packaging/skill-guidance.test.ts) fails if any
+  A drift lint (packages/engine/mcp-server/tests/packaging/skill-guidance.test.ts) fails if any
   copy diverges from this source. To change the guidance: edit this file, then
   re-copy it into every skill listed in that test.
 -->

--- a/packages/engine/plugin/skills/init-project/references/places-guidance.md
+++ b/packages/engine/plugin/skills/init-project/references/places-guidance.md
@@ -3,7 +3,7 @@
   This block is duplicated, byte-for-byte, into each place-using skill's
   references/places-guidance.md (Claude Code can't reliably load a shared
   reference across skills — issue #17741 — so each skill carries its own copy).
-  A drift lint (mcp-server/tests/packaging/skill-guidance.test.ts) fails if any
+  A drift lint (packages/engine/mcp-server/tests/packaging/skill-guidance.test.ts) fails if any
   copy diverges from this source. To change the guidance: edit this file, then
   re-copy it into every skill listed in that test.
 -->

--- a/packages/engine/plugin/skills/locality-guide/references/places-guidance.md
+++ b/packages/engine/plugin/skills/locality-guide/references/places-guidance.md
@@ -3,7 +3,7 @@
   This block is duplicated, byte-for-byte, into each place-using skill's
   references/places-guidance.md (Claude Code can't reliably load a shared
   reference across skills — issue #17741 — so each skill carries its own copy).
-  A drift lint (mcp-server/tests/packaging/skill-guidance.test.ts) fails if any
+  A drift lint (packages/engine/mcp-server/tests/packaging/skill-guidance.test.ts) fails if any
   copy diverges from this source. To change the guidance: edit this file, then
   re-copy it into every skill listed in that test.
 -->

--- a/packages/engine/plugin/skills/record-extraction/references/places-guidance.md
+++ b/packages/engine/plugin/skills/record-extraction/references/places-guidance.md
@@ -3,7 +3,7 @@
   This block is duplicated, byte-for-byte, into each place-using skill's
   references/places-guidance.md (Claude Code can't reliably load a shared
   reference across skills — issue #17741 — so each skill carries its own copy).
-  A drift lint (mcp-server/tests/packaging/skill-guidance.test.ts) fails if any
+  A drift lint (packages/engine/mcp-server/tests/packaging/skill-guidance.test.ts) fails if any
   copy diverges from this source. To change the guidance: edit this file, then
   re-copy it into every skill listed in that test.
 -->

--- a/packages/engine/plugin/skills/research-plan/references/places-guidance.md
+++ b/packages/engine/plugin/skills/research-plan/references/places-guidance.md
@@ -3,7 +3,7 @@
   This block is duplicated, byte-for-byte, into each place-using skill's
   references/places-guidance.md (Claude Code can't reliably load a shared
   reference across skills — issue #17741 — so each skill carries its own copy).
-  A drift lint (mcp-server/tests/packaging/skill-guidance.test.ts) fails if any
+  A drift lint (packages/engine/mcp-server/tests/packaging/skill-guidance.test.ts) fails if any
   copy diverges from this source. To change the guidance: edit this file, then
   re-copy it into every skill listed in that test.
 -->

--- a/packages/engine/plugin/skills/search-external-sites/references/places-guidance.md
+++ b/packages/engine/plugin/skills/search-external-sites/references/places-guidance.md
@@ -3,7 +3,7 @@
   This block is duplicated, byte-for-byte, into each place-using skill's
   references/places-guidance.md (Claude Code can't reliably load a shared
   reference across skills — issue #17741 — so each skill carries its own copy).
-  A drift lint (mcp-server/tests/packaging/skill-guidance.test.ts) fails if any
+  A drift lint (packages/engine/mcp-server/tests/packaging/skill-guidance.test.ts) fails if any
   copy diverges from this source. To change the guidance: edit this file, then
   re-copy it into every skill listed in that test.
 -->

--- a/packages/engine/plugin/skills/timeline/references/places-guidance.md
+++ b/packages/engine/plugin/skills/timeline/references/places-guidance.md
@@ -3,7 +3,7 @@
   This block is duplicated, byte-for-byte, into each place-using skill's
   references/places-guidance.md (Claude Code can't reliably load a shared
   reference across skills — issue #17741 — so each skill carries its own copy).
-  A drift lint (mcp-server/tests/packaging/skill-guidance.test.ts) fails if any
+  A drift lint (packages/engine/mcp-server/tests/packaging/skill-guidance.test.ts) fails if any
   copy diverges from this source. To change the guidance: edit this file, then
   re-copy it into every skill listed in that test.
 -->

--- a/packages/engine/plugin/skills/tree-edit/references/places-guidance.md
+++ b/packages/engine/plugin/skills/tree-edit/references/places-guidance.md
@@ -3,7 +3,7 @@
   This block is duplicated, byte-for-byte, into each place-using skill's
   references/places-guidance.md (Claude Code can't reliably load a shared
   reference across skills — issue #17741 — so each skill carries its own copy).
-  A drift lint (mcp-server/tests/packaging/skill-guidance.test.ts) fails if any
+  A drift lint (packages/engine/mcp-server/tests/packaging/skill-guidance.test.ts) fails if any
   copy diverges from this source. To change the guidance: edit this file, then
   re-copy it into every skill listed in that test.
 -->


### PR DESCRIPTION
## What this is

A skill authoring + improvement framework so the developer+genealogist pairs can create, test, and continually improve the genealogy skills. **Entry point + complete flow: `docs/skill-lifecycle.md`.**

## The 8-step flow (all built)

1. **Author** — `docs/skill-authoring-guide.md` (prose standard) + a blocking frontmatter lint (`eval/harness/scripts/check_skill_frontmatter.py`, wired into CI).
2. **Test** — `make eval-skill SKILL=<name>` (rebuilds the engine, then runs the harness).
3. **Review & annotate** — CRUD-UI loop + the new `holdout` test flag + a correction-comment convention.
4. **Audit the rubric** — `rubric-critic` agent (read-only): non-discriminating / flaky / unexercised dimensions + judge-vs-human divergence.
5. **Improve the body** — `skill-improver` agent (report-only): proposes evidence-cited SKILL.md edits and **routes non-body causes** (test-data / triggering / rubric) elsewhere; the pair applies / re-runs / commits.
6. **Verify** — single-run, qualitative, big-problems-first.
7. **Release** — existing GH-Action gate (active + fully-annotated run-log).
8. **Optimize the description** — `make optimize-skill SKILL=<name>`: derives trigger queries from the test corpus (`eval/triggering/build_eval_set.py`) and runs skill-creator's `run_loop` (vendored verbatim; `eval/triggering/VENDORED.md`). On-demand (real `claude -p`), not CI.

## Validated
- Frontmatter lint passes the corpus; blocks over-1024 / angle-bracket descriptions.
- `skill-improver` exercised against a real annotated `tree-edit` run-log — produced **0 wrong edits** and routed all 3 human disagreements correctly; the def was hardened from that run.
- `build_eval_set.py` + vendored optimizer import-checked under uv (>=3.10); places-guidance drift-lint test green after the path fixes.

## Not yet / fast-follow
- The description optimizer hasn't run end-to-end here (needs network + model cost); first team use validates it.
- Folding optimizer output into `eval/runlogs/optimizer/`.
- `skill-improver` is report-only by design (the pair applies edits in-session).

## Notes
- Editing any file under a skill dir (incl. `references/` / comments) invalidates run-logs by design (`eval/CLAUDE.md`).
- Includes a teammate's Windows UTF-8 fix to the lint (`ea95a25`) and the repo owner's `eval-ui` Make target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)