### PR TITLE
eval: fix stale citation-rubric dimension count in test_rubric

### DIFF
--- a/eval/harness/tests/unit/test_rubric.py
+++ b/eval/harness/tests/unit/test_rubric.py
@@ -67,9 +67,9 @@ Gamma description.
 
 
 def test_parse_real_citation_rubric():
-    r = parse_rubric(CITATION_RUBRIC.read_text())
+    r = parse_rubric(CITATION_RUBRIC.read_text(encoding="utf-8"))
     assert r.skill == "Citation Rubric"
-    assert len(r.dimensions) == 3
+    assert len(r.dimensions) == 5
     names = [d.name for d in r.dimensions]
     assert "Evidence Explained compliance" in names
     for d in r.dimensions:


### PR DESCRIPTION
## Problem

`main`'s harness pytest job is **currently red for every PR**. PR #363 expanded the citation rubric from 3 → 5 dimensions ("systemic rubric calibration"), but `test_parse_real_citation_rubric` in `eval/harness/tests/unit/test_rubric.py` still asserts `len(r.dimensions) == 3`:

```
FAILED tests/unit/test_rubric.py::test_parse_real_citation_rubric - AssertionError: assert 5 == 3
```

## Change

- Update the expected count `3` → `5` to match the current `eval/tests/unit/citation/rubric.md` (Evidence Explained compliance, Replication test, Source vs information distinction, Does not create new source entries, Source fidelity — no fabricated detail).
- Pass `encoding="utf-8"` to `CITATION_RUBRIC.read_text()`. The rubric now contains an em-dash ("Source fidelity — no fabricated detail"), which crashes a bare `read_text()` on Windows cp1252 — exactly the failure mode the project's encoding rule guards against.

## Verification

Full unit suite on this branch: **1 failed, 542 passed**. The one remaining failure is `test_reinvocation_sections[search-wikipedia]`, a *separate* pre-existing breakage fixed by **#376**. The two PRs mutually unblock — whichever merges first, rebasing the other turns its pytest green.

cc the #363 author — this is just catching the test up to your intentional rubric change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)