### PR TITLE
eval/briefs: research is the deep-dive's unit-test exception

### DIFF
--- a/eval/briefs/research.md
+++ b/eval/briefs/research.md
@@ -2,43 +2,36 @@
 
 > Per-skill map for the deep-dive. Generic process: [`eval/JUNIOR-WALKTHROUGH.md`](../JUNIOR-WALKTHROUGH.md).
 
-**Effort profile:** Greenfield — no tests, no rubric exist yet; the day's job is to stand up the first `eval/tests/unit/research/` directory + rubric + initial routing tests from scratch. This is a router, so the work is test-mechanics-heavy (crafting a research.json state per routing-table row) plus one net-new rubric dimension (Routing Correctness) the other skills don't have. Genealogical judgment is light — you grade *which sub-skill was picked*, not genealogical output.
-**Files:** SKILL.md (189 lines) · references ×0 (none) · tests ×0 (NONE) · rubric ✗ (missing — no test dir).
+**Effort profile:** **Skill-body review, not unit-test authoring.** research is the one skill whose deep-dive does **not** stand up `eval/tests/unit/research/`. It's a thin orchestrator with no isolatable unit: the harness stages every sub-skill into `.claude/skills/` and grants the `Skill` tool, so any "routing" run cascades into the full sub-skill chain (mocked MCP) — a slow mini-e2e that grades the chain, not the router, over a `Skill`-tool mechanism Cowork production doesn't have (`docs/specs/skill-architecture-spec.md` §92: "Cowork lacks programmatic skill invocation"). A green unit suite would bless a routing path that can't occur in production. So the day's job is to **review and tighten the SKILL.md** (routing table, `--autonomous` contract, gps-mentor verdict protocol, stop conditions); the **e2e GPS fixtures are the regression floor**. Genealogical judgment is light — you're checking orchestration/routing logic, not genealogical output.
+
+**Files:** SKILL.md (227 lines) · references ×0 (none) · tests ×0 (**by design — no unit directory, see Effort profile**) · rubric ✗ (intentionally none).
 
 ## What this skill does
-The thin **orchestrator** for the full GPS workflow. It reads `research.json` state and routes to the right sub-skill (question-selection → research-plan → search-records → record-extraction → assertion-classification → person-evidence → conflict-resolution → hypothesis-tracking → research-exhaustiveness → proof-conclusion), iterating until all questions resolve. It **writes nothing directly** — every write is delegated to the sub-skill it routes to; between steps it calls `validate_research_schema` (read-only). It has an `--autonomous` mode (no clarifying questions; log decisions and rationale to the audit trail) and three `gps-mentor` subagent checkpoints (pre-exhaustiveness, conclusion-readiness, proof-critique) with a four-verdict handling protocol (`looks_solid` / `consider_addressing` / `address_first` / `refused`) that **branches between interactive and autonomous mode**. The only side-channel writes during a run come from the mentor subagent, which writes verdict files under `evaluations/`. Key invariant: it never introduces GPS logic, never skips steps, and never auto-routes past an `address_first` verdict in interactive mode.
+The thin **orchestrator** for the full GPS workflow. It reads `research.json` state and routes to the right sub-skill (question-selection → research-plan → search-records → record-extraction → assertion-classification → person-evidence → conflict-resolution → hypothesis-tracking → research-exhaustiveness → proof-conclusion), iterating until all questions resolve. It **writes nothing directly** — every write is delegated to the sub-skill it routes to. It does **not** run periodic `validate_research_schema` passes between steps: each writer tool (`research_append`, `research_log_append`, `tree_edit`) validates the whole project before persisting, so the orchestrator only calls `validate_research_schema` to confirm an external/manual edit. It has an `--autonomous` mode (no clarifying questions; log decisions and rationale to the audit trail) and three `gps-mentor` subagent checkpoints (pre-exhaustiveness, conclusion-readiness, proof-critique) with a four-verdict handling protocol (`looks_solid` / `consider_addressing` / `address_first` / `refused`) that **branches between interactive and autonomous mode**. The only side-channel writes during a run come from the mentor subagent, which writes verdict files under `evaluations/`. Key invariant: it never introduces GPS logic, never skips steps, and never auto-routes past an `address_first` verdict in interactive mode.
 
 ## Where everything lives
