### PR TITLE
Rewrite skills to call the structured-persistence + deterministic tools

### DIFF
--- a/docs/specs/skill-rewrites-for-persistence-tools-spec.md
+++ b/docs/specs/skill-rewrites-for-persistence-tools-spec.md
@@ -176,10 +176,19 @@ arithmetic). The skill keeps every analytical decision. A determinism audit of a
   (add source / `add_fact` / `update_fact`); a tier-downgrade removal →
   `tree_edit({ operation: "remove", factId | relationshipId })`.
 - **Wave 1 — Step 6 person merging:** `merge_tree_persons` (or `merge_record_into_tree`).
-- **Wave 2 — Step 7 resolve question:** `research_append({ section: "questions",
-  op: "update", fields: { status: "resolved", resolved, resolution_assertion_ids } })`.
+- **Step 7 — DO NOT resolve the question here.** Proof-conclusion deliberately
+  does **not** write the `questions` section — marking a question `resolved` (and
+  setting `resolved` / `resolution_assertion_ids`) is `question-selection`'s job,
+  and `exhaustive_declaration` is `research-exhaustiveness`'s. Leave §7 ("Do not
+  modify the question") intact. (An earlier draft of this spec wrongly listed a
+  `research_append` questions-update here — that reverses the skill's standing
+  ownership boundary and must not be applied.)
 - **Trim:** Step 6's hand S-entry field table and the manual primary swap; the
   post-write validate step.
+- **Known limits (leave hand-done):** the `S` source-description entry in
+  `tree.gedcomx.json` (Step 6) — `tree_edit` has no source operation yet, so the
+  source write stays by hand; and `project.status` (Step 8) — `research_append`
+  has no `project` section yet (§5 gap).
 
 ---
 
@@ -196,6 +205,11 @@ arithmetic). The skill keeps every analytical decision. A determinism audit of a
   `project.status: "completed"`, but `research_append` has no `project` section yet
   (deferred). Until it does, that one update stays hand-done (or extend
   `research_append` with a `project` single-object section — small follow-up).
