### PR TITLE
Speedup: batch persistence tools + skill/harness efficiency (Ideas 1, 2a, 2b, 3a)

### DIFF
--- a/apps/server/app/agent/real_agent.py
+++ b/apps/server/app/agent/real_agent.py
@@ -59,7 +59,15 @@ def build_options(project_dir: Path, resume: str | None = None):
         mcp_servers={
             "genealogy": {"type": "stdio", "command": "node", "args": [_MCP_BUILD]},
         },
-        env={"ANTHROPIC_API_KEY": os.environ.get("ANTHROPIC_API_KEY", "")},
+        # ENABLE_TOOL_SEARCH=true eager-loads the genealogy MCP tool schemas
+        # instead of deferring them above the bundled CLI's token threshold
+        # (the ~38-tool server trips it), which otherwise forces repeated
+        # ToolSearch re-discovery mid-session. See speedup plan §3a — kept in
+        # sync with the e2e orchestrator so hosted-web users get the same win.
+        env={
+            "ANTHROPIC_API_KEY": os.environ.get("ANTHROPIC_API_KEY", ""),
+            "ENABLE_TOOL_SEARCH": "true",
+        },
     )
     if resume:
         kwargs["resume"] = resume  # reload the prior conversation transcript

--- a/docs/plan/e2e-research-runtime-speedup-plan.md
+++ b/docs/plan/e2e-research-runtime-speedup-plan.md
@@ -191,11 +191,18 @@ atomic — the persisted content is identical.
 - **Drop the standalone `validate_research_schema` passes**
   (`research/SKILL.md:107-109`). Every writer tool already validates-before-
   persist, so the periodic orchestrator validate is pure redundancy. Risk: low.
