### PR TITLE
Pass encoding="utf-8" on all read_text calls; strengthen the rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -326,10 +326,17 @@ cp1252 on Windows — and crashes with `UnicodeDecodeError` on the em-dashes
 and smart quotes that SKILL.md, the test JSON, and `research.json`
 routinely contain. It works on macOS/Linux (utf-8 default) but breaks for
 the Windows-based genealogist team, and it has bitten us repeatedly (the
-eval-harness scripts, `eval/triggering/`). This applies to harness/dev
-scripts, GH-action checks, and stdlib-only skill `scripts/` alike. For a
-vendored third-party script, apply the patch and record it under a "Local
-divergences from upstream" note so it survives re-vendoring.
+eval-harness scripts, `eval/triggering/`). This applies to **every** Python
+call with no exceptions — harness/dev scripts, GH-action checks, stdlib-only
+skill `scripts/`, the `apps/server/` FastAPI control plane, **and test files**
+(`tests/`, `*_test.py`, `test_*.py`) alike. It applies even when the result is
+immediately handed to `json.loads(...)` — `read_text()` decodes before
+`json` ever sees the bytes, so `json.loads(p.read_text(encoding="utf-8"))`,
+never `json.loads(p.read_text())`. Pass it as a keyword (`encoding="utf-8"`),
+not positionally, so a `read_text(` / `open(` grep that excludes `encoding=`
+reliably finds every offender. For a vendored third-party script, apply the
+patch and record it under a "Local divergences from upstream" note so it
+survives re-vendoring.
 
 ## Code reuse
 

--- a/apps/server/app/agent/mock_agent.py
+++ b/apps/server/app/agent/mock_agent.py
@@ -55,7 +55,7 @@ class MockAgent:
         p = self.dir / STATE_FILE
         if p.is_file():
             try:
-                return json.loads(p.read_text())
+                return json.loads(p.read_text(encoding="utf-8"))
             except json.JSONDecodeError:
                 pass
         # Pre-seeded (sample) project: skip onboarding.
@@ -72,7 +72,7 @@ class MockAgent:
         p = self.dir / "research.json"
         if p.is_file():
             try:
-                return json.loads(p.read_text())
+                return json.loads(p.read_text(encoding="utf-8"))
             except json.JSONDecodeError:
                 return None
         return None

--- a/apps/server/app/agent/real_agent.py
+++ b/apps/server/app/agent/real_agent.py
@@ -122,7 +122,7 @@ class RealAgent:
         self._tool_names: dict[str, str] = {}  # tool_use_id → name, for tool_result tagging
         if self._session_file.exists():
             try:
-                self._resume_id = self._session_file.read_text().strip() or None
+                self._resume_id = self._session_file.read_text(encoding="utf-8").strip() or None
             except OSError:
                 self._resume_id = None
 

