### PR TITLE
eval harness: stop part-way with Ctrl-C, keeping completed results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,13 @@ eval/app/lib/schema/
 eval/runlogs/unit/*/scratch_*.json
 eval/runlogs/unit/*/scratch_*.ann.json
 
+# In-progress partial run logs — rewritten after each completed test so a
+# Ctrl-C or crash mid-run keeps the tests that finished. Deleted on a clean
+# finish; promoted to scratch_* on interrupt. The .tmp is the atomic-write
+# staging file. See docs/plan/eval-harness-stop-early.md.
+eval/runlogs/unit/*/.partial_*.json
+eval/runlogs/unit/*/.partial_*.json.tmp
+
 # Non-passing e2e runs write as scratch_* — only a passing run validates a
 # fixture and is committed (e2e-test-spec.md §14). Keeps a failed run from
 # being committed as if it had validated the fixture.

--- a/docs/plan/eval-harness-stop-early.md
+++ b/docs/plan/eval-harness-stop-early.md
@@ -1,0 +1,154 @@
+# Stopping the eval harness part-way — design
+
+> Lets a genealogist/developer running the unit-test harness stop it with
+> Ctrl-C the moment they see a failing test, instead of waiting for the
+> whole skill suite to finish, **without losing the results that already
+> ran**. Documents what shipped (the quick path) and the heavier refactor
+> we deliberately deferred (the robust path), so we don't rediscover the
+> design if the quick path proves insufficient.
+
+## Problem
+
+The harness (`eval/harness/run_tests.py`) runs a skill's tests through a
+bounded thread pool and streams a `✓/✗ [n/total] … — outcome` line as each
+test completes. A skill suite is minutes per test; a full `--skill` run can
+be an hour or more. A tester watching the stream often knows after one red
+line that they need to fix something and re-run — but before this change
+there was no way to act on that:
+
+- **No interrupt handling.** Ctrl-C raised `KeyboardInterrupt`, which
+  unwound *past* the end-of-run write step, so **every completed test
+  result was discarded**. Stopping meant the whole run so far was wasted.
+- **All-or-nothing persistence.** Run logs were written once, at the very
+  end. A crash or the SIGKILL-under-memory-pressure failure that
+  `eval/CLAUDE.md` already warns about had the same effect: total loss.
+
+## Mechanism background (why the quick path is cheap)
+
+Three facts about the execution model, verified against the installed
+`claude-agent-sdk`, decide the design:
+
+1. **Threads can't be killed.** Tests run in a `ThreadPoolExecutor`; Python
+   can't force-terminate a worker thread, and `future.cancel()` only drops
+   *not-yet-started* futures. The only way to stop an in-flight test is to
+   kill the `claude` CLI subprocess its worker is blocked on.
+2. **One Ctrl-C already kills those subprocesses.** The SDK spawns `claude`
+   via `anyio.open_process` with **no `start_new_session`**
+   (`_internal/transport/subprocess_cli.py`), so the children sit in the
+   harness's own process group. A terminal Ctrl-C is delivered by the OS to
+   the entire foreground process group — every in-flight `claude` gets
+   SIGINT directly and exits, independent of anything Python does. The SDK
+   also registers an `atexit` SIGTERM sweep of tracked children as a
+   backstop. (`query()`, which the harness uses, is documented as "No
+   interrupts" — the in-band `interrupt()` only exists on the streaming
+   `ClaudeSDKClient`, which we don't use.)
+3. **In-flight tests have no result yet.** A test's entry is only produced
+   when it finishes. So killing in-flight tests discards *unfinished* work,
+   never a result — there is nothing to preserve about them.
+
+Consequence: on the threaded path, a single Ctrl-C *is* the immediate kill.
+The harness's only job is to **catch** the resulting `KeyboardInterrupt` so
+it can save what finished instead of crashing. A second Ctrl-C is just an
+escape hatch if the save path itself hangs.
+
+## What shipped (the quick path)
+
+Two pieces — incremental persistence (so a stop is never destructive) plus a
+catch-and-flush handler (the human-facing control).
+
+### C — incremental partial persistence
+
+As each test completes, the runner rewrites a **partial envelope per skill**
+to a dotfile `eval/runlogs/unit/<skill>/.partial_<ts>.json`:
+
+- Helpers live in `eval/harness/harness/runlog.py`:
+  `write_partial_runlog()` (atomic temp-file + `os.replace`, validates
+  against the v2 schema, **overwrites** each call) and
+  `promote_partial_to_scratch()` (renames the dotfile to a recognized
+  `scratch_<ts>.json`).
+- The dotfile name is deliberately **not** one `versioning.classify()`
+  recognizes (it classifies as `other`), so it never participates in
+  version numbering, active-state, or the release gate, and is `.gitignore`d.
+- Snapshots and the judge hash the partial needs are computed once up front
+  and reused for both the partial and the final write (snapshot captured at
+  run start — skill files don't change mid-run, and that's the state the
+  tests executed against).
+
+This decouples *stopping* from *losing data*: a Ctrl-C, a crash, or a
+SIGKILL all leave the completed tests in a valid envelope on disk.
+
+### Catch-and-flush handler
+
+The run loop in `run_tests.py` is wrapped in `try/except KeyboardInterrupt`:
+
+- **First Ctrl-C:** the OS has already SIGINT'd the in-flight `claude`
+  subprocesses (they exit); the handler sets `stop_submitting`, drops
+  pending tests via `ex.shutdown(wait=False, cancel_futures=True)`, does a
+  final partial flush, prints the summary of what ran, **promotes each
+  partial dotfile to `scratch_<ts>.json`**, and returns exit code **130**
+  (128 + SIGINT).
+- **A run is never released from a partial.** Even a `--skill` (normally
+  releasable) invocation that is interrupted writes only `scratch_`, never a
+  `v{N}` candidate — an interrupted run is not a full-suite result.
+- **Clean finish** is unchanged: the existing end-of-run write produces the
+  releasable `v{N}_<ts>.json` (or `scratch_` for filtered runs), then the
+  partial dotfiles are deleted.
+- **Second Ctrl-C** (e.g. during the shutdown join) re-raises past `main()`;
+  a guard in `__main__` exits 130 quietly instead of dumping a traceback.
+
+### Tests
+
+- `eval/harness/tests/unit/test_partial_runlog.py` — the writer/promote
+  helpers (atomic overwrite, no leftover `.tmp`, dotfile stays unclassified,
+  rename to scratch).
+- `eval/harness/tests/unit/test_cli.py::test_ctrl_c_keeps_completed_tests_as_scratch_and_exits_130`
+  — the integration wiring (interrupt mid-run → 1 completed test promoted to
+  `scratch_`, no `v{N}` minted, dotfile gone, rc 130).
+
+### Known limitation of the quick path
+
+It leans on OS process-group signal delivery and the SDK's `atexit` sweep to
+kill in-flight subprocesses. That is reliable on macOS/Linux. On **Windows**
+(the genealogist team's platform) `CTRL_C_EVENT` reaching child console
+processes is murkier. **Verify on a real Windows box.** If in-flight
+`claude` processes are observed surviving a Ctrl-C there, that is the signal
+to adopt the robust path below.
+
+## The robust path (deferred — implement only if the quick path proves insufficient)
+
+Run each test in a **child process the harness owns**, not just a thread, so
+in-flight tests can be terminated deterministically and cross-platform.
+
+- Replace the `ThreadPoolExecutor` of `run_one_test` calls with a
+  `ProcessPoolExecutor` (or explicit `subprocess`/`multiprocessing`),
+  spawning each worker with `start_new_session=True` (its own process
+  group / session).
+- On stop, the handler explicitly terminates each worker's process group
+  (`os.killpg` on POSIX; `CTRL_BREAK_EVENT` / `TerminateProcess` on
+  Windows) rather than relying on the terminal's implicit group delivery.
+
+Trade-offs and notes:
+
+- **Why it's more work.** `run_one_test` currently shares the parent's
+  imports, auth object, and `OrchestratorPaths` in-process. Across a process
+  boundary, inputs (the `TestSpec`, `auth`, `paths`, timestamp) must be
+  picklable or reconstructed in the child, and each child re-imports the
+  harness + re-resolves auth. The per-test entry dict comes back over the
+  pickle channel (it already round-trips through JSON, so this is benign).
+- **Inversion to be aware of.** Putting children in their own session means
+  a terminal Ctrl-C **no longer** auto-kills them — the handler *must* signal
+  the group itself. Same end-user outcome, but now it's our code doing the
+  killing, not the OS. Don't ship the robust path without that explicit
+  teardown or interrupts will hang.
+- **What stays the same.** Incremental partial persistence (C) is
+  transport-agnostic and unchanged; it's what makes any stop non-destructive
+  regardless of thread-vs-process. The robust path only changes *how
+  in-flight tests are killed*, not *how results are saved*.
+- **Bonus.** Owned subprocesses also make the existing
+  SIGKILL-under-memory-pressure failure recoverable per-test (a killed child
+  is one lost test, caught as a worker error) rather than a process-wide
+  hazard.
+
+Decision: not built now. The quick path satisfies the request at a fraction
+of the cost; the robust path is the known next step if Windows kill
+reliability (or a future need for hard per-test timeouts) forces it.

--- a/eval/harness/harness/runlog.py
+++ b/eval/harness/harness/runlog.py
@@ -19,6 +19,7 @@ Pieces this module exposes:
 from __future__ import annotations
 
 import json
+import os
 import re
 from dataclasses import dataclass
 from functools import lru_cache
@@ -450,3 +451,61 @@ def write_run_log(
         )
     out.write_text(json.dumps(log, indent=2))
     return out
+
+
+# ---- Partial (in-progress) run logs ---------------------------------------
+#
+# When the harness is stopped part-way (Ctrl-C) or crashes, the completed
+# tests must not be lost. As each test finishes, the runner rewrites a
+# *partial* envelope to a dotfile (`.partial_<ts>.json`). The dotfile name
+# is deliberately not one `versioning.classify()` recognizes, so it never
+# participates in version numbering, active-state, or the release gate, and
+# `.gitignore` keeps it out of version control. On a clean finish the runner
+# deletes it; on an interrupt it is promoted to a real `scratch_<ts>.json`
+# run log the CRUD UI can open.
+
+_PARTIAL_PREFIX = ".partial_"
+
+
+def partial_runlog_path(runlogs_root: Path, skill: str, timestamp: str) -> Path:
+    """The dotfile path the in-progress partial envelope is written to."""
+    return (
+        Path(runlogs_root) / "unit" / skill / f"{_PARTIAL_PREFIX}{timestamp}.json"
+    )
+
+
+def write_partial_runlog(
+    log: dict[str, Any],
+    *,
+    runlogs_root: Path,
+    skill: str,
+    timestamp: str,
+) -> Path:
+    """Atomically (over)write the in-progress partial envelope dotfile.
+
+    Unlike `write_run_log`, this **overwrites** (the runner calls it after
+    every completed test) and does **not** spill large `text_response`
+    payloads to sidecars — the partial is an ephemeral recovery artifact,
+    not a release. The write is atomic (temp file + `os.replace`) so a
+    SIGKILL mid-write leaves the previous good partial intact. Validates
+    against the v2 schema before writing.
+    """
+    out = partial_runlog_path(runlogs_root, skill, timestamp)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    validate_run_log(log)
+    tmp = out.parent / (out.name + ".tmp")
+    tmp.write_text(json.dumps(log, indent=2), encoding="utf-8")
+    os.replace(tmp, out)
+    return out
+
+
+def promote_partial_to_scratch(partial_path: Path, *, timestamp: str) -> Path:
+    """Rename a partial dotfile to a `scratch_<ts>.json` run log (atomic).
+
+    Called when a run is interrupted: the partial holds every completed
+    test, and renaming it makes it a recognized (gitignored) scratch run
+    log the CRUD UI can read.
+    """
+    scratch = partial_path.parent / f"scratch_{timestamp}.json"
+    os.replace(partial_path, scratch)
+    return scratch

--- a/eval/harness/run_tests.py
+++ b/eval/harness/run_tests.py
@@ -13,6 +13,9 @@ Exit codes:
      that doesn't exist at all — Type 1 unmatched_tool_call)
   3  any test was aborted for an execution reason
      (max_turns / wall clock / tool calls / tokens / error)
+  130  the run was interrupted with Ctrl-C (SIGINT). Completed tests are
+     saved as a partial `scratch_<ts>.json` run log per skill; in-flight
+     tests are terminated and discarded. Conventional 128 + SIGINT(2).
 
 Note on unmatched tool calls (Phase 2):
   - Type 1 (tool doesn't exist): aborts with unmatched_tool_call (exit 2)
@@ -43,7 +46,12 @@ from harness.orchestrator import (
     REPO_ROOT,
     run_one_test,
 )
-from harness.runlog import build_run_log, write_run_log
+from harness.runlog import (
+    build_run_log,
+    promote_partial_to_scratch,
+    write_partial_runlog,
+    write_run_log,
+)
 from harness.skill_runner import DEFAULT_MODEL
 from harness.snapshot import build_snapshot, hash_file
 from harness.versioning import (
@@ -478,8 +486,57 @@ def main(argv: list[str] | None = None) -> int:
     # Reversed so list.pop() yields specs in selection order.
     pending = list(reversed(list(enumerate(specs))))
     stop_submitting = False
+    interrupted = False
     total = len(specs)
     done_n = 0
+
+    # --- Partial-result persistence (Ctrl-C safety) -----------------------
+    # After every completed test we rewrite a partial envelope per skill to a
+    # `.partial_<ts>.json` dotfile, so a Ctrl-C (or crash) never loses the
+    # tests that already finished. The judge hash and per-skill snapshots the
+    # partial needs are the same ones the final write uses, so we compute them
+    # up front and reuse them. Snapshots are captured at run start — skill
+    # files don't change mid-run, and start-of-run is the state the tests
+    # actually executed against.
+    judge_prompt_path = REPO_ROOT / "eval" / "harness" / "judge" / "prompt.md"
+    judge_hash = hash_file("eval/harness/judge/prompt.md", judge_prompt_path)
+    snapshot_cache: dict[str, dict] = {}
+    partial_paths: dict[str, Path] = {}
+
+    def _snapshot_for(skill: str) -> dict:
+        if skill not in snapshot_cache:
+            snapshot_cache[skill] = build_snapshot(skill=skill, repo_root=REPO_ROOT)
+        return snapshot_cache[skill]
+
+    def _flush_partials() -> None:
+        """(Over)write the partial scratch envelope for every skill that has
+        at least one completed test. Cheap relative to a minutes-long test;
+        called after each completion and once more on interrupt."""
+        by_skill: dict[str, list[dict]] = {}
+        for i, sp in enumerate(specs):
+            e = results_by_index.get(i)
+            if e is not None:
+                by_skill.setdefault(sp.skill, []).append(e)
+        for skill, entries in by_skill.items():
+            log = build_run_log(
+                skill=skill,
+                version=None,
+                released=False,
+                releasable=False,
+                invocation=mode,
+                timestamp=invocation_timestamp,
+                harness_version=HARNESS_VERSION,
+                model=DEFAULT_MODEL,
+                judge_prompt_hash=judge_hash,
+                snapshot=_snapshot_for(skill),
+                tests=entries,
+            )
+            partial_paths[skill] = write_partial_runlog(
+                log,
+                runlogs_root=paths.runlogs_root,
+                skill=skill,
+                timestamp=invocation_timestamp,
+            )
 
     def _budget_blocks_next(spec) -> bool:
         """True (and flips stop_submitting) when a suite cap would be
@@ -528,53 +585,77 @@ def main(argv: list[str] | None = None) -> int:
                 )
                 inflight[fut] = (idx, spec)
 
-        _fill()
-        while inflight:
-            completed, _ = wait(inflight, return_when=FIRST_COMPLETED)
-            for fut in completed:
-                idx, spec = inflight.pop(fut)
-                try:
-                    entry = fut.result()
-                except Exception as e:  # noqa: BLE001 — last-resort guard
-                    harness_error = e
-                    stop_submitting = True
-                    print(
-                        f"    ✗ HARNESS ERROR in {spec.id}: "
-                        f"{type(e).__name__}: {e}",
-                        file=sys.stderr,
-                    )
-                    continue
-
-                done_n += 1
-                outcome = entry["outcome"]
-                this_cost = float(entry["totals"].get("total_cost_usd") or 0.0)
-                cumulative_cost += this_cost
-                recent_costs.append(this_cost)
-                results_by_index[idx] = entry
-
-                if outcome == "aborted":
-                    reason = entry["runs"][0].get("aborted_reason")
-                    # not_runnable (pre-execution gate) and Type 1
-                    # unmatched_tool_call (calling a tool that doesn't exist)
-                    # are test-corpus issues — exit 2. Every other abort reason
-                    # is an execution failure — exit 3. Note (Phase 2): Type 2
-                    # unmatched_tool_call (wrong args to existing tool) no
-                    # longer aborts; it continues to judge and fails (exit 1).
-                    if reason in ("not_runnable", "unmatched_tool_call"):
-                        saw_corpus_issue = True
-                    else:
-                        saw_exec_abort = True
-                elif outcome in {"fail", "xpass"}:
-                    saw_fail_or_xpass = True
-
-                dur = float(entry["totals"].get("duration_ms") or 0.0) / 1000.0
-                mark = "✓" if outcome in {"pass", "partial", "xfail"} else "✗"
-                print(
-                    f"  {mark} [{done_n}/{total}] {spec.id} ({spec.skill}) "
-                    f"— {outcome} ({dur:.0f}s skill)",
-                    flush=True,
-                )
+        # A single Ctrl-C terminates the in-flight tests (the terminal
+        # delivers SIGINT to the whole process group, including the `claude`
+        # subprocesses each worker is blocked on) and unwinds here. We catch
+        # it so the completed results that _flush_partials() already wrote
+        # survive, instead of crashing past the save step. A second Ctrl-C
+        # during the shutdown join re-raises and exits via __main__.
+        try:
             _fill()
+            while inflight:
+                completed, _ = wait(inflight, return_when=FIRST_COMPLETED)
+                for fut in completed:
+                    idx, spec = inflight.pop(fut)
+                    try:
+                        entry = fut.result()
+                    except Exception as e:  # noqa: BLE001 — last-resort guard
+                        harness_error = e
+                        stop_submitting = True
+                        print(
+                            f"    ✗ HARNESS ERROR in {spec.id}: "
+                            f"{type(e).__name__}: {e}",
+                            file=sys.stderr,
+                        )
+                        continue
+
+                    done_n += 1
+                    outcome = entry["outcome"]
+                    this_cost = float(entry["totals"].get("total_cost_usd") or 0.0)
+                    cumulative_cost += this_cost
+                    recent_costs.append(this_cost)
+                    results_by_index[idx] = entry
+
+                    if outcome == "aborted":
+                        reason = entry["runs"][0].get("aborted_reason")
+                        # not_runnable (pre-execution gate) and Type 1
+                        # unmatched_tool_call (calling a tool that doesn't
+                        # exist) are test-corpus issues — exit 2. Every other
+                        # abort reason is an execution failure — exit 3. Note
+                        # (Phase 2): Type 2 unmatched_tool_call (wrong args to
+                        # existing tool) no longer aborts; it continues to
+                        # judge and fails (exit 1).
+                        if reason in ("not_runnable", "unmatched_tool_call"):
+                            saw_corpus_issue = True
+                        else:
+                            saw_exec_abort = True
+                    elif outcome in {"fail", "xpass"}:
+                        saw_fail_or_xpass = True
+
+                    dur = float(entry["totals"].get("duration_ms") or 0.0) / 1000.0
+                    mark = "✓" if outcome in {"pass", "partial", "xfail"} else "✗"
+                    print(
+                        f"  {mark} [{done_n}/{total}] {spec.id} ({spec.skill}) "
+                        f"— {outcome} ({dur:.0f}s skill)",
+                        flush=True,
+                    )
+                # Persist everything finished so far before blocking on the
+                # next batch — this is the snapshot a Ctrl-C would keep.
+                _flush_partials()
+                _fill()
+        except KeyboardInterrupt:
+            interrupted = True
+            stop_submitting = True
+            print(
+                "\n  ! interrupted (Ctrl-C) — terminating in-flight tests and "
+                "saving completed results...",
+                file=sys.stderr,
+                flush=True,
+            )
+            # Drop not-yet-started tests; in-flight worker subprocesses already
+            # got SIGINT from the terminal and are exiting. Don't wait on them.
+            ex.shutdown(wait=False, cancel_futures=True)
+            _flush_partials()
 
     # A harness exception is fatal regardless of the other results.
     if harness_error is not None:
@@ -603,12 +684,26 @@ def main(argv: list[str] | None = None) -> int:
     )
     if saw_budget_skip:
         print("Some tests skipped due to suite-level budget cap.")
+    if interrupted:
+        print("Run interrupted with Ctrl-C — keeping the tests that finished.")
 
     _print_summary(rows)
 
+    # Interrupted run: the completed tests are already in the partial dotfiles.
+    # Promote each to a recognized (gitignored) scratch run log the CRUD UI can
+    # open, then exit 130. We never write a releasable v{N} from a partial run.
+    if interrupted:
+        promoted = False
+        for skill, pp in partial_paths.items():
+            if pp.exists():
+                sp = promote_partial_to_scratch(pp, timestamp=invocation_timestamp)
+                print(f"  → wrote {_format_path(sp)} (partial)")
+                promoted = True
+        if not promoted:
+            print("  (no tests finished before the interrupt — nothing to save)")
+        return 130
+
     # --- Write one run log per skill --------------------------------------
-    judge_prompt_path = REPO_ROOT / "eval" / "harness" / "judge" / "prompt.md"
-    judge_hash = hash_file("eval/harness/judge/prompt.md", judge_prompt_path)
     written_paths: list[Path] = []
     for skill, entries in per_skill_entries.items():
         skill_runlog_dir = paths.runlogs_root / "unit" / skill
@@ -617,7 +712,6 @@ def main(argv: list[str] | None = None) -> int:
             releasable=releasable,
             timestamp=invocation_timestamp,
         )
-        snapshot = build_snapshot(skill=skill, repo_root=REPO_ROOT)
         log = build_run_log(
             skill=skill,
             version=version,
@@ -628,7 +722,7 @@ def main(argv: list[str] | None = None) -> int:
             harness_version=HARNESS_VERSION,
             model=DEFAULT_MODEL,
             judge_prompt_hash=judge_hash,
-            snapshot=snapshot,
+            snapshot=_snapshot_for(skill),
             tests=entries,
         )
         path = write_run_log(
@@ -636,6 +730,10 @@ def main(argv: list[str] | None = None) -> int:
         )
         written_paths.append(path)
         print(f"  → wrote {_format_path(path)} ({len(entries)} test(s))")
+
+    # The final run logs supersede the in-progress partials; remove them.
+    for pp in partial_paths.values():
+        pp.unlink(missing_ok=True)
 
     # Precedence: harness crashes already returned above. Among test-level
     # outcomes, surface the most actionable signal: fail/xpass first
@@ -652,4 +750,10 @@ def main(argv: list[str] | None = None) -> int:
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+    # A second Ctrl-C (e.g. during the executor shutdown join) re-raises
+    # KeyboardInterrupt past main(); exit quietly with the conventional code
+    # instead of dumping a traceback.
+    try:
+        sys.exit(main())
+    except KeyboardInterrupt:
+        sys.exit(130)

--- a/eval/harness/tests/unit/test_cli.py
+++ b/eval/harness/tests/unit/test_cli.py
@@ -169,6 +169,14 @@ def _run_with_stubbed_outcomes(tmp_path, monkeypatch, outcomes):
 
     monkeypatch.setattr(run_tests, "run_one_test", fake_run)
     monkeypatch.setattr(run_tests, "write_run_log", fake_write)
+    # The incremental partial writer validates against the schema; these
+    # exit-code tests use minimal non-schema entries, so stub it like
+    # write_run_log above.
+    monkeypatch.setattr(
+        run_tests, "write_partial_runlog",
+        lambda log, *, runlogs_root, skill, timestamp:
+            Path(runlogs_root) / "unit" / skill / f".partial_{timestamp}.json",
+    )
 
     runlogs = tmp_path / "runlogs"
     runlogs.mkdir()
@@ -265,6 +273,14 @@ def test_suite_cost_cap_stops_after_threshold(tmp_path, monkeypatch, capsys):
 
     monkeypatch.setattr(run_tests, "run_one_test", fake_run)
     monkeypatch.setattr(run_tests, "write_run_log", fake_write)
+    # The incremental partial writer validates against the schema; these
+    # exit-code tests use minimal non-schema entries, so stub it like
+    # write_run_log above.
+    monkeypatch.setattr(
+        run_tests, "write_partial_runlog",
+        lambda log, *, runlogs_root, skill, timestamp:
+            Path(runlogs_root) / "unit" / skill / f".partial_{timestamp}.json",
+    )
 
     runlogs = tmp_path / "runlogs"
     runlogs.mkdir()
@@ -341,6 +357,14 @@ def test_suite_cost_cap_resists_early_outlier(tmp_path, monkeypatch):
 
     monkeypatch.setattr(run_tests, "run_one_test", fake_run)
     monkeypatch.setattr(run_tests, "write_run_log", fake_write)
+    # The incremental partial writer validates against the schema; these
+    # exit-code tests use minimal non-schema entries, so stub it like
+    # write_run_log above.
+    monkeypatch.setattr(
+        run_tests, "write_partial_runlog",
+        lambda log, *, runlogs_root, skill, timestamp:
+            Path(runlogs_root) / "unit" / skill / f".partial_{timestamp}.json",
+    )
 
     runlogs = tmp_path / "runlogs"
     runlogs.mkdir()
@@ -412,6 +436,14 @@ def test_suite_wall_clock_cap_stops(tmp_path, monkeypatch):
 
     monkeypatch.setattr(run_tests, "run_one_test", fake_run)
     monkeypatch.setattr(run_tests, "write_run_log", fake_write)
+    # The incremental partial writer validates against the schema; these
+    # exit-code tests use minimal non-schema entries, so stub it like
+    # write_run_log above.
+    monkeypatch.setattr(
+        run_tests, "write_partial_runlog",
+        lambda log, *, runlogs_root, skill, timestamp:
+            Path(runlogs_root) / "unit" / skill / f".partial_{timestamp}.json",
+    )
 
     # max-wall-clock-seconds of 0 means "stop before any test runs"
     # except the first one — the cap check happens at the start of each
@@ -538,6 +570,14 @@ def test_concurrency_runs_every_test_and_preserves_order(tmp_path, monkeypatch):
 
     monkeypatch.setattr(run_tests, "run_one_test", fake_run)
     monkeypatch.setattr(run_tests, "write_run_log", fake_write)
+    # The incremental partial writer validates against the schema; these
+    # exit-code tests use minimal non-schema entries, so stub it like
+    # write_run_log above.
+    monkeypatch.setattr(
+        run_tests, "write_partial_runlog",
+        lambda log, *, runlogs_root, skill, timestamp:
+            Path(runlogs_root) / "unit" / skill / f".partial_{timestamp}.json",
+    )
 
     runlogs = tmp_path / "runlogs"
     runlogs.mkdir()
@@ -556,3 +596,72 @@ def test_concurrency_runs_every_test_and_preserves_order(tmp_path, monkeypatch):
     assert len(captured_logs) == 1
     logged_ids = [t["test_id"] for t in captured_logs[0]["tests"]]
     assert logged_ids == [f"ut_a_{i:03d}" for i in range(n)]
+
+
+def test_ctrl_c_keeps_completed_tests_as_scratch_and_exits_130(tmp_path, monkeypatch):
+    """A Ctrl-C part-way through saves the tests that finished as a partial
+    scratch run log, never a releasable v{N}, and exits 130.
+
+    See docs/plan/eval-harness-stop-early.md. Concurrency is pinned to 1 so
+    exactly one test completes before the interrupt, deterministically.
+    """
+    from harness.auth import AuthConfig
+
+    root = tmp_path / "unit"
+    skill_dir = root / "skill-a"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "rubric.md").write_text(
+        "# skill-a\n\n## Dim1\n\n- **pass:** ok\n- **partial:** mid\n- **fail:** no\n",
+        encoding="utf-8",
+    )
+    for i in range(3):
+        (skill_dir / f"t{i}.json").write_text(json.dumps({
+            "test": {"id": f"ut_a_{i:03d}", "skill": "skill-a", "name": "n",
+                      "type": "positive", "description": "x", "tags": []},
+            "input": {"user_message": "m", "scenario": None},
+            "judge_context": [],
+        }), encoding="utf-8")
+
+    monkeypatch.setattr(
+        run_tests, "resolve_auth",
+        lambda: AuthConfig(skill_runner_mode="api_key", api_key="x", detail="stub"),
+    )
+
+    counter = {"n": 0}
+
+    def fake_run(spec, **kwargs):
+        counter["n"] += 1
+        if counter["n"] == 1:
+            return _stub_log(spec.id, spec.skill, "pass")
+        raise KeyboardInterrupt  # genealogist hits Ctrl-C during test 2
+
+    # Stub the partial writer (real one validates full schema entries); write a
+    # real dotfile so the *real* promote_partial_to_scratch can rename it.
+    def fake_partial_write(log, *, runlogs_root, skill, timestamp):
+        out = Path(runlogs_root) / "unit" / skill / f".partial_{timestamp}.json"
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(json.dumps({"n_tests": len(log["tests"])}), encoding="utf-8")
+        return out
+
+    monkeypatch.setattr(run_tests, "run_one_test", fake_run)
+    monkeypatch.setattr(run_tests, "write_partial_runlog", fake_partial_write)
+
+    runlogs = tmp_path / "runlogs"
+    runlogs.mkdir()
+    rc = run_tests.main([
+        "--skill", "skill-a",
+        "--tests-dir", str(root),
+        "--runlogs-root", str(runlogs),
+        "--concurrency", "1",
+    ])
+
+    assert rc == 130
+    out_dir = runlogs / "unit" / "skill-a"
+    scratch = list(out_dir.glob("scratch_*.json"))
+    assert len(scratch) == 1, "completed tests should be promoted to a scratch log"
+    # The completed test was captured...
+    assert json.loads(scratch[0].read_text(encoding="utf-8"))["n_tests"] == 1
+    # ...and we must NOT mint a releasable candidate from an interrupted run.
+    assert list(out_dir.glob("v*.json")) == []
+    # The in-progress dotfile was moved, not left behind.
+    assert list(out_dir.glob(".partial_*")) == []

--- a/eval/harness/tests/unit/test_partial_runlog.py
+++ b/eval/harness/tests/unit/test_partial_runlog.py
@@ -1,0 +1,123 @@
+"""Tests for the partial (in-progress) run-log helpers — the Ctrl-C safety
+net that keeps completed tests when a harness run is stopped part-way.
+
+See docs/plan/eval-harness-stop-early.md.
+"""
+
+import json
+
+import pytest
+
+from harness.runlog import (
+    JudgeResult,
+    SingleRun,
+    ValidatorResult,
+    assemble_test_entry,
+    build_run_log,
+    partial_runlog_path,
+    promote_partial_to_scratch,
+    validate_run_log,
+    write_partial_runlog,
+)
+from harness.versioning import classify
+
+
+def _entry(test_id="ut_demo_001", outcome="pass"):
+    run = SingleRun(
+        outcome=outcome,
+        aborted_reason=None,
+        duration_ms=1000.0,
+        input_tokens=100,
+        cached_input_tokens=0,
+        output_tokens=10,
+        skill_cost_usd=0.01,
+        output={
+            "text_response": "did the thing",
+            "activated": True,
+            "skills_invoked": ["search-familysearch-wiki"],
+            "tool_calls": [],
+            "files_created": [],
+        },
+        validators=ValidatorResult(passed=True, results=[]),
+        judge=JudgeResult(
+            skipped=False,
+            dimensions=[
+                {"source": "base", "name": "Correctness", "score": 3, "rationale": "ok"},
+                {"source": "base", "name": "Completeness", "score": 3, "rationale": "ok"},
+                {"source": "base", "name": "Tool Arguments", "score": None,
+                 "rationale": "no tool calls — N/A"},
+            ],
+            judge_cost_usd=0.001,
+        ),
+    )
+    return assemble_test_entry(
+        test_id=test_id,
+        test_type="positive",
+        expected_outcome="pass",
+        scenario=None,
+        mcp_fixtures=[],
+        runs=[run],
+        timestamp_for_run_id="2026-06-28_10-00-00",
+    )
+
+
+def _envelope(entries):
+    # A partial is always scratch-shaped: no version, not releasable.
+    return build_run_log(
+        skill="search-familysearch-wiki",
+        version=None,
+        released=False,
+        releasable=False,
+        invocation="skill",
+        timestamp="2026-06-28_10-00-00",
+        harness_version="0.2.0",
+        model="claude-sonnet-4-6",
+        judge_prompt_hash="a" * 64,
+        snapshot={},
+        tests=entries,
+    )
+
+
+TS = "2026-06-28_10-00-00"
+SKILL = "search-familysearch-wiki"
+
+
+def test_write_partial_creates_dotfile_thats_a_valid_envelope(tmp_path):
+    log = _envelope([_entry()])
+    out = write_partial_runlog(log, runlogs_root=tmp_path, skill=SKILL, timestamp=TS)
+
+    assert out == partial_runlog_path(tmp_path, SKILL, TS)
+    assert out.name == f".partial_{TS}.json"
+    # Round-trips and still validates against the v2 schema.
+    reloaded = json.loads(out.read_text(encoding="utf-8"))
+    validate_run_log(reloaded)
+    assert len(reloaded["tests"]) == 1
+
+
+def test_partial_dotfile_is_not_classified_as_a_run_log():
+    # The dotfile must stay invisible to version numbering / the release gate.
+    assert classify(f".partial_{TS}.json").kind == "other"
+
+
+def test_write_partial_overwrites_in_place_and_leaves_no_tmp(tmp_path):
+    write_partial_runlog(_envelope([_entry("ut_a")]),
+                         runlogs_root=tmp_path, skill=SKILL, timestamp=TS)
+    out = write_partial_runlog(_envelope([_entry("ut_a"), _entry("ut_b")]),
+                               runlogs_root=tmp_path, skill=SKILL, timestamp=TS)
+
+    reloaded = json.loads(out.read_text(encoding="utf-8"))
+    assert len(reloaded["tests"]) == 2  # second write replaced the first
+    # The atomic-write staging file is gone.
+    assert not (out.parent / (out.name + ".tmp")).exists()
+    assert list(out.parent.glob(".partial_*")) == [out]
+
+
+def test_promote_partial_to_scratch_renames(tmp_path):
+    partial = write_partial_runlog(_envelope([_entry()]),
+                                   runlogs_root=tmp_path, skill=SKILL, timestamp=TS)
+    scratch = promote_partial_to_scratch(partial, timestamp=TS)
+
+    assert scratch.name == f"scratch_{TS}.json"
+    assert classify(scratch.name).kind == "scratch"
+    assert not partial.exists()  # the dotfile was moved, not copied
+    validate_run_log(json.loads(scratch.read_text(encoding="utf-8")))


### PR DESCRIPTION
## What

Lets a genealogist/developer running the unit-test harness (`make eval-skill SKILL=…` / `run_tests.py --skill …`) **stop with Ctrl-C the moment they see a failing test**, instead of waiting out the whole skill suite — and keeps the results that already ran.

Before this, Ctrl-C unwound past the end-of-run write step, so **every completed result was discarded** (same for a crash or the SIGKILL-under-memory-pressure failure `eval/CLAUDE.md` warns about).

## How

**Incremental partial persistence** (`runlog.py`)
- After each completed test, the runner rewrites a per-skill `.partial_<ts>.json` dotfile — atomic (temp + `os.replace`), schema-validated, overwrites each call.
- The dotfile classifies as `other` (invisible to version numbering / active-state / the release gate) and is gitignored. Deleted on a clean finish; promoted to `scratch_<ts>.json` on interrupt.
- This decouples *stopping* from *losing data*: Ctrl-C, crash, or SIGKILL all leave the completed tests in a valid envelope on disk.

**Catch-and-flush handler** (`run_tests.py`)
- The run loop catches `KeyboardInterrupt`. A single Ctrl-C already terminates the in-flight `claude` subprocesses (they share the harness's process group, so the terminal SIGINT reaches them directly), so the handler just stops submitting, drops pending tests, does a final flush, **promotes partials to `scratch_`**, and exits **130**.
- An interrupted `--skill` run **never** mints a releasable `v{N}` — only `scratch_`.
- Second Ctrl-C exits cleanly via a `__main__` guard instead of dumping a traceback.

## Why the quick path is cheap (and its one caveat)

The threaded model means one Ctrl-C *is* the immediate kill (the OS signals the subprocess group); the harness only needs to **catch** the interrupt to save what finished. This is reliable on macOS/Linux. On **Windows** (the genealogist team's platform) `CTRL_C_EVENT` reaching child console processes is murkier — **worth verifying on a real Windows box.** If in-flight processes survive Ctrl-C there, the deferred robust path (owned child processes + explicit `killpg`) in `docs/plan/eval-harness-stop-early.md` is the next step.

## Tests
- `test_partial_runlog.py` — writer/promote helpers (atomic overwrite, no leftover `.tmp`, dotfile unclassified, rename to scratch).
- `test_cli.py::test_ctrl_c_keeps_completed_tests_as_scratch_and_exits_130` — interrupt wiring (1 completed test → scratch, no `v{N}`, dotfile gone, rc 130); stable over repeated runs.
- Full harness suite: **627 passed, 8 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)