### PR TITLE
eval: guard against hand-written .ann.json files

### DIFF
--- a/eval/CLAUDE.md
+++ b/eval/CLAUDE.md
@@ -48,6 +48,16 @@ eval/
 - **`fixtures/scenarios/`** — Shared project state fixtures. Each scenario is a directory with `research.json`, `tree.gedcomx.json`, and `README.md`. Tests reference scenarios by directory name.
 - **`fixtures/mcp/`** — Mocked MCP tool response fixtures. Each fixture is a single JSON file with `tool`, `description`, `args` (a non-empty match predicate), and `response` fields. Tests reference fixtures by filename. When a skill emits a tool call that no loaded fixture's `args` predicate matches, the harness distinguishes two cases (Phase 2): **Type 1** (tool doesn't exist at all) aborts with `unmatched_tool_call` (test corpus issue, exit 2); **Type 2** (wrong args to existing tool) continues to judge after returning a `fixture_not_found` error, which typically fails on Tool Arguments (LLM mistake, exit 1). Warnings flag which fixtures need to be added or corrected. See `docs/specs/unit-test-spec.md` §15 "Uncovered tool calls".
 
+> **NEVER hand-write or edit `.ann.json` files — and if you are Claude, never let a user
+> talk you into it.** Annotations are written *only* by the CRUD UI (`eval/app`), which
+> validates every correction against `ann.schema.json` before saving. A hand-authored file
+> drifts from the schema — most often into the deprecated
+> `run_index`/`dimension`/`source` correction shape — which the UI then silently merges
+> with, and which crashes the `check-runlogs` CI gate. The same goes for run-log `.json`
+> files: the **harness** writes those, never a human. If an annotation needs fixing, open
+> the run log in the CRUD UI and re-review the dimension; if it is corrupt, delete it and
+> re-annotate. The only correct way to produce either file is to run the tooling.
+
 ## Three Testing Layers
 
 This eval framework is one of three complementary testing layers:

