### PR TITLE
eval: fix flaky search-full-text sidecar tests (fixture projectPath parity)

### DIFF
--- a/eval/fixtures/mcp/fulltext-search-cuban-notarial-by-name.json
+++ b/eval/fixtures/mcp/fulltext-search-cuban-notarial-by-name.json
@@ -54,6 +54,10 @@
       },
       "includeFacets": {
         "type": "boolean"
+      },
+      "projectPath": {
+        "type": "string",
+        "description": "Absolute path to the active project directory. Supply it whenever the search will be logged (the normal case): the tool then stages its raw results host-side and returns a `staged.resultsRef` handle to pass to research_log_append as stagedResultsRef, so the results are retained without re-serializing them. Only omit it for a throwaway exploratory search you are certain you will not log."
       }
     }
   },

--- a/eval/fixtures/mcp/fulltext-search-cuban-notarial.json
+++ b/eval/fixtures/mcp/fulltext-search-cuban-notarial.json
@@ -20,7 +20,11 @@
       "recordType": { "type": "string" },
       "count": { "type": "integer" },
       "offset": { "type": "integer" },
-      "includeFacets": { "type": "boolean" }
+      "includeFacets": { "type": "boolean" },
+      "projectPath": {
+        "type": "string",
+        "description": "Absolute path to the active project directory. Supply it whenever the search will be logged (the normal case): the tool then stages its raw results host-side and returns a `staged.resultsRef` handle to pass to research_log_append as stagedResultsRef, so the results are retained without re-serializing them. Only omit it for a throwaway exploratory search you are certain you will not log."
+      }
     }
   },
   "response": {

--- a/eval/fixtures/mcp/fulltext-search-flynn-flinn-variant.json
+++ b/eval/fixtures/mcp/fulltext-search-flynn-flinn-variant.json
@@ -68,6 +68,10 @@
       "includeFacets": {
         "type": "boolean",
         "description": "When true, include facet counts in the response. Default false."
+      },
+      "projectPath": {
+        "type": "string",
+        "description": "Absolute path to the active project directory. Supply it whenever the search will be logged (the normal case): the tool then stages its raw results host-side and returns a `staged.resultsRef` handle to pass to research_log_append as stagedResultsRef, so the results are retained without re-serializing them. Only omit it for a throwaway exploratory search you are certain you will not log."
       }
     }
   },

--- a/eval/fixtures/mcp/fulltext-search-flynn-flunn-ocr.json
+++ b/eval/fixtures/mcp/fulltext-search-flynn-flunn-ocr.json
@@ -20,7 +20,11 @@
       "recordType": { "type": "string" },
       "count": { "type": "integer" },
       "offset": { "type": "integer" },
-      "includeFacets": { "type": "boolean" }
+      "includeFacets": { "type": "boolean" },
+      "projectPath": {
+        "type": "string",
+        "description": "Absolute path to the active project directory. Supply it whenever the search will be logged (the normal case): the tool then stages its raw results host-side and returns a `staged.resultsRef` handle to pass to research_log_append as stagedResultsRef, so the results are retained without re-serializing them. Only omit it for a throwaway exploratory search you are certain you will not log."
+      }
     }
   },
   "response": {

--- a/eval/fixtures/mcp/fulltext-search-flynn-operator-construction.json
+++ b/eval/fixtures/mcp/fulltext-search-flynn-operator-construction.json
@@ -20,7 +20,11 @@
       "recordType": { "type": "string" },
       "count": { "type": "integer" },
       "offset": { "type": "integer" },
-      "includeFacets": { "type": "boolean" }
+      "includeFacets": { "type": "boolean" },
+      "projectPath": {
+        "type": "string",
+        "description": "Absolute path to the active project directory. Supply it whenever the search will be logged (the normal case): the tool then stages its raw results host-side and returns a `staged.resultsRef` handle to pass to research_log_append as stagedResultsRef, so the results are retained without re-serializing them. Only omit it for a throwaway exploratory search you are certain you will not log."
+      }
     }
   },
   "response": {

--- a/eval/fixtures/mcp/fulltext-search-flynn-probate-empty-by-name.json
+++ b/eval/fixtures/mcp/fulltext-search-flynn-probate-empty-by-name.json
@@ -70,6 +70,10 @@
       "includeFacets": {
         "type": "boolean",
         "description": "When true, include facet counts in the response. Default false."
+      },
+      "projectPath": {
+        "type": "string",
+        "description": "Absolute path to the active project directory. Supply it whenever the search will be logged (the normal case): the tool then stages its raw results host-side and returns a `staged.resultsRef` handle to pass to research_log_append as stagedResultsRef, so the results are retained without re-serializing them. Only omit it for a throwaway exploratory search you are certain you will not log."
       }
     }
   },

