### PR TITLE
Deterministic skill tools: convert_calendar, tree_edit, research_append

### DIFF
--- a/docs/specs/convert-calendar-tool-spec.md
+++ b/docs/specs/convert-calendar-tool-spec.md
@@ -1,0 +1,236 @@
+# `convert_calendar` — calendar conversion tool — Spec
+
+> **Status:** New (2026-06-19). Migrates the deterministic arithmetic the
+> `convert-dates` skill currently performs **by hand in context** into a tested
+> MCP tool. The skill's own SKILL.md already anticipates this: *"A
+> `convert_calendar` tool is specced for the future but is **not yet
+> implemented**"* (`convert-dates/SKILL.md:64`). The LLM keeps every judgment
+> (which jurisdiction/era applies, whether conversion is even needed, which
+> correction was asked for); the tool does only the arithmetic.
+
+A pure, offline tool that applies the three independent calendar corrections a
+genealogist needs — Old Style→New Style **year**, Julian→Gregorian **day**
+offset, and Quaker numbered-**month** resolution — each only when the caller
+requests it. It computes nothing about *which* regime applies; the caller
+supplies that judgment as input.
+
+```
+convert_calendar({ date, corrections }) -> { original, converted, applied, notes }
+```
+
+---
+
+## 1. Why this exists
+
+Calendar conversion is the one place in the catalog where a hand-arithmetic slip
+changes the **year**, not just the day — `convert-dates/SKILL.md:142` lists "a
+date seems 'off by one year'" as a trigger, and the OS/NS rule (`SKILL.md:98–110`)
+turns "15 February 1720" into 1721. The century-dependent Julian→Gregorian offset
+(10/11/12/13 days across the 1700/1800/1900 leap-skip thresholds,
+`SKILL.md:84–87`) and the pre-/post-1752 Quaker month shift (`SKILL.md:126–129`)
+are equally mechanical and equally easy to get wrong by a day or a month. A wrong
+result also propagates: `conflict-resolution` uses the *expected* offset to decide
+whether two dates that differ are a real conflict or a calendar artifact
+(`SKILL.md:31–36`, `convert-dates/references/calendar-conflicts.md`) — a
+miscomputed offset silently suppresses a real conflict or fabricates a fake one.
+
+This is exactly the "pure arithmetic the LLM does in-context" anti-pattern: the
+rules are fixed tables, the inputs are a date plus a regime, and the output is
+deterministic. It belongs in tested code.
+
+---
+
+## 2. Evidence base (seen directly)
+
+| Fact | Source |
+|------|--------|
+| The skill is knowledge-only today; conversion is "deterministic arithmetic you perform in context"; a `convert_calendar` tool is specced-but-unbuilt | `packages/engine/plugin/skills/convert-dates/SKILL.md:62–65` |
+| Julian→Gregorian offset table by jurisdiction + the "grows one day each skipped Julian leap year (1700→11, 1800→12, 1900→13)" rule, with the Feb-29-Julian threshold | `convert-dates/SKILL.md:71–87` |
+| OS/NS: legal year began March 25; dates Jan 1–Mar 24 are the "previous" year by modern reckoning; double-dated "1750/1" → use the **later** year | `convert-dates/SKILL.md:94–110, 198, 202` |
+| Quaker numbered months; the 1752 shift (before: 1st month = March; after: 1st month = January); 11th/12th month roll into the next year before 1752 | `convert-dates/SKILL.md:112–129` |
+| "Answer only the calendar question that was asked" — each correction is a **separate** operation; do not bundle unprompted | `convert-dates/SKILL.md:220–229` |
+| Standardized-date parsing/representation already exists | `src/utils/date-standardize.ts` (`stdDate`), `src/utils/date-helpers.ts` (`getDayRange`, `earliestYear`, `latestYear`) |
+| The skill writes nothing — output-only, idempotent | `convert-dates/SKILL.md:231–242` |
+
+---
+
+## 3. The tool
+
+```typescript
+convert_calendar({
+  // The recorded date, as structured fields (the caller has already read it off
+  // the record). `month` is the calendar month 1–12, EXCEPT when a quakerMonth
+  // correction is requested, where `month` is the Quaker ordinal 1–12.
+  date: {
+    year: number,
+    month?: number,       // 1–12; required for day-offset and quaker conversions
+    day?: number,         // 1–31; required for the day-offset conversion
+    doubleYear?: number,  // the "/N" of a double-dated year, e.g. 1 for "1750/1"
+  },
+
+  // Which corrections to apply, in this fixed order: doubleDatedYear → osNsYear
+  // → quakerMonth → julianToGregorianDay. Request only what was asked (§5b).
+  corrections: {
+    doubleDatedYear?: boolean,          // resolve year/doubleYear → the later year
+    osNsYear?: boolean,                 // if month/day ∈ [Jan 1, Mar 24], year += 1
+    quakerMonth?: { era: "pre_1752" | "post_1752" }, // interpret `month` as a Quaker ordinal
+    julianToGregorianDay?: boolean,     // add the era-appropriate Julian→Gregorian offset
+  },
+})
+```
+
+`corrections` must request **at least one** correction. Each requested correction
+is applied in the fixed order above (so an OS/NS year fix lands before the Quaker
+month roll-over and the day offset operate on it). Omitted corrections are not
+applied — the tool never "helpfully" bundles one the caller didn't ask for.
+
+### 3.1 Return value
+
+```typescript
+{
+  original: { year, month?, day?, doubleYear? },   // echoed input date
+  converted: { year, month?, day? },               // after the requested corrections
+  applied: Array<{                                  // one per correction actually applied
+    correction: "doubleDatedYear" | "osNsYear" | "quakerMonth" | "julianToGregorianDay",
+    rule: string,                                   // human-readable rule, for narration
+    offsetDays?: number,                            // julianToGregorianDay only (10/11/12/13)
+    monthShift?: number,                            // quakerMonth only
+    yearAdjusted?: boolean,                          // osNsYear / doubleDatedYear
+  }>,
+  notes: string[],                                   // e.g. "day omitted; day offset not applied"
+}
+```
+
+The skill narrates from `applied`/`notes` and keeps presenting the original
+alongside the converted date (`SKILL.md:209–211`); the tool never persists
+anything (§6).
+
+---
+
+## 4. The arithmetic (deterministic rules)
+
+### 4.1 `doubleDatedYear`
+Given `year` and `doubleYear`, the New-Style year is the **later** of the two:
+the value formed by taking `year`'s leading digits and `doubleYear`'s trailing
+digits, choosing the later year (`SKILL.md:107–110, 202`). E.g. `1750` + `1` →
+`1751`; `1699` + `700` → `1700`. Sets `converted.year`; no day/month change.
+
+### 4.2 `osNsYear`
+If the (calendar) `month`/`day` falls on or after **January 1** and on or before
+**March 24**, add 1 to `converted.year`; otherwise no change
+(`SKILL.md:98–101, 198`). Requires `month` (and `day` when the date is in March,
+to test the ≤24 boundary). The day and month are unchanged — this is the
+year-start correction only.
+
+### 4.3 `quakerMonth`
+Interpret `date.month` as a Quaker ordinal (1–12) and map to a calendar month
+(`SKILL.md:117–129`):
+- **`post_1752`:** calendar month = ordinal (1st month = January).
+- **`pre_1752`:** calendar month = `((ordinal + 1) % 12) + 1` shifted so 1st = March,
+  …, 10th = December, **11th = January of `year + 1`**, **12th = February of
+  `year + 1`** (the two roll into the next year). The tool sets
+  `converted.month` and, for the 11th/12th cases, increments `converted.year`.
+
+### 4.4 `julianToGregorianDay`
+Add the era-appropriate offset to the Julian `year/month/day`, rolling month/year
+over correctly (and respecting Julian leap years). The offset is a pure function
+of the Julian date, keyed off the skipped-Julian-leap thresholds
+(`SKILL.md:84–87`):
+
+| Julian date range | Offset (days) |
+|-------------------|---------------|
+| 1582-10-15 … before 1700-03-01 (Julian) | 10 |
+| 1700-03-01 … before 1800-03-01 (Julian) | 11 |
+| 1800-03-01 … before 1900-03-01 (Julian) | 12 |
+| 1900-03-01 … 2099 (Julian) | 13 |
+
+(The boundary sits at the day after each skipped Julian Feb 29 — i.e. March 1
+Julian of 1700/1800/1900.) Requires a full `year/month/day`; if `day` is absent
+the tool **skips** this correction and adds a `notes` entry rather than guessing.
+Output is the Gregorian `year/month/day`.
+
+> **Implementation:** reuse `date-standardize.ts`/`date-helpers.ts` for the
+> day-number representation rather than hand-rolling date math. The offset table
+> and the OS/NS + Quaker rules transcribe directly from `convert-dates/SKILL.md`,
+> which is the de-facto spec for the regime tables.
+
+---
+
+## 5. What the tool owns vs. what the caller decides
+
+| Owned by the tool (mechanical) | Decided by the caller (judgment) |
+|--------------------------------|----------------------------------|
+| The offset value for a Julian date; the ≤Mar-24 year bump; the Quaker month/year roll; double-date resolution | The jurisdiction and era; whether the source date is Julian vs. Gregorian; whether conversion is needed at all; **which** corrections to request |
+
+### 5b. Single-correction discipline
+The `corrections` object is how the spec's "answer only the calendar question that
+was asked" rule (`SKILL.md:220–229`) becomes structural: the caller passes exactly
+the corrections the user asked for, and the tool applies exactly those. Asking for
+the New-Style **year** of "25 March 1750/1" → `{ doubleDatedYear: true }` (or
+`{ osNsYear: true }`) and nothing else; the day offset is not applied unprompted.
+
+---
+
+## 6. Non-goals / persistence
+
+- **Writes nothing.** Like the skill it replaces, the tool is output-only — it
+  returns the conversion; it does not touch `research.json` or `tree.gedcomx.json`
+  (`SKILL.md:231–238`). Assertions keep the original record date; the conversion is
+  interpretation shown to the user. (No project write layer, no validation pass.)
+- **Does not identify the regime.** It will not infer jurisdiction or guess whether
+  a date is Julian — that is the caller's judgment and the source of the "flag the
+  ambiguity rather than guess" rule (`SKILL.md:162–163`).
+- **No free-text date parsing as the primary path.** The caller passes structured
+  `year/month/day`; a future convenience overload that accepts a raw string via
+  `stdDate` is out of scope for v1.
+- Not a network tool — pure arithmetic, no auth.
+
+---
+
+## 7. Errors / edge cases
+
+| Condition | Behavior |
+|-----------|----------|
+| `corrections` requests nothing | input error (nothing to do) |
+| `julianToGregorianDay` but `day` (or `month`) absent | skip that correction; add a `notes` entry ("day offset needs a full day-month-year date"); still apply the others |
+| `osNsYear` but `month` absent | input error (cannot test the Jan 1–Mar 24 window) |
+| `quakerMonth.era` missing/invalid | input error (the shift is era-dependent) |
+| `date.month` outside 1–12 / `day` outside 1–31 | input error |
+| Julian date before the jurisdiction's Gregorian-era table start (pre-1582) | apply the 10-day offset and note that pre-1582 Julian/Gregorian coincided (no offset) — or input error; pick one and document (recommend: note + 10-day floor) |
+
+---
+
+## 8. Test plan (vitest)
+
+- **Double date** — `{1750, doubleYear:1}` + `doubleDatedYear` → `1751`.
+- **OS/NS year** — `15 Feb 1720` + `osNsYear` → `1721`; `15 June 1720` → unchanged.
+- **OS/NS boundary** — `24 Mar 1720` → bumped; `25 Mar 1720` → unchanged.
+- **Quaker pre-1752** — `{month:1}` (1st) `pre_1752` → March; `{month:11}` → January of `year+1`.
+- **Quaker post-1752** — `{month:1}` `post_1752` → January.
+- **Day offset by era** — a 1690 Julian date → +10; 1750 → +11; 1850 → +12; 1950 → +13; check month/year rollover at e.g. `1752-09-02` Julian → `1752-09-13`.
+- **Single-correction discipline** — requesting only `doubleDatedYear` on `25 Mar 1750/1` does NOT change the day or apply the offset.
+- **Combined** — OS/NS year then day offset on one call, applied in order, both reflected in `applied`.
+- **Missing day** — `julianToGregorianDay` with no `day` skips the offset and notes it; other requested corrections still apply.
+- **Purity / idempotence** — same input → same output; input object not mutated.
+
+---
+
+## 9. Consumers
+
+- `convert-dates` skill — replaces the in-context arithmetic; SKILL.md becomes
+  "identify the regime, call `convert_calendar` with the requested corrections,
+  present original + converted." Its regime tables stay as reference for the
+  identification judgment.
+- `conflict-resolution` — calls `convert_calendar` (or reads `applied[].offsetDays`)
+  to get the **expected** offset between two jurisdictions, so a date difference
+  that matches the calendar offset is correctly classified as an artifact, not a
+  conflict (`SKILL.md:31–36`).
+
+---
+
+## 10. Wiring
+
+Standard MCP tool: implementation in `src/tools/convert-calendar.ts`, schema added
+to `allToolSchemas` in `src/tool-schemas.ts`, dispatch in `src/index.ts`, name in
+`manifest.json`'s `tools` array (the packaging drift test enforces parity).
+camelCase at the boundary; no persisted output so no snake_case rename applies.

