### PR TITLE
Research-latency quick wins: tree_edit source ops + pinned SKILL enums

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -185,11 +185,29 @@ Three architectural rules made this design necessary:
   Cross-cutting instructions go in each `SKILL.md`, not in a single
   plugin-level file.
 
-Net effect: shared per-project state goes in `research.json`. Schema
-extensions (new `researcher_profile` fields, new project sections)
-require updates to three places: `docs/specs/schemas/research.schema.json`,
-the prose table in `docs/specs/research-schema-spec.md`, and the
-validator in the TypeScript MCP tool `validate_research_schema` at `packages/engine/mcp-server/src/validation/validator.ts`.
+Net effect: shared per-project state goes in `research.json`. Its schema is
+specified as JSON Schema under `docs/specs/schemas/` and mirrored independently
+in `packages/schema/` (JSON Schema + hand-maintained TypeScript types in
+`src/index.ts`, consumed by viewer-ui/web/server). The engine's runtime check is
+the hand-maintained `validate_research_schema` (`validator.ts`) — it does **not**
+load the JSON Schema, so it must be edited too. There are two kinds of schema
+change, with two different (and easy-to-undercount) site lists:
+
+- **New field or section:** `docs/specs/schemas/research.schema.json`, the prose
+  table in `docs/specs/research-schema-spec.md`, the validator
+  (`packages/engine/mcp-server/src/validation/validator.ts`), **and** the web
+  mirror (`packages/schema/schemas/research.schema.json` + the matching `interface`
+  in `packages/schema/src/index.ts`). A *required* field additionally breaks
+  `eval/fixtures/scenarios/*/research.json` and the eval Python stubs, which fail
+  validation until backfilled.
+- **New value on a closed enum** (e.g. `evidence_type`): the enum lives in
+  `enums.schema.json` (`$defs`), **not** `research.schema.json` (which only
+  `$ref`s it). Edit `enums.schema.json` in *both* schema trees (`docs/specs/schemas/`
+  and `packages/schema/schemas/`), the matching TS union in
+  `packages/schema/src/index.ts`, the `CLOSED_ENUMS` set in `validator.ts`, and the
+  prose tables/discussion in `research-schema-spec.md`. Worked blast-radius and
+  rationale: `docs/plan/no-evidence-evidence-type-decision.md`.
+
 The interview lives in `init-project/SKILL.md`.
 
 ## Auth architecture (`packages/engine/mcp-server/src/auth/`)

--- a/docs/plan/no-evidence-evidence-type-decision.md
+++ b/docs/plan/no-evidence-evidence-type-decision.md
@@ -1,0 +1,98 @@
+# Adding a `no_evidence` value to `evidence_type` — blast-radius & decision record
+
+**Status:** DEFERRED (recommend *not* doing it as a quick fix; see Recommendation).
+**Date:** 2026-06-21.
+**Context:** [`research-latency-quick-wins-spec.md`](../specs/research-latency-quick-wins-spec.md) §"Out of scope" deferred this; this doc is the captured analysis so it does not have to be re-derived. Cited line numbers are point-in-time (verified 2026-06-21) — confirm against current files before acting.
+
+---
+
+## The question
+
+`evidence_type` is a closed enum `direct | indirect | negative`. Skills repeatedly observe the model *try* to write a fourth value, `no_evidence`, for a fact that is irrelevant to every open research question — the model's instinct is GPS-correct (the BCG three-layer model genuinely has a fourth "No Evidence" relationship), but the schema rejects it, costing retry turns. The quick-wins work pinned the closed set in SKILL prose to stop the retries. Should we instead make `no_evidence` a *real* enum value?
+
+## TL;DR
+
+**Mechanically cheap and backward-compatible; semantically expensive.** It is an enum-**value** widening, not a required-**field** add, so it breaks no existing data. But it is **loud-safe / silent-risky**: validation won't catch the places that now silently miscount the new value, and the field's scalar shape can't represent "no evidence" honestly. **Recommendation: don't add it as a quick win** — the retry pain is already fixed by the prose pin. If pursued, do it as a deliberate schema change with the design decisions below settled first.
+
+## Why this is *not* like adding a required field
+
+The expensive, fixture-breaking schema change is adding a **required field** (see the sibling note: it breaks `eval/fixtures/scenarios/*/research.json` and Python stubs because `additionalProperties:false` + required-key validation fails on every doc lacking the field).
+
+Adding an enum **value** is the opposite: validation is allow-list membership (`validator.ts` `checkEnum` → `validValues.has(value)`; JSON-Schema `enum`). **Widening an allow-list never invalidates data that used the narrower set.** All 471 `evidence_type` occurrences across 41 fixtures (250 `direct` / 220 `indirect` / 1 `negative`) stay valid; nothing needs a backfill.
+
+| | Required-field add | Enum-value add (this) |
+|---|---|---|
+| Existing data | **breaks loudly** (validation fails everywhere) | **stays valid** (membership widening) |
+| Risk profile | loud-risky / silent-safe | **loud-safe / silent-risky** |
+| Where the real risk is | mechanical backfill of every doc | consumers silently miscounting the new value |
+
+## Definition edit sites (~6) — and why CLAUDE.md's "three places" rule undercounts here
+
+`evidence_type` is defined/validated in **two parallel schema trees plus a hand-maintained validator Set plus a TS union**:
+
+| # | Site | Note |
+|---|---|---|
+| 1 | `docs/specs/schemas/enums.schema.json:25` (`$defs.evidence_type`) | **Canonical** enum. `research.schema.json` only `$ref`s it (`:431`, required at `:405`) — editing `research.schema.json` itself does nothing. |
+| 2 | `packages/engine/mcp-server/src/validation/validator.ts:31` (`CLOSED_ENUMS`) | Hand-maintained `Set`, **not** derived from the JSON Schema. Rebuild the `build/` artifact after. |
+| 3 | `docs/specs/research-schema-spec.md:69` | §4 shared-enums table. |
+| 4 | `docs/specs/research-schema-spec.md:390` | §5.6 per-field row ("Direct, Indirect, or Negative"). |
+| 5 | `packages/schema/schemas/enums.schema.json:25` | **Second, independent copy** of the enum (web/monorepo overlay). |
+| 6 | `packages/schema/src/index.ts:13` (`export type EvidenceType`) | Hand-maintained TS union, re-exported to viewer-ui / web / server. |
+
+Plus **semantic prose that must be hand-written, not just appended to a list**: the §5.6 "Negative evidence / dog not barking" paragraph (`research-schema-spec.md:370`) is the *only* place the negative-family values are disambiguated; it ties `negative` to `record_role:"absent"` + a real `source_id`. A `no_evidence` value needs prose drawing the line between `negative` (meaningful expected-but-absent finding) and `no_evidence` (present but irrelevant), and stating its `record_role`/`source_id` expectations.
+
+Stale-risk duplicate (not runtime): `apps/electron/docs/research-schema-spec.md:59,276,294`.
+
+> **Meta-finding — fix separately:** CLAUDE.md's "three places" rule (the `research_profile`/schema-extension paragraph) is **inaccurate for an enum-value change**: it names `research.schema.json` (wrong file — the enum lives in `enums.schema.json` via `$ref`) and omits the `packages/schema` copy + the `EvidenceType` TS union. It's ~6 sites here, not 3.
+
+## Code consumers — essentially zero
+
+- **MCP server `src/`: no consumers.** The token `evidence_type` appears 0× under `packages/engine/mcp-server/src/`. `research-append` treats assertions as opaque pass-through (spread fields, assign ids, validate). Adding the value is transparent to all tool code.
+- **Viewer is data-derived:** `AssertionsSection` builds its filter from values present in the data, so `no_evidence` surfaces automatically; `StatusBadge` falls back to a gray "no evidence" badge (add a color entry if a deliberate one is wanted). No hardcoded list to edit.
+- **Validator has no value-specific branch:** there is no special-casing of `negative` in `validator.ts`. The §5.6 negative-evidence rules (`record_role:"absent"`, `source_id` present) are **documented but not machine-enforced**. So any cross-field rule `no_evidence` needs is **new logic to write**, not a tweak.
+
+## The real cost: prose + semantics
+
+1. **Two guards just landed would have to be reversed.** They now assert the set is closed and `no_evidence` is rejected — that becomes false:
+   - `record-extraction/SKILL.md:345,347`
+   - `assertion-classification/SKILL.md:146,149,226,235`
+   - `assertion-classification/references/three-layer-model.md` already teaches "No Evidence" as a real 4th category (as a *concept*) — currently in tension with the guards; promoting the value reconciles them but requires editing that model + the Direct/Indirect/Negative subsections + Standard-40 phrasing.
+
+2. **The semantic crux — scalar vs. (fact, question) pair.** "No evidence" is a property of a **(fact, question) pair**, but `evidence_type` is a **single scalar** on the assertion (relevance lives in the `extracted_for_question_ids` *list*). One assertion can be `direct` for q1 and no-evidence for q2; a scalar can't express that. A bare value silently commits to "irrelevant to *all* listed questions," which **goes stale the moment a new question opens** (assertion-classification §4 already warns the type changes with new questions — but nothing recomputes it).
+
+3. **Silent miscounting in consumers — the part no validator catches.** `proof-conclusion` quality scoring (`SKILL.md:294`), `conflict-resolution` weighing, `timeline`, and `hypothesis-tracking` (`SKILL.md:209` filters supporting assertions on `evidence_type:"direct"`) all treat every assertion as carrying weight. A `no_evidence` assertion would silently enter analysis / scoring unless each is taught to exclude it.
+
+4. **Extraction-time sequencing.** At extraction, open questions may not exist yet (opportunistic extraction writes empty `extracted_for_question_ids`), so the "correct" value would be `no_evidence` for almost everything → floods the field → defeats its purpose. The current best-effort-`indirect`-then-refine workflow exists *precisely because* the field is required but questions arrive later.
+
+## Eval impact
+
+Fixtures don't break (value widening). But:
+- Rubrics that **grade** `evidence_type`: `eval/tests/unit/record-extraction/rubric.md` (Evidence-type accuracy) and `eval/tests/unit/assertion-classification/rubric.md` (Layer-3) enumerate only the three values — extend or the judge can't reward/penalize the 4th.
+- Negative-control tests use "no evidence" as a *concept* to reject: `assertion-classification/negative-evidence-will-omission.json` and `no-open-questions-guard.json` would need rewording.
+- Python goldens assert exact values (`test_assertion_classification.py` demands `a_001 == "direct"`) — update any whose expected classification legitimately becomes `no_evidence`.
+- **Zero positive coverage** today — a new scenario fixture + a validator (none exists; the negative-evidence validators key only on `=="negative"`) would be needed.
+
+## Design decisions to settle *before* this is safe
+
+1. **Scalar vs. per-question relevance.** Does `no_evidence` mean "irrelevant to all listed questions" (lossy scalar, goes stale on question churn) — or should relevance move to a per-question structure on `extracted_for_question_ids` (the larger change that actually fixes the root mismatch)? Adding the bare value picks the lossy interpretation by default.
+2. **Who may write it, and when.** Extraction-time (floods the field) vs. classification-time-only (then record-extraction must forbid emitting it).
+3. **Re-classification lifecycle.** Define the trigger/owner that re-evaluates `no_evidence` assertions when a new question opens. Without it the values are write-once and silently rot.
+4. **Structural convention + invariant.** Mirror the crispness §5.6 gives `negative` (role/source). Confirm a `no_evidence` assertion keeps its real role and is barred from `absent`-role and from `proof_summary.supporting_assertion_ids`.
+5. **Is it worth it at all?** The model's actual pain (wasted retries) is already removed by the prose pin (PR #433). Weigh semantic honesty against touching every consumer.
+
+## Recommendation
+
+**Do not add `no_evidence` as a quick fix.** The retry-loop pain is already addressed by the lower-blast-radius prose pin landed in PR #433 (state the valid values inline + "there is no `no_evidence`; keep best-effort `indirect`"), which kills the loop without touching a single consumer. The model's instinct is GPS-correct, but the scalar `evidence_type` cannot represent "no evidence" honestly, and a bare enum add buys semantic honesty at the cost of new exclusion logic in four consumers (none validator-caught) plus an under-specified value. If the team later decides the honesty is worth it, do it deliberately: settle decision #1 (the root mismatch) first, define the structural convention + eval invariant + re-classification trigger, and land all ~6 definition sites + both skills + the eval rubrics/goldens **at once**.
+
+## If we do proceed — the one-pass checklist
+
+- [ ] `docs/specs/schemas/enums.schema.json` `$defs.evidence_type` enum
+- [ ] `packages/schema/schemas/enums.schema.json` enum (second copy)
+- [ ] `packages/schema/src/index.ts` `EvidenceType` union
+- [ ] `packages/engine/mcp-server/src/validation/validator.ts` `CLOSED_ENUMS.evidence_type` Set (+ rebuild `build/`)
+- [ ] `docs/specs/research-schema-spec.md` §4 table (`:69`), §5.6 field row (`:390`), §5.6 negative-evidence prose (`:370` — add the negative-vs-no_evidence distinction + role/source convention)
+- [ ] `apps/electron/docs/research-schema-spec.md` duplicate prose (`:59,294,276`)
+- [ ] Reverse the guards: `record-extraction/SKILL.md`, `assertion-classification/SKILL.md`, `three-layer-model.md`
+- [ ] Add exclusion rules: `proof-conclusion`, `conflict-resolution`, `timeline`, `hypothesis-tracking`
+- [ ] Eval: `record-extraction`/`assertion-classification` `rubric.md`, the two negative-control tests, Python goldens, + a new positive-coverage fixture & validator
+- [ ] Fix CLAUDE.md's "three places" rule (it undercounts for enum-value changes)

