### PR TITLE
fix(image_read): cap inline image size to prevent MCP transport crash

### DIFF
--- a/docs/specs/image-read-spec.md
+++ b/docs/specs/image-read-spec.md
@@ -55,11 +55,34 @@ The tool returns two content blocks:
 | Invalid imageId format | "Unrecognized imageId. Expected an Image Group Number of the form NUMBER_NUMBER (e.g. 004884748_02613)." |
 | FamilySearch returns non-2xx | "FamilySearch image fetch failed: {status} {statusText}" |
 | Response is not an image | "Expected an image response but got content-type: {type}" |
+| Image exceeds the inline size cap | "FamilySearch image {imageId} is {N} MB — too large to return inline. The MCP transport caps a single response near 1 MB and base64 encoding inflates the image by ~33%, so returning it would crash the session. Read the indexed record for this image with record_read / record_search instead of fetching the page scan, or choose a more specific image." |
 
 ## Auth
 
 Uses `getValidToken()` from `src/auth/refresh.ts`. Passes the token as
 `Authorization: Bearer {token}`. Do not re-implement token logic.
+
+## Size cap
+
+The MCP stdio transport decodes one JSON message at a time behind a hard
+~1 MiB (1,048,576-byte) buffer. Base64 encoding inflates the image ~33%, so
+a raw `dist.jpg` much above ~780 KB yields a response message that overflows
+that buffer and crashes the **entire session** — an uncatchable transport
+error, not a per-tool failure. (This was observed killing an e2e run when the
+agent browsed a 1950 census page scan.)
+
+The tool therefore refuses any image whose raw bytes exceed
+`MAX_INLINE_IMAGE_BYTES` (**700 KB** → ~933 KB of base64, under the cap with
+envelope headroom), throwing the "too large to return inline" error above
+instead of returning the bytes. The check runs **before** base64-encoding, so
+an oversized image is never materialized.
+
+This is a refuse-not-degrade guard: a large scan becomes unreadable via this
+tool rather than crashing the run. Making large scans readable would mean
+downscaling/re-encoding to fit, which needs an image-processing dependency
+(e.g. `sharp`/`jimp`) bundled into the cross-platform `.mcpb`. That is a
+deliberate packaging decision deferred until reading large images is actually
+required.
 
 ## What NOT to return
 

--- a/packages/engine/mcp-server/src/tools/image-read.ts
+++ b/packages/engine/mcp-server/src/tools/image-read.ts
@@ -6,6 +6,19 @@ import { BROWSER_USER_AGENT } from "../constants.js";
 // e.g. "004884748_02613").
 const IMAGE_ID_PATTERN = /^\d+_\d+$/;
 
+// Ceiling on the raw image bytes we will base64-encode and return inline.
+// The MCP stdio transport decodes one JSON message at a time with a hard
+// ~1 MiB (1,048,576-byte) buffer; base64 inflates the payload ~33%, so a
+// raw image much above ~780 KB produces a response message that overflows
+// the buffer and crashes the *entire session* — an uncatchable transport
+// error, not a per-tool failure (observed killing an e2e run on a 1950
+// census page scan). 700 KB raw → ~933 KB of base64, comfortably under the
+// cap with headroom for the JSON-RPC envelope. Above this we throw an
+// actionable error instead of returning the bytes. (Downscaling to fit so
+// large scans stay readable would require an image-processing dependency in
+// the shipped .mcpb — deferred; see docs/specs/image-read-spec.md.)
+const MAX_INLINE_IMAGE_BYTES = 700_000;
+
 export interface ImageReadInput {
   imageId: string;
 }
@@ -56,6 +69,20 @@ export async function imageReadTool(input: ImageReadInput): Promise<{
   }
 
   const buffer = await response.arrayBuffer();
+
+  // Refuse oversized images before encoding — returning them would overflow
+  // the MCP transport buffer and crash the session (see MAX_INLINE_IMAGE_BYTES).
+  if (buffer.byteLength > MAX_INLINE_IMAGE_BYTES) {
+    const mb = (buffer.byteLength / 1_000_000).toFixed(1);
+    throw new Error(
+      `FamilySearch image ${input.imageId} is ${mb} MB — too large to return inline. ` +
+        `The MCP transport caps a single response near 1 MB and base64 encoding inflates ` +
+        `the image by ~33%, so returning it would crash the session. Read the indexed ` +
+        `record for this image with record_read / record_search instead of fetching the ` +
+        `page scan, or choose a more specific image.`
+    );
+  }
+
   const bytes = new Uint8Array(buffer);
 
   // Convert binary buffer to base64