--- a/docs/specs/convert-calendar-tool-spec.md
+++ b/docs/specs/convert-calendar-tool-spec.md
@@ -196,7 +196,9 @@ the New-Style **year** of "25 March 1750/1" → `{ doubleDatedYear: true }` (or
 | `osNsYear` but `month` absent | input error (cannot test the Jan 1–Mar 24 window) |
 | `quakerMonth.era` missing/invalid | input error (the shift is era-dependent) |
 | `date.month` outside 1–12 / `day` outside 1–31 | input error |
-| Julian date before the jurisdiction's Gregorian-era table start (pre-1582) | apply the 10-day offset and note that pre-1582 Julian/Gregorian coincided (no offset) — or input error; pick one and document (recommend: note + 10-day floor) |
+| `julianToGregorianDay` on a Julian date before 1582-10-15 | **input error** — the Gregorian calendar did not exist before its introduction, so there is no meaningful day offset to apply (the other corrections, if requested, are unaffected) |
+| `quakerMonth.era` not exactly `pre_1752` / `post_1752` | input error (the shift is era-dependent; the exported function is called outside the MCP enum guard) |
+| `doubleYear` given but inconsistent with `year + 1` | input error (a real double date always spans consecutive years) |
 
 ---
 

--- a/docs/specs/research-append-tool-spec.md
+++ b/docs/specs/research-append-tool-spec.md
@@ -1,0 +1,257 @@
+# `research_append` — research.json section writer — Spec
+
+> **Status:** New (2026-06-19). The broader sibling of the **shipped**
+> `research_log_append` (`research-log-editor-spec.md`). That tool owns the one
+> append-only section (`log[]` + its sidecars); this one owns the **other**
+> mutable `research.json` sections — sources, assertions, person_evidence,
+> questions, plans, conflicts, hypotheses, known_holdings, timelines. It is the
+> single largest remaining hand-edited-JSON surface in the skill catalog and the
+> home for the state-coupling invariants the skill-determinism audit surfaced.
+> The log was split out and shipped first because of its two-file atomic write +
+> sidecar integrity; the machinery it proved (id assignment, validate-before-
+> persist, atomic write, compact return) is reused wholesale here.
+
+```
+research_append({ projectPath, section, op, entry | entryId + fields }) -> compact summary
+```
+
+One tool with a `section` + `op` discriminator. The LLM supplies the analytical
+content (the assertion's value, the conflict's weighing, the question text); the
+tool assigns the section's id, enforces the schema and the cross-field invariants,
+preserves the supersede-not-delete rule structurally, and does the validate-before-
+persist atomic write.
+
+---
+
+## 1. Why this exists
+
+Per `research-schema-spec.md:143`: *"Append-only sections (`log`) are never
+rewritten. All other sections allow field updates but skills must preserve IDs and
+never delete entries — supersede with a status field instead."* Today every one of
+those "all other sections" is written **by hand** across ~8 skills, each ending in
+the re-serialize-and-revalidate loop this tool direction exists to kill:
+
+- **Id allocation by hand** — every section uses a prefix + next-number id
+  (`src_`, `a_`, `pe_`, `q_`, `pl_`, `pli_`, `c_`, `h_`, `t_`, `kh_`); the LLM
+  computes "next available" and can collide or skip.
+- **Supersede-not-delete is prose, not structure** — `person_evidence` revision
+  sets `superseded_by` on the old entry (`research-schema-spec.md:431`); a stray
+  delete breaks the audit trail. Only a tool can make it structural.
+- **Cross-field invariants are prose the LLM must remember** — and the validator
+  already hard-fails on them after the fact: `exhaustive_declaration` requires
+  `log_entry_ids` non-empty and `stop_criteria` non-null when `declared`
+  (`validator.ts:417–424`); a fact conflict needs ≥2 `competing_assertion_ids`,
+  identity ≥1 (`validator.ts:607–611`); a `ruled_out` hypothesis needs
+  `ruled_out_reason` (`validator.ts:637–638`). Enforcing these *before* the write
+  turns "validation failure, fix, re-serialize" into "rejected with a clear error,
+  nothing written."
+- **Multi-entry / multi-file writes re-serialize large JSON** — `record-extraction`
+  writes a source + many assertions and is told to "write first persona, then
+  Edit-append the rest" — the same large-JSON failure mode the log tool removed.
+
+---
+
+## 2. Evidence base (seen directly)
+
+| Fact | Source |
+|------|--------|
+| Section ownership + mutability table ("Mutable; never delete, supersede with status") | `docs/specs/research-schema-spec.md:131–143` |
+| Only `log` is append-only; all other sections allow field updates, preserve ids, never delete | `research-schema-spec.md:134, 143, 291` |
+| `person_evidence` revision sets `superseded_by`, never deletes | `research-schema-spec.md:427, 431` |
+| `plans`: re-plan creates a new plan, old one set `superseded`; search skills update only `items[].status` | `research-schema-spec.md:133, 265` |
+| id prefixes per section | `src/validation/validator.ts` `ID_PREFIXES` (`src_/a_/pe_/q_/pl_/pli_/c_/h_/t_/kh_`) |
+| Coupling invariants already validated post-hoc | `validator.ts:417–424` (exhaustive_declaration), `:607–611` (conflict), `:637–638` (hypothesis) |
+| The shipped append template: id/timestamp assignment, validate-before-persist, atomic write, compact return, camelCase→snake_case | `src/tools/research-log-append.ts`, `research-log-editor-spec.md` |
+| Shared write layer | `src/utils/project-io.ts` (`atomicWriteJson`), `src/validation/validator.ts` (`validateParsed`) |
+
+---
+
+## 3. The tool
+
+```typescript
+research_append({
+  projectPath: string,
+  section:
+    | "sources" | "assertions" | "person_evidence"
+    | "questions" | "plans" | "plan_items"
+    | "conflicts" | "hypotheses" | "known_holdings" | "timelines",
+  op: "append" | "update",
+
+  // op = "append": a new entry WITHOUT its id (the tool assigns the prefix id).
+  entry?: object,
+
+  // op = "update": target an existing entry by id and supply the fields to change.
+  entryId?: string,          // e.g. "c_003" — must match `section`'s prefix
+  fields?: object,           // shallow-merged onto the existing entry; ids immutable
+
+  // plan_items append/update target their parent plan:
+  planId?: string,           // required for section = "plan_items"
+})
+```
+
+camelCase at the boundary; the entry/fields are already the snake_case persisted
+shape (the skill writes simplified project JSON directly). The tool renames any
+camelCase convenience fields the same way `research_log_append` does.
+
+### 3.1 Semantics
+
+- **`append`** — assign the next `<prefix>NNN` id above the section's current max
+  (max + 1, never count + 1), set any tool-owned timestamps (`created`), append to
+  the section array (or, for `plan_items`, to `plans[planId].items`), validate,
+  persist. Returns the assigned id.
+- **`update`** — locate the entry by `entryId`, shallow-merge `fields`, **preserving
+  the id and never removing the entry**. A status transition (e.g. a plan →
+  `superseded`, a question → `resolved`) is an `update`. There is **no delete op** —
+  the supersede-not-delete rule is structural (`research-schema-spec.md:143`).
+
+### 3.2 Return value (compact — never echoes the section)
+
+```typescript
+{
+  ok: true,
+  section: string,
+  op: "append" | "update",
+  entryId: string,                 // assigned (append) or echoed (update)
+  filesWritten: ["research.json"],
+  validation: { valid: true, warnings: string[] },
+}
+// on failure: { ok: false, errors: string[] } — nothing written
+```
+
+---
+
+## 4. Persistence — validate-before-persist, atomic, single-file
+
+Mirrors `research_log_append` minus the sidecar:
+
+1. Read `research.json` (and `tree.gedcomx.json`, for the cross-file checks
+   `validateParsed` runs).
+2. Apply the `append`/`update` in memory — id assignment, field merge, tool-owned
+   timestamps.
+3. **Enforce the section invariants (§5) as preconditions.** A violation returns
+   `{ ok: false, errors }` and writes nothing — the same verdict the validator
+   would give, but *before* the write.
+4. **Validate** with `validateParsed(research, tree, { projectPath })`. If invalid →
+   write nothing.
+5. Commit `research.json` with `atomicWriteJson`.
+
+Only `research.json` is written. No `.bak` (this section, unlike the irreversible
+merges, is append/supersede with full history-in-file — the GPS audit trail is the
+recovery mechanism; consistent with `research_log_append`).
+
+---
+
+## 5. State-coupling invariants enforced as preconditions
+
+These are today prose rules repeated across skills (some 3×) precisely because they
+are easy to violate by hand. As tool preconditions they become structural (the
+audit's recommendation #5):
+
+| Section / op | Invariant (reject if violated) | Source |
+|--------------|-------------------------------|--------|
+| `conflicts` append (fact) | ≥2 `competing_assertion_ids`; identity ≥1 | `validator.ts:607–611` |
+| `conflicts` update → `resolved` | `independence_analysis`, `weighing_analysis`, `resolution_rationale` all set; `preferred_assertion_id` ∈ `competing_assertion_ids` | audit; `validator.ts` NULLABLE set |
+| `hypotheses` update → `ruled_out`/`status: ruled_out` | `ruled_out_reason` non-empty | `validator.ts:637–638` |
+| `questions` update → `exhaustive_declared` | `exhaustive_declaration.declared` true ⇒ `log_entry_ids` non-empty and `stop_criteria` non-null; a re-declare on an already-declared question is a **no-op short-circuit** (don't overwrite a settled GPS Component-1 record) | `validator.ts:417–424` + audit |
+| `plans` append | at most **one active plan per question** — a second `active` plan for the same `question_id` is rejected | audit; `research-schema-spec.md:265` |
+| `person_evidence` revision | revision is an `append` of the new entry **plus** an `update` setting `superseded_by` on the old one; never a field-overwrite-in-place that loses the prior link | `research-schema-spec.md:427–431` |
+| any section | `entry` for `append` must NOT carry an `id`; `update` must NOT change the `id` or the entry's prefix | `research-schema-spec.md:101` |
+
+The LLM still makes every substantive decision and supplies the fields — the tool
+only refuses to persist a structurally incoherent combination.
+
+---
+
+## 6. Decisions recorded
+
+- **One tool with `section` + `op`, not per-section tools.** Same rationale as
+  `tree_edit` and the repo's "generic tools with parameters, not one per endpoint"
+  rule: all sections share the read → apply → enforce → validate → write pipeline;
+  only the id prefix, field shape, and invariant set differ, and those are data
+  (a per-section table), not separate code paths. *Rejected:* `append_assertion`,
+  `append_conflict`, … (10+ near-identical tools).
+- **`append` + `update`, no `delete`.** The schema forbids deletion outside `log`'s
+  append-only model; supersede-via-status is the only "removal." Encoding that as
+  "there is no delete op" makes the rule unbreakable.
+- **Name kept as `research_append`** despite also doing `update`, to match the
+  established reference in the project memory and `research-log-editor-spec.md:268`.
+  The `op` discriminator carries the append-vs-update distinction; rename to
+  `research_write` is a cosmetic option for the implementor.
+- **Field shapes are referenced, not re-specified.** `research-schema-spec.md` §5 is
+  the source of truth for each section's required fields, enums, and id prefix
+  (and `validator.ts` is its executable form). This spec defines the tool's
+  *mechanical contract* and the *invariants*, not a second copy of the field tables —
+  the same "trust the existing source of truth" stance the merge spec takes toward
+  the shipped core.
+
+---
+
+## 7. Scope & phasing
+
+**In scope:** the mutable `research.json` sections listed in §3 (the
+`research-schema-spec.md:131–143` ownership table minus `log`).
+
+**Suggested phase 1** (highest frequency, unblocks the most skill rewrites):
+`sources`, `assertions`, `person_evidence` (the `record-extraction` /
+`assertion-classification` / `person-evidence` write paths — the multi-entry
+re-serialize hazard). **Phase 2:** `questions`, `plans`/`plan_items`, `conflicts`,
+`hypotheses` (the status-transition + invariant sections). **Phase 3 / deferred:**
+`timelines` (its *build* — supersede-filter + chronological sort + gap/impossibility
+analysis — is a richer "timeline-build" operation the audit flagged separately; the
+plain entry write fits here, the computed build may warrant its own tool),
+`proof_summaries`, `evaluations`, and `project`/`researcher_profile` skeleton
+(written once by `init-project`).
+
+**Out of scope:** `log[]` + sidecars (shipped: `research_log_append`);
+`tree.gedcomx.json` (the merge tools + `tree_edit`, `tree-edit-tool-spec.md`).
+
+---
+
+## 8. Errors / edge cases
+
+| Condition | Behavior |
+|-----------|----------|
+| `projectPath` missing/invalid `research.json` or `tree.gedcomx.json` | input error; write nothing |
+| `op: append` with an `entry` that carries an `id` | input error (the tool assigns ids) |
+| `op: update` with an `entryId` not found in `section` (or wrong prefix) | staleness error; write nothing |
+| `op: update` `fields` attempting to change `id` | input error |
+| `section: plan_items` without a resolvable `planId` | input error |
+| A §5 invariant violated | input error with the specific rule; write nothing |
+| Resulting `research.json` fails `validateParsed` | write nothing; `{ ok: false, errors }` |
+
+---
+
+## 9. Test plan (vitest)
+
+- **append assigns max + 1 id** per section prefix; gap-tolerant (`a_001..a_003, a_009 → a_010`).
+- **append validates** — a malformed assertion is rejected, nothing written.
+- **update preserves id + supersede** — setting `superseded_by` on the old
+  `person_evidence` entry while appending the new one; old entry never removed.
+- **status transition** — question → `exhaustive_declared` rejected when
+  `log_entry_ids` empty; accepted when satisfied; re-declare is a no-op.
+- **conflict invariants** — fact conflict with <2 competing rejected; resolve
+  without `weighing_analysis` rejected.
+- **hypothesis** — `ruled_out` without reason rejected.
+- **one-active-plan** — a second active plan for a question rejected.
+- **plan_items** — appended into the right parent plan's `items`.
+- **append-only enforced** — there is no delete op; an update never shrinks an array.
+- **camelCase→snake_case** — persisted entry uses snake_case keys.
+- **atomicity** — a validation failure leaves `research.json` byte-unchanged.
+
+---
+
+## 10. Consumers / wiring
+
+Standard MCP tool: `src/tools/research-append.ts`, schema in `allToolSchemas`,
+dispatch in `src/index.ts`, name in `manifest.json` (packaging drift test enforces
+parity). Reuses `atomicWriteJson` + `validateParsed`; share the per-prefix max-id
+helper with `tree_edit`/the merge core (lift `maxIdNum` to a shared util).
+
+Consumers — the skills whose hand-written section writes it replaces:
+`record-extraction` (sources + assertions), `assertion-classification` (classification
+field updates), `person-evidence` (`pe_` links + supersede), `conflict-resolution`
+(conflict append + resolve), `hypothesis-tracking`, `research-exhaustiveness`
+(exhaustive_declaration), `question-selection`/`research-plan` (questions, plans,
+plan-items), `proof-conclusion` (question resolution). Their SKILL.md rewrites are a
+follow-up (companion to `skill-rewrites-for-persistence-tools-spec.md`), not part of
+this tool's landing.

--- a/docs/specs/skill-rewrites-for-persistence-tools-spec.md
+++ b/docs/specs/skill-rewrites-for-persistence-tools-spec.md
@@ -1,173 +1,230 @@
-# Skill rewrites for the structured-persistence tools — Spec
+# Skill rewrites for the structured-persistence + deterministic tools — Spec
 
-> **Status:** New (2026-06-19). Companion to the four structured-persistence
-> tool work items (`validate-project-refactor-spec.md`, `merge-gedcomx-spec.md`
-> §5b, `research-log-editor-spec.md`, `search-result-staging-spec.md`). Those
-> shipped the **tools**; this spec covers the **skill rewrites** that switch the
-> consuming skills from hand-done persistence to those tool calls. Deliberately
-> split out so the tools could land and be unit-tested in isolation first.
+> **Status:** Consolidated (2026-06-19). Supersedes the wave-1-only draft of this
+> file. Now covers **both** migration waves, organized **by skill** so every
+> `SKILL.md` is rewritten **once** even when both waves touch it. (Filename is
+> historical — the scope is all the migration tools, not just persistence.)
+>
+> **Do this after the tools land**, not before — a rewrite is only as stable as
+> the tool contract it targets, and the contracts are now shipped:
+> - **Wave 1** (on `main`, #397): `merge_record_into_tree`, `merge_tree_persons`,
+>   `research_log_append`, and the `record_search`/`fulltext_search` `projectPath`
+>   staging + shared write layer.
+> - **Wave 2** (branch `deterministic-skill-tools`, PR #400): `convert_calendar`,
+>   `tree_edit`, `research_append`.
 
-The MCP tools now exist and are unit-tested:
-
-| Tool | Replaces hand-work in |
-|------|------------------------|
-| `merge_record_into_tree`, `merge_tree_persons` | `tree-edit` "Person merging" |
-| `research_log_append` | the log + sidecar write in `search-records`, `search-full-text`, `search-external-sites`, `record-extraction` |
-| `record_search` / `fulltext_search` new optional `projectPath` (returns a `staged` handle) | the sidecar-payload write in `search-records`, `search-full-text` |
-
-This spec is the contract for editing the **`SKILL.md` files and their
-`references/`** to call those tools. No MCP-server code changes here.
+This is the contract for editing the **`SKILL.md` files and their `references/`**
+to call those tools instead of hand-editing JSON / doing arithmetic by hand. No
+MCP-server code changes here.
 
 ---
 
 ## 1. Why this exists
 
-The hand-done versions are the error-prone clerical work the tools were built to
-remove: a hand-merge that can miss a reference or collide ids, and a hand-written
-log + sidecar whose `returned_count` integrity and `results_ref`↔`log_id`↔filename
-wiring the LLM has to get right, with a documented large-payload failure mode
-("write in ~40-result chunks"). Each rewrite deletes that mechanical guidance and
-replaces it with one tool call; the skill keeps only the **analytical** decisions
-(who merges, was the outcome negative, what to put in `query`/`notes`).
-
-A latent correctness win comes for free: the current `tree-edit` merge protocol
-(SKILL.md "Step 3") repoints only `subject_person_ids`, `person_evidence`, and
-`timelines` — it **omits `known_holdings.relates_to_person_ids`**.
-`merge_tree_persons` repoints all four (driven by the shared `PERSON_ID_REF_FIELDS`
-walker), so the rewrite closes that gap.
+Every consuming skill ends its write path with the same anti-pattern: *hand-assemble
+JSON (or compute arithmetic) → call `validate_research_schema` → fix errors →
+re-serialize the whole file*. The tools replace that clerical seam with one call
+that takes the judgment as input and does the mechanical work (id assignment,
+validation-before-persist, atomic write, supersede-not-delete, calendar
+arithmetic). The skill keeps every analytical decision. A determinism audit of all
+26 skills found the hand-work concentrated in exactly the skills below;
+`check-warnings` is already migrated (it calls `person_warnings`).
 
 ---
 
-## 2. Scope
+## 2. The tools each rewrite targets
 
-In scope: editing these skill folders under `packages/engine/plugin/skills/`:
-
-- `tree-edit/SKILL.md`
-- `search-records/SKILL.md` + `search-records/references/research-log-protocol.md`
-- `search-full-text/SKILL.md` + its `research-log-protocol.md`
-- `search-external-sites/SKILL.md` + its `research-log-protocol.md`
-- `record-extraction/SKILL.md` + its `research-log-protocol.md`
-
-Out of scope: the MCP tools themselves (shipped), and any skill that only *reads*
-the log/tree. The four `research-log-protocol.md` copies are duplicated per the
-repo's "no shared SKILL.md reference loading" rule (CLAUDE.md) — each must be
-edited; they are not symlinked.
+| Tool | Wave | Replaces (hand-work) |
+|------|------|----------------------|
+| `merge_tree_persons` / `merge_record_into_tree` | 1 | hand person-merge / folding a record into the tree |
+| `research_log_append` (+ `record_search`/`fulltext_search` `projectPath` staging) | 1 | hand log entry + `results/` sidecar + chunking |
+| `convert_calendar` | 2 | in-context calendar arithmetic |
+| `tree_edit` | 2 | ad-hoc single-entity `tree.gedcomx.json` edits |
+| `research_append` | 2 | hand-written `research.json` section entries/updates |
 
 ---
 
-## 3. `tree-edit` — rewrite "Person merging"
+## 3. The rewrite pattern (apply to every skill)
 
-Replace the hand protocol (current SKILL.md Steps 1–5, names/facts/relationships
-dedup + research-ref edit + delete + log) with a **tool selection** step:
-
-- **Folding a candidate record just read with `record_read` into the tree** →
-  call **`merge_record_into_tree`** with `{ projectPath, candidateGedcomx, merges }`,
-  where `merges` is `[treeId, candidateId]` pairs the skill chose (via `same_person`
-  / proof-conclusion). It writes only `tree.gedcomx.json`.
-- **Collapsing two persons already in the tree** (e.g. two father records that
-  turn out to be the same) → call **`merge_tree_persons`** with
-  `{ projectPath, merges }` (`[survivorId, collapsedId]` pairs). It rewrites
-  `tree.gedcomx.json` and repoints every `research.json` person-id reference.
-
-The skill **no longer**: dedups names/facts by hand, repoints relationships,
-hand-edits `research.json` refs, deletes the deprecated person, or calls
-`validate_research_schema` (the tool validates structurally before persisting and
-writes nothing on failure). The skill **still**:
-
-- makes the analytical merge decision (which ids pair) — the tool never decides who
-  is the same person;
-- narrates from the tool's compact summary (per-pair name/fact counts, new-relative
-  ids, `researchRefsUpdated`) without ever holding the merged tree;
-- runs **`check-warnings`** after the merge (genealogical-plausibility checks —
-  e.g. parent younger than child — are not structural and remain a skill step);
-- handles `{ ok: false, errors }` by surfacing the error (e.g. a stale `merges` id
-  that no longer exists on disk) rather than retrying blindly.
-
-Note the **recovery** caveat from `merge-gedcomx-spec.md` §5b.2: a merge is
-irreversible. The tools write a one-deep `.bak`, but the skill should still confirm
-the merge pairs with the user when the identity decision is anything short of
-certain.
+1. **Replace the hand-JSON / arithmetic step with the tool call** (the per-skill
+   recipes in §4 name the exact call).
+2. **Trim the now-obsolete mechanical guidance** from `references/` — sidecar
+   mechanics, chunking, id-allocation, the "Update ALL references" cleanups, the
+   regime/offset tables (kept only as identification reference).
+3. **Drop the post-write `validate_research_schema` call.** Every tool
+   validates-before-persist and writes nothing on `{ ok: false, errors }`. Soften
+   `references/validation-protocol.md` step 1 accordingly; **keep step 2
+   (`check-warnings`)** — genealogical plausibility is not structural.
+4. **Keep the judgment** — the analytical decisions the tool takes as input.
+5. **Add the recovery fallback** where relevant (e.g. a TTL-expired
+   `staged.resultsRef` → re-run the search; surface `{ ok: false }` rather than
+   retrying blindly).
+6. **Update frontmatter `allowed-tools`** — add the new tool(s); `validate_research_schema`
+   may be dropped where it was only the post-write backstop.
+7. **Verify** per the layered testing guides (Inspector → Claude Code → Cowork).
 
 ---
 
-## 4. `search-records` / `search-full-text` — stage + append
+## 4. Per-skill rewrites
 
-Two changes:
+### 4.1 `tree-edit` — BOTH waves (rewrite once)
+- **Wave 1 — "Person merging" (Steps 1–5 + the worked example):** replace the
+  whole hand protocol with `merge_tree_persons({ projectPath, merges })`
+  (`[survivorId, collapsedId]` pairs) — or `merge_record_into_tree({ projectPath,
+  candidateGedcomx, merges })` when folding a `record_read` candidate. Narrate from
+  the tool's compact summary; the tool repoints all four `research.json` person-id
+  refs (closing the hand protocol's `known_holdings` gap).
+- **Wave 2 — "Ad-hoc edits":** each subsection → a `tree_edit` operation —
+  `add_fact` / `update_fact` / `add_name` / `update_name` / `update_person` /
+  `add_person` / `add_relationship` / `remove` (facts/relationships only). The tool
+  assigns ids, swaps primary/preferred, and auto-resolves `standard_place`.
+- **Trim:** the merge worked-example; `relationship-accuracy.md` post-merge cleanup
+  list; "Update ALL references" and "edits in place by id" from Important rules /
+  Re-invocation. **Keep:** survivor-selection convention, "merges are irreversible /
+  confirm pairs when identity is uncertain," "ad-hoc edits should be rare," and
+  **running `check-warnings` after every edit/merge.**
 
-1. **Pass `projectPath`** on the `record_search` / `fulltext_search` call. The
-   response gains a `staged` handle (`{ resultsRef, returnedCount }` on a hit,
-   `null` on a nil search). The model-facing `results[]` are unchanged — staging
-   only affects *persistence*, not *triage*.
-2. **Replace the hand-written log entry + sidecar** with a single
-   **`research_log_append`** call, passing `staged.resultsRef` as `stagedResultsRef`.
-   The tool assigns the `log_` id, `performed` timestamp, `results_ref`, and the
-   whole sidecar envelope (including a recomputed `returned_count`).
+### 4.2 `search-records`, `search-full-text`, `search-external-sites` — Wave 1 (+ a wave-2 touch)
+- **The search call:** add `projectPath` to `record_search` / `fulltext_search`;
+  the response gains a `staged` handle.
+- **Retain + log:** delete the hand sidecar-write and the verify-count step; call
+  `research_log_append({ projectPath, planItemId, tool, query, outcome,
+  resultsExamined, resultsAvailable, notes, stagedResultsRef: staged.resultsRef })`.
+  `search-external-sites` passes `tool: "external_site"` + `externalSite` and **no**
+  `stagedResultsRef` (no sidecar ever; it appends twice per loop — URL-generated then
+  capture-received).
+- **Wave-2 touch — plan-item status (Step 6/7/9):** route the `plans[].items[].status`
+  mutation through `research_append({ section: "plan_items", op: "update", planId,
+  entryId, fields: { status } })`.
+- **Trim:** the four `references/research-log-protocol.md` sidecar/chunking copies and
+  the post-write validate guidance. **Recovery:** a TTL-expired `staged.resultsRef`
+  → re-run the search (cheap, re-stages).
 
-For a **nil search**, omit `stagedResultsRef` (or pass null) — no sidecar is
-written, `results_ref` is null.
+### 4.3 `record-extraction` — BOTH waves (rewrite once)
+- **Wave 1 — Step 4:** route the `user_provided` log entry through
+  `research_log_append` (nil sidecar), and when the source came from a staged
+  `record_search`, pass `staged.resultsRef`.
+- **Wave 2 — Steps 1/3/5a:** `research_append({ section: "sources", op: "append" })`
+  for the `src_` entry, then one `research_append({ section: "assertions", op:
+  "append" })` per assertion (including negative assertions) — the tool assigns each
+  id and validates each, removing the "write first persona, then Edit-append the
+  rest" chunking dance.
+- **Trim:** the sidecar/log-protocol references; the by-hand "next available id"
+  guidance; the post-write validate step. **Keep:** all extraction judgment (BCG
+  objectivity, one-fact-per-assertion, classification values, source-reuse decision).
 
-**Recovery:** if `research_log_append` rejects a `stagedResultsRef` (e.g. the staged
-file aged out past its 24h TTL in a long multi-turn session, or the turn died), the
-skill re-runs the search — re-staging is cheap. Document this one-line fallback.
+### 4.4 `convert-dates` — Wave 2 (the cleanest consumer)
+- Replace the "deterministic arithmetic you perform in context" paragraph and the
+  Step-3 hand-arithmetic bullets with one `convert_calendar({ date, corrections })`
+  call, requesting **only** the corrections the user asked for (the "answer only the
+  question asked" rule is now structural). Narrate from `applied[].rule` / `notes[]`
+  / `converted`.
+- **Trim:** none of the regime tables — **keep** them and `references/calendar-conflicts.md`
+  as the identification reference (deciding *which* corrections apply stays the LLM's
+  judgment). Output-only behavior unchanged (the tool writes nothing).
+
+### 4.5 `conflict-resolution` — Wave 2
+- **Create (Step 2):** `research_append({ section: "conflicts", op: "append" })`.
+  **Resolve (Steps 3–5):** `research_append({ section: "conflicts", op: "update",
+  entryId, fields: { independence_analysis, weighing_analysis, resolution_rationale,
+  preferred_assertion_id, status: "resolved" } })` — the tool enforces the
+  resolved-completeness + `preferred ∈ competing` invariants.
+- **Calendar artifact check (Step 4):** call `convert_calendar` (read
+  `applied[].offsetDays`) for the expected offset instead of computing 10/11/12/13 by
+  hand. **Keep** `references/historical-contradictions.md` and the weighing judgment.
+
+### 4.6 `assertion-classification` — Wave 2
+- **Step 6:** `research_append({ section: "assertions", op: "update", entryId,
+  fields: { information_quality, informant, informant_proximity, evidence_type, … } })`
+  — never `append` (this skill only refines). The immutable-field list becomes
+  structural (you only pass classification fields). **Keep** `references/three-layer-model.md`
+  in full (pure classification judgment).
+
+### 4.7 `person-evidence` — Wave 2 (two tools)
+- **Step 4 link:** `research_append({ section: "person_evidence", op: "append" })`.
+- **Step 5 stub person:** `tree_edit({ operation: "add_person" })` (tool allocates
+  the synthetic `I`/`N` ids).
+- **Step 6 revision:** two calls — `append` the corrected `pe_` link, then `update`
+  the old entry's `superseded_by` (never delete).
+
+### 4.8 `hypothesis-tracking` — Wave 2
+- **Create:** `research_append({ section: "hypotheses", op: "append" })`. **Update /
+  status transitions (active → supported / ruled_out):** `op: "update"` with the
+  status + (for ruled_out) `ruled_out: true, ruled_out_reason` (validator enforces
+  the reason). The Step-3 age arithmetic stays plain LLM reasoning.
+
+### 4.9 `research-exhaustiveness` — Wave 2
+- **Steps 4/5:** `research_append({ section: "questions", op: "update", entryId,
+  fields: { status: "exhaustive_declared", exhaustive_declaration: { declared,
+  log_entry_ids, stop_criteria } } })`. Early termination → `declared: false` form.
+  Re-declaring an already-declared question is a structural no-op. **Keep**
+  `references/research-exhaustiveness.md` in full.
+
+### 4.10 `question-selection` — Wave 2
+- **Step 4:** `research_append({ section: "questions", op: "append" })`. **Supersede:**
+  `op: "update"` setting `status: "superseded"` (preserves the id; never delete).
+
+### 4.11 `research-plan` — Wave 2
+- **Step 5:** `research_append({ section: "plans", op: "append" })` for the plan
+  shell, then `research_append({ section: "plan_items", op: "append", planId })` per
+  item. **Re-plan (Step 6):** `op: "update"` on the old plan → `status: "superseded"`
+  (at most one active plan per question — the tool enforces it).
+
+### 4.12 `proof-conclusion` — BOTH waves (rewrite once)
+- **Wave 2 — Step 5:** `research_append({ section: "proof_summaries", op: "append" })`.
+- **Wave 2 — Step 6 tree updates (tier ≥ probable):** route each through `tree_edit`
+  (add source / `add_fact` / `update_fact`); a tier-downgrade removal →
+  `tree_edit({ operation: "remove", factId | relationshipId })`.
+- **Wave 1 — Step 6 person merging:** `merge_tree_persons` (or `merge_record_into_tree`).
+- **Wave 2 — Step 7 resolve question:** `research_append({ section: "questions",
+  op: "update", fields: { status: "resolved", resolved, resolution_assertion_ids } })`.
+- **Trim:** Step 6's hand S-entry field table and the manual primary swap; the
+  post-write validate step.
 
 ---
 
-## 5. `search-external-sites` — append only
+## 5. Cross-cutting
 
-External-site searches write **no sidecar**. Replace the hand-written log entry
-with `research_log_append` passing `externalSite: { site, urlGenerated,
-captureReceived, captureFilename? }` and `tool: "external_site"`; do **not** pass
-`stagedResultsRef`. The tool renames to the snake_case `external_site` shape on
-persist.
-
----
-
-## 6. `record-extraction` — append the `user_provided` entry via the tool
-
-`record-extraction` writes a `user_provided` log entry when no search skill logged
-the record (`research-log-protocol.md` §"When record-extraction writes log
-entries"). Route that write through `research_log_append` as well — typically a nil
-sidecar (the record came from the user, not a search), so no `stagedResultsRef`.
-
----
-
-## 7. Trim the four `research-log-protocol.md` copies
-
-Delete the now-obsolete mechanical guidance from each copy:
-
-- the **"Result sidecar files"** sidecar-writing mechanics, the **"≤40 results /
-  ~40-result chunks"** chunking rule, and the **"If retention fails"** fallback —
-  the tool counts and writes deterministically or fails the whole append atomically;
-- the hand-maintained `returned_count` and the three-way `results_ref`/`log_id`/
-  filename wiring — the tool wires all three by construction.
-
-**Keep** the analytical rules: log every search (including nil), what belongs in
-`query` / `notes`, when a negative outcome is meaningful, and the append-only
-intent (now structurally enforced by the tool). Reframe the section as "call
-`research_log_append` with these fields" + the judgment rules.
+- **Rewrite both-waves skills once.** `tree-edit`, `record-extraction`, and
+  `proof-conclusion` are each touched by both waves — do a single pass per file so
+  the `SKILL.md` is edited once (the whole reason this spec is consolidated).
+- **Supersede-not-delete coordination.** `question-selection` / `research-plan` /
+  `research-exhaustiveness` / `proof-conclusion` all transition `questions` /
+  `plans` status via `research_append` `op: "update"`; keep their supersede rules
+  aligned (the tool makes deletion structurally impossible).
+- **Known gap — `project.status`.** `proof-conclusion` Step 8 sets
+  `project.status: "completed"`, but `research_append` has no `project` section yet
+  (deferred). Until it does, that one update stays hand-done (or extend
+  `research_append` with a `project` single-object section — small follow-up).
+- **`allowed-tools` frontmatter** updated per skill; `validate_research_schema`
+  dropped where it was only the post-write backstop (it remains a user-invokable
+  audit tool).
 
 ---
 
-## 8. Verification (manual, layered per `docs/*-testing-guide.md`)
+## 6. Suggested ordering
 
-- **tree-edit:** in a scratch project, fold a `record_read` candidate into a focus
-  person (`merge_record_into_tree`) and collapse two existing tree persons
-  (`merge_tree_persons`); confirm `tree.gedcomx.json` updates, `research.json` refs
-  repoint (Mode 2), a `.bak` is written, and the project still validates.
-- **search-records / search-full-text:** run a real search with `projectPath`,
-  then `research_log_append` with the returned `staged.resultsRef`; confirm the
-  `results/<log_id>.json` sidecar appears, `returned_count` matches, the
-  `.staging/` file is gone, and `validate_research_schema` is clean.
-- **search-external-sites / record-extraction:** confirm the log entry persists in
-  snake_case with `results_ref: null` and no sidecar.
+Wave-2-only, single-tool skills first (lowest risk): `convert-dates`,
+`assertion-classification`, `hypothesis-tracking`, `research-exhaustiveness`,
+`question-selection`, `research-plan`, `conflict-resolution`. Then the
+`research_append`+`tree_edit` skill `person-evidence`. Then the both-waves skills
+(`tree-edit`, `record-extraction`, `proof-conclusion`). The three search skills can
+go any time (wave-1 dominant). Each skill is an independent, verifiable PR.
 
 ---
 
-## 9. Non-goals
+## 7. Verification (per `docs/*-testing-guide.md`)
 
-- No MCP-server code changes (the tools are shipped and unit-tested).
-- No change to the reverse-lookup provenance model — downstream skills still link
-  to a log entry via `log_entry_id` on sources/assertions.
-- Not a new shared-reference mechanism for the four protocol copies (the per-skill
-  duplication stands, per CLAUDE.md).
-- No `research_append` for the other `research.json` sections (separate effort).
+For each rewritten skill, in a scratch project: drive the skill, confirm the tool
+call replaces the hand-write, the persisted JSON is correct, `validate_research_schema`
+is clean, and (for tree/merge skills) `check-warnings` still runs. Confirm the
+recovery fallbacks (stale `stagedResultsRef`; `{ ok: false }` errors surfaced).
+
+---
+
+## 8. Non-goals
+
+- No MCP-server code changes (all tools shipped).
+- No change to the reverse-lookup provenance model (`log_entry_id` on sources/assertions).
+- No new shared-reference mechanism for the duplicated `references/` copies (per CLAUDE.md, they stay duplicated and are each trimmed).
+- The `project`-section `research_append` extension (§5 gap) is a separate follow-up.

--- a/docs/specs/tree-edit-tool-spec.md
+++ b/docs/specs/tree-edit-tool-spec.md
@@ -1,0 +1,279 @@
+# `tree_edit` — single-edit tree mutation tool — Spec
+
+> **Status:** New (2026-06-19). The sibling of the merge tools
+> (`merge-gedcomx-spec.md` §5b): where those collapse persons, this one does the
+> **ad-hoc single-entity edits** the `tree-edit` skill performs today by hand —
+> add/correct a fact or name, add a person or relationship, and the one permitted
+> deletion (tier downgrade). It reuses the exact write layer shipped with the
+> merge tools (`validate-project-refactor-spec.md` §10) so the last hand-edited-
+> JSON path in `tree-edit` becomes a validated, atomic, id-assigning tool call.
+
+```
+tree_edit({ projectPath, operation, ...operationFields }) -> compact summary
+```
+
+A single tool with an `operation` discriminator. The LLM supplies the **content
+judgment** (which fact, what value, which relationship); the tool does the
+error-prone clerical work — id allocation, the primary/preferred flag swaps,
+`standard_place` resolution, array mutation, validate-before-persist, and the
+atomic write.
+
+---
+
+## 1. Why this exists
+
+`tree-edit/SKILL.md` §"Ad-hoc edits" (lines 52–124) is hand-done JSON surgery on
+`tree.gedcomx.json`, and the skill itself warns the cost of getting it wrong:
+*"Get this right on the first write — validation failures cost turns"* and *"Ad-hoc
+edits should be rare."* The mechanical hazards are exactly the ones the merge tools
+already removed for the collapse case:
+
+- **Id allocation by hand** — "Generate the next available `F` prefix ID"
+  (`SKILL.md:67`), "Use synthetic IDs (`I` prefix + next number)" (`SKILL.md:85`).
+  A reused or skipped id corrupts the tree.
+- **The primary-flag swap** — "add `primary: true` (and remove `primary` from any
+  existing fact of the same type)" (`SKILL.md:70–72`). Forgetting the second half
+  leaves two primaries of one type.
+- **`standard_place` re-resolution** — "Whenever you set a fact's `place`, also set
+  `standard_place`: call `place_search` … use the first result's `standardPlace`"
+  (`SKILL.md:68–70`), repeated for corrections (`SKILL.md:79–81`). Easy to forget on
+  a place edit, leaving a stale standardized place.
+- **Re-serialize-and-revalidate** — every edit ends at "call
+  `validate_research_schema` … fix errors" (`SKILL.md:243–248`), the whole-file
+  rewrite loop this whole tool direction exists to kill.
+
+The merge work already built the machinery (atomic write, `validateParsed`,
+`.bak`); a single-entity edit is a strict subset of it.
+
+---
+
+## 2. Scope
+
+In scope — the `tree-edit` ad-hoc operations (`SKILL.md:52–124`):
+
+| Operation | Replaces (SKILL.md) |
+|-----------|---------------------|
+| `add_fact` | "Adding a fact to a person" |
+| `update_fact` | "Correcting a value" (fact date/place/value) |
+| `add_name` / `update_name` | "Correcting a value" (name given/surname) |
+| `update_person` | gender/ark correction |
+| `add_person` | "Adding a person" |
+| `add_relationship` | "Adding a relationship" |
+| `remove` | "Removing concluded data (tier downgrade)" — facts/relationships only |
+
+Out of scope: **person merging / person removal** — that is the merge tools'
+job (`merge_tree_persons` removes a collapsed person and remaps `research.json`);
+`tree_edit` never deletes a person. Also out of scope: `research.json` edits
+(those are the future `research_append`), and `check-warnings` (a separate skill
+step, run after — see §8).
+
+---
+
+## 3. Evidence base (seen directly)
+
+| Fact | Source |
+|------|--------|
+| Ad-hoc fact/name/person/relationship payload shapes + id rules + primary swap + standard_place resolution | `packages/engine/plugin/skills/tree-edit/SKILL.md:52–124` |
+| Deletion is permitted ONLY for facts/relationships on a tier downgrade | `tree-edit/SKILL.md:118–124` |
+| Simplified ids are `I/N/F/R/S`, "unique within their array, immutable once created" | `docs/specs/simplified-gedcomx-spec.md:61–69` |
+| `SimplifiedFact.primary?`, `SimplifiedName.preferred?`, relationship `parent/child` vs `person1/person2` | `src/types/gedcomx.ts:104–151` |
+| Shared write layer: `atomicWriteJson`, `assertInsideProject`, `validateParsed`, exported `validateGedcomx` | `src/utils/project-io.ts`, `src/validation/validator.ts` (shipped) |
+| `.bak`-before-overwrite + compact-return + validate-before-persist pattern | `src/tools/merge-record-into-tree.ts` (Mode 1 writes only the tree) |
+| Per-prefix max-id logic already exists (private) | `src/utils/merge-gedcomx.ts` `maxIdNum` |
+| Name→standard place resolver | `src/utils/place-resolver.ts` `resolveStandardPlace` (`place_search` returns `standardPlace`) |
+
+---
+
+## 4. The tool
+
+```typescript
+tree_edit({
+  projectPath: string,
+  operation:
+    | "add_fact" | "update_fact"
+    | "add_name" | "update_name" | "update_person"
+    | "add_person" | "add_relationship" | "remove",
+
+  // ── targeting (per operation) ──
+  personId?: string,          // add_fact, add_name, update_fact, update_name, update_person
+  factId?: string,            // update_fact, remove
+  nameId?: string,            // update_name
+  relationshipId?: string,    // remove
+
+  // ── payloads (snake_case, NO id — the tool assigns) ──
+  fact?: SimplifiedFact,            // add_fact (full) / update_fact (fields to set)
+  name?: SimplifiedName,            // add_name (full) / update_name (fields to set)
+  person?: SimplifiedPerson,        // add_person (full; nested names get N ids too)
+  relationship?: SimplifiedRelationship, // add_relationship (full)
+  gender?: string, ark?: string,    // update_person
+
+  resolveStandardPlace?: boolean,   // default true: auto-resolve standard_place when place is set
+})
+```
+
+### 4.1 Per-operation contract
+
+- **`add_fact`** `{ personId, fact }` — append `fact` to the person's `facts`,
+  assigning the next `F` id above the tree max. If `fact.primary === true`, clear
+  `primary` on every other fact of the **same `type`** on that person. If
+  `fact.place` is set and `resolveStandardPlace !== false` and no
+  `fact.standard_place` was supplied, resolve it via `resolveStandardPlace` (null
+  when nothing resolves).
+- **`update_fact`** `{ personId, factId, fact }` — shallow-merge the provided
+  `fact` fields onto the existing fact (id immutable). If `place` changed (and not
+  explicitly accompanied by `standard_place`), re-resolve `standard_place`. If
+  `primary: true` set, run the same-type swap.
+- **`add_name`** `{ personId, name }` — append, assign next `N`. If
+  `name.preferred === true`, clear `preferred` on the person's other names.
+- **`update_name`** `{ personId, nameId, name }` — shallow-merge fields; preferred
+  swap if set true.
+- **`update_person`** `{ personId, gender?, ark? }` — set scalar person fields.
+- **`add_person`** `{ person }` — append a new person, assigning the next `I` id
+  and an `N` id for each nested name (exactly-one `preferred`). Synthesized stubs
+  omit `ark` (`simplified-gedcomx-spec.md` §4.6).
+- **`add_relationship`** `{ relationship }` — append, assign next `R`. Validate the
+  endpoints (`parent`/`child` for `ParentChild`, `person1`/`person2` for `Couple`)
+  reference existing persons (tree persons or FS ids already present); reject a
+  shape mismatch (e.g. `person1` on a `ParentChild`).
+- **`remove`** `{ factId }` **or** `{ relationshipId }` — delete that entry. **Only
+  facts and relationships** — a `personId` here is an error (person removal is
+  `merge_tree_persons`).
+
+### 4.2 Return value (compact — never the tree)
+
+```typescript
+{
+  ok: true,
+  operation: string,
+  assignedIds?: {                 // ids the tool allocated, for narration
+    person?: string, fact?: string, name?: string,
+    relationship?: string, names?: string[],
+  },
+  filesWritten: ["tree.gedcomx.json"],
+  validation: { valid: true, warnings: string[] },
+}
+// on failure: { ok: false, errors: string[] } — nothing written
+```
+
+---
+
+## 5. Persistence — validate-before-persist, atomic, tree-only
+
+Sequence (mirrors `merge_record_into_tree`):
+
+1. Read `tree.gedcomx.json` fresh from disk (ids checked against current state;
+   a stale `factId`/`personId`/`relationshipId` is a clear error, not a silent
+   no-op). Read `research.json` too — needed for the cross-file validation pass.
+2. Apply the operation **in memory**: allocate ids, run the primary/preferred
+   swaps, resolve `standard_place`.
+3. **Validate** the would-be tree with `validateParsed(research, tree, { projectPath })`
+   before any write. If invalid → write nothing, return `{ ok: false, errors }`.
+4. Persist: back up `tree.gedcomx.json` → `tree.gedcomx.json.bak`, then
+   `atomicWriteJson` the new tree. **Only `tree.gedcomx.json` is written** —
+   `research.json` is untouched (ad-hoc adds create ids nothing references yet;
+   corrections change values, not ids; `remove` deletes facts/relationships, not
+   persons — so no person-id reference can dangle). This is the Mode-1 write shape.
+
+> **Reuse, don't reinvent.** Id allocation needs the per-prefix max that
+> `merge-gedcomx.ts` already computes privately as `maxIdNum`; with a second
+> consumer now, lift it to a shared `src/utils/gedcomx-ids.ts` (the repo's
+> "second concrete need → factor it out" rule) and have both call it. The persist
+> half is `atomicWriteJson` + `backupIfExists` + `validateParsed`, all shipped.
+
+> **Recovery, not undo** (same caveat as the merge tools): validate-before-persist
+> guarantees schema-valid, not *correct*. The `.bak` is the one-deep safety net for
+> a wrong-but-valid edit; there is no undo.
+
+---
+
+## 6. Decisions recorded
+
+- **One tool with an `operation` discriminator, not one tool per edit.** Follows
+  this repo's "don't create one MCP tool per endpoint — use generic tools with
+  parameters" rule (CLAUDE.md) and keeps Claude's tool list lean. The eight
+  operations share the entire read → apply → validate → backup → write pipeline;
+  only the in-memory mutation differs. *Rejected:* `tree_add_fact`,
+  `tree_add_person`, … (eight near-identical tools, eight schema entries, more
+  context for no behavioral gain). The merge tools are two tools only because they
+  have **different side effects** (one writes one file, the other two + a remap);
+  every `tree_edit` operation has the *same* side effect (write the tree), so the
+  split that justified two merge tools does not apply here.
+- **`standard_place` resolution is internal and on by default.** Removes the
+  "call `place_search`, copy the first result's `standardPlace`" hand-step
+  (`SKILL.md:68–70`) and makes `place`/`standard_place` atomic. Overridable:
+  pass `standard_place` explicitly, or `resolveStandardPlace: false`, to skip the
+  network call.
+- **`remove` is fact/relationship-only.** The skill permits deletion only on a
+  tier downgrade (`SKILL.md:118–124`); person removal is structurally reserved to
+  the merge tools, so `tree_edit` cannot delete a person.
+
+---
+
+## 7. Errors / edge cases
+
+| Condition | Behavior |
+|-----------|----------|
+| `projectPath` missing `tree.gedcomx.json` / invalid JSON | input error; write nothing |
+| `personId` / `factId` / `nameId` / `relationshipId` not found in the on-disk tree | staleness error; write nothing |
+| `operation` requires a payload that is absent (e.g. `add_fact` with no `fact`) | input error |
+| `add_relationship` endpoint references a non-existent person, or field shape mismatches the `type` | input error (also caught by validation) |
+| `remove` with a `personId` (attempt to delete a person) | input error — use `merge_tree_persons` |
+| `resolveStandardPlace` network call fails | best-effort: set `standard_place: null`, add a warning; never fail the edit on a place-resolution miss |
+| Resulting tree fails project validation | write nothing; return `{ ok: false, errors }` |
+
+---
+
+## 8. Boundary — tool vs. caller
+
+The tool does the **structural** edit (id assignment, swaps, schema validation).
+The caller (`tree-edit` skill) still:
+
+- decides the content (which fact/value/relationship, justified by a source);
+- runs **`check-warnings`** after the edit to catch genealogical impossibilities
+  the structural pass does not (parent younger than child, etc.) — the same
+  division of labor the merge spec sets (`merge-gedcomx-spec.md` §10);
+- no longer hand-edits JSON, hand-allocates ids, or calls
+  `validate_research_schema` itself — the tool does the structural validate.
+
+---
+
+## 9. Test plan (vitest, mirroring the merge tool tests)
+
+- **add_fact** — appends with the next `F` id; `primary: true` clears the prior
+  same-type primary; `place` set → `standard_place` resolved (mock the resolver);
+  only `tree.gedcomx.json` written; `.bak` created; project validates.
+- **update_fact** — field merge by `factId`; a place change re-resolves
+  `standard_place`; id unchanged.
+- **add_name / update_name** — `N` id assigned; `preferred: true` clears other
+  preferred; exactly one preferred remains.
+- **update_person** — gender/ark set; nothing else changed.
+- **add_person** — `I` id + `N` ids assigned; stub omits `ark`.
+- **add_relationship** — `R` id assigned; endpoints validated; `ParentChild` with
+  `person1` rejected.
+- **remove** — fact/relationship deleted by id; `remove` with `personId` rejected.
+- **id allocation** — adding to a tree with `F1..F9` yields `F10` (max + 1).
+- **staleness** — an unknown `factId` returns an error, writes nothing.
+- **validate-before-persist** — an edit that would invalidate the project writes
+  nothing and returns `{ ok: false, errors }`; no `.bak` written.
+- **research.json untouched** — byte-unchanged after any operation.
+
+---
+
+## 10. Wiring
+
+Standard MCP tool: `src/tools/tree-edit.ts`, schema in `allToolSchemas`
+(`src/tool-schemas.ts`), dispatch in `src/index.ts`, name in `manifest.json`
+(packaging drift test enforces parity). camelCase params at the boundary;
+persisted tree stays snake_case (the tool renames nothing — payload fields are
+already the snake_case simplified-GedcomX shape the skill passes).
+
+---
+
+## 11. Consumers
+
+- `tree-edit` skill — its "Ad-hoc edits" section is rewritten to call `tree_edit`
+  (one call per edit) instead of hand-editing JSON + calling
+  `validate_research_schema`. The "Person merging" section already routes to the
+  merge tools (per `skill-rewrites-for-persistence-tools-spec.md`); this completes
+  the migration of the skill's write paths. Together, `merge_*` + `tree_edit` cover
+  every write to `tree.gedcomx.json`.

--- a/packages/engine/mcp-server/manifest.json
+++ b/packages/engine/mcp-server/manifest.json
@@ -59,7 +59,8 @@
     { "name": "merge_record_into_tree" },
     { "name": "merge_tree_persons" },
     { "name": "research_log_append" },
-    { "name": "convert_calendar" }
+    { "name": "convert_calendar" },
+    { "name": "tree_edit" }
   ],
   "compatibility": {
     "platforms": ["darwin", "win32", "linux"],

--- a/packages/engine/mcp-server/manifest.json
+++ b/packages/engine/mcp-server/manifest.json
@@ -60,7 +60,8 @@
     { "name": "merge_tree_persons" },
     { "name": "research_log_append" },
     { "name": "convert_calendar" },
-    { "name": "tree_edit" }
+    { "name": "tree_edit" },
+    { "name": "research_append" }
   ],
   "compatibility": {
     "platforms": ["darwin", "win32", "linux"],

--- a/packages/engine/mcp-server/manifest.json
+++ b/packages/engine/mcp-server/manifest.json
@@ -58,7 +58,8 @@
     { "name": "volume_search" },
     { "name": "merge_record_into_tree" },
     { "name": "merge_tree_persons" },
-    { "name": "research_log_append" }
+    { "name": "research_log_append" },
+    { "name": "convert_calendar" }
   ],
   "compatibility": {
     "platforms": ["darwin", "win32", "linux"],

--- a/packages/engine/mcp-server/src/index.ts
+++ b/packages/engine/mcp-server/src/index.ts
@@ -70,6 +70,10 @@ import {
   researchLogAppend,
   type ResearchLogAppendInput,
 } from "./tools/research-log-append.js";
+import {
+  convertCalendar,
+  type ConvertCalendarInput,
+} from "./tools/convert-calendar.js";
 import { allToolSchemas } from "./tool-schemas.js";
 
 const server = new Server(
@@ -544,6 +548,16 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
     try {
       const args = request.params.arguments as unknown as ResearchLogAppendInput;
       const result = await researchLogAppend(args);
+      return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Unknown error";
+      return { content: [{ type: "text", text: JSON.stringify({ error: message }) }], isError: true };
+    }
+  }
+  if (request.params.name === "convert_calendar") {
+    try {
+      const args = request.params.arguments as unknown as ConvertCalendarInput;
+      const result = convertCalendar(args);
       return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
     } catch (error) {
       const message = error instanceof Error ? error.message : "Unknown error";

--- a/packages/engine/mcp-server/src/index.ts
+++ b/packages/engine/mcp-server/src/index.ts
@@ -74,6 +74,7 @@ import {
   convertCalendar,
   type ConvertCalendarInput,
 } from "./tools/convert-calendar.js";
+import { treeEdit, type TreeEditInput } from "./tools/tree-edit.js";
 import { allToolSchemas } from "./tool-schemas.js";
 
 const server = new Server(
@@ -558,6 +559,16 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
     try {
       const args = request.params.arguments as unknown as ConvertCalendarInput;
       const result = convertCalendar(args);
+      return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Unknown error";
+      return { content: [{ type: "text", text: JSON.stringify({ error: message }) }], isError: true };
+    }
+  }
+  if (request.params.name === "tree_edit") {
+    try {
+      const args = request.params.arguments as unknown as TreeEditInput;
+      const result = await treeEdit(args);
       return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
     } catch (error) {
       const message = error instanceof Error ? error.message : "Unknown error";

--- a/packages/engine/mcp-server/src/index.ts
+++ b/packages/engine/mcp-server/src/index.ts
@@ -75,6 +75,10 @@ import {
   type ConvertCalendarInput,
 } from "./tools/convert-calendar.js";
 import { treeEdit, type TreeEditInput } from "./tools/tree-edit.js";
+import {
+  researchAppend,
+  type ResearchAppendInput,
+} from "./tools/research-append.js";
 import { allToolSchemas } from "./tool-schemas.js";
 
 const server = new Server(
@@ -569,6 +573,16 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
     try {
       const args = request.params.arguments as unknown as TreeEditInput;
       const result = await treeEdit(args);
+      return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Unknown error";
+      return { content: [{ type: "text", text: JSON.stringify({ error: message }) }], isError: true };
+    }
+  }
+  if (request.params.name === "research_append") {
+    try {
+      const args = request.params.arguments as unknown as ResearchAppendInput;
+      const result = await researchAppend(args);
       return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
     } catch (error) {
       const message = error instanceof Error ? error.message : "Unknown error";

--- a/packages/engine/mcp-server/src/tool-schemas.ts
+++ b/packages/engine/mcp-server/src/tool-schemas.ts
@@ -42,6 +42,7 @@ import { volumeSearchSchema } from "./tools/volume-search.js";
 import { mergeRecordIntoTreeSchema } from "./tools/merge-record-into-tree.js";
 import { mergeTreePersonsSchema } from "./tools/merge-tree-persons.js";
 import { researchLogAppendSchema } from "./tools/research-log-append.js";
+import { convertCalendarSchema } from "./tools/convert-calendar.js";
 
 export const allToolSchemas = [
   wikipediaSearchSchema,
@@ -78,4 +79,5 @@ export const allToolSchemas = [
   mergeRecordIntoTreeSchema,
   mergeTreePersonsSchema,
   researchLogAppendSchema,
+  convertCalendarSchema,
 ];

--- a/packages/engine/mcp-server/src/tool-schemas.ts
+++ b/packages/engine/mcp-server/src/tool-schemas.ts
@@ -43,6 +43,7 @@ import { mergeRecordIntoTreeSchema } from "./tools/merge-record-into-tree.js";
 import { mergeTreePersonsSchema } from "./tools/merge-tree-persons.js";
 import { researchLogAppendSchema } from "./tools/research-log-append.js";
 import { convertCalendarSchema } from "./tools/convert-calendar.js";
+import { treeEditSchema } from "./tools/tree-edit.js";
 
 export const allToolSchemas = [
   wikipediaSearchSchema,
@@ -80,4 +81,5 @@ export const allToolSchemas = [
   mergeTreePersonsSchema,
   researchLogAppendSchema,
   convertCalendarSchema,
+  treeEditSchema,
 ];

--- a/packages/engine/mcp-server/src/tool-schemas.ts
+++ b/packages/engine/mcp-server/src/tool-schemas.ts
@@ -44,6 +44,7 @@ import { mergeTreePersonsSchema } from "./tools/merge-tree-persons.js";
 import { researchLogAppendSchema } from "./tools/research-log-append.js";
 import { convertCalendarSchema } from "./tools/convert-calendar.js";
 import { treeEditSchema } from "./tools/tree-edit.js";
+import { researchAppendSchema } from "./tools/research-append.js";
 
 export const allToolSchemas = [
   wikipediaSearchSchema,
@@ -82,4 +83,5 @@ export const allToolSchemas = [
   researchLogAppendSchema,
   convertCalendarSchema,
   treeEditSchema,
+  researchAppendSchema,
 ];

--- a/packages/engine/mcp-server/src/tools/convert-calendar.ts
+++ b/packages/engine/mcp-server/src/tools/convert-calendar.ts
@@ -119,6 +119,14 @@ export function convertCalendar(input: ConvertCalendarInput): ConvertCalendarRes
   // 1. Double-dated year → the later (New Style) year. The slash already signals
   //    the Jan 1–Mar 24 boundary, so the New-Style year is always +1.
   if (c.doubleDatedYear) {
+    // A legitimate double date spans consecutive years, so the New-Style year is
+    // always year + 1; the recorded "/N" must be consistent with that.
+    if (date.doubleYear !== undefined && !String(year + 1).endsWith(String(date.doubleYear))) {
+      return {
+        ok: false,
+        errors: [`doubleYear ${date.doubleYear} is not consistent with the New-Style year ${year + 1}`],
+      };
+    }
     year += 1;
     applied.push({
       correction: "doubleDatedYear",
@@ -163,6 +171,9 @@ export function convertCalendar(input: ConvertCalendarInput): ConvertCalendarRes
 
   // 3. Quaker numbered month → calendar month, respecting the 1752 shift.
   if (c.quakerMonth) {
+    if (c.quakerMonth.era !== "pre_1752" && c.quakerMonth.era !== "post_1752") {
+      return { ok: false, errors: ["quakerMonth.era must be 'pre_1752' or 'post_1752'"] };
+    }
     if (month === undefined) {
       return {
         ok: false,
@@ -205,6 +216,15 @@ export function convertCalendar(input: ConvertCalendarInput): ConvertCalendarRes
       notes.push(
         "julianToGregorianDay needs a full day-month-year date; day offset not applied",
       );
+    } else if (julianToJDN(year, month, day) < gregorianToJDN(1582, 10, 15)) {
+      // The Gregorian calendar did not exist before 1582-10-15, so there is no
+      // genealogically meaningful Julian→Gregorian day offset to apply.
+      return {
+        ok: false,
+        errors: [
+          "julianToGregorianDay is not defined before the 1582-10-15 Gregorian introduction (the Julian and Gregorian calendars had not diverged)",
+        ],
+      };
     } else {
       const jdn = julianToJDN(year, month, day);
       const offsetDays = jdn - gregorianToJDN(year, month, day);

--- a/packages/engine/mcp-server/src/tools/convert-calendar.ts
+++ b/packages/engine/mcp-server/src/tools/convert-calendar.ts
@@ -1,0 +1,298 @@
+// convert_calendar — deterministic calendar-conversion arithmetic.
+//
+// Migrates the in-context arithmetic the `convert-dates` skill does by hand into
+// tested code. The LLM keeps every judgment (jurisdiction/era, whether conversion
+// is needed, which correction was asked for); the tool applies only the requested
+// corrections. Spec: docs/specs/convert-calendar-tool-spec.md.
+//
+// The three corrections are independent and applied in a fixed order:
+//   doubleDatedYear → osNsYear → quakerMonth → julianToGregorianDay
+// so a year fix lands before the Quaker roll-over and the day offset operate on it.
+
+export interface ConvertCalendarDate {
+  year: number;
+  month?: number; // 1–12 calendar month, OR the Quaker ordinal when quakerMonth is requested
+  day?: number; // 1–31
+  doubleYear?: number; // the "/N" of a double-dated year, e.g. 1 for "1750/1"
+}
+
+export interface ConvertCalendarCorrections {
+  doubleDatedYear?: boolean;
+  osNsYear?: boolean;
+  quakerMonth?: { era: "pre_1752" | "post_1752" };
+  julianToGregorianDay?: boolean;
+}
+
+export interface ConvertCalendarInput {
+  date: ConvertCalendarDate;
+  corrections: ConvertCalendarCorrections;
+}
+
+interface AppliedCorrection {
+  correction: "doubleDatedYear" | "osNsYear" | "quakerMonth" | "julianToGregorianDay";
+  rule: string;
+  offsetDays?: number;
+  monthShift?: number;
+  yearAdjusted?: boolean;
+}
+
+export type ConvertCalendarResult =
+  | {
+      ok: true;
+      original: ConvertCalendarDate;
+      converted: { year: number; month?: number; day?: number };
+      applied: AppliedCorrection[];
+      notes: string[];
+    }
+  | { ok: false; errors: string[] };
+
+// ─── Julian Day Number conversions (Fliegel/Van Flandern) ───────────────────
+// JDN is the rigorous form of the spec's offset table: converting a Julian-
+// calendar date to its JDN and reading it back as a Gregorian date yields the
+// era-correct offset (10/11/12/13) automatically, including the 1700/1800/1900
+// skipped-leap thresholds.
+
+function gregorianToJDN(y: number, m: number, d: number): number {
+  const a = Math.floor((14 - m) / 12);
+  const yy = y + 4800 - a;
+  const mm = m + 12 * a - 3;
+  return (
+    d +
+    Math.floor((153 * mm + 2) / 5) +
+    365 * yy +
+    Math.floor(yy / 4) -
+    Math.floor(yy / 100) +
+    Math.floor(yy / 400) -
+    32045
+  );
+}
+
+function julianToJDN(y: number, m: number, d: number): number {
+  const a = Math.floor((14 - m) / 12);
+  const yy = y + 4800 - a;
+  const mm = m + 12 * a - 3;
+  return d + Math.floor((153 * mm + 2) / 5) + 365 * yy + Math.floor(yy / 4) - 32083;
+}
+
+function gregorianFromJDN(jdn: number): { year: number; month: number; day: number } {
+  const a = jdn + 32044;
+  const b = Math.floor((4 * a + 3) / 146097);
+  const c = a - Math.floor((146097 * b) / 4);
+  const d = Math.floor((4 * c + 3) / 1461);
+  const e = c - Math.floor((1461 * d) / 4);
+  const m = Math.floor((5 * e + 2) / 153);
+  const day = e - Math.floor((153 * m + 2) / 5) + 1;
+  const month = m + 3 - 12 * Math.floor(m / 10);
+  const year = 100 * b + d - 4800 + Math.floor(m / 10);
+  return { year, month, day };
+}
+
+// ─── Tool ────────────────────────────────────────────────────────────────────
+
+export function convertCalendar(input: ConvertCalendarInput): ConvertCalendarResult {
+  const { date, corrections } = input ?? {};
+  if (!date || !Number.isInteger(date.year)) {
+    return { ok: false, errors: ["date.year is required and must be an integer"] };
+  }
+  if (date.month !== undefined && (date.month < 1 || date.month > 12)) {
+    return { ok: false, errors: ["date.month must be 1–12"] };
+  }
+  if (date.day !== undefined && (date.day < 1 || date.day > 31)) {
+    return { ok: false, errors: ["date.day must be 1–31"] };
+  }
+  const c = corrections ?? {};
+  const requested =
+    Number(!!c.doubleDatedYear) +
+    Number(!!c.osNsYear) +
+    Number(!!c.quakerMonth) +
+    Number(!!c.julianToGregorianDay);
+  if (requested === 0) {
+    return { ok: false, errors: ["corrections must request at least one conversion"] };
+  }
+
+  let year = date.year;
+  let month = date.month;
+  let day = date.day;
+  const applied: AppliedCorrection[] = [];
+  const notes: string[] = [];
+
+  // 1. Double-dated year → the later (New Style) year. The slash already signals
+  //    the Jan 1–Mar 24 boundary, so the New-Style year is always +1.
+  if (c.doubleDatedYear) {
+    year += 1;
+    applied.push({
+      correction: "doubleDatedYear",
+      rule: "Double-dated year resolved to the later (New Style) year (+1)",
+      yearAdjusted: true,
+    });
+  }
+
+  // 2. Old Style → New Style year: dates Jan 1–Mar 24 in a March-25 year-start
+  //    jurisdiction belong to the following year by modern reckoning.
+  if (c.osNsYear) {
+    if (month === undefined) {
+      return { ok: false, errors: ["osNsYear requires date.month"] };
+    }
+    let bump = false;
+    if (month < 3) {
+      bump = true;
+    } else if (month === 3) {
+      if (day === undefined) {
+        notes.push(
+          "osNsYear: a March date without a day is ambiguous for the March 24 boundary; year not adjusted",
+        );
+      } else if (day <= 24) {
+        bump = true;
+      }
+    }
+    if (bump) {
+      year += 1;
+      applied.push({
+        correction: "osNsYear",
+        rule: "Date falls Jan 1–Mar 24 in an Old-Style (year starts March 25) jurisdiction; New-Style year is +1",
+        yearAdjusted: true,
+      });
+    } else if (month !== 3 || day !== undefined) {
+      applied.push({
+        correction: "osNsYear",
+        rule: "Date is after March 24; no Old-Style year correction needed",
+        yearAdjusted: false,
+      });
+    }
+  }
+
+  // 3. Quaker numbered month → calendar month, respecting the 1752 shift.
+  if (c.quakerMonth) {
+    if (month === undefined) {
+      return {
+        ok: false,
+        errors: ["quakerMonth requires date.month (the Quaker ordinal)"],
+      };
+    }
+    const ordinal = month;
+    if (c.quakerMonth.era === "post_1752") {
+      month = ordinal; // 1st month = January
+      applied.push({
+        correction: "quakerMonth",
+        rule: `Post-1752 Quaker numbering: ${ordinal} month → calendar month ${month} (1st = January)`,
+        monthShift: 0,
+      });
+    } else {
+      // pre_1752: 1st month = March; the 11th/12th roll into the next year.
+      if (ordinal <= 10) {
+        month = ordinal + 2;
+        applied.push({
+          correction: "quakerMonth",
+          rule: `Pre-1752 Quaker numbering: ${ordinal} month → calendar month ${month} (1st = March)`,
+          monthShift: 2,
+        });
+      } else {
+        month = ordinal - 10; // 11 → January, 12 → February
+        year += 1;
+        applied.push({
+          correction: "quakerMonth",
+          rule: `Pre-1752 Quaker numbering: ${ordinal} month → ${month === 1 ? "January" : "February"} of the following year (1st = March)`,
+          monthShift: -10,
+          yearAdjusted: true,
+        });
+      }
+    }
+  }
+
+  // 4. Julian → Gregorian day offset, via JDN round-trip.
+  if (c.julianToGregorianDay) {
+    if (month === undefined || day === undefined) {
+      notes.push(
+        "julianToGregorianDay needs a full day-month-year date; day offset not applied",
+      );
+    } else {
+      const jdn = julianToJDN(year, month, day);
+      const offsetDays = jdn - gregorianToJDN(year, month, day);
+      const g = gregorianFromJDN(jdn);
+      year = g.year;
+      month = g.month;
+      day = g.day;
+      applied.push({
+        correction: "julianToGregorianDay",
+        rule: `Julian → Gregorian: +${offsetDays} days`,
+        offsetDays,
+      });
+    }
+  }
+
+  const converted: { year: number; month?: number; day?: number } = { year };
+  if (month !== undefined) converted.month = month;
+  if (day !== undefined) converted.day = day;
+
+  return { ok: true, original: { ...date }, converted, applied, notes };
+}
+
+// ─── MCP schema ──────────────────────────────────────────────────────────────
+
+export const convertCalendarSchema = {
+  name: "convert_calendar",
+  description:
+    "Convert a date between historical calendar systems — Old Style→New Style " +
+    "year, Julian→Gregorian day offset, and Quaker numbered-month resolution. Use " +
+    "when a genealogist asks to convert a date, when a double-dated year (e.g. " +
+    "'1750/1') or a Quaker numbered month appears, or when a date seems off by a " +
+    "year/days because of a calendar transition.\n" +
+    "\n" +
+    "You decide the regime (jurisdiction, era, whether conversion is even needed) " +
+    "and request ONLY the correction(s) the user asked for via `corrections` — the " +
+    "tool does just those, in a fixed order, and never bundles a correction you " +
+    "didn't request. Pass `date` as structured year/month/day; `month` is the " +
+    "Quaker ordinal when you request `quakerMonth`. Returns the converted date, the " +
+    "rule(s) applied (with the day offset), and notes. It writes nothing — present " +
+    "the original date alongside the conversion.",
+  inputSchema: {
+    type: "object" as const,
+    properties: {
+      date: {
+        type: "object",
+        description: "The recorded date, as structured fields.",
+        properties: {
+          year: { type: "number", description: "The year as recorded." },
+          month: {
+            type: "number",
+            description:
+              "Calendar month 1–12 — EXCEPT when requesting quakerMonth, where this is the Quaker ordinal 1–12. Required for the day offset and Quaker conversions.",
+          },
+          day: { type: "number", description: "Day of month 1–31. Required for the day offset." },
+          doubleYear: {
+            type: "number",
+            description: "The trailing '/N' of a double-dated year, e.g. 1 for '1750/1' (used with doubleDatedYear).",
+          },
+        },
+        required: ["year"],
+      },
+      corrections: {
+        type: "object",
+        description: "Which correction(s) to apply — request only what was asked.",
+        properties: {
+          doubleDatedYear: {
+            type: "boolean",
+            description: "Resolve a double-dated year ('1750/1') to the later New-Style year.",
+          },
+          osNsYear: {
+            type: "boolean",
+            description: "Apply the Old Style→New Style year correction (Jan 1–Mar 24 → year + 1).",
+          },
+          quakerMonth: {
+            type: "object",
+            description: "Interpret `month` as a Quaker numbered month using the pre/post-1752 shift.",
+            properties: {
+              era: { type: "string", enum: ["pre_1752", "post_1752"] },
+            },
+            required: ["era"],
+          },
+          julianToGregorianDay: {
+            type: "boolean",
+            description: "Add the era-appropriate Julian→Gregorian day offset (10/11/12/13).",
+          },
+        },
+      },
+    },
+    required: ["date", "corrections"],
+  },
+};

--- a/packages/engine/mcp-server/src/tools/merge-shared.ts
+++ b/packages/engine/mcp-server/src/tools/merge-shared.ts
@@ -5,13 +5,16 @@
 // from the merged document, backing up before an irreversible overwrite, and
 // the Mode-2 research.json person-id remap. Spec: merge-gedcomx-spec.md §5b.
 
-import { readFile, copyFile, access } from "fs/promises";
+import { readFile } from "fs/promises";
 import { join } from "path";
 import type { SimplifiedGedcomX, SimplifiedPerson } from "../types/gedcomx.js";
 import { validateGedcomx } from "../validation/validator.js";
 import { createReport, isValid } from "../validation/types.js";
 import type { ValidationError } from "../validation/types.js";
 import { iteratePersonIdRefs } from "../validation/person-id-refs.js";
+import { backupIfExists } from "../utils/project-io.js";
+
+export { backupIfExists };
 
 /** Vital types the core marks exactly one `primary` fact for (mirrors the core). */
 const VITAL_PRIMARY_TYPES: ReadonlySet<string> = new Set([
@@ -104,16 +107,6 @@ export function validateCandidateGedcomx(candidate: unknown): string[] {
     const path = e.path.replace(/^tree\.gedcomx\.json/, "candidateGedcomx");
     return path ? `${path}: ${e.message}` : e.message;
   });
-}
-
-/** Copy `path` to `path.bak` if it exists (one-deep pre-overwrite backup). */
-export async function backupIfExists(path: string): Promise<void> {
-  try {
-    await access(path);
-  } catch {
-    return;
-  }
-  await copyFile(path, `${path}.bak`);
 }
 
 /**

--- a/packages/engine/mcp-server/src/tools/research-append.ts
+++ b/packages/engine/mcp-server/src/tools/research-append.ts
@@ -23,13 +23,56 @@ interface SectionConfig {
   prefix: string;
   /** Set `created` = today on append when the entry omits it (tool-owned). */
   stampCreated?: boolean;
+  /** Nested section: entries live in `<parent>[<param>].<field>` (plan_items). */
+  nested?: { parent: string; param: "planId"; field: string };
 }
 
 const SECTIONS: Record<string, SectionConfig> = {
+  // Phase 1
   sources: { prefix: "src_" },
   assertions: { prefix: "a_" },
   person_evidence: { prefix: "pe_", stampCreated: true },
+  // Phase 2
+  questions: { prefix: "q_", stampCreated: true },
+  plans: { prefix: "pl_", stampCreated: true },
+  plan_items: { prefix: "pli_", nested: { parent: "plans", param: "planId", field: "items" } },
+  conflicts: { prefix: "c_" },
+  hypotheses: { prefix: "h_" },
 };
+
+// Section invariants the project validator does NOT already enforce. (It already
+// checks conflict competing-counts, hypothesis ruled_out⇒reason, and
+// exhaustive-declaration completeness — those are left to validate-before-persist.)
+// Each returns error strings on the post-mutation entry; empty = ok.
+
+function conflictInvariants(entry: any): string[] {
+  if (entry.status !== "resolved") return [];
+  const errs: string[] = [];
+  for (const f of ["independence_analysis", "weighing_analysis", "resolution_rationale"]) {
+    const v = entry[f];
+    if (v === undefined || v === null || v === "") {
+      errs.push(`a resolved conflict requires '${f}'`);
+    }
+  }
+  const competing = Array.isArray(entry.competing_assertion_ids) ? entry.competing_assertion_ids : [];
+  if (entry.preferred_assertion_id != null && !competing.includes(entry.preferred_assertion_id)) {
+    errs.push("preferred_assertion_id must be one of competing_assertion_ids");
+  }
+  return errs;
+}
+
+function planAppendInvariants(entry: any, research: any): string[] {
+  if (entry.status !== "active") return [];
+  const conflicting = (research.plans ?? []).filter(
+    (p: any) => p !== entry && p.question_id === entry.question_id && p.status === "active",
+  );
+  if (conflicting.length > 0) {
+    return [
+      `question '${entry.question_id}' already has an active plan (${conflicting[0].id}); supersede it before adding another`,
+    ];
+  }
+  return [];
+}
 
 export type ResearchAppendSection = keyof typeof SECTIONS | string;
 
@@ -40,6 +83,7 @@ export interface ResearchAppendInput {
   entry?: Record<string, unknown>; // op = append (no id — the tool assigns it)
   entryId?: string; // op = update
   fields?: Record<string, unknown>; // op = update (shallow-merged; id immutable)
+  planId?: string; // required for section = "plan_items"
 }
 
 export type ResearchAppendResult =
@@ -110,12 +154,37 @@ export async function researchAppend(
     const research = await readJson(projectPath, "research.json");
     const tree = await readJson(projectPath, "tree.gedcomx.json");
 
-    const array = research[section];
-    if (!Array.isArray(array)) {
-      return { ok: false, errors: [`research.json '${section}' is missing or not an array`] };
+    // Resolve the target array and the pool to scan for the next id. Nested
+    // sections (plan_items) live under a parent entry (plans[planId].items),
+    // and their ids are unique across all parents.
+    let array: any[];
+    let idPool: any[];
+    if (config.nested) {
+      if (!input.planId) {
+        return { ok: false, errors: [`section '${section}' requires a 'planId'`] };
+      }
+      const parents = research[config.nested.parent];
+      const parent = Array.isArray(parents)
+        ? parents.find((p) => p && p.id === input.planId)
+        : undefined;
+      if (!parent) {
+        return { ok: false, errors: [`${config.nested.parent} entry '${input.planId}' not found`] };
+      }
+      if (!Array.isArray(parent[config.nested.field])) parent[config.nested.field] = [];
+      array = parent[config.nested.field];
+      idPool = (Array.isArray(parents) ? parents : []).flatMap((p: any) =>
+        Array.isArray(p?.[config.nested!.field]) ? p[config.nested!.field] : [],
+      );
+    } else {
+      if (!Array.isArray(research[section])) {
+        return { ok: false, errors: [`research.json '${section}' is missing or not an array`] };
+      }
+      array = research[section];
+      idPool = array;
     }
 
     let entryId: string;
+    let resultEntry: any;
 
     if (op === "append") {
       const entry = input.entry;
@@ -125,7 +194,7 @@ export async function researchAppend(
       if (entry.id !== undefined && entry.id !== null) {
         return { ok: false, errors: ["append `entry` must not carry an id — the tool assigns it"] };
       }
-      entryId = nextResearchId(array, config.prefix);
+      entryId = nextResearchId(idPool, config.prefix);
       // Strip any id key before assigning so the spread can never clobber it.
       const rest: Record<string, unknown> = { ...entry };
       delete rest.id;
@@ -134,6 +203,7 @@ export async function researchAppend(
         newEntry.created = today();
       }
       array.push(newEntry);
+      resultEntry = newEntry;
     } else if (op === "update") {
       if (!input.entryId) {
         return { ok: false, errors: ["update requires an `entryId`"] };
@@ -154,13 +224,44 @@ export async function researchAppend(
       if (!existing) {
         return { ok: false, errors: [`entryId '${input.entryId}' not found in '${section}'`] };
       }
+
+      // Questions: re-declaring exhaustiveness on an already-declared question is
+      // a no-op — never overwrite a settled GPS Component-1 record.
+      if (section === "questions") {
+        const newEd = input.fields.exhaustive_declaration as any;
+        if (existing.exhaustive_declaration?.declared === true && newEd?.declared === true) {
+          return {
+            ok: true,
+            section,
+            op,
+            entryId: input.entryId,
+            filesWritten: [],
+            validation: {
+              valid: true,
+              warnings: [`question '${input.entryId}' is already exhaustive_declared; no-op`],
+            },
+          };
+        }
+      }
+
       for (const [k, v] of Object.entries(input.fields)) {
         if (k === "id") continue;
         existing[k] = v;
       }
       entryId = input.entryId;
+      resultEntry = existing;
     } else {
       return { ok: false, errors: [`unknown op '${op}' (expected 'append' or 'update')`] };
+    }
+
+    // Section invariants the project validator does not already enforce.
+    const invariantErrors: string[] = [];
+    if (section === "conflicts") invariantErrors.push(...conflictInvariants(resultEntry));
+    if (section === "plans" && op === "append") {
+      invariantErrors.push(...planAppendInvariants(resultEntry, research));
+    }
+    if (invariantErrors.length > 0) {
+      return { ok: false, errors: invariantErrors };
     }
 
     const validation = await validateParsed(research, tree, { projectPath });
@@ -209,8 +310,17 @@ export const researchAppendSchema = {
       },
       section: {
         type: "string",
-        // Phase 1 sections only; phases 2–3 extend this enum.
-        enum: ["sources", "assertions", "person_evidence"],
+        // Phase 3 will add timelines, proof_summaries, evaluations, known_holdings.
+        enum: [
+          "sources",
+          "assertions",
+          "person_evidence",
+          "questions",
+          "plans",
+          "plan_items",
+          "conflicts",
+          "hypotheses",
+        ],
         description: "The research.json section to write.",
       },
       op: {
@@ -229,6 +339,10 @@ export const researchAppendSchema = {
       fields: {
         type: "object",
         description: "update: the fields to shallow-merge onto the existing entry (the id is immutable).",
+      },
+      planId: {
+        type: "string",
+        description: "Required for section 'plan_items' — the pl_ id of the parent plan to write into.",
       },
     },
     required: ["projectPath", "section", "op"],

--- a/packages/engine/mcp-server/src/tools/research-append.ts
+++ b/packages/engine/mcp-server/src/tools/research-append.ts
@@ -21,23 +21,30 @@ import { atomicWriteJson } from "../utils/project-io.js";
 interface SectionConfig {
   /** id prefix, including the trailing underscore (e.g. "src_"). */
   prefix: string;
-  /** Set `created` = today on append when the entry omits it (tool-owned). */
-  stampCreated?: boolean;
+  /** Tool-owned timestamp stamped on append when the entry omits it. */
+  stampTimestamp?: { field: string; kind: "date" | "datetime" };
   /** Nested section: entries live in `<parent>[<param>].<field>` (plan_items). */
   nested?: { parent: string; param: "planId"; field: string };
 }
+
+const CREATED_DATE = { field: "created", kind: "date" } as const;
 
 const SECTIONS: Record<string, SectionConfig> = {
   // Phase 1
   sources: { prefix: "src_" },
   assertions: { prefix: "a_" },
-  person_evidence: { prefix: "pe_", stampCreated: true },
+  person_evidence: { prefix: "pe_", stampTimestamp: CREATED_DATE },
   // Phase 2
-  questions: { prefix: "q_", stampCreated: true },
-  plans: { prefix: "pl_", stampCreated: true },
+  questions: { prefix: "q_", stampTimestamp: CREATED_DATE },
+  plans: { prefix: "pl_", stampTimestamp: CREATED_DATE },
   plan_items: { prefix: "pli_", nested: { parent: "plans", param: "planId", field: "items" } },
   conflicts: { prefix: "c_" },
   hypotheses: { prefix: "h_" },
+  // Phase 3
+  timelines: { prefix: "t_", stampTimestamp: { field: "generated", kind: "datetime" } },
+  proof_summaries: { prefix: "ps_" },
+  evaluations: { prefix: "ev_", stampTimestamp: { field: "timestamp", kind: "datetime" } },
+  known_holdings: { prefix: "kh_", stampTimestamp: CREATED_DATE },
 };
 
 // Section invariants the project validator does NOT already enforce. (It already
@@ -135,6 +142,10 @@ function today(): string {
   return new Date().toISOString().slice(0, 10);
 }
 
+function now(): string {
+  return new Date().toISOString();
+}
+
 export async function researchAppend(
   input: ResearchAppendInput,
 ): Promise<ResearchAppendResult> {
@@ -176,8 +187,10 @@ export async function researchAppend(
         Array.isArray(p?.[config.nested!.field]) ? p[config.nested!.field] : [],
       );
     } else {
+      // Initialize an absent optional section (e.g. known_holdings) on first write.
+      if (research[section] === undefined) research[section] = [];
       if (!Array.isArray(research[section])) {
-        return { ok: false, errors: [`research.json '${section}' is missing or not an array`] };
+        return { ok: false, errors: [`research.json '${section}' is not an array`] };
       }
       array = research[section];
       idPool = array;
@@ -199,8 +212,9 @@ export async function researchAppend(
       const rest: Record<string, unknown> = { ...entry };
       delete rest.id;
       const newEntry: Record<string, unknown> = { id: entryId, ...rest };
-      if (config.stampCreated && newEntry.created === undefined) {
-        newEntry.created = today();
+      const stamp = config.stampTimestamp;
+      if (stamp && newEntry[stamp.field] === undefined) {
+        newEntry[stamp.field] = stamp.kind === "date" ? today() : now();
       }
       array.push(newEntry);
       resultEntry = newEntry;
@@ -310,7 +324,6 @@ export const researchAppendSchema = {
       },
       section: {
         type: "string",
-        // Phase 3 will add timelines, proof_summaries, evaluations, known_holdings.
         enum: [
           "sources",
           "assertions",
@@ -320,6 +333,10 @@ export const researchAppendSchema = {
           "plan_items",
           "conflicts",
           "hypotheses",
+          "timelines",
+          "proof_summaries",
+          "evaluations",
+          "known_holdings",
         ],
         description: "The research.json section to write.",
       },

--- a/packages/engine/mcp-server/src/tools/research-append.ts
+++ b/packages/engine/mcp-server/src/tools/research-append.ts
@@ -240,8 +240,10 @@ export async function researchAppend(
       }
 
       // Questions: re-declaring exhaustiveness on an already-declared question is
-      // a no-op — never overwrite a settled GPS Component-1 record.
-      if (section === "questions") {
+      // a no-op — never overwrite a settled GPS Component-1 record. Only when the
+      // declaration is the SOLE field being set, so a bundled update that also
+      // changes other fields is not silently dropped.
+      if (section === "questions" && Object.keys(input.fields).length === 1) {
         const newEd = input.fields.exhaustive_declaration as any;
         if (existing.exhaustive_declaration?.declared === true && newEd?.declared === true) {
           return {

--- a/packages/engine/mcp-server/src/tools/research-append.ts
+++ b/packages/engine/mcp-server/src/tools/research-append.ts
@@ -1,0 +1,236 @@
+// research_append — structured writer for the mutable research.json sections
+// (everything except the append-only `log`, which is research_log_append's job).
+//
+// One tool with a `section` + `op` discriminator. The LLM supplies the analytical
+// content; the tool assigns the section's prefix id, stamps tool-owned timestamps,
+// enforces supersede-not-delete (no delete op), runs the section invariants as
+// preconditions, validates the whole project, and writes research.json atomically.
+//
+// Phased per docs/specs/research-append-tool-spec.md §7. This file implements
+// Phase 1 (sources, assertions, person_evidence) plus the framework; phases 2–3
+// extend SECTIONS.
+
+import { join } from "path";
+import { readFile } from "fs/promises";
+import { validateParsed } from "../validation/validator.js";
+import type { ValidationError } from "../validation/types.js";
+import { atomicWriteJson } from "../utils/project-io.js";
+
+// ─── Section configuration (the per-section table phases 2–3 extend) ─────────
+
+interface SectionConfig {
+  /** id prefix, including the trailing underscore (e.g. "src_"). */
+  prefix: string;
+  /** Set `created` = today on append when the entry omits it (tool-owned). */
+  stampCreated?: boolean;
+}
+
+const SECTIONS: Record<string, SectionConfig> = {
+  sources: { prefix: "src_" },
+  assertions: { prefix: "a_" },
+  person_evidence: { prefix: "pe_", stampCreated: true },
+};
+
+export type ResearchAppendSection = keyof typeof SECTIONS | string;
+
+export interface ResearchAppendInput {
+  projectPath: string;
+  section: ResearchAppendSection;
+  op: "append" | "update";
+  entry?: Record<string, unknown>; // op = append (no id — the tool assigns it)
+  entryId?: string; // op = update
+  fields?: Record<string, unknown>; // op = update (shallow-merged; id immutable)
+}
+
+export type ResearchAppendResult =
+  | {
+      ok: true;
+      section: string;
+      op: "append" | "update";
+      entryId: string;
+      filesWritten: string[];
+      validation: { valid: true; warnings: string[] };
+    }
+  | { ok: false; errors: string[] };
+
+class ResearchAppendError extends Error {}
+
+function formatIssues(issues: ValidationError[]): string[] {
+  return issues.map((e) => (e.path ? `${e.path}: ${e.message}` : e.message));
+}
+
+async function readJson(projectPath: string, filename: string): Promise<any> {
+  let text: string;
+  try {
+    text = await readFile(join(projectPath, filename), "utf-8");
+  } catch {
+    throw new ResearchAppendError(`${filename} not found in projectPath`);
+  }
+  try {
+    return JSON.parse(text);
+  } catch {
+    throw new ResearchAppendError(`${filename} is not valid JSON`);
+  }
+}
+
+/** Next `<prefix>NNN` id (max + 1, zero-padded to 3) for a research section. */
+function nextResearchId(entries: any[], prefix: string): string {
+  let max = 0;
+  const re = new RegExp(`^${prefix}(\\d+)$`);
+  for (const e of entries) {
+    const m = e && typeof e.id === "string" ? e.id.match(re) : null;
+    if (m) {
+      const n = Number(m[1]);
+      if (n > max) max = n;
+    }
+  }
+  return `${prefix}${String(max + 1).padStart(3, "0")}`;
+}
+
+function today(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+export async function researchAppend(
+  input: ResearchAppendInput,
+): Promise<ResearchAppendResult> {
+  const { projectPath, section, op } = input;
+
+  try {
+    const config = SECTIONS[section];
+    if (!config) {
+      return {
+        ok: false,
+        errors: [
+          `section '${section}' is not supported by research_append (supported: ${Object.keys(SECTIONS).join(", ")})`,
+        ],
+      };
+    }
+
+    const research = await readJson(projectPath, "research.json");
+    const tree = await readJson(projectPath, "tree.gedcomx.json");
+
+    const array = research[section];
+    if (!Array.isArray(array)) {
+      return { ok: false, errors: [`research.json '${section}' is missing or not an array`] };
+    }
+
+    let entryId: string;
+
+    if (op === "append") {
+      const entry = input.entry;
+      if (!entry || typeof entry !== "object") {
+        return { ok: false, errors: ["append requires an `entry` object"] };
+      }
+      if (entry.id !== undefined && entry.id !== null) {
+        return { ok: false, errors: ["append `entry` must not carry an id — the tool assigns it"] };
+      }
+      entryId = nextResearchId(array, config.prefix);
+      // Strip any id key before assigning so the spread can never clobber it.
+      const rest: Record<string, unknown> = { ...entry };
+      delete rest.id;
+      const newEntry: Record<string, unknown> = { id: entryId, ...rest };
+      if (config.stampCreated && newEntry.created === undefined) {
+        newEntry.created = today();
+      }
+      array.push(newEntry);
+    } else if (op === "update") {
+      if (!input.entryId) {
+        return { ok: false, errors: ["update requires an `entryId`"] };
+      }
+      if (!input.entryId.startsWith(config.prefix)) {
+        return {
+          ok: false,
+          errors: [`entryId '${input.entryId}' does not match section '${section}' (prefix ${config.prefix})`],
+        };
+      }
+      if (!input.fields || typeof input.fields !== "object") {
+        return { ok: false, errors: ["update requires a `fields` object"] };
+      }
+      if ("id" in input.fields && input.fields.id !== input.entryId) {
+        return { ok: false, errors: ["update `fields` must not change the entry id"] };
+      }
+      const existing = array.find((e) => e && e.id === input.entryId);
+      if (!existing) {
+        return { ok: false, errors: [`entryId '${input.entryId}' not found in '${section}'`] };
+      }
+      for (const [k, v] of Object.entries(input.fields)) {
+        if (k === "id") continue;
+        existing[k] = v;
+      }
+      entryId = input.entryId;
+    } else {
+      return { ok: false, errors: [`unknown op '${op}' (expected 'append' or 'update')`] };
+    }
+
+    const validation = await validateParsed(research, tree, { projectPath });
+    if (!validation.valid) {
+      return { ok: false, errors: formatIssues(validation.errors) };
+    }
+
+    await atomicWriteJson(join(projectPath, "research.json"), research);
+
+    return {
+      ok: true,
+      section,
+      op,
+      entryId,
+      filesWritten: ["research.json"],
+      validation: { valid: true, warnings: formatIssues(validation.warnings) },
+    };
+  } catch (e) {
+    if (e instanceof ResearchAppendError) return { ok: false, errors: [e.message] };
+    throw e;
+  }
+}
+
+// ─── MCP schema ──────────────────────────────────────────────────────────────
+
+export const researchAppendSchema = {
+  name: "research_append",
+  description:
+    "Write a structured entry to a mutable research.json section — append a new " +
+    "entry (the tool assigns the id) or update an existing one in place (preserving " +
+    "its id; there is no delete — supersede via a status/`superseded_by` field). Use " +
+    "this for the analytical sections; use research_log_append for the research log, " +
+    "and the merge / tree_edit tools for tree.gedcomx.json.\n" +
+    "\n" +
+    "Supply the entry in its persisted snake_case shape WITHOUT an id; the tool " +
+    "assigns the next `<prefix>NNN`, stamps tool-owned timestamps, validates the " +
+    "whole project, and writes research.json atomically. To revise a person_evidence " +
+    "link, append the new entry then update the old one's `superseded_by`. Returns a " +
+    "compact summary; on a validation failure nothing is written.",
+  inputSchema: {
+    type: "object" as const,
+    properties: {
+      projectPath: {
+        type: "string",
+        description: "Absolute path to the project directory holding research.json.",
+      },
+      section: {
+        type: "string",
+        // Phase 1 sections only; phases 2–3 extend this enum.
+        enum: ["sources", "assertions", "person_evidence"],
+        description: "The research.json section to write.",
+      },
+      op: {
+        type: "string",
+        enum: ["append", "update"],
+        description: "append a new entry (tool assigns the id) or update an existing one by id.",
+      },
+      entry: {
+        type: "object",
+        description: "append: the new entry in snake_case, WITHOUT an id (the tool assigns it).",
+      },
+      entryId: {
+        type: "string",
+        description: "update: the id of the existing entry to modify (must match the section's prefix).",
+      },
+      fields: {
+        type: "object",
+        description: "update: the fields to shallow-merge onto the existing entry (the id is immutable).",
+      },
+    },
+    required: ["projectPath", "section", "op"],
+  },
+};

--- a/packages/engine/mcp-server/src/tools/tree-edit.ts
+++ b/packages/engine/mcp-server/src/tools/tree-edit.ts
@@ -1,0 +1,354 @@
+// tree_edit — single-entity ad-hoc mutations of tree.gedcomx.json.
+//
+// The sibling of the merge tools: where those collapse persons, this one does
+// the add/correct/remove edits the tree-edit skill performs by hand today. It
+// reuses the shipped write layer (atomicWriteJson, backupIfExists, validateParsed)
+// and the shared id allocator, so the LLM passes only the content judgment and
+// the tool does id assignment, the primary/preferred swaps, standard_place
+// resolution, validate-before-persist, and the atomic write. Writes only
+// tree.gedcomx.json. Spec: docs/specs/tree-edit-tool-spec.md.
+
+import { join } from "path";
+import { readFile } from "fs/promises";
+import type {
+  SimplifiedGedcomX,
+  SimplifiedPerson,
+  SimplifiedName,
+  SimplifiedFact,
+  SimplifiedRelationship,
+} from "../types/gedcomx.js";
+import { validateParsed } from "../validation/validator.js";
+import type { ValidationError } from "../validation/types.js";
+import { atomicWriteJson, backupIfExists } from "../utils/project-io.js";
+import { maxIdNum, nextId } from "../utils/gedcomx-ids.js";
+import { resolveStandardPlace } from "../utils/place-resolver.js";
+
+export type TreeEditOperation =
+  | "add_fact"
+  | "update_fact"
+  | "add_name"
+  | "update_name"
+  | "update_person"
+  | "add_person"
+  | "add_relationship"
+  | "remove";
+
+export interface TreeEditInput {
+  projectPath: string;
+  operation: TreeEditOperation;
+  personId?: string;
+  factId?: string;
+  nameId?: string;
+  relationshipId?: string;
+  fact?: SimplifiedFact;
+  name?: SimplifiedName;
+  person?: SimplifiedPerson;
+  relationship?: SimplifiedRelationship;
+  gender?: string;
+  ark?: string;
+  /** Auto-resolve standard_place when a place is set (default true). */
+  resolveStandardPlace?: boolean;
+}
+
+interface AssignedIds {
+  person?: string;
+  fact?: string;
+  name?: string;
+  relationship?: string;
+  names?: string[];
+}
+
+export type TreeEditResult =
+  | {
+      ok: true;
+      operation: TreeEditOperation;
+      assignedIds?: AssignedIds;
+      filesWritten: string[];
+      validation: { valid: true; warnings: string[] };
+    }
+  | { ok: false; errors: string[] };
+
+class TreeEditError extends Error {}
+
+function formatIssues(issues: ValidationError[]): string[] {
+  return issues.map((e) => (e.path ? `${e.path}: ${e.message}` : e.message));
+}
+
+async function readJson(projectPath: string, filename: string): Promise<any> {
+  let text: string;
+  try {
+    text = await readFile(join(projectPath, filename), "utf-8");
+  } catch {
+    throw new TreeEditError(`${filename} not found in projectPath`);
+  }
+  try {
+    return JSON.parse(text);
+  } catch {
+    throw new TreeEditError(`${filename} is not valid JSON`);
+  }
+}
+
+function requirePerson(tree: SimplifiedGedcomX, personId: string | undefined): SimplifiedPerson {
+  if (!personId) throw new TreeEditError("personId is required for this operation");
+  const p = (tree.persons ?? []).find((x) => x.id === personId);
+  if (!p) throw new TreeEditError(`person '${personId}' not found in tree`);
+  return p;
+}
+
+/** Remove the `primary` flag from the person's other facts of the same type. */
+function clearPrimaryOfType(person: SimplifiedPerson, type: string | undefined, exceptId: string | undefined): void {
+  for (const f of person.facts ?? []) {
+    if (f.id !== exceptId && f.type === type && f.primary) delete f.primary;
+  }
+}
+
+/** Remove the `preferred` flag from the person's other names. */
+function clearPreferred(person: SimplifiedPerson, exceptId: string | undefined): void {
+  for (const n of person.names ?? []) {
+    if (n.id !== exceptId && n.preferred) delete n.preferred;
+  }
+}
+
+async function applyOperation(
+  tree: SimplifiedGedcomX,
+  input: TreeEditInput,
+): Promise<{ assignedIds: AssignedIds; warnings: string[] }> {
+  const assignedIds: AssignedIds = {};
+  const warnings: string[] = [];
+  const wantResolve = input.resolveStandardPlace !== false;
+
+  // Resolve a fact's standard_place in place when it has a place and no explicit
+  // standard_place; best-effort — never fail the edit on a resolution miss.
+  const maybeResolvePlace = async (fact: SimplifiedFact, explicitStandardPlace: boolean): Promise<void> => {
+    if (!wantResolve || !fact.place || explicitStandardPlace) return;
+    try {
+      fact.standard_place = (await resolveStandardPlace(fact.place)) ?? undefined;
+      if (fact.standard_place === undefined) delete fact.standard_place;
+    } catch {
+      delete fact.standard_place;
+      warnings.push(`could not resolve standard_place for '${fact.place}' (left unset)`);
+    }
+  };
+
+  switch (input.operation) {
+    case "add_fact": {
+      const person = requirePerson(tree, input.personId);
+      if (!input.fact) throw new TreeEditError("add_fact requires a `fact`");
+      if (input.fact.id) throw new TreeEditError("add_fact `fact` must not carry an id — the tool assigns it");
+      const fact: SimplifiedFact = { ...input.fact, id: nextId(tree, "F") };
+      await maybeResolvePlace(fact, input.fact.standard_place !== undefined);
+      if (fact.primary === true) clearPrimaryOfType(person, fact.type, fact.id);
+      person.facts = [...(person.facts ?? []), fact];
+      assignedIds.fact = fact.id;
+      break;
+    }
+    case "update_fact": {
+      const person = requirePerson(tree, input.personId);
+      if (!input.factId) throw new TreeEditError("update_fact requires a `factId`");
+      if (!input.fact) throw new TreeEditError("update_fact requires `fact` fields to set");
+      const existing = (person.facts ?? []).find((f) => f.id === input.factId);
+      if (!existing) throw new TreeEditError(`fact '${input.factId}' not found on person '${input.personId}'`);
+      for (const [k, v] of Object.entries(input.fact)) {
+        if (k === "id") continue;
+        (existing as any)[k] = v;
+      }
+      if (input.fact.place !== undefined) await maybeResolvePlace(existing, input.fact.standard_place !== undefined);
+      if (existing.primary === true) clearPrimaryOfType(person, existing.type, existing.id);
+      break;
+    }
+    case "add_name": {
+      const person = requirePerson(tree, input.personId);
+      if (!input.name) throw new TreeEditError("add_name requires a `name`");
+      if (input.name.id) throw new TreeEditError("add_name `name` must not carry an id");
+      const name: SimplifiedName = { ...input.name, id: nextId(tree, "N") };
+      if (name.preferred === true) clearPreferred(person, name.id);
+      person.names = [...(person.names ?? []), name];
+      assignedIds.name = name.id;
+      break;
+    }
+    case "update_name": {
+      const person = requirePerson(tree, input.personId);
+      if (!input.nameId) throw new TreeEditError("update_name requires a `nameId`");
+      if (!input.name) throw new TreeEditError("update_name requires `name` fields to set");
+      const existing = (person.names ?? []).find((n) => n.id === input.nameId);
+      if (!existing) throw new TreeEditError(`name '${input.nameId}' not found on person '${input.personId}'`);
+      for (const [k, v] of Object.entries(input.name)) {
+        if (k === "id") continue;
+        (existing as any)[k] = v;
+      }
+      if (existing.preferred === true) clearPreferred(person, existing.id);
+      break;
+    }
+    case "update_person": {
+      const person = requirePerson(tree, input.personId);
+      if (input.gender === undefined && input.ark === undefined) {
+        throw new TreeEditError("update_person requires `gender` and/or `ark`");
+      }
+      if (input.gender !== undefined) person.gender = input.gender;
+      if (input.ark !== undefined) person.ark = input.ark;
+      break;
+    }
+    case "add_person": {
+      if (!input.person) throw new TreeEditError("add_person requires a `person`");
+      if (input.person.id) throw new TreeEditError("add_person `person` must not carry an id");
+      const personId = nextId(tree, "I");
+      const nMax = maxIdNum(tree, "N");
+      const names = (input.person.names ?? []).map((n, i) => ({ ...n, id: `N${nMax + 1 + i}` }));
+      const person: SimplifiedPerson = { ...input.person, id: personId, names };
+      tree.persons = [...(tree.persons ?? []), person];
+      assignedIds.person = personId;
+      assignedIds.names = names.map((n) => n.id!).filter(Boolean);
+      break;
+    }
+    case "add_relationship": {
+      if (!input.relationship) throw new TreeEditError("add_relationship requires a `relationship`");
+      if (input.relationship.id) throw new TreeEditError("add_relationship `relationship` must not carry an id");
+      const rel: SimplifiedRelationship = { ...input.relationship, id: nextId(tree, "R") };
+      tree.relationships = [...(tree.relationships ?? []), rel];
+      assignedIds.relationship = rel.id;
+      break;
+    }
+    case "remove": {
+      if (input.personId) {
+        throw new TreeEditError("remove does not delete persons — use merge_tree_persons to collapse a person");
+      }
+      const targets = [input.factId, input.relationshipId].filter(Boolean);
+      if (targets.length !== 1) {
+        throw new TreeEditError("remove requires exactly one of `factId` or `relationshipId`");
+      }
+      if (input.factId) {
+        let found = false;
+        for (const p of tree.persons ?? []) {
+          const before = (p.facts ?? []).length;
+          if (before) {
+            p.facts = p.facts!.filter((f) => f.id !== input.factId);
+            if (p.facts.length !== before) found = true;
+          }
+        }
+        for (const r of tree.relationships ?? []) {
+          const before = (r.facts ?? []).length;
+          if (before) {
+            r.facts = r.facts!.filter((f) => f.id !== input.factId);
+            if (r.facts.length !== before) found = true;
+          }
+        }
+        if (!found) throw new TreeEditError(`fact '${input.factId}' not found in tree`);
+      } else {
+        const before = (tree.relationships ?? []).length;
+        tree.relationships = (tree.relationships ?? []).filter((r) => r.id !== input.relationshipId);
+        if (tree.relationships.length === before) {
+          throw new TreeEditError(`relationship '${input.relationshipId}' not found in tree`);
+        }
+      }
+      break;
+    }
+    default:
+      throw new TreeEditError(`unknown operation '${input.operation}'`);
+  }
+
+  return { assignedIds, warnings };
+}
+
+export async function treeEdit(input: TreeEditInput): Promise<TreeEditResult> {
+  const { projectPath, operation } = input;
+  try {
+    const tree = (await readJson(projectPath, "tree.gedcomx.json")) as SimplifiedGedcomX;
+    const research = await readJson(projectPath, "research.json");
+
+    const { assignedIds, warnings } = await applyOperation(tree, input);
+
+    const validation = await validateParsed(research, tree, { projectPath });
+    if (!validation.valid) {
+      return { ok: false, errors: formatIssues(validation.errors) };
+    }
+
+    const treePath = join(projectPath, "tree.gedcomx.json");
+    await backupIfExists(treePath);
+    await atomicWriteJson(treePath, tree);
+
+    const result: TreeEditResult = {
+      ok: true,
+      operation,
+      filesWritten: ["tree.gedcomx.json"],
+      validation: { valid: true, warnings: [...formatIssues(validation.warnings), ...warnings] },
+    };
+    if (Object.keys(assignedIds).length > 0) result.assignedIds = assignedIds;
+    return result;
+  } catch (e) {
+    if (e instanceof TreeEditError) return { ok: false, errors: [e.message] };
+    throw e;
+  }
+}
+
+// ─── MCP schema ──────────────────────────────────────────────────────────────
+
+export const treeEditSchema = {
+  name: "tree_edit",
+  description:
+    "Make a single ad-hoc edit to the project's tree.gedcomx.json — add or correct " +
+    "a fact or name, add a person or relationship, or remove a fact/relationship on " +
+    "a tier downgrade. Use this for direct corrections; use merge_record_into_tree / " +
+    "merge_tree_persons to fold in a record or collapse duplicate persons (this tool " +
+    "never deletes a person).\n" +
+    "\n" +
+    "Pick the `operation` and supply the content (snake_case simplified-GedcomX " +
+    "fields) WITHOUT ids — the tool assigns the next F/N/I/R id, swaps the " +
+    "primary/preferred flag, resolves standard_place for a place, validates the " +
+    "whole project, and writes only tree.gedcomx.json (with a one-deep .bak). " +
+    "Returns a compact summary (the assigned ids); on a validation failure nothing " +
+    "is written and `{ ok: false, errors }` is returned. Run check-warnings after " +
+    "for genealogical-plausibility checks.",
+  inputSchema: {
+    type: "object" as const,
+    properties: {
+      projectPath: {
+        type: "string",
+        description: "Absolute path to the project directory holding tree.gedcomx.json and research.json.",
+      },
+      operation: {
+        type: "string",
+        enum: [
+          "add_fact",
+          "update_fact",
+          "add_name",
+          "update_name",
+          "update_person",
+          "add_person",
+          "add_relationship",
+          "remove",
+        ],
+        description: "The edit to perform.",
+      },
+      personId: {
+        type: "string",
+        description: "Target person id — for add_fact, add_name, update_fact, update_name, update_person.",
+      },
+      factId: { type: "string", description: "Target fact id — for update_fact and remove." },
+      nameId: { type: "string", description: "Target name id — for update_name." },
+      relationshipId: { type: "string", description: "Target relationship id — for remove." },
+      fact: {
+        type: "object",
+        description: "The fact to add (full, no id) or the fields to set (update_fact). Set `primary: true` to make it the primary of its type.",
+      },
+      name: {
+        type: "object",
+        description: "The name to add (full, no id) or fields to set (update_name). Set `preferred: true` to make it the preferred name.",
+      },
+      person: {
+        type: "object",
+        description: "The person to add (gender + at least one name; no ids — the tool assigns I and N ids). Omit `ark` for a synthesized stub.",
+      },
+      relationship: {
+        type: "object",
+        description: "The relationship to add (no id). Use `parent`/`child` for ParentChild, `person1`/`person2` for Couple; endpoints must be existing person ids.",
+      },
+      gender: { type: "string", description: "update_person: new gender (Male/Female/Unknown)." },
+      ark: { type: "string", description: "update_person: the FamilySearch ARK to set." },
+      resolveStandardPlace: {
+        type: "boolean",
+        description: "Default true: auto-resolve standard_place when a fact place is set. Pass false to skip the lookup.",
+      },
+    },
+    required: ["projectPath", "operation"],
+  },
+};

--- a/packages/engine/mcp-server/src/tools/tree-edit.ts
+++ b/packages/engine/mcp-server/src/tools/tree-edit.ts
@@ -194,6 +194,16 @@ async function applyOperation(
       const personId = nextId(tree, "I");
       const nMax = maxIdNum(tree, "N");
       const names = (input.person.names ?? []).map((n, i) => ({ ...n, id: `N${nMax + 1 + i}` }));
+      // Normalize to exactly one preferred name (spec §4.1): keep the first
+      // flagged preferred, or mark the first name preferred if none were.
+      if (names.length > 0) {
+        let kept = false;
+        for (const n of names) {
+          if (n.preferred === true && !kept) kept = true;
+          else if (n.preferred === true) delete n.preferred;
+        }
+        if (!kept) names[0].preferred = true;
+      }
       const person: SimplifiedPerson = { ...input.person, id: personId, names };
       tree.persons = [...(tree.persons ?? []), person];
       assignedIds.person = personId;

--- a/packages/engine/mcp-server/src/utils/gedcomx-ids.ts
+++ b/packages/engine/mcp-server/src/utils/gedcomx-ids.ts
@@ -1,0 +1,37 @@
+// gedcomx-ids — shared id-allocation helpers for SimplifiedGedcomX writers.
+//
+// The merge core (utils/merge-gedcomx.ts) and the tree_edit tool both allocate
+// the next `<prefix><n>` id above the document's current maximum. This is the
+// single source of that logic so the two cannot drift.
+
+import type { SimplifiedGedcomX } from "../types/gedcomx.js";
+
+/** Highest numeric suffix used by any `<prefix><n>` id of `prefix` in `doc`. */
+export function maxIdNum(doc: SimplifiedGedcomX, prefix: string): number {
+  let max = 0;
+  const consider = (id: string | undefined): void => {
+    if (!id) return;
+    const m = id.match(/^([A-Za-z]+)(\d+)$/);
+    if (m && m[1] === prefix) {
+      const n = Number(m[2]);
+      if (n > max) max = n;
+    }
+  };
+  for (const p of doc.persons ?? []) {
+    consider(p.id);
+    for (const n of p.names ?? []) consider(n.id);
+    for (const f of p.facts ?? []) consider(f.id);
+  }
+  for (const r of doc.relationships ?? []) {
+    consider(r.id);
+    for (const f of r.facts ?? []) consider(f.id);
+  }
+  for (const s of doc.sources ?? []) consider(s.id);
+  for (const pl of doc.places ?? []) consider(pl.id);
+  return max;
+}
+
+/** The next free `<prefix><n>` id (max + 1) in `doc`. */
+export function nextId(doc: SimplifiedGedcomX, prefix: string): string {
+  return `${prefix}${maxIdNum(doc, prefix) + 1}`;
+}

--- a/packages/engine/mcp-server/src/utils/merge-gedcomx.ts
+++ b/packages/engine/mcp-server/src/utils/merge-gedcomx.ts
@@ -27,6 +27,7 @@ import type {
 } from "../types/gedcomx.js";
 import { getDayRange } from "./date-helpers.js";
 import { getStandardDate } from "./fact-helpers.js";
+import { maxIdNum } from "./gedcomx-ids.js";
 
 /**
  * Merge `candidate` into `target` (or persons within `target` when
@@ -466,31 +467,6 @@ function dedupSourceRefs(
     out.push(structuredClone(r));
   }
   return out;
-}
-
-/** Highest numeric suffix used by any `<prefix><n>` id of `prefix` in `doc`. */
-function maxIdNum(doc: SimplifiedGedcomX, prefix: string): number {
-  let max = 0;
-  const consider = (id: string | undefined): void => {
-    if (!id) return;
-    const m = id.match(/^([A-Za-z]+)(\d+)$/);
-    if (m && m[1] === prefix) {
-      const n = Number(m[2]);
-      if (n > max) max = n;
-    }
-  };
-  for (const p of doc.persons ?? []) {
-    consider(p.id);
-    for (const n of p.names ?? []) consider(n.id);
-    for (const f of p.facts ?? []) consider(f.id);
-  }
-  for (const r of doc.relationships ?? []) {
-    consider(r.id);
-    for (const f of r.facts ?? []) consider(f.id);
-  }
-  for (const s of doc.sources ?? []) consider(s.id);
-  for (const pl of doc.places ?? []) consider(pl.id);
-  return max;
 }
 
 /**

--- a/packages/engine/mcp-server/src/utils/project-io.ts
+++ b/packages/engine/mcp-server/src/utils/project-io.ts
@@ -8,7 +8,7 @@
 // here as independently unit-tested utils rather than being reimplemented per
 // tool. Spec: docs/specs/validate-project-refactor-spec.md §10.
 
-import { writeFile, rename, mkdir, unlink } from "fs/promises";
+import { writeFile, rename, mkdir, unlink, copyFile, access } from "fs/promises";
 import { dirname, resolve, relative, isAbsolute } from "path";
 import { randomUUID } from "node:crypto";
 
@@ -40,6 +40,20 @@ export function assertInsideProject(projectPath: string, ref: string): string {
 /** Serialize an object to pretty JSON, matching the on-disk project format. */
 function serialize(obj: unknown): string {
   return JSON.stringify(obj, null, 2);
+}
+
+/**
+ * Copy `path` to `path.bak` if it exists — a one-deep backup before an
+ * irreversible overwrite (the merge and tree-edit tools call this; the
+ * append-only writers do not). No-op when `path` doesn't exist yet.
+ */
+export async function backupIfExists(path: string): Promise<void> {
+  try {
+    await access(path);
+  } catch {
+    return;
+  }
+  await copyFile(path, `${path}.bak`);
 }
 
 /**

--- a/packages/engine/mcp-server/tests/tools/convert-calendar.test.ts
+++ b/packages/engine/mcp-server/tests/tools/convert-calendar.test.ts
@@ -108,10 +108,44 @@ describe("convert_calendar", () => {
     });
   });
 
+  describe("day offset at the leap-skip thresholds", () => {
+    const off = (y: number, m: number, d: number) => {
+      const r = convertCalendar({ date: { year: y, month: m, day: d }, corrections: { julianToGregorianDay: true } });
+      if (!r.ok) return null;
+      return r.applied.find((a) => a.correction === "julianToGregorianDay")?.offsetDays;
+    };
+    it("steps from 10→11 across 1700, 11→12 across 1800, 12→13 across 1900 (boundary = Mar 1 Julian)", () => {
+      expect(off(1700, 2, 28)).toBe(10);
+      expect(off(1700, 3, 1)).toBe(11);
+      expect(off(1800, 2, 28)).toBe(11);
+      expect(off(1800, 3, 1)).toBe(12);
+      expect(off(1900, 2, 28)).toBe(12);
+      expect(off(1900, 3, 1)).toBe(13);
+    });
+  });
+
   describe("errors + purity", () => {
     it("rejects when no correction is requested", () => {
       const r = convertCalendar({ date: { year: 1750 }, corrections: {} });
       expect(r.ok).toBe(false);
+    });
+    it("rejects an invalid quakerMonth.era (exported function is called outside the MCP enum)", () => {
+      const r = convertCalendar({ date: { year: 1740, month: 1 }, corrections: { quakerMonth: { era: "bogus" as any } } });
+      expect(r.ok).toBe(false);
+      if (r.ok) return;
+      expect(r.errors.join(" ")).toMatch(/era must be/);
+    });
+    it("rejects julianToGregorianDay before the 1582 Gregorian introduction", () => {
+      const r = convertCalendar({ date: { year: 1500, month: 1, day: 1 }, corrections: { julianToGregorianDay: true } });
+      expect(r.ok).toBe(false);
+      if (r.ok) return;
+      expect(r.errors.join(" ")).toMatch(/1582/);
+    });
+    it("rejects a doubleYear inconsistent with year + 1", () => {
+      const r = convertCalendar({ date: { year: 1750, doubleYear: 9 }, corrections: { doubleDatedYear: true } });
+      expect(r.ok).toBe(false);
+      if (r.ok) return;
+      expect(r.errors.join(" ")).toMatch(/doubleYear/);
     });
     it("rejects an out-of-range month/day", () => {
       expect(convertCalendar({ date: { year: 1750, month: 13 }, corrections: { osNsYear: true } }).ok).toBe(false);

--- a/packages/engine/mcp-server/tests/tools/convert-calendar.test.ts
+++ b/packages/engine/mcp-server/tests/tools/convert-calendar.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect } from "vitest";
+import { convertCalendar } from "../../src/tools/convert-calendar.js";
+
+describe("convert_calendar", () => {
+  describe("doubleDatedYear", () => {
+    it("resolves '1750/1' to the later New-Style year", () => {
+      const r = convertCalendar({
+        date: { year: 1750, month: 3, day: 25, doubleYear: 1 },
+        corrections: { doubleDatedYear: true },
+      });
+      expect(r.ok).toBe(true);
+      if (!r.ok) return;
+      expect(r.converted).toEqual({ year: 1751, month: 3, day: 25 });
+      expect(r.applied.map((a) => a.correction)).toEqual(["doubleDatedYear"]);
+    });
+  });
+
+  describe("osNsYear", () => {
+    it("bumps a February date in a pre-1752 jurisdiction", () => {
+      const r = convertCalendar({ date: { year: 1720, month: 2, day: 15 }, corrections: { osNsYear: true } });
+      expect(r.ok && r.converted.year).toBe(1721);
+    });
+    it("leaves a June date unchanged", () => {
+      const r = convertCalendar({ date: { year: 1720, month: 6, day: 15 }, corrections: { osNsYear: true } });
+      expect(r.ok && r.converted.year).toBe(1720);
+    });
+    it("bumps on the Mar 24 boundary but not Mar 25", () => {
+      const before = convertCalendar({ date: { year: 1720, month: 3, day: 24 }, corrections: { osNsYear: true } });
+      const after = convertCalendar({ date: { year: 1720, month: 3, day: 25 }, corrections: { osNsYear: true } });
+      expect(before.ok && before.converted.year).toBe(1721);
+      expect(after.ok && after.converted.year).toBe(1720);
+    });
+    it("notes ambiguity for a March date with no day", () => {
+      const r = convertCalendar({ date: { year: 1720, month: 3 }, corrections: { osNsYear: true } });
+      expect(r.ok).toBe(true);
+      if (!r.ok) return;
+      expect(r.converted.year).toBe(1720);
+      expect(r.notes.join(" ")).toMatch(/ambiguous/);
+    });
+    it("requires a month", () => {
+      const r = convertCalendar({ date: { year: 1720 }, corrections: { osNsYear: true } });
+      expect(r.ok).toBe(false);
+    });
+  });
+
+  describe("quakerMonth", () => {
+    it("pre-1752: 1st month is March", () => {
+      const r = convertCalendar({ date: { year: 1740, month: 1, day: 3 }, corrections: { quakerMonth: { era: "pre_1752" } } });
+      expect(r.ok && r.converted).toEqual({ year: 1740, month: 3, day: 3 });
+    });
+    it("pre-1752: 11th month rolls into January of the next year", () => {
+      const r = convertCalendar({ date: { year: 1740, month: 11, day: 3 }, corrections: { quakerMonth: { era: "pre_1752" } } });
+      expect(r.ok && r.converted).toEqual({ year: 1741, month: 1, day: 3 });
+    });
+    it("post-1752: 1st month is January", () => {
+      const r = convertCalendar({ date: { year: 1760, month: 1, day: 3 }, corrections: { quakerMonth: { era: "post_1752" } } });
+      expect(r.ok && r.converted).toEqual({ year: 1760, month: 1, day: 3 });
+    });
+  });
+
+  describe("julianToGregorianDay", () => {
+    const offset = (year: number) => {
+      const r = convertCalendar({ date: { year, month: 6, day: 15 }, corrections: { julianToGregorianDay: true } });
+      if (!r.ok) throw new Error("unexpected");
+      return r.applied.find((a) => a.correction === "julianToGregorianDay")?.offsetDays;
+    };
+    it("applies the era-appropriate offset (10/11/12/13)", () => {
+      expect(offset(1690)).toBe(10);
+      expect(offset(1750)).toBe(11);
+      expect(offset(1850)).toBe(12);
+      expect(offset(1950)).toBe(13);
+    });
+    it("converts the 1752 English cutover date Sep 2 → Sep 13", () => {
+      const r = convertCalendar({ date: { year: 1752, month: 9, day: 2 }, corrections: { julianToGregorianDay: true } });
+      expect(r.ok && r.converted).toEqual({ year: 1752, month: 9, day: 13 });
+    });
+    it("skips (with a note) when the day is missing", () => {
+      const r = convertCalendar({ date: { year: 1752, month: 9 }, corrections: { julianToGregorianDay: true } });
+      expect(r.ok).toBe(true);
+      if (!r.ok) return;
+      expect(r.applied).toHaveLength(0);
+      expect(r.notes.join(" ")).toMatch(/day offset not applied/);
+    });
+  });
+
+  describe("composition + discipline", () => {
+    it("applies only the requested correction (no unprompted day shift)", () => {
+      const r = convertCalendar({
+        date: { year: 1750, month: 3, day: 25, doubleYear: 1 },
+        corrections: { doubleDatedYear: true },
+      });
+      expect(r.ok).toBe(true);
+      if (!r.ok) return;
+      // year resolved, but day/month untouched and no offset applied.
+      expect(r.converted).toEqual({ year: 1751, month: 3, day: 25 });
+      expect(r.applied.some((a) => a.correction === "julianToGregorianDay")).toBe(false);
+    });
+    it("applies year then day offset in order", () => {
+      const r = convertCalendar({
+        date: { year: 1720, month: 2, day: 15 },
+        corrections: { osNsYear: true, julianToGregorianDay: true },
+      });
+      expect(r.ok).toBe(true);
+      if (!r.ok) return;
+      // OS/NS bumps to 1721, then +11 days → 26 Feb 1721 Gregorian.
+      expect(r.converted).toEqual({ year: 1721, month: 2, day: 26 });
+      expect(r.applied.map((a) => a.correction)).toEqual(["osNsYear", "julianToGregorianDay"]);
+    });
+  });
+
+  describe("errors + purity", () => {
+    it("rejects when no correction is requested", () => {
+      const r = convertCalendar({ date: { year: 1750 }, corrections: {} });
+      expect(r.ok).toBe(false);
+    });
+    it("rejects an out-of-range month/day", () => {
+      expect(convertCalendar({ date: { year: 1750, month: 13 }, corrections: { osNsYear: true } }).ok).toBe(false);
+      expect(convertCalendar({ date: { year: 1750, month: 1, day: 40 }, corrections: { osNsYear: true } }).ok).toBe(false);
+    });
+    it("does not mutate the input date and is idempotent", () => {
+      const input = { date: { year: 1752, month: 9, day: 2 }, corrections: { julianToGregorianDay: true } };
+      const r1 = convertCalendar(input);
+      const r2 = convertCalendar(input);
+      expect(input.date).toEqual({ year: 1752, month: 9, day: 2 });
+      expect(r1).toEqual(r2);
+    });
+  });
+});

--- a/packages/engine/mcp-server/tests/tools/research-append.test.ts
+++ b/packages/engine/mcp-server/tests/tools/research-append.test.ts
@@ -1,0 +1,202 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtemp, writeFile, readFile, rm } from "fs/promises";
+import { join } from "path";
+import { tmpdir } from "os";
+import { researchAppend } from "../../src/tools/research-append.js";
+
+const citationDetail = {
+  who: "Census enumerator",
+  what: "1850 U.S. Census",
+  when_created: "1850",
+  when_accessed: "2026-01-01",
+  where: "Schuylkill County, Pennsylvania",
+  where_within: "dwelling 201",
+};
+const validSource = (id: string) => ({
+  id,
+  gedcomx_source_description_id: "SD-001",
+  citation: "1850 U.S. Census, Schuylkill County, PA",
+  citation_detail: citationDetail,
+  source_classification: "original",
+  repository: "NARA",
+  access_date: "2026-01-01",
+});
+const validAssertion = (id: string, sourceId = "src_001") => ({
+  id,
+  source_id: sourceId,
+  record_id: "rec1",
+  record_role: "principal",
+  fact_type: "birth",
+  value: "1850",
+  information_quality: "primary",
+  informant: "self",
+  informant_proximity: "self",
+  evidence_type: "direct",
+  extracted_for_question_ids: [],
+});
+
+function baseResearch() {
+  return {
+    project: { id: "rp_001", objective: "Test", status: "active", created: "2026-01-01", updated: "2026-01-01" },
+    questions: [],
+    plans: [],
+    log: [],
+    sources: [validSource("src_001")],
+    assertions: [validAssertion("a_001")],
+    person_evidence: [],
+    conflicts: [],
+    hypotheses: [],
+    timelines: [],
+    proof_summaries: [],
+    evaluations: [],
+  };
+}
+const baseTree = {
+  persons: [{ id: "I1", gender: "Male", names: [{ id: "N1", given: "John", surname: "Smith" }] }],
+  relationships: [],
+  sources: [{ id: "SD-001", title: "1850 U.S. Census" }],
+};
+
+describe("research_append (Phase 1)", () => {
+  let dir: string;
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "research-append-test-"));
+  });
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  async function writeProject(research: any = baseResearch(), tree: any = baseTree) {
+    await writeFile(join(dir, "research.json"), JSON.stringify(research, null, 2));
+    await writeFile(join(dir, "tree.gedcomx.json"), JSON.stringify(tree, null, 2));
+  }
+  const readResearch = async () => JSON.parse(await readFile(join(dir, "research.json"), "utf-8"));
+
+  it("rejects an append entry that carries a real id (the tool assigns ids)", async () => {
+    await writeProject();
+    const r = await researchAppend({
+      projectPath: dir,
+      section: "sources",
+      op: "append",
+      entry: validSource("src_999"),
+    });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.errors.join(" ")).toMatch(/must not carry an id/);
+  });
+
+  it("appends a source (no id) → src_002 and validates", async () => {
+    await writeProject();
+    const { id: _omit, ...sourceNoId } = validSource("x");
+    const r = await researchAppend({ projectPath: dir, section: "sources", op: "append", entry: sourceNoId });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.entryId).toBe("src_002");
+    expect(r.filesWritten).toEqual(["research.json"]);
+    const research = await readResearch();
+    expect(research.sources.map((s: any) => s.id)).toEqual(["src_001", "src_002"]);
+  });
+
+  it("appends an assertion referencing an existing source", async () => {
+    await writeProject();
+    const { id: _omit, ...assertionNoId } = validAssertion("x", "src_001");
+    const r = await researchAppend({ projectPath: dir, section: "assertions", op: "append", entry: assertionNoId });
+    expect(r.ok && r.entryId).toBe("a_002");
+  });
+
+  it("appends a person_evidence link, stamps created, references an existing assertion + tree person", async () => {
+    await writeProject();
+    const r = await researchAppend({
+      projectPath: dir,
+      section: "person_evidence",
+      op: "append",
+      entry: { assertion_id: "a_001", person_id: "I1", confidence: "confident", rationale: "Name + birth year match", superseded_by: null },
+    });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.entryId).toBe("pe_001");
+    const pe = (await readResearch()).person_evidence[0];
+    expect(pe.person_id).toBe("I1");
+    expect(typeof pe.created).toBe("string"); // tool-stamped
+    expect(pe.created.length).toBeGreaterThanOrEqual(10);
+  });
+
+  it("assigns max + 1, not count + 1", async () => {
+    const research = baseResearch();
+    research.sources = [validSource("src_001"), validSource("src_003")];
+    await writeProject(research);
+    const { id: _omit, ...sourceNoId } = validSource("x");
+    const r = await researchAppend({ projectPath: dir, section: "sources", op: "append", entry: sourceNoId });
+    expect(r.ok && r.entryId).toBe("src_004");
+  });
+
+  it("updates a field on an existing entry, preserving the id", async () => {
+    await writeProject();
+    const r = await researchAppend({
+      projectPath: dir,
+      section: "assertions",
+      op: "update",
+      entryId: "a_001",
+      fields: { value: "1851" },
+    });
+    expect(r.ok).toBe(true);
+    const a = (await readResearch()).assertions[0];
+    expect(a.id).toBe("a_001");
+    expect(a.value).toBe("1851");
+  });
+
+  it("supports the person_evidence supersede pattern (append new + update old's superseded_by)", async () => {
+    const research = baseResearch();
+    research.person_evidence = [
+      { id: "pe_001", assertion_id: "a_001", person_id: "I1", confidence: "probable", rationale: "first guess", created: "2026-01-01", superseded_by: null },
+    ];
+    await writeProject(research);
+
+    const appended = await researchAppend({
+      projectPath: dir,
+      section: "person_evidence",
+      op: "append",
+      entry: { assertion_id: "a_001", person_id: "I1", confidence: "confident", rationale: "stronger match", superseded_by: null },
+    });
+    expect(appended.ok && appended.entryId).toBe("pe_002");
+
+    const superseded = await researchAppend({
+      projectPath: dir,
+      section: "person_evidence",
+      op: "update",
+      entryId: "pe_001",
+      fields: { superseded_by: "pe_002" },
+    });
+    expect(superseded.ok).toBe(true);
+    const pe = await readResearch();
+    expect(pe.person_evidence).toHaveLength(2); // old entry not deleted
+    expect(pe.person_evidence.find((e: any) => e.id === "pe_001").superseded_by).toBe("pe_002");
+  });
+
+  it("rejects update of a non-existent id and writes nothing", async () => {
+    await writeProject();
+    const before = await readFile(join(dir, "research.json"), "utf-8");
+    const r = await researchAppend({ projectPath: dir, section: "assertions", op: "update", entryId: "a_999", fields: { value: "x" } });
+    expect(r.ok).toBe(false);
+    expect(await readFile(join(dir, "research.json"), "utf-8")).toBe(before);
+  });
+
+  it("writes nothing when the appended entry would invalidate the project", async () => {
+    await writeProject();
+    const before = await readFile(join(dir, "research.json"), "utf-8");
+    const { id: _omit, ...assertionNoId } = validAssertion("x", "src_999"); // dangling source_id
+    const r = await researchAppend({ projectPath: dir, section: "assertions", op: "append", entry: assertionNoId });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.errors.join(" ")).toMatch(/src_999|source/);
+    expect(await readFile(join(dir, "research.json"), "utf-8")).toBe(before);
+  });
+
+  it("rejects an unsupported section (phase 2/3 not yet implemented)", async () => {
+    await writeProject();
+    const r = await researchAppend({ projectPath: dir, section: "conflicts", op: "append", entry: {} });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.errors.join(" ")).toMatch(/not supported/);
+  });
+});

--- a/packages/engine/mcp-server/tests/tools/research-append.test.ts
+++ b/packages/engine/mcp-server/tests/tools/research-append.test.ts
@@ -192,9 +192,9 @@ describe("research_append (Phase 1)", () => {
     expect(await readFile(join(dir, "research.json"), "utf-8")).toBe(before);
   });
 
-  it("rejects an unsupported section (phase 3 not yet implemented)", async () => {
+  it("rejects an unknown section name", async () => {
     await writeProject();
-    const r = await researchAppend({ projectPath: dir, section: "timelines", op: "append", entry: {} });
+    const r = await researchAppend({ projectPath: dir, section: "bogus_section", op: "append", entry: {} });
     expect(r.ok).toBe(false);
     if (r.ok) return;
     expect(r.errors.join(" ")).toMatch(/not supported/);
@@ -419,5 +419,94 @@ describe("research_append (Phase 2)", () => {
     if (!r.ok) return;
     expect(r.filesWritten).toEqual([]); // no-op, nothing written
     expect(await readFile(join(dir, "research.json"), "utf-8")).toBe(before);
+  });
+});
+
+// ─── Phase 3 ───────────────────────────────────────────────────────────────
+
+describe("research_append (Phase 3)", () => {
+  let dir: string;
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "research-append-p3-"));
+  });
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  function phase3Research() {
+    const r = baseResearch();
+    r.questions = [validQuestion("q_001")];
+    return r;
+  }
+  async function writeProject(research: any = phase3Research(), tree: any = baseTree) {
+    await writeFile(join(dir, "research.json"), JSON.stringify(research, null, 2));
+    await writeFile(join(dir, "tree.gedcomx.json"), JSON.stringify(tree, null, 2));
+  }
+  const readResearch = async () => JSON.parse(await readFile(join(dir, "research.json"), "utf-8"));
+
+  it("appends a timeline and stamps `generated` (datetime), refs an existing person", async () => {
+    await writeProject();
+    const r = await researchAppend({
+      projectPath: dir,
+      section: "timelines",
+      op: "append",
+      entry: { label: "John Smith timeline", person_ids: ["I1"], events: [], gaps: [], impossibilities: [] },
+    });
+    expect(r.ok && r.entryId).toBe("t_001");
+    const t = (await readResearch()).timelines[0];
+    expect(t.generated).toMatch(/T.*:/); // ISO datetime, not a bare date
+  });
+
+  it("appends a proof_summary referencing an existing question", async () => {
+    await writeProject();
+    const r = await researchAppend({
+      projectPath: dir,
+      section: "proof_summaries",
+      op: "append",
+      entry: {
+        question_id: "q_001",
+        tier: "probable",
+        vehicle: "summary",
+        supporting_assertion_ids: ["a_001"],
+        resolved_conflict_ids: [],
+        exhaustive_search_summary: "Searched census + vitals",
+        narrative_markdown: "## Conclusion\n...",
+      },
+    });
+    expect(r.ok && r.entryId).toBe("ps_001");
+  });
+
+  it("appends an evaluation and stamps `timestamp` (datetime)", async () => {
+    await writeProject();
+    const r = await researchAppend({
+      projectPath: dir,
+      section: "evaluations",
+      op: "append",
+      entry: {
+        focus: "conclusion-readiness",
+        target_id: "q_001",
+        target_type: "question",
+        verdict: "looks_solid",
+        file_path: "evaluations/ev_001.md",
+        superseded_by: null,
+      },
+    });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.entryId).toBe("ev_001");
+    expect((await readResearch()).evaluations[0].timestamp).toMatch(/T.*:/);
+  });
+
+  it("appends a known_holding and stamps `created` (date)", async () => {
+    await writeProject();
+    const r = await researchAppend({
+      projectPath: dir,
+      section: "known_holdings",
+      op: "append",
+      entry: { holding_type: "document", description: "Family bible", confidence: "confident", promoted: false },
+    });
+    expect(r.ok && r.entryId).toBe("kh_001");
+    const kh = (await readResearch()).known_holdings[0];
+    expect(kh.created).toMatch(/^\d{4}-\d{2}-\d{2}$/); // bare date
   });
 });

--- a/packages/engine/mcp-server/tests/tools/research-append.test.ts
+++ b/packages/engine/mcp-server/tests/tools/research-append.test.ts
@@ -192,11 +192,232 @@ describe("research_append (Phase 1)", () => {
     expect(await readFile(join(dir, "research.json"), "utf-8")).toBe(before);
   });
 
-  it("rejects an unsupported section (phase 2/3 not yet implemented)", async () => {
+  it("rejects an unsupported section (phase 3 not yet implemented)", async () => {
     await writeProject();
-    const r = await researchAppend({ projectPath: dir, section: "conflicts", op: "append", entry: {} });
+    const r = await researchAppend({ projectPath: dir, section: "timelines", op: "append", entry: {} });
     expect(r.ok).toBe(false);
     if (r.ok) return;
     expect(r.errors.join(" ")).toMatch(/not supported/);
+  });
+});
+
+// ─── Phase 2 ───────────────────────────────────────────────────────────────
+
+const validQuestion = (id: string) => ({
+  id,
+  question: "Who were the parents of John Smith?",
+  rationale: "Timeline gap before 1850",
+  selection_basis: "objective_decomposition",
+  priority: "high",
+  status: "open",
+  depends_on: [],
+  unblocks: [],
+  created: "2026-01-01",
+  resolved: null,
+  resolution_assertion_ids: [],
+  exhaustive_declaration: { declared: false, log_entry_ids: [] },
+});
+const validPlan = (id: string, questionId: string, status = "active") => ({
+  id,
+  question_id: questionId,
+  status,
+  created: "2026-01-01",
+  items: [],
+});
+const validPlanItem = () => ({
+  sequence: 1,
+  record_type: "census",
+  jurisdiction: "Schuylkill, Pennsylvania, United States",
+  date_range: "1850-1860",
+  repository: "NARA",
+  rationale: "Census should list the household",
+  fallback_for: null,
+  status: "planned",
+});
+const validConflict = () => ({
+  conflict_type: "fact",
+  description: "Two different birth years",
+  competing_assertion_ids: ["a_001", "a_002"],
+  status: "unresolved",
+  blocks_question_ids: [],
+  disputed_attribute: "birth_year",
+});
+const validHypothesis = () => ({
+  claim: "John is the son of Robert",
+  status: "active",
+  supporting_assertion_ids: [],
+  contradicting_assertion_ids: [],
+  ruled_out: false,
+  related_question_ids: [],
+});
+
+describe("research_append (Phase 2)", () => {
+  let dir: string;
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "research-append-p2-"));
+  });
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  function phase2Research() {
+    const r = baseResearch();
+    r.assertions.push(validAssertion("a_002")); // a second assertion for fact-conflict competing
+    r.questions = [validQuestion("q_001")];
+    return r;
+  }
+  async function writeProject(research: any = phase2Research(), tree: any = baseTree) {
+    await writeFile(join(dir, "research.json"), JSON.stringify(research, null, 2));
+    await writeFile(join(dir, "tree.gedcomx.json"), JSON.stringify(tree, null, 2));
+  }
+  const readResearch = async () => JSON.parse(await readFile(join(dir, "research.json"), "utf-8"));
+
+  it("appends a question and stamps created", async () => {
+    await writeProject();
+    const { id: _o, created: _c, ...q } = validQuestion("x");
+    const r = await researchAppend({ projectPath: dir, section: "questions", op: "append", entry: q });
+    expect(r.ok && r.entryId).toBe("q_002");
+    const created = (await readResearch()).questions.find((x: any) => x.id === "q_002").created;
+    expect(typeof created).toBe("string");
+  });
+
+  it("appends a plan, then rejects a second active plan for the same question", async () => {
+    await writeProject();
+    const { id: _o, ...plan } = validPlan("x", "q_001", "active");
+    const first = await researchAppend({ projectPath: dir, section: "plans", op: "append", entry: plan });
+    expect(first.ok && first.entryId).toBe("pl_001");
+
+    const { id: _o2, ...plan2 } = validPlan("y", "q_001", "active");
+    const second = await researchAppend({ projectPath: dir, section: "plans", op: "append", entry: plan2 });
+    expect(second.ok).toBe(false);
+    if (second.ok) return;
+    expect(second.errors.join(" ")).toMatch(/already has an active plan/);
+  });
+
+  it("appends a plan_item into the named plan", async () => {
+    const research = phase2Research();
+    research.plans = [validPlan("pl_001", "q_001", "active")];
+    await writeProject(research);
+    const r = await researchAppend({
+      projectPath: dir,
+      section: "plan_items",
+      op: "append",
+      planId: "pl_001",
+      entry: validPlanItem(),
+    });
+    expect(r.ok && r.entryId).toBe("pli_001");
+    const items = (await readResearch()).plans[0].items;
+    expect(items).toHaveLength(1);
+    expect(items[0].id).toBe("pli_001");
+  });
+
+  it("requires planId for plan_items", async () => {
+    await writeProject();
+    const r = await researchAppend({ projectPath: dir, section: "plan_items", op: "append", entry: validPlanItem() });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.errors.join(" ")).toMatch(/requires a 'planId'/);
+  });
+
+  it("appends a fact conflict referencing two assertions", async () => {
+    await writeProject();
+    const r = await researchAppend({ projectPath: dir, section: "conflicts", op: "append", entry: validConflict() });
+    expect(r.ok && r.entryId).toBe("c_001");
+  });
+
+  it("rejects resolving a conflict without the resolution analysis fields", async () => {
+    const research = phase2Research();
+    research.conflicts = [{ ...validConflict(), id: "c_001" }];
+    await writeProject(research);
+    const r = await researchAppend({
+      projectPath: dir,
+      section: "conflicts",
+      op: "update",
+      entryId: "c_001",
+      fields: { status: "resolved", preferred_assertion_id: "a_001" }, // missing weighing/independence/rationale
+    });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.errors.join(" ")).toMatch(/weighing_analysis|independence_analysis|resolution_rationale/);
+  });
+
+  it("rejects a resolved conflict whose preferred_assertion_id is not among the competing", async () => {
+    const research = phase2Research();
+    research.conflicts = [{ ...validConflict(), id: "c_001" }];
+    await writeProject(research);
+    const r = await researchAppend({
+      projectPath: dir,
+      section: "conflicts",
+      op: "update",
+      entryId: "c_001",
+      fields: {
+        status: "resolved",
+        independence_analysis: "independent sources",
+        weighing_analysis: "census outweighs the later record",
+        resolution_rationale: "primary informant",
+        preferred_assertion_id: "a_999",
+      },
+    });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.errors.join(" ")).toMatch(/preferred_assertion_id/);
+  });
+
+  it("accepts a fully-resolved conflict", async () => {
+    const research = phase2Research();
+    research.conflicts = [{ ...validConflict(), id: "c_001" }];
+    await writeProject(research);
+    const r = await researchAppend({
+      projectPath: dir,
+      section: "conflicts",
+      op: "update",
+      entryId: "c_001",
+      fields: {
+        status: "resolved",
+        independence_analysis: "independent sources",
+        weighing_analysis: "census outweighs the later record",
+        resolution_rationale: "primary informant",
+        preferred_assertion_id: "a_001",
+      },
+    });
+    expect(r.ok).toBe(true);
+    expect((await readResearch()).conflicts[0].status).toBe("resolved");
+  });
+
+  it("rejects ruling out a hypothesis without a reason (validator)", async () => {
+    const research = phase2Research();
+    research.hypotheses = [{ ...validHypothesis(), id: "h_001" }];
+    await writeProject(research);
+    const r = await researchAppend({
+      projectPath: dir,
+      section: "hypotheses",
+      op: "update",
+      entryId: "h_001",
+      fields: { ruled_out: true, status: "ruled_out" },
+    });
+    expect(r.ok).toBe(false);
+  });
+
+  it("treats re-declaring an already-declared question as a no-op", async () => {
+    const research = phase2Research();
+    research.questions = [
+      { ...validQuestion("q_001"), status: "exhaustive_declared", exhaustive_declaration: { declared: true, log_entry_ids: ["log_001"], stop_criteria: {} } },
+    ];
+    research.log = [
+      { id: "log_001", plan_item_id: null, performed: "2026-01-01T00:00:00Z", tool: "record_search", query: {}, outcome: "negative", results_examined: 0, external_site: null, results_ref: null },
+    ];
+    await writeProject(research);
+    const before = await readFile(join(dir, "research.json"), "utf-8");
+    const r = await researchAppend({
+      projectPath: dir,
+      section: "questions",
+      op: "update",
+      entryId: "q_001",
+      fields: { exhaustive_declaration: { declared: true, log_entry_ids: ["log_001", "log_002"], stop_criteria: {} } },
+    });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.filesWritten).toEqual([]); // no-op, nothing written
+    expect(await readFile(join(dir, "research.json"), "utf-8")).toBe(before);
   });
 });

--- a/packages/engine/mcp-server/tests/tools/research-append.test.ts
+++ b/packages/engine/mcp-server/tests/tools/research-append.test.ts
@@ -420,6 +420,32 @@ describe("research_append (Phase 2)", () => {
     expect(r.filesWritten).toEqual([]); // no-op, nothing written
     expect(await readFile(join(dir, "research.json"), "utf-8")).toBe(before);
   });
+
+  it("does NOT no-op a bundled update that re-declares AND changes another field", async () => {
+    const sc = {
+      goal_alignment: true, repository_breadth: true, original_substitution: true,
+      independent_verification: true, evidence_class: true, conflict_resolution: true, overturn_risk: true,
+    };
+    const research = phase2Research();
+    research.questions = [
+      { ...validQuestion("q_001"), status: "exhaustive_declared", priority: "high", exhaustive_declaration: { declared: true, log_entry_ids: ["log_001"], stop_criteria: sc } },
+    ];
+    research.log = [
+      { id: "log_001", plan_item_id: null, performed: "2026-01-01T00:00:00Z", tool: "record_search", query: {}, outcome: "negative", results_examined: 0, external_site: null, results_ref: null },
+    ];
+    await writeProject(research);
+    const r = await researchAppend({
+      projectPath: dir,
+      section: "questions",
+      op: "update",
+      entryId: "q_001",
+      fields: { priority: "low", exhaustive_declaration: { declared: true, log_entry_ids: ["log_001"], stop_criteria: sc } },
+    });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.filesWritten).toEqual(["research.json"]); // wrote — not a no-op
+    expect((await readResearch()).questions[0].priority).toBe("low");
+  });
 });
 
 // ─── Phase 3 ───────────────────────────────────────────────────────────────

--- a/packages/engine/mcp-server/tests/tools/tree-edit.test.ts
+++ b/packages/engine/mcp-server/tests/tools/tree-edit.test.ts
@@ -132,6 +132,36 @@ describe("tree_edit", () => {
     expect(tree.persons.map((p: any) => p.id)).toEqual(["I1", "I2"]);
   });
 
+  it("add_person: normalizes to exactly one preferred name", async () => {
+    await writeProject(onePerson());
+    // two names both flagged preferred → only the first kept
+    const r1 = await treeEdit({
+      projectPath: dir,
+      operation: "add_person",
+      person: {
+        gender: "Female",
+        names: [
+          { given: "Margaret", surname: "Smith", preferred: true },
+          { given: "Maggie", surname: "Smith", preferred: true },
+        ],
+      },
+    });
+    expect(r1.ok).toBe(true);
+    const p2 = (await readTree()).persons.find((p: any) => p.id === "I2");
+    expect(p2.names.filter((n: any) => n.preferred === true)).toHaveLength(1);
+    expect(p2.names[0].preferred).toBe(true);
+
+    // no name flagged preferred → first is marked
+    const r2 = await treeEdit({
+      projectPath: dir,
+      operation: "add_person",
+      person: { gender: "Male", names: [{ given: "Sam", surname: "Smith" }] },
+    });
+    expect(r2.ok).toBe(true);
+    const p3 = (await readTree()).persons.find((p: any) => p.id === "I3");
+    expect(p3.names[0].preferred).toBe(true);
+  });
+
   it("add_relationship: assigns R id and links existing persons", async () => {
     const tree = onePerson();
     tree.persons.push({ id: "I2", gender: "Female", names: [{ id: "N2", given: "Mary", surname: "Smith", preferred: true }], facts: [] } as any);

--- a/packages/engine/mcp-server/tests/tools/tree-edit.test.ts
+++ b/packages/engine/mcp-server/tests/tools/tree-edit.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtemp, writeFile, readFile, rm, access } from "fs/promises";
+import { join } from "path";
+import { tmpdir } from "os";
+
+// Stub the network place resolver so add_fact/update_fact tests are offline and
+// deterministic. The tool calls resolveStandardPlace(place) → standardized name.
+vi.mock("../../src/utils/place-resolver.js", () => ({
+  resolveStandardPlace: vi.fn(async (text: string) =>
+    text === "Schuylkill County, Pennsylvania" ? "Schuylkill, Pennsylvania, United States" : null,
+  ),
+}));
+
+import { treeEdit } from "../../src/tools/tree-edit.js";
+
+const minimalResearch = {
+  project: { id: "rp_001", objective: "Test", status: "active", created: "2026-01-01", updated: "2026-01-01" },
+  questions: [],
+  plans: [],
+  log: [],
+  sources: [],
+  assertions: [],
+  person_evidence: [],
+  conflicts: [],
+  hypotheses: [],
+  timelines: [],
+  proof_summaries: [],
+  evaluations: [],
+};
+
+describe("tree_edit", () => {
+  let dir: string;
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "tree-edit-test-"));
+  });
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  async function writeProject(tree: any, research: any = minimalResearch) {
+    await writeFile(join(dir, "research.json"), JSON.stringify(research, null, 2));
+    await writeFile(join(dir, "tree.gedcomx.json"), JSON.stringify(tree, null, 2));
+  }
+  const readTree = async () => JSON.parse(await readFile(join(dir, "tree.gedcomx.json"), "utf-8"));
+  const exists = async (rel: string) => access(join(dir, rel)).then(() => true, () => false);
+
+  const onePerson = () => ({
+    persons: [
+      {
+        id: "I1",
+        gender: "Male",
+        names: [{ id: "N1", given: "John", surname: "Smith", preferred: true }],
+        facts: [{ id: "F1", type: "Birth", date: "1850", primary: true }],
+      },
+    ],
+    relationships: [],
+    sources: [],
+  });
+
+  it("add_fact: assigns the next F id, resolves standard_place, swaps the primary, writes only the tree + .bak", async () => {
+    await writeProject(onePerson());
+    const researchBefore = await readFile(join(dir, "research.json"), "utf-8");
+
+    const r = await treeEdit({
+      projectPath: dir,
+      operation: "add_fact",
+      personId: "I1",
+      fact: { type: "Birth", date: "1851", place: "Schuylkill County, Pennsylvania", primary: true },
+    });
+
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.assignedIds?.fact).toBe("F2");
+    expect(r.filesWritten).toEqual(["tree.gedcomx.json"]);
+
+    const tree = await readTree();
+    const facts = tree.persons[0].facts;
+    expect(facts).toHaveLength(2);
+    const f2 = facts.find((f: any) => f.id === "F2");
+    expect(f2.standard_place).toBe("Schuylkill, Pennsylvania, United States");
+    expect(f2.primary).toBe(true);
+    // the old Birth lost its primary (one primary per type)
+    expect(facts.find((f: any) => f.id === "F1").primary).toBeUndefined();
+
+    expect(await exists("tree.gedcomx.json.bak")).toBe(true);
+    expect(await readFile(join(dir, "research.json"), "utf-8")).toBe(researchBefore);
+  });
+
+  it("update_fact: merges fields by id and re-resolves standard_place on a place change", async () => {
+    await writeProject(onePerson());
+    const r = await treeEdit({
+      projectPath: dir,
+      operation: "update_fact",
+      personId: "I1",
+      factId: "F1",
+      fact: { date: "1849", place: "Schuylkill County, Pennsylvania" },
+    });
+    expect(r.ok).toBe(true);
+    const f1 = (await readTree()).persons[0].facts[0];
+    expect(f1.date).toBe("1849");
+    expect(f1.standard_place).toBe("Schuylkill, Pennsylvania, United States");
+    expect(f1.id).toBe("F1");
+  });
+
+  it("add_name: assigns N id and moves the preferred flag", async () => {
+    await writeProject(onePerson());
+    const r = await treeEdit({
+      projectPath: dir,
+      operation: "add_name",
+      personId: "I1",
+      name: { given: "Johnny", surname: "Smith", preferred: true },
+    });
+    expect(r.ok && r.assignedIds?.name).toBe("N2");
+    const names = (await readTree()).persons[0].names;
+    expect(names).toHaveLength(2);
+    expect(names.find((n: any) => n.id === "N1").preferred).toBeUndefined();
+    expect(names.find((n: any) => n.id === "N2").preferred).toBe(true);
+  });
+
+  it("add_person: assigns I + N ids", async () => {
+    await writeProject(onePerson());
+    const r = await treeEdit({
+      projectPath: dir,
+      operation: "add_person",
+      person: { gender: "Female", names: [{ given: "Margaret", surname: "Smith", preferred: true }] },
+    });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.assignedIds?.person).toBe("I2");
+    expect(r.assignedIds?.names).toEqual(["N2"]);
+    const tree = await readTree();
+    expect(tree.persons.map((p: any) => p.id)).toEqual(["I1", "I2"]);
+  });
+
+  it("add_relationship: assigns R id and links existing persons", async () => {
+    const tree = onePerson();
+    tree.persons.push({ id: "I2", gender: "Female", names: [{ id: "N2", given: "Mary", surname: "Smith", preferred: true }], facts: [] } as any);
+    await writeProject(tree);
+    const r = await treeEdit({
+      projectPath: dir,
+      operation: "add_relationship",
+      relationship: { type: "Couple", person1: "I1", person2: "I2" },
+    });
+    expect(r.ok && r.assignedIds?.relationship).toBe("R1");
+    expect((await readTree()).relationships[0]).toMatchObject({ id: "R1", type: "Couple", person1: "I1", person2: "I2" });
+  });
+
+  it("remove: deletes a fact by id; refuses to remove a person", async () => {
+    await writeProject(onePerson());
+    const ok = await treeEdit({ projectPath: dir, operation: "remove", factId: "F1" });
+    // removing the only Birth is structurally fine (person still has a name); validates.
+    expect(ok.ok).toBe(true);
+    expect((await readTree()).persons[0].facts).toHaveLength(0);
+
+    const bad = await treeEdit({ projectPath: dir, operation: "remove", personId: "I1" });
+    expect(bad.ok).toBe(false);
+    if (bad.ok) return;
+    expect(bad.errors.join(" ")).toMatch(/merge_tree_persons/);
+  });
+
+  it("rejects a stale target id and writes nothing", async () => {
+    await writeProject(onePerson());
+    const treeBefore = await readFile(join(dir, "tree.gedcomx.json"), "utf-8");
+    const r = await treeEdit({ projectPath: dir, operation: "update_fact", personId: "I1", factId: "F999", fact: { date: "1800" } });
+    expect(r.ok).toBe(false);
+    expect(await readFile(join(dir, "tree.gedcomx.json"), "utf-8")).toBe(treeBefore);
+    expect(await exists("tree.gedcomx.json.bak")).toBe(false);
+  });
+
+  it("rejects an add_person payload that carries an id", async () => {
+    await writeProject(onePerson());
+    const r = await treeEdit({ projectPath: dir, operation: "add_person", person: { id: "I9", gender: "Male", names: [{ given: "X", surname: "Y" }] } as any });
+    expect(r.ok).toBe(false);
+  });
+
+  it("writes nothing when the edit would invalidate the project", async () => {
+    await writeProject(onePerson());
+    const treeBefore = await readFile(join(dir, "tree.gedcomx.json"), "utf-8");
+    // A ParentChild relationship referencing a non-existent child fails validation.
+    const r = await treeEdit({
+      projectPath: dir,
+      operation: "add_relationship",
+      relationship: { type: "ParentChild", parent: "I1", child: "I_GHOST" },
+    });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.errors.join(" ")).toMatch(/I_GHOST/);
+    expect(await readFile(join(dir, "tree.gedcomx.json"), "utf-8")).toBe(treeBefore);
+    expect(await exists("tree.gedcomx.json.bak")).toBe(false);
+  });
+});


### PR DESCRIPTION
Second batch of the skill-determinism migration (the first batch — merge tools, `research_log_append`, search-result staging, the shared write layer — landed in #397). From a 26-skill audit of hand-done work that belongs in deterministic code, three new MCP tools, each specced then implemented and adversarially reviewed:

- **`convert_calendar`** — Julian↔Gregorian / Old-Style→New-Style year / Quaker numbered-month arithmetic the `convert-dates` skill does by hand. JDN-based (correct era offsets 10/11/12/13 across the 1700/1800/1900 leap-skip thresholds); writes nothing.
- **`tree_edit`** — single-entity `tree.gedcomx.json` mutations (add/update fact, name, person, relationship; remove fact/relationship — never a person; that stays with the merge tools). One tool with an `operation` discriminator. Reuses the shipped write layer; lifts `maxIdNum`/`nextId` into `src/utils/gedcomx-ids.ts`.
- **`research_append`** — structured writer for the mutable `research.json` sections (sources, assertions, person_evidence, questions, plans, plan_items, conflicts, hypotheses, timelines, proof_summaries, evaluations, known_holdings). Append + in-place update, supersede-not-delete, with the coupling invariants the validator doesn't already enforce. Distinct from `research_log_append` (log only — two-file + sidecar + staging, strictly append-only).

Each tool: validate-before-persist, atomic write, compact return, camelCase→snake_case at the boundary; the tree-writers also write a one-deep `.bak`.

**Quality:** full suite **1005/1005**, typecheck + build clean, manifest↔schema parity holds. An adversarial spec-review pass found `tree_edit` and `research_append` compliant and **two real bugs in `convert_calendar`** (invalid `quakerMonth.era` silently treated as pre-1752; pre-1582 `julianToGregorianDay` emitting a meaningless offset — both in paths the MCP enum doesn't guard since the function is called by `conflict-resolution`); both fixed with tests (commit `e8cf502`).

Specs: `docs/specs/{convert-calendar,tree-edit,research-append}-tool-spec.md`.

Follow-up (not in this PR): the consolidated by-skill rewrite pass that points the consuming skills at these tools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)