--- a/docs/plan/no-evidence-evidence-type-decision.md
+++ b/docs/plan/no-evidence-evidence-type-decision.md
@@ -43,7 +43,7 @@ Plus **semantic prose that must be hand-written, not just appended to a list**: 
 
 Stale-risk duplicate (not runtime): `apps/electron/docs/research-schema-spec.md:59,276,294`.
 
-> **Meta-finding — fix separately:** CLAUDE.md's "three places" rule (the `research_profile`/schema-extension paragraph) is **inaccurate for an enum-value change**: it names `research.schema.json` (wrong file — the enum lives in `enums.schema.json` via `$ref`) and omits the `packages/schema` copy + the `EvidenceType` TS union. It's ~6 sites here, not 3.
+> **Meta-finding (fixed in this PR):** CLAUDE.md's "three places" rule (the `research_profile`/schema-extension paragraph) was **inaccurate for an enum-value change** — it named `research.schema.json` (wrong file — the enum lives in `enums.schema.json` via `$ref`) and omitted the `packages/schema` copy + the `EvidenceType` TS union. It has been corrected into two checklists (new-field vs. enum-value).
 
 ## Code consumers — essentially zero
 
@@ -95,4 +95,4 @@ Fixtures don't break (value widening). But:
 - [ ] Reverse the guards: `record-extraction/SKILL.md`, `assertion-classification/SKILL.md`, `three-layer-model.md`
 - [ ] Add exclusion rules: `proof-conclusion`, `conflict-resolution`, `timeline`, `hypothesis-tracking`
 - [ ] Eval: `record-extraction`/`assertion-classification` `rubric.md`, the two negative-control tests, Python goldens, + a new positive-coverage fixture & validator
-- [ ] Fix CLAUDE.md's "three places" rule (it undercounts for enum-value changes)
+- [x] ~~Fix CLAUDE.md's "three places" rule~~ — done in this PR (now two checklists: new-field vs. enum-value)

--- a/docs/plan/research-latency-quick-wins-implementation-plan.md
+++ b/docs/plan/research-latency-quick-wins-implementation-plan.md
@@ -156,7 +156,9 @@ drift):
 Whether to *add* a `no_evidence` value to the `evidence_type` schema (so the model's
 GPS-correct instinct is representable) is a schema change — higher blast radius (schema
 + `validator.ts` + every consumer + the three-places rule in CLAUDE.md). Left to the
-reduction plan / a separate schema decision.
+reduction plan / a separate schema decision. The full blast-radius analysis and
+recommendation are captured in
+[`no-evidence-evidence-type-decision.md`](./no-evidence-evidence-type-decision.md).
 
 ---
 

