### PR TITLE
search-full-text: re-run + re-grade (#482)

### DIFF
--- a/eval/runlogs/unit/search-full-text/v1_2026-06-29_17-02-34.ann.json
+++ b/eval/runlogs/unit/search-full-text/v1_2026-06-29_17-02-34.ann.json
@@ -1,0 +1,438 @@
+{
+  "run_log": "v1_2026-06-29_17-02-34.json",
+  "annotator": "mercybocumy2000@gmail.com",
+  "corrections": [
+    {
+      "test_id": "ut_search_full_text_011",
+      "dimension_source": "base",
+      "dimension_name": "Correctness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_full_text_011",
+      "dimension_source": "base",
+      "dimension_name": "Completeness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_full_text_011",
+      "dimension_source": "base",
+      "dimension_name": "Tool Arguments",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_full_text_011",
+      "dimension_source": "rubric",
+      "dimension_name": "Query construction",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_full_text_011",
+      "dimension_source": "rubric",
+      "dimension_name": "FAN awareness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_full_text_011",
+      "dimension_source": "rubric",
+      "dimension_name": "Negative result handling",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_full_text_009",
+      "dimension_source": "base",
+      "dimension_name": "Correctness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_full_text_009",
+      "dimension_source": "base",
+      "dimension_name": "Completeness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_full_text_009",
+      "dimension_source": "base",
+      "dimension_name": "Tool Arguments",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_full_text_009",
+      "dimension_source": "rubric",
+      "dimension_name": "Query construction",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_full_text_009",
+      "dimension_source": "rubric",
+      "dimension_name": "FAN awareness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_full_text_009",
+      "dimension_source": "rubric",
+      "dimension_name": "Negative result handling",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_full_text_007",
+      "dimension_source": "base",
+      "dimension_name": "Correctness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_full_text_007",
+      "dimension_source": "base",
+      "dimension_name": "Completeness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_full_text_007",
+      "dimension_source": "base",
+      "dimension_name": "Tool Arguments",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_full_text_007",
+      "dimension_source": "rubric",
+      "dimension_name": "Query construction",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_full_text_007",
+      "dimension_source": "rubric",
+      "dimension_name": "FAN awareness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_full_text_007",
+      "dimension_source": "rubric",
+      "dimension_name": "Negative result handling",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_full_text_003",
+      "dimension_source": "base",
+      "dimension_name": "Correctness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_full_text_003",
+      "dimension_source": "base",
+      "dimension_name": "Completeness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_full_text_003",
+      "dimension_source": "base",
+      "dimension_name": "Tool Arguments",
+      "llm_score": null,
+      "corrected_score": null,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_full_text_006",
+      "dimension_source": "base",
+      "dimension_name": "Tool Arguments",
+      "llm_score": null,
+      "corrected_score": null,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_full_text_005",
+      "dimension_source": "base",
+      "dimension_name": "Correctness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_full_text_005",
+      "dimension_source": "base",
+      "dimension_name": "Completeness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_full_text_005",
+      "dimension_source": "base",
+      "dimension_name": "Tool Arguments",
+      "llm_score": null,
+      "corrected_score": null,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_full_text_006",
+      "dimension_source": "base",
+      "dimension_name": "Correctness",
+      "llm_score": 1,
+      "corrected_score": 3,
+      "comment": "The skill was not activated, and it correctly routed to the question-selection skill."
+    },
+    {
+      "test_id": "ut_search_full_text_006",
+      "dimension_source": "base",
+      "dimension_name": "Completeness",
+      "llm_score": 1,
+      "corrected_score": 3,
+      "comment": "The skill was not activated, and it correctly routed to the question-selection skill."
+    },
+    {
+      "test_id": "ut_search_full_text_002",
+      "dimension_source": "base",
+      "dimension_name": "Correctness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_full_text_002",
+      "dimension_source": "base",
+      "dimension_name": "Completeness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_full_text_002",
+      "dimension_source": "base",
+      "dimension_name": "Tool Arguments",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_full_text_002",
+      "dimension_source": "rubric",
+      "dimension_name": "Query construction",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_full_text_002",
+      "dimension_source": "rubric",
+      "dimension_name": "FAN awareness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_full_text_002",
+      "dimension_source": "rubric",
+      "dimension_name": "Negative result handling",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_full_text_004",
+      "dimension_source": "base",
+      "dimension_name": "Correctness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_full_text_004",
+      "dimension_source": "base",
+      "dimension_name": "Completeness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_full_text_004",
+      "dimension_source": "base",
+      "dimension_name": "Tool Arguments",
+      "llm_score": null,
+      "corrected_score": null,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_full_text_012",
+      "dimension_source": "base",
+      "dimension_name": "Correctness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_full_text_012",
+      "dimension_source": "base",
+      "dimension_name": "Completeness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_full_text_012",
+      "dimension_source": "base",
+      "dimension_name": "Tool Arguments",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_full_text_012",
+      "dimension_source": "rubric",
+      "dimension_name": "Query construction",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_full_text_012",
+      "dimension_source": "rubric",
+      "dimension_name": "FAN awareness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_full_text_012",
+      "dimension_source": "rubric",
+      "dimension_name": "Negative result handling",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_full_text_001",
+      "dimension_source": "base",
+      "dimension_name": "Correctness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_full_text_001",
+      "dimension_source": "base",
+      "dimension_name": "Completeness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_full_text_001",
+      "dimension_source": "base",
+      "dimension_name": "Tool Arguments",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_full_text_001",
+      "dimension_source": "rubric",
+      "dimension_name": "Query construction",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_full_text_001",
+      "dimension_source": "rubric",
+      "dimension_name": "FAN awareness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_full_text_001",
+      "dimension_source": "rubric",
+      "dimension_name": "Negative result handling",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_full_text_010",
+      "dimension_source": "base",
+      "dimension_name": "Correctness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_full_text_010",
+      "dimension_source": "base",
+      "dimension_name": "Completeness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_full_text_010",
+      "dimension_source": "base",
+      "dimension_name": "Tool Arguments",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_full_text_010",
+      "dimension_source": "rubric",
+      "dimension_name": "Query construction",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_full_text_010",
+      "dimension_source": "rubric",
+      "dimension_name": "FAN awareness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_full_text_010",
+      "dimension_source": "rubric",
+      "dimension_name": "Negative result handling",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    }
+  ]
+}

--- a/eval/runlogs/unit/search-full-text/v1_2026-06-29_17-02-34.json
+++ b/eval/runlogs/unit/search-full-text/v1_2026-06-29_17-02-34.json
@@ -1,0 +1,3537 @@
+{
+  "schema_version": 2,
+  "skill": "search-full-text",
+  "version": 1,
+  "released": false,
+  "releasable": true,
+  "invocation": "skill",
+  "timestamp": "2026-06-29_17-02-34",
+  "harness_version": "0.1.0",
+  "model": "claude-sonnet-4-6",
+  "judge_prompt_hash": "adea6e4cb2c9ddf0c436c31e893da766866cc67ed749df0a7c6b8a9df52c6914",
+  "snapshot": {
+    "packages/engine/plugin/skills/search-full-text/SKILL.md": "---\nname: search-full-text\nmodel: claude-sonnet-4-6\ndescription: Invoke for FamilySearch full-text search (FTS) \u2014 immediately\n  when the user says \"full-text search\", \"FTS\", \"search document\n  transcripts\", or \"construct a full-text query\". Use this skill to find a\n  person as a witness, executor, executrix, administrator, appraiser, heir,\n  neighbor, surety, or other non-principal in deeds, probate, wills, court\n  minutes, or notarial protocolos; to run Lucene-style queries with\n  +required terms, wildcards, or phrase matching; and to cover spelling and\n  transcription variants across FamilySearch's AI-transcribed historical\n  documents. FamilySearch document images only. Exclude external sites like\n  Ancestry or Newspapers.com (use search-external-sites), structured\n  indexed search by name/date/place (use search-records), and planning what\n  to search (use research-plan).\nallowed-tools:\n  - fulltext_search\n  - source_attachments\n  - research_log_append\n  - research_append\n---\n\n# Search Full-Text\n\n**Narration:** Read `researcher_profile.narration_guidance` from `research.json` and apply it as your narration style for this invocation. If absent, default to a one-line preamble per action.\n\nExecutes full-text searches against FamilySearch's AI-transcribed\nhistorical document images. FTS searches the raw transcript text of\n~1.95 billion document images \u2014 a fundamentally different search\nsurface than indexed Records search. FTS finds people mentioned\nanywhere in a document (witnesses, neighbors, heirs, appraisers),\nnot just indexed principals.\n\nThis skill is the FTS counterpart to search-records (indexed search)\nand search-external-sites (non-FamilySearch repositories).\n\n## MCP tool\n\nThis skill uses one search tool:\n\n| MCP tool | Purpose |\n|----------|---------|\n| `fulltext_search` | Full-text search of AI-transcribed document images using Lucene-style operators |\n\n## Key differences from indexed Records search\n\nFTS and indexed search are completely different systems:\n\n| | Indexed (`record_search`) | Full-text (`fulltext_search`) |\n|---|---|---|\n| What's searched | Structured fields (name, date, place) | Raw transcript text of document images |\n| Fuzzy matching | Auto-applies nicknames, phonetic variants, Soundex | **None.** Exact text matching only. |\n| Abbreviation expansion | Wm\u2192William, Jno\u2192John automatic | **Not expanded.** Must search Wm and William separately. |\n| Operators | `q.*` parameters with `.exact=on` modifier | `+` (require), `-` (exclude), `\"\u2026\"` (phrase), `?`/`*` (wildcards) |\n| Default behavior | Fuzzy matching on all terms | **OR** \u2014 at least one term must appear |\n| Unique strength | Finding indexed principals | Finding non-principal mentions (witnesses, neighbors, heirs) |\n| Source type | Structured index (derivative) | AI transcript of document images (also derivative) |\n\n### Critical: FTS results are derivative sources\n\nChain: original \u2192 image \u2192 AI transcript \u2192 textDocument. Each step can\nintroduce errors (~10% observed). **Always verify against the\noriginal image** (linked from each result).\n\n## Steps\n\n### 1. Identify the plan item to execute\n\nRead `research.json` `plans[]` and find the next plan item with\n`status: \"planned\"` that targets full-text search. If the user\nspecifies a particular search, match it to a plan item or create\nan ad-hoc search (with `plan_item_id: null` in the log).\n\n### 2. Evaluate the target database\n\nBefore constructing any query, verify FTS covers the target. Read\n`references/online-search-literacy.md` for the evaluation checklist.\n\n- **Coverage:** ~6,665 searchable collections as of mid-2026. Not\n  all FamilySearch collections are FTS-searchable.\n- **Collection scope:** Read the description \u2014 titles mislead about\n  geographic/temporal coverage.\n- **Error rate:** ~10% observed. Plan for transcription variants.\n\n### 3. Choose a search philosophy\n\n**Default to \"less is more\" for FTS.** No fuzzy matching means every\nextra required term risks missing transcription variants.\n\n- **Uncommon surname** \u2192 `+Surname` only, filter after\n- **Common surname** \u2192 `+Surname +Associate` or `+Surname +Keyword`\n- **Very common surname (Smith, Jones)** \u2192 multiple required terms\n  or phrase search (\"kitchen sink\")\n\nSee `references/online-search-literacy.md` for the full framework.\n\n### 4. Determine the search strategy\n\nRead `references/search-strategies.md` for the full strategy\ncatalog. Key decision: what kind of FTS search is this?\n\n| Research goal | Query approach |\n|---|---|\n| Find person as witness/appraiser/heir | `+Surname` in Name field, place filter after |\n| Find person in narrative records (deeds, probate, court) | `+GivenName +Surname` in Keywords, place filter after |\n| FAN cluster search | `+TargetSurname +AssociateSurname` in Keywords |\n| Kinship determination | `+Surname +\"daughter of\"` or `+Surname +\"my beloved wife\"` |\n| Migration tracing | `+Surname` with successive place filters |\n| Enslaved persons | Enslaver surname + slavery keywords (see strategies reference) |\n\n### 5. Construct the search query\n\nRead `references/query-syntax.md` for operator rules.\n\n**Critical rules:**\n- **Always use `+` to require terms.** Default is OR, which returns\n  millions of irrelevant results.\n- **Search by name only first.** Do NOT include place in the initial\n  query \u2014 place matches collection metadata and causes false\n  positives. Apply place as a post-search filter.\n- **Abbreviations must be searched explicitly.** FTS does not\n  auto-expand. If searching for William, also search Wm. If\n  searching for Thomas, also search Thos.\n- **Mine prior records for known surname variants before querying.**\n  Scan existing `research.json` assertions and log entries for the\n  target surname. If prior records show a transcription variant\n  (e.g., a \"Flinn\" assertion or log entry when searching \"Flynn\"),\n  include the variant in your initial query set. FTS does not\n  auto-expand spelling variants \u2014 the work has already been done\n  upstream, and ignoring it wastes queries on the wrong spelling.\n- **Phrases tolerate one intervening word.** `\"Ezekiel Pearce\"`\n  also matches \"Ezekiel John Pearce.\"\n- **Wildcards:** `?` (one char), `*` (zero or more). Cannot appear\n  inside quotes or as first character. Minimum 3 literal characters.\n\n**Example queries:**\n\n```\n# Basic person search (require both terms). Pass projectPath so the\n# host stages results and returns a staged.resultsRef for step 8.\nfulltext_search({ keywords: \"+Patrick +Flynn\", projectPath })\n\n# Phrase search\nfulltext_search({ keywords: '+\"Patrick Flynn\"' })\n\n# Person + boilerplate phrase (will search)\nfulltext_search({ keywords: '+\"Thomas Flynn\" +\"Last Will and Testament\"' })\n\n# FAN cluster (target + associate)\nfulltext_search({ keywords: \"+Flynn +Brennan\" })\n\n# Wildcard for HTR errors\nfulltext_search({ keywords: \"+Fl?nn +Patrick\" })\n\n# Abbreviation variant (separate query)\nfulltext_search({ keywords: \"+Wm +Flynn\" })\n\n# Natural language search\nfulltext_search({ nlQuery: \"Search for John Doe born in Austria\" })\n\n# Search by tree person ID\nfulltext_search({ nlQuery: \"KD96-TV2\" })\n\n# Search within a specific volume\nfulltext_search({ imageGroupNumber: \"4057677\" })\n```\n\n**When searching a specific volume:** Use the Image Group Number field to restrict to one digitized volume, then add keywords.\n\n### 6. Execute and iterate\n\nCall `fulltext_search` with the constructed query. This skill **logs\nevery search**, so `projectPath` (the absolute path to the project\nfolder) is **mandatory on every call** \u2014 never omit it. When supplied,\nthe host stages the raw results and the response gains a\n`staged.resultsRef` handle you hand to `research_log_append` in step 8\nto retain them \u2014 you never serialize the payload yourself.\n\n**Verify staging before you log.** If a search returned \u22651 result but\nthe response has no `staged.resultsRef`, you omitted `projectPath` \u2014\nre-run the identical query **with** `projectPath` before step 8, or the\nresults are not retained and the log entry will have no sidecar. (A nil\nsearch correctly has no `staged.resultsRef`; that is expected.)\n\n**Decision rules by hit count:**\n- **0 results** \u2192 See step 10 (handle nil results)\n- **1\u201350 results** \u2192 Review all\n- **50\u2013500 results** \u2192 Add Year/RecordType filter\n- **>500 results** \u2192 Add a second required term (`+associate`,\n  `+occupation`, `+landmark`) or add place filter\n\n**If searching a collection-specific quirk:** Read\n`references/transcription-quirks.md` for HTR error patterns,\nera-specific handwriting issues, and coverage gaps.\n\n### 7. Triage results\n\nFor each result, evaluate match quality:\n\n**Quick triage:**\n- Does the target name appear in the textDocument?\n- Is the name in the right context (witness signature, will clause,\n  deed party) or a false positive (cross-column alignment, place\n  name matching)?\n- Is the place and approximate date consistent?\n\n**Attachment check:** After narrowing to promising results, call\n`source_attachments({ uris: [ark1, ark2, ...] })` to check whether\neach record is already attached to a tree person.\n- **Attached to the target person** \u2192 deprioritize for extraction\n  unless the user wants to re-examine it.\n- **Attached to a different person** \u2192 flag as potentially relevant\n  (could be a family member or duplicate).\n- **Unattached** \u2192 prioritize for extraction \u2014 this is new evidence.\n\n**Present triage to the user:** List the top results with match\nquality, context (what role the person plays in the document), and\nattachment status. Let the user confirm which records to examine in\ndetail.\n\n### 8. Retain results and write the log entry\n\n**Every search gets a log entry and retains its results \u2014 no\nexceptions.** Call `research_log_append` once per search. The tool\nassigns the log id and `performed` timestamp, finalizes the staged\nresults into the `results/<log_id>.json` sidecar (recomputing the\ncount), and validates-before-persist \u2014 you supply only the judgment\n(outcome, counts, notes) and the staged handle:\n\n```\nresearch_log_append({\n  projectPath,\n  planItemId: \"pli_010\",          // null for an ad-hoc search\n  tool: \"fulltext_search\",\n  query: {\n    keywords: \"+Flynn +\\\"Last Will and Testament\\\"\",\n    recordPlace1: \"Pennsylvania\",\n    recordPlace2: \"Schuylkill\",\n    yearFrom: 1870,\n    yearTo: 1890\n  },\n  outcome: \"positive\",            // your judgment: positive/negative/partial/error\n  resultsExamined: 5,\n  resultsAvailable: 47,           // upstream totalResults, or null\n  notes: \"47 Schuylkill will hits 1870\u20131890; 5 examined. Thomas Flynn's will (1881) names wife Mary and children Patrick, John, Margaret; Flynn also appears as a witness on two unrelated wills.\",\n  stagedResultsRef: staged.resultsRef   // omit for a nil search\n})\n```\n\n`notes` is a one-line human summary of what the search returned. For a\n**nil** search, omit `stagedResultsRef` entirely (no sidecar is\nwritten) and set `resultsExamined: 0`.\n\n**Recovery.** If the search response is stale or the\n`staged.resultsRef` handle has expired (the host's staging TTL lapsed),\nre-run the `fulltext_search` (with `projectPath`) to re-stage \u2014 it is\ncheap. If `research_log_append` returns `{ ok: false, errors }`, surface\nthe errors to the user rather than retrying blindly.\n\n### 9. Update plan item status\n\nRoute the plan-item `status` mutation through `research_append`\n(it validates-before-persist and writes nothing on `{ ok: false }`):\n\n```\nresearch_append({\n  projectPath,\n  section: \"plan_items\",\n  op: \"update\",\n  planId: \"pl_003\",        // the parent plan's pl_ id\n  entryId: \"pli_010\",      // the plan item's pli_ id\n  fields: { status: \"completed\" }\n})\n```\n\nSet `status` to:\n- `completed`: Search executed regardless of outcome\n- `skipped`: The search was determined to be unnecessary (e.g., the\n  question was already answered by a prior search)\n\n### 10. Handle nil results\n\nWhen a search returns no results:\n\n1. Log the nil result via `research_log_append` with `outcome:\n   \"negative\"`, `resultsExamined: 0`, and **no** `stagedResultsRef`\n   (a nil search retains no sidecar). **The `notes` field on a negative log entry must explicitly state the collection class searched, the place filters and date range applied, the spelling/variant forms queried, and the count of variants tried before declaring negative** (for example: \"Searched FamilySearch FTS, FamilySearch Probate collections, Schuylkill County, Pennsylvania, 1870\u20131890; 5 variants tried (+'Patrick Flynn', +Patrick +Flynn, +Patrick +Flinn, +Patrick +Flunn, +Flynn surname-only); 0 results \u2014 FTS coverage gap probable; recommend indexed search-records or volume browse\"). A bare \"no results\" note is insufficient for the GPS exhaustive-search audit trail; the future reader must be able to see the search scope without re-deriving it from the query payload.\n2. **Iterate through variants before declaring negative \u2014 but cap\n   total queries (initial + retries) at 5 per plan item.** Pick the\n   most promising 4 variants from `references/search-strategies.md`\n   (decision tree) and `references/online-search-literacy.md`\n   (nil-result checklist) for the specific record class and locality;\n   do not exhaustively walk the full variant catalogue. Log each\n   retry separately. Once you have logged 5 nil queries for the same\n   subject, stop and declare a coverage gap \u2014 additional retries\n   produce diminishing returns and inflate the tool-call budget\n   without changing the answer.\n3. **Verify coverage exists.** A nil result may mean the record was\n   never transcribed \u2014 not that it doesn't exist.\n4. **Assess whether absence is meaningful** (negative evidence) \u2014\n   only when coverage is known to be good for that locality/period.\n5. Check for fallback plan items or suggest search-records/re-plan.\n6. **Do NOT execute unrelated diagnostic queries to \"test\" the FTS\n   index.** When a long string of variant queries returns zeros, the\n   right next step is to declare a coverage gap and log the negative\n   finding \u2014 not to query a common surname (`+Smith`, `+Jones`) to\n   see whether the tool is \"broken.\" The tool's response is\n   authoritative. Diagnostic probes both inflate Tool Arguments cost\n   on unrelated subjects and rationalize away genuine negative\n   findings as \"must be a test environment issue.\"\n\n### 11. Queue cross-reference searches\n\nWhen reading FTS results, automatically queue sub-searches for:\n- Every named non-target person (witnesses, executors, appraisers,\n  heirs, neighbors)\n- Distinctive landmarks or property descriptions\n- Slaveholder \u2194 enslaved name pairs\n- Powers of attorney \u2192 search the named agent in the other county\n- Marginal annotations referencing later transactions\n\nPresent these as suggestions: \"This deed names John Brennan as a\nwitness. Would you like me to search for other documents mentioning\nBrennan in this county?\"\n\n### 12. Pass records to extraction\n\nFor each promising record, invoke record-extraction to process it.\nFTS results include transcript text \u2014 pass this context along.\n\n### 13. Present results\n\nAfter completing a search (or a batch of searches from the plan):\n- Summarize what was searched and what was found\n- Highlight non-principal mentions (witnesses, neighbors) \u2014 these\n  are FTS's unique value\n- Show the log entries created\n- Show plan progress\n- Suggest next steps:\n  - More plan items \u2192 \"Shall I continue with the next search?\"\n  - Cross-reference opportunities \u2192 \"I found 3 witnesses. Search\n    for them?\"\n  - All plan items done \u2192 \"All planned searches are complete.\"\n  - No results \u2192 \"No matches in FTS. Would you like to try indexed\n    search (search-records) or re-plan?\"\n\n## Important rules\n\n- **Always use `+` to require terms.** Default is OR (millions of\n  irrelevant results).\n- **Search name first, filter place after.** Place in the query\n  causes metadata false positives.\n- **FTS results are derivative sources.** Always verify against the\n  original image.\n- **A nil result does not prove absence.** Try variants before\n  declaring negative; log exact parameters for reproducibility.\n- **Log every search.** Including nil results. The log is the GPS\n  audit trail.\n- **Let the user confirm before extraction.** Never fabricate\n  results.\n- **Do NOT write to `sources` or `assertions`.** This skill only\n  writes to `log` and `plans` (status updates). Creating source\n  entries and extracting assertions is record-extraction's job \u2014\n  pass promising records there instead.\n- **Do NOT add extra fields to plan items.** Plan items have a\n  fixed schema (`id`, `sequence`, `record_type`, `jurisdiction`,\n  `date_range`, `repository`, `rationale`, `fallback_for`,\n  `status`). Do not add `completion_note`, `notes`, or any other\n  fields \u2014 the schema enforces `additionalProperties: false`.\n- **Always use `keywords` for queries.** Do not fall back to\n  `nlQuery` when `keywords` queries return few or no results.\n  Use `nlQuery` only when the user explicitly asks for a natural\n  language search or provides a tree person ID.\n\n## Re-invocation behavior\n\n**Writes:** via `research_log_append`, a new entry in the `log` section\nof `research.json` (append-only) plus its `results/log_NNN.json`\nsidecar (the tool finalizes the staged payload); and, via\n`research_append`, the `status` field on the corresponding plan item.\n\n**On repeat invocation:** always appends a new `log_` entry \u2014 re-running\nthe search is itself a logged event. Updates the plan item's `status`\nif applicable.\n\n**Do not duplicate:** the log is append-only and `research_log_append`\nonly appends (no update or delete), so prior `log_` entries and their\nsidecars are never touched. Two consecutive runs of the same query\nproduce two log entries and two sidecars; that's correct.\n",
+    "packages/engine/plugin/skills/search-full-text/references/online-search-literacy.md": "# Online Search Literacy \u2014 Quick Reference\n\nLoad this reference when evaluating a database before searching or\nwhen handling nil results.\n\n## Search Philosophy Decision\n\n| Situation | Approach |\n|---|---|\n| Uncommon surname, uncertain spelling/dates, new locality | **\"Less is more\"** \u2014 surname only, filter after |\n| Extremely common surname (Smith, Johnson), high confidence in details | **\"Kitchen sink\"** \u2014 multiple required terms |\n| FTS specifically (no fuzzy matching, no abbreviation expansion) | **Default to \"less is more\"** \u2014 every extra term risks missing variant transcriptions |\n\nStart broad, check hit count, narrow iteratively with filters.\n\n## Database Evaluation Checklist\n\nBefore searching, answer these:\n\n1. **What does this database actually contain?** Read the collection\n   description \u2014 titles can mislead about geographic/temporal scope.\n2. **Is this an index or original records?** FTS searches AI\n   transcripts (derivative). The chain is: original \u2192 image \u2192 AI\n   transcript \u2192 search snippet.\n3. **What coverage exists?** ~6,665 FTS-searchable collections as of\n   mid-2026. Not all FamilySearch collections are included.\n4. **Known limitations?** English-language records from Americas/UK/\n   Australasia are strongest. Non-Latin scripts and continental\n   European records have weaker support.\n\n## Nil-Result Checklist\n\nWork through in order before declaring a search negative:\n\n1. Is the query too restrictive? Drop terms, use filter instead.\n2. Spelling/abbreviation variants? (Wm, Jno, Jas, Thos)\n3. Transcription errors hiding it? Use wildcards on confused letters.\n4. Wrong field? Try Keywords vs. Name (different behavior).\n5. Does the collection exist in FTS? Verify coverage.\n6. Would this record type exist for this place/time?\n\nAfter exhausting variants:\n- Log the negative with exact query and date\n- Note whether absence is analytically meaningful (negative evidence)\n- Coverage grows ~4-6 collections/week \u2014 today's nil may be\n  tomorrow's hit\n- Suggest alternatives: indexed search, different repository,\n  physical visit\n\n## Derivative Source Awareness\n\n```\nOriginal (handwritten) \u2192 Image \u2192 AI transcript \u2192 Search snippet\n```\n\nEach step introduces errors. Professional standards require working\nback toward the original. When citing, distinguish whether information\ncame from the transcript or from the original image examined.\n\nA well-maintained search log transforms \"I couldn't find anything\"\ninto \"I searched these specific sources with these parameters on\nthese dates and found no matching records.\"\n",
+    "packages/engine/plugin/skills/search-full-text/references/query-syntax.md": "# Full-Text Search Query Syntax \u2014 FamilySearch\n\nReference for constructing `fulltext_search` queries. FTS searches\nAI-transcribed historical document images, not structured indexes.\nBehavior differs fundamentally from indexed Records search.\n\n## Search fields\n\n| Field | Purpose | Notes |\n|---|---|---|\n| Keywords | Free text against entire transcript | All operators (`+`, `-`, `\"\u2026\"`, `?`, `*`) work here |\n| Name | NLP-recognized person names only | Auto-handles last-name-first inversions (\"Mills Alexander\" matches \"Alexander Mills\"). Keywords field does NOT auto-invert. |\n| Place | Place name | Matches BOTH transcript content AND collection metadata \u2014 major source of false positives. **Prefer filtering by place after search rather than including place in the query.** |\n| Year Range | Numeric range | Matches AI-recognized years in transcript and/or collection metadata. Documents often contain multiple dates. |\n| Image Group Number | Restrict to one digitized volume | Enter without leading zeros. Combine with keywords to scan one volume. |\n\n**Cross-field semantics:** If multiple fields are specified, results\nmust match ALL fields. Within a field, operators control which terms\nare required.\n\n## Operators\n\n| Operator | Example | Behavior |\n|---|---|---|\n| (none) | `Ezekiel Pearce` | **OR** \u2014 results contain at least one term. Produces large hit counts. |\n| `+` | `+Ezekiel +Pearce` | **Require** \u2014 term must appear. No space between `+` and term. |\n| `-` | `+Ezekiel +Pearce -Pierce` | **Exclude** \u2014 omit results containing this term. |\n| `\"\u2026\"` | `+\"Ezekiel Pearce\"` | **Phrase** with one-word slop \u2014 matches \"Ezekiel John Pearce\" too. |\n| `?` | `Ezeki?l` | Single-character wildcard. |\n| `*` | `execut*r*` | Multi-character wildcard (zero or more). Matches executor, executrix, executors, etc. |\n\n**Multiple required phrases:** `+\"phrase one\" +\"phrase two\"` works.\n\n## What is NOT supported\n\n- **No Boolean keywords.** `AND`/`OR`/`NOT` are treated as literal\n  words. Use `+`, `-` symbols only.\n- **No proximity operator (`~N`).** Anecdotally reported but\n  unreliable. Do not use.\n- **No grouping parentheses.** Treated as literal characters.\n- **No stemming.** `marries` does NOT match `married`. Use `marri*`.\n- **No phonetic/Soundex matching.** \"Stephen Jarman\" \u2260 \"Steven\n  Jarmon\". Search both explicitly.\n- **No abbreviation expansion.** `Wm`\u2260`William`, `Jno`\u2260`John`,\n  `Jas`\u2260`James`, `Thos`\u2260`Thomas`. Run separate queries.\n- **Case insensitive** \u2014 confirmed.\n- **Diacritic insensitivity** \u2014 partial; generally works for\n  Spanish/Portuguese but coverage is uneven.\n\n## Wildcard rules\n\n- `?` = exactly one character; `*` = zero or more characters\n- **Cannot appear inside quotes:** `\"Eben* Mills\"` does not work\n- **Cannot be the first character of a term:** `*Smith` is invalid\n- Multiple wildcards per term allowed: `Sm?th??`\n- Best practice: \u22653 literal characters per wildcard term\n- Up to four `*` per term\n\n## Filters (post-search)\n\nFilters operate on **collection metadata**, not transcript text:\n\n- **Collection** \u2014 auto-generated collections (place + record type +\n  date range)\n- **Year** \u2014 by century, then decade. Reflects collection metadata\n  date, NOT necessarily the document's actual date.\n- **Place** \u2014 hierarchical (country \u2192 state \u2192 county). Reflects\n  collection metadata place, NOT places mentioned in the document.\n- **Record Type** \u2014 deeds, probate, court, vital, military, etc.\n\n**Critical rule:** Apply place and date via filters AFTER the initial\nsearch, not by typing into Place/Year fields. This avoids false\npositives from collection-metadata matching.\n\n**Filter order:** Place first, then year, then record type.\n\n## Hit-count interpretation\n\n- Hits are **per-image-mention**, not per-document. A multi-page\n  document generates multiple hits.\n- A query returning millions of results means OR default is in\n  effect \u2014 switch to `+TermA +TermB`.\n- Some matches won't appear in snippets when the term is in the\n  full transcript but not the displayed excerpt.\n\n## Unit of indexing\n\nThe unit is the **IMAGE**, not the document. A deed spanning two\nmicrofilm images yields two separate results. Deduplicate by\nARK URL.\n",
+    "packages/engine/plugin/skills/search-full-text/references/research-log-protocol.md": "# Research Log Protocol\n\nThis protocol must be followed by every skill that searches for or\nprocesses genealogical records. The research log is the GPS audit trail\nthat makes \"reasonably exhaustive\" claims provable.\n\n## Rules\n\n1. **Every search produces a log entry.** No exceptions. If you called\n   a search tool or generated a search URL, log it.\n\n2. **Nil results are recorded explicitly.** When a search returns no\n   results, write a log entry with `outcome: \"negative\"` and\n   `results_examined: 0`. The absence of a result is itself a finding.\n\n3. **Log entries are append-only.** Never modify or delete an existing\n   log entry. The log is the primary audit trail \u2014 if entries could be\n   edited, the exhaustive search declaration would be unfalsifiable.\n\n4. **Include search parameters.** The `query` object must capture\n   enough detail to reproduce the search: names, dates, places,\n   collection, and any filters used.\n\n5. **Link to plan items.** If the search was part of a research plan,\n   set `plan_item_id` to the `pli_` ID. For ad-hoc searches, use null.\n\n6. **Link outputs back to the search.** The log entry is immutable\n   (Rule 3). When sources and assertions are extracted from a logged\n   search, the extracting skill stamps each new source and assertion\n   with a `log_entry_id` pointing at the log entry. \"What did this\n   search produce\" is a reverse lookup over those fields \u2014 the log\n   entry itself is never revisited.\n\n7. **Retain the raw results.** A log entry records *that* a search ran;\n   the results it returned are retained too, so a later step can\n   re-examine or refute them (GPS Element 1 \u2014 reasonably exhaustive\n   research). For tool-payload searches (`record_search`,\n   `fulltext_search`) the raw response is written to a sidecar file \u2014\n   see \"Result sidecar files\" below. External-site searches retain the\n   captured PDF/HTML instead, via `external_site.capture_filename`. A\n   search that returns nothing retains nothing \u2014 `results_ref` is null.\n\n## Log entry structure\n\n```json\n{\n  \"id\": \"log_001\",\n  \"plan_item_id\": \"pli_001\",\n  \"performed\": \"2026-05-04T10:15:00Z\",\n  \"tool\": \"record_search\",\n  \"query\": {\n    \"surname\": \"Flynn\",\n    \"given\": \"Patrick\",\n    \"birth_year\": 1845,\n    \"birth_place\": \"Pennsylvania\",\n    \"collection\": \"1850 Census\"\n  },\n  \"outcome\": \"positive\",\n  \"results_examined\": 8,\n  \"results_available\": 1240,\n  \"results_ref\": \"results/log_001.json\",\n  \"notes\": \"1,240 1850-census hits; 8 examined; Patrick Flynn age 5 found in household of Thomas Flynn.\",\n  \"external_site\": null\n}\n```\n\n- `results_examined` \u2014 how many results you actually triaged.\n- `results_available` \u2014 the total hit count the tool reported, or null\n  when the tool reports no total.\n- `results_ref` \u2014 path to the result sidecar (see below), or null.\n- `notes` \u2014 a one-line human summary of what the search returned.\n\n## Result sidecar files\n\nThe raw results of a tool-payload search are not stored inline in\n`research.json` \u2014 that file is read by every skill at startup and must\nstay lean. Instead the results live in a sidecar file\n`results/<log_id>.json` in the project folder, and `results_ref` on the\nlog entry points at it.\n\n**The sidecar is written by the tool, not by hand.** Call the search\nwith `projectPath` so the host stages the raw response; then pass the\nreturned `staged.resultsRef` to `research_log_append`, which finalizes\nit into `results/<log_id>.json` (assigning the id, recomputing the\ncount, validating before persist). You never serialize the payload,\nallocate the id, chunk a large write, or verify the count yourself.\n\n- **Nil searches retain no sidecar.** When a search returns zero\n  results, omit `stagedResultsRef` \u2014 `research_log_append` leaves\n  `results_ref` null, and the log entry's `outcome` and counts record\n  the nil.\n- **Stale staged handle.** If the `staged.resultsRef` has expired\n  (staging TTL lapsed), re-run the search with `projectPath` to\n  re-stage. Surface a `{ ok: false, errors }` from\n  `research_log_append` to the user rather than retrying blindly.\n- External-site searches retain no sidecar; their capture is retained\n  via `external_site.capture_filename`.\n\n## When record-extraction writes log entries\n\nrecord-extraction writes a log entry **only** when processing a\nrecord that was not produced by search-records or\nsearch-external-sites \u2014 e.g., a user-provided PDF uploaded directly.\nWhen a search skill already logged the search, link to that log\nentry by setting `log_entry_id` on each new source and assertion,\nrather than creating a duplicate log entry.\n",
+    "packages/engine/plugin/skills/search-full-text/references/search-strategies.md": "# Full-Text Search Strategies \u2014 FamilySearch\n\nStrategies for constructing and iterating `fulltext_search` queries.\nFTS does not auto-expand abbreviations or apply phonetic matching \u2014\nthe agent must generate variants explicitly.\n\n## When to use FTS vs. indexed Records search\n\n| Scenario | Tool |\n|---|---|\n| Known name + indexed event (BMD, census, vital) | Indexed `record_search` |\n| Person mentioned as witness, neighbor, heir, surety, appraiser | **FTS** |\n| Pre-1850 US research with thin indexed coverage | **FTS first** |\n| Latin American notarial protocolos | **FTS strongly preferred** |\n| Narrative paragraph records (court minutes, meetings) | **FTS** |\n| Burned-county research | **FTS in adjacent counties** |\n\nFTS uniquely surfaces: witness signatures on deeds, estate appraisers\nand bondsmen in probate, heirs-at-law in wills, sureties and guardians,\npowers of attorney in distant counties, chains of title, enslaved\npersons' given names, marginalia, tax-list and store-account entries.\n\n## Core tactic: name only \u2192 filter\n\nSearch a name (or surname + contextual keyword), then filter by\nPlace \u2192 Year \u2192 Record Type using post-search filters. Do NOT put\nplace in the initial query \u2014 it causes false positives from\ncollection-metadata matching.\n\n## Decision tree by hit count\n\n```\n0 results     \u2192 drop place; try Keywords field; try wildcards\n1\u201350 results  \u2192 review all\n50\u2013500        \u2192 add Year/RecordType filter\n>500          \u2192 add second required term (+associate, +occupation)\n```\n\n**Still 0 after above:**\n1. Try given name in Keywords + surname in Keywords (separate `+`)\n2. Try surname only + place filter\n3. Try abbreviations (Wm, Jno, Jas, Thos, Chas)\n4. Try wildcards on likely-misread letters\n5. Try last-name-first phrase: `\"Surname Given\"`\n6. Try maiden vs. married surname for women\n7. Try DGS-scoped search of the most likely volume\n8. Try keyword-only search of boilerplate phrases + place filter\n\n**Still 0:**\n- Verify the collection is in FTS (coverage is not complete)\n- Fall back to manual image browsing\n- Log negative result with exact query\n\n## Name variant queries (must run explicitly \u2014 no auto-expansion)\n\n| Formal | Abbreviations to search separately |\n|---|---|\n| William | Wm, Wm., Will. |\n| John | Jno, Jno., Jn\u00b0 |\n| James | Jas, Jas., Js |\n| Thomas | Thos, Thos., Tho. |\n| Charles | Chas, Chas., Cha. |\n| Robert | Robt, Robt., Rob. |\n| Richard | Richd, Richd., Rich. |\n| Samuel | Saml, Saml., Sam. |\n| Joseph | Jos, Jos. |\n| Benjamin | Benj, Benj., Benjm. |\n| Henry | Hy, Hy. |\n| George | Geo, Geo. |\n| Margaret | Margt, Margt., Marg. |\n| Elizabeth | Eliz, Eliz., Elizth. |\n\nAlso search nicknames: Peggy/Margaret, Polly/Mary, Sally/Sarah,\nBill/William, Dick/Richard, Jack/John, etc.\n\n**Cross-language equivalences (for ecclesiastical/colonial records):**\n- Latin: Joannes\u2194John, Iacobus\u2194James, Petrus\u2194Peter,\n  Henricus\u2194Henry, Carolus\u2194Charles\n- Spanish: Diego/Santiago\u2194James, Catalina\u2194Catherine,\n  Guillermo\u2194William\n- German: Johann/Hans\u2194John, Wilhelm\u2194William, Heinrich\u2194Henry,\n  Friedrich\u2194Frederick\n\n## Phrase and reordering variants\n\nFor target \"John Henry Smith,\" try progressively:\n1. `+\"John Smith\"` (slop allows middle name)\n2. `+\"John Henry Smith\"`\n3. `+\"John H Smith\"` and `+\"J H Smith\"`\n4. Name field: `\"Smith, John\"` (auto-inverts)\n5. Keywords field: `+\"Smith John\"` (does NOT auto-invert)\n6. `+John +Smith +Henry` (arbitrary co-occurrence)\n7. Surname only with place filter: `+Smith`\n\n## FAN / co-occurrence searches\n\nThe unique value proposition of FTS. Search for:\n- Target + associate surname: `+\"John Rodgers\" +Caldwell`\n- Target + spouse maiden surname: `+Brewer +Gay`\n- Target + occupation: `+Davis +blacksmith`\n- Target + neighbor's distinctive item: `+Cochran +\"silver watch\"`\n- Target + landmark: `+Rodgers +\"Turnip Creek\"`\n\n## Exclusion searches\n\n- Disambiguate same-named people: `+\"John Smith\" +Pennsylvania -Ohio`\n- Famous-figure collisions: `+Lincoln +Kentucky -Abraham -President`\n- Common-word surname: `+Rice -paddy -planting`\n\n## Place-name variants to try\n\n- Pre-split parent counties (e.g., for post-1842 Catawba Co., NC,\n  also search parent Lincoln Co.)\n- Variant forms: \"Lauderdale Co.\", \"Lauderdale County\", \"County of\n  Lauderdale\"\n- State abbreviations: \"Ala.\", \"Va.\", \"Virga\", \"N.C.\", \"No. Caro.\"\n- Spelling variants: Pittsburgh/Pittsburg, Worchester/Worcester\n- Historical jurisdictions: \"British North America\" (pre-1867\n  Canada), \"New Spain\" (pre-1821 Mexico)\n\n## Date variants to try\n\n- Year as keyword: `1834`\n- Written-out: `+\"twenty-fifth day\"`, `+\"day of August\"`\n- Quaker dates: `+\"first month\"`, `+\"7th day of the 9th month\"`\n- Abbreviated: `25 Augt`, `Septr 1834`, `Xber` (December)\n- Use Year Range filter for ranges; do NOT force year as keyword\n  unless searching for a specific recorded date\n\n## Boilerplate phrase searches\n\nCo-locates with target names and survives HTR errors better than\npersonal names.\n\n**Wills:** `\"being of sound mind\"`, `\"to my beloved wife\"`,\n`\"unto my son\"`, `\"I give and bequeath\"`, `\"Last Will and Testament\"`,\n`\"residue and remainder of my estate\"`\n\n**Deeds:** `\"know all men by these presents\"`,\n`\"in consideration of the sum of\"`, `\"to have and to hold\"`,\n`\"sealed and delivered in the presence of\"`\n\n**Court/depositions:** `\"personally appeared before me\"`,\n`\"being duly sworn\"`, `\"the deponent saith\"`\n\n**Probate:** `\"appraisers of the estate of\"`,\n`\"administrator of the estate\"`, `\"inventory and appraisement\"`\n\n**Slavery research** (hurtful content warning \u2014 research vocabulary):\n- `+Negr*` (~60% coverage) \u2192 `+slave*` (cumulative 83%) \u2192\n  `+Freedm?n` (cumulative 92%)\n- `+\"aged about\"`, `+\"her child\"`, `+Emanc*`, `+Manum*`\n- Spanish: `+esclav*`, `+\"de color\"`, `+moren*`\n\n## Iterative refinement\n\n- **Too many (>1000):** add `+` to require terms; add Place filter;\n  add Year Range; add third keyword\n- **Too few or zero:** drop quotes; add wildcards; try Keywords\n  instead of Name field (or vice versa); try abbreviations; remove\n  year filter (collection year \u2260 document year)\n- **Wrong matches:** use `-` to exclude noise; switch Name\u2194Keywords\n\n## Cross-reference triggers\n\nWhen reading a result, queue sub-searches for:\n- Every named non-target person (witnesses, executors, appraisers)\n- Every named place not previously researched\n- Distinctive landmarks, inventory items, or brand markings\n- Slaveholder \u2194 enslaved name pairs\n- Powers of attorney \u2192 search named agent and principal\n- Marginal annotations referencing later transactions\n",
+    "packages/engine/plugin/skills/search-full-text/references/transcription-quirks.md": "# Full-Text Search Transcription and Coverage Quirks\n\nRead this reference when interpreting FTS results or when searches\nreturn unexpected results. These quirks affect query construction\nand result interpretation.\n\n## HTR error patterns\n\nCommon AI handwriting-recognition confusions. Use wildcards to\ncompensate.\n\n| Pattern | Substitution | Example | Wildcard |\n|---|---|---|---|\n| long-s `\u0283` | f, l, t | Massachusetts \u2192 Mafsachusetts | `Ma?sachusetts` |\n| `rn` | m, in, iii | Turnpike \u2192 Tumpike | `Tu*pike` |\n| `u` | n, ii | Mountain \u2192 Mountan | `Mo?ntain` |\n| `m` | rn, in, iii | William \u2192 Williain | `Willi*m` |\n| `c` | e, o | Cole \u2192 Cele | `C?le` |\n| `e` | c, o | execute \u2192 cxccute | `*xecute` |\n| `l` | I, 1, t | Alice \u2192 Atice | `A?ice` |\n| ornate capital S | F | Scott \u2192 Fcott | `?cott` |\n| double-l | tt, H | Allen \u2192 Atten | `A??en` |\n| `&` ligature | et, &c | & \u2192 et | search both |\n| superscript abbrev | dropped | Mrs \u2192 Mes | `M?s` |\n\n## Faithful representation symbols\n\nThe AI transcription uses special symbols:\n- `\u270d` = clerk's flourish\n- `\u2328` = unrecognizable symbol(s)\n- `\u2588 \u2593 \u2592` = shading or bleed-through\n- `\u2194` = horizontal rules, dashes, ditto strings\n- `\u23ac` = brace\n- `* \u3030 \u26ad \u271d \u25ad` = church register symbols (birth, baptism,\n  marriage, death, burial)\n\nSearching for these is technically possible but rarely useful.\nThey help interpret transcripts.\n\n## Era-specific handwriting issues\n\n- **Secretary hand (16th\u201317th c. English):** Errors concentrate\n  in word endings (-ed, -es, -eth). `e` looks like a backwards-c.\n- **Copperplate (18th\u201319th c. legal):** Stylized capitals (S, F,\n  T, L) confuse recognition. \"Gasper\" vs. \"Casper\" confusion.\n- **German Kurrent/S\u00fctterlin:** NOT well-supported as of 2026.\n  H/Y, e/n, B/L most confused. Search English transliterations.\n- **Spanish Procesal/colonial:** Abbreviations (`q'`=que,\n  `dho`=dicho) frequently truncated or expanded inconsistently.\n\n## Content quirks\n\n- **Marginalia ARE indexed** \u2014 annotations added later can surface\n  in searches.\n- **Struck-through text is indexed as written** \u2014 AI does not\n  interpret strikethrough as deletion.\n- **Multi-column/tabular data** is read row-major across columns,\n  causing spurious cross-column phrase matches (e.g., Col A\n  \"William\" aligns with Col B \"Wilson\" on same row).\n- **Line-broken/hyphenated words** \u2014 inconsistently handled. A\n  surname wrapping across a page boundary may not be findable as\n  a whole token. Try both halves.\n- **~10% error rate** in user-perceived results (empirically\n  observed). Always verify against the original image.\n\n## Coverage (as of mid-2026)\n\n~6,665 searchable auto-collections; ~1.95 billion result-records.\nCoverage is opaque and dynamic \u2014 collections grow by ~4\u20136 per week.\n\n**Strong coverage:**\n- US deeds and wills 1750\u20131900\n- US Legal, Vitals, Migrations, Land/Probate, Military\n- UK Military and Legal\n- Latin American notarial protocols (17th\u201319th c.)\n- Revolutionary War Pension files\n- Australian and New Zealand probate\n- Italian civil records (growing rapidly)\n\n**Weak/absent:**\n- Continental European records in non-Latin scripts (German\n  Kurrent, Cyrillic, Greek)\n- East Asian (Chinese, Japanese, Korean \u2014 models under development)\n- Arabic, Hebrew\n- Eastern European (Polish, Czech, Hungarian)\n\n**Coverage mismatch:** FamilySearch's internal count is \"8,000+\"\nauto-collection definitions; the user-searchable surface is ~6,665.\nAgents should not assume all collections are searchable.\n\n## Important behaviors\n\n- **FTS does NOT deduplicate against indexed Records search.**\n  A record findable via both will appear in both.\n- **Auto-collection dates/places come from metadata, not document\n  content.** A document's actual date may not match the collection's\n  date range. Do not exclude possibilities solely because a date\n  filter doesn't match.\n- **Today's negative result may be positive tomorrow.** Coverage\n  grows continuously. Log exact queries with timestamps for\n  periodic re-checking.\n",
+    "packages/engine/plugin/skills/search-full-text/references/validation-protocol.md": "# Validation Protocol\n\nThe persistence tools (`research_log_append`, `research_append`,\n`tree_edit`, the merge tools) **validate before they persist** and\nwrite nothing on `{ ok: false, errors }`. You no longer run a\npost-write structural validation pass by hand \u2014 if a write returns\n`{ ok: false }`, fix the inputs and re-call; surface the errors to the\nuser rather than retrying blindly. (`validate-schema` remains available\nas a user-invokable audit, but is not a required step after a tool\nwrite.)\n\n1. **Invoke `check-warnings`** if you added assertions or\n   person_evidence entries. This checks for genealogical\n   plausibility \u2014 impossibilities like married before 12, died after\n   120, or a child born after a parent's death \u2014 which is judgment the\n   structural validation does not cover. It is not auto-triggered; you\n   must invoke it explicitly.\n",
+    "eval/tests/unit/search-full-text/attachment-triage-witnesses.json": "{\n  \"execution\": {\n    \"max_wall_clock_seconds\": 600\n  },\n  \"input\": {\n    \"scenario\": \"mid-research-flynn\",\n    \"user_message\": \"Run separate full-text searches for Thomas Flynn AND for Patrick Flynn appearing as witnesses in Schuylkill County records \u2014 both names must be queried. Then check whether any returned records are already attached to tree persons.\"\n  },\n  \"judge_context\": [\n    \"After fulltext_search returns results, the skill should call source_attachments with the ARK URLs to check attachment status\",\n    \"Since all results come back unattached, the skill should note this and prioritize all results for extraction as new evidence\",\n    \"The triage presentation should include attachment status alongside match quality and document context\",\n    \"QUERY-CONSTRUCTION GRADING NOTE: this test's focus is the attachment-triage flow, NOT the search itself. Canonical-spelling phrase queries (+\\\"Thomas Flynn\\\" / +\\\"Patrick Flynn\\\") that return the witness record are sufficient \u2014 per rubric Query construction, this dimension grades queries the skill ACTUALLY EXECUTED, not a wishlist. Variants like Thos/Patk are valuable but NOT required when the canonical query already recovers the record. Judges MUST NOT score Query construction partial on the grounds that variants could have been tried\"\n  ],\n  \"mcp_fixtures\": [\n    \"fulltext-search-flynn-witnesses\",\n    \"fulltext-search-flynn-witnesses-by-name\",\n    \"fulltext-search-flynn-flinn-variant\",\n    \"fulltext-search-flynn-wildcard-variant\",\n    \"record-attachments-flynn-witnesses\"\n  ],\n  \"test\": {\n    \"id\": \"ut_search_full_text_011\",\n    \"skill\": \"search-full-text\",\n    \"type\": \"positive\"\n  }\n}\n",
+    "eval/tests/unit/search-full-text/latin-american-notarial.json": "{\n  \"input\": {\n    \"scenario\": \"mid-research-flynn\",\n    \"user_message\": \"Run a full-text search of FamilySearch's Cuban notarial protocolos collection for 'Jos\u00e9 Maria Garc\u00eda' (1830s Habana). Use the Spanish-orthography spelling (with the diacritic) rather than an Anglicised form, since FTS does not transliterate. Log the search in this project's research log as an ad-hoc query (plan_item_id: null) \u2014 do not add a new question or plan item; only the search log entry and its result sidecar should be written.\"\n  },\n  \"judge_context\": [\n    \"Should recognise that pre-1850 Latin American notarial protocolos are exactly the thin-index source class that the skill's references/search-strategies.md flags as FTS-preferred \u2014 and should explain the rationale briefly to the user\",\n    \"Should construct a query whose keywords include the Spanish-orthography 'Garc\u00eda' (with the diacritic, or at minimum the unaccented 'Garcia') \u2014 NOT an Anglicised form like 'Garcia/Garcis/Garsey'\",\n    \"Should successfully recover the fixture's 1834 poder otorgado (recordPlace: Habana, recordType: Notarial), which records Garc\u00eda as the apoderado on a power of attorney\",\n    \"Should NOT mistakenly treat the prompt as out-of-scope and refuse \u2014 Latin American notarial coverage is explicitly listed in the skill's allowed scope (references/transcription-quirks.md 'Latin American notarial protocols (17th\u201319th c.)' under Strong coverage)\",\n    \"Should mention in passing that FTS searches the AI transcript and Spanish-orthography variants (e.g. accented vs unaccented) may need separate queries if the canonical query returns nothing\"\n  ],\n  \"mcp_fixtures\": [\n    \"fulltext-search-cuban-notarial\",\n    \"fulltext-search-cuban-notarial-by-name\"\n  ],\n  \"test\": {\n    \"id\": \"ut_search_full_text_009\",\n    \"skill\": \"search-full-text\",\n    \"type\": \"positive\"\n  }\n}\n",
+    "eval/tests/unit/search-full-text/lucene-operator-construction.json": "{\n  \"input\": {\n    \"scenario\": \"mid-research-flynn\",\n    \"user_message\": \"Look for Patrick Flynn in pre-1850 Schuylkill County, Pennsylvania probate records. Construct ONE full-text query that combines required-term operators with a wildcard so we cover the common surname transcription variants (Flynn, Flinn, Flyn, Flynne) in a single search \u2014 don't run separate per-variant queries.\"\n  },\n  \"judge_context\": [\n    \"Should construct one Lucene query that combines required-term (+Patrick) with a wildcard on the surname that ACTUALLY covers all four variants the prompt lists (Flynn, Flinn, Flyn, Flynne). The reference pattern is `+Patrick +Fl?n*` \u2014 `?` matches a single character (covers Flynn/Flinn), and the trailing `*` matches zero-or-more (covers Flyn with no trailing chars AND Flynne with 'ne' trailing)\",\n    \"Should NOT submit a `+Fl?nn` or `+Fl*nn` query as the SINGLE-query answer \u2014 those patterns are 5-or-more chars ending in 'nn' and miss both Flyn (4 chars, single n) and Flynne (ends in 'e'). The judge should note this in scoring: a `Fl?nn`/`Fl*nn`-only answer satisfies the operator-combination demonstration but FAILS the prompt's explicit 'cover all variants in one query' requirement\",\n    \"Should NOT issue one query per spelling variant (`+Patrick +Flynn` then `+Patrick +Flinn` then `+Patrick +Flyn`) \u2014 the prompt explicitly asks for a single wildcard query that covers all variants\",\n    \"The wildcard query should successfully recover the fixture's Hugh Devlin will (1849), which renders the surname as 'Flinn' in the textDocument \u2014 Claude should report this hit as confirmation that the wildcard caught the variant\",\n    \"Should explain why the wildcard works here: FTS does not phonetically expand surnames, so without a wildcard the +Flynn term would miss a 'Flinn' transcription entirely. Bonus: the response should note that `?` is fixed-length while `*` is variable-length, which is why `Fl?n*` is the smallest pattern that covers all four listed variants\"\n  ],\n  \"mcp_fixtures\": [\n    \"fulltext-search-flynn-operator-construction\",\n    \"fulltext-search-flynn-witnesses\",\n    \"fulltext-search-flynn-flinn-variant\"\n  ],\n  \"test\": {\n    \"id\": \"ut_search_full_text_007\",\n    \"skill\": \"search-full-text\",\n    \"type\": \"positive\"\n  }\n}\n",
+    "eval/tests/unit/search-full-text/negative-external-sites.json": "{\n  \"input\": {\n    \"scenario\": \"mid-research-flynn\",\n    \"user_message\": \"Search Newspapers.com and Ancestry for any Flynn family obituaries or news mentions in Schuylkill County, Pennsylvania between 1860 and 1910.\"\n  },\n  \"judge_context\": [\n    \"Should route to search-external-sites \u2014 Newspapers.com and Ancestry are not in FamilySearch's FTS coverage\",\n    \"Should NOT execute a fulltext_search call \u2014 the tool covers FamilySearch's AI-transcribed documents only\",\n    \"Should clearly explain that FTS does not cover the named sites, so the request belongs to a different skill\"\n  ],\n  \"negative\": {\n    \"correct_skill\": [\n      \"search-external-sites\"\n    ],\n    \"explanation\": \"The user is asking to search commercial sites (Newspapers.com, Ancestry) which are outside FamilySearch's full-text index. search-full-text only has access to FamilySearch's fulltext_search MCP tool \u2014 it cannot search external repositories. search-external-sites handles URL construction and capture for those sites.\"\n  },\n  \"test\": {\n    \"id\": \"ut_search_full_text_005\",\n    \"skill\": \"search-full-text\",\n    \"type\": \"negative\"\n  }\n}\n",
+    "eval/tests/unit/search-full-text/negative-record-extraction.json": "{\n  \"input\": {\n    \"scenario\": \"mid-research-flynn\",\n    \"user_message\": \"I have a deed where Patrick Flynn is named as a witness. Extract the relevant assertions.\"\n  },\n  \"judge_context\": [\n    \"Should route to record-extraction rather than re-querying the full-text tool with the deed content\"\n  ],\n  \"negative\": {\n    \"correct_skill\": [\n      \"record-extraction\"\n    ],\n    \"explanation\": \"The user has a record in hand (the deed) and wants assertions extracted from it. search-full-text is for FINDING records that mention a person/term \u2014 once found, extraction is record-extraction's job. The distinction matters because they have different SKILL.md `allowed-tools` and different output shapes.\"\n  },\n  \"test\": {\n    \"id\": \"ut_search_full_text_003\",\n    \"skill\": \"search-full-text\",\n    \"type\": \"negative\"\n  }\n}\n",
+    "eval/tests/unit/search-full-text/negative-research-plan.json": "{\n  \"execution\": {\n    \"max_wall_clock_seconds\": 600\n  },\n  \"input\": {\n    \"scenario\": \"empty-project-just-created\",\n    \"user_message\": \"I'm just starting a project on Patrick Flynn (b. ca. 1845, PA; d. 1908, Schuylkill Co.). Help me figure out the right opening research questions to scope this \u2014 I haven't written any plans or questions yet. Don't run any searches.\"\n  },\n  \"judge_context\": [\n    \"Should route to a planning skill (research-plan OR question-selection) \u2014 the user is asking what to ask and search next, which is planning territory\",\n    \"Should NOT execute a fulltext_search call without a plan item to anchor it\",\n    \"May briefly explain the difference between planning (research-plan / question-selection) and executing a search (search-full-text) if it helps the genealogist understand the routing\"\n  ],\n  \"negative\": {\n    \"correct_skill\": [\n      \"research-plan\",\n      \"question-selection\"\n    ],\n    \"explanation\": \"The user is asking for planning advice (what questions to ask, what to search next), not asking the skill to execute a specific search. On an empty project the right opener is question-selection; once a question exists it's research-plan. Both are acceptable routes here \u2014 what matters is that search-full-text does NOT execute a fulltext_search call without a plan item to anchor it.\"\n  },\n  \"test\": {\n    \"id\": \"ut_search_full_text_006\",\n    \"skill\": \"search-full-text\",\n    \"type\": \"negative\"\n  }\n}\n",
+    "eval/tests/unit/search-full-text/negative-result-with-detail.json": "{\n  \"execution\": {\n    \"max_turns\": 30,\n    \"max_wall_clock_seconds\": 600\n  },\n  \"input\": {\n    \"scenario\": \"mid-research-flynn\",\n    \"user_message\": \"Search for Patrick Flynn as a beneficiary or executor in Schuylkill County probate records \u2014 full-text search.\"\n  },\n  \"judge_context\": [\n    \"Notes on the log entry should describe what collections and date-ranges were covered, not just record that the search ran \u2014 the GPS audit trail needs to know WHAT was searched, not just that nothing came up\",\n    \"Should not fabricate results to fill in a perceived gap \u2014 negative is a legitimate outcome and must be honestly recorded\",\n    \"Should suggest at least one variant query the user could try if they wanted to widen the search (alternative spelling, broader date range, different collection)\",\n    \"FAN awareness \u2014 this is a direct subject search prompt ('Patrick Flynn as beneficiary or executor'), not a FAN exploration request. The dimension passes when the requested direct search executes correctly. The skill is NOT expected to unprompted-expand to FAN, suggest FAN follow-ups, or 'acknowledge missed FAN opportunities' \u2014 do not penalise it for staying focused on the asked subject\"\n  ],\n  \"mcp_fixtures\": [\n    \"fulltext-search-flynn-probate-empty\",\n    \"fulltext-search-flynn-probate-empty-by-name\",\n    \"fulltext-search-flynn-flinn-variant\",\n    \"fulltext-search-flynn-wildcard-variant\"\n  ],\n  \"test\": {\n    \"id\": \"ut_search_full_text_002\",\n    \"skill\": \"search-full-text\",\n    \"type\": \"positive\"\n  }\n}\n",
+    "eval/tests/unit/search-full-text/negative-search-records.json": "{\n  \"input\": {\n    \"scenario\": \"empty-project-just-created\",\n    \"user_message\": \"Search the 1880 US census index for Flynn family members born in Pennsylvania.\"\n  },\n  \"judge_context\": [\n    \"Should route to search-records \u2014 the request is for an indexed search by person attributes (Flynn, Pennsylvania, 1880 census), which is search-records' territory\",\n    \"Should NOT execute a fulltext_search call \u2014 that tool is for free-text search of document transcripts, not for indexed lookups by name and place\",\n    \"May briefly explain the indexed-vs-fulltext distinction (different matching semantics, different result types) if doing so helps the genealogist understand the routing\"\n  ],\n  \"negative\": {\n    \"correct_skill\": [\n      \"search-records\"\n    ],\n    \"explanation\": \"The user's request is an indexed-search by person attributes (name, place, year, record class). search-records handles structured indexed search \u2014 applying fuzzy matching, nickname expansion, and Soundex \u2014 none of which FTS provides. search-full-text searches raw transcript text and does not match the user's task here.\"\n  },\n  \"test\": {\n    \"id\": \"ut_search_full_text_004\",\n    \"skill\": \"search-full-text\",\n    \"type\": \"negative\"\n  }\n}\n",
+    "eval/tests/unit/search-full-text/nlquery-tree-person.json": "{\n  \"input\": {\n    \"scenario\": \"mid-research-flynn\",\n    \"user_message\": \"Run a full-text search for Patrick Flynn using the FamilySearch tree person ID KWCJ-RN4. Use the natural-language entry point so the upstream uses the person's known facts to widen the search.\"\n  },\n  \"judge_context\": [\n    \"Should call fulltext_search with the nlQuery parameter containing the tree person ID 'KWCJ-RN4' \u2014 NOT a keyword query like `+Patrick +Flynn`\",\n    \"Should explain briefly why nlQuery is the right field here (per SKILL.md and references/query-syntax.md, the upstream resolves the tree ID against the person's facts and aliases \u2014 a keyword query would not get that expansion)\",\n    \"Should report the two records the fixture returns (1869 deed transferring land to Patrick Flynn, and the 1885 Cornelius Sheridan estate appraisement on which Patrick Flynn served as appraiser) as new evidence \u2014 both link to Patrick Flynn in non-principal roles and would not have been obvious from a name-only keyword query\"\n  ],\n  \"mcp_fixtures\": [\n    \"fulltext-search-nlquery-tree-person\",\n    \"fulltext-search-flynn-witnesses\"\n  ],\n  \"test\": {\n    \"id\": \"ut_search_full_text_012\",\n    \"skill\": \"search-full-text\",\n    \"type\": \"positive\"\n  }\n}\n",
+    "eval/tests/unit/search-full-text/rubric.md": "# Search Full Text Rubric\n\nGrading dimensions for search-full-text unit tests. Evaluated by the LLM judge alongside the base rubric (correctness, completeness).\n\n## Query construction\n\nDid the skill construct effective full-text search queries using appropriate operators? Queries should use the right operators for FTS (which does not auto-expand abbreviations or apply phonetic matching) and be scoped to plausible jurisdictions where the prompt supplies one.\n\nThis dimension grades the queries the skill *actually executed*, not a wishlist of variants it could have tried. Spelling variants and abbreviation forms (Flinn, Wm, Thos) are valuable but only required when the prompt or initial results signal that a variant is plausible.\n\n- **pass:** Queries use the search engine's operators correctly (phrase quoting, `+`/`-`, `?`/`*` wildcards), are scoped to plausible jurisdictions/collections when supplied, and use the right field (Name vs. Keywords) for the query intent. A canonical-spelling query that returns the expected record is acceptable.\n- **partial:** Queries are effective but mishandle an obvious operator or scoping decision (e.g., use OR-default by omitting `+`, put place in the query field instead of using filters), OR the prompt explicitly suggests a variant is needed and the skill omits it.\n- **fail:** Queries are bare strings with no operators; the genealogist would have to re-search from scratch to get useful coverage.\n\n## FAN awareness\n\nDid the skill look for Family, Associates, and Neighbors when the prompt or research state warranted it? Witness signatures, neighbor listings, and business associates can provide indirect evidence. **For direct subject searches the skill is not required to pivot to FAN unprompted \u2014 grade pass if the requested search executes correctly.**\n\n- **pass:** Either (a) at least one query targets FAN persons with a rationale, OR (b) the prompt is a direct subject search (\"find X as beneficiary in Y\", \"search for X in record class Z\") \u2014 in case (b), the dimension passes solely on whether the requested search executed; the skill is NOT expected to unprompted-expand to FAN, acknowledge \"missed FAN opportunities\", or suggest follow-up FAN searches. Judges must not score partial on the grounds that the skill could have but did not pivot to FAN.\n- **partial:** Prompt or research state called for FAN exploration but the FAN query is too broad or its rationale missing.\n- **fail:** Prompt or research state clearly called for FAN, and the skill produced no FAN query and no acknowledgement of FAN evidence.\n\n## Negative result handling\n\nDid the skill log negative results with enough detail to support exhaustiveness claims? \"No results\" is different from \"searched X, Y, Z collections with queries A, B, C \u2014 no results.\"\n\n**When every executed search returned positive results, this dimension has nothing to grade \u2014 score `pass`. Judges must NOT score partial on the grounds that the skill's exhaustiveness narrative for a positive-result test could have been more explicit; the dimension only fires when at least one search returned zero results.**\n\n- **pass:** Either (a) all executed searches returned results (nothing to grade), OR (b) the negative log entries capture the collections searched, the queries used, and what was examined (e.g., \"0 results for 'Flynn' in the 1900 census Pennsylvania state-wide index, plus a 100-result browse of Schuylkill County images\").\n- **partial:** At least one search returned zero results AND the negative entry captures the query but not the breadth of the search (no mention of how many results were examined, or which collections were skipped).\n- **fail:** At least one search returned zero results AND the negative entry is bare (\"nothing found\") with no detail that would support a future exhaustive-search declaration.\n",
+    "eval/tests/unit/search-full-text/search-for-flynn-witnesses.json": "{\n  \"execution\": {\n    \"max_wall_clock_seconds\": 600\n  },\n  \"input\": {\n    \"scenario\": \"mid-research-flynn\",\n    \"user_message\": \"Run separate full-text searches for Thomas Flynn AND for Patrick Flynn appearing as witnesses in Schuylkill County records \u2014 both names must be queried.\"\n  },\n  \"judge_context\": [\n    \"Should construct a full-text query targeting Flynn family names in witness/associate contexts \u2014 typically requires phrase quoting or proximity operators since 'Flynn' as a witness appears in others' records rather than the family's own\",\n    \"The canonical-spelling queries ('Thomas Flynn', 'Patrick Flynn') are sufficient when they return results. Per rubric Query construction: this dimension grades queries the skill ACTUALLY EXECUTED, not a wishlist \u2014 variants like 'Flynne'/'Phlynn'/'Thos' are valuable but NOT required when the canonical query already recovers the record. Judges MUST NOT score partial on the grounds that variants could have been tried proactively.\",\n    \"Should report the fixture's results as FAN evidence rather than as direct subject evidence \u2014 the value is in establishing community networks, not in confirming Patrick's birth or parentage directly\"\n  ],\n  \"mcp_fixtures\": [\n    \"fulltext-search-flynn-witnesses\",\n    \"fulltext-search-flynn-witnesses-by-name\",\n    \"fulltext-search-flynn-flinn-variant\",\n    \"fulltext-search-flynn-wildcard-variant\"\n  ],\n  \"test\": {\n    \"id\": \"ut_search_full_text_001\",\n    \"skill\": \"search-full-text\",\n    \"type\": \"positive\"\n  }\n}\n",
+    "eval/tests/unit/search-full-text/transcription-quirk-variant.json": "{\n  \"input\": {\n    \"scenario\": \"mid-research-flynn\",\n    \"user_message\": \"I have seen Schuylkill County 1870s land records where the AI transcript rendered the surname Flynn as 'Flunn' \u2014 the cursive 'y' misread as 'u'. Run a full-text search whose keywords field contains the literal string '+Flunn' (the misread form as a required term). Do not use a wildcard query \u2014 use the literal 'Flunn' spelling so the underlying tool matches exactly that variant.\"\n  },\n  \"judge_context\": [\n    \"Should issue at least one fulltext_search query whose keywords contain 'Flunn' explicitly (e.g. `+Flunn`, `+Patrick +Flunn`, or `+Flunn +Schuylkill`) \u2014 covering the OCR misread the prompt named\",\n    \"Should successfully recover the fixture's 1872 Owen Boyle \u2192 Edward McNally deed, which renders the Flynn surname as 'Flunn' in the textDocument and would never surface from a canonical `+Flynn` query\",\n    \"Should briefly explain why the misread form is needed \u2014 FTS does not phonetically or visually expand surnames, so the genealogist has to include the OCR variants in the query themselves\",\n    \"Should not silently substitute the canonical spelling; the variant query must appear in the executed search\"\n  ],\n  \"mcp_fixtures\": [\n    \"fulltext-search-flynn-flunn-ocr\",\n    \"fulltext-search-flynn-witnesses\",\n    \"fulltext-search-flynn-flinn-variant\",\n    \"fulltext-search-flynn-wildcard-variant\"\n  ],\n  \"test\": {\n    \"id\": \"ut_search_full_text_008\",\n    \"skill\": \"search-full-text\",\n    \"type\": \"positive\"\n  }\n}\n",
+    "eval/tests/unit/search-full-text/write-result-sidecar.json": "{\n  \"input\": {\n    \"scenario\": \"flynn-record-matching\",\n    \"user_message\": \"Run a full-text search of FamilySearch for any document naming Flynn as a witness in Schuylkill County, Pennsylvania.\"\n  },\n  \"judge_context\": [\n    \"The new log entry must carry a non-null results_ref pointing at results/<log_id>.json, and a results/<log_id>.json sidecar must be written containing the verbatim fulltext_search response\",\n    \"The sidecar's returned_count must equal the number of results in its payload\",\n    \"results_available should reflect the upstream totalResults count, and notes should be a one-line human summary of what the search returned\",\n    \"Tool-arguments grading note: the fixture's `args` predicate is a SUBSTRING MATCH (`~Flynn`), not a literal equality. The judge MUST grade Tool Arguments / Query construction on the actual args the skill sent (visible in the call log), not infer from the predicate that 'witness' or any other co-required term was dropped. A call with `keywords: '+Flynn +witness'` matches a `~Flynn` predicate AND retains the witness term \u2014 these are not in conflict.\"\n  ],\n  \"mcp_fixtures\": [\n    \"fulltext-search-flynn-witnesses\",\n    \"fulltext-search-flynn-flinn-variant\"\n  ],\n  \"test\": {\n    \"id\": \"ut_search_full_text_010\",\n    \"skill\": \"search-full-text\",\n    \"type\": \"positive\"\n  }\n}\n",
+    "eval/fixtures/scenarios/empty-project-just-created/README.md": "# empty-project-just-created\n\nProject state immediately after `init-project` runs successfully: the objective is captured, a stub person exists in `tree.gedcomx.json`, but no research work has been done yet.\n\n- **Objective:** Identify the parents of Patrick Flynn (b. ~1845, d. 1908)\n- **Questions:** none\n- **Plans:** none\n- **Log:** empty\n- **Sources:** none\n- **Assertions:** none\n- **GedcomX persons:** I1 (Patrick Flynn \u2014 stub, name only, no facts)\n- **GedcomX relationships:** none\n- **GedcomX sources:** none\n\n## Used by\n\n- `question-selection` tests where the skill must derive a first research question from the objective rather than choose from an existing question list.\n- `research-plan` tests where the skill must produce a plan for a question that has no prior search log.\n- Any skill whose behavior on a freshly-initialized project differs from mid-research behavior.\n\n## What this scenario tests boundary-wise\n\nA skill given this scenario should not pretend prior research exists. If it tries to read assertions, sources, or the log and they're empty, the right behavior is to reason from the objective + stub person alone, or to politely decline if it requires data that doesn't exist yet.\n",
+    "eval/fixtures/scenarios/empty-project-just-created/research.json": "{\n  \"assertions\": [],\n  \"conflicts\": [],\n  \"evaluations\": [],\n  \"hypotheses\": [],\n  \"log\": [],\n  \"person_evidence\": [],\n  \"plans\": [],\n  \"project\": {\n    \"created\": \"2026-05-13\",\n    \"id\": \"rp_001\",\n    \"objective\": \"Identify the parents of Patrick Flynn, born ca. 1845 in Pennsylvania, died 1908 in Schuylkill County, PA\",\n    \"status\": \"active\",\n    \"subject_person_ids\": [\n      \"I1\"\n    ],\n    \"updated\": \"2026-05-13\"\n  },\n  \"proof_summaries\": [],\n  \"questions\": [],\n  \"sources\": [],\n  \"timelines\": []\n}\n",
+    "eval/fixtures/scenarios/empty-project-just-created/tree.gedcomx.json": "{\n  \"persons\": [\n    {\n      \"gender\": \"Male\",\n      \"id\": \"I1\",\n      \"names\": [\n        {\n          \"given\": \"Patrick\",\n          \"id\": \"N1\",\n          \"preferred\": true,\n          \"surname\": \"Flynn\"\n        }\n      ]\n    }\n  ],\n  \"relationships\": [],\n  \"sources\": []\n}\n",
+    "eval/fixtures/scenarios/flynn-record-matching/README.md": "# Scenario: flynn-record-matching\n\nA mid-research project for Patrick Flynn's parentage, in the state **after\ncandidate records have been gathered but before identity resolution**.\nBuilt for the research-log result-retention eval cases \u2014 it exercises the\n`results/` sidecar files and the `same_person` wiring.\n\n## State\n\n- **Subject:** Patrick Flynn (`I1`), b. ~1845 Ireland, Schuylkill County, PA.\n  The tree also holds candidate parents Thomas (`I2`) and Mary (`I3`) Flynn.\n- **Four gathered records**, each with a `results/<log_id>.json` sidecar:\n  - `log_001` \u2014 clean 1850-census match (`MXHY-TP4`): Patrick Flynn age 5 in\n    Thomas Flynn's household. Strong on every identifier.\n  - `log_002` \u2014 conflict record (`CFLT-9K2`): a \"Patrick Flynn\" whose\n    birthplace is recorded as **Germany**, contradicting the Ireland\n    birthplace in every other source.\n  - `log_003` \u2014 variant record (`VRNT-7M3`): \"Patrick **Flinn**\" \u2014 a\n    transcription-variant surname \u2014 age 5 in 1850, Schuylkill, in Thomas\n    Flinn's household. Strong on every identifier *except* the spelling.\n  - `log_004` \u2014 full-text probate hit (`FTXT-Q88`): a will of Thomas Flynn\n    naming \"my son Patrick Flynn\". No structured GedcomX persona.\n- **Four unlinked assertions** (`a_001`\u2013`a_004`), no `person_evidence` yet.\n  `a_001`/`a_002`/`a_003` carry `record_persona_id` (`P1`/`CP1`/`VP1`);\n  `a_004` (full-text) has `record_persona_id: null`.\n\n## What it exercises\n\n- person-evidence resolving an assertion through its sidecar and scoring the\n  match with `same_person` \u2014 including the score-as-input threshold\n  policy: a high score must not auto-link past the `log_002` birthplace\n  conflict, and the low score on the `log_003` variant must not dismiss a\n  strong qualitative match.\n- The full-text path (`a_004`): no `record_persona_id`, so no score \u2014\n  correlation analysis alone.\n- search-records / search-full-text writing fresh sidecars against the open\n  plan items `pli_001` / `pli_002`.\n",
+    "eval/fixtures/scenarios/flynn-record-matching/research.json": "{\n  \"assertions\": [\n    {\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"name\",\n      \"id\": \"a_001\",\n      \"informant\": \"Unknown informant (most likely a household member, possibly a neighbor) reporting to the census enumerator\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_001\",\n      \"record_id\": \"https://www.familysearch.org/ark:/61903/1:1:MXHY-TP4\",\n      \"record_persona_id\": \"P1\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_001\",\n      \"structured_value\": {\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"value\": \"Patrick Flynn\"\n    },\n    {\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"name\",\n      \"id\": \"a_002\",\n      \"informant\": \"Officiating minister\",\n      \"informant_proximity\": \"official_duty\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_002\",\n      \"record_id\": \"https://www.familysearch.org/ark:/61903/1:1:CFLT-9K2\",\n      \"record_persona_id\": \"CP1\",\n      \"record_role\": \"principal\",\n      \"source_id\": \"src_002\",\n      \"structured_value\": {\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"value\": \"Patrick Flynn\"\n    },\n    {\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"name\",\n      \"id\": \"a_003\",\n      \"informant\": \"Unknown informant (most likely a household member, possibly a neighbor) reporting to the census enumerator\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_003\",\n      \"record_id\": \"https://www.familysearch.org/ark:/61903/1:1:VRNT-7M3\",\n      \"record_persona_id\": \"VP1\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_003\",\n      \"structured_value\": {\n        \"given\": \"Patrick\",\n        \"surname\": \"Flinn\"\n      },\n      \"value\": \"Patrick Flinn\"\n    },\n    {\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"relationship\",\n      \"id\": \"a_004\",\n      \"informant\": \"Thomas Flynn (testator)\",\n      \"informant_proximity\": \"household_member\",\n      \"information_quality\": \"primary\",\n      \"log_entry_id\": \"log_004\",\n      \"record_id\": \"https://www.familysearch.org/ark:/61903/1:1:FTXT-Q88\",\n      \"record_persona_id\": null,\n      \"record_role\": \"heir_1\",\n      \"source_id\": \"src_004\",\n      \"structured_value\": {\n        \"related_person_role\": \"testator\",\n        \"relationship_type\": \"son\"\n      },\n      \"value\": \"Named as 'my son Patrick Flynn' in the will of Thomas Flynn\"\n    }\n  ],\n  \"conflicts\": [],\n  \"evaluations\": [],\n  \"hypotheses\": [],\n  \"log\": [\n    {\n      \"external_site\": null,\n      \"id\": \"log_001\",\n      \"notes\": \"1850 census household of Thomas Flynn; Patrick Flynn age 5, born Ireland. Clean candidate match.\",\n      \"outcome\": \"positive\",\n      \"performed\": \"2026-05-04T10:00:00Z\",\n      \"plan_item_id\": \"pli_001\",\n      \"query\": {\n        \"collection\": \"1850 Census\",\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"results_available\": 1,\n      \"results_examined\": 1,\n      \"results_ref\": \"results/log_001.json\",\n      \"tool\": \"record_search\"\n    },\n    {\n      \"external_site\": null,\n      \"id\": \"log_002\",\n      \"notes\": \"A Patrick Flynn baptism \u2014 name and county align, but the record gives the birthplace as Germany, conflicting with all other evidence (Ireland).\",\n      \"outcome\": \"positive\",\n      \"performed\": \"2026-05-04T10:10:00Z\",\n      \"plan_item_id\": \"pli_001\",\n      \"query\": {\n        \"collection\": \"Church records\",\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"results_examined\": 1,\n      \"results_ref\": \"results/log_002.json\",\n      \"tool\": \"record_search\"\n    },\n    {\n      \"external_site\": null,\n      \"id\": \"log_003\",\n      \"notes\": \"1850 census household of Thomas Flinn; Patrick Flinn age 5, born Ireland. Surname indexed as 'Flinn' \u2014 a likely transcription variant of Flynn.\",\n      \"outcome\": \"positive\",\n      \"performed\": \"2026-05-04T10:20:00Z\",\n      \"plan_item_id\": \"pli_001\",\n      \"query\": {\n        \"collection\": \"1850 Census\",\n        \"given\": \"Patrick\",\n        \"surname\": \"~Fl\"\n      },\n      \"results_available\": 1,\n      \"results_examined\": 1,\n      \"results_ref\": \"results/log_003.json\",\n      \"tool\": \"record_search\"\n    },\n    {\n      \"external_site\": null,\n      \"id\": \"log_004\",\n      \"notes\": \"Full-text probate hit \u2014 a will of Thomas Flynn bequeathing to 'my son Patrick Flynn'.\",\n      \"outcome\": \"positive\",\n      \"performed\": \"2026-05-04T10:30:00Z\",\n      \"plan_item_id\": \"pli_002\",\n      \"query\": {\n        \"keywords\": \"+Flynn +son\",\n        \"recordPlace2\": \"Schuylkill\"\n      },\n      \"results_available\": 1,\n      \"results_examined\": 1,\n      \"results_ref\": \"results/log_004.json\",\n      \"tool\": \"fulltext_search\"\n    }\n  ],\n  \"person_evidence\": [],\n  \"plans\": [\n    {\n      \"created\": \"2026-05-04\",\n      \"id\": \"pl_001\",\n      \"items\": [\n        {\n          \"date_range\": \"1850\",\n          \"fallback_for\": null,\n          \"id\": \"pli_001\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"The 1850 census places Patrick in a household, identifying candidate parents.\",\n          \"record_type\": \"census\",\n          \"repository\": \"FamilySearch\",\n          \"sequence\": 1,\n          \"status\": \"in_progress\"\n        },\n        {\n          \"date_range\": \"1860-1890\",\n          \"fallback_for\": null,\n          \"id\": \"pli_002\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"Full-text search of probate records for a will naming Patrick as a son.\",\n          \"record_type\": \"probate\",\n          \"repository\": \"FamilySearch\",\n          \"sequence\": 2,\n          \"status\": \"in_progress\"\n        }\n      ],\n      \"question_id\": \"q_001\",\n      \"status\": \"active\"\n    }\n  ],\n  \"project\": {\n    \"created\": \"2026-05-04\",\n    \"id\": \"rp_001\",\n    \"objective\": \"Identify the parents of Patrick Flynn (b. ~1845, Ireland; resident Schuylkill County, Pennsylvania) \u2014 candidate records gathered, identity resolution pending\",\n    \"status\": \"active\",\n    \"subject_person_ids\": [\n      \"I1\"\n    ],\n    \"updated\": \"2026-05-04\"\n  },\n  \"proof_summaries\": [],\n  \"questions\": [\n    {\n      \"created\": \"2026-05-04\",\n      \"depends_on\": [],\n      \"exhaustive_declaration\": {\n        \"declared\": false,\n        \"justification\": null,\n        \"log_entry_ids\": [],\n        \"stop_criteria\": null\n      },\n      \"id\": \"q_001\",\n      \"priority\": \"high\",\n      \"question\": \"Who were the parents of Patrick Flynn (b. ~1845)?\",\n      \"rationale\": \"Primary research objective. Candidate records have been gathered; person-evidence must now resolve which record personas are the subject.\",\n      \"resolution_assertion_ids\": [],\n      \"resolved\": null,\n      \"selection_basis\": \"objective_decomposition\",\n      \"status\": \"in_progress\",\n      \"unblocks\": []\n    }\n  ],\n  \"sources\": [\n    {\n      \"access_date\": \"2026-05-04\",\n      \"citation\": \"1850 U.S. Census, Schuylkill County, Pennsylvania, population schedule, Branch Township, Thomas Flynn household; digital image, FamilySearch.org, accessed 4 May 2026.\",\n      \"citation_detail\": {\n        \"what\": \"1850 U.S. Federal Census, population schedule\",\n        \"when_accessed\": \"2026-05-04\",\n        \"when_created\": \"1850\",\n        \"where\": \"FamilySearch.org\",\n        \"where_within\": \"Branch Township, Schuylkill County, Thomas Flynn household\",\n        \"who\": \"U.S. Census Bureau\"\n      },\n      \"gedcomx_source_description_id\": \"S1\",\n      \"id\": \"src_001\",\n      \"log_entry_id\": \"log_001\",\n      \"notes\": null,\n      \"repository\": \"FamilySearch\",\n      \"source_classification\": \"original\",\n      \"transcription\": null,\n      \"url\": \"https://www.familysearch.org/ark:/61903/1:1:MXHY-TP4\",\n      \"url_archived\": null\n    },\n    {\n      \"access_date\": \"2026-05-04\",\n      \"citation\": \"Patrick Flynn baptism, Pennsylvania church and town records; digital image, FamilySearch.org, accessed 4 May 2026.\",\n      \"citation_detail\": {\n        \"what\": \"Baptism register entry\",\n        \"when_accessed\": \"2026-05-04\",\n        \"when_created\": \"1845\",\n        \"where\": \"FamilySearch.org\",\n        \"where_within\": \"Patrick Flynn baptism entry\",\n        \"who\": \"Officiating minister\"\n      },\n      \"gedcomx_source_description_id\": \"S2\",\n      \"id\": \"src_002\",\n      \"log_entry_id\": \"log_002\",\n      \"notes\": \"Birthplace recorded as Germany \u2014 conflicts with the Ireland birthplace in every census record for the subject.\",\n      \"repository\": \"FamilySearch\",\n      \"source_classification\": \"original\",\n      \"transcription\": null,\n      \"url\": \"https://www.familysearch.org/ark:/61903/1:1:CFLT-9K2\",\n      \"url_archived\": null\n    },\n    {\n      \"access_date\": \"2026-05-04\",\n      \"citation\": \"1850 U.S. Census, Schuylkill County, Pennsylvania, population schedule, Branch Township, Thomas Flinn household; digital image, FamilySearch.org, accessed 4 May 2026.\",\n      \"citation_detail\": {\n        \"what\": \"1850 U.S. Federal Census, population schedule\",\n        \"when_accessed\": \"2026-05-04\",\n        \"when_created\": \"1850\",\n        \"where\": \"FamilySearch.org\",\n        \"where_within\": \"Branch Township, Schuylkill County, Thomas Flinn household\",\n        \"who\": \"U.S. Census Bureau\"\n      },\n      \"gedcomx_source_description_id\": \"S3\",\n      \"id\": \"src_003\",\n      \"log_entry_id\": \"log_003\",\n      \"notes\": \"Surname indexed as 'Flinn'; likely a transcription variant of Flynn.\",\n      \"repository\": \"FamilySearch\",\n      \"source_classification\": \"original\",\n      \"transcription\": null,\n      \"url\": \"https://www.familysearch.org/ark:/61903/1:1:VRNT-7M3\",\n      \"url_archived\": null\n    },\n    {\n      \"access_date\": \"2026-05-04\",\n      \"citation\": \"Will of Thomas Flynn, Schuylkill County, Pennsylvania probate records; full-text image, FamilySearch.org, accessed 4 May 2026.\",\n      \"citation_detail\": {\n        \"what\": \"Last will and testament\",\n        \"when_accessed\": \"2026-05-04\",\n        \"when_created\": \"1871\",\n        \"where\": \"FamilySearch.org\",\n        \"where_within\": \"Will of Thomas Flynn\",\n        \"who\": \"Thomas Flynn (testator)\"\n      },\n      \"gedcomx_source_description_id\": \"S4\",\n      \"id\": \"src_004\",\n      \"log_entry_id\": \"log_004\",\n      \"notes\": \"Full-text search hit; the snippet names Patrick as a son but carries no structured GedcomX persona.\",\n      \"repository\": \"FamilySearch\",\n      \"source_classification\": \"original\",\n      \"transcription\": null,\n      \"url\": \"https://www.familysearch.org/ark:/61903/1:1:FTXT-Q88\",\n      \"url_archived\": null\n    }\n  ],\n  \"timelines\": []\n}\n",
+    "eval/fixtures/scenarios/flynn-record-matching/results/log_001.json": "{\n  \"log_id\": \"log_001\",\n  \"payload\": {\n    \"hasMore\": false,\n    \"offset\": 0,\n    \"paginationCappedAt\": 100,\n    \"query\": {\n      \"givenName\": \"Patrick\",\n      \"surname\": \"Flynn\"\n    },\n    \"results\": [\n      {\n        \"arkUrl\": \"https://www.familysearch.org/ark:/61903/1:1:MXHY-TP4\",\n        \"birthDate\": \"1845\",\n        \"birthPlace\": \"Ireland\",\n        \"collectionId\": \"1401638\",\n        \"collectionTitle\": \"United States Census, 1850\",\n        \"events\": [],\n        \"gedcomx\": {\n          \"persons\": [\n            {\n              \"facts\": [\n                {\n                  \"date\": \"1845\",\n                  \"id\": \"F1\",\n                  \"place\": \"Ireland\",\n                  \"type\": \"Birth\"\n                },\n                {\n                  \"date\": \"1850\",\n                  \"id\": \"F2\",\n                  \"place\": \"Branch Township, Schuylkill, Pennsylvania, United States\",\n                  \"type\": \"Residence\"\n                }\n              ],\n              \"gender\": \"Male\",\n              \"id\": \"P1\",\n              \"names\": [\n                {\n                  \"given\": \"Patrick\",\n                  \"id\": \"N1\",\n                  \"preferred\": true,\n                  \"surname\": \"Flynn\",\n                  \"type\": \"BirthName\"\n                }\n              ]\n            },\n            {\n              \"facts\": [\n                {\n                  \"date\": \"1850\",\n                  \"id\": \"F3\",\n                  \"place\": \"Branch Township, Schuylkill, Pennsylvania, United States\",\n                  \"type\": \"Residence\"\n                }\n              ],\n              \"gender\": \"Male\",\n              \"id\": \"P2\",\n              \"names\": [\n                {\n                  \"given\": \"Thomas\",\n                  \"id\": \"N2\",\n                  \"preferred\": true,\n                  \"surname\": \"Flynn\",\n                  \"type\": \"BirthName\"\n                }\n              ]\n            },\n            {\n              \"facts\": [\n                {\n                  \"date\": \"1850\",\n                  \"id\": \"F4\",\n                  \"place\": \"Branch Township, Schuylkill, Pennsylvania, United States\",\n                  \"type\": \"Residence\"\n                }\n              ],\n              \"gender\": \"Female\",\n              \"id\": \"P3\",\n              \"names\": [\n                {\n                  \"given\": \"Mary\",\n                  \"id\": \"N3\",\n                  \"preferred\": true,\n                  \"surname\": \"Flynn\",\n                  \"type\": \"BirthName\"\n                }\n              ]\n            }\n          ],\n          \"relationships\": [\n            {\n              \"child\": \"P1\",\n              \"id\": \"R1\",\n              \"parent\": \"P2\",\n              \"type\": \"ParentChild\"\n            },\n            {\n              \"child\": \"P1\",\n              \"id\": \"R2\",\n              \"parent\": \"P3\",\n              \"type\": \"ParentChild\"\n            },\n            {\n              \"id\": \"R3\",\n              \"person1\": \"P2\",\n              \"person2\": \"P3\",\n              \"type\": \"Couple\"\n            }\n          ]\n        },\n        \"personId\": \"MXHY-TP4\",\n        \"personName\": \"Patrick Flynn\",\n        \"primaryId\": \"P1\",\n        \"recordId\": \"https://www.familysearch.org/ark:/61903/1:1:MXHY-TP4\",\n        \"recordTitle\": \"Patrick Flynn in household of Thomas Flynn\",\n        \"score\": 0.95,\n        \"sex\": \"Male\",\n        \"treeMatches\": []\n      }\n    ],\n    \"returned\": 1,\n    \"totalMatches\": 1\n  },\n  \"retrieved\": \"2026-05-04T10:00:00Z\",\n  \"returned_count\": 1,\n  \"tool\": \"record_search\"\n}\n",
+    "eval/fixtures/scenarios/flynn-record-matching/results/log_002.json": "{\n  \"log_id\": \"log_002\",\n  \"payload\": {\n    \"hasMore\": false,\n    \"offset\": 0,\n    \"paginationCappedAt\": 100,\n    \"query\": {\n      \"givenName\": \"Patrick\",\n      \"surname\": \"Flynn\"\n    },\n    \"results\": [\n      {\n        \"arkUrl\": \"https://www.familysearch.org/ark:/61903/1:1:CFLT-9K2\",\n        \"birthDate\": \"1845\",\n        \"birthPlace\": \"Germany\",\n        \"collectionId\": \"1488411\",\n        \"collectionTitle\": \"Pennsylvania, Church and Town Records\",\n        \"events\": [],\n        \"gedcomx\": {\n          \"persons\": [\n            {\n              \"facts\": [\n                {\n                  \"date\": \"1845\",\n                  \"id\": \"CF1\",\n                  \"place\": \"Germany\",\n                  \"type\": \"Birth\"\n                },\n                {\n                  \"date\": \"1850\",\n                  \"id\": \"CF2\",\n                  \"place\": \"Branch Township, Schuylkill, Pennsylvania, United States\",\n                  \"type\": \"Residence\"\n                }\n              ],\n              \"gender\": \"Male\",\n              \"id\": \"CP1\",\n              \"names\": [\n                {\n                  \"given\": \"Patrick\",\n                  \"id\": \"CN1\",\n                  \"preferred\": true,\n                  \"surname\": \"Flynn\",\n                  \"type\": \"BirthName\"\n                }\n              ]\n            }\n          ]\n        },\n        \"personId\": \"CFLT-9K2\",\n        \"personName\": \"Patrick Flynn\",\n        \"primaryId\": \"CP1\",\n        \"recordId\": \"https://www.familysearch.org/ark:/61903/1:1:CFLT-9K2\",\n        \"recordTitle\": \"Patrick Flynn, baptism\",\n        \"score\": 0.71,\n        \"sex\": \"Male\",\n        \"treeMatches\": []\n      }\n    ],\n    \"returned\": 1,\n    \"totalMatches\": 1\n  },\n  \"retrieved\": \"2026-05-04T10:10:00Z\",\n  \"returned_count\": 1,\n  \"tool\": \"record_search\"\n}\n",
+    "eval/fixtures/scenarios/flynn-record-matching/results/log_003.json": "{\n  \"log_id\": \"log_003\",\n  \"payload\": {\n    \"hasMore\": false,\n    \"offset\": 0,\n    \"paginationCappedAt\": 100,\n    \"query\": {\n      \"givenName\": \"Patrick\",\n      \"surname\": \"~Fl\"\n    },\n    \"results\": [\n      {\n        \"arkUrl\": \"https://www.familysearch.org/ark:/61903/1:1:VRNT-7M3\",\n        \"birthDate\": \"1845\",\n        \"birthPlace\": \"Ireland\",\n        \"collectionId\": \"1401638\",\n        \"collectionTitle\": \"United States Census, 1850\",\n        \"events\": [],\n        \"gedcomx\": {\n          \"persons\": [\n            {\n              \"facts\": [\n                {\n                  \"date\": \"1845\",\n                  \"id\": \"VF1\",\n                  \"place\": \"Ireland\",\n                  \"type\": \"Birth\"\n                },\n                {\n                  \"date\": \"1850\",\n                  \"id\": \"VF2\",\n                  \"place\": \"Branch Township, Schuylkill, Pennsylvania, United States\",\n                  \"type\": \"Residence\"\n                }\n              ],\n              \"gender\": \"Male\",\n              \"id\": \"VP1\",\n              \"names\": [\n                {\n                  \"given\": \"Patrick\",\n                  \"id\": \"VN1\",\n                  \"preferred\": true,\n                  \"surname\": \"Flinn\",\n                  \"type\": \"BirthName\"\n                }\n              ]\n            },\n            {\n              \"facts\": [\n                {\n                  \"date\": \"1850\",\n                  \"id\": \"VF3\",\n                  \"place\": \"Branch Township, Schuylkill, Pennsylvania, United States\",\n                  \"type\": \"Residence\"\n                }\n              ],\n              \"gender\": \"Male\",\n              \"id\": \"VP2\",\n              \"names\": [\n                {\n                  \"given\": \"Thomas\",\n                  \"id\": \"VN2\",\n                  \"preferred\": true,\n                  \"surname\": \"Flinn\",\n                  \"type\": \"BirthName\"\n                }\n              ]\n            }\n          ],\n          \"relationships\": [\n            {\n              \"child\": \"VP1\",\n              \"id\": \"VR1\",\n              \"parent\": \"VP2\",\n              \"type\": \"ParentChild\"\n            }\n          ]\n        },\n        \"personId\": \"VRNT-7M3\",\n        \"personName\": \"Patrick Flinn\",\n        \"primaryId\": \"VP1\",\n        \"recordId\": \"https://www.familysearch.org/ark:/61903/1:1:VRNT-7M3\",\n        \"recordTitle\": \"Patrick Flinn in household of Thomas Flinn\",\n        \"score\": 0.66,\n        \"sex\": \"Male\",\n        \"treeMatches\": []\n      }\n    ],\n    \"returned\": 1,\n    \"totalMatches\": 1\n  },\n  \"retrieved\": \"2026-05-04T10:20:00Z\",\n  \"returned_count\": 1,\n  \"tool\": \"record_search\"\n}\n",
+    "eval/fixtures/scenarios/flynn-record-matching/results/log_004.json": "{\n  \"log_id\": \"log_004\",\n  \"payload\": {\n    \"hasMore\": false,\n    \"offset\": 0,\n    \"results\": [\n      {\n        \"collectionTitle\": \"Pennsylvania, Probate Records\",\n        \"highlightTerms\": [\n          \"Flynn\",\n          \"son\"\n        ],\n        \"id\": \"https://www.familysearch.org/ark:/61903/1:1:FTXT-Q88\",\n        \"names\": [\n          \"Thomas Flynn\",\n          \"Patrick Flynn\"\n        ],\n        \"places\": [\n          \"Branch Township\",\n          \"Schuylkill County\"\n        ],\n        \"recordPlace\": \"Schuylkill, Pennsylvania, United States\",\n        \"recordType\": \"Wills and Probate\",\n        \"textDocument\": \"...the said Thomas Flynn, of Branch Township, doth give and bequeath unto my son Patrick Flynn the sum of one hundred dollars, to be paid within one year of my decease...\"\n      }\n    ],\n    \"returned\": 1,\n    \"totalResults\": 1\n  },\n  \"retrieved\": \"2026-05-04T10:30:00Z\",\n  \"returned_count\": 1,\n  \"tool\": \"fulltext_search\"\n}\n",
+    "eval/fixtures/scenarios/flynn-record-matching/tree.gedcomx.json": "{\n  \"persons\": [\n    {\n      \"facts\": [\n        {\n          \"date\": \"~1845\",\n          \"id\": \"F1\",\n          \"place\": \"Ireland\",\n          \"type\": \"Birth\"\n        }\n      ],\n      \"gender\": \"Male\",\n      \"id\": \"I1\",\n      \"names\": [\n        {\n          \"given\": \"Patrick\",\n          \"id\": \"N1\",\n          \"preferred\": true,\n          \"surname\": \"Flynn\",\n          \"type\": \"BirthName\"\n        }\n      ]\n    },\n    {\n      \"facts\": [\n        {\n          \"date\": \"~1818\",\n          \"id\": \"F2\",\n          \"place\": \"Ireland\",\n          \"type\": \"Birth\"\n        }\n      ],\n      \"gender\": \"Male\",\n      \"id\": \"I2\",\n      \"names\": [\n        {\n          \"given\": \"Thomas\",\n          \"id\": \"N2\",\n          \"preferred\": true,\n          \"surname\": \"Flynn\",\n          \"type\": \"BirthName\"\n        }\n      ]\n    },\n    {\n      \"gender\": \"Female\",\n      \"id\": \"I3\",\n      \"names\": [\n        {\n          \"given\": \"Mary\",\n          \"id\": \"N3\",\n          \"preferred\": true,\n          \"surname\": \"Flynn\",\n          \"type\": \"BirthName\"\n        }\n      ]\n    }\n  ],\n  \"relationships\": [\n    {\n      \"child\": \"I1\",\n      \"id\": \"RT1\",\n      \"parent\": \"I2\",\n      \"type\": \"ParentChild\"\n    },\n    {\n      \"child\": \"I1\",\n      \"id\": \"RT2\",\n      \"parent\": \"I3\",\n      \"type\": \"ParentChild\"\n    },\n    {\n      \"id\": \"RT3\",\n      \"person1\": \"I2\",\n      \"person2\": \"I3\",\n      \"type\": \"Couple\"\n    }\n  ],\n  \"sources\": [\n    {\n      \"id\": \"S1\",\n      \"title\": \"1850 U.S. Census, Schuylkill County, Pennsylvania \u2014 Thomas Flynn household\"\n    },\n    {\n      \"id\": \"S2\",\n      \"title\": \"Pennsylvania church and town records \u2014 Patrick Flynn baptism\"\n    },\n    {\n      \"id\": \"S3\",\n      \"title\": \"1850 U.S. Census, Schuylkill County, Pennsylvania \u2014 Thomas Flinn household\"\n    },\n    {\n      \"id\": \"S4\",\n      \"title\": \"Schuylkill County, Pennsylvania probate records\"\n    }\n  ]\n}\n",
+    "eval/fixtures/scenarios/mid-research-flynn/README.md": "# mid-research-flynn\n\nPatrick Flynn parentage research, mid-project.\n\n- **Objective:** Identify the parents of Patrick Flynn (b. ~1845, d. 1908)\n- **Questions:** q_001 (parentage, in_progress), q_002 (1850 census placement, resolved)\n- **Plans:** pl_001 (1850 census search, completed), pl_002 (parentage evidence, active)\n- **Log:** 5 entries \u2014 1850 census on FamilySearch/Ancestry/MyHeritage, 1860 census, death cert\n- **Sources:** 4 sources (1850 census FS, 1850 census Ancestry, 1860 census, death cert)\n- **Assertions:** 13 assertions across 4 sources\n- **Person evidence:** 6 links (Patrick \u2192 I1, Thomas \u2192 I2)\n- **Conflicts:** 1 resolved (birthplace: Ireland vs Pennsylvania)\n- **Hypotheses:** h_001 (Thomas is Patrick's father, supported)\n- **Timelines:** t_001 (Patrick, 4 events, 1 gap)\n- **Proof summaries:** ps_001 (parentage, probable)\n- **GedcomX persons:** I1 (Patrick Flynn), I2 (Thomas Flynn), I3 (Mary Flynn, sister), I4 (James Flynn, brother)\n- **GedcomX relationships:** R1 (Thomas \u2192 Patrick), R2 (Thomas \u2192 Mary), R3 (Thomas \u2192 James) \u2014 all ParentChild\n- **Note on siblings:** Mary and James are stub entries (preferred name + gender only, no facts).\n  They represent the canonical shape Dallan called for: when researching Patrick on a household\n  census, the siblings should exist as persons in `tree.gedcomx.json` so warnings like\n  `relativesChildBirthRange40` and skills like `person-evidence` can reach them. Their detailed\n  facts would land later via record-extraction + person-evidence as the user works through the\n  1850 census record.\n",
+    "eval/fixtures/scenarios/mid-research-flynn/research.json": "{\n  \"assertions\": [\n    {\n      \"date\": null,\n      \"date_certainty\": null,\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_002\"\n      ],\n      \"fact_type\": \"name\",\n      \"id\": \"a_001\",\n      \"informant\": \"Unknown informant (most likely a household member, possibly a neighbor) reporting to census enumerator\",\n      \"informant_bias_notes\": \"Census enumerator is the recorder, not the informant. The person who provided the name is unknown \u2014 most likely a household member, possibly a neighbor. Proximity is 'unknown' rather than 'household_member' because for names specifically, the enumerator may have heard the name from a neighbor or made an assumption \u2014 the name fact doesn't necessarily require active reporting the way age/birthplace does.\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_001\",\n      \"place\": null,\n      \"record_id\": \"ark:/61903/1:1:MXYZ\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_001\",\n      \"structured_value\": {\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"value\": \"Patrick Flynn\"\n    },\n    {\n      \"date\": \"~1845\",\n      \"date_certainty\": \"estimated\",\n      \"evidence_type\": \"indirect\",\n      \"extracted_for_question_ids\": [\n        \"q_002\"\n      ],\n      \"fact_type\": \"birth\",\n      \"id\": \"a_002\",\n      \"informant\": \"Unknown \u2014 most likely a household member (such as Thomas Flynn or his wife), but possibly a neighbor\",\n      \"informant_bias_notes\": \"Age and birthplace require active reporting by an informant \u2014 someone had to tell the enumerator these facts. That informant was most likely a household member, but enumerators also took information from neighbors when residents were unavailable, and the census does not identify who answered. Proximity is 'unknown' because the informant cannot be established from the record.\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_001\",\n      \"place\": \"Ireland\",\n      \"record_id\": \"ark:/61903/1:1:MXYZ\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_001\",\n      \"structured_value\": {\n        \"place\": \"Ireland\",\n        \"year\": 1845\n      },\n      \"value\": \"age 5\"\n    },\n    {\n      \"date\": \"1850\",\n      \"date_certainty\": \"exact\",\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_002\"\n      ],\n      \"fact_type\": \"residence\",\n      \"id\": \"a_003\",\n      \"informant\": \"Census enumerator (witness to residence by visiting the dwelling)\",\n      \"informant_bias_notes\": \"For residence facts specifically, the enumerator is a direct witness \u2014 they physically visited the dwelling and recorded who lived there. This distinguishes residence from other census facts where an unidentified informant (most likely a household member, possibly a neighbor) supplied the information.\",\n      \"informant_proximity\": \"witness\",\n      \"information_quality\": \"primary\",\n      \"log_entry_id\": \"log_001\",\n      \"place\": \"Schuylkill County, Pennsylvania\",\n      \"record_id\": \"ark:/61903/1:1:MXYZ\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_001\",\n      \"value\": \"Schuylkill County, Pennsylvania\"\n    },\n    {\n      \"date\": \"1850\",\n      \"date_certainty\": \"exact\",\n      \"evidence_type\": \"indirect\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"relationship\",\n      \"id\": \"a_004\",\n      \"informant\": \"Inferred from household structure \u2014 no explicit informant for relationships in 1850 census\",\n      \"informant_bias_notes\": \"1850 census does not state relationships; this assertion is inferred from household position and shared surname, not directly reported by any informant. The relationship is indirect evidence constructed by the researcher, not information provided by a census informant.\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_001\",\n      \"place\": \"Schuylkill County, Pennsylvania\",\n      \"record_id\": \"ark:/61903/1:1:MXYZ\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_001\",\n      \"structured_value\": {\n        \"related_person_role\": \"head_of_household\",\n        \"relationship_type\": \"child_inferred\"\n      },\n      \"value\": \"Listed in household of Thomas Flynn (head), position consistent with child\"\n    },\n    {\n      \"date\": null,\n      \"date_certainty\": null,\n      \"evidence_type\": \"indirect\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"name\",\n      \"id\": \"a_005\",\n      \"informant\": \"Unknown informant (likely Thomas Flynn himself) reporting to census enumerator\",\n      \"informant_bias_notes\": \"Census enumerator is the recorder, not the informant. As head of household, Thomas likely provided his own name, but the 1850 census does not identify the informant.\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_001\",\n      \"place\": null,\n      \"record_id\": \"ark:/61903/1:1:MXYZ\",\n      \"record_role\": \"head_of_household\",\n      \"source_id\": \"src_001\",\n      \"value\": \"Thomas Flynn\"\n    },\n    {\n      \"date\": null,\n      \"date_certainty\": null,\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_002\"\n      ],\n      \"fact_type\": \"name\",\n      \"id\": \"a_006\",\n      \"informant\": \"Ancestry transcriber (derivative of census enumerator)\",\n      \"informant_bias_notes\": \"Derivative index \u2014 transcription errors possible\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_002\",\n      \"place\": null,\n      \"record_id\": \"ancestry:8054:patrick-flynn-1850\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_002\",\n      \"value\": \"Patrick Flynn\"\n    },\n    {\n      \"date\": \"~1845\",\n      \"date_certainty\": \"estimated\",\n      \"evidence_type\": \"indirect\",\n      \"extracted_for_question_ids\": [\n        \"q_002\"\n      ],\n      \"fact_type\": \"birth\",\n      \"id\": \"a_007\",\n      \"informant\": \"Ancestry transcriber (derivative)\",\n      \"informant_bias_notes\": null,\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_002\",\n      \"place\": \"Ireland\",\n      \"record_id\": \"ancestry:8054:patrick-flynn-1850\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_002\",\n      \"value\": \"age 5\"\n    },\n    {\n      \"date\": null,\n      \"date_certainty\": null,\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"name\",\n      \"id\": \"a_008\",\n      \"informant\": \"Unknown informant (most likely a household member, possibly a neighbor) reporting to census enumerator\",\n      \"informant_bias_notes\": \"Census enumerator is the recorder, not the informant. Proximity is 'unknown' for names (same reasoning as a_001 \u2014 name facts don't necessarily require active reporting).\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_004\",\n      \"place\": null,\n      \"record_id\": \"ark:/61903/1:1:MABC\",\n      \"record_role\": \"child_2\",\n      \"source_id\": \"src_003\",\n      \"value\": \"Patrick Flynn\"\n    },\n    {\n      \"date\": \"~1845\",\n      \"date_certainty\": \"estimated\",\n      \"evidence_type\": \"indirect\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"birth\",\n      \"id\": \"a_009\",\n      \"informant\": \"Unknown \u2014 most likely a household member (such as Thomas Flynn or his wife), but possibly a neighbor\",\n      \"informant_bias_notes\": \"Age and birthplace require active reporting by an informant \u2014 most likely a household member, possibly a neighbor (same reasoning as a_002).\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_004\",\n      \"place\": \"Ireland\",\n      \"record_id\": \"ark:/61903/1:1:MABC\",\n      \"record_role\": \"child_2\",\n      \"source_id\": \"src_003\",\n      \"value\": \"age 15\"\n    },\n    {\n      \"date\": \"1860\",\n      \"date_certainty\": \"exact\",\n      \"evidence_type\": \"indirect\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"relationship\",\n      \"id\": \"a_010\",\n      \"informant\": \"Inferred from household structure \u2014 no explicit informant for relationships in 1860 census\",\n      \"informant_bias_notes\": \"1860 census does not state relationships; like the 1850 census, this assertion is inferred from household position, age, and shared surname. The relationship column was not introduced until the 1880 census.\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_004\",\n      \"place\": \"Schuylkill County, Pennsylvania\",\n      \"record_id\": \"ark:/61903/1:1:MABC\",\n      \"record_role\": \"child_2\",\n      \"source_id\": \"src_003\",\n      \"structured_value\": {\n        \"related_person_role\": \"head_of_household\",\n        \"relationship_type\": \"child_inferred\"\n      },\n      \"value\": \"Listed in household of Thomas Flynn (head), position and age consistent with son\"\n    },\n    {\n      \"date\": \"1908-03-12\",\n      \"date_certainty\": \"exact\",\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [],\n      \"fact_type\": \"death\",\n      \"id\": \"a_011\",\n      \"informant\": \"Attending physician (signature on certificate)\",\n      \"informant_bias_notes\": null,\n      \"informant_proximity\": \"witness\",\n      \"information_quality\": \"primary\",\n      \"log_entry_id\": \"log_005\",\n      \"place\": \"Schuylkill County, Pennsylvania\",\n      \"record_id\": \"ark:/61903/1:1:MDEF\",\n      \"record_role\": \"deceased\",\n      \"source_id\": \"src_004\",\n      \"value\": \"Died 12 March 1908\"\n    },\n    {\n      \"date\": \"1845\",\n      \"date_certainty\": \"approximate\",\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"birth\",\n      \"id\": \"a_012\",\n      \"informant\": \"James Brown (son-in-law)\",\n      \"informant_bias_notes\": \"Son-in-law reporting birth facts decades after the event. Note: death cert says Pennsylvania, but census records say Ireland. Son-in-law may not have known Patrick was born in Ireland.\",\n      \"informant_proximity\": \"family_not_present\",\n      \"information_quality\": \"secondary\",\n      \"log_entry_id\": \"log_005\",\n      \"place\": \"Pennsylvania\",\n      \"record_id\": \"ark:/61903/1:1:MDEF\",\n      \"record_role\": \"deceased\",\n      \"source_id\": \"src_004\",\n      \"structured_value\": {\n        \"place\": \"Pennsylvania\",\n        \"year\": 1845\n      },\n      \"value\": \"Born 1845, Pennsylvania\"\n    },\n    {\n      \"date\": null,\n      \"date_certainty\": null,\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"relationship\",\n      \"id\": \"a_013\",\n      \"informant\": \"James Brown (son-in-law)\",\n      \"informant_bias_notes\": \"Secondary information \u2014 son-in-law reporting what he was told about father-in-law's parentage\",\n      \"informant_proximity\": \"family_not_present\",\n      \"information_quality\": \"secondary\",\n      \"log_entry_id\": \"log_005\",\n      \"place\": null,\n      \"record_id\": \"ark:/61903/1:1:MDEF\",\n      \"record_role\": \"deceased\",\n      \"source_id\": \"src_004\",\n      \"structured_value\": {\n        \"related_person_role\": \"deceased\",\n        \"relationship_type\": \"father\"\n      },\n      \"value\": \"Father: Thomas Flynn\"\n    }\n  ],\n  \"conflicts\": [\n    {\n      \"blocks_question_ids\": [],\n      \"competing_assertion_ids\": [\n        \"a_002\",\n        \"a_009\",\n        \"a_012\"\n      ],\n      \"conflict_type\": \"fact\",\n      \"description\": \"Patrick Flynn's birthplace: Ireland (1850 and 1860 censuses) vs. Pennsylvania (1908 death certificate)\",\n      \"disputed_attribute\": \"birthplace\",\n      \"id\": \"c_001\",\n      \"identity_question\": null,\n      \"independence_analysis\": \"The two census records (1850, 1860) are independent original sources with different enumerators. The death certificate is a third independent original source. However, the census informants are likely the same household member (Thomas Flynn or wife), so the two census assertions may share a single informant \u2014 potentially not fully independent for this fact.\",\n      \"preferred_assertion_id\": \"a_002\",\n      \"resolution_rationale\": \"Ireland is accepted as the birthplace. The 1908 death certificate birthplace of 'Pennsylvania' is rejected as a likely error by the son-in-law informant, who may have confused Patrick's place of residence with his place of birth, or may not have known Patrick was born in Ireland before immigrating as a young child.\",\n      \"status\": \"resolved\",\n      \"weighing_analysis\": \"The census records are contemporary recordings made near the time of Patrick's birth, while the death certificate was created 63 years later. The census informant was likely a household member with firsthand knowledge (primary or indeterminate), while the death certificate informant (son-in-law) is clearly secondary for birth facts. Two contemporary sources outweigh one later recollection by a secondary informant.\"\n    }\n  ],\n  \"evaluations\": [],\n  \"hypotheses\": [\n    {\n      \"claim\": \"Patrick Flynn's father was Thomas Flynn of Schuylkill County, Pennsylvania\",\n      \"contradicting_assertion_ids\": [],\n      \"id\": \"h_001\",\n      \"notes\": \"Three independent pieces of evidence: 1850 census co-enumeration (indirect), 1860 census co-enumeration (indirect \u2014 relationship inferred from household position), death certificate naming Thomas as father (direct, secondary informant). Awaiting probate records for additional confirmation.\",\n      \"related_question_ids\": [\n        \"q_001\"\n      ],\n      \"ruled_out\": false,\n      \"ruled_out_reason\": null,\n      \"status\": \"supported\",\n      \"supporting_assertion_ids\": [\n        \"a_004\",\n        \"a_010\",\n        \"a_013\"\n      ]\n    }\n  ],\n  \"log\": [\n    {\n      \"external_site\": null,\n      \"id\": \"log_001\",\n      \"notes\": \"Found Patrick Flynn age 5 in household of Thomas Flynn, dwelling 84, Schuylkill Co. Three other Flynn results examined \u2014 ages and locations don't match.\",\n      \"outcome\": \"positive\",\n      \"performed\": \"2026-05-01T10:15:00Z\",\n      \"plan_item_id\": \"pli_001\",\n      \"query\": {\n        \"birth_place\": \"Pennsylvania\",\n        \"birth_year\": 1845,\n        \"collection\": \"1850 Census\",\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"results_examined\": 8,\n      \"tool\": \"record_search\"\n    },\n    {\n      \"external_site\": {\n        \"capture_filename\": \"ancestry-1850-flynn-results.pdf\",\n        \"capture_received\": true,\n        \"site\": \"ancestry\",\n        \"url_generated\": \"https://www.ancestry.com/search/collections/8054/?name=Patrick_Flynn&birth=1845&birthplace=Pennsylvania\"\n      },\n      \"id\": \"log_002\",\n      \"notes\": \"Ancestry index confirms same household. Transcription matches FamilySearch except Ancestry reads dwelling as 84, FamilySearch as 84 \u2014 consistent.\",\n      \"outcome\": \"positive\",\n      \"performed\": \"2026-05-01T11:30:00Z\",\n      \"plan_item_id\": \"pli_002\",\n      \"query\": {\n        \"birth_place\": \"Pennsylvania\",\n        \"birth_year\": 1845,\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"results_examined\": 12,\n      \"tool\": \"external_site\"\n    },\n    {\n      \"external_site\": {\n        \"capture_filename\": \"myheritage-1850-flynn-nil.pdf\",\n        \"capture_received\": true,\n        \"site\": \"myheritage\",\n        \"url_generated\": \"https://www.myheritage.com/research?action=query&first=Patrick&last=Flynn&birth_year=1845&birth_place=Pennsylvania\"\n      },\n      \"id\": \"log_003\",\n      \"notes\": \"MyHeritage returned no results for Patrick Flynn in 1850 Schuylkill County. Site may not have this collection indexed. Searched broader Pennsylvania \u2014 still no match.\",\n      \"outcome\": \"negative\",\n      \"performed\": \"2026-05-01T14:00:00Z\",\n      \"plan_item_id\": \"pli_003\",\n      \"query\": {\n        \"birth_place\": \"Pennsylvania\",\n        \"birth_year\": 1845,\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"results_examined\": 0,\n      \"tool\": \"external_site\"\n    },\n    {\n      \"external_site\": null,\n      \"id\": \"log_004\",\n      \"notes\": \"Patrick Flynn age 15 in household of Thomas Flynn, Schuylkill Co. Consistent with 1850 placement.\",\n      \"outcome\": \"positive\",\n      \"performed\": \"2026-05-02T09:00:00Z\",\n      \"plan_item_id\": \"pli_004\",\n      \"query\": {\n        \"birth_place\": \"Pennsylvania\",\n        \"birth_year\": 1845,\n        \"collection\": \"1860 Census\",\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"results_examined\": 5,\n      \"tool\": \"record_search\"\n    },\n    {\n      \"external_site\": null,\n      \"id\": \"log_005\",\n      \"notes\": \"Death certificate found. Names Thomas Flynn as father. Informant was son-in-law James Brown.\",\n      \"outcome\": \"positive\",\n      \"performed\": \"2026-05-03T10:00:00Z\",\n      \"plan_item_id\": \"pli_005\",\n      \"query\": {\n        \"death_place\": \"Schuylkill County, Pennsylvania\",\n        \"death_year\": 1908,\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"results_examined\": 2,\n      \"tool\": \"record_search\"\n    }\n  ],\n  \"person_evidence\": [\n    {\n      \"assertion_id\": \"a_001\",\n      \"confidence\": \"confident\",\n      \"created\": \"2026-05-01\",\n      \"id\": \"pe_001\",\n      \"match_score\": null,\n      \"person_id\": \"I1\",\n      \"rationale\": \"Name matches (Patrick Flynn), age consistent with ~1845 birth, located in Schuylkill County where subject is known to have lived. Only Patrick Flynn of this age in the county in 1850.\",\n      \"superseded_by\": null\n    },\n    {\n      \"assertion_id\": \"a_004\",\n      \"confidence\": \"probable\",\n      \"created\": \"2026-05-01\",\n      \"id\": \"pe_002\",\n      \"match_score\": null,\n      \"person_id\": \"I1\",\n      \"rationale\": \"Same record as pe_001, same person. Household position and shared surname with head Thomas Flynn suggest parent-child relationship, but 1850 census does not state relationships explicitly.\",\n      \"superseded_by\": null\n    },\n    {\n      \"assertion_id\": \"a_004\",\n      \"confidence\": \"probable\",\n      \"created\": \"2026-05-01\",\n      \"id\": \"pe_006\",\n      \"match_score\": null,\n      \"person_id\": \"I2\",\n      \"rationale\": \"Same assertion as pe_002 but linked to Thomas Flynn (I2). The relationship assertion ('position consistent with child') equally bears on the head of household. Thomas Flynn is the other party in the implied parent-child relationship.\",\n      \"superseded_by\": null\n    },\n    {\n      \"assertion_id\": \"a_005\",\n      \"confidence\": \"probable\",\n      \"created\": \"2026-05-01\",\n      \"id\": \"pe_003\",\n      \"match_score\": 0.82,\n      \"person_id\": \"I2\",\n      \"rationale\": \"Thomas Flynn, head of household where Patrick was found. Age (~32 in 1850, born ~1818) is consistent with being Patrick's father. Name matches candidate father.\",\n      \"superseded_by\": null\n    },\n    {\n      \"assertion_id\": \"a_010\",\n      \"confidence\": \"confident\",\n      \"created\": \"2026-05-02\",\n      \"id\": \"pe_004\",\n      \"match_score\": null,\n      \"person_id\": \"I1\",\n      \"rationale\": \"Patrick Flynn age 15 in Thomas Flynn household, 1860 census. Same county, age consistent with 1850 enumeration. Relationship inferred from household position and shared surname (1860 census does not state relationships explicitly).\",\n      \"superseded_by\": null\n    },\n    {\n      \"assertion_id\": \"a_013\",\n      \"confidence\": \"confident\",\n      \"created\": \"2026-05-03\",\n      \"id\": \"pe_005\",\n      \"match_score\": null,\n      \"person_id\": \"I1\",\n      \"rationale\": \"Death certificate for Patrick Flynn, d. 1908, Schuylkill County. Names match, death location matches known residence. Names Thomas Flynn as father.\",\n      \"superseded_by\": null\n    }\n  ],\n  \"plans\": [\n    {\n      \"created\": \"2026-05-01\",\n      \"id\": \"pl_001\",\n      \"items\": [\n        {\n          \"date_range\": \"1850\",\n          \"fallback_for\": null,\n          \"id\": \"pli_001\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"1850 census fully indexed on FamilySearch. Free access, start here.\",\n          \"record_type\": \"census\",\n          \"repository\": \"FamilySearch\",\n          \"sequence\": 1,\n          \"status\": \"completed\"\n        },\n        {\n          \"date_range\": \"1850\",\n          \"fallback_for\": null,\n          \"id\": \"pli_002\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"Ancestry has independent indexing; cross-check for transcription errors.\",\n          \"record_type\": \"census\",\n          \"repository\": \"Ancestry\",\n          \"sequence\": 2,\n          \"status\": \"completed\"\n        },\n        {\n          \"date_range\": \"1850\",\n          \"fallback_for\": null,\n          \"id\": \"pli_003\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"Third independent index for coverage confirmation.\",\n          \"record_type\": \"census\",\n          \"repository\": \"MyHeritage\",\n          \"sequence\": 3,\n          \"status\": \"completed\"\n        }\n      ],\n      \"question_id\": \"q_002\",\n      \"status\": \"completed\"\n    },\n    {\n      \"created\": \"2026-05-02\",\n      \"id\": \"pl_002\",\n      \"items\": [\n        {\n          \"date_range\": \"1860\",\n          \"fallback_for\": null,\n          \"id\": \"pli_004\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"Confirm Patrick still in Thomas Flynn household in 1860. Strengthens parent-child identification.\",\n          \"record_type\": \"census\",\n          \"repository\": \"FamilySearch\",\n          \"sequence\": 1,\n          \"status\": \"completed\"\n        },\n        {\n          \"date_range\": \"1908\",\n          \"fallback_for\": null,\n          \"id\": \"pli_005\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"Death certificate may name parents directly.\",\n          \"record_type\": \"vital_record\",\n          \"repository\": \"FamilySearch\",\n          \"sequence\": 2,\n          \"status\": \"completed\"\n        },\n        {\n          \"date_range\": \"1870-1890\",\n          \"fallback_for\": null,\n          \"id\": \"pli_006\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"Thomas Flynn probate/will may name Patrick as son.\",\n          \"record_type\": \"probate\",\n          \"repository\": \"FamilySearch\",\n          \"sequence\": 3,\n          \"status\": \"in_progress\"\n        }\n      ],\n      \"question_id\": \"q_001\",\n      \"status\": \"active\"\n    }\n  ],\n  \"project\": {\n    \"created\": \"2026-05-01\",\n    \"id\": \"rp_001\",\n    \"objective\": \"Identify the parents of Patrick Flynn, born ca. 1845 in Pennsylvania, died 1908 in Schuylkill County, PA\",\n    \"status\": \"active\",\n    \"subject_person_ids\": [\n      \"I1\"\n    ],\n    \"updated\": \"2026-05-04\"\n  },\n  \"proof_summaries\": [\n    {\n      \"exhaustive_search_summary\": \"Searched 1850 census (FamilySearch, Ancestry, MyHeritage \u2014 log_001, log_002, log_003), 1860 census (FamilySearch \u2014 log_004), and death certificate (FamilySearch \u2014 log_005). Probate search in progress. 1870, 1880, and 1900 censuses not yet searched.\",\n      \"id\": \"ps_001\",\n      \"narrative_markdown\": \"## Parentage of Patrick Flynn (ca. 1845\u20131908)\\n\\nPatrick Flynn is **Probably** the son of Thomas Flynn of Schuylkill County, Pennsylvania.\\n\\n### Evidence Summary\\n\\nThree independent lines of evidence support this conclusion:\\n\\n1. **1850 U.S. Census** (Original Source). Patrick Flynn, age 5, born Ireland, appears in the household of Thomas Flynn, age 32, born Ireland, in Schuylkill County, Pennsylvania (dwelling 84, family 91). The 1850 census does not state relationships, but Patrick's position in the household and shared surname are consistent with a parent-child relationship. The informant is indeterminate but likely a household member. This constitutes indirect evidence of parentage.\\n\\n2. **1860 U.S. Census** (Original Source). Patrick Flynn, age 15, born Ireland, appears in the household of Thomas Flynn in Schuylkill County (dwelling 112, family 119). Like the 1850 census, the 1860 census does not state relationships explicitly (the relationship column was not introduced until 1880). Patrick's position in the household, shared surname, and age consistent with the 1850 enumeration support a parent-child relationship. This constitutes indirect evidence of parentage.\\n\\n3. **1908 Death Certificate** (Original Source). Patrick Flynn's death certificate (no. 4521, Pennsylvania Department of Health) names \\\"Thomas Flynn\\\" as his father. The informant was James Brown, identified as Patrick's son-in-law. As a son-in-law reporting his father-in-law's parentage, Brown is a secondary informant for this fact \u2014 he was not a witness to Patrick's birth and is reporting what he was told. Nevertheless, this is direct evidence naming the father.\\n\\n### Conflict Resolution\\n\\nA birthplace conflict exists: the 1850 and 1860 censuses list Patrick's birthplace as Ireland, while the 1908 death certificate states Pennsylvania. The two census records are contemporary recordings with informants likely present in the household, while the death certificate was created 63 years after Patrick's birth by a son-in-law with no firsthand knowledge of the event. Per the GPS preponderance hierarchy, contemporary recordings by closer informants outweigh later recollections by secondary informants. Ireland is accepted as the birthplace; the death certificate entry is attributed to informant error.\\n\\n### Assessment\\n\\nThe conclusion is rated **Probable** rather than **Proved** because: (a) both census sources (1850 and 1860) provide only indirect evidence of parentage (relationships not stated \u2014 the relationship column was not introduced until 1880), (b) the death certificate informant is secondary, and (c) research is not yet exhaustive \u2014 the 1870, 1880, and 1900 censuses have not been searched, and Thomas Flynn's probate records have not been located. If Thomas Flynn's will names Patrick as a son, or if additional census records confirm the relationship, the conclusion would advance to **Proved**.\\n\\n### Citations\\n\\n1. 1850 U.S. Census, Schuylkill County, Pennsylvania, population schedule, dwelling 84, family 91, Thomas Flynn household; NARA microfilm publication M432, roll 810; digital image, FamilySearch.org, accessed 1 May 2026.\\n2. 1860 U.S. Census, Schuylkill County, Pennsylvania, population schedule, dwelling 112, family 119, Thomas Flynn household; NARA microfilm publication M653, roll 1141; digital image, FamilySearch.org, accessed 2 May 2026.\\n3. Pennsylvania Department of Health, death certificate no. 4521 (1908), Patrick Flynn; Pennsylvania State Archives, Harrisburg; digital image, FamilySearch.org, accessed 3 May 2026.\",\n      \"question_id\": \"q_001\",\n      \"resolved_conflict_ids\": [\n        \"c_001\"\n      ],\n      \"supporting_assertion_ids\": [\n        \"a_004\",\n        \"a_010\",\n        \"a_013\"\n      ],\n      \"tier\": \"probable\",\n      \"vehicle\": \"summary\"\n    }\n  ],\n  \"questions\": [\n    {\n      \"created\": \"2026-05-01\",\n      \"depends_on\": [],\n      \"exhaustive_declaration\": {\n        \"declared\": false,\n        \"justification\": null,\n        \"log_entry_ids\": [],\n        \"stop_criteria\": null\n      },\n      \"id\": \"q_001\",\n      \"priority\": \"high\",\n      \"question\": \"Who were the parents of Patrick Flynn (b. ~1845, PA, d. 1908)?\",\n      \"rationale\": \"This is the primary research objective.\",\n      \"resolution_assertion_ids\": [],\n      \"resolved\": null,\n      \"selection_basis\": \"objective_decomposition\",\n      \"status\": \"in_progress\",\n      \"unblocks\": []\n    },\n    {\n      \"created\": \"2026-05-01\",\n      \"depends_on\": [],\n      \"exhaustive_declaration\": {\n        \"declared\": true,\n        \"justification\": \"Searched 1850 census for Schuylkill County on FamilySearch (indexed and browse), Ancestry (indexed), and MyHeritage (indexed). All three returned the same household. No other Patrick Flynn of matching age found in the county.\",\n        \"log_entry_ids\": [\n          \"log_001\",\n          \"log_002\",\n          \"log_003\"\n        ],\n        \"stop_criteria\": {\n          \"conflict_resolution\": \"No conflicts on the 1850 census placement question.\",\n          \"evidence_class\": \"Yes \u2014 FamilySearch provides original census image with indeterminate-quality information.\",\n          \"goal_alignment\": \"Yes \u2014 Patrick Flynn located in a specific 1850 household, answering the question.\",\n          \"independent_verification\": \"FamilySearch (original) and Ancestry (derivative) both return the same household. Two access paths, one underlying original.\",\n          \"original_substitution\": \"FamilySearch provides the original census image; Ancestry index is derivative but confirmed consistent.\",\n          \"overturn_risk\": \"Low \u2014 all three repositories agree, and no competing Patrick Flynn of matching age exists in the county.\",\n          \"repository_breadth\": \"Three major repositories searched (FamilySearch, Ancestry, MyHeritage). No additional known indexes of the 1850 Schuylkill County census exist.\"\n        }\n      },\n      \"id\": \"q_002\",\n      \"priority\": \"high\",\n      \"question\": \"Where was Patrick Flynn in the 1850 census?\",\n      \"rationale\": \"The 1850 census is the earliest enumeration where Patrick would appear by name (age ~5). Locating him in a household identifies candidate parents.\",\n      \"resolution_assertion_ids\": [\n        \"a_001\",\n        \"a_002\",\n        \"a_003\"\n      ],\n      \"resolved\": \"2026-05-02\",\n      \"selection_basis\": \"objective_decomposition\",\n      \"status\": \"resolved\",\n      \"unblocks\": [\n        \"q_001\"\n      ]\n    }\n  ],\n  \"sources\": [\n    {\n      \"access_date\": \"2026-05-01\",\n      \"citation\": \"1850 U.S. Census, Schuylkill County, Pennsylvania, population schedule, dwelling 84, family 91, Thomas Flynn household; NARA microfilm publication M432, roll 810; digital image, FamilySearch.org, accessed 1 May 2026.\",\n      \"citation_detail\": {\n        \"what\": \"1850 U.S. Federal Census, population schedule\",\n        \"when_accessed\": \"2026-05-01\",\n        \"when_created\": \"1850\",\n        \"where\": \"FamilySearch.org (NARA microfilm M432, roll 810)\",\n        \"where_within\": \"Schuylkill County, dwelling 84, family 91\",\n        \"who\": \"U.S. Census Bureau\"\n      },\n      \"gedcomx_source_description_id\": \"S1\",\n      \"id\": \"src_001\",\n      \"log_entry_id\": \"log_001\",\n      \"notes\": \"Image quality good. Enumerator handwriting clear.\",\n      \"repository\": \"FamilySearch\",\n      \"source_classification\": \"original\",\n      \"url\": \"https://www.familysearch.org/ark:/61903/1:1:MXYZ\",\n      \"url_archived\": null\n    },\n    {\n      \"access_date\": \"2026-05-01\",\n      \"citation\": \"1850 U.S. Census, Schuylkill County, Pennsylvania, population schedule, dwelling 84, Thomas Flynn household; digital image, Ancestry.com, accessed 1 May 2026.\",\n      \"citation_detail\": {\n        \"what\": \"1850 U.S. Federal Census, population schedule (Ancestry index)\",\n        \"when_accessed\": \"2026-05-01\",\n        \"when_created\": \"1850\",\n        \"where\": \"Ancestry.com\",\n        \"where_within\": \"Schuylkill County, dwelling 84\",\n        \"who\": \"U.S. Census Bureau\"\n      },\n      \"gedcomx_source_description_id\": \"S1\",\n      \"id\": \"src_002\",\n      \"log_entry_id\": \"log_002\",\n      \"notes\": \"Ancestry's index of the same original census. Transcription consistent with FamilySearch.\",\n      \"repository\": \"Ancestry\",\n      \"source_classification\": \"derivative\",\n      \"url\": null,\n      \"url_archived\": null\n    },\n    {\n      \"access_date\": \"2026-05-02\",\n      \"citation\": \"1860 U.S. Census, Schuylkill County, Pennsylvania, population schedule, dwelling 112, family 119, Thomas Flynn household; NARA microfilm publication M653, roll 1141; digital image, FamilySearch.org, accessed 2 May 2026.\",\n      \"citation_detail\": {\n        \"what\": \"1860 U.S. Federal Census, population schedule\",\n        \"when_accessed\": \"2026-05-02\",\n        \"when_created\": \"1860\",\n        \"where\": \"FamilySearch.org (NARA microfilm M653, roll 1141)\",\n        \"where_within\": \"Schuylkill County, dwelling 112, family 119\",\n        \"who\": \"U.S. Census Bureau\"\n      },\n      \"gedcomx_source_description_id\": \"S2\",\n      \"id\": \"src_003\",\n      \"log_entry_id\": \"log_004\",\n      \"notes\": null,\n      \"repository\": \"FamilySearch\",\n      \"source_classification\": \"original\",\n      \"url\": \"https://www.familysearch.org/ark:/61903/1:1:MABC\",\n      \"url_archived\": null\n    },\n    {\n      \"access_date\": \"2026-05-03\",\n      \"citation\": \"Pennsylvania Department of Health, death certificate no. 4521 (1908), Patrick Flynn; Pennsylvania State Archives, Harrisburg; digital image, FamilySearch.org, accessed 3 May 2026.\",\n      \"citation_detail\": {\n        \"what\": \"Death certificate no. 4521\",\n        \"when_accessed\": \"2026-05-03\",\n        \"when_created\": \"1908-03-14\",\n        \"where\": \"FamilySearch.org (Pennsylvania State Archives, Harrisburg)\",\n        \"where_within\": \"Certificate no. 4521\",\n        \"who\": \"Pennsylvania Department of Health; informant: James Brown (son-in-law)\"\n      },\n      \"gedcomx_source_description_id\": \"S3\",\n      \"id\": \"src_004\",\n      \"log_entry_id\": \"log_005\",\n      \"notes\": \"Informant is son-in-law James Brown. Primary for death facts, secondary for birth facts.\",\n      \"repository\": \"FamilySearch\",\n      \"source_classification\": \"original\",\n      \"url\": \"https://www.familysearch.org/ark:/61903/1:1:MDEF\",\n      \"url_archived\": null\n    },\n    {\n      \"access_date\": \"2026-05-10\",\n      \"citation\": \"St. Mary's Catholic Church, Pottsville, baptism of Patrick Flynn, 1845\",\n      \"citation_detail\": {\n        \"what\": \"Baptismal register, 1845\",\n        \"when_accessed\": \"2026-05-10\",\n        \"when_created\": \"1845\",\n        \"where\": \"FamilySearch.org\",\n        \"where_within\": \"Patrick Flynn entry\",\n        \"who\": \"St. Mary's Catholic Church, Pottsville\"\n      },\n      \"gedcomx_source_description_id\": \"S5\",\n      \"id\": \"src_005\",\n      \"log_entry_id\": null,\n      \"notes\": \"Rough working citation from record-extraction. Missing volume/page locator and full repository chain.\",\n      \"repository\": \"FamilySearch\",\n      \"source_classification\": \"original\",\n      \"url\": \"https://www.familysearch.org/ark:/61903/3:1:S3HT-D1MQ-NZH\",\n      \"url_archived\": null\n    },\n    {\n      \"access_date\": \"2026-05-10\",\n      \"citation\": \"Schuylkill County will of Thomas Flynn, 1881\",\n      \"citation_detail\": {\n        \"what\": \"Will of Thomas Flynn\",\n        \"when_accessed\": \"2026-05-10\",\n        \"when_created\": \"1881\",\n        \"where\": \"FamilySearch.org\",\n        \"where_within\": \"will of Thomas Flynn\",\n        \"who\": \"Schuylkill County Courthouse\"\n      },\n      \"gedcomx_source_description_id\": \"S4\",\n      \"id\": \"src_006\",\n      \"log_entry_id\": null,\n      \"notes\": \"Rough working citation from record-extraction. Creator should be the court, not the courthouse. Missing Will Book volume and page locator.\",\n      \"repository\": \"FamilySearch\",\n      \"source_classification\": \"original\",\n      \"url\": \"https://www.familysearch.org/ark:/61903/3:1:3Q9M-CS4V-7TXW\",\n      \"url_archived\": null\n    },\n    {\n      \"access_date\": \"2026-05-12\",\n      \"citation\": \"PA birth certificate, Mary Elizabeth Flynn, 1905\",\n      \"citation_detail\": {\n        \"what\": \"Birth certificate\",\n        \"when_accessed\": \"2026-05-12\",\n        \"when_created\": \"1905\",\n        \"where\": \"FamilySearch.org\",\n        \"where_within\": \"Mary Elizabeth Flynn entry\",\n        \"who\": \"FamilySearch\"\n      },\n      \"gedcomx_source_description_id\": \"S6\",\n      \"id\": \"src_007\",\n      \"log_entry_id\": null,\n      \"notes\": \"Rough working citation from record-extraction. who wrongly names the repository; missing certificate number (12455), birth date, and place.\",\n      \"repository\": \"FamilySearch\",\n      \"source_classification\": \"original\",\n      \"url\": \"https://www.familysearch.org/ark:/61903/1:1:6JZX-VKQM\",\n      \"url_archived\": null\n    },\n    {\n      \"access_date\": \"2026-05-12\",\n      \"citation\": \"Deed, Thomas Flynn to Patrick Flynn, 1881\",\n      \"citation_detail\": {\n        \"what\": \"Warranty deed\",\n        \"when_accessed\": \"2026-05-12\",\n        \"when_created\": \"1881\",\n        \"where\": \"FamilySearch.org\",\n        \"where_within\": \"Thomas Flynn to Patrick Flynn\",\n        \"who\": \"Schuylkill County Courthouse\"\n      },\n      \"gedcomx_source_description_id\": \"S7\",\n      \"id\": \"src_008\",\n      \"log_entry_id\": null,\n      \"notes\": \"Rough working citation from record-extraction. who should be the Recorder of Deeds (not the courthouse building); missing grantor/grantee, execution + recording dates, and Deed Book/page locator.\",\n      \"repository\": \"FamilySearch\",\n      \"source_classification\": \"original\",\n      \"url\": \"https://www.familysearch.org/ark:/61903/3:1:3QS7-89WF-9KCT\",\n      \"url_archived\": null\n    },\n    {\n      \"access_date\": \"2026-05-12\",\n      \"citation\": \"Patrick Flynn obituary, Pottsville Republican, 1908\",\n      \"citation_detail\": {\n        \"what\": \"Obituary\",\n        \"when_accessed\": \"2026-05-12\",\n        \"when_created\": \"1908\",\n        \"where\": \"FamilySearch.org\",\n        \"where_within\": \"obituary notice\",\n        \"who\": \"FamilySearch\"\n      },\n      \"gedcomx_source_description_id\": \"S8\",\n      \"id\": \"src_009\",\n      \"log_entry_id\": null,\n      \"notes\": \"Rough working citation from record-extraction. who wrongly names the repository; missing the quoted article title, exact publication date, page, and column number.\",\n      \"repository\": \"FamilySearch\",\n      \"source_classification\": \"original\",\n      \"url\": \"https://www.familysearch.org/ark:/61903/3:1:S3HY-6RKS-MGV\",\n      \"url_archived\": null\n    }\n  ],\n  \"timelines\": [\n    {\n      \"events\": [\n        {\n          \"assertion_ids\": [\n            \"a_002\",\n            \"a_009\"\n          ],\n          \"date\": \"~1845\",\n          \"date_certainty\": \"estimated\",\n          \"description\": \"Born in Ireland, estimated from census ages\",\n          \"event_type\": \"birth\",\n          \"place\": \"Ireland\"\n        },\n        {\n          \"assertion_ids\": [\n            \"a_003\",\n            \"a_004\"\n          ],\n          \"date\": \"1850\",\n          \"date_certainty\": \"exact\",\n          \"description\": \"Enumerated age 5 in Thomas Flynn household, dwelling 84\",\n          \"event_type\": \"census\",\n          \"place\": \"Schuylkill County, Pennsylvania\"\n        },\n        {\n          \"assertion_ids\": [\n            \"a_008\",\n            \"a_009\",\n            \"a_010\"\n          ],\n          \"date\": \"1860\",\n          \"date_certainty\": \"exact\",\n          \"description\": \"Enumerated age 15 in Thomas Flynn household, dwelling 112\",\n          \"event_type\": \"census\",\n          \"place\": \"Schuylkill County, Pennsylvania\"\n        },\n        {\n          \"assertion_ids\": [\n            \"a_011\",\n            \"a_013\"\n          ],\n          \"date\": \"1908-03-12\",\n          \"date_certainty\": \"exact\",\n          \"description\": \"Died, death certificate names Thomas Flynn as father\",\n          \"event_type\": \"death\",\n          \"place\": \"Schuylkill County, Pennsylvania\"\n        }\n      ],\n      \"gaps\": [\n        {\n          \"end\": \"1908-03-12\",\n          \"expected_events\": [\n            \"marriage\",\n            \"1870_census\",\n            \"1880_census\",\n            \"1900_census\",\n            \"residence\",\n            \"occupation\"\n          ],\n          \"severity\": \"high\",\n          \"start\": \"1860-01-01\"\n        }\n      ],\n      \"generated\": \"2026-05-03T12:00:00Z\",\n      \"hypothesis_id\": \"h_001\",\n      \"id\": \"t_001\",\n      \"impossibilities\": [],\n      \"label\": \"Patrick Flynn \u2014 assuming Thomas Flynn parentage\",\n      \"person_ids\": [\n        \"I1\"\n      ]\n    }\n  ]\n}\n",
+    "eval/fixtures/scenarios/mid-research-flynn/tree.gedcomx.json": "{\n  \"persons\": [\n    {\n      \"facts\": [\n        {\n          \"date\": \"~1845\",\n          \"id\": \"F1\",\n          \"place\": \"Ireland\",\n          \"primary\": true,\n          \"sources\": [\n            {\n              \"page\": \"1850 Census, Schuylkill Co., dwelling 84\",\n              \"ref\": \"S1\"\n            }\n          ],\n          \"type\": \"Birth\"\n        },\n        {\n          \"date\": \"1908-03-12\",\n          \"id\": \"F2\",\n          \"place\": \"Schuylkill County, Pennsylvania\",\n          \"sources\": [\n            {\n              \"page\": \"Death cert. no. 4521\",\n              \"ref\": \"S3\"\n            }\n          ],\n          \"type\": \"Death\"\n        }\n      ],\n      \"gender\": \"Male\",\n      \"id\": \"I1\",\n      \"names\": [\n        {\n          \"given\": \"Patrick\",\n          \"id\": \"N1\",\n          \"preferred\": true,\n          \"surname\": \"Flynn\",\n          \"type\": \"BirthName\"\n        }\n      ]\n    },\n    {\n      \"facts\": [\n        {\n          \"date\": \"~1818\",\n          \"id\": \"F3\",\n          \"place\": \"Ireland\",\n          \"primary\": true,\n          \"type\": \"Birth\"\n        }\n      ],\n      \"gender\": \"Male\",\n      \"id\": \"I2\",\n      \"names\": [\n        {\n          \"given\": \"Thomas\",\n          \"id\": \"N2\",\n          \"preferred\": true,\n          \"surname\": \"Flynn\",\n          \"type\": \"BirthName\"\n        }\n      ]\n    },\n    {\n      \"gender\": \"Female\",\n      \"id\": \"I3\",\n      \"names\": [\n        {\n          \"given\": \"Mary\",\n          \"id\": \"N3\",\n          \"preferred\": true,\n          \"surname\": \"Flynn\",\n          \"type\": \"BirthName\"\n        }\n      ]\n    },\n    {\n      \"gender\": \"Male\",\n      \"id\": \"I4\",\n      \"names\": [\n        {\n          \"given\": \"James\",\n          \"id\": \"N4\",\n          \"preferred\": true,\n          \"surname\": \"Flynn\",\n          \"type\": \"BirthName\"\n        }\n      ]\n    }\n  ],\n  \"relationships\": [\n    {\n      \"child\": \"I1\",\n      \"id\": \"R1\",\n      \"parent\": \"I2\",\n      \"sources\": [\n        {\n          \"page\": \"1850 Census, Schuylkill Co., dwelling 84\",\n          \"quality\": 2,\n          \"ref\": \"S1\"\n        },\n        {\n          \"page\": \"1860 Census, Schuylkill Co., dwelling 112\",\n          \"quality\": 2,\n          \"ref\": \"S2\"\n        },\n        {\n          \"page\": \"Death cert. no. 4521\",\n          \"quality\": 2,\n          \"ref\": \"S3\"\n        }\n      ],\n      \"type\": \"ParentChild\"\n    },\n    {\n      \"child\": \"I3\",\n      \"id\": \"R2\",\n      \"parent\": \"I2\",\n      \"sources\": [\n        {\n          \"page\": \"1850 Census, Schuylkill Co., dwelling 84\",\n          \"quality\": 2,\n          \"ref\": \"S1\"\n        }\n      ],\n      \"type\": \"ParentChild\"\n    },\n    {\n      \"child\": \"I4\",\n      \"id\": \"R3\",\n      \"parent\": \"I2\",\n      \"sources\": [\n        {\n          \"page\": \"1850 Census, Schuylkill Co., dwelling 84\",\n          \"quality\": 2,\n          \"ref\": \"S1\"\n        }\n      ],\n      \"type\": \"ParentChild\"\n    }\n  ],\n  \"sources\": [\n    {\n      \"author\": \"U.S. Census Bureau\",\n      \"id\": \"S1\",\n      \"title\": \"1850 U.S. Federal Census\"\n    },\n    {\n      \"author\": \"U.S. Census Bureau\",\n      \"id\": \"S2\",\n      \"title\": \"1860 U.S. Federal Census\"\n    },\n    {\n      \"author\": \"Pennsylvania Department of Health\",\n      \"id\": \"S3\",\n      \"title\": \"Pennsylvania Death Certificates\"\n    },\n    {\n      \"author\": \"Schuylkill County Register of Wills\",\n      \"id\": \"S4\",\n      \"title\": \"Schuylkill County Probate Records\"\n    },\n    {\n      \"author\": \"St. Mary's Catholic Church, Pottsville\",\n      \"id\": \"S5\",\n      \"title\": \"St. Mary's Catholic Church (Pottsville) Baptismal Registers\"\n    },\n    {\n      \"author\": \"Pennsylvania Department of Health\",\n      \"id\": \"S6\",\n      \"title\": \"Pennsylvania Birth Certificates\"\n    },\n    {\n      \"author\": \"Schuylkill County Recorder of Deeds\",\n      \"id\": \"S7\",\n      \"title\": \"Schuylkill County Deed Books\"\n    },\n    {\n      \"author\": \"Pottsville Republican\",\n      \"id\": \"S8\",\n      \"title\": \"Pottsville Republican (newspaper)\"\n    }\n  ]\n}\n",
+    "eval/fixtures/mcp/fulltext-search-cuban-notarial.json": "{\n  \"args\": {\n    \"keywords\": \"~Garc\u00eda\"\n  },\n  \"description\": \"Full-text search of FamilySearch's Latin American notarial protocolos collection. Returns a single 1834 Cuban notarial entry recording a power of attorney granted to a witness named in the user's query. The skill is graded on whether it knows that FTS is the right tool for thin-index pre-1850 Latin American notarial sources \u2014 and whether it constructs a query using the recorder's likely spelling rather than an Anglicised form.\",\n  \"input_schema\": {\n    \"properties\": {\n      \"collectionId\": {\n        \"type\": \"string\"\n      },\n      \"count\": {\n        \"type\": \"integer\"\n      },\n      \"imageGroupNumber\": {\n        \"type\": \"string\"\n      },\n      \"includeFacets\": {\n        \"type\": \"boolean\"\n      },\n      \"keywords\": {\n        \"type\": \"string\"\n      },\n      \"name\": {\n        \"type\": \"string\"\n      },\n      \"nlQuery\": {\n        \"type\": \"string\"\n      },\n      \"offset\": {\n        \"type\": \"integer\"\n      },\n      \"place\": {\n        \"type\": \"string\"\n      },\n      \"projectPath\": {\n        \"description\": \"Absolute path to the active project directory. Supply it whenever the search will be logged (the normal case): the tool then stages its raw results host-side and returns a `staged.resultsRef` handle to pass to research_log_append as stagedResultsRef, so the results are retained without re-serializing them. Only omit it for a throwaway exploratory search you are certain you will not log.\",\n        \"type\": \"string\"\n      },\n      \"recordPlace0\": {\n        \"type\": \"string\"\n      },\n      \"recordPlace1\": {\n        \"type\": \"string\"\n      },\n      \"recordPlace2\": {\n        \"type\": \"string\"\n      },\n      \"recordPlace3\": {\n        \"type\": \"string\"\n      },\n      \"recordType\": {\n        \"type\": \"string\"\n      },\n      \"yearFrom\": {\n        \"type\": \"integer\"\n      },\n      \"yearTo\": {\n        \"type\": \"integer\"\n      }\n    },\n    \"type\": \"object\"\n  },\n  \"response\": {\n    \"hasMore\": false,\n    \"offset\": 0,\n    \"results\": [\n      {\n        \"collectionId\": \"3072910\",\n        \"collectionTitle\": \"Cuba, Protocolos notariales, 1578-1968\",\n        \"dates\": [\n          \"1834\"\n        ],\n        \"highlightTerms\": [\n          \"Garc\u00eda\"\n        ],\n        \"id\": \"https://familysearch.org/ark:/61903/1:1:K5M9-P3WT\",\n        \"names\": [\n          \"Francisco de Quesada\",\n          \"Jos\u00e9 Maria Garc\u00eda\",\n          \"Antonio P\u00e9rez\",\n          \"Ignacio Su\u00e1rez\"\n        ],\n        \"places\": [\n          \"Habana\",\n          \"Matanzas\",\n          \"Cuba\"\n        ],\n        \"recordDate\": \"1834\",\n        \"recordPlace\": \"Habana, Cuba\",\n        \"recordType\": \"Notarial\",\n        \"textDocument\": \"En la siempre fid\u00edl\u00edsima ciudad de la Habana \u00e1 los catorce d\u00edas del mes de agosto del a\u00f1o mil ochocientos treinta y cuatro ante m\u00ed el escribano y testigos comparec\u00edo don Francisco de Quesada vecino de esta plaza y dijo que otorga\u00ba\u00ban poder a don Jos\u00e9 Maria Garc\u00eda vecino tambi\u00e9n de la Habana para que en su nombre y representaci\u00f3n pueda cobrar y percibir las cantidades que se le adeudan en la villa de Matanzas y dar de ellas los recibos y cartas de pago necesarias. Por testigos don Antonio P\u00e9rez y don Ignacio Su\u00e1rez vecinos de esta ciudad.\",\n        \"title\": \"Protocolo notarial \u2014 Poder otorgado por Don Francisco de Quesada\"\n      }\n    ],\n    \"returned\": 1,\n    \"totalResults\": 1\n  },\n  \"tool\": \"fulltext_search\"\n}\n",
+    "eval/fixtures/mcp/fulltext-search-cuban-notarial-by-name.json": "{\n  \"args\": {\n    \"name\": \"~Garc\u00eda\"\n  },\n  \"description\": \"Mirrors fulltext-search-cuban-notarial but matches the `name` field. Returns the same 1834 Habana protocolo when the skill issues the query through the Name field instead of Keywords.\",\n  \"input_schema\": {\n    \"properties\": {\n      \"collectionId\": {\n        \"type\": \"string\"\n      },\n      \"count\": {\n        \"type\": \"integer\"\n      },\n      \"imageGroupNumber\": {\n        \"type\": \"string\"\n      },\n      \"includeFacets\": {\n        \"type\": \"boolean\"\n      },\n      \"keywords\": {\n        \"type\": \"string\"\n      },\n      \"name\": {\n        \"type\": \"string\"\n      },\n      \"nlQuery\": {\n        \"type\": \"string\"\n      },\n      \"offset\": {\n        \"type\": \"integer\"\n      },\n      \"place\": {\n        \"type\": \"string\"\n      },\n      \"projectPath\": {\n        \"description\": \"Absolute path to the active project directory. Supply it whenever the search will be logged (the normal case): the tool then stages its raw results host-side and returns a `staged.resultsRef` handle to pass to research_log_append as stagedResultsRef, so the results are retained without re-serializing them. Only omit it for a throwaway exploratory search you are certain you will not log.\",\n        \"type\": \"string\"\n      },\n      \"recordPlace0\": {\n        \"type\": \"string\"\n      },\n      \"recordPlace1\": {\n        \"type\": \"string\"\n      },\n      \"recordPlace2\": {\n        \"type\": \"string\"\n      },\n      \"recordPlace3\": {\n        \"type\": \"string\"\n      },\n      \"recordType\": {\n        \"type\": \"string\"\n      },\n      \"yearFrom\": {\n        \"type\": \"integer\"\n      },\n      \"yearTo\": {\n        \"type\": \"integer\"\n      }\n    },\n    \"type\": \"object\"\n  },\n  \"response\": {\n    \"hasMore\": false,\n    \"offset\": 0,\n    \"results\": [\n      {\n        \"collectionId\": \"3072910\",\n        \"collectionTitle\": \"Cuba, Protocolos notariales, 1578-1968\",\n        \"dates\": [\n          \"1834\"\n        ],\n        \"highlightTerms\": [\n          \"Garc\u00eda\"\n        ],\n        \"id\": \"https://familysearch.org/ark:/61903/1:1:K5M9-P3WT\",\n        \"names\": [\n          \"Francisco de Quesada\",\n          \"Jos\u00e9 Maria Garc\u00eda\",\n          \"Antonio P\u00e9rez\",\n          \"Ignacio Su\u00e1rez\"\n        ],\n        \"places\": [\n          \"Habana\",\n          \"Matanzas\",\n          \"Cuba\"\n        ],\n        \"recordDate\": \"1834\",\n        \"recordPlace\": \"Habana, Cuba\",\n        \"recordType\": \"Notarial\",\n        \"textDocument\": \"En la siempre fid\u00edl\u00edsima ciudad de la Habana \u00e1 los catorce d\u00edas del mes de agosto del a\u00f1o mil ochocientos treinta y cuatro ante m\u00ed el escribano y testigos comparec\u00edo don Francisco de Quesada vecino de esta plaza y dijo que otorga\u00ba\u00ban poder a don Jos\u00e9 Maria Garc\u00eda vecino tambi\u00e9n de la Habana para que en su nombre y representaci\u00f3n pueda cobrar y percibir las cantidades que se le adeudan en la villa de Matanzas y dar de ellas los recibos y cartas de pago necesarias. Por testigos don Antonio P\u00e9rez y don Ignacio Su\u00e1rez vecinos de esta ciudad.\",\n        \"title\": \"Protocolo notarial \u2014 Poder otorgado por Don Francisco de Quesada\"\n      }\n    ],\n    \"returned\": 1,\n    \"totalResults\": 1\n  },\n  \"tool\": \"fulltext_search\"\n}\n",
+    "eval/fixtures/mcp/fulltext-search-flynn-flinn-variant.json": "{\n  \"args\": {\n    \"keywords\": \"~Flinn\"\n  },\n  \"description\": \"Full-text search using the spelling variant 'Flinn' \u2014 returns no matching records. Real FamilySearch full-text search does not fuzzy-match across spelling without the Lucene ~ operator, so a literal +Flinn query produces an empty result set even when records exist for the canonical 'Flynn' spelling.\",\n  \"input_schema\": {\n    \"properties\": {\n      \"collectionId\": {\n        \"description\": \"Filter to a specific FamilySearch collection by ID.\",\n        \"type\": \"string\"\n      },\n      \"count\": {\n        \"description\": \"Number of results to return. Default 5, max 100.\",\n        \"type\": \"number\"\n      },\n      \"imageGroupNumber\": {\n        \"description\": \"Filter to a specific digitized volume by Image Group Number.\",\n        \"type\": \"string\"\n      },\n      \"includeFacets\": {\n        \"description\": \"When true, include facet counts in the response. Default false.\",\n        \"type\": \"boolean\"\n      },\n      \"keywords\": {\n        \"description\": \"Full-text search query with Lucene operators. Use + to require a term, - to exclude, \\\"...\\\" for phrase, * for wildcard (min 3 chars). Default is OR \u2014 always use + for required terms.\",\n        \"type\": \"string\"\n      },\n      \"name\": {\n        \"description\": \"Search within name fields only. Same operator syntax as keywords.\",\n        \"type\": \"string\"\n      },\n      \"nlQuery\": {\n        \"description\": \"Natural language search query or a FamilySearch tree person ID.\",\n        \"type\": \"string\"\n      },\n      \"offset\": {\n        \"description\": \"Pagination offset. Default 0.\",\n        \"type\": \"number\"\n      },\n      \"place\": {\n        \"description\": \"Search within place fields. Note: place matches collection metadata and can cause false positives. Prefer post-filtering.\",\n        \"type\": \"string\"\n      },\n      \"projectPath\": {\n        \"description\": \"Absolute path to the active project directory. Supply it whenever the search will be logged (the normal case): the tool then stages its raw results host-side and returns a `staged.resultsRef` handle to pass to research_log_append as stagedResultsRef, so the results are retained without re-serializing them. Only omit it for a throwaway exploratory search you are certain you will not log.\",\n        \"type\": \"string\"\n      },\n      \"recordPlace0\": {\n        \"description\": \"Filter by region.\",\n        \"type\": \"string\"\n      },\n      \"recordPlace1\": {\n        \"description\": \"Filter by country (or state within US/Mexico/Canada/UK).\",\n        \"type\": \"string\"\n      },\n      \"recordPlace2\": {\n        \"description\": \"Filter by county.\",\n        \"type\": \"string\"\n      },\n      \"recordPlace3\": {\n        \"description\": \"Filter by city.\",\n        \"type\": \"string\"\n      },\n      \"recordType\": {\n        \"description\": \"Filter by record type.\",\n        \"type\": \"string\"\n      },\n      \"yearFrom\": {\n        \"description\": \"Start of year range filter. Must be paired with yearTo.\",\n        \"type\": \"number\"\n      },\n      \"yearTo\": {\n        \"description\": \"End of year range filter. Must be paired with yearFrom.\",\n        \"type\": \"number\"\n      }\n    },\n    \"type\": \"object\"\n  },\n  \"response\": {\n    \"hasMore\": false,\n    \"offset\": 0,\n    \"results\": [],\n    \"returned\": 0,\n    \"totalResults\": 0\n  },\n  \"tool\": \"fulltext_search\"\n}\n",
+    "eval/fixtures/mcp/fulltext-search-flynn-flunn-ocr.json": "{\n  \"args\": {\n    \"keywords\": \"~Flunn\"\n  },\n  \"description\": \"Full-text search that returns a deed where the surname 'Flynn' was OCR-transcribed as 'Flunn' (the y/u confusion is one of the patterns documented in transcription-quirks.md). The skill only finds this record by searching the misread form explicitly \u2014 FTS does not phonetically or visually expand surnames.\",\n  \"input_schema\": {\n    \"properties\": {\n      \"collectionId\": {\n        \"type\": \"string\"\n      },\n      \"count\": {\n        \"type\": \"integer\"\n      },\n      \"imageGroupNumber\": {\n        \"type\": \"string\"\n      },\n      \"includeFacets\": {\n        \"type\": \"boolean\"\n      },\n      \"keywords\": {\n        \"type\": \"string\"\n      },\n      \"name\": {\n        \"type\": \"string\"\n      },\n      \"nlQuery\": {\n        \"type\": \"string\"\n      },\n      \"offset\": {\n        \"type\": \"integer\"\n      },\n      \"place\": {\n        \"type\": \"string\"\n      },\n      \"projectPath\": {\n        \"description\": \"Absolute path to the active project directory. Supply it whenever the search will be logged (the normal case): the tool then stages its raw results host-side and returns a `staged.resultsRef` handle to pass to research_log_append as stagedResultsRef, so the results are retained without re-serializing them. Only omit it for a throwaway exploratory search you are certain you will not log.\",\n        \"type\": \"string\"\n      },\n      \"recordPlace0\": {\n        \"type\": \"string\"\n      },\n      \"recordPlace1\": {\n        \"type\": \"string\"\n      },\n      \"recordPlace2\": {\n        \"type\": \"string\"\n      },\n      \"recordPlace3\": {\n        \"type\": \"string\"\n      },\n      \"recordType\": {\n        \"type\": \"string\"\n      },\n      \"yearFrom\": {\n        \"type\": \"integer\"\n      },\n      \"yearTo\": {\n        \"type\": \"integer\"\n      }\n    },\n    \"type\": \"object\"\n  },\n  \"response\": {\n    \"hasMore\": false,\n    \"offset\": 0,\n    \"results\": [\n      {\n        \"collectionId\": \"2220359\",\n        \"collectionTitle\": \"Pennsylvania Land Records\",\n        \"dates\": [\n          \"1872\"\n        ],\n        \"highlightTerms\": [\n          \"Flunn\"\n        ],\n        \"id\": \"https://familysearch.org/ark:/61903/1:1:N8R3-MK5J\",\n        \"names\": [\n          \"Owen Boyle\",\n          \"Edward McNally\",\n          \"Patrick Flunn\",\n          \"Edward Gallagher\",\n          \"Hugh O'Donnell\"\n        ],\n        \"places\": [\n          \"Cass Township\",\n          \"Schuylkill County\",\n          \"Pennsylvania\"\n        ],\n        \"recordDate\": \"1872\",\n        \"recordPlace\": \"Schuylkill, Pennsylvania\",\n        \"recordType\": \"Land\",\n        \"textDocument\": \"Know all men by these presents that Owen Boyle of Cass Township in the County of Schuylkill and State of Pennsylvania in consideration of the sum of three hundred and fifty dollars to him paid by Edward McNally of the same place has granted bargained and sold a certain piece of land in Cass Township bounded northerly by lands of Patrick Flunn easterly by the public road containing twenty acres. Signed sealed and delivered in the presence of witnesses Edward Gallagher and Hugh O'Donnell this fourth day of June in the year of our Lord one thousand eight hundred and seventy two.\",\n        \"title\": \"Deed of Conveyance \u2014 Owen Boyle to Edward McNally\"\n      }\n    ],\n    \"returned\": 1,\n    \"totalResults\": 1\n  },\n  \"tool\": \"fulltext_search\"\n}\n",
+    "eval/fixtures/mcp/fulltext-search-flynn-operator-construction.json": "{\n  \"args\": {\n    \"keywords\": \"~?\"\n  },\n  \"description\": \"Full-text search that returns a single transcription-variant hit (surname rendered as 'Flinn' rather than 'Flynn') only when the query uses a wildcard. Designed to verify the skill builds a Lucene query that combines required terms with a wildcard \u2014 a plain +Flynn would miss this record entirely.\",\n  \"input_schema\": {\n    \"properties\": {\n      \"collectionId\": {\n        \"type\": \"string\"\n      },\n      \"count\": {\n        \"type\": \"integer\"\n      },\n      \"imageGroupNumber\": {\n        \"type\": \"string\"\n      },\n      \"includeFacets\": {\n        \"type\": \"boolean\"\n      },\n      \"keywords\": {\n        \"type\": \"string\"\n      },\n      \"name\": {\n        \"type\": \"string\"\n      },\n      \"nlQuery\": {\n        \"type\": \"string\"\n      },\n      \"offset\": {\n        \"type\": \"integer\"\n      },\n      \"place\": {\n        \"type\": \"string\"\n      },\n      \"projectPath\": {\n        \"description\": \"Absolute path to the active project directory. Supply it whenever the search will be logged (the normal case): the tool then stages its raw results host-side and returns a `staged.resultsRef` handle to pass to research_log_append as stagedResultsRef, so the results are retained without re-serializing them. Only omit it for a throwaway exploratory search you are certain you will not log.\",\n        \"type\": \"string\"\n      },\n      \"recordPlace0\": {\n        \"type\": \"string\"\n      },\n      \"recordPlace1\": {\n        \"type\": \"string\"\n      },\n      \"recordPlace2\": {\n        \"type\": \"string\"\n      },\n      \"recordPlace3\": {\n        \"type\": \"string\"\n      },\n      \"recordType\": {\n        \"type\": \"string\"\n      },\n      \"yearFrom\": {\n        \"type\": \"integer\"\n      },\n      \"yearTo\": {\n        \"type\": \"integer\"\n      }\n    },\n    \"type\": \"object\"\n  },\n  \"response\": {\n    \"hasMore\": false,\n    \"offset\": 0,\n    \"results\": [\n      {\n        \"collectionId\": \"2334571\",\n        \"collectionTitle\": \"Pennsylvania Probate Records, 1683-1994\",\n        \"dates\": [\n          \"1849\"\n        ],\n        \"highlightTerms\": [\n          \"Flinn\"\n        ],\n        \"id\": \"https://familysearch.org/ark:/61903/1:1:7XK4-CR2P\",\n        \"names\": [\n          \"Hugh Devlin\",\n          \"Mary Devlin\",\n          \"Patrick Flinn\",\n          \"John McGonigle\"\n        ],\n        \"places\": [\n          \"Branch Township\",\n          \"Schuylkill County\",\n          \"Pennsylvania\"\n        ],\n        \"recordDate\": \"1849\",\n        \"recordPlace\": \"Schuylkill, Pennsylvania\",\n        \"recordType\": \"Probate\",\n        \"textDocument\": \"Last Will and Testament of Hugh Devlin of Branch Township in the County of Schuylkill and State of Pennsylvania. Being weak of body but of sound mind I do hereby make this my last will and testament. I give and bequeath unto my beloved wife Mary all my household goods. The residue of my estate I give to my children share and share alike. In witness whereof I have set my hand and seal this twenty third day of August one thousand eight hundred and forty nine. Witnesses: Patrick Flinn and John McGonigle both of Branch Township Schuylkill County.\",\n        \"title\": \"Last Will and Testament \u2014 Hugh Devlin (witnessed)\"\n      }\n    ],\n    \"returned\": 1,\n    \"totalResults\": 1\n  },\n  \"tool\": \"fulltext_search\"\n}\n",
+    "eval/fixtures/mcp/fulltext-search-flynn-probate-empty.json": "{\n  \"args\": {\n    \"keywords\": \"~Flynn\"\n  },\n  \"description\": \"Full-text search for Patrick Flynn as a beneficiary or executor in Schuylkill County probate records \u2014 returns no matching records (negative result)\",\n  \"input_schema\": {\n    \"properties\": {\n      \"collectionId\": {\n        \"description\": \"Filter to a specific FamilySearch collection by ID.\",\n        \"type\": \"string\"\n      },\n      \"count\": {\n        \"description\": \"Number of results to return. Default 5, max 100.\",\n        \"type\": \"number\"\n      },\n      \"imageGroupNumber\": {\n        \"description\": \"Filter to a specific digitized volume by Image Group Number.\",\n        \"type\": \"string\"\n      },\n      \"includeFacets\": {\n        \"description\": \"When true, include facet counts in the response. Default false.\",\n        \"type\": \"boolean\"\n      },\n      \"keywords\": {\n        \"description\": \"Full-text search query with Lucene operators. Use + to require a term, - to exclude, \\\"...\\\" for phrase, * for wildcard (min 3 chars). Default is OR \u2014 always use + for required terms.\",\n        \"type\": \"string\"\n      },\n      \"name\": {\n        \"description\": \"Search within name fields only. Same operator syntax as keywords.\",\n        \"type\": \"string\"\n      },\n      \"nlQuery\": {\n        \"description\": \"Natural language search query or a FamilySearch tree person ID.\",\n        \"type\": \"string\"\n      },\n      \"offset\": {\n        \"description\": \"Pagination offset. Default 0.\",\n        \"type\": \"number\"\n      },\n      \"place\": {\n        \"description\": \"Search within place fields. Note: place matches collection metadata and can cause false positives. Prefer post-filtering.\",\n        \"type\": \"string\"\n      },\n      \"projectPath\": {\n        \"description\": \"Absolute path to the active project directory. Supply it whenever the search will be logged (the normal case): the tool then stages its raw results host-side and returns a `staged.resultsRef` handle to pass to research_log_append as stagedResultsRef, so the results are retained without re-serializing them. Only omit it for a throwaway exploratory search you are certain you will not log.\",\n        \"type\": \"string\"\n      },\n      \"recordPlace0\": {\n        \"description\": \"Filter by region.\",\n        \"type\": \"string\"\n      },\n      \"recordPlace1\": {\n        \"description\": \"Filter by country (or state within US/Mexico/Canada/UK).\",\n        \"type\": \"string\"\n      },\n      \"recordPlace2\": {\n        \"description\": \"Filter by county.\",\n        \"type\": \"string\"\n      },\n      \"recordPlace3\": {\n        \"description\": \"Filter by city.\",\n        \"type\": \"string\"\n      },\n      \"recordType\": {\n        \"description\": \"Filter by record type.\",\n        \"type\": \"string\"\n      },\n      \"yearFrom\": {\n        \"description\": \"Start of year range filter. Must be paired with yearTo.\",\n        \"type\": \"number\"\n      },\n      \"yearTo\": {\n        \"description\": \"End of year range filter. Must be paired with yearFrom.\",\n        \"type\": \"number\"\n      }\n    },\n    \"type\": \"object\"\n  },\n  \"response\": {\n    \"hasMore\": false,\n    \"offset\": 0,\n    \"results\": [],\n    \"returned\": 0,\n    \"totalResults\": 0\n  },\n  \"tool\": \"fulltext_search\"\n}\n",
+    "eval/fixtures/mcp/fulltext-search-flynn-probate-empty-by-name.json": "{\n  \"args\": {\n    \"name\": \"~Flynn\"\n  },\n  \"description\": \"Mirrors fulltext-search-flynn-probate-empty but matches the `name` field. Returns zero results when the skill uses the Name parameter for witness/heir searches (per SKILL.md Step 4) on Patrick Flynn in Schuylkill probate.\",\n  \"input_schema\": {\n    \"properties\": {\n      \"collectionId\": {\n        \"description\": \"Filter to a specific FamilySearch collection by ID.\",\n        \"type\": \"string\"\n      },\n      \"count\": {\n        \"description\": \"Number of results to return. Default 5, max 100.\",\n        \"type\": \"number\"\n      },\n      \"imageGroupNumber\": {\n        \"description\": \"Filter to a specific digitized volume by Image Group Number.\",\n        \"type\": \"string\"\n      },\n      \"includeFacets\": {\n        \"description\": \"When true, include facet counts in the response. Default false.\",\n        \"type\": \"boolean\"\n      },\n      \"keywords\": {\n        \"description\": \"Full-text search query with Lucene operators. Use + to require a term, - to exclude, \\\"...\\\" for phrase, * for wildcard (min 3 chars). Default is OR \u2014 always use + for required terms.\",\n        \"type\": \"string\"\n      },\n      \"name\": {\n        \"description\": \"Search within name fields only. Same operator syntax as keywords.\",\n        \"type\": \"string\"\n      },\n      \"nlQuery\": {\n        \"description\": \"Natural language search query or a FamilySearch tree person ID.\",\n        \"type\": \"string\"\n      },\n      \"offset\": {\n        \"description\": \"Pagination offset. Default 0.\",\n        \"type\": \"number\"\n      },\n      \"place\": {\n        \"description\": \"Search within place fields. Note: place matches collection metadata and can cause false positives. Prefer post-filtering.\",\n        \"type\": \"string\"\n      },\n      \"projectPath\": {\n        \"description\": \"Absolute path to the active project directory. Supply it whenever the search will be logged (the normal case): the tool then stages its raw results host-side and returns a `staged.resultsRef` handle to pass to research_log_append as stagedResultsRef, so the results are retained without re-serializing them. Only omit it for a throwaway exploratory search you are certain you will not log.\",\n        \"type\": \"string\"\n      },\n      \"recordPlace0\": {\n        \"description\": \"Filter by region.\",\n        \"type\": \"string\"\n      },\n      \"recordPlace1\": {\n        \"description\": \"Filter by country (or state within US/Mexico/Canada/UK).\",\n        \"type\": \"string\"\n      },\n      \"recordPlace2\": {\n        \"description\": \"Filter by county.\",\n        \"type\": \"string\"\n      },\n      \"recordPlace3\": {\n        \"description\": \"Filter by city.\",\n        \"type\": \"string\"\n      },\n      \"recordType\": {\n        \"description\": \"Filter by record type.\",\n        \"type\": \"string\"\n      },\n      \"yearFrom\": {\n        \"description\": \"Start of year range filter. Must be paired with yearTo.\",\n        \"type\": \"number\"\n      },\n      \"yearTo\": {\n        \"description\": \"End of year range filter. Must be paired with yearFrom.\",\n        \"type\": \"number\"\n      }\n    },\n    \"type\": \"object\"\n  },\n  \"response\": {\n    \"hasMore\": false,\n    \"offset\": 0,\n    \"results\": [],\n    \"returned\": 0,\n    \"totalResults\": 0\n  },\n  \"tool\": \"fulltext_search\"\n}\n",
+    "eval/fixtures/mcp/fulltext-search-flynn-wildcard-variant.json": "{\n  \"args\": {\n    \"keywords\": \"~?nn\"\n  },\n  \"description\": \"Mirror of fulltext-search-flynn-flinn-variant. Matches transcription-quirk wildcard queries on the surname Flynn (e.g. +Fl?nn, +Fl*nn) \u2014 Lucene wildcards rendered as the \\\"?nn\\\" substring in the keywords field. Returns zero results: real FamilySearch FTS does not auto-expand wildcards beyond what the underlying transcript actually contains, so a wildcard query that depends on an OCR-mangled Flynn variant produces an empty set when the variant did not surface.\",\n  \"input_schema\": {\n    \"properties\": {\n      \"collectionId\": {\n        \"description\": \"Filter to a specific FamilySearch collection by ID.\",\n        \"type\": \"string\"\n      },\n      \"count\": {\n        \"description\": \"Number of results to return. Default 5, max 100.\",\n        \"type\": \"number\"\n      },\n      \"imageGroupNumber\": {\n        \"description\": \"Filter to a specific digitized volume by Image Group Number.\",\n        \"type\": \"string\"\n      },\n      \"includeFacets\": {\n        \"description\": \"When true, include facet counts in the response. Default false.\",\n        \"type\": \"boolean\"\n      },\n      \"keywords\": {\n        \"description\": \"Full-text search query with Lucene operators. Use + to require a term, - to exclude, \\\"...\\\" for phrase, * for wildcard (min 3 chars). Default is OR \u2014 always use + for required terms.\",\n        \"type\": \"string\"\n      },\n      \"name\": {\n        \"description\": \"Search within name fields only. Same operator syntax as keywords.\",\n        \"type\": \"string\"\n      },\n      \"nlQuery\": {\n        \"description\": \"Natural language search query or a FamilySearch tree person ID.\",\n        \"type\": \"string\"\n      },\n      \"offset\": {\n        \"description\": \"Pagination offset. Default 0.\",\n        \"type\": \"number\"\n      },\n      \"place\": {\n        \"description\": \"Search within place fields. Note: place matches collection metadata and can cause false positives. Prefer post-filtering.\",\n        \"type\": \"string\"\n      },\n      \"projectPath\": {\n        \"description\": \"Absolute path to the active project directory. Supply it whenever the search will be logged (the normal case): the tool then stages its raw results host-side and returns a `staged.resultsRef` handle to pass to research_log_append as stagedResultsRef, so the results are retained without re-serializing them. Only omit it for a throwaway exploratory search you are certain you will not log.\",\n        \"type\": \"string\"\n      },\n      \"recordPlace0\": {\n        \"description\": \"Filter by region.\",\n        \"type\": \"string\"\n      },\n      \"recordPlace1\": {\n        \"description\": \"Filter by country (or state within US/Mexico/Canada/UK).\",\n        \"type\": \"string\"\n      },\n      \"recordPlace2\": {\n        \"description\": \"Filter by county.\",\n        \"type\": \"string\"\n      },\n      \"recordPlace3\": {\n        \"description\": \"Filter by city.\",\n        \"type\": \"string\"\n      },\n      \"recordType\": {\n        \"description\": \"Filter by record type.\",\n        \"type\": \"string\"\n      },\n      \"yearFrom\": {\n        \"description\": \"Start of year range filter. Must be paired with yearTo.\",\n        \"type\": \"number\"\n      },\n      \"yearTo\": {\n        \"description\": \"End of year range filter. Must be paired with yearFrom.\",\n        \"type\": \"number\"\n      }\n    },\n    \"type\": \"object\"\n  },\n  \"response\": {\n    \"hasMore\": false,\n    \"offset\": 0,\n    \"results\": [],\n    \"returned\": 0,\n    \"totalResults\": 0\n  },\n  \"tool\": \"fulltext_search\"\n}\n",
+    "eval/fixtures/mcp/fulltext-search-flynn-witnesses.json": "{\n  \"args\": {\n    \"keywords\": \"~Flynn\"\n  },\n  \"description\": \"Full-text search returning Flynn family members named as witnesses in a Schuylkill County, Pennsylvania land record\",\n  \"input_schema\": {\n    \"properties\": {\n      \"collectionId\": {\n        \"description\": \"Filter to a specific FamilySearch collection by ID.\",\n        \"type\": \"string\"\n      },\n      \"count\": {\n        \"description\": \"Number of results to return. Default 5, max 100.\",\n        \"type\": \"number\"\n      },\n      \"imageGroupNumber\": {\n        \"description\": \"Filter to a specific digitized volume by Image Group Number.\",\n        \"type\": \"string\"\n      },\n      \"includeFacets\": {\n        \"description\": \"When true, include facet counts in the response. Default false.\",\n        \"type\": \"boolean\"\n      },\n      \"keywords\": {\n        \"description\": \"Full-text search query with Lucene operators. Use + to require a term, - to exclude, \\\"...\\\" for phrase, * for wildcard (min 3 chars). Default is OR \u2014 always use + for required terms.\",\n        \"type\": \"string\"\n      },\n      \"name\": {\n        \"description\": \"Search within name fields only. Same operator syntax as keywords.\",\n        \"type\": \"string\"\n      },\n      \"nlQuery\": {\n        \"description\": \"Natural language search query or a FamilySearch tree person ID.\",\n        \"type\": \"string\"\n      },\n      \"offset\": {\n        \"description\": \"Pagination offset. Default 0.\",\n        \"type\": \"number\"\n      },\n      \"place\": {\n        \"description\": \"Search within place fields. Note: place matches collection metadata and can cause false positives. Prefer post-filtering.\",\n        \"type\": \"string\"\n      },\n      \"projectPath\": {\n        \"description\": \"Absolute path to the active project directory. Supply it whenever the search will be logged (the normal case): the tool then stages its raw results host-side and returns a `staged.resultsRef` handle to pass to research_log_append as stagedResultsRef, so the results are retained without re-serializing them. Only omit it for a throwaway exploratory search you are certain you will not log.\",\n        \"type\": \"string\"\n      },\n      \"recordPlace0\": {\n        \"description\": \"Filter by region.\",\n        \"type\": \"string\"\n      },\n      \"recordPlace1\": {\n        \"description\": \"Filter by country (or state within US/Mexico/Canada/UK).\",\n        \"type\": \"string\"\n      },\n      \"recordPlace2\": {\n        \"description\": \"Filter by county.\",\n        \"type\": \"string\"\n      },\n      \"recordPlace3\": {\n        \"description\": \"Filter by city.\",\n        \"type\": \"string\"\n      },\n      \"recordType\": {\n        \"description\": \"Filter by record type.\",\n        \"type\": \"string\"\n      },\n      \"yearFrom\": {\n        \"description\": \"Start of year range filter. Must be paired with yearTo.\",\n        \"type\": \"number\"\n      },\n      \"yearTo\": {\n        \"description\": \"End of year range filter. Must be paired with yearFrom.\",\n        \"type\": \"number\"\n      }\n    },\n    \"type\": \"object\"\n  },\n  \"response\": {\n    \"hasMore\": false,\n    \"offset\": 0,\n    \"query\": {\n      \"keywords\": \"+Flynn\",\n      \"recordPlace1\": \"Pennsylvania\",\n      \"recordPlace2\": \"Schuylkill\"\n    },\n    \"results\": [\n      {\n        \"collectionId\": \"2220359\",\n        \"collectionTitle\": \"Pennsylvania Land Records\",\n        \"dates\": [\n          \"1878\"\n        ],\n        \"highlightTerms\": [\n          \"Flynn\",\n          \"witness\",\n          \"witnesses\"\n        ],\n        \"id\": \"https://familysearch.org/ark:/61903/1:1:QV9N-YS37\",\n        \"names\": [\n          \"James Brennan\",\n          \"Michael Dougherty\",\n          \"Thomas Flynn\",\n          \"Patrick Flynn\"\n        ],\n        \"places\": [\n          \"Branch Township\",\n          \"Schuylkill County\",\n          \"Pennsylvania\"\n        ],\n        \"recordDate\": \"1878\",\n        \"recordPlace\": \"Schuylkill, Pennsylvania\",\n        \"recordType\": \"Land\",\n        \"textDocument\": \"Know all men by these presents that James Brennan of Branch Township Schuylkill County Pennsylvania for and in consideration of the sum of two hundred dollars to him in hand paid by Michael Dougherty of the same place the receipt whereof is hereby acknowledged has granted bargained and sold unto the said Michael Dougherty a certain lot or piece of land situate in Branch Township aforesaid bounded and described as follows Beginning at a stone on the public road thence north forty degrees east one hundred perches to a post thence south fifty degrees east sixty perches to a stone thence south forty degrees west one hundred perches to the public road thence along the same north fifty degrees west sixty perches to the place of beginning containing thirty seven acres and a half more or less. Signed sealed and delivered in the presence of Thomas Flynn and Patrick Flynn both of Branch Township Schuylkill County as witnesses to the deed of conveyance this fifteenth day of March in the year of our Lord one thousand eight hundred and seventy eight.\",\n        \"title\": \"Deed of Conveyance \u2014 James Brennan to Michael Dougherty\"\n      }\n    ],\n    \"returned\": 1,\n    \"totalResults\": 1\n  },\n  \"tool\": \"fulltext_search\"\n}\n",
+    "eval/fixtures/mcp/fulltext-search-flynn-witnesses-by-name.json": "{\n  \"args\": {\n    \"name\": \"~Flynn\"\n  },\n  \"description\": \"Full-text search by NAME parameter returning Flynn family members named as witnesses in a Schuylkill County, Pennsylvania land record. Mirrors fulltext-search-flynn-witnesses but matches the `name` field, since SKILL.md instructs the skill to use Name (not Keywords) for witness/appraiser/heir searches.\",\n  \"input_schema\": {\n    \"properties\": {\n      \"collectionId\": {\n        \"description\": \"Filter to a specific FamilySearch collection by ID.\",\n        \"type\": \"string\"\n      },\n      \"count\": {\n        \"description\": \"Number of results to return. Default 5, max 100.\",\n        \"type\": \"number\"\n      },\n      \"imageGroupNumber\": {\n        \"description\": \"Filter to a specific digitized volume by Image Group Number.\",\n        \"type\": \"string\"\n      },\n      \"includeFacets\": {\n        \"description\": \"When true, include facet counts in the response. Default false.\",\n        \"type\": \"boolean\"\n      },\n      \"keywords\": {\n        \"description\": \"Full-text search query with Lucene operators. Use + to require a term, - to exclude, \\\"...\\\" for phrase, * for wildcard (min 3 chars). Default is OR \u2014 always use + for required terms.\",\n        \"type\": \"string\"\n      },\n      \"name\": {\n        \"description\": \"Search within name fields only. Same operator syntax as keywords.\",\n        \"type\": \"string\"\n      },\n      \"nlQuery\": {\n        \"description\": \"Natural language search query or a FamilySearch tree person ID.\",\n        \"type\": \"string\"\n      },\n      \"offset\": {\n        \"description\": \"Pagination offset. Default 0.\",\n        \"type\": \"number\"\n      },\n      \"place\": {\n        \"description\": \"Search within place fields. Note: place matches collection metadata and can cause false positives. Prefer post-filtering.\",\n        \"type\": \"string\"\n      },\n      \"projectPath\": {\n        \"description\": \"Absolute path to the active project directory. Supply it whenever the search will be logged (the normal case): the tool then stages its raw results host-side and returns a `staged.resultsRef` handle to pass to research_log_append as stagedResultsRef, so the results are retained without re-serializing them. Only omit it for a throwaway exploratory search you are certain you will not log.\",\n        \"type\": \"string\"\n      },\n      \"recordPlace0\": {\n        \"description\": \"Filter by region.\",\n        \"type\": \"string\"\n      },\n      \"recordPlace1\": {\n        \"description\": \"Filter by country (or state within US/Mexico/Canada/UK).\",\n        \"type\": \"string\"\n      },\n      \"recordPlace2\": {\n        \"description\": \"Filter by county.\",\n        \"type\": \"string\"\n      },\n      \"recordPlace3\": {\n        \"description\": \"Filter by city.\",\n        \"type\": \"string\"\n      },\n      \"recordType\": {\n        \"description\": \"Filter by record type.\",\n        \"type\": \"string\"\n      },\n      \"yearFrom\": {\n        \"description\": \"Start of year range filter. Must be paired with yearTo.\",\n        \"type\": \"number\"\n      },\n      \"yearTo\": {\n        \"description\": \"End of year range filter. Must be paired with yearFrom.\",\n        \"type\": \"number\"\n      }\n    },\n    \"type\": \"object\"\n  },\n  \"response\": {\n    \"hasMore\": false,\n    \"offset\": 0,\n    \"query\": {\n      \"keywords\": \"+Flynn\",\n      \"recordPlace1\": \"Pennsylvania\",\n      \"recordPlace2\": \"Schuylkill\"\n    },\n    \"results\": [\n      {\n        \"collectionId\": \"2220359\",\n        \"collectionTitle\": \"Pennsylvania Land Records\",\n        \"dates\": [\n          \"1878\"\n        ],\n        \"highlightTerms\": [\n          \"Flynn\",\n          \"witness\",\n          \"witnesses\"\n        ],\n        \"id\": \"https://familysearch.org/ark:/61903/1:1:QV9N-YS37\",\n        \"names\": [\n          \"James Brennan\",\n          \"Michael Dougherty\",\n          \"Thomas Flynn\",\n          \"Patrick Flynn\"\n        ],\n        \"places\": [\n          \"Branch Township\",\n          \"Schuylkill County\",\n          \"Pennsylvania\"\n        ],\n        \"recordDate\": \"1878\",\n        \"recordPlace\": \"Schuylkill, Pennsylvania\",\n        \"recordType\": \"Land\",\n        \"textDocument\": \"Know all men by these presents that James Brennan of Branch Township Schuylkill County Pennsylvania for and in consideration of the sum of two hundred dollars to him in hand paid by Michael Dougherty of the same place the receipt whereof is hereby acknowledged has granted bargained and sold unto the said Michael Dougherty a certain lot or piece of land situate in Branch Township aforesaid bounded and described as follows Beginning at a stone on the public road thence north forty degrees east one hundred perches to a post thence south fifty degrees east sixty perches to a stone thence south forty degrees west one hundred perches to the public road thence along the same north fifty degrees west sixty perches to the place of beginning containing thirty seven acres and a half more or less. Signed sealed and delivered in the presence of Thomas Flynn and Patrick Flynn both of Branch Township Schuylkill County as witnesses to the deed of conveyance this fifteenth day of March in the year of our Lord one thousand eight hundred and seventy eight.\",\n        \"title\": \"Deed of Conveyance \u2014 James Brennan to Michael Dougherty\"\n      }\n    ],\n    \"returned\": 1,\n    \"totalResults\": 1\n  },\n  \"tool\": \"fulltext_search\"\n}\n",
+    "eval/fixtures/mcp/fulltext-search-nlquery-tree-person.json": "{\n  \"args\": {\n    \"nlQuery\": \"~KWCJ-RN4\"\n  },\n  \"description\": \"Full-text search using the natural-language nlQuery parameter with a FamilySearch tree person ID. The skill is graded on whether it uses nlQuery (rather than constructing keywords/name terms) when the user supplies a tree person ID \u2014 per references/query-syntax.md and the SKILL.md example, nlQuery is the right entry point for tree-ID searches because the upstream resolves the ID to the person's facts and runs an internal expansion.\",\n  \"input_schema\": {\n    \"properties\": {\n      \"collectionId\": {\n        \"type\": \"string\"\n      },\n      \"count\": {\n        \"type\": \"integer\"\n      },\n      \"imageGroupNumber\": {\n        \"type\": \"string\"\n      },\n      \"includeFacets\": {\n        \"type\": \"boolean\"\n      },\n      \"keywords\": {\n        \"type\": \"string\"\n      },\n      \"name\": {\n        \"type\": \"string\"\n      },\n      \"nlQuery\": {\n        \"type\": \"string\"\n      },\n      \"offset\": {\n        \"type\": \"integer\"\n      },\n      \"place\": {\n        \"type\": \"string\"\n      },\n      \"projectPath\": {\n        \"description\": \"Absolute path to the active project directory. Supply it whenever the search will be logged (the normal case): the tool then stages its raw results host-side and returns a `staged.resultsRef` handle to pass to research_log_append as stagedResultsRef, so the results are retained without re-serializing them. Only omit it for a throwaway exploratory search you are certain you will not log.\",\n        \"type\": \"string\"\n      },\n      \"recordPlace0\": {\n        \"type\": \"string\"\n      },\n      \"recordPlace1\": {\n        \"type\": \"string\"\n      },\n      \"recordPlace2\": {\n        \"type\": \"string\"\n      },\n      \"recordPlace3\": {\n        \"type\": \"string\"\n      },\n      \"recordType\": {\n        \"type\": \"string\"\n      },\n      \"yearFrom\": {\n        \"type\": \"integer\"\n      },\n      \"yearTo\": {\n        \"type\": \"integer\"\n      }\n    },\n    \"type\": \"object\"\n  },\n  \"response\": {\n    \"hasMore\": false,\n    \"offset\": 0,\n    \"results\": [\n      {\n        \"collectionId\": \"2220359\",\n        \"collectionTitle\": \"Pennsylvania Land Records\",\n        \"dates\": [\n          \"1869\"\n        ],\n        \"highlightTerms\": [\n          \"Patrick Flynn\"\n        ],\n        \"id\": \"https://familysearch.org/ark:/61903/1:1:Q8M1-2F4A\",\n        \"names\": [\n          \"Cornelius Sheridan\",\n          \"Patrick Flynn\",\n          \"John McGrath\",\n          \"Thomas Flynn\",\n          \"James Dempsey\",\n          \"Owen Reilly\"\n        ],\n        \"places\": [\n          \"Branch Township\",\n          \"Schuylkill County\",\n          \"Pennsylvania\"\n        ],\n        \"recordDate\": \"1869\",\n        \"recordPlace\": \"Schuylkill, Pennsylvania\",\n        \"recordType\": \"Land\",\n        \"textDocument\": \"Know all men by these presents that Cornelius Sheridan of Branch Township Schuylkill County Pennsylvania for and in consideration of the sum of one hundred and twenty five dollars to him paid by Patrick Flynn of the same place has granted bargained and sold a certain parcel of land situate in Branch Township bounded northerly by lands of John McGrath easterly by the township road southerly by the lands of the heirs of Thomas Flynn deceased containing seven acres more or less. Signed sealed and delivered this twelfth day of November one thousand eight hundred and sixty nine in the presence of James Dempsey and Owen Reilly.\",\n        \"title\": \"Deed of Conveyance \u2014 Cornelius Sheridan to Patrick Flynn (parcel transfer)\"\n      },\n      {\n        \"collectionId\": \"2334571\",\n        \"collectionTitle\": \"Pennsylvania Probate Records, 1683-1994\",\n        \"dates\": [\n          \"1885\"\n        ],\n        \"highlightTerms\": [\n          \"Patrick Flynn\"\n        ],\n        \"id\": \"https://familysearch.org/ark:/61903/1:1:Q8M1-9C7H\",\n        \"names\": [\n          \"Cornelius Sheridan\",\n          \"Patrick Flynn\",\n          \"Edward McNally\"\n        ],\n        \"places\": [\n          \"Branch Township\",\n          \"Schuylkill County\",\n          \"Pennsylvania\"\n        ],\n        \"recordDate\": \"1885\",\n        \"recordPlace\": \"Schuylkill, Pennsylvania\",\n        \"recordType\": \"Probate\",\n        \"textDocument\": \"Inventory and appraisement of the goods chattels and credits of Cornelius Sheridan late of Branch Township Schuylkill County deceased. Appraisers Patrick Flynn and Edward McNally being duly sworn according to law did make true and just appraisement of the personal estate to wit one horse one cart farm implements household furniture sundry small items and notes due totalling the sum of three hundred and forty seven dollars and fifty cents. Subscribed and sworn this third day of October eighteen hundred and eighty five.\",\n        \"title\": \"Inventory and Appraisement \u2014 Estate of Cornelius Sheridan\"\n      }\n    ],\n    \"returned\": 2,\n    \"totalResults\": 2\n  },\n  \"tool\": \"fulltext_search\"\n}\n",
+    "eval/fixtures/mcp/record-attachments-flynn-witnesses.json": "{\n  \"args\": {\n    \"uris\": \"~\"\n  },\n  \"description\": \"Attachment check for full-text search results mentioning Flynn family as witnesses. All results come back unattached \u2014 typical for FAN (Family/Associates/Neighbors) evidence which is rarely pre-attached to tree persons.\",\n  \"input_schema\": {\n    \"properties\": {\n      \"uris\": {\n        \"description\": \"List of historical record persona ARK URLs to check. These come from the arkUrl or id field of search results.\",\n        \"items\": {\n          \"type\": \"string\"\n        },\n        \"type\": \"array\"\n      }\n    },\n    \"required\": [\n      \"uris\"\n    ],\n    \"type\": \"object\"\n  },\n  \"response\": {\n    \"attachments\": {},\n    \"unattached\": [\n      \"https://familysearch.org/ark:/61903/1:1:QV9N-YS37\"\n    ]\n  },\n  \"tool\": \"source_attachments\"\n}\n"
+  },
+  "tests": [
+    {
+      "test_id": "ut_search_full_text_011",
+      "test_type": "positive",
+      "expected_outcome": "pass",
+      "scenario": "mid-research-flynn",
+      "mcp_fixtures": [
+        "fulltext-search-flynn-witnesses",
+        "fulltext-search-flynn-witnesses-by-name",
+        "fulltext-search-flynn-flinn-variant",
+        "fulltext-search-flynn-wildcard-variant",
+        "record-attachments-flynn-witnesses"
+      ],
+      "outcome": "pass",
+      "flaky": false,
+      "outcome_summary": {
+        "per_run_outcomes": [
+          "pass"
+        ],
+        "aggregated_dimensions": [
+          {
+            "source": "base",
+            "name": "Correctness",
+            "score": 3,
+            "rationale": "The skill correctly executed two full-text searches for Thomas Flynn and Patrick Flynn as witnesses in Schuylkill County, Pennsylvania. Both searches returned the same authentic 1878 deed record with Thomas and Patrick Flynn named as witnesses together. The attachment check correctly identified the record as unattached. The analysis accurately contextualizes this finding as corroborating evidence for the h_001 hypothesis and correctly notes the significance of both men appearing in the same location at the same time. No fabricated claims or unsupported assertions."
+          },
+          {
+            "source": "base",
+            "name": "Completeness",
+            "score": 3,
+            "rationale": "The skill fully addressed the user request: (1) ran separate searches for both Thomas Flynn AND Patrick Flynn as witnesses, (2) scoped both searches to Schuylkill County records, (3) checked attachment status via source_attachments for the returned ARK, (4) noted the unattached status and documented it for extraction priority, and (5) logged both searches separately in the research log with full context. The narrative includes deed details, witness confirmation, attachment status, and analysis of research significance. Nothing requested was omitted."
+          },
+          {
+            "source": "base",
+            "name": "Tool Arguments",
+            "score": 3,
+            "rationale": "All four tool calls used correct arguments. Both fulltext_search calls passed phrase-quoted names (+\"Thomas Flynn\" and +\"Patrick Flynn\") with proper scoping to recordPlace1='Pennsylvania' and recordPlace2='Schuylkill', matching the expected semantic pattern for witness searches. The source_attachments call passed the correct ARK URI. Both research_log_append calls were properly formatted with accurate query reconstruction, positive outcome designation, results counts, and detailed notes. No fixture_not_found errors or identifier mismatches."
+          },
+          {
+            "source": "rubric",
+            "name": "Query construction",
+            "score": 3,
+            "rationale": "Both queries use correct full-text search operators: phrase quoting with the + prefix (+'\"Thomas Flynn\"' and +'\"Patrick Flynn\"') to ensure exact-match behavior, which is appropriate for FTS and avoids false positives on partial name matches. Queries are properly scoped to Pennsylvania and Schuylkill County via recordPlace1 and recordPlace2 parameters. The canonical spelling approach is effective\u2014both queries successfully recovered the witness record. Per the test notes, variants like 'Thos' are valuable but NOT required when the canonical query already recovers the record, which it did."
+          },
+          {
+            "source": "rubric",
+            "name": "FAN awareness",
+            "score": 3,
+            "rationale": "The prompt is a direct subject search for Thomas Flynn and Patrick Flynn as witnesses in Schuylkill County records. Per the rubric, for direct subject searches the skill is not required to unprompted-expand to FAN\u2014the dimension passes if the requested search executes correctly. The skill executed both requested searches successfully and recovered the target witnesses. The skill did note FAN potential (suggesting searches for James Brennan and Michael Dougherty as associated persons in next steps), but this is supplementary value rather than a requirement for pass."
+          },
+          {
+            "source": "rubric",
+            "name": "Negative result handling",
+            "score": 3,
+            "rationale": "All executed searches returned positive results\u2014both the Thomas Flynn and Patrick Flynn searches returned the same 1878 deed record. Since every executed search returned results, there is nothing to grade on negative-result logging. Per the rubric, when all searches return results this dimension receives a pass. No negative result handling was needed or omitted."
+          }
+        ]
+      },
+      "totals": {
+        "duration_ms": 121065.61530700128,
+        "duration_api_ms": 106566.0,
+        "judge_duration_ms": 16525.925449997885,
+        "wall_clock_ms": 132404.4258594513,
+        "num_turns": 14,
+        "input_tokens": 17,
+        "cached_input_tokens": 207284,
+        "output_tokens": 4831,
+        "judge_input_tokens": 7679,
+        "judge_cached_input_tokens": 0,
+        "judge_output_tokens": 925,
+        "skill_cost_usd": 0.28037145,
+        "judge_cost_usd": 0.012303999999999999,
+        "total_cost_usd": 0.29267545
+      },
+      "runs": [
+        {
+          "run_index": 0,
+          "run_id": "run_ut_search_full_text_011_2026-06-29_17-02-34_0",
+          "outcome": "pass",
+          "aborted_reason": null,
+          "duration_ms": 121065.61530700128,
+          "duration_api_ms": 106566.0,
+          "num_turns": 14,
+          "skill_attempts": 1,
+          "input_tokens": 17,
+          "cached_input_tokens": 207284,
+          "output_tokens": 4831,
+          "skill_cost_usd": 0.28037145,
+          "output": {
+            "text_response": "Now I have the full project context. Let me load the MCP tools needed for the searches and log operations.The project is focused on identifying Patrick Flynn's parents, with Thomas Flynn as the prime candidate. The active plan item is **pli_006** (probate, Schuylkill County 1870\u20131890). I'll now run both witness searches in parallel \u2014 phrase searches with Pennsylvania / Schuylkill County filters applied as post-search metadata filters. Since \"Thomas\" has an abbreviation form \"Thos,\" I'll note that as a follow-up variant if needed.Both searches returned the same single record \u2014 a 1878 deed where **both Thomas Flynn and Patrick Flynn appear as witnesses together**. That's a highly significant find. Now checking attachment status for that ARK before logging.Unattached to any tree person \u2014 this is new evidence. Now logging both searches separately with their respective staged result refs.Both searches logged successfully. Here's the full summary:\n\n---\n\n## Search Results \u2014 Thomas Flynn & Patrick Flynn as Witnesses, Schuylkill County\n\n### Searches Executed\n\n| Search | Query | Results |\n|---|---|---|\n| Thomas Flynn (log_006) | `+\"Thomas Flynn\"`, Schuylkill Co., PA | 1 hit |\n| Patrick Flynn (log_007) | `+\"Patrick Flynn\"`, Schuylkill Co., PA | 1 hit |\n\nBoth searches returned **the same record** \u2014 a single document where Thomas and Patrick appear together.\n\n---\n\n### Record Found (ARK: `ark:/61903/1:1:QV9N-YS37`)\n\n**Collection:** Pennsylvania Land Records (FamilySearch #2220359)  \n**Title:** Deed of Conveyance \u2014 James Brennan to Michael Dougherty  \n**Date:** 15 March 1878  \n**Place:** Branch Township, Schuylkill County, Pennsylvania\n\n**Relevant text:**\n> *\"Signed sealed and delivered in the presence of Thomas Flynn and Patrick Flynn both of Branch Township Schuylkill County as witnesses to the deed of conveyance this fifteenth day of March in the year of our Lord one thousand eight hundred and seventy eight.\"*\n\n---\n\n### Attachment Check\n\n| ARK | Attached to tree? |\n|---|---|\n| `ark:/61903/1:1:QV9N-YS37` | \u2705 **Unattached** \u2014 new evidence |\n\n---\n\n### Why This Matters\n\nThis is a **significant corroborating find** for hypothesis h_001 (Thomas Flynn is Patrick's father):\n\n1. **Co-location:** Both men lived in **Branch Township, Schuylkill County** as of 1878 \u2014 consistent with census placements.\n2. **Named together explicitly:** The deed identifies them as *separate individuals* acting jointly as witnesses, meaning this is not a confusion of one man \u2014 there are indeed two Flynn men active in the same community.\n3. **Patrick Flynn's independent activity:** At ~33 years old in 1878, Patrick signing as witness on a deed in the same township as Thomas shows him as an established adult in the same community.\n4. **Unattached to the tree** \u2014 this record has not been previously extracted. It is a priority candidate for record-extraction to create a new source entry and extract assertions for both I1 (Patrick) and I2 (Thomas).\n\n---\n\n### Suggested Next Steps\n\n- **Extract this deed** (record-extraction) to create source entries and witness-presence assertions for both Patrick (I1) and Thomas (I2)\n- **Search for more deeds** involving James Brennan or Michael Dougherty \u2014 the principals in this deed \u2014 as FAN cluster members who may appear alongside the Flynns in other records\n- **Search for Thomas Flynn's probate/will** (pli_006 remains in progress) \u2014 this deed confirms Thomas was alive in 1878, narrowing the search window\n\nShall I proceed with record-extraction for this deed, or continue with the probate search (pli_006) next?",
+            "activated": true,
+            "skills_invoked": [
+              "search-full-text"
+            ],
+            "tool_calls": [
+              {
+                "tool": "mcp__genealogy__fulltext_search",
+                "args": {
+                  "keywords": "+\"Thomas Flynn\"",
+                  "recordPlace1": "Pennsylvania",
+                  "recordPlace2": "Schuylkill",
+                  "count": 20,
+                  "projectPath": "/tmp/eval-ut_search_full_text_011-0-0-9h0uxxgd"
+                },
+                "expected_args": {
+                  "keywords": "~Flynn"
+                },
+                "matched": {
+                  "kind": "predicate",
+                  "index": 0
+                },
+                "response_fixture": "fulltext-search-flynn-witnesses"
+              },
+              {
+                "tool": "mcp__genealogy__fulltext_search",
+                "args": {
+                  "keywords": "+\"Patrick Flynn\"",
+                  "recordPlace1": "Pennsylvania",
+                  "recordPlace2": "Schuylkill",
+                  "count": 20,
+                  "projectPath": "/tmp/eval-ut_search_full_text_011-0-0-9h0uxxgd"
+                },
+                "expected_args": {
+                  "keywords": "~Flynn"
+                },
+                "matched": {
+                  "kind": "predicate",
+                  "index": 0
+                },
+                "response_fixture": "fulltext-search-flynn-witnesses"
+              },
+              {
+                "tool": "mcp__genealogy__source_attachments",
+                "args": {
+                  "uris": [
+                    "https://familysearch.org/ark:/61903/1:1:QV9N-YS37"
+                  ]
+                },
+                "expected_args": {
+                  "uris": "~"
+                },
+                "matched": {
+                  "kind": "predicate",
+                  "index": 0
+                },
+                "response_fixture": "record-attachments-flynn-witnesses"
+              },
+              {
+                "tool": "mcp__genealogy__research_log_append",
+                "args": {
+                  "projectPath": "/tmp/eval-ut_search_full_text_011-0-0-9h0uxxgd",
+                  "planItemId": null,
+                  "tool": "fulltext_search",
+                  "query": {
+                    "keywords": "+\"Thomas Flynn\"",
+                    "recordPlace1": "Pennsylvania",
+                    "recordPlace2": "Schuylkill"
+                  },
+                  "outcome": "positive",
+                  "resultsExamined": 1,
+                  "resultsAvailable": 1,
+                  "notes": "Ad-hoc witness search: 1 hit \u2014 1878 deed of conveyance (James Brennan to Michael Dougherty, Branch Township, Schuylkill Co.); Thomas Flynn named as witness alongside Patrick Flynn, both identified as residents of Branch Township; record unattached to any tree person; ARK ark:/61903/1:1:QV9N-YS37.",
+                  "stagedResultsRef": "results/.staging/92276237-14c4-42cc-995c-32d59551855f.json"
+                },
+                "expected_args": null,
+                "matched": {
+                  "kind": "live",
+                  "index": null
+                },
+                "response_fixture": "live:research_log_append"
+              },
+              {
+                "tool": "mcp__genealogy__research_log_append",
+                "args": {
+                  "projectPath": "/tmp/eval-ut_search_full_text_011-0-0-9h0uxxgd",
+                  "planItemId": null,
+                  "tool": "fulltext_search",
+                  "query": {
+                    "keywords": "+\"Patrick Flynn\"",
+                    "recordPlace1": "Pennsylvania",
+                    "recordPlace2": "Schuylkill"
+                  },
+                  "outcome": "positive",
+                  "resultsExamined": 1,
+                  "resultsAvailable": 1,
+                  "notes": "Ad-hoc witness search: 1 hit \u2014 same 1878 deed (James Brennan to Michael Dougherty, Branch Township, Schuylkill Co.); Patrick Flynn named as witness alongside Thomas Flynn, both of Branch Township; record unattached to any tree person; ARK ark:/61903/1:1:QV9N-YS37.",
+                  "stagedResultsRef": "results/.staging/b10afa85-c95f-4530-ad98-c64fda48a6f3.json"
+                },
+                "expected_args": null,
+                "matched": {
+                  "kind": "live",
+                  "index": null
+                },
+                "response_fixture": "live:research_log_append"
+              }
+            ],
+            "files_created": [
+              "results/log_006.json",
+              "results/log_007.json"
+            ],
+            "file_changes": {
+              "research.json": {
+                "sections_modified": [
+                  "log"
+                ],
+                "diff": {
+                  "log": {
+                    "added": [
+                      {
+                        "id": "log_006",
+                        "plan_item_id": null,
+                        "performed": "2026-06-29T17:04:09.517Z",
+                        "tool": "fulltext_search",
+                        "query": {
+                          "keywords": "+\"Thomas Flynn\"",
+                          "recordPlace1": "Pennsylvania",
+                          "recordPlace2": "Schuylkill"
+                        },
+                        "outcome": "positive",
+                        "results_examined": 1,
+                        "external_site": null,
+                        "results_ref": "results/log_006.json",
+                        "results_available": 1,
+                        "notes": "Ad-hoc witness search: 1 hit \u2014 1878 deed of conveyance (James Brennan to Michael Dougherty, Branch Township, Schuylkill Co.); Thomas Flynn named as witness alongside Patrick Flynn, both identified as residents of Branch Township; record unattached to any tree person; ARK ark:/61903/1:1:QV9N-YS37."
+                      },
+                      {
+                        "id": "log_007",
+                        "plan_item_id": null,
+                        "performed": "2026-06-29T17:04:12.343Z",
+                        "tool": "fulltext_search",
+                        "query": {
+                          "keywords": "+\"Patrick Flynn\"",
+                          "recordPlace1": "Pennsylvania",
+                          "recordPlace2": "Schuylkill"
+                        },
+                        "outcome": "positive",
+                        "results_examined": 1,
+                        "external_site": null,
+                        "results_ref": "results/log_007.json",
+                        "results_available": 1,
+                        "notes": "Ad-hoc witness search: 1 hit \u2014 same 1878 deed (James Brennan to Michael Dougherty, Branch Township, Schuylkill Co.); Patrick Flynn named as witness alongside Thomas Flynn, both of Branch Township; record unattached to any tree person; ARK ark:/61903/1:1:QV9N-YS37."
+                      }
+                    ],
+                    "modified": [],
+                    "deleted": []
+                  }
+                }
+              }
+            },
+            "warnings": [
+              {
+                "kind": "missing_tool_usage_dimension",
+                "advisory": "Skill called MCP tools but the rubric has no dimension name suggesting tool-usage coverage (matched against keywords: ['tool usage', 'tool use', 'tool work', 'tool call', 'argument quality', 'argument-quality', 'response interpretation', 'tool selection', 'mcp tool', 'fixture']). The judge will grade other dimensions but won't score tool work explicitly. Consider adding a tool-usage dimension or renaming an existing one."
+              }
+            ]
+          },
+          "validators": {
+            "passed": true,
+            "results": [
+              {
+                "name": "test_id_references_resolve",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_log_append_only",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_entries_deleted",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_research_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tool_allowlist",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_gedcomx_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_negative_result_log_shape",
+                "passed": true,
+                "error": "skipped: not a negative-result-log scenario"
+              },
+              {
+                "name": "test_positive_appends_log_entry",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_sidecar_written_for_positive_fts",
+                "passed": true,
+                "error": "skipped: not a sidecar-write scenario"
+              }
+            ]
+          },
+          "judge": {
+            "skipped": false,
+            "dimensions": [
+              {
+                "source": "base",
+                "name": "Correctness",
+                "score": 3,
+                "rationale": "The skill correctly executed two full-text searches for Thomas Flynn and Patrick Flynn as witnesses in Schuylkill County, Pennsylvania. Both searches returned the same authentic 1878 deed record with Thomas and Patrick Flynn named as witnesses together. The attachment check correctly identified the record as unattached. The analysis accurately contextualizes this finding as corroborating evidence for the h_001 hypothesis and correctly notes the significance of both men appearing in the same location at the same time. No fabricated claims or unsupported assertions."
+              },
+              {
+                "source": "base",
+                "name": "Completeness",
+                "score": 3,
+                "rationale": "The skill fully addressed the user request: (1) ran separate searches for both Thomas Flynn AND Patrick Flynn as witnesses, (2) scoped both searches to Schuylkill County records, (3) checked attachment status via source_attachments for the returned ARK, (4) noted the unattached status and documented it for extraction priority, and (5) logged both searches separately in the research log with full context. The narrative includes deed details, witness confirmation, attachment status, and analysis of research significance. Nothing requested was omitted."
+              },
+              {
+                "source": "base",
+                "name": "Tool Arguments",
+                "score": 3,
+                "rationale": "All four tool calls used correct arguments. Both fulltext_search calls passed phrase-quoted names (+\"Thomas Flynn\" and +\"Patrick Flynn\") with proper scoping to recordPlace1='Pennsylvania' and recordPlace2='Schuylkill', matching the expected semantic pattern for witness searches. The source_attachments call passed the correct ARK URI. Both research_log_append calls were properly formatted with accurate query reconstruction, positive outcome designation, results counts, and detailed notes. No fixture_not_found errors or identifier mismatches."
+              },
+              {
+                "source": "rubric",
+                "name": "Query construction",
+                "score": 3,
+                "rationale": "Both queries use correct full-text search operators: phrase quoting with the + prefix (+'\"Thomas Flynn\"' and +'\"Patrick Flynn\"') to ensure exact-match behavior, which is appropriate for FTS and avoids false positives on partial name matches. Queries are properly scoped to Pennsylvania and Schuylkill County via recordPlace1 and recordPlace2 parameters. The canonical spelling approach is effective\u2014both queries successfully recovered the witness record. Per the test notes, variants like 'Thos' are valuable but NOT required when the canonical query already recovers the record, which it did."
+              },
+              {
+                "source": "rubric",
+                "name": "FAN awareness",
+                "score": 3,
+                "rationale": "The prompt is a direct subject search for Thomas Flynn and Patrick Flynn as witnesses in Schuylkill County records. Per the rubric, for direct subject searches the skill is not required to unprompted-expand to FAN\u2014the dimension passes if the requested search executes correctly. The skill executed both requested searches successfully and recovered the target witnesses. The skill did note FAN potential (suggesting searches for James Brennan and Michael Dougherty as associated persons in next steps), but this is supplementary value rather than a requirement for pass."
+              },
+              {
+                "source": "rubric",
+                "name": "Negative result handling",
+                "score": 3,
+                "rationale": "All executed searches returned positive results\u2014both the Thomas Flynn and Patrick Flynn searches returned the same 1878 deed record. Since every executed search returned results, there is nothing to grade on negative-result logging. Per the rubric, when all searches return results this dimension receives a pass. No negative result handling was needed or omitted."
+              }
+            ],
+            "judge_cost_usd": 0.012303999999999999,
+            "duration_ms": 16525.925449997885,
+            "error": null,
+            "input_tokens": 7679,
+            "cached_input_tokens": 0,
+            "output_tokens": 925
+          },
+          "started_at": 1782752554.9440062,
+          "ended_at": 1782752687.348432
+        }
+      ]
+    },
+    {
+      "test_id": "ut_search_full_text_009",
+      "test_type": "positive",
+      "expected_outcome": "pass",
+      "scenario": "mid-research-flynn",
+      "mcp_fixtures": [
+        "fulltext-search-cuban-notarial",
+        "fulltext-search-cuban-notarial-by-name"
+      ],
+      "outcome": "pass",
+      "flaky": false,
+      "outcome_summary": {
+        "per_run_outcomes": [
+          "pass"
+        ],
+        "aggregated_dimensions": [
+          {
+            "source": "base",
+            "name": "Correctness",
+            "score": 3,
+            "rationale": "The skill correctly executed a full-text search of FamilySearch's Cuban notarial protocolos collection. It retrieved the exact 1834 poder naming Jos\u00e9 Maria Garc\u00eda as attorney-in-fact in Habana. The query correctly used the Spanish orthography (Garc\u00eda with diacritic), the phrase syntax was appropriate for FTS, and all facts in the narrative (document date, place, collection title, named persons) match the tool's response. No fabricated claims."
+          },
+          {
+            "source": "base",
+            "name": "Completeness",
+            "score": 3,
+            "rationale": "The skill fully addressed the user's request: it constructed and executed the search with Spanish-orthography spelling, logged the result as an ad-hoc query with plan_item_id: null as specified, provided the result sidecar, and wrote both research.json and results/log_006.json. It documented the search comprehensively in the research log entry and did not omit any major requirement from the prompt."
+          },
+          {
+            "source": "base",
+            "name": "Tool Arguments",
+            "score": 3,
+            "rationale": "Both MCP calls used correct arguments. The fulltext_search call included keywords with the Spanish-orthography Garc\u00eda (\u00b1Jos\u00e9 Garc\u00eda as phrase), yearFrom/yearTo 1830\u20131839, recordPlace0: Cuba, and projectPath for staging results\u2014all matching the fixture's expected_args predicate (~Garc\u00eda). The research_log_append call correctly set planItemId: null as per the user's instruction for an ad-hoc entry (not tied to a plan). Both calls matched.kind == 'predicate' or 'live', indicating successful fixture satisfaction."
+          },
+          {
+            "source": "rubric",
+            "name": "Query construction",
+            "score": 3,
+            "rationale": "The skill constructed an effective full-text search query using the phrase operator (+\"Jos\u00e9 Garc\u00eda\") with correct FTS syntax. It applied date-range filtering (1830\u20131839) and scoped to Cuba, the plausible jurisdiction supplied in the prompt. The phrase query correctly tolerates one intervening word to match 'Jos\u00e9 Mar\u00eda Garc\u00eda' without requiring a separate variant query. The Spanish-orthography spelling (Garc\u00eda with diacritic, not Anglicised forms) was preserved as required, and the query successfully retrieved the target record."
+          },
+          {
+            "source": "rubric",
+            "name": "FAN awareness",
+            "score": 3,
+            "rationale": "This dimension passes because the prompt was a direct subject search ('search for Jos\u00e9 Maria Garc\u00eda in 1830s Cuban notarial protocolos')\u2014not a request to pivot to Family, Associates, and Neighbors unprompted. The skill executed the requested search correctly. However, the skill did proactively suggest FAN cross-references in the 'Suggested next steps' (Francisco de Quesada, Antonio P\u00e9rez, Ignacio Su\u00e1rez as witnesses/counterparties), which is thoughtful added value, though not required for this dimension."
+          },
+          {
+            "source": "rubric",
+            "name": "Negative result handling",
+            "score": 3,
+            "rationale": "All executed searches returned positive results (1 record found and examined). Per the rubric, when every executed search returns positive results, this dimension has nothing to grade and passes automatically. The skill logged the positive outcome with full detail, including collection, date, place, and named persons, supporting future exhaustiveness claims if needed."
+          }
+        ]
+      },
+      "totals": {
+        "duration_ms": 133569.99543200072,
+        "duration_api_ms": 120407.0,
+        "judge_duration_ms": 11471.099342001253,
+        "wall_clock_ms": 139842.9992198944,
+        "num_turns": 9,
+        "input_tokens": 15,
+        "cached_input_tokens": 125757,
+        "output_tokens": 5766,
+        "judge_input_tokens": 6640,
+        "judge_cached_input_tokens": 0,
+        "judge_output_tokens": 886,
+        "skill_cost_usd": 0.2518441,
+        "judge_cost_usd": 0.01107,
+        "total_cost_usd": 0.26291410000000004
+      },
+      "runs": [
+        {
+          "run_index": 0,
+          "run_id": "run_ut_search_full_text_009_2026-06-29_17-02-34_0",
+          "outcome": "pass",
+          "aborted_reason": null,
+          "duration_ms": 133569.99543200072,
+          "duration_api_ms": 120407.0,
+          "num_turns": 9,
+          "skill_attempts": 1,
+          "input_tokens": 15,
+          "cached_input_tokens": 125757,
+          "output_tokens": 5766,
+          "skill_cost_usd": 0.2518441,
+          "output": {
+            "text_response": "Reading the project state and references before constructing the query.Project read. Now loading the MCP tools I need.Project context noted \u2014 this is an ad-hoc search, unrelated to the active Flynn/Pennsylvania question. Now constructing the query.\n\n**Query rationale:**\n- `\"Jos\u00e9 Garc\u00eda\"` as a phrase: FTS phrase search tolerates one intervening word, so this also matches *Jos\u00e9 Mar\u00eda Garc\u00eda* and *Jos\u00e9 Maria Garc\u00eda* without requiring a separate query \u2014 a tight two-term phrase is better than `+Jos\u00e9 +Garc\u00eda` for a common surname.\n- Date range 1830\u20131839 scoped to the 1830s decade.\n- Cuba as the place filter to target the protocolos corpus (applied here together with date because the name-only first rule guards against metadata false positives on place *text* in the transcript; restricting to a Cuban collection does not introduce that risk).\n- `projectPath` supplied so results are staged for the sidecar.One strong hit \u2014 a power of attorney from Havana, 1834, naming **don Jos\u00e9 Maria Garc\u00eda** (vecino de la Habana) as attorney-in-fact. Now logging the search.Search logged successfully. Here's the full summary:\n\n---\n\n## FTS Search Complete \u2014 Ad-hoc Query `log_006`\n\n**Query:** `+\"Jos\u00e9 Garc\u00eda\"` (phrase, tolerating one intervening word \u2192 catches *Jos\u00e9 Mar\u00eda Garc\u00eda*, *Jos\u00e9 Maria Garc\u00eda*)\n**Collection:** Cuba, Protocolos notariales, 1578\u20131968 (collection 3072910)\n**Scope:** 1830\u20131839 \u00b7 Cuba\n**Results:** 1 found, 1 examined \u00b7 Outcome: **positive**\n\n---\n\n### Record Found\n\n| Field | Value |\n|---|---|\n| **ARK** | `ark:/61903/1:1:K5M9-P3WT` |\n| **Document type** | Poder (power of attorney) |\n| **Date** | 14 August 1834 |\n| **Place** | Habana, Cuba |\n| **Collection** | Cuba, Protocolos notariales, 1578\u20131968 |\n\n**Transcript excerpt:**\n> *En la siempre fidel\u00edsima ciudad de la Habana \u00e1 los catorce d\u00edas del mes de agosto del a\u00f1o mil ochocientos treinta y cuatro ante m\u00ed el escribano y testigos compareci\u00f3 don Francisco de Quesada vecino de esta plaza y dijo que otorgaban poder a **don Jos\u00e9 Maria Garc\u00eda** vecino tambi\u00e9n de la Habana para que en su nombre y representaci\u00f3n pueda cobrar y percibir las cantidades que se le adeudan en la villa de Matanzas y dar de ellas los recibos y cartas de pago necesarias. Por testigos don Antonio P\u00e9rez y don Ignacio Su\u00e1rez vecinos de esta ciudad.*\n\n**Named persons in the document:**\n- Francisco de Quesada (grantor, vecino de la Habana)\n- **Jos\u00e9 Maria Garc\u00eda** (attorney-in-fact, vecino de la Habana) \u2190 subject\n- Antonio P\u00e9rez (witness)\n- Ignacio Su\u00e1rez (witness)\n\n**Note on transcript spelling:** The HTR transcription renders the name as *Jos\u00e9 Maria Garc\u00eda* \u2014 *Mar\u00eda* without the accent on the *i*. The diacritic on *Garc\u00eda* is present. This is a common HTR omission for secondary diacritics in 1830s Cuban script; the phrase query `\"Jos\u00e9 Garc\u00eda\"` successfully retrieved it regardless.\n\n---\n\n### Files written\n- `research.json` \u2014 log entry `log_006` appended (ad-hoc, `plan_item_id: null`)\n- `results/log_006.json` \u2014 result sidecar (1 record retained)\n\n### Suggested next steps\n- **Verify against the original image** at the ARK link above \u2014 FTS transcripts are derivative (HTR), and the full protocolo text may contain additional information (property descriptions, debt amounts, Matanzas counterparty names).\n- **Cross-reference searches:** The document names three other individuals \u2014 would you like me to search for Francisco de Quesada, Antonio P\u00e9rez, or Ignacio Su\u00e1rez in the same collection? Any of them could be members of a FAN cluster around Jos\u00e9 Maria Garc\u00eda.\n- **Pass to record-extraction** if you want assertions drawn from this poder (e.g., residence, legal role, date, associated persons).",
+            "activated": true,
+            "skills_invoked": [
+              "search-full-text"
+            ],
+            "tool_calls": [
+              {
+                "tool": "mcp__genealogy__fulltext_search",
+                "args": {
+                  "keywords": "+\"Jos\u00e9 Garc\u00eda\"",
+                  "yearFrom": 1830,
+                  "yearTo": 1839,
+                  "recordPlace0": "Cuba",
+                  "projectPath": "/tmp/eval-ut_search_full_text_009-0-0-x7hxxpzi"
+                },
+                "expected_args": {
+                  "keywords": "~Garc\u00eda"
+                },
+                "matched": {
+                  "kind": "predicate",
+                  "index": 0
+                },
+                "response_fixture": "fulltext-search-cuban-notarial"
+              },
+              {
+                "tool": "mcp__genealogy__research_log_append",
+                "args": {
+                  "projectPath": "/tmp/eval-ut_search_full_text_009-0-0-x7hxxpzi",
+                  "planItemId": null,
+                  "tool": "fulltext_search",
+                  "query": {
+                    "keywords": "+\"Jos\u00e9 Garc\u00eda\"",
+                    "yearFrom": 1830,
+                    "yearTo": 1839,
+                    "recordPlace0": "Cuba"
+                  },
+                  "outcome": "positive",
+                  "resultsExamined": 1,
+                  "resultsAvailable": 1,
+                  "notes": "1 hit in Cuba, Protocolos notariales, 1578\u20131968 (collection 3072910); 1834 poder (Habana, 14 Aug) names \"don Jos\u00e9 Maria Garc\u00eda, vecino tambi\u00e9n de la Habana\" as attorney-in-fact empowered by Francisco de Quesada to collect debts in Matanzas; witnesses Antonio P\u00e9rez and Ignacio Su\u00e1rez; transcript spelling \"Jos\u00e9 Maria Garc\u00eda\" (Mar\u00eda without accent on i). Phrase query +\"Jos\u00e9 Garc\u00eda\" (tolerating one intervening word) retrieved the record.",
+                  "stagedResultsRef": "results/.staging/6af62848-d33c-4cbd-b95a-00c4cebbac54.json"
+                },
+                "expected_args": null,
+                "matched": {
+                  "kind": "live",
+                  "index": null
+                },
+                "response_fixture": "live:research_log_append"
+              }
+            ],
+            "files_created": [
+              "results/log_006.json"
+            ],
+            "file_changes": {
+              "research.json": {
+                "sections_modified": [
+                  "log"
+                ],
+                "diff": {
+                  "log": {
+                    "added": [
+                      {
+                        "id": "log_006",
+                        "plan_item_id": null,
+                        "performed": "2026-06-29T17:04:21.775Z",
+                        "tool": "fulltext_search",
+                        "query": {
+                          "keywords": "+\"Jos\u00e9 Garc\u00eda\"",
+                          "yearFrom": 1830,
+                          "yearTo": 1839,
+                          "recordPlace0": "Cuba"
+                        },
+                        "outcome": "positive",
+                        "results_examined": 1,
+                        "external_site": null,
+                        "results_ref": "results/log_006.json",
+                        "results_available": 1,
+                        "notes": "1 hit in Cuba, Protocolos notariales, 1578\u20131968 (collection 3072910); 1834 poder (Habana, 14 Aug) names \"don Jos\u00e9 Maria Garc\u00eda, vecino tambi\u00e9n de la Habana\" as attorney-in-fact empowered by Francisco de Quesada to collect debts in Matanzas; witnesses Antonio P\u00e9rez and Ignacio Su\u00e1rez; transcript spelling \"Jos\u00e9 Maria Garc\u00eda\" (Mar\u00eda without accent on i). Phrase query +\"Jos\u00e9 Garc\u00eda\" (tolerating one intervening word) retrieved the record."
+                      }
+                    ],
+                    "modified": [],
+                    "deleted": []
+                  }
+                }
+              }
+            },
+            "warnings": [
+              {
+                "kind": "missing_tool_usage_dimension",
+                "advisory": "Skill called MCP tools but the rubric has no dimension name suggesting tool-usage coverage (matched against keywords: ['tool usage', 'tool use', 'tool work', 'tool call', 'argument quality', 'argument-quality', 'response interpretation', 'tool selection', 'mcp tool', 'fixture']). The judge will grade other dimensions but won't score tool work explicitly. Consider adding a tool-usage dimension or renaming an existing one."
+              }
+            ]
+          },
+          "validators": {
+            "passed": true,
+            "results": [
+              {
+                "name": "test_id_references_resolve",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_log_append_only",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_entries_deleted",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_research_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tool_allowlist",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_gedcomx_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_negative_result_log_shape",
+                "passed": true,
+                "error": "skipped: not a negative-result-log scenario"
+              },
+              {
+                "name": "test_positive_appends_log_entry",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_sidecar_written_for_positive_fts",
+                "passed": true,
+                "error": "skipped: not a sidecar-write scenario"
+              }
+            ]
+          },
+          "judge": {
+            "skipped": false,
+            "dimensions": [
+              {
+                "source": "base",
+                "name": "Correctness",
+                "score": 3,
+                "rationale": "The skill correctly executed a full-text search of FamilySearch's Cuban notarial protocolos collection. It retrieved the exact 1834 poder naming Jos\u00e9 Maria Garc\u00eda as attorney-in-fact in Habana. The query correctly used the Spanish orthography (Garc\u00eda with diacritic), the phrase syntax was appropriate for FTS, and all facts in the narrative (document date, place, collection title, named persons) match the tool's response. No fabricated claims."
+              },
+              {
+                "source": "base",
+                "name": "Completeness",
+                "score": 3,
+                "rationale": "The skill fully addressed the user's request: it constructed and executed the search with Spanish-orthography spelling, logged the result as an ad-hoc query with plan_item_id: null as specified, provided the result sidecar, and wrote both research.json and results/log_006.json. It documented the search comprehensively in the research log entry and did not omit any major requirement from the prompt."
+              },
+              {
+                "source": "base",
+                "name": "Tool Arguments",
+                "score": 3,
+                "rationale": "Both MCP calls used correct arguments. The fulltext_search call included keywords with the Spanish-orthography Garc\u00eda (\u00b1Jos\u00e9 Garc\u00eda as phrase), yearFrom/yearTo 1830\u20131839, recordPlace0: Cuba, and projectPath for staging results\u2014all matching the fixture's expected_args predicate (~Garc\u00eda). The research_log_append call correctly set planItemId: null as per the user's instruction for an ad-hoc entry (not tied to a plan). Both calls matched.kind == 'predicate' or 'live', indicating successful fixture satisfaction."
+              },
+              {
+                "source": "rubric",
+                "name": "Query construction",
+                "score": 3,
+                "rationale": "The skill constructed an effective full-text search query using the phrase operator (+\"Jos\u00e9 Garc\u00eda\") with correct FTS syntax. It applied date-range filtering (1830\u20131839) and scoped to Cuba, the plausible jurisdiction supplied in the prompt. The phrase query correctly tolerates one intervening word to match 'Jos\u00e9 Mar\u00eda Garc\u00eda' without requiring a separate variant query. The Spanish-orthography spelling (Garc\u00eda with diacritic, not Anglicised forms) was preserved as required, and the query successfully retrieved the target record."
+              },
+              {
+                "source": "rubric",
+                "name": "FAN awareness",
+                "score": 3,
+                "rationale": "This dimension passes because the prompt was a direct subject search ('search for Jos\u00e9 Maria Garc\u00eda in 1830s Cuban notarial protocolos')\u2014not a request to pivot to Family, Associates, and Neighbors unprompted. The skill executed the requested search correctly. However, the skill did proactively suggest FAN cross-references in the 'Suggested next steps' (Francisco de Quesada, Antonio P\u00e9rez, Ignacio Su\u00e1rez as witnesses/counterparties), which is thoughtful added value, though not required for this dimension."
+              },
+              {
+                "source": "rubric",
+                "name": "Negative result handling",
+                "score": 3,
+                "rationale": "All executed searches returned positive results (1 record found and examined). Per the rubric, when every executed search returns positive results, this dimension has nothing to grade and passes automatically. The skill logged the positive outcome with full detail, including collection, date, place, and named persons, supporting future exhaustiveness claims if needed."
+              }
+            ],
+            "judge_cost_usd": 0.01107,
+            "duration_ms": 11471.099342001253,
+            "error": null,
+            "input_tokens": 6640,
+            "cached_input_tokens": 0,
+            "output_tokens": 886
+          },
+          "started_at": 1782752554.9387987,
+          "ended_at": 1782752694.781798
+        }
+      ]
+    },
+    {
+      "test_id": "ut_search_full_text_007",
+      "test_type": "positive",
+      "expected_outcome": "pass",
+      "scenario": "mid-research-flynn",
+      "mcp_fixtures": [
+        "fulltext-search-flynn-operator-construction",
+        "fulltext-search-flynn-witnesses",
+        "fulltext-search-flynn-flinn-variant"
+      ],
+      "outcome": "pass",
+      "flaky": false,
+      "outcome_summary": {
+        "per_run_outcomes": [
+          "pass"
+        ],
+        "aggregated_dimensions": [
+          {
+            "source": "base",
+            "name": "Correctness",
+            "score": 3,
+            "rationale": "Claude correctly identified all four surname variants (Flynn, Flinn, Flyn, Flynne), constructed the appropriate wildcard pattern +Fl?n*, executed the search, and accurately reported the result: Hugh Devlin will with Patrick Flinn as witness. The wildcard explanation is accurate\u2014? matches single character (y/i) and * matches zero or more trailing characters. The result confirms the variant coverage worked as intended."
+          },
+          {
+            "source": "base",
+            "name": "Completeness",
+            "score": 3,
+            "rationale": "Claude fully addressed the user request: constructed a single combined wildcard query (+Patrick +Fl?n*) that covers all four variants without separate per-variant searches, explained the query logic in detail, executed the search with appropriate filters (Pennsylvania, Schuylkill County, 1800-1849, probate), logged the result, and provided contextual triage assessing the witness as a different person and suggesting next research steps."
+          },
+          {
+            "source": "base",
+            "name": "Tool Arguments",
+            "score": 3,
+            "rationale": "Both MCP calls used correct arguments. The fulltext_search call passed keywords '+Patrick +Fl?n*' matching expected_args expectation (substring match on '?'), with proper place and date filters. The research_log_append call correctly documented the query, outcome, and results count. No fixture_not_found errors; matched.kind shows 'predicate' and 'live' respectively."
+          },
+          {
+            "source": "rubric",
+            "name": "Query construction",
+            "score": 3,
+            "rationale": "Claude constructed +Fl?n* which correctly covers all four variants: Flyn (Fl?n with * matching zero chars), Flynn (Fl?n with * matching n), Flynne (Fl?n with * matching ne), and Flinn (Fl?n with i in ? position). The pattern uses FTS operators correctly with required-term + and wildcard ? and *. The canonical-spelling query executed successfully and returned the variant-case result (Flinn), confirming the pattern's effectiveness."
+          },
+          {
+            "source": "rubric",
+            "name": "FAN awareness",
+            "score": 3,
+            "rationale": "This is a direct subject search (find Patrick Flynn in pre-1850 probate records)\u2014the prompt does not require FAN exploration. Per rubric guidance, case (b) applies: for direct subject searches the skill is not required to pivot to FAN unprompted. The requested search executed correctly and recovered a relevant record. Notably, Claude did recognize the witness Patrick Flinn as potential FAN evidence (older relative cluster) and flagged it as a follow-up lead, showing sound contextual judgment."
+          },
+          {
+            "source": "rubric",
+            "name": "Negative result handling",
+            "score": 3,
+            "rationale": "The executed search returned 1 positive result, so this dimension has nothing to grade per rubric guidance: 'When every executed search returned positive results, this dimension has nothing to grade \u2014 score pass.' The search logged outcome='positive' with 1 result examined and available. No negative result logs required."
+          }
+        ]
+      },
+      "totals": {
+        "duration_ms": 164181.50286300806,
+        "duration_api_ms": 149676.0,
+        "judge_duration_ms": 72693.35560499167,
+        "wall_clock_ms": 227475.06070137024,
+        "num_turns": 9,
+        "input_tokens": 15,
+        "cached_input_tokens": 155503,
+        "output_tokens": 7439,
+        "judge_input_tokens": 6850,
+        "judge_cached_input_tokens": 0,
+        "judge_output_tokens": 831,
+        "skill_cost_usd": 0.26986915,
+        "judge_cost_usd": 0.011005000000000001,
+        "total_cost_usd": 0.28087415
+      },
+      "runs": [
+        {
+          "run_index": 0,
+          "run_id": "run_ut_search_full_text_007_2026-06-29_17-02-34_0",
+          "outcome": "pass",
+          "aborted_reason": null,
+          "duration_ms": 164181.50286300806,
+          "duration_api_ms": 149676.0,
+          "num_turns": 9,
+          "skill_attempts": 1,
+          "input_tokens": 15,
+          "cached_input_tokens": 155503,
+          "output_tokens": 7439,
+          "skill_cost_usd": 0.26986915,
+          "output": {
+            "text_response": "Good. No reference files in this project, so I'll work from the skill's built-in guidance. Let me now review the project state, then load the MCP tool schema and execute the search.\n\n**Project context summary:**\n- Research subject: Patrick Flynn, b. ~1845 Ireland, d. 1908 Schuylkill Co. PA\n- Active plan item `pli_006`: Thomas Flynn probate 1870\u20131890 (status: in_progress)\n- Prior log entries: all surname searches used \"Flynn\" \u2014 no Flinn/Flyn variants encountered yet\n- The user's requested target (pre-1850 probate) is **separate** from pli_006 \u2192 ad-hoc search, plan_item_id: null\n\n**Query reasoning:**\n\nThe four variants share the structure `F-l-[vowel]-n[n][e]`:\n| Variant | Breakdown |\n|---------|-----------|\n| Flyn | F\u00b7l\u00b7**y**\u00b7n |\n| Flynn | F\u00b7l\u00b7**y**\u00b7n\u00b7n |\n| Flynne | F\u00b7l\u00b7**y**\u00b7n\u00b7n\u00b7e |\n| Flinn | F\u00b7l\u00b7**i**\u00b7n\u00b7n |\n\nA single `Fl?n*` wildcard covers all four in one pass:\n- `?` absorbs the vowel position (y or i)\n- `*` absorbs everything after the first n (\u2205, n, ne, \u2026)\n- 3 literal chars (F, l, n) satisfies the minimum before `*`\n\nFinal query: **`+Patrick +Fl?n*`** \u2014 both terms required, one wildcard, no separate per-variant passes.Executing the search now with place and date applied as post-query filters (not embedded in keywords), per FTS best practice.One result returned \u2014 and it validated the wildcard immediately: the hit is **\"Flinn\"**, not \"Flynn\". The `?` wildcard caught the vowel variant that a bare `+Flynn` query would have missed entirely. Let me log this, then triage.Logged as **log_006** with sidecar `results/log_006.json`. Here's the full picture:\n\n---\n\n## Search Results \u2014 Pre-1850 Schuylkill County Probate, FTS\n\n### Query constructed\n```\n+Patrick +Fl?n*\n```\n| Operator | Role |\n|----------|------|\n| `+Patrick` | Required \u2014 given name |\n| `+Fl?n*` | Required \u2014 surname wildcard: `?` absorbs the y/i vowel slot; `*` absorbs trailing \u2205/n/ne |\n\n**Coverage in one pass:** Flyn \u00b7 Flynn \u00b7 Flynne \u00b7 Flinn \u2713 \u2014 no separate per-variant queries needed.\n\nFilters applied post-query: Pennsylvania \u2192 Schuylkill County \u00b7 1800\u20131849 \u00b7 Probate.\n\n---\n\n### Result (1 of 1)\n\n> **Last Will and Testament \u2014 Hugh Devlin (witnessed)**\n> *Pennsylvania Probate Records, 1683\u20131994* \u00b7 Schuylkill County \u00b7 1849\n> ARK: `ark:/61903/1:1:7XK4-CR2P`\n\nRelevant excerpt from the AI transcript:\n\n> *\"\u2026In witness whereof I have set my hand and seal this twenty third day of August one thousand eight hundred and forty nine. **Witnesses: Patrick Flinn** and John McGonigle both of Branch Township Schuylkill County.\"*\n\n**Patrick Flinn** appears as a **witness**, not a principal. The `?` wildcard caught \"Flinn\" \u2014 a variant that `+Flynn` alone would have missed entirely.\n\n---\n\n### Triage\n\n| Factor | Assessment |\n|--------|------------|\n| Name match | **Flinn** \u2014 vowel-variant of Flynn; consistent with Irish immigrant spelling patterns |\n| Role in document | Witness to Hugh Devlin's will, 1849, Branch Township |\n| Place | Branch Township, Schuylkill County \u2014 same county as our Patrick Flynn's household |\n| Date | August 1849 \u2014 Patrick Flynn b. ~1845 would be ~4 years old; this witness is almost certainly an **adult**, making him a different person (a relative, perhaps a neighbor or uncle) |\n| Research value | Identifies a **Patrick Flinn/Flynn adult** present in Schuylkill County in 1849, plausibly from the same immigrant cluster as Thomas Flynn's household |\n| Attachment status | Not checked \u2014 unattached record, new evidence |\n\n**Key inference:** Because our subject Patrick was only ~4 years old in August 1849, the witnessing Patrick Flinn must be someone else \u2014 potentially an older relative (uncle, cousin, or father's brother) in the same Irish community. This is a promising **FAN-cluster lead**: Who is this adult Patrick Flinn in Branch Township?\n\n---\n\n### Suggested next steps\n\n1. **Browse the original image** at `ark:/61903/1:1:7XK4-CR2P` to verify the AI transcript \u2014 particularly the witness signature (some witnesses sign with a mark, which could confirm literacy level).\n2. **Search for this adult Patrick Flinn** in the 1850 census \u2014 he should appear as a head or co-resident in Branch Township, and his age would distinguish him from our subject.\n3. **Continue pli_006** \u2014 Thomas Flynn's will (1870\u20131890) is still the primary probate target for directly naming Patrick as son. Shall I run that search next?",
+            "activated": true,
+            "skills_invoked": [
+              "search-full-text"
+            ],
+            "tool_calls": [
+              {
+                "tool": "mcp__genealogy__fulltext_search",
+                "args": {
+                  "keywords": "+Patrick +Fl?n*",
+                  "recordPlace1": "Pennsylvania",
+                  "recordPlace2": "Schuylkill",
+                  "yearFrom": 1800,
+                  "yearTo": 1849,
+                  "recordType": "probate",
+                  "projectPath": "/tmp/eval-ut_search_full_text_007-0-0-37vp36ss"
+                },
+                "expected_args": {
+                  "keywords": "~?"
+                },
+                "matched": {
+                  "kind": "predicate",
+                  "index": 0
+                },
+                "response_fixture": "fulltext-search-flynn-operator-construction"
+              },
+              {
+                "tool": "mcp__genealogy__research_log_append",
+                "args": {
+                  "projectPath": "/tmp/eval-ut_search_full_text_007-0-0-37vp36ss",
+                  "planItemId": null,
+                  "tool": "fulltext_search",
+                  "query": {
+                    "keywords": "+Patrick +Fl?n*",
+                    "recordPlace1": "Pennsylvania",
+                    "recordPlace2": "Schuylkill",
+                    "yearFrom": 1800,
+                    "yearTo": 1849,
+                    "recordType": "probate"
+                  },
+                  "outcome": "positive",
+                  "resultsExamined": 1,
+                  "resultsAvailable": 1,
+                  "notes": "Ad-hoc FTS of FamilySearch Pennsylvania Probate Records (1683-1994), Schuylkill County, 1800-1849, single wildcard query +Patrick +Fl?n* covering Flynn/Flinn/Flyn/Flynne. 1 result: Hugh Devlin will (1849, Branch Township) names Patrick Flinn as a witness alongside John McGonigle \u2014 a non-principal mention. Wildcard variant matched was Flinn, not Flynn; confirms value of wildcard coverage.",
+                  "stagedResultsRef": "results/.staging/3d4a76ec-e505-4037-92be-da91930f03d3.json"
+                },
+                "expected_args": null,
+                "matched": {
+                  "kind": "live",
+                  "index": null
+                },
+                "response_fixture": "live:research_log_append"
+              }
+            ],
+            "files_created": [
+              "results/log_006.json"
+            ],
+            "file_changes": {
+              "research.json": {
+                "sections_modified": [
+                  "log"
+                ],
+                "diff": {
+                  "log": {
+                    "added": [
+                      {
+                        "id": "log_006",
+                        "plan_item_id": null,
+                        "performed": "2026-06-29T17:06:58.548Z",
+                        "tool": "fulltext_search",
+                        "query": {
+                          "keywords": "+Patrick +Fl?n*",
+                          "recordPlace1": "Pennsylvania",
+                          "recordPlace2": "Schuylkill",
+                          "yearFrom": 1800,
+                          "yearTo": 1849,
+                          "recordType": "probate"
+                        },
+                        "outcome": "positive",
+                        "results_examined": 1,
+                        "external_site": null,
+                        "results_ref": "results/log_006.json",
+                        "results_available": 1,
+                        "notes": "Ad-hoc FTS of FamilySearch Pennsylvania Probate Records (1683-1994), Schuylkill County, 1800-1849, single wildcard query +Patrick +Fl?n* covering Flynn/Flinn/Flyn/Flynne. 1 result: Hugh Devlin will (1849, Branch Township) names Patrick Flinn as a witness alongside John McGonigle \u2014 a non-principal mention. Wildcard variant matched was Flinn, not Flynn; confirms value of wildcard coverage."
+                      }
+                    ],
+                    "modified": [],
+                    "deleted": []
+                  }
+                }
+              }
+            },
+            "warnings": [
+              {
+                "kind": "missing_tool_usage_dimension",
+                "advisory": "Skill called MCP tools but the rubric has no dimension name suggesting tool-usage coverage (matched against keywords: ['tool usage', 'tool use', 'tool work', 'tool call', 'argument quality', 'argument-quality', 'response interpretation', 'tool selection', 'mcp tool', 'fixture']). The judge will grade other dimensions but won't score tool work explicitly. Consider adding a tool-usage dimension or renaming an existing one."
+              }
+            ]
+          },
+          "validators": {
+            "passed": true,
+            "results": [
+              {
+                "name": "test_id_references_resolve",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_log_append_only",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_entries_deleted",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_research_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tool_allowlist",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_gedcomx_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_negative_result_log_shape",
+                "passed": true,
+                "error": "skipped: not a negative-result-log scenario"
+              },
+              {
+                "name": "test_positive_appends_log_entry",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_sidecar_written_for_positive_fts",
+                "passed": true,
+                "error": "skipped: not a sidecar-write scenario"
+              }
+            ]
+          },
+          "judge": {
+            "skipped": false,
+            "dimensions": [
+              {
+                "source": "base",
+                "name": "Correctness",
+                "score": 3,
+                "rationale": "Claude correctly identified all four surname variants (Flynn, Flinn, Flyn, Flynne), constructed the appropriate wildcard pattern +Fl?n*, executed the search, and accurately reported the result: Hugh Devlin will with Patrick Flinn as witness. The wildcard explanation is accurate\u2014? matches single character (y/i) and * matches zero or more trailing characters. The result confirms the variant coverage worked as intended."
+              },
+              {
+                "source": "base",
+                "name": "Completeness",
+                "score": 3,
+                "rationale": "Claude fully addressed the user request: constructed a single combined wildcard query (+Patrick +Fl?n*) that covers all four variants without separate per-variant searches, explained the query logic in detail, executed the search with appropriate filters (Pennsylvania, Schuylkill County, 1800-1849, probate), logged the result, and provided contextual triage assessing the witness as a different person and suggesting next research steps."
+              },
+              {
+                "source": "base",
+                "name": "Tool Arguments",
+                "score": 3,
+                "rationale": "Both MCP calls used correct arguments. The fulltext_search call passed keywords '+Patrick +Fl?n*' matching expected_args expectation (substring match on '?'), with proper place and date filters. The research_log_append call correctly documented the query, outcome, and results count. No fixture_not_found errors; matched.kind shows 'predicate' and 'live' respectively."
+              },
+              {
+                "source": "rubric",
+                "name": "Query construction",
+                "score": 3,
+                "rationale": "Claude constructed +Fl?n* which correctly covers all four variants: Flyn (Fl?n with * matching zero chars), Flynn (Fl?n with * matching n), Flynne (Fl?n with * matching ne), and Flinn (Fl?n with i in ? position). The pattern uses FTS operators correctly with required-term + and wildcard ? and *. The canonical-spelling query executed successfully and returned the variant-case result (Flinn), confirming the pattern's effectiveness."
+              },
+              {
+                "source": "rubric",
+                "name": "FAN awareness",
+                "score": 3,
+                "rationale": "This is a direct subject search (find Patrick Flynn in pre-1850 probate records)\u2014the prompt does not require FAN exploration. Per rubric guidance, case (b) applies: for direct subject searches the skill is not required to pivot to FAN unprompted. The requested search executed correctly and recovered a relevant record. Notably, Claude did recognize the witness Patrick Flinn as potential FAN evidence (older relative cluster) and flagged it as a follow-up lead, showing sound contextual judgment."
+              },
+              {
+                "source": "rubric",
+                "name": "Negative result handling",
+                "score": 3,
+                "rationale": "The executed search returned 1 positive result, so this dimension has nothing to grade per rubric guidance: 'When every executed search returned positive results, this dimension has nothing to grade \u2014 score pass.' The search logged outcome='positive' with 1 result examined and available. No negative result logs required."
+              }
+            ],
+            "judge_cost_usd": 0.011005000000000001,
+            "duration_ms": 72693.35560499167,
+            "error": null,
+            "input_tokens": 6850,
+            "cached_input_tokens": 0,
+            "output_tokens": 831
+          },
+          "started_at": 1782752687.4754138,
+          "ended_at": 1782752914.9504745
+        }
+      ]
+    },
+    {
+      "test_id": "ut_search_full_text_005",
+      "test_type": "negative",
+      "expected_outcome": "pass",
+      "scenario": "mid-research-flynn",
+      "mcp_fixtures": [],
+      "outcome": "pass",
+      "flaky": false,
+      "outcome_summary": {
+        "per_run_outcomes": [
+          "pass"
+        ],
+        "aggregated_dimensions": [
+          {
+            "source": "base",
+            "name": "Correctness",
+            "score": 3,
+            "rationale": "The skill correctly declined to perform a full-text search on FamilySearch and properly routed the user to search-external-sites. The decision was accurate because Newspapers.com and Ancestry are external sites not covered by FamilySearch's AI-transcribed FTS database. The routing choice aligns precisely with the input request and test expectations."
+          },
+          {
+            "source": "base",
+            "name": "Completeness",
+            "score": 3,
+            "rationale": "The skill fully addressed the user's request by recognizing that the task fell outside its scope (search-full-text covers only FamilySearch FTS) and appropriately delegated to the correct skill (search-external-sites). It did not omit any required component of the decline-and-route decision."
+          },
+          {
+            "source": "base",
+            "name": "Tool Arguments",
+            "score": null,
+            "rationale": "No MCP tool calls were made. The skill correctly declined to call fulltext_search and instead routed the user to search-external-sites, so no tool arguments were passed. N/A per test design."
+          }
+        ]
+      },
+      "totals": {
+        "duration_ms": 11329.894661001163,
+        "duration_api_ms": 0.0,
+        "judge_duration_ms": 4082.0333900046535,
+        "wall_clock_ms": 16705.69610595703,
+        "num_turns": 0,
+        "input_tokens": 0,
+        "cached_input_tokens": 0,
+        "output_tokens": 0,
+        "judge_input_tokens": 3195,
+        "judge_cached_input_tokens": 0,
+        "judge_output_tokens": 335,
+        "skill_cost_usd": 0.0,
+        "judge_cost_usd": 0.00487,
+        "total_cost_usd": 0.00487
+      },
+      "runs": [
+        {
+          "run_index": 0,
+          "run_id": "run_ut_search_full_text_005_2026-06-29_17-02-34_0",
+          "outcome": "pass",
+          "aborted_reason": null,
+          "duration_ms": 11329.894661001163,
+          "duration_api_ms": 0.0,
+          "num_turns": 0,
+          "skill_attempts": 1,
+          "input_tokens": 0,
+          "cached_input_tokens": 0,
+          "output_tokens": 0,
+          "skill_cost_usd": 0.0,
+          "output": {
+            "text_response": "",
+            "activated": false,
+            "skills_invoked": [
+              "search-external-sites"
+            ],
+            "tool_calls": [],
+            "files_created": []
+          },
+          "validators": {
+            "passed": true,
+            "results": [
+              {
+                "name": "test_id_references_resolve",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_log_append_only",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_entries_deleted",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_ownership_table",
+                "passed": true,
+                "error": "skipped: ownership is not checked on negative tests \u2014 writes belong to the routed-to skill, not the skill under test"
+              },
+              {
+                "name": "test_research_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tool_allowlist",
+                "passed": true,
+                "error": "skipped: allowlist is not checked on negative tests \u2014 tool calls belong to the routed-to skill, not the skill under test"
+              },
+              {
+                "name": "test_tree_gedcomx_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_ownership_table",
+                "passed": true,
+                "error": "skipped: ownership is not checked on negative tests \u2014 writes belong to the routed-to skill, not the skill under test"
+              },
+              {
+                "name": "test_negative_result_log_shape",
+                "passed": true,
+                "error": "skipped: not a negative-result-log scenario"
+              },
+              {
+                "name": "test_positive_appends_log_entry",
+                "passed": true,
+                "error": "skipped: only positive tests record searches"
+              },
+              {
+                "name": "test_sidecar_written_for_positive_fts",
+                "passed": true,
+                "error": "skipped: not a sidecar-write scenario"
+              }
+            ]
+          },
+          "judge": {
+            "skipped": false,
+            "dimensions": [
+              {
+                "source": "base",
+                "name": "Correctness",
+                "score": 3,
+                "rationale": "The skill correctly declined to perform a full-text search on FamilySearch and properly routed the user to search-external-sites. The decision was accurate because Newspapers.com and Ancestry are external sites not covered by FamilySearch's AI-transcribed FTS database. The routing choice aligns precisely with the input request and test expectations."
+              },
+              {
+                "source": "base",
+                "name": "Completeness",
+                "score": 3,
+                "rationale": "The skill fully addressed the user's request by recognizing that the task fell outside its scope (search-full-text covers only FamilySearch FTS) and appropriately delegated to the correct skill (search-external-sites). It did not omit any required component of the decline-and-route decision."
+              },
+              {
+                "source": "base",
+                "name": "Tool Arguments",
+                "score": null,
+                "rationale": "No MCP tool calls were made. The skill correctly declined to call fulltext_search and instead routed the user to search-external-sites, so no tool arguments were passed. N/A per test design."
+              }
+            ],
+            "judge_cost_usd": 0.00487,
+            "duration_ms": 4082.0333900046535,
+            "error": null,
+            "input_tokens": 3195,
+            "cached_input_tokens": 0,
+            "output_tokens": 335
+          },
+          "started_at": 1782752554.9468367,
+          "ended_at": 1782752571.6525328
+        }
+      ]
+    },
+    {
+      "test_id": "ut_search_full_text_003",
+      "test_type": "negative",
+      "expected_outcome": "pass",
+      "scenario": "mid-research-flynn",
+      "mcp_fixtures": [],
+      "outcome": "pass",
+      "flaky": false,
+      "outcome_summary": {
+        "per_run_outcomes": [
+          "pass"
+        ],
+        "aggregated_dimensions": [
+          {
+            "source": "base",
+            "name": "Correctness",
+            "score": 3,
+            "rationale": "The skill correctly declined to perform its own task (search-full-text) and routed the user to record-extraction, which is the appropriate skill for extracting assertions from a deed document. No fabricated material was produced."
+          },
+          {
+            "source": "base",
+            "name": "Completeness",
+            "score": 3,
+            "rationale": "The skill fully addressed the required behavior for this negative test: it declined to search the full-text tool with the deed content and instead properly routed the user to record-extraction, which is the correct next step."
+          },
+          {
+            "source": "base",
+            "name": "Tool Arguments",
+            "score": null,
+            "rationale": "No MCP tool calls were made. The skill appropriately declined to invoke its own tools and instead routed the user to a different skill, which is the correct behavior for this negative test scenario."
+          }
+        ]
+      },
+      "totals": {
+        "duration_ms": 10033.227497013286,
+        "duration_api_ms": 0.0,
+        "judge_duration_ms": 3066.4455779915443,
+        "wall_clock_ms": 14009.601831436157,
+        "num_turns": 0,
+        "input_tokens": 0,
+        "cached_input_tokens": 0,
+        "output_tokens": 0,
+        "judge_input_tokens": 3117,
+        "judge_cached_input_tokens": 0,
+        "judge_output_tokens": 281,
+        "skill_cost_usd": 0.0,
+        "judge_cost_usd": 0.004522,
+        "total_cost_usd": 0.004522
+      },
+      "runs": [
+        {
+          "run_index": 0,
+          "run_id": "run_ut_search_full_text_003_2026-06-29_17-02-34_0",
+          "outcome": "pass",
+          "aborted_reason": null,
+          "duration_ms": 10033.227497013286,
+          "duration_api_ms": 0.0,
+          "num_turns": 0,
+          "skill_attempts": 1,
+          "input_tokens": 0,
+          "cached_input_tokens": 0,
+          "output_tokens": 0,
+          "skill_cost_usd": 0.0,
+          "output": {
+            "text_response": "",
+            "activated": false,
+            "skills_invoked": [
+              "record-extraction"
+            ],
+            "tool_calls": [],
+            "files_created": []
+          },
+          "validators": {
+            "passed": true,
+            "results": [
+              {
+                "name": "test_id_references_resolve",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_log_append_only",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_entries_deleted",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_ownership_table",
+                "passed": true,
+                "error": "skipped: ownership is not checked on negative tests \u2014 writes belong to the routed-to skill, not the skill under test"
+              },
+              {
+                "name": "test_research_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tool_allowlist",
+                "passed": true,
+                "error": "skipped: allowlist is not checked on negative tests \u2014 tool calls belong to the routed-to skill, not the skill under test"
+              },
+              {
+                "name": "test_tree_gedcomx_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_ownership_table",
+                "passed": true,
+                "error": "skipped: ownership is not checked on negative tests \u2014 writes belong to the routed-to skill, not the skill under test"
+              },
+              {
+                "name": "test_negative_result_log_shape",
+                "passed": true,
+                "error": "skipped: not a negative-result-log scenario"
+              },
+              {
+                "name": "test_positive_appends_log_entry",
+                "passed": true,
+                "error": "skipped: only positive tests record searches"
+              },
+              {
+                "name": "test_sidecar_written_for_positive_fts",
+                "passed": true,
+                "error": "skipped: not a sidecar-write scenario"
+              }
+            ]
+          },
+          "judge": {
+            "skipped": false,
+            "dimensions": [
+              {
+                "source": "base",
+                "name": "Correctness",
+                "score": 3,
+                "rationale": "The skill correctly declined to perform its own task (search-full-text) and routed the user to record-extraction, which is the appropriate skill for extracting assertions from a deed document. No fabricated material was produced."
+              },
+              {
+                "source": "base",
+                "name": "Completeness",
+                "score": 3,
+                "rationale": "The skill fully addressed the required behavior for this negative test: it declined to search the full-text tool with the deed content and instead properly routed the user to record-extraction, which is the correct next step."
+              },
+              {
+                "source": "base",
+                "name": "Tool Arguments",
+                "score": null,
+                "rationale": "No MCP tool calls were made. The skill appropriately declined to invoke its own tools and instead routed the user to a different skill, which is the correct behavior for this negative test scenario."
+              }
+            ],
+            "judge_cost_usd": 0.004522,
+            "duration_ms": 3066.4455779915443,
+            "error": null,
+            "input_tokens": 3117,
+            "cached_input_tokens": 0,
+            "output_tokens": 281
+          },
+          "started_at": 1782752798.941881,
+          "ended_at": 1782752812.9514828
+        }
+      ]
+    },
+    {
+      "test_id": "ut_search_full_text_006",
+      "test_type": "negative",
+      "expected_outcome": "pass",
+      "scenario": "empty-project-just-created",
+      "mcp_fixtures": [],
+      "outcome": "pass",
+      "flaky": false,
+      "outcome_summary": {
+        "per_run_outcomes": [
+          "pass"
+        ],
+        "aggregated_dimensions": [
+          {
+            "source": "base",
+            "name": "Correctness",
+            "score": 1,
+            "rationale": "Claude provided an empty response with no text output to guide the user toward research questions. The user explicitly asked for help scoping opening research questions, but received nothing. An empty response is fundamentally incorrect behavior even for a routing/decline scenario\u2014the skill should have provided guidance."
+          },
+          {
+            "source": "base",
+            "name": "Completeness",
+            "score": 1,
+            "rationale": "The skill failed to address the core request. The user asked for help figuring out the right opening research questions to scope the Patrick Flynn project. Claude generated no output, no guidance, and no suggested questions or framework. This is a major omission of what was explicitly asked."
+          },
+          {
+            "source": "base",
+            "name": "Tool Arguments",
+            "score": null,
+            "rationale": "No MCP tool calls were made during this skill execution. The Tool Arguments dimension is N/A."
+          }
+        ]
+      },
+      "totals": {
+        "duration_ms": 9176.236612998764,
+        "duration_api_ms": 0.0,
+        "judge_duration_ms": 4263.599637997686,
+        "wall_clock_ms": 11689.115762710571,
+        "num_turns": 0,
+        "input_tokens": 0,
+        "cached_input_tokens": 0,
+        "output_tokens": 0,
+        "judge_input_tokens": 3042,
+        "judge_cached_input_tokens": 0,
+        "judge_output_tokens": 283,
+        "skill_cost_usd": 0.0,
+        "judge_cost_usd": 0.004457,
+        "total_cost_usd": 0.004457
+      },
+      "runs": [
+        {
+          "run_index": 0,
+          "run_id": "run_ut_search_full_text_006_2026-06-29_17-02-34_0",
+          "outcome": "pass",
+          "aborted_reason": null,
+          "duration_ms": 9176.236612998764,
+          "duration_api_ms": 0.0,
+          "num_turns": 0,
+          "skill_attempts": 1,
+          "input_tokens": 0,
+          "cached_input_tokens": 0,
+          "output_tokens": 0,
+          "skill_cost_usd": 0.0,
+          "output": {
+            "text_response": "",
+            "activated": false,
+            "skills_invoked": [
+              "question-selection"
+            ],
+            "tool_calls": [],
+            "files_created": []
+          },
+          "validators": {
+            "passed": true,
+            "results": [
+              {
+                "name": "test_id_references_resolve",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_log_append_only",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_entries_deleted",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_ownership_table",
+                "passed": true,
+                "error": "skipped: ownership is not checked on negative tests \u2014 writes belong to the routed-to skill, not the skill under test"
+              },
+              {
+                "name": "test_research_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tool_allowlist",
+                "passed": true,
+                "error": "skipped: allowlist is not checked on negative tests \u2014 tool calls belong to the routed-to skill, not the skill under test"
+              },
+              {
+                "name": "test_tree_gedcomx_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_ownership_table",
+                "passed": true,
+                "error": "skipped: ownership is not checked on negative tests \u2014 writes belong to the routed-to skill, not the skill under test"
+              },
+              {
+                "name": "test_negative_result_log_shape",
+                "passed": true,
+                "error": "skipped: not a negative-result-log scenario"
+              },
+              {
+                "name": "test_positive_appends_log_entry",
+                "passed": true,
+                "error": "skipped: only positive tests record searches"
+              },
+              {
+                "name": "test_sidecar_written_for_positive_fts",
+                "passed": true,
+                "error": "skipped: not a sidecar-write scenario"
+              }
+            ]
+          },
+          "judge": {
+            "skipped": false,
+            "dimensions": [
+              {
+                "source": "base",
+                "name": "Correctness",
+                "score": 1,
+                "rationale": "Claude provided an empty response with no text output to guide the user toward research questions. The user explicitly asked for help scoping opening research questions, but received nothing. An empty response is fundamentally incorrect behavior even for a routing/decline scenario\u2014the skill should have provided guidance."
+              },
+              {
+                "source": "base",
+                "name": "Completeness",
+                "score": 1,
+                "rationale": "The skill failed to address the core request. The user asked for help figuring out the right opening research questions to scope the Patrick Flynn project. Claude generated no output, no guidance, and no suggested questions or framework. This is a major omission of what was explicitly asked."
+              },
+              {
+                "source": "base",
+                "name": "Tool Arguments",
+                "score": null,
+                "rationale": "No MCP tool calls were made during this skill execution. The Tool Arguments dimension is N/A."
+              }
+            ],
+            "judge_cost_usd": 0.004457,
+            "duration_ms": 4263.599637997686,
+            "error": null,
+            "input_tokens": 3042,
+            "cached_input_tokens": 0,
+            "output_tokens": 283
+          },
+          "started_at": 1782752775.9462998,
+          "ended_at": 1782752787.6354156
+        }
+      ]
+    },
+    {
+      "test_id": "ut_search_full_text_002",
+      "test_type": "positive",
+      "expected_outcome": "pass",
+      "scenario": "mid-research-flynn",
+      "mcp_fixtures": [
+        "fulltext-search-flynn-probate-empty",
+        "fulltext-search-flynn-probate-empty-by-name",
+        "fulltext-search-flynn-flinn-variant",
+        "fulltext-search-flynn-wildcard-variant"
+      ],
+      "outcome": "pass",
+      "flaky": false,
+      "outcome_summary": {
+        "per_run_outcomes": [
+          "pass"
+        ],
+        "aggregated_dimensions": [
+          {
+            "source": "base",
+            "name": "Correctness",
+            "score": 3,
+            "rationale": "All four FTS queries executed correctly with appropriate syntax (+/phrase operators). Zero results were legitimate \u2014 verified by the surname-only query returning zero, confirming FTS has no Schuylkill County probate coverage for 1870\u20131890. The skill correctly distinguished absence from the collection (coverage gap) versus actual absence of the person from existing records. Log entries accurately captured queries and results. All log tool calls succeeded and were validated. No fabricated results or unsupported claims."
+          },
+          {
+            "source": "base",
+            "name": "Completeness",
+            "score": 3,
+            "rationale": "The skill fully addressed the user request: search for Patrick Flynn as beneficiary/executor in Schuylkill County probate records. Four search variants were tried (phrase, non-phrase, surname variant Flinn, surname alone), all covering the specified geographic and date range (1870\u20131890). The plan item pli_006 was marked completed. Four detailed log entries were written. Recommendations for follow-up searches (indexed record_search, volume browse, Thomas Flynn's will examination) were provided."
+          },
+          {
+            "source": "base",
+            "name": "Tool Arguments",
+            "score": 3,
+            "rationale": "All four fulltext_search calls passed correct arguments: keywords matched expected patterns (~Flynn), recordType='probate', recordPlace1='Pennsylvania', recordPlace2='Schuylkill', yearFrom=1870, yearTo=1890. All four research_log_append calls had expected_args=null (live tool, no fixture comparison required) and succeeded with validation=true. No fixture_not_found errors. All arguments semantically matched test expectations."
+          },
+          {
+            "source": "rubric",
+            "name": "Query construction",
+            "score": 3,
+            "rationale": "Queries used FTS operators correctly: phrase quoting (+\"Patrick Flynn\"), required term operators (+Patrick +Flynn), and surname-only broad search (+Flynn). The skill correctly scoped to Schuylkill County and probate collection using provided filters. Four variants executed (phrase, non-phrase, spelling variant Flinn, surname-only) demonstrate systematic coverage. The surname-alone query was the critical diagnostic test \u2014 zero results on the broadest possible query confirmed a collection gap rather than a name issue."
+          },
+          {
+            "source": "rubric",
+            "name": "FAN awareness",
+            "score": 3,
+            "rationale": "This is a direct subject search ('Patrick Flynn as beneficiary or executor'), not a FAN exploration request. Per rubric guidance, the dimension passes when the requested direct search executes correctly. The skill executed the directed search appropriately and was NOT expected to unprompted-expand to FAN or suggest FAN follow-ups. No penalty for staying focused on the asked subject."
+          },
+          {
+            "source": "rubric",
+            "name": "Negative result handling",
+            "score": 3,
+            "rationale": "All four executed searches returned zero results, and the skill logged each with full detail: query syntax, collection/place/date filters, results available vs. examined (0 each). The final log entry (log_009) explicitly identified the outcome as a collection coverage gap, supported by the diagnostic logic that a surname-only query returning zero means FTS has no transcribed Schuylkill County probate corpus for the period. Four variants tried were enumerated. Skill suggested concrete next steps (indexed search, volume browse). This satisfies the standard for 'searches used, collections named, what was examined.'"
+          }
+        ]
+      },
+      "totals": {
+        "duration_ms": 182559.74110899842,
+        "duration_api_ms": 164447.0,
+        "judge_duration_ms": 11724.050317003275,
+        "wall_clock_ms": 185693.8989162445,
+        "num_turns": 21,
+        "input_tokens": 29,
+        "cached_input_tokens": 526223,
+        "output_tokens": 7078,
+        "judge_input_tokens": 7519,
+        "judge_cached_input_tokens": 0,
+        "judge_output_tokens": 897,
+        "skill_cost_usd": 0.4004314,
+        "judge_cost_usd": 0.012004,
+        "total_cost_usd": 0.4124354
+      },
+      "runs": [
+        {
+          "run_index": 0,
+          "run_id": "run_ut_search_full_text_002_2026-06-29_17-02-34_0",
+          "outcome": "pass",
+          "aborted_reason": null,
+          "duration_ms": 182559.74110899842,
+          "duration_api_ms": 164447.0,
+          "num_turns": 21,
+          "skill_attempts": 1,
+          "input_tokens": 29,
+          "cached_input_tokens": 526223,
+          "output_tokens": 7078,
+          "skill_cost_usd": 0.4004314,
+          "output": {
+            "text_response": "I'll start by reading the project files and references to prepare the search.Good \u2014 I have a clear picture. The active plan item is **pli_006** (probate, Schuylkill County, 1870\u20131890). I can also see that `src_006` (Thomas Flynn's 1881 will) exists with no log entry \u2014 meaning it was found outside the formal search process. I'll now execute the FTS search for Patrick Flynn in probate records.\n\n**Strategy:** Patrick Flynn is a moderately common name, so I'll use a phrase search `+\"Patrick Flynn\"` to require both names together. No surname variants appear in prior log entries, so I'll start with the standard spelling.Now executing the search \u2014 phrase query `+\"Patrick Flynn\"` with Schuylkill County and probate filters:Zero results on the phrase search. I'll now try with both terms required (non-phrase) to catch transcriptions where first and last name are separated on the page:Still nil. Trying the common Irish spelling variant \"Flinn\":Nil again. One more probe \u2014 surname alone (`+Flynn`) to check if the collection has *any* Schuylkill probate coverage at all:Confirmed coverage gap \u2014 even `+Flynn` alone returns zero results in Schuylkill County probate 1870\u20131890. Four queries, all nil. Now I'll log all four searches and close the plan item.All four log entries written. Now I'll mark pli_006 as completed:The `research_append` tool isn't in the available MCP set, so I'll update pli_006 directly in the file:Now validate the file:Validation permission denied \u2014 I'll proceed. The edit was a single field change on a known-valid file.\n\n---\n\n## FTS Search Results: Patrick Flynn in Schuylkill County Probate Records\n\n### What was searched\n\n| # | Query | Variant | Result |\n|---|-------|---------|--------|\n| log_006 | `+\"Patrick Flynn\"` | Phrase \u2014 both names adjacent | 0 |\n| log_007 | `+Patrick +Flynn` | Both required, non-phrase | 0 |\n| log_008 | `+Patrick +Flinn` | Common Irish spelling variant | 0 |\n| log_009 | `+Flynn` | Surname alone, broadest possible | 0 |\n\nAll searches applied the same filters: **FamilySearch FTS \u00b7 probate \u00b7 Schuylkill County, Pennsylvania \u00b7 1870\u20131890**.\n\n### Finding: Coverage gap, not absence of records\n\nThe surname-alone query (`+Flynn`) returning zero is the decisive signal. If FTS had *any* transcribed Schuylkill County probate documents from this period, a common Irish surname would almost certainly appear somewhere. Instead, the corpus is empty \u2014 **FamilySearch FTS simply does not have Schuylkill County probate records (1870\u20131890) in its AI-transcribed layer.** This is a collection gap, not evidence that Patrick Flynn is absent from those records.\n\nNote: `src_006` in this project (Thomas Flynn's 1881 will) was already found by a prior search or record-extraction step \u2014 that record exists and names family members \u2014 so the underlying documents do survive; they're just not FTS-accessible.\n\n### Plan item pli_006 \u2192 `completed`\n\n### Recommended next steps\n\n1. **Indexed search-records** \u2014 Run `record_search` against FamilySearch's indexed probate collections for Schuylkill County. The same records may be indexed even if not FTS-transcribed.\n2. **Volume browse** \u2014 The Schuylkill County Will Books are likely digitized as image-only volumes on FamilySearch. Browse by Image Group Number for Will Books circa 1870\u20131890 to look for Patrick Flynn as executor or legatee.\n3. **Thomas Flynn's will (src_006)** \u2014 That will from 1881 is already in the project but has a rough citation and no log entry. It would be worth confirming whether it explicitly names Patrick as a son/executor, and running record-extraction on it if not already done.\n\nShall I queue an indexed search-records run, or help locate the Will Book volume numbers for a manual browse?",
+            "activated": true,
+            "skills_invoked": [
+              "search-full-text"
+            ],
+            "tool_calls": [
+              {
+                "tool": "mcp__genealogy__fulltext_search",
+                "args": {
+                  "keywords": "+\"Patrick Flynn\"",
+                  "recordType": "probate",
+                  "recordPlace1": "Pennsylvania",
+                  "recordPlace2": "Schuylkill",
+                  "yearFrom": 1870,
+                  "yearTo": 1890,
+                  "count": 20,
+                  "projectPath": "/tmp/eval-ut_search_full_text_002-0-0-sl391_ty"
+                },
+                "expected_args": {
+                  "keywords": "~Flynn"
+                },
+                "matched": {
+                  "kind": "predicate",
+                  "index": 0
+                },
+                "response_fixture": "fulltext-search-flynn-probate-empty"
+              },
+              {
+                "tool": "mcp__genealogy__fulltext_search",
+                "args": {
+                  "keywords": "+Patrick +Flynn",
+                  "recordType": "probate",
+                  "recordPlace1": "Pennsylvania",
+                  "recordPlace2": "Schuylkill",
+                  "yearFrom": 1870,
+                  "yearTo": 1890,
+                  "count": 20,
+                  "projectPath": "/tmp/eval-ut_search_full_text_002-0-0-sl391_ty"
+                },
+                "expected_args": {
+                  "keywords": "~Flynn"
+                },
+                "matched": {
+                  "kind": "predicate",
+                  "index": 0
+                },
+                "response_fixture": "fulltext-search-flynn-probate-empty"
+              },
+              {
+                "tool": "mcp__genealogy__fulltext_search",
+                "args": {
+                  "keywords": "+Patrick +Flinn",
+                  "recordType": "probate",
+                  "recordPlace1": "Pennsylvania",
+                  "recordPlace2": "Schuylkill",
+                  "yearFrom": 1870,
+                  "yearTo": 1890,
+                  "count": 20,
+                  "projectPath": "/tmp/eval-ut_search_full_text_002-0-0-sl391_ty"
+                },
+                "expected_args": {
+                  "keywords": "~Flinn"
+                },
+                "matched": {
+                  "kind": "predicate",
+                  "index": 2
+                },
+                "response_fixture": "fulltext-search-flynn-flinn-variant"
+              },
+              {
+                "tool": "mcp__genealogy__fulltext_search",
+                "args": {
+                  "keywords": "+Flynn",
+                  "recordType": "probate",
+                  "recordPlace1": "Pennsylvania",
+                  "recordPlace2": "Schuylkill",
+                  "yearFrom": 1870,
+                  "yearTo": 1890,
+                  "count": 20,
+                  "projectPath": "/tmp/eval-ut_search_full_text_002-0-0-sl391_ty"
+                },
+                "expected_args": {
+                  "keywords": "~Flynn"
+                },
+                "matched": {
+                  "kind": "predicate",
+                  "index": 0
+                },
+                "response_fixture": "fulltext-search-flynn-probate-empty"
+              },
+              {
+                "tool": "mcp__genealogy__research_log_append",
+                "args": {
+                  "projectPath": "/tmp/eval-ut_search_full_text_002-0-0-sl391_ty",
+                  "planItemId": "pli_006",
+                  "tool": "fulltext_search",
+                  "query": {
+                    "keywords": "+\"Patrick Flynn\"",
+                    "recordType": "probate",
+                    "recordPlace1": "Pennsylvania",
+                    "recordPlace2": "Schuylkill",
+                    "yearFrom": 1870,
+                    "yearTo": 1890
+                  },
+                  "outcome": "negative",
+                  "resultsExamined": 0,
+                  "resultsAvailable": 0,
+                  "notes": "Searched FamilySearch FTS, probate collection, Schuylkill County, Pennsylvania, 1870\u20131890; phrase query +\"Patrick Flynn\"; 0 results."
+                },
+                "expected_args": null,
+                "matched": {
+                  "kind": "live",
+                  "index": null
+                },
+                "response_fixture": "live:research_log_append"
+              },
+              {
+                "tool": "mcp__genealogy__research_log_append",
+                "args": {
+                  "projectPath": "/tmp/eval-ut_search_full_text_002-0-0-sl391_ty",
+                  "planItemId": "pli_006",
+                  "tool": "fulltext_search",
+                  "query": {
+                    "keywords": "+Patrick +Flynn",
+                    "recordType": "probate",
+                    "recordPlace1": "Pennsylvania",
+                    "recordPlace2": "Schuylkill",
+                    "yearFrom": 1870,
+                    "yearTo": 1890
+                  },
+                  "outcome": "negative",
+                  "resultsExamined": 0,
+                  "resultsAvailable": 0,
+                  "notes": "Retry 1: non-phrase both-required query +Patrick +Flynn; same filters; 0 results."
+                },
+                "expected_args": null,
+                "matched": {
+                  "kind": "live",
+                  "index": null
+                },
+                "response_fixture": "live:research_log_append"
+              },
+              {
+                "tool": "mcp__genealogy__research_log_append",
+                "args": {
+                  "projectPath": "/tmp/eval-ut_search_full_text_002-0-0-sl391_ty",
+                  "planItemId": "pli_006",
+                  "tool": "fulltext_search",
+                  "query": {
+                    "keywords": "+Patrick +Flinn",
+                    "recordType": "probate",
+                    "recordPlace1": "Pennsylvania",
+                    "recordPlace2": "Schuylkill",
+                    "yearFrom": 1870,
+                    "yearTo": 1890
+                  },
+                  "outcome": "negative",
+                  "resultsExamined": 0,
+                  "resultsAvailable": 0,
+                  "notes": "Retry 2: spelling variant +Patrick +Flinn; same filters; 0 results."
+                },
+                "expected_args": null,
+                "matched": {
+                  "kind": "live",
+                  "index": null
+                },
+                "response_fixture": "live:research_log_append"
+              },
+              {
+                "tool": "mcp__genealogy__research_log_append",
+                "args": {
+                  "projectPath": "/tmp/eval-ut_search_full_text_002-0-0-sl391_ty",
+                  "planItemId": "pli_006",
+                  "tool": "fulltext_search",
+                  "query": {
+                    "keywords": "+Flynn",
+                    "recordType": "probate",
+                    "recordPlace1": "Pennsylvania",
+                    "recordPlace2": "Schuylkill",
+                    "yearFrom": 1870,
+                    "yearTo": 1890
+                  },
+                  "outcome": "negative",
+                  "resultsExamined": 0,
+                  "resultsAvailable": 0,
+                  "notes": "Retry 3: surname-only +Flynn, same filters; 0 results \u2014 confirms FTS has no Schuylkill County probate coverage for 1870\u20131890; coverage gap, not a name-spelling issue. 4 variants tried total (phrase, non-phrase, Flinn, surname-only). Recommend indexed search-records or volume browse of Schuylkill County Will Books."
+                },
+                "expected_args": null,
+                "matched": {
+                  "kind": "live",
+                  "index": null
+                },
+                "response_fixture": "live:research_log_append"
+              }
+            ],
+            "files_created": [],
+            "file_changes": {
+              "research.json": {
+                "sections_modified": [
+                  "log",
+                  "plans"
+                ],
+                "diff": {
+                  "log": {
+                    "added": [
+                      {
+                        "id": "log_006",
+                        "plan_item_id": "pli_006",
+                        "performed": "2026-06-29T17:04:14.087Z",
+                        "tool": "fulltext_search",
+                        "query": {
+                          "keywords": "+\"Patrick Flynn\"",
+                          "recordType": "probate",
+                          "recordPlace1": "Pennsylvania",
+                          "recordPlace2": "Schuylkill",
+                          "yearFrom": 1870,
+                          "yearTo": 1890
+                        },
+                        "outcome": "negative",
+                        "results_examined": 0,
+                        "external_site": null,
+                        "results_ref": null,
+                        "results_available": 0,
+                        "notes": "Searched FamilySearch FTS, probate collection, Schuylkill County, Pennsylvania, 1870\u20131890; phrase query +\"Patrick Flynn\"; 0 results."
+                      },
+                      {
+                        "id": "log_007",
+                        "plan_item_id": "pli_006",
+                        "performed": "2026-06-29T17:04:20.816Z",
+                        "tool": "fulltext_search",
+                        "query": {
+                          "keywords": "+Patrick +Flynn",
+                          "recordType": "probate",
+                          "recordPlace1": "Pennsylvania",
+                          "recordPlace2": "Schuylkill",
+                          "yearFrom": 1870,
+                          "yearTo": 1890
+                        },
+                        "outcome": "negative",
+                        "results_examined": 0,
+                        "external_site": null,
+                        "results_ref": null,
+                        "results_available": 0,
+                        "notes": "Retry 1: non-phrase both-required query +Patrick +Flynn; same filters; 0 results."
+                      },
+                      {
+                        "id": "log_008",
+                        "plan_item_id": "pli_006",
+                        "performed": "2026-06-29T17:04:27.155Z",
+                        "tool": "fulltext_search",
+                        "query": {
+                          "keywords": "+Patrick +Flinn",
+                          "recordType": "probate",
+                          "recordPlace1": "Pennsylvania",
+                          "recordPlace2": "Schuylkill",
+                          "yearFrom": 1870,
+                          "yearTo": 1890
+                        },
+                        "outcome": "negative",
+                        "results_examined": 0,
+                        "external_site": null,
+                        "results_ref": null,
+                        "results_available": 0,
+                        "notes": "Retry 2: spelling variant +Patrick +Flinn; same filters; 0 results."
+                      },
+                      {
+                        "id": "log_009",
+                        "plan_item_id": "pli_006",
+                        "performed": "2026-06-29T17:04:35.564Z",
+                        "tool": "fulltext_search",
+                        "query": {
+                          "keywords": "+Flynn",
+                          "recordType": "probate",
+                          "recordPlace1": "Pennsylvania",
+                          "recordPlace2": "Schuylkill",
+                          "yearFrom": 1870,
+                          "yearTo": 1890
+                        },
+                        "outcome": "negative",
+                        "results_examined": 0,
+                        "external_site": null,
+                        "results_ref": null,
+                        "results_available": 0,
+                        "notes": "Retry 3: surname-only +Flynn, same filters; 0 results \u2014 confirms FTS has no Schuylkill County probate coverage for 1870\u20131890; coverage gap, not a name-spelling issue. 4 variants tried total (phrase, non-phrase, Flinn, surname-only). Recommend indexed search-records or volume browse of Schuylkill County Will Books."
+                      }
+                    ],
+                    "modified": [],
+                    "deleted": []
+                  },
+                  "plans": {
+                    "added": [],
+                    "modified": [
+                      {
+                        "id": "pl_002",
+                        "changed_fields": {
+                          "items": {
+                            "before": [
+                              {
+                                "id": "pli_004",
+                                "sequence": 1,
+                                "record_type": "census",
+                                "jurisdiction": "Schuylkill County, Pennsylvania",
+                                "date_range": "1860",
+                                "repository": "FamilySearch",
+                                "rationale": "Confirm Patrick still in Thomas Flynn household in 1860. Strengthens parent-child identification.",
+                                "fallback_for": null,
+                                "status": "completed"
+                              },
+                              {
+                                "id": "pli_005",
+                                "sequence": 2,
+                                "record_type": "vital_record",
+                                "jurisdiction": "Schuylkill County, Pennsylvania",
+                                "date_range": "1908",
+                                "repository": "FamilySearch",
+                                "rationale": "Death certificate may name parents directly.",
+                                "fallback_for": null,
+                                "status": "completed"
+                              },
+                              {
+                                "id": "pli_006",
+                                "sequence": 3,
+                                "record_type": "probate",
+                                "jurisdiction": "Schuylkill County, Pennsylvania",
+                                "date_range": "1870-1890",
+                                "repository": "FamilySearch",
+                                "rationale": "Thomas Flynn probate/will may name Patrick as son.",
+                                "fallback_for": null,
+                                "status": "in_progress"
+                              }
+                            ],
+                            "after": [
+                              {
+                                "id": "pli_004",
+                                "sequence": 1,
+                                "record_type": "census",
+                                "jurisdiction": "Schuylkill County, Pennsylvania",
+                                "date_range": "1860",
+                                "repository": "FamilySearch",
+                                "rationale": "Confirm Patrick still in Thomas Flynn household in 1860. Strengthens parent-child identification.",
+                                "fallback_for": null,
+                                "status": "completed"
+                              },
+                              {
+                                "id": "pli_005",
+                                "sequence": 2,
+                                "record_type": "vital_record",
+                                "jurisdiction": "Schuylkill County, Pennsylvania",
+                                "date_range": "1908",
+                                "repository": "FamilySearch",
+                                "rationale": "Death certificate may name parents directly.",
+                                "fallback_for": null,
+                                "status": "completed"
+                              },
+                              {
+                                "id": "pli_006",
+                                "sequence": 3,
+                                "record_type": "probate",
+                                "jurisdiction": "Schuylkill County, Pennsylvania",
+                                "date_range": "1870-1890",
+                                "repository": "FamilySearch",
+                                "rationale": "Thomas Flynn probate/will may name Patrick as son.",
+                                "fallback_for": null,
+                                "status": "completed"
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    ],
+                    "deleted": []
+                  }
+                }
+              }
+            },
+            "warnings": [
+              {
+                "kind": "missing_tool_usage_dimension",
+                "advisory": "Skill called MCP tools but the rubric has no dimension name suggesting tool-usage coverage (matched against keywords: ['tool usage', 'tool use', 'tool work', 'tool call', 'argument quality', 'argument-quality', 'response interpretation', 'tool selection', 'mcp tool', 'fixture']). The judge will grade other dimensions but won't score tool work explicitly. Consider adding a tool-usage dimension or renaming an existing one."
+              },
+              {
+                "kind": "uncovered_tool_call",
+                "advisory": "1 of 9 MCP tool call(s) matched no fixture predicate \u2014 the skill ran against a fixture_not_found or denied/unknown-tool error. Add or fix an mcp_fixture whose args match the call.",
+                "attempted": [
+                  {
+                    "tool": "mcp__genealogy__fulltext_search",
+                    "args": {
+                      "keywords": "+\"Patrick Flynn\"",
+                      "recordType": "probate",
+                      "recordPlace1": "Pennsylvania",
+                      "recordPlace2": "Schuylkill",
+                      "yearFrom": 1870,
+                      "yearTo": 1890,
+                      "count": 20,
+                      "projectPath": "/tmp/eval-ut_search_full_text_002-0-0-sl391_ty"
+                    }
+                  },
+                  {
+                    "tool": "mcp__genealogy__fulltext_search",
+                    "args": {
+                      "keywords": "+Patrick +Flynn",
+                      "recordType": "probate",
+                      "recordPlace1": "Pennsylvania",
+                      "recordPlace2": "Schuylkill",
+                      "yearFrom": 1870,
+                      "yearTo": 1890,
+                      "count": 20,
+                      "projectPath": "/tmp/eval-ut_search_full_text_002-0-0-sl391_ty"
+                    }
+                  },
+                  {
+                    "tool": "mcp__genealogy__fulltext_search",
+                    "args": {
+                      "keywords": "+Patrick +Flinn",
+                      "recordType": "probate",
+                      "recordPlace1": "Pennsylvania",
+                      "recordPlace2": "Schuylkill",
+                      "yearFrom": 1870,
+                      "yearTo": 1890,
+                      "count": 20,
+                      "projectPath": "/tmp/eval-ut_search_full_text_002-0-0-sl391_ty"
+                    }
+                  },
+                  {
+                    "tool": "mcp__genealogy__fulltext_search",
+                    "args": {
+                      "keywords": "+Flynn",
+                      "recordType": "probate",
+                      "recordPlace1": "Pennsylvania",
+                      "recordPlace2": "Schuylkill",
+                      "yearFrom": 1870,
+                      "yearTo": 1890,
+                      "count": 20,
+                      "projectPath": "/tmp/eval-ut_search_full_text_002-0-0-sl391_ty"
+                    }
+                  },
+                  {
+                    "tool": "mcp__genealogy__research_log_append",
+                    "args": {
+                      "projectPath": "/tmp/eval-ut_search_full_text_002-0-0-sl391_ty",
+                      "planItemId": "pli_006",
+                      "tool": "fulltext_search",
+                      "query": {
+                        "keywords": "+\"Patrick Flynn\"",
+                        "recordType": "probate",
+                        "recordPlace1": "Pennsylvania",
+                        "recordPlace2": "Schuylkill",
+                        "yearFrom": 1870,
+                        "yearTo": 1890
+                      },
+                      "outcome": "negative",
+                      "resultsExamined": 0,
+                      "resultsAvailable": 0,
+                      "notes": "Searched FamilySearch FTS, probate collection, Schuylkill County, Pennsylvania, 1870\u20131890; phrase query +\"Patrick Flynn\"; 0 results."
+                    }
+                  },
+                  {
+                    "tool": "mcp__genealogy__research_log_append",
+                    "args": {
+                      "projectPath": "/tmp/eval-ut_search_full_text_002-0-0-sl391_ty",
+                      "planItemId": "pli_006",
+                      "tool": "fulltext_search",
+                      "query": {
+                        "keywords": "+Patrick +Flynn",
+                        "recordType": "probate",
+                        "recordPlace1": "Pennsylvania",
+                        "recordPlace2": "Schuylkill",
+                        "yearFrom": 1870,
+                        "yearTo": 1890
+                      },
+                      "outcome": "negative",
+                      "resultsExamined": 0,
+                      "resultsAvailable": 0,
+                      "notes": "Retry 1: non-phrase both-required query +Patrick +Flynn; same filters; 0 results."
+                    }
+                  },
+                  {
+                    "tool": "mcp__genealogy__research_log_append",
+                    "args": {
+                      "projectPath": "/tmp/eval-ut_search_full_text_002-0-0-sl391_ty",
+                      "planItemId": "pli_006",
+                      "tool": "fulltext_search",
+                      "query": {
+                        "keywords": "+Patrick +Flinn",
+                        "recordType": "probate",
+                        "recordPlace1": "Pennsylvania",
+                        "recordPlace2": "Schuylkill",
+                        "yearFrom": 1870,
+                        "yearTo": 1890
+                      },
+                      "outcome": "negative",
+                      "resultsExamined": 0,
+                      "resultsAvailable": 0,
+                      "notes": "Retry 2: spelling variant +Patrick +Flinn; same filters; 0 results."
+                    }
+                  },
+                  {
+                    "tool": "mcp__genealogy__research_log_append",
+                    "args": {
+                      "projectPath": "/tmp/eval-ut_search_full_text_002-0-0-sl391_ty",
+                      "planItemId": "pli_006",
+                      "tool": "fulltext_search",
+                      "query": {
+                        "keywords": "+Flynn",
+                        "recordType": "probate",
+                        "recordPlace1": "Pennsylvania",
+                        "recordPlace2": "Schuylkill",
+                        "yearFrom": 1870,
+                        "yearTo": 1890
+                      },
+                      "outcome": "negative",
+                      "resultsExamined": 0,
+                      "resultsAvailable": 0,
+                      "notes": "Retry 3: surname-only +Flynn, same filters; 0 results \u2014 confirms FTS has no Schuylkill County probate coverage for 1870\u20131890; coverage gap, not a name-spelling issue. 4 variants tried total (phrase, non-phrase, Flinn, surname-only). Recommend indexed search-records or volume browse of Schuylkill County Will Books."
+                    }
+                  },
+                  {
+                    "tool": "mcp__genealogy__validate_research_schema",
+                    "args": {
+                      "projectPath": "/tmp/eval-ut_search_full_text_002-0-0-sl391_ty"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "validators": {
+            "passed": true,
+            "results": [
+              {
+                "name": "test_id_references_resolve",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_log_append_only",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_entries_deleted",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_research_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tool_allowlist",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_gedcomx_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_negative_result_log_shape",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_positive_appends_log_entry",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_sidecar_written_for_positive_fts",
+                "passed": true,
+                "error": "skipped: not a sidecar-write scenario"
+              }
+            ]
+          },
+          "judge": {
+            "skipped": false,
+            "dimensions": [
+              {
+                "source": "base",
+                "name": "Correctness",
+                "score": 3,
+                "rationale": "All four FTS queries executed correctly with appropriate syntax (+/phrase operators). Zero results were legitimate \u2014 verified by the surname-only query returning zero, confirming FTS has no Schuylkill County probate coverage for 1870\u20131890. The skill correctly distinguished absence from the collection (coverage gap) versus actual absence of the person from existing records. Log entries accurately captured queries and results. All log tool calls succeeded and were validated. No fabricated results or unsupported claims."
+              },
+              {
+                "source": "base",
+                "name": "Completeness",
+                "score": 3,
+                "rationale": "The skill fully addressed the user request: search for Patrick Flynn as beneficiary/executor in Schuylkill County probate records. Four search variants were tried (phrase, non-phrase, surname variant Flinn, surname alone), all covering the specified geographic and date range (1870\u20131890). The plan item pli_006 was marked completed. Four detailed log entries were written. Recommendations for follow-up searches (indexed record_search, volume browse, Thomas Flynn's will examination) were provided."
+              },
+              {
+                "source": "base",
+                "name": "Tool Arguments",
+                "score": 3,
+                "rationale": "All four fulltext_search calls passed correct arguments: keywords matched expected patterns (~Flynn), recordType='probate', recordPlace1='Pennsylvania', recordPlace2='Schuylkill', yearFrom=1870, yearTo=1890. All four research_log_append calls had expected_args=null (live tool, no fixture comparison required) and succeeded with validation=true. No fixture_not_found errors. All arguments semantically matched test expectations."
+              },
+              {
+                "source": "rubric",
+                "name": "Query construction",
+                "score": 3,
+                "rationale": "Queries used FTS operators correctly: phrase quoting (+\"Patrick Flynn\"), required term operators (+Patrick +Flynn), and surname-only broad search (+Flynn). The skill correctly scoped to Schuylkill County and probate collection using provided filters. Four variants executed (phrase, non-phrase, spelling variant Flinn, surname-only) demonstrate systematic coverage. The surname-alone query was the critical diagnostic test \u2014 zero results on the broadest possible query confirmed a collection gap rather than a name issue."
+              },
+              {
+                "source": "rubric",
+                "name": "FAN awareness",
+                "score": 3,
+                "rationale": "This is a direct subject search ('Patrick Flynn as beneficiary or executor'), not a FAN exploration request. Per rubric guidance, the dimension passes when the requested direct search executes correctly. The skill executed the directed search appropriately and was NOT expected to unprompted-expand to FAN or suggest FAN follow-ups. No penalty for staying focused on the asked subject."
+              },
+              {
+                "source": "rubric",
+                "name": "Negative result handling",
+                "score": 3,
+                "rationale": "All four executed searches returned zero results, and the skill logged each with full detail: query syntax, collection/place/date filters, results available vs. examined (0 each). The final log entry (log_009) explicitly identified the outcome as a collection coverage gap, supported by the diagnostic logic that a surname-only query returning zero means FTS has no transcribed Schuylkill County probate corpus for the period. Four variants tried were enumerated. Skill suggested concrete next steps (indexed search, volume browse). This satisfies the standard for 'searches used, collections named, what was examined.'"
+              }
+            ],
+            "judge_cost_usd": 0.012004,
+            "duration_ms": 11724.050317003275,
+            "error": null,
+            "input_tokens": 7519,
+            "cached_input_tokens": 0,
+            "output_tokens": 897
+          },
+          "started_at": 1782752554.9506075,
+          "ended_at": 1782752740.6445065
+        }
+      ]
+    },
+    {
+      "test_id": "ut_search_full_text_004",
+      "test_type": "negative",
+      "expected_outcome": "pass",
+      "scenario": "empty-project-just-created",
+      "mcp_fixtures": [],
+      "outcome": "pass",
+      "flaky": false,
+      "outcome_summary": {
+        "per_run_outcomes": [
+          "pass"
+        ],
+        "aggregated_dimensions": [
+          {
+            "source": "base",
+            "name": "Correctness",
+            "score": 3,
+            "rationale": "The skill correctly recognized that the user's request for an indexed search by person attributes (Flynn, Pennsylvania, 1880 census) should be routed to search-records, not handled by search-full-text. This is the correct behavior for this negative test\u2014declining to execute a fulltext search task when the request requires indexed lookup semantics is factually correct."
+          },
+          {
+            "source": "base",
+            "name": "Completeness",
+            "score": 3,
+            "rationale": "The skill fully addressed what was required in this negative test scenario: it declined to perform search-full-text's task and routed the user to the appropriate skill (search-records). The routing decision itself is complete and unambiguous. No additional explanation was necessary given the instructions to focus on the routing quality."
+          },
+          {
+            "source": "base",
+            "name": "Tool Arguments",
+            "score": null,
+            "rationale": "No MCP tool calls were made by the skill. This is the correct behavior for a negative test that requires declining the task and routing to another skill. N/A applies when zero tool calls are present."
+          }
+        ]
+      },
+      "totals": {
+        "duration_ms": 6375.774237996666,
+        "duration_api_ms": 0.0,
+        "judge_duration_ms": 4445.891979004955,
+        "wall_clock_ms": 10981.152296066284,
+        "num_turns": 0,
+        "input_tokens": 0,
+        "cached_input_tokens": 0,
+        "output_tokens": 0,
+        "judge_input_tokens": 3007,
+        "judge_cached_input_tokens": 0,
+        "judge_output_tokens": 332,
+        "skill_cost_usd": 0.0,
+        "judge_cost_usd": 0.004667,
+        "total_cost_usd": 0.004667
+      },
+      "runs": [
+        {
+          "run_index": 0,
+          "run_id": "run_ut_search_full_text_004_2026-06-29_17-02-34_0",
+          "outcome": "pass",
+          "aborted_reason": null,
+          "duration_ms": 6375.774237996666,
+          "duration_api_ms": 0.0,
+          "num_turns": 0,
+          "skill_attempts": 1,
+          "input_tokens": 0,
+          "cached_input_tokens": 0,
+          "output_tokens": 0,
+          "skill_cost_usd": 0.0,
+          "output": {
+            "text_response": "",
+            "activated": false,
+            "skills_invoked": [
+              "search-records"
+            ],
+            "tool_calls": [],
+            "files_created": []
+          },
+          "validators": {
+            "passed": true,
+            "results": [
+              {
+                "name": "test_id_references_resolve",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_log_append_only",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_entries_deleted",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_ownership_table",
+                "passed": true,
+                "error": "skipped: ownership is not checked on negative tests \u2014 writes belong to the routed-to skill, not the skill under test"
+              },
+              {
+                "name": "test_research_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tool_allowlist",
+                "passed": true,
+                "error": "skipped: allowlist is not checked on negative tests \u2014 tool calls belong to the routed-to skill, not the skill under test"
+              },
+              {
+                "name": "test_tree_gedcomx_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_ownership_table",
+                "passed": true,
+                "error": "skipped: ownership is not checked on negative tests \u2014 writes belong to the routed-to skill, not the skill under test"
+              },
+              {
+                "name": "test_negative_result_log_shape",
+                "passed": true,
+                "error": "skipped: not a negative-result-log scenario"
+              },
+              {
+                "name": "test_positive_appends_log_entry",
+                "passed": true,
+                "error": "skipped: only positive tests record searches"
+              },
+              {
+                "name": "test_sidecar_written_for_positive_fts",
+                "passed": true,
+                "error": "skipped: not a sidecar-write scenario"
+              }
+            ]
+          },
+          "judge": {
+            "skipped": false,
+            "dimensions": [
+              {
+                "source": "base",
+                "name": "Correctness",
+                "score": 3,
+                "rationale": "The skill correctly recognized that the user's request for an indexed search by person attributes (Flynn, Pennsylvania, 1880 census) should be routed to search-records, not handled by search-full-text. This is the correct behavior for this negative test\u2014declining to execute a fulltext search task when the request requires indexed lookup semantics is factually correct."
+              },
+              {
+                "source": "base",
+                "name": "Completeness",
+                "score": 3,
+                "rationale": "The skill fully addressed what was required in this negative test scenario: it declined to perform search-full-text's task and routed the user to the appropriate skill (search-records). The routing decision itself is complete and unambiguous. No additional explanation was necessary given the instructions to focus on the routing quality."
+              },
+              {
+                "source": "base",
+                "name": "Tool Arguments",
+                "score": null,
+                "rationale": "No MCP tool calls were made by the skill. This is the correct behavior for a negative test that requires declining the task and routing to another skill. N/A applies when zero tool calls are present."
+              }
+            ],
+            "judge_cost_usd": 0.004667,
+            "duration_ms": 4445.891979004955,
+            "error": null,
+            "input_tokens": 3007,
+            "cached_input_tokens": 0,
+            "output_tokens": 332
+          },
+          "started_at": 1782752787.6858108,
+          "ended_at": 1782752798.666963
+        }
+      ]
+    },
+    {
+      "test_id": "ut_search_full_text_012",
+      "test_type": "positive",
+      "expected_outcome": "pass",
+      "scenario": "mid-research-flynn",
+      "mcp_fixtures": [
+        "fulltext-search-nlquery-tree-person",
+        "fulltext-search-flynn-witnesses"
+      ],
+      "outcome": "pass",
+      "flaky": false,
+      "outcome_summary": {
+        "per_run_outcomes": [
+          "pass"
+        ],
+        "aggregated_dimensions": [
+          {
+            "source": "base",
+            "name": "Correctness",
+            "score": 3,
+            "rationale": "The skill correctly executed a natural-language FTS search using the tree person ID 'KWCJ-RN4' as instructed. Both results reported match the fixture's expected responses: the 1869 deed of conveyance to Patrick Flynn with the boundary clause mentioning 'heirs of Thomas Flynn deceased,' and the 1885 Cornelius Sheridan probate inventory. The skill accurately extracted key details from both records (dates, place names, principal and non-principal actors) and made sound inferences (Thomas Flynn's death before November 1869, the BranchTownship neighborhood connection, and implications for the probate search window). No fabricated material or contradictions with the input state."
+          },
+          {
+            "source": "base",
+            "name": "Completeness",
+            "score": 3,
+            "rationale": "The skill fully addressed the user's request: it executed the FTS search using the nlQuery tree person ID entry point as explicitly requested, examined all 2 returned results, logged them with detailed notes, and provided implications for next steps (record extraction, revised search window, FAN cross-reference opportunities). The response included the full summary and file changes tracking, meeting all requirements of the task."
+          },
+          {
+            "source": "base",
+            "name": "Tool Arguments",
+            "score": 3,
+            "rationale": "Both MCP tool calls passed arguments matching the fixture's expected_args. The fulltext_search call correctly passed nlQuery as 'KWCJ-RN4' (matching the expected substring ~KWCJ-RN4) and included projectPath as required. The research_log_append call properly captured the query, outcome, results examined, and detailed notes. The tool invocations matched the canonical shape expected by the test fixture."
+          },
+          {
+            "source": "rubric",
+            "name": "Query construction",
+            "score": 3,
+            "rationale": "The skill used the correct FTS entry point: nlQuery with the tree person ID 'KWCJ-RN4' rather than a bare keyword query. The skill explicitly explained why this was the right choice, noting that the upstream resolves the tree ID against the person's facts and aliases to widen the search\u2014a meaningful advantage over a keyword-only approach like '+Patrick +Flynn'. No additional queries were needed; the single nlQuery successfully returned the expected records."
+          },
+          {
+            "source": "rubric",
+            "name": "FAN awareness",
+            "score": 3,
+            "rationale": "This was a direct subject search ('search for Patrick Flynn using his tree person ID'). The skill is not required to pivot to FAN unprompted in such cases. However, the skill went further and identified multiple FAN leads (Cornelius Sheridan, John McGrath, James Dempsey, Owen Reilly) in its narrative and suggested queuing FTS searches for them in the 'Suggested Next Steps' section, demonstrating awareness of FAN opportunity without overreaching the original request."
+          },
+          {
+            "source": "rubric",
+            "name": "Negative result handling",
+            "score": 3,
+            "rationale": "All executed searches returned positive results (2 of 2 examined, outcome 'positive'). The negative result handling dimension does not fire when all searches return results. Per the rubric, this dimension scores pass when 'all executed searches returned results (nothing to grade).' The skill properly logged both results with full detail (collection titles, ARKs, record dates, key extracts)."
+          }
+        ]
+      },
+      "totals": {
+        "duration_ms": 108694.36883401067,
+        "duration_api_ms": 100938.0,
+        "judge_duration_ms": 50807.607662995,
+        "wall_clock_ms": 153431.81347846985,
+        "num_turns": 9,
+        "input_tokens": 15,
+        "cached_input_tokens": 128136,
+        "output_tokens": 4417,
+        "judge_input_tokens": 6698,
+        "judge_cached_input_tokens": 0,
+        "judge_output_tokens": 891,
+        "skill_cost_usd": 0.20694154999999997,
+        "judge_cost_usd": 0.011153,
+        "total_cost_usd": 0.21809454999999997
+      },
+      "runs": [
+        {
+          "run_index": 0,
+          "run_id": "run_ut_search_full_text_012_2026-06-29_17-02-34_0",
+          "outcome": "pass",
+          "aborted_reason": null,
+          "duration_ms": 108694.36883401067,
+          "duration_api_ms": 100938.0,
+          "num_turns": 9,
+          "skill_attempts": 1,
+          "input_tokens": 15,
+          "cached_input_tokens": 128136,
+          "output_tokens": 4417,
+          "skill_cost_usd": 0.20694154999999997,
+          "output": {
+            "text_response": "I'll start by reading `research.json` to get the project state and narration guidance, then execute the natural-language FTS search.Good \u2014 I have a clear picture of the project. No `narration_guidance` is set, so I'll use one-line preambles. The active plan item is **pli_006** (Thomas Flynn probate, Schuylkill County, 1870\u20131890), currently `in_progress`. No prior surname variants in the log (only \"Flynn\"). The user explicitly requested the natural-language / tree-person-ID entry point, which the skill instructs me to honour with `nlQuery`.\n\nLoading the FTS tool schema now.Executing the natural-language FTS search \u2014 passing the tree person ID so FamilySearch can widen the query using Patrick Flynn's known facts.Two results returned \u2014 both relevant. Triaging before logging.\n\n**Result 1 \u2014 1869 Deed of Conveyance (Land Records)**\nPatrick Flynn purchases land in Branch Township from Cornelius Sheridan. The boundary description reads *\"southerly by the lands of the heirs of Thomas Flynn deceased.\"* This is significant new evidence: Thomas Flynn was **dead by November 1869**, and his heirs' land directly adjoined the parcel Patrick Flynn bought \u2014 placing the two men in the same Branch Township neighbourhood. This is a non-principal mention of Thomas Flynn (boundary marker) that directly bears on hypothesis h_001.\n\n**Result 2 \u2014 1885 Probate Inventory, Estate of Cornelius Sheridan**\nPatrick Flynn appears as one of two court-appointed appraisers \u2014 a non-principal role. This places him still in Branch Township, Schuylkill County in 1885 and within the FAN cluster of the same Sheridan/McGrath neighbourhood. Useful for timeline but no new parentage evidence.\n\nBoth results unattached to any tree person (found via nlQuery, not an attachment check needed before logging). Logging now.Logged as **log_006** with sidecar `results/log_006.json`. Here's the full summary:\n\n---\n\n## FTS Search Complete \u2014 Patrick Flynn (KWCJ-RN4)\n\n**Search method:** Natural-language / tree person ID (`nlQuery: \"KWCJ-RN4\"`)\n**Results:** 2 of 2 examined \u00b7 Outcome: **positive**\n\n---\n\n### Result 1 \u2014 1869 Deed of Conveyance \u2b50 High priority\n**Collection:** Pennsylvania Land Records \u00b7 **ARK:** `ark:/61903/1:1:Q8M1-2F4A`\n\nPatrick Flynn purchases a 7-acre parcel in Branch Township, Schuylkill County from Cornelius Sheridan. The boundary description contains the key phrase:\n\n> *\"southerly by the lands of the heirs of **Thomas Flynn deceased**\"*\n\nThis is entirely new evidence:\n- Thomas Flynn was **dead before 12 November 1869** \u2014 this revises the probate search window for pli_006 backward (should now target roughly 1860\u20131870, not 1870\u20131890)\n- Thomas Flynn's land directly bounded Patrick Flynn's purchase \u2014 placing them in the same Branch Township neighbourhood and further corroborating hypothesis **h_001**\n- Witnesses: **James Dempsey** and **Owen Reilly** (FAN leads)\n- Neighbour named: **John McGrath** (FAN lead)\n\n---\n\n### Result 2 \u2014 1885 Probate Inventory, Estate of Cornelius Sheridan\n**Collection:** Pennsylvania Probate Records, 1683\u20131994 \u00b7 **ARK:** `ark:/61903/1:1:Q8M1-9C7H`\n\nPatrick Flynn named as a court-appointed appraiser alongside Edward McNally. Non-principal mention \u2014 useful for timeline (places Patrick in Branch Township in 1885) but adds no new parentage evidence.\n\n---\n\n### Implications & Suggested Next Steps\n\n1. **Pass the 1869 deed to record-extraction** \u2014 the \"heirs of Thomas Flynn deceased\" boundary clause is direct documentary evidence bearing on h_001 and warrants a formal assertion.\n2. **Revise pli_006 search window** \u2014 Thomas Flynn was dead before November 1869; the probate search should target **ca. 1860\u20131869** rather than 1870\u20131890.\n3. **Cross-reference FAN leads** \u2014 shall I queue FTS searches for **Cornelius Sheridan**, **John McGrath**, **James Dempsey**, or **Owen Reilly** in Branch Township? Any of them may appear in records alongside other Flynn family members.",
+            "activated": true,
+            "skills_invoked": [
+              "search-full-text"
+            ],
+            "tool_calls": [
+              {
+                "tool": "mcp__genealogy__fulltext_search",
+                "args": {
+                  "nlQuery": "KWCJ-RN4",
+                  "projectPath": "/tmp/eval-ut_search_full_text_012-0-0-qwypqyld"
+                },
+                "expected_args": {
+                  "nlQuery": "~KWCJ-RN4"
+                },
+                "matched": {
+                  "kind": "predicate",
+                  "index": 0
+                },
+                "response_fixture": "fulltext-search-nlquery-tree-person"
+              },
+              {
+                "tool": "mcp__genealogy__research_log_append",
+                "args": {
+                  "projectPath": "/tmp/eval-ut_search_full_text_012-0-0-qwypqyld",
+                  "planItemId": null,
+                  "tool": "fulltext_search",
+                  "query": {
+                    "nlQuery": "KWCJ-RN4"
+                  },
+                  "outcome": "positive",
+                  "resultsExamined": 2,
+                  "resultsAvailable": 2,
+                  "notes": "Ad-hoc FTS via tree-person ID KWCJ-RN4 (natural-language entry point). 2 results, both examined. (1) 1869 deed: Patrick Flynn buys land in Branch Township from Cornelius Sheridan; boundary clause reads \\\"heirs of Thomas Flynn deceased\\\" \u2014 confirms Thomas Flynn was dead before Nov 1869 and his land adjoined Patrick's purchase, strongly corroborating h_001. (2) 1885 probate inventory for Cornelius Sheridan estate: Patrick Flynn named as appraiser \u2014 non-principal mention placing him in Branch Township in 1885. Implication: pli_006 probate search window should extend back to ca. 1860\u20131870, not 1870\u20131890. Cross-reference opportunities: John McGrath (neighbor), James Dempsey and Owen Reilly (witnesses on deed), Cornelius Sheridan (FAN).\"",
+                  "stagedResultsRef": "results/.staging/36570327-439a-478b-809f-4440595b4c37.json"
+                },
+                "expected_args": null,
+                "matched": {
+                  "kind": "live",
+                  "index": null
+                },
+                "response_fixture": "live:research_log_append"
+              }
+            ],
+            "files_created": [
+              "results/log_006.json"
+            ],
+            "file_changes": {
+              "research.json": {
+                "sections_modified": [
+                  "log"
+                ],
+                "diff": {
+                  "log": {
+                    "added": [
+                      {
+                        "id": "log_006",
+                        "plan_item_id": null,
+                        "performed": "2026-06-29T17:07:07.793Z",
+                        "tool": "fulltext_search",
+                        "query": {
+                          "nlQuery": "KWCJ-RN4"
+                        },
+                        "outcome": "positive",
+                        "results_examined": 2,
+                        "external_site": null,
+                        "results_ref": "results/log_006.json",
+                        "results_available": 2,
+                        "notes": "Ad-hoc FTS via tree-person ID KWCJ-RN4 (natural-language entry point). 2 results, both examined. (1) 1869 deed: Patrick Flynn buys land in Branch Township from Cornelius Sheridan; boundary clause reads \\\"heirs of Thomas Flynn deceased\\\" \u2014 confirms Thomas Flynn was dead before Nov 1869 and his land adjoined Patrick's purchase, strongly corroborating h_001. (2) 1885 probate inventory for Cornelius Sheridan estate: Patrick Flynn named as appraiser \u2014 non-principal mention placing him in Branch Township in 1885. Implication: pli_006 probate search window should extend back to ca. 1860\u20131870, not 1870\u20131890. Cross-reference opportunities: John McGrath (neighbor), James Dempsey and Owen Reilly (witnesses on deed), Cornelius Sheridan (FAN).\""
+                      }
+                    ],
+                    "modified": [],
+                    "deleted": []
+                  }
+                }
+              }
+            },
+            "warnings": [
+              {
+                "kind": "missing_tool_usage_dimension",
+                "advisory": "Skill called MCP tools but the rubric has no dimension name suggesting tool-usage coverage (matched against keywords: ['tool usage', 'tool use', 'tool work', 'tool call', 'argument quality', 'argument-quality', 'response interpretation', 'tool selection', 'mcp tool', 'fixture']). The judge will grade other dimensions but won't score tool work explicitly. Consider adding a tool-usage dimension or renaming an existing one."
+              }
+            ]
+          },
+          "validators": {
+            "passed": true,
+            "results": [
+              {
+                "name": "test_id_references_resolve",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_log_append_only",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_entries_deleted",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_research_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tool_allowlist",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_gedcomx_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_negative_result_log_shape",
+                "passed": true,
+                "error": "skipped: not a negative-result-log scenario"
+              },
+              {
+                "name": "test_positive_appends_log_entry",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_sidecar_written_for_positive_fts",
+                "passed": true,
+                "error": "skipped: not a sidecar-write scenario"
+              }
+            ]
+          },
+          "judge": {
+            "skipped": false,
+            "dimensions": [
+              {
+                "source": "base",
+                "name": "Correctness",
+                "score": 3,
+                "rationale": "The skill correctly executed a natural-language FTS search using the tree person ID 'KWCJ-RN4' as instructed. Both results reported match the fixture's expected responses: the 1869 deed of conveyance to Patrick Flynn with the boundary clause mentioning 'heirs of Thomas Flynn deceased,' and the 1885 Cornelius Sheridan probate inventory. The skill accurately extracted key details from both records (dates, place names, principal and non-principal actors) and made sound inferences (Thomas Flynn's death before November 1869, the BranchTownship neighborhood connection, and implications for the probate search window). No fabricated material or contradictions with the input state."
+              },
+              {
+                "source": "base",
+                "name": "Completeness",
+                "score": 3,
+                "rationale": "The skill fully addressed the user's request: it executed the FTS search using the nlQuery tree person ID entry point as explicitly requested, examined all 2 returned results, logged them with detailed notes, and provided implications for next steps (record extraction, revised search window, FAN cross-reference opportunities). The response included the full summary and file changes tracking, meeting all requirements of the task."
+              },
+              {
+                "source": "base",
+                "name": "Tool Arguments",
+                "score": 3,
+                "rationale": "Both MCP tool calls passed arguments matching the fixture's expected_args. The fulltext_search call correctly passed nlQuery as 'KWCJ-RN4' (matching the expected substring ~KWCJ-RN4) and included projectPath as required. The research_log_append call properly captured the query, outcome, results examined, and detailed notes. The tool invocations matched the canonical shape expected by the test fixture."
+              },
+              {
+                "source": "rubric",
+                "name": "Query construction",
+                "score": 3,
+                "rationale": "The skill used the correct FTS entry point: nlQuery with the tree person ID 'KWCJ-RN4' rather than a bare keyword query. The skill explicitly explained why this was the right choice, noting that the upstream resolves the tree ID against the person's facts and aliases to widen the search\u2014a meaningful advantage over a keyword-only approach like '+Patrick +Flynn'. No additional queries were needed; the single nlQuery successfully returned the expected records."
+              },
+              {
+                "source": "rubric",
+                "name": "FAN awareness",
+                "score": 3,
+                "rationale": "This was a direct subject search ('search for Patrick Flynn using his tree person ID'). The skill is not required to pivot to FAN unprompted in such cases. However, the skill went further and identified multiple FAN leads (Cornelius Sheridan, John McGrath, James Dempsey, Owen Reilly) in its narrative and suggested queuing FTS searches for them in the 'Suggested Next Steps' section, demonstrating awareness of FAN opportunity without overreaching the original request."
+              },
+              {
+                "source": "rubric",
+                "name": "Negative result handling",
+                "score": 3,
+                "rationale": "All executed searches returned positive results (2 of 2 examined, outcome 'positive'). The negative result handling dimension does not fire when all searches return results. Per the rubric, this dimension scores pass when 'all executed searches returned results (nothing to grade).' The skill properly logged both results with full detail (collection titles, ARKs, record dates, key extracts)."
+              }
+            ],
+            "judge_cost_usd": 0.011153,
+            "duration_ms": 50807.607662995,
+            "error": null,
+            "input_tokens": 6698,
+            "cached_input_tokens": 0,
+            "output_tokens": 891
+          },
+          "started_at": 1782752740.6867018,
+          "ended_at": 1782752894.1185153
+        }
+      ]
+    },
+    {
+      "test_id": "ut_search_full_text_001",
+      "test_type": "positive",
+      "expected_outcome": "pass",
+      "scenario": "mid-research-flynn",
+      "mcp_fixtures": [
+        "fulltext-search-flynn-witnesses",
+        "fulltext-search-flynn-witnesses-by-name",
+        "fulltext-search-flynn-flinn-variant",
+        "fulltext-search-flynn-wildcard-variant"
+      ],
+      "outcome": "pass",
+      "flaky": false,
+      "outcome_summary": {
+        "per_run_outcomes": [
+          "pass"
+        ],
+        "aggregated_dimensions": [
+          {
+            "source": "base",
+            "name": "Correctness",
+            "score": 3,
+            "rationale": "The skill correctly executed both FTS searches for 'Thomas Flynn' and 'Patrick Flynn' in Schuylkill County and accurately reported the deed found. The witness clause excerpt is correctly quoted from the tool response. The interpretation that both men appear together in 1878 as witnesses in Branch Township is factually supported by the returned document, and the connection to hypothesis h_001 is appropriate FAN evidence. No fabrications or unsupported claims."
+          },
+          {
+            "source": "base",
+            "name": "Completeness",
+            "score": 3,
+            "rationale": "The skill fully addressed the user's request to run separate FTS searches for both Thomas Flynn AND Patrick Flynn as witnesses in Schuylkill County records. Both queries were executed and logged independently with their own log entries (log_006 and log_007). Results were examined, outcomes recorded, and the shared discovery documented. The skill also identified follow-up opportunities (abbreviation variants, FAN pivots, record extraction) without being asked, demonstrating thoroughness."
+          },
+          {
+            "source": "base",
+            "name": "Tool Arguments",
+            "score": 3,
+            "rationale": "Both fulltext_search calls passed correctly formed arguments. Query 1 used keywords:'+\"Thomas Flynn\"' and query 2 used keywords:'+\"Patrick Flynn\"', both matching the expected pattern ~Flynn with appropriate phrase quoting operators. Place filtering (Pennsylvania \u2192 Schuylkill) was applied correctly post-search as noted. The research_log_append calls included all required fields with accurate query metadata and coherent outcome descriptions. No fixture_not_found errors; all matched.kind values show successful execution (predicate and live)."
+          },
+          {
+            "source": "rubric",
+            "name": "Query construction",
+            "score": 3,
+            "rationale": "Both queries used phrase quoting correctly (+'Thomas Flynn' and +'Patrick Flynn') to target exact name matches in the Keywords field\u2014the right approach for witness-level matches where loose substring matching would return too many results. The queries were scoped to Schuylkill County via place filtering after search, consistent with the user's jurisdictional specification. The canonical-spelling approach returned the expected record immediately; no spelling variants were required."
+          },
+          {
+            "source": "rubric",
+            "name": "FAN awareness",
+            "score": 3,
+            "rationale": "The prompt explicitly asked for witness searches\u2014a direct subject search for two named individuals appearing in specific record roles. Per rubric guidance, direct subject searches do not require unprompted FAN expansion. The skill correctly executed the requested witness searches and appropriately reported the results as FAN evidence ('Witnesses to a deed were typically neighbors or family members'). Additionally, the skill voluntarily flagged James Brennan and Michael Dougherty as FAN candidates for follow-up, showing initiative without being asked."
+          },
+          {
+            "source": "rubric",
+            "name": "Negative result handling",
+            "score": 3,
+            "rationale": "Both executed searches returned positive results (1 result each), so this dimension has nothing to grade per rubric instruction: 'When every executed search returned positive results, this dimension has nothing to grade \u2014 score pass.' No negative logs required evaluation. Both searches successfully converged on the same 1878 deed."
+          }
+        ]
+      },
+      "totals": {
+        "duration_ms": 169476.10749900923,
+        "duration_api_ms": 155321.0,
+        "judge_duration_ms": 11439.426486002048,
+        "wall_clock_ms": 172741.87660217285,
+        "num_turns": 14,
+        "input_tokens": 1423,
+        "cached_input_tokens": 223508,
+        "output_tokens": 6882,
+        "judge_input_tokens": 7516,
+        "judge_cached_input_tokens": 0,
+        "judge_output_tokens": 844,
+        "skill_cost_usd": 0.3098874,
+        "judge_cost_usd": 0.011736,
+        "total_cost_usd": 0.3216234
+      },
+      "runs": [
+        {
+          "run_index": 0,
+          "run_id": "run_ut_search_full_text_001_2026-06-29_17-02-34_0",
+          "outcome": "pass",
+          "aborted_reason": null,
+          "duration_ms": 169476.10749900923,
+          "duration_api_ms": 155321.0,
+          "num_turns": 14,
+          "skill_attempts": 1,
+          "input_tokens": 1423,
+          "cached_input_tokens": 223508,
+          "output_tokens": 6882,
+          "skill_cost_usd": 0.3098874,
+          "output": {
+            "text_response": "Good \u2014 the project is researching Patrick Flynn's parentage, with Thomas Flynn as the leading candidate father. Plan item `pli_006` targets Schuylkill County probate, and no FTS searches have been run yet. Now I'll load the MCP tools and execute both queries.Running both FTS queries simultaneously \u2014 phrase search for each name, no place in the keywords field (will apply Schuylkill County as a post-search filter based on hit counts).Remarkable find \u2014 both searches surfaced the **same 1878 deed**, which names \"Thomas Flynn and Patrick Flynn both of Branch Township Schuylkill County as witnesses.\" That phrase places them in the same township in the same year. Now I'll log each search separately with its own staged-results sidecar.Both searches logged. Here's the full picture.\n\n---\n\n## Search Results \u2014 Thomas Flynn & Patrick Flynn as Witnesses, Schuylkill County\n\n### What was searched\n\n| # | Query | Field | Place filter |\n|---|---|---|---|\n| 1 | `+\"Thomas Flynn\"` | Keywords | Pennsylvania \u2192 Schuylkill (log_006) |\n| 2 | `+\"Patrick Flynn\"` | Keywords | Pennsylvania \u2192 Schuylkill (log_007) |\n\n---\n\n### What was found \u2014 one document, both names\n\n> **Deed of Conveyance \u2014 James Brennan to Michael Dougherty**\n> Pennsylvania Land Records, 1878\n> ARK: `https://familysearch.org/ark:/61903/1:1:QV9N-YS37`\n\nBoth searches converged on the same document. The closing witness clause reads:\n\n> *\"Signed sealed and delivered in the presence of **Thomas Flynn and Patrick Flynn both of Branch Township Schuylkill County** as witnesses to the deed of conveyance this fifteenth day of March in the year of our Lord one thousand eight hundred and seventy eight.\"*\n\n---\n\n### Why this matters\n\n| Point | Significance |\n|---|---|\n| **Same township, same date** | Thomas and Patrick Flynn are both placed in Branch Township, Schuylkill County in March 1878 \u2014 consistent with the 1850 and 1860 census placements of both men in the same Schuylkill County household |\n| **Co-witnesses on a deed** | Witnesses to a deed were typically neighbors or family members \u2014 their joint appearance reinforces the relationship implied by the census co-enumeration |\n| **Non-principal mention** | Neither man is a party to this deed; FTS is the only search surface that would have surfaced them here \u2014 this is exactly what FTS is for |\n| **Corroborates h_001** | Adds a third-record category (land records) confirming Thomas and Patrick Flynn in close proximity, strengthening the \"Thomas is Patrick's father\" hypothesis |\n\n---\n\n### Logs created\n\n| Log ID | Query | Outcome | Sidecar |\n|---|---|---|---|\n| `log_006` | `+\"Thomas Flynn\"` | positive (1 result) | `results/log_006.json` |\n| `log_007` | `+\"Patrick Flynn\"` | positive (1 result) | `results/log_007.json` |\n\n---\n\n### Cross-reference opportunities flagged\n\nThe deed names two additional people worth querying:\n- **James Brennan** (grantor) \u2014 also of Branch Township; could appear in other Schuylkill County records alongside the Flynns\n- **Michael Dougherty** (grantee) \u2014 same township; may be a neighbor in the FAN cluster\n\n---\n\n### Next steps\n\n1. **Record extraction** \u2014 Shall I pass this deed to `record-extraction` to log it as a source and extract the witness-role assertion formally?\n2. **Abbreviation follow-up** \u2014 \"Thos Flynn\" was not yet searched; given this positive result the abbreviation query is lower priority but available if needed.\n3. **pli_006 (probate) is still open** \u2014 These FTS deed results are supplementary; the indexed probate/will search for Thomas Flynn (1870\u20131890) remains in progress and should still be executed.\n4. **FAN search** \u2014 Search for `+\"James Brennan\" +Flynn` or `+\"Michael Dougherty\" +Flynn` to find other documents linking these neighbors?",
+            "activated": true,
+            "skills_invoked": [
+              "search-full-text"
+            ],
+            "tool_calls": [
+              {
+                "tool": "mcp__genealogy__fulltext_search",
+                "args": {
+                  "keywords": "+\"Thomas Flynn\"",
+                  "projectPath": "/tmp/eval-ut_search_full_text_001-0-0-j15t8fkj",
+                  "count": 20
+                },
+                "expected_args": {
+                  "keywords": "~Flynn"
+                },
+                "matched": {
+                  "kind": "predicate",
+                  "index": 0
+                },
+                "response_fixture": "fulltext-search-flynn-witnesses"
+              },
+              {
+                "tool": "mcp__genealogy__fulltext_search",
+                "args": {
+                  "keywords": "+\"Patrick Flynn\"",
+                  "projectPath": "/tmp/eval-ut_search_full_text_001-0-0-j15t8fkj",
+                  "count": 20
+                },
+                "expected_args": {
+                  "keywords": "~Flynn"
+                },
+                "matched": {
+                  "kind": "predicate",
+                  "index": 0
+                },
+                "response_fixture": "fulltext-search-flynn-witnesses"
+              },
+              {
+                "tool": "mcp__genealogy__research_log_append",
+                "args": {
+                  "projectPath": "/tmp/eval-ut_search_full_text_001-0-0-j15t8fkj",
+                  "planItemId": "pli_006",
+                  "tool": "fulltext_search",
+                  "query": {
+                    "keywords": "+\"Thomas Flynn\"",
+                    "recordPlace1": "Pennsylvania",
+                    "recordPlace2": "Schuylkill"
+                  },
+                  "outcome": "positive",
+                  "resultsExamined": 1,
+                  "resultsAvailable": 1,
+                  "notes": "1 result: 1878 deed of conveyance (James Brennan to Michael Dougherty), Branch Township, Schuylkill County, PA \u2014 Thomas Flynn named as witness alongside Patrick Flynn, both explicitly described as 'of Branch Township Schuylkill County'; places Thomas and Patrick Flynn in the same township in 1878, corroborating h_001.",
+                  "stagedResultsRef": "results/.staging/af46e781-8ab7-45ea-9566-1453046a0ad0.json"
+                },
+                "expected_args": null,
+                "matched": {
+                  "kind": "live",
+                  "index": null
+                },
+                "response_fixture": "live:research_log_append"
+              },
+              {
+                "tool": "mcp__genealogy__research_log_append",
+                "args": {
+                  "projectPath": "/tmp/eval-ut_search_full_text_001-0-0-j15t8fkj",
+                  "planItemId": "pli_006",
+                  "tool": "fulltext_search",
+                  "query": {
+                    "keywords": "+\"Patrick Flynn\"",
+                    "recordPlace1": "Pennsylvania",
+                    "recordPlace2": "Schuylkill"
+                  },
+                  "outcome": "positive",
+                  "resultsExamined": 1,
+                  "resultsAvailable": 1,
+                  "notes": "1 result: same 1878 deed of conveyance (Brennan to Dougherty), Branch Township, Schuylkill County, PA \u2014 Patrick Flynn named as witness alongside Thomas Flynn, both described as 'of Branch Township'; supports hypothesis h_001 by co-locating Patrick and Thomas Flynn in the same township in 1878.",
+                  "stagedResultsRef": "results/.staging/c8e1467d-5551-42a2-a21c-4b26f90a1ec2.json"
+                },
+                "expected_args": null,
+                "matched": {
+                  "kind": "live",
+                  "index": null
+                },
+                "response_fixture": "live:research_log_append"
+              }
+            ],
+            "files_created": [
+              "results/log_006.json",
+              "results/log_007.json"
+            ],
+            "file_changes": {
+              "research.json": {
+                "sections_modified": [
+                  "log"
+                ],
+                "diff": {
+                  "log": {
+                    "added": [
+                      {
+                        "id": "log_006",
+                        "plan_item_id": "pli_006",
+                        "performed": "2026-06-29T17:04:58.103Z",
+                        "tool": "fulltext_search",
+                        "query": {
+                          "keywords": "+\"Thomas Flynn\"",
+                          "recordPlace1": "Pennsylvania",
+                          "recordPlace2": "Schuylkill"
+                        },
+                        "outcome": "positive",
+                        "results_examined": 1,
+                        "external_site": null,
+                        "results_ref": "results/log_006.json",
+                        "results_available": 1,
+                        "notes": "1 result: 1878 deed of conveyance (James Brennan to Michael Dougherty), Branch Township, Schuylkill County, PA \u2014 Thomas Flynn named as witness alongside Patrick Flynn, both explicitly described as 'of Branch Township Schuylkill County'; places Thomas and Patrick Flynn in the same township in 1878, corroborating h_001."
+                      },
+                      {
+                        "id": "log_007",
+                        "plan_item_id": "pli_006",
+                        "performed": "2026-06-29T17:05:05.851Z",
+                        "tool": "fulltext_search",
+                        "query": {
+                          "keywords": "+\"Patrick Flynn\"",
+                          "recordPlace1": "Pennsylvania",
+                          "recordPlace2": "Schuylkill"
+                        },
+                        "outcome": "positive",
+                        "results_examined": 1,
+                        "external_site": null,
+                        "results_ref": "results/log_007.json",
+                        "results_available": 1,
+                        "notes": "1 result: same 1878 deed of conveyance (Brennan to Dougherty), Branch Township, Schuylkill County, PA \u2014 Patrick Flynn named as witness alongside Thomas Flynn, both described as 'of Branch Township'; supports hypothesis h_001 by co-locating Patrick and Thomas Flynn in the same township in 1878."
+                      }
+                    ],
+                    "modified": [],
+                    "deleted": []
+                  }
+                }
+              }
+            },
+            "warnings": [
+              {
+                "kind": "missing_tool_usage_dimension",
+                "advisory": "Skill called MCP tools but the rubric has no dimension name suggesting tool-usage coverage (matched against keywords: ['tool usage', 'tool use', 'tool work', 'tool call', 'argument quality', 'argument-quality', 'response interpretation', 'tool selection', 'mcp tool', 'fixture']). The judge will grade other dimensions but won't score tool work explicitly. Consider adding a tool-usage dimension or renaming an existing one."
+              }
+            ]
+          },
+          "validators": {
+            "passed": true,
+            "results": [
+              {
+                "name": "test_id_references_resolve",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_log_append_only",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_entries_deleted",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_research_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tool_allowlist",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_gedcomx_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_negative_result_log_shape",
+                "passed": true,
+                "error": "skipped: not a negative-result-log scenario"
+              },
+              {
+                "name": "test_positive_appends_log_entry",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_sidecar_written_for_positive_fts",
+                "passed": true,
+                "error": "skipped: not a sidecar-write scenario"
+              }
+            ]
+          },
+          "judge": {
+            "skipped": false,
+            "dimensions": [
+              {
+                "source": "base",
+                "name": "Correctness",
+                "score": 3,
+                "rationale": "The skill correctly executed both FTS searches for 'Thomas Flynn' and 'Patrick Flynn' in Schuylkill County and accurately reported the deed found. The witness clause excerpt is correctly quoted from the tool response. The interpretation that both men appear together in 1878 as witnesses in Branch Township is factually supported by the returned document, and the connection to hypothesis h_001 is appropriate FAN evidence. No fabrications or unsupported claims."
+              },
+              {
+                "source": "base",
+                "name": "Completeness",
+                "score": 3,
+                "rationale": "The skill fully addressed the user's request to run separate FTS searches for both Thomas Flynn AND Patrick Flynn as witnesses in Schuylkill County records. Both queries were executed and logged independently with their own log entries (log_006 and log_007). Results were examined, outcomes recorded, and the shared discovery documented. The skill also identified follow-up opportunities (abbreviation variants, FAN pivots, record extraction) without being asked, demonstrating thoroughness."
+              },
+              {
+                "source": "base",
+                "name": "Tool Arguments",
+                "score": 3,
+                "rationale": "Both fulltext_search calls passed correctly formed arguments. Query 1 used keywords:'+\"Thomas Flynn\"' and query 2 used keywords:'+\"Patrick Flynn\"', both matching the expected pattern ~Flynn with appropriate phrase quoting operators. Place filtering (Pennsylvania \u2192 Schuylkill) was applied correctly post-search as noted. The research_log_append calls included all required fields with accurate query metadata and coherent outcome descriptions. No fixture_not_found errors; all matched.kind values show successful execution (predicate and live)."
+              },
+              {
+                "source": "rubric",
+                "name": "Query construction",
+                "score": 3,
+                "rationale": "Both queries used phrase quoting correctly (+'Thomas Flynn' and +'Patrick Flynn') to target exact name matches in the Keywords field\u2014the right approach for witness-level matches where loose substring matching would return too many results. The queries were scoped to Schuylkill County via place filtering after search, consistent with the user's jurisdictional specification. The canonical-spelling approach returned the expected record immediately; no spelling variants were required."
+              },
+              {
+                "source": "rubric",
+                "name": "FAN awareness",
+                "score": 3,
+                "rationale": "The prompt explicitly asked for witness searches\u2014a direct subject search for two named individuals appearing in specific record roles. Per rubric guidance, direct subject searches do not require unprompted FAN expansion. The skill correctly executed the requested witness searches and appropriately reported the results as FAN evidence ('Witnesses to a deed were typically neighbors or family members'). Additionally, the skill voluntarily flagged James Brennan and Michael Dougherty as FAN candidates for follow-up, showing initiative without being asked."
+              },
+              {
+                "source": "rubric",
+                "name": "Negative result handling",
+                "score": 3,
+                "rationale": "Both executed searches returned positive results (1 result each), so this dimension has nothing to grade per rubric instruction: 'When every executed search returned positive results, this dimension has nothing to grade \u2014 score pass.' No negative logs required evaluation. Both searches successfully converged on the same 1878 deed."
+              }
+            ],
+            "judge_cost_usd": 0.011736,
+            "duration_ms": 11439.426486002048,
+            "error": null,
+            "input_tokens": 7516,
+            "cached_input_tokens": 0,
+            "output_tokens": 844
+          },
+          "started_at": 1782752570.3611495,
+          "ended_at": 1782752743.1030262
+        }
+      ]
+    },
+    {
+      "test_id": "ut_search_full_text_008",
+      "test_type": "positive",
+      "expected_outcome": "pass",
+      "scenario": "mid-research-flynn",
+      "mcp_fixtures": [
+        "fulltext-search-flynn-flunn-ocr",
+        "fulltext-search-flynn-witnesses",
+        "fulltext-search-flynn-flinn-variant",
+        "fulltext-search-flynn-wildcard-variant"
+      ],
+      "outcome": "fail",
+      "flaky": false,
+      "outcome_summary": {
+        "per_run_outcomes": [
+          "fail"
+        ],
+        "aggregated_dimensions": []
+      },
+      "totals": {
+        "duration_ms": 33805.83689500054,
+        "duration_api_ms": 28978.0,
+        "judge_duration_ms": 0.0,
+        "wall_clock_ms": 32625.048637390137,
+        "num_turns": 3,
+        "input_tokens": 7,
+        "cached_input_tokens": 23249,
+        "output_tokens": 1456,
+        "judge_input_tokens": 0,
+        "judge_cached_input_tokens": 0,
+        "judge_output_tokens": 0,
+        "skill_cost_usd": 0.04705845,
+        "judge_cost_usd": 0.0,
+        "total_cost_usd": 0.04705845
+      },
+      "runs": [
+        {
+          "run_index": 0,
+          "run_id": "run_ut_search_full_text_008_2026-06-29_17-02-34_0",
+          "outcome": "fail",
+          "aborted_reason": null,
+          "duration_ms": 33805.83689500054,
+          "duration_api_ms": 28978.0,
+          "num_turns": 3,
+          "skill_attempts": 1,
+          "input_tokens": 7,
+          "cached_input_tokens": 23249,
+          "output_tokens": 1456,
+          "skill_cost_usd": 0.04705845,
+          "output": {
+            "text_response": "Now I'll fire the full-text search with the exact parameters you specified \u2014 `+Flunn` as a required term, narrowed to Schuylkill County, Pennsylvania, 1870\u20131879.The search returned **1 result** \u2014 a strong hit. Here's a full breakdown:\n\n---\n\n### \ud83d\udd0d Search Result\n\n| Field | Detail |\n|---|---|\n| **Collection** | Pennsylvania Land Records (Collection ID: 2220359) |\n| **Record Type** | Land |\n| **Title** | *Deed of Conveyance \u2014 Owen Boyle to Edward McNally* |\n| **Date** | 4 June 1872 |\n| **Place** | Cass Township, Schuylkill County, Pennsylvania |\n| **ARK** | [familysearch.org/ark:/61903/1:1:N8R3-MK5J](https://familysearch.org/ark:/61903/1:1:N8R3-MK5J) |\n\n---\n\n### \ud83d\udcdc Transcript (verbatim)\n\n> *\"Know all men by these presents that Owen Boyle of Cass Township in the County of Schuylkill and State of Pennsylvania in consideration of the sum of three hundred and fifty dollars to him paid by Edward McNally of the same place has granted bargained and sold a certain piece of land in Cass Township **bounded northerly by lands of Patrick Flunn** easterly by the public road containing twenty acres. Signed sealed and delivered in the presence of witnesses Edward Gallagher and Hugh O'Donnell this fourth day of June in the year of our Lord one thousand eight hundred and seventy two.\"*\n\n---\n\n### \ud83e\udded Analysis\n\n- **The AI transcript rendered the surname as \"Flunn\"** exactly as you predicted \u2014 almost certainly a misread of the cursive *y* in **Flynn** as a *u*.\n- **Patrick Flunn (= Patrick Flynn)** appears not as a party to this deed but as an **abutting landowner** \u2014 his land formed the northern boundary of the parcel being conveyed from Owen Boyle to Edward McNally.\n- The other parties and witnesses \u2014 Owen Boyle, Edward McNally, Edward Gallagher, and Hugh O'Donnell \u2014 are all Irish-surnamed, consistent with the heavily Irish-immigrant community of the Schuylkill anthracite coal region in the 1870s.\n- Because Patrick Flynn is only a **neighbor/abutter** (not a grantor or grantee), he would **not** appear in indexed name searches \u2014 this is a textbook case where full-text search on the raw transcript is the only way to surface the record.\n\nWould you like to run a complementary search using the corrected spelling `+Flynn` to catch any records where the transcription got it right, or shall we look at neighboring deeds in this same Cass Township volume?",
+            "activated": false,
+            "skills_invoked": [],
+            "tool_calls": [
+              {
+                "tool": "mcp__genealogy__fulltext_search",
+                "args": {
+                  "keywords": "+Flunn",
+                  "recordPlace1": "Pennsylvania",
+                  "recordPlace2": "Schuylkill",
+                  "yearFrom": 1870,
+                  "yearTo": 1879
+                },
+                "expected_args": {
+                  "keywords": "~Flunn"
+                },
+                "matched": {
+                  "kind": "predicate",
+                  "index": 0
+                },
+                "response_fixture": "fulltext-search-flynn-flunn-ocr"
+              }
+            ],
+            "files_created": [],
+            "warnings": [
+              {
+                "kind": "missing_tool_usage_dimension",
+                "advisory": "Skill called MCP tools but the rubric has no dimension name suggesting tool-usage coverage (matched against keywords: ['tool usage', 'tool use', 'tool work', 'tool call', 'argument quality', 'argument-quality', 'response interpretation', 'tool selection', 'mcp tool', 'fixture']). The judge will grade other dimensions but won't score tool work explicitly. Consider adding a tool-usage dimension or renaming an existing one."
+              }
+            ]
+          },
+          "validators": {
+            "passed": false,
+            "results": [
+              {
+                "name": "test_id_references_resolve",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_log_append_only",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_entries_deleted",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_research_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tool_allowlist",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_gedcomx_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_negative_result_log_shape",
+                "passed": true,
+                "error": "skipped: not a negative-result-log scenario"
+              },
+              {
+                "name": "test_positive_appends_log_entry",
+                "passed": false,
+                "error": "expected at least one new log entry recording the search"
+              },
+              {
+                "name": "test_sidecar_written_for_positive_fts",
+                "passed": true,
+                "error": "skipped: not a sidecar-write scenario"
+              }
+            ]
+          },
+          "judge": {
+            "skipped": true,
+            "dimensions": [],
+            "judge_cost_usd": 0.0,
+            "duration_ms": 0.0,
+            "error": null,
+            "input_tokens": 0,
+            "cached_input_tokens": 0,
+            "output_tokens": 0
+          },
+          "started_at": 1782752743.2752283,
+          "ended_at": 1782752775.900277
+        }
+      ]
+    },
+    {
+      "test_id": "ut_search_full_text_010",
+      "test_type": "positive",
+      "expected_outcome": "pass",
+      "scenario": "flynn-record-matching",
+      "mcp_fixtures": [
+        "fulltext-search-flynn-witnesses",
+        "fulltext-search-flynn-flinn-variant"
+      ],
+      "outcome": "pass",
+      "flaky": false,
+      "outcome_summary": {
+        "per_run_outcomes": [
+          "pass"
+        ],
+        "aggregated_dimensions": [
+          {
+            "source": "base",
+            "name": "Correctness",
+            "score": 3,
+            "rationale": "All outputs are factually accurate. The 1878 deed is correctly described as naming Thomas and Patrick Flynn as witnesses in Branch Township, Schuylkill County. The age calculation (Patrick ~33 in 1878 given ~1845 birth) is correct. No fabricated claims; all assertions are supported by the tool response and prior log entries."
+          },
+          {
+            "source": "base",
+            "name": "Completeness",
+            "score": 3,
+            "rationale": "The skill fully addressed the user's request: executed a full-text witness search for Flynn in Schuylkill County PA, documented the positive result with rich context, logged the negative variant variant search (+Flinn), and created two new log entries with proper sidecars as required by the test specification."
+          },
+          {
+            "source": "base",
+            "name": "Tool Arguments",
+            "score": 3,
+            "rationale": "All MCP tool calls passed args matching expected values. First fulltext_search call used keywords '+Flynn +witness' matching the predicate ~Flynn; second used '+Flinn +witness' matching ~Flinn. Both research_log_append calls included required arguments (planItemId null, outcome, results counts, notes). No fixture_not_found errors; matched.kind is 'predicate' (first two) and 'live' (latter two) throughout."
+          },
+          {
+            "source": "rubric",
+            "name": "Query construction",
+            "score": 3,
+            "rationale": "Queries were well-constructed using correct FTS operators. Primary query '+Flynn +witness' correctly uses the + operator to require both terms; variant query '+Flinn +witness' applies the documented transcription variant from log_003. Both queries properly target the Keywords field (not place field) for surname+role search. The skill's rationale for omitting place from the initial query (noting FamilySearch FTS applies location filtering automatically) shows sound operator understanding."
+          },
+          {
+            "source": "rubric",
+            "name": "FAN awareness",
+            "score": 3,
+            "rationale": "The user's prompt explicitly called for 'witness' search \u2014 a direct, specific request rather than open-ended parentage exploration. Per the rubric, direct subject searches do not require unprompted FAN pivots. The skill executed the requested witness search correctly. The post-result mention of Brennan and Dougherty as 'cross-reference opportunities' appropriately acknowledges FAN context without claiming failure for not executing those searches."
+          },
+          {
+            "source": "rubric",
+            "name": "Negative result handling",
+            "score": 3,
+            "rationale": "The skill logged the zero-result variant search (log_006) with comprehensive detail: stated the FTS corpus searched, the exact query (+Flinn +witness), the number examined (0), the breadth ('full corpus, no place filter'), and that 2 spelling variants were tried total. This meets the standard for 'negative log entries [capturing] collections searched, queries used, and what was examined.' The positive result (log_005) requires no negative handling."
+          }
+        ]
+      },
+      "totals": {
+        "duration_ms": 257335.96508498886,
+        "duration_api_ms": 241976.0,
+        "judge_duration_ms": 11989.636031998089,
+        "wall_clock_ms": 258453.27043533325,
+        "num_turns": 15,
+        "input_tokens": 15,
+        "cached_input_tokens": 171124,
+        "output_tokens": 8456,
+        "judge_input_tokens": 6938,
+        "judge_cached_input_tokens": 0,
+        "judge_output_tokens": 805,
+        "skill_cost_usd": 0.27879394999999996,
+        "judge_cost_usd": 0.010963,
+        "total_cost_usd": 0.28975694999999996
+      },
+      "runs": [
+        {
+          "run_index": 0,
+          "run_id": "run_ut_search_full_text_010_2026-06-29_17-02-34_0",
+          "outcome": "pass",
+          "aborted_reason": null,
+          "duration_ms": 257335.96508498886,
+          "duration_api_ms": 241976.0,
+          "num_turns": 15,
+          "skill_attempts": 1,
+          "input_tokens": 15,
+          "cached_input_tokens": 171124,
+          "output_tokens": 8456,
+          "skill_cost_usd": 0.27879394999999996,
+          "output": {
+            "text_response": "I'll start by reading the project files and references to build the right query.Now let me read the search strategies reference and check previous log results for surname variants.Good \u2014 prior records confirm **\"Flinn\"** as a documented transcription variant (log_003/a_003). I need to factor that into the witness query. Let me load the MCP tool and check the online-search-literacy reference before constructing the query.I have everything I need. Key observations from the project:\n\n- **Subject:** Patrick Flynn (b. ~1845, Ireland; Schuylkill County, PA) \u2014 identifying his parents\n- **Prior variant documented:** \"Flinn\" (log_003, a_003) \u2014 must search this alongside \"Flynn\"\n- **This is an ad-hoc search** \u2014 not directly mapped to pli_001 or pli_002 (plan_item_id: null)\n- **Strategy:** \"Find person as witness\" \u2192 `+Surname +witness` in keywords; \"less is more\" for FTS; no place in initial query \u2014 apply Schuylkill filter post-search\n\nExecuting Query 1 now: `+Flynn +witness`, no place filter yet.Excellent \u2014 a strong hit. Both **Thomas Flynn** and **Patrick Flynn** appear together as witnesses on a 1878 deed in Branch Township, Schuylkill County. Let me log this and immediately run the \"Flinn\" variant search in parallel.No results for the \"Flinn\" variant \u2014 logging the nil result now.---\n\n## FTS Witness Search \u2014 Results\n\n### What was searched\n\n| # | Query | Variant | Results |\n|---|-------|---------|---------|\n| log_005 | `+Flynn +witness` | Primary spelling | **1 hit** |\n| log_006 | `+Flinn +witness` | Known transcription variant (log_003) | 0 |\n\n---\n\n### What was found \u2014 log_005\n\n**1878 Deed of Conveyance \u2014 James Brennan to Michael Dougherty**\n*Pennsylvania Land Records \u00b7 Branch Township, Schuylkill County \u00b7 15 March 1878*\n\ud83d\udd17 `https://familysearch.org/ark:/61903/1:1:QV9N-YS37`\n\nThe witness clause reads:\n\n> *\"Signed sealed and delivered in the presence of **Thomas Flynn** and **Patrick Flynn** both of Branch Township Schuylkill County as witnesses to the deed of conveyance this fifteenth day of March in the year of our Lord one thousand eight hundred and seventy eight.\"*\n\n**Why this matters:**\n\n- **Thomas Flynn and Patrick Flynn witness together**, both described as residing in **Branch Township** \u2014 the exact same township as the 1850 census household (log_001/log_003) and Thomas Flynn's will (log_004).\n- In 1878 Patrick would be ~33 (born ~1845 per census evidence) \u2014 age-consistent with acting as a legal witness.\n- This is a **non-principal mention** \u2014 precisely the kind of record only FTS surfaces. It independently places the Thomas\u2013Patrick pairing in the same household jurisdiction 28 years after the census, strongly reinforcing Thomas as Patrick's father.\n- **FTS is a derivative source** \u2014 verify against the original image before citing.\n\n---\n\n### Cross-reference opportunities from this deed\n\nThe document also names two other Branch Township residents worth pursuing:\n\n- **James Brennan** (grantor) \u2014 neighbor/FAN cluster member\n- **Michael Dougherty** (grantee) \u2014 neighbor/FAN cluster member\n\nWould you like me to search for other documents mentioning Brennan or Dougherty in Schuylkill County? They may appear in records alongside the Flynns, helping build the FAN cluster.\n\n---\n\n### Next steps\n\n- **Record extraction:** Shall I pass this deed to `record-extraction` to create a source entry and extract assertions (Patrick's residence, Thomas\u2013Patrick co-witness relationship)?\n- **Broader witness sweep:** I could run a surname-only `+Flynn` search filtered to Schuylkill County to surface any additional witness or non-principal mentions not caught by the `+witness` keyword.\n- **FAN pivot:** Search Brennan or Dougherty in FTS to triangulate the neighborhood.",
+            "activated": true,
+            "skills_invoked": [
+              "search-full-text"
+            ],
+            "tool_calls": [
+              {
+                "tool": "mcp__genealogy__fulltext_search",
+                "args": {
+                  "keywords": "+Flynn +witness",
+                  "projectPath": "/tmp/eval-ut_search_full_text_010-0-0-3pnkp9cx",
+                  "count": 20
+                },
+                "expected_args": {
+                  "keywords": "~Flynn"
+                },
+                "matched": {
+                  "kind": "predicate",
+                  "index": 0
+                },
+                "response_fixture": "fulltext-search-flynn-witnesses"
+              },
+              {
+                "tool": "mcp__genealogy__research_log_append",
+                "args": {
+                  "projectPath": "/tmp/eval-ut_search_full_text_010-0-0-3pnkp9cx",
+                  "planItemId": null,
+                  "tool": "fulltext_search",
+                  "query": {
+                    "keywords": "+Flynn +witness"
+                  },
+                  "outcome": "positive",
+                  "resultsExamined": 1,
+                  "resultsAvailable": 1,
+                  "notes": "FTS hit: 1878 Schuylkill deed (Brennan to Dougherty, Branch Twp.) names both Thomas Flynn and Patrick Flynn as witnesses \u2014 same Branch Township pairing as the 1850 census household and the Thomas Flynn will. Direct corroboration of the Thomas\u2013Patrick relationship in a land record context.",
+                  "stagedResultsRef": "results/.staging/8b0ea9c7-bd2f-4a90-9adf-50d562efbaac.json"
+                },
+                "expected_args": null,
+                "matched": {
+                  "kind": "live",
+                  "index": null
+                },
+                "response_fixture": "live:research_log_append"
+              },
+              {
+                "tool": "mcp__genealogy__fulltext_search",
+                "args": {
+                  "keywords": "+Flinn +witness",
+                  "projectPath": "/tmp/eval-ut_search_full_text_010-0-0-3pnkp9cx",
+                  "count": 20
+                },
+                "expected_args": {
+                  "keywords": "~Flinn"
+                },
+                "matched": {
+                  "kind": "predicate",
+                  "index": 1
+                },
+                "response_fixture": "fulltext-search-flynn-flinn-variant"
+              },
+              {
+                "tool": "mcp__genealogy__research_log_append",
+                "args": {
+                  "projectPath": "/tmp/eval-ut_search_full_text_010-0-0-3pnkp9cx",
+                  "planItemId": null,
+                  "tool": "fulltext_search",
+                  "query": {
+                    "keywords": "+Flinn +witness"
+                  },
+                  "outcome": "negative",
+                  "resultsExamined": 0,
+                  "resultsAvailable": 0,
+                  "notes": "FTS nil \u2014 FamilySearch FTS, full corpus, no place filter; searched variant spelling +Flinn +witness (Flinn being documented in log_003/a_003); 0 results. 2 spelling variants tried total (Flynn, Flinn). No Flinn-as-witness documents found in FTS corpus."
+                },
+                "expected_args": null,
+                "matched": {
+                  "kind": "live",
+                  "index": null
+                },
+                "response_fixture": "live:research_log_append"
+              }
+            ],
+            "files_created": [
+              "results/log_005.json"
+            ],
+            "file_changes": {
+              "research.json": {
+                "sections_modified": [
+                  "log"
+                ],
+                "diff": {
+                  "log": {
+                    "added": [
+                      {
+                        "id": "log_005",
+                        "plan_item_id": null,
+                        "performed": "2026-06-29T17:07:27.730Z",
+                        "tool": "fulltext_search",
+                        "query": {
+                          "keywords": "+Flynn +witness"
+                        },
+                        "outcome": "positive",
+                        "results_examined": 1,
+                        "external_site": null,
+                        "results_ref": "results/log_005.json",
+                        "results_available": 1,
+                        "notes": "FTS hit: 1878 Schuylkill deed (Brennan to Dougherty, Branch Twp.) names both Thomas Flynn and Patrick Flynn as witnesses \u2014 same Branch Township pairing as the 1850 census household and the Thomas Flynn will. Direct corroboration of the Thomas\u2013Patrick relationship in a land record context."
+                      },
+                      {
+                        "id": "log_006",
+                        "plan_item_id": null,
+                        "performed": "2026-06-29T17:08:32.034Z",
+                        "tool": "fulltext_search",
+                        "query": {
+                          "keywords": "+Flinn +witness"
+                        },
+                        "outcome": "negative",
+                        "results_examined": 0,
+                        "external_site": null,
+                        "results_ref": null,
+                        "results_available": 0,
+                        "notes": "FTS nil \u2014 FamilySearch FTS, full corpus, no place filter; searched variant spelling +Flinn +witness (Flinn being documented in log_003/a_003); 0 results. 2 spelling variants tried total (Flynn, Flinn). No Flinn-as-witness documents found in FTS corpus."
+                      }
+                    ],
+                    "modified": [],
+                    "deleted": []
+                  }
+                }
+              }
+            },
+            "warnings": [
+              {
+                "kind": "missing_tool_usage_dimension",
+                "advisory": "Skill called MCP tools but the rubric has no dimension name suggesting tool-usage coverage (matched against keywords: ['tool usage', 'tool use', 'tool work', 'tool call', 'argument quality', 'argument-quality', 'response interpretation', 'tool selection', 'mcp tool', 'fixture']). The judge will grade other dimensions but won't score tool work explicitly. Consider adding a tool-usage dimension or renaming an existing one."
+              }
+            ]
+          },
+          "validators": {
+            "passed": true,
+            "results": [
+              {
+                "name": "test_id_references_resolve",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_log_append_only",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_entries_deleted",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_research_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tool_allowlist",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_gedcomx_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_negative_result_log_shape",
+                "passed": true,
+                "error": "skipped: not a negative-result-log scenario"
+              },
+              {
+                "name": "test_positive_appends_log_entry",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_sidecar_written_for_positive_fts",
+                "passed": true,
+                "error": null
+              }
+            ]
+          },
+          "judge": {
+            "skipped": false,
+            "dimensions": [
+              {
+                "source": "base",
+                "name": "Correctness",
+                "score": 3,
+                "rationale": "All outputs are factually accurate. The 1878 deed is correctly described as naming Thomas and Patrick Flynn as witnesses in Branch Township, Schuylkill County. The age calculation (Patrick ~33 in 1878 given ~1845 birth) is correct. No fabricated claims; all assertions are supported by the tool response and prior log entries."
+              },
+              {
+                "source": "base",
+                "name": "Completeness",
+                "score": 3,
+                "rationale": "The skill fully addressed the user's request: executed a full-text witness search for Flynn in Schuylkill County PA, documented the positive result with rich context, logged the negative variant variant search (+Flinn), and created two new log entries with proper sidecars as required by the test specification."
+              },
+              {
+                "source": "base",
+                "name": "Tool Arguments",
+                "score": 3,
+                "rationale": "All MCP tool calls passed args matching expected values. First fulltext_search call used keywords '+Flynn +witness' matching the predicate ~Flynn; second used '+Flinn +witness' matching ~Flinn. Both research_log_append calls included required arguments (planItemId null, outcome, results counts, notes). No fixture_not_found errors; matched.kind is 'predicate' (first two) and 'live' (latter two) throughout."
+              },
+              {
+                "source": "rubric",
+                "name": "Query construction",
+                "score": 3,
+                "rationale": "Queries were well-constructed using correct FTS operators. Primary query '+Flynn +witness' correctly uses the + operator to require both terms; variant query '+Flinn +witness' applies the documented transcription variant from log_003. Both queries properly target the Keywords field (not place field) for surname+role search. The skill's rationale for omitting place from the initial query (noting FamilySearch FTS applies location filtering automatically) shows sound operator understanding."
+              },
+              {
+                "source": "rubric",
+                "name": "FAN awareness",
+                "score": 3,
+                "rationale": "The user's prompt explicitly called for 'witness' search \u2014 a direct, specific request rather than open-ended parentage exploration. Per the rubric, direct subject searches do not require unprompted FAN pivots. The skill executed the requested witness search correctly. The post-result mention of Brennan and Dougherty as 'cross-reference opportunities' appropriately acknowledges FAN context without claiming failure for not executing those searches."
+              },
+              {
+                "source": "rubric",
+                "name": "Negative result handling",
+                "score": 3,
+                "rationale": "The skill logged the zero-result variant search (log_006) with comprehensive detail: stated the FTS corpus searched, the exact query (+Flinn +witness), the number examined (0), the breadth ('full corpus, no place filter'), and that 2 spelling variants were tried total. This meets the standard for 'negative log entries [capturing] collections searched, queries used, and what was examined.' The positive result (log_005) requires no negative handling."
+              }
+            ],
+            "judge_cost_usd": 0.010963,
+            "duration_ms": 11989.636031998089,
+            "error": null,
+            "input_tokens": 6938,
+            "cached_input_tokens": 0,
+            "output_tokens": 805
+          },
+          "started_at": 1782752694.8497283,
+          "ended_at": 1782752953.3029988
+        }
+      ]
+    }
+  ],
+  "totals": {
+    "duration_ms": 1207604.2660330278,
+    "duration_api_ms": 1068309.0,
+    "judge_duration_ms": 202509.07147998805,
+    "num_turns": 94,
+    "input_tokens": 1536,
+    "cached_input_tokens": 1560784,
+    "output_tokens": 46325,
+    "judge_input_tokens": 62201,
+    "judge_cached_input_tokens": 0,
+    "judge_output_tokens": 7310,
+    "skill_cost_usd": 2.04519745,
+    "judge_cost_usd": 0.09875099999999999,
+    "total_cost_usd": 2.1439484500000003,
+    "wall_clock_ms": 398364.20011520386
+  }
+}


### PR DESCRIPTION
## What this PR does

Re-runs and re-grades the `search-full-text` unit eval (issue #482). Adds the candidate runlog `v1_2026-06-29_17-02-34.json` (11/12 pass) and its complete annotation (`.ann.json`, reviewed by @mercyokum). No skill/test changes — runlog + annotation only.

## Results

- ✅ **The sidecar flakiness #482 was filed about is fixed** — `test_sidecar_written_for_positive_fts` passes on every run.
- ✅ **Grading reconciled** — the only judge↔human disagreement was `ut_search_full_text_006` (judge scored it fail; corrected to pass — the skill correctly routed to question-selection, which is the expected behavior for that routing test).
- ❌ **One unresolved flake: `ut_search_full_text_008`** (transcription-quirk variant) fails the `test_positive_appends_log_entry` validator — the model runs the `+Flunn` search and reports the hit but often skips `research_log_append`.

## The 008 flake — needs a decision

**Root cause:** the test's user message is a narrow imperative (*"Run a full-text search whose keywords contain '+Flunn'… do not use a wildcard"*). It doesn't cue the research-logging workflow, so the model treats it as a one-shot lookup (~3 turns: `fulltext_search` only, then a "next step" suggestion — no log entry).

**Attempts to stabilize it — 23 runs across 5 variants, none reliably green:**

| Variant | Pass rate |
|---|---|
| Unedited skill (current main) | ~1 / 3 |
| SKILL.md body — "log before you pause" guard | 0 / 4 |
| SKILL.md body — structural reorder (log before the user-pause) | 0 / 5 |
| Test prompt cue (`+ "...record the search in my research log"`) | 2 / 5 |
| Test prompt cue + description mention of logging | 3 / 5 |

Ceiling ~50–60%. The residual is single-run variance — `runs_per_test` is schema-pinned to 1 and the SDK exposes no `temperature=0`, which per `eval/CLAUDE.md` we are not addressing yet. The test's *actual* grading purpose — variant query construction — succeeds on every run (the `+Flunn` query is always issued); only the generic positive-test log validator flakes. All experimental edits reverted.

**Decision needed (@DallanQ):**
1. Accept as known single-run variance — merge as-is, 008 flake noted.
2. Adopt the prompt cue as a test edit (helped most, still not a full fix).
3. Reconsider whether a pure-imperative positive test should require single-turn logging.

Closes #482 . cc @mercyokum
