### PR TITLE
person-evidence: fix ut_person_evidence_002 — treat 1860 census head/relationship as inferred, not stated

### DIFF
--- a/eval/tests/unit/person-evidence/link-relationship-to-both-persons.json
+++ b/eval/tests/unit/person-evidence/link-relationship-to-both-persons.json
@@ -4,7 +4,7 @@
     "skill": "person-evidence",
     "name": "Relationship assertion should link to BOTH persons",
     "type": "positive",
-    "description": "Per research-schema-spec.md §5.7, an assertion implying a relationship bears on BOTH persons — the child and the parent. The mid-research-flynn scenario has a_010 ('Patrick listed in Thomas's household in 1860 census') linked via pe_004 to Patrick (I1). Tests whether the skill recognizes the assertion also bears on Thomas (I2) and creates the matching second link, OR confirms one already exists.",
+    "description": "Per research-schema-spec.md §5.7, an assertion implying a relationship bears on BOTH persons — the child and the parent. The mid-research-flynn scenario has a_010 ('Patrick enumerated in the same 1860 census household as Thomas') linked via pe_004 to Patrick (I1). The 1860 census records only co-residence in a household; it does not state relationships or designate a head — both the head-of-household role and the parent-child relationship are inferred (like the 1850 census; the relationship column was not introduced until 1880). Tests whether the skill recognizes the assertion also bears on Thomas (I2) and creates the matching second link, OR confirms one already exists.",
     "tags": ["person-evidence", "multi-person-awareness", "relationship-assertion", "pe_004", "a_010"]
   },
   "input": {
@@ -14,6 +14,6 @@
   "judge_context": [
     "Should recognize that a_010 is a relationship-implying assertion that bears on BOTH persons named in the relationship",
     "The new entry's confidence should match or be no higher than pe_004's confidence (cannot be more confident about Thomas's identity than about Patrick's, since they're tied to the same assertion)",
-    "Should populate the new entry's `rationale` to explain why the assertion bears on Thomas: the 1860 census names Thomas as head of household with Patrick listed in the household — the assertion is indirect evidence of Thomas's parental role too (household position implies parent-child relationship)"
+    "Should populate the new entry's `rationale` to explain why the assertion bears on Thomas: the 1860 census enumerates Patrick in the same household as Thomas, with Thomas inferred (not explicitly stated) to be the head of household — the assertion is indirect evidence of Thomas's parental role too (household position, age, and shared surname imply a parent-child relationship). The 1860 census does not state relationships or designate a head of household explicitly — like the 1850 census, both are inferred by the researcher; the relationship column was not introduced until 1880. The rationale should not assert as recorded fact that the census lists Thomas as head or Patrick as son."
   ]
 }


### PR DESCRIPTION
## What

Fixes the grading prose in the person-evidence test `ut_person_evidence_002`
(`link-relationship-to-both-persons.json`) so it no longer treats the 1860
U.S. Census head-of-household and parent-child relationship as recorded facts.

## Why

Pre-1880 U.S. federal censuses (1850–1870) record only *co-residence* in a
household. They do **not** state relationships or explicitly designate a head
of household — the relationship-to-head column wasn't introduced until 1880.
Both the head-of-household role and the parent-child tie must be *inferred* by
the researcher.

The test's `judge_context` and `description` graded against two false absolutes:
- that the 1860 census *"names Thomas as head of household"*, and
- that it lists Patrick as son.

This contradicted the scenario fixture itself ([mid-research-flynn/research.json](eval/fixtures/scenarios/mid-research-flynn/research.json)),
where `a_010` is already correctly modeled as `child_inferred` with notes
stating *"1860 census does not state relationships… the relationship column
was not introduced until the 1880 census."* The bug was grading-prose drift,
not the fixture.

## Change

- **`judge_context[2]`** — the expected `rationale` now frames Thomas-as-head
  and the parent-child relationship as inferred (from household position, age,
  shared surname), with an explicit instruction that the rationale must not
  assert as recorded fact that the census lists Thomas as head or Patrick as son.
- **`description`** — now states the 1860 census records only co-residence;
  head role and relationship are inferred (like the 1850 census).

The test's actual intent — does the skill link a relationship assertion to
**both** persons (child *and* parent)? — is unchanged.

## Verification

Ran the harness for the `person-evidence` skill; `ut_person_evidence_002`
**passes** with the rewritten `judge_context`. (Run log not committed.)

> Note: an unrelated negative test, `ut_person_evidence_003`, hit the
> `max_wall_clock_seconds` cap during that run — pre-existing execution
> flakiness, not touched by this change.
