### PR TITLE
Add findagrave + newspapers to the external_site enum

### DIFF
--- a/docs/specs/research-schema-spec.md
+++ b/docs/specs/research-schema-spec.md
@@ -274,7 +274,7 @@ Array of log entry objects. **Append-only — entries are never modified or dele
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `site` | string | yes | `ancestry`, `myheritage`, `findmypast`, or `familysearch_web` |
+| `site` | string | yes | `ancestry`, `myheritage`, `findmypast`, `findagrave`, `newspapers`, or `familysearch_web` |
 | `url_generated` | string | yes | The search URL presented to the user |
 | `capture_received` | boolean | yes | Whether the user returned a PDF/capture |
 | `capture_filename` | string or null | no | Filename of the returned capture |

--- a/docs/specs/schemas/enums.schema.json
+++ b/docs/specs/schemas/enums.schema.json
@@ -168,7 +168,7 @@
     },
     "external_site": {
       "description": "Sites supported by the generate-click-capture-analyze workflow.",
-      "enum": ["ancestry", "myheritage", "findmypast", "familysearch_web"]
+      "enum": ["ancestry", "myheritage", "findmypast", "familysearch_web", "findagrave", "newspapers"]
     },
     "gender": {
       "enum": ["Male", "Female", "Unknown"]

--- a/packages/engine/mcp-server/src/validation/validator.ts
+++ b/packages/engine/mcp-server/src/validation/validator.ts
@@ -73,6 +73,7 @@ const DATE_CERTAINTY_TIMELINE = new Set([
 
 const EXTERNAL_SITE_VALUES = new Set([
   "ancestry", "myheritage", "findmypast", "familysearch_web",
+  "findagrave", "newspapers",
 ]);
 
 const ID_PREFIXES: Record<string, string> = {

--- a/packages/schema/schemas/enums.schema.json
+++ b/packages/schema/schemas/enums.schema.json
@@ -168,7 +168,7 @@
     },
     "external_site": {
       "description": "Sites supported by the generate-click-capture-analyze workflow.",
-      "enum": ["ancestry", "myheritage", "findmypast", "familysearch_web"]
+      "enum": ["ancestry", "myheritage", "findmypast", "familysearch_web", "findagrave", "newspapers"]
     },
     "gender": {
       "enum": ["Male", "Female", "Unknown"]


### PR DESCRIPTION
The search-external-sites skill supports five sites (Ancestry, MyHeritage, FindMyPast, FindAGrave, Newspapers.com) but the external_site enum only accepted four values - findagrave and newspapers were missing. Any logged FindAGrave or Newspapers.com search failed schema validation, and the agent loops on the unfixable error until the turn cap.

Updated in all four places: `docs/specs/schemas/enums.schema.json`, `packages/schema/schemas/enums.schema.json`, `validator.ts` EXTERNAL_SITE_VALUES, and the `research-schema-spec.md` site table.

familysearch_web is left in the enum for data compatibility (existing logs may use it);
