### PR TITLE
Fix Windows compat in vendored triggering scripts

### DIFF
--- a/eval/triggering/VENDORED.md
+++ b/eval/triggering/VENDORED.md
@@ -41,8 +41,28 @@ upstream commit here when re-vendoring.
 
 ## Local divergences from upstream
 
-- **`encoding="utf-8"`** added to all `read_text()` calls (utils.py,
-  run_loop.py, run_eval.py, improve_description.py, generate_report.py).
-  Without this, `read_text()` defaults to cp1252 on Windows and crashes on
-  SKILL.md files containing em dashes or smart quotes. Re-apply after
+- **`encoding="utf-8"`** added to all `read_text()` and `write_text()` calls
+  (utils.py, run_loop.py, run_eval.py, improve_description.py,
+  generate_report.py). Without this, Python defaults to cp1252 on Windows
+  and crashes on SKILL.md files containing em dashes or smart quotes, or
+  HTML reports containing Unicode check/cross marks (✓/✗). Re-apply after
   re-vendoring.
+
+- **`encoding="utf-8"`** added to `subprocess.run()` in
+  improve_description.py. The `text=True` flag uses the system default
+  encoding for stdin/stdout; on Windows that's cp1252, which crashes when
+  the prompt contains Unicode characters from SKILL.md content. Re-apply
+  after re-vendoring.
+
+- **`shutil.which("claude")`** replaces bare `"claude"` in subprocess
+  commands (run_eval.py, improve_description.py). On Windows, npm-installed
+  CLIs are batch wrappers (`claude.cmd`); `subprocess.Popen` without
+  `shell=True` cannot find them by bare name. `shutil.which` resolves the
+  full path on all platforms. Re-apply after re-vendoring.
+
+- **Thread-based pipe reader on Windows** in run_eval.py. The original
+  `select.select()` + `os.read()` streaming loop raises `OSError` on
+  Windows because `select` only works on sockets there, not on pipe file
+  descriptors. Replaced with a platform-conditional block: Windows uses a
+  daemon reader thread feeding a `queue.Queue`; Unix keeps the original
+  `select`-based path. Re-apply after re-vendoring.

--- a/eval/triggering/scripts/generate_report.py
+++ b/eval/triggering/scripts/generate_report.py
@@ -316,7 +316,7 @@ def main():
     html_output = generate_html(data, skill_name=args.skill_name)
 
     if args.output:
-        Path(args.output).write_text(html_output)
+        Path(args.output).write_text(html_output, encoding="utf-8")
         print(f"Report written to {args.output}", file=sys.stderr)
     else:
         print(html_output)

--- a/eval/triggering/scripts/improve_description.py
+++ b/eval/triggering/scripts/improve_description.py
@@ -10,11 +10,27 @@ import argparse
 import json
 import os
 import re
+import shutil
 import subprocess
 import sys
 from pathlib import Path
 
 from scripts.utils import parse_skill_md
+
+
+def _resolve_claude_cmd() -> str:
+    """Resolve the claude CLI path, handling Windows .cmd extension.
+
+    On Windows, npm-installed CLIs are batch wrappers (``claude.cmd``).
+    ``subprocess.Popen`` without ``shell=True`` cannot find them by bare
+    name; ``shutil.which`` resolves the full path regardless of platform.
+    """
+    path = shutil.which("claude")
+    if path is None:
+        raise FileNotFoundError(
+            "Could not find 'claude' on PATH. Install Claude Code CLI."
+        )
+    return path
 
 
 def _call_claude(prompt: str, model: str | None, timeout: int = 300) -> str:
