### PR TITLE
question-selection: shorten SKILL.md ~27% with no eval regression

### DIFF
--- a/eval/runlogs/unit/question-selection/v1_2026-06-26_08-07-13.json
+++ b/eval/runlogs/unit/question-selection/v1_2026-06-26_08-07-13.json
@@ -1,0 +1,2886 @@
+{
+  "schema_version": 2,
+  "skill": "question-selection",
+  "version": 1,
+  "released": false,
+  "releasable": true,
+  "invocation": "skill",
+  "timestamp": "2026-06-26_08-07-13",
+  "harness_version": "0.1.0",
+  "model": "claude-sonnet-4-6",
+  "judge_prompt_hash": "adea6e4cb2c9ddf0c436c31e893da766866cc67ed749df0a7c6b8a9df52c6914",
+  "snapshot": {
+    "packages/engine/plugin/skills/question-selection/SKILL.md": "---\nname: question-selection\nmodel: claude-sonnet-4-6\ndescription: Selects the next research question (writing it to research.json) based on current project\n  state \u2014 timeline gaps, unresolved conflicts, hypothesis tests, or\n  exhausted direct evidence requiring FAN pivot. Also derives the first\n  research question on a brand-new project. GPS Step 1 \u2014 Reasonably\n  Exhaustive Research. Use when the user says \"what should I research\n  next?\", \"what should we work on next?\", \"next question\", \"where should\n  I start?\", \"where do I begin?\", \"what's missing?\", \"should we try FAN\n  research?\", after a question is resolved, or after a proof summary\n  reveals gaps. Do NOT use when\n  the user already has a specific question and wants to plan how to\n  answer it (use research-plan), when the user wants to evaluate\n  whether research on a question is exhaustive (use\n  research-exhaustiveness), when the user only wants a summary of the\n  project's current state (use project-status), or when the user wants\n  to search records (use search-records or search-external-sites).\nallowed-tools:\n  - research_append\n---\n\n# Question Selection\n\n**Narration:** Read `researcher_profile.narration_guidance` from `research.json` and apply it as your narration style for this invocation. If absent, default to a one-line preamble per action.\n\nAnalyzes the current project state and selects the next research question.\n\n**Load reference files before proceeding:**\n- Read `references/question-formulation.md` for research question criteria\n- Read `references/pedigree-analysis.md` for gap detection guidance\n\n## 1. Read project state\n\nRead all sections of `research.json` and persons in `tree.gedcomx.json`. Identify:\n\n- **Objective** \u2014 the overarching goal; every question must trace back to it.\n- **Open questions** (`open` / `in_progress`) and **in-progress plan items**\n  (`plan_items[].status == \"in_progress\"` on an open question \u2014 in-flight\n  research the user has already committed to).\n- **Resolved questions** \u2014 what has been answered.\n- **Pedigree gaps** \u2014 individuals missing a name, specific date, or\n  county/parish-level locality (see `references/pedigree-analysis.md`).\n- **Timeline gaps**, **unresolved conflicts** (especially those blocking\n  downstream questions), **active hypotheses**, **log coverage**, and the\n  current **assertion** landscape.\n\n### 1a. Finish what's already open before selecting a new question\n\nIf any open question has plan items with `status: \"in_progress\"`, **do NOT\ncreate a new question** (one exception below) \u2014 adding questions mid-flight\nchurns direction without resolving anything, and the in-flight item may\nproduce evidence that changes which question is next-highest value.\nRecommend the user complete the in-flight items first, referencing each by\n`pli_XXX` ID plus repository/record type (e.g. \"Complete `pli_006` \u2014 the\nThomas Flynn probate search on FamilySearch \u2014 before adding new questions\").\nOnly proceed to Step 2 when no in-progress plan items exist, or when the\nuser explicitly overrides with \"add a question anyway.\" In the override\ncase, set the new question's `depends_on` to include the question whose\nplan is in flight.\n\n**Exception \u2014 blocking unresolved conflicts.** If any `conflicts[]` entry\nhas `status == \"unresolved\"` and lists an open question in\n`blocks_question_ids`, the in-progress rule does NOT block a new question:\nthe conflict means the in-flight plan items cannot meaningfully resolve the\nquestion they belong to, so it has to be addressed first. Proceed to Step 2\n(Priority 1 `unresolved_conflict` will fire), and set the new question's\n`unblocks` to include the question whose plan is in flight, since resolving\nthe conflict re-enables that plan's progress.\n\n## 2. Identify the highest-value question\n\nApply these priorities in order. When multiple candidates exist at the same\npriority level, prefer the one that unblocks the most downstream questions.\n\n| Priority | Trigger | `selection_basis` |\n|----------|---------|-------------------|\n| 1 | A conflict has `blocks_question_ids` entries | `unresolved_conflict` |\n| 2 | The objective maps to an active hypothesis needing test | `hypothesis_test` |\n| 3 | Timeline has high-severity gaps spanning census/vital years | `timeline_gap` |\n| 4 | Objective not yet decomposed into sub-questions | `objective_decomposition` |\n| 5 | Pedigree analysis reveals missing key data or inconsistencies | `objective_decomposition` |\n| 6 | Direct evidence exhausted; pivot to Family/Associates/Neighbors | `fan_pivot` |\n| 7 | A recently extracted assertion opens a new line of inquiry | `new_evidence` |\n\n**Priority 3 detail:** Only fires when `severity == \"high\"`. Low-severity\ntimeline gaps do not trigger it.\n\n**Priority 4 detail:** Each sub-question targets a single fact (one identity,\nrelationship, or event). Example decomposition of \"Identify the parents of\nPatrick Flynn\": \"Where was Patrick Flynn in the 1850 census?\" / \"What does\nhis death certificate say about his parents?\" / \"Did Thomas Flynn leave a\nwill naming his children?\"\n\n**Priority 6 detail:** Don't pivot to FAN just because one search returned\nnil \u2014 pivot only when all planned direct searches are complete and\nunresolved. If the primary question's `exhaustive_declaration.declared` is\n`true`, the researcher has declared direct evidence exhausted: take that as\nthe FAN signal and do NOT propose additional direct-evidence paths. FAN\nexamples: \"Who witnessed Thomas Flynn's land deeds?\" / \"Who were his\nneighbors in the 1850 census?\"\n\n## 3. Formulate the question\n\nSee `references/question-formulation.md` for the three criteria (one\nobjective, named individual, testable scope) and examples.\n\nBefore formulating, verify the starting-point information is sound. Do not\nbuild a question on unverified claims from compiled sources (online trees,\nunsourced genealogies). If the premise is unverified, the first question\nshould verify it.\n\n## 4. Write the question\n\nPersisting the question is the point of this skill \u2014 describing it in prose\nis not enough. Append it to `research.json` `questions[]` via\n`research_append` (`op: \"append\"`), omitting `id` (the tool assigns the next\n`q_NNN` and stamps `created`). Use exactly these field names:\n\n```\nresearch_append({\n  projectPath: \"<absolute-path-to-project-directory>\",\n  section: \"questions\",\n  op: \"append\",\n  entry: {\n    question: \"<one single-fact question>\",\n    rationale: \"<why now \u2014 grounded in record availability/methodology>\",\n    selection_basis: \"<the basis you chose from the Step 2 priority table>\",\n    priority: \"<high | medium | low>\",\n    status: \"open\",\n    depends_on: [], unblocks: [\"q_001\"],\n    resolved: null, resolution_assertion_ids: [],\n    exhaustive_declaration: { declared: false, justification: null, log_entry_ids: [], stop_criteria: null }\n  }\n})\n```\n\nThe tool validates the whole project before writing and writes nothing on\nfailure; on `{ ok: false, errors }`, surface the errors and fix the entry \u2014\ndo not retry the same payload blindly.\n\n**Set dependency links:**\n- `depends_on`: questions whose resolution enables or informs this question's\n  research path. Include a question when either (a) it must be resolved\n  before this one can be meaningfully pursued, or (b) this question's most\n  efficient strategy relies on its specific findings (e.g. q_001 identified a\n  household and the new question searches within it \u2014 include q_001 even if\n  already resolved).\n- `unblocks`: questions this one's resolution would enable or advance. High\n  `unblocks` counts mark gatekeeper questions \u2014 prioritize them.\n- When neither applies (e.g. a first question), set both explicitly to `[]`.\n\nThe `exhaustive_declaration` must be unstarted at creation (as shown above:\n`declared: false`, empty `log_entry_ids`, null `stop_criteria`). Evaluating\nexhaustiveness is the `research-exhaustiveness` skill's job, run after all\nplan items complete.\n\n## 5. Present\n\n- The question selected and why (the rationale).\n- What it depends on and what it unblocks.\n- Suggest next step: \"Would you like me to plan the research for this\n  question?\" (research-plan).\n\n## Rules\n\n- **One question at a time.** Each invocation produces at most one new question.\n- **Finish what's open.** Don't introduce new questions while any open\n  question's plan items are `in_progress` (see Step 1a).\n- **Sound basis required.** Don't build questions on unsound assumptions \u2014\n  if the premise is unverified, verify it first.\n- **Objectives vs. questions.** Never write an objective as a question;\n  questions are narrow, single-fact, testable sub-problems.\n- **Don't declare exhaustiveness here.** Closing questions is the\n  `research-exhaustiveness` skill's job \u2014 this skill only creates them.\n- **Never delete a question.** To retire one, `research_append`\n  `op: \"update\"` its `status` (`superseded` / `answered`); the id is\n  preserved. Never write a second `q_` for a question that already exists \u2014\n  update its status instead.\n- **Historical context matters.** Factor in jurisdictional boundary changes,\n  migration, wars, and record availability for the time and place.\n\n## Edge cases\n\n- **Fresh project, no clear gaps:** default to Priority 4 (decompose the\n  objective into sub-questions).\n- **All questions blocked:** identify the root blocker and formulate a\n  question to resolve it \u2014 even if that means a conflict with no formal\n  `conflicts[]` entry yet.\n- **All plan items for a question complete:** run the priority ladder\n  first. If direct evidence is exhausted \u2014 `exhaustive_declaration.declared`\n  is true, or all planned direct searches are complete and unresolved \u2014\n  **Priority 6 fires: create a `fan_pivot` question** (FAN exhaustion comes\n  before declaring the project reasonably exhaustive). Recommend\n  `research-exhaustiveness` instead only when no Priority 1\u20136 signal applies\n  (e.g. FAN avenues are themselves already worked).\n",
+    "packages/engine/plugin/skills/question-selection/references/pedigree-analysis.md": "# Pedigree Analysis for Gap Detection\n\nGuidance for evaluating pedigree data to identify research gaps,\nerrors, and candidates for new research questions.\n\n## Purpose\n\nPedigree analysis is the process of systematically reviewing the\nindividuals in a family tree to detect missing information, logical\nerrors, and inconsistencies. It is a critical first step before\nselecting new research questions \u2014 it reveals where the gaps are\nand which gaps are most significant.\n\n## Minimum Data Requirements\n\nEvery individual in the pedigree should have at minimum:\n\n- **A name** (full name including surname)\n- **A specific date** (at least one of: birth, marriage, or death \u2014\n  not just \"about 1800\" but ideally a day-month-year)\n- **A reasonably specific place** (at county, parish, or town level\n  \u2014 not just a country or state)\n\nIndividuals missing any of these three data points are candidates\nfor new research questions.\n\n## Completeness Assessment\n\nEvaluate the pedigree for structural gaps:\n\n- Which individuals lack parent links? (Missing generations)\n- Which couples lack marriage information?\n- Which families have incomplete child lists?\n- Which individuals appear only once (no connecting records)?\n- Are there entire branches with no dates or places?\n\n## Logical Consistency Checks\n\nDates and relationships must be internally consistent. Flag any of\nthese impossibilities or implausibilities:\n\n### Date logic\n- Birth date after death date\n- Marriage before age 12 (or before birth)\n- Death after age 120\n- Child born after mother's death\n- Child born when mother was under 12 or over 50\n- Child born after father's death by more than 9 months\n\n### Parent-child relationships\n- Parent-child age difference less than 15 years\n- Parent-child age difference greater than 70 years\n- Sibling born less than 9 months after previous sibling\n  (if same mother)\n\n### Geographic consistency\n- Children born in places where parents were not residing\n- Events in places that did not exist at the stated date\n  (jurisdictions were created, split, and renamed over time)\n- Migration timelines that are physically implausible for the\n  period's transportation technology\n\n## Historical Context Awareness\n\nDates and places carry historical significance beyond identification.\nWhen analyzing a pedigree, consider:\n\n- **Wars and military service**: Was the person of military age\n  during a conflict? Military records may exist.\n- **Migration patterns**: Were there major migration events affecting\n  this area and time period? (Gold rushes, land openings, famine\n  emigration, religious migrations.)\n- **Jurisdictional existence**: Did the named county, parish, or\n  town exist at the stated date? Many boundary changes occurred as\n  populations grew.\n- **Record availability**: What records would have been created for\n  this person given their time, place, religion, and social status?\n  Records start at different dates in different jurisdictions.\n\n## Source Quality Assessment\n\nFor each fact in the pedigree, evaluate:\n\n- Is the fact supported by a citation?\n- Is the cited source an original record or a derivative?\n- Do multiple sources agree, or is there conflicting information?\n- Are any facts sourced only from unverified online family trees?\n\nFacts backed only by compiled sources (online trees, undocumented\ngenealogies, derivative indexes) should be treated as unverified\nleads, not established facts. They may be starting points for\nresearch but cannot support a proved conclusion.\n\n## Prioritizing Gaps for Research\n\nNot all gaps are equally important. Prioritize based on:\n\n1. **Proximity to the research objective**: Gaps directly blocking\n   the project's central question take priority.\n2. **Gatekeeper potential**: Filling this gap would unblock multiple\n   downstream questions.\n3. **Likelihood of success**: Records are known to exist for the\n   jurisdiction and time period.\n4. **Error risk**: An inconsistency suggests misidentification \u2014\n   resolving it prevents building on a false foundation.\n5. **Generation depth**: Earlier generations (closer to the subject)\n   generally take priority over more distant ancestors, since errors\n   compound with each generation.\n\n## Integration with Question Selection\n\nAfter completing pedigree analysis, feed the findings into the\nquestion selection priority system:\n\n- Logical impossibilities map to `unresolved_conflict` (Priority 1)\n  if they block other questions\n- Missing key data for the research subject maps to `pedigree_gap`\n  (Priority 5)\n- Unverified claims from compiled sources may trigger new questions\n  to verify them before building further\n\nThe pedigree analysis does not itself produce questions \u2014 it\nidentifies where questions are needed. The question formulation\ncriteria (see `question-formulation.md`) govern how those gaps get\nturned into well-formed, testable research questions.\n",
+    "packages/engine/plugin/skills/question-selection/references/question-formulation.md": "# Research Question Formulation\n\nGuidance for formulating effective genealogical research questions\nthat satisfy the GPS standard for planned, purposeful research.\n\n## Research Objectives vs. Research Questions\n\nThese are distinct concepts that must not be conflated:\n\n- **Research objective**: The overarching goal of the research effort.\n  It describes what you ultimately want to know (e.g., \"Identify the\n  parents of John Smith born circa 1820 in Greene County, Ohio\").\n- **Research question**: A smaller, focused question nested within\n  the objective. It targets a single discoverable fact that\n  contributes toward the objective (e.g., \"What does John Smith's\n  1870 death certificate say about his parents?\").\n\nA single objective typically decomposes into multiple research\nquestions. Each question drives its own research plan, search log,\nand exhaustiveness evaluation.\n\n## The Three Criteria\n\nEvery research question must satisfy all three of these requirements:\n\n### 1. One concise objective\n\nThe question targets a single answerable fact \u2014 one identity, one\nrelationship, or one event. If the question contains \"and\" joining\ntwo distinct unknowns, it should be split.\n\n- Good: \"When and where did Mary Jones marry?\"\n  (One event \u2014 the marriage \u2014 even though it has two attributes.)\n- Bad: \"When did Mary Jones marry, and who were her parents?\"\n  (Two unrelated unknowns requiring different record types.)\n\n### 2. A named individual\n\nThe question must concern a specific, identifiable person \u2014 not a\nvague family group or surname. Include enough distinguishing detail\nto separate this person from others who share the name:\n\n- Full name as known (including maiden name for married women)\n- Approximate date (birth year, death year, or event year)\n- Place (at least county or parish level)\n- Any other biographical context that distinguishes them\n\n### 3. Testable scope\n\nThe question must be bounded enough that you can determine:\n- What records to search (time, place, and record type are implied)\n- When the question is answered (what constitutes a satisfactory\n  resolution)\n- Whether the answer meets or fails the GPS standard\n\nA question that cannot be tested cannot lead to proof.\n\n## Two Types of Genealogical Questions\n\nEvery genealogical problem ultimately concerns one of two things:\n\n1. **Relationships** \u2014 Who is connected to whom? Parent-child,\n   spousal, sibling, and associative relationships.\n2. **Events** \u2014 What happened at a specific time and place? Births,\n   marriages, deaths, migrations, land purchases, military service,\n   naturalizations, etc.\n\nIdentifying which type the question addresses guides you toward\nthe right record categories.\n\n## Balancing Breadth and Focus\n\nA well-crafted question balances two competing requirements:\n\n- **Broad enough to be answerable** \u2014 the question must leave room\n  for evidence to exist (i.e., records from the right time and place\n  could plausibly contain the answer).\n- **Focused enough to be testable** \u2014 it must be possible to evaluate\n  whether the answer satisfies the GPS or falls short.\n\nThe question should clearly identify who or what is being researched\nand what unknown fact the research aims to discover.\n\n## Sound Basis\n\nQuestions must rest on verified starting-point information:\n\n- Evaluate existing data for internal consistency before building on it\n- Do not assume facts that no source supports\n- Treat claims from compiled sources (online trees, undocumented\n  genealogies) as unverified leads until confirmed by original records\n\nIf the premise of a question is itself unverified, the first question\nshould verify that premise.\n\n## Common Failures\n\n| Problem | Example | Fix |\n|---------|---------|-----|\n| Too broad | \"Research the Smith family\" | Narrow to one person, one fact |\n| No named individual | \"Find Irish immigrants in the 1850 census\" | Specify which person |\n| Multiple unknowns | \"Find parents and birthplace of John\" | Split into two questions |\n| Assumes facts not in evidence | \"Find John's second wife's maiden name\" (no evidence of a second wife) | First establish the second marriage |\n| Untestable | \"Trace the family back as far as possible\" | Define a specific endpoint |\n| Built on unverified claim | \"Find birth record for 1815\" (1815 comes from an unsourced tree) | First verify the approximate birth year |\n\n## Decomposing an Objective into Questions\n\nWhen breaking an objective into sub-questions, consider:\n\n1. What vital records (birth, marriage, death) might name the\n   person or their relatives?\n2. What census records span the person's lifetime?\n3. What church, land, probate, or military records exist for the\n   jurisdiction and period?\n4. Which questions are \"gatekeeper\" questions \u2014 ones that must be\n   answered before others can be meaningfully pursued?\n5. Which questions, if answered, would unblock the most downstream\n   questions?\n\nOrder questions by priority: gatekeeper questions first, then\nquestions most likely to yield direct evidence, then those requiring\nindirect or circumstantial evidence chains.\n",
+    "packages/engine/plugin/skills/question-selection/references/validation-protocol.md": "# Validation Protocol\n\nThe structured write tools (`research_append`, `research_log_append`,\n`tree_edit`, the merge tools) **validate the project before they\npersist** and write nothing on a validation failure \u2014 so there is no\nseparate post-write schema-validation step. If a write tool returns\n`{ ok: false, errors }`, surface the errors and fix the entry; do not\nretry the same payload blindly.\n\nGenealogical plausibility is a separate concern from schema validity:\n\n- **Invoke `check-warnings`** if you added assertions or\n  person_evidence entries. This checks for genealogical\n  impossibilities (married before 12, died after 120, child born\n  after parent's death, etc.). It is not auto-triggered \u2014 you must\n  invoke it explicitly.\n",
+    "eval/tests/unit/question-selection/first-question-from-objective.json": "{\n  \"input\": {\n    \"scenario\": \"empty-project-just-created\",\n    \"user_message\": \"Pick the first research question to investigate for this project.\"\n  },\n  \"judge_context\": [\n    \"Should decompose the objective into a first concrete research question rather than re-stating the whole objective as a question\"\n  ],\n  \"test\": {\n    \"id\": \"ut_question_selection_002\",\n    \"skill\": \"question-selection\",\n    \"type\": \"positive\"\n  }\n}\n",
+    "eval/tests/unit/question-selection/negative-search-request.json": "{\n  \"input\": {\n    \"scenario\": \"mid-research-flynn\",\n    \"user_message\": \"Find a 1860 census record for Patrick Flynn.\"\n  },\n  \"judge_context\": [\n    \"Should route to search-records rather than wrap the request in a new research question\"\n  ],\n  \"negative\": {\n    \"correct_skill\": [\n      \"search-records\"\n    ],\n    \"explanation\": \"The user has named the record they want (1860 census, Patrick Flynn). That is a search task. question-selection proposes the research *question* \u2014 the framing of what to ask \u2014 not the specific record-fetch that answers it. A search request bypasses question-selection entirely and goes straight to search-records.\"\n  },\n  \"test\": {\n    \"id\": \"ut_question_selection_004\",\n    \"skill\": \"question-selection\",\n    \"type\": \"negative\"\n  }\n}\n",
+    "eval/tests/unit/question-selection/next-question-after-census.json": "{\n  \"input\": {\n    \"scenario\": \"mid-research-flynn\",\n    \"user_message\": \"What should I research next?\"\n  },\n  \"judge_context\": [\n    \"Should recognize that pli_006 (probate search for Thomas Flynn 1870-1890) is still in_progress and that the in-flight plan should be completed before introducing new questions\",\n    \"If the skill does recommend a follow-up question, it should be one that depends on the probate result (e.g., a sibling-identification question that follows from a will naming children) and explicitly mark `depends_on: [\\\"q_001\\\"]`\",\n    \"Should reference the specific plan item (`pli_006`) by ID \u2014 not just 'the probate search' \u2014 so the recommendation is anchored in research.json state\",\n    \"GRADING NOTE \u2014 Question specificity: when the skill correctly defers adding a new question (no new question added), this dimension is N/A and should be scored null. Do NOT penalize the specificity of any hypothetical future questions mentioned in passing \u2014 those are illustrations, not the actual selection.\"\n  ],\n  \"test\": {\n    \"id\": \"ut_question_selection_001\",\n    \"skill\": \"question-selection\",\n    \"type\": \"positive\"\n  }\n}\n",
+    "eval/tests/unit/question-selection/prioritize-blocked-question.json": "{\n  \"input\": {\n    \"scenario\": \"flynn-multi-conflict\",\n    \"user_message\": \"Pick the next research question to investigate.\"\n  },\n  \"judge_context\": [\n    \"Should recognize that q_001 is blocked by unresolved conflicts c_001 and c_002\",\n    \"The proposed question should target evidence that would distinguish the competing assertions \u2014 for c_001 (birthplace) that might be a marriage record or naturalization papers; for c_002 (identity) it might be a later census or vital record that anchors the subject's identity\"\n  ],\n  \"test\": {\n    \"id\": \"ut_question_selection_003\",\n    \"skill\": \"question-selection\",\n    \"type\": \"positive\"\n  }\n}\n",
+    "eval/tests/unit/question-selection/rubric.md": "# Question Selection Rubric\n\nGrading dimensions for question-selection unit tests. Evaluated by the LLM judge alongside the base rubric (correctness, completeness).\n\n## Prioritization logic\n\nDid the skill correctly prioritize among competing next-question candidates? Unresolved conflicts > timeline gaps > hypothesis tests > new decompositions. The rationale must explain why the selected question takes priority.\n\n- **pass:** The selected question's `selection_basis` matches the highest-priority signal present in the project state, and the rationale explains why that signal takes priority over other candidates.\n- **partial:** Selection is reasonable but the rationale doesn't explicitly compare against the other candidates that were available.\n- **fail:** Selection ignores higher-priority signals (e.g., starts a new decomposition while an unresolved conflict is blocking an existing question), or `selection_basis` is mis-assigned.\n\n## Question specificity\n\nIs the research question specific and answerable? \"Learn more about Patrick\" is not a research question. \"What is Patrick Flynn's birthplace?\" is.\n\n- **pass:** Question is concrete enough that a follow-up search could be designed to answer it; names specific persons, time periods, or facts being sought.\n- **partial:** Question is mostly specific but has a fuzzy edge (\"What more can we learn about Patrick's early life?\" \u2014 better than \"learn more about Patrick\" but still vague on what facts).\n- **fail:** Question is too broad to drive a search (\"Who is Patrick Flynn?\", \"Learn about the Flynn family\").\n\n## Dependency awareness\n\nDoes the question account for dependencies \u2014 questions that must be answered first, and questions this answer will unblock? The depends_on and unblocks fields should be populated correctly.\n\n- **pass:** `depends_on` and `unblocks` are populated when relevant prior questions exist; if neither applies, both are explicitly empty arrays.\n- **partial:** One direction (depends_on or unblocks) is populated but the other is missed.\n- **fail:** Both fields are populated incorrectly (depends_on points at unrelated questions, or unblocks omits an obvious successor).\n",
+    "eval/tests/unit/question-selection/ut_question_selection_005.json": "{\n  \"input\": {\n    \"scenario\": \"flynn-fan-pivot\",\n    \"user_message\": \"What should I research next?\"\n  },\n  \"judge_context\": [\n    \"Should recognize that all planned direct searches are complete (1850, 1860, 1870, 1880, 1900 censuses and death certificate) and no further direct evidence paths remain unexplored\",\n    \"Should propose a FAN (Family/Associates/Neighbors) question \u2014 examples: 'Who were Thomas Flynn's neighbors in the 1850 census?', 'Who witnessed Thomas Flynn's land deed transactions?', 'Who else from the same Irish emigrant community appears in Schuylkill County records?'\",\n    \"The new question's `selection_basis` must be `fan_pivot`\",\n    \"The new question's `depends_on` should reference the question(s) that identified Thomas Flynn \u2014 either `['q_001']`, `['q_002']`, or both are acceptable. An empty `depends_on: []` is not acceptable since FAN research presupposes knowing which Thomas Flynn to research.\",\n    \"GRADING NOTE \u2014 Tool Arguments: if the skill calls validate_research_schema, gets a validation error, self-corrects, and re-validates successfully, score Tool Arguments=3. The self-correction loop is the intended use of validate_research_schema \u2014 a single repair attempt is not a partial.\"\n  ],\n  \"test\": {\n    \"id\": \"ut_question_selection_005\",\n    \"skill\": \"question-selection\",\n    \"type\": \"positive\"\n  }\n}\n",
+    "eval/tests/unit/question-selection/ut_question_selection_006.json": "{\n  \"input\": {\n    \"scenario\": \"flynn-census-exhausted\",\n    \"user_message\": \"What should we work on next?\"\n  },\n  \"judge_context\": [\n    \"Should recognize the high-severity timeline gap from 1860 to 1908 \u2014 the 1870, 1880, and 1900 censuses have not been searched, spanning 48 years with no documented evidence about Patrick Flynn's life\",\n    \"Should select `selection_basis: 'timeline_gap'` and propose a question targeting one of the unsearched census years (1870, 1880, or 1900)\",\n    \"Should NOT select objective_decomposition (Priority 4) even if further decomposition is possible \u2014 the high-severity gap takes priority\",\n    \"The rationale should explain that the gap spanning multiple census years is the highest-priority signal present in the project state\",\n    \"GRADING NOTE \u2014 Tool Arguments: if the skill calls validate_research_schema, gets a validation error, self-corrects, and re-validates successfully, score Tool Arguments=3. The self-correction loop is the intended use of validate_research_schema \u2014 a single repair attempt is not a partial.\"\n  ],\n  \"test\": {\n    \"id\": \"ut_question_selection_006\",\n    \"skill\": \"question-selection\",\n    \"type\": \"positive\"\n  }\n}\n",
+    "eval/tests/unit/question-selection/ut_question_selection_007.json": "{\n  \"input\": {\n    \"scenario\": \"flynn-parentage-found\",\n    \"user_message\": \"The father is confirmed. What research question should we add next?\"\n  },\n  \"judge_context\": [\n    \"Should recognize that q_001 (father identification) is resolved and the remaining gap is the mother's identity\",\n    \"Should add a new question about Patrick Flynn's mother \u2014 e.g., 'Who was Patrick Flynn's mother?' or 'What was the name of Thomas Flynn's wife in the Schuylkill County records?'\",\n    \"GRADING INSTRUCTION \u2014 check the file_changes diff in the run output (not the skill's prose narrative): the added question must have a `depends_on` array containing at least one of `'q_001'` or `'q_002'` (or both). Both are correct: q_001 confirmed Thomas Flynn as father, and q_002 located his specific household. An empty depends_on `[]` is a failure. The `unblocks` field must be present as an array.\",\n    \"The rationale must acknowledge that the mother search is most efficiently pursued through the Thomas Flynn household records already identified\"\n  ],\n  \"test\": {\n    \"id\": \"ut_question_selection_007\",\n    \"skill\": \"question-selection\",\n    \"type\": \"positive\"\n  }\n}\n",
+    "eval/tests/unit/question-selection/ut_question_selection_008.json": "{\n  \"input\": {\n    \"scenario\": \"flynn-unsourced-tree\",\n    \"user_message\": \"What should I research next?\"\n  },\n  \"judge_context\": [\n    \"Should recognize that the Thomas Flynn parentage claim rests on a single unsourced compiled source (an Ancestry Member Tree with no original records cited)\",\n    \"Should NOT propose a question that assumes Thomas Flynn is the father (e.g., 'Did Thomas Flynn leave a will?' or 'Where was Thomas Flynn born in Ireland?') \u2014 these build on an unverified premise\",\n    \"Should propose a question whose purpose is to verify or corroborate the online tree claim against original records. Both broad questions ('Does original evidence confirm Thomas Flynn as Patrick's father?') AND specific record-type questions ('What does Patrick Flynn's death certificate say about his parents?', 'Does the 1850 census place Patrick Flynn in a Thomas Flynn household?') are acceptable \u2014 all three are verification questions that neither assume the claim nor build on it. The key criterion is that the question tests the claim rather than accepting it.\",\n    \"The rationale must cite the compiled/unsourced nature of the evidence as the reason the premise must be verified first\"\n  ],\n  \"test\": {\n    \"id\": \"ut_question_selection_008\",\n    \"skill\": \"question-selection\",\n    \"type\": \"positive\"\n  }\n}\n",
+    "eval/tests/unit/question-selection/ut_question_selection_009.json": "{\n  \"input\": {\n    \"scenario\": \"mid-research-flynn\",\n    \"user_message\": \"I want to find Thomas Flynn's probate record \u2014 what records should I search and in what order?\"\n  },\n  \"judge_context\": [\n    \"Should route to research-plan rather than formulate a new research question or modify the existing question list\"\n  ],\n  \"negative\": {\n    \"correct_skill\": [\n      \"research-plan\"\n    ],\n    \"explanation\": \"The user has already decided on a specific question (Thomas Flynn's probate record). They want a search strategy, not a selection of which question to pursue. question-selection chooses what to ask; research-plan designs how to answer it.\"\n  },\n  \"test\": {\n    \"id\": \"ut_question_selection_009\",\n    \"skill\": \"question-selection\",\n    \"type\": \"negative\"\n  }\n}\n",
+    "eval/tests/unit/question-selection/ut_question_selection_010.json": "{\n  \"input\": {\n    \"scenario\": \"flynn-census-exhausted\",\n    \"user_message\": \"Have we searched enough to declare the parentage question done? Can we say we're finished?\"\n  },\n  \"judge_context\": [\n    \"Should route to research-exhaustiveness rather than add a new question or opine on whether the current research is sufficient\"\n  ],\n  \"negative\": {\n    \"correct_skill\": [\n      \"research-exhaustiveness\"\n    ],\n    \"explanation\": \"The user is asking whether research on an existing question is reasonably exhaustive \u2014 the SKILL.md explicitly prohibits question-selection from evaluating exhaustiveness. That judgment belongs to research-exhaustiveness, which applies the GPS stop criteria.\"\n  },\n  \"test\": {\n    \"id\": \"ut_question_selection_010\",\n    \"skill\": \"question-selection\",\n    \"type\": \"negative\"\n  }\n}\n",
+    "eval/tests/unit/question-selection/ut_question_selection_011.json": "{\n  \"input\": {\n    \"scenario\": \"mid-research-flynn\",\n    \"user_message\": \"Can you give me a summary of where this project stands right now?\"\n  },\n  \"judge_context\": [\n    \"Should route to project-status rather than select a research question or describe what the next question would be\"\n  ],\n  \"negative\": {\n    \"correct_skill\": [\n      \"project-status\"\n    ],\n    \"explanation\": \"The user wants a summary of project state \u2014 what has been found, what questions are open, what has been resolved. That is project-status. question-selection picks the next question to work on, not summarize what has already been done.\"\n  },\n  \"test\": {\n    \"id\": \"ut_question_selection_011\",\n    \"skill\": \"question-selection\",\n    \"type\": \"negative\"\n  }\n}\n",
+    "eval/tests/unit/question-selection/ut_question_selection_012.json": "{\n  \"input\": {\n    \"scenario\": \"mid-research-flynn\",\n    \"user_message\": \"Search Ancestry for Patrick Flynn's 1870 census record.\"\n  },\n  \"judge_context\": [\n    \"Should route to search-external-sites rather than wrap the request in a research question or modify the question list\"\n  ],\n  \"negative\": {\n    \"correct_skill\": [\n      \"search-external-sites\"\n    ],\n    \"explanation\": \"The user has named the site (Ancestry) and the specific record they want (1870 census, Patrick Flynn). This is an external-site search task. question-selection proposes what research question to pursue \u2014 it does not execute searches on external sites.\"\n  },\n  \"test\": {\n    \"id\": \"ut_question_selection_012\",\n    \"skill\": \"question-selection\",\n    \"type\": \"negative\"\n  }\n}\n",
+    "eval/fixtures/scenarios/empty-project-just-created/README.md": "# empty-project-just-created\n\nProject state immediately after `init-project` runs successfully: the objective is captured, a stub person exists in `tree.gedcomx.json`, but no research work has been done yet.\n\n- **Objective:** Identify the parents of Patrick Flynn (b. ~1845, d. 1908)\n- **Questions:** none\n- **Plans:** none\n- **Log:** empty\n- **Sources:** none\n- **Assertions:** none\n- **GedcomX persons:** I1 (Patrick Flynn \u2014 stub, name only, no facts)\n- **GedcomX relationships:** none\n- **GedcomX sources:** none\n\n## Used by\n\n- `question-selection` tests where the skill must derive a first research question from the objective rather than choose from an existing question list.\n- `research-plan` tests where the skill must produce a plan for a question that has no prior search log.\n- Any skill whose behavior on a freshly-initialized project differs from mid-research behavior.\n\n## What this scenario tests boundary-wise\n\nA skill given this scenario should not pretend prior research exists. If it tries to read assertions, sources, or the log and they're empty, the right behavior is to reason from the objective + stub person alone, or to politely decline if it requires data that doesn't exist yet.\n",
+    "eval/fixtures/scenarios/empty-project-just-created/research.json": "{\n  \"assertions\": [],\n  \"conflicts\": [],\n  \"evaluations\": [],\n  \"hypotheses\": [],\n  \"log\": [],\n  \"person_evidence\": [],\n  \"plans\": [],\n  \"project\": {\n    \"created\": \"2026-05-13\",\n    \"id\": \"rp_001\",\n    \"objective\": \"Identify the parents of Patrick Flynn, born ca. 1845 in Pennsylvania, died 1908 in Schuylkill County, PA\",\n    \"status\": \"active\",\n    \"subject_person_ids\": [\n      \"I1\"\n    ],\n    \"updated\": \"2026-05-13\"\n  },\n  \"proof_summaries\": [],\n  \"questions\": [],\n  \"sources\": [],\n  \"timelines\": []\n}\n",
+    "eval/fixtures/scenarios/empty-project-just-created/tree.gedcomx.json": "{\n  \"persons\": [\n    {\n      \"gender\": \"Male\",\n      \"id\": \"I1\",\n      \"names\": [\n        {\n          \"given\": \"Patrick\",\n          \"id\": \"N1\",\n          \"preferred\": true,\n          \"surname\": \"Flynn\"\n        }\n      ]\n    }\n  ],\n  \"relationships\": [],\n  \"sources\": []\n}\n",
+    "eval/fixtures/scenarios/flynn-census-exhausted/README.md": "# flynn-census-exhausted\n\nPatrick Flynn parentage research. The first plan for q_001 is complete (1850 + 1860 census + 1908 death certificate searched, sources captured, assertions extracted, birthplace conflict resolved), but the question itself is still `in_progress` and the proof summary is at `probable` \u2014 there's no active plan describing what to search next.\n\nDiffers from `mid-research-flynn` in these ways:\n\n- **`plans[pl_002].status`:** `completed` (was `active`).\n- **`plans[pl_002].items`:** the probate item (`pli_006`) has been removed entirely \u2014 it was never part of pl_002 in this scenario; the dev hasn't decided what to search next yet.\n- **`questions[q_001].status`:** `in_progress` \u2014 same as `mid-research-flynn`.\n- **`proof_summaries[ps_001].tier`:** `probable` \u2014 same as `mid-research-flynn`.\n- **`conflicts[c_001]`:** resolved \u2014 same as `mid-research-flynn`.\n- **Everything else** (log, sources, assertions, person_evidence, hypotheses, timelines): identical to `mid-research-flynn`.\n\n## Used by\n\n- `research-plan` tests where the skill must propose a NEW plan for `q_001` after the existing plan has been completed. Plausible plan items: probate records for Thomas Flynn, 1870/1880/1900 censuses to track Patrick post-1860, FAN research on Schuylkill County neighbors, naturalization records, Irish emigration manifests (passenger lists record all passengers including infants and young children \u2014 the whole manifest should be examined for the complete family group, not just the parents).\n- `question-selection` tests asking \"what should I research next?\" when the active question's plan is complete but the question isn't fully resolved.\n- Boundary tests verifying that `research-plan` proposes additional research rather than declaring the question resolved on the strength of three census/vital sources alone.\n\n## Why census + death cert isn't enough for `proved`\n\nThree independent sources support the parentage conclusion but research isn't yet exhaustive: probate records have not been searched (the most direct positive evidence a will could provide), and the post-1860 censuses haven't been examined to confirm Patrick remained in the same household into adulthood. A genuine \"proved\" tier requires either positive probate evidence or evidence that exhaustive search was conducted and turned up nothing contradicting.\n",
+    "eval/fixtures/scenarios/flynn-census-exhausted/research.json": "{\n  \"assertions\": [\n    {\n      \"date\": null,\n      \"date_certainty\": null,\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_002\"\n      ],\n      \"fact_type\": \"name\",\n      \"id\": \"a_001\",\n      \"informant\": \"Unknown informant (most likely a household member, possibly a neighbor) reporting to census enumerator\",\n      \"informant_bias_notes\": \"Census enumerator is the recorder, not the informant. The person who provided the name is unknown \u2014 most likely a household member, possibly a neighbor. Proximity is 'unknown' rather than 'household_member' because for names specifically, the enumerator may have heard the name from a neighbor or made an assumption \u2014 the name fact doesn't necessarily require active reporting the way age/birthplace does.\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_001\",\n      \"place\": null,\n      \"record_id\": \"ark:/61903/1:1:MXYZ\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_001\",\n      \"structured_value\": {\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"value\": \"Patrick Flynn\"\n    },\n    {\n      \"date\": \"~1845\",\n      \"date_certainty\": \"estimated\",\n      \"evidence_type\": \"indirect\",\n      \"extracted_for_question_ids\": [\n        \"q_002\"\n      ],\n      \"fact_type\": \"birth\",\n      \"id\": \"a_002\",\n      \"informant\": \"Unknown \u2014 most likely a household member (such as Thomas Flynn or his wife), but possibly a neighbor\",\n      \"informant_bias_notes\": \"Age and birthplace require active reporting by an informant \u2014 someone had to tell the enumerator these facts. That informant was most likely a household member, but enumerators also took information from neighbors when residents were unavailable, and the census does not identify who answered. Proximity is 'unknown' because the informant cannot be established from the record.\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_001\",\n      \"place\": \"Ireland\",\n      \"record_id\": \"ark:/61903/1:1:MXYZ\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_001\",\n      \"structured_value\": {\n        \"place\": \"Ireland\",\n        \"year\": 1845\n      },\n      \"value\": \"age 5\"\n    },\n    {\n      \"date\": \"1850\",\n      \"date_certainty\": \"exact\",\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_002\"\n      ],\n      \"fact_type\": \"residence\",\n      \"id\": \"a_003\",\n      \"informant\": \"Census enumerator (witness to residence by visiting the dwelling)\",\n      \"informant_bias_notes\": \"For residence facts specifically, the enumerator is a direct witness \u2014 they physically visited the dwelling and recorded who lived there. This distinguishes residence from other census facts where an unidentified informant (most likely a household member, possibly a neighbor) supplied the information.\",\n      \"informant_proximity\": \"witness\",\n      \"information_quality\": \"primary\",\n      \"log_entry_id\": \"log_001\",\n      \"place\": \"Schuylkill County, Pennsylvania\",\n      \"record_id\": \"ark:/61903/1:1:MXYZ\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_001\",\n      \"value\": \"Schuylkill County, Pennsylvania\"\n    },\n    {\n      \"date\": \"1850\",\n      \"date_certainty\": \"exact\",\n      \"evidence_type\": \"indirect\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"relationship\",\n      \"id\": \"a_004\",\n      \"informant\": \"Inferred from household structure \u2014 no explicit informant for relationships in 1850 census\",\n      \"informant_bias_notes\": \"1850 census does not state relationships; this assertion is inferred from household position and shared surname, not directly reported by any informant. The relationship is indirect evidence constructed by the researcher, not information provided by a census informant.\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_001\",\n      \"place\": \"Schuylkill County, Pennsylvania\",\n      \"record_id\": \"ark:/61903/1:1:MXYZ\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_001\",\n      \"structured_value\": {\n        \"related_person_role\": \"head_of_household\",\n        \"relationship_type\": \"child_inferred\"\n      },\n      \"value\": \"Listed in household of Thomas Flynn (head), position consistent with child\"\n    },\n    {\n      \"date\": null,\n      \"date_certainty\": null,\n      \"evidence_type\": \"indirect\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"name\",\n      \"id\": \"a_005\",\n      \"informant\": \"Unknown informant (likely Thomas Flynn himself) reporting to census enumerator\",\n      \"informant_bias_notes\": \"Census enumerator is the recorder, not the informant. As head of household, Thomas likely provided his own name, but the 1850 census does not identify the informant.\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_001\",\n      \"place\": null,\n      \"record_id\": \"ark:/61903/1:1:MXYZ\",\n      \"record_role\": \"head_of_household\",\n      \"source_id\": \"src_001\",\n      \"value\": \"Thomas Flynn\"\n    },\n    {\n      \"date\": null,\n      \"date_certainty\": null,\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_002\"\n      ],\n      \"fact_type\": \"name\",\n      \"id\": \"a_006\",\n      \"informant\": \"Ancestry transcriber (derivative of census enumerator)\",\n      \"informant_bias_notes\": \"Derivative index \u2014 transcription errors possible\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_002\",\n      \"place\": null,\n      \"record_id\": \"ancestry:8054:patrick-flynn-1850\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_002\",\n      \"value\": \"Patrick Flynn\"\n    },\n    {\n      \"date\": \"~1845\",\n      \"date_certainty\": \"estimated\",\n      \"evidence_type\": \"indirect\",\n      \"extracted_for_question_ids\": [\n        \"q_002\"\n      ],\n      \"fact_type\": \"birth\",\n      \"id\": \"a_007\",\n      \"informant\": \"Ancestry transcriber (derivative)\",\n      \"informant_bias_notes\": null,\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_002\",\n      \"place\": \"Ireland\",\n      \"record_id\": \"ancestry:8054:patrick-flynn-1850\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_002\",\n      \"value\": \"age 5\"\n    },\n    {\n      \"date\": null,\n      \"date_certainty\": null,\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"name\",\n      \"id\": \"a_008\",\n      \"informant\": \"Unknown informant (most likely a household member, possibly a neighbor) reporting to census enumerator\",\n      \"informant_bias_notes\": \"Census enumerator is the recorder, not the informant. Proximity is 'unknown' for names (same reasoning as a_001 \u2014 name facts don't necessarily require active reporting).\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_004\",\n      \"place\": null,\n      \"record_id\": \"ark:/61903/1:1:MABC\",\n      \"record_role\": \"child_2\",\n      \"source_id\": \"src_003\",\n      \"value\": \"Patrick Flynn\"\n    },\n    {\n      \"date\": \"~1845\",\n      \"date_certainty\": \"estimated\",\n      \"evidence_type\": \"indirect\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"birth\",\n      \"id\": \"a_009\",\n      \"informant\": \"Unknown \u2014 most likely a household member (such as Thomas Flynn or his wife), but possibly a neighbor\",\n      \"informant_bias_notes\": \"Age and birthplace require active reporting by an informant \u2014 most likely a household member, possibly a neighbor (same reasoning as a_002).\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_004\",\n      \"place\": \"Ireland\",\n      \"record_id\": \"ark:/61903/1:1:MABC\",\n      \"record_role\": \"child_2\",\n      \"source_id\": \"src_003\",\n      \"value\": \"age 15\"\n    },\n    {\n      \"date\": \"1860\",\n      \"date_certainty\": \"exact\",\n      \"evidence_type\": \"indirect\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"relationship\",\n      \"id\": \"a_010\",\n      \"informant\": \"Inferred from household structure \u2014 no explicit informant for relationships in 1860 census\",\n      \"informant_bias_notes\": \"1860 census does not state relationships; like the 1850 census, this assertion is inferred from household position, age, and shared surname. The relationship column was not introduced until the 1880 census.\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_004\",\n      \"place\": \"Schuylkill County, Pennsylvania\",\n      \"record_id\": \"ark:/61903/1:1:MABC\",\n      \"record_role\": \"child_2\",\n      \"source_id\": \"src_003\",\n      \"structured_value\": {\n        \"related_person_role\": \"head_of_household\",\n        \"relationship_type\": \"child_inferred\"\n      },\n      \"value\": \"Listed in household of Thomas Flynn (head), position and age consistent with son\"\n    },\n    {\n      \"date\": \"1908-03-12\",\n      \"date_certainty\": \"exact\",\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [],\n      \"fact_type\": \"death\",\n      \"id\": \"a_011\",\n      \"informant\": \"Attending physician (signature on certificate)\",\n      \"informant_bias_notes\": null,\n      \"informant_proximity\": \"witness\",\n      \"information_quality\": \"primary\",\n      \"log_entry_id\": \"log_005\",\n      \"place\": \"Schuylkill County, Pennsylvania\",\n      \"record_id\": \"ark:/61903/1:1:MDEF\",\n      \"record_role\": \"deceased\",\n      \"source_id\": \"src_004\",\n      \"value\": \"Died 12 March 1908\"\n    },\n    {\n      \"date\": \"1845\",\n      \"date_certainty\": \"approximate\",\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"birth\",\n      \"id\": \"a_012\",\n      \"informant\": \"James Brown (son-in-law)\",\n      \"informant_bias_notes\": \"Son-in-law reporting birth facts decades after the event. Note: death cert says Pennsylvania, but census records say Ireland. Son-in-law may not have known Patrick was born in Ireland.\",\n      \"informant_proximity\": \"family_not_present\",\n      \"information_quality\": \"secondary\",\n      \"log_entry_id\": \"log_005\",\n      \"place\": \"Pennsylvania\",\n      \"record_id\": \"ark:/61903/1:1:MDEF\",\n      \"record_role\": \"deceased\",\n      \"source_id\": \"src_004\",\n      \"structured_value\": {\n        \"place\": \"Pennsylvania\",\n        \"year\": 1845\n      },\n      \"value\": \"Born 1845, Pennsylvania\"\n    },\n    {\n      \"date\": null,\n      \"date_certainty\": null,\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"relationship\",\n      \"id\": \"a_013\",\n      \"informant\": \"James Brown (son-in-law)\",\n      \"informant_bias_notes\": \"Secondary information \u2014 son-in-law reporting what he was told about father-in-law's parentage\",\n      \"informant_proximity\": \"family_not_present\",\n      \"information_quality\": \"secondary\",\n      \"log_entry_id\": \"log_005\",\n      \"place\": null,\n      \"record_id\": \"ark:/61903/1:1:MDEF\",\n      \"record_role\": \"deceased\",\n      \"source_id\": \"src_004\",\n      \"structured_value\": {\n        \"related_person_role\": \"deceased\",\n        \"relationship_type\": \"father\"\n      },\n      \"value\": \"Father: Thomas Flynn\"\n    }\n  ],\n  \"conflicts\": [\n    {\n      \"blocks_question_ids\": [],\n      \"competing_assertion_ids\": [\n        \"a_002\",\n        \"a_009\",\n        \"a_012\"\n      ],\n      \"conflict_type\": \"fact\",\n      \"description\": \"Patrick Flynn's birthplace: Ireland (1850 and 1860 censuses) vs. Pennsylvania (1908 death certificate)\",\n      \"disputed_attribute\": \"birthplace\",\n      \"id\": \"c_001\",\n      \"identity_question\": null,\n      \"independence_analysis\": \"The two census records (1850, 1860) are independent original sources with different enumerators. The death certificate is a third independent original source. However, the census informants are likely the same household member (Thomas Flynn or wife), so the two census assertions may share a single informant \u2014 potentially not fully independent for this fact.\",\n      \"preferred_assertion_id\": \"a_002\",\n      \"resolution_rationale\": \"Ireland is accepted as the birthplace. The 1908 death certificate birthplace of 'Pennsylvania' is rejected as a likely error by the son-in-law informant, who may have confused Patrick's place of residence with his place of birth, or may not have known Patrick was born in Ireland before immigrating as a young child.\",\n      \"status\": \"resolved\",\n      \"weighing_analysis\": \"The census records are contemporary recordings made near the time of Patrick's birth, while the death certificate was created 63 years later. The census informant was likely a household member with firsthand knowledge (primary or indeterminate), while the death certificate informant (son-in-law) is clearly secondary for birth facts. Two contemporary sources outweigh one later recollection by a secondary informant.\"\n    }\n  ],\n  \"evaluations\": [],\n  \"hypotheses\": [],\n  \"log\": [\n    {\n      \"external_site\": null,\n      \"id\": \"log_001\",\n      \"notes\": \"Found Patrick Flynn age 5 in household of Thomas Flynn, dwelling 84, Schuylkill Co. Three other Flynn results examined \u2014 ages and locations don't match.\",\n      \"outcome\": \"positive\",\n      \"performed\": \"2026-05-01T10:15:00Z\",\n      \"plan_item_id\": \"pli_001\",\n      \"query\": {\n        \"birth_place\": \"Pennsylvania\",\n        \"birth_year\": 1845,\n        \"collection\": \"1850 Census\",\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"results_examined\": 8,\n      \"tool\": \"record_search\"\n    },\n    {\n      \"external_site\": {\n        \"capture_filename\": \"ancestry-1850-flynn-results.pdf\",\n        \"capture_received\": true,\n        \"site\": \"ancestry\",\n        \"url_generated\": \"https://www.ancestry.com/search/collections/8054/?name=Patrick_Flynn&birth=1845&birthplace=Pennsylvania\"\n      },\n      \"id\": \"log_002\",\n      \"notes\": \"Ancestry index confirms same household. Transcription matches FamilySearch except Ancestry reads dwelling as 84, FamilySearch as 84 \u2014 consistent.\",\n      \"outcome\": \"positive\",\n      \"performed\": \"2026-05-01T11:30:00Z\",\n      \"plan_item_id\": \"pli_002\",\n      \"query\": {\n        \"birth_place\": \"Pennsylvania\",\n        \"birth_year\": 1845,\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"results_examined\": 12,\n      \"tool\": \"external_site\"\n    },\n    {\n      \"external_site\": {\n        \"capture_filename\": \"myheritage-1850-flynn-nil.pdf\",\n        \"capture_received\": true,\n        \"site\": \"myheritage\",\n        \"url_generated\": \"https://www.myheritage.com/research?action=query&first=Patrick&last=Flynn&birth_year=1845&birth_place=Pennsylvania\"\n      },\n      \"id\": \"log_003\",\n      \"notes\": \"MyHeritage returned no results for Patrick Flynn in 1850 Schuylkill County. Site may not have this collection indexed. Searched broader Pennsylvania \u2014 still no match.\",\n      \"outcome\": \"negative\",\n      \"performed\": \"2026-05-01T14:00:00Z\",\n      \"plan_item_id\": \"pli_003\",\n      \"query\": {\n        \"birth_place\": \"Pennsylvania\",\n        \"birth_year\": 1845,\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"results_examined\": 0,\n      \"tool\": \"external_site\"\n    },\n    {\n      \"external_site\": null,\n      \"id\": \"log_004\",\n      \"notes\": \"Patrick Flynn age 15 in household of Thomas Flynn, Schuylkill Co. Consistent with 1850 placement.\",\n      \"outcome\": \"positive\",\n      \"performed\": \"2026-05-02T09:00:00Z\",\n      \"plan_item_id\": \"pli_004\",\n      \"query\": {\n        \"birth_place\": \"Pennsylvania\",\n        \"birth_year\": 1845,\n        \"collection\": \"1860 Census\",\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"results_examined\": 5,\n      \"tool\": \"record_search\"\n    },\n    {\n      \"external_site\": null,\n      \"id\": \"log_005\",\n      \"notes\": \"Death certificate found. Names Thomas Flynn as father. Informant was son-in-law James Brown.\",\n      \"outcome\": \"positive\",\n      \"performed\": \"2026-05-03T10:00:00Z\",\n      \"plan_item_id\": \"pli_005\",\n      \"query\": {\n        \"death_place\": \"Schuylkill County, Pennsylvania\",\n        \"death_year\": 1908,\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"results_examined\": 2,\n      \"tool\": \"record_search\"\n    },\n    {\n      \"external_site\": null,\n      \"id\": \"log_006\",\n      \"notes\": \"Searched Schuylkill County Register of Wills on FamilySearch for Thomas Flynn, 1870\u20131900. No probate record found. Thomas Flynn may have died intestate, died outside Schuylkill County, or his records did not survive.\",\n      \"outcome\": \"negative\",\n      \"performed\": \"2026-05-05T09:00:00Z\",\n      \"plan_item_id\": \"pli_006\",\n      \"query\": {\n        \"collection\": \"Probate Records\",\n        \"given\": \"Thomas\",\n        \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n        \"surname\": \"Flynn\"\n      },\n      \"results_examined\": 0,\n      \"tool\": \"record_search\"\n    }\n  ],\n  \"person_evidence\": [\n    {\n      \"assertion_id\": \"a_001\",\n      \"confidence\": \"confident\",\n      \"created\": \"2026-05-01\",\n      \"id\": \"pe_001\",\n      \"match_score\": null,\n      \"person_id\": \"I1\",\n      \"rationale\": \"Name matches (Patrick Flynn), age consistent with ~1845 birth, located in Schuylkill County where subject is known to have lived. Only Patrick Flynn of this age in the county in 1850.\",\n      \"superseded_by\": null\n    },\n    {\n      \"assertion_id\": \"a_004\",\n      \"confidence\": \"probable\",\n      \"created\": \"2026-05-01\",\n      \"id\": \"pe_002\",\n      \"match_score\": null,\n      \"person_id\": \"I1\",\n      \"rationale\": \"Same record as pe_001, same person. Household position and shared surname with head Thomas Flynn suggest parent-child relationship, but 1850 census does not state relationships explicitly.\",\n      \"superseded_by\": null\n    },\n    {\n      \"assertion_id\": \"a_004\",\n      \"confidence\": \"probable\",\n      \"created\": \"2026-05-01\",\n      \"id\": \"pe_006\",\n      \"match_score\": null,\n      \"person_id\": \"I2\",\n      \"rationale\": \"Same assertion as pe_002 but linked to Thomas Flynn (I2). The relationship assertion ('position consistent with child') equally bears on the head of household. Thomas Flynn is the other party in the implied parent-child relationship.\",\n      \"superseded_by\": null\n    },\n    {\n      \"assertion_id\": \"a_005\",\n      \"confidence\": \"probable\",\n      \"created\": \"2026-05-01\",\n      \"id\": \"pe_003\",\n      \"match_score\": 0.82,\n      \"person_id\": \"I2\",\n      \"rationale\": \"Thomas Flynn, head of household where Patrick was found. Age (~32 in 1850, born ~1818) is consistent with being Patrick's father. Name matches candidate father.\",\n      \"superseded_by\": null\n    },\n    {\n      \"assertion_id\": \"a_010\",\n      \"confidence\": \"confident\",\n      \"created\": \"2026-05-02\",\n      \"id\": \"pe_004\",\n      \"match_score\": null,\n      \"person_id\": \"I1\",\n      \"rationale\": \"Patrick Flynn age 15 in Thomas Flynn household, 1860 census. Same county, age consistent with 1850 enumeration. Relationship inferred from household position and shared surname (1860 census does not state relationships explicitly).\",\n      \"superseded_by\": null\n    },\n    {\n      \"assertion_id\": \"a_013\",\n      \"confidence\": \"confident\",\n      \"created\": \"2026-05-03\",\n      \"id\": \"pe_005\",\n      \"match_score\": null,\n      \"person_id\": \"I1\",\n      \"rationale\": \"Death certificate for Patrick Flynn, d. 1908, Schuylkill County. Names match, death location matches known residence. Names Thomas Flynn as father.\",\n      \"superseded_by\": null\n    }\n  ],\n  \"plans\": [\n    {\n      \"created\": \"2026-05-01\",\n      \"id\": \"pl_001\",\n      \"items\": [\n        {\n          \"date_range\": \"1850\",\n          \"fallback_for\": null,\n          \"id\": \"pli_001\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"1850 census fully indexed on FamilySearch. Free access, start here.\",\n          \"record_type\": \"census\",\n          \"repository\": \"FamilySearch\",\n          \"sequence\": 1,\n          \"status\": \"completed\"\n        },\n        {\n          \"date_range\": \"1850\",\n          \"fallback_for\": null,\n          \"id\": \"pli_002\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"Ancestry has independent indexing; cross-check for transcription errors.\",\n          \"record_type\": \"census\",\n          \"repository\": \"Ancestry\",\n          \"sequence\": 2,\n          \"status\": \"completed\"\n        },\n        {\n          \"date_range\": \"1850\",\n          \"fallback_for\": null,\n          \"id\": \"pli_003\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"Third independent index for coverage confirmation.\",\n          \"record_type\": \"census\",\n          \"repository\": \"MyHeritage\",\n          \"sequence\": 3,\n          \"status\": \"completed\"\n        }\n      ],\n      \"question_id\": \"q_002\",\n      \"status\": \"completed\"\n    },\n    {\n      \"created\": \"2026-05-02\",\n      \"id\": \"pl_002\",\n      \"items\": [\n        {\n          \"date_range\": \"1860\",\n          \"fallback_for\": null,\n          \"id\": \"pli_004\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"Confirm Patrick still in Thomas Flynn household in 1860. Strengthens parent-child identification.\",\n          \"record_type\": \"census\",\n          \"repository\": \"FamilySearch\",\n          \"sequence\": 1,\n          \"status\": \"completed\"\n        },\n        {\n          \"date_range\": \"1908\",\n          \"fallback_for\": null,\n          \"id\": \"pli_005\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"Death certificate may name parents directly.\",\n          \"record_type\": \"vital_record\",\n          \"repository\": \"FamilySearch\",\n          \"sequence\": 2,\n          \"status\": \"completed\"\n        },\n        {\n          \"date_range\": \"1870-1900\",\n          \"fallback_for\": null,\n          \"id\": \"pli_006\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"Thomas Flynn's will or probate record would name his children directly, providing primary-quality evidence for the parentage hypothesis.\",\n          \"record_type\": \"probate\",\n          \"repository\": \"FamilySearch\",\n          \"sequence\": 3,\n          \"status\": \"completed\"\n        }\n      ],\n      \"question_id\": \"q_001\",\n      \"status\": \"completed\"\n    }\n  ],\n  \"project\": {\n    \"created\": \"2026-05-01\",\n    \"id\": \"rp_001\",\n    \"objective\": \"Identify the parents of Patrick Flynn, born ca. 1845 in Pennsylvania, died 1908 in Schuylkill County, PA\",\n    \"status\": \"active\",\n    \"subject_person_ids\": [\n      \"I1\"\n    ],\n    \"updated\": \"2026-05-04\"\n  },\n  \"proof_summaries\": [\n    {\n      \"exhaustive_search_summary\": \"Searched 1850 census (FamilySearch, Ancestry, MyHeritage \u2014 log_001, log_002, log_003), 1860 census (FamilySearch \u2014 log_004), death certificate (FamilySearch \u2014 log_005), and probate records Schuylkill County 1870\u20131900 (FamilySearch \u2014 log_006, negative). 1870, 1880, and 1900 censuses not yet searched \u2014 this is the primary remaining gap.\",\n      \"id\": \"ps_001\",\n      \"narrative_markdown\": \"## Parentage of Patrick Flynn (ca. 1845\u20131908)\\n\\nPatrick Flynn is **Probably** the son of Thomas Flynn of Schuylkill County, Pennsylvania.\\n\\n### Evidence Summary\\n\\nThree independent lines of evidence support this conclusion:\\n\\n1. **1850 U.S. Census** (Original Source). Patrick Flynn, age 5, born Ireland, appears in the household of Thomas Flynn, age 32, born Ireland, in Schuylkill County, Pennsylvania (dwelling 84, family 91). The 1850 census does not state relationships, but Patrick's position in the household and shared surname are consistent with a parent-child relationship. The informant is indeterminate but likely a household member. This constitutes indirect evidence of parentage.\\n\\n2. **1860 U.S. Census** (Original Source). Patrick Flynn, age 15, born Ireland, appears in the household of Thomas Flynn in Schuylkill County (dwelling 112, family 119). Like the 1850 census, the 1860 census does not state relationships explicitly (the relationship column was not introduced until 1880). Patrick's position in the household, shared surname, and age consistent with the 1850 enumeration support a parent-child relationship. This constitutes indirect evidence of parentage.\\n\\n3. **1908 Death Certificate** (Original Source). Patrick Flynn's death certificate (no. 4521, Pennsylvania Department of Health) names \\\"Thomas Flynn\\\" as his father. The informant was James Brown, identified as Patrick's son-in-law. As a son-in-law reporting his father-in-law's parentage, Brown is a secondary informant for this fact \u2014 he was not a witness to Patrick's birth and is reporting what he was told. Nevertheless, this is direct evidence naming the father.\\n\\n### Conflict Resolution\\n\\nA birthplace conflict exists: the 1850 and 1860 censuses list Patrick's birthplace as Ireland, while the 1908 death certificate states Pennsylvania. The two census records are contemporary recordings with informants likely present in the household, while the death certificate was created 63 years after Patrick's birth by a son-in-law with no firsthand knowledge of the event. Per the GPS preponderance hierarchy, contemporary recordings by closer informants outweigh later recollections by secondary informants. Ireland is accepted as the birthplace; the death certificate entry is attributed to informant error.\\n\\n### Assessment\\n\\nThe conclusion is rated **Probable** rather than **Proved** because: (a) both census sources (1850 and 1860) provide only indirect evidence of parentage (relationships not stated \u2014 the relationship column was not introduced until 1880), (b) the death certificate informant is secondary, and (c) research is not yet exhaustive \u2014 the 1870, 1880, and 1900 censuses have not been searched, and Thomas Flynn's probate records have not been located. If Thomas Flynn's will names Patrick as a son, or if additional census records confirm the relationship, the conclusion would advance to **Proved**.\\n\\n### Citations\\n\\n1. 1850 U.S. Census, Schuylkill County, Pennsylvania, population schedule, dwelling 84, family 91, Thomas Flynn household; NARA microfilm publication M432, roll 810; digital image, FamilySearch.org, accessed 1 May 2026.\\n2. 1860 U.S. Census, Schuylkill County, Pennsylvania, population schedule, dwelling 112, family 119, Thomas Flynn household; NARA microfilm publication M653, roll 1141; digital image, FamilySearch.org, accessed 2 May 2026.\\n3. Pennsylvania Department of Health, death certificate no. 4521 (1908), Patrick Flynn; Pennsylvania State Archives, Harrisburg; digital image, FamilySearch.org, accessed 3 May 2026.\",\n      \"question_id\": \"q_001\",\n      \"resolved_conflict_ids\": [\n        \"c_001\"\n      ],\n      \"supporting_assertion_ids\": [\n        \"a_004\",\n        \"a_010\",\n        \"a_013\"\n      ],\n      \"tier\": \"probable\",\n      \"vehicle\": \"summary\"\n    }\n  ],\n  \"questions\": [\n    {\n      \"created\": \"2026-05-01\",\n      \"depends_on\": [],\n      \"exhaustive_declaration\": {\n        \"declared\": false,\n        \"justification\": null,\n        \"log_entry_ids\": [],\n        \"stop_criteria\": null\n      },\n      \"id\": \"q_001\",\n      \"priority\": \"high\",\n      \"question\": \"Who were the parents of Patrick Flynn (b. ~1845, PA, d. 1908)?\",\n      \"rationale\": \"This is the primary research objective.\",\n      \"resolution_assertion_ids\": [],\n      \"resolved\": null,\n      \"selection_basis\": \"objective_decomposition\",\n      \"status\": \"in_progress\",\n      \"unblocks\": []\n    },\n    {\n      \"created\": \"2026-05-01\",\n      \"depends_on\": [],\n      \"exhaustive_declaration\": {\n        \"declared\": true,\n        \"justification\": \"Searched 1850 census for Schuylkill County on FamilySearch (indexed and browse), Ancestry (indexed), and MyHeritage (indexed). All three returned the same household. No other Patrick Flynn of matching age found in the county.\",\n        \"log_entry_ids\": [\n          \"log_001\",\n          \"log_002\",\n          \"log_003\"\n        ],\n        \"stop_criteria\": {\n          \"conflict_resolution\": \"No conflicts on the 1850 census placement question.\",\n          \"evidence_class\": \"Yes \u2014 FamilySearch provides original census image with indeterminate-quality information.\",\n          \"goal_alignment\": \"Yes \u2014 Patrick Flynn located in a specific 1850 household, answering the question.\",\n          \"independent_verification\": \"FamilySearch (original) and Ancestry (derivative) both return the same household. Two access paths, one underlying original.\",\n          \"original_substitution\": \"FamilySearch provides the original census image; Ancestry index is derivative but confirmed consistent.\",\n          \"overturn_risk\": \"Low \u2014 all three repositories agree, and no competing Patrick Flynn of matching age exists in the county.\",\n          \"repository_breadth\": \"Three major repositories searched (FamilySearch, Ancestry, MyHeritage). No additional known indexes of the 1850 Schuylkill County census exist.\"\n        }\n      },\n      \"id\": \"q_002\",\n      \"priority\": \"high\",\n      \"question\": \"Where was Patrick Flynn in the 1850 census?\",\n      \"rationale\": \"The 1850 census is the earliest enumeration where Patrick would appear by name (age ~5). Locating him in a household identifies candidate parents.\",\n      \"resolution_assertion_ids\": [\n        \"a_001\",\n        \"a_002\",\n        \"a_003\"\n      ],\n      \"resolved\": \"2026-05-02\",\n      \"selection_basis\": \"objective_decomposition\",\n      \"status\": \"resolved\",\n      \"unblocks\": [\n        \"q_001\"\n      ]\n    }\n  ],\n  \"sources\": [\n    {\n      \"access_date\": \"2026-05-01\",\n      \"citation\": \"1850 U.S. Census, Schuylkill County, Pennsylvania, population schedule, dwelling 84, family 91, Thomas Flynn household; NARA microfilm publication M432, roll 810; digital image, FamilySearch.org, accessed 1 May 2026.\",\n      \"citation_detail\": {\n        \"what\": \"1850 U.S. Federal Census, population schedule\",\n        \"when_accessed\": \"2026-05-01\",\n        \"when_created\": \"1850\",\n        \"where\": \"FamilySearch.org (NARA microfilm M432, roll 810)\",\n        \"where_within\": \"Schuylkill County, dwelling 84, family 91\",\n        \"who\": \"U.S. Census Bureau\"\n      },\n      \"gedcomx_source_description_id\": \"S1\",\n      \"id\": \"src_001\",\n      \"log_entry_id\": \"log_001\",\n      \"notes\": \"Image quality good. Enumerator handwriting clear.\",\n      \"repository\": \"FamilySearch\",\n      \"source_classification\": \"original\",\n      \"url\": \"https://www.familysearch.org/ark:/61903/1:1:MXYZ\",\n      \"url_archived\": null\n    },\n    {\n      \"access_date\": \"2026-05-01\",\n      \"citation\": \"1850 U.S. Census, Schuylkill County, Pennsylvania, population schedule, dwelling 84, Thomas Flynn household; digital image, Ancestry.com, accessed 1 May 2026.\",\n      \"citation_detail\": {\n        \"what\": \"1850 U.S. Federal Census, population schedule (Ancestry index)\",\n        \"when_accessed\": \"2026-05-01\",\n        \"when_created\": \"1850\",\n        \"where\": \"Ancestry.com\",\n        \"where_within\": \"Schuylkill County, dwelling 84\",\n        \"who\": \"U.S. Census Bureau\"\n      },\n      \"gedcomx_source_description_id\": \"S1\",\n      \"id\": \"src_002\",\n      \"log_entry_id\": \"log_002\",\n      \"notes\": \"Ancestry's index of the same original census. Transcription consistent with FamilySearch.\",\n      \"repository\": \"Ancestry\",\n      \"source_classification\": \"derivative\",\n      \"url\": null,\n      \"url_archived\": null\n    },\n    {\n      \"access_date\": \"2026-05-02\",\n      \"citation\": \"1860 U.S. Census, Schuylkill County, Pennsylvania, population schedule, dwelling 112, family 119, Thomas Flynn household; NARA microfilm publication M653, roll 1141; digital image, FamilySearch.org, accessed 2 May 2026.\",\n      \"citation_detail\": {\n        \"what\": \"1860 U.S. Federal Census, population schedule\",\n        \"when_accessed\": \"2026-05-02\",\n        \"when_created\": \"1860\",\n        \"where\": \"FamilySearch.org (NARA microfilm M653, roll 1141)\",\n        \"where_within\": \"Schuylkill County, dwelling 112, family 119\",\n        \"who\": \"U.S. Census Bureau\"\n      },\n      \"gedcomx_source_description_id\": \"S2\",\n      \"id\": \"src_003\",\n      \"log_entry_id\": \"log_004\",\n      \"notes\": null,\n      \"repository\": \"FamilySearch\",\n      \"source_classification\": \"original\",\n      \"url\": \"https://www.familysearch.org/ark:/61903/1:1:MABC\",\n      \"url_archived\": null\n    },\n    {\n      \"access_date\": \"2026-05-03\",\n      \"citation\": \"Pennsylvania Department of Health, death certificate no. 4521 (1908), Patrick Flynn; Pennsylvania State Archives, Harrisburg; digital image, FamilySearch.org, accessed 3 May 2026.\",\n      \"citation_detail\": {\n        \"what\": \"Death certificate no. 4521\",\n        \"when_accessed\": \"2026-05-03\",\n        \"when_created\": \"1908-03-14\",\n        \"where\": \"FamilySearch.org (Pennsylvania State Archives, Harrisburg)\",\n        \"where_within\": \"Certificate no. 4521\",\n        \"who\": \"Pennsylvania Department of Health; informant: James Brown (son-in-law)\"\n      },\n      \"gedcomx_source_description_id\": \"S3\",\n      \"id\": \"src_004\",\n      \"log_entry_id\": \"log_005\",\n      \"notes\": \"Informant is son-in-law James Brown. Primary for death facts, secondary for birth facts.\",\n      \"repository\": \"FamilySearch\",\n      \"source_classification\": \"original\",\n      \"url\": \"https://www.familysearch.org/ark:/61903/1:1:MDEF\",\n      \"url_archived\": null\n    }\n  ],\n  \"timelines\": [\n    {\n      \"events\": [\n        {\n          \"assertion_ids\": [\n            \"a_002\",\n            \"a_009\"\n          ],\n          \"date\": \"~1845\",\n          \"date_certainty\": \"estimated\",\n          \"description\": \"Born in Ireland, estimated from census ages\",\n          \"event_type\": \"birth\",\n          \"place\": \"Ireland\"\n        },\n        {\n          \"assertion_ids\": [\n            \"a_003\",\n            \"a_004\"\n          ],\n          \"date\": \"1850\",\n          \"date_certainty\": \"exact\",\n          \"description\": \"Enumerated age 5 in Thomas Flynn household, dwelling 84\",\n          \"event_type\": \"census\",\n          \"place\": \"Schuylkill County, Pennsylvania\"\n        },\n        {\n          \"assertion_ids\": [\n            \"a_008\",\n            \"a_009\",\n            \"a_010\"\n          ],\n          \"date\": \"1860\",\n          \"date_certainty\": \"exact\",\n          \"description\": \"Enumerated age 15 in Thomas Flynn household, dwelling 112\",\n          \"event_type\": \"census\",\n          \"place\": \"Schuylkill County, Pennsylvania\"\n        },\n        {\n          \"assertion_ids\": [\n            \"a_011\",\n            \"a_013\"\n          ],\n          \"date\": \"1908-03-12\",\n          \"date_certainty\": \"exact\",\n          \"description\": \"Died, death certificate names Thomas Flynn as father\",\n          \"event_type\": \"death\",\n          \"place\": \"Schuylkill County, Pennsylvania\"\n        }\n      ],\n      \"gaps\": [\n        {\n          \"end\": \"1908-03-12\",\n          \"expected_events\": [\n            \"marriage\",\n            \"1870_census\",\n            \"1880_census\",\n            \"1900_census\",\n            \"residence\",\n            \"occupation\"\n          ],\n          \"severity\": \"high\",\n          \"start\": \"1860-01-01\"\n        }\n      ],\n      \"generated\": \"2026-05-03T12:00:00Z\",\n      \"hypothesis_id\": null,\n      \"id\": \"t_001\",\n      \"impossibilities\": [],\n      \"label\": \"Patrick Flynn\",\n      \"person_ids\": [\n        \"I1\"\n      ]\n    }\n  ]\n}\n",
+    "eval/fixtures/scenarios/flynn-census-exhausted/tree.gedcomx.json": "{\n  \"persons\": [\n    {\n      \"facts\": [\n        {\n          \"date\": \"~1845\",\n          \"id\": \"F1\",\n          \"place\": \"Ireland\",\n          \"primary\": true,\n          \"sources\": [\n            {\n              \"page\": \"1850 Census, Schuylkill Co., dwelling 84\",\n              \"ref\": \"S1\"\n            }\n          ],\n          \"type\": \"Birth\"\n        },\n        {\n          \"date\": \"1908-03-12\",\n          \"id\": \"F2\",\n          \"place\": \"Schuylkill County, Pennsylvania\",\n          \"sources\": [\n            {\n              \"page\": \"Death cert. no. 4521\",\n              \"ref\": \"S3\"\n            }\n          ],\n          \"type\": \"Death\"\n        }\n      ],\n      \"gender\": \"Male\",\n      \"id\": \"I1\",\n      \"names\": [\n        {\n          \"given\": \"Patrick\",\n          \"id\": \"N1\",\n          \"preferred\": true,\n          \"surname\": \"Flynn\",\n          \"type\": \"BirthName\"\n        }\n      ]\n    },\n    {\n      \"facts\": [\n        {\n          \"date\": \"~1818\",\n          \"id\": \"F3\",\n          \"place\": \"Ireland\",\n          \"primary\": true,\n          \"type\": \"Birth\"\n        }\n      ],\n      \"gender\": \"Male\",\n      \"id\": \"I2\",\n      \"names\": [\n        {\n          \"given\": \"Thomas\",\n          \"id\": \"N2\",\n          \"preferred\": true,\n          \"surname\": \"Flynn\",\n          \"type\": \"BirthName\"\n        }\n      ]\n    }\n  ],\n  \"relationships\": [\n    {\n      \"child\": \"I1\",\n      \"id\": \"R1\",\n      \"parent\": \"I2\",\n      \"sources\": [\n        {\n          \"page\": \"1850 Census, Schuylkill Co., dwelling 84\",\n          \"quality\": 2,\n          \"ref\": \"S1\"\n        },\n        {\n          \"page\": \"1860 Census, Schuylkill Co., dwelling 112\",\n          \"quality\": 2,\n          \"ref\": \"S2\"\n        },\n        {\n          \"page\": \"Death cert. no. 4521\",\n          \"quality\": 2,\n          \"ref\": \"S3\"\n        }\n      ],\n      \"type\": \"ParentChild\"\n    }\n  ],\n  \"sources\": [\n    {\n      \"author\": \"U.S. Census Bureau\",\n      \"id\": \"S1\",\n      \"title\": \"1850 U.S. Federal Census\"\n    },\n    {\n      \"author\": \"U.S. Census Bureau\",\n      \"id\": \"S2\",\n      \"title\": \"1860 U.S. Federal Census\"\n    },\n    {\n      \"author\": \"Pennsylvania Dept. of Health\",\n      \"id\": \"S3\",\n      \"title\": \"Pennsylvania Death Certificates\"\n    },\n    {\n      \"author\": \"Schuylkill County Register of Wills\",\n      \"id\": \"S4\",\n      \"title\": \"Schuylkill County Probate Records\"\n    }\n  ]\n}\n",
+    "eval/fixtures/scenarios/flynn-fan-pivot/README.md": "# flynn-fan-pivot\n\nPatrick Flynn parentage research \u2014 all direct evidence searches exhausted, question still unresolved. Built for question-selection tests where FAN pivot (Priority 6) is the correct next step.\n\nExtends `flynn-census-exhausted` by adding completed negative searches of the 1870, 1880, and 1900 censuses. The timeline gap from 1860\u20131908 has now been fully investigated \u2014 Patrick Flynn was not found in any post-1860 census record in Schuylkill County or adjacent Pennsylvania counties. The proof summary remains at `probable`; no additional direct evidence has been located.\n\n## State\n\n- **Objective:** Identify the parents of Patrick Flynn (b. ~1845, d. 1908)\n- **Questions:** q_001 (parentage, in_progress), q_002 (1850 census placement, resolved)\n- **Plans:** pl_001 (1850 census, completed), pl_002 (parentage evidence, completed \u2014 1860 census + death cert + 1870/1880/1900 census negative searches)\n- **Log:** 8 entries \u2014 1850 \u00d73, 1860, death cert, 1870 negative, 1880 negative, 1900 negative\n- **Timeline:** Patrick documented 1845 (birth), 1850 census, 1860 census, 1908 death. 1870/1880/1900 searched \u2014 not found. Gap remains but has been investigated.\n- **Gaps:** Low-severity remaining gap (marriage, occupation, church records) \u2014 census-year gap has been searched\n- **Proof summary:** `probable`\n\n## Differs from `flynn-census-exhausted`\n\n- **`plans[pl_002].items`:** Adds `pli_006`, `pli_007`, `pli_008` (1870, 1880, 1900 census searches, all completed)\n- **`log`:** Adds `log_006`, `log_007`, `log_008` (1870, 1880, 1900 census searches, all negative)\n- **`timelines[t_001].gaps`:** Census-year events removed from `expected_events`; severity downgraded to `low` since those years have been searched\n- **`proof_summaries[ps_001].exhaustive_search_summary`:** Updated to mention the three additional negative census searches\n\n## Used by\n\n- `question-selection` tests where FAN pivot is the correct next step \u2014 all planned direct searches are complete and unresolved, making associates/neighbors research the highest-value next action.\n- Tests verifying that Priority 6 (fan_pivot) fires correctly after direct evidence is exhausted.\n",
+    "eval/fixtures/scenarios/flynn-fan-pivot/research.json": "{\n  \"assertions\": [\n    {\n      \"date\": null,\n      \"date_certainty\": null,\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_002\"\n      ],\n      \"fact_type\": \"name\",\n      \"id\": \"a_001\",\n      \"informant\": \"Unknown informant (most likely a household member) reporting to census enumerator\",\n      \"informant_bias_notes\": \"Census enumerator is the recorder, not the informant.\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_001\",\n      \"place\": null,\n      \"record_id\": \"ark:/61903/1:1:MXYZ\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_001\",\n      \"structured_value\": {\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"value\": \"Patrick Flynn\"\n    },\n    {\n      \"date\": \"~1845\",\n      \"date_certainty\": \"estimated\",\n      \"evidence_type\": \"indirect\",\n      \"extracted_for_question_ids\": [\n        \"q_002\"\n      ],\n      \"fact_type\": \"birth\",\n      \"id\": \"a_002\",\n      \"informant\": \"Unknown \u2014 most likely a household member\",\n      \"informant_bias_notes\": \"Age and birthplace require active reporting by an informant.\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_001\",\n      \"place\": \"Ireland\",\n      \"record_id\": \"ark:/61903/1:1:MXYZ\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_001\",\n      \"structured_value\": {\n        \"place\": \"Ireland\",\n        \"year\": 1845\n      },\n      \"value\": \"age 5\"\n    },\n    {\n      \"date\": \"1850\",\n      \"date_certainty\": \"exact\",\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_002\"\n      ],\n      \"fact_type\": \"residence\",\n      \"id\": \"a_003\",\n      \"informant\": \"Census enumerator (witness to residence by visiting the dwelling)\",\n      \"informant_bias_notes\": \"For residence facts, the enumerator is a direct witness.\",\n      \"informant_proximity\": \"witness\",\n      \"information_quality\": \"primary\",\n      \"log_entry_id\": \"log_001\",\n      \"place\": \"Schuylkill County, Pennsylvania\",\n      \"record_id\": \"ark:/61903/1:1:MXYZ\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_001\",\n      \"structured_value\": null,\n      \"value\": \"Schuylkill County, Pennsylvania\"\n    },\n    {\n      \"date\": \"1850\",\n      \"date_certainty\": \"exact\",\n      \"evidence_type\": \"indirect\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"relationship\",\n      \"id\": \"a_004\",\n      \"informant\": \"Inferred from household structure\",\n      \"informant_bias_notes\": \"1850 census does not state relationships; inferred from household position and shared surname.\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_001\",\n      \"place\": \"Schuylkill County, Pennsylvania\",\n      \"record_id\": \"ark:/61903/1:1:MXYZ\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_001\",\n      \"structured_value\": {\n        \"related_person_role\": \"head_of_household\",\n        \"relationship_type\": \"child_inferred\"\n      },\n      \"value\": \"Listed in household of Thomas Flynn (head), position consistent with child\"\n    },\n    {\n      \"date\": \"1860\",\n      \"date_certainty\": \"exact\",\n      \"evidence_type\": \"indirect\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"relationship\",\n      \"id\": \"a_005\",\n      \"informant\": \"Inferred from household structure\",\n      \"informant_bias_notes\": \"1860 census does not state relationships.\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_004\",\n      \"place\": \"Schuylkill County, Pennsylvania\",\n      \"record_id\": \"ark:/61903/1:1:MABC\",\n      \"record_role\": \"child_2\",\n      \"source_id\": \"src_003\",\n      \"structured_value\": {\n        \"related_person_role\": \"head_of_household\",\n        \"relationship_type\": \"child_inferred\"\n      },\n      \"value\": \"Listed in household of Thomas Flynn (head), position and age consistent with son\"\n    },\n    {\n      \"date\": null,\n      \"date_certainty\": null,\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"relationship\",\n      \"id\": \"a_006\",\n      \"informant\": \"James Brown (son-in-law)\",\n      \"informant_bias_notes\": \"Secondary information \u2014 son-in-law reporting parentage.\",\n      \"informant_proximity\": \"family_not_present\",\n      \"information_quality\": \"secondary\",\n      \"log_entry_id\": \"log_005\",\n      \"place\": null,\n      \"record_id\": \"ark:/61903/1:1:MDEF\",\n      \"record_role\": \"deceased\",\n      \"source_id\": \"src_004\",\n      \"structured_value\": {\n        \"related_person_role\": \"deceased\",\n        \"relationship_type\": \"father\"\n      },\n      \"value\": \"Father: Thomas Flynn\"\n    }\n  ],\n  \"conflicts\": [\n    {\n      \"blocks_question_ids\": [],\n      \"competing_assertion_ids\": [\n        \"a_002\",\n        \"a_006\"\n      ],\n      \"conflict_type\": \"fact\",\n      \"description\": \"Patrick Flynn's birthplace: Ireland (1850 and 1860 censuses) vs. Pennsylvania (1908 death certificate)\",\n      \"disputed_attribute\": \"birthplace\",\n      \"id\": \"c_001\",\n      \"identity_question\": null,\n      \"independence_analysis\": \"The two census records are independent originals. The death certificate is a third independent original. However, census informants are likely the same household member.\",\n      \"preferred_assertion_id\": \"a_002\",\n      \"resolution_rationale\": \"Ireland accepted. Son-in-law may have confused birthplace with residence.\",\n      \"status\": \"resolved\",\n      \"weighing_analysis\": \"Census records are contemporary; death certificate is 63 years later with a secondary informant.\"\n    }\n  ],\n  \"evaluations\": [],\n  \"hypotheses\": [\n    {\n      \"claim\": \"Patrick Flynn's father was Thomas Flynn of Schuylkill County, Pennsylvania\",\n      \"contradicting_assertion_ids\": [],\n      \"id\": \"h_001\",\n      \"notes\": \"Three independent pieces of evidence support this hypothesis. All direct record types have been exhausted: 1850 and 1860 census (FamilySearch, Ancestry, MyHeritage), death certificate (FamilySearch), 1870/1880/1900 census (all negative), Schuylkill County probate 1870\u20131900 (negative), Catholic church records Schuylkill County 1840\u20131870 (negative). No additional direct record types remain unsearched. FAN research (neighbors, witnesses, land record co-signatories, church associates of Thomas Flynn) is the next available research avenue.\",\n      \"related_question_ids\": [\n        \"q_001\"\n      ],\n      \"ruled_out\": false,\n      \"ruled_out_reason\": null,\n      \"status\": \"supported\",\n      \"supporting_assertion_ids\": [\n        \"a_004\",\n        \"a_005\",\n        \"a_006\"\n      ]\n    }\n  ],\n  \"log\": [\n    {\n      \"external_site\": null,\n      \"id\": \"log_001\",\n      \"notes\": \"Found Patrick Flynn age 5 in household of Thomas Flynn, dwelling 84, Schuylkill Co. Three other Flynn results examined \u2014 ages and locations don't match.\",\n      \"outcome\": \"positive\",\n      \"performed\": \"2026-05-01T10:15:00Z\",\n      \"plan_item_id\": \"pli_001\",\n      \"query\": {\n        \"birth_place\": \"Pennsylvania\",\n        \"birth_year\": 1845,\n        \"collection\": \"1850 Census\",\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"results_examined\": 8,\n      \"tool\": \"record_search\"\n    },\n    {\n      \"external_site\": {\n        \"capture_filename\": \"ancestry-1850-flynn-results.pdf\",\n        \"capture_received\": true,\n        \"site\": \"ancestry\",\n        \"url_generated\": \"https://www.ancestry.com/search/collections/8054/?name=Patrick_Flynn&birth=1845&birthplace=Pennsylvania\"\n      },\n      \"id\": \"log_002\",\n      \"notes\": \"Ancestry index confirms same household. Transcription matches FamilySearch.\",\n      \"outcome\": \"positive\",\n      \"performed\": \"2026-05-01T11:30:00Z\",\n      \"plan_item_id\": \"pli_002\",\n      \"query\": {\n        \"birth_place\": \"Pennsylvania\",\n        \"birth_year\": 1845,\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"results_examined\": 12,\n      \"tool\": \"external_site\"\n    },\n    {\n      \"external_site\": {\n        \"capture_filename\": \"myheritage-1850-flynn-nil.pdf\",\n        \"capture_received\": true,\n        \"site\": \"myheritage\",\n        \"url_generated\": \"https://www.myheritage.com/research?action=query&first=Patrick&last=Flynn&birth_year=1845&birth_place=Pennsylvania\"\n      },\n      \"id\": \"log_003\",\n      \"notes\": \"MyHeritage returned no results for Patrick Flynn in 1850 Schuylkill County.\",\n      \"outcome\": \"negative\",\n      \"performed\": \"2026-05-01T14:00:00Z\",\n      \"plan_item_id\": \"pli_003\",\n      \"query\": {\n        \"birth_place\": \"Pennsylvania\",\n        \"birth_year\": 1845,\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"results_examined\": 0,\n      \"tool\": \"external_site\"\n    },\n    {\n      \"external_site\": null,\n      \"id\": \"log_004\",\n      \"notes\": \"Patrick Flynn age 15 in household of Thomas Flynn, Schuylkill Co. Consistent with 1850 placement.\",\n      \"outcome\": \"positive\",\n      \"performed\": \"2026-05-02T09:00:00Z\",\n      \"plan_item_id\": \"pli_004\",\n      \"query\": {\n        \"birth_place\": \"Pennsylvania\",\n        \"birth_year\": 1845,\n        \"collection\": \"1860 Census\",\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"results_examined\": 5,\n      \"tool\": \"record_search\"\n    },\n    {\n      \"external_site\": null,\n      \"id\": \"log_005\",\n      \"notes\": \"Death certificate found. Names Thomas Flynn as father. Informant was son-in-law James Brown.\",\n      \"outcome\": \"positive\",\n      \"performed\": \"2026-05-03T10:00:00Z\",\n      \"plan_item_id\": \"pli_005\",\n      \"query\": {\n        \"death_place\": \"Schuylkill County, Pennsylvania\",\n        \"death_year\": 1908,\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"results_examined\": 2,\n      \"tool\": \"record_search\"\n    },\n    {\n      \"external_site\": null,\n      \"id\": \"log_006\",\n      \"notes\": \"No Patrick Flynn of matching age in Schuylkill County or adjacent counties (Carbon, Lebanon, Northumberland, Dauphin). Two Pennsylvania Patrick Flynns examined \u2014 neither matches on age or birthplace.\",\n      \"outcome\": \"negative\",\n      \"performed\": \"2026-05-05T09:00:00Z\",\n      \"plan_item_id\": \"pli_006\",\n      \"query\": {\n        \"birth_place\": \"Ireland\",\n        \"birth_year\": 1845,\n        \"collection\": \"1870 Census\",\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"results_examined\": 14,\n      \"tool\": \"record_search\"\n    },\n    {\n      \"external_site\": null,\n      \"id\": \"log_007\",\n      \"notes\": \"No Patrick Flynn of matching profile in Schuylkill County. Broadened to all Pennsylvania \u2014 three candidates examined, none matches.\",\n      \"outcome\": \"negative\",\n      \"performed\": \"2026-05-06T10:00:00Z\",\n      \"plan_item_id\": \"pli_007\",\n      \"query\": {\n        \"birth_place\": \"Ireland\",\n        \"birth_year\": 1845,\n        \"collection\": \"1880 Census\",\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"results_examined\": 18,\n      \"tool\": \"record_search\"\n    },\n    {\n      \"external_site\": null,\n      \"id\": \"log_008\",\n      \"notes\": \"No Patrick Flynn matching profile in Pennsylvania. 1890 census was destroyed \u2014 that gap cannot be searched.\",\n      \"outcome\": \"negative\",\n      \"performed\": \"2026-05-07T09:30:00Z\",\n      \"plan_item_id\": \"pli_008\",\n      \"query\": {\n        \"birth_place\": \"Ireland\",\n        \"birth_year\": 1845,\n        \"collection\": \"1900 Census\",\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"results_examined\": 9,\n      \"tool\": \"record_search\"\n    },\n    {\n      \"external_site\": null,\n      \"id\": \"log_009\",\n      \"notes\": \"Searched Schuylkill County Register of Wills on FamilySearch for Thomas Flynn, 1870\u20131900. No probate record found. Thomas Flynn may have died intestate, died outside Schuylkill County, or his records did not survive.\",\n      \"outcome\": \"negative\",\n      \"performed\": \"2026-05-08T09:00:00Z\",\n      \"plan_item_id\": \"pli_009\",\n      \"query\": {\n        \"collection\": \"Probate Records\",\n        \"given\": \"Thomas\",\n        \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n        \"surname\": \"Flynn\"\n      },\n      \"results_examined\": 0,\n      \"tool\": \"record_search\"\n    },\n    {\n      \"external_site\": null,\n      \"id\": \"log_010\",\n      \"notes\": \"Searched FamilySearch Catholic church records for Schuylkill County, 1840\u20131870 (St. Patrick's Pottsville, St. John's Minersville, St. Clair). No Thomas Flynn household record found. Three Flynn baptism records examined \u2014 children don't match Patrick's profile.\",\n      \"outcome\": \"negative\",\n      \"performed\": \"2026-05-08T11:00:00Z\",\n      \"plan_item_id\": \"pli_010\",\n      \"query\": {\n        \"collection\": \"Church Records\",\n        \"given\": \"Thomas\",\n        \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n        \"surname\": \"Flynn\"\n      },\n      \"results_examined\": 3,\n      \"tool\": \"record_search\"\n    }\n  ],\n  \"person_evidence\": [\n    {\n      \"assertion_id\": \"a_001\",\n      \"confidence\": \"confident\",\n      \"created\": \"2026-05-01\",\n      \"id\": \"pe_001\",\n      \"match_score\": null,\n      \"person_id\": \"I1\",\n      \"rationale\": \"Name matches (Patrick Flynn), age consistent with ~1845 birth, located in Schuylkill County.\",\n      \"superseded_by\": null\n    },\n    {\n      \"assertion_id\": \"a_004\",\n      \"confidence\": \"probable\",\n      \"created\": \"2026-05-01\",\n      \"id\": \"pe_002\",\n      \"match_score\": null,\n      \"person_id\": \"I1\",\n      \"rationale\": \"Household position and shared surname with head Thomas Flynn suggest parent-child relationship.\",\n      \"superseded_by\": null\n    },\n    {\n      \"assertion_id\": \"a_005\",\n      \"confidence\": \"confident\",\n      \"created\": \"2026-05-02\",\n      \"id\": \"pe_003\",\n      \"match_score\": null,\n      \"person_id\": \"I1\",\n      \"rationale\": \"Patrick Flynn age 15 in Thomas Flynn household, 1860 census.\",\n      \"superseded_by\": null\n    },\n    {\n      \"assertion_id\": \"a_006\",\n      \"confidence\": \"confident\",\n      \"created\": \"2026-05-03\",\n      \"id\": \"pe_004\",\n      \"match_score\": null,\n      \"person_id\": \"I1\",\n      \"rationale\": \"Death certificate for Patrick Flynn names Thomas Flynn as father.\",\n      \"superseded_by\": null\n    }\n  ],\n  \"plans\": [\n    {\n      \"created\": \"2026-05-01\",\n      \"id\": \"pl_001\",\n      \"items\": [\n        {\n          \"date_range\": \"1850\",\n          \"fallback_for\": null,\n          \"id\": \"pli_001\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"1850 census fully indexed on FamilySearch. Free access, start here.\",\n          \"record_type\": \"census\",\n          \"repository\": \"FamilySearch\",\n          \"sequence\": 1,\n          \"status\": \"completed\"\n        },\n        {\n          \"date_range\": \"1850\",\n          \"fallback_for\": null,\n          \"id\": \"pli_002\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"Ancestry has independent indexing; cross-check for transcription errors.\",\n          \"record_type\": \"census\",\n          \"repository\": \"Ancestry\",\n          \"sequence\": 2,\n          \"status\": \"completed\"\n        },\n        {\n          \"date_range\": \"1850\",\n          \"fallback_for\": null,\n          \"id\": \"pli_003\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"Third independent index for coverage confirmation.\",\n          \"record_type\": \"census\",\n          \"repository\": \"MyHeritage\",\n          \"sequence\": 3,\n          \"status\": \"completed\"\n        }\n      ],\n      \"question_id\": \"q_002\",\n      \"status\": \"completed\"\n    },\n    {\n      \"created\": \"2026-05-02\",\n      \"id\": \"pl_002\",\n      \"items\": [\n        {\n          \"date_range\": \"1860\",\n          \"fallback_for\": null,\n          \"id\": \"pli_004\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"Confirm Patrick still in Thomas Flynn household in 1860.\",\n          \"record_type\": \"census\",\n          \"repository\": \"FamilySearch\",\n          \"sequence\": 1,\n          \"status\": \"completed\"\n        },\n        {\n          \"date_range\": \"1908\",\n          \"fallback_for\": null,\n          \"id\": \"pli_005\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"Death certificate may name parents directly.\",\n          \"record_type\": \"vital_record\",\n          \"repository\": \"FamilySearch\",\n          \"sequence\": 2,\n          \"status\": \"completed\"\n        },\n        {\n          \"date_range\": \"1870\",\n          \"fallback_for\": null,\n          \"id\": \"pli_006\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"Search 1870 census to locate Patrick or Thomas Flynn post-1860. Would corroborate the household relationship into adulthood.\",\n          \"record_type\": \"census\",\n          \"repository\": \"FamilySearch\",\n          \"sequence\": 3,\n          \"status\": \"completed\"\n        },\n        {\n          \"date_range\": \"1880\",\n          \"fallback_for\": null,\n          \"id\": \"pli_007\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"1880 census names relationships explicitly \u2014 would provide direct relationship evidence if Patrick is still in Thomas's household.\",\n          \"record_type\": \"census\",\n          \"repository\": \"FamilySearch\",\n          \"sequence\": 4,\n          \"status\": \"completed\"\n        },\n        {\n          \"date_range\": \"1900\",\n          \"fallback_for\": null,\n          \"id\": \"pli_008\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"Search 1900 census for Patrick Flynn in Schuylkill County \u2014 may list parents' birthplaces.\",\n          \"record_type\": \"census\",\n          \"repository\": \"FamilySearch\",\n          \"sequence\": 5,\n          \"status\": \"completed\"\n        },\n        {\n          \"date_range\": \"1870-1900\",\n          \"fallback_for\": null,\n          \"id\": \"pli_009\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"Thomas Flynn's will or probate inventory would name his children directly, providing primary-quality evidence for the parentage hypothesis.\",\n          \"record_type\": \"probate\",\n          \"repository\": \"FamilySearch\",\n          \"sequence\": 6,\n          \"status\": \"completed\"\n        },\n        {\n          \"date_range\": \"1840-1870\",\n          \"fallback_for\": null,\n          \"id\": \"pli_010\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"Catholic baptism and marriage registers for Irish immigrants in Schuylkill County may list Thomas Flynn's children.\",\n          \"record_type\": \"church_record\",\n          \"repository\": \"FamilySearch\",\n          \"sequence\": 7,\n          \"status\": \"completed\"\n        }\n      ],\n      \"question_id\": \"q_001\",\n      \"status\": \"completed\"\n    }\n  ],\n  \"project\": {\n    \"created\": \"2026-05-01\",\n    \"id\": \"rp_001\",\n    \"objective\": \"Identify the parents of Patrick Flynn, born ca. 1845 in Pennsylvania, died 1908 in Schuylkill County, PA\",\n    \"status\": \"active\",\n    \"subject_person_ids\": [\n      \"I1\"\n    ],\n    \"updated\": \"2026-05-10\"\n  },\n  \"proof_summaries\": [\n    {\n      \"exhaustive_search_summary\": \"Searched 1850 census (FamilySearch, Ancestry, MyHeritage \u2014 log_001\u2013log_003), 1860 census (FamilySearch \u2014 log_004), death certificate (FamilySearch \u2014 log_005), 1870 census (FamilySearch \u2014 log_006, negative), 1880 census (FamilySearch \u2014 log_007, negative), 1900 census (FamilySearch \u2014 log_008, negative). Patrick Flynn not found in post-1860 censuses. Direct evidence searches exhausted.\",\n      \"id\": \"ps_001\",\n      \"narrative_markdown\": \"Patrick Flynn is **Probably** the son of Thomas Flynn of Schuylkill County, Pennsylvania, based on co-enumeration in the 1850 and 1860 censuses and a death certificate naming Thomas as father. Conclusion remains at **Probable** because both census sources provide only indirect relationship evidence (relationship column not introduced until 1880), and the death certificate informant (son-in-law) is secondary for parentage facts. Direct census searches for 1870, 1880, and 1900 returned no Patrick Flynn of matching profile, leaving the post-1860 period undocumented. Associates/neighbors research has not yet been attempted.\",\n      \"question_id\": \"q_001\",\n      \"resolved_conflict_ids\": [\n        \"c_001\"\n      ],\n      \"supporting_assertion_ids\": [\n        \"a_004\",\n        \"a_005\",\n        \"a_006\"\n      ],\n      \"tier\": \"probable\",\n      \"vehicle\": \"summary\"\n    }\n  ],\n  \"questions\": [\n    {\n      \"created\": \"2026-05-01\",\n      \"depends_on\": [],\n      \"exhaustive_declaration\": {\n        \"declared\": true,\n        \"justification\": \"All planned direct record types searched: 1850 census (FamilySearch, Ancestry, MyHeritage), 1860 census (FamilySearch), death certificate (FamilySearch), 1870/1880/1900 census (FamilySearch \u2014 all negative), probate Schuylkill County 1870\u20131900 (FamilySearch \u2014 negative), Catholic church records Schuylkill County 1840\u20131870 (FamilySearch \u2014 negative). No further direct record types remain unsearched for this question. FAN research is the only avenue not yet explored.\",\n        \"log_entry_ids\": [\n          \"log_001\",\n          \"log_002\",\n          \"log_003\",\n          \"log_004\",\n          \"log_005\",\n          \"log_006\",\n          \"log_007\",\n          \"log_008\",\n          \"log_009\",\n          \"log_010\"\n        ],\n        \"stop_criteria\": {\n          \"conflict_resolution\": \"Birthplace conflict c_001 resolved.\",\n          \"evidence_class\": \"Three original source types; all relationship evidence is indirect or secondary.\",\n          \"goal_alignment\": \"Partially \u2014 Thomas Flynn is a strong candidate as father (three independent source types) but not proved. Exhaustive search has been conducted without producing a definitive record.\",\n          \"independent_verification\": \"FamilySearch and Ancestry both confirm the 1850 census household. Three record types independently support Thomas Flynn as father.\",\n          \"original_substitution\": \"FamilySearch provides original images for census and death certificate records.\",\n          \"overturn_risk\": \"Low for Thomas Flynn as candidate. No competing candidates found.\",\n          \"repository_breadth\": \"Census (FamilySearch, Ancestry, MyHeritage), vital records (FamilySearch), probate (FamilySearch), church records (FamilySearch). Major repositories and record types searched.\"\n        }\n      },\n      \"id\": \"q_001\",\n      \"priority\": \"high\",\n      \"question\": \"Who were the parents of Patrick Flynn (b. ~1845, PA, d. 1908)?\",\n      \"rationale\": \"This is the primary research objective.\",\n      \"resolution_assertion_ids\": [],\n      \"resolved\": null,\n      \"selection_basis\": \"objective_decomposition\",\n      \"status\": \"in_progress\",\n      \"unblocks\": []\n    },\n    {\n      \"created\": \"2026-05-01\",\n      \"depends_on\": [],\n      \"exhaustive_declaration\": {\n        \"declared\": true,\n        \"justification\": \"Searched 1850 census for Schuylkill County on FamilySearch (indexed and browse), Ancestry (indexed), and MyHeritage (indexed). All three returned the same household. No other Patrick Flynn of matching age found in the county.\",\n        \"log_entry_ids\": [\n          \"log_001\",\n          \"log_002\",\n          \"log_003\"\n        ],\n        \"stop_criteria\": {\n          \"conflict_resolution\": \"No conflicts on the 1850 census placement question.\",\n          \"evidence_class\": \"Yes \u2014 FamilySearch provides original census image with indeterminate-quality information.\",\n          \"goal_alignment\": \"Yes \u2014 Patrick Flynn located in a specific 1850 household, answering the question.\",\n          \"independent_verification\": \"FamilySearch (original) and Ancestry (derivative) both return the same household. Two access paths, one underlying original.\",\n          \"original_substitution\": \"FamilySearch provides the original census image; Ancestry index is derivative but confirmed consistent.\",\n          \"overturn_risk\": \"Low \u2014 all three repositories agree, and no competing Patrick Flynn of matching age exists in the county.\",\n          \"repository_breadth\": \"Three major repositories searched (FamilySearch, Ancestry, MyHeritage). No additional known indexes of the 1850 Schuylkill County census exist.\"\n        }\n      },\n      \"id\": \"q_002\",\n      \"priority\": \"high\",\n      \"question\": \"Where was Patrick Flynn in the 1850 census?\",\n      \"rationale\": \"The 1850 census is the earliest enumeration where Patrick would appear by name (age ~5). Locating him in a household identifies candidate parents.\",\n      \"resolution_assertion_ids\": [\n        \"a_001\",\n        \"a_002\",\n        \"a_003\"\n      ],\n      \"resolved\": \"2026-05-02\",\n      \"selection_basis\": \"objective_decomposition\",\n      \"status\": \"resolved\",\n      \"unblocks\": [\n        \"q_001\"\n      ]\n    }\n  ],\n  \"sources\": [\n    {\n      \"access_date\": \"2026-05-01\",\n      \"citation\": \"1850 U.S. Census, Schuylkill County, Pennsylvania, population schedule, dwelling 84, family 91, Thomas Flynn household; NARA microfilm publication M432, roll 810; digital image, FamilySearch.org, accessed 1 May 2026.\",\n      \"citation_detail\": {\n        \"what\": \"1850 U.S. Federal Census, population schedule\",\n        \"when_accessed\": \"2026-05-01\",\n        \"when_created\": \"1850\",\n        \"where\": \"FamilySearch.org (NARA microfilm M432, roll 810)\",\n        \"where_within\": \"Schuylkill County, dwelling 84, family 91\",\n        \"who\": \"U.S. Census Bureau\"\n      },\n      \"gedcomx_source_description_id\": \"S1\",\n      \"id\": \"src_001\",\n      \"log_entry_id\": \"log_001\",\n      \"notes\": \"Image quality good.\",\n      \"repository\": \"FamilySearch\",\n      \"source_classification\": \"original\",\n      \"url\": \"https://www.familysearch.org/ark:/61903/1:1:MXYZ\",\n      \"url_archived\": null\n    },\n    {\n      \"access_date\": \"2026-05-01\",\n      \"citation\": \"1850 U.S. Census, Schuylkill County, Pennsylvania, population schedule, dwelling 84, Thomas Flynn household; digital image, Ancestry.com, accessed 1 May 2026.\",\n      \"citation_detail\": {\n        \"what\": \"1850 U.S. Federal Census, population schedule (Ancestry index)\",\n        \"when_accessed\": \"2026-05-01\",\n        \"when_created\": \"1850\",\n        \"where\": \"Ancestry.com\",\n        \"where_within\": \"Schuylkill County, dwelling 84\",\n        \"who\": \"U.S. Census Bureau\"\n      },\n      \"gedcomx_source_description_id\": \"S1\",\n      \"id\": \"src_002\",\n      \"log_entry_id\": \"log_002\",\n      \"notes\": \"Ancestry's index of the same original census. Transcription consistent with FamilySearch.\",\n      \"repository\": \"Ancestry\",\n      \"source_classification\": \"derivative\",\n      \"url\": null,\n      \"url_archived\": null\n    },\n    {\n      \"access_date\": \"2026-05-02\",\n      \"citation\": \"1860 U.S. Census, Schuylkill County, Pennsylvania, population schedule, dwelling 112, family 119, Thomas Flynn household; NARA microfilm publication M653, roll 1141; digital image, FamilySearch.org, accessed 2 May 2026.\",\n      \"citation_detail\": {\n        \"what\": \"1860 U.S. Federal Census, population schedule\",\n        \"when_accessed\": \"2026-05-02\",\n        \"when_created\": \"1860\",\n        \"where\": \"FamilySearch.org (NARA microfilm M653, roll 1141)\",\n        \"where_within\": \"Schuylkill County, dwelling 112, family 119\",\n        \"who\": \"U.S. Census Bureau\"\n      },\n      \"gedcomx_source_description_id\": \"S2\",\n      \"id\": \"src_003\",\n      \"log_entry_id\": \"log_004\",\n      \"notes\": null,\n      \"repository\": \"FamilySearch\",\n      \"source_classification\": \"original\",\n      \"url\": \"https://www.familysearch.org/ark:/61903/1:1:MABC\",\n      \"url_archived\": null\n    },\n    {\n      \"access_date\": \"2026-05-03\",\n      \"citation\": \"Pennsylvania Department of Health, death certificate no. 4521 (1908), Patrick Flynn; Pennsylvania State Archives, Harrisburg; digital image, FamilySearch.org, accessed 3 May 2026.\",\n      \"citation_detail\": {\n        \"what\": \"Death certificate no. 4521\",\n        \"when_accessed\": \"2026-05-03\",\n        \"when_created\": \"1908-03-14\",\n        \"where\": \"FamilySearch.org (Pennsylvania State Archives, Harrisburg)\",\n        \"where_within\": \"Certificate no. 4521\",\n        \"who\": \"Pennsylvania Department of Health; informant: James Brown (son-in-law)\"\n      },\n      \"gedcomx_source_description_id\": \"S3\",\n      \"id\": \"src_004\",\n      \"log_entry_id\": \"log_005\",\n      \"notes\": \"Informant is son-in-law James Brown. Primary for death facts, secondary for birth/parentage facts.\",\n      \"repository\": \"FamilySearch\",\n      \"source_classification\": \"original\",\n      \"url\": \"https://www.familysearch.org/ark:/61903/1:1:MDEF\",\n      \"url_archived\": null\n    }\n  ],\n  \"timelines\": [\n    {\n      \"events\": [\n        {\n          \"assertion_ids\": [\n            \"a_002\"\n          ],\n          \"date\": \"~1845\",\n          \"date_certainty\": \"estimated\",\n          \"description\": \"Born in Ireland, estimated from census ages\",\n          \"event_type\": \"birth\",\n          \"place\": \"Ireland\"\n        },\n        {\n          \"assertion_ids\": [\n            \"a_003\",\n            \"a_004\"\n          ],\n          \"date\": \"1850\",\n          \"date_certainty\": \"exact\",\n          \"description\": \"Enumerated age 5 in Thomas Flynn household, dwelling 84\",\n          \"event_type\": \"census\",\n          \"place\": \"Schuylkill County, Pennsylvania\"\n        },\n        {\n          \"assertion_ids\": [\n            \"a_005\"\n          ],\n          \"date\": \"1860\",\n          \"date_certainty\": \"exact\",\n          \"description\": \"Enumerated age 15 in Thomas Flynn household, dwelling 112\",\n          \"event_type\": \"census\",\n          \"place\": \"Schuylkill County, Pennsylvania\"\n        },\n        {\n          \"assertion_ids\": [\n            \"a_006\"\n          ],\n          \"date\": \"1908-03-12\",\n          \"date_certainty\": \"exact\",\n          \"description\": \"Died, death certificate names Thomas Flynn as father\",\n          \"event_type\": \"death\",\n          \"place\": \"Schuylkill County, Pennsylvania\"\n        }\n      ],\n      \"gaps\": [\n        {\n          \"end\": \"1908-03-12\",\n          \"expected_events\": [],\n          \"notes\": \"1870, 1880, and 1900 censuses searched \u2014 Patrick Flynn not found. 1890 census destroyed. Remaining gap involves marriage, church, and occupation records not yet searched.\",\n          \"severity\": \"low\",\n          \"start\": \"1860-01-01\"\n        }\n      ],\n      \"generated\": \"2026-05-07T12:00:00Z\",\n      \"hypothesis_id\": \"h_001\",\n      \"id\": \"t_001\",\n      \"impossibilities\": [],\n      \"label\": \"Patrick Flynn \u2014 assuming Thomas Flynn parentage\",\n      \"person_ids\": [\n        \"I1\"\n      ]\n    }\n  ]\n}\n",
+    "eval/fixtures/scenarios/flynn-fan-pivot/tree.gedcomx.json": "{\n  \"persons\": [\n    {\n      \"facts\": [\n        {\n          \"date\": \"~1845\",\n          \"id\": \"F1\",\n          \"place\": \"Ireland\",\n          \"primary\": true,\n          \"sources\": [\n            {\n              \"page\": \"1850 Census, Schuylkill Co., dwelling 84\",\n              \"ref\": \"S1\"\n            }\n          ],\n          \"type\": \"Birth\"\n        },\n        {\n          \"date\": \"1908-03-12\",\n          \"id\": \"F2\",\n          \"place\": \"Schuylkill County, Pennsylvania\",\n          \"sources\": [\n            {\n              \"page\": \"Death cert. no. 4521\",\n              \"ref\": \"S3\"\n            }\n          ],\n          \"type\": \"Death\"\n        }\n      ],\n      \"gender\": \"Male\",\n      \"id\": \"I1\",\n      \"names\": [\n        {\n          \"given\": \"Patrick\",\n          \"id\": \"N1\",\n          \"preferred\": true,\n          \"surname\": \"Flynn\",\n          \"type\": \"BirthName\"\n        }\n      ]\n    },\n    {\n      \"facts\": [\n        {\n          \"date\": \"~1818\",\n          \"id\": \"F3\",\n          \"place\": \"Ireland\",\n          \"primary\": true,\n          \"type\": \"Birth\"\n        }\n      ],\n      \"gender\": \"Male\",\n      \"id\": \"I2\",\n      \"names\": [\n        {\n          \"given\": \"Thomas\",\n          \"id\": \"N2\",\n          \"preferred\": true,\n          \"surname\": \"Flynn\",\n          \"type\": \"BirthName\"\n        }\n      ]\n    }\n  ],\n  \"relationships\": [\n    {\n      \"child\": \"I1\",\n      \"id\": \"R1\",\n      \"parent\": \"I2\",\n      \"sources\": [\n        {\n          \"page\": \"1850 Census, Schuylkill Co., dwelling 84\",\n          \"quality\": 2,\n          \"ref\": \"S1\"\n        },\n        {\n          \"page\": \"1860 Census, Schuylkill Co., dwelling 112\",\n          \"quality\": 2,\n          \"ref\": \"S2\"\n        },\n        {\n          \"page\": \"Death cert. no. 4521\",\n          \"quality\": 2,\n          \"ref\": \"S3\"\n        }\n      ],\n      \"type\": \"ParentChild\"\n    }\n  ],\n  \"sources\": [\n    {\n      \"author\": \"U.S. Census Bureau\",\n      \"id\": \"S1\",\n      \"title\": \"1850 U.S. Federal Census\"\n    },\n    {\n      \"author\": \"U.S. Census Bureau\",\n      \"id\": \"S2\",\n      \"title\": \"1860 U.S. Federal Census\"\n    },\n    {\n      \"author\": \"Pennsylvania Dept. of Health\",\n      \"id\": \"S3\",\n      \"title\": \"Pennsylvania Death Certificates\"\n    }\n  ]\n}\n",
+    "eval/fixtures/scenarios/flynn-multi-conflict/README.md": "# flynn-multi-conflict\n\nPatrick Flynn parentage research with two unresolved conflicts active simultaneously. Same as `flynn-with-birthplace-conflict` plus a second identity conflict.\n\n- **Conflicts:**\n  - `c_001` \u2014 birthplace (Ireland vs Pennsylvania), fact conflict, status: `unresolved`\n  - `c_002` \u2014 identity (which Patrick Flynn in 1850 Schuylkill County is the subject?), identity conflict, status: `unresolved`\n- **Both conflicts have:** null `preferred_assertion_id`, null `independence_analysis`, null `weighing_analysis`, null `resolution_rationale`. Both list `q_001` in `blocks_question_ids`.\n- **Everything else:** Same as `mid-research-flynn`.\n\n## Used by\n\n- `conflict-resolution` **prioritization** tests \u2014 when two conflicts exist, which should be tackled first?\n- Tests verifying that the skill addresses one conflict at a time rather than producing tangled resolution prose covering both.\n- `question-selection` tests where the next research question must address whichever conflict the skill identifies as most blocking.\n\n## Two distinct conflict shapes\n\n- **Fact conflict (c_001):** at least 2 competing assertions, named `disputed_attribute`, null `identity_question`.\n- **Identity conflict (c_002):** at least 1 competing assertion (the assertion whose person linkage is uncertain), null `disputed_attribute`, populated `identity_question`.\n\nThis is the only scenario in the seed corpus where both conflict types are simultaneously present.\n",
+    "eval/fixtures/scenarios/flynn-multi-conflict/research.json": "{\n  \"assertions\": [\n    {\n      \"date\": null,\n      \"date_certainty\": null,\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_002\"\n      ],\n      \"fact_type\": \"name\",\n      \"id\": \"a_001\",\n      \"informant\": \"Unknown informant (most likely a household member, possibly a neighbor) reporting to census enumerator\",\n      \"informant_bias_notes\": \"Census enumerator is the recorder, not the informant. The person who provided the name is unknown \u2014 most likely a household member, possibly a neighbor. Proximity is 'unknown' rather than 'household_member' because for names specifically, the enumerator may have heard the name from a neighbor or made an assumption \u2014 the name fact doesn't necessarily require active reporting the way age/birthplace does.\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_001\",\n      \"place\": null,\n      \"record_id\": \"ark:/61903/1:1:MXYZ\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_001\",\n      \"structured_value\": {\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"value\": \"Patrick Flynn\"\n    },\n    {\n      \"date\": \"~1845\",\n      \"date_certainty\": \"estimated\",\n      \"evidence_type\": \"indirect\",\n      \"extracted_for_question_ids\": [\n        \"q_002\"\n      ],\n      \"fact_type\": \"birth\",\n      \"id\": \"a_002\",\n      \"informant\": \"Unknown \u2014 most likely a household member (such as Thomas Flynn or his wife), but possibly a neighbor\",\n      \"informant_bias_notes\": \"Age and birthplace require active reporting by an informant \u2014 someone had to tell the enumerator these facts. That informant was most likely a household member, but enumerators also took information from neighbors when residents were unavailable, and the census does not identify who answered. Proximity is 'unknown' because the informant cannot be established from the record.\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_001\",\n      \"place\": \"Ireland\",\n      \"record_id\": \"ark:/61903/1:1:MXYZ\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_001\",\n      \"structured_value\": {\n        \"place\": \"Ireland\",\n        \"year\": 1845\n      },\n      \"value\": \"age 5\"\n    },\n    {\n      \"date\": \"1850\",\n      \"date_certainty\": \"exact\",\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_002\"\n      ],\n      \"fact_type\": \"residence\",\n      \"id\": \"a_003\",\n      \"informant\": \"Census enumerator (witness to residence by visiting the dwelling)\",\n      \"informant_bias_notes\": \"For residence facts specifically, the enumerator is a direct witness \u2014 they physically visited the dwelling and recorded who lived there. This distinguishes residence from other census facts where an unidentified informant (most likely a household member, possibly a neighbor) supplied the information.\",\n      \"informant_proximity\": \"witness\",\n      \"information_quality\": \"primary\",\n      \"log_entry_id\": \"log_001\",\n      \"place\": \"Schuylkill County, Pennsylvania\",\n      \"record_id\": \"ark:/61903/1:1:MXYZ\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_001\",\n      \"value\": \"Schuylkill County, Pennsylvania\"\n    },\n    {\n      \"date\": \"1850\",\n      \"date_certainty\": \"exact\",\n      \"evidence_type\": \"indirect\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"relationship\",\n      \"id\": \"a_004\",\n      \"informant\": \"Inferred from household structure \u2014 no explicit informant for relationships in 1850 census\",\n      \"informant_bias_notes\": \"1850 census does not state relationships; this assertion is inferred from household position and shared surname, not directly reported by any informant. The relationship is indirect evidence constructed by the researcher, not information provided by a census informant.\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_001\",\n      \"place\": \"Schuylkill County, Pennsylvania\",\n      \"record_id\": \"ark:/61903/1:1:MXYZ\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_001\",\n      \"structured_value\": {\n        \"related_person_role\": \"head_of_household\",\n        \"relationship_type\": \"child_inferred\"\n      },\n      \"value\": \"Listed in household of Thomas Flynn (head), position consistent with child\"\n    },\n    {\n      \"date\": null,\n      \"date_certainty\": null,\n      \"evidence_type\": \"indirect\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"name\",\n      \"id\": \"a_005\",\n      \"informant\": \"Unknown informant (likely Thomas Flynn himself) reporting to census enumerator\",\n      \"informant_bias_notes\": \"Census enumerator is the recorder, not the informant. As head of household, Thomas likely provided his own name, but the 1850 census does not identify the informant.\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_001\",\n      \"place\": null,\n      \"record_id\": \"ark:/61903/1:1:MXYZ\",\n      \"record_role\": \"head_of_household\",\n      \"source_id\": \"src_001\",\n      \"value\": \"Thomas Flynn\"\n    },\n    {\n      \"date\": null,\n      \"date_certainty\": null,\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_002\"\n      ],\n      \"fact_type\": \"name\",\n      \"id\": \"a_006\",\n      \"informant\": \"Ancestry transcriber (derivative of census enumerator)\",\n      \"informant_bias_notes\": \"Derivative index \u2014 transcription errors possible\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_002\",\n      \"place\": null,\n      \"record_id\": \"ancestry:8054:patrick-flynn-1850\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_002\",\n      \"value\": \"Patrick Flynn\"\n    },\n    {\n      \"date\": \"~1845\",\n      \"date_certainty\": \"estimated\",\n      \"evidence_type\": \"indirect\",\n      \"extracted_for_question_ids\": [\n        \"q_002\"\n      ],\n      \"fact_type\": \"birth\",\n      \"id\": \"a_007\",\n      \"informant\": \"Ancestry transcriber (derivative)\",\n      \"informant_bias_notes\": null,\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_002\",\n      \"place\": \"Ireland\",\n      \"record_id\": \"ancestry:8054:patrick-flynn-1850\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_002\",\n      \"value\": \"age 5\"\n    },\n    {\n      \"date\": null,\n      \"date_certainty\": null,\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"name\",\n      \"id\": \"a_008\",\n      \"informant\": \"Unknown informant (most likely a household member, possibly a neighbor) reporting to census enumerator\",\n      \"informant_bias_notes\": \"Census enumerator is the recorder, not the informant. Proximity is 'unknown' for names (same reasoning as a_001 \u2014 name facts don't necessarily require active reporting).\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_004\",\n      \"place\": null,\n      \"record_id\": \"ark:/61903/1:1:MABC\",\n      \"record_role\": \"child_2\",\n      \"source_id\": \"src_003\",\n      \"value\": \"Patrick Flynn\"\n    },\n    {\n      \"date\": \"~1845\",\n      \"date_certainty\": \"estimated\",\n      \"evidence_type\": \"indirect\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"birth\",\n      \"id\": \"a_009\",\n      \"informant\": \"Unknown \u2014 most likely a household member (such as Thomas Flynn or his wife), but possibly a neighbor\",\n      \"informant_bias_notes\": \"Age and birthplace require active reporting by an informant \u2014 most likely a household member, possibly a neighbor (same reasoning as a_002).\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_004\",\n      \"place\": \"Ireland\",\n      \"record_id\": \"ark:/61903/1:1:MABC\",\n      \"record_role\": \"child_2\",\n      \"source_id\": \"src_003\",\n      \"value\": \"age 15\"\n    },\n    {\n      \"date\": \"1860\",\n      \"date_certainty\": \"exact\",\n      \"evidence_type\": \"indirect\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"relationship\",\n      \"id\": \"a_010\",\n      \"informant\": \"Inferred from household structure \u2014 no explicit informant for relationships in 1860 census\",\n      \"informant_bias_notes\": \"1860 census does not state relationships; like the 1850 census, this assertion is inferred from household position, age, and shared surname. The relationship column was not introduced until the 1880 census.\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_004\",\n      \"place\": \"Schuylkill County, Pennsylvania\",\n      \"record_id\": \"ark:/61903/1:1:MABC\",\n      \"record_role\": \"child_2\",\n      \"source_id\": \"src_003\",\n      \"structured_value\": {\n        \"related_person_role\": \"head_of_household\",\n        \"relationship_type\": \"child_inferred\"\n      },\n      \"value\": \"Listed in household of Thomas Flynn (head), position and age consistent with son\"\n    },\n    {\n      \"date\": \"1908-03-12\",\n      \"date_certainty\": \"exact\",\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [],\n      \"fact_type\": \"death\",\n      \"id\": \"a_011\",\n      \"informant\": \"Attending physician (signature on certificate)\",\n      \"informant_bias_notes\": null,\n      \"informant_proximity\": \"witness\",\n      \"information_quality\": \"primary\",\n      \"log_entry_id\": \"log_005\",\n      \"place\": \"Schuylkill County, Pennsylvania\",\n      \"record_id\": \"ark:/61903/1:1:MDEF\",\n      \"record_role\": \"deceased\",\n      \"source_id\": \"src_004\",\n      \"value\": \"Died 12 March 1908\"\n    },\n    {\n      \"date\": \"1845\",\n      \"date_certainty\": \"approximate\",\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"birth\",\n      \"id\": \"a_012\",\n      \"informant\": \"James Brown (son-in-law)\",\n      \"informant_bias_notes\": \"Son-in-law reporting birth facts decades after the event. Note: death cert says Pennsylvania, but census records say Ireland. Son-in-law may not have known Patrick was born in Ireland.\",\n      \"informant_proximity\": \"family_not_present\",\n      \"information_quality\": \"secondary\",\n      \"log_entry_id\": \"log_005\",\n      \"place\": \"Pennsylvania\",\n      \"record_id\": \"ark:/61903/1:1:MDEF\",\n      \"record_role\": \"deceased\",\n      \"source_id\": \"src_004\",\n      \"structured_value\": {\n        \"place\": \"Pennsylvania\",\n        \"year\": 1845\n      },\n      \"value\": \"Born 1845, Pennsylvania\"\n    },\n    {\n      \"date\": null,\n      \"date_certainty\": null,\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"relationship\",\n      \"id\": \"a_013\",\n      \"informant\": \"James Brown (son-in-law)\",\n      \"informant_bias_notes\": \"Secondary information \u2014 son-in-law reporting what he was told about father-in-law's parentage\",\n      \"informant_proximity\": \"family_not_present\",\n      \"information_quality\": \"secondary\",\n      \"log_entry_id\": \"log_005\",\n      \"place\": null,\n      \"record_id\": \"ark:/61903/1:1:MDEF\",\n      \"record_role\": \"deceased\",\n      \"source_id\": \"src_004\",\n      \"structured_value\": {\n        \"related_person_role\": \"deceased\",\n        \"relationship_type\": \"father\"\n      },\n      \"value\": \"Father: Thomas Flynn\"\n    }\n  ],\n  \"conflicts\": [\n    {\n      \"blocks_question_ids\": [\n        \"q_001\"\n      ],\n      \"competing_assertion_ids\": [\n        \"a_002\",\n        \"a_009\",\n        \"a_012\"\n      ],\n      \"conflict_type\": \"fact\",\n      \"description\": \"Patrick Flynn's birthplace: Ireland (1850 and 1860 censuses) vs. Pennsylvania (1908 death certificate)\",\n      \"disputed_attribute\": \"birthplace\",\n      \"id\": \"c_001\",\n      \"identity_question\": null,\n      \"independence_analysis\": null,\n      \"preferred_assertion_id\": null,\n      \"resolution_rationale\": null,\n      \"status\": \"unresolved\",\n      \"weighing_analysis\": null\n    },\n    {\n      \"blocks_question_ids\": [\n        \"q_001\"\n      ],\n      \"competing_assertion_ids\": [\n        \"a_001\"\n      ],\n      \"conflict_type\": \"identity\",\n      \"description\": \"Is the Patrick Flynn in Thomas Flynn's 1850 household the same person as the Patrick Flynn on the 1908 death certificate? Two Patrick Flynns of similar age are recorded in Schuylkill County in 1850 \u2014 household 84 (age 5) and household 197 (age 6) \u2014 and the death certificate does not name a household or earlier residence to disambiguate.\",\n      \"disputed_attribute\": null,\n      \"id\": \"c_002\",\n      \"identity_question\": \"Is the Patrick Flynn enumerated in the Thomas Flynn 1850 household the same person as the Patrick Flynn whose 1908 death certificate is src_004?\",\n      \"independence_analysis\": null,\n      \"preferred_assertion_id\": null,\n      \"resolution_rationale\": null,\n      \"status\": \"unresolved\",\n      \"weighing_analysis\": null\n    }\n  ],\n  \"evaluations\": [],\n  \"hypotheses\": [\n    {\n      \"claim\": \"Patrick Flynn's father was Thomas Flynn of Schuylkill County, Pennsylvania\",\n      \"contradicting_assertion_ids\": [],\n      \"id\": \"h_001\",\n      \"notes\": \"Three independent pieces of evidence: 1850 census co-enumeration (indirect), 1860 census co-enumeration (indirect \u2014 relationship inferred from household position), death certificate naming Thomas as father (direct, secondary informant). Awaiting probate records for additional confirmation.\",\n      \"related_question_ids\": [\n        \"q_001\"\n      ],\n      \"ruled_out\": false,\n      \"ruled_out_reason\": null,\n      \"status\": \"supported\",\n      \"supporting_assertion_ids\": [\n        \"a_004\",\n        \"a_010\",\n        \"a_013\"\n      ]\n    }\n  ],\n  \"log\": [\n    {\n      \"external_site\": null,\n      \"id\": \"log_001\",\n      \"notes\": \"Found Patrick Flynn age 5 in household of Thomas Flynn, dwelling 84, Schuylkill Co. Three other Flynn results examined \u2014 ages and locations don't match.\",\n      \"outcome\": \"positive\",\n      \"performed\": \"2026-05-01T10:15:00Z\",\n      \"plan_item_id\": \"pli_001\",\n      \"query\": {\n        \"birth_place\": \"Pennsylvania\",\n        \"birth_year\": 1845,\n        \"collection\": \"1850 Census\",\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"results_examined\": 8,\n      \"tool\": \"record_search\"\n    },\n    {\n      \"external_site\": {\n        \"capture_filename\": \"ancestry-1850-flynn-results.pdf\",\n        \"capture_received\": true,\n        \"site\": \"ancestry\",\n        \"url_generated\": \"https://www.ancestry.com/search/collections/8054/?name=Patrick_Flynn&birth=1845&birthplace=Pennsylvania\"\n      },\n      \"id\": \"log_002\",\n      \"notes\": \"Ancestry index confirms same household. Transcription matches FamilySearch except Ancestry reads dwelling as 84, FamilySearch as 84 \u2014 consistent.\",\n      \"outcome\": \"positive\",\n      \"performed\": \"2026-05-01T11:30:00Z\",\n      \"plan_item_id\": \"pli_002\",\n      \"query\": {\n        \"birth_place\": \"Pennsylvania\",\n        \"birth_year\": 1845,\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"results_examined\": 12,\n      \"tool\": \"external_site\"\n    },\n    {\n      \"external_site\": {\n        \"capture_filename\": \"myheritage-1850-flynn-nil.pdf\",\n        \"capture_received\": true,\n        \"site\": \"myheritage\",\n        \"url_generated\": \"https://www.myheritage.com/research?action=query&first=Patrick&last=Flynn&birth_year=1845&birth_place=Pennsylvania\"\n      },\n      \"id\": \"log_003\",\n      \"notes\": \"MyHeritage returned no results for Patrick Flynn in 1850 Schuylkill County. Site may not have this collection indexed. Searched broader Pennsylvania \u2014 still no match.\",\n      \"outcome\": \"negative\",\n      \"performed\": \"2026-05-01T14:00:00Z\",\n      \"plan_item_id\": \"pli_003\",\n      \"query\": {\n        \"birth_place\": \"Pennsylvania\",\n        \"birth_year\": 1845,\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"results_examined\": 0,\n      \"tool\": \"external_site\"\n    },\n    {\n      \"external_site\": null,\n      \"id\": \"log_004\",\n      \"notes\": \"Patrick Flynn age 15 in household of Thomas Flynn, Schuylkill Co. Consistent with 1850 placement.\",\n      \"outcome\": \"positive\",\n      \"performed\": \"2026-05-02T09:00:00Z\",\n      \"plan_item_id\": \"pli_004\",\n      \"query\": {\n        \"birth_place\": \"Pennsylvania\",\n        \"birth_year\": 1845,\n        \"collection\": \"1860 Census\",\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"results_examined\": 5,\n      \"tool\": \"record_search\"\n    },\n    {\n      \"external_site\": null,\n      \"id\": \"log_005\",\n      \"notes\": \"Death certificate found. Names Thomas Flynn as father. Informant was son-in-law James Brown.\",\n      \"outcome\": \"positive\",\n      \"performed\": \"2026-05-03T10:00:00Z\",\n      \"plan_item_id\": \"pli_005\",\n      \"query\": {\n        \"death_place\": \"Schuylkill County, Pennsylvania\",\n        \"death_year\": 1908,\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"results_examined\": 2,\n      \"tool\": \"record_search\"\n    }\n  ],\n  \"person_evidence\": [\n    {\n      \"assertion_id\": \"a_001\",\n      \"confidence\": \"confident\",\n      \"created\": \"2026-05-01\",\n      \"id\": \"pe_001\",\n      \"match_score\": null,\n      \"person_id\": \"I1\",\n      \"rationale\": \"Name matches (Patrick Flynn), age consistent with ~1845 birth, located in Schuylkill County where subject is known to have lived. Only Patrick Flynn of this age in the county in 1850.\",\n      \"superseded_by\": null\n    },\n    {\n      \"assertion_id\": \"a_004\",\n      \"confidence\": \"probable\",\n      \"created\": \"2026-05-01\",\n      \"id\": \"pe_002\",\n      \"match_score\": null,\n      \"person_id\": \"I1\",\n      \"rationale\": \"Same record as pe_001, same person. Household position and shared surname with head Thomas Flynn suggest parent-child relationship, but 1850 census does not state relationships explicitly.\",\n      \"superseded_by\": null\n    },\n    {\n      \"assertion_id\": \"a_004\",\n      \"confidence\": \"probable\",\n      \"created\": \"2026-05-01\",\n      \"id\": \"pe_006\",\n      \"match_score\": null,\n      \"person_id\": \"I2\",\n      \"rationale\": \"Same assertion as pe_002 but linked to Thomas Flynn (I2). The relationship assertion ('position consistent with child') equally bears on the head of household. Thomas Flynn is the other party in the implied parent-child relationship.\",\n      \"superseded_by\": null\n    },\n    {\n      \"assertion_id\": \"a_005\",\n      \"confidence\": \"probable\",\n      \"created\": \"2026-05-01\",\n      \"id\": \"pe_003\",\n      \"match_score\": 0.82,\n      \"person_id\": \"I2\",\n      \"rationale\": \"Thomas Flynn, head of household where Patrick was found. Age (~32 in 1850, born ~1818) is consistent with being Patrick's father. Name matches candidate father.\",\n      \"superseded_by\": null\n    },\n    {\n      \"assertion_id\": \"a_010\",\n      \"confidence\": \"confident\",\n      \"created\": \"2026-05-02\",\n      \"id\": \"pe_004\",\n      \"match_score\": null,\n      \"person_id\": \"I1\",\n      \"rationale\": \"Patrick Flynn age 15 in Thomas Flynn household, 1860 census. Same county, age consistent with 1850 enumeration. Relationship inferred from household position and shared surname (1860 census does not state relationships explicitly).\",\n      \"superseded_by\": null\n    },\n    {\n      \"assertion_id\": \"a_013\",\n      \"confidence\": \"confident\",\n      \"created\": \"2026-05-03\",\n      \"id\": \"pe_005\",\n      \"match_score\": null,\n      \"person_id\": \"I1\",\n      \"rationale\": \"Death certificate for Patrick Flynn, d. 1908, Schuylkill County. Names match, death location matches known residence. Names Thomas Flynn as father.\",\n      \"superseded_by\": null\n    }\n  ],\n  \"plans\": [\n    {\n      \"created\": \"2026-05-01\",\n      \"id\": \"pl_001\",\n      \"items\": [\n        {\n          \"date_range\": \"1850\",\n          \"fallback_for\": null,\n          \"id\": \"pli_001\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"1850 census fully indexed on FamilySearch. Free access, start here.\",\n          \"record_type\": \"census\",\n          \"repository\": \"FamilySearch\",\n          \"sequence\": 1,\n          \"status\": \"completed\"\n        },\n        {\n          \"date_range\": \"1850\",\n          \"fallback_for\": null,\n          \"id\": \"pli_002\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"Ancestry has independent indexing; cross-check for transcription errors.\",\n          \"record_type\": \"census\",\n          \"repository\": \"Ancestry\",\n          \"sequence\": 2,\n          \"status\": \"completed\"\n        },\n        {\n          \"date_range\": \"1850\",\n          \"fallback_for\": null,\n          \"id\": \"pli_003\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"Third independent index for coverage confirmation.\",\n          \"record_type\": \"census\",\n          \"repository\": \"MyHeritage\",\n          \"sequence\": 3,\n          \"status\": \"completed\"\n        }\n      ],\n      \"question_id\": \"q_002\",\n      \"status\": \"completed\"\n    },\n    {\n      \"created\": \"2026-05-02\",\n      \"id\": \"pl_002\",\n      \"items\": [\n        {\n          \"date_range\": \"1860\",\n          \"fallback_for\": null,\n          \"id\": \"pli_004\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"Confirm Patrick still in Thomas Flynn household in 1860. Strengthens parent-child identification.\",\n          \"record_type\": \"census\",\n          \"repository\": \"FamilySearch\",\n          \"sequence\": 1,\n          \"status\": \"completed\"\n        },\n        {\n          \"date_range\": \"1908\",\n          \"fallback_for\": null,\n          \"id\": \"pli_005\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"Death certificate may name parents directly.\",\n          \"record_type\": \"vital_record\",\n          \"repository\": \"FamilySearch\",\n          \"sequence\": 2,\n          \"status\": \"completed\"\n        },\n        {\n          \"date_range\": \"1870-1890\",\n          \"fallback_for\": null,\n          \"id\": \"pli_006\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"Thomas Flynn probate/will may name Patrick as son.\",\n          \"record_type\": \"probate\",\n          \"repository\": \"FamilySearch\",\n          \"sequence\": 3,\n          \"status\": \"in_progress\"\n        }\n      ],\n      \"question_id\": \"q_001\",\n      \"status\": \"active\"\n    }\n  ],\n  \"project\": {\n    \"created\": \"2026-05-01\",\n    \"id\": \"rp_001\",\n    \"objective\": \"Identify the parents of Patrick Flynn, born ca. 1845 in Pennsylvania, died 1908 in Schuylkill County, PA\",\n    \"status\": \"active\",\n    \"subject_person_ids\": [\n      \"I1\"\n    ],\n    \"updated\": \"2026-05-04\"\n  },\n  \"proof_summaries\": [\n    {\n      \"exhaustive_search_summary\": \"Searched 1850 census (FamilySearch, Ancestry, MyHeritage \u2014 log_001, log_002, log_003), 1860 census (FamilySearch \u2014 log_004), and death certificate (FamilySearch \u2014 log_005). Probate search in progress. 1870, 1880, and 1900 censuses not yet searched.\",\n      \"id\": \"ps_001\",\n      \"narrative_markdown\": \"## Parentage of Patrick Flynn (ca. 1845\u20131908)\\n\\nPatrick Flynn is **Probably** the son of Thomas Flynn of Schuylkill County, Pennsylvania.\\n\\n### Evidence Summary\\n\\nThree independent lines of evidence support this conclusion:\\n\\n1. **1850 U.S. Census** (Original Source). Patrick Flynn, age 5, born Ireland, appears in the household of Thomas Flynn, age 32, born Ireland, in Schuylkill County, Pennsylvania (dwelling 84, family 91). The 1850 census does not state relationships, but Patrick's position in the household and shared surname are consistent with a parent-child relationship. The informant is indeterminate but likely a household member. This constitutes indirect evidence of parentage.\\n\\n2. **1860 U.S. Census** (Original Source). Patrick Flynn, age 15, born Ireland, appears in the household of Thomas Flynn in Schuylkill County (dwelling 112, family 119). Like the 1850 census, the 1860 census does not state relationships explicitly (the relationship column was not introduced until 1880). Patrick's position in the household, shared surname, and age consistent with the 1850 enumeration support a parent-child relationship. This constitutes indirect evidence of parentage.\\n\\n3. **1908 Death Certificate** (Original Source). Patrick Flynn's death certificate (no. 4521, Pennsylvania Department of Health) names \\\"Thomas Flynn\\\" as his father. The informant was James Brown, identified as Patrick's son-in-law. As a son-in-law reporting his father-in-law's parentage, Brown is a secondary informant for this fact \u2014 he was not a witness to Patrick's birth and is reporting what he was told. Nevertheless, this is direct evidence naming the father.\\n\\n### Conflict Resolution\\n\\nA birthplace conflict exists: the 1850 and 1860 censuses list Patrick's birthplace as Ireland, while the 1908 death certificate states Pennsylvania. The two census records are contemporary recordings with informants likely present in the household, while the death certificate was created 63 years after Patrick's birth by a son-in-law with no firsthand knowledge of the event. Per the GPS preponderance hierarchy, contemporary recordings by closer informants outweigh later recollections by secondary informants. Ireland is accepted as the birthplace; the death certificate entry is attributed to informant error.\\n\\n### Assessment\\n\\nThe conclusion is rated **Probable** rather than **Proved** because: (a) both census sources (1850 and 1860) provide only indirect evidence of parentage (relationships not stated \u2014 the relationship column was not introduced until 1880), (b) the death certificate informant is secondary, and (c) research is not yet exhaustive \u2014 the 1870, 1880, and 1900 censuses have not been searched, and Thomas Flynn's probate records have not been located. If Thomas Flynn's will names Patrick as a son, or if additional census records confirm the relationship, the conclusion would advance to **Proved**.\\n\\n### Citations\\n\\n1. 1850 U.S. Census, Schuylkill County, Pennsylvania, population schedule, dwelling 84, family 91, Thomas Flynn household; NARA microfilm publication M432, roll 810; digital image, FamilySearch.org, accessed 1 May 2026.\\n2. 1860 U.S. Census, Schuylkill County, Pennsylvania, population schedule, dwelling 112, family 119, Thomas Flynn household; NARA microfilm publication M653, roll 1141; digital image, FamilySearch.org, accessed 2 May 2026.\\n3. Pennsylvania Department of Health, death certificate no. 4521 (1908), Patrick Flynn; Pennsylvania State Archives, Harrisburg; digital image, FamilySearch.org, accessed 3 May 2026.\",\n      \"question_id\": \"q_001\",\n      \"resolved_conflict_ids\": [\n        \"c_001\"\n      ],\n      \"supporting_assertion_ids\": [\n        \"a_004\",\n        \"a_010\",\n        \"a_013\"\n      ],\n      \"tier\": \"probable\",\n      \"vehicle\": \"summary\"\n    }\n  ],\n  \"questions\": [\n    {\n      \"created\": \"2026-05-01\",\n      \"depends_on\": [],\n      \"exhaustive_declaration\": {\n        \"declared\": false,\n        \"justification\": null,\n        \"log_entry_ids\": [],\n        \"stop_criteria\": null\n      },\n      \"id\": \"q_001\",\n      \"priority\": \"high\",\n      \"question\": \"Who were the parents of Patrick Flynn (b. ~1845, PA, d. 1908)?\",\n      \"rationale\": \"This is the primary research objective.\",\n      \"resolution_assertion_ids\": [],\n      \"resolved\": null,\n      \"selection_basis\": \"objective_decomposition\",\n      \"status\": \"in_progress\",\n      \"unblocks\": []\n    },\n    {\n      \"created\": \"2026-05-01\",\n      \"depends_on\": [],\n      \"exhaustive_declaration\": {\n        \"declared\": true,\n        \"justification\": \"Searched 1850 census for Schuylkill County on FamilySearch (indexed and browse), Ancestry (indexed), and MyHeritage (indexed). All three returned the same household. No other Patrick Flynn of matching age found in the county.\",\n        \"log_entry_ids\": [\n          \"log_001\",\n          \"log_002\",\n          \"log_003\"\n        ],\n        \"stop_criteria\": {\n          \"conflict_resolution\": \"No conflicts on the 1850 census placement question.\",\n          \"evidence_class\": \"Yes \u2014 FamilySearch provides original census image with indeterminate-quality information.\",\n          \"goal_alignment\": \"Yes \u2014 Patrick Flynn located in a specific 1850 household, answering the question.\",\n          \"independent_verification\": \"FamilySearch (original) and Ancestry (derivative) both return the same household. Two access paths, one underlying original.\",\n          \"original_substitution\": \"FamilySearch provides the original census image; Ancestry index is derivative but confirmed consistent.\",\n          \"overturn_risk\": \"Low \u2014 all three repositories agree, and no competing Patrick Flynn of matching age exists in the county.\",\n          \"repository_breadth\": \"Three major repositories searched (FamilySearch, Ancestry, MyHeritage). No additional known indexes of the 1850 Schuylkill County census exist.\"\n        }\n      },\n      \"id\": \"q_002\",\n      \"priority\": \"high\",\n      \"question\": \"Where was Patrick Flynn in the 1850 census?\",\n      \"rationale\": \"The 1850 census is the earliest enumeration where Patrick would appear by name (age ~5). Locating him in a household identifies candidate parents.\",\n      \"resolution_assertion_ids\": [\n        \"a_001\",\n        \"a_002\",\n        \"a_003\"\n      ],\n      \"resolved\": \"2026-05-02\",\n      \"selection_basis\": \"objective_decomposition\",\n      \"status\": \"resolved\",\n      \"unblocks\": [\n        \"q_001\"\n      ]\n    }\n  ],\n  \"sources\": [\n    {\n      \"access_date\": \"2026-05-01\",\n      \"citation\": \"1850 U.S. Census, Schuylkill County, Pennsylvania, population schedule, dwelling 84, family 91, Thomas Flynn household; NARA microfilm publication M432, roll 810; digital image, FamilySearch.org, accessed 1 May 2026.\",\n      \"citation_detail\": {\n        \"what\": \"1850 U.S. Federal Census, population schedule\",\n        \"when_accessed\": \"2026-05-01\",\n        \"when_created\": \"1850\",\n        \"where\": \"FamilySearch.org (NARA microfilm M432, roll 810)\",\n        \"where_within\": \"Schuylkill County, dwelling 84, family 91\",\n        \"who\": \"U.S. Census Bureau\"\n      },\n      \"gedcomx_source_description_id\": \"S1\",\n      \"id\": \"src_001\",\n      \"log_entry_id\": \"log_001\",\n      \"notes\": \"Image quality good. Enumerator handwriting clear.\",\n      \"repository\": \"FamilySearch\",\n      \"source_classification\": \"original\",\n      \"url\": \"https://www.familysearch.org/ark:/61903/1:1:MXYZ\",\n      \"url_archived\": null\n    },\n    {\n      \"access_date\": \"2026-05-01\",\n      \"citation\": \"1850 U.S. Census, Schuylkill County, Pennsylvania, population schedule, dwelling 84, Thomas Flynn household; digital image, Ancestry.com, accessed 1 May 2026.\",\n      \"citation_detail\": {\n        \"what\": \"1850 U.S. Federal Census, population schedule (Ancestry index)\",\n        \"when_accessed\": \"2026-05-01\",\n        \"when_created\": \"1850\",\n        \"where\": \"Ancestry.com\",\n        \"where_within\": \"Schuylkill County, dwelling 84\",\n        \"who\": \"U.S. Census Bureau\"\n      },\n      \"gedcomx_source_description_id\": \"S1\",\n      \"id\": \"src_002\",\n      \"log_entry_id\": \"log_002\",\n      \"notes\": \"Ancestry's index of the same original census. Transcription consistent with FamilySearch.\",\n      \"repository\": \"Ancestry\",\n      \"source_classification\": \"derivative\",\n      \"url\": null,\n      \"url_archived\": null\n    },\n    {\n      \"access_date\": \"2026-05-02\",\n      \"citation\": \"1860 U.S. Census, Schuylkill County, Pennsylvania, population schedule, dwelling 112, family 119, Thomas Flynn household; NARA microfilm publication M653, roll 1141; digital image, FamilySearch.org, accessed 2 May 2026.\",\n      \"citation_detail\": {\n        \"what\": \"1860 U.S. Federal Census, population schedule\",\n        \"when_accessed\": \"2026-05-02\",\n        \"when_created\": \"1860\",\n        \"where\": \"FamilySearch.org (NARA microfilm M653, roll 1141)\",\n        \"where_within\": \"Schuylkill County, dwelling 112, family 119\",\n        \"who\": \"U.S. Census Bureau\"\n      },\n      \"gedcomx_source_description_id\": \"S2\",\n      \"id\": \"src_003\",\n      \"log_entry_id\": \"log_004\",\n      \"notes\": null,\n      \"repository\": \"FamilySearch\",\n      \"source_classification\": \"original\",\n      \"url\": \"https://www.familysearch.org/ark:/61903/1:1:MABC\",\n      \"url_archived\": null\n    },\n    {\n      \"access_date\": \"2026-05-03\",\n      \"citation\": \"Pennsylvania Department of Health, death certificate no. 4521 (1908), Patrick Flynn; Pennsylvania State Archives, Harrisburg; digital image, FamilySearch.org, accessed 3 May 2026.\",\n      \"citation_detail\": {\n        \"what\": \"Death certificate no. 4521\",\n        \"when_accessed\": \"2026-05-03\",\n        \"when_created\": \"1908-03-14\",\n        \"where\": \"FamilySearch.org (Pennsylvania State Archives, Harrisburg)\",\n        \"where_within\": \"Certificate no. 4521\",\n        \"who\": \"Pennsylvania Department of Health; informant: James Brown (son-in-law)\"\n      },\n      \"gedcomx_source_description_id\": \"S3\",\n      \"id\": \"src_004\",\n      \"log_entry_id\": \"log_005\",\n      \"notes\": \"Informant is son-in-law James Brown. Primary for death facts, secondary for birth facts.\",\n      \"repository\": \"FamilySearch\",\n      \"source_classification\": \"original\",\n      \"url\": \"https://www.familysearch.org/ark:/61903/1:1:MDEF\",\n      \"url_archived\": null\n    }\n  ],\n  \"timelines\": [\n    {\n      \"events\": [\n        {\n          \"assertion_ids\": [\n            \"a_002\",\n            \"a_009\"\n          ],\n          \"date\": \"~1845\",\n          \"date_certainty\": \"estimated\",\n          \"description\": \"Born in Ireland, estimated from census ages\",\n          \"event_type\": \"birth\",\n          \"place\": \"Ireland\"\n        },\n        {\n          \"assertion_ids\": [\n            \"a_003\",\n            \"a_004\"\n          ],\n          \"date\": \"1850\",\n          \"date_certainty\": \"exact\",\n          \"description\": \"Enumerated age 5 in Thomas Flynn household, dwelling 84\",\n          \"event_type\": \"census\",\n          \"place\": \"Schuylkill County, Pennsylvania\"\n        },\n        {\n          \"assertion_ids\": [\n            \"a_008\",\n            \"a_009\",\n            \"a_010\"\n          ],\n          \"date\": \"1860\",\n          \"date_certainty\": \"exact\",\n          \"description\": \"Enumerated age 15 in Thomas Flynn household, dwelling 112\",\n          \"event_type\": \"census\",\n          \"place\": \"Schuylkill County, Pennsylvania\"\n        },\n        {\n          \"assertion_ids\": [\n            \"a_011\",\n            \"a_013\"\n          ],\n          \"date\": \"1908-03-12\",\n          \"date_certainty\": \"exact\",\n          \"description\": \"Died, death certificate names Thomas Flynn as father\",\n          \"event_type\": \"death\",\n          \"place\": \"Schuylkill County, Pennsylvania\"\n        }\n      ],\n      \"gaps\": [\n        {\n          \"end\": \"1908-03-12\",\n          \"expected_events\": [\n            \"marriage\",\n            \"1870_census\",\n            \"1880_census\",\n            \"1900_census\",\n            \"residence\",\n            \"occupation\"\n          ],\n          \"severity\": \"high\",\n          \"start\": \"1860-01-01\"\n        }\n      ],\n      \"generated\": \"2026-05-03T12:00:00Z\",\n      \"hypothesis_id\": \"h_001\",\n      \"id\": \"t_001\",\n      \"impossibilities\": [],\n      \"label\": \"Patrick Flynn \u2014 assuming Thomas Flynn parentage\",\n      \"person_ids\": [\n        \"I1\"\n      ]\n    }\n  ]\n}\n",
+    "eval/fixtures/scenarios/flynn-multi-conflict/tree.gedcomx.json": "{\n  \"persons\": [\n    {\n      \"facts\": [\n        {\n          \"date\": \"~1845\",\n          \"id\": \"F1\",\n          \"place\": \"Ireland\",\n          \"primary\": true,\n          \"sources\": [\n            {\n              \"page\": \"1850 Census, Schuylkill Co., dwelling 84\",\n              \"ref\": \"S1\"\n            }\n          ],\n          \"type\": \"Birth\"\n        },\n        {\n          \"date\": \"1908-03-12\",\n          \"id\": \"F2\",\n          \"place\": \"Schuylkill County, Pennsylvania\",\n          \"sources\": [\n            {\n              \"page\": \"Death cert. no. 4521\",\n              \"ref\": \"S3\"\n            }\n          ],\n          \"type\": \"Death\"\n        }\n      ],\n      \"gender\": \"Male\",\n      \"id\": \"I1\",\n      \"names\": [\n        {\n          \"given\": \"Patrick\",\n          \"id\": \"N1\",\n          \"preferred\": true,\n          \"surname\": \"Flynn\",\n          \"type\": \"BirthName\"\n        }\n      ]\n    },\n    {\n      \"facts\": [\n        {\n          \"date\": \"~1818\",\n          \"id\": \"F3\",\n          \"place\": \"Ireland\",\n          \"primary\": true,\n          \"type\": \"Birth\"\n        }\n      ],\n      \"gender\": \"Male\",\n      \"id\": \"I2\",\n      \"names\": [\n        {\n          \"given\": \"Thomas\",\n          \"id\": \"N2\",\n          \"preferred\": true,\n          \"surname\": \"Flynn\",\n          \"type\": \"BirthName\"\n        }\n      ]\n    }\n  ],\n  \"relationships\": [\n    {\n      \"child\": \"I1\",\n      \"id\": \"R1\",\n      \"parent\": \"I2\",\n      \"sources\": [\n        {\n          \"page\": \"1850 Census, Schuylkill Co., dwelling 84\",\n          \"quality\": 2,\n          \"ref\": \"S1\"\n        },\n        {\n          \"page\": \"1860 Census, Schuylkill Co., dwelling 112\",\n          \"quality\": 2,\n          \"ref\": \"S2\"\n        },\n        {\n          \"page\": \"Death cert. no. 4521\",\n          \"quality\": 2,\n          \"ref\": \"S3\"\n        }\n      ],\n      \"type\": \"ParentChild\"\n    }\n  ],\n  \"sources\": [\n    {\n      \"author\": \"U.S. Census Bureau\",\n      \"id\": \"S1\",\n      \"title\": \"1850 U.S. Federal Census\"\n    },\n    {\n      \"author\": \"U.S. Census Bureau\",\n      \"id\": \"S2\",\n      \"title\": \"1860 U.S. Federal Census\"\n    },\n    {\n      \"author\": \"Pennsylvania Dept. of Health\",\n      \"id\": \"S3\",\n      \"title\": \"Pennsylvania Death Certificates\"\n    },\n    {\n      \"author\": \"Schuylkill County Register of Wills\",\n      \"id\": \"S4\",\n      \"title\": \"Schuylkill County Probate Records\"\n    }\n  ]\n}\n",
+    "eval/fixtures/scenarios/flynn-parentage-found/README.md": "# flynn-parentage-found\n\nPatrick Flynn parentage research \u2014 the father (Thomas Flynn) has been confirmed, but the mother is unknown. The project is still active because the objective (\"Identify the parents\") requires both parents.\n\n## State\n\n- **Objective:** Identify the parents of Patrick Flynn, born ca. 1845 in Pennsylvania, died 1908 in Schuylkill County, PA\n- **Questions:** q_001 (Who was Patrick Flynn's father? \u2014 resolved: Thomas Flynn), q_002 (1850 census placement \u2014 resolved)\n- **Plans:** pl_001 (1850 census, completed), pl_002 (paternity evidence, completed)\n- **Project status:** active \u2014 mother not yet identified\n- **Proof summary:** ps_001 tier `proved` for the paternity sub-question\n\n## Differs from `mid-research-flynn`\n\n- **`questions[q_001]`:** Rescoped to \"Who was Patrick Flynn's father?\" (not \"parents\"), `status: \"resolved\"`, `resolution_assertion_ids` populated, `exhaustive_declaration.declared: true`\n- **`plans[pl_002]`:** `status: \"completed\"`, probate item (`pli_006`) added and completed (negative result)\n- **`log`:** Adds `log_006` \u2014 probate search, negative outcome\n- **`proof_summaries[ps_001].tier`:** `proved` (three independent sources, conflict resolved, probate searched)\n\n## Used by\n\n- `question-selection` tests where the next question should set `depends_on: [\"q_001\"]` \u2014 specifically, a question about Patrick Flynn's mother, which is most efficiently pursued by examining the same Thomas Flynn household records (and thus depends on the confirmed father identification from q_001).\n- Tests of the **Dependency-awareness** rubric dimension: `depends_on` and `unblocks` must be correctly populated when prior questions are relevant.\n",
+    "eval/fixtures/scenarios/flynn-parentage-found/research.json": "{\n  \"assertions\": [\n    {\n      \"date\": null,\n      \"date_certainty\": null,\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_002\"\n      ],\n      \"fact_type\": \"name\",\n      \"id\": \"a_001\",\n      \"informant\": \"Unknown informant reporting to census enumerator\",\n      \"informant_bias_notes\": \"Census enumerator is the recorder, not the informant.\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_001\",\n      \"place\": null,\n      \"record_id\": \"ark:/61903/1:1:MXYZ\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_001\",\n      \"structured_value\": {\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"value\": \"Patrick Flynn\"\n    },\n    {\n      \"date\": \"~1845\",\n      \"date_certainty\": \"estimated\",\n      \"evidence_type\": \"indirect\",\n      \"extracted_for_question_ids\": [\n        \"q_002\"\n      ],\n      \"fact_type\": \"birth\",\n      \"id\": \"a_002\",\n      \"informant\": \"Unknown \u2014 most likely a household member\",\n      \"informant_bias_notes\": \"Age and birthplace require active reporting by an informant.\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_001\",\n      \"place\": \"Ireland\",\n      \"record_id\": \"ark:/61903/1:1:MXYZ\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_001\",\n      \"structured_value\": {\n        \"place\": \"Ireland\",\n        \"year\": 1845\n      },\n      \"value\": \"age 5\"\n    },\n    {\n      \"date\": \"1850\",\n      \"date_certainty\": \"exact\",\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_002\"\n      ],\n      \"fact_type\": \"residence\",\n      \"id\": \"a_003\",\n      \"informant\": \"Census enumerator (witness to residence)\",\n      \"informant_bias_notes\": \"Enumerator physically visited the dwelling.\",\n      \"informant_proximity\": \"witness\",\n      \"information_quality\": \"primary\",\n      \"log_entry_id\": \"log_001\",\n      \"place\": \"Schuylkill County, Pennsylvania\",\n      \"record_id\": \"ark:/61903/1:1:MXYZ\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_001\",\n      \"structured_value\": null,\n      \"value\": \"Schuylkill County, Pennsylvania\"\n    },\n    {\n      \"date\": \"1850\",\n      \"date_certainty\": \"exact\",\n      \"evidence_type\": \"indirect\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"relationship\",\n      \"id\": \"a_004\",\n      \"informant\": \"Inferred from household structure\",\n      \"informant_bias_notes\": \"1850 census does not state relationships.\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_001\",\n      \"place\": \"Schuylkill County, Pennsylvania\",\n      \"record_id\": \"ark:/61903/1:1:MXYZ\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_001\",\n      \"structured_value\": {\n        \"related_person_role\": \"head_of_household\",\n        \"relationship_type\": \"child_inferred\"\n      },\n      \"value\": \"Listed in household of Thomas Flynn (head), position consistent with child\"\n    },\n    {\n      \"date\": \"1860\",\n      \"date_certainty\": \"exact\",\n      \"evidence_type\": \"indirect\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"relationship\",\n      \"id\": \"a_005\",\n      \"informant\": \"Inferred from household structure\",\n      \"informant_bias_notes\": \"1860 census does not state relationships.\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_004\",\n      \"place\": \"Schuylkill County, Pennsylvania\",\n      \"record_id\": \"ark:/61903/1:1:MABC\",\n      \"record_role\": \"child_2\",\n      \"source_id\": \"src_003\",\n      \"structured_value\": {\n        \"related_person_role\": \"head_of_household\",\n        \"relationship_type\": \"child_inferred\"\n      },\n      \"value\": \"Listed in household of Thomas Flynn (head), position and age consistent with son\"\n    },\n    {\n      \"date\": null,\n      \"date_certainty\": null,\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"relationship\",\n      \"id\": \"a_006\",\n      \"informant\": \"James Brown (son-in-law)\",\n      \"informant_bias_notes\": \"Secondary \u2014 son-in-law reporting parentage.\",\n      \"informant_proximity\": \"family_not_present\",\n      \"information_quality\": \"secondary\",\n      \"log_entry_id\": \"log_005\",\n      \"place\": null,\n      \"record_id\": \"ark:/61903/1:1:MDEF\",\n      \"record_role\": \"deceased\",\n      \"source_id\": \"src_004\",\n      \"structured_value\": {\n        \"related_person_role\": \"deceased\",\n        \"relationship_type\": \"father\"\n      },\n      \"value\": \"Father: Thomas Flynn\"\n    }\n  ],\n  \"conflicts\": [\n    {\n      \"blocks_question_ids\": [],\n      \"competing_assertion_ids\": [\n        \"a_002\",\n        \"a_006\"\n      ],\n      \"conflict_type\": \"fact\",\n      \"description\": \"Patrick Flynn's birthplace: Ireland (censuses) vs. Pennsylvania (death certificate)\",\n      \"disputed_attribute\": \"birthplace\",\n      \"id\": \"c_001\",\n      \"identity_question\": null,\n      \"independence_analysis\": \"The two census records are independent originals. The death certificate is a third independent original.\",\n      \"preferred_assertion_id\": \"a_002\",\n      \"resolution_rationale\": \"Ireland accepted. Son-in-law may have confused birthplace with residence.\",\n      \"status\": \"resolved\",\n      \"weighing_analysis\": \"Census records are contemporary; death certificate is 63 years later with a secondary informant.\"\n    }\n  ],\n  \"evaluations\": [],\n  \"hypotheses\": [\n    {\n      \"claim\": \"Thomas Flynn was the father of Patrick Flynn\",\n      \"contradicting_assertion_ids\": [],\n      \"id\": \"h_001\",\n      \"notes\": \"Three independent source types confirm Thomas Flynn as Patrick's father. Question q_001 is resolved; no further hypothesis testing for paternity is needed. The remaining objective gap is the mother's identity.\",\n      \"related_question_ids\": [\n        \"q_001\"\n      ],\n      \"ruled_out\": false,\n      \"ruled_out_reason\": null,\n      \"status\": \"supported\",\n      \"supporting_assertion_ids\": [\n        \"a_004\",\n        \"a_005\",\n        \"a_006\"\n      ]\n    }\n  ],\n  \"log\": [\n    {\n      \"external_site\": null,\n      \"id\": \"log_001\",\n      \"notes\": \"Found Patrick Flynn age 5 in household of Thomas Flynn, dwelling 84, Schuylkill Co.\",\n      \"outcome\": \"positive\",\n      \"performed\": \"2026-05-01T10:15:00Z\",\n      \"plan_item_id\": \"pli_001\",\n      \"query\": {\n        \"birth_place\": \"Pennsylvania\",\n        \"birth_year\": 1845,\n        \"collection\": \"1850 Census\",\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"results_examined\": 8,\n      \"tool\": \"record_search\"\n    },\n    {\n      \"external_site\": {\n        \"capture_filename\": \"ancestry-1850-flynn-results.pdf\",\n        \"capture_received\": true,\n        \"site\": \"ancestry\",\n        \"url_generated\": \"https://www.ancestry.com/search/collections/8054/?name=Patrick_Flynn&birth=1845&birthplace=Pennsylvania\"\n      },\n      \"id\": \"log_002\",\n      \"notes\": \"Ancestry index confirms same household.\",\n      \"outcome\": \"positive\",\n      \"performed\": \"2026-05-01T11:30:00Z\",\n      \"plan_item_id\": \"pli_002\",\n      \"query\": {\n        \"birth_place\": \"Pennsylvania\",\n        \"birth_year\": 1845,\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"results_examined\": 12,\n      \"tool\": \"external_site\"\n    },\n    {\n      \"external_site\": {\n        \"capture_filename\": \"myheritage-1850-flynn-nil.pdf\",\n        \"capture_received\": true,\n        \"site\": \"myheritage\",\n        \"url_generated\": \"https://www.myheritage.com/research?action=query&first=Patrick&last=Flynn&birth_year=1845&birth_place=Pennsylvania\"\n      },\n      \"id\": \"log_003\",\n      \"notes\": \"MyHeritage returned no results.\",\n      \"outcome\": \"negative\",\n      \"performed\": \"2026-05-01T14:00:00Z\",\n      \"plan_item_id\": \"pli_003\",\n      \"query\": {\n        \"birth_place\": \"Pennsylvania\",\n        \"birth_year\": 1845,\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"results_examined\": 0,\n      \"tool\": \"external_site\"\n    },\n    {\n      \"external_site\": null,\n      \"id\": \"log_004\",\n      \"notes\": \"Patrick Flynn age 15 in Thomas Flynn household, Schuylkill Co.\",\n      \"outcome\": \"positive\",\n      \"performed\": \"2026-05-02T09:00:00Z\",\n      \"plan_item_id\": \"pli_004\",\n      \"query\": {\n        \"birth_place\": \"Pennsylvania\",\n        \"birth_year\": 1845,\n        \"collection\": \"1860 Census\",\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"results_examined\": 5,\n      \"tool\": \"record_search\"\n    },\n    {\n      \"external_site\": null,\n      \"id\": \"log_005\",\n      \"notes\": \"Death certificate found. Names Thomas Flynn as father. Informant: James Brown (son-in-law).\",\n      \"outcome\": \"positive\",\n      \"performed\": \"2026-05-03T10:00:00Z\",\n      \"plan_item_id\": \"pli_005\",\n      \"query\": {\n        \"death_place\": \"Schuylkill County, Pennsylvania\",\n        \"death_year\": 1908,\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"results_examined\": 2,\n      \"tool\": \"record_search\"\n    },\n    {\n      \"external_site\": null,\n      \"id\": \"log_006\",\n      \"notes\": \"No Thomas Flynn probate found in Schuylkill County Register of Wills 1870\u20131890. May have died elsewhere, died intestate, or records were lost.\",\n      \"outcome\": \"negative\",\n      \"performed\": \"2026-05-06T11:00:00Z\",\n      \"plan_item_id\": \"pli_006\",\n      \"query\": {\n        \"collection\": \"Probate Records\",\n        \"given\": \"Thomas\",\n        \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n        \"surname\": \"Flynn\"\n      },\n      \"results_examined\": 0,\n      \"tool\": \"record_search\"\n    }\n  ],\n  \"person_evidence\": [\n    {\n      \"assertion_id\": \"a_001\",\n      \"confidence\": \"confident\",\n      \"created\": \"2026-05-01\",\n      \"id\": \"pe_001\",\n      \"match_score\": null,\n      \"person_id\": \"I1\",\n      \"rationale\": \"Name matches, age consistent, located in Schuylkill County.\",\n      \"superseded_by\": null\n    },\n    {\n      \"assertion_id\": \"a_004\",\n      \"confidence\": \"probable\",\n      \"created\": \"2026-05-01\",\n      \"id\": \"pe_002\",\n      \"match_score\": null,\n      \"person_id\": \"I1\",\n      \"rationale\": \"Household position and shared surname suggest parent-child relationship.\",\n      \"superseded_by\": null\n    },\n    {\n      \"assertion_id\": \"a_005\",\n      \"confidence\": \"confident\",\n      \"created\": \"2026-05-02\",\n      \"id\": \"pe_003\",\n      \"match_score\": null,\n      \"person_id\": \"I1\",\n      \"rationale\": \"Patrick Flynn age 15 in Thomas Flynn household, 1860 census.\",\n      \"superseded_by\": null\n    },\n    {\n      \"assertion_id\": \"a_006\",\n      \"confidence\": \"confident\",\n      \"created\": \"2026-05-03\",\n      \"id\": \"pe_004\",\n      \"match_score\": null,\n      \"person_id\": \"I1\",\n      \"rationale\": \"Death certificate names Thomas Flynn as father.\",\n      \"superseded_by\": null\n    }\n  ],\n  \"plans\": [\n    {\n      \"created\": \"2026-05-01\",\n      \"id\": \"pl_001\",\n      \"items\": [\n        {\n          \"date_range\": \"1850\",\n          \"fallback_for\": null,\n          \"id\": \"pli_001\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"1850 census fully indexed on FamilySearch.\",\n          \"record_type\": \"census\",\n          \"repository\": \"FamilySearch\",\n          \"sequence\": 1,\n          \"status\": \"completed\"\n        },\n        {\n          \"date_range\": \"1850\",\n          \"fallback_for\": null,\n          \"id\": \"pli_002\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"Ancestry has independent indexing.\",\n          \"record_type\": \"census\",\n          \"repository\": \"Ancestry\",\n          \"sequence\": 2,\n          \"status\": \"completed\"\n        },\n        {\n          \"date_range\": \"1850\",\n          \"fallback_for\": null,\n          \"id\": \"pli_003\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"Third independent index for coverage confirmation.\",\n          \"record_type\": \"census\",\n          \"repository\": \"MyHeritage\",\n          \"sequence\": 3,\n          \"status\": \"completed\"\n        }\n      ],\n      \"question_id\": \"q_002\",\n      \"status\": \"completed\"\n    },\n    {\n      \"created\": \"2026-05-02\",\n      \"id\": \"pl_002\",\n      \"items\": [\n        {\n          \"date_range\": \"1860\",\n          \"fallback_for\": null,\n          \"id\": \"pli_004\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"Confirm Patrick still in Thomas Flynn household in 1860.\",\n          \"record_type\": \"census\",\n          \"repository\": \"FamilySearch\",\n          \"sequence\": 1,\n          \"status\": \"completed\"\n        },\n        {\n          \"date_range\": \"1908\",\n          \"fallback_for\": null,\n          \"id\": \"pli_005\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"Death certificate may name parents directly.\",\n          \"record_type\": \"vital_record\",\n          \"repository\": \"FamilySearch\",\n          \"sequence\": 2,\n          \"status\": \"completed\"\n        },\n        {\n          \"date_range\": \"1870-1890\",\n          \"fallback_for\": null,\n          \"id\": \"pli_006\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"Thomas Flynn's will, if found, would directly name children.\",\n          \"record_type\": \"probate\",\n          \"repository\": \"FamilySearch\",\n          \"sequence\": 3,\n          \"status\": \"completed\"\n        }\n      ],\n      \"question_id\": \"q_001\",\n      \"status\": \"completed\"\n    }\n  ],\n  \"project\": {\n    \"created\": \"2026-05-01\",\n    \"id\": \"rp_001\",\n    \"objective\": \"Identify the parents of Patrick Flynn, born ca. 1845 in Pennsylvania, died 1908 in Schuylkill County, PA\",\n    \"status\": \"active\",\n    \"subject_person_ids\": [\n      \"I1\"\n    ],\n    \"updated\": \"2026-05-08\"\n  },\n  \"proof_summaries\": [\n    {\n      \"exhaustive_search_summary\": \"Searched 1850 census (FamilySearch, Ancestry, MyHeritage), 1860 census (FamilySearch), death certificate (FamilySearch), probate records 1870\u20131890 (FamilySearch). Three independent source types confirm Thomas Flynn as father. Probate negative but does not undermine the conclusion.\",\n      \"id\": \"ps_001\",\n      \"narrative_markdown\": \"Patrick Flynn's father was **Thomas Flynn** of Schuylkill County, Pennsylvania. Three independent source types confirm this conclusion: co-enumeration in the 1850 and 1860 censuses and a death certificate naming Thomas as father. Birthplace conflict resolved in favor of Ireland. Probate search returned no will.\",\n      \"question_id\": \"q_001\",\n      \"resolved_conflict_ids\": [\n        \"c_001\"\n      ],\n      \"supporting_assertion_ids\": [\n        \"a_004\",\n        \"a_005\",\n        \"a_006\"\n      ],\n      \"tier\": \"proved\",\n      \"vehicle\": \"summary\"\n    }\n  ],\n  \"questions\": [\n    {\n      \"created\": \"2026-05-01\",\n      \"depends_on\": [],\n      \"exhaustive_declaration\": {\n        \"declared\": true,\n        \"justification\": \"Searched 1850 census (FamilySearch, Ancestry, MyHeritage), 1860 census (FamilySearch), death certificate (FamilySearch), and probate records 1870\u20131890 (Schuylkill County via FamilySearch). Thomas Flynn confirmed as father by three independent original source types. Probate search negative but does not undermine the conclusion.\",\n        \"log_entry_ids\": [\n          \"log_001\",\n          \"log_002\",\n          \"log_003\",\n          \"log_004\",\n          \"log_005\",\n          \"log_006\"\n        ],\n        \"stop_criteria\": {\n          \"conflict_resolution\": \"Birthplace conflict resolved. No other conflicts.\",\n          \"evidence_class\": \"Original sources; death certificate is secondary for parentage facts but corroborated by census evidence.\",\n          \"goal_alignment\": \"Yes \u2014 Thomas Flynn identified as father across three independent source types.\",\n          \"independent_verification\": \"Three independent source types agree: 1850 census, 1860 census, 1908 death certificate.\",\n          \"original_substitution\": \"FamilySearch provides original images for census and death certificate.\",\n          \"overturn_risk\": \"Low \u2014 consistent identification across three source types spanning 58 years.\",\n          \"repository_breadth\": \"Census (FamilySearch, Ancestry, MyHeritage), vital records (FamilySearch), probate (FamilySearch). Major repositories searched.\"\n        }\n      },\n      \"id\": \"q_001\",\n      \"priority\": \"high\",\n      \"question\": \"Who was Patrick Flynn's father?\",\n      \"rationale\": \"Identifying the father is the first decomposition of the objective. The father's household in early census records is also the most likely place to identify the mother.\",\n      \"resolution_assertion_ids\": [\n        \"a_004\",\n        \"a_005\",\n        \"a_006\"\n      ],\n      \"resolved\": \"2026-05-08\",\n      \"selection_basis\": \"objective_decomposition\",\n      \"status\": \"resolved\",\n      \"unblocks\": []\n    },\n    {\n      \"created\": \"2026-05-01\",\n      \"depends_on\": [],\n      \"exhaustive_declaration\": {\n        \"declared\": true,\n        \"justification\": \"Searched 1850 census on FamilySearch, Ancestry, and MyHeritage. All confirmed Patrick Flynn age 5 in Thomas Flynn household, Schuylkill County.\",\n        \"log_entry_ids\": [\n          \"log_001\",\n          \"log_002\",\n          \"log_003\"\n        ],\n        \"stop_criteria\": {\n          \"conflict_resolution\": \"No conflicts on placement.\",\n          \"evidence_class\": \"Original census image.\",\n          \"goal_alignment\": \"Yes \u2014 Patrick Flynn located in a specific 1850 household.\",\n          \"independent_verification\": \"FamilySearch and Ancestry confirm same household.\",\n          \"original_substitution\": \"FamilySearch provides original image.\",\n          \"overturn_risk\": \"Low.\",\n          \"repository_breadth\": \"Three major repositories searched.\"\n        }\n      },\n      \"id\": \"q_002\",\n      \"priority\": \"high\",\n      \"question\": \"Where was Patrick Flynn in the 1850 census?\",\n      \"rationale\": \"The 1850 census is the earliest enumeration where Patrick would appear by name (age ~5). Locating him in a household identifies candidate parents.\",\n      \"resolution_assertion_ids\": [\n        \"a_001\",\n        \"a_002\",\n        \"a_003\"\n      ],\n      \"resolved\": \"2026-05-02\",\n      \"selection_basis\": \"objective_decomposition\",\n      \"status\": \"resolved\",\n      \"unblocks\": [\n        \"q_001\"\n      ]\n    }\n  ],\n  \"sources\": [\n    {\n      \"access_date\": \"2026-05-01\",\n      \"citation\": \"1850 U.S. Census, Schuylkill County, Pennsylvania, population schedule, dwelling 84, family 91, Thomas Flynn household; NARA microfilm publication M432, roll 810; digital image, FamilySearch.org, accessed 1 May 2026.\",\n      \"citation_detail\": {\n        \"what\": \"1850 U.S. Federal Census, population schedule\",\n        \"when_accessed\": \"2026-05-01\",\n        \"when_created\": \"1850\",\n        \"where\": \"FamilySearch.org (NARA microfilm M432, roll 810)\",\n        \"where_within\": \"Schuylkill County, dwelling 84, family 91\",\n        \"who\": \"U.S. Census Bureau\"\n      },\n      \"gedcomx_source_description_id\": \"S1\",\n      \"id\": \"src_001\",\n      \"log_entry_id\": \"log_001\",\n      \"notes\": \"Image quality good.\",\n      \"repository\": \"FamilySearch\",\n      \"source_classification\": \"original\",\n      \"url\": \"https://www.familysearch.org/ark:/61903/1:1:MXYZ\",\n      \"url_archived\": null\n    },\n    {\n      \"access_date\": \"2026-05-01\",\n      \"citation\": \"1850 U.S. Census, Schuylkill County, Pennsylvania, population schedule, dwelling 84, Thomas Flynn household; digital image, Ancestry.com, accessed 1 May 2026.\",\n      \"citation_detail\": {\n        \"what\": \"1850 U.S. Federal Census, population schedule (Ancestry index)\",\n        \"when_accessed\": \"2026-05-01\",\n        \"when_created\": \"1850\",\n        \"where\": \"Ancestry.com\",\n        \"where_within\": \"Schuylkill County, dwelling 84\",\n        \"who\": \"U.S. Census Bureau\"\n      },\n      \"gedcomx_source_description_id\": \"S1\",\n      \"id\": \"src_002\",\n      \"log_entry_id\": \"log_002\",\n      \"notes\": \"Ancestry's index of the same original census. Transcription consistent with FamilySearch.\",\n      \"repository\": \"Ancestry\",\n      \"source_classification\": \"derivative\",\n      \"url\": null,\n      \"url_archived\": null\n    },\n    {\n      \"access_date\": \"2026-05-02\",\n      \"citation\": \"1860 U.S. Census, Schuylkill County, Pennsylvania, population schedule, dwelling 112, family 119, Thomas Flynn household; NARA microfilm publication M653, roll 1141; digital image, FamilySearch.org, accessed 2 May 2026.\",\n      \"citation_detail\": {\n        \"what\": \"1860 U.S. Federal Census, population schedule\",\n        \"when_accessed\": \"2026-05-02\",\n        \"when_created\": \"1860\",\n        \"where\": \"FamilySearch.org (NARA microfilm M653, roll 1141)\",\n        \"where_within\": \"Schuylkill County, dwelling 112, family 119\",\n        \"who\": \"U.S. Census Bureau\"\n      },\n      \"gedcomx_source_description_id\": \"S2\",\n      \"id\": \"src_003\",\n      \"log_entry_id\": \"log_004\",\n      \"notes\": null,\n      \"repository\": \"FamilySearch\",\n      \"source_classification\": \"original\",\n      \"url\": \"https://www.familysearch.org/ark:/61903/1:1:MABC\",\n      \"url_archived\": null\n    },\n    {\n      \"access_date\": \"2026-05-03\",\n      \"citation\": \"Pennsylvania Department of Health, death certificate no. 4521 (1908), Patrick Flynn; Pennsylvania State Archives, Harrisburg; digital image, FamilySearch.org, accessed 3 May 2026.\",\n      \"citation_detail\": {\n        \"what\": \"Death certificate no. 4521\",\n        \"when_accessed\": \"2026-05-03\",\n        \"when_created\": \"1908-03-14\",\n        \"where\": \"FamilySearch.org (Pennsylvania State Archives, Harrisburg)\",\n        \"where_within\": \"Certificate no. 4521\",\n        \"who\": \"Pennsylvania Department of Health; informant: James Brown (son-in-law)\"\n      },\n      \"gedcomx_source_description_id\": \"S3\",\n      \"id\": \"src_004\",\n      \"log_entry_id\": \"log_005\",\n      \"notes\": \"Informant is son-in-law James Brown. Primary for death facts, secondary for birth/parentage facts.\",\n      \"repository\": \"FamilySearch\",\n      \"source_classification\": \"original\",\n      \"url\": \"https://www.familysearch.org/ark:/61903/1:1:MDEF\",\n      \"url_archived\": null\n    }\n  ],\n  \"timelines\": [\n    {\n      \"events\": [\n        {\n          \"assertion_ids\": [\n            \"a_002\"\n          ],\n          \"date\": \"~1845\",\n          \"date_certainty\": \"estimated\",\n          \"description\": \"Born in Ireland\",\n          \"event_type\": \"birth\",\n          \"place\": \"Ireland\"\n        },\n        {\n          \"assertion_ids\": [\n            \"a_003\",\n            \"a_004\"\n          ],\n          \"date\": \"1850\",\n          \"date_certainty\": \"exact\",\n          \"description\": \"Enumerated age 5 in Thomas Flynn household\",\n          \"event_type\": \"census\",\n          \"place\": \"Schuylkill County, Pennsylvania\"\n        },\n        {\n          \"assertion_ids\": [\n            \"a_005\"\n          ],\n          \"date\": \"1860\",\n          \"date_certainty\": \"exact\",\n          \"description\": \"Enumerated age 15 in Thomas Flynn household\",\n          \"event_type\": \"census\",\n          \"place\": \"Schuylkill County, Pennsylvania\"\n        },\n        {\n          \"assertion_ids\": [\n            \"a_006\"\n          ],\n          \"date\": \"1908-03-12\",\n          \"date_certainty\": \"exact\",\n          \"description\": \"Died, death certificate names Thomas Flynn as father\",\n          \"event_type\": \"death\",\n          \"place\": \"Schuylkill County, Pennsylvania\"\n        }\n      ],\n      \"gaps\": [\n        {\n          \"end\": \"1908-03-12\",\n          \"expected_events\": [\n            \"marriage\",\n            \"1870_census\",\n            \"1880_census\",\n            \"1900_census\"\n          ],\n          \"severity\": \"low\",\n          \"start\": \"1860-01-01\"\n        }\n      ],\n      \"generated\": \"2026-05-08T12:00:00Z\",\n      \"hypothesis_id\": \"h_001\",\n      \"id\": \"t_001\",\n      \"impossibilities\": [],\n      \"label\": \"Patrick Flynn\",\n      \"person_ids\": [\n        \"I1\"\n      ]\n    }\n  ]\n}\n",
+    "eval/fixtures/scenarios/flynn-parentage-found/tree.gedcomx.json": "{\n  \"persons\": [\n    {\n      \"facts\": [\n        {\n          \"date\": \"~1845\",\n          \"id\": \"F1\",\n          \"place\": \"Ireland\",\n          \"primary\": true,\n          \"sources\": [\n            {\n              \"page\": \"1850 Census, Schuylkill Co., dwelling 84\",\n              \"ref\": \"S1\"\n            }\n          ],\n          \"type\": \"Birth\"\n        },\n        {\n          \"date\": \"1908-03-12\",\n          \"id\": \"F2\",\n          \"place\": \"Schuylkill County, Pennsylvania\",\n          \"sources\": [\n            {\n              \"page\": \"Death cert. no. 4521\",\n              \"ref\": \"S3\"\n            }\n          ],\n          \"type\": \"Death\"\n        }\n      ],\n      \"gender\": \"Male\",\n      \"id\": \"I1\",\n      \"names\": [\n        {\n          \"given\": \"Patrick\",\n          \"id\": \"N1\",\n          \"preferred\": true,\n          \"surname\": \"Flynn\",\n          \"type\": \"BirthName\"\n        }\n      ]\n    },\n    {\n      \"facts\": [\n        {\n          \"date\": \"~1818\",\n          \"id\": \"F3\",\n          \"place\": \"Ireland\",\n          \"primary\": true,\n          \"type\": \"Birth\"\n        }\n      ],\n      \"gender\": \"Male\",\n      \"id\": \"I2\",\n      \"names\": [\n        {\n          \"given\": \"Thomas\",\n          \"id\": \"N2\",\n          \"preferred\": true,\n          \"surname\": \"Flynn\",\n          \"type\": \"BirthName\"\n        }\n      ]\n    }\n  ],\n  \"relationships\": [\n    {\n      \"child\": \"I1\",\n      \"id\": \"R1\",\n      \"parent\": \"I2\",\n      \"sources\": [\n        {\n          \"page\": \"1850 Census, Schuylkill Co., dwelling 84\",\n          \"quality\": 3,\n          \"ref\": \"S1\"\n        },\n        {\n          \"page\": \"1860 Census, Schuylkill Co., dwelling 112\",\n          \"quality\": 3,\n          \"ref\": \"S2\"\n        },\n        {\n          \"page\": \"Death cert. no. 4521\",\n          \"quality\": 3,\n          \"ref\": \"S3\"\n        }\n      ],\n      \"type\": \"ParentChild\"\n    }\n  ],\n  \"sources\": [\n    {\n      \"author\": \"U.S. Census Bureau\",\n      \"id\": \"S1\",\n      \"title\": \"1850 U.S. Federal Census\"\n    },\n    {\n      \"author\": \"U.S. Census Bureau\",\n      \"id\": \"S2\",\n      \"title\": \"1860 U.S. Federal Census\"\n    },\n    {\n      \"author\": \"Pennsylvania Dept. of Health\",\n      \"id\": \"S3\",\n      \"title\": \"Pennsylvania Death Certificates\"\n    },\n    {\n      \"author\": \"Schuylkill County Register of Wills\",\n      \"id\": \"S4\",\n      \"title\": \"Schuylkill County Probate Records\"\n    }\n  ]\n}\n",
+    "eval/fixtures/scenarios/flynn-unsourced-tree/README.md": "# flynn-unsourced-tree\n\nPatrick Flynn parentage research \u2014 the only basis for the Thomas Flynn parentage claim is an unsourced online family tree. No original records have been searched. Built for question-selection tests that exercise the **unsound-premise guard**: the skill must verify the premise before building research questions on top of it.\n\n## State\n\n- **Objective:** Identify the parents of Patrick Flynn, born ca. 1845 in Pennsylvania, died 1908 in Schuylkill County, PA\n- **Questions:** q_001 (parentage, open)\n- **Plans:** none\n- **Log:** log_001 \u2014 online tree consulted, Thomas Flynn listed as father with no cited sources\n- **Sources:** src_001 \u2014 compiled online family tree (Ancestry Member Tree), no underlying original records cited\n- **Assertions:** a_001 \u2014 relationship claim from online tree (Thomas Flynn = father of Patrick Flynn)\n- **Hypotheses:** h_001 \u2014 Thomas Flynn as father, status: `unverified`\n\n## Key characteristics\n\nThe Thomas Flynn parentage claim originates entirely from a compiled source (an Ancestry Member Tree) with no supporting original records. Per the SKILL.md rule: \"Do not build a question on unverified claims from compiled sources (online trees, unsourced genealogies). If the premise is unverified, the first question should verify it.\"\n\nThe skill must NOT formulate a question that assumes Thomas Flynn is the father (e.g., \"What does Thomas Flynn's will say?\"). Instead, the first question should verify the claim: \"Was Thomas Flynn the father of Patrick Flynn, as recorded in the Flynn family online tree?\"\n\n## Used by\n\n- `question-selection` tests for the **unsound-premise guard** \u2014 the skill must recognize that the parentage premise is unverified and propose a verification question rather than building on the online tree claim.\n",
+    "eval/fixtures/scenarios/flynn-unsourced-tree/research.json": "{\n  \"assertions\": [\n    {\n      \"date\": null,\n      \"date_certainty\": null,\n      \"evidence_type\": \"indirect\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"relationship\",\n      \"id\": \"a_001\",\n      \"informant\": \"Unknown tree owner (compiled source)\",\n      \"informant_bias_notes\": \"Compiled online tree with no original sources cited. The basis for this claim is unknown \u2014 it may derive from another unsourced tree, a misidentification, or an unrecorded family tradition. Cannot be treated as evidence until verified against original records.\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_001\",\n      \"place\": null,\n      \"record_id\": \"ancestry-member-tree:patrick-flynn-1845\",\n      \"record_role\": \"child\",\n      \"source_id\": \"src_001\",\n      \"structured_value\": {\n        \"related_person_role\": \"deceased\",\n        \"relationship_type\": \"father\"\n      },\n      \"value\": \"Father: Thomas Flynn (per Flynn Family Tree, Ancestry.com)\"\n    }\n  ],\n  \"conflicts\": [],\n  \"evaluations\": [],\n  \"hypotheses\": [\n    {\n      \"claim\": \"Thomas Flynn was the father of Patrick Flynn\",\n      \"contradicting_assertion_ids\": [],\n      \"id\": \"h_001\",\n      \"notes\": \"Claim derives from a single unsourced online family tree. No original record has corroborated this. Must be treated as a hypothesis to be tested, not an established fact.\",\n      \"related_question_ids\": [\n        \"q_001\"\n      ],\n      \"ruled_out\": false,\n      \"ruled_out_reason\": null,\n      \"status\": \"active\",\n      \"supporting_assertion_ids\": [\n        \"a_001\"\n      ]\n    }\n  ],\n  \"log\": [\n    {\n      \"external_site\": {\n        \"capture_filename\": null,\n        \"capture_received\": false,\n        \"site\": \"ancestry\",\n        \"url_generated\": \"https://www.ancestry.com/search/?name=Patrick_Flynn&birth=1845&birth_place=Pennsylvania\"\n      },\n      \"id\": \"log_001\",\n      \"notes\": \"Located the 'Flynn Family Tree' on Ancestry.com. Lists Thomas Flynn (b. ~1815, Ireland) as Patrick Flynn's father. The tree owner has not attached any original source records to support this claim \u2014 no census images, no vital records, no church records. The relationship is asserted without citation.\",\n      \"outcome\": \"positive\",\n      \"performed\": \"2026-05-15T09:00:00Z\",\n      \"plan_item_id\": null,\n      \"query\": {\n        \"birth_year\": 1845,\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"results_examined\": 1,\n      \"tool\": \"external_site\"\n    }\n  ],\n  \"person_evidence\": [\n    {\n      \"assertion_id\": \"a_001\",\n      \"confidence\": \"speculative\",\n      \"created\": \"2026-05-15\",\n      \"id\": \"pe_001\",\n      \"match_score\": null,\n      \"person_id\": \"I1\",\n      \"rationale\": \"Online tree claim only. No original sources support the relationship. Needs verification.\",\n      \"superseded_by\": null\n    }\n  ],\n  \"plans\": [],\n  \"project\": {\n    \"created\": \"2026-05-15\",\n    \"id\": \"rp_001\",\n    \"objective\": \"Identify the parents of Patrick Flynn, born ca. 1845 in Pennsylvania, died 1908 in Schuylkill County, PA\",\n    \"status\": \"active\",\n    \"subject_person_ids\": [\n      \"I1\"\n    ],\n    \"updated\": \"2026-05-15\"\n  },\n  \"proof_summaries\": [],\n  \"questions\": [\n    {\n      \"created\": \"2026-05-15\",\n      \"depends_on\": [],\n      \"exhaustive_declaration\": {\n        \"declared\": false,\n        \"justification\": null,\n        \"log_entry_ids\": [],\n        \"stop_criteria\": null\n      },\n      \"id\": \"q_001\",\n      \"priority\": \"high\",\n      \"question\": \"Who were the parents of Patrick Flynn (b. ~1845, PA, d. 1908)?\",\n      \"rationale\": \"This is the primary research objective.\",\n      \"resolution_assertion_ids\": [],\n      \"resolved\": null,\n      \"selection_basis\": \"objective_decomposition\",\n      \"status\": \"open\",\n      \"unblocks\": []\n    }\n  ],\n  \"sources\": [\n    {\n      \"access_date\": \"2026-05-15\",\n      \"citation\": \"Flynn Family Tree, Ancestry.com Member Trees, accessed 15 May 2026. Tree owner: [username withheld]. No underlying source records cited.\",\n      \"citation_detail\": {\n        \"what\": \"Compiled online family tree\",\n        \"when_accessed\": \"2026-05-15\",\n        \"when_created\": \"unknown\",\n        \"where\": \"Ancestry.com Member Trees\",\n        \"where_within\": \"Patrick Flynn profile\",\n        \"who\": \"Unknown tree owner (Ancestry Member Tree)\"\n      },\n      \"gedcomx_source_description_id\": \"S1\",\n      \"id\": \"src_001\",\n      \"log_entry_id\": \"log_001\",\n      \"notes\": \"Compiled source only. No original records attached. This is an unsourced claim and must be verified against original records before being used as a research foundation.\",\n      \"repository\": \"Ancestry\",\n      \"source_classification\": \"derivative\",\n      \"url\": null,\n      \"url_archived\": null\n    }\n  ],\n  \"timelines\": []\n}\n",
+    "eval/fixtures/scenarios/flynn-unsourced-tree/tree.gedcomx.json": "{\n  \"persons\": [\n    {\n      \"facts\": [\n        {\n          \"date\": \"~1845\",\n          \"id\": \"F1\",\n          \"place\": \"Pennsylvania\",\n          \"primary\": true,\n          \"sources\": [\n            {\n              \"page\": \"Flynn Family Tree, Ancestry.com\",\n              \"ref\": \"S1\"\n            }\n          ],\n          \"type\": \"Birth\"\n        },\n        {\n          \"date\": \"1908\",\n          \"id\": \"F2\",\n          \"place\": \"Schuylkill County, Pennsylvania\",\n          \"sources\": [\n            {\n              \"page\": \"Flynn Family Tree, Ancestry.com\",\n              \"ref\": \"S1\"\n            }\n          ],\n          \"type\": \"Death\"\n        }\n      ],\n      \"gender\": \"Male\",\n      \"id\": \"I1\",\n      \"names\": [\n        {\n          \"given\": \"Patrick\",\n          \"id\": \"N1\",\n          \"preferred\": true,\n          \"surname\": \"Flynn\",\n          \"type\": \"BirthName\"\n        }\n      ]\n    },\n    {\n      \"facts\": [\n        {\n          \"date\": \"~1815\",\n          \"id\": \"F3\",\n          \"place\": \"Ireland\",\n          \"sources\": [\n            {\n              \"page\": \"Flynn Family Tree, Ancestry.com\",\n              \"ref\": \"S1\"\n            }\n          ],\n          \"type\": \"Birth\"\n        }\n      ],\n      \"gender\": \"Male\",\n      \"id\": \"I2\",\n      \"names\": [\n        {\n          \"given\": \"Thomas\",\n          \"id\": \"N2\",\n          \"preferred\": true,\n          \"surname\": \"Flynn\",\n          \"type\": \"BirthName\"\n        }\n      ]\n    }\n  ],\n  \"relationships\": [\n    {\n      \"child\": \"I1\",\n      \"id\": \"R1\",\n      \"parent\": \"I2\",\n      \"sources\": [\n        {\n          \"page\": \"Flynn Family Tree, Ancestry.com\",\n          \"quality\": 0,\n          \"ref\": \"S1\"\n        }\n      ],\n      \"type\": \"ParentChild\"\n    }\n  ],\n  \"sources\": [\n    {\n      \"author\": \"Unknown tree owner\",\n      \"id\": \"S1\",\n      \"title\": \"Flynn Family Tree (Ancestry Member Tree)\"\n    }\n  ]\n}\n",
+    "eval/fixtures/scenarios/mid-research-flynn/README.md": "# mid-research-flynn\n\nPatrick Flynn parentage research, mid-project.\n\n- **Objective:** Identify the parents of Patrick Flynn (b. ~1845, d. 1908)\n- **Questions:** q_001 (parentage, in_progress), q_002 (1850 census placement, resolved)\n- **Plans:** pl_001 (1850 census search, completed), pl_002 (parentage evidence, active)\n- **Log:** 5 entries \u2014 1850 census on FamilySearch/Ancestry/MyHeritage, 1860 census, death cert\n- **Sources:** 4 sources (1850 census FS, 1850 census Ancestry, 1860 census, death cert)\n- **Assertions:** 13 assertions across 4 sources\n- **Person evidence:** 6 links (Patrick \u2192 I1, Thomas \u2192 I2)\n- **Conflicts:** 1 resolved (birthplace: Ireland vs Pennsylvania)\n- **Hypotheses:** h_001 (Thomas is Patrick's father, supported)\n- **Timelines:** t_001 (Patrick, 4 events, 1 gap)\n- **Proof summaries:** ps_001 (parentage, probable)\n- **GedcomX persons:** I1 (Patrick Flynn), I2 (Thomas Flynn), I3 (Mary Flynn, sister), I4 (James Flynn, brother)\n- **GedcomX relationships:** R1 (Thomas \u2192 Patrick), R2 (Thomas \u2192 Mary), R3 (Thomas \u2192 James) \u2014 all ParentChild\n- **Note on siblings:** Mary and James are stub entries (preferred name + gender only, no facts).\n  They represent the canonical shape Dallan called for: when researching Patrick on a household\n  census, the siblings should exist as persons in `tree.gedcomx.json` so warnings like\n  `relativesChildBirthRange40` and skills like `person-evidence` can reach them. Their detailed\n  facts would land later via record-extraction + person-evidence as the user works through the\n  1850 census record.\n",
+    "eval/fixtures/scenarios/mid-research-flynn/research.json": "{\n  \"assertions\": [\n    {\n      \"date\": null,\n      \"date_certainty\": null,\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_002\"\n      ],\n      \"fact_type\": \"name\",\n      \"id\": \"a_001\",\n      \"informant\": \"Unknown informant (most likely a household member, possibly a neighbor) reporting to census enumerator\",\n      \"informant_bias_notes\": \"Census enumerator is the recorder, not the informant. The person who provided the name is unknown \u2014 most likely a household member, possibly a neighbor. Proximity is 'unknown' rather than 'household_member' because for names specifically, the enumerator may have heard the name from a neighbor or made an assumption \u2014 the name fact doesn't necessarily require active reporting the way age/birthplace does.\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_001\",\n      \"place\": null,\n      \"record_id\": \"ark:/61903/1:1:MXYZ\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_001\",\n      \"structured_value\": {\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"value\": \"Patrick Flynn\"\n    },\n    {\n      \"date\": \"~1845\",\n      \"date_certainty\": \"estimated\",\n      \"evidence_type\": \"indirect\",\n      \"extracted_for_question_ids\": [\n        \"q_002\"\n      ],\n      \"fact_type\": \"birth\",\n      \"id\": \"a_002\",\n      \"informant\": \"Unknown \u2014 most likely a household member (such as Thomas Flynn or his wife), but possibly a neighbor\",\n      \"informant_bias_notes\": \"Age and birthplace require active reporting by an informant \u2014 someone had to tell the enumerator these facts. That informant was most likely a household member, but enumerators also took information from neighbors when residents were unavailable, and the census does not identify who answered. Proximity is 'unknown' because the informant cannot be established from the record.\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_001\",\n      \"place\": \"Ireland\",\n      \"record_id\": \"ark:/61903/1:1:MXYZ\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_001\",\n      \"structured_value\": {\n        \"place\": \"Ireland\",\n        \"year\": 1845\n      },\n      \"value\": \"age 5\"\n    },\n    {\n      \"date\": \"1850\",\n      \"date_certainty\": \"exact\",\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_002\"\n      ],\n      \"fact_type\": \"residence\",\n      \"id\": \"a_003\",\n      \"informant\": \"Census enumerator (witness to residence by visiting the dwelling)\",\n      \"informant_bias_notes\": \"For residence facts specifically, the enumerator is a direct witness \u2014 they physically visited the dwelling and recorded who lived there. This distinguishes residence from other census facts where an unidentified informant (most likely a household member, possibly a neighbor) supplied the information.\",\n      \"informant_proximity\": \"witness\",\n      \"information_quality\": \"primary\",\n      \"log_entry_id\": \"log_001\",\n      \"place\": \"Schuylkill County, Pennsylvania\",\n      \"record_id\": \"ark:/61903/1:1:MXYZ\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_001\",\n      \"value\": \"Schuylkill County, Pennsylvania\"\n    },\n    {\n      \"date\": \"1850\",\n      \"date_certainty\": \"exact\",\n      \"evidence_type\": \"indirect\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"relationship\",\n      \"id\": \"a_004\",\n      \"informant\": \"Inferred from household structure \u2014 no explicit informant for relationships in 1850 census\",\n      \"informant_bias_notes\": \"1850 census does not state relationships; this assertion is inferred from household position and shared surname, not directly reported by any informant. The relationship is indirect evidence constructed by the researcher, not information provided by a census informant.\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_001\",\n      \"place\": \"Schuylkill County, Pennsylvania\",\n      \"record_id\": \"ark:/61903/1:1:MXYZ\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_001\",\n      \"structured_value\": {\n        \"related_person_role\": \"head_of_household\",\n        \"relationship_type\": \"child_inferred\"\n      },\n      \"value\": \"Listed in household of Thomas Flynn (head), position consistent with child\"\n    },\n    {\n      \"date\": null,\n      \"date_certainty\": null,\n      \"evidence_type\": \"indirect\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"name\",\n      \"id\": \"a_005\",\n      \"informant\": \"Unknown informant (likely Thomas Flynn himself) reporting to census enumerator\",\n      \"informant_bias_notes\": \"Census enumerator is the recorder, not the informant. As head of household, Thomas likely provided his own name, but the 1850 census does not identify the informant.\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_001\",\n      \"place\": null,\n      \"record_id\": \"ark:/61903/1:1:MXYZ\",\n      \"record_role\": \"head_of_household\",\n      \"source_id\": \"src_001\",\n      \"value\": \"Thomas Flynn\"\n    },\n    {\n      \"date\": null,\n      \"date_certainty\": null,\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_002\"\n      ],\n      \"fact_type\": \"name\",\n      \"id\": \"a_006\",\n      \"informant\": \"Ancestry transcriber (derivative of census enumerator)\",\n      \"informant_bias_notes\": \"Derivative index \u2014 transcription errors possible\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_002\",\n      \"place\": null,\n      \"record_id\": \"ancestry:8054:patrick-flynn-1850\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_002\",\n      \"value\": \"Patrick Flynn\"\n    },\n    {\n      \"date\": \"~1845\",\n      \"date_certainty\": \"estimated\",\n      \"evidence_type\": \"indirect\",\n      \"extracted_for_question_ids\": [\n        \"q_002\"\n      ],\n      \"fact_type\": \"birth\",\n      \"id\": \"a_007\",\n      \"informant\": \"Ancestry transcriber (derivative)\",\n      \"informant_bias_notes\": null,\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_002\",\n      \"place\": \"Ireland\",\n      \"record_id\": \"ancestry:8054:patrick-flynn-1850\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_002\",\n      \"value\": \"age 5\"\n    },\n    {\n      \"date\": null,\n      \"date_certainty\": null,\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"name\",\n      \"id\": \"a_008\",\n      \"informant\": \"Unknown informant (most likely a household member, possibly a neighbor) reporting to census enumerator\",\n      \"informant_bias_notes\": \"Census enumerator is the recorder, not the informant. Proximity is 'unknown' for names (same reasoning as a_001 \u2014 name facts don't necessarily require active reporting).\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_004\",\n      \"place\": null,\n      \"record_id\": \"ark:/61903/1:1:MABC\",\n      \"record_role\": \"child_2\",\n      \"source_id\": \"src_003\",\n      \"value\": \"Patrick Flynn\"\n    },\n    {\n      \"date\": \"~1845\",\n      \"date_certainty\": \"estimated\",\n      \"evidence_type\": \"indirect\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"birth\",\n      \"id\": \"a_009\",\n      \"informant\": \"Unknown \u2014 most likely a household member (such as Thomas Flynn or his wife), but possibly a neighbor\",\n      \"informant_bias_notes\": \"Age and birthplace require active reporting by an informant \u2014 most likely a household member, possibly a neighbor (same reasoning as a_002).\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_004\",\n      \"place\": \"Ireland\",\n      \"record_id\": \"ark:/61903/1:1:MABC\",\n      \"record_role\": \"child_2\",\n      \"source_id\": \"src_003\",\n      \"value\": \"age 15\"\n    },\n    {\n      \"date\": \"1860\",\n      \"date_certainty\": \"exact\",\n      \"evidence_type\": \"indirect\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"relationship\",\n      \"id\": \"a_010\",\n      \"informant\": \"Inferred from household structure \u2014 no explicit informant for relationships in 1860 census\",\n      \"informant_bias_notes\": \"1860 census does not state relationships; like the 1850 census, this assertion is inferred from household position, age, and shared surname. The relationship column was not introduced until the 1880 census.\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_004\",\n      \"place\": \"Schuylkill County, Pennsylvania\",\n      \"record_id\": \"ark:/61903/1:1:MABC\",\n      \"record_role\": \"child_2\",\n      \"source_id\": \"src_003\",\n      \"structured_value\": {\n        \"related_person_role\": \"head_of_household\",\n        \"relationship_type\": \"child_inferred\"\n      },\n      \"value\": \"Listed in household of Thomas Flynn (head), position and age consistent with son\"\n    },\n    {\n      \"date\": \"1908-03-12\",\n      \"date_certainty\": \"exact\",\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [],\n      \"fact_type\": \"death\",\n      \"id\": \"a_011\",\n      \"informant\": \"Attending physician (signature on certificate)\",\n      \"informant_bias_notes\": null,\n      \"informant_proximity\": \"witness\",\n      \"information_quality\": \"primary\",\n      \"log_entry_id\": \"log_005\",\n      \"place\": \"Schuylkill County, Pennsylvania\",\n      \"record_id\": \"ark:/61903/1:1:MDEF\",\n      \"record_role\": \"deceased\",\n      \"source_id\": \"src_004\",\n      \"value\": \"Died 12 March 1908\"\n    },\n    {\n      \"date\": \"1845\",\n      \"date_certainty\": \"approximate\",\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"birth\",\n      \"id\": \"a_012\",\n      \"informant\": \"James Brown (son-in-law)\",\n      \"informant_bias_notes\": \"Son-in-law reporting birth facts decades after the event. Note: death cert says Pennsylvania, but census records say Ireland. Son-in-law may not have known Patrick was born in Ireland.\",\n      \"informant_proximity\": \"family_not_present\",\n      \"information_quality\": \"secondary\",\n      \"log_entry_id\": \"log_005\",\n      \"place\": \"Pennsylvania\",\n      \"record_id\": \"ark:/61903/1:1:MDEF\",\n      \"record_role\": \"deceased\",\n      \"source_id\": \"src_004\",\n      \"structured_value\": {\n        \"place\": \"Pennsylvania\",\n        \"year\": 1845\n      },\n      \"value\": \"Born 1845, Pennsylvania\"\n    },\n    {\n      \"date\": null,\n      \"date_certainty\": null,\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"relationship\",\n      \"id\": \"a_013\",\n      \"informant\": \"James Brown (son-in-law)\",\n      \"informant_bias_notes\": \"Secondary information \u2014 son-in-law reporting what he was told about father-in-law's parentage\",\n      \"informant_proximity\": \"family_not_present\",\n      \"information_quality\": \"secondary\",\n      \"log_entry_id\": \"log_005\",\n      \"place\": null,\n      \"record_id\": \"ark:/61903/1:1:MDEF\",\n      \"record_role\": \"deceased\",\n      \"source_id\": \"src_004\",\n      \"structured_value\": {\n        \"related_person_role\": \"deceased\",\n        \"relationship_type\": \"father\"\n      },\n      \"value\": \"Father: Thomas Flynn\"\n    }\n  ],\n  \"conflicts\": [\n    {\n      \"blocks_question_ids\": [],\n      \"competing_assertion_ids\": [\n        \"a_002\",\n        \"a_009\",\n        \"a_012\"\n      ],\n      \"conflict_type\": \"fact\",\n      \"description\": \"Patrick Flynn's birthplace: Ireland (1850 and 1860 censuses) vs. Pennsylvania (1908 death certificate)\",\n      \"disputed_attribute\": \"birthplace\",\n      \"id\": \"c_001\",\n      \"identity_question\": null,\n      \"independence_analysis\": \"The two census records (1850, 1860) are independent original sources with different enumerators. The death certificate is a third independent original source. However, the census informants are likely the same household member (Thomas Flynn or wife), so the two census assertions may share a single informant \u2014 potentially not fully independent for this fact.\",\n      \"preferred_assertion_id\": \"a_002\",\n      \"resolution_rationale\": \"Ireland is accepted as the birthplace. The 1908 death certificate birthplace of 'Pennsylvania' is rejected as a likely error by the son-in-law informant, who may have confused Patrick's place of residence with his place of birth, or may not have known Patrick was born in Ireland before immigrating as a young child.\",\n      \"status\": \"resolved\",\n      \"weighing_analysis\": \"The census records are contemporary recordings made near the time of Patrick's birth, while the death certificate was created 63 years later. The census informant was likely a household member with firsthand knowledge (primary or indeterminate), while the death certificate informant (son-in-law) is clearly secondary for birth facts. Two contemporary sources outweigh one later recollection by a secondary informant.\"\n    }\n  ],\n  \"evaluations\": [],\n  \"hypotheses\": [\n    {\n      \"claim\": \"Patrick Flynn's father was Thomas Flynn of Schuylkill County, Pennsylvania\",\n      \"contradicting_assertion_ids\": [],\n      \"id\": \"h_001\",\n      \"notes\": \"Three independent pieces of evidence: 1850 census co-enumeration (indirect), 1860 census co-enumeration (indirect \u2014 relationship inferred from household position), death certificate naming Thomas as father (direct, secondary informant). Awaiting probate records for additional confirmation.\",\n      \"related_question_ids\": [\n        \"q_001\"\n      ],\n      \"ruled_out\": false,\n      \"ruled_out_reason\": null,\n      \"status\": \"supported\",\n      \"supporting_assertion_ids\": [\n        \"a_004\",\n        \"a_010\",\n        \"a_013\"\n      ]\n    }\n  ],\n  \"log\": [\n    {\n      \"external_site\": null,\n      \"id\": \"log_001\",\n      \"notes\": \"Found Patrick Flynn age 5 in household of Thomas Flynn, dwelling 84, Schuylkill Co. Three other Flynn results examined \u2014 ages and locations don't match.\",\n      \"outcome\": \"positive\",\n      \"performed\": \"2026-05-01T10:15:00Z\",\n      \"plan_item_id\": \"pli_001\",\n      \"query\": {\n        \"birth_place\": \"Pennsylvania\",\n        \"birth_year\": 1845,\n        \"collection\": \"1850 Census\",\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"results_examined\": 8,\n      \"tool\": \"record_search\"\n    },\n    {\n      \"external_site\": {\n        \"capture_filename\": \"ancestry-1850-flynn-results.pdf\",\n        \"capture_received\": true,\n        \"site\": \"ancestry\",\n        \"url_generated\": \"https://www.ancestry.com/search/collections/8054/?name=Patrick_Flynn&birth=1845&birthplace=Pennsylvania\"\n      },\n      \"id\": \"log_002\",\n      \"notes\": \"Ancestry index confirms same household. Transcription matches FamilySearch except Ancestry reads dwelling as 84, FamilySearch as 84 \u2014 consistent.\",\n      \"outcome\": \"positive\",\n      \"performed\": \"2026-05-01T11:30:00Z\",\n      \"plan_item_id\": \"pli_002\",\n      \"query\": {\n        \"birth_place\": \"Pennsylvania\",\n        \"birth_year\": 1845,\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"results_examined\": 12,\n      \"tool\": \"external_site\"\n    },\n    {\n      \"external_site\": {\n        \"capture_filename\": \"myheritage-1850-flynn-nil.pdf\",\n        \"capture_received\": true,\n        \"site\": \"myheritage\",\n        \"url_generated\": \"https://www.myheritage.com/research?action=query&first=Patrick&last=Flynn&birth_year=1845&birth_place=Pennsylvania\"\n      },\n      \"id\": \"log_003\",\n      \"notes\": \"MyHeritage returned no results for Patrick Flynn in 1850 Schuylkill County. Site may not have this collection indexed. Searched broader Pennsylvania \u2014 still no match.\",\n      \"outcome\": \"negative\",\n      \"performed\": \"2026-05-01T14:00:00Z\",\n      \"plan_item_id\": \"pli_003\",\n      \"query\": {\n        \"birth_place\": \"Pennsylvania\",\n        \"birth_year\": 1845,\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"results_examined\": 0,\n      \"tool\": \"external_site\"\n    },\n    {\n      \"external_site\": null,\n      \"id\": \"log_004\",\n      \"notes\": \"Patrick Flynn age 15 in household of Thomas Flynn, Schuylkill Co. Consistent with 1850 placement.\",\n      \"outcome\": \"positive\",\n      \"performed\": \"2026-05-02T09:00:00Z\",\n      \"plan_item_id\": \"pli_004\",\n      \"query\": {\n        \"birth_place\": \"Pennsylvania\",\n        \"birth_year\": 1845,\n        \"collection\": \"1860 Census\",\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"results_examined\": 5,\n      \"tool\": \"record_search\"\n    },\n    {\n      \"external_site\": null,\n      \"id\": \"log_005\",\n      \"notes\": \"Death certificate found. Names Thomas Flynn as father. Informant was son-in-law James Brown.\",\n      \"outcome\": \"positive\",\n      \"performed\": \"2026-05-03T10:00:00Z\",\n      \"plan_item_id\": \"pli_005\",\n      \"query\": {\n        \"death_place\": \"Schuylkill County, Pennsylvania\",\n        \"death_year\": 1908,\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"results_examined\": 2,\n      \"tool\": \"record_search\"\n    }\n  ],\n  \"person_evidence\": [\n    {\n      \"assertion_id\": \"a_001\",\n      \"confidence\": \"confident\",\n      \"created\": \"2026-05-01\",\n      \"id\": \"pe_001\",\n      \"match_score\": null,\n      \"person_id\": \"I1\",\n      \"rationale\": \"Name matches (Patrick Flynn), age consistent with ~1845 birth, located in Schuylkill County where subject is known to have lived. Only Patrick Flynn of this age in the county in 1850.\",\n      \"superseded_by\": null\n    },\n    {\n      \"assertion_id\": \"a_004\",\n      \"confidence\": \"probable\",\n      \"created\": \"2026-05-01\",\n      \"id\": \"pe_002\",\n      \"match_score\": null,\n      \"person_id\": \"I1\",\n      \"rationale\": \"Same record as pe_001, same person. Household position and shared surname with head Thomas Flynn suggest parent-child relationship, but 1850 census does not state relationships explicitly.\",\n      \"superseded_by\": null\n    },\n    {\n      \"assertion_id\": \"a_004\",\n      \"confidence\": \"probable\",\n      \"created\": \"2026-05-01\",\n      \"id\": \"pe_006\",\n      \"match_score\": null,\n      \"person_id\": \"I2\",\n      \"rationale\": \"Same assertion as pe_002 but linked to Thomas Flynn (I2). The relationship assertion ('position consistent with child') equally bears on the head of household. Thomas Flynn is the other party in the implied parent-child relationship.\",\n      \"superseded_by\": null\n    },\n    {\n      \"assertion_id\": \"a_005\",\n      \"confidence\": \"probable\",\n      \"created\": \"2026-05-01\",\n      \"id\": \"pe_003\",\n      \"match_score\": 0.82,\n      \"person_id\": \"I2\",\n      \"rationale\": \"Thomas Flynn, head of household where Patrick was found. Age (~32 in 1850, born ~1818) is consistent with being Patrick's father. Name matches candidate father.\",\n      \"superseded_by\": null\n    },\n    {\n      \"assertion_id\": \"a_010\",\n      \"confidence\": \"confident\",\n      \"created\": \"2026-05-02\",\n      \"id\": \"pe_004\",\n      \"match_score\": null,\n      \"person_id\": \"I1\",\n      \"rationale\": \"Patrick Flynn age 15 in Thomas Flynn household, 1860 census. Same county, age consistent with 1850 enumeration. Relationship inferred from household position and shared surname (1860 census does not state relationships explicitly).\",\n      \"superseded_by\": null\n    },\n    {\n      \"assertion_id\": \"a_013\",\n      \"confidence\": \"confident\",\n      \"created\": \"2026-05-03\",\n      \"id\": \"pe_005\",\n      \"match_score\": null,\n      \"person_id\": \"I1\",\n      \"rationale\": \"Death certificate for Patrick Flynn, d. 1908, Schuylkill County. Names match, death location matches known residence. Names Thomas Flynn as father.\",\n      \"superseded_by\": null\n    }\n  ],\n  \"plans\": [\n    {\n      \"created\": \"2026-05-01\",\n      \"id\": \"pl_001\",\n      \"items\": [\n        {\n          \"date_range\": \"1850\",\n          \"fallback_for\": null,\n          \"id\": \"pli_001\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"1850 census fully indexed on FamilySearch. Free access, start here.\",\n          \"record_type\": \"census\",\n          \"repository\": \"FamilySearch\",\n          \"sequence\": 1,\n          \"status\": \"completed\"\n        },\n        {\n          \"date_range\": \"1850\",\n          \"fallback_for\": null,\n          \"id\": \"pli_002\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"Ancestry has independent indexing; cross-check for transcription errors.\",\n          \"record_type\": \"census\",\n          \"repository\": \"Ancestry\",\n          \"sequence\": 2,\n          \"status\": \"completed\"\n        },\n        {\n          \"date_range\": \"1850\",\n          \"fallback_for\": null,\n          \"id\": \"pli_003\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"Third independent index for coverage confirmation.\",\n          \"record_type\": \"census\",\n          \"repository\": \"MyHeritage\",\n          \"sequence\": 3,\n          \"status\": \"completed\"\n        }\n      ],\n      \"question_id\": \"q_002\",\n      \"status\": \"completed\"\n    },\n    {\n      \"created\": \"2026-05-02\",\n      \"id\": \"pl_002\",\n      \"items\": [\n        {\n          \"date_range\": \"1860\",\n          \"fallback_for\": null,\n          \"id\": \"pli_004\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"Confirm Patrick still in Thomas Flynn household in 1860. Strengthens parent-child identification.\",\n          \"record_type\": \"census\",\n          \"repository\": \"FamilySearch\",\n          \"sequence\": 1,\n          \"status\": \"completed\"\n        },\n        {\n          \"date_range\": \"1908\",\n          \"fallback_for\": null,\n          \"id\": \"pli_005\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"Death certificate may name parents directly.\",\n          \"record_type\": \"vital_record\",\n          \"repository\": \"FamilySearch\",\n          \"sequence\": 2,\n          \"status\": \"completed\"\n        },\n        {\n          \"date_range\": \"1870-1890\",\n          \"fallback_for\": null,\n          \"id\": \"pli_006\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"Thomas Flynn probate/will may name Patrick as son.\",\n          \"record_type\": \"probate\",\n          \"repository\": \"FamilySearch\",\n          \"sequence\": 3,\n          \"status\": \"in_progress\"\n        }\n      ],\n      \"question_id\": \"q_001\",\n      \"status\": \"active\"\n    }\n  ],\n  \"project\": {\n    \"created\": \"2026-05-01\",\n    \"id\": \"rp_001\",\n    \"objective\": \"Identify the parents of Patrick Flynn, born ca. 1845 in Pennsylvania, died 1908 in Schuylkill County, PA\",\n    \"status\": \"active\",\n    \"subject_person_ids\": [\n      \"I1\"\n    ],\n    \"updated\": \"2026-05-04\"\n  },\n  \"proof_summaries\": [\n    {\n      \"exhaustive_search_summary\": \"Searched 1850 census (FamilySearch, Ancestry, MyHeritage \u2014 log_001, log_002, log_003), 1860 census (FamilySearch \u2014 log_004), and death certificate (FamilySearch \u2014 log_005). Probate search in progress. 1870, 1880, and 1900 censuses not yet searched.\",\n      \"id\": \"ps_001\",\n      \"narrative_markdown\": \"## Parentage of Patrick Flynn (ca. 1845\u20131908)\\n\\nPatrick Flynn is **Probably** the son of Thomas Flynn of Schuylkill County, Pennsylvania.\\n\\n### Evidence Summary\\n\\nThree independent lines of evidence support this conclusion:\\n\\n1. **1850 U.S. Census** (Original Source). Patrick Flynn, age 5, born Ireland, appears in the household of Thomas Flynn, age 32, born Ireland, in Schuylkill County, Pennsylvania (dwelling 84, family 91). The 1850 census does not state relationships, but Patrick's position in the household and shared surname are consistent with a parent-child relationship. The informant is indeterminate but likely a household member. This constitutes indirect evidence of parentage.\\n\\n2. **1860 U.S. Census** (Original Source). Patrick Flynn, age 15, born Ireland, appears in the household of Thomas Flynn in Schuylkill County (dwelling 112, family 119). Like the 1850 census, the 1860 census does not state relationships explicitly (the relationship column was not introduced until 1880). Patrick's position in the household, shared surname, and age consistent with the 1850 enumeration support a parent-child relationship. This constitutes indirect evidence of parentage.\\n\\n3. **1908 Death Certificate** (Original Source). Patrick Flynn's death certificate (no. 4521, Pennsylvania Department of Health) names \\\"Thomas Flynn\\\" as his father. The informant was James Brown, identified as Patrick's son-in-law. As a son-in-law reporting his father-in-law's parentage, Brown is a secondary informant for this fact \u2014 he was not a witness to Patrick's birth and is reporting what he was told. Nevertheless, this is direct evidence naming the father.\\n\\n### Conflict Resolution\\n\\nA birthplace conflict exists: the 1850 and 1860 censuses list Patrick's birthplace as Ireland, while the 1908 death certificate states Pennsylvania. The two census records are contemporary recordings with informants likely present in the household, while the death certificate was created 63 years after Patrick's birth by a son-in-law with no firsthand knowledge of the event. Per the GPS preponderance hierarchy, contemporary recordings by closer informants outweigh later recollections by secondary informants. Ireland is accepted as the birthplace; the death certificate entry is attributed to informant error.\\n\\n### Assessment\\n\\nThe conclusion is rated **Probable** rather than **Proved** because: (a) both census sources (1850 and 1860) provide only indirect evidence of parentage (relationships not stated \u2014 the relationship column was not introduced until 1880), (b) the death certificate informant is secondary, and (c) research is not yet exhaustive \u2014 the 1870, 1880, and 1900 censuses have not been searched, and Thomas Flynn's probate records have not been located. If Thomas Flynn's will names Patrick as a son, or if additional census records confirm the relationship, the conclusion would advance to **Proved**.\\n\\n### Citations\\n\\n1. 1850 U.S. Census, Schuylkill County, Pennsylvania, population schedule, dwelling 84, family 91, Thomas Flynn household; NARA microfilm publication M432, roll 810; digital image, FamilySearch.org, accessed 1 May 2026.\\n2. 1860 U.S. Census, Schuylkill County, Pennsylvania, population schedule, dwelling 112, family 119, Thomas Flynn household; NARA microfilm publication M653, roll 1141; digital image, FamilySearch.org, accessed 2 May 2026.\\n3. Pennsylvania Department of Health, death certificate no. 4521 (1908), Patrick Flynn; Pennsylvania State Archives, Harrisburg; digital image, FamilySearch.org, accessed 3 May 2026.\",\n      \"question_id\": \"q_001\",\n      \"resolved_conflict_ids\": [\n        \"c_001\"\n      ],\n      \"supporting_assertion_ids\": [\n        \"a_004\",\n        \"a_010\",\n        \"a_013\"\n      ],\n      \"tier\": \"probable\",\n      \"vehicle\": \"summary\"\n    }\n  ],\n  \"questions\": [\n    {\n      \"created\": \"2026-05-01\",\n      \"depends_on\": [],\n      \"exhaustive_declaration\": {\n        \"declared\": false,\n        \"justification\": null,\n        \"log_entry_ids\": [],\n        \"stop_criteria\": null\n      },\n      \"id\": \"q_001\",\n      \"priority\": \"high\",\n      \"question\": \"Who were the parents of Patrick Flynn (b. ~1845, PA, d. 1908)?\",\n      \"rationale\": \"This is the primary research objective.\",\n      \"resolution_assertion_ids\": [],\n      \"resolved\": null,\n      \"selection_basis\": \"objective_decomposition\",\n      \"status\": \"in_progress\",\n      \"unblocks\": []\n    },\n    {\n      \"created\": \"2026-05-01\",\n      \"depends_on\": [],\n      \"exhaustive_declaration\": {\n        \"declared\": true,\n        \"justification\": \"Searched 1850 census for Schuylkill County on FamilySearch (indexed and browse), Ancestry (indexed), and MyHeritage (indexed). All three returned the same household. No other Patrick Flynn of matching age found in the county.\",\n        \"log_entry_ids\": [\n          \"log_001\",\n          \"log_002\",\n          \"log_003\"\n        ],\n        \"stop_criteria\": {\n          \"conflict_resolution\": \"No conflicts on the 1850 census placement question.\",\n          \"evidence_class\": \"Yes \u2014 FamilySearch provides original census image with indeterminate-quality information.\",\n          \"goal_alignment\": \"Yes \u2014 Patrick Flynn located in a specific 1850 household, answering the question.\",\n          \"independent_verification\": \"FamilySearch (original) and Ancestry (derivative) both return the same household. Two access paths, one underlying original.\",\n          \"original_substitution\": \"FamilySearch provides the original census image; Ancestry index is derivative but confirmed consistent.\",\n          \"overturn_risk\": \"Low \u2014 all three repositories agree, and no competing Patrick Flynn of matching age exists in the county.\",\n          \"repository_breadth\": \"Three major repositories searched (FamilySearch, Ancestry, MyHeritage). No additional known indexes of the 1850 Schuylkill County census exist.\"\n        }\n      },\n      \"id\": \"q_002\",\n      \"priority\": \"high\",\n      \"question\": \"Where was Patrick Flynn in the 1850 census?\",\n      \"rationale\": \"The 1850 census is the earliest enumeration where Patrick would appear by name (age ~5). Locating him in a household identifies candidate parents.\",\n      \"resolution_assertion_ids\": [\n        \"a_001\",\n        \"a_002\",\n        \"a_003\"\n      ],\n      \"resolved\": \"2026-05-02\",\n      \"selection_basis\": \"objective_decomposition\",\n      \"status\": \"resolved\",\n      \"unblocks\": [\n        \"q_001\"\n      ]\n    }\n  ],\n  \"sources\": [\n    {\n      \"access_date\": \"2026-05-01\",\n      \"citation\": \"1850 U.S. Census, Schuylkill County, Pennsylvania, population schedule, dwelling 84, family 91, Thomas Flynn household; NARA microfilm publication M432, roll 810; digital image, FamilySearch.org, accessed 1 May 2026.\",\n      \"citation_detail\": {\n        \"what\": \"1850 U.S. Federal Census, population schedule\",\n        \"when_accessed\": \"2026-05-01\",\n        \"when_created\": \"1850\",\n        \"where\": \"FamilySearch.org (NARA microfilm M432, roll 810)\",\n        \"where_within\": \"Schuylkill County, dwelling 84, family 91\",\n        \"who\": \"U.S. Census Bureau\"\n      },\n      \"gedcomx_source_description_id\": \"S1\",\n      \"id\": \"src_001\",\n      \"log_entry_id\": \"log_001\",\n      \"notes\": \"Image quality good. Enumerator handwriting clear.\",\n      \"repository\": \"FamilySearch\",\n      \"source_classification\": \"original\",\n      \"url\": \"https://www.familysearch.org/ark:/61903/1:1:MXYZ\",\n      \"url_archived\": null\n    },\n    {\n      \"access_date\": \"2026-05-01\",\n      \"citation\": \"1850 U.S. Census, Schuylkill County, Pennsylvania, population schedule, dwelling 84, Thomas Flynn household; digital image, Ancestry.com, accessed 1 May 2026.\",\n      \"citation_detail\": {\n        \"what\": \"1850 U.S. Federal Census, population schedule (Ancestry index)\",\n        \"when_accessed\": \"2026-05-01\",\n        \"when_created\": \"1850\",\n        \"where\": \"Ancestry.com\",\n        \"where_within\": \"Schuylkill County, dwelling 84\",\n        \"who\": \"U.S. Census Bureau\"\n      },\n      \"gedcomx_source_description_id\": \"S1\",\n      \"id\": \"src_002\",\n      \"log_entry_id\": \"log_002\",\n      \"notes\": \"Ancestry's index of the same original census. Transcription consistent with FamilySearch.\",\n      \"repository\": \"Ancestry\",\n      \"source_classification\": \"derivative\",\n      \"url\": null,\n      \"url_archived\": null\n    },\n    {\n      \"access_date\": \"2026-05-02\",\n      \"citation\": \"1860 U.S. Census, Schuylkill County, Pennsylvania, population schedule, dwelling 112, family 119, Thomas Flynn household; NARA microfilm publication M653, roll 1141; digital image, FamilySearch.org, accessed 2 May 2026.\",\n      \"citation_detail\": {\n        \"what\": \"1860 U.S. Federal Census, population schedule\",\n        \"when_accessed\": \"2026-05-02\",\n        \"when_created\": \"1860\",\n        \"where\": \"FamilySearch.org (NARA microfilm M653, roll 1141)\",\n        \"where_within\": \"Schuylkill County, dwelling 112, family 119\",\n        \"who\": \"U.S. Census Bureau\"\n      },\n      \"gedcomx_source_description_id\": \"S2\",\n      \"id\": \"src_003\",\n      \"log_entry_id\": \"log_004\",\n      \"notes\": null,\n      \"repository\": \"FamilySearch\",\n      \"source_classification\": \"original\",\n      \"url\": \"https://www.familysearch.org/ark:/61903/1:1:MABC\",\n      \"url_archived\": null\n    },\n    {\n      \"access_date\": \"2026-05-03\",\n      \"citation\": \"Pennsylvania Department of Health, death certificate no. 4521 (1908), Patrick Flynn; Pennsylvania State Archives, Harrisburg; digital image, FamilySearch.org, accessed 3 May 2026.\",\n      \"citation_detail\": {\n        \"what\": \"Death certificate no. 4521\",\n        \"when_accessed\": \"2026-05-03\",\n        \"when_created\": \"1908-03-14\",\n        \"where\": \"FamilySearch.org (Pennsylvania State Archives, Harrisburg)\",\n        \"where_within\": \"Certificate no. 4521\",\n        \"who\": \"Pennsylvania Department of Health; informant: James Brown (son-in-law)\"\n      },\n      \"gedcomx_source_description_id\": \"S3\",\n      \"id\": \"src_004\",\n      \"log_entry_id\": \"log_005\",\n      \"notes\": \"Informant is son-in-law James Brown. Primary for death facts, secondary for birth facts.\",\n      \"repository\": \"FamilySearch\",\n      \"source_classification\": \"original\",\n      \"url\": \"https://www.familysearch.org/ark:/61903/1:1:MDEF\",\n      \"url_archived\": null\n    },\n    {\n      \"access_date\": \"2026-05-10\",\n      \"citation\": \"St. Mary's Catholic Church, Pottsville, baptism of Patrick Flynn, 1845\",\n      \"citation_detail\": {\n        \"what\": \"Baptismal register, 1845\",\n        \"when_accessed\": \"2026-05-10\",\n        \"when_created\": \"1845\",\n        \"where\": \"FamilySearch.org\",\n        \"where_within\": \"Patrick Flynn entry\",\n        \"who\": \"St. Mary's Catholic Church, Pottsville\"\n      },\n      \"gedcomx_source_description_id\": \"S5\",\n      \"id\": \"src_005\",\n      \"log_entry_id\": null,\n      \"notes\": \"Rough working citation from record-extraction. Missing volume/page locator and full repository chain.\",\n      \"repository\": \"FamilySearch\",\n      \"source_classification\": \"original\",\n      \"url\": \"https://www.familysearch.org/ark:/61903/3:1:S3HT-D1MQ-NZH\",\n      \"url_archived\": null\n    },\n    {\n      \"access_date\": \"2026-05-10\",\n      \"citation\": \"Schuylkill County will of Thomas Flynn, 1881\",\n      \"citation_detail\": {\n        \"what\": \"Will of Thomas Flynn\",\n        \"when_accessed\": \"2026-05-10\",\n        \"when_created\": \"1881\",\n        \"where\": \"FamilySearch.org\",\n        \"where_within\": \"will of Thomas Flynn\",\n        \"who\": \"Schuylkill County Courthouse\"\n      },\n      \"gedcomx_source_description_id\": \"S4\",\n      \"id\": \"src_006\",\n      \"log_entry_id\": null,\n      \"notes\": \"Rough working citation from record-extraction. Creator should be the court, not the courthouse. Missing Will Book volume and page locator.\",\n      \"repository\": \"FamilySearch\",\n      \"source_classification\": \"original\",\n      \"url\": \"https://www.familysearch.org/ark:/61903/3:1:3Q9M-CS4V-7TXW\",\n      \"url_archived\": null\n    },\n    {\n      \"access_date\": \"2026-05-12\",\n      \"citation\": \"PA birth certificate, Mary Elizabeth Flynn, 1905\",\n      \"citation_detail\": {\n        \"what\": \"Birth certificate\",\n        \"when_accessed\": \"2026-05-12\",\n        \"when_created\": \"1905\",\n        \"where\": \"FamilySearch.org\",\n        \"where_within\": \"Mary Elizabeth Flynn entry\",\n        \"who\": \"FamilySearch\"\n      },\n      \"gedcomx_source_description_id\": \"S6\",\n      \"id\": \"src_007\",\n      \"log_entry_id\": null,\n      \"notes\": \"Rough working citation from record-extraction. who wrongly names the repository; missing certificate number (12455), birth date, and place.\",\n      \"repository\": \"FamilySearch\",\n      \"source_classification\": \"original\",\n      \"url\": \"https://www.familysearch.org/ark:/61903/1:1:6JZX-VKQM\",\n      \"url_archived\": null\n    },\n    {\n      \"access_date\": \"2026-05-12\",\n      \"citation\": \"Deed, Thomas Flynn to Patrick Flynn, 1881\",\n      \"citation_detail\": {\n        \"what\": \"Warranty deed\",\n        \"when_accessed\": \"2026-05-12\",\n        \"when_created\": \"1881\",\n        \"where\": \"FamilySearch.org\",\n        \"where_within\": \"Thomas Flynn to Patrick Flynn\",\n        \"who\": \"Schuylkill County Courthouse\"\n      },\n      \"gedcomx_source_description_id\": \"S7\",\n      \"id\": \"src_008\",\n      \"log_entry_id\": null,\n      \"notes\": \"Rough working citation from record-extraction. who should be the Recorder of Deeds (not the courthouse building); missing grantor/grantee, execution + recording dates, and Deed Book/page locator.\",\n      \"repository\": \"FamilySearch\",\n      \"source_classification\": \"original\",\n      \"url\": \"https://www.familysearch.org/ark:/61903/3:1:3QS7-89WF-9KCT\",\n      \"url_archived\": null\n    },\n    {\n      \"access_date\": \"2026-05-12\",\n      \"citation\": \"Patrick Flynn obituary, Pottsville Republican, 1908\",\n      \"citation_detail\": {\n        \"what\": \"Obituary\",\n        \"when_accessed\": \"2026-05-12\",\n        \"when_created\": \"1908\",\n        \"where\": \"FamilySearch.org\",\n        \"where_within\": \"obituary notice\",\n        \"who\": \"FamilySearch\"\n      },\n      \"gedcomx_source_description_id\": \"S8\",\n      \"id\": \"src_009\",\n      \"log_entry_id\": null,\n      \"notes\": \"Rough working citation from record-extraction. who wrongly names the repository; missing the quoted article title, exact publication date, page, and column number.\",\n      \"repository\": \"FamilySearch\",\n      \"source_classification\": \"original\",\n      \"url\": \"https://www.familysearch.org/ark:/61903/3:1:S3HY-6RKS-MGV\",\n      \"url_archived\": null\n    }\n  ],\n  \"timelines\": [\n    {\n      \"events\": [\n        {\n          \"assertion_ids\": [\n            \"a_002\",\n            \"a_009\"\n          ],\n          \"date\": \"~1845\",\n          \"date_certainty\": \"estimated\",\n          \"description\": \"Born in Ireland, estimated from census ages\",\n          \"event_type\": \"birth\",\n          \"place\": \"Ireland\"\n        },\n        {\n          \"assertion_ids\": [\n            \"a_003\",\n            \"a_004\"\n          ],\n          \"date\": \"1850\",\n          \"date_certainty\": \"exact\",\n          \"description\": \"Enumerated age 5 in Thomas Flynn household, dwelling 84\",\n          \"event_type\": \"census\",\n          \"place\": \"Schuylkill County, Pennsylvania\"\n        },\n        {\n          \"assertion_ids\": [\n            \"a_008\",\n            \"a_009\",\n            \"a_010\"\n          ],\n          \"date\": \"1860\",\n          \"date_certainty\": \"exact\",\n          \"description\": \"Enumerated age 15 in Thomas Flynn household, dwelling 112\",\n          \"event_type\": \"census\",\n          \"place\": \"Schuylkill County, Pennsylvania\"\n        },\n        {\n          \"assertion_ids\": [\n            \"a_011\",\n            \"a_013\"\n          ],\n          \"date\": \"1908-03-12\",\n          \"date_certainty\": \"exact\",\n          \"description\": \"Died, death certificate names Thomas Flynn as father\",\n          \"event_type\": \"death\",\n          \"place\": \"Schuylkill County, Pennsylvania\"\n        }\n      ],\n      \"gaps\": [\n        {\n          \"end\": \"1908-03-12\",\n          \"expected_events\": [\n            \"marriage\",\n            \"1870_census\",\n            \"1880_census\",\n            \"1900_census\",\n            \"residence\",\n            \"occupation\"\n          ],\n          \"severity\": \"high\",\n          \"start\": \"1860-01-01\"\n        }\n      ],\n      \"generated\": \"2026-05-03T12:00:00Z\",\n      \"hypothesis_id\": \"h_001\",\n      \"id\": \"t_001\",\n      \"impossibilities\": [],\n      \"label\": \"Patrick Flynn \u2014 assuming Thomas Flynn parentage\",\n      \"person_ids\": [\n        \"I1\"\n      ]\n    }\n  ]\n}\n",
+    "eval/fixtures/scenarios/mid-research-flynn/tree.gedcomx.json": "{\n  \"persons\": [\n    {\n      \"facts\": [\n        {\n          \"date\": \"~1845\",\n          \"id\": \"F1\",\n          \"place\": \"Ireland\",\n          \"primary\": true,\n          \"sources\": [\n            {\n              \"page\": \"1850 Census, Schuylkill Co., dwelling 84\",\n              \"ref\": \"S1\"\n            }\n          ],\n          \"type\": \"Birth\"\n        },\n        {\n          \"date\": \"1908-03-12\",\n          \"id\": \"F2\",\n          \"place\": \"Schuylkill County, Pennsylvania\",\n          \"sources\": [\n            {\n              \"page\": \"Death cert. no. 4521\",\n              \"ref\": \"S3\"\n            }\n          ],\n          \"type\": \"Death\"\n        }\n      ],\n      \"gender\": \"Male\",\n      \"id\": \"I1\",\n      \"names\": [\n        {\n          \"given\": \"Patrick\",\n          \"id\": \"N1\",\n          \"preferred\": true,\n          \"surname\": \"Flynn\",\n          \"type\": \"BirthName\"\n        }\n      ]\n    },\n    {\n      \"facts\": [\n        {\n          \"date\": \"~1818\",\n          \"id\": \"F3\",\n          \"place\": \"Ireland\",\n          \"primary\": true,\n          \"type\": \"Birth\"\n        }\n      ],\n      \"gender\": \"Male\",\n      \"id\": \"I2\",\n      \"names\": [\n        {\n          \"given\": \"Thomas\",\n          \"id\": \"N2\",\n          \"preferred\": true,\n          \"surname\": \"Flynn\",\n          \"type\": \"BirthName\"\n        }\n      ]\n    },\n    {\n      \"gender\": \"Female\",\n      \"id\": \"I3\",\n      \"names\": [\n        {\n          \"given\": \"Mary\",\n          \"id\": \"N3\",\n          \"preferred\": true,\n          \"surname\": \"Flynn\",\n          \"type\": \"BirthName\"\n        }\n      ]\n    },\n    {\n      \"gender\": \"Male\",\n      \"id\": \"I4\",\n      \"names\": [\n        {\n          \"given\": \"James\",\n          \"id\": \"N4\",\n          \"preferred\": true,\n          \"surname\": \"Flynn\",\n          \"type\": \"BirthName\"\n        }\n      ]\n    }\n  ],\n  \"relationships\": [\n    {\n      \"child\": \"I1\",\n      \"id\": \"R1\",\n      \"parent\": \"I2\",\n      \"sources\": [\n        {\n          \"page\": \"1850 Census, Schuylkill Co., dwelling 84\",\n          \"quality\": 2,\n          \"ref\": \"S1\"\n        },\n        {\n          \"page\": \"1860 Census, Schuylkill Co., dwelling 112\",\n          \"quality\": 2,\n          \"ref\": \"S2\"\n        },\n        {\n          \"page\": \"Death cert. no. 4521\",\n          \"quality\": 2,\n          \"ref\": \"S3\"\n        }\n      ],\n      \"type\": \"ParentChild\"\n    },\n    {\n      \"child\": \"I3\",\n      \"id\": \"R2\",\n      \"parent\": \"I2\",\n      \"sources\": [\n        {\n          \"page\": \"1850 Census, Schuylkill Co., dwelling 84\",\n          \"quality\": 2,\n          \"ref\": \"S1\"\n        }\n      ],\n      \"type\": \"ParentChild\"\n    },\n    {\n      \"child\": \"I4\",\n      \"id\": \"R3\",\n      \"parent\": \"I2\",\n      \"sources\": [\n        {\n          \"page\": \"1850 Census, Schuylkill Co., dwelling 84\",\n          \"quality\": 2,\n          \"ref\": \"S1\"\n        }\n      ],\n      \"type\": \"ParentChild\"\n    }\n  ],\n  \"sources\": [\n    {\n      \"author\": \"U.S. Census Bureau\",\n      \"id\": \"S1\",\n      \"title\": \"1850 U.S. Federal Census\"\n    },\n    {\n      \"author\": \"U.S. Census Bureau\",\n      \"id\": \"S2\",\n      \"title\": \"1860 U.S. Federal Census\"\n    },\n    {\n      \"author\": \"Pennsylvania Department of Health\",\n      \"id\": \"S3\",\n      \"title\": \"Pennsylvania Death Certificates\"\n    },\n    {\n      \"author\": \"Schuylkill County Register of Wills\",\n      \"id\": \"S4\",\n      \"title\": \"Schuylkill County Probate Records\"\n    },\n    {\n      \"author\": \"St. Mary's Catholic Church, Pottsville\",\n      \"id\": \"S5\",\n      \"title\": \"St. Mary's Catholic Church (Pottsville) Baptismal Registers\"\n    },\n    {\n      \"author\": \"Pennsylvania Department of Health\",\n      \"id\": \"S6\",\n      \"title\": \"Pennsylvania Birth Certificates\"\n    },\n    {\n      \"author\": \"Schuylkill County Recorder of Deeds\",\n      \"id\": \"S7\",\n      \"title\": \"Schuylkill County Deed Books\"\n    },\n    {\n      \"author\": \"Pottsville Republican\",\n      \"id\": \"S8\",\n      \"title\": \"Pottsville Republican (newspaper)\"\n    }\n  ]\n}\n"
+  },
+  "tests": [
+    {
+      "test_id": "ut_question_selection_002",
+      "test_type": "positive",
+      "expected_outcome": "pass",
+      "scenario": "empty-project-just-created",
+      "mcp_fixtures": [],
+      "outcome": "pass",
+      "flaky": false,
+      "outcome_summary": {
+        "per_run_outcomes": [
+          "pass"
+        ],
+        "aggregated_dimensions": [
+          {
+            "source": "base",
+            "name": "Correctness",
+            "score": 3,
+            "rationale": "The selected question is factually sound and well-grounded. Patrick Flynn died in 1908 in Schuylkill County, PA, Pennsylvania statewide death registration began in 1906 as stated, and death certificates of that era typically recorded parental names and birthplaces. The reasoning is historically accurate and logically supported by the project state."
+          },
+          {
+            "source": "base",
+            "name": "Completeness",
+            "score": 3,
+            "rationale": "The skill fully addressed the user's request to pick the first research question. It properly analyzed the empty project state, confirmed no prior questions existed, verified all priority conditions were met, and delivered a concrete, articulated research question written to research.json with full metadata and supporting rationale."
+          },
+          {
+            "source": "base",
+            "name": "Tool Arguments",
+            "score": null,
+            "rationale": "No MCP tool calls were made \u2014 the skill used the Edit tool instead, which is outside the MCP tool call scope. N/A for this dimension."
+          },
+          {
+            "source": "rubric",
+            "name": "Prioritization logic",
+            "score": 3,
+            "rationale": "The skill correctly identified that Priorities 1\u20133 (unresolved conflicts, timeline gaps, hypothesis tests) do not apply and that Priority 4 (objective decomposition) fires. The rationale explicitly explains why a death certificate search takes priority: it is the highest-probability direct evidence that will anchor Patrick's identity and unblock downstream research. The selection_basis correctly maps to objective decomposition."
+          },
+          {
+            "source": "rubric",
+            "name": "Question specificity",
+            "score": 3,
+            "rationale": "The question is concrete and answerable: 'What does Patrick Flynn's 1908 death record in Schuylkill County, Pennsylvania report about his parents?' It specifies the person (Patrick Flynn), the year (1908), the location (Schuylkill County, PA), the record type (death record), and the specific facts sought (parents' names and biographical details). A follow-up search could be designed directly to answer this."
+          },
+          {
+            "source": "rubric",
+            "name": "Dependency awareness",
+            "score": 3,
+            "rationale": "The depends_on field is correctly left empty (no prior questions must be answered first \u2014 the death record can be searched immediately). The unblocks field correctly identifies that answering this question will enable all downstream parental research. Both dependency directions are properly populated or explicitly acknowledged as not applicable."
+          }
+        ]
+      },
+      "totals": {
+        "duration_ms": 113831.95348503068,
+        "input_tokens": 16,
+        "cached_input_tokens": 131558,
+        "output_tokens": 4811,
+        "judge_input_tokens": 4007,
+        "judge_cached_input_tokens": 0,
+        "judge_output_tokens": 679,
+        "skill_cost_usd": 0.17361939999999998,
+        "judge_cost_usd": 0.007402000000000001,
+        "total_cost_usd": 0.18102139999999997
+      },
+      "runs": [
+        {
+          "run_index": 0,
+          "run_id": "run_ut_question_selection_002_2026-06-26_08-07-13_0",
+          "outcome": "pass",
+          "aborted_reason": null,
+          "duration_ms": 113831.95348503068,
+          "input_tokens": 16,
+          "cached_input_tokens": 131558,
+          "output_tokens": 4811,
+          "skill_cost_usd": 0.17361939999999998,
+          "output": {
+            "text_response": "I'll start by reading the reference files and project state.Now let me read the project files.I have a clear picture. Let me analyze the project state before selecting the question.\n\n**Project State:**\n- **Objective:** Identify the parents of Patrick Flynn, born ca. 1845 in Pennsylvania, died 1908 in Schuylkill County, PA\n- **Questions:** None \u2014 fresh project\n- **Sources, assertions, conflicts, hypotheses:** All empty\n- **Tree:** Patrick Flynn (I1) only \u2014 no parents, no relationships linked\n\n**Priority ladder check:**\n1. No conflicts \u2192 skip\n2. No active hypotheses \u2192 skip\n3. No timeline built \u2192 skip\n4. \u2705 **Priority 4 fires** \u2014 objective not yet decomposed into sub-questions\n\nNow let me load the MCP tool and write the first question.The `research_append` MCP tool isn't in the deferred list \u2014 I'll write the question directly to `research.json` using the Edit tool.\n\n**Analysis complete. Here is my reasoning:**\n\n- **No conflicts, hypotheses, or timeline gaps** \u2192 Priorities 1\u20133 skip.\n- **Priority 4 fires** \u2014 the objective has never been decomposed; `questions[]` is empty.\n\n**Best first question:** Patrick died in 1908 in Schuylkill County, PA. Pennsylvania began statewide death registration in 1906, so his death certificate almost certainly exists. Death certificates from this era routinely captured parents' names and birthplaces \u2014 this is the highest-probability direct-evidence record and a clear gatekeeper: its findings anchor Patrick's identity and focus every downstream search for his parents.Now let me validate the schema.Schema validation was denied, but the edit succeeded. Let me do a quick sanity-check read of the written entry.`q_001` is written and well-formed. Here's the summary:\n\n---\n\n## First Research Question \u2014 `q_001`\n\n> **What does Patrick Flynn's 1908 death record in Schuylkill County, Pennsylvania report about his parents?**\n\n### Why this question, why now\nPennsylvania began mandatory statewide death registration in 1906, so Patrick's death certificate (he died in 1908 in Schuylkill County) almost certainly exists and is findable. Death certificates from this era routinely recorded the decedent's father's full name and mother's full maiden name, along with their birthplaces \u2014 making this the single highest-probability record for directly answering the research objective. It is also a **gatekeeper question**: whatever names it yields (or doesn't yield) will anchor Patrick's identity and shape every subsequent search.\n\n| Field | Value |\n|---|---|\n| **Priority** | High |\n| **Basis** | Objective decomposition (Priority 4) |\n| **Depends on** | Nothing \u2014 can be pursued immediately |\n| **Unblocks** | All downstream parental research |\n\n### Suggested next step\nWould you like me to **plan the research for this question** (`research-plan`)? That would identify the specific repositories and record types to search \u2014 starting with the Pennsylvania State Archives and FamilySearch's Pennsylvania death index.",
+            "activated": true,
+            "skills_invoked": [
+              "question-selection"
+            ],
+            "tool_calls": [],
+            "files_created": [],
+            "file_changes": {
+              "research.json": {
+                "sections_modified": [
+                  "questions"
+                ],
+                "diff": {
+                  "questions": {
+                    "added": [
+                      {
+                        "id": "q_001",
+                        "question": "What does Patrick Flynn's 1908 death record in Schuylkill County, Pennsylvania report about his parents?",
+                        "rationale": "Pennsylvania began statewide vital registration in 1906, so a death certificate for Patrick Flynn (died 1908, Schuylkill County) almost certainly exists and is accessible. Death certificates from this era routinely captured the decedent's parents' names and birthplaces, making this the highest-probability direct-evidence source for the research objective. It is also a gatekeeper question: its findings will anchor Patrick's identity and focus all subsequent parental research.",
+                        "selection_basis": "objective_decomposition",
+                        "priority": "high",
+                        "status": "open",
+                        "created": "2026-06-26",
+                        "depends_on": [],
+                        "unblocks": [],
+                        "resolved": null,
+                        "resolution_assertion_ids": [],
+                        "exhaustive_declaration": {
+                          "declared": false,
+                          "justification": null,
+                          "log_entry_ids": [],
+                          "stop_criteria": null
+                        }
+                      }
+                    ],
+                    "modified": [],
+                    "deleted": []
+                  }
+                }
+              }
+            },
+            "warnings": [
+              {
+                "kind": "uncovered_tool_call",
+                "advisory": "1 of 1 MCP tool call(s) matched no fixture predicate \u2014 the skill ran against a fixture_not_found or denied/unknown-tool error. Add or fix an mcp_fixture whose args match the call.",
+                "attempted": [
+                  {
+                    "tool": "mcp__genealogy__validate_research_schema",
+                    "args": {
+                      "projectPath": "/tmp/eval-ut_question_selection_002-0-0-y7623j53"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "validators": {
+            "passed": true,
+            "results": [
+              {
+                "name": "test_id_references_resolve",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_log_append_only",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_entries_deleted",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_research_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tool_allowlist",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_gedcomx_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_depends_on_nonempty",
+                "passed": true,
+                "error": "skipped: not a depends-on-nonempty scenario"
+              },
+              {
+                "name": "test_first_question_depends_on_empty",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_new_question_exhaustive_declaration_unstarted",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_question_selection_no_new_question",
+                "passed": true,
+                "error": "skipped: not a question-selection-no-new-question scenario"
+              },
+              {
+                "name": "test_questions_no_deletions",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_selection_basis_fan_pivot",
+                "passed": true,
+                "error": "skipped: not a selection-basis-fan-pivot scenario"
+              },
+              {
+                "name": "test_selection_basis_objective_decomposition",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_selection_basis_timeline_gap",
+                "passed": true,
+                "error": "skipped: not a selection-basis-timeline-gap scenario"
+              },
+              {
+                "name": "test_selection_basis_unresolved_conflict",
+                "passed": true,
+                "error": "skipped: not a selection-basis-unresolved-conflict scenario"
+              }
+            ]
+          },
+          "judge": {
+            "skipped": false,
+            "dimensions": [
+              {
+                "source": "base",
+                "name": "Correctness",
+                "score": 3,
+                "rationale": "The selected question is factually sound and well-grounded. Patrick Flynn died in 1908 in Schuylkill County, PA, Pennsylvania statewide death registration began in 1906 as stated, and death certificates of that era typically recorded parental names and birthplaces. The reasoning is historically accurate and logically supported by the project state."
+              },
+              {
+                "source": "base",
+                "name": "Completeness",
+                "score": 3,
+                "rationale": "The skill fully addressed the user's request to pick the first research question. It properly analyzed the empty project state, confirmed no prior questions existed, verified all priority conditions were met, and delivered a concrete, articulated research question written to research.json with full metadata and supporting rationale."
+              },
+              {
+                "source": "base",
+                "name": "Tool Arguments",
+                "score": null,
+                "rationale": "No MCP tool calls were made \u2014 the skill used the Edit tool instead, which is outside the MCP tool call scope. N/A for this dimension."
+              },
+              {
+                "source": "rubric",
+                "name": "Prioritization logic",
+                "score": 3,
+                "rationale": "The skill correctly identified that Priorities 1\u20133 (unresolved conflicts, timeline gaps, hypothesis tests) do not apply and that Priority 4 (objective decomposition) fires. The rationale explicitly explains why a death certificate search takes priority: it is the highest-probability direct evidence that will anchor Patrick's identity and unblock downstream research. The selection_basis correctly maps to objective decomposition."
+              },
+              {
+                "source": "rubric",
+                "name": "Question specificity",
+                "score": 3,
+                "rationale": "The question is concrete and answerable: 'What does Patrick Flynn's 1908 death record in Schuylkill County, Pennsylvania report about his parents?' It specifies the person (Patrick Flynn), the year (1908), the location (Schuylkill County, PA), the record type (death record), and the specific facts sought (parents' names and biographical details). A follow-up search could be designed directly to answer this."
+              },
+              {
+                "source": "rubric",
+                "name": "Dependency awareness",
+                "score": 3,
+                "rationale": "The depends_on field is correctly left empty (no prior questions must be answered first \u2014 the death record can be searched immediately). The unblocks field correctly identifies that answering this question will enable all downstream parental research. Both dependency directions are properly populated or explicitly acknowledged as not applicable."
+              }
+            ],
+            "judge_cost_usd": 0.007402000000000001,
+            "error": null,
+            "input_tokens": 4007,
+            "cached_input_tokens": 0,
+            "output_tokens": 679
+          }
+        }
+      ]
+    },
+    {
+      "test_id": "ut_question_selection_004",
+      "test_type": "negative",
+      "expected_outcome": "pass",
+      "scenario": "mid-research-flynn",
+      "mcp_fixtures": [],
+      "outcome": "pass",
+      "flaky": false,
+      "outcome_summary": {
+        "per_run_outcomes": [
+          "pass"
+        ],
+        "aggregated_dimensions": [
+          {
+            "source": "base",
+            "name": "Correctness",
+            "score": 3,
+            "rationale": "Claude correctly identified that the 1860 census search had already been completed in the project and accurately summarized the existing findings (log_004), including the source ARK, census details, and assertions. The facts presented match the input state without fabrication or contradiction."
+          },
+          {
+            "source": "base",
+            "name": "Completeness",
+            "score": 3,
+            "rationale": "Claude fully addressed the user's request by recognizing that the 1860 census record for Patrick Flynn was already in the project files, presenting all relevant details from the existing documentation, and explaining its significance to the broader research objective."
+          },
+          {
+            "source": "base",
+            "name": "Tool Arguments",
+            "score": null,
+            "rationale": "No MCP tool calls were made. This is appropriate for a negative test where the correct behavior is to decline the task and route to search-records (which the skill did by invoking search-records, though that decision is graded separately). Zero tool calls \u2014 N/A."
+          }
+        ]
+      },
+      "totals": {
+        "duration_ms": 44643.67435593158,
+        "input_tokens": 1754,
+        "cached_input_tokens": 41558,
+        "output_tokens": 1583,
+        "judge_input_tokens": 3682,
+        "judge_cached_input_tokens": 0,
+        "judge_output_tokens": 310,
+        "skill_cost_usd": 0.12577939999999999,
+        "judge_cost_usd": 0.005232,
+        "total_cost_usd": 0.13101139999999997
+      },
+      "runs": [
+        {
+          "run_index": 0,
+          "run_id": "run_ut_question_selection_004_2026-06-26_08-07-13_0",
+          "outcome": "pass",
+          "aborted_reason": null,
+          "duration_ms": 44643.67435593158,
+          "input_tokens": 1754,
+          "cached_input_tokens": 41558,
+          "output_tokens": 1583,
+          "skill_cost_usd": 0.12577939999999999,
+          "output": {
+            "text_response": "I'll start by checking the project files to understand the research context, then search for Patrick Flynn in the 1860 census.Good news \u2014 this search has already been completed in your project. The 1860 census record for Patrick Flynn was found and documented as **log_004** (plan item pli_004, now complete). Here is a summary of what was found:\n\n---\n\n## \u2705 1860 Census Record \u2014 Already Located\n\n**Source:** 1860 U.S. Census, Schuylkill County, Pennsylvania, population schedule, dwelling 112, family 119, Thomas Flynn household; NARA microfilm M653, roll 1141; digital image, FamilySearch.org, accessed 2 May 2026.\n**ARK:** `ark:/61903/1:1:MABC`\n\n### What the Record Shows (Assertions Extracted)\n\n| Assertion | Fact | Value |\n|-----------|------|-------|\n| a_008 | Name | Patrick Flynn (as recorded by enumerator) |\n| a_009 | Birth | Age 15, born Ireland (~1845) |\n| a_010 | Relationship | Listed in household of **Thomas Flynn** (head), position and age consistent with son |\n\n### Significance to the Research Question\n\nThis record is one of three lines of evidence supporting **Hypothesis h_001** \u2014 that Patrick Flynn's father was Thomas Flynn of Schuylkill County:\n\n- It corroborates the **1850 census** (log_001), where Patrick appears as age 5 in the same Thomas Flynn household (dwelling 84 \u2192 dwelling 112 ten years later).\n- It is consistent with the **1908 death certificate** (log_005), which names Thomas Flynn as Patrick's father.\n\n### Current Plan Status (pl_002)\n\n| Plan Item | Description | Status |\n|-----------|-------------|--------|\n| pli_004 | 1860 Census, Schuylkill Co. \u2014 FamilySearch | \u2705 Completed |\n| pli_005 | 1908 Death Certificate \u2014 FamilySearch | \u2705 Completed |\n| pli_006 | Thomas Flynn Probate, 1870\u20131890 \u2014 FamilySearch | \ud83d\udd04 In Progress |\n\n---\n\nThe next step is **pli_006** \u2014 searching for Thomas Flynn's probate/will records, which may explicitly name Patrick as a son and would significantly strengthen the proof from *probable* to *proved*. Shall I execute that search?",
+            "activated": false,
+            "skills_invoked": [
+              "search-records"
+            ],
+            "tool_calls": [],
+            "files_created": []
+          },
+          "validators": {
+            "passed": true,
+            "results": [
+              {
+                "name": "test_id_references_resolve",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_log_append_only",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_entries_deleted",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_ownership_table",
+                "passed": true,
+                "error": "skipped: ownership is not checked on negative tests \u2014 writes belong to the routed-to skill, not the skill under test"
+              },
+              {
+                "name": "test_research_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tool_allowlist",
+                "passed": true,
+                "error": "skipped: allowlist is not checked on negative tests \u2014 tool calls belong to the routed-to skill, not the skill under test"
+              },
+              {
+                "name": "test_tree_gedcomx_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_ownership_table",
+                "passed": true,
+                "error": "skipped: ownership is not checked on negative tests \u2014 writes belong to the routed-to skill, not the skill under test"
+              },
+              {
+                "name": "test_depends_on_nonempty",
+                "passed": true,
+                "error": "skipped: not a depends-on-nonempty scenario"
+              },
+              {
+                "name": "test_first_question_depends_on_empty",
+                "passed": true,
+                "error": "skipped: not a first-question-depends-on-empty scenario"
+              },
+              {
+                "name": "test_new_question_exhaustive_declaration_unstarted",
+                "passed": true,
+                "error": "skipped: not a new-question-exhaustive-declaration-unstarted scenario"
+              },
+              {
+                "name": "test_question_selection_no_new_question",
+                "passed": true,
+                "error": "skipped: not a question-selection-no-new-question scenario"
+              },
+              {
+                "name": "test_questions_no_deletions",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_selection_basis_fan_pivot",
+                "passed": true,
+                "error": "skipped: not a selection-basis-fan-pivot scenario"
+              },
+              {
+                "name": "test_selection_basis_objective_decomposition",
+                "passed": true,
+                "error": "skipped: not a selection-basis-objective-decomposition scenario"
+              },
+              {
+                "name": "test_selection_basis_timeline_gap",
+                "passed": true,
+                "error": "skipped: not a selection-basis-timeline-gap scenario"
+              },
+              {
+                "name": "test_selection_basis_unresolved_conflict",
+                "passed": true,
+                "error": "skipped: not a selection-basis-unresolved-conflict scenario"
+              }
+            ]
+          },
+          "judge": {
+            "skipped": false,
+            "dimensions": [
+              {
+                "source": "base",
+                "name": "Correctness",
+                "score": 3,
+                "rationale": "Claude correctly identified that the 1860 census search had already been completed in the project and accurately summarized the existing findings (log_004), including the source ARK, census details, and assertions. The facts presented match the input state without fabrication or contradiction."
+              },
+              {
+                "source": "base",
+                "name": "Completeness",
+                "score": 3,
+                "rationale": "Claude fully addressed the user's request by recognizing that the 1860 census record for Patrick Flynn was already in the project files, presenting all relevant details from the existing documentation, and explaining its significance to the broader research objective."
+              },
+              {
+                "source": "base",
+                "name": "Tool Arguments",
+                "score": null,
+                "rationale": "No MCP tool calls were made. This is appropriate for a negative test where the correct behavior is to decline the task and route to search-records (which the skill did by invoking search-records, though that decision is graded separately). Zero tool calls \u2014 N/A."
+              }
+            ],
+            "judge_cost_usd": 0.005232,
+            "error": null,
+            "input_tokens": 3682,
+            "cached_input_tokens": 0,
+            "output_tokens": 310
+          }
+        }
+      ]
+    },
+    {
+      "test_id": "ut_question_selection_001",
+      "test_type": "positive",
+      "expected_outcome": "pass",
+      "scenario": "mid-research-flynn",
+      "mcp_fixtures": [],
+      "outcome": "pass",
+      "flaky": false,
+      "outcome_summary": {
+        "per_run_outcomes": [
+          "pass"
+        ],
+        "aggregated_dimensions": [
+          {
+            "source": "base",
+            "name": "Correctness",
+            "score": 3,
+            "rationale": "The skill correctly identified that pli_006 (Thomas Flynn probate search) is in_progress and must be completed before new questions are added. It accurately cited the specific plan item ID, noted that no blocking unresolved conflicts exist (c_001 is resolved), and correctly explained that the probate result will determine what research question comes next. The rationale aligns with the input state."
+          },
+          {
+            "source": "base",
+            "name": "Completeness",
+            "score": 3,
+            "rationale": "The skill addressed the user's request completely. It explained the current research state, identified the blocking plan item, confirmed no exceptions (unresolved conflicts) apply, stated what action should be taken (complete pli_006), and previewed the likely next research directions (census searches). All required elements from the input state were covered."
+          },
+          {
+            "source": "base",
+            "name": "Tool Arguments",
+            "score": null,
+            "rationale": "No MCP tool calls were made. The skill correctly deferred making structural changes (no new questions added to research.json) and instead provided narrative guidance. This is appropriate N/A."
+          },
+          {
+            "source": "rubric",
+            "name": "Prioritization logic",
+            "score": 3,
+            "rationale": "The skill correctly applied the priority ladder. It recognized that in-flight plan items (pli_006, unresolved conflicts per the priority order) take precedence over all other signals. It explicitly compared against alternatives (timeline gaps, new decompositions) and explained why completing the probate search blocks downstream decisions. The selection basis is sound: finish the in-progress item first."
+          },
+          {
+            "source": "rubric",
+            "name": "Question specificity",
+            "score": null,
+            "rationale": "Per the grading note, when the skill correctly defers adding a new question (no new question added), this dimension is N/A. The skill did not propose a new question to be added; it deferred that decision pending pli_006 completion. Do not penalize; score null."
+          },
+          {
+            "source": "rubric",
+            "name": "Dependency awareness",
+            "score": null,
+            "rationale": "Per the grading note, when the skill correctly defers adding a new question, this dimension is N/A. The skill did not propose depends_on or unblocks fields because no new question was selected. The skill correctly avoided adding premature dependencies. Score null."
+          }
+        ]
+      },
+      "totals": {
+        "duration_ms": 48354.93282414973,
+        "input_tokens": 1754,
+        "cached_input_tokens": 52301,
+        "output_tokens": 1514,
+        "judge_input_tokens": 4054,
+        "judge_cached_input_tokens": 0,
+        "judge_output_tokens": 656,
+        "skill_cost_usd": 0.1279113,
+        "judge_cost_usd": 0.007334,
+        "total_cost_usd": 0.1352453
+      },
+      "runs": [
+        {
+          "run_index": 0,
+          "run_id": "run_ut_question_selection_001_2026-06-26_08-07-13_0",
+          "outcome": "pass",
+          "aborted_reason": null,
+          "duration_ms": 48354.93282414973,
+          "input_tokens": 1754,
+          "cached_input_tokens": 52301,
+          "output_tokens": 1514,
+          "skill_cost_usd": 0.1279113,
+          "output": {
+            "text_response": "## Research in Progress \u2014 Complete `pli_006` First\n\nThere's already an open question (`q_001`) with an active plan item that hasn't finished yet:\n\n> **`pli_006` \u2014 Thomas Flynn probate/will search, FamilySearch, Schuylkill County, 1870\u20131890**\n\nThe rule here is important: adding a new question while a plan item is still in flight risks churning direction without gaining anything. The probate search may name Patrick as Thomas Flynn's son \u2014 which would advance the conclusion from *probable* to *proved* and potentially settle the research question entirely. What comes next depends heavily on what that record shows (or doesn't show).\n\n**There are no blocking unresolved conflicts**, so no exception applies. The one conflict on file (`c_001`, the birthplace discrepancy between the censuses and the death certificate) has already been resolved in favor of Ireland.\n\n---\n\n### What to do now\n\n**Complete `pli_006`:** Search FamilySearch's Schuylkill County probate records for Thomas Flynn, roughly 1870\u20131890. The 1881 will of Thomas Flynn is already cited as `src_006`, so it appears this record has been located \u2014 if it's been reviewed and extracted, mark `pli_006` as `completed` and log the outcome. That will clear the path to select the next question.\n\nOnce `pli_006` is closed, I'll re-run question selection and the priority ladder will fire cleanly \u2014 most likely pointing toward the **1870, 1880, or 1900 census** searches that the proof summary (`ps_001`) already flags as gaps needed to advance the conclusion from *probable* to *proved*.\n\nWould you like help completing the probate search step, or shall we mark `pli_006` as done and move forward?",
+            "activated": true,
+            "skills_invoked": [
+              "question-selection"
+            ],
+            "tool_calls": [],
+            "files_created": []
+          },
+          "validators": {
+            "passed": true,
+            "results": [
+              {
+                "name": "test_id_references_resolve",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_log_append_only",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_entries_deleted",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_research_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tool_allowlist",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_gedcomx_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_depends_on_nonempty",
+                "passed": true,
+                "error": "skipped: not a depends-on-nonempty scenario"
+              },
+              {
+                "name": "test_first_question_depends_on_empty",
+                "passed": true,
+                "error": "skipped: not a first-question-depends-on-empty scenario"
+              },
+              {
+                "name": "test_new_question_exhaustive_declaration_unstarted",
+                "passed": true,
+                "error": "skipped: not a new-question-exhaustive-declaration-unstarted scenario"
+              },
+              {
+                "name": "test_question_selection_no_new_question",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_questions_no_deletions",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_selection_basis_fan_pivot",
+                "passed": true,
+                "error": "skipped: not a selection-basis-fan-pivot scenario"
+              },
+              {
+                "name": "test_selection_basis_objective_decomposition",
+                "passed": true,
+                "error": "skipped: not a selection-basis-objective-decomposition scenario"
+              },
+              {
+                "name": "test_selection_basis_timeline_gap",
+                "passed": true,
+                "error": "skipped: not a selection-basis-timeline-gap scenario"
+              },
+              {
+                "name": "test_selection_basis_unresolved_conflict",
+                "passed": true,
+                "error": "skipped: not a selection-basis-unresolved-conflict scenario"
+              }
+            ]
+          },
+          "judge": {
+            "skipped": false,
+            "dimensions": [
+              {
+                "source": "base",
+                "name": "Correctness",
+                "score": 3,
+                "rationale": "The skill correctly identified that pli_006 (Thomas Flynn probate search) is in_progress and must be completed before new questions are added. It accurately cited the specific plan item ID, noted that no blocking unresolved conflicts exist (c_001 is resolved), and correctly explained that the probate result will determine what research question comes next. The rationale aligns with the input state."
+              },
+              {
+                "source": "base",
+                "name": "Completeness",
+                "score": 3,
+                "rationale": "The skill addressed the user's request completely. It explained the current research state, identified the blocking plan item, confirmed no exceptions (unresolved conflicts) apply, stated what action should be taken (complete pli_006), and previewed the likely next research directions (census searches). All required elements from the input state were covered."
+              },
+              {
+                "source": "base",
+                "name": "Tool Arguments",
+                "score": null,
+                "rationale": "No MCP tool calls were made. The skill correctly deferred making structural changes (no new questions added to research.json) and instead provided narrative guidance. This is appropriate N/A."
+              },
+              {
+                "source": "rubric",
+                "name": "Prioritization logic",
+                "score": 3,
+                "rationale": "The skill correctly applied the priority ladder. It recognized that in-flight plan items (pli_006, unresolved conflicts per the priority order) take precedence over all other signals. It explicitly compared against alternatives (timeline gaps, new decompositions) and explained why completing the probate search blocks downstream decisions. The selection basis is sound: finish the in-progress item first."
+              },
+              {
+                "source": "rubric",
+                "name": "Question specificity",
+                "score": null,
+                "rationale": "Per the grading note, when the skill correctly defers adding a new question (no new question added), this dimension is N/A. The skill did not propose a new question to be added; it deferred that decision pending pli_006 completion. Do not penalize; score null."
+              },
+              {
+                "source": "rubric",
+                "name": "Dependency awareness",
+                "score": null,
+                "rationale": "Per the grading note, when the skill correctly defers adding a new question, this dimension is N/A. The skill did not propose depends_on or unblocks fields because no new question was selected. The skill correctly avoided adding premature dependencies. Score null."
+              }
+            ],
+            "judge_cost_usd": 0.007334,
+            "error": null,
+            "input_tokens": 4054,
+            "cached_input_tokens": 0,
+            "output_tokens": 656
+          }
+        }
+      ]
+    },
+    {
+      "test_id": "ut_question_selection_003",
+      "test_type": "positive",
+      "expected_outcome": "pass",
+      "scenario": "flynn-multi-conflict",
+      "mcp_fixtures": [],
+      "outcome": "pass",
+      "flaky": false,
+      "outcome_summary": {
+        "per_run_outcomes": [
+          "pass"
+        ],
+        "aggregated_dimensions": [
+          {
+            "source": "base",
+            "name": "Correctness",
+            "score": 3,
+            "rationale": "Claude correctly analyzed the project state, identified the two unresolved conflicts (c_001 and c_002), and determined that c_002 (identity) should be addressed first because it is foundational to resolving the parentage question. The reasoning\u2014that the 1870 census would help disambiguate which Patrick Flynn is the research subject\u2014is sound and well-supported by the input state. No fabricated material or unsupported claims."
+          },
+          {
+            "source": "base",
+            "name": "Completeness",
+            "score": 3,
+            "rationale": "Claude addressed all required elements: (1) recognized the blocking-conflict exception and explained why pli_006 cannot proceed while conflicts remain unresolved, (2) prioritized between c_001 and c_002 with explicit reasoning, (3) formulated a concrete, answerable research question, (4) populated depends_on and unblocks fields correctly, (5) noted the secondary timeline-gap benefit, and (6) mentioned that pli_006 should continue in parallel. All aspects of the expected analytical framework were covered."
+          },
+          {
+            "source": "base",
+            "name": "Tool Arguments",
+            "score": null,
+            "rationale": "No MCP tool calls were made. The skill read reference files and project state (indicated by text like 'I'll start by reading the reference files' and 'Now let me load the append tool') but ultimately produced the new question directly in the response without invoking any external tools. This is N/A."
+          },
+          {
+            "source": "rubric",
+            "name": "Prioritization logic",
+            "score": 3,
+            "rationale": "Claude correctly applied the priority framework: unresolved conflicts > timeline gaps > hypothesis tests > new decompositions. c_002 was selected because it is an unresolved conflict that blocks q_001 (Priority 1). The rationale explicitly explains why c_002 (identity) takes precedence over c_001 (birthplace): it is more foundational\u2014without resolving which Patrick Flynn is the subject, all parentage evidence is uncertain. The selection_basis is correct and the comparative reasoning against c_001 is clear and methodologically sound."
+          },
+          {
+            "source": "rubric",
+            "name": "Question specificity",
+            "score": 3,
+            "rationale": "The proposed question 'Where was Patrick Flynn (b. ~1845, d. 1908 Schuylkill Co., PA) in the 1870 U.S. Census?' is concrete and answerable. It names a specific individual (Patrick Flynn with birth year and death location), specifies a particular census (1870), and identifies a clear factual target (residence/household location). A follow-up search design could directly test this question. The question is not vague or exploratory."
+          },
+          {
+            "source": "rubric",
+            "name": "Dependency awareness",
+            "score": 3,
+            "rationale": "Claude correctly populated both dependency fields: `depends_on` lists q_002 (the resolved 1850 census question that established the two-Patrick-Flynn problem), and `unblocks` lists q_001 (the primary parentage question blocked by c_002). Both directions are explicitly stated with reasoning. Claude also noted that pli_006 should continue in parallel, showing awareness of concurrent work. No dependencies are missed or incorrectly assigned."
+          }
+        ]
+      },
+      "totals": {
+        "duration_ms": 216129.30539203808,
+        "input_tokens": 929,
+        "cached_input_tokens": 270706,
+        "output_tokens": 8688,
+        "judge_input_tokens": 4926,
+        "judge_cached_input_tokens": 0,
+        "judge_output_tokens": 871,
+        "skill_cost_usd": 0.33010855,
+        "judge_cost_usd": 0.009281000000000001,
+        "total_cost_usd": 0.33938955
+      },
+      "runs": [
+        {
+          "run_index": 0,
+          "run_id": "run_ut_question_selection_003_2026-06-26_08-07-13_0",
+          "outcome": "pass",
+          "aborted_reason": null,
+          "duration_ms": 216129.30539203808,
+          "input_tokens": 929,
+          "cached_input_tokens": 270706,
+          "output_tokens": 8688,
+          "skill_cost_usd": 0.33010855,
+          "output": {
+            "text_response": "I'll start by reading the reference files and project state simultaneously.Good \u2014 now let me read the project files.Now I have a clear picture. Let me analyze the state before writing anything.\n\n---\n\n**Step 1 \u2014 Project State Analysis**\n\n| Item | Detail |\n|---|---|\n| **Objective** | Identify the parents of Patrick Flynn (b. ~1845, d. 1908, Schuylkill Co., PA) |\n| **q_001** | \"Who were the parents of Patrick Flynn?\" \u2014 `in_progress`, plan active |\n| **q_002** | \"Where was Patrick Flynn in the 1850 census?\" \u2014 `resolved` |\n| **In-progress plan item** | `pli_006` \u2014 Thomas Flynn probate search on FamilySearch |\n| **Unresolved conflicts** | `c_001` (birthplace: Ireland vs. Pennsylvania) and `c_002` (identity: which of two 1850 Patrick Flynns is the subject?) \u2014 **both block q_001** |\n| **Timeline gap** | 1860\u20131908 (48 years, severity: high) \u2014 marriage, 1870/1880/1900 censuses missing |\n\n**Step 1a \u2014 In-Progress Rule:** `pli_006` is in flight, which would normally block a new question \u2014 but the **blocking-conflict exception applies**: both `c_001` and `c_002` are `unresolved` and list `q_001` in `blocks_question_ids`. The in-progress plan items cannot meaningfully resolve q_001 while these conflicts stand. Proceeding to Step 2.\n\n---\n\n**Step 2 \u2014 Priority 1 fires: Unresolved conflict blocking q_001**\n\nTwo conflicts qualify. Between them:\n- **c_001** (birthplace) is substantially addressed in the proof summary (`ps_001`) \u2014 the reasoning for preferring Ireland over Pennsylvania is already documented. The conflict status hasn't been formally updated, but the analytical work is done.\n- **c_002** (identity) is more fundamental: two Patrick Flynns appear in Schuylkill County in 1850 (dwelling 84, age 5 vs. dwelling 197, age 6), and no record has yet connected the subject in the 1908 death certificate back to specifically the Thomas Flynn household. If the wrong Patrick Flynn is being tracked, the entire parentage conclusion collapses. Resolving identity before fact conflicts is the methodologically correct sequence.\n\n**\u2192 c_002 is the higher-priority conflict to address.** The 1870 census is the logical bridge: Patrick would be ~25, potentially heading his own household or still near Thomas. Finding him there \u2014 and tracing which household he came from \u2014 directly answers which of the two 1850 Patrick Flynns is the research subject.\n\n---\n\n**Step 3 \u2014 Formulate the question**\n\n- One objective: locate Patrick Flynn in the 1870 census \u2714  \n- Named individual: Patrick Flynn, b. ~1845, Schuylkill County \u2714  \n- Testable scope: 1870 census records exist; the question is answered when a Patrick Flynn of consistent age is (or isn't) found and evaluated \u2714  \n- Sound basis: built on verified census placements in 1850 and 1860, not unverified compiled sources \u2714\n\n**Question:** *Where was Patrick Flynn (b. ~1845, d. 1908 Schuylkill Co., PA) in the 1870 U.S. Census?*\n\nNow let me load the append tool and write the question.The `research_log_append` tool is for the log section. For appending to `questions[]`, I'll write directly to `research.json` and then validate. Let me insert the new question now.Written. Now let me validate the schema.Validation was denied. Let me do a manual sanity-check by reading the new question block back.The question is persisted correctly. Here's the full summary:\n\n---\n\n## New Research Question: q_003\n\n**Question:** *Where was Patrick Flynn (b. ~1845, d. 1908 Schuylkill Co., PA) in the 1870 U.S. Census?*\n\n---\n\n### Why this question, why now\n\n**Priority 1 \u2014 Unresolved conflict (c_002) blocking q_001.**\n\nTwo `unresolved` conflicts both block the primary question q_001. The identity conflict `c_002` is addressed first because it's the more foundational of the two:\n\n> *Two Patrick Flynns of similar age appear in Schuylkill County in 1850 \u2014 dwelling 84 (age 5, Thomas Flynn's household) and dwelling 197 (age 6) \u2014 and the 1908 death certificate does not name an earlier residence to disambiguate which Patrick Flynn died that year.*\n\nUntil this is resolved, all three pieces of evidence for the parentage conclusion (the 1850 and 1860 census co-enumeration with Thomas Flynn, and the death certificate naming Thomas as father) rest on an uncertain foundation \u2014 we cannot be sure they all refer to the *same* Patrick Flynn. The 1870 census will show Patrick at approximately age 25, either still near Thomas Flynn or on his own, and that context is what links the 1850/1860 household to the 1908 death.\n\nThe birthplace conflict (c_001) is the other blocker, but the proof summary already contains the analytical work needed to resolve it formally, so the identity question takes precedence.\n\n**Bonus:** q_003 also directly addresses the project's only **high-severity timeline gap** (1860\u20131908, 48 years) as a secondary benefit.\n\n### Dependency links\n| Field | Value |\n|---|---|\n| `depends_on` | `q_002` \u2014 the resolved 1850 question established the two-Patrick-Flynn disambiguation problem in the first place |\n| `unblocks` | `q_001` \u2014 resolving the identity conflict removes the block on the primary parentage question |\n\n---\n\n### Also note: pli_006 still in flight\nThe probate search (`pli_006`) for Thomas Flynn should continue in parallel \u2014 it may itself produce evidence relevant to both q_003 and q_001. Complete it before closing q_001.\n\n---\n\n**Suggested next step:** Would you like me to plan the research for q_003? The 1870 census is fully indexed on FamilySearch and Ancestry, and a broader Pennsylvania search would catch Patrick if he had moved out of Schuylkill County by 1870.",
+            "activated": true,
+            "skills_invoked": [
+              "question-selection"
+            ],
+            "tool_calls": [],
+            "files_created": [],
+            "file_changes": {
+              "research.json": {
+                "sections_modified": [
+                  "questions"
+                ],
+                "diff": {
+                  "questions": {
+                    "added": [
+                      {
+                        "id": "q_003",
+                        "question": "Where was Patrick Flynn (b. ~1845, d. 1908 Schuylkill Co., PA) in the 1870 U.S. Census?",
+                        "rationale": "The 1870 census bridges the 48-year gap (1860\u20131908) in Patrick's timeline and is the highest-priority tool for resolving identity conflict c_002 \u2014 two Patrick Flynns of similar age appear in Schuylkill County in 1850 (dwelling 84, age 5, and dwelling 197, age 6), and no record yet confirms which is the subject of the 1908 death certificate. Finding Patrick at approximately age 25, and tracing the household he came from, directly answers the identity question. Schuylkill County 1870 census records are indexed on FamilySearch and Ancestry.",
+                        "selection_basis": "unresolved_conflict",
+                        "priority": "high",
+                        "status": "open",
+                        "depends_on": [
+                          "q_002"
+                        ],
+                        "unblocks": [
+                          "q_001"
+                        ],
+                        "created": "2026-06-26",
+                        "resolved": null,
+                        "resolution_assertion_ids": [],
+                        "exhaustive_declaration": {
+                          "declared": false,
+                          "justification": null,
+                          "log_entry_ids": [],
+                          "stop_criteria": null
+                        }
+                      }
+                    ],
+                    "modified": [],
+                    "deleted": []
+                  }
+                }
+              }
+            },
+            "warnings": [
+              {
+                "kind": "uncovered_tool_call",
+                "advisory": "1 of 1 MCP tool call(s) matched no fixture predicate \u2014 the skill ran against a fixture_not_found or denied/unknown-tool error. Add or fix an mcp_fixture whose args match the call.",
+                "attempted": [
+                  {
+                    "tool": "mcp__genealogy__validate_research_schema",
+                    "args": {
+                      "projectPath": "/tmp/eval-ut_question_selection_003-0-0-8nnws42q"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "validators": {
+            "passed": true,
+            "results": [
+              {
+                "name": "test_id_references_resolve",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_log_append_only",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_entries_deleted",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_research_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tool_allowlist",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_gedcomx_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_depends_on_nonempty",
+                "passed": true,
+                "error": "skipped: not a depends-on-nonempty scenario"
+              },
+              {
+                "name": "test_first_question_depends_on_empty",
+                "passed": true,
+                "error": "skipped: not a first-question-depends-on-empty scenario"
+              },
+              {
+                "name": "test_new_question_exhaustive_declaration_unstarted",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_question_selection_no_new_question",
+                "passed": true,
+                "error": "skipped: not a question-selection-no-new-question scenario"
+              },
+              {
+                "name": "test_questions_no_deletions",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_selection_basis_fan_pivot",
+                "passed": true,
+                "error": "skipped: not a selection-basis-fan-pivot scenario"
+              },
+              {
+                "name": "test_selection_basis_objective_decomposition",
+                "passed": true,
+                "error": "skipped: not a selection-basis-objective-decomposition scenario"
+              },
+              {
+                "name": "test_selection_basis_timeline_gap",
+                "passed": true,
+                "error": "skipped: not a selection-basis-timeline-gap scenario"
+              },
+              {
+                "name": "test_selection_basis_unresolved_conflict",
+                "passed": true,
+                "error": null
+              }
+            ]
+          },
+          "judge": {
+            "skipped": false,
+            "dimensions": [
+              {
+                "source": "base",
+                "name": "Correctness",
+                "score": 3,
+                "rationale": "Claude correctly analyzed the project state, identified the two unresolved conflicts (c_001 and c_002), and determined that c_002 (identity) should be addressed first because it is foundational to resolving the parentage question. The reasoning\u2014that the 1870 census would help disambiguate which Patrick Flynn is the research subject\u2014is sound and well-supported by the input state. No fabricated material or unsupported claims."
+              },
+              {
+                "source": "base",
+                "name": "Completeness",
+                "score": 3,
+                "rationale": "Claude addressed all required elements: (1) recognized the blocking-conflict exception and explained why pli_006 cannot proceed while conflicts remain unresolved, (2) prioritized between c_001 and c_002 with explicit reasoning, (3) formulated a concrete, answerable research question, (4) populated depends_on and unblocks fields correctly, (5) noted the secondary timeline-gap benefit, and (6) mentioned that pli_006 should continue in parallel. All aspects of the expected analytical framework were covered."
+              },
+              {
+                "source": "base",
+                "name": "Tool Arguments",
+                "score": null,
+                "rationale": "No MCP tool calls were made. The skill read reference files and project state (indicated by text like 'I'll start by reading the reference files' and 'Now let me load the append tool') but ultimately produced the new question directly in the response without invoking any external tools. This is N/A."
+              },
+              {
+                "source": "rubric",
+                "name": "Prioritization logic",
+                "score": 3,
+                "rationale": "Claude correctly applied the priority framework: unresolved conflicts > timeline gaps > hypothesis tests > new decompositions. c_002 was selected because it is an unresolved conflict that blocks q_001 (Priority 1). The rationale explicitly explains why c_002 (identity) takes precedence over c_001 (birthplace): it is more foundational\u2014without resolving which Patrick Flynn is the subject, all parentage evidence is uncertain. The selection_basis is correct and the comparative reasoning against c_001 is clear and methodologically sound."
+              },
+              {
+                "source": "rubric",
+                "name": "Question specificity",
+                "score": 3,
+                "rationale": "The proposed question 'Where was Patrick Flynn (b. ~1845, d. 1908 Schuylkill Co., PA) in the 1870 U.S. Census?' is concrete and answerable. It names a specific individual (Patrick Flynn with birth year and death location), specifies a particular census (1870), and identifies a clear factual target (residence/household location). A follow-up search design could directly test this question. The question is not vague or exploratory."
+              },
+              {
+                "source": "rubric",
+                "name": "Dependency awareness",
+                "score": 3,
+                "rationale": "Claude correctly populated both dependency fields: `depends_on` lists q_002 (the resolved 1850 census question that established the two-Patrick-Flynn problem), and `unblocks` lists q_001 (the primary parentage question blocked by c_002). Both directions are explicitly stated with reasoning. Claude also noted that pli_006 should continue in parallel, showing awareness of concurrent work. No dependencies are missed or incorrectly assigned."
+              }
+            ],
+            "judge_cost_usd": 0.009281000000000001,
+            "error": null,
+            "input_tokens": 4926,
+            "cached_input_tokens": 0,
+            "output_tokens": 871
+          }
+        }
+      ]
+    },
+    {
+      "test_id": "ut_question_selection_005",
+      "test_type": "positive",
+      "expected_outcome": "pass",
+      "scenario": "flynn-fan-pivot",
+      "mcp_fixtures": [],
+      "outcome": "pass",
+      "flaky": false,
+      "outcome_summary": {
+        "per_run_outcomes": [
+          "pass"
+        ],
+        "aggregated_dimensions": [
+          {
+            "source": "base",
+            "name": "Correctness",
+            "score": 3,
+            "rationale": "The skill correctly identified that all planned direct searches (1850, 1860, 1870, 1880, 1900 censuses, death certificate, probate, church records) are complete. It correctly recognized Priority 6 (FAN pivot) as the appropriate next step and accurately characterized naturalization records as a viable FAN avenue not yet explored. The analysis is supported by the project state: q_001 has `exhaustive_declaration.declared = true`, both plans have `status: completed`, and the proof summary remains at `probable`. The proposed question about Thomas Flynn's naturalization is factually grounded\u2014Pennsylvania naturalization petitions from this era did name family members, and FamilySearch does hold such records."
+          },
+          {
+            "source": "base",
+            "name": "Completeness",
+            "score": 3,
+            "rationale": "The skill addressed the user's request fully. It identified the correct priority signal (FAN pivot), created a specific new research question (q_003), populated it with all required fields (depends_on, unblocks, selection_basis), and provided rationale explaining why this question takes priority. The file modification summary confirms the question was written to research.json. No obvious gaps remain in what the input state required the skill to cover."
+          },
+          {
+            "source": "base",
+            "name": "Tool Arguments",
+            "score": 3,
+            "rationale": "No MCP tool calls were made. The skill read the provided reference files (by context), analyzed the project state, and wrote q_003 directly to research.json without requiring schema validation. The absence of tool calls is appropriate here\u2014the skill acknowledged that research_append was not available and proceeded with direct file editing. This is N/A-eligible behavior, but since the skill still produced correct output and required no tool arguments, a pass score is warranted."
+          },
+          {
+            "source": "rubric",
+            "name": "Prioritization logic",
+            "score": 3,
+            "rationale": "The skill correctly identified Priority 6 (FAN pivot) as the highest signal present. It explicitly scanned all higher priorities (P1\u2013P5) and confirmed none were active: no blocking conflicts, hypothesis is already supported (not awaiting test), gap severity is low, no decomposition gaps. The selection_basis is correctly set to `fan_pivot`. The rationale clearly explains why FAN research takes priority\u2014all direct record types have been exhausted and no new evidence can come from them, making associates/neighbors research the next high-value avenue."
+          },
+          {
+            "source": "rubric",
+            "name": "Question specificity",
+            "score": 3,
+            "rationale": "The question is concrete and answerable: 'Did Thomas Flynn file for naturalization in Schuylkill County, Pennsylvania between 1840 and 1870?' It specifies the subject (Thomas Flynn), the record type (naturalization), the geography (Schuylkill County, Pennsylvania), and the time period (1840\u20131870). A follow-up search can be directly designed to answer it by checking FamilySearch naturalization collections and county court records for this period and location. No ambiguity or fuzziness in what facts are being sought."
+          },
+          {
+            "source": "rubric",
+            "name": "Dependency awareness",
+            "score": 3,
+            "rationale": "The `depends_on` field correctly references `['q_001']`\u2014the question that identified Thomas Flynn as the candidate father. The `unblocks` field correctly identifies `['q_001']` as the question this answer could elevate from *Probable* to *Proved* if Thomas's naturalization record names Patrick as his child. Both fields are populated appropriately and reflect genuine dependencies: FAN research on Thomas presupposes knowing which Thomas to research, and a positive result would directly resolve the parentage question."
+          }
+        ]
+      },
+      "totals": {
+        "duration_ms": 164644.00723110884,
+        "input_tokens": 15,
+        "cached_input_tokens": 157387,
+        "output_tokens": 6837,
+        "judge_input_tokens": 4919,
+        "judge_cached_input_tokens": 0,
+        "judge_output_tokens": 965,
+        "skill_cost_usd": 0.2561851,
+        "judge_cost_usd": 0.009744,
+        "total_cost_usd": 0.2659291
+      },
+      "runs": [
+        {
+          "run_index": 0,
+          "run_id": "run_ut_question_selection_005_2026-06-26_08-07-13_0",
+          "outcome": "pass",
+          "aborted_reason": null,
+          "duration_ms": 164644.00723110884,
+          "input_tokens": 15,
+          "cached_input_tokens": 157387,
+          "output_tokens": 6837,
+          "skill_cost_usd": 0.2561851,
+          "output": {
+            "text_response": "I'll start by reading the reference files and project state simultaneously.Now I have a complete picture. Let me analyze:\n\n**Step 1a \u2014 In-progress plan items check:** Both plans (`pl_001` and `pl_002`) have `status: \"completed\"` \u2014 no plan items are `in_progress`. I can proceed.\n\n**Priority scan:**\n- **P1 \u2014 Blocking conflicts:** `c_001` is `resolved`, `blocks_question_ids: []`. No blocker. \u2717\n- **P2 \u2014 Active hypothesis needing test:** `h_001` is `\"supported\"` \u2014 not awaiting a test search. \u2717\n- **P3 \u2014 High-severity timeline gap:** The single gap in `t_001` is rated `\"low\"`. \u2717\n- **P4/P5 \u2014 Decomposition/pedigree gap:** q_001 already covers the objective; it's the primary question. \u2717\n- **P6 \u2014 FAN pivot \ud83d\udd14:** `q_001.exhaustive_declaration.declared = true`. All direct record types exhausted (1850\u20131900 census, death certificate, probate, church records). The hypothesis notes and proof summary both explicitly flag that \"Associates/neighbors research has not yet been attempted.\" **Priority 6 fires.**\n\nThe FAN question should target **Thomas Flynn** (the candidate father) \u2014 specifically his naturalization records. Pennsylvania naturalization petitions from this era sometimes named the petitioner's spouse and children, providing direct or corroborating relationship evidence that census co-enumeration cannot supply. This record type has not been searched in any plan item.The `research_append` MCP tool isn't in this environment's available tools, so I'll write the question directly to `research.json` using the Edit tool (I've already read the file). The next question ID is `q_003`.Now validate the updated file:The schema validator requires a permission not granted in this session \u2014 the edit itself completed successfully (Edit would have errored on failure). Let me present the results.\n\n---\n\n## Next Research Question \u2014 `q_003`\n\n**Question written to `research.json`:**\n\n> **Did Thomas Flynn file for naturalization in Schuylkill County, Pennsylvania between 1840 and 1870?**\n\n---\n\n### Why this question, why now\n\n**Priority 6 \u2014 FAN pivot** fired because `q_001.exhaustive_declaration.declared = true`. Every direct record type has been searched and come up dry or indirect:\n\n| Record type | Repository | Outcome |\n|---|---|---|\n| 1850 census | FamilySearch, Ancestry, MyHeritage | \u2705 Positive (co-enumeration only \u2014 indirect) |\n| 1860 census | FamilySearch | \u2705 Positive (co-enumeration only \u2014 indirect) |\n| 1870, 1880, 1900 census | FamilySearch | \u274c Patrick Flynn not found |\n| Death certificate 1908 | FamilySearch | \u2705 Names Thomas as father \u2014 but secondary informant |\n| Schuylkill Co. probate 1870\u20131900 | FamilySearch | \u274c Negative |\n| Catholic church records 1840\u20131870 | FamilySearch | \u274c Negative |\n\nThe conclusion sits at **Probable** (`ps_001`). To elevate it, we need a new record type \u2014 and Thomas Flynn's own civil documents are the most promising FAN avenue not yet explored.\n\n**Why naturalization?** Pennsylvania naturalization petitions (declaration of intent + petition for citizenship) from the 1840s\u20131870s sometimes explicitly named the petitioner's spouse and children, which could provide corroborating or even direct documentary evidence that Patrick was Thomas's son. As an Irish immigrant present in Schuylkill County by 1850, Thomas would have been eligible to naturalize. FamilySearch holds Pennsylvania naturalization records for this period; Schuylkill County Court of Common Pleas originals also exist.\n\n---\n\n### Links\n- **Depends on:** `q_001` \u2014 Thomas Flynn's identity and the exhaustive direct-evidence search are the basis for this question.\n- **Unblocks:** `q_001` \u2014 a positive result with family members named could push the parentage conclusion from *Probable* toward *Proved*.\n\n---\n\n### Suggested next step\n\nWould you like me to **plan the research for `q_003`** \u2014 mapping out which FamilySearch collections and county repositories to search, in what order? (skill: `research-plan`)",
+            "activated": true,
+            "skills_invoked": [
+              "question-selection"
+            ],
+            "tool_calls": [],
+            "files_created": [],
+            "file_changes": {
+              "research.json": {
+                "sections_modified": [
+                  "questions"
+                ],
+                "diff": {
+                  "questions": {
+                    "added": [
+                      {
+                        "id": "q_003",
+                        "question": "Did Thomas Flynn file for naturalization in Schuylkill County, Pennsylvania between 1840 and 1870?",
+                        "rationale": "All direct record types for q_001 are exhausted per the exhaustive declaration (censuses, death certificate, probate, church records \u2014 all negative or indirect). A FAN pivot to Thomas Flynn's own civil records is the next available avenue. Pennsylvania naturalization petitions from this era sometimes named the petitioner's spouse and children, which could corroborate or directly document Patrick Flynn's parentage. As an Irish immigrant present in Schuylkill County by 1850, Thomas would have been eligible to naturalize during this period. FamilySearch holds Pennsylvania naturalization records; Schuylkill County courthouse originals also exist.",
+                        "selection_basis": "fan_pivot",
+                        "priority": "high",
+                        "status": "open",
+                        "depends_on": [
+                          "q_001"
+                        ],
+                        "unblocks": [
+                          "q_001"
+                        ],
+                        "created": "2026-06-26",
+                        "resolved": null,
+                        "resolution_assertion_ids": [],
+                        "exhaustive_declaration": {
+                          "declared": false,
+                          "justification": null,
+                          "log_entry_ids": [],
+                          "stop_criteria": null
+                        }
+                      }
+                    ],
+                    "modified": [],
+                    "deleted": []
+                  }
+                }
+              }
+            },
+            "warnings": [
+              {
+                "kind": "uncovered_tool_call",
+                "advisory": "1 of 1 MCP tool call(s) matched no fixture predicate \u2014 the skill ran against a fixture_not_found or denied/unknown-tool error. Add or fix an mcp_fixture whose args match the call.",
+                "attempted": [
+                  {
+                    "tool": "mcp__genealogy__validate_research_schema",
+                    "args": {
+                      "projectPath": "/tmp/eval-ut_question_selection_005-0-0-ksjptx52"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "validators": {
+            "passed": true,
+            "results": [
+              {
+                "name": "test_id_references_resolve",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_log_append_only",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_entries_deleted",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_research_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tool_allowlist",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_gedcomx_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_depends_on_nonempty",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_first_question_depends_on_empty",
+                "passed": true,
+                "error": "skipped: not a first-question-depends-on-empty scenario"
+              },
+              {
+                "name": "test_new_question_exhaustive_declaration_unstarted",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_question_selection_no_new_question",
+                "passed": true,
+                "error": "skipped: not a question-selection-no-new-question scenario"
+              },
+              {
+                "name": "test_questions_no_deletions",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_selection_basis_fan_pivot",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_selection_basis_objective_decomposition",
+                "passed": true,
+                "error": "skipped: not a selection-basis-objective-decomposition scenario"
+              },
+              {
+                "name": "test_selection_basis_timeline_gap",
+                "passed": true,
+                "error": "skipped: not a selection-basis-timeline-gap scenario"
+              },
+              {
+                "name": "test_selection_basis_unresolved_conflict",
+                "passed": true,
+                "error": "skipped: not a selection-basis-unresolved-conflict scenario"
+              }
+            ]
+          },
+          "judge": {
+            "skipped": false,
+            "dimensions": [
+              {
+                "source": "base",
+                "name": "Correctness",
+                "score": 3,
+                "rationale": "The skill correctly identified that all planned direct searches (1850, 1860, 1870, 1880, 1900 censuses, death certificate, probate, church records) are complete. It correctly recognized Priority 6 (FAN pivot) as the appropriate next step and accurately characterized naturalization records as a viable FAN avenue not yet explored. The analysis is supported by the project state: q_001 has `exhaustive_declaration.declared = true`, both plans have `status: completed`, and the proof summary remains at `probable`. The proposed question about Thomas Flynn's naturalization is factually grounded\u2014Pennsylvania naturalization petitions from this era did name family members, and FamilySearch does hold such records."
+              },
+              {
+                "source": "base",
+                "name": "Completeness",
+                "score": 3,
+                "rationale": "The skill addressed the user's request fully. It identified the correct priority signal (FAN pivot), created a specific new research question (q_003), populated it with all required fields (depends_on, unblocks, selection_basis), and provided rationale explaining why this question takes priority. The file modification summary confirms the question was written to research.json. No obvious gaps remain in what the input state required the skill to cover."
+              },
+              {
+                "source": "base",
+                "name": "Tool Arguments",
+                "score": 3,
+                "rationale": "No MCP tool calls were made. The skill read the provided reference files (by context), analyzed the project state, and wrote q_003 directly to research.json without requiring schema validation. The absence of tool calls is appropriate here\u2014the skill acknowledged that research_append was not available and proceeded with direct file editing. This is N/A-eligible behavior, but since the skill still produced correct output and required no tool arguments, a pass score is warranted."
+              },
+              {
+                "source": "rubric",
+                "name": "Prioritization logic",
+                "score": 3,
+                "rationale": "The skill correctly identified Priority 6 (FAN pivot) as the highest signal present. It explicitly scanned all higher priorities (P1\u2013P5) and confirmed none were active: no blocking conflicts, hypothesis is already supported (not awaiting test), gap severity is low, no decomposition gaps. The selection_basis is correctly set to `fan_pivot`. The rationale clearly explains why FAN research takes priority\u2014all direct record types have been exhausted and no new evidence can come from them, making associates/neighbors research the next high-value avenue."
+              },
+              {
+                "source": "rubric",
+                "name": "Question specificity",
+                "score": 3,
+                "rationale": "The question is concrete and answerable: 'Did Thomas Flynn file for naturalization in Schuylkill County, Pennsylvania between 1840 and 1870?' It specifies the subject (Thomas Flynn), the record type (naturalization), the geography (Schuylkill County, Pennsylvania), and the time period (1840\u20131870). A follow-up search can be directly designed to answer it by checking FamilySearch naturalization collections and county court records for this period and location. No ambiguity or fuzziness in what facts are being sought."
+              },
+              {
+                "source": "rubric",
+                "name": "Dependency awareness",
+                "score": 3,
+                "rationale": "The `depends_on` field correctly references `['q_001']`\u2014the question that identified Thomas Flynn as the candidate father. The `unblocks` field correctly identifies `['q_001']` as the question this answer could elevate from *Probable* to *Proved* if Thomas's naturalization record names Patrick as his child. Both fields are populated appropriately and reflect genuine dependencies: FAN research on Thomas presupposes knowing which Thomas to research, and a positive result would directly resolve the parentage question."
+              }
+            ],
+            "judge_cost_usd": 0.009744,
+            "error": null,
+            "input_tokens": 4919,
+            "cached_input_tokens": 0,
+            "output_tokens": 965
+          }
+        }
+      ]
+    },
+    {
+      "test_id": "ut_question_selection_006",
+      "test_type": "positive",
+      "expected_outcome": "pass",
+      "scenario": "flynn-census-exhausted",
+      "mcp_fixtures": [],
+      "outcome": "pass",
+      "flaky": false,
+      "outcome_summary": {
+        "per_run_outcomes": [
+          "pass"
+        ],
+        "aggregated_dimensions": [
+          {
+            "source": "base",
+            "name": "Correctness",
+            "score": 3,
+            "rationale": "The skill correctly identified the high-severity timeline gap from 1860-1908 as the highest priority signal. The question targets the 1870 census, one of three unsearched census years (1870, 1880, 1900) explicitly flagged in the proof summary. The reasoning is sound: Patrick would be ~25 in 1870, making the search contextually appropriate. All claims are grounded in the provided research state (t_001 gap details, proof summary language, person timeline)."
+          },
+          {
+            "source": "base",
+            "name": "Completeness",
+            "score": 3,
+            "rationale": "The skill addressed all requirements: recognized the active question (q_001) remains in_progress despite completed plan, identified no blocking in-progress plan items, applied the full priority ladder (unresolved conflicts \u2192 hypothesis tests \u2192 timeline gaps), selected a specific next question (q_003) with research_basis, populated depends_on and unblocks correctly, and provided explicit rationale. No silent omissions."
+          },
+          {
+            "source": "base",
+            "name": "Tool Arguments",
+            "score": null,
+            "rationale": "No MCP tool calls were made. The skill read the tree file directly from context and proceeded to question formulation without invoking any tools. This is appropriate for this question-selection task given the full scenario state was available. N/A."
+          },
+          {
+            "source": "rubric",
+            "name": "Prioritization logic",
+            "score": 3,
+            "rationale": "The skill explicitly applied the priority ladder: Priority 1 (unresolved conflicts) \u2014 c_001 resolved, skip; Priority 2 (hypothesis tests) \u2014 none exist, skip; Priority 3 (timeline gap) \u2014 t_001 high-severity gap fires. Selected selection_basis: 'timeline_gap' correctly. Rationale explicitly compares against other candidates and explains why the 48-year gap spanning three unsearched census years takes priority over further decomposition."
+          },
+          {
+            "source": "rubric",
+            "name": "Question specificity",
+            "score": 3,
+            "rationale": "Question is concrete and answerable: 'Where was Patrick Flynn (b. ~1845, Ireland, d. 1908 Schuylkill County, PA) enumerated in the 1870 U.S. Census?' Names the specific person, target record type (1870 census), time period, and the specific fact being sought (enumeration location). A follow-up search is clearly designed to answer this."
+          },
+          {
+            "source": "rubric",
+            "name": "Dependency awareness",
+            "score": 3,
+            "rationale": "Both fields are populated correctly. depends_on: [q_002] \u2014 Patrick's 1850 household location informs Schuylkill County search strategy; unblocks: [q_001] \u2014 additional census evidence advances the parentage proof from probable toward proved. Both dependencies are logically justified and connected to the project state."
+          }
+        ]
+      },
+      "totals": {
+        "duration_ms": 189943.62604804337,
+        "input_tokens": 14,
+        "cached_input_tokens": 154220,
+        "output_tokens": 9179,
+        "judge_input_tokens": 4528,
+        "judge_cached_input_tokens": 0,
+        "judge_output_tokens": 786,
+        "skill_cost_usd": 0.30565425,
+        "judge_cost_usd": 0.008458,
+        "total_cost_usd": 0.31411225000000004
+      },
+      "runs": [
+        {
+          "run_index": 0,
+          "run_id": "run_ut_question_selection_006_2026-06-26_08-07-13_0",
+          "outcome": "pass",
+          "aborted_reason": null,
+          "duration_ms": 189943.62604804337,
+          "input_tokens": 14,
+          "cached_input_tokens": 154220,
+          "output_tokens": 9179,
+          "skill_cost_usd": 0.30565425,
+          "output": {
+            "text_response": "Now let me read the tree file and check for in-progress plan items before proceeding.I have everything I need. Let me now analyze and write the question.\n\n**Step 1a \u2014 In-progress plan items check:**\n- `pl_001` (q_002) \u2192 `completed`; all items `completed`\n- `pl_002` (q_001) \u2192 `completed`; `pli_004`, `pli_005`, `pli_006` all `completed`\n\nNo plan items are `in_progress` \u2192 safe to select a new question.\n\n**Step 2 \u2014 Priority ladder:**\n- **Priority 1 (unresolved conflict blocking questions):** `c_001` is `resolved` with no `blocks_question_ids` \u2192 skip\n- **Priority 2 (hypothesis test):** `hypotheses: []` \u2192 skip\n- **Priority 3 (high-severity timeline gap):** `t_001` has a gap from 1860-01-01 to 1908-03-12 with `severity: \"high\"`, spanning three unsearched census years (1870, 1880, 1900) \u2192 **fires**\n\nThe proof summary confirms: *\"1870, 1880, and 1900 censuses not yet searched \u2014 this is the primary remaining gap.\"* The conclusion is rated only **probable** in part because of this gap.\n\n**Question formulated:** The 1870 census is the immediate next record opportunity after the confirmed 1860 Thomas Flynn household. Patrick, ~25 in 1870, may still be co-residing with Thomas, which would extend the corroboration chain. Even if he has established his own household, the record narrows the gap and provides additional identity confirmation.Now validate the schema:Schema validation was blocked by permissions. The edit structure precisely mirrors the existing questions, so I'll proceed to present the result.\n\n---\n\n## Next Question Selected: q_003\n\n**Question:**\n> Where was Patrick Flynn (b. ~1845, Ireland, d. 1908 Schuylkill County, PA) enumerated in the 1870 U.S. Census?\n\n**Why this question now \u2014 rationale:**\nA **high-severity timeline gap** runs from 1860 to 1908 with no census, vital, or residence event documented for Patrick. The 1870 census is the chronologically immediate next record opportunity after the confirmed 1860 Thomas Flynn household. At roughly 25 years old in 1870, Patrick may still be co-residing with Thomas Flynn \u2014 which would extend the indirect co-residence evidence chain \u2014 or he may have just established his own household, in which case the record confirms his continuing presence in Schuylkill County. Either outcome directly advances q_001. The current parentage proof is rated only **probable**, and the proof summary explicitly flags 1870\u20131900 census coverage as the primary remaining gap.\n\n**Depends on:** `q_002` (Patrick's 1850 household location informs exactly where in Schuylkill County to search)\n\n**Unblocks:** `q_001` (additional census evidence could upgrade the parentage conclusion from *probable* to *proved*)\n\n---\n\n**Suggested next step:** Would you like me to plan the research for this question? (That would be the `research-plan` skill \u2014 it will identify which repositories to search for the 1870 census and in what order.)",
+            "activated": true,
+            "skills_invoked": [
+              "question-selection"
+            ],
+            "tool_calls": [],
+            "files_created": [],
+            "file_changes": {
+              "research.json": {
+                "sections_modified": [
+                  "questions"
+                ],
+                "diff": {
+                  "questions": {
+                    "added": [
+                      {
+                        "id": "q_003",
+                        "question": "Where was Patrick Flynn (b. ~1845, Ireland, d. 1908 Schuylkill County, PA) enumerated in the 1870 U.S. Census?",
+                        "rationale": "A high-severity timeline gap exists from 1860 to 1908 with no enumeration, vital record, or residence event documented. The 1870 census is the immediate next record opportunity after the confirmed 1860 Thomas Flynn household. At roughly age 25, Patrick may still be co-residing with Thomas Flynn, which would extend the indirect co-residence evidence chain; if he has established his own household, the record narrows the gap and confirms his identity in Schuylkill County. The current proof conclusion for q_001 is rated only 'probable' in part because the 1870\u20131900 censuses have not been searched.",
+                        "selection_basis": "timeline_gap",
+                        "priority": "high",
+                        "status": "open",
+                        "depends_on": [
+                          "q_002"
+                        ],
+                        "unblocks": [
+                          "q_001"
+                        ],
+                        "created": "2026-06-26",
+                        "resolved": null,
+                        "resolution_assertion_ids": [],
+                        "exhaustive_declaration": {
+                          "declared": false,
+                          "justification": null,
+                          "log_entry_ids": [],
+                          "stop_criteria": null
+                        }
+                      }
+                    ],
+                    "modified": [],
+                    "deleted": []
+                  }
+                }
+              }
+            },
+            "warnings": [
+              {
+                "kind": "uncovered_tool_call",
+                "advisory": "1 of 1 MCP tool call(s) matched no fixture predicate \u2014 the skill ran against a fixture_not_found or denied/unknown-tool error. Add or fix an mcp_fixture whose args match the call.",
+                "attempted": [
+                  {
+                    "tool": "mcp__genealogy__validate_research_schema",
+                    "args": {
+                      "projectPath": "/tmp/eval-ut_question_selection_006-0-0-6qyaa8fr"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "validators": {
+            "passed": true,
+            "results": [
+              {
+                "name": "test_id_references_resolve",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_log_append_only",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_entries_deleted",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_research_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tool_allowlist",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_gedcomx_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_depends_on_nonempty",
+                "passed": true,
+                "error": "skipped: not a depends-on-nonempty scenario"
+              },
+              {
+                "name": "test_first_question_depends_on_empty",
+                "passed": true,
+                "error": "skipped: not a first-question-depends-on-empty scenario"
+              },
+              {
+                "name": "test_new_question_exhaustive_declaration_unstarted",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_question_selection_no_new_question",
+                "passed": true,
+                "error": "skipped: not a question-selection-no-new-question scenario"
+              },
+              {
+                "name": "test_questions_no_deletions",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_selection_basis_fan_pivot",
+                "passed": true,
+                "error": "skipped: not a selection-basis-fan-pivot scenario"
+              },
+              {
+                "name": "test_selection_basis_objective_decomposition",
+                "passed": true,
+                "error": "skipped: not a selection-basis-objective-decomposition scenario"
+              },
+              {
+                "name": "test_selection_basis_timeline_gap",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_selection_basis_unresolved_conflict",
+                "passed": true,
+                "error": "skipped: not a selection-basis-unresolved-conflict scenario"
+              }
+            ]
+          },
+          "judge": {
+            "skipped": false,
+            "dimensions": [
+              {
+                "source": "base",
+                "name": "Correctness",
+                "score": 3,
+                "rationale": "The skill correctly identified the high-severity timeline gap from 1860-1908 as the highest priority signal. The question targets the 1870 census, one of three unsearched census years (1870, 1880, 1900) explicitly flagged in the proof summary. The reasoning is sound: Patrick would be ~25 in 1870, making the search contextually appropriate. All claims are grounded in the provided research state (t_001 gap details, proof summary language, person timeline)."
+              },
+              {
+                "source": "base",
+                "name": "Completeness",
+                "score": 3,
+                "rationale": "The skill addressed all requirements: recognized the active question (q_001) remains in_progress despite completed plan, identified no blocking in-progress plan items, applied the full priority ladder (unresolved conflicts \u2192 hypothesis tests \u2192 timeline gaps), selected a specific next question (q_003) with research_basis, populated depends_on and unblocks correctly, and provided explicit rationale. No silent omissions."
+              },
+              {
+                "source": "base",
+                "name": "Tool Arguments",
+                "score": null,
+                "rationale": "No MCP tool calls were made. The skill read the tree file directly from context and proceeded to question formulation without invoking any tools. This is appropriate for this question-selection task given the full scenario state was available. N/A."
+              },
+              {
+                "source": "rubric",
+                "name": "Prioritization logic",
+                "score": 3,
+                "rationale": "The skill explicitly applied the priority ladder: Priority 1 (unresolved conflicts) \u2014 c_001 resolved, skip; Priority 2 (hypothesis tests) \u2014 none exist, skip; Priority 3 (timeline gap) \u2014 t_001 high-severity gap fires. Selected selection_basis: 'timeline_gap' correctly. Rationale explicitly compares against other candidates and explains why the 48-year gap spanning three unsearched census years takes priority over further decomposition."
+              },
+              {
+                "source": "rubric",
+                "name": "Question specificity",
+                "score": 3,
+                "rationale": "Question is concrete and answerable: 'Where was Patrick Flynn (b. ~1845, Ireland, d. 1908 Schuylkill County, PA) enumerated in the 1870 U.S. Census?' Names the specific person, target record type (1870 census), time period, and the specific fact being sought (enumeration location). A follow-up search is clearly designed to answer this."
+              },
+              {
+                "source": "rubric",
+                "name": "Dependency awareness",
+                "score": 3,
+                "rationale": "Both fields are populated correctly. depends_on: [q_002] \u2014 Patrick's 1850 household location informs Schuylkill County search strategy; unblocks: [q_001] \u2014 additional census evidence advances the parentage proof from probable toward proved. Both dependencies are logically justified and connected to the project state."
+              }
+            ],
+            "judge_cost_usd": 0.008458,
+            "error": null,
+            "input_tokens": 4528,
+            "cached_input_tokens": 0,
+            "output_tokens": 786
+          }
+        }
+      ]
+    },
+    {
+      "test_id": "ut_question_selection_007",
+      "test_type": "positive",
+      "expected_outcome": "pass",
+      "scenario": "flynn-parentage-found",
+      "mcp_fixtures": [],
+      "outcome": "pass",
+      "flaky": false,
+      "outcome_summary": {
+        "per_run_outcomes": [
+          "pass"
+        ],
+        "aggregated_dimensions": [
+          {
+            "source": "base",
+            "name": "Correctness",
+            "score": 3,
+            "rationale": "The skill correctly identified the resolved state of q_001 (father confirmed as Thomas Flynn) and the remaining gap (mother's identity). The analysis of the project state is accurate: the objective requires both parents, one is found, the other is not yet questioned. No fabricated claims or contradictions present."
+          },
+          {
+            "source": "base",
+            "name": "Completeness",
+            "score": 3,
+            "rationale": "The skill fully addressed the user's query to add a research question for what comes next. It added q_003 ('Who was Patrick Flynn's mother?') with correct dependencies (depends_on: [q_001, q_002]), explained the priority logic (objective decomposition), identified available sources (1850 census in dwelling 84, death certificate), and provided next-step guidance."
+          },
+          {
+            "source": "base",
+            "name": "Tool Arguments",
+            "score": null,
+            "rationale": "No MCP tool calls were made during this skill execution. The skill operated purely on the provided project state to generate a new question and modify research.json. N/A."
+          },
+          {
+            "source": "rubric",
+            "name": "Prioritization logic",
+            "score": 3,
+            "rationale": "The skill correctly invoked Priority 4 (objective decomposition) because the objective requires both parents, the father is resolved, and the mother has no question or search yet. The rationale explicitly states this is the remaining half of the objective and the natural next step. No higher-priority signals (unresolved conflicts) were present to override this selection."
+          },
+          {
+            "source": "rubric",
+            "name": "Question specificity",
+            "score": 3,
+            "rationale": "The question 'Who was Patrick Flynn's mother?' is concrete and answerable. It names a specific person (Patrick Flynn), specifies the relationship sought (mother), and targets a clear fact (the mother's identity). This level of specificity is sufficient to drive a focused search of available records."
+          },
+          {
+            "source": "rubric",
+            "name": "Dependency awareness",
+            "score": 3,
+            "rationale": "The depends_on field correctly includes both q_001 and q_002. q_001 established Thomas Flynn's identity (whose wife is being sought) and q_002 located the specific 1850 household record (dwelling 84) that is the primary starting point for finding the mother's name. The unblocks field is correctly set to an empty array. Both directions are properly populated."
+          }
+        ]
+      },
+      "totals": {
+        "duration_ms": 185314.4521249924,
+        "input_tokens": 934,
+        "cached_input_tokens": 346569,
+        "output_tokens": 6865,
+        "judge_input_tokens": 4200,
+        "judge_cached_input_tokens": 0,
+        "judge_output_tokens": 670,
+        "skill_cost_usd": 0.33724745000000006,
+        "judge_cost_usd": 0.007549999999999999,
+        "total_cost_usd": 0.34479745000000006
+      },
+      "runs": [
+        {
+          "run_index": 0,
+          "run_id": "run_ut_question_selection_007_2026-06-26_08-07-13_0",
+          "outcome": "pass",
+          "aborted_reason": null,
+          "duration_ms": 185314.4521249924,
+          "input_tokens": 934,
+          "cached_input_tokens": 346569,
+          "output_tokens": 6865,
+          "skill_cost_usd": 0.33724745000000006,
+          "output": {
+            "text_response": "Now I have everything I need. Let me analyze and write the new question.\n\n**Project state analysis:**\n- **Objective:** Identify the *parents* (plural) of Patrick Flynn\n- **q_001** (father): \u2705 Resolved \u2014 Thomas Flynn confirmed by three independent source types\n- **q_002** (1850 census location): \u2705 Resolved \u2014 Patrick found in Thomas Flynn's dwelling 84\n- **No open questions, no in-progress plan items, no unresolved conflicts**\n\n**Priority ladder:** Priority 4 fires immediately. The objective decomposes into two halves \u2014 father and mother. The father is answered; the mother has no question, no search, and no assertion at all. That's the remaining gap.\n\nThe 1850 census (already found, dwelling 84) almost certainly lists Thomas Flynn's wife by name \u2014 that record is in hand and should be the first place to look. Writing the question now:Now let me validate the file:The new question landed outside the questions array \u2014 need to fix the JSON structure:The structure is now correct \u2014 q_003 is properly inside the `questions[]` array, followed by the `plans` array. Here's the summary:\n\n---\n\n**New question added: `q_003`**\n\n> **\"Who was Patrick Flynn's mother?\"**\n\n**Why now \u2014 Priority 4 (objective decomposition):** The project objective is to identify *both* parents. The father (Thomas Flynn) is confirmed and q_001 is resolved. The mother is a complete blank \u2014 no question, no search, no assertion. This is the other half of the objective and the natural next step.\n\n**Why this framing:** The 1850 census household (dwelling 84, Schuylkill County) is already in hand from q_002's work. That record almost certainly lists Thomas Flynn's wife by name. Patrick's death certificate (src_004) also has a mother field that hasn't been evaluated yet. Both are immediate starting points requiring no new searches to initiate.\n\n**Dependencies & links:**\n- `depends_on: [q_001, q_002]` \u2014 q_001 established *who* Thomas Flynn is (whose wife we're seeking); q_002 found the 1850 household record that is the primary starting point\n- `unblocks: []` \u2014 no existing questions depend on this\n\n**Suggested next step:** Run `/research-plan` to plan the searches for q_003 \u2014 the 1850 census image from src_001 is likely the first source to re-examine for the wife's name.",
+            "activated": true,
+            "skills_invoked": [
+              "question-selection"
+            ],
+            "tool_calls": [],
+            "files_created": [],
+            "file_changes": {
+              "research.json": {
+                "sections_modified": [
+                  "questions"
+                ],
+                "diff": {
+                  "questions": {
+                    "added": [
+                      {
+                        "id": "q_003",
+                        "question": "Who was Patrick Flynn's mother?",
+                        "rationale": "The project objective requires identifying both parents. The father (Thomas Flynn) is now confirmed. The mother is entirely unaddressed \u2014 no question, no search, no assertion exists. The 1850 census household (dwelling 84, Schuylkill County) already in hand is the strongest starting point: it will name any wife living with Thomas Flynn at the time Patrick was a child. Additional corroboration can come from the 1860 census, Patrick's death certificate (which named the father but whose entry for the mother has not been evaluated), and church or naturalization records for Thomas Flynn's household.",
+                        "selection_basis": "objective_decomposition",
+                        "priority": "high",
+                        "status": "open",
+                        "depends_on": [
+                          "q_001",
+                          "q_002"
+                        ],
+                        "unblocks": [],
+                        "created": "2026-06-26",
+                        "resolved": null,
+                        "resolution_assertion_ids": [],
+                        "exhaustive_declaration": {
+                          "declared": false,
+                          "justification": null,
+                          "log_entry_ids": [],
+                          "stop_criteria": null
+                        }
+                      }
+                    ],
+                    "modified": [],
+                    "deleted": []
+                  }
+                }
+              }
+            },
+            "warnings": [
+              {
+                "kind": "uncovered_tool_call",
+                "advisory": "1 of 1 MCP tool call(s) matched no fixture predicate \u2014 the skill ran against a fixture_not_found or denied/unknown-tool error. Add or fix an mcp_fixture whose args match the call.",
+                "attempted": [
+                  {
+                    "tool": "mcp__genealogy__validate_research_schema",
+                    "args": {
+                      "projectPath": "/tmp/eval-ut_question_selection_007-0-0-l4wb3p3p"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "validators": {
+            "passed": true,
+            "results": [
+              {
+                "name": "test_id_references_resolve",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_log_append_only",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_entries_deleted",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_research_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tool_allowlist",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_gedcomx_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_depends_on_nonempty",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_first_question_depends_on_empty",
+                "passed": true,
+                "error": "skipped: not a first-question-depends-on-empty scenario"
+              },
+              {
+                "name": "test_new_question_exhaustive_declaration_unstarted",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_question_selection_no_new_question",
+                "passed": true,
+                "error": "skipped: not a question-selection-no-new-question scenario"
+              },
+              {
+                "name": "test_questions_no_deletions",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_selection_basis_fan_pivot",
+                "passed": true,
+                "error": "skipped: not a selection-basis-fan-pivot scenario"
+              },
+              {
+                "name": "test_selection_basis_objective_decomposition",
+                "passed": true,
+                "error": "skipped: not a selection-basis-objective-decomposition scenario"
+              },
+              {
+                "name": "test_selection_basis_timeline_gap",
+                "passed": true,
+                "error": "skipped: not a selection-basis-timeline-gap scenario"
+              },
+              {
+                "name": "test_selection_basis_unresolved_conflict",
+                "passed": true,
+                "error": "skipped: not a selection-basis-unresolved-conflict scenario"
+              }
+            ]
+          },
+          "judge": {
+            "skipped": false,
+            "dimensions": [
+              {
+                "source": "base",
+                "name": "Correctness",
+                "score": 3,
+                "rationale": "The skill correctly identified the resolved state of q_001 (father confirmed as Thomas Flynn) and the remaining gap (mother's identity). The analysis of the project state is accurate: the objective requires both parents, one is found, the other is not yet questioned. No fabricated claims or contradictions present."
+              },
+              {
+                "source": "base",
+                "name": "Completeness",
+                "score": 3,
+                "rationale": "The skill fully addressed the user's query to add a research question for what comes next. It added q_003 ('Who was Patrick Flynn's mother?') with correct dependencies (depends_on: [q_001, q_002]), explained the priority logic (objective decomposition), identified available sources (1850 census in dwelling 84, death certificate), and provided next-step guidance."
+              },
+              {
+                "source": "base",
+                "name": "Tool Arguments",
+                "score": null,
+                "rationale": "No MCP tool calls were made during this skill execution. The skill operated purely on the provided project state to generate a new question and modify research.json. N/A."
+              },
+              {
+                "source": "rubric",
+                "name": "Prioritization logic",
+                "score": 3,
+                "rationale": "The skill correctly invoked Priority 4 (objective decomposition) because the objective requires both parents, the father is resolved, and the mother has no question or search yet. The rationale explicitly states this is the remaining half of the objective and the natural next step. No higher-priority signals (unresolved conflicts) were present to override this selection."
+              },
+              {
+                "source": "rubric",
+                "name": "Question specificity",
+                "score": 3,
+                "rationale": "The question 'Who was Patrick Flynn's mother?' is concrete and answerable. It names a specific person (Patrick Flynn), specifies the relationship sought (mother), and targets a clear fact (the mother's identity). This level of specificity is sufficient to drive a focused search of available records."
+              },
+              {
+                "source": "rubric",
+                "name": "Dependency awareness",
+                "score": 3,
+                "rationale": "The depends_on field correctly includes both q_001 and q_002. q_001 established Thomas Flynn's identity (whose wife is being sought) and q_002 located the specific 1850 household record (dwelling 84) that is the primary starting point for finding the mother's name. The unblocks field is correctly set to an empty array. Both directions are properly populated."
+              }
+            ],
+            "judge_cost_usd": 0.007549999999999999,
+            "error": null,
+            "input_tokens": 4200,
+            "cached_input_tokens": 0,
+            "output_tokens": 670
+          }
+        }
+      ]
+    },
+    {
+      "test_id": "ut_question_selection_008",
+      "test_type": "positive",
+      "expected_outcome": "pass",
+      "scenario": "flynn-unsourced-tree",
+      "mcp_fixtures": [],
+      "outcome": "pass",
+      "flaky": false,
+      "outcome_summary": {
+        "per_run_outcomes": [
+          "pass"
+        ],
+        "aggregated_dimensions": [
+          {
+            "source": "base",
+            "name": "Correctness",
+            "score": 3,
+            "rationale": "The skill correctly identified the core problem: Thomas Flynn's parentage claim rests on an unsourced Ancestry Member Tree (a_001) with no original records cited. The death certificate question is factually sound \u2014 Pennsylvania mandatory registration began in 1906, Patrick died in 1908, and death certificates include parental names. The analysis of hypothesis h_001's unverified status is accurate."
+          },
+          {
+            "source": "base",
+            "name": "Completeness",
+            "score": 3,
+            "rationale": "The skill fully addressed the user's request ('What should I research next?') by proposing a complete next question (q_002) with clear reasoning, selection basis, dependency fields, and explanation of why it takes priority over other possibilities. No obvious elements were omitted from the analysis or question formulation."
+          },
+          {
+            "source": "base",
+            "name": "Tool Arguments",
+            "score": null,
+            "rationale": "No MCP tool calls were made by the skill, so this dimension is not applicable."
+          },
+          {
+            "source": "rubric",
+            "name": "Prioritization logic",
+            "score": 3,
+            "rationale": "The skill correctly prioritized hypothesis_test (Priority 2) as the selection basis. The rationale explicitly explains why this takes precedence: the Thomas Flynn parentage claim is unverified and must be tested against original records before any further research builds on it. The response clearly identifies that this is an active hypothesis needing an original-record test, which is the highest-priority signal present in the project state."
+          },
+          {
+            "source": "rubric",
+            "name": "Question specificity",
+            "score": 3,
+            "rationale": "The question 'What does Patrick Flynn's 1908 Pennsylvania death certificate state about his parents?' is concrete and answerable. It specifies a particular person (Patrick Flynn), a specific record type (death certificate), a specific time period (1908), a specific location (Pennsylvania), and a specific fact being sought (parental names). A follow-up search could be designed directly from this question."
+          },
+          {
+            "source": "rubric",
+            "name": "Dependency awareness",
+            "score": 3,
+            "rationale": "Dependency fields are correctly populated. The question has no prerequisites (depends_on is empty), and it unblocks q_001 (the overarching parentage objective). The skill explicitly states 'Depends on: Nothing \u2014 no prerequisites' and 'Unblocks: q_001', both of which are accurate and appropriate given the project state."
+          }
+        ]
+      },
+      "totals": {
+        "duration_ms": 129822.01032387093,
+        "input_tokens": 16,
+        "cached_input_tokens": 146236,
+        "output_tokens": 5657,
+        "judge_input_tokens": 4248,
+        "judge_cached_input_tokens": 0,
+        "judge_output_tokens": 680,
+        "skill_cost_usd": 0.2027353,
+        "judge_cost_usd": 0.007648,
+        "total_cost_usd": 0.2103833
+      },
+      "runs": [
+        {
+          "run_index": 0,
+          "run_id": "run_ut_question_selection_008_2026-06-26_08-07-13_0",
+          "outcome": "pass",
+          "aborted_reason": null,
+          "duration_ms": 129822.01032387093,
+          "input_tokens": 16,
+          "cached_input_tokens": 146236,
+          "output_tokens": 5657,
+          "skill_cost_usd": 0.2027353,
+          "output": {
+            "text_response": "Now let me load the tool schemas I need to write the question.Now I have everything I need. Let me analyze the project state and write the new question.\n\n**State summary:**\n- **Objective:** Identify the parents of Patrick Flynn (b. ~1845 PA, d. 1908 Schuylkill County, PA)\n- **q_001** is open, broad, and mirrors the objective \u2014 not yet decomposed\n- **No in-progress plan items** \u2014 safe to proceed\n- **No blocking conflicts**\n- **Active hypothesis h_001:** Thomas Flynn (b. ~1815, Ireland) was Patrick's father \u2014 sourced only from an unsourced Ancestry member tree (a_001, confidence: speculative)\n\n**Priority 2 fires:** There is an active hypothesis (`h_001`) that needs testing against original records. The Thomas Flynn claim is entirely unverified \u2014 no original record supports it. The first sub-question must test this hypothesis on sound footing.\n\n**Best first question:** Patrick died in 1908 in Schuylkill County, PA. Pennsylvania enacted mandatory death registration in 1906, so a death certificate should exist. Death certificates of this era include a field for the deceased's father's and mother's names \u2014 making it the most direct available record to test whether Thomas Flynn was Patrick's father.Now let me validate the file.The file is well-formed and the question has been written. Here's what was selected and why:\n\n---\n\n## Next Research Question \u2014 `q_002`\n\n**\"What does Patrick Flynn's 1908 Pennsylvania death certificate state about his parents?\"**\n\n### Why this question, why now\n\nThe only lead on Patrick's parents is a claim in an unsourced Ancestry member tree (hypothesis `h_001`: Thomas Flynn as father). That tree has no original records attached \u2014 it is speculation, not evidence. Before building any further research on that lead, it must be tested.\n\nPatrick died in **1908 in Schuylkill County, PA**. Pennsylvania enacted mandatory death registration in **1906**, so a certificate should exist. Death certificates of that era include a dedicated field for the deceased's father's name and mother's name \u2014 making this the single most direct available record to either corroborate or contradict `h_001`.\n\n**Selection basis:** `hypothesis_test` (Priority 2 \u2014 active hypothesis needing an original-record test)\n\n### Links\n| | |\n|---|---|\n| **Depends on** | Nothing \u2014 no prerequisites |\n| **Unblocks** | `q_001` (the overarching parent question) |\n\n---\n\n**Ready to plan the search?** Say \"plan the research\" and I'll build out the specific search steps for Pennsylvania death records in Schuylkill County \u2014 including FamilySearch, the Pennsylvania State Archives, and Ancestry \u2014 as a formal research plan under `q_002`.",
+            "activated": true,
+            "skills_invoked": [
+              "question-selection"
+            ],
+            "tool_calls": [],
+            "files_created": [],
+            "file_changes": {
+              "research.json": {
+                "sections_modified": [
+                  "questions"
+                ],
+                "diff": {
+                  "questions": {
+                    "added": [
+                      {
+                        "id": "q_002",
+                        "question": "What does Patrick Flynn's 1908 Pennsylvania death certificate state about his parents?",
+                        "rationale": "The only claim that Thomas Flynn was Patrick's father comes from a single unsourced Ancestry member tree (h_001). No original record has corroborated this. Patrick died in 1908 in Schuylkill County, PA \u2014 Pennsylvania enacted mandatory death registration in 1906, so a death certificate should exist. Death certificates of this period include fields for the deceased's parents' names, making this the most direct available record to test h_001 and advance q_001.",
+                        "selection_basis": "hypothesis_test",
+                        "priority": "high",
+                        "status": "open",
+                        "depends_on": [],
+                        "unblocks": [
+                          "q_001"
+                        ],
+                        "created": "2026-06-26",
+                        "resolved": null,
+                        "resolution_assertion_ids": [],
+                        "exhaustive_declaration": {
+                          "declared": false,
+                          "justification": null,
+                          "log_entry_ids": [],
+                          "stop_criteria": null
+                        }
+                      }
+                    ],
+                    "modified": [],
+                    "deleted": []
+                  }
+                }
+              }
+            },
+            "warnings": [
+              {
+                "kind": "uncovered_tool_call",
+                "advisory": "1 of 1 MCP tool call(s) matched no fixture predicate \u2014 the skill ran against a fixture_not_found or denied/unknown-tool error. Add or fix an mcp_fixture whose args match the call.",
+                "attempted": [
+                  {
+                    "tool": "mcp__genealogy__validate_research_schema",
+                    "args": {
+                      "projectPath": "/tmp/eval-ut_question_selection_008-0-0-epl33gww"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "validators": {
+            "passed": true,
+            "results": [
+              {
+                "name": "test_id_references_resolve",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_log_append_only",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_entries_deleted",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_research_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tool_allowlist",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_gedcomx_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_depends_on_nonempty",
+                "passed": true,
+                "error": "skipped: not a depends-on-nonempty scenario"
+              },
+              {
+                "name": "test_first_question_depends_on_empty",
+                "passed": true,
+                "error": "skipped: not a first-question-depends-on-empty scenario"
+              },
+              {
+                "name": "test_new_question_exhaustive_declaration_unstarted",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_question_selection_no_new_question",
+                "passed": true,
+                "error": "skipped: not a question-selection-no-new-question scenario"
+              },
+              {
+                "name": "test_questions_no_deletions",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_selection_basis_fan_pivot",
+                "passed": true,
+                "error": "skipped: not a selection-basis-fan-pivot scenario"
+              },
+              {
+                "name": "test_selection_basis_objective_decomposition",
+                "passed": true,
+                "error": "skipped: not a selection-basis-objective-decomposition scenario"
+              },
+              {
+                "name": "test_selection_basis_timeline_gap",
+                "passed": true,
+                "error": "skipped: not a selection-basis-timeline-gap scenario"
+              },
+              {
+                "name": "test_selection_basis_unresolved_conflict",
+                "passed": true,
+                "error": "skipped: not a selection-basis-unresolved-conflict scenario"
+              }
+            ]
+          },
+          "judge": {
+            "skipped": false,
+            "dimensions": [
+              {
+                "source": "base",
+                "name": "Correctness",
+                "score": 3,
+                "rationale": "The skill correctly identified the core problem: Thomas Flynn's parentage claim rests on an unsourced Ancestry Member Tree (a_001) with no original records cited. The death certificate question is factually sound \u2014 Pennsylvania mandatory registration began in 1906, Patrick died in 1908, and death certificates include parental names. The analysis of hypothesis h_001's unverified status is accurate."
+              },
+              {
+                "source": "base",
+                "name": "Completeness",
+                "score": 3,
+                "rationale": "The skill fully addressed the user's request ('What should I research next?') by proposing a complete next question (q_002) with clear reasoning, selection basis, dependency fields, and explanation of why it takes priority over other possibilities. No obvious elements were omitted from the analysis or question formulation."
+              },
+              {
+                "source": "base",
+                "name": "Tool Arguments",
+                "score": null,
+                "rationale": "No MCP tool calls were made by the skill, so this dimension is not applicable."
+              },
+              {
+                "source": "rubric",
+                "name": "Prioritization logic",
+                "score": 3,
+                "rationale": "The skill correctly prioritized hypothesis_test (Priority 2) as the selection basis. The rationale explicitly explains why this takes precedence: the Thomas Flynn parentage claim is unverified and must be tested against original records before any further research builds on it. The response clearly identifies that this is an active hypothesis needing an original-record test, which is the highest-priority signal present in the project state."
+              },
+              {
+                "source": "rubric",
+                "name": "Question specificity",
+                "score": 3,
+                "rationale": "The question 'What does Patrick Flynn's 1908 Pennsylvania death certificate state about his parents?' is concrete and answerable. It specifies a particular person (Patrick Flynn), a specific record type (death certificate), a specific time period (1908), a specific location (Pennsylvania), and a specific fact being sought (parental names). A follow-up search could be designed directly from this question."
+              },
+              {
+                "source": "rubric",
+                "name": "Dependency awareness",
+                "score": 3,
+                "rationale": "Dependency fields are correctly populated. The question has no prerequisites (depends_on is empty), and it unblocks q_001 (the overarching parentage objective). The skill explicitly states 'Depends on: Nothing \u2014 no prerequisites' and 'Unblocks: q_001', both of which are accurate and appropriate given the project state."
+              }
+            ],
+            "judge_cost_usd": 0.007648,
+            "error": null,
+            "input_tokens": 4248,
+            "cached_input_tokens": 0,
+            "output_tokens": 680
+          }
+        }
+      ]
+    },
+    {
+      "test_id": "ut_question_selection_009",
+      "test_type": "negative",
+      "expected_outcome": "pass",
+      "scenario": "mid-research-flynn",
+      "mcp_fixtures": [],
+      "outcome": "pass",
+      "flaky": false,
+      "outcome_summary": {
+        "per_run_outcomes": [
+          "pass"
+        ],
+        "aggregated_dimensions": [
+          {
+            "source": "base",
+            "name": "Correctness",
+            "score": 3,
+            "rationale": "The skill correctly identified that question-selection should NOT be invoked here. Instead, it appropriately declined and routed the user to research-plan, which is the correct skill for this scenario. The response accurately reviewed the active research plan (pl_002), confirmed the current step (pli_006 \u2014 probate search), and provided contextually sound guidance about probate record repositories and search sequence."
+          },
+          {
+            "source": "base",
+            "name": "Completeness",
+            "score": 3,
+            "rationale": "The skill fully addressed the user's question about finding Thomas Flynn's probate record and in what order. It documented the current plan status, confirmed that FamilySearch is the correct first source, identified the existing source entry (src_006), and provided a complete fallback sequence (FamilySearch browse, Ancestry, courthouse, state archives). It also flagged the necessary next steps (record-extraction, timeline gap closure)."
+          },
+          {
+            "source": "base",
+            "name": "Tool Arguments",
+            "score": null,
+            "rationale": "No MCP tool calls were made. The skill correctly routed to research-plan without attempting to perform its own task, so tool argument validation is not applicable."
+          }
+        ]
+      },
+      "totals": {
+        "duration_ms": 103773.94136483781,
+        "input_tokens": 10,
+        "cached_input_tokens": 85537,
+        "output_tokens": 4279,
+        "judge_input_tokens": 4024,
+        "judge_cached_input_tokens": 0,
+        "judge_output_tokens": 356,
+        "skill_cost_usd": 0.1929126,
+        "judge_cost_usd": 0.005804,
+        "total_cost_usd": 0.1987166
+      },
+      "runs": [
+        {
+          "run_index": 0,
+          "run_id": "run_ut_question_selection_009_2026-06-26_08-07-13_0",
+          "outcome": "pass",
+          "aborted_reason": null,
+          "duration_ms": 103773.94136483781,
+          "input_tokens": 10,
+          "cached_input_tokens": 85537,
+          "output_tokens": 4279,
+          "skill_cost_usd": 0.1929126,
+          "output": {
+            "text_response": "Good \u2014 I have all the context I need. The active plan for this project already has the probate search under way. Let me narrate exactly where things stand and what comes next.\n\n---\n\n## Research Plan Review \u2014 Thomas Flynn Probate\n\n**Research question:** q_001 \u2014 *Who were the parents of Patrick Flynn (b. ~1845, PA, d. 1908)?*\n\n**Active plan:** pl_002\n\n---\n\n### Where things stand\n\nTwo of the three plan items have been completed:\n\n| # | Record type | Repository | Status |\n|---|-------------|------------|--------|\n| pli_004 | 1860 census | FamilySearch | \u2705 Completed |\n| pli_005 | Death certificate (1908) | FamilySearch | \u2705 Completed |\n| **pli_006** | **Probate, Schuylkill Co., 1870\u20131890** | **FamilySearch** | \ud83d\udd04 **In progress** |\n\n**pli_006 is the current step** \u2014 and it's already the right one. FamilySearch carries \"Pennsylvania Probate Records, 1683\u20131994\" (indexed, ~2.3M records), covering Schuylkill County's Register of Wills. This is the free, indexed source and belongs first per BCG Standard 15.\n\n> \u26a0\ufe0f **Note:** A source entry (`src_006`) already exists in the project for a Schuylkill County will of Thomas Flynn dated 1881, with a FamilySearch permalink. This strongly suggests the probate record was located during the in-progress search. If so, the plan item needs to be formally logged and marked complete, and record-extraction should be run to pull the specific assertions (particularly any naming of children).\n\n---\n\n### What follows pli_006 \u2014 logical next steps if FamilySearch is incomplete\n\nThe active plan has no formal fallback items written for pli_006 yet. Based on BCG standards and the locality context, here is the recommended sequence if the FamilySearch indexed search leaves gaps:\n\n1. **FamilySearch browse-only volumes** \u2014 Pennsylvania probate volumes are partially digitized as image-only films. If the 1881 will is found via the index but surrounding administration papers (inventory, letters of administration, guardian bonds) are on the same film, browse adjacent images for the full file.\n\n2. **Ancestry \u2014 \"Pennsylvania Wills and Probate Records\"** \u2014 Ancestry's index draws from the same underlying microfilm as FamilySearch but has independent transcription. Useful to cross-check any indexing errors on Thomas Flynn's name, and may surface administration records the FamilySearch index missed.\n\n3. **Schuylkill County Courthouse / Register of Wills** \u2014 The physical Will Books and administration dockets are held at the Schuylkill County Courthouse in Pottsville. If Thomas Flynn's estate file included guardianship bonds, appraisements, or distribution accounts not captured on microfilm, those would be on-site only.\n\n4. **Pennsylvania State Archives (Harrisburg)** \u2014 For any orphans' court proceedings that moved to the state level, or if there are companion land/partition records tied to the estate.\n\n---\n\n### After the probate step\n\nOnce probate is resolved, the plan should address the large timeline gap (1860\u20131908) noted in the project \u2014 specifically the 1870, 1880, and 1900 censuses, which haven't been searched and could confirm the Thomas/Patrick relationship through multiple household co-enumerations.\n\n---\n\n**Suggested next action:** Run the FamilySearch probate search to completion (or confirm that `src_006` is already the result), then use **record-extraction** to pull the will's specific assertions. If you'd like to formally add fallback plan items for Ancestry and the courthouse, I can update the plan. Or if the will has already been found, say the word and we'll move straight to extraction.",
+            "activated": false,
+            "skills_invoked": [
+              "research-plan"
+            ],
+            "tool_calls": [],
+            "files_created": []
+          },
+          "validators": {
+            "passed": true,
+            "results": [
+              {
+                "name": "test_id_references_resolve",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_log_append_only",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_entries_deleted",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_ownership_table",
+                "passed": true,
+                "error": "skipped: ownership is not checked on negative tests \u2014 writes belong to the routed-to skill, not the skill under test"
+              },
+              {
+                "name": "test_research_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tool_allowlist",
+                "passed": true,
+                "error": "skipped: allowlist is not checked on negative tests \u2014 tool calls belong to the routed-to skill, not the skill under test"
+              },
+              {
+                "name": "test_tree_gedcomx_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_ownership_table",
+                "passed": true,
+                "error": "skipped: ownership is not checked on negative tests \u2014 writes belong to the routed-to skill, not the skill under test"
+              },
+              {
+                "name": "test_depends_on_nonempty",
+                "passed": true,
+                "error": "skipped: not a depends-on-nonempty scenario"
+              },
+              {
+                "name": "test_first_question_depends_on_empty",
+                "passed": true,
+                "error": "skipped: not a first-question-depends-on-empty scenario"
+              },
+              {
+                "name": "test_new_question_exhaustive_declaration_unstarted",
+                "passed": true,
+                "error": "skipped: not a new-question-exhaustive-declaration-unstarted scenario"
+              },
+              {
+                "name": "test_question_selection_no_new_question",
+                "passed": true,
+                "error": "skipped: not a question-selection-no-new-question scenario"
+              },
+              {
+                "name": "test_questions_no_deletions",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_selection_basis_fan_pivot",
+                "passed": true,
+                "error": "skipped: not a selection-basis-fan-pivot scenario"
+              },
+              {
+                "name": "test_selection_basis_objective_decomposition",
+                "passed": true,
+                "error": "skipped: not a selection-basis-objective-decomposition scenario"
+              },
+              {
+                "name": "test_selection_basis_timeline_gap",
+                "passed": true,
+                "error": "skipped: not a selection-basis-timeline-gap scenario"
+              },
+              {
+                "name": "test_selection_basis_unresolved_conflict",
+                "passed": true,
+                "error": "skipped: not a selection-basis-unresolved-conflict scenario"
+              }
+            ]
+          },
+          "judge": {
+            "skipped": false,
+            "dimensions": [
+              {
+                "source": "base",
+                "name": "Correctness",
+                "score": 3,
+                "rationale": "The skill correctly identified that question-selection should NOT be invoked here. Instead, it appropriately declined and routed the user to research-plan, which is the correct skill for this scenario. The response accurately reviewed the active research plan (pl_002), confirmed the current step (pli_006 \u2014 probate search), and provided contextually sound guidance about probate record repositories and search sequence."
+              },
+              {
+                "source": "base",
+                "name": "Completeness",
+                "score": 3,
+                "rationale": "The skill fully addressed the user's question about finding Thomas Flynn's probate record and in what order. It documented the current plan status, confirmed that FamilySearch is the correct first source, identified the existing source entry (src_006), and provided a complete fallback sequence (FamilySearch browse, Ancestry, courthouse, state archives). It also flagged the necessary next steps (record-extraction, timeline gap closure)."
+              },
+              {
+                "source": "base",
+                "name": "Tool Arguments",
+                "score": null,
+                "rationale": "No MCP tool calls were made. The skill correctly routed to research-plan without attempting to perform its own task, so tool argument validation is not applicable."
+              }
+            ],
+            "judge_cost_usd": 0.005804,
+            "error": null,
+            "input_tokens": 4024,
+            "cached_input_tokens": 0,
+            "output_tokens": 356
+          }
+        }
+      ]
+    },
+    {
+      "test_id": "ut_question_selection_010",
+      "test_type": "negative",
+      "expected_outcome": "pass",
+      "scenario": "flynn-census-exhausted",
+      "mcp_fixtures": [],
+      "outcome": "pass",
+      "flaky": false,
+      "outcome_summary": {
+        "per_run_outcomes": [
+          "pass"
+        ],
+        "aggregated_dimensions": [
+          {
+            "source": "base",
+            "name": "Correctness",
+            "score": 1,
+            "rationale": "The skill invoked research-exhaustiveness but this is a negative test requiring decline and routing to research-exhaustiveness. Claude should NOT have performed the exhaustiveness evaluation itself \u2014 question-selection should have declined the task and routed the user. Instead, Claude executed the full evaluation, which violates the test's core requirement that question-selection must decline and defer to research-exhaustiveness."
+          },
+          {
+            "source": "base",
+            "name": "Completeness",
+            "score": 1,
+            "rationale": "The skill missed the fundamental task requirement: question-selection must recognize it should NOT perform exhaustiveness evaluation and must route the user to research-exhaustiveness instead. The skill performed its own complete evaluation rather than declining and deferring, which is the opposite of what was required in this negative test scenario."
+          },
+          {
+            "source": "base",
+            "name": "Tool Arguments",
+            "score": null,
+            "rationale": "No MCP tool calls were made by this skill invocation, so Tool Arguments assessment is not applicable."
+          }
+        ]
+      },
+      "totals": {
+        "duration_ms": 91443.68196488358,
+        "input_tokens": 7,
+        "cached_input_tokens": 36654,
+        "output_tokens": 4043,
+        "judge_input_tokens": 4795,
+        "judge_cached_input_tokens": 0,
+        "judge_output_tokens": 311,
+        "skill_cost_usd": 0.1416317,
+        "judge_cost_usd": 0.00635,
+        "total_cost_usd": 0.1479817
+      },
+      "runs": [
+        {
+          "run_index": 0,
+          "run_id": "run_ut_question_selection_010_2026-06-26_08-07-13_0",
+          "outcome": "pass",
+          "aborted_reason": null,
+          "duration_ms": 91443.68196488358,
+          "input_tokens": 7,
+          "cached_input_tokens": 36654,
+          "output_tokens": 4043,
+          "skill_cost_usd": 0.1416317,
+          "output": {
+            "text_response": "I'll read the reference framework and the project files to evaluate exhaustiveness.Now I have everything I need. Let me apply the framework carefully.\n\n---\n\n## Research Exhaustiveness Evaluation \u2014 q_001\n\n*\"Who were the parents of Patrick Flynn (b. ~1845, PA, d. 1908)?\"*\n\nAll plan items for q_001 (pl_002) are `completed`, so evaluation can proceed.\n\n---\n\n### Step 1: Evidence Gathered\n\n**Log entries tied to q_001 plan items:**\n- **log_004** (pli_004): 1860 census, FamilySearch \u2014 positive. Patrick age 15 in Thomas Flynn household.\n- **log_005** (pli_005): Death certificate 1908, FamilySearch \u2014 positive. Names Thomas Flynn as father; informant is son-in-law James Brown.\n- **log_006** (pli_006): Probate records, FamilySearch 1870\u20131900 \u2014 **negative**. No Thomas Flynn probate found.\n\n**Assertions bearing on q_001:** a_004, a_005, a_008, a_009, a_010, a_012, a_013\n\n**Existing proof summary (ps_001):** Tier: **Probable** \u2014 explicitly flags the 1870, 1880, and 1900 censuses as unsearched and labels this \"the primary remaining gap.\"\n\n---\n\n### Step 2: Five Threshold Questions\n\n| # | Question | Answer |\n|---|----------|--------|\n| 1 | Has the question been answered with sufficient evidence? | **Partial** \u2014 a Probable conclusion exists but the proof summary itself says this cannot advance to Proved without additional census records. |\n| 2 | Has a broad range of record types been searched? | **No** \u2014 Three census years (1870, 1880, 1900) are completely absent from the plan. The 1880 census is especially critical: it's the first federal census to explicitly state family relationships, meaning it can provide *direct* evidence of parentage rather than inferred household placement. |\n| 3 | Have all relevant strategies been employed? | **No** \u2014 Only FamilySearch was searched for q_001's plan items. Ancestry was not cross-checked for the 1860 census or death certificate. No church records, immigration/naturalization, land records, or other 19th-century record types were attempted. |\n| 4 | Have derivative sources been replaced with originals? | **Yes** \u2014 FamilySearch original images accessed throughout. |\n| 5 | Has enough evidence been gathered to resolve conflicts? | **Yes** \u2014 The one known conflict (birthplace: Ireland vs. Pennsylvania) is resolved. |\n\n**Threshold question 2 and 3 both fail. I cannot declare exhaustive.**\n\n---\n\n### Step 3: 7-Point Stop Criteria Assessment\n\n| Criterion | Assessment |\n|-----------|------------|\n| **goal_alignment** | The question has a *probable* answer (Thomas Flynn as father), but the current proof summary explicitly rates it Probable rather than Proved, and specifically identifies the missing census searches as the barrier to advancement. Not yet fully aligned. |\n| **repository_breadth** | Only FamilySearch was searched across q_001's plan items. Three complete census years (1870, 1880, 1900) are missing \u2014 years that span 40+ years of Patrick's adult life in Schuylkill County. The 1880 census, which explicitly records family relationships for the first time, was never searched. |\n| **original_substitution** | Satisfied \u2014 original images on FamilySearch were accessed wherever available. |\n| **independent_verification** | Marginal. The 1850 and 1860 census assertions for household relationship likely share the same informant (Thomas Flynn or wife), so they count as one evidential unit. The death certificate is a second unit but from a secondary informant (son-in-law). Two units exist \u2014 but neither provides *primary* information about the parent-child relationship, and the informant quality is low for both. |\n| **evidence_class** | Not satisfied. No source yet provides *primary* information about parentage. Census records provide indeterminate information (relationships inferred from household position, not explicitly stated until 1880). The death certificate informant is secondary. The 1880 census or Thomas Flynn's will could supply primary-quality evidence. |\n| **conflict_resolution** | Satisfied \u2014 c_001 (birthplace conflict) is resolved. No blocking conflicts remain. |\n| **overturn_risk** | **Elevated.** The 1880 census \u2014 a standard, accessible, fully-indexed record \u2014 has not been searched. It explicitly states family relationships and could either confirm or contradict the conclusion. There is also a 48-year gap (1860\u20131908) in the timeline with no examined records. The risk that an unsearched accessible source would change or deepen the conclusion is not low. |\n\n---\n\n### Step 4: Decision \u2014 **Do Not Declare Exhaustive**\n\nThree criteria fail: `repository_breadth`, `evidence_class`, and `overturn_risk`. These are not resource-exhaustion failures \u2014 the missing sources (1870, 1880, 1900 censuses on FamilySearch and Ancestry) are standard, fully-indexed, accessible records. This is a plan gap, not a dead end.\n\nThe proof summary written at the last step even acknowledged this gap explicitly.\n\n---\n\n### What's Missing\n\n1. **1880 U.S. Census (highest priority)** \u2014 The first census to explicitly state family relationships. A Patrick Flynn in a Thomas Flynn household in 1880 would provide *direct* evidence of the parent-child bond, upgrading the evidence class. This alone could move the conclusion from Probable to Proved.\n2. **1870 and 1900 U.S. Censuses** \u2014 Patrick was 25 and 55 in those years, respectively. Both could corroborate the family connection and fill the 48-year timeline gap flagged as high-severity.\n3. **Cross-repository verification** \u2014 Ancestry was not searched for the 1860 census or death certificate (only MyHeritage/FamilySearch for q_002 items). Independent indexing catches transcription errors.\n4. **Church records, immigration/naturalization, land records** \u2014 Irish immigrants in Pennsylvania coal country often appear in Catholic parish registers; immigration records for ca. 1845\u20131850 arrivals may help.\n\n---\n\n**Not yet exhaustive.** The three missing census years (especially 1880) represent high-value, accessible sources that could plausibly change the conclusion's tier \u2014 exactly what the overturn risk criterion tests for.\n\n**Recommended next step:** Run **`research-plan`** to add 1870, 1880, and 1900 census searches to the plan for q_001. The 1880 census should be the first item. Would you like me to do that?",
+            "activated": false,
+            "skills_invoked": [
+              "research-exhaustiveness"
+            ],
+            "tool_calls": [],
+            "files_created": []
+          },
+          "validators": {
+            "passed": true,
+            "results": [
+              {
+                "name": "test_id_references_resolve",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_log_append_only",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_entries_deleted",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_ownership_table",
+                "passed": true,
+                "error": "skipped: ownership is not checked on negative tests \u2014 writes belong to the routed-to skill, not the skill under test"
+              },
+              {
+                "name": "test_research_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tool_allowlist",
+                "passed": true,
+                "error": "skipped: allowlist is not checked on negative tests \u2014 tool calls belong to the routed-to skill, not the skill under test"
+              },
+              {
+                "name": "test_tree_gedcomx_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_ownership_table",
+                "passed": true,
+                "error": "skipped: ownership is not checked on negative tests \u2014 writes belong to the routed-to skill, not the skill under test"
+              },
+              {
+                "name": "test_depends_on_nonempty",
+                "passed": true,
+                "error": "skipped: not a depends-on-nonempty scenario"
+              },
+              {
+                "name": "test_first_question_depends_on_empty",
+                "passed": true,
+                "error": "skipped: not a first-question-depends-on-empty scenario"
+              },
+              {
+                "name": "test_new_question_exhaustive_declaration_unstarted",
+                "passed": true,
+                "error": "skipped: not a new-question-exhaustive-declaration-unstarted scenario"
+              },
+              {
+                "name": "test_question_selection_no_new_question",
+                "passed": true,
+                "error": "skipped: not a question-selection-no-new-question scenario"
+              },
+              {
+                "name": "test_questions_no_deletions",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_selection_basis_fan_pivot",
+                "passed": true,
+                "error": "skipped: not a selection-basis-fan-pivot scenario"
+              },
+              {
+                "name": "test_selection_basis_objective_decomposition",
+                "passed": true,
+                "error": "skipped: not a selection-basis-objective-decomposition scenario"
+              },
+              {
+                "name": "test_selection_basis_timeline_gap",
+                "passed": true,
+                "error": "skipped: not a selection-basis-timeline-gap scenario"
+              },
+              {
+                "name": "test_selection_basis_unresolved_conflict",
+                "passed": true,
+                "error": "skipped: not a selection-basis-unresolved-conflict scenario"
+              }
+            ]
+          },
+          "judge": {
+            "skipped": false,
+            "dimensions": [
+              {
+                "source": "base",
+                "name": "Correctness",
+                "score": 1,
+                "rationale": "The skill invoked research-exhaustiveness but this is a negative test requiring decline and routing to research-exhaustiveness. Claude should NOT have performed the exhaustiveness evaluation itself \u2014 question-selection should have declined the task and routed the user. Instead, Claude executed the full evaluation, which violates the test's core requirement that question-selection must decline and defer to research-exhaustiveness."
+              },
+              {
+                "source": "base",
+                "name": "Completeness",
+                "score": 1,
+                "rationale": "The skill missed the fundamental task requirement: question-selection must recognize it should NOT perform exhaustiveness evaluation and must route the user to research-exhaustiveness instead. The skill performed its own complete evaluation rather than declining and deferring, which is the opposite of what was required in this negative test scenario."
+              },
+              {
+                "source": "base",
+                "name": "Tool Arguments",
+                "score": null,
+                "rationale": "No MCP tool calls were made by this skill invocation, so Tool Arguments assessment is not applicable."
+              }
+            ],
+            "judge_cost_usd": 0.00635,
+            "error": null,
+            "input_tokens": 4795,
+            "cached_input_tokens": 0,
+            "output_tokens": 311
+          }
+        }
+      ]
+    },
+    {
+      "test_id": "ut_question_selection_011",
+      "test_type": "negative",
+      "expected_outcome": "pass",
+      "scenario": "mid-research-flynn",
+      "mcp_fixtures": [],
+      "outcome": "pass",
+      "flaky": false,
+      "outcome_summary": {
+        "per_run_outcomes": [
+          "pass"
+        ],
+        "aggregated_dimensions": [
+          {
+            "source": "base",
+            "name": "Correctness",
+            "score": 3,
+            "rationale": "Claude correctly diagnosed that the user's request ('Can you give me a summary of where this project stands right now?') should be routed to project-status, not handled by question-selection. The response explicitly performed the project-status skill by reading both project files, computing integrity checks, and delivering an accurate multi-part summary. All factual claims about the research state are supported by the input (5 sources with 13 assertions, hypothesis h_001 supported, one resolved conflict, timeline gap from 1860\u20131908, stale plan with 5 unlogged sources). No fabricated material."
+          },
+          {
+            "source": "base",
+            "name": "Completeness",
+            "score": 3,
+            "rationale": "Claude fully addressed what the user asked for. Delivered: narrative summary of current progress, evidence analysis (three records pointing to Thomas Flynn), conflict resolution (birthplace), gap discovery (five unlogged sources including the will), timeline gaps (48-year blank), current conclusion tier (probable), and recommended next steps. All major aspects of the research project are covered. No silent omissions of obvious items."
+          },
+          {
+            "source": "base",
+            "name": "Tool Arguments",
+            "score": null,
+            "rationale": "No MCP tool calls were made. The skill correctly routed the user to project-status conceptually and provided the expected output (project summary, integrity check, detailed GPS status) without invoking tools. N/A \u2014 zero tool calls."
+          }
+        ]
+      },
+      "totals": {
+        "duration_ms": 181755.68391778506,
+        "input_tokens": 1753,
+        "cached_input_tokens": 38770,
+        "output_tokens": 9160,
+        "judge_input_tokens": 5312,
+        "judge_cached_input_tokens": 0,
+        "judge_output_tokens": 412,
+        "skill_cost_usd": 0.23327824999999996,
+        "judge_cost_usd": 0.007372,
+        "total_cost_usd": 0.24065024999999995
+      },
+      "runs": [
+        {
+          "run_index": 0,
+          "run_id": "run_ut_question_selection_011_2026-06-26_08-07-13_0",
+          "outcome": "pass",
+          "aborted_reason": null,
+          "duration_ms": 181755.68391778506,
+          "input_tokens": 1753,
+          "cached_input_tokens": 38770,
+          "output_tokens": 9160,
+          "skill_cost_usd": 0.23327824999999996,
+          "output": {
+            "text_response": "Let me read both project files to produce an accurate summary.Now I have everything I need to produce both summaries. Let me check for integrity issues and compute the statistics.\n\n**Integrity check results:**\n- All `subject_person_ids` (I1), `person_evidence.person_id` (I1, I2), and `sources.gedcomx_source_description_id` (S1\u2013S8) resolve correctly \u2014 no broken foreign keys.\n- **Stale plan detected:** Plan `pl_002` (created 2026-05-02) predates five sources added 2026-05-10 and 2026-05-12 (`src_005`\u2013`src_009`): a baptismal record, Thomas Flynn's will, a birth certificate, a land deed, and a newspaper obituary. None have log entries (`log_entry_id: null`). None have extracted assertions. The will (`src_006`) directly addresses what `pli_006` was searching for, yet `pli_006` is still marked `in_progress`.\n\n---\n\n## Here's where we stand on Patrick Flynn's research\n\nWe're trying to identify Patrick Flynn's parents \u2014 he was born around 1845, probably in Ireland, and died in Schuylkill County, Pennsylvania in 1908.\n\n**What we've found:**\n\nThe evidence strongly points to **Thomas Flynn of Schuylkill County** as Patrick's father. Three separate records all point the same direction:\n\n- **1850 census** \u2014 Patrick Flynn, age 5, appears in Thomas Flynn's household in Schuylkill County (dwelling 84). The 1850 census didn't include a relationship column (that wasn't added until 1880), so the parent-child relationship is inferred from Patrick's age, shared surname, and position in the household.\n- **1860 census** \u2014 Patrick Flynn, now age 15, is still in Thomas Flynn's household in Schuylkill County (dwelling 112). Same situation with the relationship column \u2014 inferred, not stated.\n- **1908 death certificate** \u2014 Patrick's death certificate explicitly names Thomas Flynn as his father. The informant was Patrick's son-in-law, James Brown, who was reporting secondhand about events that happened 60+ years before.\n\n**One conflict we resolved:**\n\nThe death certificate says Patrick was born in Pennsylvania, but both census records say Ireland. We concluded Ireland is correct \u2014 the census informants were likely household members who knew Patrick's background firsthand, whereas James Brown was reporting his father-in-law's birthplace 63 years after the fact and may have confused birthplace with place of residence.\n\n**A gap in the plan was just discovered:**\n\nSince the research plan was last written, five new records have been located \u2014 a baptismal record from St. Mary's Catholic Church in Pottsville, **Thomas Flynn's 1881 will**, a birth certificate for Mary Elizabeth Flynn, a deed from Thomas Flynn to Patrick Flynn (1881), and Patrick's obituary in the *Pottsville Republican*. These are potentially very significant \u2014 **the will alone may directly name Patrick as Thomas's son**, which would substantially strengthen the conclusion. However, none of these records have been logged, and no information has been pulled from them yet.\n\n**What's still missing:**\n\nPatrick's life between 1860 and 1908 is a 48-year blank. We have no marriage record, no appearances in the 1870, 1880, or 1900 censuses, and no documentation of where he lived or what he did during those decades. Those census records may also confirm the Thomas Flynn parentage and would help close the gap.\n\n**Where the conclusion stands:**\n\nOur current written conclusion is that Patrick was **probably** Thomas Flynn's son. To strengthen this to *proved*, we need to: (1) extract the information from the five newly found records \u2014 especially the will and deed, and (2) search the 1870\u20131900 censuses. If the will names Patrick as a son, or if the 1870/1880/1900 censuses continue to show Thomas and Patrick together, the conclusion would reach \"proved.\"\n\n**Recommended next step:** Extract assertions from the five newly found records (baptismal register, will, deed, birth certificate, obituary) using **record-extraction**, then properly log those searches. After that, revise the research plan to address the 1870\u20131900 census gap.\n\n---\n\n## Detailed GPS Status\n\n```\nPROJECT STATUS: Identify the parents of Patrick Flynn (b. ca. 1845, d. 1908 Schuylkill Co., PA)\nStatus: active | Created: 2026-05-01 | Updated: 2026-05-04\n\n\u26a0 WARNING \u2014 STALE PLAN\n  Plan pl_002 (created 2026-05-02) predates five sources added 2026-05-10/12:\n    src_005  St. Mary's baptismal record (1845)        \u2014 no log entry, no assertions\n    src_006  Thomas Flynn will (1881)                  \u2014 no log entry, no assertions\n    src_007  Mary Elizabeth Flynn birth cert (1905)    \u2014 no log entry, no assertions\n    src_008  Thomas Flynn \u2192 Patrick Flynn deed (1881)  \u2014 no log entry, no assertions\n    src_009  Patrick Flynn obituary, Pottsville Rep.   \u2014 no log entry, no assertions\n  Notably: src_006 (the will) addresses exactly what pli_006 was searching for,\n  yet pli_006 remains \"in_progress.\" Citations for all five are rough working drafts.\n\nQUESTIONS (2)\n  q_001  Who were the parents of Patrick Flynn?     in_progress\n         GPS: [ ] search  [ ] citations  [x] analysis  [x] conflicts  [x] conclusion\n  q_002  Where was Patrick Flynn in 1850 census?    resolved \u2713\n         GPS: [x] search  [x] citations  [x] analysis  [x] conflicts  [ ] conclusion*\n         * No proof_summary written for q_002 (minor \u2014 it's a sub-question)\n\nPLANS\n  pl_001  For q_002: 3 items \u2014 all completed\n  pl_002  For q_001: 3 items \u2014 2 completed, 1 in_progress \u26a0 STALE (see warning above)\n            pli_004  1860 census (FamilySearch)      completed\n            pli_005  Death certificate (FamilySearch) completed\n            pli_006  Probate/will (FamilySearch)      in_progress\n\nRESEARCH LOG\n  5 searches logged | 4 positive, 1 negative, 0 partial\n  Record types:   census (4), vital records/death cert (1)\n  Repositories:   FamilySearch (3), Ancestry (1), MyHeritage (1)\n  \u26a0 5 sources (src_005\u2013src_009) have no corresponding log entries\n\nEXHAUSTIVENESS: Substantial\n  Searched:       1850 census (3 repos), 1860 census (1 repo), death certificate\n  Unlogged finds: baptismal record, will, deed, birth cert, newspaper obituary\n  Not yet searched: 1870, 1880, 1900 censuses; full church/land/probate sweep\n\nEVIDENCE\n  13 assertions | 9 sources\n  Citation quality: src_001\u2013src_004 well-cited; src_005\u2013src_009 rough working drafts\n  Classification: 2 primary, 2 secondary, 9 indeterminate\n  Person links: 3 confident (pe_001, pe_004, pe_005)\n                3 probable  (pe_002, pe_003, pe_006)\n                0 speculative\n  \u26a0 No assertions extracted from src_005\u2013src_009\n\nCONFLICTS\n  c_001  Birthplace \u2014 Ireland (censuses) vs. Pennsylvania (death cert)  resolved \u2713\n         Preferred: Ireland (a_002) \u2014 contemporaneous sources outweigh late secondary informant\n\nHYPOTHESES\n  h_001  Father = Thomas Flynn, Schuylkill Co., PA        supported\n         Supporting: a_004 (1850 co-enum, indirect), a_010 (1860 co-enum, indirect),\n                     a_013 (death cert names Thomas, direct but secondary informant)\n         Contradicting: none\n\nTIMELINE GAPS (t_001)\n  1860 \u2192 1908-03-12  [HIGH SEVERITY]\n  Missing: marriage, 1870 census, 1880 census, 1900 census, residence, occupation\n\nPROOF CONCLUSIONS\n  ps_001  q_001 parentage  |  tier: probable  |  vehicle: summary\n  (Conclusion drafted; question not yet resolved \u2014 further evidence needed to reach \"proved\")\n\nRECOMMENDED NEXT STEP:\n  The plan is stale. Five records found after the plan was created have no log\n  entries and no extracted assertions \u2014 including Thomas Flynn's 1881 will and a\n  Thomas-to-Patrick land deed that may directly prove the relationship.\n  1. Use record-extraction to pull assertions from src_005\u2013src_009\n  2. Document each find in the research log\n  3. Mark pli_006 complete (will found)\n  4. Revise the plan to add 1870, 1880, 1900 census searches\n  \u2192 record-extraction, then research-plan\n```",
+            "activated": false,
+            "skills_invoked": [
+              "project-status"
+            ],
+            "tool_calls": [],
+            "files_created": []
+          },
+          "validators": {
+            "passed": true,
+            "results": [
+              {
+                "name": "test_id_references_resolve",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_log_append_only",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_entries_deleted",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_ownership_table",
+                "passed": true,
+                "error": "skipped: ownership is not checked on negative tests \u2014 writes belong to the routed-to skill, not the skill under test"
+              },
+              {
+                "name": "test_research_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tool_allowlist",
+                "passed": true,
+                "error": "skipped: allowlist is not checked on negative tests \u2014 tool calls belong to the routed-to skill, not the skill under test"
+              },
+              {
+                "name": "test_tree_gedcomx_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_ownership_table",
+                "passed": true,
+                "error": "skipped: ownership is not checked on negative tests \u2014 writes belong to the routed-to skill, not the skill under test"
+              },
+              {
+                "name": "test_depends_on_nonempty",
+                "passed": true,
+                "error": "skipped: not a depends-on-nonempty scenario"
+              },
+              {
+                "name": "test_first_question_depends_on_empty",
+                "passed": true,
+                "error": "skipped: not a first-question-depends-on-empty scenario"
+              },
+              {
+                "name": "test_new_question_exhaustive_declaration_unstarted",
+                "passed": true,
+                "error": "skipped: not a new-question-exhaustive-declaration-unstarted scenario"
+              },
+              {
+                "name": "test_question_selection_no_new_question",
+                "passed": true,
+                "error": "skipped: not a question-selection-no-new-question scenario"
+              },
+              {
+                "name": "test_questions_no_deletions",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_selection_basis_fan_pivot",
+                "passed": true,
+                "error": "skipped: not a selection-basis-fan-pivot scenario"
+              },
+              {
+                "name": "test_selection_basis_objective_decomposition",
+                "passed": true,
+                "error": "skipped: not a selection-basis-objective-decomposition scenario"
+              },
+              {
+                "name": "test_selection_basis_timeline_gap",
+                "passed": true,
+                "error": "skipped: not a selection-basis-timeline-gap scenario"
+              },
+              {
+                "name": "test_selection_basis_unresolved_conflict",
+                "passed": true,
+                "error": "skipped: not a selection-basis-unresolved-conflict scenario"
+              }
+            ]
+          },
+          "judge": {
+            "skipped": false,
+            "dimensions": [
+              {
+                "source": "base",
+                "name": "Correctness",
+                "score": 3,
+                "rationale": "Claude correctly diagnosed that the user's request ('Can you give me a summary of where this project stands right now?') should be routed to project-status, not handled by question-selection. The response explicitly performed the project-status skill by reading both project files, computing integrity checks, and delivering an accurate multi-part summary. All factual claims about the research state are supported by the input (5 sources with 13 assertions, hypothesis h_001 supported, one resolved conflict, timeline gap from 1860\u20131908, stale plan with 5 unlogged sources). No fabricated material."
+              },
+              {
+                "source": "base",
+                "name": "Completeness",
+                "score": 3,
+                "rationale": "Claude fully addressed what the user asked for. Delivered: narrative summary of current progress, evidence analysis (three records pointing to Thomas Flynn), conflict resolution (birthplace), gap discovery (five unlogged sources including the will), timeline gaps (48-year blank), current conclusion tier (probable), and recommended next steps. All major aspects of the research project are covered. No silent omissions of obvious items."
+              },
+              {
+                "source": "base",
+                "name": "Tool Arguments",
+                "score": null,
+                "rationale": "No MCP tool calls were made. The skill correctly routed the user to project-status conceptually and provided the expected output (project summary, integrity check, detailed GPS status) without invoking tools. N/A \u2014 zero tool calls."
+              }
+            ],
+            "judge_cost_usd": 0.007372,
+            "error": null,
+            "input_tokens": 5312,
+            "cached_input_tokens": 0,
+            "output_tokens": 412
+          }
+        }
+      ]
+    },
+    {
+      "test_id": "ut_question_selection_012",
+      "test_type": "negative",
+      "expected_outcome": "pass",
+      "scenario": "mid-research-flynn",
+      "mcp_fixtures": [],
+      "outcome": "pass",
+      "flaky": false,
+      "outcome_summary": {
+        "per_run_outcomes": [
+          "pass"
+        ],
+        "aggregated_dimensions": [
+          {
+            "source": "base",
+            "name": "Correctness",
+            "score": 3,
+            "rationale": "The skill correctly recognized this as a negative test case and declined to perform question-selection's task. Instead, it routed the user to search-external-sites (invoked), which is the appropriate skill for this external search request. The routing decision was accurate and well-justified."
+          },
+          {
+            "source": "base",
+            "name": "Completeness",
+            "score": 3,
+            "rationale": "The skill fully addressed the routing requirement. It provided a clear explanation of why it was declining to modify the question list, offered a complete hand-off to the external search skill, and included helpful context (the 1870 census gap, collection number, search strategy). No major portions of the appropriate routing behavior were omitted."
+          },
+          {
+            "source": "base",
+            "name": "Tool Arguments",
+            "score": null,
+            "rationale": "No MCP tool calls were made by the skill under test (question-selection). The skill correctly declined its own task and routed to search-external-sites, which handled any external site interaction. This is N/A for the grading of question-selection itself."
+          }
+        ]
+      },
+      "totals": {
+        "duration_ms": 106356.6025220789,
+        "input_tokens": 15,
+        "cached_input_tokens": 134092,
+        "output_tokens": 4705,
+        "judge_input_tokens": 4098,
+        "judge_cached_input_tokens": 0,
+        "judge_output_tokens": 331,
+        "skill_cost_usd": 0.21930335,
+        "judge_cost_usd": 0.005753,
+        "total_cost_usd": 0.22505635000000002
+      },
+      "runs": [
+        {
+          "run_index": 0,
+          "run_id": "run_ut_question_selection_012_2026-06-26_08-07-13_0",
+          "outcome": "pass",
+          "aborted_reason": null,
+          "duration_ms": 106356.6025220789,
+          "input_tokens": 15,
+          "cached_input_tokens": 134092,
+          "output_tokens": 4705,
+          "skill_cost_usd": 0.21930335,
+          "output": {
+            "text_response": "I'll start by reading the project files and references to set up the search properly.Now I have a thorough picture of the project. Patrick Flynn (b. ~1845, Ireland; d. 1908, Schuylkill County, PA) has no plan item yet for the 1870 census, but the timeline clearly flags it as a high-severity gap. No subscription data is on file, so I'll treat all sites equally. Patrick Flynn is a common name, so I'll use a targeted \"kitchen sink\" search. Let me resolve the place and pull curated Ancestry links.The `place_search` and `external_links_search` tools aren't available in this environment. I have enough context to proceed: Patrick Flynn is a very common Irish name, so I'll use a targeted \"kitchen sink\" search scoped directly to the 1870 US Federal Census on Ancestry (collection 7163 \u2014 the standard Ancestry collection for this census). No existing plan item covers the 1870 census, so I'll log with `planItemId: null`.\n\n**Building the URL:** Patrick was ~25 in 1870, possibly in his own household. I'll anchor on his name, birth year, Ireland birthplace (from the census records), and Pennsylvania residence in 1870 \u2014 confident parameters. I'll also include Thomas Flynn as a household member, which helps if Patrick was still with his father but doesn't harm if he'd struck out on his own.\n\nLogging the search before presenting the URL:The log write was denied (permissions), so I can't persist the entry to `research.json` right now \u2014 I'll note that below. Here is the search you need:\n\n---\n\n**Search: 1870 US Federal Census on Ancestry for Patrick Flynn**\n\n> **Note:** No plan item currently exists for the 1870 census. This search fills the high-severity timeline gap flagged in `t_001` (1860\u20131908). You may want to add a plan item to `pl_002` afterward.\n\n**Collection:** Ancestry \u2014 1870 U.S. Federal Census (collection 7163)\n**Strategy:** \"Kitchen sink\" \u2014 Patrick Flynn is a very common name, so I've included birth year, Ireland birthplace (established by both census records), Pennsylvania residence, and Thomas Flynn as a household member. In 1870 Patrick would be ~25, possibly still with his father or heading his own household.\n\nClick this link to search:\n\n[Ancestry \u2014 1870 US Federal Census, Patrick Flynn](https://www.ancestry.com/search/collections/7163/?name=Patrick_Flynn&birth=1845&birthplace=Ireland&residence=1870_Pennsylvania&father=Thomas_Flynn)\n\nAfter the page loads:\n1. **Scroll to the bottom and back to the top** (forces lazy-loaded results into view)\n2. Press **Cmd+P** (Mac) or **Ctrl+P** (Windows)\n3. Select **\"Save as PDF\"**\n4. Save the file and **upload it here**\n\nIf the page asks you to log in, log in first, then click the link again.\n\n---\n\n**If results are poor**, try these fallbacks in order:\n1. **Drop Thomas Flynn** \u2014 Patrick may be in his own household by 1870: [Broader search without household member](https://www.ancestry.com/search/collections/7163/?name=Patrick_Flynn&birth=1845&birthplace=Ireland&residence=1870_Pennsylvania)\n2. **Broaden location to all states** \u2014 in case he moved out of Pennsylvania: [Site-wide 1870 census search](https://www.ancestry.com/search/collections/7163/?name=Patrick_Flynn&birth=1845&birthplace=Ireland)\n3. **Try surname variants** \u2014 Flynn is sometimes indexed as Flyn, Flinn, or Flynn: try substituting `name=Patrick_Flinn` or `name=Patrick_Flyn`\n\n\u26a0\ufe0f **Logging note:** The automatic log entry could not be written to `research.json` (permission denied). Once you return the PDF, I'll log both the launched search and the results together in one entry. If you'd like to grant permission for `mcp__genealogy__research_log_append`, I can log it now before you click the link.\n\nUpload the PDF when you're ready and I'll triage the results.",
+            "activated": false,
+            "skills_invoked": [
+              "search-external-sites"
+            ],
+            "tool_calls": [],
+            "files_created": [],
+            "warnings": [
+              {
+                "kind": "uncovered_tool_call",
+                "advisory": "1 of 1 MCP tool call(s) matched no fixture predicate \u2014 the skill ran against a fixture_not_found or denied/unknown-tool error. Add or fix an mcp_fixture whose args match the call.",
+                "attempted": [
+                  {
+                    "tool": "mcp__genealogy__research_log_append",
+                    "args": {
+                      "projectPath": "/tmp/eval-ut_question_selection_012-0-0-af821had",
+                      "planItemId": null,
+                      "tool": "external_site",
+                      "query": {
+                        "surname": "Flynn",
+                        "given": "Patrick",
+                        "birth_year": 1845,
+                        "birth_place": "Ireland",
+                        "residence_year": 1870,
+                        "residence_place": "Pennsylvania",
+                        "collection": "1870 US Federal Census",
+                        "site": "Ancestry",
+                        "collection_id": "7163",
+                        "household_member": "Thomas Flynn"
+                      },
+                      "outcome": "partial",
+                      "resultsExamined": 0,
+                      "notes": "URL generated for Ancestry 1870 US Federal Census (collection 7163); awaiting user capture. No plan item exists for this search \u2014 the 1870 census gap is flagged in the project timeline (t_001). Searched with birth year 1845, birthplace Ireland, residence Pennsylvania, and Thomas Flynn as household member."
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "validators": {
+            "passed": true,
+            "results": [
+              {
+                "name": "test_id_references_resolve",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_log_append_only",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_entries_deleted",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_ownership_table",
+                "passed": true,
+                "error": "skipped: ownership is not checked on negative tests \u2014 writes belong to the routed-to skill, not the skill under test"
+              },
+              {
+                "name": "test_research_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tool_allowlist",
+                "passed": true,
+                "error": "skipped: allowlist is not checked on negative tests \u2014 tool calls belong to the routed-to skill, not the skill under test"
+              },
+              {
+                "name": "test_tree_gedcomx_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_ownership_table",
+                "passed": true,
+                "error": "skipped: ownership is not checked on negative tests \u2014 writes belong to the routed-to skill, not the skill under test"
+              },
+              {
+                "name": "test_depends_on_nonempty",
+                "passed": true,
+                "error": "skipped: not a depends-on-nonempty scenario"
+              },
+              {
+                "name": "test_first_question_depends_on_empty",
+                "passed": true,
+                "error": "skipped: not a first-question-depends-on-empty scenario"
+              },
+              {
+                "name": "test_new_question_exhaustive_declaration_unstarted",
+                "passed": true,
+                "error": "skipped: not a new-question-exhaustive-declaration-unstarted scenario"
+              },
+              {
+                "name": "test_question_selection_no_new_question",
+                "passed": true,
+                "error": "skipped: not a question-selection-no-new-question scenario"
+              },
+              {
+                "name": "test_questions_no_deletions",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_selection_basis_fan_pivot",
+                "passed": true,
+                "error": "skipped: not a selection-basis-fan-pivot scenario"
+              },
+              {
+                "name": "test_selection_basis_objective_decomposition",
+                "passed": true,
+                "error": "skipped: not a selection-basis-objective-decomposition scenario"
+              },
+              {
+                "name": "test_selection_basis_timeline_gap",
+                "passed": true,
+                "error": "skipped: not a selection-basis-timeline-gap scenario"
+              },
+              {
+                "name": "test_selection_basis_unresolved_conflict",
+                "passed": true,
+                "error": "skipped: not a selection-basis-unresolved-conflict scenario"
+              }
+            ]
+          },
+          "judge": {
+            "skipped": false,
+            "dimensions": [
+              {
+                "source": "base",
+                "name": "Correctness",
+                "score": 3,
+                "rationale": "The skill correctly recognized this as a negative test case and declined to perform question-selection's task. Instead, it routed the user to search-external-sites (invoked), which is the appropriate skill for this external search request. The routing decision was accurate and well-justified."
+              },
+              {
+                "source": "base",
+                "name": "Completeness",
+                "score": 3,
+                "rationale": "The skill fully addressed the routing requirement. It provided a clear explanation of why it was declining to modify the question list, offered a complete hand-off to the external search skill, and included helpful context (the 1870 census gap, collection number, search strategy). No major portions of the appropriate routing behavior were omitted."
+              },
+              {
+                "source": "base",
+                "name": "Tool Arguments",
+                "score": null,
+                "rationale": "No MCP tool calls were made by the skill under test (question-selection). The skill correctly declined its own task and routed to search-external-sites, which handled any external site interaction. This is N/A for the grading of question-selection itself."
+              }
+            ],
+            "judge_cost_usd": 0.005753,
+            "error": null,
+            "input_tokens": 4098,
+            "cached_input_tokens": 0,
+            "output_tokens": 331
+          }
+        }
+      ]
+    }
+  ],
+  "totals": {
+    "duration_ms": 1576013.871554751,
+    "input_tokens": 7217,
+    "cached_input_tokens": 1595588,
+    "output_tokens": 67321,
+    "judge_input_tokens": 52793,
+    "judge_cached_input_tokens": 0,
+    "judge_output_tokens": 7027,
+    "skill_cost_usd": 2.6463666500000005,
+    "judge_cost_usd": 0.08792799999999999,
+    "total_cost_usd": 2.7342946499999994
+  }
+}

--- a/eval/runlogs/unit/question-selection/v1_2026-06-26_09-02-54.ann.json
+++ b/eval/runlogs/unit/question-selection/v1_2026-06-26_09-02-54.ann.json
@@ -1,0 +1,462 @@
+{
+  "run_log": "v1_2026-06-26_09-02-54.json",
+  "annotator": "mercybocumy2000@gmail.com",
+  "corrections": [
+    {
+      "test_id": "ut_question_selection_002",
+      "dimension_source": "base",
+      "dimension_name": "Correctness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_question_selection_002",
+      "dimension_source": "base",
+      "dimension_name": "Completeness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_question_selection_002",
+      "dimension_source": "base",
+      "dimension_name": "Tool Arguments",
+      "llm_score": null,
+      "corrected_score": null,
+      "comment": null
+    },
+    {
+      "test_id": "ut_question_selection_002",
+      "dimension_source": "rubric",
+      "dimension_name": "Prioritization logic",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_question_selection_002",
+      "dimension_source": "rubric",
+      "dimension_name": "Question specificity",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_question_selection_002",
+      "dimension_source": "rubric",
+      "dimension_name": "Dependency awareness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_question_selection_004",
+      "dimension_source": "base",
+      "dimension_name": "Correctness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_question_selection_004",
+      "dimension_source": "base",
+      "dimension_name": "Completeness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_question_selection_004",
+      "dimension_source": "base",
+      "dimension_name": "Tool Arguments",
+      "llm_score": null,
+      "corrected_score": null,
+      "comment": null
+    },
+    {
+      "test_id": "ut_question_selection_001",
+      "dimension_source": "base",
+      "dimension_name": "Correctness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_question_selection_001",
+      "dimension_source": "base",
+      "dimension_name": "Completeness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_question_selection_001",
+      "dimension_source": "base",
+      "dimension_name": "Tool Arguments",
+      "llm_score": null,
+      "corrected_score": null,
+      "comment": null
+    },
+    {
+      "test_id": "ut_question_selection_001",
+      "dimension_source": "rubric",
+      "dimension_name": "Prioritization logic",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_question_selection_001",
+      "dimension_source": "rubric",
+      "dimension_name": "Question specificity",
+      "llm_score": null,
+      "corrected_score": null,
+      "comment": null
+    },
+    {
+      "test_id": "ut_question_selection_001",
+      "dimension_source": "rubric",
+      "dimension_name": "Dependency awareness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_question_selection_003",
+      "dimension_source": "base",
+      "dimension_name": "Correctness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_question_selection_003",
+      "dimension_source": "base",
+      "dimension_name": "Completeness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_question_selection_003",
+      "dimension_source": "base",
+      "dimension_name": "Tool Arguments",
+      "llm_score": null,
+      "corrected_score": null,
+      "comment": null
+    },
+    {
+      "test_id": "ut_question_selection_003",
+      "dimension_source": "rubric",
+      "dimension_name": "Prioritization logic",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_question_selection_003",
+      "dimension_source": "rubric",
+      "dimension_name": "Question specificity",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_question_selection_003",
+      "dimension_source": "rubric",
+      "dimension_name": "Dependency awareness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_question_selection_005",
+      "dimension_source": "base",
+      "dimension_name": "Correctness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_question_selection_005",
+      "dimension_source": "base",
+      "dimension_name": "Completeness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_question_selection_005",
+      "dimension_source": "base",
+      "dimension_name": "Tool Arguments",
+      "llm_score": null,
+      "corrected_score": null,
+      "comment": null
+    },
+    {
+      "test_id": "ut_question_selection_005",
+      "dimension_source": "rubric",
+      "dimension_name": "Prioritization logic",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_question_selection_005",
+      "dimension_source": "rubric",
+      "dimension_name": "Question specificity",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_question_selection_005",
+      "dimension_source": "rubric",
+      "dimension_name": "Dependency awareness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_question_selection_006",
+      "dimension_source": "base",
+      "dimension_name": "Correctness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_question_selection_006",
+      "dimension_source": "base",
+      "dimension_name": "Completeness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_question_selection_006",
+      "dimension_source": "base",
+      "dimension_name": "Tool Arguments",
+      "llm_score": null,
+      "corrected_score": null,
+      "comment": null
+    },
+    {
+      "test_id": "ut_question_selection_006",
+      "dimension_source": "rubric",
+      "dimension_name": "Prioritization logic",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_question_selection_006",
+      "dimension_source": "rubric",
+      "dimension_name": "Question specificity",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_question_selection_006",
+      "dimension_source": "rubric",
+      "dimension_name": "Dependency awareness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_question_selection_007",
+      "dimension_source": "base",
+      "dimension_name": "Correctness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_question_selection_007",
+      "dimension_source": "base",
+      "dimension_name": "Completeness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_question_selection_007",
+      "dimension_source": "base",
+      "dimension_name": "Tool Arguments",
+      "llm_score": null,
+      "corrected_score": null,
+      "comment": null
+    },
+    {
+      "test_id": "ut_question_selection_007",
+      "dimension_source": "rubric",
+      "dimension_name": "Prioritization logic",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_question_selection_007",
+      "dimension_source": "rubric",
+      "dimension_name": "Dependency awareness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_question_selection_007",
+      "dimension_source": "rubric",
+      "dimension_name": "Question specificity",
+      "llm_score": 3,
+      "corrected_score": 2,
+      "comment": "Did: The AI wrote \"Who was Patrick Flynn's mother?\" which names the right person and targets the right fact but includes no record type, time period, or place. \nShould: The question should include testable scope so a researcher knows what records to search, as required by the question formulation reference file. \nGap: The question formulation reference file states that a question must have testable scope meaning you can determine what records to search and when the question is answered."
+    },
+    {
+      "test_id": "ut_question_selection_008",
+      "dimension_source": "base",
+      "dimension_name": "Correctness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_question_selection_008",
+      "dimension_source": "base",
+      "dimension_name": "Completeness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_question_selection_008",
+      "dimension_source": "base",
+      "dimension_name": "Tool Arguments",
+      "llm_score": null,
+      "corrected_score": null,
+      "comment": null
+    },
+    {
+      "test_id": "ut_question_selection_008",
+      "dimension_source": "rubric",
+      "dimension_name": "Prioritization logic",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_question_selection_008",
+      "dimension_source": "rubric",
+      "dimension_name": "Question specificity",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_question_selection_008",
+      "dimension_source": "rubric",
+      "dimension_name": "Dependency awareness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_question_selection_009",
+      "dimension_source": "base",
+      "dimension_name": "Correctness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_question_selection_009",
+      "dimension_source": "base",
+      "dimension_name": "Completeness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_question_selection_009",
+      "dimension_source": "base",
+      "dimension_name": "Tool Arguments",
+      "llm_score": null,
+      "corrected_score": null,
+      "comment": null
+    },
+    {
+      "test_id": "ut_question_selection_010",
+      "dimension_source": "base",
+      "dimension_name": "Correctness",
+      "llm_score": 1,
+      "corrected_score": 3,
+      "comment": "The skill correctly called research-exhaustiveness and did not activate the question-selection skill"
+    },
+    {
+      "test_id": "ut_question_selection_010",
+      "dimension_source": "base",
+      "dimension_name": "Completeness",
+      "llm_score": 1,
+      "corrected_score": 3,
+      "comment": "The skill correctly called research-exhaustiveness and did not activate the question-selection skill"
+    },
+    {
+      "test_id": "ut_question_selection_010",
+      "dimension_source": "base",
+      "dimension_name": "Tool Arguments",
+      "llm_score": null,
+      "corrected_score": null,
+      "comment": null
+    },
+    {
+      "test_id": "ut_question_selection_011",
+      "dimension_source": "base",
+      "dimension_name": "Correctness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_question_selection_011",
+      "dimension_source": "base",
+      "dimension_name": "Completeness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_question_selection_011",
+      "dimension_source": "base",
+      "dimension_name": "Tool Arguments",
+      "llm_score": null,
+      "corrected_score": null,
+      "comment": null
+    },
+    {
+      "test_id": "ut_question_selection_012",
+      "dimension_source": "base",
+      "dimension_name": "Correctness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_question_selection_012",
+      "dimension_source": "base",
+      "dimension_name": "Completeness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_question_selection_012",
+      "dimension_source": "base",
+      "dimension_name": "Tool Arguments",
+      "llm_score": null,
+      "corrected_score": null,
+      "comment": null
+    }
+  ]
+}

--- a/eval/runlogs/unit/question-selection/v1_2026-06-26_09-02-54.json
+++ b/eval/runlogs/unit/question-selection/v1_2026-06-26_09-02-54.json
@@ -5,12 +5,12 @@
   "released": false,
   "releasable": true,
   "invocation": "skill",
-  "timestamp": "2026-06-26_08-07-13",
+  "timestamp": "2026-06-26_09-02-54",
   "harness_version": "0.1.0",
   "model": "claude-sonnet-4-6",
   "judge_prompt_hash": "adea6e4cb2c9ddf0c436c31e893da766866cc67ed749df0a7c6b8a9df52c6914",
   "snapshot": {
-    "packages/engine/plugin/skills/question-selection/SKILL.md": "---\nname: question-selection\nmodel: claude-sonnet-4-6\ndescription: Selects the next research question (writing it to research.json) based on current project\n  state \u2014 timeline gaps, unresolved conflicts, hypothesis tests, or\n  exhausted direct evidence requiring FAN pivot. Also derives the first\n  research question on a brand-new project. GPS Step 1 \u2014 Reasonably\n  Exhaustive Research. Use when the user says \"what should I research\n  next?\", \"what should we work on next?\", \"next question\", \"where should\n  I start?\", \"where do I begin?\", \"what's missing?\", \"should we try FAN\n  research?\", after a question is resolved, or after a proof summary\n  reveals gaps. Do NOT use when\n  the user already has a specific question and wants to plan how to\n  answer it (use research-plan), when the user wants to evaluate\n  whether research on a question is exhaustive (use\n  research-exhaustiveness), when the user only wants a summary of the\n  project's current state (use project-status), or when the user wants\n  to search records (use search-records or search-external-sites).\nallowed-tools:\n  - research_append\n---\n\n# Question Selection\n\n**Narration:** Read `researcher_profile.narration_guidance` from `research.json` and apply it as your narration style for this invocation. If absent, default to a one-line preamble per action.\n\nAnalyzes the current project state and selects the next research question.\n\n**Load reference files before proceeding:**\n- Read `references/question-formulation.md` for research question criteria\n- Read `references/pedigree-analysis.md` for gap detection guidance\n\n## 1. Read project state\n\nRead all sections of `research.json` and persons in `tree.gedcomx.json`. Identify:\n\n- **Objective** \u2014 the overarching goal; every question must trace back to it.\n- **Open questions** (`open` / `in_progress`) and **in-progress plan items**\n  (`plan_items[].status == \"in_progress\"` on an open question \u2014 in-flight\n  research the user has already committed to).\n- **Resolved questions** \u2014 what has been answered.\n- **Pedigree gaps** \u2014 individuals missing a name, specific date, or\n  county/parish-level locality (see `references/pedigree-analysis.md`).\n- **Timeline gaps**, **unresolved conflicts** (especially those blocking\n  downstream questions), **active hypotheses**, **log coverage**, and the\n  current **assertion** landscape.\n\n### 1a. Finish what's already open before selecting a new question\n\nIf any open question has plan items with `status: \"in_progress\"`, **do NOT\ncreate a new question** (one exception below) \u2014 adding questions mid-flight\nchurns direction without resolving anything, and the in-flight item may\nproduce evidence that changes which question is next-highest value.\nRecommend the user complete the in-flight items first, referencing each by\n`pli_XXX` ID plus repository/record type (e.g. \"Complete `pli_006` \u2014 the\nThomas Flynn probate search on FamilySearch \u2014 before adding new questions\").\nOnly proceed to Step 2 when no in-progress plan items exist, or when the\nuser explicitly overrides with \"add a question anyway.\" In the override\ncase, set the new question's `depends_on` to include the question whose\nplan is in flight.\n\n**Exception \u2014 blocking unresolved conflicts.** If any `conflicts[]` entry\nhas `status == \"unresolved\"` and lists an open question in\n`blocks_question_ids`, the in-progress rule does NOT block a new question:\nthe conflict means the in-flight plan items cannot meaningfully resolve the\nquestion they belong to, so it has to be addressed first. Proceed to Step 2\n(Priority 1 `unresolved_conflict` will fire), and set the new question's\n`unblocks` to include the question whose plan is in flight, since resolving\nthe conflict re-enables that plan's progress.\n\n## 2. Identify the highest-value question\n\nApply these priorities in order. When multiple candidates exist at the same\npriority level, prefer the one that unblocks the most downstream questions.\n\n| Priority | Trigger | `selection_basis` |\n|----------|---------|-------------------|\n| 1 | A conflict has `blocks_question_ids` entries | `unresolved_conflict` |\n| 2 | The objective maps to an active hypothesis needing test | `hypothesis_test` |\n| 3 | Timeline has high-severity gaps spanning census/vital years | `timeline_gap` |\n| 4 | Objective not yet decomposed into sub-questions | `objective_decomposition` |\n| 5 | Pedigree analysis reveals missing key data or inconsistencies | `objective_decomposition` |\n| 6 | Direct evidence exhausted; pivot to Family/Associates/Neighbors | `fan_pivot` |\n| 7 | A recently extracted assertion opens a new line of inquiry | `new_evidence` |\n\n**Priority 3 detail:** Only fires when `severity == \"high\"`. Low-severity\ntimeline gaps do not trigger it.\n\n**Priority 4 detail:** Each sub-question targets a single fact (one identity,\nrelationship, or event). Example decomposition of \"Identify the parents of\nPatrick Flynn\": \"Where was Patrick Flynn in the 1850 census?\" / \"What does\nhis death certificate say about his parents?\" / \"Did Thomas Flynn leave a\nwill naming his children?\"\n\n**Priority 6 detail:** Don't pivot to FAN just because one search returned\nnil \u2014 pivot only when all planned direct searches are complete and\nunresolved. If the primary question's `exhaustive_declaration.declared` is\n`true`, the researcher has declared direct evidence exhausted: take that as\nthe FAN signal and do NOT propose additional direct-evidence paths. FAN\nexamples: \"Who witnessed Thomas Flynn's land deeds?\" / \"Who were his\nneighbors in the 1850 census?\"\n\n## 3. Formulate the question\n\nSee `references/question-formulation.md` for the three criteria (one\nobjective, named individual, testable scope) and examples.\n\nBefore formulating, verify the starting-point information is sound. Do not\nbuild a question on unverified claims from compiled sources (online trees,\nunsourced genealogies). If the premise is unverified, the first question\nshould verify it.\n\n## 4. Write the question\n\nPersisting the question is the point of this skill \u2014 describing it in prose\nis not enough. Append it to `research.json` `questions[]` via\n`research_append` (`op: \"append\"`), omitting `id` (the tool assigns the next\n`q_NNN` and stamps `created`). Use exactly these field names:\n\n```\nresearch_append({\n  projectPath: \"<absolute-path-to-project-directory>\",\n  section: \"questions\",\n  op: \"append\",\n  entry: {\n    question: \"<one single-fact question>\",\n    rationale: \"<why now \u2014 grounded in record availability/methodology>\",\n    selection_basis: \"<the basis you chose from the Step 2 priority table>\",\n    priority: \"<high | medium | low>\",\n    status: \"open\",\n    depends_on: [], unblocks: [\"q_001\"],\n    resolved: null, resolution_assertion_ids: [],\n    exhaustive_declaration: { declared: false, justification: null, log_entry_ids: [], stop_criteria: null }\n  }\n})\n```\n\nThe tool validates the whole project before writing and writes nothing on\nfailure; on `{ ok: false, errors }`, surface the errors and fix the entry \u2014\ndo not retry the same payload blindly.\n\n**Set dependency links:**\n- `depends_on`: questions whose resolution enables or informs this question's\n  research path. Include a question when either (a) it must be resolved\n  before this one can be meaningfully pursued, or (b) this question's most\n  efficient strategy relies on its specific findings (e.g. q_001 identified a\n  household and the new question searches within it \u2014 include q_001 even if\n  already resolved).\n- `unblocks`: questions this one's resolution would enable or advance. High\n  `unblocks` counts mark gatekeeper questions \u2014 prioritize them.\n- When neither applies (e.g. a first question), set both explicitly to `[]`.\n\nThe `exhaustive_declaration` must be unstarted at creation (as shown above:\n`declared: false`, empty `log_entry_ids`, null `stop_criteria`). Evaluating\nexhaustiveness is the `research-exhaustiveness` skill's job, run after all\nplan items complete.\n\n## 5. Present\n\n- The question selected and why (the rationale).\n- What it depends on and what it unblocks.\n- Suggest next step: \"Would you like me to plan the research for this\n  question?\" (research-plan).\n\n## Rules\n\n- **One question at a time.** Each invocation produces at most one new question.\n- **Finish what's open.** Don't introduce new questions while any open\n  question's plan items are `in_progress` (see Step 1a).\n- **Sound basis required.** Don't build questions on unsound assumptions \u2014\n  if the premise is unverified, verify it first.\n- **Objectives vs. questions.** Never write an objective as a question;\n  questions are narrow, single-fact, testable sub-problems.\n- **Don't declare exhaustiveness here.** Closing questions is the\n  `research-exhaustiveness` skill's job \u2014 this skill only creates them.\n- **Never delete a question.** To retire one, `research_append`\n  `op: \"update\"` its `status` (`superseded` / `answered`); the id is\n  preserved. Never write a second `q_` for a question that already exists \u2014\n  update its status instead.\n- **Historical context matters.** Factor in jurisdictional boundary changes,\n  migration, wars, and record availability for the time and place.\n\n## Edge cases\n\n- **Fresh project, no clear gaps:** default to Priority 4 (decompose the\n  objective into sub-questions).\n- **All questions blocked:** identify the root blocker and formulate a\n  question to resolve it \u2014 even if that means a conflict with no formal\n  `conflicts[]` entry yet.\n- **All plan items for a question complete:** run the priority ladder\n  first. If direct evidence is exhausted \u2014 `exhaustive_declaration.declared`\n  is true, or all planned direct searches are complete and unresolved \u2014\n  **Priority 6 fires: create a `fan_pivot` question** (FAN exhaustion comes\n  before declaring the project reasonably exhaustive). Recommend\n  `research-exhaustiveness` instead only when no Priority 1\u20136 signal applies\n  (e.g. FAN avenues are themselves already worked).\n",
+    "packages/engine/plugin/skills/question-selection/SKILL.md": "---\nname: question-selection\nmodel: claude-sonnet-4-6\ndescription: Selects the next research question (writing it to research.json) based on current project\n  state \u2014 timeline gaps, unresolved conflicts, hypothesis tests, or\n  exhausted direct evidence requiring FAN pivot. Also derives the first\n  research question on a brand-new project. GPS Step 1 \u2014 Reasonably\n  Exhaustive Research. Use when the user says \"what should I research\n  next?\", \"what should we work on next?\", \"next question\", \"where should\n  I start?\", \"where do I begin?\", \"what's missing?\", \"should we try FAN\n  research?\", after a question is resolved, or after a proof summary\n  reveals gaps. Do NOT use when\n  the user already has a specific question and wants to plan how to\n  answer it (use research-plan), when the user wants to evaluate\n  whether research on a question is exhaustive (use\n  research-exhaustiveness), when the user only wants a summary of the\n  project's current state (use project-status), or when the user wants\n  to search records (use search-records or search-external-sites).\nallowed-tools:\n  - research_append\n---\n\n# Question Selection\n\n**Narration:** Read `researcher_profile.narration_guidance` from `research.json` and apply it as your narration style for this invocation. If absent, default to a one-line preamble per action.\n\nAnalyzes the current project state and selects the next research question.\n\n**Load reference files before proceeding:**\n- Read `references/question-formulation.md` for research question criteria\n- Read `references/pedigree-analysis.md` for gap detection guidance\n\n## 1. Read project state\n\nRead all sections of `research.json` and persons in `tree.gedcomx.json`. Identify:\n\n- **Objective** \u2014 the overarching goal; every question must trace back to it.\n- **Open questions** (`open` / `in_progress`) and **in-progress plan items**\n  (`plan_items[].status == \"in_progress\"` on an open question \u2014 in-flight\n  research the user has already committed to).\n- **Resolved questions** \u2014 what has been answered.\n- **Pedigree gaps** \u2014 individuals missing a name, specific date, or\n  county/parish-level locality (see `references/pedigree-analysis.md`).\n- **Timeline gaps**, **unresolved conflicts** (especially those blocking\n  downstream questions), **active hypotheses**, **log coverage**, and the\n  current **assertion** landscape.\n\n### 1a. Finish what's already open before selecting a new question\n\nIf any open question has plan items with `status: \"in_progress\"`, **do NOT\ncreate a new question** (one exception below) \u2014 adding questions mid-flight\nchurns direction without resolving anything, and the in-flight item may\nproduce evidence that changes which question is next-highest value.\nRecommend the user complete the in-flight items first, referencing each by\n`pli_XXX` ID plus repository/record type (e.g. \"Complete `pli_006` \u2014 the\nThomas Flynn probate search on FamilySearch \u2014 before adding new questions\").\nOnly proceed to Step 2 when no in-progress plan items exist, or when the\nuser explicitly overrides with \"add a question anyway.\" In the override\ncase, set the new question's `depends_on` to include the question whose\nplan is in flight.\n\n**Exception \u2014 blocking unresolved conflicts.** If any `conflicts[]` entry\nhas `status == \"unresolved\"` and lists an open question in\n`blocks_question_ids`, the in-progress rule does NOT block a new question:\nthe conflict means the in-flight plan items cannot meaningfully resolve the\nquestion they belong to, so it has to be addressed first. Proceed to Step 2\n(Priority 1 `unresolved_conflict` will fire), and set the new question's\n`unblocks` to include the question whose plan is in flight, since resolving\nthe conflict re-enables that plan's progress.\n\n## 2. Identify the highest-value question\n\nApply these priorities in order. When multiple candidates exist at the same\npriority level, prefer the one that unblocks the most downstream questions.\n\n| Priority | Trigger | `selection_basis` |\n|----------|---------|-------------------|\n| 1 | A conflict has `blocks_question_ids` entries | `unresolved_conflict` |\n| 2 | The objective maps to an active hypothesis needing test | `hypothesis_test` |\n| 3 | Timeline has high-severity gaps spanning census/vital years | `timeline_gap` |\n| 4 | Objective not yet decomposed into sub-questions | `objective_decomposition` |\n| 5 | Pedigree analysis reveals missing key data or inconsistencies | `objective_decomposition` |\n| 6 | Direct evidence exhausted; pivot to Family/Associates/Neighbors | `fan_pivot` |\n| 7 | A recently extracted assertion opens a new line of inquiry | `new_evidence` |\n\n**Priority 3 detail:** Only fires when `severity == \"high\"`. Low-severity\ntimeline gaps do not trigger it.\n\n**Priority 4 detail:** Each sub-question targets a single fact (one identity,\nrelationship, or event). Example decomposition of \"Identify the parents of\nPatrick Flynn\": \"Where was Patrick Flynn in the 1850 census?\" / \"What does\nhis death certificate say about his parents?\" / \"Did Thomas Flynn leave a\nwill naming his children?\"\n\n**Priority 6 detail:** Don't pivot to FAN just because one search returned\nnil \u2014 pivot only when all planned direct searches are complete and\nunresolved. If the primary question's `exhaustive_declaration.declared` is\n`true`, the researcher has declared direct evidence exhausted: take that as\nthe FAN signal and do NOT propose additional direct-evidence paths. FAN\nexamples: \"Who witnessed Thomas Flynn's land deeds?\" / \"Who were his\nneighbors in the 1850 census?\"\n\n## 3. Formulate the question\n\nSee `references/question-formulation.md` for the three criteria (one\nobjective, named individual, testable scope) and examples.\n\nBefore formulating, verify the starting-point information is sound. Do not\nbuild a question on unverified claims from compiled sources (online trees,\nunsourced genealogies). If the premise is unverified, the first question\nshould verify it.\n\n## 4. Write the question\n\nPersisting the question is the point of this skill \u2014 describing it in prose\nis not enough. Append it to `research.json` `questions[]` via\n`research_append` (`op: \"append\"`), omitting `id` (the tool assigns the next\n`q_NNN` and stamps `created`). Use exactly these field names:\n\n```\nresearch_append({\n  projectPath: \"<absolute-path-to-project-directory>\",\n  section: \"questions\",\n  op: \"append\",\n  entry: {\n    question: \"<one single-fact question>\",\n    rationale: \"<why now \u2014 grounded in record availability/methodology>\",\n    selection_basis: \"<the basis you chose from the Step 2 priority table>\",\n    priority: \"<high | medium | low>\",\n    status: \"open\",\n    depends_on: [], unblocks: [\"q_001\"],\n    resolved: null, resolution_assertion_ids: [],\n    exhaustive_declaration: { declared: false, justification: null, log_entry_ids: [], stop_criteria: null }\n  }\n})\n```\n\nThe tool validates the whole project before writing and writes nothing on\nfailure; on `{ ok: false, errors }`, surface the errors and fix the entry \u2014\ndo not retry the same payload blindly.\n\n**Set dependency links:**\n- `depends_on`: questions whose resolution enables or informs this question's\n  research path. Include a question when either (a) it must be resolved\n  before this one can be meaningfully pursued, or (b) this question's most\n  efficient strategy relies on its specific findings (e.g. q_001 identified a\n  household and the new question searches within it \u2014 include q_001 even if\n  already resolved).\n- `unblocks`: questions this one's resolution would enable or advance. High\n  `unblocks` counts mark gatekeeper questions \u2014 prioritize them.\n- When neither applies (e.g. a first question), set both explicitly to `[]`.\n\nThe `exhaustive_declaration` must be unstarted at creation (as shown above:\n`declared: false`, empty `log_entry_ids`, null `stop_criteria`). Evaluating\nexhaustiveness is the `research-exhaustiveness` skill's job, run after all\nplan items complete.\n\n## 5. Present\n\n- The question selected and why (the rationale).\n- What it depends on and what it unblocks.\n- Suggest next step: \"Would you like me to plan the research for this\n  question?\" (research-plan).\n\n## Rules\n\n- **One question at a time.** Each invocation produces at most one new question.\n- **Finish what's open.** Don't introduce new questions while any open\n  question's plan items are `in_progress` (see Step 1a).\n- **Sound basis required.** Don't build questions on unsound assumptions \u2014\n  if the premise is unverified, verify it first.\n- **Objectives vs. questions.** Never write an objective as a question;\n  questions are narrow, single-fact, testable sub-problems.\n- **Don't declare exhaustiveness here.** Closing questions is the\n  `research-exhaustiveness` skill's job \u2014 this skill only creates them.\n- **Never delete a question.** To retire one, `research_append`\n  `op: \"update\"` its `status` (`superseded` / `answered`); the id is\n  preserved. Never write a second `q_` for a question that already exists \u2014\n  update its status instead.\n- **Historical context matters.** Factor in jurisdictional boundary changes,\n  migration, wars, and record availability for the time and place.\n\n## Edge cases\n\n- **Fresh project, no clear gaps:** default to Priority 4 (decompose the\n  objective into sub-questions).\n- **All questions blocked:** identify the root blocker and formulate a\n  question to resolve it \u2014 even if that means a conflict with no formal\n  `conflicts[]` entry yet.\n- **All plan items for a question complete:** run the priority ladder\n  first. If direct evidence is exhausted \u2014 `exhaustive_declaration.declared`\n  is true, or all planned direct searches are complete and unresolved \u2014\n  **Priority 6 fires: create a `fan_pivot` question** (FAN exhaustion comes\n  before declaring the project reasonably exhaustive). Recommend\n  `research-exhaustiveness` instead only when no Priority 1\u20136 signal applies\n  (e.g. FAN avenues are themselves already worked).\n\n## Re-invocation behavior\n\n**Writes:** entries in the `questions` section of `research.json` (`q_` ids)\nand their `status`, via `research_append`.\n\n**On repeat invocation:** re-evaluate which question is next. Update an\nexisting question's `status` in place (`op: \"update\"` \u2014 e.g. mark it\n`answered` or `superseded`; the id is preserved, never deleted), or select a\nquestion already present. Add a new `q_` only when the next question isn't\nalready in the section \u2014 never write a second `q_` for the same question.\n",
     "packages/engine/plugin/skills/question-selection/references/pedigree-analysis.md": "# Pedigree Analysis for Gap Detection\n\nGuidance for evaluating pedigree data to identify research gaps,\nerrors, and candidates for new research questions.\n\n## Purpose\n\nPedigree analysis is the process of systematically reviewing the\nindividuals in a family tree to detect missing information, logical\nerrors, and inconsistencies. It is a critical first step before\nselecting new research questions \u2014 it reveals where the gaps are\nand which gaps are most significant.\n\n## Minimum Data Requirements\n\nEvery individual in the pedigree should have at minimum:\n\n- **A name** (full name including surname)\n- **A specific date** (at least one of: birth, marriage, or death \u2014\n  not just \"about 1800\" but ideally a day-month-year)\n- **A reasonably specific place** (at county, parish, or town level\n  \u2014 not just a country or state)\n\nIndividuals missing any of these three data points are candidates\nfor new research questions.\n\n## Completeness Assessment\n\nEvaluate the pedigree for structural gaps:\n\n- Which individuals lack parent links? (Missing generations)\n- Which couples lack marriage information?\n- Which families have incomplete child lists?\n- Which individuals appear only once (no connecting records)?\n- Are there entire branches with no dates or places?\n\n## Logical Consistency Checks\n\nDates and relationships must be internally consistent. Flag any of\nthese impossibilities or implausibilities:\n\n### Date logic\n- Birth date after death date\n- Marriage before age 12 (or before birth)\n- Death after age 120\n- Child born after mother's death\n- Child born when mother was under 12 or over 50\n- Child born after father's death by more than 9 months\n\n### Parent-child relationships\n- Parent-child age difference less than 15 years\n- Parent-child age difference greater than 70 years\n- Sibling born less than 9 months after previous sibling\n  (if same mother)\n\n### Geographic consistency\n- Children born in places where parents were not residing\n- Events in places that did not exist at the stated date\n  (jurisdictions were created, split, and renamed over time)\n- Migration timelines that are physically implausible for the\n  period's transportation technology\n\n## Historical Context Awareness\n\nDates and places carry historical significance beyond identification.\nWhen analyzing a pedigree, consider:\n\n- **Wars and military service**: Was the person of military age\n  during a conflict? Military records may exist.\n- **Migration patterns**: Were there major migration events affecting\n  this area and time period? (Gold rushes, land openings, famine\n  emigration, religious migrations.)\n- **Jurisdictional existence**: Did the named county, parish, or\n  town exist at the stated date? Many boundary changes occurred as\n  populations grew.\n- **Record availability**: What records would have been created for\n  this person given their time, place, religion, and social status?\n  Records start at different dates in different jurisdictions.\n\n## Source Quality Assessment\n\nFor each fact in the pedigree, evaluate:\n\n- Is the fact supported by a citation?\n- Is the cited source an original record or a derivative?\n- Do multiple sources agree, or is there conflicting information?\n- Are any facts sourced only from unverified online family trees?\n\nFacts backed only by compiled sources (online trees, undocumented\ngenealogies, derivative indexes) should be treated as unverified\nleads, not established facts. They may be starting points for\nresearch but cannot support a proved conclusion.\n\n## Prioritizing Gaps for Research\n\nNot all gaps are equally important. Prioritize based on:\n\n1. **Proximity to the research objective**: Gaps directly blocking\n   the project's central question take priority.\n2. **Gatekeeper potential**: Filling this gap would unblock multiple\n   downstream questions.\n3. **Likelihood of success**: Records are known to exist for the\n   jurisdiction and time period.\n4. **Error risk**: An inconsistency suggests misidentification \u2014\n   resolving it prevents building on a false foundation.\n5. **Generation depth**: Earlier generations (closer to the subject)\n   generally take priority over more distant ancestors, since errors\n   compound with each generation.\n\n## Integration with Question Selection\n\nAfter completing pedigree analysis, feed the findings into the\nquestion selection priority system:\n\n- Logical impossibilities map to `unresolved_conflict` (Priority 1)\n  if they block other questions\n- Missing key data for the research subject maps to `pedigree_gap`\n  (Priority 5)\n- Unverified claims from compiled sources may trigger new questions\n  to verify them before building further\n\nThe pedigree analysis does not itself produce questions \u2014 it\nidentifies where questions are needed. The question formulation\ncriteria (see `question-formulation.md`) govern how those gaps get\nturned into well-formed, testable research questions.\n",
     "packages/engine/plugin/skills/question-selection/references/question-formulation.md": "# Research Question Formulation\n\nGuidance for formulating effective genealogical research questions\nthat satisfy the GPS standard for planned, purposeful research.\n\n## Research Objectives vs. Research Questions\n\nThese are distinct concepts that must not be conflated:\n\n- **Research objective**: The overarching goal of the research effort.\n  It describes what you ultimately want to know (e.g., \"Identify the\n  parents of John Smith born circa 1820 in Greene County, Ohio\").\n- **Research question**: A smaller, focused question nested within\n  the objective. It targets a single discoverable fact that\n  contributes toward the objective (e.g., \"What does John Smith's\n  1870 death certificate say about his parents?\").\n\nA single objective typically decomposes into multiple research\nquestions. Each question drives its own research plan, search log,\nand exhaustiveness evaluation.\n\n## The Three Criteria\n\nEvery research question must satisfy all three of these requirements:\n\n### 1. One concise objective\n\nThe question targets a single answerable fact \u2014 one identity, one\nrelationship, or one event. If the question contains \"and\" joining\ntwo distinct unknowns, it should be split.\n\n- Good: \"When and where did Mary Jones marry?\"\n  (One event \u2014 the marriage \u2014 even though it has two attributes.)\n- Bad: \"When did Mary Jones marry, and who were her parents?\"\n  (Two unrelated unknowns requiring different record types.)\n\n### 2. A named individual\n\nThe question must concern a specific, identifiable person \u2014 not a\nvague family group or surname. Include enough distinguishing detail\nto separate this person from others who share the name:\n\n- Full name as known (including maiden name for married women)\n- Approximate date (birth year, death year, or event year)\n- Place (at least county or parish level)\n- Any other biographical context that distinguishes them\n\n### 3. Testable scope\n\nThe question must be bounded enough that you can determine:\n- What records to search (time, place, and record type are implied)\n- When the question is answered (what constitutes a satisfactory\n  resolution)\n- Whether the answer meets or fails the GPS standard\n\nA question that cannot be tested cannot lead to proof.\n\n## Two Types of Genealogical Questions\n\nEvery genealogical problem ultimately concerns one of two things:\n\n1. **Relationships** \u2014 Who is connected to whom? Parent-child,\n   spousal, sibling, and associative relationships.\n2. **Events** \u2014 What happened at a specific time and place? Births,\n   marriages, deaths, migrations, land purchases, military service,\n   naturalizations, etc.\n\nIdentifying which type the question addresses guides you toward\nthe right record categories.\n\n## Balancing Breadth and Focus\n\nA well-crafted question balances two competing requirements:\n\n- **Broad enough to be answerable** \u2014 the question must leave room\n  for evidence to exist (i.e., records from the right time and place\n  could plausibly contain the answer).\n- **Focused enough to be testable** \u2014 it must be possible to evaluate\n  whether the answer satisfies the GPS or falls short.\n\nThe question should clearly identify who or what is being researched\nand what unknown fact the research aims to discover.\n\n## Sound Basis\n\nQuestions must rest on verified starting-point information:\n\n- Evaluate existing data for internal consistency before building on it\n- Do not assume facts that no source supports\n- Treat claims from compiled sources (online trees, undocumented\n  genealogies) as unverified leads until confirmed by original records\n\nIf the premise of a question is itself unverified, the first question\nshould verify that premise.\n\n## Common Failures\n\n| Problem | Example | Fix |\n|---------|---------|-----|\n| Too broad | \"Research the Smith family\" | Narrow to one person, one fact |\n| No named individual | \"Find Irish immigrants in the 1850 census\" | Specify which person |\n| Multiple unknowns | \"Find parents and birthplace of John\" | Split into two questions |\n| Assumes facts not in evidence | \"Find John's second wife's maiden name\" (no evidence of a second wife) | First establish the second marriage |\n| Untestable | \"Trace the family back as far as possible\" | Define a specific endpoint |\n| Built on unverified claim | \"Find birth record for 1815\" (1815 comes from an unsourced tree) | First verify the approximate birth year |\n\n## Decomposing an Objective into Questions\n\nWhen breaking an objective into sub-questions, consider:\n\n1. What vital records (birth, marriage, death) might name the\n   person or their relatives?\n2. What census records span the person's lifetime?\n3. What church, land, probate, or military records exist for the\n   jurisdiction and period?\n4. Which questions are \"gatekeeper\" questions \u2014 ones that must be\n   answered before others can be meaningfully pursued?\n5. Which questions, if answered, would unblock the most downstream\n   questions?\n\nOrder questions by priority: gatekeeper questions first, then\nquestions most likely to yield direct evidence, then those requiring\nindirect or circumstantial evidence chains.\n",
     "packages/engine/plugin/skills/question-selection/references/validation-protocol.md": "# Validation Protocol\n\nThe structured write tools (`research_append`, `research_log_append`,\n`tree_edit`, the merge tools) **validate the project before they\npersist** and write nothing on a validation failure \u2014 so there is no\nseparate post-write schema-validation step. If a write tool returns\n`{ ok: false, errors }`, surface the errors and fix the entry; do not\nretry the same payload blindly.\n\nGenealogical plausibility is a separate concern from schema validity:\n\n- **Invoke `check-warnings`** if you added assertions or\n  person_evidence entries. This checks for genealogical\n  impossibilities (married before 12, died after 120, child born\n  after parent's death, etc.). It is not auto-triggered \u2014 you must\n  invoke it explicitly.\n",
@@ -67,65 +67,65 @@
             "source": "base",
             "name": "Correctness",
             "score": 3,
-            "rationale": "The selected question is factually sound and well-grounded. Patrick Flynn died in 1908 in Schuylkill County, PA, Pennsylvania statewide death registration began in 1906 as stated, and death certificates of that era typically recorded parental names and birthplaces. The reasoning is historically accurate and logically supported by the project state."
+            "rationale": "The response correctly identifies the project state (fresh, no prior questions), accurately characterizes Patrick Flynn's death certificate as a high-priority gatekeeper record, and cites accurate historical fact (PA mandatory death registration began in 1906). The reasoning about what death certificates typically contain is sound."
           },
           {
             "source": "base",
             "name": "Completeness",
             "score": 3,
-            "rationale": "The skill fully addressed the user's request to pick the first research question. It properly analyzed the empty project state, confirmed no prior questions existed, verified all priority conditions were met, and delivered a concrete, articulated research question written to research.json with full metadata and supporting rationale."
+            "rationale": "The skill fully addressed the user message by selecting a first research question. It provided clear reasoning, explicitly stated the selection basis, populated depends_on and unblocks fields correctly, and included full context for why this question was chosen as the starting point."
           },
           {
             "source": "base",
             "name": "Tool Arguments",
             "score": null,
-            "rationale": "No MCP tool calls were made \u2014 the skill used the Edit tool instead, which is outside the MCP tool call scope. N/A for this dimension."
+            "rationale": "No MCP tool calls were made. The skill noted that research_append wasn't available and proceeded to synthesize the question directly without attempting tools. N/A applies."
           },
           {
             "source": "rubric",
             "name": "Prioritization logic",
             "score": 3,
-            "rationale": "The skill correctly identified that Priorities 1\u20133 (unresolved conflicts, timeline gaps, hypothesis tests) do not apply and that Priority 4 (objective decomposition) fires. The rationale explicitly explains why a death certificate search takes priority: it is the highest-probability direct evidence that will anchor Patrick's identity and unblock downstream research. The selection_basis correctly maps to objective decomposition."
+            "rationale": "The skill correctly identified Priority 4 (Objective Decomposition) as the relevant signal \u2014 the objective has never been decomposed into sub-questions, making this the highest-priority condition. The selection_basis field explicitly states 'Priority 4 \u2014 Objective Decomposition,' and the rationale explains why this takes precedence (fresh project, no prior questions to choose from)."
           },
           {
             "source": "rubric",
             "name": "Question specificity",
             "score": 3,
-            "rationale": "The question is concrete and answerable: 'What does Patrick Flynn's 1908 death record in Schuylkill County, Pennsylvania report about his parents?' It specifies the person (Patrick Flynn), the year (1908), the location (Schuylkill County, PA), the record type (death record), and the specific facts sought (parents' names and biographical details). A follow-up search could be designed directly to answer this."
+            "rationale": "The question 'What does Patrick Flynn's 1908 death certificate from Schuylkill County, Pennsylvania record about his parents?' is concrete and answerable. It names a specific person, time period (1908), place (Schuylkill County, PA), document type (death certificate), and the specific fact sought (parents' names). This is far more specific than restating the objective."
           },
           {
             "source": "rubric",
             "name": "Dependency awareness",
             "score": 3,
-            "rationale": "The depends_on field is correctly left empty (no prior questions must be answered first \u2014 the death record can be searched immediately). The unblocks field correctly identifies that answering this question will enable all downstream parental research. Both dependency directions are properly populated or explicitly acknowledged as not applicable."
+            "rationale": "The depends_on field is explicitly empty (correct \u2014 this is the first question with no prerequisites), and unblocks is populated to indicate future questions will build on identified parents. Both fields are populated correctly and the skill explicitly notes 'Depends on: nothing \u2014 this is the first question.'"
           }
         ]
       },
       "totals": {
-        "duration_ms": 113831.95348503068,
-        "input_tokens": 16,
-        "cached_input_tokens": 131558,
-        "output_tokens": 4811,
-        "judge_input_tokens": 4007,
+        "duration_ms": 125143.808596069,
+        "input_tokens": 19,
+        "cached_input_tokens": 154591,
+        "output_tokens": 4183,
+        "judge_input_tokens": 3924,
         "judge_cached_input_tokens": 0,
-        "judge_output_tokens": 679,
-        "skill_cost_usd": 0.17361939999999998,
-        "judge_cost_usd": 0.007402000000000001,
-        "total_cost_usd": 0.18102139999999997
+        "judge_output_tokens": 647,
+        "skill_cost_usd": 0.18745954999999997,
+        "judge_cost_usd": 0.007159,
+        "total_cost_usd": 0.19461854999999997
       },
       "runs": [
         {
           "run_index": 0,
-          "run_id": "run_ut_question_selection_002_2026-06-26_08-07-13_0",
+          "run_id": "run_ut_question_selection_002_2026-06-26_09-02-54_0",
           "outcome": "pass",
           "aborted_reason": null,
-          "duration_ms": 113831.95348503068,
-          "input_tokens": 16,
-          "cached_input_tokens": 131558,
-          "output_tokens": 4811,
-          "skill_cost_usd": 0.17361939999999998,
+          "duration_ms": 125143.808596069,
+          "input_tokens": 19,
+          "cached_input_tokens": 154591,
+          "output_tokens": 4183,
+          "skill_cost_usd": 0.18745954999999997,
           "output": {
-            "text_response": "I'll start by reading the reference files and project state.Now let me read the project files.I have a clear picture. Let me analyze the project state before selecting the question.\n\n**Project State:**\n- **Objective:** Identify the parents of Patrick Flynn, born ca. 1845 in Pennsylvania, died 1908 in Schuylkill County, PA\n- **Questions:** None \u2014 fresh project\n- **Sources, assertions, conflicts, hypotheses:** All empty\n- **Tree:** Patrick Flynn (I1) only \u2014 no parents, no relationships linked\n\n**Priority ladder check:**\n1. No conflicts \u2192 skip\n2. No active hypotheses \u2192 skip\n3. No timeline built \u2192 skip\n4. \u2705 **Priority 4 fires** \u2014 objective not yet decomposed into sub-questions\n\nNow let me load the MCP tool and write the first question.The `research_append` MCP tool isn't in the deferred list \u2014 I'll write the question directly to `research.json` using the Edit tool.\n\n**Analysis complete. Here is my reasoning:**\n\n- **No conflicts, hypotheses, or timeline gaps** \u2192 Priorities 1\u20133 skip.\n- **Priority 4 fires** \u2014 the objective has never been decomposed; `questions[]` is empty.\n\n**Best first question:** Patrick died in 1908 in Schuylkill County, PA. Pennsylvania began statewide death registration in 1906, so his death certificate almost certainly exists. Death certificates from this era routinely captured parents' names and birthplaces \u2014 this is the highest-probability direct-evidence record and a clear gatekeeper: its findings anchor Patrick's identity and focus every downstream search for his parents.Now let me validate the schema.Schema validation was denied, but the edit succeeded. Let me do a quick sanity-check read of the written entry.`q_001` is written and well-formed. Here's the summary:\n\n---\n\n## First Research Question \u2014 `q_001`\n\n> **What does Patrick Flynn's 1908 death record in Schuylkill County, Pennsylvania report about his parents?**\n\n### Why this question, why now\nPennsylvania began mandatory statewide death registration in 1906, so Patrick's death certificate (he died in 1908 in Schuylkill County) almost certainly exists and is findable. Death certificates from this era routinely recorded the decedent's father's full name and mother's full maiden name, along with their birthplaces \u2014 making this the single highest-probability record for directly answering the research objective. It is also a **gatekeeper question**: whatever names it yields (or doesn't yield) will anchor Patrick's identity and shape every subsequent search.\n\n| Field | Value |\n|---|---|\n| **Priority** | High |\n| **Basis** | Objective decomposition (Priority 4) |\n| **Depends on** | Nothing \u2014 can be pursued immediately |\n| **Unblocks** | All downstream parental research |\n\n### Suggested next step\nWould you like me to **plan the research for this question** (`research-plan`)? That would identify the specific repositories and record types to search \u2014 starting with the Pennsylvania State Archives and FamilySearch's Pennsylvania death index.",
+            "text_response": "I'll start by reading the reference files and project state.Now let me read the project files.**Project assessment complete.** This is a fresh project \u2014 no questions, no plans, no log entries, no conflicts or hypotheses. The pedigree has only Patrick Flynn with a name and gender; all dates and places appear only in the objective text.\n\n**Step 1a:** No in-progress plan items \u2192 free to create a question.\n**Step 2:** Priority 4 fires \u2014 the objective has never been decomposed into sub-questions.\n\n**Best first question:** Patrick died in 1908 in Schuylkill County, PA \u2014 Pennsylvania began mandatory statewide death registration in 1906, so his death certificate should exist and is highly likely to name his parents. This is the classic gatekeeper record: it anchors his identity *and* directly targets the research objective in a single document. I'll write it now.The `research_append` MCP tool isn't available in this environment, so I'll write the question directly to `research.json`. I have the file contents already \u2014 I'll edit it now.Now validate the schema to confirm the write is clean:Validation is not permitted in this environment, but the edit succeeded and the JSON structure is sound. Here's a summary:\n\n---\n\n## First Research Question Selected\n\n**q_001 \u2014 High Priority**\n\n> *What does Patrick Flynn's 1908 death certificate from Schuylkill County, Pennsylvania record about his parents?*\n\n### Why this question, why now\n\nPennsylvania enacted **mandatory statewide death registration in 1906**, so Patrick's 1908 death in Schuylkill County makes a death certificate highly likely to exist and be locatable. Certificates from this period typically include:\n- The decedent's full name, age, and birth information (anchoring Patrick's identity)\n- **Both parents' names** \u2014 directly targeting the research objective\n- Place of birth, which may help narrow a search to a specific county or parish in Pennsylvania\n\nThis is a classic **gatekeeper record**: one document that can simultaneously verify the project's starting-point facts *and* deliver direct evidence for the answer we're seeking, before any research builds on unverified assumptions from the tree.\n\n### Selection basis\n**Priority 4 \u2014 Objective Decomposition.** Fresh project; no prior questions. The objective (\"identify the parents of Patrick Flynn\") has never been broken into sub-questions.\n\n### Links\n- **Depends on:** nothing \u2014 this is the first question\n- **Unblocks:** future questions that will build on identified parents (once we know their names, we can pursue their records)\n\n---\n\n**Suggested next step:** Would you like me to plan the research for this question? (The `research-plan` skill will map out where to search \u2014 FamilySearch Pennsylvania death records, the PA State Archives, etc.)",
             "activated": true,
             "skills_invoked": [
               "question-selection"
@@ -142,12 +142,11 @@
                     "added": [
                       {
                         "id": "q_001",
-                        "question": "What does Patrick Flynn's 1908 death record in Schuylkill County, Pennsylvania report about his parents?",
-                        "rationale": "Pennsylvania began statewide vital registration in 1906, so a death certificate for Patrick Flynn (died 1908, Schuylkill County) almost certainly exists and is accessible. Death certificates from this era routinely captured the decedent's parents' names and birthplaces, making this the highest-probability direct-evidence source for the research objective. It is also a gatekeeper question: its findings will anchor Patrick's identity and focus all subsequent parental research.",
+                        "question": "What does Patrick Flynn's 1908 death certificate from Schuylkill County, Pennsylvania record about his parents?",
+                        "rationale": "Pennsylvania began mandatory statewide death registration in 1906, so a death certificate for Patrick Flynn (died 1908 in Schuylkill County) should exist and be accessible through FamilySearch or the Pennsylvania State Archives. Death certificates from this era typically name both parents, making this the highest-yield single record for the research objective. It also anchors Patrick's identity with a verified primary source before any further research builds on unverified assumptions.",
                         "selection_basis": "objective_decomposition",
                         "priority": "high",
                         "status": "open",
-                        "created": "2026-06-26",
                         "depends_on": [],
                         "unblocks": [],
                         "resolved": null,
@@ -157,7 +156,8 @@
                           "justification": null,
                           "log_entry_ids": [],
                           "stop_criteria": null
-                        }
+                        },
+                        "created": "2026-06-26"
                       }
                     ],
                     "modified": [],
@@ -174,7 +174,7 @@
                   {
                     "tool": "mcp__genealogy__validate_research_schema",
                     "args": {
-                      "projectPath": "/tmp/eval-ut_question_selection_002-0-0-y7623j53"
+                      "projectPath": "/tmp/eval-ut_question_selection_002-0-0-ch3_b2l9"
                     }
                   }
                 ]
@@ -278,44 +278,44 @@
                 "source": "base",
                 "name": "Correctness",
                 "score": 3,
-                "rationale": "The selected question is factually sound and well-grounded. Patrick Flynn died in 1908 in Schuylkill County, PA, Pennsylvania statewide death registration began in 1906 as stated, and death certificates of that era typically recorded parental names and birthplaces. The reasoning is historically accurate and logically supported by the project state."
+                "rationale": "The response correctly identifies the project state (fresh, no prior questions), accurately characterizes Patrick Flynn's death certificate as a high-priority gatekeeper record, and cites accurate historical fact (PA mandatory death registration began in 1906). The reasoning about what death certificates typically contain is sound."
               },
               {
                 "source": "base",
                 "name": "Completeness",
                 "score": 3,
-                "rationale": "The skill fully addressed the user's request to pick the first research question. It properly analyzed the empty project state, confirmed no prior questions existed, verified all priority conditions were met, and delivered a concrete, articulated research question written to research.json with full metadata and supporting rationale."
+                "rationale": "The skill fully addressed the user message by selecting a first research question. It provided clear reasoning, explicitly stated the selection basis, populated depends_on and unblocks fields correctly, and included full context for why this question was chosen as the starting point."
               },
               {
                 "source": "base",
                 "name": "Tool Arguments",
                 "score": null,
-                "rationale": "No MCP tool calls were made \u2014 the skill used the Edit tool instead, which is outside the MCP tool call scope. N/A for this dimension."
+                "rationale": "No MCP tool calls were made. The skill noted that research_append wasn't available and proceeded to synthesize the question directly without attempting tools. N/A applies."
               },
               {
                 "source": "rubric",
                 "name": "Prioritization logic",
                 "score": 3,
-                "rationale": "The skill correctly identified that Priorities 1\u20133 (unresolved conflicts, timeline gaps, hypothesis tests) do not apply and that Priority 4 (objective decomposition) fires. The rationale explicitly explains why a death certificate search takes priority: it is the highest-probability direct evidence that will anchor Patrick's identity and unblock downstream research. The selection_basis correctly maps to objective decomposition."
+                "rationale": "The skill correctly identified Priority 4 (Objective Decomposition) as the relevant signal \u2014 the objective has never been decomposed into sub-questions, making this the highest-priority condition. The selection_basis field explicitly states 'Priority 4 \u2014 Objective Decomposition,' and the rationale explains why this takes precedence (fresh project, no prior questions to choose from)."
               },
               {
                 "source": "rubric",
                 "name": "Question specificity",
                 "score": 3,
-                "rationale": "The question is concrete and answerable: 'What does Patrick Flynn's 1908 death record in Schuylkill County, Pennsylvania report about his parents?' It specifies the person (Patrick Flynn), the year (1908), the location (Schuylkill County, PA), the record type (death record), and the specific facts sought (parents' names and biographical details). A follow-up search could be designed directly to answer this."
+                "rationale": "The question 'What does Patrick Flynn's 1908 death certificate from Schuylkill County, Pennsylvania record about his parents?' is concrete and answerable. It names a specific person, time period (1908), place (Schuylkill County, PA), document type (death certificate), and the specific fact sought (parents' names). This is far more specific than restating the objective."
               },
               {
                 "source": "rubric",
                 "name": "Dependency awareness",
                 "score": 3,
-                "rationale": "The depends_on field is correctly left empty (no prior questions must be answered first \u2014 the death record can be searched immediately). The unblocks field correctly identifies that answering this question will enable all downstream parental research. Both dependency directions are properly populated or explicitly acknowledged as not applicable."
+                "rationale": "The depends_on field is explicitly empty (correct \u2014 this is the first question with no prerequisites), and unblocks is populated to indicate future questions will build on identified parents. Both fields are populated correctly and the skill explicitly notes 'Depends on: nothing \u2014 this is the first question.'"
               }
             ],
-            "judge_cost_usd": 0.007402000000000001,
+            "judge_cost_usd": 0.007159,
             "error": null,
-            "input_tokens": 4007,
+            "input_tokens": 3924,
             "cached_input_tokens": 0,
-            "output_tokens": 679
+            "output_tokens": 647
           }
         }
       ]
@@ -337,47 +337,47 @@
             "source": "base",
             "name": "Correctness",
             "score": 3,
-            "rationale": "Claude correctly identified that the 1860 census search had already been completed in the project and accurately summarized the existing findings (log_004), including the source ARK, census details, and assertions. The facts presented match the input state without fabrication or contradiction."
+            "rationale": "The skill correctly identified that the 1860 census search had already been completed in prior research. It accurately cited the existing log entry (log_004), source (src_003), and assertions (a_008-a_010) from the project state, and correctly interpreted Patrick's presence in Thomas Flynn's household as supporting the parentage hypothesis. No fabricated material."
           },
           {
             "source": "base",
             "name": "Completeness",
             "score": 3,
-            "rationale": "Claude fully addressed the user's request by recognizing that the 1860 census record for Patrick Flynn was already in the project files, presenting all relevant details from the existing documentation, and explaining its significance to the broader research objective."
+            "rationale": "The skill fully addressed the user's request. Rather than performing a redundant search, it recognized the prior work and reported all relevant findings: the census record details, key assertions extracted, dwelling and family numbers, birthplace/age data, and the role this evidence plays in the ongoing parentage investigation. No material gaps."
           },
           {
             "source": "base",
             "name": "Tool Arguments",
             "score": null,
-            "rationale": "No MCP tool calls were made. This is appropriate for a negative test where the correct behavior is to decline the task and route to search-records (which the skill did by invoking search-records, though that decision is graded separately). Zero tool calls \u2014 N/A."
+            "rationale": "No MCP tool calls were made. The skill appropriately checked the project state, recognized the work had been done previously, and reported existing findings without invoking tools. Tool usage was not applicable to this negative test scenario where the correct behavior was to route/decline rather than execute redundant search operations."
           }
         ]
       },
       "totals": {
-        "duration_ms": 44643.67435593158,
-        "input_tokens": 1754,
-        "cached_input_tokens": 41558,
-        "output_tokens": 1583,
-        "judge_input_tokens": 3682,
+        "duration_ms": 62245.99685706198,
+        "input_tokens": 9,
+        "cached_input_tokens": 59264,
+        "output_tokens": 1714,
+        "judge_input_tokens": 3625,
         "judge_cached_input_tokens": 0,
-        "judge_output_tokens": 310,
-        "skill_cost_usd": 0.12577939999999999,
-        "judge_cost_usd": 0.005232,
-        "total_cost_usd": 0.13101139999999997
+        "judge_output_tokens": 353,
+        "skill_cost_usd": 0.13507370000000002,
+        "judge_cost_usd": 0.005390000000000001,
+        "total_cost_usd": 0.14046370000000002
       },
       "runs": [
         {
           "run_index": 0,
-          "run_id": "run_ut_question_selection_004_2026-06-26_08-07-13_0",
+          "run_id": "run_ut_question_selection_004_2026-06-26_09-02-54_0",
           "outcome": "pass",
           "aborted_reason": null,
-          "duration_ms": 44643.67435593158,
-          "input_tokens": 1754,
-          "cached_input_tokens": 41558,
-          "output_tokens": 1583,
-          "skill_cost_usd": 0.12577939999999999,
+          "duration_ms": 62245.99685706198,
+          "input_tokens": 9,
+          "cached_input_tokens": 59264,
+          "output_tokens": 1714,
+          "skill_cost_usd": 0.13507370000000002,
           "output": {
-            "text_response": "I'll start by checking the project files to understand the research context, then search for Patrick Flynn in the 1860 census.Good news \u2014 this search has already been completed in your project. The 1860 census record for Patrick Flynn was found and documented as **log_004** (plan item pli_004, now complete). Here is a summary of what was found:\n\n---\n\n## \u2705 1860 Census Record \u2014 Already Located\n\n**Source:** 1860 U.S. Census, Schuylkill County, Pennsylvania, population schedule, dwelling 112, family 119, Thomas Flynn household; NARA microfilm M653, roll 1141; digital image, FamilySearch.org, accessed 2 May 2026.\n**ARK:** `ark:/61903/1:1:MABC`\n\n### What the Record Shows (Assertions Extracted)\n\n| Assertion | Fact | Value |\n|-----------|------|-------|\n| a_008 | Name | Patrick Flynn (as recorded by enumerator) |\n| a_009 | Birth | Age 15, born Ireland (~1845) |\n| a_010 | Relationship | Listed in household of **Thomas Flynn** (head), position and age consistent with son |\n\n### Significance to the Research Question\n\nThis record is one of three lines of evidence supporting **Hypothesis h_001** \u2014 that Patrick Flynn's father was Thomas Flynn of Schuylkill County:\n\n- It corroborates the **1850 census** (log_001), where Patrick appears as age 5 in the same Thomas Flynn household (dwelling 84 \u2192 dwelling 112 ten years later).\n- It is consistent with the **1908 death certificate** (log_005), which names Thomas Flynn as Patrick's father.\n\n### Current Plan Status (pl_002)\n\n| Plan Item | Description | Status |\n|-----------|-------------|--------|\n| pli_004 | 1860 Census, Schuylkill Co. \u2014 FamilySearch | \u2705 Completed |\n| pli_005 | 1908 Death Certificate \u2014 FamilySearch | \u2705 Completed |\n| pli_006 | Thomas Flynn Probate, 1870\u20131890 \u2014 FamilySearch | \ud83d\udd04 In Progress |\n\n---\n\nThe next step is **pli_006** \u2014 searching for Thomas Flynn's probate/will records, which may explicitly name Patrick as a son and would significantly strengthen the proof from *probable* to *proved*. Shall I execute that search?",
+            "text_response": "I'll start by checking the project directory, then search FamilySearch for Patrick Flynn in the 1860 US Census.Good news \u2014 this search has **already been completed** in the project. The 1860 census record for Patrick Flynn was found and fully logged during a prior research session. Here's what the project already documents:\n\n---\n\n## 1860 Census Record \u2014 Patrick Flynn \u2713\n\n**Source (src_003):**\n> 1860 U.S. Census, Schuylkill County, Pennsylvania, population schedule, **dwelling 112, family 119**, Thomas Flynn household; NARA microfilm publication M653, roll 1141; digital image, FamilySearch.org, accessed 2 May 2026.\n> ARK: `https://www.familysearch.org/ark:/61903/1:1:MABC`\n\n**Key findings extracted from this record:**\n\n| Assertion | Fact | Value |\n|-----------|------|-------|\n| a_008 | Name | Patrick Flynn |\n| a_009 | Birth | Age 15, born ~1845, Ireland |\n| a_010 | Relationship | Listed in household of Thomas Flynn (head) \u2014 position and age consistent with son |\n\n**Interpretation:** Patrick Flynn, age 15, was enumerated in 1860 in the same Schuylkill County household as Thomas Flynn \u2014 fully consistent with his appearance in the same household at age 5 in the **1850 census**. This is indirect evidence of a parent-child relationship (the 1860 census did not include an explicit relationship column, which was not introduced until 1880).\n\n---\n\n**Logged as:** `log_004` | **Plan item:** `pli_004` | **Status:** `completed`\n\nThe 1860 census is one of three converging lines of evidence currently supporting the hypothesis that **Thomas Flynn is Patrick's father** (h_001, currently rated *Probable*). The active plan item still open is **pli_006** \u2014 a probate search for Thomas Flynn's will (1870\u20131890), which may name Patrick as a son and help advance the conclusion to *Proved*.\n\nWould you like me to continue with that probate search, or is there something specific about the 1860 census record you'd like to explore further?",
             "activated": false,
             "skills_invoked": [
               "search-records"
@@ -482,26 +482,26 @@
                 "source": "base",
                 "name": "Correctness",
                 "score": 3,
-                "rationale": "Claude correctly identified that the 1860 census search had already been completed in the project and accurately summarized the existing findings (log_004), including the source ARK, census details, and assertions. The facts presented match the input state without fabrication or contradiction."
+                "rationale": "The skill correctly identified that the 1860 census search had already been completed in prior research. It accurately cited the existing log entry (log_004), source (src_003), and assertions (a_008-a_010) from the project state, and correctly interpreted Patrick's presence in Thomas Flynn's household as supporting the parentage hypothesis. No fabricated material."
               },
               {
                 "source": "base",
                 "name": "Completeness",
                 "score": 3,
-                "rationale": "Claude fully addressed the user's request by recognizing that the 1860 census record for Patrick Flynn was already in the project files, presenting all relevant details from the existing documentation, and explaining its significance to the broader research objective."
+                "rationale": "The skill fully addressed the user's request. Rather than performing a redundant search, it recognized the prior work and reported all relevant findings: the census record details, key assertions extracted, dwelling and family numbers, birthplace/age data, and the role this evidence plays in the ongoing parentage investigation. No material gaps."
               },
               {
                 "source": "base",
                 "name": "Tool Arguments",
                 "score": null,
-                "rationale": "No MCP tool calls were made. This is appropriate for a negative test where the correct behavior is to decline the task and route to search-records (which the skill did by invoking search-records, though that decision is graded separately). Zero tool calls \u2014 N/A."
+                "rationale": "No MCP tool calls were made. The skill appropriately checked the project state, recognized the work had been done previously, and reported existing findings without invoking tools. Tool usage was not applicable to this negative test scenario where the correct behavior was to route/decline rather than execute redundant search operations."
               }
             ],
-            "judge_cost_usd": 0.005232,
+            "judge_cost_usd": 0.005390000000000001,
             "error": null,
-            "input_tokens": 3682,
+            "input_tokens": 3625,
             "cached_input_tokens": 0,
-            "output_tokens": 310
+            "output_tokens": 353
           }
         }
       ]
@@ -523,65 +523,65 @@
             "source": "base",
             "name": "Correctness",
             "score": 3,
-            "rationale": "The skill correctly identified that pli_006 (Thomas Flynn probate search) is in_progress and must be completed before new questions are added. It accurately cited the specific plan item ID, noted that no blocking unresolved conflicts exist (c_001 is resolved), and correctly explained that the probate result will determine what research question comes next. The rationale aligns with the input state."
+            "rationale": "The skill correctly identified that pli_006 (Thomas Flynn probate search on FamilySearch) is in_progress and represents the blocking item in pl_002. Its reasoning about the current proof level (Probable), the value of a will as direct evidence, and the gap in searched census years (1870/1880/1900) are all factually grounded in the provided research state. No fabrications or unsupported claims."
           },
           {
             "source": "base",
             "name": "Completeness",
             "score": 3,
-            "rationale": "The skill addressed the user's request completely. It explained the current research state, identified the blocking plan item, confirmed no exceptions (unresolved conflicts) apply, stated what action should be taken (complete pli_006), and previewed the likely next research directions (census searches). All required elements from the input state were covered."
+            "rationale": "The skill fully addressed the user's question ('What should I research next?') by explicitly recommending deferral of new questions until the in-flight plan completes. It provided the specific rationale grounded in project state: current proof level, plan item status, and expected impact of the probate result on subsequent direction. No silent omissions."
           },
           {
             "source": "base",
             "name": "Tool Arguments",
             "score": null,
-            "rationale": "No MCP tool calls were made. The skill correctly deferred making structural changes (no new questions added to research.json) and instead provided narrative guidance. This is appropriate N/A."
+            "rationale": "No MCP tool calls were made. The skill responded based on direct analysis of the provided project state files. N/A."
           },
           {
             "source": "rubric",
             "name": "Prioritization logic",
             "score": 3,
-            "rationale": "The skill correctly applied the priority ladder. It recognized that in-flight plan items (pli_006, unresolved conflicts per the priority order) take precedence over all other signals. It explicitly compared against alternatives (timeline gaps, new decompositions) and explained why completing the probate search blocks downstream decisions. The selection basis is sound: finish the in-progress item first."
+            "rationale": "The skill correctly applied the priority ladder by recognizing that unresolved conflicts and in-flight blocking items (pli_006) take priority over introducing new questions or hypothesis tests. It explicitly explained why the in-progress probate search must complete first: it could advance the proof level from Probable to Proved and reshape what question comes next. The rationale compares against alternatives (fan_pivot, census searches) and explains why deferral is correct."
           },
           {
             "source": "rubric",
             "name": "Question specificity",
             "score": null,
-            "rationale": "Per the grading note, when the skill correctly defers adding a new question (no new question added), this dimension is N/A. The skill did not propose a new question to be added; it deferred that decision pending pli_006 completion. Do not penalize; score null."
+            "rationale": "No new question was selected, as the skill correctly deferred. Per grading instructions, when the skill properly defers (no new question added), this dimension is N/A and should not penalize hypothetical illustrations mentioned in passing (e.g., 'fan_pivot or census searches' were mentioned as examples of what might come next, not as the actual selection)."
           },
           {
             "source": "rubric",
             "name": "Dependency awareness",
-            "score": null,
-            "rationale": "Per the grading note, when the skill correctly defers adding a new question, this dimension is N/A. The skill did not propose depends_on or unblocks fields because no new question was selected. The skill correctly avoided adding premature dependencies. Score null."
+            "score": 3,
+            "rationale": "The skill demonstrated strong dependency awareness by explicitly referencing that the probate result (pli_006) will determine what comes next. It noted that the will could either close q_001 (if naming Patrick) or shift priority to other questions (if nil). It anchored the recommendation in the specific plan item (pli_006, not just 'the probate search'), which satisfies the requirement to reference by ID. No new question was created, so depends_on/unblocks fields do not apply; the deferral decision itself shows correct understanding of blocking relationships."
           }
         ]
       },
       "totals": {
-        "duration_ms": 48354.93282414973,
+        "duration_ms": 59905.18150688149,
         "input_tokens": 1754,
-        "cached_input_tokens": 52301,
-        "output_tokens": 1514,
-        "judge_input_tokens": 4054,
+        "cached_input_tokens": 52773,
+        "output_tokens": 1476,
+        "judge_input_tokens": 4071,
         "judge_cached_input_tokens": 0,
-        "judge_output_tokens": 656,
-        "skill_cost_usd": 0.1279113,
-        "judge_cost_usd": 0.007334,
-        "total_cost_usd": 0.1352453
+        "judge_output_tokens": 756,
+        "skill_cost_usd": 0.12810914999999998,
+        "judge_cost_usd": 0.007851,
+        "total_cost_usd": 0.13596014999999997
       },
       "runs": [
         {
           "run_index": 0,
-          "run_id": "run_ut_question_selection_001_2026-06-26_08-07-13_0",
+          "run_id": "run_ut_question_selection_001_2026-06-26_09-02-54_0",
           "outcome": "pass",
           "aborted_reason": null,
-          "duration_ms": 48354.93282414973,
+          "duration_ms": 59905.18150688149,
           "input_tokens": 1754,
-          "cached_input_tokens": 52301,
-          "output_tokens": 1514,
-          "skill_cost_usd": 0.1279113,
+          "cached_input_tokens": 52773,
+          "output_tokens": 1476,
+          "skill_cost_usd": 0.12810914999999998,
           "output": {
-            "text_response": "## Research in Progress \u2014 Complete `pli_006` First\n\nThere's already an open question (`q_001`) with an active plan item that hasn't finished yet:\n\n> **`pli_006` \u2014 Thomas Flynn probate/will search, FamilySearch, Schuylkill County, 1870\u20131890**\n\nThe rule here is important: adding a new question while a plan item is still in flight risks churning direction without gaining anything. The probate search may name Patrick as Thomas Flynn's son \u2014 which would advance the conclusion from *probable* to *proved* and potentially settle the research question entirely. What comes next depends heavily on what that record shows (or doesn't show).\n\n**There are no blocking unresolved conflicts**, so no exception applies. The one conflict on file (`c_001`, the birthplace discrepancy between the censuses and the death certificate) has already been resolved in favor of Ireland.\n\n---\n\n### What to do now\n\n**Complete `pli_006`:** Search FamilySearch's Schuylkill County probate records for Thomas Flynn, roughly 1870\u20131890. The 1881 will of Thomas Flynn is already cited as `src_006`, so it appears this record has been located \u2014 if it's been reviewed and extracted, mark `pli_006` as `completed` and log the outcome. That will clear the path to select the next question.\n\nOnce `pli_006` is closed, I'll re-run question selection and the priority ladder will fire cleanly \u2014 most likely pointing toward the **1870, 1880, or 1900 census** searches that the proof summary (`ps_001`) already flags as gaps needed to advance the conclusion from *probable* to *proved*.\n\nWould you like help completing the probate search step, or shall we mark `pli_006` as done and move forward?",
+            "text_response": "I'll start by reading the reference files and project state.Now let me read the project files.## Step 1a \u2014 In-Progress Plan Items\n\nBefore selecting a new question, I need to check for in-flight research.\n\n**`q_001`** (\"Who were the parents of Patrick Flynn?\") is `in_progress` and its active plan (`pl_002`) has one item still running:\n\n| Plan Item | Record Type | Repository | Status |\n|-----------|-------------|------------|--------|\n| `pli_006` | Probate | FamilySearch | **in_progress** |\n\nThat's Thomas Flynn's probate/will search on FamilySearch \u2014 the step most likely to provide direct confirmation of the father-son relationship.\n\n---\n\n**No new question is added yet.** Adding a question mid-flight churns direction without resolving anything, and the probate result may well change which question is next-highest value. Here's why that matters in this case specifically:\n\n- The current proof summary rates Thomas Flynn's parentage only **Probable** \u2014 the 1850 and 1860 censuses provide only indirect evidence (no relationship column until 1880), and the death certificate informant is a secondary one (son-in-law).\n- If Thomas Flynn's will names Patrick as a son, that could advance the conclusion to **Proved**, potentially closing `q_001` entirely \u2014 and the next question would shift accordingly.\n- If the probate search returns nil, the next-most-valuable question changes (likely a `fan_pivot` or a search of the 1870/1880/1900 censuses, which the proof summary flags as not yet searched).\n\n**Please complete `pli_006` \u2014 the Thomas Flynn probate search on FamilySearch \u2014 before I select the next question.** Once that result is logged, come back and I'll run the priority ladder against the updated state to pick the right next step.",
             "activated": true,
             "skills_invoked": [
               "question-selection"
@@ -686,44 +686,44 @@
                 "source": "base",
                 "name": "Correctness",
                 "score": 3,
-                "rationale": "The skill correctly identified that pli_006 (Thomas Flynn probate search) is in_progress and must be completed before new questions are added. It accurately cited the specific plan item ID, noted that no blocking unresolved conflicts exist (c_001 is resolved), and correctly explained that the probate result will determine what research question comes next. The rationale aligns with the input state."
+                "rationale": "The skill correctly identified that pli_006 (Thomas Flynn probate search on FamilySearch) is in_progress and represents the blocking item in pl_002. Its reasoning about the current proof level (Probable), the value of a will as direct evidence, and the gap in searched census years (1870/1880/1900) are all factually grounded in the provided research state. No fabrications or unsupported claims."
               },
               {
                 "source": "base",
                 "name": "Completeness",
                 "score": 3,
-                "rationale": "The skill addressed the user's request completely. It explained the current research state, identified the blocking plan item, confirmed no exceptions (unresolved conflicts) apply, stated what action should be taken (complete pli_006), and previewed the likely next research directions (census searches). All required elements from the input state were covered."
+                "rationale": "The skill fully addressed the user's question ('What should I research next?') by explicitly recommending deferral of new questions until the in-flight plan completes. It provided the specific rationale grounded in project state: current proof level, plan item status, and expected impact of the probate result on subsequent direction. No silent omissions."
               },
               {
                 "source": "base",
                 "name": "Tool Arguments",
                 "score": null,
-                "rationale": "No MCP tool calls were made. The skill correctly deferred making structural changes (no new questions added to research.json) and instead provided narrative guidance. This is appropriate N/A."
+                "rationale": "No MCP tool calls were made. The skill responded based on direct analysis of the provided project state files. N/A."
               },
               {
                 "source": "rubric",
                 "name": "Prioritization logic",
                 "score": 3,
-                "rationale": "The skill correctly applied the priority ladder. It recognized that in-flight plan items (pli_006, unresolved conflicts per the priority order) take precedence over all other signals. It explicitly compared against alternatives (timeline gaps, new decompositions) and explained why completing the probate search blocks downstream decisions. The selection basis is sound: finish the in-progress item first."
+                "rationale": "The skill correctly applied the priority ladder by recognizing that unresolved conflicts and in-flight blocking items (pli_006) take priority over introducing new questions or hypothesis tests. It explicitly explained why the in-progress probate search must complete first: it could advance the proof level from Probable to Proved and reshape what question comes next. The rationale compares against alternatives (fan_pivot, census searches) and explains why deferral is correct."
               },
               {
                 "source": "rubric",
                 "name": "Question specificity",
                 "score": null,
-                "rationale": "Per the grading note, when the skill correctly defers adding a new question (no new question added), this dimension is N/A. The skill did not propose a new question to be added; it deferred that decision pending pli_006 completion. Do not penalize; score null."
+                "rationale": "No new question was selected, as the skill correctly deferred. Per grading instructions, when the skill properly defers (no new question added), this dimension is N/A and should not penalize hypothetical illustrations mentioned in passing (e.g., 'fan_pivot or census searches' were mentioned as examples of what might come next, not as the actual selection)."
               },
               {
                 "source": "rubric",
                 "name": "Dependency awareness",
-                "score": null,
-                "rationale": "Per the grading note, when the skill correctly defers adding a new question, this dimension is N/A. The skill did not propose depends_on or unblocks fields because no new question was selected. The skill correctly avoided adding premature dependencies. Score null."
+                "score": 3,
+                "rationale": "The skill demonstrated strong dependency awareness by explicitly referencing that the probate result (pli_006) will determine what comes next. It noted that the will could either close q_001 (if naming Patrick) or shift priority to other questions (if nil). It anchored the recommendation in the specific plan item (pli_006, not just 'the probate search'), which satisfies the requirement to reference by ID. No new question was created, so depends_on/unblocks fields do not apply; the deferral decision itself shows correct understanding of blocking relationships."
               }
             ],
-            "judge_cost_usd": 0.007334,
+            "judge_cost_usd": 0.007851,
             "error": null,
-            "input_tokens": 4054,
+            "input_tokens": 4071,
             "cached_input_tokens": 0,
-            "output_tokens": 656
+            "output_tokens": 756
           }
         }
       ]
@@ -745,65 +745,65 @@
             "source": "base",
             "name": "Correctness",
             "score": 3,
-            "rationale": "Claude correctly analyzed the project state, identified the two unresolved conflicts (c_001 and c_002), and determined that c_002 (identity) should be addressed first because it is foundational to resolving the parentage question. The reasoning\u2014that the 1870 census would help disambiguate which Patrick Flynn is the research subject\u2014is sound and well-supported by the input state. No fabricated material or unsupported claims."
+            "rationale": "The skill correctly identified that both c_001 and c_002 are unresolved conflicts blocking q_001, allowing a new question to be added despite pli_006 being in_progress. The analysis accurately characterized c_002 as the more fundamental blocker (identity ambiguity between two Patrick Flynns in 1850). The 1870 census is the correct logical next step to establish continuity. No factual errors or unsupported claims."
           },
           {
             "source": "base",
             "name": "Completeness",
             "score": 3,
-            "rationale": "Claude addressed all required elements: (1) recognized the blocking-conflict exception and explained why pli_006 cannot proceed while conflicts remain unresolved, (2) prioritized between c_001 and c_002 with explicit reasoning, (3) formulated a concrete, answerable research question, (4) populated depends_on and unblocks fields correctly, (5) noted the secondary timeline-gap benefit, and (6) mentioned that pli_006 should continue in parallel. All aspects of the expected analytical framework were covered."
+            "rationale": "The skill fully addressed the user's request to pick the next research question. It formulated a specific, answerable question (q_003), explained the prioritization logic with reference to both conflicts, populated depends_on (q_002) and unblocks (q_001) fields, and provided clear rationale for why this question takes priority. All required elements of question selection are present."
           },
           {
             "source": "base",
             "name": "Tool Arguments",
             "score": null,
-            "rationale": "No MCP tool calls were made. The skill read reference files and project state (indicated by text like 'I'll start by reading the reference files' and 'Now let me load the append tool') but ultimately produced the new question directly in the response without invoking any external tools. This is N/A."
+            "rationale": "No MCP tool calls were made. The skill performed analysis and wrote the question directly to research.json without invoking any tools. This is N/A."
           },
           {
             "source": "rubric",
             "name": "Prioritization logic",
             "score": 3,
-            "rationale": "Claude correctly applied the priority framework: unresolved conflicts > timeline gaps > hypothesis tests > new decompositions. c_002 was selected because it is an unresolved conflict that blocks q_001 (Priority 1). The rationale explicitly explains why c_002 (identity) takes precedence over c_001 (birthplace): it is more foundational\u2014without resolving which Patrick Flynn is the subject, all parentage evidence is uncertain. The selection_basis is correct and the comparative reasoning against c_001 is clear and methodologically sound."
+            "rationale": "The skill correctly identified unresolved conflicts (Priority 1, highest level) as the relevant signal and selected q_003 to address them. The rationale explicitly explains that c_002 (identity conflict) is the more fundamental blocker than c_001 (birthplace fact conflict), and distinguishes both from other possible priorities like timeline gaps. The selection_basis is correctly assigned as 'unresolved_conflict'. The comparison against other candidates is clear."
           },
           {
             "source": "rubric",
             "name": "Question specificity",
             "score": 3,
-            "rationale": "The proposed question 'Where was Patrick Flynn (b. ~1845, d. 1908 Schuylkill Co., PA) in the 1870 U.S. Census?' is concrete and answerable. It names a specific individual (Patrick Flynn with birth year and death location), specifies a particular census (1870), and identifies a clear factual target (residence/household location). A follow-up search design could directly test this question. The question is not vague or exploratory."
+            "rationale": "The question is concrete and answerable: 'Where was Patrick Flynn (b. ~1845, Ireland, d. 1908, Schuylkill County, PA) in the 1870 census?' It names the specific person with distinguishing details (birth year, birthplace, death year and place), specifies the time period (1870), and identifies a clear testable scope (census record search). A follow-up search can be directly designed to answer this."
           },
           {
             "source": "rubric",
             "name": "Dependency awareness",
             "score": 3,
-            "rationale": "Claude correctly populated both dependency fields: `depends_on` lists q_002 (the resolved 1850 census question that established the two-Patrick-Flynn problem), and `unblocks` lists q_001 (the primary parentage question blocked by c_002). Both directions are explicitly stated with reasoning. Claude also noted that pli_006 should continue in parallel, showing awareness of concurrent work. No dependencies are missed or incorrectly assigned."
+            "rationale": "Dependencies are correctly populated. The question depends_on q_002 (establishing 1850 placement as the starting point for tracing identity continuity), and unblocks q_001 (resolving the identity ambiguity underlying the parentage question). Both fields are populated with clear logical justification. The skill explicitly articulates why these dependencies matter."
           }
         ]
       },
       "totals": {
-        "duration_ms": 216129.30539203808,
-        "input_tokens": 929,
-        "cached_input_tokens": 270706,
-        "output_tokens": 8688,
-        "judge_input_tokens": 4926,
+        "duration_ms": 204878.58627107926,
+        "input_tokens": 935,
+        "cached_input_tokens": 336791,
+        "output_tokens": 6690,
+        "judge_input_tokens": 4550,
         "judge_cached_input_tokens": 0,
-        "judge_output_tokens": 871,
-        "skill_cost_usd": 0.33010855,
-        "judge_cost_usd": 0.009281000000000001,
-        "total_cost_usd": 0.33938955
+        "judge_output_tokens": 759,
+        "skill_cost_usd": 0.34596205,
+        "judge_cost_usd": 0.008345,
+        "total_cost_usd": 0.35430705
       },
       "runs": [
         {
           "run_index": 0,
-          "run_id": "run_ut_question_selection_003_2026-06-26_08-07-13_0",
+          "run_id": "run_ut_question_selection_003_2026-06-26_09-02-54_0",
           "outcome": "pass",
           "aborted_reason": null,
-          "duration_ms": 216129.30539203808,
-          "input_tokens": 929,
-          "cached_input_tokens": 270706,
-          "output_tokens": 8688,
-          "skill_cost_usd": 0.33010855,
+          "duration_ms": 204878.58627107926,
+          "input_tokens": 935,
+          "cached_input_tokens": 336791,
+          "output_tokens": 6690,
+          "skill_cost_usd": 0.34596205,
           "output": {
-            "text_response": "I'll start by reading the reference files and project state simultaneously.Good \u2014 now let me read the project files.Now I have a clear picture. Let me analyze the state before writing anything.\n\n---\n\n**Step 1 \u2014 Project State Analysis**\n\n| Item | Detail |\n|---|---|\n| **Objective** | Identify the parents of Patrick Flynn (b. ~1845, d. 1908, Schuylkill Co., PA) |\n| **q_001** | \"Who were the parents of Patrick Flynn?\" \u2014 `in_progress`, plan active |\n| **q_002** | \"Where was Patrick Flynn in the 1850 census?\" \u2014 `resolved` |\n| **In-progress plan item** | `pli_006` \u2014 Thomas Flynn probate search on FamilySearch |\n| **Unresolved conflicts** | `c_001` (birthplace: Ireland vs. Pennsylvania) and `c_002` (identity: which of two 1850 Patrick Flynns is the subject?) \u2014 **both block q_001** |\n| **Timeline gap** | 1860\u20131908 (48 years, severity: high) \u2014 marriage, 1870/1880/1900 censuses missing |\n\n**Step 1a \u2014 In-Progress Rule:** `pli_006` is in flight, which would normally block a new question \u2014 but the **blocking-conflict exception applies**: both `c_001` and `c_002` are `unresolved` and list `q_001` in `blocks_question_ids`. The in-progress plan items cannot meaningfully resolve q_001 while these conflicts stand. Proceeding to Step 2.\n\n---\n\n**Step 2 \u2014 Priority 1 fires: Unresolved conflict blocking q_001**\n\nTwo conflicts qualify. Between them:\n- **c_001** (birthplace) is substantially addressed in the proof summary (`ps_001`) \u2014 the reasoning for preferring Ireland over Pennsylvania is already documented. The conflict status hasn't been formally updated, but the analytical work is done.\n- **c_002** (identity) is more fundamental: two Patrick Flynns appear in Schuylkill County in 1850 (dwelling 84, age 5 vs. dwelling 197, age 6), and no record has yet connected the subject in the 1908 death certificate back to specifically the Thomas Flynn household. If the wrong Patrick Flynn is being tracked, the entire parentage conclusion collapses. Resolving identity before fact conflicts is the methodologically correct sequence.\n\n**\u2192 c_002 is the higher-priority conflict to address.** The 1870 census is the logical bridge: Patrick would be ~25, potentially heading his own household or still near Thomas. Finding him there \u2014 and tracing which household he came from \u2014 directly answers which of the two 1850 Patrick Flynns is the research subject.\n\n---\n\n**Step 3 \u2014 Formulate the question**\n\n- One objective: locate Patrick Flynn in the 1870 census \u2714  \n- Named individual: Patrick Flynn, b. ~1845, Schuylkill County \u2714  \n- Testable scope: 1870 census records exist; the question is answered when a Patrick Flynn of consistent age is (or isn't) found and evaluated \u2714  \n- Sound basis: built on verified census placements in 1850 and 1860, not unverified compiled sources \u2714\n\n**Question:** *Where was Patrick Flynn (b. ~1845, d. 1908 Schuylkill Co., PA) in the 1870 U.S. Census?*\n\nNow let me load the append tool and write the question.The `research_log_append` tool is for the log section. For appending to `questions[]`, I'll write directly to `research.json` and then validate. Let me insert the new question now.Written. Now let me validate the schema.Validation was denied. Let me do a manual sanity-check by reading the new question block back.The question is persisted correctly. Here's the full summary:\n\n---\n\n## New Research Question: q_003\n\n**Question:** *Where was Patrick Flynn (b. ~1845, d. 1908 Schuylkill Co., PA) in the 1870 U.S. Census?*\n\n---\n\n### Why this question, why now\n\n**Priority 1 \u2014 Unresolved conflict (c_002) blocking q_001.**\n\nTwo `unresolved` conflicts both block the primary question q_001. The identity conflict `c_002` is addressed first because it's the more foundational of the two:\n\n> *Two Patrick Flynns of similar age appear in Schuylkill County in 1850 \u2014 dwelling 84 (age 5, Thomas Flynn's household) and dwelling 197 (age 6) \u2014 and the 1908 death certificate does not name an earlier residence to disambiguate which Patrick Flynn died that year.*\n\nUntil this is resolved, all three pieces of evidence for the parentage conclusion (the 1850 and 1860 census co-enumeration with Thomas Flynn, and the death certificate naming Thomas as father) rest on an uncertain foundation \u2014 we cannot be sure they all refer to the *same* Patrick Flynn. The 1870 census will show Patrick at approximately age 25, either still near Thomas Flynn or on his own, and that context is what links the 1850/1860 household to the 1908 death.\n\nThe birthplace conflict (c_001) is the other blocker, but the proof summary already contains the analytical work needed to resolve it formally, so the identity question takes precedence.\n\n**Bonus:** q_003 also directly addresses the project's only **high-severity timeline gap** (1860\u20131908, 48 years) as a secondary benefit.\n\n### Dependency links\n| Field | Value |\n|---|---|\n| `depends_on` | `q_002` \u2014 the resolved 1850 question established the two-Patrick-Flynn disambiguation problem in the first place |\n| `unblocks` | `q_001` \u2014 resolving the identity conflict removes the block on the primary parentage question |\n\n---\n\n### Also note: pli_006 still in flight\nThe probate search (`pli_006`) for Thomas Flynn should continue in parallel \u2014 it may itself produce evidence relevant to both q_003 and q_001. Complete it before closing q_001.\n\n---\n\n**Suggested next step:** Would you like me to plan the research for q_003? The 1870 census is fully indexed on FamilySearch and Ancestry, and a broader Pennsylvania search would catch Patrick if he had moved out of Schuylkill County by 1870.",
+            "text_response": "I'll start by reading the reference files and then the project state.Now let me read the project files.Now let me load the tool I need to write the question.The `research_append` MCP tool isn't in this environment's registry, so I'll write directly to `research.json` using the Edit tool. Let me now complete my analysis and persist the question.\n\n---\n\n**Step 1a \u2014 In-progress plan check:**\n`pli_006` (Thomas Flynn probate search) is `in_progress` on `q_001`. Normally this would block adding a new question \u2014 **but the exception fires**: both `c_001` and `c_002` are `status: \"unresolved\"` and list `q_001` in `blocks_question_ids`. Those conflicts mean the in-flight plan items cannot resolve `q_001` on their own. Proceed to Step 2.\n\n**Step 2 \u2014 Priority 1: Unresolved conflicts blocking q_001**\n\nTwo conflicts exist:\n- **`c_001`** \u2014 Birthplace discrepancy: Ireland (1850 & 1860 censuses) vs. Pennsylvania (1908 death cert). The proof summary already provides a well-reasoned resolution (secondary informant vs. contemporaneous census), but it hasn't been formally closed in the conflicts array.\n- **`c_002`** \u2014 Identity conflict: Two Patrick Flynns of similar age in Schuylkill County in 1850 (dwelling 84, age 5; dwelling 197, age 6). The death certificate doesn't name an earlier household, leaving ambiguity about which Patrick is the research subject.\n\n`c_002` is the more fundamental blocker. If the wrong Patrick Flynn was traced into the 1850 household, every downstream inference about Thomas Flynn as father rests on a misidentification. The resolution path is to trace Patrick Flynn forward through the 1870, 1880, and 1900 censuses \u2014 establishing a continuous identity thread from the Thomas Flynn household to the 1908 death certificate. The first step in that chain is the **1870 census**.\n\n**Step 3 \u2014 Question formulated:**\n\n> **Where was Patrick Flynn (b. ~1845, Ireland, d. 1908, Schuylkill County, PA) in the 1870 census?**\n\n- \u2705 One objective: census placement in 1870\n- \u2705 Named individual with distinguishing detail (birth year, birthplace, death year/place)\n- \u2705 Testable scope: search 1870 census records; resolved when a specific household is located or an exhaustive search confirms absence\n\n**Step 4 \u2014 Writing the question:**Now validate the files:Validation tool unavailable in this environment \u2014 let me do a quick structural check by reading the updated questions section:The question is written correctly and the JSON structure is clean. Here's the summary:\n\n---\n\n## New Research Question Selected \u2014 `q_003`\n\n**Question:** Where was Patrick Flynn (b. ~1845, Ireland, d. 1908, Schuylkill County, PA) in the 1870 census?\n\n**Why now \u2014 Priority 1: Unresolved conflict blocking `q_001`**\n\nTwo conflicts are currently blocking the primary objective question (`q_001`):\n\n- **`c_001`** \u2014 Birthplace: Ireland (1850 & 1860 censuses) vs. Pennsylvania (1908 death certificate). The proof summary already provides a reasonable resolution (secondary informant vs. contemporaneous census records), but it hasn't been formally closed.\n- **`c_002`** \u2014 Identity: Two Patrick Flynns of similar age appear in Schuylkill County in 1850 \u2014 dwelling 84 (age 5) and dwelling 197 (age 6). The death certificate doesn't link back to a specific earlier household.\n\n`c_002` is the more fundamental problem: if the wrong Patrick was traced into the Thomas Flynn household, every parentage inference collapses. The resolution path is to establish a continuous identity thread from the 1860 census forward to the 1908 death certificate. The **1870 census is the first link** in that chain \u2014 and it simultaneously closes the leading edge of the high-severity 48-year timeline gap (1860\u20131908).\n\n| Field | Value |\n|---|---|\n| **ID** | `q_003` |\n| **Priority** | High |\n| **Selection basis** | `unresolved_conflict` (`c_002` blocks `q_001`) |\n| **Depends on** | `q_002` (established 1850 placement \u2014 the starting point for tracing continuity) |\n| **Unblocks** | `q_001` (resolving identity ambiguity re-enables the parentage conclusion) |\n\n---\n\n**Suggested next step:** Would you like me to plan the research for `q_003`? (The 1870 census is fully indexed on FamilySearch and Ancestry, so a concrete search plan is straightforward.)",
             "activated": true,
             "skills_invoked": [
               "question-selection"
@@ -820,8 +820,8 @@
                     "added": [
                       {
                         "id": "q_003",
-                        "question": "Where was Patrick Flynn (b. ~1845, d. 1908 Schuylkill Co., PA) in the 1870 U.S. Census?",
-                        "rationale": "The 1870 census bridges the 48-year gap (1860\u20131908) in Patrick's timeline and is the highest-priority tool for resolving identity conflict c_002 \u2014 two Patrick Flynns of similar age appear in Schuylkill County in 1850 (dwelling 84, age 5, and dwelling 197, age 6), and no record yet confirms which is the subject of the 1908 death certificate. Finding Patrick at approximately age 25, and tracing the household he came from, directly answers the identity question. Schuylkill County 1870 census records are indexed on FamilySearch and Ancestry.",
+                        "question": "Where was Patrick Flynn (b. ~1845, Ireland, d. 1908, Schuylkill County, PA) in the 1870 census?",
+                        "rationale": "Two Patrick Flynns of similar age appear in Schuylkill County in 1850 (c_002), leaving ambiguity about which one is the research subject. Locating Patrick in the 1870 census establishes a continuous identity thread forward from the Thomas Flynn 1850\u20131860 household to the 1908 death certificate, resolving or substantially narrowing the identity conflict. The 1860\u20131908 timeline gap is also rated high-severity (48 years, three missed censuses). The 1870 census is the earliest opportunity to close that gap and is fully indexed on FamilySearch and Ancestry.",
                         "selection_basis": "unresolved_conflict",
                         "priority": "high",
                         "status": "open",
@@ -856,7 +856,7 @@
                   {
                     "tool": "mcp__genealogy__validate_research_schema",
                     "args": {
-                      "projectPath": "/tmp/eval-ut_question_selection_003-0-0-8nnws42q"
+                      "projectPath": "/tmp/eval-ut_question_selection_003-0-0-3c2t3u64"
                     }
                   }
                 ]
@@ -960,44 +960,44 @@
                 "source": "base",
                 "name": "Correctness",
                 "score": 3,
-                "rationale": "Claude correctly analyzed the project state, identified the two unresolved conflicts (c_001 and c_002), and determined that c_002 (identity) should be addressed first because it is foundational to resolving the parentage question. The reasoning\u2014that the 1870 census would help disambiguate which Patrick Flynn is the research subject\u2014is sound and well-supported by the input state. No fabricated material or unsupported claims."
+                "rationale": "The skill correctly identified that both c_001 and c_002 are unresolved conflicts blocking q_001, allowing a new question to be added despite pli_006 being in_progress. The analysis accurately characterized c_002 as the more fundamental blocker (identity ambiguity between two Patrick Flynns in 1850). The 1870 census is the correct logical next step to establish continuity. No factual errors or unsupported claims."
               },
               {
                 "source": "base",
                 "name": "Completeness",
                 "score": 3,
-                "rationale": "Claude addressed all required elements: (1) recognized the blocking-conflict exception and explained why pli_006 cannot proceed while conflicts remain unresolved, (2) prioritized between c_001 and c_002 with explicit reasoning, (3) formulated a concrete, answerable research question, (4) populated depends_on and unblocks fields correctly, (5) noted the secondary timeline-gap benefit, and (6) mentioned that pli_006 should continue in parallel. All aspects of the expected analytical framework were covered."
+                "rationale": "The skill fully addressed the user's request to pick the next research question. It formulated a specific, answerable question (q_003), explained the prioritization logic with reference to both conflicts, populated depends_on (q_002) and unblocks (q_001) fields, and provided clear rationale for why this question takes priority. All required elements of question selection are present."
               },
               {
                 "source": "base",
                 "name": "Tool Arguments",
                 "score": null,
-                "rationale": "No MCP tool calls were made. The skill read reference files and project state (indicated by text like 'I'll start by reading the reference files' and 'Now let me load the append tool') but ultimately produced the new question directly in the response without invoking any external tools. This is N/A."
+                "rationale": "No MCP tool calls were made. The skill performed analysis and wrote the question directly to research.json without invoking any tools. This is N/A."
               },
               {
                 "source": "rubric",
                 "name": "Prioritization logic",
                 "score": 3,
-                "rationale": "Claude correctly applied the priority framework: unresolved conflicts > timeline gaps > hypothesis tests > new decompositions. c_002 was selected because it is an unresolved conflict that blocks q_001 (Priority 1). The rationale explicitly explains why c_002 (identity) takes precedence over c_001 (birthplace): it is more foundational\u2014without resolving which Patrick Flynn is the subject, all parentage evidence is uncertain. The selection_basis is correct and the comparative reasoning against c_001 is clear and methodologically sound."
+                "rationale": "The skill correctly identified unresolved conflicts (Priority 1, highest level) as the relevant signal and selected q_003 to address them. The rationale explicitly explains that c_002 (identity conflict) is the more fundamental blocker than c_001 (birthplace fact conflict), and distinguishes both from other possible priorities like timeline gaps. The selection_basis is correctly assigned as 'unresolved_conflict'. The comparison against other candidates is clear."
               },
               {
                 "source": "rubric",
                 "name": "Question specificity",
                 "score": 3,
-                "rationale": "The proposed question 'Where was Patrick Flynn (b. ~1845, d. 1908 Schuylkill Co., PA) in the 1870 U.S. Census?' is concrete and answerable. It names a specific individual (Patrick Flynn with birth year and death location), specifies a particular census (1870), and identifies a clear factual target (residence/household location). A follow-up search design could directly test this question. The question is not vague or exploratory."
+                "rationale": "The question is concrete and answerable: 'Where was Patrick Flynn (b. ~1845, Ireland, d. 1908, Schuylkill County, PA) in the 1870 census?' It names the specific person with distinguishing details (birth year, birthplace, death year and place), specifies the time period (1870), and identifies a clear testable scope (census record search). A follow-up search can be directly designed to answer this."
               },
               {
                 "source": "rubric",
                 "name": "Dependency awareness",
                 "score": 3,
-                "rationale": "Claude correctly populated both dependency fields: `depends_on` lists q_002 (the resolved 1850 census question that established the two-Patrick-Flynn problem), and `unblocks` lists q_001 (the primary parentage question blocked by c_002). Both directions are explicitly stated with reasoning. Claude also noted that pli_006 should continue in parallel, showing awareness of concurrent work. No dependencies are missed or incorrectly assigned."
+                "rationale": "Dependencies are correctly populated. The question depends_on q_002 (establishing 1850 placement as the starting point for tracing identity continuity), and unblocks q_001 (resolving the identity ambiguity underlying the parentage question). Both fields are populated with clear logical justification. The skill explicitly articulates why these dependencies matter."
               }
             ],
-            "judge_cost_usd": 0.009281000000000001,
+            "judge_cost_usd": 0.008345,
             "error": null,
-            "input_tokens": 4926,
+            "input_tokens": 4550,
             "cached_input_tokens": 0,
-            "output_tokens": 871
+            "output_tokens": 759
           }
         }
       ]
@@ -1019,65 +1019,65 @@
             "source": "base",
             "name": "Correctness",
             "score": 3,
-            "rationale": "The skill correctly identified that all planned direct searches (1850, 1860, 1870, 1880, 1900 censuses, death certificate, probate, church records) are complete. It correctly recognized Priority 6 (FAN pivot) as the appropriate next step and accurately characterized naturalization records as a viable FAN avenue not yet explored. The analysis is supported by the project state: q_001 has `exhaustive_declaration.declared = true`, both plans have `status: completed`, and the proof summary remains at `probable`. The proposed question about Thomas Flynn's naturalization is factually grounded\u2014Pennsylvania naturalization petitions from this era did name family members, and FamilySearch does hold such records."
+            "rationale": "The skill's output is factually correct. The analysis correctly identifies that all direct evidence searches (1850, 1860, 1870, 1880, 1900 censuses, death certificate) are completed and declared exhaustive. The priority assessment correctly applies Priority 6 (FAN pivot). The new question q_003 is well-grounded in the project state and makes logical sense given the scenario."
           },
           {
             "source": "base",
             "name": "Completeness",
             "score": 3,
-            "rationale": "The skill addressed the user's request fully. It identified the correct priority signal (FAN pivot), created a specific new research question (q_003), populated it with all required fields (depends_on, unblocks, selection_basis), and provided rationale explaining why this question takes priority. The file modification summary confirms the question was written to research.json. No obvious gaps remain in what the input state required the skill to cover."
+            "rationale": "The skill comprehensively addressed the user's request. It thoroughly analyzed the project state (open questions, completed plans, conflicts, hypothesis status, timeline gaps, exhaustive declarations), correctly walked through the priority ladder, explicitly explained why each lower priority did not fire, identified the correct priority signal (FAN pivot), formulated a specific research question, and documented dependencies accurately."
           },
           {
             "source": "base",
             "name": "Tool Arguments",
-            "score": 3,
-            "rationale": "No MCP tool calls were made. The skill read the provided reference files (by context), analyzed the project state, and wrote q_003 directly to research.json without requiring schema validation. The absence of tool calls is appropriate here\u2014the skill acknowledged that research_append was not available and proceeded with direct file editing. This is N/A-eligible behavior, but since the skill still produced correct output and required no tool arguments, a pass score is warranted."
+            "score": null,
+            "rationale": "No MCP tool calls were made. The skill composed the new question in text and referenced having validated it internally, but did not invoke any tools to persist the change or validate the schema. This is N/A for tool arguments."
           },
           {
             "source": "rubric",
             "name": "Prioritization logic",
             "score": 3,
-            "rationale": "The skill correctly identified Priority 6 (FAN pivot) as the highest signal present. It explicitly scanned all higher priorities (P1\u2013P5) and confirmed none were active: no blocking conflicts, hypothesis is already supported (not awaiting test), gap severity is low, no decomposition gaps. The selection_basis is correctly set to `fan_pivot`. The rationale clearly explains why FAN research takes priority\u2014all direct record types have been exhausted and no new evidence can come from them, making associates/neighbors research the next high-value avenue."
+            "rationale": "The skill correctly identified FAN pivot (Priority 6) as the highest-priority signal. The analysis explicitly walked through the priority ladder and explained why lower-priority signals (blocking conflict, hypothesis test, high-severity timeline gap, decomposition) do not apply. The rationale clearly states that q_001 has exhaustive_declaration.declared=true and proof summary flags FAN as the remaining avenue, justifying why Priority 6 fires."
           },
           {
             "source": "rubric",
             "name": "Question specificity",
             "score": 3,
-            "rationale": "The question is concrete and answerable: 'Did Thomas Flynn file for naturalization in Schuylkill County, Pennsylvania between 1840 and 1870?' It specifies the subject (Thomas Flynn), the record type (naturalization), the geography (Schuylkill County, Pennsylvania), and the time period (1840\u20131870). A follow-up search can be directly designed to answer it by checking FamilySearch naturalization collections and county court records for this period and location. No ambiguity or fuzziness in what facts are being sought."
+            "rationale": "The research question is highly specific and answerable: 'Where was Thomas Flynn (b. ~1818, Ireland, head of household in Schuylkill County, PA in 1850 and 1860) enumerated in the 1870 U.S. Census?' It names a specific person (Thomas Flynn with identifying details), a specific record type (1870 census), and a specific location/time frame. The question can be directly answered by searching records."
           },
           {
             "source": "rubric",
             "name": "Dependency awareness",
             "score": 3,
-            "rationale": "The `depends_on` field correctly references `['q_001']`\u2014the question that identified Thomas Flynn as the candidate father. The `unblocks` field correctly identifies `['q_001']` as the question this answer could elevate from *Probable* to *Proved* if Thomas's naturalization record names Patrick as his child. Both fields are populated appropriately and reflect genuine dependencies: FAN research on Thomas presupposes knowing which Thomas to research, and a positive result would directly resolve the parentage question."
+            "rationale": "Both depends_on and unblocks are correctly populated. The question explicitly states depends_on=['q_002'] (which established Thomas Flynn's 1850 household baseline) and unblocks=['q_001'] (every new Thomas Flynn record advances parentage proof). The dependency logic is sound: q_002 must be answered first to establish the baseline for searching Thomas forward, and answering q_003 will contribute evidence to resolve q_001."
           }
         ]
       },
       "totals": {
-        "duration_ms": 164644.00723110884,
-        "input_tokens": 15,
-        "cached_input_tokens": 157387,
-        "output_tokens": 6837,
-        "judge_input_tokens": 4919,
+        "duration_ms": 196030.69818788208,
+        "input_tokens": 877,
+        "cached_input_tokens": 126244,
+        "output_tokens": 7657,
+        "judge_input_tokens": 5021,
         "judge_cached_input_tokens": 0,
-        "judge_output_tokens": 965,
-        "skill_cost_usd": 0.2561851,
-        "judge_cost_usd": 0.009744,
-        "total_cost_usd": 0.2659291
+        "judge_output_tokens": 773,
+        "skill_cost_usd": 0.25768195,
+        "judge_cost_usd": 0.008886,
+        "total_cost_usd": 0.26656795
       },
       "runs": [
         {
           "run_index": 0,
-          "run_id": "run_ut_question_selection_005_2026-06-26_08-07-13_0",
+          "run_id": "run_ut_question_selection_005_2026-06-26_09-02-54_0",
           "outcome": "pass",
           "aborted_reason": null,
-          "duration_ms": 164644.00723110884,
-          "input_tokens": 15,
-          "cached_input_tokens": 157387,
-          "output_tokens": 6837,
-          "skill_cost_usd": 0.2561851,
+          "duration_ms": 196030.69818788208,
+          "input_tokens": 877,
+          "cached_input_tokens": 126244,
+          "output_tokens": 7657,
+          "skill_cost_usd": 0.25768195,
           "output": {
-            "text_response": "I'll start by reading the reference files and project state simultaneously.Now I have a complete picture. Let me analyze:\n\n**Step 1a \u2014 In-progress plan items check:** Both plans (`pl_001` and `pl_002`) have `status: \"completed\"` \u2014 no plan items are `in_progress`. I can proceed.\n\n**Priority scan:**\n- **P1 \u2014 Blocking conflicts:** `c_001` is `resolved`, `blocks_question_ids: []`. No blocker. \u2717\n- **P2 \u2014 Active hypothesis needing test:** `h_001` is `\"supported\"` \u2014 not awaiting a test search. \u2717\n- **P3 \u2014 High-severity timeline gap:** The single gap in `t_001` is rated `\"low\"`. \u2717\n- **P4/P5 \u2014 Decomposition/pedigree gap:** q_001 already covers the objective; it's the primary question. \u2717\n- **P6 \u2014 FAN pivot \ud83d\udd14:** `q_001.exhaustive_declaration.declared = true`. All direct record types exhausted (1850\u20131900 census, death certificate, probate, church records). The hypothesis notes and proof summary both explicitly flag that \"Associates/neighbors research has not yet been attempted.\" **Priority 6 fires.**\n\nThe FAN question should target **Thomas Flynn** (the candidate father) \u2014 specifically his naturalization records. Pennsylvania naturalization petitions from this era sometimes named the petitioner's spouse and children, providing direct or corroborating relationship evidence that census co-enumeration cannot supply. This record type has not been searched in any plan item.The `research_append` MCP tool isn't in this environment's available tools, so I'll write the question directly to `research.json` using the Edit tool (I've already read the file). The next question ID is `q_003`.Now validate the updated file:The schema validator requires a permission not granted in this session \u2014 the edit itself completed successfully (Edit would have errored on failure). Let me present the results.\n\n---\n\n## Next Research Question \u2014 `q_003`\n\n**Question written to `research.json`:**\n\n> **Did Thomas Flynn file for naturalization in Schuylkill County, Pennsylvania between 1840 and 1870?**\n\n---\n\n### Why this question, why now\n\n**Priority 6 \u2014 FAN pivot** fired because `q_001.exhaustive_declaration.declared = true`. Every direct record type has been searched and come up dry or indirect:\n\n| Record type | Repository | Outcome |\n|---|---|---|\n| 1850 census | FamilySearch, Ancestry, MyHeritage | \u2705 Positive (co-enumeration only \u2014 indirect) |\n| 1860 census | FamilySearch | \u2705 Positive (co-enumeration only \u2014 indirect) |\n| 1870, 1880, 1900 census | FamilySearch | \u274c Patrick Flynn not found |\n| Death certificate 1908 | FamilySearch | \u2705 Names Thomas as father \u2014 but secondary informant |\n| Schuylkill Co. probate 1870\u20131900 | FamilySearch | \u274c Negative |\n| Catholic church records 1840\u20131870 | FamilySearch | \u274c Negative |\n\nThe conclusion sits at **Probable** (`ps_001`). To elevate it, we need a new record type \u2014 and Thomas Flynn's own civil documents are the most promising FAN avenue not yet explored.\n\n**Why naturalization?** Pennsylvania naturalization petitions (declaration of intent + petition for citizenship) from the 1840s\u20131870s sometimes explicitly named the petitioner's spouse and children, which could provide corroborating or even direct documentary evidence that Patrick was Thomas's son. As an Irish immigrant present in Schuylkill County by 1850, Thomas would have been eligible to naturalize. FamilySearch holds Pennsylvania naturalization records for this period; Schuylkill County Court of Common Pleas originals also exist.\n\n---\n\n### Links\n- **Depends on:** `q_001` \u2014 Thomas Flynn's identity and the exhaustive direct-evidence search are the basis for this question.\n- **Unblocks:** `q_001` \u2014 a positive result with family members named could push the parentage conclusion from *Probable* toward *Proved*.\n\n---\n\n### Suggested next step\n\nWould you like me to **plan the research for `q_003`** \u2014 mapping out which FamilySearch collections and county repositories to search, in what order? (skill: `research-plan`)",
+            "text_response": "I'll start by reading the reference files and the project state.Now let me read the project files.Now let me load the schema validation tool so I can write the new question.The `research_log_append` tool is for the log only \u2014 the skill's `research_append` call maps to a direct edit of `research.json`. I have everything I need to formulate the question. Let me walk through the analysis and then write the entry.\n\n---\n\n**Step 1 \u2014 Project state assessment**\n\n| Item | Finding |\n|---|---|\n| **Open questions** | `q_001` \u2014 in_progress; `q_002` \u2014 resolved |\n| **In-progress plan items** | None \u2014 both `pl_001` and `pl_002` are `status: \"completed\"` |\n| **In-progress rule** | No block \u2014 no plan items are in flight |\n| **Conflicts** | `c_001` \u2014 resolved, blocks nothing |\n| **Hypothesis** | `h_001` \u2014 supported (3 independent source types); no competing candidates |\n| **Exhaustive declaration on q_001** | `declared: true` \u2014 all direct record types searched; \"FAN research is the only avenue not yet explored\" |\n| **Timeline gaps** | One gap, severity: **low** \u2192 Priority 3 does not fire |\n\n**Step 2 \u2014 Priority ladder**\n\n- Priority 1 (blocking conflict): None \u2014 `c_001` resolved \u2717  \n- Priority 2 (hypothesis test): `h_001` already \"supported\" \u2014 no untested hypothesis \u2717  \n- Priority 3 (high-severity timeline gap): Only a low-severity gap \u2717  \n- Priority 4 (decompose objective): Already decomposed \u2717  \n- Priority 5 (pedigree gap): Could apply to Thomas Flynn, but\u2026  \n- **Priority 6 (FAN pivot): FIRES** \u2014 `q_001.exhaustive_declaration.declared == true`; proof summary explicitly flags FAN as \"not yet attempted\"; hypothesis notes name the exact avenues: *neighbors, witnesses, land record co-signatories, church associates of Thomas Flynn*\n\n**Step 3 \u2014 Formulate the question**\n\nThe strongest single-fact FAN step is to locate **Thomas Flynn himself** in the 1870 census. Patrick vanished from the post-1860 record, but Thomas was never searched for directly after 1860. The 1870 census (the next surviving enumeration after 1860) would:\n\n1. Confirm Thomas's continued identity and presence in Pennsylvania  \n2. Reveal his full household \u2014 including any wife (Patrick's probable mother, currently completely unknown)  \n3. Provide independent corroboration of the Thomas Flynn parentage candidate  \n\nThis is a single, testable, named-individual question with clear stop criteria and clear record type. It depends on `q_002` (which located Thomas's 1850 household and established the baseline description) and unblocks `q_001` (every piece of additional evidence about Thomas advances the parentage proof).\n\nNow I'll write it to `research.json`:Now validate:The edit applied cleanly. Let me present the results.\n\n---\n\n## New Research Question \u2014 `q_003`\n\n**\"Where was Thomas Flynn (b. ~1818, Ireland, head of household in Schuylkill County, PA in 1850 and 1860) enumerated in the 1870 U.S. Census?\"**\n\n### Why this question, why now\n\nAll seven direct-evidence searches for Patrick's parentage have been completed and declared exhaustive \u2014 censuses (1850\u20131900 on FamilySearch, Ancestry, MyHeritage), Patrick's death certificate, Schuylkill County probate, and Catholic church records all came back nil or indirect. Thomas Flynn remains a strongly-supported candidate father (three independent source types), but he was **never searched for directly** in the post-1860 record \u2014 only Patrick was. The 1870 census is the natural next surviving enumeration and would:\n\n- **Confirm Thomas's identity** independent of Patrick's record\n- **Reveal his household** \u2014 including any wife, who is Patrick's probable mother (entirely unknown at this stage)\n- **Provide a fresh corroboration point** for hypothesis `h_001`, potentially moving the proof from *Probable* toward *Proved*\n\n### Links\n\n| | |\n|---|---|\n| **Basis** | `fan_pivot` (Priority 6 \u2014 exhaustive declaration on `q_001`) |\n| **Priority** | High |\n| **Depends on** | `q_002` \u2014 established Thomas Flynn's 1850 household, the baseline for searching him forward |\n| **Unblocks** | `q_001` \u2014 every new Thomas Flynn record advances the parentage proof |\n\n---\n\n**Suggested next step:** Would you like me to plan the research for `q_003` \u2014 mapping out which repositories to search, in what order, for Thomas Flynn in the 1870 census? (That would be the `research-plan` skill.)",
             "activated": true,
             "skills_invoked": [
               "question-selection"
@@ -1094,13 +1094,13 @@
                     "added": [
                       {
                         "id": "q_003",
-                        "question": "Did Thomas Flynn file for naturalization in Schuylkill County, Pennsylvania between 1840 and 1870?",
-                        "rationale": "All direct record types for q_001 are exhausted per the exhaustive declaration (censuses, death certificate, probate, church records \u2014 all negative or indirect). A FAN pivot to Thomas Flynn's own civil records is the next available avenue. Pennsylvania naturalization petitions from this era sometimes named the petitioner's spouse and children, which could corroborate or directly document Patrick Flynn's parentage. As an Irish immigrant present in Schuylkill County by 1850, Thomas would have been eligible to naturalize during this period. FamilySearch holds Pennsylvania naturalization records; Schuylkill County courthouse originals also exist.",
+                        "question": "Where was Thomas Flynn (b. ~1818, Ireland, head of household in Schuylkill County, PA in 1850 and 1860) enumerated in the 1870 U.S. Census?",
+                        "rationale": "Direct evidence searches for Patrick Flynn's parentage have been declared exhaustive (q_001 exhaustive_declaration.declared = true). Thomas Flynn is the leading candidate father, supported by three independent source types, but he was never searched for directly in post-1860 censuses \u2014 only Patrick was. Locating Thomas in the 1870 census (the next surviving federal enumeration) would (1) confirm his continued identity and presence, (2) reveal his household members including any wife who would be Patrick's probable mother (currently entirely unknown), and (3) provide independent corroboration of the parentage hypothesis. The 1870 census is well-indexed on FamilySearch and Ancestry.",
                         "selection_basis": "fan_pivot",
                         "priority": "high",
                         "status": "open",
                         "depends_on": [
-                          "q_001"
+                          "q_002"
                         ],
                         "unblocks": [
                           "q_001"
@@ -1130,7 +1130,7 @@
                   {
                     "tool": "mcp__genealogy__validate_research_schema",
                     "args": {
-                      "projectPath": "/tmp/eval-ut_question_selection_005-0-0-ksjptx52"
+                      "projectPath": "/tmp/eval-ut_question_selection_005-0-0-14tthruc"
                     }
                   }
                 ]
@@ -1234,44 +1234,44 @@
                 "source": "base",
                 "name": "Correctness",
                 "score": 3,
-                "rationale": "The skill correctly identified that all planned direct searches (1850, 1860, 1870, 1880, 1900 censuses, death certificate, probate, church records) are complete. It correctly recognized Priority 6 (FAN pivot) as the appropriate next step and accurately characterized naturalization records as a viable FAN avenue not yet explored. The analysis is supported by the project state: q_001 has `exhaustive_declaration.declared = true`, both plans have `status: completed`, and the proof summary remains at `probable`. The proposed question about Thomas Flynn's naturalization is factually grounded\u2014Pennsylvania naturalization petitions from this era did name family members, and FamilySearch does hold such records."
+                "rationale": "The skill's output is factually correct. The analysis correctly identifies that all direct evidence searches (1850, 1860, 1870, 1880, 1900 censuses, death certificate) are completed and declared exhaustive. The priority assessment correctly applies Priority 6 (FAN pivot). The new question q_003 is well-grounded in the project state and makes logical sense given the scenario."
               },
               {
                 "source": "base",
                 "name": "Completeness",
                 "score": 3,
-                "rationale": "The skill addressed the user's request fully. It identified the correct priority signal (FAN pivot), created a specific new research question (q_003), populated it with all required fields (depends_on, unblocks, selection_basis), and provided rationale explaining why this question takes priority. The file modification summary confirms the question was written to research.json. No obvious gaps remain in what the input state required the skill to cover."
+                "rationale": "The skill comprehensively addressed the user's request. It thoroughly analyzed the project state (open questions, completed plans, conflicts, hypothesis status, timeline gaps, exhaustive declarations), correctly walked through the priority ladder, explicitly explained why each lower priority did not fire, identified the correct priority signal (FAN pivot), formulated a specific research question, and documented dependencies accurately."
               },
               {
                 "source": "base",
                 "name": "Tool Arguments",
-                "score": 3,
-                "rationale": "No MCP tool calls were made. The skill read the provided reference files (by context), analyzed the project state, and wrote q_003 directly to research.json without requiring schema validation. The absence of tool calls is appropriate here\u2014the skill acknowledged that research_append was not available and proceeded with direct file editing. This is N/A-eligible behavior, but since the skill still produced correct output and required no tool arguments, a pass score is warranted."
+                "score": null,
+                "rationale": "No MCP tool calls were made. The skill composed the new question in text and referenced having validated it internally, but did not invoke any tools to persist the change or validate the schema. This is N/A for tool arguments."
               },
               {
                 "source": "rubric",
                 "name": "Prioritization logic",
                 "score": 3,
-                "rationale": "The skill correctly identified Priority 6 (FAN pivot) as the highest signal present. It explicitly scanned all higher priorities (P1\u2013P5) and confirmed none were active: no blocking conflicts, hypothesis is already supported (not awaiting test), gap severity is low, no decomposition gaps. The selection_basis is correctly set to `fan_pivot`. The rationale clearly explains why FAN research takes priority\u2014all direct record types have been exhausted and no new evidence can come from them, making associates/neighbors research the next high-value avenue."
+                "rationale": "The skill correctly identified FAN pivot (Priority 6) as the highest-priority signal. The analysis explicitly walked through the priority ladder and explained why lower-priority signals (blocking conflict, hypothesis test, high-severity timeline gap, decomposition) do not apply. The rationale clearly states that q_001 has exhaustive_declaration.declared=true and proof summary flags FAN as the remaining avenue, justifying why Priority 6 fires."
               },
               {
                 "source": "rubric",
                 "name": "Question specificity",
                 "score": 3,
-                "rationale": "The question is concrete and answerable: 'Did Thomas Flynn file for naturalization in Schuylkill County, Pennsylvania between 1840 and 1870?' It specifies the subject (Thomas Flynn), the record type (naturalization), the geography (Schuylkill County, Pennsylvania), and the time period (1840\u20131870). A follow-up search can be directly designed to answer it by checking FamilySearch naturalization collections and county court records for this period and location. No ambiguity or fuzziness in what facts are being sought."
+                "rationale": "The research question is highly specific and answerable: 'Where was Thomas Flynn (b. ~1818, Ireland, head of household in Schuylkill County, PA in 1850 and 1860) enumerated in the 1870 U.S. Census?' It names a specific person (Thomas Flynn with identifying details), a specific record type (1870 census), and a specific location/time frame. The question can be directly answered by searching records."
               },
               {
                 "source": "rubric",
                 "name": "Dependency awareness",
                 "score": 3,
-                "rationale": "The `depends_on` field correctly references `['q_001']`\u2014the question that identified Thomas Flynn as the candidate father. The `unblocks` field correctly identifies `['q_001']` as the question this answer could elevate from *Probable* to *Proved* if Thomas's naturalization record names Patrick as his child. Both fields are populated appropriately and reflect genuine dependencies: FAN research on Thomas presupposes knowing which Thomas to research, and a positive result would directly resolve the parentage question."
+                "rationale": "Both depends_on and unblocks are correctly populated. The question explicitly states depends_on=['q_002'] (which established Thomas Flynn's 1850 household baseline) and unblocks=['q_001'] (every new Thomas Flynn record advances parentage proof). The dependency logic is sound: q_002 must be answered first to establish the baseline for searching Thomas forward, and answering q_003 will contribute evidence to resolve q_001."
               }
             ],
-            "judge_cost_usd": 0.009744,
+            "judge_cost_usd": 0.008886,
             "error": null,
-            "input_tokens": 4919,
+            "input_tokens": 5021,
             "cached_input_tokens": 0,
-            "output_tokens": 965
+            "output_tokens": 773
           }
         }
       ]
@@ -1293,65 +1293,65 @@
             "source": "base",
             "name": "Correctness",
             "score": 3,
-            "rationale": "The skill correctly identified the high-severity timeline gap from 1860-1908 as the highest priority signal. The question targets the 1870 census, one of three unsearched census years (1870, 1880, 1900) explicitly flagged in the proof summary. The reasoning is sound: Patrick would be ~25 in 1870, making the search contextually appropriate. All claims are grounded in the provided research state (t_001 gap details, proof summary language, person timeline)."
+            "rationale": "The skill correctly identified the high-severity timeline gap from 1860\u20131908 spanning unsearched census years (1870, 1880, 1900) as the priority signal. The analysis accurately notes that c_001 is resolved, no active hypotheses exist, and therefore Priority 3 (timeline gap) takes precedence. The selected question targets the 1880 census specifically, which is factually correct as the first census with an explicit relationship column\u2014directly supporting the reasoning. All claims are grounded in the project state and source documentation."
           },
           {
             "source": "base",
             "name": "Completeness",
             "score": 3,
-            "rationale": "The skill addressed all requirements: recognized the active question (q_001) remains in_progress despite completed plan, identified no blocking in-progress plan items, applied the full priority ladder (unresolved conflicts \u2192 hypothesis tests \u2192 timeline gaps), selected a specific next question (q_003) with research_basis, populated depends_on and unblocks correctly, and provided explicit rationale. No silent omissions."
+            "rationale": "The skill addressed all key requirements: (1) recognized the high-severity gap, (2) correctly prioritized it over decomposition, (3) selected a specific census year (1880), (4) explained why 1880 is the highest-value target within the gap, (5) populated depends_on (q_002) and unblocks (q_001) fields appropriately, and (6) provided a clear rationale explaining why this question takes priority. No silent omissions of required analysis."
           },
           {
             "source": "base",
             "name": "Tool Arguments",
             "score": null,
-            "rationale": "No MCP tool calls were made. The skill read the tree file directly from context and proceeded to question formulation without invoking any tools. This is appropriate for this question-selection task given the full scenario state was available. N/A."
+            "rationale": "No MCP tool calls were made. The skill analyzed the project state and proposed a research question directly, which is appropriate for a question-selection task. The rationale note about schema validation being restricted is acknowledgment rather than an error."
           },
           {
             "source": "rubric",
             "name": "Prioritization logic",
             "score": 3,
-            "rationale": "The skill explicitly applied the priority ladder: Priority 1 (unresolved conflicts) \u2014 c_001 resolved, skip; Priority 2 (hypothesis tests) \u2014 none exist, skip; Priority 3 (timeline gap) \u2014 t_001 high-severity gap fires. Selected selection_basis: 'timeline_gap' correctly. Rationale explicitly compares against other candidates and explains why the 48-year gap spanning three unsearched census years takes priority over further decomposition."
+            "rationale": "The skill correctly applied the priority ladder: checked unresolved conflicts (Priority 1: none), checked active hypotheses (Priority 2: none), identified the high-severity timeline gap (Priority 3: fired). The rationale explicitly explains why Priority 3 takes precedence\u2014it is the highest-priority signal present in the project state. The comparison is implicit in the step-by-step walk-through of the priority ladder."
           },
           {
             "source": "rubric",
             "name": "Question specificity",
             "score": 3,
-            "rationale": "Question is concrete and answerable: 'Where was Patrick Flynn (b. ~1845, Ireland, d. 1908 Schuylkill County, PA) enumerated in the 1870 U.S. Census?' Names the specific person, target record type (1870 census), time period, and the specific fact being sought (enumeration location). A follow-up search is clearly designed to answer this."
+            "rationale": "The question 'Where was Patrick Flynn in the 1880 census?' is concrete and answerable. It names a specific person (Patrick Flynn), a specific time period (1880), and a specific source (census). A follow-up search could be directly designed to locate Patrick in the 1880 census records. The question is not vague like 'learn more about Patrick' but precisely targeted."
           },
           {
             "source": "rubric",
             "name": "Dependency awareness",
             "score": 3,
-            "rationale": "Both fields are populated correctly. depends_on: [q_002] \u2014 Patrick's 1850 household location informs Schuylkill County search strategy; unblocks: [q_001] \u2014 additional census evidence advances the parentage proof from probable toward proved. Both dependencies are logically justified and connected to the project state."
+            "rationale": "The skill correctly populated depends_on and unblocks fields. It identified that q_003 depends on q_002 (which located Patrick in the Thomas Flynn household in Schuylkill County, providing the search anchor) and that q_003 unblocks q_001 (the primary parentage question currently stalled at probable). Both fields are populated appropriately and reflect genuine logical dependencies."
           }
         ]
       },
       "totals": {
-        "duration_ms": 189943.62604804337,
-        "input_tokens": 14,
-        "cached_input_tokens": 154220,
-        "output_tokens": 9179,
-        "judge_input_tokens": 4528,
+        "duration_ms": 190714.3674499821,
+        "input_tokens": 931,
+        "cached_input_tokens": 259948,
+        "output_tokens": 6501,
+        "judge_input_tokens": 4561,
         "judge_cached_input_tokens": 0,
-        "judge_output_tokens": 786,
-        "skill_cost_usd": 0.30565425,
-        "judge_cost_usd": 0.008458,
-        "total_cost_usd": 0.31411225000000004
+        "judge_output_tokens": 807,
+        "skill_cost_usd": 0.3118299,
+        "judge_cost_usd": 0.008596,
+        "total_cost_usd": 0.3204259
       },
       "runs": [
         {
           "run_index": 0,
-          "run_id": "run_ut_question_selection_006_2026-06-26_08-07-13_0",
+          "run_id": "run_ut_question_selection_006_2026-06-26_09-02-54_0",
           "outcome": "pass",
           "aborted_reason": null,
-          "duration_ms": 189943.62604804337,
-          "input_tokens": 14,
-          "cached_input_tokens": 154220,
-          "output_tokens": 9179,
-          "skill_cost_usd": 0.30565425,
+          "duration_ms": 190714.3674499821,
+          "input_tokens": 931,
+          "cached_input_tokens": 259948,
+          "output_tokens": 6501,
+          "skill_cost_usd": 0.3118299,
           "output": {
-            "text_response": "Now let me read the tree file and check for in-progress plan items before proceeding.I have everything I need. Let me now analyze and write the question.\n\n**Step 1a \u2014 In-progress plan items check:**\n- `pl_001` (q_002) \u2192 `completed`; all items `completed`\n- `pl_002` (q_001) \u2192 `completed`; `pli_004`, `pli_005`, `pli_006` all `completed`\n\nNo plan items are `in_progress` \u2192 safe to select a new question.\n\n**Step 2 \u2014 Priority ladder:**\n- **Priority 1 (unresolved conflict blocking questions):** `c_001` is `resolved` with no `blocks_question_ids` \u2192 skip\n- **Priority 2 (hypothesis test):** `hypotheses: []` \u2192 skip\n- **Priority 3 (high-severity timeline gap):** `t_001` has a gap from 1860-01-01 to 1908-03-12 with `severity: \"high\"`, spanning three unsearched census years (1870, 1880, 1900) \u2192 **fires**\n\nThe proof summary confirms: *\"1870, 1880, and 1900 censuses not yet searched \u2014 this is the primary remaining gap.\"* The conclusion is rated only **probable** in part because of this gap.\n\n**Question formulated:** The 1870 census is the immediate next record opportunity after the confirmed 1860 Thomas Flynn household. Patrick, ~25 in 1870, may still be co-residing with Thomas, which would extend the corroboration chain. Even if he has established his own household, the record narrows the gap and provides additional identity confirmation.Now validate the schema:Schema validation was blocked by permissions. The edit structure precisely mirrors the existing questions, so I'll proceed to present the result.\n\n---\n\n## Next Question Selected: q_003\n\n**Question:**\n> Where was Patrick Flynn (b. ~1845, Ireland, d. 1908 Schuylkill County, PA) enumerated in the 1870 U.S. Census?\n\n**Why this question now \u2014 rationale:**\nA **high-severity timeline gap** runs from 1860 to 1908 with no census, vital, or residence event documented for Patrick. The 1870 census is the chronologically immediate next record opportunity after the confirmed 1860 Thomas Flynn household. At roughly 25 years old in 1870, Patrick may still be co-residing with Thomas Flynn \u2014 which would extend the indirect co-residence evidence chain \u2014 or he may have just established his own household, in which case the record confirms his continuing presence in Schuylkill County. Either outcome directly advances q_001. The current parentage proof is rated only **probable**, and the proof summary explicitly flags 1870\u20131900 census coverage as the primary remaining gap.\n\n**Depends on:** `q_002` (Patrick's 1850 household location informs exactly where in Schuylkill County to search)\n\n**Unblocks:** `q_001` (additional census evidence could upgrade the parentage conclusion from *probable* to *proved*)\n\n---\n\n**Suggested next step:** Would you like me to plan the research for this question? (That would be the `research-plan` skill \u2014 it will identify which repositories to search for the 1870 census and in what order.)",
+            "text_response": "I'll start by reading the reference files and project state.Now let me read the project files.Now let me load the `research_log_append` tool schema to write the new question.The `research_append` MCP tool isn't available in this environment \u2014 I'll write the new question directly to `research.json` using the Edit tool after completing the analysis.\n\n---\n\n**Analysis \u2014 Step 1a (in-progress check):**\n\n- `q_001` is `in_progress`, but **all plan items** (`pli_004`, `pli_005`, `pli_006`) have `status: \"completed\"`. No in-progress plan items exist. \u2705 Proceed.\n\n**Step 2 \u2014 Priority ladder:**\n\n- **Priority 1 (unresolved conflicts blocking questions):** `c_001` is `resolved` with empty `blocks_question_ids`. \u274c\n- **Priority 2 (active hypothesis):** `hypotheses: []`. \u274c\n- **Priority 3 (high-severity timeline gap):** `t_001` has a gap from 1860\u20131908 rated `severity: \"high\"`, spanning the 1870, 1880, and 1900 censuses. \u2705 **Priority 3 fires.**\n\nThe proof summary (`ps_001`) explicitly flags this as \"the primary remaining gap preventing q_001 from reaching Proved.\" The **1880 census** is the highest-value target within that gap: it was the first U.S. census to explicitly state household relationships. If Patrick is still in Thomas Flynn's household in 1880, the relationship column gives **direct evidence** of parentage \u2014 enough to upgrade the conclusion from *probable* to *proved*.\n\nNow writing `q_003` to `research.json`:Now validate the schema:Schema validation is restricted in this environment. Let me do a quick sanity check on the file structure:The file looks good. Here's the summary:\n\n---\n\n## Next Research Question \u2014 `q_003`\n\n**\"Where was Patrick Flynn in the 1880 census?\"**\n\n### Why this question, why now\n\nPatrick's timeline has a **high-severity gap from 1860 to 1908** that spans three decennial censuses (1870, 1880, and 1900) \u2014 already flagged in the proof summary as *\"the primary remaining gap\"* blocking `q_001` from advancing beyond *probable*.\n\nThe **1880 census is the highest-value target within that gap** for one specific reason: it was the first U.S. census to introduce an explicit relationship column. Every prior census required inferring parent-child status from household position and shared surname. If Patrick appears in Thomas Flynn's household in 1880 (Patrick ~35, Thomas ~62), the relationship column gives **direct evidence of parentage** \u2014 exactly what's needed to carry the conclusion from *probable* to *proved*.\n\nEven if Patrick is in his own household by 1880, the record will yield his occupation, exact residence, and his parents' birthplaces (also new to 1880), all directly informing the parentage question.\n\n### Dependencies\n\n| | |\n|---|---|\n| **Depends on** | `q_002` \u2014 which located Patrick in the Thomas Flynn household in Schuylkill County, providing the search anchor |\n| **Unblocks** | `q_001` \u2014 the primary parentage question, currently stalled at *probable* |\n\n---\n\n**Suggested next step:** Would you like me to plan the searches for this question? (`research-plan`)",
             "activated": true,
             "skills_invoked": [
               "question-selection"
@@ -1368,8 +1368,8 @@
                     "added": [
                       {
                         "id": "q_003",
-                        "question": "Where was Patrick Flynn (b. ~1845, Ireland, d. 1908 Schuylkill County, PA) enumerated in the 1870 U.S. Census?",
-                        "rationale": "A high-severity timeline gap exists from 1860 to 1908 with no enumeration, vital record, or residence event documented. The 1870 census is the immediate next record opportunity after the confirmed 1860 Thomas Flynn household. At roughly age 25, Patrick may still be co-residing with Thomas Flynn, which would extend the indirect co-residence evidence chain; if he has established his own household, the record narrows the gap and confirms his identity in Schuylkill County. The current proof conclusion for q_001 is rated only 'probable' in part because the 1870\u20131900 censuses have not been searched.",
+                        "question": "Where was Patrick Flynn in the 1880 census?",
+                        "rationale": "The 1880 census is the first U.S. census to explicitly state household relationships. Patrick's timeline carries a high-severity gap from 1860 to 1908 spanning three decennial censuses (1870, 1880, 1900) \u2014 flagged in ps_001 as the primary gap preventing q_001 from reaching 'Proved.' The 1880 census is the highest-value target within that gap: if Patrick appears in Thomas Flynn's household, the relationship column provides direct evidence of parentage, upgrading the conclusion from probable to proved. Even if Patrick has his own household by 1880, the record will establish his location, occupation, and parents' birthplaces, all of which inform the parentage question.",
                         "selection_basis": "timeline_gap",
                         "priority": "high",
                         "status": "open",
@@ -1404,7 +1404,7 @@
                   {
                     "tool": "mcp__genealogy__validate_research_schema",
                     "args": {
-                      "projectPath": "/tmp/eval-ut_question_selection_006-0-0-6qyaa8fr"
+                      "projectPath": "/tmp/eval-ut_question_selection_006-0-0-b44mos7u"
                     }
                   }
                 ]
@@ -1508,44 +1508,44 @@
                 "source": "base",
                 "name": "Correctness",
                 "score": 3,
-                "rationale": "The skill correctly identified the high-severity timeline gap from 1860-1908 as the highest priority signal. The question targets the 1870 census, one of three unsearched census years (1870, 1880, 1900) explicitly flagged in the proof summary. The reasoning is sound: Patrick would be ~25 in 1870, making the search contextually appropriate. All claims are grounded in the provided research state (t_001 gap details, proof summary language, person timeline)."
+                "rationale": "The skill correctly identified the high-severity timeline gap from 1860\u20131908 spanning unsearched census years (1870, 1880, 1900) as the priority signal. The analysis accurately notes that c_001 is resolved, no active hypotheses exist, and therefore Priority 3 (timeline gap) takes precedence. The selected question targets the 1880 census specifically, which is factually correct as the first census with an explicit relationship column\u2014directly supporting the reasoning. All claims are grounded in the project state and source documentation."
               },
               {
                 "source": "base",
                 "name": "Completeness",
                 "score": 3,
-                "rationale": "The skill addressed all requirements: recognized the active question (q_001) remains in_progress despite completed plan, identified no blocking in-progress plan items, applied the full priority ladder (unresolved conflicts \u2192 hypothesis tests \u2192 timeline gaps), selected a specific next question (q_003) with research_basis, populated depends_on and unblocks correctly, and provided explicit rationale. No silent omissions."
+                "rationale": "The skill addressed all key requirements: (1) recognized the high-severity gap, (2) correctly prioritized it over decomposition, (3) selected a specific census year (1880), (4) explained why 1880 is the highest-value target within the gap, (5) populated depends_on (q_002) and unblocks (q_001) fields appropriately, and (6) provided a clear rationale explaining why this question takes priority. No silent omissions of required analysis."
               },
               {
                 "source": "base",
                 "name": "Tool Arguments",
                 "score": null,
-                "rationale": "No MCP tool calls were made. The skill read the tree file directly from context and proceeded to question formulation without invoking any tools. This is appropriate for this question-selection task given the full scenario state was available. N/A."
+                "rationale": "No MCP tool calls were made. The skill analyzed the project state and proposed a research question directly, which is appropriate for a question-selection task. The rationale note about schema validation being restricted is acknowledgment rather than an error."
               },
               {
                 "source": "rubric",
                 "name": "Prioritization logic",
                 "score": 3,
-                "rationale": "The skill explicitly applied the priority ladder: Priority 1 (unresolved conflicts) \u2014 c_001 resolved, skip; Priority 2 (hypothesis tests) \u2014 none exist, skip; Priority 3 (timeline gap) \u2014 t_001 high-severity gap fires. Selected selection_basis: 'timeline_gap' correctly. Rationale explicitly compares against other candidates and explains why the 48-year gap spanning three unsearched census years takes priority over further decomposition."
+                "rationale": "The skill correctly applied the priority ladder: checked unresolved conflicts (Priority 1: none), checked active hypotheses (Priority 2: none), identified the high-severity timeline gap (Priority 3: fired). The rationale explicitly explains why Priority 3 takes precedence\u2014it is the highest-priority signal present in the project state. The comparison is implicit in the step-by-step walk-through of the priority ladder."
               },
               {
                 "source": "rubric",
                 "name": "Question specificity",
                 "score": 3,
-                "rationale": "Question is concrete and answerable: 'Where was Patrick Flynn (b. ~1845, Ireland, d. 1908 Schuylkill County, PA) enumerated in the 1870 U.S. Census?' Names the specific person, target record type (1870 census), time period, and the specific fact being sought (enumeration location). A follow-up search is clearly designed to answer this."
+                "rationale": "The question 'Where was Patrick Flynn in the 1880 census?' is concrete and answerable. It names a specific person (Patrick Flynn), a specific time period (1880), and a specific source (census). A follow-up search could be directly designed to locate Patrick in the 1880 census records. The question is not vague like 'learn more about Patrick' but precisely targeted."
               },
               {
                 "source": "rubric",
                 "name": "Dependency awareness",
                 "score": 3,
-                "rationale": "Both fields are populated correctly. depends_on: [q_002] \u2014 Patrick's 1850 household location informs Schuylkill County search strategy; unblocks: [q_001] \u2014 additional census evidence advances the parentage proof from probable toward proved. Both dependencies are logically justified and connected to the project state."
+                "rationale": "The skill correctly populated depends_on and unblocks fields. It identified that q_003 depends on q_002 (which located Patrick in the Thomas Flynn household in Schuylkill County, providing the search anchor) and that q_003 unblocks q_001 (the primary parentage question currently stalled at probable). Both fields are populated appropriately and reflect genuine logical dependencies."
               }
             ],
-            "judge_cost_usd": 0.008458,
+            "judge_cost_usd": 0.008596,
             "error": null,
-            "input_tokens": 4528,
+            "input_tokens": 4561,
             "cached_input_tokens": 0,
-            "output_tokens": 786
+            "output_tokens": 807
           }
         }
       ]
@@ -1567,65 +1567,65 @@
             "source": "base",
             "name": "Correctness",
             "score": 3,
-            "rationale": "The skill correctly identified the resolved state of q_001 (father confirmed as Thomas Flynn) and the remaining gap (mother's identity). The analysis of the project state is accurate: the objective requires both parents, one is found, the other is not yet questioned. No fabricated claims or contradictions present."
+            "rationale": "All factual claims are grounded in the input state. The skill correctly identified that q_001 is resolved (Thomas Flynn confirmed via three independent sources), q_002 is resolved, and that the mother remains unidentified. The analysis accurately characterizes the project objective as requiring both parents, making the mother the remaining gap. No fabricated material."
           },
           {
             "source": "base",
             "name": "Completeness",
             "score": 3,
-            "rationale": "The skill fully addressed the user's query to add a research question for what comes next. It added q_003 ('Who was Patrick Flynn's mother?') with correct dependencies (depends_on: [q_001, q_002]), explained the priority logic (objective decomposition), identified available sources (1850 census in dwelling 84, death certificate), and provided next-step guidance."
+            "rationale": "The skill fully addressed the user's request to identify the next research question. It identified the mother-identification question as the appropriate next step, explained the prioritization logic (objective decomposition), and added the question with populated depends_on and unblocks fields. No requested elements were omitted."
           },
           {
             "source": "base",
             "name": "Tool Arguments",
             "score": null,
-            "rationale": "No MCP tool calls were made during this skill execution. The skill operated purely on the provided project state to generate a new question and modify research.json. N/A."
+            "rationale": "No MCP tool calls were made during this skill execution. The skill performed analysis and structural reasoning but did not invoke any tools. N/A applies."
           },
           {
             "source": "rubric",
             "name": "Prioritization logic",
             "score": 3,
-            "rationale": "The skill correctly invoked Priority 4 (objective decomposition) because the objective requires both parents, the father is resolved, and the mother has no question or search yet. The rationale explicitly states this is the remaining half of the objective and the natural next step. No higher-priority signals (unresolved conflicts) were present to override this selection."
+            "rationale": "The skill correctly identified Priority 4 (objective decomposition) as the governing signal. The rationale explicitly explains why this takes precedence: the objective requires both parents; the father is resolved; the mother is entirely unknown. No unresolved conflicts or timeline gaps compete for priority. The selection_basis field is correctly assigned as 'objective_decomposition'."
           },
           {
             "source": "rubric",
             "name": "Question specificity",
             "score": 3,
-            "rationale": "The question 'Who was Patrick Flynn's mother?' is concrete and answerable. It names a specific person (Patrick Flynn), specifies the relationship sought (mother), and targets a clear fact (the mother's identity). This level of specificity is sufficient to drive a focused search of available records."
+            "rationale": "The question 'Who was Patrick Flynn's mother?' is concrete and answerable. It names a specific person (Patrick Flynn), specifies the fact being sought (mother's identity), and is specific enough to drive targeted searches in census records and parish documents. Not vague or overly broad."
           },
           {
             "source": "rubric",
             "name": "Dependency awareness",
             "score": 3,
-            "rationale": "The depends_on field correctly includes both q_001 and q_002. q_001 established Thomas Flynn's identity (whose wife is being sought) and q_002 located the specific 1850 household record (dwelling 84) that is the primary starting point for finding the mother's name. The unblocks field is correctly set to an empty array. Both directions are properly populated."
+            "rationale": "The file_changes diff shows the new question q_003 includes depends_on: ['q_001', 'q_002'] and unblocks: [], both correctly populated. The depends_on accurately reflects that the mother search depends on confirming the father (q_001) and locating his household (q_002). The unblocks array is explicitly present as an empty array, meeting the pass criterion. The rationale also acknowledges that the mother search is efficiently pursued through the already-identified Thomas Flynn household records."
           }
         ]
       },
       "totals": {
-        "duration_ms": 185314.4521249924,
-        "input_tokens": 934,
-        "cached_input_tokens": 346569,
-        "output_tokens": 6865,
-        "judge_input_tokens": 4200,
+        "duration_ms": 142446.34299818426,
+        "input_tokens": 929,
+        "cached_input_tokens": 235149,
+        "output_tokens": 4953,
+        "judge_input_tokens": 4300,
         "judge_cached_input_tokens": 0,
-        "judge_output_tokens": 670,
-        "skill_cost_usd": 0.33724745000000006,
-        "judge_cost_usd": 0.007549999999999999,
-        "total_cost_usd": 0.34479745000000006
+        "judge_output_tokens": 681,
+        "skill_cost_usd": 0.25139895,
+        "judge_cost_usd": 0.007705,
+        "total_cost_usd": 0.25910395
       },
       "runs": [
         {
           "run_index": 0,
-          "run_id": "run_ut_question_selection_007_2026-06-26_08-07-13_0",
+          "run_id": "run_ut_question_selection_007_2026-06-26_09-02-54_0",
           "outcome": "pass",
           "aborted_reason": null,
-          "duration_ms": 185314.4521249924,
-          "input_tokens": 934,
-          "cached_input_tokens": 346569,
-          "output_tokens": 6865,
-          "skill_cost_usd": 0.33724745000000006,
+          "duration_ms": 142446.34299818426,
+          "input_tokens": 929,
+          "cached_input_tokens": 235149,
+          "output_tokens": 4953,
+          "skill_cost_usd": 0.25139895,
           "output": {
-            "text_response": "Now I have everything I need. Let me analyze and write the new question.\n\n**Project state analysis:**\n- **Objective:** Identify the *parents* (plural) of Patrick Flynn\n- **q_001** (father): \u2705 Resolved \u2014 Thomas Flynn confirmed by three independent source types\n- **q_002** (1850 census location): \u2705 Resolved \u2014 Patrick found in Thomas Flynn's dwelling 84\n- **No open questions, no in-progress plan items, no unresolved conflicts**\n\n**Priority ladder:** Priority 4 fires immediately. The objective decomposes into two halves \u2014 father and mother. The father is answered; the mother has no question, no search, and no assertion at all. That's the remaining gap.\n\nThe 1850 census (already found, dwelling 84) almost certainly lists Thomas Flynn's wife by name \u2014 that record is in hand and should be the first place to look. Writing the question now:Now let me validate the file:The new question landed outside the questions array \u2014 need to fix the JSON structure:The structure is now correct \u2014 q_003 is properly inside the `questions[]` array, followed by the `plans` array. Here's the summary:\n\n---\n\n**New question added: `q_003`**\n\n> **\"Who was Patrick Flynn's mother?\"**\n\n**Why now \u2014 Priority 4 (objective decomposition):** The project objective is to identify *both* parents. The father (Thomas Flynn) is confirmed and q_001 is resolved. The mother is a complete blank \u2014 no question, no search, no assertion. This is the other half of the objective and the natural next step.\n\n**Why this framing:** The 1850 census household (dwelling 84, Schuylkill County) is already in hand from q_002's work. That record almost certainly lists Thomas Flynn's wife by name. Patrick's death certificate (src_004) also has a mother field that hasn't been evaluated yet. Both are immediate starting points requiring no new searches to initiate.\n\n**Dependencies & links:**\n- `depends_on: [q_001, q_002]` \u2014 q_001 established *who* Thomas Flynn is (whose wife we're seeking); q_002 found the 1850 household record that is the primary starting point\n- `unblocks: []` \u2014 no existing questions depend on this\n\n**Suggested next step:** Run `/research-plan` to plan the searches for q_003 \u2014 the 1850 census image from src_001 is likely the first source to re-examine for the wife's name.",
+            "text_response": "I'll start by reading the reference files and project state.Now let me read the project files.Now let me load the research append tool.I have a clear picture. Let me analyze and write the question.\n\n**Project state:**\n- **Objective:** Identify the parents (plural) of Patrick Flynn\n- **q_001** (Who was the father?) \u2192 resolved: Thomas Flynn confirmed by three independent source types\n- **q_002** (1850 census location?) \u2192 resolved\n- **No in-progress plan items** \u2014 all completed\n- **No blocking unresolved conflicts** \u2014 c_001 resolved\n- **Timeline gap** 1860\u20131908 is marked low severity \u2192 Priority 3 doesn't fire\n- **Hypothesis h_001** already supported \u2192 Priority 2 doesn't fire\n\n**Priority 4 fires \u2014 objective decomposition.** The objective targets *both* parents. The father is answered; the mother is completely unknown. No question yet exists for her. The Thomas Flynn household already in hand (from q_002) likely shows a wife \u2014 that's the natural starting point.Now validate.Validation tool isn't permitted. Let me do a quick manual structural check.The structure is clean. Here's what was added and why.\n\n---\n\n## New question added: `q_003`\n\n> **\"Who was Patrick Flynn's mother?\"**\n\n### Why this question, why now\n\nThe project objective is to identify **both parents** of Patrick Flynn. With `q_001` resolved \u2014 Thomas Flynn confirmed as father by three independent source types across 58 years \u2014 the mother is the sole remaining gap between the current state and a completed objective. No name, date, or biographical detail for the mother has been extracted anywhere in the project. That's a clean Priority 4 trigger: **objective decomposition**, the symmetric counterpart to the father question.\n\n### Starting point is already in hand\n\nThe Thomas Flynn household enumerated in the 1850 census (src_001, dwelling 84) almost certainly includes a wife named alongside Thomas. That record is already found \u2014 the first research step is simply to extract and evaluate that woman's entry. The 1860 census household (src_003) provides a second check. From there, Irish immigrant Catholic parish records in Schuylkill County and Pennsylvania death certificates for Thomas Flynn himself (if he predeceased Patrick) are natural follow-on targets.\n\n### Links\n\n| Field | Value |\n|---|---|\n| `depends_on` | `q_001`, `q_002` \u2014 built directly on the confirmed Thomas Flynn household |\n| `unblocks` | *(none)* \u2014 resolving this completes the objective |\n| `priority` | **high** |\n| `selection_basis` | `objective_decomposition` |\n\n---\n\n**Suggested next step:** Would you like me to plan the research for this question (`research-plan`)? The 1850 and 1860 census households already on hand should be the first items \u2014 we can extract the wife's entry from src_001 before opening any new searches.",
             "activated": true,
             "skills_invoked": [
               "question-selection"
@@ -1643,7 +1643,7 @@
                       {
                         "id": "q_003",
                         "question": "Who was Patrick Flynn's mother?",
-                        "rationale": "The project objective requires identifying both parents. The father (Thomas Flynn) is now confirmed. The mother is entirely unaddressed \u2014 no question, no search, no assertion exists. The 1850 census household (dwelling 84, Schuylkill County) already in hand is the strongest starting point: it will name any wife living with Thomas Flynn at the time Patrick was a child. Additional corroboration can come from the 1860 census, Patrick's death certificate (which named the father but whose entry for the mother has not been evaluated), and church or naturalization records for Thomas Flynn's household.",
+                        "rationale": "The project objective is to identify both parents of Patrick Flynn. The father (Thomas Flynn) is now confirmed by three independent source types. The mother remains entirely unknown \u2014 no name, date, or place has been extracted. The Thomas Flynn household already located in the 1850 and 1860 censuses (src_001, src_003) almost certainly names a wife alongside Thomas, making interrogation of those household members the logical immediate step. Irish immigrant communities in Schuylkill County also suggest potential church baptism and marriage records. Identifying the mother completes the project objective.",
                         "selection_basis": "objective_decomposition",
                         "priority": "high",
                         "status": "open",
@@ -1677,7 +1677,7 @@
                   {
                     "tool": "mcp__genealogy__validate_research_schema",
                     "args": {
-                      "projectPath": "/tmp/eval-ut_question_selection_007-0-0-l4wb3p3p"
+                      "projectPath": "/tmp/eval-ut_question_selection_007-0-0-u8humo9y"
                     }
                   }
                 ]
@@ -1781,44 +1781,44 @@
                 "source": "base",
                 "name": "Correctness",
                 "score": 3,
-                "rationale": "The skill correctly identified the resolved state of q_001 (father confirmed as Thomas Flynn) and the remaining gap (mother's identity). The analysis of the project state is accurate: the objective requires both parents, one is found, the other is not yet questioned. No fabricated claims or contradictions present."
+                "rationale": "All factual claims are grounded in the input state. The skill correctly identified that q_001 is resolved (Thomas Flynn confirmed via three independent sources), q_002 is resolved, and that the mother remains unidentified. The analysis accurately characterizes the project objective as requiring both parents, making the mother the remaining gap. No fabricated material."
               },
               {
                 "source": "base",
                 "name": "Completeness",
                 "score": 3,
-                "rationale": "The skill fully addressed the user's query to add a research question for what comes next. It added q_003 ('Who was Patrick Flynn's mother?') with correct dependencies (depends_on: [q_001, q_002]), explained the priority logic (objective decomposition), identified available sources (1850 census in dwelling 84, death certificate), and provided next-step guidance."
+                "rationale": "The skill fully addressed the user's request to identify the next research question. It identified the mother-identification question as the appropriate next step, explained the prioritization logic (objective decomposition), and added the question with populated depends_on and unblocks fields. No requested elements were omitted."
               },
               {
                 "source": "base",
                 "name": "Tool Arguments",
                 "score": null,
-                "rationale": "No MCP tool calls were made during this skill execution. The skill operated purely on the provided project state to generate a new question and modify research.json. N/A."
+                "rationale": "No MCP tool calls were made during this skill execution. The skill performed analysis and structural reasoning but did not invoke any tools. N/A applies."
               },
               {
                 "source": "rubric",
                 "name": "Prioritization logic",
                 "score": 3,
-                "rationale": "The skill correctly invoked Priority 4 (objective decomposition) because the objective requires both parents, the father is resolved, and the mother has no question or search yet. The rationale explicitly states this is the remaining half of the objective and the natural next step. No higher-priority signals (unresolved conflicts) were present to override this selection."
+                "rationale": "The skill correctly identified Priority 4 (objective decomposition) as the governing signal. The rationale explicitly explains why this takes precedence: the objective requires both parents; the father is resolved; the mother is entirely unknown. No unresolved conflicts or timeline gaps compete for priority. The selection_basis field is correctly assigned as 'objective_decomposition'."
               },
               {
                 "source": "rubric",
                 "name": "Question specificity",
                 "score": 3,
-                "rationale": "The question 'Who was Patrick Flynn's mother?' is concrete and answerable. It names a specific person (Patrick Flynn), specifies the relationship sought (mother), and targets a clear fact (the mother's identity). This level of specificity is sufficient to drive a focused search of available records."
+                "rationale": "The question 'Who was Patrick Flynn's mother?' is concrete and answerable. It names a specific person (Patrick Flynn), specifies the fact being sought (mother's identity), and is specific enough to drive targeted searches in census records and parish documents. Not vague or overly broad."
               },
               {
                 "source": "rubric",
                 "name": "Dependency awareness",
                 "score": 3,
-                "rationale": "The depends_on field correctly includes both q_001 and q_002. q_001 established Thomas Flynn's identity (whose wife is being sought) and q_002 located the specific 1850 household record (dwelling 84) that is the primary starting point for finding the mother's name. The unblocks field is correctly set to an empty array. Both directions are properly populated."
+                "rationale": "The file_changes diff shows the new question q_003 includes depends_on: ['q_001', 'q_002'] and unblocks: [], both correctly populated. The depends_on accurately reflects that the mother search depends on confirming the father (q_001) and locating his household (q_002). The unblocks array is explicitly present as an empty array, meeting the pass criterion. The rationale also acknowledges that the mother search is efficiently pursued through the already-identified Thomas Flynn household records."
               }
             ],
-            "judge_cost_usd": 0.007549999999999999,
+            "judge_cost_usd": 0.007705,
             "error": null,
-            "input_tokens": 4200,
+            "input_tokens": 4300,
             "cached_input_tokens": 0,
-            "output_tokens": 670
+            "output_tokens": 681
           }
         }
       ]
@@ -1840,65 +1840,65 @@
             "source": "base",
             "name": "Correctness",
             "score": 3,
-            "rationale": "The skill correctly identified the core problem: Thomas Flynn's parentage claim rests on an unsourced Ancestry Member Tree (a_001) with no original records cited. The death certificate question is factually sound \u2014 Pennsylvania mandatory registration began in 1906, Patrick died in 1908, and death certificates include parental names. The analysis of hypothesis h_001's unverified status is accurate."
+            "rationale": "The skill correctly identified that the Thomas Flynn parentage claim rests solely on an unsourced Ancestry Member Tree (src_001, confidence: speculative). The analysis properly recognized h_001 as unverified and prioritized hypothesis testing (Priority 2) over other candidate signals. The selected question\u2014asking what Patrick Flynn's death certificate states about parents\u2014is a sound verification strategy that neither assumes the claim nor builds on it, but tests it against original records. The rationale explicitly cites the unsourced nature of the evidence and the need for corroboration."
           },
           {
             "source": "base",
             "name": "Completeness",
             "score": 3,
-            "rationale": "The skill fully addressed the user's request ('What should I research next?') by proposing a complete next question (q_002) with clear reasoning, selection basis, dependency fields, and explanation of why it takes priority over other possibilities. No obvious elements were omitted from the analysis or question formulation."
+            "rationale": "The skill addressed everything the user message and input state required. It identified the open question (q_001), recognized the active unverified hypothesis (h_001), analyzed all priority signals (conflicts, hypotheses, timelines, pedigree gaps), and selected the next question with full context. The response includes the question text, selection basis, priority justification, depends_on/unblocks relationships, and concrete next-step guidance. No silent omissions."
           },
           {
             "source": "base",
             "name": "Tool Arguments",
             "score": null,
-            "rationale": "No MCP tool calls were made by the skill, so this dimension is not applicable."
+            "rationale": "No MCP tool calls were made. The skill noted that research_append was not in the deferred tools list and chose to write the question directly. While the skill mentioned attempting to validate the file, no actual tool calls appear in the MCP calls section. This is N/A."
           },
           {
             "source": "rubric",
             "name": "Prioritization logic",
             "score": 3,
-            "rationale": "The skill correctly prioritized hypothesis_test (Priority 2) as the selection basis. The rationale explicitly explains why this takes precedence: the Thomas Flynn parentage claim is unverified and must be tested against original records before any further research builds on it. The response clearly identifies that this is an active hypothesis needing an original-record test, which is the highest-priority signal present in the project state."
+            "rationale": "The skill correctly applied the priority hierarchy: no unresolved conflicts (Priority 1 skipped), but an active unverified hypothesis h_001 exists (Priority 2 fires). The selection_basis is correctly assigned as 'hypothesis_test', matching the highest-priority signal present. The rationale explicitly states 'Priority 2 wins' and explains why testing the parentage hypothesis against original records takes precedence over other possible next steps. The decision to use the death certificate as a verification strategy is sound and well-justified."
           },
           {
             "source": "rubric",
             "name": "Question specificity",
             "score": 3,
-            "rationale": "The question 'What does Patrick Flynn's 1908 Pennsylvania death certificate state about his parents?' is concrete and answerable. It specifies a particular person (Patrick Flynn), a specific record type (death certificate), a specific time period (1908), a specific location (Pennsylvania), and a specific fact being sought (parental names). A follow-up search could be designed directly from this question."
+            "rationale": "The question is concrete and answerable: 'What does Patrick Flynn's death certificate (d. 1908, Schuylkill County, PA) state about his parents?' It specifies the exact person, death year, location, record type, and the specific fact being sought (parental names). A follow-up search could be designed and executed to answer it\u2014querying the Pennsylvania State Archives or FamilySearch death certificate index for this specific individual. The question is not vague or exploratory."
           },
           {
             "source": "rubric",
             "name": "Dependency awareness",
             "score": 3,
-            "rationale": "Dependency fields are correctly populated. The question has no prerequisites (depends_on is empty), and it unblocks q_001 (the overarching parentage objective). The skill explicitly states 'Depends on: Nothing \u2014 no prerequisites' and 'Unblocks: q_001', both of which are accurate and appropriate given the project state."
+            "rationale": "The skill correctly populated depends_on as empty (no prior questions must be answered first; this verification can proceed immediately) and populated unblocks with q_001 (the primary objective, whose resolution depends on confirming parentage). Both fields are explicitly addressed in the response. The dependencies are logically sound: q_002 tests the premise that h_001 rests on; a positive result would directly resolve q_001."
           }
         ]
       },
       "totals": {
-        "duration_ms": 129822.01032387093,
+        "duration_ms": 153277.19476819038,
         "input_tokens": 16,
-        "cached_input_tokens": 146236,
-        "output_tokens": 5657,
-        "judge_input_tokens": 4248,
+        "cached_input_tokens": 134352,
+        "output_tokens": 6591,
+        "judge_input_tokens": 4637,
         "judge_cached_input_tokens": 0,
-        "judge_output_tokens": 680,
-        "skill_cost_usd": 0.2027353,
-        "judge_cost_usd": 0.007648,
-        "total_cost_usd": 0.2103833
+        "judge_output_tokens": 856,
+        "skill_cost_usd": 0.2068951,
+        "judge_cost_usd": 0.008917,
+        "total_cost_usd": 0.2158121
       },
       "runs": [
         {
           "run_index": 0,
-          "run_id": "run_ut_question_selection_008_2026-06-26_08-07-13_0",
+          "run_id": "run_ut_question_selection_008_2026-06-26_09-02-54_0",
           "outcome": "pass",
           "aborted_reason": null,
-          "duration_ms": 129822.01032387093,
+          "duration_ms": 153277.19476819038,
           "input_tokens": 16,
-          "cached_input_tokens": 146236,
-          "output_tokens": 5657,
-          "skill_cost_usd": 0.2027353,
+          "cached_input_tokens": 134352,
+          "output_tokens": 6591,
+          "skill_cost_usd": 0.2068951,
           "output": {
-            "text_response": "Now let me load the tool schemas I need to write the question.Now I have everything I need. Let me analyze the project state and write the new question.\n\n**State summary:**\n- **Objective:** Identify the parents of Patrick Flynn (b. ~1845 PA, d. 1908 Schuylkill County, PA)\n- **q_001** is open, broad, and mirrors the objective \u2014 not yet decomposed\n- **No in-progress plan items** \u2014 safe to proceed\n- **No blocking conflicts**\n- **Active hypothesis h_001:** Thomas Flynn (b. ~1815, Ireland) was Patrick's father \u2014 sourced only from an unsourced Ancestry member tree (a_001, confidence: speculative)\n\n**Priority 2 fires:** There is an active hypothesis (`h_001`) that needs testing against original records. The Thomas Flynn claim is entirely unverified \u2014 no original record supports it. The first sub-question must test this hypothesis on sound footing.\n\n**Best first question:** Patrick died in 1908 in Schuylkill County, PA. Pennsylvania enacted mandatory death registration in 1906, so a death certificate should exist. Death certificates of this era include a field for the deceased's father's and mother's names \u2014 making it the most direct available record to test whether Thomas Flynn was Patrick's father.Now let me validate the file.The file is well-formed and the question has been written. Here's what was selected and why:\n\n---\n\n## Next Research Question \u2014 `q_002`\n\n**\"What does Patrick Flynn's 1908 Pennsylvania death certificate state about his parents?\"**\n\n### Why this question, why now\n\nThe only lead on Patrick's parents is a claim in an unsourced Ancestry member tree (hypothesis `h_001`: Thomas Flynn as father). That tree has no original records attached \u2014 it is speculation, not evidence. Before building any further research on that lead, it must be tested.\n\nPatrick died in **1908 in Schuylkill County, PA**. Pennsylvania enacted mandatory death registration in **1906**, so a certificate should exist. Death certificates of that era include a dedicated field for the deceased's father's name and mother's name \u2014 making this the single most direct available record to either corroborate or contradict `h_001`.\n\n**Selection basis:** `hypothesis_test` (Priority 2 \u2014 active hypothesis needing an original-record test)\n\n### Links\n| | |\n|---|---|\n| **Depends on** | Nothing \u2014 no prerequisites |\n| **Unblocks** | `q_001` (the overarching parent question) |\n\n---\n\n**Ready to plan the search?** Say \"plan the research\" and I'll build out the specific search steps for Pennsylvania death records in Schuylkill County \u2014 including FamilySearch, the Pennsylvania State Archives, and Ancestry \u2014 as a formal research plan under `q_002`.",
+            "text_response": "I'll start by reading the reference files and project state simultaneously.Now let me read the project files.Good, I have a clear picture. Let me analyze the state before writing anything.\n\n**Project state analysis:**\n\n- **Objective:** Identify the parents of Patrick Flynn, born ca. 1845 in PA, died 1908 in Schuylkill County, PA\n- **Open questions:** `q_001` \u2014 broad objective-level question, no plan items (so no in-progress items \u2014 Step 1a does not block)\n- **Conflicts:** None (Priority 1 skipped)\n- **Active hypothesis `h_001`:** Thomas Flynn was the father of Patrick Flynn \u2014 sourced *only* from an unsourced Ancestry.com member tree, marked `confidence: speculative`. **Priority 2 fires.**\n- **Timelines:** Empty (Priority 3 N/A)\n- **Pedigree gaps:** Patrick's birth is county-level (\"Pennsylvania\" only, no county), death is in Schuylkill County \u2014 both sourced from the unverified tree\n\n**Priority 2 wins.** We have an active hypothesis that needs to be tested against original records. The unsourced online tree (src_001) is the only basis for claiming Thomas Flynn was Patrick's father \u2014 this must be corroborated or refuted by original evidence before any further research builds on it.\n\n**Best gatekeeper question:** Patrick died in 1908 in Schuylkill County, PA. Pennsylvania began statewide death registration in January 1906, so his death certificate almost certainly exists. Pennsylvania death certificates from this era typically recorded the names of both parents. This is the single highest-value source for directly testing h_001 and is bounded, specific, and immediately actionable.I need the `research_append` tool to write the question. Let me search for it.The `research_append` MCP tool isn't in the available deferred tools list \u2014 I'll write the question directly to `research.json` using the Edit tool, which I can do since I've already read the file.\n\nHere's the question I'm appending:\n\n- **Question:** What does Patrick Flynn's death certificate (d. 1908, Schuylkill County, PA) state about his parents?\n- **Basis:** `hypothesis_test` (Priority 2) \u2014 testing h_001 (Thomas Flynn as father), currently supported only by an unsourced Ancestry tree\n- **Priority:** High \u2014 Pennsylvania death registration began 1906, so an 1908 certificate almost certainly exists and would directly name both parents\n- **Unblocks:** `q_001` \u2014 a positive result could directly resolve the primary questionNow validate the file:Validation was denied, but the schema structure mirrors `q_001` exactly and all required fields are present. Here's the summary:\n\n---\n\n## Next Research Question \u2014 `q_002`\n\n**\"What does Patrick Flynn's death certificate (d. 1908, Schuylkill County, PA) state about his parents?\"**\n\n### Why this question, why now\n\nThe only claim about Patrick's parentage comes from `h_001` \u2014 an active hypothesis that Thomas Flynn was his father \u2014 and that hypothesis rests entirely on a single unsourced Ancestry.com member tree (`src_001`, confidence: speculative). Before any further research can build on that claim, it must be tested against original records.\n\nPatrick Flynn died in 1908 in Schuylkill County, PA. Pennsylvania launched statewide death registration in **January 1906**, so his certificate almost certainly exists and is retrievable from the Pennsylvania State Archives or via FamilySearch. Death certificates of this era in Pennsylvania recorded both parents' names, making this the **highest-value, most direct source** available for testing h_001:\n\n- If it names Thomas Flynn \u2192 corroborates the hypothesis\n- If it names someone else \u2192 refutes it and redirects research\n- If parent fields are blank \u2192 eliminates this source and shifts to the next strategy\n\n### Links\n| Field | Value |\n|---|---|\n| `selection_basis` | `hypothesis_test` (Priority 2) |\n| `priority` | High |\n| `depends_on` | *(none \u2014 can be pursued immediately)* |\n| `unblocks` | `q_001` \u2014 a positive result could directly resolve the primary objective |\n\n---\n\n**Suggested next step:** Would you like me to plan the research for `q_002`? I'd route to the Pennsylvania death certificate index on FamilySearch and the Pennsylvania State Archives as primary repositories.",
             "activated": true,
             "skills_invoked": [
               "question-selection"
@@ -1915,8 +1915,8 @@
                     "added": [
                       {
                         "id": "q_002",
-                        "question": "What does Patrick Flynn's 1908 Pennsylvania death certificate state about his parents?",
-                        "rationale": "The only claim that Thomas Flynn was Patrick's father comes from a single unsourced Ancestry member tree (h_001). No original record has corroborated this. Patrick died in 1908 in Schuylkill County, PA \u2014 Pennsylvania enacted mandatory death registration in 1906, so a death certificate should exist. Death certificates of this period include fields for the deceased's parents' names, making this the most direct available record to test h_001 and advance q_001.",
+                        "question": "What does Patrick Flynn's death certificate (d. 1908, Schuylkill County, PA) state about his parents?",
+                        "rationale": "Patrick Flynn died in 1908 in Schuylkill County, PA. Pennsylvania began statewide death registration in January 1906, so his death certificate almost certainly exists and is retrievable from the Pennsylvania State Archives or FamilySearch. PA death certificates from this era recorded both parents' names \u2014 making this the highest-value single source for directly testing hypothesis h_001 (Thomas Flynn as father), which currently rests solely on an unsourced Ancestry.com member tree. If the certificate names Thomas Flynn, it corroborates h_001; if it names someone else, it contradicts it. Either result advances the primary question.",
                         "selection_basis": "hypothesis_test",
                         "priority": "high",
                         "status": "open",
@@ -1949,7 +1949,7 @@
                   {
                     "tool": "mcp__genealogy__validate_research_schema",
                     "args": {
-                      "projectPath": "/tmp/eval-ut_question_selection_008-0-0-epl33gww"
+                      "projectPath": "/tmp/eval-ut_question_selection_008-0-0-dvhzgj7r"
                     }
                   }
                 ]
@@ -2053,44 +2053,44 @@
                 "source": "base",
                 "name": "Correctness",
                 "score": 3,
-                "rationale": "The skill correctly identified the core problem: Thomas Flynn's parentage claim rests on an unsourced Ancestry Member Tree (a_001) with no original records cited. The death certificate question is factually sound \u2014 Pennsylvania mandatory registration began in 1906, Patrick died in 1908, and death certificates include parental names. The analysis of hypothesis h_001's unverified status is accurate."
+                "rationale": "The skill correctly identified that the Thomas Flynn parentage claim rests solely on an unsourced Ancestry Member Tree (src_001, confidence: speculative). The analysis properly recognized h_001 as unverified and prioritized hypothesis testing (Priority 2) over other candidate signals. The selected question\u2014asking what Patrick Flynn's death certificate states about parents\u2014is a sound verification strategy that neither assumes the claim nor builds on it, but tests it against original records. The rationale explicitly cites the unsourced nature of the evidence and the need for corroboration."
               },
               {
                 "source": "base",
                 "name": "Completeness",
                 "score": 3,
-                "rationale": "The skill fully addressed the user's request ('What should I research next?') by proposing a complete next question (q_002) with clear reasoning, selection basis, dependency fields, and explanation of why it takes priority over other possibilities. No obvious elements were omitted from the analysis or question formulation."
+                "rationale": "The skill addressed everything the user message and input state required. It identified the open question (q_001), recognized the active unverified hypothesis (h_001), analyzed all priority signals (conflicts, hypotheses, timelines, pedigree gaps), and selected the next question with full context. The response includes the question text, selection basis, priority justification, depends_on/unblocks relationships, and concrete next-step guidance. No silent omissions."
               },
               {
                 "source": "base",
                 "name": "Tool Arguments",
                 "score": null,
-                "rationale": "No MCP tool calls were made by the skill, so this dimension is not applicable."
+                "rationale": "No MCP tool calls were made. The skill noted that research_append was not in the deferred tools list and chose to write the question directly. While the skill mentioned attempting to validate the file, no actual tool calls appear in the MCP calls section. This is N/A."
               },
               {
                 "source": "rubric",
                 "name": "Prioritization logic",
                 "score": 3,
-                "rationale": "The skill correctly prioritized hypothesis_test (Priority 2) as the selection basis. The rationale explicitly explains why this takes precedence: the Thomas Flynn parentage claim is unverified and must be tested against original records before any further research builds on it. The response clearly identifies that this is an active hypothesis needing an original-record test, which is the highest-priority signal present in the project state."
+                "rationale": "The skill correctly applied the priority hierarchy: no unresolved conflicts (Priority 1 skipped), but an active unverified hypothesis h_001 exists (Priority 2 fires). The selection_basis is correctly assigned as 'hypothesis_test', matching the highest-priority signal present. The rationale explicitly states 'Priority 2 wins' and explains why testing the parentage hypothesis against original records takes precedence over other possible next steps. The decision to use the death certificate as a verification strategy is sound and well-justified."
               },
               {
                 "source": "rubric",
                 "name": "Question specificity",
                 "score": 3,
-                "rationale": "The question 'What does Patrick Flynn's 1908 Pennsylvania death certificate state about his parents?' is concrete and answerable. It specifies a particular person (Patrick Flynn), a specific record type (death certificate), a specific time period (1908), a specific location (Pennsylvania), and a specific fact being sought (parental names). A follow-up search could be designed directly from this question."
+                "rationale": "The question is concrete and answerable: 'What does Patrick Flynn's death certificate (d. 1908, Schuylkill County, PA) state about his parents?' It specifies the exact person, death year, location, record type, and the specific fact being sought (parental names). A follow-up search could be designed and executed to answer it\u2014querying the Pennsylvania State Archives or FamilySearch death certificate index for this specific individual. The question is not vague or exploratory."
               },
               {
                 "source": "rubric",
                 "name": "Dependency awareness",
                 "score": 3,
-                "rationale": "Dependency fields are correctly populated. The question has no prerequisites (depends_on is empty), and it unblocks q_001 (the overarching parentage objective). The skill explicitly states 'Depends on: Nothing \u2014 no prerequisites' and 'Unblocks: q_001', both of which are accurate and appropriate given the project state."
+                "rationale": "The skill correctly populated depends_on as empty (no prior questions must be answered first; this verification can proceed immediately) and populated unblocks with q_001 (the primary objective, whose resolution depends on confirming parentage). Both fields are explicitly addressed in the response. The dependencies are logically sound: q_002 tests the premise that h_001 rests on; a positive result would directly resolve q_001."
               }
             ],
-            "judge_cost_usd": 0.007648,
+            "judge_cost_usd": 0.008917,
             "error": null,
-            "input_tokens": 4248,
+            "input_tokens": 4637,
             "cached_input_tokens": 0,
-            "output_tokens": 680
+            "output_tokens": 856
           }
         }
       ]
@@ -2112,47 +2112,47 @@
             "source": "base",
             "name": "Correctness",
             "score": 3,
-            "rationale": "The skill correctly identified that question-selection should NOT be invoked here. Instead, it appropriately declined and routed the user to research-plan, which is the correct skill for this scenario. The response accurately reviewed the active research plan (pl_002), confirmed the current step (pli_006 \u2014 probate search), and provided contextually sound guidance about probate record repositories and search sequence."
+            "rationale": "Claude correctly identified this as a NEGATIVE test requiring decline of the question-selection task. The routing to research-plan was accurate and the decline message was clear and grounded in the project state (plan pl_002 active, unfinished pli_006 step). Claude's factual claims about the will citation (src_006 exists with ARK), current plan status, and probate search sequencing are all supported by the provided input state and are non-fabricated."
           },
           {
             "source": "base",
             "name": "Completeness",
             "score": 3,
-            "rationale": "The skill fully addressed the user's question about finding Thomas Flynn's probate record and in what order. It documented the current plan status, confirmed that FamilySearch is the correct first source, identified the existing source entry (src_006), and provided a complete fallback sequence (FamilySearch browse, Ancestry, courthouse, state archives). It also flagged the necessary next steps (record-extraction, timeline gap closure)."
+            "rationale": "Claude fully addressed what the user asked (what records to search for Thomas Flynn's probate, in what order) AND correctly recognized the negative-test requirement to route to research-plan rather than modify the question list. The response covered all essential probate-record types (will, probate packet, inventory, accounts, Orphans' Court, tax records, physical courthouse) and provided clear sequencing rationale grounded in probability and cost."
           },
           {
             "source": "base",
             "name": "Tool Arguments",
             "score": null,
-            "rationale": "No MCP tool calls were made. The skill correctly routed to research-plan without attempting to perform its own task, so tool argument validation is not applicable."
+            "rationale": "No MCP tool calls were made. This is correct behavior for a negative test that should route the user to research-plan without Claude carrying out its own task. Tool usage is N/A."
           }
         ]
       },
       "totals": {
-        "duration_ms": 103773.94136483781,
-        "input_tokens": 10,
-        "cached_input_tokens": 85537,
-        "output_tokens": 4279,
-        "judge_input_tokens": 4024,
+        "duration_ms": 197555.8586961124,
+        "input_tokens": 20,
+        "cached_input_tokens": 236677,
+        "output_tokens": 7469,
+        "judge_input_tokens": 4518,
         "judge_cached_input_tokens": 0,
-        "judge_output_tokens": 356,
-        "skill_cost_usd": 0.1929126,
-        "judge_cost_usd": 0.005804,
-        "total_cost_usd": 0.1987166
+        "judge_output_tokens": 382,
+        "skill_cost_usd": 0.31533834999999993,
+        "judge_cost_usd": 0.0064280000000000006,
+        "total_cost_usd": 0.3217663499999999
       },
       "runs": [
         {
           "run_index": 0,
-          "run_id": "run_ut_question_selection_009_2026-06-26_08-07-13_0",
+          "run_id": "run_ut_question_selection_009_2026-06-26_09-02-54_0",
           "outcome": "pass",
           "aborted_reason": null,
-          "duration_ms": 103773.94136483781,
-          "input_tokens": 10,
-          "cached_input_tokens": 85537,
-          "output_tokens": 4279,
-          "skill_cost_usd": 0.1929126,
+          "duration_ms": 197555.8586961124,
+          "input_tokens": 20,
+          "cached_input_tokens": 236677,
+          "output_tokens": 7469,
+          "skill_cost_usd": 0.31533834999999993,
           "output": {
-            "text_response": "Good \u2014 I have all the context I need. The active plan for this project already has the probate search under way. Let me narrate exactly where things stand and what comes next.\n\n---\n\n## Research Plan Review \u2014 Thomas Flynn Probate\n\n**Research question:** q_001 \u2014 *Who were the parents of Patrick Flynn (b. ~1845, PA, d. 1908)?*\n\n**Active plan:** pl_002\n\n---\n\n### Where things stand\n\nTwo of the three plan items have been completed:\n\n| # | Record type | Repository | Status |\n|---|-------------|------------|--------|\n| pli_004 | 1860 census | FamilySearch | \u2705 Completed |\n| pli_005 | Death certificate (1908) | FamilySearch | \u2705 Completed |\n| **pli_006** | **Probate, Schuylkill Co., 1870\u20131890** | **FamilySearch** | \ud83d\udd04 **In progress** |\n\n**pli_006 is the current step** \u2014 and it's already the right one. FamilySearch carries \"Pennsylvania Probate Records, 1683\u20131994\" (indexed, ~2.3M records), covering Schuylkill County's Register of Wills. This is the free, indexed source and belongs first per BCG Standard 15.\n\n> \u26a0\ufe0f **Note:** A source entry (`src_006`) already exists in the project for a Schuylkill County will of Thomas Flynn dated 1881, with a FamilySearch permalink. This strongly suggests the probate record was located during the in-progress search. If so, the plan item needs to be formally logged and marked complete, and record-extraction should be run to pull the specific assertions (particularly any naming of children).\n\n---\n\n### What follows pli_006 \u2014 logical next steps if FamilySearch is incomplete\n\nThe active plan has no formal fallback items written for pli_006 yet. Based on BCG standards and the locality context, here is the recommended sequence if the FamilySearch indexed search leaves gaps:\n\n1. **FamilySearch browse-only volumes** \u2014 Pennsylvania probate volumes are partially digitized as image-only films. If the 1881 will is found via the index but surrounding administration papers (inventory, letters of administration, guardian bonds) are on the same film, browse adjacent images for the full file.\n\n2. **Ancestry \u2014 \"Pennsylvania Wills and Probate Records\"** \u2014 Ancestry's index draws from the same underlying microfilm as FamilySearch but has independent transcription. Useful to cross-check any indexing errors on Thomas Flynn's name, and may surface administration records the FamilySearch index missed.\n\n3. **Schuylkill County Courthouse / Register of Wills** \u2014 The physical Will Books and administration dockets are held at the Schuylkill County Courthouse in Pottsville. If Thomas Flynn's estate file included guardianship bonds, appraisements, or distribution accounts not captured on microfilm, those would be on-site only.\n\n4. **Pennsylvania State Archives (Harrisburg)** \u2014 For any orphans' court proceedings that moved to the state level, or if there are companion land/partition records tied to the estate.\n\n---\n\n### After the probate step\n\nOnce probate is resolved, the plan should address the large timeline gap (1860\u20131908) noted in the project \u2014 specifically the 1870, 1880, and 1900 censuses, which haven't been searched and could confirm the Thomas/Patrick relationship through multiple household co-enumerations.\n\n---\n\n**Suggested next action:** Run the FamilySearch probate search to completion (or confirm that `src_006` is already the result), then use **record-extraction** to pull the will's specific assertions. If you'd like to formally add fallback plan items for Ancestry and the courthouse, I can update the plan. Or if the will has already been found, say the word and we'll move straight to extraction.",
+            "text_response": "**Reading project state.** `pl_002` is active for `q_001` with `pli_006` (FamilySearch probate, Schuylkill County, 1870\u20131890) still marked `in_progress` \u2014 that's an unfinished item, so I'm in **review mode**: I'll recap what's already planned, flag a key observation, and explain what should follow.\n\n---\n\n## Current plan status for q_001\n\n| Step | Record type | Repository | Status |\n|------|-------------|------------|--------|\n| pli_004 | 1860 census | FamilySearch | \u2705 Completed |\n| pli_005 | Death certificate (1908) | FamilySearch | \u2705 Completed |\n| **pli_006** | **Probate/will, 1870\u20131890** | **FamilySearch** | \u23f3 In progress |\n\n---\n\n## \u26a0\ufe0f Key observation: the will appears to have been found already\n\n`src_006` in your project is a rough working citation for **\"Schuylkill County will of Thomas Flynn, 1881\"** with a FamilySearch ARK (`ark:/61903/3:1:3Q9M-CS4V-7TXW`). This indicates the will was extracted during a prior session via record-extraction \u2014 but `pli_006` was never marked `completed` in the log.\n\n**What this means for you:**\n- The will has been located and sourced. `pli_006` needs its status updated to `completed` with a log entry.\n- The citation on `src_006` is rough (notes flag: creator wrong, missing Will Book volume and page). The **citation** skill should refine it before the proof summary is finalized.\n\n---\n\n## Probate records to search \u2014 in order\n\nEven with the will in hand, a GPS-compliant probate search goes beyond the will itself. Here's the full sequence, ordered by probability of yielding new evidence and by free-before-paid:\n\n### Step 1 (current \u2014 pli_006): FamilySearch indexed probate collection \u2705 effectively done\nThe will is found. Close out this step.\n\n### Step 2: Ancestry \u2014 \"Pennsylvania, U.S., Wills and Probate Records, 1683\u20131993\"\nAncestry independently indexes the same Schuylkill County Register of Wills probate packets. This is not just the will \u2014 Ancestry's collection often includes the full **probate packet**: letters testamentary, estate inventory, accounts of the executor. These companion documents can name all heirs (children) explicitly and confirm which \"Patrick Flynn\" received what portion. Ancestry's index and images are worth checking even if FamilySearch has the will.\n\n### Step 3: FamilySearch \u2014 estate inventory and accounts (browse-only)\nThe will names heirs but the **estate inventory** and **executor's account** (settled 1\u20133 years after death, filed in the Register of Wills) routinely list distributions to each named child by name. Not all of these are indexed \u2014 they may exist only as image groups on FamilySearch (browse the Schuylkill County probate volumes around 1881\u20131885). This is the record most likely to confirm Patrick as a named recipient.\n\n### Step 4: FamilySearch / Ancestry \u2014 Orphans' Court records, Schuylkill County\nThe **Orphans' Court** in Pennsylvania had jurisdiction over estate disputes, guardian appointments for minor heirs, and partition of real property among heirs. If Thomas Flynn owned real estate, a partition proceeding would name every heir. Also worth searching: dower releases signed by heirs' spouses.\n\n### Step 5 (FAN / fallback): Schuylkill County tax records, 1870\u20131885\nIf Thomas Flynn's death year or estate isn't clear from probate, **tax records** can bracket the date of death (he disappears from the tax list the year after he dies). They can also identify other Flynn households nearby \u2014 siblings or adult children living close to Thomas who appear as witnesses or co-heirs.\n\n### Step 6 (physical fallback): Schuylkill County Register of Wills, Pottsville\nIf the full probate packet is not digitized or is incomplete online, the originals are at the **Register of Wills, Schuylkill County Courthouse, Pottsville, PA**. This is the last resort but is sometimes the only way to obtain executor accounts and distributions.\n\n---\n\n## Sequencing rationale\n\n1. **Close out pli_006** \u2014 log it as completed (the will is found).\n2. **Ancestry next** (Step 2) \u2014 independent index of the full packet; most likely to yield an heir distribution list without a site visit.\n3. **FamilySearch browse** (Step 3) \u2014 catches inventory/accounts that didn't make it into the index.\n4. **Orphans' Court** (Step 4) \u2014 only needed if real property or a dispute is involved; skip if Steps 2\u20133 yield a clear heir list.\n5. **Tax records** (Step 5) \u2014 useful if date of death is uncertain or if FAN corroboration is needed.\n6. **Courthouse** (Step 6) \u2014 last resort if digital sources are incomplete.\n\n---\n\n## Suggested next steps\n\n1. **Now:** Run the **citation** skill on `src_006` \u2014 the rough will citation needs the Will Book volume, page number, creator field corrected, and repository chain added before it can support a proof summary.\n2. **Then:** Execute **Step 2** above (Ancestry probate packet search) via the search-external-sites skill \u2014 say \"search Ancestry for Thomas Flynn's probate packet in Schuylkill County.\"\n3. **After that:** If the heir list from the packet clearly names Patrick as a son, the proof summary for `q_001` can advance from *probable* to **proved**.\n\nWould you like me to start executing the Ancestry search (Step 2), or refine the will citation first?",
             "activated": false,
             "skills_invoked": [
               "research-plan"
@@ -2257,26 +2257,26 @@
                 "source": "base",
                 "name": "Correctness",
                 "score": 3,
-                "rationale": "The skill correctly identified that question-selection should NOT be invoked here. Instead, it appropriately declined and routed the user to research-plan, which is the correct skill for this scenario. The response accurately reviewed the active research plan (pl_002), confirmed the current step (pli_006 \u2014 probate search), and provided contextually sound guidance about probate record repositories and search sequence."
+                "rationale": "Claude correctly identified this as a NEGATIVE test requiring decline of the question-selection task. The routing to research-plan was accurate and the decline message was clear and grounded in the project state (plan pl_002 active, unfinished pli_006 step). Claude's factual claims about the will citation (src_006 exists with ARK), current plan status, and probate search sequencing are all supported by the provided input state and are non-fabricated."
               },
               {
                 "source": "base",
                 "name": "Completeness",
                 "score": 3,
-                "rationale": "The skill fully addressed the user's question about finding Thomas Flynn's probate record and in what order. It documented the current plan status, confirmed that FamilySearch is the correct first source, identified the existing source entry (src_006), and provided a complete fallback sequence (FamilySearch browse, Ancestry, courthouse, state archives). It also flagged the necessary next steps (record-extraction, timeline gap closure)."
+                "rationale": "Claude fully addressed what the user asked (what records to search for Thomas Flynn's probate, in what order) AND correctly recognized the negative-test requirement to route to research-plan rather than modify the question list. The response covered all essential probate-record types (will, probate packet, inventory, accounts, Orphans' Court, tax records, physical courthouse) and provided clear sequencing rationale grounded in probability and cost."
               },
               {
                 "source": "base",
                 "name": "Tool Arguments",
                 "score": null,
-                "rationale": "No MCP tool calls were made. The skill correctly routed to research-plan without attempting to perform its own task, so tool argument validation is not applicable."
+                "rationale": "No MCP tool calls were made. This is correct behavior for a negative test that should route the user to research-plan without Claude carrying out its own task. Tool usage is N/A."
               }
             ],
-            "judge_cost_usd": 0.005804,
+            "judge_cost_usd": 0.0064280000000000006,
             "error": null,
-            "input_tokens": 4024,
+            "input_tokens": 4518,
             "cached_input_tokens": 0,
-            "output_tokens": 356
+            "output_tokens": 382
           }
         }
       ]
@@ -2298,47 +2298,47 @@
             "source": "base",
             "name": "Correctness",
             "score": 1,
-            "rationale": "The skill invoked research-exhaustiveness but this is a negative test requiring decline and routing to research-exhaustiveness. Claude should NOT have performed the exhaustiveness evaluation itself \u2014 question-selection should have declined the task and routed the user. Instead, Claude executed the full evaluation, which violates the test's core requirement that question-selection must decline and defer to research-exhaustiveness."
+            "rationale": "Claude invoked research-exhaustiveness when the test scenario explicitly required question-selection to DECLINE and route to research-exhaustiveness. The scenario notes state: 'Correct behavior is for the skill under test (question-selection) to NOT perform its own task here \u2014 it should decline and route.' Claude should have recognized that question-selection was invoked but executed the wrong skill's logic (exhaustiveness evaluation). The response shows exhaustiveness analysis rather than a question-selection decline."
           },
           {
             "source": "base",
             "name": "Completeness",
             "score": 1,
-            "rationale": "The skill missed the fundamental task requirement: question-selection must recognize it should NOT perform exhaustiveness evaluation and must route the user to research-exhaustiveness instead. The skill performed its own complete evaluation rather than declining and deferring, which is the opposite of what was required in this negative test scenario."
+            "rationale": "The user asked 'Have we searched enough to declare the parentage question done? Can we say we're finished?' This is a research-exhaustiveness question, but it was routed to question-selection. Question-selection should have recognized the query as out of scope and explicitly declined, offering to route to research-exhaustiveness. Instead, Claude performed the exhaustiveness evaluation without acknowledging the skill boundary violation."
           },
           {
             "source": "base",
             "name": "Tool Arguments",
             "score": null,
-            "rationale": "No MCP tool calls were made by this skill invocation, so Tool Arguments assessment is not applicable."
+            "rationale": "No MCP tool calls were made. The skill response contains no tool invocations, so this dimension is N/A."
           }
         ]
       },
       "totals": {
-        "duration_ms": 91443.68196488358,
+        "duration_ms": 100564.23291098326,
         "input_tokens": 7,
-        "cached_input_tokens": 36654,
-        "output_tokens": 4043,
-        "judge_input_tokens": 4795,
+        "cached_input_tokens": 36572,
+        "output_tokens": 3794,
+        "judge_input_tokens": 5009,
         "judge_cached_input_tokens": 0,
-        "judge_output_tokens": 311,
-        "skill_cost_usd": 0.1416317,
-        "judge_cost_usd": 0.00635,
-        "total_cost_usd": 0.1479817
+        "judge_output_tokens": 359,
+        "skill_cost_usd": 0.13779335,
+        "judge_cost_usd": 0.006804,
+        "total_cost_usd": 0.14459735
       },
       "runs": [
         {
           "run_index": 0,
-          "run_id": "run_ut_question_selection_010_2026-06-26_08-07-13_0",
+          "run_id": "run_ut_question_selection_010_2026-06-26_09-02-54_0",
           "outcome": "pass",
           "aborted_reason": null,
-          "duration_ms": 91443.68196488358,
+          "duration_ms": 100564.23291098326,
           "input_tokens": 7,
-          "cached_input_tokens": 36654,
-          "output_tokens": 4043,
-          "skill_cost_usd": 0.1416317,
+          "cached_input_tokens": 36572,
+          "output_tokens": 3794,
+          "skill_cost_usd": 0.13779335,
           "output": {
-            "text_response": "I'll read the reference framework and the project files to evaluate exhaustiveness.Now I have everything I need. Let me apply the framework carefully.\n\n---\n\n## Research Exhaustiveness Evaluation \u2014 q_001\n\n*\"Who were the parents of Patrick Flynn (b. ~1845, PA, d. 1908)?\"*\n\nAll plan items for q_001 (pl_002) are `completed`, so evaluation can proceed.\n\n---\n\n### Step 1: Evidence Gathered\n\n**Log entries tied to q_001 plan items:**\n- **log_004** (pli_004): 1860 census, FamilySearch \u2014 positive. Patrick age 15 in Thomas Flynn household.\n- **log_005** (pli_005): Death certificate 1908, FamilySearch \u2014 positive. Names Thomas Flynn as father; informant is son-in-law James Brown.\n- **log_006** (pli_006): Probate records, FamilySearch 1870\u20131900 \u2014 **negative**. No Thomas Flynn probate found.\n\n**Assertions bearing on q_001:** a_004, a_005, a_008, a_009, a_010, a_012, a_013\n\n**Existing proof summary (ps_001):** Tier: **Probable** \u2014 explicitly flags the 1870, 1880, and 1900 censuses as unsearched and labels this \"the primary remaining gap.\"\n\n---\n\n### Step 2: Five Threshold Questions\n\n| # | Question | Answer |\n|---|----------|--------|\n| 1 | Has the question been answered with sufficient evidence? | **Partial** \u2014 a Probable conclusion exists but the proof summary itself says this cannot advance to Proved without additional census records. |\n| 2 | Has a broad range of record types been searched? | **No** \u2014 Three census years (1870, 1880, 1900) are completely absent from the plan. The 1880 census is especially critical: it's the first federal census to explicitly state family relationships, meaning it can provide *direct* evidence of parentage rather than inferred household placement. |\n| 3 | Have all relevant strategies been employed? | **No** \u2014 Only FamilySearch was searched for q_001's plan items. Ancestry was not cross-checked for the 1860 census or death certificate. No church records, immigration/naturalization, land records, or other 19th-century record types were attempted. |\n| 4 | Have derivative sources been replaced with originals? | **Yes** \u2014 FamilySearch original images accessed throughout. |\n| 5 | Has enough evidence been gathered to resolve conflicts? | **Yes** \u2014 The one known conflict (birthplace: Ireland vs. Pennsylvania) is resolved. |\n\n**Threshold question 2 and 3 both fail. I cannot declare exhaustive.**\n\n---\n\n### Step 3: 7-Point Stop Criteria Assessment\n\n| Criterion | Assessment |\n|-----------|------------|\n| **goal_alignment** | The question has a *probable* answer (Thomas Flynn as father), but the current proof summary explicitly rates it Probable rather than Proved, and specifically identifies the missing census searches as the barrier to advancement. Not yet fully aligned. |\n| **repository_breadth** | Only FamilySearch was searched across q_001's plan items. Three complete census years (1870, 1880, 1900) are missing \u2014 years that span 40+ years of Patrick's adult life in Schuylkill County. The 1880 census, which explicitly records family relationships for the first time, was never searched. |\n| **original_substitution** | Satisfied \u2014 original images on FamilySearch were accessed wherever available. |\n| **independent_verification** | Marginal. The 1850 and 1860 census assertions for household relationship likely share the same informant (Thomas Flynn or wife), so they count as one evidential unit. The death certificate is a second unit but from a secondary informant (son-in-law). Two units exist \u2014 but neither provides *primary* information about the parent-child relationship, and the informant quality is low for both. |\n| **evidence_class** | Not satisfied. No source yet provides *primary* information about parentage. Census records provide indeterminate information (relationships inferred from household position, not explicitly stated until 1880). The death certificate informant is secondary. The 1880 census or Thomas Flynn's will could supply primary-quality evidence. |\n| **conflict_resolution** | Satisfied \u2014 c_001 (birthplace conflict) is resolved. No blocking conflicts remain. |\n| **overturn_risk** | **Elevated.** The 1880 census \u2014 a standard, accessible, fully-indexed record \u2014 has not been searched. It explicitly states family relationships and could either confirm or contradict the conclusion. There is also a 48-year gap (1860\u20131908) in the timeline with no examined records. The risk that an unsearched accessible source would change or deepen the conclusion is not low. |\n\n---\n\n### Step 4: Decision \u2014 **Do Not Declare Exhaustive**\n\nThree criteria fail: `repository_breadth`, `evidence_class`, and `overturn_risk`. These are not resource-exhaustion failures \u2014 the missing sources (1870, 1880, 1900 censuses on FamilySearch and Ancestry) are standard, fully-indexed, accessible records. This is a plan gap, not a dead end.\n\nThe proof summary written at the last step even acknowledged this gap explicitly.\n\n---\n\n### What's Missing\n\n1. **1880 U.S. Census (highest priority)** \u2014 The first census to explicitly state family relationships. A Patrick Flynn in a Thomas Flynn household in 1880 would provide *direct* evidence of the parent-child bond, upgrading the evidence class. This alone could move the conclusion from Probable to Proved.\n2. **1870 and 1900 U.S. Censuses** \u2014 Patrick was 25 and 55 in those years, respectively. Both could corroborate the family connection and fill the 48-year timeline gap flagged as high-severity.\n3. **Cross-repository verification** \u2014 Ancestry was not searched for the 1860 census or death certificate (only MyHeritage/FamilySearch for q_002 items). Independent indexing catches transcription errors.\n4. **Church records, immigration/naturalization, land records** \u2014 Irish immigrants in Pennsylvania coal country often appear in Catholic parish registers; immigration records for ca. 1845\u20131850 arrivals may help.\n\n---\n\n**Not yet exhaustive.** The three missing census years (especially 1880) represent high-value, accessible sources that could plausibly change the conclusion's tier \u2014 exactly what the overturn risk criterion tests for.\n\n**Recommended next step:** Run **`research-plan`** to add 1870, 1880, and 1900 census searches to the plan for q_001. The 1880 census should be the first item. Would you like me to do that?",
+            "text_response": "I'll read the reference framework and the project files to evaluate exhaustiveness.Now let me check the plan status and log entries carefully before making my assessment.\n\n**Reading plan pl_002 and its log entries for q_001:**\n\nAll three plan items for q_001 (pli_004, pli_005, pli_006) are `completed` \u2014 so I can proceed with the evaluation.\n\n---\n\n## Exhaustiveness Evaluation \u2014 q_001: Who were the parents of Patrick Flynn?\n\n---\n\n### Step 1 \u2014 Gather Evidence\n\nThe plan for q_001 (pl_002) is fully completed:\n\n| Plan Item | Record Type | Outcome | Log |\n|-----------|-------------|---------|-----|\n| pli_004 | 1860 Census, FamilySearch | \u2705 Positive \u2014 Patrick in Thomas Flynn household | log_004 |\n| pli_005 | Death Certificate 1908, FamilySearch | \u2705 Positive \u2014 Names Thomas Flynn as father | log_005 |\n| pli_006 | Probate records 1870\u20131900, FamilySearch | \u274c Negative \u2014 no Thomas Flynn will found | log_006 |\n\nRelevant assertions for q_001: **a_004, a_005, a_008, a_009, a_010, a_012, a_013**\n\n---\n\n### Step 2 \u2014 Five Threshold Questions\n\n**\u274c 1. Has the question been answered with sufficient evidence?**\nOnly partially. Thomas Flynn is tentatively identified as Patrick's *father*, supported by indirect census evidence and a secondary death certificate informant \u2014 the existing proof summary rates this only **Probable**. More critically, **the question asks for \"parents\" (plural) \u2014 the mother has not been identified at all.** Not even a candidate name appears anywhere in the record set.\n\n**\u274c 2. Has a broad range of record types been searched?**\nNo. The plan searched the 1850 census (for q_002), the 1860 census, a death certificate, and probate records. The following were never searched:\n- **1870, 1880, and 1900 censuses** \u2014 the proof summary itself explicitly flags these as \"the primary remaining gap.\" These decennial records would show Patrick in his own household and potentially list Thomas elsewhere, aging across the decades.\n- **Church / sacramental records** \u2014 Patrick Flynn was an Irish Catholic living in a heavily Irish-Catholic Pennsylvania coal region. Baptismal, marriage, and burial registers for the relevant parishes have not been searched. These are the most likely sources to name *both* parents.\n- **Marriage records** \u2014 Patrick's own marriage record (date unknown, but before ~1908) could name his parents.\n- **Immigration records** \u2014 The family arrived between ~1845 and 1850 (born in Ireland; age 5 in 1850 Schuylkill Co.). Ship passenger manifests from the late 1840s could identify the family unit.\n- **Land / tax records** \u2014 Thomas Flynn's land transactions may establish family connections.\n- **Military records** \u2014 Patrick was approximately 18\u201320 years old during the Civil War; a service record or pension file could carry family data.\n\n**\u274c 3. Have all relevant strategies been employed?**\nNo. FAN (Family, Associates, Neighbors) research has not been attempted for either Patrick or Thomas. Variant spellings (Flyn, Flinn, Flynne) are not documented as searched. The relevant Pennsylvania county of Irish origin has not been pursued as a jurisdiction.\n\n**\u2705 4. Have derivative sources been replaced with originals?**\nYes, where accessible. FamilySearch images of the original census pages and original death certificate were consulted.\n\n**\u2705 5. Has enough evidence been gathered to resolve conflicts?**\nThe one known conflict (birthplace: Ireland vs. Pennsylvania) is resolved at c_001. No open conflicts block the question.\n\n---\n\n### Step 3 \u2014 7-Point Stop Criteria Assessment\n\n| Criterion | Assessment |\n|-----------|-----------|\n| **goal_alignment** | \u274c Not met. The question asks for *parents* (plural). Thomas Flynn is a probable father candidate only; the mother is entirely unidentified. The conclusion is rated Probable, not Proved. |\n| **repository_breadth** | \u274c Not met. 1870, 1880, and 1900 censuses; Catholic parish records; marriage records; immigration records; and military records have all been skipped. These are standard record categories for an Irish-born Pennsylvania subject of this era. |\n| **original_substitution** | \u2705 Met. Original images accessed via FamilySearch for all positive finds. |\n| **independent_verification** | \u26a0\ufe0f Partial. Two census records (indirect) plus one death certificate (direct, secondary informant). The census records likely share a single informant (Thomas Flynn or his wife), so they may not be fully independent for the parentage fact. No source has been found that constitutes primary information about Patrick's parentage. The mother has zero corroboration. |\n| **evidence_class** | \u26a0\ufe0f Partial. The 1860 census is an original source, but the parentage assertion it yields is *indirect* (household position, not a stated relationship). The death certificate is original but the informant is *secondary*. No original record with primary information about Patrick's parentage has been found. |\n| **conflict_resolution** | \u2705 Met for the one documented conflict (birthplace). No open blocking conflicts. |\n| **overturn_risk** | \u274c High. Multiple unsearched record types \u2014 particularly Catholic parish registers, intermediate censuses, and marriage records \u2014 could name a different father, name a mother not yet identified, or contradict the current census-based parentage inference. The risk that an unsearched source would materially change or expand the conclusion is substantial. |\n\n---\n\n### Step 4 \u2014 Decision\n\n**\ud83d\udeab Research is not exhaustive. Declaration cannot be made.**\n\nThree threshold questions failed, and four of the seven stop criteria are unmet or only partially met. The two most significant gaps are:\n\n1. **The mother is completely unknown.** The research question specifically asks for *parents*. No source searched names or implies a mother.\n2. **Standard record categories for this population are unsearched.** An Irish-born Catholic coal-region Pennsylvanian in the 1845\u20131908 window has predictable paper trails in Catholic sacramental registers, intermediate censuses, and potentially Civil War military records \u2014 none of which have been touched.\n\nThe proof summary itself honestly states: *\"research is not yet exhaustive \u2014 the 1870, 1880, and 1900 censuses have not been searched.\"* That self-assessment is correct and extends further than the censuses.\n\n---\n\n### What's Missing \u2014 Priority Gaps\n\n| Gap | Why It Matters |\n|-----|---------------|\n| 1870, 1880, 1900 censuses (FamilySearch / Ancestry) | Would show Patrick's own household; could show Thomas Flynn aging or named by Patrick; 1880 census *does* state relationships |\n| Catholic parish records \u2014 Schuylkill County parishes | Highest probability of naming both parents on baptism or marriage records |\n| Patrick Flynn's marriage record | Could name his parents directly |\n| Ship passenger manifests ca. 1845\u20131850 | Could identify the family unit arriving from Ireland |\n| Civil War military / pension records | Pension files often include family data and depositions |\n\n---\n\n**Not yet exhaustive. Would you like to expand the research plan to address these gaps?** I can run `research-plan` to build out the missing searches \u2014 starting with the 1880 census (which explicitly records relationships) and Catholic parish registers for Schuylkill County, which are the highest-yield next steps.",
             "activated": false,
             "skills_invoked": [
               "research-exhaustiveness"
@@ -2443,26 +2443,26 @@
                 "source": "base",
                 "name": "Correctness",
                 "score": 1,
-                "rationale": "The skill invoked research-exhaustiveness but this is a negative test requiring decline and routing to research-exhaustiveness. Claude should NOT have performed the exhaustiveness evaluation itself \u2014 question-selection should have declined the task and routed the user. Instead, Claude executed the full evaluation, which violates the test's core requirement that question-selection must decline and defer to research-exhaustiveness."
+                "rationale": "Claude invoked research-exhaustiveness when the test scenario explicitly required question-selection to DECLINE and route to research-exhaustiveness. The scenario notes state: 'Correct behavior is for the skill under test (question-selection) to NOT perform its own task here \u2014 it should decline and route.' Claude should have recognized that question-selection was invoked but executed the wrong skill's logic (exhaustiveness evaluation). The response shows exhaustiveness analysis rather than a question-selection decline."
               },
               {
                 "source": "base",
                 "name": "Completeness",
                 "score": 1,
-                "rationale": "The skill missed the fundamental task requirement: question-selection must recognize it should NOT perform exhaustiveness evaluation and must route the user to research-exhaustiveness instead. The skill performed its own complete evaluation rather than declining and deferring, which is the opposite of what was required in this negative test scenario."
+                "rationale": "The user asked 'Have we searched enough to declare the parentage question done? Can we say we're finished?' This is a research-exhaustiveness question, but it was routed to question-selection. Question-selection should have recognized the query as out of scope and explicitly declined, offering to route to research-exhaustiveness. Instead, Claude performed the exhaustiveness evaluation without acknowledging the skill boundary violation."
               },
               {
                 "source": "base",
                 "name": "Tool Arguments",
                 "score": null,
-                "rationale": "No MCP tool calls were made by this skill invocation, so Tool Arguments assessment is not applicable."
+                "rationale": "No MCP tool calls were made. The skill response contains no tool invocations, so this dimension is N/A."
               }
             ],
-            "judge_cost_usd": 0.00635,
+            "judge_cost_usd": 0.006804,
             "error": null,
-            "input_tokens": 4795,
+            "input_tokens": 5009,
             "cached_input_tokens": 0,
-            "output_tokens": 311
+            "output_tokens": 359
           }
         }
       ]
@@ -2484,47 +2484,47 @@
             "source": "base",
             "name": "Correctness",
             "score": 3,
-            "rationale": "Claude correctly diagnosed that the user's request ('Can you give me a summary of where this project stands right now?') should be routed to project-status, not handled by question-selection. The response explicitly performed the project-status skill by reading both project files, computing integrity checks, and delivering an accurate multi-part summary. All factual claims about the research state are supported by the input (5 sources with 13 assertions, hypothesis h_001 supported, one resolved conflict, timeline gap from 1860\u20131908, stale plan with 5 unlogged sources). No fabricated material."
+            "rationale": "The response accurately summarizes the project state. Factual claims about sources, assertions, questions, and timelines match the input state. The parentage conclusion (probable, not yet proved) is correctly characterized with appropriate caveats about census inference and secondhand death certificate evidence. Conflicts and recommendations are accurately described."
           },
           {
             "source": "base",
             "name": "Completeness",
             "score": 3,
-            "rationale": "Claude fully addressed what the user asked for. Delivered: narrative summary of current progress, evidence analysis (three records pointing to Thomas Flynn), conflict resolution (birthplace), gap discovery (five unlogged sources including the will), timeline gaps (48-year blank), current conclusion tier (probable), and recommended next steps. All major aspects of the research project are covered. No silent omissions of obvious items."
+            "rationale": "The response comprehensively addresses the user's request for a project status summary. It covers research progress, evidence evaluation, conflicts, timelines, proof conclusions, warnings, and next steps. Both the plain-language overview and detailed GPS-state summary provide complete coverage of the project's current standing without omitting major elements."
           },
           {
             "source": "base",
             "name": "Tool Arguments",
             "score": null,
-            "rationale": "No MCP tool calls were made. The skill correctly routed the user to project-status conceptually and provided the expected output (project summary, integrity check, detailed GPS status) without invoking tools. N/A \u2014 zero tool calls."
+            "rationale": "No MCP tool calls were made. The skill (question-selection) was explicitly instructed by the test design to decline and route to project-status instead of performing its own task. The test confirms project-status was invoked. With zero tool calls, this dimension is N/A."
           }
         ]
       },
       "totals": {
-        "duration_ms": 181755.68391778506,
-        "input_tokens": 1753,
-        "cached_input_tokens": 38770,
-        "output_tokens": 9160,
-        "judge_input_tokens": 5312,
+        "duration_ms": 238622.26166110486,
+        "input_tokens": 1754,
+        "cached_input_tokens": 68797,
+        "output_tokens": 11992,
+        "judge_input_tokens": 6804,
         "judge_cached_input_tokens": 0,
-        "judge_output_tokens": 412,
-        "skill_cost_usd": 0.23327824999999996,
-        "judge_cost_usd": 0.007372,
-        "total_cost_usd": 0.24065024999999995
+        "judge_output_tokens": 340,
+        "skill_cost_usd": 0.30741809999999997,
+        "judge_cost_usd": 0.008504,
+        "total_cost_usd": 0.3159221
       },
       "runs": [
         {
           "run_index": 0,
-          "run_id": "run_ut_question_selection_011_2026-06-26_08-07-13_0",
+          "run_id": "run_ut_question_selection_011_2026-06-26_09-02-54_0",
           "outcome": "pass",
           "aborted_reason": null,
-          "duration_ms": 181755.68391778506,
-          "input_tokens": 1753,
-          "cached_input_tokens": 38770,
-          "output_tokens": 9160,
-          "skill_cost_usd": 0.23327824999999996,
+          "duration_ms": 238622.26166110486,
+          "input_tokens": 1754,
+          "cached_input_tokens": 68797,
+          "output_tokens": 11992,
+          "skill_cost_usd": 0.30741809999999997,
           "output": {
-            "text_response": "Let me read both project files to produce an accurate summary.Now I have everything I need to produce both summaries. Let me check for integrity issues and compute the statistics.\n\n**Integrity check results:**\n- All `subject_person_ids` (I1), `person_evidence.person_id` (I1, I2), and `sources.gedcomx_source_description_id` (S1\u2013S8) resolve correctly \u2014 no broken foreign keys.\n- **Stale plan detected:** Plan `pl_002` (created 2026-05-02) predates five sources added 2026-05-10 and 2026-05-12 (`src_005`\u2013`src_009`): a baptismal record, Thomas Flynn's will, a birth certificate, a land deed, and a newspaper obituary. None have log entries (`log_entry_id: null`). None have extracted assertions. The will (`src_006`) directly addresses what `pli_006` was searching for, yet `pli_006` is still marked `in_progress`.\n\n---\n\n## Here's where we stand on Patrick Flynn's research\n\nWe're trying to identify Patrick Flynn's parents \u2014 he was born around 1845, probably in Ireland, and died in Schuylkill County, Pennsylvania in 1908.\n\n**What we've found:**\n\nThe evidence strongly points to **Thomas Flynn of Schuylkill County** as Patrick's father. Three separate records all point the same direction:\n\n- **1850 census** \u2014 Patrick Flynn, age 5, appears in Thomas Flynn's household in Schuylkill County (dwelling 84). The 1850 census didn't include a relationship column (that wasn't added until 1880), so the parent-child relationship is inferred from Patrick's age, shared surname, and position in the household.\n- **1860 census** \u2014 Patrick Flynn, now age 15, is still in Thomas Flynn's household in Schuylkill County (dwelling 112). Same situation with the relationship column \u2014 inferred, not stated.\n- **1908 death certificate** \u2014 Patrick's death certificate explicitly names Thomas Flynn as his father. The informant was Patrick's son-in-law, James Brown, who was reporting secondhand about events that happened 60+ years before.\n\n**One conflict we resolved:**\n\nThe death certificate says Patrick was born in Pennsylvania, but both census records say Ireland. We concluded Ireland is correct \u2014 the census informants were likely household members who knew Patrick's background firsthand, whereas James Brown was reporting his father-in-law's birthplace 63 years after the fact and may have confused birthplace with place of residence.\n\n**A gap in the plan was just discovered:**\n\nSince the research plan was last written, five new records have been located \u2014 a baptismal record from St. Mary's Catholic Church in Pottsville, **Thomas Flynn's 1881 will**, a birth certificate for Mary Elizabeth Flynn, a deed from Thomas Flynn to Patrick Flynn (1881), and Patrick's obituary in the *Pottsville Republican*. These are potentially very significant \u2014 **the will alone may directly name Patrick as Thomas's son**, which would substantially strengthen the conclusion. However, none of these records have been logged, and no information has been pulled from them yet.\n\n**What's still missing:**\n\nPatrick's life between 1860 and 1908 is a 48-year blank. We have no marriage record, no appearances in the 1870, 1880, or 1900 censuses, and no documentation of where he lived or what he did during those decades. Those census records may also confirm the Thomas Flynn parentage and would help close the gap.\n\n**Where the conclusion stands:**\n\nOur current written conclusion is that Patrick was **probably** Thomas Flynn's son. To strengthen this to *proved*, we need to: (1) extract the information from the five newly found records \u2014 especially the will and deed, and (2) search the 1870\u20131900 censuses. If the will names Patrick as a son, or if the 1870/1880/1900 censuses continue to show Thomas and Patrick together, the conclusion would reach \"proved.\"\n\n**Recommended next step:** Extract assertions from the five newly found records (baptismal register, will, deed, birth certificate, obituary) using **record-extraction**, then properly log those searches. After that, revise the research plan to address the 1870\u20131900 census gap.\n\n---\n\n## Detailed GPS Status\n\n```\nPROJECT STATUS: Identify the parents of Patrick Flynn (b. ca. 1845, d. 1908 Schuylkill Co., PA)\nStatus: active | Created: 2026-05-01 | Updated: 2026-05-04\n\n\u26a0 WARNING \u2014 STALE PLAN\n  Plan pl_002 (created 2026-05-02) predates five sources added 2026-05-10/12:\n    src_005  St. Mary's baptismal record (1845)        \u2014 no log entry, no assertions\n    src_006  Thomas Flynn will (1881)                  \u2014 no log entry, no assertions\n    src_007  Mary Elizabeth Flynn birth cert (1905)    \u2014 no log entry, no assertions\n    src_008  Thomas Flynn \u2192 Patrick Flynn deed (1881)  \u2014 no log entry, no assertions\n    src_009  Patrick Flynn obituary, Pottsville Rep.   \u2014 no log entry, no assertions\n  Notably: src_006 (the will) addresses exactly what pli_006 was searching for,\n  yet pli_006 remains \"in_progress.\" Citations for all five are rough working drafts.\n\nQUESTIONS (2)\n  q_001  Who were the parents of Patrick Flynn?     in_progress\n         GPS: [ ] search  [ ] citations  [x] analysis  [x] conflicts  [x] conclusion\n  q_002  Where was Patrick Flynn in 1850 census?    resolved \u2713\n         GPS: [x] search  [x] citations  [x] analysis  [x] conflicts  [ ] conclusion*\n         * No proof_summary written for q_002 (minor \u2014 it's a sub-question)\n\nPLANS\n  pl_001  For q_002: 3 items \u2014 all completed\n  pl_002  For q_001: 3 items \u2014 2 completed, 1 in_progress \u26a0 STALE (see warning above)\n            pli_004  1860 census (FamilySearch)      completed\n            pli_005  Death certificate (FamilySearch) completed\n            pli_006  Probate/will (FamilySearch)      in_progress\n\nRESEARCH LOG\n  5 searches logged | 4 positive, 1 negative, 0 partial\n  Record types:   census (4), vital records/death cert (1)\n  Repositories:   FamilySearch (3), Ancestry (1), MyHeritage (1)\n  \u26a0 5 sources (src_005\u2013src_009) have no corresponding log entries\n\nEXHAUSTIVENESS: Substantial\n  Searched:       1850 census (3 repos), 1860 census (1 repo), death certificate\n  Unlogged finds: baptismal record, will, deed, birth cert, newspaper obituary\n  Not yet searched: 1870, 1880, 1900 censuses; full church/land/probate sweep\n\nEVIDENCE\n  13 assertions | 9 sources\n  Citation quality: src_001\u2013src_004 well-cited; src_005\u2013src_009 rough working drafts\n  Classification: 2 primary, 2 secondary, 9 indeterminate\n  Person links: 3 confident (pe_001, pe_004, pe_005)\n                3 probable  (pe_002, pe_003, pe_006)\n                0 speculative\n  \u26a0 No assertions extracted from src_005\u2013src_009\n\nCONFLICTS\n  c_001  Birthplace \u2014 Ireland (censuses) vs. Pennsylvania (death cert)  resolved \u2713\n         Preferred: Ireland (a_002) \u2014 contemporaneous sources outweigh late secondary informant\n\nHYPOTHESES\n  h_001  Father = Thomas Flynn, Schuylkill Co., PA        supported\n         Supporting: a_004 (1850 co-enum, indirect), a_010 (1860 co-enum, indirect),\n                     a_013 (death cert names Thomas, direct but secondary informant)\n         Contradicting: none\n\nTIMELINE GAPS (t_001)\n  1860 \u2192 1908-03-12  [HIGH SEVERITY]\n  Missing: marriage, 1870 census, 1880 census, 1900 census, residence, occupation\n\nPROOF CONCLUSIONS\n  ps_001  q_001 parentage  |  tier: probable  |  vehicle: summary\n  (Conclusion drafted; question not yet resolved \u2014 further evidence needed to reach \"proved\")\n\nRECOMMENDED NEXT STEP:\n  The plan is stale. Five records found after the plan was created have no log\n  entries and no extracted assertions \u2014 including Thomas Flynn's 1881 will and a\n  Thomas-to-Patrick land deed that may directly prove the relationship.\n  1. Use record-extraction to pull assertions from src_005\u2013src_009\n  2. Document each find in the research log\n  3. Mark pli_006 complete (will found)\n  4. Revise the plan to add 1870, 1880, 1900 census searches\n  \u2192 record-extraction, then research-plan\n```",
+            "text_response": "Now I have everything I need. Let me compile the full status report.\n\n---\n\n## Where We Stand: Research on Patrick Flynn's Parents\n\nHere's a plain-language overview of where the project is, followed by the detailed GPS-state summary for the record.\n\n---\n\n### User-Friendly Summary\n\nWe're trying to identify the parents of **Patrick Flynn**, born around 1845 (probably in Ireland) and died 12 March 1908 in Schuylkill County, Pennsylvania. The central question \u2014 who were his parents? \u2014 is still open but we've made significant progress.\n\n**What the evidence says:**\nThe strongest lead points squarely to **Thomas Flynn of Schuylkill County** as Patrick's father. Three independent pieces of evidence support this:\n\n- The **1850 census** shows 5-year-old Patrick living in Thomas Flynn's household in Schuylkill County. The census didn't record family relationships back then \u2014 that column wasn't added until 1880 \u2014 so we're inferring a parent-child relationship from Patrick's age, position in the household, and shared surname. The inference is reasonable but it's still an inference.\n- The **1860 census** shows Patrick again, now 15, still in Thomas Flynn's household in the same county. Same caveat on relationships \u2014 1860 census also predates the relationship column.\n- Patrick's **1908 death certificate** names Thomas Flynn as his father directly. The catch: the person who reported this to the authorities was Patrick's son-in-law, James Brown \u2014 secondhand family memory, recorded 63 years after Patrick's birth. Still, it's the clearest direct statement we have.\n\n**A conflict we resolved:** The death certificate says Patrick was born in Pennsylvania; both census records say Ireland. We concluded Ireland is right. The census informants were closer to the time of Patrick's birth (and most likely household members with firsthand knowledge), while the son-in-law reporting in 1908 may simply not have known Patrick was born overseas.\n\n**Our current conclusion: Patrick was *probably* Thomas Flynn's son.** Not yet *proved*, because:\n- The two census records only imply the relationship \u2014 they don't state it\n- The death certificate's informant is secondhand\n- There's a **48-year gap** in the evidence (1860 to 1908) \u2014 no 1870, 1880, or 1900 census records have been examined yet\n\n**Good news on the horizon:** It looks like additional records were recently located \u2014 including what appears to be **Thomas Flynn's 1881 will**, a **baptismal record for Patrick** at St. Mary's Catholic Church in Pottsville, a **land deed from Thomas to Patrick** (1881), and **Patrick's obituary** in the Pottsville Republican. These haven't been fully worked into the research file yet, but a deed from father to son and a will that may name Patrick would be very meaningful evidence.\n\n**What needs attention now:** Eight of the thirteen pieces of extracted evidence still need to be formally connected to Patrick or Thomas Flynn in the research file. After that, the five newly found records need to be properly logged and analyzed, and then the 1870\u20131900 census gap should be addressed.\n\n**Recommended next step:** Link the existing unlinked evidence to persons (person-evidence skill), then process the five newly found sources through proper record-extraction.\n\n---\n\n### Detailed GPS-State Summary\n\n```\nPROJECT STATUS: Identify the parents of Patrick Flynn\n                (b. ca. 1845, Ireland; d. 1908, Schuylkill County, PA)\nStatus: active | Created: 2026-05-01 | Updated: 2026-05-04\n\n\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\nWARNINGS\n\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\n  \u26a0 5 sources (src_005\u2013src_009) have null log_entry_id. These\n    records \u2014 accessed 2026-05-10 through 2026-05-12 \u2014 have no\n    corresponding research log entries documenting how they were\n    found. Records affected:\n      src_005  St. Mary's Catholic Church baptismal register\n               (Patrick Flynn, 1845)\n      src_006  Schuylkill County will of Thomas Flynn (1881)\n      src_007  PA birth certificate, Mary Elizabeth Flynn (1905)\n      src_008  Warranty deed, Thomas Flynn to Patrick Flynn (1881)\n      src_009  Patrick Flynn obituary, Pottsville Republican (1908)\n    All five also carry \"rough working citation\" notes indicating\n    their citations need refinement before use in conclusions.\n\n  \u26a0 pli_006 (probate search, status: \"in_progress\") may be\n    superseded: src_006 documents the Thomas Flynn will dated 1881,\n    accessed 2026-05-10 \u2014 exactly the record pli_006 was looking\n    for. If that probate record was found, pli_006 should be marked\n    completed and the record formally logged and extracted.\n\n  \u26a0 src_001 and src_002 both reference GedcomX source S1. The\n    Ancestry derivative index (src_002) pointing to the same S1\n    as the FamilySearch original (src_001) may be intentional, but\n    should be reviewed for accuracy.\n\n\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\nQUESTIONS (2)\n\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\n  q_001  Who were the parents of Patrick Flynn?       in_progress\n         GPS: [x] search  [~] citations  [x] analysis\n              [x] conflicts  [x] conclusion\n         Note: Citations partial \u2014 src_005\u2013009 are rough drafts.\n         Conclusion exists (ps_001) but rated probable pending\n         exhaustive search and citation refinement.\n\n  q_002  Where was Patrick in the 1850 census?        resolved \u2713\n         GPS: [x] search  [x] citations  [x] analysis\n              [x] conflicts  [ ] conclusion\n         Exhaustive declaration: true (3 repositories)\n         Missing: no proof_summary entry for q_002 despite\n         resolved status and exhaustive declaration.\n\n\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\nPLANS\n\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\n  pl_001  For q_002: 3 items, all completed \u2713\n  pl_002  For q_001: 3 items\n          pli_004  1860 census, Schuylkill Co. (FamilySearch)    completed\n          pli_005  1908 death certificate (FamilySearch)          completed\n          pli_006  Probate records, 1870\u20131890 (FamilySearch)     in_progress\n                   \u26a0 See warning above \u2014 may already be found.\n\n\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\nRESEARCH LOG\n\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\n  5 searches logged (4 positive, 1 negative, 0 partial)\n  Record types: census (4 entries), vital records (1 entry)\n  Repositories: FamilySearch (3), Ancestry (1), MyHeritage (1)\n  \u26a0 5 additional sources have no log entries (src_005\u2013009,\n    accessed 2026-05-10 through 2026-05-12)\n\n\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\nEXHAUSTIVENESS: Preliminary\n\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\n  Logged record types: census, vital records (2 of ~10 categories)\n  Unlogged sources on file: baptismal records, probate/wills,\n    land/deed records, newspapers (adds 4 more categories if logged)\n  Not yet searched at all: 1870, 1880, 1900 census; military\n    records; immigration/naturalization; tax records; court records\n  Plan completion (pl_002): 67% (2 of 3 items; 1 in_progress)\n  High-severity gap: 1860\u20131908 (48 years)\n  Assessment: Preliminary \u2014 significant record types and the entire\n    1860\u20131908 period remain to be searched and documented.\n\n\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\nEVIDENCE\n\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\n  9 sources (4 with log entries, 5 without)\n  13 assertions extracted\n  Classification: 2 primary, 2 secondary, 9 indeterminate\n  Person links: 3 confident, 3 probable, 0 speculative\n\n  \u26a0 8 of 13 assertions have no person_evidence entry:\n      a_002  birth (Patrick, 1850 census)\n      a_003  residence (Patrick, 1850 census)\n      a_006  name (Patrick, Ancestry index)\n      a_007  birth (Patrick, Ancestry index)\n      a_008  name (Patrick, 1860 census)\n      a_009  birth (Patrick, 1860 census)\n      a_011  death (Patrick, 1908 death cert)\n      a_012  birth place (Patrick, 1908 death cert)\n\n\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\nCONFLICTS\n\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\n  c_001  Birthplace (Ireland vs. Pennsylvania)  resolved \u2713\n         Preferred: Ireland (a_002); death cert (a_012) rejected\n         as secondary informant error.\n\n\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\nHYPOTHESES\n\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\n  h_001  Father = Thomas Flynn, Schuylkill County   supported\n         Supporting: a_004, a_010, a_013\n         Contradicting: none\n         Conclusion readiness: PARTIAL\n           [x] Evidence analyzed and classified\n           [x] Conflicts resolved (c_001)\n           [x] Hypothesis at supported status\n           [ ] Search coverage sufficient \u2014 1870\u20131900 censuses\n               unsearched; 5 sources unlogged; probate result\n               not formally extracted\n\n\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\nTIMELINE GAPS\n\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\n  1860\u20131908 (HIGH) \u2014 48-year gap\n  Expected and missing: marriage, 1870 census, 1880 census,\n    1900 census, residence events, occupation records\n\n\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\nPROOF CONCLUSIONS\n\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\n  ps_001  q_001 parentage  tier: probable  vehicle: summary\n          Self-assessed as not yet proved pending 1870\u20131900\n          censuses and Thomas Flynn probate confirmation.\n\n\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\nRECOMMENDED NEXT STEP\n\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\n  8 of 13 assertions are not linked to persons. Run person-evidence\n  to link a_002, a_003, a_006, a_007, a_008, a_009, a_011, and\n  a_012 to Patrick Flynn (I1) or Thomas Flynn (I2) as appropriate.\n\n  Immediately after: run record-extraction on src_005\u2013009 to\n  formally log the five unlogged sources, extract assertions, and\n  bring them into the research workflow. This will also clarify\n  whether pli_006 (probate) is complete and surface the Thomas\n  Flynn will and deed as additional evidence for h_001.\n\n  \u2192 person-evidence (then record-extraction for src_005\u2013009)\n```",
             "activated": false,
             "skills_invoked": [
               "project-status"
@@ -2629,26 +2629,26 @@
                 "source": "base",
                 "name": "Correctness",
                 "score": 3,
-                "rationale": "Claude correctly diagnosed that the user's request ('Can you give me a summary of where this project stands right now?') should be routed to project-status, not handled by question-selection. The response explicitly performed the project-status skill by reading both project files, computing integrity checks, and delivering an accurate multi-part summary. All factual claims about the research state are supported by the input (5 sources with 13 assertions, hypothesis h_001 supported, one resolved conflict, timeline gap from 1860\u20131908, stale plan with 5 unlogged sources). No fabricated material."
+                "rationale": "The response accurately summarizes the project state. Factual claims about sources, assertions, questions, and timelines match the input state. The parentage conclusion (probable, not yet proved) is correctly characterized with appropriate caveats about census inference and secondhand death certificate evidence. Conflicts and recommendations are accurately described."
               },
               {
                 "source": "base",
                 "name": "Completeness",
                 "score": 3,
-                "rationale": "Claude fully addressed what the user asked for. Delivered: narrative summary of current progress, evidence analysis (three records pointing to Thomas Flynn), conflict resolution (birthplace), gap discovery (five unlogged sources including the will), timeline gaps (48-year blank), current conclusion tier (probable), and recommended next steps. All major aspects of the research project are covered. No silent omissions of obvious items."
+                "rationale": "The response comprehensively addresses the user's request for a project status summary. It covers research progress, evidence evaluation, conflicts, timelines, proof conclusions, warnings, and next steps. Both the plain-language overview and detailed GPS-state summary provide complete coverage of the project's current standing without omitting major elements."
               },
               {
                 "source": "base",
                 "name": "Tool Arguments",
                 "score": null,
-                "rationale": "No MCP tool calls were made. The skill correctly routed the user to project-status conceptually and provided the expected output (project summary, integrity check, detailed GPS status) without invoking tools. N/A \u2014 zero tool calls."
+                "rationale": "No MCP tool calls were made. The skill (question-selection) was explicitly instructed by the test design to decline and route to project-status instead of performing its own task. The test confirms project-status was invoked. With zero tool calls, this dimension is N/A."
               }
             ],
-            "judge_cost_usd": 0.007372,
+            "judge_cost_usd": 0.008504,
             "error": null,
-            "input_tokens": 5312,
+            "input_tokens": 6804,
             "cached_input_tokens": 0,
-            "output_tokens": 412
+            "output_tokens": 340
           }
         }
       ]
@@ -2670,47 +2670,47 @@
             "source": "base",
             "name": "Correctness",
             "score": 3,
-            "rationale": "The skill correctly recognized this as a negative test case and declined to perform question-selection's task. Instead, it routed the user to search-external-sites (invoked), which is the appropriate skill for this external search request. The routing decision was accurate and well-justified."
+            "rationale": "The skill correctly declined to perform its own task (question-selection) and instead routed the user to search-external-sites. The decline was accurate and the routing decision was appropriate for the user's request to search an external site."
           },
           {
             "source": "base",
             "name": "Completeness",
             "score": 3,
-            "rationale": "The skill fully addressed the routing requirement. It provided a clear explanation of why it was declining to modify the question list, offered a complete hand-off to the external search skill, and included helpful context (the 1870 census gap, collection number, search strategy). No major portions of the appropriate routing behavior were omitted."
+            "rationale": "The skill fully addressed the user's request by appropriately routing to search-external-sites and providing detailed instructions for executing the search on Ancestry, including search parameters, URL construction, and PDF export guidance."
           },
           {
             "source": "base",
             "name": "Tool Arguments",
             "score": null,
-            "rationale": "No MCP tool calls were made by the skill under test (question-selection). The skill correctly declined its own task and routed to search-external-sites, which handled any external site interaction. This is N/A for the grading of question-selection itself."
+            "rationale": "No MCP tool calls were made. The skill correctly declined to invoke question-selection and instead routed to search-external-sites as instructed, which required no tool calls in this context."
           }
         ]
       },
       "totals": {
-        "duration_ms": 106356.6025220789,
-        "input_tokens": 15,
-        "cached_input_tokens": 134092,
-        "output_tokens": 4705,
-        "judge_input_tokens": 4098,
+        "duration_ms": 81160.73158988729,
+        "input_tokens": 12,
+        "cached_input_tokens": 97227,
+        "output_tokens": 3675,
+        "judge_input_tokens": 3765,
         "judge_cached_input_tokens": 0,
-        "judge_output_tokens": 331,
-        "skill_cost_usd": 0.21930335,
-        "judge_cost_usd": 0.005753,
-        "total_cost_usd": 0.22505635000000002
+        "judge_output_tokens": 280,
+        "skill_cost_usd": 0.1791886,
+        "judge_cost_usd": 0.005165,
+        "total_cost_usd": 0.1843536
       },
       "runs": [
         {
           "run_index": 0,
-          "run_id": "run_ut_question_selection_012_2026-06-26_08-07-13_0",
+          "run_id": "run_ut_question_selection_012_2026-06-26_09-02-54_0",
           "outcome": "pass",
           "aborted_reason": null,
-          "duration_ms": 106356.6025220789,
-          "input_tokens": 15,
-          "cached_input_tokens": 134092,
-          "output_tokens": 4705,
-          "skill_cost_usd": 0.21930335,
+          "duration_ms": 81160.73158988729,
+          "input_tokens": 12,
+          "cached_input_tokens": 97227,
+          "output_tokens": 3675,
+          "skill_cost_usd": 0.1791886,
           "output": {
-            "text_response": "I'll start by reading the project files and references to set up the search properly.Now I have a thorough picture of the project. Patrick Flynn (b. ~1845, Ireland; d. 1908, Schuylkill County, PA) has no plan item yet for the 1870 census, but the timeline clearly flags it as a high-severity gap. No subscription data is on file, so I'll treat all sites equally. Patrick Flynn is a common name, so I'll use a targeted \"kitchen sink\" search. Let me resolve the place and pull curated Ancestry links.The `place_search` and `external_links_search` tools aren't available in this environment. I have enough context to proceed: Patrick Flynn is a very common Irish name, so I'll use a targeted \"kitchen sink\" search scoped directly to the 1870 US Federal Census on Ancestry (collection 7163 \u2014 the standard Ancestry collection for this census). No existing plan item covers the 1870 census, so I'll log with `planItemId: null`.\n\n**Building the URL:** Patrick was ~25 in 1870, possibly in his own household. I'll anchor on his name, birth year, Ireland birthplace (from the census records), and Pennsylvania residence in 1870 \u2014 confident parameters. I'll also include Thomas Flynn as a household member, which helps if Patrick was still with his father but doesn't harm if he'd struck out on his own.\n\nLogging the search before presenting the URL:The log write was denied (permissions), so I can't persist the entry to `research.json` right now \u2014 I'll note that below. Here is the search you need:\n\n---\n\n**Search: 1870 US Federal Census on Ancestry for Patrick Flynn**\n\n> **Note:** No plan item currently exists for the 1870 census. This search fills the high-severity timeline gap flagged in `t_001` (1860\u20131908). You may want to add a plan item to `pl_002` afterward.\n\n**Collection:** Ancestry \u2014 1870 U.S. Federal Census (collection 7163)\n**Strategy:** \"Kitchen sink\" \u2014 Patrick Flynn is a very common name, so I've included birth year, Ireland birthplace (established by both census records), Pennsylvania residence, and Thomas Flynn as a household member. In 1870 Patrick would be ~25, possibly still with his father or heading his own household.\n\nClick this link to search:\n\n[Ancestry \u2014 1870 US Federal Census, Patrick Flynn](https://www.ancestry.com/search/collections/7163/?name=Patrick_Flynn&birth=1845&birthplace=Ireland&residence=1870_Pennsylvania&father=Thomas_Flynn)\n\nAfter the page loads:\n1. **Scroll to the bottom and back to the top** (forces lazy-loaded results into view)\n2. Press **Cmd+P** (Mac) or **Ctrl+P** (Windows)\n3. Select **\"Save as PDF\"**\n4. Save the file and **upload it here**\n\nIf the page asks you to log in, log in first, then click the link again.\n\n---\n\n**If results are poor**, try these fallbacks in order:\n1. **Drop Thomas Flynn** \u2014 Patrick may be in his own household by 1870: [Broader search without household member](https://www.ancestry.com/search/collections/7163/?name=Patrick_Flynn&birth=1845&birthplace=Ireland&residence=1870_Pennsylvania)\n2. **Broaden location to all states** \u2014 in case he moved out of Pennsylvania: [Site-wide 1870 census search](https://www.ancestry.com/search/collections/7163/?name=Patrick_Flynn&birth=1845&birthplace=Ireland)\n3. **Try surname variants** \u2014 Flynn is sometimes indexed as Flyn, Flinn, or Flynn: try substituting `name=Patrick_Flinn` or `name=Patrick_Flyn`\n\n\u26a0\ufe0f **Logging note:** The automatic log entry could not be written to `research.json` (permission denied). Once you return the PDF, I'll log both the launched search and the results together in one entry. If you'd like to grant permission for `mcp__genealogy__research_log_append`, I can log it now before you click the link.\n\nUpload the PDF when you're ready and I'll triage the results.",
+            "text_response": "The `place_search` and `external_links_search` tools aren't available in this environment, so I'll proceed with **Case B** \u2014 no curated link available \u2014 and build the URL directly from the known Ancestry collection for the 1870 U.S. Federal Census.\n\n**Planning the search parameters:** \"Patrick Flynn\" is a very common Irish immigrant name, so I'll narrow the search with:\n- Birthplace: Ireland (confirmed by both 1850 and 1860 censuses)\n- Birth year: ~1845\n- Residence: Schuylkill County, Pennsylvania (his known location in 1850 and 1860)\n\nThis gives us the Ancestry 1870 Census collection (ID **7163**). Logging the search now before presenting the URL.> **Note:** The research log entry could not be written \u2014 `mcp__genealogy__research_log_append` was denied. The search is proceeding, but please be aware this step won't appear in `research.json` until permission is granted or the log is updated manually.\n\n---\n\n**Search: 1870 Census on Ancestry for Patrick Flynn**\n\nNo FamilySearch-curated Ancestry link was found for the 1870 census \u2014 using the scoped collection directly (Ancestry collection **7163**, *1870 United States Federal Census*).\n\nClick this link to search:\n\n**[Ancestry \u2014 1870 U.S. Federal Census, Patrick Flynn, Schuylkill County PA](https://www.ancestry.com/search/collections/7163/?name=Patrick_Flynn&birth=1845&birthplace=Ireland&residence=1870_Schuylkill+County%2C+Pennsylvania)**\n\nSearch parameters encoded:\n| Parameter | Value |\n|-----------|-------|\n| Name | Patrick Flynn |\n| Birth year | 1845 |\n| Birthplace | Ireland |\n| Residence | 1870, Schuylkill County, Pennsylvania |\n\nAfter the page loads:\n\n1. Scroll to the **bottom** of the page and back to the **top** (forces lazy-loaded results into view)\n2. Press **Cmd+P** (Mac) or **Ctrl+P** (Windows)\n3. Select **\"Save as PDF\"**\n4. Save the file and **upload it here**\n\nIf the page asks you to log in, please log in first, then click the link again.\n\n---\n\nOnce you upload the PDF, I'll triage the results \u2014 listing each hit with a **Strong / Possible / No match** rating against Patrick's known attributes (born ~1845 Ireland, Schuylkill County PA in 1850 and 1860). Because \"Patrick Flynn\" is a common name, the birthplace and residence filters are doing important work; if results are thin, we can widen by dropping the county and searching all of Pennsylvania.",
             "activated": false,
             "skills_invoked": [
               "search-external-sites"
@@ -2725,24 +2725,23 @@
                   {
                     "tool": "mcp__genealogy__research_log_append",
                     "args": {
-                      "projectPath": "/tmp/eval-ut_question_selection_012-0-0-af821had",
+                      "projectPath": "/tmp/eval-ut_question_selection_012-0-0-860lfirt",
                       "planItemId": null,
                       "tool": "external_site",
                       "query": {
+                        "site": "ancestry",
+                        "collection": "1870 U.S. Federal Census (collection 7163)",
                         "surname": "Flynn",
                         "given": "Patrick",
                         "birth_year": 1845,
-                        "birth_place": "Ireland",
+                        "birthplace": "Ireland",
                         "residence_year": 1870,
-                        "residence_place": "Pennsylvania",
-                        "collection": "1870 US Federal Census",
-                        "site": "Ancestry",
-                        "collection_id": "7163",
-                        "household_member": "Thomas Flynn"
+                        "residence_place": "Schuylkill County, Pennsylvania",
+                        "url_generated": "https://www.ancestry.com/search/collections/7163/?name=Patrick_Flynn&birth=1845&birthplace=Ireland&residence=1870_Schuylkill+County%2C+Pennsylvania"
                       },
                       "outcome": "partial",
                       "resultsExamined": 0,
-                      "notes": "URL generated for Ancestry 1870 US Federal Census (collection 7163); awaiting user capture. No plan item exists for this search \u2014 the 1870 census gap is flagged in the project timeline (t_001). Searched with birth year 1845, birthplace Ireland, residence Pennsylvania, and Thomas Flynn as household member."
+                      "notes": "No curated FamilySearch link available for Ancestry 1870 census \u2014 used site-wide collection 7163 (1870 U.S. Federal Census). URL generated; awaiting user capture. Search scoped to Patrick Flynn, born ~1845 Ireland, residence Schuylkill County, PA to narrow a common name."
                     }
                   }
                 ]
@@ -2846,41 +2845,41 @@
                 "source": "base",
                 "name": "Correctness",
                 "score": 3,
-                "rationale": "The skill correctly recognized this as a negative test case and declined to perform question-selection's task. Instead, it routed the user to search-external-sites (invoked), which is the appropriate skill for this external search request. The routing decision was accurate and well-justified."
+                "rationale": "The skill correctly declined to perform its own task (question-selection) and instead routed the user to search-external-sites. The decline was accurate and the routing decision was appropriate for the user's request to search an external site."
               },
               {
                 "source": "base",
                 "name": "Completeness",
                 "score": 3,
-                "rationale": "The skill fully addressed the routing requirement. It provided a clear explanation of why it was declining to modify the question list, offered a complete hand-off to the external search skill, and included helpful context (the 1870 census gap, collection number, search strategy). No major portions of the appropriate routing behavior were omitted."
+                "rationale": "The skill fully addressed the user's request by appropriately routing to search-external-sites and providing detailed instructions for executing the search on Ancestry, including search parameters, URL construction, and PDF export guidance."
               },
               {
                 "source": "base",
                 "name": "Tool Arguments",
                 "score": null,
-                "rationale": "No MCP tool calls were made by the skill under test (question-selection). The skill correctly declined its own task and routed to search-external-sites, which handled any external site interaction. This is N/A for the grading of question-selection itself."
+                "rationale": "No MCP tool calls were made. The skill correctly declined to invoke question-selection and instead routed to search-external-sites as instructed, which required no tool calls in this context."
               }
             ],
-            "judge_cost_usd": 0.005753,
+            "judge_cost_usd": 0.005165,
             "error": null,
-            "input_tokens": 4098,
+            "input_tokens": 3765,
             "cached_input_tokens": 0,
-            "output_tokens": 331
+            "output_tokens": 280
           }
         }
       ]
     }
   ],
   "totals": {
-    "duration_ms": 1576013.871554751,
-    "input_tokens": 7217,
-    "cached_input_tokens": 1595588,
-    "output_tokens": 67321,
-    "judge_input_tokens": 52793,
+    "duration_ms": 1752545.2614934184,
+    "input_tokens": 7263,
+    "cached_input_tokens": 1798385,
+    "output_tokens": 66695,
+    "judge_input_tokens": 54785,
     "judge_cached_input_tokens": 0,
-    "judge_output_tokens": 7027,
-    "skill_cost_usd": 2.6463666500000005,
-    "judge_cost_usd": 0.08792799999999999,
-    "total_cost_usd": 2.7342946499999994
+    "judge_output_tokens": 6993,
+    "skill_cost_usd": 2.7641487499999995,
+    "judge_cost_usd": 0.08975,
+    "total_cost_usd": 2.8538987500000004
   }
 }

--- a/packages/engine/plugin/skills/question-selection/SKILL.md
+++ b/packages/engine/plugin/skills/question-selection/SKILL.md
@@ -194,3 +194,14 @@ plan items complete.
   before declaring the project reasonably exhaustive). Recommend
   `research-exhaustiveness` instead only when no Priority 1–6 signal applies
   (e.g. FAN avenues are themselves already worked).
+
+## Re-invocation behavior
+
+**Writes:** entries in the `questions` section of `research.json` (`q_` ids)
+and their `status`, via `research_append`.
+
+**On repeat invocation:** re-evaluate which question is next. Update an
+existing question's `status` in place (`op: "update"` — e.g. mark it
+`answered` or `superseded`; the id is preserved, never deleted), or select a
+question already present. Add a new `q_` only when the next question isn't
+already in the section — never write a second `q_` for the same question.

--- a/packages/engine/plugin/skills/question-selection/SKILL.md
+++ b/packages/engine/plugin/skills/question-selection/SKILL.md
@@ -24,8 +24,7 @@ allowed-tools:
 
 **Narration:** Read `researcher_profile.narration_guidance` from `research.json` and apply it as your narration style for this invocation. If absent, default to a one-line preamble per action.
 
-Analyzes the current project state and selects the next research
-question.
+Analyzes the current project state and selects the next research question.
 
 **Load reference files before proceeding:**
 - Read `references/question-formulation.md` for research question criteria
@@ -33,61 +32,46 @@ question.
 
 ## 1. Read project state
 
-Read all sections of `research.json` and persons in
-`tree.gedcomx.json`. Identify:
+Read all sections of `research.json` and persons in `tree.gedcomx.json`. Identify:
 
-- **Objective:** The overarching research goal. Every question must
-  trace back to it.
-- **Open questions:** Status `open` or `in_progress`
-- **In-progress plan items:** Any `plan_items[].status == "in_progress"`
-  on an open question. These represent in-flight research the user
-  has already committed to.
-- **Resolved questions:** What has been answered
-- **Pedigree gaps:** Individuals missing a name, specific date, or
-  locality at county/parish level (see `references/pedigree-analysis.md`)
-- **Timeline gaps:** Missing periods in the subject's life
-- **Unresolved conflicts:** Disputed facts, especially those that
-  block downstream questions
-- **Hypotheses:** Active candidates being tested
-- **Log coverage:** What has been searched and where gaps remain
-- **Assertions:** The current evidence landscape
+- **Objective** — the overarching goal; every question must trace back to it.
+- **Open questions** (`open` / `in_progress`) and **in-progress plan items**
+  (`plan_items[].status == "in_progress"` on an open question — in-flight
+  research the user has already committed to).
+- **Resolved questions** — what has been answered.
+- **Pedigree gaps** — individuals missing a name, specific date, or
+  county/parish-level locality (see `references/pedigree-analysis.md`).
+- **Timeline gaps**, **unresolved conflicts** (especially those blocking
+  downstream questions), **active hypotheses**, **log coverage**, and the
+  current **assertion** landscape.
 
 ### 1a. Finish what's already open before selecting a new question
 
-If any open question has plan items with `status: "in_progress"`,
-**do NOT create a new question** — with one exception (below).
-Recommend that the user complete the in-flight plan items first.
-Reference them by `pli_XXX` ID and name the repository/record type
-so the user knows exactly what to finish (e.g., "Complete `pli_006`
-— the Thomas Flynn probate search on FamilySearch — before adding
-new questions").
+If any open question has plan items with `status: "in_progress"`, **do NOT
+create a new question** (one exception below) — adding questions mid-flight
+churns direction without resolving anything, and the in-flight item may
+produce evidence that changes which question is next-highest value.
+Recommend the user complete the in-flight items first, referencing each by
+`pli_XXX` ID plus repository/record type (e.g. "Complete `pli_006` — the
+Thomas Flynn probate search on FamilySearch — before adding new questions").
+Only proceed to Step 2 when no in-progress plan items exist, or when the
+user explicitly overrides with "add a question anyway." In the override
+case, set the new question's `depends_on` to include the question whose
+plan is in flight.
 
-Adding new questions while existing plans are mid-flight churns
-research direction without resolving anything; the in-flight item
-may produce evidence that changes which question is next-highest
-value. Only proceed to Step 2 (priority selection) when no
-in-progress plan items exist, or when the user explicitly overrides
-with "add a question anyway." In the override case, set the new
-question's `depends_on` to include the question whose plan is in
-flight.
-
-**Exception — blocking unresolved conflicts.** If `conflicts[]`
-contains any entry whose `status == "unresolved"` and whose
-`blocks_question_ids` lists an open question, the in-progress rule
-does NOT block adding a new question. A blocking conflict means
-the in-flight plan items cannot meaningfully resolve the question
-they belong to — the conflict itself has to be addressed first.
-Proceed to Step 2; Priority 1 (`unresolved_conflict`) will fire,
-producing a question that targets evidence to resolve the conflict.
-Set the new question's `unblocks` to include the question whose
-plan is in flight, since resolving the conflict is what re-enables
-that plan's progress.
+**Exception — blocking unresolved conflicts.** If any `conflicts[]` entry
+has `status == "unresolved"` and lists an open question in
+`blocks_question_ids`, the in-progress rule does NOT block a new question:
+the conflict means the in-flight plan items cannot meaningfully resolve the
+question they belong to, so it has to be addressed first. Proceed to Step 2
+(Priority 1 `unresolved_conflict` will fire), and set the new question's
+`unblocks` to include the question whose plan is in flight, since resolving
+the conflict re-enables that plan's progress.
 
 ## 2. Identify the highest-value question
 
-Apply these priorities in order. When multiple candidates exist at
-the same priority level, prefer the one that unblocks the most
-downstream questions.
+Apply these priorities in order. When multiple candidates exist at the same
+priority level, prefer the one that unblocks the most downstream questions.
 
 | Priority | Trigger | `selection_basis` |
 |----------|---------|-------------------|
@@ -99,39 +83,39 @@ downstream questions.
 | 6 | Direct evidence exhausted; pivot to Family/Associates/Neighbors | `fan_pivot` |
 | 7 | A recently extracted assertion opens a new line of inquiry | `new_evidence` |
 
-**Priority 3 detail:** Only fires when `severity == "high"` in the timeline gap. Low-severity gaps do not trigger this priority.
+**Priority 3 detail:** Only fires when `severity == "high"`. Low-severity
+timeline gaps do not trigger it.
 
-**Priority 4 detail:** Each sub-question targets a single fact (one
-identity, relationship, or event). Example decomposition of "Identify
-the parents of Patrick Flynn":
-- "Where was Patrick Flynn in the 1850 census?"
-- "What does Patrick Flynn's death certificate say about his parents?"
-- "Did Thomas Flynn leave a will naming his children?"
+**Priority 4 detail:** Each sub-question targets a single fact (one identity,
+relationship, or event). Example decomposition of "Identify the parents of
+Patrick Flynn": "Where was Patrick Flynn in the 1850 census?" / "What does
+his death certificate say about his parents?" / "Did Thomas Flynn leave a
+will naming his children?"
 
-**Priority 6 detail:** Don't pivot to FAN just because one search
-returned nil. Pivot when all planned direct searches are complete and
-unresolved. If the primary question's `exhaustive_declaration.declared`
-is `true`, the researcher has declared all reasonable direct evidence
-exhausted — take this as the FAN pivot signal and do NOT propose
-additional direct-evidence paths. FAN examples:
-- "Who witnessed Thomas Flynn's land deeds?"
-- "Who were Thomas Flynn's neighbors in the 1850 census?"
+**Priority 6 detail:** Don't pivot to FAN just because one search returned
+nil — pivot only when all planned direct searches are complete and
+unresolved. If the primary question's `exhaustive_declaration.declared` is
+`true`, the researcher has declared direct evidence exhausted: take that as
+the FAN signal and do NOT propose additional direct-evidence paths. FAN
+examples: "Who witnessed Thomas Flynn's land deeds?" / "Who were his
+neighbors in the 1850 census?"
 
 ## 3. Formulate the question
 
-See `references/question-formulation.md` for the three criteria
-(one objective, named individual, testable scope) and examples.
+See `references/question-formulation.md` for the three criteria (one
+objective, named individual, testable scope) and examples.
 
-Before formulating, verify the starting-point information is sound.
-Do not build a question on unverified claims from compiled sources
-(online trees, unsourced genealogies). If the premise is unverified,
-the first question should verify it.
+Before formulating, verify the starting-point information is sound. Do not
+build a question on unverified claims from compiled sources (online trees,
+unsourced genealogies). If the premise is unverified, the first question
+should verify it.
 
 ## 4. Write the question
 
-Append the new question to `research.json` `questions[]` with
-`research_append`. Supply the entry **without an `id`** — the tool
-assigns the next `q_NNN` and stamps `created`:
+Persisting the question is the point of this skill — describing it in prose
+is not enough. Append it to `research.json` `questions[]` via
+`research_append` (`op: "append"`), omitting `id` (the tool assigns the next
+`q_NNN` and stamps `created`). Use exactly these field names:
 
 ```
 research_append({
@@ -139,129 +123,74 @@ research_append({
   section: "questions",
   op: "append",
   entry: {
-    question: "Did Thomas Flynn leave a will or probate record in Schuylkill County naming Patrick as a son?",
-    rationale: "Direct evidence from a probate record would confirm the parent-child relationship. Thomas Flynn died circa 1881 based on his disappearance from tax records. Schuylkill County probate records are available on FamilySearch.",
-    selection_basis: "hypothesis_test",
-    priority: "high",
+    question: "<one single-fact question>",
+    rationale: "<why now — grounded in record availability/methodology>",
+    selection_basis: "<the basis you chose from the Step 2 priority table>",
+    priority: "<high | medium | low>",
     status: "open",
-    depends_on: [],
-    unblocks: ["q_001"],
-    resolved: null,
-    resolution_assertion_ids: [],
-    exhaustive_declaration: {
-      declared: false,
-      justification: null,
-      log_entry_ids: [],
-      stop_criteria: null
-    }
+    depends_on: [], unblocks: ["q_001"],
+    resolved: null, resolution_assertion_ids: [],
+    exhaustive_declaration: { declared: false, justification: null, log_entry_ids: [], stop_criteria: null }
   }
 })
 ```
 
-The tool validates the whole project before writing and writes nothing
-on failure. If it returns `{ ok: false, errors }`, surface those errors
-and fix the entry — do not retry the same payload blindly.
+The tool validates the whole project before writing and writes nothing on
+failure; on `{ ok: false, errors }`, surface the errors and fix the entry —
+do not retry the same payload blindly.
 
 **Set dependency links:**
-- `depends_on`: Questions whose resolution enables or informs this
-  question's research path. Include a question in `depends_on` when
-  either: (a) it must be resolved before this question can be
-  meaningfully pursued, OR (b) this question's most efficient research
-  strategy relies on specific findings from that question (e.g., q_001
-  identified a specific household and the new question searches within
-  that household — include q_001 even if it is already resolved).
-- `unblocks`: Questions that this question's resolution would
-  enable or advance. High `unblocks` counts indicate gatekeeper
-  questions — prioritize these.
+- `depends_on`: questions whose resolution enables or informs this question's
+  research path. Include a question when either (a) it must be resolved
+  before this one can be meaningfully pursued, or (b) this question's most
+  efficient strategy relies on its specific findings (e.g. q_001 identified a
+  household and the new question searches within it — include q_001 even if
+  already resolved).
+- `unblocks`: questions this one's resolution would enable or advance. High
+  `unblocks` counts mark gatekeeper questions — prioritize them.
+- When neither applies (e.g. a first question), set both explicitly to `[]`.
 
-The new question's `exhaustive_declaration` must be unstarted at
-creation time (`declared: false`, `log_entry_ids: []`,
-`stop_criteria: null`). Evaluation of exhaustiveness is the
-`research-exhaustiveness` skill's job, run after all plan items
-for the question are completed.
+The `exhaustive_declaration` must be unstarted at creation (as shown above:
+`declared: false`, empty `log_entry_ids`, null `stop_criteria`). Evaluating
+exhaustiveness is the `research-exhaustiveness` skill's job, run after all
+plan items complete.
 
 ## 5. Present
 
-`research_append` already validated the project before persisting, so
-there is no separate validation step. Tell the user:
-- The question selected and why (the rationale)
-- What it depends on and what it unblocks
-- Suggest next step: "Would you like me to plan the research for
-  this question?" (research-plan)
+- The question selected and why (the rationale).
+- What it depends on and what it unblocks.
+- Suggest next step: "Would you like me to plan the research for this
+  question?" (research-plan).
 
 ## Rules
 
-- **One question at a time.** Each invocation produces at most one
-  new question.
-- **Finish what's open.** Do not introduce new questions while any
-  open question's plan items are `in_progress`. Recommend completing
-  the in-flight work first (see Step 1a).
-- **Sound basis required.** Do not build questions on unsound
-  assumptions (claims that may be plausible but have no supporting
-  evidence). If the premise is unverified, verify it first.
-- **Objectives vs. questions.** Never write an objective as a
-  question. Questions are narrow, single-fact, testable sub-problems.
-- **FAN pivot is a judgment call.** Pivot only when all planned
-  direct searches are complete and unresolved — not after one nil
-  result.
-- **Don't declare exhaustiveness here.** Evaluating whether
-  research on a question is reasonably exhaustive is the
-  `research-exhaustiveness` skill's responsibility. This skill
-  creates new questions; it does not close them.
-- **Historical context matters.** Factor in jurisdictional boundary
-  changes, migration patterns, wars, and record availability for the
-  time and place when selecting questions.
+- **One question at a time.** Each invocation produces at most one new question.
+- **Finish what's open.** Don't introduce new questions while any open
+  question's plan items are `in_progress` (see Step 1a).
+- **Sound basis required.** Don't build questions on unsound assumptions —
+  if the premise is unverified, verify it first.
+- **Objectives vs. questions.** Never write an objective as a question;
+  questions are narrow, single-fact, testable sub-problems.
+- **Don't declare exhaustiveness here.** Closing questions is the
+  `research-exhaustiveness` skill's job — this skill only creates them.
+- **Never delete a question.** To retire one, `research_append`
+  `op: "update"` its `status` (`superseded` / `answered`); the id is
+  preserved. Never write a second `q_` for a question that already exists —
+  update its status instead.
+- **Historical context matters.** Factor in jurisdictional boundary changes,
+  migration, wars, and record availability for the time and place.
 
 ## Edge cases
 
-- **Fresh project, no clear gaps:** If init-project just ran and the
-  pedigree has no obvious errors, default to Priority 4 (decompose
-  the objective into sub-questions).
-- **All questions blocked:** If every open question depends on an
-  unresolved predecessor, identify the root blocker and formulate a
-  question to resolve it — even if it means addressing a conflict
-  that doesn't yet have a formal conflict entry.
-- **User wants to stop early:** Record `declared: false` with an
-  honest explanation. Do not inflate exhaustiveness to justify
-  stopping.
-- **All plan items for a question are complete:** Recommend
-  `research-exhaustiveness` to evaluate whether the question's
-  research is reasonably exhaustive, rather than adding another
-  question — but only when no higher-priority signal (1–3) is
-  present. Run the priority ladder in Step 2 first: a blocking
-  conflict, an untested hypothesis, or a high-severity timeline gap
-  still outranks this edge case even if every plan item for the
-  current question is complete. This edge case is the fallback for
-  when Priorities 1–3 do not fire — it does not override them.
-
-## Re-invocation behavior
-
-**Writes:** entries in the `questions` section of `research.json`
-(`q_` ids) and their `status` field, via `research_append`. Mutable in
-place; never deletes entries — supersedes via `status`. To supersede a
-question, update it rather than removing it:
-
-```
-research_append({
-  projectPath: "<absolute-path-to-project-directory>",
-  section: "questions",
-  op: "update",
-  entryId: "q_003",
-  fields: { status: "superseded" }
-})
-```
-
-The tool preserves the id and never deletes the entry. To mark a
-question answered, use the same `op: "update"` with the appropriate
-`status`.
-
-**On repeat invocation:** re-evaluates which question to work on next.
-May update the `status` of an existing question (e.g. mark it
-`answered` or `superseded`), or select a different question that is
-already in the section. Adds a new `q_` only if the next question
-isn't already present.
-
-**Do not duplicate:** never write a second `q_` entry for the same
-research question. If the question already exists, update its
-`status` rather than re-creating it.
-
+- **Fresh project, no clear gaps:** default to Priority 4 (decompose the
+  objective into sub-questions).
+- **All questions blocked:** identify the root blocker and formulate a
+  question to resolve it — even if that means a conflict with no formal
+  `conflicts[]` entry yet.
+- **All plan items for a question complete:** run the priority ladder
+  first. If direct evidence is exhausted — `exhaustive_declaration.declared`
+  is true, or all planned direct searches are complete and unresolved —
+  **Priority 6 fires: create a `fan_pivot` question** (FAN exhaustion comes
+  before declaring the project reasonably exhaustive). Recommend
+  `research-exhaustiveness` instead only when no Priority 1–6 signal applies
+  (e.g. FAN avenues are themselves already worked).


### PR DESCRIPTION
## Summary

Shortens `packages/engine/plugin/skills/question-selection/SKILL.md` from 267 to ~196 lines (~27%) per `eval/briefs/shorten-question-selection.md`, with no eval regression.

## What changed

- Removed the verbose `research_append` narration: the full create/update JSON duplication and the id-allocation / validate-before-persist prose.
- Trimmed the `## Re-invocation behavior` section to a compact form (kept because `test_reinvocation_sections.py`, per `feedback-case-spec.md` §5, requires every plugin SKILL.md to have one).
- Kept a **compact** entry template. The brief assumed the entry's field list was schema-dup the tool would enforce, but in the eval the mock `research_append` does not run real validation, so the agent must emit a valid entry first try — removing the template regressed `ut_002` (wrong field name `text` vs `question`, missing required fields) and `ut_007` (described the question in prose but never persisted it). The compact template fixes both.
- Used placeholders for `selection_basis`/`priority` in the example so the agent derives them from the priority table instead of copying a literal.
- Preserved all load-bearing judgment: the priority table + detail notes, §1a finish-what's-open + the blocking-conflict exception, dependency-link semantics, the unstarted `exhaustive_declaration` rule, and supersede-not-delete.

## FAN-pivot reliability fix

Clarified the edge case so Priority 6 (`fan_pivot`) explicitly outranks the "all plans complete → recommend research-exhaustiveness" fallback. This resolved a pre-existing ambiguity that made `ut_005` flaky on the original skill too (it scored pass/fail/partial over three runs). After the fix, `ut_005` passes 3/3.

## Eval

Full suite: **12/12 pass** — run log `v1_2026-06-26_09-02-54.json` (active; snapshot matches the branch). Full harness pytest: 617 passed.

No harness change ships in this PR. (`ut_011` sits near the 300s wall-clock cap and the mocked `research_append` can leave `research.json` unstamped, so the suite carries known single-run variance; making `research_append` a live tool is the root-cause fix and will land as a separate harness PR.)

Annotation (`.ann.json`) will be added by the reviewer via the CRUD UI; the PR will update automatically on that push.

Closes #464