-- `plugin/skills/research/SKILL.md`
+- `packages/engine/plugin/skills/research/SKILL.md`
 - references: none
-- `eval/tests/unit/research/` — **does not exist yet**; the deep-dive creates it (test JSONs + `rubric.md`).
-- Scenarios available to reuse: `empty-project-just-created`, `mid-research-flynn`, `flynn-census-exhausted`, `flynn-research-complete-no-proof`, `flynn-resolved` map onto routing-table rows; mentor-checkpoint tests may need an `evaluations/` verdict fixture added to a scenario.
+- `eval/tests/unit/research/` — **intentionally absent** (see Effort profile). No test JSONs, no `rubric.md`, no `test_research.py` validator.
+- Regression coverage lives in the **e2e framework**: the GPS fixtures under `eval/tests/e2e/` (e.g. `eval/tests/e2e/kenneth-quass-death/`) drive the full autonomous loop. Treat those as research's floor.
 
-## Current tests (0) — greenfield
-> ⚠️ This skill is **unevaluated**: zero tests, no `rubric.md`, and no `eval/tests/unit/research/` directory at all. There is nothing to harden — the deep-dive stands up the first test directory, authors the first rubric (including a Routing Correctness dimension), and lands the initial tests below.
+## Why no unit suite (don't author one)
+> ⚠️ research has **no unit tests and no `rubric.md` by design** — not a gap to be filled. A unit run here degenerates into a mocked mini-e2e (the harness stages all sub-skills and grants the `Skill` tool) and exercises a routing mechanism production lacks. Review the SKILL.md directly and lean on the e2e fixtures.
 
-## Tests to author (none exist yet)
-**Positive (one routing test per major routing-table row — assert the right next sub-skill is chosen):**
-- **objective, no questions → `question-selection`** (use `empty-project-just-created` extended with an objective).
-- **question, no plan → `research-plan`**.
-- **plan not executed → `search-records`** (use `mid-research-flynn`).
-- **all plan items done, analysis complete → `research-exhaustiveness`** (use `flynn-census-exhausted`).
-- **`exhaustive_declared`, no `proof_summaries` entry → `proof-conclusion`** (use `flynn-research-complete-no-proof`).
-- **all questions `resolved`, `project.status == "completed"` → stop** (use `flynn-resolved`).
-- **Mentor checkpoint — `address_first` verdict:** interactive mode *asks the user* before routing; autonomous mode routes to the first `must_address` item's `suggested_skill`. Two tests (or one per mode), each needing an `evaluations/<focus>-<target>-*.json` verdict fixture in the scenario.
+Two facts make the orchestrator un-unit-testable on the same footing as the other skills:
+- **No isolatable unit.** A routing run cascades through the whole sub-skill chain, so you'd be grading the chain (slow, redundant with the real e2e framework), not the routing decision.
+- **Fictional mechanism.** That cascade runs over the harness's `Skill` tool; Cowork has no programmatic skill-to-skill invocation, so its production routing is prose auto-discovery. For every other skill this divergence is minor; for the orchestrator it *is* the behavior.
 
