### PR TITLE
Add e2e testing kickoff deck + make e2e-view convenience tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,10 @@ eval/runlogs/unit/*/.partial_*.json.tmp
 # being committed as if it had validated the fixture.
 eval/runlogs/e2e/*/scratch_*
 
+# `make e2e-view` staging folder — the latest run's final state copied in as
+# research.json + tree.gedcomx.json for the Research Viewer to open. Throwaway.
+eval/.e2e-view/
+
 # Raw SDK session transcripts copied next to each e2e runlog. Multi-MB forensic
 # data (per-turn timestamps/tokens/thinking) for local latency+cost analysis —
 # not a fixture validity artifact, so kept out of git to avoid repo bloat.

--- a/Makefile
+++ b/Makefile
@@ -286,6 +286,16 @@ e2e-run: $(ENGINE_BUILD) ## Run ONE e2e benchmark fixture against live FamilySea
 	@test -n "$(TEST)" || { echo "ERROR: set TEST, e.g. make e2e-run TEST=kenneth-quass-death" >&2; exit 1; }
 	cd eval/harness && uv run python -m e2e.run_e2e --test $(TEST) $(if $(filter 0 false no off,$(RESUME_ON_STALL)),--no-resume-on-stall,)
 
+.PHONY: e2e-view
+e2e-view: ## Load the latest e2e run into the Research Viewer (eval/.e2e-view): make e2e-view TEST=kenneth-quass-death
+	# Copies the newest run's final tree + research.json into eval/.e2e-view/
+	# (the shape the viewer opens + live-watches). Open that folder once in
+	# the viewer (its Open Project button, or `make electron`); later runs
+	# refresh it in place. Cheap + instant — and it picks the newest run, so
+	# a failing scratch_ run (what you usually want to inspect) works too.
+	@test -n "$(TEST)" || { echo "ERROR: set TEST, e.g. make e2e-view TEST=kenneth-quass-death" >&2; exit 1; }
+	cd eval/harness && uv run python -m e2e.view --test $(TEST)
+
 .PHONY: e2e-validate
 e2e-validate: ## Stripping linter for an e2e fixture (or all): make e2e-validate TEST=kenneth-quass-death  (omit TEST for --all)
 	cd eval/harness && uv run python -m e2e.validate_fixture $${TEST:---all}

--- a/eval/README.md
+++ b/eval/README.md
@@ -32,6 +32,7 @@ eval/
   Login.bat               Windows: FamilySearch login for e2e (once a day)
   CheckSetup.bat          Windows: e2e preflight (run this first)
   RunE2E.bat              Windows: run one e2e benchmark fixture (live FS)
+  ViewE2E.bat             Windows: load the latest e2e run into the Research Viewer
   ValidateFixture.bat     Windows: e2e stripping linter
   ScratchResearch.bat     Windows: set up a throwaway dir to debug /research by hand
   RunCalibration.bat      Windows: run judge calibration (maintainer only)
@@ -307,7 +308,11 @@ equivalent in parentheses:
 7. `eval\RunE2E.bat` → enter the slug (`make e2e-run TEST=<slug>`) →
    live run (20–60 min, $3–10).
 8. `/interpret-e2e-result` → read the verdict.
-9. If it passes, commit the fixture (and optionally its run log), and
+9. `eval\ViewE2E.bat` → enter the slug (`make e2e-view TEST=<slug>`) → open
+   `eval\.e2e-view` in the Research Viewer (its **Open Project** button) to
+   inspect the agent's final tree, research log, and each finding's
+   direct/indirect badge. Keep the viewer open — re-running refreshes it live.
+10. If it passes, commit the fixture (and optionally its run log), and
    open a PR.
 
 ### Keep the machine awake during a run