+- **Known gap — tree source descriptions.** `record-extraction` (the `S` entry)
+  and `proof-conclusion` (Step 6 "ensure every cited source has a GedcomX `S`
+  entry") write `tree.gedcomx.json` `sources[]`, but `tree_edit` has no source
+  operation. Those source writes stay hand-done until `tree_edit` gains
+  `add_source` / `update_source` (a small follow-up to the tree-edit tool).
 - **`allowed-tools` frontmatter** updated per skill; `validate_research_schema`
   dropped where it was only the post-write backstop (it remains a user-invokable
   audit tool).

--- a/packages/engine/plugin/skills/assertion-classification/SKILL.md
+++ b/packages/engine/plugin/skills/assertion-classification/SKILL.md
@@ -13,7 +13,8 @@ description: Refines GPS three-layer evidence classifications on assertions in r
   resolve conflicting evidence (use conflict-resolution), or wants to
   write a conclusion (use proof-conclusion).
 allowed-tools:
-  - validate_research_schema
+  - research_append
+  - person_warnings
 ---
 
 # Assertion Classification
@@ -197,26 +198,44 @@ assertion, write the correction. Steps 6-7 run whenever any
 classification field changed during analysis, not only when the user
 said "fix it."
 
-Write the refined classifications back to `research.json`. For each
-assertion updated, change:
-- `information_quality` -- if the refined value differs from
-  record-extraction's best-effort
-- `informant` -- if the analysis identifies a more specific informant
-- `informant_proximity` -- if the analysis changes the proximity
-- `informant_bias_notes` -- add bias analysis if relevant
-- `evidence_type` -- if the refined classification differs
-- `extracted_for_question_ids` -- add any newly relevant question IDs
+Write the refined classifications back to `research.json` with one
+`research_append` call per assertion, using `op: "update"` (never
+`append` — this skill only refines existing assertions, it never
+creates them):
 
-Do NOT change: `id`, `source_id`, `record_id`, `record_role`,
-`fact_type`, `value`, `structured_value`, `date`, `date_certainty`,
-`place`, `log_entry_id`. These are set by record-extraction and are
-immutable.
+```
+research_append({
+  projectPath: "<absolute-path-to-project-directory>",
+  section: "assertions",
+  op: "update",
+  entryId: "<assertion id, e.g. a_012>",
+  fields: {
+    information_quality: "...",   // if the refined value differs from record-extraction's best-effort
+    informant: "...",             // if the analysis identifies a more specific informant
+    informant_proximity: "...",   // if the analysis changes the proximity
+    informant_bias_notes: "...",  // add bias analysis if relevant
+    evidence_type: "...",         // if the refined classification differs
+    extracted_for_question_ids: [ ... ]  // add any newly relevant question IDs
+  }
+})
+```
 
-### 7. Validate
+Pass only the classification fields that actually changed. You only ever
+pass classification fields; the immutable fields (`id`, `source_id`,
+`record_id`, `record_role`, `fact_type`, `value`, `structured_value`,
+`date`, `date_certainty`, `place`, `log_entry_id` — all set by
+record-extraction) are not yours to pass and the tool will not let you
+mutate them. The tool validates each update before persisting and writes
+nothing on `{ ok: false, errors }`; surface those errors to the user
+rather than retrying blindly.
 
-Call `validate_research_schema({ projectPath: "<absolute-path-to-project-directory>" })`
-to verify both research.json and tree.gedcomx.json are valid. If validation
-fails, fix the errors before presenting.
+### 7. Check warnings
+
+After writing the refined classifications, invoke `check-warnings` on the
+affected persons to catch genealogical impossibilities (married before 12,
+died after 120, child born after a parent's death, etc.). This checks
+plausibility, which the persistence step does not. Surface any warnings to
+the user.
 
 ### 8. Present results
 

--- a/packages/engine/plugin/skills/assertion-classification/references/validation-protocol.md
+++ b/packages/engine/plugin/skills/assertion-classification/references/validation-protocol.md
@@ -1,14 +1,13 @@
 # Validation Protocol
 
-After writing to `research.json` or `tree.gedcomx.json`, follow these steps:
+The persistence tools (`research_append`, `tree_edit`, and the merge
+tools) validate-before-persist: they check the document against the
+published schema and write nothing on `{ ok: false, errors }`. So a
+structural schema pass is no longer a separate step — surface any
+returned errors instead of re-validating by hand.
 
-1. **Invoke `validate-schema`** to verify both files conform to the
-   published schemas. If validation fails, fix the errors before
-   proceeding.
-
-2. **Invoke `check-warnings`** if you added assertions or
-   person_evidence entries. This checks for genealogical
-   impossibilities (married before 12, died after 120, child born
-   after parent's death, etc.).
-
-These are not auto-triggered — you must invoke them explicitly.
+**Invoke `check-warnings`** after writing assertions or person_evidence
+entries. This checks for genealogical impossibilities (married before 12,
+died after 120, child born after a parent's death, etc.) — plausibility,
+not structure, which the persistence step does not cover. It is not
+auto-triggered; you must invoke it explicitly.

--- a/packages/engine/plugin/skills/conflict-resolution/SKILL.md
+++ b/packages/engine/plugin/skills/conflict-resolution/SKILL.md
@@ -5,7 +5,8 @@ allowed-tools:
   - place_search
   - place_search_all
   - place_distance
-  - validate_research_schema
+  - research_append
+  - convert_calendar
 description: Identifies and resolves conflicting genealogical evidence —
   both fact-level conflicts (three different birthplaces) and identity-level
   conflicts where multiple candidate persons or records genuinely compete
@@ -100,47 +101,62 @@ Look for:
 
 ### 2. Create the conflict entry
 
-For each new conflict identified:
+For each new conflict identified, append it to the `conflicts`
+section with `research_append`. Pass the entry in snake_case
+**without an id** — the tool assigns the next `c_` id, validates
+the whole project, and writes atomically:
 
-```json
-{
-  "id": "c_002",
-  "conflict_type": "fact",
-  "description": "Patrick Flynn's birth year: 1845 (1850 census, age 5) vs. 1843 (delayed birth certificate)",
-  "disputed_attribute": "birth_year",
-  "identity_question": null,
-  "competing_assertion_ids": ["a_002", "a_025"],
-  "independence_analysis": null,
-  "weighing_analysis": null,
-  "preferred_assertion_id": null,
-  "resolution_rationale": null,
-  "status": "unresolved",
-  "blocks_question_ids": []
-}
+```
+research_append({
+  projectPath: "<absolute-path-to-project-directory>",
+  section: "conflicts",
+  op: "append",
+  entry: {
+    "conflict_type": "fact",
+    "description": "Patrick Flynn's birth year: 1845 (1850 census, age 5) vs. 1843 (delayed birth certificate)",
+    "disputed_attribute": "birth_year",
+    "identity_question": null,
+    "competing_assertion_ids": ["a_002", "a_025"],
+    "independence_analysis": null,
+    "weighing_analysis": null,
+    "preferred_assertion_id": null,
+    "resolution_rationale": null,
+    "status": "unresolved",
+    "blocks_question_ids": []
+  }
+})
 ```
 
-For identity conflicts:
+For identity conflicts, the same call with the identity shape:
 
-```json
-{
-  "id": "c_003",
-  "conflict_type": "identity",
-  "description": "Is the Patrick Flynn in the 1870 Allegheny County census (a_030) our subject from Schuylkill County?",
-  "disputed_attribute": null,
-  "identity_question": "Is the Patrick Flynn in the 1870 Allegheny County census the same as Patrick Flynn (KWCJ-RN4) from Schuylkill County?",
-  "competing_assertion_ids": ["a_030"],
-  "independence_analysis": null,
-  "weighing_analysis": null,
-  "preferred_assertion_id": null,
-  "resolution_rationale": null,
-  "status": "unresolved",
-  "blocks_question_ids": ["q_004"]
-}
+```
+research_append({
+  projectPath: "<absolute-path-to-project-directory>",
+  section: "conflicts",
+  op: "append",
+  entry: {
+    "conflict_type": "identity",
+    "description": "Is the Patrick Flynn in the 1870 Allegheny County census (a_030) our subject from Schuylkill County?",
+    "disputed_attribute": null,
+    "identity_question": "Is the Patrick Flynn in the 1870 Allegheny County census the same as Patrick Flynn (KWCJ-RN4) from Schuylkill County?",
+    "competing_assertion_ids": ["a_030"],
+    "independence_analysis": null,
+    "weighing_analysis": null,
+    "preferred_assertion_id": null,
+    "resolution_rationale": null,
+    "status": "unresolved",
+    "blocks_question_ids": ["q_004"]
+  }
+})
 ```
 
 Set `blocks_question_ids` when the unresolved conflict prevents
 safe downstream work — e.g., you can't conclude parentage if you
 don't know which census records belong to the subject.
+
+If the call returns `{ ok: false, errors }`, the entry was **not**
+written — read the errors, fix the entry shape (or the referenced
+assertion ids), and call again. Do not retry blindly.
 
 ### 3. Analyze source independence (GPS Standard 46)
 
@@ -189,10 +205,47 @@ extensive rail networks). A quantified distance strengthens or
 eliminates a travel-impossibility argument far more than a subjective
 description of "distant locations."
 
+**For date conflicts that a calendar transition might explain:** when
+you suspect the discrepancy is a Julian→Gregorian artifact rather than a
+genuine error (see the calendar-change pattern in
+`references/historical-contradictions.md`), do not compute the
+10/11/12/13-day offset by hand. Call
+`convert_calendar({ date, corrections: { julianToGregorianDay: true } })`
+on the recorded date and read `applied[].offsetDays` for the
+era-appropriate offset. If the two competing dates differ by exactly that
+offset, the conflict is an artifact of the calendar switch, not a
+substantive disagreement — note that in the weighing analysis. (You still
+decide *whether* a calendar correction applies; the tool only does the
+arithmetic.)
+
 ### 5. Resolve or defer
 
-**If the preponderance is clear:** Set `preferred_assertion_id` and
-write `resolution_rationale`. Set `status: "resolved"`.
+**If the preponderance is clear:** update the conflict entry with
+`research_append`, filling all four resolved fields plus the status on
+the same write — the tool enforces the resolved-completeness invariant
+(every field non-null) and `preferred_assertion_id ∈
+competing_assertion_ids`, validates, and writes atomically:
+
+```
+research_append({
+  projectPath: "<absolute-path-to-project-directory>",
+  section: "conflicts",
+  op: "update",
+  entryId: "c_002",
+  fields: {
+    "independence_analysis": "<prose>",
+    "weighing_analysis": "<prose>",
+    "resolution_rationale": "<four-part prose, see below>",
+    "preferred_assertion_id": "a_002",
+    "status": "resolved"
+  }
+})
+```
+
+If the call returns `{ ok: false, errors }`, nothing was written —
+read the errors (a half-filled "resolved", or a `preferred_assertion_id`
+not among the competing set, will be rejected here), correct the
+`fields`, and call again. Do not retry blindly.
 
 The `resolution_rationale` must follow the **four-part structure**
 (see `references/resolution-writing.md` for full guidance):
@@ -231,7 +284,8 @@ preferred answer, the resolution must follow the evidence.
 
 **If more evidence is needed (Standard 49):** Deferral is a
 documented finding, not a stopping point — persist it to the
-conflict record, not only to your reply. On the same write, fill
+conflict record (a `research_append` `op: "update"` call as above),
+not only to your reply. On the same write, fill
 `independence_analysis` and `weighing_analysis` with the work you
 did (these are required regardless of outcome — you analyzed the
 conflict even if you could not resolve it), keep `status:
@@ -302,11 +356,12 @@ section here; recommend the owning skill for any person/link work):
   and `weighing_analysis` fields anyway, and name the records that
   would decide it (see "If more evidence is needed" above).
 
-### 7. Validate and present
+### 7. Present
 
-Call `validate_research_schema({ projectPath: "<absolute-path-to-project-directory>" })`
-to verify both research.json and tree.gedcomx.json are valid. If validation
-fails, fix the errors before presenting. Present each conflict with:
+`research_append` validates the whole project before persisting and
+writes nothing on `{ ok: false }`, so a successful write is already
+schema-valid — no separate validation pass is needed. Present each
+conflict with:
 - The competing assertions and their classifications
 - The independence analysis
 - The weighing analysis

--- a/packages/engine/plugin/skills/conflict-resolution/references/validation-protocol.md
+++ b/packages/engine/plugin/skills/conflict-resolution/references/validation-protocol.md
@@ -1,14 +1,16 @@
 # Validation Protocol
 
-After writing to `research.json` or `tree.gedcomx.json`, follow these steps:
+The persistence tools (`research_append`, the merge / `tree_edit`
+tools) validate the whole project before writing and persist nothing
+on `{ ok: false, errors }` — a successful write is already
+schema-valid, so no separate post-write schema validation is needed.
 
-1. **Invoke `validate-schema`** to verify both files conform to the
-   published schemas. If validation fails, fix the errors before
-   proceeding.
+After writing, still:
 
-2. **Invoke `check-warnings`** if you added assertions or
+1. **Invoke `check-warnings`** if you added assertions or
    person_evidence entries. This checks for genealogical
    impossibilities (married before 12, died after 120, child born
-   after parent's death, etc.).
+   after parent's death, etc.) — plausibility, not structure, so the
+   write tools do not cover it.
 
-These are not auto-triggered — you must invoke them explicitly.
+This is not auto-triggered — you must invoke it explicitly.

--- a/packages/engine/plugin/skills/convert-dates/SKILL.md
+++ b/packages/engine/plugin/skills/convert-dates/SKILL.md
@@ -14,6 +14,8 @@ description: Use when a genealogist asks to convert a date "to the
   (use validate-schema), source conflicts where both records used the
   same calendar (use conflict-resolution), and explanations of why a
   calendar convention existed (use historical-context).
+allowed-tools:
+  - convert_calendar
 ---
 
 # Convert Dates
@@ -59,10 +61,38 @@ Do not answer it by performing a conversion the user did not ask for.
 
 ## How the conversion works
 
-This is a knowledge skill — there is no MCP tool to call. The conversion
-is deterministic arithmetic you perform in context from the jurisdiction,
-the era, and the tables below. (A `convert_calendar` tool is specced for
-the future but is **not yet implemented** — do not attempt to call it.)
+The conversion arithmetic runs in the `convert_calendar` MCP tool. Your
+job is the judgment — read the regime off the record (jurisdiction, era,
+which calendar was in force) using the tables below, decide whether
+conversion is even needed, and decide **which** corrections the user
+actually asked for. The tool does only the arithmetic, in a fixed order,
+and never bundles a correction you didn't request. It writes nothing.
+
+Call it with the recorded date as structured fields and exactly the
+corrections you want:
+
+```
+convert_calendar({
+  date: { year, month?, day?, doubleYear? },
+  corrections: {
+    doubleDatedYear?: true,                  // resolve "1750/1" → later year
+    osNsYear?: true,                         // Jan 1–Mar 24 → year + 1
+    quakerMonth?: { era: "pre_1752" | "post_1752" }, // `month` is the Quaker ordinal
+    julianToGregorianDay?: true,             // add the era day offset (10–13)
+  },
+})
+```
+
+It returns `{ ok: true, original, converted, applied, notes }`. Narrate
+from `applied[].rule` (one per correction, with `offsetDays` on the day
+shift) and `notes[]` (e.g. a day was omitted so the offset was skipped),
+and present `converted` next to `original`.
+
+If the call returns `{ ok: false, errors }` (e.g. a missing `month` for an
+OS/NS check, or a Julian day offset requested before 1582-10-15), surface
+the error and the missing input to the user rather than retrying blindly
+or falling back to hand arithmetic — fix the input or the regime choice
+and call again.
 
 ## Calendar systems relevant to genealogy
 
@@ -152,43 +182,70 @@ Critical — the conversion depends on WHERE and WHEN:
 
 ### 3. Apply the conversion
 
-Work it from the tables above:
-- Apply the Old Style → New Style **year** correction if the date falls
-  between January 1 and March 24 in a pre-transition jurisdiction.
-- Apply the Julian → Gregorian **day** offset (10–13 days, depending on
-  jurisdiction and era) when a full Gregorian equivalent is needed.
-- Resolve Quaker month numbering against the pre-/post-1752 shift.
+Use the tables above to decide the regime, then call `convert_calendar`
+with **only** the corrections the user asked for — the tool does the
+arithmetic:
 
-If you can't determine the jurisdiction or which calendar was in use,
-flag the ambiguity rather than guessing.
+- Old Style → New Style **year** (date between January 1 and March 24 in
+  a pre-transition jurisdiction): `corrections: { osNsYear: true }`.
+- Double-dated year like "1750/1": pass `date: { year: 1750, doubleYear: 1 }`
+  with `corrections: { doubleDatedYear: true }` — the tool returns the
+  later (New Style) year.
+- Julian → Gregorian **day** offset (10–13 days, when a full Gregorian
+  equivalent is needed): `corrections: { julianToGregorianDay: true }`
+  with a full `year/month/day`. The tool picks the era offset and reports
+  it as `applied[].offsetDays`.
+- Quaker month numbering: pass the Quaker ordinal as `date.month` with
+  `corrections: { quakerMonth: { era: "pre_1752" | "post_1752" } }`.
+
+Request each correction separately and only when asked (see "Answer only
+the calendar question that was asked" below). If you can't determine the
+jurisdiction or which calendar was in use, flag the ambiguity rather than
+guessing — do not call the tool on a regime you haven't pinned down.
 
 ### 4. Present the conversion
 
-Show the user:
-- Original date and system
-- Converted date
-- The rule that applies
+Narrate from the tool's result. Show the user:
+- Original date and system (`original`)
+- Converted date (`converted`)
+- The rule that applies (`applied[].rule`, plus `applied[].offsetDays`
+  on a day shift, and any `notes[]`)
 - Why the conversion matters for their research
 
-**Example:**
+**Example** — the user asks which YEAR to use for "25 March 1750/1":
 
 ```
-Date conversion: "25 March 1750/1"
+convert_calendar({
+  date: { year: 1750, month: 3, day: 25, doubleYear: 1 },
+  corrections: { doubleDatedYear: true },
+})
+→ { ok: true,
+    original: { year: 1750, month: 3, day: 25, doubleYear: 1 },
+    converted: { year: 1751, month: 3, day: 25 },
+    applied: [{ correction: "doubleDatedYear",
+                rule: "Double-dated year resolved to the later (New Style) year (+1)",
+                yearAdjusted: true }],
+    notes: [] }
+```
 
-This is a double-dated English record (pre-1752).
-- Old Style: 25 March 1750 (year starts March 25)
-- New Style: 25 March 1751 (year starts January 1)
+Present it:
+
+```
+Date conversion: "25 March 1750/1" (double-dated English record, pre-1752)
+- Original (Old Style): 25 March 1750 (year starts March 25)
+- New Style year: 25 March 1751
 
 The correct modern date is: 25 March 1751
 
-Additionally, the Julian calendar was 11 days behind:
-- Gregorian equivalent: 5 April 1751
-
-For genealogical records, use: 1751-03-25 (New Style year,
-Julian day — the standard convention for pre-1752 English dates)
-unless precise Gregorian conversion is needed for cross-country
-comparison.
+For genealogical records, use: 1751-03-25 (New Style year, Julian day —
+the standard convention for pre-1752 English dates).
 ```
+
+The user asked only for the year, so we requested only `doubleDatedYear`
+and did not apply the 11-day Julian offset. If they also want the precise
+Gregorian DAY equivalent for a cross-country comparison, call again with
+`corrections: { julianToGregorianDay: true }` and present that as a
+separate result.
 
 ## Common traps
 

--- a/packages/engine/plugin/skills/hypothesis-tracking/SKILL.md
+++ b/packages/engine/plugin/skills/hypothesis-tracking/SKILL.md
@@ -16,7 +16,7 @@ description: Creates, updates, and reviews hypotheses about person identity,
   (use conflict-resolution), wants to build a timeline (use timeline), or
   wants to write a final conclusion (use proof-conclusion).
 allowed-tools:
-  - validate_research_schema
+  - research_append
 ---
 
 ## Step 0 — Scope gate (MANDATORY, before any file reads)
@@ -36,7 +36,7 @@ If the classification is NOT "in scope": output the one-sentence reply shown abo
 
 **Narration:** Read `researcher_profile.narration_guidance` from `research.json` and apply it as your narration style for this invocation. If absent, default to a one-line preamble per action.
 
-**After completing every task (including read-only status reviews), call `validate_research_schema` on the project directory before presenting results.**
+**All writes to the `hypotheses` section go through `research_append` — never hand-assemble the JSON and write the file yourself.** The tool assigns the `h_` id, validates the entry before persisting, and writes atomically; on `{ ok: false, errors }` it writes nothing. Surface those errors and fix the input rather than retrying blindly. Because the tool validates before persisting, there is no separate post-write `validate_research_schema` step.
 
 **Read-only detection:** If the user asks for a summary, review, or
 status check without requesting changes ("where do things stand?",
@@ -110,20 +110,25 @@ Promotion to `supported` happens in a separate evaluation step after
 the evidence has been explicitly reviewed against the criteria in
 Step 3.
 
-When new evidence suggests a testable claim:
+When new evidence suggests a testable claim, append it with
+`research_append` — the tool assigns the `h_` id, so omit it from the
+entry:
 
-```json
-{
-  "id": "h_002",
-  "claim": "Patrick Flynn's father was Thomas Flynn of Luzerne County, not Thomas Flynn of Schuylkill County",
-  "status": "active",
-  "supporting_assertion_ids": [],
-  "contradicting_assertion_ids": [],
-  "ruled_out": false,
-  "ruled_out_reason": null,
-  "notes": "Alternative candidate to h_001. Luzerne County Thomas Flynn appears in the 1850 census with a Patrick of the right age. Needs investigation.",
-  "related_question_ids": ["q_001"]
-}
+```
+research_append({
+  section: "hypotheses",
+  op: "append",
+  entry: {
+    claim: "Patrick Flynn's father was Thomas Flynn of Luzerne County, not Thomas Flynn of Schuylkill County",
+    status: "active",
+    supporting_assertion_ids: [],
+    contradicting_assertion_ids: [],
+    ruled_out: false,
+    ruled_out_reason: null,
+    notes: "Alternative candidate to h_001. Luzerne County Thomas Flynn appears in the 1850 census with a Patrick of the right age. Needs investigation.",
+    related_question_ids: ["q_001"]
+  }
+})
 ```
 
 **Claim requirements:**
@@ -145,6 +150,21 @@ hypothesis, ask: "What evidence would DISPROVE this?" Then prioritize
 searching for that evidence. A hypothesis that survives deliberate
 refutation attempts is far stronger than one supported only by
 confirmatory searches.
+
+Link evidence by updating the hypothesis in place with `research_append`
+(`op: "update"`, passing the `h_` id as `entryId` and only the fields
+that change), e.g.:
+
+```
+research_append({
+  section: "hypotheses",
+  op: "update",
+  entryId: "h_001",
+  fields: {
+    supporting_assertion_ids: ["a_004", "a_010", "a_013"]
+  }
+})
+```
 
 **Supporting evidence:** Assertions that make the claim more likely.
 Add their IDs to `supporting_assertion_ids`.
@@ -229,15 +249,25 @@ read-only summary/review ("just want to see the current state",
 research.json — identify the issue in your response text but defer
 the actual file changes to a follow-up request.
 
-When ruling out, `ruled_out_reason` is REQUIRED. Be specific:
+Transition status with `research_append` (`op: "update"`). When ruling
+out, `ruled_out_reason` is REQUIRED — the validator rejects the entry
+if it is missing. Be specific:
 
-```json
-{
-  "status": "ruled_out",
-  "ruled_out": true,
-  "ruled_out_reason": "Thomas Flynn of Luzerne County died in 1840, five years before Patrick's estimated birth in 1845. His will (probated 1840) names three children, none named Patrick. Timeline impossibility and negative evidence from probate."
-}
 ```
+research_append({
+  section: "hypotheses",
+  op: "update",
+  entryId: "h_002",
+  fields: {
+    status: "ruled_out",
+    ruled_out: true,
+    ruled_out_reason: "Thomas Flynn of Luzerne County died in 1840, five years before Patrick's estimated birth in 1845. His will (probated 1840) names three children, none named Patrick. Timeline impossibility and negative evidence from probate."
+  }
+})
+```
+
+Promotion to `supported` is the same call with
+`fields: { status: "supported" }`.
 
 ### 4. Handle competing hypotheses
 
@@ -268,7 +298,9 @@ two candidate fathers), manage them as a group:
 ### 5. Update existing hypotheses
 
 When new evidence arrives (new assertions extracted, conflicts
-resolved, timelines updated):
+resolved, timelines updated), update the hypothesis in place with
+`research_append({ section: "hypotheses", op: "update", entryId, fields })`,
+passing only the fields that change:
 
 - Check if the evidence supports or contradicts any active hypothesis
 - Add assertion IDs to the appropriate list
@@ -298,9 +330,14 @@ status, it's ready for a proof conclusion. "Hypothesis h_001 is
 supported by three direct evidence assertions with no contradictions.
 Ready for proof-conclusion."
 
-### 7. Validate and present
+### 7. Present
 
-**Always** call `validate_research_schema({ projectPath: "<absolute-path-to-project-directory>" })` at the end of every interaction — including read-only status reviews, not just when you made changes. Verify both research.json and tree.gedcomx.json are valid. If validation fails, fix the errors before presenting. Then present the hypothesis state:
+`research_append` validates each entry before persisting and writes
+nothing on `{ ok: false, errors }`, so there is no separate post-write
+`validate_research_schema` step. If a write returns `{ ok: false }`,
+surface the errors, correct the input, and retry the call — do not
+re-run the write blindly. Once the writes succeed, present the
+hypothesis state:
 
 ```
 Hypothesis: h_001 — Patrick Flynn's father was Thomas Flynn

--- a/packages/engine/plugin/skills/hypothesis-tracking/references/validation-protocol.md
+++ b/packages/engine/plugin/skills/hypothesis-tracking/references/validation-protocol.md
@@ -1,14 +1,15 @@
 # Validation Protocol
 
-After writing to `research.json` or `tree.gedcomx.json`, follow these steps:
-
-1. **Invoke `validate-schema`** to verify both files conform to the
-   published schemas. If validation fails, fix the errors before
-   proceeding.
+1. **Schema validation is automatic.** Writes go through the
+   persistence tools (`research_append`, `tree_edit`, the merge tools),
+   which validate every entry before persisting and write nothing on
+   `{ ok: false, errors }`. There is no separate post-write
+   `validate-schema` step — surface the returned errors and fix the
+   input instead. (`validate-schema` remains available as a manual
+   audit tool when you want to re-check an existing project.)
 
 2. **Invoke `check-warnings`** if you added assertions or
    person_evidence entries. This checks for genealogical
    impossibilities (married before 12, died after 120, child born
-   after parent's death, etc.).
-
-These are not auto-triggered — you must invoke them explicitly.
+   after parent's death, etc.). It is not auto-triggered — you must
+   invoke it explicitly.

--- a/packages/engine/plugin/skills/person-evidence/SKILL.md
+++ b/packages/engine/plugin/skills/person-evidence/SKILL.md
@@ -22,7 +22,8 @@ description: Links assertions to GedcomX persons — the identity-resolution
   compete (use conflict-resolution), or wants to merge two
   confirmed-identical persons (use tree-edit after proof-conclusion).
 allowed-tools:
-  - validate_research_schema
+  - research_append
+  - tree_edit
   - same_person
 ---
 
@@ -136,8 +137,8 @@ include: "is the confidence on pe_NNN appropriate?",
 - **Produce a written analysis only.** Do NOT write to `research.json`
   or `tree.gedcomx.json`. Do NOT create new `pe_` entries. Do NOT
   modify the entry under review (not its `confidence`, not its
-  `rationale`, not any other field). Do NOT call
-  `validate_research_schema` — no writes were made.
+  `rationale`, not any other field). No writes are made in this mode,
+  so no persistence call is needed.
 - If the review **confirms** the existing entry: state that, citing
   the specific attributes that support the recorded confidence.
 - If the review **surfaces a concern** (calibration off, rationale
@@ -255,19 +256,26 @@ reach and tree-edit to execute.
 
 ### 4. Create person_evidence entries
 
-For each assertion → person link:
+For each assertion → person link, call `research_append` with
+`op: "append"`. Supply the entry WITHOUT an `id`, `created`, or
+`superseded_by` — the tool assigns the next `pe_` id, stamps `created`,
+validates before persisting, and writes nothing on
+`{ ok: false, errors }`. Surface those errors to the user rather than
+retrying blindly.
 
-```json
-{
-  "id": "pe_007",
-  "assertion_id": "a_015",
-  "person_id": "KWCJ-RN4",
-  "confidence": "probable",
-  "rationale": "Thomas Flynn, will dated 1881, Schuylkill County. Names match. Location matches (same county as census records). Death date consistent with disappearance from tax records after 1880. Will names 'my son Patrick' — this assertion links the testator role to the Thomas Flynn (I2) in the tree.",
-  "match_score": 0.64,
-  "created": "2026-05-04",
-  "superseded_by": null
-}
+```
+research_append({
+  projectPath: "<absolute-path-to-project-directory>",
+  section: "person_evidence",
+  op: "append",
+  entry: {
+    assertion_id: "a_015",
+    person_id: "KWCJ-RN4",
+    confidence: "probable",
+    rationale: "Thomas Flynn, will dated 1881, Schuylkill County. Names match. Location matches (same county as census records). Death date consistent with disappearance from tax records after 1880. Will names 'my son Patrick' — this assertion links the testator role to the Thomas Flynn (I2) in the tree.",
+    match_score: 0.64
+  }
+})
 ```
 
 **Field guidance:**
@@ -286,38 +294,40 @@ For each assertion → person link:
   image-, and PDF-sourced assertions, for searches with no sidecar, and
   for any link where no score was obtained. The score is an input to
   the confidence decision (step 3), not the decision itself.
-- `superseded_by`: null for active links. Set to the new `pe_` ID
-  when this link is revised.
+- `superseded_by`: the tool sets this null on append. When a link is
+  revised, set it via an `op: "update"` on the old entry (Step 6) —
+  never edit it by hand.
 
 ### 5. Handle new persons (stub creation)
 
 When an assertion's persona doesn't match any existing GedcomX
-person, create a new **stub person** in tree.gedcomx.json:
+person, create a new **stub person** in tree.gedcomx.json with
+`tree_edit({ operation: "add_person" })`. Supply the person WITHOUT
+ids — the tool allocates the synthetic `I` person id and the `N` name
+id, validates before persisting, and writes nothing on
+`{ ok: false, errors }`:
 
-```json
-{
-  "id": "I5",
-  "gender": "Male",
-  "names": [
-    {
-      "id": "N5",
-      "preferred": true,
-      "given": "James",
-      "surname": "Flynn"
-    }
-  ]
-}
+```
+tree_edit({
+  projectPath: "<absolute-path-to-project-directory>",
+  operation: "add_person",
+  person: {
+    gender: "Male",
+    names: [{ preferred: true, given: "James", surname: "Flynn" }]
+  }
+})
 ```
 
 **Stub person rules:**
-- Use synthetic IDs (`I5`, `I6`, etc.) — not FamilySearch IDs (those
-  belong to persons already in the tree)
-- Minimum: `id`, `gender` (may be `Unknown`), one name with at
+- The tool assigns synthetic ids (`I5`/`N5`, etc.) — never supply
+  ids, and never use FamilySearch IDs (those belong to persons
+  already in the tree)
+- Minimum: `gender` (may be `Unknown`), one name with at
   least a `surname`. `given` may be empty string if unknown.
 - `facts` may be omitted entirely — they'll be populated as
   proof-conclusion writes confirmed facts
-- Add the person to `tree.gedcomx.json` `persons[]`
-- Then create the `pe_` entry linking the assertion to the new person
+- Then create the `pe_` entry (Step 4) linking the assertion to the
+  new person, using the `I` id the tool returned in its compact summary
 - **Confidence:** a stub rests on the single record that introduced the
   person, with no independent corroboration yet, so its `pe_` link is
   `probable` at most — `speculative` when the persona is only
@@ -333,25 +343,26 @@ person, create a new **stub person** in tree.gedcomx.json:
 
 ### 6. Handle link revisions
 
-When new evidence shows an assertion was linked to the wrong person:
-1. Set `superseded_by` on the old `pe_` entry to the new entry's ID
-2. Create a new `pe_` entry with the corrected `person_id`
-3. Never delete the old entry — it's part of the audit trail
+When new evidence shows an assertion was linked to the wrong person,
+make two `research_append` calls — never delete the old entry, it's
+part of the audit trail:
+
+1. **Append** the corrected link (Step 4) to get its new `pe_` id.
+2. **Update** the old entry's `superseded_by` to that new id.
 
 Example: You initially linked a_020 to I3 (speculative). New evidence
-shows it's actually I7 (a different person with the same name).
+shows it's actually I7 (a different person with the same name). First
+append the corrected `a_020 → I7` link; the tool returns its id (say
+`pe_015`). Then point the old entry at it:
 
-```json
-{
-  "id": "pe_010",
-  "assertion_id": "a_020",
-  "person_id": "I3",
-  "confidence": "speculative",
-  "rationale": "Initial link based on name match only.",
-  "match_score": null,
-  "created": "2026-05-03",
-  "superseded_by": "pe_015"
-}
+```
+research_append({
+  projectPath: "<absolute-path-to-project-directory>",
+  section: "person_evidence",
+  op: "update",
+  entryId: "pe_010",
+  fields: { superseded_by: "pe_015" }
+})
 ```
 
 ### 7. Systematic record linking
@@ -374,11 +385,15 @@ will naming heirs), link ALL relevant roles systematically:
 For each role, evaluate the match independently. The testator may
 be a `confident` match while an heir may be `speculative`.
 
-### 8. Validate and present
+### 8. Check warnings and present
 
-Call `validate_research_schema({ projectPath: "<absolute-path-to-project-directory>" })`
-to verify both research.json and tree.gedcomx.json are valid. If validation
-fails, fix the errors before presenting.
+`research_append` and `tree_edit` both validate-before-persist — they
+write nothing on `{ ok: false, errors }`, so no separate
+`validate_research_schema` pass is needed. After creating links and any
+stub persons, invoke `check-warnings` on the affected persons to catch
+genealogical impossibilities (married before 12, died after 120, child
+born after a parent's death, etc.). This checks plausibility, which the
+persistence step does not. Surface any warnings to the user.
 
 Present the results:
 - Each link created, with the assertion, the person, and the

--- a/packages/engine/plugin/skills/person-evidence/references/validation-protocol.md
+++ b/packages/engine/plugin/skills/person-evidence/references/validation-protocol.md
@@ -1,14 +1,17 @@
 # Validation Protocol
 
-After writing to `research.json` or `tree.gedcomx.json`, follow these steps:
+The persistence tools (`research_append`, `tree_edit`) validate
+the project schema *before* they persist — they write nothing on
+`{ ok: false, errors }`. So a separate post-write schema validation
+pass is no longer needed; surface those errors to the user instead of
+retrying blindly.
 
-1. **Invoke `validate-schema`** to verify both files conform to the
-   published schemas. If validation fails, fix the errors before
-   proceeding.
+One check still runs separately, because it is about genealogical
+plausibility rather than structure:
 
-2. **Invoke `check-warnings`** if you added assertions or
-   person_evidence entries. This checks for genealogical
-   impossibilities (married before 12, died after 120, child born
-   after parent's death, etc.).
+- **Invoke `check-warnings`** after you add person_evidence entries
+  or stub persons. This checks for genealogical impossibilities
+  (married before 12, died after 120, child born after parent's death,
+  etc.).
 
-These are not auto-triggered — you must invoke them explicitly.
+It is not auto-triggered — you must invoke it explicitly.

--- a/packages/engine/plugin/skills/proof-conclusion/SKILL.md
+++ b/packages/engine/plugin/skills/proof-conclusion/SKILL.md
@@ -15,7 +15,10 @@ description: Writes GPS-conformant proof conclusions — selects the
   wants to select the next question (use question-selection), or wants to
   classify evidence (use assertion-classification).
 allowed-tools:
-  - validate_research_schema
+  - research_append
+  - tree_edit
+  - merge_tree_persons
+  - merge_record_into_tree
 ---
 
 # Proof Conclusion
@@ -224,58 +227,90 @@ guidance):
 
 ### 5. Write the proof_summaries entry
 
-```json
-{
-  "id": "ps_001",
-  "question_id": "q_001",
-  "tier": "probable",
-  "vehicle": "summary",
-  "supporting_assertion_ids": ["a_004", "a_010", "a_013"],
-  "resolved_conflict_ids": ["c_001"],
-  "exhaustive_search_summary": "Searched 1850 census (FamilySearch, Ancestry), 1860 census (FamilySearch), death certificate (FamilySearch), probate records (FamilySearch, Ancestry). Three independent sources confirm parentage. 1870-1900 censuses not yet searched.",
-  "narrative_markdown": "## Parentage of Patrick Flynn...\n\n..."
-}
+Append the proof summary to `research.json` `proof_summaries[]` with
+`research_append`. Supply the entry **without an `id`** — the tool
+assigns the next `ps_NNN`, validates the whole project before writing,
+and writes nothing on failure:
+
 ```
+research_append({
+  projectPath: "<absolute-path-to-project-directory>",
+  section: "proof_summaries",
+  op: "append",
+  entry: {
+    question_id: "q_001",
+    tier: "probable",
+    vehicle: "summary",
+    supporting_assertion_ids: ["a_004", "a_010", "a_013"],
+    resolved_conflict_ids: ["c_001"],
+    exhaustive_search_summary: "Searched 1850 census (FamilySearch, Ancestry), 1860 census (FamilySearch), death certificate (FamilySearch), probate records (FamilySearch, Ancestry). Three independent sources confirm parentage. 1870-1900 censuses not yet searched.",
+    narrative_markdown: "## Parentage of Patrick Flynn...\n\n..."
+  }
+})
+```
+
+If it returns `{ ok: false, errors }`, surface those errors and fix the
+entry — do not retry the same payload blindly.
+
+On a repeat invocation where a proof summary for this question already
+exists, refine it in place with `op: "update"` (target by the existing
+`ps_` id, supply only the changed fields) rather than appending a second
+one — see Re-invocation behavior.
 
 ### 6. Update tree.gedcomx.json (tier >= probable)
 
-When the conclusion reaches `probable` or higher, update the GedcomX
-file:
+When the conclusion reaches `probable` or higher, write the concluded
+facts and relationships into `tree.gedcomx.json` with `tree_edit` — one
+call per edit. The tool assigns ids, swaps the primary/preferred flags,
+resolves `standard_place`, validates the whole project, and writes
+nothing on `{ ok: false, errors }`. You supply the content judgment;
+the tool does the clerical work.
 
-- **Source descriptions:** Ensure every source cited in the proof has
-  a GedcomX `S` entry in the `sources` array. A source description has
-  exactly these fields — **no others are permitted** (the file is
-  validated with `additionalProperties: false`):
+- **Facts:** add the concluded birth, death, etc. on the person with
+  `tree_edit({ operation: "add_fact", personId, fact })`, or correct an
+  existing one with `update_fact`. Pass `primary: true` on the concluded
+  fact — the tool clears `primary` on the person's other facts of the
+  same type, so you do **not** swap the flag by hand.
 
-  | Field | Required | Notes |
-  |-------|----------|-------|
-  | `id` | yes | `S` prefix |
-  | `title` | yes | Human-readable source title |
-  | `citation` | no | Finalized Evidence Explained citation |
-  | `author` | no | Creator/agency |
-  | `url` | no | URL to the digital source |
-
-  This is the upload step for citations: copy the finalized
-  `research.json` `sources[].citation` into each `S` entry's
-  `citation` field. Do **not** add a `description`, `notes`, or any
-  other field — they fail schema validation.
-- **Facts:** Add/update birth, death, etc. on the person with source
-  references. Set `primary: true` on the concluded fact.
-- **Relationships:** Add ParentChild or Couple relationships with
-  source references.
+  ```
+  tree_edit({
+    projectPath: "<absolute-path-to-project-directory>",
+    operation: "add_fact",
+    personId: "I3",
+    fact: { type: "Death", date: "1881", place: "Schuylkill County, Pennsylvania, United States", primary: true, sources: ["S2"] }
+  })
+  ```
+- **Relationships:** add a ParentChild or Couple relationship with
+  `tree_edit({ operation: "add_relationship", relationship })`,
+  referencing the concluded source(s).
+- **Sources:** ensure every source cited in the proof has a GedcomX `S`
+  entry. If one is missing, add it through the tree (the tool validates
+  the source shape — copy the finalized `research.json`
+  `sources[].citation` into the `S` entry's `citation`).
 - **Source references:** Set `quality` based on evidence analysis:
   - `3`: Original + primary + direct
   - `2`: Original + secondary/indirect, or derivative + primary
   - `1`: Derivative + secondary, or single uncorroborated source
   - `0`: Authored/unreliable
 
-**If the tier is later revised downward** (new evidence contradicts),
-remove concluded facts/relationships via tree-edit.
+If a call returns `{ ok: false, errors }`, surface the errors and fix
+the edit — do not retry the same payload blindly. After the edits, run
+`check-warnings` (see `references/validation-protocol.md`).
 
-**Person merging:** If the conclusion confirms two GedcomX persons
-are the same individual, invoke tree-edit to execute the merge.
-proof-conclusion decides WHETHER to merge; tree-edit does the
-mechanical operation.
+**If the tier is later revised downward** (new evidence contradicts),
+remove the concluded fact or relationship with
+`tree_edit({ operation: "remove", factId })` or
+`tree_edit({ operation: "remove", relationshipId })`.
+
+**Person merging:** If the conclusion confirms two GedcomX persons are
+the same individual, merge them with
+`merge_tree_persons({ projectPath, merges })` (pass
+`[survivorId, collapsedId]` pairs), or
+`merge_record_into_tree({ projectPath, candidateGedcomx, merges })` when
+folding a `record_read` candidate into the tree. proof-conclusion
+decides WHETHER to merge; the merge tool does the mechanical operation
+and repoints the `research.json` person-id references. Narrate from the
+tool's compact summary, then run `check-warnings`.
 
 ### 7. Do not modify the question
 
@@ -299,11 +334,14 @@ the question is marked resolved by its owner.
 - If ALL questions in the project are now `resolved`, set
   `project.status` to `completed`
 
-### 9. Validate and present
+### 9. Present
 
-Call `validate_research_schema({ projectPath: "<absolute-path-to-project-directory>" })`
-to verify both research.json and tree.gedcomx.json are valid. If validation
-fails, fix the errors before presenting.
+The persistence tools validate the whole project before writing and
+persist nothing on `{ ok: false, errors }`, so a successful write is
+already schema-valid — there is no separate post-write validation step.
+If you added or updated facts, relationships, or merged persons in
+step 6, run `check-warnings` (see `references/validation-protocol.md`)
+for genealogical plausibility.
 
 Present to the user:
 - The full narrative markdown (formatted)

--- a/packages/engine/plugin/skills/proof-conclusion/references/validation-protocol.md
+++ b/packages/engine/plugin/skills/proof-conclusion/references/validation-protocol.md
@@ -1,14 +1,19 @@
 # Validation Protocol
 
-After writing to `research.json` or `tree.gedcomx.json`, follow these steps:
+`research_append`, `tree_edit`, `merge_tree_persons`, and
+`merge_record_into_tree` validate-before-persist — they conform-check
+the project against the published schemas and write nothing on
+`{ ok: false, errors }`. So there is no separate post-write
+`validate-schema` step for those writes; just surface any returned
+errors. (`validate-schema` remains available as a user-invokable audit
+of the whole project.)
 
-1. **Invoke `validate-schema`** to verify both files conform to the
-   published schemas. If validation fails, fix the errors before
-   proceeding.
+What is NOT structural — and so still needs an explicit step:
 
-2. **Invoke `check-warnings`** if you added assertions or
-   person_evidence entries. This checks for genealogical
-   impossibilities (married before 12, died after 120, child born
-   after parent's death, etc.).
+1. **Invoke `check-warnings`** after any tree edit or merge (added or
+   updated facts/relationships, or a person merge). This checks for
+   genealogical impossibilities the schema validator cannot (married
+   before 12, died after 120, child born after a parent's death, a
+   merge that put the same person on both ends of a relationship, etc.).
 
-These are not auto-triggered — you must invoke them explicitly.
+This is not auto-triggered — you must invoke it explicitly.

--- a/packages/engine/plugin/skills/question-selection/SKILL.md
+++ b/packages/engine/plugin/skills/question-selection/SKILL.md
@@ -17,7 +17,7 @@ description: Selects the next research question (writing it to research.json) ba
   project's current state (use project-status), or when the user wants
   to search records (use search-records or search-external-sites).
 allowed-tools:
-  - validate_research_schema
+  - research_append
 ---
 
 # Question Selection
@@ -129,29 +129,38 @@ the first question should verify it.
 
 ## 4. Write the question
 
-Add a new question to `research.json` `questions[]`:
+Append the new question to `research.json` `questions[]` with
+`research_append`. Supply the entry **without an `id`** — the tool
+assigns the next `q_NNN` and stamps `created`:
 
-```json
-{
-  "id": "q_003",
-  "question": "Did Thomas Flynn leave a will or probate record in Schuylkill County naming Patrick as a son?",
-  "rationale": "Direct evidence from a probate record would confirm the parent-child relationship. Thomas Flynn died circa 1881 based on his disappearance from tax records. Schuylkill County probate records are available on FamilySearch.",
-  "selection_basis": "hypothesis_test",
-  "priority": "high",
-  "status": "open",
-  "depends_on": [],
-  "unblocks": ["q_001"],
-  "created": "2026-05-04",
-  "resolved": null,
-  "resolution_assertion_ids": [],
-  "exhaustive_declaration": {
-    "declared": false,
-    "justification": null,
-    "log_entry_ids": [],
-    "stop_criteria": null
-  }
-}
 ```
+research_append({
+  projectPath: "<absolute-path-to-project-directory>",
+  section: "questions",
+  op: "append",
+  entry: {
+    question: "Did Thomas Flynn leave a will or probate record in Schuylkill County naming Patrick as a son?",
+    rationale: "Direct evidence from a probate record would confirm the parent-child relationship. Thomas Flynn died circa 1881 based on his disappearance from tax records. Schuylkill County probate records are available on FamilySearch.",
+    selection_basis: "hypothesis_test",
+    priority: "high",
+    status: "open",
+    depends_on: [],
+    unblocks: ["q_001"],
+    resolved: null,
+    resolution_assertion_ids: [],
+    exhaustive_declaration: {
+      declared: false,
+      justification: null,
+      log_entry_ids: [],
+      stop_criteria: null
+    }
+  }
+})
+```
+
+The tool validates the whole project before writing and writes nothing
+on failure. If it returns `{ ok: false, errors }`, surface those errors
+and fix the entry — do not retry the same payload blindly.
 
 **Set dependency links:**
 - `depends_on`: Questions whose resolution enables or informs this
@@ -171,11 +180,10 @@ creation time (`declared: false`, `log_entry_ids: []`,
 `research-exhaustiveness` skill's job, run after all plan items
 for the question are completed.
 
-## 5. Validate and present
+## 5. Present
 
-Call `validate_research_schema({ projectPath: "<absolute-path-to-project-directory>" })`
-to verify both research.json and tree.gedcomx.json are valid. If validation
-fails, fix the errors before presenting. Then tell the user:
+`research_append` already validated the project before persisting, so
+there is no separate validation step. Tell the user:
 - The question selected and why (the rationale)
 - What it depends on and what it unblocks
 - Suggest next step: "Would you like me to plan the research for
@@ -224,8 +232,23 @@ fails, fix the errors before presenting. Then tell the user:
 ## Re-invocation behavior
 
 **Writes:** entries in the `questions` section of `research.json`
-(`q_` ids) and their `status` field. Mutable in place; never deletes
-entries — supersedes via `status`.
+(`q_` ids) and their `status` field, via `research_append`. Mutable in
+place; never deletes entries — supersedes via `status`. To supersede a
+question, update it rather than removing it:
+
+```
+research_append({
+  projectPath: "<absolute-path-to-project-directory>",
+  section: "questions",
+  op: "update",
+  entryId: "q_003",
+  fields: { status: "superseded" }
+})
+```
+
+The tool preserves the id and never deletes the entry. To mark a
+question answered, use the same `op: "update"` with the appropriate
+`status`.
 
 **On repeat invocation:** re-evaluates which question to work on next.
 May update the `status` of an existing question (e.g. mark it

--- a/packages/engine/plugin/skills/question-selection/references/validation-protocol.md
+++ b/packages/engine/plugin/skills/question-selection/references/validation-protocol.md
@@ -1,14 +1,16 @@
 # Validation Protocol
 
-After writing to `research.json` or `tree.gedcomx.json`, follow these steps:
+The structured write tools (`research_append`, `research_log_append`,
+`tree_edit`, the merge tools) **validate the project before they
+persist** and write nothing on a validation failure — so there is no
+separate post-write schema-validation step. If a write tool returns
+`{ ok: false, errors }`, surface the errors and fix the entry; do not
+retry the same payload blindly.
 
-1. **Invoke `validate-schema`** to verify both files conform to the
-   published schemas. If validation fails, fix the errors before
-   proceeding.
+Genealogical plausibility is a separate concern from schema validity:
 
-2. **Invoke `check-warnings`** if you added assertions or
-   person_evidence entries. This checks for genealogical
-   impossibilities (married before 12, died after 120, child born
-   after parent's death, etc.).
-
-These are not auto-triggered — you must invoke them explicitly.
+- **Invoke `check-warnings`** if you added assertions or
+  person_evidence entries. This checks for genealogical
+  impossibilities (married before 12, died after 120, child born
+  after parent's death, etc.). It is not auto-triggered — you must
+  invoke it explicitly.

--- a/packages/engine/plugin/skills/record-extraction/SKILL.md
+++ b/packages/engine/plugin/skills/record-extraction/SKILL.md
@@ -20,7 +20,8 @@ allowed-tools:
   - volume_search
   - place_search
   - place_search_all
-  - validate_research_schema
+  - research_append
+  - research_log_append
   - record_person_matches
   - record_record_matches
 ---
@@ -106,18 +107,20 @@ Determine the source of the record:
 
 Create or find the source entry:
 - Check if a source entry (`src_`) already exists in `research.json`
-  for this record accessed from this repository.
-- If not, create a new source entry with the next available `src_` ID.
+  for this record accessed from this repository. If one does, reuse it
+  (refine its citation via `research_append` `op: "update"`).
+- If not, append a new source entry in step 5a via `research_append`
+  — the tool assigns the next `src_` id; do not invent one.
 - Also create or find the corresponding source description in
   `tree.gedcomx.json` (the `S` prefix entry). Remember: multiple
   research sources can reference the same GedcomX source description
   (e.g., same census accessed via FamilySearch and Ancestry).
 
-**Source entry fields:**
+**Source entry fields** — assemble this shape WITHOUT an `id` (the
+tool assigns it on append):
 
 ```json
 {
-  "id": "src_001",
   "gedcomx_source_description_id": "S1",
   "citation": "<working citation — best-effort Evidence Explained format>",
   "citation_detail": {
@@ -205,11 +208,11 @@ individuals unless a question targets them.
 with the same care as supporting ones. Suspend judgment until
 correlation.
 
-**Each assertion must have:**
+**Each assertion must have** (assemble WITHOUT an `id` — the tool
+assigns the next `a_` id on append):
 
 ```json
 {
-  "id": "a_001",
   "source_id": "src_001",
   "record_id": "<record identifier>",
   "record_role": "<role in this record>",
@@ -365,71 +368,110 @@ already wrote the log entry — reference it via `log_entry_id`.
 
 When processing a user-provided record (direct PDF upload, manual
 record analysis, or a `record_search` result handed over in the
-message), create a log entry. **Never modify an existing log
-entry — the log is append-only.** Use the next available `log_` ID
-(check `research.json` for existing entries first).
+message), append a log entry with `research_log_append`. The log is
+append-only; the tool only appends — it assigns the `log_` id, the
+`performed` timestamp, and `results_ref`. Do not invent an id or
+hand-write a sidecar.
 
-```json
-{
-  "id": "log_NNN",
-  "plan_item_id": null,
-  "performed": "2026-05-24T14:30:00Z",
-  "tool": "user_provided",
-  "query": { "description": "<what the user provided>" },
-  "outcome": "positive",
-  "results_examined": 1,
-  "results_ref": "results/log_NNN.json",
-  "notes": "<description of the record>",
-  "external_site": null
-}
+```
+research_log_append({
+  projectPath: "<absolute project dir>",
+  tool: "user_provided",
+  query: { description: "<what the user provided>" },
+  outcome: "positive",
+  resultsExamined: 1,
+  notes: "<description of the record>"
+})
 ```
 
-**Sidecar for `record_search` results:** When assertions carry
-`record_persona_id`, the validator cross-checks against a sidecar at
-`results/log_NNN.json`. Create it with: `{ "log_id": "log_NNN",
-"tool": "record_search", "retrieved": "<ISO timestamp>",
-"returned_count": 1, "payload": { "results": [{ "recordId":
-"<arkUrl>", "gedcomx": <the gedcomx from the search result> }] } }`.
-Set `results_ref` on the log entry to `"results/log_NNN.json"`.
-For image/PDF records (no `record_persona_id`), set `results_ref`
-to null and skip the sidecar.
+Use the returned `logId` as the `log_entry_id` you stamp on the
+source and assertions in step 5.
 
-### 5. Write the files
+**Retaining `record_search` results:** when the record came from a
+`record_search` you called with `projectPath`, that response carried a
+`staged.resultsRef` handle. Pass it as `stagedResultsRef` so the host
+finalizes the `results/<log_id>.json` sidecar (the validator needs it
+to cross-check assertions that carry a `record_persona_id`) — you never
+re-serialize the payload:
 
-**You must actually write the files — do not just describe the
-extraction in your response.** Use file-write tools to persist the
-data to `research.json` and `tree.gedcomx.json`. A text summary
-without persisted files is an incomplete extraction.
+```
+research_log_append({
+  projectPath: "<absolute project dir>",
+  tool: "record_search",
+  query: { description: "<the search>" },
+  outcome: "positive",
+  resultsExamined: 1,
+  stagedResultsRef: "<staged.resultsRef from the search response>"
+})
+```
 
-**Write each file in its own turn** — do not bundle into one mega-write.
+For image/PDF/full-text records (no `record_persona_id`, no staged
+results), omit `stagedResultsRef` entirely — no sidecar is written.
 
-**5a. Write `research.json`** — source, log entry (if applicable), and
-assertions. **Only modify `sources`, `assertions`, `log`** — do not
-touch `timelines`, `persons`, `questions` (other skills own those).
-For multi-persona records (3+), split: first persona in the initial
-write, subsequent personas via Edit appends. Every persona must have
-fully expanded individual `a_` entries — never compress into ranges.
+**Recovery:** a staged handle expires (TTL ~24h), so on a long session
+`research_log_append` may return `{ ok: false }` because the
+`stagedResultsRef` no longer resolves. Re-run the `record_search` (it
+re-stages cheaply) and pass the fresh handle. Surface any other
+`{ ok: false, errors }` to the user rather than retrying blindly.
 
-**5b. Write `tree.gedcomx.json`** — append the `S` entry to `sources`.
-Root has exactly three keys: `persons`, `relationships`, `sources` —
-do not add `id` or other keys at root. Optional `S` fields (author,
-url) must be omitted if not applicable — never set to `null`.
+### 5. Persist source and assertions
 
-### 6. Validate
+**You must actually persist the data — do not just describe the
+extraction in your response.** A text summary without persisted entries
+is an incomplete extraction. Each tool validates the whole project
+before it writes and writes nothing on `{ ok: false, errors }`, so
+there is no separate validate-and-fix pass — surface any errors and
+correct the offending entry.
 
-After all writes are done, call
-`validate_research_schema({ projectPath: "<absolute-path-to-project-directory>" })`
-to verify both research.json and tree.gedcomx.json are valid. If
-validation fails, fix the errors before presenting.
+**5a. Append the source** with `research_append` (the tool assigns the
+`src_` id; stamp the source's `log_entry_id` with the `logId` from step
+4's `research_log_append`, when applicable):
 
-**Aim to pass validation on the first call.** Repeated validation
-failures indicate sloppy initial writes. Before writing, double-check:
+```
+research_append({
+  projectPath: "<absolute project dir>",
+  section: "sources",
+  op: "append",
+  entry: { /* the source fields from step 1, WITHOUT an id */ }
+})
+```
+
+If a source for this record already exists, refine it instead:
+`research_append({ section: "sources", op: "update", entryId: "<src_>",
+fields: { /* changed fields */ } })`.
+
+**5b. Append each assertion** with `research_append` — one call per
+assertion (including each negative assertion). The tool assigns each
+`a_` id and validates each entry, so there is no first-persona /
+Edit-append chunking: just loop, one append per fact:
+
+```
+research_append({
+  projectPath: "<absolute project dir>",
+  section: "assertions",
+  op: "append",
+  entry: { /* the assertion fields from step 3, WITHOUT an id */ }
+})
+```
+
+Every persona gets fully expanded individual `a_` entries — never
+compress into ranges. Stamp each assertion's `source_id` with the
+`src_` id step 5a returned and its `log_entry_id` with step 4's `logId`.
+
+**5c. Write `tree.gedcomx.json`** — append the `S` entry to `sources`.
+This file is not a `research_append` section; write it directly. Root
+has exactly three keys: `persons`, `relationships`, `sources` — do not
+add `id` or other keys at root. Optional `S` fields (author, url) must
+be omitted if not applicable — never set to `null`.
+
+Before appending, double-check the fields the validator is strict about,
+so each `research_append` passes on the first call:
 - `record_id` uses the correct format (full URL for FamilySearch, not bare ARK)
 - `record_persona_id` is set (non-null) for `record_search` sources
 - All required assertion fields are present (informant, informant_proximity, evidence_type)
 - The GedcomX `S` entry has only allowed fields (id, title, citation, author, url)
 
-### 7. Present results
+### 6. Present results
 
 Show source, assertions by person-role, and classifications. Suggest
 assertion-classification or person-evidence as next steps.
@@ -474,11 +516,12 @@ log entries for them. Report verbally only.
 
 When a search returned nil results and the absence is analytically
 meaningful (e.g., "Patrick should appear in the 1870 census but
-doesn't"), create a negative assertion:
+doesn't"), append a negative assertion via `research_append`
+(`section: "assertions", op: "append"`) — like any other assertion,
+without an `id`:
 
 ```json
 {
-  "id": "a_015",
   "source_id": "src_005",
   "record_id": "<the record/collection that was searched>",
   "record_role": "absent",
@@ -535,20 +578,23 @@ Note the per-fact informant analysis with reasoning in
 
 ## Re-invocation behavior
 
-**Writes:** new entries in `sources` (`src_` ids), `assertions`
-(`asn_` ids), and `log` (append-only `log_` ids) in `research.json`,
-plus the corresponding GedcomX `sources` in `tree.gedcomx.json` and
-optionally a `results/log_NNN.json` sidecar for the underlying search.
+**Writes:** new entries in `sources` (`src_` ids) and `assertions`
+(`a_` ids) via `research_append`, and `log` (append-only `log_` ids)
+via `research_log_append` — all in `research.json` — plus the
+corresponding GedcomX `sources` in `tree.gedcomx.json`. When a search's
+results are retained, `research_log_append` also finalizes the
+`results/<log_id>.json` sidecar from the staged handle; the skill never
+writes that sidecar by hand.
 
 **On repeat invocation:** detects whether a source for this record (by
 `gedcomx_source_description_id` or by working citation) already
-exists. If so, refines its working citation and re-derives
-assertions for the same `src_` instead of creating a duplicate
-source. **Always appends a new `log_` entry with the next available
-ID — never modify or overwrite existing log entries.** The log is
+exists. If so, refines its working citation (`research_append`
+`op: "update"`) and re-derives assertions for the same `src_` instead
+of creating a duplicate source. **Always appends a new `log_` entry —
+never modify or overwrite existing log entries.** The log is
 append-only by design (see `docs/specs/research-schema-spec.md` §4).
 
 **Do not duplicate:** never create a second source entry for the same
 underlying record. If working-citation lookup matches an existing
 `src_`, reuse that id. Assertions tied to that source are refined
-in place by `asn_` id, not duplicated.
+in place via `research_append` `op: "update"`, not duplicated.

--- a/packages/engine/plugin/skills/record-extraction/references/research-log-protocol.md
+++ b/packages/engine/plugin/skills/record-extraction/references/research-log-protocol.md
@@ -35,83 +35,38 @@ that makes "reasonably exhaustive" claims provable.
    the results it returned are retained too, so a later step can
    re-examine or refute them (GPS Element 1 — reasonably exhaustive
    research). For tool-payload searches (`record_search`,
-   `fulltext_search`) the raw response is written to a sidecar file —
-   see "Result sidecar files" below. External-site searches retain the
-   captured PDF/HTML instead, via `external_site.capture_filename`. A
-   search that returns nothing retains nothing — `results_ref` is null.
+   `fulltext_search`) the raw response is retained as a sidecar at
+   `results/<log_id>.json`. External-site searches retain the captured
+   PDF/HTML instead, via `external_site.capture_filename`. A search that
+   returns nothing retains nothing.
 
-## Log entry structure
+## Writing log entries with `research_log_append`
 
-```json
-{
-  "id": "log_001",
-  "plan_item_id": "pli_001",
-  "performed": "2026-05-04T10:15:00Z",
-  "tool": "record_search",
-  "query": {
-    "surname": "Flynn",
-    "given": "Patrick",
-    "birth_year": 1845,
-    "birth_place": "Pennsylvania",
-    "collection": "1850 Census"
-  },
-  "outcome": "positive",
-  "results_examined": 8,
-  "results_available": 1240,
-  "results_ref": "results/log_001.json",
-  "notes": "1,240 1850-census hits; 8 examined; Patrick Flynn age 5 found in household of Thomas Flynn.",
-  "external_site": null
-}
-```
+Log entries — and their sidecars — are written by the
+`research_log_append` MCP tool, not by hand. The tool assigns the
+`log_` id, stamps `performed`, sets `results_ref`, and (when a search's
+results were retained) finalizes the `results/<log_id>.json` sidecar
+from the staged handle the search tool returned, recomputing
+`returned_count` itself. You never serialize the payload, allocate the
+id, or wire `results_ref` by hand — pass the analytical inputs and the
+`stagedResultsRef` handle, and the tool does the clerical work.
 
-- `results_examined` — how many results you actually triaged.
-- `results_available` — the total hit count the tool reported, or null
+- `resultsExamined` — how many results you actually triaged.
+- `resultsAvailable` — the total hit count the tool reported, or null
   when the tool reports no total.
-- `results_ref` — path to the result sidecar (see below), or null.
 - `notes` — a one-line human summary of what the search returned.
-
-## Result sidecar files
-
-The raw results of a tool-payload search are not stored inline in
-`research.json` — that file is read by every skill at startup and must
-stay lean. Instead the search skill writes the full response to a
-sidecar file `results/<log_id>.json` in the project folder and sets
-`results_ref` on the log entry to point at it.
-
-Sidecar file shape:
-
-```json
-{
-  "log_id": "log_001",
-  "tool": "record_search",
-  "retrieved": "2026-05-04T10:15:00Z",
-  "returned_count": 12,
-  "payload": { "...": "the verbatim MCP tool response" }
-}
-```
-
-- `returned_count` must equal the number of results in `payload` — it
-  is the integrity check that catches a truncated write.
-- **Write fidelity.** Reproducing a large payload into a single `Write`
-  is reliable up to ~50 results. Write single-shot for **≤40 results**;
-  for larger payloads write in **~40-result chunks** (appended).
-  validate-schema verifies `returned_count` against the payload either
-  way.
-- **Nil searches write no sidecar.** When a search returns zero
-  results, leave `results_ref` null — the log entry's `outcome` and
-  counts already record the nil.
-- **If retention fails.** If the sidecar cannot be written faithfully
-  (the integrity check keeps failing after a retry), set `results_ref`
-  to null, note it in the log entry's `notes`, and tell the user
-  plainly that the search's results could not be retained.
-- External-site searches write no sidecar; their capture is retained
-  via `external_site.capture_filename`.
+- `stagedResultsRef` — the `staged.resultsRef` handle from a
+  `record_search` / `fulltext_search` you called with `projectPath`.
+  Omit it for nil searches and external-site searches (no sidecar).
+- A staged handle can expire (TTL ~24h); on a stale handle
+  `research_log_append` returns `{ ok: false }` and writes nothing.
+  Re-run the search (it re-stages cheaply) and pass the fresh handle.
 
 ## When record-extraction writes log entries
 
-record-extraction writes a log entry **only** when processing a
-record that was not produced by search-records or
+record-extraction calls `research_log_append` **only** when processing
+a record that was not produced by search-records or
 search-external-sites — e.g., a user-provided PDF uploaded directly.
 When a search skill already logged the search, link to that log
 entry by setting `log_entry_id` on each new source and assertion,
-rather than creating a duplicate log entry.
+rather than appending a duplicate log entry.

--- a/packages/engine/plugin/skills/record-extraction/references/validation-protocol.md
+++ b/packages/engine/plugin/skills/record-extraction/references/validation-protocol.md
@@ -2,16 +2,20 @@
 
 After writing to `research.json` or `tree.gedcomx.json`, follow these steps:
 
-1. **Invoke `validate-schema`** to verify both files conform to the
-   published schemas. If validation fails, fix the errors before
-   proceeding.
+1. **Structural validation is handled by the write tools.**
+   `research_append` and `research_log_append` validate the whole
+   project before persisting and write nothing on `{ ok: false,
+   errors }` — so there is no separate `validate-schema` pass for the
+   entries they write. Surface any returned errors and correct the
+   offending entry. (`validate-schema` remains available as a manual
+   audit when you want to re-check the project as a whole.)
 
 2. **Invoke `check-warnings`** if you added assertions or
    person_evidence entries. This checks for genealogical
    impossibilities (married before 12, died after 120, child born
-   after parent's death, etc.).
-
-These are not auto-triggered — you must invoke them explicitly.
+   after parent's death, etc.). It is NOT auto-triggered — you must
+   invoke it explicitly, and it is not structural validation, so the
+   write tools do not run it.
 
 3. **Internal consistency check** (BCG Standard 35): Before
    finalizing, scan the extracted assertions for contradictions

--- a/packages/engine/plugin/skills/research-exhaustiveness/SKILL.md
+++ b/packages/engine/plugin/skills/research-exhaustiveness/SKILL.md
@@ -13,7 +13,7 @@ description: Evaluates whether research on a question is reasonably
   for an open question (use research-plan), or when the user wants to
   write the proof conclusion (use proof-conclusion).
 allowed-tools:
-  - validate_research_schema
+  - research_append
 ---
 
 # Research Exhaustiveness
@@ -67,10 +67,8 @@ Write a 1-2 sentence assessment for each:
 
 ## 4. Decide: declare or continue
 
-**Declare exhaustive** if all criteria are met. Set the question's
-`status` to `"exhaustive_declared"` and write a filled
-`exhaustive_declaration` object with `declared: true` (see JSON
-example below).
+**Declare exhaustive** if all criteria are met. Persist the
+declaration and flip the status in one call (see Step 5).
 
 **Do not declare** if criteria are unmet. Explain what is missing and
 recommend either expanding the plan (`research-plan`) or, if no further
@@ -87,31 +85,67 @@ meet the GPS standard.
 
 ## 5. Write the declaration
 
-```json
-{
-  "status": "exhaustive_declared",
-  "exhaustive_declaration": {
-    "declared": true,
-    "justification": "Searched 1850 and 1860 censuses (FamilySearch, Ancestry), death certificate (FamilySearch), and probate records (FamilySearch). Three independent sources confirm parentage.",
-    "log_entry_ids": ["log_001", "log_002", "log_003"],
-    "stop_criteria": {
-      "goal_alignment": "Yes — three sources name Thomas Flynn as Patrick's father.",
-      "repository_breadth": "Census, vital records, and probate all searched.",
-      "original_substitution": "Original images accessed; derivative index confirmed.",
-      "independent_verification": "Three independent sources with different informants.",
-      "evidence_class": "1860 census (original, primary) and death certificate (original, direct).",
-      "conflict_resolution": "Birthplace conflict resolved per preponderance hierarchy.",
-      "overturn_risk": "Low. No unexamined record type likely to name a different father."
+Persist the declaration with `research_append` `op: "update"` on the
+question. The tool assigns nothing here — you pass the analytical
+judgment (the `stop_criteria` assessments and the `log_entry_ids` you
+gathered) and it validates-before-persist and writes atomically.
+
+**Declare exhaustive** (all criteria met) — sets `status` and the
+filled declaration in one call:
+
+```
+research_append({
+  projectPath: "<absolute-path-to-project-directory>",
+  section: "questions",
+  op: "update",
+  entryId: "<q_ id of the question being evaluated>",
+  fields: {
+    status: "exhaustive_declared",
+    exhaustive_declaration: {
+      declared: true,
+      justification: "Searched 1850 and 1860 censuses (FamilySearch, Ancestry), death certificate (FamilySearch), and probate records (FamilySearch). Three independent sources confirm parentage.",
+      log_entry_ids: ["log_001", "log_002", "log_003"],
+      stop_criteria: {
+        goal_alignment: "Yes — three sources name Thomas Flynn as Patrick's father.",
+        repository_breadth: "Census, vital records, and probate all searched.",
+        original_substitution: "Original images accessed; derivative index confirmed.",
+        independent_verification: "Three independent sources with different informants.",
+        evidence_class: "1860 census (original, primary) and death certificate (original, direct).",
+        conflict_resolution: "Birthplace conflict resolved per preponderance hierarchy.",
+        overturn_risk: "Low. No unexamined record type likely to name a different father."
+      }
     }
   }
-}
+})
 ```
 
-## 6. Validate and present
+**Early termination** (`declared: false`) — leave `status` as
+`"in_progress"`; pass only `exhaustive_declaration`, NOT `status`:
 
-Call `validate_research_schema({ projectPath: "<absolute-path-to-project-directory>" })`
-to verify both research.json and tree.gedcomx.json are valid. If validation
-fails, fix the errors before presenting. Tell the user:
+```
+research_append({
+  projectPath: "<absolute-path-to-project-directory>",
+  section: "questions",
+  op: "update",
+  entryId: "<q_ id of the question being evaluated>",
+  fields: {
+    exhaustive_declaration: {
+      declared: false,
+      justification: "Probate and church records for the parish were destroyed in an 1862 fire; no surviving source names the father. Terminating for lack of further known sources.",
+      log_entry_ids: ["log_001", "log_002"],
+      stop_criteria: { /* honest per-criterion assessment of what was and wasn't met */ }
+    }
+  }
+})
+```
+
+If the call returns `{ ok: false, errors }`, surface the errors to the
+user and fix the offending field — do not retry the same payload
+blindly.
+
+## 6. Present
+
+Tell the user:
 - If exhaustive: "Research declared reasonably exhaustive. Ready for
   proof-conclusion."
 - If not: "Not yet exhaustive. [What's missing.] Create a plan to
@@ -141,15 +175,16 @@ fails, fix the errors before presenting. Tell the user:
 - **Plan items still in progress:** Refuse to declare; recommend
   completing the in-flight work first.
 - **Already declared:** If `exhaustive_declaration.declared` is
-  already true, do not re-declare and do not modify `research.json`
-  at all — no status changes, no field updates. Report the existing
-  declaration and suggest `proof-conclusion` instead.
+  already true, do not re-declare — re-running the Step 5 `update` on
+  an already-declared question is a structural no-op. Report the
+  existing declaration and suggest `proof-conclusion` instead.
 
 ## Re-invocation behavior
 
 **Writes:** the `exhaustive_declaration` object and the `status` field
-on a single `question` (`q_` id) in `research.json`. Writes nothing
-else — no new questions, no `tree.gedcomx.json` changes.
+on a single `question` (`q_` id) via `research_append` `op: "update"`.
+Writes nothing else — no new questions, no `tree.gedcomx.json`
+changes.
 
 **On repeat invocation:** if the question's
 `exhaustive_declaration.declared` is already `true`, does not

--- a/packages/engine/plugin/skills/research-plan/SKILL.md
+++ b/packages/engine/plugin/skills/research-plan/SKILL.md
@@ -21,7 +21,7 @@ allowed-tools:
   - external_links_search
   - volume_search
   - wiki_place_page
-  - validate_research_schema
+  - research_append
 ---
 
 # Research Plan
@@ -29,6 +29,8 @@ allowed-tools:
 **Narration:** Read `researcher_profile.narration_guidance` from `research.json` and apply it as your narration style for this invocation. If absent, default to a one-line preamble per action.
 
 **Places:** When resolving or writing places, follow `references/places-guidance.md` — resolve with `place_search` / `place_search_all` and record the `standardPlace` (and `standard_place` on persisted facts/assertions/events).
+
+**All writes to the `plans` and `plan_items` sections go through `research_append` — never hand-assemble the JSON and write `research.json` yourself.** The tool assigns the `pl_` / `pli_` id, enforces the schema and the one-active-plan-per-question invariant before persisting, and writes atomically; on `{ ok: false, errors }` it writes nothing. Surface those errors and fix the input rather than retrying blindly. Because the tool validates before persisting, there is no separate post-write `validate_research_schema` step.
 
 Given a specific research question, produces a concrete plan to answer
 it: which record sets to search, in what order, from which repositories,
@@ -192,51 +194,55 @@ items may indicate the question is too broad — consider splitting.
 
 ### 5. Write the plan
 
-Add a new plan to `research.json` `plans[]`:
+Write the plan in two phases: append the plan shell, then append each
+plan item into it.
 
-```json
-{
-  "id": "pl_003",
-  "question_id": "q_003",
-  "status": "active",
-  "created": "2026-05-04",
-  "items": [
-    {
-      "id": "pli_007",
-      "sequence": 1,
-      "record_type": "probate",
-      "jurisdiction": "Schuylkill County, Pennsylvania",
-      "date_range": "1875-1890",
-      "repository": "FamilySearch",
-      "rationale": "Thomas Flynn likely died circa 1881 (disappears from tax records). Schuylkill County probate records 1810-1920 are indexed on FamilySearch. A will naming Patrick as a son would be direct evidence of parentage.",
-      "fallback_for": null,
-      "status": "planned"
-    },
-    {
-      "id": "pli_008",
-      "sequence": 2,
-      "record_type": "probate",
-      "jurisdiction": "Schuylkill County, Pennsylvania",
-      "date_range": "1875-1890",
-      "repository": "Ancestry",
-      "rationale": "Ancestry has a separate probate index for Schuylkill County. Cross-check in case FamilySearch indexing missed the record.",
-      "fallback_for": null,
-      "status": "planned"
-    },
-    {
-      "id": "pli_009",
-      "sequence": 3,
-      "record_type": "land",
-      "jurisdiction": "Schuylkill County, Pennsylvania",
-      "date_range": "1850-1885",
-      "repository": "FamilySearch",
-      "rationale": "If no probate record exists, land deeds may name Thomas Flynn's heirs. Also useful for FAN research — witnesses on deeds are often family members.",
-      "fallback_for": "pli_007",
-      "status": "planned"
-    }
-  ]
-}
+**Phase 1 — append the plan shell.** Omit the `id` (the tool assigns
+the `pl_` id) and omit `items` (you add those in Phase 2):
+
 ```
+research_append({
+  section: "plans",
+  op: "append",
+  entry: {
+    question_id: "q_003",
+    status: "active",
+    created: "2026-05-04"
+  }
+})
+```
+
+The tool rejects a second `active` plan for the same `question_id`
+(one active plan per question). On `{ ok: true, ... }` it returns the
+assigned `entryId` (e.g. `pl_003`) — use that as the `planId` in
+Phase 2.
+
+**Phase 2 — append each plan item.** One call per item, in sequence
+order, targeting the plan from Phase 1 via `planId`. Omit each item's
+`id` (the tool assigns the `pli_` id):
+
+```
+research_append({
+  section: "plan_items",
+  op: "append",
+  planId: "pl_003",
+  entry: {
+    sequence: 1,
+    record_type: "probate",
+    jurisdiction: "Schuylkill County, Pennsylvania",
+    date_range: "1875-1890",
+    repository: "FamilySearch",
+    rationale: "Thomas Flynn likely died circa 1881 (disappears from tax records). Schuylkill County probate records 1810-1920 are indexed on FamilySearch. A will naming Patrick as a son would be direct evidence of parentage.",
+    fallback_for: null,
+    status: "planned"
+  }
+})
+```
+
+For a `fallback_for`, pass the `pli_` id the tool returned for the
+primary item it falls back from (so append the primary before its
+fallback). If a call returns `{ ok: false, errors }`, surface the
+errors and fix the input — do not re-issue the same call blindly.
 
 **Plan item fields:**
 
@@ -256,25 +262,49 @@ Add a new plan to `research.json` `plans[]`:
 If a previous plan for this question exists and all items are searched
 but the question remains unresolved:
 
-1. Set the old plan's status to `superseded`
-2. Create a new plan targeting what the old plan missed (different
-   repositories, adjacent jurisdictions, different record types,
-   FAN-directed searches, contextual sources)
-3. Reference the old plan in the rationale
+1. Supersede the old plan with an `update`:
+
+   ```
+   research_append({
+     section: "plans",
+     op: "update",
+     entryId: "pl_003",
+     fields: { status: "superseded" }
+   })
+   ```
+
+   Supersede first — the tool rejects a new `active` plan while another
+   `active` plan exists for the same `question_id`.
+
+2. Create a new plan (Step 5) targeting what the old plan missed
+   (different repositories, adjacent jurisdictions, different record
+   types, FAN-directed searches, contextual sources). Reference the old
+   plan in the rationale.
 
 Never modify a superseded plan — it is part of the audit trail.
 
 **Termination (BCG Standard 18):** If all identified sources are
-exhausted or inaccessible and the question remains unresolved, set
-the plan status to `exhausted`. Note explicitly that the GPS cannot
-be met. This is an acceptable outcome — not every question is
-answerable with available records.
+exhausted or inaccessible and the question remains unresolved, set the
+plan status to `exhausted` with an update:
 
-### 7. Validate and present
+```
+research_append({
+  section: "plans",
+  op: "update",
+  entryId: "pl_003",
+  fields: { status: "exhausted" }
+})
+```
 
-Call `validate_research_schema({ projectPath: "<absolute-path-to-project-directory>" })`
-to verify both research.json and tree.gedcomx.json are valid. If validation
-fails, fix the errors before presenting. Then present the plan to the user:
+Note explicitly that the GPS cannot be met. This is an acceptable
+outcome — not every question is answerable with available records.
+
+### 7. Present
+
+`research_append` validates each plan and plan-item before persisting,
+so there is no separate post-write validation step. If any call
+returned `{ ok: false, errors }`, fix the input and re-issue that call
+before presenting. Then present the plan to the user:
 
 - The question being addressed
 - Each plan item with its rationale, in execution order

--- a/packages/engine/plugin/skills/research-plan/references/validation-protocol.md
+++ b/packages/engine/plugin/skills/research-plan/references/validation-protocol.md
@@ -1,14 +1,16 @@
 # Validation Protocol
 
-After writing to `research.json` or `tree.gedcomx.json`, follow these steps:
+The persistence tools (`research_append`, the merge / `tree_edit`
+tools) validate the whole project before writing and persist nothing
+on `{ ok: false, errors }` — a successful write is already
+schema-valid, so no separate post-write schema validation is needed.
 
-1. **Invoke `validate-schema`** to verify both files conform to the
-   published schemas. If validation fails, fix the errors before
-   proceeding.
+After writing, still:
 
-2. **Invoke `check-warnings`** if you added assertions or
+1. **Invoke `check-warnings`** if you added assertions or
    person_evidence entries. This checks for genealogical
    impossibilities (married before 12, died after 120, child born
-   after parent's death, etc.).
+   after parent's death, etc.) — plausibility, not structure, so the
+   write tools do not cover it.
 
-These are not auto-triggered — you must invoke them explicitly.
+This is not auto-triggered — you must invoke it explicitly.

--- a/packages/engine/plugin/skills/search-external-sites/SKILL.md
+++ b/packages/engine/plugin/skills/search-external-sites/SKILL.md
@@ -16,7 +16,8 @@ description: Generates search URLs for external genealogy sites (Ancestry,
 allowed-tools:
   - place_search
   - external_links_search
-  - validate_research_schema
+  - research_log_append
+  - research_append
 ---
 
 # Search External Sites
@@ -212,32 +213,40 @@ nothing happened: downstream skills, the user's next session, and the
 "reasonably exhaustive" audit trail all go blind. The capture may never
 come back; the log is the proof the search was launched.
 
-Append this entry to the **end** of `research.json#log[]` (the log is
-append-only — see "Re-invocation"), filling in the real values:
+Call `research_log_append` — it assigns the `log_NNN` id, stamps
+`performed`, validates the whole project before persisting, and writes
+`research.json` atomically (the log is append-only — see "Re-invocation"):
 
-```json
-{
-  "id": "log_NNN",
-  "plan_item_id": "pli_XXX_or_null",
-  "performed": "<ISO-8601-utc>",
-  "tool": "external_site",
-  "query": { /* the params you encoded in the URL */ },
-  "outcome": "partial",
-  "results_examined": 0,
-  "notes": "URL generated; awaiting user capture.",
-  "external_site": {
-    "site": "<ancestry|myheritage|findmypast|findagrave|newspapers>",
-    "url_generated": "<the exact URL you present below>",
-    "capture_received": false,
-    "capture_filename": null
+```
+research_log_append({
+  projectPath: <absolute path of the current working directory>,
+  planItemId: "<pli_XXX or null>",
+  tool: "external_site",
+  query: { /* the params you encoded in the URL */ },
+  outcome: "partial",
+  resultsExamined: 0,
+  notes: "URL generated; awaiting user capture.",
+  externalSite: {
+    site: "<ancestry|myheritage|findmypast|findagrave|newspapers>",
+    urlGenerated: "<the exact URL you present below>",
+    captureReceived: false,
+    captureFilename: null
   }
-}
+})
 ```
 
-`outcome: "partial"` + `capture_received: false` mark it in-flight. When a
+`projectPath` is the project folder you are already operating in (the
+directory that contains `research.json`). Pass its absolute path.
+External-site searches retain no result sidecar, so do **not** pass
+`stagedResultsRef`.
+
+`outcome: "partial"` + `captureReceived: false` mark it in-flight. When a
 capture comes back you append a **new** entry (step 6) — never edit this
-one. Run `validate_research_schema` after the write
-(`references/validation-protocol.md`).
+one.
+
+If the call returns `{ ok: false, errors }`, surface the errors and fix
+the inputs rather than retrying blindly or hand-writing the entry; nothing
+was written. On success the response carries the `logId` it assigned.
 
 Then present the URL:
 
@@ -298,13 +307,14 @@ user picks which records are worth examining.
 ### 6. Log results, including nil results
 
 Every search gets logged in enough detail to reproduce it — site,
-collection, all parameters, filters, results examined
-(`references/research-log-protocol.md`). When a capture comes back, append
-a new entry:
+collection, all parameters, filters, results examined. When a capture
+comes back, append a **new** `research_log_append` entry (never edit the
+in-flight one from step 4). Set `query` to the same params, set
+`externalSite.captureReceived: true`, and choose `outcome` from your
+triage:
 
-- **Results found** → `outcome: "positive"`, `results_examined: <n>`,
-  `capture_received: true`, `capture_filename` set; `notes` summarize the
-  matches.
+- **Results found** → `outcome: "positive"`, `resultsExamined: <n>`,
+  `externalSite.captureFilename` set; `notes` summarize the matches.
 - **Nil result** → `outcome: "negative"`. A search that legitimately finds
   nothing is a *finding*, not a failure. In `notes` record what collection
   was searched, its known coverage gaps, and whether the absence is
@@ -314,6 +324,27 @@ a new entry:
 - **No access** (subscription/login wall the user can't pass) →
   `outcome: "error"` with the reason; suggest the fallback plan item.
 
+```
+research_log_append({
+  projectPath: <absolute path of the current working directory>,
+  planItemId: "<pli_XXX or null>",
+  tool: "external_site",
+  query: { /* the same params you encoded in the URL */ },
+  outcome: "<positive|negative|error>",
+  resultsExamined: <n>,
+  notes: "<one-line summary of what the capture returned>",
+  externalSite: {
+    site: "<ancestry|myheritage|findmypast|findagrave|newspapers>",
+    urlGenerated: "<the URL you generated in step 4>",
+    captureReceived: true,
+    captureFilename: "<the uploaded PDF's filename, or null>"
+  }
+})
+```
+
+If the call returns `{ ok: false, errors }`, surface the errors and
+correct the inputs — nothing was written.
+
 Before calling a site exhausted on zero results, try at least two
 variations (name variant, broader place, dropped parameter) — log each as
 its own entry (`references/search-strategy-external.md`, "Exit criteria").
@@ -322,8 +353,22 @@ in courthouses, parish archives, and historical societies.
 
 ### 7. Update status and suggest the next step
 
-Set the plan item to `completed` once the search is logged, found or not.
-Then offer the natural next move:
+Set the plan item to `completed` once the search is logged, found or not,
+via `research_append` (it validates and writes atomically):
+
+```
+research_append({
+  projectPath: <absolute path of the current working directory>,
+  section: "plan_items",
+  op: "update",
+  planId: "<pl_XXX, the parent plan>",
+  entryId: "<pli_XXX, the plan item you searched>",
+  fields: { status: "completed" }
+})
+```
+
+If it returns `{ ok: false, errors }`, surface the errors rather than
+hand-editing the status. Then offer the natural next move:
 - More plan items → "Shall I continue with the next search?"
 - A record worth examining → "Capture the full record page for result #1?"
 - All done → "All planned searches are complete — evaluate whether

--- a/packages/engine/plugin/skills/search-external-sites/references/research-log-protocol.md
+++ b/packages/engine/plugin/skills/search-external-sites/references/research-log-protocol.md
@@ -34,78 +34,27 @@ that makes "reasonably exhaustive" claims provable.
 7. **Retain the raw results.** A log entry records *that* a search ran;
    the results it returned are retained too, so a later step can
    re-examine or refute them (GPS Element 1 — reasonably exhaustive
-   research). For tool-payload searches (`record_search`,
-   `fulltext_search`) the raw response is written to a sidecar file —
-   see "Result sidecar files" below. External-site searches retain the
-   captured PDF/HTML instead, via `external_site.capture_filename`. A
-   search that returns nothing retains nothing — `results_ref` is null.
+   research). External-site searches retain the captured PDF/HTML via
+   `external_site.capture_filename` — there is no result sidecar. (For
+   tool-payload searches, `research_log_append` finalizes the sidecar
+   itself from the search's staged handle; an external-site search never
+   passes one.)
 
-## Log entry structure
+## What you supply, what the tool owns
 
-```json
-{
-  "id": "log_001",
-  "plan_item_id": "pli_001",
-  "performed": "2026-05-04T10:15:00Z",
-  "tool": "record_search",
-  "query": {
-    "surname": "Flynn",
-    "given": "Patrick",
-    "birth_year": 1845,
-    "birth_place": "Pennsylvania",
-    "collection": "1850 Census"
-  },
-  "outcome": "positive",
-  "results_examined": 8,
-  "results_available": 1240,
-  "results_ref": "results/log_001.json",
-  "notes": "1,240 1850-census hits; 8 examined; Patrick Flynn age 5 found in household of Thomas Flynn.",
-  "external_site": null
-}
-```
+You call `research_log_append` with the analytical fields below; the tool
+assigns the `log_NNN` id, the `performed` timestamp, and `results_ref`,
+validates the project, and writes atomically. The persisted entry is
+snake_case; you pass the camelCase tool parameters.
 
-- `results_examined` — how many results you actually triaged.
-- `results_available` — the total hit count the tool reported, or null
-  when the tool reports no total.
-- `results_ref` — path to the result sidecar (see below), or null.
+- `outcome` — your judgment: `positive` / `negative` / `partial` / `error`.
+- `resultsExamined` — how many results you actually triaged (0 for a nil
+  search).
+- `resultsAvailable` — the total hit count the tool reported, or null.
 - `notes` — a one-line human summary of what the search returned.
-
-## Result sidecar files
-
-The raw results of a tool-payload search are not stored inline in
-`research.json` — that file is read by every skill at startup and must
-stay lean. Instead the search skill writes the full response to a
-sidecar file `results/<log_id>.json` in the project folder and sets
-`results_ref` on the log entry to point at it.
-
-Sidecar file shape:
-
-```json
-{
-  "log_id": "log_001",
-  "tool": "record_search",
-  "retrieved": "2026-05-04T10:15:00Z",
-  "returned_count": 12,
-  "payload": { "...": "the verbatim MCP tool response" }
-}
-```
-
-- `returned_count` must equal the number of results in `payload` — it
-  is the integrity check that catches a truncated write.
-- **Write fidelity.** Reproducing a large payload into a single `Write`
-  is reliable up to ~50 results. Write single-shot for **≤40 results**;
-  for larger payloads write in **~40-result chunks** (appended).
-  validate-schema verifies `returned_count` against the payload either
-  way.
-- **Nil searches write no sidecar.** When a search returns zero
-  results, leave `results_ref` null — the log entry's `outcome` and
-  counts already record the nil.
-- **If retention fails.** If the sidecar cannot be written faithfully
-  (the integrity check keeps failing after a retry), set `results_ref`
-  to null, note it in the log entry's `notes`, and tell the user
-  plainly that the search's results could not be retained.
-- External-site searches write no sidecar; their capture is retained
-  via `external_site.capture_filename`.
+- `externalSite` — for an external-site search, `{ site, urlGenerated,
+  captureReceived, captureFilename }`. The tool maps this to the persisted
+  `external_site` object.
 
 ## When record-extraction writes log entries
 

--- a/packages/engine/plugin/skills/search-external-sites/references/validation-protocol.md
+++ b/packages/engine/plugin/skills/search-external-sites/references/validation-protocol.md
@@ -1,14 +1,16 @@
 # Validation Protocol
 
-After writing to `research.json` or `tree.gedcomx.json`, follow these steps:
-
-1. **Invoke `validate-schema`** to verify both files conform to the
-   published schemas. If validation fails, fix the errors before
-   proceeding.
+1. **Structural validation is automatic.** The persistence tools
+   (`research_log_append`, `research_append`, `tree_edit`, the merge
+   tools) validate the whole project *before* writing and persist
+   nothing on `{ ok: false, errors }`. You do not run `validate-schema`
+   after a tool write — if a call returns `{ ok: false }`, fix the
+   inputs and call again. (`validate-schema` remains available as a
+   manual audit of a project you did not just write through a tool.)
 
 2. **Invoke `check-warnings`** if you added assertions or
    person_evidence entries. This checks for genealogical
    impossibilities (married before 12, died after 120, child born
-   after parent's death, etc.).
-
-These are not auto-triggered — you must invoke them explicitly.
+   after parent's death, etc.) — structural validation does not cover
+   genealogical plausibility. It is not auto-triggered; invoke it
+   explicitly.

--- a/packages/engine/plugin/skills/search-full-text/SKILL.md
+++ b/packages/engine/plugin/skills/search-full-text/SKILL.md
@@ -16,6 +16,8 @@ description: Invoke for FamilySearch full-text search (FTS) — immediately
 allowed-tools:
   - fulltext_search
   - source_attachments
+  - research_log_append
+  - research_append
 ---
 
 # Search Full-Text
@@ -134,8 +136,9 @@ Read `references/query-syntax.md` for operator rules.
 **Example queries:**
 
 ```
-# Basic person search (require both terms)
-fulltext_search({ keywords: "+Patrick +Flynn" })
+# Basic person search (require both terms). Pass projectPath so the
+# host stages results and returns a staged.resultsRef for step 8.
+fulltext_search({ keywords: "+Patrick +Flynn", projectPath })
 
 # Phrase search
 fulltext_search({ keywords: '+"Patrick Flynn"' })
@@ -166,7 +169,11 @@ fulltext_search({ imageGroupNumber: "4057677" })
 
 ### 6. Execute and iterate
 
-Call `fulltext_search` with the constructed query.
+Call `fulltext_search` with the constructed query. **Always pass
+`projectPath`** (the absolute path to the project folder) so the host
+stages the raw results: the response gains a `staged.resultsRef` handle
+you hand to `research_log_append` in step 8 to retain them — you never
+serialize the payload yourself.
 
 **Decision rules by hit count:**
 - **0 results** → See step 10 (handle nil results)
@@ -207,75 +214,59 @@ detail.
 ### 8. Retain results and write the log entry
 
 **Every search gets a log entry and retains its results — no
-exceptions.** Follow the research-log-protocol (see
-`references/research-log-protocol.md`); the essentials:
+exceptions.** Call `research_log_append` once per search. The tool
+assigns the log id and `performed` timestamp, finalizes the staged
+results into the `results/<log_id>.json` sidecar (recomputing the
+count), and validates-before-persist — you supply only the judgment
+(outcome, counts, notes) and the staged handle:
 
-**a. Write the result sidecar.** Write the verbatim `fulltext_search`
-response to `results/<log_id>.json` in the project folder:
-
-```json
-{
-  "log_id": "log_008",
-  "tool": "fulltext_search",
-  "retrieved": "2026-05-04T16:00:00Z",
-  "returned_count": 5,
-  "payload": { "...": "the verbatim fulltext_search response" }
-}
 ```
-
-`returned_count` must equal the number of results in `payload`. Write
-single-shot for ≤40 results; for larger payloads write in ~40-result
-chunks (appended) — full-text searches can return up to 100 snippets,
-so chunking is common here. A search that returns **zero** results
-writes no sidecar.
-
-**b. Write the log entry**, with `results_ref` pointing at the sidecar
-(null for a nil search) and `results_available` set to the upstream
-`totalResults` count.
-
-**Append, do not rewrite.** Read the existing `log` array from
-`research.json` first, then push the new entry onto its tail and write
-the file back. The log is append-only (research-log-protocol Rule 3) —
-existing log entries must remain byte-identical to what was there
-before. Re-serialising the whole `log` array with new ordering, new
-whitespace, or any modification to a prior entry's fields is a
-violation even when the intent was only to add the new tail. The
-validator `test_log_append_only` will fail the run if any prior entry's
-content differs.
-
-```json
-{
-  "id": "log_008",
-  "plan_item_id": "pli_010",
-  "performed": "2026-05-04T16:00:00Z",
-  "tool": "fulltext_search",
-  "query": {
-    "keywords": "+Flynn +\"Last Will and Testament\"",
-    "recordPlace1": "Pennsylvania",
-    "recordPlace2": "Schuylkill",
-    "yearFrom": 1870,
-    "yearTo": 1890
+research_log_append({
+  projectPath,
+  planItemId: "pli_010",          // null for an ad-hoc search
+  tool: "fulltext_search",
+  query: {
+    keywords: "+Flynn +\"Last Will and Testament\"",
+    recordPlace1: "Pennsylvania",
+    recordPlace2: "Schuylkill",
+    yearFrom: 1870,
+    yearTo: 1890
   },
-  "outcome": "positive",
-  "results_examined": 5,
-  "results_available": 47,
-  "results_ref": "results/log_008.json",
-  "notes": "47 Schuylkill will hits 1870–1890; 5 examined. Thomas Flynn's will (1881) names wife Mary and children Patrick, John, Margaret; Flynn also appears as a witness on two unrelated wills.",
-  "external_site": null
-}
+  outcome: "positive",            // your judgment: positive/negative/partial/error
+  resultsExamined: 5,
+  resultsAvailable: 47,           // upstream totalResults, or null
+  notes: "47 Schuylkill will hits 1870–1890; 5 examined. Thomas Flynn's will (1881) names wife Mary and children Patrick, John, Margaret; Flynn also appears as a witness on two unrelated wills.",
+  stagedResultsRef: staged.resultsRef   // omit for a nil search
+})
 ```
 
-`notes` is a one-line human summary of what the search returned.
+`notes` is a one-line human summary of what the search returned. For a
+**nil** search, omit `stagedResultsRef` entirely (no sidecar is
+written) and set `resultsExamined: 0`.
 
-**c. Verify the sidecar.** validate-schema checks `returned_count`
-against the payload. If the sidecar cannot be written faithfully (the
-count keeps mismatching after one retry), set `results_ref` to null,
-note the failure in the log entry's `notes`, and **tell the user
-plainly** that this search's results could not be retained.
+**Recovery.** If the search response is stale or the
+`staged.resultsRef` handle has expired (the host's staging TTL lapsed),
+re-run the `fulltext_search` (with `projectPath`) to re-stage — it is
+cheap. If `research_log_append` returns `{ ok: false, errors }`, surface
+the errors to the user rather than retrying blindly.
 
 ### 9. Update plan item status
 
-Set the plan item's `status` to:
+Route the plan-item `status` mutation through `research_append`
+(it validates-before-persist and writes nothing on `{ ok: false }`):
+
+```
+research_append({
+  projectPath,
+  section: "plan_items",
+  op: "update",
+  planId: "pl_003",        // the parent plan's pl_ id
+  entryId: "pli_010",      // the plan item's pli_ id
+  fields: { status: "completed" }
+})
+```
+
+Set `status` to:
 - `completed`: Search executed regardless of outcome
 - `skipped`: The search was determined to be unnecessary (e.g., the
   question was already answered by a prior search)
@@ -284,7 +275,9 @@ Set the plan item's `status` to:
 
 When a search returns no results:
 
-1. Log the nil result with `outcome: "negative"`. **The `notes` field on a negative log entry must explicitly state the collection class searched, the place filters and date range applied, the spelling/variant forms queried, and the count of variants tried before declaring negative** (for example: "Searched FamilySearch FTS, FamilySearch Probate collections, Schuylkill County, Pennsylvania, 1870–1890; 5 variants tried (+'Patrick Flynn', +Patrick +Flynn, +Patrick +Flinn, +Patrick +Flunn, +Flynn surname-only); 0 results — FTS coverage gap probable; recommend indexed search-records or volume browse"). A bare "no results" note is insufficient for the GPS exhaustive-search audit trail; the future reader must be able to see the search scope without re-deriving it from the query payload.
+1. Log the nil result via `research_log_append` with `outcome:
+   "negative"`, `resultsExamined: 0`, and **no** `stagedResultsRef`
+   (a nil search retains no sidecar). **The `notes` field on a negative log entry must explicitly state the collection class searched, the place filters and date range applied, the spelling/variant forms queried, and the count of variants tried before declaring negative** (for example: "Searched FamilySearch FTS, FamilySearch Probate collections, Schuylkill County, Pennsylvania, 1870–1890; 5 variants tried (+'Patrick Flynn', +Patrick +Flynn, +Patrick +Flinn, +Patrick +Flunn, +Flynn surname-only); 0 results — FTS coverage gap probable; recommend indexed search-records or volume browse"). A bare "no results" note is insufficient for the GPS exhaustive-search audit trail; the future reader must be able to see the search scope without re-deriving it from the query payload.
 2. **Iterate through variants before declaring negative — but cap
    total queries (initial + retries) at 5 per plan item.** Pick the
    most promising 4 variants from `references/search-strategies.md`
@@ -374,17 +367,16 @@ After completing a search (or a batch of searches from the plan):
 
 ## Re-invocation behavior
 
-**Writes:** a new entry in the `log` section of `research.json`
-(append-only), a new `results/log_NNN.json` sidecar file with the
-raw `fulltext_search` payload, and updates the `status` field on
-the corresponding plan item.
+**Writes:** via `research_log_append`, a new entry in the `log` section
+of `research.json` (append-only) plus its `results/log_NNN.json`
+sidecar (the tool finalizes the staged payload); and, via
+`research_append`, the `status` field on the corresponding plan item.
 
-**On repeat invocation:** always appends a new `log_` entry and writes a
-new sidecar — re-running the search is itself a logged event.
-Updates the plan item's `status` if applicable.
+**On repeat invocation:** always appends a new `log_` entry — re-running
+the search is itself a logged event. Updates the plan item's `status`
+if applicable.
 
-**Do not duplicate:** never modify or delete prior `log_` entries or
-overwrite an existing sidecar. The append-only rule keeps the
-exhaustive-search declaration auditable. Two consecutive runs of
-the same query produce two log entries and two sidecars; that's
-correct.
+**Do not duplicate:** the log is append-only and `research_log_append`
+only appends (no update or delete), so prior `log_` entries and their
+sidecars are never touched. Two consecutive runs of the same query
+produce two log entries and two sidecars; that's correct.

--- a/packages/engine/plugin/skills/search-full-text/references/research-log-protocol.md
+++ b/packages/engine/plugin/skills/search-full-text/references/research-log-protocol.md
@@ -74,37 +74,26 @@ that makes "reasonably exhaustive" claims provable.
 
 The raw results of a tool-payload search are not stored inline in
 `research.json` — that file is read by every skill at startup and must
-stay lean. Instead the search skill writes the full response to a
-sidecar file `results/<log_id>.json` in the project folder and sets
-`results_ref` on the log entry to point at it.
+stay lean. Instead the results live in a sidecar file
+`results/<log_id>.json` in the project folder, and `results_ref` on the
+log entry points at it.
 
-Sidecar file shape:
+**The sidecar is written by the tool, not by hand.** Call the search
+with `projectPath` so the host stages the raw response; then pass the
+returned `staged.resultsRef` to `research_log_append`, which finalizes
+it into `results/<log_id>.json` (assigning the id, recomputing the
+count, validating before persist). You never serialize the payload,
+allocate the id, chunk a large write, or verify the count yourself.
 
-```json
-{
-  "log_id": "log_001",
-  "tool": "record_search",
-  "retrieved": "2026-05-04T10:15:00Z",
-  "returned_count": 12,
-  "payload": { "...": "the verbatim MCP tool response" }
-}
-```
-
-- `returned_count` must equal the number of results in `payload` — it
-  is the integrity check that catches a truncated write.
-- **Write fidelity.** Reproducing a large payload into a single `Write`
-  is reliable up to ~50 results. Write single-shot for **≤40 results**;
-  for larger payloads write in **~40-result chunks** (appended).
-  validate-schema verifies `returned_count` against the payload either
-  way.
-- **Nil searches write no sidecar.** When a search returns zero
-  results, leave `results_ref` null — the log entry's `outcome` and
-  counts already record the nil.
-- **If retention fails.** If the sidecar cannot be written faithfully
-  (the integrity check keeps failing after a retry), set `results_ref`
-  to null, note it in the log entry's `notes`, and tell the user
-  plainly that the search's results could not be retained.
-- External-site searches write no sidecar; their capture is retained
+- **Nil searches retain no sidecar.** When a search returns zero
+  results, omit `stagedResultsRef` — `research_log_append` leaves
+  `results_ref` null, and the log entry's `outcome` and counts record
+  the nil.
+- **Stale staged handle.** If the `staged.resultsRef` has expired
+  (staging TTL lapsed), re-run the search with `projectPath` to
+  re-stage. Surface a `{ ok: false, errors }` from
+  `research_log_append` to the user rather than retrying blindly.
+- External-site searches retain no sidecar; their capture is retained
   via `external_site.capture_filename`.
 
 ## When record-extraction writes log entries

--- a/packages/engine/plugin/skills/search-full-text/references/validation-protocol.md
+++ b/packages/engine/plugin/skills/search-full-text/references/validation-protocol.md
@@ -1,14 +1,17 @@
 # Validation Protocol
 
-After writing to `research.json` or `tree.gedcomx.json`, follow these steps:
+The persistence tools (`research_log_append`, `research_append`,
+`tree_edit`, the merge tools) **validate before they persist** and
+write nothing on `{ ok: false, errors }`. You no longer run a
+post-write structural validation pass by hand — if a write returns
+`{ ok: false }`, fix the inputs and re-call; surface the errors to the
+user rather than retrying blindly. (`validate-schema` remains available
+as a user-invokable audit, but is not a required step after a tool
+write.)
 
-1. **Invoke `validate-schema`** to verify both files conform to the
-   published schemas. If validation fails, fix the errors before
-   proceeding.
-
-2. **Invoke `check-warnings`** if you added assertions or
+1. **Invoke `check-warnings`** if you added assertions or
    person_evidence entries. This checks for genealogical
-   impossibilities (married before 12, died after 120, child born
-   after parent's death, etc.).
-
-These are not auto-triggered — you must invoke them explicitly.
+   plausibility — impossibilities like married before 12, died after
+   120, or a child born after a parent's death — which is judgment the
+   structural validation does not cover. It is not auto-triggered; you
+   must invoke it explicitly.

--- a/packages/engine/plugin/skills/search-records/SKILL.md
+++ b/packages/engine/plugin/skills/search-records/SKILL.md
@@ -18,6 +18,8 @@ allowed-tools:
   - record_read
   - same_person
   - source_attachments
+  - research_log_append
+  - research_append
 ---
 
 # Search Records
@@ -85,7 +87,8 @@ On demand, load these references for detailed guidance:
   information quality, evidence types
 - `references/research-log-standards.md` — nine essential log
   elements, completeness criteria
-- `references/validation-protocol.md` — post-write schema validation
+- `references/validation-protocol.md` — genealogical plausibility
+  checks (`check-warnings`) after a write
 
 ## MCP tools and routing
 
@@ -215,7 +218,11 @@ spelling of one or both rather than removing givenName entirely.
 
 ### 3. Execute the search
 
-Call the appropriate MCP tool:
+Call the appropriate MCP tool. **Always pass `projectPath`** (the
+absolute path of the project directory you are operating in) so the
+tool stages its raw results host-side and returns a `staged.resultsRef`
+handle — you hand that to `research_log_append` in Step 5 to retain the
+results without re-serializing the payload yourself:
 
 ```
 record_search({
@@ -226,9 +233,14 @@ record_search({
   birthPlace: "Pennsylvania",
   residencePlace: "Schuylkill County, Pennsylvania",
   residenceYearFrom: 1850,
-  residenceYearTo: 1850
+  residenceYearTo: 1850,
+  projectPath: "<absolute-path-to-project-directory>"
 })
 ```
+
+The response carries the full `results[]` for triage plus a `staged`
+field: `{ resultsRef, returnedCount }` on a hit, or `null` for a nil
+search. Hold `staged.resultsRef` for the log call in Step 5.
 
 **If the search fails due to authentication:** Instruct the user
 to log in: "The search requires FamilySearch authentication. Please
@@ -311,93 +323,104 @@ before extraction.
 ### 5. Retain results and write the log entry
 
 **Every search gets a log entry and retains its results — no
-exceptions.** Follow `references/research-log-protocol.md` for the full
-protocol; the essentials:
+exceptions.** Call `research_log_append` once per search. The tool
+assigns the `log_` id, stamps the timestamp, finalizes the staged
+results into the `results/<log_id>.json` sidecar (counting them itself),
+validates the project before persisting, and appends to the tail of
+`log[]` atomically — so you never hand-assemble the entry, count
+results, or worry about ordering. See `references/research-log-protocol.md`
+for the analytical rules (when an outcome is negative, what belongs in
+`query`/`notes`).
 
-**a. Write the result sidecar.** Write the verbatim `record_search`
-response to `results/<log_id>.json` in the project folder:
-
-```json
-{
-  "log_id": "log_006",
-  "tool": "record_search",
-  "retrieved": "2026-05-04T14:30:00Z",
-  "returned_count": 3,
-  "payload": { "...": "the verbatim record_search response" }
-}
 ```
-
-`returned_count` must equal the number of results in `payload`. Write
-single-shot for ≤40 results; for larger payloads write in ~40-result
-chunks (appended).
-
-**One case where no sidecar is written:** The search returns **zero**
-results. In this case `results_ref` is null.
-
-In all other cases (results returned, even from the wrong collection),
-write the sidecar. When the collection doesn't match the intended
-query (collection-mismatch), write the sidecar AND:
-- Set `outcome: "partial"` (not `"negative"` — negative means zero results)
-- Explain the mismatch in `notes` (e.g., "Searched 1870 census; results
-  returned 1850 collection — not a 1870 finding. Sidecar preserved for
-  audit; query should be retried with explicit 1870 collection filter.")
-- **STOP after confirming the mismatch.** Collection-mismatch is not nil — the index returned results, just from the wrong collection. Variant spellings will NOT fix a collection mismatch. In your summary, do NOT suggest variant surname searches as a next step. Instead, suggest consulting a different source (e.g., Ancestry for US census years not well-covered on FamilySearch) or adjusting the collection filter.
-
-**b. Write the log entry**, with `results_ref` pointing at the sidecar
-(null for a nil search) and `results_available` set to the total hit
-count the tool reported:
-
-```json
-{
-  "id": "log_006",
-  "plan_item_id": "pli_007",
-  "performed": "2026-05-04T14:30:00Z",
-  "tool": "record_search",
-  "query": {
-    "surname": "Flynn",
-    "givenName": "Thomas",
-    "deathYearFrom": 1881,
-    "deathYearTo": 1881,
-    "deathPlace": "Schuylkill County, Pennsylvania",
-    "collectionId": 2421317
+research_log_append({
+  projectPath: "<absolute-path-to-project-directory>",
+  tool: "record_search",
+  planItemId: "pli_007",            // or null for an ad-hoc search
+  query: {
+    surname: "Flynn",
+    givenName: "Thomas",
+    deathYearFrom: 1881,
+    deathYearTo: 1881,
+    deathPlace: "Schuylkill County, Pennsylvania",
+    collectionId: 2421317
   },
-  "outcome": "positive",
-  "results_examined": 3,
-  "results_available": 3,
-  "results_ref": "results/log_006.json",
-  "notes": "3 Flynn probate hits; all 3 examined. One matches — Thomas Flynn, will dated 1881; the other two are different Thomas Flynns (wrong county, wrong dates).",
-  "external_site": null
-}
+  outcome: "positive",
+  resultsExamined: 3,
+  resultsAvailable: 3,              // total hit count the tool reported
+  notes: "3 Flynn probate hits; all 3 examined. One matches — Thomas Flynn, will dated 1881; the other two are different Thomas Flynns (wrong county, wrong dates).",
+  stagedResultsRef: staged.resultsRef   // from the record_search response
+})
 ```
 
-`notes` is a one-line human summary of what the search returned.
+- `query` — enough detail to reproduce the search.
+- `resultsExamined` — how many results you actually triaged.
+- `resultsAvailable` — the total hit count the tool reported (or null).
+- `notes` — a one-line human summary of what the search returned.
+- `stagedResultsRef` — the `staged.resultsRef` from Step 3's
+  `record_search` response. **Omit it (or pass null) for a nil search**
+  (the search returned zero results, so there is nothing to retain and
+  `staged` was `null`).
 
-**Append at the end.** Add the new entry to the **tail** of
-`research.json#log[]`. Do not insert mid-array, re-sort, group by
-tool, or otherwise rearrange existing entries. The array's index is
-part of the audit trail — readers (and the per-test validators)
-rely on chronological insertion order.
+The tool returns a compact summary — `{ ok: true, logId, resultsRef,
+returnedCount, filesWritten, validation }`. Narrate from it ("logged as
+log_006; retained 3 results"); do not echo the payload.
 
-**c. Verify the sidecar.** validate-schema checks `returned_count`
-against the payload. If the sidecar cannot be written faithfully (the
-count keeps mismatching after one retry), set `results_ref` to null,
-note the failure in the log entry's `notes`, and **tell the user
-plainly** that this search's results could not be retained.
+**Collection-mismatch.** When the index returns results but from the
+wrong collection (e.g., you searched the 1870 census and got 1850
+results), that is **not a nil result and not a positive finding for the
+asked-for collection.** Call `research_log_append` with:
+- `outcome: "partial"` (not `"negative"` — negative means zero results)
+- a `notes` line explaining the mismatch (e.g., "Searched 1870 census;
+  results returned 1850 collection — not a 1870 finding. Query should be
+  retried with explicit 1870 collection filter.")
+- still pass `stagedResultsRef` (the results were returned and are worth
+  retaining for audit)
+- **STOP after confirming the mismatch.** Variant spellings will NOT fix
+  a collection mismatch. In your summary, do NOT suggest variant surname
+  searches as a next step. Instead, suggest consulting a different source
+  (e.g., Ancestry for US census years not well-covered on FamilySearch)
+  or adjusting the collection filter.
 
 **outcome values:**
 - `positive`: Matching results found
 - `negative`: No matching results (this IS a finding)
-- `partial`: Results found but incomplete (e.g., image unavailable)
+- `partial`: Results found but incomplete (e.g., image unavailable, or
+  collection-mismatch)
 - `error`: Search failed (authentication, server error)
 
-The log entry is append-only — write it once and never modify it.
-When record-extraction later creates sources and assertions from
-this search, it stamps each of them with this entry's `log_entry_id`.
-The search-to-output link lives there, not back on the log entry.
+**If the call returns `{ ok: false, errors }`:** the tool wrote
+nothing. Surface the errors plainly rather than retrying blindly. A
+common cause is a **stale `stagedResultsRef`** — staged result files are
+pruned after ~24h, so if you searched in an earlier session and only now
+log it, the handle may no longer resolve. The fix is cheap: re-run the
+`record_search` (Step 3) to re-stage, then call `research_log_append`
+with the fresh `staged.resultsRef`.
+
+The log entry is append-only — the tool appends it once and offers no
+update or delete. When record-extraction later creates sources and
+assertions from this search, it stamps each of them with this entry's
+`log_entry_id`. The search-to-output link lives there, not back on the
+log entry.
 
 ### 6. Update plan item status
 
-Set the plan item's `status` to:
+Route the plan item's `status` change through `research_append`
+(`op: "update"`) — the tool locates the item by id within its parent
+plan, validates, and persists atomically:
+
+```
+research_append({
+  projectPath: "<absolute-path-to-project-directory>",
+  section: "plan_items",
+  op: "update",
+  planId: "pl_002",          // the parent plan's id
+  entryId: "pli_007",        // the plan item you executed
+  fields: { status: "in_progress" }
+})
+```
+
+Set the `status` field to:
 - `in_progress`: Search executed — work continues downstream in
   record-extraction. Use this whenever you have found records to
   pass on, OR when the search was exhausted with nil results and
@@ -410,6 +433,9 @@ is set by record-extraction once the results have been fully
 analyzed and assertions have been created. Setting it here would
 signal to downstream skills that no further work is needed, which
 is premature.
+
+If the call returns `{ ok: false, errors }`, surface the errors (e.g.
+a stale `entryId`/`planId`) rather than retrying blindly.
 
 ### 7. Pass records to extraction
 
@@ -458,8 +484,10 @@ confirm family composition and can resolve parentage questions.
 
 When a search returns no results:
 
-1. **Log the nil result** with `outcome: "negative"` and exact
-   parameters used.
+1. **Log the nil result** via `research_log_append` with
+   `outcome: "negative"` and the exact parameters used. A nil search
+   retains nothing — omit `stagedResultsRef` (the `record_search`
+   response returned `staged: null`).
 2. **Iterate through search strategy levers** before declaring
    the search negative. Read `references/search-strategy-levers.md`
    for the full catalog. Try at least 3 lever variations for
@@ -525,32 +553,38 @@ search-external-sites).
 
 ## Important rules
 
-- **Log every search.** Each retry gets its own entry. A search
-  without a log entry is a search that didn't happen.
-- **Append-only, end-only.** New log entries go at the tail of
-  `log[]`. Never modify, delete, re-sort, or insert mid-array.
-  Existing entries' positions are fixed.
+- **Log every search.** Each retry gets its own `research_log_append`
+  call. A search without a log entry is a search that didn't happen.
+- **Append-only.** `research_log_append` appends to the tail of `log[]`
+  and offers no update or delete — the audit trail's chronological order
+  is guaranteed by the tool, not by hand.
 - **Don't skip plan items silently.** Set status to `skipped` with
   an explanation if you decide not to execute.
 - **Let the user confirm before extraction.** Show triage results
   first — don't silently extract every hit.
 - **Never fabricate results.** If the MCP tool returns nothing,
   report nothing.
-- **Validate after writes.** Run `validate-schema` after writing
-  to `research.json` (see `references/validation-protocol.md`).
+- **No post-write validation needed.** `research_log_append` and
+  `research_append` validate-before-persist and write nothing on
+  `{ ok: false }`. This skill writes only log entries and plan-item
+  status — neither adds assertions, so `check-warnings` does not apply
+  here (it runs in the skills that create assertions). See
+  `references/validation-protocol.md`.
 
 ## Re-invocation behavior
 
-**Writes:** a new entry in the `log` section of `research.json`
-(append-only), a new `results/log_NNN.json` sidecar file with the
-raw `record_search` payload, and updates the `status` field on the
-corresponding plan item.
+**Writes:** via `research_log_append`, a new entry in the `log` section
+of `research.json` (append-only) and its `results/log_NNN.json` sidecar
+(the tool finalizes the staged `record_search` payload); via
+`research_append`, an update to the `status` field on the corresponding
+plan item.
 
-**On repeat invocation:** always appends a new `log_` entry and writes a
-new sidecar — re-running the search is itself a logged event.
-Updates the plan item's `status` if applicable.
+**On repeat invocation:** always appends a new `log_` entry and a new
+sidecar — re-running the search is itself a logged event. Updates the
+plan item's `status` if applicable.
 
-**Do not duplicate:** never modify or delete prior `log_` entries or
-overwrite an existing sidecar. Two consecutive runs of the same
-query produce two log entries and two sidecars; that's the
-append-only contract that makes the search log auditable.
+**Do not duplicate:** `research_log_append` only appends, never modifies
+prior `log_` entries, and the tool assigns each `log_` id, so two
+consecutive runs of the same query produce two distinct log entries and
+two distinct sidecars; that's the append-only contract that makes the
+search log auditable.

--- a/packages/engine/plugin/skills/search-records/references/research-log-protocol.md
+++ b/packages/engine/plugin/skills/search-records/references/research-log-protocol.md
@@ -4,6 +4,15 @@ This protocol must be followed by every skill that searches for or
 processes genealogical records. The research log is the GPS audit trail
 that makes "reasonably exhaustive" claims provable.
 
+The mechanical side of logging is owned by the **`research_log_append`**
+MCP tool: it assigns the `log_` id, stamps the timestamp, finalizes the
+staged search payload into the `results/<log_id>.json` sidecar (counting
+the results itself), validates before persisting, and appends to the
+tail of `log[]` atomically. You never hand-assemble the entry, count
+results, write a sidecar, or chunk a large payload. This protocol covers
+the **analytical** rules — what to log, when an outcome is negative,
+what belongs in `query`/`notes` — that remain your judgment.
+
 ## Rules
 
 1. **Every search produces a log entry.** No exceptions. If you called
@@ -35,77 +44,34 @@ that makes "reasonably exhaustive" claims provable.
    the results it returned are retained too, so a later step can
    re-examine or refute them (GPS Element 1 — reasonably exhaustive
    research). For tool-payload searches (`record_search`,
-   `fulltext_search`) the raw response is written to a sidecar file —
-   see "Result sidecar files" below. External-site searches retain the
-   captured PDF/HTML instead, via `external_site.capture_filename`. A
-   search that returns nothing retains nothing — `results_ref` is null.
+   `fulltext_search`) you pass the search response's `staged.resultsRef`
+   to `research_log_append` as `stagedResultsRef`, and the tool retains
+   the raw payload in `results/<log_id>.json` for you — no hand-written
+   sidecar, no chunking. External-site searches retain the captured
+   PDF/HTML instead, via `external_site.capture_filename`. A search that
+   returns nothing retains nothing — omit `stagedResultsRef` and the
+   tool sets `results_ref` to null.
 
-## Log entry structure
+## The fields you supply to `research_log_append`
 
-```json
-{
-  "id": "log_001",
-  "plan_item_id": "pli_001",
-  "performed": "2026-05-04T10:15:00Z",
-  "tool": "record_search",
-  "query": {
-    "surname": "Flynn",
-    "given": "Patrick",
-    "birth_year": 1845,
-    "birth_place": "Pennsylvania",
-    "collection": "1850 Census"
-  },
-  "outcome": "positive",
-  "results_examined": 8,
-  "results_available": 1240,
-  "results_ref": "results/log_001.json",
-  "notes": "1,240 1850-census hits; 8 examined; Patrick Flynn age 5 found in household of Thomas Flynn.",
-  "external_site": null
-}
-```
+You provide the analytical content; the tool assigns the id, timestamp,
+`results_ref`, and the sidecar.
 
-- `results_examined` — how many results you actually triaged.
-- `results_available` — the total hit count the tool reported, or null
-  when the tool reports no total.
-- `results_ref` — path to the result sidecar (see below), or null.
+- `tool` — the search tool used (`record_search`, `fulltext_search`, …).
+- `query` — enough detail to reproduce the search.
+- `outcome` — `positive` / `negative` / `partial` / `error`.
+- `resultsExamined` — how many results you actually triaged.
+- `resultsAvailable` — the total hit count the tool reported, or null.
+- `planItemId` — the `pli_` this search addresses, or null for ad-hoc.
 - `notes` — a one-line human summary of what the search returned.
+- `stagedResultsRef` — `staged.resultsRef` from the search response
+  (omit for a nil or external-site search).
 
-## Result sidecar files
-
-The raw results of a tool-payload search are not stored inline in
-`research.json` — that file is read by every skill at startup and must
-stay lean. Instead the search skill writes the full response to a
-sidecar file `results/<log_id>.json` in the project folder and sets
-`results_ref` on the log entry to point at it.
-
-Sidecar file shape:
-
-```json
-{
-  "log_id": "log_001",
-  "tool": "record_search",
-  "retrieved": "2026-05-04T10:15:00Z",
-  "returned_count": 12,
-  "payload": { "...": "the verbatim MCP tool response" }
-}
-```
-
-- `returned_count` must equal the number of results in `payload` — it
-  is the integrity check that catches a truncated write.
-- **Write fidelity.** Reproducing a large payload into a single `Write`
-  is reliable up to ~50 results. Write single-shot for **≤40 results**;
-  for larger payloads write in **~40-result chunks** (appended).
-  validate-schema verifies `returned_count` against the payload either
-  way.
-- **Nil searches write no sidecar.** When a search returns zero
-  results, leave `results_ref` null — the log entry's `outcome` and
-  counts already record the nil.
-- **If retention fails.** If the sidecar cannot be written faithfully
-  (the integrity check keeps failing after a retry), set `results_ref`
-  to null, note it in the log entry's `notes`, and tell the user
-  plainly that the search's results could not be retained.
-- External-site searches write no sidecar; their capture is retained
-  via `external_site.capture_filename`.
+**Recovery.** If `research_log_append` returns `{ ok: false, errors }`
+it wrote nothing — surface the errors rather than retrying blindly. A
+stale `stagedResultsRef` (staged result files are pruned after ~24h) is
+the common case: re-run the search to re-stage, then log with the fresh
+`staged.resultsRef`.
 
 ## When record-extraction writes log entries
 

--- a/packages/engine/plugin/skills/search-records/references/validation-protocol.md
+++ b/packages/engine/plugin/skills/search-records/references/validation-protocol.md
@@ -1,14 +1,20 @@
 # Validation Protocol
 
-After writing to `research.json` or `tree.gedcomx.json`, follow these steps:
+The structured persistence tools (`research_log_append`,
+`research_append`, `tree_edit`, the merge tools) **validate before they
+persist** — they write nothing and return `{ ok: false, errors }` when a
+write would invalidate the project. There is no need to invoke
+`validate-schema` as a post-write backstop; surface those errors instead
+of retrying blindly. (`validate-schema` remains available as a
+user-invokable audit of the whole project.)
 
-1. **Invoke `validate-schema`** to verify both files conform to the
-   published schemas. If validation fails, fix the errors before
-   proceeding.
+What the tools do **not** check is genealogical plausibility:
 
-2. **Invoke `check-warnings`** if you added assertions or
+1. **Invoke `check-warnings`** if you added assertions or
    person_evidence entries. This checks for genealogical
    impossibilities (married before 12, died after 120, child born
-   after parent's death, etc.).
+   after parent's death, etc.). It is not auto-triggered — you must
+   invoke it explicitly.
 
-These are not auto-triggered — you must invoke them explicitly.
+(search-records writes only log entries and plan-item status, so it does
+not trigger `check-warnings`; the assertion-creating skills do.)

--- a/packages/engine/plugin/skills/tree-edit/SKILL.md
+++ b/packages/engine/plugin/skills/tree-edit/SKILL.md
@@ -19,7 +19,9 @@ description: Direct edits to tree.gedcomx.json — add fact, correct value,
 allowed-tools:
   - place_search
   - place_search_all
-  - validate_research_schema
+  - tree_edit
+  - merge_tree_persons
+  - merge_record_into_tree
   - person_record_matches
   - person_person_matches
 ---
@@ -51,154 +53,153 @@ Load these for detailed guidance on specific topics:
 
 ## Ad-hoc edits
 
+Each ad-hoc edit is one `tree_edit` call. Supply the content WITHOUT
+ids — the tool assigns the next `F`/`N`/`I`/`R` id, swaps the
+primary/preferred flag, resolves `standard_place` for any place,
+validates the whole project, and writes only `tree.gedcomx.json`. It
+returns a compact summary of the assigned ids; on a validation failure
+nothing is written and it returns `{ ok: false, errors }` — surface
+those errors to the user rather than retrying blindly.
+
 ### Adding a fact to a person
 
-```json
-{
-  "id": "F8",
-  "type": "Occupation",
-  "date": "1870",
-  "place": "Schuylkill County, Pennsylvania",
-  "standard_place": "Schuylkill, Pennsylvania, United States",
-  "sources": [{ "ref": "S2", "page": "1870 Census, dwelling 201" }]
-}
+```
+tree_edit({
+  projectPath: "<absolute-path-to-project-directory>",
+  operation: "add_fact",
+  personId: "KWCJ-RN4",
+  fact: {
+    type: "Occupation",
+    date: "1870",
+    place: "Schuylkill County, Pennsylvania",
+    sources: [{ ref: "S2", page: "1870 Census, dwelling 201" }]
+  }
+})
 ```
 
-Add to the person's `facts` array. Generate the next available `F`
-prefix ID. Whenever you set a fact's `place`, also set `standard_place`:
-call `place_search({ placeName: "<place>" })` and use the first result's
-`standardPlace` field (leave it null if nothing resolves). If the fact should be the primary of its type, add
-`"primary": true` (and remove `primary` from any existing fact of
-the same type on this person).
+The tool resolves `standard_place` from `place` automatically. If the
+fact should be the primary of its type, set `primary: true` in `fact` —
+the tool clears `primary` from any existing fact of the same type.
 
 ### Correcting a value
 
-Find the field to correct and update it. Examples:
-- Change given name: update `names[].given`
-- Fix birth year: update `facts[].date` where `type: "Birth"`
-- Correct a place: update `facts[].place` **and** re-resolve
-  `facts[].standard_place` via `place_search` (or set it null if the new
-  place doesn't resolve)
+Use `update_fact` (by `factId`), `update_name` (by `nameId`), or
+`update_person` (gender/ark) and pass only the fields to change:
+- Change given name: `tree_edit({ ..., operation: "update_name",
+  personId, nameId, name: { given: "Margaret" } })`
+- Fix birth year: `tree_edit({ ..., operation: "update_fact",
+  personId, factId, fact: { date: "1849" } })`
+- Correct a place: pass the new `place` in `fact` for `update_fact` —
+  the tool re-resolves `standard_place`
 
 ### Adding a person
 
-Create a new person entry. Use synthetic IDs (`I` prefix + next
-number) for locally created persons:
-
-```json
-{
-  "id": "I8",
-  "gender": "Female",
-  "names": [
-    {
-      "id": "N8",
-      "preferred": true,
-      "given": "Margaret",
-      "surname": "Flynn",
-      "type": "BirthName"
-    }
-  ]
-}
 ```
+tree_edit({
+  projectPath: "<absolute-path-to-project-directory>",
+  operation: "add_person",
+  person: {
+    gender: "Female",
+    names: [{ preferred: true, given: "Margaret", surname: "Flynn", type: "BirthName" }]
+  }
+})
+```
+
+The tool assigns a synthetic `I` id and the `N` name id. Omit `ark` for
+a synthesized stub.
 
 ### Adding a relationship
 
-```json
-{
-  "id": "R5",
-  "type": "ParentChild",
-  "parent": "KWCJ-RN4",
-  "child": "I8",
-  "sources": [{ "ref": "S4", "page": "Will Book 12, p. 247" }]
-}
+```
+tree_edit({
+  projectPath: "<absolute-path-to-project-directory>",
+  operation: "add_relationship",
+  relationship: {
+    type: "ParentChild",
+    parent: "KWCJ-RN4",
+    child: "I8",
+    sources: [{ ref: "S4", page: "Will Book 12, p. 247" }]
+  }
+})
 ```
 
-Use `parent`/`child` for ParentChild, `person1`/`person2` for Couple.
+Use `parent`/`child` for ParentChild, `person1`/`person2` for Couple;
+the endpoints must be existing person ids.
 
 ### Removing concluded data (tier downgrade)
 
 When proof-conclusion revises a tier downward to `not_proved` or
-`disproved`, remove the previously concluded facts/relationships:
-- Delete the fact or relationship entry from the array
-- This is the ONE case where deletion from tree.gedcomx.json is
-  permitted (the conclusion was withdrawn)
+`disproved`, remove the previously concluded fact or relationship:
+
+```
+tree_edit({ projectPath: "<absolute-path-to-project-directory>", operation: "remove", factId: "F8" })
+```
+
+Pass exactly one of `factId` or `relationshipId`. This is the ONE case
+where removing data from tree.gedcomx.json is permitted (the conclusion
+was withdrawn); `remove` never deletes a person — duplicate persons are
+collapsed via `merge_tree_persons`.
 
 ## Person merging
 
 When proof-conclusion confirms two GedcomX persons are the same
 individual, this skill executes the merge. This is a mechanical
-data operation — proof-conclusion made the analytical decision.
+data operation — proof-conclusion made the analytical decision. The
+merge tool does all the clerical work (folding names/facts, repointing
+relationships, repointing every research.json reference, removing the
+collapsed person); your job is to pick the survivor and confirm the
+pairs.
 
-### Merge protocol
-
-**Input:** Two person IDs — the "keep" person (the one that survives)
-and the "deprecated" person (the one being merged away).
-
-Convention: Keep the person with:
+**Survivor-selection convention.** Keep the person with:
 - The FamilySearch ID (if one has it and the other is a synthetic
   stub), or
 - The most complete data, or
 - The ID referenced by `project.subject_person_ids`
 
-**Step 1: Merge person data**
+### Collapsing two persons already in the tree
 
-Combine into the "keep" person:
-- **Names:** Add any names from the deprecated person that don't
-  already exist on the keep person. Preserve `preferred` on the
-  keep person's primary name.
-- **Facts:** Add any facts from the deprecated person that aren't
-  duplicates. If both have a Birth fact with different values, keep
-  the one from the proof conclusion (the concluded value). Generate
-  new `F` IDs for merged facts if there would be collisions.
-- **Source references:** Merge source ref arrays on shared facts.
-  Don't duplicate identical source references.
+When both people are already in `tree.gedcomx.json` (e.g. two father
+records that were never merged), call `merge_tree_persons` with
+`[survivorId, collapsedId]` pairs:
 
-**Step 2: Update relationships**
+```
+merge_tree_persons({
+  projectPath: "<absolute-path-to-project-directory>",
+  merges: [["KWCJ-RN7", "I5"]]
+})
+```
 
-For every relationship in `tree.gedcomx.json` that references the
-deprecated person ID:
-- Replace `parent`, `child`, `person1`, or `person2` with the keep
-  person ID
-- Remove duplicate relationships (if the same parent-child pair now
-  exists twice)
+The survivor (`KWCJ-RN7`) is kept; the collapsed person (`I5`) folds
+into it (names/facts merged, never discarded) and is removed;
+relationships are repointed; and every research.json reference to the
+collapsed id (subject persons, person_evidence, timelines,
+known_holdings) is repointed to the survivor. Both files are written
+both-or-neither and not returned — narrate from the compact summary
+(the per-pair name/fact counts and `researchRefsUpdated`).
 
-**Step 3: Update research.json references**
+### Folding a record candidate into the tree
 
-Scan research.json and update every reference to the deprecated
-person ID:
+When the data to merge comes from a `record_read` candidate (after
+deciding via `same_person` / proof reasoning which record persons match
+tree persons), call `merge_record_into_tree` with the candidate's
+simplified GedcomX and `[treeId, candidateId]` pairs:
 
-| Section | Field to update |
-|---------|----------------|
-| `project` | `subject_person_ids` — replace deprecated ID with keep ID |
-| `person_evidence` | `person_id` — replace deprecated ID with keep ID |
-| `timelines` | `person_ids` — replace deprecated ID with keep ID |
+```
+merge_record_into_tree({
+  projectPath: "<absolute-path-to-project-directory>",
+  candidateGedcomx: <the `gedcomx` field of the record_read result>,
+  merges: [["KWCJ-RN7", "p1"]]
+})
+```
 
-**Step 4: Remove the deprecated person**
+The tree person survives; the candidate folds into it; unpaired
+candidate persons are carried in as new relatives with fresh ids
+(reported in `newRelatives`). research.json is not modified by this
+call.
 
-Delete the deprecated person from `tree.gedcomx.json` `persons[]`.
-
-**Step 5: Log the merge**
-
-The merge itself is tracked by the proof_summary that triggered it.
-No separate log entry is needed — the proof conclusion's narrative
-documents why the merge happened.
-
-### Merge example
-
-**Merge I5 (stub: "James Flynn") into KWCJ-RN7 (FamilySearch:
-"James Patrick Flynn"):**
-
-1. I5 has: name "James Flynn", no facts
-2. KWCJ-RN7 has: name "James Patrick Flynn", Birth 1848 Ireland
-3. Keep KWCJ-RN7 (has FamilySearch ID and more data)
-4. I5's name "James Flynn" is a subset of KWCJ-RN7's name — don't
-   add a duplicate
-5. Update any relationships referencing I5 → KWCJ-RN7
-6. Update person_evidence entries: pe_009 (person_id: "I5") →
-   pe_009 (person_id: "KWCJ-RN7")
-7. Update timelines: t_002 (person_ids: ["I5"]) →
-   t_002 (person_ids: ["KWCJ-RN7"])
-8. Delete I5 from persons[]
+On a validation failure either merge tool writes nothing and returns
+`{ ok: false, errors }` — surface the errors to the user rather than
+retrying blindly.
 
 ## Record match checking
 
@@ -242,10 +243,14 @@ merge decisions require proof-conclusion confirmation first.
 
 ## Validation
 
-After ANY edit (ad-hoc or merge), call `validate_research_schema({ projectPath: "<absolute-path-to-project-directory>" })`
-to verify both research.json and tree.gedcomx.json are valid. If validation
-fails, fix the errors before presenting. Merges are complex enough that validation errors are
-possible — check carefully.
+`tree_edit`, `merge_tree_persons`, and `merge_record_into_tree` all
+validate-before-persist: they write nothing on `{ ok: false, errors }`,
+so a separate `validate_research_schema` pass after an edit is no longer
+needed. After ANY edit (ad-hoc or merge), run **`check-warnings`** to
+catch genealogical impossibilities the structural validator cannot
+(married before 12, child born after a parent's death, a merge that put
+the same person on both ends of a relationship, etc.). See
+`references/validation-protocol.md`.
 
 ## Important rules
 
@@ -262,9 +267,6 @@ possible — check carefully.
 - **Preserve the more complete record.** When in doubt about which
   person to keep, keep the one with more data and the more
   authoritative ID (FamilySearch ID > synthetic ID).
-- **Update ALL references.** Missing a reference creates a broken
-  foreign key. After merging, run validate-schema — it will catch
-  any references to the deleted person.
 - **Ad-hoc edits should be rare.** Most tree updates come through
   the formal pipeline (record-extraction → person-evidence →
   proof-conclusion → tree-edit). Direct edits are for corrections
@@ -310,15 +312,13 @@ to the user, not in tree fields.
 
 ## Re-invocation behavior
 
-**Writes:** persons, relationships, names, and facts directly in
-`tree.gedcomx.json` (the concluded-tree file). Operates by GedcomX
-id — `I1`, `R1`, `F1`, etc.
-
-**On repeat invocation:** edits in place by id. If a person, relationship,
-or fact with the requested id already exists, updates its fields
-rather than creating a duplicate.
+**Writes:** persons, relationships, names, and facts in
+`tree.gedcomx.json` (the concluded-tree file) via `tree_edit` and the
+merge tools.
 
 **Do not duplicate:** never add a second person record for the same
 individual. If the user is editing a person already in
-`tree.gedcomx.json` (by `I…` id or by name match), update that
-person in place. Same for relationships and facts.
+`tree.gedcomx.json` (by `I…` id or by name match), use an `update_*`
+operation against that person's id rather than `add_person`. Same for
+relationships and facts — when something with the requested id already
+exists, update it in place; do not create a duplicate.

--- a/packages/engine/plugin/skills/tree-edit/references/relationship-accuracy.md
+++ b/packages/engine/plugin/skills/tree-edit/references/relationship-accuracy.md
@@ -47,20 +47,14 @@ Do NOT create a relationship entry when:
 
 ## Merge implications for relationships
 
-When merging two persons, all relationships referencing the
-deprecated person must transfer to the surviving person. After
-transfer, check for:
-
-- **Duplicate relationships** — the same parent-child pair now
-  appearing twice (remove the duplicate)
-- **Contradictory relationships** — the merged person now appears
-  as both parent and child of the same individual, or has two
-  sets of biological parents (flag for review)
-- **Impossible configurations** — a child born before their
-  parent, or other logical impossibilities introduced by the
-  merge
-
-These checks are why `check-warnings` must run after every merge.
+The merge tools (`merge_tree_persons` / `merge_record_into_tree`)
+repoint every relationship referencing the collapsed person to the
+survivor and drop the duplicate parent-child pairs that result — you do
+not transfer or de-duplicate relationships by hand. What the tools
+cannot judge is genealogical plausibility: a merge can still leave the
+person as both parent and child of the same individual, give them two
+sets of biological parents, or imply a child born before their parent.
+This is why `check-warnings` must run after every merge.
 
 ## Biographical context beyond vital statistics
 

--- a/packages/engine/plugin/skills/tree-edit/references/validation-protocol.md
+++ b/packages/engine/plugin/skills/tree-edit/references/validation-protocol.md
@@ -1,14 +1,17 @@
 # Validation Protocol
 
-After writing to `research.json` or `tree.gedcomx.json`, follow these steps:
+`tree_edit`, `merge_tree_persons`, and `merge_record_into_tree`
+validate-before-persist — they conform-check both files against the
+published schemas and write nothing on `{ ok: false, errors }`. So
+there is no separate post-write `validate-schema` step for those edits;
+just surface any returned errors. (`validate-schema` remains available
+as a user-invokable audit of the whole project.)
 
-1. **Invoke `validate-schema`** to verify both files conform to the
-   published schemas. If validation fails, fix the errors before
-   proceeding.
+What is NOT structural — and so still needs an explicit step:
 
-2. **Invoke `check-warnings`** if you added assertions or
-   person_evidence entries. This checks for genealogical
-   impossibilities (married before 12, died after 120, child born
-   after parent's death, etc.).
+1. **Invoke `check-warnings`** after any edit or merge. This checks for
+   genealogical impossibilities the schema validator cannot (married
+   before 12, died after 120, child born after a parent's death, a
+   merge that put the same person on both ends of a relationship, etc.).
 
-These are not auto-triggered — you must invoke them explicitly.
+This is not auto-triggered — you must invoke it explicitly.


### PR DESCRIPTION
Executes the consolidated skill-rewrite pass (`docs/specs/skill-rewrites-for-persistence-tools-spec.md`) across all **14 consuming skills**, moving each off hand-edited JSON / in-context arithmetic and onto the shipped migration tools. One PR, one commit; each skill scoped strictly to its own folder.

### What changed, per skill
- **tree-edit** — "Person merging" → `merge_tree_persons` / `merge_record_into_tree`; "Ad-hoc edits" → `tree_edit` operations.
- **search-records / search-full-text / search-external-sites** — `record_search`/`fulltext_search` now take `projectPath`; the hand sidecar-write + log entry → `research_log_append` (with `staged.resultsRef`); plan-item status → `research_append`.
- **record-extraction** — `user_provided` log → `research_log_append`; sources + assertions → `research_append`.
- **convert-dates** — in-context calendar arithmetic → `convert_calendar`.
- **conflict-resolution** — conflicts append/resolve → `research_append`; expected calendar offset → `convert_calendar`.
- **assertion-classification** — classification field updates → `research_append` (`op: update`).
- **person-evidence** — links → `research_append`; stub persons → `tree_edit` add_person.
- **hypothesis-tracking / research-exhaustiveness / question-selection / research-plan** — their `research.json` section writes → `research_append`.
- **proof-conclusion** — `proof_summaries` → `research_append`; tree facts → `tree_edit`; person merges → `merge_tree_persons`.

Across all: dropped the now-redundant post-write `validate_research_schema` calls (the tools validate-before-persist; `check-warnings` kept), updated frontmatter `allowed-tools`, trimmed obsolete sidecar/chunking/id-allocation reference guidance, and preserved all judgment + analytical references.

### Correctness note
The `proof-conclusion` rewrite is held to a **pure tool-migration** — §7 keeps the standing "do not write the questions section" boundary (resolution is `question-selection`'s job). An earlier spec draft wrongly added a questions-update there; that was reverted and the spec corrected. Two gaps are intentionally left hand-done and documented in spec §5: `project.status` (no `research_append` `project` section yet) and `tree.gedcomx.json` source descriptions (no `tree_edit` source operation yet).

### Authoring + review
Drafted by a per-skill parallel pass working from the §4 recipes, then reviewed: scope confined to the 14 skill folders, frontmatter intact, each skill wired to its expected tool, every agent's flagged concern triaged (the proof-conclusion behavior-reversal was the only real issue and is fixed).

**The eval harness was not run** (per request) — all skills will be reviewed and retested next week.

🤖 Generated with [Claude Code](https://claude.com/claude-code)