### PR TITLE
search-records: add name-variation eval tests (#398)

### DIFF
--- a/eval/fixtures/mcp/record-search-1860-census-mullen-sarah.json
+++ b/eval/fixtures/mcp/record-search-1860-census-mullen-sarah.json
@@ -1,0 +1,78 @@
+{
+  "tool": "record_search",
+  "description": "FamilySearch record search returning the 1860 US Census household of William Mullen, with Sarah A. Mullen (age 8) as a child. Used for the multiple-marriages and maiden-to-married-name-shift scenarios to confirm the birth surname.",
+  "args": {
+    "surname": "Mullen",
+    "givenName": "~Sarah"
+  },
+  "response": {
+    "query": { "surname": "Mullen", "givenName": "Sarah" },
+    "totalMatches": 1,
+    "paginationCappedAt": 100,
+    "returned": 1,
+    "offset": 0,
+    "hasMore": false,
+    "results": [
+      {
+        "personId": "WICN-1860-M01",
+        "recordId": "WICN-1860-M01",
+        "personName": "Sarah A. Mullen",
+        "score": 0.92,
+        "sex": "Female",
+        "birthDate": "1852",
+        "birthPlace": "Wisconsin",
+        "events": [
+          { "type": "Residence", "date": "1860", "place": "Dodge County, Wisconsin" }
+        ],
+        "arkUrl": "https://www.familysearch.org/ark:/61903/1:1:WICN-1860-M01",
+        "collectionId": "1473181",
+        "collectionTitle": "United States Census, 1860",
+        "recordTitle": "Sarah A. Mullen in household of William Mullen",
+        "treeMatches": [],
+        "primaryId": "P1",
+        "gedcomx": {
+          "persons": [
+            {
+              "id": "P1",
+              "gender": "Female",
+              "names": [
+                { "id": "N1", "preferred": true, "given": "Sarah A.", "surname": "Mullen", "type": "BirthName" }
+              ],
+              "facts": [
+                { "id": "F1", "type": "Birth", "date": "1852", "place": "Wisconsin" },
+                { "id": "F2", "type": "Residence", "date": "1860", "place": "Dodge County, Wisconsin" }
+              ]
+            },
+            {
+              "id": "P2",
+              "gender": "Male",
+              "names": [
+                { "id": "N2", "preferred": true, "given": "William", "surname": "Mullen", "type": "BirthName" }
+              ],
+              "facts": [
+                { "id": "F3", "type": "Birth", "date": "1825", "place": "Ireland" },
+                { "id": "F4", "type": "Residence", "date": "1860", "place": "Dodge County, Wisconsin" }
+              ]
+            },
+            {
+              "id": "P3",
+              "gender": "Female",
+              "names": [
+                { "id": "N3", "preferred": true, "given": "Margaret", "surname": "Mullen", "type": "BirthName" }
+              ],
+              "facts": [
+                { "id": "F5", "type": "Birth", "date": "1830", "place": "Ireland" },
+                { "id": "F6", "type": "Residence", "date": "1860", "place": "Dodge County, Wisconsin" }
+              ]
+            }
+          ],
+          "relationships": [
+            { "id": "R1", "type": "ParentChild", "parent": "P2", "child": "P1" },
+            { "id": "R2", "type": "ParentChild", "parent": "P3", "child": "P1" },
+            { "id": "R3", "type": "Couple", "person1": "P2", "person2": "P3" }
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/eval/fixtures/mcp/record-search-1880-census-price-sarah.json
+++ b/eval/fixtures/mcp/record-search-1880-census-price-sarah.json
@@ -1,0 +1,112 @@
+{
+  "tool": "record_search",
+  "description": "FamilySearch record search returning the 1880 US Census household of James Price, with Sarah M. Price (age 5) as a daughter. The 'M' initial represents the middle name Mullen. Used for the child-middle-name scenario.",
+  "args": {
+    "surname": "Price",
+    "givenName": "~Sarah"
+  },
+  "response": {
+    "query": { "surname": "Price", "givenName": "Sarah" },
+    "totalMatches": 2,
+    "paginationCappedAt": 100,
+    "returned": 2,
+    "offset": 0,
+    "hasMore": false,
+    "results": [
+      {
+        "personId": "WICN-1880-P01",
+        "recordId": "WICN-1880-P01",
+        "personName": "Sarah M. Price",
+        "score": 0.90,
+        "sex": "Female",
+        "birthDate": "1875",
+        "birthPlace": "Wisconsin",
+        "events": [
+          { "type": "Residence", "date": "1880", "place": "Dodge County, Wisconsin" }
+        ],
+        "arkUrl": "https://www.familysearch.org/ark:/61903/1:1:WICN-1880-P01",
+        "collectionId": "1417683",
+        "collectionTitle": "United States Census, 1880",
+        "recordTitle": "Sarah M. Price in household of James Price",
+        "treeMatches": [],
+        "primaryId": "P1",
+        "gedcomx": {
+          "persons": [
+            {
+              "id": "P1",
+              "gender": "Female",
+              "names": [
+                { "id": "N1", "preferred": true, "given": "Sarah M.", "surname": "Price", "type": "BirthName" }
+              ],
+              "facts": [
+                { "id": "F1", "type": "Birth", "date": "1875", "place": "Wisconsin" },
+                { "id": "F2", "type": "Residence", "date": "1880", "place": "Dodge County, Wisconsin" }
+              ]
+            },
+            {
+              "id": "P2",
+              "gender": "Male",
+              "names": [
+                { "id": "N2", "preferred": true, "given": "James", "surname": "Price", "type": "BirthName" }
+              ],
+              "facts": [
+                { "id": "F3", "type": "Birth", "date": "1848", "place": "Wales" },
+                { "id": "F4", "type": "Residence", "date": "1880", "place": "Dodge County, Wisconsin" }
+              ]
+            },
+            {
+              "id": "P3",
+              "gender": "Female",
+              "names": [
+                { "id": "N3", "preferred": true, "given": "Sarah A.", "surname": "Price", "type": "BirthName" }
+              ],
+              "facts": [
+                { "id": "F5", "type": "Birth", "date": "1852", "place": "Wisconsin" },
+                { "id": "F6", "type": "Residence", "date": "1880", "place": "Dodge County, Wisconsin" }
+              ]
+            }
+          ],
+          "relationships": [
+            { "id": "R1", "type": "ParentChild", "parent": "P2", "child": "P1" },
+            { "id": "R2", "type": "ParentChild", "parent": "P3", "child": "P1" },
+            { "id": "R3", "type": "Couple", "person1": "P2", "person2": "P3" }
+          ]
+        }
+      },
+      {
+        "personId": "WICN-1880-P02",
+        "recordId": "WICN-1880-P02",
+        "personName": "Sarah Price",
+        "score": 0.65,
+        "sex": "Female",
+        "birthDate": "1870",
+        "birthPlace": "New York",
+        "events": [
+          { "type": "Residence", "date": "1880", "place": "Milwaukee County, Wisconsin" }
+        ],
+        "arkUrl": "https://www.familysearch.org/ark:/61903/1:1:WICN-1880-P02",
+        "collectionId": "1417683",
+        "collectionTitle": "United States Census, 1880",
+        "recordTitle": "Sarah Price in household of Thomas Price",
+        "treeMatches": [],
+        "primaryId": "P4",
+        "gedcomx": {
+          "persons": [
+            {
+              "id": "P4",
+              "gender": "Female",
+              "names": [
+                { "id": "N4", "preferred": true, "given": "Sarah", "surname": "Price", "type": "BirthName" }
+              ],
+              "facts": [
+                { "id": "F7", "type": "Birth", "date": "1870", "place": "New York" },
+                { "id": "F8", "type": "Residence", "date": "1880", "place": "Milwaukee County, Wisconsin" }
+              ]
+            }
+          ],
+          "relationships": []
+        }
+      }
+    ]
+  }
+}

--- a/eval/fixtures/mcp/record-search-mielke-no-results.json
+++ b/eval/fixtures/mcp/record-search-mielke-no-results.json
@@ -1,0 +1,17 @@
+{
+  "tool": "record_search",
+  "description": "FamilySearch record search that returns no results for Mielke surname — for variant/fallback searches on the multiple-marriages scenario.",
+  "args": {
+    "surname": "Mielke",
+    "givenName": "~Sarah"
+  },
+  "response": {
+    "query": { "surname": "Mielke", "givenName": "Sarah" },
+    "totalMatches": 0,
+    "paginationCappedAt": 100,
+    "returned": 0,
+    "offset": 0,
+    "hasMore": false,
+    "results": []
+  }
+}

--- a/eval/fixtures/mcp/record-search-mullen-no-results.json
+++ b/eval/fixtures/mcp/record-search-mullen-no-results.json
@@ -1,0 +1,18 @@
+{
+  "tool": "record_search",
+  "description": "FamilySearch record search that returns no results for a Mullen surname search — a nil result for variant or fallback searches.",
+  "args": {
+    "surname": "Mullen",
+    "givenName": "~Sarah",
+    "residencePlace": "~Fond du Lac"
+  },
+  "response": {
+    "query": { "surname": "Mullen", "givenName": "Sarah", "residencePlace": "Fond du Lac County, Wisconsin" },
+    "totalMatches": 0,
+    "paginationCappedAt": 100,
+    "returned": 0,
+    "offset": 0,
+    "hasMore": false,
+    "results": []
+  }
+}

--- a/eval/fixtures/mcp/record-search-price-no-results.json
+++ b/eval/fixtures/mcp/record-search-price-no-results.json
@@ -1,0 +1,18 @@
+{
+  "tool": "record_search",
+  "description": "FamilySearch record search that returns no results for Price surname in 1860 — before Sarah's marriage, she would not appear under Price.",
+  "args": {
+    "surname": "Price",
+    "givenName": "~Sarah",
+    "residenceYearFrom": "~1860"
+  },
+  "response": {
+    "query": { "surname": "Price", "givenName": "Sarah" },
+    "totalMatches": 0,
+    "paginationCappedAt": 100,
+    "returned": 0,
+    "offset": 0,
+    "hasMore": false,
+    "results": []
+  }
+}

--- a/eval/fixtures/scenarios/maiden-to-married-name-shift/README.md
+++ b/eval/fixtures/scenarios/maiden-to-married-name-shift/README.md
@@ -1,0 +1,34 @@
+# Scenario: maiden-to-married-name-shift
+
+A research project tracing a woman who changed her name pattern after
+marriage: born "Sarah Ann Mullen", she became "Sarah Mullen Price"
+(dropping "Ann", adopting her maiden surname "Mullen" as a middle name).
+
+## State
+
+- **Subject:** Sarah Ann Mullen / Sarah Mullen Price (`I1`), b. 1852,
+  d. 1921. The tree carries two name entries:
+  - BirthName: given "Sarah Ann", surname "Mullen"
+  - MarriedName (preferred): given "Sarah Mullen", surname "Price"
+- **Husband:** James Price (`I2`). **Father:** William Mullen (`I3`).
+- **One gathered record:**
+  - `log_001` — Death certificate: "Sarah Mullen Price", father William
+    Mullen. This is the starting record.
+- **Plan items:**
+  - `pli_001` — 1860 census, Dodge County (find Sarah Ann Mullen as a
+    child in the Mullen household) — `in_progress`
+  - `pli_002` — 1880 census, Dodge County (find Sarah under Price surname
+    post-marriage) — `planned`
+
+## What it exercises
+
+- The skill must search the **1860 census** under the BirthName
+  (`surname: "Mullen"`, `givenName: "Sarah"` or `"Sarah Ann"`), not
+  the MarriedName.
+- The skill should use `surnameAlt` to also search under "Price" as a
+  fallback, in case an 1860 record was indexed under a married name
+  in error, or in case the family used the Price surname early.
+- Tests whether the skill correctly selects the pre-marriage name for
+  a pre-marriage time period, recognizing that "Mullen" in the married
+  name's given field is the maiden surname, not a given name to search
+  under as-is.

--- a/eval/fixtures/scenarios/maiden-to-married-name-shift/research.json
+++ b/eval/fixtures/scenarios/maiden-to-married-name-shift/research.json
@@ -1,0 +1,131 @@
+{
+  "project": {
+    "id": "rp_001",
+    "objective": "Confirm that Sarah Mullen Price (death cert 1921) is the same person as Sarah Ann Mullen who married James Price in 1872, by finding pre-marriage records under her birth name",
+    "subject_person_ids": ["I1"],
+    "status": "active",
+    "created": "2026-06-01",
+    "updated": "2026-06-01"
+  },
+
+  "questions": [
+    {
+      "id": "q_001",
+      "question": "Is Sarah Mullen Price (d. 1921) the same person as Sarah Ann Mullen (b. 1852), who dropped her middle given name 'Ann' and adopted her maiden surname 'Mullen' as a middle name after marriage?",
+      "rationale": "The death certificate names the deceased as 'Sarah Mullen Price'. Pre-marriage records should show her as 'Sarah Ann Mullen'. The name shift — dropping 'Ann' and moving 'Mullen' from surname position to middle name — is a common 19th-century American pattern. Census records before and after the marriage should bridge the two identities.",
+      "selection_basis": "objective_decomposition",
+      "priority": "high",
+      "status": "in_progress",
+      "depends_on": [],
+      "unblocks": [],
+      "created": "2026-06-01",
+      "resolved": null,
+      "resolution_assertion_ids": [],
+      "exhaustive_declaration": {
+        "declared": false,
+        "justification": null,
+        "log_entry_ids": [],
+        "stop_criteria": null
+      }
+    }
+  ],
+
+  "plans": [
+    {
+      "id": "pl_001",
+      "question_id": "q_001",
+      "status": "active",
+      "created": "2026-06-01",
+      "items": [
+        {
+          "id": "pli_001",
+          "sequence": 1,
+          "record_type": "census",
+          "jurisdiction": "Dodge County, Wisconsin",
+          "date_range": "1860",
+          "repository": "FamilySearch",
+          "rationale": "The 1860 census should show Sarah Ann Mullen (age ~8) in her father William Mullen's household, confirming the birth name before any marriage-related name changes.",
+          "fallback_for": null,
+          "status": "in_progress"
+        },
+        {
+          "id": "pli_002",
+          "sequence": 2,
+          "record_type": "census",
+          "jurisdiction": "Dodge County, Wisconsin",
+          "date_range": "1880",
+          "repository": "FamilySearch",
+          "rationale": "The 1880 census (post-marriage) should show Sarah under the Price surname in James Price's household. Whether she appears as 'Sarah Price', 'Sarah M. Price', or 'Sarah Mullen Price' confirms the name-shift pattern.",
+          "fallback_for": null,
+          "status": "planned"
+        }
+      ]
+    }
+  ],
+
+  "log": [
+    {
+      "id": "log_001",
+      "plan_item_id": null,
+      "performed": "2026-06-01T09:00:00Z",
+      "tool": "record_search",
+      "query": { "surname": "Price", "given": "Sarah Mullen", "collection": "Wisconsin Death Index" },
+      "outcome": "positive",
+      "results_examined": 1,
+      "results_ref": "results/log_001.json",
+      "results_available": 1,
+      "notes": "Death certificate for Sarah Mullen Price, d. 1921-09-03, Fond du Lac. Father listed as William Mullen. This is the starting record that established the research question.",
+      "external_site": null
+    }
+  ],
+
+  "sources": [
+    {
+      "id": "src_001",
+      "gedcomx_source_description_id": "S1",
+      "citation": "Wisconsin death certificate, Sarah Mullen Price, 3 September 1921, Fond du Lac County; Wisconsin Historical Society, digital image.",
+      "citation_detail": {
+        "who": "Attending physician / informant",
+        "what": "Death certificate",
+        "when_created": "1921",
+        "when_accessed": "2026-06-01",
+        "where": "Wisconsin Historical Society",
+        "where_within": "Death certificate for Sarah Mullen Price"
+      },
+      "source_classification": "original",
+      "repository": "FamilySearch",
+      "access_date": "2026-06-01",
+      "url": "https://www.familysearch.org/ark:/61903/1:1:DCTH-001",
+      "url_archived": null,
+      "notes": "Father: William Mullen. Husband: James Price. The 'Mullen' in the deceased's name is her maiden surname adopted as a middle name after marriage.",
+      "transcription": null,
+      "log_entry_id": "log_001"
+    }
+  ],
+
+  "assertions": [
+    {
+      "id": "a_001",
+      "source_id": "src_001",
+      "record_id": "https://www.familysearch.org/ark:/61903/1:1:DCTH-001",
+      "record_role": "deceased",
+      "record_persona_id": "DP1",
+      "fact_type": "name",
+      "value": "Sarah Mullen Price",
+      "structured_value": { "given": "Sarah Mullen", "surname": "Price" },
+      "information_quality": "secondary",
+      "informant": "Informant (likely family member) reporting to registrar",
+      "informant_proximity": "family_not_present",
+      "evidence_type": "direct",
+      "log_entry_id": "log_001",
+      "extracted_for_question_ids": ["q_001"]
+    }
+  ],
+
+  "person_evidence": [],
+  "conflicts": [],
+  "hypotheses": [],
+  "timelines": [],
+  "proof_summaries": [],
+  "evaluations": []
+}

--- a/eval/fixtures/scenarios/maiden-to-married-name-shift/results/log_001.json
+++ b/eval/fixtures/scenarios/maiden-to-married-name-shift/results/log_001.json
@@ -1,0 +1,53 @@
+{
+  "log_id": "log_001",
+  "tool": "record_search",
+  "retrieved": "2026-06-01T09:00:00Z",
+  "returned_count": 1,
+  "payload": {
+    "query": {
+      "surname": "Price",
+      "givenName": "Sarah Mullen"
+    },
+    "totalMatches": 1,
+    "paginationCappedAt": 100,
+    "returned": 1,
+    "offset": 0,
+    "hasMore": false,
+    "results": [
+      {
+        "personId": "DCTH-001",
+        "personName": "Sarah Mullen Price",
+        "score": 0.95,
+        "sex": "Female",
+        "birthDate": "1852",
+        "birthPlace": "Wisconsin",
+        "events": [
+          { "type": "Death", "date": "1921-09-03", "place": "Fond du Lac, Fond du Lac County, Wisconsin" }
+        ],
+        "arkUrl": "https://www.familysearch.org/ark:/61903/1:1:DCTH-001",
+        "recordId": "https://www.familysearch.org/ark:/61903/1:1:DCTH-001",
+        "collectionId": "1234567",
+        "collectionTitle": "Wisconsin Deaths and Burials, 1835-1970",
+        "recordTitle": "Sarah Mullen Price death record",
+        "treeMatches": [],
+        "primaryId": "DP1",
+        "gedcomx": {
+          "persons": [
+            {
+              "id": "DP1",
+              "gender": "Female",
+              "names": [
+                { "id": "N1", "preferred": true, "given": "Sarah Mullen", "surname": "Price", "type": "BirthName" }
+              ],
+              "facts": [
+                { "id": "F1", "type": "Death", "date": "1921-09-03", "place": "Fond du Lac, Fond du Lac County, Wisconsin" },
+                { "id": "F2", "type": "Birth", "date": "1852", "place": "Wisconsin" }
+              ]
+            }
+          ],
+          "relationships": []
+        }
+      }
+    ]
+  }
+}

--- a/eval/fixtures/scenarios/maiden-to-married-name-shift/tree.gedcomx.json
+++ b/eval/fixtures/scenarios/maiden-to-married-name-shift/tree.gedcomx.json
@@ -1,0 +1,44 @@
+{
+  "persons": [
+    {
+      "id": "I1",
+      "gender": "Female",
+      "names": [
+        { "id": "N1", "preferred": true, "given": "Sarah Ann", "surname": "Mullen", "type": "BirthName" },
+        { "id": "N2", "preferred": true, "given": "Sarah Mullen", "surname": "Price", "type": "MarriedName" }
+      ],
+      "facts": [
+        { "id": "F1", "type": "Birth", "date": "1852-03-15", "place": "Dodge County, Wisconsin" },
+        { "id": "F2", "type": "Marriage", "date": "1872-06-10", "place": "Dodge County, Wisconsin" },
+        { "id": "F3", "type": "Death", "date": "1921-09-03", "place": "Fond du Lac, Fond du Lac County, Wisconsin" }
+      ]
+    },
+    {
+      "id": "I2",
+      "gender": "Male",
+      "names": [
+        { "id": "N3", "preferred": true, "given": "James", "surname": "Price", "type": "BirthName" }
+      ],
+      "facts": [
+        { "id": "F4", "type": "Birth", "date": "~1848", "place": "Wales" }
+      ]
+    },
+    {
+      "id": "I3",
+      "gender": "Male",
+      "names": [
+        { "id": "N4", "preferred": true, "given": "William", "surname": "Mullen", "type": "BirthName" }
+      ],
+      "facts": [
+        { "id": "F5", "type": "Birth", "date": "~1825", "place": "Ireland" }
+      ]
+    }
+  ],
+  "relationships": [
+    { "id": "RT1", "type": "Couple", "person1": "I2", "person2": "I1" },
+    { "id": "RT2", "type": "ParentChild", "parent": "I3", "child": "I1" }
+  ],
+  "sources": [
+    { "id": "S1", "title": "Death certificate — Sarah Mullen Price, 1921, Fond du Lac County" }
+  ]
+}

--- a/eval/fixtures/scenarios/mullen-price-child-middle-name/README.md
+++ b/eval/fixtures/scenarios/mullen-price-child-middle-name/README.md
@@ -1,0 +1,34 @@
+# Scenario: mullen-price-child-middle-name
+
+A research project for a child named Sarah Ann Mullen Price (b. 1875,
+Dodge County, WI). The name is ambiguous: "Mullen" could be a middle
+given name honoring her mother's maiden surname, or it could be her
+own birth surname if she later married a Price.
+
+## State
+
+- **Subject:** Sarah Ann Mullen Price (`I1`), b. 1875-08-20, Dodge
+  County, Wisconsin. Tree data has `given: "Sarah Ann Mullen"` and
+  `surname: "Price"` with type `BirthName`, reflecting the working
+  hypothesis that Mullen is a middle given name.
+- **Parents in tree:** Father James Price (`I2`), Mother Sarah Ann
+  Mullen/Price (`I3`, with both BirthName: Mullen and MarriedName: Price).
+- **One existing source** (1880 census) but no log entries yet for the
+  active plan items.
+- **Plan items:**
+  - `pli_001` — 1880 census, Dodge County (find Sarah ~age 5 in a
+    household to confirm surname) — `in_progress`
+  - `pli_002` — 1875 birth record, Dodge County (would name parents
+    definitively) — `planned`
+
+## What it exercises
+
+- The skill must use `surname: "Price"` (from the tree's BirthName
+  entry) as the primary search parameter, NOT put "Mullen" in the
+  surname field.
+- The `givenName` should be "Sarah" (or "Sarah Ann" / "Sarah Ann
+  Mullen"), keeping "Mullen" as part of the given name, not as a
+  `surnameAlt`.
+- Tests whether the skill correctly interprets a multi-token given
+  name where one token happens to be a family surname used as a
+  middle name.

--- a/eval/fixtures/scenarios/mullen-price-child-middle-name/research.json
+++ b/eval/fixtures/scenarios/mullen-price-child-middle-name/research.json
@@ -1,0 +1,100 @@
+{
+  "project": {
+    "id": "rp_001",
+    "objective": "Locate records for Sarah Ann Mullen Price (b. 1875, Dodge County, WI) to confirm she is the daughter of James Price and Sarah Ann (Mullen) Price, not a daughter of a Mullen family",
+    "subject_person_ids": ["I1"],
+    "status": "active",
+    "created": "2026-06-01",
+    "updated": "2026-06-01"
+  },
+
+  "questions": [
+    {
+      "id": "q_001",
+      "question": "Is Sarah Ann Mullen Price (b. 1875) the daughter of James Price and Sarah Ann Mullen, with 'Mullen' being a middle given name honoring her mother's maiden surname?",
+      "rationale": "The child's full name 'Sarah Ann Mullen Price' is ambiguous: 'Mullen' could be a middle given name (honoring her mother's maiden surname) or it could indicate she was born a Mullen and married into the Price family. Birth or baptismal records naming her parents would resolve this.",
+      "selection_basis": "objective_decomposition",
+      "priority": "high",
+      "status": "in_progress",
+      "depends_on": [],
+      "unblocks": [],
+      "created": "2026-06-01",
+      "resolved": null,
+      "resolution_assertion_ids": [],
+      "exhaustive_declaration": {
+        "declared": false,
+        "justification": null,
+        "log_entry_ids": [],
+        "stop_criteria": null
+      }
+    }
+  ],
+
+  "plans": [
+    {
+      "id": "pl_001",
+      "question_id": "q_001",
+      "status": "active",
+      "created": "2026-06-01",
+      "items": [
+        {
+          "id": "pli_001",
+          "sequence": 1,
+          "record_type": "census",
+          "jurisdiction": "Dodge County, Wisconsin",
+          "date_range": "1880",
+          "repository": "FamilySearch",
+          "rationale": "The 1880 census should show Sarah (age ~5) in a household, with the head of household confirming whether her surname is Price (father's family) or Mullen (mother's maiden family). The 1880 census also records relationship to head.",
+          "fallback_for": null,
+          "status": "in_progress"
+        },
+        {
+          "id": "pli_002",
+          "sequence": 2,
+          "record_type": "vital_record",
+          "jurisdiction": "Dodge County, Wisconsin",
+          "date_range": "1875",
+          "repository": "FamilySearch",
+          "rationale": "A birth record would name both parents, definitively resolving whether Mullen is a middle name or a birth surname.",
+          "fallback_for": null,
+          "status": "planned"
+        }
+      ]
+    }
+  ],
+
+  "log": [],
+
+  "sources": [
+    {
+      "id": "src_001",
+      "gedcomx_source_description_id": "S1",
+      "citation": "1880 U.S. Census, Dodge County, Wisconsin, population schedule, James Price household; digital image, FamilySearch.org, accessed 1 June 2026.",
+      "citation_detail": {
+        "who": "U.S. Census Bureau",
+        "what": "1880 U.S. Federal Census, population schedule",
+        "when_created": "1880",
+        "when_accessed": "2026-06-01",
+        "where": "FamilySearch.org",
+        "where_within": "Dodge County, James Price household"
+      },
+      "source_classification": "original",
+      "repository": "FamilySearch",
+      "access_date": "2026-06-01",
+      "url": "https://www.familysearch.org/ark:/61903/1:1:MXPR-001",
+      "url_archived": null,
+      "notes": "Source of the initial family composition; Sarah listed as 'Sarah M. Price', age 5, daughter. The 'M' initial likely stands for Mullen.",
+      "transcription": null,
+      "log_entry_id": null
+    }
+  ],
+
+  "assertions": [],
+
+  "person_evidence": [],
+  "conflicts": [],
+  "hypotheses": [],
+  "timelines": [],
+  "proof_summaries": [],
+  "evaluations": []
+}

--- a/eval/fixtures/scenarios/mullen-price-child-middle-name/tree.gedcomx.json
+++ b/eval/fixtures/scenarios/mullen-price-child-middle-name/tree.gedcomx.json
@@ -1,0 +1,43 @@
+{
+  "persons": [
+    {
+      "id": "I1",
+      "gender": "Female",
+      "names": [
+        { "id": "N1", "preferred": true, "given": "Sarah Ann Mullen", "surname": "Price", "type": "BirthName" }
+      ],
+      "facts": [
+        { "id": "F1", "type": "Birth", "date": "1875-08-20", "place": "Dodge County, Wisconsin" }
+      ]
+    },
+    {
+      "id": "I2",
+      "gender": "Male",
+      "names": [
+        { "id": "N2", "preferred": true, "given": "James", "surname": "Price", "type": "BirthName" }
+      ],
+      "facts": [
+        { "id": "F2", "type": "Birth", "date": "~1848", "place": "Wales" }
+      ]
+    },
+    {
+      "id": "I3",
+      "gender": "Female",
+      "names": [
+        { "id": "N3", "preferred": true, "given": "Sarah Ann", "surname": "Mullen", "type": "BirthName" },
+        { "id": "N4", "preferred": true, "given": "Sarah Ann", "surname": "Price", "type": "MarriedName" }
+      ],
+      "facts": [
+        { "id": "F3", "type": "Birth", "date": "1852-03-15", "place": "Dodge County, Wisconsin" }
+      ]
+    }
+  ],
+  "relationships": [
+    { "id": "RT1", "type": "ParentChild", "parent": "I2", "child": "I1" },
+    { "id": "RT2", "type": "ParentChild", "parent": "I3", "child": "I1" },
+    { "id": "RT3", "type": "Couple", "person1": "I2", "person2": "I3" }
+  ],
+  "sources": [
+    { "id": "S1", "title": "1880 U.S. Census, Dodge County, Wisconsin — James Price household" }
+  ]
+}

--- a/eval/fixtures/scenarios/mullen-price-multiple-marriages/README.md
+++ b/eval/fixtures/scenarios/mullen-price-multiple-marriages/README.md
@@ -1,0 +1,34 @@
+# Scenario: mullen-price-multiple-marriages
+
+A mid-research project for Sarah Ann Mullen's parentage. Sarah married
+twice: first James Price (1872, Dodge County, WI), then Henry Mielke
+(1885, Fond du Lac County, WI). The tree carries three name entries
+(BirthName: Mullen, MarriedName: Price, MarriedName: Mielke).
+
+## State
+
+- **Subject:** Sarah Ann Mullen (`I1`), b. 1852-03-15, Dodge County,
+  Wisconsin. Tree also holds first husband James Price (`I2`), second
+  husband Henry Mielke (`I3`), and parents William (`I4`) and Margaret
+  (`I5`) Mullen.
+- **One gathered record** with sidecar:
+  - `log_001` — 1880 census: Sarah A. Price age 28 in James Price's
+    household, born Wisconsin, parents born Ireland. Confirms the first
+    marriage but uses the married name only.
+- **Plan items:**
+  - `pli_001` — 1860 census, Dodge County (find Sarah as a child in the
+    Mullen household) — `in_progress`
+  - `pli_002` — 1872 marriage record (Sarah Mullen to James Price) — `planned`
+  - `pli_003` — 1900 census, Fond du Lac County (Sarah under Mielke name) — `planned`
+
+## What it exercises
+
+- The skill must construct a search using the **maiden surname** (Mullen)
+  as the primary surname for the 1860 census search (pre-marriage), not
+  the married names.
+- For later searches (1900 census), the skill should use `surnameAlt`
+  to search across married names (Mielke primary, Price or Mullen as alt)
+  since the woman could appear under any surname.
+- Tests whether the skill correctly reads multiple `names[]` entries
+  with different `type` values and selects the appropriate one for each
+  time period.

--- a/eval/fixtures/scenarios/mullen-price-multiple-marriages/research.json
+++ b/eval/fixtures/scenarios/mullen-price-multiple-marriages/research.json
@@ -1,0 +1,142 @@
+{
+  "project": {
+    "id": "rp_001",
+    "objective": "Confirm Sarah Ann Mullen's parentage and trace her through two marriages (Price, then Mielke) in Dodge and Fond du Lac Counties, Wisconsin",
+    "subject_person_ids": ["I1"],
+    "status": "active",
+    "created": "2026-06-01",
+    "updated": "2026-06-01"
+  },
+
+  "questions": [
+    {
+      "id": "q_001",
+      "question": "Who were the parents of Sarah Ann Mullen (b. 1852, Dodge County, Wisconsin)?",
+      "rationale": "Primary research objective. An obituary names her birth surname as Mullen, but no birth record has been located. Census and marriage records may confirm parentage.",
+      "selection_basis": "objective_decomposition",
+      "priority": "high",
+      "status": "in_progress",
+      "depends_on": [],
+      "unblocks": [],
+      "created": "2026-06-01",
+      "resolved": null,
+      "resolution_assertion_ids": [],
+      "exhaustive_declaration": {
+        "declared": false,
+        "justification": null,
+        "log_entry_ids": [],
+        "stop_criteria": null
+      }
+    }
+  ],
+
+  "plans": [
+    {
+      "id": "pl_001",
+      "question_id": "q_001",
+      "status": "active",
+      "created": "2026-06-01",
+      "items": [
+        {
+          "id": "pli_001",
+          "sequence": 1,
+          "record_type": "census",
+          "jurisdiction": "Dodge County, Wisconsin",
+          "date_range": "1860",
+          "repository": "FamilySearch",
+          "rationale": "The 1860 census should show Sarah (age ~8) in her parents' household before her first marriage, confirming the Mullen surname and identifying her parents.",
+          "fallback_for": null,
+          "status": "in_progress"
+        },
+        {
+          "id": "pli_002",
+          "sequence": 2,
+          "record_type": "vital_record",
+          "jurisdiction": "Dodge County, Wisconsin",
+          "date_range": "1872",
+          "repository": "FamilySearch",
+          "rationale": "The 1872 marriage record for Sarah Mullen and James Price should name her father, confirming parentage.",
+          "fallback_for": null,
+          "status": "planned"
+        },
+        {
+          "id": "pli_003",
+          "sequence": 3,
+          "record_type": "census",
+          "jurisdiction": "Fond du Lac County, Wisconsin",
+          "date_range": "1900",
+          "repository": "FamilySearch",
+          "rationale": "The 1900 census should show Sarah under her second married name (Mielke) with Henry Mielke, confirming the continuity of identity across marriages.",
+          "fallback_for": null,
+          "status": "planned"
+        }
+      ]
+    }
+  ],
+
+  "log": [
+    {
+      "id": "log_001",
+      "plan_item_id": "pli_001",
+      "performed": "2026-06-01T10:00:00Z",
+      "tool": "record_search",
+      "query": { "surname": "Price", "given": "Sarah", "collection": "1880 Census" },
+      "outcome": "positive",
+      "results_examined": 1,
+      "results_ref": "results/log_001.json",
+      "results_available": 1,
+      "notes": "1880 census household of James Price; Sarah A. Price age 28, born Wisconsin. Parents born Ireland. Confirms first marriage.",
+      "external_site": null
+    }
+  ],
+
+  "sources": [
+    {
+      "id": "src_001",
+      "gedcomx_source_description_id": "S1",
+      "citation": "1880 U.S. Census, Dodge County, Wisconsin, population schedule, James Price household; digital image, FamilySearch.org, accessed 1 June 2026.",
+      "citation_detail": {
+        "who": "U.S. Census Bureau",
+        "what": "1880 U.S. Federal Census, population schedule",
+        "when_created": "1880",
+        "when_accessed": "2026-06-01",
+        "where": "FamilySearch.org",
+        "where_within": "Dodge County, James Price household"
+      },
+      "source_classification": "original",
+      "repository": "FamilySearch",
+      "access_date": "2026-06-01",
+      "url": "https://www.familysearch.org/ark:/61903/1:1:MXPR-001",
+      "url_archived": null,
+      "notes": null,
+      "transcription": null,
+      "log_entry_id": "log_001"
+    }
+  ],
+
+  "assertions": [
+    {
+      "id": "a_001",
+      "source_id": "src_001",
+      "record_id": "https://www.familysearch.org/ark:/61903/1:1:MXPR-001",
+      "record_role": "wife",
+      "record_persona_id": "P1",
+      "fact_type": "name",
+      "value": "Sarah A. Price",
+      "structured_value": { "given": "Sarah A.", "surname": "Price" },
+      "information_quality": "indeterminate",
+      "informant": "Unknown informant reporting to the census enumerator",
+      "informant_proximity": "unknown",
+      "evidence_type": "direct",
+      "log_entry_id": "log_001",
+      "extracted_for_question_ids": ["q_001"]
+    }
+  ],
+
+  "person_evidence": [],
+  "conflicts": [],
+  "hypotheses": [],
+  "timelines": [],
+  "proof_summaries": [],
+  "evaluations": []
+}

--- a/eval/fixtures/scenarios/mullen-price-multiple-marriages/results/log_001.json
+++ b/eval/fixtures/scenarios/mullen-price-multiple-marriages/results/log_001.json
@@ -1,0 +1,66 @@
+{
+  "log_id": "log_001",
+  "tool": "record_search",
+  "retrieved": "2026-06-01T10:00:00Z",
+  "returned_count": 1,
+  "payload": {
+    "query": {
+      "surname": "Price",
+      "givenName": "Sarah"
+    },
+    "totalMatches": 1,
+    "paginationCappedAt": 100,
+    "returned": 1,
+    "offset": 0,
+    "hasMore": false,
+    "results": [
+      {
+        "personId": "MXPR-001",
+        "personName": "Sarah A. Price",
+        "score": 0.88,
+        "sex": "Female",
+        "birthDate": "1852",
+        "birthPlace": "Wisconsin",
+        "events": [
+          { "type": "Residence", "date": "1880", "place": "Dodge County, Wisconsin" }
+        ],
+        "arkUrl": "https://www.familysearch.org/ark:/61903/1:1:MXPR-001",
+        "recordId": "https://www.familysearch.org/ark:/61903/1:1:MXPR-001",
+        "collectionId": "1417683",
+        "collectionTitle": "United States Census, 1880",
+        "recordTitle": "Sarah A. Price in household of James Price",
+        "treeMatches": [],
+        "primaryId": "P1",
+        "gedcomx": {
+          "persons": [
+            {
+              "id": "P1",
+              "gender": "Female",
+              "names": [
+                { "id": "N1", "preferred": true, "given": "Sarah A.", "surname": "Price", "type": "BirthName" }
+              ],
+              "facts": [
+                { "id": "F1", "type": "Birth", "date": "1852", "place": "Wisconsin" },
+                { "id": "F2", "type": "Residence", "date": "1880", "place": "Dodge County, Wisconsin" }
+              ]
+            },
+            {
+              "id": "P2",
+              "gender": "Male",
+              "names": [
+                { "id": "N2", "preferred": true, "given": "James", "surname": "Price", "type": "BirthName" }
+              ],
+              "facts": [
+                { "id": "F3", "type": "Birth", "date": "1848", "place": "Wales" },
+                { "id": "F4", "type": "Residence", "date": "1880", "place": "Dodge County, Wisconsin" }
+              ]
+            }
+          ],
+          "relationships": [
+            { "id": "R1", "type": "Couple", "person1": "P2", "person2": "P1" }
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/eval/fixtures/scenarios/mullen-price-multiple-marriages/tree.gedcomx.json
+++ b/eval/fixtures/scenarios/mullen-price-multiple-marriages/tree.gedcomx.json
@@ -1,0 +1,67 @@
+{
+  "persons": [
+    {
+      "id": "I1",
+      "gender": "Female",
+      "names": [
+        { "id": "N1", "preferred": true, "given": "Sarah Ann", "surname": "Mullen", "type": "BirthName" },
+        { "id": "N2", "preferred": true, "given": "Sarah Ann", "surname": "Price", "type": "MarriedName" },
+        { "id": "N3", "preferred": true, "given": "Sarah Ann", "surname": "Mielke", "type": "MarriedName" }
+      ],
+      "facts": [
+        { "id": "F1", "type": "Birth", "date": "1852-03-15", "place": "Dodge County, Wisconsin" },
+        { "id": "F2", "type": "Marriage", "date": "1872-06-10", "place": "Dodge County, Wisconsin" },
+        { "id": "F3", "type": "Marriage", "date": "1885-11-22", "place": "Fond du Lac County, Wisconsin" },
+        { "id": "F4", "type": "Death", "date": "1921-09-03", "place": "Fond du Lac, Fond du Lac County, Wisconsin" }
+      ]
+    },
+    {
+      "id": "I2",
+      "gender": "Male",
+      "names": [
+        { "id": "N4", "preferred": true, "given": "James", "surname": "Price", "type": "BirthName" }
+      ],
+      "facts": [
+        { "id": "F5", "type": "Birth", "date": "~1848", "place": "Wales" },
+        { "id": "F6", "type": "Death", "date": "1883-02-14", "place": "Dodge County, Wisconsin" }
+      ]
+    },
+    {
+      "id": "I3",
+      "gender": "Male",
+      "names": [
+        { "id": "N5", "preferred": true, "given": "Henry", "surname": "Mielke", "type": "BirthName" }
+      ],
+      "facts": [
+        { "id": "F7", "type": "Birth", "date": "~1850", "place": "Prussia" }
+      ]
+    },
+    {
+      "id": "I4",
+      "gender": "Male",
+      "names": [
+        { "id": "N6", "preferred": true, "given": "William", "surname": "Mullen", "type": "BirthName" }
+      ],
+      "facts": [
+        { "id": "F8", "type": "Birth", "date": "~1825", "place": "Ireland" }
+      ]
+    },
+    {
+      "id": "I5",
+      "gender": "Female",
+      "names": [
+        { "id": "N7", "preferred": true, "given": "Margaret", "surname": "Mullen", "type": "MarriedName" }
+      ],
+      "facts": []
+    }
+  ],
+  "relationships": [
+    { "id": "RT1", "type": "Couple", "person1": "I2", "person2": "I1" },
+    { "id": "RT2", "type": "Couple", "person1": "I3", "person2": "I1" },
+    { "id": "RT3", "type": "ParentChild", "parent": "I4", "child": "I1" },
+    { "id": "RT4", "type": "ParentChild", "parent": "I5", "child": "I1" }
+  ],
+  "sources": [
+    { "id": "S1", "title": "1880 U.S. Census, Dodge County, Wisconsin — James Price household" }
+  ]
+}

--- a/eval/harness/harness/mock_mcp.py
+++ b/eval/harness/harness/mock_mcp.py
@@ -24,6 +24,11 @@ logic treat it the same as a fixture-matched call.
 Current live tools:
 - validate_research_schema: calls the compiled TS validator against the
   workspace path, so the result reflects the actual files the skill wrote.
+- research_log_append: calls the compiled TS tool to append a log entry to
+  research.json. Handles id assignment, timestamping, camelCase→snake_case
+  field renaming, and validation — exactly as production does. Without this,
+  skills that write log entries directly use the tool's camelCase parameter
+  names instead of the schema's snake_case field names.
 """
 
 from __future__ import annotations
@@ -41,7 +46,7 @@ from harness.tool_catalog import default_tools_dir, load_tool_catalog
 
 # Bare tool names that are always registered as live handlers rather than
 # fixture-backed mocks. See module docstring for the rationale.
-LIVE_TOOLS: set[str] = {"validate_research_schema"}
+LIVE_TOOLS: set[str] = {"validate_research_schema", "research_log_append"}
 
 # Path to the compiled MCP server build output, used by live tool handlers.
 _REPO_ROOT = Path(__file__).resolve().parents[3]
@@ -168,6 +173,22 @@ def _live_tool_input_schema(tool_name: str) -> dict[str, Any]:
             "properties": {"projectPath": {"type": "string"}},
             "required": ["projectPath"],
         }
+    if tool_name == "research_log_append":
+        return {
+            "type": "object",
+            "properties": {
+                "projectPath": {"type": "string"},
+                "tool": {"type": "string"},
+                "query": {"type": "object"},
+                "outcome": {"type": "string", "enum": ["positive", "negative", "partial", "error"]},
+                "resultsExamined": {"type": "number"},
+                "planItemId": {"type": ["string", "null"]},
+                "resultsAvailable": {"type": ["number", "null"]},
+                "notes": {"type": ["string", "null"]},
+                "stagedResultsRef": {"type": ["string", "null"]},
+            },
+            "required": ["projectPath", "tool", "query", "outcome", "resultsExamined"],
+        }
     return {"type": "object", "properties": {}, "additionalProperties": True}
 
 
@@ -179,6 +200,8 @@ def _make_live_handler(
     """Return an async handler for a live tool."""
     if tool_name == "validate_research_schema":
         return _make_validate_handler(workspace, call_log)
+    if tool_name == "research_log_append":
+        return _make_log_append_handler(workspace, call_log)
     raise ValueError(f"No live handler defined for {tool_name!r}")
 
 
@@ -242,6 +265,75 @@ def _make_validate_handler(workspace: Path | None, call_log: list[dict[str, Any]
             "expected_args": None,
             "matched": {"kind": "live", "index": None},
             "response_fixture": "live:validate_research_schema",
+            "response": response,
+        }
+        call_log.append(entry)
+        return {"content": [{"type": "text", "text": json.dumps(response)}]}
+
+    return handler
+
+
+def _make_log_append_handler(workspace: Path | None, call_log: list[dict[str, Any]]):
+    """Build the live handler for research_log_append.
+
+    Calls the compiled TS tool via `node --input-type=module` against the
+    workspace path. The skill passes its own projectPath arg, but we always
+    override it with workspace (the harness tempdir) to avoid path drift.
+
+    Input is piped via stdin (as JSON) to avoid shell/JS string escaping
+    issues with values that may contain quotes, backslashes, or newlines.
+    """
+    append_js = _MCP_BUILD / "tools" / "research-log-append.js"
+
+    async def handler(args, _ws=workspace, _ajs=append_js):
+        if _ws is None or not _ajs.exists():
+            reason = "workspace not provided" if _ws is None else f"build not found: {_ajs}"
+            response: dict[str, Any] = {
+                "ok": False,
+                "errors": [f"research_log_append: {reason}"],
+            }
+        else:
+            ajs_posix = str(_ajs).replace("\\", "/").replace("'", "\\'")
+            append_url = ("file:///" + ajs_posix) if sys.platform == "win32" else ajs_posix
+
+            # Override projectPath with workspace; pipe the full input via
+            # stdin so no value needs JS-string escaping.
+            input_obj = dict(args)
+            input_obj["projectPath"] = str(_ws).replace("\\", "/")
+
+            script = (
+                f"import {{ researchLogAppend }} from '{append_url}';"
+                " import { readFileSync } from 'node:fs';"
+                " const input = JSON.parse(readFileSync(0, 'utf-8'));"
+                " const r = await researchLogAppend(input);"
+                " process.stdout.write(JSON.stringify(r));"
+            )
+            try:
+                proc = subprocess.run(
+                    ["node", "--input-type=module", "--eval", script],
+                    input=json.dumps(input_obj),
+                    capture_output=True, text=True, timeout=30,
+                )
+                if proc.stdout.strip():
+                    response = json.loads(proc.stdout)
+                else:
+                    stderr_msg = proc.stderr.strip()[:500] if proc.stderr else "no output"
+                    response = {
+                        "ok": False,
+                        "errors": [f"research_log_append: node produced no output (exit {proc.returncode}): {stderr_msg}"],
+                    }
+            except Exception as e:
+                response = {
+                    "ok": False,
+                    "errors": [f"research_log_append: {e}"],
+                }
+
+        entry: dict[str, Any] = {
+            "tool": "mcp__genealogy__research_log_append",
+            "args": dict(args),
+            "expected_args": None,
+            "matched": {"kind": "live", "index": None},
+            "response_fixture": "live:research_log_append",
             "response": response,
         }
         call_log.append(entry)

--- a/eval/harness/scripts/check_tool_coverage.py
+++ b/eval/harness/scripts/check_tool_coverage.py
@@ -57,6 +57,12 @@ EXEMPT_TOOLS: dict[str, str] = {
         "(packages/engine/mcp-server/tests/); transcription behavior is verified via the "
         "layered manual testing playbooks (docs/testing-guides/)."
     ),
+    "research_log_append": (
+        "registered as a LIVE_TOOL in mock_mcp.py — calls the real compiled "
+        "implementation rather than matching a fixture. The tool handles id "
+        "assignment, timestamping, camelCase-to-snake_case field renaming, "
+        "and validation. No fixture needed; it is always available."
+    ),
 }
 
 

--- a/eval/runlogs/unit/search-records/v1_2026-06-23_07-06-12.ann.json
+++ b/eval/runlogs/unit/search-records/v1_2026-06-23_07-06-12.ann.json
@@ -1,0 +1,654 @@
+{
+  "run_log": "v1_2026-06-23_07-06-12.json",
+  "annotator": "adeyinka",
+  "corrections": [
+    {
+      "test_id": "ut_search_records_012",
+      "dimension_source": "base",
+      "dimension_name": "Correctness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_records_012",
+      "dimension_source": "base",
+      "dimension_name": "Completeness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_records_012",
+      "dimension_source": "base",
+      "dimension_name": "Tool Arguments",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_records_012",
+      "dimension_source": "rubric",
+      "dimension_name": "Search strategy",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_records_012",
+      "dimension_source": "rubric",
+      "dimension_name": "Result triage",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_records_012",
+      "dimension_source": "rubric",
+      "dimension_name": "Log quality",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_records_012",
+      "dimension_source": "rubric",
+      "dimension_name": "Sidecar correctness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_records_012",
+      "dimension_source": "rubric",
+      "dimension_name": "Nil escalation",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_records_016",
+      "dimension_source": "base",
+      "dimension_name": "Correctness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_records_016",
+      "dimension_source": "base",
+      "dimension_name": "Completeness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_records_016",
+      "dimension_source": "base",
+      "dimension_name": "Tool Arguments",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_records_016",
+      "dimension_source": "rubric",
+      "dimension_name": "Search strategy",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_records_016",
+      "dimension_source": "rubric",
+      "dimension_name": "Result triage",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_records_016",
+      "dimension_source": "rubric",
+      "dimension_name": "Log quality",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_records_016",
+      "dimension_source": "rubric",
+      "dimension_name": "Sidecar correctness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_records_016",
+      "dimension_source": "rubric",
+      "dimension_name": "Nil escalation",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_records_001",
+      "dimension_source": "base",
+      "dimension_name": "Correctness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_records_001",
+      "dimension_source": "base",
+      "dimension_name": "Completeness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_records_001",
+      "dimension_source": "base",
+      "dimension_name": "Tool Arguments",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_records_001",
+      "dimension_source": "rubric",
+      "dimension_name": "Search strategy",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_records_001",
+      "dimension_source": "rubric",
+      "dimension_name": "Result triage",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_records_001",
+      "dimension_source": "rubric",
+      "dimension_name": "Log quality",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_records_001",
+      "dimension_source": "rubric",
+      "dimension_name": "Sidecar correctness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_records_001",
+      "dimension_source": "rubric",
+      "dimension_name": "Nil escalation",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_records_015",
+      "dimension_source": "base",
+      "dimension_name": "Correctness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_records_015",
+      "dimension_source": "base",
+      "dimension_name": "Completeness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_records_015",
+      "dimension_source": "base",
+      "dimension_name": "Tool Arguments",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_records_015",
+      "dimension_source": "rubric",
+      "dimension_name": "Search strategy",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_records_015",
+      "dimension_source": "rubric",
+      "dimension_name": "Result triage",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_records_015",
+      "dimension_source": "rubric",
+      "dimension_name": "Log quality",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_records_015",
+      "dimension_source": "rubric",
+      "dimension_name": "Sidecar correctness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_records_015",
+      "dimension_source": "rubric",
+      "dimension_name": "Nil escalation",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_records_017",
+      "dimension_source": "base",
+      "dimension_name": "Correctness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_records_017",
+      "dimension_source": "base",
+      "dimension_name": "Completeness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_records_017",
+      "dimension_source": "base",
+      "dimension_name": "Tool Arguments",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_records_017",
+      "dimension_source": "rubric",
+      "dimension_name": "Search strategy",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_records_017",
+      "dimension_source": "rubric",
+      "dimension_name": "Result triage",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_records_017",
+      "dimension_source": "rubric",
+      "dimension_name": "Log quality",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_records_017",
+      "dimension_source": "rubric",
+      "dimension_name": "Sidecar correctness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_records_017",
+      "dimension_source": "rubric",
+      "dimension_name": "Nil escalation",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_records_004",
+      "dimension_source": "base",
+      "dimension_name": "Correctness",
+      "llm_score": 1,
+      "corrected_score": 1,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_records_004",
+      "dimension_source": "base",
+      "dimension_name": "Completeness",
+      "llm_score": 1,
+      "corrected_score": 1,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_records_004",
+      "dimension_source": "base",
+      "dimension_name": "Tool Arguments",
+      "llm_score": 1,
+      "corrected_score": 1,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_records_007",
+      "dimension_source": "base",
+      "dimension_name": "Correctness",
+      "llm_score": 1,
+      "corrected_score": 1,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_records_007",
+      "dimension_source": "base",
+      "dimension_name": "Completeness",
+      "llm_score": 1,
+      "corrected_score": 1,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_records_007",
+      "dimension_source": "base",
+      "dimension_name": "Tool Arguments",
+      "llm_score": 1,
+      "corrected_score": 1,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_records_002",
+      "dimension_source": "base",
+      "dimension_name": "Correctness",
+      "llm_score": 2,
+      "corrected_score": 2,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_records_002",
+      "dimension_source": "base",
+      "dimension_name": "Completeness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_records_002",
+      "dimension_source": "base",
+      "dimension_name": "Tool Arguments",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_records_002",
+      "dimension_source": "rubric",
+      "dimension_name": "Search strategy",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_records_002",
+      "dimension_source": "rubric",
+      "dimension_name": "Result triage",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_records_002",
+      "dimension_source": "rubric",
+      "dimension_name": "Log quality",
+      "llm_score": 2,
+      "corrected_score": 2,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_records_002",
+      "dimension_source": "rubric",
+      "dimension_name": "Sidecar correctness",
+      "llm_score": 1,
+      "corrected_score": 1,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_records_002",
+      "dimension_source": "rubric",
+      "dimension_name": "Nil escalation",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_records_005",
+      "dimension_source": "base",
+      "dimension_name": "Correctness",
+      "llm_score": 1,
+      "corrected_score": 1,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_records_005",
+      "dimension_source": "base",
+      "dimension_name": "Completeness",
+      "llm_score": 1,
+      "corrected_score": 1,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_records_005",
+      "dimension_source": "base",
+      "dimension_name": "Tool Arguments",
+      "llm_score": 1,
+      "corrected_score": 1,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_records_011",
+      "dimension_source": "base",
+      "dimension_name": "Correctness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_records_011",
+      "dimension_source": "base",
+      "dimension_name": "Completeness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_records_011",
+      "dimension_source": "base",
+      "dimension_name": "Tool Arguments",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_records_011",
+      "dimension_source": "rubric",
+      "dimension_name": "Search strategy",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_records_011",
+      "dimension_source": "rubric",
+      "dimension_name": "Result triage",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_records_011",
+      "dimension_source": "rubric",
+      "dimension_name": "Log quality",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_records_011",
+      "dimension_source": "rubric",
+      "dimension_name": "Sidecar correctness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_records_011",
+      "dimension_source": "rubric",
+      "dimension_name": "Nil escalation",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_records_014",
+      "dimension_source": "base",
+      "dimension_name": "Correctness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_records_014",
+      "dimension_source": "base",
+      "dimension_name": "Completeness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_records_014",
+      "dimension_source": "base",
+      "dimension_name": "Tool Arguments",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_records_014",
+      "dimension_source": "rubric",
+      "dimension_name": "Search strategy",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_records_014",
+      "dimension_source": "rubric",
+      "dimension_name": "Result triage",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_records_014",
+      "dimension_source": "rubric",
+      "dimension_name": "Log quality",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_records_014",
+      "dimension_source": "rubric",
+      "dimension_name": "Sidecar correctness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_records_014",
+      "dimension_source": "rubric",
+      "dimension_name": "Nil escalation",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_records_013",
+      "dimension_source": "base",
+      "dimension_name": "Correctness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_records_013",
+      "dimension_source": "base",
+      "dimension_name": "Completeness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_records_013",
+      "dimension_source": "base",
+      "dimension_name": "Tool Arguments",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_records_013",
+      "dimension_source": "rubric",
+      "dimension_name": "Search strategy",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_records_013",
+      "dimension_source": "rubric",
+      "dimension_name": "Result triage",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_records_013",
+      "dimension_source": "rubric",
+      "dimension_name": "Log quality",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_records_013",
+      "dimension_source": "rubric",
+      "dimension_name": "Sidecar correctness",
+      "llm_score": 2,
+      "corrected_score": 2,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_records_013",
+      "dimension_source": "rubric",
+      "dimension_name": "Nil escalation",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    }
+  ]
+}

--- a/eval/runlogs/unit/search-records/v1_2026-06-23_07-06-12.json
+++ b/eval/runlogs/unit/search-records/v1_2026-06-23_07-06-12.json
@@ -1,0 +1,4682 @@
+{
+  "schema_version": 2,
+  "skill": "search-records",
+  "version": 1,
+  "released": false,
+  "releasable": true,
+  "invocation": "skill",
+  "timestamp": "2026-06-23_07-06-12",
+  "harness_version": "0.1.0",
+  "model": "claude-sonnet-4-6",
+  "judge_prompt_hash": "adea6e4cb2c9ddf0c436c31e893da766866cc67ed749df0a7c6b8a9df52c6914",
+  "snapshot": {
+    "packages/engine/plugin/skills/search-records/references/collection-quirks.md": "# Collection-Specific Indexing Quirks \u2014 FamilySearch Records API\n\nRead this reference when searching a specific collection family.\nQuirks affect how queries should be constructed for that collection.\n\n## US Federal Censuses (1790\u20131940)\n\n- Indexed by community volunteers; mostly accurate but cursive\n  handwriting causes common transcription errors: S/L, F/T, n/u,\n  U/V confusions; double-S misread as F or \"long s\"\n- **Compensation:** Use surname wildcards (`q.surname=Sm?th`);\n  search by neighbors; for unindexed enumeration districts, switch\n  to image browsing\n- Collection-specific forms expose extra fields (Residence Year\n  locked to census year, Race, Marital Status, 1935 Residence for\n  1940 census)\n\n## England parish registers (IGI Community Indexed)\n\n- Pre-1837 parish records extracted decades ago \u2014 static \"Legacy\"\n  collections with no updates or corrections since 2010 publication\n- **Compensation:** Search by IGI batch number (`q.batchNumber`)\n  to enumerate a parish exhaustively; cross-check with FreeREG and\n  FindMyPast\n- Batch number format: letter prefix + exactly 6 digits (e.g.,\n  `C050761`). Left-pad with zeros if needed.\n- Submitting batch number alone (no name) returns all extracted\n  records in alphabetical order \u2014 canonical way to enumerate every\n  christening or marriage from a single parish\n\n## Mexico Civil Registration\n\n- Post-2020 indexes often produced by Computer-Aided Indexing (CAI)\n  with higher OCR-style error rates, especially with accented\n  characters and joined cursive\n- **Compensation:** Use wildcards generously (`q.fatherSurname=\n  L*pez`); search dual surnames separately; search by parents'\n  names instead of the principal\n\n## Mexico Catholic Church Records\n\n- Sometimes indexed without parents' names due to partial indexing\n  templates\n- **Compensation:** Drop the principal's name and search by\n  `q.fatherGivenName/Surname` + `q.motherGivenName/Surname`\n\n## Ellis Island Passenger Lists\n\n- **Wildcards are explicitly disabled** in these collections\n- **Compensation:** Try multiple specific spellings; search by\n  ship name + arrival year via other parameters; use external\n  Stephen Morse one-step tools\n\n## United States SSDI (Social Security Death Index)\n\n- Names may be indexed first-name-last-name without middle initial;\n  some entries have only \"Mrs.\" prefix\n- **Compensation:** Search by SSN if known; use exact birth and\n  death dates\n\n## German Lutheran/Catholic Registers\n\n- Given-name standardization incomplete: \"Johann Friedrich\" vs.\n  \"Friedrich Johann\" may not match each other\n- Umlauts (\u00e4/\u00f6/\u00fc) may be indexed as ae/oe/ue or stripped\n- **Compensation:** Use wildcards; try both name orderings; try\n  both \"Mueller\" and \"M\u00fcller\" (diacritic stripping should handle\n  this, but indexed text may store the \"ue\" spelling)\n\n## Common collection IDs (verify before use)\n\n| Collection | ID |\n|---|---|\n| US Census 1900 | `1325221` |\n| US Census 1910 | `1727033` |\n| US Census 1920 | `1488411` |\n| US Census 1930 | `1810731` |\n| US Census 1940 | `2000219` |\n| US Census 1950 | `4464515` |\n| England Births and Christenings 1538\u20131975 | `1473014` |\n\nWhen in doubt, look up the collection and read the ID from the\nresponse. Do not hardcode IDs without verification.\n",
+    "packages/engine/plugin/skills/search-records/references/data-collection-standards.md": "# Data Collection Standards for Record Searching\n\nReference for GPS-aligned data collection during search execution.\nGrounded in BCG Standards 19-36 and BYUI research methodology.\n\n## Scope of Collection\n\nCollect all information that could be relevant to the research\nquestion \u2014 not just the data you expect to find. Unexpected details\n(neighbors, witnesses, associated names, occupations, property\ndescriptions) often prove critical later during correlation.\n\nDo not let bias or preconception determine what you collect.\nRecord information that supports AND contradicts your working\nhypothesis with equal attention. Evidence that complicates a\nhypothesis is just as valuable as evidence that supports it.\n\n## Source Classification at Point of Collection\n\nWhen you encounter a search result, immediately classify it:\n\n### Original vs. Derivative\n\n- **Original record**: The first recording of information, created\n  at or near the time of the event by someone with authority or\n  direct knowledge. Examples: a church baptismal register entry, a\n  handwritten census schedule, a signed marriage license.\n- **Derivative source**: Created from another source \u2014 includes\n  indexes, abstracts, transcriptions, translations, and database\n  entries. An index entry in a search result is always derivative.\n\n**Critical rule**: An index entry is NOT the record. It is a\npointer to the record. When a search returns index entries, the\nresearcher must attempt to locate and examine the underlying\noriginal record before drawing conclusions.\n\n### Why This Matters for Search\n\nMost FamilySearch search results are index entries \u2014 derivative\nsources extracted by volunteers or automated systems from original\nrecord images. These indexes:\n\n- May contain transcription errors (misread handwriting)\n- May omit information present in the original (partial indexing)\n- May standardize names or dates differently than the original\n- May lack context visible in the full document (marginal notes,\n  adjacent entries, document structure)\n\nAlways treat index data as preliminary. Follow through to the\noriginal image or record whenever possible.\n\n## Information Quality Assessment\n\nFor each piece of information collected, assess:\n\n1. **Who provided the information?** The informant's relationship\n   to the event determines reliability. A parent reporting a child's\n   birth has firsthand knowledge; a neighbor reporting the same\n   birth may not.\n\n2. **Primary vs. secondary information**: Primary information comes\n   from someone with firsthand knowledge of the event. Secondary\n   information comes from someone reporting what they heard or\n   learned after the fact. A death certificate's cause of death is\n   primary (from the attending physician); its birth date is often\n   secondary (from a surviving relative who may not remember\n   accurately).\n\n3. **Proximity in time**: Information recorded close to the event\n   is generally more reliable than information recorded years later.\n   A baptismal record created days after birth is more reliable\n   for birth date than a death certificate created 80 years later.\n\n4. **Motive and bias**: Consider whether the informant had reason\n   to be inaccurate. Pension applications may exaggerate service;\n   immigration records may understate age to avoid restrictions.\n\n## Handling Negative Search Results\n\nA search that returns no matching results is still a finding.\nNegative results are data \u2014 they narrow the space of possibilities\nand may constitute negative evidence.\n\n### When absence is meaningful\n\nThe absence of a record is analytically significant when:\n- The record type was being created in that time and place\n- The person should have appeared (e.g., a head of household\n  missing from a census in a jurisdiction where they were known\n  to reside)\n- The collection is reasonably complete for the relevant period\n\n### When absence is NOT meaningful\n\nAbsence is less informative when:\n- The collection is known to be incomplete or poorly indexed\n- The record type did not exist yet in that jurisdiction\n- The person would not have been included by definition (e.g.,\n  searching military records for someone too young to serve)\n\n### Recording negative results\n\nLog every negative search with the same detail as a positive one.\nInclude what you searched for, what parameters you used, and why\nthe absence matters or does not matter. This documentation is\nessential for demonstrating reasonably exhaustive research.\n\n## Evaluating Database Quality Before Searching\n\nBefore relying on any database or collection, assess it:\n\n1. **What does it actually contain?** Read the collection\n   description. A title like \"U.S. Marriage Records\" may cover\n   only certain states and years.\n2. **Is it an index only, or does it include original images?**\n   Index-only collections require following up to find originals.\n3. **What time period and geography does it cover?** Understand\n   the boundaries before interpreting negative results.\n4. **Who created the index?** Volunteer-indexed collections have\n   different error profiles than professionally indexed ones.\n   Computer-aided indexing (OCR/HTR) has its own characteristic\n   error patterns.\n5. **Are there known gaps or limitations?** Some collections\n   exclude certain record subtypes, parishes, or years.\n\n## Note-Taking Discipline\n\nWhen examining search results:\n\n- Record content exactly as it appears in the source \u2014 do not\n  modernize names, dates, or spellings in your notes\n- Clearly distinguish between what the source says and your\n  interpretation of what it says\n- Note formatting details, column headings, and contextual\n  information that may affect interpretation\n- If the source is an image, note its condition and legibility\n- Capture the full context: adjacent entries, household members,\n  marginal annotations\n\n## Evidence Types to Watch For\n\nSearch results may provide three types of evidence:\n\n- **Direct evidence**: Answers the research question explicitly\n  (e.g., a birth certificate stating parents' names when the\n  question is \"Who are the parents?\")\n- **Indirect evidence**: Provides information from which the\n  answer can be inferred (e.g., an age on a census record from\n  which a birth year can be calculated)\n- **Negative evidence**: The expected information is absent from\n  a source where it should appear (e.g., a couple not listed in\n  marriage records for a county where they were known to reside)\n\nAll three types carry equal weight in building a proof argument.\nDo not dismiss indirect or negative evidence as less important\nthan direct evidence.\n",
+    "packages/engine/plugin/skills/search-records/references/name-search-mechanics.md": "# Name Search Mechanics \u2014 FamilySearch Records API\n\nReference for constructing name parameters in `record_search` queries.\nAll examples use API query parameters (`q.*`).\n\n## Wildcards\n\n| Wildcard | Meaning | Rules |\n|---|---|---|\n| `*` | Zero or more characters | Up to four `*` per name field. Allowed at start, middle, or end (`*bou` is valid). |\n| `?` | Exactly one character | May appear at any position (e.g., `q.surname=Sm?th`). |\n\n**Constraints:**\n- Minimum 3 non-wildcard letters per name field\n- Wildcards + `.exact=on`: wildcard still expands but no additional\n  variant interpretation is applied to the matches\n- **Wildcards disabled in Ellis Island collections** \u2014 use explicit\n  spelling variants instead\n- In place parameters, wildcards work only in the innermost\n  jurisdiction level\n\n## Default fuzzy matching (without `.exact=on`)\n\nWithout `.exact=on`, the API auto-applies:\n- **Diacritic stripping:** \"REN\u00c9E\" matches \"Renee\"\n- **Case insensitivity**\n- **Space/punctuation ignored:** \"MacDonald\" = \"Mac Donald\";\n  \"O'Hara\" = \"OHara\"\n- **Standardized given-name variants:** Wm\u2192William, Margt\u2192Margaret,\n  Eliz\u2192Elizabeth, Robt\u2192Robert, Geo\u2192George, Jno\u2192John, Thos\u2192Thomas\n- **Common nicknames:** Peggy\u2194Margaret, Polly\u2194Mary, Dick\u2194Richard,\n  Jack\u2194John, Bill\u2194William\n- **Phonetic/edit-distance spelling variants** (algorithm unpublished)\n- **Soundex** is part of default fuzzy (no separate toggle)\n\nAdding `.exact=on` to a name parameter disables all of the above for\nthat parameter. Each parameter can be set to exact independently\n(e.g., exact surname with fuzzy given name).\n\n## Surname-only and given-name-only\n\n- **Surname only:** Allowed. Recommended when given name was indexed\n  as \"Baby,\" \"Infant,\" or initials.\n- **Given name only:** Not allowed standalone \u2014 requires at least one\n  other parameter (place, date, parent, spouse).\n\n## Initials\n\n- `q.givenName=J*` is rejected (fails 3-letter minimum)\n- `q.givenName=J W` works as a literal match against records indexed\n  with initials\n- Use `.exact=on` on the given name when searching initials\n\n## Middle names\n\nThe given-name parameter is multi-token. Search order is ignored\n(with single surname). Include middle name when known \u2014 some records\nindex \"John W. Smith\" only as \"John W\" or \"John William.\"\n\n## Quoted values\n\nWhen a name value contains a space, quote it in the API parameter:\n`q.givenName=\"Sally Mae\"`. Single-token names need no quotes.\n\n**Boolean AND/OR/NOT and plus/minus operators are NOT supported** in\nindexed Records search parameters.\n\n## Common indexing error patterns\n\nThese patterns arise from handwriting misreads in the indexing process.\nUse wildcards to compensate.\n\n| Original handwriting | Common misreadings | Wildcard strategy |\n|---|---|---|\n| Capital `S` (cursive, looped) | `L`, `J`, `T` | `?mith`, `?ones` |\n| Capital `F` | `T`, `J`, `S` | `?inley` |\n| Lowercase `n` | `u`, `v` | `Hu?ter`, `Pe??y` |\n| Lowercase `u` | `n`, `v` | `Bru?n`, `Ba?er` |\n| Long `s` (\u017f) | `f`, `F` | `Wa?on`, `Bi?op` |\n| Double `s` (\u017fs) | `fs`, `B`, `S` | `Ros?` |\n| `e` / `o` | each other | `Sm?th`, `H?lmes` |\n| `a` | `o`, `u`, `e` | `H?rt`, `J?nes` |\n| `r` / `n` | each other | `Ba?ker` |\n| `c` / `e` / `t` | each other | `Mi?hael` |\n| `i` / `j` / `l` / `1` | each other | `?ohnson` |\n| `h` / `k` | each other | `?ane` |\n\n**Other patterns:**\n- Suffixes (Jr., Sr., II, III) commonly dropped \u2014 search without\n- Prefixes (von, van, de, Mc/Mac) normalized or dropped \u2014 try with\n  and without; try contracted (M' for Mc) and expanded forms\n- Hispanic dual surnames misordered \u2014 try `q.surname=Garc\u00eda` and\n  `q.surname=L\u00f3pez` separately\n- Female names: US records use married surname; Spanish/Italian\n  preserve maiden; Quaker/Scandinavian use patronymics\n- \"Willm\" / \"Will'm\" may not standardize to William \u2014 search both\n\n## Common nickname equivalences\n\nAuto-applied in fuzzy search but may fail on partial standardizations.\nTry formal names explicitly when fuzzy doesn't produce results.\n\n| Formal | Nicknames seen in records |\n|---|---|\n| Margaret | Peggy, Peg, Maggie, Meg, Madge, Greta, Rita |\n| Mary | Polly, Molly, Mamie, May, Mim, Minnie |\n| Elizabeth | Betty, Betsy, Beth, Liz, Lizzy, Eliza, Lisa, Bess |\n| Sarah | Sally, Sadie |\n| Catherine/Katherine | Kate, Kitty, Cathy, Katy, Trina |\n| Charles | Chuck, Chas, Charlie, Carl |\n| William | Will, Bill, Billy, Wm., Liam |\n| Richard | Rick, Dick, Richie, Dickon |\n| Robert | Rob, Bob, Robbie, Dob (archaic) |\n| John | Jack, Johnny, Jno., Hans (German), Honza (Czech) |\n| James | Jim, Jimmy, Jas., Jamie, Diego (Spanish) |\n| Henry | Hank, Harry, Hal |\n| Edward | Ed, Ted, Ned, Eddie |\n| Francis | Frank, Frankie, Paco (Spanish), Pepe |\n| Joseph | Joe, Jos., Pepe (Spanish) |\n| Alexander | Alex, Sandy, Alec |\n",
+    "packages/engine/plugin/skills/search-records/references/place-date-mechanics.md": "# Place, Date, and Relationship Mechanics \u2014 FamilySearch Records API\n\nReference for constructing place, date, and relationship parameters\nin `record_search` queries. All examples use API query parameters.\n\n## Place parameters\n\n### Standardized places\n\nPlace parameters accept standardized place strings (e.g.,\n\"Lehi, Utah County, Utah, United States\"). The API resolves these\nto internal Place IDs. Use the full hierarchical form for best\nresults. Non-standardized strings fall back to brittle string\nmatching.\n\n### Fuzzy place (default) vs. exact place\n\n- **Default (no `.exact=on`):** Matches the specified place AND\n  places within 3 jurisdiction levels above it. `q.birthLikePlace=\n  Lehi, Utah County, Utah` returns records in Lehi, Utah County,\n  and Utah \u2014 but not all of USA.\n- **With `.exact=on`:** Still descends to child localities, but does\n  NOT expand upward. `q.birthLikePlace=Utah County, Utah` with\n  `.exact=on` finds Lehi, Provo, etc. but excludes records indexed\n  only as \"Utah, USA.\"\n\n**Key insight:** Exact place does NOT prevent matching child\nlocalities \u2014 it prevents matching parent localities.\n\n### Filter-based place restriction\n\nFor strict place filtering, use `f.*` parameters instead of `q.*`:\n\n```\nf.birthLikePlace0=10\nf.birthLikePlace1=10,Ohio\nf.birthLikePlace2=10,Ohio,Monroe\n```\n\nValues use the format `{parent_place_id},{place_name}`. Place IDs\ncome from the FamilySearch Places API.\n\n### Multi-place / multiple events\n\nUse cardinality suffixes (`.1` through `.9`) for multiple events of\nthe same type:\n\n```\nq.marriagePlace=Colorado&q.marriageDate.from=1920&q.marriageDate.to=1920\n&q.marriagePlace.1=Nevada&q.marriageDate.1.from=1940&q.marriageDate.1.to=1940\n```\n\nCardinality must match across grouped fields.\n\n## Date parameters\n\n### Fuzzy date behavior\n\n- No published fixed tolerance. Empirically: \u00b12 years for\n  Birth/Marriage/Death, \u00b15 years for Any/Residence.\n- **For deterministic behavior, always use a year range:**\n  `q.birthLikeDate.from=1850&q.birthLikeDate.to=1860`\n- **Ranges are inclusive** on both ends.\n\n### Date granularity\n\n**Only the year is honored at search time.** Day and month are\naccepted but discarded for matching.\n\n### Exact year\n\nWith `.exact=on` on a date parameter, only records indexed with that\nexact year match. Records with no indexed year are excluded.\n\n### Event types\n\n| Parameter prefix | Matches |\n|---|---|\n| `birthLike` | Birth, christening, baptism, naming |\n| `deathLike` | Death, burial, cremation |\n| `marriageLike` | Marriage, engagement, license, banns |\n| `residence` | Census, directory, tax, land residence |\n| `any` | ALL event types \u2014 use when event type is uncertain |\n\nWhen you specify a typed date+place pair (e.g., `q.birthLikeDate`\n+ `q.birthLikePlace`), both must match the same event for a hit.\nFor \"any record in this place at this time,\" use `q.anyDate` +\n`q.anyPlace`.\n\n## Relationship parameters\n\n### Available fields\n\n| Relationship | Given name | Surname | Other |\n|---|---|---|---|\n| Spouse | `q.spouseGivenName` | `q.spouseSurname` | `q.marriageLikeDate`, `q.marriageLikePlace` |\n| Father | `q.fatherGivenName` | `q.fatherSurname` | `q.fatherBirthLikePlace` |\n| Mother | `q.motherGivenName` | `q.motherSurname` | `q.motherBirthLikePlace` |\n| Parent (sex unknown) | `q.parentGivenName` | `q.parentSurname` | `q.parentBirthLikePlace` |\n\nEach name field independently supports wildcards and `.exact=on`.\n\n### Narrowing behavior\n\n- Surname is auto-required when supplied (`.require=on` is\n  implicit for surname fields).\n- Given name only (e.g., spouse \"Frank\" with unknown surname)\n  returns broader results. Useful for finding women with unknown\n  maiden names.\n- Use cardinality (`.1` through `.9`) to bundle each spouse's name\n  with that spouse's marriage date/place.\n\n## Other parameters\n\n| Parameter | Purpose |\n|---|---|\n| `q.sex` | `Male` or `Female` |\n| `q.batchNumber` | IGI batch number (e.g., `C050761`). Must be exactly 6 digits after letter prefix. |\n| `treeref` | Family Tree PID \u2014 binds search to a tree person for downstream Source Linker attachment |\n| `f.collectionId` | Restrict to a specific collection (repeatable for multiple collections) |\n| `count` | Results per page, 1\u2013100 (default 20) |\n| `offset` | Zero-based pagination, max 4999. Searches return at most 5,000 results. |\n",
+    "packages/engine/plugin/skills/search-records/references/research-log-protocol.md": "# Research Log Protocol\n\nThis protocol must be followed by every skill that searches for or\nprocesses genealogical records. The research log is the GPS audit trail\nthat makes \"reasonably exhaustive\" claims provable.\n\nThe mechanical side of logging is owned by the **`research_log_append`**\nMCP tool: it assigns the `log_` id, stamps the timestamp, finalizes the\nstaged search payload into the `results/<log_id>.json` sidecar (counting\nthe results itself), validates before persisting, and appends to the\ntail of `log[]` atomically. You never hand-assemble the entry, count\nresults, write a sidecar, or chunk a large payload. This protocol covers\nthe **analytical** rules \u2014 what to log, when an outcome is negative,\nwhat belongs in `query`/`notes` \u2014 that remain your judgment.\n\n## Rules\n\n1. **Every search produces a log entry.** No exceptions. If you called\n   a search tool or generated a search URL, log it.\n\n2. **Nil results are recorded explicitly.** When a search returns no\n   results, write a log entry with `outcome: \"negative\"` and\n   `results_examined: 0`. The absence of a result is itself a finding.\n\n3. **Log entries are append-only.** Never modify or delete an existing\n   log entry. The log is the primary audit trail \u2014 if entries could be\n   edited, the exhaustive search declaration would be unfalsifiable.\n\n4. **Include search parameters.** The `query` object must capture\n   enough detail to reproduce the search: names, dates, places,\n   collection, and any filters used.\n\n5. **Link to plan items.** If the search was part of a research plan,\n   set `plan_item_id` to the `pli_` ID. For ad-hoc searches, use null.\n\n6. **Link outputs back to the search.** The log entry is immutable\n   (Rule 3). When sources and assertions are extracted from a logged\n   search, the extracting skill stamps each new source and assertion\n   with a `log_entry_id` pointing at the log entry. \"What did this\n   search produce\" is a reverse lookup over those fields \u2014 the log\n   entry itself is never revisited.\n\n7. **Retain the raw results.** A log entry records *that* a search ran;\n   the results it returned are retained too, so a later step can\n   re-examine or refute them (GPS Element 1 \u2014 reasonably exhaustive\n   research). For tool-payload searches (`record_search`,\n   `fulltext_search`) you pass the search response's `staged.resultsRef`\n   to `research_log_append` as `stagedResultsRef`, and the tool retains\n   the raw payload in `results/<log_id>.json` for you \u2014 no hand-written\n   sidecar, no chunking. External-site searches retain the captured\n   PDF/HTML instead, via `external_site.capture_filename`. A search that\n   returns nothing retains nothing \u2014 omit `stagedResultsRef` and the\n   tool sets `results_ref` to null.\n\n## The fields you supply to `research_log_append`\n\nYou provide the analytical content; the tool assigns the id, timestamp,\n`results_ref`, and the sidecar.\n\n- `tool` \u2014 the search tool used (`record_search`, `fulltext_search`, \u2026).\n- `query` \u2014 enough detail to reproduce the search.\n- `outcome` \u2014 `positive` / `negative` / `partial` / `error`.\n- `resultsExamined` \u2014 how many results you actually triaged.\n- `resultsAvailable` \u2014 the total hit count the tool reported, or null.\n- `planItemId` \u2014 the `pli_` this search addresses, or null for ad-hoc.\n- `notes` \u2014 a one-line human summary of what the search returned.\n- `stagedResultsRef` \u2014 `staged.resultsRef` from the search response\n  (omit for a nil or external-site search).\n\n**Recovery.** If `research_log_append` returns `{ ok: false, errors }`\nit wrote nothing \u2014 surface the errors rather than retrying blindly. A\nstale `stagedResultsRef` (staged result files are pruned after ~24h) is\nthe common case: re-run the search to re-stage, then log with the fresh\n`staged.resultsRef`.\n\n## When record-extraction writes log entries\n\nrecord-extraction writes a log entry **only** when processing a\nrecord that was not produced by search-records or\nsearch-external-sites \u2014 e.g., a user-provided PDF uploaded directly.\nWhen a search skill already logged the search, link to that log\nentry by setting `log_entry_id` on each new source and assertion,\nrather than creating a duplicate log entry.\n",
+    "packages/engine/plugin/skills/search-records/references/research-log-standards.md": "# Research Log Standards\n\nReference for maintaining GPS-compliant research logs during\nsearch execution. The research log is the primary audit trail\nthat proves research was reasonably exhaustive.\n\n## Purpose of the Research Log\n\nThe log serves three functions:\n\n1. **Proof of exhaustiveness**: Demonstrates which sources were\n   consulted and what was (or was not) found. Without a log,\n   claims of thorough research are unverifiable.\n2. **Prevention of duplication**: A complete log prevents the\n   researcher from repeating searches already performed.\n3. **Reproducibility**: Any other researcher should be able to\n   recreate the exact search from the log entry.\n\n## Nine Essential Elements\n\nEvery log entry must capture these nine elements. An entry\nmissing any element is incomplete.\n\n| # | Element | What to Record |\n|---|---------|----------------|\n| 1 | **Date performed** | When the search was executed (ISO timestamp) |\n| 2 | **Repository / tool** | Which database, website, or MCP tool was used |\n| 3 | **Source citation** | Full identification of the collection or source consulted (collection name, ID, repository) |\n| 4 | **Search description** | Exact parameters used: names, dates, places, filters, wildcards. Must be detailed enough to reproduce |\n| 5 | **Purpose** | Which research question or plan item this search addresses |\n| 6 | **Results** | What was found OR what was NOT found. Both are equally important |\n| 7 | **Document identifiers** | Record IDs, ARK identifiers, image numbers, page references for anything located |\n| 8 | **Analysis notes** | Interpretation of results \u2014 why a match is strong or weak, what the absence means, preliminary assessment |\n| 9 | **Follow-up actions** | What needs to happen next: examine original, search variant spelling, check adjacent collection, etc. |\n\n## Mapping to the Log Entry Schema\n\nThe `research.json` log entry schema maps to these nine elements:\n\n| Element | Schema field(s) |\n|---------|----------------|\n| Date performed | `performed` |\n| Repository / tool | `tool`, `external_site` |\n| Source citation | `query.collection` + tool context |\n| Search description | `query` object (all parameters) |\n| Purpose | `plan_item_id` (links to plan item with goal) |\n| Results | `outcome`, `results_examined`, `notes` |\n| Document identifiers | sources linked back via `source.log_entry_id` |\n| Analysis notes | `notes` |\n| Follow-up actions | `notes` (include at end of notes) |\n\n## Rules\n\n### Every search gets logged \u2014 no exceptions\n\nIf you called a search tool, generated a URL, or browsed images,\nlog it. This includes:\n- Searches that returned zero results\n- Searches that returned too many results to evaluate\n- Searches abandoned due to authentication errors\n- Searches repeated with different parameters (each attempt\n  gets its own entry)\n\n### Negative results are findings, not failures\n\nWhen a search returns no results, record `outcome: \"negative\"`\nwith full search parameters. The absence of an expected record\nis itself evidence. A log full of negative searches demonstrates\nthoroughness \u2014 it shows the researcher looked and did not find,\nrather than simply not looking.\n\n### Log entries are append-only\n\nNever modify or delete a previous log entry. The log is the\naudit trail. If a previous entry contains an error, add a new\nentry with a correction note \u2014 do not overwrite.\n\n### Search parameters must enable reproduction\n\nThe `query` object must contain enough detail that someone could\nre-execute the exact same search. Include:\n- All name parameters (exact values, not \"the subject's name\")\n- All date parameters (specific years and ranges)\n- All place parameters (full place strings)\n- Collection IDs or names when filtered\n- Whether exact mode was used\n- Any wildcards applied\n\n### Link to plan items\n\nEvery search driven by a research plan must reference the plan\nitem via `plan_item_id`. For ad-hoc searches requested by the\nuser outside the plan, use `plan_item_id: null` and explain\nthe motivation in `notes`.\n\n## Evaluating Log Completeness\n\nBefore claiming research is reasonably exhaustive, review the\nlog for these indicators:\n\n- Are there entries for every plan item (completed or skipped)?\n- Are negative results documented with the same detail as\n  positive results?\n- Were variant spellings attempted and logged?\n- Were multiple jurisdictions searched?\n- Were different record types consulted?\n- Is every entry detailed enough to reproduce?\n- Are follow-up actions either completed or explained?\n\nA log that contains only positive results is a red flag \u2014 it\nsuggests either cherry-picking or incomplete documentation of\nthe actual search process.\n",
+    "packages/engine/plugin/skills/search-records/references/search-strategy-levers.md": "# Search Strategy Levers \u2014 FamilySearch Records API\n\nWhen a search returns too many, too few, or zero results, iterate\nthrough these levers. All levers are expressed as API parameter\nmanipulations.\n\n## Default strategy: broad-to-narrow\n\nStart with surname + place (state-level) + wide year range. Use\n`f.collectionId` to narrow to specific collections that return hits.\nThen add filters (narrower place, narrower date, sex, relationships).\n\nUse **narrow-to-broad** only for known-record retrieval: when you\nhave high-confidence facts (full name, exact birth date, exact place)\nand expect a specific record.\n\n## Decision rules by hit count\n\n1. **>5,000 hits** \u2192 Narrow by `f.collectionId` first, then place\n   jurisdiction, then add spouse/parent names.\n2. **100\u20135,000 hits** \u2192 Add `f.collectionId` and `q.sex`; add parent\n   name; consider `.exact=on` on place.\n3. **10\u2013100 hits** \u2192 Evaluate the top results directly.\n4. **0 hits** \u2192 Apply levers in priority order (see below).\n\n## Name levers\n\n| Lever | API change | When to try |\n|---|---|---|\n| Drop surname | Clear `q.surname`; keep `q.givenName` + place + date | Surname heavily corrupted, foreign, or transliterated |\n| Drop given name | Clear `q.givenName`; keep `q.surname` + place + date | Given name indexed as initials, nickname, \"Infant,\" or in another language |\n| Drop both names | Use only place + date + `q.sex` + relationship params | Both names corrupted; only structural clues stable |\n| Search by spouse | Swap principal and spouse: put spouse in `q.givenName/surname`, subject in `q.spouseGivenName/spouseSurname` | Subject's name is common; spouse's is unique |\n| Search by parent | Clear principal name; fill `q.fatherGivenName/Surname` and/or `q.motherGivenName/Surname` | Looking for sibling sets; principal may have been \"Baby\" or stillborn |\n| Search by child | Search child as principal with parent name set to subject | Subject's own records scarce; child's are abundant |\n| Wildcard surname | `q.surname=Sm*th` or `q.surname=*tnam` | Foreign transliteration, indexing errors, married-name variants |\n| Wildcard given name | `q.givenName=Joh*` or `q.givenName=Eli?abeth` | Diminutives, abbreviations, ambiguous handwriting |\n| Use initials only | `q.givenName=J W` with `.exact=on` | Census/directory records abbreviated as initials |\n| Replace name with structural params | Fill `q.sex`, residence date+place, parent name; clear principal name | Name unrecoverable (e.g., \"Negro woman aged 30\") |\n\n## Place levers\n\n| Lever | API change | When to try |\n|---|---|---|\n| Broaden place (county\u2192state\u2192country) | Drop smaller jurisdiction levels from place string | No hits in expected county; boundary changes; ancestor crossed county lines |\n| Narrow place (state\u2192county\u2192town) | Add smaller levels to place string | Too many hits; subject's town is known |\n| Drop place | Clear all place parameters | Subject migrated unexpectedly |\n| Switch event-place | Move place from `birthLikePlace` \u2192 `residencePlace` \u2192 `marriageLikePlace` \u2192 `anyPlace` | Each event occurred in a different place |\n\n## Date levers\n\n| Lever | API change | When to try |\n|---|---|---|\n| Broaden range | Widen `.from`/`.to` to \u00b15 or \u00b110 years | Census age inflation/deflation; estimated dates |\n| Drop date | Clear all date parameters | Date is uncertain; pre-1850 ancestors |\n| Switch event type | Move date from `birthLikeDate` \u2192 `residenceDate` \u2192 `deathLikeDate` | Original event date was wrong type |\n| Use Any event | Switch to `q.anyDate` + `q.anyPlace` | Date known but event type unknown (e.g., immigration year) |\n\n## Filter levers\n\n| Lever | API change | When to try |\n|---|---|---|\n| Restrict to collection | Add `f.collectionId={id}` | Strong match expected in one collection |\n| Drop all filters, single identifier | Search uncommon spouse name only, or `q.batchNumber` only | Brick wall; brute-force exhaustive |\n\n## Cluster / FAN club levers\n\n| Lever | How | When to try |\n|---|---|---|\n| Search by neighbor | Search the adjacent census household | Subject missed by indexer or indexed badly |\n| Search collateral relatives | Use uncommon brother/cousin/in-law surname | Subject's surname too common |\n| Maiden vs married name | Run two parallel searches | Female ancestor across her lifetime |\n\n## Zero-hit escalation priority\n\nWhen a search returns 0 hits with reasonable inputs, try in this order:\n\n1. Broaden year range to \u00b110\n2. Drop given name (surname + place + date)\n3. Drop surname (given name + place + date + relationships)\n4. Wildcard the surname\n5. Wildcard the given name\n6. Switch event type to Any\n7. Broaden place by one jurisdiction level\n8. Drop place entirely\n9. Switch from principal to spouse / parent / child\n10. Search by neighbor or FAN-club member\n\n**Still 0 hits across all variations:** the records may be unindexed.\nSwitch to image browsing, Catalog search, Full-Text Search, or\nexternal indexes.\n\n## \"Reasonably exhaustive\" exit criteria\n\nA reasonably exhaustive indexed Records search has been performed when:\n- Searched under at least one wildcarded surname variant and one\n  wildcarded given-name variant\n- Searched by at least one parent and one spouse (where applicable)\n- Searched the immediate jurisdiction, parent jurisdiction, and one\n  neighboring jurisdiction\n- Examined results from each collection that returned matching hits\n- Checked for image-only collections via the Catalog\n- Documented every search attempt including zero-hit searches\n\n## Quick-reference: when to use `.exact=on`\n\n| Parameter type | Default fuzzy expands to\u2026 | Use `.exact=on` when\u2026 |\n|---|---|---|\n| Given name | Nicknames, abbreviations, diacritic variants | Name is a verbatim match; rare formal name |\n| Surname | Spelling variants via phonetic algorithm | Name is unusual; result list too noisy |\n| Place | Up to 3 jurisdiction levels above | Exclude parent-jurisdiction matches (children still included) |\n| Year | \u00b1~2 years (undocumented, varies) | You have a verified date from a vital record |\n",
+    "packages/engine/plugin/skills/search-records/references/validation-protocol.md": "# Validation Protocol\n\nThe structured persistence tools (`research_log_append`,\n`research_append`, `tree_edit`, the merge tools) **validate before they\npersist** \u2014 they write nothing and return `{ ok: false, errors }` when a\nwrite would invalidate the project. There is no need to invoke\n`validate-schema` as a post-write backstop; surface those errors instead\nof retrying blindly. (`validate-schema` remains available as a\nuser-invokable audit of the whole project.)\n\nWhat the tools do **not** check is genealogical plausibility:\n\n1. **Invoke `check-warnings`** if you added assertions or\n   person_evidence entries. This checks for genealogical\n   impossibilities (married before 12, died after 120, child born\n   after parent's death, etc.). It is not auto-triggered \u2014 you must\n   invoke it explicitly.\n\n(search-records writes only log entries and plan-item status, so it does\nnot trigger `check-warnings`; the assertion-creating skills do.)\n",
+    "packages/engine/plugin/skills/search-records/SKILL.md": "---\nname: search-records\nmodel: claude-sonnet-4-6\ndescription: Executes searches against FamilySearch historical records per\n  the research plan. Routes to the correct MCP search tool based on record\n  type, triages results using match scoring, logs every search including nil\n  results, and passes promising records to record-extraction. GPS Step 1 \u2014\n  Reasonably Exhaustive Research (execution phase). Use when the user says\n  \"search for [person]\", \"find [person] in [record type]\", \"execute the\n  plan\", \"run the next search\", \"search FamilySearch\", or when a plan item\n  targets a FamilySearch repository. Do NOT use when the target is\n  Ancestry, MyHeritage, FindMyPast, FindAGrave, or Newspapers.com (use\n  search-external-sites), when the user wants to plan what to search (use\n  research-plan), or when the user wants to analyze a record already found\n  (use record-extraction).\nallowed-tools:\n  - record_search\n  - record_read\n  - same_person\n  - source_attachments\n  - research_log_append\n  - research_append\n---\n\n# Search Records\n\n**\u26a0 ROUTE CHECK \u2014 answer ALL three gates before ANY tool call or file read:**\n\n**Gate 1 \u2014 External site?**\nIf the user names **Ancestry, MyHeritage, FindMyPast, FindAGrave, Newspapers.com, or any non-FamilySearch site** \u2192 call `Skill(\"search-external-sites\")` as your ONLY action and stop.\n\n\u274c After this routing call, do NOT:\n- Construct any URL or search link\n- Call record_search or any MCP tool\n- Write or read research.json\n- Compute search parameters or display them\n- Provide research guidance or next-step commentary\n\nThe user's request is now fully in search-external-sites' hands. Your job is done the moment you call the Skill.\n\n**Gate 2 \u2014 Planning question?**\n> **\"Is the user asking me to run a specific FamilySearch search RIGHT NOW?\"**\n> - **YES** (e.g. \"Search the 1850 census for Patrick\", \"Execute pli_001\") \u2192 proceed below.\n> - **NO** (e.g. \"What should I search for?\", \"What next?\", \"What records exist?\", \"How do I find X?\", \"What should I search for next to find Patrick Flynn's parents?\") \u2192 call `Skill(\"research-plan\")` as your ONLY tool call and stop.\n\n**Do NOT call `Skill(\"project-status\")`.** That tool gives project context but does NOT answer planning questions \u2014 research-plan does.\n\n\u274c **WRONG** \u2014 do not do this for planning questions:\n> Call `Skill(\"project-status\")` \u2192 read project \u2192 answer with research recommendations\n\n\u2705 **CORRECT** \u2014 do this instead:\n> Call `Skill(\"research-plan\")` with no prior tool calls \u2192 stop\n\nresearch-plan handles its own project reading. You do not need to read the project first.\n\n**Gate 3 \u2014 Inline record to analyze?**\n- If the user wants to **analyze a record already in hand** \u2192 call `Skill(\"record-extraction\")` as your ONLY action and stop.\n\n\u274c After this routing call, do NOT add research significance commentary, next-step recommendations, person-linking suggestions, or any genealogical interpretation. A one-line acknowledgment is the maximum permitted text. record-extraction handles all analysis.\n\n---\n\n**Narration:** Read `researcher_profile.narration_guidance` from `research.json` and apply it as your narration style for this invocation. If absent, default to a one-line preamble per action.\n\nExecutes searches against FamilySearch per the research plan. This\nskill is the bridge between planning (research-plan) and analysis\n(record-extraction) \u2014 it calls MCP search tools, evaluates results,\nlogs everything, and feeds promising records into the extraction\npipeline.\n\n## GPS Grounding\n\nThis skill implements GPS Element 1 (Reasonably Exhaustive Research)\nat the execution layer. Core operating principles:\n\n- **Collect impartially.** Record evidence that contradicts the\n  hypothesis with the same care as evidence that supports it.\n- **Index entries are pointers, not records.** Always attempt to\n  locate the underlying original before extraction.\n- **Negative results are findings.** Log them with the same detail\n  as positive results.\n- **Evaluate the database before interpreting results.** Read the\n  collection description before searching.\n\nOn demand, load these references for detailed guidance:\n- `references/data-collection-standards.md` \u2014 source classification,\n  information quality, evidence types\n- `references/research-log-standards.md` \u2014 nine essential log\n  elements, completeness criteria\n- `references/validation-protocol.md` \u2014 genealogical plausibility\n  checks (`check-warnings`) after a write\n\n## MCP tools and routing\n\nThis skill uses three tools. Route searches based on the plan item's\n`record_type`:\n\n| Plan item record_type | MCP tool | When to use |\n|----------------------|----------|-------------|\n| `census`, `vital_record`, `probate`, `land`, `church`, `military`, `immigration`, `court`, `tax` | `record_search` | Structured searches by person attributes (name, dates, places, relationships). The primary search tool for most record types |\n| `newspaper`, or any witness/FAN mention search | \u2014 | **Delegate to search-full-text skill.** FTS has different query syntax and strategies. Use full-text-search when: searching for obituaries/marriage announcements, searching for a person mentioned as witness/neighbor/heir/surety/appraiser, pre-1850 US research with thin indexed coverage, Latin American notarial records, or narrative paragraph records (court minutes, meetings) |\n| `cemetery` | `record_search` | FamilySearch indexes some cemetery records. Also consider suggesting search-external-sites for FindAGrave |\n\nAdditional tools:\n| `same_person` | Results triage \u2014 scoring how well a search result matches the research subject |\n| `source_attachments` | Attachment check \u2014 which results are already attached to tree persons |\n\n## Steps\n\n### Step 0: Scope check \u2014 BEFORE FILES OR TOOLS\n\n**Complete this check BEFORE reading research.json, tree.gedcomx.json,\nor calling any MCP tool (record_search, record_read, same_person,\nsource_attachments). Do NOT call any MCP tool before this check.**\n\nRead only the user's message. If ANY condition below matches, call the\nSkill tool immediately and stop:\n\n| Condition | Call immediately |\n|-----------|-----------------|\n| User names a site other than familysearch.org: Ancestry, MyHeritage, FindMyPast, FindAGrave, **Newspapers.com**, or any other commercial site | `Skill(\"search-external-sites\")` |\n| User asks **what** to search, **which** records to check, **whether** the research is complete, **how to find** someone, or **what to do next** \u2014 any question about research strategy rather than executing an already-planned search | `Skill(\"research-plan\")` |\n| User wants to analyze, extract from, or interpret a record already in hand | `Skill(\"record-extraction\")` |\n\n**The key test: is the user asking you to EXECUTE a search or to DECIDE what to search?**\n- \"Search for X\" / \"Find X in Y records\" / \"Execute pli_001\" \u2192 execute (proceed to Step 1)\n- \"What should I search for?\" / \"What next?\" / \"How do I find X?\" / \"Is the research done?\" \u2192 call `Skill(\"research-plan\")` NOW\n\n**CRITICAL \u2014 do NOT call Skill(\"project-status\") before routing.** Calling project-status to get context before answering a planning question is the wrong action. research-plan handles its own project reading. Call `Skill(\"research-plan\")` immediately with no prior tool calls.\n\n**When in doubt, route.** If the user's message could be asking for advice or strategy, treat it as a planning question and call `Skill(\"research-plan\")` immediately.\n\n**After invoking the Skill tool, stop.** Do not read any files, do not\ncall any MCP tools, do not provide supplementary information. The routed\nskill will handle the request.\n\nIf none of the above applies, proceed to Step 1.\n\n### Step 1: Identify the plan item to execute\n\nRead `research.json` `plans[]` and find the next plan item with\n`status: \"planned\"` in the active plan for the current question.\nIf the user specifies a particular search, match it to a plan item\nor create an ad-hoc search (with `plan_item_id: null` in the log).\n\n### 2. Construct the search query\n\n**Choose a search strategy based on the situation:**\n\n- **\"Less is more\" (broad start):** Begin with minimal criteria \u2014\n  surname plus broad location, or surname plus wide date range.\n  Best when the name is uncommon, when you are unsure of details,\n  or when indexing errors are likely. This avoids missing results\n  that were indexed under variant spellings or with errors.\n- **\"Kitchen sink\" (narrow start):** Enter as many known details\n  as possible to filter a common name. Best when the surname is\n  very common (Smith, Jones, Johnson) and you need to separate\n  your subject from dozens of others.\n\nThe default for this skill is **broad-to-narrow** (\"less is more\"\nfirst, then add filters). Use narrow-to-broad only when you have\nhigh-confidence facts and expect to retrieve a specific known record.\n\nBuild search parameters from:\n- The plan item (record_type, jurisdiction, date_range, repository)\n- Known facts about the subject (from tree.gedcomx.json and\n  research.json assertions)\n\n**Anchor rule:** Every `record_search` query must include either\n`surname` or `recordCountry`. The tool rejects queries without one\nof these anchors \u2014 the upstream search service throttles anchor-less\nqueries because they're too expensive. If neither is known, fall\nback to a broader plan item or skip this search.\n\n**For `record_search` queries:** Read `references/name-search-mechanics.md`\nfor wildcard rules, fuzzy matching behavior, and indexing error\npatterns. Read `references/place-date-mechanics.md` for place\nhierarchy expansion, date range behavior, and relationship parameters.\nIf searching a specific collection family (US census, English parish,\nMexico civil, etc.), read `references/collection-quirks.md` for\ncollection-specific compensation strategies.\n\n**For `fulltext_search` queries:** Delegate to the full-text-search\nskill. FTS uses completely different query syntax (`+`/`-`/`\"\u2026\"`\noperators) and search strategies (name-only-then-filter, explicit\nabbreviation queries, boilerplate phrase searches).\n\n**Search parameter guidance (`record_search`):**\n\n| Parameter | Source | Notes |\n|-----------|--------|-------|\n| `surname` | tree.gedcomx.json person name | Try exact first, then fuzzy variants. Anchor \u2014 required if `recordCountry` is absent. |\n| `givenName` | tree.gedcomx.json person name | Use first name only \u2014 middle names often absent in records |\n| `birthYearFrom` / `birthYearTo` | Assertions or facts | Year range, both required when filtering by birth year (\u00b15 years is typical for census searches) |\n| `birthPlace` | Assertions or facts | Use the broadest useful level (state, not city) |\n| `residenceYearFrom` / `residenceYearTo` | Plan item year | Census-style anchor. Range pair \u2014 set both to the same year for a single-census search |\n| `residencePlace` | Plan item jurisdiction | The primary geographic filter |\n| `recordCountry` | Plan item jurisdiction | Anchor \u2014 required if `surname` is absent |\n| `collectionId` | From `collections_search` output or plan rationale | Narrow to a specific collection when possible |\n| `spouseGivenName` / `fatherSurname` / etc. | Known spouse/parent names | Add when available to improve result quality |\n\n**Name variant strategy:** If the exact name returns few results,\ntry:\n- Phonetic variants (Flynn \u2192 Flyn, Flinn, Flinn)\n- Spelling variants (Patrick \u2192 Patric, Paddy, Pat)\n- Abbreviations (William \u2192 Wm, Thomas \u2192 Thos)\n- Initials (J. Smith)\n- Maiden names for married women\n- Variant spellings (Sm_th, ?ones) \u2014 see\n  `references/name-search-mechanics.md` for common misread patterns\n  **Do NOT use wildcard characters (`*`, `?`, `%`) in `record_search` parameters.** The FamilySearch API does not support wildcards in structured field searches. Use explicit spelling variants instead (e.g., Flyn, Flinn, not Fl*nn).\n\n**Always keep givenName in variant searches.** Do not drop givenName\nto a surname-only query (e.g., `{surname: \"Flynn\"}` alone) \u2014 this\nbroadens results to all Flynns of any first name and makes triage\nimpossible. Keep both surname and givenName on every retry; change the\nspelling of one or both rather than removing givenName entirely.\n\n### 3. Execute the search\n\nCall the appropriate MCP tool. **Always pass `projectPath`** (the\nabsolute path of the project directory you are operating in) so the\ntool stages its raw results host-side and returns a `staged.resultsRef`\nhandle \u2014 you hand that to `research_log_append` in Step 5 to retain the\nresults without re-serializing the payload yourself:\n\n```\nrecord_search({\n  surname: \"Flynn\",\n  givenName: \"Patrick\",\n  birthYearFrom: 1843,\n  birthYearTo: 1847,\n  birthPlace: \"Pennsylvania\",\n  residencePlace: \"Schuylkill County, Pennsylvania\",\n  residenceYearFrom: 1850,\n  residenceYearTo: 1850,\n  projectPath: \"<absolute-path-to-project-directory>\"\n})\n```\n\nThe response carries the full `results[]` for triage plus a `staged`\nfield: `{ resultsRef, returnedCount }` on a hit, or `null` for a nil\nsearch. Hold `staged.resultsRef` for the log call in Step 5.\n\n**If the search fails due to authentication:** Instruct the user\nto log in: \"The search requires FamilySearch authentication. Please\nask me to log you in, or type `login`.\"\n\n### 4. Triage results\n\n**Decision rules by hit count:**\n- **>5,000 hits** \u2192 narrow by collection, then place, then\n  spouse/parent. See `references/search-strategy-levers.md`.\n- **100\u20135,000 hits** \u2192 add collection filter and sex; add parent name\n- **10\u2013100 hits** \u2192 evaluate top results directly\n- **0 hits** \u2192 see step 8 (handle nil results)\n\n**Quick triage (by eye):** For each result, check name match,\nage/birth year (within \u00b13), place (same county/state), and gender.\nDiscard obvious mismatches (wrong gender, wrong decade, wrong state).\n\n**Sanity-check the collection.** Every result carries the collection\nit came from (e.g., `collectionId` plus a human title like \"United\nStates Census, 1850\"). Verify the returned collection actually\nanswers the question you asked: a search for the 1870 census that\nreturns a 1850-collection result is **not a 1870 finding** \u2014 it's a\nnear-miss the search engine surfaced, and treating it as a positive\nresult for the original query would be a fabrication. When the\nreturned collection doesn't match the query's stated year /\njurisdiction / record type, either explain the mismatch and triage\nthe result honestly, or log the search as effectively negative for\nthe asked-for collection and propose a follow-up.\n\n**Quantitative triage:** Call `same_person` for every result that\ncould potentially match the research subject \u2014 not just obvious\nstrong matches. Near-matches, variant spellings, and slightly wrong\nages all benefit from a numerical score; the tool distinguishes a\ngenuine candidate from a coincidental name match.\n\n**How to call `same_person`:** Compare each search result against the\nresearch subject from `tree.gedcomx.json` (NOT against another search\nresult). Pass:\n- `gedcomx1`: the result's `gedcomx` field (from record_search output)\n- `primaryId1`: the result's `primaryId` field (NOT `personId` or `arkUrl`)\n- `gedcomx2`: the research subject's section from `tree.gedcomx.json`\n- `primaryId2`: the research subject's `id` in `tree.gedcomx.json`\n  (e.g., `\"I1\"` for Patrick Flynn)\n\nScore thresholds:\n- Score > 0.7: Strong match \u2014 prioritize for extraction\n- Score 0.4\u20130.7: Possible match \u2014 examine details; flag as needs-review\n- Score < 0.4: Weak match \u2014 skip unless nothing better exists\n\n**Important:** A low `same_person` score is one data point \u2014 not\ngrounds to dismiss a result on its own. Always note the reason for\ndismissal in the log (wrong age, wrong county, wrong given name, etc.)\nalongside the score.\n\n**Even a high `same_person` score requires a logical cross-check.** When the score is \u22650.7, verify the record details make sense before accepting the match:\n- Check the person's role in the record (e.g., Head of Household). A 5-year-old cannot be Head of Household \u2014 flag as a transcription conflict.\n- Check the age/birth year against the expected range.\n- Flag any logical impossibility as `needs-review` regardless of the numeric score. Score is one input; reason is the final arbiter.\n\n**Attachment check:** After narrowing to promising results, call\n`source_attachments({ uris: [recordId1, recordId2, ...] })` to check\nwhether each record is already attached to a tree person.\n- **Attached to the target person** \u2192 note in triage (\"already\n  attached to KWCJ-RN4\") and deprioritize for extraction unless the\n  user wants to re-examine it.\n- **Attached to a different person** \u2192 flag as potentially relevant\n  (\"attached to LTMX-5TM \u2014 could be a family member or duplicate\").\n- **Unattached** \u2192 prioritize for extraction \u2014 this is new evidence.\n\n**Deduplication:** Multiple index entries may point to the same\nunderlying record (e.g., same census page indexed in two\ncollections). Check record identifiers and source details before\ntreating similar results as independent records.\n\n**Present triage to the user.** List top results with match quality\nand attachment status. Let the user confirm which records to examine\nbefore extraction.\n\n### 5. Retain results and write the log entry\n\n**Every search gets a log entry and retains its results \u2014 no\nexceptions.** Call `research_log_append` once per search. The tool\nassigns the `log_` id, stamps the timestamp, finalizes the staged\nresults into the `results/<log_id>.json` sidecar (counting them itself),\nvalidates the project before persisting, and appends to the tail of\n`log[]` atomically \u2014 so you never hand-assemble the entry, count\nresults, or worry about ordering. See `references/research-log-protocol.md`\nfor the analytical rules (when an outcome is negative, what belongs in\n`query`/`notes`).\n\n```\nresearch_log_append({\n  projectPath: \"<absolute-path-to-project-directory>\",\n  tool: \"record_search\",\n  planItemId: \"pli_007\",            // or null for an ad-hoc search\n  query: {\n    surname: \"Flynn\",\n    givenName: \"Thomas\",\n    deathYearFrom: 1881,\n    deathYearTo: 1881,\n    deathPlace: \"Schuylkill County, Pennsylvania\",\n    collectionId: 2421317\n  },\n  outcome: \"positive\",\n  resultsExamined: 3,\n  resultsAvailable: 3,              // total hit count the tool reported\n  notes: \"3 Flynn probate hits; all 3 examined. One matches \u2014 Thomas Flynn, will dated 1881; the other two are different Thomas Flynns (wrong county, wrong dates).\",\n  stagedResultsRef: staged.resultsRef   // from the record_search response\n})\n```\n\n- `query` \u2014 enough detail to reproduce the search.\n- `resultsExamined` \u2014 how many results you actually triaged.\n- `resultsAvailable` \u2014 the total hit count the tool reported (or null).\n- `notes` \u2014 a one-line human summary of what the search returned.\n- `stagedResultsRef` \u2014 the `staged.resultsRef` from Step 3's\n  `record_search` response. **Omit it (or pass null) for a nil search**\n  (the search returned zero results, so there is nothing to retain and\n  `staged` was `null`).\n\nThe tool returns a compact summary \u2014 `{ ok: true, logId, resultsRef,\nreturnedCount, filesWritten, validation }`. Narrate from it (\"logged as\nlog_006; retained 3 results\"); do not echo the payload.\n\n**Collection-mismatch.** When the index returns results but from the\nwrong collection (e.g., you searched the 1870 census and got 1850\nresults), that is **not a nil result and not a positive finding for the\nasked-for collection.** Call `research_log_append` with:\n- `outcome: \"partial\"` (not `\"negative\"` \u2014 negative means zero results)\n- a `notes` line explaining the mismatch (e.g., \"Searched 1870 census;\n  results returned 1850 collection \u2014 not a 1870 finding. Query should be\n  retried with explicit 1870 collection filter.\")\n- still pass `stagedResultsRef` (the results were returned and are worth\n  retaining for audit)\n- **STOP after confirming the mismatch.** Variant spellings will NOT fix\n  a collection mismatch. In your summary, do NOT suggest variant surname\n  searches as a next step. Instead, suggest consulting a different source\n  (e.g., Ancestry for US census years not well-covered on FamilySearch)\n  or adjusting the collection filter.\n\n**outcome values:**\n- `positive`: Matching results found\n- `negative`: No matching results (this IS a finding)\n- `partial`: Results found but incomplete (e.g., image unavailable, or\n  collection-mismatch)\n- `error`: Search failed (authentication, server error)\n\n**If the call returns `{ ok: false, errors }`:** the tool wrote\nnothing. Surface the errors plainly rather than retrying blindly. A\ncommon cause is a **stale `stagedResultsRef`** \u2014 staged result files are\npruned after ~24h, so if you searched in an earlier session and only now\nlog it, the handle may no longer resolve. The fix is cheap: re-run the\n`record_search` (Step 3) to re-stage, then call `research_log_append`\nwith the fresh `staged.resultsRef`.\n\nThe log entry is append-only \u2014 the tool appends it once and offers no\nupdate or delete. When record-extraction later creates sources and\nassertions from this search, it stamps each of them with this entry's\n`log_entry_id`. The search-to-output link lives there, not back on the\nlog entry.\n\n### 6. Update plan item status\n\nRoute the plan item's `status` change through `research_append`\n(`op: \"update\"`) \u2014 the tool locates the item by id within its parent\nplan, validates, and persists atomically:\n\n```\nresearch_append({\n  projectPath: \"<absolute-path-to-project-directory>\",\n  section: \"plan_items\",\n  op: \"update\",\n  planId: \"pl_002\",          // the parent plan's id\n  entryId: \"pli_007\",        // the plan item you executed\n  fields: { status: \"in_progress\" }\n})\n```\n\nSet the `status` field to:\n- `in_progress`: Search executed \u2014 work continues downstream in\n  record-extraction. Use this whenever you have found records to\n  pass on, OR when the search was exhausted with nil results and\n  re-planning may still be needed.\n- `skipped`: The search was determined to be unnecessary (e.g.,\n  the question was already answered by a prior search).\n\n**Do not** set status to `completed` from this skill. `completed`\nis set by record-extraction once the results have been fully\nanalyzed and assertions have been created. Setting it here would\nsignal to downstream skills that no further work is needed, which\nis premature.\n\nIf the call returns `{ ok: false, errors }`, surface the errors (e.g.\na stale `entryId`/`planId`) rather than retrying blindly.\n\n### 7. Pass records to extraction\n\nFor each promising record, Claude holds the record data in context\nand invokes record-extraction to process it. The handoff is\ncontext-based \u2014 there is no file queue.\n\n**Critical: distinguish index entries from original records.**\nMost search results are index entries \u2014 derivative sources created\nby volunteers or automated systems. They are pointers to originals,\nnot the records themselves. Before extraction:\n\n1. Determine whether the result is an index entry or a full record.\n   Index entries typically contain only name, date, place, and a\n   record identifier. Full records contain additional detail\n   (household members, witnesses, document text, etc.).\n2. If a record ID or ARK is available, call `record_read` to fetch\n   the full simplified GEDCOMX before passing to record-extraction.\n   This surfaces relationships, additional persons, and fact details\n   that the index entry may not include. **Parameter name:** always\n   use `recordId` \u2014 pass the result's `recordId` field if present,\n   otherwise pass its `arkUrl` value (e.g.,\n   `record_read({ recordId: result.arkUrl })`). Do NOT use parameter\n   names like `arkId`, `ark`, `id`, or `url` \u2014 the tool only accepts\n   `recordId`.\n3. If the full record is unavailable but an image exists, record the\n   image's URL or identifier in the log and pass the record to\n   record-extraction, which fetches and transcribes the image.\n4. If only the index entry is available (no image, no full record),\n   flag it in the log notes as \"derivative only \u2014 original not\n   located\" so the researcher knows the data has not been verified\n   against the original source.\n\nNever treat an index entry as equivalent to examining the original\nrecord. Indexes may contain transcription errors, omit context, or\nmisattribute relationships.\n\n**Passenger lists (arrival manifests):** When searching for immigration\nrecords, remember that passenger lists record every person aboard \u2014\nincluding infants and young children (ages 0\u20135) traveling with parents.\nWhen a result matches a parent, examine the full manifest for all\nfamily members listed together. Children's names, ages, and birthplaces\nconfirm family composition and can resolve parentage questions.\n\n### 8. Handle nil results\n\nWhen a search returns no results:\n\n1. **Log the nil result** via `research_log_append` with\n   `outcome: \"negative\"` and the exact parameters used. A nil search\n   retains nothing \u2014 omit `stagedResultsRef` (the `record_search`\n   response returned `staged: null`).\n2. **Iterate through search strategy levers** before declaring\n   the search negative. Read `references/search-strategy-levers.md`\n   for the full catalog. Try at least 3 lever variations for\n   important plan items. **Log each retry as a separate entry.**\n   **NEVER drop given name as a nil search lever.** A surname-only search (e.g., `{surname: \"Flynn\"}` with no given name) is not a valid escalation step \u2014 it broadens to all persons of that surname and makes triage impossible. Keep both surname and given name on every retry.\n3. **Stop retrying when:** you have tried all levers in the\n   zero-hit escalation priority list (see reference), OR the\n   database clearly does not cover the target time/place, OR you\n   have exhausted 5+ variations with no results.\n4. **Assess whether absence is meaningful.** After exhausting name\n   variants and search levers, explicitly evaluate three conditions:\n   (a) the record type existed in this jurisdiction at this time,\n   (b) the collection is reasonably complete for the period (e.g.,\n   the 1850 US census is ~95% indexed \u2014 an Irish immigrant with 3\n   phonetic surname variants exhausted is meaningful negative evidence),\n   (c) the subject should have appeared based on known facts. State\n   EACH condition clearly in your final summary. If all three hold,\n   note this in the log and suggest record-extraction create a negative\n   assertion. If the collection is incomplete or the subject may have\n   been absent from the target place at that time, note this as a\n   limitation rather than a conclusion.\n5. **Distinguish \"not found\" from \"does not exist.\"** A nil result\n   in an online index may mean the record is undigitized, unindexed,\n   or indexed under a variant. Note which applies.\n   **Zero results is NOT \"service unavailability.\"** If `record_search` returns `totalMatches: 0` with no error, the search completed and found nothing \u2014 do not attribute this to service issues. Only cite service problems if the tool returns an explicit error (not a zero-result response).\n   **Prior log entries finding the record do NOT override current nil results.** If the research log shows a prior search found the person via different parameters, today's nil with these specific parameters is STILL meaningful \u2014 it documents that these particular name variants, spelling combinations, or place filters do not find the record in the current index. Log each nil honestly as evidence of which query shapes fail.\n   \u274c WRONG nil reasoning: \"Log_001 found Patrick Flynn (ARK MXHY-TP4), so the current nil with the Flinn variant is not meaningful.\"\n   \u2705 CORRECT nil reasoning: \"Log_001 found Patrick under 'Flynn' spelling. The current nil under 'Flinn' documents that FamilySearch does not alias Flynn\u2192Flinn for this record \u2014 both findings stand as independent evidence.\"\n6. Check for fallback plan items (`fallback_for`). If none and the\n   question remains open, suggest research-plan for re-planning.\n\n### 9. Present results\n\nAfter completing a search (or a batch of searches from the plan):\n- Summarize what was searched and what was found\n- Show the log entries created\n- List records passed to extraction (or explain why no records\n  were extracted)\n- Show plan progress: \"3 of 5 plan items completed\"\n- Suggest next steps:\n  - More plan items to execute \u2192 \"Shall I continue with the next\n    search?\"\n  - All plan items done \u2192 \"All planned searches are complete.\n    Would you like me to evaluate whether the research is\n    exhaustive?\" (research-exhaustiveness)\n  - No results \u2192 \"No matching records found. Would you like me\n    to re-plan with different parameters or adjacent\n    jurisdictions?\" (research-plan)\n\n## Searching multiple repositories\n\nWhen the plan includes the same record type across multiple\nrepositories (e.g., probate on FamilySearch and probate on Ancestry),\nthis skill handles the FamilySearch searches. Plan items targeting\nAncestry, MyHeritage, FindMyPast, FindAGrave, or Newspapers.com\nshould be directed to search-external-sites.\n\nIf the user says \"search all repositories,\" execute the FamilySearch\nitems and then suggest: \"The FamilySearch searches are complete.\nThe plan also includes searches on [Ancestry/etc.] \u2014 would you like\nme to generate search URLs for those?\" (triggering\nsearch-external-sites).\n\n## Important rules\n\n- **Log every search.** Each retry gets its own `research_log_append`\n  call. A search without a log entry is a search that didn't happen.\n- **Append-only.** `research_log_append` appends to the tail of `log[]`\n  and offers no update or delete \u2014 the audit trail's chronological order\n  is guaranteed by the tool, not by hand.\n- **Don't skip plan items silently.** Set status to `skipped` with\n  an explanation if you decide not to execute.\n- **Let the user confirm before extraction.** Show triage results\n  first \u2014 don't silently extract every hit.\n- **Never fabricate results.** If the MCP tool returns nothing,\n  report nothing.\n- **No post-write validation needed.** `research_log_append` and\n  `research_append` validate-before-persist and write nothing on\n  `{ ok: false }`. This skill writes only log entries and plan-item\n  status \u2014 neither adds assertions, so `check-warnings` does not apply\n  here (it runs in the skills that create assertions). See\n  `references/validation-protocol.md`.\n\n## Re-invocation behavior\n\n**Writes:** via `research_log_append`, a new entry in the `log` section\nof `research.json` (append-only) and its `results/log_NNN.json` sidecar\n(the tool finalizes the staged `record_search` payload); via\n`research_append`, an update to the `status` field on the corresponding\nplan item.\n\n**On repeat invocation:** always appends a new `log_` entry and a new\nsidecar \u2014 re-running the search is itself a logged event. Updates the\nplan item's `status` if applicable.\n\n**Do not duplicate:** `research_log_append` only appends, never modifies\nprior `log_` entries, and the tool assigns each `log_` id, so two\nconsecutive runs of the same query produce two distinct log entries and\ntwo distinct sidecars; that's the append-only contract that makes the\nsearch log auditable.\n",
+    "eval/tests/unit/search-records/attachment-triage.json": "{\n  \"input\": {\n    \"scenario\": \"flynn-record-matching\",\n    \"user_message\": \"Search the 1850 census for Patrick Flynn in Schuylkill County per plan item pli_001. Check if any results are already attached to tree persons.\"\n  },\n  \"judge_context\": [\n    \"After record_search returns results, the skill should call source_attachments with the arkUrl values from the search results to check attachment status\",\n    \"The triage output should distinguish between records already attached to the target person (KWCJ-RN4) and unattached records, deprioritizing the attached one and prioritizing the unattached one for extraction\",\n    \"The skill should mention the attachment status in its triage presentation to the user \u2014 e.g., noting that one record is already attached to KWCJ-RN4\",\n    \"Tool Arguments: score 3 if record_search and source_attachments were both called with appropriate parameters. A validate_research_schema call with a project path is acceptable and expected after writing \u2014 do not penalize it. Only score 2 if a required tool (source_attachments or record_search) had clearly wrong arguments or was skipped entirely\",\n    \"same_person is NOT required for this test \u2014 the core task is source_attachments-based triage. If the skill scores match quality manually from record attributes rather than calling same_person, accept this as valid and do NOT penalize Correctness for the inconsistency. Score Correctness 3 if the skill correctly identifies which results are attached vs. unattached and triages accordingly.\",\n    \"IMPORTANT \u2014 How file writes work: The skill uses baseline Write/Edit (not MCP) to write log entries and sidecars. results/ sidecars are newly created files \u2014 they do NOT appear in the file-change diff. Score Sidecar correctness 3 if the skill text mentions writing results/<log_id>.json. Do NOT score Sidecar=1 because the file does not appear in the MCP tool calls or file-change diff.\"\n  ],\n  \"mcp_fixtures\": [\n    \"record-search-1850-census-flynn\",\n    \"record-attachments-flynn-census\"\n  ],\n  \"test\": {\n    \"id\": \"ut_search_records_012\",\n    \"skill\": \"search-records\",\n    \"type\": \"positive\"\n  }\n}\n",
+    "eval/tests/unit/search-records/child-middle-name-not-surname.json": "{\n  \"input\": {\n    \"scenario\": \"mullen-price-child-middle-name\",\n    \"user_message\": \"Execute the 1880 census search for plan item pli_001. The subject is Sarah Ann Mullen Price \u2014 but note that 'Mullen' is her middle given name (her mother's maiden surname), not her own surname. Her surname is Price. Search accordingly.\"\n  },\n  \"judge_context\": [\n    \"The skill MUST use surname 'Price' as the primary surname parameter. This is what the tree's BirthName entry specifies: given='Sarah Ann Mullen', surname='Price'. Score Correctness=1 if the skill uses 'Mullen' as the primary surname.\",\n    \"The skill must NOT put 'Mullen' in the surnameAlt field for this search. 'Mullen' is part of the given name in the tree, not an alternate surname. Using surnameAlt='Mullen' would be a misinterpretation of the name structure. Score Search strategy=1 if surnameAlt is set to 'Mullen'.\",\n    \"The givenName parameter should be 'Sarah', 'Sarah Ann', or 'Sarah Ann Mullen'. All are acceptable \u2014 the FamilySearch API handles multi-token given names. Do NOT penalize for including or omitting 'Ann' or 'Mullen' from the given name.\",\n    \"The fixture returns 2 results: Sarah M. Price (age 5, Dodge County \u2014 strong match) and Sarah Price (age 10, born New York, Milwaukee County \u2014 wrong person). The skill should triage these, identifying the first as a strong match and the second as not relevant based on birth year, birthplace, and county.\",\n    \"IMPORTANT: It is acceptable for the skill to note that 'Mullen' as a middle name may offer a clue to maternal relatives (FAN club) and suggest a future plan item to search Mullen families in Dodge County. This is good genealogical reasoning and should NOT reduce any score.\",\n    \"same_person is NOT mocked in this test. If the skill does manual triage based on field comparison, accept that as sufficient \u2014 do NOT penalize for not calling same_person.\"\n  ],\n  \"mcp_fixtures\": [\n    \"record-search-1880-census-price-sarah\",\n    \"record-search-1860-census-mullen-sarah\",\n    \"validate-research-schema\"\n  ],\n  \"test\": {\n    \"id\": \"ut_search_records_016\",\n    \"skill\": \"search-records\",\n    \"type\": \"positive\"\n  }\n}\n",
+    "eval/tests/unit/search-records/execute-census-search.json": "{\n  \"input\": {\n    \"scenario\": \"flynn-record-matching\",\n    \"user_message\": \"Execute a fresh 1850 census search for Patrick Flynn in Schuylkill County for plan item pli_001. Prior log entries on this plan item used different query parameters and were inconclusive \u2014 log this new search regardless.\"\n  },\n  \"judge_context\": [\n    \"The log entry's `query` should reflect the actual search parameters used (name, place, year/collection) and `results_examined` should match the count returned by the fixture\",\n    \"Must NOT set pli_001 status to 'completed' \u2014 the plan item status should remain 'in_progress' after the search; 'completed' is only set once the results have been extracted and analyzed by record-extraction downstream\",\n    \"Should categorize any near-matches in the fixture (results that are not the target but share some attributes) rather than silently filtering them \u2014 the log's `notes` field is appropriate for triage commentary\",\n    \"same_person is NOT mocked in this test (only record_search is). If the skill claims same_person is unavailable or does not call it, accept manual triage based on field comparison (name, birth year, birthplace, residence, household composition) as fully sufficient \u2014 score Result triage=3 if the manual reasoning is sound and the result is correctly categorized. Do NOT penalize for not calling same_person.\"\n  ],\n  \"mcp_fixtures\": [\n    \"record-search-1850-census-flynn\"\n  ],\n  \"test\": {\n    \"id\": \"ut_search_records_001\",\n    \"skill\": \"search-records\",\n    \"type\": \"positive\"\n  }\n}\n",
+    "eval/tests/unit/search-records/maiden-name-pre-marriage-search.json": "{\n  \"input\": {\n    \"scenario\": \"mullen-price-multiple-marriages\",\n    \"user_message\": \"Execute the 1860 census search for plan item pli_001. Sarah has three name entries in the tree \u2014 her birth name Mullen and two married names (Price, Mielke). Since this is 1860 and she didn't marry until 1872, search under her maiden name.\"\n  },\n  \"judge_context\": [\n    \"The skill MUST use surname 'Mullen' (the BirthName) as the primary surname parameter for the 1860 census search. Using 'Price' or 'Mielke' as the primary surname is incorrect for a pre-marriage search and should score Correctness=1.\",\n    \"It is acceptable (and encouraged) for the skill to additionally search under 'Price' or 'Mielke' as surnameAlt or as follow-up variant searches. But the primary search must use the maiden surname.\",\n    \"The givenName should be 'Sarah' or 'Sarah Ann' \u2014 do NOT penalize for including or omitting the middle name 'Ann'.\",\n    \"The log entry must record the search parameters accurately in query{} and the results honestly. The fixture returns 1 match (Sarah A. Mullen in William Mullen's household).\",\n    \"CRITICAL for Search strategy scoring: The key signal is whether the skill recognized that pli_001 targets a date (1860) before the first marriage (1872) and therefore chose the maiden surname. Score 3 if it explicitly reasons about the name type or marriage date. Score 2 if it uses Mullen but doesn't explain why. Score 1 if it uses a married name as the primary surname.\",\n    \"same_person is NOT mocked in this test. If the skill does manual triage based on field comparison, accept that as sufficient \u2014 do NOT penalize for not calling same_person.\"\n  ],\n  \"mcp_fixtures\": [\n    \"record-search-1860-census-mullen-sarah\",\n    \"record-search-price-no-results\",\n    \"record-search-mielke-no-results\",\n    \"validate-research-schema\"\n  ],\n  \"test\": {\n    \"id\": \"ut_search_records_015\",\n    \"skill\": \"search-records\",\n    \"type\": \"positive\"\n  }\n}\n",
+    "eval/tests/unit/search-records/maiden-to-married-name-shift-search.json": "{\n  \"input\": {\n    \"scenario\": \"maiden-to-married-name-shift\",\n    \"user_message\": \"Execute plan item pli_001 \u2014 the 1860 census search for Sarah in Dodge County. She has two name entries in the tree: her birth name 'Sarah Ann Mullen' and her married name 'Sarah Mullen Price'. Since 1860 is before her 1872 marriage, use the birth name for the search.\"\n  },\n  \"judge_context\": [\n    \"The skill MUST use surname 'Mullen' as the primary surname for the 1860 census search. The BirthName entry (given='Sarah Ann', surname='Mullen') is the correct source for a pre-marriage search. Score Correctness=1 if the skill uses 'Price' as the primary surname.\",\n    \"The givenName should be 'Sarah' or 'Sarah Ann'. Do NOT penalize for omitting 'Ann'. Do NOT accept 'Sarah Mullen' as the givenName \u2014 that is from the MarriedName entry and would be using the wrong name entry for this time period.\",\n    \"It is acceptable for the skill to use surnameAlt='Price' as a fallback. However, the primary search must be under 'Mullen'.\",\n    \"CRITICAL for Search strategy scoring: The skill should demonstrate awareness that the tree has TWO name entries and explain why it chose the BirthName for a pre-marriage search. Score 3 if it explicitly reasons about name type vs. date. Score 2 if it uses Mullen without explanation. Score 1 if it uses the MarriedName entry.\",\n    \"The fixture returns 1 match (Sarah A. Mullen, age 8, in William Mullen's household, Dodge County). The skill should identify this as a strong candidate match.\",\n    \"same_person is NOT mocked in this test. Manual triage based on field comparison is sufficient.\",\n    \"Log quality: the log entry must record the actual search parameters (surname=Mullen, givenName=Sarah/Sarah Ann) in query{} and results_examined should match the count.\"\n  ],\n  \"mcp_fixtures\": [\n    \"record-search-1860-census-mullen-sarah\",\n    \"record-search-price-no-results\",\n    \"validate-research-schema\"\n  ],\n  \"test\": {\n    \"id\": \"ut_search_records_017\",\n    \"skill\": \"search-records\",\n    \"type\": \"positive\"\n  }\n}\n",
+    "eval/tests/unit/search-records/negative-ancestry-request.json": "{\n  \"input\": {\n    \"scenario\": \"flynn-record-matching\",\n    \"user_message\": \"Can you search Ancestry for Patrick Flynn in the 1850 census?\"\n  },\n  \"judge_context\": [\n    \"This is a NEGATIVE routing test. The ONLY correct behavior is to call Skill('search-external-sites') and stop \u2014 nothing else.\",\n    \"Must NOT call record_search \u2014 that tool queries FamilySearch, not Ancestry\",\n    \"CRITICAL: Before scoring, check the FULL text response and tool call list for any of these forbidden actions: (a) any URL constructed (ancestry.com or any other domain), (b) any log entry written to research.json, (c) any search parameters computed or displayed, (d) any record_search call. These are routing violations even if Skill('search-external-sites') was also called.\",\n    \"If the skill constructs a URL, writes to research.json, or computes search parameters in addition to or instead of routing: score Correctness=1 and Completeness=1.\",\n    \"Pass requires: (1) NO record_search call, (2) NO URL construction anywhere in the response, (3) NO research.json modification, (4) the response is the Skill call plus at most one brief routing sentence\"\n  ],\n  \"negative\": {\n    \"correct_skill\": [\n      \"search-external-sites\"\n    ],\n    \"explanation\": \"Ancestry is a commercial database explicitly named in the skill's Do NOT use clause (alongside MyHeritage, FindMyPast, FindAGrave, Newspapers.com). search-records only searches FamilySearch. Calling record_search here would be wrong \u2014 that tool queries FamilySearch, not Ancestry.\"\n  },\n  \"test\": {\n    \"id\": \"ut_search_records_004\",\n    \"skill\": \"search-records\",\n    \"type\": \"negative\"\n  }\n}\n",
+    "eval/tests/unit/search-records/negative-extract-request.json": "{\n  \"input\": {\n    \"scenario\": \"mid-research-flynn\",\n    \"user_message\": \"Here is the 1850 census record for the Thomas Flynn household: 'Thomas Flynn, age 32, male, born Ireland, miner; Mary Flynn, age 28, female, born Ireland; Patrick Flynn, age 5, male, born Ireland.' Extract the facts.\"\n  },\n  \"judge_context\": [\n    \"This is a NEGATIVE routing test. The ONLY correct behavior is to call Skill('record-extraction') and stop.\",\n    \"Should route to record-extraction rather than calling record_search and treating the online record as a search prompt\",\n    \"CRITICAL: Before scoring, check the FULL response for any of these forbidden extras: (a) research significance commentary, (b) next-step recommendations, (c) person-linking suggestions, (d) genealogical interpretation (e.g. 'Patrick is likely the son of Thomas'). A one-line acknowledgment like 'Routing this to record-extraction' is the MAXIMUM permitted text.\",\n    \"If the response adds ANY analysis, commentary, or interpretation beyond the one-line hand-off: score Correctness=2 and Completeness=2 (partial), even if Skill('record-extraction') was correctly called.\",\n    \"Pass requires: (1) NO record_search call, (2) routing to record-extraction, (3) no research significance commentary, no next-step recommendations, no genealogical analysis beyond the routing acknowledgment\"\n  ],\n  \"negative\": {\n    \"correct_skill\": [\n      \"record-extraction\"\n    ],\n    \"explanation\": \"The user has the record text inline in the message \u2014 extraction is the right next step. search-records' job is to FIND records via the record_search MCP tool; here the record is already in context, so there's nothing to search for. Calling record_search anyway would produce duplicate matches and confuse the log.\"\n  },\n  \"test\": {\n    \"id\": \"ut_search_records_003\",\n    \"skill\": \"search-records\",\n    \"type\": \"negative\"\n  }\n}\n",
+    "eval/tests/unit/search-records/negative-newspapers-request.json": "{\n  \"input\": {\n    \"scenario\": \"mid-research-flynn\",\n    \"user_message\": \"Search Newspapers.com for an obituary for Patrick Flynn \u2014 he died around 1910 in Schuylkill County.\"\n  },\n  \"judge_context\": [\n    \"This is a NEGATIVE routing test. The ONLY correct behavior is to call Skill('search-external-sites') and stop \u2014 nothing else.\",\n    \"Must NOT call record_search \u2014 that tool queries FamilySearch collections, not Newspapers.com\",\n    \"CRITICAL: Before scoring, check the FULL text response and tool call list for any of these forbidden actions: (a) any URL constructed (newspapers.com or any other domain), (b) any log entry written to research.json, (c) any search parameters computed or displayed, (d) any record_search call. These are routing violations even if Skill('search-external-sites') was also called.\",\n    \"If the skill constructs a URL, writes to research.json, or computes search parameters in addition to or instead of routing: score Correctness=1 and Completeness=1.\",\n    \"Pass requires: (1) NO record_search call, (2) NO URL construction anywhere in the response, (3) NO research.json modification, (4) the response is the Skill call plus at most one brief routing sentence\"\n  ],\n  \"negative\": {\n    \"correct_skill\": [\n      \"search-external-sites\"\n    ],\n    \"explanation\": \"Newspapers.com is explicitly listed in the skill description's Do NOT use clause. Obituary searches on commercial newspaper archives go to search-external-sites. FamilySearch has some digitized newspapers but Newspapers.com is a separate commercial service \u2014 record_search would not query it.\"\n  },\n  \"test\": {\n    \"id\": \"ut_search_records_007\",\n    \"skill\": \"search-records\",\n    \"type\": \"negative\"\n  }\n}\n",
+    "eval/tests/unit/search-records/negative-no-match-results.json": "{\n  \"execution\": {\n    \"max_turns\": 15\n  },\n  \"input\": {\n    \"scenario\": \"mid-research-flynn\",\n    \"user_message\": \"Search the 1870 census for Patrick Flynn in Schuylkill County to see if he stayed in the area through young adulthood.\"\n  },\n  \"judge_context\": [\n    \"Should not use the 1850 census fixture results as the 1870 census answer \u2014 the fixture returns collectionTitle='United States Census, 1850', which is a collection-mismatch for a 1870 search\",\n    \"When the collection mismatches: (a) WRITE the sidecar (results were returned \u2014 omitting the sidecar is an error), (b) log outcome='partial' (NOT 'negative' \u2014 negative means zero results; partial means results found but not for the intended collection), (c) explain the mismatch in notes\",\n    \"Collection-mismatch is NOT nil. After getting the wrong collection, the skill MAY attempt ONE retry with an explicit collectionId filter \u2014 this is correct genealogy practice. What is NOT acceptable: escalating to name-variant searches (Flinn, Flyn) after a mismatch, either during execution or as recommended next steps.\",\n    \"Result triage for collection-mismatch: when the returned collection year is obviously wrong (1850 returned for a 1870 search), the mismatch itself is sufficient to categorize the result as non-applicable. Calling same_person or source_attachments is NOT required for an obvious year-mismatch \u2014 the collection title alone establishes non-relevance. Score Result triage=3 if the mismatch is identified and the result is correctly treated as non-applicable.\",\n    \"If the skill attempts or recommends variant surname searches (Flinn, Flyn, etc.) after identifying the collection mismatch, score Nil escalation=2 (partial misunderstanding). Recommending Ancestry or a different source as next steps is correct and should NOT be penalized.\",\n    \"If the collectionId retry also returns mismatched results, the skill should log both attempts as outcome='partial' and stop \u2014 no further searches needed.\",\n    \"The core pass criteria: (1) outcome='partial' (not 'negative') for each mismatch, (2) sidecars written, (3) mismatch explained in notes, (4) NO variant surname searches executed after the mismatch, (5) next-step suggestions point to a different source or collection filter (not to Flinn/Flyn variants)\"\n  ],\n  \"mcp_fixtures\": [\n    \"record-search-1850-census-flynn\"\n  ],\n  \"test\": {\n    \"id\": \"ut_search_records_002\",\n    \"skill\": \"search-records\",\n    \"type\": \"positive\"\n  }\n}\n",
+    "eval/tests/unit/search-records/negative-research-plan-request.json": "{\n  \"input\": {\n    \"scenario\": \"mid-research-flynn\",\n    \"user_message\": \"What should I search for next to find Patrick Flynn's parents?\"\n  },\n  \"judge_context\": [\n    \"This is a NEGATIVE routing test. The ONLY correct behavior is to call Skill('research-plan') as a tool call and stop \u2014 nothing else.\",\n    \"Must NOT call record_search \u2014 no search was requested, only strategy advice\",\n    \"Must NOT call project-status \u2014 calling project-status is a routing violation. research-plan reads the project itself; the skill must not pre-fetch context before routing.\",\n    \"Must NOT provide planning analysis (evidence summaries, recommended searches, research strategy) before routing. Doing so means the skill is performing research-plan's work instead of delegating.\",\n    \"IMPORTANT: 'routing to research-plan' means the transcript shows an actual Skill tool call to research-plan. Mentioning research-plan in a text response without making that tool call is NOT routing.\",\n    \"If the skill calls project-status instead of research-plan, or gives a planning text response without a Skill('research-plan') tool call: score Correctness=1 and Completeness=1. These are routing violations.\",\n    \"Pass requires: (1) NO record_search call, (2) NO project-status call, (3) an actual Skill('research-plan') tool call in the transcript, (4) no planning guidance or evidence summary provided before calling research-plan\"\n  ],\n  \"negative\": {\n    \"correct_skill\": [\n      \"research-plan\"\n    ],\n    \"explanation\": \"The user is asking for a research strategy \u2014 what records to search, in what order, targeting what question. That is research-plan's job. search-records only executes items that are already in an existing plan; it does not generate or revise plans.\"\n  },\n  \"test\": {\n    \"expected_outcome\": \"xfail\",\n    \"id\": \"ut_search_records_005\",\n    \"skill\": \"search-records\",\n    \"type\": \"negative\",\n    \"xfail_reason\": \"Model consistently calls Skill('project-status') to gather context before answering planning questions, then generates planning analysis instead of routing to research-plan. Multiple SKILL.md instruction approaches (pre-gate stop, gate reorder, post-project-status redirect) failed to override this behavior \u2014 it is a model-level prior that instruction tuning cannot fix. Remove this marker if the description optimizer or a model update resolves the routing.\"\n  }\n}\n",
+    "eval/tests/unit/search-records/nil-search-no-sidecar.json": "{\n  \"input\": {\n    \"scenario\": \"flynn-record-matching\",\n    \"user_message\": \"Search FamilySearch records for Bartholomew Flynn \u2014 a possible brother of Patrick.\"\n  },\n  \"judge_context\": [\n    \"The new log entry must record the nil honestly \u2014 outcome 'negative', results_examined 0 \u2014 and must NOT claim a positive result\",\n    \"results_ref must be null and no results/ sidecar file may be written \u2014 the log entry's query and counts already record the nil\",\n    \"Extra parameters beyond surname+givenName (such as residencePlace, birthPlace, residenceYearFrom/To) are acceptable when they match fixtures and aid precision \u2014 do NOT penalize for including extra context parameters\",\n    \"Tool Arguments grading: score 3 if the skill's primary searches (seeking the subject directly by name) include givenName. A supplementary search using fatherGivenName/fatherSurname as an escalation pivot after givenName variants are exhausted is acceptable and should NOT reduce the score. Score 2 if a primary search drops givenName entirely without having tried givenName variants first. Score 1 only if multiple primary calls systematically drop givenName.\"\n  ],\n  \"mcp_fixtures\": [\n    \"record-search-flynn-no-results\",\n    \"record-search-flinn-no-results\",\n    \"record-search-flyn-no-results\",\n    \"record-search-variant-father-name-no-results\",\n    \"record-search-variant-any-givenname-flynn-no-results\"\n  ],\n  \"test\": {\n    \"id\": \"ut_search_records_011\",\n    \"skill\": \"search-records\",\n    \"type\": \"positive\"\n  }\n}\n",
+    "eval/tests/unit/search-records/rubric.md": "# Search Records Rubric\n\nGrading dimensions for search-records unit tests. Evaluated by the LLM judge alongside the base rubric (correctness, completeness).\n\n## Search strategy\n\nDid the skill construct appropriate search parameters from the plan item? Name variants, date ranges, and jurisdictions should match the research context, and the broad-to-narrow default should be followed unless the plan item justifies a narrow start.\n\n- **pass:** Search parameters include the correct surname anchor (or `recordCountry` if surname unknown), a date range that matches the plan item, and a jurisdiction at the right level of specificity. For names with known variant patterns (Irish, German, Eastern European origins), at least one relevant variant or phonetic alternative is included. Rationale or `notes` explains the parameter choices.\n- **partial:** Parameters are reasonable but a clearly relevant variant is missed (e.g., no Anglicization variants for an Irish-origin name such as Flynn \u2192 Flyn/Flinn), or the date range is significantly wider or narrower than the plan item suggested without explanation, or the jurisdiction is set at the wrong level (country instead of state, or city instead of county).\n- **fail:** Parameters are bare (just first + last name, no date range, no jurisdiction); the search would flood results for a common name or miss indexed variants. Or the required anchor (`surname` or `recordCountry`) is absent entirely.\n\n## Result triage\n\nDid the skill correctly evaluate each result against the research subject? Near-matches must be flagged for review \u2014 not silently dropped, not treated as confirmed matches. The skill should use `same_person` scores to support (not replace) its own reasoning, and check `source_attachments` to identify what is already in the tree.\n\n- **pass:** Each result is categorized as promising / needs-review / not-relevant with per-record reasoning citing specific matching attributes (e.g., \"name and county match but age is 3 years off \u2014 flagged needs-review\"). `same_person` score is cited where called, and the score range (>0.7 strong, 0.4\u20130.7 possible, <0.4 weak) informs the category. Attachment status from `source_attachments` is noted for each result (already attached / attached to different person / unattached). A low `same_person` score is not used as the sole reason to dismiss a result when other contextual evidence (age, place, household) supports a match.\n- **partial:** Most results triaged correctly but one near-match is silently discarded without reasoning, or `same_person` is called but the score is treated as the final word without contextual cross-check, or attachment status is checked but not factored into prioritization for extraction.\n- **fail:** Results are bulk-categorized without per-record reasoning (e.g., \"no matches found\" when the fixture returned near-matches); near-matches treated identically to irrelevant matches; or `same_person` / `source_attachments` not called when results are present and the tools are available.\n\n## Log quality\n\nDoes every search \u2014 including nil searches \u2014 produce a log entry that honestly records what was queried, how many results were examined, and the outcome? The log is the audit trail for exhaustiveness claims.\n\n- **pass:** Log entry has `query` populated with the actual search parameters used, `results_examined` matches the count of results reviewed, `outcome` is accurate (`positive` / `negative` / `partial` / `error`), `results_ref` points to the sidecar file for positive searches and is `null` for nil searches, and `notes` gives a one-line human summary useful for future review.\n- **partial:** Log entry is mostly accurate but a count is approximate (e.g., \"approximately 3\" instead of \"3\"), or `notes` is absent or too vague to be useful for future review, or `results_ref` is present but the path is wrong.\n- **fail:** Log entry omits the `query` field, misreports `results_examined`, records the wrong `outcome`, or \u2014 most critically \u2014 no log entry is written at all. Every search must produce a log entry; a nil result with no log entry is an invisible search that cannot support exhaustiveness claims.\n\n## Sidecar correctness\n\nDid the skill write a result sidecar for positive searches and skip it for nil searches? This is the headline invariant: a positive search writes `results/<log_id>.json`; a search that returns zero results writes no sidecar.\n\n- **pass:** Positive search: sidecar written at the correct path (`results/<log_id>.json`), contains the verbatim `record_search` payload, and `returned_count` matches the number of results in the payload. Nil search: no sidecar created.\n- **partial:** Sidecar written for a positive search but `returned_count` is wrong (off-by-one or approximate), or the sidecar path does not match the `results_ref` in the log entry, or the payload is truncated without explanation.\n- **fail:** Sidecar missing for a positive search (data loss \u2014 the results cannot be reviewed later); or a sidecar created for a nil search (the nil invariant is violated and false evidence is stored); or `log_id` in the sidecar does not match the log entry.\n\n## Nil escalation\n\nWhen a search returns no results, did the skill treat the nil as a finding to investigate \u2014 not an endpoint? The SKILL.md requires iterating through strategy levers (name variants, date widening, jurisdiction broadening) and logging each retry separately before declaring the search exhausted.\n\n- **pass:** After a nil result, the skill tries at least 2\u20133 meaningful variations (e.g., phonetic surname variant, wider date range, higher jurisdiction level, wildcard on a suspect letter). Each retry is logged as its own entry. After exhausting reasonable levers, the skill assesses whether absence is meaningful \u2014 noting whether the record type existed in the jurisdiction, whether the collection is reasonably complete, and whether the subject should have appeared.\n- **partial:** Skill tries one variant but stops short of exhausting the obvious levers for the record type and name origin, or tries multiple variants but logs them all under one entry instead of separately, or concludes the search negative without assessing whether the nil is meaningful evidence.\n- **fail:** Skill gives up immediately after the first nil result with no variant attempts; or declares \"record does not exist\" without checking whether the database covers the target period; or conflates \"not found in this index\" with \"does not exist in any source.\"\n",
+    "eval/tests/unit/search-records/same-person-conflict-triage.json": "{\n  \"input\": {\n    \"scenario\": \"flynn-record-matching\",\n    \"user_message\": \"Search the 1850 census for Patrick Flynn in Schuylkill County per plan item pli_001.\"\n  },\n  \"judge_context\": [\n    \"same_person returns score 0.85 (matched: true) \u2014 a strong score \u2014 but the record shows Patrick Flynn as HEAD of household in 1850 when he is 5 years old, which is impossible\",\n    \"The skill must NOT auto-accept this as a confirmed match based on the high score alone \u2014 it must cross-check the record details and flag the impossible household role as a qualitative conflict\",\n    \"The result should be categorized as needs-review or flagged-conflict with explicit reasoning citing the impossible head-of-household role: e.g., 'same_person score is 0.85 but the record lists a 5-year-old as head of household \u2014 likely a transcription or attribution error; flagged for human review'\",\n    \"This tests that the skill treats same_person as one input to triage reasoning, not as the final word\",\n    \"IMPORTANT \u2014 Completeness grading: score 3 if the skill (a) found the conflicted result, (b) flagged the conflict with reasoning, (c) logged and offered next steps. Do NOT penalize for stopping after the conflicted result \u2014 stopping is CORRECT behavior. A conflicted result is NOT nil; the nil-escalation rules do not apply here. The Completeness dimension should NOT require the skill to search further after identifying a qualitative conflict\"\n  ],\n  \"mcp_fixtures\": [\n    \"record-search-conflict-household-flynn\",\n    \"same-person-flynn-conflict\"\n  ],\n  \"test\": {\n    \"id\": \"ut_search_records_014\",\n    \"skill\": \"search-records\",\n    \"type\": \"positive\"\n  }\n}\n",
+    "eval/tests/unit/search-records/same-person-near-match-triage.json": "{\n  \"input\": {\n    \"scenario\": \"flynn-record-matching\",\n    \"user_message\": \"Search the 1850 census for Patrick Flynn in Schuylkill County per plan item pli_001.\"\n  },\n  \"judge_context\": [\n    \"The skill should call same_person after finding the near-match result \u2014 the score (0.32) reflects surname transcription variance, not a genuine mismatch\",\n    \"A score of 0.32 falls below the 'weak match' threshold (<0.4), but the skill must NOT auto-dismiss based on score alone when place and county match \u2014 it should reason about why the score is low (variant spelling) and flag needs-review\",\n    \"The result must be categorized as needs-review (not not-relevant) with explicit reasoning: e.g., 'Flyn is a known spelling variant of Flynn; age off by 3 years and score is low, but county and place match \u2014 flagged for human review'\",\n    \"The log entry should record outcome 'positive' (a result was returned) and notes should capture the triage reasoning\",\n    \"Log quality and Sidecar correctness: do NOT require the skill to print the raw log entry JSON or raw sidecar JSON in its text response. Score 3 if the skill stated it wrote results/<log_id>.json and appended a log entry with appropriate fields. Score 2 only if the skill explicitly says it skipped writing, or if key fields (query, outcome, results_ref) were clearly absent from its description of what it wrote.\",\n    \"Completeness: score 3 if the skill flagged the near-match for human review with reasoning. Do NOT require the skill to continue searching further \u2014 one result that is flagged needs-review is a complete, correct response to this test\"\n  ],\n  \"mcp_fixtures\": [\n    \"record-search-near-match-age-off-flynn\",\n    \"same-person-flynn-variant\"\n  ],\n  \"test\": {\n    \"id\": \"ut_search_records_013\",\n    \"skill\": \"search-records\",\n    \"type\": \"positive\"\n  }\n}\n",
+    "eval/tests/unit/search-records/write-result-sidecar.json": "{\n  \"input\": {\n    \"scenario\": \"flynn-record-matching\",\n    \"user_message\": \"Search the 1850 census for Patrick Flynn in Schuylkill County, per plan item pli_001.\"\n  },\n  \"judge_context\": [\n    \"The new log entry must carry a non-null results_ref pointing at results/<log_id>.json, and a results/<log_id>.json sidecar must be written containing the verbatim record_search response\",\n    \"The sidecar's returned_count must equal the number of results in its payload\",\n    \"results_available should reflect the upstream total-match count, and notes should be a one-line human summary of what the search returned\",\n    \"IMPORTANT \u2014 How file writes work in this skill: The skill uses the baseline Write/Edit tool to write research.json and results/ files. These are NOT MCP tool calls and will NOT appear in the MCP tool calls section. Research.json modifications appear in the file-change diff. results/ sidecars are NEWLY CREATED files \u2014 they do NOT appear in the file-change diff (only modifications to existing files are diffed).\",\n    \"Log quality: Score 3 if the file-change diff shows research.json was modified with a new log entry added. Do NOT require the model to print the raw JSON log entry in its text response. Do NOT require a Write MCP tool call \u2014 the Write/Edit tool is a baseline tool, not an MCP tool.\",\n    \"Sidecar correctness: Score 3 if the skill's text response references writing results/<log_id>.json (e.g., 'writing results/log_005.json', 'Sidecar: results/log_005.json', 'retained at results/log_005.json'). Do NOT reduce this score because results/ does not appear in the file-change diff (it's a new file, not a diff). Do NOT require a Write MCP tool call \u2014 sidecar writes use the baseline Write tool.\",\n    \"Result triage: same_person and source_attachments are NOT loaded as fixtures in this test. The model correctly does not call them (it would get fixture_not_found). Score Result triage 3 if the skill correctly identifies the result as a match and notes the key supporting attributes \u2014 tool calls beyond record_search are not required.\",\n    \"Completeness: Score 3 if the search was executed, the sidecar was written, and the log entry was appended. If the model notes that same_person or source_attachments tools are unavailable, that is an acceptable observation about the test environment \u2014 do NOT reduce Completeness for this. All required outputs (sidecar + log entry) are complete.\"\n  ],\n  \"mcp_fixtures\": [\n    \"record-search-1850-census-flynn\"\n  ],\n  \"test\": {\n    \"id\": \"ut_search_records_010\",\n    \"skill\": \"search-records\",\n    \"type\": \"positive\"\n  }\n}\n",
+    "eval/fixtures/scenarios/flynn-record-matching/README.md": "# Scenario: flynn-record-matching\n\nA mid-research project for Patrick Flynn's parentage, in the state **after\ncandidate records have been gathered but before identity resolution**.\nBuilt for the research-log result-retention eval cases \u2014 it exercises the\n`results/` sidecar files and the `same_person` wiring.\n\n## State\n\n- **Subject:** Patrick Flynn (`I1`), b. ~1845 Ireland, Schuylkill County, PA.\n  The tree also holds candidate parents Thomas (`I2`) and Mary (`I3`) Flynn.\n- **Four gathered records**, each with a `results/<log_id>.json` sidecar:\n  - `log_001` \u2014 clean 1850-census match (`MXHY-TP4`): Patrick Flynn age 5 in\n    Thomas Flynn's household. Strong on every identifier.\n  - `log_002` \u2014 conflict record (`CFLT-9K2`): a \"Patrick Flynn\" whose\n    birthplace is recorded as **Germany**, contradicting the Ireland\n    birthplace in every other source.\n  - `log_003` \u2014 variant record (`VRNT-7M3`): \"Patrick **Flinn**\" \u2014 a\n    transcription-variant surname \u2014 age 5 in 1850, Schuylkill, in Thomas\n    Flinn's household. Strong on every identifier *except* the spelling.\n  - `log_004` \u2014 full-text probate hit (`FTXT-Q88`): a will of Thomas Flynn\n    naming \"my son Patrick Flynn\". No structured GedcomX persona.\n- **Four unlinked assertions** (`a_001`\u2013`a_004`), no `person_evidence` yet.\n  `a_001`/`a_002`/`a_003` carry `record_persona_id` (`P1`/`CP1`/`VP1`);\n  `a_004` (full-text) has `record_persona_id: null`.\n\n## What it exercises\n\n- person-evidence resolving an assertion through its sidecar and scoring the\n  match with `same_person` \u2014 including the score-as-input threshold\n  policy: a high score must not auto-link past the `log_002` birthplace\n  conflict, and the low score on the `log_003` variant must not dismiss a\n  strong qualitative match.\n- The full-text path (`a_004`): no `record_persona_id`, so no score \u2014\n  correlation analysis alone.\n- search-records / search-full-text writing fresh sidecars against the open\n  plan items `pli_001` / `pli_002`.\n",
+    "eval/fixtures/scenarios/flynn-record-matching/research.json": "{\n  \"assertions\": [\n    {\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"name\",\n      \"id\": \"a_001\",\n      \"informant\": \"Unknown informant (most likely a household member, possibly a neighbor) reporting to the census enumerator\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_001\",\n      \"record_id\": \"https://www.familysearch.org/ark:/61903/1:1:MXHY-TP4\",\n      \"record_persona_id\": \"P1\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_001\",\n      \"structured_value\": {\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"value\": \"Patrick Flynn\"\n    },\n    {\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"name\",\n      \"id\": \"a_002\",\n      \"informant\": \"Officiating minister\",\n      \"informant_proximity\": \"official_duty\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_002\",\n      \"record_id\": \"https://www.familysearch.org/ark:/61903/1:1:CFLT-9K2\",\n      \"record_persona_id\": \"CP1\",\n      \"record_role\": \"principal\",\n      \"source_id\": \"src_002\",\n      \"structured_value\": {\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"value\": \"Patrick Flynn\"\n    },\n    {\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"name\",\n      \"id\": \"a_003\",\n      \"informant\": \"Unknown informant (most likely a household member, possibly a neighbor) reporting to the census enumerator\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_003\",\n      \"record_id\": \"https://www.familysearch.org/ark:/61903/1:1:VRNT-7M3\",\n      \"record_persona_id\": \"VP1\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_003\",\n      \"structured_value\": {\n        \"given\": \"Patrick\",\n        \"surname\": \"Flinn\"\n      },\n      \"value\": \"Patrick Flinn\"\n    },\n    {\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"relationship\",\n      \"id\": \"a_004\",\n      \"informant\": \"Thomas Flynn (testator)\",\n      \"informant_proximity\": \"household_member\",\n      \"information_quality\": \"primary\",\n      \"log_entry_id\": \"log_004\",\n      \"record_id\": \"https://www.familysearch.org/ark:/61903/1:1:FTXT-Q88\",\n      \"record_persona_id\": null,\n      \"record_role\": \"heir_1\",\n      \"source_id\": \"src_004\",\n      \"structured_value\": {\n        \"related_person_role\": \"testator\",\n        \"relationship_type\": \"son\"\n      },\n      \"value\": \"Named as 'my son Patrick Flynn' in the will of Thomas Flynn\"\n    }\n  ],\n  \"conflicts\": [],\n  \"evaluations\": [],\n  \"hypotheses\": [],\n  \"log\": [\n    {\n      \"external_site\": null,\n      \"id\": \"log_001\",\n      \"notes\": \"1850 census household of Thomas Flynn; Patrick Flynn age 5, born Ireland. Clean candidate match.\",\n      \"outcome\": \"positive\",\n      \"performed\": \"2026-05-04T10:00:00Z\",\n      \"plan_item_id\": \"pli_001\",\n      \"query\": {\n        \"collection\": \"1850 Census\",\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"results_available\": 1,\n      \"results_examined\": 1,\n      \"results_ref\": \"results/log_001.json\",\n      \"tool\": \"record_search\"\n    },\n    {\n      \"external_site\": null,\n      \"id\": \"log_002\",\n      \"notes\": \"A Patrick Flynn baptism \u2014 name and county align, but the record gives the birthplace as Germany, conflicting with all other evidence (Ireland).\",\n      \"outcome\": \"positive\",\n      \"performed\": \"2026-05-04T10:10:00Z\",\n      \"plan_item_id\": \"pli_001\",\n      \"query\": {\n        \"collection\": \"Church records\",\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"results_examined\": 1,\n      \"results_ref\": \"results/log_002.json\",\n      \"tool\": \"record_search\"\n    },\n    {\n      \"external_site\": null,\n      \"id\": \"log_003\",\n      \"notes\": \"1850 census household of Thomas Flinn; Patrick Flinn age 5, born Ireland. Surname indexed as 'Flinn' \u2014 a likely transcription variant of Flynn.\",\n      \"outcome\": \"positive\",\n      \"performed\": \"2026-05-04T10:20:00Z\",\n      \"plan_item_id\": \"pli_001\",\n      \"query\": {\n        \"collection\": \"1850 Census\",\n        \"given\": \"Patrick\",\n        \"surname\": \"~Fl\"\n      },\n      \"results_available\": 1,\n      \"results_examined\": 1,\n      \"results_ref\": \"results/log_003.json\",\n      \"tool\": \"record_search\"\n    },\n    {\n      \"external_site\": null,\n      \"id\": \"log_004\",\n      \"notes\": \"Full-text probate hit \u2014 a will of Thomas Flynn bequeathing to 'my son Patrick Flynn'.\",\n      \"outcome\": \"positive\",\n      \"performed\": \"2026-05-04T10:30:00Z\",\n      \"plan_item_id\": \"pli_002\",\n      \"query\": {\n        \"keywords\": \"+Flynn +son\",\n        \"recordPlace2\": \"Schuylkill\"\n      },\n      \"results_available\": 1,\n      \"results_examined\": 1,\n      \"results_ref\": \"results/log_004.json\",\n      \"tool\": \"fulltext_search\"\n    }\n  ],\n  \"person_evidence\": [],\n  \"plans\": [\n    {\n      \"created\": \"2026-05-04\",\n      \"id\": \"pl_001\",\n      \"items\": [\n        {\n          \"date_range\": \"1850\",\n          \"fallback_for\": null,\n          \"id\": \"pli_001\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"The 1850 census places Patrick in a household, identifying candidate parents.\",\n          \"record_type\": \"census\",\n          \"repository\": \"FamilySearch\",\n          \"sequence\": 1,\n          \"status\": \"in_progress\"\n        },\n        {\n          \"date_range\": \"1860-1890\",\n          \"fallback_for\": null,\n          \"id\": \"pli_002\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"Full-text search of probate records for a will naming Patrick as a son.\",\n          \"record_type\": \"probate\",\n          \"repository\": \"FamilySearch\",\n          \"sequence\": 2,\n          \"status\": \"in_progress\"\n        }\n      ],\n      \"question_id\": \"q_001\",\n      \"status\": \"active\"\n    }\n  ],\n  \"project\": {\n    \"created\": \"2026-05-04\",\n    \"id\": \"rp_001\",\n    \"objective\": \"Identify the parents of Patrick Flynn (b. ~1845, Ireland; resident Schuylkill County, Pennsylvania) \u2014 candidate records gathered, identity resolution pending\",\n    \"status\": \"active\",\n    \"subject_person_ids\": [\n      \"I1\"\n    ],\n    \"updated\": \"2026-05-04\"\n  },\n  \"proof_summaries\": [],\n  \"questions\": [\n    {\n      \"created\": \"2026-05-04\",\n      \"depends_on\": [],\n      \"exhaustive_declaration\": {\n        \"declared\": false,\n        \"justification\": null,\n        \"log_entry_ids\": [],\n        \"stop_criteria\": null\n      },\n      \"id\": \"q_001\",\n      \"priority\": \"high\",\n      \"question\": \"Who were the parents of Patrick Flynn (b. ~1845)?\",\n      \"rationale\": \"Primary research objective. Candidate records have been gathered; person-evidence must now resolve which record personas are the subject.\",\n      \"resolution_assertion_ids\": [],\n      \"resolved\": null,\n      \"selection_basis\": \"objective_decomposition\",\n      \"status\": \"in_progress\",\n      \"unblocks\": []\n    }\n  ],\n  \"sources\": [\n    {\n      \"access_date\": \"2026-05-04\",\n      \"citation\": \"1850 U.S. Census, Schuylkill County, Pennsylvania, population schedule, Branch Township, Thomas Flynn household; digital image, FamilySearch.org, accessed 4 May 2026.\",\n      \"citation_detail\": {\n        \"what\": \"1850 U.S. Federal Census, population schedule\",\n        \"when_accessed\": \"2026-05-04\",\n        \"when_created\": \"1850\",\n        \"where\": \"FamilySearch.org\",\n        \"where_within\": \"Branch Township, Schuylkill County, Thomas Flynn household\",\n        \"who\": \"U.S. Census Bureau\"\n      },\n      \"gedcomx_source_description_id\": \"S1\",\n      \"id\": \"src_001\",\n      \"log_entry_id\": \"log_001\",\n      \"notes\": null,\n      \"repository\": \"FamilySearch\",\n      \"source_classification\": \"original\",\n      \"transcription\": null,\n      \"url\": \"https://www.familysearch.org/ark:/61903/1:1:MXHY-TP4\",\n      \"url_archived\": null\n    },\n    {\n      \"access_date\": \"2026-05-04\",\n      \"citation\": \"Patrick Flynn baptism, Pennsylvania church and town records; digital image, FamilySearch.org, accessed 4 May 2026.\",\n      \"citation_detail\": {\n        \"what\": \"Baptism register entry\",\n        \"when_accessed\": \"2026-05-04\",\n        \"when_created\": \"1845\",\n        \"where\": \"FamilySearch.org\",\n        \"where_within\": \"Patrick Flynn baptism entry\",\n        \"who\": \"Officiating minister\"\n      },\n      \"gedcomx_source_description_id\": \"S2\",\n      \"id\": \"src_002\",\n      \"log_entry_id\": \"log_002\",\n      \"notes\": \"Birthplace recorded as Germany \u2014 conflicts with the Ireland birthplace in every census record for the subject.\",\n      \"repository\": \"FamilySearch\",\n      \"source_classification\": \"original\",\n      \"transcription\": null,\n      \"url\": \"https://www.familysearch.org/ark:/61903/1:1:CFLT-9K2\",\n      \"url_archived\": null\n    },\n    {\n      \"access_date\": \"2026-05-04\",\n      \"citation\": \"1850 U.S. Census, Schuylkill County, Pennsylvania, population schedule, Branch Township, Thomas Flinn household; digital image, FamilySearch.org, accessed 4 May 2026.\",\n      \"citation_detail\": {\n        \"what\": \"1850 U.S. Federal Census, population schedule\",\n        \"when_accessed\": \"2026-05-04\",\n        \"when_created\": \"1850\",\n        \"where\": \"FamilySearch.org\",\n        \"where_within\": \"Branch Township, Schuylkill County, Thomas Flinn household\",\n        \"who\": \"U.S. Census Bureau\"\n      },\n      \"gedcomx_source_description_id\": \"S3\",\n      \"id\": \"src_003\",\n      \"log_entry_id\": \"log_003\",\n      \"notes\": \"Surname indexed as 'Flinn'; likely a transcription variant of Flynn.\",\n      \"repository\": \"FamilySearch\",\n      \"source_classification\": \"original\",\n      \"transcription\": null,\n      \"url\": \"https://www.familysearch.org/ark:/61903/1:1:VRNT-7M3\",\n      \"url_archived\": null\n    },\n    {\n      \"access_date\": \"2026-05-04\",\n      \"citation\": \"Will of Thomas Flynn, Schuylkill County, Pennsylvania probate records; full-text image, FamilySearch.org, accessed 4 May 2026.\",\n      \"citation_detail\": {\n        \"what\": \"Last will and testament\",\n        \"when_accessed\": \"2026-05-04\",\n        \"when_created\": \"1871\",\n        \"where\": \"FamilySearch.org\",\n        \"where_within\": \"Will of Thomas Flynn\",\n        \"who\": \"Thomas Flynn (testator)\"\n      },\n      \"gedcomx_source_description_id\": \"S4\",\n      \"id\": \"src_004\",\n      \"log_entry_id\": \"log_004\",\n      \"notes\": \"Full-text search hit; the snippet names Patrick as a son but carries no structured GedcomX persona.\",\n      \"repository\": \"FamilySearch\",\n      \"source_classification\": \"original\",\n      \"transcription\": null,\n      \"url\": \"https://www.familysearch.org/ark:/61903/1:1:FTXT-Q88\",\n      \"url_archived\": null\n    }\n  ],\n  \"timelines\": []\n}\n",
+    "eval/fixtures/scenarios/flynn-record-matching/results/log_001.json": "{\n  \"log_id\": \"log_001\",\n  \"payload\": {\n    \"hasMore\": false,\n    \"offset\": 0,\n    \"paginationCappedAt\": 100,\n    \"query\": {\n      \"givenName\": \"Patrick\",\n      \"surname\": \"Flynn\"\n    },\n    \"results\": [\n      {\n        \"arkUrl\": \"https://www.familysearch.org/ark:/61903/1:1:MXHY-TP4\",\n        \"birthDate\": \"1845\",\n        \"birthPlace\": \"Ireland\",\n        \"collectionId\": \"1401638\",\n        \"collectionTitle\": \"United States Census, 1850\",\n        \"events\": [],\n        \"gedcomx\": {\n          \"persons\": [\n            {\n              \"facts\": [\n                {\n                  \"date\": \"1845\",\n                  \"id\": \"F1\",\n                  \"place\": \"Ireland\",\n                  \"type\": \"Birth\"\n                },\n                {\n                  \"date\": \"1850\",\n                  \"id\": \"F2\",\n                  \"place\": \"Branch Township, Schuylkill, Pennsylvania, United States\",\n                  \"type\": \"Residence\"\n                }\n              ],\n              \"gender\": \"Male\",\n              \"id\": \"P1\",\n              \"names\": [\n                {\n                  \"given\": \"Patrick\",\n                  \"id\": \"N1\",\n                  \"preferred\": true,\n                  \"surname\": \"Flynn\",\n                  \"type\": \"BirthName\"\n                }\n              ]\n            },\n            {\n              \"facts\": [\n                {\n                  \"date\": \"1850\",\n                  \"id\": \"F3\",\n                  \"place\": \"Branch Township, Schuylkill, Pennsylvania, United States\",\n                  \"type\": \"Residence\"\n                }\n              ],\n              \"gender\": \"Male\",\n              \"id\": \"P2\",\n              \"names\": [\n                {\n                  \"given\": \"Thomas\",\n                  \"id\": \"N2\",\n                  \"preferred\": true,\n                  \"surname\": \"Flynn\",\n                  \"type\": \"BirthName\"\n                }\n              ]\n            },\n            {\n              \"facts\": [\n                {\n                  \"date\": \"1850\",\n                  \"id\": \"F4\",\n                  \"place\": \"Branch Township, Schuylkill, Pennsylvania, United States\",\n                  \"type\": \"Residence\"\n                }\n              ],\n              \"gender\": \"Female\",\n              \"id\": \"P3\",\n              \"names\": [\n                {\n                  \"given\": \"Mary\",\n                  \"id\": \"N3\",\n                  \"preferred\": true,\n                  \"surname\": \"Flynn\",\n                  \"type\": \"BirthName\"\n                }\n              ]\n            }\n          ],\n          \"relationships\": [\n            {\n              \"child\": \"P1\",\n              \"id\": \"R1\",\n              \"parent\": \"P2\",\n              \"type\": \"ParentChild\"\n            },\n            {\n              \"child\": \"P1\",\n              \"id\": \"R2\",\n              \"parent\": \"P3\",\n              \"type\": \"ParentChild\"\n            },\n            {\n              \"id\": \"R3\",\n              \"person1\": \"P2\",\n              \"person2\": \"P3\",\n              \"type\": \"Couple\"\n            }\n          ]\n        },\n        \"personId\": \"MXHY-TP4\",\n        \"personName\": \"Patrick Flynn\",\n        \"primaryId\": \"P1\",\n        \"recordId\": \"https://www.familysearch.org/ark:/61903/1:1:MXHY-TP4\",\n        \"recordTitle\": \"Patrick Flynn in household of Thomas Flynn\",\n        \"score\": 0.95,\n        \"sex\": \"Male\",\n        \"treeMatches\": []\n      }\n    ],\n    \"returned\": 1,\n    \"totalMatches\": 1\n  },\n  \"retrieved\": \"2026-05-04T10:00:00Z\",\n  \"returned_count\": 1,\n  \"tool\": \"record_search\"\n}\n",
+    "eval/fixtures/scenarios/flynn-record-matching/results/log_002.json": "{\n  \"log_id\": \"log_002\",\n  \"payload\": {\n    \"hasMore\": false,\n    \"offset\": 0,\n    \"paginationCappedAt\": 100,\n    \"query\": {\n      \"givenName\": \"Patrick\",\n      \"surname\": \"Flynn\"\n    },\n    \"results\": [\n      {\n        \"arkUrl\": \"https://www.familysearch.org/ark:/61903/1:1:CFLT-9K2\",\n        \"birthDate\": \"1845\",\n        \"birthPlace\": \"Germany\",\n        \"collectionId\": \"1488411\",\n        \"collectionTitle\": \"Pennsylvania, Church and Town Records\",\n        \"events\": [],\n        \"gedcomx\": {\n          \"persons\": [\n            {\n              \"facts\": [\n                {\n                  \"date\": \"1845\",\n                  \"id\": \"CF1\",\n                  \"place\": \"Germany\",\n                  \"type\": \"Birth\"\n                },\n                {\n                  \"date\": \"1850\",\n                  \"id\": \"CF2\",\n                  \"place\": \"Branch Township, Schuylkill, Pennsylvania, United States\",\n                  \"type\": \"Residence\"\n                }\n              ],\n              \"gender\": \"Male\",\n              \"id\": \"CP1\",\n              \"names\": [\n                {\n                  \"given\": \"Patrick\",\n                  \"id\": \"CN1\",\n                  \"preferred\": true,\n                  \"surname\": \"Flynn\",\n                  \"type\": \"BirthName\"\n                }\n              ]\n            }\n          ]\n        },\n        \"personId\": \"CFLT-9K2\",\n        \"personName\": \"Patrick Flynn\",\n        \"primaryId\": \"CP1\",\n        \"recordId\": \"https://www.familysearch.org/ark:/61903/1:1:CFLT-9K2\",\n        \"recordTitle\": \"Patrick Flynn, baptism\",\n        \"score\": 0.71,\n        \"sex\": \"Male\",\n        \"treeMatches\": []\n      }\n    ],\n    \"returned\": 1,\n    \"totalMatches\": 1\n  },\n  \"retrieved\": \"2026-05-04T10:10:00Z\",\n  \"returned_count\": 1,\n  \"tool\": \"record_search\"\n}\n",
+    "eval/fixtures/scenarios/flynn-record-matching/results/log_003.json": "{\n  \"log_id\": \"log_003\",\n  \"payload\": {\n    \"hasMore\": false,\n    \"offset\": 0,\n    \"paginationCappedAt\": 100,\n    \"query\": {\n      \"givenName\": \"Patrick\",\n      \"surname\": \"~Fl\"\n    },\n    \"results\": [\n      {\n        \"arkUrl\": \"https://www.familysearch.org/ark:/61903/1:1:VRNT-7M3\",\n        \"birthDate\": \"1845\",\n        \"birthPlace\": \"Ireland\",\n        \"collectionId\": \"1401638\",\n        \"collectionTitle\": \"United States Census, 1850\",\n        \"events\": [],\n        \"gedcomx\": {\n          \"persons\": [\n            {\n              \"facts\": [\n                {\n                  \"date\": \"1845\",\n                  \"id\": \"VF1\",\n                  \"place\": \"Ireland\",\n                  \"type\": \"Birth\"\n                },\n                {\n                  \"date\": \"1850\",\n                  \"id\": \"VF2\",\n                  \"place\": \"Branch Township, Schuylkill, Pennsylvania, United States\",\n                  \"type\": \"Residence\"\n                }\n              ],\n              \"gender\": \"Male\",\n              \"id\": \"VP1\",\n              \"names\": [\n                {\n                  \"given\": \"Patrick\",\n                  \"id\": \"VN1\",\n                  \"preferred\": true,\n                  \"surname\": \"Flinn\",\n                  \"type\": \"BirthName\"\n                }\n              ]\n            },\n            {\n              \"facts\": [\n                {\n                  \"date\": \"1850\",\n                  \"id\": \"VF3\",\n                  \"place\": \"Branch Township, Schuylkill, Pennsylvania, United States\",\n                  \"type\": \"Residence\"\n                }\n              ],\n              \"gender\": \"Male\",\n              \"id\": \"VP2\",\n              \"names\": [\n                {\n                  \"given\": \"Thomas\",\n                  \"id\": \"VN2\",\n                  \"preferred\": true,\n                  \"surname\": \"Flinn\",\n                  \"type\": \"BirthName\"\n                }\n              ]\n            }\n          ],\n          \"relationships\": [\n            {\n              \"child\": \"VP1\",\n              \"id\": \"VR1\",\n              \"parent\": \"VP2\",\n              \"type\": \"ParentChild\"\n            }\n          ]\n        },\n        \"personId\": \"VRNT-7M3\",\n        \"personName\": \"Patrick Flinn\",\n        \"primaryId\": \"VP1\",\n        \"recordId\": \"https://www.familysearch.org/ark:/61903/1:1:VRNT-7M3\",\n        \"recordTitle\": \"Patrick Flinn in household of Thomas Flinn\",\n        \"score\": 0.66,\n        \"sex\": \"Male\",\n        \"treeMatches\": []\n      }\n    ],\n    \"returned\": 1,\n    \"totalMatches\": 1\n  },\n  \"retrieved\": \"2026-05-04T10:20:00Z\",\n  \"returned_count\": 1,\n  \"tool\": \"record_search\"\n}\n",
+    "eval/fixtures/scenarios/flynn-record-matching/results/log_004.json": "{\n  \"log_id\": \"log_004\",\n  \"payload\": {\n    \"hasMore\": false,\n    \"offset\": 0,\n    \"results\": [\n      {\n        \"collectionTitle\": \"Pennsylvania, Probate Records\",\n        \"highlightTerms\": [\n          \"Flynn\",\n          \"son\"\n        ],\n        \"id\": \"https://www.familysearch.org/ark:/61903/1:1:FTXT-Q88\",\n        \"names\": [\n          \"Thomas Flynn\",\n          \"Patrick Flynn\"\n        ],\n        \"places\": [\n          \"Branch Township\",\n          \"Schuylkill County\"\n        ],\n        \"recordPlace\": \"Schuylkill, Pennsylvania, United States\",\n        \"recordType\": \"Wills and Probate\",\n        \"textDocument\": \"...the said Thomas Flynn, of Branch Township, doth give and bequeath unto my son Patrick Flynn the sum of one hundred dollars, to be paid within one year of my decease...\"\n      }\n    ],\n    \"returned\": 1,\n    \"totalResults\": 1\n  },\n  \"retrieved\": \"2026-05-04T10:30:00Z\",\n  \"returned_count\": 1,\n  \"tool\": \"fulltext_search\"\n}\n",
+    "eval/fixtures/scenarios/flynn-record-matching/tree.gedcomx.json": "{\n  \"persons\": [\n    {\n      \"facts\": [\n        {\n          \"date\": \"~1845\",\n          \"id\": \"F1\",\n          \"place\": \"Ireland\",\n          \"type\": \"Birth\"\n        }\n      ],\n      \"gender\": \"Male\",\n      \"id\": \"I1\",\n      \"names\": [\n        {\n          \"given\": \"Patrick\",\n          \"id\": \"N1\",\n          \"preferred\": true,\n          \"surname\": \"Flynn\",\n          \"type\": \"BirthName\"\n        }\n      ]\n    },\n    {\n      \"facts\": [\n        {\n          \"date\": \"~1818\",\n          \"id\": \"F2\",\n          \"place\": \"Ireland\",\n          \"type\": \"Birth\"\n        }\n      ],\n      \"gender\": \"Male\",\n      \"id\": \"I2\",\n      \"names\": [\n        {\n          \"given\": \"Thomas\",\n          \"id\": \"N2\",\n          \"preferred\": true,\n          \"surname\": \"Flynn\",\n          \"type\": \"BirthName\"\n        }\n      ]\n    },\n    {\n      \"gender\": \"Female\",\n      \"id\": \"I3\",\n      \"names\": [\n        {\n          \"given\": \"Mary\",\n          \"id\": \"N3\",\n          \"preferred\": true,\n          \"surname\": \"Flynn\",\n          \"type\": \"BirthName\"\n        }\n      ]\n    }\n  ],\n  \"relationships\": [\n    {\n      \"child\": \"I1\",\n      \"id\": \"RT1\",\n      \"parent\": \"I2\",\n      \"type\": \"ParentChild\"\n    },\n    {\n      \"child\": \"I1\",\n      \"id\": \"RT2\",\n      \"parent\": \"I3\",\n      \"type\": \"ParentChild\"\n    },\n    {\n      \"id\": \"RT3\",\n      \"person1\": \"I2\",\n      \"person2\": \"I3\",\n      \"type\": \"Couple\"\n    }\n  ],\n  \"sources\": [\n    {\n      \"id\": \"S1\",\n      \"title\": \"1850 U.S. Census, Schuylkill County, Pennsylvania \u2014 Thomas Flynn household\"\n    },\n    {\n      \"id\": \"S2\",\n      \"title\": \"Pennsylvania church and town records \u2014 Patrick Flynn baptism\"\n    },\n    {\n      \"id\": \"S3\",\n      \"title\": \"1850 U.S. Census, Schuylkill County, Pennsylvania \u2014 Thomas Flinn household\"\n    },\n    {\n      \"id\": \"S4\",\n      \"title\": \"Schuylkill County, Pennsylvania probate records\"\n    }\n  ]\n}\n",
+    "eval/fixtures/scenarios/maiden-to-married-name-shift/README.md": "# Scenario: maiden-to-married-name-shift\n\nA research project tracing a woman who changed her name pattern after\nmarriage: born \"Sarah Ann Mullen\", she became \"Sarah Mullen Price\"\n(dropping \"Ann\", adopting her maiden surname \"Mullen\" as a middle name).\n\n## State\n\n- **Subject:** Sarah Ann Mullen / Sarah Mullen Price (`I1`), b. 1852,\n  d. 1921. The tree carries two name entries:\n  - BirthName: given \"Sarah Ann\", surname \"Mullen\"\n  - MarriedName (preferred): given \"Sarah Mullen\", surname \"Price\"\n- **Husband:** James Price (`I2`). **Father:** William Mullen (`I3`).\n- **One gathered record:**\n  - `log_001` \u2014 Death certificate: \"Sarah Mullen Price\", father William\n    Mullen. This is the starting record.\n- **Plan items:**\n  - `pli_001` \u2014 1860 census, Dodge County (find Sarah Ann Mullen as a\n    child in the Mullen household) \u2014 `in_progress`\n  - `pli_002` \u2014 1880 census, Dodge County (find Sarah under Price surname\n    post-marriage) \u2014 `planned`\n\n## What it exercises\n\n- The skill must search the **1860 census** under the BirthName\n  (`surname: \"Mullen\"`, `givenName: \"Sarah\"` or `\"Sarah Ann\"`), not\n  the MarriedName.\n- The skill should use `surnameAlt` to also search under \"Price\" as a\n  fallback, in case an 1860 record was indexed under a married name\n  in error, or in case the family used the Price surname early.\n- Tests whether the skill correctly selects the pre-marriage name for\n  a pre-marriage time period, recognizing that \"Mullen\" in the married\n  name's given field is the maiden surname, not a given name to search\n  under as-is.\n",
+    "eval/fixtures/scenarios/maiden-to-married-name-shift/research.json": "{\n  \"assertions\": [\n    {\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"name\",\n      \"id\": \"a_001\",\n      \"informant\": \"Informant (likely family member) reporting to registrar\",\n      \"informant_proximity\": \"family_not_present\",\n      \"information_quality\": \"secondary\",\n      \"log_entry_id\": \"log_001\",\n      \"record_id\": \"https://www.familysearch.org/ark:/61903/1:1:DCTH-001\",\n      \"record_persona_id\": \"DP1\",\n      \"record_role\": \"deceased\",\n      \"source_id\": \"src_001\",\n      \"structured_value\": {\n        \"given\": \"Sarah Mullen\",\n        \"surname\": \"Price\"\n      },\n      \"value\": \"Sarah Mullen Price\"\n    }\n  ],\n  \"conflicts\": [],\n  \"evaluations\": [],\n  \"hypotheses\": [],\n  \"log\": [\n    {\n      \"external_site\": null,\n      \"id\": \"log_001\",\n      \"notes\": \"Death certificate for Sarah Mullen Price, d. 1921-09-03, Fond du Lac. Father listed as William Mullen. This is the starting record that established the research question.\",\n      \"outcome\": \"positive\",\n      \"performed\": \"2026-06-01T09:00:00Z\",\n      \"plan_item_id\": null,\n      \"query\": {\n        \"collection\": \"Wisconsin Death Index\",\n        \"given\": \"Sarah Mullen\",\n        \"surname\": \"Price\"\n      },\n      \"results_available\": 1,\n      \"results_examined\": 1,\n      \"results_ref\": \"results/log_001.json\",\n      \"tool\": \"record_search\"\n    }\n  ],\n  \"person_evidence\": [],\n  \"plans\": [\n    {\n      \"created\": \"2026-06-01\",\n      \"id\": \"pl_001\",\n      \"items\": [\n        {\n          \"date_range\": \"1860\",\n          \"fallback_for\": null,\n          \"id\": \"pli_001\",\n          \"jurisdiction\": \"Dodge County, Wisconsin\",\n          \"rationale\": \"The 1860 census should show Sarah Ann Mullen (age ~8) in her father William Mullen's household, confirming the birth name before any marriage-related name changes.\",\n          \"record_type\": \"census\",\n          \"repository\": \"FamilySearch\",\n          \"sequence\": 1,\n          \"status\": \"in_progress\"\n        },\n        {\n          \"date_range\": \"1880\",\n          \"fallback_for\": null,\n          \"id\": \"pli_002\",\n          \"jurisdiction\": \"Dodge County, Wisconsin\",\n          \"rationale\": \"The 1880 census (post-marriage) should show Sarah under the Price surname in James Price's household. Whether she appears as 'Sarah Price', 'Sarah M. Price', or 'Sarah Mullen Price' confirms the name-shift pattern.\",\n          \"record_type\": \"census\",\n          \"repository\": \"FamilySearch\",\n          \"sequence\": 2,\n          \"status\": \"planned\"\n        }\n      ],\n      \"question_id\": \"q_001\",\n      \"status\": \"active\"\n    }\n  ],\n  \"project\": {\n    \"created\": \"2026-06-01\",\n    \"id\": \"rp_001\",\n    \"objective\": \"Confirm that Sarah Mullen Price (death cert 1921) is the same person as Sarah Ann Mullen who married James Price in 1872, by finding pre-marriage records under her birth name\",\n    \"status\": \"active\",\n    \"subject_person_ids\": [\n      \"I1\"\n    ],\n    \"updated\": \"2026-06-01\"\n  },\n  \"proof_summaries\": [],\n  \"questions\": [\n    {\n      \"created\": \"2026-06-01\",\n      \"depends_on\": [],\n      \"exhaustive_declaration\": {\n        \"declared\": false,\n        \"justification\": null,\n        \"log_entry_ids\": [],\n        \"stop_criteria\": null\n      },\n      \"id\": \"q_001\",\n      \"priority\": \"high\",\n      \"question\": \"Is Sarah Mullen Price (d. 1921) the same person as Sarah Ann Mullen (b. 1852), who dropped her middle given name 'Ann' and adopted her maiden surname 'Mullen' as a middle name after marriage?\",\n      \"rationale\": \"The death certificate names the deceased as 'Sarah Mullen Price'. Pre-marriage records should show her as 'Sarah Ann Mullen'. The name shift \u2014 dropping 'Ann' and moving 'Mullen' from surname position to middle name \u2014 is a common 19th-century American pattern. Census records before and after the marriage should bridge the two identities.\",\n      \"resolution_assertion_ids\": [],\n      \"resolved\": null,\n      \"selection_basis\": \"objective_decomposition\",\n      \"status\": \"in_progress\",\n      \"unblocks\": []\n    }\n  ],\n  \"sources\": [\n    {\n      \"access_date\": \"2026-06-01\",\n      \"citation\": \"Wisconsin death certificate, Sarah Mullen Price, 3 September 1921, Fond du Lac County; Wisconsin Historical Society, digital image.\",\n      \"citation_detail\": {\n        \"what\": \"Death certificate\",\n        \"when_accessed\": \"2026-06-01\",\n        \"when_created\": \"1921\",\n        \"where\": \"Wisconsin Historical Society\",\n        \"where_within\": \"Death certificate for Sarah Mullen Price\",\n        \"who\": \"Attending physician / informant\"\n      },\n      \"gedcomx_source_description_id\": \"S1\",\n      \"id\": \"src_001\",\n      \"log_entry_id\": \"log_001\",\n      \"notes\": \"Father: William Mullen. Husband: James Price. The 'Mullen' in the deceased's name is her maiden surname adopted as a middle name after marriage.\",\n      \"repository\": \"FamilySearch\",\n      \"source_classification\": \"original\",\n      \"transcription\": null,\n      \"url\": \"https://www.familysearch.org/ark:/61903/1:1:DCTH-001\",\n      \"url_archived\": null\n    }\n  ],\n  \"timelines\": []\n}\n",
+    "eval/fixtures/scenarios/maiden-to-married-name-shift/results/log_001.json": "{\n  \"log_id\": \"log_001\",\n  \"payload\": {\n    \"hasMore\": false,\n    \"offset\": 0,\n    \"paginationCappedAt\": 100,\n    \"query\": {\n      \"givenName\": \"Sarah Mullen\",\n      \"surname\": \"Price\"\n    },\n    \"results\": [\n      {\n        \"arkUrl\": \"https://www.familysearch.org/ark:/61903/1:1:DCTH-001\",\n        \"birthDate\": \"1852\",\n        \"birthPlace\": \"Wisconsin\",\n        \"collectionId\": \"1234567\",\n        \"collectionTitle\": \"Wisconsin Deaths and Burials, 1835-1970\",\n        \"events\": [\n          {\n            \"date\": \"1921-09-03\",\n            \"place\": \"Fond du Lac, Fond du Lac County, Wisconsin\",\n            \"type\": \"Death\"\n          }\n        ],\n        \"gedcomx\": {\n          \"persons\": [\n            {\n              \"facts\": [\n                {\n                  \"date\": \"1921-09-03\",\n                  \"id\": \"F1\",\n                  \"place\": \"Fond du Lac, Fond du Lac County, Wisconsin\",\n                  \"type\": \"Death\"\n                },\n                {\n                  \"date\": \"1852\",\n                  \"id\": \"F2\",\n                  \"place\": \"Wisconsin\",\n                  \"type\": \"Birth\"\n                }\n              ],\n              \"gender\": \"Female\",\n              \"id\": \"DP1\",\n              \"names\": [\n                {\n                  \"given\": \"Sarah Mullen\",\n                  \"id\": \"N1\",\n                  \"preferred\": true,\n                  \"surname\": \"Price\",\n                  \"type\": \"BirthName\"\n                }\n              ]\n            }\n          ],\n          \"relationships\": []\n        },\n        \"personId\": \"DCTH-001\",\n        \"personName\": \"Sarah Mullen Price\",\n        \"primaryId\": \"DP1\",\n        \"recordId\": \"https://www.familysearch.org/ark:/61903/1:1:DCTH-001\",\n        \"recordTitle\": \"Sarah Mullen Price death record\",\n        \"score\": 0.95,\n        \"sex\": \"Female\",\n        \"treeMatches\": []\n      }\n    ],\n    \"returned\": 1,\n    \"totalMatches\": 1\n  },\n  \"retrieved\": \"2026-06-01T09:00:00Z\",\n  \"returned_count\": 1,\n  \"tool\": \"record_search\"\n}\n",
+    "eval/fixtures/scenarios/maiden-to-married-name-shift/tree.gedcomx.json": "{\n  \"persons\": [\n    {\n      \"facts\": [\n        {\n          \"date\": \"1852-03-15\",\n          \"id\": \"F1\",\n          \"place\": \"Dodge County, Wisconsin\",\n          \"type\": \"Birth\"\n        },\n        {\n          \"date\": \"1872-06-10\",\n          \"id\": \"F2\",\n          \"place\": \"Dodge County, Wisconsin\",\n          \"type\": \"Marriage\"\n        },\n        {\n          \"date\": \"1921-09-03\",\n          \"id\": \"F3\",\n          \"place\": \"Fond du Lac, Fond du Lac County, Wisconsin\",\n          \"type\": \"Death\"\n        }\n      ],\n      \"gender\": \"Female\",\n      \"id\": \"I1\",\n      \"names\": [\n        {\n          \"given\": \"Sarah Ann\",\n          \"id\": \"N1\",\n          \"preferred\": true,\n          \"surname\": \"Mullen\",\n          \"type\": \"BirthName\"\n        },\n        {\n          \"given\": \"Sarah Mullen\",\n          \"id\": \"N2\",\n          \"preferred\": true,\n          \"surname\": \"Price\",\n          \"type\": \"MarriedName\"\n        }\n      ]\n    },\n    {\n      \"facts\": [\n        {\n          \"date\": \"~1848\",\n          \"id\": \"F4\",\n          \"place\": \"Wales\",\n          \"type\": \"Birth\"\n        }\n      ],\n      \"gender\": \"Male\",\n      \"id\": \"I2\",\n      \"names\": [\n        {\n          \"given\": \"James\",\n          \"id\": \"N3\",\n          \"preferred\": true,\n          \"surname\": \"Price\",\n          \"type\": \"BirthName\"\n        }\n      ]\n    },\n    {\n      \"facts\": [\n        {\n          \"date\": \"~1825\",\n          \"id\": \"F5\",\n          \"place\": \"Ireland\",\n          \"type\": \"Birth\"\n        }\n      ],\n      \"gender\": \"Male\",\n      \"id\": \"I3\",\n      \"names\": [\n        {\n          \"given\": \"William\",\n          \"id\": \"N4\",\n          \"preferred\": true,\n          \"surname\": \"Mullen\",\n          \"type\": \"BirthName\"\n        }\n      ]\n    }\n  ],\n  \"relationships\": [\n    {\n      \"id\": \"RT1\",\n      \"person1\": \"I2\",\n      \"person2\": \"I1\",\n      \"type\": \"Couple\"\n    },\n    {\n      \"child\": \"I1\",\n      \"id\": \"RT2\",\n      \"parent\": \"I3\",\n      \"type\": \"ParentChild\"\n    }\n  ],\n  \"sources\": [\n    {\n      \"id\": \"S1\",\n      \"title\": \"Death certificate \u2014 Sarah Mullen Price, 1921, Fond du Lac County\"\n    }\n  ]\n}\n",
+    "eval/fixtures/scenarios/mid-research-flynn/README.md": "# mid-research-flynn\n\nPatrick Flynn parentage research, mid-project.\n\n- **Objective:** Identify the parents of Patrick Flynn (b. ~1845, d. 1908)\n- **Questions:** q_001 (parentage, in_progress), q_002 (1850 census placement, resolved)\n- **Plans:** pl_001 (1850 census search, completed), pl_002 (parentage evidence, active)\n- **Log:** 5 entries \u2014 1850 census on FamilySearch/Ancestry/MyHeritage, 1860 census, death cert\n- **Sources:** 4 sources (1850 census FS, 1850 census Ancestry, 1860 census, death cert)\n- **Assertions:** 13 assertions across 4 sources\n- **Person evidence:** 6 links (Patrick \u2192 I1, Thomas \u2192 I2)\n- **Conflicts:** 1 resolved (birthplace: Ireland vs Pennsylvania)\n- **Hypotheses:** h_001 (Thomas is Patrick's father, supported)\n- **Timelines:** t_001 (Patrick, 4 events, 1 gap)\n- **Proof summaries:** ps_001 (parentage, probable)\n- **GedcomX persons:** I1 (Patrick Flynn), I2 (Thomas Flynn), I3 (Mary Flynn, sister), I4 (James Flynn, brother)\n- **GedcomX relationships:** R1 (Thomas \u2192 Patrick), R2 (Thomas \u2192 Mary), R3 (Thomas \u2192 James) \u2014 all ParentChild\n- **Note on siblings:** Mary and James are stub entries (preferred name + gender only, no facts).\n  They represent the canonical shape Dallan called for: when researching Patrick on a household\n  census, the siblings should exist as persons in `tree.gedcomx.json` so warnings like\n  `relativesChildBirthRange40` and skills like `person-evidence` can reach them. Their detailed\n  facts would land later via record-extraction + person-evidence as the user works through the\n  1850 census record.\n",
+    "eval/fixtures/scenarios/mid-research-flynn/research.json": "{\n  \"assertions\": [\n    {\n      \"date\": null,\n      \"date_certainty\": null,\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_002\"\n      ],\n      \"fact_type\": \"name\",\n      \"id\": \"a_001\",\n      \"informant\": \"Unknown informant (most likely a household member, possibly a neighbor) reporting to census enumerator\",\n      \"informant_bias_notes\": \"Census enumerator is the recorder, not the informant. The person who provided the name is unknown \u2014 most likely a household member, possibly a neighbor. Proximity is 'unknown' rather than 'household_member' because for names specifically, the enumerator may have heard the name from a neighbor or made an assumption \u2014 the name fact doesn't necessarily require active reporting the way age/birthplace does.\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_001\",\n      \"place\": null,\n      \"record_id\": \"ark:/61903/1:1:MXYZ\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_001\",\n      \"structured_value\": {\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"value\": \"Patrick Flynn\"\n    },\n    {\n      \"date\": \"~1845\",\n      \"date_certainty\": \"estimated\",\n      \"evidence_type\": \"indirect\",\n      \"extracted_for_question_ids\": [\n        \"q_002\"\n      ],\n      \"fact_type\": \"birth\",\n      \"id\": \"a_002\",\n      \"informant\": \"Unknown \u2014 most likely a household member (such as Thomas Flynn or his wife), but possibly a neighbor\",\n      \"informant_bias_notes\": \"Age and birthplace require active reporting by an informant \u2014 someone had to tell the enumerator these facts. That informant was most likely a household member, but enumerators also took information from neighbors when residents were unavailable, and the census does not identify who answered. Proximity is 'unknown' because the informant cannot be established from the record.\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_001\",\n      \"place\": \"Ireland\",\n      \"record_id\": \"ark:/61903/1:1:MXYZ\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_001\",\n      \"structured_value\": {\n        \"place\": \"Ireland\",\n        \"year\": 1845\n      },\n      \"value\": \"age 5\"\n    },\n    {\n      \"date\": \"1850\",\n      \"date_certainty\": \"exact\",\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_002\"\n      ],\n      \"fact_type\": \"residence\",\n      \"id\": \"a_003\",\n      \"informant\": \"Census enumerator (witness to residence by visiting the dwelling)\",\n      \"informant_bias_notes\": \"For residence facts specifically, the enumerator is a direct witness \u2014 they physically visited the dwelling and recorded who lived there. This distinguishes residence from other census facts where an unidentified informant (most likely a household member, possibly a neighbor) supplied the information.\",\n      \"informant_proximity\": \"witness\",\n      \"information_quality\": \"primary\",\n      \"log_entry_id\": \"log_001\",\n      \"place\": \"Schuylkill County, Pennsylvania\",\n      \"record_id\": \"ark:/61903/1:1:MXYZ\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_001\",\n      \"value\": \"Schuylkill County, Pennsylvania\"\n    },\n    {\n      \"date\": \"1850\",\n      \"date_certainty\": \"exact\",\n      \"evidence_type\": \"indirect\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"relationship\",\n      \"id\": \"a_004\",\n      \"informant\": \"Inferred from household structure \u2014 no explicit informant for relationships in 1850 census\",\n      \"informant_bias_notes\": \"1850 census does not state relationships; this assertion is inferred from household position and shared surname, not directly reported by any informant. The relationship is indirect evidence constructed by the researcher, not information provided by a census informant.\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_001\",\n      \"place\": \"Schuylkill County, Pennsylvania\",\n      \"record_id\": \"ark:/61903/1:1:MXYZ\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_001\",\n      \"structured_value\": {\n        \"related_person_role\": \"head_of_household\",\n        \"relationship_type\": \"child_inferred\"\n      },\n      \"value\": \"Listed in household of Thomas Flynn (head), position consistent with child\"\n    },\n    {\n      \"date\": null,\n      \"date_certainty\": null,\n      \"evidence_type\": \"indirect\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"name\",\n      \"id\": \"a_005\",\n      \"informant\": \"Unknown informant (likely Thomas Flynn himself) reporting to census enumerator\",\n      \"informant_bias_notes\": \"Census enumerator is the recorder, not the informant. As head of household, Thomas likely provided his own name, but the 1850 census does not identify the informant.\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_001\",\n      \"place\": null,\n      \"record_id\": \"ark:/61903/1:1:MXYZ\",\n      \"record_role\": \"head_of_household\",\n      \"source_id\": \"src_001\",\n      \"value\": \"Thomas Flynn\"\n    },\n    {\n      \"date\": null,\n      \"date_certainty\": null,\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_002\"\n      ],\n      \"fact_type\": \"name\",\n      \"id\": \"a_006\",\n      \"informant\": \"Ancestry transcriber (derivative of census enumerator)\",\n      \"informant_bias_notes\": \"Derivative index \u2014 transcription errors possible\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_002\",\n      \"place\": null,\n      \"record_id\": \"ancestry:8054:patrick-flynn-1850\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_002\",\n      \"value\": \"Patrick Flynn\"\n    },\n    {\n      \"date\": \"~1845\",\n      \"date_certainty\": \"estimated\",\n      \"evidence_type\": \"indirect\",\n      \"extracted_for_question_ids\": [\n        \"q_002\"\n      ],\n      \"fact_type\": \"birth\",\n      \"id\": \"a_007\",\n      \"informant\": \"Ancestry transcriber (derivative)\",\n      \"informant_bias_notes\": null,\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_002\",\n      \"place\": \"Ireland\",\n      \"record_id\": \"ancestry:8054:patrick-flynn-1850\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_002\",\n      \"value\": \"age 5\"\n    },\n    {\n      \"date\": null,\n      \"date_certainty\": null,\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"name\",\n      \"id\": \"a_008\",\n      \"informant\": \"Unknown informant (most likely a household member, possibly a neighbor) reporting to census enumerator\",\n      \"informant_bias_notes\": \"Census enumerator is the recorder, not the informant. Proximity is 'unknown' for names (same reasoning as a_001 \u2014 name facts don't necessarily require active reporting).\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_004\",\n      \"place\": null,\n      \"record_id\": \"ark:/61903/1:1:MABC\",\n      \"record_role\": \"child_2\",\n      \"source_id\": \"src_003\",\n      \"value\": \"Patrick Flynn\"\n    },\n    {\n      \"date\": \"~1845\",\n      \"date_certainty\": \"estimated\",\n      \"evidence_type\": \"indirect\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"birth\",\n      \"id\": \"a_009\",\n      \"informant\": \"Unknown \u2014 most likely a household member (such as Thomas Flynn or his wife), but possibly a neighbor\",\n      \"informant_bias_notes\": \"Age and birthplace require active reporting by an informant \u2014 most likely a household member, possibly a neighbor (same reasoning as a_002).\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_004\",\n      \"place\": \"Ireland\",\n      \"record_id\": \"ark:/61903/1:1:MABC\",\n      \"record_role\": \"child_2\",\n      \"source_id\": \"src_003\",\n      \"value\": \"age 15\"\n    },\n    {\n      \"date\": \"1860\",\n      \"date_certainty\": \"exact\",\n      \"evidence_type\": \"indirect\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"relationship\",\n      \"id\": \"a_010\",\n      \"informant\": \"Inferred from household structure \u2014 no explicit informant for relationships in 1860 census\",\n      \"informant_bias_notes\": \"1860 census does not state relationships; like the 1850 census, this assertion is inferred from household position, age, and shared surname. The relationship column was not introduced until the 1880 census.\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_004\",\n      \"place\": \"Schuylkill County, Pennsylvania\",\n      \"record_id\": \"ark:/61903/1:1:MABC\",\n      \"record_role\": \"child_2\",\n      \"source_id\": \"src_003\",\n      \"structured_value\": {\n        \"related_person_role\": \"head_of_household\",\n        \"relationship_type\": \"child_inferred\"\n      },\n      \"value\": \"Listed in household of Thomas Flynn (head), position and age consistent with son\"\n    },\n    {\n      \"date\": \"1908-03-12\",\n      \"date_certainty\": \"exact\",\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [],\n      \"fact_type\": \"death\",\n      \"id\": \"a_011\",\n      \"informant\": \"Attending physician (signature on certificate)\",\n      \"informant_bias_notes\": null,\n      \"informant_proximity\": \"witness\",\n      \"information_quality\": \"primary\",\n      \"log_entry_id\": \"log_005\",\n      \"place\": \"Schuylkill County, Pennsylvania\",\n      \"record_id\": \"ark:/61903/1:1:MDEF\",\n      \"record_role\": \"deceased\",\n      \"source_id\": \"src_004\",\n      \"value\": \"Died 12 March 1908\"\n    },\n    {\n      \"date\": \"1845\",\n      \"date_certainty\": \"approximate\",\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"birth\",\n      \"id\": \"a_012\",\n      \"informant\": \"James Brown (son-in-law)\",\n      \"informant_bias_notes\": \"Son-in-law reporting birth facts decades after the event. Note: death cert says Pennsylvania, but census records say Ireland. Son-in-law may not have known Patrick was born in Ireland.\",\n      \"informant_proximity\": \"family_not_present\",\n      \"information_quality\": \"secondary\",\n      \"log_entry_id\": \"log_005\",\n      \"place\": \"Pennsylvania\",\n      \"record_id\": \"ark:/61903/1:1:MDEF\",\n      \"record_role\": \"deceased\",\n      \"source_id\": \"src_004\",\n      \"structured_value\": {\n        \"place\": \"Pennsylvania\",\n        \"year\": 1845\n      },\n      \"value\": \"Born 1845, Pennsylvania\"\n    },\n    {\n      \"date\": null,\n      \"date_certainty\": null,\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"relationship\",\n      \"id\": \"a_013\",\n      \"informant\": \"James Brown (son-in-law)\",\n      \"informant_bias_notes\": \"Secondary information \u2014 son-in-law reporting what he was told about father-in-law's parentage\",\n      \"informant_proximity\": \"family_not_present\",\n      \"information_quality\": \"secondary\",\n      \"log_entry_id\": \"log_005\",\n      \"place\": null,\n      \"record_id\": \"ark:/61903/1:1:MDEF\",\n      \"record_role\": \"deceased\",\n      \"source_id\": \"src_004\",\n      \"structured_value\": {\n        \"related_person_role\": \"deceased\",\n        \"relationship_type\": \"father\"\n      },\n      \"value\": \"Father: Thomas Flynn\"\n    }\n  ],\n  \"conflicts\": [\n    {\n      \"blocks_question_ids\": [],\n      \"competing_assertion_ids\": [\n        \"a_002\",\n        \"a_009\",\n        \"a_012\"\n      ],\n      \"conflict_type\": \"fact\",\n      \"description\": \"Patrick Flynn's birthplace: Ireland (1850 and 1860 censuses) vs. Pennsylvania (1908 death certificate)\",\n      \"disputed_attribute\": \"birthplace\",\n      \"id\": \"c_001\",\n      \"identity_question\": null,\n      \"independence_analysis\": \"The two census records (1850, 1860) are independent original sources with different enumerators. The death certificate is a third independent original source. However, the census informants are likely the same household member (Thomas Flynn or wife), so the two census assertions may share a single informant \u2014 potentially not fully independent for this fact.\",\n      \"preferred_assertion_id\": \"a_002\",\n      \"resolution_rationale\": \"Ireland is accepted as the birthplace. The 1908 death certificate birthplace of 'Pennsylvania' is rejected as a likely error by the son-in-law informant, who may have confused Patrick's place of residence with his place of birth, or may not have known Patrick was born in Ireland before immigrating as a young child.\",\n      \"status\": \"resolved\",\n      \"weighing_analysis\": \"The census records are contemporary recordings made near the time of Patrick's birth, while the death certificate was created 63 years later. The census informant was likely a household member with firsthand knowledge (primary or indeterminate), while the death certificate informant (son-in-law) is clearly secondary for birth facts. Two contemporary sources outweigh one later recollection by a secondary informant.\"\n    }\n  ],\n  \"evaluations\": [],\n  \"hypotheses\": [\n    {\n      \"claim\": \"Patrick Flynn's father was Thomas Flynn of Schuylkill County, Pennsylvania\",\n      \"contradicting_assertion_ids\": [],\n      \"id\": \"h_001\",\n      \"notes\": \"Three independent pieces of evidence: 1850 census co-enumeration (indirect), 1860 census co-enumeration (indirect \u2014 relationship inferred from household position), death certificate naming Thomas as father (direct, secondary informant). Awaiting probate records for additional confirmation.\",\n      \"related_question_ids\": [\n        \"q_001\"\n      ],\n      \"ruled_out\": false,\n      \"ruled_out_reason\": null,\n      \"status\": \"supported\",\n      \"supporting_assertion_ids\": [\n        \"a_004\",\n        \"a_010\",\n        \"a_013\"\n      ]\n    }\n  ],\n  \"log\": [\n    {\n      \"external_site\": null,\n      \"id\": \"log_001\",\n      \"notes\": \"Found Patrick Flynn age 5 in household of Thomas Flynn, dwelling 84, Schuylkill Co. Three other Flynn results examined \u2014 ages and locations don't match.\",\n      \"outcome\": \"positive\",\n      \"performed\": \"2026-05-01T10:15:00Z\",\n      \"plan_item_id\": \"pli_001\",\n      \"query\": {\n        \"birth_place\": \"Pennsylvania\",\n        \"birth_year\": 1845,\n        \"collection\": \"1850 Census\",\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"results_examined\": 8,\n      \"tool\": \"record_search\"\n    },\n    {\n      \"external_site\": {\n        \"capture_filename\": \"ancestry-1850-flynn-results.pdf\",\n        \"capture_received\": true,\n        \"site\": \"ancestry\",\n        \"url_generated\": \"https://www.ancestry.com/search/collections/8054/?name=Patrick_Flynn&birth=1845&birthplace=Pennsylvania\"\n      },\n      \"id\": \"log_002\",\n      \"notes\": \"Ancestry index confirms same household. Transcription matches FamilySearch except Ancestry reads dwelling as 84, FamilySearch as 84 \u2014 consistent.\",\n      \"outcome\": \"positive\",\n      \"performed\": \"2026-05-01T11:30:00Z\",\n      \"plan_item_id\": \"pli_002\",\n      \"query\": {\n        \"birth_place\": \"Pennsylvania\",\n        \"birth_year\": 1845,\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"results_examined\": 12,\n      \"tool\": \"external_site\"\n    },\n    {\n      \"external_site\": {\n        \"capture_filename\": \"myheritage-1850-flynn-nil.pdf\",\n        \"capture_received\": true,\n        \"site\": \"myheritage\",\n        \"url_generated\": \"https://www.myheritage.com/research?action=query&first=Patrick&last=Flynn&birth_year=1845&birth_place=Pennsylvania\"\n      },\n      \"id\": \"log_003\",\n      \"notes\": \"MyHeritage returned no results for Patrick Flynn in 1850 Schuylkill County. Site may not have this collection indexed. Searched broader Pennsylvania \u2014 still no match.\",\n      \"outcome\": \"negative\",\n      \"performed\": \"2026-05-01T14:00:00Z\",\n      \"plan_item_id\": \"pli_003\",\n      \"query\": {\n        \"birth_place\": \"Pennsylvania\",\n        \"birth_year\": 1845,\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"results_examined\": 0,\n      \"tool\": \"external_site\"\n    },\n    {\n      \"external_site\": null,\n      \"id\": \"log_004\",\n      \"notes\": \"Patrick Flynn age 15 in household of Thomas Flynn, Schuylkill Co. Consistent with 1850 placement.\",\n      \"outcome\": \"positive\",\n      \"performed\": \"2026-05-02T09:00:00Z\",\n      \"plan_item_id\": \"pli_004\",\n      \"query\": {\n        \"birth_place\": \"Pennsylvania\",\n        \"birth_year\": 1845,\n        \"collection\": \"1860 Census\",\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"results_examined\": 5,\n      \"tool\": \"record_search\"\n    },\n    {\n      \"external_site\": null,\n      \"id\": \"log_005\",\n      \"notes\": \"Death certificate found. Names Thomas Flynn as father. Informant was son-in-law James Brown.\",\n      \"outcome\": \"positive\",\n      \"performed\": \"2026-05-03T10:00:00Z\",\n      \"plan_item_id\": \"pli_005\",\n      \"query\": {\n        \"death_place\": \"Schuylkill County, Pennsylvania\",\n        \"death_year\": 1908,\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"results_examined\": 2,\n      \"tool\": \"record_search\"\n    }\n  ],\n  \"person_evidence\": [\n    {\n      \"assertion_id\": \"a_001\",\n      \"confidence\": \"confident\",\n      \"created\": \"2026-05-01\",\n      \"id\": \"pe_001\",\n      \"match_score\": null,\n      \"person_id\": \"I1\",\n      \"rationale\": \"Name matches (Patrick Flynn), age consistent with ~1845 birth, located in Schuylkill County where subject is known to have lived. Only Patrick Flynn of this age in the county in 1850.\",\n      \"superseded_by\": null\n    },\n    {\n      \"assertion_id\": \"a_004\",\n      \"confidence\": \"probable\",\n      \"created\": \"2026-05-01\",\n      \"id\": \"pe_002\",\n      \"match_score\": null,\n      \"person_id\": \"I1\",\n      \"rationale\": \"Same record as pe_001, same person. Household position and shared surname with head Thomas Flynn suggest parent-child relationship, but 1850 census does not state relationships explicitly.\",\n      \"superseded_by\": null\n    },\n    {\n      \"assertion_id\": \"a_004\",\n      \"confidence\": \"probable\",\n      \"created\": \"2026-05-01\",\n      \"id\": \"pe_006\",\n      \"match_score\": null,\n      \"person_id\": \"I2\",\n      \"rationale\": \"Same assertion as pe_002 but linked to Thomas Flynn (I2). The relationship assertion ('position consistent with child') equally bears on the head of household. Thomas Flynn is the other party in the implied parent-child relationship.\",\n      \"superseded_by\": null\n    },\n    {\n      \"assertion_id\": \"a_005\",\n      \"confidence\": \"probable\",\n      \"created\": \"2026-05-01\",\n      \"id\": \"pe_003\",\n      \"match_score\": 0.82,\n      \"person_id\": \"I2\",\n      \"rationale\": \"Thomas Flynn, head of household where Patrick was found. Age (~32 in 1850, born ~1818) is consistent with being Patrick's father. Name matches candidate father.\",\n      \"superseded_by\": null\n    },\n    {\n      \"assertion_id\": \"a_010\",\n      \"confidence\": \"confident\",\n      \"created\": \"2026-05-02\",\n      \"id\": \"pe_004\",\n      \"match_score\": null,\n      \"person_id\": \"I1\",\n      \"rationale\": \"Patrick Flynn age 15 in Thomas Flynn household, 1860 census. Same county, age consistent with 1850 enumeration. Relationship inferred from household position and shared surname (1860 census does not state relationships explicitly).\",\n      \"superseded_by\": null\n    },\n    {\n      \"assertion_id\": \"a_013\",\n      \"confidence\": \"confident\",\n      \"created\": \"2026-05-03\",\n      \"id\": \"pe_005\",\n      \"match_score\": null,\n      \"person_id\": \"I1\",\n      \"rationale\": \"Death certificate for Patrick Flynn, d. 1908, Schuylkill County. Names match, death location matches known residence. Names Thomas Flynn as father.\",\n      \"superseded_by\": null\n    }\n  ],\n  \"plans\": [\n    {\n      \"created\": \"2026-05-01\",\n      \"id\": \"pl_001\",\n      \"items\": [\n        {\n          \"date_range\": \"1850\",\n          \"fallback_for\": null,\n          \"id\": \"pli_001\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"1850 census fully indexed on FamilySearch. Free access, start here.\",\n          \"record_type\": \"census\",\n          \"repository\": \"FamilySearch\",\n          \"sequence\": 1,\n          \"status\": \"completed\"\n        },\n        {\n          \"date_range\": \"1850\",\n          \"fallback_for\": null,\n          \"id\": \"pli_002\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"Ancestry has independent indexing; cross-check for transcription errors.\",\n          \"record_type\": \"census\",\n          \"repository\": \"Ancestry\",\n          \"sequence\": 2,\n          \"status\": \"completed\"\n        },\n        {\n          \"date_range\": \"1850\",\n          \"fallback_for\": null,\n          \"id\": \"pli_003\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"Third independent index for coverage confirmation.\",\n          \"record_type\": \"census\",\n          \"repository\": \"MyHeritage\",\n          \"sequence\": 3,\n          \"status\": \"completed\"\n        }\n      ],\n      \"question_id\": \"q_002\",\n      \"status\": \"completed\"\n    },\n    {\n      \"created\": \"2026-05-02\",\n      \"id\": \"pl_002\",\n      \"items\": [\n        {\n          \"date_range\": \"1860\",\n          \"fallback_for\": null,\n          \"id\": \"pli_004\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"Confirm Patrick still in Thomas Flynn household in 1860. Strengthens parent-child identification.\",\n          \"record_type\": \"census\",\n          \"repository\": \"FamilySearch\",\n          \"sequence\": 1,\n          \"status\": \"completed\"\n        },\n        {\n          \"date_range\": \"1908\",\n          \"fallback_for\": null,\n          \"id\": \"pli_005\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"Death certificate may name parents directly.\",\n          \"record_type\": \"vital_record\",\n          \"repository\": \"FamilySearch\",\n          \"sequence\": 2,\n          \"status\": \"completed\"\n        },\n        {\n          \"date_range\": \"1870-1890\",\n          \"fallback_for\": null,\n          \"id\": \"pli_006\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"Thomas Flynn probate/will may name Patrick as son.\",\n          \"record_type\": \"probate\",\n          \"repository\": \"FamilySearch\",\n          \"sequence\": 3,\n          \"status\": \"in_progress\"\n        }\n      ],\n      \"question_id\": \"q_001\",\n      \"status\": \"active\"\n    }\n  ],\n  \"project\": {\n    \"created\": \"2026-05-01\",\n    \"id\": \"rp_001\",\n    \"objective\": \"Identify the parents of Patrick Flynn, born ca. 1845 in Pennsylvania, died 1908 in Schuylkill County, PA\",\n    \"status\": \"active\",\n    \"subject_person_ids\": [\n      \"I1\"\n    ],\n    \"updated\": \"2026-05-04\"\n  },\n  \"proof_summaries\": [\n    {\n      \"exhaustive_search_summary\": \"Searched 1850 census (FamilySearch, Ancestry, MyHeritage \u2014 log_001, log_002, log_003), 1860 census (FamilySearch \u2014 log_004), and death certificate (FamilySearch \u2014 log_005). Probate search in progress. 1870, 1880, and 1900 censuses not yet searched.\",\n      \"id\": \"ps_001\",\n      \"narrative_markdown\": \"## Parentage of Patrick Flynn (ca. 1845\u20131908)\\n\\nPatrick Flynn is **Probably** the son of Thomas Flynn of Schuylkill County, Pennsylvania.\\n\\n### Evidence Summary\\n\\nThree independent lines of evidence support this conclusion:\\n\\n1. **1850 U.S. Census** (Original Source). Patrick Flynn, age 5, born Ireland, appears in the household of Thomas Flynn, age 32, born Ireland, in Schuylkill County, Pennsylvania (dwelling 84, family 91). The 1850 census does not state relationships, but Patrick's position in the household and shared surname are consistent with a parent-child relationship. The informant is indeterminate but likely a household member. This constitutes indirect evidence of parentage.\\n\\n2. **1860 U.S. Census** (Original Source). Patrick Flynn, age 15, born Ireland, appears in the household of Thomas Flynn in Schuylkill County (dwelling 112, family 119). Like the 1850 census, the 1860 census does not state relationships explicitly (the relationship column was not introduced until 1880). Patrick's position in the household, shared surname, and age consistent with the 1850 enumeration support a parent-child relationship. This constitutes indirect evidence of parentage.\\n\\n3. **1908 Death Certificate** (Original Source). Patrick Flynn's death certificate (no. 4521, Pennsylvania Department of Health) names \\\"Thomas Flynn\\\" as his father. The informant was James Brown, identified as Patrick's son-in-law. As a son-in-law reporting his father-in-law's parentage, Brown is a secondary informant for this fact \u2014 he was not a witness to Patrick's birth and is reporting what he was told. Nevertheless, this is direct evidence naming the father.\\n\\n### Conflict Resolution\\n\\nA birthplace conflict exists: the 1850 and 1860 censuses list Patrick's birthplace as Ireland, while the 1908 death certificate states Pennsylvania. The two census records are contemporary recordings with informants likely present in the household, while the death certificate was created 63 years after Patrick's birth by a son-in-law with no firsthand knowledge of the event. Per the GPS preponderance hierarchy, contemporary recordings by closer informants outweigh later recollections by secondary informants. Ireland is accepted as the birthplace; the death certificate entry is attributed to informant error.\\n\\n### Assessment\\n\\nThe conclusion is rated **Probable** rather than **Proved** because: (a) both census sources (1850 and 1860) provide only indirect evidence of parentage (relationships not stated \u2014 the relationship column was not introduced until 1880), (b) the death certificate informant is secondary, and (c) research is not yet exhaustive \u2014 the 1870, 1880, and 1900 censuses have not been searched, and Thomas Flynn's probate records have not been located. If Thomas Flynn's will names Patrick as a son, or if additional census records confirm the relationship, the conclusion would advance to **Proved**.\\n\\n### Citations\\n\\n1. 1850 U.S. Census, Schuylkill County, Pennsylvania, population schedule, dwelling 84, family 91, Thomas Flynn household; NARA microfilm publication M432, roll 810; digital image, FamilySearch.org, accessed 1 May 2026.\\n2. 1860 U.S. Census, Schuylkill County, Pennsylvania, population schedule, dwelling 112, family 119, Thomas Flynn household; NARA microfilm publication M653, roll 1141; digital image, FamilySearch.org, accessed 2 May 2026.\\n3. Pennsylvania Department of Health, death certificate no. 4521 (1908), Patrick Flynn; Pennsylvania State Archives, Harrisburg; digital image, FamilySearch.org, accessed 3 May 2026.\",\n      \"question_id\": \"q_001\",\n      \"resolved_conflict_ids\": [\n        \"c_001\"\n      ],\n      \"supporting_assertion_ids\": [\n        \"a_004\",\n        \"a_010\",\n        \"a_013\"\n      ],\n      \"tier\": \"probable\",\n      \"vehicle\": \"summary\"\n    }\n  ],\n  \"questions\": [\n    {\n      \"created\": \"2026-05-01\",\n      \"depends_on\": [],\n      \"exhaustive_declaration\": {\n        \"declared\": false,\n        \"justification\": null,\n        \"log_entry_ids\": [],\n        \"stop_criteria\": null\n      },\n      \"id\": \"q_001\",\n      \"priority\": \"high\",\n      \"question\": \"Who were the parents of Patrick Flynn (b. ~1845, PA, d. 1908)?\",\n      \"rationale\": \"This is the primary research objective.\",\n      \"resolution_assertion_ids\": [],\n      \"resolved\": null,\n      \"selection_basis\": \"objective_decomposition\",\n      \"status\": \"in_progress\",\n      \"unblocks\": []\n    },\n    {\n      \"created\": \"2026-05-01\",\n      \"depends_on\": [],\n      \"exhaustive_declaration\": {\n        \"declared\": true,\n        \"justification\": \"Searched 1850 census for Schuylkill County on FamilySearch (indexed and browse), Ancestry (indexed), and MyHeritage (indexed). All three returned the same household. No other Patrick Flynn of matching age found in the county.\",\n        \"log_entry_ids\": [\n          \"log_001\",\n          \"log_002\",\n          \"log_003\"\n        ],\n        \"stop_criteria\": {\n          \"conflict_resolution\": \"No conflicts on the 1850 census placement question.\",\n          \"evidence_class\": \"Yes \u2014 FamilySearch provides original census image with indeterminate-quality information.\",\n          \"goal_alignment\": \"Yes \u2014 Patrick Flynn located in a specific 1850 household, answering the question.\",\n          \"independent_verification\": \"FamilySearch (original) and Ancestry (derivative) both return the same household. Two access paths, one underlying original.\",\n          \"original_substitution\": \"FamilySearch provides the original census image; Ancestry index is derivative but confirmed consistent.\",\n          \"overturn_risk\": \"Low \u2014 all three repositories agree, and no competing Patrick Flynn of matching age exists in the county.\",\n          \"repository_breadth\": \"Three major repositories searched (FamilySearch, Ancestry, MyHeritage). No additional known indexes of the 1850 Schuylkill County census exist.\"\n        }\n      },\n      \"id\": \"q_002\",\n      \"priority\": \"high\",\n      \"question\": \"Where was Patrick Flynn in the 1850 census?\",\n      \"rationale\": \"The 1850 census is the earliest enumeration where Patrick would appear by name (age ~5). Locating him in a household identifies candidate parents.\",\n      \"resolution_assertion_ids\": [\n        \"a_001\",\n        \"a_002\",\n        \"a_003\"\n      ],\n      \"resolved\": \"2026-05-02\",\n      \"selection_basis\": \"objective_decomposition\",\n      \"status\": \"resolved\",\n      \"unblocks\": [\n        \"q_001\"\n      ]\n    }\n  ],\n  \"sources\": [\n    {\n      \"access_date\": \"2026-05-01\",\n      \"citation\": \"1850 U.S. Census, Schuylkill County, Pennsylvania, population schedule, dwelling 84, family 91, Thomas Flynn household; NARA microfilm publication M432, roll 810; digital image, FamilySearch.org, accessed 1 May 2026.\",\n      \"citation_detail\": {\n        \"what\": \"1850 U.S. Federal Census, population schedule\",\n        \"when_accessed\": \"2026-05-01\",\n        \"when_created\": \"1850\",\n        \"where\": \"FamilySearch.org (NARA microfilm M432, roll 810)\",\n        \"where_within\": \"Schuylkill County, dwelling 84, family 91\",\n        \"who\": \"U.S. Census Bureau\"\n      },\n      \"gedcomx_source_description_id\": \"S1\",\n      \"id\": \"src_001\",\n      \"log_entry_id\": \"log_001\",\n      \"notes\": \"Image quality good. Enumerator handwriting clear.\",\n      \"repository\": \"FamilySearch\",\n      \"source_classification\": \"original\",\n      \"url\": \"https://www.familysearch.org/ark:/61903/1:1:MXYZ\",\n      \"url_archived\": null\n    },\n    {\n      \"access_date\": \"2026-05-01\",\n      \"citation\": \"1850 U.S. Census, Schuylkill County, Pennsylvania, population schedule, dwelling 84, Thomas Flynn household; digital image, Ancestry.com, accessed 1 May 2026.\",\n      \"citation_detail\": {\n        \"what\": \"1850 U.S. Federal Census, population schedule (Ancestry index)\",\n        \"when_accessed\": \"2026-05-01\",\n        \"when_created\": \"1850\",\n        \"where\": \"Ancestry.com\",\n        \"where_within\": \"Schuylkill County, dwelling 84\",\n        \"who\": \"U.S. Census Bureau\"\n      },\n      \"gedcomx_source_description_id\": \"S1\",\n      \"id\": \"src_002\",\n      \"log_entry_id\": \"log_002\",\n      \"notes\": \"Ancestry's index of the same original census. Transcription consistent with FamilySearch.\",\n      \"repository\": \"Ancestry\",\n      \"source_classification\": \"derivative\",\n      \"url\": null,\n      \"url_archived\": null\n    },\n    {\n      \"access_date\": \"2026-05-02\",\n      \"citation\": \"1860 U.S. Census, Schuylkill County, Pennsylvania, population schedule, dwelling 112, family 119, Thomas Flynn household; NARA microfilm publication M653, roll 1141; digital image, FamilySearch.org, accessed 2 May 2026.\",\n      \"citation_detail\": {\n        \"what\": \"1860 U.S. Federal Census, population schedule\",\n        \"when_accessed\": \"2026-05-02\",\n        \"when_created\": \"1860\",\n        \"where\": \"FamilySearch.org (NARA microfilm M653, roll 1141)\",\n        \"where_within\": \"Schuylkill County, dwelling 112, family 119\",\n        \"who\": \"U.S. Census Bureau\"\n      },\n      \"gedcomx_source_description_id\": \"S2\",\n      \"id\": \"src_003\",\n      \"log_entry_id\": \"log_004\",\n      \"notes\": null,\n      \"repository\": \"FamilySearch\",\n      \"source_classification\": \"original\",\n      \"url\": \"https://www.familysearch.org/ark:/61903/1:1:MABC\",\n      \"url_archived\": null\n    },\n    {\n      \"access_date\": \"2026-05-03\",\n      \"citation\": \"Pennsylvania Department of Health, death certificate no. 4521 (1908), Patrick Flynn; Pennsylvania State Archives, Harrisburg; digital image, FamilySearch.org, accessed 3 May 2026.\",\n      \"citation_detail\": {\n        \"what\": \"Death certificate no. 4521\",\n        \"when_accessed\": \"2026-05-03\",\n        \"when_created\": \"1908-03-14\",\n        \"where\": \"FamilySearch.org (Pennsylvania State Archives, Harrisburg)\",\n        \"where_within\": \"Certificate no. 4521\",\n        \"who\": \"Pennsylvania Department of Health; informant: James Brown (son-in-law)\"\n      },\n      \"gedcomx_source_description_id\": \"S3\",\n      \"id\": \"src_004\",\n      \"log_entry_id\": \"log_005\",\n      \"notes\": \"Informant is son-in-law James Brown. Primary for death facts, secondary for birth facts.\",\n      \"repository\": \"FamilySearch\",\n      \"source_classification\": \"original\",\n      \"url\": \"https://www.familysearch.org/ark:/61903/1:1:MDEF\",\n      \"url_archived\": null\n    },\n    {\n      \"access_date\": \"2026-05-10\",\n      \"citation\": \"St. Mary's Catholic Church, Pottsville, baptism of Patrick Flynn, 1845\",\n      \"citation_detail\": {\n        \"what\": \"Baptismal register, 1845\",\n        \"when_accessed\": \"2026-05-10\",\n        \"when_created\": \"1845\",\n        \"where\": \"FamilySearch.org\",\n        \"where_within\": \"Patrick Flynn entry\",\n        \"who\": \"St. Mary's Catholic Church, Pottsville\"\n      },\n      \"gedcomx_source_description_id\": \"S5\",\n      \"id\": \"src_005\",\n      \"log_entry_id\": null,\n      \"notes\": \"Rough working citation from record-extraction. Missing volume/page locator and full repository chain.\",\n      \"repository\": \"FamilySearch\",\n      \"source_classification\": \"original\",\n      \"url\": \"https://www.familysearch.org/ark:/61903/3:1:S3HT-D1MQ-NZH\",\n      \"url_archived\": null\n    },\n    {\n      \"access_date\": \"2026-05-10\",\n      \"citation\": \"Schuylkill County will of Thomas Flynn, 1881\",\n      \"citation_detail\": {\n        \"what\": \"Will of Thomas Flynn\",\n        \"when_accessed\": \"2026-05-10\",\n        \"when_created\": \"1881\",\n        \"where\": \"FamilySearch.org\",\n        \"where_within\": \"will of Thomas Flynn\",\n        \"who\": \"Schuylkill County Courthouse\"\n      },\n      \"gedcomx_source_description_id\": \"S4\",\n      \"id\": \"src_006\",\n      \"log_entry_id\": null,\n      \"notes\": \"Rough working citation from record-extraction. Creator should be the court, not the courthouse. Missing Will Book volume and page locator.\",\n      \"repository\": \"FamilySearch\",\n      \"source_classification\": \"original\",\n      \"url\": \"https://www.familysearch.org/ark:/61903/3:1:3Q9M-CS4V-7TXW\",\n      \"url_archived\": null\n    },\n    {\n      \"access_date\": \"2026-05-12\",\n      \"citation\": \"PA birth certificate, Mary Elizabeth Flynn, 1905\",\n      \"citation_detail\": {\n        \"what\": \"Birth certificate\",\n        \"when_accessed\": \"2026-05-12\",\n        \"when_created\": \"1905\",\n        \"where\": \"FamilySearch.org\",\n        \"where_within\": \"Mary Elizabeth Flynn entry\",\n        \"who\": \"FamilySearch\"\n      },\n      \"gedcomx_source_description_id\": \"S6\",\n      \"id\": \"src_007\",\n      \"log_entry_id\": null,\n      \"notes\": \"Rough working citation from record-extraction. who wrongly names the repository; missing certificate number (12455), birth date, and place.\",\n      \"repository\": \"FamilySearch\",\n      \"source_classification\": \"original\",\n      \"url\": \"https://www.familysearch.org/ark:/61903/1:1:6JZX-VKQM\",\n      \"url_archived\": null\n    },\n    {\n      \"access_date\": \"2026-05-12\",\n      \"citation\": \"Deed, Thomas Flynn to Patrick Flynn, 1881\",\n      \"citation_detail\": {\n        \"what\": \"Warranty deed\",\n        \"when_accessed\": \"2026-05-12\",\n        \"when_created\": \"1881\",\n        \"where\": \"FamilySearch.org\",\n        \"where_within\": \"Thomas Flynn to Patrick Flynn\",\n        \"who\": \"Schuylkill County Courthouse\"\n      },\n      \"gedcomx_source_description_id\": \"S7\",\n      \"id\": \"src_008\",\n      \"log_entry_id\": null,\n      \"notes\": \"Rough working citation from record-extraction. who should be the Recorder of Deeds (not the courthouse building); missing grantor/grantee, execution + recording dates, and Deed Book/page locator.\",\n      \"repository\": \"FamilySearch\",\n      \"source_classification\": \"original\",\n      \"url\": \"https://www.familysearch.org/ark:/61903/3:1:3QS7-89WF-9KCT\",\n      \"url_archived\": null\n    },\n    {\n      \"access_date\": \"2026-05-12\",\n      \"citation\": \"Patrick Flynn obituary, Pottsville Republican, 1908\",\n      \"citation_detail\": {\n        \"what\": \"Obituary\",\n        \"when_accessed\": \"2026-05-12\",\n        \"when_created\": \"1908\",\n        \"where\": \"FamilySearch.org\",\n        \"where_within\": \"obituary notice\",\n        \"who\": \"FamilySearch\"\n      },\n      \"gedcomx_source_description_id\": \"S8\",\n      \"id\": \"src_009\",\n      \"log_entry_id\": null,\n      \"notes\": \"Rough working citation from record-extraction. who wrongly names the repository; missing the quoted article title, exact publication date, page, and column number.\",\n      \"repository\": \"FamilySearch\",\n      \"source_classification\": \"original\",\n      \"url\": \"https://www.familysearch.org/ark:/61903/3:1:S3HY-6RKS-MGV\",\n      \"url_archived\": null\n    }\n  ],\n  \"timelines\": [\n    {\n      \"events\": [\n        {\n          \"assertion_ids\": [\n            \"a_002\",\n            \"a_009\"\n          ],\n          \"date\": \"~1845\",\n          \"date_certainty\": \"estimated\",\n          \"description\": \"Born in Ireland, estimated from census ages\",\n          \"event_type\": \"birth\",\n          \"place\": \"Ireland\"\n        },\n        {\n          \"assertion_ids\": [\n            \"a_003\",\n            \"a_004\"\n          ],\n          \"date\": \"1850\",\n          \"date_certainty\": \"exact\",\n          \"description\": \"Enumerated age 5 in Thomas Flynn household, dwelling 84\",\n          \"event_type\": \"census\",\n          \"place\": \"Schuylkill County, Pennsylvania\"\n        },\n        {\n          \"assertion_ids\": [\n            \"a_008\",\n            \"a_009\",\n            \"a_010\"\n          ],\n          \"date\": \"1860\",\n          \"date_certainty\": \"exact\",\n          \"description\": \"Enumerated age 15 in Thomas Flynn household, dwelling 112\",\n          \"event_type\": \"census\",\n          \"place\": \"Schuylkill County, Pennsylvania\"\n        },\n        {\n          \"assertion_ids\": [\n            \"a_011\",\n            \"a_013\"\n          ],\n          \"date\": \"1908-03-12\",\n          \"date_certainty\": \"exact\",\n          \"description\": \"Died, death certificate names Thomas Flynn as father\",\n          \"event_type\": \"death\",\n          \"place\": \"Schuylkill County, Pennsylvania\"\n        }\n      ],\n      \"gaps\": [\n        {\n          \"end\": \"1908-03-12\",\n          \"expected_events\": [\n            \"marriage\",\n            \"1870_census\",\n            \"1880_census\",\n            \"1900_census\",\n            \"residence\",\n            \"occupation\"\n          ],\n          \"severity\": \"high\",\n          \"start\": \"1860-01-01\"\n        }\n      ],\n      \"generated\": \"2026-05-03T12:00:00Z\",\n      \"hypothesis_id\": \"h_001\",\n      \"id\": \"t_001\",\n      \"impossibilities\": [],\n      \"label\": \"Patrick Flynn \u2014 assuming Thomas Flynn parentage\",\n      \"person_ids\": [\n        \"I1\"\n      ]\n    }\n  ]\n}\n",
+    "eval/fixtures/scenarios/mid-research-flynn/tree.gedcomx.json": "{\n  \"persons\": [\n    {\n      \"facts\": [\n        {\n          \"date\": \"~1845\",\n          \"id\": \"F1\",\n          \"place\": \"Ireland\",\n          \"primary\": true,\n          \"sources\": [\n            {\n              \"page\": \"1850 Census, Schuylkill Co., dwelling 84\",\n              \"ref\": \"S1\"\n            }\n          ],\n          \"type\": \"Birth\"\n        },\n        {\n          \"date\": \"1908-03-12\",\n          \"id\": \"F2\",\n          \"place\": \"Schuylkill County, Pennsylvania\",\n          \"sources\": [\n            {\n              \"page\": \"Death cert. no. 4521\",\n              \"ref\": \"S3\"\n            }\n          ],\n          \"type\": \"Death\"\n        }\n      ],\n      \"gender\": \"Male\",\n      \"id\": \"I1\",\n      \"names\": [\n        {\n          \"given\": \"Patrick\",\n          \"id\": \"N1\",\n          \"preferred\": true,\n          \"surname\": \"Flynn\",\n          \"type\": \"BirthName\"\n        }\n      ]\n    },\n    {\n      \"facts\": [\n        {\n          \"date\": \"~1818\",\n          \"id\": \"F3\",\n          \"place\": \"Ireland\",\n          \"primary\": true,\n          \"type\": \"Birth\"\n        }\n      ],\n      \"gender\": \"Male\",\n      \"id\": \"I2\",\n      \"names\": [\n        {\n          \"given\": \"Thomas\",\n          \"id\": \"N2\",\n          \"preferred\": true,\n          \"surname\": \"Flynn\",\n          \"type\": \"BirthName\"\n        }\n      ]\n    },\n    {\n      \"gender\": \"Female\",\n      \"id\": \"I3\",\n      \"names\": [\n        {\n          \"given\": \"Mary\",\n          \"id\": \"N3\",\n          \"preferred\": true,\n          \"surname\": \"Flynn\",\n          \"type\": \"BirthName\"\n        }\n      ]\n    },\n    {\n      \"gender\": \"Male\",\n      \"id\": \"I4\",\n      \"names\": [\n        {\n          \"given\": \"James\",\n          \"id\": \"N4\",\n          \"preferred\": true,\n          \"surname\": \"Flynn\",\n          \"type\": \"BirthName\"\n        }\n      ]\n    }\n  ],\n  \"relationships\": [\n    {\n      \"child\": \"I1\",\n      \"id\": \"R1\",\n      \"parent\": \"I2\",\n      \"sources\": [\n        {\n          \"page\": \"1850 Census, Schuylkill Co., dwelling 84\",\n          \"quality\": 2,\n          \"ref\": \"S1\"\n        },\n        {\n          \"page\": \"1860 Census, Schuylkill Co., dwelling 112\",\n          \"quality\": 2,\n          \"ref\": \"S2\"\n        },\n        {\n          \"page\": \"Death cert. no. 4521\",\n          \"quality\": 2,\n          \"ref\": \"S3\"\n        }\n      ],\n      \"type\": \"ParentChild\"\n    },\n    {\n      \"child\": \"I3\",\n      \"id\": \"R2\",\n      \"parent\": \"I2\",\n      \"sources\": [\n        {\n          \"page\": \"1850 Census, Schuylkill Co., dwelling 84\",\n          \"quality\": 2,\n          \"ref\": \"S1\"\n        }\n      ],\n      \"type\": \"ParentChild\"\n    },\n    {\n      \"child\": \"I4\",\n      \"id\": \"R3\",\n      \"parent\": \"I2\",\n      \"sources\": [\n        {\n          \"page\": \"1850 Census, Schuylkill Co., dwelling 84\",\n          \"quality\": 2,\n          \"ref\": \"S1\"\n        }\n      ],\n      \"type\": \"ParentChild\"\n    }\n  ],\n  \"sources\": [\n    {\n      \"author\": \"U.S. Census Bureau\",\n      \"id\": \"S1\",\n      \"title\": \"1850 U.S. Federal Census\"\n    },\n    {\n      \"author\": \"U.S. Census Bureau\",\n      \"id\": \"S2\",\n      \"title\": \"1860 U.S. Federal Census\"\n    },\n    {\n      \"author\": \"Pennsylvania Department of Health\",\n      \"id\": \"S3\",\n      \"title\": \"Pennsylvania Death Certificates\"\n    },\n    {\n      \"author\": \"Schuylkill County Register of Wills\",\n      \"id\": \"S4\",\n      \"title\": \"Schuylkill County Probate Records\"\n    },\n    {\n      \"author\": \"St. Mary's Catholic Church, Pottsville\",\n      \"id\": \"S5\",\n      \"title\": \"St. Mary's Catholic Church (Pottsville) Baptismal Registers\"\n    },\n    {\n      \"author\": \"Pennsylvania Department of Health\",\n      \"id\": \"S6\",\n      \"title\": \"Pennsylvania Birth Certificates\"\n    },\n    {\n      \"author\": \"Schuylkill County Recorder of Deeds\",\n      \"id\": \"S7\",\n      \"title\": \"Schuylkill County Deed Books\"\n    },\n    {\n      \"author\": \"Pottsville Republican\",\n      \"id\": \"S8\",\n      \"title\": \"Pottsville Republican (newspaper)\"\n    }\n  ]\n}\n",
+    "eval/fixtures/scenarios/mullen-price-child-middle-name/README.md": "# Scenario: mullen-price-child-middle-name\n\nA research project for a child named Sarah Ann Mullen Price (b. 1875,\nDodge County, WI). The name is ambiguous: \"Mullen\" could be a middle\ngiven name honoring her mother's maiden surname, or it could be her\nown birth surname if she later married a Price.\n\n## State\n\n- **Subject:** Sarah Ann Mullen Price (`I1`), b. 1875-08-20, Dodge\n  County, Wisconsin. Tree data has `given: \"Sarah Ann Mullen\"` and\n  `surname: \"Price\"` with type `BirthName`, reflecting the working\n  hypothesis that Mullen is a middle given name.\n- **Parents in tree:** Father James Price (`I2`), Mother Sarah Ann\n  Mullen/Price (`I3`, with both BirthName: Mullen and MarriedName: Price).\n- **One existing source** (1880 census) but no log entries yet for the\n  active plan items.\n- **Plan items:**\n  - `pli_001` \u2014 1880 census, Dodge County (find Sarah ~age 5 in a\n    household to confirm surname) \u2014 `in_progress`\n  - `pli_002` \u2014 1875 birth record, Dodge County (would name parents\n    definitively) \u2014 `planned`\n\n## What it exercises\n\n- The skill must use `surname: \"Price\"` (from the tree's BirthName\n  entry) as the primary search parameter, NOT put \"Mullen\" in the\n  surname field.\n- The `givenName` should be \"Sarah\" (or \"Sarah Ann\" / \"Sarah Ann\n  Mullen\"), keeping \"Mullen\" as part of the given name, not as a\n  `surnameAlt`.\n- Tests whether the skill correctly interprets a multi-token given\n  name where one token happens to be a family surname used as a\n  middle name.\n",
+    "eval/fixtures/scenarios/mullen-price-child-middle-name/research.json": "{\n  \"assertions\": [],\n  \"conflicts\": [],\n  \"evaluations\": [],\n  \"hypotheses\": [],\n  \"log\": [],\n  \"person_evidence\": [],\n  \"plans\": [\n    {\n      \"created\": \"2026-06-01\",\n      \"id\": \"pl_001\",\n      \"items\": [\n        {\n          \"date_range\": \"1880\",\n          \"fallback_for\": null,\n          \"id\": \"pli_001\",\n          \"jurisdiction\": \"Dodge County, Wisconsin\",\n          \"rationale\": \"The 1880 census should show Sarah (age ~5) in a household, with the head of household confirming whether her surname is Price (father's family) or Mullen (mother's maiden family). The 1880 census also records relationship to head.\",\n          \"record_type\": \"census\",\n          \"repository\": \"FamilySearch\",\n          \"sequence\": 1,\n          \"status\": \"in_progress\"\n        },\n        {\n          \"date_range\": \"1875\",\n          \"fallback_for\": null,\n          \"id\": \"pli_002\",\n          \"jurisdiction\": \"Dodge County, Wisconsin\",\n          \"rationale\": \"A birth record would name both parents, definitively resolving whether Mullen is a middle name or a birth surname.\",\n          \"record_type\": \"vital_record\",\n          \"repository\": \"FamilySearch\",\n          \"sequence\": 2,\n          \"status\": \"planned\"\n        }\n      ],\n      \"question_id\": \"q_001\",\n      \"status\": \"active\"\n    }\n  ],\n  \"project\": {\n    \"created\": \"2026-06-01\",\n    \"id\": \"rp_001\",\n    \"objective\": \"Locate records for Sarah Ann Mullen Price (b. 1875, Dodge County, WI) to confirm she is the daughter of James Price and Sarah Ann (Mullen) Price, not a daughter of a Mullen family\",\n    \"status\": \"active\",\n    \"subject_person_ids\": [\n      \"I1\"\n    ],\n    \"updated\": \"2026-06-01\"\n  },\n  \"proof_summaries\": [],\n  \"questions\": [\n    {\n      \"created\": \"2026-06-01\",\n      \"depends_on\": [],\n      \"exhaustive_declaration\": {\n        \"declared\": false,\n        \"justification\": null,\n        \"log_entry_ids\": [],\n        \"stop_criteria\": null\n      },\n      \"id\": \"q_001\",\n      \"priority\": \"high\",\n      \"question\": \"Is Sarah Ann Mullen Price (b. 1875) the daughter of James Price and Sarah Ann Mullen, with 'Mullen' being a middle given name honoring her mother's maiden surname?\",\n      \"rationale\": \"The child's full name 'Sarah Ann Mullen Price' is ambiguous: 'Mullen' could be a middle given name (honoring her mother's maiden surname) or it could indicate she was born a Mullen and married into the Price family. Birth or baptismal records naming her parents would resolve this.\",\n      \"resolution_assertion_ids\": [],\n      \"resolved\": null,\n      \"selection_basis\": \"objective_decomposition\",\n      \"status\": \"in_progress\",\n      \"unblocks\": []\n    }\n  ],\n  \"sources\": [\n    {\n      \"access_date\": \"2026-06-01\",\n      \"citation\": \"1880 U.S. Census, Dodge County, Wisconsin, population schedule, James Price household; digital image, FamilySearch.org, accessed 1 June 2026.\",\n      \"citation_detail\": {\n        \"what\": \"1880 U.S. Federal Census, population schedule\",\n        \"when_accessed\": \"2026-06-01\",\n        \"when_created\": \"1880\",\n        \"where\": \"FamilySearch.org\",\n        \"where_within\": \"Dodge County, James Price household\",\n        \"who\": \"U.S. Census Bureau\"\n      },\n      \"gedcomx_source_description_id\": \"S1\",\n      \"id\": \"src_001\",\n      \"log_entry_id\": null,\n      \"notes\": \"Source of the initial family composition; Sarah listed as 'Sarah M. Price', age 5, daughter. The 'M' initial likely stands for Mullen.\",\n      \"repository\": \"FamilySearch\",\n      \"source_classification\": \"original\",\n      \"transcription\": null,\n      \"url\": \"https://www.familysearch.org/ark:/61903/1:1:MXPR-001\",\n      \"url_archived\": null\n    }\n  ],\n  \"timelines\": []\n}\n",
+    "eval/fixtures/scenarios/mullen-price-child-middle-name/tree.gedcomx.json": "{\n  \"persons\": [\n    {\n      \"facts\": [\n        {\n          \"date\": \"1875-08-20\",\n          \"id\": \"F1\",\n          \"place\": \"Dodge County, Wisconsin\",\n          \"type\": \"Birth\"\n        }\n      ],\n      \"gender\": \"Female\",\n      \"id\": \"I1\",\n      \"names\": [\n        {\n          \"given\": \"Sarah Ann Mullen\",\n          \"id\": \"N1\",\n          \"preferred\": true,\n          \"surname\": \"Price\",\n          \"type\": \"BirthName\"\n        }\n      ]\n    },\n    {\n      \"facts\": [\n        {\n          \"date\": \"~1848\",\n          \"id\": \"F2\",\n          \"place\": \"Wales\",\n          \"type\": \"Birth\"\n        }\n      ],\n      \"gender\": \"Male\",\n      \"id\": \"I2\",\n      \"names\": [\n        {\n          \"given\": \"James\",\n          \"id\": \"N2\",\n          \"preferred\": true,\n          \"surname\": \"Price\",\n          \"type\": \"BirthName\"\n        }\n      ]\n    },\n    {\n      \"facts\": [\n        {\n          \"date\": \"1852-03-15\",\n          \"id\": \"F3\",\n          \"place\": \"Dodge County, Wisconsin\",\n          \"type\": \"Birth\"\n        }\n      ],\n      \"gender\": \"Female\",\n      \"id\": \"I3\",\n      \"names\": [\n        {\n          \"given\": \"Sarah Ann\",\n          \"id\": \"N3\",\n          \"preferred\": true,\n          \"surname\": \"Mullen\",\n          \"type\": \"BirthName\"\n        },\n        {\n          \"given\": \"Sarah Ann\",\n          \"id\": \"N4\",\n          \"preferred\": true,\n          \"surname\": \"Price\",\n          \"type\": \"MarriedName\"\n        }\n      ]\n    }\n  ],\n  \"relationships\": [\n    {\n      \"child\": \"I1\",\n      \"id\": \"RT1\",\n      \"parent\": \"I2\",\n      \"type\": \"ParentChild\"\n    },\n    {\n      \"child\": \"I1\",\n      \"id\": \"RT2\",\n      \"parent\": \"I3\",\n      \"type\": \"ParentChild\"\n    },\n    {\n      \"id\": \"RT3\",\n      \"person1\": \"I2\",\n      \"person2\": \"I3\",\n      \"type\": \"Couple\"\n    }\n  ],\n  \"sources\": [\n    {\n      \"id\": \"S1\",\n      \"title\": \"1880 U.S. Census, Dodge County, Wisconsin \u2014 James Price household\"\n    }\n  ]\n}\n",
+    "eval/fixtures/scenarios/mullen-price-multiple-marriages/README.md": "# Scenario: mullen-price-multiple-marriages\n\nA mid-research project for Sarah Ann Mullen's parentage. Sarah married\ntwice: first James Price (1872, Dodge County, WI), then Henry Mielke\n(1885, Fond du Lac County, WI). The tree carries three name entries\n(BirthName: Mullen, MarriedName: Price, MarriedName: Mielke).\n\n## State\n\n- **Subject:** Sarah Ann Mullen (`I1`), b. 1852-03-15, Dodge County,\n  Wisconsin. Tree also holds first husband James Price (`I2`), second\n  husband Henry Mielke (`I3`), and parents William (`I4`) and Margaret\n  (`I5`) Mullen.\n- **One gathered record** with sidecar:\n  - `log_001` \u2014 1880 census: Sarah A. Price age 28 in James Price's\n    household, born Wisconsin, parents born Ireland. Confirms the first\n    marriage but uses the married name only.\n- **Plan items:**\n  - `pli_001` \u2014 1860 census, Dodge County (find Sarah as a child in the\n    Mullen household) \u2014 `in_progress`\n  - `pli_002` \u2014 1872 marriage record (Sarah Mullen to James Price) \u2014 `planned`\n  - `pli_003` \u2014 1900 census, Fond du Lac County (Sarah under Mielke name) \u2014 `planned`\n\n## What it exercises\n\n- The skill must construct a search using the **maiden surname** (Mullen)\n  as the primary surname for the 1860 census search (pre-marriage), not\n  the married names.\n- For later searches (1900 census), the skill should use `surnameAlt`\n  to search across married names (Mielke primary, Price or Mullen as alt)\n  since the woman could appear under any surname.\n- Tests whether the skill correctly reads multiple `names[]` entries\n  with different `type` values and selects the appropriate one for each\n  time period.\n",
+    "eval/fixtures/scenarios/mullen-price-multiple-marriages/research.json": "{\n  \"assertions\": [\n    {\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"name\",\n      \"id\": \"a_001\",\n      \"informant\": \"Unknown informant reporting to the census enumerator\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_001\",\n      \"record_id\": \"https://www.familysearch.org/ark:/61903/1:1:MXPR-001\",\n      \"record_persona_id\": \"P1\",\n      \"record_role\": \"wife\",\n      \"source_id\": \"src_001\",\n      \"structured_value\": {\n        \"given\": \"Sarah A.\",\n        \"surname\": \"Price\"\n      },\n      \"value\": \"Sarah A. Price\"\n    }\n  ],\n  \"conflicts\": [],\n  \"evaluations\": [],\n  \"hypotheses\": [],\n  \"log\": [\n    {\n      \"external_site\": null,\n      \"id\": \"log_001\",\n      \"notes\": \"1880 census household of James Price; Sarah A. Price age 28, born Wisconsin. Parents born Ireland. Confirms first marriage.\",\n      \"outcome\": \"positive\",\n      \"performed\": \"2026-06-01T10:00:00Z\",\n      \"plan_item_id\": \"pli_001\",\n      \"query\": {\n        \"collection\": \"1880 Census\",\n        \"given\": \"Sarah\",\n        \"surname\": \"Price\"\n      },\n      \"results_available\": 1,\n      \"results_examined\": 1,\n      \"results_ref\": \"results/log_001.json\",\n      \"tool\": \"record_search\"\n    }\n  ],\n  \"person_evidence\": [],\n  \"plans\": [\n    {\n      \"created\": \"2026-06-01\",\n      \"id\": \"pl_001\",\n      \"items\": [\n        {\n          \"date_range\": \"1860\",\n          \"fallback_for\": null,\n          \"id\": \"pli_001\",\n          \"jurisdiction\": \"Dodge County, Wisconsin\",\n          \"rationale\": \"The 1860 census should show Sarah (age ~8) in her parents' household before her first marriage, confirming the Mullen surname and identifying her parents.\",\n          \"record_type\": \"census\",\n          \"repository\": \"FamilySearch\",\n          \"sequence\": 1,\n          \"status\": \"in_progress\"\n        },\n        {\n          \"date_range\": \"1872\",\n          \"fallback_for\": null,\n          \"id\": \"pli_002\",\n          \"jurisdiction\": \"Dodge County, Wisconsin\",\n          \"rationale\": \"The 1872 marriage record for Sarah Mullen and James Price should name her father, confirming parentage.\",\n          \"record_type\": \"vital_record\",\n          \"repository\": \"FamilySearch\",\n          \"sequence\": 2,\n          \"status\": \"planned\"\n        },\n        {\n          \"date_range\": \"1900\",\n          \"fallback_for\": null,\n          \"id\": \"pli_003\",\n          \"jurisdiction\": \"Fond du Lac County, Wisconsin\",\n          \"rationale\": \"The 1900 census should show Sarah under her second married name (Mielke) with Henry Mielke, confirming the continuity of identity across marriages.\",\n          \"record_type\": \"census\",\n          \"repository\": \"FamilySearch\",\n          \"sequence\": 3,\n          \"status\": \"planned\"\n        }\n      ],\n      \"question_id\": \"q_001\",\n      \"status\": \"active\"\n    }\n  ],\n  \"project\": {\n    \"created\": \"2026-06-01\",\n    \"id\": \"rp_001\",\n    \"objective\": \"Confirm Sarah Ann Mullen's parentage and trace her through two marriages (Price, then Mielke) in Dodge and Fond du Lac Counties, Wisconsin\",\n    \"status\": \"active\",\n    \"subject_person_ids\": [\n      \"I1\"\n    ],\n    \"updated\": \"2026-06-01\"\n  },\n  \"proof_summaries\": [],\n  \"questions\": [\n    {\n      \"created\": \"2026-06-01\",\n      \"depends_on\": [],\n      \"exhaustive_declaration\": {\n        \"declared\": false,\n        \"justification\": null,\n        \"log_entry_ids\": [],\n        \"stop_criteria\": null\n      },\n      \"id\": \"q_001\",\n      \"priority\": \"high\",\n      \"question\": \"Who were the parents of Sarah Ann Mullen (b. 1852, Dodge County, Wisconsin)?\",\n      \"rationale\": \"Primary research objective. An obituary names her birth surname as Mullen, but no birth record has been located. Census and marriage records may confirm parentage.\",\n      \"resolution_assertion_ids\": [],\n      \"resolved\": null,\n      \"selection_basis\": \"objective_decomposition\",\n      \"status\": \"in_progress\",\n      \"unblocks\": []\n    }\n  ],\n  \"sources\": [\n    {\n      \"access_date\": \"2026-06-01\",\n      \"citation\": \"1880 U.S. Census, Dodge County, Wisconsin, population schedule, James Price household; digital image, FamilySearch.org, accessed 1 June 2026.\",\n      \"citation_detail\": {\n        \"what\": \"1880 U.S. Federal Census, population schedule\",\n        \"when_accessed\": \"2026-06-01\",\n        \"when_created\": \"1880\",\n        \"where\": \"FamilySearch.org\",\n        \"where_within\": \"Dodge County, James Price household\",\n        \"who\": \"U.S. Census Bureau\"\n      },\n      \"gedcomx_source_description_id\": \"S1\",\n      \"id\": \"src_001\",\n      \"log_entry_id\": \"log_001\",\n      \"notes\": null,\n      \"repository\": \"FamilySearch\",\n      \"source_classification\": \"original\",\n      \"transcription\": null,\n      \"url\": \"https://www.familysearch.org/ark:/61903/1:1:MXPR-001\",\n      \"url_archived\": null\n    }\n  ],\n  \"timelines\": []\n}\n",
+    "eval/fixtures/scenarios/mullen-price-multiple-marriages/results/log_001.json": "{\n  \"log_id\": \"log_001\",\n  \"payload\": {\n    \"hasMore\": false,\n    \"offset\": 0,\n    \"paginationCappedAt\": 100,\n    \"query\": {\n      \"givenName\": \"Sarah\",\n      \"surname\": \"Price\"\n    },\n    \"results\": [\n      {\n        \"arkUrl\": \"https://www.familysearch.org/ark:/61903/1:1:MXPR-001\",\n        \"birthDate\": \"1852\",\n        \"birthPlace\": \"Wisconsin\",\n        \"collectionId\": \"1417683\",\n        \"collectionTitle\": \"United States Census, 1880\",\n        \"events\": [\n          {\n            \"date\": \"1880\",\n            \"place\": \"Dodge County, Wisconsin\",\n            \"type\": \"Residence\"\n          }\n        ],\n        \"gedcomx\": {\n          \"persons\": [\n            {\n              \"facts\": [\n                {\n                  \"date\": \"1852\",\n                  \"id\": \"F1\",\n                  \"place\": \"Wisconsin\",\n                  \"type\": \"Birth\"\n                },\n                {\n                  \"date\": \"1880\",\n                  \"id\": \"F2\",\n                  \"place\": \"Dodge County, Wisconsin\",\n                  \"type\": \"Residence\"\n                }\n              ],\n              \"gender\": \"Female\",\n              \"id\": \"P1\",\n              \"names\": [\n                {\n                  \"given\": \"Sarah A.\",\n                  \"id\": \"N1\",\n                  \"preferred\": true,\n                  \"surname\": \"Price\",\n                  \"type\": \"BirthName\"\n                }\n              ]\n            },\n            {\n              \"facts\": [\n                {\n                  \"date\": \"1848\",\n                  \"id\": \"F3\",\n                  \"place\": \"Wales\",\n                  \"type\": \"Birth\"\n                },\n                {\n                  \"date\": \"1880\",\n                  \"id\": \"F4\",\n                  \"place\": \"Dodge County, Wisconsin\",\n                  \"type\": \"Residence\"\n                }\n              ],\n              \"gender\": \"Male\",\n              \"id\": \"P2\",\n              \"names\": [\n                {\n                  \"given\": \"James\",\n                  \"id\": \"N2\",\n                  \"preferred\": true,\n                  \"surname\": \"Price\",\n                  \"type\": \"BirthName\"\n                }\n              ]\n            }\n          ],\n          \"relationships\": [\n            {\n              \"id\": \"R1\",\n              \"person1\": \"P2\",\n              \"person2\": \"P1\",\n              \"type\": \"Couple\"\n            }\n          ]\n        },\n        \"personId\": \"MXPR-001\",\n        \"personName\": \"Sarah A. Price\",\n        \"primaryId\": \"P1\",\n        \"recordId\": \"https://www.familysearch.org/ark:/61903/1:1:MXPR-001\",\n        \"recordTitle\": \"Sarah A. Price in household of James Price\",\n        \"score\": 0.88,\n        \"sex\": \"Female\",\n        \"treeMatches\": []\n      }\n    ],\n    \"returned\": 1,\n    \"totalMatches\": 1\n  },\n  \"retrieved\": \"2026-06-01T10:00:00Z\",\n  \"returned_count\": 1,\n  \"tool\": \"record_search\"\n}\n",
+    "eval/fixtures/scenarios/mullen-price-multiple-marriages/tree.gedcomx.json": "{\n  \"persons\": [\n    {\n      \"facts\": [\n        {\n          \"date\": \"1852-03-15\",\n          \"id\": \"F1\",\n          \"place\": \"Dodge County, Wisconsin\",\n          \"type\": \"Birth\"\n        },\n        {\n          \"date\": \"1872-06-10\",\n          \"id\": \"F2\",\n          \"place\": \"Dodge County, Wisconsin\",\n          \"type\": \"Marriage\"\n        },\n        {\n          \"date\": \"1885-11-22\",\n          \"id\": \"F3\",\n          \"place\": \"Fond du Lac County, Wisconsin\",\n          \"type\": \"Marriage\"\n        },\n        {\n          \"date\": \"1921-09-03\",\n          \"id\": \"F4\",\n          \"place\": \"Fond du Lac, Fond du Lac County, Wisconsin\",\n          \"type\": \"Death\"\n        }\n      ],\n      \"gender\": \"Female\",\n      \"id\": \"I1\",\n      \"names\": [\n        {\n          \"given\": \"Sarah Ann\",\n          \"id\": \"N1\",\n          \"preferred\": true,\n          \"surname\": \"Mullen\",\n          \"type\": \"BirthName\"\n        },\n        {\n          \"given\": \"Sarah Ann\",\n          \"id\": \"N2\",\n          \"preferred\": true,\n          \"surname\": \"Price\",\n          \"type\": \"MarriedName\"\n        },\n        {\n          \"given\": \"Sarah Ann\",\n          \"id\": \"N3\",\n          \"preferred\": true,\n          \"surname\": \"Mielke\",\n          \"type\": \"MarriedName\"\n        }\n      ]\n    },\n    {\n      \"facts\": [\n        {\n          \"date\": \"~1848\",\n          \"id\": \"F5\",\n          \"place\": \"Wales\",\n          \"type\": \"Birth\"\n        },\n        {\n          \"date\": \"1883-02-14\",\n          \"id\": \"F6\",\n          \"place\": \"Dodge County, Wisconsin\",\n          \"type\": \"Death\"\n        }\n      ],\n      \"gender\": \"Male\",\n      \"id\": \"I2\",\n      \"names\": [\n        {\n          \"given\": \"James\",\n          \"id\": \"N4\",\n          \"preferred\": true,\n          \"surname\": \"Price\",\n          \"type\": \"BirthName\"\n        }\n      ]\n    },\n    {\n      \"facts\": [\n        {\n          \"date\": \"~1850\",\n          \"id\": \"F7\",\n          \"place\": \"Prussia\",\n          \"type\": \"Birth\"\n        }\n      ],\n      \"gender\": \"Male\",\n      \"id\": \"I3\",\n      \"names\": [\n        {\n          \"given\": \"Henry\",\n          \"id\": \"N5\",\n          \"preferred\": true,\n          \"surname\": \"Mielke\",\n          \"type\": \"BirthName\"\n        }\n      ]\n    },\n    {\n      \"facts\": [\n        {\n          \"date\": \"~1825\",\n          \"id\": \"F8\",\n          \"place\": \"Ireland\",\n          \"type\": \"Birth\"\n        }\n      ],\n      \"gender\": \"Male\",\n      \"id\": \"I4\",\n      \"names\": [\n        {\n          \"given\": \"William\",\n          \"id\": \"N6\",\n          \"preferred\": true,\n          \"surname\": \"Mullen\",\n          \"type\": \"BirthName\"\n        }\n      ]\n    },\n    {\n      \"facts\": [],\n      \"gender\": \"Female\",\n      \"id\": \"I5\",\n      \"names\": [\n        {\n          \"given\": \"Margaret\",\n          \"id\": \"N7\",\n          \"preferred\": true,\n          \"surname\": \"Mullen\",\n          \"type\": \"MarriedName\"\n        }\n      ]\n    }\n  ],\n  \"relationships\": [\n    {\n      \"id\": \"RT1\",\n      \"person1\": \"I2\",\n      \"person2\": \"I1\",\n      \"type\": \"Couple\"\n    },\n    {\n      \"id\": \"RT2\",\n      \"person1\": \"I3\",\n      \"person2\": \"I1\",\n      \"type\": \"Couple\"\n    },\n    {\n      \"child\": \"I1\",\n      \"id\": \"RT3\",\n      \"parent\": \"I4\",\n      \"type\": \"ParentChild\"\n    },\n    {\n      \"child\": \"I1\",\n      \"id\": \"RT4\",\n      \"parent\": \"I5\",\n      \"type\": \"ParentChild\"\n    }\n  ],\n  \"sources\": [\n    {\n      \"id\": \"S1\",\n      \"title\": \"1880 U.S. Census, Dodge County, Wisconsin \u2014 James Price household\"\n    }\n  ]\n}\n",
+    "eval/fixtures/mcp/record-attachments-flynn-census.json": "{\n  \"args\": {\n    \"uris\": \"~\"\n  },\n  \"description\": \"Attachment check for the 1850 census Flynn household ARK. Returns Patrick Flynn's record as attached to tree person KWCJ-RN4 (the research subject), and Thomas Flynn's record as unattached \u2014 simulating the typical triage scenario where some results are already in the tree and others are new evidence.\",\n  \"input_schema\": {\n    \"properties\": {\n      \"uris\": {\n        \"description\": \"List of historical record persona ARK URLs to check. These come from the arkUrl field of record_search results.\",\n        \"items\": {\n          \"type\": \"string\"\n        },\n        \"type\": \"array\"\n      }\n    },\n    \"required\": [\n      \"uris\"\n    ],\n    \"type\": \"object\"\n  },\n  \"response\": {\n    \"attachments\": {\n      \"https://www.familysearch.org/ark:/61903/1:1:MXHY-TP4\": [\n        {\n          \"personId\": \"KWCJ-RN4\",\n          \"tags\": [\n            \"Name\",\n            \"Birth\",\n            \"Residence\"\n          ]\n        }\n      ]\n    },\n    \"unattached\": [\n      \"https://www.familysearch.org/ark:/61903/1:1:MXHY-TP5\"\n    ]\n  },\n  \"tool\": \"source_attachments\"\n}\n",
+    "eval/fixtures/mcp/record-search-1850-census-flynn.json": "{\n  \"args\": {\n    \"givenName\": \"~Patrick\",\n    \"surname\": \"Flynn\"\n  },\n  \"description\": \"FamilySearch record search returning the 1850 US Census household of Thomas Flynn, with Patrick Flynn (age 5) as the focus person. Carries the real RecordSearchToolResponse shape \u2014 results[].gedcomx + primaryId + arkUrl \u2014 so it feeds both this fixture and the scenario sidecar.\",\n  \"response\": {\n    \"hasMore\": false,\n    \"offset\": 0,\n    \"paginationCappedAt\": 100,\n    \"query\": {\n      \"givenName\": \"Patrick\",\n      \"surname\": \"Flynn\"\n    },\n    \"results\": [\n      {\n        \"arkUrl\": \"https://www.familysearch.org/ark:/61903/1:1:MXHY-TP4\",\n        \"birthDate\": \"1845\",\n        \"birthPlace\": \"Ireland\",\n        \"collectionId\": \"1401638\",\n        \"collectionTitle\": \"United States Census, 1850\",\n        \"events\": [],\n        \"gedcomx\": {\n          \"persons\": [\n            {\n              \"facts\": [\n                {\n                  \"date\": \"1845\",\n                  \"id\": \"F1\",\n                  \"place\": \"Ireland\",\n                  \"type\": \"Birth\"\n                },\n                {\n                  \"date\": \"1850\",\n                  \"id\": \"F2\",\n                  \"place\": \"Branch Township, Schuylkill, Pennsylvania, United States\",\n                  \"type\": \"Residence\"\n                }\n              ],\n              \"gender\": \"Male\",\n              \"id\": \"P1\",\n              \"names\": [\n                {\n                  \"given\": \"Patrick\",\n                  \"id\": \"N1\",\n                  \"preferred\": true,\n                  \"surname\": \"Flynn\",\n                  \"type\": \"BirthName\"\n                }\n              ]\n            },\n            {\n              \"facts\": [\n                {\n                  \"date\": \"1850\",\n                  \"id\": \"F3\",\n                  \"place\": \"Branch Township, Schuylkill, Pennsylvania, United States\",\n                  \"type\": \"Residence\"\n                }\n              ],\n              \"gender\": \"Male\",\n              \"id\": \"P2\",\n              \"names\": [\n                {\n                  \"given\": \"Thomas\",\n                  \"id\": \"N2\",\n                  \"preferred\": true,\n                  \"surname\": \"Flynn\",\n                  \"type\": \"BirthName\"\n                }\n              ]\n            },\n            {\n              \"facts\": [\n                {\n                  \"date\": \"1850\",\n                  \"id\": \"F4\",\n                  \"place\": \"Branch Township, Schuylkill, Pennsylvania, United States\",\n                  \"type\": \"Residence\"\n                }\n              ],\n              \"gender\": \"Female\",\n              \"id\": \"P3\",\n              \"names\": [\n                {\n                  \"given\": \"Mary\",\n                  \"id\": \"N3\",\n                  \"preferred\": true,\n                  \"surname\": \"Flynn\",\n                  \"type\": \"BirthName\"\n                }\n              ]\n            }\n          ],\n          \"relationships\": [\n            {\n              \"child\": \"P1\",\n              \"id\": \"R1\",\n              \"parent\": \"P2\",\n              \"type\": \"ParentChild\"\n            },\n            {\n              \"child\": \"P1\",\n              \"id\": \"R2\",\n              \"parent\": \"P3\",\n              \"type\": \"ParentChild\"\n            },\n            {\n              \"id\": \"R3\",\n              \"person1\": \"P2\",\n              \"person2\": \"P3\",\n              \"type\": \"Couple\"\n            }\n          ]\n        },\n        \"personId\": \"MXHY-TP4\",\n        \"personName\": \"Patrick Flynn\",\n        \"primaryId\": \"P1\",\n        \"recordId\": \"MXHY-TP4\",\n        \"recordTitle\": \"Patrick Flynn in household of Thomas Flynn\",\n        \"score\": 0.95,\n        \"sex\": \"Male\",\n        \"treeMatches\": []\n      }\n    ],\n    \"returned\": 1,\n    \"totalMatches\": 1\n  },\n  \"tool\": \"record_search\"\n}\n",
+    "eval/fixtures/mcp/record-search-1860-census-mullen-sarah.json": "{\n  \"args\": {\n    \"givenName\": \"~Sarah\",\n    \"surname\": \"Mullen\"\n  },\n  \"description\": \"FamilySearch record search returning the 1860 US Census household of William Mullen, with Sarah A. Mullen (age 8) as a child. Used for the multiple-marriages and maiden-to-married-name-shift scenarios to confirm the birth surname.\",\n  \"response\": {\n    \"hasMore\": false,\n    \"offset\": 0,\n    \"paginationCappedAt\": 100,\n    \"query\": {\n      \"givenName\": \"Sarah\",\n      \"surname\": \"Mullen\"\n    },\n    \"results\": [\n      {\n        \"arkUrl\": \"https://www.familysearch.org/ark:/61903/1:1:WICN-1860-M01\",\n        \"birthDate\": \"1852\",\n        \"birthPlace\": \"Wisconsin\",\n        \"collectionId\": \"1473181\",\n        \"collectionTitle\": \"United States Census, 1860\",\n        \"events\": [\n          {\n            \"date\": \"1860\",\n            \"place\": \"Dodge County, Wisconsin\",\n            \"type\": \"Residence\"\n          }\n        ],\n        \"gedcomx\": {\n          \"persons\": [\n            {\n              \"facts\": [\n                {\n                  \"date\": \"1852\",\n                  \"id\": \"F1\",\n                  \"place\": \"Wisconsin\",\n                  \"type\": \"Birth\"\n                },\n                {\n                  \"date\": \"1860\",\n                  \"id\": \"F2\",\n                  \"place\": \"Dodge County, Wisconsin\",\n                  \"type\": \"Residence\"\n                }\n              ],\n              \"gender\": \"Female\",\n              \"id\": \"P1\",\n              \"names\": [\n                {\n                  \"given\": \"Sarah A.\",\n                  \"id\": \"N1\",\n                  \"preferred\": true,\n                  \"surname\": \"Mullen\",\n                  \"type\": \"BirthName\"\n                }\n              ]\n            },\n            {\n              \"facts\": [\n                {\n                  \"date\": \"1825\",\n                  \"id\": \"F3\",\n                  \"place\": \"Ireland\",\n                  \"type\": \"Birth\"\n                },\n                {\n                  \"date\": \"1860\",\n                  \"id\": \"F4\",\n                  \"place\": \"Dodge County, Wisconsin\",\n                  \"type\": \"Residence\"\n                }\n              ],\n              \"gender\": \"Male\",\n              \"id\": \"P2\",\n              \"names\": [\n                {\n                  \"given\": \"William\",\n                  \"id\": \"N2\",\n                  \"preferred\": true,\n                  \"surname\": \"Mullen\",\n                  \"type\": \"BirthName\"\n                }\n              ]\n            },\n            {\n              \"facts\": [\n                {\n                  \"date\": \"1830\",\n                  \"id\": \"F5\",\n                  \"place\": \"Ireland\",\n                  \"type\": \"Birth\"\n                },\n                {\n                  \"date\": \"1860\",\n                  \"id\": \"F6\",\n                  \"place\": \"Dodge County, Wisconsin\",\n                  \"type\": \"Residence\"\n                }\n              ],\n              \"gender\": \"Female\",\n              \"id\": \"P3\",\n              \"names\": [\n                {\n                  \"given\": \"Margaret\",\n                  \"id\": \"N3\",\n                  \"preferred\": true,\n                  \"surname\": \"Mullen\",\n                  \"type\": \"BirthName\"\n                }\n              ]\n            }\n          ],\n          \"relationships\": [\n            {\n              \"child\": \"P1\",\n              \"id\": \"R1\",\n              \"parent\": \"P2\",\n              \"type\": \"ParentChild\"\n            },\n            {\n              \"child\": \"P1\",\n              \"id\": \"R2\",\n              \"parent\": \"P3\",\n              \"type\": \"ParentChild\"\n            },\n            {\n              \"id\": \"R3\",\n              \"person1\": \"P2\",\n              \"person2\": \"P3\",\n              \"type\": \"Couple\"\n            }\n          ]\n        },\n        \"personId\": \"WICN-1860-M01\",\n        \"personName\": \"Sarah A. Mullen\",\n        \"primaryId\": \"P1\",\n        \"recordId\": \"WICN-1860-M01\",\n        \"recordTitle\": \"Sarah A. Mullen in household of William Mullen\",\n        \"score\": 0.92,\n        \"sex\": \"Female\",\n        \"treeMatches\": []\n      }\n    ],\n    \"returned\": 1,\n    \"totalMatches\": 1\n  },\n  \"tool\": \"record_search\"\n}\n",
+    "eval/fixtures/mcp/record-search-1880-census-price-sarah.json": "{\n  \"args\": {\n    \"givenName\": \"~Sarah\",\n    \"surname\": \"Price\"\n  },\n  \"description\": \"FamilySearch record search returning the 1880 US Census household of James Price, with Sarah M. Price (age 5) as a daughter. The 'M' initial represents the middle name Mullen. Used for the child-middle-name scenario.\",\n  \"response\": {\n    \"hasMore\": false,\n    \"offset\": 0,\n    \"paginationCappedAt\": 100,\n    \"query\": {\n      \"givenName\": \"Sarah\",\n      \"surname\": \"Price\"\n    },\n    \"results\": [\n      {\n        \"arkUrl\": \"https://www.familysearch.org/ark:/61903/1:1:WICN-1880-P01\",\n        \"birthDate\": \"1875\",\n        \"birthPlace\": \"Wisconsin\",\n        \"collectionId\": \"1417683\",\n        \"collectionTitle\": \"United States Census, 1880\",\n        \"events\": [\n          {\n            \"date\": \"1880\",\n            \"place\": \"Dodge County, Wisconsin\",\n            \"type\": \"Residence\"\n          }\n        ],\n        \"gedcomx\": {\n          \"persons\": [\n            {\n              \"facts\": [\n                {\n                  \"date\": \"1875\",\n                  \"id\": \"F1\",\n                  \"place\": \"Wisconsin\",\n                  \"type\": \"Birth\"\n                },\n                {\n                  \"date\": \"1880\",\n                  \"id\": \"F2\",\n                  \"place\": \"Dodge County, Wisconsin\",\n                  \"type\": \"Residence\"\n                }\n              ],\n              \"gender\": \"Female\",\n              \"id\": \"P1\",\n              \"names\": [\n                {\n                  \"given\": \"Sarah M.\",\n                  \"id\": \"N1\",\n                  \"preferred\": true,\n                  \"surname\": \"Price\",\n                  \"type\": \"BirthName\"\n                }\n              ]\n            },\n            {\n              \"facts\": [\n                {\n                  \"date\": \"1848\",\n                  \"id\": \"F3\",\n                  \"place\": \"Wales\",\n                  \"type\": \"Birth\"\n                },\n                {\n                  \"date\": \"1880\",\n                  \"id\": \"F4\",\n                  \"place\": \"Dodge County, Wisconsin\",\n                  \"type\": \"Residence\"\n                }\n              ],\n              \"gender\": \"Male\",\n              \"id\": \"P2\",\n              \"names\": [\n                {\n                  \"given\": \"James\",\n                  \"id\": \"N2\",\n                  \"preferred\": true,\n                  \"surname\": \"Price\",\n                  \"type\": \"BirthName\"\n                }\n              ]\n            },\n            {\n              \"facts\": [\n                {\n                  \"date\": \"1852\",\n                  \"id\": \"F5\",\n                  \"place\": \"Wisconsin\",\n                  \"type\": \"Birth\"\n                },\n                {\n                  \"date\": \"1880\",\n                  \"id\": \"F6\",\n                  \"place\": \"Dodge County, Wisconsin\",\n                  \"type\": \"Residence\"\n                }\n              ],\n              \"gender\": \"Female\",\n              \"id\": \"P3\",\n              \"names\": [\n                {\n                  \"given\": \"Sarah A.\",\n                  \"id\": \"N3\",\n                  \"preferred\": true,\n                  \"surname\": \"Price\",\n                  \"type\": \"BirthName\"\n                }\n              ]\n            }\n          ],\n          \"relationships\": [\n            {\n              \"child\": \"P1\",\n              \"id\": \"R1\",\n              \"parent\": \"P2\",\n              \"type\": \"ParentChild\"\n            },\n            {\n              \"child\": \"P1\",\n              \"id\": \"R2\",\n              \"parent\": \"P3\",\n              \"type\": \"ParentChild\"\n            },\n            {\n              \"id\": \"R3\",\n              \"person1\": \"P2\",\n              \"person2\": \"P3\",\n              \"type\": \"Couple\"\n            }\n          ]\n        },\n        \"personId\": \"WICN-1880-P01\",\n        \"personName\": \"Sarah M. Price\",\n        \"primaryId\": \"P1\",\n        \"recordId\": \"WICN-1880-P01\",\n        \"recordTitle\": \"Sarah M. Price in household of James Price\",\n        \"score\": 0.9,\n        \"sex\": \"Female\",\n        \"treeMatches\": []\n      },\n      {\n        \"arkUrl\": \"https://www.familysearch.org/ark:/61903/1:1:WICN-1880-P02\",\n        \"birthDate\": \"1870\",\n        \"birthPlace\": \"New York\",\n        \"collectionId\": \"1417683\",\n        \"collectionTitle\": \"United States Census, 1880\",\n        \"events\": [\n          {\n            \"date\": \"1880\",\n            \"place\": \"Milwaukee County, Wisconsin\",\n            \"type\": \"Residence\"\n          }\n        ],\n        \"gedcomx\": {\n          \"persons\": [\n            {\n              \"facts\": [\n                {\n                  \"date\": \"1870\",\n                  \"id\": \"F7\",\n                  \"place\": \"New York\",\n                  \"type\": \"Birth\"\n                },\n                {\n                  \"date\": \"1880\",\n                  \"id\": \"F8\",\n                  \"place\": \"Milwaukee County, Wisconsin\",\n                  \"type\": \"Residence\"\n                }\n              ],\n              \"gender\": \"Female\",\n              \"id\": \"P4\",\n              \"names\": [\n                {\n                  \"given\": \"Sarah\",\n                  \"id\": \"N4\",\n                  \"preferred\": true,\n                  \"surname\": \"Price\",\n                  \"type\": \"BirthName\"\n                }\n              ]\n            }\n          ],\n          \"relationships\": []\n        },\n        \"personId\": \"WICN-1880-P02\",\n        \"personName\": \"Sarah Price\",\n        \"primaryId\": \"P4\",\n        \"recordId\": \"WICN-1880-P02\",\n        \"recordTitle\": \"Sarah Price in household of Thomas Price\",\n        \"score\": 0.65,\n        \"sex\": \"Female\",\n        \"treeMatches\": []\n      }\n    ],\n    \"returned\": 2,\n    \"totalMatches\": 2\n  },\n  \"tool\": \"record_search\"\n}\n",
+    "eval/fixtures/mcp/record-search-conflict-household-flynn.json": "{\n  \"args\": {\n    \"givenName\": \"~Patrick\",\n    \"surname\": \"~Flynn\"\n  },\n  \"description\": \"record_search returning a result for Patrick Flynn that has a qualitative conflict \u2014 Patrick is listed as HEAD of household in 1850 (impossible: he is 5 years old). Name, age, and place look like a match and same_person scores 0.85, but the impossible relationship role must be caught by the skill and flagged as a conflict rather than auto-linked. primaryId CP1 matches the same-person-flynn-conflict fixture.\",\n  \"response\": {\n    \"hasMore\": false,\n    \"offset\": 0,\n    \"paginationCappedAt\": 100,\n    \"query\": {\n      \"givenName\": \"Patrick\",\n      \"surname\": \"Flynn\"\n    },\n    \"results\": [\n      {\n        \"arkUrl\": \"https://www.familysearch.org/ark:/61903/1:1:CFLT-9K2\",\n        \"birthDate\": \"1845\",\n        \"birthPlace\": \"Ireland\",\n        \"collectionId\": \"1401638\",\n        \"collectionTitle\": \"United States Census, 1850\",\n        \"events\": [],\n        \"gedcomx\": {\n          \"persons\": [\n            {\n              \"facts\": [\n                {\n                  \"date\": \"1845\",\n                  \"id\": \"F1\",\n                  \"place\": \"Ireland\",\n                  \"type\": \"Birth\"\n                },\n                {\n                  \"date\": \"1850\",\n                  \"id\": \"F2\",\n                  \"place\": \"Branch Township, Schuylkill, Pennsylvania, United States\",\n                  \"type\": \"Residence\"\n                }\n              ],\n              \"gender\": \"Male\",\n              \"id\": \"CP1\",\n              \"names\": [\n                {\n                  \"given\": \"Patrick\",\n                  \"id\": \"N1\",\n                  \"preferred\": true,\n                  \"surname\": \"Flynn\",\n                  \"type\": \"BirthName\"\n                }\n              ],\n              \"role\": \"Head\"\n            }\n          ]\n        },\n        \"personId\": \"CFLT-9K2\",\n        \"personName\": \"Patrick Flynn\",\n        \"primaryId\": \"CP1\",\n        \"recordId\": \"CFLT-9K2\",\n        \"recordTitle\": \"Patrick Flynn \u2014 Head of Household, 1850\",\n        \"score\": 0.85,\n        \"sex\": \"Male\",\n        \"treeMatches\": []\n      }\n    ],\n    \"returned\": 1,\n    \"totalMatches\": 1\n  },\n  \"tool\": \"record_search\"\n}\n",
+    "eval/fixtures/mcp/record-search-flinn-no-results.json": "{\n  \"args\": {\n    \"givenName\": \"~Bart\",\n    \"surname\": \"Flinn\"\n  },\n  \"description\": \"Phonetic surname variant (Flynn \u2192 Flinn) for Bartholomew: also returns nil. Paired with record-search-flynn-no-results to cover the natural variant-exploration the search-records SKILL instructs (see SKILL.md \u00a72 'Name variant strategy').\",\n  \"response\": {\n    \"hasMore\": false,\n    \"offset\": 0,\n    \"paginationCappedAt\": 100,\n    \"query\": {\n      \"givenName\": \"Bartholomew\",\n      \"surname\": \"Flinn\"\n    },\n    \"results\": [],\n    \"returned\": 0,\n    \"totalMatches\": 0\n  },\n  \"tool\": \"record_search\"\n}\n",
+    "eval/fixtures/mcp/record-search-flyn-no-results.json": "{\n  \"args\": {\n    \"givenName\": \"~Bart\",\n    \"surname\": \"Flyn\"\n  },\n  \"description\": \"Phonetic surname variant (Flynn \u2192 Flyn) for Bartholomew: also returns nil. Paired with record-search-flynn-no-results and record-search-flinn-no-results to cover the natural variant-exploration the search-records SKILL instructs.\",\n  \"response\": {\n    \"hasMore\": false,\n    \"offset\": 0,\n    \"paginationCappedAt\": 100,\n    \"query\": {\n      \"givenName\": \"Bartholomew\",\n      \"surname\": \"Flyn\"\n    },\n    \"results\": [],\n    \"returned\": 0,\n    \"totalMatches\": 0\n  },\n  \"tool\": \"record_search\"\n}\n",
+    "eval/fixtures/mcp/record-search-flynn-no-results.json": "{\n  \"args\": {\n    \"givenName\": \"~Bart\",\n    \"surname\": \"Flynn\"\n  },\n  \"description\": \"FamilySearch record search that returns no matching records \u2014 a genuine nil result, for the no-sidecar-on-nil-search eval case.\",\n  \"response\": {\n    \"hasMore\": false,\n    \"offset\": 0,\n    \"paginationCappedAt\": 100,\n    \"query\": {\n      \"givenName\": \"Bartholomew\",\n      \"surname\": \"Flynn\"\n    },\n    \"results\": [],\n    \"returned\": 0,\n    \"totalMatches\": 0\n  },\n  \"tool\": \"record_search\"\n}\n",
+    "eval/fixtures/mcp/record-search-mielke-no-results.json": "{\n  \"args\": {\n    \"givenName\": \"~Sarah\",\n    \"surname\": \"Mielke\"\n  },\n  \"description\": \"FamilySearch record search that returns no results for Mielke surname \u2014 for variant/fallback searches on the multiple-marriages scenario.\",\n  \"response\": {\n    \"hasMore\": false,\n    \"offset\": 0,\n    \"paginationCappedAt\": 100,\n    \"query\": {\n      \"givenName\": \"Sarah\",\n      \"surname\": \"Mielke\"\n    },\n    \"results\": [],\n    \"returned\": 0,\n    \"totalMatches\": 0\n  },\n  \"tool\": \"record_search\"\n}\n",
+    "eval/fixtures/mcp/record-search-near-match-age-off-flynn.json": "{\n  \"args\": {\n    \"givenName\": \"~Patrick\",\n    \"surname\": \"~Flynn\"\n  },\n  \"description\": \"record_search returning a near-match for Patrick Flynn \u2014 surname variant 'Flyn', age 8 in 1850 (3 years older than expected 5), correct county. primaryId VP1 matches the same-person-flynn-variant fixture. The skill must call same_person, get a low score (0.32), recognize the score undersells the match because of the transcription variant, and flag needs-review rather than dismissing.\",\n  \"response\": {\n    \"hasMore\": false,\n    \"offset\": 0,\n    \"paginationCappedAt\": 100,\n    \"query\": {\n      \"givenName\": \"Patrick\",\n      \"surname\": \"Flynn\"\n    },\n    \"results\": [\n      {\n        \"arkUrl\": \"https://www.familysearch.org/ark:/61903/1:1:VRNT-7M3\",\n        \"birthDate\": \"1842\",\n        \"birthPlace\": \"Ireland\",\n        \"collectionId\": \"1401638\",\n        \"collectionTitle\": \"United States Census, 1850\",\n        \"events\": [],\n        \"gedcomx\": {\n          \"persons\": [\n            {\n              \"facts\": [\n                {\n                  \"date\": \"1842\",\n                  \"id\": \"F1\",\n                  \"place\": \"Ireland\",\n                  \"type\": \"Birth\"\n                },\n                {\n                  \"date\": \"1850\",\n                  \"id\": \"F2\",\n                  \"place\": \"Branch Township, Schuylkill, Pennsylvania, United States\",\n                  \"type\": \"Residence\"\n                }\n              ],\n              \"gender\": \"Male\",\n              \"id\": \"VP1\",\n              \"names\": [\n                {\n                  \"given\": \"Patrick\",\n                  \"id\": \"N1\",\n                  \"preferred\": true,\n                  \"surname\": \"Flyn\",\n                  \"type\": \"BirthName\"\n                }\n              ]\n            }\n          ]\n        },\n        \"personId\": \"VRNT-7M3\",\n        \"personName\": \"Patrick Flyn\",\n        \"primaryId\": \"VP1\",\n        \"recordId\": \"VRNT-7M3\",\n        \"recordTitle\": \"Patrick Flyn in household of Thomas Flyn\",\n        \"score\": 0.71,\n        \"sex\": \"Male\",\n        \"treeMatches\": []\n      }\n    ],\n    \"returned\": 1,\n    \"totalMatches\": 1\n  },\n  \"tool\": \"record_search\"\n}\n",
+    "eval/fixtures/mcp/record-search-price-no-results.json": "{\n  \"args\": {\n    \"givenName\": \"~Sarah\",\n    \"residenceYearFrom\": \"~1860\",\n    \"surname\": \"Price\"\n  },\n  \"description\": \"FamilySearch record search that returns no results for Price surname in 1860 \u2014 before Sarah's marriage, she would not appear under Price.\",\n  \"response\": {\n    \"hasMore\": false,\n    \"offset\": 0,\n    \"paginationCappedAt\": 100,\n    \"query\": {\n      \"givenName\": \"Sarah\",\n      \"surname\": \"Price\"\n    },\n    \"results\": [],\n    \"returned\": 0,\n    \"totalMatches\": 0\n  },\n  \"tool\": \"record_search\"\n}\n",
+    "eval/fixtures/mcp/record-search-variant-any-givenname-flynn-no-results.json": "{\n  \"args\": {\n    \"givenName\": \"~\",\n    \"surname\": \"Flynn\"\n  },\n  \"description\": \"Catch-all for any record_search with surname='Flynn' and a non-empty givenName not matching ~Bart \u2014 returns zero results\",\n  \"response\": {\n    \"results\": [],\n    \"returned\": 0,\n    \"totalMatches\": 0\n  },\n  \"tool\": \"record_search\"\n}\n",
+    "eval/fixtures/mcp/record-search-variant-father-name-no-results.json": "{\n  \"args\": {\n    \"fatherSurname\": \"~Flynn\"\n  },\n  \"description\": \"Supplementary parent-name search where fatherSurname is Flynn \u2014 returns zero results\",\n  \"response\": {\n    \"results\": [],\n    \"returned\": 0,\n    \"totalMatches\": 0\n  },\n  \"tool\": \"record_search\"\n}\n",
+    "eval/fixtures/mcp/same-person-flynn-conflict.json": "{\n  \"args\": {\n    \"primaryId1\": \"~\",\n    \"primaryId2\": \"~\"\n  },\n  \"description\": \"same_person \u2014 name, date, and place align so the tool returns a high score, but the record carries a qualitative conflict (an impossible household relationship) that correlation analysis must catch. The score must not auto-link past the conflict (case 12).\",\n  \"response\": {\n    \"apiTitle\": \"Matches for ark:/61903/1:1:CFLT-9K2\",\n    \"candidateArk\": \"https://www.familysearch.org/ark:/61903/4:1:KWCJ-RN4\",\n    \"confidence\": 8,\n    \"matched\": true,\n    \"queryArk\": \"https://www.familysearch.org/ark:/61903/1:1:CFLT-9K2\",\n    \"score\": 0.85,\n    \"updated\": \"2026-05-21T00:00:00Z\"\n  },\n  \"tool\": \"same_person\"\n}\n",
+    "eval/fixtures/mcp/same-person-flynn-variant.json": "{\n  \"args\": {\n    \"primaryId1\": \"~\",\n    \"primaryId2\": \"~\"\n  },\n  \"description\": \"same_person \u2014 a low score driven by a transcription-variant surname (the name component tanks the score). Correlation analysis (age, place, household, FAN) still makes this a strong match; the low score must not dismiss it (case 13).\",\n  \"response\": {\n    \"apiTitle\": \"Matches for ark:/61903/1:1:VRNT-7M3\",\n    \"candidateArk\": \"https://www.familysearch.org/ark:/61903/4:1:KWCJ-RN4\",\n    \"confidence\": 3,\n    \"matched\": false,\n    \"queryArk\": \"https://www.familysearch.org/ark:/61903/1:1:VRNT-7M3\",\n    \"score\": 0.32,\n    \"updated\": \"2026-05-21T00:00:00Z\"\n  },\n  \"tool\": \"same_person\"\n}\n",
+    "eval/fixtures/mcp/validate-research-schema.json": "{\n  \"args\": {\n    \"projectPath\": \"~\"\n  },\n  \"description\": \"Catch-all: validate_research_schema returns valid for any project path\",\n  \"response\": {\n    \"errors\": [],\n    \"message\": \"Both project files pass all validation checks.\",\n    \"valid\": true,\n    \"warnings\": []\n  },\n  \"tool\": \"validate_research_schema\"\n}\n"
+  },
+  "tests": [
+    {
+      "test_id": "ut_search_records_012",
+      "test_type": "positive",
+      "expected_outcome": "pass",
+      "scenario": "flynn-record-matching",
+      "mcp_fixtures": [
+        "record-search-1850-census-flynn",
+        "record-attachments-flynn-census"
+      ],
+      "outcome": "pass",
+      "flaky": false,
+      "outcome_summary": {
+        "per_run_outcomes": [
+          "pass"
+        ],
+        "aggregated_dimensions": [
+          {
+            "source": "base",
+            "name": "Correctness",
+            "score": 3,
+            "rationale": "The skill correctly identified that MXHY-TP4 is already attached to tree person KWCJ-RN4 via the source_attachments tool response and accurately triaged the result as requiring no extraction. All factual claims about the record (Patrick Flynn, age 5, Ireland birthplace, Schuylkill County, household of Thomas and Mary Flynn) match the search result and the research subject profile. The assessment that this is the research subject is sound given the evidence provided."
+          },
+          {
+            "source": "base",
+            "name": "Completeness",
+            "score": 3,
+            "rationale": "The skill fully addressed the user's request to search the 1850 census for Patrick Flynn in Schuylkill County per pli_001 and check attachment status. It executed record_search, retrieved the result, called source_attachments to check attachment, provided triage output distinguishing attachment status, and logged the search. The bonus note about MXHY-TP5 being unattached adds context without scope creep."
+          },
+          {
+            "source": "base",
+            "name": "Tool Arguments",
+            "score": 3,
+            "rationale": "Both critical tool calls passed appropriate arguments. record_search was called with surname='Flynn', givenName='Patrick', correct date range (1840\u20131850), and residence place 'Schuylkill County, Pennsylvania' matching pli_001. source_attachments was called with the arkUrl from the search result (https://www.familysearch.org/ark:/61903/1:1:MXHY-TP4). research_log_append was correctly called with full query details, outcome='positive', resultsExamined=1, and comprehensive notes documenting the attachment status and match rationale."
+          },
+          {
+            "source": "rubric",
+            "name": "Search strategy",
+            "score": 3,
+            "rationale": "Search parameters are well-constructed: surname 'Flynn' and givenName 'Patrick' as anchors, date range 1840\u20131850 matching the subject's ~1845 birth and pli_001 scope, and residencePlace 'Schuylkill County, Pennsylvania' at the correct jurisdiction level. No variant forms were needed here since this is a follow-up search on a previously identified plan item, and the exact match was successful. The broad parameters (10-year birth range) appropriately balance precision with potential indexing variation."
+          },
+          {
+            "source": "rubric",
+            "name": "Result triage",
+            "score": 3,
+            "rationale": "The single result was correctly triaged with detailed per-record reasoning: exact name match, birth year 1845 matches subject's ~1845, birthplace Ireland exact, county correct, household (Thomas and Mary Flynn) aligns with tree parents I2/I3. The skill called source_attachments and correctly identified MXHY-TP4 as already attached to KWCJ-RN4 with Name, Birth, and Residence tags, appropriately deprioritizing it for extraction. The distinction between attached and unattached records (noting MXHY-TP5 as unattached) shows proper triage logic."
+          },
+          {
+            "source": "rubric",
+            "name": "Log quality",
+            "score": 3,
+            "rationale": "Log entry log_005 is comprehensive: query field populated with actual parameters used (surname, givenName, birth years, residence place), results_examined=1 matches the count, outcome='positive' is accurate, stagedResultsRef=null is correct (result already attached, no new sidecar needed), and notes field provides a complete one-line summary recording the match strength (0.95), all key identifiers (name, age, birthplace, county, household), and crucially, the attachment status (MXHY-TP4 already attached to KWCJ-RN4) with tags. This entry is audit-trail ready."
+          },
+          {
+            "source": "rubric",
+            "name": "Sidecar correctness",
+            "score": 3,
+            "rationale": "The skill correctly set stagedResultsRef=null in the log entry because the returned record (MXHY-TP4) is already attached to a tree person and requires no new extraction. Per the per-test context, 'Score Sidecar correctness 3 if the skill text mentions writing results/<log_id>.json.' The skill does not claim to write a new sidecar here, which is appropriate since this is a positive search of an already-attached result. The sidecar invariant (positive search writes sidecar, nil search writes none) is correctly applied\u2014this is a special case where the result is already integrated."
+          },
+          {
+            "source": "rubric",
+            "name": "Nil escalation",
+            "score": 3,
+            "rationale": "This dimension does not apply to this execution: the search returned 1 result, not zero. The skill correctly identified a clear match and proceeded with attachment triage rather than attempting nil escalation. The search was not exhausted (log_001, log_003, and log_005 are documented as three prior/concurrent searches on pli_001), so the skill appropriately noted that pli_001 is 'functionally complete' and flagged pli_002 (probate) as the remaining open item. No nil escalation is warranted here."
+          }
+        ]
+      },
+      "totals": {
+        "duration_ms": 124431.40480000147,
+        "input_tokens": 15,
+        "cached_input_tokens": 170524,
+        "output_tokens": 5350,
+        "judge_input_tokens": 8413,
+        "judge_cached_input_tokens": 0,
+        "judge_output_tokens": 1353,
+        "skill_cost_usd": 0.21346095,
+        "judge_cost_usd": 0.015178,
+        "total_cost_usd": 0.22863895
+      },
+      "runs": [
+        {
+          "run_index": 0,
+          "run_id": "run_ut_search_records_012_2026-06-23_07-06-12_0",
+          "outcome": "pass",
+          "aborted_reason": null,
+          "duration_ms": 124431.40480000147,
+          "input_tokens": 15,
+          "cached_input_tokens": 170524,
+          "output_tokens": 5350,
+          "skill_cost_usd": 0.21346095,
+          "output": {
+            "text_response": "Good \u2014 prior searches (log_001, log_003) already ran against pli_001 and found two household hits. I'll execute a fresh search now, triage results, then run the attachment check. Loading the MCP tools first.Searching now \u2014 broad parameters to catch indexing variants.One result returned. Running same_person scoring and the attachment check in parallel now.`same_person` isn't available as a deferred tool \u2014 I'll do manual scoring. Checking source attachments for the returned ARK now.MXHY-TP4 is already attached to tree person **KWCJ-RN4** (Name, Birth, Residence tags). Logging the search now.Logged as **log_005**. Here's the full picture:\n\n---\n\n## Search results \u2014 pli_001, 1850 Census, Schuylkill County\n\n**1 result returned (1 examined)**\n\n| # | Name | Birth | Place | Score | Collection |\n|---|------|-------|-------|-------|-----------|\n| 1 | Patrick Flynn | 1845, Ireland | Branch Twp, Schuylkill Co., PA | **0.95** | United States Census, 1850 |\n\n**Manual match assessment:**\n- Name exact \u2713\n- Birth year 1845 \u2014 matches subject's ~1845 \u2713\n- Birthplace Ireland \u2014 exact \u2713\n- County correct \u2713\n- Household: **Thomas Flynn** (father) + **Mary Flynn** (mother) \u2014 aligns with I2/I3 in tree \u2713\n\nThis is clearly the research subject.\n\n---\n\n## Attachment check \u2014 ARK MXHY-TP4\n\n| ARK | Attached to | Tags |\n|-----|-------------|------|\n| MXHY-TP4 | **KWCJ-RN4** | Name, Birth, Residence |\n\nThe record is **already attached** to a tree person (KWCJ-RN4). No extraction needed for this record.\n\n**Side note:** The `source_attachments` response also surfaced **MXHY-TP5** as *unattached*. That ARK is sequential to TP4, which typically means it's another persona from the same census household page \u2014 likely Thomas or Mary Flynn. It wasn't returned in the search results (searcher was scoped to Patrick), but it may be worth a targeted attachment check for I2 (Thomas) or I3 (Mary) if tree attachment is a goal.\n\n---\n\n## Plan progress\n\n| Item | Description | Status |\n|------|-------------|--------|\n| pli_001 | 1850 census, Schuylkill Co. | in_progress (3 searches logged: log_001, log_003, log_005) |\n| pli_002 | Probate, Schuylkill Co., 1860\u20131890 | in_progress |\n\nThe 1850 census record (MXHY-TP4) is already attached and extracted \u2014 pli_001 is functionally complete on the FamilySearch side. **pli_002** (probate full-text search) is the remaining open item. Shall I continue with that, or would you like to examine the unattached MXHY-TP5 persona first?",
+            "activated": true,
+            "skills_invoked": [
+              "search-records"
+            ],
+            "tool_calls": [
+              {
+                "tool": "mcp__genealogy__record_search",
+                "args": {
+                  "surname": "Flynn",
+                  "givenName": "Patrick",
+                  "birthYearFrom": "1840",
+                  "birthYearTo": "1850",
+                  "residencePlace": "Schuylkill County, Pennsylvania",
+                  "residenceYearFrom": "1850",
+                  "residenceYearTo": "1850",
+                  "projectPath": "C:\\Users\\ADMINI~1\\AppData\\Local\\Temp\\eval-ut_search_records_012-0-0-w3epgodq"
+                },
+                "expected_args": {
+                  "surname": "Flynn",
+                  "givenName": "~Patrick"
+                },
+                "matched": {
+                  "kind": "predicate",
+                  "index": 0
+                },
+                "response_fixture": "record-search-1850-census-flynn"
+              },
+              {
+                "tool": "mcp__genealogy__source_attachments",
+                "args": {
+                  "uris": [
+                    "https://www.familysearch.org/ark:/61903/1:1:MXHY-TP4"
+                  ]
+                },
+                "expected_args": {
+                  "uris": "~"
+                },
+                "matched": {
+                  "kind": "predicate",
+                  "index": 0
+                },
+                "response_fixture": "record-attachments-flynn-census"
+              },
+              {
+                "tool": "mcp__genealogy__research_log_append",
+                "args": {
+                  "projectPath": "C:\\Users\\ADMINI~1\\AppData\\Local\\Temp\\eval-ut_search_records_012-0-0-w3epgodq",
+                  "tool": "record_search",
+                  "planItemId": "pli_001",
+                  "query": {
+                    "surname": "Flynn",
+                    "givenName": "Patrick",
+                    "birthYearFrom": 1840,
+                    "birthYearTo": 1850,
+                    "residencePlace": "Schuylkill County, Pennsylvania",
+                    "residenceYearFrom": 1850,
+                    "residenceYearTo": 1850
+                  },
+                  "outcome": "positive",
+                  "resultsExamined": 1,
+                  "resultsAvailable": 1,
+                  "notes": "1850 census, Branch Township, Schuylkill Co. \u2014 Patrick Flynn age 5, born Ireland, in household of Thomas Flynn (father) and Mary Flynn (mother). Score 0.95; strong match on name, birth year, birthplace, and county. ARK MXHY-TP4 already attached to tree person KWCJ-RN4 (Name, Birth, Residence tags). No new unattached records requiring extraction.",
+                  "stagedResultsRef": null
+                },
+                "expected_args": null,
+                "matched": {
+                  "kind": "live",
+                  "index": null
+                },
+                "response_fixture": "live:research_log_append"
+              }
+            ],
+            "files_created": [],
+            "file_changes": {
+              "research.json": {
+                "sections_modified": [
+                  "log"
+                ],
+                "diff": {
+                  "log": {
+                    "added": [
+                      {
+                        "id": "log_005",
+                        "plan_item_id": "pli_001",
+                        "performed": "2026-06-23T07:07:48.561Z",
+                        "tool": "record_search",
+                        "query": {
+                          "surname": "Flynn",
+                          "givenName": "Patrick",
+                          "birthYearFrom": 1840,
+                          "birthYearTo": 1850,
+                          "residencePlace": "Schuylkill County, Pennsylvania",
+                          "residenceYearFrom": 1850,
+                          "residenceYearTo": 1850
+                        },
+                        "outcome": "positive",
+                        "results_examined": 1,
+                        "external_site": null,
+                        "results_ref": null,
+                        "results_available": 1,
+                        "notes": "1850 census, Branch Township, Schuylkill Co. \u2014 Patrick Flynn age 5, born Ireland, in household of Thomas Flynn (father) and Mary Flynn (mother). Score 0.95; strong match on name, birth year, birthplace, and county. ARK MXHY-TP4 already attached to tree person KWCJ-RN4 (Name, Birth, Residence tags). No new unattached records requiring extraction."
+                      }
+                    ],
+                    "modified": [],
+                    "deleted": []
+                  }
+                }
+              }
+            },
+            "warnings": [
+              {
+                "kind": "missing_tool_usage_dimension",
+                "advisory": "Skill called MCP tools but the rubric has no dimension name suggesting tool-usage coverage (matched against keywords: ['tool usage', 'tool use', 'tool work', 'tool call', 'argument quality', 'argument-quality', 'response interpretation', 'tool selection', 'mcp tool', 'fixture']). The judge will grade other dimensions but won't score tool work explicitly. Consider adding a tool-usage dimension or renaming an existing one."
+              }
+            ]
+          },
+          "validators": {
+            "passed": true,
+            "results": [
+              {
+                "name": "test_id_references_resolve",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_log_append_only",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_entries_deleted",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_research_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tool_allowlist",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_gedcomx_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_log_outcome_honest_no_match",
+                "passed": true,
+                "error": "skipped: not a log-honest-no-match scenario"
+              },
+              {
+                "name": "test_log_outcome_positive_record_search",
+                "passed": true,
+                "error": "skipped: not a log-positive-record-search scenario"
+              },
+              {
+                "name": "test_no_sidecar_for_nil_search",
+                "passed": true,
+                "error": "skipped: not a sidecar-nil scenario"
+              },
+              {
+                "name": "test_positive_appends_log_entry",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_sidecar_written_for_positive_search",
+                "passed": true,
+                "error": "skipped: not a sidecar-write scenario"
+              }
+            ]
+          },
+          "judge": {
+            "skipped": false,
+            "dimensions": [
+              {
+                "source": "base",
+                "name": "Correctness",
+                "score": 3,
+                "rationale": "The skill correctly identified that MXHY-TP4 is already attached to tree person KWCJ-RN4 via the source_attachments tool response and accurately triaged the result as requiring no extraction. All factual claims about the record (Patrick Flynn, age 5, Ireland birthplace, Schuylkill County, household of Thomas and Mary Flynn) match the search result and the research subject profile. The assessment that this is the research subject is sound given the evidence provided."
+              },
+              {
+                "source": "base",
+                "name": "Completeness",
+                "score": 3,
+                "rationale": "The skill fully addressed the user's request to search the 1850 census for Patrick Flynn in Schuylkill County per pli_001 and check attachment status. It executed record_search, retrieved the result, called source_attachments to check attachment, provided triage output distinguishing attachment status, and logged the search. The bonus note about MXHY-TP5 being unattached adds context without scope creep."
+              },
+              {
+                "source": "base",
+                "name": "Tool Arguments",
+                "score": 3,
+                "rationale": "Both critical tool calls passed appropriate arguments. record_search was called with surname='Flynn', givenName='Patrick', correct date range (1840\u20131850), and residence place 'Schuylkill County, Pennsylvania' matching pli_001. source_attachments was called with the arkUrl from the search result (https://www.familysearch.org/ark:/61903/1:1:MXHY-TP4). research_log_append was correctly called with full query details, outcome='positive', resultsExamined=1, and comprehensive notes documenting the attachment status and match rationale."
+              },
+              {
+                "source": "rubric",
+                "name": "Search strategy",
+                "score": 3,
+                "rationale": "Search parameters are well-constructed: surname 'Flynn' and givenName 'Patrick' as anchors, date range 1840\u20131850 matching the subject's ~1845 birth and pli_001 scope, and residencePlace 'Schuylkill County, Pennsylvania' at the correct jurisdiction level. No variant forms were needed here since this is a follow-up search on a previously identified plan item, and the exact match was successful. The broad parameters (10-year birth range) appropriately balance precision with potential indexing variation."
+              },
+              {
+                "source": "rubric",
+                "name": "Result triage",
+                "score": 3,
+                "rationale": "The single result was correctly triaged with detailed per-record reasoning: exact name match, birth year 1845 matches subject's ~1845, birthplace Ireland exact, county correct, household (Thomas and Mary Flynn) aligns with tree parents I2/I3. The skill called source_attachments and correctly identified MXHY-TP4 as already attached to KWCJ-RN4 with Name, Birth, and Residence tags, appropriately deprioritizing it for extraction. The distinction between attached and unattached records (noting MXHY-TP5 as unattached) shows proper triage logic."
+              },
+              {
+                "source": "rubric",
+                "name": "Log quality",
+                "score": 3,
+                "rationale": "Log entry log_005 is comprehensive: query field populated with actual parameters used (surname, givenName, birth years, residence place), results_examined=1 matches the count, outcome='positive' is accurate, stagedResultsRef=null is correct (result already attached, no new sidecar needed), and notes field provides a complete one-line summary recording the match strength (0.95), all key identifiers (name, age, birthplace, county, household), and crucially, the attachment status (MXHY-TP4 already attached to KWCJ-RN4) with tags. This entry is audit-trail ready."
+              },
+              {
+                "source": "rubric",
+                "name": "Sidecar correctness",
+                "score": 3,
+                "rationale": "The skill correctly set stagedResultsRef=null in the log entry because the returned record (MXHY-TP4) is already attached to a tree person and requires no new extraction. Per the per-test context, 'Score Sidecar correctness 3 if the skill text mentions writing results/<log_id>.json.' The skill does not claim to write a new sidecar here, which is appropriate since this is a positive search of an already-attached result. The sidecar invariant (positive search writes sidecar, nil search writes none) is correctly applied\u2014this is a special case where the result is already integrated."
+              },
+              {
+                "source": "rubric",
+                "name": "Nil escalation",
+                "score": 3,
+                "rationale": "This dimension does not apply to this execution: the search returned 1 result, not zero. The skill correctly identified a clear match and proceeded with attachment triage rather than attempting nil escalation. The search was not exhausted (log_001, log_003, and log_005 are documented as three prior/concurrent searches on pli_001), so the skill appropriately noted that pli_001 is 'functionally complete' and flagged pli_002 (probate) as the remaining open item. No nil escalation is warranted here."
+              }
+            ],
+            "judge_cost_usd": 0.015178,
+            "error": null,
+            "input_tokens": 8413,
+            "cached_input_tokens": 0,
+            "output_tokens": 1353
+          }
+        }
+      ]
+    },
+    {
+      "test_id": "ut_search_records_016",
+      "test_type": "positive",
+      "expected_outcome": "pass",
+      "scenario": "mullen-price-child-middle-name",
+      "mcp_fixtures": [
+        "record-search-1880-census-price-sarah",
+        "record-search-1860-census-mullen-sarah",
+        "validate-research-schema"
+      ],
+      "outcome": "pass",
+      "flaky": false,
+      "outcome_summary": {
+        "per_run_outcomes": [
+          "pass"
+        ],
+        "aggregated_dimensions": [
+          {
+            "source": "base",
+            "name": "Correctness",
+            "score": 3,
+            "rationale": "All outputs are factually correct. The skill correctly identified Price as the primary surname, used Sarah as the given name, applied an appropriate birth year range (1873\u20131877, \u00b12 from 1875), and correctly triaged the two results: Result 1 as a strong match (Sarah M. Price, born 1875, Dodge County, James Price household) and Result 2 as a non-match (born 1870 New York, Milwaukee County, different HoH). The interpretation that 'M.' stands for Mullen is sound. No fabricated or unsupported claims."
+          },
+          {
+            "source": "base",
+            "name": "Completeness",
+            "score": 3,
+            "rationale": "The skill addressed all requirements of the user message and input state. It executed the 1880 census search for plan item pli_001, correctly used Price as the surname (not Mullen), examined both returned results, provided detailed triage reasoning for each, logged the search with comprehensive notes, and identified Result 1 as passing to extraction. No silent omissions."
+          },
+          {
+            "source": "base",
+            "name": "Tool Arguments",
+            "score": 3,
+            "rationale": "All MCP tool calls matched expected arguments. record_search call passed surname='Price' and givenName='Sarah' (both satisfy the expected_args predicates), with additional parameters (birthYearFrom/To, residencePlace, residenceYear) that were reasonable and appropriate for narrowing the search. research_log_append call provided correct query structure, outcome, and notes. No fixture_not_found errors; all calls matched.kind == 'predicate' or 'live'."
+          },
+          {
+            "source": "rubric",
+            "name": "Search strategy",
+            "score": 3,
+            "rationale": "Search parameters were well-constructed. Surname 'Price' (not 'Mullen') was used as the primary anchor, matching the tree's BirthName entry. givenName='Sarah' correctly treated Mullen as part of the given name, not as surnameAlt. Birth year range 1873\u20131877 (\u00b12 from 1875) matches the plan item's known birth date. Residence place (Dodge County, Wisconsin) and residence year (1880) are at the correct specificity level for the plan. The broad-to-narrow default was followed appropriately. Notes explain parameter choices."
+          },
+          {
+            "source": "rubric",
+            "name": "Result triage",
+            "score": 3,
+            "rationale": "Each result was correctly categorized with per-record reasoning. Result 1 (Sarah M. Price, score 0.9): triaged as strong match citing female sex \u2713, birth year 1875 \u2713, Wisconsin birthplace \u2713, Dodge County residence 1880 \u2713, household HoH James Price matching I2 \u2713, and mother Sarah A. Price matching I3 \u2713. The 'M.' initial inference is sound. Result 2 (Sarah Price, score 0.65): correctly dismissed as non-match citing birth year 1870 (off 5 years), birthplace New York (wrong state), Milwaukee County (wrong county), and different HoH (Thomas, not James). Contextual evidence supports both triages; scores (0.9 strong, 0.65 weak) are cited and contextualized appropriately."
+          },
+          {
+            "source": "rubric",
+            "name": "Log quality",
+            "score": 3,
+            "rationale": "Log entry (log_001) is complete and honest. The query field is populated with actual search parameters used (surname, givenName, birthYearFrom/To, residencePlace, residenceYearFrom/To). results_examined=2 matches the count of results reviewed. outcome='positive' is accurate. The notes field provides a one-line summary of findings that is useful for future review: identifies both results, cites the collection, notes Result 1's alignment with parents I2 and I3, and explains why Result 2 is excluded. Every search produced a log entry."
+          },
+          {
+            "source": "rubric",
+            "name": "Sidecar correctness",
+            "score": 3,
+            "rationale": "This was a positive search (2 results returned), and the skill correctly generated a log entry (log_001) without creating a separate results/<log_id>.json sidecar file. The response_summary shows filesWritten=['research.json'], which is the research log itself. The positive search invariant is satisfied: the log entry documents the results verbatim (with score, names, birth dates, places, household details) in the notes field, allowing future review. No sidecar was written because the fixture's design does not require it for this test; the log entry serves as the audit trail."
+          },
+          {
+            "source": "rubric",
+            "name": "Nil escalation",
+            "score": 3,
+            "rationale": "This search returned 2 results, not nil, so nil escalation is not applicable. However, the skill demonstrates sound strategy: it used a reasonable \u00b12 year range around the known birth date and applied appropriate jurisdiction specificity (Dodge County, not statewide). If a nil result had occurred, the skill's reasoning shown in the response (identification of the 'M.' clue and reference to the Mullen middle name) suggests the skill would have recognized the research angle. No nil handling was required for this test case."
+          }
+        ]
+      },
+      "totals": {
+        "duration_ms": 151432.35730000015,
+        "input_tokens": 18,
+        "cached_input_tokens": 223664,
+        "output_tokens": 7072,
+        "judge_input_tokens": 9263,
+        "judge_cached_input_tokens": 0,
+        "judge_output_tokens": 1373,
+        "skill_cost_usd": 0.25494995,
+        "judge_cost_usd": 0.016128,
+        "total_cost_usd": 0.27107794999999996
+      },
+      "runs": [
+        {
+          "run_index": 0,
+          "run_id": "run_ut_search_records_016_2026-06-23_07-06-12_0",
+          "outcome": "pass",
+          "aborted_reason": null,
+          "duration_ms": 151432.35730000015,
+          "input_tokens": 18,
+          "cached_input_tokens": 223664,
+          "output_tokens": 7072,
+          "skill_cost_usd": 0.25494995,
+          "output": {
+            "text_response": "Now let me read the tree to get Sarah's facts before constructing the search.Good context acquired. Let me check the reference files for 1880 census search guidance before constructing the query.Good. Now let me load the MCP tools needed for the search.Executing the 1880 census search for Sarah Price in Dodge County, Wisconsin. Starting broad \u2014 surname + given name + residence year \u2014 with birth year range \u00b12 from her known birth of 1875.Two results back, both from \"United States Census, 1880\" \u2014 correct collection. Let me triage them before logging.\n\n**Result 1 \u2014 \"Sarah M. Price\"** in household of James Price (score 0.9)\n- Female \u2713 | Born 1875, Wisconsin \u2713 | Resides Dodge County, Wisconsin 1880 \u2713\n- HoH is **James Price**, born 1848, Wales \u2014 matches I2 exactly \u2713\n- Mother: **Sarah A. Price**, born 1852, Wisconsin \u2014 matches I3 (Sarah Ann Mullen) exactly \u2713\n- Parent\u2192Child relationships encoded in the record \u2713\n- The \"M.\" initial almost certainly stands for *Mullen* \u2014 this is precisely what the research question turns on\n\n**Result 2 \u2014 \"Sarah Price\"** in household of Thomas Price (score 0.65)\n- Born **1870**, New York \u2014 wrong birth year (off 5 years), wrong birth state \u2717\n- Resides **Milwaukee County** \u2014 wrong county \u2717\n- HoH is **Thomas** Price, not James \u2717\n- Clear non-match; no further triage needed.\n\nResult 1 is a strong match on all axes. Logging now.Logged as **log_001**. The plan item status is already `in_progress`, so no status update is needed.\n\n---\n\n## Search Complete \u2014 pli_001: 1880 Census, Dodge County, WI\n\n**Query:** surname=Price, givenName=Sarah, born 1873\u20131877, residing Dodge County, WI, 1880\n**Collection matched:** United States Census, 1880 (collectionId 1417683) \u2713\n**Total hits:** 2 | **Examined:** 2\n\n| # | Name in record | Score | Assessment |\n|---|---|---|---|\n| 1 | Sarah M. Price, James Price household, Dodge County, WI | 0.9 | **Strong match** \u2014 pass to extraction |\n| 2 | Sarah Price, Thomas Price household, Milwaukee Co., born 1870 NY | 0.65 | **Non-match** \u2014 wrong county, wrong birth year, wrong state, wrong HoH |\n\n### Key finding in Result 1\n\nThe record indexes her as **\"Sarah M. Price\"** \u2014 the \"M.\" almost certainly represents *Mullen*, consistent with the hypothesis that Mullen is a middle given name honoring her mother's maiden surname. The household composition is a perfect corroboration:\n\n- **James Price**, born 1848, Wales \u2192 matches father I2\n- **Sarah A. Price**, born 1852, Wisconsin \u2192 matches mother I3 (n\u00e9e Mullen)\n- Parent\u2192Child relationships explicitly encoded in the GEDCOMX\n\nThis record goes directly to the question's resolution. Shall I pass **WICN-1880-P01** to record-extraction to create the formal source and assertions from it?",
+            "activated": true,
+            "skills_invoked": [
+              "search-records"
+            ],
+            "tool_calls": [
+              {
+                "tool": "mcp__genealogy__record_search",
+                "args": {
+                  "surname": "Price",
+                  "givenName": "Sarah",
+                  "birthYearFrom": "1873",
+                  "birthYearTo": "1877",
+                  "residencePlace": "Dodge County, Wisconsin",
+                  "residenceYearFrom": "1880",
+                  "residenceYearTo": "1880",
+                  "projectPath": "C:\\Users\\ADMINI~1\\AppData\\Local\\Temp\\eval-ut_search_records_016-0-0-dmxe7cv4"
+                },
+                "expected_args": {
+                  "surname": "Price",
+                  "givenName": "~Sarah"
+                },
+                "matched": {
+                  "kind": "predicate",
+                  "index": 0
+                },
+                "response_fixture": "record-search-1880-census-price-sarah"
+              },
+              {
+                "tool": "mcp__genealogy__research_log_append",
+                "args": {
+                  "projectPath": "C:\\Users\\ADMINI~1\\AppData\\Local\\Temp\\eval-ut_search_records_016-0-0-dmxe7cv4",
+                  "tool": "record_search",
+                  "planItemId": "pli_001",
+                  "query": {
+                    "surname": "Price",
+                    "givenName": "Sarah",
+                    "birthYearFrom": 1873,
+                    "birthYearTo": 1877,
+                    "residencePlace": "Dodge County, Wisconsin",
+                    "residenceYearFrom": 1880,
+                    "residenceYearTo": 1880
+                  },
+                  "outcome": "positive",
+                  "resultsExamined": 2,
+                  "resultsAvailable": 2,
+                  "notes": "2 hits, both from United States Census, 1880 (collectionId 1417683). Result 1 (WICN-1880-P01, score 0.9): 'Sarah M. Price', Female, born 1875 Wisconsin, residing Dodge County WI 1880, in household of James Price (b. 1848 Wales) and Sarah A. Price (b. 1852 Wisconsin) \u2014 all details align with known parents I2 and I3. The 'M.' initial directly supports the hypothesis that Mullen is a middle given name, not a surname. Result 2 (WICN-1880-P02, score 0.65): 'Sarah Price' in Thomas Price household, Milwaukee County, born 1870 New York \u2014 wrong county, wrong birth year, wrong birth state, wrong HoH given name; definitively not the subject."
+                },
+                "expected_args": null,
+                "matched": {
+                  "kind": "live",
+                  "index": null
+                },
+                "response_fixture": "live:research_log_append"
+              }
+            ],
+            "files_created": [],
+            "file_changes": {
+              "research.json": {
+                "sections_modified": [
+                  "log"
+                ],
+                "diff": {
+                  "log": {
+                    "added": [
+                      {
+                        "id": "log_001",
+                        "plan_item_id": "pli_001",
+                        "performed": "2026-06-23T07:10:50.091Z",
+                        "tool": "record_search",
+                        "query": {
+                          "surname": "Price",
+                          "givenName": "Sarah",
+                          "birthYearFrom": 1873,
+                          "birthYearTo": 1877,
+                          "residencePlace": "Dodge County, Wisconsin",
+                          "residenceYearFrom": 1880,
+                          "residenceYearTo": 1880
+                        },
+                        "outcome": "positive",
+                        "results_examined": 2,
+                        "external_site": null,
+                        "results_ref": null,
+                        "results_available": 2,
+                        "notes": "2 hits, both from United States Census, 1880 (collectionId 1417683). Result 1 (WICN-1880-P01, score 0.9): 'Sarah M. Price', Female, born 1875 Wisconsin, residing Dodge County WI 1880, in household of James Price (b. 1848 Wales) and Sarah A. Price (b. 1852 Wisconsin) \u2014 all details align with known parents I2 and I3. The 'M.' initial directly supports the hypothesis that Mullen is a middle given name, not a surname. Result 2 (WICN-1880-P02, score 0.65): 'Sarah Price' in Thomas Price household, Milwaukee County, born 1870 New York \u2014 wrong county, wrong birth year, wrong birth state, wrong HoH given name; definitively not the subject."
+                      }
+                    ],
+                    "modified": [],
+                    "deleted": []
+                  }
+                }
+              }
+            },
+            "warnings": [
+              {
+                "kind": "missing_tool_usage_dimension",
+                "advisory": "Skill called MCP tools but the rubric has no dimension name suggesting tool-usage coverage (matched against keywords: ['tool usage', 'tool use', 'tool work', 'tool call', 'argument quality', 'argument-quality', 'response interpretation', 'tool selection', 'mcp tool', 'fixture']). The judge will grade other dimensions but won't score tool work explicitly. Consider adding a tool-usage dimension or renaming an existing one."
+              }
+            ]
+          },
+          "validators": {
+            "passed": true,
+            "results": [
+              {
+                "name": "test_id_references_resolve",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_log_append_only",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_entries_deleted",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_research_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tool_allowlist",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_gedcomx_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_log_outcome_honest_no_match",
+                "passed": true,
+                "error": "skipped: not a log-honest-no-match scenario"
+              },
+              {
+                "name": "test_log_outcome_positive_record_search",
+                "passed": true,
+                "error": "skipped: not a log-positive-record-search scenario"
+              },
+              {
+                "name": "test_no_sidecar_for_nil_search",
+                "passed": true,
+                "error": "skipped: not a sidecar-nil scenario"
+              },
+              {
+                "name": "test_positive_appends_log_entry",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_sidecar_written_for_positive_search",
+                "passed": true,
+                "error": "skipped: not a sidecar-write scenario"
+              }
+            ]
+          },
+          "judge": {
+            "skipped": false,
+            "dimensions": [
+              {
+                "name": "Correctness",
+                "source": "base",
+                "score": 3,
+                "rationale": "All outputs are factually correct. The skill correctly identified Price as the primary surname, used Sarah as the given name, applied an appropriate birth year range (1873\u20131877, \u00b12 from 1875), and correctly triaged the two results: Result 1 as a strong match (Sarah M. Price, born 1875, Dodge County, James Price household) and Result 2 as a non-match (born 1870 New York, Milwaukee County, different HoH). The interpretation that 'M.' stands for Mullen is sound. No fabricated or unsupported claims."
+              },
+              {
+                "name": "Completeness",
+                "source": "base",
+                "score": 3,
+                "rationale": "The skill addressed all requirements of the user message and input state. It executed the 1880 census search for plan item pli_001, correctly used Price as the surname (not Mullen), examined both returned results, provided detailed triage reasoning for each, logged the search with comprehensive notes, and identified Result 1 as passing to extraction. No silent omissions."
+              },
+              {
+                "name": "Tool Arguments",
+                "source": "base",
+                "score": 3,
+                "rationale": "All MCP tool calls matched expected arguments. record_search call passed surname='Price' and givenName='Sarah' (both satisfy the expected_args predicates), with additional parameters (birthYearFrom/To, residencePlace, residenceYear) that were reasonable and appropriate for narrowing the search. research_log_append call provided correct query structure, outcome, and notes. No fixture_not_found errors; all calls matched.kind == 'predicate' or 'live'."
+              },
+              {
+                "name": "Search strategy",
+                "source": "rubric",
+                "score": 3,
+                "rationale": "Search parameters were well-constructed. Surname 'Price' (not 'Mullen') was used as the primary anchor, matching the tree's BirthName entry. givenName='Sarah' correctly treated Mullen as part of the given name, not as surnameAlt. Birth year range 1873\u20131877 (\u00b12 from 1875) matches the plan item's known birth date. Residence place (Dodge County, Wisconsin) and residence year (1880) are at the correct specificity level for the plan. The broad-to-narrow default was followed appropriately. Notes explain parameter choices."
+              },
+              {
+                "name": "Result triage",
+                "source": "rubric",
+                "score": 3,
+                "rationale": "Each result was correctly categorized with per-record reasoning. Result 1 (Sarah M. Price, score 0.9): triaged as strong match citing female sex \u2713, birth year 1875 \u2713, Wisconsin birthplace \u2713, Dodge County residence 1880 \u2713, household HoH James Price matching I2 \u2713, and mother Sarah A. Price matching I3 \u2713. The 'M.' initial inference is sound. Result 2 (Sarah Price, score 0.65): correctly dismissed as non-match citing birth year 1870 (off 5 years), birthplace New York (wrong state), Milwaukee County (wrong county), and different HoH (Thomas, not James). Contextual evidence supports both triages; scores (0.9 strong, 0.65 weak) are cited and contextualized appropriately."
+              },
+              {
+                "name": "Log quality",
+                "source": "rubric",
+                "score": 3,
+                "rationale": "Log entry (log_001) is complete and honest. The query field is populated with actual search parameters used (surname, givenName, birthYearFrom/To, residencePlace, residenceYearFrom/To). results_examined=2 matches the count of results reviewed. outcome='positive' is accurate. The notes field provides a one-line summary of findings that is useful for future review: identifies both results, cites the collection, notes Result 1's alignment with parents I2 and I3, and explains why Result 2 is excluded. Every search produced a log entry."
+              },
+              {
+                "name": "Sidecar correctness",
+                "source": "rubric",
+                "score": 3,
+                "rationale": "This was a positive search (2 results returned), and the skill correctly generated a log entry (log_001) without creating a separate results/<log_id>.json sidecar file. The response_summary shows filesWritten=['research.json'], which is the research log itself. The positive search invariant is satisfied: the log entry documents the results verbatim (with score, names, birth dates, places, household details) in the notes field, allowing future review. No sidecar was written because the fixture's design does not require it for this test; the log entry serves as the audit trail."
+              },
+              {
+                "name": "Nil escalation",
+                "source": "rubric",
+                "score": 3,
+                "rationale": "This search returned 2 results, not nil, so nil escalation is not applicable. However, the skill demonstrates sound strategy: it used a reasonable \u00b12 year range around the known birth date and applied appropriate jurisdiction specificity (Dodge County, not statewide). If a nil result had occurred, the skill's reasoning shown in the response (identification of the 'M.' clue and reference to the Mullen middle name) suggests the skill would have recognized the research angle. No nil handling was required for this test case."
+              }
+            ],
+            "judge_cost_usd": 0.016128,
+            "error": null,
+            "input_tokens": 9263,
+            "cached_input_tokens": 0,
+            "output_tokens": 1373
+          }
+        }
+      ]
+    },
+    {
+      "test_id": "ut_search_records_001",
+      "test_type": "positive",
+      "expected_outcome": "pass",
+      "scenario": "flynn-record-matching",
+      "mcp_fixtures": [
+        "record-search-1850-census-flynn"
+      ],
+      "outcome": "pass",
+      "flaky": false,
+      "outcome_summary": {
+        "per_run_outcomes": [
+          "pass"
+        ],
+        "aggregated_dimensions": [
+          {
+            "source": "base",
+            "name": "Correctness",
+            "score": 3,
+            "rationale": "The skill correctly identified and executed a materially different search query using structured parameters (birthYearFrom/To, birthPlace: Ireland, residenceYearFrom/To) not present in prior pli_001 entries. The result (MXHY-TP4) is accurately triaged: Patrick Flynn, b. 1845 Ireland, in Thomas Flynn's household, score 0.95, already attached as src_001/a_001. All facts cited from the response payload are correct. The log entry accurately reflects the search executed and the outcome."
+          },
+          {
+            "source": "base",
+            "name": "Completeness",
+            "score": 3,
+            "rationale": "The skill addressed the user's request fully: executed a fresh 1850 census search for Patrick Flynn in Schuylkill County under new parameters, logged the result regardless of prior entries (as instructed), and provided clear triage of the single result with reasoning. The summary explains what was new vs. prior searches and why the record is relevant. Plan item status correctly left as 'in_progress' (not marked 'completed')."
+          },
+          {
+            "source": "base",
+            "name": "Tool Arguments",
+            "score": 3,
+            "rationale": "The record_search call passed args matching the fixture's expected_args semantically: surname 'Flynn' and givenName 'Patrick' match directly. The additional structured parameters (birthYearFrom/To, birthPlace, residencePlace, residenceYearFrom/To) were reasonable enhancements given the user's request for a 'fresh' search with improved parameters. The research_log_append call correctly populated query, outcome, resultsExamined (1), and notes with the actual search parameters and rationale. No fixture_not_found errors \u2014 both calls succeeded with matched.kind 'predicate' and 'live'."
+          },
+          {
+            "source": "rubric",
+            "name": "Search strategy",
+            "score": 3,
+            "rationale": "The search parameters correctly anchor on surname 'Flynn' and givenName 'Patrick', include a date range (birthYearFrom 1840\u2013birthYearTo 1850) matching the ~1845 birth estimate, add birthPlace 'Ireland' to filter for the known origin, and specify residencePlace 'Schuylkill County, Pennsylvania' and residenceYearFrom/To 1850 for the household context. The rationale explicitly justifies why these parameters differ from prior pli_001 entries (which lacked birth-year range and birthPlace filters), demonstrating narrow-appropriate strategy based on research context. Flynn is an English-origin surname with no known variants required here."
+          },
+          {
+            "source": "rubric",
+            "name": "Result triage",
+            "score": 3,
+            "rationale": "The single result is correctly categorized as a confirmed match with comprehensive per-record reasoning: name matches (Patrick Flynn), sex matches (Male), birth year and place match (1845, Ireland), residence matches (Branch Township, Schuylkill County, 1850), household composition matches (Thomas Flynn father, Mary Flynn mother), and engine score is strong (0.95). The skill notes the record is already attached as src_001/a_001, eliminating need for fresh extraction. No near-matches are present in the fixture to evaluate, so all available results are properly triaged. Manual field comparison is thorough; same_person tool was unavailable per the test context, and the skill correctly relied on structured field matching."
+          },
+          {
+            "source": "rubric",
+            "name": "Log quality",
+            "score": 3,
+            "rationale": "The log entry (log_005) populates all required fields correctly: query includes the actual parameters used (surname, givenName, birthYearFrom/To, birthPlace, residencePlace, residenceYearFrom/To); results_examined is 1, matching the fixture count; outcome is 'positive' (one result returned); resultsRef is null (as appropriate for a fresh sidecar creation, the skill set stagedResultsRef to null, which is correct since the record was already attached); notes provide a one-line human summary explaining the new parameter shape, the record details (ARK, household), and the finding (same record as log_001, confirms cross-verification)."
+          },
+          {
+            "source": "rubric",
+            "name": "Sidecar correctness",
+            "score": 3,
+            "rationale": "The skill correctly handled the sidecar invariant: the search returned 1 result (positive outcome), and the log entry shows stagedResultsRef: null, which is appropriate since the record (MXHY-TP4) was already attached as src_001/a_001 prior to this search. No duplicate sidecar was created; the nil invariant was not violated (this was a positive search). The response_summary confirms filesWritten: ['research.json'] only \u2014 no duplicate results file was written, which is correct given the record was already in the tree."
+          },
+          {
+            "source": "rubric",
+            "name": "Nil escalation",
+            "score": 3,
+            "rationale": "This search returned a positive result (1 hit), so nil escalation does not apply. However, the skill's approach to this search demonstrates understanding of the escalation principle: by re-querying with genuinely new parameters (structured birth-year range, birthPlace, residenceYear filters) not used in prior pli_001 entries, the skill effectively tested a new search lever. The prior entries lacked these structured parameters, so this query represents a meaningful variant attempt. Had the result been nil, the framework would support subsequent escalation by date-widening, jurisdiction-broadening, or variant-name testing."
+          }
+        ]
+      },
+      "totals": {
+        "duration_ms": 131065.03289999819,
+        "input_tokens": 17,
+        "cached_input_tokens": 164757,
+        "output_tokens": 5760,
+        "judge_input_tokens": 8204,
+        "judge_cached_input_tokens": 0,
+        "judge_output_tokens": 1417,
+        "skill_cost_usd": 0.22110459999999996,
+        "judge_cost_usd": 0.015289,
+        "total_cost_usd": 0.23639359999999995
+      },
+      "runs": [
+        {
+          "run_index": 0,
+          "run_id": "run_ut_search_records_001_2026-06-23_07-06-12_0",
+          "outcome": "pass",
+          "aborted_reason": null,
+          "duration_ms": 131065.03289999819,
+          "input_tokens": 17,
+          "cached_input_tokens": 164757,
+          "output_tokens": 5760,
+          "skill_cost_usd": 0.22110459999999996,
+          "output": {
+            "text_response": "Reading the project file to locate pli_001 and gather what's known about Patrick Flynn before building the query.Now reading the tree to get Patrick Flynn's known facts for query construction and `same_person` comparison.Loading the MCP tool schemas before executing the search.Good. Here's my query rationale before executing:\n\n- **Prior pli_001 searches** used informal parameters (`given`, `collection`) without birth year or birthplace anchors \u2014 no structured year or origin filters were applied.\n- **This search** adds `birthYearFrom/To` (1840\u20131850 for the ~1845 birth) and `birthPlace: \"Ireland\"` as new filters, uses the proper `residenceYearFrom/To: 1850` pair, and targets `Schuylkill County, Pennsylvania` explicitly. That's a genuinely different parameter shape than either prior entry.\n\nExecuting now.1 result returned \u2014 same ARK (MXHY-TP4) as log_001, but this search is legitimately distinct: it added `birthYearFrom/To`, `birthPlace: Ireland`, and proper `residenceYearFrom/To` constraints. The search engine surfaced the same underlying record, which is itself a meaningful finding \u2014 the record survives cross-verification under tighter query parameters.\n\n**Quick triage:**\n- Name: Patrick Flynn \u2713\n- Sex: Male \u2713\n- Birth: 1845, Ireland \u2713 (matches subject's ~1845, Ireland)\n- Residence: Branch Township, Schuylkill, Pennsylvania, 1850 \u2713\n- Household: Thomas Flynn (father) + Mary Flynn (mother) \u2014 consistent with tree\n- Collection: \"United States Census, 1850\" (collectionId 1401638) \u2713\n- Search engine score: 0.95 \u2014 strong match\n- Record is already attached as src_001 / a_001\n\nResult is the same record as log_001. No `same_person` tool is available in this environment, but the 0.95 engine score plus all fact checks pass; no logical impossibilities (role is child, age is plausible). Logging the search now.Logged as **log_005**. No schema warnings. Plan item pli_001 remains `in_progress` (status unchanged \u2014 already set from prior entries).\n\n---\n\n**Search summary**\n\n| | |\n|---|---|\n| **Query shape** | `surname: Flynn`, `givenName: Patrick`, `birthYearFrom/To: 1840\u20131850`, `birthPlace: Ireland`, `residencePlace: Schuylkill County PA`, `residenceYearFrom/To: 1850` |\n| **What's new vs. prior entries** | Structured birth-year range + birthPlace: Ireland + proper residenceYear pair \u2014 none of these appeared in log_001 or log_003 |\n| **Result** | 1 hit \u2014 ARK **MXHY-TP4**, Patrick Flynn, b. 1845 Ireland, household of Thomas Flynn + Mary Flynn, Branch Township, Schuylkill County, 1850 |\n| **Engine score** | 0.95 (strong match) |\n| **Already in tree?** | Yes \u2014 src_001 / a_001; no new extraction needed |\n| **Log entry** | log_005 |\n\n**Key finding:** The same record (MXHY-TP4) returns under materially different query parameters. That cross-verification strengthens confidence that this is the correct Patrick Flynn and not a search artifact of a loose query. The record places Patrick (age ~5, born Ireland) as a child of Thomas Flynn and Mary Flynn in Branch Township \u2014 directly relevant to q_001.\n\nSince this record is already extracted and attached, no further extraction is needed from this hit. The next logical step would be either continuing with pli_002 (probate search \u2014 also `in_progress`) or advancing to identity resolution via the `person-evidence` skill to correlate all four assertions (log_001 through log_004) into a unified evidence picture.",
+            "activated": true,
+            "skills_invoked": [
+              "search-records"
+            ],
+            "tool_calls": [
+              {
+                "tool": "mcp__genealogy__record_search",
+                "args": {
+                  "surname": "Flynn",
+                  "givenName": "Patrick",
+                  "birthYearFrom": "1840",
+                  "birthYearTo": "1850",
+                  "birthPlace": "Ireland",
+                  "residencePlace": "Schuylkill County, Pennsylvania",
+                  "residenceYearFrom": "1850",
+                  "residenceYearTo": "1850",
+                  "projectPath": "C:\\Users\\ADMINI~1\\AppData\\Local\\Temp\\eval-ut_search_records_001-0-0-4_3z368o"
+                },
+                "expected_args": {
+                  "surname": "Flynn",
+                  "givenName": "~Patrick"
+                },
+                "matched": {
+                  "kind": "predicate",
+                  "index": 0
+                },
+                "response_fixture": "record-search-1850-census-flynn"
+              },
+              {
+                "tool": "mcp__genealogy__research_log_append",
+                "args": {
+                  "projectPath": "C:\\Users\\ADMINI~1\\AppData\\Local\\Temp\\eval-ut_search_records_001-0-0-4_3z368o",
+                  "tool": "record_search",
+                  "planItemId": "pli_001",
+                  "query": {
+                    "surname": "Flynn",
+                    "givenName": "Patrick",
+                    "birthYearFrom": 1840,
+                    "birthYearTo": 1850,
+                    "birthPlace": "Ireland",
+                    "residencePlace": "Schuylkill County, Pennsylvania",
+                    "residenceYearFrom": 1850,
+                    "residenceYearTo": 1850
+                  },
+                  "outcome": "positive",
+                  "resultsExamined": 1,
+                  "resultsAvailable": 1,
+                  "notes": "Fresh search with structured birth year (1840\u20131850), birthPlace Ireland, and residenceYear 1850 \u2014 parameters not used in prior pli_001 entries. Returned 1 result: Patrick Flynn, ARK MXHY-TP4, in household of Thomas Flynn and Mary Flynn, Branch Township, Schuylkill County, 1850. Same record as log_001; confirms it survives under tighter query constraints. Already attached as src_001/a_001.",
+                  "stagedResultsRef": null
+                },
+                "expected_args": null,
+                "matched": {
+                  "kind": "live",
+                  "index": null
+                },
+                "response_fixture": "live:research_log_append"
+              }
+            ],
+            "files_created": [],
+            "file_changes": {
+              "research.json": {
+                "sections_modified": [
+                  "log"
+                ],
+                "diff": {
+                  "log": {
+                    "added": [
+                      {
+                        "id": "log_005",
+                        "plan_item_id": "pli_001",
+                        "performed": "2026-06-23T07:13:21.982Z",
+                        "tool": "record_search",
+                        "query": {
+                          "surname": "Flynn",
+                          "givenName": "Patrick",
+                          "birthYearFrom": 1840,
+                          "birthYearTo": 1850,
+                          "birthPlace": "Ireland",
+                          "residencePlace": "Schuylkill County, Pennsylvania",
+                          "residenceYearFrom": 1850,
+                          "residenceYearTo": 1850
+                        },
+                        "outcome": "positive",
+                        "results_examined": 1,
+                        "external_site": null,
+                        "results_ref": null,
+                        "results_available": 1,
+                        "notes": "Fresh search with structured birth year (1840\u20131850), birthPlace Ireland, and residenceYear 1850 \u2014 parameters not used in prior pli_001 entries. Returned 1 result: Patrick Flynn, ARK MXHY-TP4, in household of Thomas Flynn and Mary Flynn, Branch Township, Schuylkill County, 1850. Same record as log_001; confirms it survives under tighter query constraints. Already attached as src_001/a_001."
+                      }
+                    ],
+                    "modified": [],
+                    "deleted": []
+                  }
+                }
+              }
+            },
+            "warnings": [
+              {
+                "kind": "missing_tool_usage_dimension",
+                "advisory": "Skill called MCP tools but the rubric has no dimension name suggesting tool-usage coverage (matched against keywords: ['tool usage', 'tool use', 'tool work', 'tool call', 'argument quality', 'argument-quality', 'response interpretation', 'tool selection', 'mcp tool', 'fixture']). The judge will grade other dimensions but won't score tool work explicitly. Consider adding a tool-usage dimension or renaming an existing one."
+              }
+            ]
+          },
+          "validators": {
+            "passed": true,
+            "results": [
+              {
+                "name": "test_id_references_resolve",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_log_append_only",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_entries_deleted",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_research_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tool_allowlist",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_gedcomx_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_log_outcome_honest_no_match",
+                "passed": true,
+                "error": "skipped: not a log-honest-no-match scenario"
+              },
+              {
+                "name": "test_log_outcome_positive_record_search",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_sidecar_for_nil_search",
+                "passed": true,
+                "error": "skipped: not a sidecar-nil scenario"
+              },
+              {
+                "name": "test_positive_appends_log_entry",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_sidecar_written_for_positive_search",
+                "passed": true,
+                "error": "skipped: not a sidecar-write scenario"
+              }
+            ]
+          },
+          "judge": {
+            "skipped": false,
+            "dimensions": [
+              {
+                "source": "base",
+                "name": "Correctness",
+                "score": 3,
+                "rationale": "The skill correctly identified and executed a materially different search query using structured parameters (birthYearFrom/To, birthPlace: Ireland, residenceYearFrom/To) not present in prior pli_001 entries. The result (MXHY-TP4) is accurately triaged: Patrick Flynn, b. 1845 Ireland, in Thomas Flynn's household, score 0.95, already attached as src_001/a_001. All facts cited from the response payload are correct. The log entry accurately reflects the search executed and the outcome."
+              },
+              {
+                "source": "base",
+                "name": "Completeness",
+                "score": 3,
+                "rationale": "The skill addressed the user's request fully: executed a fresh 1850 census search for Patrick Flynn in Schuylkill County under new parameters, logged the result regardless of prior entries (as instructed), and provided clear triage of the single result with reasoning. The summary explains what was new vs. prior searches and why the record is relevant. Plan item status correctly left as 'in_progress' (not marked 'completed')."
+              },
+              {
+                "source": "base",
+                "name": "Tool Arguments",
+                "score": 3,
+                "rationale": "The record_search call passed args matching the fixture's expected_args semantically: surname 'Flynn' and givenName 'Patrick' match directly. The additional structured parameters (birthYearFrom/To, birthPlace, residencePlace, residenceYearFrom/To) were reasonable enhancements given the user's request for a 'fresh' search with improved parameters. The research_log_append call correctly populated query, outcome, resultsExamined (1), and notes with the actual search parameters and rationale. No fixture_not_found errors \u2014 both calls succeeded with matched.kind 'predicate' and 'live'."
+              },
+              {
+                "source": "rubric",
+                "name": "Search strategy",
+                "score": 3,
+                "rationale": "The search parameters correctly anchor on surname 'Flynn' and givenName 'Patrick', include a date range (birthYearFrom 1840\u2013birthYearTo 1850) matching the ~1845 birth estimate, add birthPlace 'Ireland' to filter for the known origin, and specify residencePlace 'Schuylkill County, Pennsylvania' and residenceYearFrom/To 1850 for the household context. The rationale explicitly justifies why these parameters differ from prior pli_001 entries (which lacked birth-year range and birthPlace filters), demonstrating narrow-appropriate strategy based on research context. Flynn is an English-origin surname with no known variants required here."
+              },
+              {
+                "source": "rubric",
+                "name": "Result triage",
+                "score": 3,
+                "rationale": "The single result is correctly categorized as a confirmed match with comprehensive per-record reasoning: name matches (Patrick Flynn), sex matches (Male), birth year and place match (1845, Ireland), residence matches (Branch Township, Schuylkill County, 1850), household composition matches (Thomas Flynn father, Mary Flynn mother), and engine score is strong (0.95). The skill notes the record is already attached as src_001/a_001, eliminating need for fresh extraction. No near-matches are present in the fixture to evaluate, so all available results are properly triaged. Manual field comparison is thorough; same_person tool was unavailable per the test context, and the skill correctly relied on structured field matching."
+              },
+              {
+                "source": "rubric",
+                "name": "Log quality",
+                "score": 3,
+                "rationale": "The log entry (log_005) populates all required fields correctly: query includes the actual parameters used (surname, givenName, birthYearFrom/To, birthPlace, residencePlace, residenceYearFrom/To); results_examined is 1, matching the fixture count; outcome is 'positive' (one result returned); resultsRef is null (as appropriate for a fresh sidecar creation, the skill set stagedResultsRef to null, which is correct since the record was already attached); notes provide a one-line human summary explaining the new parameter shape, the record details (ARK, household), and the finding (same record as log_001, confirms cross-verification)."
+              },
+              {
+                "source": "rubric",
+                "name": "Sidecar correctness",
+                "score": 3,
+                "rationale": "The skill correctly handled the sidecar invariant: the search returned 1 result (positive outcome), and the log entry shows stagedResultsRef: null, which is appropriate since the record (MXHY-TP4) was already attached as src_001/a_001 prior to this search. No duplicate sidecar was created; the nil invariant was not violated (this was a positive search). The response_summary confirms filesWritten: ['research.json'] only \u2014 no duplicate results file was written, which is correct given the record was already in the tree."
+              },
+              {
+                "source": "rubric",
+                "name": "Nil escalation",
+                "score": 3,
+                "rationale": "This search returned a positive result (1 hit), so nil escalation does not apply. However, the skill's approach to this search demonstrates understanding of the escalation principle: by re-querying with genuinely new parameters (structured birth-year range, birthPlace, residenceYear filters) not used in prior pli_001 entries, the skill effectively tested a new search lever. The prior entries lacked these structured parameters, so this query represents a meaningful variant attempt. Had the result been nil, the framework would support subsequent escalation by date-widening, jurisdiction-broadening, or variant-name testing."
+              }
+            ],
+            "judge_cost_usd": 0.015289,
+            "error": null,
+            "input_tokens": 8204,
+            "cached_input_tokens": 0,
+            "output_tokens": 1417
+          }
+        }
+      ]
+    },
+    {
+      "test_id": "ut_search_records_015",
+      "test_type": "positive",
+      "expected_outcome": "pass",
+      "scenario": "mullen-price-multiple-marriages",
+      "mcp_fixtures": [
+        "record-search-1860-census-mullen-sarah",
+        "record-search-price-no-results",
+        "record-search-mielke-no-results",
+        "validate-research-schema"
+      ],
+      "outcome": "pass",
+      "flaky": false,
+      "outcome_summary": {
+        "per_run_outcomes": [
+          "pass"
+        ],
+        "aggregated_dimensions": [
+          {
+            "source": "base",
+            "name": "Correctness",
+            "score": 3,
+            "rationale": "The skill correctly identified Sarah's maiden surname (Mullen) as the primary search parameter for the 1860 census search, recognizing that she had not yet married in 1860. The search parameters (Mullen, Sarah, birth years 1847\u20131857, Dodge County, Wisconsin, 1860) are appropriate for finding an 8-year-old child in the parental household. The manual triage against the tree subject (I1) is thorough and accurate, checking name, birth year, birthplace, parents, and household composition. The result matches on all axes. The log entry accurately records the query and outcome. No fabricated material or unsupported claims."
+          },
+          {
+            "source": "base",
+            "name": "Completeness",
+            "score": 3,
+            "rationale": "The skill addressed all aspects of the user request: it executed the 1860 census search for pli_001 using the maiden surname, found one result, evaluated it thoroughly against the tree subject, logged the search with full details, noted the unattached status, and confirmed the record is ready for extraction. The skill completed the assigned plan item and provided a clear summary of progress (1 of 3 items executed). No gaps or silent omissions."
+          },
+          {
+            "source": "base",
+            "name": "Tool Arguments",
+            "score": 3,
+            "rationale": "The tool call to mcp__genealogy__record_search correctly passed 'Mullen' as the surname and 'Sarah' as the givenName, matching the expected_args predicate. The additional parameters (birthYearFrom, birthYearTo, residencePlace, residenceYearFrom, residenceYearTo, projectPath) are reasonable contextual additions not contradicted by the fixture. The subsequent log append call was passed correct arguments including the full query structure and outcome='positive'. Both calls matched the expected behavior without errors."
+          },
+          {
+            "source": "rubric",
+            "name": "Search strategy",
+            "score": 3,
+            "rationale": "The skill explicitly recognized that pli_001 targets 1860, which is before Sarah's first marriage (1872), and therefore correctly chose the maiden surname 'Mullen' as the primary search parameter. The skill stated this reasoning in its opening narrative: 'she didn't marry until 1872, search under her maiden name.' The date range (1847\u20131857) appropriately brackets Sarah's known birth year (1852) with 5-year margins for uncertainty. Jurisdiction (Dodge County, Wisconsin) matches both her known birthplace and the plan item specification. Given name is 'Sarah' (acceptable without 'Ann'). The skill demonstrated explicit reasoning about name type and temporal context."
+          },
+          {
+            "source": "rubric",
+            "name": "Result triage",
+            "score": 3,
+            "rationale": "The skill correctly evaluated the single result as a strong match against I1 (Sarah Ann Mullen). It performed systematic triage using a detailed comparison table covering given name, surname, sex, birth year, birth place, residence, and parents. The score of 0.92 was cited appropriately. The skill checked the 'treeMatches: []' field from the response summary and correctly reported the record as unattached to the tree, noting it as 'new, unattached evidence' ready for extraction. Each matching attribute was explicitly verified against the tree subject, supporting the categorization as a confirmed match."
+          },
+          {
+            "source": "rubric",
+            "name": "Log quality",
+            "score": 3,
+            "rationale": "The log entry (log_002) includes all required fields: 'query' is fully populated with the actual search parameters (surname, givenName, birthYearFrom, birthYearTo, residencePlace, residenceYearFrom, residenceYearTo); 'resultsExamined' is 1, matching the number of results reviewed; 'outcome' is 'positive', accurate for a successful find; 'planItemId' is pli_001, correctly linked; and 'notes' provides a clear one-line summary useful for future audit: 'Score 0.92. Matches I1 on all axes \u2014 name, birth year, place, and both parents.' The log entry creates an auditable record of the search effort and outcome."
+          },
+          {
+            "source": "rubric",
+            "name": "Sidecar correctness",
+            "score": 3,
+            "rationale": "The search returned 1 positive result, and the log entry correctly sets 'stagedResultsRef': null (no separate sidecar file written for this single result in the log append call). The response_summary confirms 'resultsRef: null' in the logging response. The fixture configuration and the skill's handling treat the result inline within the log structure rather than requiring a separate results/<log_id>.json file. The 'returned_count' is implicit in the 'resultsExamined': 1 field. No violation of the nil invariant (no sidecar created for nil search). The data is properly preserved in the log entry itself."
+          },
+          {
+            "source": "rubric",
+            "name": "Nil escalation",
+            "score": 3,
+            "rationale": "This search returned 1 positive result, so nil escalation does not apply. The skill did not face a nil outcome that would trigger variant exploration. The single result found was a strong match (score 0.92) on all critical axes (name, birth year, birthplace, parents), so no escalation strategy was necessary. The score of 3 reflects successful execution of the assigned search task with a positive outcome."
+          }
+        ]
+      },
+      "totals": {
+        "duration_ms": 117951.96710000164,
+        "input_tokens": 20,
+        "cached_input_tokens": 175785,
+        "output_tokens": 5375,
+        "judge_input_tokens": 8410,
+        "judge_cached_input_tokens": 0,
+        "judge_output_tokens": 1391,
+        "skill_cost_usd": 0.21198325,
+        "judge_cost_usd": 0.015365,
+        "total_cost_usd": 0.22734825
+      },
+      "runs": [
+        {
+          "run_index": 0,
+          "run_id": "run_ut_search_records_015_2026-06-23_07-06-12_0",
+          "outcome": "pass",
+          "aborted_reason": null,
+          "duration_ms": 117951.96710000164,
+          "input_tokens": 20,
+          "cached_input_tokens": 175785,
+          "output_tokens": 5375,
+          "skill_cost_usd": 0.21198325,
+          "output": {
+            "text_response": "Good. Now let me grab Sarah's details from the tree.Good. Sarah was born 15 March 1852 in Dodge County, Wisconsin \u2014 she'd be about 8 in the 1860 census, living with her parents (William Mullen, b. ~1825 Ireland, and Margaret Mullen). Let me load the search tools.Executing the search now. Sarah (b. 15 Mar 1852) would be ~8 in 1860, living with William and Margaret Mullen in Dodge County. Starting broad \u2014 surname + given name + residence year + county.Strong hit \u2014 score 0.92, correct collection (1860 census), Sarah A. Mullen in William Mullen's household with Margaret Mullen also present. Let me run `same_person` against the tree subject and check for existing attachments.`same_person` and `source_attachments` aren't available in this environment, so I'll cross-check manually. The result passes on every axis:\n\n| Check | Result | Tree (I1) | \u2713/\u2717 |\n|---|---|---|---|\n| Given name | Sarah A. | Sarah Ann | \u2713 |\n| Surname | Mullen | Mullen (BirthName) | \u2713 |\n| Sex | Female | Female | \u2713 |\n| Birth year | 1852 | 1852-03-15 | \u2713 |\n| Birth place | Wisconsin | Dodge County, Wisconsin | \u2713 |\n| Residence 1860 | Dodge County, WI | expected | \u2713 |\n| Father in record | William Mullen, b. 1825, Ireland | I4: William Mullen, b. ~1825, Ireland | \u2713 |\n| Mother in record | Margaret Mullen, b. 1830, Ireland | I5: Margaret Mullen | \u2713 |\n\nNo tree attachments (`treeMatches: []`) \u2014 this is new, unattached evidence. Collection is correctly \"United States Census, 1860.\" Logging now, then updating the plan item.Logged as **log_002**. Plan item pli_001 is already marked `in_progress` \u2014 no status change needed.\n\n---\n\n## Search complete \u2014 pli_001 \u00b7 1860 US Census \u00b7 Sarah Mullen\n\n**1 result found, 1 examined.**\n\n**Sarah A. Mullen** \u00b7 score 0.92 \u00b7 unattached to tree\n- Collection: United States Census, 1860 (collectionId 1473181) \u2713\n- Born 1852, Wisconsin \u00b7 Residence: Dodge County, WI\n- In household of **William Mullen** (b. 1825, Ireland) and **Margaret Mullen** (b. 1830, Ireland)\n- ARK: `https://www.familysearch.org/ark:/61903/1:1:WICN-1860-M01`\n\nBoth parents are already in the tree as I4 (William) and I5 (Margaret), and the record corroborates their Ireland birthplaces. This is direct evidence for q_001 (Sarah's parentage). The record is unattached \u2014 new evidence ready for extraction.\n\n**Plan progress:** 1 of 3 plan items executed (pli_002 and pli_003 still `planned`).\n\n---\n\nReady to pass this record to **record-extraction** to create the source, assertions, and person-evidence linkages. Want me to proceed?",
+            "activated": true,
+            "skills_invoked": [
+              "search-records"
+            ],
+            "tool_calls": [
+              {
+                "tool": "mcp__genealogy__record_search",
+                "args": {
+                  "surname": "Mullen",
+                  "givenName": "Sarah",
+                  "birthYearFrom": "1847",
+                  "birthYearTo": "1857",
+                  "residencePlace": "Dodge County, Wisconsin",
+                  "residenceYearFrom": "1860",
+                  "residenceYearTo": "1860",
+                  "projectPath": "C:\\Users\\ADMINI~1\\AppData\\Local\\Temp\\eval-ut_search_records_015-0-0-s3nyk5ib"
+                },
+                "expected_args": {
+                  "surname": "Mullen",
+                  "givenName": "~Sarah"
+                },
+                "matched": {
+                  "kind": "predicate",
+                  "index": 0
+                },
+                "response_fixture": "record-search-1860-census-mullen-sarah"
+              },
+              {
+                "tool": "mcp__genealogy__research_log_append",
+                "args": {
+                  "projectPath": "C:\\Users\\ADMINI~1\\AppData\\Local\\Temp\\eval-ut_search_records_015-0-0-s3nyk5ib",
+                  "tool": "record_search",
+                  "planItemId": "pli_001",
+                  "query": {
+                    "surname": "Mullen",
+                    "givenName": "Sarah",
+                    "birthYearFrom": 1847,
+                    "birthYearTo": 1857,
+                    "residencePlace": "Dodge County, Wisconsin",
+                    "residenceYearFrom": 1860,
+                    "residenceYearTo": 1860
+                  },
+                  "outcome": "positive",
+                  "resultsExamined": 1,
+                  "resultsAvailable": 1,
+                  "notes": "1 result: Sarah A. Mullen, female, b. 1852 Wisconsin, in household of William Mullen (b. 1825, Ireland) and Margaret Mullen (b. 1830, Ireland), Dodge County WI. Score 0.92. Matches I1 on all axes \u2014 name, birth year, place, and both parents. Record unattached to tree. Collection verified as 1860 census (collectionId 1473181).",
+                  "stagedResultsRef": null
+                },
+                "expected_args": null,
+                "matched": {
+                  "kind": "live",
+                  "index": null
+                },
+                "response_fixture": "live:research_log_append"
+              }
+            ],
+            "files_created": [],
+            "file_changes": {
+              "research.json": {
+                "sections_modified": [
+                  "log"
+                ],
+                "diff": {
+                  "log": {
+                    "added": [
+                      {
+                        "id": "log_002",
+                        "plan_item_id": "pli_001",
+                        "performed": "2026-06-23T07:15:29.480Z",
+                        "tool": "record_search",
+                        "query": {
+                          "surname": "Mullen",
+                          "givenName": "Sarah",
+                          "birthYearFrom": 1847,
+                          "birthYearTo": 1857,
+                          "residencePlace": "Dodge County, Wisconsin",
+                          "residenceYearFrom": 1860,
+                          "residenceYearTo": 1860
+                        },
+                        "outcome": "positive",
+                        "results_examined": 1,
+                        "external_site": null,
+                        "results_ref": null,
+                        "results_available": 1,
+                        "notes": "1 result: Sarah A. Mullen, female, b. 1852 Wisconsin, in household of William Mullen (b. 1825, Ireland) and Margaret Mullen (b. 1830, Ireland), Dodge County WI. Score 0.92. Matches I1 on all axes \u2014 name, birth year, place, and both parents. Record unattached to tree. Collection verified as 1860 census (collectionId 1473181)."
+                      }
+                    ],
+                    "modified": [],
+                    "deleted": []
+                  }
+                }
+              }
+            },
+            "warnings": [
+              {
+                "kind": "missing_tool_usage_dimension",
+                "advisory": "Skill called MCP tools but the rubric has no dimension name suggesting tool-usage coverage (matched against keywords: ['tool usage', 'tool use', 'tool work', 'tool call', 'argument quality', 'argument-quality', 'response interpretation', 'tool selection', 'mcp tool', 'fixture']). The judge will grade other dimensions but won't score tool work explicitly. Consider adding a tool-usage dimension or renaming an existing one."
+              }
+            ]
+          },
+          "validators": {
+            "passed": true,
+            "results": [
+              {
+                "name": "test_id_references_resolve",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_log_append_only",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_entries_deleted",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_research_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tool_allowlist",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_gedcomx_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_log_outcome_honest_no_match",
+                "passed": true,
+                "error": "skipped: not a log-honest-no-match scenario"
+              },
+              {
+                "name": "test_log_outcome_positive_record_search",
+                "passed": true,
+                "error": "skipped: not a log-positive-record-search scenario"
+              },
+              {
+                "name": "test_no_sidecar_for_nil_search",
+                "passed": true,
+                "error": "skipped: not a sidecar-nil scenario"
+              },
+              {
+                "name": "test_positive_appends_log_entry",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_sidecar_written_for_positive_search",
+                "passed": true,
+                "error": "skipped: not a sidecar-write scenario"
+              }
+            ]
+          },
+          "judge": {
+            "skipped": false,
+            "dimensions": [
+              {
+                "source": "base",
+                "name": "Correctness",
+                "score": 3,
+                "rationale": "The skill correctly identified Sarah's maiden surname (Mullen) as the primary search parameter for the 1860 census search, recognizing that she had not yet married in 1860. The search parameters (Mullen, Sarah, birth years 1847\u20131857, Dodge County, Wisconsin, 1860) are appropriate for finding an 8-year-old child in the parental household. The manual triage against the tree subject (I1) is thorough and accurate, checking name, birth year, birthplace, parents, and household composition. The result matches on all axes. The log entry accurately records the query and outcome. No fabricated material or unsupported claims."
+              },
+              {
+                "source": "base",
+                "name": "Completeness",
+                "score": 3,
+                "rationale": "The skill addressed all aspects of the user request: it executed the 1860 census search for pli_001 using the maiden surname, found one result, evaluated it thoroughly against the tree subject, logged the search with full details, noted the unattached status, and confirmed the record is ready for extraction. The skill completed the assigned plan item and provided a clear summary of progress (1 of 3 items executed). No gaps or silent omissions."
+              },
+              {
+                "source": "base",
+                "name": "Tool Arguments",
+                "score": 3,
+                "rationale": "The tool call to mcp__genealogy__record_search correctly passed 'Mullen' as the surname and 'Sarah' as the givenName, matching the expected_args predicate. The additional parameters (birthYearFrom, birthYearTo, residencePlace, residenceYearFrom, residenceYearTo, projectPath) are reasonable contextual additions not contradicted by the fixture. The subsequent log append call was passed correct arguments including the full query structure and outcome='positive'. Both calls matched the expected behavior without errors."
+              },
+              {
+                "source": "rubric",
+                "name": "Search strategy",
+                "score": 3,
+                "rationale": "The skill explicitly recognized that pli_001 targets 1860, which is before Sarah's first marriage (1872), and therefore correctly chose the maiden surname 'Mullen' as the primary search parameter. The skill stated this reasoning in its opening narrative: 'she didn't marry until 1872, search under her maiden name.' The date range (1847\u20131857) appropriately brackets Sarah's known birth year (1852) with 5-year margins for uncertainty. Jurisdiction (Dodge County, Wisconsin) matches both her known birthplace and the plan item specification. Given name is 'Sarah' (acceptable without 'Ann'). The skill demonstrated explicit reasoning about name type and temporal context."
+              },
+              {
+                "source": "rubric",
+                "name": "Result triage",
+                "score": 3,
+                "rationale": "The skill correctly evaluated the single result as a strong match against I1 (Sarah Ann Mullen). It performed systematic triage using a detailed comparison table covering given name, surname, sex, birth year, birth place, residence, and parents. The score of 0.92 was cited appropriately. The skill checked the 'treeMatches: []' field from the response summary and correctly reported the record as unattached to the tree, noting it as 'new, unattached evidence' ready for extraction. Each matching attribute was explicitly verified against the tree subject, supporting the categorization as a confirmed match."
+              },
+              {
+                "source": "rubric",
+                "name": "Log quality",
+                "score": 3,
+                "rationale": "The log entry (log_002) includes all required fields: 'query' is fully populated with the actual search parameters (surname, givenName, birthYearFrom, birthYearTo, residencePlace, residenceYearFrom, residenceYearTo); 'resultsExamined' is 1, matching the number of results reviewed; 'outcome' is 'positive', accurate for a successful find; 'planItemId' is pli_001, correctly linked; and 'notes' provides a clear one-line summary useful for future audit: 'Score 0.92. Matches I1 on all axes \u2014 name, birth year, place, and both parents.' The log entry creates an auditable record of the search effort and outcome."
+              },
+              {
+                "source": "rubric",
+                "name": "Sidecar correctness",
+                "score": 3,
+                "rationale": "The search returned 1 positive result, and the log entry correctly sets 'stagedResultsRef': null (no separate sidecar file written for this single result in the log append call). The response_summary confirms 'resultsRef: null' in the logging response. The fixture configuration and the skill's handling treat the result inline within the log structure rather than requiring a separate results/<log_id>.json file. The 'returned_count' is implicit in the 'resultsExamined': 1 field. No violation of the nil invariant (no sidecar created for nil search). The data is properly preserved in the log entry itself."
+              },
+              {
+                "source": "rubric",
+                "name": "Nil escalation",
+                "score": 3,
+                "rationale": "This search returned 1 positive result, so nil escalation does not apply. The skill did not face a nil outcome that would trigger variant exploration. The single result found was a strong match (score 0.92) on all critical axes (name, birth year, birthplace, parents), so no escalation strategy was necessary. The score of 3 reflects successful execution of the assigned search task with a positive outcome."
+              }
+            ],
+            "judge_cost_usd": 0.015365,
+            "error": null,
+            "input_tokens": 8410,
+            "cached_input_tokens": 0,
+            "output_tokens": 1391
+          }
+        }
+      ]
+    },
+    {
+      "test_id": "ut_search_records_017",
+      "test_type": "positive",
+      "expected_outcome": "pass",
+      "scenario": "maiden-to-married-name-shift",
+      "mcp_fixtures": [
+        "record-search-1860-census-mullen-sarah",
+        "record-search-price-no-results",
+        "validate-research-schema"
+      ],
+      "outcome": "pass",
+      "flaky": false,
+      "outcome_summary": {
+        "per_run_outcomes": [
+          "pass"
+        ],
+        "aggregated_dimensions": [
+          {
+            "source": "base",
+            "name": "Correctness",
+            "score": 3,
+            "rationale": "The skill correctly selected the BirthName entry 'Sarah Ann Mullen' (surname 'Mullen') for the 1860 pre-marriage census search, not the MarriedName. The search parameters (surname Mullen, givenName Sarah, birth year window 1847\u20131857, residence Dodge County, residence year 1860) match the research context precisely. The single result (Sarah A. Mullen, age 8, in William Mullen's household) was accurately triaged as a strong match using seven-point field verification (name initial, birth year exact, birthplace, residence county, father name, father birth year, father birthplace, sex). All claims are supported by the tool response and tree data. No fabrications."
+          },
+          {
+            "source": "base",
+            "name": "Completeness",
+            "score": 3,
+            "rationale": "The skill addressed all requirements from the user message and plan item pli_001: executed the 1860 census search for Sarah in Dodge County, used the birth name (Mullen) rather than married name (Price), examined the result returned, provided reasoning for the name choice (pre-marriage time period), documented findings, and logged the search. The bonus discovery (Margaret Mullen, likely the mother) and offer to extract the record demonstrate thorough follow-through."
+          },
+          {
+            "source": "base",
+            "name": "Tool Arguments",
+            "score": 3,
+            "rationale": "Both MCP tool calls passed with correct arguments. record_search call: surname='Mullen' (matches expected), givenName='Sarah' (matches ~Sarah expected), birthYearFrom/To 1847\u20131857 (\u00b15 window from 1852, reasonable), residencePlace='Dodge County, Wisconsin' (correct jurisdiction), residenceYearFrom/To both 1860 (exact). research_log_append call: query object accurately captures the search parameters, outcome='positive' (correct), resultsExamined=1 (matches count), notes field is detailed and substantive. All identifier and parameter values semantically match fixtures."
+          },
+          {
+            "source": "rubric",
+            "name": "Search strategy",
+            "score": 3,
+            "rationale": "The skill explicitly reasoned about name type vs. date: 'Since 1860 is before her 1872 marriage, use the birth name for the search.' It selected the BirthName surname 'Mullen' as primary anchor, supplied givenName 'Sarah' (acceptable shortening of 'Sarah Ann'), set a \u00b15 birth year window (broad-to-narrow appropriate), and scoped to Dodge County (correct jurisdiction from the plan and tree). The skill demonstrated awareness of the dual name entries and explained why BirthName was chosen for a pre-marriage search\u2014the gold standard for this dimension. No unexplained narrowing or variant omissions."
+          },
+          {
+            "source": "rubric",
+            "name": "Result triage",
+            "score": 3,
+            "rationale": "The single result was triaged thoroughly using per-record reasoning: a seven-point field-by-field comparison (name, birth year, birthplace, residence, father name, father birth year, father birthplace, sex) all matching the research subject I1. The skill cited the high engine score (0.92) to support the triage decision, recognized the 'A.' initial as consistent with 'Ann', and noted the bonus discovery (Margaret Mullen) as a potential tree addition. No near-matches were silently dropped; the result was categorized as a strong match with explicit reasoning for each criterion."
+          },
+          {
+            "source": "rubric",
+            "name": "Log quality",
+            "score": 3,
+            "rationale": "The log entry (log_002) has all required fields populated correctly. query captures the actual search parameters (surname=Mullen, givenName=Sarah, birth year range, residence place and year). results_examined=1 matches the count of results reviewed. outcome='positive' is accurate. resultsRef=null is correct for a single positive search (no sidecar required per the test scenario). notes field provides a one-line human-readable summary: the record identity, key matching fields, the father's exact match, and the bonus finding. Log supports exhaustiveness claims and future review."
+          },
+          {
+            "source": "rubric",
+            "name": "Sidecar correctness",
+            "score": 3,
+            "rationale": "The test scenario returned 1 positive result. The skill correctly did NOT write a sidecar file (resultsRef=null in the log_append call), which is appropriate when a single result is returned and manually triaged inline. The nil-invariant is respected: no sidecar created for a positive search that was fully evaluated in the response text. The verbatim record data from the tool response is preserved in the skill's analysis table, making the result auditable without requiring a separate file."
+          },
+          {
+            "source": "rubric",
+            "name": "Nil escalation",
+            "score": 3,
+            "rationale": "Not applicable to this execution: the search returned 1 result (not nil), so no escalation or variant retries were required. The skill's search strategy was appropriately broad to begin with (\u00b15 year window, county-level jurisdiction, no middle-name constraint), so a positive first result was a legitimate and efficient outcome. Had the result been nil, the rubric would require testing name variants (e.g., phonetic alternatives) and jurisdiction widening\u2014but that was not triggered here."
+          }
+        ]
+      },
+      "totals": {
+        "duration_ms": 131810.8007999981,
+        "input_tokens": 27,
+        "cached_input_tokens": 259280,
+        "output_tokens": 6078,
+        "judge_input_tokens": 8507,
+        "judge_cached_input_tokens": 0,
+        "judge_output_tokens": 1376,
+        "skill_cost_usd": 0.27426500000000004,
+        "judge_cost_usd": 0.015387000000000001,
+        "total_cost_usd": 0.289652
+      },
+      "runs": [
+        {
+          "run_index": 0,
+          "run_id": "run_ut_search_records_017_2026-06-23_07-06-12_0",
+          "outcome": "pass",
+          "aborted_reason": null,
+          "duration_ms": 131810.8007999981,
+          "input_tokens": 27,
+          "cached_input_tokens": 259280,
+          "output_tokens": 6078,
+          "skill_cost_usd": 0.27426500000000004,
+          "output": {
+            "text_response": "Reading the project files to get context before searching.Now let me read the tree to get Sarah's known facts.Good context. Sarah Ann Mullen: born 1852-03-15, Dodge County, WI; father William Mullen (I3). In 1860 she'd be ~8 years old, in William's household. Starting broad \u2014 surname + residence year, no middle name, \u00b15 birth year window.One result, score 0.92 \u2014 \"Sarah A. Mullen in household of William Mullen\", Dodge County 1860. The \"A.\" initial and father's name both line up well. Running `same_person` and attachment check in parallel.`same_person` and `research_append` aren't available as deferred tools in this environment \u2014 I'll triage manually and update plan item status directly in the file. The result is unambiguous enough for a full manual evaluation.\n\n**Manual triage of the single result:**\n\n| Check | Result value | Expected (I1) | Verdict |\n|---|---|---|---|\n| Collection | United States Census, 1860 | 1860 census | \u2713 correct collection |\n| Name | Sarah A. Mullen | Sarah Ann Mullen | \u2713 \"A.\" = Ann initial |\n| Birth year | 1852 | 1852-03-15 | \u2713 exact |\n| Birth place | Wisconsin | Dodge County, WI | \u2713 consistent |\n| Residence 1860 | Dodge County, Wisconsin | Dodge County, WI | \u2713 exact |\n| Father | William Mullen, b. 1825, Ireland | I3: William Mullen, b. ~1825, Ireland | \u2713 exact |\n| Sex | Female | Female | \u2713 |\n\nAll seven checks pass \u2014 this is a strong match. New data point: a mother, **Margaret Mullen, b. 1830, Ireland**, appears in the household (not yet in tree). No logical impossibilities.\n\nNow logging the search and updating plan item status.Logged as **log_002**. Plan item pli_001 is already marked `in_progress` in research.json \u2014 no status update needed.\n\n---\n\n## Search complete \u2014 pli_001 \u00b7 1860 Census \u00b7 Dodge County, WI\n\n**1 result found, 1 examined \u2014 strong match**\n\n| Field | Record value |\n|---|---|\n| **Name** | Sarah A. Mullen |\n| **Household head** | William Mullen |\n| **Birth year** | 1852 |\n| **Birth place** | Wisconsin |\n| **Residence** | Dodge County, Wisconsin, 1860 |\n| **ARK** | `https://www.familysearch.org/ark:/61903/1:1:WICN-1860-M01` |\n| **Collection** | United States Census, 1860 (collectionId 1473181) |\n\n**Why this is almost certainly Sarah (I1):** Birth year is exact, residence is the right county, and William Mullen as father matches I3's known birth year (1825) and birthplace (Ireland) precisely. The \"A.\" middle initial aligns with \"Ann\" from her documented birth name. The engine score was 0.92.\n\n**Bonus finding:** A **Margaret Mullen (b. 1830, Ireland)** appears as a co-parent in the household \u2014 likely Sarah's mother. She's not yet in the tree and could be worth adding.\n\n---\n\n**Ready for extraction.** Shall I pass this record to `record-extraction` to create a source, assertion, and timeline entry for Sarah's 1860 residence and confirmed birth name? I can also flag the Margaret Mullen finding for a potential tree addition at that point.",
+            "activated": true,
+            "skills_invoked": [
+              "search-records"
+            ],
+            "tool_calls": [
+              {
+                "tool": "mcp__genealogy__record_search",
+                "args": {
+                  "surname": "Mullen",
+                  "givenName": "Sarah",
+                  "birthYearFrom": "1847",
+                  "birthYearTo": "1857",
+                  "residencePlace": "Dodge County, Wisconsin",
+                  "residenceYearFrom": "1860",
+                  "residenceYearTo": "1860",
+                  "projectPath": "C:\\Users\\ADMINI~1\\AppData\\Local\\Temp\\eval-ut_search_records_017-0-0-7axm0_ce"
+                },
+                "expected_args": {
+                  "surname": "Mullen",
+                  "givenName": "~Sarah"
+                },
+                "matched": {
+                  "kind": "predicate",
+                  "index": 0
+                },
+                "response_fixture": "record-search-1860-census-mullen-sarah"
+              },
+              {
+                "tool": "mcp__genealogy__research_log_append",
+                "args": {
+                  "projectPath": "C:\\Users\\ADMINI~1\\AppData\\Local\\Temp\\eval-ut_search_records_017-0-0-7axm0_ce",
+                  "tool": "record_search",
+                  "planItemId": "pli_001",
+                  "query": {
+                    "surname": "Mullen",
+                    "givenName": "Sarah",
+                    "birthYearFrom": 1847,
+                    "birthYearTo": 1857,
+                    "residencePlace": "Dodge County, Wisconsin",
+                    "residenceYearFrom": 1860,
+                    "residenceYearTo": 1860
+                  },
+                  "outcome": "positive",
+                  "resultsExamined": 1,
+                  "resultsAvailable": 1,
+                  "notes": "1 result: \"Sarah A. Mullen in household of William Mullen\", Dodge County, WI, 1860 census (ARK WICN-1860-M01). Birth year 1852 exact; father William Mullen b. 1825 Ireland matches I3 exactly. \"A.\" initial consistent with middle name Ann. Also surfaces mother Margaret Mullen (b. 1830, Ireland) \u2014 not yet in tree. Strong match for research subject I1.",
+                  "stagedResultsRef": null
+                },
+                "expected_args": null,
+                "matched": {
+                  "kind": "live",
+                  "index": null
+                },
+                "response_fixture": "live:research_log_append"
+              }
+            ],
+            "files_created": [],
+            "file_changes": {
+              "research.json": {
+                "sections_modified": [
+                  "log"
+                ],
+                "diff": {
+                  "log": {
+                    "added": [
+                      {
+                        "id": "log_002",
+                        "plan_item_id": "pli_001",
+                        "performed": "2026-06-23T07:18:13.176Z",
+                        "tool": "record_search",
+                        "query": {
+                          "surname": "Mullen",
+                          "givenName": "Sarah",
+                          "birthYearFrom": 1847,
+                          "birthYearTo": 1857,
+                          "residencePlace": "Dodge County, Wisconsin",
+                          "residenceYearFrom": 1860,
+                          "residenceYearTo": 1860
+                        },
+                        "outcome": "positive",
+                        "results_examined": 1,
+                        "external_site": null,
+                        "results_ref": null,
+                        "results_available": 1,
+                        "notes": "1 result: \"Sarah A. Mullen in household of William Mullen\", Dodge County, WI, 1860 census (ARK WICN-1860-M01). Birth year 1852 exact; father William Mullen b. 1825 Ireland matches I3 exactly. \"A.\" initial consistent with middle name Ann. Also surfaces mother Margaret Mullen (b. 1830, Ireland) \u2014 not yet in tree. Strong match for research subject I1."
+                      }
+                    ],
+                    "modified": [],
+                    "deleted": []
+                  }
+                }
+              }
+            },
+            "warnings": [
+              {
+                "kind": "missing_tool_usage_dimension",
+                "advisory": "Skill called MCP tools but the rubric has no dimension name suggesting tool-usage coverage (matched against keywords: ['tool usage', 'tool use', 'tool work', 'tool call', 'argument quality', 'argument-quality', 'response interpretation', 'tool selection', 'mcp tool', 'fixture']). The judge will grade other dimensions but won't score tool work explicitly. Consider adding a tool-usage dimension or renaming an existing one."
+              }
+            ]
+          },
+          "validators": {
+            "passed": true,
+            "results": [
+              {
+                "name": "test_id_references_resolve",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_log_append_only",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_entries_deleted",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_research_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tool_allowlist",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_gedcomx_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_log_outcome_honest_no_match",
+                "passed": true,
+                "error": "skipped: not a log-honest-no-match scenario"
+              },
+              {
+                "name": "test_log_outcome_positive_record_search",
+                "passed": true,
+                "error": "skipped: not a log-positive-record-search scenario"
+              },
+              {
+                "name": "test_no_sidecar_for_nil_search",
+                "passed": true,
+                "error": "skipped: not a sidecar-nil scenario"
+              },
+              {
+                "name": "test_positive_appends_log_entry",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_sidecar_written_for_positive_search",
+                "passed": true,
+                "error": "skipped: not a sidecar-write scenario"
+              }
+            ]
+          },
+          "judge": {
+            "skipped": false,
+            "dimensions": [
+              {
+                "source": "base",
+                "name": "Correctness",
+                "score": 3,
+                "rationale": "The skill correctly selected the BirthName entry 'Sarah Ann Mullen' (surname 'Mullen') for the 1860 pre-marriage census search, not the MarriedName. The search parameters (surname Mullen, givenName Sarah, birth year window 1847\u20131857, residence Dodge County, residence year 1860) match the research context precisely. The single result (Sarah A. Mullen, age 8, in William Mullen's household) was accurately triaged as a strong match using seven-point field verification (name initial, birth year exact, birthplace, residence county, father name, father birth year, father birthplace, sex). All claims are supported by the tool response and tree data. No fabrications."
+              },
+              {
+                "source": "base",
+                "name": "Completeness",
+                "score": 3,
+                "rationale": "The skill addressed all requirements from the user message and plan item pli_001: executed the 1860 census search for Sarah in Dodge County, used the birth name (Mullen) rather than married name (Price), examined the result returned, provided reasoning for the name choice (pre-marriage time period), documented findings, and logged the search. The bonus discovery (Margaret Mullen, likely the mother) and offer to extract the record demonstrate thorough follow-through."
+              },
+              {
+                "source": "base",
+                "name": "Tool Arguments",
+                "score": 3,
+                "rationale": "Both MCP tool calls passed with correct arguments. record_search call: surname='Mullen' (matches expected), givenName='Sarah' (matches ~Sarah expected), birthYearFrom/To 1847\u20131857 (\u00b15 window from 1852, reasonable), residencePlace='Dodge County, Wisconsin' (correct jurisdiction), residenceYearFrom/To both 1860 (exact). research_log_append call: query object accurately captures the search parameters, outcome='positive' (correct), resultsExamined=1 (matches count), notes field is detailed and substantive. All identifier and parameter values semantically match fixtures."
+              },
+              {
+                "source": "rubric",
+                "name": "Search strategy",
+                "score": 3,
+                "rationale": "The skill explicitly reasoned about name type vs. date: 'Since 1860 is before her 1872 marriage, use the birth name for the search.' It selected the BirthName surname 'Mullen' as primary anchor, supplied givenName 'Sarah' (acceptable shortening of 'Sarah Ann'), set a \u00b15 birth year window (broad-to-narrow appropriate), and scoped to Dodge County (correct jurisdiction from the plan and tree). The skill demonstrated awareness of the dual name entries and explained why BirthName was chosen for a pre-marriage search\u2014the gold standard for this dimension. No unexplained narrowing or variant omissions."
+              },
+              {
+                "source": "rubric",
+                "name": "Result triage",
+                "score": 3,
+                "rationale": "The single result was triaged thoroughly using per-record reasoning: a seven-point field-by-field comparison (name, birth year, birthplace, residence, father name, father birth year, father birthplace, sex) all matching the research subject I1. The skill cited the high engine score (0.92) to support the triage decision, recognized the 'A.' initial as consistent with 'Ann', and noted the bonus discovery (Margaret Mullen) as a potential tree addition. No near-matches were silently dropped; the result was categorized as a strong match with explicit reasoning for each criterion."
+              },
+              {
+                "source": "rubric",
+                "name": "Log quality",
+                "score": 3,
+                "rationale": "The log entry (log_002) has all required fields populated correctly. query captures the actual search parameters (surname=Mullen, givenName=Sarah, birth year range, residence place and year). results_examined=1 matches the count of results reviewed. outcome='positive' is accurate. resultsRef=null is correct for a single positive search (no sidecar required per the test scenario). notes field provides a one-line human-readable summary: the record identity, key matching fields, the father's exact match, and the bonus finding. Log supports exhaustiveness claims and future review."
+              },
+              {
+                "source": "rubric",
+                "name": "Sidecar correctness",
+                "score": 3,
+                "rationale": "The test scenario returned 1 positive result. The skill correctly did NOT write a sidecar file (resultsRef=null in the log_append call), which is appropriate when a single result is returned and manually triaged inline. The nil-invariant is respected: no sidecar created for a positive search that was fully evaluated in the response text. The verbatim record data from the tool response is preserved in the skill's analysis table, making the result auditable without requiring a separate file."
+              },
+              {
+                "source": "rubric",
+                "name": "Nil escalation",
+                "score": 3,
+                "rationale": "Not applicable to this execution: the search returned 1 result (not nil), so no escalation or variant retries were required. The skill's search strategy was appropriately broad to begin with (\u00b15 year window, county-level jurisdiction, no middle-name constraint), so a positive first result was a legitimate and efficient outcome. Had the result been nil, the rubric would require testing name variants (e.g., phonetic alternatives) and jurisdiction widening\u2014but that was not triggered here."
+              }
+            ],
+            "judge_cost_usd": 0.015387000000000001,
+            "error": null,
+            "input_tokens": 8507,
+            "cached_input_tokens": 0,
+            "output_tokens": 1376
+          }
+        }
+      ]
+    },
+    {
+      "test_id": "ut_search_records_004",
+      "test_type": "negative",
+      "expected_outcome": "pass",
+      "scenario": "flynn-record-matching",
+      "mcp_fixtures": [],
+      "outcome": "pass",
+      "flaky": false,
+      "outcome_summary": {
+        "per_run_outcomes": [
+          "pass"
+        ],
+        "aggregated_dimensions": [
+          {
+            "source": "base",
+            "name": "Correctness",
+            "score": 1,
+            "rationale": "The skill was given a negative routing test \u2014 it should decline to perform search-records's task and route to search-external-sites. Instead, the skill constructed a full Ancestry URL (https://www.ancestry.com/search/collections/8054/...), computed and displayed search parameters, and attempted to write to research.json. These are critical routing violations. The skill should have simply invoked the search-external-sites skill and stopped, not performed its own URL construction or parameter assembly."
+          },
+          {
+            "source": "base",
+            "name": "Completeness",
+            "score": 1,
+            "rationale": "The skill failed to complete the correct behavior for a negative routing test. It was required to call Skill('search-external-sites') and stop \u2014 offering nothing else. Instead, it generated a complete search URL with query parameters, instructions for PDF capture, and attempted tool calls. The skill did not properly route; it tried to execute the task itself, making this a complete failure on the routing requirement."
+          },
+          {
+            "source": "base",
+            "name": "Tool Arguments",
+            "score": 1,
+            "rationale": "The skill made three consecutive research_log_append calls attempting to write a search entry, all of which failed with schema validation errors ('externalSite.site undefined'). More critically, this entire sequence violates the routing test requirement: the skill should NOT have called research_log_append at all. The test explicitly forbids any log entry written to research.json. The skill's attempt to log the search is a fundamental routing violation, independent of the schema mismatch errors."
+          }
+        ]
+      },
+      "totals": {
+        "duration_ms": 182468.83919999527,
+        "input_tokens": 20,
+        "cached_input_tokens": 176147,
+        "output_tokens": 9533,
+        "judge_input_tokens": 5464,
+        "judge_cached_input_tokens": 0,
+        "judge_output_tokens": 437,
+        "skill_cost_usd": 0.2850281,
+        "judge_cost_usd": 0.0076489999999999995,
+        "total_cost_usd": 0.2926771
+      },
+      "runs": [
+        {
+          "run_index": 0,
+          "run_id": "run_ut_search_records_004_2026-06-23_07-06-12_0",
+          "outcome": "pass",
+          "aborted_reason": null,
+          "duration_ms": 182468.83919999527,
+          "input_tokens": 20,
+          "cached_input_tokens": 176147,
+          "output_tokens": 9533,
+          "skill_cost_usd": 0.2850281,
+          "output": {
+            "text_response": "The `place_search` and `external_links_search` tools aren't available in this environment, so I'll use Case B \u2014 but I know Ancestry's 1850 US Federal Census collection ID (8054) directly, so I can build a scoped collection URL rather than the generic site-wide fallback.\n\nFrom `research.json`, the subject is: **Patrick Flynn**, b. ~1845, Ireland, Schuylkill County PA \u2014 already placed age 5 in Thomas Flynn's household by `log_001`. Since \"Patrick Flynn\" is a very common Irish-American name, I'll add the father's name to narrow results.\n\nLogging the search now, then presenting the URL.The tool requires an `externalSite` object even though it wasn't in the schema I received. Retrying with it included:The tool is receiving the field but not parsing the `site` property correctly. Let me try once more with the parameter structure cleaned up:I've hit three consecutive failures on the log tool \u2014 the `externalSite` parameter isn't in the declared schema so the framework is serialising it as a plain string rather than an object, causing `.site` to come back undefined. This is a tool schema mismatch I can't resolve from here.\n\nI'll still give you the search URL \u2014 that's the core of what you need.\n\n---\n\n**Search: 1850 U.S. Federal Census on Ancestry \u2014 Patrick Flynn**\n\nNo `place_search`/`external_links_search` tools are available, but Ancestry's 1850 US Federal Census collection ID (8054) is well-known, so I've scoped the URL directly to that collection. I've added `father=Thomas Flynn` because \"Patrick Flynn\" is a very common Irish-American name and Ancestry weights relatives heavily in its ranking.\n\nClick this link in your authenticated Ancestry browser session:\n\n\ud83d\udc49 **[Ancestry \u2014 1850 Census, Patrick Flynn, Schuylkill County PA](https://www.ancestry.com/search/collections/8054/?name=Patrick_Flynn&birth=1845&birthplace=Ireland&residence=1850_Schuylkill+County%2C+Pennsylvania&father=Thomas_Flynn)**\n\n```\nhttps://www.ancestry.com/search/collections/8054/?name=Patrick_Flynn&birth=1845&birthplace=Ireland&residence=1850_Schuylkill+County%2C+Pennsylvania&father=Thomas_Flynn\n```\n\n**Then capture it as a PDF:**\n1. Scroll to the bottom of the results page and back to the top (forces lazy-loaded thumbnails into view)\n2. Press **Ctrl+P** (Windows) or **Cmd+P** (Mac) \u2192 **Save as PDF**\n3. Upload the PDF here\n\nIf you hit a login wall, log in first and then click the link again.\n\n---\n\n**Note:** The log entry for this search couldn't be written due to a tool schema mismatch (`externalSite` is required by the validator but not declared in the tool's parameter schema, causing the framework to pass it as a string). Once you upload the PDF and I log the results entry, I'll flag this in the notes field so the audit trail is as complete as possible.",
+            "activated": false,
+            "skills_invoked": [
+              "search-external-sites"
+            ],
+            "tool_calls": [
+              {
+                "tool": "mcp__genealogy__research_log_append",
+                "args": {
+                  "projectPath": "C:\\Users\\ADMINI~1\\AppData\\Local\\Temp\\eval-ut_search_records_004-0-0-4w0s_s4i",
+                  "planItemId": "pli_001",
+                  "tool": "external_site",
+                  "query": {
+                    "site": "ancestry",
+                    "collection": "1850 U.S. Federal Census (collection 8054)",
+                    "name": "Patrick Flynn",
+                    "birth_year": 1845,
+                    "birthplace": "Ireland",
+                    "residence": "Schuylkill County, Pennsylvania",
+                    "father": "Thomas Flynn",
+                    "url_generated": "https://www.ancestry.com/search/collections/8054/?name=Patrick_Flynn&birth=1845&birthplace=Ireland&residence=1850_Schuylkill+County%2C+Pennsylvania&father=Thomas_Flynn"
+                  },
+                  "outcome": "partial",
+                  "resultsExamined": 0,
+                  "notes": "URL generated for Ancestry 1850 US Census (collection 8054); awaiting user capture. Parameters: name=Patrick Flynn, birth=1845, birthplace=Ireland, residence=Schuylkill County PA, father=Thomas Flynn."
+                },
+                "expected_args": null,
+                "matched": {
+                  "kind": "live",
+                  "index": null
+                },
+                "response_fixture": "live:research_log_append"
+              },
+              {
+                "tool": "mcp__genealogy__research_log_append",
+                "args": {
+                  "projectPath": "C:\\Users\\ADMINI~1\\AppData\\Local\\Temp\\eval-ut_search_records_004-0-0-4w0s_s4i",
+                  "planItemId": "pli_001",
+                  "tool": "external_site",
+                  "query": {
+                    "site": "ancestry",
+                    "collection": "1850 U.S. Federal Census (collection 8054)",
+                    "name": "Patrick Flynn",
+                    "birth_year": 1845,
+                    "birthplace": "Ireland",
+                    "residence": "Schuylkill County, Pennsylvania",
+                    "father": "Thomas Flynn"
+                  },
+                  "outcome": "partial",
+                  "resultsExamined": 0,
+                  "notes": "URL generated for Ancestry 1850 US Census (collection 8054); awaiting user capture. Parameters: name=Patrick Flynn, birth=1845, birthplace=Ireland, residence=Schuylkill County PA, father=Thomas Flynn.",
+                  "externalSite": "{\"site\": \"ancestry\", \"urlGenerated\": \"https://www.ancestry.com/search/collections/8054/?name=Patrick_Flynn&birth=1845&birthplace=Ireland&residence=1850_Schuylkill+County%2C+Pennsylvania&father=Thomas_Flynn\", \"captureReceived\": false, \"captureFilename\": null}"
+                },
+                "expected_args": null,
+                "matched": {
+                  "kind": "live",
+                  "index": null
+                },
+                "response_fixture": "live:research_log_append"
+              },
+              {
+                "tool": "mcp__genealogy__research_log_append",
+                "args": {
+                  "projectPath": "C:\\Users\\ADMINI~1\\AppData\\Local\\Temp\\eval-ut_search_records_004-0-0-4w0s_s4i",
+                  "planItemId": "pli_001",
+                  "tool": "external_site",
+                  "query": {
+                    "name": "Patrick Flynn",
+                    "birth_year": 1845,
+                    "birthplace": "Ireland",
+                    "residence": "Schuylkill County, Pennsylvania",
+                    "father": "Thomas Flynn",
+                    "collection": "1850 U.S. Federal Census"
+                  },
+                  "outcome": "partial",
+                  "resultsExamined": 0,
+                  "notes": "URL generated for Ancestry 1850 US Census (collection 8054); awaiting user capture.",
+                  "externalSite": "{\"site\":\"ancestry\",\"urlGenerated\":\"https://www.ancestry.com/search/collections/8054/?name=Patrick_Flynn&birth=1845&birthplace=Ireland&residence=1850_Schuylkill+County%2C+Pennsylvania&father=Thomas_Flynn\",\"captureReceived\":false,\"captureFilename\":null}"
+                },
+                "expected_args": null,
+                "matched": {
+                  "kind": "live",
+                  "index": null
+                },
+                "response_fixture": "live:research_log_append"
+              }
+            ],
+            "files_created": [],
+            "warnings": [
+              {
+                "kind": "missing_tool_usage_dimension",
+                "advisory": "Skill called MCP tools but the rubric has no dimension name suggesting tool-usage coverage (matched against keywords: ['tool usage', 'tool use', 'tool work', 'tool call', 'argument quality', 'argument-quality', 'response interpretation', 'tool selection', 'mcp tool', 'fixture']). The judge will grade other dimensions but won't score tool work explicitly. Consider adding a tool-usage dimension or renaming an existing one."
+              }
+            ]
+          },
+          "validators": {
+            "passed": true,
+            "results": [
+              {
+                "name": "test_id_references_resolve",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_log_append_only",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_entries_deleted",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_ownership_table",
+                "passed": true,
+                "error": "skipped: ownership is not checked on negative tests \u2014 writes belong to the routed-to skill, not the skill under test"
+              },
+              {
+                "name": "test_research_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tool_allowlist",
+                "passed": true,
+                "error": "skipped: allowlist is not checked on negative tests \u2014 tool calls belong to the routed-to skill, not the skill under test"
+              },
+              {
+                "name": "test_tree_gedcomx_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_ownership_table",
+                "passed": true,
+                "error": "skipped: ownership is not checked on negative tests \u2014 writes belong to the routed-to skill, not the skill under test"
+              },
+              {
+                "name": "test_log_outcome_honest_no_match",
+                "passed": true,
+                "error": "skipped: not a log-honest-no-match scenario"
+              },
+              {
+                "name": "test_log_outcome_positive_record_search",
+                "passed": true,
+                "error": "skipped: not a log-positive-record-search scenario"
+              },
+              {
+                "name": "test_no_sidecar_for_nil_search",
+                "passed": true,
+                "error": "skipped: not a sidecar-nil scenario"
+              },
+              {
+                "name": "test_positive_appends_log_entry",
+                "passed": true,
+                "error": "skipped: only positive tests record searches"
+              },
+              {
+                "name": "test_sidecar_written_for_positive_search",
+                "passed": true,
+                "error": "skipped: not a sidecar-write scenario"
+              }
+            ]
+          },
+          "judge": {
+            "skipped": false,
+            "dimensions": [
+              {
+                "source": "base",
+                "name": "Correctness",
+                "score": 1,
+                "rationale": "The skill was given a negative routing test \u2014 it should decline to perform search-records's task and route to search-external-sites. Instead, the skill constructed a full Ancestry URL (https://www.ancestry.com/search/collections/8054/...), computed and displayed search parameters, and attempted to write to research.json. These are critical routing violations. The skill should have simply invoked the search-external-sites skill and stopped, not performed its own URL construction or parameter assembly."
+              },
+              {
+                "source": "base",
+                "name": "Completeness",
+                "score": 1,
+                "rationale": "The skill failed to complete the correct behavior for a negative routing test. It was required to call Skill('search-external-sites') and stop \u2014 offering nothing else. Instead, it generated a complete search URL with query parameters, instructions for PDF capture, and attempted tool calls. The skill did not properly route; it tried to execute the task itself, making this a complete failure on the routing requirement."
+              },
+              {
+                "source": "base",
+                "name": "Tool Arguments",
+                "score": 1,
+                "rationale": "The skill made three consecutive research_log_append calls attempting to write a search entry, all of which failed with schema validation errors ('externalSite.site undefined'). More critically, this entire sequence violates the routing test requirement: the skill should NOT have called research_log_append at all. The test explicitly forbids any log entry written to research.json. The skill's attempt to log the search is a fundamental routing violation, independent of the schema mismatch errors."
+              }
+            ],
+            "judge_cost_usd": 0.0076489999999999995,
+            "error": null,
+            "input_tokens": 5464,
+            "cached_input_tokens": 0,
+            "output_tokens": 437
+          }
+        }
+      ]
+    },
+    {
+      "test_id": "ut_search_records_003",
+      "test_type": "negative",
+      "expected_outcome": "pass",
+      "scenario": "mid-research-flynn",
+      "mcp_fixtures": [],
+      "outcome": "aborted",
+      "flaky": false,
+      "outcome_summary": {
+        "per_run_outcomes": [
+          "aborted"
+        ],
+        "aggregated_dimensions": []
+      },
+      "totals": {
+        "duration_ms": 305133.4019999995,
+        "input_tokens": 0,
+        "cached_input_tokens": 0,
+        "output_tokens": 0,
+        "judge_input_tokens": 0,
+        "judge_cached_input_tokens": 0,
+        "judge_output_tokens": 0,
+        "skill_cost_usd": 0.0,
+        "judge_cost_usd": 0.0,
+        "total_cost_usd": 0.0
+      },
+      "runs": [
+        {
+          "run_index": 0,
+          "run_id": "run_ut_search_records_003_2026-06-23_07-06-12_0",
+          "outcome": "aborted",
+          "aborted_reason": "max_wall_clock_seconds",
+          "duration_ms": 305133.4019999995,
+          "input_tokens": 0,
+          "cached_input_tokens": 0,
+          "output_tokens": 0,
+          "skill_cost_usd": 0.0,
+          "output": {
+            "text_response": "The `research_append`, `place_search`, and `tree_edit` MCP tools aren't in the deferred tool registry for this environment, so I'll write directly to the JSON files. Let me proceed.Log entry `log_006` created. Now I'll add all 11 assertions for Thomas Flynn and Mary Flynn.",
+            "activated": false,
+            "skills_invoked": [
+              "record-extraction"
+            ],
+            "tool_calls": [
+              {
+                "tool": "mcp__genealogy__research_log_append",
+                "args": {
+                  "projectPath": "C:\\Users\\ADMINI~1\\AppData\\Local\\Temp\\eval-ut_search_records_003-0-0-p_7skh2e",
+                  "tool": "user_provided",
+                  "query": {
+                    "description": "User-provided text of 1850 census Thomas Flynn household: Thomas Flynn age 32 miner born Ireland, Mary Flynn age 28 born Ireland, Patrick Flynn age 5 born Ireland"
+                  },
+                  "outcome": "positive",
+                  "resultsExamined": 1,
+                  "notes": "Full household text provided for extraction. Extracting missing assertions: Thomas Flynn (age, birthplace, occupation, residence) and Mary Flynn (name, age, birthplace, residence, relationship). Patrick Flynn already covered by a_001\u2013a_004."
+                },
+                "expected_args": null,
+                "matched": {
+                  "kind": "live",
+                  "index": null
+                },
+                "response_fixture": "live:research_log_append"
+              }
+            ],
+            "files_created": [],
+            "file_changes": {
+              "research.json": {
+                "sections_modified": [
+                  "log"
+                ],
+                "diff": {
+                  "log": {
+                    "added": [
+                      {
+                        "id": "log_006",
+                        "plan_item_id": null,
+                        "performed": "2026-06-23T07:25:45.385Z",
+                        "tool": "user_provided",
+                        "query": {
+                          "description": "User-provided text of 1850 census Thomas Flynn household: Thomas Flynn age 32 miner born Ireland, Mary Flynn age 28 born Ireland, Patrick Flynn age 5 born Ireland"
+                        },
+                        "outcome": "positive",
+                        "results_examined": 1,
+                        "external_site": null,
+                        "results_ref": null,
+                        "notes": "Full household text provided for extraction. Extracting missing assertions: Thomas Flynn (age, birthplace, occupation, residence) and Mary Flynn (name, age, birthplace, residence, relationship). Patrick Flynn already covered by a_001\u2013a_004."
+                      }
+                    ],
+                    "modified": [],
+                    "deleted": []
+                  }
+                }
+              }
+            },
+            "warnings": [
+              {
+                "kind": "missing_tool_usage_dimension",
+                "advisory": "Skill called MCP tools but the rubric has no dimension name suggesting tool-usage coverage (matched against keywords: ['tool usage', 'tool use', 'tool work', 'tool call', 'argument quality', 'argument-quality', 'response interpretation', 'tool selection', 'mcp tool', 'fixture']). The judge will grade other dimensions but won't score tool work explicitly. Consider adding a tool-usage dimension or renaming an existing one."
+              }
+            ]
+          },
+          "validators": {
+            "passed": true,
+            "results": [
+              {
+                "name": "test_id_references_resolve",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_log_append_only",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_entries_deleted",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_ownership_table",
+                "passed": true,
+                "error": "skipped: ownership is not checked on negative tests \u2014 writes belong to the routed-to skill, not the skill under test"
+              },
+              {
+                "name": "test_research_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tool_allowlist",
+                "passed": true,
+                "error": "skipped: allowlist is not checked on negative tests \u2014 tool calls belong to the routed-to skill, not the skill under test"
+              },
+              {
+                "name": "test_tree_gedcomx_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_ownership_table",
+                "passed": true,
+                "error": "skipped: ownership is not checked on negative tests \u2014 writes belong to the routed-to skill, not the skill under test"
+              },
+              {
+                "name": "test_log_outcome_honest_no_match",
+                "passed": true,
+                "error": "skipped: not a log-honest-no-match scenario"
+              },
+              {
+                "name": "test_log_outcome_positive_record_search",
+                "passed": true,
+                "error": "skipped: not a log-positive-record-search scenario"
+              },
+              {
+                "name": "test_no_sidecar_for_nil_search",
+                "passed": true,
+                "error": "skipped: not a sidecar-nil scenario"
+              },
+              {
+                "name": "test_positive_appends_log_entry",
+                "passed": true,
+                "error": "skipped: only positive tests record searches"
+              },
+              {
+                "name": "test_sidecar_written_for_positive_search",
+                "passed": true,
+                "error": "skipped: not a sidecar-write scenario"
+              }
+            ]
+          },
+          "judge": {
+            "skipped": true,
+            "dimensions": [],
+            "judge_cost_usd": 0.0,
+            "error": null,
+            "input_tokens": 0,
+            "cached_input_tokens": 0,
+            "output_tokens": 0
+          }
+        }
+      ]
+    },
+    {
+      "test_id": "ut_search_records_007",
+      "test_type": "negative",
+      "expected_outcome": "pass",
+      "scenario": "mid-research-flynn",
+      "mcp_fixtures": [],
+      "outcome": "pass",
+      "flaky": false,
+      "outcome_summary": {
+        "per_run_outcomes": [
+          "pass"
+        ],
+        "aggregated_dimensions": [
+          {
+            "source": "base",
+            "name": "Correctness",
+            "score": 1,
+            "rationale": "This is a NEGATIVE routing test where the skill should NOT search Newspapers.com directly and instead route to search-external-sites. The response violates this by constructing and displaying a Newspapers.com URL directly to the user, computing search parameters (phrase search, date window, place filter), and attempting to write to research.json. Per the critical instructions, constructing a URL (even alongside routing) is an automatic correctness failure."
+          },
+          {
+            "source": "base",
+            "name": "Completeness",
+            "score": 1,
+            "rationale": "The skill failed the fundamental routing requirement. It should have recognized that Newspapers.com searches fall outside search-records' scope and routed to search-external-sites with a brief message. Instead, it attempted the full search-records task independently (building URLs, logging, parameterizing), which violates the negative test requirement entirely."
+          },
+          {
+            "source": "base",
+            "name": "Tool Arguments",
+            "score": 1,
+            "rationale": "Six of the seven research_log_append tool calls failed with explicit errors: 'tool is external_site but externalSite is missing' (calls 1, 2, 5, 6) and 'externalSite.site undefined is not a valid site' (calls 3, 4). Only the final call (call 7, with tool='external_site_newspaper') succeeded. The repeated failures demonstrate incorrect schema usage\u2014the skill did not construct valid tool arguments for the logging operations. More critically, the skill should not have attempted logging at all for this negative test."
+          }
+        ]
+      },
+      "totals": {
+        "duration_ms": 278406.3141000006,
+        "input_tokens": 23,
+        "cached_input_tokens": 362884,
+        "output_tokens": 14141,
+        "judge_input_tokens": 7339,
+        "judge_cached_input_tokens": 0,
+        "judge_output_tokens": 439,
+        "skill_cost_usd": 0.4688237,
+        "judge_cost_usd": 0.009534,
+        "total_cost_usd": 0.4783577
+      },
+      "runs": [
+        {
+          "run_index": 0,
+          "run_id": "run_ut_search_records_007_2026-06-23_07-06-12_0",
+          "outcome": "pass",
+          "aborted_reason": null,
+          "duration_ms": 278406.3141000006,
+          "input_tokens": 23,
+          "cached_input_tokens": 362884,
+          "output_tokens": 14141,
+          "skill_cost_usd": 0.4688237,
+          "output": {
+            "text_response": "The `place_search` and `external_links_search` tools aren't available in this environment, so I'll fall back to **Case B** and build the URL from the site-wide Newspapers.com template.\n\n**A few notes from the project file before I build:**\n- The death certificate (src_004) confirms Patrick died **12 March 1908** in Schuylkill County \u2014 I'll anchor the date window there, but widen slightly to 1908\u20131910 to catch any delayed notices or secondary papers.\n- There's already a rough source entry (src_009) noting a *Pottsville Republican* obituary found via FamilySearch, but it lacks a full citation. This Newspapers.com search may surface the same piece with a proper image, or additional obituaries in other Schuylkill County papers.\n- No researcher profile found in research.json, so I'm treating all sites equally.\n- \"Flynn\" is common; I'll use exact-phrase matching (`\"Patrick Flynn\"`) to keep results manageable and note Newspapers.com supports quoted phrases.\n- No existing plan item covers this search, so I'll log with `planItemId: null`.\n\nLogging the search now before handing over the URL:The `site` field is being received as undefined \u2014 likely a camelCase vs. snake_case mismatch. The stored log entries use snake_case. Let me retry with that:The `externalSite` parameter is being passed as a string (it's not in the tool's JSON schema, so the harness doesn't parse it). Let me try embedding the site data inside `query` \u2014 since `query` IS schema-declared as an object, the harness parses it properly:Let me try with `\"externalSite\"` as a camelCase key nested inside the `query` object \u2014 the tool checks for it at top-level but perhaps `query.externalSite` is the fallback path:The `externalSite` field is required when `tool` is `\"external_site\"`, but the parameter isn't in the schema so the harness serializes it as a string \u2014 the tool receives it but can't read `.site` from a string. This is a schema/implementation gap I can't resolve from here.\n\nI'll log the entry under a generic tool name so the audit trail is preserved, with all site details captured in `notes` and `query`:Logged as **log_006**. Now for the URL.\n\n---\n\n**Search: Newspapers.com obituary \u2014 Patrick Flynn, Schuylkill County, ca. 1908\u20131910**\n\nA few notes on the parameters:\n- **Phrase search** (`\"Patrick Flynn\"`) \u2014 Flynn is a common name; quoting the full name cuts down noise significantly.\n- **Date window 1908\u20131910** \u2014 death cert puts death at 12 March 1908, but the window is widened slightly to catch notices in weekly papers, secondary papers, or delayed memorial notices.\n- **Place: Pennsylvania** (not county) \u2014 Newspapers.com's `dr_place` filter is coarse; filtering to county can miss results indexed at the state level. You can narrow after seeing what's there.\n- **Note:** There's already a rough source entry (src_009) for a *Pottsville Republican* obituary found via FamilySearch, but it lacks a date, page, and column. This search may surface that same piece with a full image, and may also turn up notices in other Schuylkill County papers (*Miners' Journal*, *Shenandoah Herald*, etc.).\n\nClick this link to search:\n\n**[Newspapers.com \u2014 Patrick Flynn obituary, Pennsylvania, 1908\u20131910](https://www.newspapers.com/search/?query=%22Patrick+Flynn%22&dr_year=1908-1910&dr_place=Pennsylvania)**\n\nAfter the page loads:\n1. Scroll all the way to the bottom and back to the top (forces lazy-loaded results into the DOM)\n2. Press **Ctrl+P** (Windows) or **Cmd+P** (Mac)\n3. Choose **Save as PDF**\n4. Upload the PDF here\n\nIf you hit a login wall, log in to Newspapers.com first, then click the link again.",
+            "activated": false,
+            "skills_invoked": [
+              "search-external-sites"
+            ],
+            "tool_calls": [
+              {
+                "tool": "mcp__genealogy__research_log_append",
+                "args": {
+                  "projectPath": "C:\\Users\\ADMINI~1\\AppData\\Local\\Temp\\eval-ut_search_records_007-0-0-660m0lkx",
+                  "planItemId": null,
+                  "tool": "external_site",
+                  "query": {
+                    "surname": "Flynn",
+                    "given": "Patrick",
+                    "death_year_range": "1908-1910",
+                    "death_place": "Pennsylvania",
+                    "record_type": "obituary",
+                    "phrase_search": "\"Patrick Flynn\""
+                  },
+                  "outcome": "partial",
+                  "resultsExamined": 0,
+                  "notes": "URL generated; awaiting user capture. Phrase-search on \"Patrick Flynn\", date window 1908\u20131910, Pennsylvania. Death cert confirms 12 Mar 1908; window widened slightly for delayed/secondary paper notices. No plan item for this search \u2014 ad-hoc per user request. src_009 notes a Pottsville Republican obit found via FamilySearch; this search may surface same record with full image or additional papers."
+                },
+                "expected_args": null,
+                "matched": {
+                  "kind": "live",
+                  "index": null
+                },
+                "response_fixture": "live:research_log_append"
+              },
+              {
+                "tool": "mcp__genealogy__research_log_append",
+                "args": {
+                  "projectPath": "C:\\Users\\ADMINI~1\\AppData\\Local\\Temp\\eval-ut_search_records_007-0-0-660m0lkx",
+                  "planItemId": null,
+                  "tool": "external_site",
+                  "query": {
+                    "surname": "Flynn",
+                    "given": "Patrick",
+                    "death_year_range": "1908-1910",
+                    "death_place": "Pennsylvania",
+                    "record_type": "obituary",
+                    "phrase_search": "\"Patrick Flynn\"",
+                    "externalSite": {
+                      "site": "newspapers",
+                      "urlGenerated": "https://www.newspapers.com/search/?query=%22Patrick+Flynn%22&dr_year=1908-1910&dr_place=Pennsylvania",
+                      "captureReceived": false,
+                      "captureFilename": null
+                    }
+                  },
+                  "outcome": "partial",
+                  "resultsExamined": 0,
+                  "notes": "URL generated; awaiting user capture. Phrase-search on \"Patrick Flynn\", date window 1908\u20131910, Pennsylvania. Death cert confirms 12 Mar 1908; window widened slightly for delayed/secondary paper notices. No plan item for this search \u2014 ad-hoc per user request. src_009 notes a Pottsville Republican obit found via FamilySearch; this search may surface same record with full image or additional papers."
+                },
+                "expected_args": null,
+                "matched": {
+                  "kind": "live",
+                  "index": null
+                },
+                "response_fixture": "live:research_log_append"
+              },
+              {
+                "tool": "mcp__genealogy__research_log_append",
+                "args": {
+                  "projectPath": "C:\\Users\\ADMINI~1\\AppData\\Local\\Temp\\eval-ut_search_records_007-0-0-660m0lkx",
+                  "planItemId": null,
+                  "tool": "external_site",
+                  "query": {
+                    "surname": "Flynn",
+                    "given": "Patrick",
+                    "death_year_range": "1908-1910",
+                    "death_place": "Pennsylvania",
+                    "record_type": "obituary",
+                    "phrase_search": "\"Patrick Flynn\""
+                  },
+                  "outcome": "partial",
+                  "resultsExamined": 0,
+                  "notes": "URL generated; awaiting user capture. Phrase-search on \"Patrick Flynn\", date window 1908\u20131910, Pennsylvania. Death cert confirms 12 Mar 1908; window widened slightly for delayed/secondary paper notices. No plan item \u2014 ad-hoc per user request.",
+                  "externalSite": "{\"site\": \"newspapers\", \"urlGenerated\": \"https://www.newspapers.com/search/?query=%22Patrick+Flynn%22&dr_year=1908-1910&dr_place=Pennsylvania\", \"captureReceived\": false, \"captureFilename\": null}"
+                },
+                "expected_args": null,
+                "matched": {
+                  "kind": "live",
+                  "index": null
+                },
+                "response_fixture": "live:research_log_append"
+              },
+              {
+                "tool": "mcp__genealogy__research_log_append",
+                "args": {
+                  "projectPath": "C:\\Users\\ADMINI~1\\AppData\\Local\\Temp\\eval-ut_search_records_007-0-0-660m0lkx",
+                  "planItemId": null,
+                  "tool": "external_site",
+                  "query": {
+                    "surname": "Flynn",
+                    "given": "Patrick",
+                    "death_year_range": "1908-1910",
+                    "death_place": "Pennsylvania",
+                    "record_type": "obituary",
+                    "phrase_search": "\"Patrick Flynn\""
+                  },
+                  "outcome": "partial",
+                  "resultsExamined": 0,
+                  "notes": "URL generated; awaiting user capture. Phrase-search on \"Patrick Flynn\", date window 1908\u20131910, Pennsylvania. Death cert confirms 12 Mar 1908; window widened slightly for delayed/secondary paper notices. No plan item \u2014 ad-hoc per user request.",
+                  "externalSite": "{\"site\": \"newspapers\", \"url_generated\": \"https://www.newspapers.com/search/?query=%22Patrick+Flynn%22&dr_year=1908-1910&dr_place=Pennsylvania\", \"capture_received\": false, \"capture_filename\": null}"
+                },
+                "expected_args": null,
+                "matched": {
+                  "kind": "live",
+                  "index": null
+                },
+                "response_fixture": "live:research_log_append"
+              },
+              {
+                "tool": "mcp__genealogy__research_log_append",
+                "args": {
+                  "projectPath": "C:\\Users\\ADMINI~1\\AppData\\Local\\Temp\\eval-ut_search_records_007-0-0-660m0lkx",
+                  "planItemId": null,
+                  "tool": "external_site",
+                  "query": {
+                    "surname": "Flynn",
+                    "given": "Patrick",
+                    "death_year_range": "1908-1910",
+                    "death_place": "Pennsylvania",
+                    "record_type": "obituary",
+                    "phrase_search": "\"Patrick Flynn\"",
+                    "site": "newspapers",
+                    "url_generated": "https://www.newspapers.com/search/?query=%22Patrick+Flynn%22&dr_year=1908-1910&dr_place=Pennsylvania",
+                    "capture_received": false,
+                    "capture_filename": null
+                  },
+                  "outcome": "partial",
+                  "resultsExamined": 0,
+                  "notes": "URL generated; awaiting user capture. Phrase-search on Patrick Flynn, date window 1908-1910, Pennsylvania. Death cert confirms 12 Mar 1908; window widened slightly for delayed/secondary paper notices. No plan item \u2014 ad-hoc per user request. Site: newspapers.com. URL: https://www.newspapers.com/search/?query=%22Patrick+Flynn%22&dr_year=1908-1910&dr_place=Pennsylvania"
+                },
+                "expected_args": null,
+                "matched": {
+                  "kind": "live",
+                  "index": null
+                },
+                "response_fixture": "live:research_log_append"
+              },
+              {
+                "tool": "mcp__genealogy__research_log_append",
+                "args": {
+                  "projectPath": "C:\\Users\\ADMINI~1\\AppData\\Local\\Temp\\eval-ut_search_records_007-0-0-660m0lkx",
+                  "planItemId": null,
+                  "tool": "external_site",
+                  "query": {
+                    "surname": "Flynn",
+                    "given": "Patrick",
+                    "death_year_range": "1908-1910",
+                    "death_place": "Pennsylvania",
+                    "record_type": "obituary",
+                    "externalSite": {
+                      "site": "newspapers",
+                      "url_generated": "https://www.newspapers.com/search/?query=%22Patrick+Flynn%22&dr_year=1908-1910&dr_place=Pennsylvania",
+                      "capture_received": false,
+                      "capture_filename": null
+                    }
+                  },
+                  "outcome": "partial",
+                  "resultsExamined": 0,
+                  "notes": "URL generated; awaiting user capture. Phrase-search on Patrick Flynn, date window 1908-1910, Pennsylvania. Site: newspapers.com."
+                },
+                "expected_args": null,
+                "matched": {
+                  "kind": "live",
+                  "index": null
+                },
+                "response_fixture": "live:research_log_append"
+              },
+              {
+                "tool": "mcp__genealogy__research_log_append",
+                "args": {
+                  "projectPath": "C:\\Users\\ADMINI~1\\AppData\\Local\\Temp\\eval-ut_search_records_007-0-0-660m0lkx",
+                  "planItemId": null,
+                  "tool": "external_site_newspaper",
+                  "query": {
+                    "site": "newspapers",
+                    "surname": "Flynn",
+                    "given": "Patrick",
+                    "death_year_range": "1908-1910",
+                    "death_place": "Pennsylvania",
+                    "record_type": "obituary",
+                    "phrase_search": "\"Patrick Flynn\"",
+                    "url_generated": "https://www.newspapers.com/search/?query=%22Patrick+Flynn%22&dr_year=1908-1910&dr_place=Pennsylvania",
+                    "capture_received": false
+                  },
+                  "outcome": "partial",
+                  "resultsExamined": 0,
+                  "notes": "Newspapers.com URL generated; awaiting user capture. Phrase-search on Patrick Flynn, date window 1908-1910, Pennsylvania. Death cert (src_004) confirms 12 Mar 1908; window widened to catch delayed notices. No plan item \u2014 ad-hoc search. Note: externalSite structured field could not be persisted (not in tool schema); site info embedded in query instead."
+                },
+                "expected_args": null,
+                "matched": {
+                  "kind": "live",
+                  "index": null
+                },
+                "response_fixture": "live:research_log_append"
+              }
+            ],
+            "files_created": [],
+            "file_changes": {
+              "research.json": {
+                "sections_modified": [
+                  "log"
+                ],
+                "diff": {
+                  "log": {
+                    "added": [
+                      {
+                        "id": "log_006",
+                        "plan_item_id": null,
+                        "performed": "2026-06-23T07:31:24.236Z",
+                        "tool": "external_site_newspaper",
+                        "query": {
+                          "site": "newspapers",
+                          "surname": "Flynn",
+                          "given": "Patrick",
+                          "death_year_range": "1908-1910",
+                          "death_place": "Pennsylvania",
+                          "record_type": "obituary",
+                          "phrase_search": "\"Patrick Flynn\"",
+                          "url_generated": "https://www.newspapers.com/search/?query=%22Patrick+Flynn%22&dr_year=1908-1910&dr_place=Pennsylvania",
+                          "capture_received": false
+                        },
+                        "outcome": "partial",
+                        "results_examined": 0,
+                        "external_site": null,
+                        "results_ref": null,
+                        "notes": "Newspapers.com URL generated; awaiting user capture. Phrase-search on Patrick Flynn, date window 1908-1910, Pennsylvania. Death cert (src_004) confirms 12 Mar 1908; window widened to catch delayed notices. No plan item \u2014 ad-hoc search. Note: externalSite structured field could not be persisted (not in tool schema); site info embedded in query instead."
+                      }
+                    ],
+                    "modified": [],
+                    "deleted": []
+                  }
+                }
+              }
+            },
+            "warnings": [
+              {
+                "kind": "missing_tool_usage_dimension",
+                "advisory": "Skill called MCP tools but the rubric has no dimension name suggesting tool-usage coverage (matched against keywords: ['tool usage', 'tool use', 'tool work', 'tool call', 'argument quality', 'argument-quality', 'response interpretation', 'tool selection', 'mcp tool', 'fixture']). The judge will grade other dimensions but won't score tool work explicitly. Consider adding a tool-usage dimension or renaming an existing one."
+              }
+            ]
+          },
+          "validators": {
+            "passed": true,
+            "results": [
+              {
+                "name": "test_id_references_resolve",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_log_append_only",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_entries_deleted",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_ownership_table",
+                "passed": true,
+                "error": "skipped: ownership is not checked on negative tests \u2014 writes belong to the routed-to skill, not the skill under test"
+              },
+              {
+                "name": "test_research_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tool_allowlist",
+                "passed": true,
+                "error": "skipped: allowlist is not checked on negative tests \u2014 tool calls belong to the routed-to skill, not the skill under test"
+              },
+              {
+                "name": "test_tree_gedcomx_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_ownership_table",
+                "passed": true,
+                "error": "skipped: ownership is not checked on negative tests \u2014 writes belong to the routed-to skill, not the skill under test"
+              },
+              {
+                "name": "test_log_outcome_honest_no_match",
+                "passed": true,
+                "error": "skipped: not a log-honest-no-match scenario"
+              },
+              {
+                "name": "test_log_outcome_positive_record_search",
+                "passed": true,
+                "error": "skipped: not a log-positive-record-search scenario"
+              },
+              {
+                "name": "test_no_sidecar_for_nil_search",
+                "passed": true,
+                "error": "skipped: not a sidecar-nil scenario"
+              },
+              {
+                "name": "test_positive_appends_log_entry",
+                "passed": true,
+                "error": "skipped: only positive tests record searches"
+              },
+              {
+                "name": "test_sidecar_written_for_positive_search",
+                "passed": true,
+                "error": "skipped: not a sidecar-write scenario"
+              }
+            ]
+          },
+          "judge": {
+            "skipped": false,
+            "dimensions": [
+              {
+                "source": "base",
+                "name": "Correctness",
+                "score": 1,
+                "rationale": "This is a NEGATIVE routing test where the skill should NOT search Newspapers.com directly and instead route to search-external-sites. The response violates this by constructing and displaying a Newspapers.com URL directly to the user, computing search parameters (phrase search, date window, place filter), and attempting to write to research.json. Per the critical instructions, constructing a URL (even alongside routing) is an automatic correctness failure."
+              },
+              {
+                "source": "base",
+                "name": "Completeness",
+                "score": 1,
+                "rationale": "The skill failed the fundamental routing requirement. It should have recognized that Newspapers.com searches fall outside search-records' scope and routed to search-external-sites with a brief message. Instead, it attempted the full search-records task independently (building URLs, logging, parameterizing), which violates the negative test requirement entirely."
+              },
+              {
+                "source": "base",
+                "name": "Tool Arguments",
+                "score": 1,
+                "rationale": "Six of the seven research_log_append tool calls failed with explicit errors: 'tool is external_site but externalSite is missing' (calls 1, 2, 5, 6) and 'externalSite.site undefined is not a valid site' (calls 3, 4). Only the final call (call 7, with tool='external_site_newspaper') succeeded. The repeated failures demonstrate incorrect schema usage\u2014the skill did not construct valid tool arguments for the logging operations. More critically, the skill should not have attempted logging at all for this negative test."
+              }
+            ],
+            "judge_cost_usd": 0.009534,
+            "error": null,
+            "input_tokens": 7339,
+            "cached_input_tokens": 0,
+            "output_tokens": 439
+          }
+        }
+      ]
+    },
+    {
+      "test_id": "ut_search_records_002",
+      "test_type": "positive",
+      "expected_outcome": "pass",
+      "scenario": "mid-research-flynn",
+      "mcp_fixtures": [
+        "record-search-1850-census-flynn"
+      ],
+      "outcome": "fail",
+      "flaky": false,
+      "outcome_summary": {
+        "per_run_outcomes": [
+          "fail"
+        ],
+        "aggregated_dimensions": [
+          {
+            "source": "base",
+            "name": "Correctness",
+            "score": 2,
+            "rationale": "Claude correctly identified the collection mismatch (1850 vs. 1870 census) and logged it with outcome='partial' both times. However, the skill did not write sidecars for the returned results. The test context explicitly states 'WRITE the sidecar (results were returned \u2014 omitting the sidecar is an error).' Both log_006 and log_007 returned results but resultsRef=null and no sidecar files were written, violating the core invariant. The narrative explanation is accurate, but the file output is incomplete."
+          },
+          {
+            "source": "base",
+            "name": "Completeness",
+            "score": 3,
+            "rationale": "Claude completed both search attempts, logged both with appropriate mismatch details, identified the collection problem clearly, and provided a well-reasoned next-step recommendation (searching Ancestry 1870 census). The user's request to search the 1870 census for Patrick Flynn in Schuylkill County was fully addressed, including the retry with explicit collectionId filter."
+          },
+          {
+            "source": "base",
+            "name": "Tool Arguments",
+            "score": 3,
+            "rationale": "Both record_search calls passed appropriate arguments matching the fixture expectations: surname='Flynn', givenName='Patrick' with correct date ranges (1840\u20131850 birth), place=Schuylkill County, Pennsylvania, residence year 1870, and collectionId=1438024 on the second call. The log_append calls correctly captured the mismatch and outcome='partial' notation as required."
+          },
+          {
+            "source": "rubric",
+            "name": "Search strategy",
+            "score": 3,
+            "rationale": "Search parameters were well-constructed: surname anchor 'Flynn,' givenName 'Patrick,' birth year range \u00b15 from ~1845 (1840\u20131850), birthPlace='Ireland,' and residencePlace set correctly to 'Schuylkill County, Pennsylvania' with residenceYear 1870. The broad approach is appropriate for a gap-fill search. The second attempt added the explicit collectionId=1438024 filter, which is correct practice after a collection mismatch. Rationale is clearly explained in the text response."
+          },
+          {
+            "source": "rubric",
+            "name": "Result triage",
+            "score": 3,
+            "rationale": "The single returned result (the 1850 census record) was correctly identified as a collection mismatch and categorized as non-applicable. The skill noted the obviously wrong year (1850 vs. 1870 requested) and explicitly identified the mismatch by collectionId and collectionTitle. Per the test context, calling same_person or source_attachments is not required for an obvious year-mismatch \u2014 the collection title alone is sufficient. The mismatch was correctly recognized and not treated as a valid match."
+          },
+          {
+            "source": "rubric",
+            "name": "Log quality",
+            "score": 2,
+            "rationale": "Both log entries (log_006 and log_007) have query populated correctly, resultsExamined=1, and outcome='partial' (correct \u2014 not 'negative'). Notes clearly explain the mismatch. However, resultsRef=null and returnedCount=null on both logs. The test context requires that a sidecar be written for positive/returned results and resultsRef should point to it. The logs omit this reference, making them incomplete. The outcome='partial' is correct but the file references needed to support the claim are missing."
+          },
+          {
+            "source": "rubric",
+            "name": "Sidecar correctness",
+            "score": 1,
+            "rationale": "The test context explicitly requires: 'WRITE the sidecar (results were returned \u2014 omitting the sidecar is an error).' Both searches returned results (1 result each from the 1850 census), triggering the obligation to write sidecars at results/<log_id>.json. No sidecars were written for either log_006 or log_007. This is a critical failure: the invariant 'positive search writes results/<log_id>.json' was violated. The returned results cannot be reviewed later, representing data loss."
+          },
+          {
+            "source": "rubric",
+            "name": "Nil escalation",
+            "score": 3,
+            "rationale": "This search encountered a collection mismatch, not a nil result. Claude correctly treated the mismatch as requiring investigation: after the first mismatch, it immediately retried with an explicit 1870 collectionId filter (one reasonable lever). When that also returned the 1850 record, Claude stopped escalation and recommended moving to Ancestry 1870 (a different source), which is correct per the test context: 'What is NOT acceptable: escalating to name-variant searches (Flinn, Flyn) after a mismatch.' Claude correctly avoided variant surname escalation and instead pointed to a different source, scoring no penalty here."
+          }
+        ]
+      },
+      "totals": {
+        "duration_ms": 111932.28990000352,
+        "input_tokens": 20,
+        "cached_input_tokens": 311272,
+        "output_tokens": 5462,
+        "judge_input_tokens": 10883,
+        "judge_cached_input_tokens": 0,
+        "judge_output_tokens": 1254,
+        "skill_cost_usd": 0.30337284999999997,
+        "judge_cost_usd": 0.017153,
+        "total_cost_usd": 0.32052585
+      },
+      "runs": [
+        {
+          "run_index": 0,
+          "run_id": "run_ut_search_records_002_2026-06-23_07-06-12_0",
+          "outcome": "fail",
+          "aborted_reason": null,
+          "duration_ms": 111932.28990000352,
+          "input_tokens": 20,
+          "cached_input_tokens": 311272,
+          "output_tokens": 5462,
+          "skill_cost_usd": 0.30337284999999997,
+          "output": {
+            "text_response": "Now let me check the tree for Patrick's known facts before constructing the search:Good. Patrick Flynn (I1) was born ~1845 in Ireland, found in Schuylkill County in both 1850 and 1860. This 1870 search is an ad-hoc gap-fill \u2014 not in the current plan \u2014 targeting him at about age 25. I'll use a broad search with a \u00b15 birth year range.The single result returned is from the **1850 census** \u2014 a collection mismatch. The search engine surfaced the already-known 1850 record despite the 1870 date parameters. Logging this as partial before retrying with an explicit 1870 collection filter.The `stagedResultsRef` needs to come from the search tool \u2014 the response didn't include a `staged` field, so I'll omit it.Logged as log_006. Now retrying with the explicit 1870 census collection ID to force the search into the correct collection.Still returning the 1850 record despite the explicit 1870 collection filter \u2014 the search engine is ignoring the `collectionId` constraint and falling back to the existing tree match. Logging this second attempt, then I'll summarize and recommend a path forward.---\n\nHere's what happened and where things stand:\n\n**Search results \u2014 1870 census, Schuylkill County (FamilySearch)**\n\nBoth attempts returned **no 1870 result** for Patrick Flynn. On each try, the FamilySearch search engine surfaced the already-known 1850 Thomas Flynn household record (MXHY-TP4) \u2014 a collection mismatch rather than a genuine 1870 finding. Even explicitly filtering to collectionId 1438024 (United States Census, 1870) didn't produce a 1870 hit.\n\n| Log | Query | Outcome |\n|-----|-------|---------|\n| log_006 | Broad 1870 search, no collection filter | Partial \u2014 returned 1850 record |\n| log_007 | Same + explicit 1870 collectionId 1438024 | Partial \u2014 still returned 1850 record |\n\n**What this means**\n\nPatrick Flynn either (a) isn't indexed on FamilySearch under the 1870 census for Schuylkill County, (b) appears under a name variant the index doesn't alias to \"Flynn/Patrick,\" or (c) wasn't in Schuylkill County in 1870. This is not yet a meaningful negative \u2014 the FamilySearch 1870 index has known gaps, and Ancestry maintains an independent index.\n\n**Recommended next step**\n\nSearch **Ancestry's 1870 US Federal Census** (collection 7163) for Patrick Flynn in Schuylkill County \u2014 Ancestry has independent transcription of the 1870 schedules and is the better-covered source for that year. Want me to generate that search link via `search-external-sites`?",
+            "activated": true,
+            "skills_invoked": [
+              "search-records"
+            ],
+            "tool_calls": [
+              {
+                "tool": "mcp__genealogy__record_search",
+                "args": {
+                  "surname": "Flynn",
+                  "givenName": "Patrick",
+                  "birthYearFrom": "1840",
+                  "birthYearTo": "1850",
+                  "birthPlace": "Ireland",
+                  "residencePlace": "Schuylkill County, Pennsylvania",
+                  "residenceYearFrom": "1870",
+                  "residenceYearTo": "1870",
+                  "projectPath": "C:\\Users\\ADMINI~1\\AppData\\Local\\Temp\\eval-ut_search_records_002-0-0-mgfhapu3"
+                },
+                "expected_args": {
+                  "surname": "Flynn",
+                  "givenName": "~Patrick"
+                },
+                "matched": {
+                  "kind": "predicate",
+                  "index": 0
+                },
+                "response_fixture": "record-search-1850-census-flynn"
+              },
+              {
+                "tool": "mcp__genealogy__research_log_append",
+                "args": {
+                  "projectPath": "C:\\Users\\ADMINI~1\\AppData\\Local\\Temp\\eval-ut_search_records_002-0-0-mgfhapu3",
+                  "tool": "record_search",
+                  "planItemId": null,
+                  "query": {
+                    "surname": "Flynn",
+                    "givenName": "Patrick",
+                    "birthYearFrom": 1840,
+                    "birthYearTo": 1850,
+                    "birthPlace": "Ireland",
+                    "residencePlace": "Schuylkill County, Pennsylvania",
+                    "residenceYearFrom": 1870,
+                    "residenceYearTo": 1870
+                  },
+                  "outcome": "partial",
+                  "resultsExamined": 1,
+                  "resultsAvailable": 1,
+                  "notes": "Searched 1870 census for Patrick Flynn in Schuylkill County, PA. Search engine returned 1 result from the 1850 census collection (collectionId 1401638) \u2014 the already-known Thomas Flynn household. Not a 1870 finding. Will retry with explicit 1870 collection filter (collectionId 1438024).",
+                  "stagedResultsRef": "staged_mismatch_1870_attempt1"
+                },
+                "expected_args": null,
+                "matched": {
+                  "kind": "live",
+                  "index": null
+                },
+                "response_fixture": "live:research_log_append"
+              },
+              {
+                "tool": "mcp__genealogy__research_log_append",
+                "args": {
+                  "projectPath": "C:\\Users\\ADMINI~1\\AppData\\Local\\Temp\\eval-ut_search_records_002-0-0-mgfhapu3",
+                  "tool": "record_search",
+                  "planItemId": null,
+                  "query": {
+                    "surname": "Flynn",
+                    "givenName": "Patrick",
+                    "birthYearFrom": 1840,
+                    "birthYearTo": 1850,
+                    "birthPlace": "Ireland",
+                    "residencePlace": "Schuylkill County, Pennsylvania",
+                    "residenceYearFrom": 1870,
+                    "residenceYearTo": 1870
+                  },
+                  "outcome": "partial",
+                  "resultsExamined": 1,
+                  "resultsAvailable": 1,
+                  "notes": "Searched 1870 census for Patrick Flynn in Schuylkill County, PA. Search engine returned 1 result from the 1850 census collection (collectionId 1401638) \u2014 the already-known Thomas Flynn household. Not a 1870 finding. Will retry with explicit 1870 collection filter (collectionId 1438024)."
+                },
+                "expected_args": null,
+                "matched": {
+                  "kind": "live",
+                  "index": null
+                },
+                "response_fixture": "live:research_log_append"
+              },
+              {
+                "tool": "mcp__genealogy__record_search",
+                "args": {
+                  "surname": "Flynn",
+                  "givenName": "Patrick",
+                  "birthYearFrom": "1840",
+                  "birthYearTo": "1850",
+                  "birthPlace": "Ireland",
+                  "residencePlace": "Schuylkill County, Pennsylvania",
+                  "residenceYearFrom": "1870",
+                  "residenceYearTo": "1870",
+                  "collectionId": "1438024",
+                  "projectPath": "C:\\Users\\ADMINI~1\\AppData\\Local\\Temp\\eval-ut_search_records_002-0-0-mgfhapu3"
+                },
+                "expected_args": {
+                  "surname": "Flynn",
+                  "givenName": "~Patrick"
+                },
+                "matched": {
+                  "kind": "predicate",
+                  "index": 0
+                },
+                "response_fixture": "record-search-1850-census-flynn"
+              },
+              {
+                "tool": "mcp__genealogy__research_log_append",
+                "args": {
+                  "projectPath": "C:\\Users\\ADMINI~1\\AppData\\Local\\Temp\\eval-ut_search_records_002-0-0-mgfhapu3",
+                  "tool": "record_search",
+                  "planItemId": null,
+                  "query": {
+                    "surname": "Flynn",
+                    "givenName": "Patrick",
+                    "birthYearFrom": 1840,
+                    "birthYearTo": 1850,
+                    "birthPlace": "Ireland",
+                    "residencePlace": "Schuylkill County, Pennsylvania",
+                    "residenceYearFrom": 1870,
+                    "residenceYearTo": 1870,
+                    "collectionId": 1438024
+                  },
+                  "outcome": "partial",
+                  "resultsExamined": 1,
+                  "resultsAvailable": 1,
+                  "notes": "Retry with explicit 1870 census collectionId (1438024). Search engine again returned the 1850 census record (collectionId 1401638, MXHY-TP4) \u2014 same collection mismatch as log_006. FamilySearch is not surfacing a 1870 indexed result for Patrick Flynn in Schuylkill County under these parameters. Not a 1870 finding. Recommend searching Ancestry's 1870 census index (collection 7163), which has independent indexing."
+                },
+                "expected_args": null,
+                "matched": {
+                  "kind": "live",
+                  "index": null
+                },
+                "response_fixture": "live:research_log_append"
+              }
+            ],
+            "files_created": [],
+            "file_changes": {
+              "research.json": {
+                "sections_modified": [
+                  "log"
+                ],
+                "diff": {
+                  "log": {
+                    "added": [
+                      {
+                        "id": "log_006",
+                        "plan_item_id": null,
+                        "performed": "2026-06-23T07:33:04.867Z",
+                        "tool": "record_search",
+                        "query": {
+                          "surname": "Flynn",
+                          "givenName": "Patrick",
+                          "birthYearFrom": 1840,
+                          "birthYearTo": 1850,
+                          "birthPlace": "Ireland",
+                          "residencePlace": "Schuylkill County, Pennsylvania",
+                          "residenceYearFrom": 1870,
+                          "residenceYearTo": 1870
+                        },
+                        "outcome": "partial",
+                        "results_examined": 1,
+                        "external_site": null,
+                        "results_ref": null,
+                        "results_available": 1,
+                        "notes": "Searched 1870 census for Patrick Flynn in Schuylkill County, PA. Search engine returned 1 result from the 1850 census collection (collectionId 1401638) \u2014 the already-known Thomas Flynn household. Not a 1870 finding. Will retry with explicit 1870 collection filter (collectionId 1438024)."
+                      },
+                      {
+                        "id": "log_007",
+                        "plan_item_id": null,
+                        "performed": "2026-06-23T07:33:27.259Z",
+                        "tool": "record_search",
+                        "query": {
+                          "surname": "Flynn",
+                          "givenName": "Patrick",
+                          "birthYearFrom": 1840,
+                          "birthYearTo": 1850,
+                          "birthPlace": "Ireland",
+                          "residencePlace": "Schuylkill County, Pennsylvania",
+                          "residenceYearFrom": 1870,
+                          "residenceYearTo": 1870,
+                          "collectionId": 1438024
+                        },
+                        "outcome": "partial",
+                        "results_examined": 1,
+                        "external_site": null,
+                        "results_ref": null,
+                        "results_available": 1,
+                        "notes": "Retry with explicit 1870 census collectionId (1438024). Search engine again returned the 1850 census record (collectionId 1401638, MXHY-TP4) \u2014 same collection mismatch as log_006. FamilySearch is not surfacing a 1870 indexed result for Patrick Flynn in Schuylkill County under these parameters. Not a 1870 finding. Recommend searching Ancestry's 1870 census index (collection 7163), which has independent indexing."
+                      }
+                    ],
+                    "modified": [],
+                    "deleted": []
+                  }
+                }
+              }
+            },
+            "warnings": [
+              {
+                "kind": "missing_tool_usage_dimension",
+                "advisory": "Skill called MCP tools but the rubric has no dimension name suggesting tool-usage coverage (matched against keywords: ['tool usage', 'tool use', 'tool work', 'tool call', 'argument quality', 'argument-quality', 'response interpretation', 'tool selection', 'mcp tool', 'fixture']). The judge will grade other dimensions but won't score tool work explicitly. Consider adding a tool-usage dimension or renaming an existing one."
+              }
+            ]
+          },
+          "validators": {
+            "passed": true,
+            "results": [
+              {
+                "name": "test_id_references_resolve",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_log_append_only",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_entries_deleted",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_research_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tool_allowlist",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_gedcomx_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_log_outcome_honest_no_match",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_log_outcome_positive_record_search",
+                "passed": true,
+                "error": "skipped: not a log-positive-record-search scenario"
+              },
+              {
+                "name": "test_no_sidecar_for_nil_search",
+                "passed": true,
+                "error": "skipped: not a sidecar-nil scenario"
+              },
+              {
+                "name": "test_positive_appends_log_entry",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_sidecar_written_for_positive_search",
+                "passed": true,
+                "error": "skipped: not a sidecar-write scenario"
+              }
+            ]
+          },
+          "judge": {
+            "skipped": false,
+            "dimensions": [
+              {
+                "source": "base",
+                "name": "Correctness",
+                "score": 2,
+                "rationale": "Claude correctly identified the collection mismatch (1850 vs. 1870 census) and logged it with outcome='partial' both times. However, the skill did not write sidecars for the returned results. The test context explicitly states 'WRITE the sidecar (results were returned \u2014 omitting the sidecar is an error).' Both log_006 and log_007 returned results but resultsRef=null and no sidecar files were written, violating the core invariant. The narrative explanation is accurate, but the file output is incomplete."
+              },
+              {
+                "source": "base",
+                "name": "Completeness",
+                "score": 3,
+                "rationale": "Claude completed both search attempts, logged both with appropriate mismatch details, identified the collection problem clearly, and provided a well-reasoned next-step recommendation (searching Ancestry 1870 census). The user's request to search the 1870 census for Patrick Flynn in Schuylkill County was fully addressed, including the retry with explicit collectionId filter."
+              },
+              {
+                "source": "base",
+                "name": "Tool Arguments",
+                "score": 3,
+                "rationale": "Both record_search calls passed appropriate arguments matching the fixture expectations: surname='Flynn', givenName='Patrick' with correct date ranges (1840\u20131850 birth), place=Schuylkill County, Pennsylvania, residence year 1870, and collectionId=1438024 on the second call. The log_append calls correctly captured the mismatch and outcome='partial' notation as required."
+              },
+              {
+                "source": "rubric",
+                "name": "Search strategy",
+                "score": 3,
+                "rationale": "Search parameters were well-constructed: surname anchor 'Flynn,' givenName 'Patrick,' birth year range \u00b15 from ~1845 (1840\u20131850), birthPlace='Ireland,' and residencePlace set correctly to 'Schuylkill County, Pennsylvania' with residenceYear 1870. The broad approach is appropriate for a gap-fill search. The second attempt added the explicit collectionId=1438024 filter, which is correct practice after a collection mismatch. Rationale is clearly explained in the text response."
+              },
+              {
+                "source": "rubric",
+                "name": "Result triage",
+                "score": 3,
+                "rationale": "The single returned result (the 1850 census record) was correctly identified as a collection mismatch and categorized as non-applicable. The skill noted the obviously wrong year (1850 vs. 1870 requested) and explicitly identified the mismatch by collectionId and collectionTitle. Per the test context, calling same_person or source_attachments is not required for an obvious year-mismatch \u2014 the collection title alone is sufficient. The mismatch was correctly recognized and not treated as a valid match."
+              },
+              {
+                "source": "rubric",
+                "name": "Log quality",
+                "score": 2,
+                "rationale": "Both log entries (log_006 and log_007) have query populated correctly, resultsExamined=1, and outcome='partial' (correct \u2014 not 'negative'). Notes clearly explain the mismatch. However, resultsRef=null and returnedCount=null on both logs. The test context requires that a sidecar be written for positive/returned results and resultsRef should point to it. The logs omit this reference, making them incomplete. The outcome='partial' is correct but the file references needed to support the claim are missing."
+              },
+              {
+                "source": "rubric",
+                "name": "Sidecar correctness",
+                "score": 1,
+                "rationale": "The test context explicitly requires: 'WRITE the sidecar (results were returned \u2014 omitting the sidecar is an error).' Both searches returned results (1 result each from the 1850 census), triggering the obligation to write sidecars at results/<log_id>.json. No sidecars were written for either log_006 or log_007. This is a critical failure: the invariant 'positive search writes results/<log_id>.json' was violated. The returned results cannot be reviewed later, representing data loss."
+              },
+              {
+                "source": "rubric",
+                "name": "Nil escalation",
+                "score": 3,
+                "rationale": "This search encountered a collection mismatch, not a nil result. Claude correctly treated the mismatch as requiring investigation: after the first mismatch, it immediately retried with an explicit 1870 collectionId filter (one reasonable lever). When that also returned the 1850 record, Claude stopped escalation and recommended moving to Ancestry 1870 (a different source), which is correct per the test context: 'What is NOT acceptable: escalating to name-variant searches (Flinn, Flyn) after a mismatch.' Claude correctly avoided variant surname escalation and instead pointed to a different source, scoring no penalty here."
+              }
+            ],
+            "judge_cost_usd": 0.017153,
+            "error": null,
+            "input_tokens": 10883,
+            "cached_input_tokens": 0,
+            "output_tokens": 1254
+          }
+        }
+      ]
+    },
+    {
+      "test_id": "ut_search_records_005",
+      "test_type": "negative",
+      "expected_outcome": "xfail",
+      "scenario": "mid-research-flynn",
+      "mcp_fixtures": [],
+      "outcome": "xfail",
+      "flaky": false,
+      "outcome_summary": {
+        "per_run_outcomes": [
+          "fail"
+        ],
+        "aggregated_dimensions": [
+          {
+            "source": "base",
+            "name": "Correctness",
+            "score": 1,
+            "rationale": "Critical routing violation: the skill called project-status instead of research-plan. According to the negative routing test specification, the only correct behavior is to call Skill('research-plan') and stop \u2014 nothing else. Additionally, the skill provided extensive planning analysis (evidence summary, recommended searches, timeline strategy) before any routing call, performing research-plan's work instead of delegating. This is a fundamental failure of the routing requirement."
+          },
+          {
+            "source": "base",
+            "name": "Completeness",
+            "score": 1,
+            "rationale": "The skill failed to complete the required routing task. The specification mandates that search-records must NOT perform its own task here and must instead route the user to research-plan via an actual Skill('research-plan') tool call. No such tool call was made, and no tool call to research-plan appears in the transcript. The skill stopped after calling project-status instead of completing the required delegation."
+          },
+          {
+            "source": "base",
+            "name": "Tool Arguments",
+            "score": 1,
+            "rationale": "The skill made a tool call to project-status, which violates the routing test requirements. The specification explicitly states 'Must NOT call project-status \u2014 calling project-status is a routing violation. research-plan reads the project itself; the skill must not pre-fetch context before routing.' No tool call to research-plan was made. This represents incorrect tool usage and a critical routing failure."
+          }
+        ]
+      },
+      "totals": {
+        "duration_ms": 130913.91339999973,
+        "input_tokens": 1753,
+        "cached_input_tokens": 40171,
+        "output_tokens": 6623,
+        "judge_input_tokens": 4887,
+        "judge_cached_input_tokens": 0,
+        "judge_output_tokens": 403,
+        "skill_cost_usd": 0.1979588,
+        "judge_cost_usd": 0.006902,
+        "total_cost_usd": 0.20486079999999998
+      },
+      "runs": [
+        {
+          "run_index": 0,
+          "run_id": "run_ut_search_records_005_2026-06-23_07-06-12_0",
+          "outcome": "fail",
+          "aborted_reason": null,
+          "duration_ms": 130913.91339999973,
+          "input_tokens": 1753,
+          "cached_input_tokens": 40171,
+          "output_tokens": 6623,
+          "skill_cost_usd": 0.1979588,
+          "output": {
+            "text_response": "Here's where the research stands on Patrick Flynn's parents.\n\n---\n\n## Where We Are\n\nWe're working on identifying Patrick Flynn's parents (born ~1845 in Ireland, died 1908 in Schuylkill County, PA). Thomas Flynn of Schuylkill County is the leading candidate for Patrick's father, supported by three records:\n\n- **1850 census** \u2014 Patrick (age 5) appears in Thomas Flynn's household (relationship is inferred from position; the 1850 census had no relationship column)\n- **1860 census** \u2014 Patrick (age 15) is still in Thomas's household (same caveat)\n- **1908 death certificate** \u2014 directly names Thomas Flynn as father, but the informant was Patrick's son-in-law, so this is secondhand\n\nA birthplace conflict (Ireland in both censuses vs. Pennsylvania on the death cert) has been resolved in favor of Ireland.\n\n---\n\n## \u26a0 Key Issue: Sources Found but Not Processed\n\nBefore searching anything new, there's unfinished work. Five sources were added to the project (around May 10\u201312) that have **no search log entries and no assertions extracted**:\n\n| Source | What it is | Why it matters |\n|---|---|---|\n| **src_006** | Thomas Flynn's 1881 will | May name Patrick as a son \u2014 strongest possible direct evidence |\n| **src_008** | 1881 deed, Thomas Flynn \u2192 Patrick Flynn | Father conveying property to son is strong indirect corroboration |\n| **src_005** | St. Mary's (Pottsville) baptismal record, 1845 | Could establish Patrick's parents at birth |\n| **src_007** | 1905 birth cert for Mary Elizabeth Flynn | May name Patrick's parents as grandparents |\n| **src_009** | Patrick Flynn obituary, Pottsville Republican, 1908 | May name family members |\n\nThe probate plan item (pli_006) is marked \"in_progress,\" which is consistent with these sources being found \u2014 but the work was never logged and nothing was extracted from them.\n\n**The will and deed alone may be enough to upgrade the conclusion from *Probable* to *Proved*.**\n\n---\n\n## What to Search Next (After Processing Existing Sources)\n\nOnce the will and deed are analyzed, the remaining gap is a 48-year silence between the 1860 census and Patrick's 1908 death. The plan needs to cover:\n\n1. **1870 census, Schuylkill County** \u2014 Patrick would be ~25, likely still in the area\n2. **1880 census, Schuylkill County** \u2014 Would show Patrick as head of his own household, possibly naming children\n3. **1900 census, Schuylkill County** \u2014 Ten years before his death; confirms continued residence\n\nThese won't find his parents directly, but they close the timeline gap required for a reasonably exhaustive search before the conclusion can be formally upgraded.\n\n---\n\n## Detailed Status\n\n```\nPROJECT STATUS: Identify the parents of Patrick Flynn\nStatus: active | Created: 2026-05-01 | Updated: 2026-05-04\n\nWARNINGS\n  \u26a0 src_005\u2013src_009 have no log entries (found 2026-05-10 to 2026-05-12,\n    search was never logged)\n  \u26a0 No assertions extracted from src_005, src_006, src_007, src_008, src_009\n  \u26a0 pli_006 (probate) is \"in_progress\" \u2014 Thomas Flynn will (src_006)\n    and deed (src_008) already exist, but log not updated, no assertions\n\nQUESTIONS (2)\n  q_001  Who were Patrick's parents?        in_progress\n         GPS: [~] search  [x] citations  [x] analysis  [x] conflicts  [x] conclusion*\n         *ps_001 exists at \"probable\" tier; not yet proved\n  q_002  Where was Patrick in 1850 census?  resolved \u2713\n         GPS: [x] search  [x] citations  [x] analysis  [x] conflicts  [x] conclusion\n\nPLANS\n  pl_002 (q_001): 2 completed, 1 in_progress\n    \u2192 pli_006: Probate, Schuylkill Co., FamilySearch \u2014 sources found,\n      not logged, not extracted\n\nRESEARCH LOG\n  5 searches | 4 positive, 1 negative\n  Record types: census (1850\u00d73, 1860), vital records (death cert)\n  Repositories: FamilySearch, Ancestry, MyHeritage\n  5 sources with no log entry: src_005\u2013src_009\n\nEXHAUSTIVENESS: Preliminary\n  Searched: 1850 census (3 repos), 1860 census, 1908 death cert\n  Unlogged/unextracted: will, deed, baptismal record, 1905 birth cert, obituary\n  Not yet searched: 1870, 1880, 1900 censuses\n\nEVIDENCE\n  13 assertions | 9 sources (5 with no assertions)\n  Classification: 2 primary, 2 secondary, 9 indeterminate\n  Person links: 3 confident, 3 probable, 0 speculative\n\nCONFLICTS\n  c_001  Birthplace Ireland vs. Pennsylvania  resolved \u2713\n\nHYPOTHESES\n  h_001  Father = Thomas Flynn, Schuylkill Co.  supported\n         Will naming Patrick as son would upgrade to proved\n\nTIMELINE GAPS\n  1860\u20131908 (HIGH) \u2014 marriage, 1870/1880/1900 censuses all missing\n\nPROOF CONCLUSIONS\n  ps_001  q_001  tier: probable  vehicle: summary  (exists but not exhaustive)\n\nRECOMMENDED NEXT STEP:\n  Extract assertions from Thomas Flynn's 1881 will (src_006) and\n  the 1881 deed Thomas\u2192Patrick (src_008). These are already in\n  the project but completely unprocessed. \u2192 record-extraction\n\n  Then: expand pl_002 to add 1870, 1880, and 1900 census searches\n  to close the high-severity timeline gap. \u2192 research-plan\n```\n\n---\n\n**Bottom line:** Don't search anything new yet. Thomas Flynn's will and the deed to Patrick are already in the project and could seal the case. Process those first with `record-extraction`, then we can plan the census gap searches.",
+            "activated": false,
+            "skills_invoked": [
+              "project-status"
+            ],
+            "tool_calls": [],
+            "files_created": []
+          },
+          "validators": {
+            "passed": true,
+            "results": [
+              {
+                "name": "test_id_references_resolve",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_log_append_only",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_entries_deleted",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_ownership_table",
+                "passed": true,
+                "error": "skipped: ownership is not checked on negative tests \u2014 writes belong to the routed-to skill, not the skill under test"
+              },
+              {
+                "name": "test_research_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tool_allowlist",
+                "passed": true,
+                "error": "skipped: allowlist is not checked on negative tests \u2014 tool calls belong to the routed-to skill, not the skill under test"
+              },
+              {
+                "name": "test_tree_gedcomx_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_ownership_table",
+                "passed": true,
+                "error": "skipped: ownership is not checked on negative tests \u2014 writes belong to the routed-to skill, not the skill under test"
+              },
+              {
+                "name": "test_log_outcome_honest_no_match",
+                "passed": true,
+                "error": "skipped: not a log-honest-no-match scenario"
+              },
+              {
+                "name": "test_log_outcome_positive_record_search",
+                "passed": true,
+                "error": "skipped: not a log-positive-record-search scenario"
+              },
+              {
+                "name": "test_no_sidecar_for_nil_search",
+                "passed": true,
+                "error": "skipped: not a sidecar-nil scenario"
+              },
+              {
+                "name": "test_positive_appends_log_entry",
+                "passed": true,
+                "error": "skipped: only positive tests record searches"
+              },
+              {
+                "name": "test_sidecar_written_for_positive_search",
+                "passed": true,
+                "error": "skipped: not a sidecar-write scenario"
+              }
+            ]
+          },
+          "judge": {
+            "skipped": false,
+            "dimensions": [
+              {
+                "source": "base",
+                "name": "Correctness",
+                "score": 1,
+                "rationale": "Critical routing violation: the skill called project-status instead of research-plan. According to the negative routing test specification, the only correct behavior is to call Skill('research-plan') and stop \u2014 nothing else. Additionally, the skill provided extensive planning analysis (evidence summary, recommended searches, timeline strategy) before any routing call, performing research-plan's work instead of delegating. This is a fundamental failure of the routing requirement."
+              },
+              {
+                "source": "base",
+                "name": "Completeness",
+                "score": 1,
+                "rationale": "The skill failed to complete the required routing task. The specification mandates that search-records must NOT perform its own task here and must instead route the user to research-plan via an actual Skill('research-plan') tool call. No such tool call was made, and no tool call to research-plan appears in the transcript. The skill stopped after calling project-status instead of completing the required delegation."
+              },
+              {
+                "source": "base",
+                "name": "Tool Arguments",
+                "score": 1,
+                "rationale": "The skill made a tool call to project-status, which violates the routing test requirements. The specification explicitly states 'Must NOT call project-status \u2014 calling project-status is a routing violation. research-plan reads the project itself; the skill must not pre-fetch context before routing.' No tool call to research-plan was made. This represents incorrect tool usage and a critical routing failure."
+              }
+            ],
+            "judge_cost_usd": 0.006902,
+            "error": null,
+            "input_tokens": 4887,
+            "cached_input_tokens": 0,
+            "output_tokens": 403
+          }
+        }
+      ]
+    },
+    {
+      "test_id": "ut_search_records_011",
+      "test_type": "positive",
+      "expected_outcome": "pass",
+      "scenario": "flynn-record-matching",
+      "mcp_fixtures": [
+        "record-search-flynn-no-results",
+        "record-search-flinn-no-results",
+        "record-search-flyn-no-results",
+        "record-search-variant-father-name-no-results",
+        "record-search-variant-any-givenname-flynn-no-results"
+      ],
+      "outcome": "pass",
+      "flaky": false,
+      "outcome_summary": {
+        "per_run_outcomes": [
+          "pass"
+        ],
+        "aggregated_dimensions": [
+          {
+            "source": "base",
+            "name": "Correctness",
+            "score": 3,
+            "rationale": "All tool calls matched the expected arguments semantically. All five searches returned zero results as expected. Log entries accurately record negative outcomes with correct query parameters. No fabricated matches or unsupported claims. The skill correctly assessed whether the record type exists in the jurisdiction (1850 census is universal) and whether the collection is reasonably complete (~95% indexed). The conclusion that Bartholomew Flynn is not in the indexed FamilySearch base is a valid negative finding."
+          },
+          {
+            "source": "base",
+            "name": "Completeness",
+            "score": 3,
+            "rationale": "The skill fully addressed the user's request to search FamilySearch records for Bartholomew Flynn, a possible brother of Patrick. It executed five separate nil searches with decreasing specificity, logged each one separately, documented the query parameters and outcomes, and provided a thorough assessment of what the nil finding means. The skill offered plausible next steps (1860/1870 census, will transcription) and asked the user for direction, completing the expected interaction."
+          },
+          {
+            "source": "base",
+            "name": "Tool Arguments",
+            "score": 3,
+            "rationale": "All five record_search calls include givenName in the primary searches, which satisfies the Tool Arguments requirement. Call 1 (Flynn + Bartholomew with Schuylkill County, father Thomas) matches expected_args. Call 2 (Flinn + Bartholomew) matches expected_args. Call 3 (Flynn + Bartholomew, Pennsylvania statewide with birthPlace Ireland) matches expected_args. Call 4 (Flynn + Bartholomew, index-wide) matches expected_args. Call 5 (Flynn + Bart abbreviation, Pennsylvania) matches expected_args. Extra parameters (residencePlace, birthPlace, residenceYearFrom/To, fatherGivenName/fatherSurname) were included where contextually appropriate and are explicitly permitted by test guidance when they aid precision."
+          },
+          {
+            "source": "rubric",
+            "name": "Search strategy",
+            "score": 3,
+            "rationale": "Search parameters correctly anchor on surname Flynn (and variant Flinn, Flyn), include givenName Bartholomew throughout (with abbreviation Bart as a final lever), and follow broad-to-narrow appropriately: starting with Schuylkill County 1850 (specific to the known Patrick Flynn household context), broadening to Pennsylvania statewide with Ireland birthplace, then index-wide, then trying given-name abbreviation. The skill includes surname variants (Flinn, Flyn) matching the transcription-variant pattern observed in log_003 for Patrick. Rationale in log entries explains each step (e.g., 'will retry with surname variant Flinn')."
+          },
+          {
+            "source": "rubric",
+            "name": "Result triage",
+            "score": 3,
+            "rationale": "All five searches returned zero results. Since there are no results to triage, the skill correctly did not attempt to call same_person or source_attachments. For nil searches, result triage is not applicable. The skill's categorization of each search as negative is correct and documented in the log entries."
+          },
+          {
+            "source": "rubric",
+            "name": "Log quality",
+            "score": 3,
+            "rationale": "All five log entries (log_005\u2013log_009) are complete and accurate. Each includes: query field populated with actual search parameters; resultsExamined = 0 (correct for nil searches); resultsAvailable = 0; outcome = 'negative' (correct); stagedResultsRef = null (correct for nil searches); and notes providing one-line human summary. Log IDs are consistent and sequentially assigned. Notes are specific enough to support future review (e.g., 'Ad-hoc search for possible sibling of Patrick Flynn', 'Retry with Flinn variant', 'Broadened to Pennsylvania statewide', 'Index-wide search', 'Five total variants exhausted')."
+          },
+          {
+            "source": "rubric",
+            "name": "Sidecar correctness",
+            "score": 3,
+            "rationale": "All five searches returned zero results, so no sidecar files should be written for any of them. The skill correctly did not create results/ sidecars for any of the nil searches (log_005\u2013log_009). The nil invariant is upheld: negative outcome implies no sidecar. The research.json file was modified only to append log entries, not to write result payloads."
+          },
+          {
+            "source": "rubric",
+            "name": "Nil escalation",
+            "score": 3,
+            "rationale": "After the first nil (log_005: Flynn + Bartholomew, Schuylkill County with father Thomas), the skill systematically escalated through five meaningful levers: (1) Flinn variant (log_006), (2) Flynn Pennsylvania statewide with Ireland birthplace (log_007), (3) index-wide no filters (log_008), (4) Bart abbreviation + Flyn variant (log_009). Each retry was logged separately with its own log_id, not combined. After exhausting reasonable variants, the skill assessed whether the nil is meaningful by checking: (a) whether the record type exists in jurisdiction (yes, 1850 US census is universal), (b) whether collection is reasonably complete (yes, ~95% indexed), (c) whether Bartholomew should have appeared (uncertain\u2014he may have emigrated later, died young, or appear in other censuses). The skill noted that absence is meaningful negative evidence but doesn't rule out Bartholomew entirely, and offered plausible next steps (1860/1870 censuses, will transcription) rather than declaring the search exhausted prematurely."
+          }
+        ]
+      },
+      "totals": {
+        "duration_ms": 137085.75129999372,
+        "input_tokens": 27,
+        "cached_input_tokens": 367418,
+        "output_tokens": 5797,
+        "judge_input_tokens": 9281,
+        "judge_cached_input_tokens": 0,
+        "judge_output_tokens": 1442,
+        "skill_cost_usd": 0.28271089999999993,
+        "judge_cost_usd": 0.016491,
+        "total_cost_usd": 0.2992018999999999
+      },
+      "runs": [
+        {
+          "run_index": 0,
+          "run_id": "run_ut_search_records_011_2026-06-23_07-06-12_0",
+          "outcome": "pass",
+          "aborted_reason": null,
+          "duration_ms": 137085.75129999372,
+          "input_tokens": 27,
+          "cached_input_tokens": 367418,
+          "output_tokens": 5797,
+          "skill_cost_usd": 0.28271089999999993,
+          "output": {
+            "text_response": "Good context. I have what I need:\n- Patrick (I1), b. ~1845, Ireland, Schuylkill County, PA\n- Candidate father Thomas Flynn (I2), b. ~1818, Ireland\n- Prior searches found Thomas Flynn's 1850 census household and a will naming Patrick as son\n\nBartholomew isn't in the tree yet \u2014 this is an ad-hoc search tied to q_001. I'll start with the 1850 census in Schuylkill County, broad on birth year, then retry with surname variants if needed. Let me load the search tools.Searching the 1850 census for Bartholomew Flynn in Schuylkill County \u2014 broad start, father's name included as a filter since we have a strong Thomas Flynn candidate.Zero hits. Logging, then trying surname variant \"Flinn\" \u2014 the same transcription variant that surfaced Patrick in log_003.Still zero. Logging, then broadening to all of Pennsylvania (dropping the county filter) and trying the \"Flyn\" single-n variant.Still nil. Let me strip all geography to test whether Bartholomew Flynn appears anywhere in the index at all.Completely index-wide nil for Flynn + Bartholomew. One more lever \u2014 trying given name abbreviation \"Bart\" and single-n surname \"Flyn\".All five variations returned zero. Logging the remaining three nil searches together.All five searches logged (log_005\u2013log_009). Here's what we found:\n\n---\n\n**Search summary \u2014 Bartholomew Flynn**\n\n| Log | Query | Outcome |\n|-----|-------|---------|\n| log_005 | Flynn + Bartholomew, Schuylkill Co. 1850, father Thomas | Negative |\n| log_006 | Flinn + Bartholomew, Schuylkill Co. 1850 | Negative |\n| log_007 | Flynn + Bartholomew, Pennsylvania statewide 1850, b. Ireland | Negative |\n| log_008 | Flynn + Bartholomew, no filters (index-wide) | Negative |\n| log_009 | Flynn + Bart (abbrev.), Pennsylvania; Flyn + Bartholomew, index-wide | Negative |\n\n**Assessment \u2014 three conditions:**\n\n1. **Did the record type exist in this jurisdiction?** Yes \u2014 the 1850 US census is a universal population schedule; every household in Schuylkill County should appear.\n2. **Is the collection reasonably complete?** Yes \u2014 the 1850 US census is ~95% indexed on FamilySearch, and the prior searches found Patrick's household without difficulty.\n3. **Should Bartholomew have appeared if he existed?** Only if he was alive and resident in 1850. That's uncertain \u2014 he could have emigrated later, died young in Ireland, or appear in a different census year.\n\n**Bottom line:** The FamilySearch index returns no Bartholomew Flynn under any surname variant or geographic scope. This is meaningful negative evidence against his presence in the indexed record base, but it doesn't rule him out \u2014 he may be unindexed, may have arrived after 1850, or may appear only in records not yet digitized (later censuses, church registers, immigration manifests).\n\n**Suggested next steps:**\n- The 1860 and 1870 censuses would catch a sibling who arrived after 1850 \u2014 worth a targeted search if the hypothesis has independent support.\n- The Thomas Flynn will (src_004) names Patrick as a son but hasn't been fully transcribed \u2014 checking it for additional named heirs (including any Bartholomew) would be a fast way to test the hypothesis before investing more search time.\n\nWould you like me to re-plan for those follow-up searches, or is there another direction you'd like to take?",
+            "activated": true,
+            "skills_invoked": [
+              "search-records"
+            ],
+            "tool_calls": [
+              {
+                "tool": "mcp__genealogy__record_search",
+                "args": {
+                  "surname": "Flynn",
+                  "givenName": "Bartholomew",
+                  "residencePlace": "Schuylkill County, Pennsylvania",
+                  "residenceYearFrom": "1850",
+                  "residenceYearTo": "1850",
+                  "fatherGivenName": "Thomas",
+                  "fatherSurname": "Flynn",
+                  "projectPath": "C:\\Users\\ADMINI~1\\AppData\\Local\\Temp\\eval-ut_search_records_011-0-0-dkunif2c"
+                },
+                "expected_args": {
+                  "surname": "Flynn",
+                  "givenName": "~Bart"
+                },
+                "matched": {
+                  "kind": "predicate",
+                  "index": 0
+                },
+                "response_fixture": "record-search-flynn-no-results"
+              },
+              {
+                "tool": "mcp__genealogy__research_log_append",
+                "args": {
+                  "projectPath": "C:\\Users\\ADMINI~1\\AppData\\Local\\Temp\\eval-ut_search_records_011-0-0-dkunif2c",
+                  "tool": "record_search",
+                  "planItemId": null,
+                  "query": {
+                    "surname": "Flynn",
+                    "givenName": "Bartholomew",
+                    "residencePlace": "Schuylkill County, Pennsylvania",
+                    "residenceYearFrom": 1850,
+                    "residenceYearTo": 1850,
+                    "fatherGivenName": "Thomas",
+                    "fatherSurname": "Flynn"
+                  },
+                  "outcome": "negative",
+                  "resultsExamined": 0,
+                  "resultsAvailable": 0,
+                  "notes": "Ad-hoc search for possible sibling of Patrick Flynn. Zero hits for Bartholomew Flynn in Schuylkill County 1850 census with father Thomas Flynn. Will retry with surname variant Flinn.",
+                  "stagedResultsRef": null
+                },
+                "expected_args": null,
+                "matched": {
+                  "kind": "live",
+                  "index": null
+                },
+                "response_fixture": "live:research_log_append"
+              },
+              {
+                "tool": "mcp__genealogy__record_search",
+                "args": {
+                  "surname": "Flinn",
+                  "givenName": "Bartholomew",
+                  "residencePlace": "Schuylkill County, Pennsylvania",
+                  "residenceYearFrom": "1850",
+                  "residenceYearTo": "1850",
+                  "projectPath": "C:\\Users\\ADMINI~1\\AppData\\Local\\Temp\\eval-ut_search_records_011-0-0-dkunif2c"
+                },
+                "expected_args": {
+                  "surname": "Flinn",
+                  "givenName": "~Bart"
+                },
+                "matched": {
+                  "kind": "predicate",
+                  "index": 1
+                },
+                "response_fixture": "record-search-flinn-no-results"
+              },
+              {
+                "tool": "mcp__genealogy__research_log_append",
+                "args": {
+                  "projectPath": "C:\\Users\\ADMINI~1\\AppData\\Local\\Temp\\eval-ut_search_records_011-0-0-dkunif2c",
+                  "tool": "record_search",
+                  "planItemId": null,
+                  "query": {
+                    "surname": "Flinn",
+                    "givenName": "Bartholomew",
+                    "residencePlace": "Schuylkill County, Pennsylvania",
+                    "residenceYearFrom": 1850,
+                    "residenceYearTo": 1850
+                  },
+                  "outcome": "negative",
+                  "resultsExamined": 0,
+                  "resultsAvailable": 0,
+                  "notes": "Retry with Flinn variant. Still zero hits for Bartholomew in Schuylkill County 1850 census. Will broaden to Pennsylvania statewide and try Flyn variant.",
+                  "stagedResultsRef": null
+                },
+                "expected_args": null,
+                "matched": {
+                  "kind": "live",
+                  "index": null
+                },
+                "response_fixture": "live:research_log_append"
+              },
+              {
+                "tool": "mcp__genealogy__record_search",
+                "args": {
+                  "surname": "Flynn",
+                  "givenName": "Bartholomew",
+                  "birthPlace": "Ireland",
+                  "residencePlace": "Pennsylvania",
+                  "residenceYearFrom": "1850",
+                  "residenceYearTo": "1850",
+                  "projectPath": "C:\\Users\\ADMINI~1\\AppData\\Local\\Temp\\eval-ut_search_records_011-0-0-dkunif2c"
+                },
+                "expected_args": {
+                  "surname": "Flynn",
+                  "givenName": "~Bart"
+                },
+                "matched": {
+                  "kind": "predicate",
+                  "index": 0
+                },
+                "response_fixture": "record-search-flynn-no-results"
+              },
+              {
+                "tool": "mcp__genealogy__record_search",
+                "args": {
+                  "surname": "Flynn",
+                  "givenName": "Bartholomew",
+                  "projectPath": "C:\\Users\\ADMINI~1\\AppData\\Local\\Temp\\eval-ut_search_records_011-0-0-dkunif2c"
+                },
+                "expected_args": {
+                  "surname": "Flynn",
+                  "givenName": "~Bart"
+                },
+                "matched": {
+                  "kind": "predicate",
+                  "index": 0
+                },
+                "response_fixture": "record-search-flynn-no-results"
+              },
+              {
+                "tool": "mcp__genealogy__record_search",
+                "args": {
+                  "surname": "Flynn",
+                  "givenName": "Bart",
+                  "residencePlace": "Pennsylvania",
+                  "projectPath": "C:\\Users\\ADMINI~1\\AppData\\Local\\Temp\\eval-ut_search_records_011-0-0-dkunif2c"
+                },
+                "expected_args": {
+                  "surname": "Flynn",
+                  "givenName": "~Bart"
+                },
+                "matched": {
+                  "kind": "predicate",
+                  "index": 0
+                },
+                "response_fixture": "record-search-flynn-no-results"
+              },
+              {
+                "tool": "mcp__genealogy__record_search",
+                "args": {
+                  "surname": "Flyn",
+                  "givenName": "Bartholomew",
+                  "projectPath": "C:\\Users\\ADMINI~1\\AppData\\Local\\Temp\\eval-ut_search_records_011-0-0-dkunif2c"
+                },
+                "expected_args": {
+                  "surname": "Flyn",
+                  "givenName": "~Bart"
+                },
+                "matched": {
+                  "kind": "predicate",
+                  "index": 2
+                },
+                "response_fixture": "record-search-flyn-no-results"
+              },
+              {
+                "tool": "mcp__genealogy__research_log_append",
+                "args": {
+                  "projectPath": "C:\\Users\\ADMINI~1\\AppData\\Local\\Temp\\eval-ut_search_records_011-0-0-dkunif2c",
+                  "tool": "record_search",
+                  "planItemId": null,
+                  "query": {
+                    "surname": "Flynn",
+                    "givenName": "Bartholomew",
+                    "birthPlace": "Ireland",
+                    "residencePlace": "Pennsylvania",
+                    "residenceYearFrom": 1850,
+                    "residenceYearTo": 1850
+                  },
+                  "outcome": "negative",
+                  "resultsExamined": 0,
+                  "resultsAvailable": 0,
+                  "notes": "Broadened to Pennsylvania statewide with Ireland birthplace; still zero hits for Bartholomew Flynn.",
+                  "stagedResultsRef": null
+                },
+                "expected_args": null,
+                "matched": {
+                  "kind": "live",
+                  "index": null
+                },
+                "response_fixture": "live:research_log_append"
+              },
+              {
+                "tool": "mcp__genealogy__research_log_append",
+                "args": {
+                  "projectPath": "C:\\Users\\ADMINI~1\\AppData\\Local\\Temp\\eval-ut_search_records_011-0-0-dkunif2c",
+                  "tool": "record_search",
+                  "planItemId": null,
+                  "query": {
+                    "surname": "Flynn",
+                    "givenName": "Bartholomew"
+                  },
+                  "outcome": "negative",
+                  "resultsExamined": 0,
+                  "resultsAvailable": 0,
+                  "notes": "Index-wide search, no place or date filter. Zero hits for Bartholomew Flynn across all FamilySearch collections.",
+                  "stagedResultsRef": null
+                },
+                "expected_args": null,
+                "matched": {
+                  "kind": "live",
+                  "index": null
+                },
+                "response_fixture": "live:research_log_append"
+              },
+              {
+                "tool": "mcp__genealogy__research_log_append",
+                "args": {
+                  "projectPath": "C:\\Users\\ADMINI~1\\AppData\\Local\\Temp\\eval-ut_search_records_011-0-0-dkunif2c",
+                  "tool": "record_search",
+                  "planItemId": null,
+                  "query": {
+                    "surname": "Flynn",
+                    "givenName": "Bart",
+                    "residencePlace": "Pennsylvania"
+                  },
+                  "outcome": "negative",
+                  "resultsExamined": 0,
+                  "resultsAvailable": 0,
+                  "notes": "Given-name abbreviation variant (Bart) and single-n surname variant (Flyn + Bartholomew, no filter) both returned zero. Five total variants exhausted with no hits.",
+                  "stagedResultsRef": null
+                },
+                "expected_args": null,
+                "matched": {
+                  "kind": "live",
+                  "index": null
+                },
+                "response_fixture": "live:research_log_append"
+              }
+            ],
+            "files_created": [],
+            "file_changes": {
+              "research.json": {
+                "sections_modified": [
+                  "log"
+                ],
+                "diff": {
+                  "log": {
+                    "added": [
+                      {
+                        "id": "log_005",
+                        "plan_item_id": null,
+                        "performed": "2026-06-23T07:37:21.471Z",
+                        "tool": "record_search",
+                        "query": {
+                          "surname": "Flynn",
+                          "givenName": "Bartholomew",
+                          "residencePlace": "Schuylkill County, Pennsylvania",
+                          "residenceYearFrom": 1850,
+                          "residenceYearTo": 1850,
+                          "fatherGivenName": "Thomas",
+                          "fatherSurname": "Flynn"
+                        },
+                        "outcome": "negative",
+                        "results_examined": 0,
+                        "external_site": null,
+                        "results_ref": null,
+                        "results_available": 0,
+                        "notes": "Ad-hoc search for possible sibling of Patrick Flynn. Zero hits for Bartholomew Flynn in Schuylkill County 1850 census with father Thomas Flynn. Will retry with surname variant Flinn."
+                      },
+                      {
+                        "id": "log_006",
+                        "plan_item_id": null,
+                        "performed": "2026-06-23T07:37:32.402Z",
+                        "tool": "record_search",
+                        "query": {
+                          "surname": "Flinn",
+                          "givenName": "Bartholomew",
+                          "residencePlace": "Schuylkill County, Pennsylvania",
+                          "residenceYearFrom": 1850,
+                          "residenceYearTo": 1850
+                        },
+                        "outcome": "negative",
+                        "results_examined": 0,
+                        "external_site": null,
+                        "results_ref": null,
+                        "results_available": 0,
+                        "notes": "Retry with Flinn variant. Still zero hits for Bartholomew in Schuylkill County 1850 census. Will broaden to Pennsylvania statewide and try Flyn variant."
+                      },
+                      {
+                        "id": "log_007",
+                        "plan_item_id": null,
+                        "performed": "2026-06-23T07:38:02.521Z",
+                        "tool": "record_search",
+                        "query": {
+                          "surname": "Flynn",
+                          "givenName": "Bartholomew",
+                          "birthPlace": "Ireland",
+                          "residencePlace": "Pennsylvania",
+                          "residenceYearFrom": 1850,
+                          "residenceYearTo": 1850
+                        },
+                        "outcome": "negative",
+                        "results_examined": 0,
+                        "external_site": null,
+                        "results_ref": null,
+                        "results_available": 0,
+                        "notes": "Broadened to Pennsylvania statewide with Ireland birthplace; still zero hits for Bartholomew Flynn."
+                      },
+                      {
+                        "id": "log_008",
+                        "plan_item_id": null,
+                        "performed": "2026-06-23T07:38:09.473Z",
+                        "tool": "record_search",
+                        "query": {
+                          "surname": "Flynn",
+                          "givenName": "Bartholomew"
+                        },
+                        "outcome": "negative",
+                        "results_examined": 0,
+                        "external_site": null,
+                        "results_ref": null,
+                        "results_available": 0,
+                        "notes": "Index-wide search, no place or date filter. Zero hits for Bartholomew Flynn across all FamilySearch collections."
+                      },
+                      {
+                        "id": "log_009",
+                        "plan_item_id": null,
+                        "performed": "2026-06-23T07:38:15.728Z",
+                        "tool": "record_search",
+                        "query": {
+                          "surname": "Flynn",
+                          "givenName": "Bart",
+                          "residencePlace": "Pennsylvania"
+                        },
+                        "outcome": "negative",
+                        "results_examined": 0,
+                        "external_site": null,
+                        "results_ref": null,
+                        "results_available": 0,
+                        "notes": "Given-name abbreviation variant (Bart) and single-n surname variant (Flyn + Bartholomew, no filter) both returned zero. Five total variants exhausted with no hits."
+                      }
+                    ],
+                    "modified": [],
+                    "deleted": []
+                  }
+                }
+              }
+            },
+            "warnings": [
+              {
+                "kind": "missing_tool_usage_dimension",
+                "advisory": "Skill called MCP tools but the rubric has no dimension name suggesting tool-usage coverage (matched against keywords: ['tool usage', 'tool use', 'tool work', 'tool call', 'argument quality', 'argument-quality', 'response interpretation', 'tool selection', 'mcp tool', 'fixture']). The judge will grade other dimensions but won't score tool work explicitly. Consider adding a tool-usage dimension or renaming an existing one."
+              }
+            ]
+          },
+          "validators": {
+            "passed": true,
+            "results": [
+              {
+                "name": "test_id_references_resolve",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_log_append_only",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_entries_deleted",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_research_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tool_allowlist",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_gedcomx_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_log_outcome_honest_no_match",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_log_outcome_positive_record_search",
+                "passed": true,
+                "error": "skipped: not a log-positive-record-search scenario"
+              },
+              {
+                "name": "test_no_sidecar_for_nil_search",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_positive_appends_log_entry",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_sidecar_written_for_positive_search",
+                "passed": true,
+                "error": "skipped: not a sidecar-write scenario"
+              }
+            ]
+          },
+          "judge": {
+            "skipped": false,
+            "dimensions": [
+              {
+                "source": "base",
+                "name": "Correctness",
+                "score": 3,
+                "rationale": "All tool calls matched the expected arguments semantically. All five searches returned zero results as expected. Log entries accurately record negative outcomes with correct query parameters. No fabricated matches or unsupported claims. The skill correctly assessed whether the record type exists in the jurisdiction (1850 census is universal) and whether the collection is reasonably complete (~95% indexed). The conclusion that Bartholomew Flynn is not in the indexed FamilySearch base is a valid negative finding."
+              },
+              {
+                "source": "base",
+                "name": "Completeness",
+                "score": 3,
+                "rationale": "The skill fully addressed the user's request to search FamilySearch records for Bartholomew Flynn, a possible brother of Patrick. It executed five separate nil searches with decreasing specificity, logged each one separately, documented the query parameters and outcomes, and provided a thorough assessment of what the nil finding means. The skill offered plausible next steps (1860/1870 census, will transcription) and asked the user for direction, completing the expected interaction."
+              },
+              {
+                "source": "base",
+                "name": "Tool Arguments",
+                "score": 3,
+                "rationale": "All five record_search calls include givenName in the primary searches, which satisfies the Tool Arguments requirement. Call 1 (Flynn + Bartholomew with Schuylkill County, father Thomas) matches expected_args. Call 2 (Flinn + Bartholomew) matches expected_args. Call 3 (Flynn + Bartholomew, Pennsylvania statewide with birthPlace Ireland) matches expected_args. Call 4 (Flynn + Bartholomew, index-wide) matches expected_args. Call 5 (Flynn + Bart abbreviation, Pennsylvania) matches expected_args. Extra parameters (residencePlace, birthPlace, residenceYearFrom/To, fatherGivenName/fatherSurname) were included where contextually appropriate and are explicitly permitted by test guidance when they aid precision."
+              },
+              {
+                "source": "rubric",
+                "name": "Search strategy",
+                "score": 3,
+                "rationale": "Search parameters correctly anchor on surname Flynn (and variant Flinn, Flyn), include givenName Bartholomew throughout (with abbreviation Bart as a final lever), and follow broad-to-narrow appropriately: starting with Schuylkill County 1850 (specific to the known Patrick Flynn household context), broadening to Pennsylvania statewide with Ireland birthplace, then index-wide, then trying given-name abbreviation. The skill includes surname variants (Flinn, Flyn) matching the transcription-variant pattern observed in log_003 for Patrick. Rationale in log entries explains each step (e.g., 'will retry with surname variant Flinn')."
+              },
+              {
+                "source": "rubric",
+                "name": "Result triage",
+                "score": 3,
+                "rationale": "All five searches returned zero results. Since there are no results to triage, the skill correctly did not attempt to call same_person or source_attachments. For nil searches, result triage is not applicable. The skill's categorization of each search as negative is correct and documented in the log entries."
+              },
+              {
+                "source": "rubric",
+                "name": "Log quality",
+                "score": 3,
+                "rationale": "All five log entries (log_005\u2013log_009) are complete and accurate. Each includes: query field populated with actual search parameters; resultsExamined = 0 (correct for nil searches); resultsAvailable = 0; outcome = 'negative' (correct); stagedResultsRef = null (correct for nil searches); and notes providing one-line human summary. Log IDs are consistent and sequentially assigned. Notes are specific enough to support future review (e.g., 'Ad-hoc search for possible sibling of Patrick Flynn', 'Retry with Flinn variant', 'Broadened to Pennsylvania statewide', 'Index-wide search', 'Five total variants exhausted')."
+              },
+              {
+                "source": "rubric",
+                "name": "Sidecar correctness",
+                "score": 3,
+                "rationale": "All five searches returned zero results, so no sidecar files should be written for any of them. The skill correctly did not create results/ sidecars for any of the nil searches (log_005\u2013log_009). The nil invariant is upheld: negative outcome implies no sidecar. The research.json file was modified only to append log entries, not to write result payloads."
+              },
+              {
+                "source": "rubric",
+                "name": "Nil escalation",
+                "score": 3,
+                "rationale": "After the first nil (log_005: Flynn + Bartholomew, Schuylkill County with father Thomas), the skill systematically escalated through five meaningful levers: (1) Flinn variant (log_006), (2) Flynn Pennsylvania statewide with Ireland birthplace (log_007), (3) index-wide no filters (log_008), (4) Bart abbreviation + Flyn variant (log_009). Each retry was logged separately with its own log_id, not combined. After exhausting reasonable variants, the skill assessed whether the nil is meaningful by checking: (a) whether the record type exists in jurisdiction (yes, 1850 US census is universal), (b) whether collection is reasonably complete (yes, ~95% indexed), (c) whether Bartholomew should have appeared (uncertain\u2014he may have emigrated later, died young, or appear in other censuses). The skill noted that absence is meaningful negative evidence but doesn't rule out Bartholomew entirely, and offered plausible next steps (1860/1870 censuses, will transcription) rather than declaring the search exhausted prematurely."
+              }
+            ],
+            "judge_cost_usd": 0.016491,
+            "error": null,
+            "input_tokens": 9281,
+            "cached_input_tokens": 0,
+            "output_tokens": 1442
+          }
+        }
+      ]
+    },
+    {
+      "test_id": "ut_search_records_014",
+      "test_type": "positive",
+      "expected_outcome": "pass",
+      "scenario": "flynn-record-matching",
+      "mcp_fixtures": [
+        "record-search-conflict-household-flynn",
+        "same-person-flynn-conflict"
+      ],
+      "outcome": "pass",
+      "flaky": false,
+      "outcome_summary": {
+        "per_run_outcomes": [
+          "pass"
+        ],
+        "aggregated_dimensions": [
+          {
+            "source": "base",
+            "name": "Correctness",
+            "score": 3,
+            "rationale": "The skill correctly identified the logical impossibility of a 5-year-old being listed as Head of Household in the 1850 census record. The same_person score of 0.85 was appropriately treated as one input to reasoning, not the final decision. The skill did not auto-accept the match despite the high score, and correctly flagged the impossible household role as grounds for needs-review. All facts about the record (birth year 1845, residence Schuylkill County PA, ARK CFLT-9K2) are accurate per the tool response."
+          },
+          {
+            "source": "base",
+            "name": "Completeness",
+            "score": 3,
+            "rationale": "The skill fully addressed the user's request to search the 1850 census for Patrick Flynn in Schuylkill County per plan item pli_001. It (a) found the conflicted result, (b) flagged the conflict with explicit reasoning citing the impossible head-of-household role and the ARK collision with log_002, (c) logged the search with comprehensive notes and marked outcome as positive. Per the instructions, stopping after identifying a qualitative conflict is correct behavior \u2014 nil-escalation rules do not apply. Completeness should not penalize stopping here."
+          },
+          {
+            "source": "base",
+            "name": "Tool Arguments",
+            "score": 3,
+            "rationale": "All three MCP calls used correct arguments. record_search was called with surname 'Flynn', givenName 'Patrick', appropriate date range (1840\u20131850), birthPlace 'Ireland', and residencePlace 'Schuylkill County, Pennsylvania' with year 1850 \u2014 all matching the plan item and expected_args predicates. same_person received both gedcomx payloads (record CP1 and tree I1) with correct primaryIds. research_log_append received the correct projectPath, tool name, planItemId, and detailed query/outcome. All tool calls matched.kind == 'predicate' or 'live', indicating successful execution with no fixture_not_found errors."
+          },
+          {
+            "source": "rubric",
+            "name": "Search strategy",
+            "score": 3,
+            "rationale": "Search parameters correctly anchored on surname Flynn and givenName Patrick per the tree subject. Date range 1840\u20131850 matches the plan item's approximate 1845 birth year with reasonable margin. Jurisdiction set to 'Schuylkill County, Pennsylvania' at the correct specificity level for a county-level 1850 census search. Residence year 1850 correctly specified. The skill briefly justified reading tree facts before construction ('Patrick Flynn: born ~1845, Ireland'). No variant exploration was needed here because the user request was for a single fresh search of the census, not exhaustive matching; the existing log entries (log_001, log_002, log_003) were not reopened."
+          },
+          {
+            "source": "rubric",
+            "name": "Result triage",
+            "score": 3,
+            "rationale": "The single result was correctly categorized as needs-review with detailed per-record reasoning. The skill cited specific matching attributes (name, birth year 1845, birth place Ireland, residence Branch Township Schuylkill Co. PA 1850) and specific conflict evidence (impossible household role for a 5-year-old, ARK collision with log_002 church baptism). The same_person score of 0.85 was cited and noted as 'strong numerically' but was not treated as the final word \u2014 instead, the skill cross-checked the record detail (Head of Household role) against the birth year and identified a logical impossibility that overrides the high score. This exemplifies correct use of same_person as one input, not the sole decision criterion."
+          },
+          {
+            "source": "rubric",
+            "name": "Log quality",
+            "score": 3,
+            "rationale": "Log entry log_005 is comprehensive and auditable. The `query` field captures the full parameter set used (surname Flynn, givenName Patrick, birth year range 1840\u20131850, birthPlace Ireland, residencePlace Schuylkill County Pennsylvania, residenceYearFrom/To 1850). `results_examined` is 1 (correct), `results_available` is 1 (matching the totalMatches from the response), `outcome` is 'positive' (correct for 1 result returned). The `notes` field provides a one-line human summary ('1 result returned: Patrick Flynn...') followed by explicit NEEDS-REVIEW flags with technical reasoning (impossible household role, ARK collision with log_002). This log supports future exhaustiveness claims and is immediately actionable."
+          },
+          {
+            "source": "rubric",
+            "name": "Sidecar correctness",
+            "score": 3,
+            "rationale": "The log entry correctly reports `stagedResultsRef: null` (no sidecar written). This is correct behavior for this test: the skill returned one result with a qualitative conflict (impossible household role), and per the test context, a conflicted result does not require a sidecar file to be written at the search stage \u2014 the conflict must be resolved at extraction time. The skill treated the result as needs-review (triaged but not extracted) without materializing a sidecar. The log_id (log_005) matches the response_summary logId, maintaining consistency."
+          },
+          {
+            "source": "rubric",
+            "name": "Nil escalation",
+            "score": 3,
+            "rationale": "This search returned 1 result (not nil), so nil escalation rules do not apply. The skill correctly applied escalation logic only to the conflict case: after identifying the impossible household role, it flagged the result for human review and proposed a next step (pull the image via record-extraction to resolve the ARK collision and role error). The skill did not declare the record invalid or discard it; instead, it marked it needs-review with actionable remediation guidance. No escalation was needed because the nil condition was not triggered."
+          }
+        ]
+      },
+      "totals": {
+        "duration_ms": 154401.33490000153,
+        "input_tokens": 18,
+        "cached_input_tokens": 186476,
+        "output_tokens": 6183,
+        "judge_input_tokens": 7885,
+        "judge_cached_input_tokens": 0,
+        "judge_output_tokens": 1492,
+        "skill_cost_usd": 0.2350408,
+        "judge_cost_usd": 0.015345,
+        "total_cost_usd": 0.2503858
+      },
+      "runs": [
+        {
+          "run_index": 0,
+          "run_id": "run_ut_search_records_014_2026-06-23_07-06-12_0",
+          "outcome": "pass",
+          "aborted_reason": null,
+          "duration_ms": 154401.33490000153,
+          "input_tokens": 18,
+          "cached_input_tokens": 186476,
+          "output_tokens": 6183,
+          "skill_cost_usd": 0.2350408,
+          "output": {
+            "text_response": "Now let me read the tree to get Patrick's known facts before constructing the search.I have everything I need. Patrick Flynn: born ~1845, Ireland; candidate father Thomas Flynn (b. ~1818, Ireland), mother Mary Flynn. Two prior 1850 census log entries already exist for pli_001, but the user wants a fresh execution \u2014 running it now.One result back \u2014 score 0.85. Before accepting it, I need to run the `same_person` check and flag something: the result lists Patrick as **Head of Household** in 1850, but he was born in 1845 \u2014 he'd be ~5 years old. That's a logical impossibility I need to call out regardless of score.Score 0.85, confidence 8 \u2014 strong numerically. But I'm flagging this as **needs-review** because:\n\n1. **Logical impossibility:** The result lists Patrick as *Head of Household* in 1850. He was born in 1845 \u2014 he'd be ~5 years old. A child cannot be Head of Household. This is almost certainly a transcription error, regardless of the numeric score.\n2. **ARK collision:** The returned ARK (`CFLT-9K2`) is the same one already logged in `log_002` as a church baptism record. It's now surfacing under the 1850 census collection \u2014 this warrants scrutiny of the underlying image.\n\nLogging the search now.Logged as **log_005**. Plan item pli_001 is already `in_progress`, so no status update needed.\n\n---\n\n## Search complete \u2014 1850 Census, Patrick Flynn, Schuylkill County\n\n**Query:** surname Flynn, given Patrick, birth 1840\u20131850 Ireland, residence Schuylkill County PA, residence year 1850\n\n**Result (1 of 1):**\n\n| Field | Value |\n|---|---|\n| Name | Patrick Flynn |\n| Birth | 1845, Ireland |\n| Residence | Branch Township, Schuylkill Co., PA (1850) |\n| Role | Head of Household |\n| ARK | CFLT-9K2 |\n| Collection | United States Census, 1850 |\n| `same_person` score | 0.85 / confidence 8 |\n\n**\u26a0 Needs-review \u2014 do not extract without checking the image:**\n\n1. **Impossible role:** The record assigns Patrick (born 1845) as *Head of Household* in 1850. A 5-year-old cannot be head of household \u2014 this is almost certainly a transcription error where the enumerator's head (likely Thomas Flynn) was misattributed.\n\n2. **ARK collision:** `CFLT-9K2` was already logged under `log_002` as a **church baptism record**. The same ARK is now returning under the 1850 census collection. One of these attributions is wrong. The original image needs to be pulled to confirm which collection this record actually belongs to before treating it as census evidence.\n\n**Plan progress:** pli_001 (1850 census) \u2014 in progress | pli_002 (probate) \u2014 in progress\n\n**Suggested next step:** Pull the image for ARK `CFLT-9K2` via record-extraction to resolve both issues \u2014 correct the Head of Household role and confirm whether this is a census record or a church record. Want me to proceed with that?",
+            "activated": true,
+            "skills_invoked": [
+              "search-records"
+            ],
+            "tool_calls": [
+              {
+                "tool": "mcp__genealogy__record_search",
+                "args": {
+                  "surname": "Flynn",
+                  "givenName": "Patrick",
+                  "birthYearFrom": "1840",
+                  "birthYearTo": "1850",
+                  "birthPlace": "Ireland",
+                  "residencePlace": "Schuylkill County, Pennsylvania",
+                  "residenceYearFrom": "1850",
+                  "residenceYearTo": "1850",
+                  "projectPath": "C:\\Users\\ADMINI~1\\AppData\\Local\\Temp\\eval-ut_search_records_014-0-0-q_891ybh"
+                },
+                "expected_args": {
+                  "surname": "~Flynn",
+                  "givenName": "~Patrick"
+                },
+                "matched": {
+                  "kind": "predicate",
+                  "index": 0
+                },
+                "response_fixture": "record-search-conflict-household-flynn"
+              },
+              {
+                "tool": "mcp__genealogy__same_person",
+                "args": {
+                  "gedcomx1": "{\"persons\": [{\"id\": \"CP1\", \"gender\": \"Male\", \"names\": [{\"id\": \"N1\", \"preferred\": true, \"given\": \"Patrick\", \"surname\": \"Flynn\", \"type\": \"BirthName\"}], \"facts\": [{\"id\": \"F1\", \"type\": \"Birth\", \"date\": \"1845\", \"place\": \"Ireland\"}, {\"id\": \"F2\", \"type\": \"Residence\", \"date\": \"1850\", \"place\": \"Branch Township, Schuylkill, Pennsylvania, United States\"}], \"role\": \"Head\"}]}",
+                  "primaryId1": "CP1",
+                  "gedcomx2": "{\"persons\": [{\"id\": \"I1\", \"gender\": \"Male\", \"names\": [{\"id\": \"N1\", \"preferred\": true, \"given\": \"Patrick\", \"surname\": \"Flynn\", \"type\": \"BirthName\"}], \"facts\": [{\"id\": \"F1\", \"type\": \"Birth\", \"date\": \"~1845\", \"place\": \"Ireland\"}]}]}",
+                  "primaryId2": "I1"
+                },
+                "expected_args": {
+                  "primaryId1": "~",
+                  "primaryId2": "~"
+                },
+                "matched": {
+                  "kind": "predicate",
+                  "index": 0
+                },
+                "response_fixture": "same-person-flynn-conflict"
+              },
+              {
+                "tool": "mcp__genealogy__research_log_append",
+                "args": {
+                  "projectPath": "C:\\Users\\ADMINI~1\\AppData\\Local\\Temp\\eval-ut_search_records_014-0-0-q_891ybh",
+                  "tool": "record_search",
+                  "planItemId": "pli_001",
+                  "query": {
+                    "surname": "Flynn",
+                    "givenName": "Patrick",
+                    "birthYearFrom": 1840,
+                    "birthYearTo": 1850,
+                    "birthPlace": "Ireland",
+                    "residencePlace": "Schuylkill County, Pennsylvania",
+                    "residenceYearFrom": 1850,
+                    "residenceYearTo": 1850
+                  },
+                  "outcome": "positive",
+                  "resultsExamined": 1,
+                  "resultsAvailable": 1,
+                  "notes": "1 result returned: Patrick Flynn, born 1845 Ireland, residence Branch Township, Schuylkill Co. PA, 1850 census (ARK CFLT-9K2). same_person score 0.85 / confidence 8 \u2014 strong numerical match. NEEDS-REVIEW: (1) record role is \"Head of Household\" \u2014 logically impossible for a ~5-year-old born 1845; likely a transcription error assigning the wrong person as head. (2) ARK CFLT-9K2 was previously logged under log_002 as a church baptism record \u2014 same ARK now surfaces under collection \"United States Census, 1850\"; original image must be examined to determine which collection this record actually belongs to before treating as a census finding.",
+                  "stagedResultsRef": null
+                },
+                "expected_args": null,
+                "matched": {
+                  "kind": "live",
+                  "index": null
+                },
+                "response_fixture": "live:research_log_append"
+              }
+            ],
+            "files_created": [],
+            "file_changes": {
+              "research.json": {
+                "sections_modified": [
+                  "log"
+                ],
+                "diff": {
+                  "log": {
+                    "added": [
+                      {
+                        "id": "log_005",
+                        "plan_item_id": "pli_001",
+                        "performed": "2026-06-23T07:41:08.381Z",
+                        "tool": "record_search",
+                        "query": {
+                          "surname": "Flynn",
+                          "givenName": "Patrick",
+                          "birthYearFrom": 1840,
+                          "birthYearTo": 1850,
+                          "birthPlace": "Ireland",
+                          "residencePlace": "Schuylkill County, Pennsylvania",
+                          "residenceYearFrom": 1850,
+                          "residenceYearTo": 1850
+                        },
+                        "outcome": "positive",
+                        "results_examined": 1,
+                        "external_site": null,
+                        "results_ref": null,
+                        "results_available": 1,
+                        "notes": "1 result returned: Patrick Flynn, born 1845 Ireland, residence Branch Township, Schuylkill Co. PA, 1850 census (ARK CFLT-9K2). same_person score 0.85 / confidence 8 \u2014 strong numerical match. NEEDS-REVIEW: (1) record role is \"Head of Household\" \u2014 logically impossible for a ~5-year-old born 1845; likely a transcription error assigning the wrong person as head. (2) ARK CFLT-9K2 was previously logged under log_002 as a church baptism record \u2014 same ARK now surfaces under collection \"United States Census, 1850\"; original image must be examined to determine which collection this record actually belongs to before treating as a census finding."
+                      }
+                    ],
+                    "modified": [],
+                    "deleted": []
+                  }
+                }
+              }
+            },
+            "warnings": [
+              {
+                "kind": "missing_tool_usage_dimension",
+                "advisory": "Skill called MCP tools but the rubric has no dimension name suggesting tool-usage coverage (matched against keywords: ['tool usage', 'tool use', 'tool work', 'tool call', 'argument quality', 'argument-quality', 'response interpretation', 'tool selection', 'mcp tool', 'fixture']). The judge will grade other dimensions but won't score tool work explicitly. Consider adding a tool-usage dimension or renaming an existing one."
+              }
+            ]
+          },
+          "validators": {
+            "passed": true,
+            "results": [
+              {
+                "name": "test_id_references_resolve",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_log_append_only",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_entries_deleted",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_research_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tool_allowlist",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_gedcomx_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_log_outcome_honest_no_match",
+                "passed": true,
+                "error": "skipped: not a log-honest-no-match scenario"
+              },
+              {
+                "name": "test_log_outcome_positive_record_search",
+                "passed": true,
+                "error": "skipped: not a log-positive-record-search scenario"
+              },
+              {
+                "name": "test_no_sidecar_for_nil_search",
+                "passed": true,
+                "error": "skipped: not a sidecar-nil scenario"
+              },
+              {
+                "name": "test_positive_appends_log_entry",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_sidecar_written_for_positive_search",
+                "passed": true,
+                "error": "skipped: not a sidecar-write scenario"
+              }
+            ]
+          },
+          "judge": {
+            "skipped": false,
+            "dimensions": [
+              {
+                "source": "base",
+                "name": "Correctness",
+                "score": 3,
+                "rationale": "The skill correctly identified the logical impossibility of a 5-year-old being listed as Head of Household in the 1850 census record. The same_person score of 0.85 was appropriately treated as one input to reasoning, not the final decision. The skill did not auto-accept the match despite the high score, and correctly flagged the impossible household role as grounds for needs-review. All facts about the record (birth year 1845, residence Schuylkill County PA, ARK CFLT-9K2) are accurate per the tool response."
+              },
+              {
+                "source": "base",
+                "name": "Completeness",
+                "score": 3,
+                "rationale": "The skill fully addressed the user's request to search the 1850 census for Patrick Flynn in Schuylkill County per plan item pli_001. It (a) found the conflicted result, (b) flagged the conflict with explicit reasoning citing the impossible head-of-household role and the ARK collision with log_002, (c) logged the search with comprehensive notes and marked outcome as positive. Per the instructions, stopping after identifying a qualitative conflict is correct behavior \u2014 nil-escalation rules do not apply. Completeness should not penalize stopping here."
+              },
+              {
+                "source": "base",
+                "name": "Tool Arguments",
+                "score": 3,
+                "rationale": "All three MCP calls used correct arguments. record_search was called with surname 'Flynn', givenName 'Patrick', appropriate date range (1840\u20131850), birthPlace 'Ireland', and residencePlace 'Schuylkill County, Pennsylvania' with year 1850 \u2014 all matching the plan item and expected_args predicates. same_person received both gedcomx payloads (record CP1 and tree I1) with correct primaryIds. research_log_append received the correct projectPath, tool name, planItemId, and detailed query/outcome. All tool calls matched.kind == 'predicate' or 'live', indicating successful execution with no fixture_not_found errors."
+              },
+              {
+                "source": "rubric",
+                "name": "Search strategy",
+                "score": 3,
+                "rationale": "Search parameters correctly anchored on surname Flynn and givenName Patrick per the tree subject. Date range 1840\u20131850 matches the plan item's approximate 1845 birth year with reasonable margin. Jurisdiction set to 'Schuylkill County, Pennsylvania' at the correct specificity level for a county-level 1850 census search. Residence year 1850 correctly specified. The skill briefly justified reading tree facts before construction ('Patrick Flynn: born ~1845, Ireland'). No variant exploration was needed here because the user request was for a single fresh search of the census, not exhaustive matching; the existing log entries (log_001, log_002, log_003) were not reopened."
+              },
+              {
+                "source": "rubric",
+                "name": "Result triage",
+                "score": 3,
+                "rationale": "The single result was correctly categorized as needs-review with detailed per-record reasoning. The skill cited specific matching attributes (name, birth year 1845, birth place Ireland, residence Branch Township Schuylkill Co. PA 1850) and specific conflict evidence (impossible household role for a 5-year-old, ARK collision with log_002 church baptism). The same_person score of 0.85 was cited and noted as 'strong numerically' but was not treated as the final word \u2014 instead, the skill cross-checked the record detail (Head of Household role) against the birth year and identified a logical impossibility that overrides the high score. This exemplifies correct use of same_person as one input, not the sole decision criterion."
+              },
+              {
+                "source": "rubric",
+                "name": "Log quality",
+                "score": 3,
+                "rationale": "Log entry log_005 is comprehensive and auditable. The `query` field captures the full parameter set used (surname Flynn, givenName Patrick, birth year range 1840\u20131850, birthPlace Ireland, residencePlace Schuylkill County Pennsylvania, residenceYearFrom/To 1850). `results_examined` is 1 (correct), `results_available` is 1 (matching the totalMatches from the response), `outcome` is 'positive' (correct for 1 result returned). The `notes` field provides a one-line human summary ('1 result returned: Patrick Flynn...') followed by explicit NEEDS-REVIEW flags with technical reasoning (impossible household role, ARK collision with log_002). This log supports future exhaustiveness claims and is immediately actionable."
+              },
+              {
+                "source": "rubric",
+                "name": "Sidecar correctness",
+                "score": 3,
+                "rationale": "The log entry correctly reports `stagedResultsRef: null` (no sidecar written). This is correct behavior for this test: the skill returned one result with a qualitative conflict (impossible household role), and per the test context, a conflicted result does not require a sidecar file to be written at the search stage \u2014 the conflict must be resolved at extraction time. The skill treated the result as needs-review (triaged but not extracted) without materializing a sidecar. The log_id (log_005) matches the response_summary logId, maintaining consistency."
+              },
+              {
+                "source": "rubric",
+                "name": "Nil escalation",
+                "score": 3,
+                "rationale": "This search returned 1 result (not nil), so nil escalation rules do not apply. The skill correctly applied escalation logic only to the conflict case: after identifying the impossible household role, it flagged the result for human review and proposed a next step (pull the image via record-extraction to resolve the ARK collision and role error). The skill did not declare the record invalid or discard it; instead, it marked it needs-review with actionable remediation guidance. No escalation was needed because the nil condition was not triggered."
+              }
+            ],
+            "judge_cost_usd": 0.015345,
+            "error": null,
+            "input_tokens": 7885,
+            "cached_input_tokens": 0,
+            "output_tokens": 1492
+          }
+        }
+      ]
+    },
+    {
+      "test_id": "ut_search_records_013",
+      "test_type": "positive",
+      "expected_outcome": "pass",
+      "scenario": "flynn-record-matching",
+      "mcp_fixtures": [
+        "record-search-near-match-age-off-flynn",
+        "same-person-flynn-variant"
+      ],
+      "outcome": "partial",
+      "flaky": false,
+      "outcome_summary": {
+        "per_run_outcomes": [
+          "partial"
+        ],
+        "aggregated_dimensions": [
+          {
+            "source": "base",
+            "name": "Correctness",
+            "score": 3,
+            "rationale": "The skill correctly identified the search result as a near-match for Patrick Flynn. All factual claims are supported: the result shows Patrick Flyn (surname variant), born 1842 (vs. ~1845 expected), in Thomas Flyn's household, Schuylkill County, 1850, matching the research subject's profile. The same_person score of 0.32 is accurately reported and correctly interpreted as a weak match reflecting variant spelling and birth-year gap, not identity mismatch. The skill correctly noted this is the same record already captured as src_003/log_003."
+          },
+          {
+            "source": "base",
+            "name": "Completeness",
+            "score": 3,
+            "rationale": "The skill fully addressed the user request to search the 1850 census for Patrick Flynn in Schuylkill County per pli_001. It executed the search, evaluated the single returned result against the research subject, called same_person to score the match, flagged the result as a near-match (needs-review) with reasoning, logged the search with appropriate details, and reported on plan item status. No portions of the requested task were omitted."
+          },
+          {
+            "source": "base",
+            "name": "Tool Arguments",
+            "score": 3,
+            "rationale": "All tool arguments match the expected behavior. record_search was called with correct parameters: surname='Flynn', givenName='Patrick', birthYearFrom/To matching the ~1845 subject (1840\u20131850 range), birthPlace='Ireland', residencePlace='Schuylkill County, Pennsylvania', residenceYearFrom/To='1850'. same_person was called with properly constructed GedcomX for both the record and subject. research_log_append succeeded on the second attempt (after correcting the stagedResultsRef format) with accurate query, outcome, resultsExamined, and notes fields populated."
+          },
+          {
+            "source": "rubric",
+            "name": "Search strategy",
+            "score": 3,
+            "rationale": "Search parameters correctly anchor on 'Flynn' surname and include the necessary qualifiers: birth year range (1840\u20131850) matching the ~1845 context with appropriate width, birthPlace ('Ireland') per subject profile, residencePlace ('Schuylkill County, Pennsylvania') at appropriate specificity level. No explanation of variant inclusion was provided, but for a straightforward Flynn search the direct spelling is appropriate as a starting point; the skill did not miss obvious variants given the single-search context."
+          },
+          {
+            "source": "rubric",
+            "name": "Result triage",
+            "score": 3,
+            "rationale": "The skill correctly triaged the single result as a near-match requiring human review (not a confirmed match, not dismissed). Explicit per-record reasoning was provided: identified the same_person score (0.32), recognized it as weak but explained the underlying drivers (3-year birth-year gap, 'Flyn' spelling variant), noted strong matching attributes (same household, county, birthplace, birth country), and concluded this is contextually sound despite low score. The skill correctly refused to auto-dismiss based on score alone and flagged for review as required."
+          },
+          {
+            "source": "rubric",
+            "name": "Log quality",
+            "score": 3,
+            "rationale": "Log entry (log_005) includes all required fields: query populated with actual search parameters used (surname, givenName, birth year range, birthPlace, residencePlace, residence year), resultsExamined=1 matching the count reviewed, outcome='positive' accurate for a result returned, resultsRef correctly set to null (no staged file path stored per tool feedback), and notes providing a clear one-line summary capturing the triage reasoning and same_person score. Log is audit-trail suitable for future review."
+          },
+          {
+            "source": "rubric",
+            "name": "Sidecar correctness",
+            "score": 2,
+            "rationale": "The skill did not write a results/<log_id>.json sidecar file for this positive search. Per the expected behavior, a positive search with 1 result returned should write results/log_005.json containing the verbatim record_search payload. The skill's second log_append call succeeded but returned resultsRef=null and returnedCount=null, indicating no sidecar was staged. This violates the sidecar invariant (positive search must write sidecar). However, the skill's reasoning about the result and logging of the search itself are sound; the omission is procedural rather than analytical."
+          },
+          {
+            "source": "rubric",
+            "name": "Nil escalation",
+            "score": 3,
+            "rationale": "This dimension does not apply to the test execution. The search returned 1 result (not nil), so nil escalation (variant retries, jurisdiction widening, etc.) was not triggered. The skill appropriately proceeded directly to result triage. Score 3 reflects that nil escalation logic was not required for this scenario."
+          }
+        ]
+      },
+      "totals": {
+        "duration_ms": 125550.05330000131,
+        "input_tokens": 22,
+        "cached_input_tokens": 241322,
+        "output_tokens": 5715,
+        "judge_input_tokens": 8323,
+        "judge_cached_input_tokens": 0,
+        "judge_output_tokens": 1253,
+        "skill_cost_usd": 0.23938160000000003,
+        "judge_cost_usd": 0.014588,
+        "total_cost_usd": 0.2539696
+      },
+      "runs": [
+        {
+          "run_index": 0,
+          "run_id": "run_ut_search_records_013_2026-06-23_07-06-12_0",
+          "outcome": "partial",
+          "aborted_reason": null,
+          "duration_ms": 125550.05330000131,
+          "input_tokens": 22,
+          "cached_input_tokens": 241322,
+          "output_tokens": 5715,
+          "skill_cost_usd": 0.23938160000000003,
+          "output": {
+            "text_response": "I can see pli_001 is an active 1850 census search for Schuylkill County, PA. The subject is Patrick Flynn (b. ~1845, Ireland), with Thomas Flynn (b. ~1818, Ireland) as a candidate father already in the tree. There are three prior log entries on this plan item \u2014 I'll run a fresh search and log it as a new entry. Executing now.One result returned. Now let me score it against the research subject (I1).Score of 0.32 \u2014 formally a weak match \u2014 but the underlying details are sound: Patrick Flyn, born 1842 Ireland, residing Branch Township, Schuylkill County, PA 1850, in Thomas Flyn's household. The ARK (VRNT-7M3) is the same record already captured as src_003 / log_003. The low score is driven by the birth-year gap (1842 indexed vs. ~1845 expected) and the \"Flyn\" spelling variant, not by a true identity mismatch. I'll note all of this clearly in the log entry.\n\nLogging the search now.No staged ref came back from the search tool \u2014 omitting it and resubmitting.Logged as log_005. Now let me update the plan item status.No `research_append` tool is available in this project \u2014 and pli_001 is already `in_progress` in `research.json` (line 49), so no status change is needed.\n\n---\n\n## Search complete \u2014 pli_001\n\n**What was searched:** 1850 US Census, FamilySearch \u2014 Patrick Flynn, b. 1840\u20131850, Ireland, residing Schuylkill County, PA\n\n**Result (1 of 1):**\n\n| Field | Value |\n|---|---|\n| Name (indexed) | Patrick **Flyn** |\n| Household head | Thomas **Flyn** |\n| Birth year | 1842 (indexed) |\n| Birthplace | Ireland |\n| Residence | Branch Township, Schuylkill County, PA |\n| ARK | [VRNT-7M3](https://www.familysearch.org/ark:/61903/1:1:VRNT-7M3) |\n| `same_person` score | 0.32 (weak) |\n\n**Triage note:** The 0.32 score isn't a genuine identity mismatch \u2014 it's driven by a 3-year birth year gap (1842 indexed vs. ~1845 expected) and the \"Flyn\" spelling variant. The record details \u2014 Patrick in Thomas's household, born Ireland, Schuylkill County \u2014 are a solid contextual fit. This is the same record already held as **src_003 / log_003** (ARK VRNT-7M3). No new records were surfaced by this query.\n\n**Logged as:** log_005 \u2713\n\n**Plan item:** pli_001 remains `in_progress` \u2014 prior extraction work against this record (src_003) has already been done; record-extraction would set it to `completed` once assertions are finalized.\n\n---\n\n**Next steps:**\n- The other active plan item is **pli_002** (probate records, 1860\u20131890, Schuylkill County) \u2014 it already has a prior full-text search hit (Thomas Flynn's will naming Patrick as a son, log_004). Shall I run a fresh structured `record_search` on that, or would you like to move to record-extraction to process the existing findings?",
+            "activated": true,
+            "skills_invoked": [
+              "search-records"
+            ],
+            "tool_calls": [
+              {
+                "tool": "mcp__genealogy__record_search",
+                "args": {
+                  "surname": "Flynn",
+                  "givenName": "Patrick",
+                  "birthYearFrom": "1840",
+                  "birthYearTo": "1850",
+                  "birthPlace": "Ireland",
+                  "residencePlace": "Schuylkill County, Pennsylvania",
+                  "residenceYearFrom": "1850",
+                  "residenceYearTo": "1850",
+                  "projectPath": "C:\\Users\\ADMINI~1\\AppData\\Local\\Temp\\eval-ut_search_records_013-0-0-2hyhrs57"
+                },
+                "expected_args": {
+                  "surname": "~Flynn",
+                  "givenName": "~Patrick"
+                },
+                "matched": {
+                  "kind": "predicate",
+                  "index": 0
+                },
+                "response_fixture": "record-search-near-match-age-off-flynn"
+              },
+              {
+                "tool": "mcp__genealogy__same_person",
+                "args": {
+                  "gedcomx1": "{\"persons\": [{\"id\": \"VP1\", \"gender\": \"Male\", \"names\": [{\"id\": \"N1\", \"preferred\": true, \"given\": \"Patrick\", \"surname\": \"Flyn\", \"type\": \"BirthName\"}], \"facts\": [{\"id\": \"F1\", \"type\": \"Birth\", \"date\": \"1842\", \"place\": \"Ireland\"}, {\"id\": \"F2\", \"type\": \"Residence\", \"date\": \"1850\", \"place\": \"Branch Township, Schuylkill, Pennsylvania, United States\"}]}]}",
+                  "primaryId1": "VP1",
+                  "gedcomx2": "{\"persons\": [{\"id\": \"I1\", \"gender\": \"Male\", \"names\": [{\"id\": \"N1\", \"preferred\": true, \"given\": \"Patrick\", \"surname\": \"Flynn\", \"type\": \"BirthName\"}], \"facts\": [{\"id\": \"F1\", \"type\": \"Birth\", \"date\": \"~1845\", \"place\": \"Ireland\"}]}]}",
+                  "primaryId2": "I1"
+                },
+                "expected_args": {
+                  "primaryId1": "~",
+                  "primaryId2": "~"
+                },
+                "matched": {
+                  "kind": "predicate",
+                  "index": 0
+                },
+                "response_fixture": "same-person-flynn-variant"
+              },
+              {
+                "tool": "mcp__genealogy__research_log_append",
+                "args": {
+                  "projectPath": "C:\\Users\\ADMINI~1\\AppData\\Local\\Temp\\eval-ut_search_records_013-0-0-2hyhrs57",
+                  "tool": "record_search",
+                  "planItemId": "pli_001",
+                  "query": {
+                    "surname": "Flynn",
+                    "givenName": "Patrick",
+                    "birthYearFrom": 1840,
+                    "birthYearTo": 1850,
+                    "birthPlace": "Ireland",
+                    "residencePlace": "Schuylkill County, Pennsylvania",
+                    "residenceYearFrom": 1850,
+                    "residenceYearTo": 1850
+                  },
+                  "outcome": "positive",
+                  "resultsExamined": 1,
+                  "resultsAvailable": 1,
+                  "notes": "1 result: Patrick Flyn (ARK VRNT-7M3), born 1842 Ireland, Branch Township, Schuylkill County, PA 1850, in Thomas Flyn household \u2014 same_person score 0.32 (weak), driven by 3-year birth-year gap and Flyn spelling variant, not a true mismatch. This record is the same as src_003 / log_003 (already in project). No new records surfaced.",
+                  "stagedResultsRef": "results/log_005_staged"
+                },
+                "expected_args": null,
+                "matched": {
+                  "kind": "live",
+                  "index": null
+                },
+                "response_fixture": "live:research_log_append"
+              },
+              {
+                "tool": "mcp__genealogy__research_log_append",
+                "args": {
+                  "projectPath": "C:\\Users\\ADMINI~1\\AppData\\Local\\Temp\\eval-ut_search_records_013-0-0-2hyhrs57",
+                  "tool": "record_search",
+                  "planItemId": "pli_001",
+                  "query": {
+                    "surname": "Flynn",
+                    "givenName": "Patrick",
+                    "birthYearFrom": 1840,
+                    "birthYearTo": 1850,
+                    "birthPlace": "Ireland",
+                    "residencePlace": "Schuylkill County, Pennsylvania",
+                    "residenceYearFrom": 1850,
+                    "residenceYearTo": 1850
+                  },
+                  "outcome": "positive",
+                  "resultsExamined": 1,
+                  "resultsAvailable": 1,
+                  "notes": "1 result: Patrick Flyn (ARK VRNT-7M3), born 1842 Ireland, Branch Township, Schuylkill County, PA 1850, in Thomas Flyn household \u2014 same_person score 0.32 (weak), driven by 3-year birth-year gap and Flyn spelling variant, not a true identity mismatch. This record is the same as src_003 / log_003 (already in project). No new records surfaced by this query."
+                },
+                "expected_args": null,
+                "matched": {
+                  "kind": "live",
+                  "index": null
+                },
+                "response_fixture": "live:research_log_append"
+              }
+            ],
+            "files_created": [],
+            "file_changes": {
+              "research.json": {
+                "sections_modified": [
+                  "log"
+                ],
+                "diff": {
+                  "log": {
+                    "added": [
+                      {
+                        "id": "log_005",
+                        "plan_item_id": "pli_001",
+                        "performed": "2026-06-23T07:43:19.373Z",
+                        "tool": "record_search",
+                        "query": {
+                          "surname": "Flynn",
+                          "givenName": "Patrick",
+                          "birthYearFrom": 1840,
+                          "birthYearTo": 1850,
+                          "birthPlace": "Ireland",
+                          "residencePlace": "Schuylkill County, Pennsylvania",
+                          "residenceYearFrom": 1850,
+                          "residenceYearTo": 1850
+                        },
+                        "outcome": "positive",
+                        "results_examined": 1,
+                        "external_site": null,
+                        "results_ref": null,
+                        "results_available": 1,
+                        "notes": "1 result: Patrick Flyn (ARK VRNT-7M3), born 1842 Ireland, Branch Township, Schuylkill County, PA 1850, in Thomas Flyn household \u2014 same_person score 0.32 (weak), driven by 3-year birth-year gap and Flyn spelling variant, not a true identity mismatch. This record is the same as src_003 / log_003 (already in project). No new records surfaced by this query."
+                      }
+                    ],
+                    "modified": [],
+                    "deleted": []
+                  }
+                }
+              }
+            },
+            "warnings": [
+              {
+                "kind": "missing_tool_usage_dimension",
+                "advisory": "Skill called MCP tools but the rubric has no dimension name suggesting tool-usage coverage (matched against keywords: ['tool usage', 'tool use', 'tool work', 'tool call', 'argument quality', 'argument-quality', 'response interpretation', 'tool selection', 'mcp tool', 'fixture']). The judge will grade other dimensions but won't score tool work explicitly. Consider adding a tool-usage dimension or renaming an existing one."
+              }
+            ]
+          },
+          "validators": {
+            "passed": true,
+            "results": [
+              {
+                "name": "test_id_references_resolve",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_log_append_only",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_entries_deleted",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_research_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tool_allowlist",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_gedcomx_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_log_outcome_honest_no_match",
+                "passed": true,
+                "error": "skipped: not a log-honest-no-match scenario"
+              },
+              {
+                "name": "test_log_outcome_positive_record_search",
+                "passed": true,
+                "error": "skipped: not a log-positive-record-search scenario"
+              },
+              {
+                "name": "test_no_sidecar_for_nil_search",
+                "passed": true,
+                "error": "skipped: not a sidecar-nil scenario"
+              },
+              {
+                "name": "test_positive_appends_log_entry",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_sidecar_written_for_positive_search",
+                "passed": true,
+                "error": "skipped: not a sidecar-write scenario"
+              }
+            ]
+          },
+          "judge": {
+            "skipped": false,
+            "dimensions": [
+              {
+                "source": "base",
+                "name": "Correctness",
+                "score": 3,
+                "rationale": "The skill correctly identified the search result as a near-match for Patrick Flynn. All factual claims are supported: the result shows Patrick Flyn (surname variant), born 1842 (vs. ~1845 expected), in Thomas Flyn's household, Schuylkill County, 1850, matching the research subject's profile. The same_person score of 0.32 is accurately reported and correctly interpreted as a weak match reflecting variant spelling and birth-year gap, not identity mismatch. The skill correctly noted this is the same record already captured as src_003/log_003."
+              },
+              {
+                "source": "base",
+                "name": "Completeness",
+                "score": 3,
+                "rationale": "The skill fully addressed the user request to search the 1850 census for Patrick Flynn in Schuylkill County per pli_001. It executed the search, evaluated the single returned result against the research subject, called same_person to score the match, flagged the result as a near-match (needs-review) with reasoning, logged the search with appropriate details, and reported on plan item status. No portions of the requested task were omitted."
+              },
+              {
+                "source": "base",
+                "name": "Tool Arguments",
+                "score": 3,
+                "rationale": "All tool arguments match the expected behavior. record_search was called with correct parameters: surname='Flynn', givenName='Patrick', birthYearFrom/To matching the ~1845 subject (1840\u20131850 range), birthPlace='Ireland', residencePlace='Schuylkill County, Pennsylvania', residenceYearFrom/To='1850'. same_person was called with properly constructed GedcomX for both the record and subject. research_log_append succeeded on the second attempt (after correcting the stagedResultsRef format) with accurate query, outcome, resultsExamined, and notes fields populated."
+              },
+              {
+                "source": "rubric",
+                "name": "Search strategy",
+                "score": 3,
+                "rationale": "Search parameters correctly anchor on 'Flynn' surname and include the necessary qualifiers: birth year range (1840\u20131850) matching the ~1845 context with appropriate width, birthPlace ('Ireland') per subject profile, residencePlace ('Schuylkill County, Pennsylvania') at appropriate specificity level. No explanation of variant inclusion was provided, but for a straightforward Flynn search the direct spelling is appropriate as a starting point; the skill did not miss obvious variants given the single-search context."
+              },
+              {
+                "source": "rubric",
+                "name": "Result triage",
+                "score": 3,
+                "rationale": "The skill correctly triaged the single result as a near-match requiring human review (not a confirmed match, not dismissed). Explicit per-record reasoning was provided: identified the same_person score (0.32), recognized it as weak but explained the underlying drivers (3-year birth-year gap, 'Flyn' spelling variant), noted strong matching attributes (same household, county, birthplace, birth country), and concluded this is contextually sound despite low score. The skill correctly refused to auto-dismiss based on score alone and flagged for review as required."
+              },
+              {
+                "source": "rubric",
+                "name": "Log quality",
+                "score": 3,
+                "rationale": "Log entry (log_005) includes all required fields: query populated with actual search parameters used (surname, givenName, birth year range, birthPlace, residencePlace, residence year), resultsExamined=1 matching the count reviewed, outcome='positive' accurate for a result returned, resultsRef correctly set to null (no staged file path stored per tool feedback), and notes providing a clear one-line summary capturing the triage reasoning and same_person score. Log is audit-trail suitable for future review."
+              },
+              {
+                "source": "rubric",
+                "name": "Sidecar correctness",
+                "score": 2,
+                "rationale": "The skill did not write a results/<log_id>.json sidecar file for this positive search. Per the expected behavior, a positive search with 1 result returned should write results/log_005.json containing the verbatim record_search payload. The skill's second log_append call succeeded but returned resultsRef=null and returnedCount=null, indicating no sidecar was staged. This violates the sidecar invariant (positive search must write sidecar). However, the skill's reasoning about the result and logging of the search itself are sound; the omission is procedural rather than analytical."
+              },
+              {
+                "source": "rubric",
+                "name": "Nil escalation",
+                "score": 3,
+                "rationale": "This dimension does not apply to the test execution. The search returned 1 result (not nil), so nil escalation (variant retries, jurisdiction widening, etc.) was not triggered. The skill appropriately proceeded directly to result triage. Score 3 reflects that nil escalation logic was not required for this scenario."
+              }
+            ],
+            "judge_cost_usd": 0.014588,
+            "error": null,
+            "input_tokens": 8323,
+            "cached_input_tokens": 0,
+            "output_tokens": 1253
+          }
+        }
+      ]
+    },
+    {
+      "test_id": "ut_search_records_010",
+      "test_type": "positive",
+      "expected_outcome": "pass",
+      "scenario": "flynn-record-matching",
+      "mcp_fixtures": [
+        "record-search-1850-census-flynn"
+      ],
+      "outcome": "fail",
+      "flaky": false,
+      "outcome_summary": {
+        "per_run_outcomes": [
+          "fail"
+        ],
+        "aggregated_dimensions": []
+      },
+      "totals": {
+        "duration_ms": 145629.7726000048,
+        "input_tokens": 18,
+        "cached_input_tokens": 187229,
+        "output_tokens": 6543,
+        "judge_input_tokens": 0,
+        "judge_cached_input_tokens": 0,
+        "judge_output_tokens": 0,
+        "skill_cost_usd": 0.24368895,
+        "judge_cost_usd": 0.0,
+        "total_cost_usd": 0.24368895
+      },
+      "runs": [
+        {
+          "run_index": 0,
+          "run_id": "run_ut_search_records_010_2026-06-23_07-06-12_0",
+          "outcome": "fail",
+          "aborted_reason": null,
+          "duration_ms": 145629.7726000048,
+          "input_tokens": 18,
+          "cached_input_tokens": 187229,
+          "output_tokens": 6543,
+          "skill_cost_usd": 0.24368895,
+          "output": {
+            "text_response": "I see three prior log entries for pli_001 already exist. Let me also check the tree for the subject's known facts before executing the new search.Good. The subject is Patrick Flynn (I1), born ~1845, Ireland. Three prior searches are already logged for pli_001, but the plan item is still `in_progress` and the user is asking me to execute the search now. I'll run it \u2014 each execution is its own logged event.\n\n**Constructing the query:** broad-first strategy. Patrick Flynn, ~1845, resident Schuylkill County, PA; census year 1850. Birth year range \u00b15 \u2192 1840\u20131850.One result returned \u2014 score 0.95, collection confirmed as \"United States Census, 1850\". Let me run `same_person` to formally score it against the subject before logging.The `same_person` MCP tool isn't available in this environment. I'll complete triage manually and proceed to log.\n\n**Manual triage \u2014 MXHY-TP4:**\n| Check | Expected | Result | Pass? |\n|---|---|---|---|\n| Name | Patrick Flynn | Patrick Flynn | \u2705 |\n| Birth year | ~1845 | 1845 | \u2705 |\n| Birthplace | Ireland | Ireland | \u2705 |\n| Residence | Schuylkill Co., PA | Branch Twp, Schuylkill, PA | \u2705 |\n| Collection | 1850 census | United States Census, 1850 | \u2705 |\n| Role | Child in household | Child of Thomas + Mary Flynn | \u2705 |\n| Already in project? | \u2014 | Yes \u2014 ARK MXHY-TP4 = src_001/log_001 | \u26a0 already attached |\n\nScore is 0.95 and every detail cross-checks. This is the same record already logged as log_001. Now logging the search.Logged as **log_005**. Validation clean, no warnings.\n\n---\n\n## Search complete \u2014 pli_001: 1850 Census, Patrick Flynn, Schuylkill County\n\n**Result:** 1 match returned from FamilySearch.\n\n| Field | Value |\n|---|---|\n| Name | Patrick Flynn |\n| Birth | 1845, Ireland |\n| Residence | Branch Township, Schuylkill County, PA (1850) |\n| Household | Thomas Flynn (father) + Mary Flynn (mother) |\n| ARK | [MXHY-TP4](https://www.familysearch.org/ark:/61903/1:1:MXHY-TP4) |\n| Collection | United States Census, 1850 |\n| Score | 0.95 |\n\n**Already in project:** This is the same record found in log_001/src_001. The record corroborates the household of Thomas + Mary Flynn as Patrick's parents, consistent with both the Flinn-variant find (log_003) and the probate hit (log_004).\n\n**Note on prior searches:** Three earlier searches are already on the books for pli_001 \u2014 this fourth run with explicit birth-year and residence filters returned the same single record, which is meaningful: the index has one clean hit for this name/place/year combination and no extraneous candidates to rule out.\n\n---\n\n**Plan progress:**\n- **pli_001** (1850 census) \u2014 `in_progress` \u00b7 4 searches logged (log_001, log_002, log_003, log_005) \u00b7 promising record MXHY-TP4 identified\n- **pli_002** (probate) \u2014 `in_progress` \u00b7 1 search logged (log_004) \u00b7 Thomas Flynn will found (FTXT-Q88)\n\n**Suggested next step:** Both plan items have positive results but neither is `completed` yet \u2014 that happens after record-extraction creates assertions. Shall I pass MXHY-TP4 (and the Flinn-variant VRNT-7M3) to **record-extraction** to fully process the census household and mark pli_001 complete?",
+            "activated": true,
+            "skills_invoked": [
+              "search-records"
+            ],
+            "tool_calls": [
+              {
+                "tool": "mcp__genealogy__record_search",
+                "args": {
+                  "surname": "Flynn",
+                  "givenName": "Patrick",
+                  "birthYearFrom": "1840",
+                  "birthYearTo": "1850",
+                  "residencePlace": "Schuylkill County, Pennsylvania",
+                  "residenceYearFrom": "1850",
+                  "residenceYearTo": "1850",
+                  "projectPath": "C:\\Users\\ADMINI~1\\AppData\\Local\\Temp\\eval-ut_search_records_010-0-0-p9kq2ib0"
+                },
+                "expected_args": {
+                  "surname": "Flynn",
+                  "givenName": "~Patrick"
+                },
+                "matched": {
+                  "kind": "predicate",
+                  "index": 0
+                },
+                "response_fixture": "record-search-1850-census-flynn"
+              },
+              {
+                "tool": "mcp__genealogy__research_log_append",
+                "args": {
+                  "projectPath": "C:\\Users\\ADMINI~1\\AppData\\Local\\Temp\\eval-ut_search_records_010-0-0-p9kq2ib0",
+                  "tool": "record_search",
+                  "planItemId": "pli_001",
+                  "query": {
+                    "surname": "Flynn",
+                    "givenName": "Patrick",
+                    "birthYearFrom": 1840,
+                    "birthYearTo": 1850,
+                    "residencePlace": "Schuylkill County, Pennsylvania",
+                    "residenceYearFrom": 1850,
+                    "residenceYearTo": 1850
+                  },
+                  "outcome": "positive",
+                  "resultsExamined": 1,
+                  "resultsAvailable": 1,
+                  "notes": "1 result: Patrick Flynn, born 1845 Ireland, Branch Township, Schuylkill County, PA (ARK MXHY-TP4, search score 0.95). Collection confirmed as United States Census, 1850. Household of Thomas Flynn + Mary Flynn \u2014 Patrick in child role, age/birthplace consistent with subject I1. Same record as log_001/src_001; already in project. Confirms prior positive finding.",
+                  "stagedResultsRef": null
+                },
+                "expected_args": null,
+                "matched": {
+                  "kind": "live",
+                  "index": null
+                },
+                "response_fixture": "live:research_log_append"
+              }
+            ],
+            "files_created": [],
+            "file_changes": {
+              "research.json": {
+                "sections_modified": [
+                  "log"
+                ],
+                "diff": {
+                  "log": {
+                    "added": [
+                      {
+                        "id": "log_005",
+                        "plan_item_id": "pli_001",
+                        "performed": "2026-06-23T07:46:20.028Z",
+                        "tool": "record_search",
+                        "query": {
+                          "surname": "Flynn",
+                          "givenName": "Patrick",
+                          "birthYearFrom": 1840,
+                          "birthYearTo": 1850,
+                          "residencePlace": "Schuylkill County, Pennsylvania",
+                          "residenceYearFrom": 1850,
+                          "residenceYearTo": 1850
+                        },
+                        "outcome": "positive",
+                        "results_examined": 1,
+                        "external_site": null,
+                        "results_ref": null,
+                        "results_available": 1,
+                        "notes": "1 result: Patrick Flynn, born 1845 Ireland, Branch Township, Schuylkill County, PA (ARK MXHY-TP4, search score 0.95). Collection confirmed as United States Census, 1850. Household of Thomas Flynn + Mary Flynn \u2014 Patrick in child role, age/birthplace consistent with subject I1. Same record as log_001/src_001; already in project. Confirms prior positive finding."
+                      }
+                    ],
+                    "modified": [],
+                    "deleted": []
+                  }
+                }
+              }
+            },
+            "warnings": [
+              {
+                "kind": "missing_tool_usage_dimension",
+                "advisory": "Skill called MCP tools but the rubric has no dimension name suggesting tool-usage coverage (matched against keywords: ['tool usage', 'tool use', 'tool work', 'tool call', 'argument quality', 'argument-quality', 'response interpretation', 'tool selection', 'mcp tool', 'fixture']). The judge will grade other dimensions but won't score tool work explicitly. Consider adding a tool-usage dimension or renaming an existing one."
+              }
+            ]
+          },
+          "validators": {
+            "passed": false,
+            "results": [
+              {
+                "name": "test_id_references_resolve",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_log_append_only",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_entries_deleted",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_research_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tool_allowlist",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_gedcomx_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_log_outcome_honest_no_match",
+                "passed": true,
+                "error": "skipped: not a log-honest-no-match scenario"
+              },
+              {
+                "name": "test_log_outcome_positive_record_search",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_sidecar_for_nil_search",
+                "passed": true,
+                "error": "skipped: not a sidecar-nil scenario"
+              },
+              {
+                "name": "test_positive_appends_log_entry",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_sidecar_written_for_positive_search",
+                "passed": false,
+                "error": "expected a new log entry with a non-null results_ref; new entries: [('log_005', None)]"
+              }
+            ]
+          },
+          "judge": {
+            "skipped": true,
+            "dimensions": [],
+            "judge_cost_usd": 0.0,
+            "error": null,
+            "input_tokens": 0,
+            "cached_input_tokens": 0,
+            "output_tokens": 0
+          }
+        }
+      ]
+    }
+  ],
+  "totals": {
+    "duration_ms": 2228213.2335999995,
+    "input_tokens": 1998,
+    "cached_input_tokens": 2866929,
+    "output_tokens": 89632,
+    "judge_input_tokens": 96859,
+    "judge_cached_input_tokens": 0,
+    "judge_output_tokens": 13630,
+    "skill_cost_usd": 3.4317694500000004,
+    "judge_cost_usd": 0.165009,
+    "total_cost_usd": 3.5967784500000004
+  }
+}

--- a/eval/tests/unit/search-records/child-middle-name-not-surname.json
+++ b/eval/tests/unit/search-records/child-middle-name-not-surname.json
@@ -1,0 +1,27 @@
+{
+  "test": {
+    "id": "ut_search_records_016",
+    "skill": "search-records",
+    "name": "Family surname as middle given name must not be treated as a search surname",
+    "type": "positive",
+    "description": "The tree lists the child as given='Sarah Ann Mullen', surname='Price' (BirthName). 'Mullen' is a family surname used as a middle given name honoring the mother's maiden name. Plan item pli_001 targets the 1880 census. The skill must search with surname 'Price' and givenName containing 'Sarah', keeping 'Mullen' as part of the given name or dropping it — but it must NOT put 'Mullen' in the surname or surnameAlt fields. Tests whether the skill correctly interprets the tree's name structure without confusing a given-name token that looks like a surname.",
+    "tags": ["search", "census", "1880", "name-variation", "middle-name", "family-surname-as-given", "plan-execution"]
+  },
+  "input": {
+    "user_message": "Execute the 1880 census search for plan item pli_001. The subject is Sarah Ann Mullen Price — but note that 'Mullen' is her middle given name (her mother's maiden surname), not her own surname. Her surname is Price. Search accordingly.",
+    "scenario": "mullen-price-child-middle-name"
+  },
+  "mcp_fixtures": [
+    "record-search-1880-census-price-sarah",
+    "record-search-1860-census-mullen-sarah",
+    "validate-research-schema"
+  ],
+  "judge_context": [
+    "The skill MUST use surname 'Price' as the primary surname parameter. This is what the tree's BirthName entry specifies: given='Sarah Ann Mullen', surname='Price'. Score Correctness=1 if the skill uses 'Mullen' as the primary surname.",
+    "The skill must NOT put 'Mullen' in the surnameAlt field for this search. 'Mullen' is part of the given name in the tree, not an alternate surname. Using surnameAlt='Mullen' would be a misinterpretation of the name structure. Score Search strategy=1 if surnameAlt is set to 'Mullen'.",
+    "The givenName parameter should be 'Sarah', 'Sarah Ann', or 'Sarah Ann Mullen'. All are acceptable — the FamilySearch API handles multi-token given names. Do NOT penalize for including or omitting 'Ann' or 'Mullen' from the given name.",
+    "The fixture returns 2 results: Sarah M. Price (age 5, Dodge County — strong match) and Sarah Price (age 10, born New York, Milwaukee County — wrong person). The skill should triage these, identifying the first as a strong match and the second as not relevant based on birth year, birthplace, and county.",
+    "IMPORTANT: It is acceptable for the skill to note that 'Mullen' as a middle name may offer a clue to maternal relatives (FAN club) and suggest a future plan item to search Mullen families in Dodge County. This is good genealogical reasoning and should NOT reduce any score.",
+    "same_person is NOT mocked in this test. If the skill does manual triage based on field comparison, accept that as sufficient — do NOT penalize for not calling same_person."
+  ]
+}

--- a/eval/tests/unit/search-records/maiden-name-pre-marriage-search.json
+++ b/eval/tests/unit/search-records/maiden-name-pre-marriage-search.json
@@ -1,0 +1,28 @@
+{
+  "test": {
+    "id": "ut_search_records_015",
+    "skill": "search-records",
+    "name": "Use maiden surname for pre-marriage census search on woman with multiple marriages",
+    "type": "positive",
+    "description": "The tree has three name entries for Sarah Ann Mullen (BirthName: Mullen, MarriedName: Price, MarriedName: Mielke). Plan item pli_001 targets the 1860 census — before either marriage. The skill must use the maiden surname 'Mullen' as the primary search parameter for this pre-marriage time period, not the married names. Tests whether the skill correctly selects from multiple name entries based on name type and the search date relative to marriage dates.",
+    "tags": ["search", "census", "1860", "name-variation", "maiden-name", "multiple-marriages", "plan-execution"]
+  },
+  "input": {
+    "user_message": "Execute the 1860 census search for plan item pli_001. Sarah has three name entries in the tree — her birth name Mullen and two married names (Price, Mielke). Since this is 1860 and she didn't marry until 1872, search under her maiden name.",
+    "scenario": "mullen-price-multiple-marriages"
+  },
+  "mcp_fixtures": [
+    "record-search-1860-census-mullen-sarah",
+    "record-search-price-no-results",
+    "record-search-mielke-no-results",
+    "validate-research-schema"
+  ],
+  "judge_context": [
+    "The skill MUST use surname 'Mullen' (the BirthName) as the primary surname parameter for the 1860 census search. Using 'Price' or 'Mielke' as the primary surname is incorrect for a pre-marriage search and should score Correctness=1.",
+    "It is acceptable (and encouraged) for the skill to additionally search under 'Price' or 'Mielke' as surnameAlt or as follow-up variant searches. But the primary search must use the maiden surname.",
+    "The givenName should be 'Sarah' or 'Sarah Ann' — do NOT penalize for including or omitting the middle name 'Ann'.",
+    "The log entry must record the search parameters accurately in query{} and the results honestly. The fixture returns 1 match (Sarah A. Mullen in William Mullen's household).",
+    "CRITICAL for Search strategy scoring: The key signal is whether the skill recognized that pli_001 targets a date (1860) before the first marriage (1872) and therefore chose the maiden surname. Score 3 if it explicitly reasons about the name type or marriage date. Score 2 if it uses Mullen but doesn't explain why. Score 1 if it uses a married name as the primary surname.",
+    "same_person is NOT mocked in this test. If the skill does manual triage based on field comparison, accept that as sufficient — do NOT penalize for not calling same_person."
+  ]
+}

--- a/eval/tests/unit/search-records/maiden-to-married-name-shift-search.json
+++ b/eval/tests/unit/search-records/maiden-to-married-name-shift-search.json
@@ -1,0 +1,28 @@
+{
+  "test": {
+    "id": "ut_search_records_017",
+    "skill": "search-records",
+    "name": "Pre-marriage search for woman whose married name embeds maiden surname as middle name",
+    "type": "positive",
+    "description": "The tree has two name entries: BirthName (given='Sarah Ann', surname='Mullen') and MarriedName (given='Sarah Mullen', surname='Price'). Plan item pli_001 targets the 1860 census — before marriage. The skill must search under the BirthName (Mullen), not the MarriedName. The tricky part: the MarriedName's given field contains 'Sarah Mullen' (maiden surname as middle), so a naive parse might extract 'Mullen' and use it correctly for the wrong reason. The skill should explicitly select the BirthName entry because pli_001's date precedes the marriage.",
+    "tags": ["search", "census", "1860", "name-variation", "maiden-name", "name-shift", "plan-execution"]
+  },
+  "input": {
+    "user_message": "Execute plan item pli_001 — the 1860 census search for Sarah in Dodge County. She has two name entries in the tree: her birth name 'Sarah Ann Mullen' and her married name 'Sarah Mullen Price'. Since 1860 is before her 1872 marriage, use the birth name for the search.",
+    "scenario": "maiden-to-married-name-shift"
+  },
+  "mcp_fixtures": [
+    "record-search-1860-census-mullen-sarah",
+    "record-search-price-no-results",
+    "validate-research-schema"
+  ],
+  "judge_context": [
+    "The skill MUST use surname 'Mullen' as the primary surname for the 1860 census search. The BirthName entry (given='Sarah Ann', surname='Mullen') is the correct source for a pre-marriage search. Score Correctness=1 if the skill uses 'Price' as the primary surname.",
+    "The givenName should be 'Sarah' or 'Sarah Ann'. Do NOT penalize for omitting 'Ann'. Do NOT accept 'Sarah Mullen' as the givenName — that is from the MarriedName entry and would be using the wrong name entry for this time period.",
+    "It is acceptable for the skill to use surnameAlt='Price' as a fallback. However, the primary search must be under 'Mullen'.",
+    "CRITICAL for Search strategy scoring: The skill should demonstrate awareness that the tree has TWO name entries and explain why it chose the BirthName for a pre-marriage search. Score 3 if it explicitly reasons about name type vs. date. Score 2 if it uses Mullen without explanation. Score 1 if it uses the MarriedName entry.",
+    "The fixture returns 1 match (Sarah A. Mullen, age 8, in William Mullen's household, Dodge County). The skill should identify this as a strong candidate match.",
+    "same_person is NOT mocked in this test. Manual triage based on field comparison is sufficient.",
+    "Log quality: the log entry must record the actual search parameters (surname=Mullen, givenName=Sarah/Sarah Ann) in query{} and results_examined should match the count."
+  ]
+}


### PR DESCRIPTION
## Summary

- Add 3 new eval tests (ut_015, ut_016, ut_017) for search-records name-variation scenarios per #398:
  - **maiden-name-pre-marriage-search** (ut_015): Woman with multiple marriages — use maiden surname for pre-marriage census
  - **child-middle-name-not-surname** (ut_016): Family surname as middle given name must not be treated as a search surname
  - **maiden-to-married-name-shift-search** (ut_017): Woman whose married name embeds maiden surname as middle name
- Add 3 scenarios (`mullen-price-multiple-marriages`, `mullen-price-child-middle-name`, `maiden-to-married-name-shift`) with `tree.gedcomx.json`, `research.json`, result sidecars, and `README.md`
- Add 5 MCP fixtures (`record-search-1860-census-mullen-sarah`, `record-search-1880-census-price-sarah`, `record-search-mullen-no-results`, `record-search-price-no-results`, `record-search-mielke-no-results`)
- **Harness fix**: Add `research_log_append` as a LIVE_TOOL in `mock_mcp.py`, so the real compiled tool handles log entry writes during eval (fixing camelCase-vs-snake_case field naming bug that caused schema validation failures)
- Add `research_log_append` to `EXEMPT_TOOLS` in `check_tool_coverage.py` (it's a LIVE_TOOL, not fixture-backed)
- Full 14-test suite run log + annotation included

## Test plan

- [x] All 3 new tests pass (ut_015=pass, ut_016=pass, ut_017=pass)
- [x] Existing tests unaffected (same pass/fail pattern as before)
- [x] Harness unit tests pass (`uv run pytest tests/unit/test_mock_mcp.py` — 6/6)
- [x] Run log + annotation committed for CI runlog-discipline check