--- a/docs/plan/research-latency-quick-wins-implementation-plan.md
+++ b/docs/plan/research-latency-quick-wins-implementation-plan.md
@@ -1,0 +1,194 @@
+# Research-Latency Quick Wins — Implementation Plan
+
+**Project:** Cowork Genealogy — AI genealogy research assistant
+**Status:** DRAFT, for review
+**Implements:** [`docs/specs/research-latency-quick-wins-spec.md`](../specs/research-latency-quick-wins-spec.md)
+**Companion:** [`research-latency-reduction-plan.md`](./research-latency-reduction-plan.md) (the larger, measurement-gated effort)
+
+This is the *how-to-build* for the two changes in the spec. They are independent and
+may ship as one PR or two. Work item A is a tool extension; work item B is SKILL prose.
+
+**Reduced blast radius (confirmed in code):** adding operations to `tree_edit` changes
+only the tool's own file and schema object — **no edit to `tool-schemas.ts`** (it
+imports `treeEditSchema`, `tool-schemas.ts:46,85`) and **no edit to `manifest.json`**
+(it lists the tool by name, `manifest.json:63`, which is unchanged). The validate +
+backup + atomic-write tail (`tree-edit.ts:262-291`) is shared by all operations, so it
+needs no change either. (The spec's Risk section,
+`research-latency-quick-wins-spec.md:122-123`, still lists `tool-schemas.ts` +
+`manifest.json` as touched — stale; this plan is the accurate account. Align the spec
+separately.)
+
+---
+
+## Work item A — `tree_edit`: `add_source` / `update_source`
+
+### Files to touch
+
+| File | Change |
+|---|---|
+| `packages/engine/mcp-server/src/tools/tree-edit.ts` | New operations: union type, input type, switch cases, schema enum + props, result type |
+| `packages/engine/mcp-server/src/types/gedcomx.ts` | Add `author?: string` to `SimplifiedSourceDescription` — documented in `simplified-gedcomx-spec.md:151` + used in examples, but currently missing from the type |
+| `packages/engine/mcp-server/src/utils/gedcomx-ids.ts` (verify only) | **Already S-aware** — `maxIdNum` scans `tree.sources[]` (`gedcomx-ids.ts:29`). No change; a unit test confirms `S1`→`S2`. |
+| `packages/engine/mcp-server/tests/tools/tree-edit.test.ts` | Tests for both operations |
+| `docs/specs/tree-edit-tool-spec.md` | Reflect the two new operations (so `spec-review` covers them) |
+| `packages/engine/plugin/skills/record-extraction/SKILL.md` | Step 5c: use `add_source` instead of hand-writing the `S` entry |
+| `packages/engine/plugin/skills/proof-conclusion/SKILL.md` | Step 6: use `add_source`/`update_source` |
+
+### Steps (tree-edit.ts)
+
+1. **Union type** (`~line 33`): add `"add_source" | "update_source"` to `TreeEditOperation`.
+2. **Input type** (`~line 38/64`): add optional `source?: SimplifiedSourceDescription`
+   (the partial/full source object — the type is `SimplifiedSourceDescription`, **not**
+   `SimplifiedSource`, which does not exist; see `types/gedcomx.ts:159`) and
+   `sourceId?: string`. (`factId`/`nameId`/`relationshipId` already exist; `sourceId` is
+   new.) Add `author?: string` to `SimplifiedSourceDescription` first (see Files to
+   touch) so a caller-supplied `author` is type-safe.
+3. **Switch cases** (in `applyOperation`, after `add_relationship`, before `remove`,
+   `~line 220`):
+   - `add_source` — structurally mirror **`add_relationship`** (`:213-219`), not
+     `add_fact`: sources are top-level (no `requirePerson`, no place resolution, no
+     primary swap). Require `input.source`; reject a caller-supplied `id`; allocate
+     `const id = nextId(tree, "S")`; push to `tree.sources` (init `tree.sources ??= []`);
+     set `assignedIds.source = id`.
+   - `update_source` — mirror `update_fact` (`:145-158`) **minus the `requirePerson`
+     lookup** (sources aren't person-scoped): require `sourceId` + `source`; `find` the
+     existing source in `tree.sources`; `TreeEditError` if not found; merge non-`id` keys
+     via the same `for (const [k,v] of Object.entries(input.source))` loop.
+   No place resolution / primary-flag handling applies to sources (skip those bits).
+4. **ID helper** (`gedcomx-ids.ts`): **no change needed** — `maxIdNum` already scans
+   `doc.sources` (and `doc.places`) for the `"S"` prefix (`gedcomx-ids.ts:29`), so
+   `nextId(tree,"S")` works today. Verify-only; a unit test asserting `S1`→`S2` locks it
+   in.
+5. **Schema** (`treeEditSchema`, `:295-363`): add `"add_source"`, `"update_source"` to the
+   `operation` enum (`:320`); add `source` (object) and `sourceId` (string) properties
+   with descriptions; extend the schema's prose to mention adding/correcting a source.
+   `required` stays `["projectPath","operation"]`.
+6. **Result type** (`TreeEditResult.assignedIds`): add an optional `source?: string`.
+7. **No change** to `tool-schemas.ts` or `manifest.json` (see note above). The shared
+   `treeEdit()` tail already runs `validateParsed` then `backupIfExists` +
+   `atomicWriteJson` and returns `{ok:false,errors}` on invalid — sources get this free.
+
+### `source` object shape
+
+Simplified-GedcomX tree source (`SimplifiedSourceDescription`; see
+`docs/specs/simplified-gedcomx-spec.md` §4.3): `title` (required on add), optional
+`author`, `url`, `citation`. **Note:** the TS type currently omits `author` even though
+the spec documents it (`simplified-gedcomx-spec.md:151`) and examples use it — add
+`author?: string` to the type (Files to touch). `title`-required is enforced by the
+shared `validateParsed` tail (`validator.ts:810` requires `[id, title]`), so the op
+itself needs no title check. This is the lightweight tree `sources[]` entry (e.g. `S2`
+in `tree.gedcomx.json`), distinct from the rich `research.json` `sources[]` that
+`research_append` owns.
+
+### Tests (tree-edit.test.ts)
+
+- `add_source`: assigns the next `S<N>`, rejects a caller-supplied `id`, returns
+  `assignedIds.source`, and the project validates + writes (with `.bak`).
+- `add_source` twice: ids increment (`S1`→`S2`), confirming `nextId(tree,"S")` (covers
+  the already-S-aware `gedcomx-ids.ts:29`).
+- `add_source`: a caller-supplied `author`/`url` round-trips into the written `S` entry
+  (locks in the new `author` type field).
+- `update_source`: merges supplied fields, leaves others intact, errors on an unknown
+  `sourceId`, refuses to change `id`.
+- Missing-argument guards: `add_source` with no `source` → `{ok:false}`; `update_source`
+  with no `sourceId` → `{ok:false}`; `update_source` with no `source` → `{ok:false}`.
+- A failing case: a `source` with no `title` breaks tree validation, returns `{ok:false}`
+  and writes nothing (covers the shared validate-before-persist path for the new op).
+
+### SKILL adoption
+
+- `record-extraction` SKILL.md step 5c (`~lines 461-465`): replace *"This file is not a
+  `research_append` section; write it directly"* with a `tree_edit({operation:"add_source",
+  source:{…}})` call, one per new source; drop the "written directly / separate validate"
+  caveat (the tool validates).
+- `proof-conclusion` SKILL.md step 6 (`~lines 286-289`): this is **already tool-first
+  prose** — *"add it through the tree (the tool validates the source shape…)"* — which
+  promises a `tree_edit` source op that does not exist yet, so the shipped SKILL is
+  latently broken today. This is a small clarification (name the operation explicitly:
+  `tree_edit({operation:"add_source"})`, or `update_source` to correct an existing `S`
+  entry's citation), **not** a hand-write→tool rewrite. Work item A is what makes this
+  shipped instruction actually work.
+
+### Verification
+
+- `cd packages/engine/mcp-server && npm test` (the tree_edit suite).
+- Run `spec-review` on `tree-edit.ts` against `docs/specs/tree-edit-tool-spec.md`.
+- Re-run the `record-extraction` and `proof-conclusion` skill evals — expected delta:
+  one fewer hand-edit, identical resulting tree state.
+- Optional: extend `dev/try-tree-edit.ts` (if present) with an `add_source` smoke call.
+
+---
+
+## Work item B — Pin closed-vocabulary enums in SKILL prose
+
+### Files to touch
+
+| File | Change |
+|---|---|
+| `packages/engine/plugin/skills/assertion-classification/SKILL.md` | State valid values where `evidence_type` / `information_quality` / `informant_proximity` are set (`~lines 206-230`) |
+| `packages/engine/plugin/skills/record-extraction/SKILL.md` | Same lists at extraction time, where these fields are first written |
+
+### Steps
+
+At the point each field is set, add the valid-value list inline and cite
+`docs/specs/research-schema-spec.md` as the source of truth (so the prose can't silently
+drift):
+
+- **`evidence_type`** ∈ `direct` | `indirect` | `negative`. Add explicitly:
+  *"There is no `no_evidence` value — a fact irrelevant to the open question keeps
+  `indirect`. Do not attempt `no_evidence`; the schema rejects it and the write tool
+  will refuse the entry."*
+- **`information_quality`** ∈ `primary` | `secondary` | `indeterminate`.
+- **`informant_proximity`** ∈ `self` | `household_member` | `family_not_present` |
+  `official_duty` | `witness` | `unknown`.
+
+### Verification
+
+- Re-run the `assertion-classification` eval: confirm the transcript shows no
+  `no_evidence` attempt and no invalid-`informant_proximity` retry (these were the
+  wasted loops in the baseline run).
+- No code change; nothing to unit-test. The e2e re-measure (reduction plan Phase 0)
+  confirms the turn/time delta, but this lands first because it is confident and
+  zero-risk.
+
+### Out of scope (a real decision, deferred)
+
+Whether to *add* a `no_evidence` value to the `evidence_type` schema (so the model's
+GPS-correct instinct is representable) is a schema change — higher blast radius (schema
++ `validator.ts` + every consumer + the three-places rule in CLAUDE.md). Left to the
+reduction plan / a separate schema decision.
+
+---
+
+## Sequencing & ownership
+
+1. **Work item A** — developer. Follows the `tree_edit` scaffolding; PR includes the
+   tool change, tests, the `tree-edit-tool-spec.md` update, and the two SKILL edits.
+   `spec-review` audits the tool against its spec before merge.
+2. **Work item B** — genealogist or developer; prose-only.
+3. Either order; B has no dependency on A. Both can land in one PR.
+4. Neither blocks the reduction plan's Phase 0 re-measure — but landing them first means
+   the re-measure already reflects them, which is the point of doing them up front.
+
+## Risk / rollback
+
+- Work item A is additive (new operations); existing `tree_edit` behavior is untouched,
+  so rollback is reverting the tool + type + two SKILL edits. Even lower risk than first
+  drafted: the `nextId`/`maxIdNum` `"S"`-prefix support is **already present**
+  (`gedcomx-ids.ts:29`), so there is no non-trivial code spot — only the additive switch
+  cases and a one-line type field, both covered by unit tests.
+- Work item B is prose; rollback is a revert with no runtime effect.
+
+## GSTACK REVIEW REPORT
+
+| Review | Trigger | Why | Runs | Status | Findings |
+|--------|---------|-----|------|--------|----------|
+| CEO Review | `/plan-ceo-review` | Scope & strategy | 0 | — | — |
+| Codex Review | `/codex review` | Independent 2nd opinion | 0 | — | — |
+| Eng Review | `/plan-eng-review` | Architecture & tests (required) | 1 | issues_found | 6 findings (1 reframing, 4 corrections, 1 type gap); 0 critical failure-mode gaps; +4 tests; all folded into plan |
+| Design Review | `/plan-design-review` | UI/UX gaps | 0 | — | — |
+| DX Review | `/plan-devex-review` | Developer experience gaps | 0 | — | — |
+
+- **VERDICT:** ENG CLEARED — scope accepted as-is, 6 findings resolved into the plan, 0 critical gaps. Work item A reframed as also fixing a latent `proof-conclusion` breakage. Outside-voice (Codex) pass offered but not run (tiny prose + one-op change). Ready to implement.
+
+NO UNRESOLVED DECISIONS

--- a/docs/plan/research-latency-reduction-plan.md
+++ b/docs/plan/research-latency-reduction-plan.md
@@ -1,0 +1,246 @@
+# Research-Latency Reduction — Plan
+
+**Project:** Cowork Genealogy — AI genealogy research assistant
+**Status:** DRAFT, for review (dev + designer + genealogist)
+**Goal:** Roughly halve the agent-controllable wall-clock of a single research
+session, without removing safety gates on irreversible/external actions and without
+re-architecting the skill pipeline.
+**Companion doc:** [`research-latency-quick-wins-spec.md`](../specs/research-latency-quick-wins-spec.md)
+covers the two changes that should land *before* this plan's measurement gate.
+
+---
+
+## 1. Baseline — and why it is already stale
+
+The decomposition below comes from the timestamped Claude Code transcript of the
+Kenneth Quass session (a real research run). It is the evidence that motivates this
+work — **and the reason Phase 0 exists.**
+
+**Wall-clock (one 19-min human walk-away removed → ~37 min of real session):**
+
+| Bucket | Share of active work |
+|---|---|
+| Model generation (thinking + writing + tool-call args) | **~90%** |
+| Human turnaround (confirmation "yes" gates, ex-walkaway) | ~8% |
+| **Tool / API latency** (FamilySearch, MCP) | **~0%** |
+
+The two phases that dominate model time:
+
+| Phase | Model time | Model turns | Thinking volume |
+|---|---|---|---|
+| record-extraction | 12.7 min | 68 | 38k chars |
+| search-records | 11.3 min | 89 | 28k chars |
+
+Two mechanical drivers: **turn count** (241 model turns; many from sequential
+`Edit`/`validate`/`ToolSearch` round-trips) and **thinking volume** (~21k tokens of
+reasoning, including a dead-end exploring an invalid `no_evidence` enum).
+
+**The stale-baseline caveat (load-bearing).** This run is dated **2026-06-18**. The
+persistence-tool migration shipped **2026-06-19**: five validate-before-persist atomic
+write tools (`research_append`, `research_log_append`, `tree_edit`,
+`merge_record_into_tree`, `merge_tree_persons`) and a rewrite of 7 of 8 write-heavy
+skills to use them, which **dropped the separate `validate_research_schema` calls and
+the array-re-serialization through `Edit`**. That removed a large slice of the turn-count
+driver above. So the numbers that should set this plan's *priorities* are partly
+obsolete: we do not know whether the dominant remaining cost is now write-mechanics
+(turn count) or deliberation (thinking). **Speccing the optimizations against the
+2026-06-18 numbers would risk optimizing the wrong thing.** Hence Phase 0.
+
+(One headline finding is *not* stale and reframes the whole effort: tool/API latency
+is ~0. This is not a "make the searches faster" problem; it is a "make the model
+generate less, in fewer round-trips" problem.)
+
+---
+
+## 2. Goals / non-goals
+
+**Goals**
+- Halve the agent-controllable time (≈ model-generation time) of a representative
+  research session.
+- Complete the half-built persistence-tool architecture so no skill hand-edits JSON.
+
+**Non-goals**
+- Removing safety gates on irreversible or external actions (e.g. the user-capture
+  step in `search-external-sites`). Those stay.
+- Re-architecting the skill pipeline or the GPS workflow.
+- Faster FamilySearch/MCP calls — latency is already ~0; not the bottleneck.
+
+---
+
+## 3. Phase 0 — Re-measure (the gate)
+
+**Do this before sizing Phase 2.** Phase 1 (structural) may proceed in parallel because
+it is sound regardless of the numbers; Phase 2 (behavior tuning) priorities are
+**gated** on this.
+
+- Re-run the existing e2e fixture `eval/tests/e2e/kenneth-quass-death` against the
+  **migrated** skills (post-2026-06-19), in `real` agent mode.
+- Capture the session transcript JSONL from the sandbox
+  (`/home/user/.claude/projects/-project/<session-id>.jsonl`; the session id is in
+  `/project/.agent_session`) — note this is now also bundled into web feedback, per the
+  feedback-transcript change.
+- Decompose with the same method used for the baseline: total wall-clock; model-gen vs
+  tool-latency vs human-turnaround; per-phase model time, turn count, and thinking
+  volume; top single gaps.
+
+**Deliverable:** a short post-migration baseline doc (drop it next to this plan).
+**Decision it drives:** if write-mechanics (turn count) still dominates →
+prioritize Phase 1c (batch-append). If deliberation (thinking) dominates → prioritize
+Phase 2a (thinking/narration). Likely both contribute; the measure says in what ratio.
+
+---
+
+## 4. Phase 1 — Tool-coverage completion (sound regardless of measurement)
+
+The migration left three hand-edit gaps and one ergonomics gap. Closing them finishes
+the persistence-tool architecture and removes the last JSON hand-edits.
+
+### 1a. `tree_edit`: `add_source` / `update_source`
+**Delivered by the quick-wins spec** — see
+[`research-latency-quick-wins-spec.md`](../specs/research-latency-quick-wins-spec.md) §2.
+Removes the hand-written tree `S` entries in `record-extraction` and `proof-conclusion`.
+Listed here for completeness of the coverage map; assumed already landed.
+
+### 1b. `project` / `researcher_profile` writer
+**Problem:** `research_append` operates on **arrays of ID'd entries**; the `project`
+header and `researcher_profile` are **singleton objects**, so they have no write tool.
+Today `proof-conclusion` hand-edits `project.status`/`project.updated`, and
+`init-project` hand-writes the whole `project` block + `researcher_profile`.
+
+**Proposed:** a small dedicated tool (e.g. `research_set`) — or a special-cased
+`research_append` mode — with **update/merge-only** semantics on these singletons:
+no append, no ID allocation, shallow-merge supplied fields, stamp `project.updated`,
+validate-before-persist + atomic write. Sections: `project` (settable: `objective`,
+`status`, `title`; `updated` tool-owned) and `researcher_profile`
+(`experience_level`, `subscriptions`, `narration_guidance`).
+
+**Risk:** medium-low. New (or extended) tool surface; singleton semantics differ from
+`research_append`'s array model, so keep it a distinct path to avoid muddying the
+array-append contract. Per the three-places rule in CLAUDE.md, any schema touch must
+update `research.schema.json`, `research-schema-spec.md`, and `validator.ts` — but this
+adds no fields, only a writer, so likely no schema change.
+
+### 1c. `research_append` batch append (`entries[]`)
+**Problem:** `research_append` writes **one entry per call** (`record-extraction` calls
+it "once per fact" — ~29 assertion calls + 5 source calls; `person-evidence` ~31 calls).
+Each is a model turn. This trades the old array-re-serialization tax for per-entry turn
+overhead.
+
+**Proposed:** add an optional `entries: [...]` to the `append` op (alongside the
+existing single `entry`): validate the whole batch once, **all-or-nothing**, allocate
+ids sequentially, and on failure return the **per-entry index** that caused it. Adopt
+in `record-extraction` (assertions), `person-evidence` (pe entries), and
+`research-plan` (plan_items).
+
+**Risk:** medium — this re-touches **freshly-migrated** skills and their evals
+(re-validate the `skill-rewrites-for-persistence-tools` test suite). The tool change
+itself is additive (existing single-`entry` callers unaffected). **Magnitude is
+measurement-dependent** — if Phase 0 shows deliberation dominates, this saves fewer
+minutes than the turn count suggests. Size it after Phase 0; it is the clearest
+turn-count lever if turn count still dominates.
+
+### 1d. Migrate `init-project`
+**Problem:** `init-project` is the one un-migrated write-heavy skill — it hand-writes
+both `research.json` and `tree.gedcomx.json` from scratch (manual `I`/`N`/`F`/`R`/`S`
+id allocation) and still calls `validate_research_schema` separately.
+
+**Proposed:** rewrite it to use `tree_edit` (`add_person`/`add_fact`/`add_source`) +
+the 1b writer (`project`/`researcher_profile`) + `research_append` (any seed
+sources/assertions), and drop the separate validate. **Depends on 1a + 1b.**
+
+**Risk:** highest in Phase 1 — `init-project` is the project bootstrap; a regression
+breaks every session. Land it **last**, behind unit tests and an e2e smoke. Time-wise
+it was small in the baseline (~1.3 min ex-walkaway), so this is for consistency and
+correctness, not raw speed.
+
+---
+
+## 5. Phase 2 — Behavior tuning (sized after Phase 0)
+
+Priorities here depend on Phase 0's breakdown. All three target model-generation time
+directly.
+
+### 2a. Thinking / narration precision
+The novice narration guidance ("narrate the why, define every term, err toward more
+context") inflates both visible output and, indirectly, deliberation. The user's own
+feedback was *"it did great, just too long."*
+- The enum-pinning in the quick-wins spec is the first, safe slice (kills the
+  `no_evidence` dead-end).
+- Beyond that: scope novice narration to **user-facing output**, not internal thinking;
+  cut re-derivation of analysis the tools/skills already encode. This interacts with
+  the in-flight **SKILL.md shortening briefs** (`eval/briefs/shorten-*.md`) — coordinate
+  so the two efforts don't fight.
+- Tradeoff: do not gut the teaching value — the complaint is verbosity, the fix is
+  *precision*, not silence. This is the lever most likely to move the needle if Phase 0
+  shows deliberation dominates.
+
+### 2b. Round-trip reduction
+- **MCP-tool preloading:** the run spent ~11 turns on `ToolSearch` (one per deferred-tool
+  load). Pre-loading the always-used genealogy tools would remove them — **but the
+  mechanism is runtime-dependent**: per `skill-mcp-optimization-plan.md` §12,
+  `allowed-tools` SKILL.md frontmatter is honored by **Cowork** but **silently ignored
+  by the Agent SDK** (the hosted-web path). So this is "investigate the deferral knob per
+  runtime, then apply where controllable," not a confident win. Verify first.
+- **Batch adaptive search retries:** `search-records` fired the wildcard + broad-fallback
+  searches as separate sequential turns. Where the broadening is not data-dependent,
+  issue them together (as `research-plan`'s locality survey already does). Lower
+  confidence — the broadening is partly adaptive — so measure the realized turn savings.
+
+### 2c. Auto-chaining the pipeline — DESIGN-REVIEW ITEM (not a foregone optimization)
+The agent stops for a "yes" confirmation between every skill (question-selection →
+research-plan → search-records …), each adding a human round-trip **and** a fresh
+skill-load turn that re-reads the skill's reference docs. Auto-chaining the pipeline
+when the user has already committed to researching a person would remove both.
+
+**But this is a UX/safety call, not a pure speed change.** The persistence ops here are
+reversible and local (so these gates are UX-pacing, not safety gates on irreversible/
+external actions — those, like `search-external-sites`' user capture, stay regardless).
+Whether to auto-chain, and how much to narrate while doing so, trades against the
+"simple, predictable UI" and "user stays in control" values. **Route through
+`plan-design-review`** before building.
+
+---
+
+## 6. Risks & tradeoffs (cross-cutting)
+
+- **Stale baseline (the big one):** Phase 2 priorities are unknown until Phase 0. Do
+  not commit Phase 2 sizing on the 2026-06-18 numbers.
+- **Batch-append churn:** 1c re-touches skills migrated only days ago; budget eval
+  re-validation, not just the tool change.
+- **Enum/vocabulary drift:** pinning enums in prose (quick wins) must cite
+  `research-schema-spec.md` as canonical.
+- **Narration trim vs novice value:** precision, not silence.
+- **Auto-chain vs UX/safety:** designer's call; keep gates on external/irreversible
+  actions.
+- **Singleton-writer semantics (1b):** keep distinct from the array-append contract.
+
+---
+
+## 7. Build order
+
+1. **Quick wins** (separate spec): `tree_edit add_source` + enum-pinning. Land first.
+2. **Phase 0 re-measure.** Produces the post-migration baseline (reflecting the quick
+   wins). Gates Phase 2.
+3. **Phase 1 structural**, in parallel with Phase 0 where possible: 1b (project/profile
+   writer) → 1c (batch-append, sized by Phase 0) → 1d (`init-project` migration, last,
+   behind tests).
+4. **Phase 2 behavior tuning**, prioritized by Phase 0: 2a (thinking/narration) and/or
+   2b (round-trips); 2c (auto-chaining) only after `plan-design-review`.
+5. **Re-measure again** against the same fixture to confirm the halving target and to
+   decide whether to stop.
+
+---
+
+## 8. References
+
+- `docs/specs/research-append-tool-spec.md`, `docs/specs/tree-edit-tool-spec.md`,
+  `docs/specs/research-log-editor-spec.md` — the write tools extended here.
+- `docs/specs/research-schema-spec.md` + `docs/specs/schemas/research.schema.json` +
+  `packages/engine/mcp-server/src/validation/validator.ts` — the three-places rule for any
+  schema touch.
+- `docs/specs/skill-rewrites-for-persistence-tools-spec.md` — the 2026-06-19 migration
+  whose skills 1c/1d re-touch.
+- `docs/plan/skill-mcp-optimization-plan.md` §12 — `allowed-tools` is honored by Cowork,
+  ignored by the Agent SDK (relevant to 2b).
+- `eval/tests/e2e/kenneth-quass-death` — the fixture for Phase 0 / final re-measure.
+- `eval/briefs/shorten-*.md` — the in-flight SKILL-shortening work that 2a coordinates with.

--- a/docs/specs/research-latency-quick-wins-spec.md
+++ b/docs/specs/research-latency-quick-wins-spec.md
@@ -184,7 +184,9 @@ Whether to *add* a `no_evidence` value to the `evidence_type` schema (so the mod
 GPS-correct instinct is representable) is a schema design question — higher blast
 radius (schema + `validator.ts` + every consumer + the three-places rule in CLAUDE.md)
 and not a quick win. Left to the reduction plan / a separate schema decision. This
-change takes the low-blast-radius path: tell the model the valid values.
+change takes the low-blast-radius path: tell the model the valid values. The full
+blast-radius analysis and recommendation (do *not* add it as a quick fix) is captured
+in [`docs/plan/no-evidence-evidence-type-decision.md`](../plan/no-evidence-evidence-type-decision.md).
 
 ### Verification
 

--- a/docs/specs/research-latency-quick-wins-spec.md
+++ b/docs/specs/research-latency-quick-wins-spec.md
@@ -1,0 +1,206 @@
+# Research-Latency Quick Wins — Spec
+
+**Project:** Cowork Genealogy — AI genealogy research assistant
+**Status:** DRAFT, for review (dev + genealogist)
+**Scope:** Two high-value, high-confidence, low-blast-radius changes to cut
+wasted agent turns/thinking in a research session — landed **before** the
+re-measurement gate in [`research-latency-reduction-plan.md`](../plan/research-latency-reduction-plan.md).
+
+---
+
+## 1. Why these two, why now
+
+The latency analysis (see the reduction plan §"Baseline") found that a research
+session's wall-clock is ~90% **model generation** (tool/API latency is ~0), and
+that two phases dominate: `search-records` and `record-extraction`. The 2026-06-19
+persistence-tool migration already removed the biggest mechanical tax (the separate
+`validate_research_schema` calls + the array-re-serialization through `Edit`), so the
+*right* next step is to re-measure before prioritizing the rest.
+
+But two changes are worth landing **first** because they are correct regardless of
+what the re-measure shows, carry near-zero risk, and remove *known* wasted work:
+
+| Change | Value | Confidence | Blast radius |
+|---|---|---|---|
+| 1. `tree_edit` gains `add_source`/`update_source` | Removes the last hand-edit in the #1-cost phase (`record-extraction`) and in `proof-conclusion` | High — the gap is verified in code | Low — additive op on an existing tool; two SKILLs get *simpler* |
+| 2. Pin closed-vocabulary enums in SKILL prose | Kills the `no_evidence` dead-end + invalid-enum validation-retry loops observed in the run | High — the loops are verified in the transcript | None — prose only, no code |
+
+Neither depends on the re-measure. Neither changes a contract other code relies on.
+
+**Explicitly deferred to the reduction plan** (NOT quick wins): `research_append`
+batch/`entries[]` (re-touches freshly-migrated skills + their evals; magnitude is
+measurement-dependent), the `project`/`researcher_profile` writer, the `init-project`
+migration, MCP-tool preloading (runtime-dependent — `allowed-tools` is ignored by the
+Agent SDK; see reduction plan §Phase 2), and any auto-chaining of the skill pipeline
+(a UX/design decision).
+
+---
+
+## 2. Change 1 — `tree_edit`: `add_source` / `update_source`
+
+### Problem
+
+`tree.gedcomx.json` has a top-level `sources[]` array (the `S1`, `S2`, … source
+descriptions). Today **no write tool can add or edit one** outside a record merge:
+`tree_edit`'s operations are `add_fact` / `update_fact` / `add_name` / `update_name`
+/ `update_person` / `add_person` / `add_relationship` / `remove` (`tree-edit.ts`),
+none of which touch `sources[]`; `merge_record_into_tree` only folds in sources
+carried on a candidate record. So two skills still author the `S` entry without a
+working tool path — in two different ways:
+
+- **`record-extraction`** — step 5c: *"Write `tree.gedcomx.json` — append the `S`
+  entry to `sources`. This file is not a `research_append` section; write it
+  directly."* (SKILL.md ~lines 461-465) — an explicit hand-write with `Edit`/`Write`.
+  This runs once per source, and `record-extraction` is the #1-cost phase.
+- **`proof-conclusion`** — step 6 "Sources": *"ensure every source cited in the proof
+  has a GedcomX `S` entry. If one is missing, add it through the tree (the tool
+  validates the source shape…)"* (SKILL.md ~lines 286-289). This prose is **already
+  tool-first** — it promises a `tree_edit` source op that does not exist yet, so the
+  shipped SKILL is latently broken today. Work item A is what makes the instruction
+  actually work.
+
+Hand-editing forces the model to re-serialize tree JSON and re-derive the next `S`
+id, and (pre-migration) triggered a separate validate. It is the one remaining
+instance of exactly the pattern the persistence tools were built to eliminate.
+
+### Proposed change
+
+Add two operations to `tree_edit`, following the existing op-dispatch pattern:
+
+- **`add_source`** — append a new source description to `tree.gedcomx.json`
+  `sources[]`. Caller passes a `source` object **without an `id`**; the tool
+  allocates the next `S<N>` via the existing `nextId(tree, "S")` helper and rejects a
+  caller-supplied id (same discipline as `add_person`/`add_fact`).
+- **`update_source`** — merge a partial `source` object (skipping `id`) into an
+  existing source identified by `sourceId` — mirrors `update_fact`'s `factId` +
+  partial `fact` convention.
+
+**`source` object shape** (simplified-GedcomX tree source; see
+`docs/specs/simplified-gedcomx-spec.md`): `title` (required), optional `author`,
+`url`, `citation`. No nested entries; this is the lightweight tree-level source
+description, distinct from the rich `research.json` `sources[]` (which
+`research_append` already owns).
+
+**Input schema delta** (additive):
+
+```jsonc
+// operation enum gains: "add_source" | "update_source"
+{
+  "operation": "add_source",
+  "source": { "title": "...", "author": "...", "url": "...", "citation": "..." }
+}
+{
+  "operation": "update_source",
+  "sourceId": "S3",
+  "source": { "citation": "...", "url": "..." }
+}
+```
+
+**Behavior** (identical discipline to the other `tree_edit` ops):
+- Read `tree.gedcomx.json` fresh, mutate in memory.
+- `add_source`: reject if `source` carries an `id`; allocate `nextId(tree,"S")`.
+- `update_source`: error if `sourceId` not found; merge the partial `source`
+  (skipping `id`), exactly as `update_fact` merges its partial `fact`.
+- Validate the whole project via `validateParsed(research, tree, {projectPath})`
+  before persisting — **no separate `validate_research_schema` needed**.
+- On success persist via `backupIfExists` + `atomicWriteJson` (writes the one-deep
+  `.bak`, as the existing ops do). On `valid:false` return `{ok:false, errors}` and
+  write nothing.
+- Return the allocated/updated `sourceId` and `filesWritten: ["tree.gedcomx.json"]`.
+
+### SKILL changes
+
+- `record-extraction` step 5c: replace the hand-write instruction with
+  `tree_edit({operation:"add_source", source:{…}})`, one call per new source. Note
+  that `tree_edit` validates-before-persist, so the existing "this file is written
+  directly" caveat is removed.
+- `proof-conclusion` step 6: a small clarification (not a hand-write→tool rewrite) — the
+  prose is already tool-first but promises a missing op; name the operation explicitly,
+  `tree_edit({operation:"add_source"|"update_source"})`.
+
+### Risk / blast radius
+
+Low. The change is additive — existing `tree_edit` operations are untouched, and the
+two SKILL edits *remove* hand-written-JSON instructions (net-simpler skills). The only
+files touched: `packages/engine/mcp-server/src/tools/tree-edit.ts` (the op + its
+co-located `treeEditSchema`), `src/types/gedcomx.ts` (the `author` field on
+`SimplifiedSourceDescription`), the two SKILL.md files, and
+`docs/specs/tree-edit-tool-spec.md`. **No edit to `src/tool-schemas.ts`** (it imports
+`treeEditSchema`, `tool-schemas.ts:46,85`) or **`manifest.json`** (it lists the tool by
+name, `manifest.json:63`) — both are unchanged.
+
+### Verification
+
+- Unit test: `add_source` allocates the next `S` id, rejects a caller id, validates,
+  writes atomically; `update_source` merges fields and 404s on a missing id.
+- Re-run the `record-extraction` and `proof-conclusion` unit tests/evals — the
+  expected behavior is one fewer hand-edit, identical resulting tree state.
+
+---
+
+## 3. Change 2 — Pin closed-vocabulary enums in SKILL prose
+
+### Problem
+
+The session burned real model time exploring **invalid enum values**, then failing
+validation and retrying — a pure dead-weight loop:
+
+- `evidence_type`: the agent tried `no_evidence` (a category the GPS three-layer model
+  has conceptually but the schema does **not** allow), validation rejected it, and it
+  reverted all the changes — a documented multi-turn detour in `assertion-classification`.
+- `informant_proximity`: the agent emitted `self_or_household_member` (not a valid
+  value), validation rejected it, fix-and-retry.
+
+The schema only allows fixed vocabularies for these fields, but the SKILLs don't state
+them inline, so the model guesses and learns the constraint the slow way — via a
+validation round-trip. Post-migration the write tool returns the error in-band rather
+than via a separate validate, but the *retry turn* and the *deliberation* remain.
+
+### Proposed change
+
+In `assertion-classification` and `record-extraction` SKILL.md, state the valid values
+inline at the point each field is set, citing `docs/specs/research-schema-spec.md` as
+the source of truth so the prose can't silently drift:
+
+- **`evidence_type`** ∈ `direct` | `indirect` | `negative`. Add explicitly: *"There is
+  no `no_evidence` value. A fact that is irrelevant to the open question keeps
+  `indirect`; do not attempt `no_evidence` — the schema rejects it."*
+- **`information_quality`** ∈ `primary` | `secondary` | `indeterminate`.
+- **`informant_proximity`** ∈ `self` | `household_member` | `family_not_present` |
+  `official_duty` | `witness` | `unknown`.
+
+(`assertion-classification` owns `evidence_type`/`information_quality`/`informant_*`;
+`record-extraction` sets them at extraction time — both should carry the list.)
+
+### Risk / blast radius
+
+None code-wise — prose only, in two SKILL.md files. The one mild risk is
+**vocabulary drift** between the prose and the schema; mitigated by citing
+`research-schema-spec.md` as canonical and keeping the lists in one place per skill.
+
+### Out of scope (a real decision, deferred)
+
+Whether to *add* a `no_evidence` value to the `evidence_type` schema (so the model's
+GPS-correct instinct is representable) is a schema design question — higher blast
+radius (schema + `validator.ts` + every consumer + the three-places rule in CLAUDE.md)
+and not a quick win. Left to the reduction plan / a separate schema decision. This
+change takes the low-blast-radius path: tell the model the valid values.
+
+### Verification
+
+- Re-run `assertion-classification` unit tests/evals: expect no `no_evidence` attempt
+  and no invalid-`informant_proximity` retry in the transcript.
+- The e2e re-measure (reduction plan Phase 0) confirms the turn/time delta, but this
+  change lands first because it is confident and zero-risk regardless.
+
+---
+
+## 4. Sequencing & ownership
+
+- Both changes are independent and can land in one PR or two.
+- Change 1: developer (tool op + schema + manifest + 2 SKILL edits + unit test +
+  spec update). Follows the `tree_edit` scaffolding; `spec-review` audits against
+  `tree-edit-tool-spec.md`.
+- Change 2: genealogist or developer (prose only).
+- Neither blocks, nor is blocked by, the reduction plan's Phase 0 re-measure — but
+  landing them first means the re-measure already reflects them.

--- a/docs/specs/tree-edit-tool-spec.md
+++ b/docs/specs/tree-edit-tool-spec.md
@@ -59,12 +59,19 @@ In scope — the `tree-edit` ad-hoc operations (`SKILL.md:52–124`):
 | `update_person` | gender/ark correction |
 | `add_person` | "Adding a person" |
 | `add_relationship` | "Adding a relationship" |
+| `add_source` / `update_source` | source-description (`S` entry) add/correct — record-extraction step 5c, proof-conclusion step 6 |
 | `remove` | "Removing concluded data (tier downgrade)" — facts/relationships only |
+
+In scope for sources: the lightweight **tree** `sources[]` entry (the `S`
+description in `tree.gedcomx.json`, `simplified-gedcomx-spec.md` §4.3) — `title`,
+optional `author`/`url`/`citation`. Out of scope: the rich `research.json`
+`sources[]` (citation, repository, classification, …), which `research_append`
+owns; the two are linked by `gedcomx_source_description_id`.
 
 Out of scope: **person merging / person removal** — that is the merge tools'
 job (`merge_tree_persons` removes a collapsed person and remaps `research.json`);
 `tree_edit` never deletes a person. Also out of scope: `research.json` edits
-(those are the future `research_append`), and `check-warnings` (a separate skill
+(those are `research_append`), and `check-warnings` (a separate skill
 step, run after — see §8).
 
 ---
@@ -92,19 +99,22 @@ tree_edit({
   operation:
     | "add_fact" | "update_fact"
     | "add_name" | "update_name" | "update_person"
-    | "add_person" | "add_relationship" | "remove",
+    | "add_person" | "add_relationship"
+    | "add_source" | "update_source" | "remove",
 
   // ── targeting (per operation) ──
   personId?: string,          // add_fact, add_name, update_fact, update_name, update_person
   factId?: string,            // update_fact, remove
   nameId?: string,            // update_name
   relationshipId?: string,    // remove
+  sourceId?: string,          // update_source
 
   // ── payloads (snake_case, NO id — the tool assigns) ──
   fact?: SimplifiedFact,            // add_fact (full) / update_fact (fields to set)
   name?: SimplifiedName,            // add_name (full) / update_name (fields to set)
   person?: SimplifiedPerson,        // add_person (full; nested names get N ids too)
   relationship?: SimplifiedRelationship, // add_relationship (full)
+  source?: SimplifiedSourceDescription,  // add_source (full) / update_source (fields to set)
   gender?: string, ark?: string,    // update_person
 
   resolveStandardPlace?: boolean,   // default true: auto-resolve standard_place when place is set
@@ -135,6 +145,14 @@ tree_edit({
   endpoints (`parent`/`child` for `ParentChild`, `person1`/`person2` for `Couple`)
   reference existing persons (tree persons or FS ids already present); reject a
   shape mismatch (e.g. `person1` on a `ParentChild`).
+- **`add_source`** `{ source }` — append `source` to the tree's `sources`, assigning
+  the next `S` id above the tree max (top-level, like `add_relationship` — no person
+  scope, no place resolution, no primary swap). A caller-supplied `id` is rejected.
+  `title` is required, enforced by the shared validation pass (`validator.ts`
+  requires `[id, title]` on each tree source), so a titleless source writes nothing.
+- **`update_source`** `{ sourceId, source }` — shallow-merge the provided `source`
+  fields onto the existing source (`id` immutable). Errors if `sourceId` is not found
+  in the on-disk tree.
 - **`remove`** `{ factId }` **or** `{ relationshipId }` — delete that entry. **Only
   facts and relationships** — a `personId` here is an error (person removal is
   `merge_tree_persons`).
@@ -147,7 +165,7 @@ tree_edit({
   operation: string,
   assignedIds?: {                 // ids the tool allocated, for narration
     person?: string, fact?: string, name?: string,
-    relationship?: string, names?: string[],
+    relationship?: string, source?: string, names?: string[],
   },
   filesWritten: ["tree.gedcomx.json"],
   validation: { valid: true, warnings: string[] },
@@ -190,10 +208,10 @@ Sequence (mirrors `merge_record_into_tree`):
 
 - **One tool with an `operation` discriminator, not one tool per edit.** Follows
   this repo's "don't create one MCP tool per endpoint — use generic tools with
-  parameters" rule (CLAUDE.md) and keeps Claude's tool list lean. The eight
+  parameters" rule (CLAUDE.md) and keeps Claude's tool list lean. The ten
   operations share the entire read → apply → validate → backup → write pipeline;
   only the in-memory mutation differs. *Rejected:* `tree_add_fact`,
-  `tree_add_person`, … (eight near-identical tools, eight schema entries, more
+  `tree_add_person`, … (ten near-identical tools, ten schema entries, more
   context for no behavioral gain). The merge tools are two tools only because they
   have **different side effects** (one writes one file, the other two + a remap);
   every `tree_edit` operation has the *same* side effect (write the tree), so the
@@ -214,8 +232,10 @@ Sequence (mirrors `merge_record_into_tree`):
 | Condition | Behavior |
 |-----------|----------|
 | `projectPath` missing `tree.gedcomx.json` / invalid JSON | input error; write nothing |
-| `personId` / `factId` / `nameId` / `relationshipId` not found in the on-disk tree | staleness error; write nothing |
-| `operation` requires a payload that is absent (e.g. `add_fact` with no `fact`) | input error |
+| `personId` / `factId` / `nameId` / `relationshipId` / `sourceId` not found in the on-disk tree | staleness error; write nothing |
+| `operation` requires a payload that is absent (e.g. `add_fact` with no `fact`, `add_source` with no `source`, `update_source` with no `sourceId`/`source`) | input error |
+| `add_source` / `update_source` payload carries an `id` | rejected (add) / ignored (update — `id` is immutable) |
+| `add_source` with a source missing `title` | validation failure; write nothing (the shared validate-before-persist pass requires `[id, title]`) |
 | `add_relationship` endpoint references a non-existent person, or field shape mismatches the `type` | input error (also caught by validation) |
 | `remove` with a `personId` (attempt to delete a person) | input error — use `merge_tree_persons` |
 | `resolveStandardPlace` network call fails | best-effort: set `standard_place: null`, add a warning; never fail the edit on a place-resolution miss |
@@ -250,6 +270,11 @@ The caller (`tree-edit` skill) still:
 - **add_person** — `I` id + `N` ids assigned; stub omits `ark`.
 - **add_relationship** — `R` id assigned; endpoints validated; `ParentChild` with
   `person1` rejected.
+- **add_source / update_source** — `S` id assigned above the tree max (S-aware
+  `nextId`, so `S1`→`S2`); a caller-supplied `id` is rejected on add; `author`/`url`
+  round-trip into the written `S` entry; `update_source` merges by `sourceId` (id
+  immutable), errors on an unknown `sourceId`; missing-payload guards return
+  `{ ok: false }`; a titleless `add_source` fails validation and writes nothing.
 - **remove** — fact/relationship deleted by id; `remove` with `personId` rejected.
 - **id allocation** — adding to a tree with `F1..F9` yields `F10` (max + 1).
 - **staleness** — an unknown `factId` returns an error, writes nothing.

--- a/packages/engine/mcp-server/src/tools/tree-edit.ts
+++ b/packages/engine/mcp-server/src/tools/tree-edit.ts
@@ -16,6 +16,7 @@ import type {
   SimplifiedName,
   SimplifiedFact,
   SimplifiedRelationship,
+  SimplifiedSourceDescription,
 } from "../types/gedcomx.js";
 import { validateParsed } from "../validation/validator.js";
 import type { ValidationError } from "../validation/types.js";
@@ -31,6 +32,8 @@ export type TreeEditOperation =
   | "update_person"
   | "add_person"
   | "add_relationship"
+  | "add_source"
+  | "update_source"
   | "remove";
 
 export interface TreeEditInput {
@@ -40,10 +43,12 @@ export interface TreeEditInput {
   factId?: string;
   nameId?: string;
   relationshipId?: string;
+  sourceId?: string;
   fact?: SimplifiedFact;
   name?: SimplifiedName;
   person?: SimplifiedPerson;
   relationship?: SimplifiedRelationship;
+  source?: SimplifiedSourceDescription;
   gender?: string;
   ark?: string;
   /** Auto-resolve standard_place when a place is set (default true). */
@@ -55,6 +60,7 @@ interface AssignedIds {
   fact?: string;
   name?: string;
   relationship?: string;
+  source?: string;
   names?: string[];
 }
 
@@ -218,6 +224,25 @@ async function applyOperation(
       assignedIds.relationship = rel.id;
       break;
     }
+    case "add_source": {
+      if (!input.source) throw new TreeEditError("add_source requires a `source`");
+      if (input.source.id) throw new TreeEditError("add_source `source` must not carry an id — the tool assigns it");
+      const source: SimplifiedSourceDescription = { ...input.source, id: nextId(tree, "S") };
+      tree.sources = [...(tree.sources ?? []), source];
+      assignedIds.source = source.id;
+      break;
+    }
+    case "update_source": {
+      if (!input.sourceId) throw new TreeEditError("update_source requires a `sourceId`");
+      if (!input.source) throw new TreeEditError("update_source requires `source` fields to set");
+      const existing = (tree.sources ?? []).find((s) => s.id === input.sourceId);
+      if (!existing) throw new TreeEditError(`source '${input.sourceId}' not found in tree`);
+      for (const [k, v] of Object.entries(input.source)) {
+        if (k === "id") continue;
+        (existing as any)[k] = v;
+      }
+      break;
+    }
     case "remove": {
       if (input.personId) {
         throw new TreeEditError("remove does not delete persons — use merge_tree_persons to collapse a person");
@@ -296,13 +321,13 @@ export const treeEditSchema = {
   name: "tree_edit",
   description:
     "Make a single ad-hoc edit to the project's tree.gedcomx.json — add or correct " +
-    "a fact or name, add a person or relationship, or remove a fact/relationship on " +
-    "a tier downgrade. Use this for direct corrections; use merge_record_into_tree / " +
-    "merge_tree_persons to fold in a record or collapse duplicate persons (this tool " +
-    "never deletes a person).\n" +
+    "a fact or name, add a person or relationship, add or correct a source, or remove " +
+    "a fact/relationship on a tier downgrade. Use this for direct corrections; use " +
+    "merge_record_into_tree / merge_tree_persons to fold in a record or collapse " +
+    "duplicate persons (this tool never deletes a person).\n" +
     "\n" +
     "Pick the `operation` and supply the content (snake_case simplified-GedcomX " +
-    "fields) WITHOUT ids — the tool assigns the next F/N/I/R id, swaps the " +
+    "fields) WITHOUT ids — the tool assigns the next F/N/I/R/S id, swaps the " +
     "primary/preferred flag, resolves standard_place for a place, validates the " +
     "whole project, and writes only tree.gedcomx.json (with a one-deep .bak). " +
     "Returns a compact summary (the assigned ids); on a validation failure nothing " +
@@ -325,6 +350,8 @@ export const treeEditSchema = {
           "update_person",
           "add_person",
           "add_relationship",
+          "add_source",
+          "update_source",
           "remove",
         ],
         description: "The edit to perform.",
@@ -336,6 +363,7 @@ export const treeEditSchema = {
       factId: { type: "string", description: "Target fact id — for update_fact and remove." },
       nameId: { type: "string", description: "Target name id — for update_name." },
       relationshipId: { type: "string", description: "Target relationship id — for remove." },
+      sourceId: { type: "string", description: "Target source id — for update_source." },
       fact: {
         type: "object",
         description: "The fact to add (full, no id) or the fields to set (update_fact). Set `primary: true` to make it the primary of its type.",
@@ -351,6 +379,10 @@ export const treeEditSchema = {
       relationship: {
         type: "object",
         description: "The relationship to add (no id). Use `parent`/`child` for ParentChild, `person1`/`person2` for Couple; endpoints must be existing person ids.",
+      },
+      source: {
+        type: "object",
+        description: "The source description to add (full, no id — the tool assigns the next S id) or the fields to set (update_source). Fields: `title` (required on add), optional `author`, `url`, `citation` — a plain top-level entry, so no place resolution or primary/preferred handling applies. This is the lightweight tree sources[] entry, distinct from the rich research.json source.",
       },
       gender: { type: "string", description: "update_person: new gender (Male/Female/Unknown)." },
       ark: { type: "string", description: "update_person: the FamilySearch ARK to set." },

--- a/packages/engine/mcp-server/src/types/gedcomx.ts
+++ b/packages/engine/mcp-server/src/types/gedcomx.ts
@@ -160,6 +160,7 @@ export interface SimplifiedSourceDescription {
   id?: string;
   title?: string;
   citation?: string;
+  author?: string;
   url?: string;
 }
 

--- a/packages/engine/mcp-server/tests/tools/tree-edit.test.ts
+++ b/packages/engine/mcp-server/tests/tools/tree-edit.test.ts
@@ -218,4 +218,113 @@ describe("tree_edit", () => {
     expect(await readFile(join(dir, "tree.gedcomx.json"), "utf-8")).toBe(treeBefore);
     expect(await exists("tree.gedcomx.json.bak")).toBe(false);
   });
+
+  it("add_source: assigns the next S id, rejects a caller-supplied id, writes only the tree + .bak", async () => {
+    await writeProject(onePerson());
+    const researchBefore = await readFile(join(dir, "research.json"), "utf-8");
+
+    const r = await treeEdit({
+      projectPath: dir,
+      operation: "add_source",
+      source: { title: "1850 U.S. Federal Census" },
+    });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.assignedIds?.source).toBe("S1");
+    expect(r.filesWritten).toEqual(["tree.gedcomx.json"]);
+
+    const tree = await readTree();
+    expect(tree.sources).toHaveLength(1);
+    expect(tree.sources[0]).toMatchObject({ id: "S1", title: "1850 U.S. Federal Census" });
+
+    expect(await exists("tree.gedcomx.json.bak")).toBe(true);
+    // research.json is never touched by a source add
+    expect(await readFile(join(dir, "research.json"), "utf-8")).toBe(researchBefore);
+
+    // a caller-supplied id is rejected (the tool assigns ids)
+    const bad = await treeEdit({
+      projectPath: dir,
+      operation: "add_source",
+      source: { id: "S9", title: "Should fail" } as any,
+    });
+    expect(bad.ok).toBe(false);
+  });
+
+  it("add_source twice: ids increment S1 -> S2 (nextId is S-aware)", async () => {
+    await writeProject(onePerson());
+    const r1 = await treeEdit({ projectPath: dir, operation: "add_source", source: { title: "First" } });
+    expect(r1.ok && r1.assignedIds?.source).toBe("S1");
+    const r2 = await treeEdit({ projectPath: dir, operation: "add_source", source: { title: "Second" } });
+    expect(r2.ok && r2.assignedIds?.source).toBe("S2");
+    expect((await readTree()).sources.map((s: any) => s.id)).toEqual(["S1", "S2"]);
+  });
+
+  it("add_source: author/url round-trip into the written S entry", async () => {
+    await writeProject(onePerson());
+    const r = await treeEdit({
+      projectPath: dir,
+      operation: "add_source",
+      source: { title: "Pension File", author: "National Archives", url: "https://example.com/pension" },
+    });
+    expect(r.ok).toBe(true);
+    const s1 = (await readTree()).sources.find((s: any) => s.id === "S1");
+    expect(s1).toMatchObject({
+      id: "S1",
+      title: "Pension File",
+      author: "National Archives",
+      url: "https://example.com/pension",
+    });
+  });
+
+  it("update_source: merges fields, leaves others intact, refuses to change id, errors on unknown id", async () => {
+    const tree = onePerson();
+    (tree as any).sources = [{ id: "S1", title: "Original Title", author: "Old Author" }];
+    await writeProject(tree);
+
+    const r = await treeEdit({
+      projectPath: dir,
+      operation: "update_source",
+      sourceId: "S1",
+      source: { citation: "Smith, *Census*, p. 4.", id: "S99" } as any,
+    });
+    expect(r.ok).toBe(true);
+    const s1 = (await readTree()).sources.find((s: any) => s.id === "S1");
+    expect(s1.id).toBe("S1"); // id immutable — the supplied id is ignored
+    expect(s1.citation).toBe("Smith, *Census*, p. 4.");
+    expect(s1.title).toBe("Original Title"); // untouched
+    expect(s1.author).toBe("Old Author"); // untouched
+    // no S99 was created
+    expect((await readTree()).sources.map((s: any) => s.id)).toEqual(["S1"]);
+
+    const bad = await treeEdit({
+      projectPath: dir,
+      operation: "update_source",
+      sourceId: "S404",
+      source: { title: "X" },
+    });
+    expect(bad.ok).toBe(false);
+  });
+
+  it("source operations: missing-argument guards write nothing", async () => {
+    await writeProject(onePerson());
+    const noSource = await treeEdit({ projectPath: dir, operation: "add_source" });
+    expect(noSource.ok).toBe(false);
+    const noId = await treeEdit({ projectPath: dir, operation: "update_source", source: { title: "X" } });
+    expect(noId.ok).toBe(false);
+    const noFields = await treeEdit({ projectPath: dir, operation: "update_source", sourceId: "S1" });
+    expect(noFields.ok).toBe(false);
+  });
+
+  it("add_source: a source with no title fails validation and writes nothing", async () => {
+    await writeProject(onePerson());
+    const treeBefore = await readFile(join(dir, "tree.gedcomx.json"), "utf-8");
+    const r = await treeEdit({
+      projectPath: dir,
+      operation: "add_source",
+      source: { author: "No Title Source" } as any,
+    });
+    expect(r.ok).toBe(false);
+    expect(await readFile(join(dir, "tree.gedcomx.json"), "utf-8")).toBe(treeBefore);
+    expect(await exists("tree.gedcomx.json.bak")).toBe(false);
+  });
 });

--- a/packages/engine/plugin/skills/assertion-classification/SKILL.md
+++ b/packages/engine/plugin/skills/assertion-classification/SKILL.md
@@ -133,14 +133,21 @@ opening a question is the unblocking step. You may still refine Layer-2
 (information quality / informant) fields, which do not depend on a
 question.
 
-Decision rules:
+`evidence_type` is a closed set of exactly three values: `direct` |
+`indirect` | `negative` (source of truth
+`docs/specs/research-schema-spec.md`). Decision rules:
 - **Direct**: explicitly answers a question with no inference needed.
 - **Indirect**: implies an answer but requires inference or
   correlation with other facts.
 - **Negative**: meaningful absence of EXPECTED information. The record
   must be one where the fact SHOULD appear if true, and the absence
   must be meaningful given context.
-- **No evidence**: the information is irrelevant to any open question.
+
+**There is no `no_evidence` value.** "No evidence" describes a fact that
+is irrelevant to every open question — it is **not** a fourth
+`evidence_type`. Such a fact keeps its existing best-effort value (often
+`indirect`); do not set `evidence_type: "no_evidence"` — the schema
+rejects it and the write tool will refuse the entry.
 
 **Subject-identification rule.** An assertion whose value identifies
 the subject within the record — typically the `name` assertion for
@@ -167,8 +174,10 @@ multi-fact records work, not an inference chain that triggers
 > `direct` — changing it to `indirect` is wrong.)
 
 **Critical distinctions:**
-- Absence of information NOT expected in a record type = "no evidence"
-  (e.g., parents' names missing from a marriage record)
+- Absence of information NOT expected in a record type is the "no
+  evidence" *concept* (e.g., parents' names missing from a marriage
+  record) — it is neither negative evidence nor an `evidence_type` value
+  (see above); such a fact is simply not classified `negative`
 - A nil search result is NOT negative evidence unless search was
   reasonably exhaustive
 - Evidence type can change when new questions are added -- update
@@ -210,17 +219,22 @@ research_append({
   op: "update",
   entryId: "<assertion id, e.g. a_012>",
   fields: {
-    information_quality: "...",   // if the refined value differs from record-extraction's best-effort
+    information_quality: "...",   // primary | secondary | indeterminate (closed set)
     informant: "...",             // if the analysis identifies a more specific informant
-    informant_proximity: "...",   // if the analysis changes the proximity
+    informant_proximity: "...",   // self | witness | household_member | family_not_present | official_duty | unknown (closed set)
     informant_bias_notes: "...",  // add bias analysis if relevant
-    evidence_type: "...",         // if the refined classification differs
+    evidence_type: "...",         // direct | indirect | negative (closed set — there is no no_evidence)
     extracted_for_question_ids: [ ... ]  // add any newly relevant question IDs
   }
 })
 ```
 
