### PR TITLE
Add eval-cosmetic-skip label: bypass eval re-run for behavior-neutral skill edits

### DIFF
--- a/.github/workflows/check-runlogs.yml
+++ b/.github/workflows/check-runlogs.yml
@@ -23,6 +23,11 @@ name: Check runlog discipline
 
 on:
   pull_request:
+    # `labeled`/`unlabeled` added so the cosmetic-skip escape hatch (below)
+    # re-evaluates the moment a senior applies/removes the label. The default
+    # types (opened, synchronize, reopened) are listed explicitly because
+    # naming any type replaces the defaults.
+    types: [opened, synchronize, reopened, labeled, unlabeled]
     paths:
       - 'eval/runlogs/unit/**'
       - 'eval/tests/unit/**'
@@ -33,10 +38,48 @@ on:
       # trigger: it is no longer embedded in the run-log snapshot, so a
       # src-only change cannot affect run-log activeness (rule 2).
 
+# `issues: write` lets the auto-strip step remove the bypass label from the PR.
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+# Cosmetic-skip escape hatch (rule 2 only). A senior applies the
+# `eval-cosmetic-skip` label on a PR whose only skill-side change is
+# behavior-neutral (rewording, typo) to keep the prior run log active without
+# a re-run + re-grade. Safety: any NEW commit auto-removes the label (the
+# strip step below runs on `synchronize`), so the bypass can never outlive the
+# commit it was approved for — the senior must re-apply after each push. The
+# label must exist in the repo once: `gh label create eval-cosmetic-skip`.
 jobs:
   check:
     runs-on: ubuntu-latest
     steps:
+      - name: Drop stale cosmetic-skip label on new commits
+        if: github.event.action == 'synchronize'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh pr edit "${{ github.event.pull_request.number }}" \
+            --repo "${{ github.repository }}" \
+            --remove-label "eval-cosmetic-skip" || true
+
+      - name: Resolve cosmetic-skip state
+        id: cosmetic
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Read labels FRESH (post-strip), not from the event payload, so a
+          # `synchronize` run that just removed the label sees skip=0.
+          labels=$(gh pr view "${{ github.event.pull_request.number }}" \
+            --repo "${{ github.repository }}" --json labels --jq '.labels[].name')
+          if echo "$labels" | grep -qx "eval-cosmetic-skip"; then
+            echo "skip=1" >> "$GITHUB_OUTPUT"
+            echo "::notice::eval-cosmetic-skip label present — rule 2 will be bypassed for this PR."
+          else
+            echo "skip=0" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Check out PR with full history
         uses: actions/checkout@v4
         with:
@@ -51,6 +94,7 @@ jobs:
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          COSMETIC_SKIP: ${{ steps.cosmetic.outputs.skip }}
         run: python eval/harness/scripts/check_runlogs.py
 
       - name: Check skill tool-coverage drift (warn-only)