--- a/eval/ViewE2E.bat
+++ b/eval/ViewE2E.bat
@@ -1,0 +1,25 @@
+@echo off
+cd %~dp0
+
+echo === Cowork Genealogy E2E — Load a run into the Research Viewer ===
+echo.
+echo Copies the latest run's final tree + research into eval\.e2e-view\ so you
+echo can open it in the Research Viewer. Cheap and instant — no rebuild, no login.
+echo.
+set /p SLUG="Which fixture (slug) do you want to view? (e.g. kenneth-quass-death): "
+
+if "%SLUG%"=="" (
+  echo.
+  echo No fixture entered. Aborting.
+  pause
+  exit /b 1
+)
+
+cd harness
+call uv run python -m e2e.view --test %SLUG%
+
+echo.
+echo Now open the  eval\.e2e-view  folder in the Research Viewer using its
+echo "Open Project" button. Keep the viewer open — run this again after each
+echo e2e run and the viewer refreshes live.
+pause

--- a/eval/harness/e2e/view.py
+++ b/eval/harness/e2e/view.py
@@ -1,0 +1,96 @@
+"""Load the latest e2e run's final state into the Research Viewer folder.
+
+`make e2e-view TEST=<slug>` (Windows: `ViewE2E.bat`) copies the newest run's
+`*.final-research.json` + `*.final-tree.gedcomx.json` for a fixture into one
+stable folder — `eval/.e2e-view/` — renamed to `research.json` +
+`tree.gedcomx.json`, the shape the Electron Research Viewer opens and
+live-watches.
+
+Open that folder once in the viewer (its "Open Project" button, or start the
+viewer with `make electron`); every later `make e2e-view` overwrites the two
+files in place, so an already-open viewer refreshes live across the
+run -> interpret -> grade -> improve -> re-run loop.
+
+Picks the newest run by mtime, so it works on a failing `scratch_*` run (the
+usual thing to inspect) as well as a committed passing `run-*` one.
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import sys
+from pathlib import Path
+
+from .orchestrator import DEFAULT_RUNLOG_ROOT, REPO_ROOT
+
+VIEW_DIR = REPO_ROOT / "eval" / ".e2e-view"
+
+
+def latest_final_pair(slug_dir: Path) -> tuple[Path, Path] | None:
+    """Return the newest (tree, research) `final-*` pair in slug_dir, or None."""
+    trees = sorted(
+        slug_dir.glob("*.final-tree.gedcomx.json"),
+        key=lambda p: p.stat().st_mtime,
+        reverse=True,
+    )
+    for tree in trees:
+        research = tree.with_name(
+            tree.name.replace(".final-tree.gedcomx.json", ".final-research.json")
+        )
+        if research.exists():
+            return tree, research
+    return None
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="e2e.view",
+        description="Load the latest e2e run for a fixture into the Research Viewer folder.",
+    )
+    parser.add_argument(
+        "--test", required=True, help="Fixture slug, e.g. kenneth-quass-death"
+    )
+    parser.add_argument("--runlog-root", type=Path, default=DEFAULT_RUNLOG_ROOT)
+    args = parser.parse_args(argv)
+
+    slug_dir = args.runlog_root / args.test
+    if not slug_dir.is_dir():
+        print(
+            f"No runs for '{args.test}' — {slug_dir} does not exist. "
+            f"Run `make e2e-run TEST={args.test}` first.",
+            file=sys.stderr,
+        )
+        return 1
+
+    pair = latest_final_pair(slug_dir)
+    if pair is None:
+        print(
+            f"No completed run in {slug_dir} (need a matching "
+            f"*.final-tree.gedcomx.json + *.final-research.json). "
+            f"Run `make e2e-run TEST={args.test}` first.",
+            file=sys.stderr,
+        )
+        return 1
+
+    tree, research = pair
+    VIEW_DIR.mkdir(parents=True, exist_ok=True)
+    shutil.copyfile(tree, VIEW_DIR / "tree.gedcomx.json")
+    shutil.copyfile(research, VIEW_DIR / "research.json")
+
+    run_stem = tree.name.replace(".final-tree.gedcomx.json", "")
+    print(f"Loaded {run_stem} into {VIEW_DIR}")
+    print()
+    print("Open it in the Research Viewer:")
+    print(f"  - In the viewer, click Open Project and choose:  {VIEW_DIR}")
+    print("  - No viewer open yet? Start it with `make electron`.")
+    print()
+    print(
+        "Keep the viewer open — run `make e2e-view` again after each run "
+        "and it refreshes live."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/eval/slides/e2e-testing-kickoff.html
+++ b/eval/slides/e2e-testing-kickoff.html
@@ -1,0 +1,343 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>E2E Testing — Create, Run & Evaluate</title>
+<style>
+  :root {
+    --bg: #0f172a;
+    --panel: #1e293b;
+    --ink: #f1f5f9;
+    --muted: #94a3b8;
+    --accent: #38bdf8;
+    --accent2: #fbbf24;
+    --good: #4ade80;
+    --line: #334155;
+  }
+  * { box-sizing: border-box; -webkit-print-color-adjust: exact; print-color-adjust: exact; }
+  html, body { margin: 0; height: 100%; }
+  body {
+    background: var(--bg);
+    color: var(--ink);
+    font-family: -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    font-size: 28px;
+    line-height: 1.45;
+    overflow: hidden;
+  }
+  .deck { height: 100vh; width: 100vw; }
+  .slide {
+    display: none;
+    height: 100vh;
+    width: 100vw;
+    padding: 4.5vh 6vw 9vh;
+    flex-direction: column;
+    justify-content: flex-start;
+    overflow: hidden;
+  }
+  .slide.active { display: flex; }
+  h1 { font-size: 2.0em; margin: 0 0 0.3em; line-height: 1.1; }
+  h2 { font-size: 1.35em; margin: 0 0 0.55em; color: var(--accent); line-height: 1.15; }
+  h3 { font-size: 1.0em; margin: 0.6em 0 0.2em; color: var(--accent2); }
+  p { margin: 0.25em 0; }
+  ul, ol { margin: 0.2em 0; padding-left: 1.1em; }
+  li { margin: 0.32em 0; }
+  li ul { margin: 0.1em 0; }
+  .sub { color: var(--muted); }
+  strong { color: #fff; }
+  code {
+    background: #0b1220;
+    color: #e2e8f0;
+    padding: 0.08em 0.35em;
+    border-radius: 5px;
+    font-family: "SF Mono", Menlo, Consolas, monospace;
+    font-size: 0.82em;
+  }
+  pre {
+    background: #0b1220;
+    border: 1px solid var(--line);
+    border-radius: 8px;
+    padding: 0.55em 0.8em;
+    margin: 0.2em 0 0;
+    overflow: auto;
+  }
+  pre code { background: none; padding: 0; font-size: 0.74em; line-height: 1.5; }
+  .chip {
+    display: inline-block;
+    font-size: 0.5em;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: var(--bg);
+    background: var(--accent);
+    padding: 0.25em 0.7em;
+    border-radius: 999px;
+    vertical-align: middle;
+    margin-left: 0.5em;
+  }
+  .chip.who { background: var(--accent2); }
+  .chip.time { background: var(--good); }
+  .kicker { color: var(--muted); font-size: 0.6em; letter-spacing: 0.08em; text-transform: uppercase; margin-bottom: 0.4em; }
+  .cols { display: flex; gap: 4%; }
+  .cols > div { flex: 1; }
+  .card {
+    background: var(--panel);
+    border: 1px solid var(--line);
+    border-radius: 12px;
+    padding: 0.7em 1em;
+    margin: 0.4em 0;
+  }
+  .lead { justify-content: center; align-items: flex-start; text-align: left; }
+  .lead h1 { font-size: 2.6em; }
+  .center { justify-content: center; }
+  table { border-collapse: collapse; width: 100%; font-size: 0.82em; margin-top: 0.3em; }
+  th, td { border: 1px solid var(--line); padding: 0.45em 0.6em; text-align: left; vertical-align: top; }
+  th { background: var(--panel); color: var(--accent); }
+  .big { font-size: 1.15em; }
+  .pill { display:inline-block; background:var(--panel); border:1px solid var(--line); border-radius:8px; padding:0.15em 0.6em; margin:0.15em 0.2em; font-size:0.8em;}
+  /* side-by-side command pair */
+  .cmds { display:flex; gap:3%; margin-top:0.35em; }
+  .cmds > div { flex:1; min-width:0; }
+  .os { display:inline-block; font-size:0.55em; font-weight:700; text-transform:uppercase; letter-spacing:0.05em; color:var(--muted); margin-bottom:0.2em; }
+  .os.win { color:var(--accent); }
+  .os.nix { color:var(--good); }
+  /* horizontal flow diagram */
+  .flow { display:flex; align-items:center; flex-wrap:wrap; gap:0.35em; margin:0.6em 0; }
+  .flow .step { background:var(--panel); border:1px solid var(--line); border-radius:8px; padding:0.28em 0.6em; font-size:0.78em; white-space:nowrap; }
+  .flow .step.hot { border-color:var(--accent2); color:#fff; }
+  .flow .arr { color:var(--accent); font-size:0.9em; }
+  .footer {
+    position: fixed; bottom: 2.5vh; left: 6vw; right: 6vw;
+    display: flex; justify-content: space-between; align-items: center;
+    color: var(--muted); font-size: 0.5em; letter-spacing: 0.03em;
+    border-top: 1px solid var(--line); padding-top: 0.7vh;
+  }
+  .score { display:inline-block; width:1.5em; height:1.5em; line-height:1.5em; text-align:center; border-radius:6px; font-weight:700; margin-right:0.2em;}
+  .s1 { background:#7f1d1d; color:#fecaca;}
+  .s2 { background:#78350f; color:#fde68a;}
+  .s3 { background:#14532d; color:#bbf7d0;}
+  kbd { background:#0b1220; border:1px solid var(--line); border-bottom-width:2px; border-radius:5px; padding:0.05em 0.4em; font-family:monospace; font-size:0.8em;}
+  .hint { position:fixed; top:2vh; right:2vw; color:var(--muted); font-size:0.42em; opacity:0.6;}
+  @media print {
+    @page { size: 13.333in 7.5in; margin: 0; }
+    html, body { width: 13.333in; height: auto; overflow: visible; background: var(--bg); }
+    .deck { height: auto !important; width: 13.333in !important; display: block !important; }
+    .slide {
+      display: flex !important;
+      width: 13.333in;
+      height: 7.5in;
+      padding: 0.55in 0.8in 0.65in;
+      page-break-after: always;
+      break-after: page;
+      overflow: hidden;
+    }
+    .slide:last-child { page-break-after: avoid; break-after: avoid; }
+    .footer, .hint { display: none !important; }
+  }
+</style>
+</head>
+<body>
+<div class="hint">← → to navigate · F for fullscreen</div>
+<div class="deck" id="deck">
+
+<!-- 1 TITLE -->
+<section class="slide lead">
+  <div class="kicker">Cowork Genealogy · E2E Testing</div>
+  <h1>Creating, Running &amp;<br>Evaluating E2E Tests</h1>
+  <p class="sub big"><strong>E2E means "end-to-end"</strong> — a test that asks the AI to do a whole piece of real research, start to finish. A 30-minute orientation; the step-by-step how-to is the <strong>"E2e tests"</strong> section of <code>eval/README.md</code>.</p>
+</section>
+
+<!-- 2 WHAT IT IS -->
+<section class="slide">
+  <h2>What an e2e test is</h2>
+  <ul>
+    <li><strong>Snapshot</strong> a real, well-researched FamilySearch tree.</li>
+    <li><strong>Hide the answer</strong> — strip a focused fact (e.g. <em>who were the parents?</em>).</li>
+    <li>The AI must <strong>recover it from records</strong>, via <code>/research</code>.</li>
+    <li>A <strong>judge</strong> grades the result: <strong>pass / partial / fail</strong>.</li>
+  </ul>
+  <div class="card">The tree-reading tools are <strong>blocked</strong> during the run, so the AI can't just look the answer up on FamilySearch. A <strong>pass means it researched it</strong> — not that it peeked.</div>
+</section>
+
+<!-- 3 THE LOOP -->
+<section class="slide">
+  <h2>The work is a loop</h2>
+  <div class="flow">
+    <span class="step">Create</span><span class="arr">→</span>
+    <span class="step hot">Run</span><span class="arr">→</span>
+    <span class="step hot">Interpret</span><span class="arr">→</span>
+    <span class="step hot">Grade</span><span class="arr">→</span>
+    <span class="step hot">Improve skill</span><span class="arr">→</span>
+    <span class="step hot">Re-run</span><span class="arr">↺</span>
+    <span class="step">PR</span>
+  </div>
+  <p>Run it, see how the skill did, <strong>improve the skill</strong>, and re-run — until you <strong>can't improve the result anymore</strong>. Then submit a PR.</p>
+  <div class="card sub"><strong>One run ≈ 20–60 minutes and $3–10.</strong> Run one at a time, and plan your day around a handful — not dozens.</div>
+</section>
+
+<!-- 4 HOW WE WORK -->
+<section class="slide">
+  <h2>How we work: as a team</h2>
+  <p>The work splits into two flavors — <strong>divide it however your team works best.</strong></p>
+  <div class="cols">
+    <div class="card">
+      <h3>Genealogy judgment</h3>
+      <p>Which person &amp; question, what good research looks like, grading each finding.</p>
+    </div>
+    <div class="card">
+      <h3>Hands-on mechanics</h3>
+      <p>Setup, running tests, Git — plus turning that judgment into skill edits.</p>
+    </div>
+  </div>
+  <p class="sub"><strong>Dallan</strong> handles judge calibration &amp; releases — never you.</p>
+</section>
+
+<!-- 5 SETUP -->
+<section class="slide">
+  <h2>Setup</h2>
+  <h3>Once per machine</h3>
+  <div class="cmds">
+    <div><span class="os win">Windows</span><pre><code>Setup.bat</code></pre></div>
+    <div><span class="os nix">macOS / Linux</span><pre><code>make install
+echo 'ANTHROPIC_API_KEY=sk-...' &gt;&gt; eval/.env</code></pre></div>
+  </div>
+  <h3>Each day, before running</h3>
+  <div class="cmds">
+    <div><span class="os win">Windows</span><pre><code>Login.bat        &amp; CheckSetup.bat</code></pre></div>
+    <div><span class="os nix">macOS / Linux</span><pre><code>make e2e-login   &amp;&amp; make e2e-preflight</code></pre></div>
+  </div>
+  <p class="sub">Log in once a day (~24h FamilySearch token). The ready-check ("preflight") confirms login, server, key &amp; tools <em>before</em> you spend time and money on a run.</p>
+</section>
+
+<!-- 6 CREATE -->
+<section class="slide">
+  <h2>Create — <code>/author-e2e-fixture</code></h2>
+  <p class="sub">Run it in Claude Code at the repo root. Two ways to give it the data — the subject must be <strong>deceased</strong> either way, and it does the writing for you:</p>
+  <div class="cols">
+    <div class="card">
+      <h3>From a FamilySearch PID</h3>
+      <p>Give it a well-researched person ID. It reads the tree, <strong>you pick what to hide</strong>, and writes the files.</p>
+    </div>
+    <div class="card">
+      <h3>From a research document</h3>
+      <p>No FamilySearch access? Hand it a report, research log, or proof article — it <strong>builds the starting tree by hand</strong> from the document and uses the document's conclusion as the answer.</p>
+    </div>
+  </div>
+  <p class="sub">Either way, keep it focused (one question, 1–5 findings), then confirm the answer is really gone: <code>ValidateFixture.bat</code> / <code>make e2e-validate TEST=&lt;slug&gt;</code>.</p>
+</section>
+
+<!-- 7 RUN -->
+<section class="slide">
+  <h2>Run a test</h2>
+  <div class="cmds">
+    <div><span class="os win">Windows</span><pre><code>RunE2E.bat
+# prompts for the slug</code></pre></div>
+    <div><span class="os nix">macOS / Linux</span><pre><code>make e2e-run TEST=kenneth-quass-death</code></pre></div>
+  </div>
+  <p>Writes the result, a readable transcript, and the AI's final tree to <code>eval/runlogs/e2e/&lt;slug&gt;/</code>.</p>
+  <p class="sub">Rebuilds the server first if needed. Remember — one run at a time.</p>
+</section>
+
+<!-- 8 DIAGNOSE -->
+<section class="slide">
+  <h2>See what the AI did</h2>
+  <p>Start with <code>/interpret-e2e-result</code> for the headline verdict. Then read the <strong>step-by-step</strong> — every search, result, and skill it used is in <code>run-&lt;ts&gt;.transcript.md</code>.</p>
+  <div class="card">
+    <h3>Ask Claude about the run</h3>
+    <p>"Did it <strong>skip a search</strong> it should have run? Try <strong>maiden-name or spelling variations</strong>? Call a finding <strong>direct</strong> when the evidence is only indirect? <strong>Where and why did it stop?</strong>"</p>
+  </div>
+  <p class="sub">This is where you catch the missed search or the over-claim — the verdict alone won't show it.</p>
+</section>
+
+<!-- 9 VIEW -->
+<section class="slide">
+  <h2>View the result in the app</h2>
+  <div class="cmds">
+    <div><span class="os win">Windows</span><pre><code>ViewE2E.bat</code></pre></div>
+    <div><span class="os nix">macOS / Linux</span><pre><code>make e2e-view TEST=&lt;slug&gt;</code></pre></div>
+  </div>
+  <p>Loads the latest run into the <strong>Research Viewer</strong> — the final tree, the research log, conflicts, and each finding's <strong>direct vs indirect</strong> badge.</p>
+  <div class="card sub">Open <code>eval/.e2e-view</code> in the viewer once (its <strong>Open Project</strong> button) and <strong>keep it open</strong> — every re-run, just run <code>e2e-view</code> again and it refreshes live.</div>
+</section>
+
+<!-- 10 GRADE -->
+<section class="slide">
+  <h2>Grade the result</h2>
+  <ul>
+    <li>For each expected finding, decide whether the AI really found it: <strong>true / partial / false</strong>.</li>
+    <li><strong>Ask Claude Code to grade the run</strong> — it records your labels in <code>run-&lt;ts&gt;.ann.json</code>, saved beside the run log.</li>
+  </ul>
+  <div class="card">Grading is <strong>squarely genealogy judgment</strong> — and that <code>.ann.json</code> is the grade you commit. Where you disagree with the AI judge, your label is what counts.</div>
+</section>
+
+<!-- 11 IMPROVE -->
+<section class="slide">
+  <h2>Improve the skill → re-run → compare</h2>
+  <p class="sub">A "skill" is a page of <strong>plain-English instructions</strong> telling the AI how to research (a <code>SKILL.md</code> file).</p>
+  <ul>
+    <li><strong>Diagnose</strong> — what did the AI get wrong, and what <em>should</em> good research have done?</li>
+    <li><strong>Adjust</strong> the skill's instructions, then <strong>re-run</strong> (picked up automatically).</li>
+    <li>Did it improve? <strong>Repeat until you can't improve it anymore.</strong></li>
+  </ul>
+  <div class="card sub"><strong>Re-run before concluding</strong> — the AI isn't perfectly repeatable; one finding flipping may be chance.</div>
+</section>
+
+<!-- 12 PR -->
+<section class="slide">
+  <h2>Submit a PR</h2>
+  <p>Commit together:</p>
+  <ul>
+    <li>the <strong>fixture</strong> + a <strong>passing run log</strong></li>
+    <li>your <strong>grade</strong> (<code>run-&lt;ts&gt;.ann.json</code>) + any <strong>skill improvements</strong></li>
+  </ul>
+  <div class="card sub">The maintainers review and merge. You create and push; you don't merge your own.</div>
+</section>
+
+<!-- 13 QUESTIONS -->
+<section class="slide lead center">
+  <h1>Questions?</h1>
+  <p class="big sub">Then hands-on — we author, run, and interpret <strong>Kenneth Quass</strong> together.</p>
+</section>
+
+</div>
+
+<div class="footer">
+  <span>E2E Testing · Cowork Genealogy</span>
+  <span id="counter">1</span>
+</div>
+
+<script>
+  const slides = Array.from(document.querySelectorAll('.slide'));
+  let i = 0;
+  const counter = document.getElementById('counter');
+  function show(n) {
+    i = Math.max(0, Math.min(slides.length - 1, n));
+    slides.forEach((s, idx) => s.classList.toggle('active', idx === i));
+    counter.textContent = (i + 1) + ' / ' + slides.length;
+    location.hash = i + 1;
+  }
+  function next() { show(i + 1); }
+  function prev() { show(i - 1); }
+  document.addEventListener('keydown', (e) => {
+    if (['ArrowRight', 'PageDown', ' '].includes(e.key)) { e.preventDefault(); next(); }
+    else if (['ArrowLeft', 'PageUp'].includes(e.key)) { e.preventDefault(); prev(); }
+    else if (e.key === 'Home') show(0);
+    else if (e.key === 'End') show(slides.length - 1);
+    else if (e.key.toLowerCase() === 'f') {
+      if (!document.fullscreenElement) document.documentElement.requestFullscreen();
+      else document.exitFullscreen();
+    }
+  });
+  let downX = null, downY = null;
+  document.addEventListener('mousedown', (e) => { downX = e.clientX; downY = e.clientY; });
+  document.addEventListener('click', (e) => {
+    // don't advance while selecting or copying text
+    if (window.getSelection && window.getSelection().toString().length > 0) return;
+    if (downX !== null && (Math.abs(e.clientX - downX) > 6 || Math.abs(e.clientY - downY) > 6)) return;
+    if (e.clientX > window.innerWidth * 0.25) next(); else prev();
+  });
+  const start = parseInt(location.hash.replace('#', '')) || 1;
+  show(start - 1);
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

A 30-minute orientation deck for teaching the genealogist + developer teams to **create, run, and evaluate e2e tests**, plus a small convenience tool for reviewing run results in the Research Viewer.

## What's included

- **`eval/slides/e2e-testing-kickoff.html`** — self-contained 13-slide deck (arrow-key nav, `F` fullscreen, prints to 16:9 PDF), matching the style of the existing `junior-kickoff.html`. Walks the create → run → evaluate → improve loop, framed as team work with a *loose* split (genealogy judgment ↔ hands-on mechanics) that fits an all-genealogist senior team as well as a genealogist + developer team. Commands shown side-by-side as Windows `.bat` / `make`.
- **`make e2e-view` / `eval/ViewE2E.bat`** (`eval/harness/e2e/view.py`) — copies the latest e2e run's `final-tree.gedcomx.json` + `final-research.json` for a fixture into `eval/.e2e-view/` (renamed to `tree.gedcomx.json` + `research.json`) so the Research Viewer can open it. Picks the newest run by mtime, so a failing `scratch_*` run — the usual thing to inspect — works too; keep the viewer open and it refreshes live across re-runs.
- **`eval/README.md`** — lists `ViewE2E.bat` in the batch-file reference and adds a "view the result" step to the e2e walkthrough.
- **`.gitignore`** — ignores the `eval/.e2e-view/` staging folder.

## Test plan

- `make e2e-view TEST=kenneth-quass-death` → exit 0; stages `research.json` + `tree.gedcomx.json` into `eval/.e2e-view/` (confirmed gitignored).
- Deck opens in a browser; navigation + print path unchanged from the existing decks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
