### PR TITLE
DO NOT MERGE: research: re-check sufficiency after each finding, not only after draining the plan

### DIFF
--- a/packages/engine/plugin/skills/research/SKILL.md
+++ b/packages/engine/plugin/skills/research/SKILL.md
@@ -82,29 +82,44 @@ user as you encounter them.
    |-------------------------|--------|
    | Objective but no questions | `question-selection` (derive first question) |
    | A question with no plan | `research-plan` |
-   | Plan items not yet executed | `search-records` (or `search-external-sites` for non-FS sources) |
+   | Plan items not yet executed, and no analyzed evidence yet plausibly answers the active question | `search-records` (or `search-external-sites` for non-FS sources) |
    | Log entries with no assertions extracted | `record-extraction` |
    | Assertions needing GPS three-layer classification | `assertion-classification` |
    | Assertions not yet linked to persons | `person-evidence` |
    | Evidence conflicts present | `conflict-resolution` |
    | Identity uncertainty across assertions | `hypothesis-tracking` |
+   | Analyzed evidence now plausibly answers the active question — **even with plan items still `planned`** | `research-exhaustiveness` (consult the stop criteria *before* draining the rest of the plan; it sends you back to `research-plan` if the question — e.g. a completeness "did they have *any other* children?" question — is not yet reasonably exhausted) |
    | All plan items for a question are `completed` or `skipped`, and analysis above is done | `research-exhaustiveness` |
    | `research-exhaustiveness` returned "not yet exhaustive" with gaps to fill | `research-plan` (extend the plan) or `question-selection` (FAN pivot) |
    | A question is at `status: "exhaustive_declared"` with no `proof_summaries` entry yet | `proof-conclusion` (writes the proof and flips the question to `resolved`) |
    | All questions are `resolved` and `project.status` is `completed` | Stop |
 
-   Exhaustiveness is the last gate before proof. It evaluates a
-   question only after its plan has been executed and the resulting
-   evidence has been extracted, classified, person-linked, and
-   conflict-resolved — the 5 threshold questions and 7-point stop
-   criteria cannot be answered without those upstream artifacts.
+   A front-loaded plan is a **prioritized list, not a checklist to
+   drain.** Consult `research-exhaustiveness` as soon as analyzed
+   evidence plausibly answers the active question — do not reflexively
+   execute the remaining `planned` items first. Exhaustiveness is the
+   stop gate: it weighs the question against the 5 threshold questions
+   and 7-point stop criteria and either declares the search reasonably
+   exhaustive (→ proof) or routes you back to `research-plan` /
+   `question-selection` for the gaps. That round-trip is what lets a
+   simple-recall question stop early **without** weakening a
+   completeness / negative one ("did they have *any other* children?"):
+   finding a single child does not satisfy such a question, so
+   exhaustiveness will send you back for the enumerating sources (the
+   household census, parent-indexed births, obituaries) before it lets
+   you conclude. The gate still requires the evidence to have been
+   extracted, classified, person-linked, and conflict-resolved first —
+   those upstream artifacts are what its criteria read.
 
 3. **Iterate — without yielding.** After each sub-skill returns, route
    to the next step **in the same turn** (under `--autonomous`; see
    "Autonomous mode") from the sub-skill's compact return plus the state
    you already hold — re-read `research.json` only if the sub-skill
    changed state you don't have in context, or you're routing into a
-   phase cold. New evidence may reveal new
+   phase cold. After a plan item completes and its evidence is analyzed,
+   re-assess sufficiency — route to `research-exhaustiveness` once the
+   evidence plausibly answers the active question — before reflexively
+   executing the next `planned` item. New evidence may reveal new
    questions — return to `question-selection`. Resolved conflicts may
    unblock `proof-conclusion`. Do not assume the chain is linear; the
    same sub-skill may be invoked multiple times across the run. Do not


### PR DESCRIPTION
## What

Make `/research` re-check sufficiency **after each finding** instead of only after the whole plan is drained.

Today the orchestrator routes to `research-exhaustiveness` (the GPS stop gate) only on the row *"All plan items for a question are `completed` or `skipped`"* (`research/SKILL.md`). Since `research-plan` is designed to front-load a 4–10 item plan, the executor drains every item even when the objective was answered on item 1 — the plan is treated as a checklist, not a prioritized list.

This PR adds a routing row + principle so the orchestrator consults `research-exhaustiveness` as soon as analyzed evidence *plausibly answers* the active question, before executing the remaining `planned` items.

## Why

Surfaced by the `ivyl-greenley-daughter` e2e run (completeness objective: *"did Ivyl & Kenneth have any children other than Donald?"*). The agent recovered the answer (daughter Alice Jeannette, birth + death, sourced from Minnesota vital records) in **~9 minutes**, then spent **~34 more** grinding the rest of the plan and escalating to browsing raw 1950-census images — which overflowed the 1 MB MCP stdio buffer (`image_read` base64) and crashed the run (`stop_reason: error`). The verdict was still `pass`, but the run was ~5× longer than the research warranted.

## Design note — completeness objectives are preserved

The fix deliberately pushes the tier judgment to `research-exhaustiveness`, which already owns it. So this does **not** make the agent stop at the first hit:

- **Simple-recall objective** → evidence answers it → exhaustiveness says "reasonably exhaustive" → proof. Stops early. ✅
- **Completeness / negative objective** ("any *other* children?") → one child found does **not** satisfy it → exhaustiveness routes back to `research-plan` for the enumerating sources (household census, parent-indexed births, obituaries). Keeps searching. ✅

That round-trip is what lets recall questions stop early without weakening completeness questions — which we want to keep as a test shape.

## Scope

Single file: `packages/engine/plugin/skills/research/SKILL.md` (+22 / −7). Four touches: one routing-row qualifier, one new routing row, the explanatory paragraph rewritten, and one reinforcing line in the "Iterate" step.

## ⚠️ CI: `check-runlogs` will be red — by design

`research` has **no eval scaffolding** (no `eval/tests/unit/research/`, no `eval/runlogs/unit/research/`), so `check_runlogs.py` hard-errors on any touch of the skill dir (the missing-runlog path isn't covered by the `eval-cosmetic-skip` label). Clearing it requires authoring `research` unit tests, running the harness on the host, and annotating — **the dev+gen team will run the tests.** Not mergeable until that lands.

Worth a separate discussion: `research` is the **orchestrator**, validated via e2e fixtures (this is how the gap surfaced), not unit tests — so the unit-runlog gate may be the wrong gate for orchestrator changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
