### PR TITLE
eval: stop the scenario-validity lint from emitting 8 deliberate skips

### DIFF
--- a/eval/harness/tests/unit/test_scenario_fixtures.py
+++ b/eval/harness/tests/unit/test_scenario_fixtures.py
@@ -69,13 +69,28 @@ def _intentionally_invalid_scenarios(tests_dir: Path = TESTS_DIR) -> set[str]:
 INTENTIONALLY_INVALID_SCENARIOS = _intentionally_invalid_scenarios()
 
 
-@pytest.mark.parametrize("scenario", _scenario_dirs(), ids=lambda p: p.name)
+def _lintable_scenario_dirs() -> list[Path]:
+    """Scenario dirs the validity lint runs over: every fixture except the
+    ones a test deliberately broke (`intentionally_invalid`).
+
+    Those four `mid-research-flynn-*` fixtures are invalid on purpose so the
+    `validate-schema` skill tests (ut_validate_schema_004–007) can prove the
+    skill *detects* each error class. Linting them as "must be valid" would be
+    wrong, and parametrizing-then-skipping them only adds noise to the run —
+    so they are excluded at collection time instead. The skill tests are what
+    keep them honest: if one accidentally became valid, those tests fail
+    (they assert the skill reports "validation FAILED"). The
+    `intentionally_invalid` test flag remains the single source of truth for
+    which scenarios are exempt; the fixture READMEs document the breakage.
+    """
+    return [
+        p for p in _scenario_dirs()
+        if p.name not in INTENTIONALLY_INVALID_SCENARIOS
+    ]
+
+
+@pytest.mark.parametrize("scenario", _lintable_scenario_dirs(), ids=lambda p: p.name)
 def test_scenario_research_json_is_schema_valid(scenario: Path) -> None:
-    if scenario.name in INTENTIONALLY_INVALID_SCENARIOS:
-        pytest.skip(
-            f"{scenario.name} is broken on purpose (referenced by an "
-            "intentionally_invalid test)"
-        )
     path = scenario / "research.json"
     data = json.loads(path.read_text(encoding="utf-8"))
     errors = validate_research_json(data)
@@ -85,13 +100,8 @@ def test_scenario_research_json_is_schema_valid(scenario: Path) -> None:
     )
 
 
-@pytest.mark.parametrize("scenario", _scenario_dirs(), ids=lambda p: p.name)
+@pytest.mark.parametrize("scenario", _lintable_scenario_dirs(), ids=lambda p: p.name)
 def test_scenario_tree_gedcomx_json_is_schema_valid(scenario: Path) -> None:
-    if scenario.name in INTENTIONALLY_INVALID_SCENARIOS:
-        pytest.skip(
-            f"{scenario.name} is broken on purpose (referenced by an "
-            "intentionally_invalid test)"
-        )
     path = scenario / "tree.gedcomx.json"
     if not path.exists():
         pytest.skip(f"{scenario.name} has no tree.gedcomx.json")


### PR DESCRIPTION
## What

The harness suite reported **8 skipped tests on every run**. This removes all 8 without losing any coverage.

## Why they existed

`test_scenario_fixtures.py` has two lint tests asserting every scenario fixture is schema-valid (one for `research.json`, one for `tree.gedcomx.json`). They parametrized over *all* fixtures, then skipped the four intentionally-broken `mid-research-flynn-*` fixtures inside the body — 4 fixtures × 2 tests = 8 skips.

Those fixtures are invalid **on purpose**: each backs a `validate-schema` skill test that proves the skill detects one error class.

| Fixture | Skill test | Error proven detected |
|---|---|---|
| `bad-enum` | `ut_validate_schema_004` | invalid closed-enum value |
| `missing-field` | `ut_validate_schema_005` | missing required field |
| `bad-id-prefix` | `ut_validate_schema_006` | malformed ID prefix |
| `dangling-ref` | `ut_validate_schema_007` | reference pointing nowhere |

So "make them valid" would break `ut_validate_schema_004–007`, and "delete them" would drop the skill's error-detection coverage. Neither is right.

## The fix

Exclude the `intentionally_invalid` fixtures from the lint's parametrization (new `_lintable_scenario_dirs()` helper) so no test item — and therefore no skip — is generated for them, instead of generating-then-skipping.

- The `intentionally_invalid` test flag stays the single source of truth for the exemption (the helper reads it).
- No separate "assert these are actually broken" guard is needed: the `validate-schema` skill tests already fail loudly if a fixture accidentally becomes valid (they assert the skill reports "validation FAILED").
- The "broken on purpose" fact stays documented in the `intentionally_invalid` flag, the fixture READMEs, and a comment in the lint.

## Verification

- `test_scenario_fixtures.py`: **87 passed / 0 skipped** (was 87 / 8).
- Full harness suite (`-m 'not e2e'`): **622 passed / 0 skipped** (was 622 / 8).
- Passing count unchanged → no coverage lost. `0 skipped` is now the baseline, so a future skip is a real anomaly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)