### PR TITLE
Add make e2e-project: seed an editable Cowork project to debug /research live

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,10 @@ eval/runlogs/e2e/*/scratch_*
 # research.json + tree.gedcomx.json for the Research Viewer to open. Throwaway.
 eval/.e2e-view/
 
+# `make e2e-project` seeds editable Cowork projects from fixtures' starting
+# state here — debugging workspaces, not committed artifacts.
+eval/.e2e-project/
+
 # Raw SDK session transcripts copied next to each e2e runlog. Multi-MB forensic
 # data (per-turn timestamps/tokens/thinking) for local latency+cost analysis —
 # not a fixture validity artifact, so kept out of git to avoid repo bloat.

--- a/Makefile
+++ b/Makefile
@@ -296,6 +296,18 @@ e2e-view: ## Load the latest e2e run into the Research Viewer (eval/.e2e-view): 
 	@test -n "$(TEST)" || { echo "ERROR: set TEST, e.g. make e2e-view TEST=kenneth-quass-death" >&2; exit 1; }
 	cd eval/harness && uv run python -m e2e.view --test $(TEST)
 
+.PHONY: e2e-project
+e2e-project: ## Seed an editable Cowork project from a fixture's STARTING state to debug /research live: make e2e-project TEST=kenneth-quass-death
+	# Copies the fixture's starting-research.json + starting-tree.gedcomx.json
+	# into eval/.e2e-project/<slug>/ as research.json + tree.gedcomx.json — a
+	# fresh, editable project you open in Claude Cowork to run /research
+	# step-by-step (init-project auto-skipped) while watching it live in the
+	# Research Viewer. For DEBUGGING the process, NOT scoring: a live run does
+	# not block the tree-read tools the headless `make e2e-run` blocks, so the
+	# agent can read the answer off the live tree. Re-seed (wiping work) with FORCE=1.
+	@test -n "$(TEST)" || { echo "ERROR: set TEST, e.g. make e2e-project TEST=kenneth-quass-death" >&2; exit 1; }
+	cd eval/harness && uv run python -m e2e.project --test $(TEST) $(if $(FORCE),--force,)
+
 .PHONY: e2e-validate
 e2e-validate: ## Stripping linter for an e2e fixture (or all): make e2e-validate TEST=kenneth-quass-death  (omit TEST for --all)
 	cd eval/harness && uv run python -m e2e.validate_fixture $${TEST:---all}

--- a/docs/e2e-testing-guide.md
+++ b/docs/e2e-testing-guide.md
@@ -535,7 +535,17 @@ The full help text:
 uv run python -m e2e.run_e2e --help
 ```
 
-### Debugging `/research` by hand (scratch workspace)
+### Debugging `/research` by hand (scratch workspace — the Claude Code path)
+
+> **Prefer Cowork + the viewer for live debugging.** The recommended way to
+> watch a run unfold with structured output — research log, assertions,
+> conflicts — is `make e2e-project TEST=<slug>` (Windows: `SeedProject.bat`),
+> which seeds an editable project you open in **Claude Cowork** alongside the
+> **Research Viewer**. See eval/README.md → "Debug a fixture interactively
+> (Cowork + the viewer)". The scratch workspace below is the lighter-weight
+> **Claude Code** alternative — no Cowork needed, handy for developers
+> debugging `/research` routing (and the first-time `/research` validation in
+> the setup checklist above).
 
 A headless harness run can't show you *why* the agent stopped or skipped
 a step — you can't watch it think or nudge it. For that, run `/research`

--- a/eval/README.md
+++ b/eval/README.md
@@ -35,6 +35,7 @@ eval/
   ViewE2E.bat             Windows: load the latest e2e run into the Research Viewer
   ValidateFixture.bat     Windows: e2e stripping linter
   ScratchResearch.bat     Windows: set up a throwaway dir to debug /research by hand
+  SeedProject.bat         Windows: seed an editable Cowork project from a fixture (debug /research live)
   RunCalibration.bat      Windows: run judge calibration (maintainer only)
 ```
 
@@ -314,6 +315,31 @@ equivalent in parentheses:
    direct/indirect badge. Keep the viewer open — re-running refreshes it live.
 10. If it passes, commit the fixture (and optionally its run log), and
    open a PR.
+
+### Debug a fixture interactively (Cowork + the viewer)
+
+Before — or instead of — a headless `RunE2E.bat`, run the fixture **live in
+Claude Cowork** and watch it unfold. This is the recommended starting point
+for debugging *why* the agent did or didn't do something, and it keeps the
+test-improve loop fast: you watch the fix work in minutes instead of waiting
+20–60 min for a headless verdict.
+
+1. `eval\SeedProject.bat` → enter the slug (`make e2e-project TEST=<slug>`).
+   Copies the fixture's starting state into `eval\.e2e-project\<slug>\` as a
+   fresh, editable `research.json` + `tree.gedcomx.json`.
+2. Open that folder in **Claude Cowork** (genealogy plugin installed, logged
+   in to FamilySearch) and run `/research`. `init-project` is auto-skipped
+   (research.json already exists); question-selection still runs unless the
+   fixture seeds a question.
+3. Open the **same folder** in the Research Viewer to watch the research log,
+   assertions, and conflicts appear live — and ask Claude *"why didn't you
+   search X?"*, *"why direct, not indirect?"* as it works.
+
+**For understanding, not scoring.** A live run does **not** block the tree-read
+tools (`person_read` / `person_search` / `person_ancestors`) that the headless
+`make e2e-run` blocks — so confirm the agent found the answer by *searching
+records*, not by reading the live tree. The honest pass/fail is always the
+headless run. Re-seed a fresh project (wiping any work) with `FORCE=1`.
 
 ### Keep the machine awake during a run
 

--- a/eval/SeedProject.bat
+++ b/eval/SeedProject.bat
@@ -1,0 +1,28 @@
+@echo off
+cd %~dp0
+
+echo === Cowork Genealogy E2E — Seed an editable project to debug /research live ===
+echo.
+echo Copies a fixture's STARTING state into eval\.e2e-project\<slug>\ as a fresh,
+echo editable project. Open it in Claude Cowork to run /research step-by-step, and
+echo open the same folder in the Research Viewer to watch it live.
+echo.
+echo For DEBUGGING the process, not scoring: a live run does NOT block the
+echo tree-read tools, so use RunE2E.bat for the honest pass/fail.
+echo.
+set /p SLUG="Which fixture (slug) do you want to debug? (e.g. kenneth-quass-death): "
+
+if "%SLUG%"=="" (
+  echo.
+  echo No fixture entered. Aborting.
+  pause
+  exit /b 1
+)
+
+cd harness
+call uv run python -m e2e.project --test %SLUG%
+
+echo.
+echo (Already seeded and want to start over? Re-run and it will tell you how to
+echo re-seed from scratch.)
+pause

--- a/eval/harness/e2e/project.py
+++ b/eval/harness/e2e/project.py
@@ -1,0 +1,108 @@
+"""Seed an editable Cowork project from a fixture's STARTING state.
+
+`make e2e-project TEST=<slug>` (Windows: `SeedProject.bat`) copies a fixture's
+`starting-research.json` + `starting-tree.gedcomx.json` into a fresh, editable
+project folder — `eval/.e2e-project/<slug>/` — as `research.json` +
+`tree.gedcomx.json`. Open that folder in Claude Cowork to run `/research`
+step-by-step (init-project is auto-skipped because research.json already
+exists), and open the SAME folder in the Research Viewer to watch the run
+unfold live.
+
+This is for *understanding and debugging* the research process — NOT for
+scoring. An interactive run does NOT block the tree-read tools
+(`person_read` / `person_search` / `person_ancestors`) that the headless
+`make e2e-run` blocks, so the agent can read the stripped answer off the live
+FamilySearch tree. When watching live, check it found the answer by *searching
+records*, not by reading the tree. The honest pass/fail is always
+`make e2e-run`.
+
+Refuses to overwrite an already-seeded project (so a re-seed can't silently
+wipe a debugging session); pass --force / FORCE=1 to start fresh.
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import sys
+from pathlib import Path
+
+from .orchestrator import DEFAULT_FIXTURES_ROOT, REPO_ROOT
+
+PROJECT_ROOT = REPO_ROOT / "eval" / ".e2e-project"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="e2e.project",
+        description="Seed an editable Cowork project from a fixture's starting state.",
+    )
+    parser.add_argument(
+        "--test", required=True, help="Fixture slug, e.g. kenneth-quass-death"
+    )
+    parser.add_argument("--fixtures-root", type=Path, default=DEFAULT_FIXTURES_ROOT)
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Re-seed even if the project folder already exists (wipes its research.json).",
+    )
+    args = parser.parse_args(argv)
+
+    fixture_dir = args.fixtures_root / args.test
+    starting_research = fixture_dir / "starting-research.json"
+    starting_tree = fixture_dir / "starting-tree.gedcomx.json"
+    if not starting_research.exists() or not starting_tree.exists():
+        print(
+            f"Fixture '{args.test}' is missing its starting state (expected "
+            f"{starting_research.name} + {starting_tree.name} in {fixture_dir}).",
+            file=sys.stderr,
+        )
+        return 1
+
+    out_dir = PROJECT_ROOT / args.test
+    dest_research = out_dir / "research.json"
+    if dest_research.exists() and not args.force:
+        print(
+            f"A project is already seeded at {out_dir}.\n"
+            f"Re-seeding would wipe any work there. Delete it, or re-run with "
+            f"FORCE=1 (make e2e-project TEST={args.test} FORCE=1) to start fresh.",
+            file=sys.stderr,
+        )
+        return 1
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    shutil.copyfile(starting_research, dest_research)
+    shutil.copyfile(starting_tree, out_dir / "tree.gedcomx.json")
+
+    print(f"Seeded an editable project at {out_dir}")
+    print()
+    print("Next:")
+    print(
+        f"  1. Open {out_dir} in Claude Cowork (genealogy plugin installed, "
+        f"logged in to FamilySearch)."
+    )
+    print(
+        "  2. Run  /research  — it reads the objective from research.json. "
+        "init-project is auto-skipped;"
+    )
+    print(
+        "     question-selection still runs unless the fixture seeds a question."
+    )
+    print(
+        "  3. Open the SAME folder in the Research Viewer to watch it live, and "
+        "ask Claude why it did/didn't do a step."
+    )
+    print()
+    print(
+        "For DEBUGGING, not scoring: a live run does NOT block the tree-read tools, "
+        "so confirm it"
+    )
+    print(
+        "found the answer by searching records (not by reading the tree). "
+        "Score with `make e2e-run`."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/eval/slides/e2e-testing-kickoff.html
+++ b/eval/slides/e2e-testing-kickoff.html
@@ -238,26 +238,29 @@ echo 'ANTHROPIC_API_KEY=sk-...' &gt;&gt; eval/.env</code></pre></div>
   <p class="sub">Rebuilds the server first if needed. Remember — one run at a time.</p>
 </section>
 
-<!-- 8 DIAGNOSE -->
+<!-- 8 LIVE -->
 <section class="slide">
-  <h2>See what the AI did</h2>
-  <p>Start with <code>/interpret-e2e-result</code> for the headline verdict. Then read the <strong>step-by-step</strong> — every search, result, and skill it used is in <code>run-&lt;ts&gt;.transcript.md</code>.</p>
-  <div class="card">
-    <h3>Ask Claude about the run</h3>
-    <p>"Did it <strong>skip a search</strong> it should have run? Try <strong>maiden-name or spelling variations</strong>? Call a finding <strong>direct</strong> when the evidence is only indirect? <strong>Where and why did it stop?</strong>"</p>
+  <h2>Watch it work live — start here when debugging</h2>
+  <div class="cmds">
+    <div><span class="os win">Windows</span><pre><code>SeedProject.bat</code></pre></div>
+    <div><span class="os nix">macOS / Linux</span><pre><code>make e2e-project TEST=&lt;slug&gt;</code></pre></div>
   </div>
-  <p class="sub">This is where you catch the missed search or the over-claim — the verdict alone won't show it.</p>
+  <ul>
+    <li>Seeds an editable project from the fixture's <strong>starting state</strong>. Open it in <strong>Claude Cowork</strong>, run <code>/research</code> — <strong>init-project is auto-skipped</strong>.</li>
+    <li>Open the same folder in the <strong>Research Viewer</strong>: watch the log, assertions, and conflicts appear <strong>live</strong>, and ask Claude <em>"why didn't you search X? why direct, not indirect?"</em> as it goes.</li>
+  </ul>
+  <div class="card sub"><strong>To understand, not to score.</strong> Live runs don't block the tree-read tools — so check it found the answer <em>by searching records</em>, not by reading the tree. The honest pass/fail is always <code>make e2e-run</code>.</div>
 </section>
 
-<!-- 9 VIEW -->
+<!-- 9 DIAGNOSE -->
 <section class="slide">
-  <h2>View the result in the app</h2>
-  <div class="cmds">
-    <div><span class="os win">Windows</span><pre><code>ViewE2E.bat</code></pre></div>
-    <div><span class="os nix">macOS / Linux</span><pre><code>make e2e-view TEST=&lt;slug&gt;</code></pre></div>
+  <h2>Dig into a finished (headless) run</h2>
+  <p>After a scored <code>make e2e-run</code>: start with <code>/interpret-e2e-result</code> for the verdict, then read the <strong>step-by-step</strong> in <code>run-&lt;ts&gt;.transcript.md</code>.</p>
+  <div class="card">
+    <h3>Ask Claude about the run</h3>
+    <p>"Did it <strong>skip a search</strong> it should have run? Try <strong>maiden-name or spelling variations</strong>? Call a finding <strong>direct</strong> when it's only indirect? Where did it stop?"</p>
   </div>
-  <p>Loads the latest run into the <strong>Research Viewer</strong> — the final tree, the research log, conflicts, and each finding's <strong>direct vs indirect</strong> badge.</p>
-  <div class="card sub">Open <code>eval/.e2e-view</code> in the viewer once (its <strong>Open Project</strong> button) and <strong>keep it open</strong> — every re-run, just run <code>e2e-view</code> again and it refreshes live.</div>
+  <p class="sub">Prefer the viewer? <code>ViewE2E.bat</code> / <code>make e2e-view TEST=&lt;slug&gt;</code> loads that run's final tree + research into the Research Viewer.</p>
 </section>
 
 <!-- 10 GRADE -->

--- a/eval/slides/e2e-testing-kickoff.html
+++ b/eval/slides/e2e-testing-kickoff.html
@@ -161,18 +161,16 @@
 
 <!-- 3 THE LOOP -->
 <section class="slide">
-  <h2>The work is a loop</h2>
+  <h2>Two speeds: a fast loop, one slow score</h2>
   <div class="flow">
     <span class="step">Create</span><span class="arr">→</span>
-    <span class="step hot">Run</span><span class="arr">→</span>
-    <span class="step hot">Interpret</span><span class="arr">→</span>
-    <span class="step hot">Grade</span><span class="arr">→</span>
-    <span class="step hot">Improve skill</span><span class="arr">→</span>
-    <span class="step hot">Re-run</span><span class="arr">↺</span>
+    <span class="step hot">Debug live in Cowork</span><span class="arr">⟳</span>
+    <span class="step hot">tweak the skill</span><span class="arr">→</span>
+    <span class="step">Headless run + grade</span><span class="arr">→</span>
     <span class="step">PR</span>
   </div>
-  <p>Run it, see how the skill did, <strong>improve the skill</strong>, and re-run — until you <strong>can't improve the result anymore</strong>. Then submit a PR.</p>
-  <div class="card sub"><strong>One run ≈ 20–60 minutes and $3–10.</strong> Run one at a time, and plan your day around a handful — not dozens.</div>
+  <p><strong>Iterate fast, live:</strong> watch <code>/research</code> in Cowork, tweak the skill, run again — <strong>minutes</strong> per loop, no waiting for a verdict.</p>
+  <div class="card sub"><strong>Score once, at the end.</strong> When it works live, do <em>one</em> headless run — the honest, tree-read-blocked check — then grade that run. A 20–60 min / $3–10 run belongs at the end, not after every tweak.</div>
 </section>
 
 <!-- 4 HOW WE WORK -->
@@ -226,66 +224,54 @@ echo 'ANTHROPIC_API_KEY=sk-...' &gt;&gt; eval/.env</code></pre></div>
   <p class="sub">Either way, keep it focused (one question, 1–5 findings), then confirm the answer is really gone: <code>ValidateFixture.bat</code> / <code>make e2e-validate TEST=&lt;slug&gt;</code>.</p>
 </section>
 
-<!-- 7 RUN -->
+<!-- 7 DEBUG LIVE -->
 <section class="slide">
-  <h2>Run a test</h2>
-  <div class="cmds">
-    <div><span class="os win">Windows</span><pre><code>RunE2E.bat
-# prompts for the slug</code></pre></div>
-    <div><span class="os nix">macOS / Linux</span><pre><code>make e2e-run TEST=kenneth-quass-death</code></pre></div>
-  </div>
-  <p>Writes the result, a readable transcript, and the AI's final tree to <code>eval/runlogs/e2e/&lt;slug&gt;/</code>.</p>
-  <p class="sub">Rebuilds the server first if needed. Remember — one run at a time.</p>
-</section>
-
-<!-- 8 LIVE -->
-<section class="slide">
-  <h2>Watch it work live — start here when debugging</h2>
+  <h2>Debug live in Cowork — start here</h2>
   <div class="cmds">
     <div><span class="os win">Windows</span><pre><code>SeedProject.bat</code></pre></div>
     <div><span class="os nix">macOS / Linux</span><pre><code>make e2e-project TEST=&lt;slug&gt;</code></pre></div>
   </div>
   <ul>
     <li>Seeds an editable project from the fixture's <strong>starting state</strong>. Open it in <strong>Claude Cowork</strong>, run <code>/research</code> — <strong>init-project is auto-skipped</strong>.</li>
-    <li>Open the same folder in the <strong>Research Viewer</strong>: watch the log, assertions, and conflicts appear <strong>live</strong>, and ask Claude <em>"why didn't you search X? why direct, not indirect?"</em> as it goes.</li>
+    <li>Open the same folder in the <strong>Research Viewer</strong>: watch the log, assertions, and conflicts appear <strong>live</strong>, and ask Claude <em>"why didn't you search X? why direct, not indirect?"</em></li>
   </ul>
-  <div class="card sub"><strong>To understand, not to score.</strong> Live runs don't block the tree-read tools — so check it found the answer <em>by searching records</em>, not by reading the tree. The honest pass/fail is always <code>make e2e-run</code>.</div>
+  <div class="card sub"><strong>Watch HOW it gets each answer</strong> — by searching records, not by reading the tree. Live runs don't block tree-reads, so a "find" via the tree won't hold up when you score.</div>
 </section>
 
-<!-- 9 DIAGNOSE -->
+<!-- 8 TWEAK LIVE -->
 <section class="slide">
-  <h2>Dig into a finished (headless) run</h2>
-  <p>After a scored <code>make e2e-run</code>: start with <code>/interpret-e2e-result</code> for the verdict, then read the <strong>step-by-step</strong> in <code>run-&lt;ts&gt;.transcript.md</code>.</p>
-  <div class="card">
-    <h3>Ask Claude about the run</h3>
-    <p>"Did it <strong>skip a search</strong> it should have run? Try <strong>maiden-name or spelling variations</strong>? Call a finding <strong>direct</strong> when it's only indirect? Where did it stop?"</p>
+  <h2>Tweak the skill, re-run live — repeat</h2>
+  <p class="sub">A "skill" is a page of <strong>plain-English instructions</strong> telling the AI how to research (a <code>SKILL.md</code> file).</p>
+  <ul>
+    <li><strong>Diagnose</strong> what went wrong, <strong>reword the skill's instructions</strong>, and run <code>/research</code> again in Cowork.</li>
+    <li>Edits are picked up on the next run — <strong>watch the fix work in minutes</strong>, no waiting for a verdict.</li>
+    <li><strong>Loop</strong> until it researches well <em>and gets there by searching records.</em></li>
+  </ul>
+  <div class="card sub">This is the <strong>fast inner loop</strong> — stay here, iterating live, until you're confident. No headless runs yet.</div>
+</section>
+
+<!-- 9 SCORE -->
+<section class="slide">
+  <h2>Score it — once, at the end</h2>
+  <div class="cmds">
+    <div><span class="os win">Windows</span><pre><code>RunE2E.bat</code></pre></div>
+    <div><span class="os nix">macOS / Linux</span><pre><code>make e2e-run TEST=&lt;slug&gt;</code></pre></div>
   </div>
-  <p class="sub">Prefer the viewer? <code>ViewE2E.bat</code> / <code>make e2e-view TEST=&lt;slug&gt;</code> loads that run's final tree + research into the Research Viewer.</p>
+  <p>When it works live, do <strong>one</strong> headless run — the honest check that <strong>blocks the tree-read tools</strong>. It writes the result + transcript + final tree to <code>eval/runlogs/e2e/&lt;slug&gt;/</code>; then <code>/interpret-e2e-result</code> for the verdict.</p>
+  <div class="card sub"><strong>If it fails</strong>, the live fix didn't hold — read <code>run-&lt;ts&gt;.transcript.md</code> (or <code>make e2e-view</code>) to see what the blocked run did, then back to live debugging. One run is noisy — re-run a borderline result before trusting it.</div>
 </section>
 
 <!-- 10 GRADE -->
 <section class="slide">
-  <h2>Grade the result</h2>
+  <h2>Grade the run</h2>
   <ul>
-    <li>For each expected finding, decide whether the AI really found it: <strong>true / partial / false</strong>.</li>
-    <li><strong>Ask Claude Code to grade the run</strong> — it records your labels in <code>run-&lt;ts&gt;.ann.json</code>, saved beside the run log.</li>
+    <li>For the run you'll commit, decide for each finding: <strong>true / partial / false</strong>.</li>
+    <li><strong>Ask Claude Code to grade the run</strong> — it records your labels in <code>run-&lt;ts&gt;.ann.json</code>, beside the run log.</li>
   </ul>
-  <div class="card">Grading is <strong>squarely genealogy judgment</strong> — and that <code>.ann.json</code> is the grade you commit. Where you disagree with the AI judge, your label is what counts.</div>
+  <div class="card">Grading is <strong>squarely genealogy judgment</strong> — and that <code>.ann.json</code> is the grade you commit. Do it <strong>once, on the passing run</strong>, not every iteration.</div>
 </section>
 
-<!-- 11 IMPROVE -->
-<section class="slide">
-  <h2>Improve the skill → re-run → compare</h2>
-  <p class="sub">A "skill" is a page of <strong>plain-English instructions</strong> telling the AI how to research (a <code>SKILL.md</code> file).</p>
-  <ul>
-    <li><strong>Diagnose</strong> — what did the AI get wrong, and what <em>should</em> good research have done?</li>
-    <li><strong>Adjust</strong> the skill's instructions, then <strong>re-run</strong> (picked up automatically).</li>
-    <li>Did it improve? <strong>Repeat until you can't improve it anymore.</strong></li>
-  </ul>
-  <div class="card sub"><strong>Re-run before concluding</strong> — the AI isn't perfectly repeatable; one finding flipping may be chance.</div>
-</section>
-
-<!-- 12 PR -->
+<!-- 11 PR -->
 <section class="slide">
   <h2>Submit a PR</h2>
   <p>Commit together:</p>
@@ -296,7 +282,7 @@ echo 'ANTHROPIC_API_KEY=sk-...' &gt;&gt; eval/.env</code></pre></div>
   <div class="card sub">The maintainers review and merge. You create and push; you don't merge your own.</div>
 </section>
 
-<!-- 13 QUESTIONS -->
+<!-- 12 QUESTIONS -->
 <section class="slide lead center">
   <h1>Questions?</h1>
   <p class="big sub">Then hands-on — we author, run, and interpret <strong>Kenneth Quass</strong> together.</p>

--- a/eval/slides/e2e-testing-kickoff.html
+++ b/eval/slides/e2e-testing-kickoff.html
@@ -220,7 +220,7 @@ echo 'ANTHROPIC_API_KEY=sk-...' &gt;&gt; eval/.env</code></pre></div>
     </div>
     <div class="card">
       <h3>From a research document</h3>
-      <p>No FamilySearch access? Hand it a report, research log, or proof article — it <strong>builds the starting tree by hand</strong> from the document and uses the document's conclusion as the answer.</p>
+      <p>Alternatively, hand it a report, research log, or proof article — it <strong>builds the starting tree by hand</strong> from the document and uses the document's conclusion as the answer.</p>
     </div>
   </div>
   <p class="sub">Either way, keep it focused (one question, 1–5 findings), then confirm the answer is really gone: <code>ValidateFixture.bat</code> / <code>make e2e-validate TEST=&lt;slug&gt;</code>.</p>


### PR DESCRIPTION
## Summary

Adds `make e2e-project` / `SeedProject.bat` — seeds an editable Cowork project from a fixture's *starting* state, so teams can run `/research` step-by-step in Cowork and watch it unfold live in the Research Viewer. This is the recommended starting point for **debugging** the research process (watch the fix work in minutes instead of waiting 20–60 min for a headless verdict). The headless `make e2e-run` stays the scored pass/fail.

Follow-up to #501 (the e2e testing kickoff deck + `make e2e-view`).

## What's included

- **`make e2e-project TEST=<slug>` / `eval/SeedProject.bat`** (`eval/harness/e2e/project.py`) — copies a fixture's `starting-research.json` + `starting-tree.gedcomx.json` into `eval/.e2e-project/<slug>/` as `research.json` + `tree.gedcomx.json`. Open it in Claude Cowork to run `/research` (init-project auto-skips because `research.json` already exists) and open the same folder in the Research Viewer to watch live. Refuses to overwrite an already-seeded project unless `FORCE=1`.
- **Deck** (`eval/slides/e2e-testing-kickoff.html`) — adds a "watch it work live" slide as the recommended debugging start, and merges the transcript + `e2e-view` slides into one "dig into a finished run" slide (stays at 13 slides).
- **`eval/README.md`** — `SeedProject.bat` in the batch-file list + a new "Debug a fixture interactively (Cowork + the viewer)" section.
- **`.gitignore`** — ignores the `eval/.e2e-project/` staging folder.

## Important caveat (documented in the tool, deck, and README)

An interactive run does **not** block the tree-read tools (`person_read` / `person_search` / `person_ancestors`) that the headless `make e2e-run` blocks — so the agent could read the stripped answer off the live tree. This is for **understanding the process, not scoring**: when watching live, confirm it found the answer by *searching records*. The honest pass/fail stays `make e2e-run`.

## Test plan

- `make e2e-project TEST=kenneth-quass-death` → seeds `eval/.e2e-project/kenneth-quass-death/{research.json,tree.gedcomx.json}` (gitignored), exit 0.
- Re-run without `FORCE` → refuses (exit 1) with a clear message; bad slug → clear error (exit 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
