### PR TITLE
Prefer subscription over API key for the eval skill runner

### DIFF
--- a/eval/README.md
+++ b/eval/README.md
@@ -52,11 +52,11 @@ the e2e benchmark; see
   npm install -g @anthropic-ai/claude-code
   ```
   Then run `claude` once to authenticate (browser login or paste an API key). `Setup.bat` installs the CLI for you on Windows; macOS/Linux users do this step manually. If `claude --version` returns "not recognized," the harness will fail every test with a misleading "Claude Code returned an error result: success" error even though the SKILL.md, fixtures, and tests are fine.
-- **Anthropic API key** — required. The skill runner and the LLM judge both use it. `Setup.bat` will prompt for the key and save it to `eval/.env`; you can also put it there directly:
+- **Anthropic API key** — required for the LLM judge (the Anthropic SDK has no subscription path). `Setup.bat` will prompt for the key and save it to `eval/.env`; you can also put it there directly:
   ```
   ANTHROPIC_API_KEY=sk-ant-...
   ```
-  Or set it in your shell. Claude Code subscription auth (`~/.claude/`) is supported as a fallback only when no API key is configured. See `eval/harness/harness/auth.py` for resolution rules.
+  Or set it in your shell. The **skill runner** prefers your Claude Code subscription (`~/.claude/`) when one is available, billing it rather than the metered key, and only falls back to the API key when no subscription session is found. The judge always uses the key regardless. See `eval/harness/harness/auth.py` for resolution rules.
 
 ## Running manually (macOS / Linux)
 

--- a/eval/harness/e2e/orchestrator.py
+++ b/eval/harness/e2e/orchestrator.py
@@ -36,6 +36,8 @@ from claude_agent_sdk import (
     query,
 )
 
+from harness.auth import env_for_sdk, resolve_auth
+
 from e2e.result import E2eResult, timestamp_slug, write_result_files
 from e2e.stop_checker import (
     derive_stop_reason,
@@ -483,8 +485,15 @@ async def _run_agent(
         # re-discovery (17x in the spriggs run). Forcing tool search off loads
         # them once at session start. `env` MERGES onto the inherited environment
         # (claude_agent_sdk subprocess_cli merges os.environ, then options.env),
-        # so this adds the var without dropping ANTHROPIC_API_KEY/PATH.
-        env={"ENABLE_TOOL_SEARCH": "true"},
+        # so this adds the var without dropping PATH.
+        #
+        # env_for_sdk(resolve_auth()) routes the agent run to the operator's
+        # subscription when one is available (suppressing the ANTHROPIC_API_KEY
+        # that run_e2e.load_env_file pushed into os.environ for the judge), and
+        # falls back to injecting the key when there's no subscription. The
+        # judge keeps using the key from os.environ — only the agent subprocess
+        # env is overridden here.
+        env={"ENABLE_TOOL_SEARCH": "true", **env_for_sdk(resolve_auth())},
         model=fixture.agent_model,
         max_turns=fixture.caps.max_turns,
         hooks={

--- a/eval/harness/harness/auth.py
+++ b/eval/harness/harness/auth.py
@@ -1,15 +1,23 @@
 """Authentication for the harness.
 
 Resolution order:
-  1. Skill runner — prefer the API key. If ANTHROPIC_API_KEY is set
-     (in the shell or in eval/.env via Setup.bat), the skill runner
-     uses it. Subscription auth (~/.claude/) is only a fallback for
-     the case where no key is configured.
+  1. Skill runner — prefer the subscription. If a Claude Code
+     subscription session is available (~/.claude/ exists), the skill
+     runner uses it for both unit-test and e2e skill execution. The
+     API key (from the shell or eval/.env via Setup.bat) is only a
+     fallback for the case where no subscription is configured.
 
-     Policy: eval runs should bill the project's API key, not an
-     operator's personal Claude subscription. Setup.bat collects the
-     key and writes it to eval/.env; resolve_auth picks it up before
-     checking for any subscription session.
+     Policy: the skill runner — the expensive layer that drives the
+     full agent loop — should bill the operator's flat-rate Claude
+     subscription, not the project's metered API key. The judge stays
+     on the key (see below). resolve_auth still resolves the API key
+     even in subscription mode and carries it on AuthConfig so the
+     judge has it.
+
+     Note: an inherited ANTHROPIC_API_KEY in the SDK subprocess would
+     otherwise take precedence over the subscription session, so
+     env_for_sdk actively suppresses it in subscription mode (see
+     that function).
 
   2. Judge — always uses an ANTHROPIC_API_KEY. The Anthropic SDK (the
      judge talks to it directly, bypassing the Agent SDK) has no
@@ -50,41 +58,48 @@ class AuthError(Exception):
 def resolve_auth() -> AuthConfig:
     """Resolve auth for both the skill runner and the judge.
 
-    Skill runner: prefer the API key (from env or eval/.env). Fall back
-    to subscription (~/.claude/) only when no key is configured.
+    Skill runner: prefer the subscription (~/.claude/). Fall back to the
+    API key (from env or eval/.env) only when no subscription session is
+    configured. Either way the API key, if present, is carried on the
+    returned config for the judge.
     Judge: always uses the API key; errors at grade time if absent.
 
-    Raises AuthError only when neither a key nor a subscription is
+    Raises AuthError only when neither a subscription nor a key is
     available — in that case nothing can run.
     """
     api_key = _load_api_key()
     has_sub = _has_subscription()
+
+    if has_sub:
+        return AuthConfig(
+            skill_runner_mode="subscription",
+            # Kept for the judge even in subscription mode. None is allowed
+            # (run_tests warns up front that the judge will fail when reached).
+            api_key=api_key,
+            detail=(
+                f"skill runner: subscription auth from {SUBSCRIPTION_DIRS[0]}; "
+                + (
+                    f"judge: ANTHROPIC_API_KEY (length={len(api_key)})"
+                    if api_key
+                    else "judge: MISSING — judge will fail when reached"
+                )
+            ),
+        )
 
     if api_key:
         return AuthConfig(
             skill_runner_mode="api_key",
             api_key=api_key,
             detail=(
-                f"skill runner: ANTHROPIC_API_KEY (length={len(api_key)}); "
-                f"judge: same key"
-            ),
-        )
-
-    if has_sub:
-        return AuthConfig(
-            skill_runner_mode="subscription",
-            api_key=None,
-            detail=(
-                f"skill runner: subscription auth from {SUBSCRIPTION_DIRS[0]} "
-                "(fallback — no ANTHROPIC_API_KEY configured); "
-                "judge: MISSING — judge will fail when reached"
+                f"skill runner: ANTHROPIC_API_KEY (length={len(api_key)}) "
+                "(fallback — no subscription session found); judge: same key"
             ),
         )
 
     raise AuthError(
-        "No auth available. Set ANTHROPIC_API_KEY in your environment or "
-        f"in {ENV_FILE} (Setup.bat does this for you), or run `claude` "
-        "once to log into a subscription as a fallback."
+        "No auth available. Run `claude` once to log into a subscription, "
+        "or set ANTHROPIC_API_KEY in your environment or in "
+        f"{ENV_FILE} (Setup.bat does this for you)."
     )
 
 
@@ -109,11 +124,16 @@ def env_for_sdk(auth: AuthConfig) -> dict[str, str]:
     For api_key mode: explicitly inject the key (covers the case where it
     lives in eval/.env but isn't in the shell environment).
 
-    For subscription mode: inject nothing. The SDK subprocess will use the
-    CLI's session. See module docstring for the os.environ-inheritance
-    caveat — if the operator has ANTHROPIC_API_KEY in their shell, the
-    subprocess may still see and prefer it over the subscription session.
+    For subscription mode: force the subprocess onto the CLI's
+    subscription session by suppressing any inherited ANTHROPIC_API_KEY.
+    The SDK merges os.environ then options.env (see
+    claude_agent_sdk subprocess_cli), so we cannot *delete* an inherited
+    key — but the Claude Code CLI resolves the key with a truthiness
+    check, so an empty string reads as "unset" and the CLI falls back to
+    its OAuth session. Without this, a key in the operator's shell (or one
+    the e2e runner loaded into os.environ for the judge) would silently
+    win over the subscription.
     """
     if auth.skill_runner_mode == "api_key" and auth.api_key:
         return {"ANTHROPIC_API_KEY": auth.api_key}
-    return {}
+    return {"ANTHROPIC_API_KEY": ""}

--- a/eval/harness/tests/unit/test_auth.py
+++ b/eval/harness/tests/unit/test_auth.py
@@ -9,21 +9,25 @@ import pytest
 from harness import auth
 
 
-def test_api_key_preferred_when_both_available(monkeypatch, tmp_path):
-    """Policy: when both an API key and a subscription are available,
-    the API key wins. Eval runs should bill the project's key, not the
-    operator's personal Claude subscription."""
+def test_subscription_preferred_when_both_available(monkeypatch, tmp_path):
+    """Policy: when both a subscription and an API key are available, the
+    subscription wins for the skill runner — eval runs should bill the
+    operator's flat-rate subscription, not the project's metered key. The
+    key is still carried on the config so the judge can use it."""
     fake_home = tmp_path / "home" / ".claude"
     fake_home.mkdir(parents=True)
     monkeypatch.setattr(auth, "SUBSCRIPTION_DIRS", [fake_home])
     monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test-deadbeef")
     monkeypatch.setattr(auth, "ENV_FILE", tmp_path / "not-a-real-env-file")
     cfg = auth.resolve_auth()
-    assert cfg.skill_runner_mode == "api_key"
+    assert cfg.skill_runner_mode == "subscription"
+    # The judge still needs the key, so it rides along on the config.
     assert cfg.api_key == "sk-test-deadbeef"
 
 
-def test_subscription_only_when_no_key(monkeypatch, tmp_path):
+def test_subscription_with_no_key_leaves_judge_keyless(monkeypatch, tmp_path):
+    """Subscription present, no key: skill runner uses the subscription and
+    the judge has no key (run_tests warns; the judge errors when reached)."""
     fake_home = tmp_path / "home" / ".claude"
     fake_home.mkdir(parents=True)
     monkeypatch.setattr(auth, "SUBSCRIPTION_DIRS", [fake_home])
@@ -62,9 +66,13 @@ def test_raises_when_no_auth_available(monkeypatch, tmp_path):
         auth.resolve_auth()
 
 
-def test_env_for_sdk_returns_empty_in_subscription_mode():
+def test_env_for_sdk_suppresses_key_in_subscription_mode():
+    """Subscription mode forces the SDK subprocess onto the CLI session by
+    setting ANTHROPIC_API_KEY="" — an empty string reads as unset to the
+    Claude Code CLI's truthiness check, so it falls back to its OAuth
+    session even when a key was inherited from os.environ."""
     cfg = auth.AuthConfig(skill_runner_mode="subscription", api_key=None, detail="x")
-    assert auth.env_for_sdk(cfg) == {}
+    assert auth.env_for_sdk(cfg) == {"ANTHROPIC_API_KEY": ""}
 
 
 def test_env_for_sdk_returns_key_in_api_mode():
@@ -72,11 +80,11 @@ def test_env_for_sdk_returns_key_in_api_mode():
     assert auth.env_for_sdk(cfg) == {"ANTHROPIC_API_KEY": "sk-x"}
 
 
-def test_env_for_sdk_subscription_mode_omits_key_even_if_present():
-    """Subscription mode means the skill runner uses the CLI session; we
-    do NOT inject the API key into the SDK subprocess (the os.environ
-    inheritance caveat is documented in auth.py module docstring)."""
+def test_env_for_sdk_subscription_mode_suppresses_key_even_if_present():
+    """Even when a key is available (carried for the judge), subscription
+    mode must NOT let the skill-runner subprocess use it — it's overridden
+    to empty so the CLI session wins."""
     cfg = auth.AuthConfig(
         skill_runner_mode="subscription", api_key="sk-x", detail="x"
     )
-    assert auth.env_for_sdk(cfg) == {}
+    assert auth.env_for_sdk(cfg) == {"ANTHROPIC_API_KEY": ""}


### PR DESCRIPTION
## What

When **both** a Claude Code subscription (`~/.claude/`) and an `ANTHROPIC_API_KEY` are configured, the eval **skill runner** now bills the operator's flat-rate subscription instead of the project's metered API key — for **both unit-test and e2e** skill execution. The **judge layer is unchanged**: it always uses the API key (the Anthropic SDK has no subscription path).

This flips the previous "API key wins" preference and brings `auth.py` in line with the already-documented intent in `docs/eval-rollout.md:113` ("Subscription-preferred auth ✅ done"), which the code had never actually implemented.

## The subtle part (why flipping `resolve_auth` alone wasn't enough)

The Agent SDK subprocess inherits `os.environ`, and the Claude Code CLI **prefers an inherited `ANTHROPIC_API_KEY` over the subscription session**. So just changing the preference order would still run the agent on the API key whenever the key is in the environment.

Fix: in subscription mode, `env_for_sdk` now sets `ANTHROPIC_API_KEY=""`. The CLI resolves the key with a **truthiness check** (verified against the bundled CLI: `if(...&&t)` / `!process.env.ANTHROPIC_API_KEY`), so an empty string reads as "unset" and it falls back to the OAuth session. `options.env` can only override, not delete, an inherited var — so empty-string is exactly the right lever.

- `resolve_auth` still resolves the key in subscription mode and carries it on `AuthConfig` so the **judge** has it.
- e2e's `_run_agent` now reuses `env_for_sdk(resolve_auth())`, so the key that `run_e2e.load_env_file` pushes into `os.environ` for the judge no longer leaks into the agent subprocess.

## Changes

- `eval/harness/harness/auth.py` — prefer subscription; suppress inherited key in subscription mode; docstrings.
- `eval/harness/e2e/orchestrator.py` — agent subprocess env routed through `env_for_sdk(resolve_auth())`.
- `eval/harness/tests/unit/test_auth.py` — updated assertions for the new preference + empty-string suppression.
- `eval/README.md` — wording.

## One tradeoff to flag

Subscription detection remains the existing `~/.claude/`-exists heuristic. Now that subscription is *preferred*, a machine with that directory but no live login would fail even when a good API key is present. This matches the stated setup (a real, logged-in subscription) and avoids cross-platform credential probing (macOS Keychain vs. Windows). Easy to tighten later if it bites.

## Testing

- Full harness unit suite green: **640 passed** (`uv run pytest tests/unit`), including the rewritten `test_auth.py` and `test_cli.py`/`test_e2e_run_env.py`/`test_orchestrator.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)