-**Negative (boundaries from the description):**
-- → `question-selection` / `research-plan` / `search-records` (etc.): "Just do the research-plan step on q_001." — driving a *specific* step directly must NOT trigger the orchestrator.
-- → `project-status`: "Give me a status summary of where this project stands." — status-only, no routing.
-- → `init-project`: a prompt against a folder with **no `research.json`** — must defer to init-project, not route.
+## How to review it (no unit run to lean on)
+- **Routing table** — walk each `research.json` state row and confirm the next sub-skill is correct, and that exhaustiveness stays the last gate before proof-conclusion. The representative scenarios (`empty-project-just-created`, `mid-research-flynn`, `flynn-census-exhausted`, `flynn-research-complete-no-proof`, `flynn-resolved`) map onto rows and are useful as **read-through reference**, not unit fixtures.
+- **`--autonomous` contract** — confirm the keep-going-in-one-turn rule and audit-trail logging read correctly; the e2e runs depend on it.
+- **gps-mentor verdict protocol** — confirm the interactive-vs-autonomous branching and the `address_first` "never auto-route in interactive mode" rule still match the spec (`docs/specs/gps-mentor-agent-spec.md`).
+- **Stop conditions** — the real stops (`project.status == "completed"`, user halt, genuine logged blocker).
+- **Route-out boundaries** — drive a specific step → that sub-skill; status-only → project-status; no `research.json` → init-project. These live in the frontmatter `description` and are **description-triggering** concerns: exercise them through the description-optimizer's triggering set, not a unit rubric here.
 
 ## ⚠️ Known issues
-- **Routing tests collide with neighbor skills' descriptions.** Each sub-skill's own `description` competes for the same prompt; the `research` negative tests and the neighbor skills' negatives must be authored in coordination so they don't contradict.
-- **No Routing Correctness rubric dimension exists.** Grading "did it pick the right next sub-skill" needs a dimension the other skills don't have — author it as part of standing up `rubric.md`.
-- **Mentor checkpoint invokes a real subagent (`@plugin:gps-mentor`).** Decide up front whether the harness can exercise the subagent or whether the test only asserts the orchestrator *reached* the checkpoint and handled the verdict — the latter is the safer first cut.
-
-## Fixture work
-Light on MCP fixtures — the only declared tool is `validate_research_schema` (read-only, no API), so no `eval/fixtures/mcp/` entries are needed. The fixture cost is **scenario state**: most routing-table rows already have a representative scenario (listed above), but the mentor-checkpoint tests need a net-new `evaluations/` verdict file dropped into the chosen scenario. The "objective, no questions" row may need `empty-project-just-created` extended with an objective.
+- **Mentor checkpoint invokes a real subagent (`@plugin:gps-mentor`).** Its verdict branching is specced but only exercised end-to-end — confirm the prose still matches `docs/specs/gps-mentor-agent-spec.md` during review.
+- **Route-out boundaries are undefended.** With no negative tests here, the only thing keeping research from grabbing single-step / status-only / no-research.json prompts is the frontmatter `description`. Any future hardening of those boundaries belongs to the description-optimizer, not this directory.
 
 ## Definition of done
-Stand up `eval/tests/unit/research/` with a first `rubric.md` (add the Routing Correctness dimension) → add one positive routing test per major routing-table row reusing existing scenarios → add the `address_first` mentor-checkpoint test(s) with an `evaluations/` verdict fixture → add the three "drive a step directly / status-only / no-research.json" negatives (coordinated with neighbor skills) → first full harness pass + CRUD grade-correction + PR.
+Review and tighten the SKILL.md — routing table (every row), `--autonomous` contract, gps-mentor verdict protocol, stop conditions — keeping the orchestration semantics intact (no unit harness will catch a regression). Confirm an e2e GPS fixture still drives the full autonomous loop without yielding mid-chain and with the mentor gates firing. **No `eval/tests/unit/research/`, no `rubric.md`** — intentionally omitted for the orchestrator. PR the SKILL.md changes per the usual cadence.

--- a/eval/briefs/shorten-research.md
+++ b/eval/briefs/shorten-research.md
@@ -6,7 +6,8 @@ confirms the routing-table semantics and the mentor-gate logic are preserved)
 **Current size:** 212 lines → **Target:** ~150–165 lines (~25% reduction)
 **Tool migration:** **n/a** — no persistence tool. research is a thin
 orchestrator; its only `allowed-tools` entry is `validate_research_schema`