--- a/eval/CLAUDE.md
+++ b/eval/CLAUDE.md
@@ -151,9 +151,11 @@ Scratch runs are gitignored via `.gitignore` patterns on `eval/runlogs/unit/*/sc
 | Rule | Severity | What |
 |---|---|---|
 | 1 | block | At most one newly-added-or-renamed-into-place `v{N}.json` per skill (`--diff-filter=AR` catches the candidate → released rename). |
-| 2 | block | The latest full-skill run log per touched skill is **active** — its snapshot matches the current PR-branch state. |
+| 2 | block | The latest full-skill run log per touched skill is **active** — its snapshot matches the current PR-branch state. **Cosmetic-skip:** a senior can apply the `eval-cosmetic-skip` label to a PR whose only skill-side change is behavior-neutral; the workflow sets `COSMETIC_SKIP=1` and this rule downgrades to a warning (no re-run). |
 | 2b | warn | The same run log's `judge_prompt_hash` matches the current judge prompt. Mismatch is non-blocking (judge edits are a separate cadence). |
-| 3 | block | The same run log's `.ann.json` has a correction entry for every dimension in every test. |
+| 3 | block | The same run log's `.ann.json` has a correction entry for every dimension in every test. (Cosmetic-skip keeps the *prior* run log as the target, so its already-complete `.ann.json` satisfies this with no re-grade — and because rule 3 still runs, an unannotated baseline can't be waved through.) |
+
+The `eval-cosmetic-skip` label is for genuinely behavior-neutral edits only (rewording, typos, comments, formatting). It is **auto-removed on every new push** (the workflow's `synchronize` step), so the bypass can't outlive the commit it was approved for — a later substantive push re-reds the check until the senior re-applies. Only rule 2 is relaxed. Full workflow + one-time `gh label create` setup: `eval/README.md` "Cosmetic-change exemption". The label must exist in the repo and seniors need Triage/Write to apply it.
 
 The same workflow also runs `eval/harness/scripts/check_tool_coverage.py` (warn-only): it flags any skill whose `allowed-tools` declares a tool with no fixture in its test corpus. `image_read` is exempt — the mock cannot emit image content blocks; see `docs/specs/unit-test-spec.md` §15 "Uncovered tool calls".
 

--- a/eval/README.md
+++ b/eval/README.md
@@ -203,6 +203,57 @@ See [`docs/plan/eval-runlog-versioning.md`](../docs/plan/eval-runlog-versioning.
 7. Senior clicks **Release** on the active candidate → `v{N}_<ts>.json` → `v{N}.json` rename. Commits, pushes, approves.
 8. Project owner merges.
 
+## Cosmetic-change exemption (skip the re-run for a minor wording change)
+
+A PR reviewer asks for a one-word rewording or a typo fix in a `SKILL.md`.
+That edit changes the skill-side snapshot, which flips the latest run log
+**inactive** — so by default the gate (rule 2) demands a full harness re-run
+(~$1–3) *and* a complete re-grade, even though the behavior can't have
+changed. A senior can waive that for a genuinely behavior-neutral edit by
+applying a **PR label** — no branch checkout, no commands, nothing to install.
+
+**It exempts the PR from both:** no harness re-run, and no re-correcting
+scores. The prior run log stays the active one, and its already-complete
+`.ann.json` satisfies the completeness rule as-is. (Only rule 2 is relaxed —
+rules 1 and 3 still run, so an *unannotated* baseline can't be waved through.)
+
+**Use it only for genuinely behavior-neutral edits** — rewording, typos,
+comments, formatting. If a change *could* alter what Claude does (a new
+instruction, a reordered step, a changed tool argument, an edited fixture or
+scenario), it is **not** cosmetic: re-run the harness.
+
+### How a senior sets the flag (entirely in the GitHub web UI)
+
+1. Open the PR on github.com.
+2. In the right-hand sidebar, under **Labels**, add **`eval-cosmetic-skip`**.
+3. (Recommended) leave a one-line comment saying *why* it's behavior-neutral —
+   e.g. "Reworded step 3 'Look for' → 'Search for'; no behavior change." The
+   label records *who* and *when*; the comment records *why*.
+
+The `Check runlog discipline` check re-runs automatically when the label is
+added and turns green, with a warning noting the bypass so reviewers see it.
+
+### Safety: the label auto-expires on every new push
+
+The label is **removed automatically whenever a new commit is pushed** to the
+PR. So a waiver can never silently cover a *later* substantive change — if more
+commits land, the check goes red again and the senior must re-apply the label
+(after confirming the new commits are still cosmetic). This is the same
+"voids on any further edit" guarantee a re-run would give, with none of the
+work.
+
+### One-time repo setup
+
+The label has to exist before anyone can apply it. An admin creates it once:
+
+```bash
+gh label create eval-cosmetic-skip \
+  --description "Senior waiver: skill change is behavior-neutral; skip the eval re-run" \
+  --color FBCA04
+```
+
+Seniors need **Triage** or **Write** access on the repo to apply labels.
+
 ## Windows users
 
 `Setup.bat` performs the one-time setup. Then `Start.bat` launches the CRUD UI and `RunTests.bat` runs the harness against the current corpus.

--- a/eval/harness/scripts/check_runlogs.py
+++ b/eval/harness/scripts/check_runlogs.py
@@ -121,17 +121,37 @@ def latest_full_skill_runlog(skill_dir: Path) -> tuple[str, dict] | None:
 
 
 def rule2_active(skill: str, log: dict, filename: str) -> int:
-    """Rule 2 (blocking): latest run log's snapshot matches disk."""
+    """Rule 2 (blocking): latest run log's snapshot matches disk.
+
+    Cosmetic-skip escape hatch: when `COSMETIC_SKIP=1` (set by the workflow
+    because a senior applied the `eval-cosmetic-skip` label on this PR), a
+    snapshot mismatch is downgraded to a warning instead of a block — the
+    prior run log + its already-complete annotations stand without a re-run.
+    The label is auto-removed on every new push (see check-runlogs.yml), so
+    the bypass can never outlive the commit it was approved for. Only rule 2
+    is relaxed: rules 1 and 3 still run, so an unannotated baseline can't be
+    waved through.
+    """
     snapshot = log.get("snapshot") or {}
     diffs = diff_snapshot_vs_disk(snapshot, REPO_ROOT)
     if not diffs:
+        return 0
+    diff_lines = "\n".join(f"  - {p}: {kind}" for p, kind in sorted(diffs.items()))
+    if os.environ.get("COSMETIC_SKIP") == "1":
+        gh_warning(
+            f"skill `{skill}`: latest run log `{filename}` differs from the working "
+            f"tree in {len(diffs)} file(s), but the `eval-cosmetic-skip` label "
+            f"bypasses rule 2 for this PR — no re-run required. Confirm the change "
+            f"is behavior-neutral before approving.\n" + diff_lines,
+        )
         return 0
     gh_error(
         f"skill `{skill}`: latest full-skill run log `{filename}` is NOT active — "
         f"{len(diffs)} snapshot file(s) differ from the working tree. Re-run the "
         f"harness (`uv run python eval/harness/run_tests.py --skill {skill}`) so "
-        f"the run log reflects the PR-branch state.\n"
-        + "\n".join(f"  - {p}: {kind}" for p, kind in sorted(diffs.items())),
+        f"the run log reflects the PR-branch state. If the change is purely "
+        f"cosmetic (no behavior change), a senior can instead apply the "
+        f"`eval-cosmetic-skip` label to this PR.\n" + diff_lines,
     )
     return 1
 

--- a/eval/harness/tests/unit/test_check_runlogs.py
+++ b/eval/harness/tests/unit/test_check_runlogs.py
@@ -103,3 +103,36 @@ def test_rule3_missing_dimension_still_reported(tmp_path, capsys):
     rc = check_runlogs.rule3_completeness("init-project", _log_with_one_dimension(), fn, skill_dir)
     assert rc == 1
     assert "unreviewed" in capsys.readouterr().out
+
+
+# --- Rule 2 cosmetic-skip escape hatch -----------------------------------
+
+# A snapshot entry pointing at a path that does not exist under REPO_ROOT
+# guarantees diff_snapshot_vs_disk reports a mismatch (missing-on-disk), so
+# rule 2 has something to either block on or bypass.
+_INACTIVE_LOG = {"snapshot": {"eval/__no_such_cosmetic_test__/x.md": "expected\n"}}
+
+
+def test_rule2_blocks_without_cosmetic_skip(monkeypatch, capsys):
+    monkeypatch.delenv("COSMETIC_SKIP", raising=False)
+    rc = check_runlogs.rule2_active("demo", _INACTIVE_LOG, "v1.json")
+    assert rc == 1
+    out = capsys.readouterr().out
+    assert "NOT active" in out
+    assert "eval-cosmetic-skip" in out  # tells the senior the escape hatch exists
+
+
+def test_rule2_bypassed_with_cosmetic_skip(monkeypatch, capsys):
+    monkeypatch.setenv("COSMETIC_SKIP", "1")
+    rc = check_runlogs.rule2_active("demo", _INACTIVE_LOG, "v1.json")
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "::warning" in out and "eval-cosmetic-skip" in out
+
+
+def test_rule2_skip_zero_does_not_bypass(monkeypatch, capsys):
+    """Only COSMETIC_SKIP == '1' bypasses; '0' (label absent) still blocks."""
+    monkeypatch.setenv("COSMETIC_SKIP", "0")
+    rc = check_runlogs.rule2_active("demo", _INACTIVE_LOG, "v1.json")
+    assert rc == 1
+    assert "NOT active" in capsys.readouterr().out


### PR DESCRIPTION
## What

Adds a senior-only escape hatch so a **behavior-neutral** skill edit (a PR reviewer's minor rewording, a typo fix) doesn't force a full eval re-run + re-grade.

A senior applies the **`eval-cosmetic-skip`** label to the PR — entirely in the GitHub web UI, no checkout. The runlog-discipline gate then bypasses rule 2 ("latest run log must be active"), keeping the prior run log and its already-complete annotations. **Both** costs are skipped: the ~$1–3 harness re-run and the human re-grade.

## Safety

- The label is **auto-removed on every new push**, so a waiver can never outlive the commit it was approved for. A later push re-reds the check; the senior re-applies only if the new commit is still cosmetic.
- **Only rule 2** is relaxed. Rules 1 (≤1 released file) and 3 (annotations complete) still run, so an unannotated baseline can't be waved through.

## Files

- `.github/workflows/check-runlogs.yml` — `labeled`/`unlabeled` triggers, drop-label-on-`synchronize` step, resolve label → `COSMETIC_SKIP`, label-edit permissions.
- `eval/harness/scripts/check_runlogs.py` — `rule2_active` honors `COSMETIC_SKIP=1` (warn instead of block).
- `eval/harness/tests/unit/test_check_runlogs.py` — three rule-2 cases.
- `eval/README.md`, `eval/CLAUDE.md` — senior-facing flow + rationale.

## One-time setup (already done by the maintainer)

```
gh label create eval-cosmetic-skip \
  --description "Senior waiver: skill change is behavior-neutral; skip the eval re-run" --color FBCA04
```

Seniors need Triage+/Maintain to apply labels.

## Note on activation

The new `labeled` trigger only takes effect once this workflow is on `main` (GitHub reads `pull_request` trigger config from the base branch). Test the label on a throwaway PR **after** merge, not on this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
