### PR TITLE
eval: drop MCP source from run-log snapshot

### DIFF
--- a/.github/workflows/check-runlogs.yml
+++ b/.github/workflows/check-runlogs.yml
@@ -29,7 +29,9 @@ on:
       - 'packages/engine/plugin/skills/**'
       - 'eval/fixtures/**'
       - 'eval/harness/**'
-      - 'packages/engine/mcp-server/src/**'
+      # MCP source (packages/engine/mcp-server/src/**) is intentionally not a
+      # trigger: it is no longer embedded in the run-log snapshot, so a
+      # src-only change cannot affect run-log activeness (rule 2).
 
 jobs:
   check:

--- a/eval/CLAUDE.md
+++ b/eval/CLAUDE.md
@@ -103,9 +103,10 @@ Every run log embeds a `snapshot: {repo-relative-path: normalized content}` bloc
 - `eval/tests/unit/<skill>/**` (rubric + test JSONs)
 - referenced `eval/fixtures/scenarios/<name>/**`
 - referenced `eval/fixtures/mcp/<name>.json`
-- `packages/engine/mcp-server/src/**` (all MCP tool source — conservative: changes to any shared util can affect any tool's behavior, so the whole tree is tracked rather than a per-skill subset)
 
-By design this is conservative: editing **any** file under the skill dir — including a `references/` doc or even a comment — flips prior run logs inactive and forces a re-run. That is intentional (decided 2026-06): a reference-doc change can change behavior, and a cheap re-run is the price of a trustworthy active-state check; docs and comments are **not** excluded from the snapshot.
+By design this is conservative on the **skill side**: editing **any** file under the skill dir — including a `references/` doc or even a comment — flips prior run logs inactive and forces a re-run. That is intentional: a reference-doc change can change behavior, and a cheap re-run is the price of a trustworthy active-state check; docs and comments are **not** excluded from the snapshot.
+
+MCP tool source (`packages/engine/mcp-server/src/**`) is deliberately **not** in the snapshot (changed 2026-06). The harness serves every tool call from a mock fixture (`mock_mcp.py`); the only real-code path is `LIVE_TOOLS`, which runs the **compiled** `build/**` output, not `src/`. So MCP source is not a dependency of a run — tracking it (the original conservative design) flipped *every* skill's run log inactive on any `src/` edit while the run never executed that code, which under active development was pure churn with no eval signal. Tool-code correctness is Vitest's job (`packages/engine/mcp-server/tests/`), not the runlog snapshot's. Legacy run logs that embedded the whole `src/**` tree stay active: `diff_snapshot_vs_disk` (Python) and `diffSnapshotVsDisk` (TS) both skip keys under that prefix, so no re-run is needed to clear them. If a live tool's real behavior ever needs tracking, hash the compiled artifact separately (as `judge_prompt_hash` does) rather than re-tracking source.
 
 `eval/harness/judge/prompt.md` is **not** in the snapshot — it's project-global and gets a separate `judge_prompt_hash` field. This keeps "activate this run log" a per-skill operation; activating skill A's v1 doesn't clobber skill B's judge calibration.
 
@@ -126,7 +127,7 @@ Scratch runs are gitignored via `.gitignore` patterns on `eval/runlogs/unit/*/sc
 
 ## GitHub Action rules
 
-`.github/workflows/check-runlogs.yml` invokes `eval/harness/scripts/check_runlogs.py` on every PR that touches `eval/runlogs/unit/**`, `eval/tests/unit/**`, `packages/engine/plugin/skills/**`, `eval/fixtures/**`, `eval/harness/**`, or `packages/engine/mcp-server/src/**`. Three blocking rules + one warn-only check (per `docs/plan/eval-runlog-versioning.md` §C6):
+`.github/workflows/check-runlogs.yml` invokes `eval/harness/scripts/check_runlogs.py` on every PR that touches `eval/runlogs/unit/**`, `eval/tests/unit/**`, `packages/engine/plugin/skills/**`, `eval/fixtures/**`, or `eval/harness/**`. (`packages/engine/mcp-server/src/**` is no longer a trigger — MCP source isn't in the snapshot, so a src-only change can't affect run-log activeness.) Three blocking rules + one warn-only check (per `docs/plan/eval-runlog-versioning.md` §C6):
 
 | Rule | Severity | What |
 |---|---|---|

--- a/eval/app/lib/snapshot.ts
+++ b/eval/app/lib/snapshot.ts
@@ -14,6 +14,13 @@ import crypto from 'node:crypto';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 
+// MCP source is no longer embedded in new snapshots (the harness serves
+// tool calls from mocks; live tools run compiled build/, not src/). Run logs
+// written before that change embedded the whole tree; the diff ignores keys
+// under this prefix so they re-validate without a re-run. Mirrors
+// _MCP_SRC_PREFIX in eval/harness/harness/snapshot.py.
+const MCP_SRC_PREFIX = 'packages/engine/mcp-server/src/';
+
 const COSMETIC_TEST_FIELDS = ['name', 'description', 'tags'] as const;
 const JSON_EXTS = new Set(['.json']);
 const TEXT_EXTS = new Set([
@@ -153,6 +160,7 @@ export async function diffSnapshotVsDisk(
 ): Promise<Record<string, 'missing-on-disk' | 'content-differs'>> {
   const out: Record<string, 'missing-on-disk' | 'content-differs'> = {};
   for (const [rel, expected] of Object.entries(snapshot)) {
+    if (rel.startsWith(MCP_SRC_PREFIX)) continue;
     const absPath = path.join(repoRoot, rel);
     let bytes: Buffer;
     try {

--- a/eval/app/tests/unit/snapshot.test.ts
+++ b/eval/app/tests/unit/snapshot.test.ts
@@ -145,4 +145,14 @@ describe('diffSnapshotVsDisk', () => {
     await fs.writeFile(path.join(dir, 'skill.md'), Buffer.from('hello\r\n'));
     expect(await diffSnapshotVsDisk({ 'skill.md': 'hello\n' }, dir)).toEqual({});
   });
+
+  it('ignores legacy packages/engine/mcp-server/src keys', async () => {
+    await fs.writeFile(path.join(dir, 'skill.md'), 'body\n');
+    // src/ file absent on disk and would differ — neither is flagged.
+    const snapshot = {
+      'skill.md': 'body\n',
+      'packages/engine/mcp-server/src/constants.ts': "export const UA = 'old';\n",
+    };
+    expect(await diffSnapshotVsDisk(snapshot, dir)).toEqual({});
+  });
 });

--- a/eval/harness/harness/snapshot.py
+++ b/eval/harness/harness/snapshot.py
@@ -25,6 +25,12 @@ from pathlib import Path
 from typing import Any, Iterable
 
 
+# MCP source is no longer embedded in new snapshots (see build_snapshot),
+# but run logs written before that change embedded the whole tree. The diff
+# ignores keys under this prefix so those legacy run logs re-validate without
+# a re-run rather than staying inactive forever on unrelated MCP-source churn.
+_MCP_SRC_PREFIX = "packages/engine/mcp-server/src/"
+
 _COSMETIC_TEST_FIELDS = ("name", "description", "tags")
 _JSON_EXTS = {".json"}
 _TEXT_EXTS = {
@@ -104,11 +110,15 @@ def build_snapshot(
       - `eval/fixtures/scenarios/<name>/**` for each scenario referenced
         by an included test
       - `eval/fixtures/mcp/<name>.json` for each MCP fixture referenced
-      - `packages/engine/mcp-server/src/**/*.ts` (all MCP tool source). Conservative:
-        any change to MCP source invalidates every skill's runlog. A
-        change to a shared util (`auth/`, `constants.ts`, `types/`) can
-        affect any tool's behavior, so tracking the whole tree is the
-        only way to avoid silently missed invalidations.
+
+    MCP tool source (`packages/engine/mcp-server/src/**`) is deliberately
+    NOT embedded. The harness serves every tool call from a mock fixture
+    (`mock_mcp.py`); the only exception is the LIVE_TOOLS path, which runs
+    the *compiled* `build/**` output, not `src/`. So MCP source is not a
+    dependency of a run and tracking it produced churn with no eval signal
+    — a `src/` edit flipped every skill's run log inactive even though the
+    run never executed that code. Tool-code correctness is Vitest's job
+    (`packages/engine/mcp-server/tests/`), not this framework's.
 
     When `test_ids` is given, only those tests' scenarios + fixtures are
     embedded. When None, every test in the skill contributes.
@@ -133,9 +143,6 @@ def build_snapshot(
             rel = f"eval/fixtures/mcp/{fixture}.json"
             snapshot[rel] = normalize(rel, fixture_path.read_bytes())
 
-    mcp_src_dir = repo_root / "packages" / "engine" / "mcp-server" / "src"
-    _embed_tree(snapshot, mcp_src_dir, repo_root)
-
     return snapshot
 
 
@@ -153,9 +160,16 @@ def diff_snapshot_vs_disk(snapshot: dict[str, str], repo_root: Path) -> dict[str
       - "content-differs" — file exists but normalized bytes differ
     Paths present on disk but absent from the snapshot are NOT flagged —
     the snapshot is the authority on what's tracked.
+
+    Keys under `packages/engine/mcp-server/src/` are skipped: MCP source is
+    no longer a tracked dependency (see `_MCP_SRC_PREFIX` and
+    `build_snapshot`), so legacy run logs that embedded it stay active
+    through unrelated MCP-source churn instead of needing a re-run.
     """
     out: dict[str, str] = {}
     for rel, expected in snapshot.items():
+        if rel.startswith(_MCP_SRC_PREFIX):
+            continue
         abs_path = repo_root / rel
         if not abs_path.is_file():
             out[rel] = "missing-on-disk"

--- a/eval/harness/tests/unit/test_snapshot.py
+++ b/eval/harness/tests/unit/test_snapshot.py
@@ -161,11 +161,11 @@ def test_build_snapshot_skips_missing_skill(tmp_path: Path):
     assert snap == {}
 
 
-def test_build_snapshot_embeds_mcp_server_source(tmp_path: Path):
-    """Any TS file under packages/engine/mcp-server/src/ is embedded so that MCP-side
-    changes invalidate the runlog. Conservative: shared utils
-    (auth/, constants.ts, types/) affect any tool, so the whole tree
-    is tracked rather than a per-skill subset."""
+def test_build_snapshot_excludes_mcp_server_source(tmp_path: Path):
+    """MCP source under packages/engine/mcp-server/src/ is NOT embedded.
+    The harness serves tool calls from mocks (and live tools run compiled
+    build/, not src/), so MCP source is not a dependency of a run. Tool-code
+    correctness is Vitest's job, not the runlog snapshot's."""
     repo = tmp_path
     (repo / "packages" / "engine" / "plugin" / "skills" / "x").mkdir(parents=True)
     src_dir = repo / "packages" / "engine" / "mcp-server" / "src"
@@ -175,8 +175,8 @@ def test_build_snapshot_embeds_mcp_server_source(tmp_path: Path):
     (src_dir / "constants.ts").write_text("export const UA = 'mozilla';\n")
 
     snap = build_snapshot(skill="x", repo_root=repo)
-    assert "packages/engine/mcp-server/src/tools/wikipedia.ts" in snap
-    assert "packages/engine/mcp-server/src/constants.ts" in snap
+    assert "packages/engine/mcp-server/src/tools/wikipedia.ts" not in snap
+    assert "packages/engine/mcp-server/src/constants.ts" not in snap
 
 
 # ---- diff vs disk --------------------------------------------------------
@@ -205,6 +205,19 @@ def test_diff_normalizes_before_comparing(tmp_path: Path):
     f.write_bytes(b"hello\r\n")
     snapshot = {"skill.md": "hello\n"}  # Normalized form
     # Disk's CRLF normalizes to LF → matches snapshot.
+    assert diff_snapshot_vs_disk(snapshot, tmp_path) == {}
+
+
+def test_diff_ignores_legacy_mcp_server_source(tmp_path: Path):
+    """Legacy run logs embedded packages/engine/mcp-server/src/**. Those
+    keys are skipped so a changed-or-missing MCP source file no longer
+    flips the run log inactive."""
+    snapshot = {
+        "skill.md": "body\n",
+        "packages/engine/mcp-server/src/constants.ts": "export const UA = 'old';\n",
+    }
+    (tmp_path / "skill.md").write_text("body\n")
+    # The src/ file is absent on disk AND would differ — yet neither is flagged.
     assert diff_snapshot_vs_disk(snapshot, tmp_path) == {}
 
 


### PR DESCRIPTION
## Problem

The run-log snapshot embedded the entire `packages/engine/mcp-server/src/**` tree. Any edit to MCP source flipped **every** skill's run log inactive and forced a harness re-run (rule 2 of the runlog discipline check). Under active development of core files, this was pure churn:

- The harness serves every tool call from a **mock fixture** (`mock_mcp.py`).
- The only real-code path, `LIVE_TOOLS` (today just `validate_research_schema`), runs the **compiled `build/**`** output — not `src/`.

So MCP source was never a dependency of an eval run. Re-running the harness reproduced **identical** scores against identical mocks — the invalidation carried no eval signal. Tool-code correctness is already covered by Vitest (`packages/engine/mcp-server/tests/`), which eval/CLAUDE.md explicitly lists under "What This Framework Does NOT Cover."

## Change

- `build_snapshot` no longer embeds `mcp-server/src/**`.
- `diff_snapshot_vs_disk` (Python) and `diffSnapshotVsDisk` (TS) skip keys under that prefix. This re-validates **legacy run logs** that embedded the tree **without a re-run** — and keeps the CI gate and the CRUD UI's `detectActiveRunLog` in agreement.
- Removed `mcp-server/src/**` from the `check-runlogs.yml` trigger paths (a src-only change can no longer affect activeness).
- Updated Python + TS snapshot tests and `eval/CLAUDE.md`.

## Why drop entirely vs. per-skill / live-skill tracking

Live-skill tracking (embed src only for skills that call a live tool) would still embed the whole tree for the 16 skills that use `validate_research_schema` — the central, heavily-developed ones — so it barely reduces churn, and it drags `allowed-tools` resolution into the stdlib-only CI check. Dropping entirely is simpler, fixes all 26 skills, and the "signal" it gives up was a proxy anyway (snapshot tracked `src/`; the live tool runs compiled `build/`). If a live tool's real behavior ever needs tracking, the right mechanism is a separate hash of the compiled artifact — mirroring `judge_prompt_hash` — not whole-tree source tracking.

## Relationship to #341

#341 was blocked solely because convert-dates' v1 run log had one stale snapshot entry: `validator.ts`. After this merges, #341's check will pass on re-run (rebase or re-run the workflow) with no harness re-run needed.

## Testing

- `eval/harness` `test_snapshot.py`: 20 passed.
- `eval/app` `snapshot.test.ts`: 15 passed.
- (Pre-existing unrelated failures in `test_cli.py` / `test_reinvocation_sections.py` exist on `main` and are untouched here.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)