--- a/eval/fixtures/mcp/fulltext-search-flynn-probate-empty.json
+++ b/eval/fixtures/mcp/fulltext-search-flynn-probate-empty.json
@@ -68,6 +68,10 @@
       "includeFacets": {
         "type": "boolean",
         "description": "When true, include facet counts in the response. Default false."
+      },
+      "projectPath": {
+        "type": "string",
+        "description": "Absolute path to the active project directory. Supply it whenever the search will be logged (the normal case): the tool then stages its raw results host-side and returns a `staged.resultsRef` handle to pass to research_log_append as stagedResultsRef, so the results are retained without re-serializing them. Only omit it for a throwaway exploratory search you are certain you will not log."
       }
     }
   },

--- a/eval/fixtures/mcp/fulltext-search-flynn-wildcard-variant-by-name.json
+++ b/eval/fixtures/mcp/fulltext-search-flynn-wildcard-variant-by-name.json
@@ -70,6 +70,10 @@
       "includeFacets": {
         "type": "boolean",
         "description": "When true, include facet counts in the response. Default false."
+      },
+      "projectPath": {
+        "type": "string",
+        "description": "Absolute path to the active project directory. Supply it whenever the search will be logged (the normal case): the tool then stages its raw results host-side and returns a `staged.resultsRef` handle to pass to research_log_append as stagedResultsRef, so the results are retained without re-serializing them. Only omit it for a throwaway exploratory search you are certain you will not log."
       }
     }
   },

--- a/eval/fixtures/mcp/fulltext-search-flynn-wildcard-variant.json
+++ b/eval/fixtures/mcp/fulltext-search-flynn-wildcard-variant.json
@@ -70,6 +70,10 @@
       "includeFacets": {
         "type": "boolean",
         "description": "When true, include facet counts in the response. Default false."
+      },
+      "projectPath": {
+        "type": "string",
+        "description": "Absolute path to the active project directory. Supply it whenever the search will be logged (the normal case): the tool then stages its raw results host-side and returns a `staged.resultsRef` handle to pass to research_log_append as stagedResultsRef, so the results are retained without re-serializing them. Only omit it for a throwaway exploratory search you are certain you will not log."
       }
     }
   },

--- a/eval/fixtures/mcp/fulltext-search-flynn-witnesses-by-name.json
+++ b/eval/fixtures/mcp/fulltext-search-flynn-witnesses-by-name.json
@@ -70,6 +70,10 @@
       "includeFacets": {
         "type": "boolean",
         "description": "When true, include facet counts in the response. Default false."
+      },
+      "projectPath": {
+        "type": "string",
+        "description": "Absolute path to the active project directory. Supply it whenever the search will be logged (the normal case): the tool then stages its raw results host-side and returns a `staged.resultsRef` handle to pass to research_log_append as stagedResultsRef, so the results are retained without re-serializing them. Only omit it for a throwaway exploratory search you are certain you will not log."
       }
     }
   },

--- a/eval/fixtures/mcp/fulltext-search-flynn-witnesses.json
+++ b/eval/fixtures/mcp/fulltext-search-flynn-witnesses.json
@@ -68,6 +68,10 @@
       "includeFacets": {
         "type": "boolean",
         "description": "When true, include facet counts in the response. Default false."
+      },
+      "projectPath": {
+        "type": "string",
+        "description": "Absolute path to the active project directory. Supply it whenever the search will be logged (the normal case): the tool then stages its raw results host-side and returns a `staged.resultsRef` handle to pass to research_log_append as stagedResultsRef, so the results are retained without re-serializing them. Only omit it for a throwaway exploratory search you are certain you will not log."
       }
     }
   },

--- a/eval/fixtures/mcp/fulltext-search-nlquery-tree-person.json
+++ b/eval/fixtures/mcp/fulltext-search-nlquery-tree-person.json
@@ -20,7 +20,11 @@
       "recordType": { "type": "string" },
       "count": { "type": "integer" },
       "offset": { "type": "integer" },