-Pass only the classification fields that actually changed. You only ever
+`information_quality`, `informant_proximity`, and `evidence_type` are
+closed enums — the allowed values are exactly those listed above (source
+of truth `docs/specs/research-schema-spec.md`). Any other value (e.g.
+`no_evidence`, `analyst`) is rejected by the schema and the write tool
+refuses the entry, so do not attempt one. Pass only the classification
+fields that actually changed. You only ever
 pass classification fields; the immutable fields (`id`, `source_id`,
 `record_id`, `record_role`, `fact_type`, `value`, `structured_value`,
 `date`, `date_certainty`, `place`, `log_entry_id` — all set by

--- a/packages/engine/plugin/skills/proof-conclusion/SKILL.md
+++ b/packages/engine/plugin/skills/proof-conclusion/SKILL.md
@@ -284,9 +284,12 @@ the tool does the clerical work.
   `tree_edit({ operation: "add_relationship", relationship })`,
   referencing the concluded source(s).
 - **Sources:** ensure every source cited in the proof has a GedcomX `S`
-  entry. If one is missing, add it through the tree (the tool validates
-  the source shape — copy the finalized `research.json`
-  `sources[].citation` into the `S` entry's `citation`).
+  entry. If one is missing, add it with `tree_edit({ operation:
+  "add_source", source: { title, citation, … } })` — copy the finalized
+  `research.json` `sources[].citation` into the `S` entry's `citation`.
+  To correct an existing `S` entry's citation or title, use `tree_edit({
+  operation: "update_source", sourceId, source })`. The tool assigns the
+  `S` id and validates the source shape; you supply only the fields.
 - **Source references:** Set `quality` based on evidence analysis:
   - `3`: Original + primary + direct
   - `2`: Original + secondary/indirect, or derivative + primary

--- a/packages/engine/plugin/skills/proof-conclusion/SKILL.md
+++ b/packages/engine/plugin/skills/proof-conclusion/SKILL.md
@@ -277,7 +277,7 @@ the tool does the clerical work.
     projectPath: "<absolute-path-to-project-directory>",
     operation: "add_fact",
     personId: "I3",
-    fact: { type: "Death", date: "1881", place: "Schuylkill County, Pennsylvania, United States", primary: true, sources: ["S2"] }
+    fact: { type: "Death", date: "1881", place: "Schuylkill County, Pennsylvania, United States", primary: true, sources: [{ ref: "S2" }] }
   })
   ```
 - **Relationships:** add a ParentChild or Couple relationship with