@@ -23,7 +39,7 @@ def _call_claude(prompt: str, model: str | None, timeout: int = 300) -> str:
     Prompt goes over stdin (not argv) because it embeds the full SKILL.md
     body and can easily exceed comfortable argv length.
     """
-    cmd = ["claude", "-p", "--output-format", "text"]
+    cmd = [_resolve_claude_cmd(), "-p", "--output-format", "text"]
     if model:
         cmd.extend(["--model", model])
 
@@ -37,6 +53,7 @@ def _call_claude(prompt: str, model: str | None, timeout: int = 300) -> str:
         input=prompt,
         capture_output=True,
         text=True,
+        encoding="utf-8",
         env=env,
         timeout=timeout,
     )
@@ -186,7 +203,7 @@ Please respond with only the new description text in <new_description> tags, not
     if log_dir:
         log_dir.mkdir(parents=True, exist_ok=True)
         log_file = log_dir / f"improve_iter_{iteration or 'unknown'}.json"
-        log_file.write_text(json.dumps(transcript, indent=2))
+        log_file.write_text(json.dumps(transcript, indent=2), encoding="utf-8")
 
     return description
 

--- a/eval/triggering/scripts/run_eval.py
+++ b/eval/triggering/scripts/run_eval.py
@@ -8,15 +8,37 @@ for a set of queries. Outputs results as JSON.
 import argparse
 import json
 import os
-import select
+import shutil
 import subprocess
 import sys
 import time
 import uuid
+
+if sys.platform != "win32":
+    import select
+
+if sys.platform == "win32":
+    import queue as _queue_mod
+    import threading as _threading_mod
 from concurrent.futures import ProcessPoolExecutor, as_completed
 from pathlib import Path
 
 from scripts.utils import parse_skill_md
+
+
+def _resolve_claude_cmd() -> str:
+    """Resolve the claude CLI path, handling Windows .cmd extension.
+
+    On Windows, npm-installed CLIs are batch wrappers (``claude.cmd``).
+    ``subprocess.Popen`` without ``shell=True`` cannot find them by bare
+    name; ``shutil.which`` resolves the full path regardless of platform.
+    """
+    path = shutil.which("claude")
+    if path is None:
+        raise FileNotFoundError(
+            "Could not find 'claude' on PATH. Install Claude Code CLI."
+        )
+    return path
 
 
 def find_project_root() -> Path:
@@ -65,10 +87,10 @@ def run_single_query(
             f"# {skill_name}\n\n"
             f"This skill handles: {skill_description}\n"
         )
-        command_file.write_text(command_content)
+        command_file.write_text(command_content, encoding="utf-8")
 
         cmd = [
-            "claude",
+            _resolve_claude_cmd(),
             "-p", query,
             "--output-format", "stream-json",
             "--verbose",
@@ -97,21 +119,50 @@ def run_single_query(
         pending_tool_name = None
         accumulated_json = ""
 
+        # On Windows, select() only works on sockets, not pipes.
+        # Use a reader thread + queue to get chunks with timeout.
+        if sys.platform == "win32":
+            _read_queue: _queue_mod.Queue[bytes] = _queue_mod.Queue()
+
+            def _pipe_reader() -> None:
+                try:
+                    while True:
+                        data = process.stdout.read(8192)
+                        if not data:
+                            break
+                        _read_queue.put(data)
+                except Exception:
+                    pass
+                _read_queue.put(b"")  # sentinel for EOF
+
+            _reader = _threading_mod.Thread(target=_pipe_reader, daemon=True)
+            _reader.start()
+
         try:
             while time.time() - start_time < timeout:
-                if process.poll() is not None:
-                    remaining = process.stdout.read()
-                    if remaining:
-                        buffer += remaining.decode("utf-8", errors="replace")
-                    break
+                if sys.platform == "win32":
+                    try:
+                        chunk = _read_queue.get(timeout=1.0)
+                    except _queue_mod.Empty:
+                        if process.poll() is not None:
+                            break
+                        continue
+                    if not chunk:  # EOF sentinel
+                        break
+                else:
+                    if process.poll() is not None:
+                        remaining = process.stdout.read()
+                        if remaining:
+                            buffer += remaining.decode("utf-8", errors="replace")
+                        break
 
-                ready, _, _ = select.select([process.stdout], [], [], 1.0)
-                if not ready:
-                    continue
+                    ready, _, _ = select.select([process.stdout], [], [], 1.0)
+                    if not ready:
+                        continue
 
-                chunk = os.read(process.stdout.fileno(), 8192)
-                if not chunk:
-                    break
+                    chunk = os.read(process.stdout.fileno(), 8192)
+                    if not chunk:
+                        break
                 buffer += chunk.decode("utf-8", errors="replace")
 
                 while "\n" in buffer:

--- a/eval/triggering/scripts/run_loop.py
+++ b/eval/triggering/scripts/run_loop.py
@@ -148,7 +148,7 @@ def run_loop(
                 "test_size": len(test_set),
                 "history": history,
             }
-            live_report_path.write_text(generate_html(partial_output, auto_refresh=True, skill_name=name))
+            live_report_path.write_text(generate_html(partial_output, auto_refresh=True, skill_name=name), encoding="utf-8")
 
         if verbose:
             def print_eval_stats(label, results, elapsed):
@@ -275,7 +275,7 @@ def main():
         else:
             live_report_path = Path(args.report)
         # Open the report immediately so the user can watch
-        live_report_path.write_text("<html><body><h1>Starting optimization loop...</h1><meta http-equiv='refresh' content='5'></body></html>")
+        live_report_path.write_text("<html><body><h1>Starting optimization loop...</h1><meta http-equiv='refresh' content='5'></body></html>", encoding="utf-8")
         webbrowser.open(str(live_report_path))
     else:
         live_report_path = None
@@ -310,15 +310,15 @@ def main():
     json_output = json.dumps(output, indent=2)
     print(json_output)
     if results_dir:
-        (results_dir / "results.json").write_text(json_output)
+        (results_dir / "results.json").write_text(json_output, encoding="utf-8")
 
     # Write final HTML report (without auto-refresh)
     if live_report_path:
-        live_report_path.write_text(generate_html(output, auto_refresh=False, skill_name=name))
+        live_report_path.write_text(generate_html(output, auto_refresh=False, skill_name=name), encoding="utf-8")
         print(f"\nReport: {live_report_path}", file=sys.stderr)
 
     if results_dir and live_report_path:
-        (results_dir / "report.html").write_text(generate_html(output, auto_refresh=False, skill_name=name))
+        (results_dir / "report.html").write_text(generate_html(output, auto_refresh=False, skill_name=name), encoding="utf-8")
 
     if results_dir:
         print(f"Results saved to: {results_dir}", file=sys.stderr)


### PR DESCRIPTION
## Summary
- Fixes four Windows-specific crashes in the vendored description optimizer scripts (`eval/triggering/scripts/`)
- Adds `encoding="utf-8"` to all `write_text()` and `subprocess.run()` calls to avoid cp1252 crashes on Unicode content
- Replaces bare `"claude"` with `shutil.which("claude")` to resolve the `.cmd` batch wrapper on Windows
- Replaces `select.select()` with a thread-based pipe reader on Windows (select only works on sockets there)
- All four divergences documented in `VENDORED.md` with "Re-apply after re-vendoring" notes

## Test plan
- [x] All four Python files pass `py_compile`
- [x] Validated end-to-end: ran the full description optimizer loop (`make optimize-skill SKILL=search-wikipedia`) through 2 iterations on Windows, producing train/test scores and an HTML report
- [ ] Verify on Unix/macOS that the `select`-based path still works (platform-conditional, Unix code is unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)