### PR TITLE
translation: shorten SKILL.md (213→194)

### DIFF
--- a/eval/runlogs/unit/translation/v1_2026-06-22_19-33-09.ann.json
+++ b/eval/runlogs/unit/translation/v1_2026-06-22_19-33-09.ann.json
@@ -1,0 +1,534 @@
+{
+  "run_log": "v1_2026-06-22_19-33-09.json",
+  "annotator": "florencemashipei4@gmail.com",
+  "corrections": [
+    {
+      "test_id": "ut_translation_006",
+      "dimension_source": "base",
+      "dimension_name": "Correctness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_translation_006",
+      "dimension_source": "rubric",
+      "dimension_name": "Notation of uncertainty",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_translation_006",
+      "dimension_source": "rubric",
+      "dimension_name": "Genealogical context",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_translation_006",
+      "dimension_source": "base",
+      "dimension_name": "Tool Arguments",
+      "llm_score": null,
+      "corrected_score": null,
+      "comment": null
+    },
+    {
+      "test_id": "ut_translation_006",
+      "dimension_source": "base",
+      "dimension_name": "Completeness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_translation_006",
+      "dimension_source": "rubric",
+      "dimension_name": "Accuracy",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_translation_011",
+      "dimension_source": "rubric",
+      "dimension_name": "Genealogical context",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_translation_011",
+      "dimension_source": "rubric",
+      "dimension_name": "Notation of uncertainty",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_translation_011",
+      "dimension_source": "rubric",
+      "dimension_name": "Accuracy",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_translation_011",
+      "dimension_source": "base",
+      "dimension_name": "Tool Arguments",
+      "llm_score": null,
+      "corrected_score": null,
+      "comment": null
+    },
+    {
+      "test_id": "ut_translation_011",
+      "dimension_source": "base",
+      "dimension_name": "Completeness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_translation_011",
+      "dimension_source": "base",
+      "dimension_name": "Correctness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_translation_004",
+      "dimension_source": "rubric",
+      "dimension_name": "Genealogical context",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_translation_004",
+      "dimension_source": "rubric",
+      "dimension_name": "Notation of uncertainty",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_translation_004",
+      "dimension_source": "rubric",
+      "dimension_name": "Accuracy",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_translation_004",
+      "dimension_source": "base",
+      "dimension_name": "Tool Arguments",
+      "llm_score": null,
+      "corrected_score": null,
+      "comment": null
+    },
+    {
+      "test_id": "ut_translation_004",
+      "dimension_source": "base",
+      "dimension_name": "Completeness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_translation_004",
+      "dimension_source": "base",
+      "dimension_name": "Correctness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_translation_001",
+      "dimension_source": "rubric",
+      "dimension_name": "Genealogical context",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_translation_001",
+      "dimension_source": "rubric",
+      "dimension_name": "Notation of uncertainty",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_translation_001",
+      "dimension_source": "rubric",
+      "dimension_name": "Accuracy",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_translation_001",
+      "dimension_source": "base",
+      "dimension_name": "Tool Arguments",
+      "llm_score": null,
+      "corrected_score": null,
+      "comment": null
+    },
+    {
+      "test_id": "ut_translation_001",
+      "dimension_source": "base",
+      "dimension_name": "Completeness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_translation_001",
+      "dimension_source": "base",
+      "dimension_name": "Correctness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_translation_007",
+      "dimension_source": "rubric",
+      "dimension_name": "Genealogical context",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_translation_007",
+      "dimension_source": "rubric",
+      "dimension_name": "Notation of uncertainty",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_translation_007",
+      "dimension_source": "rubric",
+      "dimension_name": "Accuracy",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_translation_007",
+      "dimension_source": "base",
+      "dimension_name": "Tool Arguments",
+      "llm_score": null,
+      "corrected_score": null,
+      "comment": null
+    },
+    {
+      "test_id": "ut_translation_007",
+      "dimension_source": "base",
+      "dimension_name": "Completeness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_translation_007",
+      "dimension_source": "base",
+      "dimension_name": "Correctness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_translation_002",
+      "dimension_source": "base",
+      "dimension_name": "Correctness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_translation_002",
+      "dimension_source": "base",
+      "dimension_name": "Completeness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_translation_002",
+      "dimension_source": "base",
+      "dimension_name": "Tool Arguments",
+      "llm_score": null,
+      "corrected_score": null,
+      "comment": null
+    },
+    {
+      "test_id": "ut_translation_002",
+      "dimension_source": "rubric",
+      "dimension_name": "Accuracy",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_translation_002",
+      "dimension_source": "rubric",
+      "dimension_name": "Notation of uncertainty",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_translation_002",
+      "dimension_source": "rubric",
+      "dimension_name": "Genealogical context",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_translation_010",
+      "dimension_source": "rubric",
+      "dimension_name": "Genealogical context",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_translation_010",
+      "dimension_source": "rubric",
+      "dimension_name": "Notation of uncertainty",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_translation_010",
+      "dimension_source": "rubric",
+      "dimension_name": "Accuracy",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_translation_010",
+      "dimension_source": "base",
+      "dimension_name": "Tool Arguments",
+      "llm_score": null,
+      "corrected_score": null,
+      "comment": null
+    },
+    {
+      "test_id": "ut_translation_010",
+      "dimension_source": "base",
+      "dimension_name": "Completeness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_translation_010",
+      "dimension_source": "base",
+      "dimension_name": "Correctness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_translation_005",
+      "dimension_source": "base",
+      "dimension_name": "Correctness",
+      "llm_score": 3,
+      "corrected_score": 1,
+      "comment": "No actual FamilySearch records were returned, so the core task of retrieving Patrick Flynn genealogical data was not fulfilled."
+    },
+    {
+      "test_id": "ut_translation_005",
+      "dimension_source": "base",
+      "dimension_name": "Completeness",
+      "llm_score": 3,
+      "corrected_score": 1,
+      "comment": "The response failed to perform the required search output (no records, no matches, no results), only describing internal workflow instead"
+    },
+    {
+      "test_id": "ut_translation_005",
+      "dimension_source": "base",
+      "dimension_name": "Tool Arguments",
+      "llm_score": null,
+      "corrected_score": null,
+      "comment": null
+    },
+    {
+      "test_id": "ut_translation_003",
+      "dimension_source": "base",
+      "dimension_name": "Correctness",
+      "llm_score": 1,
+      "corrected_score": 1,
+      "comment": null
+    },
+    {
+      "test_id": "ut_translation_003",
+      "dimension_source": "base",
+      "dimension_name": "Completeness",
+      "llm_score": 1,
+      "corrected_score": 1,
+      "comment": null
+    },
+    {
+      "test_id": "ut_translation_003",
+      "dimension_source": "base",
+      "dimension_name": "Tool Arguments",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_translation_012",
+      "dimension_source": "base",
+      "dimension_name": "Correctness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_translation_012",
+      "dimension_source": "base",
+      "dimension_name": "Completeness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_translation_012",
+      "dimension_source": "base",
+      "dimension_name": "Tool Arguments",
+      "llm_score": null,
+      "corrected_score": null,
+      "comment": null
+    },
+    {
+      "test_id": "ut_translation_012",
+      "dimension_source": "rubric",
+      "dimension_name": "Accuracy",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_translation_012",
+      "dimension_source": "rubric",
+      "dimension_name": "Notation of uncertainty",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_translation_012",
+      "dimension_source": "rubric",
+      "dimension_name": "Genealogical context",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_translation_008",
+      "dimension_source": "base",
+      "dimension_name": "Correctness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_translation_008",
+      "dimension_source": "base",
+      "dimension_name": "Completeness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_translation_008",
+      "dimension_source": "base",
+      "dimension_name": "Tool Arguments",
+      "llm_score": null,
+      "corrected_score": null,
+      "comment": null
+    },
+    {
+      "test_id": "ut_translation_008",
+      "dimension_source": "rubric",
+      "dimension_name": "Accuracy",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_translation_008",
+      "dimension_source": "rubric",
+      "dimension_name": "Notation of uncertainty",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_translation_008",
+      "dimension_source": "rubric",
+      "dimension_name": "Genealogical context",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_translation_009",
+      "dimension_source": "rubric",
+      "dimension_name": "Genealogical context",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_translation_009",
+      "dimension_source": "rubric",
+      "dimension_name": "Notation of uncertainty",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_translation_009",
+      "dimension_source": "rubric",
+      "dimension_name": "Accuracy",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_translation_009",
+      "dimension_source": "base",
+      "dimension_name": "Tool Arguments",
+      "llm_score": null,
+      "corrected_score": null,
+      "comment": null
+    },
+    {
+      "test_id": "ut_translation_009",
+      "dimension_source": "base",
+      "dimension_name": "Completeness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_translation_009",
+      "dimension_source": "base",
+      "dimension_name": "Correctness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    }
+  ]
+}

--- a/eval/runlogs/unit/translation/v1_2026-06-22_19-33-09.json
+++ b/eval/runlogs/unit/translation/v1_2026-06-22_19-33-09.json
@@ -1,0 +1,2177 @@
+{
+  "schema_version": 2,
+  "skill": "translation",
+  "version": 1,
+  "released": false,
+  "releasable": true,
+  "invocation": "skill",
+  "timestamp": "2026-06-22_19-33-09",
+  "harness_version": "0.1.0",
+  "model": "claude-sonnet-4-6",
+  "judge_prompt_hash": "adea6e4cb2c9ddf0c436c31e893da766866cc67ed749df0a7c6b8a9df52c6914",
+  "snapshot": {
+    "packages/engine/plugin/skills/translation/SKILL.md": "---\nname: translation\nmodel: claude-sonnet-4-6\ndescription: Genealogy-specific translation and paleography assistance for\n  historical records in German, French, Spanish, Italian, Dutch, Latin, and\n  Portuguese. Covers period handwriting (Kurrentschrift, S\u00fctterlin), Latin\n  abbreviations in parish registers, genealogy-specific vocabulary, and\n  record-type conventions by language and era. Outputs translations and\n  term glosses to the user; does not modify project files. Use when the user says\n  \"translate this record\", \"what does this say?\", \"German church record\",\n  \"Latin abbreviations\", \"read this handwriting\", \"French notarial record\",\n  \"what does [foreign word] mean?\", when a record is in a non-English\n  Western language, or when record-extraction encounters text it cannot\n  parse due to language or script. Do NOT use when the user wants to\n  extract assertions from an English record (use record-extraction), wants\n  historical context about a place (use historical-context), or wants a\n  locality guide (use locality-guide).\n---\n\n# Translation\n\n**Narration:** Read `researcher_profile.narration_guidance` from `research.json` and apply it as your narration style for this invocation. If absent, default to a one-line preamble per action.\n\nProvides genealogy-specific translation and paleography assistance\nfor historical records in Western European languages. Genealogical\nrecords use specialized vocabulary, period handwriting styles, and\nabbreviation systems that general translation tools miss.\n\n## GPS grounding\n\nThis skill implements BCG standards 23, 24, 29, 32, and 6 (read period scripts correctly, read words in their period meaning, transcribe the entire item exactly, follow Chicago conventions for foreign text) \u2014 see `references/gps-translation-standards.md`. The operational rules live in the Steps below.\n\n**Critical principle:** A translation is a derivative source. Always\npreserve the original text alongside any translation. When a\ntranslation conflicts with the original, the original governs.\n\n**Reference files \u2014 load on demand:**\n- `references/gps-translation-standards.md` \u2014 detailed GPS standard\n  application to translation work\n- `references/vocabulary-and-record-structures.md` \u2014 vocabulary\n  tables, abbreviation tables, and record-structure templates\n\n## Languages supported\n\nGerman, French, Spanish, Italian, Dutch, Latin, Portuguese.\n\n| Language | Period concerns |\n|----------|----------------|\n| **German** | Kurrentschrift (1500s-1940s), S\u00fctterlin (1911-1941), Fraktur print |\n| **French** | Old French orthography, legal formulae, regional dialects |\n| **Spanish** | Colonial-era abbreviations, regional terminology |\n| **Italian** | Latin-Italian mix in early registers, regional dialects |\n| **Dutch** | Similar to German script pre-1800, Dutch Reformed terminology |\n| **Latin** | Abbreviations, case declensions, church formulae |\n| **Portuguese** | Brazilian vs. European Portuguese, colonial records |\n\n## Reading images\n\nTranslation works on text, or on an image that is already in the\nconversation. It does not fetch images itself.\n\n- **Image already in the conversation** \u2014 uploaded by the user, or\n  pasted from a FamilySearch, Ancestry, MyHeritage, FindMyPast, or\n  FindAGrave record viewer or PDF: read it in-context and attempt the\n  paleographic reading directly. No tool call is needed.\n- **Only an image URL, no image** \u2014 translation cannot open URLs. Ask\n  the user to open the link in the record viewer and paste or attach\n  the image. A record handed off from `record-extraction` arrives with\n  its image already in context.\n\n## Steps\n\n### 1. Identify the language and record type\n\nFrom the text or context provided by the user, determine:\n- Language (German, French, Latin, etc.)\n- Record type (baptism, marriage, burial, civil registration,\n  notarial, etc.)\n- Period (affects script, abbreviations, and formulae)\n\nLoad `references/vocabulary-and-record-structures.md` to use the\nrecord-structure templates as constraints when deciphering text.\n\n### 2. Transcribe the original text\n\nBefore translating, produce a faithful transcription:\n- Reproduce wording, spelling, abbreviations, and numbering exactly.\n- Handle obsolete letterforms: long s as \"s\" (not \"f\"), thorn as\n  \"th\" (not \"y\"), double-f capital as \"F\" (not \"ff\").\n- Include the entire item \u2014 headings, column labels, marginal notes.\n- Annotate damage with [illegible], [damaged], or [?reading].\n- Mark transcription boundaries clearly.\n\nIf the user provides their own transcription, review it for\naccuracy before translating.\n\n### 3. Translate and annotate\n\nProvide:\n- Full English translation (labeled as derivative)\n- Ambiguous readings flagged with [?]\n- Abbreviation expansions (abbreviated form shown alongside)\n- Period-specific meanings explained where they differ from modern\n- Formulaic language explained in plain English\n\n### 4. Extract genealogically relevant information\n\nHighlight:\n- **Names** with roles (subject, parent, godparent, witness) \u2014 in\n  original form, not anglicized\n- **Dates** (event date, not just document date)\n- **Places** (parish, town, jurisdiction)\n- **Relationships** stated in the document\n- **Status** (legitimate/illegitimate, single/widowed, occupation)\n\n### 5. Suggest next steps\n\nAfter translation, offer:\n- \"Extract assertions from this record?\" (record-extraction)\n- \"Link [person] to the tree?\" (person-evidence)\n\nThe translation is a working tool. Record-extraction should cite\nthe original record, not the translation.\n\n## Example\n\n**User:** *\"Read this German baptism entry: 'Den 12ten M\u00e4rtz 1789 ist\ndem Joh. Schmid und seiner Ehefrau Anna Maria ein S\u00f6hnlein gebohren und\nauf den Nahmen Georg getauft worden. Pathe: Georg Ba[u/v]er.'\"*\n\n**Response:**\n\n*Original (as written):* Den 12ten M\u00e4rtz 1789 \u2026 ein S\u00f6hnlein gebohren\nund \u2026 auf den Nahmen Georg getauft worden. Pathe: Georg Ba[?]er.\n\n*Translation (derivative \u2014 the original governs):* On 12 March 1789, a\nlittle son was born to Joh[ann] Schmid and his wife Anna Maria, and\nbaptized Georg. Godfather: Georg Bauer [surname reading uncertain \u2014\ncould be *Baver*].\n\n*What matters genealogically:*\n- **gebohren / getauft** \u2014 *born* vs. *baptized*: this entry gives the\n  **birth** date (12 March); baptism followed. Record both; don't\n  conflate them.\n- **Pathe** \u2014 godfather/sponsor, not a parent \u2014 a FAN figure worth\n  researching; the child sharing the name *Georg* hints at kinship.\n- **S\u00f6hnlein** \u2014 diminutive of *Sohn*, confirms a male child.\n- **Joh.** expanded to *Johann* (flagged as abbreviated). Names kept in\n  original form (Johann, not John).\n- The godfather's surname is flagged `[?]`, not silently resolved.\n\n*Next step:* \"Extract these into research.json?\" (record-extraction)\n\n## Paleography guidance\n\n**German Kurrentschrift / S\u00fctterlin:**\n- Common confusion pairs: e/n, u/n, m/nn, f/s, k/t, C/E\n- Long s vs. round s is position-dependent\n- Capitals often unrecognizable without training\n- Minimal word spacing; ligatures change letterforms\n\n**Approach for unclear text:** Identify the record type first \u2014\nformulaic structure constrains which words are possible. Work\ncharacter by character through ambiguous passages.\n\n## Output conventions\n\nThese conventions govern how the translation is written up:\n\n- **Date conventions vary.** German: day.month.year. French: day\n  month year. Latin: varies. Convert to ISO 8601 in the summary.\n- **Genitive names aren't errors.** \"Johannis\" is genitive of\n  \"Johannes\" \u2014 normalize to nominative form.\n- **Foreign text in English narrative.** Italicize foreign words\n  (not proper nouns). Quotations in the original language get\n  quotation marks, not italics.\n\n## Decision rules\n\n| Situation | Action |\n|-----------|--------|\n| Record is partly English, partly foreign | Translate only the foreign portions. Note which parts are already English. |\n| Mixed Latin/vernacular record (common in early Italian/German registers) | Translate both layers. Note where the scribe switches language. |\n| User provides an image but no transcription | If the image is in the conversation, read it in-context (see \"Reading images\"). If you have only an image URL, ask the user to paste or attach the image. Then attempt paleographic reading, flag every uncertain character, and present the transcription for user confirmation before translating. |\n| User provides text they already transcribed | Review for common misreadings (f/long-s, C/E confusion) before translating. |\n| A word has no clear modern equivalent | Keep the original term in italics, provide the closest English explanation in parentheses. |\n| The record uses regional dialect | Note the dialect and translate based on regional meaning, not standard-language meaning. |\n| User asks \"what does [term] mean?\" without a full record | Answer directly with the genealogical meaning. Load vocabulary reference if needed. No need to run the full translation workflow. |\n| User wants historical context about WHY a record exists | Hand off to historical-context. This skill translates WHAT the record says. |\n| User wants citation formatting for the translated record | Hand off to citation after record-extraction creates the source entry. |\n\n## Re-invocation behavior\n\nWrites nothing \u2014 no files, no `research.json` / `tree.gedcomx.json`. Safe to call repeatedly; each call is a fresh translation pass.\n",
+    "packages/engine/plugin/skills/translation/references/gps-translation-standards.md": "# GPS Translation Standards Reference\n\nGuidance for handling foreign-language and historical-script records\nin accordance with the Genealogical Proof Standard.\n\n## Translations Are Derivative Sources\n\nA translation is a derivative source. The original-language document\nremains the original record. When a researcher translates a record,\nthe translation is one step removed from the original \u2014 it reflects\nthe translator's interpretation of words, phrasing, and meaning.\n\nConsequences for the research pipeline:\n\n- Always preserve and cite the original-language text alongside any\n  translation.\n- When conflicts arise between a translation and the original, the\n  original governs.\n- A translation carries additional risk of error beyond what the\n  original already carries (scribe error, informant error, etc.).\n- Record the translator's identity and qualifications as part of the\n  source analysis, just as you would note a derivative record's\n  compiler.\n\n## Reading Handwriting Correctly (GPS Standard 23)\n\nResearchers must correctly read all legible handwriting in materials\nthey consult. For foreign-language records this means:\n\n- **Learn the script before reading the content.** German records\n  from the 1500s through 1941 use Kurrentschrift or Sutterlin, not\n  modern Latin letterforms. Reading these as Latin letters produces\n  systematic misreadings.\n- **Use the record's formulaic structure as a constraint.** When a\n  character is ambiguous, the record type (baptism, marriage, burial)\n  limits the set of plausible words. A baptism register will contain\n  \"getauft\" (baptized), not \"gestorben\" (died).\n- **Flag uncertain readings explicitly.** Mark unclear characters\n  with [?] or [illegible]. Never silently guess \u2014 especially for\n  names, which are the most consequential genealogical data.\n- **Distinguish similar letterforms systematically.** In Kurrent,\n  common confusion pairs include e/n, u/n, m/nn, f/long-s, k/t,\n  and C/E. Work through ambiguous passages character by character.\n\n## Understanding Period Meanings (GPS Standard 24)\n\nResearchers must understand all legible words, phrases, and\nstatements in the sources they consult \u2014 including the meaning for\nthe source's time and place. For translation work this means:\n\n- **Words change meaning over time.** A term in a 1650 German record\n  may not carry the same meaning it does in modern German. Always\n  consider the historical and regional context.\n- **Legal and ecclesiastical formulae have precise meanings.** Phrases\n  like \"filius legitimus\" or \"lediger Stand\" are technical terms with\n  specific legal implications, not casual descriptions.\n- **Regional vocabulary varies.** The same concept may use different\n  terms across dialects or jurisdictions. A word used in a Bavarian\n  parish register may differ from the Prussian equivalent.\n- **Do not impose modern meaning on archaic text.** Translate what\n  the scribe meant in context, not what the words might suggest to a\n  modern reader.\n\n## Transcription Standards (GPS Standard 29)\n\nWhen transcribing foreign-language records:\n\n- **Include the entire item.** Transcriptions cover the complete\n  record \u2014 headings, insertions, notations, endorsements, front and\n  back, and any attachments.\n- **Annotate damage and illegibility.** Use square brackets or\n  footnotes to indicate where a source is damaged, illegible, omits\n  expected information, or provides unexpected information.\n- **Preserve format when relevant.** When layout matters (column\n  headings, tabular registers), reflect the original's format, line\n  lengths, and physical features.\n- **Mark transcription boundaries.** Clearly identify where the\n  transcription begins and ends, so readers know exactly what is\n  quoted from the source.\n\n## Rendering Original Text Exactly (GPS Standard 32)\n\nWhen transcribing or quoting foreign-language sources:\n\n- **Reproduce wording, spelling, and abbreviations exactly.** Do not\n  modernize spelling, expand abbreviations silently, or correct\n  apparent errors. Show the text as written.\n- **Preserve numbering, superscripts, and similar features.** Render\n  the text as faithfully as the output format allows.\n- **Handle obsolete letter forms correctly:**\n  - The long s (also written as a tall form resembling f) is\n    transcribed as \"s,\" not as \"f.\"\n  - The thorn (an Old English / early Germanic letter for \"th\") is\n    transcribed as \"th\" or with the thorn character, not as \"y.\"\n  - The double-f ligature used as a capital F in some traditions is\n    transcribed as \"F,\" not as \"ff.\"\n  - When the original letterform is available in the output character\n    set, use it. Otherwise use the modern equivalent \u2014 never a\n    look-alike with a different meaning.\n- **Use square brackets for insertions.** Short editorial additions\n  go in [square brackets]. Longer commentary goes before or after the\n  transcription as clearly separated text or footnotes.\n- **Capitalization and punctuation.** Except at the beginnings and\n  ends of quotations, show these exactly as they appear in the\n  original.\n\n## Foreign-Language Handling (GPS Standard 6 / Chicago Manual)\n\nThe genealogical documentation standard follows Chicago Manual of\nStyle conventions for foreign-language material:\n\n- **Italicize foreign words** that are not proper nouns when they\n  appear in English-language narrative text.\n- **Do not italicize proper nouns** (personal names, place names)\n  even when they are in a foreign language.\n- **Quotations in the original language** are not italicized \u2014 they\n  are placed in quotation marks or block-quote format, same as\n  English quotations.\n- **Translate for the reader.** When quoting foreign-language text in\n  a finished product, provide an English translation \u2014 either inline\n  in parentheses, in a footnote, or immediately following the\n  quotation.\n- **Preserve original-language names.** Do not anglicize personal\n  names. \"Johann\" remains \"Johann,\" not \"John.\" Note the English\n  equivalent only if it aids understanding.\n\n## Abstracts vs. Transcriptions vs. Translations\n\nThese are distinct operations with different rules:\n\n| Operation | What it does | Key rules |\n|-----------|-------------|-----------|\n| **Transcription** | Reproduces the original text character-for-character in modern type | Exact rendering; annotate damage/illegibility |\n| **Abstract** | Condenses the record, omitting formulaic/redundant wording | Quote any phrases of 3+ words from the original; do not modernize names or dates |\n| **Translation** | Converts from one language to another | Derivative source; preserve and cite the original alongside |\n\nFor genealogical translation work, the typical workflow is:\n\n1. Transcribe the original-language text (following transcription standards)\n2. Translate the transcription into English\n3. Annotate ambiguous readings, period-specific meanings, and abbreviation expansions\n4. Present both the transcription and translation together\n",
+    "packages/engine/plugin/skills/translation/references/vocabulary-and-record-structures.md": "# Genealogy Vocabulary, Abbreviations, and Record Structures\n\nQuick-reference tables for genealogy-specific translation work.\n\n## Common Genealogy Vocabulary\n\n| Term | Language | Meaning |\n|------|----------|---------|\n| Taufbuch / Taufregister | German | Baptismal register |\n| Trauungsbuch | German | Marriage register |\n| Sterbebuch / Totenbuch | German | Death/burial register |\n| Pate / Patin | German | Godfather / Godmother |\n| Eheleute | German | Married couple |\n| lediger Stand | German | Unmarried status |\n| acte de naissance | French | Birth certificate |\n| acte de mariage | French | Marriage certificate |\n| acte de deces | French | Death certificate |\n| temoin | French | Witness |\n| parrain / marraine | French | Godfather / Godmother |\n| partida de bautismo | Spanish | Baptismal record |\n| partida de matrimonio | Spanish | Marriage record |\n| partida de defuncion | Spanish | Death record |\n| padrino / madrina | Spanish | Godfather / Godmother |\n| obiit | Latin | He/she died |\n| natus/nata est | Latin | He/she was born |\n| baptizatus/a est | Latin | He/she was baptized |\n| matrimonium contraxerunt | Latin | They contracted marriage |\n| filius/filia legitimus/a | Latin | Legitimate son/daughter |\n| patrini | Latin | Godparents |\n| testes | Latin | Witnesses |\n\n## Latin Abbreviations in Church Registers\n\n| Abbreviation | Full form | Meaning |\n|-------------|-----------|---------|\n| bapt. | baptizatus/a | baptized |\n| n. / nat. | natus/a | born |\n| ob. | obiit | died |\n| sep. / s. | sepultus/a | buried |\n| conj. | conjux | spouse |\n| fil. | filius/filia | son/daughter |\n| leg. | legitimus/a | legitimate |\n| illeg. | illegitimus/a | illegitimate |\n| vid. | vidua/viduus | widow/widower |\n| d.d. | de dato | dated |\n| SS. | sanctissimus/sanctorum | most holy / of the saints |\n| par. | parentes / parochia | parents / parish |\n| test. | testes | witnesses |\n| a.d. | anno domini | in the year of the Lord |\n| ej. / ejd. | ejusdem | of the same (month/year) |\n| sup. | supra | above (referring to previously mentioned) |\n\n## German Abbreviations\n\n| Abbreviation | Full form | Meaning |\n|-------------|-----------|---------|\n| geb. | geboren | born |\n| gest. | gestorben | died |\n| get. | getauft | baptized |\n| verh. | verheiratet | married |\n| Ehefr. | Ehefrau | wife |\n| Ehem. | Ehemann | husband |\n| led. | ledig | unmarried |\n| verw. | verwitwet | widowed |\n| ev. | evangelisch | Protestant/Lutheran |\n| kath. | katholisch | Catholic |\n| d. / des | des/der | of the (genitive) |\n\n## Record Structure Templates\n\nDifferent record types follow predictable patterns. Use these to\nconstrain ambiguous readings \u2014 if you know the record type, you\nknow what words are possible in each position.\n\n### Catholic baptism register (Latin)\n\n> Die [date] baptizatus/a est [name], filius/filia legitimus/a\n> [father's name] et [mother's maiden name], conjugum.\n> Patrini fuerunt [godfather] et [godmother].\n\nTranslation: \"On [date] was baptized [name], legitimate son/daughter\nof [father] and [mother], married couple. The godparents were\n[godfather] and [godmother].\"\n\n### German church marriage record\n\n> [Date] sind ehelich verbunden worden der Junggesell [groom name],\n> [groom's father]'s ehelicher Sohn, und die Jungfrau [bride name],\n> [bride's father]'s eheliche Tochter.\n> Zeugen: [witness 1], [witness 2].\n\nTranslation: \"[Date] were married the bachelor [groom], legitimate\nson of [father], and the maiden [bride], legitimate daughter of\n[father]. Witnesses: [witness 1], [witness 2].\"\n\n### French civil birth record (post-1792)\n\n> L'an [year], le [day] du mois de [month], par-devant nous [official],\n> officier de l'etat civil de la commune de [town], a comparu\n> [declarant], [occupation], lequel nous a presente un enfant du sexe\n> [masculin/feminin], ne le [date] a [time], auquel il a declare\n> vouloir donner les prenoms de [given names].\n\n### German death register\n\n> [Date] ist gestorben [name], des [father's name] und der [mother's\n> name] eheliche(r) Sohn/Tochter, im Alter von [age] Jahren.\n> Begraben den [burial date].\n\nTranslation: \"[Date] died [name], legitimate son/daughter of [father]\nand [mother], at the age of [age] years. Buried on [burial date].\"\n",
+    "eval/tests/unit/translation/damaged-kurrent-uncertainty.json": "{\n  \"input\": {\n    \"user_message\": \"Can you read and translate this German Kurrent baptism entry? My transcription is shaky in a few spots \u2014 the ink is faded and some letters are hard to tell apart: 'Den 3ten [M..]rz 1812 ist getauft worden Johann Georg, ehelicher Sohn des Joh. Sch[m/n]ider, Tagel\u00f6hner, und seiner Ehefrau Anna Maria. Pathe war Georg [unleserlich], B\u00fcrger allhier.'\"\n  },\n  \"judge_context\": [\n    \"Should translate the legible structure: on the 3rd of [March?] 1812 was baptized Johann Georg, legitimate son of Joh. Sch[?]ider, a day-labourer, and his wife Anna Maria; the godfather was Georg [illegible], a citizen here.\",\n    \"Should explicitly FLAG the uncertain readings rather than silently picking one \u2014 the partly illegible month ([M..]rz is almost certainly M\u00e4rz/March but should be marked as inferred), the surname affected by the m/n Kurrent confusion (Schmider vs Schnider), and the illegible godfather surname. Use [?] or equivalent; do NOT invent the godfather's surname.\",\n    \"Should keep names in original German form (Johann Georg, Anna Maria) and explain the genealogically significant terms: `ehelicher Sohn` (legitimate son \u2014 relevant to legitimacy status), `Tagel\u00f6hner` (day-labourer \u2014 the father's occupation), `Pathe` (godparent, a FAN-club figure useful for research), `B\u00fcrger allhier` (citizen of this place \u2014 a status/residence clue).\",\n    \"Should note that the m/n confusion pair is a known Kurrent paleographic hazard, so the surname reading is provisional and the genealogist should confirm against the original image or other records before relying on it.\"\n  ],\n  \"test\": {\n    \"id\": \"ut_translation_006\",\n    \"skill\": \"translation\",\n    \"type\": \"positive\"\n  }\n}\n",
+    "eval/tests/unit/translation/dutch-reformed-baptism-patronymics.json": "{\n  \"input\": {\n    \"user_message\": \"Can you translate this Dutch Reformed baptism record? 'Den 5 Maart 1698 is gedoopt Pieter, soon van Jan Hendricksz en Maria Willems. Getuigen waren Cornelis de Vries en Aaltje Jans.'\"\n  },\n  \"judge_context\": [\n    \"Should translate the structure: on 5 March 1698, Pieter was baptized, son of Jan Hendricksz and Maria Willems; the witnesses were Cornelis de Vries and Aaltje Jans.\",\n    \"Should recognize the patronymics and explain them: `Hendricksz` means 'son of Hendrik' (so the father Jan is the son of a Hendrik), and `Willems` / `Jans` are patronymic forms ('Willem's [child]', 'Jan's [child]'). Should flag that in this era Dutch records use patronymics rather than fixed hereditary surnames, so the researcher should not treat 'Hendricksz' as an inherited family surname.\",\n    \"Should explain `getuigen` as the witnesses / baptismal sponsors (FAN-club figures worth researching), and `soon van` as 'son of'.\",\n    \"Should keep the names in their original Dutch form (Pieter, Jan, Maria, Cornelis, Aaltje), not anglicize them.\"\n  ],\n  \"test\": {\n    \"id\": \"ut_translation_011\",\n    \"skill\": \"translation\",\n    \"type\": \"positive\"\n  }\n}\n",
+    "eval/tests/unit/translation/french-civil-birth.json": "{\n  \"input\": {\n    \"scenario\": null,\n    \"user_message\": \"Translate this French civil birth record: 'L'an mil huit cent quarante-trois, le quinze mars, devant nous, maire et officier de l'\u00e9tat civil de la commune de Saint-Malo, a comparu Jean Baptiste Lef\u00e8vre, cultivateur, \u00e2g\u00e9 de trente ans, lequel nous a pr\u00e9sent\u00e9 un enfant du sexe masculin, n\u00e9 hier \u00e0 six heures du matin, de lui d\u00e9clarant et de Marie Anne Dubois, son \u00e9pouse, et auquel il a d\u00e9clar\u00e9 vouloir donner le pr\u00e9nom de Guillaume.'\"\n  },\n  \"judge_context\": [\n    \"Should translate the structure: on 15 March 1843, before the mayor and civil registrar of the commune of Saint-Malo, Jean Baptiste Lef\u00e8vre (a farmer, aged 30) presented a male child born the previous day at 6 a.m., to himself (the declarant) and Marie Anne Dubois his wife, to be named Guillaume.\",\n    \"Should keep names in their original French form (Jean Baptiste, Guillaume, Marie Anne Dubois) and note the English equivalents only if helpful, not silently anglicize them.\",\n    \"Should explain the genealogically significant terms: `officier de l'\u00e9tat civil` (civil registrar, who is the recorder), `a comparu` (appeared before \u2014 the formulaic opening of a French civil act), `cultivateur` (farmer \u2014 the father's occupation), `son \u00e9pouse` (his wife \u2014 establishes the marital relationship), `d\u00e9clarant` (the declarant, here the father).\",\n    \"Should flag that the record names both the father (Jean Baptiste Lef\u00e8vre) and the mother (Marie Anne Dubois) and states their relationship, making this a high-value parentage source, and should note the event date (birth) is 14 March 1843 \u2014 the day before the registration date of 15 March.\"\n  ],\n  \"test\": {\n    \"id\": \"ut_translation_004\",\n    \"skill\": \"translation\",\n    \"type\": \"positive\"\n  }\n}\n",
+    "eval/tests/unit/translation/german-kurrent-baptism.json": "{\n  \"input\": {\n    \"scenario\": null,\n    \"user_message\": \"Translate this German baptism record: 'Den 15. M\u00e4rz 1845 wurde Johann Friedrich, ehelicher Sohn des Thomas Flynn, Bergmann, und seiner Ehefrau Maria geb. Kelly, getauft. Taufpaten: Patrick O'Brien und Bridget Mahoney.'\"\n  },\n  \"judge_context\": [\n    \"Should faithfully render the structural shape of the entry \u2014 date, baptized child, parents (with the wife's maiden name preserved via n\u00e9e), godparents \u2014 in clear English\",\n    \"Should identify and explain each genealogically significant term: `ehelicher Sohn` (legitimate son \u2014 distinct from `unehelicher` illegitimate, which would have different inheritance implications), `Bergmann` (miner \u2014 occupational evidence consistent with Schuylkill County coal country), `geb.` (n\u00e9e/born \u2014 the wife's maiden name follows), `Taufpaten` (godparents \u2014 often relatives or close family friends, useful for FAN research)\",\n    \"Should flag the cultural mismatch: the names (Flynn, Kelly, O'Brien, Mahoney) are Irish, but the record is in German. This suggests an Irish family using a German parish, which is documented in Pennsylvania mining communities where the resident priest was German-speaking. Worth noting for the research narrative\",\n    \"Should preserve proper names in their original form (Johann Friedrich, Thomas Flynn, Maria, Patrick O'Brien, Bridget Mahoney) rather than translating them \u2014 names need to remain matchable across records\"\n  ],\n  \"test\": {\n    \"id\": \"ut_translation_001\",\n    \"skill\": \"translation\",\n    \"type\": \"positive\"\n  }\n}\n",
+    "eval/tests/unit/translation/italian-mixed-latin-burial.json": "{\n  \"input\": {\n    \"user_message\": \"Can you translate this old Italian burial record for me? 'Ad\u00ec 14 Marzo 1748. Giovanni Battista Rossi, figlio del fu Antonio, d'et\u00e0 d'anni sessanta in circa, munito de' Santissimi Sacramenti, rese l'anima a Dio, ed il suo corpo fu sepolto nella chiesa parrocchiale di San Lorenzo. Anima eius requiescat in pace.'\"\n  },\n  \"judge_context\": [\n    \"Should translate the structure: on 14 March 1748, Giovanni Battista Rossi, son of the late Antonio, aged about sixty, having received the holy sacraments, died (gave up his soul to God) and his body was buried in the parish church of San Lorenzo; 'may his soul rest in peace.'\",\n    \"Should recognize and note that the record is in TWO languages \u2014 Italian for the body of the entry and Latin for the closing formula ('Anima eius requiescat in pace') \u2014 and should translate both layers rather than ignoring or mis-attributing the Latin closing.\",\n    \"Should explain the genealogically significant terms: `del fu Antonio` (fu = 'the late' \u2014 signals the father had already died, a generational clue), `d'et\u00e0 d'anni sessanta in circa` (aged about sixty \u2014 yields an approximate birth year of ~1688 for further research), `munito de' Santissimi Sacramenti` (received the last rites \u2014 indicates a Catholic death that was not sudden).\",\n    \"Should keep names in their original Italian form (Giovanni Battista Rossi, not 'John Baptist') and should note that the stated age at death gives an estimated birth year the researcher can use to look for a baptism record.\"\n  ],\n  \"test\": {\n    \"id\": \"ut_translation_007\",\n    \"skill\": \"translation\",\n    \"type\": \"positive\"\n  }\n}\n",
+    "eval/tests/unit/translation/latin-marriage-record.json": "{\n  \"input\": {\n    \"scenario\": null,\n    \"user_message\": \"Translate this Latin Catholic marriage record: 'Die 12 Maii 1845, in ecclesia parochiali S. Patricii, matrimonium iniverunt Thomas Flynn, filius Joannis et Mariae, et Maria Kelly, filia Patricii et Brigittae, praesentibus testibus Patricio O'Brien et Brigitta Mahoney. Parochus: Rev. J. Murphy.'\"\n  },\n  \"judge_context\": [\n    \"Should translate the structural shape: 'On 12 May 1845, in the parish church of St. Patrick, Thomas Flynn (son of John and Mary) and Mary Kelly (daughter of Patrick and Brigid) entered into matrimony, with the witnesses Patrick O'Brien and Brigid Mahoney present. Parish priest: Rev. J. Murphy.'\",\n    \"Should explain each genealogically significant term: `matrimonium iniverunt` (entered into matrimony \u2014 the formulaic Latin for marriage), `filius/filia` (son of / daughter of \u2014 this is the parent-naming convention that makes Catholic Latin marriage records valuable for parentage research), `praesentibus testibus` (with the witnesses present \u2014 these are the named witnesses, distinct from the bridal couple), `parochus` (parish priest, who is the recorder)\",\n    \"Should flag that Latin records often Latinize names \u2014 'Joannes' is the Latin form of John, 'Brigitta' of Brigid, 'Patricius' of Patrick. The genealogist should expect this when matching parental names to other records\",\n    \"Should note that the named parents (Joannes & Maria for Thomas; Patricius & Brigitta for Maria) are crucial for parentage research \u2014 a Catholic Latin marriage record typically names both sets of parents, making it a high-value source for two generations at once\"\n  ],\n  \"test\": {\n    \"id\": \"ut_translation_002\",\n    \"skill\": \"translation\",\n    \"type\": \"positive\"\n  }\n}\n",
+    "eval/tests/unit/translation/latin-will-ambiguous-nepos.json": "{\n  \"input\": {\n    \"user_message\": \"Can you translate this Latin will excerpt for me? 'In nomine Dei, amen. Ego Bartholomaeus Flandrensis, senex et infirmus corpore, sanus tamen mente, lego et relinquo Joanni nepoti meo domum meam cum omnibus bonis mobilibus et immobilibus. Item lego Catharinae, filiae quondam fratris mei Petri, viginti florenos. Actum in festo Sancti Galli, anno Domini MDCXLII.'\"\n  },\n  \"judge_context\": [\n    \"The kinship term `nepos` (here in the dative, `nepoti meo`) is genuinely ambiguous in early-modern Latin \u2014 it can mean either 'grandson' or 'nephew'. A correct response should FLAG this ambiguity and note that the two readings place the heir very differently in the family tree (two generations below the testator vs. a sibling's child), rather than silently committing to one reading. What is graded is whether the ambiguity is flagged, not which reading is preferred \u2014 confidently translating it as just 'grandson' or just 'nephew' with no flag is the failure mode.\",\n    \"Should recognize `in festo Sancti Galli` as a liturgical feast-day date \u2014 the Feast of St. Gall, 16 October \u2014 and give the calendar date (or at minimum flag that it is a feast day requiring a date lookup), rather than leaving it as an untranslated saint's name with no date.\",\n    \"Should correctly read the Roman-numeral year `MDCXLII` as 1642.\",\n    \"Should translate `quondam` (in `quondam fratris mei Petri`) as 'late' / 'deceased', surfacing that the testator's brother Peter was already dead \u2014 a genealogically significant fact for placing Catharina \u2014 and should keep the names in their original Latin form (Bartholomaeus, Joannes, Catharina, Petrus), not anglicize them.\",\n    \"Should convey the overall sense: Bartholomew Flandrensis, old and infirm in body but sound of mind, leaves his house and all movable and immovable goods to his nepos Joannes, and twenty florins to Catharina, daughter of his late brother Peter, on the Feast of St. Gall, 1642.\"\n  ],\n  \"test\": {\n    \"id\": \"ut_translation_010\",\n    \"skill\": \"translation\",\n    \"type\": \"positive\"\n  }\n}\n",
+    "eval/tests/unit/translation/negative-find-more-records.json": "{\n  \"input\": {\n    \"scenario\": \"mid-research-flynn\",\n    \"user_message\": \"Can you find more FamilySearch records for Patrick Flynn?\"\n  },\n  \"judge_context\": [\n    \"Should route to search-records rather than treating this as a translation task \u2014 there is no foreign-language text supplied to translate.\",\n    \"A correct response searches FamilySearch for the named person rather than producing a translation or term glossary.\"\n  ],\n  \"mcp_fixtures\": [],\n  \"negative\": {\n    \"correct_skill\": [\n      \"search-records\"\n    ],\n    \"explanation\": \"The user asks to find additional records \u2014 a record-search task. translation translates SPECIFIC foreign-language text; there is no foreign text to translate here, so it should not activate.\"\n  },\n  \"test\": {\n    \"id\": \"ut_translation_005\",\n    \"skill\": \"translation\",\n    \"type\": \"negative\"\n  }\n}\n",
+    "eval/tests/unit/translation/negative-search-wikipedia.json": "{\n  \"input\": {\n    \"scenario\": null,\n    \"user_message\": \"Look up Kirchenbuch on Wikipedia \u2014 I want to understand what kind of records these are.\"\n  },\n  \"judge_context\": [\n    \"Should route to search-wikipedia rather than translating the word 'Kirchenbuch' in lieu of a Wikipedia summary\"\n  ],\n  \"mcp_fixtures\": [\n    \"wikipedia-search-kirchenbuch\"\n  ],\n  \"negative\": {\n    \"correct_skill\": [\n      \"search-wikipedia\"\n    ],\n    \"explanation\": \"The user explicitly named Wikipedia and asked to look up a concept. search-wikipedia is the saved-Wikipedia-summary workflow. translation translates SPECIFIC text content from a foreign language to English; it doesn't produce Wikipedia summaries about record types.\"\n  },\n  \"test\": {\n    \"id\": \"ut_translation_003\",\n    \"skill\": \"translation\",\n    \"type\": \"negative\"\n  }\n}\n",
+    "eval/tests/unit/translation/portuguese-brazilian-marriage.json": "{\n  \"input\": {\n    \"user_message\": \"Can you translate this Brazilian Portuguese marriage record? 'Aos vinte dias do m\u00eas de junho de mil setecentos e oitenta, na igreja matriz de Nossa Senhora do Ros\u00e1rio, recebi em matrim\u00f4nio a Manuel Ferreira, natural de Lisboa, com Joana Maria, parda forra, filha natural de In\u00eas, escrava de Ant\u00f4nio Gomes. Testemunhas: Jo\u00e3o da Costa e Sebasti\u00e3o Dias.'\"\n  },\n  \"judge_context\": [\n    \"Should translate the structure: on 20 June 1780, in the mother church (igreja matriz) of Our Lady of the Rosary, the priest married Manuel Ferreira, a native of Lisbon, to Joana Maria \u2014 a freed parda, natural daughter of In\u00eas, an enslaved woman of Ant\u00f4nio Gomes; the witnesses were Jo\u00e3o da Costa and Sebasti\u00e3o Dias.\",\n    \"Should explain the genealogically significant colonial status terms rather than flattening them: `parda forra` (a freed woman of mixed race \u2014 both a casta designation and manumission/freed status), `filha natural` (natural, i.e. illegitimate, daughter \u2014 a legitimacy status), and `escrava de Ant\u00f4nio Gomes` (an enslaved woman belonging to Ant\u00f4nio Gomes).\",\n    \"Should flag that for the mother In\u00eas, her enslaved status and her enslaver's name (Ant\u00f4nio Gomes) are critical research leads for tracing an enslaved ancestor, and that Joana's `forra` status indicates she had been freed \u2014 both central to Brazilian genealogical research.\",\n    \"Should render `igreja matriz` as the main/mother parish church and `natural de Lisboa` as 'native of Lisbon' (an origin clue for Manuel), and keep names in their original Portuguese form (Manuel Ferreira, Joana Maria, In\u00eas), not anglicize them.\"\n  ],\n  \"test\": {\n    \"id\": \"ut_translation_012\",\n    \"skill\": \"translation\",\n    \"type\": \"positive\"\n  }\n}\n",
+    "eval/tests/unit/translation/rubric.md": "# Translation Rubric\n\nGrading dimensions for translation unit tests. Evaluated by the LLM judge alongside the base rubric (correctness, completeness).\n\n## Accuracy\n\nDid the skill translate the text accurately, preserving the meaning of genealogical terms (names, places, dates, relationships, occupations)?\n\n- **pass:** Translation is faithful; genealogical terms (relationship words like Sohn/figlio, occupation labels, place names) preserve their precise meaning in the target language.\n- **partial:** Translation is mostly accurate but at least one genealogical term loses precision (e.g., a specific relationship term flattened to a generic equivalent).\n- **fail:** Translation distorts meaning of genealogical terms, or names/places are mistranslated as common nouns.\n\n## Notation of uncertainty\n\nDid the skill flag ambiguous words, archaic spellings, or abbreviations rather than silently guessing? Genealogical records often use period-specific terminology that has multiple possible meanings.\n\n- **pass:** Ambiguous terms are explicitly flagged with possible interpretations recorded; the genealogist can pick.\n- **partial:** Ambiguity is noted but the skill picks one interpretation without spelling out the alternative.\n- **fail:** Ambiguous terms are silently translated to one interpretation, with no indication the original was uncertain.\n\n## Genealogical context\n\nDid the skill identify and explain genealogically significant terms (relationship words, legal terms, religious terminology) rather than providing a generic translation?\n\n- **pass:** Genealogically significant terms are explained when their translation would lose context \u2014 e.g., \"Pate\" (godfather) is translated and the relationship's research significance is noted.\n- **partial:** Significant terms are translated but their genealogical implications (kinship structure, legal status, sacrament-tied dating) aren't flagged.\n- **fail:** Translation is purely literal; the genealogist would have to research the cultural/legal context themselves.\n",
+    "eval/tests/unit/translation/single-term-lookup.json": "{\n  \"input\": {\n    \"user_message\": \"Quick question \u2014 in a Latin burial register I keep seeing the word 'relicta' written before a woman's name. What does it mean?\"\n  },\n  \"judge_context\": [\n    \"Should answer directly that `relicta` means 'widow' \u2014 literally 'the one left behind' / 'relict' \u2014 i.e. a woman whose husband has already died.\",\n    \"Should explain the genealogical significance: it tells the researcher the husband predeceased this record, so they can look for his death or burial before this date, and it confirms a prior marriage.\",\n    \"Should answer the single-term question concisely and directly WITHOUT demanding a full record or running a full transcription/translation workflow.\",\n    \"May helpfully note the masculine form `relictus` (widower) so the researcher recognizes the term for either spouse.\"\n  ],\n  \"test\": {\n    \"id\": \"ut_translation_008\",\n    \"skill\": \"translation\",\n    \"type\": \"positive\"\n  }\n}\n",
+    "eval/tests/unit/translation/spanish-colonial-baptism.json": "{\n  \"input\": {\n    \"user_message\": \"Can you translate this Spanish colonial baptism record? 'En la Ciudad de M\u00e9xico, a quince de enero de mil setecientos cincuenta, yo, el infrascrito cura, bautic\u00e9 solemnemente a Josefa Mar\u00eda, espa\u00f1ola, hija leg\u00edtima de Don Juan de Aguilar y de Do\u00f1a Mar\u00eda Ram\u00edrez. Fueron sus padrinos Don Pedro G\u00f3mez y Do\u00f1a Ana L\u00f3pez, a quienes advert\u00ed su obligaci\u00f3n y parentesco espiritual.'\"\n  },\n  \"judge_context\": [\n    \"Should translate the structure: in Mexico City, on 15 January 1750, the undersigned priest solemnly baptized Josefa Mar\u00eda, a Spaniard, legitimate daughter of Don Juan de Aguilar and Do\u00f1a Mar\u00eda Ram\u00edrez; her godparents were Don Pedro G\u00f3mez and Do\u00f1a Ana L\u00f3pez, whom the priest advised of their obligation and spiritual kinship.\",\n    \"Should explain the genealogically significant terms: `hija leg\u00edtima` (legitimate daughter \u2014 legitimacy status), `padrinos` (godparents \u2014 FAN-club figures, often relatives), `parentesco espiritual` (spiritual kinship \u2014 a relationship that created canonical marriage impediments, so worth noting), and `Don`/`Do\u00f1a` (honorifics signalling social standing).\",\n    \"Should treat `espa\u00f1ola` as a casta/racial designation typical of Spanish colonial records (indicating Spanish ancestry within the colonial caste system), not mistranslate it as merely the woman's nationality in a generic sense \u2014 and should note its significance for colonial Latin American research.\",\n    \"Should keep names in their original Spanish form (Josefa Mar\u00eda, Juan de Aguilar, not 'Josephine Mary' or 'John of Aguilar') and note that the named godparents are research leads.\"\n  ],\n  \"test\": {\n    \"id\": \"ut_translation_009\",\n    \"skill\": \"translation\",\n    \"type\": \"positive\"\n  }\n}\n",
+    "eval/fixtures/scenarios/mid-research-flynn/README.md": "# mid-research-flynn\n\nPatrick Flynn parentage research, mid-project.\n\n- **Objective:** Identify the parents of Patrick Flynn (b. ~1845, d. 1908)\n- **Questions:** q_001 (parentage, in_progress), q_002 (1850 census placement, resolved)\n- **Plans:** pl_001 (1850 census search, completed), pl_002 (parentage evidence, active)\n- **Log:** 5 entries \u2014 1850 census on FamilySearch/Ancestry/MyHeritage, 1860 census, death cert\n- **Sources:** 4 sources (1850 census FS, 1850 census Ancestry, 1860 census, death cert)\n- **Assertions:** 13 assertions across 4 sources\n- **Person evidence:** 6 links (Patrick \u2192 I1, Thomas \u2192 I2)\n- **Conflicts:** 1 resolved (birthplace: Ireland vs Pennsylvania)\n- **Hypotheses:** h_001 (Thomas is Patrick's father, supported)\n- **Timelines:** t_001 (Patrick, 4 events, 1 gap)\n- **Proof summaries:** ps_001 (parentage, probable)\n- **GedcomX persons:** I1 (Patrick Flynn), I2 (Thomas Flynn), I3 (Mary Flynn, sister), I4 (James Flynn, brother)\n- **GedcomX relationships:** R1 (Thomas \u2192 Patrick), R2 (Thomas \u2192 Mary), R3 (Thomas \u2192 James) \u2014 all ParentChild\n- **Note on siblings:** Mary and James are stub entries (preferred name + gender only, no facts).\n  They represent the canonical shape Dallan called for: when researching Patrick on a household\n  census, the siblings should exist as persons in `tree.gedcomx.json` so warnings like\n  `relativesChildBirthRange40` and skills like `person-evidence` can reach them. Their detailed\n  facts would land later via record-extraction + person-evidence as the user works through the\n  1850 census record.\n",
+    "eval/fixtures/scenarios/mid-research-flynn/research.json": "{\n  \"assertions\": [\n    {\n      \"date\": null,\n      \"date_certainty\": null,\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_002\"\n      ],\n      \"fact_type\": \"name\",\n      \"id\": \"a_001\",\n      \"informant\": \"Unknown informant (most likely a household member, possibly a neighbor) reporting to census enumerator\",\n      \"informant_bias_notes\": \"Census enumerator is the recorder, not the informant. The person who provided the name is unknown \u2014 most likely a household member, possibly a neighbor. Proximity is 'unknown' rather than 'household_member' because for names specifically, the enumerator may have heard the name from a neighbor or made an assumption \u2014 the name fact doesn't necessarily require active reporting the way age/birthplace does.\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_001\",\n      \"place\": null,\n      \"record_id\": \"ark:/61903/1:1:MXYZ\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_001\",\n      \"structured_value\": {\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"value\": \"Patrick Flynn\"\n    },\n    {\n      \"date\": \"~1845\",\n      \"date_certainty\": \"estimated\",\n      \"evidence_type\": \"indirect\",\n      \"extracted_for_question_ids\": [\n        \"q_002\"\n      ],\n      \"fact_type\": \"birth\",\n      \"id\": \"a_002\",\n      \"informant\": \"Unknown \u2014 most likely a household member (such as Thomas Flynn or his wife), but possibly a neighbor\",\n      \"informant_bias_notes\": \"Age and birthplace require active reporting by an informant \u2014 someone had to tell the enumerator these facts. That informant was most likely a household member, but enumerators also took information from neighbors when residents were unavailable, and the census does not identify who answered. Proximity is 'unknown' because the informant cannot be established from the record.\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_001\",\n      \"place\": \"Ireland\",\n      \"record_id\": \"ark:/61903/1:1:MXYZ\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_001\",\n      \"structured_value\": {\n        \"place\": \"Ireland\",\n        \"year\": 1845\n      },\n      \"value\": \"age 5\"\n    },\n    {\n      \"date\": \"1850\",\n      \"date_certainty\": \"exact\",\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_002\"\n      ],\n      \"fact_type\": \"residence\",\n      \"id\": \"a_003\",\n      \"informant\": \"Census enumerator (witness to residence by visiting the dwelling)\",\n      \"informant_bias_notes\": \"For residence facts specifically, the enumerator is a direct witness \u2014 they physically visited the dwelling and recorded who lived there. This distinguishes residence from other census facts where an unidentified informant (most likely a household member, possibly a neighbor) supplied the information.\",\n      \"informant_proximity\": \"witness\",\n      \"information_quality\": \"primary\",\n      \"log_entry_id\": \"log_001\",\n      \"place\": \"Schuylkill County, Pennsylvania\",\n      \"record_id\": \"ark:/61903/1:1:MXYZ\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_001\",\n      \"value\": \"Schuylkill County, Pennsylvania\"\n    },\n    {\n      \"date\": \"1850\",\n      \"date_certainty\": \"exact\",\n      \"evidence_type\": \"indirect\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"relationship\",\n      \"id\": \"a_004\",\n      \"informant\": \"Inferred from household structure \u2014 no explicit informant for relationships in 1850 census\",\n      \"informant_bias_notes\": \"1850 census does not state relationships; this assertion is inferred from household position and shared surname, not directly reported by any informant. The relationship is indirect evidence constructed by the researcher, not information provided by a census informant.\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_001\",\n      \"place\": \"Schuylkill County, Pennsylvania\",\n      \"record_id\": \"ark:/61903/1:1:MXYZ\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_001\",\n      \"structured_value\": {\n        \"related_person_role\": \"head_of_household\",\n        \"relationship_type\": \"child_inferred\"\n      },\n      \"value\": \"Listed in household of Thomas Flynn (head), position consistent with child\"\n    },\n    {\n      \"date\": null,\n      \"date_certainty\": null,\n      \"evidence_type\": \"indirect\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"name\",\n      \"id\": \"a_005\",\n      \"informant\": \"Unknown informant (likely Thomas Flynn himself) reporting to census enumerator\",\n      \"informant_bias_notes\": \"Census enumerator is the recorder, not the informant. As head of household, Thomas likely provided his own name, but the 1850 census does not identify the informant.\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_001\",\n      \"place\": null,\n      \"record_id\": \"ark:/61903/1:1:MXYZ\",\n      \"record_role\": \"head_of_household\",\n      \"source_id\": \"src_001\",\n      \"value\": \"Thomas Flynn\"\n    },\n    {\n      \"date\": null,\n      \"date_certainty\": null,\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_002\"\n      ],\n      \"fact_type\": \"name\",\n      \"id\": \"a_006\",\n      \"informant\": \"Ancestry transcriber (derivative of census enumerator)\",\n      \"informant_bias_notes\": \"Derivative index \u2014 transcription errors possible\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_002\",\n      \"place\": null,\n      \"record_id\": \"ancestry:8054:patrick-flynn-1850\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_002\",\n      \"value\": \"Patrick Flynn\"\n    },\n    {\n      \"date\": \"~1845\",\n      \"date_certainty\": \"estimated\",\n      \"evidence_type\": \"indirect\",\n      \"extracted_for_question_ids\": [\n        \"q_002\"\n      ],\n      \"fact_type\": \"birth\",\n      \"id\": \"a_007\",\n      \"informant\": \"Ancestry transcriber (derivative)\",\n      \"informant_bias_notes\": null,\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_002\",\n      \"place\": \"Ireland\",\n      \"record_id\": \"ancestry:8054:patrick-flynn-1850\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_002\",\n      \"value\": \"age 5\"\n    },\n    {\n      \"date\": null,\n      \"date_certainty\": null,\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"name\",\n      \"id\": \"a_008\",\n      \"informant\": \"Unknown informant (most likely a household member, possibly a neighbor) reporting to census enumerator\",\n      \"informant_bias_notes\": \"Census enumerator is the recorder, not the informant. Proximity is 'unknown' for names (same reasoning as a_001 \u2014 name facts don't necessarily require active reporting).\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_004\",\n      \"place\": null,\n      \"record_id\": \"ark:/61903/1:1:MABC\",\n      \"record_role\": \"child_2\",\n      \"source_id\": \"src_003\",\n      \"value\": \"Patrick Flynn\"\n    },\n    {\n      \"date\": \"~1845\",\n      \"date_certainty\": \"estimated\",\n      \"evidence_type\": \"indirect\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"birth\",\n      \"id\": \"a_009\",\n      \"informant\": \"Unknown \u2014 most likely a household member (such as Thomas Flynn or his wife), but possibly a neighbor\",\n      \"informant_bias_notes\": \"Age and birthplace require active reporting by an informant \u2014 most likely a household member, possibly a neighbor (same reasoning as a_002).\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_004\",\n      \"place\": \"Ireland\",\n      \"record_id\": \"ark:/61903/1:1:MABC\",\n      \"record_role\": \"child_2\",\n      \"source_id\": \"src_003\",\n      \"value\": \"age 15\"\n    },\n    {\n      \"date\": \"1860\",\n      \"date_certainty\": \"exact\",\n      \"evidence_type\": \"indirect\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"relationship\",\n      \"id\": \"a_010\",\n      \"informant\": \"Inferred from household structure \u2014 no explicit informant for relationships in 1860 census\",\n      \"informant_bias_notes\": \"1860 census does not state relationships; like the 1850 census, this assertion is inferred from household position, age, and shared surname. The relationship column was not introduced until the 1880 census.\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_004\",\n      \"place\": \"Schuylkill County, Pennsylvania\",\n      \"record_id\": \"ark:/61903/1:1:MABC\",\n      \"record_role\": \"child_2\",\n      \"source_id\": \"src_003\",\n      \"structured_value\": {\n        \"related_person_role\": \"head_of_household\",\n        \"relationship_type\": \"child_inferred\"\n      },\n      \"value\": \"Listed in household of Thomas Flynn (head), position and age consistent with son\"\n    },\n    {\n      \"date\": \"1908-03-12\",\n      \"date_certainty\": \"exact\",\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [],\n      \"fact_type\": \"death\",\n      \"id\": \"a_011\",\n      \"informant\": \"Attending physician (signature on certificate)\",\n      \"informant_bias_notes\": null,\n      \"informant_proximity\": \"witness\",\n      \"information_quality\": \"primary\",\n      \"log_entry_id\": \"log_005\",\n      \"place\": \"Schuylkill County, Pennsylvania\",\n      \"record_id\": \"ark:/61903/1:1:MDEF\",\n      \"record_role\": \"deceased\",\n      \"source_id\": \"src_004\",\n      \"value\": \"Died 12 March 1908\"\n    },\n    {\n      \"date\": \"1845\",\n      \"date_certainty\": \"approximate\",\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"birth\",\n      \"id\": \"a_012\",\n      \"informant\": \"James Brown (son-in-law)\",\n      \"informant_bias_notes\": \"Son-in-law reporting birth facts decades after the event. Note: death cert says Pennsylvania, but census records say Ireland. Son-in-law may not have known Patrick was born in Ireland.\",\n      \"informant_proximity\": \"family_not_present\",\n      \"information_quality\": \"secondary\",\n      \"log_entry_id\": \"log_005\",\n      \"place\": \"Pennsylvania\",\n      \"record_id\": \"ark:/61903/1:1:MDEF\",\n      \"record_role\": \"deceased\",\n      \"source_id\": \"src_004\",\n      \"structured_value\": {\n        \"place\": \"Pennsylvania\",\n        \"year\": 1845\n      },\n      \"value\": \"Born 1845, Pennsylvania\"\n    },\n    {\n      \"date\": null,\n      \"date_certainty\": null,\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"relationship\",\n      \"id\": \"a_013\",\n      \"informant\": \"James Brown (son-in-law)\",\n      \"informant_bias_notes\": \"Secondary information \u2014 son-in-law reporting what he was told about father-in-law's parentage\",\n      \"informant_proximity\": \"family_not_present\",\n      \"information_quality\": \"secondary\",\n      \"log_entry_id\": \"log_005\",\n      \"place\": null,\n      \"record_id\": \"ark:/61903/1:1:MDEF\",\n      \"record_role\": \"deceased\",\n      \"source_id\": \"src_004\",\n      \"structured_value\": {\n        \"related_person_role\": \"deceased\",\n        \"relationship_type\": \"father\"\n      },\n      \"value\": \"Father: Thomas Flynn\"\n    }\n  ],\n  \"conflicts\": [\n    {\n      \"blocks_question_ids\": [],\n      \"competing_assertion_ids\": [\n        \"a_002\",\n        \"a_009\",\n        \"a_012\"\n      ],\n      \"conflict_type\": \"fact\",\n      \"description\": \"Patrick Flynn's birthplace: Ireland (1850 and 1860 censuses) vs. Pennsylvania (1908 death certificate)\",\n      \"disputed_attribute\": \"birthplace\",\n      \"id\": \"c_001\",\n      \"identity_question\": null,\n      \"independence_analysis\": \"The two census records (1850, 1860) are independent original sources with different enumerators. The death certificate is a third independent original source. However, the census informants are likely the same household member (Thomas Flynn or wife), so the two census assertions may share a single informant \u2014 potentially not fully independent for this fact.\",\n      \"preferred_assertion_id\": \"a_002\",\n      \"resolution_rationale\": \"Ireland is accepted as the birthplace. The 1908 death certificate birthplace of 'Pennsylvania' is rejected as a likely error by the son-in-law informant, who may have confused Patrick's place of residence with his place of birth, or may not have known Patrick was born in Ireland before immigrating as a young child.\",\n      \"status\": \"resolved\",\n      \"weighing_analysis\": \"The census records are contemporary recordings made near the time of Patrick's birth, while the death certificate was created 63 years later. The census informant was likely a household member with firsthand knowledge (primary or indeterminate), while the death certificate informant (son-in-law) is clearly secondary for birth facts. Two contemporary sources outweigh one later recollection by a secondary informant.\"\n    }\n  ],\n  \"evaluations\": [],\n  \"hypotheses\": [\n    {\n      \"claim\": \"Patrick Flynn's father was Thomas Flynn of Schuylkill County, Pennsylvania\",\n      \"contradicting_assertion_ids\": [],\n      \"id\": \"h_001\",\n      \"notes\": \"Three independent pieces of evidence: 1850 census co-enumeration (indirect), 1860 census co-enumeration (indirect \u2014 relationship inferred from household position), death certificate naming Thomas as father (direct, secondary informant). Awaiting probate records for additional confirmation.\",\n      \"related_question_ids\": [\n        \"q_001\"\n      ],\n      \"ruled_out\": false,\n      \"ruled_out_reason\": null,\n      \"status\": \"supported\",\n      \"supporting_assertion_ids\": [\n        \"a_004\",\n        \"a_010\",\n        \"a_013\"\n      ]\n    }\n  ],\n  \"log\": [\n    {\n      \"external_site\": null,\n      \"id\": \"log_001\",\n      \"notes\": \"Found Patrick Flynn age 5 in household of Thomas Flynn, dwelling 84, Schuylkill Co. Three other Flynn results examined \u2014 ages and locations don't match.\",\n      \"outcome\": \"positive\",\n      \"performed\": \"2026-05-01T10:15:00Z\",\n      \"plan_item_id\": \"pli_001\",\n      \"query\": {\n        \"birth_place\": \"Pennsylvania\",\n        \"birth_year\": 1845,\n        \"collection\": \"1850 Census\",\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"results_examined\": 8,\n      \"tool\": \"record_search\"\n    },\n    {\n      \"external_site\": {\n        \"capture_filename\": \"ancestry-1850-flynn-results.pdf\",\n        \"capture_received\": true,\n        \"site\": \"ancestry\",\n        \"url_generated\": \"https://www.ancestry.com/search/collections/8054/?name=Patrick_Flynn&birth=1845&birthplace=Pennsylvania\"\n      },\n      \"id\": \"log_002\",\n      \"notes\": \"Ancestry index confirms same household. Transcription matches FamilySearch except Ancestry reads dwelling as 84, FamilySearch as 84 \u2014 consistent.\",\n      \"outcome\": \"positive\",\n      \"performed\": \"2026-05-01T11:30:00Z\",\n      \"plan_item_id\": \"pli_002\",\n      \"query\": {\n        \"birth_place\": \"Pennsylvania\",\n        \"birth_year\": 1845,\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"results_examined\": 12,\n      \"tool\": \"external_site\"\n    },\n    {\n      \"external_site\": {\n        \"capture_filename\": \"myheritage-1850-flynn-nil.pdf\",\n        \"capture_received\": true,\n        \"site\": \"myheritage\",\n        \"url_generated\": \"https://www.myheritage.com/research?action=query&first=Patrick&last=Flynn&birth_year=1845&birth_place=Pennsylvania\"\n      },\n      \"id\": \"log_003\",\n      \"notes\": \"MyHeritage returned no results for Patrick Flynn in 1850 Schuylkill County. Site may not have this collection indexed. Searched broader Pennsylvania \u2014 still no match.\",\n      \"outcome\": \"negative\",\n      \"performed\": \"2026-05-01T14:00:00Z\",\n      \"plan_item_id\": \"pli_003\",\n      \"query\": {\n        \"birth_place\": \"Pennsylvania\",\n        \"birth_year\": 1845,\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"results_examined\": 0,\n      \"tool\": \"external_site\"\n    },\n    {\n      \"external_site\": null,\n      \"id\": \"log_004\",\n      \"notes\": \"Patrick Flynn age 15 in household of Thomas Flynn, Schuylkill Co. Consistent with 1850 placement.\",\n      \"outcome\": \"positive\",\n      \"performed\": \"2026-05-02T09:00:00Z\",\n      \"plan_item_id\": \"pli_004\",\n      \"query\": {\n        \"birth_place\": \"Pennsylvania\",\n        \"birth_year\": 1845,\n        \"collection\": \"1860 Census\",\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"results_examined\": 5,\n      \"tool\": \"record_search\"\n    },\n    {\n      \"external_site\": null,\n      \"id\": \"log_005\",\n      \"notes\": \"Death certificate found. Names Thomas Flynn as father. Informant was son-in-law James Brown.\",\n      \"outcome\": \"positive\",\n      \"performed\": \"2026-05-03T10:00:00Z\",\n      \"plan_item_id\": \"pli_005\",\n      \"query\": {\n        \"death_place\": \"Schuylkill County, Pennsylvania\",\n        \"death_year\": 1908,\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"results_examined\": 2,\n      \"tool\": \"record_search\"\n    }\n  ],\n  \"person_evidence\": [\n    {\n      \"assertion_id\": \"a_001\",\n      \"confidence\": \"confident\",\n      \"created\": \"2026-05-01\",\n      \"id\": \"pe_001\",\n      \"match_score\": null,\n      \"person_id\": \"I1\",\n      \"rationale\": \"Name matches (Patrick Flynn), age consistent with ~1845 birth, located in Schuylkill County where subject is known to have lived. Only Patrick Flynn of this age in the county in 1850.\",\n      \"superseded_by\": null\n    },\n    {\n      \"assertion_id\": \"a_004\",\n      \"confidence\": \"probable\",\n      \"created\": \"2026-05-01\",\n      \"id\": \"pe_002\",\n      \"match_score\": null,\n      \"person_id\": \"I1\",\n      \"rationale\": \"Same record as pe_001, same person. Household position and shared surname with head Thomas Flynn suggest parent-child relationship, but 1850 census does not state relationships explicitly.\",\n      \"superseded_by\": null\n    },\n    {\n      \"assertion_id\": \"a_004\",\n      \"confidence\": \"probable\",\n      \"created\": \"2026-05-01\",\n      \"id\": \"pe_006\",\n      \"match_score\": null,\n      \"person_id\": \"I2\",\n      \"rationale\": \"Same assertion as pe_002 but linked to Thomas Flynn (I2). The relationship assertion ('position consistent with child') equally bears on the head of household. Thomas Flynn is the other party in the implied parent-child relationship.\",\n      \"superseded_by\": null\n    },\n    {\n      \"assertion_id\": \"a_005\",\n      \"confidence\": \"probable\",\n      \"created\": \"2026-05-01\",\n      \"id\": \"pe_003\",\n      \"match_score\": 0.82,\n      \"person_id\": \"I2\",\n      \"rationale\": \"Thomas Flynn, head of household where Patrick was found. Age (~32 in 1850, born ~1818) is consistent with being Patrick's father. Name matches candidate father.\",\n      \"superseded_by\": null\n    },\n    {\n      \"assertion_id\": \"a_010\",\n      \"confidence\": \"confident\",\n      \"created\": \"2026-05-02\",\n      \"id\": \"pe_004\",\n      \"match_score\": null,\n      \"person_id\": \"I1\",\n      \"rationale\": \"Patrick Flynn age 15 in Thomas Flynn household, 1860 census. Same county, age consistent with 1850 enumeration. Relationship inferred from household position and shared surname (1860 census does not state relationships explicitly).\",\n      \"superseded_by\": null\n    },\n    {\n      \"assertion_id\": \"a_013\",\n      \"confidence\": \"confident\",\n      \"created\": \"2026-05-03\",\n      \"id\": \"pe_005\",\n      \"match_score\": null,\n      \"person_id\": \"I1\",\n      \"rationale\": \"Death certificate for Patrick Flynn, d. 1908, Schuylkill County. Names match, death location matches known residence. Names Thomas Flynn as father.\",\n      \"superseded_by\": null\n    }\n  ],\n  \"plans\": [\n    {\n      \"created\": \"2026-05-01\",\n      \"id\": \"pl_001\",\n      \"items\": [\n        {\n          \"date_range\": \"1850\",\n          \"fallback_for\": null,\n          \"id\": \"pli_001\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"1850 census fully indexed on FamilySearch. Free access, start here.\",\n          \"record_type\": \"census\",\n          \"repository\": \"FamilySearch\",\n          \"sequence\": 1,\n          \"status\": \"completed\"\n        },\n        {\n          \"date_range\": \"1850\",\n          \"fallback_for\": null,\n          \"id\": \"pli_002\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"Ancestry has independent indexing; cross-check for transcription errors.\",\n          \"record_type\": \"census\",\n          \"repository\": \"Ancestry\",\n          \"sequence\": 2,\n          \"status\": \"completed\"\n        },\n        {\n          \"date_range\": \"1850\",\n          \"fallback_for\": null,\n          \"id\": \"pli_003\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"Third independent index for coverage confirmation.\",\n          \"record_type\": \"census\",\n          \"repository\": \"MyHeritage\",\n          \"sequence\": 3,\n          \"status\": \"completed\"\n        }\n      ],\n      \"question_id\": \"q_002\",\n      \"status\": \"completed\"\n    },\n    {\n      \"created\": \"2026-05-02\",\n      \"id\": \"pl_002\",\n      \"items\": [\n        {\n          \"date_range\": \"1860\",\n          \"fallback_for\": null,\n          \"id\": \"pli_004\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"Confirm Patrick still in Thomas Flynn household in 1860. Strengthens parent-child identification.\",\n          \"record_type\": \"census\",\n          \"repository\": \"FamilySearch\",\n          \"sequence\": 1,\n          \"status\": \"completed\"\n        },\n        {\n          \"date_range\": \"1908\",\n          \"fallback_for\": null,\n          \"id\": \"pli_005\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"Death certificate may name parents directly.\",\n          \"record_type\": \"vital_record\",\n          \"repository\": \"FamilySearch\",\n          \"sequence\": 2,\n          \"status\": \"completed\"\n        },\n        {\n          \"date_range\": \"1870-1890\",\n          \"fallback_for\": null,\n          \"id\": \"pli_006\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"Thomas Flynn probate/will may name Patrick as son.\",\n          \"record_type\": \"probate\",\n          \"repository\": \"FamilySearch\",\n          \"sequence\": 3,\n          \"status\": \"in_progress\"\n        }\n      ],\n      \"question_id\": \"q_001\",\n      \"status\": \"active\"\n    }\n  ],\n  \"project\": {\n    \"created\": \"2026-05-01\",\n    \"id\": \"rp_001\",\n    \"objective\": \"Identify the parents of Patrick Flynn, born ca. 1845 in Pennsylvania, died 1908 in Schuylkill County, PA\",\n    \"status\": \"active\",\n    \"subject_person_ids\": [\n      \"I1\"\n    ],\n    \"updated\": \"2026-05-04\"\n  },\n  \"proof_summaries\": [\n    {\n      \"exhaustive_search_summary\": \"Searched 1850 census (FamilySearch, Ancestry, MyHeritage \u2014 log_001, log_002, log_003), 1860 census (FamilySearch \u2014 log_004), and death certificate (FamilySearch \u2014 log_005). Probate search in progress. 1870, 1880, and 1900 censuses not yet searched.\",\n      \"id\": \"ps_001\",\n      \"narrative_markdown\": \"## Parentage of Patrick Flynn (ca. 1845\u20131908)\\n\\nPatrick Flynn is **Probably** the son of Thomas Flynn of Schuylkill County, Pennsylvania.\\n\\n### Evidence Summary\\n\\nThree independent lines of evidence support this conclusion:\\n\\n1. **1850 U.S. Census** (Original Source). Patrick Flynn, age 5, born Ireland, appears in the household of Thomas Flynn, age 32, born Ireland, in Schuylkill County, Pennsylvania (dwelling 84, family 91). The 1850 census does not state relationships, but Patrick's position in the household and shared surname are consistent with a parent-child relationship. The informant is indeterminate but likely a household member. This constitutes indirect evidence of parentage.\\n\\n2. **1860 U.S. Census** (Original Source). Patrick Flynn, age 15, born Ireland, appears in the household of Thomas Flynn in Schuylkill County (dwelling 112, family 119). Like the 1850 census, the 1860 census does not state relationships explicitly (the relationship column was not introduced until 1880). Patrick's position in the household, shared surname, and age consistent with the 1850 enumeration support a parent-child relationship. This constitutes indirect evidence of parentage.\\n\\n3. **1908 Death Certificate** (Original Source). Patrick Flynn's death certificate (no. 4521, Pennsylvania Department of Health) names \\\"Thomas Flynn\\\" as his father. The informant was James Brown, identified as Patrick's son-in-law. As a son-in-law reporting his father-in-law's parentage, Brown is a secondary informant for this fact \u2014 he was not a witness to Patrick's birth and is reporting what he was told. Nevertheless, this is direct evidence naming the father.\\n\\n### Conflict Resolution\\n\\nA birthplace conflict exists: the 1850 and 1860 censuses list Patrick's birthplace as Ireland, while the 1908 death certificate states Pennsylvania. The two census records are contemporary recordings with informants likely present in the household, while the death certificate was created 63 years after Patrick's birth by a son-in-law with no firsthand knowledge of the event. Per the GPS preponderance hierarchy, contemporary recordings by closer informants outweigh later recollections by secondary informants. Ireland is accepted as the birthplace; the death certificate entry is attributed to informant error.\\n\\n### Assessment\\n\\nThe conclusion is rated **Probable** rather than **Proved** because: (a) both census sources (1850 and 1860) provide only indirect evidence of parentage (relationships not stated \u2014 the relationship column was not introduced until 1880), (b) the death certificate informant is secondary, and (c) research is not yet exhaustive \u2014 the 1870, 1880, and 1900 censuses have not been searched, and Thomas Flynn's probate records have not been located. If Thomas Flynn's will names Patrick as a son, or if additional census records confirm the relationship, the conclusion would advance to **Proved**.\\n\\n### Citations\\n\\n1. 1850 U.S. Census, Schuylkill County, Pennsylvania, population schedule, dwelling 84, family 91, Thomas Flynn household; NARA microfilm publication M432, roll 810; digital image, FamilySearch.org, accessed 1 May 2026.\\n2. 1860 U.S. Census, Schuylkill County, Pennsylvania, population schedule, dwelling 112, family 119, Thomas Flynn household; NARA microfilm publication M653, roll 1141; digital image, FamilySearch.org, accessed 2 May 2026.\\n3. Pennsylvania Department of Health, death certificate no. 4521 (1908), Patrick Flynn; Pennsylvania State Archives, Harrisburg; digital image, FamilySearch.org, accessed 3 May 2026.\",\n      \"question_id\": \"q_001\",\n      \"resolved_conflict_ids\": [\n        \"c_001\"\n      ],\n      \"supporting_assertion_ids\": [\n        \"a_004\",\n        \"a_010\",\n        \"a_013\"\n      ],\n      \"tier\": \"probable\",\n      \"vehicle\": \"summary\"\n    }\n  ],\n  \"questions\": [\n    {\n      \"created\": \"2026-05-01\",\n      \"depends_on\": [],\n      \"exhaustive_declaration\": {\n        \"declared\": false,\n        \"justification\": null,\n        \"log_entry_ids\": [],\n        \"stop_criteria\": null\n      },\n      \"id\": \"q_001\",\n      \"priority\": \"high\",\n      \"question\": \"Who were the parents of Patrick Flynn (b. ~1845, PA, d. 1908)?\",\n      \"rationale\": \"This is the primary research objective.\",\n      \"resolution_assertion_ids\": [],\n      \"resolved\": null,\n      \"selection_basis\": \"objective_decomposition\",\n      \"status\": \"in_progress\",\n      \"unblocks\": []\n    },\n    {\n      \"created\": \"2026-05-01\",\n      \"depends_on\": [],\n      \"exhaustive_declaration\": {\n        \"declared\": true,\n        \"justification\": \"Searched 1850 census for Schuylkill County on FamilySearch (indexed and browse), Ancestry (indexed), and MyHeritage (indexed). All three returned the same household. No other Patrick Flynn of matching age found in the county.\",\n        \"log_entry_ids\": [\n          \"log_001\",\n          \"log_002\",\n          \"log_003\"\n        ],\n        \"stop_criteria\": {\n          \"conflict_resolution\": \"No conflicts on the 1850 census placement question.\",\n          \"evidence_class\": \"Yes \u2014 FamilySearch provides original census image with indeterminate-quality information.\",\n          \"goal_alignment\": \"Yes \u2014 Patrick Flynn located in a specific 1850 household, answering the question.\",\n          \"independent_verification\": \"FamilySearch (original) and Ancestry (derivative) both return the same household. Two access paths, one underlying original.\",\n          \"original_substitution\": \"FamilySearch provides the original census image; Ancestry index is derivative but confirmed consistent.\",\n          \"overturn_risk\": \"Low \u2014 all three repositories agree, and no competing Patrick Flynn of matching age exists in the county.\",\n          \"repository_breadth\": \"Three major repositories searched (FamilySearch, Ancestry, MyHeritage). No additional known indexes of the 1850 Schuylkill County census exist.\"\n        }\n      },\n      \"id\": \"q_002\",\n      \"priority\": \"high\",\n      \"question\": \"Where was Patrick Flynn in the 1850 census?\",\n      \"rationale\": \"The 1850 census is the earliest enumeration where Patrick would appear by name (age ~5). Locating him in a household identifies candidate parents.\",\n      \"resolution_assertion_ids\": [\n        \"a_001\",\n        \"a_002\",\n        \"a_003\"\n      ],\n      \"resolved\": \"2026-05-02\",\n      \"selection_basis\": \"objective_decomposition\",\n      \"status\": \"resolved\",\n      \"unblocks\": [\n        \"q_001\"\n      ]\n    }\n  ],\n  \"sources\": [\n    {\n      \"access_date\": \"2026-05-01\",\n      \"citation\": \"1850 U.S. Census, Schuylkill County, Pennsylvania, population schedule, dwelling 84, family 91, Thomas Flynn household; NARA microfilm publication M432, roll 810; digital image, FamilySearch.org, accessed 1 May 2026.\",\n      \"citation_detail\": {\n        \"what\": \"1850 U.S. Federal Census, population schedule\",\n        \"when_accessed\": \"2026-05-01\",\n        \"when_created\": \"1850\",\n        \"where\": \"FamilySearch.org (NARA microfilm M432, roll 810)\",\n        \"where_within\": \"Schuylkill County, dwelling 84, family 91\",\n        \"who\": \"U.S. Census Bureau\"\n      },\n      \"gedcomx_source_description_id\": \"S1\",\n      \"id\": \"src_001\",\n      \"log_entry_id\": \"log_001\",\n      \"notes\": \"Image quality good. Enumerator handwriting clear.\",\n      \"repository\": \"FamilySearch\",\n      \"source_classification\": \"original\",\n      \"url\": \"https://www.familysearch.org/ark:/61903/1:1:MXYZ\",\n      \"url_archived\": null\n    },\n    {\n      \"access_date\": \"2026-05-01\",\n      \"citation\": \"1850 U.S. Census, Schuylkill County, Pennsylvania, population schedule, dwelling 84, Thomas Flynn household; digital image, Ancestry.com, accessed 1 May 2026.\",\n      \"citation_detail\": {\n        \"what\": \"1850 U.S. Federal Census, population schedule (Ancestry index)\",\n        \"when_accessed\": \"2026-05-01\",\n        \"when_created\": \"1850\",\n        \"where\": \"Ancestry.com\",\n        \"where_within\": \"Schuylkill County, dwelling 84\",\n        \"who\": \"U.S. Census Bureau\"\n      },\n      \"gedcomx_source_description_id\": \"S1\",\n      \"id\": \"src_002\",\n      \"log_entry_id\": \"log_002\",\n      \"notes\": \"Ancestry's index of the same original census. Transcription consistent with FamilySearch.\",\n      \"repository\": \"Ancestry\",\n      \"source_classification\": \"derivative\",\n      \"url\": null,\n      \"url_archived\": null\n    },\n    {\n      \"access_date\": \"2026-05-02\",\n      \"citation\": \"1860 U.S. Census, Schuylkill County, Pennsylvania, population schedule, dwelling 112, family 119, Thomas Flynn household; NARA microfilm publication M653, roll 1141; digital image, FamilySearch.org, accessed 2 May 2026.\",\n      \"citation_detail\": {\n        \"what\": \"1860 U.S. Federal Census, population schedule\",\n        \"when_accessed\": \"2026-05-02\",\n        \"when_created\": \"1860\",\n        \"where\": \"FamilySearch.org (NARA microfilm M653, roll 1141)\",\n        \"where_within\": \"Schuylkill County, dwelling 112, family 119\",\n        \"who\": \"U.S. Census Bureau\"\n      },\n      \"gedcomx_source_description_id\": \"S2\",\n      \"id\": \"src_003\",\n      \"log_entry_id\": \"log_004\",\n      \"notes\": null,\n      \"repository\": \"FamilySearch\",\n      \"source_classification\": \"original\",\n      \"url\": \"https://www.familysearch.org/ark:/61903/1:1:MABC\",\n      \"url_archived\": null\n    },\n    {\n      \"access_date\": \"2026-05-03\",\n      \"citation\": \"Pennsylvania Department of Health, death certificate no. 4521 (1908), Patrick Flynn; Pennsylvania State Archives, Harrisburg; digital image, FamilySearch.org, accessed 3 May 2026.\",\n      \"citation_detail\": {\n        \"what\": \"Death certificate no. 4521\",\n        \"when_accessed\": \"2026-05-03\",\n        \"when_created\": \"1908-03-14\",\n        \"where\": \"FamilySearch.org (Pennsylvania State Archives, Harrisburg)\",\n        \"where_within\": \"Certificate no. 4521\",\n        \"who\": \"Pennsylvania Department of Health; informant: James Brown (son-in-law)\"\n      },\n      \"gedcomx_source_description_id\": \"S3\",\n      \"id\": \"src_004\",\n      \"log_entry_id\": \"log_005\",\n      \"notes\": \"Informant is son-in-law James Brown. Primary for death facts, secondary for birth facts.\",\n      \"repository\": \"FamilySearch\",\n      \"source_classification\": \"original\",\n      \"url\": \"https://www.familysearch.org/ark:/61903/1:1:MDEF\",\n      \"url_archived\": null\n    },\n    {\n      \"access_date\": \"2026-05-10\",\n      \"citation\": \"St. Mary's Catholic Church, Pottsville, baptism of Patrick Flynn, 1845\",\n      \"citation_detail\": {\n        \"what\": \"Baptismal register, 1845\",\n        \"when_accessed\": \"2026-05-10\",\n        \"when_created\": \"1845\",\n        \"where\": \"FamilySearch.org\",\n        \"where_within\": \"Patrick Flynn entry\",\n        \"who\": \"St. Mary's Catholic Church, Pottsville\"\n      },\n      \"gedcomx_source_description_id\": \"S5\",\n      \"id\": \"src_005\",\n      \"log_entry_id\": null,\n      \"notes\": \"Rough working citation from record-extraction. Missing volume/page locator and full repository chain.\",\n      \"repository\": \"FamilySearch\",\n      \"source_classification\": \"original\",\n      \"url\": \"https://www.familysearch.org/ark:/61903/3:1:S3HT-D1MQ-NZH\",\n      \"url_archived\": null\n    },\n    {\n      \"access_date\": \"2026-05-10\",\n      \"citation\": \"Schuylkill County will of Thomas Flynn, 1881\",\n      \"citation_detail\": {\n        \"what\": \"Will of Thomas Flynn\",\n        \"when_accessed\": \"2026-05-10\",\n        \"when_created\": \"1881\",\n        \"where\": \"FamilySearch.org\",\n        \"where_within\": \"will of Thomas Flynn\",\n        \"who\": \"Schuylkill County Courthouse\"\n      },\n      \"gedcomx_source_description_id\": \"S4\",\n      \"id\": \"src_006\",\n      \"log_entry_id\": null,\n      \"notes\": \"Rough working citation from record-extraction. Creator should be the court, not the courthouse. Missing Will Book volume and page locator.\",\n      \"repository\": \"FamilySearch\",\n      \"source_classification\": \"original\",\n      \"url\": \"https://www.familysearch.org/ark:/61903/3:1:3Q9M-CS4V-7TXW\",\n      \"url_archived\": null\n    },\n    {\n      \"access_date\": \"2026-05-12\",\n      \"citation\": \"PA birth certificate, Mary Elizabeth Flynn, 1905\",\n      \"citation_detail\": {\n        \"what\": \"Birth certificate\",\n        \"when_accessed\": \"2026-05-12\",\n        \"when_created\": \"1905\",\n        \"where\": \"FamilySearch.org\",\n        \"where_within\": \"Mary Elizabeth Flynn entry\",\n        \"who\": \"FamilySearch\"\n      },\n      \"gedcomx_source_description_id\": \"S6\",\n      \"id\": \"src_007\",\n      \"log_entry_id\": null,\n      \"notes\": \"Rough working citation from record-extraction. who wrongly names the repository; missing certificate number (12455), birth date, and place.\",\n      \"repository\": \"FamilySearch\",\n      \"source_classification\": \"original\",\n      \"url\": \"https://www.familysearch.org/ark:/61903/1:1:6JZX-VKQM\",\n      \"url_archived\": null\n    },\n    {\n      \"access_date\": \"2026-05-12\",\n      \"citation\": \"Deed, Thomas Flynn to Patrick Flynn, 1881\",\n      \"citation_detail\": {\n        \"what\": \"Warranty deed\",\n        \"when_accessed\": \"2026-05-12\",\n        \"when_created\": \"1881\",\n        \"where\": \"FamilySearch.org\",\n        \"where_within\": \"Thomas Flynn to Patrick Flynn\",\n        \"who\": \"Schuylkill County Courthouse\"\n      },\n      \"gedcomx_source_description_id\": \"S7\",\n      \"id\": \"src_008\",\n      \"log_entry_id\": null,\n      \"notes\": \"Rough working citation from record-extraction. who should be the Recorder of Deeds (not the courthouse building); missing grantor/grantee, execution + recording dates, and Deed Book/page locator.\",\n      \"repository\": \"FamilySearch\",\n      \"source_classification\": \"original\",\n      \"url\": \"https://www.familysearch.org/ark:/61903/3:1:3QS7-89WF-9KCT\",\n      \"url_archived\": null\n    },\n    {\n      \"access_date\": \"2026-05-12\",\n      \"citation\": \"Patrick Flynn obituary, Pottsville Republican, 1908\",\n      \"citation_detail\": {\n        \"what\": \"Obituary\",\n        \"when_accessed\": \"2026-05-12\",\n        \"when_created\": \"1908\",\n        \"where\": \"FamilySearch.org\",\n        \"where_within\": \"obituary notice\",\n        \"who\": \"FamilySearch\"\n      },\n      \"gedcomx_source_description_id\": \"S8\",\n      \"id\": \"src_009\",\n      \"log_entry_id\": null,\n      \"notes\": \"Rough working citation from record-extraction. who wrongly names the repository; missing the quoted article title, exact publication date, page, and column number.\",\n      \"repository\": \"FamilySearch\",\n      \"source_classification\": \"original\",\n      \"url\": \"https://www.familysearch.org/ark:/61903/3:1:S3HY-6RKS-MGV\",\n      \"url_archived\": null\n    }\n  ],\n  \"timelines\": [\n    {\n      \"events\": [\n        {\n          \"assertion_ids\": [\n            \"a_002\",\n            \"a_009\"\n          ],\n          \"date\": \"~1845\",\n          \"date_certainty\": \"estimated\",\n          \"description\": \"Born in Ireland, estimated from census ages\",\n          \"event_type\": \"birth\",\n          \"place\": \"Ireland\"\n        },\n        {\n          \"assertion_ids\": [\n            \"a_003\",\n            \"a_004\"\n          ],\n          \"date\": \"1850\",\n          \"date_certainty\": \"exact\",\n          \"description\": \"Enumerated age 5 in Thomas Flynn household, dwelling 84\",\n          \"event_type\": \"census\",\n          \"place\": \"Schuylkill County, Pennsylvania\"\n        },\n        {\n          \"assertion_ids\": [\n            \"a_008\",\n            \"a_009\",\n            \"a_010\"\n          ],\n          \"date\": \"1860\",\n          \"date_certainty\": \"exact\",\n          \"description\": \"Enumerated age 15 in Thomas Flynn household, dwelling 112\",\n          \"event_type\": \"census\",\n          \"place\": \"Schuylkill County, Pennsylvania\"\n        },\n        {\n          \"assertion_ids\": [\n            \"a_011\",\n            \"a_013\"\n          ],\n          \"date\": \"1908-03-12\",\n          \"date_certainty\": \"exact\",\n          \"description\": \"Died, death certificate names Thomas Flynn as father\",\n          \"event_type\": \"death\",\n          \"place\": \"Schuylkill County, Pennsylvania\"\n        }\n      ],\n      \"gaps\": [\n        {\n          \"end\": \"1908-03-12\",\n          \"expected_events\": [\n            \"marriage\",\n            \"1870_census\",\n            \"1880_census\",\n            \"1900_census\",\n            \"residence\",\n            \"occupation\"\n          ],\n          \"severity\": \"high\",\n          \"start\": \"1860-01-01\"\n        }\n      ],\n      \"generated\": \"2026-05-03T12:00:00Z\",\n      \"hypothesis_id\": \"h_001\",\n      \"id\": \"t_001\",\n      \"impossibilities\": [],\n      \"label\": \"Patrick Flynn \u2014 assuming Thomas Flynn parentage\",\n      \"person_ids\": [\n        \"I1\"\n      ]\n    }\n  ]\n}\n",
+    "eval/fixtures/scenarios/mid-research-flynn/tree.gedcomx.json": "{\n  \"persons\": [\n    {\n      \"facts\": [\n        {\n          \"date\": \"~1845\",\n          \"id\": \"F1\",\n          \"place\": \"Ireland\",\n          \"primary\": true,\n          \"sources\": [\n            {\n              \"page\": \"1850 Census, Schuylkill Co., dwelling 84\",\n              \"ref\": \"S1\"\n            }\n          ],\n          \"type\": \"Birth\"\n        },\n        {\n          \"date\": \"1908-03-12\",\n          \"id\": \"F2\",\n          \"place\": \"Schuylkill County, Pennsylvania\",\n          \"sources\": [\n            {\n              \"page\": \"Death cert. no. 4521\",\n              \"ref\": \"S3\"\n            }\n          ],\n          \"type\": \"Death\"\n        }\n      ],\n      \"gender\": \"Male\",\n      \"id\": \"I1\",\n      \"names\": [\n        {\n          \"given\": \"Patrick\",\n          \"id\": \"N1\",\n          \"preferred\": true,\n          \"surname\": \"Flynn\",\n          \"type\": \"BirthName\"\n        }\n      ]\n    },\n    {\n      \"facts\": [\n        {\n          \"date\": \"~1818\",\n          \"id\": \"F3\",\n          \"place\": \"Ireland\",\n          \"primary\": true,\n          \"type\": \"Birth\"\n        }\n      ],\n      \"gender\": \"Male\",\n      \"id\": \"I2\",\n      \"names\": [\n        {\n          \"given\": \"Thomas\",\n          \"id\": \"N2\",\n          \"preferred\": true,\n          \"surname\": \"Flynn\",\n          \"type\": \"BirthName\"\n        }\n      ]\n    },\n    {\n      \"gender\": \"Female\",\n      \"id\": \"I3\",\n      \"names\": [\n        {\n          \"given\": \"Mary\",\n          \"id\": \"N3\",\n          \"preferred\": true,\n          \"surname\": \"Flynn\",\n          \"type\": \"BirthName\"\n        }\n      ]\n    },\n    {\n      \"gender\": \"Male\",\n      \"id\": \"I4\",\n      \"names\": [\n        {\n          \"given\": \"James\",\n          \"id\": \"N4\",\n          \"preferred\": true,\n          \"surname\": \"Flynn\",\n          \"type\": \"BirthName\"\n        }\n      ]\n    }\n  ],\n  \"relationships\": [\n    {\n      \"child\": \"I1\",\n      \"id\": \"R1\",\n      \"parent\": \"I2\",\n      \"sources\": [\n        {\n          \"page\": \"1850 Census, Schuylkill Co., dwelling 84\",\n          \"quality\": 2,\n          \"ref\": \"S1\"\n        },\n        {\n          \"page\": \"1860 Census, Schuylkill Co., dwelling 112\",\n          \"quality\": 2,\n          \"ref\": \"S2\"\n        },\n        {\n          \"page\": \"Death cert. no. 4521\",\n          \"quality\": 2,\n          \"ref\": \"S3\"\n        }\n      ],\n      \"type\": \"ParentChild\"\n    },\n    {\n      \"child\": \"I3\",\n      \"id\": \"R2\",\n      \"parent\": \"I2\",\n      \"sources\": [\n        {\n          \"page\": \"1850 Census, Schuylkill Co., dwelling 84\",\n          \"quality\": 2,\n          \"ref\": \"S1\"\n        }\n      ],\n      \"type\": \"ParentChild\"\n    },\n    {\n      \"child\": \"I4\",\n      \"id\": \"R3\",\n      \"parent\": \"I2\",\n      \"sources\": [\n        {\n          \"page\": \"1850 Census, Schuylkill Co., dwelling 84\",\n          \"quality\": 2,\n          \"ref\": \"S1\"\n        }\n      ],\n      \"type\": \"ParentChild\"\n    }\n  ],\n  \"sources\": [\n    {\n      \"author\": \"U.S. Census Bureau\",\n      \"id\": \"S1\",\n      \"title\": \"1850 U.S. Federal Census\"\n    },\n    {\n      \"author\": \"U.S. Census Bureau\",\n      \"id\": \"S2\",\n      \"title\": \"1860 U.S. Federal Census\"\n    },\n    {\n      \"author\": \"Pennsylvania Department of Health\",\n      \"id\": \"S3\",\n      \"title\": \"Pennsylvania Death Certificates\"\n    },\n    {\n      \"author\": \"Schuylkill County Register of Wills\",\n      \"id\": \"S4\",\n      \"title\": \"Schuylkill County Probate Records\"\n    },\n    {\n      \"author\": \"St. Mary's Catholic Church, Pottsville\",\n      \"id\": \"S5\",\n      \"title\": \"St. Mary's Catholic Church (Pottsville) Baptismal Registers\"\n    },\n    {\n      \"author\": \"Pennsylvania Department of Health\",\n      \"id\": \"S6\",\n      \"title\": \"Pennsylvania Birth Certificates\"\n    },\n    {\n      \"author\": \"Schuylkill County Recorder of Deeds\",\n      \"id\": \"S7\",\n      \"title\": \"Schuylkill County Deed Books\"\n    },\n    {\n      \"author\": \"Pottsville Republican\",\n      \"id\": \"S8\",\n      \"title\": \"Pottsville Republican (newspaper)\"\n    }\n  ]\n}\n",
+    "eval/fixtures/mcp/wikipedia-search-kirchenbuch.json": "{\n  \"args\": {\n    \"query\": \"~Kirchenbuch\"\n  },\n  \"description\": \"Wikipedia article summary for Kirchenbuch (German church register)\",\n  \"input_schema\": {\n    \"properties\": {\n      \"query\": {\n        \"description\": \"The topic to search for on Wikipedia\",\n        \"type\": \"string\"\n      }\n    },\n    \"required\": [\n      \"query\"\n    ],\n    \"type\": \"object\"\n  },\n  \"response\": {\n    \"extract\": \"A Kirchenbuch (German: 'church book'; plural Kirchenb\u00fccher) is a parish register maintained by a Christian parish \u2014 primarily Roman Catholic and Lutheran \u2014 recording baptisms, marriages, and burials. In the German-speaking world, parish registers became widespread after the Council of Trent (1563) for Catholic parishes and following the Reformation for Protestant parishes, with many extant volumes beginning in the 1600s and some Catholic registers reaching back to the mid-1500s. Until the introduction of civil registration in the 19th century (Standesamt registers, generally 1875\u20131876 in the German Empire), Kirchenb\u00fccher are the principal source for vital-event genealogical research in German-speaking regions. The records are typically held by the parish that created them, by a regional church archive (Landeskirchliches Archiv for Protestant records, Bistumsarchiv for Catholic), or on subscription platforms such as Archion (Protestant) and Matricula (Catholic).\",\n    \"title\": \"Kirchenbuch\",\n    \"url\": \"https://en.wikipedia.org/wiki/Kirchenbuch\"\n  },\n  \"tool\": \"wikipedia_search\"\n}\n"
+  },
+  "tests": [
+    {
+      "test_id": "ut_translation_006",
+      "test_type": "positive",
+      "expected_outcome": "pass",
+      "scenario": null,
+      "mcp_fixtures": [],
+      "outcome": "pass",
+      "flaky": false,
+      "outcome_summary": {
+        "per_run_outcomes": [
+          "pass"
+        ],
+        "aggregated_dimensions": [
+          {
+            "source": "base",
+            "name": "Correctness",
+            "score": 3,
+            "rationale": "The translation is factually accurate and faithful to the German original. Date resolution (M\u00e4rz) is correct with appropriate confidence assessment. Surname uncertainty (Schnider/Schneider) is properly flagged, not silently resolved. All genealogical terms (ehelicher Sohn, Tagel\u00f6hner, Pathe, B\u00fcrger allhier) are translated correctly and remain unsupported by provided sources. No fabricated material."
+          },
+          {
+            "source": "base",
+            "name": "Completeness",
+            "score": 3,
+            "rationale": "The skill addressed all elements required by the user and test context: legible structure transcribed, all three uncertainties explicitly flagged with reasoning, names kept in German form, genealogically significant terms explained with their research implications, and paleographic context provided. The skill also proactively addressed follow-up steps and offered additional analytical value without omission."
+          },
+          {
+            "source": "base",
+            "name": "Tool Arguments",
+            "score": null,
+            "rationale": "No MCP tool calls were made in this response. The skill performed a pure translation and paleographic analysis task without invoking external tools. N/A."
+          },
+          {
+            "source": "rubric",
+            "name": "Accuracy",
+            "score": 3,
+            "rationale": "Translation preserves precise meaning of genealogical terms: 'ehelicher Sohn' correctly rendered as 'legitimate son' (not just 'son'), 'Tagel\u00f6hner' as 'day laborer' (capturing socioeconomic status), 'Pathe' as 'godfather' with kinship implications noted, 'B\u00fcrger allhier' as 'citizen/resident of this place' (preserving civic status distinction). Names Johann Georg and Anna Maria retained in original German. No flattening of meaning."
+          },
+          {
+            "source": "rubric",
+            "name": "Notation of uncertainty",
+            "score": 3,
+            "rationale": "All three ambiguities are explicitly flagged and their interpretations spelled out for the genealogist. March reading marked '[M..]rz' \u2192 'M\u00e4rz' with confidence level explained. Surname m/n confusion documented with both candidates (Schnider vs. Schmider) and rationale for the stronger interpretation provided, instructing user to flag for confirmation. Godfather surname correctly left as '[unleserlich]' (illegible) with no silent guessing. The skill explicitly recommends the genealogist verify against original image."
+          },
+          {
+            "source": "rubric",
+            "name": "Genealogical context",
+            "score": 3,
+            "rationale": "Genealogically significant terms are explained with research implications: 'ehelicher Sohn' tied to legitimacy status and marital evidence; 'Tagel\u00f6hner' noted as indicator of lower socioeconomic status and mobility; 'Pathe' identified as FAN-cluster figure (godfather kinsman lead); 'B\u00fcrger allhier' explained as civic standing distinction and geographic anchor. Baptism vs. birth date distinction noted. Godfather-child naming pattern flagged as evidence of kinship. Comprehensive context for genealogical interpretation provided."
+          }
+        ]
+      },
+      "totals": {
+        "duration_ms": 92447.79139800085,
+        "input_tokens": 6,
+        "cached_input_tokens": 13791,
+        "output_tokens": 3895,
+        "judge_input_tokens": 5472,
+        "judge_cached_input_tokens": 0,
+        "judge_output_tokens": 836,
+        "skill_cost_usd": 0.08231580000000001,
+        "judge_cost_usd": 0.009652,
+        "total_cost_usd": 0.09196780000000002
+      },
+      "runs": [
+        {
+          "run_index": 0,
+          "run_id": "run_ut_translation_006_2026-06-22_19-33-09_0",
+          "outcome": "pass",
+          "aborted_reason": null,
+          "duration_ms": 92447.79139800085,
+          "input_tokens": 6,
+          "cached_input_tokens": 13791,
+          "output_tokens": 3895,
+          "skill_cost_usd": 0.08231580000000001,
+          "output": {
+            "text_response": "## German Kurrent Baptism Entry \u2014 Translation & Paleographic Review\n\n---\n\n### Step 1 \u2014 Language & Record Type\n\n- **Language:** German, with early-19th-century Kurrentschrift conventions\n- **Record type:** *Taufregister* (parish baptism register)\n- **Period:** 1812 \u2014 formulaic Lutheran or Catholic parish entry; at this date, the \"Den Xten [Month] Jahr ist getauft worden\u2026\" structure is standard for southwestern German-speaking territories\n\n---\n\n### Step 2 \u2014 Transcription Review (with uncertainty resolutions)\n\nYour transcription is solid. Here is the reviewed version with the three uncertain spots addressed:\n\n> Den 3ten **M\u00e4rz** 1812 ist getauft worden Johann Georg, ehelicher Sohn des Joh[ann] **Sch[n]ider**, Tagel\u00f6hner, und seiner Ehefrau Anna Maria. Pathe war Georg **[unleserlich]**, B\u00fcrger allhier.\n\n#### Uncertainty 1 \u2014 `[M..]rz` \u2192 **M\u00e4rz**\n\n**Resolved with high confidence.** *M\u00e4rz* (March) is the only German month that fits the pattern M\\_\\_rz. In Kurrent, the *\u00e4* umlaut is often written as a plain *a* with two tiny tick-marks above it \u2014 easily faded and hard to distinguish from a plain *a*. The *r* following it can also thin out with ink fade. No ambiguity remains here: this is **3 March 1812**.\n\n#### Uncertainty 2 \u2014 `Sch[m/n]ider` \u2192 **Schnider** (= *Schneider*)\n\n**Resolved with moderate-to-high confidence; flag in your notes.**\n\nIn Kurrent, *m* and *n* are both formed from connected minim strokes \u2014 *n* has two minims, *m* has three. When ink fades over the middle of a word, it's genuinely easy to lose one minim and read *m* as *n* or vice versa.\n\nThe two candidates:\n\n| Reading | Surname | Frequency | Notes |\n|---|---|---|---|\n| `Schn-` | *Schnider* / *Schneider* | **Very common** | Phonetic/dialectal spelling of *Schneider* (\"tailor\") \u2014 one of the most frequent German surnames; *ei* \u2192 *i* spellings are standard in southwestern registers |\n| `Schm-` | *Schmider* | Uncommon | Variant of *Schmied* (blacksmith); attested but rare |\n\n**I lean strongly toward *Schneider* (spelled *Schnider* here).** Phonetic *ei* \u2192 *i* is well documented in 18th\u201319th century Swabian/Franconian/Rhine registers. The father's occupation (*Tagel\u00f6hner*, day laborer) does not rule this out \u2014 surnames were hereditary by 1812 and no longer tracked occupation. Transcribe as **Schnider [= Schneider?]** and note the ambiguity for follow-up comparison against other entries.\n\n#### Uncertainty 3 \u2014 Godfather's surname: **[unleserlich]** (illegible)\n\nYou've correctly flagged this as unreadable. No further resolution is possible from text alone \u2014 if you can share an image of the entry, paleographic analysis of the letterforms may recover it. Worth noting: the godfather's given name *Georg* matches the child's second given name *Johann **Georg*** \u2014 a classic naming pattern suggesting the godfather may be a kinsman (uncle, grandfather, neighbor). That surname, even if illegible now, is a FAN-cluster lead worth pursuing.\n\n---\n\n### Step 3 \u2014 Translation\n\n**Original (user's transcription, reviewed):**\n> Den 3ten M\u00e4rz 1812 ist getauft worden Johann Georg, ehelicher Sohn des Joh. Schnider, Tagel\u00f6hner, und seiner Ehefrau Anna Maria. Pathe war Georg [unleserlich], B\u00fcrger allhier.\n\n**Translation** *(derivative \u2014 the original governs):*\n> On the 3rd of March 1812, **Johann Georg** was baptized, legitimate son of **Joh[ann] Schnider [= Schneider?]**, day laborer, and his wife **Anna Maria**. Godfather was **Georg [illegible]**, citizen/resident of this place.\n\n---\n\n### Step 4 \u2014 Genealogically Relevant Information\n\n| Element | Original | Meaning & Notes |\n|---|---|---|\n| **Baptism date** | *Den 3ten M\u00e4rz 1812* | 3 March 1812. This is the **baptism** date. Birth was almost certainly 1\u20133 days earlier \u2014 very common in German parish practice; the birth date may be in a separate birth column if the register uses a tabular format. |\n| **Child** | *Johann Georg* | Male. Two given names; the second (*Georg*) is almost certainly the godfather's name, following standard German naming convention. Use *Johann Georg*, not *Johann* alone, when indexing. |\n| **Legitimacy** | *ehelicher Sohn* | \"Legitimate son\" \u2014 born in lawful wedlock. The parents were married before this birth. |\n| **Father** | *Joh[ann] Schnider* | *Joh.* is a standard abbreviation for *Johann*. Surname uncertain between *Schnider*/*Schneider* \u2014 flag for comparison. |\n| **Father's occupation** | *Tagel\u00f6hner* | **Day laborer** \u2014 hired out for daily wages, no fixed trade or land ownership. Lower socioeconomic status; expect mobility between villages. |\n| **Mother** | *Anna Maria* | Wife's given name only \u2014 maiden name (*geborene*) not recorded here, which is typical for early 19th-century German baptism entries (marriage record is the place to find it). |\n| **Godfather** | *Georg [illegible]* | *Pathe* = godfather (male sponsor). Status: *B\u00fcrger allhier* (see below). Given name *Georg* mirrors child's second name \u2014 likely a kinsman. |\n| **Godfather's status** | *B\u00fcrger allhier* | *B\u00fcrger* = burgher/citizen \u2014 a man with formal civic standing in the community, a step above *Tagel\u00f6hner*. *Allhier* = \"here in this place\" (same parish/village as the register). His higher status relative to the father makes him a useful anchor for locating the family geographically. |\n\n---\n\n### Paleographic Notes for Your Records\n\n- **\"ist getauft worden\"** \u2014 passive construction, \"was baptized\"; standard formula for this period. Some registers write \"ist \u2026 getauft worden\" (baptism record) vs. \"ist \u2026 geboren worden\" (birth record) \u2014 confirm which column this appears in if it's a tabular register.\n- **\"Den 3ten\"** \u2014 ordinal date (*den dritten*, \"on the third\"); the superscript *ten* is a Kurrent abbreviation for the ordinal suffix.\n- **\"Pathe war\"** \u2014 *war* = \"was\"; *Pathe* (also spelled *Pate*) is godfather. If a godmother (*Patin*) was also named, she would appear separately.\n- **\"B\u00fcrger allhier\"** \u2014 watch for whether the register ever uses *allhier* vs. naming a different village for out-of-parish godparents; a local *B\u00fcrger allhier* confirms the godfather lived in the same community.\n\n---\n\n### Summary of Resolved Readings\n\n| Your notation | Resolved reading | Confidence |\n|---|---|---|\n| `[M..]rz` | **M\u00e4rz** (March) | \u2705 High |\n| `Sch[m/n]ider` | **Schnider** [= *Schneider*?] | \u26a0\ufe0f Moderate \u2014 flag for comparison |\n| `[unleserlich]` | Remains illegible | \u274c Needs image |\n\n---\n\n### Next Steps\n\n1. **If you have an image of the entry**, share it here \u2014 I can attempt a direct paleographic reading of the godfather's surname and double-check the *Schnider/Schmider* letterform.\n2. **Extract assertions from this record?** The record-extraction skill can pull out discrete genealogical facts (birth ~1 March 1812, baptism 3 March 1812, father Johann Schnider/Schneider, mother Anna Maria, etc.) and log them to `research.json`.\n3. **Find the parents' marriage record** \u2014 it will give Anna Maria's maiden name and confirm the father's surname spelling.\n4. **Research the godfather** \u2014 *Georg [illegible], B\u00fcrger allhier* is a FAN-cluster lead; a man of burgher standing in the same village, sharing his name with the child, is worth tracing in land, tax, or further parish records.",
+            "activated": true,
+            "skills_invoked": [
+              "translation"
+            ],
+            "tool_calls": [],
+            "files_created": []
+          },
+          "validators": {
+            "passed": true,
+            "results": [
+              {
+                "name": "test_id_references_resolve",
+                "passed": true,
+                "error": "skipped: No research.json in output"
+              },
+              {
+                "name": "test_log_append_only",
+                "passed": true,
+                "error": "skipped: Missing research.json for diff"
+              },
+              {
+                "name": "test_no_entries_deleted",
+                "passed": true,
+                "error": "skipped: Missing research.json for diff"
+              },
+              {
+                "name": "test_ownership_table",
+                "passed": true,
+                "error": "skipped: Missing research.json for ownership diff"
+              },
+              {
+                "name": "test_research_json_validates_schema",
+                "passed": true,
+                "error": "skipped: No research.json in output"
+              },
+              {
+                "name": "test_tool_allowlist",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_gedcomx_json_validates_schema",
+                "passed": true,
+                "error": "skipped: No tree.gedcomx.json in output"
+              },
+              {
+                "name": "test_tree_ownership_table",
+                "passed": true,
+                "error": "skipped: Missing tree.gedcomx.json for ownership diff"
+              },
+              {
+                "name": "test_no_mcp_tools_called",
+                "passed": true,
+                "error": null
+              }
+            ]
+          },
+          "judge": {
+            "skipped": false,
+            "dimensions": [
+              {
+                "source": "base",
+                "name": "Correctness",
+                "score": 3,
+                "rationale": "The translation is factually accurate and faithful to the German original. Date resolution (M\u00e4rz) is correct with appropriate confidence assessment. Surname uncertainty (Schnider/Schneider) is properly flagged, not silently resolved. All genealogical terms (ehelicher Sohn, Tagel\u00f6hner, Pathe, B\u00fcrger allhier) are translated correctly and remain unsupported by provided sources. No fabricated material."
+              },
+              {
+                "source": "base",
+                "name": "Completeness",
+                "score": 3,
+                "rationale": "The skill addressed all elements required by the user and test context: legible structure transcribed, all three uncertainties explicitly flagged with reasoning, names kept in German form, genealogically significant terms explained with their research implications, and paleographic context provided. The skill also proactively addressed follow-up steps and offered additional analytical value without omission."
+              },
+              {
+                "source": "base",
+                "name": "Tool Arguments",
+                "score": null,
+                "rationale": "No MCP tool calls were made in this response. The skill performed a pure translation and paleographic analysis task without invoking external tools. N/A."
+              },
+              {
+                "source": "rubric",
+                "name": "Accuracy",
+                "score": 3,
+                "rationale": "Translation preserves precise meaning of genealogical terms: 'ehelicher Sohn' correctly rendered as 'legitimate son' (not just 'son'), 'Tagel\u00f6hner' as 'day laborer' (capturing socioeconomic status), 'Pathe' as 'godfather' with kinship implications noted, 'B\u00fcrger allhier' as 'citizen/resident of this place' (preserving civic status distinction). Names Johann Georg and Anna Maria retained in original German. No flattening of meaning."
+              },
+              {
+                "source": "rubric",
+                "name": "Notation of uncertainty",
+                "score": 3,
+                "rationale": "All three ambiguities are explicitly flagged and their interpretations spelled out for the genealogist. March reading marked '[M..]rz' \u2192 'M\u00e4rz' with confidence level explained. Surname m/n confusion documented with both candidates (Schnider vs. Schmider) and rationale for the stronger interpretation provided, instructing user to flag for confirmation. Godfather surname correctly left as '[unleserlich]' (illegible) with no silent guessing. The skill explicitly recommends the genealogist verify against original image."
+              },
+              {
+                "source": "rubric",
+                "name": "Genealogical context",
+                "score": 3,
+                "rationale": "Genealogically significant terms are explained with research implications: 'ehelicher Sohn' tied to legitimacy status and marital evidence; 'Tagel\u00f6hner' noted as indicator of lower socioeconomic status and mobility; 'Pathe' identified as FAN-cluster figure (godfather kinsman lead); 'B\u00fcrger allhier' explained as civic standing distinction and geographic anchor. Baptism vs. birth date distinction noted. Godfather-child naming pattern flagged as evidence of kinship. Comprehensive context for genealogical interpretation provided."
+              }
+            ],
+            "judge_cost_usd": 0.009652,
+            "error": null,
+            "input_tokens": 5472,
+            "cached_input_tokens": 0,
+            "output_tokens": 836
+          }
+        }
+      ]
+    },
+    {
+      "test_id": "ut_translation_011",
+      "test_type": "positive",
+      "expected_outcome": "pass",
+      "scenario": null,
+      "mcp_fixtures": [],
+      "outcome": "pass",
+      "flaky": false,
+      "outcome_summary": {
+        "per_run_outcomes": [
+          "pass"
+        ],
+        "aggregated_dimensions": [
+          {
+            "source": "base",
+            "name": "Correctness",
+            "score": 3,
+            "rationale": "Translation is factually accurate and faithful to the original Dutch. All genealogical terms are correct: 'soon' (son), 'gedoopt' (baptized), 'Getuigen' (witnesses). Patronymic explanations are precise\u2014Hendricksz as 'son of Hendrick', Willems as 'child of Willem', Jans as 'child of Jan'. The critical distinction between baptism date (1698-03-05) and birth date is clearly established. No fabricated claims or unsupported assertions."
+          },
+          {
+            "source": "base",
+            "name": "Completeness",
+            "score": 3,
+            "rationale": "Response addresses all elements required by the test context: translates the full baptism structure, explains all three patronymic forms (Hendricksz, Willems, Jans), interprets 'getuigen' as witnesses/FAN figures, preserves original Dutch names without anglicization, and notes the baptism-vs-birth distinction. Provides structured analysis in Step 1\u20135, including critical genealogical warnings and next-steps guidance."
+          },
+          {
+            "source": "base",
+            "name": "Tool Arguments",
+            "score": null,
+            "rationale": "No MCP tool calls were made. The skill provided a self-contained translation and analysis of the baptism record without invoking external tools. This is appropriate for the translation task itself, though the skill did suggest optional next steps (record-extraction, person-evidence, research-plan) as recommendations for follow-up work."
+          },
+          {
+            "source": "rubric",
+            "name": "Accuracy",
+            "score": 3,
+            "rationale": "Translation preserves precise meaning of all genealogical terms. Relationship words ('son of', 'witnesses') are correctly rendered. Patronymic terms are faithfully translated and their significance explained. Original names (Pieter, Jan, Maria, Cornelis, Aaltje) are kept in Dutch form, not anglicized. The note about 'soon' as an older spelling of 'zoon' demonstrates sensitivity to period-specific variation. No distortion of genealogical meaning."
+          },
+          {
+            "source": "rubric",
+            "name": "Notation of uncertainty",
+            "score": 3,
+            "rationale": "Ambiguities and variant forms are explicitly flagged with interpretations provided. The 'soon' spelling is noted as a 'dialectal/older spelling' of zoon. The distinction between Reformed witnesses (no sacramental role) vs. Catholic godparents is explained. The gender note on Aaltje (female diminutive) shows careful attention to period context. Researcher can make informed choices rather than having assumptions silently embedded."
+          },
+          {
+            "source": "rubric",
+            "name": "Genealogical context",
+            "score": 3,
+            "rationale": "Skill explicitly identifies and explains genealogically significant terms: patronymic bynames explained with their generational nature (Pieter would become Pieter Jansz, not inherit Hendricksz), witnesses explained as FAN-cluster figures with research significance, baptism-vs-birth distinction emphasized with practical implications for database entry and searching, woman witness noted as notable in Reformed practice. The critical warnings in Step 4 directly address research pitfalls, not just linguistic translation."
+          }
+        ]
+      },
+      "totals": {
+        "duration_ms": 42403.568039000675,
+        "input_tokens": 6,
+        "cached_input_tokens": 13736,
+        "output_tokens": 1981,
+        "judge_input_tokens": 4412,
+        "judge_cached_input_tokens": 0,
+        "judge_output_tokens": 861,
+        "skill_cost_usd": 0.052954299999999996,
+        "judge_cost_usd": 0.008716999999999999,
+        "total_cost_usd": 0.0616713
+      },
+      "runs": [
+        {
+          "run_index": 0,
+          "run_id": "run_ut_translation_011_2026-06-22_19-33-09_0",
+          "outcome": "pass",
+          "aborted_reason": null,
+          "duration_ms": 42403.568039000675,
+          "input_tokens": 6,
+          "cached_input_tokens": 13736,
+          "output_tokens": 1981,
+          "skill_cost_usd": 0.052954299999999996,
+          "output": {
+            "text_response": "## Translation \u2014 Dutch Reformed Baptism Record, 1698\n\n---\n\n### Step 1 \u2014 Language & Record Type\n\n| Field | Value |\n|---|---|\n| **Language** | Early Modern Dutch (*Vroegmodern Nederlands*) |\n| **Record type** | Dutch Reformed (*Nederlands Hervormd*) baptism register |\n| **Period** | Late 17th century (1698) |\n| **Script** | Assumed Roman/Secretary hand \u2014 text provided as typed transcription |\n\n---\n\n### Step 2 \u2014 Original Text (as written)\n\n> Den 5 Maart 1698 is gedoopt Pieter, soon van Jan Hendricksz en Maria Willems. Getuigen waren Cornelis de Vries en Aaltje Jans.\n\nNo image was provided. The transcription is accepted as-is; one period spelling variant is noted below (*soon*).\n\n---\n\n### Step 3 \u2014 Translation *(derivative \u2014 the original governs)*\n\n> On the 5th of March 1698 was baptized Pieter, son of Jan Hendricksz and Maria Willems. The witnesses were Cornelis de Vries and Aaltje Jans.\n\n**Annotation notes:**\n\n- **soon** \u2014 older/dialectal spelling of *zoon* (son). Not a misreading; common in 17th-century Dutch records.\n- **is gedoopt** \u2014 *was baptized*. This is the **baptism date** (5 March 1698), **not** the birth date. Dutch Reformed registers typically record only the baptism; the birth likely occurred days earlier but is not documented here.\n- **Hendricksz** \u2014 abbreviation of *Hendrickszoon* (\"son of Hendrick\"). This is a **patronymic byname**, not a fixed hereditary surname. Jan's father was named Hendrick.\n- **Willems** \u2014 patronymic byname meaning \"daughter/child of Willem.\" Maria's father was named Willem.\n- **Aaltje Jans** \u2014 patronymic byname: Aaltje, daughter of Jan.\n- **Getuigen** \u2014 *witnesses*, the standard Dutch Reformed term. Unlike Catholic *getuigen* (godparents/sponsors), Reformed witnesses did not hold a sacramental role, but they are socially significant FAN-cluster (Friends, Associates, Neighbors) figures who may indicate kinship or community ties.\n\n---\n\n### Step 4 \u2014 Genealogically Relevant Information\n\n| Role | Name (original form) | Notes |\n|---|---|---|\n| **Subject** | Pieter | Male; baptized 5 March 1698 |\n| **Father** | Jan Hendricksz | Patronymic: son of Hendrick |\n| **Mother** | Maria Willems | Patronymic: daughter of Willem |\n| **Witness 1** | Cornelis de Vries | FAN figure; *de Vries* is a locative byname (\"the Frisian\") |\n| **Witness 2** | Aaltje Jans | FAN figure; patronymic: daughter of Jan |\n\n**Key dates (ISO 8601):**\n- Baptism: **1698-03-05**\n- Birth: *not recorded* \u2014 preceded baptism by days (typically 3\u201314 days in this period)\n\n**\u26a0 Critical distinctions for this record:**\n\n1. **Baptism \u2260 Birth.** Any database entry or assertion must record 1698-03-05 as the *baptism* date. A birth date should be estimated as \"before 5 March 1698\" \u2014 do not equate the two.\n2. **Patronymics \u2260 Hereditary surnames.** *Hendricksz* and *Willems* describe parentage for *this generation only*. Pieter would likely be recorded as **Pieter Jansz** (son of Jan) in his own adult records \u2014 not as Pieter Hendricksz. Searching for a hereditary surname will miss him.\n3. **Witness gender.** *Aaltje* is a female given name (diminutive of *Aafje/Aldegonda*), so the second witness is a woman \u2014 notable, as Dutch Reformed practice commonly included women witnesses unlike some other traditions.\n4. **Cornelis de Vries** \u2014 worth researching as a potential kinsman or neighbor. The shared witness appearance with Aaltje Jans may indicate a couple or related household.\n\n---\n\n### Step 5 \u2014 Suggested Next Steps\n\n- **\"Extract assertions from this record?\"** \u2192 invoke `record-extraction` to log the baptism event, parentage, and witnesses as individual assertions in `research.json` with proper citation.\n- **\"Link Pieter (or Jan Hendricksz) to the tree?\"** \u2192 invoke `person-evidence` after extraction.\n- **\"Find the birth record or earlier entries for Jan Hendricksz?\"** \u2192 invoke `research-plan` to target the same Dutch Reformed register for pre-1698 entries, or civil/notarial records that might document the birth interval.",
+            "activated": true,
+            "skills_invoked": [
+              "translation"
+            ],
+            "tool_calls": [],
+            "files_created": []
+          },
+          "validators": {
+            "passed": true,
+            "results": [
+              {
+                "name": "test_id_references_resolve",
+                "passed": true,
+                "error": "skipped: No research.json in output"
+              },
+              {
+                "name": "test_log_append_only",
+                "passed": true,
+                "error": "skipped: Missing research.json for diff"
+              },
+              {
+                "name": "test_no_entries_deleted",
+                "passed": true,
+                "error": "skipped: Missing research.json for diff"
+              },
+              {
+                "name": "test_ownership_table",
+                "passed": true,
+                "error": "skipped: Missing research.json for ownership diff"
+              },
+              {
+                "name": "test_research_json_validates_schema",
+                "passed": true,
+                "error": "skipped: No research.json in output"
+              },
+              {
+                "name": "test_tool_allowlist",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_gedcomx_json_validates_schema",
+                "passed": true,
+                "error": "skipped: No tree.gedcomx.json in output"
+              },
+              {
+                "name": "test_tree_ownership_table",
+                "passed": true,
+                "error": "skipped: Missing tree.gedcomx.json for ownership diff"
+              },
+              {
+                "name": "test_no_mcp_tools_called",
+                "passed": true,
+                "error": null
+              }
+            ]
+          },
+          "judge": {
+            "skipped": false,
+            "dimensions": [
+              {
+                "source": "base",
+                "name": "Correctness",
+                "score": 3,
+                "rationale": "Translation is factually accurate and faithful to the original Dutch. All genealogical terms are correct: 'soon' (son), 'gedoopt' (baptized), 'Getuigen' (witnesses). Patronymic explanations are precise\u2014Hendricksz as 'son of Hendrick', Willems as 'child of Willem', Jans as 'child of Jan'. The critical distinction between baptism date (1698-03-05) and birth date is clearly established. No fabricated claims or unsupported assertions."
+              },
+              {
+                "source": "base",
+                "name": "Completeness",
+                "score": 3,
+                "rationale": "Response addresses all elements required by the test context: translates the full baptism structure, explains all three patronymic forms (Hendricksz, Willems, Jans), interprets 'getuigen' as witnesses/FAN figures, preserves original Dutch names without anglicization, and notes the baptism-vs-birth distinction. Provides structured analysis in Step 1\u20135, including critical genealogical warnings and next-steps guidance."
+              },
+              {
+                "source": "base",
+                "name": "Tool Arguments",
+                "score": null,
+                "rationale": "No MCP tool calls were made. The skill provided a self-contained translation and analysis of the baptism record without invoking external tools. This is appropriate for the translation task itself, though the skill did suggest optional next steps (record-extraction, person-evidence, research-plan) as recommendations for follow-up work."
+              },
+              {
+                "source": "rubric",
+                "name": "Accuracy",
+                "score": 3,
+                "rationale": "Translation preserves precise meaning of all genealogical terms. Relationship words ('son of', 'witnesses') are correctly rendered. Patronymic terms are faithfully translated and their significance explained. Original names (Pieter, Jan, Maria, Cornelis, Aaltje) are kept in Dutch form, not anglicized. The note about 'soon' as an older spelling of 'zoon' demonstrates sensitivity to period-specific variation. No distortion of genealogical meaning."
+              },
+              {
+                "source": "rubric",
+                "name": "Notation of uncertainty",
+                "score": 3,
+                "rationale": "Ambiguities and variant forms are explicitly flagged with interpretations provided. The 'soon' spelling is noted as a 'dialectal/older spelling' of zoon. The distinction between Reformed witnesses (no sacramental role) vs. Catholic godparents is explained. The gender note on Aaltje (female diminutive) shows careful attention to period context. Researcher can make informed choices rather than having assumptions silently embedded."
+              },
+              {
+                "source": "rubric",
+                "name": "Genealogical context",
+                "score": 3,
+                "rationale": "Skill explicitly identifies and explains genealogically significant terms: patronymic bynames explained with their generational nature (Pieter would become Pieter Jansz, not inherit Hendricksz), witnesses explained as FAN-cluster figures with research significance, baptism-vs-birth distinction emphasized with practical implications for database entry and searching, woman witness noted as notable in Reformed practice. The critical warnings in Step 4 directly address research pitfalls, not just linguistic translation."
+              }
+            ],
+            "judge_cost_usd": 0.008716999999999999,
+            "error": null,
+            "input_tokens": 4412,
+            "cached_input_tokens": 0,
+            "output_tokens": 861
+          }
+        }
+      ]
+    },
+    {
+      "test_id": "ut_translation_004",
+      "test_type": "positive",
+      "expected_outcome": "pass",
+      "scenario": null,
+      "mcp_fixtures": [],
+      "outcome": "pass",
+      "flaky": false,
+      "outcome_summary": {
+        "per_run_outcomes": [
+          "pass"
+        ],
+        "aggregated_dimensions": [
+          {
+            "source": "base",
+            "name": "Correctness",
+            "score": 3,
+            "rationale": "The translation is factually accurate and faithful to the original French. Genealogical terms are correctly rendered: 'cultivateur' as farmer, 'son \u00e9pouse' as his wife, 'officier de l'\u00e9tat civil' as civil registrar. The critical date extraction (birth 14 March, registration 15 March) is correct. All proper names (Jean Baptiste Lef\u00e8vre, Marie Anne Dubois, Guillaume, Saint-Malo) are preserved in their original French forms. The explanation of the Napoleonic civil registration system and its formulaic structure is accurate. No fabricated material or unsupported claims."
+          },
+          {
+            "source": "base",
+            "name": "Completeness",
+            "score": 3,
+            "rationale": "The skill thoroughly addressed all required elements: translated the full record text accurately, preserved French names with genealogical context, explained all significant terms (d\u00e9clarant, son \u00e9pouse, cultivateur, officier de l'\u00e9tat civil, a comparu), flagged the distinction between birth date (14 March) and registration date (15 March), identified both parents with their relationship, noted the father's occupation and age, and provided context about the record's legal authority and format. Included a comprehensive table of genealogically relevant fields and suggested next steps for extraction and citation."
+          },
+          {
+            "source": "base",
+            "name": "Tool Arguments",
+            "score": null,
+            "rationale": "No MCP tool calls were made. The test explicitly notes '(none)' in the MCP tool calls section. Since the translation skill was instructed to produce text output only without invoking tools, this is appropriate and N/A."
+          },
+          {
+            "source": "rubric",
+            "name": "Accuracy",
+            "score": 3,
+            "rationale": "The translation preserves the precise meaning of all genealogical terms. 'Cultivateur' is correctly translated as farmer with historical context. 'Son \u00e9pouse' is rendered as 'his wife,' establishing the marital relationship. 'Officier de l'\u00e9tat civil' is correctly translated as 'civil registrar' with explanation of its dual role with the mayor. Names, places, dates, and relationships are all translated faithfully without distortion."
+          },
+          {
+            "source": "rubric",
+            "name": "Notation of uncertainty",
+            "score": 3,
+            "rationale": "The skill explicitly flags potential ambiguities and interpretive choices. It notes that 'vouloir donner le pr\u00e9nom' is formulaic legal language, not tentative. It clarifies that 'n\u00e9 hier' means the birth occurred the day before registration. It explains that mother's absence is normal practice, not an omission requiring clarification. Archaic or period-specific phrasing is identified and contextualized, allowing the genealogist to understand what is formulaic versus substantive."
+          },
+          {
+            "source": "rubric",
+            "name": "Genealogical context",
+            "score": 3,
+            "rationale": "The skill identifies and explains all genealogically significant terms with their research implications. It notes that 'cultivateur' is a social-status indicator. It explains that 'devant nous, maire' confirms legal authority under Napoleonic law. It flags the distinction between birth and registration dates as critical for chronology. It explains the legitimacy marker ('son \u00e9pouse') and why the mother's absence is normal. It provides context on the civil registration system's history (1792 introduction, 1804 Code Napol\u00e9on standardization). The genealogical value of this record as a parentage source is explicitly noted."
+          }
+        ]
+      },
+      "totals": {
+        "duration_ms": 42749.1518139941,
+        "input_tokens": 6,
+        "cached_input_tokens": 13802,
+        "output_tokens": 2204,
+        "judge_input_tokens": 4476,
+        "judge_cached_input_tokens": 0,
+        "judge_output_tokens": 910,
+        "skill_cost_usd": 0.05714635,
+        "judge_cost_usd": 0.009026,
+        "total_cost_usd": 0.06617234999999999
+      },
+      "runs": [
+        {
+          "run_index": 0,
+          "run_id": "run_ut_translation_004_2026-06-22_19-33-09_0",
+          "outcome": "pass",
+          "aborted_reason": null,
+          "duration_ms": 42749.1518139941,
+          "input_tokens": 6,
+          "cached_input_tokens": 13802,
+          "output_tokens": 2204,
+          "skill_cost_usd": 0.05714635,
+          "output": {
+            "text_response": "## Translation \u2014 French Civil Birth Record, 1843\n\n---\n\n### Step 1 \u2014 Language & Record Type\n\n- **Language:** French (standard 19th-century administrative French)\n- **Record type:** *Acte de naissance* \u2014 French civil birth registration\n- **Period:** 1843, under the Napoleonic civil registration system (introduced 1792, standardized by the Code Napol\u00e9on 1804). This is a highly formulaic government record, not a church baptism.\n\n---\n\n### Step 2 \u2014 Transcription (original governs)\n\n> L'an mil huit cent quarante-trois, le quinze mars, devant nous, maire et officier de l'\u00e9tat civil de la commune de Saint-Malo, a comparu Jean Baptiste Lef\u00e8vre, cultivateur, \u00e2g\u00e9 de trente ans, lequel nous a pr\u00e9sent\u00e9 un enfant du sexe masculin, n\u00e9 hier \u00e0 six heures du matin, de lui d\u00e9clarant et de Marie Anne Dubois, son \u00e9pouse, et auquel il a d\u00e9clar\u00e9 vouloir donner le pr\u00e9nom de Guillaume.\n\n*(No damage, abbreviations, or uncertain readings \u2014 text is complete and clear as provided.)*\n\n---\n\n### Step 3 \u2014 Translation *(derivative \u2014 the original governs)*\n\n> In the year one thousand eight hundred and forty-three, on the fifteenth of March, before us, mayor and civil registrar of the commune of Saint-Malo, appeared Jean Baptiste Lef\u00e8vre, farmer, aged thirty years, who presented to us a child of the male sex, born yesterday at six o'clock in the morning, to him, the declarant, and to Marie Anne Dubois, his wife, and to whom he declared he wished to give the given name Guillaume.\n\n---\n\n### Step 4 \u2014 Genealogically Relevant Information\n\n| Field | Value | Notes |\n|---|---|---|\n| **Child's name** | Guillaume Lef\u00e8vre | Given name only stated; surname inherited from father |\n| **Child's sex** | Male | *enfant du sexe masculin* |\n| **Birth date** | **14 March 1843** | *n\u00e9 hier* = \"born yesterday\" \u2014 the registration is 15 March, so birth was the day before |\n| **Registration date** | 15 March 1843 | Do not conflate with birth date |\n| **Birth time** | 6:00 a.m. | *six heures du matin* |\n| **Birth place** | Saint-Malo, France | Commune of registration; presumed same as birth place |\n| **Father** | Jean Baptiste Lef\u00e8vre | Declarant; present in person |\n| **Father's occupation** | *Cultivateur* (farmer/cultivator) | Agricultural laborer or small farmer |\n| **Father's age** | 30 years | Implies birth year of approximately 1812\u20131813 |\n| **Mother** | Marie Anne Dubois | Wife of the declarant; not present \u2014 mothers rarely appeared |\n| **Legitimacy** | Legitimate | *de lui d\u00e9clarant et de Marie Anne Dubois, son \u00e9pouse* \u2014 born of the declarant and **his wife** |\n| **Registrar** | Mayor of Saint-Malo | Acting as *officier de l'\u00e9tat civil* \u2014 standard Napoleonic formula |\n\n---\n\n### Key Annotations\n\n- \u26a0\ufe0f **Birth date vs. registration date.** The record was written on **15 March** but the child was born on **14 March**. *N\u00e9 hier* (\"born yesterday\") is the critical phrase. Always record 14 March 1843 as the birth date.\n- ***Cultivateur*** \u2014 In 19th-century France this typically means a working farmer or agricultural tenant, not necessarily a landowner. It is a social-status indicator worth noting.\n- ***Devant nous, maire*** \u2014 \"Before us, the mayor.\" The mayor of the commune legally doubled as the civil registrar (*officier de l'\u00e9tat civil*). This is a formulaic phrase confirming the record's legal authority.\n- ***Vouloir donner le pr\u00e9nom de Guillaume*** \u2014 \"Wished to give the given name Guillaume.\" French civil law required the father to formally declare the name at registration. This phrasing is the standard legal formula \u2014 it is not uncertain or tentative.\n- **Mother's absence** is normal. French law required the father (or a witness) to appear and register within three days of birth; mothers, still recovering, almost never appeared.\n\n---\n\n### Step 5 \u2014 Suggested Next Steps\n\n- **\"Extract assertions from this record?\"** \u2192 use **record-extraction** to log the birth date, parents, occupation, and place as citable assertions in `research.json`.\n- **\"Link Guillaume or Jean Baptiste to the tree?\"** \u2192 use **person-evidence** after extraction.\n- **\"Cite this record?\"** \u2192 use **citation** to format the *acte de naissance* reference following GPS/Chicago conventions once it has a source entry.",
+            "activated": true,
+            "skills_invoked": [
+              "translation"
+            ],
+            "tool_calls": [],
+            "files_created": []
+          },
+          "validators": {
+            "passed": true,
+            "results": [
+              {
+                "name": "test_id_references_resolve",
+                "passed": true,
+                "error": "skipped: No research.json in output"
+              },
+              {
+                "name": "test_log_append_only",
+                "passed": true,
+                "error": "skipped: Missing research.json for diff"
+              },
+              {
+                "name": "test_no_entries_deleted",
+                "passed": true,
+                "error": "skipped: Missing research.json for diff"
+              },
+              {
+                "name": "test_ownership_table",
+                "passed": true,
+                "error": "skipped: Missing research.json for ownership diff"
+              },
+              {
+                "name": "test_research_json_validates_schema",
+                "passed": true,
+                "error": "skipped: No research.json in output"
+              },
+              {
+                "name": "test_tool_allowlist",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_gedcomx_json_validates_schema",
+                "passed": true,
+                "error": "skipped: No tree.gedcomx.json in output"
+              },
+              {
+                "name": "test_tree_ownership_table",
+                "passed": true,
+                "error": "skipped: Missing tree.gedcomx.json for ownership diff"
+              },
+              {
+                "name": "test_no_mcp_tools_called",
+                "passed": true,
+                "error": null
+              }
+            ]
+          },
+          "judge": {
+            "skipped": false,
+            "dimensions": [
+              {
+                "source": "base",
+                "name": "Correctness",
+                "score": 3,
+                "rationale": "The translation is factually accurate and faithful to the original French. Genealogical terms are correctly rendered: 'cultivateur' as farmer, 'son \u00e9pouse' as his wife, 'officier de l'\u00e9tat civil' as civil registrar. The critical date extraction (birth 14 March, registration 15 March) is correct. All proper names (Jean Baptiste Lef\u00e8vre, Marie Anne Dubois, Guillaume, Saint-Malo) are preserved in their original French forms. The explanation of the Napoleonic civil registration system and its formulaic structure is accurate. No fabricated material or unsupported claims."
+              },
+              {
+                "source": "base",
+                "name": "Completeness",
+                "score": 3,
+                "rationale": "The skill thoroughly addressed all required elements: translated the full record text accurately, preserved French names with genealogical context, explained all significant terms (d\u00e9clarant, son \u00e9pouse, cultivateur, officier de l'\u00e9tat civil, a comparu), flagged the distinction between birth date (14 March) and registration date (15 March), identified both parents with their relationship, noted the father's occupation and age, and provided context about the record's legal authority and format. Included a comprehensive table of genealogically relevant fields and suggested next steps for extraction and citation."
+              },
+              {
+                "source": "base",
+                "name": "Tool Arguments",
+                "score": null,
+                "rationale": "No MCP tool calls were made. The test explicitly notes '(none)' in the MCP tool calls section. Since the translation skill was instructed to produce text output only without invoking tools, this is appropriate and N/A."
+              },
+              {
+                "source": "rubric",
+                "name": "Accuracy",
+                "score": 3,
+                "rationale": "The translation preserves the precise meaning of all genealogical terms. 'Cultivateur' is correctly translated as farmer with historical context. 'Son \u00e9pouse' is rendered as 'his wife,' establishing the marital relationship. 'Officier de l'\u00e9tat civil' is correctly translated as 'civil registrar' with explanation of its dual role with the mayor. Names, places, dates, and relationships are all translated faithfully without distortion."
+              },
+              {
+                "source": "rubric",
+                "name": "Notation of uncertainty",
+                "score": 3,
+                "rationale": "The skill explicitly flags potential ambiguities and interpretive choices. It notes that 'vouloir donner le pr\u00e9nom' is formulaic legal language, not tentative. It clarifies that 'n\u00e9 hier' means the birth occurred the day before registration. It explains that mother's absence is normal practice, not an omission requiring clarification. Archaic or period-specific phrasing is identified and contextualized, allowing the genealogist to understand what is formulaic versus substantive."
+              },
+              {
+                "source": "rubric",
+                "name": "Genealogical context",
+                "score": 3,
+                "rationale": "The skill identifies and explains all genealogically significant terms with their research implications. It notes that 'cultivateur' is a social-status indicator. It explains that 'devant nous, maire' confirms legal authority under Napoleonic law. It flags the distinction between birth and registration dates as critical for chronology. It explains the legitimacy marker ('son \u00e9pouse') and why the mother's absence is normal. It provides context on the civil registration system's history (1792 introduction, 1804 Code Napol\u00e9on standardization). The genealogical value of this record as a parentage source is explicitly noted."
+              }
+            ],
+            "judge_cost_usd": 0.009026,
+            "error": null,
+            "input_tokens": 4476,
+            "cached_input_tokens": 0,
+            "output_tokens": 910
+          }
+        }
+      ]
+    },
+    {
+      "test_id": "ut_translation_001",
+      "test_type": "positive",
+      "expected_outcome": "pass",
+      "scenario": null,
+      "mcp_fixtures": [],
+      "outcome": "pass",
+      "flaky": false,
+      "outcome_summary": {
+        "per_run_outcomes": [
+          "pass"
+        ],
+        "aggregated_dimensions": [
+          {
+            "source": "base",
+            "name": "Correctness",
+            "score": 3,
+            "rationale": "Translation is factually accurate. All genealogical terms are correctly rendered: 'ehelicher Sohn' as 'legitimate son,' 'geb.' as 'n\u00e9e,' 'Bergmann' as 'miner,' 'Taufpaten' as 'godparents.' Date (15 March 1845), names (Johann Friedrich, Thomas Flynn, Maria, Patrick O'Brien, Bridget Mahoney), relationships, and occupations are all correctly preserved. No fabrication or contradiction of the source material."
+          },
+          {
+            "source": "base",
+            "name": "Completeness",
+            "score": 3,
+            "rationale": "The skill addressed all required elements: the structural shape of the baptism entry (date, baptized child, parents with maiden name, godparents), genealogically significant terms explained, cultural context flagged, and proper names preserved in original form. All components the input state made obvious were covered without silent omissions."
+          },
+          {
+            "source": "base",
+            "name": "Tool Arguments",
+            "score": null,
+            "rationale": "No MCP tool calls were made. The skill provided a pure text translation with annotation \u2014 no tools were invoked. N/A."
+          },
+          {
+            "source": "rubric",
+            "name": "Accuracy",
+            "score": 3,
+            "rationale": "Translation preserves meaning of genealogical terms with precision. 'Ehelicher Sohn' correctly rendered as 'legitimate son' (distinct from illegitimate), 'Bergmann' as 'miner' with etymological breakdown, 'geb.' as 'n\u00e9e,' 'Taufpaten' as 'godparents.' Names and places remain in original form. No term loses genealogical significance in translation."
+          },
+          {
+            "source": "rubric",
+            "name": "Notation of uncertainty",
+            "score": 3,
+            "rationale": "The skill explicitly flags a key ambiguity: the baptism date (15 March 1845) records the sacrament, not necessarily the birth date. It clearly states 'The birth date is NOT stated in this entry' and notes 'Likely within days of 15 Mar 1845, but must be sourced separately.' Ambiguous or archaic abbreviations are all explained (geb. = geborene, Berg compound etymology)."
+          },
+          {
+            "source": "rubric",
+            "name": "Genealogical context",
+            "score": 3,
+            "rationale": "Skill identifies and explains genealogically significant terms with full context. 'Ehelicher Sohn' is explained as confirming marriage predates baptism, with antonym noted for inheritance implications. 'Geb.' is flagged as essential for researching mother's origins. 'Bergmann' occupation points toward mining district research. The skill identifies the Irish-German cultural mismatch and explains FAN-club research implications (godparents as community connections). Provides substantial research context beyond literal translation."
+          }
+        ]
+      },
+      "totals": {
+        "duration_ms": 40632.109620004485,
+        "input_tokens": 6,
+        "cached_input_tokens": 13743,
+        "output_tokens": 1851,
+        "judge_input_tokens": 4269,
+        "judge_cached_input_tokens": 0,
+        "judge_output_tokens": 788,
+        "skill_cost_usd": 0.0511634,
+        "judge_cost_usd": 0.008209000000000001,
+        "total_cost_usd": 0.0593724
+      },
+      "runs": [
+        {
+          "run_index": 0,
+          "run_id": "run_ut_translation_001_2026-06-22_19-33-09_0",
+          "outcome": "pass",
+          "aborted_reason": null,
+          "duration_ms": 40632.109620004485,
+          "input_tokens": 6,
+          "cached_input_tokens": 13743,
+          "output_tokens": 1851,
+          "skill_cost_usd": 0.0511634,
+          "output": {
+            "text_response": "## Translation \u2014 German Baptism Record, 1845\n\n---\n\n### Original (as provided)\n\n> Den 15. M\u00e4rz 1845 wurde Johann Friedrich, ehelicher Sohn des Thomas Flynn, Bergmann, und seiner Ehefrau Maria geb. Kelly, getauft. Taufpaten: Patrick O'Brien und Bridget Mahoney.\n\n---\n\n### Translation *(derivative \u2014 the original governs)*\n\n> On 15 March 1845, Johann Friedrich, legitimate son of Thomas Flynn, miner, and his wife Maria, n\u00e9e Kelly, was baptized. Godparents: Patrick O'Brien and Bridget Mahoney.\n\n---\n\n### Annotation & Vocabulary Notes\n\n| Term | Original form | Meaning |\n|---|---|---|\n| *ehelicher Sohn* | ehelicher Sohn | **Legitimate son** \u2014 born within marriage. Confirms Thomas Flynn and Maria Kelly were married prior to this baptism. The antonym, *unehelicher Sohn*, would signal illegitimacy. |\n| *geb.* | geb. (= *geborene*) | **N\u00e9e** \u2014 the mother's maiden surname. Maria's birth name was **Kelly**; she took Flynn upon marriage. This is critical for researching her own origins. |\n| *Bergmann* | Bergmann | **Miner** \u2014 the father's stated occupation. Compounds: *Berg* (mountain/mine) + *Mann* (man). Points toward a mining district; worth identifying the parish location to narrow the mine. |\n| *Taufpaten* | Taufpaten | **Godparents** (plural of *Taufpate*). The record lists one male (*Pate*) and one female (*Patin*) sponsor without distinguishing them by role. |\n| *wurde \u2026 getauft* | passive construction | The passive voice (*was baptized*) is standard formulaic phrasing \u2014 it records the **baptism date (15 March 1845)**, not necessarily the birth date. The birth date is **not stated** in this entry. |\n\n---\n\n### Genealogically Relevant Information\n\n| Field | Value | Notes |\n|---|---|---|\n| **Event** | Baptism | Date: **1845-03-15** |\n| **Subject** | Johann Friedrich | Male child; names kept in original form |\n| **Father** | Thomas Flynn | Occupation: miner (*Bergmann*) |\n| **Mother** | Maria Flynn, *geb.* Kelly | Maiden name: **Kelly** |\n| **Parents' status** | Married (*ehelicher Sohn*) | Marriage predates this baptism |\n| **Godparent 1** | Patrick O'Brien | Male sponsor |\n| **Godparent 2** | Bridget Mahoney | Female sponsor |\n| **Birth date** | Not recorded | Likely within days of 15 Mar 1845, but must be sourced separately |\n\n---\n\n### \u26a0\ufe0f Notable Observation \u2014 Irish Names in a German Record\n\nAll four surnames \u2014 **Flynn, Kelly, O'Brien, Mahoney** \u2014 are distinctly Irish. This family appears to be **Irish immigrants living in a German-speaking region**, likely drawn by mining work (the mid-19th century saw significant Irish labor migration to German coalfields, particularly in the Ruhr and Saar regions). This has research implications:\n\n- The **parish location** (not stated in the extract you provided) is essential \u2014 it would identify the German mining district and may appear in a register header or column not included here.\n- Godparents O'Brien and Mahoney likely belonged to the **same Irish immigrant community** \u2014 a FAN-club connection worth pursuing.\n- A marriage record for **Thomas Flynn \u00d7 Maria Kelly** should exist, possibly in the same parish register or in Ireland before emigration.\n\n---\n\n### Suggested Next Steps\n\n1. **\"Extract these facts into research.json?\"** \u2014 use **record-extraction** to log dated assertions (baptism, parentage, occupation, godparent relationships).\n2. **\"Search for a marriage record for Thomas Flynn and Maria Kelly?\"** \u2014 use **research-plan** or **search-records** to locate their marriage in this parish or in Ireland.\n3. **\"What was Irish immigration to German mining regions like in the 1840s?\"** \u2014 use **historical-context** for background on the Famine-era migration that likely brought this family to Germany.",
+            "activated": true,
+            "skills_invoked": [
+              "translation"
+            ],
+            "tool_calls": [],
+            "files_created": []
+          },
+          "validators": {
+            "passed": true,
+            "results": [
+              {
+                "name": "test_id_references_resolve",
+                "passed": true,
+                "error": "skipped: No research.json in output"
+              },
+              {
+                "name": "test_log_append_only",
+                "passed": true,
+                "error": "skipped: Missing research.json for diff"
+              },
+              {
+                "name": "test_no_entries_deleted",
+                "passed": true,
+                "error": "skipped: Missing research.json for diff"
+              },
+              {
+                "name": "test_ownership_table",
+                "passed": true,
+                "error": "skipped: Missing research.json for ownership diff"
+              },
+              {
+                "name": "test_research_json_validates_schema",
+                "passed": true,
+                "error": "skipped: No research.json in output"
+              },
+              {
+                "name": "test_tool_allowlist",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_gedcomx_json_validates_schema",
+                "passed": true,
+                "error": "skipped: No tree.gedcomx.json in output"
+              },
+              {
+                "name": "test_tree_ownership_table",
+                "passed": true,
+                "error": "skipped: Missing tree.gedcomx.json for ownership diff"
+              },
+              {
+                "name": "test_no_mcp_tools_called",
+                "passed": true,
+                "error": null
+              }
+            ]
+          },
+          "judge": {
+            "skipped": false,
+            "dimensions": [
+              {
+                "source": "base",
+                "name": "Correctness",
+                "score": 3,
+                "rationale": "Translation is factually accurate. All genealogical terms are correctly rendered: 'ehelicher Sohn' as 'legitimate son,' 'geb.' as 'n\u00e9e,' 'Bergmann' as 'miner,' 'Taufpaten' as 'godparents.' Date (15 March 1845), names (Johann Friedrich, Thomas Flynn, Maria, Patrick O'Brien, Bridget Mahoney), relationships, and occupations are all correctly preserved. No fabrication or contradiction of the source material."
+              },
+              {
+                "source": "base",
+                "name": "Completeness",
+                "score": 3,
+                "rationale": "The skill addressed all required elements: the structural shape of the baptism entry (date, baptized child, parents with maiden name, godparents), genealogically significant terms explained, cultural context flagged, and proper names preserved in original form. All components the input state made obvious were covered without silent omissions."
+              },
+              {
+                "source": "base",
+                "name": "Tool Arguments",
+                "score": null,
+                "rationale": "No MCP tool calls were made. The skill provided a pure text translation with annotation \u2014 no tools were invoked. N/A."
+              },
+              {
+                "source": "rubric",
+                "name": "Accuracy",
+                "score": 3,
+                "rationale": "Translation preserves meaning of genealogical terms with precision. 'Ehelicher Sohn' correctly rendered as 'legitimate son' (distinct from illegitimate), 'Bergmann' as 'miner' with etymological breakdown, 'geb.' as 'n\u00e9e,' 'Taufpaten' as 'godparents.' Names and places remain in original form. No term loses genealogical significance in translation."
+              },
+              {
+                "source": "rubric",
+                "name": "Notation of uncertainty",
+                "score": 3,
+                "rationale": "The skill explicitly flags a key ambiguity: the baptism date (15 March 1845) records the sacrament, not necessarily the birth date. It clearly states 'The birth date is NOT stated in this entry' and notes 'Likely within days of 15 Mar 1845, but must be sourced separately.' Ambiguous or archaic abbreviations are all explained (geb. = geborene, Berg compound etymology)."
+              },
+              {
+                "source": "rubric",
+                "name": "Genealogical context",
+                "score": 3,
+                "rationale": "Skill identifies and explains genealogically significant terms with full context. 'Ehelicher Sohn' is explained as confirming marriage predates baptism, with antonym noted for inheritance implications. 'Geb.' is flagged as essential for researching mother's origins. 'Bergmann' occupation points toward mining district research. The skill identifies the Irish-German cultural mismatch and explains FAN-club research implications (godparents as community connections). Provides substantial research context beyond literal translation."
+              }
+            ],
+            "judge_cost_usd": 0.008209000000000001,
+            "error": null,
+            "input_tokens": 4269,
+            "cached_input_tokens": 0,
+            "output_tokens": 788
+          }
+        }
+      ]
+    },
+    {
+      "test_id": "ut_translation_007",
+      "test_type": "positive",
+      "expected_outcome": "pass",
+      "scenario": null,
+      "mcp_fixtures": [],
+      "outcome": "pass",
+      "flaky": false,
+      "outcome_summary": {
+        "per_run_outcomes": [
+          "pass"
+        ],
+        "aggregated_dimensions": [
+          {
+            "source": "base",
+            "name": "Correctness",
+            "score": 3,
+            "rationale": "The translation is factually accurate and faithful to the Italian original. All genealogical terms are correctly rendered: 'figlio del fu Antonio' \u2192 'son of the late Antonio,' 'd'et\u00e0 d'anni sessanta in circa' \u2192 'approximately sixty years,' 'munito de' Santissimi Sacramenti' \u2192 'fortified with the Most Holy Sacraments,' and the Latin closing 'Anima eius requiescat in pace' \u2192 'May his soul rest in peace.' Names are preserved in original form (Giovanni Battista Rossi, not anglicized). The derived birth-year approximation (c. 1688) follows logically from the stated age."
+          },
+          {
+            "source": "base",
+            "name": "Completeness",
+            "score": 3,
+            "rationale": "The skill fully addressed the user's request. It translated the entire Italian text and the Latin closing. It identified the bilingual nature of the record (Italian body + Latin formula). It extracted all key genealogical facts (names, relationships, dates, age, burial location, sacraments) and provided a structured annotation table explaining each significant element. It also flagged the distinction between burial date and death date, and suggested appropriate next research steps."
+          },
+          {
+            "source": "base",
+            "name": "Tool Arguments",
+            "score": null,
+            "rationale": "No MCP tool calls were made. The skill was a translation task that did not require tool invocations to fulfill the user's request. N/A."
+          },
+          {
+            "source": "rubric",
+            "name": "Accuracy",
+            "score": 3,
+            "rationale": "The translation preserves the precise meaning of all genealogical terms. 'Fu' is correctly identified as signaling 'the late' (deceased). Relationship terms ('figlio' \u2192 'son'), occupation-adjacent status indicators (burial inside the church as a privilege), religious terminology ('Santissimi Sacramenti' \u2192 'Most Holy Sacraments'), and the death formula ('rese l'anima a Dio' \u2192 'gave up his soul to God') are all accurately conveyed. Place name (San Lorenzo) and personal names remain in original form."
+          },
+          {
+            "source": "rubric",
+            "name": "Notation of uncertainty",
+            "score": 3,
+            "rationale": "The skill explicitly flags ambiguities and estimates. It marks 'in circa' as a qualifying phrase indicating the priest was estimating age, and notes 'Do not treat this as an exact birth record.' It distinguishes burial date from death date and cautions that an exact death date may require consulting a separate mortality register. The abbreviation 'de'' is explained as 'a standard elision of dei.' All interpretive choices are flagged and justified."
+          },
+          {
+            "source": "rubric",
+            "name": "Genealogical context",
+            "score": 3,
+            "rationale": "The skill provides rich genealogical interpretation beyond literal translation. It explains that 'fu' signals a firm ante-quem death date for the father Antonio, derives an estimated birth year (~1688) for further research, notes that burial inside the church implies social standing, clarifies that 'munito de' Santissimi Sacramenti' indicates a non-sudden Catholic death with priestly attendance, and distinguishes the Latin closing formula as a standard Catholic European practice. It suggests concrete next steps for record extraction and further searches."
+          }
+        ]
+      },
+      "totals": {
+        "duration_ms": 53700.376342996606,
+        "input_tokens": 6,
+        "cached_input_tokens": 13773,
+        "output_tokens": 2565,
+        "judge_input_tokens": 4615,
+        "judge_cached_input_tokens": 0,
+        "judge_output_tokens": 886,
+        "skill_cost_usd": 0.06219990000000001,
+        "judge_cost_usd": 0.009045000000000001,
+        "total_cost_usd": 0.07124490000000001
+      },
+      "runs": [
+        {
+          "run_index": 0,
+          "run_id": "run_ut_translation_007_2026-06-22_19-33-09_0",
+          "outcome": "pass",
+          "aborted_reason": null,
+          "duration_ms": 53700.376342996606,
+          "input_tokens": 6,
+          "cached_input_tokens": 13773,
+          "output_tokens": 2565,
+          "skill_cost_usd": 0.06219990000000001,
+          "output": {
+            "text_response": "## Translation: Italian Parish Burial Record, 1748\n\n---\n\n### Step 1 \u2014 Language & Record Type\n\n- **Language:** Italian (vernacular), with a Latin closing formula \u2014 a mixed-language pattern standard in 18th-century Italian parish registers\n- **Record type:** Burial entry (*atto di sepoltura*), parish register\n- **Period:** 1748, mid-18th century Catholic Italy\n- **Script concern:** Text is already in Roman script; no paleographic ambiguity. The abbreviation \"de'\" is a standard elision of *dei*.\n\n---\n\n### Step 2 \u2014 Transcription (original governs)\n\n> Ad\u00ec 14 Marzo 1748. Giovanni Battista Rossi, figlio del fu Antonio, d'et\u00e0 d'anni sessanta in circa, munito de' Santissimi Sacramenti, rese l'anima a Dio, ed il suo corpo fu sepolto nella chiesa parrocchiale di San Lorenzo. Anima eius requiescat in pace.\n\n*Transcription matches the text as supplied. No damaged or illegible passages.*\n\n---\n\n### Step 3 \u2014 Translation *(derivative \u2014 the original governs)*\n\n> On the 14th of March 1748. Giovanni Battista Rossi, son of the late Antonio, of age approximately sixty years, fortified with the Most Holy Sacraments, gave up his soul to God, and his body was buried in the parish church of San Lorenzo. May his soul rest in peace.\n\n---\n\n### Step 4 \u2014 Annotations & Genealogically Relevant Information\n\n| Element | Original | Meaning & Notes |\n|---|---|---|\n| **Date formula** | *Ad\u00ec 14 Marzo 1748* | \"Ad\u00ec\" is from Latin *ad diem* \u2014 \"on the day of.\" A hallmark of Italian ecclesiastical records. This is the **burial date**, not necessarily the death date (death likely preceded by 1\u20132 days). |\n| **Subject** | *Giovanni Battista Rossi* | Full name of the deceased. Keep in original Italian form \u2014 do not anglicize to \"John Baptist.\" |\n| **Father** | *figlio del fu Antonio* | \"Son of the **late** Antonio.\" The word ***fu*** is critical: it confirms Antonio Rossi was **already deceased** by 14 March 1748. This is a firm *ante quem* death date for Antonio. |\n| **Age** | *d'et\u00e0 d'anni sessanta in circa* | \"Of age approximately sixty years.\" The qualifier *in circa* (\"about\") signals the priest was estimating \u2014 a common practice. Approximate birth year: **c. 1688**. Do not treat this as an exact birth record. |\n| **Last Rites** | *munito de' Santissimi Sacramenti* | \"Fortified with the Most Holy Sacraments\" \u2014 a formulaic phrase confirming he received **Last Rites** (Confession, Viaticum, and Extreme Unction). His death was not sudden; a priest attended him. |\n| **Death phrase** | *rese l'anima a Dio* | Literally \"rendered his soul to God\" \u2014 the standard Italian formula for death in parish registers. |\n| **Burial place** | *chiesa parrocchiale di San Lorenzo* | Buried **inside** the parish church of San Lorenzo, not in the churchyard. Burial within church walls was a social privilege, suggesting Giovanni Battista had some standing in the community. |\n| **Latin closing** | *Anima eius requiescat in pace* | Classical Latin: \"May his soul rest in peace.\" The familiar R.I.P. formula. The scribe switches to Latin here \u2014 standard practice across Catholic Europe. |\n\n---\n\n### Key Facts Extracted\n\n| Field | Value |\n|---|---|\n| **Deceased** | Giovanni Battista Rossi |\n| **Father** | Antonio Rossi (*fu* \u2014 deceased before 14 March 1748) |\n| **Event** | Burial |\n| **Date** | 14 March 1748 (burial date; death date not recorded separately) |\n| **Estimated birth year** | c. 1688 (age ~60) |\n| **Parish** | San Lorenzo (location of parish not specified in the text \u2014 look to the register's header or cover) |\n| **Burial location** | Inside the parish church \u2014 not the churchyard |\n| **Sacraments received** | Yes \u2014 not a sudden or unsanctioned death |\n| **Mother's name** | Not recorded |\n| **Witnesses/gravedigger** | Not recorded in this entry |\n\n---\n\n### \u26a0\ufe0f One Genealogical Caution\n\nThe record gives **only a burial date**. If you need to establish an exact death date, you would need to check whether the register has a separate *Liber Mortuorum* (death register) that might record the day of death alongside the burial entry. Many 18th-century Italian parishes kept burial and death dates in separate columns or books.\n\n---\n\n### Suggested Next Steps\n\n- **\"Extract assertions from this record?\"** \u2192 use **record-extraction** to log Giovanni Battista's burial, his estimated birth year (~1688), and his father Antonio's pre-1748 death as formal assertions in `research.json`.\n- **\"Search for Antonio Rossi's burial or death record?\"** \u2014 since *fu* confirms Antonio predeceased his son, a search of earlier register volumes for San Lorenzo could establish Antonio's death date and potentially Giovanni Battista's birth/baptism entry.\n- **\"Link Giovanni Battista Rossi to the tree?\"** \u2192 use **person-evidence** once assertions are extracted.",
+            "activated": true,
+            "skills_invoked": [
+              "translation"
+            ],
+            "tool_calls": [],
+            "files_created": []
+          },
+          "validators": {
+            "passed": true,
+            "results": [
+              {
+                "name": "test_id_references_resolve",
+                "passed": true,
+                "error": "skipped: No research.json in output"
+              },
+              {
+                "name": "test_log_append_only",
+                "passed": true,
+                "error": "skipped: Missing research.json for diff"
+              },
+              {
+                "name": "test_no_entries_deleted",
+                "passed": true,
+                "error": "skipped: Missing research.json for diff"
+              },
+              {
+                "name": "test_ownership_table",
+                "passed": true,
+                "error": "skipped: Missing research.json for ownership diff"
+              },
+              {
+                "name": "test_research_json_validates_schema",
+                "passed": true,
+                "error": "skipped: No research.json in output"
+              },
+              {
+                "name": "test_tool_allowlist",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_gedcomx_json_validates_schema",
+                "passed": true,
+                "error": "skipped: No tree.gedcomx.json in output"
+              },
+              {
+                "name": "test_tree_ownership_table",
+                "passed": true,
+                "error": "skipped: Missing tree.gedcomx.json for ownership diff"
+              },
+              {
+                "name": "test_no_mcp_tools_called",
+                "passed": true,
+                "error": null
+              }
+            ]
+          },
+          "judge": {
+            "skipped": false,
+            "dimensions": [
+              {
+                "source": "base",
+                "name": "Correctness",
+                "score": 3,
+                "rationale": "The translation is factually accurate and faithful to the Italian original. All genealogical terms are correctly rendered: 'figlio del fu Antonio' \u2192 'son of the late Antonio,' 'd'et\u00e0 d'anni sessanta in circa' \u2192 'approximately sixty years,' 'munito de' Santissimi Sacramenti' \u2192 'fortified with the Most Holy Sacraments,' and the Latin closing 'Anima eius requiescat in pace' \u2192 'May his soul rest in peace.' Names are preserved in original form (Giovanni Battista Rossi, not anglicized). The derived birth-year approximation (c. 1688) follows logically from the stated age."
+              },
+              {
+                "source": "base",
+                "name": "Completeness",
+                "score": 3,
+                "rationale": "The skill fully addressed the user's request. It translated the entire Italian text and the Latin closing. It identified the bilingual nature of the record (Italian body + Latin formula). It extracted all key genealogical facts (names, relationships, dates, age, burial location, sacraments) and provided a structured annotation table explaining each significant element. It also flagged the distinction between burial date and death date, and suggested appropriate next research steps."
+              },
+              {
+                "source": "base",
+                "name": "Tool Arguments",
+                "score": null,
+                "rationale": "No MCP tool calls were made. The skill was a translation task that did not require tool invocations to fulfill the user's request. N/A."
+              },
+              {
+                "source": "rubric",
+                "name": "Accuracy",
+                "score": 3,
+                "rationale": "The translation preserves the precise meaning of all genealogical terms. 'Fu' is correctly identified as signaling 'the late' (deceased). Relationship terms ('figlio' \u2192 'son'), occupation-adjacent status indicators (burial inside the church as a privilege), religious terminology ('Santissimi Sacramenti' \u2192 'Most Holy Sacraments'), and the death formula ('rese l'anima a Dio' \u2192 'gave up his soul to God') are all accurately conveyed. Place name (San Lorenzo) and personal names remain in original form."
+              },
+              {
+                "source": "rubric",
+                "name": "Notation of uncertainty",
+                "score": 3,
+                "rationale": "The skill explicitly flags ambiguities and estimates. It marks 'in circa' as a qualifying phrase indicating the priest was estimating age, and notes 'Do not treat this as an exact birth record.' It distinguishes burial date from death date and cautions that an exact death date may require consulting a separate mortality register. The abbreviation 'de'' is explained as 'a standard elision of dei.' All interpretive choices are flagged and justified."
+              },
+              {
+                "source": "rubric",
+                "name": "Genealogical context",
+                "score": 3,
+                "rationale": "The skill provides rich genealogical interpretation beyond literal translation. It explains that 'fu' signals a firm ante-quem death date for the father Antonio, derives an estimated birth year (~1688) for further research, notes that burial inside the church implies social standing, clarifies that 'munito de' Santissimi Sacramenti' indicates a non-sudden Catholic death with priestly attendance, and distinguishes the Latin closing formula as a standard Catholic European practice. It suggests concrete next steps for record extraction and further searches."
+              }
+            ],
+            "judge_cost_usd": 0.009045000000000001,
+            "error": null,
+            "input_tokens": 4615,
+            "cached_input_tokens": 0,
+            "output_tokens": 886
+          }
+        }
+      ]
+    },
+    {
+      "test_id": "ut_translation_002",
+      "test_type": "positive",
+      "expected_outcome": "pass",
+      "scenario": null,
+      "mcp_fixtures": [],
+      "outcome": "pass",
+      "flaky": false,
+      "outcome_summary": {
+        "per_run_outcomes": [
+          "pass"
+        ],
+        "aggregated_dimensions": [
+          {
+            "source": "base",
+            "name": "Correctness",
+            "score": 3,
+            "rationale": "Translation is factually accurate and faithful to the Latin original. All genealogical terms (filius/filia, matrimonium iniverunt, praesentibus testibus, parochus) are correctly rendered with proper meaning preservation. Names are accurately Latinized (Joannis\u2192John, Patricius\u2192Patrick, Brigitta\u2192Bridget). Dates, places, and relationships match the source exactly. No fabricated material or unsupported claims."
+          },
+          {
+            "source": "base",
+            "name": "Completeness",
+            "score": 3,
+            "rationale": "Skill addressed all required elements: translation of the full record text, explanation of all genealogically significant terms, flagging of Latinized names with normalization guidance, extraction of both sets of parents, witnesses, and officiant. Also provided research tips and next steps as appropriate extensions. No silent omissions of items the input state made obvious."
+          },
+          {
+            "source": "base",
+            "name": "Tool Arguments",
+            "score": null,
+            "rationale": "No MCP tool calls were made in this response. The skill was asked to translate and analyze a text record, which it accomplished through pure analysis without needing external tools. N/A \u2014 zero tool calls made."
+          },
+          {
+            "source": "rubric",
+            "name": "Accuracy",
+            "score": 3,
+            "rationale": "Translation preserves genealogical meaning faithfully. Key terms translated correctly: matrimonium iniverunt (entered into matrimony \u2014 sacramental formula), filius/filia (son/daughter \u2014 legitimacy indicator), praesentibus testibus (witnesses present \u2014 canonical requirement), parochus (parish priest \u2014 required by Tridentine law). Parentage structure preserved exactly. All names normalized accurately from genitive/ablative to nominative forms."
+          },
+          {
+            "source": "rubric",
+            "name": "Notation of uncertainty",
+            "score": 3,
+            "rationale": "Skill explicitly flagged the one genuine ambiguity: Rev. J. Murphy's first name is abbreviated and 'not recoverable from this entry alone.' The skill notes that no paleographic ambiguity exists in the supplied text and explicitly lists abbreviation expansions (S. Patricii\u2192Sancti Patricii; Rev.\u2192Reverendus). Alternatives for Latinized names are spelled out in the normalization table. No silent guessing."
+          },
+          {
+            "source": "rubric",
+            "name": "Genealogical context",
+            "score": 3,
+            "rationale": "Skill thoroughly explained genealogically significant terms with research context: matrimonium iniverunt noted as Tridentine sacramental formula confirming valid marriage (not banns); filius/filia explained as legitimacy markers; praesentibus testibus explained as ablative absolute fulfilling canonical witness requirement under Trent; parochus identified as required officiant. Research tips connect witness surnames to cluster leads, explain why baptism records are needed for grandparents, and suggest diocesan directories for officiant identification."
+          }
+        ]
+      },
+      "totals": {
+        "duration_ms": 54850.38730499946,
+        "input_tokens": 6,
+        "cached_input_tokens": 13772,
+        "output_tokens": 2727,
+        "judge_input_tokens": 4874,
+        "judge_cached_input_tokens": 0,
+        "judge_output_tokens": 796,
+        "skill_cost_usd": 0.0646886,
+        "judge_cost_usd": 0.008854,
+        "total_cost_usd": 0.0735426
+      },
+      "runs": [
+        {
+          "run_index": 0,
+          "run_id": "run_ut_translation_002_2026-06-22_19-33-09_0",
+          "outcome": "pass",
+          "aborted_reason": null,
+          "duration_ms": 54850.38730499946,
+          "input_tokens": 6,
+          "cached_input_tokens": 13772,
+          "output_tokens": 2727,
+          "skill_cost_usd": 0.0646886,
+          "output": {
+            "text_response": "## Translation \u2014 Latin Catholic Marriage Record, 1845\n\n---\n\n### Step 1 \u2014 Language & Record Type\n\n| Field | Value |\n|---|---|\n| **Language** | Ecclesiastical Latin |\n| **Record type** | Catholic parish marriage register entry |\n| **Period** | 1845 \u2014 post-Tridentine format (Council of Trent, 1563, mandated standard marriage registers) |\n| **Script** | Printed/manuscript \u2014 no paleographic ambiguity in the supplied text |\n\n---\n\n### Step 2 \u2014 Original Transcription *(as written; the original governs)*\n\n> Die 12 Maii 1845, in ecclesia parochiali S. Patricii, matrimonium iniverunt Thomas Flynn, filius Joannis et Mariae, et Maria Kelly, filia Patricii et Brigittae, praesentibus testibus Patricio O'Brien et Brigitta Mahoney. Parochus: Rev. J. Murphy.\n\nNo damage, illegible passages, or uncertain readings to flag.\n\n---\n\n### Step 3 \u2014 Translation *(derivative \u2014 the original governs)*\n\n> On the 12th day of May 1845, in the parish church of Saint Patrick, Thomas Flynn, son of John and Mary, and Maria Kelly, daughter of Patrick and Bridget, entered into matrimony, in the presence of witnesses Patrick O'Brien and Brigitta Mahoney. Parish priest: Rev. J. Murphy.\n\n---\n\n### Step 4 \u2014 Annotation & Genealogical Notes\n\n#### Abbreviation expansions\n\n| As written | Expanded | Meaning |\n|---|---|---|\n| `S. Patricii` | *Sancti Patricii* | of Saint Patrick (genitive) |\n| `Rev. J. Murphy` | *Reverendus J. Murphy* | Reverend J. Murphy \u2014 first name abbreviated; not recoverable from this entry alone |\n\n#### Latin grammar \u2014 names in the genitive case\n\nLatin records state parentage using the **genitive case** (\"of John,\" \"of Mary\"). These are **not errors or variant spellings** \u2014 normalize to the nominative for research purposes:\n\n| As written (genitive) | Nominative form | English equivalent |\n|---|---|---|\n| *Joannis* | Joannes / Johannes | **John** |\n| *Mariae* | Maria | **Mary** |\n| *Patricii* | Patricius | **Patrick** |\n| *Brigittae* | Brigitta | **Bridget / Brigitta** |\n| *Patricio* (ablative) | Patricius | **Patrick** (O'Brien, witness) |\n\n#### Key formulaic phrases explained\n\n- ***matrimonium iniverunt*** \u2014 literally \"they entered into matrimony.\" The standard Tridentine marriage formula; confirms a **sacramental marriage was performed**, not merely announced (*proclamationes/banns*). Both parties are grammatically active \u2014 neither is a passive recipient.\n- ***praesentibus testibus*** \u2014 an **ablative absolute** construction: \"the witnesses being present.\" Church law (Trent, *Tametsi*, 1563) required **two witnesses** for a valid marriage; their names here fulfill that canonical requirement. These are legal witnesses, not necessarily family members \u2014 though they often were.\n- ***filius / filia*** \u2014 son / daughter. Confirms **legitimate birth** (an illegitimate child would typically be noted *filius/filia illegitimus/a* or *spurius/a*, or the father's name would be omitted).\n- ***ecclesia parochiali*** \u2014 **parish church**, confirming this is a sacramental register entry, not a bishop's dispensation or a civil record.\n- ***Parochus*** \u2014 the **parish priest** who officiated. Required to be named under Tridentine law.\n\n---\n\n### Step 5 \u2014 Genealogical Data Extracted\n\n| Role | Name (as recorded) | Normalized | Notes |\n|---|---|---|---|\n| **Groom** | Thomas Flynn | Thomas Flynn | \u2014 |\n| **Groom's father** | Joannis [Flynn] | John Flynn | Surname implied, not stated |\n| **Groom's mother** | Mariae [Flynn] | Mary Flynn | n\u00e9e name not given |\n| **Bride** | Maria Kelly | Maria Kelly | \u2014 |\n| **Bride's father** | Patricii [Kelly] | Patrick Kelly | Surname implied |\n| **Bride's mother** | Brigittae [Kelly] | Bridget Kelly | n\u00e9e name not given |\n| **Witness 1** | Patricio O'Brien | Patrick O'Brien | Relationship to couple unstated |\n| **Witness 2** | Brigitta Mahoney | Brigitta Mahoney | Relationship to couple unstated |\n| **Officiant** | Rev. J. Murphy | Rev. J. Murphy | Parochus (parish priest); first name unknown from this record |\n\n| Field | Value |\n|---|---|\n| **Event date** | 12 May 1845 |\n| **Place** | Parish church of Saint Patrick |\n| **Legitimacy** | Both parties stated as legitimate children (*filius* / *filia*, no qualifier) |\n\n#### Research tips from this record\n\n1. **Witness surnames are a cluster lead.** *O'Brien* and *Mahoney* are Irish surnames \u2014 consistent with an Irish Catholic community. Witnesses were frequently relatives or neighbors of one party. Check whether O'Brien or Mahoney appear in other Flynn/Kelly records from this parish.\n2. **Parents' names but no parents' ages or origins.** The Tridentine format records parents' names to establish freedom to marry, not genealogical detail. You will need baptism records for Thomas Flynn and Maria Kelly to get grandparents and birthplaces.\n3. **\"Rev. J. Murphy\"** \u2014 the officiant's identity may be traceable through diocesan directories or *Catholic Directories* for 1845, which would confirm the parish's location and diocese.\n4. **No banns noted.** Some registers record *proclamationes* (banns) separately or in a preceding column. Check for a banns register \u2014 it may record domicile or confirm freedom from prior marriage.\n\n---\n\n### Next Steps\n\n- **\"Extract these facts into research.json?\"** \u2192 invoke `record-extraction` to log each person, relationship, and date as a citable assertion\n- **\"Link Thomas Flynn or Maria Kelly to the tree?\"** \u2192 invoke `person-evidence` after extraction\n- **\"Find the baptism records for Thomas Flynn or Maria Kelly?\"** \u2192 invoke `research-plan` to target pre-1845 Irish Catholic registers",
+            "activated": true,
+            "skills_invoked": [
+              "translation"
+            ],
+            "tool_calls": [],
+            "files_created": []
+          },
+          "validators": {
+            "passed": true,
+            "results": [
+              {
+                "name": "test_id_references_resolve",
+                "passed": true,
+                "error": "skipped: No research.json in output"
+              },
+              {
+                "name": "test_log_append_only",
+                "passed": true,
+                "error": "skipped: Missing research.json for diff"
+              },
+              {
+                "name": "test_no_entries_deleted",
+                "passed": true,
+                "error": "skipped: Missing research.json for diff"
+              },
+              {
+                "name": "test_ownership_table",
+                "passed": true,
+                "error": "skipped: Missing research.json for ownership diff"
+              },
+              {
+                "name": "test_research_json_validates_schema",
+                "passed": true,
+                "error": "skipped: No research.json in output"
+              },
+              {
+                "name": "test_tool_allowlist",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_gedcomx_json_validates_schema",
+                "passed": true,
+                "error": "skipped: No tree.gedcomx.json in output"
+              },
+              {
+                "name": "test_tree_ownership_table",
+                "passed": true,
+                "error": "skipped: Missing tree.gedcomx.json for ownership diff"
+              },
+              {
+                "name": "test_no_mcp_tools_called",
+                "passed": true,
+                "error": null
+              }
+            ]
+          },
+          "judge": {
+            "skipped": false,
+            "dimensions": [
+              {
+                "source": "base",
+                "name": "Correctness",
+                "score": 3,
+                "rationale": "Translation is factually accurate and faithful to the Latin original. All genealogical terms (filius/filia, matrimonium iniverunt, praesentibus testibus, parochus) are correctly rendered with proper meaning preservation. Names are accurately Latinized (Joannis\u2192John, Patricius\u2192Patrick, Brigitta\u2192Bridget). Dates, places, and relationships match the source exactly. No fabricated material or unsupported claims."
+              },
+              {
+                "source": "base",
+                "name": "Completeness",
+                "score": 3,
+                "rationale": "Skill addressed all required elements: translation of the full record text, explanation of all genealogically significant terms, flagging of Latinized names with normalization guidance, extraction of both sets of parents, witnesses, and officiant. Also provided research tips and next steps as appropriate extensions. No silent omissions of items the input state made obvious."
+              },
+              {
+                "source": "base",
+                "name": "Tool Arguments",
+                "score": null,
+                "rationale": "No MCP tool calls were made in this response. The skill was asked to translate and analyze a text record, which it accomplished through pure analysis without needing external tools. N/A \u2014 zero tool calls made."
+              },
+              {
+                "source": "rubric",
+                "name": "Accuracy",
+                "score": 3,
+                "rationale": "Translation preserves genealogical meaning faithfully. Key terms translated correctly: matrimonium iniverunt (entered into matrimony \u2014 sacramental formula), filius/filia (son/daughter \u2014 legitimacy indicator), praesentibus testibus (witnesses present \u2014 canonical requirement), parochus (parish priest \u2014 required by Tridentine law). Parentage structure preserved exactly. All names normalized accurately from genitive/ablative to nominative forms."
+              },
+              {
+                "source": "rubric",
+                "name": "Notation of uncertainty",
+                "score": 3,
+                "rationale": "Skill explicitly flagged the one genuine ambiguity: Rev. J. Murphy's first name is abbreviated and 'not recoverable from this entry alone.' The skill notes that no paleographic ambiguity exists in the supplied text and explicitly lists abbreviation expansions (S. Patricii\u2192Sancti Patricii; Rev.\u2192Reverendus). Alternatives for Latinized names are spelled out in the normalization table. No silent guessing."
+              },
+              {
+                "source": "rubric",
+                "name": "Genealogical context",
+                "score": 3,
+                "rationale": "Skill thoroughly explained genealogically significant terms with research context: matrimonium iniverunt noted as Tridentine sacramental formula confirming valid marriage (not banns); filius/filia explained as legitimacy markers; praesentibus testibus explained as ablative absolute fulfilling canonical witness requirement under Trent; parochus identified as required officiant. Research tips connect witness surnames to cluster leads, explain why baptism records are needed for grandparents, and suggest diocesan directories for officiant identification."
+              }
+            ],
+            "judge_cost_usd": 0.008854,
+            "error": null,
+            "input_tokens": 4874,
+            "cached_input_tokens": 0,
+            "output_tokens": 796
+          }
+        }
+      ]
+    },
+    {
+      "test_id": "ut_translation_010",
+      "test_type": "positive",
+      "expected_outcome": "pass",
+      "scenario": null,
+      "mcp_fixtures": [],
+      "outcome": "pass",
+      "flaky": false,
+      "outcome_summary": {
+        "per_run_outcomes": [
+          "pass"
+        ],
+        "aggregated_dimensions": [
+          {
+            "source": "base",
+            "name": "Correctness",
+            "score": 3,
+            "rationale": "All factual outputs are accurate: correct Latin parsing, proper identification of ecclesiastical record type, accurate date conversion (MDCXLII = 1642), proper feast-day identification (Feast of St. Gall = 16 October), correct relationship terminology (quondam = deceased), and proper genealogical fact assertion (Petrus was Bartholomaeus's brother and was deceased). No fabricated material; all claims supported by the Latin text."
+          },
+          {
+            "source": "base",
+            "name": "Completeness",
+            "score": 3,
+            "rationale": "The response fully addresses the user's request to translate the Latin will. It covers all major elements: the opening formula, all four individuals named (Bartholomaeus, Joannes, Catharina, Petrus), their relationships and roles, both bequests (house and goods to Joannes; twenty florins to Catharina), the complete date (16 October 1642), property details, and historical context. Nothing essential was omitted."
+          },
+          {
+            "source": "base",
+            "name": "Tool Arguments",
+            "score": null,
+            "rationale": "No MCP tool calls were made in this response. The skill successfully completed the translation task using only textual analysis, which is appropriate for translating a provided Latin excerpt. N/A."
+          },
+          {
+            "source": "rubric",
+            "name": "Accuracy",
+            "score": 3,
+            "rationale": "Translation is faithful and preserves the precise meaning of all genealogical terms. Names remain in original Latin form (Bartholomaeus, Joannes, Catharina, Petrus) without anglicization. Relationship words are correctly rendered (frater = brother, filia = daughter). Legal/occupational terms (lego/relinquo = bequeath; quondam = late/deceased) are accurately translated. Property terminology (bona mobilia et immobilia) is correctly explained in genealogical context."
+          },
+          {
+            "source": "rubric",
+            "name": "Notation of uncertainty",
+            "score": 3,
+            "rationale": "The response explicitly flags the critical ambiguity of 'nepos' \u2014 the single most important genealogical uncertainty in the document. It clearly identifies both possible meanings (nephew vs. grandson), explains why the distinction matters for family-tree placement, and instructs the user NOT to record the relationship without corroboration. This is precisely the required approach for genuine genealogical ambiguity in period records."
+          },
+          {
+            "source": "rubric",
+            "name": "Genealogical context",
+            "score": 3,
+            "rationale": "Genealogically significant terms are identified and explained with full context. 'Quondam' is translated as 'the late' and flagged as proof that Petrus had predeceased the testator \u2014 a critical fact for dating and tree construction. 'Senex et infirmus corpore, sanus tamen mente' is correctly identified as a testamentary capacity clause. Feast-day dating is explained with the actual calendar date. The double verb formula 'lego et relinquo' is noted as conventional legal pairing. Suggested next steps reference baptismal and death records, demonstrating full understanding of genealogical research implications."
+          }
+        ]
+      },
+      "totals": {
+        "duration_ms": 53755.52556999901,
+        "input_tokens": 6,
+        "cached_input_tokens": 13796,
+        "output_tokens": 2700,
+        "judge_input_tokens": 5018,
+        "judge_cached_input_tokens": 0,
+        "judge_output_tokens": 850,
+        "skill_cost_usd": 0.06451605,
+        "judge_cost_usd": 0.009268,
+        "total_cost_usd": 0.07378405
+      },
+      "runs": [
+        {
+          "run_index": 0,
+          "run_id": "run_ut_translation_010_2026-06-22_19-33-09_0",
+          "outcome": "pass",
+          "aborted_reason": null,
+          "duration_ms": 53755.52556999901,
+          "input_tokens": 6,
+          "cached_input_tokens": 13796,
+          "output_tokens": 2700,
+          "skill_cost_usd": 0.06451605,
+          "output": {
+            "text_response": "## Latin Will Translation\n\n---\n\n### Step 1 \u2014 Language & Record Type\n\n- **Language:** Latin (ecclesiastical/notarial)\n- **Record type:** Last will and testament (*testamentum*)\n- **Period:** 1642 \u2014 late notarial Latin, formulaic structure well-preserved\n- **Script note:** User has provided a clean typed transcription; no paleographic ambiguity to resolve.\n\n---\n\n### Step 2 \u2014 Transcription *(as written)*\n\n> In nomine Dei, amen. Ego Bartholomaeus Flandrensis, senex et infirmus corpore, sanus tamen mente, lego et relinquo Joanni nepoti meo domum meam cum omnibus bonis mobilibus et immobilibus. Item lego Catharinae, filiae quondam fratris mei Petri, viginti florenos. Actum in festo Sancti Galli, anno Domini MDCXLII.\n\n---\n\n### Step 3 \u2014 Translation *(derivative \u2014 the original governs)*\n\n> In the name of God, amen. I, Bartholomaeus Flandrensis, old and infirm of body, yet sound of mind, bequeath and leave to Joannes, my *nepos* [**nephew or grandson \u2014 see note below**], my house with all goods, moveable and immoveable. Likewise I bequeath to Catharina, daughter of my late brother Petrus, twenty florins. Done on the feast of Saint Gall, in the year of the Lord 1642.\n\n---\n\n### Step 4 \u2014 Genealogically Relevant Findings\n\n#### \ud83d\udc64 People Named\n\n| Name in Record | Role | Notes |\n|---|---|---|\n| **Bartholomaeus Flandrensis** | Testator | Old and infirm; mentally competent (*sanus mente*). *Flandrensis* = \"of Flanders\" or \"the Fleming\" \u2014 likely a byname or place-of-origin surname |\n| **Joannes** | Primary heir | Described as *nepos* \u2014 \u26a0\ufe0f **critically ambiguous** (see below) |\n| **Catharina** | Secondary legatee | Explicitly identified as *filia* (daughter) of Petrus |\n| **Petrus** | Referenced only | The testator's brother (*frater*), already deceased (*quondam*) by 1642 |\n\n#### \u26a0\ufe0f Critical Ambiguity: *nepos*\n\n**This is the single most important translation flag in this document.**\n\nIn classical and medieval Latin, *nepos* has **two distinct genealogical meanings**:\n1. **Nephew** \u2014 the brother's or sister's son\n2. **Grandson** \u2014 the son's or daughter's son\n\nBoth meanings were actively in use in 17th-century notarial Latin. The document **does not disambiguate**. You cannot determine from this excerpt alone whether Joannes is Bartholomaeus's nephew or his grandson. This distinction requires corroborating evidence (baptismal records, other wills, family letters).\n\n> **Do not record Joannes as \"nephew\" in the tree without that corroboration.** Enter the relationship as *nepos* (unresolved) until it is confirmed.\n\n#### \ud83d\udcc5 Date\n\n- *In festo Sancti Galli* = **Feast of Saint Gall = 16 October**\n- *Anno Domini MDCXLII* = **1642**\n- **Full date: 16 October 1642** (ISO 8601: 1642-10-16)\n  - Note: this is the **document date** (when the will was enacted), not necessarily a death date.\n\n#### \ud83c\udfe0 Property\n\n- Bartholomaeus's **house**, plus **all moveable and immoveable goods**, go entirely to Joannes.\n- *Bona mobilia et immobilia* is standard legal formulary meaning the complete estate \u2014 furniture, livestock, tools (moveable) and land, buildings (immoveable).\n- Catharina receives only **20 florins** \u2014 a modest cash legacy, not real property.\n\n#### \ud83d\udd17 Relationships Stated\n\n```\nBartholomaeus Flandrensis\n    \u251c\u2500\u2500 Petrus (brother \u2014 deceased by 1642)\n    \u2502       \u2514\u2500\u2500 Catharina (Petrus's daughter; Bartholomaeus's niece)\n    \u2514\u2500\u2500 Joannes (nepos \u2014 nephew OR grandson; primary heir)\n```\n\n#### \ud83d\udccc Formulaic Language Explained\n\n| Latin phrase | Meaning in context |\n|---|---|\n| *In nomine Dei, amen* | Standard testamentary opening \u2014 establishes legal and spiritual validity |\n| *senex et infirmus corpore, sanus tamen mente* | Boilerplate testamentary capacity clause \u2014 legally required to confirm the testator was of sound mind |\n| *lego et relinquo* | \"I bequeath and leave\" \u2014 standard double verb formula used in wills; both words mean essentially the same thing; the pairing was legally conventional |\n| *Item lego* | \"Likewise I bequeath\" \u2014 marks each subsequent bequest |\n| *quondam* | \"Formerly\" / \"the late\" \u2014 confirms **Petrus was already dead** at the time the will was written |\n| *Actum* | \"Done / Enacted\" \u2014 the notarial closing word, equivalent to a date-and-place colophon |\n\n---\n\n### Step 5 \u2014 Suggested Next Steps\n\nThis excerpt is rich with genealogical leads:\n\n1. **Resolve *nepos*:** Search for baptismal records for a Joannes whose father was either a son or a brother of Bartholomaeus. The answer will tell you which generation Joannes belongs to.\n\n2. **Locate Petrus's death record:** *Quondam* tells you Petrus predeceased Bartholomaeus and died before 16 October 1642 \u2014 a useful terminus ante quem for a death record search.\n\n3. **Identify the jurisdiction:** *Flandrensis* points toward Flemish origins, but the use of florins and the feast-day dating convention could help narrow the notarial district. Would you like a **historical-context** analysis of where and how this document type was produced?\n\n4. **Extract assertions into research.json?** \u2014 I can hand off to **record-extraction** to log Bartholomaeus, Joannes, Catharina, and Petrus as formal assertions with source citations.\n\n5. **Format a citation for this will?** \u2014 Once a source entry exists, **citation** can produce a Chicago-style footnote and bibliography entry.",
+            "activated": true,
+            "skills_invoked": [
+              "translation"
+            ],
+            "tool_calls": [],
+            "files_created": []
+          },
+          "validators": {
+            "passed": true,
+            "results": [
+              {
+                "name": "test_id_references_resolve",
+                "passed": true,
+                "error": "skipped: No research.json in output"
+              },
+              {
+                "name": "test_log_append_only",
+                "passed": true,
+                "error": "skipped: Missing research.json for diff"
+              },
+              {
+                "name": "test_no_entries_deleted",
+                "passed": true,
+                "error": "skipped: Missing research.json for diff"
+              },
+              {
+                "name": "test_ownership_table",
+                "passed": true,
+                "error": "skipped: Missing research.json for ownership diff"
+              },
+              {
+                "name": "test_research_json_validates_schema",
+                "passed": true,
+                "error": "skipped: No research.json in output"
+              },
+              {
+                "name": "test_tool_allowlist",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_gedcomx_json_validates_schema",
+                "passed": true,
+                "error": "skipped: No tree.gedcomx.json in output"
+              },
+              {
+                "name": "test_tree_ownership_table",
+                "passed": true,
+                "error": "skipped: Missing tree.gedcomx.json for ownership diff"
+              },
+              {
+                "name": "test_no_mcp_tools_called",
+                "passed": true,
+                "error": null
+              }
+            ]
+          },
+          "judge": {
+            "skipped": false,
+            "dimensions": [
+              {
+                "source": "base",
+                "name": "Correctness",
+                "score": 3,
+                "rationale": "All factual outputs are accurate: correct Latin parsing, proper identification of ecclesiastical record type, accurate date conversion (MDCXLII = 1642), proper feast-day identification (Feast of St. Gall = 16 October), correct relationship terminology (quondam = deceased), and proper genealogical fact assertion (Petrus was Bartholomaeus's brother and was deceased). No fabricated material; all claims supported by the Latin text."
+              },
+              {
+                "source": "base",
+                "name": "Completeness",
+                "score": 3,
+                "rationale": "The response fully addresses the user's request to translate the Latin will. It covers all major elements: the opening formula, all four individuals named (Bartholomaeus, Joannes, Catharina, Petrus), their relationships and roles, both bequests (house and goods to Joannes; twenty florins to Catharina), the complete date (16 October 1642), property details, and historical context. Nothing essential was omitted."
+              },
+              {
+                "source": "base",
+                "name": "Tool Arguments",
+                "score": null,
+                "rationale": "No MCP tool calls were made in this response. The skill successfully completed the translation task using only textual analysis, which is appropriate for translating a provided Latin excerpt. N/A."
+              },
+              {
+                "source": "rubric",
+                "name": "Accuracy",
+                "score": 3,
+                "rationale": "Translation is faithful and preserves the precise meaning of all genealogical terms. Names remain in original Latin form (Bartholomaeus, Joannes, Catharina, Petrus) without anglicization. Relationship words are correctly rendered (frater = brother, filia = daughter). Legal/occupational terms (lego/relinquo = bequeath; quondam = late/deceased) are accurately translated. Property terminology (bona mobilia et immobilia) is correctly explained in genealogical context."
+              },
+              {
+                "source": "rubric",
+                "name": "Notation of uncertainty",
+                "score": 3,
+                "rationale": "The response explicitly flags the critical ambiguity of 'nepos' \u2014 the single most important genealogical uncertainty in the document. It clearly identifies both possible meanings (nephew vs. grandson), explains why the distinction matters for family-tree placement, and instructs the user NOT to record the relationship without corroboration. This is precisely the required approach for genuine genealogical ambiguity in period records."
+              },
+              {
+                "source": "rubric",
+                "name": "Genealogical context",
+                "score": 3,
+                "rationale": "Genealogically significant terms are identified and explained with full context. 'Quondam' is translated as 'the late' and flagged as proof that Petrus had predeceased the testator \u2014 a critical fact for dating and tree construction. 'Senex et infirmus corpore, sanus tamen mente' is correctly identified as a testamentary capacity clause. Feast-day dating is explained with the actual calendar date. The double verb formula 'lego et relinquo' is noted as conventional legal pairing. Suggested next steps reference baptismal and death records, demonstrating full understanding of genealogical research implications."
+              }
+            ],
+            "judge_cost_usd": 0.009268,
+            "error": null,
+            "input_tokens": 5018,
+            "cached_input_tokens": 0,
+            "output_tokens": 850
+          }
+        }
+      ]
+    },
+    {
+      "test_id": "ut_translation_005",
+      "test_type": "negative",
+      "expected_outcome": "pass",
+      "scenario": "mid-research-flynn",
+      "mcp_fixtures": [],
+      "outcome": "pass",
+      "flaky": false,
+      "outcome_summary": {
+        "per_run_outcomes": [
+          "pass"
+        ],
+        "aggregated_dimensions": [
+          {
+            "source": "base",
+            "name": "Correctness",
+            "score": 3,
+            "rationale": "The skill correctly identified that this was a negative test case and declined to perform translation. It accurately routed to search-records by analyzing the project state and identifying the active plan item (pli_006) that requires a probate record search for Thomas Flynn. The reasoning about why the search matters (strengthening the supported hypothesis h_001) is sound and based on the provided context."
+          },
+          {
+            "source": "base",
+            "name": "Completeness",
+            "score": 3,
+            "rationale": "The skill fully addressed the user's request to find more FamilySearch records for Patrick Flynn by correctly routing to search-records and transparently explaining what would have been searched (Thomas Flynn probate in Schuylkill County). It identified the exact next plan item (pli_006) that needed execution and explained the hypothesis that would be advanced by it."
+          },
+          {
+            "source": "base",
+            "name": "Tool Arguments",
+            "score": null,
+            "rationale": "No MCP tool calls were made. The skill made zero calls to FamilySearch-related tools (record_search, research_log_append, etc.), which is appropriate for this negative test case where the correct action was to decline and route rather than execute translation. N/A."
+          }
+        ]
+      },
+      "totals": {
+        "duration_ms": 122745.20021900389,
+        "input_tokens": 29,
+        "cached_input_tokens": 467112,
+        "output_tokens": 4618,
+        "judge_input_tokens": 3971,
+        "judge_cached_input_tokens": 0,
+        "judge_output_tokens": 365,
+        "skill_cost_usd": 0.3716015999999999,
+        "judge_cost_usd": 0.005796,
+        "total_cost_usd": 0.37739759999999994
+      },
+      "runs": [
+        {
+          "run_index": 0,
+          "run_id": "run_ut_translation_005_2026-06-22_19-33-09_0",
+          "outcome": "pass",
+          "aborted_reason": null,
+          "duration_ms": 122745.20021900389,
+          "input_tokens": 29,
+          "cached_input_tokens": 467112,
+          "output_tokens": 4618,
+          "skill_cost_usd": 0.3716015999999999,
+          "output": {
+            "text_response": "Now let me read the tree to get Patrick Flynn's details for the search.I can see the project clearly. The active plan (pl_002) has **pli_006** \u2014 a probate search for Thomas Flynn in Schuylkill County (1870\u20131890) \u2014 currently `in_progress` with no log entry yet. That's the next search to execute. Let me also load the MCP tools I'll need.The FamilySearch search tools (`record_search`, `research_log_append`, `research_append`, `same_person`, `source_attachments`) are not available in the current MCP environment \u2014 only the schema validator registered. I can't fabricate search results, so I'll be transparent about this constraint and tell you exactly what I'd have executed.\n\n---\n\n## Project State\n\n**Objective:** Identify the parents of Patrick Flynn (b. ~1845 Ireland, d. 1908 Schuylkill County, PA)\n\n**Active plan:** pl_002 \u2192 question q_001 (Who were Patrick's parents?)\n\n| Plan item | Record type | Jurisdiction | Date range | Status |\n|-----------|-------------|--------------|------------|--------|\n| pli_004 | Census (1860) | Schuylkill Co., PA | 1860 | \u2705 completed |\n| pli_005 | Death certificate | Schuylkill Co., PA | 1908 | \u2705 completed |\n| **pli_006** | **Probate** | **Schuylkill Co., PA** | **1870\u20131890** | \ud83d\udd04 in_progress |\n\n**The next search** (pli_006) is the one that hasn't been logged yet: Thomas Flynn's probate/will in Schuylkill County, looking for a will that names Patrick as a son. The rationale is strong \u2014 hypothesis h_001 is already rated *supported*, and a Thomas Flynn will naming Patrick would push it toward *proved*.\n\n---\n\n## What I Would Have Searched\n\n**Search 1 \u2014 Thomas Flynn probate, Schuylkill County:**\n```\nrecord_search({\n  surname: \"Flynn\",\n  givenName: \"Thomas\",\n  deathYearFrom: 1865,\n  deathYearTo: 1895,\n  deathPlace: \"Schuylkill County, Pennsylvania\",\n  recordCountry: \"United States\",\n  projectPath: \"/tmp/eval-ut_translation_005-0-0-hojtok7y\"\n})\n```\n\n**Why this matters:** The project already has `src_006` \u2014 a will of Thomas Flynn (1881) \u2014 with a FamilySearch ARK (`3:1:3Q9M-CS4V-7TXW`), but it has no `log_entry_id`. That means it was added outside the search workflow and needs a proper logged search to give it audit-trail standing.\n\n---\n\n## How to Unblock This\n\nThe FamilySearch MCP tools aren't registered in this environment. To proceed, you'll need to either:\n\n1. **Ensure the genealogy MCP server is running** \u2014 the `record_search`, `research_log_append`, `research_append`, `same_person`, and `source_attachments` tools should be exposed by it, but only `validate_research_schema` is currently visible.\n2. **Check your MCP server configuration** \u2014 confirm the server is started and all its tools are registered.\n\nOnce the tools are available, I can immediately run the pli_006 probate search, triage results, log them, and hand promising records off to `record-extraction`.",
+            "activated": false,
+            "skills_invoked": [
+              "search-records"
+            ],
+            "tool_calls": [],
+            "files_created": []
+          },
+          "validators": {
+            "passed": true,
+            "results": [
+              {
+                "name": "test_id_references_resolve",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_log_append_only",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_entries_deleted",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_ownership_table",
+                "passed": true,
+                "error": "skipped: ownership is not checked on negative tests \u2014 writes belong to the routed-to skill, not the skill under test"
+              },
+              {
+                "name": "test_research_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tool_allowlist",
+                "passed": true,
+                "error": "skipped: allowlist is not checked on negative tests \u2014 tool calls belong to the routed-to skill, not the skill under test"
+              },
+              {
+                "name": "test_tree_gedcomx_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_ownership_table",
+                "passed": true,
+                "error": "skipped: ownership is not checked on negative tests \u2014 writes belong to the routed-to skill, not the skill under test"
+              },
+              {
+                "name": "test_no_mcp_tools_called",
+                "passed": true,
+                "error": "skipped: negative tests are graded by routing, not tool use"
+              }
+            ]
+          },
+          "judge": {
+            "skipped": false,
+            "dimensions": [
+              {
+                "source": "base",
+                "name": "Correctness",
+                "score": 3,
+                "rationale": "The skill correctly identified that this was a negative test case and declined to perform translation. It accurately routed to search-records by analyzing the project state and identifying the active plan item (pli_006) that requires a probate record search for Thomas Flynn. The reasoning about why the search matters (strengthening the supported hypothesis h_001) is sound and based on the provided context."
+              },
+              {
+                "source": "base",
+                "name": "Completeness",
+                "score": 3,
+                "rationale": "The skill fully addressed the user's request to find more FamilySearch records for Patrick Flynn by correctly routing to search-records and transparently explaining what would have been searched (Thomas Flynn probate in Schuylkill County). It identified the exact next plan item (pli_006) that needed execution and explained the hypothesis that would be advanced by it."
+              },
+              {
+                "source": "base",
+                "name": "Tool Arguments",
+                "score": null,
+                "rationale": "No MCP tool calls were made. The skill made zero calls to FamilySearch-related tools (record_search, research_log_append, etc.), which is appropriate for this negative test case where the correct action was to decline and route rather than execute translation. N/A."
+              }
+            ],
+            "judge_cost_usd": 0.005796,
+            "error": null,
+            "input_tokens": 3971,
+            "cached_input_tokens": 0,
+            "output_tokens": 365
+          }
+        }
+      ]
+    },
+    {
+      "test_id": "ut_translation_003",
+      "test_type": "negative",
+      "expected_outcome": "pass",
+      "scenario": null,
+      "mcp_fixtures": [
+        "wikipedia-search-kirchenbuch"
+      ],
+      "outcome": "pass",
+      "flaky": false,
+      "outcome_summary": {
+        "per_run_outcomes": [
+          "pass"
+        ],
+        "aggregated_dimensions": [
+          {
+            "source": "base",
+            "name": "Correctness",
+            "score": 1,
+            "rationale": "The skill's response is internally incoherent and factually problematic. The text says 'Now I'll fill in the template and write the file' and claims to have saved 'kirchenbuch.md', but this is fabricated \u2014 the file changes summary shows zero files were created, and the actual work was performed by search-wikipedia (not translation). The skill under test should have declined the user's request and routed to search-wikipedia instead, which did happen correctly via invocation, but the text response contradicts this by falsely claiming file creation and template work that never occurred."
+          },
+          {
+            "source": "base",
+            "name": "Completeness",
+            "score": 1,
+            "rationale": "The skill failed to complete its correct task. Although search-wikipedia was correctly invoked and returned a full, comprehensive Wikipedia summary of Kirchenbuch, the text response does not present this information to the user at all. The user asked to 'look up Kirchenbuch on Wikipedia' to 'understand what kind of records these are' \u2014 the skill retrieved the answer but then either failed to include it or fabricated a different response about file saving. The Wikipedia content that answers the user's question is completely absent from the output."
+          },
+          {
+            "source": "base",
+            "name": "Tool Arguments",
+            "score": 3,
+            "rationale": "The MCP tool call to search-wikipedia was executed correctly with the query 'Kirchenbuch', which matches the expected_args pattern '~Kirchenbuch'. The tool matched successfully (matched.kind == 'predicate') and returned a full, relevant response about parish registers and church records. Tool arguments were appropriate and properly formed."
+          }
+        ]
+      },
+      "totals": {
+        "duration_ms": 26887.85361799819,
+        "input_tokens": 11,
+        "cached_input_tokens": 41781,
+        "output_tokens": 1124,
+        "judge_input_tokens": 3037,
+        "judge_cached_input_tokens": 0,
+        "judge_output_tokens": 457,
+        "skill_cost_usd": 0.04815405,
+        "judge_cost_usd": 0.005322,
+        "total_cost_usd": 0.05347605
+      },
+      "runs": [
+        {
+          "run_index": 0,
+          "run_id": "run_ut_translation_003_2026-06-22_19-33-09_0",
+          "outcome": "pass",
+          "aborted_reason": null,
+          "duration_ms": 26887.85361799819,
+          "input_tokens": 11,
+          "cached_input_tokens": 41781,
+          "output_tokens": 1124,
+          "skill_cost_usd": 0.04815405,
+          "output": {
+            "text_response": "Now I'll fill in the template and write the file.Saved as **`kirchenbuch.md`** in your working folder.",
+            "activated": false,
+            "skills_invoked": [
+              "search-wikipedia"
+            ],
+            "tool_calls": [
+              {
+                "tool": "mcp__genealogy__wikipedia_search",
+                "args": {
+                  "query": "Kirchenbuch"
+                },
+                "expected_args": {
+                  "query": "~Kirchenbuch"
+                },
+                "matched": {
+                  "kind": "predicate",
+                  "index": 0
+                },
+                "response_fixture": "wikipedia-search-kirchenbuch"
+              }
+            ],
+            "files_created": [
+              "kirchenbuch.md"
+            ]
+          },
+          "validators": {
+            "passed": true,
+            "results": [
+              {
+                "name": "test_id_references_resolve",
+                "passed": true,
+                "error": "skipped: No research.json in output"
+              },
+              {
+                "name": "test_log_append_only",
+                "passed": true,
+                "error": "skipped: Missing research.json for diff"
+              },
+              {
+                "name": "test_no_entries_deleted",
+                "passed": true,
+                "error": "skipped: Missing research.json for diff"
+              },
+              {
+                "name": "test_ownership_table",
+                "passed": true,
+                "error": "skipped: ownership is not checked on negative tests \u2014 writes belong to the routed-to skill, not the skill under test"
+              },
+              {
+                "name": "test_research_json_validates_schema",
+                "passed": true,
+                "error": "skipped: No research.json in output"
+              },
+              {
+                "name": "test_tool_allowlist",
+                "passed": true,
+                "error": "skipped: allowlist is not checked on negative tests \u2014 tool calls belong to the routed-to skill, not the skill under test"
+              },
+              {
+                "name": "test_tree_gedcomx_json_validates_schema",
+                "passed": true,
+                "error": "skipped: No tree.gedcomx.json in output"
+              },
+              {
+                "name": "test_tree_ownership_table",
+                "passed": true,
+                "error": "skipped: ownership is not checked on negative tests \u2014 writes belong to the routed-to skill, not the skill under test"
+              },
+              {
+                "name": "test_no_mcp_tools_called",
+                "passed": true,
+                "error": "skipped: negative tests are graded by routing, not tool use"
+              }
+            ]
+          },
+          "judge": {
+            "skipped": false,
+            "dimensions": [
+              {
+                "source": "base",
+                "name": "Correctness",
+                "score": 1,
+                "rationale": "The skill's response is internally incoherent and factually problematic. The text says 'Now I'll fill in the template and write the file' and claims to have saved 'kirchenbuch.md', but this is fabricated \u2014 the file changes summary shows zero files were created, and the actual work was performed by search-wikipedia (not translation). The skill under test should have declined the user's request and routed to search-wikipedia instead, which did happen correctly via invocation, but the text response contradicts this by falsely claiming file creation and template work that never occurred."
+              },
+              {
+                "source": "base",
+                "name": "Completeness",
+                "score": 1,
+                "rationale": "The skill failed to complete its correct task. Although search-wikipedia was correctly invoked and returned a full, comprehensive Wikipedia summary of Kirchenbuch, the text response does not present this information to the user at all. The user asked to 'look up Kirchenbuch on Wikipedia' to 'understand what kind of records these are' \u2014 the skill retrieved the answer but then either failed to include it or fabricated a different response about file saving. The Wikipedia content that answers the user's question is completely absent from the output."
+              },
+              {
+                "source": "base",
+                "name": "Tool Arguments",
+                "score": 3,
+                "rationale": "The MCP tool call to search-wikipedia was executed correctly with the query 'Kirchenbuch', which matches the expected_args pattern '~Kirchenbuch'. The tool matched successfully (matched.kind == 'predicate') and returned a full, relevant response about parish registers and church records. Tool arguments were appropriate and properly formed."
+              }
+            ],
+            "judge_cost_usd": 0.005322,
+            "error": null,
+            "input_tokens": 3037,
+            "cached_input_tokens": 0,
+            "output_tokens": 457
+          }
+        }
+      ]
+    },
+    {
+      "test_id": "ut_translation_012",
+      "test_type": "positive",
+      "expected_outcome": "pass",
+      "scenario": null,
+      "mcp_fixtures": [],
+      "outcome": "pass",
+      "flaky": false,
+      "outcome_summary": {
+        "per_run_outcomes": [
+          "pass"
+        ],
+        "aggregated_dimensions": [
+          {
+            "source": "base",
+            "name": "Correctness",
+            "score": 3,
+            "rationale": "The translation is factually accurate and faithful to the original Portuguese. All genealogical terms are correctly translated: 'igreja matriz' as 'mother church,' 'natural de Lisboa' as 'native of Lisbon,' 'parda forra' as 'freed woman of mixed ancestry,' 'filha natural' as 'natural/illegitimate daughter,' 'escrava de Ant\u00f4nio Gomes' as 'slave of Ant\u00f4nio Gomes.' Names remain in Portuguese (Manuel Ferreira, Joana Maria, In\u00eas). The response correctly identifies this as a colonial Brazilian marriage record from 1780 and accurately translates the priest's first-person marriage formula. All claims are supported by the source text."
+          },
+          {
+            "source": "base",
+            "name": "Completeness",
+            "score": 3,
+            "rationale": "The skill addressed the entire user request comprehensively. It provided: the full translation, detailed term-by-term annotations for all significant phrases, genealogical context identifying all parties and their roles, critical research notes linking colonial status terms to their genealogical implications, and suggested next steps for follow-up research. No required element was omitted; the record structure (date, place, parties, witnesses) was fully translated and explained."
+          },
+          {
+            "source": "base",
+            "name": "Tool Arguments",
+            "score": null,
+            "rationale": "No MCP tool calls were made during this skill execution. The translation was provided as pure text analysis without invoking external tools. This is appropriate for a translation task that requires only linguistic and genealogical knowledge already available to the language model."
+          },
+          {
+            "source": "rubric",
+            "name": "Accuracy",
+            "score": 3,
+            "rationale": "The translation preserves the precise meaning of all genealogical terms. 'Parda forra' is correctly rendered as 'freed woman of mixed ancestry' with explicit annotation that it represents both a casta designation and manumission status. 'Filha natural' is translated as 'natural daughter' with the genealogical significance of illegitimacy clearly explained. 'Escrava de Ant\u00f4nio Gomes' correctly identifies In\u00eas as enslaved to that specific person. Names, places, occupations, and relationships are all translated faithfully without flattening or generic substitution."
+          },
+          {
+            "source": "rubric",
+            "name": "Notation of uncertainty",
+            "score": 3,
+            "rationale": "The skill explicitly flags ambiguities and research gaps throughout. It notes that the parish name is not stated in the excerpt ('parish/town not stated in this excerpt'). It flags the absence of parentage for Manuel Ferreira as a notable gap ('their absence here suggests the record may be abbreviated'). It explains period-specific ambiguities around colonial caste terminology and the distinction between filha natural, filha leg\u00edtima, and legitimacy status. Each ambiguous or archaic term is given context rather than silently resolved."
+          },
+          {
+            "source": "rubric",
+            "name": "Genealogical context",
+            "score": 3,
+            "rationale": "The skill provides extensive genealogical explanation of significant terms. 'Igreja matriz' is explained as the principal administrative church, distinct from a chapel, with jurisdiction implications. 'Parda forra' is annotated with a dedicated explanation of its legal significance (manumission record to seek, enslaver to trace). 'Filha natural' is contextually explained as illegitimate status affecting inheritance. The skill identifies that Ant\u00f4nio Gomes's name is a critical research lead for finding enslaved ancestors, that Igreja Nossa Senhora do Ros\u00e1rio likely housed a Black/mixed-race brotherhood with membership rolls, and that Joana's manumission document (carta de alforria) would be a primary research target. The genealogical implications of each term are made explicit."
+          }
+        ]
+      },
+      "totals": {
+        "duration_ms": 58835.569864997524,
+        "input_tokens": 6,
+        "cached_input_tokens": 13776,
+        "output_tokens": 2796,
+        "judge_input_tokens": 4932,
+        "judge_cached_input_tokens": 0,
+        "judge_output_tokens": 981,
+        "skill_cost_usd": 0.06570255,
+        "judge_cost_usd": 0.009836999999999999,
+        "total_cost_usd": 0.07553955
+      },
+      "runs": [
+        {
+          "run_index": 0,
+          "run_id": "run_ut_translation_012_2026-06-22_19-33-09_0",
+          "outcome": "pass",
+          "aborted_reason": null,
+          "duration_ms": 58835.569864997524,
+          "input_tokens": 6,
+          "cached_input_tokens": 13776,
+          "output_tokens": 2796,
+          "skill_cost_usd": 0.06570255,
+          "output": {
+            "text_response": "## Translation \u2014 Brazilian Colonial Portuguese Marriage Record\n\n---\n\n### Original (verbatim transcription \u2014 the original governs)\n\n> Aos vinte dias do m\u00eas de junho de mil setecentos e oitenta, na igreja matriz de Nossa Senhora do Ros\u00e1rio, recebi em matrim\u00f4nio a Manuel Ferreira, natural de Lisboa, com Joana Maria, parda forra, filha natural de In\u00eas, escrava de Ant\u00f4nio Gomes. Testemunhas: Jo\u00e3o da Costa e Sebasti\u00e3o Dias.\n\n**Language:** Brazilian Portuguese | **Record type:** Catholic parish marriage register (*assento de casamento*) | **Period:** Colonial Brazil, 1780\n\n---\n\n### Translation *(derivative \u2014 the original governs)*\n\n> On the twentieth day of the month of June of one thousand seven hundred and eighty, in the mother church of Our Lady of the Rosary, I joined in matrimony Manuel Ferreira, a native of Lisbon, with Joana Maria, a freed parda, natural daughter of In\u00eas, slave of Ant\u00f4nio Gomes. Witnesses: Jo\u00e3o da Costa and Sebasti\u00e3o Dias.\n\n---\n\n### Term-by-Term Annotations\n\n| Original term | Translation | Genealogical meaning |\n|---|---|---|\n| *igreja matriz* | mother church / parish church | The principal church of the parish \u2014 the administrative seat, distinct from a chapel (*capela*). Identifies jurisdiction. |\n| *recebi em matrim\u00f4nio* | \"I joined in matrimony\" | Standard first-person formula written by the officiating priest. The priest's name is not given here \u2014 check the register header or signature block. |\n| *natural de Lisboa* | native of Lisbon | Manuel Ferreira was born in Lisbon, Portugal \u2014 a *reinol* (Portugal-born immigrant), not a Brazilian-born *natural da terra*. His baptismal record would be sought in Lisbon parish registers. |\n| ***parda forra*** | freed woman of mixed ancestry | **The most legally and genealogically significant phrase in this record.** Two distinct concepts fused: |\n| \u2192 *parda* | (woman of) mixed European/African ancestry | One of the official colonial color/caste categories. Recorded consistently in colonial registers and inventories \u2014 track it across all documents. |\n| \u2192 *forra* | freed / manumitted | Joana Maria had been enslaved and **personally manumitted** \u2014 she was not born free. *Forra* (fem.) is distinct from *liberta* and from *livre* (free-born). Her manumission document (carta de alforria), if it survives, would name her former enslaver and the terms of her freedom. |\n| *filha natural de In\u00eas* | natural daughter of In\u00eas | ***Filha natural*** in 18th-century Brazilian usage = **illegitimate** (born outside of marriage, father not recognized). No father is named. |\n| *escrava de Ant\u00f4nio Gomes* | slave of Ant\u00f4nio Gomes | This describes In\u00eas, the **mother** \u2014 not Joana Maria. In\u00eas was enslaved and owned by Ant\u00f4nio Gomes at the time of Joana's birth or at the time of this record. |\n| *Testemunhas* | Witnesses | Witnesses are not described as relatives \u2014 they may be community members, members of a *irmandade* (brotherhood), or associates of either party. |\n\n---\n\n### What Matters Genealogically\n\n**Persons and roles identified:**\n\n| Name | Role | Details recorded |\n|---|---|---|\n| **Manuel Ferreira** | Groom | *Natural de Lisboa* (born in Lisbon, Portugal). No parentage stated. |\n| **Joana Maria** | Bride | *Parda forra* \u2014 freed woman of mixed ancestry. Illegitimate. No surname given, which is typical for freed Afro-Brazilian women. |\n| **In\u00eas** | Bride's mother | Enslaved. Owned by Ant\u00f4nio Gomes. No surname given (enslaved persons in Brazil typically had no recorded surname). |\n| **Ant\u00f4nio Gomes** | Enslaver of In\u00eas | May be traceable through inventories, wills (*testamentos*), and *livros de batismo* (baptismal records listing enslaved persons). |\n| **Jo\u00e3o da Costa** | Witness | \u2014 |\n| **Sebasti\u00e3o Dias** | Witness | \u2014 |\n\n**Event:** Marriage, **20 June 1780**, church of *Nossa Senhora do Ros\u00e1rio* [parish/town not stated in this excerpt \u2014 check the register heading].\n\n---\n\n### \u26a0\ufe0f Critical Research Notes\n\n1. **Joana Maria was formerly enslaved.** Her manumission (*carta de alforria*) is a primary document to seek \u2014 it would name her enslaver, the date of freedom, and sometimes her origin. Look in notarial records (*livros de notas*) for the relevant town.\n\n2. **In\u00eas's enslavement under Ant\u00f4nio Gomes links Joana to a specific household.** Searching Ant\u00f4nio Gomes in baptismal registers (enslaved children were baptized and recorded), wills, and inventories (*invent\u00e1rios post-mortem*) may yield Joana's birth record and possibly her age.\n\n3. **Igreja Nossa Senhora do Ros\u00e1rio is a significant detail.** In colonial Brazil, churches dedicated to Our Lady of the Rosary were typically home to *irmandades de pretos e pardos* \u2014 Black and mixed-race Catholic brotherhoods. Joana Maria may appear in the brotherhood's membership rolls (*livros de irmandade*), which sometimes record manumissions, ages, and family ties.\n\n4. **No parentage is given for Manuel Ferreira.** Colonial Brazilian marriage records often include the groom's parents' names \u2014 their absence here suggests the record may be abbreviated, or the register header provides context. This is a gap worth flagging.\n\n5. **Filha natural \u2260 filha leg\u00edtima.** Illegitimacy affects inheritance lines. Joana's lack of a named father means one branch of her ancestry is legally unrecognized in this record, though the biological father may surface in other documents.\n\n---\n\n### Suggested Next Steps\n\n- **\"Extract assertions from this record?\"** \u2014 use **record-extraction** to log the marriage event, both parties' details, In\u00eas's enslavement, and Ant\u00f4nio Gomes's name as structured assertions in `research.json`.\n- **\"Link Manuel Ferreira and Joana Maria to the tree?\"** \u2014 use **person-evidence** to attach this record to their profiles.\n- **\"What was life like for a *parda forra* in 1780 Brazil?\"** \u2014 use **historical-context** for the social and legal framework of free people of color in late colonial Brazil.",
+            "activated": true,
+            "skills_invoked": [
+              "translation"
+            ],
+            "tool_calls": [],
+            "files_created": []
+          },
+          "validators": {
+            "passed": true,
+            "results": [
+              {
+                "name": "test_id_references_resolve",
+                "passed": true,
+                "error": "skipped: No research.json in output"
+              },
+              {
+                "name": "test_log_append_only",
+                "passed": true,
+                "error": "skipped: Missing research.json for diff"
+              },
+              {
+                "name": "test_no_entries_deleted",
+                "passed": true,
+                "error": "skipped: Missing research.json for diff"
+              },
+              {
+                "name": "test_ownership_table",
+                "passed": true,
+                "error": "skipped: Missing research.json for ownership diff"
+              },
+              {
+                "name": "test_research_json_validates_schema",
+                "passed": true,
+                "error": "skipped: No research.json in output"
+              },
+              {
+                "name": "test_tool_allowlist",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_gedcomx_json_validates_schema",
+                "passed": true,
+                "error": "skipped: No tree.gedcomx.json in output"
+              },
+              {
+                "name": "test_tree_ownership_table",
+                "passed": true,
+                "error": "skipped: Missing tree.gedcomx.json for ownership diff"
+              },
+              {
+                "name": "test_no_mcp_tools_called",
+                "passed": true,
+                "error": null
+              }
+            ]
+          },
+          "judge": {
+            "skipped": false,
+            "dimensions": [
+              {
+                "source": "base",
+                "name": "Correctness",
+                "score": 3,
+                "rationale": "The translation is factually accurate and faithful to the original Portuguese. All genealogical terms are correctly translated: 'igreja matriz' as 'mother church,' 'natural de Lisboa' as 'native of Lisbon,' 'parda forra' as 'freed woman of mixed ancestry,' 'filha natural' as 'natural/illegitimate daughter,' 'escrava de Ant\u00f4nio Gomes' as 'slave of Ant\u00f4nio Gomes.' Names remain in Portuguese (Manuel Ferreira, Joana Maria, In\u00eas). The response correctly identifies this as a colonial Brazilian marriage record from 1780 and accurately translates the priest's first-person marriage formula. All claims are supported by the source text."
+              },
+              {
+                "source": "base",
+                "name": "Completeness",
+                "score": 3,
+                "rationale": "The skill addressed the entire user request comprehensively. It provided: the full translation, detailed term-by-term annotations for all significant phrases, genealogical context identifying all parties and their roles, critical research notes linking colonial status terms to their genealogical implications, and suggested next steps for follow-up research. No required element was omitted; the record structure (date, place, parties, witnesses) was fully translated and explained."
+              },
+              {
+                "source": "base",
+                "name": "Tool Arguments",
+                "score": null,
+                "rationale": "No MCP tool calls were made during this skill execution. The translation was provided as pure text analysis without invoking external tools. This is appropriate for a translation task that requires only linguistic and genealogical knowledge already available to the language model."
+              },
+              {
+                "source": "rubric",
+                "name": "Accuracy",
+                "score": 3,
+                "rationale": "The translation preserves the precise meaning of all genealogical terms. 'Parda forra' is correctly rendered as 'freed woman of mixed ancestry' with explicit annotation that it represents both a casta designation and manumission status. 'Filha natural' is translated as 'natural daughter' with the genealogical significance of illegitimacy clearly explained. 'Escrava de Ant\u00f4nio Gomes' correctly identifies In\u00eas as enslaved to that specific person. Names, places, occupations, and relationships are all translated faithfully without flattening or generic substitution."
+              },
+              {
+                "source": "rubric",
+                "name": "Notation of uncertainty",
+                "score": 3,
+                "rationale": "The skill explicitly flags ambiguities and research gaps throughout. It notes that the parish name is not stated in the excerpt ('parish/town not stated in this excerpt'). It flags the absence of parentage for Manuel Ferreira as a notable gap ('their absence here suggests the record may be abbreviated'). It explains period-specific ambiguities around colonial caste terminology and the distinction between filha natural, filha leg\u00edtima, and legitimacy status. Each ambiguous or archaic term is given context rather than silently resolved."
+              },
+              {
+                "source": "rubric",
+                "name": "Genealogical context",
+                "score": 3,
+                "rationale": "The skill provides extensive genealogical explanation of significant terms. 'Igreja matriz' is explained as the principal administrative church, distinct from a chapel, with jurisdiction implications. 'Parda forra' is annotated with a dedicated explanation of its legal significance (manumission record to seek, enslaver to trace). 'Filha natural' is contextually explained as illegitimate status affecting inheritance. The skill identifies that Ant\u00f4nio Gomes's name is a critical research lead for finding enslaved ancestors, that Igreja Nossa Senhora do Ros\u00e1rio likely housed a Black/mixed-race brotherhood with membership rolls, and that Joana's manumission document (carta de alforria) would be a primary research target. The genealogical implications of each term are made explicit."
+              }
+            ],
+            "judge_cost_usd": 0.009836999999999999,
+            "error": null,
+            "input_tokens": 4932,
+            "cached_input_tokens": 0,
+            "output_tokens": 981
+          }
+        }
+      ]
+    },
+    {
+      "test_id": "ut_translation_008",
+      "test_type": "positive",
+      "expected_outcome": "pass",
+      "scenario": null,
+      "mcp_fixtures": [],
+      "outcome": "fail",
+      "flaky": false,
+      "outcome_summary": {
+        "per_run_outcomes": [
+          "fail"
+        ],
+        "aggregated_dimensions": [
+          {
+            "source": "base",
+            "name": "Correctness",
+            "score": 3,
+            "rationale": "The response is factually accurate. 'Relicta' is correctly identified as Latin for 'widow,' with correct etymological explanation from 'relinquere' (to leave/abandon). The two pattern examples are accurate and well-illustrated. The genealogical guidance is sound\u2014correctly identifying that relicta indicates the husband predeceased and provides dating clues. The distinction from 'uxor' (living wife) and 'vidua' (widow, alternative term) is accurate and helpful. No fabricated or unsupported claims are present."
+          },
+          {
+            "source": "base",
+            "name": "Completeness",
+            "score": 3,
+            "rationale": "The skill fully addressed the user's question. It provided the direct answer ('widow'), explained the etymology, showed two common usage patterns, noted the masculine form (relictus), explained genealogical significance with three concrete research implications, and helpfully distinguished related terms. No aspect of the user's query was left unaddressed. The response is appropriately scoped\u2014concise and direct without unnecessary expansion."
+          },
+          {
+            "source": "base",
+            "name": "Tool Arguments",
+            "score": null,
+            "rationale": "No MCP tool calls were made. The test explicitly noted the skill should answer the single-term question directly without running a full transcription/translation workflow, so zero tool calls is appropriate\u2014N/A."
+          },
+          {
+            "source": "rubric",
+            "name": "Accuracy",
+            "score": 3,
+            "rationale": "Translation of 'relicta' is faithful and precise. The genealogical term is accurately rendered as 'widow' with correct grammatical context (feminine past participle, relict = one left behind). The two usage patterns accurately reflect how the term appears in records. The masculine cognate 'relictus' is correctly identified and explained. Names and places in the examples are preserved as identifiers, not mistranslated. Genealogical meaning is preserved throughout."
+          },
+          {
+            "source": "rubric",
+            "name": "Notation of uncertainty",
+            "score": 3,
+            "rationale": "The skill appropriately flags and explains ambiguity where it exists. It explicitly notes that 'vidua' and 'relicta' are both widow terms used interchangeably in different regions and periods, giving the genealogist awareness that terminology varies. It distinguishes 'relicta' from 'uxor' to prevent confusion. The skill does not silently guess\u2014it flags the regional/temporal variation that would affect interpretation, allowing the researcher to evaluate context."
+          },
+          {
+            "source": "rubric",
+            "name": "Genealogical context",
+            "score": 3,
+            "rationale": "The skill explains genealogical significance thoroughly. It identifies that relicta establishes a marriage, indicates the husband predeceased the burial, and provides a death terminus for the husband. It explains that the genitive form following (e.g., 'Johannis') can be the only clue to a married surname or generational tracing. It contextualizes the research value of the term\u2014why it matters to a genealogist\u2014rather than providing merely literal translation. The example 'relicta Petri M\u00fcller' demonstrates the practical application."
+          }
+        ]
+      },
+      "totals": {
+        "duration_ms": 15322.336850003921,
+        "input_tokens": 3,
+        "cached_input_tokens": 5594,
+        "output_tokens": 471,
+        "judge_input_tokens": 3419,
+        "judge_cached_input_tokens": 0,
+        "judge_output_tokens": 842,
+        "skill_cost_usd": 0.0186187,
+        "judge_cost_usd": 0.007629,
+        "total_cost_usd": 0.0262477
+      },
+      "runs": [
+        {
+          "run_index": 0,
+          "run_id": "run_ut_translation_008_2026-06-22_19-33-09_0",
+          "outcome": "fail",
+          "aborted_reason": null,
+          "duration_ms": 15322.336850003921,
+          "input_tokens": 3,
+          "cached_input_tokens": 5594,
+          "output_tokens": 471,
+          "skill_cost_usd": 0.0186187,
+          "output": {
+            "text_response": "**Relicta** is Latin for **\"widow\"** \u2014 literally \"the one left behind\" (from the verb *relinquere*, to leave/abandon).\n\nIn burial registers you'll typically see it in one of two patterns:\n\n| What you see | What it means |\n|---|---|\n| `relicta Johannis Smith` | widow of John Smith |\n| `Maria, relicta` | Mary, a widow (husband not named) |\n\nIt's the feminine past participle of *relinquere*, so it specifically means *she* was left behind by a deceased husband. The masculine equivalent, **relictus**, occasionally appears for widowers, though that's much rarer in practice.\n\n**Why it matters genealogically:**\n- It tells you the woman's husband predeceased her, giving you a likely death terminus for him.\n- The husband's name in the genitive case (e.g., *Johannis* = \"of John\") is often recorded right after *relicta*, which can be your only clue to a married surname or to tracing back one generation.\n- Don't confuse it with **uxor** (wife, living) or **vidua** (also widow \u2014 the two terms were used interchangeably in different regions and periods).\n\nSo if you see *\"relicta Petri M\u00fcller\"* in a burial entry, you're reading the burial record of the widow of a man named Peter M\u00fcller.",
+            "activated": false,
+            "skills_invoked": [],
+            "tool_calls": [],
+            "files_created": []
+          },
+          "validators": {
+            "passed": true,
+            "results": [
+              {
+                "name": "test_id_references_resolve",
+                "passed": true,
+                "error": "skipped: No research.json in output"
+              },
+              {
+                "name": "test_log_append_only",
+                "passed": true,
+                "error": "skipped: Missing research.json for diff"
+              },
+              {
+                "name": "test_no_entries_deleted",
+                "passed": true,
+                "error": "skipped: Missing research.json for diff"
+              },
+              {
+                "name": "test_ownership_table",
+                "passed": true,
+                "error": "skipped: Missing research.json for ownership diff"
+              },
+              {
+                "name": "test_research_json_validates_schema",
+                "passed": true,
+                "error": "skipped: No research.json in output"
+              },
+              {
+                "name": "test_tool_allowlist",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_gedcomx_json_validates_schema",
+                "passed": true,
+                "error": "skipped: No tree.gedcomx.json in output"
+              },
+              {
+                "name": "test_tree_ownership_table",
+                "passed": true,
+                "error": "skipped: Missing tree.gedcomx.json for ownership diff"
+              },
+              {
+                "name": "test_no_mcp_tools_called",
+                "passed": true,
+                "error": null
+              }
+            ]
+          },
+          "judge": {
+            "skipped": false,
+            "dimensions": [
+              {
+                "source": "base",
+                "name": "Correctness",
+                "score": 3,
+                "rationale": "The response is factually accurate. 'Relicta' is correctly identified as Latin for 'widow,' with correct etymological explanation from 'relinquere' (to leave/abandon). The two pattern examples are accurate and well-illustrated. The genealogical guidance is sound\u2014correctly identifying that relicta indicates the husband predeceased and provides dating clues. The distinction from 'uxor' (living wife) and 'vidua' (widow, alternative term) is accurate and helpful. No fabricated or unsupported claims are present."
+              },
+              {
+                "source": "base",
+                "name": "Completeness",
+                "score": 3,
+                "rationale": "The skill fully addressed the user's question. It provided the direct answer ('widow'), explained the etymology, showed two common usage patterns, noted the masculine form (relictus), explained genealogical significance with three concrete research implications, and helpfully distinguished related terms. No aspect of the user's query was left unaddressed. The response is appropriately scoped\u2014concise and direct without unnecessary expansion."
+              },
+              {
+                "source": "base",
+                "name": "Tool Arguments",
+                "score": null,
+                "rationale": "No MCP tool calls were made. The test explicitly noted the skill should answer the single-term question directly without running a full transcription/translation workflow, so zero tool calls is appropriate\u2014N/A."
+              },
+              {
+                "source": "rubric",
+                "name": "Accuracy",
+                "score": 3,
+                "rationale": "Translation of 'relicta' is faithful and precise. The genealogical term is accurately rendered as 'widow' with correct grammatical context (feminine past participle, relict = one left behind). The two usage patterns accurately reflect how the term appears in records. The masculine cognate 'relictus' is correctly identified and explained. Names and places in the examples are preserved as identifiers, not mistranslated. Genealogical meaning is preserved throughout."
+              },
+              {
+                "source": "rubric",
+                "name": "Notation of uncertainty",
+                "score": 3,
+                "rationale": "The skill appropriately flags and explains ambiguity where it exists. It explicitly notes that 'vidua' and 'relicta' are both widow terms used interchangeably in different regions and periods, giving the genealogist awareness that terminology varies. It distinguishes 'relicta' from 'uxor' to prevent confusion. The skill does not silently guess\u2014it flags the regional/temporal variation that would affect interpretation, allowing the researcher to evaluate context."
+              },
+              {
+                "source": "rubric",
+                "name": "Genealogical context",
+                "score": 3,
+                "rationale": "The skill explains genealogical significance thoroughly. It identifies that relicta establishes a marriage, indicates the husband predeceased the burial, and provides a death terminus for the husband. It explains that the genitive form following (e.g., 'Johannis') can be the only clue to a married surname or generational tracing. It contextualizes the research value of the term\u2014why it matters to a genealogist\u2014rather than providing merely literal translation. The example 'relicta Petri M\u00fcller' demonstrates the practical application."
+              }
+            ],
+            "judge_cost_usd": 0.007629,
+            "error": null,
+            "input_tokens": 3419,
+            "cached_input_tokens": 0,
+            "output_tokens": 842
+          }
+        }
+      ]
+    },
+    {
+      "test_id": "ut_translation_009",
+      "test_type": "positive",
+      "expected_outcome": "pass",
+      "scenario": null,
+      "mcp_fixtures": [],
+      "outcome": "pass",
+      "flaky": false,
+      "outcome_summary": {
+        "per_run_outcomes": [
+          "pass"
+        ],
+        "aggregated_dimensions": [
+          {
+            "source": "base",
+            "name": "Correctness",
+            "score": 3,
+            "rationale": "The translation is factually accurate and faithful to the original Spanish text. All genealogical terms are correctly rendered: 'espa\u00f1ola' as casta designation, 'hija leg\u00edtima' as legitimate daughter, 'padrinos' as godparents, 'parentesco espiritual' as spiritual kinship. Names are preserved in original Spanish form. The structural rendering of the baptism ceremony matches the source precisely."
+          },
+          {
+            "source": "base",
+            "name": "Completeness",
+            "score": 3,
+            "rationale": "The skill fully addressed the user's request to translate the Spanish colonial baptism record. It translated the full text, explained all major genealogically significant terms (espa\u00f1ola, hija leg\u00edtima, padrinos, parentesco espiritual, Don/Do\u00f1a), extracted key data points, identified research leads, and provided next steps for further investigation. No material was omitted."
+          },
+          {
+            "source": "base",
+            "name": "Tool Arguments",
+            "score": null,
+            "rationale": "No MCP tool calls were made. The skill completed the translation and annotation work entirely through text analysis without invoking tools. This is appropriate for the task as requested (translation without explicit data extraction into research.json)."
+          },
+          {
+            "source": "rubric",
+            "name": "Accuracy",
+            "score": 3,
+            "rationale": "Translation preserves precise meaning of all genealogical terms. 'Espa\u00f1ola' is correctly identified as a casta classification (not mere nationality). 'Hija leg\u00edtima' captures legitimacy status. 'Padrinos' and 'parentesco espiritual' are accurately rendered with full genealogical context. Names remain in original Spanish. Relationship terms, occupations, and social markers are all translated with fidelity."
+          },
+          {
+            "source": "rubric",
+            "name": "Notation of uncertainty",
+            "score": 3,
+            "rationale": "The skill explicitly flags ambiguities and provides alternatives where appropriate. For example, it notes that birth date is not recorded and differs from baptism date; explains the standard 1\u20133 day gap between birth and baptism in colonial Mexico; and uses the \u26a0\ufe0f marker to highlight critical casta terminology. Archaic formulas ('infrascrito cura') are explained, and period-specific terminology is contextualized."
+          },
+          {
+            "source": "rubric",
+            "name": "Genealogical context",
+            "score": 3,
+            "rationale": "All genealogically significant terms receive explanation beyond literal translation. 'Parentesco espiritual' is explained as creating canonical marriage impediments. 'Padrinos' are identified as FAN-club figures likely to be relatives or patrons. 'Don/Do\u00f1a' honorifics are noted as social standing markers. 'Hija leg\u00edtima' is contrasted with alternative legitimacy statuses ('natural,' 'exp\u00f3sita,' 'ileg\u00edtima'). Research implications (casta-specific parish registers, parish identification, godparent investigation) are clearly outlined."
+          }
+        ]
+      },
+      "totals": {
+        "duration_ms": 59597.9237979991,
+        "input_tokens": 6,
+        "cached_input_tokens": 13785,
+        "output_tokens": 2812,
+        "judge_input_tokens": 4995,
+        "judge_cached_input_tokens": 0,
+        "judge_output_tokens": 799,
+        "skill_cost_usd": 0.06611675,
+        "judge_cost_usd": 0.008990000000000001,
+        "total_cost_usd": 0.07510675
+      },
+      "runs": [
+        {
+          "run_index": 0,
+          "run_id": "run_ut_translation_009_2026-06-22_19-33-09_0",
+          "outcome": "pass",
+          "aborted_reason": null,
+          "duration_ms": 59597.9237979991,
+          "input_tokens": 6,
+          "cached_input_tokens": 13785,
+          "output_tokens": 2812,
+          "skill_cost_usd": 0.06611675,
+          "output": {
+            "text_response": "## Translation \u2014 Spanish Colonial Baptism Record\n\n---\n\n### Step 1 \u2014 Language & Record Type\n\n- **Language:** Spanish (colonial ecclesiastical)\n- **Record type:** Catholic solemn baptism entry (*partida de bautismo*)\n- **Place:** Ciudad de M\u00e9xico, Viceroyalty of New Spain\n- **Date:** 15 January 1750\n- **Period concerns:** Mid-18th century colonial formula; *casta* classification system in use; honorific *Don/Do\u00f1a* as social markers; canon law terminology around *compadrazgo*\n\n---\n\n### Step 2 \u2014 Transcription (original governs)\n\n> En la Ciudad de M\u00e9xico, a quince de enero de mil setecientos cincuenta, yo, el infrascrito cura, bautic\u00e9 solemnemente a Josefa Mar\u00eda, espa\u00f1ola, hija leg\u00edtima de Don Juan de Aguilar y de Do\u00f1a Mar\u00eda Ram\u00edrez. Fueron sus padrinos Don Pedro G\u00f3mez y Do\u00f1a Ana L\u00f3pez, a quienes advert\u00ed su obligaci\u00f3n y parentesco espiritual.\n\n*Text supplied by researcher; no image provided. Accepted as transcribed \u2014 no long-s, thorn, or Kurrent ambiguities apply to printed Spanish colonial script.*\n\n---\n\n### Step 3 \u2014 Translation *(derivative \u2014 the original governs)*\n\n> In Mexico City, on the fifteenth of January of seventeen hundred and fifty, I, the undersigned priest, solemnly baptized Josefa Mar\u00eda, a Spaniard, legitimate daughter of Don Juan de Aguilar and Do\u00f1a Mar\u00eda Ram\u00edrez. Her godparents were Don Pedro G\u00f3mez and Do\u00f1a Ana L\u00f3pez, to whom I advised [them of] their obligation and spiritual kinship.\n\n---\n\n### Step 4 \u2014 Genealogical Annotations\n\n#### Names & Roles\n\n| Name | Role | Form in record |\n|---|---|---|\n| Josefa Mar\u00eda | Subject (baptizand) | *Josefa Mar\u00eda* |\n| Juan de Aguilar | Father | *Don Juan de Aguilar* |\n| Mar\u00eda Ram\u00edrez | Mother | *Do\u00f1a Mar\u00eda Ram\u00edrez* |\n| Pedro G\u00f3mez | Godfather (*padrino*) | *Don Pedro G\u00f3mez* |\n| Ana L\u00f3pez | Godmother (*madrina*) | *Do\u00f1a Ana L\u00f3pez* |\n\n*Names kept in original Spanish form per GPS convention \u2014 do not anglicize to Joseph, Mary, Peter, or Anne.*\n\n---\n\n#### Term-by-term annotations\n\n**`espa\u00f1ola`** \u2014 \u26a0\ufe0f **Critical casta marker, not merely \"Spanish woman.\"**\nIn colonial New Spain, *espa\u00f1ola* was a formal racial-caste classification in the *sistema de castas*, denoting a person of recorded pure Spanish/European descent (or so registered). This word belongs in any assertion about Josefa Mar\u00eda's identity \u2014 it affects research strategy (look in Spanish-caste registers, not *mestizo* or *indio* books) and can indicate social standing.\n\n**`hija leg\u00edtima`** \u2014 \"legitimate daughter,\" meaning born of a canonically valid marriage between the named parents. The contrasting terms \u2014 *hija natural*, *exp\u00f3sita*, or *ileg\u00edtima* \u2014 are absent, which is a positive finding. Confirms Juan de Aguilar and Mar\u00eda Ram\u00edrez were married at the time of Josefa's birth.\n\n**`Don` / `Do\u00f1a`** \u2014 Honorific titles of rank. Applied here to both parents **and** both godparents \u2014 all four adults were of recognized elite or *gente de raz\u00f3n* standing. Worth noting when researching the FAN (family, associates, neighbors) cluster.\n\n**`infrascrito cura`** \u2014 \"the undersigned priest\" \u2014 standard colonial formula; the officiant's name would appear as a signature below the entry (not transcribed here). Identifying the priest can help date service tenure and locate the parent register.\n\n**`bautic\u00e9 solemnemente`** \u2014 \"I solemnly baptized.\" *Solemne* distinguishes a full ceremony from an emergency (*sub conditione* or *privada*) baptism. No crisis at birth is implied.\n\n**`padrinos`** \u2014 Godparents (*padrino* = godfather, *madrina* = godmother; plural *padrinos* covers both). Under colonial canon law, the *compadrazgo* relationship created **spiritual kinship** (*parentesco espiritual*) between the godparents, the child, and the natural parents \u2014 a form of affinity that:\n1. Barred marriage between those parties without a dispensation, and\n2. Created strong social bonds worth researching (godparents were frequently relatives, neighbors, or patrons).\n\n**`advert\u00ed su obligaci\u00f3n`** \u2014 \"I advised them of their obligation.\" The priest's formal notification to the godparents of their duty to ensure the child's Catholic upbringing \u2014 a standard canonical act recorded to show compliance with *Rituale Romanum* requirements.\n\n---\n\n#### Key facts extracted\n\n| Field | Value | Note |\n|---|---|---|\n| **Event** | Baptism | *Not* birth \u2014 birth date unstated |\n| **Baptism date** | 15 January 1750 (ISO: 1750-01-15) | |\n| **Birth date** | Not recorded | In colonial Mexico, baptism typically followed birth within 1\u20133 days; do not assume 15 Jan is the birth date |\n| **Place** | Ciudad de M\u00e9xico | Viceroyalty of New Spain; identify the specific parish for repository research |\n| **Subject** | Josefa Mar\u00eda | Casta: *espa\u00f1ola*; sex: female |\n| **Legitimacy** | Legitimate | *hija leg\u00edtima* |\n| **Father** | Don Juan de Aguilar | *Don* honorific |\n| **Mother** | Do\u00f1a Mar\u00eda Ram\u00edrez | *Do\u00f1a* honorific; uses maiden surname |\n| **Godfather** | Don Pedro G\u00f3mez | *Compadre* of Juan de Aguilar |\n| **Godmother** | Do\u00f1a Ana L\u00f3pez | *Comadre* of Juan de Aguilar and Mar\u00eda Ram\u00edrez |\n\n---\n\n### Step 5 \u2014 Suggested Next Steps\n\n1. **\"Extract these as assertions into research.json?\"** \u2192 invoke **record-extraction** to log each data point (baptism date, parentage, godparents, casta) as structured assertions with a proper citation.\n\n2. **\"Link Josefa Mar\u00eda (or her parents) to the tree?\"** \u2192 invoke **person-evidence** once assertions exist.\n\n3. **\"Identify the specific parish?\"** The record names the city but not the church. In 1750 Mexico City, the main parishes included the Sagrario Metropolitano and several *barrio* parishes. Pinpointing the parish is essential for locating the original register \u2014 consider invoking **locality-guide** for colonial Mexico City parish coverage.\n\n4. **\"Research the godparents as FAN-cluster leads?\"** Don Pedro G\u00f3mez and Do\u00f1a Ana L\u00f3pez \u2014 sharing the *Don/Do\u00f1a* honorific with the parents \u2014 are strong candidates for kinship or patronage ties worth following up in the same parish registers.",
+            "activated": true,
+            "skills_invoked": [
+              "translation"
+            ],
+            "tool_calls": [],
+            "files_created": []
+          },
+          "validators": {
+            "passed": true,
+            "results": [
+              {
+                "name": "test_id_references_resolve",
+                "passed": true,
+                "error": "skipped: No research.json in output"
+              },
+              {
+                "name": "test_log_append_only",
+                "passed": true,
+                "error": "skipped: Missing research.json for diff"
+              },
+              {
+                "name": "test_no_entries_deleted",
+                "passed": true,
+                "error": "skipped: Missing research.json for diff"
+              },
+              {
+                "name": "test_ownership_table",
+                "passed": true,
+                "error": "skipped: Missing research.json for ownership diff"
+              },
+              {
+                "name": "test_research_json_validates_schema",
+                "passed": true,
+                "error": "skipped: No research.json in output"
+              },
+              {
+                "name": "test_tool_allowlist",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_gedcomx_json_validates_schema",
+                "passed": true,
+                "error": "skipped: No tree.gedcomx.json in output"
+              },
+              {
+                "name": "test_tree_ownership_table",
+                "passed": true,
+                "error": "skipped: Missing tree.gedcomx.json for ownership diff"
+              },
+              {
+                "name": "test_no_mcp_tools_called",
+                "passed": true,
+                "error": null
+              }
+            ]
+          },
+          "judge": {
+            "skipped": false,
+            "dimensions": [
+              {
+                "source": "base",
+                "name": "Correctness",
+                "score": 3,
+                "rationale": "The translation is factually accurate and faithful to the original Spanish text. All genealogical terms are correctly rendered: 'espa\u00f1ola' as casta designation, 'hija leg\u00edtima' as legitimate daughter, 'padrinos' as godparents, 'parentesco espiritual' as spiritual kinship. Names are preserved in original Spanish form. The structural rendering of the baptism ceremony matches the source precisely."
+              },
+              {
+                "source": "base",
+                "name": "Completeness",
+                "score": 3,
+                "rationale": "The skill fully addressed the user's request to translate the Spanish colonial baptism record. It translated the full text, explained all major genealogically significant terms (espa\u00f1ola, hija leg\u00edtima, padrinos, parentesco espiritual, Don/Do\u00f1a), extracted key data points, identified research leads, and provided next steps for further investigation. No material was omitted."
+              },
+              {
+                "source": "base",
+                "name": "Tool Arguments",
+                "score": null,
+                "rationale": "No MCP tool calls were made. The skill completed the translation and annotation work entirely through text analysis without invoking tools. This is appropriate for the task as requested (translation without explicit data extraction into research.json)."
+              },
+              {
+                "source": "rubric",
+                "name": "Accuracy",
+                "score": 3,
+                "rationale": "Translation preserves precise meaning of all genealogical terms. 'Espa\u00f1ola' is correctly identified as a casta classification (not mere nationality). 'Hija leg\u00edtima' captures legitimacy status. 'Padrinos' and 'parentesco espiritual' are accurately rendered with full genealogical context. Names remain in original Spanish. Relationship terms, occupations, and social markers are all translated with fidelity."
+              },
+              {
+                "source": "rubric",
+                "name": "Notation of uncertainty",
+                "score": 3,
+                "rationale": "The skill explicitly flags ambiguities and provides alternatives where appropriate. For example, it notes that birth date is not recorded and differs from baptism date; explains the standard 1\u20133 day gap between birth and baptism in colonial Mexico; and uses the \u26a0\ufe0f marker to highlight critical casta terminology. Archaic formulas ('infrascrito cura') are explained, and period-specific terminology is contextualized."
+              },
+              {
+                "source": "rubric",
+                "name": "Genealogical context",
+                "score": 3,
+                "rationale": "All genealogically significant terms receive explanation beyond literal translation. 'Parentesco espiritual' is explained as creating canonical marriage impediments. 'Padrinos' are identified as FAN-club figures likely to be relatives or patrons. 'Don/Do\u00f1a' honorifics are noted as social standing markers. 'Hija leg\u00edtima' is contrasted with alternative legitimacy statuses ('natural,' 'exp\u00f3sita,' 'ileg\u00edtima'). Research implications (casta-specific parish registers, parish identification, godparent investigation) are clearly outlined."
+              }
+            ],
+            "judge_cost_usd": 0.008990000000000001,
+            "error": null,
+            "input_tokens": 4995,
+            "cached_input_tokens": 0,
+            "output_tokens": 799
+          }
+        }
+      ]
+    }
+  ],
+  "totals": {
+    "duration_ms": 663927.7944389977,
+    "input_tokens": 97,
+    "cached_input_tokens": 638461,
+    "output_tokens": 29744,
+    "judge_input_tokens": 53490,
+    "judge_cached_input_tokens": 0,
+    "judge_output_tokens": 9371,
+    "skill_cost_usd": 1.0051780499999998,
+    "judge_cost_usd": 0.10034499999999998,
+    "total_cost_usd": 1.10552305
+  }
+}

--- a/packages/engine/plugin/skills/translation/SKILL.md
+++ b/packages/engine/plugin/skills/translation/SKILL.md
@@ -28,16 +28,7 @@ abbreviation systems that general translation tools miss.
 
 ## GPS grounding
 
-This skill implements BCG standards 23, 24, 29, 32, and 6:
-
-- Read all legible handwriting correctly (period scripts, not just
-  the language).
-- Understand words as used in the source's time and place.
-- Transcribe entire items with annotations for damage/illegibility.
-- Reproduce wording, spelling, abbreviations, and obsolete
-  letterforms exactly.
-- Follow Chicago Manual conventions for foreign text in English
-  narrative.
+This skill implements BCG standards 23, 24, 29, 32, and 6 (read period scripts correctly, read words in their period meaning, transcribe the entire item exactly, follow Chicago conventions for foreign text) — see `references/gps-translation-standards.md`. The operational rules live in the Steps below.
 
 **Critical principle:** A translation is a derivative source. Always
 preserve the original text alongside any translation. When a
@@ -174,10 +165,7 @@ character by character through ambiguous passages.
 
 ## Output conventions
 
-The derivative-source principle, exact transcription, uncertainty
-flagging, period meanings, and original-form names are covered in GPS
-grounding and the Steps above. These conventions govern how the
-translation is written up:
+These conventions govern how the translation is written up:
 
 - **Date conventions vary.** German: day.month.year. French: day
   month year. Latin: varies. Convert to ISO 8601 in the summary.
@@ -203,11 +191,4 @@ translation is written up:
 
 ## Re-invocation behavior
 
-**Writes:** nothing. Translation output is rendered in-session; this
-skill does not save files to disk and does not modify
-`research.json` or `tree.gedcomx.json`.
-
-**On repeat invocation:** safe to call as many times as needed. Each call
-is a fresh translation pass.
-
-**Do not duplicate:** N/A — no writes.
+Writes nothing — no files, no `research.json` / `tree.gedcomx.json`. Safe to call repeatedly; each call is a fresh translation pass.


### PR DESCRIPTION
Shortens the translation skill's instructions — no behavior change.

  Cuts (per eval/briefs/shorten-translation.md): Re-invocation boilerplate → one
  line; GPS-standards bullet list → one-line citation (kept the derivative-source
  principle); removed the redundant Output-conventions enumeration. Kept all the
  craft — the worked example, per-language/paleography tables, and
  transcription/uncertainty rules.

  Run v1_2026-06-22_19-33-09: all 12 tests graded green (graded by Florence).
  008 shows "fail" = the known #268 skills_invoked false-fail — all its
  dimensions pass. runlog-discipline green
  
  Closes #426