--- a/packages/engine/plugin/skills/record-extraction/SKILL.md
+++ b/packages/engine/plugin/skills/record-extraction/SKILL.md
@@ -22,6 +22,7 @@ allowed-tools:
   - place_search_all
   - research_append
   - research_log_append
+  - tree_edit
   - record_person_matches
   - record_record_matches
 ---
@@ -226,7 +227,7 @@ assigns the next `a_` id on append):
   "standard_place": "<standardized place name or null — see Standardizing places>",
   "information_quality": "<primary|secondary|indeterminate>",
   "informant": "<who provided this fact — REQUIRED, never omit>",
-  "informant_proximity": "<self|witness|household_member|... — REQUIRED, never omit>",
+  "informant_proximity": "<self|witness|household_member|family_not_present|official_duty|unknown — REQUIRED, closed set, never omit>",
   "informant_bias_notes": "<bias concerns or null>",
   "evidence_type": "<direct|indirect|negative>",
   "log_entry_id": "<log_ reference or null>",
@@ -293,9 +294,10 @@ occupation facts. Shapes:
   relationship is deduced from position, not stated in the record.
 - `occupation`: `{ "occupation": "coal miner" }`
 
-**`information_quality`** — Best-effort classification. Will be
-refined by assertion-classification, but provide an initial value
-using the two-question decision tree:
+**`information_quality`** ∈ `primary` | `secondary` | `indeterminate`
+(closed set; source of truth `docs/specs/research-schema-spec.md`).
+Best-effort classification — will be refined by assertion-classification,
+but provide an initial value using the two-question decision tree:
 1. Do we know the informant? No -> `indeterminate`
 2. Did the informant witness/participate? Yes -> `primary`;
    No -> `secondary`; Cannot tell -> `indeterminate`