--- a/packages/engine/mcp-server/tests/tools/image-read.test.ts
+++ b/packages/engine/mcp-server/tests/tools/image-read.test.ts
@@ -12,8 +12,8 @@ const mockedGetValidToken = vi.mocked(getValidToken);
 const mockFetch = vi.fn();
 vi.stubGlobal("fetch", mockFetch);
 
-function mockImageResponse() {
-  const pixel = new Uint8Array([0xff, 0xd8, 0xff, 0xd9]);
+function mockImageResponse(bytes?: Uint8Array) {
+  const pixel = bytes ?? new Uint8Array([0xff, 0xd8, 0xff, 0xd9]);
   mockFetch.mockResolvedValueOnce({
     ok: true,
     status: 200,
@@ -61,6 +61,25 @@ describe("imageReadTool — imageId input", () => {
     const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
     const headers = init.headers as Record<string, string>;
     expect(headers["User-Agent"]).toBe(BROWSER_USER_AGENT);
+  });
+
+  it("rejects an image that exceeds the inline size cap", async () => {
+    // 700 KB is the cap; 800 KB would base64-inflate past the ~1 MiB MCP
+    // transport buffer and crash the session, so the tool must refuse it.
+    mockImageResponse(new Uint8Array(800_000));
+
+    await expect(imageReadTool({ imageId: "004884748_02613" })).rejects.toThrow(
+      /too large to return inline/i
+    );
+  });
+
+  it("returns an image sitting just under the size cap", async () => {
+    mockImageResponse(new Uint8Array(699_999));
+
+    const result = await imageReadTool({ imageId: "004884748_02613" });
+
+    expect(result.metadata.sizeBytes).toBe(699_999);
+    expect(result.imageData.length).toBeGreaterThan(0);
   });
 
   it.each([


### PR DESCRIPTION
## The bug

`image_read` fetched the FamilySearch `dist.jpg` and base64-encoded it inline with **no size bound**. A high-resolution page scan base64-inflates well past the MCP stdio transport's hard **~1 MiB (1,048,576-byte) single-message buffer**, which throws

```
Failed to decode JSON: JSON message exceeded maximum buffer size of 1048576 bytes
```

That error is at the **transport layer**, before any per-tool error handling — it crashes the **entire session** (`stop_reason: error`), not just the one call.

**Evidence:** in the `ivyl-greenley-daughter` e2e run, the last two tool calls were `image_read` of 1950-census page scans (`108956928_00005`, `_00010`), both with `resp: None`, immediately followed by the 1 MiB decode error. (The `record_search` that returned 283 KB earlier in the same run hit Claude Code's *soft* per-result token limit and was saved to a file — that one survived. The crash was `image_read`.)

## The fix

Refuse any image whose raw bytes exceed `MAX_INLINE_IMAGE_BYTES` (**700 KB** → ~933 KB of base64, comfortably under the 1 MiB cap with headroom for the JSON-RPC envelope), throwing an actionable error **before** base64-encoding so the oversized buffer is never even materialized:

> FamilySearch image {id} is {N} MB — too large to return inline. … Read the indexed record for this image with record_read / record_search instead of fetching the page scan, or choose a more specific image.

This converts a session-killing transport crash into a recoverable per-tool error: the agent gets a clear message and can move on, instead of the run dying.

## Refuse, not degrade — and why

This guard makes a too-large scan **unreadable** via the tool rather than crashing the run. Keeping large scans *readable* would mean downscaling / re-encoding to fit, which requires an image-processing dependency (`sharp` native, or `jimp` pure-JS) bundled into the cross-platform `.mcpb` shipped to the Windows genealogist team — a deliberate packaging decision. Deferred until reading large images is actually needed; called out in the spec.

## Threshold math

MCP single-message cap = 1,048,576 bytes. base64 length ≈ raw × 4/3. At 700 KB raw → ~933 KB base64 + a few hundred bytes of content-block/JSON-RPC envelope ≈ 934 KB — ~110 KB under the cap. Images up to ~780 KB raw are technically safe; 700 KB leaves a real margin while still admitting the bulk of distribution JPEGs.

## Tests & scope

- `image-read.test.ts`: rejects an 800 KB image with `/too large to return inline/i`; a 699,999-byte image still returns normally.
- `tsc` build clean; **full mcp-server suite green (57 files, 1198 tests)**.
- MCP source isn't in the eval snapshot, so `check-runlogs` is not triggered — this is covered by Vitest, not the eval gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