-(read-only, periodic). It isn't in
+(read-only, and no longer run periodically — only to confirm an external/manual
+edit). It isn't in
 `docs/specs/skill-rewrites-for-persistence-tools-spec.md` §4 — every write is
 delegated to a sub-skill.
 **Still needed as a skill?** **Yes, but it's the riskiest of the three to
@@ -116,7 +117,9 @@ behavior") that restate the routing table's premises.
    routes to sub-skills; no programmatic invocation, so routing is by judgment).
 2. Autonomous mode — the keep-going contract, stated once + audit-logging.
 3. What to do: read state → **routing table (whole)** → iterate (one-line, refers
-   back to Autonomous) → validate periodically.
+   back to Autonomous). (The skill no longer runs periodic
+   `validate_research_schema`; don't reintroduce it — the writer tools validate
+   before persisting.)
 4. Mentor checkpoints — the two tables + verdict rules, prose tightened.
 5. When to stop — the three conditions, no yielding re-argument.
 6. One-line routing-out boundaries (status→project-status, step→sub-skill,
@@ -141,7 +144,10 @@ repetition (the thrice-stated no-yielding rule) and the two boilerplate tails.
 **Developer** does the structural compression; **genealogist** (or whoever owns
 the GPS workflow + the gps-mentor spec) signs off that the routing table and
 mentor protocol are semantically unchanged before merge — because no harness
-will. If the team wants this skill to be unit-shortenable on the same footing as
-the others, the prerequisite is authoring `eval/tests/unit/research/` (routing
-positives + the three routing-out negatives) and a `test_research.py` validator
-asserting read-only — that's a separate task, noted here as the real gap.
+will. The absence of `eval/tests/unit/research/` is **intentional, not a gap**:
+research is a thin orchestrator with no isolatable unit (a routing run in the
+harness cascades through every sub-skill over a `Skill` tool that Cowork
+production lacks), so a unit suite would grade a fictional routing path. The e2e
+GPS fixtures are this skill's floor by design — don't author a unit directory to
+"bring it onto the same footing" as the others. See the deep-dive brief
+(`research.md`) for the full rationale.


### PR DESCRIPTION
## What

Updates the two `research` briefs to reflect that the research skill should **not** get a unit-test suite in its deep-dive — it's the exception.

## Why

`research` is a thin orchestrator with no isolatable unit:

- The eval harness stages **every** sub-skill into `.claude/skills/` (`workspace.py`) and grants the `Skill` tool (`allowed_tools.py` baseline). So a "routing" run cascades into the full sub-skill chain (mocked MCP) — a slow mini-e2e that grades the chain, not the router, and is redundant with the real e2e framework.
- That cascade runs over the harness's `Skill` tool, which **Cowork production doesn't have** (`docs/specs/skill-architecture-spec.md` §92: "Cowork lacks programmatic skill invocation"; production routing is prose auto-discovery). A green unit suite would bless a routing path that can't occur in production.

The real regression floor for the orchestrator is the **e2e GPS fixtures** — which is also why reviewing/improving this skill now is timely, as we move people onto e2e tests.

## Changes

- **`eval/briefs/research.md`** (deep-dive) — reframed from "stand up `eval/tests/unit/research/` + rubric + routing tests" to "review and tighten the SKILL.md; e2e fixtures are the floor." Recast Tests-to-author → How-to-review; updated Effort profile, Files, Known issues, Definition of done.
- **`eval/briefs/shorten-research.md`** (shorten) — flipped the "authoring a unit suite is the real gap" note to "the absence is intentional, not a gap." Kept the existing cut-conservatively / e2e-gated caution.
- **Staleness fixes** from the batch-persistence speedup (`184f857`): the orchestrator no longer runs periodic `validate_research_schema` between steps — corrected in both briefs. Also fixed the stale SKILL.md path (`plugin/` → `packages/engine/plugin/`) and line count in `research.md`.

Docs-only; no code or test changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)