@@ -304,7 +306,13 @@ Classification is about the informant's proximity to the event,
 not accuracy. Primary information can still be wrong.
 
 **`informant` and `informant_proximity`** — **Required on every
-assertion — never omit these fields.** The recorder and informant are
+assertion — never omit these fields.** `informant_proximity` is a closed
+set: `self` | `witness` | `household_member` | `family_not_present` |
+`official_duty` | `unknown` (source of truth
+`docs/specs/research-schema-spec.md`). There is no `analyst` or
+`researcher` value — for a negative assertion the researcher concluded
+(no informant in the record), use `unknown` and explain the analyst
+inference in `informant_bias_notes`. The recorder and informant are
 different people. For census records the enumerator is the recorder —
 a household member answered the questions.
 
@@ -323,7 +331,9 @@ When the informant is named on the record, use their name. For
 non-census records, load
 `references/information-classification-at-extraction.md`.
 
-**`evidence_type`** — Best-effort classification:
+**`evidence_type`** ∈ `direct` | `indirect` | `negative` (closed set;
+source of truth `docs/specs/research-schema-spec.md`). Best-effort
+classification:
 - `direct`: the fact is explicitly stated in the record (name,
   age, birthplace, occupation, residence — all `direct` when the
   record column contains the value)
@@ -331,6 +341,11 @@ non-census records, load
   (e.g., birth year computed from age, household position suggesting
   parent-child relationship)
 - `negative`: the meaningful absence of expected information
