### PR TITLE
harness: add intentionally_invalid per-test flag for validator-skill test

### DIFF
--- a/docs/specs/schemas/unit-test.schema.json
+++ b/docs/specs/schemas/unit-test.schema.json
@@ -116,6 +116,11 @@
       "maximum": 10,
       "description": "Optional override of the harness default (1). See unit-test-spec.md Section 7, Variance: runs per test."
     },
+    "intentionally_invalid": {
+      "type": "boolean",
+      "default": false,
+      "description": "When true, the test's scenario files are broken on purpose — e.g. for a validator/guardrail skill (validate-schema) whose job is to detect invalid input. The runnability gate then skips schema validation of the scenario, the post-run file-validity validators are not counted against the test, and the scenario-fixture lint exempts the referenced scenario. Defaults to false; only set it on tests that genuinely need an invalid starting state. See unit-test-spec.md Section 9."
+    },
     "execution": {
       "type": "object",
       "additionalProperties": false,

--- a/docs/specs/unit-test-spec.md
+++ b/docs/specs/unit-test-spec.md
@@ -399,6 +399,11 @@ The machine-readable schema lives at [`docs/specs/schemas/unit-test.schema.json`
       "maximum": 10,
       "description": "Optional override of the harness default (1). See Section 7, Variance: runs per test."
     },
+    "intentionally_invalid": {
+      "type": "boolean",
+      "default": false,
+      "description": "When true, the scenario files are broken on purpose (validator/guardrail skills). Skips scenario schema validation in the runnability gate, excuses the file-validity validators, and exempts the scenario from the fixture lint. See Section 5.8."
+    },
     "execution": {
       "type": "object",
       "properties": {
@@ -519,6 +524,16 @@ Optional object overriding the harness's default execution limits. All fields ar
 | `max_tool_calls` | integer | 50 | Maximum MCP tool calls. Bounds fixture consumption and accidental fan-out |
 | `max_input_tokens_per_turn` | integer | 200000 | Maximum input tokens to the model in any single turn |
 | `sdk_message_silence_seconds` | integer | 180 | Maximum seconds the harness will wait between SDK messages before aborting with `sdk_stream_silence` (retryable). Bump per-test only for skills whose model spends >180s on a single thinking/generation step before emitting its first message — open-ended conflict-resolution prompts and multi-persona record-extraction are the typical cases. Don't bump the default (60s→180s already covers the long tail) — a tighter watchdog catches real upstream stalls faster |
+
+### 5.8 `intentionally_invalid`
+
+Optional boolean (default `false`). Set it on a test whose scenario files are **broken on purpose** — the case of a validator/guardrail skill (`validate-schema`) whose whole job is to detect invalid input. Every other skill operates on valid project state, so the harness assumes scenarios are schema-valid and gates on it in three places; this flag is the opt-out for the one skill that must see invalid input:
+
+- the **runnability gate** (Section 9) skips schema validation of the scenario instead of aborting the test as `not_runnable`;
+- the **post-run file-validity validators** (`test_research_json_validates_schema`, `test_tree_gedcomx_json_validates_schema`, `test_id_references_resolve`) are not counted against the test — the invalid state is expected. Behavioural validators (allowlist, append-only, …) still apply;
+- the **scenario-fixture lint** (`eval/harness/tests/unit/test_scenario_fixtures.py`) exempts the scenario the flagged test references, reading the flag from the test so the per-test field stays the single source of truth.
+
+Set it only when a test genuinely needs an invalid starting state; on every other test the schema gates are a valuable safety net against fixture drift.
 
 ---
 
@@ -950,7 +965,7 @@ The harness refuses to execute a test if any of the following are true. The chec
 | `scenario_notes` is a non-empty string | The scenario doesn't match the test's stated needs. Running anyway grades the skill against the wrong reality |
 | The referenced `scenario` directory does not exist | Test points at a scenario that hasn't been created |
 | Any referenced fixture in `mcp_fixtures` does not exist | Test points at a fixture that hasn't been created |
-| The scenario's `research.json` or `tree.gedcomx.json` does not validate against its schema | A broken scenario silently fails every test that uses it; gate it instead |
+| The scenario's `research.json` or `tree.gedcomx.json` does not validate against its schema (and the test does **not** set `intentionally_invalid`) | A broken scenario silently fails every test that uses it; gate it instead. A test that opts in via `intentionally_invalid: true` (Section 5.8) is exempt — it needs the invalid input |
 | The skill referenced by `test.skill` does not exist in `packages/engine/plugin/skills/` | Test points at a skill that has been removed or renamed |
 | The skill's `rubric.md` does not exist or fails to parse per the format in Section 7 | The harness can't compute `rubric_hash`, can't load dimensions, and the judge prompt slot would be empty. Block rather than grade against an empty rubric |
 | For MCP-calling skills (`allowed-tools` non-empty in frontmatter), the `rubric.md` has no tool-usage dimension | Section 7 requires at least one tool-usage dimension (substring match against `tool usage`, `argument quality`, `response interpretation`, `tool selection`, `mcp tool`, `tool work`, `tool call`, or `fixture` in any dimension name). Block rather than grade tool quality with no rubric dimension covering it |

--- a/eval/harness/harness/loader.py
+++ b/eval/harness/harness/loader.py
@@ -40,6 +40,7 @@ class TestSpec:
     xfail_reason: str | None
     runs_per_test: int
     execution: dict[str, int]
+    intentionally_invalid: bool = False
     source_path: Path | None = None
     raw: dict[str, Any] = field(default_factory=dict)
 
@@ -90,5 +91,6 @@ def load_test_from_dict(raw: dict[str, Any]) -> TestSpec:
         xfail_reason=test.get("xfail_reason"),
         runs_per_test=int(raw.get("runs_per_test", 1)),
         execution=dict(raw.get("execution", {})),
+        intentionally_invalid=bool(raw.get("intentionally_invalid", False)),
         raw=raw,
     )

--- a/eval/harness/harness/orchestrator.py
+++ b/eval/harness/harness/orchestrator.py
@@ -97,6 +97,34 @@ class OrchestratorPaths:
     runlogs_root: Path = DEFAULT_RUNLOGS
 
 
+# Validators that assert the persisted project files are valid (schema-
+# conformant, references resolve). A test that declares its scenario broken
+# on purpose (`intentionally_invalid: true`) expects these to fail — the
+# invalid input is the whole point — so they are not counted against such a
+# test. Behavioural validators (allowlist, append-only, …) still apply.
+FILE_VALIDITY_VALIDATORS = frozenset(
+    {
+        "test_research_json_validates_schema",
+        "test_tree_gedcomx_json_validates_schema",
+        "test_id_references_resolve",
+    }
+)
+
+
+def compute_validators_passed(validator_results, *, intentionally_invalid: bool) -> bool:
+    """True when no validator failed.
+
+    When the test's scenario is intentionally invalid, the file-validity
+    validators are expected to fail and are ignored; every other validator
+    still counts.
+    """
+    return all(
+        r.passed
+        for r in validator_results
+        if not (intentionally_invalid and r.name in FILE_VALIDITY_VALIDATORS)
+    )
+
+
 def run_one_test(
     spec: TestSpec,
     *,
@@ -329,7 +357,9 @@ async def _execute_single_run(
         skill_frontmatter=skill_frontmatter,
         test=spec.raw.get("test", {}),
     )
-    validators_passed = all(r.passed for r in validator_results)
+    validators_passed = compute_validators_passed(
+        validator_results, intentionally_invalid=spec.intentionally_invalid
+    )
 
     # --- Judge ----------------------------------------------------------
     if validators_passed and result.aborted_reason is None:

--- a/eval/harness/harness/runnability.py
+++ b/eval/harness/harness/runnability.py
@@ -5,7 +5,9 @@ Block a test from executing when:
 - the referenced scenario directory doesn't exist
 - any referenced fixture is missing
 - the scenario's research.json or tree.gedcomx.json fails to JSON-parse
-  OR fails schema validation per spec §9
+  OR fails schema validation per spec §9 (unless the test sets
+  `intentionally_invalid: true`, for validator skills that must run
+  against broken-on-purpose scenarios)
 - the skill directory doesn't exist
 - the skill's rubric.md is missing or malformed
 """
@@ -61,7 +63,10 @@ def check_runnable(
                     False, f"scenario {fname} is not valid JSON: {e}"
                 )
             schema_errors = validator(data)
-            if schema_errors:
+            # A test may declare its scenario broken on purpose (e.g. a
+            # validator/guardrail skill that must detect invalid input). The
+            # schema gate would otherwise wrongly abort it, so honour the flag.
+            if schema_errors and not spec.intentionally_invalid:
                 # Surface the first few to keep the message scannable; the
                 # full list lives in the run log when this gate aborts.
                 preview = "; ".join(schema_errors[:3])

--- a/eval/harness/tests/unit/test_orchestrator.py
+++ b/eval/harness/tests/unit/test_orchestrator.py
@@ -730,3 +730,44 @@ def test_live_tool_call_is_covered(tmp_path, monkeypatch):
     assert entry["runs"][0]["judge"]["skipped"] is False
     warnings = entry["runs"][0]["output"].get("warnings", [])
     assert not any(w["kind"] == "uncovered_tool_call" for w in warnings)
+
+
+# --- intentionally_invalid: file-validity validators are not counted -----
+
+from dataclasses import dataclass as _dataclass
+
+from harness.orchestrator import (
+    FILE_VALIDITY_VALIDATORS,
+    compute_validators_passed,
+)
+
+
+@_dataclass
+class _FakeValidator:
+    name: str
+    passed: bool
+
+
+def test_compute_validators_passed_all_pass():
+    results = [_FakeValidator("test_log_append_only", True)]
+    assert compute_validators_passed(results, intentionally_invalid=False) is True
+    assert compute_validators_passed(results, intentionally_invalid=True) is True
+
+
+def test_compute_validators_passed_file_validity_failure_honors_flag():
+    # A file-validity validator failing is expected when the scenario is
+    # intentionally invalid, so it must not fail the test then — but it must
+    # fail a normal test.
+    name = sorted(FILE_VALIDITY_VALIDATORS)[0]
+    results = [_FakeValidator(name, False)]
+    assert compute_validators_passed(results, intentionally_invalid=False) is False
+    assert compute_validators_passed(results, intentionally_invalid=True) is True
+
+
+def test_compute_validators_passed_behavioral_failure_always_fails():
+    # A behavioural validator (not file-validity) failing fails the test even
+    # under the flag — the flag only excuses the invalid input, not bad skill
+    # behaviour.
+    results = [_FakeValidator("test_log_append_only", False)]
+    assert compute_validators_passed(results, intentionally_invalid=True) is False
+    assert compute_validators_passed(results, intentionally_invalid=False) is False

--- a/eval/harness/tests/unit/test_runnability.py
+++ b/eval/harness/tests/unit/test_runnability.py
@@ -262,3 +262,32 @@ def test_blocks_when_scenario_research_json_invalid(tmp_path):
     result = check_runnable(spec, scenarios_dir=fake_scenarios, fixtures_dir=FIXTURES, skills_dir=SKILLS, tests_dir=TESTS)
     assert result.runnable is False
     assert "research.json" in result.reason or "scenario" in result.reason
+
+
+def test_intentionally_invalid_flag_bypasses_schema_gate(tmp_path):
+    """A test that opts in with `intentionally_invalid` runs against a
+    schema-invalid scenario instead of being aborted. The flag is the only
+    difference from test_blocks_when_scenario_research_json_fails_schema, so
+    this also proves the flag — not a blanket bypass — is what unblocks it."""
+    fake_scenarios = tmp_path / "scenarios"
+    (fake_scenarios / "schemabad").mkdir(parents=True)
+    # Same broken-on-purpose scenario as the blocking test above.
+    (fake_scenarios / "schemabad" / "research.json").write_text(
+        '{"project": {"id": "rp_1"}, "questions": [], "plans": [],'
+        ' "log": [], "sources": [], "assertions": [], "person_evidence": [],'
+        ' "conflicts": [], "hypotheses": [], "timelines": [],'
+        ' "proof_summaries": []}'
+    )
+    (fake_scenarios / "schemabad" / "tree.gedcomx.json").write_text(
+        '{"persons":[],"relationships":[],"sources":[]}'
+    )
+    d = _runnable_test_dict()
+    d["input"]["scenario"] = "schemabad"
+    d["intentionally_invalid"] = True
+    spec = load_test_from_dict(d)
+    result = check_runnable(
+        spec, scenarios_dir=fake_scenarios, fixtures_dir=FIXTURES,
+        skills_dir=SKILLS, tests_dir=TESTS,
+    )
+    assert result.runnable is True
+    assert result.reason is None

--- a/eval/harness/tests/unit/test_scenario_fixtures.py
+++ b/eval/harness/tests/unit/test_scenario_fixtures.py
@@ -30,6 +30,7 @@ from harness.schema_validator import (
 
 REPO_ROOT = Path(__file__).resolve().parents[4]
 SCENARIOS_DIR = REPO_ROOT / "eval" / "fixtures" / "scenarios"
+TESTS_DIR = REPO_ROOT / "eval" / "tests"
 
 
 def _scenario_dirs() -> list[Path]:
@@ -43,8 +44,38 @@ def _scenario_dirs() -> list[Path]:
     return dirs
 
 
+def _intentionally_invalid_scenarios(tests_dir: Path = TESTS_DIR) -> set[str]:
+    """Scenario names referenced by tests that set `intentionally_invalid`.
+
+    These scenarios are broken on purpose (a validator/guardrail skill must
+    be able to run against invalid input), so the schema-validity lint must
+    exempt them. The per-test flag stays the single source of truth — this
+    lint reads it from the tests rather than introducing a per-scenario
+    marker.
+    """
+    invalid: set[str] = set()
+    for f in tests_dir.rglob("*.json"):
+        try:
+            raw = json.loads(f.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            continue
+        if isinstance(raw, dict) and raw.get("intentionally_invalid") is True:
+            scenario = (raw.get("input") or {}).get("scenario")
+            if isinstance(scenario, str) and scenario:
+                invalid.add(scenario)
+    return invalid
+
+
+INTENTIONALLY_INVALID_SCENARIOS = _intentionally_invalid_scenarios()
+
+
 @pytest.mark.parametrize("scenario", _scenario_dirs(), ids=lambda p: p.name)
 def test_scenario_research_json_is_schema_valid(scenario: Path) -> None:
+    if scenario.name in INTENTIONALLY_INVALID_SCENARIOS:
+        pytest.skip(
+            f"{scenario.name} is broken on purpose (referenced by an "
+            "intentionally_invalid test)"
+        )
     path = scenario / "research.json"
     data = json.loads(path.read_text(encoding="utf-8"))
     errors = validate_research_json(data)
@@ -56,6 +87,11 @@ def test_scenario_research_json_is_schema_valid(scenario: Path) -> None:
 
 @pytest.mark.parametrize("scenario", _scenario_dirs(), ids=lambda p: p.name)
 def test_scenario_tree_gedcomx_json_is_schema_valid(scenario: Path) -> None:
+    if scenario.name in INTENTIONALLY_INVALID_SCENARIOS:
+        pytest.skip(
+            f"{scenario.name} is broken on purpose (referenced by an "
+            "intentionally_invalid test)"
+        )
     path = scenario / "tree.gedcomx.json"
     if not path.exists():
         pytest.skip(f"{scenario.name} has no tree.gedcomx.json")
@@ -65,3 +101,24 @@ def test_scenario_tree_gedcomx_json_is_schema_valid(scenario: Path) -> None:
         f"{path.relative_to(REPO_ROOT)} fails tree.gedcomx schema "
         "validation:\n  - " + "\n  - ".join(errors)
     )
+
+
+def test_intentionally_invalid_scenarios_reads_the_flag(tmp_path) -> None:
+    tests_dir = tmp_path / "tests" / "some-skill"
+    tests_dir.mkdir(parents=True)
+    # A flagged test contributes its scenario; an unflagged one does not.
+    (tests_dir / "flagged.json").write_text(
+        json.dumps(
+            {
+                "input": {"scenario": "broken-on-purpose"},
+                "intentionally_invalid": True,
+            }
+        ),
+        encoding="utf-8",
+    )
+    (tests_dir / "normal.json").write_text(
+        json.dumps({"input": {"scenario": "perfectly-fine"}}),
+        encoding="utf-8",
+    )
+    result = _intentionally_invalid_scenarios(tmp_path / "tests")
+    assert result == {"broken-on-purpose"}


### PR DESCRIPTION
Title:
harness: add intentionally_invalid per-test flag for validator-skill tests

Why
Validator/guardrail skills like validate-schema exist to detect invalid project files, so their tests need scenarios that are broken on purpose. The harness assumes every scenario is schema-valid and enforces it in three places, which blocks those tests: the runnability gate aborts them, the post-run file-validity validators fail them, and the scenario-fixture lint goes red in CI.

What
Adds an opt-in intentionally_invalid: true flag on a test. When set:
  - the runnability gate skips scenario schema validation instead of aborting;
  - the file-validity validators (research/tree schema + id references) aren't counted against the test — the invalid state is the point; behavioural validators (allowlist, append-only, …) still apply;
  - the scenario-fixture lint exempts the scenario the flagged test references, reading the flag from the tests so the per-test field stays the single source of truth.

Defaults to false, so the schema gates remain a safety net against fixture drift on every other test.

Testing
uv run pytest -m 'not e2e' → 426 passed. Includes a load-bearing test proving the flag (not a blanket bypass) is what unblocks.