--- a/apps/server/app/config.py
+++ b/apps/server/app/config.py
@@ -124,7 +124,7 @@ class Settings(BaseSettings):
         present this exact id (and the in-sandbox MCP refreshes with the same)."""
         p = REPO_ROOT / "packages" / "engine" / "mcp-server" / "config" / "familysearch.json"
         try:
-            return json.loads(p.read_text())["clientId"]
+            return json.loads(p.read_text(encoding="utf-8"))["clientId"]
         except (OSError, KeyError, json.JSONDecodeError):
             return None
 

--- a/apps/server/app/sandbox/local.py
+++ b/apps/server/app/sandbox/local.py
@@ -230,7 +230,7 @@ class LocalProvider(SandboxProvider):
         meta = self._root(sandbox_id) / "meta.json"
         if meta.is_file():
             try:
-                return json.loads(meta.read_text())
+                return json.loads(meta.read_text(encoding="utf-8"))
             except json.JSONDecodeError:
                 return {}
         return {}

--- a/apps/server/app/sandbox_server.py
+++ b/apps/server/app/sandbox_server.py
@@ -64,7 +64,7 @@ def verify_token(token: str | None) -> bool:
 
 def _read_json(path: Path):
     try:
-        return json.loads(path.read_text("utf-8"))
+        return json.loads(path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError):
         return None
 

--- a/apps/server/tests/test_familysearch.py
+++ b/apps/server/tests/test_familysearch.py
@@ -55,7 +55,7 @@ def test_create_session_injects_real_fs_token():
         path = _tokens_path(app.state.provider, sandbox_id)
         assert path.is_file(), "tokens.json should be injected at create"
 
-        tok = json.loads(path.read_text())
+        tok = json.loads(path.read_text(encoding="utf-8"))
         assert tok["accessToken"] == "real-access"
         assert tok["refreshToken"] == "real-refresh"
         assert "mock" not in tok  # real token, not the old dev-connect mock shape

--- a/apps/server/tests/test_v1_api.py
+++ b/apps/server/tests/test_v1_api.py
@@ -113,7 +113,7 @@ def test_create_injects_supplied_familysearch_token():
         sid = r.json()["session_id"]
         assert "familysearch_token" not in r.json()  # not echoed back
 
-        tok = json.loads(_tokens_path(sid).read_text())
+        tok = json.loads(_tokens_path(sid).read_text(encoding="utf-8"))
         assert tok["accessToken"] == "v1-access"
         assert tok["refreshToken"] == "v1-refresh"
         assert isinstance(tok["expiresAt"], int) and tok["expiresAt"] > 0

--- a/eval/harness/tests/unit/test_e2e_orchestrator.py
+++ b/eval/harness/tests/unit/test_e2e_orchestrator.py
@@ -123,7 +123,7 @@ def test_build_workspace_renames_starting_files(tmp_path: Path):
     workspace.mkdir()
     build_workspace(fixture, workspace, skills_dir)
 
-    parsed = json.loads((workspace / "research.json").read_text())
+    parsed = json.loads((workspace / "research.json").read_text(encoding="utf-8"))
     assert parsed["project"]["objective"] == "Find John's parents"
 
 

--- a/eval/harness/tests/unit/test_e2e_result.py
+++ b/eval/harness/tests/unit/test_e2e_result.py
@@ -46,7 +46,7 @@ def test_write_result_files_creates_all_four_artifacts(tmp_path: Path):
     assert paths["research"].exists()
 
     # Result is valid JSON with expected fields
-    payload = json.loads(paths["result"].read_text())
+    payload = json.loads(paths["result"].read_text(encoding="utf-8"))
     assert payload["test_id"] == "smith-parents-1850"
     assert payload["verdict"] == "pass"
     assert payload["stop_reason"] == "completed"

--- a/eval/harness/tests/unit/test_judge.py
+++ b/eval/harness/tests/unit/test_judge.py
@@ -21,7 +21,7 @@ CITATION_RUBRIC = REPO_ROOT / "eval/tests/unit/citation/rubric.md"
 
 @pytest.fixture
 def sample_rubric():
-    return parse_rubric(CITATION_RUBRIC.read_text())
+    return parse_rubric(CITATION_RUBRIC.read_text(encoding="utf-8"))
 
 
 def test_prompt_hash_is_sha256_hex():

--- a/eval/harness/tests/unit/test_runlog.py
+++ b/eval/harness/tests/unit/test_runlog.py
@@ -295,7 +295,7 @@ def test_write_to_skill_directory(tmp_path: Path):
     path = write_run_log(log, runlogs_root=tmp_path, filename="v1_2026-05-18_10-30-00.json")
     assert path.parent == tmp_path / "unit" / "search-familysearch-wiki"
     assert path.name == "v1_2026-05-18_10-30-00.json"
-    loaded = json.loads(path.read_text())
+    loaded = json.loads(path.read_text(encoding="utf-8"))
     assert loaded["skill"] == "search-familysearch-wiki"
 
 
@@ -313,12 +313,12 @@ def test_write_spills_large_text_response_to_sidecar(tmp_path: Path):
     run.output["text_response"] = big
     log = _wrap_envelope(_make_entry(runs=[run]))
     path = write_run_log(log, runlogs_root=tmp_path, filename="v1_2026-05-18_10-30-00.json")
-    loaded = json.loads(path.read_text())
+    loaded = json.loads(path.read_text(encoding="utf-8"))
     text_field = loaded["tests"][0]["runs"][0]["output"]["text_response"]
     assert isinstance(text_field, dict)
     assert "ref" in text_field
     sidecar = path.parent / text_field["ref"]
-    assert sidecar.read_text() == big
+    assert sidecar.read_text(encoding="utf-8") == big
 
 
 # ---- derive_activated regression tests (spec §6) -------------------------

--- a/eval/harness/tests/unit/test_setup_feedback_case.py
+++ b/eval/harness/tests/unit/test_setup_feedback_case.py
@@ -94,7 +94,7 @@ def test_writes_feedback_repo_root_marker(tmp_path, monkeypatch):
     dest = tmp_path / "home" / "feedback" / slug
     marker = dest / ".feedback-repo-root"
     assert marker.is_file()
-    assert marker.read_text().strip() == str(REPO_ROOT)
+    assert marker.read_text(encoding="utf-8").strip() == str(REPO_ROOT)
 
 
 def test_initial_git_commit_titled_imported(tmp_path, monkeypatch):
@@ -147,7 +147,7 @@ def test_gitignore_appended_when_zip_has_one(tmp_path, monkeypatch):
     assert result.returncode == 0, result.stderr
 
     dest = tmp_path / "home" / "feedback" / slug
-    gitignore = (dest / ".gitignore").read_text()
+    gitignore = (dest / ".gitignore").read_text(encoding="utf-8")
     assert "scratch/" in gitignore, "existing entries preserved"
     assert "*.tmp" in gitignore, "existing entries preserved"
     assert ".claude/" in gitignore, ".claude/ appended"
@@ -163,7 +163,7 @@ def test_gitignore_created_when_absent(tmp_path, monkeypatch):
     assert result.returncode == 0, result.stderr
 
     dest = tmp_path / "home" / "feedback" / slug
-    assert (dest / ".gitignore").read_text() == ".claude/\n"
+    assert (dest / ".gitignore").read_text(encoding="utf-8") == ".claude/\n"
 
 
 def test_claude_skills_dir_is_real_with_symlinks(tmp_path, monkeypatch):

--- a/eval/harness/tests/unit/test_workspace.py
+++ b/eval/harness/tests/unit/test_workspace.py
@@ -64,7 +64,7 @@ def test_scenario_workspace_copies_results_sidecars(tmp_path):
     )
     sidecar = ws / "results" / "log_001.json"
     assert sidecar.exists()
-    assert json.loads(sidecar.read_text())["log_id"] == "log_001"
+    assert json.loads(sidecar.read_text(encoding="utf-8"))["log_id"] == "log_001"
 
 
 def test_missing_scenario_raises(tmp_path):


### PR DESCRIPTION
## Problem

CLAUDE.md already requires `encoding="utf-8"` on every Python text read, but **18 bare `read_text()` calls** had slipped in — **all** in test files and the `apps/server/` FastAPI control plane, the two areas the rule's wording didn't explicitly name. A bare read uses cp1252 on Windows and crashes with `UnicodeDecodeError` on the em-dashes / smart quotes in `SKILL.md`, `research.json`, `rubric.md`, and fixtures. It's silently fine on macOS/Linux CI but breaks the Windows-based genealogist team — and the citation rubric's new em-dash (just fixed in #377) is exactly this failure mode.

## Change

- **Add `encoding="utf-8"` to all 18 bare calls** across `eval/harness/tests/` and `apps/server/`, including those whose result is immediately `json.loads()`'d (the decode happens in `read_text`, before `json` sees anything). Normalized one positional `read_text("utf-8")` to the keyword form.
- **Strengthen the CLAUDE.md rule**: "every call, no exceptions," naming test files + `apps/server` explicitly, calling out the `json.loads(read_text())` case, and requiring the keyword form so a `read_text(`-without-`encoding=` grep reliably finds offenders.

## Verification

- `grep` for bare `read_text(` (no `encoding=`): **0 remaining**.
- `eval/harness` unit tests for the touched files: **92 passed**.
- `apps/server` tests: **42 passed**.
- All changed files `py_compile` clean.

Mechanical, no behavior change on macOS/Linux; purely hardens Windows correctness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)