+
+There is no `no_evidence` value — a fact irrelevant to every open
+question keeps its best-effort type (most often `indirect`). Do not
+attempt `no_evidence`; the schema rejects it and the write tool will
+refuse the entry.
 
 **Age vs. birth year:** If the record states "age 32", an assertion
 for fact_type `age` with value "32" is `direct` (explicitly stated).
@@ -458,18 +473,23 @@ Every persona gets fully expanded individual `a_` entries — never
 compress into ranges. Stamp each assertion's `source_id` with the
 `src_` id step 5a returned and its `log_entry_id` with step 4's `logId`.
 
-**5c. Write `tree.gedcomx.json`** — append the `S` entry to `sources`.
-This file is not a `research_append` section; write it directly. Root
-has exactly three keys: `persons`, `relationships`, `sources` — do not
-add `id` or other keys at root. Optional `S` fields (author, url) must
-be omitted if not applicable — never set to `null`.
+**5c. Add the source `S` entry to `tree.gedcomx.json`** — for each new
+source, call `tree_edit({ operation: "add_source", source: {…} })`. The
+tool assigns the next `S` id, validates the whole project, and writes the
+tree (with a one-deep `.bak`) on success — returning `{ ok: false,
+errors }` and writing nothing on a problem. Do **not** hand-edit the
+file, allocate the `S` id, or call `validate_research_schema` for it.
+Pass `title` (required) plus the optional `author`/`url`; omit any field
+that doesn't apply — never set it to `null`, and never pass an `id` (the
+tool assigns it). To correct an existing `S` entry's title or citation
+later, use `tree_edit({ operation: "update_source", sourceId, source })`.
 
 Before appending, double-check the fields the validator is strict about,
 so each `research_append` passes on the first call:
 - `record_id` uses the correct format (full URL for FamilySearch, not bare ARK)
 - `record_persona_id` is set (non-null) for `record_search` sources
 - All required assertion fields are present (informant, informant_proximity, evidence_type)
