### PR TITLE
eval(e2e): add ivyl-greenley-daughter fixture (completeness / children question)

### DIFF
--- a/eval/runlogs/e2e/ivyl-greenley-daughter/run-2026-06-29_22-24-03.final-research.json
+++ b/eval/runlogs/e2e/ivyl-greenley-daughter/run-2026-06-29_22-24-03.final-research.json
@@ -1,0 +1,946 @@
+{
+  "project": {
+    "id": "rp_ivyl_greenley_daughter",
+    "objective": "Besides their son Donald, did Ivyl Phylena Greenley and her husband Kenneth Werner Quass have any other children? Identify each additional child and that child's birth and death dates.",
+    "subject_person_ids": [
+      "KWZP-4Q8"
+    ],
+    "status": "active",
+    "created": "2026-06-29T00:00:00Z",
+    "updated": "2026-06-29T00:00:00Z"
+  },
+  "researcher_profile": {
+    "experience_level": "intermediate",
+    "subscriptions": [],
+    "narration_guidance": "concise"
+  },
+  "questions": [
+    {
+      "id": "q_001",
+      "question": "Did Kenneth Werner Quass (b. 4 Dec 1917, Sumner, Bremer County, Iowa; d. 17 Sep 1982) and Ivyl Phylena Greenley (b. 26 May 1914, Dubuque County, Iowa; d. 24 May 2005) have any children other than Donald Wendell Quass (b. 16 Jan 1940)?",
+      "rationale": "This is the core research objective. The couple married 6 Mar 1938 and Ivyl was of childbearing age through approximately 1964. The 1940 census shows only Donald (newborn) in the household. Census records (1950), obituaries of Kenneth (1982), Ivyl (2005), and Donald (2024), plus Iowa/Minnesota vital records and the existing FamilySearch source (QK2L-WL7) mentioning 'Bernice H Quass Wegner and Ralph Quass,' may reveal additional children. Direct evidence from original records is required to satisfy GPS.",
+      "selection_basis": "objective_decomposition",
+      "priority": "high",
+      "status": "open",
+      "depends_on": [],
+      "unblocks": [],
+      "resolved": null,
+      "resolution_assertion_ids": [],
+      "exhaustive_declaration": {
+        "declared": false,
+        "justification": null,
+        "log_entry_ids": [],
+        "stop_criteria": null
+      },
+      "created": "2026-06-29"
+    }
+  ],
+  "plans": [
+    {
+      "id": "pl_001",
+      "question_id": "q_001",
+      "status": "active",
+      "created": "2026-06-29",
+      "items": [
+        {
+          "id": "pli_001",
+          "sequence": 1,
+          "record_type": "newspaper",
+          "jurisdiction": "Watonwan County, Minnesota (Madelia area)",
+          "date_range": "2024",
+          "repository": "FamilySearch",
+          "rationale": "Donald Wendell Quass's April 2024 obituary (already cited in tree as source WWDC-3KV, ark:/61903/1:1:XM5X-SPSB) is a direct source likely naming surviving family members including any siblings. Extract and analyze this record to identify whether any siblings of Donald are named.",
+          "fallback_for": null,
+          "status": "completed"
+        },
+        {
+          "id": "pli_002",
+          "sequence": 2,
+          "record_type": "newspaper",
+          "jurisdiction": "United States",
+          "date_range": "2010",
+          "repository": "FamilySearch",
+          "rationale": "Source QK2L-WL7 (GenealogyBank Obituaries 1980\u20132015, ark:/61903/1:1:QKGC-W3S7) is already cited in the tree with the description 'Entry for Mrs Bernice H Quass Wegner and Ralph Quass, 22 Jun 2010.' The surnames Quass Wegner and Quass are highly suggestive of other children of Kenneth. This record must be read and analyzed to determine whether Bernice and Ralph are children of Kenneth and Ivyl or of another Quass family.",
+          "fallback_for": null,
+          "status": "completed"
+        },
+        {
+          "id": "pli_003",
+          "sequence": 3,
+          "record_type": "census",
+          "jurisdiction": "Watonwan County, Minnesota",
+          "date_range": "1950",
+          "repository": "FamilySearch",
+          "rationale": "The 1950 US Census (released 2022, indexed on FamilySearch) would capture all household members as of April 1, 1950, including any children of Kenneth and Ivyl then living at home. Kenneth and Ivyl were in Madelia, Watonwan County in 1940; searching that county in 1950 should locate the family and show the composition of the household at that time.",
+          "fallback_for": null,
+          "status": "completed"
+        },
+        {
+          "id": "pli_004",
+          "sequence": 4,
+          "record_type": "vital_record",
+          "jurisdiction": "Minnesota",
+          "date_range": "1938-1965",
+          "repository": "FamilySearch",
+          "rationale": "Minnesota Birth Index 1935\u20132002 (FS collection 1949334, 4.2M records, indexed) allows searching by parent surname. Searching for births to a Quass father or Greenley/Quass mother in Minnesota during the couple's likely childbearing years (1938\u20131965) would identify any children born and registered in Minnesota.",
+          "fallback_for": null,
+          "status": "completed"
+        },
+        {
+          "id": "pli_005",
+          "sequence": 5,
+          "record_type": "newspaper",
+          "jurisdiction": "Minnesota",
+          "date_range": "1982",
+          "repository": "FamilySearch",
+          "rationale": "Kenneth Werner Quass died 17 September 1982 in Grapevine, Tarrant County, Texas. An obituary for him \u2014 searchable in Minnesota Obituaries 1865\u20132006 (FS collection 2469546) or GenealogyBank \u2014 would likely name surviving children. This is a priority source because it predates Ivyl's death and would capture children who survived Kenneth.",
+          "fallback_for": null,
+          "status": "completed"
+        },
+        {
+          "id": "pli_006",
+          "sequence": 6,
+          "record_type": "newspaper",
+          "jurisdiction": "San Diego, California",
+          "date_range": "2005",
+          "repository": "other",
+          "rationale": "Ivyl Phylena Greenley Quass died 24 May 2005 in San Diego, California and was buried in Madelia, Watonwan County, Minnesota. Her obituary \u2014 searchable in GenealogyBank, Newspapers.com, or the San Diego Union-Tribune archives \u2014 would name surviving children. This is direct evidence for the research question. The existing source MS62-1FF is only a legacy stub citation, not the full obituary text.",
+          "fallback_for": null,
+          "status": "skipped"
+        },
+        {
+          "id": "pli_007",
+          "sequence": 7,
+          "record_type": "vital_record",
+          "jurisdiction": "Iowa (Fayette County, Watonwan County area)",
+          "date_range": "1938-1942",
+          "repository": "FamilySearch",
+          "rationale": "Donald Wendell Quass was born 16 January 1940 in Randalia, Fayette County, Iowa, suggesting the family may have briefly resided in Iowa early in their marriage (married March 1938). Iowa County Births records (FS collection for Iowa) should be searched to confirm whether any other children were born in Iowa before or around the time of Donald's birth.",
+          "fallback_for": null,
+          "status": "completed"
+        },
+        {
+          "id": "pli_008",
+          "sequence": 8,
+          "record_type": "other",
+          "jurisdiction": "United States",
+          "date_range": "1938-2005",
+          "repository": "FamilySearch",
+          "rationale": "FamilySearch person record for Kenneth Werner Quass (FamilySearch ID KNS4-P6W) and Ivyl Phylena Greenley (KWZP-4Q8) may have additional children linked by other FamilySearch contributors. Reading the person_person_matches or searching directly for children attached to this couple on FamilySearch provides a cross-check and may surface leads not captured by vital records searches.",
+          "fallback_for": null,
+          "status": "completed"
+        }
+      ]
+    }
+  ],
+  "log": [
+    {
+      "id": "log_001",
+      "plan_item_id": "pli_001",
+      "performed": "2026-06-29T21:46:05.306Z",
+      "tool": "record_read",
+      "query": {
+        "recordId": "ark:/61903/1:1:XM5X-SPSB",
+        "description": "Donald Wendell Quass 2024 obituary, source WWDC-3KV, FamilySearch United States Obituary Records 2014-2023"
+      },
+      "outcome": "positive",
+      "results_examined": 1,
+      "external_site": null,
+      "results_ref": null,
+      "results_available": 1,
+      "notes": "Obituary for Donald Wendell Quass (b. 16 Jan 1940, d. 25 Apr 2024) lists three siblings who are also children of Kenneth Werner Quass and Phylena Ivyl Greenley: (1) Ken Quass [male, surname Quass, married Bobbi Quass]; (2) Pat Norman [female, born Quass, married Bob Norman \u2014 sibling-in-law relationship]; (3) Jeanette [female, no surname given]. All three named as children of Kenneth Werner Quass (p_306774614787) and Phylena Ivyl Greenley (p_306774614788) via ParentChild relationships. Additionally listed is Linnea, identified as Donald's grandchild via Grandparent relationship. Record ARKs: Ken Quass ark:/61903/1:1:XM5X-SPSP; Jeanette ark:/61903/1:1:XM5X-SPS1; Pat Norman ark:/61903/1:1:XM5X-SPSR."
+    },
+    {
+      "id": "log_002",
+      "plan_item_id": "pli_002",
+      "performed": "2026-06-29T21:46:53.313Z",
+      "tool": "record_read",
+      "query": {
+        "recordId": "ark:/61903/1:1:QKGC-W3S7",
+        "description": "GenealogyBank obituary for Bernice H. Quass Wegner (d. 19 Jun 2010), source QK2L-WL7, FamilySearch United States GenealogyBank Obituaries 1980-2015"
+      },
+      "outcome": "partial",
+      "results_examined": 1,
+      "external_site": null,
+      "results_ref": null,
+      "results_available": 1,
+      "notes": "Obituary is for Bernice H. Quass Wegner (b. 29 Aug 1926, Buchanan County, Iowa; d. 19 Jun 2010, Waterloo, Iowa), published 22 Jun 2010. Parents: Ralph Quass and Emma Nehls Quass. Husband: Ralph Wegner. Siblings of Bernice include: Kenneth Quass (= Kenneth Werner Quass, our research subject), Norman Quass, Wayne Quass, Lucille Quass Clemens, Dorothy Quass Ostrander. 'Avyl Quass' listed as sibling-in-law = Ivyl Phylena Greenley Quass (variant spelling). This confirms Kenneth Werner Quass is Bernice's brother. This record is about Kenneth's family of origin \u2014 his parents and siblings \u2014 NOT about children of Kenneth and Ivyl. Ralph Quass is Kenneth's father, not a son. Bernice is Kenneth's sister, not a daughter. No new children of Kenneth and Ivyl identified here."
+    },
+    {
+      "id": "log_003",
+      "plan_item_id": "pli_003",
+      "performed": "2026-06-29T21:48:34.414Z",
+      "tool": "record_search",
+      "query": {
+        "surname": "Quass",
+        "givenName": "Kenneth",
+        "birthYearFrom": 1912,
+        "birthYearTo": 1922,
+        "residenceYearFrom": 1950,
+        "residenceYearTo": 1950,
+        "recordCountry": "United States",
+        "recordSubdivision": "Minnesota",
+        "note": "First attempt with Watonwan residencePlace returned 0 results; broadened to all Minnesota"
+      },
+      "outcome": "partial",
+      "results_examined": 12,
+      "external_site": null,
+      "results_ref": "results/log_003.json",
+      "results_available": 12,
+      "notes": "No 1950 census record found for Kenneth Quass \u2014 results came from Find a Grave, Minnesota Birth Index, death records, and the 2024 Donald Quass obituary. The 1950 census collection may not be indexed under this search profile. Key incidental find: Alice Jeanette Quass (Minnesota Birth Index ark:/61903/1:1:VCF7-BY8, parents Kenneth Warner Quass and Ivyl Phylena Greenley, b. 6 Dec 1940, Watonwan MN) and her death record (Minnesota Death Records 1900-1955 ark:/61903/1:1:FDX7-8MF, d. 3 Feb 1955, Madelia MN). This child is the 'Jeanette' named in Donald's 2024 obituary. Also confirmed 'Kenneth Werner Quass Sr' suffix on Find a Grave (KNS4-P6W tree match). The 1950 census search should be retried with collection-specific filter."
+    },
+    {
+      "id": "log_004",
+      "plan_item_id": "pli_003",
+      "performed": "2026-06-29T21:49:49.651Z",
+      "tool": "record_search",
+      "query": {
+        "surname": "Quass",
+        "givenName": "Kenneth",
+        "birthYearFrom": 1912,
+        "birthYearTo": 1922,
+        "collectionId": "3948617",
+        "description": "US 1950 Census \u2014 collection ID 3948617"
+      },
+      "outcome": "negative",
+      "results_examined": 0,
+      "external_site": null,
+      "results_ref": null,
+      "results_available": 0,
+      "notes": "Zero results. Collection ID 3948617 may be incorrect for the US 1950 Census on FamilySearch, or Kenneth Quass is not yet indexed in it. The family was in Madelia, Watonwan County in 1940; expected to remain there in 1950. 1950 census search is inconclusive \u2014 would require browsing the unindexed images or using a correct collection ID. Will rely on birth/death records and obituaries for household composition evidence."
+    },
+    {
+      "id": "log_005",
+      "plan_item_id": "pli_004",
+      "performed": "2026-06-29T21:49:59.109Z",
+      "tool": "record_search",
+      "query": {
+        "fatherSurname": "Quass",
+        "motherSurname": "Greenley",
+        "collectionId": "1949334",
+        "recordCountry": "United States",
+        "description": "Minnesota Birth Index 1935-2002, father surname Quass + mother surname Greenley"
+      },
+      "outcome": "positive",
+      "results_examined": 1,
+      "external_site": null,
+      "results_ref": "results/log_005.json",
+      "results_available": 1,
+      "notes": "Only one result: Alice Jeanette Quass (b. 6 Dec 1940, Watonwan, Minnesota), father Kenneth Warner Quass, mother Ivyl Phylena Greenley (ark:/61903/1:1:VCF7-BY8). No other children registered in the Minnesota Birth Index under this parent combination. 'Ken Quass' and 'Pat Norman (born Quass)' \u2014 identified as siblings in Donald's 2024 obituary \u2014 do not appear here. They may have been born in Iowa, California, or another state, or their birth records in MN use a different spelling of parent names. Broader search needed."
+    },
+    {
+      "id": "log_006",
+      "plan_item_id": "pli_004",
+      "performed": "2026-06-29T21:50:32.747Z",
+      "tool": "record_search",
+      "query": {
+        "fatherGivenName": "Kenneth",
+        "fatherSurname": "Quass",
+        "motherGivenName": "Ivyl",
+        "collectionId": "1949334",
+        "description": "Minnesota Birth Index 1935-2002, father Kenneth Quass + mother Ivyl"
+      },
+      "outcome": "positive",
+      "results_examined": 1,
+      "external_site": null,
+      "results_ref": "results/log_006.json",
+      "results_available": 1,
+      "notes": "Again only Alice Jeanette Quass returned (b. 6 Dec 1940, Watonwan MN). No other children of Kenneth and Ivyl found in Minnesota Birth Index regardless of parameter variation. 'Ken Quass' and 'Pat Norman (Quass)' siblings named in Donald's 2024 obituary are not registered as births in MN under these parents. They were likely born in Iowa or another state, or their birth records in MN use different parent name spellings."
+    },
+    {
+      "id": "log_007",
+      "plan_item_id": "pli_005",
+      "performed": "2026-06-29T21:50:36.711Z",
+      "tool": "record_search",
+      "query": {
+        "surname": "Quass",
+        "givenName": "Kenneth",
+        "deathYearFrom": 1978,
+        "deathYearTo": 1986,
+        "collectionId": "2469546",
+        "description": "Minnesota Obituaries 1865-2006 for Kenneth Quass d. 1982"
+      },
+      "outcome": "negative",
+      "results_examined": 0,
+      "external_site": null,
+      "results_ref": null,
+      "results_available": 0,
+      "notes": "No Minnesota obituary found for Kenneth Quass (d. 17 Sep 1982). Expected \u2014 he died in Grapevine, Tarrant County, Texas; his obituary would likely appear in Texas newspapers or GenealogyBank, not Minnesota newspaper obituary collections. Will search external sites (GenealogyBank/Newspapers.com) for his obituary."
+    },
+    {
+      "id": "log_008",
+      "plan_item_id": "pli_004",
+      "performed": "2026-06-29T21:51:14.602Z",
+      "tool": "record_search",
+      "query": {
+        "surname": "Quass",
+        "givenName": "Kenneth",
+        "birthYearFrom": 1941,
+        "birthYearTo": 1952,
+        "fatherSurname": "Quass",
+        "collectionId": "1949334",
+        "description": "MN Birth Index \u2014 Kenneth Quass as child born 1941-1952"
+      },
+      "outcome": "negative",
+      "results_examined": 4,
+      "external_site": null,
+      "results_ref": "results/log_008.json",
+      "results_available": 4,
+      "notes": "All 4 results show 'Kenneth Warner Quass Jr' as FATHER of children born 1965-1974 in Hennepin County MN \u2014 not as a child born in the target range. Ken Quass Jr's own birth record not found in Minnesota Birth Index. Similarly no Iowa birth record for Quass + Greenley parents. Ken's and Pat's birth records not located in indexed collections; may require browsing unindexed county birth registers or searching other states."
+    },
+    {
+      "id": "log_009",
+      "plan_item_id": "pli_007",
+      "performed": "2026-06-29T21:51:18.837Z",
+      "tool": "record_search",
+      "query": {
+        "fatherSurname": "Quass",
+        "motherSurname": "Greenley",
+        "recordCountry": "United States",
+        "recordSubdivision": "Iowa",
+        "recordType": "birth",
+        "description": "Iowa birth records for Quass + Greenley children"
+      },
+      "outcome": "negative",
+      "results_examined": 0,
+      "external_site": null,
+      "results_ref": null,
+      "results_available": 0,
+      "notes": "No Iowa birth records found for children of Kenneth Quass and Ivyl Greenley. Donald's 1940 birth was in Randalia, Fayette County, Iowa, but no other children appear registered in Iowa birth indexes. Family moved to Watonwan County, MN by mid-1940. Remaining siblings (Ken, Pat) not located in Iowa or Minnesota birth indexes \u2014 birth dates unknown from vital records searches."
+    },
+    {
+      "id": "log_010",
+      "plan_item_id": "pli_005",
+      "performed": "2026-06-29T21:56:07.376Z",
+      "tool": "fulltext_search",
+      "query": {
+        "keywords": "+Ivyl +Quass",
+        "description": "Fulltext search for Ivyl Quass across all collections, no year filter"
+      },
+      "outcome": "positive",
+      "results_examined": 5,
+      "external_site": null,
+      "results_ref": "results/log_010.json",
+      "results_available": 5,
+      "notes": "5 results. Most significant: (1) Texas Death Certificate 1982 (ark:/61903/3:1:3QS7-8992-XXT, collection M9J1-953) for Kenneth Quass: DoD Sep 17 1982, DoB 12-4-1917, place Tarrant County TX (Grapevine), surviving spouse Ivyl Greenley, residence San Diego CA (5941 Lancaster Drive), informant = Kenneth Quass Jr. (SON \u2014 confirms Ken Jr. is a child), father Ralph K. Quass, mother Emma Nehls, SS# 483-03-9478, buried Madelia Cemetery Watonwan MN. (2) Iowa Marriage 1938 (Buchanan Co.): Kenneth W. Quass + Ivyl P. Greenley married March 5, 1938. (3) Herbert Thomas Greenley obituary 1963: Ivyl Quass was living in Glendale, CA. (4) Watonwan County Death Record Index confirming Alice Jeannette Quass, parents Kenneth Quass and Ivyl Greenley. Family was in San Diego by 1982; moved to California between 1955 and 1963."
+    },
+    {
+      "id": "log_011",
+      "plan_item_id": "pli_005",
+      "performed": "2026-06-29T22:03:49.448Z",
+      "tool": "record_search",
+      "query": {
+        "collectionId": "1202535",
+        "givenName": "Kenneth",
+        "surname": "Quass",
+        "description": "SSDI for Kenneth Quass to find death or birth info for Ken Quass Jr."
+      },
+      "outcome": "negative",
+      "results_examined": 10,
+      "external_site": null,
+      "results_ref": "results/log_011.json",
+      "results_available": 10,
+      "notes": "10 SSDI results returned; none match Kenneth Quass Jr. (son of Kenneth Werner Quass and Ivyl Greenley). Results are phonetically similar names (Quasney, Kaas) \u2014 no Quass surname matches. Kenneth Quass Jr. is alive as of 2024 (listed as survivor in Donald's April 2024 obituary), so no SSDI entry expected."
+    },
+    {
+      "id": "log_012",
+      "plan_item_id": "pli_004",
+      "performed": "2026-06-29T22:03:54.275Z",
+      "tool": "record_search",
+      "query": {
+        "collectionId": "1949334",
+        "givenName": "Patricia",
+        "surname": "Quass",
+        "fatherSurname": "Quass",
+        "description": "MN Birth Index for Patricia Quass with father Quass"
+      },
+      "outcome": "negative",
+      "results_examined": 1,
+      "external_site": null,
+      "results_ref": "results/log_012.json",
+      "results_available": 1,
+      "notes": "Only result is Colleen Patrice Kaas (b. 7 Mar 1960, Kanabec MN) \u2014 not relevant. Patricia Quass (later Pat Norman) is not found in Minnesota Birth Index. She is alive as of 2024 per Donald's obituary. Her birth record is likely in Watonwan County unindexed image records (collection 1920099) or possibly in Iowa."
+    },
+    {
+      "id": "log_013",
+      "plan_item_id": "pli_004",
+      "performed": "2026-06-29T22:04:06.666Z",
+      "tool": "fulltext_search",
+      "query": {
+        "keywords": "+Patricia +\"Quass\"",
+        "description": "Fulltext search for Patricia Quass across all collections"
+      },
+      "outcome": "negative",
+      "results_examined": 5,
+      "external_site": null,
+      "results_ref": "results/log_013.json",
+      "results_available": 69,
+      "notes": "69 total results but none matching Patricia Quass daughter of Kenneth Werner Quass and Ivyl Greenley. Results include: Wisconsin obituary for unrelated Harold J. Quass (second wife Patricia Calhorn), Iowa 1926 birth record containing Quinn/Quass names, Alabama 1991 newspaper (Ann Gabrielle Quass-Little, daughter of Kenneth Warner Quass Jr. of Plymouth MN \u2014 confirms Ken Jr. lived in Plymouth/Hennepin MN in 1991), Minnesota centennial history (unrelated Quass family), Wisconsin obituary for Patricia Quass of Whitewater WI (unrelated, daughter of Palma Keyes). Our target Patricia Quass/Norman not identified. She is alive as of 2024."
+    },
+    {
+      "id": "log_014",
+      "plan_item_id": "pli_004",
+      "performed": "2026-06-29T22:04:10.168Z",
+      "tool": "fulltext_search",
+      "query": {
+        "keywords": "+\"Kenneth Quass Jr\" +born",
+        "description": "Fulltext for Kenneth Quass Jr birth information"
+      },
+      "outcome": "negative",
+      "results_examined": 0,
+      "external_site": null,
+      "results_ref": null,
+      "results_available": 0,
+      "notes": "Zero results. No fulltext document on FamilySearch mentions 'Kenneth Quass Jr' alongside birth information. Birth date for Kenneth Warner Quass Jr. not determinable from indexed FamilySearch records. He is alive as of 2024 per Donald's obituary."
+    },
+    {
+      "id": "log_015",
+      "plan_item_id": "pli_005",
+      "performed": "2026-06-29T22:04:22.862Z",
+      "tool": "fulltext_search",
+      "query": {
+        "keywords": "+Kenneth +\"Quass Jr\"",
+        "description": "Fulltext search confirming Ken Jr. as informant on Kenneth Sr.'s Texas death cert"
+      },
+      "outcome": "positive",
+      "results_examined": 2,
+      "external_site": null,
+      "results_ref": "results/log_015.json",
+      "results_available": 2,
+      "notes": "2 results. Result 1 (irrelevant): Iowa Buchanan County 1950 obituary pages mentioning 'Ronnie Quass Jr.' \u2014 unrelated. Result 2 (significant): Texas Death Certificate 1982 for Kenneth Quass (ark:/61903/3:1:3QS7-8992-XXT, collection M9J1-953), full text confirmed \u2014 informant signature reads 'Kenneth Quass Jr.' confirming that Kenneth Warner Quass Jr. is a child of Kenneth Werner Quass and Ivyl Greenley. Certificate states: d. Sep 17 1982, Tarrant County TX (Grapevine area), surviving spouse Ivyl Greenley, residence 5941 Lancaster Drive, San Diego CA, father Ralph K. Quass, mother Emma Nehls, buried Madelia Cemetery MN. Note: record_read on this ARK returns 'not found' \u2014 the ARK is accessible only via fulltext, not the record_read endpoint."
+    },
+    {
+      "id": "log_016",
+      "plan_item_id": "pli_003",
+      "performed": "2026-06-29T22:04:30.030Z",
+      "tool": "record_search",
+      "query": {
+        "givenName": "Kenneth",
+        "surname": "Quass",
+        "residenceYearFrom": 1950,
+        "residenceYearTo": 1950,
+        "residencePlace": "Watonwan, Minnesota",
+        "recordCountry": "United States",
+        "description": "1950 census search \u2014 Kenneth Quass, Watonwan County MN"
+      },
+      "outcome": "negative",
+      "results_examined": 20,
+      "external_site": null,
+      "results_ref": null,
+      "results_available": 23,
+      "notes": "23 results returned, none are a 1950 US Census entry for Kenneth Quass. Top result is Find a Grave (Kenneth Werner Quass Sr., KNS4-P6W); remaining results appear to be death records, birth index entries, and other records. The 1950 census for Watonwan County MN is either not yet indexed on FamilySearch or Kenneth Quass does not appear under this query. Without 1950 census access, household composition in 1950 cannot be confirmed. Family was in Madelia, Watonwan County through at least Feb 1955 (Alice Jeanette's death)."
+    },
+    {
+      "id": "log_017",
+      "plan_item_id": "pli_006",
+      "performed": "2026-06-29T22:04:37.924Z",
+      "tool": "fulltext_search",
+      "query": {
+        "keywords": "+Ivyl +\"Quass\" +obituary",
+        "description": "Fulltext search for Ivyl Quass obituary on FamilySearch"
+      },
+      "outcome": "negative",
+      "results_examined": 0,
+      "external_site": null,
+      "results_ref": null,
+      "results_available": 0,
+      "notes": "Zero results. Ivyl Phylena Greenley Quass (d. 24 May 2005, San Diego CA) obituary not found in any FamilySearch fulltext collection. Her 2005 San Diego obituary would be in local newspapers (San Diego Union-Tribune) or GenealogyBank, which are external sites not accessible via FamilySearch record_search or fulltext_search. Ivyl's obituary would most likely name her surviving children with birth information. This search should be redirected to search-external-sites."
+    },
+    {
+      "id": "log_018",
+      "plan_item_id": "pli_004",
+      "performed": "2026-06-29T22:04:44.125Z",
+      "tool": "record_search",
+      "query": {
+        "fatherSurname": "Quass",
+        "collectionId": "1949334",
+        "birthYearFrom": 1941,
+        "birthYearTo": 1962,
+        "recordCountry": "United States",
+        "description": "MN Birth Index \u2014 all Quass children 1941-1962 (broad search)"
+      },
+      "outcome": "negative",
+      "results_examined": 19,
+      "external_site": null,
+      "results_ref": null,
+      "results_available": 19,
+      "notes": "19 results, all examined. Results are children of various Quass families across Minnesota. No child with father Kenneth Quass (or Kenneth Warner Quass) and mother Ivyl Greenley found in this range except Alice Jeanette (already logged). Kenneth Warner Quass Jr. and Patricia Quass (later Norman) do not appear as children in the MN Birth Index 1935-2002 for any year. Their birth records are not in any indexed Minnesota collection; they were likely recorded in Watonwan County registers that are image-only on FamilySearch (collection 1920099)."
+    },
+    {
+      "id": "log_019",
+      "plan_item_id": "pli_006",
+      "performed": "2026-06-29T22:19:31.022Z",
+      "tool": "external_site",
+      "query": {
+        "description": "GenealogyBank search for Ivyl Quass obituary, San Diego CA, 2005",
+        "name": "Ivyl Quass",
+        "keywords": "Ivyl Quass obituary 2005",
+        "site": "GenealogyBank"
+      },
+      "outcome": "partial",
+      "results_examined": 0,
+      "external_site": {
+        "site": "newspapers",
+        "url_generated": "https://genealogybank.com/find/obituaries/name/Ivyl-Quass/from/2005/to/2005/state/California",
+        "capture_received": false
+      },
+      "results_ref": null,
+      "notes": "URL generated for GenealogyBank search for Ivyl Phylena Greenley Quass obituary (d. 24 May 2005, San Diego CA). In autonomous mode, capture was not received \u2014 results require human retrieval. Ivyl's obituary would be in the San Diego Union-Tribune (May 2005) and would likely name surviving children (Kenneth Jr., Pat Norman) with possible birth year information. This is the primary remaining source for birth year data on Kenneth Jr. and Patricia Norman. FamilySearch fulltext search (log_017) returned zero results for this obituary, confirming it is not in any indexed FamilySearch collection."
+    }
+  ],
+  "sources": [
+    {
+      "id": "src_001",
+      "gedcomx_source_description_id": "WWDC-3KV",
+      "citation": "\"Donald Quass Obituary,\" Dignity Memorial (online, April 2024); FamilySearch, United States Obituary Records 2014\u20132023, ark:/61903/1:1:XM5X-SPSB.",
+      "citation_detail": {
+        "who": "Dignity Memorial / Quass family",
+        "what": "Obituary for Donald Wendell Quass (b. 16 Jan 1940, d. 25 Apr 2024)",
+        "when_created": "April 2024",
+        "when_accessed": "2026-06-29",
+        "where": "FamilySearch, United States Obituary Records 2014\u20132023",
+        "where_within": "Record for Donald Wendell Quass; sibling personas ark:/61903/1:1:XM5X-SPS1 (Jeanette), ark:/61903/1:1:XM5X-SPSP (Ken Quass), ark:/61903/1:1:XM5X-SPSR (Pat Norman)"
+      },
+      "source_classification": "authored",
+      "repository": "FamilySearch",
+      "access_date": "2026-06-29",
+      "url": "https://www.familysearch.org/ark:/61903/1:1:XM5X-SPSB",
+      "url_archived": null,
+      "notes": "Obituary published by Dignity Memorial funeral home, April 2024. Lists three siblings of Donald Wendell Quass, each shown as child of Kenneth Werner Quass and Phylena Ivyl Greenley via ParentChild relationships encoded in the GedcomX record: (1) Jeanette (deceased), (2) Ken Quass (surviving; married Bobbi Quass), (3) Pat Norman (surviving; n\u00e9e Quass, married Bob Norman). Parents Kenneth Werner Quass (d. 17 Sep 1982) and Ivyl Phylena Greenley (d. 24 May 2005) also confirmed.",
+      "transcription": null,
+      "log_entry_id": "log_001"
+    },
+    {
+      "id": "src_002",
+      "gedcomx_source_description_id": "S1",
+      "citation": "\"Minnesota Birth Index, 1935\u20132002,\" entry for Alice Jeanette Quass (b. 6 Dec 1940, Watonwan, MN); FamilySearch, collection 1949334, ark:/61903/1:1:VCF7-BY8.",
+      "citation_detail": {
+        "who": "Minnesota Department of Health",
+        "what": "Minnesota Birth Index 1935\u20132002",
+        "when_created": "circa December 1940",
+        "when_accessed": "2026-06-29",
+        "where": "FamilySearch, Minnesota Birth Index 1935\u20132002 (collection 1949334)",
+        "where_within": "Entry for Alice Jeanette Quass, b. 6 Dec 1940, Watonwan, Minnesota; father Kenneth Warner Quass, mother Ivyl Phylena Greenley"
+      },
+      "source_classification": "derivative",
+      "repository": "FamilySearch",
+      "access_date": "2026-06-29",
+      "url": "https://www.familysearch.org/ark:/61903/1:1:VCF7-BY8",
+      "url_archived": null,
+      "notes": "Index entry derived from the original Minnesota birth certificate. Father listed as Kenneth Warner Quass; mother as Ivyl Phylena Greenley. This Jeanette (Alice Jeanette) is the same individual named as a deceased sibling in Donald's 2024 obituary. Original certificate not yet accessed.",
+      "transcription": null,
+      "log_entry_id": "log_005"
+    },
+    {
+      "id": "src_003",
+      "gedcomx_source_description_id": "S2",
+      "citation": "\"Minnesota Death Records, 1900\u20131955,\" entry for Alice Jeanette Quass (d. 3 Feb 1955, Madelia, MN); FamilySearch, ark:/61903/1:1:FDX7-8MF.",
+      "citation_detail": {
+        "who": "Minnesota Department of Health",
+        "what": "Minnesota Death Records 1900\u20131955",
+        "when_created": "circa February 1955",
+        "when_accessed": "2026-06-29",
+        "where": "FamilySearch, Minnesota Death Records 1900\u20131955",
+        "where_within": "Entry for Alice Jeanette Quass (b. 6 Dec 1940), d. 3 Feb 1955, Madelia, Watonwan County, Minnesota"
+      },
+      "source_classification": "derivative",
+      "repository": "FamilySearch",
+      "access_date": "2026-06-29",
+      "url": "https://www.familysearch.org/ark:/61903/1:1:FDX7-8MF",
+      "url_archived": null,
+      "notes": "Index entry from Minnesota Death Records 1900\u20131955. Confirms death of Alice Jeanette Quass, daughter of Kenneth Quass and Ivyl Greenley, at Madelia, Watonwan County, MN on 3 Feb 1955 (aged 14). Corroborated by Watonwan County Death Record Index found via fulltext search (log_010). Original death certificate not yet accessed.",
+      "transcription": null,
+      "log_entry_id": "log_003"
+    },
+    {
+      "id": "src_004",
+      "gedcomx_source_description_id": "S3",
+      "citation": "Texas Department of Health, Death Certificate for Kenneth Werner Quass, 17 Sep 1982, Tarrant County, Texas; FamilySearch Texas Death Certificates (collection M9J1-953), ark:/61903/3:1:3QS7-8992-XXT.",
+      "citation_detail": {
+        "who": "Texas Department of Health; informant: Kenneth Quass Jr. (son)",
+        "what": "Texas State Death Certificate for Kenneth Werner Quass",
+        "when_created": "17 September 1982",
+        "when_accessed": "2026-06-29",
+        "where": "FamilySearch, Texas Death Certificates (collection M9J1-953)",
+        "where_within": "Certificate for Kenneth Werner Quass, d. 17 Sep 1982, Grapevine, Tarrant County, Texas"
+      },
+      "source_classification": "original",
+      "repository": "FamilySearch",
+      "access_date": "2026-06-29",
+      "url": "https://www.familysearch.org/ark:/61903/3:1:3QS7-8992-XXT",
+      "url_archived": null,
+      "notes": "Texas death certificate for Kenneth Werner Quass (b. 4 Dec 1917, d. 17 Sep 1982, Grapevine TX). Informant: Kenneth Quass Jr. (son), confirming Kenneth Warner Quass Jr. is a son of Kenneth Werner Quass. Surviving spouse: Ivyl Greenley. Residence: 5941 Lancaster Drive, San Diego CA. Parents: Ralph K. Quass, Emma Nehls. Buried Madelia Cemetery, Watonwan MN. NOTE: Accessible via FamilySearch fulltext only (ARK format 3:1:) \u2014 not via record_read endpoint.",
+      "transcription": null,
+      "log_entry_id": "log_010"
+    }
+  ],
+  "assertions": [
+    {
+      "id": "a_001",
+      "source_id": "src_001",
+      "record_id": "ark:/61903/1:1:XM5X-SPS1",
+      "record_role": "sibling (deceased)",
+      "record_persona_id": null,
+      "fact_type": "relationship",
+      "value": "Alice Jeanette Quass (Jeanette) named as deceased sibling of Donald Wendell Quass and child of Kenneth Werner Quass and Ivyl Phylena Greenley in Donald's April 2024 obituary",
+      "structured_value": {
+        "relationship_type": "ParentChild",
+        "parents": [
+          "KNS4-P6W",
+          "KWZP-4Q8"
+        ],
+        "child_tree_id": "I1",
+        "child_status": "deceased"
+      },
+      "date": null,
+      "date_certainty": null,
+      "place": null,
+      "standard_place": null,
+      "information_quality": "secondary",
+      "informant": "Quass family / Dignity Memorial funeral home",
+      "informant_proximity": "family_not_present",
+      "informant_bias_notes": "Family-prepared obituary; reliable for identifying immediate family members but may omit estranged members or contain minor errors in names.",
+      "evidence_type": "direct",
+      "log_entry_id": "log_001",
+      "extracted_for_question_ids": [
+        "q_001"
+      ]
+    },
+    {
+      "id": "a_002",
+      "source_id": "src_001",
+      "record_id": "ark:/61903/1:1:XM5X-SPSP",
+      "record_role": "sibling (surviving)",
+      "record_persona_id": null,
+      "fact_type": "relationship",
+      "value": "Kenneth Warner Quass Jr. (Ken Quass) named as surviving sibling of Donald Wendell Quass and child of Kenneth Werner Quass and Ivyl Phylena Greenley in Donald's April 2024 obituary; married Bobbi Quass",
+      "structured_value": {
+        "relationship_type": "ParentChild",
+        "parents": [
+          "KNS4-P6W",
+          "KWZP-4Q8"
+        ],
+        "child_tree_id": "I2",
+        "child_status": "surviving_as_of_2024"
+      },
+      "date": null,
+      "date_certainty": null,
+      "place": null,
+      "standard_place": null,
+      "information_quality": "secondary",
+      "informant": "Quass family / Dignity Memorial funeral home",
+      "informant_proximity": "family_not_present",
+      "informant_bias_notes": "Family-prepared obituary; reliable for identifying immediate family members but may omit estranged members or contain minor errors in names.",
+      "evidence_type": "direct",
+      "log_entry_id": "log_001",
+      "extracted_for_question_ids": [
+        "q_001"
+      ]
+    },
+    {
+      "id": "a_003",
+      "source_id": "src_001",
+      "record_id": "ark:/61903/1:1:XM5X-SPSR",
+      "record_role": "sibling (surviving)",
+      "record_persona_id": null,
+      "fact_type": "relationship",
+      "value": "Patricia Quass Norman (Pat Norman, n\u00e9e Quass) named as surviving sibling of Donald Wendell Quass and child of Kenneth Werner Quass and Ivyl Phylena Greenley in Donald's April 2024 obituary; married Bob Norman",
+      "structured_value": {
+        "relationship_type": "ParentChild",
+        "parents": [
+          "KNS4-P6W",
+          "KWZP-4Q8"
+        ],
+        "child_tree_id": "I3",
+        "child_status": "surviving_as_of_2024"
+      },
+      "date": null,
+      "date_certainty": null,
+      "place": null,
+      "standard_place": null,
+      "information_quality": "secondary",
+      "informant": "Quass family / Dignity Memorial funeral home",
+      "informant_proximity": "family_not_present",
+      "informant_bias_notes": "Family-prepared obituary; reliable for identifying immediate family members but may omit estranged members or contain minor errors in names.",
+      "evidence_type": "direct",
+      "log_entry_id": "log_001",
+      "extracted_for_question_ids": [
+        "q_001"
+      ]
+    },
+    {
+      "id": "a_004",
+      "source_id": "src_002",
+      "record_id": "ark:/61903/1:1:VCF7-BY8",
+      "record_role": "child (principal)",
+      "record_persona_id": null,
+      "fact_type": "birth",
+      "value": "Alice Jeanette Quass born 6 December 1940, Watonwan, Minnesota; father Kenneth Warner Quass, mother Ivyl Phylena Greenley",
+      "structured_value": {
+        "year": 1940,
+        "month": 12,
+        "day": 6,
+        "father": "Kenneth Warner Quass",
+        "mother": "Ivyl Phylena Greenley"
+      },
+      "date": "6 December 1940",
+      "date_certainty": "exact",
+      "place": "Watonwan, Minnesota",
+      "standard_place": "Watonwan, Minnesota, United States",
+      "information_quality": "primary",
+      "informant": "Parents (Kenneth Quass and Ivyl Greenley Quass) / Minnesota birth registrar",
+      "informant_proximity": "official_duty",
+      "informant_bias_notes": null,
+      "evidence_type": "direct",
+      "log_entry_id": "log_005",
+      "extracted_for_question_ids": [
+        "q_001"
+      ]
+    },
+    {
+      "id": "a_005",
+      "source_id": "src_002",
+      "record_id": "ark:/61903/1:1:VCF7-BY8",
+      "record_role": "child (principal)",
+      "record_persona_id": null,
+      "fact_type": "relationship",
+      "value": "Alice Jeanette Quass's father is Kenneth Warner Quass and mother is Ivyl Phylena Greenley, per Minnesota Birth Index 1935\u20132002 entry for her 6 Dec 1940 birth in Watonwan, Minnesota",
+      "structured_value": {
+        "relationship_type": "ParentChild",
+        "father": "Kenneth Warner Quass",
+        "mother": "Ivyl Phylena Greenley",
+        "child": "Alice Jeanette Quass"
+      },
+      "date": "6 December 1940",
+      "date_certainty": "exact",
+      "place": "Watonwan, Minnesota",
+      "standard_place": "Watonwan, Minnesota, United States",
+      "information_quality": "primary",
+      "informant": "Parents (Kenneth Quass and Ivyl Greenley Quass) / Minnesota birth registrar",
+      "informant_proximity": "official_duty",
+      "informant_bias_notes": null,
+      "evidence_type": "direct",
+      "log_entry_id": "log_005",
+      "extracted_for_question_ids": [
+        "q_001"
+      ]
+    },
+    {
+      "id": "a_006",
+      "source_id": "src_003",
+      "record_id": "ark:/61903/1:1:FDX7-8MF",
+      "record_role": "deceased (principal)",
+      "record_persona_id": null,
+      "fact_type": "death",
+      "value": "Alice Jeanette Quass died 3 February 1955, Madelia, Watonwan County, Minnesota; aged 14",
+      "structured_value": {
+        "year": 1955,
+        "month": 2,
+        "day": 3
+      },
+      "date": "3 February 1955",
+      "date_certainty": "exact",
+      "place": "Madelia, Watonwan County, Minnesota",
+      "standard_place": "Madelia, Watonwan, Minnesota, United States",
+      "information_quality": "primary",
+      "informant": "Family members / Minnesota death registrar",
+      "informant_proximity": "official_duty",
+      "informant_bias_notes": null,
+      "evidence_type": "direct",
+      "log_entry_id": "log_003",
+      "extracted_for_question_ids": [
+        "q_001"
+      ]
+    },
+    {
+      "id": "a_007",
+      "source_id": "src_004",
+      "record_id": "ark:/61903/3:1:3QS7-8992-XXT",
+      "record_role": "informant (son of decedent)",
+      "record_persona_id": null,
+      "fact_type": "relationship",
+      "value": "Kenneth Warner Quass Jr. signed as informant on Kenneth Werner Quass's 17 Sep 1982 Texas death certificate, confirming he is a son of Kenneth Werner Quass; surviving spouse listed as Ivyl Greenley corroborates he is also a son of Ivyl Phylena Greenley Quass",
+      "structured_value": {
+        "relationship_type": "ParentChild",
+        "parent": "Kenneth Werner Quass (KNS4-P6W)",
+        "child": "Kenneth Warner Quass Jr. (I2)",
+        "informant_role": "son"
+      },
+      "date": "17 September 1982",
+      "date_certainty": "exact",
+      "place": "Grapevine, Tarrant County, Texas",
+      "standard_place": "Grapevine, Tarrant, Texas, United States",
+      "information_quality": "primary",
+      "informant": "Kenneth Warner Quass Jr. (son of decedent)",
+      "informant_proximity": "family_not_present",
+      "informant_bias_notes": null,
+      "evidence_type": "indirect",
+      "log_entry_id": "log_010",
+      "extracted_for_question_ids": [
+        "q_001"
+      ]
+    }
+  ],
+  "person_evidence": [
+    {
+      "id": "pe_001",
+      "assertion_id": "a_001",
+      "person_id": "I1",
+      "confidence": "confident",
+      "rationale": "Donald Quass's April 2024 obituary names 'Jeanette' as a deceased sibling and child of Kenneth Werner Quass and Ivyl Phylena Greenley. MN Birth Index (a_004) confirms Alice Jeanette Quass was born 6 Dec 1940 in Watonwan MN to these same parents; MN Death Records (a_006) confirm she died 3 Feb 1955. The obituary's 'Jeanette' (a nickname from her middle name) maps to Alice Jeanette Quass (I1). Name, deceased status, parents, and location all agree.",
+      "match_score": null,
+      "created": "2026-06-29"
+    },
+    {
+      "id": "pe_002",
+      "assertion_id": "a_001",
+      "person_id": "KNS4-P6W",
+      "confidence": "confident",
+      "rationale": "The obituary encodes a ParentChild relationship from Kenneth Werner Quass (p_306774614787) to Jeanette. The GedcomX encoding in the obituary record matches the FamilySearch tree person KNS4-P6W (Kenneth Werner Quass Sr.) on name and established identity. No competing candidates.",
+      "match_score": null,
+      "created": "2026-06-29"
+    },
+    {
+      "id": "pe_003",
+      "assertion_id": "a_001",
+      "person_id": "KWZP-4Q8",
+      "confidence": "confident",
+      "rationale": "The obituary encodes a ParentChild relationship from Ivyl Phylena Greenley (p_306774614788) to Jeanette. The GedcomX encoding maps to KWZP-4Q8 (Ivyl Phylena Greenley) on name and established identity. No competing candidates.",
+      "match_score": null,
+      "created": "2026-06-29"
+    },
+    {
+      "id": "pe_004",
+      "assertion_id": "a_002",
+      "person_id": "I2",
+      "confidence": "confident",
+      "rationale": "Donald Quass's 2024 obituary names 'Ken Quass' (married Bobbi Quass) as a surviving sibling and child of Kenneth Werner Quass and Ivyl Phylena Greenley. Texas death certificate (a_007) independently confirms 'Kenneth Quass Jr.' as a son and informant on Kenneth Sr.'s 1982 death certificate. MN Birth Index (log_008) shows Kenneth Warner Quass Jr. as father of children born 1965-1974 in Hennepin County, consistent with living in Minnesota. Name, role, and corroborating records all identify this persona as I2 Kenneth Warner Quass Jr.",
+      "match_score": null,
+      "created": "2026-06-29"
+    },
+    {
+      "id": "pe_005",
+      "assertion_id": "a_002",
+      "person_id": "KNS4-P6W",
+      "confidence": "confident",
+      "rationale": "The obituary's ParentChild encoding from Kenneth Werner Quass to Ken Quass matches KNS4-P6W by name and established identity.",
+      "match_score": null,
+      "created": "2026-06-29"
+    },
+    {
+      "id": "pe_006",
+      "assertion_id": "a_002",
+      "person_id": "KWZP-4Q8",
+      "confidence": "confident",
+      "rationale": "The obituary's ParentChild encoding from Ivyl Phylena Greenley to Ken Quass matches KWZP-4Q8 by name and established identity.",
+      "match_score": null,
+      "created": "2026-06-29"
+    },
+    {
+      "id": "pe_007",
+      "assertion_id": "a_003",
+      "person_id": "I3",
+      "confidence": "confident",
+      "rationale": "Donald Quass's 2024 obituary names 'Pat Norman' (n\u00e9e Quass, married Bob Norman) as a surviving sibling and child of Kenneth Werner Quass and Ivyl Phylena Greenley. The full-text search (log_013) found a 1991 Alabama newspaper naming Ann Gabrielle Quass-Little as daughter of 'Kenneth Wuass' (= Quass) of Plymouth MN \u2014 the same family cluster. Name, married name, sibling role, and family context identify this persona as I3 Patricia Quass Norman.",
+      "match_score": null,
+      "created": "2026-06-29"
+    },
+    {
+      "id": "pe_008",
+      "assertion_id": "a_003",
+      "person_id": "KNS4-P6W",
+      "confidence": "confident",
+      "rationale": "The obituary's ParentChild encoding from Kenneth Werner Quass to Pat Norman matches KNS4-P6W by name and established identity.",
+      "match_score": null,
+      "created": "2026-06-29"
+    },
+    {
+      "id": "pe_009",
+      "assertion_id": "a_003",
+      "person_id": "KWZP-4Q8",
+      "confidence": "confident",
+      "rationale": "The obituary's ParentChild encoding from Ivyl Phylena Greenley to Pat Norman matches KWZP-4Q8 by name and established identity.",
+      "match_score": null,
+      "created": "2026-06-29"
+    },
+    {
+      "id": "pe_010",
+      "assertion_id": "a_004",
+      "person_id": "I1",
+      "confidence": "confident",
+      "rationale": "Minnesota Birth Index (collection 1949334) entry for Alice Jeanette Quass, b. 6 Dec 1940, Watonwan MN, father Kenneth Warner Quass, mother Ivyl Phylena Greenley. Exact name match to I1. Birth year (1940), county (Watonwan), and parents (Quass/Greenley) all match established facts for I1. This is the primary birth record supporting I1's identity.",
+      "match_score": null,
+      "created": "2026-06-29"
+    },
+    {
+      "id": "pe_011",
+      "assertion_id": "a_005",
+      "person_id": "I1",
+      "confidence": "confident",
+      "rationale": "Same MN Birth Index entry as a_004 \u2014 the parentage fact (father Kenneth Warner Quass, mother Ivyl Phylena Greenley) in the birth record directly identifies I1 Alice Jeanette Quass and establishes her parents.",
+      "match_score": null,
+      "created": "2026-06-29"
+    },
+    {
+      "id": "pe_012",
+      "assertion_id": "a_005",
+      "person_id": "KNS4-P6W",
+      "confidence": "confident",
+      "rationale": "The MN Birth Index entry for Alice Jeanette Quass names Kenneth Warner Quass as father. This is consistent with KNS4-P6W (Kenneth Werner Quass, b. 4 Dec 1917, Iowa), who was residing in Watonwan County MN by 1940. Minor variant spelling 'Warner' vs 'Werner' is consistent with name spelling variation in indexed records.",
+      "match_score": null,
+      "created": "2026-06-29"
+    },
+    {
+      "id": "pe_013",
+      "assertion_id": "a_005",
+      "person_id": "KWZP-4Q8",
+      "confidence": "confident",
+      "rationale": "The MN Birth Index entry names Ivyl Phylena Greenley as mother, exactly matching KWZP-4Q8 (Ivyl Phylena Greenley, b. 26 May 1914). Name and location (Watonwan County) match the established profile.",
+      "match_score": null,
+      "created": "2026-06-29"
+    },
+    {
+      "id": "pe_014",
+      "assertion_id": "a_006",
+      "person_id": "I1",
+      "confidence": "confident",
+      "rationale": "MN Death Records 1900-1955 entry for Alice Jeanette Quass, d. 3 Feb 1955, Madelia, Watonwan County MN. The name, birth year (1940, per MN Birth Index), and location (Watonwan County) are consistent with I1. Death at age 14 is biologically plausible. This record corroborates the obituary's identification of 'Jeanette' as a deceased sibling.",
+      "match_score": null,
+      "created": "2026-06-29"
+    },
+    {
+      "id": "pe_015",
+      "assertion_id": "a_007",
+      "person_id": "I2",
+      "confidence": "confident",
+      "rationale": "Texas death certificate for Kenneth Werner Quass Sr. (1982) lists informant as 'Kenneth Quass Jr.' The 'Jr.' suffix, same surname, and informant role together identify this person as I2 Kenneth Warner Quass Jr. (son of KNS4-P6W). This is independently corroborated by the obituary (a_002). MN Birth Index (log_008) further confirms a Kenneth Warner Quass Jr. was father of children in Hennepin County MN 1965-1974.",
+      "match_score": null,
+      "created": "2026-06-29"
+    },
+    {
+      "id": "pe_016",
+      "assertion_id": "a_007",
+      "person_id": "KNS4-P6W",
+      "confidence": "confident",
+      "rationale": "The Texas death certificate is for Kenneth Werner Quass (KNS4-P6W): DoB 12-4-1917 (vs. 4 Dec 1917 per tree), DoD 17 Sep 1982 (matches), Tarrant County TX (matches), SS# 483-03-9478, parents Ralph K. Quass and Emma Nehls (both match tree). Identity of the decedent as KNS4-P6W is unambiguous.",
+      "match_score": null,
+      "created": "2026-06-29"
+    }
+  ],
+  "conflicts": [],
+  "hypotheses": [],
+  "timelines": [],
+  "proof_summaries": [],
+  "evaluations": [
+    {
+      "id": "ev_001",
+      "focus": "pre-exhaustiveness",
+      "target_id": "q_001",
+      "target_type": "question",
+      "verdict": "address_first",
+      "file_path": "evaluations/pre-exhaustiveness-q_001-2026-06-29T222000Z.json",
+      "timestamp": "2026-06-29T22:20:00Z",
+      "superseded_by": null
+    }
+  ]
+}

--- a/eval/runlogs/e2e/ivyl-greenley-daughter/run-2026-06-29_22-24-03.final-tree.gedcomx.json
+++ b/eval/runlogs/e2e/ivyl-greenley-daughter/run-2026-06-29_22-24-03.final-tree.gedcomx.json
@@ -1,0 +1,738 @@
+{
+  "persons": [
+    {
+      "id": "KWZP-4Q8",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "given": "Ivyl Phylena",
+          "surname": "Greenley",
+          "id": "KWZP-4Q8-name-1"
+        }
+      ],
+      "facts": [
+        {
+          "id": "248eaba5-34ae-4182-9874-bfcc07166241",
+          "type": "Birth",
+          "date": "26 May 1914",
+          "standard_date": "26 May 1914",
+          "place": "Farley, Taylor Twsp, Dubuque County, Iowa",
+          "standard_place": "Taylor Township, Dubuque, Iowa, United States"
+        },
+        {
+          "id": "9381f219-2889-4bfc-9b03-5527232282c1",
+          "type": "Death",
+          "date": "24 May 2005",
+          "standard_date": "24 May 2005",
+          "place": "San Diego, San Diego, California",
+          "standard_place": "San Diego, San Diego, California, United States"
+        },
+        {
+          "id": "e28231e3-b161-49ad-b96f-74418af12297",
+          "type": "Residence",
+          "date": "1915",
+          "standard_date": "1915",
+          "place": "Farley, Dubuque, Iowa, United States",
+          "standard_place": "Farley, Dubuque, Iowa, United States"
+        },
+        {
+          "id": "98445906-2723-43fb-82e4-d2c9c3c38b0b",
+          "type": "Residence",
+          "date": "1915",
+          "standard_date": "1915",
+          "place": "Farley, Saskatchewan, Canada",
+          "standard_place": "Farley, Corman Park No. 344, Saskatchewan, Canada",
+          "value": "Census"
+        },
+        {
+          "id": "49dd74a8-b659-4133-87c9-c30a0156589b",
+          "type": "Residence",
+          "date": "1920",
+          "standard_date": "1920",
+          "place": "Taylor, Dubuque, Iowa, United States",
+          "standard_place": "Taylor Township, Dubuque, Iowa, United States"
+        },
+        {
+          "id": "4c12a7e2-0f16-4631-bc0d-6f2c32298a6e",
+          "type": "Residence",
+          "date": "1925",
+          "standard_date": "1925",
+          "place": "Dubuque, Iowa, United States",
+          "standard_place": "Dubuque, Iowa, United States"
+        },
+        {
+          "id": "2bfab2b9-5551-49c8-bfb6-09753ac1e2f8",
+          "type": "Residence",
+          "date": "1930",
+          "standard_date": "1930",
+          "place": "Taylor, Dubuque, Iowa",
+          "standard_place": "Taylor Township, Dubuque, Iowa, United States"
+        },
+        {
+          "id": "52a19080-3339-40df-9b3f-b80fb7b9b521",
+          "type": "Burial",
+          "place": "Madelia, Watonwan, Minnesota",
+          "standard_place": "Madelia, Brown, Minnesota, United States"
+        }
+      ]
+    },
+    {
+      "id": "KW4T-D9J",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "given": "Donald Wendell",
+          "surname": "Quass",
+          "id": "KW4T-D9J-name-1"
+        }
+      ],
+      "facts": [
+        {
+          "id": "ebe0d4fe-20f8-4dad-b4b8-c69c03d0f100",
+          "type": "Birth",
+          "date": "16 January 1940",
+          "standard_date": "16 Jan 1940",
+          "place": "Randalia, Fayette, Iowa, United States",
+          "standard_place": "Randalia, Fayette, Iowa, United States"
+        },
+        {
+          "id": "a3ca8aea-4b58-4dbf-aecf-8fd8437e7791",
+          "type": "Residence",
+          "date": "1940",
+          "standard_date": "1940",
+          "place": "Madelia Village, Madelia, Watonwan, Minnesota",
+          "standard_place": "Madelia, Brown, Minnesota, United States"
+        },
+        {
+          "id": "b52c85f4-5f6c-4d7a-a8df-87e932a8bc25",
+          "type": "Christening",
+          "date": "31 May 1943",
+          "standard_date": "31 May 1943",
+          "place": "Randalia, Fayette, Iowa, United States",
+          "standard_place": "Randalia, Fayette, Iowa, United States"
+        },
+        {
+          "id": "7b2291a8-18a0-4189-aa93-d2d71618545b",
+          "type": "Death",
+          "date": "25 April 2024",
+          "standard_date": "25 Apr 2024",
+          "place": "Breezy Point, Crow Wing, Minnesota, United States",
+          "standard_place": "Breezy Point, Crow Wing, Minnesota, United States"
+        },
+        {
+          "id": "bf435172-7ef5-47ff-91d4-747781eac965",
+          "type": "Obituary",
+          "date": "27 April 2024",
+          "standard_date": "27 Apr 2024",
+          "place": "Saint Paul, Ramsey, Minnesota, United States",
+          "standard_place": "Saint Paul, Ramsey, Minnesota, United States"
+        },
+        {
+          "id": "df09702a-d087-4277-aebb-db9057efae45",
+          "type": "Burial",
+          "date": "1 May 2024",
+          "standard_date": "1 May 2024",
+          "place": "Madelia, Watonwan, Minnesota, United States",
+          "standard_place": "Madelia, Watonwan, Minnesota, United States"
+        }
+      ]
+    },
+    {
+      "id": "KNS4-P6W",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "given": "Kenneth Werner",
+          "surname": "Quass",
+          "id": "KNS4-P6W-name-1"
+        }
+      ],
+      "facts": [
+        {
+          "id": "248eaba5-34ae-4182-9874-bfcc07166241",
+          "type": "Birth",
+          "date": "4 December 1917",
+          "standard_date": "4 Dec 1917",
+          "place": "Sumner, Bremer, Iowa, United States",
+          "standard_place": "Sumner, Bremer, Iowa, United States"
+        },
+        {
+          "id": "e02d8c27-c8bb-4c09-9f8e-c1ba505d2ee4",
+          "type": "Residence",
+          "date": "1920",
+          "standard_date": "1920",
+          "place": "Sumner, Buchanan, Iowa, United States",
+          "standard_place": "Sumner Township, Buchanan, Iowa, United States"
+        },
+        {
+          "id": "4a25d8ab-9854-478c-9090-a9004769dce4",
+          "type": "Residence",
+          "date": "1930",
+          "standard_date": "1930",
+          "place": "Sumner, Buchanan, Iowa",
+          "standard_place": "Sumner Township, Buchanan, Iowa, United States"
+        },
+        {
+          "id": "e91362a2-3d50-4409-ad4e-02ece0716fb1",
+          "type": "Residence",
+          "date": "1935",
+          "standard_date": "1935",
+          "place": "R, Buchanan, Iowa",
+          "standard_place": "Buchanan, Iowa, United States"
+        },
+        {
+          "id": "70b33fab-ab40-4e6f-8e9e-71e3d0c05da7",
+          "type": "Residence",
+          "date": "1940",
+          "standard_date": "1940",
+          "place": "Madelia Village, Madelia, Watonwan, Minnesota",
+          "standard_place": "Madelia, Brown, Minnesota, United States"
+        },
+        {
+          "id": "55b16226-9fe3-46c9-9ad9-7fecf3c40e57",
+          "type": "Military Draft Registration",
+          "date": "16 Oct 1940",
+          "standard_date": "16 Oct 1940",
+          "place": "Marshall, Watonwan, Minnesota, United States",
+          "standard_place": "Marshall, Minnesota, United States"
+        },
+        {
+          "id": "ab93f448-37cc-401f-b1c8-739d271affbb",
+          "type": "Move",
+          "date": "2 July 1962",
+          "standard_date": "2 Jul 1962",
+          "place": "Los Angeles, California, United States",
+          "standard_place": "Los Angeles, California, United States"
+        },
+        {
+          "id": "9381f219-2889-4bfc-9b03-5527232282c1",
+          "type": "Death",
+          "date": "17 September 1982",
+          "standard_date": "17 Sep 1982",
+          "place": "Grapevine, Tarrant County, Texas, United States",
+          "standard_place": "Grapevine, Tarrant, Texas, United States"
+        },
+        {
+          "id": "52a19080-3339-40df-9b3f-b80fb7b9b521",
+          "type": "Burial",
+          "date": "25 September 1982",
+          "standard_date": "25 Sep 1982",
+          "place": "Madelia, Watonwan, Minnesota, United States",
+          "standard_place": "Madelia, Brown, Minnesota, United States"
+        },
+        {
+          "id": "32f3ba77-8481-4d6d-8b66-a50d689b4d5f",
+          "type": "Residence",
+          "place": "Marshall, Watonwan, Minnesota",
+          "standard_place": "Marshall, Minnesota, United States"
+        }
+      ]
+    },
+    {
+      "id": "KNSS-9QM",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "given": "Herbert Thomas",
+          "surname": "Greenley",
+          "id": "KNSS-9QM-name-1"
+        }
+      ],
+      "facts": [
+        {
+          "id": "248eaba5-34ae-4182-9874-bfcc07166241",
+          "type": "Birth",
+          "date": "23 June 1881",
+          "standard_date": "23 Jun 1881",
+          "place": "Concord Township, Dubuque, Iowa, United States",
+          "standard_place": "Concord Township, Dubuque, Iowa, United States"
+        },
+        {
+          "id": "1e064ad1-d4b2-4f6c-bdb3-53c72906ead9",
+          "type": "Census",
+          "date": "1900",
+          "standard_date": "1900",
+          "place": "Taylor, Dubuque, Iowa, USA",
+          "standard_place": "Taylor Township, Dubuque, Iowa, United States",
+          "value": "Listed as a servant at the Ensign household."
+        },
+        {
+          "id": "560b2c7a-282a-4730-8eac-f2a07f1f9d77",
+          "type": "Census",
+          "date": "1910",
+          "standard_date": "1910",
+          "place": "Center, Dubuque, Iowa, USA",
+          "standard_place": "Center Township, Dubuque, Iowa, United States",
+          "value": "Living with wife. Listed as a Rural Mailman."
+        },
+        {
+          "id": "00d1c902-289f-4fe4-a2d8-635c8114e44b",
+          "type": "Residence",
+          "date": "1910",
+          "standard_date": "1910",
+          "place": "Center, Dubuque, Iowa, United States",
+          "standard_place": "Center Township, Dubuque, Iowa, United States"
+        },
+        {
+          "id": "e7ab0d2c-4582-4321-b093-1ea2d8c42fca",
+          "type": "Military Draft Registration",
+          "date": "1917-1918",
+          "standard_date": "Bet 1917 and 1918",
+          "place": "Faribault, Minnesota, United States",
+          "standard_place": "Faribault, Minnesota, United States"
+        },
+        {
+          "id": "8736a128-79f5-4476-869b-aafb833b08d2",
+          "type": "MilitaryService",
+          "date": "from 1917 to 1918",
+          "standard_date": "Bet 1917 and 1918",
+          "place": "WWI Draft Registration Cards",
+          "standard_place": "Draft, Sharp, Arkansas, United States",
+          "value": "Enlisted at Faribault, Minnesota. Listed as a Farmer and as having wife Alice."
+        },
+        {
+          "id": "dfbb4101-b189-41e1-9b31-71f5d8a3c95f",
+          "type": "Census",
+          "date": "1920",
+          "standard_date": "1920",
+          "place": "Kiester, Fairbault, Minnesota, USA",
+          "standard_place": "Kiester, Faribault, Minnesota, United States",
+          "value": "Living alone. Listed as a Widower and as a General Farmer."
+        },
+        {
+          "id": "19cd8758-ae0e-435e-a865-8a3168afe66c",
+          "type": "Census",
+          "date": "1925",
+          "standard_date": "1925",
+          "place": "Epworth, Dubuque, Iowa, USA",
+          "standard_place": "Epworth, Dubuque, Iowa, United States",
+          "value": "Living with daughters ZMG and IPG."
+        },
+        {
+          "id": "8205f7b2-71a9-4176-8a27-fbfabd722a72",
+          "type": "Census",
+          "date": "1930",
+          "standard_date": "1930",
+          "place": "State Hospital, Washington, Buchanan, Iowa, USA",
+          "standard_place": "Washington Township, Buchanan, Iowa, United States",
+          "value": "Living with daughter ZMG. Listed as a Laundryman and as a Widower."
+        },
+        {
+          "id": "6b01be4e-11e1-4878-898a-3415a2395ef8",
+          "type": "Residence",
+          "date": "1930",
+          "standard_date": "1930",
+          "place": "Washington, Buchanan, Iowa, United States",
+          "standard_place": "Washington Township, Buchanan, Iowa, United States"
+        },
+        {
+          "id": "977ed40e-7eb6-458b-b24e-47a7458928ba",
+          "type": "Residence",
+          "date": "1935",
+          "standard_date": "1935",
+          "place": "Same Place",
+          "standard_place": "Same, Manufahi, Timor-Leste"
+        },
+        {
+          "id": "b0d370f6-43ff-4e7c-92bc-a9d83d62aca2",
+          "type": "Residence",
+          "date": "1940",
+          "standard_date": "1940",
+          "place": "Ward 2, Independence City, Washington Township, Buchanan, Iowa, United States",
+          "standard_place": "Washington Township, Buchanan, Iowa, United States"
+        },
+        {
+          "id": "976f2f02-1614-4562-a411-e04d04a44185",
+          "type": "Military Draft Registration",
+          "date": "27 Apr 1942",
+          "standard_date": "27 Apr 1942",
+          "place": "Frederika, Bremer, Iowa, United States",
+          "standard_place": "Frederika, Bremer, Iowa, United States"
+        },
+        {
+          "id": "0a9810c0-295b-4321-bb0d-ab2792650fc8",
+          "type": "Residence",
+          "date": "May 3, 1950",
+          "standard_date": "3 May 1950",
+          "place": "Tripoli, Bremer, Iowa, United States",
+          "standard_place": "Tripoli, Bremer, Iowa, United States"
+        },
+        {
+          "id": "9381f219-2889-4bfc-9b03-5527232282c1",
+          "type": "Death",
+          "date": "29 May 1963",
+          "standard_date": "29 May 1963",
+          "place": "Independence, Buchanan, Iowa, United States",
+          "standard_place": "Independence, Buchanan, Iowa, United States"
+        },
+        {
+          "id": "c5be31e4-c57a-417a-b672-456ec4e963d8",
+          "type": "Burial",
+          "date": "2 June 1963",
+          "standard_date": "2 Jun 1963",
+          "place": "Epworth, Dubuque, Iowa, United States",
+          "standard_place": "Epworth, Dubuque, Iowa, United States"
+        },
+        {
+          "id": "85f2157f-9872-4d3f-aeea-95597b5ad006",
+          "type": "Residence",
+          "place": "Frederika, Bremer, Iowa",
+          "standard_place": "Frederika, Bremer, Iowa, United States"
+        },
+        {
+          "id": "8373b325-0002-485d-b83d-740de608b4b8",
+          "type": "Occupation",
+          "value": "Farmer"
+        },
+        {
+          "id": "63b86a13-dcd7-49b4-99c8-a35cf9fc642c",
+          "type": "Occupation",
+          "value": "Rural Mailman"
+        },
+        {
+          "id": "31972d47-f82f-4cdd-a630-df652a23d382",
+          "type": "Citizenship",
+          "place": "United States",
+          "standard_place": "United States"
+        }
+      ]
+    },
+    {
+      "id": "KNS9-5S7",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "given": "Alice Ann",
+          "surname": "Wilkinson",
+          "id": "KNS9-5S7-name-1"
+        }
+      ],
+      "facts": [
+        {
+          "id": "248eaba5-34ae-4182-9874-bfcc07166241",
+          "type": "Birth",
+          "date": "26 Jan 1880",
+          "standard_date": "26 Jan 1880",
+          "place": "Hazel Green, Grant, Wisconsin, United States",
+          "standard_place": "Hazel Green, Grant, Wisconsin, United States"
+        },
+        {
+          "id": "60606fc0-7d8b-44d0-8f16-dcf96a1cf62e",
+          "type": "Residence",
+          "date": "1880",
+          "standard_date": "1880",
+          "place": "Hazel Green, Grant, Wisconsin, United States",
+          "standard_place": "Hazel Green, Grant, Wisconsin, United States"
+        },
+        {
+          "id": "a387f02c-8766-4fd7-beb2-96909e7ccefc",
+          "type": "Residence",
+          "date": "1910",
+          "standard_date": "1910",
+          "place": "Center, Dubuque, Iowa, United States",
+          "standard_place": "Center Township, Dubuque, Iowa, United States"
+        },
+        {
+          "id": "9381f219-2889-4bfc-9b03-5527232282c1",
+          "type": "Death",
+          "date": "3 Aug 1919",
+          "standard_date": "3 Aug 1919",
+          "place": "Kiester, Faribault, Minnesota, United States",
+          "standard_place": "Kiester, Faribault, Minnesota, United States"
+        },
+        {
+          "id": "c5be31e4-c57a-417a-b672-456ec4e963d8",
+          "type": "Burial",
+          "date": "6 August 1919",
+          "standard_date": "6 Aug 1919",
+          "place": "Epworth, Dubuque, Iowa, United States",
+          "standard_place": "Epworth, Dubuque, Iowa, United States"
+        }
+      ]
+    },
+    {
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "type": "BirthName",
+          "given": "Alice Jeanette",
+          "surname": "Quass",
+          "preferred": true,
+          "id": "N1"
+        }
+      ],
+      "id": "I1",
+      "facts": [
+        {
+          "type": "Birth",
+          "date": "6 December 1940",
+          "place": "Watonwan, Minnesota, United States",
+          "primary": true,
+          "id": "F1",
+          "standard_place": "Watonwan, Minnesota, United States"
+        },
+        {
+          "type": "Death",
+          "date": "3 February 1955",
+          "place": "Madelia, Watonwan, Minnesota, United States",
+          "primary": true,
+          "id": "F2",
+          "standard_place": "Madelia, Cleburne, Arkansas, United States"
+        }
+      ]
+    },
+    {
+      "gender": "Male",
+      "living": true,
+      "names": [
+        {
+          "type": "BirthName",
+          "given": "Kenneth Warner",
+          "surname": "Quass",
+          "suffix": "Jr",
+          "preferred": true,
+          "id": "N2"
+        }
+      ],
+      "id": "I2"
+    },
+    {
+      "gender": "Female",
+      "living": true,
+      "names": [
+        {
+          "type": "BirthName",
+          "given": "Patricia",
+          "surname": "Quass",
+          "preferred": true,
+          "id": "N3"
+        },
+        {
+          "type": "MarriedName",
+          "given": "Patricia",
+          "surname": "Norman",
+          "id": "N4"
+        }
+      ],
+      "id": "I3"
+    }
+  ],
+  "relationships": [
+    {
+      "type": "Couple",
+      "person1": "KNS4-P6W",
+      "person2": "KWZP-4Q8",
+      "facts": [
+        {
+          "id": "27913e02-f2f7-4653-9bc3-9a13a0896872",
+          "type": "Marriage",
+          "date": "06 Mar 1938",
+          "standard_date": "6 Mar 1938",
+          "place": "Independence, Buchman, Iowa",
+          "standard_place": "Independence, Buchanan, Iowa, United States"
+        }
+      ],
+      "id": "rel-1"
+    },
+    {
+      "type": "Couple",
+      "person1": "KNSS-9QM",
+      "person2": "KNS9-5S7",
+      "facts": [
+        {
+          "type": "Marriage",
+          "date": "26 January 1910",
+          "standard_date": "26 Jan 1910",
+          "place": "Epworth, Dubuque, Iowa, United States",
+          "standard_place": "Epworth, Dubuque, Iowa, United States"
+        }
+      ],
+      "id": "rel-2"
+    },
+    {
+      "type": "ParentChild",
+      "parent": "KNSS-9QM",
+      "child": "KWZP-4Q8",
+      "subtype": "Biological",
+      "id": "rel-3"
+    },
+    {
+      "type": "ParentChild",
+      "parent": "KNS9-5S7",
+      "child": "KWZP-4Q8",
+      "subtype": "Biological",
+      "id": "rel-4"
+    },
+    {
+      "type": "ParentChild",
+      "parent": "KNS4-P6W",
+      "child": "KW4T-D9J",
+      "subtype": "Biological",
+      "id": "rel-5"
+    },
+    {
+      "type": "ParentChild",
+      "parent": "KWZP-4Q8",
+      "child": "KW4T-D9J",
+      "subtype": "Biological",
+      "id": "rel-6"
+    },
+    {
+      "type": "ParentChild",
+      "parent": "KNS4-P6W",
+      "child": "I1",
+      "subtype": "Biological",
+      "id": "R1"
+    },
+    {
+      "type": "ParentChild",
+      "parent": "KWZP-4Q8",
+      "child": "I1",
+      "subtype": "Biological",
+      "id": "R2"
+    },
+    {
+      "type": "ParentChild",
+      "parent": "KNS4-P6W",
+      "child": "I2",
+      "subtype": "Biological",
+      "id": "R3"
+    },
+    {
+      "type": "ParentChild",
+      "parent": "KWZP-4Q8",
+      "child": "I2",
+      "subtype": "Biological",
+      "id": "R4"
+    },
+    {
+      "type": "ParentChild",
+      "parent": "KNS4-P6W",
+      "child": "I3",
+      "subtype": "Biological",
+      "id": "R5"
+    },
+    {
+      "type": "ParentChild",
+      "parent": "KWZP-4Q8",
+      "child": "I3",
+      "subtype": "Biological",
+      "id": "R6"
+    }
+  ],
+  "sources": [
+    {
+      "id": "MS62-1FF",
+      "title": "Legacy NFS Source: Ivyl Phylena Greenley - Published information: Obituary: death: 24 May 2005; San Diego, San Diego, California, United States",
+      "citation": "Article"
+    },
+    {
+      "id": "38FF-11V",
+      "title": "Inyl Greenley, \"Iowa, State Census, 1925\"",
+      "citation": "\"Iowa, State Census, 1925\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:QKQH-C5YP : Sun Mar 10 15:16:39 UTC 2024), Entry for Inyl Greenley, 1925.",
+      "url": "https://familysearch.org/ark:/61903/1:1:QKQH-C5YP"
+    },
+    {
+      "id": "QK2L-WL7",
+      "title": "Avyl Quass, \"United States, GenealogyBank Obituaries, Births, and Marriages, 1980-2015\"",
+      "citation": "\"United States, GenealogyBank Obituaries, Births, and Marriages, 1980-2015\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:QKGC-WSLK : Mon Jan 13 11:12:58 UTC 2025), Entry for Mrs Bernice H Quass Wegner and Ralph Quass, 22 Jun 2010.",
+      "url": "https://familysearch.org/ark:/61903/1:1:QKGC-W3S7"
+    },
+    {
+      "id": "M39F-8DF",
+      "title": "Ivyl Greenley, \"United States, Census, 1930\"",
+      "citation": "\"United States, Census, 1930\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:XMJ7-HKN : Fri Mar 08 20:16:20 UTC 2024), Entry for Phylang Wilkinson and Ivyl Greenley, 1930.",
+      "url": "https://familysearch.org/ark:/61903/1:1:XMJ7-HKJ"
+    },
+    {
+      "id": "9XZ1-Y2Q",
+      "title": "Ivyl Phylena Greenley Quass, \"Find a Grave Index\"",
+      "citation": "\"Find a Grave Index\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:QVK1-PM7Q : Thu Apr 03 09:52:45 UTC 2025), Entry for Ivyl Phylena Greenley Quass, 2005.",
+      "url": "https://familysearch.org/ark:/61903/1:1:QVK1-PM7Q"
+    },
+    {
+      "id": "MMMK-RW5",
+      "title": "Ivyl Quass, \"United States Census, 1940\"",
+      "citation": "\"United States, Census, 1940\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:KSLN-B52 : Tue Jan 14 18:58:12 UTC 2025), Entry for Ivyl Quass and Kenneth Quass, 1940.",
+      "url": "https://familysearch.org/ark:/61903/1:1:KSLN-B52"
+    },
+    {
+      "id": "SLTH-PYH",
+      "title": "Ivyl Phylena Quass, \"Minnesota, World War II Draft Registration Cards, 1940-1947\"",
+      "citation": "\"Minnesota, World War II Draft Registration Cards, 1940-1947\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:QLF9-1GKW : Thu Apr 10 20:11:45 UTC 2025), Entry for Kenneth Warner Quass and Ivyl Phylena Quass, 16 Oct 1940.",
+      "url": "https://familysearch.org/ark:/61903/1:1:QLF9-1GKC"
+    },
+    {
+      "id": "WWDC-3KV",
+      "title": "Phylena Ivyl Greenley, \"United States, Obituary Records, 2014-2023\"",
+      "citation": "\"United States, Obituary Records, 2014-2023\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:XM5X-SPSL : Sat Nov 30 06:36:18 UTC 2024), Entry for Donald Wendell Quass and Karen Ann Spriggs Quass, 27 April 2024.",
+      "url": "https://familysearch.org/ark:/61903/1:1:XM5X-SPSB"
+    },
+    {
+      "id": "MMMK-RC8",
+      "title": "Ivyl P Quass, \"United States Social Security Death Index\"",
+      "citation": "\"United States, Social Security Death Index,\" database, <i>FamilySearch</i> (https://familysearch.org/ark:/61903/1:1:VMQN-DYM : 11 January 2021), Ivyl P Quass, 24 May 2005; citing U.S. Social Security Administration, <i>Death Master File</i>, database (Alexandria, Virginia: National Technical Information Service, ongoing).",
+      "url": "https://familysearch.org/ark:/61903/1:1:VMQN-DYM"
+    },
+    {
+      "id": "Q16G-TWF",
+      "title": "Ivyl Phylena Greenley, \"United States, Social Security Numerical Identification Files (NUMIDENT), 1936-2007\"",
+      "citation": "\"United States, Social Security Numerical Identification Files (NUMIDENT), 1936-2007\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:6K7Y-MX4V : Tue Jun 09 07:59:37 UTC 2026), Entry for Ivyl P Quass and Herbert T Greenley.",
+      "url": "https://familysearch.org/ark:/61903/1:1:6K7Y-MX4V"
+    },
+    {
+      "id": "WWG4-K8T",
+      "title": "Ingel Greenley, \"Iowa, County Births, 1880-1935\"",
+      "citation": "\"Iowa, County Births, 1880-1935\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:V464-9MW : Fri Jul 25 06:03:47 UTC 2025), Entry for Ingel Greenley and Hubert Greenley, 26 May 1914.",
+      "url": "https://familysearch.org/ark:/61903/1:1:V464-9MW"
+    },
+    {
+      "id": "9XZ1-BT5",
+      "title": "Ivyl Greenley, \"Iowa, State Census, 1915\"",
+      "citation": "\"Iowa, State Census, 1915\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:QK4T-SNZH : Sun Mar 10 16:22:43 UTC 2024), Entry for Ivyl Greenley, 1915.",
+      "url": "https://familysearch.org/ark:/61903/1:1:QK4T-SNZH"
+    },
+    {
+      "id": "9P9Q-9BF",
+      "title": "Ivyl Greenly in household of Robert Wilkinson, \"United States Census, 1920\"",
+      "citation": "\"United States, Census, 1920\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:M8BG-TGM : Tue Oct 21 19:49:25 UTC 2025), Entry for Robert Wilkinson and Phyellna Wilkinson, 1920.",
+      "url": "https://familysearch.org/ark:/61903/1:1:M8BG-TGQ"
+    },
+    {
+      "id": "39HN-W9G",
+      "title": "Ivyl Grunley, \"Iowa, State Census, 1915\"",
+      "citation": "\"Iowa, State Census, 1915\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:QK45-XJW8 : Sun Oct 12 08:54:09 UTC 2025), Entry for Ivyl Grunley, 1915.",
+      "url": "https://familysearch.org/ark:/61903/1:1:QK45-XJW8"
+    },
+    {
+      "id": "WWG4-2MT",
+      "title": "Ingel Greenley, \"Iowa, County Births, 1880-1935\"",
+      "citation": "\"Iowa, County Births, 1880-1935\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:V464-W1M : Fri Jul 25 06:51:50 UTC 2025), Entry for Ingel Greenley and Hubert Greenley, 26 May 1914.",
+      "url": "https://familysearch.org/ark:/61903/1:1:V464-W1M"
+    },
+    {
+      "title": "Alice Jeanette Quass, \"Minnesota, Birth Index, 1935-2002\"",
+      "citation": "\"Minnesota, Birth Index, 1935-2002\", FamilySearch (https://www.familysearch.org/ark:/61903/1:1:VCF7-BY8), Entry for Alice Jeanette Quass and Kenneth Warner Quass, 06 Dec 1940.",
+      "url": "https://familysearch.org/ark:/61903/1:1:VCF7-BY8",
+      "id": "S1"
+    },
+    {
+      "title": "Alice Jeanette Quass, \"Minnesota Death Records, 1900-1955\"",
+      "citation": "\"Minnesota Death Records, 1900-1955\", FamilySearch (https://www.familysearch.org/ark:/61903/1:1:FDX7-8MF), Entry for Alice Jeanette Quass, 03 Feb 1955.",
+      "url": "https://familysearch.org/ark:/61903/1:1:FDX7-8MF",
+      "id": "S2"
+    },
+    {
+      "title": "Kenneth Quass, \"Texas Death Certificates\" (1982)",
+      "citation": "\"United States, Texas, Deaths\", FamilySearch fulltext (https://www.familysearch.org/ark:/61903/3:1:3QS7-8992-XXT), Death certificate for Kenneth Quass, 17 Sep 1982, Tarrant County TX; informant listed as Kenneth Quass Jr.",
+      "url": "https://www.familysearch.org/ark:/61903/3:1:3QS7-8992-XXT",
+      "id": "S3"
+    }
+  ]
+}

--- a/eval/runlogs/e2e/ivyl-greenley-daughter/run-2026-06-29_22-24-03.json
+++ b/eval/runlogs/e2e/ivyl-greenley-daughter/run-2026-06-29_22-24-03.json
@@ -1,0 +1,4949 @@
+{
+  "test_id": "ivyl-greenley-daughter",
+  "captured_at": "2026-06-29_22-24-03",
+  "verdict": "pass",
+  "stop_reason": "error",
+  "judge_output": {
+    "per_finding": [
+      {
+        "finding_id": "f1",
+        "matched": "true",
+        "agent_evidence": "Person record with id 'I1': Alice Jeanette Quass, born 6 December 1940, in Watonwan, Minnesota. ParentChild relationships (R1 and R2) establish her as child of both KNS4-P6W (Kenneth Werner Quass) and KWZP-4Q8 (Ivyl Phylena Greenley). Source S1 cites Minnesota Birth Index, 1935-2002 for Alice Jeanette Quass, born 6 Dec 1940, father Kenneth Warner Quass.",
+        "notes": "Agent successfully recovered the second child Alice Jeannette Quass with correct birth date and location. The person is properly linked as a child of both parents in the tree via parent-child relationships."
+      },
+      {
+        "finding_id": "f2",
+        "matched": "true",
+        "agent_evidence": "Person record I1 (Alice Jeanette Quass) includes Death fact with date '3 February 1955' and place 'Madelia, Watonwan, Minnesota, United States'. Source S2 cites Minnesota Death Records, 1900-1955 for Alice Jeanette Quass, 03 Feb 1955.",
+        "notes": "Agent recovered the death date and location correctly. The death fact is present in the tree with proper sourcing from Minnesota death records."
+      },
+      {
+        "finding_id": "f3",
+        "matched": "false",
+        "agent_evidence": "No burial fact is present for Alice Jeanette Quass (person I1) in the final tree.",
+        "notes": "The agent did not recover the burial date of 21 February 1955 in Madelia, Minnesota. While this finding is marked as not required, the burial information is absent from the tree."
+      }
+    ],
+    "recall_required": 1.0,
+    "recall_total": 0.8666666666666667,
+    "verdict": "pass",
+    "rationale": "The agent successfully recovered both required findings (f1 and f2). Alice Jeanette Quass is present in the final tree as person I1 with correct name, birth date (6 December 1940), birth place (Watonwan, Minnesota), and death date (3 February 1955). She is properly linked as a child of both Ivyl Phylena Greenley and Kenneth Werner Quass through ParentChild relationships. The supporting sources (Minnesota Birth Index and Minnesota Death Records) are correctly cited. The optional burial information (f3) was not recovered, but this does not affect the verdict since both required findings matched. The agent met the research objective of identifying the second child and providing birth and death dates.",
+    "proof_quality": {
+      "score": null,
+      "exhaustiveness": "na",
+      "conflicts_addressed": "na",
+      "corroboration": "na",
+      "tier_appropriate": "na",
+      "rationale": "No proof summary was provided in the agent's research.json output. The proof_quality fields cannot be evaluated because there is no written proof statement to assess. This does not reflect negatively on the recall verdict, which passed based on the tree evidence alone."
+    }
+  },
+  "usage": {
+    "continue_nudges": 0,
+    "session_id": "bbf38148-6301-4b4b-85c0-51b7f01068c4",
+    "resumes": 0,
+    "resume_on_stall": true,
+    "timeline": [
+      [
+        0.9,
+        "system:init"
+      ],
+      [
+        3.9,
+        "assistant"
+      ],
+      [
+        5.6,
+        "assistant"
+      ],
+      [
+        5.7,
+        "tool_result"
+      ],
+      [
+        7.7,
+        "assistant"
+      ],
+      [
+        7.9,
+        "assistant"
+      ],
+      [
+        8.0,
+        "tool_result"
+      ],
+      [
+        8.0,
+        "tool_result"
+      ],
+      [
+        9.9,
+        "assistant"
+      ],
+      [
+        12.3,
+        "assistant"
+      ],
+      [
+        12.8,
+        "tool_result"
+      ],
+      [
+        13.0,
+        "assistant"
+      ],
+      [
+        13.0,
+        "tool_result"
+      ],
+      [
+        20.9,
+        "assistant"
+      ],
+      [
+        21.9,
+        "assistant"
+      ],
+      [
+        22.0,
+        "tool_result"
+      ],
+      [
+        23.9,
+        "assistant"
+      ],
+      [
+        24.2,
+        "tool_result"
+      ],
+      [
+        68.2,
+        "assistant"
+      ],
+      [
+        68.2,
+        "assistant"
+      ],
+      [
+        68.2,
+        "tool_result"
+      ],
+      [
+        75.6,
+        "assistant"
+      ],
+      [
+        84.0,
+        "assistant"
+      ],
+      [
+        84.0,
+        "tool_result"
+      ],
+      [
+        86.0,
+        "assistant"
+      ],
+      [
+        86.6,
+        "assistant"
+      ],
+      [
+        86.7,
+        "assistant"
+      ],
+      [
+        86.8,
+        "tool_result"
+      ],
+      [
+        86.8,
+        "tool_result"
+      ],
+      [
+        107.1,
+        "assistant"
+      ],
+      [
+        107.6,
+        "assistant"
+      ],
+      [
+        108.1,
+        "assistant"
+      ],
+      [
+        108.1,
+        "tool_result"
+      ],
+      [
+        111.0,
+        "assistant"
+      ],
+      [
+        111.4,
+        "assistant"
+      ],
+      [
+        111.9,
+        "assistant"
+      ],
+      [
+        112.2,
+        "tool_result"
+      ],
+      [
+        112.9,
+        "tool_result"
+      ],
+      [
+        115.6,
+        "assistant"
+      ],
+      [
+        116.5,
+        "assistant"
+      ],
+      [
+        117.2,
+        "assistant"
+      ],
+      [
+        119.1,
+        "tool_result"
+      ],
+      [
+        120.2,
+        "tool_result"
+      ],
+      [
+        180.5,
+        "assistant"
+      ],
+      [
+        180.5,
+        "assistant"
+      ],
+      [
+        208.5,
+        "assistant"
+      ],
+      [
+        208.6,
+        "tool_result"
+      ],
+      [
+        225.2,
+        "assistant"
+      ],
+      [
+        225.2,
+        "assistant"
+      ],
+      [
+        230.8,
+        "assistant"
+      ],
+      [
+        230.8,
+        "tool_result"
+      ],
+      [
+        230.8,
+        "tool_result"
+      ],
+      [
+        234.9,
+        "assistant"
+      ],
+      [
+        235.8,
+        "assistant"
+      ],
+      [
+        235.8,
+        "tool_result"
+      ],
+      [
+        240.1,
+        "assistant"
+      ],
+      [
+        240.4,
+        "assistant"
+      ],
+      [
+        241.3,
+        "tool_result"
+      ],
+      [
+        293.4,
+        "assistant"
+      ],
+      [
+        294.0,
+        "assistant"
+      ],
+      [
+        302.3,
+        "assistant"
+      ],
+      [
+        302.7,
+        "tool_result"
+      ],
+      [
+        306.6,
+        "assistant"
+      ],
+      [
+        308.4,
+        "assistant"
+      ],
+      [
+        308.4,
+        "tool_result"
+      ],
+      [
+        310.5,
+        "assistant"
+      ],
+      [
+        311.4,
+        "assistant"
+      ],
+      [
+        311.6,
+        "assistant"
+      ],
+      [
+        312.8,
+        "tool_result"
+      ],
+      [
+        341.6,
+        "assistant"
+      ],
+      [
+        342.3,
+        "assistant"
+      ],
+      [
+        350.4,
+        "assistant"
+      ],
+      [
+        350.4,
+        "tool_result"
+      ],
+      [
+        353.8,
+        "assistant"
+      ],
+      [
+        353.9,
+        "tool_result"
+      ],
+      [
+        358.5,
+        "assistant"
+      ],
+      [
+        358.9,
+        "assistant"
+      ],
+      [
+        361.3,
+        "assistant"
+      ],
+      [
+        361.6,
+        "tool_result"
+      ],
+      [
+        364.4,
+        "assistant"
+      ],
+      [
+        365.6,
+        "assistant"
+      ],
+      [
+        367.2,
+        "assistant"
+      ],
+      [
+        367.5,
+        "tool_result"
+      ],
+      [
+        418.7,
+        "assistant"
+      ],
+      [
+        420.1,
+        "assistant"
+      ],
+      [
+        420.4,
+        "assistant"
+      ],
+      [
+        421.6,
+        "tool_result"
+      ],
+      [
+        438.3,
+        "assistant"
+      ],
+      [
+        439.6,
+        "assistant"
+      ],
+      [
+        451.5,
+        "assistant"
+      ],
+      [
+        451.5,
+        "tool_result"
+      ],
+      [
+        460.8,
+        "assistant"
+      ],
+      [
+        460.9,
+        "assistant"
+      ],
+      [
+        461.4,
+        "assistant"
+      ],
+      [
+        462.6,
+        "tool_result"
+      ],
+      [
+        463.7,
+        "assistant"
+      ],
+      [
+        465.0,
+        "tool_result"
+      ],
+      [
+        468.9,
+        "assistant"
+      ],
+      [
+        470.0,
+        "assistant"
+      ],
+      [
+        470.1,
+        "tool_result"
+      ],
+      [
+        474.6,
+        "assistant"
+      ],
+      [
+        474.6,
+        "tool_result"
+      ],
+      [
+        477.4,
+        "assistant"
+      ],
+      [
+        477.6,
+        "tool_result"
+      ],
+      [
+        479.8,
+        "assistant"
+      ],
+      [
+        481.7,
+        "assistant"
+      ],
+      [
+        481.7,
+        "tool_result"
+      ],
+      [
+        484.8,
+        "assistant"
+      ],
+      [
+        484.8,
+        "tool_result"
+      ],
+      [
+        487.6,
+        "assistant"
+      ],
+      [
+        489.4,
+        "assistant"
+      ],
+      [
+        489.4,
+        "tool_result"
+      ],
+      [
+        493.1,
+        "assistant"
+      ],
+      [
+        494.8,
+        "assistant"
+      ],
+      [
+        496.8,
+        "assistant"
+      ],
+      [
+        496.8,
+        "tool_result"
+      ],
+      [
+        500.1,
+        "assistant"
+      ],
+      [
+        500.5,
+        "tool_result"
+      ],
+      [
+        501.5,
+        "assistant"
+      ],
+      [
+        501.8,
+        "tool_result"
+      ],
+      [
+        517.6,
+        "assistant"
+      ],
+      [
+        519.3,
+        "assistant"
+      ],
+      [
+        526.7,
+        "assistant"
+      ],
+      [
+        526.7,
+        "tool_result"
+      ],
+      [
+        536.2,
+        "assistant"
+      ],
+      [
+        536.2,
+        "tool_result"
+      ],
+      [
+        541.2,
+        "assistant"
+      ],
+      [
+        542.9,
+        "assistant"
+      ],
+      [
+        542.9,
+        "tool_result"
+      ],
+      [
+        545.2,
+        "assistant"
+      ],
+      [
+        547.0,
+        "assistant"
+      ],
+      [
+        548.0,
+        "tool_result"
+      ],
+      [
+        548.7,
+        "assistant"
+      ],
+      [
+        548.8,
+        "tool_result"
+      ],
+      [
+        563.0,
+        "assistant"
+      ],
+      [
+        563.6,
+        "assistant"
+      ],
+      [
+        569.8,
+        "assistant"
+      ],
+      [
+        570.3,
+        "tool_result"
+      ],
+      [
+        573.8,
+        "assistant"
+      ],
+      [
+        573.8,
+        "tool_result"
+      ],
+      [
+        581.1,
+        "assistant"
+      ],
+      [
+        581.2,
+        "assistant"
+      ],
+      [
+        583.1,
+        "assistant"
+      ],
+      [
+        583.1,
+        "tool_result"
+      ],
+      [
+        587.5,
+        "assistant"
+      ],
+      [
+        588.0,
+        "tool_result"
+      ],
+      [
+        589.0,
+        "assistant"
+      ],
+      [
+        589.3,
+        "tool_result"
+      ],
+      [
+        604.2,
+        "assistant"
+      ],
+      [
+        604.9,
+        "assistant"
+      ],
+      [
+        611.6,
+        "assistant"
+      ],
+      [
+        611.7,
+        "tool_result"
+      ],
+      [
+        615.9,
+        "assistant"
+      ],
+      [
+        615.9,
+        "tool_result"
+      ],
+      [
+        654.4,
+        "assistant"
+      ],
+      [
+        654.5,
+        "assistant"
+      ],
+      [
+        656.5,
+        "assistant"
+      ],
+      [
+        656.5,
+        "tool_result"
+      ],
+      [
+        660.6,
+        "assistant"
+      ],
+      [
+        662.0,
+        "tool_result"
+      ],
+      [
+        662.4,
+        "assistant"
+      ],
+      [
+        663.2,
+        "tool_result"
+      ],
+      [
+        666.0,
+        "assistant"
+      ],
+      [
+        668.3,
+        "assistant"
+      ],
+      [
+        668.9,
+        "tool_result"
+      ],
+      [
+        669.8,
+        "assistant"
+      ],
+      [
+        669.9,
+        "tool_result"
+      ],
+      [
+        672.1,
+        "assistant"
+      ],
+      [
+        673.9,
+        "assistant"
+      ],
+      [
+        674.3,
+        "tool_result"
+      ],
+      [
+        675.9,
+        "assistant"
+      ],
+      [
+        675.9,
+        "tool_result"
+      ],
+      [
+        680.0,
+        "assistant"
+      ],
+      [
+        681.7,
+        "assistant"
+      ],
+      [
+        681.8,
+        "tool_result"
+      ],
+      [
+        689.3,
+        "assistant"
+      ],
+      [
+        690.0,
+        "assistant"
+      ],
+      [
+        692.6,
+        "assistant"
+      ],
+      [
+        693.1,
+        "tool_result"
+      ],
+      [
+        710.7,
+        "assistant"
+      ],
+      [
+        711.0,
+        "assistant"
+      ],
+      [
+        711.3,
+        "assistant"
+      ],
+      [
+        711.3,
+        "tool_result"
+      ],
+      [
+        714.4,
+        "assistant"
+      ],
+      [
+        714.7,
+        "assistant"
+      ],
+      [
+        714.7,
+        "tool_result"
+      ],
+      [
+        741.1,
+        "assistant"
+      ],
+      [
+        741.6,
+        "assistant"
+      ],
+      [
+        745.0,
+        "assistant"
+      ],
+      [
+        746.0,
+        "tool_result"
+      ],
+      [
+        746.8,
+        "assistant"
+      ],
+      [
+        747.3,
+        "tool_result"
+      ],
+      [
+        750.9,
+        "assistant"
+      ],
+      [
+        752.9,
+        "assistant"
+      ],
+      [
+        753.4,
+        "tool_result"
+      ],
+      [
+        754.5,
+        "assistant"
+      ],
+      [
+        754.7,
+        "tool_result"
+      ],
+      [
+        765.8,
+        "assistant"
+      ],
+      [
+        765.9,
+        "assistant"
+      ],
+      [
+        765.9,
+        "tool_result"
+      ],
+      [
+        772.9,
+        "assistant"
+      ],
+      [
+        772.9,
+        "assistant"
+      ],
+      [
+        775.7,
+        "assistant"
+      ],
+      [
+        776.2,
+        "tool_result"
+      ],
+      [
+        776.9,
+        "assistant"
+      ],
+      [
+        777.0,
+        "tool_result"
+      ],
+      [
+        779.1,
+        "assistant"
+      ],
+      [
+        780.0,
+        "assistant"
+      ],
+      [
+        781.4,
+        "assistant"
+      ],
+      [
+        781.9,
+        "tool_result"
+      ],
+      [
+        782.8,
+        "assistant"
+      ],
+      [
+        783.1,
+        "tool_result"
+      ],
+      [
+        796.3,
+        "assistant"
+      ],
+      [
+        797.4,
+        "assistant"
+      ],
+      [
+        798.9,
+        "assistant"
+      ],
+      [
+        799.8,
+        "tool_result"
+      ],
+      [
+        800.0,
+        "assistant"
+      ],
+      [
+        800.9,
+        "tool_result"
+      ],
+      [
+        893.7,
+        "assistant"
+      ],
+      [
+        894.6,
+        "assistant"
+      ],
+      [
+        904.4,
+        "assistant"
+      ],
+      [
+        904.4,
+        "tool_result"
+      ],
+      [
+        904.4,
+        "system:status"
+      ],
+      [
+        1033.3,
+        "system:status"
+      ],
+      [
+        1033.4,
+        "system:compact_boundary"
+      ],
+      [
+        1033.4,
+        "tool_result"
+      ],
+      [
+        1037.0,
+        "assistant"
+      ],
+      [
+        1037.4,
+        "assistant"
+      ],
+      [
+        1037.6,
+        "tool_result"
+      ],
+      [
+        1053.2,
+        "assistant"
+      ],
+      [
+        1054.0,
+        "assistant"
+      ],
+      [
+        1054.1,
+        "tool_result"
+      ],
+      [
+        1090.5,
+        "assistant"
+      ],
+      [
+        1090.5,
+        "assistant"
+      ],
+      [
+        1090.5,
+        "assistant"
+      ],
+      [
+        1090.6,
+        "assistant"
+      ],
+      [
+        1090.9,
+        "tool_result"
+      ],
+      [
+        1090.9,
+        "assistant"
+      ],
+      [
+        1091.1,
+        "tool_result"
+      ],
+      [
+        1091.3,
+        "tool_result"
+      ],
+      [
+        1106.4,
+        "assistant"
+      ],
+      [
+        1107.0,
+        "assistant"
+      ],
+      [
+        1109.6,
+        "assistant"
+      ],
+      [
+        1110.0,
+        "tool_result"
+      ],
+      [
+        1111.0,
+        "assistant"
+      ],
+      [
+        1112.0,
+        "tool_result"
+      ],
+      [
+        1112.1,
+        "assistant"
+      ],
+      [
+        1112.4,
+        "tool_result"
+      ],
+      [
+        1122.9,
+        "assistant"
+      ],
+      [
+        1122.9,
+        "assistant"
+      ],
+      [
+        1129.5,
+        "assistant"
+      ],
+      [
+        1130.0,
+        "tool_result"
+      ],
+      [
+        1131.0,
+        "assistant"
+      ],
+      [
+        1131.0,
+        "tool_result"
+      ],
+      [
+        1133.0,
+        "assistant"
+      ],
+      [
+        1133.0,
+        "tool_result"
+      ],
+      [
+        1141.7,
+        "assistant"
+      ],
+      [
+        1141.8,
+        "assistant"
+      ],
+      [
+        1142.6,
+        "tool_result"
+      ],
+      [
+        1142.9,
+        "assistant"
+      ],
+      [
+        1143.3,
+        "tool_result"
+      ],
+      [
+        1150.0,
+        "assistant"
+      ],
+      [
+        1152.0,
+        "assistant"
+      ],
+      [
+        1152.9,
+        "tool_result"
+      ],
+      [
+        1153.8,
+        "assistant"
+      ],
+      [
+        1153.9,
+        "tool_result"
+      ],
+      [
+        1156.9,
+        "assistant"
+      ],
+      [
+        1158.0,
+        "assistant"
+      ],
+      [
+        1158.2,
+        "tool_result"
+      ],
+      [
+        1190.3,
+        "assistant"
+      ],
+      [
+        1190.7,
+        "assistant"
+      ],
+      [
+        1194.0,
+        "assistant"
+      ],
+      [
+        1194.6,
+        "tool_result"
+      ],
+      [
+        1195.6,
+        "assistant"
+      ],
+      [
+        1198.6,
+        "tool_result"
+      ],
+      [
+        1198.6,
+        "assistant"
+      ],
+      [
+        1198.9,
+        "tool_result"
+      ],
+      [
+        1234.7,
+        "assistant"
+      ],
+      [
+        1235.5,
+        "assistant"
+      ],
+      [
+        1236.9,
+        "assistant"
+      ],
+      [
+        1237.6,
+        "tool_result"
+      ],
+      [
+        1238.8,
+        "assistant"
+      ],
+      [
+        1239.5,
+        "tool_result"
+      ],
+      [
+        1268.1,
+        "assistant"
+      ],
+      [
+        1268.1,
+        "assistant"
+      ],
+      [
+        1268.1,
+        "assistant"
+      ],
+      [
+        1268.1,
+        "assistant"
+      ],
+      [
+        1268.7,
+        "tool_result"
+      ],
+      [
+        1269.0,
+        "tool_result"
+      ],
+      [
+        1274.8,
+        "assistant"
+      ],
+      [
+        1276.8,
+        "assistant"
+      ],
+      [
+        1276.8,
+        "tool_result"
+      ],
+      [
+        1280.0,
+        "assistant"
+      ],
+      [
+        1281.0,
+        "assistant"
+      ],
+      [
+        1281.2,
+        "tool_result"
+      ],
+      [
+        1358.8,
+        "assistant"
+      ],
+      [
+        1360.2,
+        "assistant"
+      ],
+      [
+        1366.5,
+        "assistant"
+      ],
+      [
+        1367.0,
+        "tool_result"
+      ],
+      [
+        1371.3,
+        "assistant"
+      ],
+      [
+        1371.4,
+        "tool_result"
+      ],
+      [
+        1375.7,
+        "assistant"
+      ],
+      [
+        1383.7,
+        "assistant"
+      ],
+      [
+        1384.2,
+        "tool_result"
+      ],
+      [
+        1387.2,
+        "assistant"
+      ],
+      [
+        1387.3,
+        "tool_result"
+      ],
+      [
+        1399.9,
+        "assistant"
+      ],
+      [
+        1400.4,
+        "tool_result"
+      ],
+      [
+        1407.1,
+        "assistant"
+      ],
+      [
+        1407.1,
+        "tool_result"
+      ],
+      [
+        1415.0,
+        "assistant"
+      ],
+      [
+        1415.4,
+        "tool_result"
+      ],
+      [
+        1421.2,
+        "assistant"
+      ],
+      [
+        1421.2,
+        "tool_result"
+      ],
+      [
+        1457.4,
+        "assistant"
+      ],
+      [
+        1457.4,
+        "assistant"
+      ],
+      [
+        1458.0,
+        "assistant"
+      ],
+      [
+        1458.4,
+        "tool_result"
+      ],
+      [
+        1462.2,
+        "assistant"
+      ],
+      [
+        1462.2,
+        "tool_result"
+      ],
+      [
+        1469.7,
+        "assistant"
+      ],
+      [
+        1469.7,
+        "assistant"
+      ],
+      [
+        1478.2,
+        "assistant"
+      ],
+      [
+        1478.2,
+        "tool_result"
+      ],
+      [
+        1488.7,
+        "assistant"
+      ],
+      [
+        1489.1,
+        "assistant"
+      ],
+      [
+        1490.0,
+        "assistant"
+      ],
+      [
+        1490.0,
+        "tool_result"
+      ],
+      [
+        1498.9,
+        "assistant"
+      ],
+      [
+        1500.3,
+        "assistant"
+      ],
+      [
+        1500.4,
+        "tool_result"
+      ],
+      [
+        1531.4,
+        "assistant"
+      ],
+      [
+        1532.8,
+        "assistant"
+      ],
+      [
+        1532.9,
+        "tool_result"
+      ],
+      [
+        1538.1,
+        "assistant"
+      ],
+      [
+        1540.6,
+        "assistant"
+      ],
+      [
+        1540.6,
+        "tool_result"
+      ],
+      [
+        1572.4,
+        "assistant"
+      ],
+      [
+        1572.7,
+        "assistant"
+      ],
+      [
+        1580.3,
+        "assistant"
+      ],
+      [
+        1580.3,
+        "tool_result"
+      ],
+      [
+        1591.4,
+        "assistant"
+      ],
+      [
+        1591.5,
+        "assistant"
+      ],
+      [
+        1598.3,
+        "assistant"
+      ],
+      [
+        1598.4,
+        "tool_result"
+      ],
+      [
+        1605.7,
+        "assistant"
+      ],
+      [
+        1605.7,
+        "tool_result"
+      ],
+      [
+        1647.4,
+        "assistant"
+      ],
+      [
+        1647.4,
+        "assistant"
+      ],
+      [
+        1682.3,
+        "assistant"
+      ],
+      [
+        1682.3,
+        "tool_result"
+      ],
+      [
+        1696.5,
+        "assistant"
+      ],
+      [
+        1696.8,
+        "assistant"
+      ],
+      [
+        1698.7,
+        "assistant"
+      ],
+      [
+        1698.7,
+        "tool_result"
+      ],
+      [
+        1701.5,
+        "assistant"
+      ],
+      [
+        1702.0,
+        "tool_result"
+      ],
+      [
+        1702.0,
+        "assistant"
+      ],
+      [
+        1702.1,
+        "tool_result"
+      ],
+      [
+        1705.3,
+        "assistant"
+      ],
+      [
+        1707.3,
+        "assistant"
+      ],
+      [
+        1707.4,
+        "tool_result"
+      ],
+      [
+        1710.1,
+        "assistant"
+      ],
+      [
+        1710.1,
+        "tool_result"
+      ],
+      [
+        1712.7,
+        "assistant"
+      ],
+      [
+        1712.7,
+        "tool_result"
+      ],
+      [
+        1717.6,
+        "assistant"
+      ],
+      [
+        1717.7,
+        "tool_result"
+      ],
+      [
+        1717.7,
+        "system:status"
+      ],
+      [
+        1861.1,
+        "system:status"
+      ],
+      [
+        1861.1,
+        "system:compact_boundary"
+      ],
+      [
+        1861.1,
+        "tool_result"
+      ],
+      [
+        1865.0,
+        "assistant"
+      ],
+      [
+        1866.2,
+        "assistant"
+      ],
+      [
+        1866.2,
+        "tool_result"
+      ],
+      [
+        1869.3,
+        "assistant"
+      ],
+      [
+        1871.5,
+        "assistant"
+      ],
+      [
+        1871.5,
+        "tool_result"
+      ],
+      [
+        1875.6,
+        "assistant"
+      ],
+      [
+        1875.6,
+        "tool_result"
+      ],
+      [
+        1880.2,
+        "assistant"
+      ],
+      [
+        1880.3,
+        "tool_result"
+      ],
+      [
+        1884.2,
+        "assistant"
+      ],
+      [
+        1884.3,
+        "tool_result"
+      ],
+      [
+        2055.7,
+        "assistant"
+      ],
+      [
+        2113.3,
+        "assistant"
+      ],
+      [
+        2113.3,
+        "tool_result"
+      ],
+      [
+        2134.1,
+        "assistant"
+      ],
+      [
+        2134.1,
+        "assistant"
+      ],
+      [
+        2134.3,
+        "assistant"
+      ],
+      [
+        2134.4,
+        "tool_result"
+      ],
+      [
+        2138.2,
+        "assistant"
+      ],
+      [
+        2138.2,
+        "tool_result"
+      ],
+      [
+        2142.0,
+        "assistant"
+      ],
+      [
+        2142.0,
+        "tool_result"
+      ],
+      [
+        2146.2,
+        "assistant"
+      ],
+      [
+        2146.2,
+        "tool_result"
+      ],
+      [
+        2150.3,
+        "assistant"
+      ],
+      [
+        2150.5,
+        "tool_result"
+      ],
+      [
+        2200.3,
+        "assistant"
+      ],
+      [
+        2200.4,
+        "assistant"
+      ],
+      [
+        2233.8,
+        "assistant"
+      ],
+      [
+        2233.9,
+        "tool_result"
+      ],
+      [
+        2261.5,
+        "assistant"
+      ],
+      [
+        2261.5,
+        "assistant"
+      ],
+      [
+        2266.1,
+        "assistant"
+      ],
+      [
+        2266.2,
+        "tool_result"
+      ],
+      [
+        2300.9,
+        "assistant"
+      ],
+      [
+        2300.9,
+        "assistant"
+      ],
+      [
+        2308.0,
+        "assistant"
+      ],
+      [
+        2308.1,
+        "tool_result"
+      ],
+      [
+        2311.7,
+        "assistant"
+      ],
+      [
+        2311.8,
+        "tool_result"
+      ],
+      [
+        2316.4,
+        "assistant"
+      ],
+      [
+        2316.9,
+        "assistant"
+      ],
+      [
+        2317.7,
+        "assistant"
+      ],
+      [
+        2317.7,
+        "tool_result"
+      ],
+      [
+        2319.9,
+        "assistant"
+      ],
+      [
+        2320.3,
+        "assistant"
+      ],
+      [
+        2335.0,
+        "assistant"
+      ],
+      [
+        2335.1,
+        "system:task_started"
+      ],
+      [
+        2335.1,
+        "tool_result"
+      ],
+      [
+        2337.6,
+        "system:task_progress"
+      ],
+      [
+        2337.6,
+        "assistant"
+      ],
+      [
+        2338.1,
+        "tool_result"
+      ],
+      [
+        2338.2,
+        "system:task_progress"
+      ],
+      [
+        2338.2,
+        "assistant"
+      ],
+      [
+        2338.6,
+        "tool_result"
+      ],
+      [
+        2422.8,
+        "system:task_notification"
+      ],
+      [
+        2422.8,
+        "tool_result"
+      ],
+      [
+        2436.8,
+        "assistant"
+      ],
+      [
+        2436.8,
+        "assistant"
+      ],
+      [
+        2436.8,
+        "assistant"
+      ],
+      [
+        2436.9,
+        "tool_result"
+      ],
+      [
+        2473.6,
+        "assistant"
+      ],
+      [
+        2473.7,
+        "tool_result"
+      ],
+      [
+        2478.1,
+        "assistant"
+      ],
+      [
+        2478.1,
+        "tool_result"
+      ],
+      [
+        2485.2,
+        "assistant"
+      ],
+      [
+        2485.2,
+        "assistant"
+      ],
+      [
+        2485.6,
+        "assistant"
+      ],
+      [
+        2485.6,
+        "tool_result"
+      ],
+      [
+        2492.8,
+        "assistant"
+      ],
+      [
+        2492.8,
+        "assistant"
+      ],
+      [
+        2492.9,
+        "tool_result"
+      ],
+      [
+        2496.1,
+        "assistant"
+      ],
+      [
+        2496.4,
+        "assistant"
+      ],
+      [
+        2499.2,
+        "tool_result"
+      ],
+      [
+        2515.0,
+        "assistant"
+      ],
+      [
+        2515.0,
+        "assistant"
+      ],
+      [
+        2518.2,
+        "assistant"
+      ],
+      [
+        2518.5,
+        "tool_result"
+      ],
+      [
+        2521.2,
+        "assistant"
+      ],
+      [
+        2521.3,
+        "tool_result"
+      ],
+      [
+        2524.6,
+        "assistant"
+      ],
+      [
+        2525.4,
+        "assistant"
+      ],
+      [
+        2525.9,
+        "tool_result"
+      ],
+      [
+        2526.3,
+        "assistant"
+      ],
+      [
+        2526.5,
+        "tool_result"
+      ],
+      [
+        2534.1,
+        "assistant"
+      ],
+      [
+        2534.1,
+        "assistant"
+      ],
+      [
+        2534.1,
+        "assistant"
+      ],
+      [
+        2534.9,
+        "tool_result"
+      ],
+      [
+        2535.8,
+        "assistant"
+      ],
+      [
+        2536.8,
+        "tool_result"
+      ],
+      [
+        2554.3,
+        "assistant"
+      ],
+      [
+        2554.3,
+        "assistant"
+      ],
+      [
+        2554.4,
+        "assistant"
+      ],
+      [
+        2554.4,
+        "assistant"
+      ]
+    ],
+    "caps": {
+      "wall_clock_seconds": 3600,
+      "inactivity_seconds": 600,
+      "progress_stall_seconds": 600,
+      "tool_calls": 300,
+      "max_turns": 250,
+      "max_cost_usd": 15.0
+    },
+    "wall_clock_seconds": 2580.635650917,
+    "real_clock_seconds": 2580.656460762024,
+    "slept_seconds": 0.020809845023904927,
+    "judge_seconds": 14.220715584000573
+  },
+  "tool_calls": [
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f/research.json"
+      },
+      "response_summary": "1\t{\n2\t  \"project\": {\n3\t    \"id\": \"rp_ivyl_greenley_daughter\",\n4\t    \"objective\": \"Besides their son Donald, did Ivyl Phylena Greenley and her husband Kenneth Werner Quass have any other children? Identify each additional child and that child's birth and death dates.\",\n5\t    \"subject_person_ids\": [\"KWZP-4Q8\"],\n6\t    \"status\": \"active\",\n7\t    \"created\": \"2026-06-29T00:00:00Z\",\n8\t    \"updated\": \"2026-06-29T00:00:00Z\"\n9\t  },\n10\t  \"researcher_profile\": {\n11\t    \"experience_level\": \"intermediate\",\n..."
+    },
+    {
+      "tool": "Skill",
+      "args": {
+        "skill": "question-selection"
+      },
+      "response_summary": "Launching skill: question-selection"
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f/.claude/skills/question-selection/references/question-formulation.md"
+      },
+      "response_summary": "1\t# Research Question Formulation\n2\t\n3\tGuidance for formulating effective genealogical research questions\n4\tthat satisfy the GPS standard for planned, purposeful research.\n5\t\n6\t## Research Objectives vs. Research Questions\n7\t\n8\tThese are distinct concepts that must not be conflated:\n9\t\n10\t- **Research objective**: The overarching goal of the research effort.\n11\t  It describes what you ultimately want to know (e.g., \"Identify the\n12\t  parents of John Smith born circa 1820 in Greene County, Ohi..."
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f/.claude/skills/question-selection/references/pedigree-analysis.md"
+      },
+      "response_summary": "1\t# Pedigree Analysis for Gap Detection\n2\t\n3\tGuidance for evaluating pedigree data to identify research gaps,\n4\terrors, and candidates for new research questions.\n5\t\n6\t## Purpose\n7\t\n8\tPedigree analysis is the process of systematically reviewing the\n9\tindividuals in a family tree to detect missing information, logical\n10\terrors, and inconsistencies. It is a critical first step before\n11\tselecting new research questions \u2014 it reveals where the gaps are\n12\tand which gaps are most significant.\n13\t..."
+    },
+    {
+      "tool": "Glob",
+      "args": {
+        "pattern": "**/*.json",
+        "path": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f"
+      },
+      "response_summary": ".claude/skills/init-project/templates/research.json\nresearch.json\ntree.gedcomx.json"
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f/tree.gedcomx.json"
+      },
+      "response_summary": "1\t{\n2\t  \"persons\": [\n3\t    {\n4\t      \"id\": \"KWZP-4Q8\",\n5\t      \"gender\": \"Female\",\n6\t      \"living\": false,\n7\t      \"names\": [\n8\t        {\n9\t          \"given\": \"Ivyl Phylena\",\n10\t          \"surname\": \"Greenley\",\n11\t          \"id\": \"KWZP-4Q8-name-1\"\n12\t        }\n13\t      ],\n14\t      \"facts\": [\n15\t        {\n16\t          \"id\": \"248eaba5-34ae-4182-9874-bfcc07166241\",\n17\t          \"type\": \"Birth\",\n18\t          \"date\": \"26 May 1914\",\n19\t          \"standard_date\": \"26 May 1914\",\n20\t          \"place\"..."
+    },
+    {
+      "tool": "ToolSearch",
+      "args": {
+        "query": "select:mcp__genealogy__research_append",
+        "max_results": 1
+      },
+      "response_summary": "[{\"type\": \"tool_reference\", \"tool_name\": \"mcp__genealogy__research_append\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__research_append",
+      "args": {
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f",
+        "section": "questions",
+        "op": "append",
+        "entry": {
+          "question": "Did Kenneth Werner Quass (b. 4 Dec 1917, Sumner, Bremer County, Iowa; d. 17 Sep 1982) and Ivyl Phylena Greenley (b. 26 May 1914, Dubuque County, Iowa; d. 24 May 2005) have any children other than Donald Wendell Quass (b. 16 Jan 1940)?",
+          "rationale": "This is the core research objective. The couple married 6 Mar 1938 and Ivyl was of childbearing age through approximately 1964. The 1940 census shows only Donald (newborn) in the household. Census records (1950), obituaries of Kenneth (1982), Ivyl (2005), and Donald (2024), plus Iowa/Minnesota vital records and the existing FamilySearch source (QK2L-WL7) mentioning 'Bernice H Quass Wegner and Ralph Quass,' may reveal additional children. Direct evidence from original records is required to satisfy GPS.",
+          "selection_basis": "objective_decomposition",
+          "priority": "high",
+          "status": "open",
+          "depends_on": [],
+          "unblocks": [],
+          "resolved": null,
+          "resolution_assertion_ids": [],
+          "exhaustive_declaration": {
+            "declared": false,
+            "justification": null,
+            "log_entry_ids": [],
+            "stop_criteria": null
+          }
+        }
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"section\\\": \\\"questions\\\",\\n  \\\"op\\\": \\\"append\\\",\\n  \\\"entryId\\\": \\\"q_001\\\",\\n  \\\"filesWritten\\\": [\\n    \\\"research.json\\\"\\n  ],\\n  \\\"validation\\\": {\\n    \\\"valid\\\": true,\\n    \\\"warnings\\\": []\\n  }\\n}\"}]"
+    },
+    {
+      "tool": "Skill",
+      "args": {
+        "skill": "research-plan",
+        "args": "q_001"
+      },
+      "response_summary": "Launching skill: research-plan"
+    },
+    {
+      "tool": "ToolSearch",
+      "args": {
+        "query": "select:mcp__genealogy__place_search,mcp__genealogy__collections_search,mcp__genealogy__external_links_search",
+        "max_results": 3
+      },
+      "response_summary": "[{\"type\": \"tool_reference\", \"tool_name\": \"mcp__genealogy__place_search\"}, {\"type\": \"tool_reference\", \"tool_name\": \"mcp__genealogy__collections_search\"}, {\"type\": \"tool_reference\", \"tool_name\": \"mcp__genealogy__external_links_search\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__place_search",
+      "args": {
+        "placeName": "Watonwan County",
+        "contextName": "Minnesota"
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"results\\\": [\\n    {\\n      \\\"standardPlace\\\": \\\"Watonwan, Minnesota, United States\\\",\\n      \\\"type\\\": \\\"County\\\",\\n      \\\"dateRange\\\": \\\"+1860/\\\",\\n      \\\"latitude\\\": 43.96667,\\n      \\\"longitude\\\": -94.61667,\\n      \\\"familysearchUrl\\\": \\\"https://www.familysearch.org/en/research/places/?text=Watonwan&focusedId=394316\\\",\\n      \\\"wikipediaUrl\\\": \\\"https://en.wikipedia.org/wiki/Watonwan_County,_Minnesota\\\"\\n    },\\n    {\\n      \\\"standardPlace\\\": \\\"Brown, M..."
+    },
+    {
+      "tool": "mcp__genealogy__place_search",
+      "args": {
+        "placeName": "Iowa",
+        "contextName": "United States"
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"results\\\": [\\n    {\\n      \\\"standardPlace\\\": \\\"Iowa, United States\\\",\\n      \\\"type\\\": \\\"State\\\",\\n      \\\"dateRange\\\": \\\"+1838/\\\",\\n      \\\"latitude\\\": 42,\\n      \\\"longitude\\\": -93.5,\\n      \\\"familysearchUrl\\\": \\\"https://www.familysearch.org/en/research/places/?text=Iowa&focusedId=364\\\",\\n      \\\"wikipediaUrl\\\": \\\"https://en.wikipedia.org/wiki/Iowa\\\"\\n    },\\n    {\\n      \\\"standardPlace\\\": \\\"Iowa, Wisconsin, United States\\\",\\n      \\\"type\\\": \\\"County\\\",\\..."
+    },
+    {
+      "tool": "mcp__genealogy__collections_search",
+      "args": {
+        "standardPlace": "Minnesota, United States",
+        "startYear": 1938,
+        "endYear": 1965
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"query\\\": {\\n    \\\"standardPlace\\\": \\\"Minnesota, United States\\\",\\n    \\\"startYear\\\": 1938,\\n    \\\"endYear\\\": 1965\\n  },\\n  \\\"scope\\\": \\\"Minnesota\\\",\\n  \\\"totalForPlace\\\": 46,\\n  \\\"results\\\": [\\n    {\\n      \\\"id\\\": \\\"1949334\\\",\\n      \\\"title\\\": \\\"Minnesota, Birth Index, 1935-2002\\\",\\n      \\\"dateRange\\\": \\\"1935-2002\\\",\\n      \\\"recordCount\\\": 4267571,\\n      \\\"personCount\\\": 5632,\\n      \\\"imageCount\\\": 0,\\n      \\\"url\\\": \\\"https://www.familysearch.org/searc..."
+    },
+    {
+      "tool": "mcp__genealogy__external_links_search",
+      "args": {
+        "standardPlace": "Watonwan, Minnesota, United States",
+        "startYear": 1938,
+        "endYear": 1965
+      },
+      "response_summary": "<persisted-output>\nOutput too large (52.6KB). Full output saved to: /Users/dallan/.claude/projects/-private-var-folders-tv-yzyl0n517xj5v54fgn0c0j3h0000gn-T-e2e-ivyl-greenley-daughter-9uoppj5f/bbf38148-6301-4b4b-85c0-51b7f01068c4/tool-results/toolu_01NYdZcuLNzaDGChGUmwL847.json\n\nPreview (first 2KB):\n[\n  {\n    \"type\": \"text\",\n    \"text\": \"{\\n  \\\"query\\\": {\\n    \\\"standardPlace\\\": \\\"Watonwan, Minnesota, United States\\\",\\n    \\\"startYear\\\": 1938,\\n    \\\"endYear\\\": 1965\\n  },\\n  \\\"totalForPlace\\\":..."
+    },
+    {
+      "tool": "mcp__genealogy__research_append",
+      "args": {
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f",
+        "ops": [
+          {
+            "section": "plans",
+            "op": "append",
+            "entry": {
+              "question_id": "q_001",
+              "status": "active",
+              "created": "2026-06-29"
+            }
+          },
+          {
+            "section": "plan_items",
+            "op": "append",
+            "planId": "pl_001",
+            "entry": {
+              "sequence": 1,
+              "record_type": "newspaper",
+              "jurisdiction": "Watonwan County, Minnesota (Madelia area)",
+              "date_range": "2024",
+              "repository": "FamilySearch",
+              "rationale": "Donald Wendell Quass's April 2024 obituary (already cited in tree as source WWDC-3KV, ark:/61903/1:1:XM5X-SPSB) is a direct source likely naming surviving family members including any siblings. Extract and analyze this record to identify whether any siblings of Donald are named.",
+              "fallback_for": null,
+              "status": "planned"
+            }
+          },
+          {
+            "section": "plan_items",
+            "op": "append",
+            "planId": "pl_001",
+            "entry": {
+              "sequence": 2,
+              "record_type": "newspaper",
+              "jurisdiction": "United States",
+              "date_range": "2010",
+              "repository": "FamilySearch",
+              "rationale": "Source QK2L-WL7 (GenealogyBank Obituaries 1980\u20132015, ark:/61903/1:1:QKGC-W3S7) is already cited in the tree with the description 'Entry for Mrs Bernice H Quass Wegner and Ralph Quass, 22 Jun 2010.' The surnames Quass Wegner and Quass are highly suggestive of other children of Kenneth. This record must be read and analyzed to determine whether Bernice and Ralph are children of Kenneth and Ivyl or of another Quass family.",
+              "fallback_for": null,
+              "status": "planned"
+            }
+          },
+          {
+            "section": "plan_items",
+            "op": "append",
+            "planId": "pl_001",
+            "entry": {
+              "sequence": 3,
+              "record_type": "census",
+              "jurisdiction": "Watonwan County, Minnesota",
+              "date_range": "1950",
+              "repository": "FamilySearch",
+              "rationale": "The 1950 US Census (released 2022, indexed on FamilySearch) would capture all household members as of April 1, 1950, including any children of Kenneth and Ivyl then living at home. Kenneth and Ivyl were in Madelia, Watonwan County in 1940; searching that county in 1950 should locate the family and show the composition of the household at that time.",
+              "fallback_for": null,
+              "status": "planned"
+            }
+          },
+          {
+            "section": "plan_items",
+            "op": "append",
+            "planId": "pl_001",
+            "entry": {
+              "sequence": 4,
+              "record_type": "vital_record",
+              "jurisdiction": "Minnesota",
+              "date_range": "1938-1965",
+              "repository": "FamilySearch",
+              "rationale": "Minnesota Birth Index 1935\u20132002 (FS collection 1949334, 4.2M records, indexed) allows searching by parent surname. Searching for births to a Quass father or Greenley/Quass mother in Minnesota during the couple's likely childbearing years (1938\u20131965) would identify any children born and registered in Minnesota.",
+              "fallback_for": null,
+              "status": "planned"
+            }
+          },
+          {
+            "section": "plan_items",
+            "op": "append",
+            "planId": "pl_001",
+            "entry": {
+              "sequence": 5,
+              "record_type": "newspaper",
+              "jurisdiction": "Minnesota",
+              "date_range": "1982",
+              "repository": "FamilySearch",
+              "rationale": "Kenneth Werner Quass died 17 September 1982 in Grapevine, Tarrant County, Texas. An obituary for him \u2014 searchable in Minnesota Obituaries 1865\u20132006 (FS collection 2469546) or GenealogyBank \u2014 would likely name surviving children. This is a priority source because it predates Ivyl's death and would capture children who survived Kenneth.",
+              "fallback_for": null,
+              "status": "planned"
+            }
+          },
+          {
+            "section": "plan_items",
+            "op": "append",
+            "planId": "pl_001",
+            "entry": {
+              "sequence": 6,
+              "record_type": "newspaper",
+              "jurisdiction": "San Diego, California",
+              "date_range": "2005",
+              "repository": "other",
+              "rationale": "Ivyl Phylena Greenley Quass died 24 May 2005 in San Diego, California and was buried in Madelia, Watonwan County, Minnesota. Her obituary \u2014 searchable in GenealogyBank, Newspapers.com, or the San Diego Union-Tribune archives \u2014 would name surviving children. This is direct evidence for the research question. The existing source MS62-1FF is only a legacy stub citation, not the full obituary text.",
+              "fallback_for": null,
+              "status": "planned"
+            }
+          },
+          {
+            "section": "plan_items",
+            "op": "append",
+            "planId": "pl_001",
+            "entry": {
+              "sequence": 7,
+              "record_type": "vital_record",
+              "jurisdiction": "Iowa (Fayette County, Watonwan County area)",
+              "date_range": "1938-1942",
+              "repository": "FamilySearch",
+              "rationale": "Donald Wendell Quass was born 16 January 1940 in Randalia, Fayette County, Iowa, suggesting the family may have briefly resided in Iowa early in their marriage (married March 1938). Iowa County Births records (FS collection for Iowa) should be searched to confirm whether any other children were born in Iowa before or around the time of Donald's birth.",
+              "fallback_for": null,
+              "status": "planned"
+            }
+          },
+          {
+            "section": "plan_items",
+            "op": "append",
+            "planId": "pl_001",
+            "entry": {
+              "sequence": 8,
+              "record_type": "other",
+              "jurisdiction": "United States",
+              "date_range": "1938-2005",
+              "repository": "FamilySearch",
+              "rationale": "FamilySearch person record for Kenneth Werner Quass (FamilySearch ID KNS4-P6W) and Ivyl Phylena Greenley (KWZP-4Q8) may have additional children linked by other FamilySearch contributors. Reading the person_person_matches or searching directly for children attached to this couple on FamilySearch provides a cross-check and may surface leads not captured by vital records searches.",
+              "fallback_for": null,
+              "status": "planned"
+            }
+          }
+        ]
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"results\\\": [\\n    {\\n      \\\"section\\\": \\\"plans\\\",\\n      \\\"op\\\": \\\"append\\\",\\n      \\\"entryId\\\": \\\"pl_001\\\"\\n    },\\n    {\\n      \\\"section\\\": \\\"plan_items\\\",\\n      \\\"op\\\": \\\"append\\\",\\n      \\\"entryId\\\": \\\"pli_001\\\"\\n    },\\n    {\\n      \\\"section\\\": \\\"plan_items\\\",\\n      \\\"op\\\": \\\"append\\\",\\n      \\\"entryId\\\": \\\"pli_002\\\"\\n    },\\n    {\\n      \\\"section\\\": \\\"plan_items\\\",\\n      \\\"op\\\": \\\"append\\\",\\n      \\\"entryId\\\": \\\"pli_003\\\"\\n    },..."
+    },
+    {
+      "tool": "Skill",
+      "args": {
+        "skill": "search-records",
+        "args": "Execute plan pl_001 for question q_001. Start with pli_001 (read and extract existing FamilySearch source WWDC-3KV at ark:/61903/1:1:XM5X-SPSB \u2014 Donald Wendell Quass's 2024 obituary), then pli_002 (read and extract existing FamilySearch source QK2L-WL7 at ark:/61903/1:1:QKGC-W3S7 \u2014 GenealogyBank obituary mentioning Bernice H Quass Wegner and Ralph Quass), then pli_003 (search 1950 US Census for Kenneth Quass / Kenneth Werner Quass in Watonwan County, Minnesota), then pli_004 (search Minnesota Birth Index 1935-2002 for Quass births), then pli_005 (search Minnesota Obituaries 1865-2006 for Kenneth Quass d. 1982 in Grapevine TX / Madelia MN area). Project path: /private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f"
+      },
+      "response_summary": "Launching skill: search-records"
+    },
+    {
+      "tool": "ToolSearch",
+      "args": {
+        "query": "select:mcp__genealogy__record_read,mcp__genealogy__research_log_append,mcp__genealogy__same_person,mcp__genealogy__record_search",
+        "max_results": 4
+      },
+      "response_summary": "[{\"type\": \"tool_reference\", \"tool_name\": \"mcp__genealogy__record_read\"}, {\"type\": \"tool_reference\", \"tool_name\": \"mcp__genealogy__research_log_append\"}, {\"type\": \"tool_reference\", \"tool_name\": \"mcp__genealogy__same_person\"}, {\"type\": \"tool_reference\", \"tool_name\": \"mcp__genealogy__record_search\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__record_read",
+      "args": {
+        "recordId": "ark:/61903/1:1:XM5X-SPSB"
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"persons\\\": [\\n    {\\n      \\\"id\\\": \\\"p_306774614781\\\",\\n      \\\"ark\\\": \\\"ark:/61903/1:1:XM5X-SPSL\\\",\\n      \\\"gender\\\": \\\"Male\\\",\\n      \\\"names\\\": [\\n        {\\n          \\\"id\\\": \\\"1dcf5d75-3c0e-49ef-aa0e-180854c3650e\\\",\\n          \\\"type\\\": \\\"BirthName\\\",\\n          \\\"given\\\": \\\"Donald Wendell\\\",\\n          \\\"surname\\\": \\\"Quass\\\"\\n        }\\n      ],\\n      \\\"facts\\\": [\\n        {\\n          \\\"id\\\": \\\"bd1540c2-061d-4d82-828f-92562d24a652\\\",\\n          \\\"typ..."
+    },
+    {
+      "tool": "mcp__genealogy__research_log_append",
+      "args": {
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f",
+        "tool": "record_read",
+        "planItemId": "pli_001",
+        "query": {
+          "recordId": "ark:/61903/1:1:XM5X-SPSB",
+          "description": "Donald Wendell Quass 2024 obituary, source WWDC-3KV, FamilySearch United States Obituary Records 2014-2023"
+        },
+        "outcome": "positive",
+        "resultsExamined": 1,
+        "resultsAvailable": 1,
+        "notes": "Obituary for Donald Wendell Quass (b. 16 Jan 1940, d. 25 Apr 2024) lists three siblings who are also children of Kenneth Werner Quass and Phylena Ivyl Greenley: (1) Ken Quass [male, surname Quass, married Bobbi Quass]; (2) Pat Norman [female, born Quass, married Bob Norman \u2014 sibling-in-law relationship]; (3) Jeanette [female, no surname given]. All three named as children of Kenneth Werner Quass (p_306774614787) and Phylena Ivyl Greenley (p_306774614788) via ParentChild relationships. Additionally listed is Linnea, identified as Donald's grandchild via Grandparent relationship. Record ARKs: Ken Quass ark:/61903/1:1:XM5X-SPSP; Jeanette ark:/61903/1:1:XM5X-SPS1; Pat Norman ark:/61903/1:1:XM5X-SPSR."
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"logId\\\": \\\"log_001\\\",\\n  \\\"performed\\\": \\\"2026-06-29T21:46:05.306Z\\\",\\n  \\\"resultsRef\\\": null,\\n  \\\"returnedCount\\\": null,\\n  \\\"filesWritten\\\": [\\n    \\\"research.json\\\"\\n  ],\\n  \\\"validation\\\": {\\n    \\\"valid\\\": true,\\n    \\\"warnings\\\": []\\n  }\\n}\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__research_append",
+      "args": {
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f",
+        "section": "plan_items",
+        "op": "update",
+        "planId": "pl_001",
+        "entryId": "pli_001",
+        "fields": {
+          "status": "in_progress"
+        }
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"section\\\": \\\"plan_items\\\",\\n  \\\"op\\\": \\\"update\\\",\\n  \\\"entryId\\\": \\\"pli_001\\\",\\n  \\\"filesWritten\\\": [\\n    \\\"research.json\\\"\\n  ],\\n  \\\"validation\\\": {\\n    \\\"valid\\\": true,\\n    \\\"warnings\\\": []\\n  }\\n}\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__record_read",
+      "args": {
+        "recordId": "ark:/61903/1:1:QKGC-W3S7"
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"persons\\\": [\\n    {\\n      \\\"id\\\": \\\"p_101873054449\\\",\\n      \\\"ark\\\": \\\"ark:/61903/1:1:QKGC-WSLK\\\",\\n      \\\"gender\\\": \\\"Female\\\",\\n      \\\"names\\\": [\\n        {\\n          \\\"id\\\": \\\"e2965eb8-08aa-4cdc-80d8-4088ae8b2167\\\",\\n          \\\"type\\\": \\\"BirthName\\\",\\n          \\\"prefix\\\": \\\"Mrs\\\",\\n          \\\"surname\\\": \\\"Quass Wegner\\\",\\n          \\\"given\\\": \\\"Bernice H\\\"\\n        }\\n      ],\\n      \\\"facts\\\": [\\n        {\\n          \\\"id\\\": \\\"d02cb0a1-524c-4c66-a..."
+    },
+    {
+      "tool": "mcp__genealogy__research_log_append",
+      "args": {
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f",
+        "tool": "record_read",
+        "planItemId": "pli_002",
+        "query": {
+          "recordId": "ark:/61903/1:1:QKGC-W3S7",
+          "description": "GenealogyBank obituary for Bernice H. Quass Wegner (d. 19 Jun 2010), source QK2L-WL7, FamilySearch United States GenealogyBank Obituaries 1980-2015"
+        },
+        "outcome": "partial",
+        "resultsExamined": 1,
+        "resultsAvailable": 1,
+        "notes": "Obituary is for Bernice H. Quass Wegner (b. 29 Aug 1926, Buchanan County, Iowa; d. 19 Jun 2010, Waterloo, Iowa), published 22 Jun 2010. Parents: Ralph Quass and Emma Nehls Quass. Husband: Ralph Wegner. Siblings of Bernice include: Kenneth Quass (= Kenneth Werner Quass, our research subject), Norman Quass, Wayne Quass, Lucille Quass Clemens, Dorothy Quass Ostrander. 'Avyl Quass' listed as sibling-in-law = Ivyl Phylena Greenley Quass (variant spelling). This confirms Kenneth Werner Quass is Bernice's brother. This record is about Kenneth's family of origin \u2014 his parents and siblings \u2014 NOT about children of Kenneth and Ivyl. Ralph Quass is Kenneth's father, not a son. Bernice is Kenneth's sister, not a daughter. No new children of Kenneth and Ivyl identified here."
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"logId\\\": \\\"log_002\\\",\\n  \\\"performed\\\": \\\"2026-06-29T21:46:53.313Z\\\",\\n  \\\"resultsRef\\\": null,\\n  \\\"returnedCount\\\": null,\\n  \\\"filesWritten\\\": [\\n    \\\"research.json\\\"\\n  ],\\n  \\\"validation\\\": {\\n    \\\"valid\\\": true,\\n    \\\"warnings\\\": []\\n  }\\n}\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__research_append",
+      "args": {
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f",
+        "section": "plan_items",
+        "op": "update",
+        "planId": "pl_001",
+        "entryId": "pli_002",
+        "fields": {
+          "status": "in_progress"
+        }
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"section\\\": \\\"plan_items\\\",\\n  \\\"op\\\": \\\"update\\\",\\n  \\\"entryId\\\": \\\"pli_002\\\",\\n  \\\"filesWritten\\\": [\\n    \\\"research.json\\\"\\n  ],\\n  \\\"validation\\\": {\\n    \\\"valid\\\": true,\\n    \\\"warnings\\\": []\\n  }\\n}\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__record_search",
+      "args": {
+        "surname": "Quass",
+        "givenName": "Kenneth",
+        "birthYearFrom": 1912,
+        "birthYearTo": 1922,
+        "residencePlace": "Watonwan, Minnesota",
+        "residenceYearFrom": 1950,
+        "residenceYearTo": 1950,
+        "recordType": "census",
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f"
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"query\\\": {\\n    \\\"surname\\\": \\\"Quass\\\",\\n    \\\"givenName\\\": \\\"Kenneth\\\",\\n    \\\"birthYearFrom\\\": 1912,\\n    \\\"birthYearTo\\\": 1922,\\n    \\\"residencePlace\\\": \\\"Watonwan, Minnesota\\\",\\n    \\\"residenceYearFrom\\\": 1950,\\n    \\\"residenceYearTo\\\": 1950,\\n    \\\"recordType\\\": \\\"census\\\",\\n    \\\"projectPath\\\": \\\"/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f\\\"\\n  },\\n  \\\"totalMatches\\\": 0,\\n  \\\"paginationCappedAt\\\": 4999,\\n..."
+    },
+    {
+      "tool": "mcp__genealogy__record_search",
+      "args": {
+        "surname": "Quass",
+        "givenName": "Kenneth",
+        "birthYearFrom": 1912,
+        "birthYearTo": 1922,
+        "residenceYearFrom": 1950,
+        "residenceYearTo": 1950,
+        "recordCountry": "United States",
+        "recordSubdivision": "Minnesota",
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f"
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"query\\\": {\\n    \\\"surname\\\": \\\"Quass\\\",\\n    \\\"givenName\\\": \\\"Kenneth\\\",\\n    \\\"birthYearFrom\\\": 1912,\\n    \\\"birthYearTo\\\": 1922,\\n    \\\"residenceYearFrom\\\": 1950,\\n    \\\"residenceYearTo\\\": 1950,\\n    \\\"recordCountry\\\": \\\"United States\\\",\\n    \\\"recordSubdivision\\\": \\\"Minnesota\\\",\\n    \\\"projectPath\\\": \\\"/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f\\\"\\n  },\\n  \\\"totalMatches\\\": 12,\\n  \\\"paginationCappedAt\\\": 499..."
+    },
+    {
+      "tool": "mcp__genealogy__record_read",
+      "args": {
+        "recordId": "ark:/61903/1:1:FDX7-8MF"
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"persons\\\": [\\n    {\\n      \\\"id\\\": \\\"p_11238084915\\\",\\n      \\\"ark\\\": \\\"ark:/61903/1:1:FDX7-8MF\\\",\\n      \\\"gender\\\": \\\"Female\\\",\\n      \\\"names\\\": [\\n        {\\n          \\\"id\\\": \\\"279a9790-02d1-46f6-acd1-600aec1638bc\\\",\\n          \\\"type\\\": \\\"BirthName\\\",\\n          \\\"surname\\\": \\\"Quass\\\",\\n          \\\"given\\\": \\\"Alice Jeannette\\\"\\n        }\\n      ],\\n      \\\"facts\\\": [\\n        {\\n          \\\"id\\\": \\\"39099907-8449-4d99-b91d-f9d02c6ef293\\\",\\n          \\\"ty..."
+    },
+    {
+      "tool": "mcp__genealogy__research_log_append",
+      "args": {
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f",
+        "tool": "record_search",
+        "planItemId": "pli_003",
+        "query": {
+          "surname": "Quass",
+          "givenName": "Kenneth",
+          "birthYearFrom": 1912,
+          "birthYearTo": 1922,
+          "residenceYearFrom": 1950,
+          "residenceYearTo": 1950,
+          "recordCountry": "United States",
+          "recordSubdivision": "Minnesota",
+          "note": "First attempt with Watonwan residencePlace returned 0 results; broadened to all Minnesota"
+        },
+        "outcome": "partial",
+        "resultsExamined": 12,
+        "resultsAvailable": 12,
+        "stagedResultsRef": "results/.staging/a8af03ec-fa3e-4869-9a52-0ac22f8e61e4.json",
+        "notes": "No 1950 census record found for Kenneth Quass \u2014 results came from Find a Grave, Minnesota Birth Index, death records, and the 2024 Donald Quass obituary. The 1950 census collection may not be indexed under this search profile. Key incidental find: Alice Jeanette Quass (Minnesota Birth Index ark:/61903/1:1:VCF7-BY8, parents Kenneth Warner Quass and Ivyl Phylena Greenley, b. 6 Dec 1940, Watonwan MN) and her death record (Minnesota Death Records 1900-1955 ark:/61903/1:1:FDX7-8MF, d. 3 Feb 1955, Madelia MN). This child is the 'Jeanette' named in Donald's 2024 obituary. Also confirmed 'Kenneth Werner Quass Sr' suffix on Find a Grave (KNS4-P6W tree match). The 1950 census search should be retried with collection-specific filter."
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"logId\\\": \\\"log_003\\\",\\n  \\\"performed\\\": \\\"2026-06-29T21:48:34.414Z\\\",\\n  \\\"resultsRef\\\": \\\"results/log_003.json\\\",\\n  \\\"returnedCount\\\": 12,\\n  \\\"filesWritten\\\": [\\n    \\\"research.json\\\",\\n    \\\"results/log_003.json\\\"\\n  ],\\n  \\\"validation\\\": {\\n    \\\"valid\\\": true,\\n    \\\"warnings\\\": []\\n  }\\n}\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__record_read",
+      "args": {
+        "recordId": "ark:/61903/1:1:VCF7-BY8"
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"persons\\\": [\\n    {\\n      \\\"id\\\": \\\"p_13353011021\\\",\\n      \\\"ark\\\": \\\"ark:/61903/1:1:VCF7-BY8\\\",\\n      \\\"names\\\": [\\n        {\\n          \\\"id\\\": \\\"3d005700-ebfc-49b4-b074-0e8418af2ba1\\\",\\n          \\\"type\\\": \\\"BirthName\\\",\\n          \\\"surname\\\": \\\"Quass\\\",\\n          \\\"given\\\": \\\"Alice Jeanette\\\"\\n        }\\n      ],\\n      \\\"facts\\\": [\\n        {\\n          \\\"id\\\": \\\"f6d0cbfc-ef2d-42b5-b33f-1660ae2a8855\\\",\\n          \\\"type\\\": \\\"Birth\\\",\\n          \\\"pr..."
+    },
+    {
+      "tool": "mcp__genealogy__record_search",
+      "args": {
+        "surname": "Quass",
+        "givenName": "Kenneth",
+        "birthYearFrom": 1912,
+        "birthYearTo": 1922,
+        "recordType": "census",
+        "recordCountry": "United States",
+        "anyYearFrom": 1950,
+        "anyYearTo": 1950,
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f"
+      },
+      "response_summary": "Error: result (160,466 characters) exceeds maximum allowed tokens. Output has been saved to /Users/dallan/.claude/projects/-private-var-folders-tv-yzyl0n517xj5v54fgn0c0j3h0000gn-T-e2e-ivyl-greenley-daughter-9uoppj5f/bbf38148-6301-4b4b-85c0-51b7f01068c4/tool-results/mcp-genealogy-record_search-1782769727921.txt.\nFormat: JSON array with schema: [{type: string, text: string}]\nUse offset and limit parameters to read specific portions of the file, search within it for specific content, and jq to m..."
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/Users/dallan/.claude/projects/-private-var-folders-tv-yzyl0n517xj5v54fgn0c0j3h0000gn-T-e2e-ivyl-greenley-daughter-9uoppj5f/bbf38148-6301-4b4b-85c0-51b7f01068c4/tool-results/mcp-genealogy-record_search-1782769727921.txt",
+        "limit": 100
+      },
+      "response_summary": "File content (52060 tokens) exceeds maximum allowed tokens (25000). Use offset and limit parameters to read specific portions of the file, or search for specific content instead of reading the whole file."
+    },
+    {
+      "tool": "Bash",
+      "args": {
+        "command": "cat \"/Users/dallan/.claude/projects/-private-var-folders-tv-yzyl0n517xj5v54fgn0c0j3h0000gn-T-e2e-ivyl-greenley-daughter-9uoppj5f/bbf38148-6301-4b4b-85c0-51b7f01068c4/tool-results/mcp-genealogy-record_search-1782769727921.txt\" | python3 -c \"import sys,json; data=json.load(sys.stdin); text=data[0]['text'] if data else '{}'; obj=json.loads(text); print('totalMatches:', obj.get('totalMatches'), 'returned:', obj.get('returned')); [print(r.get('collectionTitle','?'), '|', r.get('personName','?'), '|', r.get('recordTitle','?'), '|', r.get('score','?')) for r in obj.get('results',[])[:20]]\""
+      },
+      "response_summary": "Permission to use Bash has been denied because Claude Code is running in don't ask mode. IMPORTANT: You *may* attempt to accomplish this action using other tools that might naturally be used to accomplish this goal, e.g. using head instead of cat. But you *should not* attempt to work around this denial in malicious ways, e.g. do not use your ability to run tests to execute non-test actions. You should only try to work around this restriction in reasonable ways that do not attempt to bypass th..."
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/Users/dallan/.claude/projects/-private-var-folders-tv-yzyl0n517xj5v54fgn0c0j3h0000gn-T-e2e-ivyl-greenley-daughter-9uoppj5f/bbf38148-6301-4b4b-85c0-51b7f01068c4/tool-results/mcp-genealogy-record_search-1782769727921.txt",
+        "limit": 50,
+        "offset": 0
+      },
+      "response_summary": "File content (52060 tokens) exceeds maximum allowed tokens (25000). Use offset and limit parameters to read specific portions of the file, or search for specific content instead of reading the whole file."
+    },
+    {
+      "tool": "Grep",
+      "args": {
+        "pattern": "\"totalMatches\"|\"collectionTitle\"|\"personName\"|Census 1950",
+        "path": "/Users/dallan/.claude/projects/-private-var-folders-tv-yzyl0n517xj5v54fgn0c0j3h0000gn-T-e2e-ivyl-greenley-daughter-9uoppj5f/bbf38148-6301-4b4b-85c0-51b7f01068c4/tool-results/mcp-genealogy-record_search-1782769727921.txt",
+        "output_mode": "content",
+        "head_limit": 30
+      },
+      "response_summary": "No matches found"
+    },
+    {
+      "tool": "Grep",
+      "args": {
+        "pattern": "totalMatches|collectionTitle|Census",
+        "path": "/Users/dallan/.claude/projects/-private-var-folders-tv-yzyl0n517xj5v54fgn0c0j3h0000gn-T-e2e-ivyl-greenley-daughter-9uoppj5f/bbf38148-6301-4b4b-85c0-51b7f01068c4/tool-results/mcp-genealogy-record_search-1782769727921.txt",
+        "output_mode": "content",
+        "head_limit": 30
+      },
+      "response_summary": "4:[Omitted long matching line]"
+    },
+    {
+      "tool": "Grep",
+      "args": {
+        "pattern": "1950 Census|United States Census, 1950|census.*1950",
+        "path": "/Users/dallan/.claude/projects/-private-var-folders-tv-yzyl0n517xj5v54fgn0c0j3h0000gn-T-e2e-ivyl-greenley-daughter-9uoppj5f/bbf38148-6301-4b4b-85c0-51b7f01068c4/tool-results/mcp-genealogy-record_search-1782769727921.txt",
+        "output_mode": "content",
+        "-i": true,
+        "head_limit": 10
+      },
+      "response_summary": "4:[Omitted long matching line]"
+    },
+    {
+      "tool": "mcp__genealogy__research_append",
+      "args": {
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f",
+        "section": "plan_items",
+        "op": "update",
+        "planId": "pl_001",
+        "entryId": "pli_003",
+        "fields": {
+          "status": "in_progress"
+        }
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"section\\\": \\\"plan_items\\\",\\n  \\\"op\\\": \\\"update\\\",\\n  \\\"entryId\\\": \\\"pli_003\\\",\\n  \\\"filesWritten\\\": [\\n    \\\"research.json\\\"\\n  ],\\n  \\\"validation\\\": {\\n    \\\"valid\\\": true,\\n    \\\"warnings\\\": []\\n  }\\n}\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__record_search",
+      "args": {
+        "surname": "Quass",
+        "givenName": "Kenneth",
+        "birthYearFrom": 1912,
+        "birthYearTo": 1922,
+        "collectionId": "3948617",
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f"
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"query\\\": {\\n    \\\"surname\\\": \\\"Quass\\\",\\n    \\\"givenName\\\": \\\"Kenneth\\\",\\n    \\\"birthYearFrom\\\": 1912,\\n    \\\"birthYearTo\\\": 1922,\\n    \\\"collectionId\\\": \\\"3948617\\\",\\n    \\\"projectPath\\\": \\\"/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f\\\"\\n  },\\n  \\\"totalMatches\\\": 0,\\n  \\\"paginationCappedAt\\\": 4999,\\n  \\\"returned\\\": 0,\\n  \\\"offset\\\": 0,\\n  \\\"hasMore\\\": false,\\n  \\\"results\\\": [],\\n  \\\"staged\\\": null\\n}\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__record_search",
+      "args": {
+        "fatherSurname": "Quass",
+        "motherSurname": "Greenley",
+        "collectionId": "1949334",
+        "recordCountry": "United States",
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f"
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"query\\\": {\\n    \\\"fatherSurname\\\": \\\"Quass\\\",\\n    \\\"motherSurname\\\": \\\"Greenley\\\",\\n    \\\"collectionId\\\": \\\"1949334\\\",\\n    \\\"recordCountry\\\": \\\"United States\\\",\\n    \\\"projectPath\\\": \\\"/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f\\\"\\n  },\\n  \\\"totalMatches\\\": 1,\\n  \\\"paginationCappedAt\\\": 4999,\\n  \\\"returned\\\": 1,\\n  \\\"offset\\\": 0,\\n  \\\"hasMore\\\": false,\\n  \\\"results\\\": [\\n    {\\n      \\\"recordId\\\": \\\"ark:/6190..."
+    },
+    {
+      "tool": "mcp__genealogy__research_log_append",
+      "args": {
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f",
+        "tool": "record_search",
+        "planItemId": "pli_003",
+        "query": {
+          "surname": "Quass",
+          "givenName": "Kenneth",
+          "birthYearFrom": 1912,
+          "birthYearTo": 1922,
+          "collectionId": "3948617",
+          "description": "US 1950 Census \u2014 collection ID 3948617"
+        },
+        "outcome": "negative",
+        "resultsExamined": 0,
+        "resultsAvailable": 0,
+        "notes": "Zero results. Collection ID 3948617 may be incorrect for the US 1950 Census on FamilySearch, or Kenneth Quass is not yet indexed in it. The family was in Madelia, Watonwan County in 1940; expected to remain there in 1950. 1950 census search is inconclusive \u2014 would require browsing the unindexed images or using a correct collection ID. Will rely on birth/death records and obituaries for household composition evidence."
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"logId\\\": \\\"log_004\\\",\\n  \\\"performed\\\": \\\"2026-06-29T21:49:49.651Z\\\",\\n  \\\"resultsRef\\\": null,\\n  \\\"returnedCount\\\": null,\\n  \\\"filesWritten\\\": [\\n    \\\"research.json\\\"\\n  ],\\n  \\\"validation\\\": {\\n    \\\"valid\\\": true,\\n    \\\"warnings\\\": []\\n  }\\n}\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__research_log_append",
+      "args": {
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f",
+        "tool": "record_search",
+        "planItemId": "pli_004",
+        "query": {
+          "fatherSurname": "Quass",
+          "motherSurname": "Greenley",
+          "collectionId": "1949334",
+          "recordCountry": "United States",
+          "description": "Minnesota Birth Index 1935-2002, father surname Quass + mother surname Greenley"
+        },
+        "outcome": "positive",
+        "resultsExamined": 1,
+        "resultsAvailable": 1,
+        "stagedResultsRef": "results/.staging/20c90db1-23d6-47e8-81cc-40b3c5977d6b.json",
+        "notes": "Only one result: Alice Jeanette Quass (b. 6 Dec 1940, Watonwan, Minnesota), father Kenneth Warner Quass, mother Ivyl Phylena Greenley (ark:/61903/1:1:VCF7-BY8). No other children registered in the Minnesota Birth Index under this parent combination. 'Ken Quass' and 'Pat Norman (born Quass)' \u2014 identified as siblings in Donald's 2024 obituary \u2014 do not appear here. They may have been born in Iowa, California, or another state, or their birth records in MN use a different spelling of parent names. Broader search needed."
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"logId\\\": \\\"log_005\\\",\\n  \\\"performed\\\": \\\"2026-06-29T21:49:59.109Z\\\",\\n  \\\"resultsRef\\\": \\\"results/log_005.json\\\",\\n  \\\"returnedCount\\\": 1,\\n  \\\"filesWritten\\\": [\\n    \\\"research.json\\\",\\n    \\\"results/log_005.json\\\"\\n  ],\\n  \\\"validation\\\": {\\n    \\\"valid\\\": true,\\n    \\\"warnings\\\": []\\n  }\\n}\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__research_append",
+      "args": {
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f",
+        "section": "plan_items",
+        "op": "update",
+        "planId": "pl_001",
+        "entryId": "pli_004",
+        "fields": {
+          "status": "in_progress"
+        }
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"section\\\": \\\"plan_items\\\",\\n  \\\"op\\\": \\\"update\\\",\\n  \\\"entryId\\\": \\\"pli_004\\\",\\n  \\\"filesWritten\\\": [\\n    \\\"research.json\\\"\\n  ],\\n  \\\"validation\\\": {\\n    \\\"valid\\\": true,\\n    \\\"warnings\\\": []\\n  }\\n}\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__record_search",
+      "args": {
+        "fatherGivenName": "Kenneth",
+        "fatherSurname": "Quass",
+        "motherGivenName": "Ivyl",
+        "collectionId": "1949334",
+        "recordCountry": "United States",
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f"
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"query\\\": {\\n    \\\"fatherGivenName\\\": \\\"Kenneth\\\",\\n    \\\"fatherSurname\\\": \\\"Quass\\\",\\n    \\\"motherGivenName\\\": \\\"Ivyl\\\",\\n    \\\"collectionId\\\": \\\"1949334\\\",\\n    \\\"recordCountry\\\": \\\"United States\\\",\\n    \\\"projectPath\\\": \\\"/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f\\\"\\n  },\\n  \\\"totalMatches\\\": 1,\\n  \\\"paginationCappedAt\\\": 4999,\\n  \\\"returned\\\": 1,\\n  \\\"offset\\\": 0,\\n  \\\"hasMore\\\": false,\\n  \\\"results\\\": [\\n ..."
+    },
+    {
+      "tool": "mcp__genealogy__record_search",
+      "args": {
+        "surname": "Quass",
+        "givenName": "Kenneth",
+        "deathYearFrom": 1978,
+        "deathYearTo": 1986,
+        "collectionId": "2469546",
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f"
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"query\\\": {\\n    \\\"surname\\\": \\\"Quass\\\",\\n    \\\"givenName\\\": \\\"Kenneth\\\",\\n    \\\"deathYearFrom\\\": 1978,\\n    \\\"deathYearTo\\\": 1986,\\n    \\\"collectionId\\\": \\\"2469546\\\",\\n    \\\"projectPath\\\": \\\"/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f\\\"\\n  },\\n  \\\"totalMatches\\\": 0,\\n  \\\"paginationCappedAt\\\": 4999,\\n  \\\"returned\\\": 0,\\n  \\\"offset\\\": 0,\\n  \\\"hasMore\\\": false,\\n  \\\"results\\\": [],\\n  \\\"staged\\\": null\\n}\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__research_log_append",
+      "args": {
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f",
+        "tool": "record_search",
+        "planItemId": "pli_004",
+        "query": {
+          "fatherGivenName": "Kenneth",
+          "fatherSurname": "Quass",
+          "motherGivenName": "Ivyl",
+          "collectionId": "1949334",
+          "description": "Minnesota Birth Index 1935-2002, father Kenneth Quass + mother Ivyl"
+        },
+        "outcome": "positive",
+        "resultsExamined": 1,
+        "resultsAvailable": 1,
+        "stagedResultsRef": "results/.staging/1b24fa2a-58d3-42aa-add4-40c6dbb5c715.json",
+        "notes": "Again only Alice Jeanette Quass returned (b. 6 Dec 1940, Watonwan MN). No other children of Kenneth and Ivyl found in Minnesota Birth Index regardless of parameter variation. 'Ken Quass' and 'Pat Norman (Quass)' siblings named in Donald's 2024 obituary are not registered as births in MN under these parents. They were likely born in Iowa or another state, or their birth records in MN use different parent name spellings."
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"logId\\\": \\\"log_006\\\",\\n  \\\"performed\\\": \\\"2026-06-29T21:50:32.747Z\\\",\\n  \\\"resultsRef\\\": \\\"results/log_006.json\\\",\\n  \\\"returnedCount\\\": 1,\\n  \\\"filesWritten\\\": [\\n    \\\"research.json\\\",\\n    \\\"results/log_006.json\\\"\\n  ],\\n  \\\"validation\\\": {\\n    \\\"valid\\\": true,\\n    \\\"warnings\\\": []\\n  }\\n}\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__research_log_append",
+      "args": {
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f",
+        "tool": "record_search",
+        "planItemId": "pli_005",
+        "query": {
+          "surname": "Quass",
+          "givenName": "Kenneth",
+          "deathYearFrom": 1978,
+          "deathYearTo": 1986,
+          "collectionId": "2469546",
+          "description": "Minnesota Obituaries 1865-2006 for Kenneth Quass d. 1982"
+        },
+        "outcome": "negative",
+        "resultsExamined": 0,
+        "resultsAvailable": 0,
+        "notes": "No Minnesota obituary found for Kenneth Quass (d. 17 Sep 1982). Expected \u2014 he died in Grapevine, Tarrant County, Texas; his obituary would likely appear in Texas newspapers or GenealogyBank, not Minnesota newspaper obituary collections. Will search external sites (GenealogyBank/Newspapers.com) for his obituary."
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"logId\\\": \\\"log_007\\\",\\n  \\\"performed\\\": \\\"2026-06-29T21:50:36.711Z\\\",\\n  \\\"resultsRef\\\": null,\\n  \\\"returnedCount\\\": null,\\n  \\\"filesWritten\\\": [\\n    \\\"research.json\\\"\\n  ],\\n  \\\"validation\\\": {\\n    \\\"valid\\\": true,\\n    \\\"warnings\\\": []\\n  }\\n}\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__research_append",
+      "args": {
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f",
+        "section": "plan_items",
+        "op": "update",
+        "planId": "pl_001",
+        "entryId": "pli_005",
+        "fields": {
+          "status": "in_progress"
+        }
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"section\\\": \\\"plan_items\\\",\\n  \\\"op\\\": \\\"update\\\",\\n  \\\"entryId\\\": \\\"pli_005\\\",\\n  \\\"filesWritten\\\": [\\n    \\\"research.json\\\"\\n  ],\\n  \\\"validation\\\": {\\n    \\\"valid\\\": true,\\n    \\\"warnings\\\": []\\n  }\\n}\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__record_search",
+      "args": {
+        "surname": "Quass",
+        "givenName": "Kenneth",
+        "birthYearFrom": 1941,
+        "birthYearTo": 1952,
+        "fatherSurname": "Quass",
+        "collectionId": "1949334",
+        "recordCountry": "United States",
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f"
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"query\\\": {\\n    \\\"surname\\\": \\\"Quass\\\",\\n    \\\"givenName\\\": \\\"Kenneth\\\",\\n    \\\"birthYearFrom\\\": 1941,\\n    \\\"birthYearTo\\\": 1952,\\n    \\\"fatherSurname\\\": \\\"Quass\\\",\\n    \\\"collectionId\\\": \\\"1949334\\\",\\n    \\\"recordCountry\\\": \\\"United States\\\",\\n    \\\"projectPath\\\": \\\"/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f\\\"\\n  },\\n  \\\"totalMatches\\\": 4,\\n  \\\"paginationCappedAt\\\": 4999,\\n  \\\"returned\\\": 4,\\n  \\\"offset\\\": 0..."
+    },
+    {
+      "tool": "mcp__genealogy__record_search",
+      "args": {
+        "fatherSurname": "Quass",
+        "motherSurname": "Greenley",
+        "recordCountry": "United States",
+        "recordSubdivision": "Iowa",
+        "recordType": "birth",
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f"
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"query\\\": {\\n    \\\"fatherSurname\\\": \\\"Quass\\\",\\n    \\\"motherSurname\\\": \\\"Greenley\\\",\\n    \\\"recordCountry\\\": \\\"United States\\\",\\n    \\\"recordSubdivision\\\": \\\"Iowa\\\",\\n    \\\"recordType\\\": \\\"birth\\\",\\n    \\\"projectPath\\\": \\\"/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f\\\"\\n  },\\n  \\\"totalMatches\\\": 0,\\n  \\\"paginationCappedAt\\\": 4999,\\n  \\\"returned\\\": 0,\\n  \\\"offset\\\": 0,\\n  \\\"hasMore\\\": false,\\n  \\\"results\\\": [],\\n  ..."
+    },
+    {
+      "tool": "mcp__genealogy__research_log_append",
+      "args": {
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f",
+        "tool": "record_search",
+        "planItemId": "pli_004",
+        "query": {
+          "surname": "Quass",
+          "givenName": "Kenneth",
+          "birthYearFrom": 1941,
+          "birthYearTo": 1952,
+          "fatherSurname": "Quass",
+          "collectionId": "1949334",
+          "description": "MN Birth Index \u2014 Kenneth Quass as child born 1941-1952"
+        },
+        "outcome": "negative",
+        "resultsExamined": 4,
+        "resultsAvailable": 4,
+        "stagedResultsRef": "results/.staging/86aa5a74-dee8-4ba1-b98e-1f67e0eb0e26.json",
+        "notes": "All 4 results show 'Kenneth Warner Quass Jr' as FATHER of children born 1965-1974 in Hennepin County MN \u2014 not as a child born in the target range. Ken Quass Jr's own birth record not found in Minnesota Birth Index. Similarly no Iowa birth record for Quass + Greenley parents. Ken's and Pat's birth records not located in indexed collections; may require browsing unindexed county birth registers or searching other states."
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"logId\\\": \\\"log_008\\\",\\n  \\\"performed\\\": \\\"2026-06-29T21:51:14.602Z\\\",\\n  \\\"resultsRef\\\": \\\"results/log_008.json\\\",\\n  \\\"returnedCount\\\": 4,\\n  \\\"filesWritten\\\": [\\n    \\\"research.json\\\",\\n    \\\"results/log_008.json\\\"\\n  ],\\n  \\\"validation\\\": {\\n    \\\"valid\\\": true,\\n    \\\"warnings\\\": []\\n  }\\n}\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__research_log_append",
+      "args": {
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f",
+        "tool": "record_search",
+        "planItemId": "pli_007",
+        "query": {
+          "fatherSurname": "Quass",
+          "motherSurname": "Greenley",
+          "recordCountry": "United States",
+          "recordSubdivision": "Iowa",
+          "recordType": "birth",
+          "description": "Iowa birth records for Quass + Greenley children"
+        },
+        "outcome": "negative",
+        "resultsExamined": 0,
+        "resultsAvailable": 0,
+        "notes": "No Iowa birth records found for children of Kenneth Quass and Ivyl Greenley. Donald's 1940 birth was in Randalia, Fayette County, Iowa, but no other children appear registered in Iowa birth indexes. Family moved to Watonwan County, MN by mid-1940. Remaining siblings (Ken, Pat) not located in Iowa or Minnesota birth indexes \u2014 birth dates unknown from vital records searches."
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"logId\\\": \\\"log_009\\\",\\n  \\\"performed\\\": \\\"2026-06-29T21:51:18.837Z\\\",\\n  \\\"resultsRef\\\": null,\\n  \\\"returnedCount\\\": null,\\n  \\\"filesWritten\\\": [\\n    \\\"research.json\\\"\\n  ],\\n  \\\"validation\\\": {\\n    \\\"valid\\\": true,\\n    \\\"warnings\\\": []\\n  }\\n}\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__research_append",
+      "args": {
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f",
+        "section": "plan_items",
+        "op": "update",
+        "planId": "pl_001",
+        "entryId": "pli_007",
+        "fields": {
+          "status": "in_progress"
+        }
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"section\\\": \\\"plan_items\\\",\\n  \\\"op\\\": \\\"update\\\",\\n  \\\"entryId\\\": \\\"pli_007\\\",\\n  \\\"filesWritten\\\": [\\n    \\\"research.json\\\"\\n  ],\\n  \\\"validation\\\": {\\n    \\\"valid\\\": true,\\n    \\\"warnings\\\": []\\n  }\\n}\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__record_search",
+      "args": {
+        "surname": "Quass",
+        "givenName": "Kenneth",
+        "deathYearFrom": 1980,
+        "deathYearTo": 1984,
+        "collectionId": "2333694",
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f"
+      },
+      "response_summary": "Error: result (142,236 characters) exceeds maximum allowed tokens. Output has been saved to /Users/dallan/.claude/projects/-private-var-folders-tv-yzyl0n517xj5v54fgn0c0j3h0000gn-T-e2e-ivyl-greenley-daughter-9uoppj5f/bbf38148-6301-4b4b-85c0-51b7f01068c4/tool-results/mcp-genealogy-record_search-1782769924493.txt.\nFormat: JSON array with schema: [{type: string, text: string}]\nUse offset and limit parameters to read specific portions of the file, search within it for specific content, and jq to m..."
+    },
+    {
+      "tool": "mcp__genealogy__record_search",
+      "args": {
+        "surname": "Quass",
+        "givenName": "Kenneth",
+        "deathYearFrom": 1980,
+        "deathYearTo": 1984,
+        "deathPlace": "Texas",
+        "recordCountry": "United States",
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f"
+      },
+      "response_summary": "Error: result (94,287 characters) exceeds maximum allowed tokens. Output has been saved to /Users/dallan/.claude/projects/-private-var-folders-tv-yzyl0n517xj5v54fgn0c0j3h0000gn-T-e2e-ivyl-greenley-daughter-9uoppj5f/bbf38148-6301-4b4b-85c0-51b7f01068c4/tool-results/mcp-genealogy-record_search-1782769926144.txt.\nFormat: JSON array with schema: [{type: string, text: string}]\nUse offset and limit parameters to read specific portions of the file, search within it for specific content, and jq to ma..."
+    },
+    {
+      "tool": "Grep",
+      "args": {
+        "pattern": "Kenneth.*Quass|Quass.*Kenneth|totalMatches",
+        "path": "/Users/dallan/.claude/projects/-private-var-folders-tv-yzyl0n517xj5v54fgn0c0j3h0000gn-T-e2e-ivyl-greenley-daughter-9uoppj5f/bbf38148-6301-4b4b-85c0-51b7f01068c4/tool-results/mcp-genealogy-record_search-1782769924493.txt",
+        "output_mode": "content",
+        "head_limit": 20
+      },
+      "response_summary": "4:[Omitted long matching line]"
+    },
+    {
+      "tool": "Grep",
+      "args": {
+        "pattern": "Kenneth.*Quass|Quass.*Kenneth|totalMatches",
+        "path": "/Users/dallan/.claude/projects/-private-var-folders-tv-yzyl0n517xj5v54fgn0c0j3h0000gn-T-e2e-ivyl-greenley-daughter-9uoppj5f/bbf38148-6301-4b4b-85c0-51b7f01068c4/tool-results/mcp-genealogy-record_search-1782769926144.txt",
+        "output_mode": "content",
+        "head_limit": 20
+      },
+      "response_summary": "4:[Omitted long matching line]"
+    },
+    {
+      "tool": "Grep",
+      "args": {
+        "pattern": "Werner Quass",
+        "path": "/Users/dallan/.claude/projects/-private-var-folders-tv-yzyl0n517xj5v54fgn0c0j3h0000gn-T-e2e-ivyl-greenley-daughter-9uoppj5f/bbf38148-6301-4b4b-85c0-51b7f01068c4/tool-results/mcp-genealogy-record_search-1782769924493.txt",
+        "output_mode": "count"
+      },
+      "response_summary": "No matches found\n\nFound 0 total occurrences across 0 files."
+    },
+    {
+      "tool": "Grep",
+      "args": {
+        "pattern": "Ivyl|Greenley|Madelia|Watonwan|Grapevine|1917",
+        "path": "/Users/dallan/.claude/projects/-private-var-folders-tv-yzyl0n517xj5v54fgn0c0j3h0000gn-T-e2e-ivyl-greenley-daughter-9uoppj5f/bbf38148-6301-4b4b-85c0-51b7f01068c4/tool-results/mcp-genealogy-record_search-1782769926144.txt",
+        "output_mode": "count"
+      },
+      "response_summary": "/Users/dallan/.claude/projects/-private-var-folders-tv-yzyl0n517xj5v54fgn0c0j3h0000gn-T-e2e-ivyl-greenley-daughter-9uoppj5f/bbf38148-6301-4b4b-85c0-51b7f01068c4/tool-results/mcp-genealogy-record_search-1782769926144.txt:1\n\nFound 1 total occurrence across 1 file."
+    },
+    {
+      "tool": "Grep",
+      "args": {
+        "pattern": "Ivyl|Greenley|Madelia|Watonwan|Grapevine|1917",
+        "path": "/Users/dallan/.claude/projects/-private-var-folders-tv-yzyl0n517xj5v54fgn0c0j3h0000gn-T-e2e-ivyl-greenley-daughter-9uoppj5f/bbf38148-6301-4b4b-85c0-51b7f01068c4/tool-results/mcp-genealogy-record_search-1782769926144.txt",
+        "output_mode": "content",
+        "-C": 2
+      },
+      "response_summary": "2-  {\n3-    \"type\": \"text\",\n4:[Omitted long matching line]\n5-  }\n6-]"
+    },
+    {
+      "tool": "mcp__genealogy__record_search",
+      "args": {
+        "surname": "Quass",
+        "givenName": "Kenneth",
+        "birthYearFrom": 1912,
+        "birthYearTo": 1922,
+        "deathYearFrom": 1980,
+        "deathYearTo": 1985,
+        "recordCountry": "United States",
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f"
+      },
+      "response_summary": "Error: result (103,741 characters) exceeds maximum allowed tokens. Output has been saved to /Users/dallan/.claude/projects/-private-var-folders-tv-yzyl0n517xj5v54fgn0c0j3h0000gn-T-e2e-ivyl-greenley-daughter-9uoppj5f/bbf38148-6301-4b4b-85c0-51b7f01068c4/tool-results/mcp-genealogy-record_search-1782769956083.txt.\nFormat: JSON array with schema: [{type: string, text: string}]\nUse offset and limit parameters to read specific portions of the file, search within it for specific content, and jq to m..."
+    },
+    {
+      "tool": "ToolSearch",
+      "args": {
+        "query": "select:mcp__genealogy__person_read",
+        "max_results": 1
+      },
+      "response_summary": "[{\"type\": \"tool_reference\", \"tool_name\": \"mcp__genealogy__person_read\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__person_read",
+      "args": {
+        "personId": "KNS4-P6W",
+        "relatives": true
+      },
+      "response_summary": "person_read is disabled in e2e benchmark runs. Reading the tree would hand you the stripped answer for free. Recover it through records instead (record_search, record_read, fulltext_search, image_search, \u2026)."
+    },
+    {
+      "tool": "mcp__genealogy__record_search",
+      "args": {
+        "surname": "Quass",
+        "givenName": "Ivyl",
+        "birthYearFrom": 1909,
+        "birthYearTo": 1919,
+        "recordType": "census",
+        "recordCountry": "United States",
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f"
+      },
+      "response_summary": "Error: result (106,178 characters) exceeds maximum allowed tokens. Output has been saved to /Users/dallan/.claude/projects/-private-var-folders-tv-yzyl0n517xj5v54fgn0c0j3h0000gn-T-e2e-ivyl-greenley-daughter-9uoppj5f/bbf38148-6301-4b4b-85c0-51b7f01068c4/tool-results/mcp-genealogy-record_search-1782770008664.txt.\nFormat: JSON array with schema: [{type: string, text: string}]\nUse offset and limit parameters to read specific portions of the file, search within it for specific content, and jq to m..."
+    },
+    {
+      "tool": "mcp__genealogy__record_search",
+      "args": {
+        "surname": "Quass",
+        "givenName": "Patricia",
+        "recordCountry": "United States",
+        "recordSubdivision": "Minnesota",
+        "anyYearFrom": 1955,
+        "anyYearTo": 1975,
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f"
+      },
+      "response_summary": "Error: result (106,457 characters) exceeds maximum allowed tokens. Output has been saved to /Users/dallan/.claude/projects/-private-var-folders-tv-yzyl0n517xj5v54fgn0c0j3h0000gn-T-e2e-ivyl-greenley-daughter-9uoppj5f/bbf38148-6301-4b4b-85c0-51b7f01068c4/tool-results/mcp-genealogy-record_search-1782770010282.txt.\nFormat: JSON array with schema: [{type: string, text: string}]\nUse offset and limit parameters to read specific portions of the file, search within it for specific content, and jq to m..."
+    },
+    {
+      "tool": "Grep",
+      "args": {
+        "pattern": "1950|Census|Watonwan|Madelia|Phylena",
+        "path": "/Users/dallan/.claude/projects/-private-var-folders-tv-yzyl0n517xj5v54fgn0c0j3h0000gn-T-e2e-ivyl-greenley-daughter-9uoppj5f/bbf38148-6301-4b4b-85c0-51b7f01068c4/tool-results/mcp-genealogy-record_search-1782770008664.txt",
+        "output_mode": "count"
+      },
+      "response_summary": "/Users/dallan/.claude/projects/-private-var-folders-tv-yzyl0n517xj5v54fgn0c0j3h0000gn-T-e2e-ivyl-greenley-daughter-9uoppj5f/bbf38148-6301-4b4b-85c0-51b7f01068c4/tool-results/mcp-genealogy-record_search-1782770008664.txt:1\n\nFound 1 total occurrence across 1 file."
+    },
+    {
+      "tool": "Grep",
+      "args": {
+        "pattern": "Norman|Patricia|Pat Quass",
+        "path": "/Users/dallan/.claude/projects/-private-var-folders-tv-yzyl0n517xj5v54fgn0c0j3h0000gn-T-e2e-ivyl-greenley-daughter-9uoppj5f/bbf38148-6301-4b4b-85c0-51b7f01068c4/tool-results/mcp-genealogy-record_search-1782770010282.txt",
+        "output_mode": "count"
+      },
+      "response_summary": "/Users/dallan/.claude/projects/-private-var-folders-tv-yzyl0n517xj5v54fgn0c0j3h0000gn-T-e2e-ivyl-greenley-daughter-9uoppj5f/bbf38148-6301-4b4b-85c0-51b7f01068c4/tool-results/mcp-genealogy-record_search-1782770010282.txt:1\n\nFound 1 total occurrence across 1 file."
+    },
+    {
+      "tool": "ToolSearch",
+      "args": {
+        "query": "select:mcp__genealogy__fulltext_search",
+        "max_results": 1
+      },
+      "response_summary": "[{\"type\": \"tool_reference\", \"tool_name\": \"mcp__genealogy__fulltext_search\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__fulltext_search",
+      "args": {
+        "keywords": "+\"Ivyl\" +\"Quass\"",
+        "recordType": "Obituary",
+        "yearFrom": 2003,
+        "yearTo": 2007,
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f",
+        "count": 10
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"query\\\": {\\n    \\\"keywords\\\": \\\"+\\\\\\\"Ivyl\\\\\\\" +\\\\\\\"Quass\\\\\\\"\\\",\\n    \\\"recordType\\\": \\\"Obituary\\\",\\n    \\\"yearFrom\\\": 2003,\\n    \\\"yearTo\\\": 2007,\\n    \\\"projectPath\\\": \\\"/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f\\\",\\n    \\\"count\\\": 10\\n  },\\n  \\\"totalResults\\\": 0,\\n  \\\"returned\\\": 0,\\n  \\\"offset\\\": 0,\\n  \\\"hasMore\\\": false,\\n  \\\"results\\\": [],\\n  \\\"staged\\\": null\\n}\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__fulltext_search",
+      "args": {
+        "keywords": "+\"Kenneth\" +\"Quass\"",
+        "recordType": "Obituary",
+        "yearFrom": 1980,
+        "yearTo": 1985,
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f",
+        "count": 10
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"query\\\": {\\n    \\\"keywords\\\": \\\"+\\\\\\\"Kenneth\\\\\\\" +\\\\\\\"Quass\\\\\\\"\\\",\\n    \\\"recordType\\\": \\\"Obituary\\\",\\n    \\\"yearFrom\\\": 1980,\\n    \\\"yearTo\\\": 1985,\\n    \\\"projectPath\\\": \\\"/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f\\\",\\n    \\\"count\\\": 10\\n  },\\n  \\\"totalResults\\\": 0,\\n  \\\"returned\\\": 0,\\n  \\\"offset\\\": 0,\\n  \\\"hasMore\\\": false,\\n  \\\"results\\\": [],\\n  \\\"staged\\\": null\\n}\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__fulltext_search",
+      "args": {
+        "keywords": "+Ivyl +Quass +obituary",
+        "yearFrom": 2003,
+        "yearTo": 2008,
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f",
+        "count": 10
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"query\\\": {\\n    \\\"keywords\\\": \\\"+Ivyl +Quass +obituary\\\",\\n    \\\"yearFrom\\\": 2003,\\n    \\\"yearTo\\\": 2008,\\n    \\\"projectPath\\\": \\\"/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f\\\",\\n    \\\"count\\\": 10\\n  },\\n  \\\"totalResults\\\": 0,\\n  \\\"returned\\\": 0,\\n  \\\"offset\\\": 0,\\n  \\\"hasMore\\\": false,\\n  \\\"results\\\": [],\\n  \\\"staged\\\": null\\n}\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__fulltext_search",
+      "args": {
+        "keywords": "+Kenneth +Quass +Madelia",
+        "yearFrom": 1980,
+        "yearTo": 1985,
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f",
+        "count": 10
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"query\\\": {\\n    \\\"keywords\\\": \\\"+Kenneth +Quass +Madelia\\\",\\n    \\\"yearFrom\\\": 1980,\\n    \\\"yearTo\\\": 1985,\\n    \\\"projectPath\\\": \\\"/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f\\\",\\n    \\\"count\\\": 10\\n  },\\n  \\\"totalResults\\\": 0,\\n  \\\"returned\\\": 0,\\n  \\\"offset\\\": 0,\\n  \\\"hasMore\\\": false,\\n  \\\"results\\\": [],\\n  \\\"staged\\\": null\\n}\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__fulltext_search",
+      "args": {
+        "keywords": "+Ivyl +Quass",
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f",
+        "count": 10
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"query\\\": {\\n    \\\"keywords\\\": \\\"+Ivyl +Quass\\\",\\n    \\\"projectPath\\\": \\\"/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f\\\",\\n    \\\"count\\\": 10\\n  },\\n  \\\"totalResults\\\": 5,\\n  \\\"returned\\\": 5,\\n  \\\"offset\\\": 0,\\n  \\\"hasMore\\\": false,\\n  \\\"results\\\": [\\n    {\\n      \\\"id\\\": \\\"ark:/61903/3:1:3QS7-8992-XXT\\\",\\n      \\\"sourceUrl\\\": \\\"https://www.familysearch.org/ark:/61903/3:1:3QS7-8992-XXT\\\",\\n      \\\"collectionId\\\": \\..."
+    },
+    {
+      "tool": "mcp__genealogy__fulltext_search",
+      "args": {
+        "keywords": "+Quass +Grapevine",
+        "yearFrom": 1980,
+        "yearTo": 1985,
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f",
+        "count": 10
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"query\\\": {\\n    \\\"keywords\\\": \\\"+Quass +Grapevine\\\",\\n    \\\"yearFrom\\\": 1980,\\n    \\\"yearTo\\\": 1985,\\n    \\\"projectPath\\\": \\\"/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f\\\",\\n    \\\"count\\\": 10\\n  },\\n  \\\"totalResults\\\": 0,\\n  \\\"returned\\\": 0,\\n  \\\"offset\\\": 0,\\n  \\\"hasMore\\\": false,\\n  \\\"results\\\": [],\\n  \\\"staged\\\": null\\n}\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__research_log_append",
+      "args": {
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f",
+        "tool": "fulltext_search",
+        "planItemId": "pli_005",
+        "query": {
+          "keywords": "+Ivyl +Quass",
+          "description": "Fulltext search for Ivyl Quass across all collections, no year filter"
+        },
+        "outcome": "positive",
+        "resultsExamined": 5,
+        "resultsAvailable": 5,
+        "stagedResultsRef": "results/.staging/3b987110-6f57-462a-b0bd-4cf70780fd22.json",
+        "notes": "5 results. Most significant: (1) Texas Death Certificate 1982 (ark:/61903/3:1:3QS7-8992-XXT, collection M9J1-953) for Kenneth Quass: DoD Sep 17 1982, DoB 12-4-1917, place Tarrant County TX (Grapevine), surviving spouse Ivyl Greenley, residence San Diego CA (5941 Lancaster Drive), informant = Kenneth Quass Jr. (SON \u2014 confirms Ken Jr. is a child), father Ralph K. Quass, mother Emma Nehls, SS# 483-03-9478, buried Madelia Cemetery Watonwan MN. (2) Iowa Marriage 1938 (Buchanan Co.): Kenneth W. Quass + Ivyl P. Greenley married March 5, 1938. (3) Herbert Thomas Greenley obituary 1963: Ivyl Quass was living in Glendale, CA. (4) Watonwan County Death Record Index confirming Alice Jeannette Quass, parents Kenneth Quass and Ivyl Greenley. Family was in San Diego by 1982; moved to California between 1955 and 1963."
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"logId\\\": \\\"log_010\\\",\\n  \\\"performed\\\": \\\"2026-06-29T21:56:07.376Z\\\",\\n  \\\"resultsRef\\\": \\\"results/log_010.json\\\",\\n  \\\"returnedCount\\\": 5,\\n  \\\"filesWritten\\\": [\\n    \\\"research.json\\\",\\n    \\\"results/log_010.json\\\"\\n  ],\\n  \\\"validation\\\": {\\n    \\\"valid\\\": true,\\n    \\\"warnings\\\": []\\n  }\\n}\"}]"
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f/research.json"
+      },
+      "response_summary": "1\t{\n2\t  \"project\": {\n3\t    \"id\": \"rp_ivyl_greenley_daughter\",\n4\t    \"objective\": \"Besides their son Donald, did Ivyl Phylena Greenley and her husband Kenneth Werner Quass have any other children? Identify each additional child and that child's birth and death dates.\",\n5\t    \"subject_person_ids\": [\n6\t      \"KWZP-4Q8\"\n7\t    ],\n8\t    \"status\": \"active\",\n9\t    \"created\": \"2026-06-29T00:00:00Z\",\n10\t    \"updated\": \"2026-06-29T00:00:00Z\"\n11\t  },\n12\t  \"researcher_profile\": {\n13\t    \"experience_level\"..."
+    },
+    {
+      "tool": "ToolSearch",
+      "args": {
+        "query": "select:mcp__genealogy__record_search,mcp__genealogy__record_read,mcp__genealogy__fulltext_search,mcp__genealogy__research_append,mcp__genealogy__research_log_append",
+        "max_results": 5
+      },
+      "response_summary": "[{\"type\": \"tool_reference\", \"tool_name\": \"mcp__genealogy__record_search\"}, {\"type\": \"tool_reference\", \"tool_name\": \"mcp__genealogy__record_read\"}, {\"type\": \"tool_reference\", \"tool_name\": \"mcp__genealogy__fulltext_search\"}, {\"type\": \"tool_reference\", \"tool_name\": \"mcp__genealogy__research_append\"}, {\"type\": \"tool_reference\", \"tool_name\": \"mcp__genealogy__research_log_append\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__record_read",
+      "args": {
+        "recordId": "ark:/61903/3:1:3QS7-8992-XXT"
+      },
+      "response_summary": "{\"error\":\"Record 3QS7-8992-XXT was not found in FamilySearch historical records.\"}"
+    },
+    {
+      "tool": "mcp__genealogy__record_read",
+      "args": {
+        "recordId": "ark:/61903/1:1:XM5X-SPSR"
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"persons\\\": [\\n    {\\n      \\\"id\\\": \\\"p_306774614781\\\",\\n      \\\"ark\\\": \\\"ark:/61903/1:1:XM5X-SPSL\\\",\\n      \\\"gender\\\": \\\"Male\\\",\\n      \\\"names\\\": [\\n        {\\n          \\\"id\\\": \\\"1dcf5d75-3c0e-49ef-aa0e-180854c3650e\\\",\\n          \\\"type\\\": \\\"BirthName\\\",\\n          \\\"given\\\": \\\"Donald Wendell\\\",\\n          \\\"surname\\\": \\\"Quass\\\"\\n        }\\n      ],\\n      \\\"facts\\\": [\\n        {\\n          \\\"id\\\": \\\"bd1540c2-061d-4d82-828f-92562d24a652\\\",\\n          \\\"typ..."
+    },
+    {
+      "tool": "mcp__genealogy__record_read",
+      "args": {
+        "recordId": "ark:/61903/1:1:XM5X-SPSP"
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"persons\\\": [\\n    {\\n      \\\"id\\\": \\\"p_306774614781\\\",\\n      \\\"ark\\\": \\\"ark:/61903/1:1:XM5X-SPSL\\\",\\n      \\\"gender\\\": \\\"Male\\\",\\n      \\\"names\\\": [\\n        {\\n          \\\"id\\\": \\\"1dcf5d75-3c0e-49ef-aa0e-180854c3650e\\\",\\n          \\\"type\\\": \\\"BirthName\\\",\\n          \\\"given\\\": \\\"Donald Wendell\\\",\\n          \\\"surname\\\": \\\"Quass\\\"\\n        }\\n      ],\\n      \\\"facts\\\": [\\n        {\\n          \\\"id\\\": \\\"bd1540c2-061d-4d82-828f-92562d24a652\\\",\\n          \\\"typ..."
+    },
+    {
+      "tool": "mcp__genealogy__record_search",
+      "args": {
+        "givenName": "Kenneth",
+        "surname": "Quass",
+        "collectionId": "1202535",
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f"
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"query\\\": {\\n    \\\"givenName\\\": \\\"Kenneth\\\",\\n    \\\"surname\\\": \\\"Quass\\\",\\n    \\\"collectionId\\\": \\\"1202535\\\",\\n    \\\"projectPath\\\": \\\"/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f\\\"\\n  },\\n  \\\"totalMatches\\\": 10,\\n  \\\"paginationCappedAt\\\": 4999,\\n  \\\"returned\\\": 10,\\n  \\\"offset\\\": 0,\\n  \\\"hasMore\\\": false,\\n  \\\"results\\\": [\\n    {\\n      \\\"recordId\\\": \\\"ark:/61903/1:1:VMBJ-FQ3\\\",\\n      \\\"events\\\": [],\\n      \\\"tr..."
+    },
+    {
+      "tool": "mcp__genealogy__record_search",
+      "args": {
+        "givenName": "Patricia",
+        "surname": "Quass",
+        "recordCountry": "United States",
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f"
+      },
+      "response_summary": "Error: result (143,037 characters) exceeds maximum allowed tokens. Output has been saved to /Users/dallan/.claude/projects/-private-var-folders-tv-yzyl0n517xj5v54fgn0c0j3h0000gn-T-e2e-ivyl-greenley-daughter-9uoppj5f/bbf38148-6301-4b4b-85c0-51b7f01068c4/tool-results/mcp-genealogy-record_search-1782770374441.txt.\nFormat: JSON array with schema: [{type: string, text: string}]\nUse offset and limit parameters to read specific portions of the file, search within it for specific content, and jq to m..."
+    },
+    {
+      "tool": "mcp__genealogy__fulltext_search",
+      "args": {
+        "keywords": "+Kenneth +\"Quass Jr\"",
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f"
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"query\\\": {\\n    \\\"keywords\\\": \\\"+Kenneth +\\\\\\\"Quass Jr\\\\\\\"\\\",\\n    \\\"projectPath\\\": \\\"/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f\\\"\\n  },\\n  \\\"totalResults\\\": 2,\\n  \\\"returned\\\": 2,\\n  \\\"offset\\\": 0,\\n  \\\"hasMore\\\": false,\\n  \\\"results\\\": [\\n    {\\n      \\\"id\\\": \\\"ark:/61903/3:1:3Q9M-CSLL-9QT6-N\\\",\\n      \\\"sourceUrl\\\": \\\"https://www.familysearch.org/ark:/61903/3:1:3Q9M-CSLL-9QT6-N\\\",\\n      \\\"collectionId\\\": \\..."
+    },
+    {
+      "tool": "Bash",
+      "args": {
+        "command": "python3 -c \"\nimport json\ndata = open('/Users/dallan/.claude/projects/-private-var-folders-tv-yzyl0n517xj5v54fgn0c0j3h0000gn-T-e2e-ivyl-greenley-daughter-9uoppj5f/bbf38148-6301-4b4b-85c0-51b7f01068c4/tool-results/mcp-genealogy-record_search-1782770374441.txt').read()\nparsed = json.loads(data)\ntext = parsed[0]['text']\n# Parse the JSON within\nresult = json.loads(text)\ntotal = result.get('totalMatches', 0)\nprint('Total matches:', total)\n# Print first 5 results summary\nfor r in result.get('results', [])[:10]:\n    name = r.get('personName','')\n    bd = r.get('birthDate','')\n    dd = r.get('deathDate','')\n    dp = r.get('deathPlace','')\n    print(f'  {name} | b: {bd} | d: {dd} | {dp}')\n\" 2>&1 | head -50",
+        "description": "Parse Patricia Quass search results"
+      },
+      "response_summary": "Permission to use Bash has been denied because Claude Code is running in don't ask mode. IMPORTANT: You *may* attempt to accomplish this action using other tools that might naturally be used to accomplish this goal, e.g. using head instead of cat. But you *should not* attempt to work around this denial in malicious ways, e.g. do not use your ability to run tests to execute non-test actions. You should only try to work around this restriction in reasonable ways that do not attempt to bypass th..."
+    },
+    {
+      "tool": "mcp__genealogy__fulltext_search",
+      "args": {
+        "keywords": "+Patricia +\"Quass\"",
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f"
+      },
+      "response_summary": "<tool_use_error>Cancelled: parallel tool call Bash(python3 -c \"\nimport json\ndata = open('/U\u2026) errored</tool_use_error>"
+    },
+    {
+      "tool": "mcp__genealogy__record_search",
+      "args": {
+        "givenName": "Kenneth",
+        "surname": "Quass",
+        "birthYearFrom": 1941,
+        "birthYearTo": 1958,
+        "recordCountry": "United States",
+        "recordType": "death",
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f"
+      },
+      "response_summary": "<tool_use_error>Cancelled: parallel tool call Bash(python3 -c \"\nimport json\ndata = open('/U\u2026) errored</tool_use_error>"
+    },
+    {
+      "tool": "mcp__genealogy__fulltext_search",
+      "args": {
+        "keywords": "+Patricia +\"Quass\"",
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f"
+      },
+      "response_summary": "<persisted-output>\nOutput too large (52.3KB). Full output saved to: /Users/dallan/.claude/projects/-private-var-folders-tv-yzyl0n517xj5v54fgn0c0j3h0000gn-T-e2e-ivyl-greenley-daughter-9uoppj5f/bbf38148-6301-4b4b-85c0-51b7f01068c4/tool-results/toolu_01HLptWn1LY4VXxyADidcSUj.json\n\nPreview (first 2KB):\n[\n  {\n    \"type\": \"text\",\n    \"text\": \"{\\n  \\\"query\\\": {\\n    \\\"keywords\\\": \\\"+Patricia +\\\\\\\"Quass\\\\\\\"\\\",\\n    \\\"projectPath\\\": \\\"/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-g..."
+    },
+    {
+      "tool": "mcp__genealogy__record_search",
+      "args": {
+        "givenName": "Kenneth",
+        "surname": "Quass",
+        "birthYearFrom": 1941,
+        "birthYearTo": 1958,
+        "recordCountry": "United States",
+        "recordType": "death",
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f"
+      },
+      "response_summary": "Error: result (147,478 characters) exceeds maximum allowed tokens. Output has been saved to /Users/dallan/.claude/projects/-private-var-folders-tv-yzyl0n517xj5v54fgn0c0j3h0000gn-T-e2e-ivyl-greenley-daughter-9uoppj5f/bbf38148-6301-4b4b-85c0-51b7f01068c4/tool-results/mcp-genealogy-record_search-1782770406295.txt.\nFormat: JSON array with schema: [{type: string, text: string}]\nUse offset and limit parameters to read specific portions of the file, search within it for specific content, and jq to m..."
+    },
+    {
+      "tool": "Grep",
+      "args": {
+        "pattern": "Patricia.*Quass|Quass.*Patricia|Pat.*Quass|Quass.*Pat",
+        "path": "/Users/dallan/.claude/projects/-private-var-folders-tv-yzyl0n517xj5v54fgn0c0j3h0000gn-T-e2e-ivyl-greenley-daughter-9uoppj5f/bbf38148-6301-4b4b-85c0-51b7f01068c4/tool-results/toolu_01HLptWn1LY4VXxyADidcSUj.json",
+        "output_mode": "content",
+        "head_limit": 20
+      },
+      "response_summary": "4:[Omitted long matching line]"
+    },
+    {
+      "tool": "Grep",
+      "args": {
+        "pattern": "personName.*Quass|birthDate|deathDate|deathPlace",
+        "path": "/Users/dallan/.claude/projects/-private-var-folders-tv-yzyl0n517xj5v54fgn0c0j3h0000gn-T-e2e-ivyl-greenley-daughter-9uoppj5f/bbf38148-6301-4b4b-85c0-51b7f01068c4/tool-results/mcp-genealogy-record_search-1782770406295.txt",
+        "output_mode": "content",
+        "head_limit": 30
+      },
+      "response_summary": "4:[Omitted long matching line]"
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/Users/dallan/.claude/projects/-private-var-folders-tv-yzyl0n517xj5v54fgn0c0j3h0000gn-T-e2e-ivyl-greenley-daughter-9uoppj5f/bbf38148-6301-4b4b-85c0-51b7f01068c4/tool-results/toolu_01HLptWn1LY4VXxyADidcSUj.json",
+        "limit": 100
+      },
+      "response_summary": "1\t[\n2\t  {\n3\t    \"type\": \"text\",\n4\t    \"text\": \"{\\n  \\\"query\\\": {\\n    \\\"keywords\\\": \\\"+Patricia +\\\\\\\"Quass\\\\\\\"\\\",\\n    \\\"projectPath\\\": \\\"/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f\\\"\\n  },\\n  \\\"totalResults\\\": 69,\\n  \\\"returned\\\": 5,\\n  \\\"offset\\\": 0,\\n  \\\"hasMore\\\": true,\\n  \\\"results\\\": [\\n    {\\n      \\\"id\\\": \\\"ark:/61903/3:1:3QHV-NQL1-RPVJ\\\",\\n      \\\"sourceUrl\\\": \\\"https://www.familysearch.org/ark:/61903/3:1:3QHV-NQL1-RPVJ\\\",\\n      \\\"col..."
+    },
+    {
+      "tool": "mcp__genealogy__record_search",
+      "args": {
+        "givenName": "Kenneth",
+        "surname": "Quass",
+        "fatherSurname": "Quass",
+        "collectionId": "1949334",
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f"
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"query\\\": {\\n    \\\"givenName\\\": \\\"Kenneth\\\",\\n    \\\"surname\\\": \\\"Quass\\\",\\n    \\\"fatherSurname\\\": \\\"Quass\\\",\\n    \\\"collectionId\\\": \\\"1949334\\\",\\n    \\\"projectPath\\\": \\\"/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f\\\"\\n  },\\n  \\\"totalMatches\\\": 6,\\n  \\\"paginationCappedAt\\\": 4999,\\n  \\\"returned\\\": 6,\\n  \\\"offset\\\": 0,\\n  \\\"hasMore\\\": false,\\n  \\\"results\\\": [\\n    {\\n      \\\"recordId\\\": \\\"ark:/61903/1:1:VCKB-LVD\\\",\\n..."
+    },
+    {
+      "tool": "mcp__genealogy__record_search",
+      "args": {
+        "givenName": "Patricia",
+        "surname": "Quass",
+        "fatherSurname": "Quass",
+        "collectionId": "1949334",
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f"
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"query\\\": {\\n    \\\"givenName\\\": \\\"Patricia\\\",\\n    \\\"surname\\\": \\\"Quass\\\",\\n    \\\"fatherSurname\\\": \\\"Quass\\\",\\n    \\\"collectionId\\\": \\\"1949334\\\",\\n    \\\"projectPath\\\": \\\"/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f\\\"\\n  },\\n  \\\"totalMatches\\\": 1,\\n  \\\"paginationCappedAt\\\": 4999,\\n  \\\"returned\\\": 1,\\n  \\\"offset\\\": 0,\\n  \\\"hasMore\\\": false,\\n  \\\"results\\\": [\\n    {\\n      \\\"recordId\\\": \\\"ark:/61903/1:1:VCGD-NHK\\\",\\..."
+    },
+    {
+      "tool": "mcp__genealogy__fulltext_search",
+      "args": {
+        "keywords": "+\"Kenneth Quass Jr\" +born",
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f"
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"query\\\": {\\n    \\\"keywords\\\": \\\"+\\\\\\\"Kenneth Quass Jr\\\\\\\" +born\\\",\\n    \\\"projectPath\\\": \\\"/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f\\\"\\n  },\\n  \\\"totalResults\\\": 0,\\n  \\\"returned\\\": 0,\\n  \\\"offset\\\": 0,\\n  \\\"hasMore\\\": false,\\n  \\\"results\\\": [],\\n  \\\"staged\\\": null\\n}\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__fulltext_search",
+      "args": {
+        "keywords": "+Ivyl +\"Quass\" +obituary",
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f"
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"query\\\": {\\n    \\\"keywords\\\": \\\"+Ivyl +\\\\\\\"Quass\\\\\\\" +obituary\\\",\\n    \\\"projectPath\\\": \\\"/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f\\\"\\n  },\\n  \\\"totalResults\\\": 0,\\n  \\\"returned\\\": 0,\\n  \\\"offset\\\": 0,\\n  \\\"hasMore\\\": false,\\n  \\\"results\\\": [],\\n  \\\"staged\\\": null\\n}\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__record_search",
+      "args": {
+        "fatherSurname": "Quass",
+        "collectionId": "1949334",
+        "birthYearFrom": 1941,
+        "birthYearTo": 1962,
+        "recordCountry": "United States",
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f"
+      },
+      "response_summary": "<persisted-output>\nOutput too large (73KB). Full output saved to: /Users/dallan/.claude/projects/-private-var-folders-tv-yzyl0n517xj5v54fgn0c0j3h0000gn-T-e2e-ivyl-greenley-daughter-9uoppj5f/bbf38148-6301-4b4b-85c0-51b7f01068c4/tool-results/toolu_01KX3LWb1Sd1QucrxQQA2AW4.json\n\nPreview (first 2KB):\n[\n  {\n    \"type\": \"text\",\n    \"text\": \"{\\n  \\\"query\\\": {\\n    \\\"fatherSurname\\\": \\\"Quass\\\",\\n    \\\"collectionId\\\": \\\"1949334\\\",\\n    \\\"birthYearFrom\\\": 1941,\\n    \\\"birthYearTo\\\": 1962,\\n    \\\"record..."
+    },
+    {
+      "tool": "mcp__genealogy__record_search",
+      "args": {
+        "givenName": "Kenneth",
+        "surname": "Quass",
+        "residenceYearFrom": 1950,
+        "residenceYearTo": 1950,
+        "residencePlace": "Watonwan, Minnesota",
+        "recordCountry": "United States",
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f"
+      },
+      "response_summary": "<persisted-output>\nOutput too large (76.7KB). Full output saved to: /Users/dallan/.claude/projects/-private-var-folders-tv-yzyl0n517xj5v54fgn0c0j3h0000gn-T-e2e-ivyl-greenley-daughter-9uoppj5f/bbf38148-6301-4b4b-85c0-51b7f01068c4/tool-results/toolu_01ARQKD9rdvBFHsNZZszmBJq.json\n\nPreview (first 2KB):\n[\n  {\n    \"type\": \"text\",\n    \"text\": \"{\\n  \\\"query\\\": {\\n    \\\"givenName\\\": \\\"Kenneth\\\",\\n    \\\"surname\\\": \\\"Quass\\\",\\n    \\\"residenceYearFrom\\\": 1950,\\n    \\\"residenceYearTo\\\": 1950,\\n    \\\"resid..."
+    },
+    {
+      "tool": "mcp__genealogy__fulltext_search",
+      "args": {
+        "keywords": "+\"Kenneth Quass\" +\"Pat\" +\"Ken\"",
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f"
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"query\\\": {\\n    \\\"keywords\\\": \\\"+\\\\\\\"Kenneth Quass\\\\\\\" +\\\\\\\"Pat\\\\\\\" +\\\\\\\"Ken\\\\\\\"\\\",\\n    \\\"projectPath\\\": \\\"/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f\\\"\\n  },\\n  \\\"totalResults\\\": 0,\\n  \\\"returned\\\": 0,\\n  \\\"offset\\\": 0,\\n  \\\"hasMore\\\": false,\\n  \\\"results\\\": [],\\n  \\\"staged\\\": null\\n}\"}]"
+    },
+    {
+      "tool": "Grep",
+      "args": {
+        "pattern": "collectionTitle|personName|birthDate|1950",
+        "path": "/Users/dallan/.claude/projects/-private-var-folders-tv-yzyl0n517xj5v54fgn0c0j3h0000gn-T-e2e-ivyl-greenley-daughter-9uoppj5f/bbf38148-6301-4b4b-85c0-51b7f01068c4/tool-results/toolu_01ARQKD9rdvBFHsNZZszmBJq.json",
+        "output_mode": "content",
+        "head_limit": 60
+      },
+      "response_summary": "4:[Omitted long matching line]"
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/Users/dallan/.claude/projects/-private-var-folders-tv-yzyl0n517xj5v54fgn0c0j3h0000gn-T-e2e-ivyl-greenley-daughter-9uoppj5f/bbf38148-6301-4b4b-85c0-51b7f01068c4/tool-results/toolu_01ARQKD9rdvBFHsNZZszmBJq.json",
+        "limit": 50
+      },
+      "response_summary": "File content (27882 tokens) exceeds maximum allowed tokens (25000). Use offset and limit parameters to read specific portions of the file, or search for specific content instead of reading the whole file."
+    },
+    {
+      "tool": "mcp__genealogy__research_log_append",
+      "args": {
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f",
+        "tool": "record_search",
+        "planItemId": "pli_005",
+        "query": {
+          "collectionId": "1202535",
+          "givenName": "Kenneth",
+          "surname": "Quass",
+          "description": "SSDI for Kenneth Quass to find death or birth info for Ken Quass Jr."
+        },
+        "outcome": "negative",
+        "resultsExamined": 10,
+        "resultsAvailable": 10,
+        "stagedResultsRef": "results/.staging/5845e734-d7c5-4a1c-b4b1-bee9a463b419.json",
+        "notes": "10 SSDI results returned; none match Kenneth Quass Jr. (son of Kenneth Werner Quass and Ivyl Greenley). Results are phonetically similar names (Quasney, Kaas) \u2014 no Quass surname matches. Kenneth Quass Jr. is alive as of 2024 (listed as survivor in Donald's April 2024 obituary), so no SSDI entry expected."
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"logId\\\": \\\"log_011\\\",\\n  \\\"performed\\\": \\\"2026-06-29T22:03:49.448Z\\\",\\n  \\\"resultsRef\\\": \\\"results/log_011.json\\\",\\n  \\\"returnedCount\\\": 10,\\n  \\\"filesWritten\\\": [\\n    \\\"research.json\\\",\\n    \\\"results/log_011.json\\\"\\n  ],\\n  \\\"validation\\\": {\\n    \\\"valid\\\": true,\\n    \\\"warnings\\\": []\\n  }\\n}\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__research_log_append",
+      "args": {
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f",
+        "tool": "record_search",
+        "planItemId": "pli_004",
+        "query": {
+          "collectionId": "1949334",
+          "givenName": "Patricia",
+          "surname": "Quass",
+          "fatherSurname": "Quass",
+          "description": "MN Birth Index for Patricia Quass with father Quass"
+        },
+        "outcome": "negative",
+        "resultsExamined": 1,
+        "resultsAvailable": 1,
+        "stagedResultsRef": "results/.staging/c4bae1db-0c0a-409a-9ddc-4d946df2a230.json",
+        "notes": "Only result is Colleen Patrice Kaas (b. 7 Mar 1960, Kanabec MN) \u2014 not relevant. Patricia Quass (later Pat Norman) is not found in Minnesota Birth Index. She is alive as of 2024 per Donald's obituary. Her birth record is likely in Watonwan County unindexed image records (collection 1920099) or possibly in Iowa."
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"logId\\\": \\\"log_012\\\",\\n  \\\"performed\\\": \\\"2026-06-29T22:03:54.275Z\\\",\\n  \\\"resultsRef\\\": \\\"results/log_012.json\\\",\\n  \\\"returnedCount\\\": 1,\\n  \\\"filesWritten\\\": [\\n    \\\"research.json\\\",\\n    \\\"results/log_012.json\\\"\\n  ],\\n  \\\"validation\\\": {\\n    \\\"valid\\\": true,\\n    \\\"warnings\\\": []\\n  }\\n}\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__research_log_append",
+      "args": {
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f",
+        "tool": "fulltext_search",
+        "planItemId": "pli_004",
+        "query": {
+          "keywords": "+Patricia +\"Quass\"",
+          "description": "Fulltext search for Patricia Quass across all collections"
+        },
+        "outcome": "negative",
+        "resultsExamined": 5,
+        "resultsAvailable": 69,
+        "stagedResultsRef": "results/.staging/90d3c669-2af4-4d4a-8e27-61d9a718e29f.json",
+        "notes": "69 total results but none matching Patricia Quass daughter of Kenneth Werner Quass and Ivyl Greenley. Results include: Wisconsin obituary for unrelated Harold J. Quass (second wife Patricia Calhorn), Iowa 1926 birth record containing Quinn/Quass names, Alabama 1991 newspaper (Ann Gabrielle Quass-Little, daughter of Kenneth Warner Quass Jr. of Plymouth MN \u2014 confirms Ken Jr. lived in Plymouth/Hennepin MN in 1991), Minnesota centennial history (unrelated Quass family), Wisconsin obituary for Patricia Quass of Whitewater WI (unrelated, daughter of Palma Keyes). Our target Patricia Quass/Norman not identified. She is alive as of 2024."
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"logId\\\": \\\"log_013\\\",\\n  \\\"performed\\\": \\\"2026-06-29T22:04:06.666Z\\\",\\n  \\\"resultsRef\\\": \\\"results/log_013.json\\\",\\n  \\\"returnedCount\\\": 5,\\n  \\\"filesWritten\\\": [\\n    \\\"research.json\\\",\\n    \\\"results/log_013.json\\\"\\n  ],\\n  \\\"validation\\\": {\\n    \\\"valid\\\": true,\\n    \\\"warnings\\\": []\\n  }\\n}\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__research_log_append",
+      "args": {
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f",
+        "tool": "fulltext_search",
+        "planItemId": "pli_004",
+        "query": {
+          "keywords": "+\"Kenneth Quass Jr\" +born",
+          "description": "Fulltext for Kenneth Quass Jr birth information"
+        },
+        "outcome": "negative",
+        "resultsExamined": 0,
+        "resultsAvailable": 0,
+        "notes": "Zero results. No fulltext document on FamilySearch mentions 'Kenneth Quass Jr' alongside birth information. Birth date for Kenneth Warner Quass Jr. not determinable from indexed FamilySearch records. He is alive as of 2024 per Donald's obituary."
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"logId\\\": \\\"log_014\\\",\\n  \\\"performed\\\": \\\"2026-06-29T22:04:10.168Z\\\",\\n  \\\"resultsRef\\\": null,\\n  \\\"returnedCount\\\": null,\\n  \\\"filesWritten\\\": [\\n    \\\"research.json\\\"\\n  ],\\n  \\\"validation\\\": {\\n    \\\"valid\\\": true,\\n    \\\"warnings\\\": []\\n  }\\n}\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__research_log_append",
+      "args": {
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f",
+        "tool": "fulltext_search",
+        "planItemId": "pli_005",
+        "query": {
+          "keywords": "+Kenneth +\"Quass Jr\"",
+          "description": "Fulltext search confirming Ken Jr. as informant on Kenneth Sr.'s Texas death cert"
+        },
+        "outcome": "positive",
+        "resultsExamined": 2,
+        "resultsAvailable": 2,
+        "stagedResultsRef": "results/.staging/b8707d14-4110-45ef-a790-a6419e64406a.json",
+        "notes": "2 results. Result 1 (irrelevant): Iowa Buchanan County 1950 obituary pages mentioning 'Ronnie Quass Jr.' \u2014 unrelated. Result 2 (significant): Texas Death Certificate 1982 for Kenneth Quass (ark:/61903/3:1:3QS7-8992-XXT, collection M9J1-953), full text confirmed \u2014 informant signature reads 'Kenneth Quass Jr.' confirming that Kenneth Warner Quass Jr. is a child of Kenneth Werner Quass and Ivyl Greenley. Certificate states: d. Sep 17 1982, Tarrant County TX (Grapevine area), surviving spouse Ivyl Greenley, residence 5941 Lancaster Drive, San Diego CA, father Ralph K. Quass, mother Emma Nehls, buried Madelia Cemetery MN. Note: record_read on this ARK returns 'not found' \u2014 the ARK is accessible only via fulltext, not the record_read endpoint."
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"logId\\\": \\\"log_015\\\",\\n  \\\"performed\\\": \\\"2026-06-29T22:04:22.862Z\\\",\\n  \\\"resultsRef\\\": \\\"results/log_015.json\\\",\\n  \\\"returnedCount\\\": 2,\\n  \\\"filesWritten\\\": [\\n    \\\"research.json\\\",\\n    \\\"results/log_015.json\\\"\\n  ],\\n  \\\"validation\\\": {\\n    \\\"valid\\\": true,\\n    \\\"warnings\\\": []\\n  }\\n}\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__research_log_append",
+      "args": {
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f",
+        "tool": "record_search",
+        "planItemId": "pli_003",
+        "query": {
+          "givenName": "Kenneth",
+          "surname": "Quass",
+          "residenceYearFrom": 1950,
+          "residenceYearTo": 1950,
+          "residencePlace": "Watonwan, Minnesota",
+          "recordCountry": "United States",
+          "description": "1950 census search \u2014 Kenneth Quass, Watonwan County MN"
+        },
+        "outcome": "negative",
+        "resultsExamined": 20,
+        "resultsAvailable": 23,
+        "notes": "23 results returned, none are a 1950 US Census entry for Kenneth Quass. Top result is Find a Grave (Kenneth Werner Quass Sr., KNS4-P6W); remaining results appear to be death records, birth index entries, and other records. The 1950 census for Watonwan County MN is either not yet indexed on FamilySearch or Kenneth Quass does not appear under this query. Without 1950 census access, household composition in 1950 cannot be confirmed. Family was in Madelia, Watonwan County through at least Feb 1955 (Alice Jeanette's death)."
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"logId\\\": \\\"log_016\\\",\\n  \\\"performed\\\": \\\"2026-06-29T22:04:30.030Z\\\",\\n  \\\"resultsRef\\\": null,\\n  \\\"returnedCount\\\": null,\\n  \\\"filesWritten\\\": [\\n    \\\"research.json\\\"\\n  ],\\n  \\\"validation\\\": {\\n    \\\"valid\\\": true,\\n    \\\"warnings\\\": []\\n  }\\n}\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__research_log_append",
+      "args": {
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f",
+        "tool": "fulltext_search",
+        "planItemId": "pli_006",
+        "query": {
+          "keywords": "+Ivyl +\"Quass\" +obituary",
+          "description": "Fulltext search for Ivyl Quass obituary on FamilySearch"
+        },
+        "outcome": "negative",
+        "resultsExamined": 0,
+        "resultsAvailable": 0,
+        "notes": "Zero results. Ivyl Phylena Greenley Quass (d. 24 May 2005, San Diego CA) obituary not found in any FamilySearch fulltext collection. Her 2005 San Diego obituary would be in local newspapers (San Diego Union-Tribune) or GenealogyBank, which are external sites not accessible via FamilySearch record_search or fulltext_search. Ivyl's obituary would most likely name her surviving children with birth information. This search should be redirected to search-external-sites."
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"logId\\\": \\\"log_017\\\",\\n  \\\"performed\\\": \\\"2026-06-29T22:04:37.924Z\\\",\\n  \\\"resultsRef\\\": null,\\n  \\\"returnedCount\\\": null,\\n  \\\"filesWritten\\\": [\\n    \\\"research.json\\\"\\n  ],\\n  \\\"validation\\\": {\\n    \\\"valid\\\": true,\\n    \\\"warnings\\\": []\\n  }\\n}\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__research_log_append",
+      "args": {
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f",
+        "tool": "record_search",
+        "planItemId": "pli_004",
+        "query": {
+          "fatherSurname": "Quass",
+          "collectionId": "1949334",
+          "birthYearFrom": 1941,
+          "birthYearTo": 1962,
+          "recordCountry": "United States",
+          "description": "MN Birth Index \u2014 all Quass children 1941-1962 (broad search)"
+        },
+        "outcome": "negative",
+        "resultsExamined": 19,
+        "resultsAvailable": 19,
+        "notes": "19 results, all examined. Results are children of various Quass families across Minnesota. No child with father Kenneth Quass (or Kenneth Warner Quass) and mother Ivyl Greenley found in this range except Alice Jeanette (already logged). Kenneth Warner Quass Jr. and Patricia Quass (later Norman) do not appear as children in the MN Birth Index 1935-2002 for any year. Their birth records are not in any indexed Minnesota collection; they were likely recorded in Watonwan County registers that are image-only on FamilySearch (collection 1920099)."
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"logId\\\": \\\"log_018\\\",\\n  \\\"performed\\\": \\\"2026-06-29T22:04:44.125Z\\\",\\n  \\\"resultsRef\\\": null,\\n  \\\"returnedCount\\\": null,\\n  \\\"filesWritten\\\": [\\n    \\\"research.json\\\"\\n  ],\\n  \\\"validation\\\": {\\n    \\\"valid\\\": true,\\n    \\\"warnings\\\": []\\n  }\\n}\"}]"
+    },
+    {
+      "tool": "ToolSearch",
+      "args": {
+        "query": "select:mcp__genealogy__tree_edit",
+        "max_results": 1
+      },
+      "response_summary": "[{\"type\": \"tool_reference\", \"tool_name\": \"mcp__genealogy__tree_edit\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__research_append",
+      "args": {
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f",
+        "ops": [
+          {
+            "section": "plan_items",
+            "op": "update",
+            "planId": "pl_001",
+            "entryId": "pli_001",
+            "fields": {
+              "status": "in_progress"
+            }
+          },
+          {
+            "section": "plan_items",
+            "op": "update",
+            "planId": "pl_001",
+            "entryId": "pli_002",
+            "fields": {
+              "status": "in_progress"
+            }
+          },
+          {
+            "section": "plan_items",
+            "op": "update",
+            "planId": "pl_001",
+            "entryId": "pli_003",
+            "fields": {
+              "status": "in_progress"
+            }
+          },
+          {
+            "section": "plan_items",
+            "op": "update",
+            "planId": "pl_001",
+            "entryId": "pli_004",
+            "fields": {
+              "status": "in_progress"
+            }
+          },
+          {
+            "section": "plan_items",
+            "op": "update",
+            "planId": "pl_001",
+            "entryId": "pli_005",
+            "fields": {
+              "status": "in_progress"
+            }
+          },
+          {
+            "section": "plan_items",
+            "op": "update",
+            "planId": "pl_001",
+            "entryId": "pli_006",
+            "fields": {
+              "status": "in_progress"
+            }
+          },
+          {
+            "section": "plan_items",
+            "op": "update",
+            "planId": "pl_001",
+            "entryId": "pli_007",
+            "fields": {
+              "status": "in_progress"
+            }
+          },
+          {
+            "section": "plan_items",
+            "op": "update",
+            "planId": "pl_001",
+            "entryId": "pli_008",
+            "fields": {
+              "status": "in_progress"
+            }
+          }
+        ]
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"results\\\": [\\n    {\\n      \\\"section\\\": \\\"plan_items\\\",\\n      \\\"op\\\": \\\"update\\\",\\n      \\\"entryId\\\": \\\"pli_001\\\"\\n    },\\n    {\\n      \\\"section\\\": \\\"plan_items\\\",\\n      \\\"op\\\": \\\"update\\\",\\n      \\\"entryId\\\": \\\"pli_002\\\"\\n    },\\n    {\\n      \\\"section\\\": \\\"plan_items\\\",\\n      \\\"op\\\": \\\"update\\\",\\n      \\\"entryId\\\": \\\"pli_003\\\"\\n    },\\n    {\\n      \\\"section\\\": \\\"plan_items\\\",\\n      \\\"op\\\": \\\"update\\\",\\n      \\\"entryId\\\": \\\"pli_004\\\"\\n..."
+    },
+    {
+      "tool": "mcp__genealogy__tree_edit",
+      "args": {
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f",
+        "ops": [
+          {
+            "operation": "add_person",
+            "person": {
+              "gender": "Female",
+              "names": [
+                {
+                  "type": "BirthName",
+                  "given": "Alice Jeanette",
+                  "surname": "Quass",
+                  "preferred": true
+                }
+              ],
+              "facts": [
+                {
+                  "type": "Birth",
+                  "date": "6 December 1940",
+                  "place": "Watonwan County, Minnesota, United States",
+                  "primary": true
+                },
+                {
+                  "type": "Death",
+                  "date": "3 February 1955",
+                  "place": "Madelia, Watonwan, Minnesota, United States",
+                  "primary": true
+                }
+              ]
+            }
+          },
+          {
+            "operation": "add_person",
+            "person": {
+              "gender": "Male",
+              "names": [
+                {
+                  "type": "BirthName",
+                  "given": "Kenneth Warner",
+                  "surname": "Quass",
+                  "suffix": "Jr",
+                  "preferred": true
+                }
+              ]
+            }
+          },
+          {
+            "operation": "add_person",
+            "person": {
+              "gender": "Female",
+              "names": [
+                {
+                  "type": "BirthName",
+                  "given": "Patricia",
+                  "surname": "Quass",
+                  "preferred": true
+                },
+                {
+                  "type": "MarriedName",
+                  "given": "Patricia",
+                  "surname": "Norman"
+                }
+              ]
+            }
+          },
+          {
+            "operation": "add_relationship",
+            "relationship": {
+              "type": "ParentChild",
+              "parent": "KNS4-P6W",
+              "child": "I6"
+            }
+          },
+          {
+            "operation": "add_relationship",
+            "relationship": {
+              "type": "ParentChild",
+              "parent": "KWZP-4Q8",
+              "child": "I6"
+            }
+          },
+          {
+            "operation": "add_relationship",
+            "relationship": {
+              "type": "ParentChild",
+              "parent": "KNS4-P6W",
+              "child": "I7"
+            }
+          },
+          {
+            "operation": "add_relationship",
+            "relationship": {
+              "type": "ParentChild",
+              "parent": "KWZP-4Q8",
+              "child": "I7"
+            }
+          },
+          {
+            "operation": "add_relationship",
+            "relationship": {
+              "type": "ParentChild",
+              "parent": "KNS4-P6W",
+              "child": "I8"
+            }
+          },
+          {
+            "operation": "add_relationship",
+            "relationship": {
+              "type": "ParentChild",
+              "parent": "KWZP-4Q8",
+              "child": "I8"
+            }
+          }
+        ]
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": false,\\n  \\\"errors\\\": [\\n    \\\"tree.gedcomx.json/persons[5]/facts[0]: missing required field 'id'\\\",\\n    \\\"tree.gedcomx.json/persons[5]/facts[1]: missing required field 'id'\\\",\\n    \\\"tree.gedcomx.json/relationships[6]: child 'I6' not found in persons\\\",\\n    \\\"tree.gedcomx.json/relationships[7]: child 'I6' not found in persons\\\",\\n    \\\"tree.gedcomx.json/relationships[8]: child 'I7' not found in persons\\\",\\n    \\\"tree.gedcomx.json/relationships[9]: ch..."
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f/tree.gedcomx.json",
+        "limit": 80
+      },
+      "response_summary": "1\t{\n2\t  \"persons\": [\n3\t    {\n4\t      \"id\": \"KWZP-4Q8\",\n5\t      \"gender\": \"Female\",\n6\t      \"living\": false,\n7\t      \"names\": [\n8\t        {\n9\t          \"given\": \"Ivyl Phylena\",\n10\t          \"surname\": \"Greenley\",\n11\t          \"id\": \"KWZP-4Q8-name-1\"\n12\t        }\n13\t      ],\n14\t      \"facts\": [\n15\t        {\n16\t          \"id\": \"248eaba5-34ae-4182-9874-bfcc07166241\",\n17\t          \"type\": \"Birth\",\n18\t          \"date\": \"26 May 1914\",\n19\t          \"standard_date\": \"26 May 1914\",\n20\t          \"place\"..."
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f/tree.gedcomx.json",
+        "offset": 80,
+        "limit": 120
+      },
+      "response_summary": "80\t    {\n81\t      \"id\": \"KW4T-D9J\",\n82\t      \"gender\": \"Male\",\n83\t      \"living\": false,\n84\t      \"names\": [\n85\t        {\n86\t          \"given\": \"Donald Wendell\",\n87\t          \"surname\": \"Quass\",\n88\t          \"id\": \"KW4T-D9J-name-1\"\n89\t        }\n90\t      ],\n91\t      \"facts\": [\n92\t        {\n93\t          \"id\": \"ebe0d4fe-20f8-4dad-b4b8-c69c03d0f100\",\n94\t          \"type\": \"Birth\",\n95\t          \"date\": \"16 January 1940\",\n96\t          \"standard_date\": \"16 Jan 1940\",\n97\t          \"place\": \"Randalia, ..."
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f/tree.gedcomx.json",
+        "offset": 200,
+        "limit": 200
+      },
+      "response_summary": "200\t          \"standard_place\": \"Marshall, Minnesota, United States\"\n201\t        },\n202\t        {\n203\t          \"id\": \"ab93f448-37cc-401f-b1c8-739d271affbb\",\n204\t          \"type\": \"Move\",\n205\t          \"date\": \"2 July 1962\",\n206\t          \"standard_date\": \"2 Jul 1962\",\n207\t          \"place\": \"Los Angeles, California, United States\",\n208\t          \"standard_place\": \"Los Angeles, California, United States\"\n209\t        },\n210\t        {\n211\t          \"id\": \"9381f219-2889-4bfc-9b03-5527232282c1\",\n..."
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f/tree.gedcomx.json",
+        "offset": 440,
+        "limit": 200
+      },
+      "response_summary": "440\t        {\n441\t          \"id\": \"9381f219-2889-4bfc-9b03-5527232282c1\",\n442\t          \"type\": \"Death\",\n443\t          \"date\": \"3 Aug 1919\",\n444\t          \"standard_date\": \"3 Aug 1919\",\n445\t          \"place\": \"Kiester, Faribault, Minnesota, United States\",\n446\t          \"standard_place\": \"Kiester, Faribault, Minnesota, United States\"\n447\t        },\n448\t        {\n449\t          \"id\": \"c5be31e4-c57a-417a-b672-456ec4e963d8\",\n450\t          \"type\": \"Burial\",\n451\t          \"date\": \"6 August 1919\",\n4..."
+    },
+    {
+      "tool": "mcp__genealogy__tree_edit",
+      "args": {
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f",
+        "ops": [
+          {
+            "operation": "add_person",
+            "person": {
+              "gender": "Female",
+              "living": false,
+              "names": [
+                {
+                  "type": "BirthName",
+                  "given": "Alice Jeanette",
+                  "surname": "Quass",
+                  "preferred": true
+                }
+              ]
+            }
+          },
+          {
+            "operation": "add_person",
+            "person": {
+              "gender": "Male",
+              "living": true,
+              "names": [
+                {
+                  "type": "BirthName",
+                  "given": "Kenneth Warner",
+                  "surname": "Quass",
+                  "suffix": "Jr",
+                  "preferred": true
+                }
+              ]
+            }
+          },
+          {
+            "operation": "add_person",
+            "person": {
+              "gender": "Female",
+              "living": true,
+              "names": [
+                {
+                  "type": "BirthName",
+                  "given": "Patricia",
+                  "surname": "Quass",
+                  "preferred": true
+                },
+                {
+                  "type": "MarriedName",
+                  "given": "Patricia",
+                  "surname": "Norman"
+                }
+              ]
+            }
+          },
+          {
+            "operation": "add_relationship",
+            "relationship": {
+              "type": "ParentChild",
+              "parent": "KNS4-P6W",
+              "child": "I1",
+              "subtype": "Biological"
+            }
+          },
+          {
+            "operation": "add_relationship",
+            "relationship": {
+              "type": "ParentChild",
+              "parent": "KWZP-4Q8",
+              "child": "I1",
+              "subtype": "Biological"
+            }
+          },
+          {
+            "operation": "add_relationship",
+            "relationship": {
+              "type": "ParentChild",
+              "parent": "KNS4-P6W",
+              "child": "I2",
+              "subtype": "Biological"
+            }
+          },
+          {
+            "operation": "add_relationship",
+            "relationship": {
+              "type": "ParentChild",
+              "parent": "KWZP-4Q8",
+              "child": "I2",
+              "subtype": "Biological"
+            }
+          },
+          {
+            "operation": "add_relationship",
+            "relationship": {
+              "type": "ParentChild",
+              "parent": "KNS4-P6W",
+              "child": "I3",
+              "subtype": "Biological"
+            }
+          },
+          {
+            "operation": "add_relationship",
+            "relationship": {
+              "type": "ParentChild",
+              "parent": "KWZP-4Q8",
+              "child": "I3",
+              "subtype": "Biological"
+            }
+          }
+        ]
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"results\\\": [\\n    {\\n      \\\"operation\\\": \\\"add_person\\\",\\n      \\\"assignedIds\\\": {\\n        \\\"person\\\": \\\"I1\\\",\\n        \\\"names\\\": [\\n          \\\"N1\\\"\\n        ]\\n      }\\n    },\\n    {\\n      \\\"operation\\\": \\\"add_person\\\",\\n      \\\"assignedIds\\\": {\\n        \\\"person\\\": \\\"I2\\\",\\n        \\\"names\\\": [\\n          \\\"N2\\\"\\n        ]\\n      }\\n    },\\n    {\\n      \\\"operation\\\": \\\"add_person\\\",\\n      \\\"assignedIds\\\": {\\n        \\\"person\\\": \\\"I3\\..."
+    },
+    {
+      "tool": "mcp__genealogy__tree_edit",
+      "args": {
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f",
+        "ops": [
+          {
+            "operation": "add_fact",
+            "personId": "I1",
+            "fact": {
+              "type": "Birth",
+              "date": "6 December 1940",
+              "place": "Watonwan, Minnesota, United States",
+              "primary": true
+            }
+          },
+          {
+            "operation": "add_fact",
+            "personId": "I1",
+            "fact": {
+              "type": "Death",
+              "date": "3 February 1955",
+              "place": "Madelia, Watonwan, Minnesota, United States",
+              "primary": true
+            }
+          },
+          {
+            "operation": "add_source",
+            "source": {
+              "id": "AJQ-BIRTH",
+              "title": "Alice Jeanette Quass, \"Minnesota, Birth Index, 1935-2002\"",
+              "citation": "\"Minnesota, Birth Index, 1935-2002\", FamilySearch (https://www.familysearch.org/ark:/61903/1:1:VCF7-BY8), Entry for Alice Jeanette Quass and Kenneth Warner Quass, 06 Dec 1940.",
+              "url": "https://familysearch.org/ark:/61903/1:1:VCF7-BY8"
+            }
+          },
+          {
+            "operation": "add_source",
+            "source": {
+              "id": "AJQ-DEATH",
+              "title": "Alice Jeanette Quass, \"Minnesota Death Records, 1900-1955\"",
+              "citation": "\"Minnesota Death Records, 1900-1955\", FamilySearch (https://www.familysearch.org/ark:/61903/1:1:FDX7-8MF), Entry for Alice Jeanette Quass, 03 Feb 1955.",
+              "url": "https://familysearch.org/ark:/61903/1:1:FDX7-8MF"
+            }
+          },
+          {
+            "operation": "add_source",
+            "source": {
+              "id": "KSR-TXDEATH",
+              "title": "Kenneth Quass, \"Texas Death Certificates, 1982\"",
+              "citation": "\"United States, Texas, Deaths\", FamilySearch fulltext (https://www.familysearch.org/ark:/61903/3:1:3QS7-8992-XXT), Death certificate for Kenneth Quass, 17 Sep 1982, Tarrant County, Texas; informant: Kenneth Quass Jr.",
+              "url": "https://www.familysearch.org/ark:/61903/3:1:3QS7-8992-XXT"
+            }
+          }
+        ]
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": false,\\n  \\\"errors\\\": [\\n    \\\"ops[2]: add_source `source` must not carry an id \\u2014 the tool assigns it\\\"\\n  ]\\n}\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__tree_edit",
+      "args": {
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f",
+        "ops": [
+          {
+            "operation": "add_fact",
+            "personId": "I1",
+            "fact": {
+              "type": "Birth",
+              "date": "6 December 1940",
+              "place": "Watonwan, Minnesota, United States",
+              "primary": true
+            }
+          },
+          {
+            "operation": "add_fact",
+            "personId": "I1",
+            "fact": {
+              "type": "Death",
+              "date": "3 February 1955",
+              "place": "Madelia, Watonwan, Minnesota, United States",
+              "primary": true
+            }
+          },
+          {
+            "operation": "add_source",
+            "source": {
+              "title": "Alice Jeanette Quass, \"Minnesota, Birth Index, 1935-2002\"",
+              "citation": "\"Minnesota, Birth Index, 1935-2002\", FamilySearch (https://www.familysearch.org/ark:/61903/1:1:VCF7-BY8), Entry for Alice Jeanette Quass and Kenneth Warner Quass, 06 Dec 1940.",
+              "url": "https://familysearch.org/ark:/61903/1:1:VCF7-BY8"
+            }
+          },
+          {
+            "operation": "add_source",
+            "source": {
+              "title": "Alice Jeanette Quass, \"Minnesota Death Records, 1900-1955\"",
+              "citation": "\"Minnesota Death Records, 1900-1955\", FamilySearch (https://www.familysearch.org/ark:/61903/1:1:FDX7-8MF), Entry for Alice Jeanette Quass, 03 Feb 1955.",
+              "url": "https://familysearch.org/ark:/61903/1:1:FDX7-8MF"
+            }
+          },
+          {
+            "operation": "add_source",
+            "source": {
+              "title": "Kenneth Quass, \"Texas Death Certificates\" (1982)",
+              "citation": "\"United States, Texas, Deaths\", FamilySearch fulltext (https://www.familysearch.org/ark:/61903/3:1:3QS7-8992-XXT), Death certificate for Kenneth Quass, 17 Sep 1982, Tarrant County TX; informant listed as Kenneth Quass Jr.",
+              "url": "https://www.familysearch.org/ark:/61903/3:1:3QS7-8992-XXT"
+            }
+          }
+        ]
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"results\\\": [\\n    {\\n      \\\"operation\\\": \\\"add_fact\\\",\\n      \\\"assignedIds\\\": {\\n        \\\"fact\\\": \\\"F1\\\"\\n      }\\n    },\\n    {\\n      \\\"operation\\\": \\\"add_fact\\\",\\n      \\\"assignedIds\\\": {\\n        \\\"fact\\\": \\\"F2\\\"\\n      }\\n    },\\n    {\\n      \\\"operation\\\": \\\"add_source\\\",\\n      \\\"assignedIds\\\": {\\n        \\\"source\\\": \\\"S1\\\"\\n      }\\n    },\\n    {\\n      \\\"operation\\\": \\\"add_source\\\",\\n      \\\"assignedIds\\\": {\\n        \\\"source\\\": \\..."
+    },
+    {
+      "tool": "mcp__genealogy__research_append",
+      "args": {
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f",
+        "ops": [
+          {
+            "section": "sources",
+            "op": "append",
+            "entry": {
+              "title": "Donald Wendell Quass obituary, 27 April 2024",
+              "record_id": "ark:/61903/1:1:XM5X-SPSB",
+              "record_type": "newspaper",
+              "collection": "United States, Obituary Records, 2014-2023",
+              "citation": "\"United States, Obituary Records, 2014-2023\", FamilySearch (https://www.familysearch.org/ark:/61903/1:1:XM5X-SPSL : 30 Nov 2024), Entry for Donald Wendell Quass, 27 April 2024.",
+              "repository": "FamilySearch",
+              "source_classification": "authored_work",
+              "information_quality": "secondary",
+              "log_entry_ids": [
+                "log_001"
+              ]
+            }
+          },
+          {
+            "section": "sources",
+            "op": "append",
+            "entry": {
+              "title": "Alice Jeanette Quass, Minnesota Birth Index 1935-2002",
+              "record_id": "ark:/61903/1:1:VCF7-BY8",
+              "record_type": "vital_record",
+              "collection": "Minnesota, Birth Index, 1935-2002",
+              "citation": "\"Minnesota, Birth Index, 1935-2002\", FamilySearch (https://www.familysearch.org/ark:/61903/1:1:VCF7-BY8), Entry for Alice Jeanette Quass and Kenneth Warner Quass, 06 Dec 1940.",
+              "repository": "FamilySearch",
+              "source_classification": "derivative",
+              "information_quality": "primary",
+              "log_entry_ids": [
+                "log_005"
+              ]
+            }
+          },
+          {
+            "section": "sources",
+            "op": "append",
+            "entry": {
+              "title": "Alice Jeanette Quass, Minnesota Death Records 1900-1955",
+              "record_id": "ark:/61903/1:1:FDX7-8MF",
+              "record_type": "vital_record",
+              "collection": "Minnesota Death Records, 1900-1955",
+              "citation": "\"Minnesota Death Records, 1900-1955\", FamilySearch (https://www.familysearch.org/ark:/61903/1:1:FDX7-8MF), Entry for Alice Jeanette Quass, 03 Feb 1955.",
+              "repository": "FamilySearch",
+              "source_classification": "derivative",
+              "information_quality": "primary",
+              "log_entry_ids": [
+                "log_003"
+              ]
+            }
+          },
+          {
+            "section": "sources",
+            "op": "append",
+            "entry": {
+              "title": "Kenneth Quass death certificate, Tarrant County Texas, 17 Sep 1982",
+              "record_id": "ark:/61903/3:1:3QS7-8992-XXT",
+              "record_type": "vital_record",
+              "collection": "United States, Texas, Deaths",
+              "citation": "\"United States, Texas, Deaths\", FamilySearch fulltext (https://www.familysearch.org/ark:/61903/3:1:3QS7-8992-XXT), Death certificate for Kenneth Quass, 17 Sep 1982, Tarrant County TX; informant: Kenneth Quass Jr.",
+              "repository": "FamilySearch",
+              "source_classification": "original",
+              "information_quality": "primary",
+              "log_entry_ids": [
+                "log_010",
+                "log_015"
+              ]
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "record_id": "ark:/61903/1:1:VCF7-BY8",
+              "record_type": "vital_record",
+              "log_entry_id": "log_005",
+              "subject_person_ids": [
+                "I1",
+                "KNS4-P6W",
+                "KWZP-4Q8"
+              ],
+              "assertion_type": "relationship",
+              "content": "Alice Jeanette Quass, born 6 December 1940, Watonwan County, Minnesota, is the biological child of Kenneth Warner Quass (father) and Ivyl Phylena Greenley (mother), per the Minnesota Birth Index 1935-2002 (indexed from original county birth certificate).",
+              "source_classification": "derivative",
+              "information_quality": "primary",
+              "evidence_type": "direct",
+              "rationale": "The birth index entry names both parents explicitly and the child's full name, date, and county. This is a derivative of the original county birth certificate and carries primary information about the birth event.",
+              "confidence": "high",
+              "status": "accepted"
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "record_id": "ark:/61903/1:1:VCF7-BY8",
+              "record_type": "vital_record",
+              "log_entry_id": "log_005",
+              "subject_person_ids": [
+                "I1"
+              ],
+              "assertion_type": "event",
+              "content": "Alice Jeanette Quass was born 6 December 1940 in Watonwan County, Minnesota.",
+              "source_classification": "derivative",
+              "information_quality": "primary",
+              "evidence_type": "direct",
+              "rationale": "Birth index entry records the date and county of birth directly from the original birth certificate.",
+              "confidence": "high",
+              "status": "accepted"
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "record_id": "ark:/61903/1:1:FDX7-8MF",
+              "record_type": "vital_record",
+              "log_entry_id": "log_003",
+              "subject_person_ids": [
+                "I1"
+              ],
+              "assertion_type": "event",
+              "content": "Alice Jeanette Quass died 3 February 1955 in Madelia, Watonwan County, Minnesota.",
+              "source_classification": "derivative",
+              "information_quality": "primary",
+              "evidence_type": "direct",
+              "rationale": "Minnesota Death Records 1900-1955 entry names Alice Jeanette Quass with death date and place. Corroborated by Minnesota Deaths 1887-2001 index and the Watonwan County Death Record Index (from fulltext search log_010).",
+              "confidence": "high",
+              "status": "accepted"
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "record_id": "ark:/61903/1:1:XM5X-SPSB",
+              "record_type": "newspaper",
+              "log_entry_id": "log_001",
+              "subject_person_ids": [
+                "I1",
+                "KNS4-P6W",
+                "KWZP-4Q8"
+              ],
+              "assertion_type": "relationship",
+              "content": "Donald Wendell Quass's April 2024 obituary names 'Jeanette' as a deceased sibling, child of Kenneth Werner Quass and Ivyl Phylena Greenley. Cross-referenced with Minnesota Birth Index (ark:/61903/1:1:VCF7-BY8) and Death Records (ark:/61903/1:1:FDX7-8MF), this 'Jeanette' is identified as Alice Jeanette Quass (b. 6 Dec 1940, d. 3 Feb 1955, Watonwan County MN).",
+              "source_classification": "authored_work",
+              "information_quality": "secondary",
+              "evidence_type": "direct",
+              "rationale": "The obituary explicitly names Jeanette as a sibling who predeceased Donald. The Minnesota Birth and Death indexes confirm Alice Jeanette Quass with the correct parents, fully consistent with the obituary's reference to a deceased 'Jeanette.'",
+              "confidence": "high",
+              "status": "accepted"
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "record_id": "ark:/61903/1:1:XM5X-SPSB",
+              "record_type": "newspaper",
+              "log_entry_id": "log_001",
+              "subject_person_ids": [
+                "I2",
+                "KNS4-P6W",
+                "KWZP-4Q8"
+              ],
+              "assertion_type": "relationship",
+              "content": "Donald Wendell Quass's April 2024 obituary names 'Ken Quass (Bobbi)' as a surviving sibling and child of Kenneth Werner Quass and Ivyl Phylena Greenley. The record encodes a ParentChild relationship from both Kenneth Werner Quass (p_306774614787) and Ivyl Phylena Greenley (p_306774614788) to Ken Quass (p_306774614783). Ken Quass is identified as Kenneth Warner Quass Jr., who appears as father of four children in the Minnesota Birth Index (Hennepin County, 1965-1974) with wife Roberta Lee Homewood.",
+              "source_classification": "authored_work",
+              "information_quality": "secondary",
+              "evidence_type": "direct",
+              "rationale": "The obituary directly names Ken Quass as a child of the research subjects. The FamilySearch GedcomX encoding of the obituary record establishes explicit ParentChild relationships. The Minnesota Birth Index (log_006, log_008) corroborates Kenneth Warner Quass Jr. as a person with the Quass surname active in Minnesota in the 1960s-1970s.",
+              "confidence": "high",
+              "status": "accepted"
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "record_id": "ark:/61903/3:1:3QS7-8992-XXT",
+              "record_type": "vital_record",
+              "log_entry_id": "log_015",
+              "subject_person_ids": [
+                "I2",
+                "KNS4-P6W"
+              ],
+              "assertion_type": "relationship",
+              "content": "Kenneth Werner Quass's 1982 Texas death certificate (Tarrant County) names 'Kenneth Quass Jr.' as the informant, confirming a parent-child relationship between Kenneth Werner Quass (deceased) and Kenneth Quass Jr.",
+              "source_classification": "original",
+              "information_quality": "primary",
+              "evidence_type": "direct",
+              "rationale": "Death certificates typically list the informant by name and relationship. The informant 'Kenneth Quass Jr.' signed the certificate for his father 'Kenneth Quass,' establishing a direct parent-child link. This is an original government record created at the time of death (September 1982).",
+              "confidence": "high",
+              "status": "accepted"
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "record_id": "ark:/61903/1:1:XM5X-SPSB",
+              "record_type": "newspaper",
+              "log_entry_id": "log_001",
+              "subject_person_ids": [
+                "I3",
+                "KNS4-P6W",
+                "KWZP-4Q8"
+              ],
+              "assertion_type": "relationship",
+              "content": "Donald Wendell Quass's April 2024 obituary names 'Pat Norman (Bob)' as a surviving sibling and child of Kenneth Werner Quass and Ivyl Phylena Greenley. The record encodes a ParentChild relationship from both Kenneth Werner Quass (p_306774614787) and Ivyl Phylena Greenley (p_306774614788) to Pat Norman (p_306774614785, born Quass, married Norman). Bob Norman is the spouse of Pat Norman.",
+              "source_classification": "authored_work",
+              "information_quality": "secondary",
+              "evidence_type": "direct",
+              "rationale": "The obituary directly names Pat Norman (born Quass) as a child of the research subjects via encoded ParentChild relationships in the FamilySearch GedcomX record.",
+              "confidence": "high",
+              "status": "accepted"
+            }
+          }
+        ]
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": false,\\n  \\\"errors\\\": [\\n    \\\"research.json/sources[0]: missing required field 'gedcomx_source_description_id'\\\",\\n    \\\"research.json/sources[0]: missing required field 'citation_detail'\\\",\\n    \\\"research.json/sources[0]: missing required field 'access_date'\\\",\\n    \\\"research.json/sources[0]: 'authored_work' is not a valid source_classification (expected one of: authored, derivative, original)\\\",\\n    \\\"research.json/sources[1]: missing required fie..."
+    },
+    {
+      "tool": "Glob",
+      "args": {
+        "pattern": "**/*.md",
+        "path": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f/.claude/skills/record-extraction/references"
+      },
+      "response_summary": ".claude/skills/record-extraction/references/information-classification-at-extraction.md\n.claude/skills/record-extraction/references/note-taking-standards.md\n.claude/skills/record-extraction/references/places-guidance.md\n.claude/skills/record-extraction/references/source-classification-guide.md\n.claude/skills/record-extraction/references/research-log-protocol.md\n.claude/skills/record-extraction/references/validation-protocol.md"
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f/.claude/skills/record-extraction/references/source-classification-guide.md"
+      },
+      "response_summary": "1\t# Source Classification Guide\n2\t\n3\tHow to classify the source itself -- the container that holds\n4\tinformation. Source classification is Layer 1 of the three-layer\n5\tmodel and is independent of the other two layers (information and\n6\tevidence).\n7\t\n8\t## Three Categories\n9\t\n10\t### Original\n11\t\n12\tThe first recording of information, or the earliest surviving version.\n13\t\n14\tCharacteristics:\n15\t- Created at or near the time of the event by someone with direct\n16\t  knowledge or official authorit..."
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f/.claude/skills/record-extraction/references/information-classification-at-extraction.md"
+      },
+      "response_summary": "1\t# Information Classification at Extraction Time\n2\t\n3\tLayer 2 of the three-layer model evaluates WHO provided each piece of\n4\tinformation and whether that person had firsthand knowledge. This\n5\tclassification is entirely independent of source classification.\n6\t\n7\t## The Two-Question Decision Tree\n8\t\n9\t1. **Do we know the informant?**\n10\t   - No -> Undetermined\n11\t   - Yes -> proceed to question 2\n12\t\n13\t2. **Did the informant witness, participate in, or have firsthand\n14\t   knowledge of the ..."
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f/.claude/skills/record-extraction"
+      },
+      "response_summary": "EISDIR: illegal operation on a directory, read '/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f/.claude/skills/record-extraction'"
+    },
+    {
+      "tool": "Glob",
+      "args": {
+        "pattern": "*.md",
+        "path": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f/.claude/skills/record-extraction"
+      },
+      "response_summary": ".claude/skills/record-extraction/references/information-classification-at-extraction.md\n.claude/skills/record-extraction/references/note-taking-standards.md\n.claude/skills/record-extraction/references/places-guidance.md\n.claude/skills/record-extraction/references/source-classification-guide.md\n.claude/skills/record-extraction/references/research-log-protocol.md\n.claude/skills/record-extraction/references/validation-protocol.md\n.claude/skills/record-extraction/SKILL.md"
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f/.claude/skills/record-extraction/SKILL.md",
+        "limit": 150
+      },
+      "response_summary": "1\t---\n2\tname: record-extraction\n3\tmodel: claude-sonnet-4-6\n4\tdescription: Extracts atomic GPS-conformant assertions from genealogical\n5\t  records. Reads a record (from MCP tool response, captured PDF, or image\n6\t  transcription), breaks it into discrete testable assertions attached to\n7\t  record_id and record_role, creates source entries with working citations,\n8\t  and writes best-effort evidence classifications. GPS Step 2 (citation)\n9\t  and Step 3 (analysis) \u2014 the extraction phase. Use when..."
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f/.claude/skills/record-extraction/SKILL.md",
+        "offset": 150,
+        "limit": 120
+      },
+      "response_summary": "150\tlog entry itself is never modified.\n151\t\n152\t**GedcomX source description (`tree.gedcomx.json` `S` entry):**\n153\tMinimal shape \u2014 `additionalProperties: false`. Required: `id` (`S`\n154\tprefix), `title`. Optional: `author`, `url`. **Omit optional fields\n155\tentirely when not applicable** \u2014 `\"url\": null` fails validation\n156\t(must be string or absent). No `description`, `notes`, or other fields.\n157\t\n158\t**Source classification (quick rules):**\n159\t- **Original:** First recording or earliest..."
+    },
+    {
+      "tool": "ToolSearch",
+      "args": {
+        "query": "select:mcp__genealogy__research_append,mcp__genealogy__research_log_append,mcp__genealogy__tree_edit,mcp__genealogy__record_read,mcp__genealogy__record_search",
+        "max_results": 5
+      },
+      "response_summary": "[{\"type\": \"tool_reference\", \"tool_name\": \"mcp__genealogy__research_append\"}, {\"type\": \"tool_reference\", \"tool_name\": \"mcp__genealogy__research_log_append\"}, {\"type\": \"tool_reference\", \"tool_name\": \"mcp__genealogy__tree_edit\"}, {\"type\": \"tool_reference\", \"tool_name\": \"mcp__genealogy__record_read\"}, {\"type\": \"tool_reference\", \"tool_name\": \"mcp__genealogy__record_search\"}]"
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f/research.json",
+        "limit": 100
+      },
+      "response_summary": "1\t{\n2\t  \"project\": {\n3\t    \"id\": \"rp_ivyl_greenley_daughter\",\n4\t    \"objective\": \"Besides their son Donald, did Ivyl Phylena Greenley and her husband Kenneth Werner Quass have any other children? Identify each additional child and that child's birth and death dates.\",\n5\t    \"subject_person_ids\": [\n6\t      \"KWZP-4Q8\"\n7\t    ],\n8\t    \"status\": \"active\",\n9\t    \"created\": \"2026-06-29T00:00:00Z\",\n10\t    \"updated\": \"2026-06-29T00:00:00Z\"\n11\t  },\n12\t  \"researcher_profile\": {\n13\t    \"experience_level\"..."
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f/research.json",
+        "limit": 150,
+        "offset": 100
+      },
+      "response_summary": "100\t        {\n101\t          \"id\": \"pli_006\",\n102\t          \"sequence\": 6,\n103\t          \"record_type\": \"newspaper\",\n104\t          \"jurisdiction\": \"San Diego, California\",\n105\t          \"date_range\": \"2005\",\n106\t          \"repository\": \"other\",\n107\t          \"rationale\": \"Ivyl Phylena Greenley Quass died 24 May 2005 in San Diego, California and was buried in Madelia, Watonwan County, Minnesota. Her obituary \u2014 searchable in GenealogyBank, Newspapers.com, or the San Diego Union-Tribune archives ..."
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f/research.json",
+        "limit": 200,
+        "offset": 250
+      },
+      "response_summary": "250\t    {\n251\t      \"id\": \"log_007\",\n252\t      \"plan_item_id\": \"pli_005\",\n253\t      \"performed\": \"2026-06-29T21:50:36.711Z\",\n254\t      \"tool\": \"record_search\",\n255\t      \"query\": {\n256\t        \"surname\": \"Quass\",\n257\t        \"givenName\": \"Kenneth\",\n258\t        \"deathYearFrom\": 1978,\n259\t        \"deathYearTo\": 1986,\n260\t        \"collectionId\": \"2469546\",\n261\t        \"description\": \"Minnesota Obituaries 1865-2006 for Kenneth Quass d. 1982\"\n262\t      },\n263\t      \"outcome\": \"negative\",\n264\t     ..."
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f/research.json",
+        "limit": 150,
+        "offset": 450
+      },
+      "response_summary": "450\t      \"id\": \"log_018\",\n451\t      \"plan_item_id\": \"pli_004\",\n452\t      \"performed\": \"2026-06-29T22:04:44.125Z\",\n453\t      \"tool\": \"record_search\",\n454\t      \"query\": {\n455\t        \"fatherSurname\": \"Quass\",\n456\t        \"collectionId\": \"1949334\",\n457\t        \"birthYearFrom\": 1941,\n458\t        \"birthYearTo\": 1962,\n459\t        \"recordCountry\": \"United States\",\n460\t        \"description\": \"MN Birth Index \u2014 all Quass children 1941-1962 (broad search)\"\n461\t      },\n462\t      \"outcome\": \"negative\",..."
+    },
+    {
+      "tool": "mcp__genealogy__research_append",
+      "args": {
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f",
+        "ops": [
+          {
+            "section": "sources",
+            "op": "append",
+            "entry": {
+              "gedcomx_source_description_id": "WWDC-3KV",
+              "citation": "\"Donald Quass Obituary,\" Dignity Memorial (online, April 2024); FamilySearch, United States Obituary Records 2014\u20132023, ark:/61903/1:1:XM5X-SPSB.",
+              "citation_detail": {
+                "who": "Dignity Memorial / Quass family",
+                "what": "Obituary for Donald Wendell Quass (b. 16 Jan 1940, d. 25 Apr 2024)",
+                "when_created": "April 2024",
+                "when_accessed": "2026-06-29",
+                "where": "FamilySearch, United States Obituary Records 2014\u20132023",
+                "where_within": "Record for Donald Wendell Quass; sibling personas ark:/61903/1:1:XM5X-SPS1 (Jeanette), ark:/61903/1:1:XM5X-SPSP (Ken Quass), ark:/61903/1:1:XM5X-SPSR (Pat Norman)"
+              },
+              "source_classification": "authored",
+              "repository": "FamilySearch",
+              "access_date": "2026-06-29",
+              "url": "https://www.familysearch.org/ark:/61903/1:1:XM5X-SPSB",
+              "url_archived": null,
+              "notes": "Obituary published by Dignity Memorial funeral home, April 2024. Lists three siblings of Donald Wendell Quass, each shown as child of Kenneth Werner Quass and Phylena Ivyl Greenley via ParentChild relationships encoded in the GedcomX record: (1) Jeanette (deceased), (2) Ken Quass (surviving; married Bobbi Quass), (3) Pat Norman (surviving; n\u00e9e Quass, married Bob Norman). Parents Kenneth Werner Quass (d. 17 Sep 1982) and Ivyl Phylena Greenley (d. 24 May 2005) also confirmed.",
+              "transcription": null,
+              "log_entry_id": "log_001"
+            }
+          },
+          {
+            "section": "sources",
+            "op": "append",
+            "entry": {
+              "gedcomx_source_description_id": "S1",
+              "citation": "\"Minnesota Birth Index, 1935\u20132002,\" entry for Alice Jeanette Quass (b. 6 Dec 1940, Watonwan, MN); FamilySearch, collection 1949334, ark:/61903/1:1:VCF7-BY8.",
+              "citation_detail": {
+                "who": "Minnesota Department of Health",
+                "what": "Minnesota Birth Index 1935\u20132002",
+                "when_created": "circa December 1940",
+                "when_accessed": "2026-06-29",
+                "where": "FamilySearch, Minnesota Birth Index 1935\u20132002 (collection 1949334)",
+                "where_within": "Entry for Alice Jeanette Quass, b. 6 Dec 1940, Watonwan, Minnesota; father Kenneth Warner Quass, mother Ivyl Phylena Greenley"
+              },
+              "source_classification": "derivative",
+              "repository": "FamilySearch",
+              "access_date": "2026-06-29",
+              "url": "https://www.familysearch.org/ark:/61903/1:1:VCF7-BY8",
+              "url_archived": null,
+              "notes": "Index entry derived from the original Minnesota birth certificate. Father listed as Kenneth Warner Quass; mother as Ivyl Phylena Greenley. This Jeanette (Alice Jeanette) is the same individual named as a deceased sibling in Donald's 2024 obituary. Original certificate not yet accessed.",
+              "transcription": null,
+              "log_entry_id": "log_005"
+            }
+          },
+          {
+            "section": "sources",
+            "op": "append",
+            "entry": {
+              "gedcomx_source_description_id": "S2",
+              "citation": "\"Minnesota Death Records, 1900\u20131955,\" entry for Alice Jeanette Quass (d. 3 Feb 1955, Madelia, MN); FamilySearch, ark:/61903/1:1:FDX7-8MF.",
+              "citation_detail": {
+                "who": "Minnesota Department of Health",
+                "what": "Minnesota Death Records 1900\u20131955",
+                "when_created": "circa February 1955",
+                "when_accessed": "2026-06-29",
+                "where": "FamilySearch, Minnesota Death Records 1900\u20131955",
+                "where_within": "Entry for Alice Jeanette Quass (b. 6 Dec 1940), d. 3 Feb 1955, Madelia, Watonwan County, Minnesota"
+              },
+              "source_classification": "derivative",
+              "repository": "FamilySearch",
+              "access_date": "2026-06-29",
+              "url": "https://www.familysearch.org/ark:/61903/1:1:FDX7-8MF",
+              "url_archived": null,
+              "notes": "Index entry from Minnesota Death Records 1900\u20131955. Confirms death of Alice Jeanette Quass, daughter of Kenneth Quass and Ivyl Greenley, at Madelia, Watonwan County, MN on 3 Feb 1955 (aged 14). Corroborated by Watonwan County Death Record Index found via fulltext search (log_010). Original death certificate not yet accessed.",
+              "transcription": null,
+              "log_entry_id": "log_003"
+            }
+          },
+          {
+            "section": "sources",
+            "op": "append",
+            "entry": {
+              "gedcomx_source_description_id": "S3",
+              "citation": "Texas Department of Health, Death Certificate for Kenneth Werner Quass, 17 Sep 1982, Tarrant County, Texas; FamilySearch Texas Death Certificates (collection M9J1-953), ark:/61903/3:1:3QS7-8992-XXT.",
+              "citation_detail": {
+                "who": "Texas Department of Health; informant: Kenneth Quass Jr. (son)",
+                "what": "Texas State Death Certificate for Kenneth Werner Quass",
+                "when_created": "17 September 1982",
+                "when_accessed": "2026-06-29",
+                "where": "FamilySearch, Texas Death Certificates (collection M9J1-953)",
+                "where_within": "Certificate for Kenneth Werner Quass, d. 17 Sep 1982, Grapevine, Tarrant County, Texas"
+              },
+              "source_classification": "original",
+              "repository": "FamilySearch",
+              "access_date": "2026-06-29",
+              "url": "https://www.familysearch.org/ark:/61903/3:1:3QS7-8992-XXT",
+              "url_archived": null,
+              "notes": "Texas death certificate for Kenneth Werner Quass (b. 4 Dec 1917, d. 17 Sep 1982, Grapevine TX). Informant: Kenneth Quass Jr. (son), confirming Kenneth Warner Quass Jr. is a son of Kenneth Werner Quass. Surviving spouse: Ivyl Greenley. Residence: 5941 Lancaster Drive, San Diego CA. Parents: Ralph K. Quass, Emma Nehls. Buried Madelia Cemetery, Watonwan MN. NOTE: Accessible via FamilySearch fulltext only (ARK format 3:1:) \u2014 not via record_read endpoint.",
+              "transcription": null,
+              "log_entry_id": "log_010"
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "source_id": "src_001",
+              "record_id": "ark:/61903/1:1:XM5X-SPS1",
+              "record_role": "sibling (deceased)",
+              "record_persona_id": null,
+              "fact_type": "relationship",
+              "value": "Alice Jeanette Quass (Jeanette) named as deceased sibling of Donald Wendell Quass and child of Kenneth Werner Quass and Ivyl Phylena Greenley in Donald's April 2024 obituary",
+              "structured_value": {
+                "relationship_type": "ParentChild",
+                "parents": [
+                  "KNS4-P6W",
+                  "KWZP-4Q8"
+                ],
+                "child_tree_id": "I1",
+                "child_status": "deceased"
+              },
+              "date": null,
+              "date_certainty": null,
+              "place": null,
+              "standard_place": null,
+              "information_quality": "secondary",
+              "informant": "Quass family / Dignity Memorial funeral home",
+              "informant_proximity": "family_not_present",
+              "informant_bias_notes": "Family-prepared obituary; reliable for identifying immediate family members but may omit estranged members or contain minor errors in names.",
+              "evidence_type": "direct",
+              "log_entry_id": "log_001",
+              "extracted_for_question_ids": [
+                "q_001"
+              ]
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "source_id": "src_001",
+              "record_id": "ark:/61903/1:1:XM5X-SPSP",
+              "record_role": "sibling (surviving)",
+              "record_persona_id": null,
+              "fact_type": "relationship",
+              "value": "Kenneth Warner Quass Jr. (Ken Quass) named as surviving sibling of Donald Wendell Quass and child of Kenneth Werner Quass and Ivyl Phylena Greenley in Donald's April 2024 obituary; married Bobbi Quass",
+              "structured_value": {
+                "relationship_type": "ParentChild",
+                "parents": [
+                  "KNS4-P6W",
+                  "KWZP-4Q8"
+                ],
+                "child_tree_id": "I2",
+                "child_status": "surviving_as_of_2024"
+              },
+              "date": null,
+              "date_certainty": null,
+              "place": null,
+              "standard_place": null,
+              "information_quality": "secondary",
+              "informant": "Quass family / Dignity Memorial funeral home",
+              "informant_proximity": "family_not_present",
+              "informant_bias_notes": "Family-prepared obituary; reliable for identifying immediate family members but may omit estranged members or contain minor errors in names.",
+              "evidence_type": "direct",
+              "log_entry_id": "log_001",
+              "extracted_for_question_ids": [
+                "q_001"
+              ]
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "source_id": "src_001",
+              "record_id": "ark:/61903/1:1:XM5X-SPSR",
+              "record_role": "sibling (surviving)",
+              "record_persona_id": null,
+              "fact_type": "relationship",
+              "value": "Patricia Quass Norman (Pat Norman, n\u00e9e Quass) named as surviving sibling of Donald Wendell Quass and child of Kenneth Werner Quass and Ivyl Phylena Greenley in Donald's April 2024 obituary; married Bob Norman",
+              "structured_value": {
+                "relationship_type": "ParentChild",
+                "parents": [
+                  "KNS4-P6W",
+                  "KWZP-4Q8"
+                ],
+                "child_tree_id": "I3",
+                "child_status": "surviving_as_of_2024"
+              },
+              "date": null,
+              "date_certainty": null,
+              "place": null,
+              "standard_place": null,
+              "information_quality": "secondary",
+              "informant": "Quass family / Dignity Memorial funeral home",
+              "informant_proximity": "family_not_present",
+              "informant_bias_notes": "Family-prepared obituary; reliable for identifying immediate family members but may omit estranged members or contain minor errors in names.",
+              "evidence_type": "direct",
+              "log_entry_id": "log_001",
+              "extracted_for_question_ids": [
+                "q_001"
+              ]
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "source_id": "src_002",
+              "record_id": "ark:/61903/1:1:VCF7-BY8",
+              "record_role": "child (principal)",
+              "record_persona_id": null,
+              "fact_type": "birth",
+              "value": "Alice Jeanette Quass born 6 December 1940, Watonwan, Minnesota; father Kenneth Warner Quass, mother Ivyl Phylena Greenley",
+              "structured_value": {
+                "year": 1940,
+                "month": 12,
+                "day": 6,
+                "father": "Kenneth Warner Quass",
+                "mother": "Ivyl Phylena Greenley"
+              },
+              "date": "6 December 1940",
+              "date_certainty": "exact",
+              "place": "Watonwan, Minnesota",
+              "standard_place": "Watonwan, Minnesota, United States",
+              "information_quality": "primary",
+              "informant": "Parents (Kenneth Quass and Ivyl Greenley Quass) / Minnesota birth registrar",
+              "informant_proximity": "official_duty",
+              "informant_bias_notes": null,
+              "evidence_type": "direct",
+              "log_entry_id": "log_005",
+              "extracted_for_question_ids": [
+                "q_001"
+              ]
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "source_id": "src_002",
+              "record_id": "ark:/61903/1:1:VCF7-BY8",
+              "record_role": "child (principal)",
+              "record_persona_id": null,
+              "fact_type": "relationship",
+              "value": "Alice Jeanette Quass's father is Kenneth Warner Quass and mother is Ivyl Phylena Greenley, per Minnesota Birth Index 1935\u20132002 entry for her 6 Dec 1940 birth in Watonwan, Minnesota",
+              "structured_value": {
+                "relationship_type": "ParentChild",
+                "father": "Kenneth Warner Quass",
+                "mother": "Ivyl Phylena Greenley",
+                "child": "Alice Jeanette Quass"
+              },
+              "date": "6 December 1940",
+              "date_certainty": "exact",
+              "place": "Watonwan, Minnesota",
+              "standard_place": "Watonwan, Minnesota, United States",
+              "information_quality": "primary",
+              "informant": "Parents (Kenneth Quass and Ivyl Greenley Quass) / Minnesota birth registrar",
+              "informant_proximity": "official_duty",
+              "informant_bias_notes": null,
+              "evidence_type": "direct",
+              "log_entry_id": "log_005",
+              "extracted_for_question_ids": [
+                "q_001"
+              ]
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "source_id": "src_003",
+              "record_id": "ark:/61903/1:1:FDX7-8MF",
+              "record_role": "deceased (principal)",
+              "record_persona_id": null,
+              "fact_type": "death",
+              "value": "Alice Jeanette Quass died 3 February 1955, Madelia, Watonwan County, Minnesota; aged 14",
+              "structured_value": {
+                "year": 1955,
+                "month": 2,
+                "day": 3
+              },
+              "date": "3 February 1955",
+              "date_certainty": "exact",
+              "place": "Madelia, Watonwan County, Minnesota",
+              "standard_place": "Madelia, Watonwan, Minnesota, United States",
+              "information_quality": "primary",
+              "informant": "Family members / Minnesota death registrar",
+              "informant_proximity": "official_duty",
+              "informant_bias_notes": null,
+              "evidence_type": "direct",
+              "log_entry_id": "log_003",
+              "extracted_for_question_ids": [
+                "q_001"
+              ]
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "source_id": "src_004",
+              "record_id": "ark:/61903/3:1:3QS7-8992-XXT",
+              "record_role": "informant (son of decedent)",
+              "record_persona_id": null,
+              "fact_type": "relationship",
+              "value": "Kenneth Warner Quass Jr. signed as informant on Kenneth Werner Quass's 17 Sep 1982 Texas death certificate, confirming he is a son of Kenneth Werner Quass; surviving spouse listed as Ivyl Greenley corroborates he is also a son of Ivyl Phylena Greenley Quass",
+              "structured_value": {
+                "relationship_type": "ParentChild",
+                "parent": "Kenneth Werner Quass (KNS4-P6W)",
+                "child": "Kenneth Warner Quass Jr. (I2)",
+                "informant_role": "son"
+              },
+              "date": "17 September 1982",
+              "date_certainty": "exact",
+              "place": "Grapevine, Tarrant County, Texas",
+              "standard_place": "Grapevine, Tarrant, Texas, United States",
+              "information_quality": "primary",
+              "informant": "Kenneth Warner Quass Jr. (son of decedent)",
+              "informant_proximity": "family_not_present",
+              "informant_bias_notes": null,
+              "evidence_type": "indirect",
+              "log_entry_id": "log_010",
+              "extracted_for_question_ids": [
+                "q_001"
+              ]
+            }
+          }
+        ]
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"results\\\": [\\n    {\\n      \\\"section\\\": \\\"sources\\\",\\n      \\\"op\\\": \\\"append\\\",\\n      \\\"entryId\\\": \\\"src_001\\\"\\n    },\\n    {\\n      \\\"section\\\": \\\"sources\\\",\\n      \\\"op\\\": \\\"append\\\",\\n      \\\"entryId\\\": \\\"src_002\\\"\\n    },\\n    {\\n      \\\"section\\\": \\\"sources\\\",\\n      \\\"op\\\": \\\"append\\\",\\n      \\\"entryId\\\": \\\"src_003\\\"\\n    },\\n    {\\n      \\\"section\\\": \\\"sources\\\",\\n      \\\"op\\\": \\\"append\\\",\\n      \\\"entryId\\\": \\\"src_004\\\"\\n    },\\n    ..."
+    },
+    {
+      "tool": "Glob",
+      "args": {
+        "pattern": "**/*.md",
+        "path": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f/.claude/skills"
+      },
+      "response_summary": ".claude/skills/assertion-classification/references/three-layer-model.md\n.claude/skills/assertion-classification/references/validation-protocol.md\n.claude/skills/check-warnings/references/assumption-categories.md\n.claude/skills/check-warnings/references/warning-checks.md\n.claude/skills/check-warnings/references/warnings-as-identity-signals.md\n.claude/skills/citation/references/gps-citation-standards.md\n.claude/skills/citation/references/validation-protocol.md\n.claude/skills/conflict-resolution..."
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f/.claude/skills/person-evidence/SKILL.md",
+        "limit": 120
+      },
+      "response_summary": "1\t---\n2\tname: person-evidence\n3\tmodel: claude-sonnet-4-6\n4\tdescription: Links assertions to GedcomX persons \u2014 the identity-resolution\n5\t  step. Evaluates whether the person in role X of record Y is the same as\n6\t  GedcomX person Z. Creates person_evidence entries with confidence and\n7\t  rationale, enforces match threshold policy, and creates stub persons when\n8\t  no existing person matches. Also reviews and audits existing\n9\t  person_evidence entries \u2014 confirming confidence calibration on a l..."
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f/.claude/skills/person-evidence/SKILL.md",
+        "limit": 120,
+        "offset": 120
+      },
+      "response_summary": "120\tformat templates.\n121\t\n122\t## Steps\n123\t\n124\t### 0. Identify the request mode\n125\t\n126\tBefore any linking work, decide which mode the user has invoked:\n127\t\n128\t**Guard \u2014 wrong skill (decline):** If the user is asking to **find, search\n129\tfor, or pull new records** \u2014 even to *confirm*, *strengthen*, or *disprove* an\n130\tidentity (e.g. \"find more records confirming X is the same person\", \"search for\n131\tadditional sources on this person\") \u2014 this is **not** a person-evidence task.\n132\tDo *..."
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f/.claude/skills/person-evidence/SKILL.md",
+        "limit": 100,
+        "offset": 240
+      },
+      "response_summary": "240\t     find the candidate's parents (ParentChild rels where `child` is the\n241\t     candidate), then the children of those parents. The simplified\n242\t     format can't always tell half- from full-siblings, so include all\n243\t     children of all parents \u2014 the match algorithm tolerates this.\n244\t   - **Cap the mob at 40 people** (mirrors the FS\n245\t     `MAX_CHILDREN_TO_COMPARE` limit) so a very large family doesn't\n246\t     bloat the `same_person` payload. If a family exceeds 40, keep the\n..."
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f/.claude/skills/person-evidence/SKILL.md",
+        "limit": 80,
+        "offset": 340
+      },
+      "response_summary": "340\t    {\n341\t      section: \"person_evidence\",\n342\t      op: \"append\",\n343\t      entry: {\n344\t        assertion_id: \"a_015\",\n345\t        person_id: \"KWCJ-RN4\",\n346\t        confidence: \"probable\",\n347\t        rationale: \"Thomas Flynn, will dated 1881, Schuylkill County. Names match. Location matches (same county as census records). Death date consistent with disappearance from tax records after 1880. Will names 'my son Patrick' \u2014 this assertion links the testator role to the Thomas Flynn (I2)..."
+    },
+    {
+      "tool": "mcp__genealogy__research_append",
+      "args": {
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f",
+        "ops": [
+          {
+            "section": "person_evidence",
+            "op": "append",
+            "entry": {
+              "assertion_id": "a_001",
+              "person_id": "I1",
+              "confidence": "confident",
+              "rationale": "Donald Quass's April 2024 obituary names 'Jeanette' as a deceased sibling and child of Kenneth Werner Quass and Ivyl Phylena Greenley. MN Birth Index (a_004) confirms Alice Jeanette Quass was born 6 Dec 1940 in Watonwan MN to these same parents; MN Death Records (a_006) confirm she died 3 Feb 1955. The obituary's 'Jeanette' (a nickname from her middle name) maps to Alice Jeanette Quass (I1). Name, deceased status, parents, and location all agree.",
+              "match_score": null
+            }
+          },
+          {
+            "section": "person_evidence",
+            "op": "append",
+            "entry": {
+              "assertion_id": "a_001",
+              "person_id": "KNS4-P6W",
+              "confidence": "confident",
+              "rationale": "The obituary encodes a ParentChild relationship from Kenneth Werner Quass (p_306774614787) to Jeanette. The GedcomX encoding in the obituary record matches the FamilySearch tree person KNS4-P6W (Kenneth Werner Quass Sr.) on name and established identity. No competing candidates.",
+              "match_score": null
+            }
+          },
+          {
+            "section": "person_evidence",
+            "op": "append",
+            "entry": {
+              "assertion_id": "a_001",
+              "person_id": "KWZP-4Q8",
+              "confidence": "confident",
+              "rationale": "The obituary encodes a ParentChild relationship from Ivyl Phylena Greenley (p_306774614788) to Jeanette. The GedcomX encoding maps to KWZP-4Q8 (Ivyl Phylena Greenley) on name and established identity. No competing candidates.",
+              "match_score": null
+            }
+          },
+          {
+            "section": "person_evidence",
+            "op": "append",
+            "entry": {
+              "assertion_id": "a_002",
+              "person_id": "I2",
+              "confidence": "confident",
+              "rationale": "Donald Quass's 2024 obituary names 'Ken Quass' (married Bobbi Quass) as a surviving sibling and child of Kenneth Werner Quass and Ivyl Phylena Greenley. Texas death certificate (a_007) independently confirms 'Kenneth Quass Jr.' as a son and informant on Kenneth Sr.'s 1982 death certificate. MN Birth Index (log_008) shows Kenneth Warner Quass Jr. as father of children born 1965-1974 in Hennepin County, consistent with living in Minnesota. Name, role, and corroborating records all identify this persona as I2 Kenneth Warner Quass Jr.",
+              "match_score": null
+            }
+          },
+          {
+            "section": "person_evidence",
+            "op": "append",
+            "entry": {
+              "assertion_id": "a_002",
+              "person_id": "KNS4-P6W",
+              "confidence": "confident",
+              "rationale": "The obituary's ParentChild encoding from Kenneth Werner Quass to Ken Quass matches KNS4-P6W by name and established identity.",
+              "match_score": null
+            }
+          },
+          {
+            "section": "person_evidence",
+            "op": "append",
+            "entry": {
+              "assertion_id": "a_002",
+              "person_id": "KWZP-4Q8",
+              "confidence": "confident",
+              "rationale": "The obituary's ParentChild encoding from Ivyl Phylena Greenley to Ken Quass matches KWZP-4Q8 by name and established identity.",
+              "match_score": null
+            }
+          },
+          {
+            "section": "person_evidence",
+            "op": "append",
+            "entry": {
+              "assertion_id": "a_003",
+              "person_id": "I3",
+              "confidence": "confident",
+              "rationale": "Donald Quass's 2024 obituary names 'Pat Norman' (n\u00e9e Quass, married Bob Norman) as a surviving sibling and child of Kenneth Werner Quass and Ivyl Phylena Greenley. The full-text search (log_013) found a 1991 Alabama newspaper naming Ann Gabrielle Quass-Little as daughter of 'Kenneth Wuass' (= Quass) of Plymouth MN \u2014 the same family cluster. Name, married name, sibling role, and family context identify this persona as I3 Patricia Quass Norman.",
+              "match_score": null
+            }
+          },
+          {
+            "section": "person_evidence",
+            "op": "append",
+            "entry": {
+              "assertion_id": "a_003",
+              "person_id": "KNS4-P6W",
+              "confidence": "confident",
+              "rationale": "The obituary's ParentChild encoding from Kenneth Werner Quass to Pat Norman matches KNS4-P6W by name and established identity.",
+              "match_score": null
+            }
+          },
+          {
+            "section": "person_evidence",
+            "op": "append",
+            "entry": {
+              "assertion_id": "a_003",
+              "person_id": "KWZP-4Q8",
+              "confidence": "confident",
+              "rationale": "The obituary's ParentChild encoding from Ivyl Phylena Greenley to Pat Norman matches KWZP-4Q8 by name and established identity.",
+              "match_score": null
+            }
+          },
+          {
+            "section": "person_evidence",
+            "op": "append",
+            "entry": {
+              "assertion_id": "a_004",
+              "person_id": "I1",
+              "confidence": "confident",
+              "rationale": "Minnesota Birth Index (collection 1949334) entry for Alice Jeanette Quass, b. 6 Dec 1940, Watonwan MN, father Kenneth Warner Quass, mother Ivyl Phylena Greenley. Exact name match to I1. Birth year (1940), county (Watonwan), and parents (Quass/Greenley) all match established facts for I1. This is the primary birth record supporting I1's identity.",
+              "match_score": null
+            }
+          },
+          {
+            "section": "person_evidence",
+            "op": "append",
+            "entry": {
+              "assertion_id": "a_005",
+              "person_id": "I1",
+              "confidence": "confident",
+              "rationale": "Same MN Birth Index entry as a_004 \u2014 the parentage fact (father Kenneth Warner Quass, mother Ivyl Phylena Greenley) in the birth record directly identifies I1 Alice Jeanette Quass and establishes her parents.",
+              "match_score": null
+            }
+          },
+          {
+            "section": "person_evidence",
+            "op": "append",
+            "entry": {
+              "assertion_id": "a_005",
+              "person_id": "KNS4-P6W",
+              "confidence": "confident",
+              "rationale": "The MN Birth Index entry for Alice Jeanette Quass names Kenneth Warner Quass as father. This is consistent with KNS4-P6W (Kenneth Werner Quass, b. 4 Dec 1917, Iowa), who was residing in Watonwan County MN by 1940. Minor variant spelling 'Warner' vs 'Werner' is consistent with name spelling variation in indexed records.",
+              "match_score": null
+            }
+          },
+          {
+            "section": "person_evidence",
+            "op": "append",
+            "entry": {
+              "assertion_id": "a_005",
+              "person_id": "KWZP-4Q8",
+              "confidence": "confident",
+              "rationale": "The MN Birth Index entry names Ivyl Phylena Greenley as mother, exactly matching KWZP-4Q8 (Ivyl Phylena Greenley, b. 26 May 1914). Name and location (Watonwan County) match the established profile.",
+              "match_score": null
+            }
+          },
+          {
+            "section": "person_evidence",
+            "op": "append",
+            "entry": {
+              "assertion_id": "a_006",
+              "person_id": "I1",
+              "confidence": "confident",
+              "rationale": "MN Death Records 1900-1955 entry for Alice Jeanette Quass, d. 3 Feb 1955, Madelia, Watonwan County MN. The name, birth year (1940, per MN Birth Index), and location (Watonwan County) are consistent with I1. Death at age 14 is biologically plausible. This record corroborates the obituary's identification of 'Jeanette' as a deceased sibling.",
+              "match_score": null
+            }
+          },
+          {
+            "section": "person_evidence",
+            "op": "append",
+            "entry": {
+              "assertion_id": "a_007",
+              "person_id": "I2",
+              "confidence": "confident",
+              "rationale": "Texas death certificate for Kenneth Werner Quass Sr. (1982) lists informant as 'Kenneth Quass Jr.' The 'Jr.' suffix, same surname, and informant role together identify this person as I2 Kenneth Warner Quass Jr. (son of KNS4-P6W). This is independently corroborated by the obituary (a_002). MN Birth Index (log_008) further confirms a Kenneth Warner Quass Jr. was father of children in Hennepin County MN 1965-1974.",
+              "match_score": null
+            }
+          },
+          {
+            "section": "person_evidence",
+            "op": "append",
+            "entry": {
+              "assertion_id": "a_007",
+              "person_id": "KNS4-P6W",
+              "confidence": "confident",
+              "rationale": "The Texas death certificate is for Kenneth Werner Quass (KNS4-P6W): DoB 12-4-1917 (vs. 4 Dec 1917 per tree), DoD 17 Sep 1982 (matches), Tarrant County TX (matches), SS# 483-03-9478, parents Ralph K. Quass and Emma Nehls (both match tree). Identity of the decedent as KNS4-P6W is unambiguous.",
+              "match_score": null
+            }
+          }
+        ]
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"results\\\": [\\n    {\\n      \\\"section\\\": \\\"person_evidence\\\",\\n      \\\"op\\\": \\\"append\\\",\\n      \\\"entryId\\\": \\\"pe_001\\\"\\n    },\\n    {\\n      \\\"section\\\": \\\"person_evidence\\\",\\n      \\\"op\\\": \\\"append\\\",\\n      \\\"entryId\\\": \\\"pe_002\\\"\\n    },\\n    {\\n      \\\"section\\\": \\\"person_evidence\\\",\\n      \\\"op\\\": \\\"append\\\",\\n      \\\"entryId\\\": \\\"pe_003\\\"\\n    },\\n    {\\n      \\\"section\\\": \\\"person_evidence\\\",\\n      \\\"op\\\": \\\"append\\\",\\n      \\\"entryId..."
+    },
+    {
+      "tool": "mcp__genealogy__research_append",
+      "args": {
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f",
+        "ops": [
+          {
+            "section": "plan_items",
+            "op": "update",
+            "planId": "pl_001",
+            "entryId": "pli_001",
+            "fields": {
+              "status": "completed"
+            }
+          },
+          {
+            "section": "plan_items",
+            "op": "update",
+            "planId": "pl_001",
+            "entryId": "pli_002",
+            "fields": {
+              "status": "completed"
+            }
+          },
+          {
+            "section": "plan_items",
+            "op": "update",
+            "planId": "pl_001",
+            "entryId": "pli_003",
+            "fields": {
+              "status": "completed"
+            }
+          },
+          {
+            "section": "plan_items",
+            "op": "update",
+            "planId": "pl_001",
+            "entryId": "pli_004",
+            "fields": {
+              "status": "completed"
+            }
+          },
+          {
+            "section": "plan_items",
+            "op": "update",
+            "planId": "pl_001",
+            "entryId": "pli_005",
+            "fields": {
+              "status": "completed"
+            }
+          },
+          {
+            "section": "plan_items",
+            "op": "update",
+            "planId": "pl_001",
+            "entryId": "pli_007",
+            "fields": {
+              "status": "completed"
+            }
+          },
+          {
+            "section": "plan_items",
+            "op": "update",
+            "planId": "pl_001",
+            "entryId": "pli_008",
+            "fields": {
+              "status": "completed"
+            }
+          }
+        ]
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"results\\\": [\\n    {\\n      \\\"section\\\": \\\"plan_items\\\",\\n      \\\"op\\\": \\\"update\\\",\\n      \\\"entryId\\\": \\\"pli_001\\\"\\n    },\\n    {\\n      \\\"section\\\": \\\"plan_items\\\",\\n      \\\"op\\\": \\\"update\\\",\\n      \\\"entryId\\\": \\\"pli_002\\\"\\n    },\\n    {\\n      \\\"section\\\": \\\"plan_items\\\",\\n      \\\"op\\\": \\\"update\\\",\\n      \\\"entryId\\\": \\\"pli_003\\\"\\n    },\\n    {\\n      \\\"section\\\": \\\"plan_items\\\",\\n      \\\"op\\\": \\\"update\\\",\\n      \\\"entryId\\\": \\\"pli_004\\\"\\n..."
+    },
+    {
+      "tool": "mcp__genealogy__research_log_append",
+      "args": {
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f",
+        "tool": "external_site",
+        "planItemId": "pli_006",
+        "query": {
+          "description": "GenealogyBank search for Ivyl Quass obituary, San Diego CA, 2005",
+          "name": "Ivyl Quass",
+          "keywords": "Ivyl Quass obituary 2005",
+          "site": "GenealogyBank"
+        },
+        "outcome": "partial",
+        "resultsExamined": 0,
+        "notes": "URL generated for GenealogyBank search for Ivyl Phylena Greenley Quass obituary (d. 24 May 2005, San Diego CA). In autonomous mode, capture was not received \u2014 results require human retrieval. Ivyl's obituary would be in the San Diego Union-Tribune (May 2005) and would likely name surviving children (Kenneth Jr., Pat Norman) with possible birth year information. This is the primary remaining source for birth year data on Kenneth Jr. and Patricia Norman. FamilySearch fulltext search (log_017) returned zero results for this obituary, confirming it is not in any indexed FamilySearch collection.",
+        "externalSite": {
+          "site": "newspapers",
+          "urlGenerated": "https://genealogybank.com/find/obituaries/name/Ivyl-Quass/from/2005/to/2005/state/California",
+          "captureReceived": false
+        }
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"logId\\\": \\\"log_019\\\",\\n  \\\"performed\\\": \\\"2026-06-29T22:19:31.022Z\\\",\\n  \\\"resultsRef\\\": null,\\n  \\\"returnedCount\\\": null,\\n  \\\"filesWritten\\\": [\\n    \\\"research.json\\\"\\n  ],\\n  \\\"validation\\\": {\\n    \\\"valid\\\": true,\\n    \\\"warnings\\\": []\\n  }\\n}\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__research_append",
+      "args": {
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f",
+        "section": "plan_items",
+        "op": "update",
+        "planId": "pl_001",
+        "entryId": "pli_006",
+        "fields": {
+          "status": "skipped"
+        }
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"section\\\": \\\"plan_items\\\",\\n  \\\"op\\\": \\\"update\\\",\\n  \\\"entryId\\\": \\\"pli_006\\\",\\n  \\\"filesWritten\\\": [\\n    \\\"research.json\\\"\\n  ],\\n  \\\"validation\\\": {\\n    \\\"valid\\\": true,\\n    \\\"warnings\\\": []\\n  }\\n}\"}]"
+    },
+    {
+      "tool": "Glob",
+      "args": {
+        "pattern": "evaluations/*",
+        "path": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f"
+      },
+      "response_summary": "No files found"
+    },
+    {
+      "tool": "Agent",
+      "args": {
+        "description": "GPS mentor pre-exhaustiveness review for q_001",
+        "subagent_type": "gps-mentor",
+        "prompt": "Please perform a GPS mentor review with focus: \"pre-exhaustiveness\" and target_id: \"q_001\".\n\nProject directory: /private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f\n\nResearch question q_001: \"Did Kenneth Werner Quass (b. 4 Dec 1917, Sumner, Bremer County, Iowa; d. 17 Sep 1982) and Ivyl Phylena Greenley (b. 26 May 1914, Dubuque County, Iowa; d. 24 May 2005) have any children other than Donald Wendell Quass (b. 16 Jan 1940)?\"\n\nContext summary:\n- 3 additional children identified: (1) Alice Jeanette Quass (b. 6 Dec 1940, d. 3 Feb 1955), (2) Kenneth Warner Quass Jr. (alive as of Apr 2024), (3) Patricia Quass Norman (alive as of Apr 2024)\n- Primary evidence: Donald's April 2024 obituary (FamilySearch United States Obituary Records, ark:/61903/1:1:XM5X-SPSB) \u2014 GedcomX ParentChild relationships encoding all three as children of Kenneth Werner Quass and Ivyl Phylena Greenley\n- Corroborating: MN Birth Index (ark:/61903/1:1:VCF7-BY8) confirms Alice Jeanette birth 6 Dec 1940, Watonwan MN, parents Kenneth Warner Quass + Ivyl Phylena Greenley\n- Corroborating: MN Death Records (ark:/61903/1:1:FDX7-8MF) confirms Alice Jeanette death 3 Feb 1955, Madelia MN\n- Corroborating: Texas Death Certificate 1982 for Kenneth Sr. (ark:/61903/3:1:3QS7-8992-XXT) \u2014 informant \"Kenneth Quass Jr.\" = son\n- Negative: 1950 census not found; MN Birth Index not found for Kenneth Jr. or Patricia; Iowa birth records negative; MN obituaries negative (Kenneth Sr. died in TX)\n- pli_006 (Ivyl's 2005 San Diego obituary) was not retrievable in autonomous mode \u2014 external site search URL generated but no capture\n\nPlease read the research.json and tree.gedcomx.json files and evaluate whether the research is ready for a research-exhaustiveness declaration, or whether there are gaps that must be addressed first."
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"I have read both files thoroughly. Let me check whether a prior verdict exists for this focus + target, and note the plan-item statuses for the refusal check.\\n\\nThe refusal check: `pre-exhaustiveness` must refuse if any plan items are `in_progress`. Scanning pl_001: pli_001 through pli_005, pli_007, pli_008 are `completed`; pli_006 is `skipped`. No item is `in_progress`. A plan exists. So no refusal \\u2014 I proceed to evaluate.\\n\\nThere is no `evaluations/` direct..."
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f/research.json"
+      },
+      "response_summary": "1\t{\n2\t  \"project\": {\n3\t    \"id\": \"rp_ivyl_greenley_daughter\",\n4\t    \"objective\": \"Besides their son Donald, did Ivyl Phylena Greenley and her husband Kenneth Werner Quass have any other children? Identify each additional child and that child's birth and death dates.\",\n5\t    \"subject_person_ids\": [\n6\t      \"KWZP-4Q8\"\n7\t    ],\n8\t    \"status\": \"active\",\n9\t    \"created\": \"2026-06-29T00:00:00Z\",\n10\t    \"updated\": \"2026-06-29T00:00:00Z\"\n11\t  },\n12\t  \"researcher_profile\": {\n13\t    \"experience_level\"..."
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f/tree.gedcomx.json"
+      },
+      "response_summary": "1\t{\n2\t  \"persons\": [\n3\t    {\n4\t      \"id\": \"KWZP-4Q8\",\n5\t      \"gender\": \"Female\",\n6\t      \"living\": false,\n7\t      \"names\": [\n8\t        {\n9\t          \"given\": \"Ivyl Phylena\",\n10\t          \"surname\": \"Greenley\",\n11\t          \"id\": \"KWZP-4Q8-name-1\"\n12\t        }\n13\t      ],\n14\t      \"facts\": [\n15\t        {\n16\t          \"id\": \"248eaba5-34ae-4182-9874-bfcc07166241\",\n17\t          \"type\": \"Birth\",\n18\t          \"date\": \"26 May 1914\",\n19\t          \"standard_date\": \"26 May 1914\",\n20\t          \"place\"..."
+    },
+    {
+      "tool": "Bash",
+      "args": {
+        "command": "mkdir -p /private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f/evaluations",
+        "description": "Create evaluations directory"
+      },
+      "response_summary": "Permission to use Bash has been denied because Claude Code is running in don't ask mode. IMPORTANT: You *may* attempt to accomplish this action using other tools that might naturally be used to accomplish this goal, e.g. using head instead of cat. But you *should not* attempt to work around this denial in malicious ways, e.g. do not use your ability to run tests to execute non-test actions. You should only try to work around this restriction in reasonable ways that do not attempt to bypass th..."
+    },
+    {
+      "tool": "Write",
+      "args": {
+        "file_path": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f/evaluations/pre-exhaustiveness-q_001-2026-06-29T222000Z.json",
+        "content": "{\n  \"focus\": \"pre-exhaustiveness\",\n  \"target_id\": \"q_001\",\n  \"target_type\": \"question\",\n  \"verdict\": \"address_first\",\n  \"timestamp\": \"2026-06-29T22:20:00Z\",\n  \"strengths\": [\n    \"Negative-result documentation (Standard 13) is genuinely strong: log_005/006/008/009/012/013/018 record nil searches with full parameters and reasoning, distinguishing them from unsearched types.\",\n    \"Independence of the core finding is sound: two genuinely independent sources \u2014 the 2024 obituary ParentChild encoding (a_001/a_002/a_003) and the 1982 Texas death certificate naming Kenneth Quass Jr. as informant-son (a_007) \u2014 plus MN vital records for Alice Jeanette (a_004/a_006).\",\n    \"pli_002 correctly excluded a false lead: the Bernice Quass Wegner obituary was analyzed and correctly identified as Kenneth's family of origin, not his children.\",\n    \"Identity reasoning in pe_001 (mapping 'Jeanette' in obituary to Alice Jeanette Quass via middle-name nickname + matching parents + deceased status) is careful and explicit.\"\n  ],\n  \"must_address\": [\n    {\n      \"standard\": \"Standard 14 \u2014 topical breadth (highest-value record)\",\n      \"issue\": \"The 1950 US Census was never actually located despite three attempts (log_003, log_004, log_016); the researcher concluded the collection may not be indexed. This is the single most decisive record for household composition and remains an unworked gap, not a documented nil. It would also fix Kenneth Jr.'s and Patricia's birth years.\",\n      \"what_would_change_my_mind\": \"Either a successful 1950 census capture for the Quass household in Watonwan/Madelia, OR a documented browse of the unindexed 1950 enumeration district images for Madelia with a recorded result.\",\n      \"suggested_skill\": \"search-records\",\n      \"specific_action\": \"Locate the 1950 ED for Madelia, Watonwan County, MN and browse the image set directly (FamilySearch 1950 Census images are browsable by ED even where name-indexing is incomplete).\"\n    },\n    {\n      \"standard\": \"Standard 14 \u2014 topical breadth (objective completeness)\",\n      \"issue\": \"The objective explicitly requires each child's birth AND death dates. Kenneth Warner Quass Jr.'s and Patricia Quass Norman's birth dates are entirely unestablished. The question cannot be answered in full until at least approximate birth data is documented or its absence is explained.\",\n      \"what_would_change_my_mind\": \"Capture of Ivyl's 2005 San Diego obituary (pli_006, currently skipped) \u2014 the source most likely to name Kenneth Jr. and Patricia with ages/birth years \u2014 OR a 1950 census enumeration giving their ages, OR a documented reasoning trail explaining why birth dates for living persons remain undeterminable from available records.\",\n      \"suggested_skill\": \"search-external-sites\",\n      \"specific_action\": \"Re-run the pli_006 GenealogyBank/Newspapers.com search for Ivyl Quass (San Diego, May 2005) with human-in-the-loop capture.\"\n    }\n  ],\n  \"consider_addressing\": [\n    {\n      \"standard\": \"Standard 32 \u2014 original vs. derivative\",\n      \"issue\": \"src_002 and src_003 (Alice Jeanette's birth and death) are index derivatives; both note 'Original certificate not yet accessed.' Original MN certificates would firm up the dates and the death certificate may name surviving siblings.\",\n      \"specific_action\": \"Order or locate the original Minnesota birth (1940) and death (1955) certificates for Alice Jeanette Quass.\"\n    },\n    {\n      \"standard\": \"Repository diversity\",\n      \"issue\": \"Every executed search is FamilySearch; the sole external attempt (pli_006) yielded only a generated URL with no capture. Single-repository research leaves index gaps unprobed.\",\n      \"specific_action\": \"Add at least one non-FamilySearch repository pass (Ancestry, Newspapers.com, or the Minnesota Historical Society) for the 1950 census and Ken Jr./Patricia birth records.\"\n    },\n    {\n      \"standard\": \"FAN coverage (children's descendants)\",\n      \"issue\": \"log_013 incidentally surfaced Ann Gabrielle Quass-Little, daughter of Kenneth Jr. (Plymouth, MN, 1991), but this lead was not pursued. His children's birth records (1965-1974, Hennepin County, log_008) can triangulate his birth window.\",\n      \"specific_action\": \"Follow the Kenneth Jr. Hennepin County thread to triangulate his birth year.\"\n    }\n  ],\n  \"non_blocking_notes\": [\n    \"tree.gedcomx.json geocoding artifacts to correct: I1 death F2 standard_place resolves to 'Madelia, Cleburne, Arkansas' (should be Madelia, Watonwan, Minnesota); Ivyl 1915 residence resolves to 'Farley, Saskatchewan, Canada'; Herbert 1935 'Same Place' resolves to Timor-Leste.\",\n    \"a_007 correctly classified as evidence_type 'indirect' \u2014 informant role implies sonship but does not state it explicitly.\"\n  ],\n  \"narrative_for_user\": \"The core finding (three additional children: Alice Jeanette, Kenneth Jr., Patricia) is independently grounded and well-documented. Two must_address items remain before declaring exhaustive: (1) the 1950 census for Madelia, Watonwan County was never successfully located \u2014 browsing the unindexed ED images would close this gap and likely provide birth-year data for Kenneth Jr. and Patricia; (2) Kenneth Jr.'s and Patricia's birth dates are entirely unestablished, and Ivyl's 2005 San Diego obituary (pli_006, skipped in autonomous mode) is the most promising remaining source for this data. Closing these two gaps would put the research in excellent shape for exhaustiveness declaration.\"\n}\n"
+      },
+      "response_summary": "File created successfully at: /private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f/evaluations/pre-exhaustiveness-q_001-2026-06-29T222000Z.json (file state is current in your context \u2014 no need to Read it back)"
+    },
+    {
+      "tool": "mcp__genealogy__research_append",
+      "args": {
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f",
+        "section": "evaluations",
+        "op": "append",
+        "entry": {
+          "focus": "pre-exhaustiveness",
+          "target_id": "q_001",
+          "target_type": "question",
+          "verdict": "address_first",
+          "file_path": "evaluations/pre-exhaustiveness-q_001-2026-06-29T222000Z.json",
+          "timestamp": "2026-06-29T22:20:00Z",
+          "superseded_by": null
+        }
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"section\\\": \\\"evaluations\\\",\\n  \\\"op\\\": \\\"append\\\",\\n  \\\"entryId\\\": \\\"ev_001\\\",\\n  \\\"filesWritten\\\": [\\n    \\\"research.json\\\"\\n  ],\\n  \\\"validation\\\": {\\n    \\\"valid\\\": true,\\n    \\\"warnings\\\": []\\n  }\\n}\"}]"
+    },
+    {
+      "tool": "ToolSearch",
+      "args": {
+        "query": "select:mcp__genealogy__image_search,mcp__genealogy__image_read,mcp__genealogy__fulltext_search",
+        "max_results": 3
+      },
+      "response_summary": "[{\"type\": \"tool_reference\", \"tool_name\": \"mcp__genealogy__image_search\"}, {\"type\": \"tool_reference\", \"tool_name\": \"mcp__genealogy__image_read\"}, {\"type\": \"tool_reference\", \"tool_name\": \"mcp__genealogy__fulltext_search\"}]"
+    },
+    {
+      "tool": "ToolSearch",
+      "args": {
+        "query": "select:mcp__genealogy__volume_search",
+        "max_results": 1
+      },
+      "response_summary": "[{\"type\": \"tool_reference\", \"tool_name\": \"mcp__genealogy__volume_search\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__volume_search",
+      "args": {
+        "standardPlace": "Watonwan, Minnesota, United States",
+        "startYear": 1950,
+        "endYear": 1950
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"query\\\": {\\n    \\\"standardPlace\\\": \\\"Watonwan, Minnesota, United States\\\",\\n    \\\"startYear\\\": 1950,\\n    \\\"endYear\\\": 1950\\n  },\\n  \\\"totalResults\\\": 30,\\n  \\\"results\\\": [\\n    {\\n      \\\"imageGroupNumber\\\": \\\"007413029_002_M99V-LL5\\\",\\n      \\\"imageGroupPrefix\\\": \\\"007413029\\\",\\n      \\\"imageCount\\\": 100,\\n      \\\"recordSearchablePercent\\\": 100,\\n      \\\"fulltextSearchable\\\": true,\\n      \\\"languages\\\": [\\n        \\\"en\\\"\\n      ],\\n      \\\"coverages\\\": [\\n ..."
+    },
+    {
+      "tool": "mcp__genealogy__record_search",
+      "args": {
+        "surname": "Quass",
+        "givenName": "Kenneth",
+        "residenceYearFrom": 1950,
+        "residenceYearTo": 1950,
+        "imageGroupNumber": "108956928",
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f"
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"query\\\": {\\n    \\\"surname\\\": \\\"Quass\\\",\\n    \\\"givenName\\\": \\\"Kenneth\\\",\\n    \\\"residenceYearFrom\\\": 1950,\\n    \\\"residenceYearTo\\\": 1950,\\n    \\\"imageGroupNumber\\\": \\\"108956928\\\",\\n    \\\"projectPath\\\": \\\"/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f\\\"\\n  },\\n  \\\"totalMatches\\\": 0,\\n  \\\"paginationCappedAt\\\": 4999,\\n  \\\"returned\\\": 0,\\n  \\\"offset\\\": 0,\\n  \\\"hasMore\\\": false,\\n  \\\"results\\\": [],\\n  \\\"staged\\\": null..."
+    },
+    {
+      "tool": "mcp__genealogy__record_search",
+      "args": {
+        "surname": "Quass",
+        "imageGroupNumber": "108956928",
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f"
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"query\\\": {\\n    \\\"surname\\\": \\\"Quass\\\",\\n    \\\"imageGroupNumber\\\": \\\"108956928\\\",\\n    \\\"projectPath\\\": \\\"/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f\\\"\\n  },\\n  \\\"totalMatches\\\": 0,\\n  \\\"paginationCappedAt\\\": 4999,\\n  \\\"returned\\\": 0,\\n  \\\"offset\\\": 0,\\n  \\\"hasMore\\\": false,\\n  \\\"results\\\": [],\\n  \\\"staged\\\": null\\n}\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__record_search",
+      "args": {
+        "surname": "Quass",
+        "imageGroupNumber": "108958018",
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f"
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"query\\\": {\\n    \\\"surname\\\": \\\"Quass\\\",\\n    \\\"imageGroupNumber\\\": \\\"108958018\\\",\\n    \\\"projectPath\\\": \\\"/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f\\\"\\n  },\\n  \\\"totalMatches\\\": 0,\\n  \\\"paginationCappedAt\\\": 4999,\\n  \\\"returned\\\": 0,\\n  \\\"offset\\\": 0,\\n  \\\"hasMore\\\": false,\\n  \\\"results\\\": [],\\n  \\\"staged\\\": null\\n}\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__record_search",
+      "args": {
+        "surname": "Quass",
+        "imageGroupNumber": "108958162",
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f"
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"query\\\": {\\n    \\\"surname\\\": \\\"Quass\\\",\\n    \\\"imageGroupNumber\\\": \\\"108958162\\\",\\n    \\\"projectPath\\\": \\\"/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f\\\"\\n  },\\n  \\\"totalMatches\\\": 0,\\n  \\\"paginationCappedAt\\\": 4999,\\n  \\\"returned\\\": 0,\\n  \\\"offset\\\": 0,\\n  \\\"hasMore\\\": false,\\n  \\\"results\\\": [],\\n  \\\"staged\\\": null\\n}\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__image_search",
+      "args": {
+        "imageGroupNumber": "108956928"
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"imageIds\\\": [\\n    \\\"108956928_00001\\\",\\n    \\\"108956928_00002\\\",\\n    \\\"108956928_00003\\\",\\n    \\\"108956928_00004\\\",\\n    \\\"108956928_00005\\\",\\n    \\\"108956928_00006\\\",\\n    \\\"108956928_00007\\\",\\n    \\\"108956928_00008\\\",\\n    \\\"108956928_00009\\\",\\n    \\\"108956928_00010\\\",\\n    \\\"108956928_00011\\\",\\n    \\\"108956928_00012\\\",\\n    \\\"108956928_00013\\\",\\n    \\\"108956928_00014\\\",\\n    \\\"108956928_00015\\\",\\n    \\\"108956928_00016\\\",\\n    \\\"108956928_00017\\\",\\n    \\\"..."
+    },
+    {
+      "tool": "mcp__genealogy__record_search",
+      "args": {
+        "givenName": "Ivyl",
+        "recordCountry": "United States",
+        "residenceYearFrom": 1950,
+        "residenceYearTo": 1950,
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f"
+      },
+      "response_summary": "Error: result (283,687 characters) exceeds maximum allowed tokens. Output has been saved to /Users/dallan/.claude/projects/-private-var-folders-tv-yzyl0n517xj5v54fgn0c0j3h0000gn-T-e2e-ivyl-greenley-daughter-9uoppj5f/bbf38148-6301-4b4b-85c0-51b7f01068c4/tool-results/mcp-genealogy-record_search-1782771799770.txt.\nFormat: JSON array with schema: [{type: string, text: string}]\nUse offset and limit parameters to read specific portions of the file, search within it for specific content, and jq to m..."
+    },
+    {
+      "tool": "mcp__genealogy__image_read",
+      "args": {
+        "imageId": "108956928_00005"
+      },
+      "response_summary": null
+    },
+    {
+      "tool": "mcp__genealogy__image_read",
+      "args": {
+        "imageId": "108956928_00010"
+      },
+      "response_summary": null
+    }
+  ],
+  "error": "Exception: Failed to decode JSON: JSON message exceeded maximum buffer size of 1048576 bytes...",
+  "tags": {
+    "question_type": "children",
+    "era": "1940s",
+    "geography": "US-MN"
+  },
+  "blocked_tree_reads": [
+    {
+      "tool": "person_read",
+      "args": {
+        "personId": "KNS4-P6W",
+        "relatives": true
+      }
+    }
+  ]
+}

--- a/eval/runlogs/e2e/ivyl-greenley-daughter/run-2026-06-29_22-24-03.transcript.md
+++ b/eval/runlogs/e2e/ivyl-greenley-daughter/run-2026-06-29_22-24-03.transcript.md
@@ -1,0 +1,1104 @@
+# E2e run: ivyl-greenley-daughter
+
+## User message
+
+```
+/research --autonomous Besides their son Donald, did Ivyl Phylena Greenley and her husband Kenneth Werner Quass have any other children? Identify each additional child and that child's birth and death dates.
+```
+
+## Trace
+
+**tool_use** `Read` — args: {"file_path": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f/research.json"}
+
+**tool_result:** 1	{
+2	  "project": {
+3	    "id": "rp_ivyl_greenley_daughter",
+4	    "objective": "Besides their son Donald, did Ivyl Phylena Greenley and her husband Kenneth Werner Quass have any other children? Identify each additional child and that child's birth and death dates.",
+5	    "subject_person_ids": ["KWZP-4Q8"],
+6	    "status": "active",
+7	    "created": "2026-06-29T00:00:00Z",
+8	    "updated": "2026-06-29T00:00:00Z"
+9	  },
+10	  "researcher_profile": {
+11	    "experience_level": "intermediate",
+...
+
+**tool_use** `Skill` — args: {"skill": "question-selection"}
+
+**tool_result:** Launching skill: question-selection
+
+**tool_use** `Read` — args: {"file_path": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f/.claude/skills/question-selection/references/question-formulation.md"}
+
+**tool_result:** 1	# Research Question Formulation
+2	
+3	Guidance for formulating effective genealogical research questions
+4	that satisfy the GPS standard for planned, purposeful research.
+5	
+6	## Research Objectives vs. Research Questions
+7	
+8	These are distinct concepts that must not be conflated:
+9	
+10	- **Research objective**: The overarching goal of the research effort.
+11	  It describes what you ultimately want to know (e.g., "Identify the
+12	  parents of John Smith born circa 1820 in Greene County, Ohi...
+
+**tool_use** `Read` — args: {"file_path": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f/.claude/skills/question-selection/references/pedigree-analysis.md"}
+
+**tool_result:** 1	# Pedigree Analysis for Gap Detection
+2	
+3	Guidance for evaluating pedigree data to identify research gaps,
+4	errors, and candidates for new research questions.
+5	
+6	## Purpose
+7	
+8	Pedigree analysis is the process of systematically reviewing the
+9	individuals in a family tree to detect missing information, logical
+10	errors, and inconsistencies. It is a critical first step before
+11	selecting new research questions — it reveals where the gaps are
+12	and which gaps are most significant.
+13	...
+
+**tool_use** `Glob` — args: {"pattern": "**/*.json", "path": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f"}
+
+**tool_result:** .claude/skills/init-project/templates/research.json
+research.json
+tree.gedcomx.json
+
+**tool_use** `Read` — args: {"file_path": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f/tree.gedcomx.json"}
+
+**tool_result:** 1	{
+2	  "persons": [
+3	    {
+4	      "id": "KWZP-4Q8",
+5	      "gender": "Female",
+6	      "living": false,
+7	      "names": [
+8	        {
+9	          "given": "Ivyl Phylena",
+10	          "surname": "Greenley",
+11	          "id": "KWZP-4Q8-name-1"
+12	        }
+13	      ],
+14	      "facts": [
+15	        {
+16	          "id": "248eaba5-34ae-4182-9874-bfcc07166241",
+17	          "type": "Birth",
+18	          "date": "26 May 1914",
+19	          "standard_date": "26 May 1914",
+20	          "place"...
+
+**tool_use** `ToolSearch` — args: {"query": "select:mcp__genealogy__research_append", "max_results": 1}
+
+**tool_result:** [{"type": "tool_reference", "tool_name": "mcp__genealogy__research_append"}]
+
+**tool_use** `mcp__genealogy__research_append` — args: {"projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f", "section": "questions", "op": "append", "entry": {"question": "Did Kenneth Werner Quass (b. 4 Dec 1917, Sumner, Bremer County, Iowa; d. 17 Sep 1982) and Ivyl Phylena Greenley (b. 26 May 1914, Dubuque County, Iowa; d. 24 May 2005) have any children other than Donald Wendell Quass (b. 16 Jan 1940)?", "rationale": "This is the core research objective. The couple married 6 Mar 1938 and ...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"section\": \"questions\",\n  \"op\": \"append\",\n  \"entryId\": \"q_001\",\n  \"filesWritten\": [\n    \"research.json\"\n  ],\n  \"validation\": {\n    \"valid\": true,\n    \"warnings\": []\n  }\n}"}]
+
+**assistant:** Question q_001 written. Now routing to research-plan.
+
+**tool_use** `Skill` — args: {"skill": "research-plan", "args": "q_001"}
+
+**tool_result:** Launching skill: research-plan
+
+**assistant:** I have the project context. Let me run a focused locality survey for Watonwan County, Minnesota, and Iowa (the couple's primary locations).
+
+**tool_use** `ToolSearch` — args: {"query": "select:mcp__genealogy__place_search,mcp__genealogy__collections_search,mcp__genealogy__external_links_search", "max_results": 3}
+
+**tool_result:** [{"type": "tool_reference", "tool_name": "mcp__genealogy__place_search"}, {"type": "tool_reference", "tool_name": "mcp__genealogy__collections_search"}, {"type": "tool_reference", "tool_name": "mcp__genealogy__external_links_search"}]
+
+**tool_use** `mcp__genealogy__place_search` — args: {"placeName": "Watonwan County", "contextName": "Minnesota"}
+
+**tool_use** `mcp__genealogy__place_search` — args: {"placeName": "Iowa", "contextName": "United States"}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"results\": [\n    {\n      \"standardPlace\": \"Watonwan, Minnesota, United States\",\n      \"type\": \"County\",\n      \"dateRange\": \"+1860/\",\n      \"latitude\": 43.96667,\n      \"longitude\": -94.61667,\n      \"familysearchUrl\": \"https://www.familysearch.org/en/research/places/?text=Watonwan&focusedId=394316\",\n      \"wikipediaUrl\": \"https://en.wikipedia.org/wiki/Watonwan_County,_Minnesota\"\n    },\n    {\n      \"standardPlace\": \"Brown, M...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"results\": [\n    {\n      \"standardPlace\": \"Iowa, United States\",\n      \"type\": \"State\",\n      \"dateRange\": \"+1838/\",\n      \"latitude\": 42,\n      \"longitude\": -93.5,\n      \"familysearchUrl\": \"https://www.familysearch.org/en/research/places/?text=Iowa&focusedId=364\",\n      \"wikipediaUrl\": \"https://en.wikipedia.org/wiki/Iowa\"\n    },\n    {\n      \"standardPlace\": \"Iowa, Wisconsin, United States\",\n      \"type\": \"County\",\...
+
+**tool_use** `mcp__genealogy__collections_search` — args: {"standardPlace": "Minnesota, United States", "startYear": 1938, "endYear": 1965}
+
+**tool_use** `mcp__genealogy__external_links_search` — args: {"standardPlace": "Watonwan, Minnesota, United States", "startYear": 1938, "endYear": 1965}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"query\": {\n    \"standardPlace\": \"Minnesota, United States\",\n    \"startYear\": 1938,\n    \"endYear\": 1965\n  },\n  \"scope\": \"Minnesota\",\n  \"totalForPlace\": 46,\n  \"results\": [\n    {\n      \"id\": \"1949334\",\n      \"title\": \"Minnesota, Birth Index, 1935-2002\",\n      \"dateRange\": \"1935-2002\",\n      \"recordCount\": 4267571,\n      \"personCount\": 5632,\n      \"imageCount\": 0,\n      \"url\": \"https://www.familysearch.org/searc...
+
+**tool_result:** <persisted-output>
+Output too large (52.6KB). Full output saved to: /Users/dallan/.claude/projects/-private-var-folders-tv-yzyl0n517xj5v54fgn0c0j3h0000gn-T-e2e-ivyl-greenley-daughter-9uoppj5f/bbf38148-6301-4b4b-85c0-51b7f01068c4/tool-results/toolu_01NYdZcuLNzaDGChGUmwL847.json
+
+Preview (first 2KB):
+[
+  {
+    "type": "text",
+    "text": "{\n  \"query\": {\n    \"standardPlace\": \"Watonwan, Minnesota, United States\",\n    \"startYear\": 1938,\n    \"endYear\": 1965\n  },\n  \"totalForPlace\":...
+
+**assistant:** Good data. I have enough for a solid plan. Key collections identified: Minnesota Birth Index 1935–2002, Minnesota Obituaries 1865–2006, US Census 1950. Two existing unextracted sources (WWDC-3KV Donald's 2024 obituary; QK2L-WL7 GenealogyBank obituary mentioning "Bernice H Quass Wegner and Ralph Quass") are prime leads.
+
+**tool_use** `mcp__genealogy__research_append` — args: {"projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f", "ops": [{"section": "plans", "op": "append", "entry": {"question_id": "q_001", "status": "active", "created": "2026-06-29"}}, {"section": "plan_items", "op": "append", "planId": "pl_001", "entry": {"sequence": 1, "record_type": "newspaper", "jurisdiction": "Watonwan County, Minnesota (Madelia area)", "date_range": "2024", "repository": "FamilySearch", "rationale": "Donald Wendell Qu...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"results\": [\n    {\n      \"section\": \"plans\",\n      \"op\": \"append\",\n      \"entryId\": \"pl_001\"\n    },\n    {\n      \"section\": \"plan_items\",\n      \"op\": \"append\",\n      \"entryId\": \"pli_001\"\n    },\n    {\n      \"section\": \"plan_items\",\n      \"op\": \"append\",\n      \"entryId\": \"pli_002\"\n    },\n    {\n      \"section\": \"plan_items\",\n      \"op\": \"append\",\n      \"entryId\": \"pli_003\"\n    },...
+
+**assistant:** Plan written (pl_001, 8 items). Routing to search-records to begin execution.
+
+**tool_use** `Skill` — args: {"skill": "search-records", "args": "Execute plan pl_001 for question q_001. Start with pli_001 (read and extract existing FamilySearch source WWDC-3KV at ark:/61903/1:1:XM5X-SPSB \u2014 Donald Wendell Quass's 2024 obituary), then pli_002 (read and extract existing FamilySearch source QK2L-WL7 at ark:/61903/1:1:QKGC-W3S7 \u2014 GenealogyBank obituary mentioning Bernice H Quass Wegner and Ralph Quass), then pli_003 (search 1950 US Census for Kenneth Quass / Kenneth Werner Quass in Watonwan Cou...
+
+**tool_result:** Launching skill: search-records
+
+**tool_use** `ToolSearch` — args: {"query": "select:mcp__genealogy__record_read,mcp__genealogy__research_log_append,mcp__genealogy__same_person,mcp__genealogy__record_search", "max_results": 4}
+
+**tool_result:** [{"type": "tool_reference", "tool_name": "mcp__genealogy__record_read"}, {"type": "tool_reference", "tool_name": "mcp__genealogy__research_log_append"}, {"type": "tool_reference", "tool_name": "mcp__genealogy__same_person"}, {"type": "tool_reference", "tool_name": "mcp__genealogy__record_search"}]
+
+**tool_use** `mcp__genealogy__record_read` — args: {"recordId": "ark:/61903/1:1:XM5X-SPSB"}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"persons\": [\n    {\n      \"id\": \"p_306774614781\",\n      \"ark\": \"ark:/61903/1:1:XM5X-SPSL\",\n      \"gender\": \"Male\",\n      \"names\": [\n        {\n          \"id\": \"1dcf5d75-3c0e-49ef-aa0e-180854c3650e\",\n          \"type\": \"BirthName\",\n          \"given\": \"Donald Wendell\",\n          \"surname\": \"Quass\"\n        }\n      ],\n      \"facts\": [\n        {\n          \"id\": \"bd1540c2-061d-4d82-828f-92562d24a652\",\n          \"typ...
+
+**assistant:** Rich result from pli_001. Donald's obituary reveals three siblings: **Ken Quass**, **Pat Norman** (born Quass, married Bob Norman), and **Jeanette** — all listed as children of Kenneth Werner Quass and Phylena Ivyl Greenley. Now logging and moving to pli_002.
+
+**tool_use** `mcp__genealogy__research_log_append` — args: {"projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f", "tool": "record_read", "planItemId": "pli_001", "query": {"recordId": "ark:/61903/1:1:XM5X-SPSB", "description": "Donald Wendell Quass 2024 obituary, source WWDC-3KV, FamilySearch United States Obituary Records 2014-2023"}, "outcome": "positive", "resultsExamined": 1, "resultsAvailable": 1, "notes": "Obituary for Donald Wendell Quass (b. 16 Jan 1940, d. 25 Apr 2024) lists three sibl...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"logId\": \"log_001\",\n  \"performed\": \"2026-06-29T21:46:05.306Z\",\n  \"resultsRef\": null,\n  \"returnedCount\": null,\n  \"filesWritten\": [\n    \"research.json\"\n  ],\n  \"validation\": {\n    \"valid\": true,\n    \"warnings\": []\n  }\n}"}]
+
+**tool_use** `mcp__genealogy__research_append` — args: {"projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f", "section": "plan_items", "op": "update", "planId": "pl_001", "entryId": "pli_001", "fields": {"status": "in_progress"}}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"section\": \"plan_items\",\n  \"op\": \"update\",\n  \"entryId\": \"pli_001\",\n  \"filesWritten\": [\n    \"research.json\"\n  ],\n  \"validation\": {\n    \"valid\": true,\n    \"warnings\": []\n  }\n}"}]
+
+**assistant:** Now reading pli_002 — the GenealogyBank obituary source QK2L-WL7.
+
+**tool_use** `mcp__genealogy__record_read` — args: {"recordId": "ark:/61903/1:1:QKGC-W3S7"}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"persons\": [\n    {\n      \"id\": \"p_101873054449\",\n      \"ark\": \"ark:/61903/1:1:QKGC-WSLK\",\n      \"gender\": \"Female\",\n      \"names\": [\n        {\n          \"id\": \"e2965eb8-08aa-4cdc-80d8-4088ae8b2167\",\n          \"type\": \"BirthName\",\n          \"prefix\": \"Mrs\",\n          \"surname\": \"Quass Wegner\",\n          \"given\": \"Bernice H\"\n        }\n      ],\n      \"facts\": [\n        {\n          \"id\": \"d02cb0a1-524c-4c66-a...
+
+**assistant:** pli_002 analyzed. Bernice H. Quass Wegner is **Kenneth Werner Quass's sister**, not a daughter of Kenneth and Ivyl. "Avyl Quass" listed as sibling-in-law confirms Ivyl Greenley married into the Quass family. This source does not add children of Kenneth and Ivyl — logging and continuing.
+
+**tool_use** `mcp__genealogy__research_log_append` — args: {"projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f", "tool": "record_read", "planItemId": "pli_002", "query": {"recordId": "ark:/61903/1:1:QKGC-W3S7", "description": "GenealogyBank obituary for Bernice H. Quass Wegner (d. 19 Jun 2010), source QK2L-WL7, FamilySearch United States GenealogyBank Obituaries 1980-2015"}, "outcome": "partial", "resultsExamined": 1, "resultsAvailable": 1, "notes": "Obituary is for Bernice H. Quass Wegner (b....
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"logId\": \"log_002\",\n  \"performed\": \"2026-06-29T21:46:53.313Z\",\n  \"resultsRef\": null,\n  \"returnedCount\": null,\n  \"filesWritten\": [\n    \"research.json\"\n  ],\n  \"validation\": {\n    \"valid\": true,\n    \"warnings\": []\n  }\n}"}]
+
+**tool_use** `mcp__genealogy__research_append` — args: {"projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f", "section": "plan_items", "op": "update", "planId": "pl_001", "entryId": "pli_002", "fields": {"status": "in_progress"}}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"section\": \"plan_items\",\n  \"op\": \"update\",\n  \"entryId\": \"pli_002\",\n  \"filesWritten\": [\n    \"research.json\"\n  ],\n  \"validation\": {\n    \"valid\": true,\n    \"warnings\": []\n  }\n}"}]
+
+**assistant:** Now searching pli_003 — 1950 US Census for Kenneth Quass, Watonwan County, Minnesota.
+
+**tool_use** `mcp__genealogy__record_search` — args: {"surname": "Quass", "givenName": "Kenneth", "birthYearFrom": 1912, "birthYearTo": 1922, "residencePlace": "Watonwan, Minnesota", "residenceYearFrom": 1950, "residenceYearTo": 1950, "recordType": "census", "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f"}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"query\": {\n    \"surname\": \"Quass\",\n    \"givenName\": \"Kenneth\",\n    \"birthYearFrom\": 1912,\n    \"birthYearTo\": 1922,\n    \"residencePlace\": \"Watonwan, Minnesota\",\n    \"residenceYearFrom\": 1950,\n    \"residenceYearTo\": 1950,\n    \"recordType\": \"census\",\n    \"projectPath\": \"/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f\"\n  },\n  \"totalMatches\": 0,\n  \"paginationCappedAt\": 4999,\n...
+
+**assistant:** Nil — broadening to all Minnesota, no record type filter.
+
+**tool_use** `mcp__genealogy__record_search` — args: {"surname": "Quass", "givenName": "Kenneth", "birthYearFrom": 1912, "birthYearTo": 1922, "residenceYearFrom": 1950, "residenceYearTo": 1950, "recordCountry": "United States", "recordSubdivision": "Minnesota", "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f"}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"query\": {\n    \"surname\": \"Quass\",\n    \"givenName\": \"Kenneth\",\n    \"birthYearFrom\": 1912,\n    \"birthYearTo\": 1922,\n    \"residenceYearFrom\": 1950,\n    \"residenceYearTo\": 1950,\n    \"recordCountry\": \"United States\",\n    \"recordSubdivision\": \"Minnesota\",\n    \"projectPath\": \"/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f\"\n  },\n  \"totalMatches\": 12,\n  \"paginationCappedAt\": 499...
+
+**assistant:** Highly significant results — no 1950 census hit, but the Minnesota Birth Index and death records surfaced **Alice Jeanette Quass** (b. 6 Dec 1940, d. 3 Feb 1955), parents Kenneth Quass and Ivyl Greenley. This is likely the "Jeanette" named in Donald's obituary. Let me read her death certificate, then log.
+
+**tool_use** `mcp__genealogy__record_read` — args: {"recordId": "ark:/61903/1:1:FDX7-8MF"}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"persons\": [\n    {\n      \"id\": \"p_11238084915\",\n      \"ark\": \"ark:/61903/1:1:FDX7-8MF\",\n      \"gender\": \"Female\",\n      \"names\": [\n        {\n          \"id\": \"279a9790-02d1-46f6-acd1-600aec1638bc\",\n          \"type\": \"BirthName\",\n          \"surname\": \"Quass\",\n          \"given\": \"Alice Jeannette\"\n        }\n      ],\n      \"facts\": [\n        {\n          \"id\": \"39099907-8449-4d99-b91d-f9d02c6ef293\",\n          \"ty...
+
+**assistant:** Confirmed: Alice Jeannette Quass (b. ~1940/41, d. 3 Feb 1955, Madelia, MN), parents Kenneth Quass & Ivyl Greenley. Now logging the census/broad search and reading the birth index entry.
+
+**tool_use** `mcp__genealogy__research_log_append` — args: {"projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f", "tool": "record_search", "planItemId": "pli_003", "query": {"surname": "Quass", "givenName": "Kenneth", "birthYearFrom": 1912, "birthYearTo": 1922, "residenceYearFrom": 1950, "residenceYearTo": 1950, "recordCountry": "United States", "recordSubdivision": "Minnesota", "note": "First attempt with Watonwan residencePlace returned 0 results; broadened to all Minnesota"}, "outcome": "par...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"logId\": \"log_003\",\n  \"performed\": \"2026-06-29T21:48:34.414Z\",\n  \"resultsRef\": \"results/log_003.json\",\n  \"returnedCount\": 12,\n  \"filesWritten\": [\n    \"research.json\",\n    \"results/log_003.json\"\n  ],\n  \"validation\": {\n    \"valid\": true,\n    \"warnings\": []\n  }\n}"}]
+
+**assistant:** Now reading the Alice Jeanette Quass birth index entry for the precise birth date, and simultaneously searching the 1950 census directly.
+
+**tool_use** `mcp__genealogy__record_read` — args: {"recordId": "ark:/61903/1:1:VCF7-BY8"}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"persons\": [\n    {\n      \"id\": \"p_13353011021\",\n      \"ark\": \"ark:/61903/1:1:VCF7-BY8\",\n      \"names\": [\n        {\n          \"id\": \"3d005700-ebfc-49b4-b074-0e8418af2ba1\",\n          \"type\": \"BirthName\",\n          \"surname\": \"Quass\",\n          \"given\": \"Alice Jeanette\"\n        }\n      ],\n      \"facts\": [\n        {\n          \"id\": \"f6d0cbfc-ef2d-42b5-b33f-1660ae2a8855\",\n          \"type\": \"Birth\",\n          \"pr...
+
+**tool_use** `mcp__genealogy__record_search` — args: {"surname": "Quass", "givenName": "Kenneth", "birthYearFrom": 1912, "birthYearTo": 1922, "recordType": "census", "recordCountry": "United States", "anyYearFrom": 1950, "anyYearTo": 1950, "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f"}
+
+**tool_result:** Error: result (160,466 characters) exceeds maximum allowed tokens. Output has been saved to /Users/dallan/.claude/projects/-private-var-folders-tv-yzyl0n517xj5v54fgn0c0j3h0000gn-T-e2e-ivyl-greenley-daughter-9uoppj5f/bbf38148-6301-4b4b-85c0-51b7f01068c4/tool-results/mcp-genealogy-record_search-1782769727921.txt.
+Format: JSON array with schema: [{type: string, text: string}]
+Use offset and limit parameters to read specific portions of the file, search within it for specific content, and jq to m...
+
+**tool_use** `Read` — args: {"file_path": "/Users/dallan/.claude/projects/-private-var-folders-tv-yzyl0n517xj5v54fgn0c0j3h0000gn-T-e2e-ivyl-greenley-daughter-9uoppj5f/bbf38148-6301-4b4b-85c0-51b7f01068c4/tool-results/mcp-genealogy-record_search-1782769727921.txt", "limit": 100}
+
+**tool_result:** File content (52060 tokens) exceeds maximum allowed tokens (25000). Use offset and limit parameters to read specific portions of the file, or search for specific content instead of reading the whole file.
+
+**tool_use** `Bash` — args: {"command": "cat \"/Users/dallan/.claude/projects/-private-var-folders-tv-yzyl0n517xj5v54fgn0c0j3h0000gn-T-e2e-ivyl-greenley-daughter-9uoppj5f/bbf38148-6301-4b4b-85c0-51b7f01068c4/tool-results/mcp-genealogy-record_search-1782769727921.txt\" | python3 -c \"import sys,json; data=json.load(sys.stdin); text=data[0]['text'] if data else '{}'; obj=json.loads(text); print('totalMatches:', obj.get('totalMatches'), 'returned:', obj.get('returned')); [print(r.get('collectionTitle','?'), '|', r.get('per...
+
+**tool_result:** Permission to use Bash has been denied because Claude Code is running in don't ask mode. IMPORTANT: You *may* attempt to accomplish this action using other tools that might naturally be used to accomplish this goal, e.g. using head instead of cat. But you *should not* attempt to work around this denial in malicious ways, e.g. do not use your ability to run tests to execute non-test actions. You should only try to work around this restriction in reasonable ways that do not attempt to bypass th...
+
+**tool_use** `Read` — args: {"file_path": "/Users/dallan/.claude/projects/-private-var-folders-tv-yzyl0n517xj5v54fgn0c0j3h0000gn-T-e2e-ivyl-greenley-daughter-9uoppj5f/bbf38148-6301-4b4b-85c0-51b7f01068c4/tool-results/mcp-genealogy-record_search-1782769727921.txt", "limit": 50, "offset": 0}
+
+**tool_result:** File content (52060 tokens) exceeds maximum allowed tokens (25000). Use offset and limit parameters to read specific portions of the file, or search for specific content instead of reading the whole file.
+
+**tool_use** `Grep` — args: {"pattern": "\"totalMatches\"|\"collectionTitle\"|\"personName\"|Census 1950", "path": "/Users/dallan/.claude/projects/-private-var-folders-tv-yzyl0n517xj5v54fgn0c0j3h0000gn-T-e2e-ivyl-greenley-daughter-9uoppj5f/bbf38148-6301-4b4b-85c0-51b7f01068c4/tool-results/mcp-genealogy-record_search-1782769727921.txt", "output_mode": "content", "head_limit": 30}
+
+**tool_result:** No matches found
+
+**tool_use** `Grep` — args: {"pattern": "totalMatches|collectionTitle|Census", "path": "/Users/dallan/.claude/projects/-private-var-folders-tv-yzyl0n517xj5v54fgn0c0j3h0000gn-T-e2e-ivyl-greenley-daughter-9uoppj5f/bbf38148-6301-4b4b-85c0-51b7f01068c4/tool-results/mcp-genealogy-record_search-1782769727921.txt", "output_mode": "content", "head_limit": 30}
+
+**tool_result:** 4:[Omitted long matching line]
+
+**tool_use** `Grep` — args: {"pattern": "1950 Census|United States Census, 1950|census.*1950", "path": "/Users/dallan/.claude/projects/-private-var-folders-tv-yzyl0n517xj5v54fgn0c0j3h0000gn-T-e2e-ivyl-greenley-daughter-9uoppj5f/bbf38148-6301-4b4b-85c0-51b7f01068c4/tool-results/mcp-genealogy-record_search-1782769727921.txt", "output_mode": "content", "-i": true, "head_limit": 10}
+
+**tool_result:** 4:[Omitted long matching line]
+
+**assistant:** The file is too large to parse usefully. I'll update pli_003, then search the 1950 census with its specific collection ID, and simultaneously search the Minnesota Birth Index for all Quass children.
+
+**tool_use** `mcp__genealogy__research_append` — args: {"projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f", "section": "plan_items", "op": "update", "planId": "pl_001", "entryId": "pli_003", "fields": {"status": "in_progress"}}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"section\": \"plan_items\",\n  \"op\": \"update\",\n  \"entryId\": \"pli_003\",\n  \"filesWritten\": [\n    \"research.json\"\n  ],\n  \"validation\": {\n    \"valid\": true,\n    \"warnings\": []\n  }\n}"}]
+
+**tool_use** `mcp__genealogy__record_search` — args: {"surname": "Quass", "givenName": "Kenneth", "birthYearFrom": 1912, "birthYearTo": 1922, "collectionId": "3948617", "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f"}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"query\": {\n    \"surname\": \"Quass\",\n    \"givenName\": \"Kenneth\",\n    \"birthYearFrom\": 1912,\n    \"birthYearTo\": 1922,\n    \"collectionId\": \"3948617\",\n    \"projectPath\": \"/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f\"\n  },\n  \"totalMatches\": 0,\n  \"paginationCappedAt\": 4999,\n  \"returned\": 0,\n  \"offset\": 0,\n  \"hasMore\": false,\n  \"results\": [],\n  \"staged\": null\n}"}]
+
+**tool_use** `mcp__genealogy__record_search` — args: {"fatherSurname": "Quass", "motherSurname": "Greenley", "collectionId": "1949334", "recordCountry": "United States", "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f"}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"query\": {\n    \"fatherSurname\": \"Quass\",\n    \"motherSurname\": \"Greenley\",\n    \"collectionId\": \"1949334\",\n    \"recordCountry\": \"United States\",\n    \"projectPath\": \"/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f\"\n  },\n  \"totalMatches\": 1,\n  \"paginationCappedAt\": 4999,\n  \"returned\": 1,\n  \"offset\": 0,\n  \"hasMore\": false,\n  \"results\": [\n    {\n      \"recordId\": \"ark:/6190...
+
+**assistant:** Good data. 1950 census collection ID 3948617 returned nil — wrong ID or unindexed. Minnesota Birth Index with Quass father + Greenley mother only returns Alice Jeanette — other children may have been born in Iowa or under variant spellings. Let me log these, update statuses, and try broader birth index searches to find Ken and Pat Quass's births.
+
+**tool_use** `mcp__genealogy__research_log_append` — args: {"projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f", "tool": "record_search", "planItemId": "pli_003", "query": {"surname": "Quass", "givenName": "Kenneth", "birthYearFrom": 1912, "birthYearTo": 1922, "collectionId": "3948617", "description": "US 1950 Census \u2014 collection ID 3948617"}, "outcome": "negative", "resultsExamined": 0, "resultsAvailable": 0, "notes": "Zero results. Collection ID 3948617 may be incorrect for the US 1950 ...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"logId\": \"log_004\",\n  \"performed\": \"2026-06-29T21:49:49.651Z\",\n  \"resultsRef\": null,\n  \"returnedCount\": null,\n  \"filesWritten\": [\n    \"research.json\"\n  ],\n  \"validation\": {\n    \"valid\": true,\n    \"warnings\": []\n  }\n}"}]
+
+**tool_use** `mcp__genealogy__research_log_append` — args: {"projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f", "tool": "record_search", "planItemId": "pli_004", "query": {"fatherSurname": "Quass", "motherSurname": "Greenley", "collectionId": "1949334", "recordCountry": "United States", "description": "Minnesota Birth Index 1935-2002, father surname Quass + mother surname Greenley"}, "outcome": "positive", "resultsExamined": 1, "resultsAvailable": 1, "stagedResultsRef": "results/.staging/20c9...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"logId\": \"log_005\",\n  \"performed\": \"2026-06-29T21:49:59.109Z\",\n  \"resultsRef\": \"results/log_005.json\",\n  \"returnedCount\": 1,\n  \"filesWritten\": [\n    \"research.json\",\n    \"results/log_005.json\"\n  ],\n  \"validation\": {\n    \"valid\": true,\n    \"warnings\": []\n  }\n}"}]
+
+**tool_use** `mcp__genealogy__research_append` — args: {"projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f", "section": "plan_items", "op": "update", "planId": "pl_001", "entryId": "pli_004", "fields": {"status": "in_progress"}}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"section\": \"plan_items\",\n  \"op\": \"update\",\n  \"entryId\": \"pli_004\",\n  \"filesWritten\": [\n    \"research.json\"\n  ],\n  \"validation\": {\n    \"valid\": true,\n    \"warnings\": []\n  }\n}"}]
+
+**assistant:** Now broadening: search Minnesota Birth Index with father given name Kenneth + father surname Quass (drop mother surname requirement), and simultaneously search the Minnesota Obituaries for Kenneth Quass.
+
+**tool_use** `mcp__genealogy__record_search` — args: {"fatherGivenName": "Kenneth", "fatherSurname": "Quass", "motherGivenName": "Ivyl", "collectionId": "1949334", "recordCountry": "United States", "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f"}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"query\": {\n    \"fatherGivenName\": \"Kenneth\",\n    \"fatherSurname\": \"Quass\",\n    \"motherGivenName\": \"Ivyl\",\n    \"collectionId\": \"1949334\",\n    \"recordCountry\": \"United States\",\n    \"projectPath\": \"/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f\"\n  },\n  \"totalMatches\": 1,\n  \"paginationCappedAt\": 4999,\n  \"returned\": 1,\n  \"offset\": 0,\n  \"hasMore\": false,\n  \"results\": [\n ...
+
+**tool_use** `mcp__genealogy__record_search` — args: {"surname": "Quass", "givenName": "Kenneth", "deathYearFrom": 1978, "deathYearTo": 1986, "collectionId": "2469546", "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f"}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"query\": {\n    \"surname\": \"Quass\",\n    \"givenName\": \"Kenneth\",\n    \"deathYearFrom\": 1978,\n    \"deathYearTo\": 1986,\n    \"collectionId\": \"2469546\",\n    \"projectPath\": \"/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f\"\n  },\n  \"totalMatches\": 0,\n  \"paginationCappedAt\": 4999,\n  \"returned\": 0,\n  \"offset\": 0,\n  \"hasMore\": false,\n  \"results\": [],\n  \"staged\": null\n}"}]
+
+**assistant:** Minnesota Birth Index still only shows Alice Jeanette; Kenneth's obituary not in MN collection (expected — he died in Texas). Now logging these, then searching Iowa birth records and trying to find Ken Quass Jr's birth in MN.
+
+**tool_use** `mcp__genealogy__research_log_append` — args: {"projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f", "tool": "record_search", "planItemId": "pli_004", "query": {"fatherGivenName": "Kenneth", "fatherSurname": "Quass", "motherGivenName": "Ivyl", "collectionId": "1949334", "description": "Minnesota Birth Index 1935-2002, father Kenneth Quass + mother Ivyl"}, "outcome": "positive", "resultsExamined": 1, "resultsAvailable": 1, "stagedResultsRef": "results/.staging/1b24fa2a-58d3-42aa-add...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"logId\": \"log_006\",\n  \"performed\": \"2026-06-29T21:50:32.747Z\",\n  \"resultsRef\": \"results/log_006.json\",\n  \"returnedCount\": 1,\n  \"filesWritten\": [\n    \"research.json\",\n    \"results/log_006.json\"\n  ],\n  \"validation\": {\n    \"valid\": true,\n    \"warnings\": []\n  }\n}"}]
+
+**tool_use** `mcp__genealogy__research_log_append` — args: {"projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f", "tool": "record_search", "planItemId": "pli_005", "query": {"surname": "Quass", "givenName": "Kenneth", "deathYearFrom": 1978, "deathYearTo": 1986, "collectionId": "2469546", "description": "Minnesota Obituaries 1865-2006 for Kenneth Quass d. 1982"}, "outcome": "negative", "resultsExamined": 0, "resultsAvailable": 0, "notes": "No Minnesota obituary found for Kenneth Quass (d. 17 Sep...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"logId\": \"log_007\",\n  \"performed\": \"2026-06-29T21:50:36.711Z\",\n  \"resultsRef\": null,\n  \"returnedCount\": null,\n  \"filesWritten\": [\n    \"research.json\"\n  ],\n  \"validation\": {\n    \"valid\": true,\n    \"warnings\": []\n  }\n}"}]
+
+**assistant:** Now searching Iowa birth records for Quass children (pli_007) and MN Birth Index for Kenneth Quass Jr as child (to find Ken's birth date).
+
+**tool_use** `mcp__genealogy__research_append` — args: {"projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f", "section": "plan_items", "op": "update", "planId": "pl_001", "entryId": "pli_005", "fields": {"status": "in_progress"}}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"section\": \"plan_items\",\n  \"op\": \"update\",\n  \"entryId\": \"pli_005\",\n  \"filesWritten\": [\n    \"research.json\"\n  ],\n  \"validation\": {\n    \"valid\": true,\n    \"warnings\": []\n  }\n}"}]
+
+**tool_use** `mcp__genealogy__record_search` — args: {"surname": "Quass", "givenName": "Kenneth", "birthYearFrom": 1941, "birthYearTo": 1952, "fatherSurname": "Quass", "collectionId": "1949334", "recordCountry": "United States", "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f"}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"query\": {\n    \"surname\": \"Quass\",\n    \"givenName\": \"Kenneth\",\n    \"birthYearFrom\": 1941,\n    \"birthYearTo\": 1952,\n    \"fatherSurname\": \"Quass\",\n    \"collectionId\": \"1949334\",\n    \"recordCountry\": \"United States\",\n    \"projectPath\": \"/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f\"\n  },\n  \"totalMatches\": 4,\n  \"paginationCappedAt\": 4999,\n  \"returned\": 4,\n  \"offset\": 0...
+
+**tool_use** `mcp__genealogy__record_search` — args: {"fatherSurname": "Quass", "motherSurname": "Greenley", "recordCountry": "United States", "recordSubdivision": "Iowa", "recordType": "birth", "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f"}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"query\": {\n    \"fatherSurname\": \"Quass\",\n    \"motherSurname\": \"Greenley\",\n    \"recordCountry\": \"United States\",\n    \"recordSubdivision\": \"Iowa\",\n    \"recordType\": \"birth\",\n    \"projectPath\": \"/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f\"\n  },\n  \"totalMatches\": 0,\n  \"paginationCappedAt\": 4999,\n  \"returned\": 0,\n  \"offset\": 0,\n  \"hasMore\": false,\n  \"results\": [],\n  ...
+
+**assistant:** The MN Birth Index search returned Ken Jr. only as a *father* (children born 1965-1974 in Hennepin), not his own birth. Iowa birth search returned nil. Let me try a broader MN birth search and also search full-text for Ivyl Quass's obituary to get the child list directly.
+
+**tool_use** `mcp__genealogy__research_log_append` — args: {"projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f", "tool": "record_search", "planItemId": "pli_004", "query": {"surname": "Quass", "givenName": "Kenneth", "birthYearFrom": 1941, "birthYearTo": 1952, "fatherSurname": "Quass", "collectionId": "1949334", "description": "MN Birth Index \u2014 Kenneth Quass as child born 1941-1952"}, "outcome": "negative", "resultsExamined": 4, "resultsAvailable": 4, "stagedResultsRef": "results/.staging...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"logId\": \"log_008\",\n  \"performed\": \"2026-06-29T21:51:14.602Z\",\n  \"resultsRef\": \"results/log_008.json\",\n  \"returnedCount\": 4,\n  \"filesWritten\": [\n    \"research.json\",\n    \"results/log_008.json\"\n  ],\n  \"validation\": {\n    \"valid\": true,\n    \"warnings\": []\n  }\n}"}]
+
+**tool_use** `mcp__genealogy__research_log_append` — args: {"projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f", "tool": "record_search", "planItemId": "pli_007", "query": {"fatherSurname": "Quass", "motherSurname": "Greenley", "recordCountry": "United States", "recordSubdivision": "Iowa", "recordType": "birth", "description": "Iowa birth records for Quass + Greenley children"}, "outcome": "negative", "resultsExamined": 0, "resultsAvailable": 0, "notes": "No Iowa birth records found for childr...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"logId\": \"log_009\",\n  \"performed\": \"2026-06-29T21:51:18.837Z\",\n  \"resultsRef\": null,\n  \"returnedCount\": null,\n  \"filesWritten\": [\n    \"research.json\"\n  ],\n  \"validation\": {\n    \"valid\": true,\n    \"warnings\": []\n  }\n}"}]
+
+**assistant:** Now let me search GenealogyBank obituaries for Kenneth Quass (d. 1982) and the SSDI for children born ~1942–1955.
+
+**tool_use** `mcp__genealogy__research_append` — args: {"projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f", "section": "plan_items", "op": "update", "planId": "pl_001", "entryId": "pli_007", "fields": {"status": "in_progress"}}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"section\": \"plan_items\",\n  \"op\": \"update\",\n  \"entryId\": \"pli_007\",\n  \"filesWritten\": [\n    \"research.json\"\n  ],\n  \"validation\": {\n    \"valid\": true,\n    \"warnings\": []\n  }\n}"}]
+
+**tool_use** `mcp__genealogy__record_search` — args: {"surname": "Quass", "givenName": "Kenneth", "deathYearFrom": 1980, "deathYearTo": 1984, "collectionId": "2333694", "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f"}
+
+**tool_result:** Error: result (142,236 characters) exceeds maximum allowed tokens. Output has been saved to /Users/dallan/.claude/projects/-private-var-folders-tv-yzyl0n517xj5v54fgn0c0j3h0000gn-T-e2e-ivyl-greenley-daughter-9uoppj5f/bbf38148-6301-4b4b-85c0-51b7f01068c4/tool-results/mcp-genealogy-record_search-1782769924493.txt.
+Format: JSON array with schema: [{type: string, text: string}]
+Use offset and limit parameters to read specific portions of the file, search within it for specific content, and jq to m...
+
+**tool_use** `mcp__genealogy__record_search` — args: {"surname": "Quass", "givenName": "Kenneth", "deathYearFrom": 1980, "deathYearTo": 1984, "deathPlace": "Texas", "recordCountry": "United States", "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f"}
+
+**tool_result:** Error: result (94,287 characters) exceeds maximum allowed tokens. Output has been saved to /Users/dallan/.claude/projects/-private-var-folders-tv-yzyl0n517xj5v54fgn0c0j3h0000gn-T-e2e-ivyl-greenley-daughter-9uoppj5f/bbf38148-6301-4b4b-85c0-51b7f01068c4/tool-results/mcp-genealogy-record_search-1782769926144.txt.
+Format: JSON array with schema: [{type: string, text: string}]
+Use offset and limit parameters to read specific portions of the file, search within it for specific content, and jq to ma...
+
+**tool_use** `Grep` — args: {"pattern": "Kenneth.*Quass|Quass.*Kenneth|totalMatches", "path": "/Users/dallan/.claude/projects/-private-var-folders-tv-yzyl0n517xj5v54fgn0c0j3h0000gn-T-e2e-ivyl-greenley-daughter-9uoppj5f/bbf38148-6301-4b4b-85c0-51b7f01068c4/tool-results/mcp-genealogy-record_search-1782769924493.txt", "output_mode": "content", "head_limit": 20}
+
+**tool_result:** 4:[Omitted long matching line]
+
+**tool_use** `Grep` — args: {"pattern": "Kenneth.*Quass|Quass.*Kenneth|totalMatches", "path": "/Users/dallan/.claude/projects/-private-var-folders-tv-yzyl0n517xj5v54fgn0c0j3h0000gn-T-e2e-ivyl-greenley-daughter-9uoppj5f/bbf38148-6301-4b4b-85c0-51b7f01068c4/tool-results/mcp-genealogy-record_search-1782769926144.txt", "output_mode": "content", "head_limit": 20}
+
+**tool_result:** 4:[Omitted long matching line]
+
+**tool_use** `Grep` — args: {"pattern": "Werner Quass", "path": "/Users/dallan/.claude/projects/-private-var-folders-tv-yzyl0n517xj5v54fgn0c0j3h0000gn-T-e2e-ivyl-greenley-daughter-9uoppj5f/bbf38148-6301-4b4b-85c0-51b7f01068c4/tool-results/mcp-genealogy-record_search-1782769924493.txt", "output_mode": "count"}
+
+**tool_result:** No matches found
+
+Found 0 total occurrences across 0 files.
+
+**tool_use** `Grep` — args: {"pattern": "Ivyl|Greenley|Madelia|Watonwan|Grapevine|1917", "path": "/Users/dallan/.claude/projects/-private-var-folders-tv-yzyl0n517xj5v54fgn0c0j3h0000gn-T-e2e-ivyl-greenley-daughter-9uoppj5f/bbf38148-6301-4b4b-85c0-51b7f01068c4/tool-results/mcp-genealogy-record_search-1782769926144.txt", "output_mode": "count"}
+
+**tool_result:** /Users/dallan/.claude/projects/-private-var-folders-tv-yzyl0n517xj5v54fgn0c0j3h0000gn-T-e2e-ivyl-greenley-daughter-9uoppj5f/bbf38148-6301-4b4b-85c0-51b7f01068c4/tool-results/mcp-genealogy-record_search-1782769926144.txt:1
+
+Found 1 total occurrence across 1 file.
+
+**tool_use** `Grep` — args: {"pattern": "Ivyl|Greenley|Madelia|Watonwan|Grapevine|1917", "path": "/Users/dallan/.claude/projects/-private-var-folders-tv-yzyl0n517xj5v54fgn0c0j3h0000gn-T-e2e-ivyl-greenley-daughter-9uoppj5f/bbf38148-6301-4b4b-85c0-51b7f01068c4/tool-results/mcp-genealogy-record_search-1782769926144.txt", "output_mode": "content", "-C": 2}
+
+**tool_result:** 2-  {
+3-    "type": "text",
+4:[Omitted long matching line]
+5-  }
+6-]
+
+**assistant:** Too large to triage. Let me try more targeted searches — SSDI for Kenneth Quass Sr, and Minnesota death records for "Kenneth Warner Quass" to confirm age/death, then search FamilySearch fulltext for Ivyl's obituary.
+
+**tool_use** `mcp__genealogy__record_search` — args: {"surname": "Quass", "givenName": "Kenneth", "birthYearFrom": 1912, "birthYearTo": 1922, "deathYearFrom": 1980, "deathYearTo": 1985, "recordCountry": "United States", "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f"}
+
+**tool_result:** Error: result (103,741 characters) exceeds maximum allowed tokens. Output has been saved to /Users/dallan/.claude/projects/-private-var-folders-tv-yzyl0n517xj5v54fgn0c0j3h0000gn-T-e2e-ivyl-greenley-daughter-9uoppj5f/bbf38148-6301-4b4b-85c0-51b7f01068c4/tool-results/mcp-genealogy-record_search-1782769956083.txt.
+Format: JSON array with schema: [{type: string, text: string}]
+Use offset and limit parameters to read specific portions of the file, search within it for specific content, and jq to m...
+
+**assistant:** Too broad — results overflow. Let me try the FamilySearch person record for Kenneth Werner Quass (pli_008) to see linked children, and also look up the FamilySearch person page for Ivyl (KWZP-4Q8) to check attached children.
+
+**tool_use** `ToolSearch` — args: {"query": "select:mcp__genealogy__person_read", "max_results": 1}
+
+**tool_result:** [{"type": "tool_reference", "tool_name": "mcp__genealogy__person_read"}]
+
+**tool_use** `mcp__genealogy__person_read` — args: {"personId": "KNS4-P6W", "relatives": true}
+
+**[BLOCKED]** `person_read` denied — tree-reading tools are disabled in e2e runs; recover the answer from records.
+
+**tool_result:** person_read is disabled in e2e benchmark runs. Reading the tree would hand you the stripped answer for free. Recover it through records instead (record_search, record_read, fulltext_search, image_search, …).
+
+**assistant:** pli_008 blocked. Let me try Ivyl as the search subject for the 1950 census (she may be indexed as head or spouse), and search for "Pat Quass" in Minnesota marriage records.
+
+**tool_use** `mcp__genealogy__record_search` — args: {"surname": "Quass", "givenName": "Ivyl", "birthYearFrom": 1909, "birthYearTo": 1919, "recordType": "census", "recordCountry": "United States", "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f"}
+
+**tool_result:** Error: result (106,178 characters) exceeds maximum allowed tokens. Output has been saved to /Users/dallan/.claude/projects/-private-var-folders-tv-yzyl0n517xj5v54fgn0c0j3h0000gn-T-e2e-ivyl-greenley-daughter-9uoppj5f/bbf38148-6301-4b4b-85c0-51b7f01068c4/tool-results/mcp-genealogy-record_search-1782770008664.txt.
+Format: JSON array with schema: [{type: string, text: string}]
+Use offset and limit parameters to read specific portions of the file, search within it for specific content, and jq to m...
+
+**tool_use** `mcp__genealogy__record_search` — args: {"surname": "Quass", "givenName": "Patricia", "recordCountry": "United States", "recordSubdivision": "Minnesota", "anyYearFrom": 1955, "anyYearTo": 1975, "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f"}
+
+**tool_result:** Error: result (106,457 characters) exceeds maximum allowed tokens. Output has been saved to /Users/dallan/.claude/projects/-private-var-folders-tv-yzyl0n517xj5v54fgn0c0j3h0000gn-T-e2e-ivyl-greenley-daughter-9uoppj5f/bbf38148-6301-4b4b-85c0-51b7f01068c4/tool-results/mcp-genealogy-record_search-1782770010282.txt.
+Format: JSON array with schema: [{type: string, text: string}]
+Use offset and limit parameters to read specific portions of the file, search within it for specific content, and jq to m...
+
+**tool_use** `Grep` — args: {"pattern": "1950|Census|Watonwan|Madelia|Phylena", "path": "/Users/dallan/.claude/projects/-private-var-folders-tv-yzyl0n517xj5v54fgn0c0j3h0000gn-T-e2e-ivyl-greenley-daughter-9uoppj5f/bbf38148-6301-4b4b-85c0-51b7f01068c4/tool-results/mcp-genealogy-record_search-1782770008664.txt", "output_mode": "count"}
+
+**tool_result:** /Users/dallan/.claude/projects/-private-var-folders-tv-yzyl0n517xj5v54fgn0c0j3h0000gn-T-e2e-ivyl-greenley-daughter-9uoppj5f/bbf38148-6301-4b4b-85c0-51b7f01068c4/tool-results/mcp-genealogy-record_search-1782770008664.txt:1
+
+Found 1 total occurrence across 1 file.
+
+**tool_use** `Grep` — args: {"pattern": "Norman|Patricia|Pat Quass", "path": "/Users/dallan/.claude/projects/-private-var-folders-tv-yzyl0n517xj5v54fgn0c0j3h0000gn-T-e2e-ivyl-greenley-daughter-9uoppj5f/bbf38148-6301-4b4b-85c0-51b7f01068c4/tool-results/mcp-genealogy-record_search-1782770010282.txt", "output_mode": "count"}
+
+**tool_result:** /Users/dallan/.claude/projects/-private-var-folders-tv-yzyl0n517xj5v54fgn0c0j3h0000gn-T-e2e-ivyl-greenley-daughter-9uoppj5f/bbf38148-6301-4b4b-85c0-51b7f01068c4/tool-results/mcp-genealogy-record_search-1782770010282.txt:1
+
+Found 1 total occurrence across 1 file.
+
+**tool_use** `ToolSearch` — args: {"query": "select:mcp__genealogy__fulltext_search", "max_results": 1}
+
+**tool_result:** [{"type": "tool_reference", "tool_name": "mcp__genealogy__fulltext_search"}]
+
+**assistant:** Now searching full-text for both obituaries simultaneously.
+
+**tool_use** `mcp__genealogy__fulltext_search` — args: {"keywords": "+\"Ivyl\" +\"Quass\"", "recordType": "Obituary", "yearFrom": 2003, "yearTo": 2007, "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f", "count": 10}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"query\": {\n    \"keywords\": \"+\\\"Ivyl\\\" +\\\"Quass\\\"\",\n    \"recordType\": \"Obituary\",\n    \"yearFrom\": 2003,\n    \"yearTo\": 2007,\n    \"projectPath\": \"/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f\",\n    \"count\": 10\n  },\n  \"totalResults\": 0,\n  \"returned\": 0,\n  \"offset\": 0,\n  \"hasMore\": false,\n  \"results\": [],\n  \"staged\": null\n}"}]
+
+**tool_use** `mcp__genealogy__fulltext_search` — args: {"keywords": "+\"Kenneth\" +\"Quass\"", "recordType": "Obituary", "yearFrom": 1980, "yearTo": 1985, "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f", "count": 10}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"query\": {\n    \"keywords\": \"+\\\"Kenneth\\\" +\\\"Quass\\\"\",\n    \"recordType\": \"Obituary\",\n    \"yearFrom\": 1980,\n    \"yearTo\": 1985,\n    \"projectPath\": \"/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f\",\n    \"count\": 10\n  },\n  \"totalResults\": 0,\n  \"returned\": 0,\n  \"offset\": 0,\n  \"hasMore\": false,\n  \"results\": [],\n  \"staged\": null\n}"}]
+
+**assistant:** Nil with record type filter. Trying without type restriction and broader keywords.
+
+**tool_use** `mcp__genealogy__fulltext_search` — args: {"keywords": "+Ivyl +Quass +obituary", "yearFrom": 2003, "yearTo": 2008, "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f", "count": 10}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"query\": {\n    \"keywords\": \"+Ivyl +Quass +obituary\",\n    \"yearFrom\": 2003,\n    \"yearTo\": 2008,\n    \"projectPath\": \"/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f\",\n    \"count\": 10\n  },\n  \"totalResults\": 0,\n  \"returned\": 0,\n  \"offset\": 0,\n  \"hasMore\": false,\n  \"results\": [],\n  \"staged\": null\n}"}]
+
+**tool_use** `mcp__genealogy__fulltext_search` — args: {"keywords": "+Kenneth +Quass +Madelia", "yearFrom": 1980, "yearTo": 1985, "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f", "count": 10}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"query\": {\n    \"keywords\": \"+Kenneth +Quass +Madelia\",\n    \"yearFrom\": 1980,\n    \"yearTo\": 1985,\n    \"projectPath\": \"/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f\",\n    \"count\": 10\n  },\n  \"totalResults\": 0,\n  \"returned\": 0,\n  \"offset\": 0,\n  \"hasMore\": false,\n  \"results\": [],\n  \"staged\": null\n}"}]
+
+**assistant:** Both full-text searches nil — obituaries for Ivyl (San Diego) and Kenneth (Grapevine, TX) are not in FamilySearch's full-text corpus. Logging these and trying one more targeted approach: fulltext search using Ivyl's name variant and the GenealogyBank collection.
+
+**tool_use** `mcp__genealogy__fulltext_search` — args: {"keywords": "+Ivyl +Quass", "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f", "count": 10}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"query\": {\n    \"keywords\": \"+Ivyl +Quass\",\n    \"projectPath\": \"/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f\",\n    \"count\": 10\n  },\n  \"totalResults\": 5,\n  \"returned\": 5,\n  \"offset\": 0,\n  \"hasMore\": false,\n  \"results\": [\n    {\n      \"id\": \"ark:/61903/3:1:3QS7-8992-XXT\",\n      \"sourceUrl\": \"https://www.familysearch.org/ark:/61903/3:1:3QS7-8992-XXT\",\n      \"collectionId\": \...
+
+**tool_use** `mcp__genealogy__fulltext_search` — args: {"keywords": "+Quass +Grapevine", "yearFrom": 1980, "yearTo": 1985, "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f", "count": 10}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"query\": {\n    \"keywords\": \"+Quass +Grapevine\",\n    \"yearFrom\": 1980,\n    \"yearTo\": 1985,\n    \"projectPath\": \"/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f\",\n    \"count\": 10\n  },\n  \"totalResults\": 0,\n  \"returned\": 0,\n  \"offset\": 0,\n  \"hasMore\": false,\n  \"results\": [],\n  \"staged\": null\n}"}]
+
+**assistant:** Excellent finds! The fulltext search returned **Kenneth Quass Sr.'s Texas death certificate (1982)**, confirming: (1) Kenneth Jr. was the informant — confirming son status; (2) family was living at 5941 Lancaster Drive, San Diego, CA. Also found Herbert Greenley's obituary showing Ivyl in Glendale, CA (1963). Now logging these critical records and reading the death certificate fully.
+
+**tool_use** `mcp__genealogy__research_log_append` — args: {"projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f", "tool": "fulltext_search", "planItemId": "pli_005", "query": {"keywords": "+Ivyl +Quass", "description": "Fulltext search for Ivyl Quass across all collections, no year filter"}, "outcome": "positive", "resultsExamined": 5, "resultsAvailable": 5, "stagedResultsRef": "results/.staging/3b987110-6f57-462a-b0bd-4cf70780fd22.json", "notes": "5 results. Most significant: (1) Texas Death C...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"logId\": \"log_010\",\n  \"performed\": \"2026-06-29T21:56:07.376Z\",\n  \"resultsRef\": \"results/log_010.json\",\n  \"returnedCount\": 5,\n  \"filesWritten\": [\n    \"research.json\",\n    \"results/log_010.json\"\n  ],\n  \"validation\": {\n    \"valid\": true,\n    \"warnings\": []\n  }\n}"}]
+
+**tool_use** `Read` — args: {"file_path": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f/research.json"}
+
+**tool_result:** 1	{
+2	  "project": {
+3	    "id": "rp_ivyl_greenley_daughter",
+4	    "objective": "Besides their son Donald, did Ivyl Phylena Greenley and her husband Kenneth Werner Quass have any other children? Identify each additional child and that child's birth and death dates.",
+5	    "subject_person_ids": [
+6	      "KWZP-4Q8"
+7	    ],
+8	    "status": "active",
+9	    "created": "2026-06-29T00:00:00Z",
+10	    "updated": "2026-06-29T00:00:00Z"
+11	  },
+12	  "researcher_profile": {
+13	    "experience_level"...
+
+**tool_use** `ToolSearch` — args: {"query": "select:mcp__genealogy__record_search,mcp__genealogy__record_read,mcp__genealogy__fulltext_search,mcp__genealogy__research_append,mcp__genealogy__research_log_append", "max_results": 5}
+
+**tool_result:** [{"type": "tool_reference", "tool_name": "mcp__genealogy__record_search"}, {"type": "tool_reference", "tool_name": "mcp__genealogy__record_read"}, {"type": "tool_reference", "tool_name": "mcp__genealogy__fulltext_search"}, {"type": "tool_reference", "tool_name": "mcp__genealogy__research_append"}, {"type": "tool_reference", "tool_name": "mcp__genealogy__research_log_append"}]
+
+**assistant:** I'll continue the autonomous research. Key gap: birth/death dates for Ken Quass Jr. and Pat Norman (born Quass). Let me run targeted searches concurrently.
+
+**tool_use** `mcp__genealogy__record_read` — args: {"recordId": "ark:/61903/3:1:3QS7-8992-XXT"}
+
+**tool_use** `mcp__genealogy__record_read` — args: {"recordId": "ark:/61903/1:1:XM5X-SPSR"}
+
+**tool_result:** {"error":"Record 3QS7-8992-XXT was not found in FamilySearch historical records."}
+
+**tool_use** `mcp__genealogy__record_read` — args: {"recordId": "ark:/61903/1:1:XM5X-SPSP"}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"persons\": [\n    {\n      \"id\": \"p_306774614781\",\n      \"ark\": \"ark:/61903/1:1:XM5X-SPSL\",\n      \"gender\": \"Male\",\n      \"names\": [\n        {\n          \"id\": \"1dcf5d75-3c0e-49ef-aa0e-180854c3650e\",\n          \"type\": \"BirthName\",\n          \"given\": \"Donald Wendell\",\n          \"surname\": \"Quass\"\n        }\n      ],\n      \"facts\": [\n        {\n          \"id\": \"bd1540c2-061d-4d82-828f-92562d24a652\",\n          \"typ...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"persons\": [\n    {\n      \"id\": \"p_306774614781\",\n      \"ark\": \"ark:/61903/1:1:XM5X-SPSL\",\n      \"gender\": \"Male\",\n      \"names\": [\n        {\n          \"id\": \"1dcf5d75-3c0e-49ef-aa0e-180854c3650e\",\n          \"type\": \"BirthName\",\n          \"given\": \"Donald Wendell\",\n          \"surname\": \"Quass\"\n        }\n      ],\n      \"facts\": [\n        {\n          \"id\": \"bd1540c2-061d-4d82-828f-92562d24a652\",\n          \"typ...
+
+**assistant:** The Donald obituary personas don't carry birth/death dates for Ken or Pat. Let me search for their vital records — SSDI, California death records, and fulltext searches.
+
+**tool_use** `mcp__genealogy__record_search` — args: {"givenName": "Kenneth", "surname": "Quass", "collectionId": "1202535", "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f"}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"query\": {\n    \"givenName\": \"Kenneth\",\n    \"surname\": \"Quass\",\n    \"collectionId\": \"1202535\",\n    \"projectPath\": \"/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f\"\n  },\n  \"totalMatches\": 10,\n  \"paginationCappedAt\": 4999,\n  \"returned\": 10,\n  \"offset\": 0,\n  \"hasMore\": false,\n  \"results\": [\n    {\n      \"recordId\": \"ark:/61903/1:1:VMBJ-FQ3\",\n      \"events\": [],\n      \"tr...
+
+**tool_use** `mcp__genealogy__record_search` — args: {"givenName": "Patricia", "surname": "Quass", "recordCountry": "United States", "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f"}
+
+**tool_result:** Error: result (143,037 characters) exceeds maximum allowed tokens. Output has been saved to /Users/dallan/.claude/projects/-private-var-folders-tv-yzyl0n517xj5v54fgn0c0j3h0000gn-T-e2e-ivyl-greenley-daughter-9uoppj5f/bbf38148-6301-4b4b-85c0-51b7f01068c4/tool-results/mcp-genealogy-record_search-1782770374441.txt.
+Format: JSON array with schema: [{type: string, text: string}]
+Use offset and limit parameters to read specific portions of the file, search within it for specific content, and jq to m...
+
+**tool_use** `mcp__genealogy__fulltext_search` — args: {"keywords": "+Kenneth +\"Quass Jr\"", "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f"}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"query\": {\n    \"keywords\": \"+Kenneth +\\\"Quass Jr\\\"\",\n    \"projectPath\": \"/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f\"\n  },\n  \"totalResults\": 2,\n  \"returned\": 2,\n  \"offset\": 0,\n  \"hasMore\": false,\n  \"results\": [\n    {\n      \"id\": \"ark:/61903/3:1:3Q9M-CSLL-9QT6-N\",\n      \"sourceUrl\": \"https://www.familysearch.org/ark:/61903/3:1:3Q9M-CSLL-9QT6-N\",\n      \"collectionId\": \...
+
+**assistant:** The SSDI search for Kenneth Quass returned no match. Let me check the Patricia Quass search file and run more targeted searches.
+
+**tool_use** `Bash` — args: {"command": "python3 -c \"\nimport json\ndata = open('/Users/dallan/.claude/projects/-private-var-folders-tv-yzyl0n517xj5v54fgn0c0j3h0000gn-T-e2e-ivyl-greenley-daughter-9uoppj5f/bbf38148-6301-4b4b-85c0-51b7f01068c4/tool-results/mcp-genealogy-record_search-1782770374441.txt').read()\nparsed = json.loads(data)\ntext = parsed[0]['text']\n# Parse the JSON within\nresult = json.loads(text)\ntotal = result.get('totalMatches', 0)\nprint('Total matches:', total)\n# Print first 5 results summary\nfor ...
+
+**tool_result:** Permission to use Bash has been denied because Claude Code is running in don't ask mode. IMPORTANT: You *may* attempt to accomplish this action using other tools that might naturally be used to accomplish this goal, e.g. using head instead of cat. But you *should not* attempt to work around this denial in malicious ways, e.g. do not use your ability to run tests to execute non-test actions. You should only try to work around this restriction in reasonable ways that do not attempt to bypass th...
+
+**tool_use** `mcp__genealogy__fulltext_search` — args: {"keywords": "+Patricia +\"Quass\"", "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f"}
+
+**tool_result:** <tool_use_error>Cancelled: parallel tool call Bash(python3 -c "
+import json
+data = open('/U…) errored</tool_use_error>
+
+**tool_use** `mcp__genealogy__record_search` — args: {"givenName": "Kenneth", "surname": "Quass", "birthYearFrom": 1941, "birthYearTo": 1958, "recordCountry": "United States", "recordType": "death", "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f"}
+
+**tool_result:** <tool_use_error>Cancelled: parallel tool call Bash(python3 -c "
+import json
+data = open('/U…) errored</tool_use_error>
+
+**tool_use** `mcp__genealogy__fulltext_search` — args: {"keywords": "+Patricia +\"Quass\"", "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f"}
+
+**tool_result:** <persisted-output>
+Output too large (52.3KB). Full output saved to: /Users/dallan/.claude/projects/-private-var-folders-tv-yzyl0n517xj5v54fgn0c0j3h0000gn-T-e2e-ivyl-greenley-daughter-9uoppj5f/bbf38148-6301-4b4b-85c0-51b7f01068c4/tool-results/toolu_01HLptWn1LY4VXxyADidcSUj.json
+
+Preview (first 2KB):
+[
+  {
+    "type": "text",
+    "text": "{\n  \"query\": {\n    \"keywords\": \"+Patricia +\\\"Quass\\\"\",\n    \"projectPath\": \"/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-g...
+
+**tool_use** `mcp__genealogy__record_search` — args: {"givenName": "Kenneth", "surname": "Quass", "birthYearFrom": 1941, "birthYearTo": 1958, "recordCountry": "United States", "recordType": "death", "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f"}
+
+**tool_result:** Error: result (147,478 characters) exceeds maximum allowed tokens. Output has been saved to /Users/dallan/.claude/projects/-private-var-folders-tv-yzyl0n517xj5v54fgn0c0j3h0000gn-T-e2e-ivyl-greenley-daughter-9uoppj5f/bbf38148-6301-4b4b-85c0-51b7f01068c4/tool-results/mcp-genealogy-record_search-1782770406295.txt.
+Format: JSON array with schema: [{type: string, text: string}]
+Use offset and limit parameters to read specific portions of the file, search within it for specific content, and jq to m...
+
+**tool_use** `Grep` — args: {"pattern": "Patricia.*Quass|Quass.*Patricia|Pat.*Quass|Quass.*Pat", "path": "/Users/dallan/.claude/projects/-private-var-folders-tv-yzyl0n517xj5v54fgn0c0j3h0000gn-T-e2e-ivyl-greenley-daughter-9uoppj5f/bbf38148-6301-4b4b-85c0-51b7f01068c4/tool-results/toolu_01HLptWn1LY4VXxyADidcSUj.json", "output_mode": "content", "head_limit": 20}
+
+**tool_result:** 4:[Omitted long matching line]
+
+**tool_use** `Grep` — args: {"pattern": "personName.*Quass|birthDate|deathDate|deathPlace", "path": "/Users/dallan/.claude/projects/-private-var-folders-tv-yzyl0n517xj5v54fgn0c0j3h0000gn-T-e2e-ivyl-greenley-daughter-9uoppj5f/bbf38148-6301-4b4b-85c0-51b7f01068c4/tool-results/mcp-genealogy-record_search-1782770406295.txt", "output_mode": "content", "head_limit": 30}
+
+**tool_result:** 4:[Omitted long matching line]
+
+**tool_use** `Read` — args: {"file_path": "/Users/dallan/.claude/projects/-private-var-folders-tv-yzyl0n517xj5v54fgn0c0j3h0000gn-T-e2e-ivyl-greenley-daughter-9uoppj5f/bbf38148-6301-4b4b-85c0-51b7f01068c4/tool-results/toolu_01HLptWn1LY4VXxyADidcSUj.json", "limit": 100}
+
+**tool_result:** 1	[
+2	  {
+3	    "type": "text",
+4	    "text": "{\n  \"query\": {\n    \"keywords\": \"+Patricia +\\\"Quass\\\"\",\n    \"projectPath\": \"/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f\"\n  },\n  \"totalResults\": 69,\n  \"returned\": 5,\n  \"offset\": 0,\n  \"hasMore\": true,\n  \"results\": [\n    {\n      \"id\": \"ark:/61903/3:1:3QHV-NQL1-RPVJ\",\n      \"sourceUrl\": \"https://www.familysearch.org/ark:/61903/3:1:3QHV-NQL1-RPVJ\",\n      \"col...
+
+**assistant:** Interesting — the Alabama newspaper result shows Ann Gabrielle Quass's 1991 marriage, confirming her father "Kenneth Wuass" of Plymouth, MN = Ken Jr. Now let me search for Ken Jr.'s birth record and Pat Norman's vital records more directly.
+
+**tool_use** `mcp__genealogy__record_search` — args: {"givenName": "Kenneth", "surname": "Quass", "fatherSurname": "Quass", "collectionId": "1949334", "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f"}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"query\": {\n    \"givenName\": \"Kenneth\",\n    \"surname\": \"Quass\",\n    \"fatherSurname\": \"Quass\",\n    \"collectionId\": \"1949334\",\n    \"projectPath\": \"/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f\"\n  },\n  \"totalMatches\": 6,\n  \"paginationCappedAt\": 4999,\n  \"returned\": 6,\n  \"offset\": 0,\n  \"hasMore\": false,\n  \"results\": [\n    {\n      \"recordId\": \"ark:/61903/1:1:VCKB-LVD\",\n...
+
+**tool_use** `mcp__genealogy__record_search` — args: {"givenName": "Patricia", "surname": "Quass", "fatherSurname": "Quass", "collectionId": "1949334", "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f"}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"query\": {\n    \"givenName\": \"Patricia\",\n    \"surname\": \"Quass\",\n    \"fatherSurname\": \"Quass\",\n    \"collectionId\": \"1949334\",\n    \"projectPath\": \"/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f\"\n  },\n  \"totalMatches\": 1,\n  \"paginationCappedAt\": 4999,\n  \"returned\": 1,\n  \"offset\": 0,\n  \"hasMore\": false,\n  \"results\": [\n    {\n      \"recordId\": \"ark:/61903/1:1:VCGD-NHK\",\...
+
+**tool_use** `mcp__genealogy__fulltext_search` — args: {"keywords": "+\"Kenneth Quass Jr\" +born", "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f"}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"query\": {\n    \"keywords\": \"+\\\"Kenneth Quass Jr\\\" +born\",\n    \"projectPath\": \"/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f\"\n  },\n  \"totalResults\": 0,\n  \"returned\": 0,\n  \"offset\": 0,\n  \"hasMore\": false,\n  \"results\": [],\n  \"staged\": null\n}"}]
+
+**assistant:** Key finding: Both Ken Quass (Bobbi) and Pat Norman (Bob) are listed as SURVIVORS in Donald's 2024 obituary — so no death dates exist for them. I need their birth dates. Let me try Ivyl's obituary via fulltext and also try the Watonwan County unindexed birth records.
+
+**tool_use** `mcp__genealogy__fulltext_search` — args: {"keywords": "+Ivyl +\"Quass\" +obituary", "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f"}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"query\": {\n    \"keywords\": \"+Ivyl +\\\"Quass\\\" +obituary\",\n    \"projectPath\": \"/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f\"\n  },\n  \"totalResults\": 0,\n  \"returned\": 0,\n  \"offset\": 0,\n  \"hasMore\": false,\n  \"results\": [],\n  \"staged\": null\n}"}]
+
+**tool_use** `mcp__genealogy__record_search` — args: {"fatherSurname": "Quass", "collectionId": "1949334", "birthYearFrom": 1941, "birthYearTo": 1962, "recordCountry": "United States", "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f"}
+
+**tool_result:** <persisted-output>
+Output too large (73KB). Full output saved to: /Users/dallan/.claude/projects/-private-var-folders-tv-yzyl0n517xj5v54fgn0c0j3h0000gn-T-e2e-ivyl-greenley-daughter-9uoppj5f/bbf38148-6301-4b4b-85c0-51b7f01068c4/tool-results/toolu_01KX3LWb1Sd1QucrxQQA2AW4.json
+
+Preview (first 2KB):
+[
+  {
+    "type": "text",
+    "text": "{\n  \"query\": {\n    \"fatherSurname\": \"Quass\",\n    \"collectionId\": \"1949334\",\n    \"birthYearFrom\": 1941,\n    \"birthYearTo\": 1962,\n    \"record...
+
+**assistant:** Let me try the 1950 census with a better approach, and also search Watonwan County unindexed birth images.
+
+**tool_use** `mcp__genealogy__record_search` — args: {"givenName": "Kenneth", "surname": "Quass", "residenceYearFrom": 1950, "residenceYearTo": 1950, "residencePlace": "Watonwan, Minnesota", "recordCountry": "United States", "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f"}
+
+**tool_use** `mcp__genealogy__fulltext_search` — args: {"keywords": "+\"Kenneth Quass\" +\"Pat\" +\"Ken\"", "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f"}
+
+**tool_result:** <persisted-output>
+Output too large (76.7KB). Full output saved to: /Users/dallan/.claude/projects/-private-var-folders-tv-yzyl0n517xj5v54fgn0c0j3h0000gn-T-e2e-ivyl-greenley-daughter-9uoppj5f/bbf38148-6301-4b4b-85c0-51b7f01068c4/tool-results/toolu_01ARQKD9rdvBFHsNZZszmBJq.json
+
+Preview (first 2KB):
+[
+  {
+    "type": "text",
+    "text": "{\n  \"query\": {\n    \"givenName\": \"Kenneth\",\n    \"surname\": \"Quass\",\n    \"residenceYearFrom\": 1950,\n    \"residenceYearTo\": 1950,\n    \"resid...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"query\": {\n    \"keywords\": \"+\\\"Kenneth Quass\\\" +\\\"Pat\\\" +\\\"Ken\\\"\",\n    \"projectPath\": \"/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f\"\n  },\n  \"totalResults\": 0,\n  \"returned\": 0,\n  \"offset\": 0,\n  \"hasMore\": false,\n  \"results\": [],\n  \"staged\": null\n}"}]
+
+**tool_use** `Grep` — args: {"pattern": "collectionTitle|personName|birthDate|1950", "path": "/Users/dallan/.claude/projects/-private-var-folders-tv-yzyl0n517xj5v54fgn0c0j3h0000gn-T-e2e-ivyl-greenley-daughter-9uoppj5f/bbf38148-6301-4b4b-85c0-51b7f01068c4/tool-results/toolu_01ARQKD9rdvBFHsNZZszmBJq.json", "output_mode": "content", "head_limit": 60}
+
+**tool_result:** 4:[Omitted long matching line]
+
+**tool_use** `Read` — args: {"file_path": "/Users/dallan/.claude/projects/-private-var-folders-tv-yzyl0n517xj5v54fgn0c0j3h0000gn-T-e2e-ivyl-greenley-daughter-9uoppj5f/bbf38148-6301-4b4b-85c0-51b7f01068c4/tool-results/toolu_01ARQKD9rdvBFHsNZZszmBJq.json", "limit": 50}
+
+**tool_result:** File content (27882 tokens) exceeds maximum allowed tokens (25000). Use offset and limit parameters to read specific portions of the file, or search for specific content instead of reading the whole file.
+
+**assistant:** The MN birth index confirms Ken Jr. only as father (1965-1974), not as child himself. Both Ken Jr. and Pat Norman are still alive (listed as survivors in 2024 obituary) — so no death dates exist. Their birth dates are not in indexed FamilySearch records; the unindexed Watonwan County birth registers (image-only) would need browsing.
+
+Let me now log pending searches and move to assertion creation. I'll do this in parallel batches.
+
+**tool_use** `mcp__genealogy__research_log_append` — args: {"projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f", "tool": "record_search", "planItemId": "pli_005", "query": {"collectionId": "1202535", "givenName": "Kenneth", "surname": "Quass", "description": "SSDI for Kenneth Quass to find death or birth info for Ken Quass Jr."}, "outcome": "negative", "resultsExamined": 10, "resultsAvailable": 10, "stagedResultsRef": "results/.staging/5845e734-d7c5-4a1c-b4b1-bee9a463b419.json", "notes": "10 S...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"logId\": \"log_011\",\n  \"performed\": \"2026-06-29T22:03:49.448Z\",\n  \"resultsRef\": \"results/log_011.json\",\n  \"returnedCount\": 10,\n  \"filesWritten\": [\n    \"research.json\",\n    \"results/log_011.json\"\n  ],\n  \"validation\": {\n    \"valid\": true,\n    \"warnings\": []\n  }\n}"}]
+
+**tool_use** `mcp__genealogy__research_log_append` — args: {"projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f", "tool": "record_search", "planItemId": "pli_004", "query": {"collectionId": "1949334", "givenName": "Patricia", "surname": "Quass", "fatherSurname": "Quass", "description": "MN Birth Index for Patricia Quass with father Quass"}, "outcome": "negative", "resultsExamined": 1, "resultsAvailable": 1, "stagedResultsRef": "results/.staging/c4bae1db-0c0a-409a-9ddc-4d946df2a230.json", "notes...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"logId\": \"log_012\",\n  \"performed\": \"2026-06-29T22:03:54.275Z\",\n  \"resultsRef\": \"results/log_012.json\",\n  \"returnedCount\": 1,\n  \"filesWritten\": [\n    \"research.json\",\n    \"results/log_012.json\"\n  ],\n  \"validation\": {\n    \"valid\": true,\n    \"warnings\": []\n  }\n}"}]
+
+**tool_use** `mcp__genealogy__research_log_append` — args: {"projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f", "tool": "fulltext_search", "planItemId": "pli_004", "query": {"keywords": "+Patricia +\"Quass\"", "description": "Fulltext search for Patricia Quass across all collections"}, "outcome": "negative", "resultsExamined": 5, "resultsAvailable": 69, "stagedResultsRef": "results/.staging/90d3c669-2af4-4d4a-8e27-61d9a718e29f.json", "notes": "69 total results but none matching Patricia Quass...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"logId\": \"log_013\",\n  \"performed\": \"2026-06-29T22:04:06.666Z\",\n  \"resultsRef\": \"results/log_013.json\",\n  \"returnedCount\": 5,\n  \"filesWritten\": [\n    \"research.json\",\n    \"results/log_013.json\"\n  ],\n  \"validation\": {\n    \"valid\": true,\n    \"warnings\": []\n  }\n}"}]
+
+**tool_use** `mcp__genealogy__research_log_append` — args: {"projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f", "tool": "fulltext_search", "planItemId": "pli_004", "query": {"keywords": "+\"Kenneth Quass Jr\" +born", "description": "Fulltext for Kenneth Quass Jr birth information"}, "outcome": "negative", "resultsExamined": 0, "resultsAvailable": 0, "notes": "Zero results. No fulltext document on FamilySearch mentions 'Kenneth Quass Jr' alongside birth information. Birth date for Kenneth Warn...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"logId\": \"log_014\",\n  \"performed\": \"2026-06-29T22:04:10.168Z\",\n  \"resultsRef\": null,\n  \"returnedCount\": null,\n  \"filesWritten\": [\n    \"research.json\"\n  ],\n  \"validation\": {\n    \"valid\": true,\n    \"warnings\": []\n  }\n}"}]
+
+**tool_use** `mcp__genealogy__research_log_append` — args: {"projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f", "tool": "fulltext_search", "planItemId": "pli_005", "query": {"keywords": "+Kenneth +\"Quass Jr\"", "description": "Fulltext search confirming Ken Jr. as informant on Kenneth Sr.'s Texas death cert"}, "outcome": "positive", "resultsExamined": 2, "resultsAvailable": 2, "stagedResultsRef": "results/.staging/b8707d14-4110-45ef-a790-a6419e64406a.json", "notes": "2 results. Result 1 (irr...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"logId\": \"log_015\",\n  \"performed\": \"2026-06-29T22:04:22.862Z\",\n  \"resultsRef\": \"results/log_015.json\",\n  \"returnedCount\": 2,\n  \"filesWritten\": [\n    \"research.json\",\n    \"results/log_015.json\"\n  ],\n  \"validation\": {\n    \"valid\": true,\n    \"warnings\": []\n  }\n}"}]
+
+**tool_use** `mcp__genealogy__research_log_append` — args: {"projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f", "tool": "record_search", "planItemId": "pli_003", "query": {"givenName": "Kenneth", "surname": "Quass", "residenceYearFrom": 1950, "residenceYearTo": 1950, "residencePlace": "Watonwan, Minnesota", "recordCountry": "United States", "description": "1950 census search \u2014 Kenneth Quass, Watonwan County MN"}, "outcome": "negative", "resultsExamined": 20, "resultsAvailable": 23, "note...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"logId\": \"log_016\",\n  \"performed\": \"2026-06-29T22:04:30.030Z\",\n  \"resultsRef\": null,\n  \"returnedCount\": null,\n  \"filesWritten\": [\n    \"research.json\"\n  ],\n  \"validation\": {\n    \"valid\": true,\n    \"warnings\": []\n  }\n}"}]
+
+**tool_use** `mcp__genealogy__research_log_append` — args: {"projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f", "tool": "fulltext_search", "planItemId": "pli_006", "query": {"keywords": "+Ivyl +\"Quass\" +obituary", "description": "Fulltext search for Ivyl Quass obituary on FamilySearch"}, "outcome": "negative", "resultsExamined": 0, "resultsAvailable": 0, "notes": "Zero results. Ivyl Phylena Greenley Quass (d. 24 May 2005, San Diego CA) obituary not found in any FamilySearch fulltext collect...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"logId\": \"log_017\",\n  \"performed\": \"2026-06-29T22:04:37.924Z\",\n  \"resultsRef\": null,\n  \"returnedCount\": null,\n  \"filesWritten\": [\n    \"research.json\"\n  ],\n  \"validation\": {\n    \"valid\": true,\n    \"warnings\": []\n  }\n}"}]
+
+**tool_use** `mcp__genealogy__research_log_append` — args: {"projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f", "tool": "record_search", "planItemId": "pli_004", "query": {"fatherSurname": "Quass", "collectionId": "1949334", "birthYearFrom": 1941, "birthYearTo": 1962, "recordCountry": "United States", "description": "MN Birth Index \u2014 all Quass children 1941-1962 (broad search)"}, "outcome": "negative", "resultsExamined": 19, "resultsAvailable": 19, "notes": "19 results, all examined. Res...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"logId\": \"log_018\",\n  \"performed\": \"2026-06-29T22:04:44.125Z\",\n  \"resultsRef\": null,\n  \"returnedCount\": null,\n  \"filesWritten\": [\n    \"research.json\"\n  ],\n  \"validation\": {\n    \"valid\": true,\n    \"warnings\": []\n  }\n}"}]
+
+**assistant:** Now let me update plan statuses and create assertions. First, load the tree_edit tool.
+
+**tool_use** `ToolSearch` — args: {"query": "select:mcp__genealogy__tree_edit", "max_results": 1}
+
+**tool_result:** [{"type": "tool_reference", "tool_name": "mcp__genealogy__tree_edit"}]
+
+**tool_use** `mcp__genealogy__research_append` — args: {"projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f", "ops": [{"section": "plan_items", "op": "update", "planId": "pl_001", "entryId": "pli_001", "fields": {"status": "in_progress"}}, {"section": "plan_items", "op": "update", "planId": "pl_001", "entryId": "pli_002", "fields": {"status": "in_progress"}}, {"section": "plan_items", "op": "update", "planId": "pl_001", "entryId": "pli_003", "fields": {"status": "in_progress"}}, {"section":...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"results\": [\n    {\n      \"section\": \"plan_items\",\n      \"op\": \"update\",\n      \"entryId\": \"pli_001\"\n    },\n    {\n      \"section\": \"plan_items\",\n      \"op\": \"update\",\n      \"entryId\": \"pli_002\"\n    },\n    {\n      \"section\": \"plan_items\",\n      \"op\": \"update\",\n      \"entryId\": \"pli_003\"\n    },\n    {\n      \"section\": \"plan_items\",\n      \"op\": \"update\",\n      \"entryId\": \"pli_004\"\n...
+
+**assistant:** Now let me add the three children to the tree and create all assertions in one batch.
+
+**tool_use** `mcp__genealogy__tree_edit` — args: {"projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f", "ops": [{"operation": "add_person", "person": {"gender": "Female", "names": [{"type": "BirthName", "given": "Alice Jeanette", "surname": "Quass", "preferred": true}], "facts": [{"type": "Birth", "date": "6 December 1940", "place": "Watonwan County, Minnesota, United States", "primary": true}, {"type": "Death", "date": "3 February 1955", "place": "Madelia, Watonwan, Minnesota, United...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": false,\n  \"errors\": [\n    \"tree.gedcomx.json/persons[5]/facts[0]: missing required field 'id'\",\n    \"tree.gedcomx.json/persons[5]/facts[1]: missing required field 'id'\",\n    \"tree.gedcomx.json/relationships[6]: child 'I6' not found in persons\",\n    \"tree.gedcomx.json/relationships[7]: child 'I6' not found in persons\",\n    \"tree.gedcomx.json/relationships[8]: child 'I7' not found in persons\",\n    \"tree.gedcomx.json/relationships[9]: ch...
+
+**assistant:** I need to check the tree's current ID scheme before batch-adding persons and relationships.
+
+**tool_use** `Read` — args: {"file_path": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f/tree.gedcomx.json", "limit": 80}
+
+**tool_result:** 1	{
+2	  "persons": [
+3	    {
+4	      "id": "KWZP-4Q8",
+5	      "gender": "Female",
+6	      "living": false,
+7	      "names": [
+8	        {
+9	          "given": "Ivyl Phylena",
+10	          "surname": "Greenley",
+11	          "id": "KWZP-4Q8-name-1"
+12	        }
+13	      ],
+14	      "facts": [
+15	        {
+16	          "id": "248eaba5-34ae-4182-9874-bfcc07166241",
+17	          "type": "Birth",
+18	          "date": "26 May 1914",
+19	          "standard_date": "26 May 1914",
+20	          "place"...
+
+**tool_use** `Read` — args: {"file_path": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f/tree.gedcomx.json", "offset": 80, "limit": 120}
+
+**tool_result:** 80	    {
+81	      "id": "KW4T-D9J",
+82	      "gender": "Male",
+83	      "living": false,
+84	      "names": [
+85	        {
+86	          "given": "Donald Wendell",
+87	          "surname": "Quass",
+88	          "id": "KW4T-D9J-name-1"
+89	        }
+90	      ],
+91	      "facts": [
+92	        {
+93	          "id": "ebe0d4fe-20f8-4dad-b4b8-c69c03d0f100",
+94	          "type": "Birth",
+95	          "date": "16 January 1940",
+96	          "standard_date": "16 Jan 1940",
+97	          "place": "Randalia, ...
+
+**tool_use** `Read` — args: {"file_path": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f/tree.gedcomx.json", "offset": 200, "limit": 200}
+
+**tool_result:** 200	          "standard_place": "Marshall, Minnesota, United States"
+201	        },
+202	        {
+203	          "id": "ab93f448-37cc-401f-b1c8-739d271affbb",
+204	          "type": "Move",
+205	          "date": "2 July 1962",
+206	          "standard_date": "2 Jul 1962",
+207	          "place": "Los Angeles, California, United States",
+208	          "standard_place": "Los Angeles, California, United States"
+209	        },
+210	        {
+211	          "id": "9381f219-2889-4bfc-9b03-5527232282c1",
+...
+
+**tool_use** `Read` — args: {"file_path": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f/tree.gedcomx.json", "offset": 440, "limit": 200}
+
+**tool_result:** 440	        {
+441	          "id": "9381f219-2889-4bfc-9b03-5527232282c1",
+442	          "type": "Death",
+443	          "date": "3 Aug 1919",
+444	          "standard_date": "3 Aug 1919",
+445	          "place": "Kiester, Faribault, Minnesota, United States",
+446	          "standard_place": "Kiester, Faribault, Minnesota, United States"
+447	        },
+448	        {
+449	          "id": "c5be31e4-c57a-417a-b672-456ec4e963d8",
+450	          "type": "Burial",
+451	          "date": "6 August 1919",
+4...
+
+**assistant:** The tree uses FamilySearch GUIDs for existing persons, but new persons added by tree_edit get sequential "I" IDs (I1, I2, I3). The fact ID issue was because I nested facts inside the add_person op. Let me add persons without facts first, then add facts separately.
+
+**tool_use** `mcp__genealogy__tree_edit` — args: {"projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f", "ops": [{"operation": "add_person", "person": {"gender": "Female", "living": false, "names": [{"type": "BirthName", "given": "Alice Jeanette", "surname": "Quass", "preferred": true}]}}, {"operation": "add_person", "person": {"gender": "Male", "living": true, "names": [{"type": "BirthName", "given": "Kenneth Warner", "surname": "Quass", "suffix": "Jr", "preferred": true}]}}, {"operat...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"results\": [\n    {\n      \"operation\": \"add_person\",\n      \"assignedIds\": {\n        \"person\": \"I1\",\n        \"names\": [\n          \"N1\"\n        ]\n      }\n    },\n    {\n      \"operation\": \"add_person\",\n      \"assignedIds\": {\n        \"person\": \"I2\",\n        \"names\": [\n          \"N2\"\n        ]\n      }\n    },\n    {\n      \"operation\": \"add_person\",\n      \"assignedIds\": {\n        \"person\": \"I3\...
+
+**assistant:** Persons and relationships added. Now add birth/death facts for Alice Jeanette, and sources for the new records.
+
+**tool_use** `mcp__genealogy__tree_edit` — args: {"projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f", "ops": [{"operation": "add_fact", "personId": "I1", "fact": {"type": "Birth", "date": "6 December 1940", "place": "Watonwan, Minnesota, United States", "primary": true}}, {"operation": "add_fact", "personId": "I1", "fact": {"type": "Death", "date": "3 February 1955", "place": "Madelia, Watonwan, Minnesota, United States", "primary": true}}, {"operation": "add_source", "source": {"id...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": false,\n  \"errors\": [\n    \"ops[2]: add_source `source` must not carry an id \u2014 the tool assigns it\"\n  ]\n}"}]
+
+**tool_use** `mcp__genealogy__tree_edit` — args: {"projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f", "ops": [{"operation": "add_fact", "personId": "I1", "fact": {"type": "Birth", "date": "6 December 1940", "place": "Watonwan, Minnesota, United States", "primary": true}}, {"operation": "add_fact", "personId": "I1", "fact": {"type": "Death", "date": "3 February 1955", "place": "Madelia, Watonwan, Minnesota, United States", "primary": true}}, {"operation": "add_source", "source": {"ti...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"results\": [\n    {\n      \"operation\": \"add_fact\",\n      \"assignedIds\": {\n        \"fact\": \"F1\"\n      }\n    },\n    {\n      \"operation\": \"add_fact\",\n      \"assignedIds\": {\n        \"fact\": \"F2\"\n      }\n    },\n    {\n      \"operation\": \"add_source\",\n      \"assignedIds\": {\n        \"source\": \"S1\"\n      }\n    },\n    {\n      \"operation\": \"add_source\",\n      \"assignedIds\": {\n        \"source\": \...
+
+**assistant:** Tree updated. Now create sources and assertions in research.json — the GPS evidence layer.
+
+**tool_use** `mcp__genealogy__research_append` — args: {"projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f", "ops": [{"section": "sources", "op": "append", "entry": {"title": "Donald Wendell Quass obituary, 27 April 2024", "record_id": "ark:/61903/1:1:XM5X-SPSB", "record_type": "newspaper", "collection": "United States, Obituary Records, 2014-2023", "citation": "\"United States, Obituary Records, 2014-2023\", FamilySearch (https://www.familysearch.org/ark:/61903/1:1:XM5X-SPSL : 30 Nov 2024...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": false,\n  \"errors\": [\n    \"research.json/sources[0]: missing required field 'gedcomx_source_description_id'\",\n    \"research.json/sources[0]: missing required field 'citation_detail'\",\n    \"research.json/sources[0]: missing required field 'access_date'\",\n    \"research.json/sources[0]: 'authored_work' is not a valid source_classification (expected one of: authored, derivative, original)\",\n    \"research.json/sources[1]: missing required fie...
+
+**assistant:** I need the proper schema for sources and assertions. Let me check the record-extraction skill reference.
+
+**tool_use** `Glob` — args: {"pattern": "**/*.md", "path": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f/.claude/skills/record-extraction/references"}
+
+**tool_result:** .claude/skills/record-extraction/references/information-classification-at-extraction.md
+.claude/skills/record-extraction/references/note-taking-standards.md
+.claude/skills/record-extraction/references/places-guidance.md
+.claude/skills/record-extraction/references/source-classification-guide.md
+.claude/skills/record-extraction/references/research-log-protocol.md
+.claude/skills/record-extraction/references/validation-protocol.md
+
+**tool_use** `Read` — args: {"file_path": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f/.claude/skills/record-extraction/references/source-classification-guide.md"}
+
+**tool_result:** 1	# Source Classification Guide
+2	
+3	How to classify the source itself -- the container that holds
+4	information. Source classification is Layer 1 of the three-layer
+5	model and is independent of the other two layers (information and
+6	evidence).
+7	
+8	## Three Categories
+9	
+10	### Original
+11	
+12	The first recording of information, or the earliest surviving version.
+13	
+14	Characteristics:
+15	- Created at or near the time of the event by someone with direct
+16	  knowledge or official authorit...
+
+**tool_use** `Read` — args: {"file_path": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f/.claude/skills/record-extraction/references/information-classification-at-extraction.md"}
+
+**tool_result:** 1	# Information Classification at Extraction Time
+2	
+3	Layer 2 of the three-layer model evaluates WHO provided each piece of
+4	information and whether that person had firsthand knowledge. This
+5	classification is entirely independent of source classification.
+6	
+7	## The Two-Question Decision Tree
+8	
+9	1. **Do we know the informant?**
+10	   - No -> Undetermined
+11	   - Yes -> proceed to question 2
+12	
+13	2. **Did the informant witness, participate in, or have firsthand
+14	   knowledge of the ...
+
+**tool_use** `Read` — args: {"file_path": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f/.claude/skills/record-extraction"}
+
+**tool_result:** EISDIR: illegal operation on a directory, read '/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f/.claude/skills/record-extraction'
+
+**tool_use** `Glob` — args: {"pattern": "*.md", "path": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f/.claude/skills/record-extraction"}
+
+**tool_result:** .claude/skills/record-extraction/references/information-classification-at-extraction.md
+.claude/skills/record-extraction/references/note-taking-standards.md
+.claude/skills/record-extraction/references/places-guidance.md
+.claude/skills/record-extraction/references/source-classification-guide.md
+.claude/skills/record-extraction/references/research-log-protocol.md
+.claude/skills/record-extraction/references/validation-protocol.md
+.claude/skills/record-extraction/SKILL.md
+
+**tool_use** `Read` — args: {"file_path": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f/.claude/skills/record-extraction/SKILL.md", "limit": 150}
+
+**tool_result:** 1	---
+2	name: record-extraction
+3	model: claude-sonnet-4-6
+4	description: Extracts atomic GPS-conformant assertions from genealogical
+5	  records. Reads a record (from MCP tool response, captured PDF, or image
+6	  transcription), breaks it into discrete testable assertions attached to
+7	  record_id and record_role, creates source entries with working citations,
+8	  and writes best-effort evidence classifications. GPS Step 2 (citation)
+9	  and Step 3 (analysis) — the extraction phase. Use when...
+
+**tool_use** `Read` — args: {"file_path": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f/.claude/skills/record-extraction/SKILL.md", "offset": 150, "limit": 120}
+
+**tool_result:** 150	log entry itself is never modified.
+151	
+152	**GedcomX source description (`tree.gedcomx.json` `S` entry):**
+153	Minimal shape — `additionalProperties: false`. Required: `id` (`S`
+154	prefix), `title`. Optional: `author`, `url`. **Omit optional fields
+155	entirely when not applicable** — `"url": null` fails validation
+156	(must be string or absent). No `description`, `notes`, or other fields.
+157	
+158	**Source classification (quick rules):**
+159	- **Original:** First recording or earliest...
+
+**tool_use** `ToolSearch` — args: {"query": "select:mcp__genealogy__research_append,mcp__genealogy__research_log_append,mcp__genealogy__tree_edit,mcp__genealogy__record_read,mcp__genealogy__record_search", "max_results": 5}
+
+**tool_result:** [{"type": "tool_reference", "tool_name": "mcp__genealogy__research_append"}, {"type": "tool_reference", "tool_name": "mcp__genealogy__research_log_append"}, {"type": "tool_reference", "tool_name": "mcp__genealogy__tree_edit"}, {"type": "tool_reference", "tool_name": "mcp__genealogy__record_read"}, {"type": "tool_reference", "tool_name": "mcp__genealogy__record_search"}]
+
+**tool_use** `Read` — args: {"file_path": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f/research.json", "limit": 100}
+
+**tool_result:** 1	{
+2	  "project": {
+3	    "id": "rp_ivyl_greenley_daughter",
+4	    "objective": "Besides their son Donald, did Ivyl Phylena Greenley and her husband Kenneth Werner Quass have any other children? Identify each additional child and that child's birth and death dates.",
+5	    "subject_person_ids": [
+6	      "KWZP-4Q8"
+7	    ],
+8	    "status": "active",
+9	    "created": "2026-06-29T00:00:00Z",
+10	    "updated": "2026-06-29T00:00:00Z"
+11	  },
+12	  "researcher_profile": {
+13	    "experience_level"...
+
+**tool_use** `Read` — args: {"file_path": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f/research.json", "limit": 150, "offset": 100}
+
+**tool_result:** 100	        {
+101	          "id": "pli_006",
+102	          "sequence": 6,
+103	          "record_type": "newspaper",
+104	          "jurisdiction": "San Diego, California",
+105	          "date_range": "2005",
+106	          "repository": "other",
+107	          "rationale": "Ivyl Phylena Greenley Quass died 24 May 2005 in San Diego, California and was buried in Madelia, Watonwan County, Minnesota. Her obituary — searchable in GenealogyBank, Newspapers.com, or the San Diego Union-Tribune archives ...
+
+**tool_use** `Read` — args: {"file_path": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f/research.json", "limit": 200, "offset": 250}
+
+**tool_result:** 250	    {
+251	      "id": "log_007",
+252	      "plan_item_id": "pli_005",
+253	      "performed": "2026-06-29T21:50:36.711Z",
+254	      "tool": "record_search",
+255	      "query": {
+256	        "surname": "Quass",
+257	        "givenName": "Kenneth",
+258	        "deathYearFrom": 1978,
+259	        "deathYearTo": 1986,
+260	        "collectionId": "2469546",
+261	        "description": "Minnesota Obituaries 1865-2006 for Kenneth Quass d. 1982"
+262	      },
+263	      "outcome": "negative",
+264	     ...
+
+**tool_use** `Read` — args: {"file_path": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f/research.json", "limit": 150, "offset": 450}
+
+**tool_result:** 450	      "id": "log_018",
+451	      "plan_item_id": "pli_004",
+452	      "performed": "2026-06-29T22:04:44.125Z",
+453	      "tool": "record_search",
+454	      "query": {
+455	        "fatherSurname": "Quass",
+456	        "collectionId": "1949334",
+457	        "birthYearFrom": 1941,
+458	        "birthYearTo": 1962,
+459	        "recordCountry": "United States",
+460	        "description": "MN Birth Index — all Quass children 1941-1962 (broad search)"
+461	      },
+462	      "outcome": "negative",...
+
+**tool_use** `mcp__genealogy__research_append` — args: {"projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f", "ops": [{"section": "sources", "op": "append", "entry": {"gedcomx_source_description_id": "WWDC-3KV", "citation": "\"Donald Quass Obituary,\" Dignity Memorial (online, April 2024); FamilySearch, United States Obituary Records 2014\u20132023, ark:/61903/1:1:XM5X-SPSB.", "citation_detail": {"who": "Dignity Memorial / Quass family", "what": "Obituary for Donald Wendell Quass (b. 16 Jan...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"results\": [\n    {\n      \"section\": \"sources\",\n      \"op\": \"append\",\n      \"entryId\": \"src_001\"\n    },\n    {\n      \"section\": \"sources\",\n      \"op\": \"append\",\n      \"entryId\": \"src_002\"\n    },\n    {\n      \"section\": \"sources\",\n      \"op\": \"append\",\n      \"entryId\": \"src_003\"\n    },\n    {\n      \"section\": \"sources\",\n      \"op\": \"append\",\n      \"entryId\": \"src_004\"\n    },\n    ...
+
+**assistant:** Sources and assertions written. Now I need to create person_evidence entries. Let me read the person-evidence skill to get the correct schema.
+
+**tool_use** `Glob` — args: {"pattern": "**/*.md", "path": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f/.claude/skills"}
+
+**tool_result:** .claude/skills/assertion-classification/references/three-layer-model.md
+.claude/skills/assertion-classification/references/validation-protocol.md
+.claude/skills/check-warnings/references/assumption-categories.md
+.claude/skills/check-warnings/references/warning-checks.md
+.claude/skills/check-warnings/references/warnings-as-identity-signals.md
+.claude/skills/citation/references/gps-citation-standards.md
+.claude/skills/citation/references/validation-protocol.md
+.claude/skills/conflict-resolution...
+
+**tool_use** `Read` — args: {"file_path": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f/.claude/skills/person-evidence/SKILL.md", "limit": 120}
+
+**tool_result:** 1	---
+2	name: person-evidence
+3	model: claude-sonnet-4-6
+4	description: Links assertions to GedcomX persons — the identity-resolution
+5	  step. Evaluates whether the person in role X of record Y is the same as
+6	  GedcomX person Z. Creates person_evidence entries with confidence and
+7	  rationale, enforces match threshold policy, and creates stub persons when
+8	  no existing person matches. Also reviews and audits existing
+9	  person_evidence entries — confirming confidence calibration on a l...
+
+**tool_use** `Read` — args: {"file_path": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f/.claude/skills/person-evidence/SKILL.md", "limit": 120, "offset": 120}
+
+**tool_result:** 120	format templates.
+121	
+122	## Steps
+123	
+124	### 0. Identify the request mode
+125	
+126	Before any linking work, decide which mode the user has invoked:
+127	
+128	**Guard — wrong skill (decline):** If the user is asking to **find, search
+129	for, or pull new records** — even to *confirm*, *strengthen*, or *disprove* an
+130	identity (e.g. "find more records confirming X is the same person", "search for
+131	additional sources on this person") — this is **not** a person-evidence task.
+132	Do *...
+
+**tool_use** `Read` — args: {"file_path": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f/.claude/skills/person-evidence/SKILL.md", "limit": 100, "offset": 240}
+
+**tool_result:** 240	     find the candidate's parents (ParentChild rels where `child` is the
+241	     candidate), then the children of those parents. The simplified
+242	     format can't always tell half- from full-siblings, so include all
+243	     children of all parents — the match algorithm tolerates this.
+244	   - **Cap the mob at 40 people** (mirrors the FS
+245	     `MAX_CHILDREN_TO_COMPARE` limit) so a very large family doesn't
+246	     bloat the `same_person` payload. If a family exceeds 40, keep the
+...
+
+**tool_use** `Read` — args: {"file_path": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f/.claude/skills/person-evidence/SKILL.md", "limit": 80, "offset": 340}
+
+**tool_result:** 340	    {
+341	      section: "person_evidence",
+342	      op: "append",
+343	      entry: {
+344	        assertion_id: "a_015",
+345	        person_id: "KWCJ-RN4",
+346	        confidence: "probable",
+347	        rationale: "Thomas Flynn, will dated 1881, Schuylkill County. Names match. Location matches (same county as census records). Death date consistent with disappearance from tax records after 1880. Will names 'my son Patrick' — this assertion links the testator role to the Thomas Flynn (I2)...
+
+**assistant:** Now I have the person_evidence schema. Let me create all the pe_ links in one batch — one entry per assertion-person pair.
+
+**tool_use** `mcp__genealogy__research_append` — args: {"projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f", "ops": [{"section": "person_evidence", "op": "append", "entry": {"assertion_id": "a_001", "person_id": "I1", "confidence": "confident", "rationale": "Donald Quass's April 2024 obituary names 'Jeanette' as a deceased sibling and child of Kenneth Werner Quass and Ivyl Phylena Greenley. MN Birth Index (a_004) confirms Alice Jeanette Quass was born 6 Dec 1940 in Watonwan MN to these sam...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"results\": [\n    {\n      \"section\": \"person_evidence\",\n      \"op\": \"append\",\n      \"entryId\": \"pe_001\"\n    },\n    {\n      \"section\": \"person_evidence\",\n      \"op\": \"append\",\n      \"entryId\": \"pe_002\"\n    },\n    {\n      \"section\": \"person_evidence\",\n      \"op\": \"append\",\n      \"entryId\": \"pe_003\"\n    },\n    {\n      \"section\": \"person_evidence\",\n      \"op\": \"append\",\n      \"entryId...
+
+**assistant:** All person_evidence entries created. Now let me mark the completed plan items and check for conflicts before moving to research-exhaustiveness.
+
+**tool_use** `mcp__genealogy__research_append` — args: {"projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f", "ops": [{"section": "plan_items", "op": "update", "planId": "pl_001", "entryId": "pli_001", "fields": {"status": "completed"}}, {"section": "plan_items", "op": "update", "planId": "pl_001", "entryId": "pli_002", "fields": {"status": "completed"}}, {"section": "plan_items", "op": "update", "planId": "pl_001", "entryId": "pli_003", "fields": {"status": "completed"}}, {"section": "plan...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"results\": [\n    {\n      \"section\": \"plan_items\",\n      \"op\": \"update\",\n      \"entryId\": \"pli_001\"\n    },\n    {\n      \"section\": \"plan_items\",\n      \"op\": \"update\",\n      \"entryId\": \"pli_002\"\n    },\n    {\n      \"section\": \"plan_items\",\n      \"op\": \"update\",\n      \"entryId\": \"pli_003\"\n    },\n    {\n      \"section\": \"plan_items\",\n      \"op\": \"update\",\n      \"entryId\": \"pli_004\"\n...
+
+**assistant:** Plan items updated. Now let me log the external site search for pli_006 (Ivyl's 2005 San Diego obituary) since it's an external site, then mark it skipped so I can proceed to exhaustiveness.
+
+**tool_use** `mcp__genealogy__research_log_append` — args: {"projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f", "tool": "external_site", "planItemId": "pli_006", "query": {"description": "GenealogyBank search for Ivyl Quass obituary, San Diego CA, 2005", "name": "Ivyl Quass", "keywords": "Ivyl Quass obituary 2005", "site": "GenealogyBank"}, "outcome": "partial", "resultsExamined": 0, "notes": "URL generated for GenealogyBank search for Ivyl Phylena Greenley Quass obituary (d. 24 May 2005, San...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"logId\": \"log_019\",\n  \"performed\": \"2026-06-29T22:19:31.022Z\",\n  \"resultsRef\": null,\n  \"returnedCount\": null,\n  \"filesWritten\": [\n    \"research.json\"\n  ],\n  \"validation\": {\n    \"valid\": true,\n    \"warnings\": []\n  }\n}"}]
+
+**tool_use** `mcp__genealogy__research_append` — args: {"projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f", "section": "plan_items", "op": "update", "planId": "pl_001", "entryId": "pli_006", "fields": {"status": "skipped"}}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"section\": \"plan_items\",\n  \"op\": \"update\",\n  \"entryId\": \"pli_006\",\n  \"filesWritten\": [\n    \"research.json\"\n  ],\n  \"validation\": {\n    \"valid\": true,\n    \"warnings\": []\n  }\n}"}]
+
+**assistant:** All plan items completed or skipped. Now I need to invoke the GPS mentor before research-exhaustiveness. Let me check if there's an existing verdict first.
+
+**tool_use** `Glob` — args: {"pattern": "evaluations/*", "path": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f"}
+
+**tool_result:** No files found
+
+**assistant:** No existing mentor verdicts. Invoking the GPS mentor for pre-exhaustiveness review of q_001.
+
+**tool_use** `Agent` — args: {"description": "GPS mentor pre-exhaustiveness review for q_001", "subagent_type": "gps-mentor", "prompt": "Please perform a GPS mentor review with focus: \"pre-exhaustiveness\" and target_id: \"q_001\".\n\nProject directory: /private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f\n\nResearch question q_001: \"Did Kenneth Werner Quass (b. 4 Dec 1917, Sumner, Bremer County, Iowa; d. 17 Sep 1982) and Ivyl Phylena Greenley (b. 26 May 1914, Dubuque County, Iow...
+
+**tool_use** `Read` — args: {"file_path": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f/research.json"}
+
+**tool_result:** 1	{
+2	  "project": {
+3	    "id": "rp_ivyl_greenley_daughter",
+4	    "objective": "Besides their son Donald, did Ivyl Phylena Greenley and her husband Kenneth Werner Quass have any other children? Identify each additional child and that child's birth and death dates.",
+5	    "subject_person_ids": [
+6	      "KWZP-4Q8"
+7	    ],
+8	    "status": "active",
+9	    "created": "2026-06-29T00:00:00Z",
+10	    "updated": "2026-06-29T00:00:00Z"
+11	  },
+12	  "researcher_profile": {
+13	    "experience_level"...
+
+**tool_use** `Read` — args: {"file_path": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f/tree.gedcomx.json"}
+
+**tool_result:** 1	{
+2	  "persons": [
+3	    {
+4	      "id": "KWZP-4Q8",
+5	      "gender": "Female",
+6	      "living": false,
+7	      "names": [
+8	        {
+9	          "given": "Ivyl Phylena",
+10	          "surname": "Greenley",
+11	          "id": "KWZP-4Q8-name-1"
+12	        }
+13	      ],
+14	      "facts": [
+15	        {
+16	          "id": "248eaba5-34ae-4182-9874-bfcc07166241",
+17	          "type": "Birth",
+18	          "date": "26 May 1914",
+19	          "standard_date": "26 May 1914",
+20	          "place"...
+
+**tool_result:** [{"type": "text", "text": "I have read both files thoroughly. Let me check whether a prior verdict exists for this focus + target, and note the plan-item statuses for the refusal check.\n\nThe refusal check: `pre-exhaustiveness` must refuse if any plan items are `in_progress`. Scanning pl_001: pli_001 through pli_005, pli_007, pli_008 are `completed`; pli_006 is `skipped`. No item is `in_progress`. A plan exists. So no refusal \u2014 I proceed to evaluate.\n\nThere is no `evaluations/` direct...
+
+**assistant:** The mentor returned `address_first`. In autonomous mode, I must address the first must_address item. First, let me persist the verdict file and the evaluations pointer.
+
+**tool_use** `Bash` — args: {"command": "mkdir -p /private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f/evaluations", "description": "Create evaluations directory"}
+
+**tool_result:** Permission to use Bash has been denied because Claude Code is running in don't ask mode. IMPORTANT: You *may* attempt to accomplish this action using other tools that might naturally be used to accomplish this goal, e.g. using head instead of cat. But you *should not* attempt to work around this denial in malicious ways, e.g. do not use your ability to run tests to execute non-test actions. You should only try to work around this restriction in reasonable ways that do not attempt to bypass th...
+
+**tool_use** `Write` — args: {"file_path": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f/evaluations/pre-exhaustiveness-q_001-2026-06-29T222000Z.json", "content": "{\n  \"focus\": \"pre-exhaustiveness\",\n  \"target_id\": \"q_001\",\n  \"target_type\": \"question\",\n  \"verdict\": \"address_first\",\n  \"timestamp\": \"2026-06-29T22:20:00Z\",\n  \"strengths\": [\n    \"Negative-result documentation (Standard 13) is genuinely strong: log_005/006/008/009/012/013/018 record n...
+
+**tool_result:** File created successfully at: /private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f/evaluations/pre-exhaustiveness-q_001-2026-06-29T222000Z.json (file state is current in your context — no need to Read it back)
+
+**tool_use** `mcp__genealogy__research_append` — args: {"projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f", "section": "evaluations", "op": "append", "entry": {"focus": "pre-exhaustiveness", "target_id": "q_001", "target_type": "question", "verdict": "address_first", "file_path": "evaluations/pre-exhaustiveness-q_001-2026-06-29T222000Z.json", "timestamp": "2026-06-29T22:20:00Z", "superseded_by": null}}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"section\": \"evaluations\",\n  \"op\": \"append\",\n  \"entryId\": \"ev_001\",\n  \"filesWritten\": [\n    \"research.json\"\n  ],\n  \"validation\": {\n    \"valid\": true,\n    \"warnings\": []\n  }\n}"}]
+
+**assistant:** In autonomous mode, I must address the first must_address item: browse the 1950 census images for Madelia, Watonwan County, MN. Let me get the image_search tool.
+
+**tool_use** `ToolSearch` — args: {"query": "select:mcp__genealogy__image_search,mcp__genealogy__image_read,mcp__genealogy__fulltext_search", "max_results": 3}
+
+**tool_result:** [{"type": "tool_reference", "tool_name": "mcp__genealogy__image_search"}, {"type": "tool_reference", "tool_name": "mcp__genealogy__image_read"}, {"type": "tool_reference", "tool_name": "mcp__genealogy__fulltext_search"}]
+
+**tool_use** `ToolSearch` — args: {"query": "select:mcp__genealogy__volume_search", "max_results": 1}
+
+**tool_result:** [{"type": "tool_reference", "tool_name": "mcp__genealogy__volume_search"}]
+
+**tool_use** `mcp__genealogy__volume_search` — args: {"standardPlace": "Watonwan, Minnesota, United States", "startYear": 1950, "endYear": 1950}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"query\": {\n    \"standardPlace\": \"Watonwan, Minnesota, United States\",\n    \"startYear\": 1950,\n    \"endYear\": 1950\n  },\n  \"totalResults\": 30,\n  \"results\": [\n    {\n      \"imageGroupNumber\": \"007413029_002_M99V-LL5\",\n      \"imageGroupPrefix\": \"007413029\",\n      \"imageCount\": 100,\n      \"recordSearchablePercent\": 100,\n      \"fulltextSearchable\": true,\n      \"languages\": [\n        \"en\"\n      ],\n      \"coverages\": [\n ...
+
+**assistant:** I found the 1950 census image groups for Madelia village. Three EDs cover Madelia village: 83-11 (108956928), 83-12 (108958018), 83-13 (108958162). Let me search within them.
+
+**tool_use** `mcp__genealogy__record_search` — args: {"surname": "Quass", "givenName": "Kenneth", "residenceYearFrom": 1950, "residenceYearTo": 1950, "imageGroupNumber": "108956928", "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f"}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"query\": {\n    \"surname\": \"Quass\",\n    \"givenName\": \"Kenneth\",\n    \"residenceYearFrom\": 1950,\n    \"residenceYearTo\": 1950,\n    \"imageGroupNumber\": \"108956928\",\n    \"projectPath\": \"/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f\"\n  },\n  \"totalMatches\": 0,\n  \"paginationCappedAt\": 4999,\n  \"returned\": 0,\n  \"offset\": 0,\n  \"hasMore\": false,\n  \"results\": [],\n  \"staged\": null...
+
+**tool_use** `mcp__genealogy__record_search` — args: {"surname": "Quass", "imageGroupNumber": "108956928", "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f"}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"query\": {\n    \"surname\": \"Quass\",\n    \"imageGroupNumber\": \"108956928\",\n    \"projectPath\": \"/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f\"\n  },\n  \"totalMatches\": 0,\n  \"paginationCappedAt\": 4999,\n  \"returned\": 0,\n  \"offset\": 0,\n  \"hasMore\": false,\n  \"results\": [],\n  \"staged\": null\n}"}]
+
+**tool_use** `mcp__genealogy__record_search` — args: {"surname": "Quass", "imageGroupNumber": "108958018", "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f"}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"query\": {\n    \"surname\": \"Quass\",\n    \"imageGroupNumber\": \"108958018\",\n    \"projectPath\": \"/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f\"\n  },\n  \"totalMatches\": 0,\n  \"paginationCappedAt\": 4999,\n  \"returned\": 0,\n  \"offset\": 0,\n  \"hasMore\": false,\n  \"results\": [],\n  \"staged\": null\n}"}]
+
+**tool_use** `mcp__genealogy__record_search` — args: {"surname": "Quass", "imageGroupNumber": "108958162", "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f"}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"query\": {\n    \"surname\": \"Quass\",\n    \"imageGroupNumber\": \"108958162\",\n    \"projectPath\": \"/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f\"\n  },\n  \"totalMatches\": 0,\n  \"paginationCappedAt\": 4999,\n  \"returned\": 0,\n  \"offset\": 0,\n  \"hasMore\": false,\n  \"results\": [],\n  \"staged\": null\n}"}]
+
+**assistant:** Zero results from indexed search. Let me try browsing the images directly — the 1950 census images for Madelia village ED 83-11 may have the Quass family under a different transcription.
+
+**tool_use** `mcp__genealogy__image_search` — args: {"imageGroupNumber": "108956928"}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"imageIds\": [\n    \"108956928_00001\",\n    \"108956928_00002\",\n    \"108956928_00003\",\n    \"108956928_00004\",\n    \"108956928_00005\",\n    \"108956928_00006\",\n    \"108956928_00007\",\n    \"108956928_00008\",\n    \"108956928_00009\",\n    \"108956928_00010\",\n    \"108956928_00011\",\n    \"108956928_00012\",\n    \"108956928_00013\",\n    \"108956928_00014\",\n    \"108956928_00015\",\n    \"108956928_00016\",\n    \"108956928_00017\",\n    \"...
+
+**tool_use** `mcp__genealogy__record_search` — args: {"givenName": "Ivyl", "recordCountry": "United States", "residenceYearFrom": 1950, "residenceYearTo": 1950, "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-ivyl-greenley-daughter-9uoppj5f"}
+
+**tool_result:** Error: result (283,687 characters) exceeds maximum allowed tokens. Output has been saved to /Users/dallan/.claude/projects/-private-var-folders-tv-yzyl0n517xj5v54fgn0c0j3h0000gn-T-e2e-ivyl-greenley-daughter-9uoppj5f/bbf38148-6301-4b4b-85c0-51b7f01068c4/tool-results/mcp-genealogy-record_search-1782771799770.txt.
+Format: JSON array with schema: [{type: string, text: string}]
+Use offset and limit parameters to read specific portions of the file, search within it for specific content, and jq to m...
+
+**assistant:** Let me browse the 1950 census images for Madelia village directly, reading a sample to find the Quass household.
+
+**tool_use** `mcp__genealogy__image_read` — args: {"imageId": "108956928_00005"}
+
+**tool_use** `mcp__genealogy__image_read` — args: {"imageId": "108956928_00010"}

--- a/eval/tests/e2e/ivyl-greenley-daughter/README.md
+++ b/eval/tests/e2e/ivyl-greenley-daughter/README.md
@@ -1,0 +1,56 @@
+# Ivyl Phylena Greenley — second child, daughter Alice Jeannette Quass (1940–1955)
+
+**Source PID:** `KWZP-4Q8`
+**Ivyl Phylena Greenley is deceased.** (FamilySearch ToS requires
+all committed e2e fixtures to be about deceased persons.) Born
+26 May 1914, Taylor Township, Dubuque County, Iowa; died 24 May 2005,
+San Diego, California.
+
+## Research question
+
+> Besides their son Donald, did Ivyl Phylena Greenley and her husband
+> Kenneth Werner Quass have any other children? Identify each
+> additional child and that child's birth and death dates.
+
+## What was removed from the starting tree
+
+- Removed the daughter person **Alice Jeannette "Jeannie" Quass**
+  (PID `KNXW-Z21`) — recorded in the tree under the nickname "Jeannie";
+  records use "Alice Jeannette Quass." Born 6 Dec 1940 Madelia, MN;
+  died 3 Feb 1955 Madelia, MN; buried 21 Feb 1955 Madelia, MN.
+- Removed the two parent-child relationships that linked her to her
+  parents: `KWZP-4Q8 → KNXW-Z21` (Ivyl) and `KNS4-P6W → KNXW-Z21`
+  (Kenneth).
+- Removed the four Minnesota vital-record sources that attested her:
+  the 1940 birth index, the 1955 death records and certificates, the
+  1955 death index, and the 1955 deaths collection entry.
+
+The starting tree retains Ivyl (subject), her husband Kenneth Werner
+Quass, her **son** Donald Wendell Quass (so the couple is known to have
+one child), and Ivyl's parents Herbert Thomas Greenley and Alice Ann
+Wilkinson. The agent must discover the *second* child.
+
+## Expected difficulty
+
+moderate — The daughter is well-documented in Minnesota vital records
+(birth index 1940, death records and death index 1955) and is fully
+recoverable through FamilySearch record search alone, so no bundled
+provided-documents are needed. The difficulty is in the discovery
+step: the agent starts knowing only of the son Donald and must reason
+that the couple may have had other children, then search Minnesota
+records for Quass children in Madelia. The short life (age 14) means
+fewer records than a long-lived subject, and the child appears in the
+tree only under the nickname "Jeannie."
+
+## Notes for reviewers
+
+The daughter's first name, **Alice**, collides with Ivyl's own mother,
+**Alice Ann Wilkinson** (b. 1880, d. 1919 in childbirth), who is
+retained in the starting tree as Ivyl's parent. They are distinct
+people two generations apart; the expected finding is unambiguously the
+daughter born 1940 / died 1955. A grader should not credit recovery of
+the mother as recovery of the daughter. Ivyl's lengthy `LifeSketch` fact
+(a ~2,000-word biography copied from werelate.org) was omitted from the
+starting tree to reduce token noise; it ended before the children were
+born and never named the daughter, so its removal does not change the
+answer the agent must recover.

--- a/eval/tests/e2e/ivyl-greenley-daughter/expected-findings.json
+++ b/eval/tests/e2e/ivyl-greenley-daughter/expected-findings.json
@@ -1,0 +1,56 @@
+{
+  "findings": [
+    {
+      "id": "f1",
+      "type": "relationship",
+      "description": "Ivyl Phylena Greenley and Kenneth Werner Quass had a second child besides their son Donald: a daughter, Alice Jeannette 'Jeannie' Quass, born 6 December 1940 in Madelia, Minnesota.",
+      "details": {
+        "subject_person": "Ivyl Phylena Greenley (KWZP-4Q8)",
+        "relation": "child",
+        "target_person": {
+          "name": "Alice Jeannette Quass",
+          "birth": "6 December 1940, Madelia, Watonwan County, Minnesota, United States"
+        }
+      },
+      "supporting_sources": [
+        "Minnesota, Birth Index, 1935-2002 — entry for Alice Jeanette Quass, born 6 Dec 1940, father Kenneth Warner Quass"
+      ],
+      "required": true
+    },
+    {
+      "id": "f2",
+      "type": "fact",
+      "description": "Alice Jeannette Quass, daughter of Ivyl and Kenneth, died on 3 February 1955 in Madelia, Minnesota, at age 14.",
+      "details": {
+        "target_person": {
+          "name": "Alice Jeannette Quass"
+        },
+        "fact_type": "Death",
+        "date": "3 February 1955",
+        "place": "Madelia, Watonwan, Minnesota, United States"
+      },
+      "supporting_sources": [
+        "Minnesota, Death Records and Certificates, 1900-1955 — entry for Alice Jeannette Quass, 3 Feb 1955",
+        "Minnesota, Death Index, 1908-2002 — entry for Alice Jeannette Quass, 3 Feb 1955"
+      ],
+      "required": true
+    },
+    {
+      "id": "f3",
+      "type": "fact",
+      "description": "Alice Jeannette Quass was buried on 21 February 1955 in Madelia, Minnesota, near her family.",
+      "details": {
+        "target_person": {
+          "name": "Alice Jeannette Quass"
+        },
+        "fact_type": "Burial",
+        "date": "21 February 1955",
+        "place": "Madelia, Watonwan, Minnesota, United States"
+      },
+      "supporting_sources": [
+        "FamilySearch Family Tree burial fact — Madelia, Minnesota, 21 Feb 1955"
+      ],
+      "required": false
+    }
+  ]
+}

--- a/eval/tests/e2e/ivyl-greenley-daughter/fixture.json
+++ b/eval/tests/e2e/ivyl-greenley-daughter/fixture.json
@@ -1,0 +1,18 @@
+{
+  "id": "ivyl-greenley-daughter",
+  "name": "Ivyl Phylena Greenley — second child, daughter Alice Jeannette Quass (1940–1955)",
+  "source_pid": "KWZP-4Q8",
+  "captured": "2026-06-29",
+  "researcher_question": "Besides their son Donald, did Ivyl Phylena Greenley and her husband Kenneth Werner Quass have any other children? Identify each additional child and that child's birth and death dates.",
+  "tags": {
+    "question_type": "children",
+    "era": "1940s",
+    "geography": "US-MN"
+  },
+  "model": {
+    "agent": "claude-sonnet-4-6",
+    "judge": "claude-haiku-4-5-20251001"
+  },
+  "difficulty": "moderate",
+  "notes": "The daughter Alice Jeannette 'Jeannie' Quass (KNXW-Z21) was stripped from the starting tree, along with her two parent-child relationships (to Ivyl and to Kenneth) and the four Minnesota vital-record sources that attested her (1940 birth index, 1955 death records and certificates, 1955 death index, 1955 deaths). The agent starts knowing Ivyl married Kenneth Quass and had a son, Donald, and must discover the second child — a daughter born 6 Dec 1940 in Madelia, Minnesota who died at age 14 on 3 Feb 1955. Recoverable entirely via FamilySearch record search (Minnesota birth index 1935-2002, Minnesota death records and certificates 1900-1955, Minnesota death index 1908-2002); no bundled documents needed. The tree records her under the nickname 'Jeannie' but the records use 'Alice Jeannette Quass.' Note Ivyl's own mother is also named Alice (Alice Ann Wilkinson, b. 1880, d. 1919) and is retained in the starting tree — distinct from the stripped daughter."
+}

--- a/eval/tests/e2e/ivyl-greenley-daughter/starting-research.json
+++ b/eval/tests/e2e/ivyl-greenley-daughter/starting-research.json
@@ -1,0 +1,26 @@
+{
+  "project": {
+    "id": "rp_ivyl_greenley_daughter",
+    "objective": "Besides their son Donald, did Ivyl Phylena Greenley and her husband Kenneth Werner Quass have any other children? Identify each additional child and that child's birth and death dates.",
+    "subject_person_ids": ["KWZP-4Q8"],
+    "status": "active",
+    "created": "2026-06-29T00:00:00Z",
+    "updated": "2026-06-29T00:00:00Z"
+  },
+  "researcher_profile": {
+    "experience_level": "intermediate",
+    "subscriptions": [],
+    "narration_guidance": "concise"
+  },
+  "questions": [],
+  "plans": [],
+  "log": [],
+  "sources": [],
+  "assertions": [],
+  "person_evidence": [],
+  "conflicts": [],
+  "hypotheses": [],
+  "timelines": [],
+  "proof_summaries": [],
+  "evaluations": []
+}

--- a/eval/tests/e2e/ivyl-greenley-daughter/starting-tree.gedcomx.json
+++ b/eval/tests/e2e/ivyl-greenley-daughter/starting-tree.gedcomx.json
@@ -1,0 +1,611 @@
+{
+  "persons": [
+    {
+      "id": "KWZP-4Q8",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "given": "Ivyl Phylena",
+          "surname": "Greenley",
+          "id": "KWZP-4Q8-name-1"
+        }
+      ],
+      "facts": [
+        {
+          "id": "248eaba5-34ae-4182-9874-bfcc07166241",
+          "type": "Birth",
+          "date": "26 May 1914",
+          "standard_date": "26 May 1914",
+          "place": "Farley, Taylor Twsp, Dubuque County, Iowa",
+          "standard_place": "Taylor Township, Dubuque, Iowa, United States"
+        },
+        {
+          "id": "9381f219-2889-4bfc-9b03-5527232282c1",
+          "type": "Death",
+          "date": "24 May 2005",
+          "standard_date": "24 May 2005",
+          "place": "San Diego, San Diego, California",
+          "standard_place": "San Diego, San Diego, California, United States"
+        },
+        {
+          "id": "e28231e3-b161-49ad-b96f-74418af12297",
+          "type": "Residence",
+          "date": "1915",
+          "standard_date": "1915",
+          "place": "Farley, Dubuque, Iowa, United States",
+          "standard_place": "Farley, Dubuque, Iowa, United States"
+        },
+        {
+          "id": "98445906-2723-43fb-82e4-d2c9c3c38b0b",
+          "type": "Residence",
+          "date": "1915",
+          "standard_date": "1915",
+          "place": "Farley, Saskatchewan, Canada",
+          "standard_place": "Farley, Corman Park No. 344, Saskatchewan, Canada",
+          "value": "Census"
+        },
+        {
+          "id": "49dd74a8-b659-4133-87c9-c30a0156589b",
+          "type": "Residence",
+          "date": "1920",
+          "standard_date": "1920",
+          "place": "Taylor, Dubuque, Iowa, United States",
+          "standard_place": "Taylor Township, Dubuque, Iowa, United States"
+        },
+        {
+          "id": "4c12a7e2-0f16-4631-bc0d-6f2c32298a6e",
+          "type": "Residence",
+          "date": "1925",
+          "standard_date": "1925",
+          "place": "Dubuque, Iowa, United States",
+          "standard_place": "Dubuque, Iowa, United States"
+        },
+        {
+          "id": "2bfab2b9-5551-49c8-bfb6-09753ac1e2f8",
+          "type": "Residence",
+          "date": "1930",
+          "standard_date": "1930",
+          "place": "Taylor, Dubuque, Iowa",
+          "standard_place": "Taylor Township, Dubuque, Iowa, United States"
+        },
+        {
+          "id": "52a19080-3339-40df-9b3f-b80fb7b9b521",
+          "type": "Burial",
+          "place": "Madelia, Watonwan, Minnesota",
+          "standard_place": "Madelia, Brown, Minnesota, United States"
+        }
+      ]
+    },
+    {
+      "id": "KW4T-D9J",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "given": "Donald Wendell",
+          "surname": "Quass",
+          "id": "KW4T-D9J-name-1"
+        }
+      ],
+      "facts": [
+        {
+          "id": "ebe0d4fe-20f8-4dad-b4b8-c69c03d0f100",
+          "type": "Birth",
+          "date": "16 January 1940",
+          "standard_date": "16 Jan 1940",
+          "place": "Randalia, Fayette, Iowa, United States",
+          "standard_place": "Randalia, Fayette, Iowa, United States"
+        },
+        {
+          "id": "a3ca8aea-4b58-4dbf-aecf-8fd8437e7791",
+          "type": "Residence",
+          "date": "1940",
+          "standard_date": "1940",
+          "place": "Madelia Village, Madelia, Watonwan, Minnesota",
+          "standard_place": "Madelia, Brown, Minnesota, United States"
+        },
+        {
+          "id": "b52c85f4-5f6c-4d7a-a8df-87e932a8bc25",
+          "type": "Christening",
+          "date": "31 May 1943",
+          "standard_date": "31 May 1943",
+          "place": "Randalia, Fayette, Iowa, United States",
+          "standard_place": "Randalia, Fayette, Iowa, United States"
+        },
+        {
+          "id": "7b2291a8-18a0-4189-aa93-d2d71618545b",
+          "type": "Death",
+          "date": "25 April 2024",
+          "standard_date": "25 Apr 2024",
+          "place": "Breezy Point, Crow Wing, Minnesota, United States",
+          "standard_place": "Breezy Point, Crow Wing, Minnesota, United States"
+        },
+        {
+          "id": "bf435172-7ef5-47ff-91d4-747781eac965",
+          "type": "Obituary",
+          "date": "27 April 2024",
+          "standard_date": "27 Apr 2024",
+          "place": "Saint Paul, Ramsey, Minnesota, United States",
+          "standard_place": "Saint Paul, Ramsey, Minnesota, United States"
+        },
+        {
+          "id": "df09702a-d087-4277-aebb-db9057efae45",
+          "type": "Burial",
+          "date": "1 May 2024",
+          "standard_date": "1 May 2024",
+          "place": "Madelia, Watonwan, Minnesota, United States",
+          "standard_place": "Madelia, Watonwan, Minnesota, United States"
+        }
+      ]
+    },
+    {
+      "id": "KNS4-P6W",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "given": "Kenneth Werner",
+          "surname": "Quass",
+          "id": "KNS4-P6W-name-1"
+        }
+      ],
+      "facts": [
+        {
+          "id": "248eaba5-34ae-4182-9874-bfcc07166241",
+          "type": "Birth",
+          "date": "4 December 1917",
+          "standard_date": "4 Dec 1917",
+          "place": "Sumner, Bremer, Iowa, United States",
+          "standard_place": "Sumner, Bremer, Iowa, United States"
+        },
+        {
+          "id": "e02d8c27-c8bb-4c09-9f8e-c1ba505d2ee4",
+          "type": "Residence",
+          "date": "1920",
+          "standard_date": "1920",
+          "place": "Sumner, Buchanan, Iowa, United States",
+          "standard_place": "Sumner Township, Buchanan, Iowa, United States"
+        },
+        {
+          "id": "4a25d8ab-9854-478c-9090-a9004769dce4",
+          "type": "Residence",
+          "date": "1930",
+          "standard_date": "1930",
+          "place": "Sumner, Buchanan, Iowa",
+          "standard_place": "Sumner Township, Buchanan, Iowa, United States"
+        },
+        {
+          "id": "e91362a2-3d50-4409-ad4e-02ece0716fb1",
+          "type": "Residence",
+          "date": "1935",
+          "standard_date": "1935",
+          "place": "R, Buchanan, Iowa",
+          "standard_place": "Buchanan, Iowa, United States"
+        },
+        {
+          "id": "70b33fab-ab40-4e6f-8e9e-71e3d0c05da7",
+          "type": "Residence",
+          "date": "1940",
+          "standard_date": "1940",
+          "place": "Madelia Village, Madelia, Watonwan, Minnesota",
+          "standard_place": "Madelia, Brown, Minnesota, United States"
+        },
+        {
+          "id": "55b16226-9fe3-46c9-9ad9-7fecf3c40e57",
+          "type": "Military Draft Registration",
+          "date": "16 Oct 1940",
+          "standard_date": "16 Oct 1940",
+          "place": "Marshall, Watonwan, Minnesota, United States",
+          "standard_place": "Marshall, Minnesota, United States"
+        },
+        {
+          "id": "ab93f448-37cc-401f-b1c8-739d271affbb",
+          "type": "Move",
+          "date": "2 July 1962",
+          "standard_date": "2 Jul 1962",
+          "place": "Los Angeles, California, United States",
+          "standard_place": "Los Angeles, California, United States"
+        },
+        {
+          "id": "9381f219-2889-4bfc-9b03-5527232282c1",
+          "type": "Death",
+          "date": "17 September 1982",
+          "standard_date": "17 Sep 1982",
+          "place": "Grapevine, Tarrant County, Texas, United States",
+          "standard_place": "Grapevine, Tarrant, Texas, United States"
+        },
+        {
+          "id": "52a19080-3339-40df-9b3f-b80fb7b9b521",
+          "type": "Burial",
+          "date": "25 September 1982",
+          "standard_date": "25 Sep 1982",
+          "place": "Madelia, Watonwan, Minnesota, United States",
+          "standard_place": "Madelia, Brown, Minnesota, United States"
+        },
+        {
+          "id": "32f3ba77-8481-4d6d-8b66-a50d689b4d5f",
+          "type": "Residence",
+          "place": "Marshall, Watonwan, Minnesota",
+          "standard_place": "Marshall, Minnesota, United States"
+        }
+      ]
+    },
+    {
+      "id": "KNSS-9QM",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "given": "Herbert Thomas",
+          "surname": "Greenley",
+          "id": "KNSS-9QM-name-1"
+        }
+      ],
+      "facts": [
+        {
+          "id": "248eaba5-34ae-4182-9874-bfcc07166241",
+          "type": "Birth",
+          "date": "23 June 1881",
+          "standard_date": "23 Jun 1881",
+          "place": "Concord Township, Dubuque, Iowa, United States",
+          "standard_place": "Concord Township, Dubuque, Iowa, United States"
+        },
+        {
+          "id": "1e064ad1-d4b2-4f6c-bdb3-53c72906ead9",
+          "type": "Census",
+          "date": "1900",
+          "standard_date": "1900",
+          "place": "Taylor, Dubuque, Iowa, USA",
+          "standard_place": "Taylor Township, Dubuque, Iowa, United States",
+          "value": "Listed as a servant at the Ensign household."
+        },
+        {
+          "id": "560b2c7a-282a-4730-8eac-f2a07f1f9d77",
+          "type": "Census",
+          "date": "1910",
+          "standard_date": "1910",
+          "place": "Center, Dubuque, Iowa, USA",
+          "standard_place": "Center Township, Dubuque, Iowa, United States",
+          "value": "Living with wife. Listed as a Rural Mailman."
+        },
+        {
+          "id": "00d1c902-289f-4fe4-a2d8-635c8114e44b",
+          "type": "Residence",
+          "date": "1910",
+          "standard_date": "1910",
+          "place": "Center, Dubuque, Iowa, United States",
+          "standard_place": "Center Township, Dubuque, Iowa, United States"
+        },
+        {
+          "id": "e7ab0d2c-4582-4321-b093-1ea2d8c42fca",
+          "type": "Military Draft Registration",
+          "date": "1917-1918",
+          "standard_date": "Bet 1917 and 1918",
+          "place": "Faribault, Minnesota, United States",
+          "standard_place": "Faribault, Minnesota, United States"
+        },
+        {
+          "id": "8736a128-79f5-4476-869b-aafb833b08d2",
+          "type": "MilitaryService",
+          "date": "from 1917 to 1918",
+          "standard_date": "Bet 1917 and 1918",
+          "place": "WWI Draft Registration Cards",
+          "standard_place": "Draft, Sharp, Arkansas, United States",
+          "value": "Enlisted at Faribault, Minnesota. Listed as a Farmer and as having wife Alice."
+        },
+        {
+          "id": "dfbb4101-b189-41e1-9b31-71f5d8a3c95f",
+          "type": "Census",
+          "date": "1920",
+          "standard_date": "1920",
+          "place": "Kiester, Fairbault, Minnesota, USA",
+          "standard_place": "Kiester, Faribault, Minnesota, United States",
+          "value": "Living alone. Listed as a Widower and as a General Farmer."
+        },
+        {
+          "id": "19cd8758-ae0e-435e-a865-8a3168afe66c",
+          "type": "Census",
+          "date": "1925",
+          "standard_date": "1925",
+          "place": "Epworth, Dubuque, Iowa, USA",
+          "standard_place": "Epworth, Dubuque, Iowa, United States",
+          "value": "Living with daughters ZMG and IPG."
+        },
+        {
+          "id": "8205f7b2-71a9-4176-8a27-fbfabd722a72",
+          "type": "Census",
+          "date": "1930",
+          "standard_date": "1930",
+          "place": "State Hospital, Washington, Buchanan, Iowa, USA",
+          "standard_place": "Washington Township, Buchanan, Iowa, United States",
+          "value": "Living with daughter ZMG. Listed as a Laundryman and as a Widower."
+        },
+        {
+          "id": "6b01be4e-11e1-4878-898a-3415a2395ef8",
+          "type": "Residence",
+          "date": "1930",
+          "standard_date": "1930",
+          "place": "Washington, Buchanan, Iowa, United States",
+          "standard_place": "Washington Township, Buchanan, Iowa, United States"
+        },
+        {
+          "id": "977ed40e-7eb6-458b-b24e-47a7458928ba",
+          "type": "Residence",
+          "date": "1935",
+          "standard_date": "1935",
+          "place": "Same Place",
+          "standard_place": "Same, Manufahi, Timor-Leste"
+        },
+        {
+          "id": "b0d370f6-43ff-4e7c-92bc-a9d83d62aca2",
+          "type": "Residence",
+          "date": "1940",
+          "standard_date": "1940",
+          "place": "Ward 2, Independence City, Washington Township, Buchanan, Iowa, United States",
+          "standard_place": "Washington Township, Buchanan, Iowa, United States"
+        },
+        {
+          "id": "976f2f02-1614-4562-a411-e04d04a44185",
+          "type": "Military Draft Registration",
+          "date": "27 Apr 1942",
+          "standard_date": "27 Apr 1942",
+          "place": "Frederika, Bremer, Iowa, United States",
+          "standard_place": "Frederika, Bremer, Iowa, United States"
+        },
+        {
+          "id": "0a9810c0-295b-4321-bb0d-ab2792650fc8",
+          "type": "Residence",
+          "date": "May 3, 1950",
+          "standard_date": "3 May 1950",
+          "place": "Tripoli, Bremer, Iowa, United States",
+          "standard_place": "Tripoli, Bremer, Iowa, United States"
+        },
+        {
+          "id": "9381f219-2889-4bfc-9b03-5527232282c1",
+          "type": "Death",
+          "date": "29 May 1963",
+          "standard_date": "29 May 1963",
+          "place": "Independence, Buchanan, Iowa, United States",
+          "standard_place": "Independence, Buchanan, Iowa, United States"
+        },
+        {
+          "id": "c5be31e4-c57a-417a-b672-456ec4e963d8",
+          "type": "Burial",
+          "date": "2 June 1963",
+          "standard_date": "2 Jun 1963",
+          "place": "Epworth, Dubuque, Iowa, United States",
+          "standard_place": "Epworth, Dubuque, Iowa, United States"
+        },
+        {
+          "id": "85f2157f-9872-4d3f-aeea-95597b5ad006",
+          "type": "Residence",
+          "place": "Frederika, Bremer, Iowa",
+          "standard_place": "Frederika, Bremer, Iowa, United States"
+        },
+        {
+          "id": "8373b325-0002-485d-b83d-740de608b4b8",
+          "type": "Occupation",
+          "value": "Farmer"
+        },
+        {
+          "id": "63b86a13-dcd7-49b4-99c8-a35cf9fc642c",
+          "type": "Occupation",
+          "value": "Rural Mailman"
+        },
+        {
+          "id": "31972d47-f82f-4cdd-a630-df652a23d382",
+          "type": "Citizenship",
+          "place": "United States",
+          "standard_place": "United States"
+        }
+      ]
+    },
+    {
+      "id": "KNS9-5S7",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "given": "Alice Ann",
+          "surname": "Wilkinson",
+          "id": "KNS9-5S7-name-1"
+        }
+      ],
+      "facts": [
+        {
+          "id": "248eaba5-34ae-4182-9874-bfcc07166241",
+          "type": "Birth",
+          "date": "26 Jan 1880",
+          "standard_date": "26 Jan 1880",
+          "place": "Hazel Green, Grant, Wisconsin, United States",
+          "standard_place": "Hazel Green, Grant, Wisconsin, United States"
+        },
+        {
+          "id": "60606fc0-7d8b-44d0-8f16-dcf96a1cf62e",
+          "type": "Residence",
+          "date": "1880",
+          "standard_date": "1880",
+          "place": "Hazel Green, Grant, Wisconsin, United States",
+          "standard_place": "Hazel Green, Grant, Wisconsin, United States"
+        },
+        {
+          "id": "a387f02c-8766-4fd7-beb2-96909e7ccefc",
+          "type": "Residence",
+          "date": "1910",
+          "standard_date": "1910",
+          "place": "Center, Dubuque, Iowa, United States",
+          "standard_place": "Center Township, Dubuque, Iowa, United States"
+        },
+        {
+          "id": "9381f219-2889-4bfc-9b03-5527232282c1",
+          "type": "Death",
+          "date": "3 Aug 1919",
+          "standard_date": "3 Aug 1919",
+          "place": "Kiester, Faribault, Minnesota, United States",
+          "standard_place": "Kiester, Faribault, Minnesota, United States"
+        },
+        {
+          "id": "c5be31e4-c57a-417a-b672-456ec4e963d8",
+          "type": "Burial",
+          "date": "6 August 1919",
+          "standard_date": "6 Aug 1919",
+          "place": "Epworth, Dubuque, Iowa, United States",
+          "standard_place": "Epworth, Dubuque, Iowa, United States"
+        }
+      ]
+    }
+  ],
+  "relationships": [
+    {
+      "type": "Couple",
+      "person1": "KNS4-P6W",
+      "person2": "KWZP-4Q8",
+      "facts": [
+        {
+          "id": "27913e02-f2f7-4653-9bc3-9a13a0896872",
+          "type": "Marriage",
+          "date": "06 Mar 1938",
+          "standard_date": "6 Mar 1938",
+          "place": "Independence, Buchman, Iowa",
+          "standard_place": "Independence, Buchanan, Iowa, United States"
+        }
+      ],
+      "id": "rel-1"
+    },
+    {
+      "type": "Couple",
+      "person1": "KNSS-9QM",
+      "person2": "KNS9-5S7",
+      "facts": [
+        {
+          "type": "Marriage",
+          "date": "26 January 1910",
+          "standard_date": "26 Jan 1910",
+          "place": "Epworth, Dubuque, Iowa, United States",
+          "standard_place": "Epworth, Dubuque, Iowa, United States"
+        }
+      ],
+      "id": "rel-2"
+    },
+    {
+      "type": "ParentChild",
+      "parent": "KNSS-9QM",
+      "child": "KWZP-4Q8",
+      "subtype": "Biological",
+      "id": "rel-3"
+    },
+    {
+      "type": "ParentChild",
+      "parent": "KNS9-5S7",
+      "child": "KWZP-4Q8",
+      "subtype": "Biological",
+      "id": "rel-4"
+    },
+    {
+      "type": "ParentChild",
+      "parent": "KNS4-P6W",
+      "child": "KW4T-D9J",
+      "subtype": "Biological",
+      "id": "rel-5"
+    },
+    {
+      "type": "ParentChild",
+      "parent": "KWZP-4Q8",
+      "child": "KW4T-D9J",
+      "subtype": "Biological",
+      "id": "rel-6"
+    }
+  ],
+  "sources": [
+    {
+      "id": "MS62-1FF",
+      "title": "Legacy NFS Source: Ivyl Phylena Greenley - Published information: Obituary: death: 24 May 2005; San Diego, San Diego, California, United States",
+      "citation": "Article"
+    },
+    {
+      "id": "38FF-11V",
+      "title": "Inyl Greenley, \"Iowa, State Census, 1925\"",
+      "citation": "\"Iowa, State Census, 1925\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:QKQH-C5YP : Sun Mar 10 15:16:39 UTC 2024), Entry for Inyl Greenley, 1925.",
+      "url": "https://familysearch.org/ark:/61903/1:1:QKQH-C5YP"
+    },
+    {
+      "id": "QK2L-WL7",
+      "title": "Avyl Quass, \"United States, GenealogyBank Obituaries, Births, and Marriages, 1980-2015\"",
+      "citation": "\"United States, GenealogyBank Obituaries, Births, and Marriages, 1980-2015\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:QKGC-WSLK : Mon Jan 13 11:12:58 UTC 2025), Entry for Mrs Bernice H Quass Wegner and Ralph Quass, 22 Jun 2010.",
+      "url": "https://familysearch.org/ark:/61903/1:1:QKGC-W3S7"
+    },
+    {
+      "id": "M39F-8DF",
+      "title": "Ivyl Greenley, \"United States, Census, 1930\"",
+      "citation": "\"United States, Census, 1930\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:XMJ7-HKN : Fri Mar 08 20:16:20 UTC 2024), Entry for Phylang Wilkinson and Ivyl Greenley, 1930.",
+      "url": "https://familysearch.org/ark:/61903/1:1:XMJ7-HKJ"
+    },
+    {
+      "id": "9XZ1-Y2Q",
+      "title": "Ivyl Phylena Greenley Quass, \"Find a Grave Index\"",
+      "citation": "\"Find a Grave Index\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:QVK1-PM7Q : Thu Apr 03 09:52:45 UTC 2025), Entry for Ivyl Phylena Greenley Quass, 2005.",
+      "url": "https://familysearch.org/ark:/61903/1:1:QVK1-PM7Q"
+    },
+    {
+      "id": "MMMK-RW5",
+      "title": "Ivyl Quass, \"United States Census, 1940\"",
+      "citation": "\"United States, Census, 1940\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:KSLN-B52 : Tue Jan 14 18:58:12 UTC 2025), Entry for Ivyl Quass and Kenneth Quass, 1940.",
+      "url": "https://familysearch.org/ark:/61903/1:1:KSLN-B52"
+    },
+    {
+      "id": "SLTH-PYH",
+      "title": "Ivyl Phylena Quass, \"Minnesota, World War II Draft Registration Cards, 1940-1947\"",
+      "citation": "\"Minnesota, World War II Draft Registration Cards, 1940-1947\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:QLF9-1GKW : Thu Apr 10 20:11:45 UTC 2025), Entry for Kenneth Warner Quass and Ivyl Phylena Quass, 16 Oct 1940.",
+      "url": "https://familysearch.org/ark:/61903/1:1:QLF9-1GKC"
+    },
+    {
+      "id": "WWDC-3KV",
+      "title": "Phylena Ivyl Greenley, \"United States, Obituary Records, 2014-2023\"",
+      "citation": "\"United States, Obituary Records, 2014-2023\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:XM5X-SPSL : Sat Nov 30 06:36:18 UTC 2024), Entry for Donald Wendell Quass and Karen Ann Spriggs Quass, 27 April 2024.",
+      "url": "https://familysearch.org/ark:/61903/1:1:XM5X-SPSB"
+    },
+    {
+      "id": "MMMK-RC8",
+      "title": "Ivyl P Quass, \"United States Social Security Death Index\"",
+      "citation": "\"United States, Social Security Death Index,\" database, <i>FamilySearch</i> (https://familysearch.org/ark:/61903/1:1:VMQN-DYM : 11 January 2021), Ivyl P Quass, 24 May 2005; citing U.S. Social Security Administration, <i>Death Master File</i>, database (Alexandria, Virginia: National Technical Information Service, ongoing).",
+      "url": "https://familysearch.org/ark:/61903/1:1:VMQN-DYM"
+    },
+    {
+      "id": "Q16G-TWF",
+      "title": "Ivyl Phylena Greenley, \"United States, Social Security Numerical Identification Files (NUMIDENT), 1936-2007\"",
+      "citation": "\"United States, Social Security Numerical Identification Files (NUMIDENT), 1936-2007\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:6K7Y-MX4V : Tue Jun 09 07:59:37 UTC 2026), Entry for Ivyl P Quass and Herbert T Greenley.",
+      "url": "https://familysearch.org/ark:/61903/1:1:6K7Y-MX4V"
+    },
+    {
+      "id": "WWG4-K8T",
+      "title": "Ingel Greenley, \"Iowa, County Births, 1880-1935\"",
+      "citation": "\"Iowa, County Births, 1880-1935\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:V464-9MW : Fri Jul 25 06:03:47 UTC 2025), Entry for Ingel Greenley and Hubert Greenley, 26 May 1914.",
+      "url": "https://familysearch.org/ark:/61903/1:1:V464-9MW"
+    },
+    {
+      "id": "9XZ1-BT5",
+      "title": "Ivyl Greenley, \"Iowa, State Census, 1915\"",
+      "citation": "\"Iowa, State Census, 1915\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:QK4T-SNZH : Sun Mar 10 16:22:43 UTC 2024), Entry for Ivyl Greenley, 1915.",
+      "url": "https://familysearch.org/ark:/61903/1:1:QK4T-SNZH"
+    },
+    {
+      "id": "9P9Q-9BF",
+      "title": "Ivyl Greenly in household of Robert Wilkinson, \"United States Census, 1920\"",
+      "citation": "\"United States, Census, 1920\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:M8BG-TGM : Tue Oct 21 19:49:25 UTC 2025), Entry for Robert Wilkinson and Phyellna Wilkinson, 1920.",
+      "url": "https://familysearch.org/ark:/61903/1:1:M8BG-TGQ"
+    },
+    {
+      "id": "39HN-W9G",
+      "title": "Ivyl Grunley, \"Iowa, State Census, 1915\"",
+      "citation": "\"Iowa, State Census, 1915\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:QK45-XJW8 : Sun Oct 12 08:54:09 UTC 2025), Entry for Ivyl Grunley, 1915.",
+      "url": "https://familysearch.org/ark:/61903/1:1:QK45-XJW8"
+    },
+    {
+      "id": "WWG4-2MT",
+      "title": "Ingel Greenley, \"Iowa, County Births, 1880-1935\"",
+      "citation": "\"Iowa, County Births, 1880-1935\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:V464-W1M : Fri Jul 25 06:51:50 UTC 2025), Entry for Ingel Greenley and Hubert Greenley, 26 May 1914.",
+      "url": "https://familysearch.org/ark:/61903/1:1:V464-W1M"
+    }
+  ]
+}


### PR DESCRIPTION
## What

A new e2e benchmark fixture: **`ivyl-greenley-daughter`**, authored from FamilySearch person `KWZP-4Q8` (Ivyl Phylena Greenley, deceased).

**Completeness / `children` objective:** *"Besides their son Donald, did Ivyl Phylena Greenley and her husband Kenneth Werner Quass have any other children? Identify each additional child and that child's birth and death dates."*

**Answer the agent must recover:** the daughter **Alice Jeannette "Jeannie" Quass** (b. 6 Dec 1940, d. 3 Feb 1955 at age 14, Madelia MN), recoverable from Minnesota vital records (birth index 1935–2002, death records and certificates 1900–1955, death index 1908–2002).

## What was stripped

- The daughter person `KNXW-Z21` (recorded in the tree under the nickname "Jeannie").
- Her two parent-child relationships (to Ivyl and to Kenneth).
- The four Minnesota vital-record sources that attested her.

The starting tree retains Ivyl, husband Kenneth, **son Donald**, and Ivyl's parents — so the couple is known to have *one* child and the agent must discover the *second*. Ivyl's lengthy `LifeSketch` was omitted from the starting tree to reduce token noise (it ends before the children are born and never names the daughter).

**Grader note:** Ivyl's *mother* is also an "Alice" (Alice Ann Wilkinson, b. 1880, d. 1919), retained in the tree and two generations removed from the stripped daughter. The expected finding is unambiguously the daughter born 1940 / died 1955.

## Validation

- `validate_research_schema` → **valid**.
- Stripping linter (`make e2e-validate TEST=ivyl-greenley-daughter`) → `OK — all findings appear stripped`.
- **Validity run included** (`eval/runlogs/e2e/ivyl-greenley-daughter/`): **verdict `pass`** — both required findings recovered. `session.jsonl` omitted per the existing e2e runlog convention (4 canonical files, matching `kenneth-quass-death` / `spriggs-parents-1898`).

## Notes for reviewers

This fixture is the test that surfaced the `/research` over-research behavior in **#500**: the agent recovered the answer in ~9 minutes but the run went ~43, draining the rest of the plan after the objective was met. The completeness framing is intentional and valuable — proving "no *other* children" legitimately requires the enumerating sources — and #500 fixes the orchestrator without weakening it. The validity run also hit a latent `image_read` 1 MB MCP-buffer crash on a large census image (`stop_reason: error`), which did not affect the `pass` verdict and is tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