-- **Defer the `gps-mentor` gates** (`research/SKILL.md:121-136`) — for a
-  single-question autonomous objective, run the mentor review **once at
-  conclusion** rather than at each transition (each gate is a cold-context
-  subagent read of the whole project). Risk: medium — these are the quality
-  backstop, so *defer, don't delete*; keep the final gate to protect the PASS.
+- **~~Defer the `gps-mentor` gates~~ — DROPPED from this plan.** The mentor is
+  **not staged into the e2e sandbox at all**: `build_workspace`
+  (`eval/harness/e2e/orchestrator.py`) copies only `plugin/skills/`, never
+  `plugin/agents/`, so both passing e2e runs recorded `evaluations: []` with
+  zero mentor invocations. Deferring the gates therefore saves the benchmark
+  **0 min** and would ship a quality-affecting change to the GPS workflow's only
+  production proof-quality backstop with no test coverage. The mentor is
+  decoupled from this speedup work; the "stage → measure → then decide" sequence
+  for reducing its cost (a production, not benchmark, concern) is recorded in
+  `docs/specs/gps-mentor-agent-spec.md` §17.1. **2b's remaining savings below are
+  unchanged** — they were always attributed to narration / re-reads / redundant
+  validates / the handoff retry loop, not the mentor.
 - **Fix the record-extraction handoff** so it doesn't re-run `record_search` to
   recover persona IDs / the `record_id` it was already handed
   (`search-records:441-447` context-only handoff; `record-extraction` then
@@ -272,14 +279,113 @@ Structural floor ~51 min → projected ~15–20 min after 1+2; with 3b capping t
 stalls, total wall-clock projects to **~12–18 min**. Reaching the 10–15 target
 reliably needs **both** the batch tool change and the stall cap.
 
-## 6. Open questions for review
+## 6. Open questions — resolved
 
-- **Batch shape:** heterogeneous `ops` (proposed — enables one-call-per-record)
-  vs. a simpler homogeneous `entries` (covers the observed streaks). Heterogeneous
-  costs the same to implement; do we want the generality?
-- **gps-mentor deferral (2b):** acceptable to run the mentor gates once at
-  conclusion for single-question autonomous runs, or keep per-transition for
-  safety? (Quality-vs-speed call for the senior reviewer.)
-- **Idea 3 ownership:** the tool-deferral and stall behavior also affect
-  production Cowork, not just the eval harness — should 3a/3b be solved in the
-  harness, raised upstream, or both?
+Resolved 2026-06-23 after a code/skills/harness research pass (parallel readers +
+adversarial verification). Each decision below cites the deciding evidence.
+
+### Q1 — Batch shape: **heterogeneous `ops`** ✅
+
+Adopt the heterogeneous shape (each op names its own `section`/`operation`); keep
+`research_append` and `tree_edit` as two separate batched tools.
+
+- **It is not more expensive than homogeneous.** Per-op dispatch already exists in
+  the single-call form (`research-append.ts` resolves `SECTIONS[section]` per call;
+  `tree-edit.ts` switches on `operation` per call), and both id allocators rescan
+  the live in-memory document, so intra-batch sequencing is automatic in either
+  shape. Homogeneous would only *add* an "all entries share one section" constraint
+  for no saving.
+- **The real run decides it.** In the spriggs run, 5 of 6 large write-blocks **mix
+  sections** (the two record-extraction blocks most of all). Whole-run write calls:
+  **111 today → ~25 homogeneous → ~17 heterogeneous.** Heterogeneous saves ~8 more
+  turns, concentrated in the record hot path (`record-extraction/SKILL.md` step 5
+  fans one record across source + assertions + tree `add_source` + sibling stubs).
+
+**Correction to Idea 1's framing:** `research_append`'s single-op body returns
+`{ok:false}` inline **~17 times** (not "~10") and the `project` singleton has its
+**own** validate+write+early-return tail (`research-append.ts:184-226`) — both must
+be folded into the shared `applyOne` + validate-once/write-once path. `tree_edit`'s
+`applyOperation` is already a clean throwing per-op helper, so it is near-free.
+
+**Batch contract the implementation must honor (shape-independent, but the het hot
+path makes it load-bearing):**
+1. **All-or-nothing:** apply every op to one in-memory doc, validate the whole doc
+   **once**, write **once**; on any per-op failure write nothing.
+2. **Per-op error indexing:** `ops[i]: <message>` so the agent can fix one row.
+3. **Result array:** `research_append` → `results: [{section, op, entryId}]`;
+   `tree_edit` → `results: [{operation, assignedIds}]`.
+4. **Intra-batch id rule:** an op MAY reference an id it *creates* earlier in the
+   same batch via that id's predictable `<prefix>NNN` (the allocator assigns
+   sequentially — e.g. an assertion's `source_id: "src_001"` after appending the
+   source as op #1, exactly as the sequential run already does). An op MAY NOT
+   `update` or otherwise depend on an id created earlier in the same batch (append
+   assigns the id internally; the caller cannot pre-name it for update).
+5. **Cross-tool ordering stays two calls:** `tree_edit add_person` assigns the
+   `I`-ids that the `research_append` `person_evidence` batch references, so the
+   tree batch commits first; do not merge or reorder the two.
+6. **Single-op form is byte-identical** to today (zero risk to existing callers);
+   persisted shapes are unchanged, so no schema/validator/web-mirror/fixture churn.
+
+### Q2 — gps-mentor: **decoupled from this plan** ✅
+
+Not a speedup lever for e2e — the mentor is never staged into the sandbox (see the
+struck bullet in Idea 2b). No production change is made here. The conditions and
+the staged "(a) land conformance PR → (b) stage + measure in e2e → (c) then decide
+gating" sequence for ever reducing mentor cost are recorded durably in
+`docs/specs/gps-mentor-agent-spec.md` §17.1.
+
+### Q3 — Ownership: **both, harness-first** ✅ (separate follow-ups, not this PR)
+
+- **3a (pin schemas):** the lever is the bundled-CLI env var **`ENABLE_TOOL_SEARCH`**
+  (`true | auto | auto:N`, keyed off tool-definition token weight) — **not** a
+  `ClaudeAgentOptions` field; set it via the SDK `env=` pass-through. The genealogy
+  server advertises **38 tools** (over the ~30 / ~10K-token guidance), which is why
+  ~20 get deferred and re-discovered 17×. Cheapest probe: add
+  `env={"ENABLE_TOOL_SEARCH": "true"}` to the orchestrator and re-run one fixture,
+  counting ToolSearch calls. **Hosted-web production (`apps/server/app/agent/real_agent.py`)
+  uses the same SDK + bundled CLI + stdio MCP config with no override**, so the same
+  env must also land there or real users get nothing. Raise upstream for (i) a
+  surgical "pin a named tool set" / `auto:N` end-state and (ii) the Cowork *desktop*
+  runtime, which the env may not reach. **Structural alternative worth evaluating:**
+  cut the tool count below the token threshold (CLAUDE.md already mandates generic
+  tools with provider params) — removes deferral everywhere without eager-loading 38.
+- **3b (stall resume): DEFERRED — not implemented (evidence too thin).** The two
+  stalls are real (measured from the spriggs transcript), but that is **n=1** — one
+  run with timing forensics, no frequency data. Building resume plumbing plus a
+  correctness-risky double-apply mitigation behind a flag, to insure against a
+  variance seen once, is premature — and the batching (shorter runs) reduces
+  cold-cache exposure on its own, possibly shrinking 3b's value before it is
+  measured. **Trigger to revisit:** the e2e re-runs (validating Idea 1/2a/2b/3a) show
+  stalls *recurring* across runs. Only then build it, with real frequency data. The
+  design below stands for that point. Ownership when built: harness, behind a flag,
+  two ordered steps. Step 1 (safe,
+  first): capture `session_id` (currently discarded — `SystemMessage` branch is a
+  bare `pass`) and lower the inactivity cap (the 15–23 min stalls currently trip the
+  3600 s wall-clock cap, not the 600 s inactivity cap, so lowering inactivity is what
+  makes a stall *detectable*). **Correction:** the "cheaper fail-fast probe" the plan
+  hoped for does **not exist** — there is no per-request Anthropic timeout / max-retries
+  knob; `CLAUDE_CODE_STREAM_CLOSE_TIMEOUT` covers only the init handshake (≥60 s floor).
+  Step 2 (off-by-default flag): resume-on-stall, gated by the **double-apply hazard** —
+  all three writers are non-idempotent on create (`max+1` ids; `tree_edit` even rejects
+  caller-supplied create ids), so a replayed already-landed turn **duplicates** rather
+  than overwrites; the "resume only if no create pending" gate narrows but does not
+  close the window (the write commits in the MCP server before the `tool_result`
+  returns). Raise the stall variance upstream regardless. **Correction:** the "5-min
+  cache-TTL cliff" parallel in §1/§3b is a misread — the cited doc's "5-min timeout" is
+  the E2B sandbox idle-pause lifecycle, not an Anthropic prompt-cache TTL; drop it.
+
+### Scope of the immediate PR
+
+This PR implements **Ideas 1, 2a, 2b, and 3a**:
+- **1** — heterogeneous-`ops` batch tools (`research_append`, `tree_edit`) + spec + vitest.
+- **2a** — the four skills rewritten to emit batched `ops` calls.
+- **2b** — prompt-only efficiency cleanups (per-phase narration, stop redundant
+  re-reads, drop standalone validates, fix the record-extraction handoff).
+- **3a** — `ENABLE_TOOL_SEARCH=true` on the e2e orchestrator **and** the hosted-web
+  `real_agent.py`, to stop the ToolSearch re-discovery loop.
+
+**Deferred:** **3b** (stall resume — n=1 evidence; see above) and the **gps-mentor**
+change (decoupled; a production concern recorded in
+`gps-mentor-agent-spec.md` §17.1). End-to-end validation of the whole set is **one
+e2e re-run** (the plan's measurement method); the unit tests cover only the tool
+batching's correctness.

--- a/docs/specs/gps-mentor-agent-spec.md
+++ b/docs/specs/gps-mentor-agent-spec.md
@@ -664,3 +664,42 @@ These items are acknowledged but not specified here. They belong in future issue
 |------|-------|
 | Wiring into `/research` orchestrator skill | Depends on `/research` landing on main. DallanQ noted this explicitly in the implementation commit. |
 | Commit pending per-action approval | Not yet understood well enough to specify. Defer to DallanQ for clarification. |
+| Reducing per-gate mentor cost | Do not defer gates ad hoc to chase speed. Follow the staged sequence in §17.1. |
+
+### 17.1 Reducing per-gate mentor cost (defer until measurable)
+
+The e2e research-runtime speedup plan
+(`docs/plan/e2e-research-runtime-speedup-plan.md`, idea 2b) considered
+collapsing the three mentor gates (pre-exhaustiveness, conclusion-readiness,
+proof-critique) to a single conclusion gate to cut the cost of an autonomous
+`/research` run. **That change is explicitly NOT adopted**, for three reasons:
+
+1. **It is unmeasurable today.** The e2e harness does not stage
+   `packages/engine/plugin/agents/` into the sandbox — `build_workspace`
+   (`eval/harness/e2e/orchestrator.py`) copies only `plugin/skills/` into
+   `.claude/skills/`. So the mentor is absent from every benchmark run, both
+   passing e2e runs recorded `evaluations: []`, and gate deferral saves the
+   benchmark nothing while shipping a quality-affecting change with no test
+   coverage.
+2. **The agent is not yet conformant.** `agents/gps-mentor.md` is still the
+   pre-spec draft (see §2) pending the implementation PR. Optimizing a
+   component that has not landed is premature.
+3. **The final gate is the only production backstop.** There is no eval judge
+   in production Cowork, so the `proof-critique` gate is the only fresh-context
+   adversarial proof-quality check a real user receives. Trimming gates trades
+   the GPS workflow's one quality net for speed.
+
+If reducing mentor cost later becomes warranted (driven by **production**
+latency/cost evidence, not the e2e benchmark), do it in this sequence — **not**
+by deferring gates first:
+
+- **(a) Land the mentor conformance PR** (§2) so the agent behaves to spec.
+- **(b) Stage `plugin/agents/` into the e2e harness** (extend `build_workspace`
+  to copy agents into `.claude/agents/`, and add an `evaluations/` verdict
+  fixture) so e2e actually *exercises and measures* the gates — both their cost
+  (turns/tokens per gate) and whether any gate ever changes a verdict or proof
+  tier.
+- **(c) Then decide gating** with the GPS/spec owner, driven by that data plus
+  production cost. If measurement shows the two early gates (pre-exhaustiveness,
+  conclusion-readiness) never change an outcome, that is the evidence to
+  collapse to the single final `proof-critique` gate — earned, not assumed.

--- a/docs/specs/research-append-tool-spec.md
+++ b/docs/specs/research-append-tool-spec.md
@@ -124,6 +124,63 @@ camelCase convenience fields the same way `research_log_append` does.
 // on failure: { ok: false, errors: string[] } — nothing written
 ```
 
+### 3.3 Batch form (`ops`) — persist a whole record in one call
+
+To persist many entries at once (e.g. a record's source + every assertion + its
+person-evidence links), pass an optional `ops` array instead of the top-level
+`section`/`op`/`entry`/`entryId`/`fields`/`planId` (which are ignored when `ops`
+is present). Each op is the same per-op shape the single form takes:
+
+```typescript
+research_append({
+  projectPath,
+  ops: [
+    { section: "sources",         op: "append", entry: {...} },
+    { section: "assertions",      op: "append", entry: {...} },   // one op per assertion/persona
+    { section: "person_evidence", op: "append", entry: {...} },   // one op per link
+    { section: "assertions",      op: "update", entryId: "a_012", fields: {...} },
+    { section: "plan_items",      op: "append", entry: {...}, planId: "pl_001" },
+  ],
+})
+// → { ok: true, results: [{ section, op, entryId }, ...], filesWritten: ["research.json"], validation }
+// on failure: { ok: false, errors: ["ops[<i>]: <msg>"] } — nothing written
+```
+
+Semantics — heterogeneous ops chosen over a homogeneous `entries` array because the
+skills' natural unit of work (one record / household / plan) spans multiple sections,
+and the single-call form already dispatches per-op on `section`, so heterogeneity is
+no more expensive (decision: `docs/plan/e2e-research-runtime-speedup-plan.md` §6 Q1):
+
+- **All-or-nothing.** Every op is applied to one in-memory `research`, the **whole
+  document is validated once**, and `research.json` is written **once**. Any op's
+  precondition failure (§5) or a final validation failure writes **nothing** and
+  returns `{ ok: false, errors }`.
+- **Per-op error indexing.** A precondition failure on op *i* (an `applyOne` check —
+  bad section, missing field, the §5 invariants enforced in-loop) returns its
+  message(s) prefixed `ops[<i>]: …`, so the caller can fix one row without losing the
+  rest. A failure caught only by the **final whole-document validation** (e.g. a
+  cross-section reference, or a §5 rule the validator owns such as the fact-conflict
+  competing-count) is reported with its `research.json/…` path instead, since it is
+  not attributable to a single op in the loop.
+- **Intra-batch id assignment.** Ids are assigned in array order, each scanning the
+  live in-memory document, so consecutive appends to a section get consecutive ids.
+  A later op **may reference an id created by an earlier op** via that id's
+  predictable `<prefix>NNN` (e.g. append the source as op #1, then an assertion op
+  carries `source_id: "src_001"`). A later op **may NOT `update`** an id created
+  earlier in the same batch — `append` assigns the id internally, so it cannot be
+  named for an in-batch update; do that update in a follow-up call.
+- **No-op ops** (e.g. re-declaring an already-exhaustive question) do not mutate; a
+  batch of only no-ops writes nothing (`filesWritten: []`). `results` still echoes a
+  row for every op (no-ops included), and any per-op no-op note is surfaced in
+  `validation.warnings`; the `results` rows do not themselves flag which op was a no-op.
+- **Section invariants (§5) hold across the batch** — e.g. two `append`s of an active
+  plan for the same question in one batch are rejected at the second op, because the
+  first is already in the live `research.plans` when the second's invariant runs.
+
+The **persisted shape is byte-identical** to the single-op form; `ops` changes only
+the number of write calls, so no `research.json` schema, validator, web-mirror, or
+fixture change is required (the reason batching is low-risk).
+
 ---
 
 ## 4. Persistence — validate-before-persist, atomic, single-file

--- a/docs/specs/tree-edit-tool-spec.md
+++ b/docs/specs/tree-edit-tool-spec.md
@@ -141,10 +141,12 @@ tree_edit({
 - **`add_person`** `{ person }` — append a new person, assigning the next `I` id
   and an `N` id for each nested name (exactly-one `preferred`). Synthesized stubs
   omit `ark` (`simplified-gedcomx-spec.md` §4.6).
-- **`add_relationship`** `{ relationship }` — append, assign next `R`. Validate the
-  endpoints (`parent`/`child` for `ParentChild`, `person1`/`person2` for `Couple`)
-  reference existing persons (tree persons or FS ids already present); reject a
-  shape mismatch (e.g. `person1` on a `ParentChild`).
+- **`add_relationship`** `{ relationship }` — append, assign next `R`. Endpoint
+  integrity (`parent`/`child` for `ParentChild`, `person1`/`person2` for `Couple`
+  reference existing persons — tree persons or FS ids already present) and shape (no
+  `person1` on a `ParentChild`) are enforced by the final whole-tree validation pass
+  (§4.3, §5), not by an inline check in the apply step — so within a batch an endpoint
+  added by an earlier op is accepted.
 - **`add_source`** `{ source }` — append `source` to the tree's `sources`, assigning
   the next `S` id above the tree max (top-level, like `add_relationship` — no person
   scope, no place resolution, no primary swap). A caller-supplied `id` is rejected.
@@ -172,6 +174,47 @@ tree_edit({
 }
 // on failure: { ok: false, errors: string[] } — nothing written
 ```
+
+### 4.3 Batch form (`ops`) — several edits in one call
+
+To make several edits at once (e.g. a record's source plus its sibling stubs), pass
+an optional `ops` array instead of the top-level `operation`/targeting/payload fields
+(ignored when `ops` is present). Each op is the same `{ operation, ...fields }` the
+single form takes:
+
+```typescript
+tree_edit({
+  projectPath,
+  ops: [
+    { operation: "add_source", source: {...} },
+    { operation: "add_person", person: {...} },   // sibling stub
+    { operation: "add_fact",   personId: "I3", fact: {...} },
+  ],
+})
+// → { ok: true, results: [{ operation, assignedIds? }, ...], filesWritten: ["tree.gedcomx.json"], validation }
+// on failure: { ok: false, errors: ["ops[<i>]: <msg>"] } — nothing written
+```
+
+Semantics (decision: `docs/plan/e2e-research-runtime-speedup-plan.md` §6 Q1):
+
+- **All-or-nothing.** Every op applies to one in-memory tree; the whole tree is
+  **validated once** and written **once** (one `.bak` reflecting pre-batch state). Any
+  op's precondition throw or the final validation failure writes **nothing**. (A
+  best-effort `standard_place` resolution miss does not throw — it leaves the field
+  unset and adds a warning; it never aborts the batch. See §7.)
+- **Per-op error indexing.** A failure on op *i* returns `ops[<i>]: <msg>`.
+- **Intra-batch id assignment.** `nextId` rescans the live tree per op, so consecutive
+  adds get consecutive `F`/`N`/`I`/`R`/`S` ids, and a later op may reference a person
+  added by an earlier op (e.g. `add_person` then `add_relationship` whose endpoint is
+  the predicted `I` id). Endpoint/reference integrity is enforced by the **single final
+  whole-tree validation**, not per-op, so an `add_person` + `add_relationship` pair in
+  one batch validates because the new person is present by validation time.
+- **Cross-tool ordering is unchanged.** `tree_edit` and `research_append` remain two
+  separate tools/calls; an `add_person` here assigns the `I` id that a later
+  `research_append` `person_evidence` op references, so the `tree_edit` batch must
+  commit before that `research_append` batch.
+
+The persisted tree shape is unchanged — `ops` changes only the number of write calls.
 
 ---
 

--- a/eval/harness/e2e/orchestrator.py
+++ b/eval/harness/e2e/orchestrator.py
@@ -419,6 +419,14 @@ async def _run_agent(
         # hook, not the allowlist, so it can deny per-call with arguments.
         allowed_tools=BASELINE_ALLOWED_TOOLS + ["mcp__genealogy"],
         permission_mode="dontAsk",
+        # Idea 3a (speedup plan §3a): eager-load the genealogy MCP tool schemas.
+        # The bundled CLI defers MCP tool schemas above a token threshold (the
+        # ~38-tool genealogy server trips it), forcing repeated ToolSearch
+        # re-discovery (17x in the spriggs run). Forcing tool search off loads
+        # them once at session start. `env` MERGES onto the inherited environment
+        # (claude_agent_sdk subprocess_cli merges os.environ, then options.env),
+        # so this adds the var without dropping ANTHROPIC_API_KEY/PATH.
+        env={"ENABLE_TOOL_SEARCH": "true"},
         model=fixture.agent_model,
         max_turns=fixture.caps.max_turns,
         hooks={

--- a/packages/engine/mcp-server/src/tools/research-append.ts
+++ b/packages/engine/mcp-server/src/tools/research-append.ts
@@ -82,7 +82,7 @@ function conflictInvariants(entry: any): string[] {
   return errs;
 }
 
-function planAppendInvariants(entry: any, research: any): string[] {
+function planActiveInvariants(entry: any, research: any): string[] {
   if (entry.status !== "active") return [];
   const conflicting = (research.plans ?? []).filter(
     (p: any) => p !== entry && p.question_id === entry.question_id && p.status === "active",
@@ -97,8 +97,8 @@ function planAppendInvariants(entry: any, research: any): string[] {
 
 export type ResearchAppendSection = keyof typeof SECTIONS | string;
 
-export interface ResearchAppendInput {
-  projectPath: string;
+/** One mutation. The body of a single call, or one element of a batch `ops`. */
+export interface ResearchAppendOp {
   section: ResearchAppendSection;
   op: "append" | "update";
   entry?: Record<string, unknown>; // op = append (no id — the tool assigns it)
@@ -107,18 +107,48 @@ export interface ResearchAppendInput {
   planId?: string; // required for section = "plan_items"
 }
 
-export type ResearchAppendResult =
-  | {
-      ok: true;
-      section: string;
-      op: "append" | "update";
-      entryId: string;
-      filesWritten: string[];
-      validation: { valid: true; warnings: string[] };
-    }
-  | { ok: false; errors: string[] };
+export interface ResearchAppendInput {
+  projectPath: string;
+  // Single-op form — supply section + op plus the relevant per-op fields:
+  section?: ResearchAppendSection;
+  op?: "append" | "update";
+  entry?: Record<string, unknown>;
+  entryId?: string;
+  fields?: Record<string, unknown>;
+  planId?: string;
+  // Batch form — supply ops; when present the single-op fields above are ignored.
+  // Every op applies to one in-memory document; the tool validates once and
+  // writes once (all-or-nothing). Ids assigned earlier in the batch are visible
+  // to later ops (the allocators scan the live document).
+  ops?: ResearchAppendOp[];
+}
 
-class ResearchAppendError extends Error {}
+interface SingleSuccess {
+  ok: true;
+  section: string;
+  op: "append" | "update";
+  entryId: string;
+  filesWritten: string[];
+  validation: { valid: true; warnings: string[] };
+}
+interface BatchSuccess {
+  ok: true;
+  results: { section: string; op: "append" | "update"; entryId: string }[];
+  filesWritten: string[];
+  validation: { valid: true; warnings: string[] };
+}
+export type ResearchAppendResult = SingleSuccess | BatchSuccess | { ok: false; errors: string[] };
+
+/** Carries one or more user-facing messages: the single form echoes them
+ *  verbatim; the batch form prefixes each with `ops[i]:`. */
+class ResearchAppendError extends Error {
+  errors: string[];
+  constructor(errors: string | string[]) {
+    const arr = Array.isArray(errors) ? errors : [errors];
+    super(arr.join("; "));
+    this.errors = arr;
+  }
+}
 
 function formatIssues(issues: ValidationError[]): string[] {
   return issues.map((e) => (e.path ? `${e.path}: ${e.message}` : e.message));
@@ -160,203 +190,260 @@ function now(): string {
   return new Date().toISOString();
 }
 
+interface AppliedOp {
+  section: string;
+  op: "append" | "update";
+  entryId: string;
+  /** A settled no-op (e.g. re-declaring an already-exhaustive question): the
+   *  document was not mutated, so the caller may skip the write. */
+  noop?: boolean;
+  warnings?: string[];
+}
+
+/** Apply ONE mutation to the in-memory research document. Mutates `research` in
+ *  place and returns a descriptor; throws ResearchAppendError on any precondition
+ *  failure so a batch aborts before anything is written. Does NOT validate or
+ *  persist — the caller validates the whole document once and writes once. */
+function applyOne(research: any, op: ResearchAppendOp): AppliedOp {
+  const section = op.section;
+  const config = SECTIONS[section];
+  if (!config) {
+    throw new ResearchAppendError(
+      `section '${section}' is not supported by research_append (supported: ${Object.keys(SECTIONS).join(", ")})`,
+    );
+  }
+
+  // Singleton sections (e.g. `project`) are a single object, not an array:
+  // `op:"update"` shallow-merges allowed fields in place — no id, no append.
+  if (config.singleton) {
+    if (op.op !== "update") {
+      throw new ResearchAppendError(`section '${section}' supports only op 'update' (it is one object, not a list)`);
+    }
+    if (!op.fields || typeof op.fields !== "object") {
+      throw new ResearchAppendError("update requires a `fields` object");
+    }
+    const target = research[section];
+    if (!target || typeof target !== "object" || Array.isArray(target)) {
+      throw new ResearchAppendError(`research.json '${section}' is missing or not an object`);
+    }
+    const allowed = new Set(config.singleton.allowedFields);
+    const rejected = Object.keys(op.fields).filter((k) => !allowed.has(k));
+    if (rejected.length > 0) {
+      throw new ResearchAppendError(
+        `field(s) not updatable on '${section}': ${rejected.join(", ")} ` +
+          `(allowed: ${config.singleton.allowedFields.join(", ")})`,
+      );
+    }
+    for (const [k, v] of Object.entries(op.fields)) target[k] = v;
+    const stamp = config.singleton.stampTimestamp;
+    if (stamp) target[stamp.field] = stamp.kind === "date" ? today() : now();
+    // a singleton has no entry id — echo the section name
+    return { section, op: "update", entryId: section };
+  }
+
+  // Resolve the target array and the pool to scan for the next id. Nested
+  // sections (plan_items) live under a parent entry (plans[planId].items),
+  // and their ids are unique across all parents.
+  let array: any[];
+  let idPool: any[];
+  if (config.nested) {
+    if (!op.planId) {
+      throw new ResearchAppendError(`section '${section}' requires a 'planId'`);
+    }
+    const parents = research[config.nested.parent];
+    const parent = Array.isArray(parents) ? parents.find((p) => p && p.id === op.planId) : undefined;
+    if (!parent) {
+      throw new ResearchAppendError(`${config.nested.parent} entry '${op.planId}' not found`);
+    }
+    if (!Array.isArray(parent[config.nested.field])) parent[config.nested.field] = [];
+    array = parent[config.nested.field];
+    idPool = (Array.isArray(parents) ? parents : []).flatMap((p: any) =>
+      Array.isArray(p?.[config.nested!.field]) ? p[config.nested!.field] : [],
+    );
+  } else {
+    // Initialize an absent optional section (e.g. known_holdings) on first write.
+    if (research[section] === undefined) research[section] = [];
+    if (!Array.isArray(research[section])) {
+      throw new ResearchAppendError(`research.json '${section}' is not an array`);
+    }
+    array = research[section];
+    idPool = array;
+  }
+
+  let entryId: string;
+  let resultEntry: any;
+
+  if (op.op === "append") {
+    const entry = op.entry;
+    if (!entry || typeof entry !== "object") {
+      throw new ResearchAppendError("append requires an `entry` object");
+    }
+    if (entry.id !== undefined && entry.id !== null) {
+      throw new ResearchAppendError("append `entry` must not carry an id — the tool assigns it");
+    }
+    entryId = nextResearchId(idPool, config.prefix);
+    // Strip any id key before assigning so the spread can never clobber it.
+    const rest: Record<string, unknown> = { ...entry };
+    delete rest.id;
+    const newEntry: Record<string, unknown> = { id: entryId, ...rest };
+    const stamp = config.stampTimestamp;
+    if (stamp && newEntry[stamp.field] === undefined) {
+      newEntry[stamp.field] = stamp.kind === "date" ? today() : now();
+    }
+    array.push(newEntry);
+    resultEntry = newEntry;
+  } else if (op.op === "update") {
+    if (!op.entryId) {
+      throw new ResearchAppendError("update requires an `entryId`");
+    }
+    if (!op.entryId.startsWith(config.prefix)) {
+      throw new ResearchAppendError(
+        `entryId '${op.entryId}' does not match section '${section}' (prefix ${config.prefix})`,
+      );
+    }
+    if (!op.fields || typeof op.fields !== "object") {
+      throw new ResearchAppendError("update requires a `fields` object");
+    }
+    if ("id" in op.fields && op.fields.id !== op.entryId) {
+      throw new ResearchAppendError("update `fields` must not change the entry id");
+    }
+    const existing = array.find((e) => e && e.id === op.entryId);
+    if (!existing) {
+      throw new ResearchAppendError(`entryId '${op.entryId}' not found in '${section}'`);
+    }
+
+    // Questions: re-declaring exhaustiveness on an already-declared question is
+    // a no-op — never overwrite a settled GPS Component-1 record. Only when the
+    // declaration is the SOLE field being set, so a bundled update that also
+    // changes other fields is not silently dropped.
+    if (section === "questions" && Object.keys(op.fields).length === 1) {
+      const newEd = op.fields.exhaustive_declaration as any;
+      if (existing.exhaustive_declaration?.declared === true && newEd?.declared === true) {
+        return {
+          section,
+          op: op.op,
+          entryId: op.entryId,
+          noop: true,
+          warnings: [`question '${op.entryId}' is already exhaustive_declared; no-op`],
+        };
+      }
+    }
+
+    for (const [k, v] of Object.entries(op.fields)) {
+      if (k === "id") continue;
+      existing[k] = v;
+    }
+    entryId = op.entryId;
+    resultEntry = existing;
+  } else {
+    throw new ResearchAppendError(`unknown op '${op.op}' (expected 'append' or 'update')`);
+  }
+
+  // Section invariants the project validator does not already enforce.
+  const invariantErrors: string[] = [];
+  if (section === "conflicts") invariantErrors.push(...conflictInvariants(resultEntry));
+  // One active plan per question — enforced on append OR an update that
+  // (re)sets status to "active"; the helper no-ops for non-active entries.
+  if (section === "plans") {
+    invariantErrors.push(...planActiveInvariants(resultEntry, research));
+  }
+  if (invariantErrors.length > 0) {
+    throw new ResearchAppendError(invariantErrors);
+  }
+
+  return { section, op: op.op, entryId };
+}
+
 export async function researchAppend(
   input: ResearchAppendInput,
 ): Promise<ResearchAppendResult> {
-  const { projectPath, section, op } = input;
+  const { projectPath } = input;
 
   try {
-    const config = SECTIONS[section];
-    if (!config) {
-      return {
-        ok: false,
-        errors: [
-          `section '${section}' is not supported by research_append (supported: ${Object.keys(SECTIONS).join(", ")})`,
-        ],
-      };
-    }
-
     const research = await readJson(projectPath, "research.json");
     const tree = await readJson(projectPath, "tree.gedcomx.json");
 
-    // Singleton sections (e.g. `project`) are a single object, not an array:
-    // `op:"update"` shallow-merges allowed fields in place — no id, no append.
-    if (config.singleton) {
-      if (op !== "update") {
-        return {
-          ok: false,
-          errors: [`section '${section}' supports only op 'update' (it is one object, not a list)`],
-        };
+    // ─── Batch form: apply every op in-memory, then validate + write once ─────
+    if (input.ops !== undefined) {
+      if (!Array.isArray(input.ops) || input.ops.length === 0) {
+        return { ok: false, errors: ["`ops` must be a non-empty array"] };
       }
-      if (!input.fields || typeof input.fields !== "object") {
-        return { ok: false, errors: ["update requires a `fields` object"] };
+      const applied: AppliedOp[] = [];
+      for (let i = 0; i < input.ops.length; i++) {
+        try {
+          applied.push(applyOne(research, input.ops[i]));
+        } catch (e) {
+          if (e instanceof ResearchAppendError) {
+            // Identify the failing op; nothing has been written.
+            return { ok: false, errors: e.errors.map((m) => `ops[${i}]: ${m}`) };
+          }
+          throw e;
+        }
       }
-      const target = research[section];
-      if (!target || typeof target !== "object" || Array.isArray(target)) {
-        return { ok: false, errors: [`research.json '${section}' is missing or not an object`] };
+      const opWarnings = applied.flatMap((a) => a.warnings ?? []);
+      const anyMutation = applied.some((a) => !a.noop);
+      let validationWarnings: string[] = [];
+      if (anyMutation) {
+        const validation = await validateParsed(research, tree, { projectPath });
+        if (!validation.valid) {
+          return { ok: false, errors: formatIssues(validation.errors) };
+        }
+        validationWarnings = formatIssues(validation.warnings);
+        await atomicWriteJson(join(projectPath, "research.json"), research);
       }
-      const allowed = new Set(config.singleton.allowedFields);
-      const rejected = Object.keys(input.fields).filter((k) => !allowed.has(k));
-      if (rejected.length > 0) {
-        return {
-          ok: false,
-          errors: [
-            `field(s) not updatable on '${section}': ${rejected.join(", ")} ` +
-              `(allowed: ${config.singleton.allowedFields.join(", ")})`,
-          ],
-        };
-      }
-      for (const [k, v] of Object.entries(input.fields)) target[k] = v;
-      const stamp = config.singleton.stampTimestamp;
-      if (stamp) target[stamp.field] = stamp.kind === "date" ? today() : now();
-
-      const validation = await validateParsed(research, tree, { projectPath });
-      if (!validation.valid) {
-        return { ok: false, errors: formatIssues(validation.errors) };
-      }
-      await atomicWriteJson(join(projectPath, "research.json"), research);
       return {
         ok: true,
-        section,
-        op: "update",
-        entryId: section, // a singleton has no entry id — echo the section name
-        filesWritten: ["research.json"],
-        validation: { valid: true, warnings: formatIssues(validation.warnings) },
+        results: applied.map((a) => ({ section: a.section, op: a.op, entryId: a.entryId })),
+        filesWritten: anyMutation ? ["research.json"] : [],
+        validation: { valid: true, warnings: [...validationWarnings, ...opWarnings] },
       };
     }
 
-    // Resolve the target array and the pool to scan for the next id. Nested
-    // sections (plan_items) live under a parent entry (plans[planId].items),
-    // and their ids are unique across all parents.
-    let array: any[];
-    let idPool: any[];
-    if (config.nested) {
-      if (!input.planId) {
-        return { ok: false, errors: [`section '${section}' requires a 'planId'`] };
-      }
-      const parents = research[config.nested.parent];
-      const parent = Array.isArray(parents)
-        ? parents.find((p) => p && p.id === input.planId)
-        : undefined;
-      if (!parent) {
-        return { ok: false, errors: [`${config.nested.parent} entry '${input.planId}' not found`] };
-      }
-      if (!Array.isArray(parent[config.nested.field])) parent[config.nested.field] = [];
-      array = parent[config.nested.field];
-      idPool = (Array.isArray(parents) ? parents : []).flatMap((p: any) =>
-        Array.isArray(p?.[config.nested!.field]) ? p[config.nested!.field] : [],
-      );
-    } else {
-      // Initialize an absent optional section (e.g. known_holdings) on first write.
-      if (research[section] === undefined) research[section] = [];
-      if (!Array.isArray(research[section])) {
-        return { ok: false, errors: [`research.json '${section}' is not an array`] };
-      }
-      array = research[section];
-      idPool = array;
+    // ─── Single-op form (behavior unchanged) ─────────────────────────────────
+    if (!input.section || !input.op) {
+      return { ok: false, errors: ["provide either `ops` (batch) or `section` + `op` (single)"] };
+    }
+    let applied: AppliedOp;
+    try {
+      applied = applyOne(research, {
+        section: input.section,
+        op: input.op,
+        entry: input.entry,
+        entryId: input.entryId,
+        fields: input.fields,
+        planId: input.planId,
+      });
+    } catch (e) {
+      if (e instanceof ResearchAppendError) return { ok: false, errors: e.errors };
+      throw e;
     }
 
-    let entryId: string;
-    let resultEntry: any;
-
-    if (op === "append") {
-      const entry = input.entry;
-      if (!entry || typeof entry !== "object") {
-        return { ok: false, errors: ["append requires an `entry` object"] };
-      }
-      if (entry.id !== undefined && entry.id !== null) {
-        return { ok: false, errors: ["append `entry` must not carry an id — the tool assigns it"] };
-      }
-      entryId = nextResearchId(idPool, config.prefix);
-      // Strip any id key before assigning so the spread can never clobber it.
-      const rest: Record<string, unknown> = { ...entry };
-      delete rest.id;
-      const newEntry: Record<string, unknown> = { id: entryId, ...rest };
-      const stamp = config.stampTimestamp;
-      if (stamp && newEntry[stamp.field] === undefined) {
-        newEntry[stamp.field] = stamp.kind === "date" ? today() : now();
-      }
-      array.push(newEntry);
-      resultEntry = newEntry;
-    } else if (op === "update") {
-      if (!input.entryId) {
-        return { ok: false, errors: ["update requires an `entryId`"] };
-      }
-      if (!input.entryId.startsWith(config.prefix)) {
-        return {
-          ok: false,
-          errors: [`entryId '${input.entryId}' does not match section '${section}' (prefix ${config.prefix})`],
-        };
-      }
-      if (!input.fields || typeof input.fields !== "object") {
-        return { ok: false, errors: ["update requires a `fields` object"] };
-      }
-      if ("id" in input.fields && input.fields.id !== input.entryId) {
-        return { ok: false, errors: ["update `fields` must not change the entry id"] };
-      }
-      const existing = array.find((e) => e && e.id === input.entryId);
-      if (!existing) {
-        return { ok: false, errors: [`entryId '${input.entryId}' not found in '${section}'`] };
-      }
-
-      // Questions: re-declaring exhaustiveness on an already-declared question is
-      // a no-op — never overwrite a settled GPS Component-1 record. Only when the
-      // declaration is the SOLE field being set, so a bundled update that also
-      // changes other fields is not silently dropped.
-      if (section === "questions" && Object.keys(input.fields).length === 1) {
-        const newEd = input.fields.exhaustive_declaration as any;
-        if (existing.exhaustive_declaration?.declared === true && newEd?.declared === true) {
-          return {
-            ok: true,
-            section,
-            op,
-            entryId: input.entryId,
-            filesWritten: [],
-            validation: {
-              valid: true,
-              warnings: [`question '${input.entryId}' is already exhaustive_declared; no-op`],
-            },
-          };
-        }
-      }
-
-      for (const [k, v] of Object.entries(input.fields)) {
-        if (k === "id") continue;
-        existing[k] = v;
-      }
-      entryId = input.entryId;
-      resultEntry = existing;
-    } else {
-      return { ok: false, errors: [`unknown op '${op}' (expected 'append' or 'update')`] };
-    }
-
-    // Section invariants the project validator does not already enforce.
-    const invariantErrors: string[] = [];
-    if (section === "conflicts") invariantErrors.push(...conflictInvariants(resultEntry));
-    if (section === "plans" && op === "append") {
-      invariantErrors.push(...planAppendInvariants(resultEntry, research));
-    }
-    if (invariantErrors.length > 0) {
-      return { ok: false, errors: invariantErrors };
+    if (applied.noop) {
+      return {
+        ok: true,
+        section: applied.section,
+        op: applied.op,
+        entryId: applied.entryId,
+        filesWritten: [],
+        validation: { valid: true, warnings: applied.warnings ?? [] },
+      };
     }
 
     const validation = await validateParsed(research, tree, { projectPath });
     if (!validation.valid) {
       return { ok: false, errors: formatIssues(validation.errors) };
     }
-
     await atomicWriteJson(join(projectPath, "research.json"), research);
-
     return {
       ok: true,
-      section,
-      op,
-      entryId,
+      section: applied.section,
+      op: applied.op,
+      entryId: applied.entryId,
       filesWritten: ["research.json"],
-      validation: { valid: true, warnings: formatIssues(validation.warnings) },
+      validation: { valid: true, warnings: [...formatIssues(validation.warnings), ...(applied.warnings ?? [])] },
     };
   } catch (e) {
-    if (e instanceof ResearchAppendError) return { ok: false, errors: [e.message] };
+    if (e instanceof ResearchAppendError) return { ok: false, errors: e.errors };
     throw e;
   }
 }
@@ -376,7 +463,17 @@ export const researchAppendSchema = {
     "assigns the next `<prefix>NNN`, stamps tool-owned timestamps, validates the " +
     "whole project, and writes research.json atomically. To revise a person_evidence " +
     "link, append the new entry then update the old one's `superseded_by`. Returns a " +
-    "compact summary; on a validation failure nothing is written.",
+    "compact summary; on a validation failure nothing is written.\n" +
+    "\n" +
+    "To persist many entries at once (e.g. a record's source + every assertion in one " +
+    "step), pass an `ops` array instead of the top-level section/op: each op is " +
+    "`{ section, op, entry?/entryId?/fields?, planId? }`. The tool applies all ops to " +
+    "one in-memory document, validates ONCE, and writes ONCE — all-or-nothing (on any " +
+    "op's failure nothing is written and the error is `ops[i]: <msg>`). Ids assigned by " +
+    "an earlier op are visible to later ops, so an assertion may reference a source " +
+    "appended earlier in the same batch by its predictable id (e.g. `src_001`); you may " +
+    "NOT update an id created earlier in the same batch. Returns `results: [{section, op, " +
+    "entryId}]`.",
   inputSchema: {
     type: "object" as const,
     properties: {
@@ -427,7 +524,44 @@ export const researchAppendSchema = {
         type: "string",
         description: "Required for section 'plan_items' — the pl_ id of the parent plan to write into.",
       },
+      ops: {
+        type: "array",
+        description:
+          "Batch form: apply many mutations in one validate-once/write-once call " +
+          "(all-or-nothing). When present, the top-level section/op/entry/entryId/" +
+          "fields/planId are ignored. Use this to persist a whole record at once.",
+        items: {
+          type: "object",
+          properties: {
+            section: {
+              type: "string",
+              enum: [
+                "sources",
+                "assertions",
+                "person_evidence",
+                "questions",
+                "plans",
+                "plan_items",
+                "conflicts",
+                "hypotheses",
+                "timelines",
+                "proof_summaries",
+                "evaluations",
+                "known_holdings",
+                "project",
+              ],
+              description: "The research.json section this op writes.",
+            },
+            op: { type: "string", enum: ["append", "update"], description: "append (tool assigns id) or update by id." },
+            entry: { type: "object", description: "append: the new entry in snake_case, WITHOUT an id." },
+            entryId: { type: "string", description: "update: the id of the existing entry to modify." },
+            fields: { type: "object", description: "update: fields to shallow-merge (the id is immutable)." },
+            planId: { type: "string", description: "Required when section is 'plan_items' — the parent pl_ id." },
+          },
+          required: ["section", "op"],
+        },
+      },
     },
-    required: ["projectPath", "section", "op"],
+    required: ["projectPath"],
   },
 };

--- a/packages/engine/mcp-server/src/tools/tree-edit.ts
+++ b/packages/engine/mcp-server/src/tools/tree-edit.ts
@@ -36,8 +36,8 @@ export type TreeEditOperation =
   | "update_source"
   | "remove";
 
-export interface TreeEditInput {
-  projectPath: string;
+/** One edit. The body of a single call, or one element of a batch `ops`. */
+export interface TreeEditOp {
   operation: TreeEditOperation;
   personId?: string;
   factId?: string;
@@ -55,6 +55,15 @@ export interface TreeEditInput {
   resolveStandardPlace?: boolean;
 }
 
+export interface TreeEditInput extends Partial<TreeEditOp> {
+  projectPath: string;
+  // Batch form — supply ops; when present the single-op fields above are ignored.
+  // Every op applies to one in-memory tree; the tool validates once and writes
+  // once (all-or-nothing). Ids assigned earlier in the batch are visible to
+  // later ops (the allocator rescans the live tree).
+  ops?: TreeEditOp[];
+}
+
 interface AssignedIds {
   person?: string;
   fact?: string;
@@ -69,6 +78,12 @@ export type TreeEditResult =
       ok: true;
       operation: TreeEditOperation;
       assignedIds?: AssignedIds;
+      filesWritten: string[];
+      validation: { valid: true; warnings: string[] };
+    }
+  | {
+      ok: true;
+      results: { operation: TreeEditOperation; assignedIds?: AssignedIds }[];
       filesWritten: string[];
       validation: { valid: true; warnings: string[] };
     }
@@ -285,11 +300,55 @@ async function applyOperation(
 }
 
 export async function treeEdit(input: TreeEditInput): Promise<TreeEditResult> {
-  const { projectPath, operation } = input;
+  const { projectPath } = input;
   try {
     const tree = (await readJson(projectPath, "tree.gedcomx.json")) as SimplifiedGedcomX;
     const research = await readJson(projectPath, "research.json");
 
+    const treePath = join(projectPath, "tree.gedcomx.json");
+
+    // ─── Batch form: apply every op in-memory, then validate + write once ─────
+    if (input.ops !== undefined) {
+      if (!Array.isArray(input.ops) || input.ops.length === 0) {
+        return { ok: false, errors: ["`ops` must be a non-empty array"] };
+      }
+      const results: { operation: TreeEditOperation; assignedIds?: AssignedIds }[] = [];
+      const opWarnings: string[] = [];
+      for (let i = 0; i < input.ops.length; i++) {
+        const op = input.ops[i];
+        try {
+          const { assignedIds, warnings } = await applyOperation(tree, { ...op, projectPath });
+          opWarnings.push(...warnings);
+          const r: { operation: TreeEditOperation; assignedIds?: AssignedIds } = { operation: op.operation };
+          if (Object.keys(assignedIds).length > 0) r.assignedIds = assignedIds;
+          results.push(r);
+        } catch (e) {
+          if (e instanceof TreeEditError) {
+            // Identify the failing op; nothing has been written.
+            return { ok: false, errors: [`ops[${i}]: ${e.message}`] };
+          }
+          throw e;
+        }
+      }
+
+      const validation = await validateParsed(research, tree, { projectPath });
+      if (!validation.valid) {
+        return { ok: false, errors: formatIssues(validation.errors) };
+      }
+      await backupIfExists(treePath);
+      await atomicWriteJson(treePath, tree);
+      return {
+        ok: true,
+        results,
+        filesWritten: ["tree.gedcomx.json"],
+        validation: { valid: true, warnings: [...formatIssues(validation.warnings), ...opWarnings] },
+      };
+    }
+
+    // ─── Single-op form (behavior unchanged) ─────────────────────────────────
+    if (!input.operation) {
+      return { ok: false, errors: ["provide either `ops` (batch) or `operation` (single)"] };
+    }
     const { assignedIds, warnings } = await applyOperation(tree, input);
 
     const validation = await validateParsed(research, tree, { projectPath });
@@ -297,13 +356,12 @@ export async function treeEdit(input: TreeEditInput): Promise<TreeEditResult> {
       return { ok: false, errors: formatIssues(validation.errors) };
     }
 
-    const treePath = join(projectPath, "tree.gedcomx.json");
     await backupIfExists(treePath);
     await atomicWriteJson(treePath, tree);
 
     const result: TreeEditResult = {
       ok: true,
-      operation,
+      operation: input.operation,
       filesWritten: ["tree.gedcomx.json"],
       validation: { valid: true, warnings: [...formatIssues(validation.warnings), ...warnings] },
     };
@@ -332,7 +390,14 @@ export const treeEditSchema = {
     "whole project, and writes only tree.gedcomx.json (with a one-deep .bak). " +
     "Returns a compact summary (the assigned ids); on a validation failure nothing " +
     "is written and `{ ok: false, errors }` is returned. Run check-warnings after " +
-    "for genealogical-plausibility checks.",
+    "for genealogical-plausibility checks.\n" +
+    "\n" +
+    "To make several edits at once (e.g. a source plus sibling stubs), pass an `ops` " +
+    "array instead of the top-level operation: each op is `{ operation, ...fields }` " +
+    "(the same per-op fields). The tool applies all ops to one in-memory tree, " +
+    "validates ONCE, and writes ONCE — all-or-nothing (on any op's failure nothing is " +
+    "written and the error is `ops[i]: <msg>`). Ids assigned by an earlier op are " +
+    "visible to later ops. Returns `results: [{operation, assignedIds}]`.",
   inputSchema: {
     type: "object" as const,
     properties: {
@@ -390,7 +455,49 @@ export const treeEditSchema = {
         type: "boolean",
         description: "Default true: auto-resolve standard_place when a fact place is set. Pass false to skip the lookup.",
       },
+      ops: {
+        type: "array",
+        description:
+          "Batch form: apply many edits in one validate-once/write-once call " +
+          "(all-or-nothing). When present, the top-level operation/fields are ignored. " +
+          "Each op is the same `{ operation, ...fields }` the single form takes.",
+        items: {
+          type: "object",
+          properties: {
+            operation: {
+              type: "string",
+              enum: [
+                "add_fact",
+                "update_fact",
+                "add_name",
+                "update_name",
+                "update_person",
+                "add_person",
+                "add_relationship",
+                "add_source",
+                "update_source",
+                "remove",
+              ],
+              description: "The edit to perform.",
+            },
+            personId: { type: "string" },
+            factId: { type: "string" },
+            nameId: { type: "string" },
+            relationshipId: { type: "string" },
+            sourceId: { type: "string" },
+            fact: { type: "object" },
+            name: { type: "object" },
+            person: { type: "object" },
+            relationship: { type: "object" },
+            source: { type: "object" },
+            gender: { type: "string" },
+            ark: { type: "string" },
+            resolveStandardPlace: { type: "boolean" },
+          },
+          required: ["operation"],
+        },
+      },
     },
-    required: ["projectPath", "operation"],
+    required: ["projectPath"],
   },
 };

--- a/packages/engine/mcp-server/src/validation/validator.ts
+++ b/packages/engine/mcp-server/src/validation/validator.ts
@@ -19,6 +19,7 @@ import {
 } from "./types.js";
 import { isInsideProject } from "../utils/project-io.js";
 import { iteratePersonIdRefs } from "./person-id-refs.js";
+import { arkToBareId } from "../utils/ark.js";
 
 // Enum definitions (single source of truth, matching Python validator)
 const CLOSED_ENUMS = {
@@ -1076,9 +1077,16 @@ async function validateSidecars(
     }
 
     const recordId = a.record_id;
+    // Match by CANONICAL FamilySearch-ARK form, not exact string: a resolver
+    // URL, a bare ARK (`ark:/61903/1:1:X`), a type-prefixed id (`1:1:X`), and a
+    // bare entity id (`X`) that denote the same record all reduce to the same
+    // key via arkToBareId. This is the tool's job — the skill copies whatever
+    // `recordId` it was handed and need not normalize the format. Non-ARK ids
+    // (e.g. `ancestry:...`) pass through unchanged, so they still match exactly.
+    const recordKey = arkToBareId(recordId);
     let record: any = null;
     for (const r of payload.results || []) {
-      if (typeof r === "object" && r !== null && r.recordId === recordId) {
+      if (typeof r === "object" && r !== null && arkToBareId(r.recordId) === recordKey) {
         record = r;
         break;
       }

--- a/packages/engine/mcp-server/tests/tools/research-append.test.ts
+++ b/packages/engine/mcp-server/tests/tools/research-append.test.ts
@@ -294,6 +294,24 @@ describe("research_append (Phase 2)", () => {
     expect(second.errors.join(" ")).toMatch(/already has an active plan/);
   });
 
+  it("rejects an update that flips a superseded plan back to active when one is already active", async () => {
+    const research = phase2Research();
+    research.plans = [validPlan("pl_001", "q_001", "active"), validPlan("pl_002", "q_001", "superseded")];
+    await writeProject(research);
+    const before = await readFile(join(dir, "research.json"), "utf-8");
+    const r = await researchAppend({
+      projectPath: dir,
+      section: "plans",
+      op: "update",
+      entryId: "pl_002",
+      fields: { status: "active" }, // would create a second active plan for q_001
+    });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.errors.join(" ")).toMatch(/already has an active plan/);
+    expect(await readFile(join(dir, "research.json"), "utf-8")).toBe(before);
+  });
+
   it("appends a plan_item into the named plan", async () => {
     const research = phase2Research();
     research.plans = [validPlan("pl_001", "q_001", "active")];
@@ -611,5 +629,183 @@ describe("research_append (project singleton section)", () => {
     expect(r.ok).toBe(false);
     if (r.ok) return;
     expect(r.errors.join(" ")).toMatch(/requires a .?fields/);
+  });
+});
+
+// ─── Batch ops ───────────────────────────────────────────────────────────────
+
+const noId = (o: any) => {
+  const { id: _omit, ...rest } = o;
+  return rest;
+};
+
+describe("research_append (batch ops)", () => {
+  let dir: string;
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "research-append-batch-"));
+  });
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+  async function writeProject(research: any = baseResearch(), tree: any = baseTree) {
+    await writeFile(join(dir, "research.json"), JSON.stringify(research, null, 2));
+    await writeFile(join(dir, "tree.gedcomx.json"), JSON.stringify(tree, null, 2));
+  }
+  const readResearch = async () => JSON.parse(await readFile(join(dir, "research.json"), "utf-8"));
+
+  it("(a/c) applies a homogeneous batch, returns ordered ids, sequences intra-batch", async () => {
+    await writeProject(); // seeded with sources [src_001]
+    const r = await researchAppend({
+      projectPath: dir,
+      ops: [
+        { section: "sources", op: "append", entry: noId(validSource("x")) },
+        { section: "sources", op: "append", entry: noId(validSource("y")) },
+      ],
+    });
+    expect(r.ok).toBe(true);
+    if (!r.ok || !("results" in r)) return;
+    expect(r.results.map((x) => x.entryId)).toEqual(["src_002", "src_003"]); // op #2 sees op #1's append
+    expect(r.filesWritten).toEqual(["research.json"]);
+    expect((await readResearch()).sources.map((s: any) => s.id)).toEqual(["src_001", "src_002", "src_003"]);
+  });
+
+  it("(d) applies a heterogeneous record in one write; assertion references a source from the same batch", async () => {
+    await writeProject();
+    const r = await researchAppend({
+      projectPath: dir,
+      ops: [
+        { section: "sources", op: "append", entry: noId(validSource("x")) }, // → src_002
+        { section: "assertions", op: "append", entry: noId(validAssertion("x", "src_002")) }, // forward ref to op #0
+        { section: "assertions", op: "append", entry: noId(validAssertion("y", "src_002")) },
+        {
+          section: "person_evidence",
+          op: "append",
+          entry: { assertion_id: "a_002", person_id: "I1", confidence: "confident", rationale: "match", superseded_by: null },
+        },
+      ],
+    });
+    expect(r.ok).toBe(true);
+    if (!r.ok || !("results" in r)) return;
+    expect(r.results.map((x) => `${x.section}:${x.entryId}`)).toEqual([
+      "sources:src_002",
+      "assertions:a_002",
+      "assertions:a_003",
+      "person_evidence:pe_001",
+    ]);
+    const research = await readResearch();
+    expect(research.sources).toHaveLength(2);
+    expect(research.assertions.map((a: any) => a.id)).toEqual(["a_001", "a_002", "a_003"]);
+    expect(research.assertions[1].source_id).toBe("src_002"); // intra-batch forward ref persisted + validated
+    expect(research.person_evidence).toHaveLength(1);
+  });
+
+  it("(d2) appends a plan + its items in one batch, referencing the predicted plan id pl_001", async () => {
+    const research = baseResearch();
+    research.questions = [validQuestion("q_001")];
+    await writeProject(research);
+    const r = await researchAppend({
+      projectPath: dir,
+      ops: [
+        { section: "plans", op: "append", entry: noId(validPlan("x", "q_001", "active")) }, // → pl_001
+        { section: "plan_items", op: "append", entry: validPlanItem(), planId: "pl_001" }, // → pli_001
+        { section: "plan_items", op: "append", entry: validPlanItem(), planId: "pl_001" }, // → pli_002
+      ],
+    });
+    expect(r.ok).toBe(true);
+    if (!r.ok || !("results" in r)) return;
+    expect(r.results.map((x) => x.entryId)).toEqual(["pl_001", "pli_001", "pli_002"]);
+    const out = await readResearch();
+    expect(out.plans[0].id).toBe("pl_001");
+    expect(out.plans[0].items.map((i: any) => i.id)).toEqual(["pli_001", "pli_002"]);
+  });
+
+  it("(b) rolls back the whole batch on a mid-batch validation failure — writes nothing", async () => {
+    await writeProject();
+    const before = await readFile(join(dir, "research.json"), "utf-8");
+    const r = await researchAppend({
+      projectPath: dir,
+      ops: [
+        { section: "sources", op: "append", entry: noId(validSource("x")) }, // valid on its own
+        { section: "assertions", op: "append", entry: noId(validAssertion("y", "src_999")) }, // dangling → whole-project validation fails
+      ],
+    });
+    expect(r.ok).toBe(false);
+    expect(await readFile(join(dir, "research.json"), "utf-8")).toBe(before); // including the valid op #0
+  });
+
+  it("(b2) indexes a per-op precondition failure as ops[i] and writes nothing", async () => {
+    await writeProject();
+    const before = await readFile(join(dir, "research.json"), "utf-8");
+    const r = await researchAppend({
+      projectPath: dir,
+      ops: [
+        { section: "sources", op: "append", entry: noId(validSource("x")) }, // op 0 ok
+        { section: "assertions", op: "append", entry: validAssertion("z", "src_001") }, // op 1 carries an id → throws
+      ],
+    });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.errors[0]).toMatch(/^ops\[1\]:/);
+    expect(r.errors.join(" ")).toMatch(/must not carry an id/);
+    expect(await readFile(join(dir, "research.json"), "utf-8")).toBe(before);
+  });
+
+  it("(b3) enforces section invariants across the batch (second active plan → ops[1])", async () => {
+    const research = baseResearch();
+    research.questions = [validQuestion("q_001")];
+    await writeProject(research);
+    const before = await readFile(join(dir, "research.json"), "utf-8");
+    const r = await researchAppend({
+      projectPath: dir,
+      ops: [
+        { section: "plans", op: "append", entry: noId(validPlan("x", "q_001", "active")) },
+        { section: "plans", op: "append", entry: noId(validPlan("y", "q_001", "active")) }, // same question, second active plan
+      ],
+    });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.errors[0]).toMatch(/^ops\[1\]:.*already has an active plan/);
+    expect(await readFile(join(dir, "research.json"), "utf-8")).toBe(before);
+  });
+
+  it("rejects an empty ops array", async () => {
+    await writeProject();
+    const r = await researchAppend({ projectPath: dir, ops: [] });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.errors.join(" ")).toMatch(/non-empty/);
+  });
+
+  it("(d3) applies a project-singleton update inside a batch and writes once", async () => {
+    await writeProject();
+    const r = await researchAppend({
+      projectPath: dir,
+      ops: [
+        { section: "sources", op: "append", entry: noId(validSource("x")) },
+        { section: "project", op: "update", fields: { status: "completed" } },
+      ],
+    });
+    expect(r.ok).toBe(true);
+    if (!r.ok || !("results" in r)) return;
+    expect(r.results).toContainEqual({ section: "project", op: "update", entryId: "project" });
+    expect(r.filesWritten).toEqual(["research.json"]);
+    const research = await readResearch();
+    expect(research.project.status).toBe("completed");
+    expect(research.project.updated).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    expect(research.sources).toHaveLength(2);
+  });
+
+  it("(d3b) fails the whole batch on an invalid project status — writes nothing", async () => {
+    await writeProject();
+    const before = await readFile(join(dir, "research.json"), "utf-8");
+    const r = await researchAppend({
+      projectPath: dir,
+      ops: [
+        { section: "sources", op: "append", entry: noId(validSource("x")) }, // valid op #0
+        { section: "project", op: "update", fields: { status: "done" } }, // invalid enum → whole batch fails
+      ],
+    });
+    expect(r.ok).toBe(false);
+    expect(await readFile(join(dir, "research.json"), "utf-8")).toBe(before);
   });
 });

--- a/packages/engine/mcp-server/tests/tools/tree-edit.test.ts
+++ b/packages/engine/mcp-server/tests/tools/tree-edit.test.ts
@@ -328,3 +328,113 @@ describe("tree_edit", () => {
     expect(await exists("tree.gedcomx.json.bak")).toBe(false);
   });
 });
+
+describe("tree_edit (batch ops)", () => {
+  let dir: string;
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "tree-edit-batch-"));
+  });
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+  async function writeProject(tree: any, research: any = minimalResearch) {
+    await writeFile(join(dir, "research.json"), JSON.stringify(research, null, 2));
+    await writeFile(join(dir, "tree.gedcomx.json"), JSON.stringify(tree, null, 2));
+  }
+  const readTree = async () => JSON.parse(await readFile(join(dir, "tree.gedcomx.json"), "utf-8"));
+  const exists = async (rel: string) => access(join(dir, rel)).then(() => true, () => false);
+  const onePerson = () => ({
+    persons: [
+      {
+        id: "I1",
+        gender: "Male",
+        names: [{ id: "N1", given: "John", surname: "Smith", preferred: true }],
+        facts: [{ id: "F1", type: "Birth", date: "1850", primary: true }],
+      },
+    ],
+    relationships: [],
+    sources: [],
+  });
+
+  it("(a/c) applies a heterogeneous batch (source + person + fact) in one write, sequencing ids, one .bak", async () => {
+    await writeProject(onePerson());
+    const r = await treeEdit({
+      projectPath: dir,
+      ops: [
+        { operation: "add_source", source: { title: "1850 Census" } }, // → S1
+        { operation: "add_person", person: { gender: "Female", names: [{ given: "Mary", surname: "Smith" }] } }, // → I2
+        { operation: "add_fact", personId: "I1", fact: { type: "Death", date: "1899" } }, // → F2 on existing person
+      ],
+    });
+    expect(r.ok).toBe(true);
+    if (!r.ok || !("results" in r)) return;
+    expect(r.results.map((x) => x.operation)).toEqual(["add_source", "add_person", "add_fact"]);
+    expect(r.results[0].assignedIds?.source).toBe("S1");
+    expect(r.results[1].assignedIds?.person).toBe("I2");
+    expect(r.results[2].assignedIds?.fact).toBe("F2");
+    expect(r.filesWritten).toEqual(["tree.gedcomx.json"]);
+    expect(await exists("tree.gedcomx.json.bak")).toBe(true);
+    const tree = await readTree();
+    expect(tree.sources.map((s: any) => s.id)).toEqual(["S1"]);
+    expect(tree.persons.map((p: any) => p.id)).toEqual(["I1", "I2"]);
+  });
+
+  it("intra-batch cross-op: add_person then add_relationship referencing the predicted I id validates", async () => {
+    await writeProject(onePerson());
+    const r = await treeEdit({
+      projectPath: dir,
+      ops: [
+        { operation: "add_person", person: { gender: "Female", names: [{ given: "Mary", surname: "Smith" }] } }, // → I2 (max I is I1)
+        { operation: "add_relationship", relationship: { type: "Couple", person1: "I1", person2: "I2" } }, // references op #0's I2
+      ],
+    });
+    expect(r.ok).toBe(true);
+    if (!r.ok || !("results" in r)) return;
+    expect(r.results[0].assignedIds?.person).toBe("I2");
+    expect(r.results[1].assignedIds?.relationship).toBe("R1");
+    expect((await readTree()).relationships[0]).toMatchObject({ id: "R1", person1: "I1", person2: "I2" });
+  });
+
+  it("(b) rolls back the whole batch on a validation failure — nothing written, no .bak", async () => {
+    await writeProject(onePerson());
+    const before = await readFile(join(dir, "tree.gedcomx.json"), "utf-8");
+    const r = await treeEdit({
+      projectPath: dir,
+      ops: [
+        { operation: "add_source", source: { title: "Valid source" } }, // ok alone
+        { operation: "add_relationship", relationship: { type: "ParentChild", parent: "I1", child: "I_GHOST" } }, // dangling → validation fails
+      ],
+    });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.errors.join(" ")).toMatch(/I_GHOST/);
+    expect(await readFile(join(dir, "tree.gedcomx.json"), "utf-8")).toBe(before); // including the valid source op
+    expect(await exists("tree.gedcomx.json.bak")).toBe(false);
+  });
+
+  it("indexes a per-op precondition failure as ops[i] and writes nothing", async () => {
+    await writeProject(onePerson());
+    const before = await readFile(join(dir, "tree.gedcomx.json"), "utf-8");
+    const r = await treeEdit({
+      projectPath: dir,
+      ops: [
+        { operation: "add_source", source: { title: "ok" } }, // op 0 ok
+        { operation: "add_person", person: { id: "I9", gender: "Male", names: [{ given: "X", surname: "Y" }] } as any }, // op 1 carries id → throws
+      ],
+    });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.errors[0]).toMatch(/^ops\[1\]:/);
+    expect(r.errors.join(" ")).toMatch(/must not carry an id/);
+    expect(await readFile(join(dir, "tree.gedcomx.json"), "utf-8")).toBe(before);
+    expect(await exists("tree.gedcomx.json.bak")).toBe(false);
+  });
+
+  it("rejects an empty ops array", async () => {
+    await writeProject(onePerson());
+    const r = await treeEdit({ projectPath: dir, ops: [] });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.errors.join(" ")).toMatch(/non-empty/);
+  });
+});

--- a/packages/engine/mcp-server/tests/validation/validator.test.ts
+++ b/packages/engine/mcp-server/tests/validation/validator.test.ts
@@ -722,6 +722,75 @@ describe("Project Validator", () => {
         )
       ).toBe(true);
     });
+
+    it("D5: matches record_id to recordId by canonical ARK form, not exact string", async () => {
+      const research = {
+        ...minimalResearch,
+        log: [
+          { id: "log_001", plan_item_id: null, performed: "2026-01-01T00:00:00Z", tool: "record_search", query: {}, outcome: "positive", results_examined: 1, results_ref: "results/log_001.json", external_site: null },
+        ],
+        sources: [
+          { id: "src_001", gedcomx_source_description_id: "SD-001", citation: "Test", citation_detail: { who: "Test", what: "Test", when_created: "2020", when_accessed: "2026-01-01", where: "Test", where_within: "Test" }, source_classification: "original", repository: "Test", access_date: "2026-01-01" },
+        ],
+        assertions: [
+          {
+            id: "a_001",
+            source_id: "src_001",
+            // Full resolver URL; the sidecar stores the bare ARK — they match by canonical form.
+            record_id: "https://www.familysearch.org/ark:/61903/1:1:MXHY-TP4",
+            record_role: "principal",
+            record_persona_id: "PERSON1",
+            fact_type: "birth",
+            value: "1850",
+            information_quality: "primary",
+            informant: "self",
+            informant_proximity: "self",
+            evidence_type: "direct",
+            extracted_for_question_ids: [],
+            log_entry_id: "log_001",
+          },
+        ],
+      };
+      const sidecar = {
+        log_id: "log_001", tool: "record_search", retrieved: "2026-01-01T00:00:00Z", returned_count: 1,
+        payload: { results: [{ recordId: "ark:/61903/1:1:MXHY-TP4", gedcomx: { persons: [{ id: "PERSON1" }] } }] },
+      };
+      const tree = { ...minimalTree, sources: [{ id: "SD-001", title: "Test" }] };
+      await writeProject(research, tree);
+      await mkdir(join(testDir, "results"));
+      await writeFile(join(testDir, "results/log_001.json"), JSON.stringify(sidecar));
+
+      const result = await validateProject(testDir);
+      // URL record_id matched bare-ARK recordId by canonical form, persona resolved → no D5 errors.
+      expect(result.errors.some((e) => e.message.includes("does not match any result's recordId"))).toBe(false);
+      expect(result.errors.some((e) => e.message.includes("does not resolve to a person in record"))).toBe(false);
+    });
+
+    it("D5: a record_id for a different entity still fails to match (canonical, not wildcard)", async () => {
+      const research = {
+        ...minimalResearch,
+        log: [
+          { id: "log_001", plan_item_id: null, performed: "2026-01-01T00:00:00Z", tool: "record_search", query: {}, outcome: "positive", results_examined: 1, results_ref: "results/log_001.json", external_site: null },
+        ],
+        sources: [
+          { id: "src_001", gedcomx_source_description_id: "SD-001", citation: "Test", citation_detail: { who: "Test", what: "Test", when_created: "2020", when_accessed: "2026-01-01", where: "Test", where_within: "Test" }, source_classification: "original", repository: "Test", access_date: "2026-01-01" },
+        ],
+        assertions: [
+          { id: "a_001", source_id: "src_001", record_id: "ark:/61903/1:1:DIFFERENT", record_role: "principal", record_persona_id: "PERSON1", fact_type: "birth", value: "1850", information_quality: "primary", informant: "self", informant_proximity: "self", evidence_type: "direct", extracted_for_question_ids: [], log_entry_id: "log_001" },
+        ],
+      };
+      const sidecar = {
+        log_id: "log_001", tool: "record_search", retrieved: "2026-01-01T00:00:00Z", returned_count: 1,
+        payload: { results: [{ recordId: "ark:/61903/1:1:MXHY-TP4", gedcomx: { persons: [{ id: "PERSON1" }] } }] },
+      };
+      const tree = { ...minimalTree, sources: [{ id: "SD-001", title: "Test" }] };
+      await writeProject(research, tree);
+      await mkdir(join(testDir, "results"));
+      await writeFile(join(testDir, "results/log_001.json"), JSON.stringify(sidecar));
+
+      const result = await validateProject(testDir);
+      expect(result.errors.some((e) => e.message.includes("does not match any result's recordId"))).toBe(true);
+    });
   });
 
   describe("Evaluations", () => {

--- a/packages/engine/plugin/skills/assertion-classification/SKILL.md
+++ b/packages/engine/plugin/skills/assertion-classification/SKILL.md
@@ -207,25 +207,34 @@ assertion, write the correction. Steps 6-7 run whenever any
 classification field changed during analysis, not only when the user
 said "fix it."
 
-Write the refined classifications back to `research.json` with one
-`research_append` call per assertion, using `op: "update"` (never
-`append` — this skill only refines existing assertions, it never
-creates them):
+Write the refined classifications back to `research.json` in ONE
+batched `research_append` call — pass an `ops` array with one `update`
+op per assertion (never `append` — this skill only refines existing
+assertions, it never creates them). Each assertion is still its own op;
+batching changes only the number of *calls*, not the data. The whole
+batch validates once and writes once; on any per-op failure it returns
+`{ ok: false, errors: ["ops[i]: <msg>"] }` and writes NOTHING — surface
+the errors and fix the offending op:
 
 ```
 research_append({
   projectPath: "<absolute-path-to-project-directory>",
-  section: "assertions",
-  op: "update",
-  entryId: "<assertion id, e.g. a_012>",
-  fields: {
-    information_quality: "...",   // primary | secondary | indeterminate (closed set)
-    informant: "...",             // if the analysis identifies a more specific informant
-    informant_proximity: "...",   // self | witness | household_member | family_not_present | official_duty | unknown (closed set)
-    informant_bias_notes: "...",  // add bias analysis if relevant
-    evidence_type: "...",         // direct | indirect | negative (closed set — there is no no_evidence)
-    extracted_for_question_ids: [ ... ]  // add any newly relevant question IDs
-  }
+  ops: [
+    {
+      section: "assertions",
+      op: "update",
+      entryId: "<assertion id, e.g. a_012>",
+      fields: {
+        information_quality: "...",   // primary | secondary | indeterminate (closed set)
+        informant: "...",             // if the analysis identifies a more specific informant
+        informant_proximity: "...",   // self | witness | household_member | family_not_present | official_duty | unknown (closed set)
+        informant_bias_notes: "...",  // add bias analysis if relevant
+        evidence_type: "...",         // direct | indirect | negative (closed set — there is no no_evidence)
+        extracted_for_question_ids: [ ... ]  // add any newly relevant question IDs
+      }
+    }
+    /* …one update op per assertion whose classification changed… */
+  ]
 })
 ```
 
@@ -239,9 +248,9 @@ pass classification fields; the immutable fields (`id`, `source_id`,
 `record_id`, `record_role`, `fact_type`, `value`, `structured_value`,
 `date`, `date_certainty`, `place`, `log_entry_id` — all set by
 record-extraction) are not yours to pass and the tool will not let you
-mutate them. The tool validates each update before persisting and writes
-nothing on `{ ok: false, errors }`; surface those errors to the user
-rather than retrying blindly.
+mutate them. The tool validates every op in the batch before persisting
+and writes nothing on `{ ok: false, errors }`; surface those errors to
+the user rather than retrying blindly.
 
 ### 7. Check warnings
 

--- a/packages/engine/plugin/skills/person-evidence/SKILL.md
+++ b/packages/engine/plugin/skills/person-evidence/SKILL.md
@@ -156,8 +156,14 @@ the same response.
 
 ### 1. Identify unlinked assertions
 
-Read `research.json` and find assertions that have no corresponding
-`person_evidence` entry (or whose existing links need revision).
+Find the assertions that have no corresponding `person_evidence` entry
+(or whose existing links need revision). If record-extraction just ran
+in this same continuous run and you already hold the new `a_` ids and the
+current `person_evidence` set in context, work from that — don't re-read
+`research.json` "to be safe"; the writer tools validate the whole project
+on every write, so the in-context view can't be silently stale. Re-read
+`research.json` when you're entering this skill cold, or when a sub-skill
+or the user changed assertions/links since you last saw them.
 
 An assertion is "unlinked" if no `pe_` entry references its `a_` ID.
 Group unlinked assertions by `record_id` + `record_role` — all
@@ -276,25 +282,34 @@ reach and tree-edit to execute.
 
 ### 4. Create person_evidence entries
 
-For each assertion → person link, call `research_append` with
-`op: "append"`. Supply the entry WITHOUT an `id`, `created`, or
-`superseded_by` — the tool assigns the next `pe_` id, stamps `created`,
-validates before persisting, and writes nothing on
-`{ ok: false, errors }`. Surface those errors to the user rather than
-retrying blindly.
+Persist all assertion → person links in ONE batched `research_append`
+call — pass an `ops` array with one `append` op per assertion-person
+pair. Each link is still its own op; batching changes only the number
+of *calls*, never the number of links (one `pe_` entry per pair, as
+before). Supply each entry WITHOUT an `id`, `created`, or
+`superseded_by` — the tool assigns each `pe_` id, stamps `created`,
+validates the whole batch once, and writes once. On any per-op failure
+it returns `{ ok: false, errors: ["ops[i]: <msg>"] }` and writes
+NOTHING — surface those errors to the user and fix the offending op
+rather than retrying blindly.
 
 ```
 research_append({
   projectPath: "<absolute-path-to-project-directory>",
-  section: "person_evidence",
-  op: "append",
-  entry: {
-    assertion_id: "a_015",
-    person_id: "KWCJ-RN4",
-    confidence: "probable",
-    rationale: "Thomas Flynn, will dated 1881, Schuylkill County. Names match. Location matches (same county as census records). Death date consistent with disappearance from tax records after 1880. Will names 'my son Patrick' — this assertion links the testator role to the Thomas Flynn (I2) in the tree.",
-    match_score: 0.64
-  }
+  ops: [
+    {
+      section: "person_evidence",
+      op: "append",
+      entry: {
+        assertion_id: "a_015",
+        person_id: "KWCJ-RN4",
+        confidence: "probable",
+        rationale: "Thomas Flynn, will dated 1881, Schuylkill County. Names match. Location matches (same county as census records). Death date consistent with disappearance from tax records after 1880. Will names 'my son Patrick' — this assertion links the testator role to the Thomas Flynn (I2) in the tree.",
+        match_score: 0.64
+      }
+    }
+    /* …one op per assertion-person pair… */
+  ]
 })
 ```
 

--- a/packages/engine/plugin/skills/question-selection/SKILL.md
+++ b/packages/engine/plugin/skills/question-selection/SKILL.md
@@ -33,8 +33,15 @@ question.
 
 ## 1. Read project state
 
-Read all sections of `research.json` and persons in
-`tree.gedcomx.json`. Identify:
+You need the current project state to select a question. If you already
+hold the relevant sections in context from the same continuous run
+(e.g. the orchestrator just routed here after a write whose compact
+return you have), trust that and don't re-read to be safe — the writer
+tools validate the whole project on every write, so an in-context view
+can't be silently stale. Re-read `research.json` (and persons in
+`tree.gedcomx.json`) when you're entering this phase cold, or when a
+sub-skill or the user changed the file in a way you don't already have.
+Either way, identify:
 
 - **Objective:** The overarching research goal. Every question must
   trace back to it.

--- a/packages/engine/plugin/skills/record-extraction/SKILL.md
+++ b/packages/engine/plugin/skills/record-extraction/SKILL.md
@@ -247,17 +247,17 @@ non-null `place` should carry a `standard_place` when one can be found.
 
 **Critical rules for each field:**
 
-**`record_id`** — Use the record's canonical identifier.
-**Get this right on the first write — validation failures for format
-mismatches cost turns and lower quality scores.**
-- FamilySearch `record_search` results: use the result's `arkUrl`
-  copied **verbatim** — the full URL form
-  (`https://www.familysearch.org/ark:/61903/1:1:MXYZ`).
-  person-evidence joins an assertion to its record by exact string match
-  on this value. Do not trim to the bare ARK — use the full URL.
-- FamilySearch `record_read` results: use the full URL form from the
-  response's `sources[].url` or construct it from the persona ark:
-  `https://www.familysearch.org/` + the `ark` value.
+**`record_id`** — Use the record's identifier from the search result
+(don't construct your own).
+- FamilySearch `record_search` results: use the result's **`recordId`**
+  field — the value search-records hands off to you. The validator matches
+  it to the record by **canonical ARK form**, so the exact format is the
+  tool's job, not yours: a bare ARK (`ark:/61903/1:1:MXYZ`), a bare id, or
+  a resolver URL for the same record all match. Pass through whatever
+  `recordId` you were given; you don't need to reformat it. (A full
+  resolver URL still belongs in the **source's** `url` field, step 1.)
+- FamilySearch `record_read` results: use the response's `recordId` field
+  the same way.
 - Ancestry: `ancestry:<collection_id>:<record_id>`
 - PDF captures: a descriptive ID (e.g., `capture:ancestry-1850-census-flynn`)
 - User-provided records with no ARK: use a descriptive capture ID
@@ -438,55 +438,83 @@ before it writes and writes nothing on `{ ok: false, errors }`, so
 there is no separate validate-and-fix pass — surface any errors and
 correct the offending entry.
 
-**5a. Append the source** with `research_append` (the tool assigns the
-`src_` id; stamp the source's `log_entry_id` with the `logId` from step
-4's `research_log_append`, when applicable):
+**5a/5b. Append the source and every assertion in ONE batched
+`research_append` call.** Pass an `ops` array: op #1 appends the source,
+then one `append` op per assertion (including each negative assertion).
+The whole batch validates once and writes once — on any per-op failure
+the call returns `{ ok: false, errors: ["ops[i]: <msg>"] }` and writes
+NOTHING, so surface the errors and correct the offending op rather than
+retrying blindly. The tool assigns each id (`src_` for the source, `a_`
+for each assertion), so there is no first-persona / Edit-append chunking
+— just enumerate every fact as its own op:
 
 ```
 research_append({
   projectPath: "<absolute project dir>",
-  section: "sources",
-  op: "append",
-  entry: { /* the source fields from step 1, WITHOUT an id */ }
+  ops: [
+    { section: "sources",    op: "append", entry: { /* the source fields from step 1, WITHOUT an id */ } },
+    { section: "assertions", op: "append", entry: { /* assertion #1 from step 3, WITHOUT an id */ } },
+    { section: "assertions", op: "append", entry: { /* assertion #2 … */ } }
+    /* …one op per assertion, including each negative assertion… */
+  ]
 })
 ```
 
-If a source for this record already exists, refine it instead:
-`research_append({ section: "sources", op: "update", entryId: "<src_>",
-fields: { /* changed fields */ } })`.
+**Intra-batch id prediction.** The source is op #1, so its assigned id
+is predictable — but it is **(highest existing `src_` in `research.json`)
++ 1**, zero-padded to 3, *not* always `src_001`. Read `research.json`'s
+`sources[]` and compute it: with `src_001`…`src_009` already present, this
+source is `src_010`. **Do NOT assume `src_001`** — that is only correct for
+the very first source in a fresh project; assuming it would point every
+assertion at a *different record's* source. Stamp each later assertion op's
+`source_id` with that computed `src_` id, and stamp each assertion's
+`log_entry_id` with step 4's `logId`. (An op may *reference* an id an
+earlier op in the same batch created, but it may not `update` one — append
+assigns the id internally.)
 
-**5b. Append each assertion** with `research_append` — one call per
-assertion (including each negative assertion). The tool assigns each
-`a_` id and validates each entry, so there is no first-persona /
-Edit-append chunking: just loop, one append per fact:
+If a source for this record already exists, refine it instead with an
+`update` op in the same batch: `{ section: "sources", op: "update",
+entryId: "<src_>", fields: { /* changed fields */ } }`, and stamp the
+assertions with that existing `src_` id rather than a predicted one.
+
+Every persona gets fully expanded individual `a_` ops — one op per
+assertion, never a range op, never compressed into ranges. Batching
+changes only the number of *calls*; every assertion is still its own op
+in the array.
+
+**5c/5d. Write the tree side in ONE batched `tree_edit` call** — the
+source `S` entry plus any sibling person stubs and their ParentChild
+edges. `tree_edit` is a SEPARATE tool from `research_append`; its ops
+cannot be merged into the `research_append` batch above. Pass a single
+`ops` array: op #1 is the `add_source`, followed by the `add_person`
+and `add_relationship` ops for any in-scope siblings (5d below). The
+whole batch validates once and writes the tree once (with a one-deep
+`.bak`) — on any per-op failure it returns `{ ok: false, errors:
+["ops[i]: <msg>"] }` and writes NOTHING. The tool assigns every id (the
+next `S` for the source, the next `I`/`N` for each person/name); do
+**not** hand-edit the file, allocate ids, or call
+`validate_research_schema` for it.
 
 ```
-research_append({
+tree_edit({
   projectPath: "<absolute project dir>",
-  section: "assertions",
-  op: "append",
-  entry: { /* the assertion fields from step 3, WITHOUT an id */ }
+  ops: [
+    { operation: "add_source", source: { /* title + optional author/url, NO id */ } }
+    /* …then one add_person op per in-scope sibling from 5d (the
+       add_relationship edges go in a SECOND tree_edit batch — see 5d)… */
+  ]
 })
 ```
 
-Every persona gets fully expanded individual `a_` entries — never
-compress into ranges. Stamp each assertion's `source_id` with the
-`src_` id step 5a returned and its `log_entry_id` with step 4's `logId`.
+For the `add_source` op, pass `title` (required) plus the optional
+`author`/`url`; omit any field that doesn't apply — never set it to
+`null`, and never pass an `id`. To correct an existing `S` entry's title
+or citation later, use a `{ operation: "update_source", sourceId,
+source }` op.
 
-**5c. Add the source `S` entry to `tree.gedcomx.json`** — for each new
-source, call `tree_edit({ operation: "add_source", source: {…} })`. The
-tool assigns the next `S` id, validates the whole project, and writes the
-tree (with a one-deep `.bak`) on success — returning `{ ok: false,
-errors }` and writing nothing on a problem. Do **not** hand-edit the
-file, allocate the `S` id, or call `validate_research_schema` for it.
-Pass `title` (required) plus the optional `author`/`url`; omit any field
-that doesn't apply — never set it to `null`, and never pass an `id` (the
-tool assigns it). To correct an existing `S` entry's title or citation
-later, use `tree_edit({ operation: "update_source", sourceId, source })`.
-
-Before appending, double-check the fields the validator is strict about,
-so each `research_append` passes on the first call:
-- `record_id` uses the correct format (full URL for FamilySearch, not bare ARK)
+Before writing, double-check the fields the validator is strict about,
+so the `research_append` batch passes on the first call:
+- `record_id` is the result's `recordId` (any ARK / URL / bare-id form — the validator matches by canonical ARK form, so just pass it through). The full resolver URL goes in the source's `url` field
 - `record_persona_id` is set (non-null) for `record_search` sources
 - All required assertion fields are present (informant, informant_proximity, evidence_type)
 - The `add_source` payload carries `title` (required) and only the optional `author`/`url`/`citation` — no `id`, no `null` values
@@ -495,7 +523,12 @@ so each `research_append` passes on the first call:
 record.** When the subject's `record_role` is `child_N` (i.e., the subject
 appears as a child in a household record such as a census), also create
 minimal person stubs in `tree.gedcomx.json` for the subject's siblings
-on this record (the household's other `child_N` roles). This is the
+on this record (the household's other `child_N` roles). The
+`add_person` ops go in the SAME `tree_edit` batch as the 5c
+`add_source` (one op per sibling); the `add_relationship` edges (one per
+sibling × in-tree parent) follow in a SECOND `tree_edit` batch, because
+each edge references the `I` id the tool assigns to its sibling — see
+the write loop below. This is the
 upstream half of the warnings-architecture chain Dallan called for: with
 siblings persisted as persons, `buildParentMob` discovers them as
 co-children, `relativesChildBirthRange40` and `person-evidence` can
@@ -550,16 +583,23 @@ whether to write any stub:
    to confirm the skip from the enumeration, not from a bare claim.
 
 **For each in-scope sibling (i.e., not already present in the tree),
-write the stub and the edges:**
+write the stub and the edges.** A sibling's ParentChild edge references
+the `I` id the tool assigns to that sibling. The tool *does* let a later
+op reference an id an earlier op created in the same batch (the `I`
+allocator is `max+1`, like `src_`/`a_`), so add_person + add_relationship
+in one batch is supported. But tree `I` ids are easier to mis-predict than
+research ids — a tree mixes synthesized `I<n>` ids with FamilySearch person
+ids — so prefer the robust pattern here: read each sibling's assigned `I`
+id back from the stub batch's `results[].assignedIds`, then reference it in
+a second `tree_edit` batch. Split this across two `tree_edit` calls:
 
-1. **Person stub** — `tree_edit({ operation: "add_person", person: {…} })`.
-   The tool assigns the next `I` id and the `N` ids for names; do not
-   set `id`. Shape:
+1. **Person stubs — in the SAME batch as the 5c `add_source`.** Add one
+   `add_person` op per in-scope sibling to that first `tree_edit` ops
+   array. The tool assigns each sibling's `I` id and the `N` ids for
+   names; do not set `id`. Each op's shape:
 
    ```
-   tree_edit({
-     projectPath: "<absolute project dir>",
-     operation: "add_person",
+   { operation: "add_person",
      person: {
        gender: "Male" | "Female",
        names: [
@@ -570,35 +610,38 @@ write the stub and the edges:**
            type: "BirthName"
          }
        ]
-     }
-   })
+     } }
    ```
 
    No facts on the stub — the sibling's facts (birth, residence, etc.)
    stay on the per-sibling assertions in `research.json` from step 5b.
    Detailed sibling facts land later via record-extraction passes on
    records that feature the sibling directly (e.g., the next census).
-   Capture the assigned `I` id from the tool response.
+   Read back each sibling's assigned `I` id from that batch's
+   `results[].assignedIds`.
 
-2. **ParentChild relationship for each existing parent** — one
-   `tree_edit({ operation: "add_relationship", relationship: {…} })`
-   call per (sibling × in-tree parent) pair:
+2. **ParentChild edges — in a SECOND `tree_edit` batch**, now that the
+   sibling `I` ids are known. Add one `add_relationship` op per (sibling
+   × in-tree parent) pair to a single ops array:
 
    ```
    tree_edit({
      projectPath: "<absolute project dir>",
-     operation: "add_relationship",
-     relationship: {
-       type: "ParentChild",
-       parent: "<the existing parent's I id>",
-       child: "<the sibling I id from step 1>"
-     }
+     ops: [
+       { operation: "add_relationship",
+         relationship: {
+           type: "ParentChild",
+           parent: "<the existing parent's I id>",
+           child: "<the sibling I id from step 1's response>"
+         } }
+       /* …one op per (sibling × in-tree parent) pair… */
+     ]
    })
    ```
 
    If both household parents exist in the tree (e.g., both
    `head_of_household` and `wife` map to in-tree persons), emit TWO
-   ParentChild edges per sibling — one per parent — so the sibling
+   ParentChild ops per sibling — one per parent — so the sibling
    shows up correctly under either parent's `buildParentMob`.
 
 **The subject's own person and the subject's ParentChild edges are

--- a/packages/engine/plugin/skills/research-plan/SKILL.md
+++ b/packages/engine/plugin/skills/research-plan/SKILL.md
@@ -65,12 +65,21 @@ record-type selection by research goal.
 
 ### 1. Understand the question's context
 
-Read the question's `rationale` and `selection_basis`. Determine:
+From the question's `rationale` and `selection_basis`, determine:
 - **Who** — the subject and what is known (tree.gedcomx.json, assertions)
 - **What** — the event or relationship under investigation
 - **Where** — jurisdiction, county, state/province, country
 - **When** — target time period
-- **Prior searches** — read the log for this question's plan items
+- **Prior searches** — the log for this question's plan items
+
+If you already hold this question and its context in memory from the
+same run, work from that — don't re-read `research.json` "to be safe."
+Read it only when you're entering planning cold without the question's
+state in context, or when a sub-skill or the user changed the file since
+you last saw it. (Step 1a's plan-mode decision below still requires
+reading **all plans for the target question** when you don't already
+know their current statuses — that read is about picking the mode, not a
+defensive re-read.)
 
 **Verify the starting point (BCG Standard 11).** Before building a
 plan, check whether starting-point facts are documented or merely
@@ -194,55 +203,68 @@ items may indicate the question is too broad — consider splitting.
 
 ### 5. Write the plan
 
-Write the plan in two phases: append the plan shell, then append each
-plan item into it.
+Write the whole plan in ONE batched `research_append` call: op #1
+appends the plan shell, then one `append` op per plan item. Each item
+is still its own op; batching changes only the number of *calls*, not
+the data. The whole batch validates once and writes once; on any per-op
+failure it returns `{ ok: false, errors: ["ops[i]: <msg>"] }` and writes
+NOTHING — surface the errors and fix the offending op, don't re-issue
+the same call blindly.
 
-**Phase 1 — append the plan shell.** Omit the `id` (the tool assigns
-the `pl_` id) and omit `items` (you add those in Phase 2):
+**Op #1 — the plan shell.** Omit the `id` (the tool assigns the `pl_`
+id) and omit `items` (the item ops add those). The tool rejects a second
+`active` plan for the same `question_id` (one active plan per question).
+
+**Ops #2…N — the plan items**, in sequence order. Each targets the plan
+from op #1 via `planId`, using the plan's **predicted** assigned id. The
+tool assigns ids as **(highest existing id of that prefix in
+`research.json`) + 1**, zero-padded to 3 — *not* always `_001`. So read
+`research.json`'s `plans[]` and compute op #1's id: if the project already
+has `pl_001`/`pl_002`, this plan becomes `pl_003`. Carry that predicted id
+as `planId` on every item op. **Do NOT hard-code `pl_001`** — that is only
+correct for the very first plan in a fresh project; in any ongoing project
+it would silently attach your items to a *different question's* existing
+plan. Omit each item's `id` (the tool assigns the `pli_` id). Likewise, a
+`fallback_for` references the primary item's predicted `pli_` id — compute
+it as (highest existing `pli_` across **all** plans' `items[]`) + 1,
+advancing by one per item op in this call — so place the primary item's op
+before its fallback's op in the array, and set the fallback's
+`fallback_for` to the primary's predicted `pli_` id:
 
 ```
 research_append({
-  section: "plans",
-  op: "append",
-  entry: {
-    question_id: "q_003",
-    status: "active",
-    created: "2026-05-04"
-  }
+  projectPath: "<absolute-path-to-project-directory>",
+  ops: [
+    {
+      section: "plans",
+      op: "append",
+      // assigned pl_ id = (highest existing pl_ in research.json) + 1.
+      // Here the project already has pl_001/pl_002, so this is pl_003.
+      entry: {
+        question_id: "q_003",
+        status: "active",
+        created: "2026-05-04"
+      }
+    },
+    {
+      section: "plan_items",
+      op: "append",
+      planId: "pl_003",   // op #1's predicted id (computed, not assumed _001)
+      entry: {
+        sequence: 1,
+        record_type: "probate",
+        jurisdiction: "Schuylkill County, Pennsylvania",
+        date_range: "1875-1890",
+        repository: "FamilySearch",
+        rationale: "Thomas Flynn likely died circa 1881 (disappears from tax records). Schuylkill County probate records 1810-1920 are indexed on FamilySearch. A will naming Patrick as a son would be direct evidence of parentage.",
+        fallback_for: null,
+        status: "planned"
+      }
+    }
+    /* …one append op per plan item, each with planId: "pl_003"… */
+  ]
 })
 ```
-
-The tool rejects a second `active` plan for the same `question_id`
-(one active plan per question). On `{ ok: true, ... }` it returns the
-assigned `entryId` (e.g. `pl_003`) — use that as the `planId` in
-Phase 2.
-
-**Phase 2 — append each plan item.** One call per item, in sequence
-order, targeting the plan from Phase 1 via `planId`. Omit each item's
-`id` (the tool assigns the `pli_` id):
-
-```
-research_append({
-  section: "plan_items",
-  op: "append",
-  planId: "pl_003",
-  entry: {
-    sequence: 1,
-    record_type: "probate",
-    jurisdiction: "Schuylkill County, Pennsylvania",
-    date_range: "1875-1890",
-    repository: "FamilySearch",
-    rationale: "Thomas Flynn likely died circa 1881 (disappears from tax records). Schuylkill County probate records 1810-1920 are indexed on FamilySearch. A will naming Patrick as a son would be direct evidence of parentage.",
-    fallback_for: null,
-    status: "planned"
-  }
-})
-```
-
-For a `fallback_for`, pass the `pli_` id the tool returned for the
-primary item it falls back from (so append the primary before its
-fallback). If a call returns `{ ok: false, errors }`, surface the
-errors and fix the input — do not re-issue the same call blindly.
 
 **Plan item fields:**
 

--- a/packages/engine/plugin/skills/research/SKILL.md
+++ b/packages/engine/plugin/skills/research/SKILL.md
@@ -24,7 +24,7 @@ allowed-tools:
 
 # /research — Full GPS Research Workflow
 
-**Narration:** Read `researcher_profile.narration_guidance` from `research.json` and apply it as your narration style for this invocation. If absent, default to a one-line preamble per action.
+**Narration:** Read `researcher_profile.narration_guidance` from `research.json` and apply it as your narration style for this invocation. If absent, default to one short preamble **per phase / per record** (e.g. once before a record's extraction, not before each individual write or `ops` op). Under `--autonomous` mode, suppress per-entry preambles entirely — the audit trail lives in the persisted `rationale`/`notes` fields, not in chat, so narrate only at phase boundaries (or not at all) and keep moving.
 
 You drive the full Genealogical Proof Standard (GPS) workflow on the
 user's research objective. Rather than the user invoking each
@@ -48,10 +48,14 @@ or conflict resolution analysis) so the audit trail captures it.
 **You are the only driver. Keep working in one continuous turn.**
 There is no human to approve a tool, answer a question, or prompt you
 onward — so do **not** end your turn to announce, plan, or ask about a
-next step. After a sub-skill returns, immediately re-read `research.json`
-and invoke the next sub-skill in the **same turn**, and keep going
-through the full routing loop (§"What to do" steps 2–4) until a real
-stop condition is met (§"When to stop"). Writing something like "Next:
+next step. After a sub-skill returns, immediately invoke the next
+sub-skill in the **same turn**, and keep going through the full routing
+loop (§"What to do" steps 2–4) until a real stop condition is met
+(§"When to stop"). Trust the compact summaries the sub-skills and writer
+tools return plus the state you already hold in context — only re-read
+`research.json` when you're entering a phase cold without the relevant
+state in context, or when a sub-skill or the user changed the file in a
+way you don't already have. Writing something like "Next:
 research-plan" or "I'll now search records" and then yielding is a
 **failure** — it ends the run before any research happens. Narrate
 briefly if you like, but always follow the narration with the actual
@@ -95,18 +99,26 @@ user as you encounter them.
    conflict-resolved — the 5 threshold questions and 7-point stop
    criteria cannot be answered without those upstream artifacts.
 
-3. **Iterate — without yielding.** After each sub-skill returns, re-read
-   `research.json` and invoke the next step **in the same turn** (under
-   `--autonomous`; see "Autonomous mode"). New evidence may reveal new
+3. **Iterate — without yielding.** After each sub-skill returns, route
+   to the next step **in the same turn** (under `--autonomous`; see
+   "Autonomous mode") from the sub-skill's compact return plus the state
+   you already hold — re-read `research.json` only if the sub-skill
+   changed state you don't have in context, or you're routing into a
+   phase cold. New evidence may reveal new
    questions — return to `question-selection`. Resolved conflicts may
    unblock `proof-conclusion`. Do not assume the chain is linear; the
    same sub-skill may be invoked multiple times across the run. Do not
    stop after invoking just one sub-skill — that's the start of the
    loop, not the end.
 
-4. **Validate periodically.** After significant state changes, run
-   `validate_research_schema` to catch schema errors before they
-   compound across many entries.
+4. **Don't insert defensive validate passes.** Every writer tool
+   (`research_append`, `research_log_append`, `tree_edit`) validates the
+   **whole** project before it persists and writes nothing on failure, so
+   a separate periodic `validate_research_schema` pass between sub-skills
+   is pure redundancy — skip it. Only run `validate_research_schema`
+   directly when an **external/manual** edit touched the files outside the
+   writer tools (a hand-edit, or a file the user changed) and you need to
+   confirm it still conforms.
 
 ## Mentor checkpoints
 
@@ -195,8 +207,11 @@ of "What to do" and invoke the next sub-skill. (See "Autonomous mode".)
 
 **Writes:** nothing directly. This skill is a thin orchestrator — it
 reads `research.json` to decide the next step and delegates every
-write to the sub-skill it routes to. Between steps it calls
-`validate_research_schema` (read-only). The only side-channel writes
+write to the sub-skill it routes to. It does **not** insert defensive
+`validate_research_schema` passes between steps (the writer tools each
+validate the whole project before persisting); it calls
+`validate_research_schema` (read-only) only to confirm an external/manual
+edit to the files. The only side-channel writes
 during a run come from the `gps-mentor` subagent it invokes, which
 writes verdict files under `evaluations/` and never touches
 `research.json` or `tree.gedcomx.json`.

--- a/packages/engine/plugin/skills/search-records/SKILL.md
+++ b/packages/engine/plugin/skills/search-records/SKILL.md
@@ -138,10 +138,16 @@ If none of the above applies, proceed to Step 1.
 
 ### Step 1: Identify the plan item to execute
 
-Read `research.json` `plans[]` and find the next plan item with
-`status: "planned"` in the active plan for the current question.
-If the user specifies a particular search, match it to a plan item
-or create an ad-hoc search (with `plan_item_id: null` in the log).
+Find the next plan item with `status: "planned"` in the active plan for
+the current question. If you already hold the active plan and its item
+statuses in context from the same run (e.g. research-plan just wrote it
+and you have its compact return), work from that — don't re-read
+`research.json` "to be safe"; the writer tools validate the whole project
+on every write, so the in-context view can't be silently stale. Re-read
+`research.json` `plans[]` when you're entering this skill cold, or when a
+sub-skill or the user changed the plan since you last saw it. If the user
+specifies a particular search, match it to a plan item or create an
+ad-hoc search (with `plan_item_id: null` in the log).
 
 ### 2. Construct the search query
 
@@ -442,6 +448,16 @@ a stale `entryId`/`planId`) rather than retrying blindly.
 For each promising record, Claude holds the record data in context
 and invokes record-extraction to process it. The handoff is
 context-based — there is no file queue.
+
+**Hand off the `recordId` explicitly.** Each search result from
+`record_search` carries a `recordId` field that record-extraction uses as
+the assertion `record_id`. Pass that `recordId` value through in the
+handoff (alongside the persona ids you already hold) so record-extraction
+does **not** have to recover it by re-running `record_search`. Its exact
+format is the validator's concern — it matches `record_id` to the record
+by canonical ARK form — so just pass `recordId` straight through; that
+lets record-extraction's first `research_append` validate without a
+re-search.
 
 **Critical: distinguish index entries from original records.**
 Most search results are index entries — derivative sources created


### PR DESCRIPTION
## What & why

Speedup work from `docs/plan/e2e-research-runtime-speedup-plan.md`: the
`spriggs-parents-1898` autonomous `/research` run passed but took ~90 min, driven
by 211 single-row writer calls (94 `research_append` + 17 `tree_edit`), redundant
re-reads/validates, and `ToolSearch` re-discovery. This PR implements **Ideas 1,
2a, 2b, and 3a**. Wall-clock is only validated by an **e2e re-run** — the unit
tests here cover correctness, not timing.

## Changes

**Idea 1 — heterogeneous `ops` batch tools (keystone)**
- `research_append` / `tree_edit` gain an optional `ops` array: apply many
  mutations to one in-memory doc, **validate once, write once**, all-or-nothing,
  with `ops[i]` error indexing and intra-batch id sequencing.
- Single-op behavior is **byte-identical**; persisted shapes unchanged → no
  `research.json` schema / validator-shape / `manifest.json` / `tool-schemas.ts`
  churn (packaging drift test stays green).
- Factored a throwing `applyOne` in `research_append`; reused `applyOperation` in
  `tree_edit`. Specs: `research-append` §3.3, `tree-edit` §4.3.
- Latent gap closed: the one-active-plan invariant now runs on `update`, not just
  `append`.

**Idea 2a — skills emit batched calls** (record-extraction, person-evidence,
assertion-classification, research-plan). Every persona/assertion/link/item stays
individually represented; id prediction computes `max+1` from `research.json`
(not a literal `_001`).

**Idea 2b — prompt-only efficiency cleanups**: per-phase narration (suppressed
under `--autonomous`), stop redundant `research.json` re-reads, drop standalone
`validate_research_schema` passes, hand off `recordId` explicitly so
record-extraction stops re-running `record_search`.

**Idea 3a — pin tool schemas**: `ENABLE_TOOL_SEARCH=true` on the e2e orchestrator
**and** hosted-web `real_agent.py` (env verified merge-safe), to stop the bundled
CLI's MCP-tool-schema deferral / `ToolSearch` re-discovery loop.

## ⚠️ Reviewer callout — validator behavior change

The validator now matches `record_id` ↔ sidecar `recordId` by **canonical ARK
form** (`arkToBareId`) instead of exact string: a resolver URL, a bare ARK
(`ark:/61903/1:1:X`), and a bare entity id (`X`) for the same record all match;
non-FamilySearch ids (`ancestry:…`) pass through and still require an exact match.
This is more permissive but **bounded to same-entity / different-format** (new
test confirms a *different* entity still fails). It moves the id-format burden off
the skills and into the tool, and fixes a latent bug: the prior skill guidance
taught a `record_id` format that could fail validator check D5. `record_persona_id`
is intentionally **not** changed — it's a local gedcomx id matched against the same
gedcomx (no format seam).

## Deferred (documented, not dangling)

- **3b (stall resume)** — the two stalls are real but **n=1**; the plan records the
  trigger to revisit (stalls recurring across re-runs) and the design.
- **gps-mentor gate change** — decoupled; the "stage → measure → then decide"
  sequence is in `gps-mentor-agent-spec.md` §17.1.

## Tests

Full vitest suite **1174 pass / 56 files; `tsc` clean.** Added: batch success +
ordered ids, atomic rollback, `ops[i]` indexing, intra-batch sequencing/refs,
heterogeneous record, project-singleton-in-batch, plan-invariant-across-batch, and
the canonical `record_id` match (positive + negative).

## Landing requirements

1. **Eval re-runs (blocking):** the skill edits invalidate eval run logs for **7
   skills** — `research`, `question-selection`, `research-plan`, `search-records`,
   `record-extraction`, `person-evidence`, `assertion-classification`. The
   `check-runlogs` action (Rule 2) blocks until each is re-run and re-released.
2. **E2E re-run:** validates the 90→15 min goal, confirms 3a's `ToolSearch` drop,
   and measures whether 3b's stalls recur. *(Owner is re-running this.)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