-- The GedcomX `S` entry has only allowed fields (id, title, citation, author, url)
+- The `add_source` payload carries `title` (required) and only the optional `author`/`url`/`citation` — no `id`, no `null` values
 
 ### 6. Present results
 
@@ -531,10 +551,10 @@ without an `id`:
   "date": "1870",
   "date_certainty": "exact",
   "place": "Schuylkill County, Pennsylvania",
-  "information_quality": "primary",
+  "information_quality": "indeterminate",
   "informant": "researcher (searched index and found no match)",
-  "informant_proximity": "analyst",
-  "informant_bias_notes": "The researcher searched the census index and concluded the person is absent. Absence could be due to: temporary relocation, enumerator error, indexing omission, damaged pages, or the subject genuinely not residing there",
+  "informant_proximity": "unknown",
+  "informant_bias_notes": "Analyst inference, not a record informant — proximity is 'unknown' because no one reported this absence. The researcher searched the census index and concluded the person is absent. Absence could be due to: temporary relocation, enumerator error, indexing omission, damaged pages, or the subject genuinely not residing there",
   "evidence_type": "negative",
   "log_entry_id": "log_010",
   "extracted_for_question_ids": ["q_001"]


### PR DESCRIPTION
Implements [`docs/plan/research-latency-quick-wins-implementation-plan.md`](docs/plan/research-latency-quick-wins-implementation-plan.md). Two independent changes that cut wasted research turns, landed together per the plan.

## Work item A — `tree_edit`: `add_source` / `update_source`

Replaces hand-writing the GedcomX `S` source entry (and the latently-broken proof-conclusion instruction that promised a source op that didn't exist) with two new `tree_edit` operations.

- **Tool** (`src/tools/tree-edit.ts`): `add_source` and `update_source`. Sources are top-level (mirrors `add_relationship` / `update_fact`, minus place/primary handling). The tool assigns the next `S` id, validates the whole project, and writes only `tree.gedcomx.json` (one-deep `.bak`). `add_source` rejects a caller-supplied `id`; `update_source` shallow-merges and treats `id` as immutable, erroring on an unknown `sourceId`.
- **Type** (`src/types/gedcomx.ts`): add `author?: string` to `SimplifiedSourceDescription` — documented in `simplified-gedcomx-spec.md` §4.3 but previously missing from the type.
- **Tests** (`tests/tools/tree-edit.test.ts`): 6 new cases — S-id allocation (`S1`→`S2`), caller-id rejection, id-immutability, missing-arg guards, `author`/`url` round-trip, titleless-source validation failure (writes nothing).
- **Spec** (`docs/specs/tree-edit-tool-spec.md`): updated §2/§4/§4.1/§4.2/§6/§7/§9 to cover both ops.
- **SKILL adoption**: `record-extraction` step 5c now calls `tree_edit({ operation: "add_source" })` (+ `tree_edit` added to its `allowed-tools`); `proof-conclusion` step 6 names the source ops explicitly.

No change to `tool-schemas.ts` or `manifest.json` — `treeEditSchema` is imported and the tool is listed by name; the packaging drift test confirms parity.

## Work item B — pin closed-vocabulary enums in SKILL prose

`assertion-classification` and `record-extraction` now state the exact allowed values for `evidence_type`, `information_quality`, and `informant_proximity` inline, citing `research-schema-spec.md` as the source of truth. Verified byte-exact against the validator's allow-lists.

Fixed two latent bugs that the plan's verification criteria explicitly target as baseline wasted loops:
- **`no_evidence`**: `assertion-classification` presented "No evidence" as a 4th `evidence_type` value (lines 143/170). Clarified the enum is exactly `direct | indirect | negative` and there is no `no_evidence` value (schema rejects it; the write tool refuses the entry).
- **`analyst`**: `record-extraction`'s negative-evidence example used `informant_proximity: "analyst"` — not in the validator's allow-list, a guaranteed retry. Corrected to `"unknown"` and aligned `information_quality` to `"indeterminate"` per the SKILL's own decision tree (unknown informant → indeterminate).

## Verification

- Full MCP server suite: **1124 tests pass** (incl. packaging/manifest drift); `tsc --noEmit` clean.
- A 3-lens adversarial review (spec-drift via `spec-review`, enum/validator fidelity, prose+tool coherence) returned **clean on all lenses, zero confirmed findings**.
- Live skill/assertion evals were **deferred** (need API + network) — the plan's documented Phase-0 follow-up.

## ⚠️ CI note — `check-runlogs` will be red

Editing the three SKILLs flips their eval run logs inactive, so the `check-runlogs` gate (Rule 2: latest run log's snapshot must match) stays red until the genealogy team re-runs and re-blesses the `record-extraction`, `proof-conclusion`, and `assertion-classification` evals. This is the expected signal for the plan's Phase-0 re-measure follow-up, not a defect in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)