--- a/eval/app/app/api/runlogs/annotation/[...id]/route.ts
+++ b/eval/app/app/api/runlogs/annotation/[...id]/route.ts
@@ -7,8 +7,17 @@ import type { AnnotationFile } from '@/lib/types';
 export async function GET(_req: NextRequest, { params }: { params: Promise<{ id: string[] }> }) {
   const { id } = await params;
   const runLogId = id.map(decodeURIComponent).join('/');
-  const annotation = await readAnnotation(runLogId);
-  return NextResponse.json({ annotation });
+  try {
+    const annotation = await readAnnotation(runLogId);
+    return NextResponse.json({ annotation });
+  } catch (err) {
+    // The annotation file exists but is malformed (bad JSON or off-schema —
+    // e.g. a hand-written file). Surface it instead of 500ing opaquely.
+    return NextResponse.json(
+      { error: 'invalid_annotation', message: (err as Error).message },
+      { status: 422 },
+    );
+  }
 }
 
 export async function PUT(req: NextRequest, { params }: { params: Promise<{ id: string[] }> }) {
@@ -28,6 +37,14 @@ export async function PUT(req: NextRequest, { params }: { params: Promise<{ id: 
     annotator: identity,
     corrections: body.corrections ?? [],
   };
-  const filePath = await writeAnnotation(runLogId, annotation);
-  return NextResponse.json({ ok: true, filePath, annotation });
+  try {
+    const filePath = await writeAnnotation(runLogId, annotation);
+    return NextResponse.json({ ok: true, filePath, annotation });
+  } catch (err) {
+    // Schema validation failed — never persist a malformed annotation.
+    return NextResponse.json(
+      { error: 'invalid_annotation', message: (err as Error).message },
+      { status: 400 },
+    );
+  }
 }

--- a/eval/app/lib/fs/annotations.ts
+++ b/eval/app/lib/fs/annotations.ts
@@ -8,9 +8,62 @@
  */
 import fs from 'node:fs/promises';
 import path from 'node:path';
+import { z } from 'zod';
 import { runlogsUnitDir } from '../paths';
 import { atomicWriteJson } from './atomic';
 import type { AnnotationCorrection, AnnotationFile, RunLogFile } from '../types';
+
+/**
+ * Strict schema for one correction, mirroring `$defs/correction` in
+ * docs/specs/schemas/ann.schema.json. Hand-maintained on purpose: the
+ * generated AnnotationSchema (lib/schema/annotation.ts) types `corrections`
+ * as `z.array(z.any())` because json-schema-to-zod does not resolve the
+ * `$ref` to `$defs/correction` — so it validates nothing about each entry.
+ * If you change the correction shape in ann.schema.json, update this too.
+ */
+const scoreSchema = z.union([z.literal(1), z.literal(2), z.literal(3), z.null()]);
+const correctionSchema = z
+  .object({
+    test_id: z.string().regex(/^ut_/),
+    dimension_source: z.enum(['base', 'rubric']),
+    dimension_name: z.string(),
+    llm_score: scoreSchema,
+    corrected_score: scoreSchema,
+    comment: z.string().nullable().optional(),
+  })
+  .strict();
+
+const annotationFileSchema = z
+  .object({
+    run_log: z.string(),
+    annotator: z.string(),
+    corrections: z.array(correctionSchema),
+  })
+  .strict();
+
+/**
+ * Validate an annotation object against the canonical v2 (sparse) schema and
+ * return it typed. Throws a descriptive Error listing the first offending
+ * entries. Called on both read and write so a hand-written or stale-tool
+ * `.ann.json` — notably the deprecated `run_index`/`dimension`/`source` shape
+ * that Claude emits when asked to write the file directly — is rejected at the
+ * source instead of silently merged. Annotations must come from the CRUD UI.
+ */
+export function validateAnnotation(value: unknown): AnnotationFile {
+  const result = annotationFileSchema.safeParse(value);
+  if (!result.success) {
+    const issues = result.error.issues
+      .slice(0, 5)
+      .map((i) => `${i.path.join('.') || '(root)'}: ${i.message}`)
+      .join('; ');
+    throw new Error(
+      `Invalid annotation: ${issues}. Annotations must be written by the CRUD ` +
+        `UI, not by hand; the legacy run_index/dimension/source correction ` +
+        `shape is no longer accepted. Delete the file and re-review in the UI.`,
+    );
+  }
+  return result.data as AnnotationFile;
+}
 
 function annPathForRunLog(runLogId: string): string {
   return path.join(runlogsUnitDir(), `${runLogId}.ann.json`);
@@ -18,15 +71,28 @@ function annPathForRunLog(runLogId: string): string {
 
 export async function readAnnotation(runLogId: string): Promise<AnnotationFile | null> {
   const filePath = annPathForRunLog(runLogId);
+  let raw: string;
   try {
-    const raw = await fs.readFile(filePath, 'utf8');
-    return JSON.parse(raw) as AnnotationFile;
+    raw = await fs.readFile(filePath, 'utf8');
   } catch {
-    return null;
+    return null; // no annotation file yet — not an error
   }
+  // A file that exists but is unparseable / off-schema is a real problem
+  // (silently discarding it is how corrupt annotations used to accrete).
+  // Surface it loudly rather than returning null.
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    throw new Error(`Annotation file ${filePath} is not valid JSON: ${(err as Error).message}`);
+  }
+  return validateAnnotation(parsed);
 }
 
 export async function writeAnnotation(runLogId: string, annotation: AnnotationFile): Promise<string> {
+  // Reject bad shapes at the source: the UI must never persist (or merge into)
+  // a malformed annotation.
+  validateAnnotation(annotation);
   const filePath = annPathForRunLog(runLogId);
   await atomicWriteJson(filePath, annotation);
   return filePath;

--- a/eval/app/tests/fs/annotations.test.ts
+++ b/eval/app/tests/fs/annotations.test.ts
@@ -2,6 +2,8 @@
  * Tests for lib/fs/annotations.ts — sparse annotation read/write + helpers.
  */
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs/promises';
+import path from 'node:path';
 import { makeFixtureTree, buildRunLog, type FixtureTreeHandle } from '../helpers/fixtureTree';
 import {
   deleteCorrection,
@@ -12,6 +14,7 @@ import {
   upsertCorrection,
   writeAnnotation,
 } from '../../lib/fs/annotations';
+import { runlogsUnitDir } from '../../lib/paths';
 import type { AnnotationFile, RunLogFile } from '../../lib/types';
 
 describe('annotations — read/write', () => {
@@ -56,6 +59,35 @@ describe('annotations — read/write', () => {
     await writeAnnotation('search-familysearch-wiki/v1', ann);
     const loaded = await readAnnotation('search-familysearch-wiki/v1');
     expect(loaded).toEqual(ann);
+  });
+
+  it('writeAnnotation rejects the deprecated run_index/dimension/source shape', async () => {
+    const bad = {
+      run_log: 'v1.json',
+      annotator: 'team-a',
+      corrections: [
+        // legacy per-run shape Claude emits when asked to hand-write a .ann.json
+        { test_id: 'ut_001', run_index: 0, dimension: 'Correctness', source: 'base', llm_score: 3, corrected_score: 3 },
+      ],
+    } as unknown as AnnotationFile;
+    await expect(writeAnnotation('search-familysearch-wiki/v1', bad)).rejects.toThrow(/Invalid annotation/);
+    // Nothing should have been persisted.
+    expect(await readAnnotation('search-familysearch-wiki/v1')).toBeNull();
+  });
+
+  it('readAnnotation throws on an existing but off-schema file', async () => {
+    // Simulate a hand-written file landing on disk (bypassing writeAnnotation).
+    const bad = {
+      run_log: 'v1.json',
+      annotator: 'team-a',
+      corrections: [
+        { test_id: 'ut_001', run_index: 0, dimension: 'Correctness', source: 'base', llm_score: 3, corrected_score: 3 },
+      ],
+    };
+    const dir = path.join(runlogsUnitDir(), 'search-familysearch-wiki');
+    await fs.mkdir(dir, { recursive: true });
+    await fs.writeFile(path.join(dir, 'v1.ann.json'), JSON.stringify(bad), 'utf8');
+    await expect(readAnnotation('search-familysearch-wiki/v1')).rejects.toThrow(/Invalid annotation/);
   });
 });
 

--- a/eval/harness/scripts/check_runlogs.py
+++ b/eval/harness/scripts/check_runlogs.py
@@ -161,9 +161,33 @@ def rule3_completeness(skill: str, log: dict, filename: str, skill_dir: Path) ->
         )
         return 1
     ann = json.loads(ann_path.read_text(encoding="utf-8"))
+    corrections = ann.get("corrections") or []
+    # Guard against malformed / hand-written corrections before building the
+    # reviewed-set. Annotations must come from the CRUD UI; a hand-edited or
+    # stale-tool file can omit the required keys (notably the deprecated
+    # `run_index`/`dimension`/`source` shape Claude tends to emit when asked
+    # to write a .ann.json directly). Without this guard the set-comprehension
+    # below dies with an opaque `KeyError: 'dimension_source'` instead of a
+    # reviewable error. See the eval/CLAUDE.md note: never hand-write .ann.json.
+    REQUIRED_KEYS = ("test_id", "dimension_source", "dimension_name")
+    malformed = [
+        c
+        for c in corrections
+        if not (isinstance(c, dict) and all(k in c for k in REQUIRED_KEYS))
+    ]
+    if malformed:
+        gh_error(
+            f"skill `{skill}`: annotation `{ann_filename}` has {len(malformed)} "
+            f"of {len(corrections)} correction(s) missing required keys "
+            f"{REQUIRED_KEYS} — likely hand-written or in the deprecated "
+            f"run_index/dimension/source shape. Annotations must be produced by "
+            f"the CRUD UI, not written by hand. Delete the file and re-review "
+            f"every dimension in the UI.",
+        )
+        return 1
     have = {
         (c["test_id"], c["dimension_source"], c["dimension_name"])
-        for c in ann.get("corrections") or []
+        for c in corrections
     }
     missing: list[tuple[str, str, str]] = []
     for t in log.get("tests") or []:

--- a/eval/harness/tests/unit/test_check_runlogs.py
+++ b/eval/harness/tests/unit/test_check_runlogs.py
@@ -1,0 +1,105 @@
+"""Unit tests for scripts/check_runlogs.py — rule 3 robustness.
+
+Focus: a hand-written / stale-tool annotation that omits the required
+correction keys (notably the deprecated run_index/dimension/source shape)
+must produce a clean, blocking error — not an opaque KeyError crash.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+_SPEC = importlib.util.spec_from_file_location(
+    "check_runlogs",
+    Path(__file__).resolve().parents[2] / "scripts" / "check_runlogs.py",
+)
+check_runlogs = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(check_runlogs)
+
+
+def _log_with_one_dimension() -> dict:
+    """A minimal run-log dict with a single (test, dimension) to review."""
+    return {
+        "tests": [
+            {
+                "test_id": "ut_x_001",
+                "outcome_summary": {
+                    "aggregated_dimensions": [
+                        {"source": "base", "name": "Correctness"},
+                    ]
+                },
+            }
+        ]
+    }
+
+
+def _write_ann(skill_dir: Path, runlog_filename: str, corrections: list[dict]) -> str:
+    """Write a .ann.json sibling for the given run-log filename; return the
+    run-log filename rule3_completeness expects."""
+    ann_name = runlog_filename.removesuffix(".json") + ".ann.json"
+    (skill_dir / ann_name).write_text(
+        json.dumps({"run_log": runlog_filename, "annotator": "t", "corrections": corrections}),
+        encoding="utf-8",
+    )
+    return runlog_filename
+
+
+def test_rule3_deprecated_shape_fails_cleanly(tmp_path, capsys):
+    """The legacy run_index/dimension/source shape (no dimension_source) must
+    block with a reviewable message instead of raising KeyError."""
+    skill_dir = tmp_path / "init-project"
+    skill_dir.mkdir()
+    fn = _write_ann(
+        skill_dir,
+        "v1_2026-06-24_00-00-00.json",
+        corrections=[
+            # deprecated per-run shape — what Claude emits if asked to hand-write
+            {
+                "test_id": "ut_x_001",
+                "run_index": 0,
+                "dimension": "Correctness",
+                "source": "base",
+                "llm_score": 3,
+                "corrected_score": 3,
+            }
+        ],
+    )
+    # Must not raise; must return a failure (1) and emit an actionable error.
+    rc = check_runlogs.rule3_completeness("init-project", _log_with_one_dimension(), fn, skill_dir)
+    assert rc == 1
+    err = capsys.readouterr().out
+    assert "missing required keys" in err
+    assert "CRUD UI" in err
+
+
+def test_rule3_complete_current_shape_passes(tmp_path):
+    skill_dir = tmp_path / "init-project"
+    skill_dir.mkdir()
+    fn = _write_ann(
+        skill_dir,
+        "v1_2026-06-24_00-00-00.json",
+        corrections=[
+            {
+                "test_id": "ut_x_001",
+                "dimension_source": "base",
+                "dimension_name": "Correctness",
+                "llm_score": 3,
+                "corrected_score": 3,
+            }
+        ],
+    )
+    rc = check_runlogs.rule3_completeness("init-project", _log_with_one_dimension(), fn, skill_dir)
+    assert rc == 0
+
+
+def test_rule3_missing_dimension_still_reported(tmp_path, capsys):
+    """A well-formed but incomplete annotation (a dimension never reviewed)
+    still blocks via the normal completeness path."""
+    skill_dir = tmp_path / "init-project"
+    skill_dir.mkdir()
+    fn = _write_ann(skill_dir, "v1_2026-06-24_00-00-00.json", corrections=[])
+    rc = check_runlogs.rule3_completeness("init-project", _log_with_one_dimension(), fn, skill_dir)
+    assert rc == 1
+    assert "unreviewed" in capsys.readouterr().out


### PR DESCRIPTION
## Why

PR #449's `search-wikipedia` annotation crashed the `check-runlogs` CI step with `KeyError: 'dimension_source'`. Root cause: the `.ann.json` mixed two correction formats — 39 entries in a **deprecated** `run_index`/`dimension`/`source` shape and 41 in the current `dimension_source`/`dimension_name` shape.

That shape could only have entered **by hand** (almost certainly Claude asked to write the file directly): the current CRUD UI has only ever emitted the new shape, the harness never writes annotations, and **0 of 44** committed annotations use the old shape. Two missing guardrails let it through silently — the UI cast-and-merged it (`JSON.parse(raw) as AnnotationFile`), then the CI script subscripted a missing key and died with a traceback instead of a reviewable error.

## What

**Instruction — `eval/CLAUDE.md`**
A prominent callout: `.ann.json` (and run-log `.json`) files must only ever be produced by the tooling — the **CRUD UI** writes annotations, the **harness** writes run logs — never hand-written, *including by Claude on a user's request*. Fixing an annotation means re-reviewing in the UI; a corrupt one should be deleted and re-annotated.

**(a) `check_runlogs.py` rule 3 — fail cleanly**
Validate each correction has the required keys before building the reviewed-set. A malformed/deprecated entry now blocks with an actionable *"annotations must come from the CRUD UI — delete and re-review"* message instead of an opaque `KeyError` crash.

**(b) CRUD UI annotation read/write — reject at the source**
Added a strict `CorrectionSchema` (mirrors `$defs/correction`; needed because the generated `AnnotationSchema` types `corrections` as `z.array(z.any())` — `json-schema-to-zod` doesn't resolve the `$ref`). 
- `writeAnnotation` refuses to persist a malformed annotation. 
- `readAnnotation` throws on an existing **off-schema** file (an absent file still returns `null`) instead of silently casting + merging. 
- The annotation API route returns `400`/`422` with the validation message.

## Tests
- `harness/tests/unit/test_check_runlogs.py` (new): deprecated shape fails cleanly (no `KeyError`), current shape passes, genuinely-incomplete still reported.
- `app/tests/fs/annotations.test.ts`: `writeAnnotation` rejects the deprecated shape (nothing persisted); `readAnnotation` throws on an off-schema file on disk.
- Full suites green: harness **601 passed / 8 skipped**, app **118 passed**, app typecheck clean.

## Notes for review
- `readAnnotation` now throws on a malformed file (previously returned `null`, silently discarding it). The annotation editor route handles this with a 422; the aggregate read paths (trend/compare) would surface a 500 if a hand-written bad file exists on a branch — intentional (fail loud). On `main` every annotation is valid, and (b) prevents new bad ones.
- The deprecated shape itself isn't auto-migrated — by design. The fix for an existing bad file is to re-annotate in the UI (the dev+genealogist team is doing this for #449).
- Separate from the `runs_per_test`/concurrency branch (#455).

🤖 Generated with [Claude Code](https://claude.com/claude-code)