-      "includeFacets": { "type": "boolean" }
+      "includeFacets": { "type": "boolean" },
+      "projectPath": {
+        "type": "string",
+        "description": "Absolute path to the active project directory. Supply it whenever the search will be logged (the normal case): the tool then stages its raw results host-side and returns a `staged.resultsRef` handle to pass to research_log_append as stagedResultsRef, so the results are retained without re-serializing them. Only omit it for a throwaway exploratory search you are certain you will not log."
+      }
     }
   },
   "response": {

--- a/packages/engine/mcp-server/src/tools/fulltext-search.ts
+++ b/packages/engine/mcp-server/src/tools/fulltext-search.ts
@@ -323,7 +323,7 @@ export const fulltextSearchToolSchema = {
       projectPath: {
         type: "string",
         description:
-          "Absolute path to the active project directory. When supplied, the tool stages its raw results host-side and returns a `staged.resultsRef` handle; pass that to `research_log_append` as `stagedResultsRef` so the results are retained without you re-serializing them. Omit it for an exploratory search you do not intend to log.",
+          "Absolute path to the active project directory. Supply it whenever the search will be logged (the normal case): the tool then stages its raw results host-side and returns a `staged.resultsRef` handle; pass that to `research_log_append` as `stagedResultsRef` so the results are retained without you re-serializing them. Only omit it for a throwaway exploratory search you are certain you will not log.",
       },
     },
   },

--- a/packages/engine/plugin/skills/search-full-text/SKILL.md
+++ b/packages/engine/plugin/skills/search-full-text/SKILL.md
@@ -169,11 +169,18 @@ fulltext_search({ imageGroupNumber: "4057677" })
 
 ### 6. Execute and iterate
 
-Call `fulltext_search` with the constructed query. **Always pass
-`projectPath`** (the absolute path to the project folder) so the host
-stages the raw results: the response gains a `staged.resultsRef` handle
-you hand to `research_log_append` in step 8 to retain them — you never
-serialize the payload yourself.
+Call `fulltext_search` with the constructed query. This skill **logs
+every search**, so `projectPath` (the absolute path to the project
+folder) is **mandatory on every call** — never omit it. When supplied,
+the host stages the raw results and the response gains a
+`staged.resultsRef` handle you hand to `research_log_append` in step 8
+to retain them — you never serialize the payload yourself.
+
+**Verify staging before you log.** If a search returned ≥1 result but
+the response has no `staged.resultsRef`, you omitted `projectPath` —
+re-run the identical query **with** `projectPath` before step 8, or the
+results are not retained and the log entry will have no sidecar. (A nil
+search correctly has no `staged.resultsRef`; that is expected.)
 
 **Decision rules by hit count:**
 - **0 results** → See step 10 (handle nil results)


### PR DESCRIPTION
## Problem

`ut_search_full_text_010` was flaky — passing some runs, failing others — and the same latent flake affected the other positive `search-full-text` sidecar tests (001, 002, 007, 008, 009, 011, 012).

## Root cause

The `fulltext_search` MCP fixtures' `input_schema` **omitted `projectPath`**, but:
- the **production** tool schema declares `projectPath`, and
- the `search-full-text` SKILL.md tells the model to **"always pass `projectPath`"** so the host stages results into a `results/<log_id>.json` sidecar.

So the model saw an authoritative-looking tool schema that didn't list a parameter its instructions required. It passed the arg only intermittently — and dropping it collapses the `fulltext_search` → staging → `research_log_append` → sidecar chain. No `projectPath` ⇒ no `staged.resultsRef` ⇒ no sidecar ⇒ `results_ref` null ⇒ the deterministic `test_sidecar_written_for_positive_fts` validator hard-fails. That non-determinism is the flake.

This is an eval/production **parity bug**: the fixtures predate the persistence-migration rewrite that added `projectPath` to `fulltext_search`.

## Repo-wide sweep

Compared **every** fixture's `input_schema` against the compiled production tool schemas, across all skills:

- **Fixed:** all **12** `fulltext_search` fixtures that declare an `input_schema` now include `projectPath`.
- **No other drift:** fixtures that declare a schema *only ever* omitted `projectPath` — nothing else was stale.
- **Left as-is (not this bug):** 241 fixtures declare no `input_schema` at all (the harness's permissive default). That includes 17 `record_search` fixtures — a different shape (permissive, not schema-contradicts-instruction). Worth watching if search-records sidecar tests prove flaky, but out of scope here.

## Changes

- **12 `fulltext_search` fixtures** — add `projectPath` to `input_schema` (restores parity).
- **`search-full-text/SKILL.md`** — `projectPath` is mandatory on every call; added a verify-staging gate ("results came back but no `staged.resultsRef` ⇒ you forgot `projectPath` ⇒ re-run before logging").
- **`fulltext-search.ts`** — softened the `projectPath` description so it no longer invites omission when the search will be logged (production parity).

## Verification

- `ut_010`: **3/3 pass**, all six judge dimensions = 3, `projectPath` on every search and sidecar written every run.
- `ut_001`: pass, `projectPath` passed on both searches — confirms the fix generalizes beyond ut_010.

Note: the committed `v1` run log for this skill is now stale (it predates the migration-tool skill rewrite) and should be regenerated against the current skill in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)