### PR TITLE
Shorten hypothesis tracking

### DIFF
--- a/eval/harness/validators/test_hypothesis_tracking.py
+++ b/eval/harness/validators/test_hypothesis_tracking.py
@@ -31,7 +31,7 @@ from validators_lib import (
 
 def test_hypotheses_no_deletions(before_state, after_state):
     """Existing hypotheses must not be deleted. Status changes (ruled
-    out, supported, proved) supersede deletion."""
+    out, supported) supersede deletion."""
     before = before_state.get("research_json")
     after = after_state.get("research_json")
     if before is None or after is None:

--- a/eval/runlogs/unit/hypothesis-tracking/v1_2026-06-29_22-28-20.ann.json
+++ b/eval/runlogs/unit/hypothesis-tracking/v1_2026-06-29_22-28-20.ann.json
@@ -1,0 +1,630 @@
+{
+  "run_log": "v1_2026-06-29_22-28-20.json",
+  "annotator": "benteroyiembo@gmail.com",
+  "corrections": [
+    {
+      "test_id": "ut_hypothesis_tracking_003",
+      "dimension_source": "base",
+      "dimension_name": "Correctness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": "**`ut_hypothesis_tracking_003`** — `base` / `Correctness`\nLLM: 3 → Junior: 3\n\n> Claude correctly identified that a_005 (Thomas Flynn's name as household head in 1850 census) directly supports h_001's parentage claim. The analysis of all 13 assertions was sound—correctly dismissing name-only, birthplace, residence, and death facts as non-supporting. The file_changes diff shows a_005 was added to supporting_assertion_ids; status remains 'supported' as required. Schema validation passed. No fabricated or unsupported claims.\n\nJunior: (Accurate analysis, correct file update and adherence to instruction was highly demonstrated – Pass.)"
+    },
+    {
+      "test_id": "ut_hypothesis_tracking_003",
+      "dimension_source": "base",
+      "dimension_name": "Completeness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": "**`ut_hypothesis_tracking_003`** — `base` / `Completeness`\nLLM: 3 → Junior: 3\n\n> Claude addressed everything the user requested: systematically reviewed all unlinked assertions, analyzed their relevance to h_001, and added the one assertion (a_005) that merited linkage. The response included detailed reasoning for why other assertions were not linked, fulfilling the 'review and add relevant assertions' task completely. No silent omissions.\n\nJunior: (The skill demonstrated complete coverage of the task — review, analysis, linkage, and validation — with no gaps. Pass.)"
+    },
+    {
+      "test_id": "ut_hypothesis_tracking_003",
+      "dimension_source": "base",
+      "dimension_name": "Tool Arguments",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": "**`ut_hypothesis_tracking_003`** — `base` / `Tool Arguments`\nLLM: 3 → Junior: 3\n\n> Both MCP tool calls used correct arguments. The research_append call properly updated h_001 with the new supporting_assertion_ids array [a_004, a_005, a_010, a_013], included a detailed notes field, and operated on the correct section ('hypotheses') and entryId ('h_001'). The validate_research_schema call correctly specified the projectPath. No fixture_not_found errors; matched.kind == 'live' for both calls.\n\nJunior: (Both tool calls were executed with correct parameters and produced the expected results — Pass)"
+    },
+    {
+      "test_id": "ut_hypothesis_tracking_003",
+      "dimension_source": "rubric",
+      "dimension_name": "Claim clarity",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": "**`ut_hypothesis_tracking_003`** — `rubric` / `Claim clarity`\nLLM: 3 → Junior: 3\n\n> h_001's claim—'Patrick Flynn's father was Thomas Flynn of Schuylkill County, Pennsylvania'—is highly specific. It names both individuals, identifies the relationship (parentage), and includes geographic detail (Schuylkill County, Pennsylvania). The claim is testable and would support targeted genealogical follow-up searches. Claude engaged with this claim structure clearly throughout the analysis.\n\nJunior: (The claim is well formed, specific, and research ready, and the skill maintained that clarity in its reasoning — Pass.)"
+    },
+    {
+      "test_id": "ut_hypothesis_tracking_003",
+      "dimension_source": "rubric",
+      "dimension_name": "Evidence linkage",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": "**`ut_hypothesis_tracking_003`** — `rubric` / `Evidence linkage`\nLLM: 3 → Junior: 3\n\n> Claude correctly linked a_005 (Thomas Flynn's name as household head, 1850 census) as supporting h_001. This assertion directly establishes the identity of the candidate father named in the hypothesis. All four linked assertions (a_004, a_005, a_010, a_013) have genuine bearing on whether Thomas Flynn was Patrick's father—either via co-enumeration or direct statement. No off-topic or tangential linkages were made.\n\nJunior: (Evidence linkage was accurate, relevant, and complete — Pass.)"
+    },
+    {
+      "test_id": "ut_hypothesis_tracking_003",
+      "dimension_source": "rubric",
+      "dimension_name": "Status transitions",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": "**`ut_hypothesis_tracking_003`** — `rubric` / `Status transitions`\nLLM: 3 → Junior: 3\n\n> Claude correctly maintained h_001's status as 'supported' and did not trigger any status transition. The instructions warned against changing status from supported, and Claude obeyed this requirement. Adding supporting assertions to an already-supported hypothesis is appropriate and does not mandate a status change. No invalid transition occurred.\n\nJunior: (Status handling was precise and compliant — Pass.)"
+    },
+    {
+      "test_id": "ut_hypothesis_tracking_002",
+      "dimension_source": "base",
+      "dimension_name": "Correctness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": "**`ut_hypothesis_tracking_002`** — `base` / `Correctness`\nLLM: 3 → Junior: 3\n\n> All outputs are factually correct. Both hypotheses are based on the actual 1850 census data cited (dwelling 84 vs household 197). The supporting and contradicting assertion linkages are accurate: a_004, a_010, a_013 genuinely bear on h_002; h_003 correctly has empty lists pending household 197 extraction. The schema validation confirms both entries passed validation. No fabricated material.\n\nJunior: (The skill demonstrated accurate, fact based hypothesis creation and proper evidence linkage. Pass.)"
+    },
+    {
+      "test_id": "ut_hypothesis_tracking_002",
+      "dimension_source": "base",
+      "dimension_name": "Completeness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": "**`ut_hypothesis_tracking_002`** — `base` / `Completeness`\nLLM: 3 → Junior: 3\n\n> The skill fully addressed the user's request to formulate identity conflict c_002 as testable hypotheses. Two competing hypotheses were created (h_002 and h_003), both with specific testable claims. All required schema fields were populated: id, claim, status, supporting_assertion_ids, contradicting_assertion_ids, ruled_out, related_question_ids, and notes. The file_changes diff confirms both entries were successfully appended to research.json.\n\nJunior: (The skill produced both hypotheses with all necessary fields and evidence linkage, fulfilling the request entirely — Pass.)"
+    },
+    {
+      "test_id": "ut_hypothesis_tracking_002",
+      "dimension_source": "base",
+      "dimension_name": "Tool Arguments",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": "**`ut_hypothesis_tracking_002`** — `base` / `Tool Arguments`\nLLM: 3 → Junior: 3\n\n> All three MCP tool calls passed arguments correctly. Both mcp__genealogy__research_append calls provided complete, valid entry objects with all required hypothesis fields; projectPath and section were correct. The mcp__genealogy__validate_research_schema call correctly validated the result. No fixture_not_found errors occurred (all matched.kind == 'live'). Arguments align with expected behavior.\n\nJunior: (Tool arguments were accurate, complete, and correctly aligned with expected behavior — Pass.)"
+    },
+    {
+      "test_id": "ut_hypothesis_tracking_002",
+      "dimension_source": "rubric",
+      "dimension_name": "Claim clarity",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": "**`ut_hypothesis_tracking_002`** — `rubric` / `Claim clarity`\nLLM: 3 → Junior: 3\n\n> Both hypotheses are stated as specific, testable claims. h_002 names Patrick Flynn as the subject, specifies he is 'age 5, enumerated in Thomas Flynn's household, dwelling 84, 1850 census,' and includes the death year (1908) and place (Schuylkill County) for verification. h_003 similarly names the specific alternative: 'age 6, enumerated in household 197' and explicitly states he is NOT the dwelling-84 Patrick. Both claims are testable through record extraction and genealogical research.\n\nJunior: (The hypotheses are well structured, precise, and research ready, making them clear and testable — Pass.)"
+    },
+    {
+      "test_id": "ut_hypothesis_tracking_002",
+      "dimension_source": "rubric",
+      "dimension_name": "Evidence linkage",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": "**`ut_hypothesis_tracking_002`** — `rubric` / `Evidence linkage`\nLLM: 3 → Junior: 3\n\n> Supporting and contradicting assertion linkages are correct and well-reasoned. h_002 links a_004 (1850 co-enumeration), a_010 (1860 continuity), and a_013 (death cert naming Thomas Flynn as father) — all direct or indirect statements about the dwelling-84 identity. h_003 correctly has empty lists, with explicit reasoning (provided in notes) that a_013 cannot be classified as contradicting until household 197's head is identified, avoiding the unsound assumption of two different Thomas Flynns. No tangential assertions are included.\n\nJunior: (Evidence linkage was accurate, relevant, and carefully justified — Pass.)"
+    },
+    {
+      "test_id": "ut_hypothesis_tracking_002",
+      "dimension_source": "rubric",
+      "dimension_name": "Status transitions",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": "**`ut_hypothesis_tracking_002`** — `rubric` / `Status transitions`\nLLM: 3 → Junior: 3\n\n> Both hypotheses were set to 'active' status, which is correct per protocol. The skill correctly noted that even though h_002 has supporting evidence, the starting state for competing candidates should be 'active' rather than 'supported,' ensuring unbiased evaluation. Neither hypothesis was transitioned to 'ruled_out' without affirmative refutation (only lack of evidence), correctly following the research-schema-spec.md §5.9 rules. ruled_out_reason is null for both, as expected.\n\nJunior: (Status transitions were managed correctly and conservatively, with no invalid changes — Pass.)"
+    },
+    {
+      "test_id": "ut_hypothesis_tracking_001",
+      "dimension_source": "base",
+      "dimension_name": "Correctness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": "**`ut_hypothesis_tracking_001`** — `base` / `Correctness`\nLLM: 3 → Junior: 3\n\n> The skill correctly identified hypothesis h_001 as SUPPORTED based on the three supporting assertions (a_004, a_010, a_013), accurately characterized their evidence types (two indirect, one direct), noted the absence of contradicting evidence, and verified chronological coherence. The analysis of the death certificate as direct evidence and the footnote about the informant being secondary is accurate. No fabricated claims; all assertions grounded in the provided research state.\n\nJunior: (The skill’s handling of correctness was thorough, accurate, and aligned with genealogical standards — Pass.)"
+    },
+    {
+      "test_id": "ut_hypothesis_tracking_001",
+      "dimension_source": "base",
+      "dimension_name": "Completeness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": "**`ut_hypothesis_tracking_001`** — `base` / `Completeness`\nLLM: 3 → Junior: 3\n\n> The skill addressed the user's query completely. It cited all three supporting assertions with their evidence types and explained why each supports the hypothesis. It noted that contradicting_assertion_ids is empty, identified probate (pli_006) as the next critical source, explained why the status is SUPPORTED vs PROVED (direct evidence present but informant secondary + research incomplete), and provided actionable next steps including the probate search.\n\nJunior: (The response was complete, covering evidence, status reasoning, contradictions, next sources, and future steps — Pass.)"
+    },
+    {
+      "test_id": "ut_hypothesis_tracking_001",
+      "dimension_source": "base",
+      "dimension_name": "Tool Arguments",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": "**`ut_hypothesis_tracking_001`** — `base` / `Tool Arguments`\nLLM: 3 → Junior: 3\n\n> The skill made one MPC tool call: validate_research_schema with projectPath argument. The call matched expected args with kind='live' (successful fixture match). The argument passed the correct project path; no wrong identifiers or critical mismatches. Schema validation was appropriate as a mandatory pre-analysis step.\n\nJunior: (Tool arguments were correct, precise, and validated successfully — Pass.)"
+    },
+    {
+      "test_id": "ut_hypothesis_tracking_001",
+      "dimension_source": "rubric",
+      "dimension_name": "Claim clarity",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": "**`ut_hypothesis_tracking_001`** — `rubric` / `Claim clarity`\nLLM: 3 → Junior: 3\n\n> The hypothesis is clearly stated as a specific, testable claim: 'Patrick Flynn's father was Thomas Flynn of Schuylkill County, Pennsylvania.' It names both specific persons, identifies the specific relationship (father-son parentage), and includes geographic detail (Schuylkill County). The claim is fully testable against the probate records and additional census searches identified in next steps.\n\nJunior: (The claim is well formed, precise, and actionable — Pass.)"
+    },
+    {
+      "test_id": "ut_hypothesis_tracking_001",
+      "dimension_source": "rubric",
+      "dimension_name": "Evidence linkage",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": "**`ut_hypothesis_tracking_001`** — `rubric` / `Evidence linkage`\nLLM: 3 → Junior: 3\n\n> All three supporting assertions are directly linked to the parentage hypothesis with clear bearing: a_004 and a_010 show Patrick in Thomas's household in consecutive censuses (household co-residence supports family relationship); a_013 directly names Thomas as Patrick's father on the death certificate. No tangential evidence was included. The skill correctly noted that the birthplace conflict (c_001) does not bear on the parentage question and thus was properly excluded from the linkage.\n\nJunior: (Evidence linkage is accurate, relevant, and carefully reasoned — Pass.)"
+    },
+    {
+      "test_id": "ut_hypothesis_tracking_001",
+      "dimension_source": "rubric",
+      "dimension_name": "Status transitions",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": "**`ut_hypothesis_tracking_001`** — `rubric` / `Status transitions`\nLLM: 3 → Junior: 3\n\n> The status transition to SUPPORTED is fully justified per research-schema-spec §5.9. The skill verified all three required criteria: at least one direct assertion (a_013, the death certificate), no unresolved contradictions (c_001 resolved and irrelevant to parentage), and no timeline impossibilities. The skill appropriately explained why status remains Probable (not Proved) due to informant being secondary and research being incomplete. The ruled_out scenario is correctly explained but not triggered; the transition logic is sound.\n\nJunior: (Status handling was precise, justified, and compliant with schema rules — Pass.)"
+    },
+    {
+      "test_id": "ut_hypothesis_tracking_004",
+      "dimension_source": "base",
+      "dimension_name": "Correctness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": "**`ut_hypothesis_tracking_004`** — `base` / `Correctness`\nLLM: 3 → Junior: 3\n\n> Claude correctly identified the chronological impossibility: Thomas Flynn of Luzerne County died 15 September 1840, five years before Patrick's ~1845 birth. The death assertion (a_016) is factually linked to the timeline, and the reasoning is sound under GPS evidence rules. No fabricated material or unsupported claims.\n\nJunior: (The contradiction was accurately recognized and applied, making the ruling out logically and factually sound — Pass.)"
+    },
+    {
+      "test_id": "ut_hypothesis_tracking_004",
+      "dimension_source": "base",
+      "dimension_name": "Completeness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": "**`ut_hypothesis_tracking_004`** — `base` / `Completeness`\nLLM: 3 → Junior: 3\n\n> Claude fully addressed the user's request to update h_002 based on the death record. The hypothesis was properly evaluated, the status transitioned to ruled_out, contradicting evidence was linked, and the ruled_out_reason was supplied with detailed justification. No gaps in coverage.\n\nJunior: (The update was complete, covering evidence linkage, status transition, and reasoning — Pass.)"
+    },
+    {
+      "test_id": "ut_hypothesis_tracking_004",
+      "dimension_source": "base",
+      "dimension_name": "Tool Arguments",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": "**`ut_hypothesis_tracking_004`** — `base` / `Tool Arguments`\nLLM: 3 → Junior: 3\n\n> Both MCP tool calls passed correct arguments. The research_append call properly targeted h_002 with correct field updates (status, contradicting_assertion_ids, ruled_out, ruled_out_reason). The validate call was appropriate for post-write verification. No fixture_not_found errors; arguments match the expected structure.\n\nJunior: (Tool arguments were accurate, complete, and aligned with protocol — Pass.)"
+    },
+    {
+      "test_id": "ut_hypothesis_tracking_004",
+      "dimension_source": "rubric",
+      "dimension_name": "Claim clarity",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": "**`ut_hypothesis_tracking_004`** — `rubric` / `Claim clarity`\nLLM: 3 → Junior: 3\n\n> The hypothesis claim is specific: 'Patrick Flynn's father was Thomas Flynn of Luzerne County, Pennsylvania.' It names specific persons, the relationship being hypothesized (paternity), and includes place detail (Luzerne County, Pennsylvania). The claim is directly testable.\n\nJunior: (The claim is specific, well structured, and testable — Pass.)"
+    },
+    {
+      "test_id": "ut_hypothesis_tracking_004",
+      "dimension_source": "rubric",
+      "dimension_name": "Evidence linkage",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": "**`ut_hypothesis_tracking_004`** — `rubric` / `Evidence linkage`\nLLM: 3 → Junior: 3\n\n> The linkage is correct and precise. The death record (a_016) showing Thomas Flynn died 15 September 1840 is appropriately placed in contradicting_assertion_ids because it directly contradicts the paternity hypothesis—a man cannot father a child born five years after his death. The supporting evidence link (a_014, census) is also relevant as circumstantial evidence of the candidate.\n\nJunior: (Evidence linkage is correct, precise, and well reasoned — Pass.)"
+    },
+    {
+      "test_id": "ut_hypothesis_tracking_004",
+      "dimension_source": "rubric",
+      "dimension_name": "Status transitions",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": "**`ut_hypothesis_tracking_004`** — `rubric` / `Status transitions`\nLLM: 3 → Junior: 3\n\n> The status transition to ruled_out is justified by affirmative refutation, not mere absence of evidence. Claude cites the specific death date (15 September 1840) and the timeline gap to Patrick's ~1845 birth as the grounds for ruling out. The ruled_out_reason explicitly states the chronological impossibility and the GPS framework violation. This meets the schema requirement for ruled_out transitions with documented affirmative refutation.\n\nJunior: (Status transition was justified, documented, and compliant with schema rules —Pass.)"
+    },
+    {
+      "test_id": "ut_hypothesis_tracking_005",
+      "dimension_source": "base",
+      "dimension_name": "Correctness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": "**`ut_hypothesis_tracking_005`** — `base` / `Correctness`\nLLM: 3 → Junior: 3\n\n> The hypothesis claim is factually correct given the user's input. Thomas Flynn of Schuylkill County, Pennsylvania in the 1840s is correctly stated as a candidate father for Patrick Flynn (b. ~1845, d. 1908). The facts in the claim align with the user's message and the stub person in the project state. No fabricated material is present. The related_question_ids is correctly set to an empty array, avoiding ownership violations.\n\nJunior: (Overall, the skill demonstrated accurate handling of user's hunch, turning it into a preciese genealogical hypotheses - Pass)"
+    },
+    {
+      "test_id": "ut_hypothesis_tracking_005",
+      "dimension_source": "base",
+      "dimension_name": "Completeness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": "**`ut_hypothesis_tracking_005`** — `base` / `Completeness`\nLLM: 3 → Junior: 3\n\n> The skill addressed all required elements: created a specific, testable hypothesis with proper formatting; called validate_research_schema as mandatory; set status to 'active' appropriately since no research evidence exists yet; included empty supporting and contradicting assertion arrays; and provided relevant guidance on next research steps.\n\nJunior: (All required elements were addressed - Pass)"
+    },
+    {
+      "test_id": "ut_hypothesis_tracking_005",
+      "dimension_source": "base",
+      "dimension_name": "Tool Arguments",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": "**`ut_hypothesis_tracking_005`** — `base` / `Tool Arguments`\nLLM: 3 → Junior: 3\n\n> Both tool calls executed successfully with matched.kind='live'. The research_append call correctly specified all required fields: claim with specific names/places/timeframe, status='active', empty assertion arrays, ruled_out=false, null ruled_out_reason, and empty related_question_ids array. The validate_research_schema call was correctly invoked with only the projectPath argument. All arguments match expected usage.\n\nJunior: (The skill’s handling of tool arguments was precise. No errors or mismatches occurred. -Pass)"
+    },
+    {
+      "test_id": "ut_hypothesis_tracking_005",
+      "dimension_source": "rubric",
+      "dimension_name": "Claim clarity",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": "**`ut_hypothesis_tracking_005`** — `rubric` / `Claim clarity`\nLLM: 3 → Junior: 3\n\n> The claim names specific persons (Thomas Flynn and Patrick Flynn), specifies the exact relationship (father-child), and includes precise place/time detail (Schuylkill County, Pennsylvania, 1840s for Thomas; born ca. 1845, died 1908 in Schuylkill County for Patrick). This is testable and would support targeted searches in census records and parish registers.\n\nJunior: (The hypothesis claim is clear and specific. The clarity ensures that research can be directed toward confirming or refuting the father–son link without ambiguity. - Pass)"
+    },
+    {
+      "test_id": "ut_hypothesis_tracking_005",
+      "dimension_source": "rubric",
+      "dimension_name": "Evidence linkage",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": "**`ut_hypothesis_tracking_005`** — `rubric` / `Evidence linkage`\nLLM: 3 → Junior: 3\n\n> No evidence has been linked yet, which is correct—this is the initial hypothesis creation. The supporting_assertion_ids and contradicting_assertion_ids arrays are appropriately empty since no research has been done. No tangential assertions are present to mislink.\n\nJunior: (No tangential or irrelevant assertions were mislinked, keeping the hypothesis clean and ready for future evidence tracking - Pass)"
+    },
+    {
+      "test_id": "ut_hypothesis_tracking_005",
+      "dimension_source": "rubric",
+      "dimension_name": "Status transitions",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": "**`ut_hypothesis_tracking_005`** — `rubric` / `Status transitions`\nLLM: 3 → Junior: 3\n\n> The status is correctly set to 'active' per research-schema-spec.md §5.9 rules. Since no supporting evidence exists yet, 'supported' would be premature and incorrect. The ruled_out field is false with null ruled_out_reason, which is proper since there is no refuting evidence. The transition from project initialization to this initial 'active' hypothesis is justified.\n \nJunior: (The transition from project initialization to this initial active hypothesis is justified and compliant with schema requirements. - Pass)"
+    },
+    {
+      "test_id": "ut_hypothesis_tracking_006",
+      "dimension_source": "base",
+      "dimension_name": "Correctness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": "**`ut_hypothesis_tracking_006`** — `base` / `Correctness`\nLLM: 3 → Junior: 3\n\n> Claude's text response accurately reflects the research state: h_001 is correctly identified as SUPPORTED with three supporting assertions (a_004, a_010, a_013) and no contradictions; h_002 is correctly identified as ACTIVE with one supporting assertion (a_014). The schema validation passed. Claude correctly identifies the chronological impossibility (a_016: death in 1840 vs. ~1845 birth) that should lead to h_002 being ruled out, and appropriately flags this gap without making unsupported claims. All factual statements are grounded in the provided research data.\n\nJunior: (All factual statements are grounded in the project data, with no fabricated material. - Pass)"
+    },
+    {
+      "test_id": "ut_hypothesis_tracking_006",
+      "dimension_source": "base",
+      "dimension_name": "Completeness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": "**`ut_hypothesis_tracking_006`** — `base` / `Completeness`\nLLM: 3 → Junior: 3\n\n> Claude presented both competing hypotheses (h_001 and h_002) as required, along with their current status, supporting evidence, and contradicting evidence. It correctly identified the chronological contradiction (a_016) that the test notes indicated should be noticed. For a read-only review, Claude appropriately deferred modification while identifying the needed next action. No major portions of the request were omitted.\n\nJunior: (No major portions of the user’s request were omitted, and the summary gave a full snapshot of the research state. - Pass)"
+    },
+    {
+      "test_id": "ut_hypothesis_tracking_006",
+      "dimension_source": "base",
+      "dimension_name": "Tool Arguments",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": "**`ut_hypothesis_tracking_006`** — `base` / `Tool Arguments`\nLLM: 3 → Junior: 3\n\n> Claude made exactly one MCP tool call: validate_research_schema with projectPath set to the correct test directory. This matches expected behavior per SKILL.md requirements for every interaction, and the call is correctly structured and executed. The test explicitly required this validation even for read-only reviews, and Claude performed it.\n\nJunior: (The call was correctly structured and executed, ensuring the project state was validated without making unintended modifications. This fulfills the explicit requirement for tool usage in this scenario. - Pass)"
+    },
+    {
+      "test_id": "ut_hypothesis_tracking_006",
+      "dimension_source": "rubric",
+      "dimension_name": "Claim clarity",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": "**`ut_hypothesis_tracking_006`** — `rubric` / `Claim clarity`\nLLM: 3 → Junior: 3\n\n> Both hypotheses are stated with high clarity: h_001 names 'Thomas Flynn of Schuylkill County, PA' as father of Patrick Flynn (~1845 birth), and h_002 names 'Thomas Flynn of Luzerne County, PA' as the competing candidate. Both are specific, testable claims with place and time detail sufficient for follow-up searches. The relationship (biological father) is explicit and the persons are named with geographic specificity.\n\nJunior: (Each claim specifies the individuals, the exact relationship (father–child), and includes geographic and temporal detail, making them specific, testable, and suitable for targeted genealogical searches. - Pass)"
+    },
+    {
+      "test_id": "ut_hypothesis_tracking_006",
+      "dimension_source": "rubric",
+      "dimension_name": "Evidence linkage",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": "**`ut_hypothesis_tracking_006`** — `rubric` / `Evidence linkage`\nLLM: 3 → Junior: 3\n\n> Claude correctly identifies and discusses the evidence linkages: a_004, a_010, a_013 genuinely support h_001 (household presence, age consistency, deathbed statement naming father); a_014 supports h_002 (Luzerne census showing Thomas with young child). Critically, Claude also correctly identifies a_016 (death record) as contradicting h_002 but appropriately flags it as 'not yet linked' in the data structure rather than falsely claiming it is already linked. This demonstrates correct read-only analysis: identifying the gap without fabricating existing linkages.\n\nJunior: (Claude correctly identified and discussed the evidence linkages, demonstrating proper read only analysis: recognizing the gap without fabricating existing linkages. - )Pass"
+    },
+    {
+      "test_id": "ut_hypothesis_tracking_006",
+      "dimension_source": "rubric",
+      "dimension_name": "Status transitions",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": "**`ut_hypothesis_tracking_006`** — `rubric` / `Status transitions`\nLLM: 3 → Junior: 3\n\n> Claude correctly identifies that h_002 should move to 'ruled_out' based on affirmative refutation (a_016: death in 1840 before Patrick's ~1845 birth), matching research-schema-spec §5.9 rules. Critically, for a read-only review, Claude defers the actual transition while explicitly identifying the needed change and providing the exact rationale ('five years before Patrick's estimated 1845 birth — biological parentage is impossible'). This demonstrates correct behavior per test guidance: identifying needed transitions without modifying the file during a read-only summary. The score is pass because Claude correctly characterizes the current status (ACTIVE) and identifies why it should change, without mischaracterizing existing statuses.\n\nJunior: (Claude correctly identified that h_002 should transition to ruled_out based on affirmative refutation (a_016: Thomas Flynn of Luzerne County died in 1840, five years before Patrick’s ~1845 birth), which matches research schema spec §5.9 rules. For a read only review, Claude appropriately deferred making the actual transition while explicitly noting the needed change and providing the rationale (biological parentage is impossible due to chronological impossibility). This demonstrates correct behavior per test guidance: identifying the required transition without modifying the file. The current statuses were accurately characterized — h_001 as SUPPORTED and h_002 as ACTIVE — with no misrepresentation. -)Pass"
+    },
+    {
+      "test_id": "ut_hypothesis_tracking_007",
+      "dimension_source": "base",
+      "dimension_name": "Correctness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": "**`ut_hypothesis_tracking_007`** — `base` / `Correctness`\nLLM: 3 → Junior: 3\n\n> The hypothesis was created with accurate details: claim names Margaret O'Brien of County Cork as Patrick's mother; correctly identified the user-submitted FamilySearch tree as a compiled source (lead, not evidence); supporting_assertion_ids correctly left empty since no original-record assertions exist yet; status set to 'active' (appropriate for unverified lead); related to q_001 (parentage question). The file was successfully written and validated. No fabricated material or unsupported claims.\n\nJunior: (The hypothesis was created with accurate details: the claim clearly names Margaret O’Brien of County Cork, Ireland as Patrick Flynn’s mother, specifies the relationship (mother–child), and includes geographic detail sufficient for research. Claude correctly flagged the origin as a compiled source (user-submitted FamilySearch tree), treating it as a lead rather than evidence. supporting_assertion_ids and contradicting_assertion_ids were correctly left empty since no original-record assertions exist yet. The status was set to active, appropriate for an unverified lead, and the hypothesis was linked to q_001 (parentage question). The file was successfully written and validated, with no fabricated material or unsupported claims. - Pass)"
+    },
+    {
+      "test_id": "ut_hypothesis_tracking_007",
+      "dimension_source": "base",
+      "dimension_name": "Completeness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": "**`ut_hypothesis_tracking_007`** — `base` / `Completeness`\nLLM: 3 → Junior: 3\n\n> The skill fully addressed the user's request: created a hypothesis tracking the Margaret O'Brien mother claim; explicitly flagged the compiled-source origin and stated the need for independent verification against original records; populated all required fields (claim, status, supporting/contradicting assertions, related question); provided concrete research pathways for verification and refutation. Nothing requested was omitted.\n\nJunior: (The skill fully addressed the user’s request by creating a hypothesis to track the Margaret O’Brien mother claim. It explicitly flagged the origin as a compiled source (user-submitted FamilySearch tree) and emphasized the need for independent verification against original records. All required fields were populated — claim, status set to active, empty supporting/contradicting assertion arrays, and linkage to q_001. The notes provided clear guidance on verification and refutation pathways, ensuring nothing was omitted from the request. - Pass)"
+    },
+    {
+      "test_id": "ut_hypothesis_tracking_007",
+      "dimension_source": "base",
+      "dimension_name": "Tool Arguments",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": "**`ut_hypothesis_tracking_007`** — `base` / `Tool Arguments`\nLLM: 3 → Junior: 3\n\n> Both MCP calls matched expectations. The mcp__genealogy__research_append call correctly appended a hypothesis entry with projectPath, section='hypotheses', op='append', and a complete entry object matching schema (claim, status, assertion arrays, ruled_out/reason, notes, related_question_ids). The mcp__genealogy__validate_research_schema call correctly passed projectPath. Both calls succeeded (matched.kind='live') with valid responses.\n\nJunior: (Both MCP calls were executed exactly as expected. The mcp__genealogy__research_append call correctly appended a new hypothesis entry with projectPath, section='hypotheses', op='append', and a complete entry object containing all required fields (claim, status, assertion arrays, ruled_out/reason, notes, related_question_ids). The mcp__genealogy__validate_research_schema call correctly passed the projectPath and validated the schema. Both calls succeeded (matched.kind='live') with valid responses, fulfilling the SKILL.md requirement for schema validation even after append operations. - Pass)"
+    },
+    {
+      "test_id": "ut_hypothesis_tracking_007",
+      "dimension_source": "rubric",
+      "dimension_name": "Claim clarity",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": "**`ut_hypothesis_tracking_007`** — `rubric` / `Claim clarity`\nLLM: 3 → Junior: 3\n\n> The hypothesis claim is highly specific and testable: 'Patrick Flynn's mother was Margaret O'Brien from County Cork, Ireland.' It names the specific person (Margaret O'Brien), the specific relationship (mother), and includes geographic detail (County Cork) and implicit temporal context (Patrick born ~1845). A follow-up search can directly test this against original Irish records or naturalization/census documents. Not vague.\n\nJunior: (The hypothesis claim is highly specific and testable: “Patrick Flynn’s mother was Margaret O’Brien from County Cork, Ireland.” It clearly identifies the person (Margaret O’Brien), the relationship (mother), and geographic detail (County Cork), with implicit temporal context from Patrick’s ~1845 birth. This precision makes the claim suitable for targeted searches in Irish baptismal records, U.S. census data, and other original sources, ensuring it is not vague. - Pass)"
+    },
+    {
+      "test_id": "ut_hypothesis_tracking_007",
+      "dimension_source": "rubric",
+      "dimension_name": "Evidence linkage",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": "**`ut_hypothesis_tracking_007`** — `rubric` / `Evidence linkage`\nLLM: 3 → Junior: 3\n\n> Supporting and contradicting assertion IDs are both empty arrays, which is correct since no assertions in research.json yet address Patrick's mother. The hypothesis is properly linked via related_question_ids to q_001 ('Who were the parents?'), a direct and appropriate connection. The notes correctly explain why no assertions are linked and outline the types of evidence (baptismal records, naturalization papers, etc.) that would bear on the hypothesis.\n\nJunior: (The hypothesis correctly leaves both supporting_assertion_ids and contradicting_assertion_ids as empty arrays, since no assertions in the project yet address Patrick Flynn’s mother. It is properly linked to q_001 (“Who were the parents?”), which covers both father and mother. The notes explicitly explain why no assertions are linked and outline the types of records that could provide supporting or refuting evidence (Irish baptismal records, naturalization papers, census entries, probate, marriage records). This is the correct setup for a lead hypothesis awaiting original-source verification. - Pass)"
+    },
+    {
+      "test_id": "ut_hypothesis_tracking_007",
+      "dimension_source": "rubric",
+      "dimension_name": "Status transitions",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": "**`ut_hypothesis_tracking_007`** — `rubric` / `Status transitions`\nLLM: 3 → Junior: 3\n\n> Status was correctly set to 'active' (not 'supported' or 'ruled_out'), which aligns with research-schema-spec.md §5.9 guidance. The hypothesis is unverified; no direct evidence exists; no affirmative refutation exists. The ruled_out field is false and ruled_out_reason is null, consistent with an active lead. The transition is justified: this is a compiled-source lead requiring investigation, not yet ready for support or dismissal.\n\nJunior: (The hypothesis was correctly set to active, which aligns with research schema spec §5.9 guidance. Since no direct evidence supports or refutes the claim yet, marking it as supported or ruled_out would be premature. The ruled_out field is properly set to false with a null ruled_out_reason, consistent with an unverified lead. This transition is justified: the claim originates from a compiled source and requires investigation before any status change. - Pass)"
+    },
+    {
+      "test_id": "ut_hypothesis_tracking_008",
+      "dimension_source": "base",
+      "dimension_name": "Correctness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": "**`ut_hypothesis_tracking_008`** — `base` / `Correctness`\nLLM: 3 → Junior: 3\n\n> The skill correctly created h_003 with accurate claim ('Patrick Flynn's father was James Flynn of Carbon County, Pennsylvania'), correct status (active), appropriate empty arrays for supporting/contradicting assertions (no evidence gathered yet), and correct related_question_ids=['q_001']. The claim is factually grounded in the user's description of the reference found. Tool calls succeeded with no fixture_not_found errors. Schema validation passed.\n\nJunior: (The new hypothesis h_003 was created correctly with the claim “Patrick Flynn's father was James Flynn of Carbon County, Pennsylvania.” The status is set to active, with both supporting_assertion_ids and contradicting_assertion_ids as empty arrays (no evidence yet). It is properly linked to q_001 (the parentage question). The notes clearly explain the lead’s origin, the need for verification, and outline research strategies. Importantly, h_001 and h_002 were not modified — the new hypothesis was added independently as a competing candidate. Tool calls succeeded, schema validation passed, and no unsupported or fabricated claims were introduced. - Pass)"
+    },
+    {
+      "test_id": "ut_hypothesis_tracking_008",
+      "dimension_source": "base",
+      "dimension_name": "Completeness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": "**`ut_hypothesis_tracking_008`** — `base` / `Completeness`\nLLM: 3 → Junior: 3\n\n> The skill fully addressed the user's request to add James Flynn as a third father candidate. It created the new hypothesis with all required fields, did not modify existing h_001 or h_002 (respecting scope rules), provided contextual analysis of the three competing candidates in a summary table, flagged the chronological impossibility in h_002 without inappropriately modifying it, and offered clear next-step research guidance for h_003. All request elements were covered.\n\nJunior: (The skill fully addressed the request by creating h_003 for James Flynn of Carbon County as a third father candidate. It included all required fields (claim, status, assertion arrays, ruled_out fields, notes, related_question_ids), respected scope rules by not modifying h_001 or h_002, and provided a clear contextual summary of all three competing hypotheses in a comparison table. It also flagged the chronological impossibility in h_002 without making inappropriate changes and offered concrete next step research guidance for h_003. Nothing was omitted from the user’s request. - Pass)"
+    },
+    {
+      "test_id": "ut_hypothesis_tracking_008",
+      "dimension_source": "base",
+      "dimension_name": "Tool Arguments",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": "**`ut_hypothesis_tracking_008`** — `base` / `Tool Arguments`\nLLM: 3 → Junior: 3\n\n> Both MCP tool calls used correct arguments. The mcp__genealogy__research_append call passed projectPath, section='hypotheses', op='append', and a well-formed entry object with the required fields (claim, status, supporting_assertion_ids, contradicting_assertion_ids, ruled_out, ruled_out_reason, notes, related_question_ids). The mcp__genealogy__validate_research_schema call correctly used only projectPath. Both calls matched.kind='live' with ok=true responses and no fixture_not_found errors.\n\nJunior: (Both MCP tool calls were correctly structured and executed. The mcp__genealogy__research_append call included the proper parameters: projectPath, section='hypotheses', op='append', and a well formed entry object with all required fields (claim, status, supporting/contradicting assertion arrays, ruled_out fields, notes, related_question_ids). The mcp__genealogy__validate_research_schema call correctly passed only the projectPath. Both calls returned matched.kind='live' with successful responses (ok=true) and no errors. This fully meets the requirements for tool usage and schema validation. - Pass)"
+    },
+    {
+      "test_id": "ut_hypothesis_tracking_008",
+      "dimension_source": "rubric",
+      "dimension_name": "Claim clarity",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": "**`ut_hypothesis_tracking_008`** — `rubric` / `Claim clarity`\nLLM: 3 → Junior: 3\n\n> The claim 'Patrick Flynn's father was James Flynn of Carbon County, Pennsylvania' is highly specific and testable. It names both persons (Patrick Flynn and James Flynn), specifies the relationship (father-son parentage), and includes precise place and time detail (Carbon County, Pennsylvania, 1840s). This claim can be directly tested through census, vital, church, and probate searches that would confirm or refute it.\n\nJunior: (The claim “Patrick Flynn's father was James Flynn of Carbon County, Pennsylvania” is clear, specific, and testable. It names both individuals (Patrick Flynn and James Flynn), defines the relationship (father–son), and provides geographic detail (Carbon County, Pennsylvania, 1840s context). This precision makes the hypothesis actionable: it can be directly tested through census records, vital records, church registers, and probate documents to confirm or refute the parentage. The claim avoids vagueness and is framed in a way that supports targeted genealogical research. - Pass)"
+    },
+    {
+      "test_id": "ut_hypothesis_tracking_008",
+      "dimension_source": "rubric",
+      "dimension_name": "Evidence linkage",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": "**`ut_hypothesis_tracking_008`** — `rubric` / `Evidence linkage`\nLLM: 3 → Junior: 3\n\n> Evidence linkage is correctly implemented. The supporting_assertion_ids and contradicting_assertion_ids are both empty arrays, which is correct because no assertions about James Flynn exist in the scenario yet—only a secondary reference was provided. The related_question_ids=['q_001'] is properly linked because all three father candidates (h_001, h_002, h_003) bear directly on the same research question about Patrick's parents. No tangential assertions are included.\n\nJunior: (Evidence linkage is correctly implemented for h_003. Both supporting_assertion_ids and contradicting_assertion_ids are empty arrays, which is appropriate since no assertions about James Flynn exist yet — only a secondary reference prompted the hypothesis. The hypothesis is properly tied to q_001 (“Who were the parents?”), ensuring all three father candidates (h_001, h_002, h_003) are tracked under the same research question. The notes explain why no assertions are linked and outline the types of records (census, vital, church, probate) that could provide supporting or refuting evidence. No unrelated or tangential assertions were included. - Pass)"
+    },
+    {
+      "test_id": "ut_hypothesis_tracking_008",
+      "dimension_source": "rubric",
+      "dimension_name": "Status transitions",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": "**`ut_hypothesis_tracking_008`** — `rubric` / `Status transitions`\nLLM: 3 → Junior: 3\n\n> The status transition is correct per research-schema-spec.md §5.9 rules. h_003 is marked as 'active' because it is a new lead from a secondary reference with no original evidence yet gathered. The hypothesis should not be 'supported' (no direct evidence) or 'ruled_out' (no refuting evidence exists yet). Status is appropriately conservative and matches the input state where this is the first mention of James Flynn. ruled_out is correctly set to false with null ruled_out_reason.\n\nJunior: (The status transition for h_003 is correct per research schema spec.md §5.9. It is marked as active because this is a new lead from a secondary reference, with no original evidence yet gathered. The hypothesis is appropriately conservative — not supported (no direct evidence) and not ruled_out (no refuting evidence). The ruled_out field is correctly set to false with ruled_out_reason as null, matching the input state where James Flynn is first introduced as a candidate father. This setup ensures the hypothesis remains open for investigation until evidence is found to confirm or refute it. - Pass)"
+    },
+    {
+      "test_id": "ut_hypothesis_tracking_009",
+      "dimension_source": "base",
+      "dimension_name": "Correctness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": "**`ut_hypothesis_tracking_009`** — `base` / `Correctness`\nLLM: 3 → Junior: 3\n\n> Claude correctly read the input state, performed the age arithmetic (1835 birth → ~10 years old when Patrick born ~1845), identified this as a biological impossibility, and transitioned h_001 to ruled_out with the baptism assertion (a_006) correctly linked as contradicting evidence. The MCP call and file state both confirm the update succeeded with a comprehensive, accurate ruled_out_reason.\n\nJunior: ( Claude independently performed the age arithmetic: Thomas Flynn’s baptism record (a_006) establishes his birth in 1835, making him only ~10 years old when Patrick was born around 1845. Claude explicitly identified this as a biological impossibility for fatherhood. The hypothesis h_001 was transitioned to ruled_out, with status=\"ruled_out\", ruled_out=true, and a clear ruled_out_reason explaining the impossibility. Assertion a_006 was correctly added to contradicting_assertion_ids, recognizing that the baptism record already existed and was linked to Thomas Flynn via pe_005 at confident level. The file state confirms the update was successful and accurate, with no fabricated evidence or mischaracterization. - Pass)"
+    },
+    {
+      "test_id": "ut_hypothesis_tracking_009",
+      "dimension_source": "base",
+      "dimension_name": "Completeness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": "**`ut_hypothesis_tracking_009`** — `base` / `Completeness`\nLLM: 3 → Junior: 3\n\n> Claude fully addressed the user's request to check whether the baptism record changes the hypothesis. The skill identified the contradiction, performed necessary arithmetic, updated the hypothesis status, linked the contradicting assertion, populated the ruled_out_reason, and validated the result. No required elements were omitted.\n\nJunior: (Claude fully carried out the requested evaluation of the baptism record against the hypothesis. It independently did the age arithmetic (Patrick born ~1845 vs. Thomas baptized 1835 → Thomas only ~10 years old), identified this as a biological impossibility, and updated h_001 accordingly. The hypothesis was transitioned to ruled_out, the contradicting assertion a_006 was correctly linked, and a clear ruled_out_reason was populated. Schema validation confirmed the update. All required elements — contradiction identification, arithmetic, hypothesis status change, assertion linkage, reason population, and validation — were addressed without omission. - Pass)"
+    },
+    {
+      "test_id": "ut_hypothesis_tracking_009",
+      "dimension_source": "base",
+      "dimension_name": "Tool Arguments",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": "**`ut_hypothesis_tracking_009`** — `base` / `Tool Arguments`\nLLM: 3 → Junior: 3\n\n> Both MCP tool calls passed correct arguments. The research_append call used valid section ('hypotheses'), operation ('update'), entryId ('h_001'), and fields with proper schema structure (status, contradicting_assertion_ids, ruled_out, ruled_out_reason). The validate_research_schema call correctly identified the project path. No fixture_not_found errors occurred; both calls matched the live endpoints successfully.\n\nJunior: (Both MCP tool calls were made with correct arguments. The research_append call used the proper parameters: section='hypotheses', op='update', entryId='h_001', and a well formed fields object containing status, contradicting_assertion_ids, ruled_out, and a detailed ruled_out_reason. The validate_research_schema call correctly passed the projectPath to confirm schema integrity. Both calls executed successfully (matched.kind='live'), with no errors or fixture issues. This confirms the update to h_001 was properly structured and validated. - Pass)"
+    },
+    {
+      "test_id": "ut_hypothesis_tracking_009",
+      "dimension_source": "rubric",
+      "dimension_name": "Claim clarity",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": "**`ut_hypothesis_tracking_009`** — `rubric` / `Claim clarity`\nLLM: 3 → Junior: 3\n\n> The hypothesis is stated with specific, testable precision: 'Patrick Flynn's father was Thomas Flynn of Schuylkill County, Pennsylvania.' It names both individuals, specifies the relationship (father), and includes geographic/temporal context sufficient for follow-up searches. The claim is concrete and falsifiable.\n\nJunior: (The hypothesis “Patrick Flynn's father was Thomas Flynn of Schuylkill County, Pennsylvania” is expressed with clear, specific, and testable precision. It names both individuals (Patrick Flynn and Thomas Flynn), defines the relationship (father–son), and provides geographic context (Schuylkill County, Pennsylvania). The temporal context (~1845 birth for Patrick vs. Thomas’s 1835 baptism) makes the claim falsifiable through direct evidence checks. This concreteness ensures the hypothesis can be investigated and either confirmed or ruled out using census, baptismal, and other original records. - Pass)"
+    },
+    {
+      "test_id": "ut_hypothesis_tracking_009",
+      "dimension_source": "rubric",
+      "dimension_name": "Evidence linkage",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": "**`ut_hypothesis_tracking_009`** — `rubric` / `Evidence linkage`\nLLM: 3 → Junior: 3\n\n> The contradicting assertion (a_006 — baptism record establishing Thomas's birth in 1835) is directly and relevantly linked. It establishes the fact that contradicts the hypothesis: a 10-year-old cannot be a biological father. The supporting assertion (a_003 — census co-enumeration) is retained but contextualized correctly as consistent with sibling or uncle relationships rather than fatherhood. No tangential assertions are linked.\n\nJunior: (The evidence linkage is handled correctly. The contradicting assertion a_006 (Thomas Flynn’s baptism record establishing his 1835 birth) is directly tied to h_001, showing the biological impossibility of fatherhood at age ~10. This is the decisive contradiction. The supporting assertion a_003 (1850 census co enumeration) is retained but properly re contextualized — it may indicate a sibling, uncle, or other family relationship rather than father son. No irrelevant or tangential assertions were linked, ensuring the hypothesis is accurately documented with the appropriate evidence connections. - Pass)"
+    },
+    {
+      "test_id": "ut_hypothesis_tracking_009",
+      "dimension_source": "rubric",
+      "dimension_name": "Status transitions",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": "**`ut_hypothesis_tracking_009`** — `rubric` / `Status transitions`\nLLM: 3 → Junior: 3\n\n> The transition from active to ruled_out is justified by affirmative refutation: the baptism record provides direct primary evidence (contemporaneous parish register) establishing Thomas's birth date at 1835, creating a biological impossibility (age 10 at Patrick's birth). This meets the research-schema-spec.md criterion for ruling out. The ruled_out_reason is fully populated, explaining the contradiction and the confidence in the person-evidence link (pe_005, 0.92) that confirms the baptism record applies to this specific Thomas Flynn.\n\nJunior: (The transition of h_001 from active to ruled_out is fully justified. The baptism record (a_006) is primary information, direct evidence from a contemporaneous parish register, establishing Thomas Flynn’s birth in 1835. With Patrick born ~1845, Thomas would have been only ~10 years old — a biological impossibility for fatherhood. This meets the research schema spec.md §5.9 criteria for ruling out a hypothesis. The ruled_out_reason is thoroughly populated, explaining both the contradiction and the confident person evidence link (pe_005, match_score 0.92) that ties the baptism record to this specific Thomas Flynn. The update is precise, evidence driven, and correctly documented. - Pass)"
+    },
+    {
+      "test_id": "ut_hypothesis_tracking_010",
+      "dimension_source": "base",
+      "dimension_name": "Correctness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": "**`ut_hypothesis_tracking_010`** — `base` / `Correctness`\nLLM: 3 → Junior: 3\n\n> Claude correctly interpreted the user's instruction that the birth year discrepancy 'doesn't disprove anything' and properly maintained h_001's 'supported' status rather than downgrading it. The linking of a_017 as contradicting evidence is factually correct. The rationale provided (census age rounding norms) is sound and well-documented. The observation about h_002 being overdue for ruling out is accurate but appropriately not acted upon since the user didn't request it. No fabricated material or unsupported claims.\n\nJunior: (Claude handled the update exactly as requested. It correctly interpreted the user’s instruction that the birth year discrepancy “doesn’t disprove anything,” so it maintained h_001’s supported status rather than downgrading it. Assertion a_017 was properly linked as contradicting evidence, reflecting the marriage record’s ~1823 birth year estimate. The rationale provided — census age rounding norms and self reported age variability among Irish immigrants — is sound and well explained. The observation about h_002 being overdue for ruling out was accurate but scope aware: it was mentioned in text only, with no file modification. No unsupported claims or fabricated evidence were introduced. - Pass)"
+    },
+    {
+      "test_id": "ut_hypothesis_tracking_010",
+      "dimension_source": "base",
+      "dimension_name": "Completeness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": "**`ut_hypothesis_tracking_010`** — `base` / `Completeness`\nLLM: 3 → Junior: 3\n\n> Claude fully addressed the user's request: linked a_017 to h_001's contradicting_assertion_ids, preserved the 'supported' status, provided clear documentation of the discrepancy and its genealogical context in the notes field, and validated the schema. The user's explicit scope was only h_001, which was completely handled. The additional observation about h_002 was appropriately flagged as outside the immediate request without being acted upon.\n\nJunior: (Claude fully carried out the requested update for h_001. It correctly linked a_017 to the contradicting_assertion_ids, preserved the hypothesis’s supported status, and documented the discrepancy in the notes with appropriate genealogical context (census age rounding norms, self reported age variability). Schema validation was run and passed. The scope was respected — only h_001 was modified, while h_002 was flagged in text as problematic but left unchanged in the file. All elements of the user’s instructions were addressed without omission. - Pass)"
+    },
+    {
+      "test_id": "ut_hypothesis_tracking_010",
+      "dimension_source": "base",
+      "dimension_name": "Tool Arguments",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": "**`ut_hypothesis_tracking_010`** — `base` / `Tool Arguments`\nLLM: 3 → Junior: 3\n\n> Both MCP calls matched expected behavior. The research_append call correctly used operation 'update', targeted h_001, and properly constructed the contradicting_assertion_ids array with a_017 and the notes field with detailed genealogical reasoning. The validate_research_schema call was appropriately invoked with the correct projectPath. Both calls returned successful responses (matched.kind == 'live', validation passed). No fixture_not_found errors or critical argument mismatches.\n\nJunior: (Both MCP calls were correctly structured and executed. The research_append call used the proper operation (update), targeted h_001, and included a well formed fields object:\n•\tcontradicting_assertion_ids correctly added a_017\n•\tnotes field documented the genealogical reasoning and clarified that the discrepancy is within normal census age rounding norms, preserving the hypothesis’s supported status\nThe validate_research_schema call was appropriately invoked with the correct projectPath, ensuring schema integrity. Both calls returned successful responses (matched.kind == 'live'), with no errors or fixture mismatches. This confirms the arguments were valid and the update was properly applied. - Pass)"
+    },
+    {
+      "test_id": "ut_hypothesis_tracking_010",
+      "dimension_source": "rubric",
+      "dimension_name": "Claim clarity",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": "**`ut_hypothesis_tracking_010`** — `rubric` / `Claim clarity`\nLLM: 3 → Junior: 3\n\n> The claim is clear and testable: 'Patrick Flynn's father was Thomas Flynn of Schuylkill County, Pennsylvania.' This names specific persons, the specific parent-child relationship, and includes geographic/temporal detail sufficient for follow-up searches. The evidence assessment is concrete (birth year ~1818 vs ~1823, based on specific documents: 1850 census, 1842 marriage record).\n\nJunior: (The hypothesis “Patrick Flynn's father was Thomas Flynn of Schuylkill County, Pennsylvania” is expressed with clear, specific, and testable detail. It identifies both individuals, defines the parent–child relationship, and situates them in a geographic context (Schuylkill County, Pennsylvania). The evidence assessment is concrete: the ~1818 birth year estimate from the 1850 census versus the ~1823 estimate from the 1842 marriage record (a_017). These are precise, document based facts that can be directly evaluated. The claim is therefore both falsifiable and actionable for genealogical research, while the discrepancy is properly contextualized as a normal census age rounding issue rather than undermining the parentage claim. - Pass)"
+    },
+    {
+      "test_id": "ut_hypothesis_tracking_010",
+      "dimension_source": "rubric",
+      "dimension_name": "Evidence linkage",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": "**`ut_hypothesis_tracking_010`** — `rubric` / `Evidence linkage`\nLLM: 3 → Junior: 3\n\n> All supporting and contradicting assertions are directly relevant. a_004, a_010, and a_013 directly support the parent-child hypothesis through census co-enumeration and death certificate naming. a_017 (marriage record birth year ~1823) genuinely contradicts the prior birth year estimate (~1818) derived from census age, making it properly classified as contradicting evidence. No tangential or off-topic links. Reasoning for each link is clear and genealogically sound.\n\nJunior: (All linked assertions are directly relevant to the hypothesis.\n•\tSupporting evidence:\n\ta_004 — 1850 census co enumeration, showing Patrick in Thomas’s household (indirect, indeterminate).\n\ta_010 — 1860 census co enumeration, again placing Patrick in Thomas’s household (indirect, indeterminate).\n\ta_013 — 1908 death certificate naming Thomas as Patrick’s father (direct, secondary informant).\n•\tContradicting evidence:\no\ta_017 — 1842 marriage record with Thomas’s self reported age of 19, implying birth ~1823, which contradicts the ~1818 estimate from census age.\nThe contradiction is genuine but minor, properly classified as contradicting evidence. The reasoning is genealogically sound: census age estimates and self reported ages often vary by several years, especially among 19th century Irish immigrants. No tangential or irrelevant assertions were linked, ensuring the hypothesis remains cleanly documented with only pertinent evidence. - Pass)"
+    },
+    {
+      "test_id": "ut_hypothesis_tracking_010",
+      "dimension_source": "rubric",
+      "dimension_name": "Status transitions",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": "**`ut_hypothesis_tracking_010`** — `rubric` / `Status transitions`\nLLM: 3 → Junior: 3\n\n> Status correctly remained 'supported' despite adding contradicting evidence. This aligns with research-schema-spec.md §5.9 rules: the contradiction (5-year birth year discrepancy) is not affirmative refutation of the parent-child claim itself, and falls within normal 19th-century census age-rounding error. Claude did not invoke 'ruled_out' inappropriately. The status transition rule (supported only with direct positive evidence and no unresolved contradictions) is satisfied—the contradiction about birth year precision is minor and does not negate the three supporting assertions about the parent-child relationship.\n\nJunior: (The hypothesis h_001 correctly retained its supported status even after adding the contradicting evidence a_017. This aligns with research schema spec.md §5.9: the contradiction (a 5 year birth year discrepancy between census estimate ~1818 and marriage record ~1823) is not affirmative refutation of the parent child claim. Such discrepancies fall within normal 19th century census age rounding and self reporting error margins, so they do not undermine the direct supporting evidence (death certificate naming Thomas as father, plus census co enumerations). Claude appropriately avoided downgrading or ruling out the hypothesis, ensuring the status transition rules were respected. - Pass)"
+    },
+    {
+      "test_id": "ut_hypothesis_tracking_011",
+      "dimension_source": "base",
+      "dimension_name": "Correctness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": "**`ut_hypothesis_tracking_011`** — `base` / `Correctness`\nLLM: 3 → Junior: 3\n\n> Claude correctly identified the chronological impossibility (death in 1840, birth ~1845), accurately cited the source evidence (a_016 from src_006 with pe_008 identification), and ruled out h_002 based on sound genealogical reasoning. All factual claims match the provided project state.\n\nJunior: (Claude handled the situation exactly as required. It refused to promote h_002 to supported, correctly identifying that:\n1.\tThe hypothesis had only one weak supporting assertion (a_014, name match).\n2.\tThe Luzerne County death record (a_016) shows Thomas Flynn died in 1840, five years before Patrick’s ~1845 birth — a chronological impossibility.\nClaude explained why promotion was unsound, then took the appropriate corrective action: formally linked a_016 as contradicting evidence and transitioned h_002 to ruled_out, with a clear ruled_out_reason. The reasoning was genealogically sound, citing the confident identification (pe_008) and the death record details.\nIt also respected scope: only h_002 was updated, while h_001 remained unchanged. No fabricated evidence or unsupported claims were introduced. This is a fully correct and appropriate resolution. - Pass) "
+    },
+    {
+      "test_id": "ut_hypothesis_tracking_011",
+      "dimension_source": "base",
+      "dimension_name": "Completeness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": "**`ut_hypothesis_tracking_011`** — `base` / `Completeness`\nLLM: 3 → Junior: 3\n\n> Claude fully addressed the user's request by refusing to mark h_002 as supported, explaining the three independent reasons why the supported threshold cannot be met, formally linking the contradicting evidence a_016, and ruling out h_002 with proper rationale. Also contextualized the impact on h_001.\n\nJunior: (Claude fully addressed the request by refusing to promote h_002 to supported, explaining clearly why the threshold could not be met (only one weak supporting assertion, unresolved contradiction, and a chronological impossibility). It then took the correct action: formally linked a_016 as contradicting evidence, transitioned h_002 to ruled_out, and provided a thorough ruled_out_reason. The explanation covered all three independent reasons for refusal and contextualized the impact on h_001, noting that ruling out h_002 strengthens the Schuylkill hypothesis. All required elements were handled, with no omissions. Pass)"
+    },
+    {
+      "test_id": "ut_hypothesis_tracking_011",
+      "dimension_source": "base",
+      "dimension_name": "Tool Arguments",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": "**`ut_hypothesis_tracking_011`** — `base` / `Tool Arguments`\nLLM: 3 → Junior: 3\n\n> Both MCP calls executed successfully (matched.kind == 'live'). The research_append call correctly updated h_002 with proper structure: supporting_assertion_ids (a_014, a_015), contradicting_assertion_ids (a_016), status set to 'ruled_out', ruled_out: true, and detailed ruled_out_reason. The validate_research_schema call was appropriate and returned clean validation.\n\nJunior: (Both MCP calls were executed successfully (matched.kind == 'live).\n•\tThe research_append call correctly updated h_002 with the proper structure:\n\tsupporting_assertion_ids included a_014 and a_015.\n\tcontradicting_assertion_ids properly added a_016 (the Luzerne County death record).\n\tstatus was set to ruled_out, with ruled_out: true.\n\tA detailed ruled_out_reason was provided, explaining the chronological impossibility (death in 1840, five years before Patrick’s ~1845 birth).\n\tnotes field documented both the supporting census evidence and the death record contradiction.\n•\tThe validate_research_schema call was appropriately invoked with the correct projectPath and returned clean validation.\nNo errors, mismatches, or fixture issues occurred. The arguments were precise, schema compliant, and genealogically sound. - Pass)"
+    },
+    {
+      "test_id": "ut_hypothesis_tracking_011",
+      "dimension_source": "rubric",
+      "dimension_name": "Claim clarity",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": "**`ut_hypothesis_tracking_011`** — `rubric` / `Claim clarity`\nLLM: 3 → Junior: 3\n\n> The hypothesis h_002 itself is stated clearly as a specific testable claim (Thomas Flynn of Luzerne County was Patrick Flynn's father), with sufficient place and time details that follow-up searches could test it. Claude articulated the exact reason for rejection: a chronological impossibility (death 15 September 1840 vs. birth ~1845).\n\nJunior: (The hypothesis h_002 is clearly stated: “Patrick Flynn's father was Thomas Flynn of Luzerne County.” It specifies both individuals, the parent–child relationship, and the geographic context (Luzerne County, Pennsylvania), making it a concrete and testable claim. Claude articulated the exact reason for rejection with precision: the Luzerne County death record (a_016) shows Thomas Flynn died on 15 September 1840, while Patrick’s estimated birth was around 1845. This creates a chronological impossibility — a deceased person cannot be a biological parent. The clarity of the claim and the explicit contradiction make the hypothesis easy to evaluate and definitively rule out.  - Pass)"
+    },
+    {
+      "test_id": "ut_hypothesis_tracking_011",
+      "dimension_source": "rubric",
+      "dimension_name": "Evidence linkage",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": "**`ut_hypothesis_tracking_011`** — `rubric` / `Evidence linkage`\nLLM: 3 → Junior: 3\n\n> Claude correctly linked a_014 and a_015 as supporting assertions (name match and residence in Luzerne County) and critically linked a_016 (death record) as contradicting evidence. Each link is directly relevant: the name and location support the identification, while the death date directly refutes the paternity claim. No tangential assertions were linked.\n\nJunior: (Claude correctly linked the relevant assertions for h_002:\n•\tSupporting evidence:\no\ta_014 — 1840 Luzerne County census: Thomas Flynn, head of household, age 30, with one male child under 5 (indirect).\no\ta_015 — 1840 Luzerne County census: residence confirmation (direct).\n•\tContradicting evidence:\no\ta_016 — Luzerne County death record: Thomas Flynn died 15 September 1840, age 30, typhoid fever (direct, confident identification pe_008).\nEach link is directly relevant to the hypothesis: the census records support the identification of Thomas Flynn in Luzerne County, while the death record directly refutes the paternity claim by establishing a chronological impossibility (death five years before Patrick’s birth). No tangential or off-topic assertions were included, and the reasoning for each link is genealogically sound. - Pass)"
+    },
+    {
+      "test_id": "ut_hypothesis_tracking_011",
+      "dimension_source": "rubric",
+      "dimension_name": "Status transitions",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": "**`ut_hypothesis_tracking_011`** — `rubric` / `Status transitions`\nLLM: 3 → Junior: 3\n\n> Claude refused the user's request to mark h_002 as supported and instead correctly transitioned it to ruled_out, meeting the research-schema-spec.md §5.9 standard: the hypothesis required affirmative refutation (death record establishing chronological impossibility), not merely lack of evidence. The ruled_out_reason field was properly populated with specific evidence (a_016, death date, confident identification pe_008).\n\nJunior: (Claude correctly refused to promote h_002 to supported and instead transitioned it to ruled_out, in line with research schema spec.md §5.9. The death record (a_016) provided affirmative refutation by establishing a chronological impossibility (Thomas Flynn of Luzerne County died in 1840, five years before Patrick’s ~1845 birth). This is direct, primary evidence that eliminates the hypothesis entirely. The ruled_out_reason was properly populated with specific details: the death date, cause, and confident identification (pe_008). The transition was justified, evidence driven, and documented with precision, meeting the schema’s requirements for ruling out a hypothesis. - Pass)"
+    },
+    {
+      "test_id": "ut_hypothesis_tracking_012",
+      "dimension_source": "base",
+      "dimension_name": "Correctness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": "**`ut_hypothesis_tracking_012`** — `base` / `Correctness`\nLLM: 3 → Junior: 3\n\n> Claude's analysis correctly distinguishes between evidence type (direct) and information quality (secondary), accurately reflects the GPS framework, and correctly states that a_013 remains direct evidence despite the secondary informant. The proof summary reference is accurate: ps_001 already rates the conclusion as Probable specifically because of the secondary informant. No factual errors or unsupported claims.\n\nJunior: (Claude’s reasoning was spot on. It refused to downgrade h_001 from supported to active, correctly citing the SKILL.md rule that minor discrepancies (like a secondary informant) do not trigger a downgrade. The analysis clearly distinguished between evidence type (direct vs. indirect) and information quality (primary vs. secondary), explaining that a_013 is still direct evidence because it explicitly names the father, even though the informant was secondary.\nClaude also accurately referenced the proof summary (ps_001) which already accounts for the secondary informant by rating the conclusion as Probable. This shows the proper separation of hypothesis status (threshold met) and proof tier (confidence level). No factual errors, unsupported claims, or misapplications of the GPS framework were present. - Pass)"
+    },
+    {
+      "test_id": "ut_hypothesis_tracking_012",
+      "dimension_source": "base",
+      "dimension_name": "Completeness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": "**`ut_hypothesis_tracking_012`** — `base` / `Completeness`\nLLM: 3 → Junior: 3\n\n> Claude addressed the full user concern: acknowledged the valid genealogical observation about informant quality, explained the distinction between evidence type and information quality, clarified where informant quality matters (proof tier, not hypothesis status), confirmed the supported threshold is still met, and provided forward research recommendations. All required elements were covered.\n\nJunior: (Claude fully addressed the user’s concern. It acknowledged the valid genealogical observation about informant quality, explained the crucial distinction between evidence type (direct vs. indirect) and information quality (primary vs. secondary), and clarified that informant quality affects the proof tier rather than the hypothesis status. Claude confirmed that h_001 still meets the supported threshold (direct evidence present, no contradictions, consistent timeline), and emphasized why downgrading would be inappropriate. It also provided forward looking research recommendations (probate search, extracting assertions from unworked sources) to strengthen the case. Schema validation was performed as required. All elements of the user’s request were covered thoroughly and correctly. - Pass)"
+    },
+    {
+      "test_id": "ut_hypothesis_tracking_012",
+      "dimension_source": "base",
+      "dimension_name": "Tool Arguments",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": "**`ut_hypothesis_tracking_012`** — `base` / `Tool Arguments`\nLLM: 3 → Junior: 3\n\n> Claude made one tool call to validate_research_schema with the correct projectPath argument matching the test context. The SKILL.md requirement to call validate_research_schema at the end of every interaction (including read-only reviews) was met. Arguments match the expected pattern.\n\nJunior: (Claude made the required single tool call to validate_research_schema with the correct projectPath argument. This matches the test context and fulfills the SKILL.md requirement that schema validation must be invoked at the end of every interaction, even when no file changes are made (read only reviews included). The arguments were properly structured, matched expectations, and validation returned clean. No mismatches, missing parameters, or fixture errors occurred. - Pass)"
+    },
+    {
+      "test_id": "ut_hypothesis_tracking_012",
+      "dimension_source": "rubric",
+      "dimension_name": "Claim clarity",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": "**`ut_hypothesis_tracking_012`** — `rubric` / `Claim clarity`\nLLM: 3 → Junior: 3\n\n> Claude clearly restates the hypothesis: 'Thomas Flynn was Patrick Flynn's father, supported by direct evidence from a secondary informant on Patrick's death certificate.' The claim is specific (names both individuals, names the relationship), testable (could be contradicted or supported by additional evidence), and includes sufficient temporal context. The recommendation is unambiguous: h_001 remains supported.\n\nJunior: (Claude restated the hypothesis clearly: “Thomas Flynn was Patrick Flynn’s father, supported by direct evidence from a secondary informant on Patrick’s death certificate.” The claim is specific (names both individuals and the parent–child relationship), testable (future records could confirm or contradict it), and includes sufficient temporal/geographic context (Patrick’s death certificate, Schuylkill County). Claude also made the recommendation unambiguous: h_001 remains supported. The explanation distinguished between evidence type (direct) and information quality (secondary), ensuring the claim is properly classified and understood. This makes the hypothesis precise, evaluable, and genealogically sound. - Pass)"
+    },
+    {
+      "test_id": "ut_hypothesis_tracking_012",
+      "dimension_source": "rubric",
+      "dimension_name": "Evidence linkage",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": "**`ut_hypothesis_tracking_012`** — `rubric` / `Evidence linkage`\nLLM: 3 → Junior: 3\n\n> Claude correctly identifies a_013 as the direct evidence supporting h_001, accurately describes the two census placements as corroborating (though not direct) evidence, and explains that no contradicting assertions remain unresolved. All linked assertions bear directly on the parentage hypothesis. The references to existing sources and unworked plans (src_005, src_006, src_008, src_009, pli_006) are contextual illustrations of where additional evidence might come from, not assertions being wrongly linked.\n\nJunior: (: Claude handled the linkage correctly for h_001:\n•\tSupporting evidence:\no\ta_013 — Patrick Flynn’s death certificate explicitly naming Thomas Flynn as father (direct evidence, though secondary informant).\no\tTwo census placements (a_004, a_010) corroborate the parent–child relationship (indirect evidence).\n•\tContradicting evidence:\no\tNone remain unresolved — no contradictions are linked to h_001.\nAll linked assertions are directly relevant to the parentage hypothesis. Claude also referenced unworked sources and plans (src_005, src_006, src_008, src_009, pli_006) as future research opportunities, not as wrongly linked assertions. This distinction was clear and appropriate. The linkage is complete, accurate, and genealogically sound. - Pass)"
+    },
+    {
+      "test_id": "ut_hypothesis_tracking_012",
+      "dimension_source": "rubric",
+      "dimension_name": "Status transitions",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": "**`ut_hypothesis_tracking_012`** — `rubric` / `Status transitions`\nLLM: 3 → Junior: 3\n\n> Claude correctly refuses to downgrade h_001 from supported to active, explicitly grounding the decision in the supported threshold criteria from research-schema-spec.md: (1) at least one direct evidence assertion present, (2) no unresolved contradictions, (3) consistent timeline. Claude explains that secondary informant quality reduces proof confidence (Probable tier), not hypothesis status. No change was made to the file, which is correct: the hypothesis remains supported and no downgrade occurred.\n\nJunior: (Claude correctly refused to downgrade h_001 from supported to active. The decision was explicitly grounded in the supported threshold criteria from research schema spec.md:\n1.\tAt least one direct evidence assertion present (a_013, Patrick’s death certificate naming Thomas Flynn).\n2.\tNo unresolved contradictions (none linked to h_001).\n3.\tConsistent timeline (census placements and death certificate align).\nClaude explained that the secondary informant quality reduces proof confidence (hence the proof tier is Probable), but does not affect hypothesis status. This distinction between evidence type and information quality was made clear. Importantly, no file changes were made — h_001 remains supported, which is correct and compliant with SKILL.md rules. - Pass)"
+    },
+    {
+      "test_id": "ut_hypothesis_tracking_013",
+      "dimension_source": "base",
+      "dimension_name": "Correctness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": "**`ut_hypothesis_tracking_013`** — `base` / `Correctness`\nLLM: 3 → Junior: 3\n\n> The new hypothesis h_002 is factually grounded. Claude correctly identified Thomas's age (~27 at Patrick's ~1845 birth) as plausible for unclehood, properly assessed that census records lack relationship statements until 1880, and correctly classified a_013 (death cert naming Thomas as father) as contradicting evidence for the uncle hypothesis. All assertions made are supported by the provided research context. The logic that a secondary informant (son-in-law) might assume the household head was the father rather than uncle is sound and consistent with genealogical standards.\n\nJunior: (Claude created the new hypothesis h_002 exactly as required:\n•\tThe claim is specific and testable: “Thomas Flynn of Schuylkill County, Pennsylvania, was Patrick Flynn’s uncle (not his father).”\n•\tStatus was set to active, with related_question_ids: [\"q_001\"] linking it to the same parentage research question.\n•\tSupporting assertions included a_004 and a_010 (census co residence), which are consistent with both father and uncle interpretations.\n•\tContradicting evidence correctly included a_013 (death certificate naming Thomas as father), since that directly conflicts with the uncle hypothesis.\n•\tThe notes field provided genealogically sound reasoning: census records don’t state relationships before 1880, household co residence is ambiguous, and the secondary informant on the death certificate could have assumed fatherhood.\n•\tImportantly, h_001 was left unchanged — still supported — avoiding a Status Transitions failure.\n•\tSchema validation was called and passed.\nAll factual claims (Thomas’s age, census relationship columns, informant quality) are accurate and consistent with genealogical standards. The logic is sound and the file changes match expectations. - Pass)"
+    },
+    {
+      "test_id": "ut_hypothesis_tracking_013",
+      "dimension_source": "base",
+      "dimension_name": "Completeness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": "**`ut_hypothesis_tracking_013`** — `base` / `Completeness`\nLLM: 3 → Junior: 3\n\n> Claude addressed all requirements: created h_002 with a specific, testable claim; set status to active; linked related_question_ids to ['q_001']; included appropriate supporting and contradicting assertion IDs; did not modify h_001; and called validate_research_schema as required. The response included detailed reasoning about evidence evaluation, BCG Standard 45 application, and next steps for testing both hypotheses. No required elements were omitted.\n\nJunior: (Claude met all the requirements for creating the new hypothesis:\n•\tCreated h_002 with a clear, specific, and testable claim: Thomas Flynn of Schuylkill County was Patrick Flynn’s uncle (not his father).\n•\tStatus set to active as appropriate for a competing but unproven hypothesis.\n•\tLinked related_question_ids to [\"q_001\"], ensuring it competes with h_001 for the same parentage research question.\n•\tSupporting assertions: included a_004 and a_010 (census co residence), which are consistent with both father and uncle interpretations.\n•\tContradicting evidence: correctly listed a_013 (death certificate naming Thomas as father), since that directly conflicts with the uncle claim.\n•\tDid not modify h_001 — it remains supported, avoiding a Status Transitions failure.\n•\tCalled validate_research_schema at the end, as required by SKILL.md.\n•\tResponse reasoning: explained the evidentiary logic, referenced BCG Standard 45 about household inference, and outlined next steps (probate search, baptismal record, sibling identification).\nAll required elements were covered thoroughly, with no omissions. - Pass)"
+    },
+    {
+      "test_id": "ut_hypothesis_tracking_013",
+      "dimension_source": "base",
+      "dimension_name": "Tool Arguments",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": "**`ut_hypothesis_tracking_013`** — `base` / `Tool Arguments`\nLLM: 3 → Junior: 3\n\n> Both MCP tool calls were executed correctly. The first call (research_append) included all required arguments: projectPath, section ('hypotheses'), op ('append'), and a complete, well-formed entry object with claim, status, assertion IDs, related_question_ids, and comprehensive notes. The second call (validate_research_schema) correctly validated the project. No critical identifiers were wrong, no fixture_not_found errors occurred, and the args matched the expected shape for genealogy research operations.\n\nJunior: (: Claude executed both tool calls correctly:\n•\tresearch_append call:\no\tIncluded all required arguments: projectPath, section: \"hypotheses\", op: \"append\".\no\tThe entry object was complete and well formed, with:\n\tA clear, specific claim (Thomas Flynn of Schuylkill County was Patrick Flynn’s uncle).\n\tstatus: \"active\".\n\tsupporting_assertion_ids: [\"a_004\",\"a_010\"] (census co residence).\n\tcontradicting_assertion_ids: [\"a_013\"] (death certificate naming Thomas as father).\n\trelated_question_ids: [\"q_001\"].\n\tComprehensive notes explaining the evidentiary reasoning and next steps.\n•\tvalidate_research_schema call:\no\tCorrectly invoked with the same projectPath.\no\tValidation passed cleanly, confirming schema compliance.\nNo identifiers were incorrect, no fixture errors occurred, and the arguments matched the expected shape for genealogy research operations. This was a precise and compliant execution. - Pass)"
+    },
+    {
+      "test_id": "ut_hypothesis_tracking_013",
+      "dimension_source": "rubric",
+      "dimension_name": "Claim clarity",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": "**`ut_hypothesis_tracking_013`** — `rubric` / `Claim clarity`\nLLM: 3 → Junior: 3\n\n> The claim is highly specific and testable: 'Thomas Flynn of Schuylkill County, Pennsylvania, was Patrick Flynn's uncle (not his father) — Patrick was a nephew raised in Thomas's household.' It names both specific persons (Thomas Flynn, Patrick Flynn), the specific relationship being hypothesized (uncle, not father), includes geographic detail (Schuylkill County, Pennsylvania), and specifies the timeframe context (~1845 birth). A follow-up search for a will, baptism record, or Thomas's siblings could directly test this claim.\n\nJunior: (The new hypothesis h_002 is articulated with precision: “Thomas Flynn of Schuylkill County, Pennsylvania, was Patrick Flynn’s uncle (not his father) — Patrick was a nephew raised in Thomas’s household.”\n•\tSpecific persons named: Thomas Flynn and Patrick Flynn.\n•\tRelationship clearly defined: uncle–nephew, explicitly contrasted with the father–son claim.\n•\tGeographic detail: Schuylkill County, Pennsylvania.\n•\tTemporal context: Patrick’s ~1845 birth, Thomas’s age (~27 at that time).\n•\tTestability: The claim can be directly tested by records such as Thomas Flynn’s will (naming Patrick as son or nephew), Patrick’s baptismal record (naming actual parents), or records of Thomas’s siblings.\nThe hypothesis is concrete, evaluable, and framed in a way that genealogical research can confirm or refute. The recommendation is unambiguous: h_002 remains active until further evidence is gathered. - Pass)"
+    },
+    {
+      "test_id": "ut_hypothesis_tracking_013",
+      "dimension_source": "rubric",
+      "dimension_name": "Evidence linkage",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": "**`ut_hypothesis_tracking_013`** — `rubric` / `Evidence linkage`\nLLM: 3 → Junior: 3\n\n> All linked assertions are directly relevant to the uncle hypothesis. a_004 and a_010 (census co-residence) are appropriately included as supporting evidence because co-residence is equally consistent with uncle-nephew as with father-son relationships. a_013 (death cert naming Thomas as father) is correctly placed in contradicting_assertion_ids because it directly states a paternal relationship, which contradicts the uncle claim. Claude explicitly reasoned why each assertion was linked, citing BCG Standard 45 and informant reliability. No tangential evidence was included.\n\nJunior: (Claude linked the assertions appropriately for h_002:\n•\tSupporting evidence:\no\ta_004 — 1850 census, Patrick in Thomas’s household.\no\ta_010 — 1860 census, Patrick in Thomas’s household. These are correctly treated as supporting because household co residence is consistent with both father–son and uncle–nephew relationships. Claude explicitly noted that assuming household position implies fatherhood is an unsound assumption per BCG Standard 45.\n•\tContradicting evidence:\no\ta_013 — Patrick’s death certificate naming Thomas as father. This was correctly placed in contradicting_assertion_ids since it directly conflicts with the uncle hypothesis. Claude explained why the informant’s secondary nature (son in law James Brown) could have led to a mistaken assumption.\nNo tangential or irrelevant assertions were included. Each link was justified with genealogical reasoning, and the distinction between supporting and contradicting evidence was clear and accurate. - Pass)"
+    },
+    {
+      "test_id": "ut_hypothesis_tracking_013",
+      "dimension_source": "rubric",
+      "dimension_name": "Status transitions",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": "**`ut_hypothesis_tracking_013`** — `rubric` / `Status transitions`\nLLM: 3 → Junior: 3\n\n> The status transition is properly justified. h_002 is marked 'active' (not 'supported' or 'ruled_out'), which is correct: there is no direct positive evidence for the uncle hypothesis, and the contradicting death certificate assertion is unresolved. Claude explicitly explained why h_002 remains active despite a_013: the informant is secondary and the assertion does not constitute definitive refutation under genealogical standards. h_001 remains 'supported' and unmodified. The schema-spec.md §5.9 rules are followed: supported requires direct evidence with no unresolved contradictions; ruled_out requires affirmative refutation; h_002 has neither, so active is the correct status.\n\nJunior: (: Claude handled the status assignment correctly:\n•\th_002 was created with status active, which is appropriate because:\no\tThere is no direct positive evidence supporting the uncle hypothesis.\no\tThe death certificate (a_013) directly contradicts the uncle claim, but since the informant was secondary, this contradiction does not rise to the level of affirmative refutation required for ruled_out.\n•\tClaude explicitly explained why the hypothesis remains active despite the contradiction: genealogical standards recognize that secondary informants may misreport relationships, so the contradiction is unresolved rather than definitive.\n•\th_001 remained supported and unmodified, avoiding a downgrade error.\n•\tThe reasoning aligns with research schema spec.md §5.9:\no\tSupported requires direct evidence with no unresolved contradictions.\no\tRuled_out requires affirmative refutation.\no\tActive is correct when neither threshold is met.\nThis was a precise and standards compliant status transition. - Pass)"
+    }
+  ]
+}

--- a/eval/runlogs/unit/hypothesis-tracking/v1_2026-06-29_22-28-20.json
+++ b/eval/runlogs/unit/hypothesis-tracking/v1_2026-06-29_22-28-20.json
@@ -1,0 +1,3914 @@
+{
+  "schema_version": 2,
+  "skill": "hypothesis-tracking",
+  "version": 1,
+  "released": false,
+  "releasable": true,
+  "invocation": "skill",
+  "timestamp": "2026-06-29_22-28-20",
+  "harness_version": "0.1.0",
+  "model": "claude-sonnet-4-6",
+  "judge_prompt_hash": "adea6e4cb2c9ddf0c436c31e893da766866cc67ed749df0a7c6b8a9df52c6914",
+  "snapshot": {
+    "packages/engine/plugin/skills/hypothesis-tracking/SKILL.md": "---\nname: hypothesis-tracking\nmodel: claude-sonnet-4-6\ndescription: Creates, updates, and reviews hypotheses about person identity,\n  parentage, and relationships. Links supporting and contradicting\n  assertions, manages status transitions (active \u2192 supported \u2192 ruled_out),\n  tracks competing candidates, and summarizes hypothesis status. GPS\n  Step 3-4 \u2014 Analysis, Correlation, and Resolution (hypothesis management).\n  Use when the user says \"I think [claim]\", \"track this hypothesis\",\n  \"could this be [candidate]?\", \"are there competing candidates?\", \"update\n  the hypothesis\", \"rule this out\", \"where do hypotheses stand?\", \"review\n  the hypotheses\", \"summarize hypothesis status\", \"add [person] as a\n  candidate\", \"add a third candidate\", when competing identity candidates\n  exist, when a conflict suggests multiple possible explanations, or when\n  the user wants to organize or review evidence for and against a claim. Do NOT use when the user wants to resolve a specific fact conflict\n  (use conflict-resolution), wants to build a timeline (use timeline), or\n  wants to write a final conclusion (use proof-conclusion).\nallowed-tools:\n  - research_append\n  - validate_research_schema\n---\n\n## Step 0 \u2014 Scope gate (MANDATORY, before any file reads)\n\nClassify the user's request into exactly one category:\n\n| Request pattern | Classification | Action |\n|---|---|---|\n| \"resolve this conflict\", \"weigh these assertions\", \"choose between\", \"which is correct\" | **conflict-resolution** | Reply: \"This is a conflict-resolution task \u2014 please use the conflict-resolution skill.\" Then STOP. |\n| \"build a timeline\", \"create a timeline\" | **timeline** | Reply: \"This is a timeline task \u2014 please use the timeline skill.\" Then STOP. |\n| \"write a proof\", \"proof conclusion\", \"write the conclusion\" | **proof-conclusion** | Reply: \"This requires proof-conclusion \u2014 please use the proof-conclusion skill.\" Then STOP. |\n| Anything about creating, updating, reviewing, or tracking hypotheses | **in scope** | Proceed below. |\n\nIf the classification is NOT \"in scope\": output the one-sentence reply shown above and **produce no other output** \u2014 no file reads, no tool calls, no analysis. This is a hard constraint, not a suggestion.\n\n# Hypothesis Tracking\n\n**Narration:** Read `researcher_profile.narration_guidance` from `research.json` and apply it as your narration style for this invocation. If absent, default to a one-line preamble per action.\n\n**All writes to the `hypotheses` section go through `research_append`** \u2014 it assigns the `h_` id, validates before persisting, and writes atomically. On `{ ok: false, errors }` it writes nothing \u2014 surface those errors and fix the input rather than retrying blindly.\n\n**Call `validate_research_schema` at the end of every interaction** \u2014 including read-only reviews. This is mandatory.\n\n**Read-only detection:** If the user asks for a summary, review, or\nstatus check without requesting changes (\"where do things stand?\",\n\"give me a quick summary\"), this is a **read-only review**. Present\nthe hypothesis states, note any issues you see, but do NOT modify\n`research.json` or `tree.gedcomx.json`. Mention needed changes in your\ntext response and let the user decide whether to proceed.\n\n**Read `references/hypothesis-gps-guidance.md`** before creating or\nevaluating any hypothesis \u2014 it covers leads vs hypotheses, the three\ncategories of assumptions, and compiled-source verification.\n\n## When to use hypotheses\n\nHypotheses are most valuable when:\n- **Multiple candidates exist.** \"Patrick Flynn's father could be\n  Thomas Flynn of Schuylkill County OR Thomas Flynn of Luzerne County.\"\n- **Identity is uncertain.** \"The Patrick Flynn in the 1870 census\n  may or may not be our subject.\"\n- **A relationship is claimed but not proven.** \"Patrick Flynn's\n  father was Thomas Flynn\" \u2014 a hypothesis until GPS proof standards.\n- **A compiled source names a relationship.** A family tree says\n  \"Phoebe's father was Daniel\" \u2014 this is a lead, not a fact. Create\n  a hypothesis and plan targeted research to verify or refute it.\n\nSimple, uncontested facts don't need hypotheses \u2014 they go directly\nfrom assertions to proof-conclusion.\n\n**Decision rule:** Create a hypothesis when (a) multiple candidates\ncompete, (b) the claim rests on a compiled source needing verification,\nor (c) evidence exists on both sides. If all evidence points one\ndirection with no competition or conflict, skip to proof-conclusion.\n\n## Create a hypothesis\n\n**Source awareness:** Before creating, identify WHERE the claim\noriginated. If from a compiled source (family tree, online genealogy,\npublished narrative), mark it as needing verification \u2014 compiled\nsources are leads, not evidence.\n\n**New hypotheses always start as `active`.** Even if existing\nevidence strongly favors the hypothesis, set `status: \"active\"` at\ncreation. Promotion to `supported` happens in a separate evaluation\nstep after evidence is explicitly reviewed against the criteria below.\n\nCreate with `research_append({ section: \"hypotheses\", op: \"append\", entry: { claim, status: \"active\", supporting_assertion_ids: [], contradicting_assertion_ids: [], ruled_out: false, ruled_out_reason: null, notes, related_question_ids } })` \u2014 the tool assigns the `h_` id.\n\n**Claim requirements:** State the claim positively and specifically,\ninclude enough detail to distinguish from competing hypotheses, and\nreference the person(s) involved.\n\n**related_question_ids:** Link the hypothesis to the research\nquestions it helps answer.\n\n## Link evidence\n\nAs assertions are extracted and linked to persons, evaluate whether\nthey support or contradict each active hypothesis. Update with\n`research_append({ section: \"hypotheses\", op: \"update\", entryId: \"h_NNN\", fields: { supporting_assertion_ids: [...] } })` \u2014 pass only the fields that change.\n\n**Design research to refute, not just confirm.** For each active\nhypothesis, ask: \"What evidence would DISPROVE this?\" Prioritize\nsearching for that evidence. A hypothesis that survives deliberate\nrefutation is far stronger than one with only confirmatory searches.\n\n**Supporting evidence:** Assertions that make the claim more likely \u2014\nadd to `supporting_assertion_ids`.\n\n**Contradicting evidence:** Assertions that make the claim less\nlikely \u2014 add to `contradicting_assertion_ids`.\n\n**FAN evidence is regular assertions.** Witness patterns, neighbor\ncorrelations, godparent relationships \u2014 link them via\n`supporting_assertion_ids` like any other evidence. No special FAN\nentity.\n\n## Status transitions\n\n```\nactive \u2500\u2500\u25ba supported \u2500\u2500\u25ba (to proof-conclusion)\n  \u2502\n  \u2514\u2500\u2500\u25ba ruled_out\n```\n\n**`active`** \u2014 Evidence accumulating, no threshold crossed. Starting state.\n\n**`supported`** \u2014 Transition when ALL of these are true:\n- At least one line of direct evidence supports the claim (an\n  assertion with `evidence_type: \"direct\"` in the supporting list)\n- No unresolved contradictions remain (contradicting assertions have\n  been explained, resolved via conflict-resolution, or outweighed)\n- The evidence is consistent \u2014 no timeline impossibilities\n\n**Do NOT downgrade from `supported` to `active` for minor\ndiscrepancies.** Census age rounding (e.g., a 5-year birth year\ndifference) is normal in 19th-century records and does not constitute\nan \"unresolved contradiction.\" Adding contradicting evidence does not\nautomatically require a status downgrade \u2014 only link the evidence and\nleave the status unchanged unless the contradiction is material enough\nto undermine the core claim. When the user explicitly tells you a\ndiscrepancy \"doesn't disprove anything,\" respect that assessment if\nit is genealogically reasonable.\n\n**`ruled_out`** \u2014 Transition when ANY of these are true:\n- Evidence affirmatively refutes the claim (e.g., a will names all\n  children and Patrick is absent \u2014 negative evidence)\n- Exhaustive elimination logic excludes the candidate\n- A chronological or biological impossibility makes the hypothesis\n  untenable (candidate was dead before subject was born, or too young\n  to be a biological parent)\n\n**Act on impossibilities immediately \u2014 unless this is a read-only\nreview.** When the user asks you to update or evaluate a hypothesis\nand the age arithmetic shows a candidate was 10 years old at the\nsubject's birth, that is a biological impossibility \u2014 rule it out in\nthis interaction. Do NOT defer to conflict-resolution or hedge on\nperson_evidence confidence when the link is rated `confident`\n(match_score >= 0.80) \u2014 treat the identification as settled and apply\nthe ruling. **Exception:** if the user explicitly asks for a read-only\nsummary/review, do NOT modify research.json \u2014 identify the issue in\nyour response text but defer changes to a follow-up request.\n\nWhen ruling out, `ruled_out_reason` is REQUIRED \u2014 the validator\nrejects the entry if it is missing. Be specific: state the\naffirmative refutation, not just \"insufficient evidence.\"\n\n## Competing hypotheses\n\nWhen multiple hypotheses compete for the same conclusion (e.g., two\ncandidate fathers): create one hypothesis per candidate, share\n`related_question_ids`, and note that the same assertion may support\none and contradict another. Rule out candidates as evidence\naccumulates \u2014 the GPS process of elimination.\n\n## Example: Tracking the elimination process\n\n| Hypothesis | Candidate | Status | Supporting | Contradicting |\n|---|---|---|---|---|\n| h_001 | Thomas Flynn, Schuylkill Co. | supported | a_004, a_010, a_013 | (none) |\n| h_002 | Thomas Flynn, Luzerne Co. | ruled_out | a_035 (same-name, right age) | a_036 (died 1840), a_037 (will excludes Patrick) |\n| h_003 | James Flynn, Carbon Co. | active | a_040 (Patrick age match) | (none yet) |\n\n## Connect to downstream skills\n\n- **timeline:** Request a hypothesis-testing timeline to check event coherence.\n- **conflict-resolution:** When supporting and contradicting evidence exist, specific conflicts may need resolution.\n- **proof-conclusion:** When a hypothesis reaches `supported`, it's ready for a proof conclusion.\n\n## Present\n\nAfter writes succeed, present the hypothesis state clearly:\n\n```\nHypothesis: h_001 \u2014 Patrick Flynn's father was Thomas Flynn\n            of Schuylkill County\nStatus:     SUPPORTED\n\nSupporting evidence (3):\n  + a_004  1850 census: Patrick in Thomas's household (indirect)\n  + a_010  1860 census: Patrick in Thomas's household (indirect)\n  + a_013  Death certificate: \"Father: Thomas Flynn\" (direct)\n\nContradicting evidence (0):  (none)\n\nCompeting hypotheses:\n  h_002  Thomas Flynn of Luzerne County \u2014 RULED OUT\n  h_003  James Flynn of Carbon County \u2014 ACTIVE (needs more research)\n\nNext steps:\n  - h_001 is ready for proof-conclusion\n  - h_003 needs more evidence \u2014 suggest question-selection\n```\n\n## Important rules\n\n- **Scope discipline \u2014 only modify what the user asked about.** If the\n  user asks to create h_003, only create h_003. Do NOT proactively fix,\n  update, downgrade, or rule out other hypotheses you notice have issues\n  \u2014 even if you believe the status is wrong. Never change a hypothesis's\n  status unless the user explicitly asked you to evaluate that specific\n  hypothesis. Mention observations in your response text and let the\n  user decide.\n- **Never modify the `conflicts` section.** Owned exclusively by\n  conflict-resolution. Create entries in `hypotheses` only.\n- **Never create or modify the `questions` section.** Managed by\n  question-selection and research-exhaustiveness. Leave\n  `related_question_ids` as `[]` if no questions exist.\n- **Never modify `tree.gedcomx.json`.** This skill only writes to the\n  `hypotheses` section of `research.json`.\n- **Hypotheses are claims, not facts.** Status reflects actual\n  evidence, not researcher preference.\n- **ruled_out_reason is mandatory.** The reason is the audit trail \u2014\n  it prevents accidentally resurrecting a ruled-out candidate.\n- **Don't confuse hypothesis status with proof tier.** A `supported`\n  hypothesis is ready for proof-conclusion, but the proof tier\n  (Proved/Probable/Possible) depends on the full body of evidence.\n- **Never ignore conflicting evidence.** Every assertion that conflicts\n  with a hypothesis MUST go in `contradicting_assertion_ids`. Record\n  it first, resolve later via conflict-resolution.\n- **Check for unstated assumptions.** When linking evidence, ask: \"Does\n  this actually support the claim, or am I relying on an unstated\n  assumption?\" See the three assumption categories in\n  `references/hypothesis-gps-guidance.md`.\n\n## Re-invocation behavior\n\nUpdates existing hypotheses in place. Creates a new `h_` entry only for a genuinely new hypothesis. If a hypothesis about the same claim already exists, update it (or mark it superseded via `superseded_by`) \u2014 do not duplicate.\n",
+    "packages/engine/plugin/skills/hypothesis-tracking/references/hypothesis-gps-guidance.md": "# Hypothesis GPS Guidance\n\nReference material for forming, testing, and evaluating genealogical\nhypotheses according to the Genealogical Proof Standard and BCG\nstandards for evidence reasoning.\n\n---\n\n## The Compiled-Source Verification Pattern\n\nA common genealogical workflow: you find a claim in a compiled source\n(online family tree, published genealogy, indexed database) and need\nto verify it. The correct sequence is:\n\n1. **Identify the claim as a lead.** The compiled source says\n   \"Phoebe's father was Daniel McCurdy.\" This is not a fact \u2014 it is\n   a claim made by another researcher, possibly without documentation.\n\n2. **Form a hypothesis.** State it testably: \"Daniel B. McCurdy of\n   Berkshire Township, Delaware County, Ohio, was the father of\n   Phoebe McCurdy (born 3 November 1827).\"\n\n3. **Plan targeted verification research.** Identify original records\n   that would confirm or refute the claim: probate records, land\n   deeds, tax lists, church records, censuses showing household\n   composition, etc.\n\n4. **Execute the research and evaluate.** Did original records\n   corroborate the compiled source's claim? Did any contradict it?\n   Are there gaps that prevent a conclusion?\n\n5. **Reach a conclusion or identify next steps.** Either the\n   hypothesis is supported by original evidence, refuted by it, or\n   more research is needed.\n\nThe key principle: compiled sources generate leads. Only original\nrecords and careful reasoning produce conclusions. Never skip from\nstep 1 to step 5.\n\n---\n\n## Evidence Mining (BCG Standard 40)\n\nWhen gathering evidence related to a hypothesis, the standard\nrequires:\n\n- **Seek all three evidence types.** Look for direct evidence\n  (statements that explicitly answer the question), indirect evidence\n  (information that implies an answer when combined with other\n  evidence), and negative evidence (the absence of expected\n  information from records where it should appear).\n\n- **Attend to details.** Seemingly insignificant details may become\n  critical. Witness names on documents, neighbors on census pages,\n  bondsmen on marriage records \u2014 these provide indirect evidence\n  about relationships.\n\n- **Never ignore inconvenient evidence.** If evidence conflicts with\n  or complicates the working hypothesis, it MUST be recorded and\n  addressed. A hypothesis that survives only because conflicting\n  evidence was overlooked or suppressed is not sound. This is the\n  single most common failure in hypothesis evaluation.\n\n- **Equal attention to all evidence.** Do not privilege direct\n  evidence and dismiss indirect or negative evidence. A thorough\n  search of probate records that produces no mention of the subject\n  (negative evidence) can be as significant as a will that names\n  them (direct evidence).\n\n---\n\n## Evidence Integrity (BCG Standard 43)\n\nEvidence must be recorded as it actually exists in the source, not\nas the researcher wishes it to be:\n\n- Do not trim quotations to remove parts that undermine a hypothesis.\n- Do not reinterpret ambiguous statements to favor one reading over\n  another without explicitly noting the ambiguity.\n- Do not slight evidence by dismissing it without analysis (e.g.,\n  \"this record is probably wrong\" without explaining why).\n- Do not harmonize conflicting evidence by assuming one source made\n  an error without articulating the reasoning.\n\nWhen evidence conflicts with a hypothesis, the proper response is to\nrecord the conflict, analyze the reliability of the conflicting\nsource and informant, and either resolve the conflict through\nreasoned analysis or acknowledge that the conflict remains\nunresolved.\n\n---\n\n## Three Categories of Assumptions (BCG Standard 45)\n\nEvery hypothesis evaluation involves assumptions. Recognizing and\ncategorizing them prevents unsound reasoning.\n\n### Fundamental Assumptions\n\nUniversally accepted truths requiring no supporting evidence:\n\n- A person cannot perform actions after their death or before their\n  birth\n- Travel between places requires time consistent with available\n  technology of the era\n- A person can only be in one place at a time\n- Biological relationships follow physical laws (gestation period,\n  etc.)\n\nUse freely in reasoning. These form the basis of timeline\nimpossibility tests.\n\n### Valid Assumptions\n\nGenerally accepted as true unless convincingly contradicted:\n\n- Women bearing children are typically between approximately 12 and\n  49 years old\n- Personal behavior and life patterns show coherence over time\n- People generally observed the legal, moral, and social norms of\n  their time and place\n- Family members tend to cluster geographically and occupationally\n\nUse in reasoning, but actively look for evidence that would overturn\nthem. If no contradicting evidence is found after appropriate\nsearching, they can support a hypothesis. If contradicted, abandon\nthem.\n\n### Unsound Assumptions\n\nMay be true but CANNOT be accepted without supporting evidence:\n\n- That a man's widow was the mother of his children (she may be a\n  second or third wife)\n- That migrating families followed popular routes (some took unusual\n  paths)\n- That a bride's surname is her parents' surname (she may have been\n  previously married, or the name may be from a stepfather)\n- That a person with the same name in the same area is the same\n  individual\n- That absence from a record means the person was not present (the\n  record may be incomplete)\n\nThese MUST have supporting evidence before they can be incorporated\ninto hypothesis evaluation. Without evidence, they are speculation\nand carry zero weight.\n\n### Applying the Framework\n\nWhen you link an assertion to a hypothesis as supporting or\ncontradicting evidence, check:\n\n1. Does the connection rely on any unstated assumption?\n2. If yes, what category does that assumption fall into?\n3. If unsound, is there independent evidence supporting the\n   assumption? If not, the link is weaker than it appears.\n\nExample: \"Patrick Flynn lived near Thomas Flynn in 1860\" supports\nthe hypothesis \"Thomas was Patrick's father\" only through an\nunstated assumption \u2014 that proximity implies relationship. This is\nan unsound assumption. It becomes valid only if combined with other\nevidence (household membership, stated relationship, naming\npatterns, etc.).\n\n---\n\n## Hypothesis Testing Through Targeted Research\n\nA hypothesis is only as good as the research designed to test it.\nEffective testing follows these principles:\n\n### Design research to refute, not just confirm\n\nFor each hypothesis, ask: \"What evidence would DISPROVE this claim?\"\nThen search for that evidence specifically. A hypothesis that\nsurvives deliberate attempts at refutation is stronger than one\nsupported only by confirmatory searches.\n\n### Test competing hypotheses in parallel\n\nWhen multiple candidates exist, plan research that can distinguish\nbetween them. The same record set may support one candidate and\neliminate another. Efficient research tests all active hypotheses\nsimultaneously where possible.\n\n### Use elimination to strengthen survivors\n\nEach candidate ruled out strengthens the remaining candidates by\nreducing the field. Document the elimination clearly \u2014 the\nruled_out_reason on each eliminated hypothesis contributes to the\noverall proof argument for the surviving candidate.\n\n### Recognize when testing is incomplete\n\nA hypothesis can be \"supported\" only relative to the research\nconducted. If obvious record sets remain unsearched, or known\ncandidates remain uninvestigated, the support is provisional. Note\nwhat further testing would strengthen or weaken the conclusion.\n\n---\n\n## Common Hypothesis Errors to Avoid\n\n1. **Accepting a compiled source as proven.** A claim in a family\n   tree is a lead, not evidence. Always verify against original\n   records.\n\n2. **Confirmation bias.** Searching only for evidence that supports\n   the preferred hypothesis while neglecting sources that might\n   contradict it.\n\n3. **Premature closure.** Declaring a hypothesis supported before\n   investigating all known competing candidates or consulting all\n   accessible relevant sources.\n\n4. **Unstated assumptions.** Building chains of reasoning on\n   unexamined assumptions, particularly unsound ones.\n\n5. **Ignoring negative evidence.** Failing to note when a thorough\n   search of expected records produces no mention of the subject.\n   Absence from records where presence is expected is itself evidence.\n\n6. **Conflating correlation with causation.** Same-name individuals\n   in proximity are correlated, not necessarily related. Additional\n   evidence is needed to establish the connection.\n\n7. **Status inflation.** Marking a hypothesis as \"supported\" when\n   contradicting evidence exists but has not been resolved. Unresolved\n   contradictions block the transition to supported status.\n",
+    "packages/engine/plugin/skills/hypothesis-tracking/references/validation-protocol.md": "# Validation Protocol\n\n1. **Schema validation is automatic.** Writes go through the\n   persistence tools (`research_append`, `tree_edit`, the merge tools),\n   which validate every entry before persisting and write nothing on\n   `{ ok: false, errors }`. There is no separate post-write\n   `validate-schema` step \u2014 surface the returned errors and fix the\n   input instead. (`validate-schema` remains available as a manual\n   audit tool when you want to re-check an existing project.)\n\n2. **Invoke `check-warnings`** if you added assertions or\n   person_evidence entries. This checks for genealogical\n   impossibilities (married before 12, died after 120, child born\n   after parent's death, etc.). It is not auto-triggered \u2014 you must\n   invoke it explicitly.\n",
+    "eval/tests/unit/hypothesis-tracking/negative-conflict-resolution.json": "{\n  \"input\": {\n    \"scenario\": \"mid-research-flynn\",\n    \"scenario_notes\": null,\n    \"user_message\": \"I noticed h_001 has three assertions linked as supporting evidence, but there are other assertions in research.json that seem relevant to the Thomas Flynn parentage claim \u2014 like a_005 which identifies Thomas Flynn by name in the 1850 census. Can you review the unlinked assertions and add any that also support the hypothesis?\"\n  },\n  \"judge_context\": [\n    \"Claude should add at least a_005 (Thomas Flynn's name as head of household in the 1850 census) to h_001's supporting_assertion_ids. a_005 identifies the candidate father by name in the same record where Patrick appears as a household member. It is indirect evidence bearing on the parentage claim. Claude may also identify other unlinked assertions as relevant \u2014 a_008 (Patrick's name in the 1860 census, identifying the subject in the household where Thomas is head) is a reasonable addition. Not every assertion needs to be linked; Claude should exercise judgment about which assertions directly bear on the parentage claim versus which are about Patrick's identity, birth facts, or residence.\",\n    \"Claude should NOT change h_001's status from supported. The hypothesis is already at the correct status. Adding more supporting assertions to an already-supported hypothesis does not trigger a status transition. If Claude changes the status in any direction, that is a Status Transitions failure.\",\n    \"The scenario has a resolved birthplace conflict (c_001: Ireland vs Pennsylvania). Claude should not treat this as an unresolved contradiction affecting h_001 \u2014 the conflict is about birthplace, not parentage, and it is already resolved in favor of Ireland. If Claude downgrades h_001 because of c_001, that is a Correctness failure.\",\n    \"Claude must call validate_research_schema after modifying the hypothesis. GRADING NOTE: Evaluate based on the ACTUAL file content written to research.json (the file_changes diff), not solely on what Claude says in its text response. If the file_changes diff shows a_005 added to supporting_assertion_ids and status remains supported, score Correctness as pass.\"\n  ],\n  \"mcp_fixtures\": [\n    \"validate-research-schema\"\n  ],\n  \"test\": {\n    \"id\": \"ut_hypothesis_tracking_003\",\n    \"skill\": \"hypothesis-tracking\",\n    \"type\": \"positive\"\n  }\n}\n",
+    "eval/tests/unit/hypothesis-tracking/new-hypothesis-from-conflict.json": "{\n  \"input\": {\n    \"scenario\": \"flynn-multi-conflict\",\n    \"user_message\": \"Given the identity conflict c_002 about which Patrick Flynn in 1850 is the subject, can we formulate this as testable hypotheses?\"\n  },\n  \"judge_context\": [\n    \"Should create one or more new `h_` entries representing the alternative identifications \u2014 e.g., 'The Patrick Flynn in the Thomas Flynn household (dwelling 84) is the subject' as one hypothesis\",\n    \"Should populate `supporting_assertion_ids` and `contradicting_assertion_ids` with the existing assertions that bear on each hypothesis (the 1850 census assertion a_001, the 1860 census assertion a_008 if it ties to the same household, etc.)\",\n    \"Should set `related_question_ids: [\\\"q_001\\\"]` since the identity conflict blocks q_001\",\n    \"GRADING NOTE: Evaluate Completeness based on the ACTUAL file content written to research.json (the file_changes diff), not solely on what Claude says in its text response. If the file_changes diff shows complete h_ entries with all required schema fields (id, claim, status, supporting_assertion_ids, contradicting_assertion_ids, ruled_out, related_question_ids, notes), score Completeness as pass.\"\n  ],\n  \"mcp_fixtures\": [\n    \"validate-research-schema\"\n  ],\n  \"test\": {\n    \"id\": \"ut_hypothesis_tracking_002\",\n    \"skill\": \"hypothesis-tracking\",\n    \"type\": \"positive\"\n  }\n}\n",
+    "eval/tests/unit/hypothesis-tracking/review-parentage-hypothesis.json": "{\n  \"input\": {\n    \"scenario\": \"mid-research-flynn\",\n    \"user_message\": \"What's the status of our hypothesis that Thomas Flynn was Patrick's father?\"\n  },\n  \"judge_context\": [\n    \"Should cite the three supporting assertions (a_004 from 1850 co-residence, a_010 from 1860 household co-residence, a_013 from death certificate) and explain why each supports the hypothesis with reference to its evidence type\",\n    \"Should note that `contradicting_assertion_ids` is empty \u2014 no evidence currently refutes the parentage claim\",\n    \"Should identify probate as the most likely next source of corroborating evidence (or refutation), since pli_006 is still in_progress\"\n  ],\n  \"mcp_fixtures\": [\n    \"validate-research-schema\"\n  ],\n  \"test\": {\n    \"id\": \"ut_hypothesis_tracking_001\",\n    \"skill\": \"hypothesis-tracking\",\n    \"type\": \"positive\"\n  }\n}\n",
+    "eval/tests/unit/hypothesis-tracking/rubric.md": "# Hypothesis Tracking Rubric\n\nGrading dimensions for hypothesis-tracking unit tests. Evaluated by the LLM judge alongside the three base dimensions (Correctness, Completeness, Tool Arguments).\n\n## Claim clarity\n\nIs the hypothesis stated as a specific, testable claim? \"Thomas Flynn might be related\" is vague. \"Thomas Flynn of Schuylkill County was the father of Patrick Flynn\" is testable.\n\n- **pass:** Claim names specific persons, the specific relationship/fact being hypothesized, and includes enough place/time detail that a follow-up search could test it.\n- **partial:** Claim is specific about the relationship but vague about the persons (uses \"an immigrant from Ireland\" rather than naming the candidate), or vice versa.\n- **fail:** Claim is too vague to test (\"Patrick had Irish ancestry\") or so broad it can't be ruled out by any evidence.\n\n## Evidence linkage\n\nAre supporting and contradicting assertions correctly linked? Each linked assertion should genuinely bear on the hypothesis \u2014 tangential evidence should not be included.\n\n- **pass:** Every `supporting_assertion_ids` and `contradicting_assertion_ids` entry is a direct or indirect statement about the hypothesized fact; no off-topic links.\n- **partial:** Mostly relevant linkage but at least one assertion is tangential (e.g., a residence assertion linked to a parentage hypothesis with no connecting reasoning).\n- **fail:** Linkage is arbitrary \u2014 assertions are dropped in without clear bearing on the claim.\n\n## Status transitions\n\nAre status transitions justified? A hypothesis should move to \"supported\" only with direct evidence and no unresolved contradictions. \"Ruled out\" requires affirmative refutation, not just lack of evidence.\n\n- **pass:** Status transitions match the research-schema-spec.md \u00a75.9 rules \u2014 `supported` only with direct positive evidence and no unresolved contradictions; `ruled_out` only with affirmative refutation; `ruled_out_reason` populated when `ruled_out: true`.\n- **partial:** Transition is plausible but the threshold is debatable (status moved to `supported` on the strength of indirect evidence alone).\n- **fail:** Hypothesis moved to `ruled_out` due to lack of evidence rather than refuting evidence, or `supported` declared in the face of unresolved contradictions.\n",
+    "eval/tests/unit/hypothesis-tracking/ut_hypothesis_tracking_004.json": "{\n  \"input\": {\n    \"scenario\": \"flynn-competing-fathers\",\n    \"scenario_notes\": null,\n    \"user_message\": \"I just found a death record showing Thomas Flynn of Luzerne County died in 1840. Update hypothesis h_002.\\\" makes sense \u2014 Claude can look at the research.json, find h_002, see the death assertion a_016, and reason about the timeline impossibility.\"\n  },\n  \"judge_context\": [\n    \"The death record directly refutes the parentage claim \u2014 it belongs in contradicting_assertion_ids because it makes the hypothesis impossible, not in supporting. A candidate father who died five years before the child's birth is a chronological impossibility, the strongest form of refutation, so the status should move to ruled_out with a specific ruled_out_reason citing the death date and the timeline gap. The key distinction: this ruling-out is justified because there's affirmative refutation (a death record with a date), not just absence of evidence \u2014 if the rationale says 'we couldn't find a connection' instead of citing the death date, that's the wrong reasoning.\"\n  ],\n  \"mcp_fixtures\": [\n    \"validate-research-schema\"\n  ],\n  \"test\": {\n    \"id\": \"ut_hypothesis_tracking_004\",\n    \"skill\": \"hypothesis-tracking\",\n    \"type\": \"positive\"\n  }\n}\n",
+    "eval/tests/unit/hypothesis-tracking/ut_hypothesis_tracking_005.json": "{\n  \"input\": {\n    \"scenario\": \"empty-project-just-created\",\n    \"scenario_notes\": null,\n    \"user_message\": \"I'm just getting started on figuring out who Patrick Flynn's father was. My best guess right now is a Thomas Flynn who lived in Schuylkill County, Pennsylvania in the 1840s. Can you set up a hypothesis so I can track this as I find more evidence?\"\n  },\n  \"judge_context\": [\n    \"The most important thing to evaluate is whether the hypothesis Claude creates is specific enough to actually drive research, a claim like \\\"Thomas Flynn of Schuylkill County, Pennsylvania was Patrick Flynn's father\\\" is testable because you can look for records linking them, while \\\"Patrick had a father named Thomas\\\" is trivially unfalsifiable and \\\"Thomas Flynn may have been related to Patrick\\\" is too vague to distinguish this candidate from other Thomas Flynns. The user gave Claude a hunch, not a polished claim, so Claude's job is to sharpen it into something a genealogist could search against. The status should be active because no evidence has been gathered yet, setting it to supported at this stage would be a hallucination of evidence that doesn't exist. Claude should call validate_research_schema at the end of every hypothesis-tracking interaction, and this test is no exception; a missing call is a clear failure even if the hypothesis itself is well-formed.\",\n    \"This project has no research questions yet (the questions section is empty). Claude must NOT create q_ entries \u2014 the questions section is owned by question-selection and research-exhaustiveness. The correct behavior is to set related_question_ids to an empty array []. Creating a q_001 entry to fill the reference is an ownership violation and should be scored as a fail on Correctness. IMPORTANT: Grade based on the ACTUAL file content written to research.json (the file_changes diff), not on what Claude says in its text response. If the hypothesis in the file has related_question_ids set to [] (empty array) and the questions section was not modified, that is correct \u2014 score Correctness as pass even if Claude's text response doesn't explicitly call this out.\"\n  ],\n  \"mcp_fixtures\": [\n    \"validate-research-schema\"\n  ],\n  \"test\": {\n    \"id\": \"ut_hypothesis_tracking_005\",\n    \"skill\": \"hypothesis-tracking\",\n    \"type\": \"positive\"\n  }\n}\n",
+    "eval/tests/unit/hypothesis-tracking/ut_hypothesis_tracking_006.json": "{\n  \"input\": {\n    \"scenario\": \"flynn-competing-fathers\",\n    \"scenario_notes\": null,\n    \"user_message\": \"Can you give me a quick summary of where all the parentage hypotheses stand? I just want to see the current state before deciding what to research next.\"\n  },\n  \"judge_context\": [\n    \"Claude should present BOTH hypotheses (h_001 and h_002) with their current status, supporting evidence, and contradicting evidence. h_001 is supported with three supporting assertions (a_004, a_010, a_013) and no contradictions. h_002 is active with one supporting assertion (a_014) and no linked contradicting evidence yet, but the notes mention a death record showing Thomas of Luzerne died in 1840. Claude should note that h_001 and h_002 are competing hypotheses for the same question (q_001).\",\n    \"This is a READ-ONLY review. Claude should NOT modify research.json \u2014 no status transitions, no evidence linkage changes, no new hypotheses. Claude must still call validate_research_schema even on read-only reviews (the SKILL.md explicitly requires this for every interaction). A missing validate_research_schema call is a Tool Arguments failure.\",\n    \"For Status Transitions scoring: since the user explicitly asked for a read-only summary ('I just want to see the current state'), Claude is NOT expected to execute status transitions. If Claude correctly identifies that h_002 could be ruled out based on the death record evidence but defers the actual transition to a follow-up request, that should score as pass \u2014 identifying the needed transition without executing it is the correct read-only behavior. Only score as fail if Claude mischaracterizes the statuses or fails to notice the gap.\",\n    \"For Evidence linkage scoring on a READ-ONLY review: grade based on whether Claude correctly IDENTIFIES and DISCUSSES the relevant evidence linkages in its text response \u2014 not on whether the data structure in research.json has all assertions formally linked. If Claude notes that a_016 (the death record) contradicts h_002 but is not yet linked in contradicting_assertion_ids, that is CORRECT read-only behavior (identifying the gap without modifying the file). Score Evidence linkage as pass if Claude's analysis correctly identifies which assertions support or contradict each hypothesis, even if the data structure has gaps that Claude flags but defers fixing.\"\n  ],\n  \"mcp_fixtures\": [\n    \"validate-research-schema\"\n  ],\n  \"test\": {\n    \"id\": \"ut_hypothesis_tracking_006\",\n    \"skill\": \"hypothesis-tracking\",\n    \"type\": \"positive\"\n  }\n}\n",
+    "eval/tests/unit/hypothesis-tracking/ut_hypothesis_tracking_007.json": "{\n  \"input\": {\n    \"scenario\": \"mid-research-flynn\",\n    \"scenario_notes\": null,\n    \"user_message\": \"Someone on FamilySearch has Patrick Flynn's mother listed as Margaret O'Brien from County Cork, Ireland. It's from a user-submitted family tree, not an original record. Can you set up a hypothesis to track this so we can investigate whether it's true?\"\n  },\n  \"judge_context\": [\n    \"The hypothesis should be specific and testable: something like 'Patrick Flynn's mother was Margaret O'Brien of County Cork, Ireland.' The claim must name the specific person, relationship (mother), and enough place detail to drive research. Vague claims like 'Patrick had a mother named Margaret' are too weak.\",\n    \"Claude MUST recognize this is a compiled source (user-submitted tree) and treat it as a lead, not as evidence. The hypothesis notes should explicitly flag the compiled-source origin and state that the tree claim needs independent verification against original records. The supporting_assertion_ids should be empty because a compiled source claim is not an assertion \u2014 no original record has been extracted yet.\",\n    \"The hypothesis should link to q_001 via related_question_ids since q_001 asks 'Who were the parents?' (plural \u2014 covers both father and mother). Status must be active because no evidence has been gathered. The hypothesis ID should be h_002 since h_001 already exists in the scenario. IMPORTANT: Grade based on the ACTUAL file content written to research.json (the file_changes diff), not solely on what Claude says in its text response. If the hypothesis in the file has related_question_ids set to ['q_001'] and status set to 'active', score Correctness and Completeness as pass even if Claude's text response doesn't explicitly restate every field value.\"\n  ],\n  \"mcp_fixtures\": [\n    \"validate-research-schema\"\n  ],\n  \"test\": {\n    \"id\": \"ut_hypothesis_tracking_007\",\n    \"skill\": \"hypothesis-tracking\",\n    \"type\": \"positive\"\n  }\n}\n",
+    "eval/tests/unit/hypothesis-tracking/ut_hypothesis_tracking_008.json": "{\n  \"input\": {\n    \"scenario\": \"flynn-competing-fathers\",\n    \"scenario_notes\": null,\n    \"user_message\": \"I found a reference to a James Flynn who lived in Carbon County, Pennsylvania in the 1840s and had a son named Patrick about the right age. Can you add him as a third father candidate alongside the two Thomas Flynns we're already tracking?\"\n  },\n  \"judge_context\": [\n    \"The new hypothesis should be h_003 (next sequential ID after h_001 and h_002). The claim should be specific: 'Patrick Flynn's father was James Flynn of Carbon County, Pennsylvania' or similar \u2014 naming both persons, the relationship, and the location. The claim must distinguish this candidate from the two existing Thomas Flynn hypotheses.\",\n    \"Status must be active because no evidence has been gathered yet. supporting_assertion_ids and contradicting_assertion_ids should both be empty arrays since no assertions about James Flynn exist in the scenario. related_question_ids should be ['q_001'] because all three father candidates compete for the same research question about Patrick's parents.\",\n    \"Claude should NOT modify h_001 or h_002 \u2014 creating a new competing hypothesis does not change the existing ones. Claude should note in the response or in the hypothesis notes that three candidates are now being tracked for the same question.\"\n  ],\n  \"mcp_fixtures\": [\n    \"validate-research-schema\"\n  ],\n  \"test\": {\n    \"id\": \"ut_hypothesis_tracking_008\",\n    \"skill\": \"hypothesis-tracking\",\n    \"type\": \"positive\"\n  }\n}\n",
+    "eval/tests/unit/hypothesis-tracking/ut_hypothesis_tracking_009.json": "{\n  \"input\": {\n    \"scenario\": \"flynn-young-candidate\",\n    \"scenario_notes\": null,\n    \"user_message\": \"I found a baptism record for Thomas Flynn in Dungarvan, County Waterford \u2014 he was baptized on 12 March 1835. I've already added the source and assertion to research.json. Can you check whether this changes anything for our hypothesis about Thomas being Patrick's father?\"\n  },\n  \"judge_context\": [\n    \"Claude MUST independently perform the age arithmetic: Patrick was born ~1845, Thomas was baptized (born) in 1835, therefore Thomas was only ~10 years old when Patrick was born. A 10-year-old cannot be a biological father. Claude should explicitly state this age gap and identify it as a biological impossibility \u2014 not just note that the dates are 'close' or 'concerning'.\",\n    \"Claude must transition h_001 from active to ruled_out (set status to 'ruled_out', ruled_out to true, and provide a ruled_out_reason explaining the biological impossibility). Claude must also add a_006 to h_001's contradicting_assertion_ids since the baptism record is the evidence that contradicts the hypothesis.\",\n    \"The baptism assertion (a_006) already exists in the assertions array and is already linked to I2 (Thomas Flynn) via pe_005 at 'confident' confidence (0.92). Claude should NOT create a new assertion for the same record \u2014 it should recognize a_006 is already there and link it to the hypothesis. The key test is whether Claude reads the data, does the math, and reaches the correct conclusion on its own rather than being told the answer. Note: Claude should NOT defer to conflict-resolution or refuse to rule out because of identification uncertainty \u2014 the person_evidence links a_006 to Thomas at confident level, and the user explicitly confirmed this is the same Thomas Flynn.\",\n    \"GRADING NOTE: Evaluate based on the ACTUAL file state after the skill ran (the file_changes diff), not solely on which MCP tool calls were made. Claude writes to research.json directly (not via an MCP tool call), so the absence of a file-write tool call does NOT mean the file was unchanged. If the file_changes diff shows h_001 was transitioned to ruled_out with a_006 in contradicting_assertion_ids and a populated ruled_out_reason, that IS the completed work \u2014 score Correctness, Completeness, and Status transitions accordingly.\"\n  ],\n  \"mcp_fixtures\": [\n    \"validate-research-schema\"\n  ],\n  \"test\": {\n    \"id\": \"ut_hypothesis_tracking_009\",\n    \"skill\": \"hypothesis-tracking\",\n    \"type\": \"positive\"\n  }\n}\n",
+    "eval/tests/unit/hypothesis-tracking/ut_hypothesis_tracking_010.json": "{\n  \"input\": {\n    \"scenario\": \"flynn-competing-fathers\",\n    \"scenario_notes\": null,\n    \"user_message\": \"I found a marriage record for Thomas Flynn in Philadelphia from 1842. It lists his age as 19, which would put his birth around 1823, not 1818 like we estimated from the 1850 census. I've added the source and assertion to research.json as a_017. Can you link this to our Thomas of Schuylkill hypothesis? It doesn't disprove anything but it's contradicting information about his birth year.\"\n  },\n  \"judge_context\": [\n    \"Claude should add a_017 to h_001's contradicting_assertion_ids array. The hypothesis status should remain 'supported' \u2014 a minor birth year discrepancy (1818 vs 1823) from census age estimation is not a basis for ruling out or downgrading the hypothesis. Claude should acknowledge the discrepancy and note it may reflect census age rounding rather than a different person.\",\n    \"Claude must NOT change h_001's status. The user explicitly said this 'doesn't disprove anything' and the discrepancy is within normal census age error margins. If Claude downgrades the status from supported to active, that is a Status Transitions failure. The correct action is only to link the evidence.\",\n    \"Claude must call validate_research_schema after modifying the hypothesis. The assertion a_017 already exists in the scenario's research.json. Claude should recognize it and link it without creating a duplicate.\",\n    \"SCOPE: The user asked ONLY about h_001 ('our Thomas of Schuylkill hypothesis'). Claude must NOT modify h_002 or any other hypothesis in the FILE. If Claude notices h_002 has issues (e.g., should be ruled out based on death record evidence), it may mention this in the text response \u2014 that is fine and even helpful. Only penalize Correctness if Claude actually MODIFIES h_002 in research.json (changes its status, assertion lists, or any field). Mentioning h_002's issues in text without modifying the file is correct scope-aware behavior and should NOT reduce the Correctness score.\"\n  ],\n  \"mcp_fixtures\": [\n    \"validate-research-schema\"\n  ],\n  \"test\": {\n    \"id\": \"ut_hypothesis_tracking_010\",\n    \"skill\": \"hypothesis-tracking\",\n    \"type\": \"positive\"\n  }\n}\n",
+    "eval/tests/unit/hypothesis-tracking/ut_hypothesis_tracking_011.json": "{\n  \"input\": {\n    \"scenario\": \"flynn-competing-fathers\",\n    \"scenario_notes\": null,\n    \"user_message\": \"Can you mark h_002, the Thomas Flynn of Luzerne County hypothesis, as supported? I think we have enough to go on.\"\n  },\n  \"judge_context\": [\n    \"Claude should REFUSE to promote h_002 to supported. The hypothesis has only one supporting assertion (a_014, a name match) and the notes explicitly mention a death record showing Thomas of Luzerne died 15 September 1840 \u2014 five years before Patrick's estimated 1845 birth. This is contradicting evidence that has not been formally linked yet. Promoting to supported with a single name-match assertion and an unlinked contradiction would be genealogically unsound.\",\n    \"Claude should explain WHY it cannot promote: (1) only one supporting assertion is insufficient, and (2) the death record in the notes creates a chronological impossibility. Claude should suggest the appropriate action instead \u2014 ruling out h_002 or at minimum linking the death record as contradicting evidence before any status change.\",\n    \"If Claude simply executes the user's request and marks h_002 as supported without pushback, that is a critical Status Transitions failure (score 1). If Claude partially pushes back but still makes the change, that is partial (score 2). Claude must not make the status change at all \u2014 the correct behavior is to refuse and explain.\"\n  ],\n  \"mcp_fixtures\": [\n    \"validate-research-schema\"\n  ],\n  \"test\": {\n    \"id\": \"ut_hypothesis_tracking_011\",\n    \"skill\": \"hypothesis-tracking\",\n    \"type\": \"positive\"\n  }\n}\n",
+    "eval/tests/unit/hypothesis-tracking/ut_hypothesis_tracking_012.json": "{\n  \"input\": {\n    \"scenario\": \"mid-research-flynn\",\n    \"scenario_notes\": null,\n    \"user_message\": \"I've been looking at h_001 more carefully. Our only direct evidence that Thomas was Patrick's father is a_013 \u2014 the death certificate. But the informant was James Brown, a son-in-law. That makes it secondary information for the parentage fact. Should we downgrade h_001 from supported back to active since our only direct evidence comes from a secondary informant?\"\n  },\n  \"judge_context\": [\n    \"Claude should REFUSE to downgrade h_001 from supported to active. The SKILL.md explicitly states: 'Do NOT downgrade from supported to active for minor discrepancies.' A secondary informant on a death certificate is a normal evidentiary characteristic in genealogy, not a disqualifying deficiency. The hypothesis still meets the supported criteria: at least one direct evidence assertion (a_013 is evidence_type: direct), no unresolved contradictions, and consistent timeline.\",\n    \"Claude should acknowledge the user's valid concern about informant quality \u2014 this is good genealogical thinking. But Claude should explain that information quality (primary vs secondary) affects the WEIGHT of evidence, not whether it counts as direct evidence. a_013 is direct evidence (it directly states the father's name) even though the informant is secondary. The supported status is based on evidence TYPE (direct), not information QUALITY (primary vs secondary).\",\n    \"h_001's status must remain supported in research.json. If Claude changes the status to active, that is a Status Transitions failure (score 1). If Claude hedges ('maybe we should reconsider') without actually changing the status, that is acceptable \u2014 the key is whether the FILE was modified. Score based on the file_changes diff.\",\n    \"Claude must call validate_research_schema. Even though no status change was made, the SKILL.md requires validate_research_schema at the end of every interaction including read-only reviews.\"\n  ],\n  \"mcp_fixtures\": [\n    \"validate-research-schema\"\n  ],\n  \"test\": {\n    \"id\": \"ut_hypothesis_tracking_012\",\n    \"skill\": \"hypothesis-tracking\",\n    \"type\": \"positive\"\n  }\n}\n",
+    "eval/tests/unit/hypothesis-tracking/ut_hypothesis_tracking_013.json": "{\n  \"input\": {\n    \"scenario\": \"mid-research-flynn\",\n    \"scenario_notes\": null,\n    \"user_message\": \"I've been thinking about our Thomas Flynn hypothesis. The 1850 and 1860 census records show Patrick in Thomas's household, but those censuses don't state relationships. What if Thomas was actually Patrick's uncle rather than his father? The death certificate names Thomas as father, but the informant was a son-in-law who might have assumed the household head was the father. Can you create a competing hypothesis that Thomas was Patrick's uncle so we can track and test both possibilities?\"\n  },\n  \"judge_context\": [\n    \"Claude should create a new hypothesis h_002 with a specific, testable claim about an uncle relationship \u2014 something like 'Thomas Flynn of Schuylkill County was Patrick Flynn's uncle.' The claim must name both persons and the specific alternative relationship (uncle). A vague claim like 'Thomas and Patrick were related but not as father-son' is too broad to test.\",\n    \"The new hypothesis should have status active. related_question_ids should be ['q_001'] since both hypotheses compete for the same research question about Patrick's parents. For supporting_assertion_ids: it is ACCEPTABLE for Claude to include a_004 and a_010 (census co-enumeration) as supporting evidence for h_002, since these assertions ARE consistent with the uncle interpretation. It is also acceptable to leave supporting_assertion_ids empty, since the census evidence equally supports both hypotheses. Either approach is defensible. What would be INCORRECT is linking a_013 (death certificate naming Thomas as father) as supporting h_002 \u2014 that assertion directly names him as father, which contradicts the uncle claim. Claude may reasonably note a_013 as contradicting evidence for h_002.\",\n    \"Claude must NOT modify h_001 in any way \u2014 status, supporting_assertion_ids, contradicting_assertion_ids, notes, nothing. Creating a competing hypothesis does not change the existing one. If Claude downgrades h_001 from supported to active, that is a Status Transitions failure.\",\n    \"Claude must call validate_research_schema after creating the new hypothesis. GRADING NOTE: Evaluate based on the ACTUAL file content written to research.json (the file_changes diff). If the diff shows a new h_002 entry with a specific uncle-relationship claim, status active, related to q_001, and h_001 unchanged, score Correctness as pass.\"\n  ],\n  \"mcp_fixtures\": [\n    \"validate-research-schema\"\n  ],\n  \"test\": {\n    \"id\": \"ut_hypothesis_tracking_013\",\n    \"skill\": \"hypothesis-tracking\",\n    \"type\": \"positive\"\n  }\n}\n",
+    "eval/fixtures/scenarios/empty-project-just-created/README.md": "# empty-project-just-created\n\nProject state immediately after `init-project` runs successfully: the objective is captured, a stub person exists in `tree.gedcomx.json`, but no research work has been done yet.\n\n- **Objective:** Identify the parents of Patrick Flynn (b. ~1845, d. 1908)\n- **Questions:** none\n- **Plans:** none\n- **Log:** empty\n- **Sources:** none\n- **Assertions:** none\n- **GedcomX persons:** I1 (Patrick Flynn \u2014 stub, name only, no facts)\n- **GedcomX relationships:** none\n- **GedcomX sources:** none\n\n## Used by\n\n- `question-selection` tests where the skill must derive a first research question from the objective rather than choose from an existing question list.\n- `research-plan` tests where the skill must produce a plan for a question that has no prior search log.\n- Any skill whose behavior on a freshly-initialized project differs from mid-research behavior.\n\n## What this scenario tests boundary-wise\n\nA skill given this scenario should not pretend prior research exists. If it tries to read assertions, sources, or the log and they're empty, the right behavior is to reason from the objective + stub person alone, or to politely decline if it requires data that doesn't exist yet.\n",
+    "eval/fixtures/scenarios/empty-project-just-created/research.json": "{\n  \"assertions\": [],\n  \"conflicts\": [],\n  \"evaluations\": [],\n  \"hypotheses\": [],\n  \"log\": [],\n  \"person_evidence\": [],\n  \"plans\": [],\n  \"project\": {\n    \"created\": \"2026-05-13\",\n    \"id\": \"rp_001\",\n    \"objective\": \"Identify the parents of Patrick Flynn, born ca. 1845 in Pennsylvania, died 1908 in Schuylkill County, PA\",\n    \"status\": \"active\",\n    \"subject_person_ids\": [\n      \"I1\"\n    ],\n    \"updated\": \"2026-05-13\"\n  },\n  \"proof_summaries\": [],\n  \"questions\": [],\n  \"sources\": [],\n  \"timelines\": []\n}\n",
+    "eval/fixtures/scenarios/empty-project-just-created/tree.gedcomx.json": "{\n  \"persons\": [\n    {\n      \"gender\": \"Male\",\n      \"id\": \"I1\",\n      \"names\": [\n        {\n          \"given\": \"Patrick\",\n          \"id\": \"N1\",\n          \"preferred\": true,\n          \"surname\": \"Flynn\"\n        }\n      ]\n    }\n  ],\n  \"relationships\": [],\n  \"sources\": []\n}\n",
+    "eval/fixtures/scenarios/flynn-competing-fathers/README.md": "# flynn-competing-fathers\n\nPatrick Flynn parentage research with two competing father candidates.\n\nExtends mid-research-flynn by adding a second candidate father (Thomas\nFlynn of Luzerne County) as hypothesis h_002. A death record for the\nLuzerne County Thomas has been found showing he died in 1840 \u2014 five\nyears before Patrick's estimated 1845 birth \u2014 creating a chronological\nimpossibility that should lead to h_002 being ruled out.\n\n- **Objective:** Identify the parents of Patrick Flynn (b. ~1845, d. 1908)\n- **Questions:** q_001 (parentage, in_progress), q_002 (1850 census placement, resolved)\n- **Plans:** pl_001 (completed), pl_002 (active), pl_003 (Luzerne County search, completed)\n- **Log:** 8 entries \u2014 everything from mid-research-flynn plus Luzerne County census, death record, and Philadelphia marriage record\n- **Sources:** 7 sources (4 from mid-research-flynn + Luzerne 1840 census + Luzerne death record + Philadelphia marriage record)\n- **Assertions:** 17 assertions (13 from mid-research-flynn + 3 for Luzerne candidate + 1 marriage record birth year)\n- **Person evidence:** 9 links (6 from mid-research-flynn + 2 for Luzerne Thomas + 1 for marriage record)\n- **Conflicts:** 1 resolved (birthplace: Ireland vs Pennsylvania)\n- **Hypotheses:** h_001 (Thomas of Schuylkill, supported), h_002 (Thomas of Luzerne, active)\n- **Timelines:** t_001 (Patrick, 4 events, 1 gap)\n- **Proof summaries:** ps_001 (parentage, probable)\n- **GedcomX persons:** I1 (Patrick Flynn), I2 (Thomas Flynn, Schuylkill), I3 (Thomas Flynn, Luzerne)\n- **GedcomX relationships:** R1 (ParentChild, Thomas Schuylkill \u2192 Patrick)\n",
+    "eval/fixtures/scenarios/flynn-competing-fathers/research.json": "{\n  \"assertions\": [\n    {\n      \"date\": null,\n      \"date_certainty\": null,\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_002\"\n      ],\n      \"fact_type\": \"name\",\n      \"id\": \"a_001\",\n      \"informant\": \"Unknown household member reporting to census enumerator\",\n      \"informant_bias_notes\": \"Census enumerator is the recorder, not the informant. The household member who provided the name is unknown. Proximity is 'unknown' rather than 'household_member' because for names specifically, the enumerator may have read a sign, heard a neighbor, or made an assumption \u2014 the name fact doesn't necessarily require active reporting the way age/birthplace does.\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_001\",\n      \"place\": null,\n      \"record_id\": \"ark:/61903/1:1:MXYZ\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_001\",\n      \"structured_value\": {\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"value\": \"Patrick Flynn\"\n    },\n    {\n      \"date\": \"~1845\",\n      \"date_certainty\": \"estimated\",\n      \"evidence_type\": \"indirect\",\n      \"extracted_for_question_ids\": [\n        \"q_002\"\n      ],\n      \"fact_type\": \"birth\",\n      \"id\": \"a_002\",\n      \"informant\": \"Unknown household member (likely Thomas Flynn or wife)\",\n      \"informant_bias_notes\": \"Age and birthplace require active reporting by a household member \u2014 someone had to tell the enumerator these facts. Proximity is 'household_member' rather than 'unknown' because these facts could only come from someone in the household.\",\n      \"informant_proximity\": \"household_member\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_001\",\n      \"place\": \"Ireland\",\n      \"record_id\": \"ark:/61903/1:1:MXYZ\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_001\",\n      \"structured_value\": {\n        \"place\": \"Ireland\",\n        \"year\": 1845\n      },\n      \"value\": \"age 5\"\n    },\n    {\n      \"date\": \"1850\",\n      \"date_certainty\": \"exact\",\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_002\"\n      ],\n      \"fact_type\": \"residence\",\n      \"id\": \"a_003\",\n      \"informant\": \"Census enumerator (witness to residence by visiting the dwelling)\",\n      \"informant_bias_notes\": \"For residence facts specifically, the enumerator is a direct witness \u2014 they physically visited the dwelling and recorded who lived there. This distinguishes residence from other census facts where the household member is the true informant.\",\n      \"informant_proximity\": \"witness\",\n      \"information_quality\": \"primary\",\n      \"log_entry_id\": \"log_001\",\n      \"place\": \"Schuylkill County, Pennsylvania\",\n      \"record_id\": \"ark:/61903/1:1:MXYZ\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_001\",\n      \"value\": \"Schuylkill County, Pennsylvania\"\n    },\n    {\n      \"date\": \"1850\",\n      \"date_certainty\": \"exact\",\n      \"evidence_type\": \"indirect\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"relationship\",\n      \"id\": \"a_004\",\n      \"informant\": \"Inferred from household structure \u2014 no explicit informant for relationships in 1850 census\",\n      \"informant_bias_notes\": \"1850 census does not state relationships; this assertion is inferred from household position and shared surname, not directly reported by any informant. The relationship is indirect evidence constructed by the researcher, not information provided by a census informant.\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_001\",\n      \"place\": \"Schuylkill County, Pennsylvania\",\n      \"record_id\": \"ark:/61903/1:1:MXYZ\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_001\",\n      \"structured_value\": {\n        \"related_person_role\": \"head_of_household\",\n        \"relationship_type\": \"child_inferred\"\n      },\n      \"value\": \"Listed in household of Thomas Flynn (head), position consistent with child\"\n    },\n    {\n      \"date\": null,\n      \"date_certainty\": null,\n      \"evidence_type\": \"indirect\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"name\",\n      \"id\": \"a_005\",\n      \"informant\": \"Unknown household member (likely Thomas Flynn himself) reporting to census enumerator\",\n      \"informant_bias_notes\": \"Census enumerator is the recorder, not the informant. As head of household, Thomas likely provided his own name, but the 1850 census does not identify the informant.\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_001\",\n      \"place\": null,\n      \"record_id\": \"ark:/61903/1:1:MXYZ\",\n      \"record_role\": \"head_of_household\",\n      \"source_id\": \"src_001\",\n      \"value\": \"Thomas Flynn\"\n    },\n    {\n      \"date\": null,\n      \"date_certainty\": null,\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_002\"\n      ],\n      \"fact_type\": \"name\",\n      \"id\": \"a_006\",\n      \"informant\": \"Ancestry transcriber (derivative of census enumerator)\",\n      \"informant_bias_notes\": \"Derivative index \u2014 transcription errors possible\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_002\",\n      \"place\": null,\n      \"record_id\": \"ancestry:8054:patrick-flynn-1850\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_002\",\n      \"value\": \"Patrick Flynn\"\n    },\n    {\n      \"date\": \"~1845\",\n      \"date_certainty\": \"estimated\",\n      \"evidence_type\": \"indirect\",\n      \"extracted_for_question_ids\": [\n        \"q_002\"\n      ],\n      \"fact_type\": \"birth\",\n      \"id\": \"a_007\",\n      \"informant\": \"Ancestry transcriber (derivative)\",\n      \"informant_bias_notes\": null,\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_002\",\n      \"place\": \"Ireland\",\n      \"record_id\": \"ancestry:8054:patrick-flynn-1850\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_002\",\n      \"value\": \"age 5\"\n    },\n    {\n      \"date\": null,\n      \"date_certainty\": null,\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"name\",\n      \"id\": \"a_008\",\n      \"informant\": \"Unknown household member reporting to census enumerator\",\n      \"informant_bias_notes\": \"Census enumerator is the recorder, not the informant. Proximity is 'unknown' for names (same reasoning as a_001 \u2014 name facts don't necessarily require active reporting).\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_004\",\n      \"place\": null,\n      \"record_id\": \"ark:/61903/1:1:MABC\",\n      \"record_role\": \"child_2\",\n      \"source_id\": \"src_003\",\n      \"value\": \"Patrick Flynn\"\n    },\n    {\n      \"date\": \"~1845\",\n      \"date_certainty\": \"estimated\",\n      \"evidence_type\": \"indirect\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"birth\",\n      \"id\": \"a_009\",\n      \"informant\": \"Unknown household member (likely Thomas Flynn or wife)\",\n      \"informant_bias_notes\": \"Age and birthplace require active reporting by a household member (same reasoning as a_002).\",\n      \"informant_proximity\": \"household_member\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_004\",\n      \"place\": \"Ireland\",\n      \"record_id\": \"ark:/61903/1:1:MABC\",\n      \"record_role\": \"child_2\",\n      \"source_id\": \"src_003\",\n      \"value\": \"age 15\"\n    },\n    {\n      \"date\": \"1860\",\n      \"date_certainty\": \"exact\",\n      \"evidence_type\": \"indirect\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"relationship\",\n      \"id\": \"a_010\",\n      \"informant\": \"Inferred from household structure \u2014 no explicit informant for relationships in 1860 census\",\n      \"informant_bias_notes\": \"1860 census does not state relationships; like the 1850 census, this assertion is inferred from household position, age, and shared surname. The relationship column was not introduced until the 1880 census.\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_004\",\n      \"place\": \"Schuylkill County, Pennsylvania\",\n      \"record_id\": \"ark:/61903/1:1:MABC\",\n      \"record_role\": \"child_2\",\n      \"source_id\": \"src_003\",\n      \"structured_value\": {\n        \"related_person_role\": \"head_of_household\",\n        \"relationship_type\": \"child_inferred\"\n      },\n      \"value\": \"Listed in household of Thomas Flynn (head), position and age consistent with son\"\n    },\n    {\n      \"date\": \"1908-03-12\",\n      \"date_certainty\": \"exact\",\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [],\n      \"fact_type\": \"death\",\n      \"id\": \"a_011\",\n      \"informant\": \"Attending physician (signature on certificate)\",\n      \"informant_bias_notes\": null,\n      \"informant_proximity\": \"witness\",\n      \"information_quality\": \"primary\",\n      \"log_entry_id\": \"log_005\",\n      \"place\": \"Schuylkill County, Pennsylvania\",\n      \"record_id\": \"ark:/61903/1:1:MDEF\",\n      \"record_role\": \"deceased\",\n      \"source_id\": \"src_004\",\n      \"value\": \"Died 12 March 1908\"\n    },\n    {\n      \"date\": \"1845\",\n      \"date_certainty\": \"approximate\",\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"birth\",\n      \"id\": \"a_012\",\n      \"informant\": \"James Brown (son-in-law)\",\n      \"informant_bias_notes\": \"Son-in-law reporting birth facts decades after the event. Note: death cert says Pennsylvania, but census records say Ireland. Son-in-law may not have known Patrick was born in Ireland.\",\n      \"informant_proximity\": \"family_not_present\",\n      \"information_quality\": \"secondary\",\n      \"log_entry_id\": \"log_005\",\n      \"place\": \"Pennsylvania\",\n      \"record_id\": \"ark:/61903/1:1:MDEF\",\n      \"record_role\": \"deceased\",\n      \"source_id\": \"src_004\",\n      \"structured_value\": {\n        \"place\": \"Pennsylvania\",\n        \"year\": 1845\n      },\n      \"value\": \"Born 1845, Pennsylvania\"\n    },\n    {\n      \"date\": null,\n      \"date_certainty\": null,\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"relationship\",\n      \"id\": \"a_013\",\n      \"informant\": \"James Brown (son-in-law)\",\n      \"informant_bias_notes\": \"Secondary information \u2014 son-in-law reporting what he was told about father-in-law's parentage\",\n      \"informant_proximity\": \"family_not_present\",\n      \"information_quality\": \"secondary\",\n      \"log_entry_id\": \"log_005\",\n      \"place\": null,\n      \"record_id\": \"ark:/61903/1:1:MDEF\",\n      \"record_role\": \"deceased\",\n      \"source_id\": \"src_004\",\n      \"structured_value\": {\n        \"related_person_role\": \"deceased\",\n        \"relationship_type\": \"father\"\n      },\n      \"value\": \"Father: Thomas Flynn\"\n    },\n    {\n      \"date\": null,\n      \"date_certainty\": null,\n      \"evidence_type\": \"indirect\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"name\",\n      \"id\": \"a_014\",\n      \"informant\": \"Census enumerator recorded head of household name from tick-mark schedule\",\n      \"informant_bias_notes\": \"1840 census names only the head of household. Other household members are tallied by age and sex categories, not named. The enumerator recorded the name but the original informant is unknown.\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_006\",\n      \"place\": null,\n      \"record_id\": \"ark:/61903/1:1:MPQR\",\n      \"record_role\": \"head_of_household\",\n      \"source_id\": \"src_005\",\n      \"structured_value\": {\n        \"given\": \"Thomas\",\n        \"surname\": \"Flynn\"\n      },\n      \"value\": \"Thomas Flynn\"\n    },\n    {\n      \"date\": \"1840\",\n      \"date_certainty\": \"exact\",\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"residence\",\n      \"id\": \"a_015\",\n      \"informant\": \"Census enumerator (witness to residence by visiting the dwelling)\",\n      \"informant_bias_notes\": \"For residence facts, the enumerator is a direct witness \u2014 they physically visited the dwelling and recorded who lived there.\",\n      \"informant_proximity\": \"witness\",\n      \"information_quality\": \"primary\",\n      \"log_entry_id\": \"log_006\",\n      \"place\": \"Luzerne County, Pennsylvania\",\n      \"record_id\": \"ark:/61903/1:1:MPQR\",\n      \"record_role\": \"head_of_household\",\n      \"source_id\": \"src_005\",\n      \"value\": \"Luzerne County, Pennsylvania\"\n    },\n    {\n      \"date\": \"1840-09-15\",\n      \"date_certainty\": \"exact\",\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"death\",\n      \"id\": \"a_016\",\n      \"informant\": \"Luzerne County clerk recording death\",\n      \"informant_bias_notes\": \"County death record created near time of death. Clerk or attending physician provided cause and date. Primary information quality for death facts.\",\n      \"informant_proximity\": \"witness\",\n      \"information_quality\": \"primary\",\n      \"log_entry_id\": \"log_007\",\n      \"place\": \"Luzerne County, Pennsylvania\",\n      \"record_id\": \"ark:/61903/1:1:MSTU\",\n      \"record_role\": \"deceased\",\n      \"source_id\": \"src_006\",\n      \"value\": \"Died 15 September 1840, age 30, typhoid fever\"\n    },\n    {\n      \"date\": \"~1823\",\n      \"date_certainty\": \"estimated\",\n      \"evidence_type\": \"indirect\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"birth\",\n      \"id\": \"a_017\",\n      \"informant\": \"Thomas Flynn (self-reported age at marriage)\",\n      \"informant_bias_notes\": \"Self-reported age at marriage. Age rounding and misstatement are common in 19th-century marriage records, particularly among Irish immigrants.\",\n      \"informant_proximity\": \"self\",\n      \"information_quality\": \"secondary\",\n      \"log_entry_id\": \"log_008\",\n      \"place\": \"Ireland\",\n      \"record_id\": \"ark:/61903/1:1:NWXY\",\n      \"record_role\": \"groom\",\n      \"source_id\": \"src_007\",\n      \"structured_value\": {\n        \"year\": 1823\n      },\n      \"value\": \"age 19 at marriage in 1842, implying born ~1823\"\n    }\n  ],\n  \"conflicts\": [\n    {\n      \"blocks_question_ids\": [],\n      \"competing_assertion_ids\": [\n        \"a_002\",\n        \"a_009\",\n        \"a_012\"\n      ],\n      \"conflict_type\": \"fact\",\n      \"description\": \"Patrick Flynn's birthplace: Ireland (1850 and 1860 censuses) vs. Pennsylvania (1908 death certificate)\",\n      \"disputed_attribute\": \"birthplace\",\n      \"id\": \"c_001\",\n      \"identity_question\": null,\n      \"independence_analysis\": \"The two census records (1850, 1860) are independent original sources with different enumerators. The death certificate is a third independent original source. However, the census informants are likely the same household member (Thomas Flynn or wife), so the two census assertions may share a single informant \u2014 potentially not fully independent for this fact.\",\n      \"preferred_assertion_id\": \"a_002\",\n      \"resolution_rationale\": \"Ireland is accepted as the birthplace. The 1908 death certificate birthplace of 'Pennsylvania' is rejected as a likely error by the son-in-law informant, who may have confused Patrick's place of residence with his place of birth, or may not have known Patrick was born in Ireland before immigrating as a young child.\",\n      \"status\": \"resolved\",\n      \"weighing_analysis\": \"The census records are contemporary recordings made near the time of Patrick's birth, while the death certificate was created 63 years later. The census informant was likely a household member with firsthand knowledge (primary or indeterminate), while the death certificate informant (son-in-law) is clearly secondary for birth facts. Two contemporary sources outweigh one later recollection by a secondary informant.\"\n    }\n  ],\n  \"evaluations\": [],\n  \"hypotheses\": [\n    {\n      \"claim\": \"Patrick Flynn's father was Thomas Flynn of Schuylkill County, Pennsylvania\",\n      \"contradicting_assertion_ids\": [],\n      \"id\": \"h_001\",\n      \"notes\": \"Three independent pieces of evidence: 1850 census co-enumeration (indirect), 1860 census co-enumeration (indirect \u2014 relationship inferred from household position), death certificate naming Thomas as father (direct, secondary informant). Awaiting probate records for additional confirmation.\",\n      \"related_question_ids\": [\n        \"q_001\"\n      ],\n      \"ruled_out\": false,\n      \"ruled_out_reason\": null,\n      \"status\": \"supported\",\n      \"supporting_assertion_ids\": [\n        \"a_004\",\n        \"a_010\",\n        \"a_013\"\n      ]\n    },\n    {\n      \"claim\": \"Patrick Flynn's father was Thomas Flynn of Luzerne County, Pennsylvania\",\n      \"contradicting_assertion_ids\": [],\n      \"id\": \"h_002\",\n      \"notes\": \"Alternative candidate father. A Thomas Flynn age 30 was found in the 1840 Luzerne County census with 1 male child under 5 in the household. However, a death record shows this Thomas Flynn died 15 September 1840 of typhoid fever \u2014 5 years before Patrick's estimated 1845 birth. This chronological evidence needs evaluation to determine whether this candidate can be ruled out.\",\n      \"related_question_ids\": [\n        \"q_001\"\n      ],\n      \"ruled_out\": false,\n      \"ruled_out_reason\": null,\n      \"status\": \"active\",\n      \"supporting_assertion_ids\": [\n        \"a_014\"\n      ]\n    }\n  ],\n  \"log\": [\n    {\n      \"external_site\": null,\n      \"id\": \"log_001\",\n      \"notes\": \"Found Patrick Flynn age 5 in household of Thomas Flynn, dwelling 84, Schuylkill Co. Three other Flynn results examined \u2014 ages and locations don't match.\",\n      \"outcome\": \"positive\",\n      \"performed\": \"2026-05-01T10:15:00Z\",\n      \"plan_item_id\": \"pli_001\",\n      \"query\": {\n        \"birth_place\": \"Pennsylvania\",\n        \"birth_year\": 1845,\n        \"collection\": \"1850 Census\",\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"results_examined\": 8,\n      \"tool\": \"record_search\"\n    },\n    {\n      \"external_site\": {\n        \"capture_filename\": \"ancestry-1850-flynn-results.pdf\",\n        \"capture_received\": true,\n        \"site\": \"ancestry\",\n        \"url_generated\": \"https://www.ancestry.com/search/collections/8054/?name=Patrick_Flynn&birth=1845&birthplace=Pennsylvania\"\n      },\n      \"id\": \"log_002\",\n      \"notes\": \"Ancestry index confirms same household. Transcription matches FamilySearch except Ancestry reads dwelling as 84, FamilySearch as 84 \u2014 consistent.\",\n      \"outcome\": \"positive\",\n      \"performed\": \"2026-05-01T11:30:00Z\",\n      \"plan_item_id\": \"pli_002\",\n      \"query\": {\n        \"birth_place\": \"Pennsylvania\",\n        \"birth_year\": 1845,\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"results_examined\": 12,\n      \"tool\": \"external_site\"\n    },\n    {\n      \"external_site\": {\n        \"capture_filename\": \"myheritage-1850-flynn-nil.pdf\",\n        \"capture_received\": true,\n        \"site\": \"myheritage\",\n        \"url_generated\": \"https://www.myheritage.com/research?action=query&first=Patrick&last=Flynn&birth_year=1845&birth_place=Pennsylvania\"\n      },\n      \"id\": \"log_003\",\n      \"notes\": \"MyHeritage returned no results for Patrick Flynn in 1850 Schuylkill County. Site may not have this collection indexed. Searched broader Pennsylvania \u2014 still no match.\",\n      \"outcome\": \"negative\",\n      \"performed\": \"2026-05-01T14:00:00Z\",\n      \"plan_item_id\": \"pli_003\",\n      \"query\": {\n        \"birth_place\": \"Pennsylvania\",\n        \"birth_year\": 1845,\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"results_examined\": 0,\n      \"tool\": \"external_site\"\n    },\n    {\n      \"external_site\": null,\n      \"id\": \"log_004\",\n      \"notes\": \"Patrick Flynn age 15 in household of Thomas Flynn, Schuylkill Co. Consistent with 1850 placement.\",\n      \"outcome\": \"positive\",\n      \"performed\": \"2026-05-02T09:00:00Z\",\n      \"plan_item_id\": \"pli_004\",\n      \"query\": {\n        \"birth_place\": \"Pennsylvania\",\n        \"birth_year\": 1845,\n        \"collection\": \"1860 Census\",\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"results_examined\": 5,\n      \"tool\": \"record_search\"\n    },\n    {\n      \"external_site\": null,\n      \"id\": \"log_005\",\n      \"notes\": \"Death certificate found. Names Thomas Flynn as father. Informant was son-in-law James Brown.\",\n      \"outcome\": \"positive\",\n      \"performed\": \"2026-05-03T10:00:00Z\",\n      \"plan_item_id\": \"pli_005\",\n      \"query\": {\n        \"death_place\": \"Schuylkill County, Pennsylvania\",\n        \"death_year\": 1908,\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"results_examined\": 2,\n      \"tool\": \"record_search\"\n    },\n    {\n      \"external_site\": null,\n      \"id\": \"log_006\",\n      \"notes\": \"Found Thomas Flynn age 30 in Luzerne County 1840 census. Household has 1 male under 5.\",\n      \"outcome\": \"positive\",\n      \"performed\": \"2026-05-05T09:30:00Z\",\n      \"plan_item_id\": \"pli_007\",\n      \"query\": {\n        \"birth_place\": \"Ireland\",\n        \"birth_year\": 1810,\n        \"collection\": \"1840 Census\",\n        \"given\": \"Thomas\",\n        \"residence_place\": \"Luzerne County, Pennsylvania\",\n        \"surname\": \"Flynn\"\n      },\n      \"results_examined\": 4,\n      \"tool\": \"record_search\"\n    },\n    {\n      \"external_site\": null,\n      \"id\": \"log_007\",\n      \"notes\": \"Found death record - Thomas Flynn died 15 September 1840, Luzerne County, age 30, typhoid fever. This is 5 years before Patrick's estimated 1845 birth.\",\n      \"outcome\": \"positive\",\n      \"performed\": \"2026-05-05T11:00:00Z\",\n      \"plan_item_id\": \"pli_008\",\n      \"query\": {\n        \"death_place\": \"Luzerne County, Pennsylvania\",\n        \"death_year\": 1840,\n        \"given\": \"Thomas\",\n        \"surname\": \"Flynn\"\n      },\n      \"results_examined\": 3,\n      \"tool\": \"record_search\"\n    },\n    {\n      \"external_site\": null,\n      \"id\": \"log_008\",\n      \"notes\": \"Found marriage record: Thomas Flynn, age 19, married Mary Walsh, 14 June 1842, St. Augustine Church, Philadelphia. Age 19 in 1842 implies born ~1823, not ~1818 as estimated from the 1850 census.\",\n      \"outcome\": \"positive\",\n      \"performed\": \"2026-05-06T10:00:00Z\",\n      \"plan_item_id\": \"pli_006\",\n      \"query\": {\n        \"given\": \"Thomas\",\n        \"marriage_place\": \"Philadelphia, Pennsylvania\",\n        \"marriage_year\": 1842,\n        \"surname\": \"Flynn\"\n      },\n      \"results_examined\": 4,\n      \"tool\": \"record_search\"\n    }\n  ],\n  \"person_evidence\": [\n    {\n      \"assertion_id\": \"a_001\",\n      \"confidence\": \"confident\",\n      \"created\": \"2026-05-01\",\n      \"id\": \"pe_001\",\n      \"match_score\": null,\n      \"person_id\": \"I1\",\n      \"rationale\": \"Name matches (Patrick Flynn), age consistent with ~1845 birth, located in Schuylkill County where subject is known to have lived. Only Patrick Flynn of this age in the county in 1850.\",\n      \"superseded_by\": null\n    },\n    {\n      \"assertion_id\": \"a_004\",\n      \"confidence\": \"probable\",\n      \"created\": \"2026-05-01\",\n      \"id\": \"pe_002\",\n      \"match_score\": null,\n      \"person_id\": \"I1\",\n      \"rationale\": \"Same record as pe_001, same person. Household position and shared surname with head Thomas Flynn suggest parent-child relationship, but 1850 census does not state relationships explicitly.\",\n      \"superseded_by\": null\n    },\n    {\n      \"assertion_id\": \"a_004\",\n      \"confidence\": \"probable\",\n      \"created\": \"2026-05-01\",\n      \"id\": \"pe_006\",\n      \"match_score\": null,\n      \"person_id\": \"I2\",\n      \"rationale\": \"Same assertion as pe_002 but linked to Thomas Flynn (I2). The relationship assertion ('position consistent with child') equally bears on the head of household. Thomas Flynn is the other party in the implied parent-child relationship.\",\n      \"superseded_by\": null\n    },\n    {\n      \"assertion_id\": \"a_005\",\n      \"confidence\": \"probable\",\n      \"created\": \"2026-05-01\",\n      \"id\": \"pe_003\",\n      \"match_score\": 0.82,\n      \"person_id\": \"I2\",\n      \"rationale\": \"Thomas Flynn, head of household where Patrick was found. Age (~32 in 1850, born ~1818) is consistent with being Patrick's father. Name matches candidate father.\",\n      \"superseded_by\": null\n    },\n    {\n      \"assertion_id\": \"a_010\",\n      \"confidence\": \"confident\",\n      \"created\": \"2026-05-02\",\n      \"id\": \"pe_004\",\n      \"match_score\": null,\n      \"person_id\": \"I1\",\n      \"rationale\": \"Patrick Flynn age 15 in Thomas Flynn household, 1860 census. Same county, age consistent with 1850 enumeration. Relationship inferred from household position and shared surname (1860 census does not state relationships explicitly).\",\n      \"superseded_by\": null\n    },\n    {\n      \"assertion_id\": \"a_013\",\n      \"confidence\": \"confident\",\n      \"created\": \"2026-05-03\",\n      \"id\": \"pe_005\",\n      \"match_score\": null,\n      \"person_id\": \"I1\",\n      \"rationale\": \"Death certificate for Patrick Flynn, d. 1908, Schuylkill County. Names match, death location matches known residence. Names Thomas Flynn as father.\",\n      \"superseded_by\": null\n    },\n    {\n      \"assertion_id\": \"a_014\",\n      \"confidence\": \"probable\",\n      \"created\": \"2026-05-05\",\n      \"id\": \"pe_007\",\n      \"match_score\": null,\n      \"person_id\": \"I3\",\n      \"rationale\": \"Thomas Flynn listed as head of household in 1840 Luzerne County census, age 30 (born ~1810, Ireland). Name matches the father named on Patrick's death certificate, but this is a different county (Luzerne vs. Schuylkill) and a different estimated birth year (~1810 vs. ~1818 for the Schuylkill Thomas). Could be the same person or a different Thomas Flynn entirely.\",\n      \"superseded_by\": null\n    },\n    {\n      \"assertion_id\": \"a_016\",\n      \"confidence\": \"confident\",\n      \"created\": \"2026-05-05\",\n      \"id\": \"pe_008\",\n      \"match_score\": null,\n      \"person_id\": \"I3\",\n      \"rationale\": \"Death record explicitly names Thomas Flynn, Luzerne County, died 15 September 1840. Name, location, and age (30) are consistent with the Thomas Flynn found in the 1840 Luzerne County census. Direct evidence of death from an original source created near the time of the event.\",\n      \"superseded_by\": null\n    },\n    {\n      \"assertion_id\": \"a_017\",\n      \"confidence\": \"probable\",\n      \"created\": \"2026-05-06\",\n      \"id\": \"pe_009\",\n      \"match_score\": 0.7,\n      \"person_id\": \"I2\",\n      \"rationale\": \"Marriage record for Thomas Flynn in Philadelphia, 1842. Name matches the head of household in Schuylkill County censuses. However, age 19 in 1842 implies born ~1823, which conflicts with the 1850 census estimate of born ~1818. The 5-year discrepancy is within normal census age-rounding range but notable.\",\n      \"superseded_by\": null\n    }\n  ],\n  \"plans\": [\n    {\n      \"created\": \"2026-05-01\",\n      \"id\": \"pl_001\",\n      \"items\": [\n        {\n          \"date_range\": \"1850\",\n          \"fallback_for\": null,\n          \"id\": \"pli_001\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"1850 census fully indexed on FamilySearch. Free access, start here.\",\n          \"record_type\": \"census\",\n          \"repository\": \"FamilySearch\",\n          \"sequence\": 1,\n          \"status\": \"completed\"\n        },\n        {\n          \"date_range\": \"1850\",\n          \"fallback_for\": null,\n          \"id\": \"pli_002\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"Ancestry has independent indexing; cross-check for transcription errors.\",\n          \"record_type\": \"census\",\n          \"repository\": \"Ancestry\",\n          \"sequence\": 2,\n          \"status\": \"completed\"\n        },\n        {\n          \"date_range\": \"1850\",\n          \"fallback_for\": null,\n          \"id\": \"pli_003\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"Third independent index for coverage confirmation.\",\n          \"record_type\": \"census\",\n          \"repository\": \"MyHeritage\",\n          \"sequence\": 3,\n          \"status\": \"completed\"\n        }\n      ],\n      \"question_id\": \"q_002\",\n      \"status\": \"completed\"\n    },\n    {\n      \"created\": \"2026-05-02\",\n      \"id\": \"pl_002\",\n      \"items\": [\n        {\n          \"date_range\": \"1860\",\n          \"fallback_for\": null,\n          \"id\": \"pli_004\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"Confirm Patrick still in Thomas Flynn household in 1860. Strengthens parent-child identification.\",\n          \"record_type\": \"census\",\n          \"repository\": \"FamilySearch\",\n          \"sequence\": 1,\n          \"status\": \"completed\"\n        },\n        {\n          \"date_range\": \"1908\",\n          \"fallback_for\": null,\n          \"id\": \"pli_005\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"Death certificate may name parents directly.\",\n          \"record_type\": \"vital_record\",\n          \"repository\": \"FamilySearch\",\n          \"sequence\": 2,\n          \"status\": \"completed\"\n        },\n        {\n          \"date_range\": \"1870-1890\",\n          \"fallback_for\": null,\n          \"id\": \"pli_006\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"Thomas Flynn probate/will may name Patrick as son.\",\n          \"record_type\": \"probate\",\n          \"repository\": \"FamilySearch\",\n          \"sequence\": 3,\n          \"status\": \"in_progress\"\n        }\n      ],\n      \"question_id\": \"q_001\",\n      \"status\": \"active\"\n    },\n    {\n      \"created\": \"2026-05-05\",\n      \"id\": \"pl_003\",\n      \"items\": [\n        {\n          \"date_range\": \"1840\",\n          \"fallback_for\": null,\n          \"id\": \"pli_007\",\n          \"jurisdiction\": \"Luzerne County, Pennsylvania\",\n          \"rationale\": \"Search for Thomas Flynn in 1840 Luzerne County census to evaluate alternative father candidate.\",\n          \"record_type\": \"census\",\n          \"repository\": \"FamilySearch\",\n          \"sequence\": 1,\n          \"status\": \"completed\"\n        },\n        {\n          \"date_range\": \"1835-1845\",\n          \"fallback_for\": null,\n          \"id\": \"pli_008\",\n          \"jurisdiction\": \"Luzerne County, Pennsylvania\",\n          \"rationale\": \"Search for death record of Thomas Flynn in Luzerne County to establish his lifespan.\",\n          \"record_type\": \"vital_record\",\n          \"repository\": \"FamilySearch\",\n          \"sequence\": 2,\n          \"status\": \"completed\"\n        }\n      ],\n      \"question_id\": \"q_001\",\n      \"status\": \"completed\"\n    }\n  ],\n  \"project\": {\n    \"created\": \"2026-05-01\",\n    \"id\": \"rp_001\",\n    \"objective\": \"Identify the parents of Patrick Flynn, born ca. 1845 in Pennsylvania, died 1908 in Schuylkill County, PA\",\n    \"status\": \"active\",\n    \"subject_person_ids\": [\n      \"I1\"\n    ],\n    \"updated\": \"2026-05-06\"\n  },\n  \"proof_summaries\": [\n    {\n      \"exhaustive_search_summary\": \"Searched 1850 census (FamilySearch, Ancestry, MyHeritage \u2014 log_001, log_002, log_003), 1860 census (FamilySearch \u2014 log_004), and death certificate (FamilySearch \u2014 log_005). Probate search in progress. 1870, 1880, and 1900 censuses not yet searched.\",\n      \"id\": \"ps_001\",\n      \"narrative_markdown\": \"## Parentage of Patrick Flynn (ca. 1845\u20131908)\\n\\nPatrick Flynn is **Probably** the son of Thomas Flynn of Schuylkill County, Pennsylvania.\\n\\n### Evidence Summary\\n\\nThree independent lines of evidence support this conclusion:\\n\\n1. **1850 U.S. Census** (Original Source). Patrick Flynn, age 5, born Ireland, appears in the household of Thomas Flynn, age 32, born Ireland, in Schuylkill County, Pennsylvania (dwelling 84, family 91). The 1850 census does not state relationships, but Patrick's position in the household and shared surname are consistent with a parent-child relationship. The informant is indeterminate but likely a household member. This constitutes indirect evidence of parentage.\\n\\n2. **1860 U.S. Census** (Original Source). Patrick Flynn, age 15, born Ireland, appears in the household of Thomas Flynn in Schuylkill County (dwelling 112, family 119). Like the 1850 census, the 1860 census does not state relationships explicitly (the relationship column was not introduced until 1880). Patrick's position in the household, shared surname, and age consistent with the 1850 enumeration support a parent-child relationship. This constitutes indirect evidence of parentage.\\n\\n3. **1908 Death Certificate** (Original Source). Patrick Flynn's death certificate (no. 4521, Pennsylvania Department of Health) names \\\"Thomas Flynn\\\" as his father. The informant was James Brown, identified as Patrick's son-in-law. As a son-in-law reporting his father-in-law's parentage, Brown is a secondary informant for this fact \u2014 he was not a witness to Patrick's birth and is reporting what he was told. Nevertheless, this is direct evidence naming the father.\\n\\n### Conflict Resolution\\n\\nA birthplace conflict exists: the 1850 and 1860 censuses list Patrick's birthplace as Ireland, while the 1908 death certificate states Pennsylvania. The two census records are contemporary recordings with informants likely present in the household, while the death certificate was created 63 years after Patrick's birth by a son-in-law with no firsthand knowledge of the event. Per the GPS preponderance hierarchy, contemporary recordings by closer informants outweigh later recollections by secondary informants. Ireland is accepted as the birthplace; the death certificate entry is attributed to informant error.\\n\\n### Assessment\\n\\nThe conclusion is rated **Probable** rather than **Proved** because: (a) both census sources (1850 and 1860) provide only indirect evidence of parentage (relationships not stated \u2014 the relationship column was not introduced until 1880), (b) the death certificate informant is secondary, and (c) research is not yet exhaustive \u2014 the 1870, 1880, and 1900 censuses have not been searched, and Thomas Flynn's probate records have not been located. If Thomas Flynn's will names Patrick as a son, or if additional census records confirm the relationship, the conclusion would advance to **Proved**.\\n\\n### Citations\\n\\n1. 1850 U.S. Census, Schuylkill County, Pennsylvania, population schedule, dwelling 84, family 91, Thomas Flynn household; NARA microfilm publication M432, roll 810; digital image, FamilySearch.org, accessed 1 May 2026.\\n2. 1860 U.S. Census, Schuylkill County, Pennsylvania, population schedule, dwelling 112, family 119, Thomas Flynn household; NARA microfilm publication M653, roll 1141; digital image, FamilySearch.org, accessed 2 May 2026.\\n3. Pennsylvania Department of Health, death certificate no. 4521 (1908), Patrick Flynn; Pennsylvania State Archives, Harrisburg; digital image, FamilySearch.org, accessed 3 May 2026.\",\n      \"question_id\": \"q_001\",\n      \"resolved_conflict_ids\": [\n        \"c_001\"\n      ],\n      \"supporting_assertion_ids\": [\n        \"a_004\",\n        \"a_010\",\n        \"a_013\"\n      ],\n      \"tier\": \"probable\",\n      \"vehicle\": \"summary\"\n    }\n  ],\n  \"questions\": [\n    {\n      \"created\": \"2026-05-01\",\n      \"depends_on\": [],\n      \"exhaustive_declaration\": {\n        \"declared\": false,\n        \"justification\": null,\n        \"log_entry_ids\": [],\n        \"stop_criteria\": null\n      },\n      \"id\": \"q_001\",\n      \"priority\": \"high\",\n      \"question\": \"Who were the parents of Patrick Flynn (b. ~1845, PA, d. 1908)?\",\n      \"rationale\": \"This is the primary research objective.\",\n      \"resolution_assertion_ids\": [],\n      \"resolved\": null,\n      \"selection_basis\": \"objective_decomposition\",\n      \"status\": \"in_progress\",\n      \"unblocks\": []\n    },\n    {\n      \"created\": \"2026-05-01\",\n      \"depends_on\": [],\n      \"exhaustive_declaration\": {\n        \"declared\": true,\n        \"justification\": \"Searched 1850 census for Schuylkill County on FamilySearch (indexed and browse), Ancestry (indexed), and MyHeritage (indexed). All three returned the same household. No other Patrick Flynn of matching age found in the county.\",\n        \"log_entry_ids\": [\n          \"log_001\",\n          \"log_002\",\n          \"log_003\"\n        ],\n        \"stop_criteria\": {\n          \"conflict_resolution\": \"No conflicts on the 1850 census placement question.\",\n          \"evidence_class\": \"Yes \u2014 FamilySearch provides original census image with indeterminate-quality information.\",\n          \"goal_alignment\": \"Yes \u2014 Patrick Flynn located in a specific 1850 household, answering the question.\",\n          \"independent_verification\": \"FamilySearch (original) and Ancestry (derivative) both return the same household. Two access paths, one underlying original.\",\n          \"original_substitution\": \"FamilySearch provides the original census image; Ancestry index is derivative but confirmed consistent.\",\n          \"overturn_risk\": \"Low \u2014 all three repositories agree, and no competing Patrick Flynn of matching age exists in the county.\",\n          \"repository_breadth\": \"Three major repositories searched (FamilySearch, Ancestry, MyHeritage). No additional known indexes of the 1850 Schuylkill County census exist.\"\n        }\n      },\n      \"id\": \"q_002\",\n      \"priority\": \"high\",\n      \"question\": \"Where was Patrick Flynn in the 1850 census?\",\n      \"rationale\": \"The 1850 census is the earliest enumeration where Patrick would appear by name (age ~5). Locating him in a household identifies candidate parents.\",\n      \"resolution_assertion_ids\": [\n        \"a_001\",\n        \"a_002\",\n        \"a_003\"\n      ],\n      \"resolved\": \"2026-05-02\",\n      \"selection_basis\": \"objective_decomposition\",\n      \"status\": \"resolved\",\n      \"unblocks\": [\n        \"q_001\"\n      ]\n    }\n  ],\n  \"sources\": [\n    {\n      \"access_date\": \"2026-05-01\",\n      \"citation\": \"1850 U.S. Census, Schuylkill County, Pennsylvania, population schedule, dwelling 84, family 91, Thomas Flynn household; NARA microfilm publication M432, roll 810; digital image, FamilySearch.org, accessed 1 May 2026.\",\n      \"citation_detail\": {\n        \"what\": \"1850 U.S. Federal Census, population schedule\",\n        \"when_accessed\": \"2026-05-01\",\n        \"when_created\": \"1850\",\n        \"where\": \"FamilySearch.org (NARA microfilm M432, roll 810)\",\n        \"where_within\": \"Schuylkill County, dwelling 84, family 91\",\n        \"who\": \"U.S. Census Bureau\"\n      },\n      \"gedcomx_source_description_id\": \"S1\",\n      \"id\": \"src_001\",\n      \"log_entry_id\": \"log_001\",\n      \"notes\": \"Image quality good. Enumerator handwriting clear.\",\n      \"repository\": \"FamilySearch\",\n      \"source_classification\": \"original\",\n      \"url\": \"https://www.familysearch.org/ark:/61903/1:1:MXYZ\",\n      \"url_archived\": null\n    },\n    {\n      \"access_date\": \"2026-05-01\",\n      \"citation\": \"1850 U.S. Census, Schuylkill County, Pennsylvania, population schedule, dwelling 84, Thomas Flynn household; digital image, Ancestry.com, accessed 1 May 2026.\",\n      \"citation_detail\": {\n        \"what\": \"1850 U.S. Federal Census, population schedule (Ancestry index)\",\n        \"when_accessed\": \"2026-05-01\",\n        \"when_created\": \"1850\",\n        \"where\": \"Ancestry.com\",\n        \"where_within\": \"Schuylkill County, dwelling 84\",\n        \"who\": \"U.S. Census Bureau\"\n      },\n      \"gedcomx_source_description_id\": \"S1\",\n      \"id\": \"src_002\",\n      \"log_entry_id\": \"log_002\",\n      \"notes\": \"Ancestry's index of the same original census. Transcription consistent with FamilySearch.\",\n      \"repository\": \"Ancestry\",\n      \"source_classification\": \"derivative\",\n      \"url\": null,\n      \"url_archived\": null\n    },\n    {\n      \"access_date\": \"2026-05-02\",\n      \"citation\": \"1860 U.S. Census, Schuylkill County, Pennsylvania, population schedule, dwelling 112, family 119, Thomas Flynn household; NARA microfilm publication M653, roll 1141; digital image, FamilySearch.org, accessed 2 May 2026.\",\n      \"citation_detail\": {\n        \"what\": \"1860 U.S. Federal Census, population schedule\",\n        \"when_accessed\": \"2026-05-02\",\n        \"when_created\": \"1860\",\n        \"where\": \"FamilySearch.org (NARA microfilm M653, roll 1141)\",\n        \"where_within\": \"Schuylkill County, dwelling 112, family 119\",\n        \"who\": \"U.S. Census Bureau\"\n      },\n      \"gedcomx_source_description_id\": \"S2\",\n      \"id\": \"src_003\",\n      \"log_entry_id\": \"log_004\",\n      \"notes\": null,\n      \"repository\": \"FamilySearch\",\n      \"source_classification\": \"original\",\n      \"url\": \"https://www.familysearch.org/ark:/61903/1:1:MABC\",\n      \"url_archived\": null\n    },\n    {\n      \"access_date\": \"2026-05-03\",\n      \"citation\": \"Pennsylvania Department of Health, death certificate no. 4521 (1908), Patrick Flynn; Pennsylvania State Archives, Harrisburg; digital image, FamilySearch.org, accessed 3 May 2026.\",\n      \"citation_detail\": {\n        \"what\": \"Death certificate no. 4521\",\n        \"when_accessed\": \"2026-05-03\",\n        \"when_created\": \"1908-03-14\",\n        \"where\": \"FamilySearch.org (Pennsylvania State Archives, Harrisburg)\",\n        \"where_within\": \"Certificate no. 4521\",\n        \"who\": \"Pennsylvania Department of Health; informant: James Brown (son-in-law)\"\n      },\n      \"gedcomx_source_description_id\": \"S3\",\n      \"id\": \"src_004\",\n      \"log_entry_id\": \"log_005\",\n      \"notes\": \"Informant is son-in-law James Brown. Primary for death facts, secondary for birth facts.\",\n      \"repository\": \"FamilySearch\",\n      \"source_classification\": \"original\",\n      \"url\": \"https://www.familysearch.org/ark:/61903/1:1:MDEF\",\n      \"url_archived\": null\n    },\n    {\n      \"access_date\": \"2026-05-05\",\n      \"citation\": \"1840 U.S. Census, Luzerne County, Pennsylvania, population schedule, Thomas Flynn household; NARA microfilm publication M704, roll 456; digital image, FamilySearch.org, accessed 5 May 2026.\",\n      \"citation_detail\": {\n        \"what\": \"1840 U.S. Federal Census, population schedule\",\n        \"when_accessed\": \"2026-05-05\",\n        \"when_created\": \"1840\",\n        \"where\": \"FamilySearch.org (NARA microfilm M704, roll 456)\",\n        \"where_within\": \"Luzerne County, Thomas Flynn household\",\n        \"who\": \"U.S. Census Bureau\"\n      },\n      \"gedcomx_source_description_id\": \"S5\",\n      \"id\": \"src_005\",\n      \"log_entry_id\": \"log_006\",\n      \"notes\": \"1840 census does not name household members \u2014 only tick marks by age/sex categories. Thomas Flynn listed as head, 1 male 30-39, 1 male under 5.\",\n      \"repository\": \"FamilySearch\",\n      \"source_classification\": \"original\",\n      \"url\": \"https://www.familysearch.org/ark:/61903/1:1:MPQR\",\n      \"url_archived\": null\n    },\n    {\n      \"access_date\": \"2026-05-05\",\n      \"citation\": \"Luzerne County death record (1840), Thomas Flynn, died 15 September 1840, age 30, typhoid fever; Luzerne County Courthouse, Wilkes-Barre; digital image, FamilySearch.org, accessed 5 May 2026.\",\n      \"citation_detail\": {\n        \"what\": \"Death record, Thomas Flynn\",\n        \"when_accessed\": \"2026-05-05\",\n        \"when_created\": \"1840\",\n        \"where\": \"FamilySearch.org (Luzerne County Courthouse, Wilkes-Barre)\",\n        \"where_within\": \"Thomas Flynn entry, 15 September 1840\",\n        \"who\": \"Luzerne County Clerk\"\n      },\n      \"gedcomx_source_description_id\": \"S6\",\n      \"id\": \"src_006\",\n      \"log_entry_id\": \"log_007\",\n      \"notes\": \"Death record states: Thomas Flynn, age 30, died 15 September 1840, cause typhoid fever. This places his death 5 years before Patrick's estimated 1845 birth.\",\n      \"repository\": \"FamilySearch\",\n      \"source_classification\": \"original\",\n      \"url\": \"https://www.familysearch.org/ark:/61903/1:1:MSTU\",\n      \"url_archived\": null\n    },\n    {\n      \"access_date\": \"2026-05-06\",\n      \"citation\": \"Marriage record, St. Augustine Church, Philadelphia, Pennsylvania, Thomas Flynn and Mary Walsh, 14 June 1842; Philadelphia Archdiocesan Historical Research Center; digital image, FamilySearch.org, accessed 6 May 2026.\",\n      \"citation_detail\": {\n        \"what\": \"Catholic marriage register entry\",\n        \"when_accessed\": \"2026-05-06\",\n        \"when_created\": \"1842-06-14\",\n        \"where\": \"FamilySearch.org (Philadelphia Archdiocesan Historical Research Center)\",\n        \"where_within\": \"Thomas Flynn and Mary Walsh entry, 14 June 1842\",\n        \"who\": \"Parish priest, St. Augustine Church\"\n      },\n      \"gedcomx_source_description_id\": \"S7\",\n      \"id\": \"src_007\",\n      \"log_entry_id\": \"log_008\",\n      \"notes\": \"Original parish register. Lists Thomas Flynn age 19, Mary Walsh age 18. Witnesses: John Flynn and Catherine Walsh.\",\n      \"repository\": \"FamilySearch\",\n      \"source_classification\": \"original\",\n      \"url\": \"https://www.familysearch.org/ark:/61903/1:1:NWXY\",\n      \"url_archived\": null\n    }\n  ],\n  \"timelines\": [\n    {\n      \"events\": [\n        {\n          \"assertion_ids\": [\n            \"a_002\",\n            \"a_009\"\n          ],\n          \"date\": \"~1845\",\n          \"date_certainty\": \"estimated\",\n          \"description\": \"Born in Ireland, estimated from census ages\",\n          \"event_type\": \"birth\",\n          \"place\": \"Ireland\"\n        },\n        {\n          \"assertion_ids\": [\n            \"a_003\",\n            \"a_004\"\n          ],\n          \"date\": \"1850\",\n          \"date_certainty\": \"exact\",\n          \"description\": \"Enumerated age 5 in Thomas Flynn household, dwelling 84\",\n          \"event_type\": \"census\",\n          \"place\": \"Schuylkill County, Pennsylvania\"\n        },\n        {\n          \"assertion_ids\": [\n            \"a_008\",\n            \"a_009\",\n            \"a_010\"\n          ],\n          \"date\": \"1860\",\n          \"date_certainty\": \"exact\",\n          \"description\": \"Enumerated age 15 in Thomas Flynn household, dwelling 112\",\n          \"event_type\": \"census\",\n          \"place\": \"Schuylkill County, Pennsylvania\"\n        },\n        {\n          \"assertion_ids\": [\n            \"a_011\",\n            \"a_013\"\n          ],\n          \"date\": \"1908-03-12\",\n          \"date_certainty\": \"exact\",\n          \"description\": \"Died, death certificate names Thomas Flynn as father\",\n          \"event_type\": \"death\",\n          \"place\": \"Schuylkill County, Pennsylvania\"\n        }\n      ],\n      \"gaps\": [\n        {\n          \"end\": \"1908-03-12\",\n          \"expected_events\": [\n            \"marriage\",\n            \"1870_census\",\n            \"1880_census\",\n            \"1900_census\",\n            \"residence\",\n            \"occupation\"\n          ],\n          \"severity\": \"high\",\n          \"start\": \"1860-01-01\"\n        }\n      ],\n      \"generated\": \"2026-05-03T12:00:00Z\",\n      \"hypothesis_id\": \"h_001\",\n      \"id\": \"t_001\",\n      \"impossibilities\": [],\n      \"label\": \"Patrick Flynn \u2014 assuming Thomas Flynn parentage\",\n      \"person_ids\": [\n        \"I1\"\n      ]\n    }\n  ]\n}\n",
+    "eval/fixtures/scenarios/flynn-competing-fathers/tree.gedcomx.json": "{\n  \"persons\": [\n    {\n      \"facts\": [\n        {\n          \"date\": \"~1845\",\n          \"id\": \"F1\",\n          \"place\": \"Ireland\",\n          \"primary\": true,\n          \"sources\": [\n            {\n              \"page\": \"1850 Census, Schuylkill Co., dwelling 84\",\n              \"ref\": \"S1\"\n            }\n          ],\n          \"type\": \"Birth\"\n        },\n        {\n          \"date\": \"1908-03-12\",\n          \"id\": \"F2\",\n          \"place\": \"Schuylkill County, Pennsylvania\",\n          \"sources\": [\n            {\n              \"page\": \"Death cert. no. 4521\",\n              \"ref\": \"S3\"\n            }\n          ],\n          \"type\": \"Death\"\n        }\n      ],\n      \"gender\": \"Male\",\n      \"id\": \"I1\",\n      \"names\": [\n        {\n          \"given\": \"Patrick\",\n          \"id\": \"N1\",\n          \"preferred\": true,\n          \"surname\": \"Flynn\",\n          \"type\": \"BirthName\"\n        }\n      ]\n    },\n    {\n      \"facts\": [\n        {\n          \"date\": \"~1818\",\n          \"id\": \"F3\",\n          \"place\": \"Ireland\",\n          \"primary\": true,\n          \"type\": \"Birth\"\n        }\n      ],\n      \"gender\": \"Male\",\n      \"id\": \"I2\",\n      \"names\": [\n        {\n          \"given\": \"Thomas\",\n          \"id\": \"N2\",\n          \"preferred\": true,\n          \"surname\": \"Flynn\",\n          \"type\": \"BirthName\"\n        }\n      ]\n    },\n    {\n      \"facts\": [\n        {\n          \"date\": \"~1810\",\n          \"id\": \"F4\",\n          \"place\": \"Ireland\",\n          \"primary\": true,\n          \"type\": \"Birth\"\n        },\n        {\n          \"date\": \"1840-09-15\",\n          \"id\": \"F5\",\n          \"place\": \"Luzerne County, Pennsylvania\",\n          \"sources\": [\n            {\n              \"page\": \"Luzerne County death record, 1840\",\n              \"ref\": \"S6\"\n            }\n          ],\n          \"type\": \"Death\"\n        }\n      ],\n      \"gender\": \"Male\",\n      \"id\": \"I3\",\n      \"names\": [\n        {\n          \"given\": \"Thomas\",\n          \"id\": \"N3\",\n          \"preferred\": true,\n          \"surname\": \"Flynn\",\n          \"type\": \"BirthName\"\n        }\n      ]\n    }\n  ],\n  \"relationships\": [\n    {\n      \"child\": \"I1\",\n      \"id\": \"R1\",\n      \"parent\": \"I2\",\n      \"sources\": [\n        {\n          \"page\": \"1850 Census, Schuylkill Co., dwelling 84\",\n          \"quality\": 2,\n          \"ref\": \"S1\"\n        },\n        {\n          \"page\": \"1860 Census, Schuylkill Co., dwelling 112\",\n          \"quality\": 2,\n          \"ref\": \"S2\"\n        },\n        {\n          \"page\": \"Death cert. no. 4521\",\n          \"quality\": 2,\n          \"ref\": \"S3\"\n        }\n      ],\n      \"type\": \"ParentChild\"\n    }\n  ],\n  \"sources\": [\n    {\n      \"author\": \"U.S. Census Bureau\",\n      \"id\": \"S1\",\n      \"title\": \"1850 U.S. Federal Census\"\n    },\n    {\n      \"author\": \"U.S. Census Bureau\",\n      \"id\": \"S2\",\n      \"title\": \"1860 U.S. Federal Census\"\n    },\n    {\n      \"author\": \"Pennsylvania Dept. of Health\",\n      \"id\": \"S3\",\n      \"title\": \"Pennsylvania Death Certificates\"\n    },\n    {\n      \"author\": \"Schuylkill County Register of Wills\",\n      \"id\": \"S4\",\n      \"title\": \"Schuylkill County Probate Records\"\n    },\n    {\n      \"author\": \"U.S. Census Bureau\",\n      \"id\": \"S5\",\n      \"title\": \"1840 U.S. Federal Census\"\n    },\n    {\n      \"author\": \"Luzerne County Clerk\",\n      \"id\": \"S6\",\n      \"title\": \"Luzerne County Death Records\"\n    },\n    {\n      \"author\": \"Parish of St. Augustine\",\n      \"id\": \"S7\",\n      \"title\": \"Catholic Marriage Register, St. Augustine Church, Philadelphia\"\n    }\n  ]\n}\n",
+    "eval/fixtures/scenarios/flynn-multi-conflict/README.md": "# flynn-multi-conflict\n\nPatrick Flynn parentage research with two unresolved conflicts active simultaneously. Same as `flynn-with-birthplace-conflict` plus a second identity conflict.\n\n- **Conflicts:**\n  - `c_001` \u2014 birthplace (Ireland vs Pennsylvania), fact conflict, status: `unresolved`\n  - `c_002` \u2014 identity (which Patrick Flynn in 1850 Schuylkill County is the subject?), identity conflict, status: `unresolved`\n- **Both conflicts have:** null `preferred_assertion_id`, null `independence_analysis`, null `weighing_analysis`, null `resolution_rationale`. Both list `q_001` in `blocks_question_ids`.\n- **Everything else:** Same as `mid-research-flynn`.\n\n## Used by\n\n- `conflict-resolution` **prioritization** tests \u2014 when two conflicts exist, which should be tackled first?\n- Tests verifying that the skill addresses one conflict at a time rather than producing tangled resolution prose covering both.\n- `question-selection` tests where the next research question must address whichever conflict the skill identifies as most blocking.\n\n## Two distinct conflict shapes\n\n- **Fact conflict (c_001):** at least 2 competing assertions, named `disputed_attribute`, null `identity_question`.\n- **Identity conflict (c_002):** at least 1 competing assertion (the assertion whose person linkage is uncertain), null `disputed_attribute`, populated `identity_question`.\n\nThis is the only scenario in the seed corpus where both conflict types are simultaneously present.\n",
+    "eval/fixtures/scenarios/flynn-multi-conflict/research.json": "{\n  \"assertions\": [\n    {\n      \"date\": null,\n      \"date_certainty\": null,\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_002\"\n      ],\n      \"fact_type\": \"name\",\n      \"id\": \"a_001\",\n      \"informant\": \"Unknown informant (most likely a household member, possibly a neighbor) reporting to census enumerator\",\n      \"informant_bias_notes\": \"Census enumerator is the recorder, not the informant. The person who provided the name is unknown \u2014 most likely a household member, possibly a neighbor. Proximity is 'unknown' rather than 'household_member' because for names specifically, the enumerator may have heard the name from a neighbor or made an assumption \u2014 the name fact doesn't necessarily require active reporting the way age/birthplace does.\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_001\",\n      \"place\": null,\n      \"record_id\": \"ark:/61903/1:1:MXYZ\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_001\",\n      \"structured_value\": {\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"value\": \"Patrick Flynn\"\n    },\n    {\n      \"date\": \"~1845\",\n      \"date_certainty\": \"estimated\",\n      \"evidence_type\": \"indirect\",\n      \"extracted_for_question_ids\": [\n        \"q_002\"\n      ],\n      \"fact_type\": \"birth\",\n      \"id\": \"a_002\",\n      \"informant\": \"Unknown \u2014 most likely a household member (such as Thomas Flynn or his wife), but possibly a neighbor\",\n      \"informant_bias_notes\": \"Age and birthplace require active reporting by an informant \u2014 someone had to tell the enumerator these facts. That informant was most likely a household member, but enumerators also took information from neighbors when residents were unavailable, and the census does not identify who answered. Proximity is 'unknown' because the informant cannot be established from the record.\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_001\",\n      \"place\": \"Ireland\",\n      \"record_id\": \"ark:/61903/1:1:MXYZ\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_001\",\n      \"structured_value\": {\n        \"place\": \"Ireland\",\n        \"year\": 1845\n      },\n      \"value\": \"age 5\"\n    },\n    {\n      \"date\": \"1850\",\n      \"date_certainty\": \"exact\",\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_002\"\n      ],\n      \"fact_type\": \"residence\",\n      \"id\": \"a_003\",\n      \"informant\": \"Census enumerator (witness to residence by visiting the dwelling)\",\n      \"informant_bias_notes\": \"For residence facts specifically, the enumerator is a direct witness \u2014 they physically visited the dwelling and recorded who lived there. This distinguishes residence from other census facts where an unidentified informant (most likely a household member, possibly a neighbor) supplied the information.\",\n      \"informant_proximity\": \"witness\",\n      \"information_quality\": \"primary\",\n      \"log_entry_id\": \"log_001\",\n      \"place\": \"Schuylkill County, Pennsylvania\",\n      \"record_id\": \"ark:/61903/1:1:MXYZ\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_001\",\n      \"value\": \"Schuylkill County, Pennsylvania\"\n    },\n    {\n      \"date\": \"1850\",\n      \"date_certainty\": \"exact\",\n      \"evidence_type\": \"indirect\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"relationship\",\n      \"id\": \"a_004\",\n      \"informant\": \"Inferred from household structure \u2014 no explicit informant for relationships in 1850 census\",\n      \"informant_bias_notes\": \"1850 census does not state relationships; this assertion is inferred from household position and shared surname, not directly reported by any informant. The relationship is indirect evidence constructed by the researcher, not information provided by a census informant.\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_001\",\n      \"place\": \"Schuylkill County, Pennsylvania\",\n      \"record_id\": \"ark:/61903/1:1:MXYZ\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_001\",\n      \"structured_value\": {\n        \"related_person_role\": \"head_of_household\",\n        \"relationship_type\": \"child_inferred\"\n      },\n      \"value\": \"Listed in household of Thomas Flynn (head), position consistent with child\"\n    },\n    {\n      \"date\": null,\n      \"date_certainty\": null,\n      \"evidence_type\": \"indirect\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"name\",\n      \"id\": \"a_005\",\n      \"informant\": \"Unknown informant (likely Thomas Flynn himself) reporting to census enumerator\",\n      \"informant_bias_notes\": \"Census enumerator is the recorder, not the informant. As head of household, Thomas likely provided his own name, but the 1850 census does not identify the informant.\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_001\",\n      \"place\": null,\n      \"record_id\": \"ark:/61903/1:1:MXYZ\",\n      \"record_role\": \"head_of_household\",\n      \"source_id\": \"src_001\",\n      \"value\": \"Thomas Flynn\"\n    },\n    {\n      \"date\": null,\n      \"date_certainty\": null,\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_002\"\n      ],\n      \"fact_type\": \"name\",\n      \"id\": \"a_006\",\n      \"informant\": \"Ancestry transcriber (derivative of census enumerator)\",\n      \"informant_bias_notes\": \"Derivative index \u2014 transcription errors possible\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_002\",\n      \"place\": null,\n      \"record_id\": \"ancestry:8054:patrick-flynn-1850\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_002\",\n      \"value\": \"Patrick Flynn\"\n    },\n    {\n      \"date\": \"~1845\",\n      \"date_certainty\": \"estimated\",\n      \"evidence_type\": \"indirect\",\n      \"extracted_for_question_ids\": [\n        \"q_002\"\n      ],\n      \"fact_type\": \"birth\",\n      \"id\": \"a_007\",\n      \"informant\": \"Ancestry transcriber (derivative)\",\n      \"informant_bias_notes\": null,\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_002\",\n      \"place\": \"Ireland\",\n      \"record_id\": \"ancestry:8054:patrick-flynn-1850\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_002\",\n      \"value\": \"age 5\"\n    },\n    {\n      \"date\": null,\n      \"date_certainty\": null,\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"name\",\n      \"id\": \"a_008\",\n      \"informant\": \"Unknown informant (most likely a household member, possibly a neighbor) reporting to census enumerator\",\n      \"informant_bias_notes\": \"Census enumerator is the recorder, not the informant. Proximity is 'unknown' for names (same reasoning as a_001 \u2014 name facts don't necessarily require active reporting).\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_004\",\n      \"place\": null,\n      \"record_id\": \"ark:/61903/1:1:MABC\",\n      \"record_role\": \"child_2\",\n      \"source_id\": \"src_003\",\n      \"value\": \"Patrick Flynn\"\n    },\n    {\n      \"date\": \"~1845\",\n      \"date_certainty\": \"estimated\",\n      \"evidence_type\": \"indirect\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"birth\",\n      \"id\": \"a_009\",\n      \"informant\": \"Unknown \u2014 most likely a household member (such as Thomas Flynn or his wife), but possibly a neighbor\",\n      \"informant_bias_notes\": \"Age and birthplace require active reporting by an informant \u2014 most likely a household member, possibly a neighbor (same reasoning as a_002).\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_004\",\n      \"place\": \"Ireland\",\n      \"record_id\": \"ark:/61903/1:1:MABC\",\n      \"record_role\": \"child_2\",\n      \"source_id\": \"src_003\",\n      \"value\": \"age 15\"\n    },\n    {\n      \"date\": \"1860\",\n      \"date_certainty\": \"exact\",\n      \"evidence_type\": \"indirect\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"relationship\",\n      \"id\": \"a_010\",\n      \"informant\": \"Inferred from household structure \u2014 no explicit informant for relationships in 1860 census\",\n      \"informant_bias_notes\": \"1860 census does not state relationships; like the 1850 census, this assertion is inferred from household position, age, and shared surname. The relationship column was not introduced until the 1880 census.\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_004\",\n      \"place\": \"Schuylkill County, Pennsylvania\",\n      \"record_id\": \"ark:/61903/1:1:MABC\",\n      \"record_role\": \"child_2\",\n      \"source_id\": \"src_003\",\n      \"structured_value\": {\n        \"related_person_role\": \"head_of_household\",\n        \"relationship_type\": \"child_inferred\"\n      },\n      \"value\": \"Listed in household of Thomas Flynn (head), position and age consistent with son\"\n    },\n    {\n      \"date\": \"1908-03-12\",\n      \"date_certainty\": \"exact\",\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [],\n      \"fact_type\": \"death\",\n      \"id\": \"a_011\",\n      \"informant\": \"Attending physician (signature on certificate)\",\n      \"informant_bias_notes\": null,\n      \"informant_proximity\": \"witness\",\n      \"information_quality\": \"primary\",\n      \"log_entry_id\": \"log_005\",\n      \"place\": \"Schuylkill County, Pennsylvania\",\n      \"record_id\": \"ark:/61903/1:1:MDEF\",\n      \"record_role\": \"deceased\",\n      \"source_id\": \"src_004\",\n      \"value\": \"Died 12 March 1908\"\n    },\n    {\n      \"date\": \"1845\",\n      \"date_certainty\": \"approximate\",\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"birth\",\n      \"id\": \"a_012\",\n      \"informant\": \"James Brown (son-in-law)\",\n      \"informant_bias_notes\": \"Son-in-law reporting birth facts decades after the event. Note: death cert says Pennsylvania, but census records say Ireland. Son-in-law may not have known Patrick was born in Ireland.\",\n      \"informant_proximity\": \"family_not_present\",\n      \"information_quality\": \"secondary\",\n      \"log_entry_id\": \"log_005\",\n      \"place\": \"Pennsylvania\",\n      \"record_id\": \"ark:/61903/1:1:MDEF\",\n      \"record_role\": \"deceased\",\n      \"source_id\": \"src_004\",\n      \"structured_value\": {\n        \"place\": \"Pennsylvania\",\n        \"year\": 1845\n      },\n      \"value\": \"Born 1845, Pennsylvania\"\n    },\n    {\n      \"date\": null,\n      \"date_certainty\": null,\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"relationship\",\n      \"id\": \"a_013\",\n      \"informant\": \"James Brown (son-in-law)\",\n      \"informant_bias_notes\": \"Secondary information \u2014 son-in-law reporting what he was told about father-in-law's parentage\",\n      \"informant_proximity\": \"family_not_present\",\n      \"information_quality\": \"secondary\",\n      \"log_entry_id\": \"log_005\",\n      \"place\": null,\n      \"record_id\": \"ark:/61903/1:1:MDEF\",\n      \"record_role\": \"deceased\",\n      \"source_id\": \"src_004\",\n      \"structured_value\": {\n        \"related_person_role\": \"deceased\",\n        \"relationship_type\": \"father\"\n      },\n      \"value\": \"Father: Thomas Flynn\"\n    }\n  ],\n  \"conflicts\": [\n    {\n      \"blocks_question_ids\": [\n        \"q_001\"\n      ],\n      \"competing_assertion_ids\": [\n        \"a_002\",\n        \"a_009\",\n        \"a_012\"\n      ],\n      \"conflict_type\": \"fact\",\n      \"description\": \"Patrick Flynn's birthplace: Ireland (1850 and 1860 censuses) vs. Pennsylvania (1908 death certificate)\",\n      \"disputed_attribute\": \"birthplace\",\n      \"id\": \"c_001\",\n      \"identity_question\": null,\n      \"independence_analysis\": null,\n      \"preferred_assertion_id\": null,\n      \"resolution_rationale\": null,\n      \"status\": \"unresolved\",\n      \"weighing_analysis\": null\n    },\n    {\n      \"blocks_question_ids\": [\n        \"q_001\"\n      ],\n      \"competing_assertion_ids\": [\n        \"a_001\"\n      ],\n      \"conflict_type\": \"identity\",\n      \"description\": \"Is the Patrick Flynn in Thomas Flynn's 1850 household the same person as the Patrick Flynn on the 1908 death certificate? Two Patrick Flynns of similar age are recorded in Schuylkill County in 1850 \u2014 household 84 (age 5) and household 197 (age 6) \u2014 and the death certificate does not name a household or earlier residence to disambiguate.\",\n      \"disputed_attribute\": null,\n      \"id\": \"c_002\",\n      \"identity_question\": \"Is the Patrick Flynn enumerated in the Thomas Flynn 1850 household the same person as the Patrick Flynn whose 1908 death certificate is src_004?\",\n      \"independence_analysis\": null,\n      \"preferred_assertion_id\": null,\n      \"resolution_rationale\": null,\n      \"status\": \"unresolved\",\n      \"weighing_analysis\": null\n    }\n  ],\n  \"evaluations\": [],\n  \"hypotheses\": [\n    {\n      \"claim\": \"Patrick Flynn's father was Thomas Flynn of Schuylkill County, Pennsylvania\",\n      \"contradicting_assertion_ids\": [],\n      \"id\": \"h_001\",\n      \"notes\": \"Three independent pieces of evidence: 1850 census co-enumeration (indirect), 1860 census co-enumeration (indirect \u2014 relationship inferred from household position), death certificate naming Thomas as father (direct, secondary informant). Awaiting probate records for additional confirmation.\",\n      \"related_question_ids\": [\n        \"q_001\"\n      ],\n      \"ruled_out\": false,\n      \"ruled_out_reason\": null,\n      \"status\": \"supported\",\n      \"supporting_assertion_ids\": [\n        \"a_004\",\n        \"a_010\",\n        \"a_013\"\n      ]\n    }\n  ],\n  \"log\": [\n    {\n      \"external_site\": null,\n      \"id\": \"log_001\",\n      \"notes\": \"Found Patrick Flynn age 5 in household of Thomas Flynn, dwelling 84, Schuylkill Co. Three other Flynn results examined \u2014 ages and locations don't match.\",\n      \"outcome\": \"positive\",\n      \"performed\": \"2026-05-01T10:15:00Z\",\n      \"plan_item_id\": \"pli_001\",\n      \"query\": {\n        \"birth_place\": \"Pennsylvania\",\n        \"birth_year\": 1845,\n        \"collection\": \"1850 Census\",\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"results_examined\": 8,\n      \"tool\": \"record_search\"\n    },\n    {\n      \"external_site\": {\n        \"capture_filename\": \"ancestry-1850-flynn-results.pdf\",\n        \"capture_received\": true,\n        \"site\": \"ancestry\",\n        \"url_generated\": \"https://www.ancestry.com/search/collections/8054/?name=Patrick_Flynn&birth=1845&birthplace=Pennsylvania\"\n      },\n      \"id\": \"log_002\",\n      \"notes\": \"Ancestry index confirms same household. Transcription matches FamilySearch except Ancestry reads dwelling as 84, FamilySearch as 84 \u2014 consistent.\",\n      \"outcome\": \"positive\",\n      \"performed\": \"2026-05-01T11:30:00Z\",\n      \"plan_item_id\": \"pli_002\",\n      \"query\": {\n        \"birth_place\": \"Pennsylvania\",\n        \"birth_year\": 1845,\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"results_examined\": 12,\n      \"tool\": \"external_site\"\n    },\n    {\n      \"external_site\": {\n        \"capture_filename\": \"myheritage-1850-flynn-nil.pdf\",\n        \"capture_received\": true,\n        \"site\": \"myheritage\",\n        \"url_generated\": \"https://www.myheritage.com/research?action=query&first=Patrick&last=Flynn&birth_year=1845&birth_place=Pennsylvania\"\n      },\n      \"id\": \"log_003\",\n      \"notes\": \"MyHeritage returned no results for Patrick Flynn in 1850 Schuylkill County. Site may not have this collection indexed. Searched broader Pennsylvania \u2014 still no match.\",\n      \"outcome\": \"negative\",\n      \"performed\": \"2026-05-01T14:00:00Z\",\n      \"plan_item_id\": \"pli_003\",\n      \"query\": {\n        \"birth_place\": \"Pennsylvania\",\n        \"birth_year\": 1845,\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"results_examined\": 0,\n      \"tool\": \"external_site\"\n    },\n    {\n      \"external_site\": null,\n      \"id\": \"log_004\",\n      \"notes\": \"Patrick Flynn age 15 in household of Thomas Flynn, Schuylkill Co. Consistent with 1850 placement.\",\n      \"outcome\": \"positive\",\n      \"performed\": \"2026-05-02T09:00:00Z\",\n      \"plan_item_id\": \"pli_004\",\n      \"query\": {\n        \"birth_place\": \"Pennsylvania\",\n        \"birth_year\": 1845,\n        \"collection\": \"1860 Census\",\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"results_examined\": 5,\n      \"tool\": \"record_search\"\n    },\n    {\n      \"external_site\": null,\n      \"id\": \"log_005\",\n      \"notes\": \"Death certificate found. Names Thomas Flynn as father. Informant was son-in-law James Brown.\",\n      \"outcome\": \"positive\",\n      \"performed\": \"2026-05-03T10:00:00Z\",\n      \"plan_item_id\": \"pli_005\",\n      \"query\": {\n        \"death_place\": \"Schuylkill County, Pennsylvania\",\n        \"death_year\": 1908,\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"results_examined\": 2,\n      \"tool\": \"record_search\"\n    }\n  ],\n  \"person_evidence\": [\n    {\n      \"assertion_id\": \"a_001\",\n      \"confidence\": \"confident\",\n      \"created\": \"2026-05-01\",\n      \"id\": \"pe_001\",\n      \"match_score\": null,\n      \"person_id\": \"I1\",\n      \"rationale\": \"Name matches (Patrick Flynn), age consistent with ~1845 birth, located in Schuylkill County where subject is known to have lived. Only Patrick Flynn of this age in the county in 1850.\",\n      \"superseded_by\": null\n    },\n    {\n      \"assertion_id\": \"a_004\",\n      \"confidence\": \"probable\",\n      \"created\": \"2026-05-01\",\n      \"id\": \"pe_002\",\n      \"match_score\": null,\n      \"person_id\": \"I1\",\n      \"rationale\": \"Same record as pe_001, same person. Household position and shared surname with head Thomas Flynn suggest parent-child relationship, but 1850 census does not state relationships explicitly.\",\n      \"superseded_by\": null\n    },\n    {\n      \"assertion_id\": \"a_004\",\n      \"confidence\": \"probable\",\n      \"created\": \"2026-05-01\",\n      \"id\": \"pe_006\",\n      \"match_score\": null,\n      \"person_id\": \"I2\",\n      \"rationale\": \"Same assertion as pe_002 but linked to Thomas Flynn (I2). The relationship assertion ('position consistent with child') equally bears on the head of household. Thomas Flynn is the other party in the implied parent-child relationship.\",\n      \"superseded_by\": null\n    },\n    {\n      \"assertion_id\": \"a_005\",\n      \"confidence\": \"probable\",\n      \"created\": \"2026-05-01\",\n      \"id\": \"pe_003\",\n      \"match_score\": 0.82,\n      \"person_id\": \"I2\",\n      \"rationale\": \"Thomas Flynn, head of household where Patrick was found. Age (~32 in 1850, born ~1818) is consistent with being Patrick's father. Name matches candidate father.\",\n      \"superseded_by\": null\n    },\n    {\n      \"assertion_id\": \"a_010\",\n      \"confidence\": \"confident\",\n      \"created\": \"2026-05-02\",\n      \"id\": \"pe_004\",\n      \"match_score\": null,\n      \"person_id\": \"I1\",\n      \"rationale\": \"Patrick Flynn age 15 in Thomas Flynn household, 1860 census. Same county, age consistent with 1850 enumeration. Relationship inferred from household position and shared surname (1860 census does not state relationships explicitly).\",\n      \"superseded_by\": null\n    },\n    {\n      \"assertion_id\": \"a_013\",\n      \"confidence\": \"confident\",\n      \"created\": \"2026-05-03\",\n      \"id\": \"pe_005\",\n      \"match_score\": null,\n      \"person_id\": \"I1\",\n      \"rationale\": \"Death certificate for Patrick Flynn, d. 1908, Schuylkill County. Names match, death location matches known residence. Names Thomas Flynn as father.\",\n      \"superseded_by\": null\n    }\n  ],\n  \"plans\": [\n    {\n      \"created\": \"2026-05-01\",\n      \"id\": \"pl_001\",\n      \"items\": [\n        {\n          \"date_range\": \"1850\",\n          \"fallback_for\": null,\n          \"id\": \"pli_001\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"1850 census fully indexed on FamilySearch. Free access, start here.\",\n          \"record_type\": \"census\",\n          \"repository\": \"FamilySearch\",\n          \"sequence\": 1,\n          \"status\": \"completed\"\n        },\n        {\n          \"date_range\": \"1850\",\n          \"fallback_for\": null,\n          \"id\": \"pli_002\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"Ancestry has independent indexing; cross-check for transcription errors.\",\n          \"record_type\": \"census\",\n          \"repository\": \"Ancestry\",\n          \"sequence\": 2,\n          \"status\": \"completed\"\n        },\n        {\n          \"date_range\": \"1850\",\n          \"fallback_for\": null,\n          \"id\": \"pli_003\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"Third independent index for coverage confirmation.\",\n          \"record_type\": \"census\",\n          \"repository\": \"MyHeritage\",\n          \"sequence\": 3,\n          \"status\": \"completed\"\n        }\n      ],\n      \"question_id\": \"q_002\",\n      \"status\": \"completed\"\n    },\n    {\n      \"created\": \"2026-05-02\",\n      \"id\": \"pl_002\",\n      \"items\": [\n        {\n          \"date_range\": \"1860\",\n          \"fallback_for\": null,\n          \"id\": \"pli_004\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"Confirm Patrick still in Thomas Flynn household in 1860. Strengthens parent-child identification.\",\n          \"record_type\": \"census\",\n          \"repository\": \"FamilySearch\",\n          \"sequence\": 1,\n          \"status\": \"completed\"\n        },\n        {\n          \"date_range\": \"1908\",\n          \"fallback_for\": null,\n          \"id\": \"pli_005\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"Death certificate may name parents directly.\",\n          \"record_type\": \"vital_record\",\n          \"repository\": \"FamilySearch\",\n          \"sequence\": 2,\n          \"status\": \"completed\"\n        },\n        {\n          \"date_range\": \"1870-1890\",\n          \"fallback_for\": null,\n          \"id\": \"pli_006\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"Thomas Flynn probate/will may name Patrick as son.\",\n          \"record_type\": \"probate\",\n          \"repository\": \"FamilySearch\",\n          \"sequence\": 3,\n          \"status\": \"in_progress\"\n        }\n      ],\n      \"question_id\": \"q_001\",\n      \"status\": \"active\"\n    }\n  ],\n  \"project\": {\n    \"created\": \"2026-05-01\",\n    \"id\": \"rp_001\",\n    \"objective\": \"Identify the parents of Patrick Flynn, born ca. 1845 in Pennsylvania, died 1908 in Schuylkill County, PA\",\n    \"status\": \"active\",\n    \"subject_person_ids\": [\n      \"I1\"\n    ],\n    \"updated\": \"2026-05-04\"\n  },\n  \"proof_summaries\": [\n    {\n      \"exhaustive_search_summary\": \"Searched 1850 census (FamilySearch, Ancestry, MyHeritage \u2014 log_001, log_002, log_003), 1860 census (FamilySearch \u2014 log_004), and death certificate (FamilySearch \u2014 log_005). Probate search in progress. 1870, 1880, and 1900 censuses not yet searched.\",\n      \"id\": \"ps_001\",\n      \"narrative_markdown\": \"## Parentage of Patrick Flynn (ca. 1845\u20131908)\\n\\nPatrick Flynn is **Probably** the son of Thomas Flynn of Schuylkill County, Pennsylvania.\\n\\n### Evidence Summary\\n\\nThree independent lines of evidence support this conclusion:\\n\\n1. **1850 U.S. Census** (Original Source). Patrick Flynn, age 5, born Ireland, appears in the household of Thomas Flynn, age 32, born Ireland, in Schuylkill County, Pennsylvania (dwelling 84, family 91). The 1850 census does not state relationships, but Patrick's position in the household and shared surname are consistent with a parent-child relationship. The informant is indeterminate but likely a household member. This constitutes indirect evidence of parentage.\\n\\n2. **1860 U.S. Census** (Original Source). Patrick Flynn, age 15, born Ireland, appears in the household of Thomas Flynn in Schuylkill County (dwelling 112, family 119). Like the 1850 census, the 1860 census does not state relationships explicitly (the relationship column was not introduced until 1880). Patrick's position in the household, shared surname, and age consistent with the 1850 enumeration support a parent-child relationship. This constitutes indirect evidence of parentage.\\n\\n3. **1908 Death Certificate** (Original Source). Patrick Flynn's death certificate (no. 4521, Pennsylvania Department of Health) names \\\"Thomas Flynn\\\" as his father. The informant was James Brown, identified as Patrick's son-in-law. As a son-in-law reporting his father-in-law's parentage, Brown is a secondary informant for this fact \u2014 he was not a witness to Patrick's birth and is reporting what he was told. Nevertheless, this is direct evidence naming the father.\\n\\n### Conflict Resolution\\n\\nA birthplace conflict exists: the 1850 and 1860 censuses list Patrick's birthplace as Ireland, while the 1908 death certificate states Pennsylvania. The two census records are contemporary recordings with informants likely present in the household, while the death certificate was created 63 years after Patrick's birth by a son-in-law with no firsthand knowledge of the event. Per the GPS preponderance hierarchy, contemporary recordings by closer informants outweigh later recollections by secondary informants. Ireland is accepted as the birthplace; the death certificate entry is attributed to informant error.\\n\\n### Assessment\\n\\nThe conclusion is rated **Probable** rather than **Proved** because: (a) both census sources (1850 and 1860) provide only indirect evidence of parentage (relationships not stated \u2014 the relationship column was not introduced until 1880), (b) the death certificate informant is secondary, and (c) research is not yet exhaustive \u2014 the 1870, 1880, and 1900 censuses have not been searched, and Thomas Flynn's probate records have not been located. If Thomas Flynn's will names Patrick as a son, or if additional census records confirm the relationship, the conclusion would advance to **Proved**.\\n\\n### Citations\\n\\n1. 1850 U.S. Census, Schuylkill County, Pennsylvania, population schedule, dwelling 84, family 91, Thomas Flynn household; NARA microfilm publication M432, roll 810; digital image, FamilySearch.org, accessed 1 May 2026.\\n2. 1860 U.S. Census, Schuylkill County, Pennsylvania, population schedule, dwelling 112, family 119, Thomas Flynn household; NARA microfilm publication M653, roll 1141; digital image, FamilySearch.org, accessed 2 May 2026.\\n3. Pennsylvania Department of Health, death certificate no. 4521 (1908), Patrick Flynn; Pennsylvania State Archives, Harrisburg; digital image, FamilySearch.org, accessed 3 May 2026.\",\n      \"question_id\": \"q_001\",\n      \"resolved_conflict_ids\": [\n        \"c_001\"\n      ],\n      \"supporting_assertion_ids\": [\n        \"a_004\",\n        \"a_010\",\n        \"a_013\"\n      ],\n      \"tier\": \"probable\",\n      \"vehicle\": \"summary\"\n    }\n  ],\n  \"questions\": [\n    {\n      \"created\": \"2026-05-01\",\n      \"depends_on\": [],\n      \"exhaustive_declaration\": {\n        \"declared\": false,\n        \"justification\": null,\n        \"log_entry_ids\": [],\n        \"stop_criteria\": null\n      },\n      \"id\": \"q_001\",\n      \"priority\": \"high\",\n      \"question\": \"Who were the parents of Patrick Flynn (b. ~1845, PA, d. 1908)?\",\n      \"rationale\": \"This is the primary research objective.\",\n      \"resolution_assertion_ids\": [],\n      \"resolved\": null,\n      \"selection_basis\": \"objective_decomposition\",\n      \"status\": \"in_progress\",\n      \"unblocks\": []\n    },\n    {\n      \"created\": \"2026-05-01\",\n      \"depends_on\": [],\n      \"exhaustive_declaration\": {\n        \"declared\": true,\n        \"justification\": \"Searched 1850 census for Schuylkill County on FamilySearch (indexed and browse), Ancestry (indexed), and MyHeritage (indexed). All three returned the same household. No other Patrick Flynn of matching age found in the county.\",\n        \"log_entry_ids\": [\n          \"log_001\",\n          \"log_002\",\n          \"log_003\"\n        ],\n        \"stop_criteria\": {\n          \"conflict_resolution\": \"No conflicts on the 1850 census placement question.\",\n          \"evidence_class\": \"Yes \u2014 FamilySearch provides original census image with indeterminate-quality information.\",\n          \"goal_alignment\": \"Yes \u2014 Patrick Flynn located in a specific 1850 household, answering the question.\",\n          \"independent_verification\": \"FamilySearch (original) and Ancestry (derivative) both return the same household. Two access paths, one underlying original.\",\n          \"original_substitution\": \"FamilySearch provides the original census image; Ancestry index is derivative but confirmed consistent.\",\n          \"overturn_risk\": \"Low \u2014 all three repositories agree, and no competing Patrick Flynn of matching age exists in the county.\",\n          \"repository_breadth\": \"Three major repositories searched (FamilySearch, Ancestry, MyHeritage). No additional known indexes of the 1850 Schuylkill County census exist.\"\n        }\n      },\n      \"id\": \"q_002\",\n      \"priority\": \"high\",\n      \"question\": \"Where was Patrick Flynn in the 1850 census?\",\n      \"rationale\": \"The 1850 census is the earliest enumeration where Patrick would appear by name (age ~5). Locating him in a household identifies candidate parents.\",\n      \"resolution_assertion_ids\": [\n        \"a_001\",\n        \"a_002\",\n        \"a_003\"\n      ],\n      \"resolved\": \"2026-05-02\",\n      \"selection_basis\": \"objective_decomposition\",\n      \"status\": \"resolved\",\n      \"unblocks\": [\n        \"q_001\"\n      ]\n    }\n  ],\n  \"sources\": [\n    {\n      \"access_date\": \"2026-05-01\",\n      \"citation\": \"1850 U.S. Census, Schuylkill County, Pennsylvania, population schedule, dwelling 84, family 91, Thomas Flynn household; NARA microfilm publication M432, roll 810; digital image, FamilySearch.org, accessed 1 May 2026.\",\n      \"citation_detail\": {\n        \"what\": \"1850 U.S. Federal Census, population schedule\",\n        \"when_accessed\": \"2026-05-01\",\n        \"when_created\": \"1850\",\n        \"where\": \"FamilySearch.org (NARA microfilm M432, roll 810)\",\n        \"where_within\": \"Schuylkill County, dwelling 84, family 91\",\n        \"who\": \"U.S. Census Bureau\"\n      },\n      \"gedcomx_source_description_id\": \"S1\",\n      \"id\": \"src_001\",\n      \"log_entry_id\": \"log_001\",\n      \"notes\": \"Image quality good. Enumerator handwriting clear.\",\n      \"repository\": \"FamilySearch\",\n      \"source_classification\": \"original\",\n      \"url\": \"https://www.familysearch.org/ark:/61903/1:1:MXYZ\",\n      \"url_archived\": null\n    },\n    {\n      \"access_date\": \"2026-05-01\",\n      \"citation\": \"1850 U.S. Census, Schuylkill County, Pennsylvania, population schedule, dwelling 84, Thomas Flynn household; digital image, Ancestry.com, accessed 1 May 2026.\",\n      \"citation_detail\": {\n        \"what\": \"1850 U.S. Federal Census, population schedule (Ancestry index)\",\n        \"when_accessed\": \"2026-05-01\",\n        \"when_created\": \"1850\",\n        \"where\": \"Ancestry.com\",\n        \"where_within\": \"Schuylkill County, dwelling 84\",\n        \"who\": \"U.S. Census Bureau\"\n      },\n      \"gedcomx_source_description_id\": \"S1\",\n      \"id\": \"src_002\",\n      \"log_entry_id\": \"log_002\",\n      \"notes\": \"Ancestry's index of the same original census. Transcription consistent with FamilySearch.\",\n      \"repository\": \"Ancestry\",\n      \"source_classification\": \"derivative\",\n      \"url\": null,\n      \"url_archived\": null\n    },\n    {\n      \"access_date\": \"2026-05-02\",\n      \"citation\": \"1860 U.S. Census, Schuylkill County, Pennsylvania, population schedule, dwelling 112, family 119, Thomas Flynn household; NARA microfilm publication M653, roll 1141; digital image, FamilySearch.org, accessed 2 May 2026.\",\n      \"citation_detail\": {\n        \"what\": \"1860 U.S. Federal Census, population schedule\",\n        \"when_accessed\": \"2026-05-02\",\n        \"when_created\": \"1860\",\n        \"where\": \"FamilySearch.org (NARA microfilm M653, roll 1141)\",\n        \"where_within\": \"Schuylkill County, dwelling 112, family 119\",\n        \"who\": \"U.S. Census Bureau\"\n      },\n      \"gedcomx_source_description_id\": \"S2\",\n      \"id\": \"src_003\",\n      \"log_entry_id\": \"log_004\",\n      \"notes\": null,\n      \"repository\": \"FamilySearch\",\n      \"source_classification\": \"original\",\n      \"url\": \"https://www.familysearch.org/ark:/61903/1:1:MABC\",\n      \"url_archived\": null\n    },\n    {\n      \"access_date\": \"2026-05-03\",\n      \"citation\": \"Pennsylvania Department of Health, death certificate no. 4521 (1908), Patrick Flynn; Pennsylvania State Archives, Harrisburg; digital image, FamilySearch.org, accessed 3 May 2026.\",\n      \"citation_detail\": {\n        \"what\": \"Death certificate no. 4521\",\n        \"when_accessed\": \"2026-05-03\",\n        \"when_created\": \"1908-03-14\",\n        \"where\": \"FamilySearch.org (Pennsylvania State Archives, Harrisburg)\",\n        \"where_within\": \"Certificate no. 4521\",\n        \"who\": \"Pennsylvania Department of Health; informant: James Brown (son-in-law)\"\n      },\n      \"gedcomx_source_description_id\": \"S3\",\n      \"id\": \"src_004\",\n      \"log_entry_id\": \"log_005\",\n      \"notes\": \"Informant is son-in-law James Brown. Primary for death facts, secondary for birth facts.\",\n      \"repository\": \"FamilySearch\",\n      \"source_classification\": \"original\",\n      \"url\": \"https://www.familysearch.org/ark:/61903/1:1:MDEF\",\n      \"url_archived\": null\n    }\n  ],\n  \"timelines\": [\n    {\n      \"events\": [\n        {\n          \"assertion_ids\": [\n            \"a_002\",\n            \"a_009\"\n          ],\n          \"date\": \"~1845\",\n          \"date_certainty\": \"estimated\",\n          \"description\": \"Born in Ireland, estimated from census ages\",\n          \"event_type\": \"birth\",\n          \"place\": \"Ireland\"\n        },\n        {\n          \"assertion_ids\": [\n            \"a_003\",\n            \"a_004\"\n          ],\n          \"date\": \"1850\",\n          \"date_certainty\": \"exact\",\n          \"description\": \"Enumerated age 5 in Thomas Flynn household, dwelling 84\",\n          \"event_type\": \"census\",\n          \"place\": \"Schuylkill County, Pennsylvania\"\n        },\n        {\n          \"assertion_ids\": [\n            \"a_008\",\n            \"a_009\",\n            \"a_010\"\n          ],\n          \"date\": \"1860\",\n          \"date_certainty\": \"exact\",\n          \"description\": \"Enumerated age 15 in Thomas Flynn household, dwelling 112\",\n          \"event_type\": \"census\",\n          \"place\": \"Schuylkill County, Pennsylvania\"\n        },\n        {\n          \"assertion_ids\": [\n            \"a_011\",\n            \"a_013\"\n          ],\n          \"date\": \"1908-03-12\",\n          \"date_certainty\": \"exact\",\n          \"description\": \"Died, death certificate names Thomas Flynn as father\",\n          \"event_type\": \"death\",\n          \"place\": \"Schuylkill County, Pennsylvania\"\n        }\n      ],\n      \"gaps\": [\n        {\n          \"end\": \"1908-03-12\",\n          \"expected_events\": [\n            \"marriage\",\n            \"1870_census\",\n            \"1880_census\",\n            \"1900_census\",\n            \"residence\",\n            \"occupation\"\n          ],\n          \"severity\": \"high\",\n          \"start\": \"1860-01-01\"\n        }\n      ],\n      \"generated\": \"2026-05-03T12:00:00Z\",\n      \"hypothesis_id\": \"h_001\",\n      \"id\": \"t_001\",\n      \"impossibilities\": [],\n      \"label\": \"Patrick Flynn \u2014 assuming Thomas Flynn parentage\",\n      \"person_ids\": [\n        \"I1\"\n      ]\n    }\n  ]\n}\n",
+    "eval/fixtures/scenarios/flynn-multi-conflict/tree.gedcomx.json": "{\n  \"persons\": [\n    {\n      \"facts\": [\n        {\n          \"date\": \"~1845\",\n          \"id\": \"F1\",\n          \"place\": \"Ireland\",\n          \"primary\": true,\n          \"sources\": [\n            {\n              \"page\": \"1850 Census, Schuylkill Co., dwelling 84\",\n              \"ref\": \"S1\"\n            }\n          ],\n          \"type\": \"Birth\"\n        },\n        {\n          \"date\": \"1908-03-12\",\n          \"id\": \"F2\",\n          \"place\": \"Schuylkill County, Pennsylvania\",\n          \"sources\": [\n            {\n              \"page\": \"Death cert. no. 4521\",\n              \"ref\": \"S3\"\n            }\n          ],\n          \"type\": \"Death\"\n        }\n      ],\n      \"gender\": \"Male\",\n      \"id\": \"I1\",\n      \"names\": [\n        {\n          \"given\": \"Patrick\",\n          \"id\": \"N1\",\n          \"preferred\": true,\n          \"surname\": \"Flynn\",\n          \"type\": \"BirthName\"\n        }\n      ]\n    },\n    {\n      \"facts\": [\n        {\n          \"date\": \"~1818\",\n          \"id\": \"F3\",\n          \"place\": \"Ireland\",\n          \"primary\": true,\n          \"type\": \"Birth\"\n        }\n      ],\n      \"gender\": \"Male\",\n      \"id\": \"I2\",\n      \"names\": [\n        {\n          \"given\": \"Thomas\",\n          \"id\": \"N2\",\n          \"preferred\": true,\n          \"surname\": \"Flynn\",\n          \"type\": \"BirthName\"\n        }\n      ]\n    }\n  ],\n  \"relationships\": [\n    {\n      \"child\": \"I1\",\n      \"id\": \"R1\",\n      \"parent\": \"I2\",\n      \"sources\": [\n        {\n          \"page\": \"1850 Census, Schuylkill Co., dwelling 84\",\n          \"quality\": 2,\n          \"ref\": \"S1\"\n        },\n        {\n          \"page\": \"1860 Census, Schuylkill Co., dwelling 112\",\n          \"quality\": 2,\n          \"ref\": \"S2\"\n        },\n        {\n          \"page\": \"Death cert. no. 4521\",\n          \"quality\": 2,\n          \"ref\": \"S3\"\n        }\n      ],\n      \"type\": \"ParentChild\"\n    }\n  ],\n  \"sources\": [\n    {\n      \"author\": \"U.S. Census Bureau\",\n      \"id\": \"S1\",\n      \"title\": \"1850 U.S. Federal Census\"\n    },\n    {\n      \"author\": \"U.S. Census Bureau\",\n      \"id\": \"S2\",\n      \"title\": \"1860 U.S. Federal Census\"\n    },\n    {\n      \"author\": \"Pennsylvania Dept. of Health\",\n      \"id\": \"S3\",\n      \"title\": \"Pennsylvania Death Certificates\"\n    },\n    {\n      \"author\": \"Schuylkill County Register of Wills\",\n      \"id\": \"S4\",\n      \"title\": \"Schuylkill County Probate Records\"\n    }\n  ]\n}\n",
+    "eval/fixtures/scenarios/flynn-young-candidate/README.md": "# flynn-young-candidate\n\nPatrick Flynn parentage research with a single father candidate who\nturns out to be too young to be the biological father.\n\nThe 1850 census lists Thomas Flynn as head of household, age\napproximately 20 (born ~1830), with Patrick Flynn age 5 in the same\ndwelling. At face value, a man born ~1830 could be Patrick's father\n(~15 at Patrick's birth). However, an Irish baptism register has been\nfound showing Thomas Flynn was baptized on 12 March 1835 in Dungarvan,\nCounty Waterford, Ireland. This makes Thomas only ~10 years old when\nPatrick was born (~1845) \u2014 a biological impossibility.\n\nThe key design: the baptism assertion (a_006) exists in the assertions\narray and is linked to Thomas (I2) via person_evidence (pe_005), but\nit is NOT linked to h_001's contradicting_assertion_ids. Claude must\nread the data, perform the age arithmetic (1845 - 1835 = 10), conclude\nbiological impossibility, and rule out the hypothesis.\n\n- **Objective:** Identify the parents of Patrick Flynn (b. ~1845, d. 1908)\n- **Questions:** q_001 (parentage, in_progress)\n- **Plans:** pl_001 (active, 2 items)\n- **Log:** 2 entries (1850 census search + Irish baptism search)\n- **Sources:** 2 (1850 census + Irish baptism register)\n- **Assertions:** 7 (census name/birth/relationship/residence + Thomas name/birth + baptism)\n- **Person evidence:** 5 links (3 for Patrick, 2 for Thomas)\n- **Conflicts:** none\n- **Hypotheses:** h_001 (Thomas of Schuylkill, active, supporting: [a_003], contradicting: [])\n- **GedcomX persons:** I1 (Patrick Flynn), I2 (Thomas Flynn)\n- **GedcomX relationships:** R1 (ParentChild, Thomas -> Patrick)\n",
+    "eval/fixtures/scenarios/flynn-young-candidate/research.json": "{\n  \"assertions\": [\n    {\n      \"date\": null,\n      \"date_certainty\": null,\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"name\",\n      \"id\": \"a_001\",\n      \"informant\": \"Unknown household member reporting to census enumerator\",\n      \"informant_bias_notes\": null,\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_001\",\n      \"place\": null,\n      \"record_id\": \"ark:/61903/1:1:MXYZ\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_001\",\n      \"structured_value\": {\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"value\": \"Patrick Flynn\"\n    },\n    {\n      \"date\": \"~1845\",\n      \"date_certainty\": \"estimated\",\n      \"evidence_type\": \"indirect\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"birth\",\n      \"id\": \"a_002\",\n      \"informant\": \"Unknown household member (likely Thomas Flynn)\",\n      \"informant_bias_notes\": null,\n      \"informant_proximity\": \"household_member\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_001\",\n      \"place\": \"Ireland\",\n      \"record_id\": \"ark:/61903/1:1:MXYZ\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_001\",\n      \"structured_value\": {\n        \"place\": \"Ireland\",\n        \"year\": 1845\n      },\n      \"value\": \"age 5\"\n    },\n    {\n      \"date\": \"1850\",\n      \"date_certainty\": \"exact\",\n      \"evidence_type\": \"indirect\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"relationship\",\n      \"id\": \"a_003\",\n      \"informant\": \"Inferred from household structure\",\n      \"informant_bias_notes\": \"1850 census does not state relationships; inferred from household position and shared surname.\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_001\",\n      \"place\": \"Schuylkill County, Pennsylvania\",\n      \"record_id\": \"ark:/61903/1:1:MXYZ\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_001\",\n      \"structured_value\": {\n        \"related_person_role\": \"head_of_household\",\n        \"relationship_type\": \"child_inferred\"\n      },\n      \"value\": \"Listed in household of Thomas Flynn (head), position consistent with child\"\n    },\n    {\n      \"date\": null,\n      \"date_certainty\": null,\n      \"evidence_type\": \"indirect\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"name\",\n      \"id\": \"a_004\",\n      \"informant\": \"Unknown household member reporting to census enumerator\",\n      \"informant_bias_notes\": null,\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_001\",\n      \"place\": null,\n      \"record_id\": \"ark:/61903/1:1:MXYZ\",\n      \"record_role\": \"head_of_household\",\n      \"source_id\": \"src_001\",\n      \"structured_value\": {\n        \"given\": \"Thomas\",\n        \"surname\": \"Flynn\"\n      },\n      \"value\": \"Thomas Flynn\"\n    },\n    {\n      \"date\": \"~1830\",\n      \"date_certainty\": \"estimated\",\n      \"evidence_type\": \"indirect\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"birth\",\n      \"id\": \"a_005\",\n      \"informant\": \"Unknown household member (likely Thomas Flynn himself)\",\n      \"informant_bias_notes\": \"Census ages are frequently rounded or misreported. The age of ~20 is the enumerator's recording, which may be approximate.\",\n      \"informant_proximity\": \"household_member\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_001\",\n      \"place\": \"Ireland\",\n      \"record_id\": \"ark:/61903/1:1:MXYZ\",\n      \"record_role\": \"head_of_household\",\n      \"source_id\": \"src_001\",\n      \"structured_value\": {\n        \"year\": 1830\n      },\n      \"value\": \"age approximately 20\"\n    },\n    {\n      \"date\": \"1835-03-12\",\n      \"date_certainty\": \"exact\",\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"birth\",\n      \"id\": \"a_006\",\n      \"informant\": \"Parish priest recording baptism at time of event\",\n      \"informant_bias_notes\": \"Original parish register entry created at time of baptism. Primary information quality \u2014 the priest witnessed the baptism and recorded it contemporaneously.\",\n      \"informant_proximity\": \"witness\",\n      \"information_quality\": \"primary\",\n      \"log_entry_id\": \"log_002\",\n      \"place\": \"Dungarvan, County Waterford, Ireland\",\n      \"record_id\": \"ark:/61903/1:1:NBCD\",\n      \"record_role\": \"child\",\n      \"source_id\": \"src_002\",\n      \"structured_value\": {\n        \"day\": 12,\n        \"month\": 3,\n        \"place\": \"Dungarvan, County Waterford, Ireland\",\n        \"year\": 1835\n      },\n      \"value\": \"Baptized 12 March 1835, parish of Dungarvan, County Waterford, Ireland. Parents: Michael Flynn and Bridget Morrissey.\"\n    },\n    {\n      \"date\": \"1850\",\n      \"date_certainty\": \"exact\",\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"residence\",\n      \"id\": \"a_007\",\n      \"informant\": \"Census enumerator (witness to residence by visiting the dwelling)\",\n      \"informant_bias_notes\": null,\n      \"informant_proximity\": \"witness\",\n      \"information_quality\": \"primary\",\n      \"log_entry_id\": \"log_001\",\n      \"place\": \"Schuylkill County, Pennsylvania\",\n      \"record_id\": \"ark:/61903/1:1:MXYZ\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_001\",\n      \"value\": \"Schuylkill County, Pennsylvania\"\n    }\n  ],\n  \"conflicts\": [],\n  \"evaluations\": [],\n  \"hypotheses\": [\n    {\n      \"claim\": \"Patrick Flynn's father was Thomas Flynn of Schuylkill County, Pennsylvania\",\n      \"contradicting_assertion_ids\": [],\n      \"id\": \"h_001\",\n      \"notes\": \"Based on 1850 census co-enumeration. Thomas Flynn listed as head of household age ~20, with Patrick age 5 in the same dwelling. Relationship inferred from household position and shared surname (1850 census does not state relationships).\",\n      \"related_question_ids\": [\n        \"q_001\"\n      ],\n      \"ruled_out\": false,\n      \"ruled_out_reason\": null,\n      \"status\": \"active\",\n      \"supporting_assertion_ids\": [\n        \"a_003\"\n      ]\n    }\n  ],\n  \"log\": [\n    {\n      \"external_site\": null,\n      \"id\": \"log_001\",\n      \"notes\": \"Found Patrick Flynn age 5 in household of Thomas Flynn, dwelling 84, Schuylkill Co. Thomas Flynn listed as head of household, age approximately 20.\",\n      \"outcome\": \"positive\",\n      \"performed\": \"2026-05-01T10:15:00Z\",\n      \"plan_item_id\": \"pli_001\",\n      \"query\": {\n        \"birth_place\": \"Pennsylvania\",\n        \"birth_year\": 1845,\n        \"collection\": \"1850 Census\",\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"results_examined\": 8,\n      \"tool\": \"record_search\"\n    },\n    {\n      \"external_site\": null,\n      \"id\": \"log_002\",\n      \"notes\": \"Found baptism entry: Thomas Flynn, baptized 12 March 1835, parish of Dungarvan, County Waterford, Ireland. Parents listed as Michael Flynn and Bridget Morrissey. This record suggests Thomas was born in 1835, not ~1830 as estimated from the 1850 census age of ~20.\",\n      \"outcome\": \"positive\",\n      \"performed\": \"2026-05-10T09:00:00Z\",\n      \"plan_item_id\": \"pli_002\",\n      \"query\": {\n        \"birth_place\": \"Ireland\",\n        \"birth_year\": 1830,\n        \"collection\": \"Ireland Catholic Parish Registers\",\n        \"given\": \"Thomas\",\n        \"surname\": \"Flynn\"\n      },\n      \"results_examined\": 6,\n      \"tool\": \"record_search\"\n    }\n  ],\n  \"person_evidence\": [\n    {\n      \"assertion_id\": \"a_001\",\n      \"confidence\": \"confident\",\n      \"created\": \"2026-05-01\",\n      \"id\": \"pe_001\",\n      \"match_score\": null,\n      \"person_id\": \"I1\",\n      \"rationale\": \"Name matches (Patrick Flynn), age consistent with ~1845 birth, located in Schuylkill County.\",\n      \"superseded_by\": null\n    },\n    {\n      \"assertion_id\": \"a_003\",\n      \"confidence\": \"probable\",\n      \"created\": \"2026-05-01\",\n      \"id\": \"pe_002\",\n      \"match_score\": null,\n      \"person_id\": \"I1\",\n      \"rationale\": \"Same record as pe_001. Household position and shared surname with head Thomas Flynn suggest parent-child relationship.\",\n      \"superseded_by\": null\n    },\n    {\n      \"assertion_id\": \"a_003\",\n      \"confidence\": \"probable\",\n      \"created\": \"2026-05-01\",\n      \"id\": \"pe_003\",\n      \"match_score\": null,\n      \"person_id\": \"I2\",\n      \"rationale\": \"Thomas Flynn is the other party in the implied parent-child relationship.\",\n      \"superseded_by\": null\n    },\n    {\n      \"assertion_id\": \"a_004\",\n      \"confidence\": \"confident\",\n      \"created\": \"2026-05-01\",\n      \"id\": \"pe_004\",\n      \"match_score\": null,\n      \"person_id\": \"I2\",\n      \"rationale\": \"Thomas Flynn, head of household where Patrick was found.\",\n      \"superseded_by\": null\n    },\n    {\n      \"assertion_id\": \"a_006\",\n      \"confidence\": \"confident\",\n      \"created\": \"2026-05-10\",\n      \"id\": \"pe_005\",\n      \"match_score\": 0.92,\n      \"person_id\": \"I2\",\n      \"rationale\": \"Thomas Flynn baptized in Dungarvan, County Waterford. Name matches the head of household in the 1850 census. The census lists birthplace as Ireland, consistent with this baptism record. The baptism year (1835) differs from the census-estimated birth year (~1830), but a 5-year census age discrepancy is common for Irish immigrants in this period. Same given name, same surname, same country of origin, same approximate generation \u2014 this is the same Thomas Flynn.\",\n      \"superseded_by\": null\n    }\n  ],\n  \"plans\": [\n    {\n      \"created\": \"2026-05-01\",\n      \"id\": \"pl_001\",\n      \"items\": [\n        {\n          \"date_range\": \"1850\",\n          \"fallback_for\": null,\n          \"id\": \"pli_001\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"1850 census fully indexed on FamilySearch. Start here to find Patrick in a household.\",\n          \"record_type\": \"census\",\n          \"repository\": \"FamilySearch\",\n          \"sequence\": 1,\n          \"status\": \"completed\"\n        },\n        {\n          \"date_range\": \"1830-1840\",\n          \"fallback_for\": null,\n          \"id\": \"pli_002\",\n          \"jurisdiction\": \"County Waterford, Ireland\",\n          \"rationale\": \"Search Irish parish registers for Thomas Flynn baptism to verify his birth year.\",\n          \"record_type\": \"vital_record\",\n          \"repository\": \"FamilySearch\",\n          \"sequence\": 2,\n          \"status\": \"completed\"\n        }\n      ],\n      \"question_id\": \"q_001\",\n      \"status\": \"active\"\n    }\n  ],\n  \"project\": {\n    \"created\": \"2026-05-01\",\n    \"id\": \"rp_001\",\n    \"objective\": \"Identify the parents of Patrick Flynn, born ca. 1845 in Pennsylvania, died 1908 in Schuylkill County, PA\",\n    \"status\": \"active\",\n    \"subject_person_ids\": [\n      \"I1\"\n    ],\n    \"updated\": \"2026-05-10\"\n  },\n  \"proof_summaries\": [],\n  \"questions\": [\n    {\n      \"created\": \"2026-05-01\",\n      \"depends_on\": [],\n      \"exhaustive_declaration\": {\n        \"declared\": false,\n        \"justification\": null,\n        \"log_entry_ids\": [],\n        \"stop_criteria\": null\n      },\n      \"id\": \"q_001\",\n      \"priority\": \"high\",\n      \"question\": \"Who were the parents of Patrick Flynn (b. ~1845, PA, d. 1908)?\",\n      \"rationale\": \"This is the primary research objective.\",\n      \"resolution_assertion_ids\": [],\n      \"resolved\": null,\n      \"selection_basis\": \"objective_decomposition\",\n      \"status\": \"in_progress\",\n      \"unblocks\": []\n    }\n  ],\n  \"sources\": [\n    {\n      \"access_date\": \"2026-05-01\",\n      \"citation\": \"1850 U.S. Census, Schuylkill County, Pennsylvania, population schedule, dwelling 84, family 91, Thomas Flynn household; NARA microfilm publication M432, roll 810; digital image, FamilySearch.org, accessed 1 May 2026.\",\n      \"citation_detail\": {\n        \"what\": \"1850 U.S. Federal Census, population schedule\",\n        \"when_accessed\": \"2026-05-01\",\n        \"when_created\": \"1850\",\n        \"where\": \"FamilySearch.org (NARA microfilm M432, roll 810)\",\n        \"where_within\": \"Schuylkill County, dwelling 84, family 91\",\n        \"who\": \"U.S. Census Bureau\"\n      },\n      \"gedcomx_source_description_id\": \"S1\",\n      \"id\": \"src_001\",\n      \"log_entry_id\": \"log_001\",\n      \"notes\": \"Image quality good. Enumerator handwriting clear. Thomas Flynn listed as head, age approximately 20.\",\n      \"repository\": \"FamilySearch\",\n      \"source_classification\": \"original\",\n      \"url\": \"https://www.familysearch.org/ark:/61903/1:1:MXYZ\",\n      \"url_archived\": null\n    },\n    {\n      \"access_date\": \"2026-05-10\",\n      \"citation\": \"Catholic Parish Registers, Dungarvan, County Waterford, Ireland, baptism entry for Thomas Flynn, 12 March 1835; digital image, FamilySearch.org, accessed 10 May 2026.\",\n      \"citation_detail\": {\n        \"what\": \"Catholic baptism register entry\",\n        \"when_accessed\": \"2026-05-10\",\n        \"when_created\": \"1835-03-12\",\n        \"where\": \"FamilySearch.org\",\n        \"where_within\": \"Dungarvan parish, 12 March 1835 entry\",\n        \"who\": \"Parish priest, Dungarvan\"\n      },\n      \"gedcomx_source_description_id\": \"S2\",\n      \"id\": \"src_002\",\n      \"log_entry_id\": \"log_002\",\n      \"notes\": \"Original parish register. Entry reads: 'Thomas, son of Michael Flynn and Bridget Morrissey, sponsors Patrick Morrissey and Mary Flynn.' Clear handwriting.\",\n      \"repository\": \"FamilySearch\",\n      \"source_classification\": \"original\",\n      \"url\": \"https://www.familysearch.org/ark:/61903/1:1:NBCD\",\n      \"url_archived\": null\n    }\n  ],\n  \"timelines\": []\n}\n",
+    "eval/fixtures/scenarios/flynn-young-candidate/tree.gedcomx.json": "{\n  \"persons\": [\n    {\n      \"facts\": [\n        {\n          \"date\": \"~1845\",\n          \"id\": \"F1\",\n          \"place\": \"Ireland\",\n          \"primary\": true,\n          \"sources\": [\n            {\n              \"page\": \"1850 Census, Schuylkill Co., dwelling 84\",\n              \"ref\": \"S1\"\n            }\n          ],\n          \"type\": \"Birth\"\n        }\n      ],\n      \"gender\": \"Male\",\n      \"id\": \"I1\",\n      \"names\": [\n        {\n          \"given\": \"Patrick\",\n          \"id\": \"N1\",\n          \"preferred\": true,\n          \"surname\": \"Flynn\",\n          \"type\": \"BirthName\"\n        }\n      ]\n    },\n    {\n      \"facts\": [\n        {\n          \"date\": \"~1830\",\n          \"id\": \"F2\",\n          \"place\": \"Ireland\",\n          \"primary\": true,\n          \"sources\": [\n            {\n              \"page\": \"1850 Census, Schuylkill Co., dwelling 84, age ~20\",\n              \"ref\": \"S1\"\n            }\n          ],\n          \"type\": \"Birth\"\n        }\n      ],\n      \"gender\": \"Male\",\n      \"id\": \"I2\",\n      \"names\": [\n        {\n          \"given\": \"Thomas\",\n          \"id\": \"N2\",\n          \"preferred\": true,\n          \"surname\": \"Flynn\",\n          \"type\": \"BirthName\"\n        }\n      ]\n    }\n  ],\n  \"relationships\": [\n    {\n      \"child\": \"I1\",\n      \"id\": \"R1\",\n      \"parent\": \"I2\",\n      \"sources\": [\n        {\n          \"page\": \"1850 Census, Schuylkill Co., dwelling 84\",\n          \"quality\": 2,\n          \"ref\": \"S1\"\n        }\n      ],\n      \"type\": \"ParentChild\"\n    }\n  ],\n  \"sources\": [\n    {\n      \"author\": \"U.S. Census Bureau\",\n      \"id\": \"S1\",\n      \"title\": \"1850 U.S. Federal Census\"\n    },\n    {\n      \"author\": \"Parish of Dungarvan\",\n      \"id\": \"S2\",\n      \"title\": \"Catholic Parish Registers, Dungarvan, Co. Waterford\"\n    }\n  ]\n}\n",
+    "eval/fixtures/scenarios/mid-research-flynn/README.md": "# mid-research-flynn\n\nPatrick Flynn parentage research, mid-project.\n\n- **Objective:** Identify the parents of Patrick Flynn (b. ~1845, d. 1908)\n- **Questions:** q_001 (parentage, in_progress), q_002 (1850 census placement, resolved)\n- **Plans:** pl_001 (1850 census search, completed), pl_002 (parentage evidence, active)\n- **Log:** 5 entries \u2014 1850 census on FamilySearch/Ancestry/MyHeritage, 1860 census, death cert\n- **Sources:** 4 sources (1850 census FS, 1850 census Ancestry, 1860 census, death cert)\n- **Assertions:** 13 assertions across 4 sources\n- **Person evidence:** 6 links (Patrick \u2192 I1, Thomas \u2192 I2)\n- **Conflicts:** 1 resolved (birthplace: Ireland vs Pennsylvania)\n- **Hypotheses:** h_001 (Thomas is Patrick's father, supported)\n- **Timelines:** t_001 (Patrick, 4 events, 1 gap)\n- **Proof summaries:** ps_001 (parentage, probable)\n- **GedcomX persons:** I1 (Patrick Flynn), I2 (Thomas Flynn), I3 (Mary Flynn, sister), I4 (James Flynn, brother)\n- **GedcomX relationships:** R1 (Thomas \u2192 Patrick), R2 (Thomas \u2192 Mary), R3 (Thomas \u2192 James) \u2014 all ParentChild\n- **Note on siblings:** Mary and James are stub entries (preferred name + gender only, no facts).\n  They represent the canonical shape Dallan called for: when researching Patrick on a household\n  census, the siblings should exist as persons in `tree.gedcomx.json` so warnings like\n  `relativesChildBirthRange40` and skills like `person-evidence` can reach them. Their detailed\n  facts would land later via record-extraction + person-evidence as the user works through the\n  1850 census record.\n",
+    "eval/fixtures/scenarios/mid-research-flynn/research.json": "{\n  \"assertions\": [\n    {\n      \"date\": null,\n      \"date_certainty\": null,\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_002\"\n      ],\n      \"fact_type\": \"name\",\n      \"id\": \"a_001\",\n      \"informant\": \"Unknown informant (most likely a household member, possibly a neighbor) reporting to census enumerator\",\n      \"informant_bias_notes\": \"Census enumerator is the recorder, not the informant. The person who provided the name is unknown \u2014 most likely a household member, possibly a neighbor. Proximity is 'unknown' rather than 'household_member' because for names specifically, the enumerator may have heard the name from a neighbor or made an assumption \u2014 the name fact doesn't necessarily require active reporting the way age/birthplace does.\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_001\",\n      \"place\": null,\n      \"record_id\": \"ark:/61903/1:1:MXYZ\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_001\",\n      \"structured_value\": {\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"value\": \"Patrick Flynn\"\n    },\n    {\n      \"date\": \"~1845\",\n      \"date_certainty\": \"estimated\",\n      \"evidence_type\": \"indirect\",\n      \"extracted_for_question_ids\": [\n        \"q_002\"\n      ],\n      \"fact_type\": \"birth\",\n      \"id\": \"a_002\",\n      \"informant\": \"Unknown \u2014 most likely a household member (such as Thomas Flynn or his wife), but possibly a neighbor\",\n      \"informant_bias_notes\": \"Age and birthplace require active reporting by an informant \u2014 someone had to tell the enumerator these facts. That informant was most likely a household member, but enumerators also took information from neighbors when residents were unavailable, and the census does not identify who answered. Proximity is 'unknown' because the informant cannot be established from the record.\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_001\",\n      \"place\": \"Ireland\",\n      \"record_id\": \"ark:/61903/1:1:MXYZ\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_001\",\n      \"structured_value\": {\n        \"place\": \"Ireland\",\n        \"year\": 1845\n      },\n      \"value\": \"age 5\"\n    },\n    {\n      \"date\": \"1850\",\n      \"date_certainty\": \"exact\",\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_002\"\n      ],\n      \"fact_type\": \"residence\",\n      \"id\": \"a_003\",\n      \"informant\": \"Census enumerator (witness to residence by visiting the dwelling)\",\n      \"informant_bias_notes\": \"For residence facts specifically, the enumerator is a direct witness \u2014 they physically visited the dwelling and recorded who lived there. This distinguishes residence from other census facts where an unidentified informant (most likely a household member, possibly a neighbor) supplied the information.\",\n      \"informant_proximity\": \"witness\",\n      \"information_quality\": \"primary\",\n      \"log_entry_id\": \"log_001\",\n      \"place\": \"Schuylkill County, Pennsylvania\",\n      \"record_id\": \"ark:/61903/1:1:MXYZ\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_001\",\n      \"value\": \"Schuylkill County, Pennsylvania\"\n    },\n    {\n      \"date\": \"1850\",\n      \"date_certainty\": \"exact\",\n      \"evidence_type\": \"indirect\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"relationship\",\n      \"id\": \"a_004\",\n      \"informant\": \"Inferred from household structure \u2014 no explicit informant for relationships in 1850 census\",\n      \"informant_bias_notes\": \"1850 census does not state relationships; this assertion is inferred from household position and shared surname, not directly reported by any informant. The relationship is indirect evidence constructed by the researcher, not information provided by a census informant.\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_001\",\n      \"place\": \"Schuylkill County, Pennsylvania\",\n      \"record_id\": \"ark:/61903/1:1:MXYZ\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_001\",\n      \"structured_value\": {\n        \"related_person_role\": \"head_of_household\",\n        \"relationship_type\": \"child_inferred\"\n      },\n      \"value\": \"Listed in household of Thomas Flynn (head), position consistent with child\"\n    },\n    {\n      \"date\": null,\n      \"date_certainty\": null,\n      \"evidence_type\": \"indirect\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"name\",\n      \"id\": \"a_005\",\n      \"informant\": \"Unknown informant (likely Thomas Flynn himself) reporting to census enumerator\",\n      \"informant_bias_notes\": \"Census enumerator is the recorder, not the informant. As head of household, Thomas likely provided his own name, but the 1850 census does not identify the informant.\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_001\",\n      \"place\": null,\n      \"record_id\": \"ark:/61903/1:1:MXYZ\",\n      \"record_role\": \"head_of_household\",\n      \"source_id\": \"src_001\",\n      \"value\": \"Thomas Flynn\"\n    },\n    {\n      \"date\": null,\n      \"date_certainty\": null,\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_002\"\n      ],\n      \"fact_type\": \"name\",\n      \"id\": \"a_006\",\n      \"informant\": \"Ancestry transcriber (derivative of census enumerator)\",\n      \"informant_bias_notes\": \"Derivative index \u2014 transcription errors possible\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_002\",\n      \"place\": null,\n      \"record_id\": \"ancestry:8054:patrick-flynn-1850\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_002\",\n      \"value\": \"Patrick Flynn\"\n    },\n    {\n      \"date\": \"~1845\",\n      \"date_certainty\": \"estimated\",\n      \"evidence_type\": \"indirect\",\n      \"extracted_for_question_ids\": [\n        \"q_002\"\n      ],\n      \"fact_type\": \"birth\",\n      \"id\": \"a_007\",\n      \"informant\": \"Ancestry transcriber (derivative)\",\n      \"informant_bias_notes\": null,\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_002\",\n      \"place\": \"Ireland\",\n      \"record_id\": \"ancestry:8054:patrick-flynn-1850\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_002\",\n      \"value\": \"age 5\"\n    },\n    {\n      \"date\": null,\n      \"date_certainty\": null,\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"name\",\n      \"id\": \"a_008\",\n      \"informant\": \"Unknown informant (most likely a household member, possibly a neighbor) reporting to census enumerator\",\n      \"informant_bias_notes\": \"Census enumerator is the recorder, not the informant. Proximity is 'unknown' for names (same reasoning as a_001 \u2014 name facts don't necessarily require active reporting).\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_004\",\n      \"place\": null,\n      \"record_id\": \"ark:/61903/1:1:MABC\",\n      \"record_role\": \"child_2\",\n      \"source_id\": \"src_003\",\n      \"value\": \"Patrick Flynn\"\n    },\n    {\n      \"date\": \"~1845\",\n      \"date_certainty\": \"estimated\",\n      \"evidence_type\": \"indirect\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"birth\",\n      \"id\": \"a_009\",\n      \"informant\": \"Unknown \u2014 most likely a household member (such as Thomas Flynn or his wife), but possibly a neighbor\",\n      \"informant_bias_notes\": \"Age and birthplace require active reporting by an informant \u2014 most likely a household member, possibly a neighbor (same reasoning as a_002).\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_004\",\n      \"place\": \"Ireland\",\n      \"record_id\": \"ark:/61903/1:1:MABC\",\n      \"record_role\": \"child_2\",\n      \"source_id\": \"src_003\",\n      \"value\": \"age 15\"\n    },\n    {\n      \"date\": \"1860\",\n      \"date_certainty\": \"exact\",\n      \"evidence_type\": \"indirect\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"relationship\",\n      \"id\": \"a_010\",\n      \"informant\": \"Inferred from household structure \u2014 no explicit informant for relationships in 1860 census\",\n      \"informant_bias_notes\": \"1860 census does not state relationships; like the 1850 census, this assertion is inferred from household position, age, and shared surname. The relationship column was not introduced until the 1880 census.\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_004\",\n      \"place\": \"Schuylkill County, Pennsylvania\",\n      \"record_id\": \"ark:/61903/1:1:MABC\",\n      \"record_role\": \"child_2\",\n      \"source_id\": \"src_003\",\n      \"structured_value\": {\n        \"related_person_role\": \"head_of_household\",\n        \"relationship_type\": \"child_inferred\"\n      },\n      \"value\": \"Listed in household of Thomas Flynn (head), position and age consistent with son\"\n    },\n    {\n      \"date\": \"1908-03-12\",\n      \"date_certainty\": \"exact\",\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [],\n      \"fact_type\": \"death\",\n      \"id\": \"a_011\",\n      \"informant\": \"Attending physician (signature on certificate)\",\n      \"informant_bias_notes\": null,\n      \"informant_proximity\": \"witness\",\n      \"information_quality\": \"primary\",\n      \"log_entry_id\": \"log_005\",\n      \"place\": \"Schuylkill County, Pennsylvania\",\n      \"record_id\": \"ark:/61903/1:1:MDEF\",\n      \"record_role\": \"deceased\",\n      \"source_id\": \"src_004\",\n      \"value\": \"Died 12 March 1908\"\n    },\n    {\n      \"date\": \"1845\",\n      \"date_certainty\": \"approximate\",\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"birth\",\n      \"id\": \"a_012\",\n      \"informant\": \"James Brown (son-in-law)\",\n      \"informant_bias_notes\": \"Son-in-law reporting birth facts decades after the event. Note: death cert says Pennsylvania, but census records say Ireland. Son-in-law may not have known Patrick was born in Ireland.\",\n      \"informant_proximity\": \"family_not_present\",\n      \"information_quality\": \"secondary\",\n      \"log_entry_id\": \"log_005\",\n      \"place\": \"Pennsylvania\",\n      \"record_id\": \"ark:/61903/1:1:MDEF\",\n      \"record_role\": \"deceased\",\n      \"source_id\": \"src_004\",\n      \"structured_value\": {\n        \"place\": \"Pennsylvania\",\n        \"year\": 1845\n      },\n      \"value\": \"Born 1845, Pennsylvania\"\n    },\n    {\n      \"date\": null,\n      \"date_certainty\": null,\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"relationship\",\n      \"id\": \"a_013\",\n      \"informant\": \"James Brown (son-in-law)\",\n      \"informant_bias_notes\": \"Secondary information \u2014 son-in-law reporting what he was told about father-in-law's parentage\",\n      \"informant_proximity\": \"family_not_present\",\n      \"information_quality\": \"secondary\",\n      \"log_entry_id\": \"log_005\",\n      \"place\": null,\n      \"record_id\": \"ark:/61903/1:1:MDEF\",\n      \"record_role\": \"deceased\",\n      \"source_id\": \"src_004\",\n      \"structured_value\": {\n        \"related_person_role\": \"deceased\",\n        \"relationship_type\": \"father\"\n      },\n      \"value\": \"Father: Thomas Flynn\"\n    }\n  ],\n  \"conflicts\": [\n    {\n      \"blocks_question_ids\": [],\n      \"competing_assertion_ids\": [\n        \"a_002\",\n        \"a_009\",\n        \"a_012\"\n      ],\n      \"conflict_type\": \"fact\",\n      \"description\": \"Patrick Flynn's birthplace: Ireland (1850 and 1860 censuses) vs. Pennsylvania (1908 death certificate)\",\n      \"disputed_attribute\": \"birthplace\",\n      \"id\": \"c_001\",\n      \"identity_question\": null,\n      \"independence_analysis\": \"The two census records (1850, 1860) are independent original sources with different enumerators. The death certificate is a third independent original source. However, the census informants are likely the same household member (Thomas Flynn or wife), so the two census assertions may share a single informant \u2014 potentially not fully independent for this fact.\",\n      \"preferred_assertion_id\": \"a_002\",\n      \"resolution_rationale\": \"Ireland is accepted as the birthplace. The 1908 death certificate birthplace of 'Pennsylvania' is rejected as a likely error by the son-in-law informant, who may have confused Patrick's place of residence with his place of birth, or may not have known Patrick was born in Ireland before immigrating as a young child.\",\n      \"status\": \"resolved\",\n      \"weighing_analysis\": \"The census records are contemporary recordings made near the time of Patrick's birth, while the death certificate was created 63 years later. The census informant was likely a household member with firsthand knowledge (primary or indeterminate), while the death certificate informant (son-in-law) is clearly secondary for birth facts. Two contemporary sources outweigh one later recollection by a secondary informant.\"\n    }\n  ],\n  \"evaluations\": [],\n  \"hypotheses\": [\n    {\n      \"claim\": \"Patrick Flynn's father was Thomas Flynn of Schuylkill County, Pennsylvania\",\n      \"contradicting_assertion_ids\": [],\n      \"id\": \"h_001\",\n      \"notes\": \"Three independent pieces of evidence: 1850 census co-enumeration (indirect), 1860 census co-enumeration (indirect \u2014 relationship inferred from household position), death certificate naming Thomas as father (direct, secondary informant). Awaiting probate records for additional confirmation.\",\n      \"related_question_ids\": [\n        \"q_001\"\n      ],\n      \"ruled_out\": false,\n      \"ruled_out_reason\": null,\n      \"status\": \"supported\",\n      \"supporting_assertion_ids\": [\n        \"a_004\",\n        \"a_010\",\n        \"a_013\"\n      ]\n    }\n  ],\n  \"log\": [\n    {\n      \"external_site\": null,\n      \"id\": \"log_001\",\n      \"notes\": \"Found Patrick Flynn age 5 in household of Thomas Flynn, dwelling 84, Schuylkill Co. Three other Flynn results examined \u2014 ages and locations don't match.\",\n      \"outcome\": \"positive\",\n      \"performed\": \"2026-05-01T10:15:00Z\",\n      \"plan_item_id\": \"pli_001\",\n      \"query\": {\n        \"birth_place\": \"Pennsylvania\",\n        \"birth_year\": 1845,\n        \"collection\": \"1850 Census\",\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"results_examined\": 8,\n      \"tool\": \"record_search\"\n    },\n    {\n      \"external_site\": {\n        \"capture_filename\": \"ancestry-1850-flynn-results.pdf\",\n        \"capture_received\": true,\n        \"site\": \"ancestry\",\n        \"url_generated\": \"https://www.ancestry.com/search/collections/8054/?name=Patrick_Flynn&birth=1845&birthplace=Pennsylvania\"\n      },\n      \"id\": \"log_002\",\n      \"notes\": \"Ancestry index confirms same household. Transcription matches FamilySearch except Ancestry reads dwelling as 84, FamilySearch as 84 \u2014 consistent.\",\n      \"outcome\": \"positive\",\n      \"performed\": \"2026-05-01T11:30:00Z\",\n      \"plan_item_id\": \"pli_002\",\n      \"query\": {\n        \"birth_place\": \"Pennsylvania\",\n        \"birth_year\": 1845,\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"results_examined\": 12,\n      \"tool\": \"external_site\"\n    },\n    {\n      \"external_site\": {\n        \"capture_filename\": \"myheritage-1850-flynn-nil.pdf\",\n        \"capture_received\": true,\n        \"site\": \"myheritage\",\n        \"url_generated\": \"https://www.myheritage.com/research?action=query&first=Patrick&last=Flynn&birth_year=1845&birth_place=Pennsylvania\"\n      },\n      \"id\": \"log_003\",\n      \"notes\": \"MyHeritage returned no results for Patrick Flynn in 1850 Schuylkill County. Site may not have this collection indexed. Searched broader Pennsylvania \u2014 still no match.\",\n      \"outcome\": \"negative\",\n      \"performed\": \"2026-05-01T14:00:00Z\",\n      \"plan_item_id\": \"pli_003\",\n      \"query\": {\n        \"birth_place\": \"Pennsylvania\",\n        \"birth_year\": 1845,\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"results_examined\": 0,\n      \"tool\": \"external_site\"\n    },\n    {\n      \"external_site\": null,\n      \"id\": \"log_004\",\n      \"notes\": \"Patrick Flynn age 15 in household of Thomas Flynn, Schuylkill Co. Consistent with 1850 placement.\",\n      \"outcome\": \"positive\",\n      \"performed\": \"2026-05-02T09:00:00Z\",\n      \"plan_item_id\": \"pli_004\",\n      \"query\": {\n        \"birth_place\": \"Pennsylvania\",\n        \"birth_year\": 1845,\n        \"collection\": \"1860 Census\",\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"results_examined\": 5,\n      \"tool\": \"record_search\"\n    },\n    {\n      \"external_site\": null,\n      \"id\": \"log_005\",\n      \"notes\": \"Death certificate found. Names Thomas Flynn as father. Informant was son-in-law James Brown.\",\n      \"outcome\": \"positive\",\n      \"performed\": \"2026-05-03T10:00:00Z\",\n      \"plan_item_id\": \"pli_005\",\n      \"query\": {\n        \"death_place\": \"Schuylkill County, Pennsylvania\",\n        \"death_year\": 1908,\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"results_examined\": 2,\n      \"tool\": \"record_search\"\n    }\n  ],\n  \"person_evidence\": [\n    {\n      \"assertion_id\": \"a_001\",\n      \"confidence\": \"confident\",\n      \"created\": \"2026-05-01\",\n      \"id\": \"pe_001\",\n      \"match_score\": null,\n      \"person_id\": \"I1\",\n      \"rationale\": \"Name matches (Patrick Flynn), age consistent with ~1845 birth, located in Schuylkill County where subject is known to have lived. Only Patrick Flynn of this age in the county in 1850.\",\n      \"superseded_by\": null\n    },\n    {\n      \"assertion_id\": \"a_004\",\n      \"confidence\": \"probable\",\n      \"created\": \"2026-05-01\",\n      \"id\": \"pe_002\",\n      \"match_score\": null,\n      \"person_id\": \"I1\",\n      \"rationale\": \"Same record as pe_001, same person. Household position and shared surname with head Thomas Flynn suggest parent-child relationship, but 1850 census does not state relationships explicitly.\",\n      \"superseded_by\": null\n    },\n    {\n      \"assertion_id\": \"a_004\",\n      \"confidence\": \"probable\",\n      \"created\": \"2026-05-01\",\n      \"id\": \"pe_006\",\n      \"match_score\": null,\n      \"person_id\": \"I2\",\n      \"rationale\": \"Same assertion as pe_002 but linked to Thomas Flynn (I2). The relationship assertion ('position consistent with child') equally bears on the head of household. Thomas Flynn is the other party in the implied parent-child relationship.\",\n      \"superseded_by\": null\n    },\n    {\n      \"assertion_id\": \"a_005\",\n      \"confidence\": \"probable\",\n      \"created\": \"2026-05-01\",\n      \"id\": \"pe_003\",\n      \"match_score\": 0.82,\n      \"person_id\": \"I2\",\n      \"rationale\": \"Thomas Flynn, head of household where Patrick was found. Age (~32 in 1850, born ~1818) is consistent with being Patrick's father. Name matches candidate father.\",\n      \"superseded_by\": null\n    },\n    {\n      \"assertion_id\": \"a_010\",\n      \"confidence\": \"confident\",\n      \"created\": \"2026-05-02\",\n      \"id\": \"pe_004\",\n      \"match_score\": null,\n      \"person_id\": \"I1\",\n      \"rationale\": \"Patrick Flynn age 15 in Thomas Flynn household, 1860 census. Same county, age consistent with 1850 enumeration. Relationship inferred from household position and shared surname (1860 census does not state relationships explicitly).\",\n      \"superseded_by\": null\n    },\n    {\n      \"assertion_id\": \"a_013\",\n      \"confidence\": \"confident\",\n      \"created\": \"2026-05-03\",\n      \"id\": \"pe_005\",\n      \"match_score\": null,\n      \"person_id\": \"I1\",\n      \"rationale\": \"Death certificate for Patrick Flynn, d. 1908, Schuylkill County. Names match, death location matches known residence. Names Thomas Flynn as father.\",\n      \"superseded_by\": null\n    }\n  ],\n  \"plans\": [\n    {\n      \"created\": \"2026-05-01\",\n      \"id\": \"pl_001\",\n      \"items\": [\n        {\n          \"date_range\": \"1850\",\n          \"fallback_for\": null,\n          \"id\": \"pli_001\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"1850 census fully indexed on FamilySearch. Free access, start here.\",\n          \"record_type\": \"census\",\n          \"repository\": \"FamilySearch\",\n          \"sequence\": 1,\n          \"status\": \"completed\"\n        },\n        {\n          \"date_range\": \"1850\",\n          \"fallback_for\": null,\n          \"id\": \"pli_002\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"Ancestry has independent indexing; cross-check for transcription errors.\",\n          \"record_type\": \"census\",\n          \"repository\": \"Ancestry\",\n          \"sequence\": 2,\n          \"status\": \"completed\"\n        },\n        {\n          \"date_range\": \"1850\",\n          \"fallback_for\": null,\n          \"id\": \"pli_003\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"Third independent index for coverage confirmation.\",\n          \"record_type\": \"census\",\n          \"repository\": \"MyHeritage\",\n          \"sequence\": 3,\n          \"status\": \"completed\"\n        }\n      ],\n      \"question_id\": \"q_002\",\n      \"status\": \"completed\"\n    },\n    {\n      \"created\": \"2026-05-02\",\n      \"id\": \"pl_002\",\n      \"items\": [\n        {\n          \"date_range\": \"1860\",\n          \"fallback_for\": null,\n          \"id\": \"pli_004\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"Confirm Patrick still in Thomas Flynn household in 1860. Strengthens parent-child identification.\",\n          \"record_type\": \"census\",\n          \"repository\": \"FamilySearch\",\n          \"sequence\": 1,\n          \"status\": \"completed\"\n        },\n        {\n          \"date_range\": \"1908\",\n          \"fallback_for\": null,\n          \"id\": \"pli_005\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"Death certificate may name parents directly.\",\n          \"record_type\": \"vital_record\",\n          \"repository\": \"FamilySearch\",\n          \"sequence\": 2,\n          \"status\": \"completed\"\n        },\n        {\n          \"date_range\": \"1870-1890\",\n          \"fallback_for\": null,\n          \"id\": \"pli_006\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"Thomas Flynn probate/will may name Patrick as son.\",\n          \"record_type\": \"probate\",\n          \"repository\": \"FamilySearch\",\n          \"sequence\": 3,\n          \"status\": \"in_progress\"\n        }\n      ],\n      \"question_id\": \"q_001\",\n      \"status\": \"active\"\n    }\n  ],\n  \"project\": {\n    \"created\": \"2026-05-01\",\n    \"id\": \"rp_001\",\n    \"objective\": \"Identify the parents of Patrick Flynn, born ca. 1845 in Pennsylvania, died 1908 in Schuylkill County, PA\",\n    \"status\": \"active\",\n    \"subject_person_ids\": [\n      \"I1\"\n    ],\n    \"updated\": \"2026-05-04\"\n  },\n  \"proof_summaries\": [\n    {\n      \"exhaustive_search_summary\": \"Searched 1850 census (FamilySearch, Ancestry, MyHeritage \u2014 log_001, log_002, log_003), 1860 census (FamilySearch \u2014 log_004), and death certificate (FamilySearch \u2014 log_005). Probate search in progress. 1870, 1880, and 1900 censuses not yet searched.\",\n      \"id\": \"ps_001\",\n      \"narrative_markdown\": \"## Parentage of Patrick Flynn (ca. 1845\u20131908)\\n\\nPatrick Flynn is **Probably** the son of Thomas Flynn of Schuylkill County, Pennsylvania.\\n\\n### Evidence Summary\\n\\nThree independent lines of evidence support this conclusion:\\n\\n1. **1850 U.S. Census** (Original Source). Patrick Flynn, age 5, born Ireland, appears in the household of Thomas Flynn, age 32, born Ireland, in Schuylkill County, Pennsylvania (dwelling 84, family 91). The 1850 census does not state relationships, but Patrick's position in the household and shared surname are consistent with a parent-child relationship. The informant is indeterminate but likely a household member. This constitutes indirect evidence of parentage.\\n\\n2. **1860 U.S. Census** (Original Source). Patrick Flynn, age 15, born Ireland, appears in the household of Thomas Flynn in Schuylkill County (dwelling 112, family 119). Like the 1850 census, the 1860 census does not state relationships explicitly (the relationship column was not introduced until 1880). Patrick's position in the household, shared surname, and age consistent with the 1850 enumeration support a parent-child relationship. This constitutes indirect evidence of parentage.\\n\\n3. **1908 Death Certificate** (Original Source). Patrick Flynn's death certificate (no. 4521, Pennsylvania Department of Health) names \\\"Thomas Flynn\\\" as his father. The informant was James Brown, identified as Patrick's son-in-law. As a son-in-law reporting his father-in-law's parentage, Brown is a secondary informant for this fact \u2014 he was not a witness to Patrick's birth and is reporting what he was told. Nevertheless, this is direct evidence naming the father.\\n\\n### Conflict Resolution\\n\\nA birthplace conflict exists: the 1850 and 1860 censuses list Patrick's birthplace as Ireland, while the 1908 death certificate states Pennsylvania. The two census records are contemporary recordings with informants likely present in the household, while the death certificate was created 63 years after Patrick's birth by a son-in-law with no firsthand knowledge of the event. Per the GPS preponderance hierarchy, contemporary recordings by closer informants outweigh later recollections by secondary informants. Ireland is accepted as the birthplace; the death certificate entry is attributed to informant error.\\n\\n### Assessment\\n\\nThe conclusion is rated **Probable** rather than **Proved** because: (a) both census sources (1850 and 1860) provide only indirect evidence of parentage (relationships not stated \u2014 the relationship column was not introduced until 1880), (b) the death certificate informant is secondary, and (c) research is not yet exhaustive \u2014 the 1870, 1880, and 1900 censuses have not been searched, and Thomas Flynn's probate records have not been located. If Thomas Flynn's will names Patrick as a son, or if additional census records confirm the relationship, the conclusion would advance to **Proved**.\\n\\n### Citations\\n\\n1. 1850 U.S. Census, Schuylkill County, Pennsylvania, population schedule, dwelling 84, family 91, Thomas Flynn household; NARA microfilm publication M432, roll 810; digital image, FamilySearch.org, accessed 1 May 2026.\\n2. 1860 U.S. Census, Schuylkill County, Pennsylvania, population schedule, dwelling 112, family 119, Thomas Flynn household; NARA microfilm publication M653, roll 1141; digital image, FamilySearch.org, accessed 2 May 2026.\\n3. Pennsylvania Department of Health, death certificate no. 4521 (1908), Patrick Flynn; Pennsylvania State Archives, Harrisburg; digital image, FamilySearch.org, accessed 3 May 2026.\",\n      \"question_id\": \"q_001\",\n      \"resolved_conflict_ids\": [\n        \"c_001\"\n      ],\n      \"supporting_assertion_ids\": [\n        \"a_004\",\n        \"a_010\",\n        \"a_013\"\n      ],\n      \"tier\": \"probable\",\n      \"vehicle\": \"summary\"\n    }\n  ],\n  \"questions\": [\n    {\n      \"created\": \"2026-05-01\",\n      \"depends_on\": [],\n      \"exhaustive_declaration\": {\n        \"declared\": false,\n        \"justification\": null,\n        \"log_entry_ids\": [],\n        \"stop_criteria\": null\n      },\n      \"id\": \"q_001\",\n      \"priority\": \"high\",\n      \"question\": \"Who were the parents of Patrick Flynn (b. ~1845, PA, d. 1908)?\",\n      \"rationale\": \"This is the primary research objective.\",\n      \"resolution_assertion_ids\": [],\n      \"resolved\": null,\n      \"selection_basis\": \"objective_decomposition\",\n      \"status\": \"in_progress\",\n      \"unblocks\": []\n    },\n    {\n      \"created\": \"2026-05-01\",\n      \"depends_on\": [],\n      \"exhaustive_declaration\": {\n        \"declared\": true,\n        \"justification\": \"Searched 1850 census for Schuylkill County on FamilySearch (indexed and browse), Ancestry (indexed), and MyHeritage (indexed). All three returned the same household. No other Patrick Flynn of matching age found in the county.\",\n        \"log_entry_ids\": [\n          \"log_001\",\n          \"log_002\",\n          \"log_003\"\n        ],\n        \"stop_criteria\": {\n          \"conflict_resolution\": \"No conflicts on the 1850 census placement question.\",\n          \"evidence_class\": \"Yes \u2014 FamilySearch provides original census image with indeterminate-quality information.\",\n          \"goal_alignment\": \"Yes \u2014 Patrick Flynn located in a specific 1850 household, answering the question.\",\n          \"independent_verification\": \"FamilySearch (original) and Ancestry (derivative) both return the same household. Two access paths, one underlying original.\",\n          \"original_substitution\": \"FamilySearch provides the original census image; Ancestry index is derivative but confirmed consistent.\",\n          \"overturn_risk\": \"Low \u2014 all three repositories agree, and no competing Patrick Flynn of matching age exists in the county.\",\n          \"repository_breadth\": \"Three major repositories searched (FamilySearch, Ancestry, MyHeritage). No additional known indexes of the 1850 Schuylkill County census exist.\"\n        }\n      },\n      \"id\": \"q_002\",\n      \"priority\": \"high\",\n      \"question\": \"Where was Patrick Flynn in the 1850 census?\",\n      \"rationale\": \"The 1850 census is the earliest enumeration where Patrick would appear by name (age ~5). Locating him in a household identifies candidate parents.\",\n      \"resolution_assertion_ids\": [\n        \"a_001\",\n        \"a_002\",\n        \"a_003\"\n      ],\n      \"resolved\": \"2026-05-02\",\n      \"selection_basis\": \"objective_decomposition\",\n      \"status\": \"resolved\",\n      \"unblocks\": [\n        \"q_001\"\n      ]\n    }\n  ],\n  \"sources\": [\n    {\n      \"access_date\": \"2026-05-01\",\n      \"citation\": \"1850 U.S. Census, Schuylkill County, Pennsylvania, population schedule, dwelling 84, family 91, Thomas Flynn household; NARA microfilm publication M432, roll 810; digital image, FamilySearch.org, accessed 1 May 2026.\",\n      \"citation_detail\": {\n        \"what\": \"1850 U.S. Federal Census, population schedule\",\n        \"when_accessed\": \"2026-05-01\",\n        \"when_created\": \"1850\",\n        \"where\": \"FamilySearch.org (NARA microfilm M432, roll 810)\",\n        \"where_within\": \"Schuylkill County, dwelling 84, family 91\",\n        \"who\": \"U.S. Census Bureau\"\n      },\n      \"gedcomx_source_description_id\": \"S1\",\n      \"id\": \"src_001\",\n      \"log_entry_id\": \"log_001\",\n      \"notes\": \"Image quality good. Enumerator handwriting clear.\",\n      \"repository\": \"FamilySearch\",\n      \"source_classification\": \"original\",\n      \"url\": \"https://www.familysearch.org/ark:/61903/1:1:MXYZ\",\n      \"url_archived\": null\n    },\n    {\n      \"access_date\": \"2026-05-01\",\n      \"citation\": \"1850 U.S. Census, Schuylkill County, Pennsylvania, population schedule, dwelling 84, Thomas Flynn household; digital image, Ancestry.com, accessed 1 May 2026.\",\n      \"citation_detail\": {\n        \"what\": \"1850 U.S. Federal Census, population schedule (Ancestry index)\",\n        \"when_accessed\": \"2026-05-01\",\n        \"when_created\": \"1850\",\n        \"where\": \"Ancestry.com\",\n        \"where_within\": \"Schuylkill County, dwelling 84\",\n        \"who\": \"U.S. Census Bureau\"\n      },\n      \"gedcomx_source_description_id\": \"S1\",\n      \"id\": \"src_002\",\n      \"log_entry_id\": \"log_002\",\n      \"notes\": \"Ancestry's index of the same original census. Transcription consistent with FamilySearch.\",\n      \"repository\": \"Ancestry\",\n      \"source_classification\": \"derivative\",\n      \"url\": null,\n      \"url_archived\": null\n    },\n    {\n      \"access_date\": \"2026-05-02\",\n      \"citation\": \"1860 U.S. Census, Schuylkill County, Pennsylvania, population schedule, dwelling 112, family 119, Thomas Flynn household; NARA microfilm publication M653, roll 1141; digital image, FamilySearch.org, accessed 2 May 2026.\",\n      \"citation_detail\": {\n        \"what\": \"1860 U.S. Federal Census, population schedule\",\n        \"when_accessed\": \"2026-05-02\",\n        \"when_created\": \"1860\",\n        \"where\": \"FamilySearch.org (NARA microfilm M653, roll 1141)\",\n        \"where_within\": \"Schuylkill County, dwelling 112, family 119\",\n        \"who\": \"U.S. Census Bureau\"\n      },\n      \"gedcomx_source_description_id\": \"S2\",\n      \"id\": \"src_003\",\n      \"log_entry_id\": \"log_004\",\n      \"notes\": null,\n      \"repository\": \"FamilySearch\",\n      \"source_classification\": \"original\",\n      \"url\": \"https://www.familysearch.org/ark:/61903/1:1:MABC\",\n      \"url_archived\": null\n    },\n    {\n      \"access_date\": \"2026-05-03\",\n      \"citation\": \"Pennsylvania Department of Health, death certificate no. 4521 (1908), Patrick Flynn; Pennsylvania State Archives, Harrisburg; digital image, FamilySearch.org, accessed 3 May 2026.\",\n      \"citation_detail\": {\n        \"what\": \"Death certificate no. 4521\",\n        \"when_accessed\": \"2026-05-03\",\n        \"when_created\": \"1908-03-14\",\n        \"where\": \"FamilySearch.org (Pennsylvania State Archives, Harrisburg)\",\n        \"where_within\": \"Certificate no. 4521\",\n        \"who\": \"Pennsylvania Department of Health; informant: James Brown (son-in-law)\"\n      },\n      \"gedcomx_source_description_id\": \"S3\",\n      \"id\": \"src_004\",\n      \"log_entry_id\": \"log_005\",\n      \"notes\": \"Informant is son-in-law James Brown. Primary for death facts, secondary for birth facts.\",\n      \"repository\": \"FamilySearch\",\n      \"source_classification\": \"original\",\n      \"url\": \"https://www.familysearch.org/ark:/61903/1:1:MDEF\",\n      \"url_archived\": null\n    },\n    {\n      \"access_date\": \"2026-05-10\",\n      \"citation\": \"St. Mary's Catholic Church, Pottsville, baptism of Patrick Flynn, 1845\",\n      \"citation_detail\": {\n        \"what\": \"Baptismal register, 1845\",\n        \"when_accessed\": \"2026-05-10\",\n        \"when_created\": \"1845\",\n        \"where\": \"FamilySearch.org\",\n        \"where_within\": \"Patrick Flynn entry\",\n        \"who\": \"St. Mary's Catholic Church, Pottsville\"\n      },\n      \"gedcomx_source_description_id\": \"S5\",\n      \"id\": \"src_005\",\n      \"log_entry_id\": null,\n      \"notes\": \"Rough working citation from record-extraction. Missing volume/page locator and full repository chain.\",\n      \"repository\": \"FamilySearch\",\n      \"source_classification\": \"original\",\n      \"url\": \"https://www.familysearch.org/ark:/61903/3:1:S3HT-D1MQ-NZH\",\n      \"url_archived\": null\n    },\n    {\n      \"access_date\": \"2026-05-10\",\n      \"citation\": \"Schuylkill County will of Thomas Flynn, 1881\",\n      \"citation_detail\": {\n        \"what\": \"Will of Thomas Flynn\",\n        \"when_accessed\": \"2026-05-10\",\n        \"when_created\": \"1881\",\n        \"where\": \"FamilySearch.org\",\n        \"where_within\": \"will of Thomas Flynn\",\n        \"who\": \"Schuylkill County Courthouse\"\n      },\n      \"gedcomx_source_description_id\": \"S4\",\n      \"id\": \"src_006\",\n      \"log_entry_id\": null,\n      \"notes\": \"Rough working citation from record-extraction. Creator should be the court, not the courthouse. Missing Will Book volume and page locator.\",\n      \"repository\": \"FamilySearch\",\n      \"source_classification\": \"original\",\n      \"url\": \"https://www.familysearch.org/ark:/61903/3:1:3Q9M-CS4V-7TXW\",\n      \"url_archived\": null\n    },\n    {\n      \"access_date\": \"2026-05-12\",\n      \"citation\": \"PA birth certificate, Mary Elizabeth Flynn, 1905\",\n      \"citation_detail\": {\n        \"what\": \"Birth certificate\",\n        \"when_accessed\": \"2026-05-12\",\n        \"when_created\": \"1905\",\n        \"where\": \"FamilySearch.org\",\n        \"where_within\": \"Mary Elizabeth Flynn entry\",\n        \"who\": \"FamilySearch\"\n      },\n      \"gedcomx_source_description_id\": \"S6\",\n      \"id\": \"src_007\",\n      \"log_entry_id\": null,\n      \"notes\": \"Rough working citation from record-extraction. who wrongly names the repository; missing certificate number (12455), birth date, and place.\",\n      \"repository\": \"FamilySearch\",\n      \"source_classification\": \"original\",\n      \"url\": \"https://www.familysearch.org/ark:/61903/1:1:6JZX-VKQM\",\n      \"url_archived\": null\n    },\n    {\n      \"access_date\": \"2026-05-12\",\n      \"citation\": \"Deed, Thomas Flynn to Patrick Flynn, 1881\",\n      \"citation_detail\": {\n        \"what\": \"Warranty deed\",\n        \"when_accessed\": \"2026-05-12\",\n        \"when_created\": \"1881\",\n        \"where\": \"FamilySearch.org\",\n        \"where_within\": \"Thomas Flynn to Patrick Flynn\",\n        \"who\": \"Schuylkill County Courthouse\"\n      },\n      \"gedcomx_source_description_id\": \"S7\",\n      \"id\": \"src_008\",\n      \"log_entry_id\": null,\n      \"notes\": \"Rough working citation from record-extraction. who should be the Recorder of Deeds (not the courthouse building); missing grantor/grantee, execution + recording dates, and Deed Book/page locator.\",\n      \"repository\": \"FamilySearch\",\n      \"source_classification\": \"original\",\n      \"url\": \"https://www.familysearch.org/ark:/61903/3:1:3QS7-89WF-9KCT\",\n      \"url_archived\": null\n    },\n    {\n      \"access_date\": \"2026-05-12\",\n      \"citation\": \"Patrick Flynn obituary, Pottsville Republican, 1908\",\n      \"citation_detail\": {\n        \"what\": \"Obituary\",\n        \"when_accessed\": \"2026-05-12\",\n        \"when_created\": \"1908\",\n        \"where\": \"FamilySearch.org\",\n        \"where_within\": \"obituary notice\",\n        \"who\": \"FamilySearch\"\n      },\n      \"gedcomx_source_description_id\": \"S8\",\n      \"id\": \"src_009\",\n      \"log_entry_id\": null,\n      \"notes\": \"Rough working citation from record-extraction. who wrongly names the repository; missing the quoted article title, exact publication date, page, and column number.\",\n      \"repository\": \"FamilySearch\",\n      \"source_classification\": \"original\",\n      \"url\": \"https://www.familysearch.org/ark:/61903/3:1:S3HY-6RKS-MGV\",\n      \"url_archived\": null\n    }\n  ],\n  \"timelines\": [\n    {\n      \"events\": [\n        {\n          \"assertion_ids\": [\n            \"a_002\",\n            \"a_009\"\n          ],\n          \"date\": \"~1845\",\n          \"date_certainty\": \"estimated\",\n          \"description\": \"Born in Ireland, estimated from census ages\",\n          \"event_type\": \"birth\",\n          \"place\": \"Ireland\"\n        },\n        {\n          \"assertion_ids\": [\n            \"a_003\",\n            \"a_004\"\n          ],\n          \"date\": \"1850\",\n          \"date_certainty\": \"exact\",\n          \"description\": \"Enumerated age 5 in Thomas Flynn household, dwelling 84\",\n          \"event_type\": \"census\",\n          \"place\": \"Schuylkill County, Pennsylvania\"\n        },\n        {\n          \"assertion_ids\": [\n            \"a_008\",\n            \"a_009\",\n            \"a_010\"\n          ],\n          \"date\": \"1860\",\n          \"date_certainty\": \"exact\",\n          \"description\": \"Enumerated age 15 in Thomas Flynn household, dwelling 112\",\n          \"event_type\": \"census\",\n          \"place\": \"Schuylkill County, Pennsylvania\"\n        },\n        {\n          \"assertion_ids\": [\n            \"a_011\",\n            \"a_013\"\n          ],\n          \"date\": \"1908-03-12\",\n          \"date_certainty\": \"exact\",\n          \"description\": \"Died, death certificate names Thomas Flynn as father\",\n          \"event_type\": \"death\",\n          \"place\": \"Schuylkill County, Pennsylvania\"\n        }\n      ],\n      \"gaps\": [\n        {\n          \"end\": \"1908-03-12\",\n          \"expected_events\": [\n            \"marriage\",\n            \"1870_census\",\n            \"1880_census\",\n            \"1900_census\",\n            \"residence\",\n            \"occupation\"\n          ],\n          \"severity\": \"high\",\n          \"start\": \"1860-01-01\"\n        }\n      ],\n      \"generated\": \"2026-05-03T12:00:00Z\",\n      \"hypothesis_id\": \"h_001\",\n      \"id\": \"t_001\",\n      \"impossibilities\": [],\n      \"label\": \"Patrick Flynn \u2014 assuming Thomas Flynn parentage\",\n      \"person_ids\": [\n        \"I1\"\n      ]\n    }\n  ]\n}\n",
+    "eval/fixtures/scenarios/mid-research-flynn/tree.gedcomx.json": "{\n  \"persons\": [\n    {\n      \"facts\": [\n        {\n          \"date\": \"~1845\",\n          \"id\": \"F1\",\n          \"place\": \"Ireland\",\n          \"primary\": true,\n          \"sources\": [\n            {\n              \"page\": \"1850 Census, Schuylkill Co., dwelling 84\",\n              \"ref\": \"S1\"\n            }\n          ],\n          \"type\": \"Birth\"\n        },\n        {\n          \"date\": \"1908-03-12\",\n          \"id\": \"F2\",\n          \"place\": \"Schuylkill County, Pennsylvania\",\n          \"sources\": [\n            {\n              \"page\": \"Death cert. no. 4521\",\n              \"ref\": \"S3\"\n            }\n          ],\n          \"type\": \"Death\"\n        }\n      ],\n      \"gender\": \"Male\",\n      \"id\": \"I1\",\n      \"names\": [\n        {\n          \"given\": \"Patrick\",\n          \"id\": \"N1\",\n          \"preferred\": true,\n          \"surname\": \"Flynn\",\n          \"type\": \"BirthName\"\n        }\n      ]\n    },\n    {\n      \"facts\": [\n        {\n          \"date\": \"~1818\",\n          \"id\": \"F3\",\n          \"place\": \"Ireland\",\n          \"primary\": true,\n          \"type\": \"Birth\"\n        }\n      ],\n      \"gender\": \"Male\",\n      \"id\": \"I2\",\n      \"names\": [\n        {\n          \"given\": \"Thomas\",\n          \"id\": \"N2\",\n          \"preferred\": true,\n          \"surname\": \"Flynn\",\n          \"type\": \"BirthName\"\n        }\n      ]\n    },\n    {\n      \"gender\": \"Female\",\n      \"id\": \"I3\",\n      \"names\": [\n        {\n          \"given\": \"Mary\",\n          \"id\": \"N3\",\n          \"preferred\": true,\n          \"surname\": \"Flynn\",\n          \"type\": \"BirthName\"\n        }\n      ]\n    },\n    {\n      \"gender\": \"Male\",\n      \"id\": \"I4\",\n      \"names\": [\n        {\n          \"given\": \"James\",\n          \"id\": \"N4\",\n          \"preferred\": true,\n          \"surname\": \"Flynn\",\n          \"type\": \"BirthName\"\n        }\n      ]\n    }\n  ],\n  \"relationships\": [\n    {\n      \"child\": \"I1\",\n      \"id\": \"R1\",\n      \"parent\": \"I2\",\n      \"sources\": [\n        {\n          \"page\": \"1850 Census, Schuylkill Co., dwelling 84\",\n          \"quality\": 2,\n          \"ref\": \"S1\"\n        },\n        {\n          \"page\": \"1860 Census, Schuylkill Co., dwelling 112\",\n          \"quality\": 2,\n          \"ref\": \"S2\"\n        },\n        {\n          \"page\": \"Death cert. no. 4521\",\n          \"quality\": 2,\n          \"ref\": \"S3\"\n        }\n      ],\n      \"type\": \"ParentChild\"\n    },\n    {\n      \"child\": \"I3\",\n      \"id\": \"R2\",\n      \"parent\": \"I2\",\n      \"sources\": [\n        {\n          \"page\": \"1850 Census, Schuylkill Co., dwelling 84\",\n          \"quality\": 2,\n          \"ref\": \"S1\"\n        }\n      ],\n      \"type\": \"ParentChild\"\n    },\n    {\n      \"child\": \"I4\",\n      \"id\": \"R3\",\n      \"parent\": \"I2\",\n      \"sources\": [\n        {\n          \"page\": \"1850 Census, Schuylkill Co., dwelling 84\",\n          \"quality\": 2,\n          \"ref\": \"S1\"\n        }\n      ],\n      \"type\": \"ParentChild\"\n    }\n  ],\n  \"sources\": [\n    {\n      \"author\": \"U.S. Census Bureau\",\n      \"id\": \"S1\",\n      \"title\": \"1850 U.S. Federal Census\"\n    },\n    {\n      \"author\": \"U.S. Census Bureau\",\n      \"id\": \"S2\",\n      \"title\": \"1860 U.S. Federal Census\"\n    },\n    {\n      \"author\": \"Pennsylvania Department of Health\",\n      \"id\": \"S3\",\n      \"title\": \"Pennsylvania Death Certificates\"\n    },\n    {\n      \"author\": \"Schuylkill County Register of Wills\",\n      \"id\": \"S4\",\n      \"title\": \"Schuylkill County Probate Records\"\n    },\n    {\n      \"author\": \"St. Mary's Catholic Church, Pottsville\",\n      \"id\": \"S5\",\n      \"title\": \"St. Mary's Catholic Church (Pottsville) Baptismal Registers\"\n    },\n    {\n      \"author\": \"Pennsylvania Department of Health\",\n      \"id\": \"S6\",\n      \"title\": \"Pennsylvania Birth Certificates\"\n    },\n    {\n      \"author\": \"Schuylkill County Recorder of Deeds\",\n      \"id\": \"S7\",\n      \"title\": \"Schuylkill County Deed Books\"\n    },\n    {\n      \"author\": \"Pottsville Republican\",\n      \"id\": \"S8\",\n      \"title\": \"Pottsville Republican (newspaper)\"\n    }\n  ]\n}\n",
+    "eval/fixtures/mcp/validate-research-schema.json": "{\n  \"args\": {\n    \"projectPath\": \"~\"\n  },\n  \"description\": \"Catch-all: validate_research_schema returns valid for any project path\",\n  \"response\": {\n    \"errors\": [],\n    \"message\": \"Both project files pass all validation checks.\",\n    \"valid\": true,\n    \"warnings\": []\n  },\n  \"tool\": \"validate_research_schema\"\n}\n"
+  },
+  "tests": [
+    {
+      "test_id": "ut_hypothesis_tracking_003",
+      "test_type": "positive",
+      "expected_outcome": "pass",
+      "scenario": "mid-research-flynn",
+      "mcp_fixtures": [
+        "validate-research-schema"
+      ],
+      "outcome": "pass",
+      "flaky": false,
+      "outcome_summary": {
+        "per_run_outcomes": [
+          "pass"
+        ],
+        "aggregated_dimensions": [
+          {
+            "source": "base",
+            "name": "Correctness",
+            "score": 3,
+            "rationale": "Claude correctly identified that a_005 (Thomas Flynn's name as household head in 1850 census) directly supports h_001's parentage claim. The analysis of all 13 assertions was sound\u2014correctly dismissing name-only, birthplace, residence, and death facts as non-supporting. The file_changes diff shows a_005 was added to supporting_assertion_ids; status remains 'supported' as required. Schema validation passed. No fabricated or unsupported claims."
+          },
+          {
+            "source": "base",
+            "name": "Completeness",
+            "score": 3,
+            "rationale": "Claude addressed everything the user requested: systematically reviewed all unlinked assertions, analyzed their relevance to h_001, and added the one assertion (a_005) that merited linkage. The response included detailed reasoning for why other assertions were not linked, fulfilling the 'review and add relevant assertions' task completely. No silent omissions."
+          },
+          {
+            "source": "base",
+            "name": "Tool Arguments",
+            "score": 3,
+            "rationale": "Both MCP tool calls used correct arguments. The research_append call properly updated h_001 with the new supporting_assertion_ids array [a_004, a_005, a_010, a_013], included a detailed notes field, and operated on the correct section ('hypotheses') and entryId ('h_001'). The validate_research_schema call correctly specified the projectPath. No fixture_not_found errors; matched.kind == 'live' for both calls."
+          },
+          {
+            "source": "rubric",
+            "name": "Claim clarity",
+            "score": 3,
+            "rationale": "h_001's claim\u2014'Patrick Flynn's father was Thomas Flynn of Schuylkill County, Pennsylvania'\u2014is highly specific. It names both individuals, identifies the relationship (parentage), and includes geographic detail (Schuylkill County, Pennsylvania). The claim is testable and would support targeted genealogical follow-up searches. Claude engaged with this claim structure clearly throughout the analysis."
+          },
+          {
+            "source": "rubric",
+            "name": "Evidence linkage",
+            "score": 3,
+            "rationale": "Claude correctly linked a_005 (Thomas Flynn's name as household head, 1850 census) as supporting h_001. This assertion directly establishes the identity of the candidate father named in the hypothesis. All four linked assertions (a_004, a_005, a_010, a_013) have genuine bearing on whether Thomas Flynn was Patrick's father\u2014either via co-enumeration or direct statement. No off-topic or tangential linkages were made."
+          },
+          {
+            "source": "rubric",
+            "name": "Status transitions",
+            "score": 3,
+            "rationale": "Claude correctly maintained h_001's status as 'supported' and did not trigger any status transition. The instructions warned against changing status from supported, and Claude obeyed this requirement. Adding supporting assertions to an already-supported hypothesis is appropriate and does not mandate a status change. No invalid transition occurred."
+          }
+        ]
+      },
+      "totals": {
+        "duration_ms": 119095.44807800012,
+        "duration_api_ms": 117471.0,
+        "judge_duration_ms": 8451.722881998649,
+        "wall_clock_ms": 128203.89914512634,
+        "num_turns": 8,
+        "input_tokens": 14,
+        "cached_input_tokens": 111941,
+        "output_tokens": 5754,
+        "judge_input_tokens": 5739,
+        "judge_cached_input_tokens": 0,
+        "judge_output_tokens": 799,
+        "skill_cost_usd": 0.24624355,
+        "judge_cost_usd": 0.009734,
+        "total_cost_usd": 0.25597755
+      },
+      "runs": [
+        {
+          "run_index": 0,
+          "run_id": "run_ut_hypothesis_tracking_003_2026-06-29_22-28-20_0",
+          "outcome": "pass",
+          "aborted_reason": null,
+          "duration_ms": 119095.44807800012,
+          "duration_api_ms": 117471.0,
+          "num_turns": 8,
+          "skill_attempts": 1,
+          "input_tokens": 14,
+          "cached_input_tokens": 111941,
+          "output_tokens": 5754,
+          "skill_cost_usd": 0.24624355,
+          "output": {
+            "text_response": "I'll start by reading the project files to understand what's currently linked to h_001 and what other assertions exist.Now I have everything I need. Let me analyze all 13 assertions against h_001 before touching anything.Now I have everything needed. Let me carefully evaluate every unlinked assertion against h_001's claim before touching anything.\n\n---\n\n**h_001 claim:** *\"Patrick Flynn's father was Thomas Flynn of Schuylkill County, Pennsylvania\"*\n**Currently linked:** a_004, a_010, a_013\n\n| Assertion | Fact | Source | Relevant to h_001? | Verdict |\n|---|---|---|---|---|\n| a_001 | Patrick Flynn *name*, 1850 census | src_001 (original) | Establishes Patrick's presence in the record, but the parentage implication is carried by a_004 (already linked). Name alone doesn't support the fatherhood claim. | \u274c Not supporting |\n| a_002 | Patrick *birth* ~1845, Ireland, 1850 | src_001 | Age/birthplace for Patrick. No bearing on who his father was. | \u274c Not supporting |\n| a_003 | Patrick *residence* Schuylkill Co., 1850 | src_001 | Places Patrick in the right county but doesn't implicate Thomas as father. | \u274c Not supporting |\n| **a_005** | **Thomas Flynn *name*, head of household, 1850** | src_001 (original) | **This is the assertion that establishes the household head is specifically named \"Thomas Flynn\" in Schuylkill County \u2014 the exact person named in the hypothesis. Without it, a_004's reference to \"Thomas Flynn (head)\" has no discrete evidentiary anchor. Directly supports h_001.** | \u2705 **Should be linked** |\n| a_006 | Patrick Flynn name, 1850 Ancestry index | src_002 (derivative) | Same reasoning as a_001, and from a derivative source. | \u274c Not supporting |\n| a_007 | Patrick birth ~1845, Ancestry derivative | src_002 | Derivative corroboration of a_002. No parentage bearing. | \u274c Not supporting |\n| a_008 | Patrick Flynn *name*, 1860 census | src_003 (original) | Establishes Patrick in the 1860 record; parentage implication is carried by a_010 (already linked). | \u274c Not supporting |\n| a_009 | Patrick *birth* ~1845, Ireland, 1860 | src_003 | Birth year/place. No parentage bearing. | \u274c Not supporting |\n| a_011 | Patrick *death* 1908 | src_004 | Death fact. No parentage bearing. | \u274c Not supporting |\n| a_012 | Patrick *birth* per death cert. | src_004 | Birth fact from same cert as a_013 (already linked); doesn't itself support h_001. | \u274c Not supporting |\n\n**Conclusion:** Only **a_005** meets the bar. It is the discrete assertion that names Thomas Flynn as head of household in the 1850 Schuylkill County census \u2014 providing the evidentiary grounding for the specific identity claim in h_001. Every other unlinked assertion either addresses Patrick's own identity/demographics, comes from a derivative source, or pertains to facts (birth, death) unrelated to the parentage question.\n\nNow updating h_001:Written successfully. Now running the mandatory schema validation:Schema passes clean. Here's the final state of h_001:\n\n---\n\n**Hypothesis: h_001 \u2014 Patrick Flynn's father was Thomas Flynn of Schuylkill County, Pennsylvania**\n**Status: SUPPORTED**\n\n**Supporting evidence (4):**\n| ID | Assertion | Evidence type |\n|---|---|---|\n| a_004 | 1850 census: Patrick listed in household of Thomas Flynn (head), position consistent with child | Indirect |\n| **a_005** *(newly added)* | **1850 census: Household head identified by name as Thomas Flynn** | Indirect |\n| a_010 | 1860 census: Patrick listed in household of Thomas Flynn (head), position/age consistent with son | Indirect |\n| a_013 | 1908 death certificate: \"Father: Thomas Flynn\" (informant: son-in-law, secondary) | Direct |\n\n**Contradicting evidence: (none)**\n\n---\n\n**Why only a_005 was added (and not others):**\n\n- **a_005** is the discrete evidentiary unit that establishes the household head's name as *Thomas Flynn* \u2014 the specific person named in the hypothesis. a_004 already referenced \"Thomas Flynn (head)\" in its value field, but a_005 is the independent name assertion grounding that identification. Without it, the co-enumeration evidence floats without a named anchor.\n- All other unlinked assertions (a_001\u2013a_003, a_006\u2013a_009, a_011\u2013a_012) address Patrick's own name, birth, residence, or death facts, or come from derivative sources \u2014 none make the specific claim that Thomas Flynn was Patrick's father any more probable on their own.\n\n**One observation (no action taken):** The existing `proof_summaries` entry (ps_001) still references only three supporting assertions [a_004, a_010, a_013] in its `supporting_assertion_ids`. You may want to update that via the proof-conclusion skill when you're ready to refresh the narrative.",
+            "activated": true,
+            "skills_invoked": [
+              "hypothesis-tracking"
+            ],
+            "tool_calls": [
+              {
+                "tool": "mcp__genealogy__research_append",
+                "args": {
+                  "projectPath": "/tmp/eval-ut_hypothesis_tracking_003-0-0-8mcdf6xo",
+                  "section": "hypotheses",
+                  "op": "update",
+                  "entryId": "h_001",
+                  "fields": {
+                    "supporting_assertion_ids": [
+                      "a_004",
+                      "a_005",
+                      "a_010",
+                      "a_013"
+                    ],
+                    "notes": "Four assertions now linked: 1850 census co-enumeration of Patrick in Thomas's household (a_004, indirect); 1850 census name assertion establishing the household head is specifically Thomas Flynn (a_005, indirect); 1860 census co-enumeration (a_010, indirect); death certificate naming Thomas as father (a_013, direct, secondary informant). Awaiting probate records for additional confirmation."
+                  }
+                },
+                "expected_args": null,
+                "matched": {
+                  "kind": "live",
+                  "index": null
+                },
+                "response_fixture": "live:research_append"
+              },
+              {
+                "tool": "mcp__genealogy__validate_research_schema",
+                "args": {
+                  "projectPath": "/tmp/eval-ut_hypothesis_tracking_003-0-0-8mcdf6xo"
+                },
+                "expected_args": null,
+                "matched": {
+                  "kind": "live",
+                  "index": null
+                },
+                "response_fixture": "live:validate_research_schema"
+              }
+            ],
+            "files_created": [],
+            "file_changes": {
+              "research.json": {
+                "sections_modified": [
+                  "hypotheses"
+                ],
+                "diff": {
+                  "hypotheses": {
+                    "added": [],
+                    "modified": [
+                      {
+                        "id": "h_001",
+                        "changed_fields": {
+                          "supporting_assertion_ids": {
+                            "before": [
+                              "a_004",
+                              "a_010",
+                              "a_013"
+                            ],
+                            "after": [
+                              "a_004",
+                              "a_005",
+                              "a_010",
+                              "a_013"
+                            ]
+                          },
+                          "notes": {
+                            "before": "Three independent pieces of evidence: 1850 census co-enumeration (indirect), 1860 census co-enumeration (indirect \u2014 relationship inferred from household position), death certificate naming Thomas as father (direct, secondary informant). Awaiting probate records for additional confirmation.",
+                            "after": "Four assertions now linked: 1850 census co-enumeration of Patrick in Thomas's household (a_004, indirect); 1850 census name assertion establishing the household head is specifically Thomas Flynn (a_005, indirect); 1860 census co-enumeration (a_010, indirect); death certificate naming Thomas as father (a_013, direct, secondary informant). Awaiting probate records for additional confirmation."
+                          }
+                        }
+                      }
+                    ],
+                    "deleted": []
+                  }
+                }
+              }
+            },
+            "warnings": [
+              {
+                "kind": "missing_tool_usage_dimension",
+                "advisory": "Skill called MCP tools but the rubric has no dimension name suggesting tool-usage coverage (matched against keywords: ['tool usage', 'tool use', 'tool work', 'tool call', 'argument quality', 'argument-quality', 'response interpretation', 'tool selection', 'mcp tool', 'fixture']). The judge will grade other dimensions but won't score tool work explicitly. Consider adding a tool-usage dimension or renaming an existing one."
+              }
+            ]
+          },
+          "validators": {
+            "passed": true,
+            "results": [
+              {
+                "name": "test_id_references_resolve",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_log_append_only",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_entries_deleted",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_research_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tool_allowlist",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_gedcomx_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_h001_not_ruled_out_when_adding_identity_hypotheses",
+                "passed": true,
+                "error": "skipped: not a c_002 scenario"
+              },
+              {
+                "name": "test_h001_status_unchanged_when_review",
+                "passed": true,
+                "error": "skipped: not an h_001 scenario"
+              },
+              {
+                "name": "test_hypotheses_assertion_refs_resolve",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_hypotheses_no_deletions",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_new_hypotheses_have_claim",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_new_hypothesis_added_for_c002",
+                "passed": true,
+                "error": "skipped: not a c_002 scenario"
+              },
+              {
+                "name": "test_ruled_out_requires_reason",
+                "passed": true,
+                "error": null
+              }
+            ]
+          },
+          "judge": {
+            "skipped": false,
+            "dimensions": [
+              {
+                "source": "base",
+                "name": "Correctness",
+                "score": 3,
+                "rationale": "Claude correctly identified that a_005 (Thomas Flynn's name as household head in 1850 census) directly supports h_001's parentage claim. The analysis of all 13 assertions was sound\u2014correctly dismissing name-only, birthplace, residence, and death facts as non-supporting. The file_changes diff shows a_005 was added to supporting_assertion_ids; status remains 'supported' as required. Schema validation passed. No fabricated or unsupported claims."
+              },
+              {
+                "source": "base",
+                "name": "Completeness",
+                "score": 3,
+                "rationale": "Claude addressed everything the user requested: systematically reviewed all unlinked assertions, analyzed their relevance to h_001, and added the one assertion (a_005) that merited linkage. The response included detailed reasoning for why other assertions were not linked, fulfilling the 'review and add relevant assertions' task completely. No silent omissions."
+              },
+              {
+                "source": "base",
+                "name": "Tool Arguments",
+                "score": 3,
+                "rationale": "Both MCP tool calls used correct arguments. The research_append call properly updated h_001 with the new supporting_assertion_ids array [a_004, a_005, a_010, a_013], included a detailed notes field, and operated on the correct section ('hypotheses') and entryId ('h_001'). The validate_research_schema call correctly specified the projectPath. No fixture_not_found errors; matched.kind == 'live' for both calls."
+              },
+              {
+                "source": "rubric",
+                "name": "Claim clarity",
+                "score": 3,
+                "rationale": "h_001's claim\u2014'Patrick Flynn's father was Thomas Flynn of Schuylkill County, Pennsylvania'\u2014is highly specific. It names both individuals, identifies the relationship (parentage), and includes geographic detail (Schuylkill County, Pennsylvania). The claim is testable and would support targeted genealogical follow-up searches. Claude engaged with this claim structure clearly throughout the analysis."
+              },
+              {
+                "source": "rubric",
+                "name": "Evidence linkage",
+                "score": 3,
+                "rationale": "Claude correctly linked a_005 (Thomas Flynn's name as household head, 1850 census) as supporting h_001. This assertion directly establishes the identity of the candidate father named in the hypothesis. All four linked assertions (a_004, a_005, a_010, a_013) have genuine bearing on whether Thomas Flynn was Patrick's father\u2014either via co-enumeration or direct statement. No off-topic or tangential linkages were made."
+              },
+              {
+                "source": "rubric",
+                "name": "Status transitions",
+                "score": 3,
+                "rationale": "Claude correctly maintained h_001's status as 'supported' and did not trigger any status transition. The instructions warned against changing status from supported, and Claude obeyed this requirement. Adding supporting assertions to an already-supported hypothesis is appropriate and does not mandate a status change. No invalid transition occurred."
+              }
+            ],
+            "judge_cost_usd": 0.009734,
+            "duration_ms": 8451.722881998649,
+            "error": null,
+            "input_tokens": 5739,
+            "cached_input_tokens": 0,
+            "output_tokens": 799
+          },
+          "started_at": 1782772100.6271455,
+          "ended_at": 1782772228.8310447
+        }
+      ]
+    },
+    {
+      "test_id": "ut_hypothesis_tracking_002",
+      "test_type": "positive",
+      "expected_outcome": "pass",
+      "scenario": "flynn-multi-conflict",
+      "mcp_fixtures": [
+        "validate-research-schema"
+      ],
+      "outcome": "pass",
+      "flaky": false,
+      "outcome_summary": {
+        "per_run_outcomes": [
+          "pass"
+        ],
+        "aggregated_dimensions": [
+          {
+            "source": "base",
+            "name": "Correctness",
+            "score": 3,
+            "rationale": "All outputs are factually correct. Both hypotheses are based on the actual 1850 census data cited (dwelling 84 vs household 197). The supporting and contradicting assertion linkages are accurate: a_004, a_010, a_013 genuinely bear on h_002; h_003 correctly has empty lists pending household 197 extraction. The schema validation confirms both entries passed validation. No fabricated material."
+          },
+          {
+            "source": "base",
+            "name": "Completeness",
+            "score": 3,
+            "rationale": "The skill fully addressed the user's request to formulate identity conflict c_002 as testable hypotheses. Two competing hypotheses were created (h_002 and h_003), both with specific testable claims. All required schema fields were populated: id, claim, status, supporting_assertion_ids, contradicting_assertion_ids, ruled_out, related_question_ids, and notes. The file_changes diff confirms both entries were successfully appended to research.json."
+          },
+          {
+            "source": "base",
+            "name": "Tool Arguments",
+            "score": 3,
+            "rationale": "All three MCP tool calls passed arguments correctly. Both mcp__genealogy__research_append calls provided complete, valid entry objects with all required hypothesis fields; projectPath and section were correct. The mcp__genealogy__validate_research_schema call correctly validated the result. No fixture_not_found errors occurred (all matched.kind == 'live'). Arguments align with expected behavior."
+          },
+          {
+            "source": "rubric",
+            "name": "Claim clarity",
+            "score": 3,
+            "rationale": "Both hypotheses are stated as specific, testable claims. h_002 names Patrick Flynn as the subject, specifies he is 'age 5, enumerated in Thomas Flynn's household, dwelling 84, 1850 census,' and includes the death year (1908) and place (Schuylkill County) for verification. h_003 similarly names the specific alternative: 'age 6, enumerated in household 197' and explicitly states he is NOT the dwelling-84 Patrick. Both claims are testable through record extraction and genealogical research."
+          },
+          {
+            "source": "rubric",
+            "name": "Evidence linkage",
+            "score": 3,
+            "rationale": "Supporting and contradicting assertion linkages are correct and well-reasoned. h_002 links a_004 (1850 co-enumeration), a_010 (1860 continuity), and a_013 (death cert naming Thomas Flynn as father) \u2014 all direct or indirect statements about the dwelling-84 identity. h_003 correctly has empty lists, with explicit reasoning (provided in notes) that a_013 cannot be classified as contradicting until household 197's head is identified, avoiding the unsound assumption of two different Thomas Flynns. No tangential assertions are included."
+          },
+          {
+            "source": "rubric",
+            "name": "Status transitions",
+            "score": 3,
+            "rationale": "Both hypotheses were set to 'active' status, which is correct per protocol. The skill correctly noted that even though h_002 has supporting evidence, the starting state for competing candidates should be 'active' rather than 'supported,' ensuring unbiased evaluation. Neither hypothesis was transitioned to 'ruled_out' without affirmative refutation (only lack of evidence), correctly following the research-schema-spec.md \u00a75.9 rules. ruled_out_reason is null for both, as expected."
+          }
+        ]
+      },
+      "totals": {
+        "duration_ms": 143817.93476500025,
+        "duration_api_ms": 142240.0,
+        "judge_duration_ms": 10008.047449000514,
+        "wall_clock_ms": 154422.55353927612,
+        "num_turns": 10,
+        "input_tokens": 16,
+        "cached_input_tokens": 153962,
+        "output_tokens": 7705,
+        "judge_input_tokens": 5721,
+        "judge_cached_input_tokens": 0,
+        "judge_output_tokens": 912,
+        "skill_cost_usd": 0.28689785,
+        "judge_cost_usd": 0.010281,
+        "total_cost_usd": 0.29717885
+      },
+      "runs": [
+        {
+          "run_index": 0,
+          "run_id": "run_ut_hypothesis_tracking_002_2026-06-29_22-28-20_0",
+          "outcome": "pass",
+          "aborted_reason": null,
+          "duration_ms": 143817.93476500025,
+          "duration_api_ms": 142240.0,
+          "num_turns": 10,
+          "skill_attempts": 1,
+          "input_tokens": 16,
+          "cached_input_tokens": 153962,
+          "output_tokens": 7705,
+          "skill_cost_usd": 0.28689785,
+          "output": {
+            "text_response": "Now I have a full picture. Let me map this out before writing.\n\n**Conflict c_002** identifies two Patrick Flynns in Schuylkill County in 1850:\n- **Candidate A:** Age 5, in Thomas Flynn's household, dwelling 84 \u2190 already linked to the subject as I1\n- **Candidate B:** Age 6, in household 197 \u2190 no assertions yet extracted\n\nThis identity question needs two competing, testable hypotheses. I'll create both as `active` \u2014 even though existing evidence favors Candidate A, the starting state is always `active` per protocol. I'll create them one at a time.`h_002` written. Now the competing candidate:`h_003` written. Now the mandatory end-of-interaction validation:Schema valid. Here's what was created:\n\n---\n\n## Hypotheses for Identity Conflict c_002\n\nThe conflict asked: *which* Patrick Flynn in 1850 is our subject? Two competing, testable claims now exist:\n\n---\n\n### h_002 \u2014 Dwelling 84 candidate (Thomas Flynn household)\n**Claim:** The Patrick Flynn who died in Schuylkill County in 1908 is the Patrick Flynn, age 5, in Thomas Flynn's household, dwelling 84, 1850 census.\n\n**Status:** ACTIVE\n\n**Supporting evidence (3):**\n| ID | Assertion | Type |\n|---|---|---|\n| a_004 | 1850: listed in Thomas Flynn's household, position consistent with child | Indirect |\n| a_010 | 1860: same Patrick in Thomas Flynn's household, age 15 \u2014 continuity confirmed | Indirect |\n| a_013 | Death certificate: \"Father: Thomas Flynn\" \u2014 directly consistent with dwelling-84 identity | Direct (secondary informant) |\n\n**Contradicting evidence:** none yet\n\n---\n\n### h_003 \u2014 Household 197 candidate\n**Claim:** The Patrick Flynn who died in 1908 is the Patrick Flynn, age 6, in household 197 in the 1850 census \u2014 and is *not* the dwelling-84 Patrick.\n\n**Status:** ACTIVE\n\n**Supporting evidence:** none yet (no assertions extracted for household 197)\n\n**Contradicting evidence:** none yet \u2014 *intentionally deferred* pending a critical unknown\n\n---\n\n## Key analytical notes\n\n**Why h_003's supporting/contradicting lists are empty right now:**\nAssertion a_013 (death cert: \"Father: Thomas Flynn\") *looks* like it contradicts h_003, but there's an **unsound assumption** lurking \u2014 that the head of household 197 was *not* also named Thomas Flynn. Per the GPS guidance on unsound assumptions, that cannot be accepted without evidence. Classifying a_013 as contradicting before identifying household 197's head would be premature.\n\n**Refutation strategy for each:**\n\n| Hypothesis | What would disprove it |\n|---|---|\n| h_002 | Find a separate death record for the dwelling-84 Patrick Flynn near 1908; or trace household 197's Patrick independently through to 1908 |\n| h_003 | Identify the head of household 197 \u2014 if not Thomas Flynn, a_013 becomes contradicting; trace household 197 Patrick into 1860 under a different head |\n\n**Recommended next step:** Extract assertions from src_001 (the 1850 census image) for household 197 \u2014 who is the head, how old, birthplace? That single step will either rule out h_003 quickly or clarify what further research is needed. This is a natural job for **record-extraction**.",
+            "activated": true,
+            "skills_invoked": [
+              "hypothesis-tracking"
+            ],
+            "tool_calls": [
+              {
+                "tool": "mcp__genealogy__research_append",
+                "args": {
+                  "projectPath": "/tmp/eval-ut_hypothesis_tracking_002-0-0-_eq3ng_j",
+                  "section": "hypotheses",
+                  "op": "append",
+                  "entry": {
+                    "claim": "The Patrick Flynn who died in Schuylkill County in 1908 (src_004) is the same individual as the Patrick Flynn, age 5, enumerated in Thomas Flynn's household, dwelling 84, in the 1850 Schuylkill County census",
+                    "status": "active",
+                    "supporting_assertion_ids": [
+                      "a_004",
+                      "a_010",
+                      "a_013"
+                    ],
+                    "contradicting_assertion_ids": [],
+                    "ruled_out": false,
+                    "ruled_out_reason": null,
+                    "notes": "Three assertions bear on this identification: a_004 (1850 co-enumeration with Thomas Flynn), a_010 (1860 co-enumeration with Thomas Flynn \u2014 same Patrick continuing in that household), and a_013 (death certificate names Thomas Flynn as father, consistent with the dwelling-84 candidate). Refutation strategy: identify and trace the household 197 Patrick Flynn (age 6) independently through 1860 and later records. If that candidate can be followed to a separate death, this hypothesis is strengthened by elimination. If household 197's head also turns out to be named Thomas Flynn, both hypotheses become harder to distinguish on the death certificate evidence alone.",
+                    "related_question_ids": [
+                      "q_001"
+                    ]
+                  }
+                },
+                "expected_args": null,
+                "matched": {
+                  "kind": "live",
+                  "index": null
+                },
+                "response_fixture": "live:research_append"
+              },
+              {
+                "tool": "mcp__genealogy__research_append",
+                "args": {
+                  "projectPath": "/tmp/eval-ut_hypothesis_tracking_002-0-0-_eq3ng_j",
+                  "section": "hypotheses",
+                  "op": "append",
+                  "entry": {
+                    "claim": "The Patrick Flynn who died in Schuylkill County in 1908 (src_004) is the same individual as the Patrick Flynn, age 6, enumerated in household 197 in the 1850 Schuylkill County census, and is NOT the Patrick Flynn in Thomas Flynn's dwelling 84",
+                    "status": "active",
+                    "supporting_assertion_ids": [],
+                    "contradicting_assertion_ids": [],
+                    "ruled_out": false,
+                    "ruled_out_reason": null,
+                    "notes": "No assertions have yet been extracted for the household-197 candidate. Critical unknowns: (1) Who is the head of household 197? If the head is also named Thomas Flynn, assertion a_013 (death certificate naming 'Thomas Flynn' as father) could support rather than undercut this hypothesis \u2014 do not classify a_013 as contradicting until the head's identity is established. (2) Is the household-197 Patrick Flynn traceable in 1860 records independently of the dwelling-84 Patrick? Finding him separately in 1860 under a different head would strongly support this hypothesis. (3) Is there a death record for a second Patrick Flynn in Schuylkill County near 1908 that could be attributed to the dwelling-84 candidate, ruling him out as the 1908 decedent? Refutation strategy: extract assertions for household 197 from src_001; if the head of household 197 is NOT Thomas Flynn and the household-197 Patrick cannot be traced to the 1908 death, this hypothesis is undermined by elimination.",
+                    "related_question_ids": [
+                      "q_001"
+                    ]
+                  }
+                },
+                "expected_args": null,
+                "matched": {
+                  "kind": "live",
+                  "index": null
+                },
+                "response_fixture": "live:research_append"
+              },
+              {
+                "tool": "mcp__genealogy__validate_research_schema",
+                "args": {
+                  "projectPath": "/tmp/eval-ut_hypothesis_tracking_002-0-0-_eq3ng_j"
+                },
+                "expected_args": null,
+                "matched": {
+                  "kind": "live",
+                  "index": null
+                },
+                "response_fixture": "live:validate_research_schema"
+              }
+            ],
+            "files_created": [],
+            "file_changes": {
+              "research.json": {
+                "sections_modified": [
+                  "hypotheses"
+                ],
+                "diff": {
+                  "hypotheses": {
+                    "added": [
+                      {
+                        "id": "h_002",
+                        "claim": "The Patrick Flynn who died in Schuylkill County in 1908 (src_004) is the same individual as the Patrick Flynn, age 5, enumerated in Thomas Flynn's household, dwelling 84, in the 1850 Schuylkill County census",
+                        "status": "active",
+                        "supporting_assertion_ids": [
+                          "a_004",
+                          "a_010",
+                          "a_013"
+                        ],
+                        "contradicting_assertion_ids": [],
+                        "ruled_out": false,
+                        "ruled_out_reason": null,
+                        "notes": "Three assertions bear on this identification: a_004 (1850 co-enumeration with Thomas Flynn), a_010 (1860 co-enumeration with Thomas Flynn \u2014 same Patrick continuing in that household), and a_013 (death certificate names Thomas Flynn as father, consistent with the dwelling-84 candidate). Refutation strategy: identify and trace the household 197 Patrick Flynn (age 6) independently through 1860 and later records. If that candidate can be followed to a separate death, this hypothesis is strengthened by elimination. If household 197's head also turns out to be named Thomas Flynn, both hypotheses become harder to distinguish on the death certificate evidence alone.",
+                        "related_question_ids": [
+                          "q_001"
+                        ]
+                      },
+                      {
+                        "id": "h_003",
+                        "claim": "The Patrick Flynn who died in Schuylkill County in 1908 (src_004) is the same individual as the Patrick Flynn, age 6, enumerated in household 197 in the 1850 Schuylkill County census, and is NOT the Patrick Flynn in Thomas Flynn's dwelling 84",
+                        "status": "active",
+                        "supporting_assertion_ids": [],
+                        "contradicting_assertion_ids": [],
+                        "ruled_out": false,
+                        "ruled_out_reason": null,
+                        "notes": "No assertions have yet been extracted for the household-197 candidate. Critical unknowns: (1) Who is the head of household 197? If the head is also named Thomas Flynn, assertion a_013 (death certificate naming 'Thomas Flynn' as father) could support rather than undercut this hypothesis \u2014 do not classify a_013 as contradicting until the head's identity is established. (2) Is the household-197 Patrick Flynn traceable in 1860 records independently of the dwelling-84 Patrick? Finding him separately in 1860 under a different head would strongly support this hypothesis. (3) Is there a death record for a second Patrick Flynn in Schuylkill County near 1908 that could be attributed to the dwelling-84 candidate, ruling him out as the 1908 decedent? Refutation strategy: extract assertions for household 197 from src_001; if the head of household 197 is NOT Thomas Flynn and the household-197 Patrick cannot be traced to the 1908 death, this hypothesis is undermined by elimination.",
+                        "related_question_ids": [
+                          "q_001"
+                        ]
+                      }
+                    ],
+                    "modified": [],
+                    "deleted": []
+                  }
+                }
+              }
+            },
+            "warnings": [
+              {
+                "kind": "missing_tool_usage_dimension",
+                "advisory": "Skill called MCP tools but the rubric has no dimension name suggesting tool-usage coverage (matched against keywords: ['tool usage', 'tool use', 'tool work', 'tool call', 'argument quality', 'argument-quality', 'response interpretation', 'tool selection', 'mcp tool', 'fixture']). The judge will grade other dimensions but won't score tool work explicitly. Consider adding a tool-usage dimension or renaming an existing one."
+              }
+            ]
+          },
+          "validators": {
+            "passed": true,
+            "results": [
+              {
+                "name": "test_id_references_resolve",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_log_append_only",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_entries_deleted",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_research_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tool_allowlist",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_gedcomx_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_h001_not_ruled_out_when_adding_identity_hypotheses",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_h001_status_unchanged_when_review",
+                "passed": true,
+                "error": "skipped: not an h_001 scenario"
+              },
+              {
+                "name": "test_hypotheses_assertion_refs_resolve",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_hypotheses_no_deletions",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_new_hypotheses_have_claim",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_new_hypothesis_added_for_c002",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_ruled_out_requires_reason",
+                "passed": true,
+                "error": null
+              }
+            ]
+          },
+          "judge": {
+            "skipped": false,
+            "dimensions": [
+              {
+                "source": "base",
+                "name": "Correctness",
+                "score": 3,
+                "rationale": "All outputs are factually correct. Both hypotheses are based on the actual 1850 census data cited (dwelling 84 vs household 197). The supporting and contradicting assertion linkages are accurate: a_004, a_010, a_013 genuinely bear on h_002; h_003 correctly has empty lists pending household 197 extraction. The schema validation confirms both entries passed validation. No fabricated material."
+              },
+              {
+                "source": "base",
+                "name": "Completeness",
+                "score": 3,
+                "rationale": "The skill fully addressed the user's request to formulate identity conflict c_002 as testable hypotheses. Two competing hypotheses were created (h_002 and h_003), both with specific testable claims. All required schema fields were populated: id, claim, status, supporting_assertion_ids, contradicting_assertion_ids, ruled_out, related_question_ids, and notes. The file_changes diff confirms both entries were successfully appended to research.json."
+              },
+              {
+                "source": "base",
+                "name": "Tool Arguments",
+                "score": 3,
+                "rationale": "All three MCP tool calls passed arguments correctly. Both mcp__genealogy__research_append calls provided complete, valid entry objects with all required hypothesis fields; projectPath and section were correct. The mcp__genealogy__validate_research_schema call correctly validated the result. No fixture_not_found errors occurred (all matched.kind == 'live'). Arguments align with expected behavior."
+              },
+              {
+                "source": "rubric",
+                "name": "Claim clarity",
+                "score": 3,
+                "rationale": "Both hypotheses are stated as specific, testable claims. h_002 names Patrick Flynn as the subject, specifies he is 'age 5, enumerated in Thomas Flynn's household, dwelling 84, 1850 census,' and includes the death year (1908) and place (Schuylkill County) for verification. h_003 similarly names the specific alternative: 'age 6, enumerated in household 197' and explicitly states he is NOT the dwelling-84 Patrick. Both claims are testable through record extraction and genealogical research."
+              },
+              {
+                "source": "rubric",
+                "name": "Evidence linkage",
+                "score": 3,
+                "rationale": "Supporting and contradicting assertion linkages are correct and well-reasoned. h_002 links a_004 (1850 co-enumeration), a_010 (1860 continuity), and a_013 (death cert naming Thomas Flynn as father) \u2014 all direct or indirect statements about the dwelling-84 identity. h_003 correctly has empty lists, with explicit reasoning (provided in notes) that a_013 cannot be classified as contradicting until household 197's head is identified, avoiding the unsound assumption of two different Thomas Flynns. No tangential assertions are included."
+              },
+              {
+                "source": "rubric",
+                "name": "Status transitions",
+                "score": 3,
+                "rationale": "Both hypotheses were set to 'active' status, which is correct per protocol. The skill correctly noted that even though h_002 has supporting evidence, the starting state for competing candidates should be 'active' rather than 'supported,' ensuring unbiased evaluation. Neither hypothesis was transitioned to 'ruled_out' without affirmative refutation (only lack of evidence), correctly following the research-schema-spec.md \u00a75.9 rules. ruled_out_reason is null for both, as expected."
+              }
+            ],
+            "judge_cost_usd": 0.010281,
+            "duration_ms": 10008.047449000514,
+            "error": null,
+            "input_tokens": 5721,
+            "cached_input_tokens": 0,
+            "output_tokens": 912
+          },
+          "started_at": 1782772100.6306005,
+          "ended_at": 1782772255.053154
+        }
+      ]
+    },
+    {
+      "test_id": "ut_hypothesis_tracking_001",
+      "test_type": "positive",
+      "expected_outcome": "pass",
+      "scenario": "mid-research-flynn",
+      "mcp_fixtures": [
+        "validate-research-schema"
+      ],
+      "outcome": "pass",
+      "flaky": false,
+      "outcome_summary": {
+        "per_run_outcomes": [
+          "pass"
+        ],
+        "aggregated_dimensions": [
+          {
+            "source": "base",
+            "name": "Correctness",
+            "score": 3,
+            "rationale": "The skill correctly identified hypothesis h_001 as SUPPORTED based on the three supporting assertions (a_004, a_010, a_013), accurately characterized their evidence types (two indirect, one direct), noted the absence of contradicting evidence, and verified chronological coherence. The analysis of the death certificate as direct evidence and the footnote about the informant being secondary is accurate. No fabricated claims; all assertions grounded in the provided research state."
+          },
+          {
+            "source": "base",
+            "name": "Completeness",
+            "score": 3,
+            "rationale": "The skill addressed the user's query completely. It cited all three supporting assertions with their evidence types and explained why each supports the hypothesis. It noted that contradicting_assertion_ids is empty, identified probate (pli_006) as the next critical source, explained why the status is SUPPORTED vs PROVED (direct evidence present but informant secondary + research incomplete), and provided actionable next steps including the probate search."
+          },
+          {
+            "source": "base",
+            "name": "Tool Arguments",
+            "score": 3,
+            "rationale": "The skill made one MPC tool call: validate_research_schema with projectPath argument. The call matched expected args with kind='live' (successful fixture match). The argument passed the correct project path; no wrong identifiers or critical mismatches. Schema validation was appropriate as a mandatory pre-analysis step."
+          },
+          {
+            "source": "rubric",
+            "name": "Claim clarity",
+            "score": 3,
+            "rationale": "The hypothesis is clearly stated as a specific, testable claim: 'Patrick Flynn's father was Thomas Flynn of Schuylkill County, Pennsylvania.' It names both specific persons, identifies the specific relationship (father-son parentage), and includes geographic detail (Schuylkill County). The claim is fully testable against the probate records and additional census searches identified in next steps."
+          },
+          {
+            "source": "rubric",
+            "name": "Evidence linkage",
+            "score": 3,
+            "rationale": "All three supporting assertions are directly linked to the parentage hypothesis with clear bearing: a_004 and a_010 show Patrick in Thomas's household in consecutive censuses (household co-residence supports family relationship); a_013 directly names Thomas as Patrick's father on the death certificate. No tangential evidence was included. The skill correctly noted that the birthplace conflict (c_001) does not bear on the parentage question and thus was properly excluded from the linkage."
+          },
+          {
+            "source": "rubric",
+            "name": "Status transitions",
+            "score": 3,
+            "rationale": "The status transition to SUPPORTED is fully justified per research-schema-spec \u00a75.9. The skill verified all three required criteria: at least one direct assertion (a_013, the death certificate), no unresolved contradictions (c_001 resolved and irrelevant to parentage), and no timeline impossibilities. The skill appropriately explained why status remains Probable (not Proved) due to informant being secondary and research being incomplete. The ruled_out scenario is correctly explained but not triggered; the transition logic is sound."
+          }
+        ]
+      },
+      "totals": {
+        "duration_ms": 52324.91654000114,
+        "duration_api_ms": 51168.0,
+        "judge_duration_ms": 9037.429340000017,
+        "wall_clock_ms": 61417.04964637756,
+        "num_turns": 10,
+        "input_tokens": 2490,
+        "cached_input_tokens": 120285,
+        "output_tokens": 2496,
+        "judge_input_tokens": 4536,
+        "judge_cached_input_tokens": 0,
+        "judge_output_tokens": 811,
+        "skill_cost_usd": 0.16967224999999997,
+        "judge_cost_usd": 0.008591,
+        "total_cost_usd": 0.17826324999999996
+      },
+      "runs": [
+        {
+          "run_index": 0,
+          "run_id": "run_ut_hypothesis_tracking_001_2026-06-29_22-28-20_0",
+          "outcome": "pass",
+          "aborted_reason": null,
+          "duration_ms": 52324.91654000114,
+          "duration_api_ms": 51168.0,
+          "num_turns": 10,
+          "skill_attempts": 1,
+          "input_tokens": 2490,
+          "cached_input_tokens": 120285,
+          "output_tokens": 2496,
+          "skill_cost_usd": 0.16967224999999997,
+          "output": {
+            "text_response": "Now let me run the mandatory schema validation before presenting my findings.Both project files pass validation. Here is your read-only review:\n\n---\n\n## Hypothesis h_001 \u2014 Status Review\n\n**Claim:** Patrick Flynn's father was Thomas Flynn of Schuylkill County, Pennsylvania\n**Status: SUPPORTED**\n\n---\n\n### Supporting evidence (3):\n\n| # | Assertion | Record | Evidence type | Info quality |\n|---|---|---|---|---|\n| + | **a_004** | 1850 census: Patrick in Thomas Flynn household, position consistent with child | Indirect | Indeterminate |\n| + | **a_010** | 1860 census: Patrick in Thomas Flynn household, position and age consistent with son | Indirect | Indeterminate |\n| + | **a_013** | 1908 death certificate: \"Father: Thomas Flynn\" (informant: son-in-law James Brown) | **Direct** | Secondary |\n\n### Contradicting evidence: none\n\n---\n\n### Why `supported` is correct\n\nAll three transition criteria are met:\n- \u2705 **At least one direct assertion** \u2014 a_013 (the death certificate) is direct evidence explicitly naming Thomas Flynn as father\n- \u2705 **No unresolved contradictions** \u2014 the only conflict on file (c_001) is about Patrick's birthplace, which has been resolved and does not bear on the parentage question\n- \u2705 **No timeline impossibilities** \u2014 timeline t_001 confirms chronological coherence (Thomas's age ~32 in 1850 is entirely consistent with being father to a 5-year-old)\n\n---\n\n### Proof tier in context\n\nThe existing proof summary (ps_001) correctly rates the conclusion **Probable** \u2014 not Proved \u2014 for three reasons:\n1. The 1850 and 1860 censuses provide only *indirect* evidence (those censuses don't state relationships; parentage is inferred from household position)\n2. The death certificate's informant (son-in-law James Brown) is a *secondary* informant for parentage facts\n3. Research is not yet exhaustive \u2014 the **Thomas Flynn probate search** (pli_006) is still **in progress**, and the 1870, 1880, and 1900 censuses have not yet been searched\n\n---\n\n### No competing hypotheses\n\nThere are no alternative candidate fathers on record \u2014 h_001 is the only hypothesis. When the probate search (pli_006) is complete:\n- **If Thomas's will names Patrick as a son** \u2192 this would add direct, primary evidence and could support upgrading the conclusion to **Proved**\n- **If Thomas's will names all children but omits Patrick** \u2192 that would be significant negative evidence requiring re-evaluation\n\n---\n\n### Suggested next steps\n\n1. **Complete pli_006** (Thomas Flynn probate records, FamilySearch) \u2014 this is the highest-value pending search\n2. **Search 1870, 1880, and 1900 censuses** for Patrick Flynn in Schuylkill County to fill the large gap noted in the timeline (1860\u20131908)\n3. **Once pli_006 resolves**, consider running **research-exhaustiveness** to evaluate whether a formal exhaustive declaration is warranted, and then **proof-conclusion** to potentially upgrade from Probable to Proved\n\n---\n\n*Schema validation: \u2705 Both project files passed all checks.*",
+            "activated": true,
+            "skills_invoked": [
+              "hypothesis-tracking"
+            ],
+            "tool_calls": [
+              {
+                "tool": "mcp__genealogy__validate_research_schema",
+                "args": {
+                  "projectPath": "/tmp/eval-ut_hypothesis_tracking_001-0-0-5c5_ntju"
+                },
+                "expected_args": null,
+                "matched": {
+                  "kind": "live",
+                  "index": null
+                },
+                "response_fixture": "live:validate_research_schema"
+              }
+            ],
+            "files_created": [],
+            "warnings": [
+              {
+                "kind": "missing_tool_usage_dimension",
+                "advisory": "Skill called MCP tools but the rubric has no dimension name suggesting tool-usage coverage (matched against keywords: ['tool usage', 'tool use', 'tool work', 'tool call', 'argument quality', 'argument-quality', 'response interpretation', 'tool selection', 'mcp tool', 'fixture']). The judge will grade other dimensions but won't score tool work explicitly. Consider adding a tool-usage dimension or renaming an existing one."
+              },
+              {
+                "kind": "uncovered_tool_call",
+                "advisory": "1 of 2 MCP tool call(s) matched no fixture predicate \u2014 the skill ran against a fixture_not_found or denied/unknown-tool error. Add or fix an mcp_fixture whose args match the call.",
+                "attempted": [
+                  {
+                    "tool": "mcp__genealogy__validate_research_schema",
+                    "args": {}
+                  },
+                  {
+                    "tool": "mcp__genealogy__validate_research_schema",
+                    "args": {
+                      "projectPath": "/tmp/eval-ut_hypothesis_tracking_001-0-0-5c5_ntju"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "validators": {
+            "passed": true,
+            "results": [
+              {
+                "name": "test_id_references_resolve",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_log_append_only",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_entries_deleted",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_research_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tool_allowlist",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_gedcomx_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_h001_not_ruled_out_when_adding_identity_hypotheses",
+                "passed": true,
+                "error": "skipped: not a c_002 scenario"
+              },
+              {
+                "name": "test_h001_status_unchanged_when_review",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_hypotheses_assertion_refs_resolve",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_hypotheses_no_deletions",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_new_hypotheses_have_claim",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_new_hypothesis_added_for_c002",
+                "passed": true,
+                "error": "skipped: not a c_002 scenario"
+              },
+              {
+                "name": "test_ruled_out_requires_reason",
+                "passed": true,
+                "error": null
+              }
+            ]
+          },
+          "judge": {
+            "skipped": false,
+            "dimensions": [
+              {
+                "source": "base",
+                "name": "Correctness",
+                "score": 3,
+                "rationale": "The skill correctly identified hypothesis h_001 as SUPPORTED based on the three supporting assertions (a_004, a_010, a_013), accurately characterized their evidence types (two indirect, one direct), noted the absence of contradicting evidence, and verified chronological coherence. The analysis of the death certificate as direct evidence and the footnote about the informant being secondary is accurate. No fabricated claims; all assertions grounded in the provided research state."
+              },
+              {
+                "source": "base",
+                "name": "Completeness",
+                "score": 3,
+                "rationale": "The skill addressed the user's query completely. It cited all three supporting assertions with their evidence types and explained why each supports the hypothesis. It noted that contradicting_assertion_ids is empty, identified probate (pli_006) as the next critical source, explained why the status is SUPPORTED vs PROVED (direct evidence present but informant secondary + research incomplete), and provided actionable next steps including the probate search."
+              },
+              {
+                "source": "base",
+                "name": "Tool Arguments",
+                "score": 3,
+                "rationale": "The skill made one MPC tool call: validate_research_schema with projectPath argument. The call matched expected args with kind='live' (successful fixture match). The argument passed the correct project path; no wrong identifiers or critical mismatches. Schema validation was appropriate as a mandatory pre-analysis step."
+              },
+              {
+                "source": "rubric",
+                "name": "Claim clarity",
+                "score": 3,
+                "rationale": "The hypothesis is clearly stated as a specific, testable claim: 'Patrick Flynn's father was Thomas Flynn of Schuylkill County, Pennsylvania.' It names both specific persons, identifies the specific relationship (father-son parentage), and includes geographic detail (Schuylkill County). The claim is fully testable against the probate records and additional census searches identified in next steps."
+              },
+              {
+                "source": "rubric",
+                "name": "Evidence linkage",
+                "score": 3,
+                "rationale": "All three supporting assertions are directly linked to the parentage hypothesis with clear bearing: a_004 and a_010 show Patrick in Thomas's household in consecutive censuses (household co-residence supports family relationship); a_013 directly names Thomas as Patrick's father on the death certificate. No tangential evidence was included. The skill correctly noted that the birthplace conflict (c_001) does not bear on the parentage question and thus was properly excluded from the linkage."
+              },
+              {
+                "source": "rubric",
+                "name": "Status transitions",
+                "score": 3,
+                "rationale": "The status transition to SUPPORTED is fully justified per research-schema-spec \u00a75.9. The skill verified all three required criteria: at least one direct assertion (a_013, the death certificate), no unresolved contradictions (c_001 resolved and irrelevant to parentage), and no timeline impossibilities. The skill appropriately explained why status remains Probable (not Proved) due to informant being secondary and research being incomplete. The ruled_out scenario is correctly explained but not triggered; the transition logic is sound."
+              }
+            ],
+            "judge_cost_usd": 0.008591,
+            "duration_ms": 9037.429340000017,
+            "error": null,
+            "input_tokens": 4536,
+            "cached_input_tokens": 0,
+            "output_tokens": 811
+          },
+          "started_at": 1782772364.9902296,
+          "ended_at": 1782772426.4072793
+        }
+      ]
+    },
+    {
+      "test_id": "ut_hypothesis_tracking_004",
+      "test_type": "positive",
+      "expected_outcome": "pass",
+      "scenario": "flynn-competing-fathers",
+      "mcp_fixtures": [
+        "validate-research-schema"
+      ],
+      "outcome": "pass",
+      "flaky": false,
+      "outcome_summary": {
+        "per_run_outcomes": [
+          "pass"
+        ],
+        "aggregated_dimensions": [
+          {
+            "source": "base",
+            "name": "Correctness",
+            "score": 3,
+            "rationale": "Claude correctly identified the chronological impossibility: Thomas Flynn of Luzerne County died 15 September 1840, five years before Patrick's ~1845 birth. The death assertion (a_016) is factually linked to the timeline, and the reasoning is sound under GPS evidence rules. No fabricated material or unsupported claims."
+          },
+          {
+            "source": "base",
+            "name": "Completeness",
+            "score": 3,
+            "rationale": "Claude fully addressed the user's request to update h_002 based on the death record. The hypothesis was properly evaluated, the status transitioned to ruled_out, contradicting evidence was linked, and the ruled_out_reason was supplied with detailed justification. No gaps in coverage."
+          },
+          {
+            "source": "base",
+            "name": "Tool Arguments",
+            "score": 3,
+            "rationale": "Both MCP tool calls passed correct arguments. The research_append call properly targeted h_002 with correct field updates (status, contradicting_assertion_ids, ruled_out, ruled_out_reason). The validate call was appropriate for post-write verification. No fixture_not_found errors; arguments match the expected structure."
+          },
+          {
+            "source": "rubric",
+            "name": "Claim clarity",
+            "score": 3,
+            "rationale": "The hypothesis claim is specific: 'Patrick Flynn's father was Thomas Flynn of Luzerne County, Pennsylvania.' It names specific persons, the relationship being hypothesized (paternity), and includes place detail (Luzerne County, Pennsylvania). The claim is directly testable."
+          },
+          {
+            "source": "rubric",
+            "name": "Evidence linkage",
+            "score": 3,
+            "rationale": "The linkage is correct and precise. The death record (a_016) showing Thomas Flynn died 15 September 1840 is appropriately placed in contradicting_assertion_ids because it directly contradicts the paternity hypothesis\u2014a man cannot father a child born five years after his death. The supporting evidence link (a_014, census) is also relevant as circumstantial evidence of the candidate."
+          },
+          {
+            "source": "rubric",
+            "name": "Status transitions",
+            "score": 3,
+            "rationale": "The status transition to ruled_out is justified by affirmative refutation, not mere absence of evidence. Claude cites the specific death date (15 September 1840) and the timeline gap to Patrick's ~1845 birth as the grounds for ruling out. The ruled_out_reason explicitly states the chronological impossibility and the GPS framework violation. This meets the schema requirement for ruled_out transitions with documented affirmative refutation."
+          }
+        ]
+      },
+      "totals": {
+        "duration_ms": 83464.089006,
+        "duration_api_ms": 81522.0,
+        "judge_duration_ms": 7475.149294999937,
+        "wall_clock_ms": 92147.79996871948,
+        "num_turns": 10,
+        "input_tokens": 2492,
+        "cached_input_tokens": 135984,
+        "output_tokens": 3466,
+        "judge_input_tokens": 5166,
+        "judge_cached_input_tokens": 0,
+        "judge_output_tokens": 708,
+        "skill_cost_usd": 0.21076295,
+        "judge_cost_usd": 0.008706,
+        "total_cost_usd": 0.21946895
+      },
+      "runs": [
+        {
+          "run_index": 0,
+          "run_id": "run_ut_hypothesis_tracking_004_2026-06-29_22-28-20_0",
+          "outcome": "pass",
+          "aborted_reason": null,
+          "duration_ms": 83464.089006,
+          "duration_api_ms": 81522.0,
+          "num_turns": 10,
+          "skill_attempts": 1,
+          "input_tokens": 2492,
+          "cached_input_tokens": 135984,
+          "output_tokens": 3466,
+          "skill_cost_usd": 0.21076295,
+          "output": {
+            "text_response": "Let me read the project files to understand the current state of h_002 and the relevant assertions.The picture is clear. Let me load the write tools and make the update.Now I have everything I need. The analysis is straightforward:\n\n- **a_016** is already in the assertions: Thomas Flynn of Luzerne County died **15 September 1840**, age 30, typhoid fever \u2014 linked to person I3 with `confidence: \"confident\"` (pe_008)\n- Patrick Flynn was born **~1845** \u2014 approximately **5 years after** this Thomas Flynn died\n- This is a **chronological impossibility** \u2014 a fundamental assumption violation under the GPS framework (a person cannot perform actions after their death)\n- The existing h_002 notes even flagged this as needing evaluation; the user is now acting on it\n\nThe correct action: add a_016 to `contradicting_assertion_ids`, set `status` to `\"ruled_out\"`, `ruled_out: true`, and supply a specific `ruled_out_reason`.Write succeeded. Now running mandatory post-write validation.Both files are valid. Here is the updated hypothesis state:\n\n---\n\n## Hypothesis h_002 \u2014 RULED OUT\n\n**Claim:** Patrick Flynn's father was Thomas Flynn of Luzerne County, Pennsylvania\n\n**Status: \u2717 RULED OUT**\n\n**Supporting evidence (1):**\n- `a_014` \u2014 1840 Luzerne County census: Thomas Flynn, age 30, head of household with 1 male child under 5 *(indirect \u2014 same-name candidate of right age, right era)*\n\n**Contradicting evidence (1):**\n- `a_016` \u2014 Luzerne County death record: Thomas Flynn died **15 September 1840**, age 30, typhoid fever *(direct, primary, original source \u2014 pe_008 confidence: confident)*\n\n**Ruled-out reason:** Chronological impossibility. The death record (a_016) establishes that this Thomas Flynn died in September 1840 \u2014 approximately **five years before Patrick's estimated ~1845 birth**. A man who died in 1840 cannot be the biological father of a child born in 1845. This is a fundamental assumption violation under GPS evidence reasoning. The dated death record is an affirmative original source created near the time of the event; it is not subject to census age-rounding ambiguity.\n\n---\n\n## Effect on competing hypothesis\n\n| Hypothesis | Candidate | Status |\n|---|---|---|\n| **h_001** | Thomas Flynn, Schuylkill Co. | **SUPPORTED** |\n| **h_002** | Thomas Flynn, Luzerne Co. | **RULED OUT** \u2717 |\n\nThe elimination of the Luzerne County candidate **strengthens h_001**. Ruling out a competing candidate is itself part of the proof argument \u2014 it narrows the field and makes the Schuylkill County identification more secure.\n\n**h_001 is now ready for proof-conclusion** when research is declared exhaustive. The probate search (pli_006) is still in progress \u2014 completing it and searching the 1870/1880/1900 censuses would advance the conclusion from *Probable* toward *Proved*.",
+            "activated": true,
+            "skills_invoked": [
+              "hypothesis-tracking"
+            ],
+            "tool_calls": [
+              {
+                "tool": "mcp__genealogy__research_append",
+                "args": {
+                  "projectPath": "/tmp/eval-ut_hypothesis_tracking_004-0-0-t_5zqf3u",
+                  "section": "hypotheses",
+                  "op": "update",
+                  "entryId": "h_002",
+                  "fields": {
+                    "status": "ruled_out",
+                    "contradicting_assertion_ids": [
+                      "a_016"
+                    ],
+                    "ruled_out": true,
+                    "ruled_out_reason": "Chronological impossibility: the Luzerne County death record (a_016) establishes that this Thomas Flynn died 15 September 1840, age 30, of typhoid fever \u2014 approximately five years before Patrick Flynn's estimated birth of ~1845. A man who died in 1840 cannot be the biological father of a child born in 1845. This is a fundamental assumption violation under GPS evidence reasoning. The identification of the deceased (I3) as this Thomas Flynn is rated confident (pe_008, match_score not required \u2014 direct death record). The chronological gap is not attributable to normal census age-rounding or informant error; it is an affirmative, dated death record from an original source created near the time of the event.",
+                    "notes": "Ruled out on the basis of a_016: Luzerne County death record, Thomas Flynn, died 15 September 1840, five years before Patrick's ~1845 birth. The 1840 census entry (a_014) confirms a Thomas Flynn of matching name and age was present in Luzerne County, but the death record eliminates him as Patrick's father. This elimination strengthens h_001 (Thomas Flynn of Schuylkill County) by reducing the field of competing candidates."
+                  }
+                },
+                "expected_args": null,
+                "matched": {
+                  "kind": "live",
+                  "index": null
+                },
+                "response_fixture": "live:research_append"
+              },
+              {
+                "tool": "mcp__genealogy__validate_research_schema",
+                "args": {
+                  "projectPath": "/tmp/eval-ut_hypothesis_tracking_004-0-0-t_5zqf3u"
+                },
+                "expected_args": null,
+                "matched": {
+                  "kind": "live",
+                  "index": null
+                },
+                "response_fixture": "live:validate_research_schema"
+              }
+            ],
+            "files_created": [],
+            "file_changes": {
+              "research.json": {
+                "sections_modified": [
+                  "hypotheses"
+                ],
+                "diff": {
+                  "hypotheses": {
+                    "added": [],
+                    "modified": [
+                      {
+                        "id": "h_002",
+                        "changed_fields": {
+                          "ruled_out": {
+                            "before": false,
+                            "after": true
+                          },
+                          "status": {
+                            "before": "active",
+                            "after": "ruled_out"
+                          },
+                          "ruled_out_reason": {
+                            "before": null,
+                            "after": "Chronological impossibility: the Luzerne County death record (a_016) establishes that this Thomas Flynn died 15 September 1840, age 30, of typhoid fever \u2014 approximately five years before Patrick Flynn's estimated birth of ~1845. A man who died in 1840 cannot be the biological father of a child born in 1845. This is a fundamental assumption violation under GPS evidence reasoning. The identification of the deceased (I3) as this Thomas Flynn is rated confident (pe_008, match_score not required \u2014 direct death record). The chronological gap is not attributable to normal census age-rounding or informant error; it is an affirmative, dated death record from an original source created near the time of the event."
+                          },
+                          "contradicting_assertion_ids": {
+                            "before": [],
+                            "after": [
+                              "a_016"
+                            ]
+                          },
+                          "notes": {
+                            "before": "Alternative candidate father. A Thomas Flynn age 30 was found in the 1840 Luzerne County census with 1 male child under 5 in the household. However, a death record shows this Thomas Flynn died 15 September 1840 of typhoid fever \u2014 5 years before Patrick's estimated 1845 birth. This chronological evidence needs evaluation to determine whether this candidate can be ruled out.",
+                            "after": "Ruled out on the basis of a_016: Luzerne County death record, Thomas Flynn, died 15 September 1840, five years before Patrick's ~1845 birth. The 1840 census entry (a_014) confirms a Thomas Flynn of matching name and age was present in Luzerne County, but the death record eliminates him as Patrick's father. This elimination strengthens h_001 (Thomas Flynn of Schuylkill County) by reducing the field of competing candidates."
+                          }
+                        }
+                      }
+                    ],
+                    "deleted": []
+                  }
+                }
+              }
+            },
+            "warnings": [
+              {
+                "kind": "missing_tool_usage_dimension",
+                "advisory": "Skill called MCP tools but the rubric has no dimension name suggesting tool-usage coverage (matched against keywords: ['tool usage', 'tool use', 'tool work', 'tool call', 'argument quality', 'argument-quality', 'response interpretation', 'tool selection', 'mcp tool', 'fixture']). The judge will grade other dimensions but won't score tool work explicitly. Consider adding a tool-usage dimension or renaming an existing one."
+              }
+            ]
+          },
+          "validators": {
+            "passed": true,
+            "results": [
+              {
+                "name": "test_id_references_resolve",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_log_append_only",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_entries_deleted",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_research_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tool_allowlist",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_gedcomx_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_h001_not_ruled_out_when_adding_identity_hypotheses",
+                "passed": true,
+                "error": "skipped: not a c_002 scenario"
+              },
+              {
+                "name": "test_h001_status_unchanged_when_review",
+                "passed": true,
+                "error": "skipped: not an h_001 scenario"
+              },
+              {
+                "name": "test_hypotheses_assertion_refs_resolve",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_hypotheses_no_deletions",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_new_hypotheses_have_claim",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_new_hypothesis_added_for_c002",
+                "passed": true,
+                "error": "skipped: not a c_002 scenario"
+              },
+              {
+                "name": "test_ruled_out_requires_reason",
+                "passed": true,
+                "error": null
+              }
+            ]
+          },
+          "judge": {
+            "skipped": false,
+            "dimensions": [
+              {
+                "source": "base",
+                "name": "Correctness",
+                "score": 3,
+                "rationale": "Claude correctly identified the chronological impossibility: Thomas Flynn of Luzerne County died 15 September 1840, five years before Patrick's ~1845 birth. The death assertion (a_016) is factually linked to the timeline, and the reasoning is sound under GPS evidence rules. No fabricated material or unsupported claims."
+              },
+              {
+                "source": "base",
+                "name": "Completeness",
+                "score": 3,
+                "rationale": "Claude fully addressed the user's request to update h_002 based on the death record. The hypothesis was properly evaluated, the status transitioned to ruled_out, contradicting evidence was linked, and the ruled_out_reason was supplied with detailed justification. No gaps in coverage."
+              },
+              {
+                "source": "base",
+                "name": "Tool Arguments",
+                "score": 3,
+                "rationale": "Both MCP tool calls passed correct arguments. The research_append call properly targeted h_002 with correct field updates (status, contradicting_assertion_ids, ruled_out, ruled_out_reason). The validate call was appropriate for post-write verification. No fixture_not_found errors; arguments match the expected structure."
+              },
+              {
+                "source": "rubric",
+                "name": "Claim clarity",
+                "score": 3,
+                "rationale": "The hypothesis claim is specific: 'Patrick Flynn's father was Thomas Flynn of Luzerne County, Pennsylvania.' It names specific persons, the relationship being hypothesized (paternity), and includes place detail (Luzerne County, Pennsylvania). The claim is directly testable."
+              },
+              {
+                "source": "rubric",
+                "name": "Evidence linkage",
+                "score": 3,
+                "rationale": "The linkage is correct and precise. The death record (a_016) showing Thomas Flynn died 15 September 1840 is appropriately placed in contradicting_assertion_ids because it directly contradicts the paternity hypothesis\u2014a man cannot father a child born five years after his death. The supporting evidence link (a_014, census) is also relevant as circumstantial evidence of the candidate."
+              },
+              {
+                "source": "rubric",
+                "name": "Status transitions",
+                "score": 3,
+                "rationale": "The status transition to ruled_out is justified by affirmative refutation, not mere absence of evidence. Claude cites the specific death date (15 September 1840) and the timeline gap to Patrick's ~1845 birth as the grounds for ruling out. The ruled_out_reason explicitly states the chronological impossibility and the GPS framework violation. This meets the schema requirement for ruled_out transitions with documented affirmative refutation."
+              }
+            ],
+            "judge_cost_usd": 0.008706,
+            "duration_ms": 7475.149294999937,
+            "error": null,
+            "input_tokens": 5166,
+            "cached_input_tokens": 0,
+            "output_tokens": 708
+          },
+          "started_at": 1782772100.628544,
+          "ended_at": 1782772192.776344
+        }
+      ]
+    },
+    {
+      "test_id": "ut_hypothesis_tracking_005",
+      "test_type": "positive",
+      "expected_outcome": "pass",
+      "scenario": "empty-project-just-created",
+      "mcp_fixtures": [
+        "validate-research-schema"
+      ],
+      "outcome": "pass",
+      "flaky": false,
+      "outcome_summary": {
+        "per_run_outcomes": [
+          "pass"
+        ],
+        "aggregated_dimensions": [
+          {
+            "source": "base",
+            "name": "Correctness",
+            "score": 3,
+            "rationale": "The hypothesis claim is factually correct given the user's input. Thomas Flynn of Schuylkill County, Pennsylvania in the 1840s is correctly stated as a candidate father for Patrick Flynn (b. ~1845, d. 1908). The facts in the claim align with the user's message and the stub person in the project state. No fabricated material is present. The related_question_ids is correctly set to an empty array, avoiding ownership violations."
+          },
+          {
+            "source": "base",
+            "name": "Completeness",
+            "score": 3,
+            "rationale": "The skill addressed all required elements: created a specific, testable hypothesis with proper formatting; called validate_research_schema as mandatory; set status to 'active' appropriately since no research evidence exists yet; included empty supporting and contradicting assertion arrays; and provided relevant guidance on next research steps."
+          },
+          {
+            "source": "base",
+            "name": "Tool Arguments",
+            "score": 3,
+            "rationale": "Both tool calls executed successfully with matched.kind='live'. The research_append call correctly specified all required fields: claim with specific names/places/timeframe, status='active', empty assertion arrays, ruled_out=false, null ruled_out_reason, and empty related_question_ids array. The validate_research_schema call was correctly invoked with only the projectPath argument. All arguments match expected usage."
+          },
+          {
+            "source": "rubric",
+            "name": "Claim clarity",
+            "score": 3,
+            "rationale": "The claim names specific persons (Thomas Flynn and Patrick Flynn), specifies the exact relationship (father-child), and includes precise place/time detail (Schuylkill County, Pennsylvania, 1840s for Thomas; born ca. 1845, died 1908 in Schuylkill County for Patrick). This is testable and would support targeted searches in census records and parish registers."
+          },
+          {
+            "source": "rubric",
+            "name": "Evidence linkage",
+            "score": 3,
+            "rationale": "No evidence has been linked yet, which is correct\u2014this is the initial hypothesis creation. The supporting_assertion_ids and contradicting_assertion_ids arrays are appropriately empty since no research has been done. No tangential assertions are present to mislink."
+          },
+          {
+            "source": "rubric",
+            "name": "Status transitions",
+            "score": 3,
+            "rationale": "The status is correctly set to 'active' per research-schema-spec.md \u00a75.9 rules. Since no supporting evidence exists yet, 'supported' would be premature and incorrect. The ruled_out field is false with null ruled_out_reason, which is proper since there is no refuting evidence. The transition from project initialization to this initial 'active' hypothesis is justified."
+          }
+        ]
+      },
+      "totals": {
+        "duration_ms": 39802.943819000575,
+        "duration_api_ms": 39014.0,
+        "judge_duration_ms": 8094.64339599981,
+        "wall_clock_ms": 47931.96749687195,
+        "num_turns": 8,
+        "input_tokens": 12,
+        "cached_input_tokens": 63665,
+        "output_tokens": 1724,
+        "judge_input_tokens": 4649,
+        "judge_cached_input_tokens": 0,
+        "judge_output_tokens": 741,
+        "skill_cost_usd": 0.0755895,
+        "judge_cost_usd": 0.008354,
+        "total_cost_usd": 0.0839435
+      },
+      "runs": [
+        {
+          "run_index": 0,
+          "run_id": "run_ut_hypothesis_tracking_005_2026-06-29_22-28-20_0",
+          "outcome": "pass",
+          "aborted_reason": null,
+          "duration_ms": 39802.943819000575,
+          "duration_api_ms": 39014.0,
+          "num_turns": 8,
+          "skill_attempts": 1,
+          "input_tokens": 12,
+          "cached_input_tokens": 63665,
+          "output_tokens": 1724,
+          "skill_cost_usd": 0.0755895,
+          "output": {
+            "text_response": "Good, `h_001` was created. Now let me run the mandatory validation.All clear. Here's where things stand:\n\n---\n\n**Hypothesis: h_001 \u2014 Thomas Flynn of Schuylkill County is Patrick Flynn's father**\n**Status: ACTIVE**\n\n> *Thomas Flynn of Schuylkill County, Pennsylvania (present in the 1840s) is the father of Patrick Flynn (born ca. 1845 in Pennsylvania, died 1908 in Schuylkill County, PA)*\n\n| | |\n|---|---|\n| Supporting evidence | (none yet) |\n| Contradicting evidence | (none yet) |\n| Competing hypotheses | (none yet) |\n\n---\n\n**A few things to keep in mind as you start researching:**\n\n- **This is an `active` hypothesis** \u2014 it stays that way until you have at least one direct assertion supporting it and no unresolved contradictions. I'll upgrade it to `supported` when that bar is met.\n- **Design searches to refute, not just confirm.** For each record you find, ask: *could this evidence prove Thomas Flynn was NOT Patrick's father?* A hypothesis that survives deliberate refutation is much stronger.\n- **If you find a competing Thomas Flynn** (say, a Thomas Flynn in Luzerne or Carbon County the right age), I can spin up a second hypothesis so you can track the candidates side by side.\n\nGood starting searches to consider would be the 1850 and 1860 Schuylkill County census (to place a Thomas Flynn of the right age in the area) and any Irish Catholic parish registers from that county. Whenever you pull a record, use **record-extraction** to turn it into assertions, then come back here to link them to `h_001`.",
+            "activated": true,
+            "skills_invoked": [
+              "hypothesis-tracking"
+            ],
+            "tool_calls": [
+              {
+                "tool": "mcp__genealogy__research_append",
+                "args": {
+                  "projectPath": "/tmp/eval-ut_hypothesis_tracking_005-0-0-1ut1n73t",
+                  "section": "hypotheses",
+                  "op": "append",
+                  "entry": {
+                    "claim": "Thomas Flynn of Schuylkill County, Pennsylvania (present in the 1840s) is the father of Patrick Flynn (born ca. 1845 in Pennsylvania, died 1908 in Schuylkill County, PA)",
+                    "status": "active",
+                    "supporting_assertion_ids": [],
+                    "contradicting_assertion_ids": [],
+                    "ruled_out": false,
+                    "ruled_out_reason": null,
+                    "notes": "Researcher's initial working hypothesis. No supporting assertions yet. Research is at the very beginning \u2014 no records have been searched or extracted.",
+                    "related_question_ids": []
+                  }
+                },
+                "expected_args": null,
+                "matched": {
+                  "kind": "live",
+                  "index": null
+                },
+                "response_fixture": "live:research_append"
+              },
+              {
+                "tool": "mcp__genealogy__validate_research_schema",
+                "args": {
+                  "projectPath": "/tmp/eval-ut_hypothesis_tracking_005-0-0-1ut1n73t"
+                },
+                "expected_args": null,
+                "matched": {
+                  "kind": "live",
+                  "index": null
+                },
+                "response_fixture": "live:validate_research_schema"
+              }
+            ],
+            "files_created": [],
+            "file_changes": {
+              "research.json": {
+                "sections_modified": [
+                  "hypotheses"
+                ],
+                "diff": {
+                  "hypotheses": {
+                    "added": [
+                      {
+                        "id": "h_001",
+                        "claim": "Thomas Flynn of Schuylkill County, Pennsylvania (present in the 1840s) is the father of Patrick Flynn (born ca. 1845 in Pennsylvania, died 1908 in Schuylkill County, PA)",
+                        "status": "active",
+                        "supporting_assertion_ids": [],
+                        "contradicting_assertion_ids": [],
+                        "ruled_out": false,
+                        "ruled_out_reason": null,
+                        "notes": "Researcher's initial working hypothesis. No supporting assertions yet. Research is at the very beginning \u2014 no records have been searched or extracted.",
+                        "related_question_ids": []
+                      }
+                    ],
+                    "modified": [],
+                    "deleted": []
+                  }
+                }
+              }
+            },
+            "warnings": [
+              {
+                "kind": "missing_tool_usage_dimension",
+                "advisory": "Skill called MCP tools but the rubric has no dimension name suggesting tool-usage coverage (matched against keywords: ['tool usage', 'tool use', 'tool work', 'tool call', 'argument quality', 'argument-quality', 'response interpretation', 'tool selection', 'mcp tool', 'fixture']). The judge will grade other dimensions but won't score tool work explicitly. Consider adding a tool-usage dimension or renaming an existing one."
+              }
+            ]
+          },
+          "validators": {
+            "passed": true,
+            "results": [
+              {
+                "name": "test_id_references_resolve",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_log_append_only",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_entries_deleted",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_research_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tool_allowlist",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_gedcomx_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_h001_not_ruled_out_when_adding_identity_hypotheses",
+                "passed": true,
+                "error": "skipped: not a c_002 scenario"
+              },
+              {
+                "name": "test_h001_status_unchanged_when_review",
+                "passed": true,
+                "error": "skipped: not an h_001 scenario"
+              },
+              {
+                "name": "test_hypotheses_assertion_refs_resolve",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_hypotheses_no_deletions",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_new_hypotheses_have_claim",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_new_hypothesis_added_for_c002",
+                "passed": true,
+                "error": "skipped: not a c_002 scenario"
+              },
+              {
+                "name": "test_ruled_out_requires_reason",
+                "passed": true,
+                "error": null
+              }
+            ]
+          },
+          "judge": {
+            "skipped": false,
+            "dimensions": [
+              {
+                "source": "base",
+                "name": "Correctness",
+                "score": 3,
+                "rationale": "The hypothesis claim is factually correct given the user's input. Thomas Flynn of Schuylkill County, Pennsylvania in the 1840s is correctly stated as a candidate father for Patrick Flynn (b. ~1845, d. 1908). The facts in the claim align with the user's message and the stub person in the project state. No fabricated material is present. The related_question_ids is correctly set to an empty array, avoiding ownership violations."
+              },
+              {
+                "source": "base",
+                "name": "Completeness",
+                "score": 3,
+                "rationale": "The skill addressed all required elements: created a specific, testable hypothesis with proper formatting; called validate_research_schema as mandatory; set status to 'active' appropriately since no research evidence exists yet; included empty supporting and contradicting assertion arrays; and provided relevant guidance on next research steps."
+              },
+              {
+                "source": "base",
+                "name": "Tool Arguments",
+                "score": 3,
+                "rationale": "Both tool calls executed successfully with matched.kind='live'. The research_append call correctly specified all required fields: claim with specific names/places/timeframe, status='active', empty assertion arrays, ruled_out=false, null ruled_out_reason, and empty related_question_ids array. The validate_research_schema call was correctly invoked with only the projectPath argument. All arguments match expected usage."
+              },
+              {
+                "source": "rubric",
+                "name": "Claim clarity",
+                "score": 3,
+                "rationale": "The claim names specific persons (Thomas Flynn and Patrick Flynn), specifies the exact relationship (father-child), and includes precise place/time detail (Schuylkill County, Pennsylvania, 1840s for Thomas; born ca. 1845, died 1908 in Schuylkill County for Patrick). This is testable and would support targeted searches in census records and parish registers."
+              },
+              {
+                "source": "rubric",
+                "name": "Evidence linkage",
+                "score": 3,
+                "rationale": "No evidence has been linked yet, which is correct\u2014this is the initial hypothesis creation. The supporting_assertion_ids and contradicting_assertion_ids arrays are appropriately empty since no research has been done. No tangential assertions are present to mislink."
+              },
+              {
+                "source": "rubric",
+                "name": "Status transitions",
+                "score": 3,
+                "rationale": "The status is correctly set to 'active' per research-schema-spec.md \u00a75.9 rules. Since no supporting evidence exists yet, 'supported' would be premature and incorrect. The ruled_out field is false with null ruled_out_reason, which is proper since there is no refuting evidence. The transition from project initialization to this initial 'active' hypothesis is justified."
+              }
+            ],
+            "judge_cost_usd": 0.008354,
+            "duration_ms": 8094.64339599981,
+            "error": null,
+            "input_tokens": 4649,
+            "cached_input_tokens": 0,
+            "output_tokens": 741
+          },
+          "started_at": 1782772346.358318,
+          "ended_at": 1782772394.2902856
+        }
+      ]
+    },
+    {
+      "test_id": "ut_hypothesis_tracking_006",
+      "test_type": "positive",
+      "expected_outcome": "pass",
+      "scenario": "flynn-competing-fathers",
+      "mcp_fixtures": [
+        "validate-research-schema"
+      ],
+      "outcome": "pass",
+      "flaky": false,
+      "outcome_summary": {
+        "per_run_outcomes": [
+          "pass"
+        ],
+        "aggregated_dimensions": [
+          {
+            "source": "base",
+            "name": "Correctness",
+            "score": 3,
+            "rationale": "Claude's text response accurately reflects the research state: h_001 is correctly identified as SUPPORTED with three supporting assertions (a_004, a_010, a_013) and no contradictions; h_002 is correctly identified as ACTIVE with one supporting assertion (a_014). The schema validation passed. Claude correctly identifies the chronological impossibility (a_016: death in 1840 vs. ~1845 birth) that should lead to h_002 being ruled out, and appropriately flags this gap without making unsupported claims. All factual statements are grounded in the provided research data."
+          },
+          {
+            "source": "base",
+            "name": "Completeness",
+            "score": 3,
+            "rationale": "Claude presented both competing hypotheses (h_001 and h_002) as required, along with their current status, supporting evidence, and contradicting evidence. It correctly identified the chronological contradiction (a_016) that the test notes indicated should be noticed. For a read-only review, Claude appropriately deferred modification while identifying the needed next action. No major portions of the request were omitted."
+          },
+          {
+            "source": "base",
+            "name": "Tool Arguments",
+            "score": 3,
+            "rationale": "Claude made exactly one MCP tool call: validate_research_schema with projectPath set to the correct test directory. This matches expected behavior per SKILL.md requirements for every interaction, and the call is correctly structured and executed. The test explicitly required this validation even for read-only reviews, and Claude performed it."
+          },
+          {
+            "source": "rubric",
+            "name": "Claim clarity",
+            "score": 3,
+            "rationale": "Both hypotheses are stated with high clarity: h_001 names 'Thomas Flynn of Schuylkill County, PA' as father of Patrick Flynn (~1845 birth), and h_002 names 'Thomas Flynn of Luzerne County, PA' as the competing candidate. Both are specific, testable claims with place and time detail sufficient for follow-up searches. The relationship (biological father) is explicit and the persons are named with geographic specificity."
+          },
+          {
+            "source": "rubric",
+            "name": "Evidence linkage",
+            "score": 3,
+            "rationale": "Claude correctly identifies and discusses the evidence linkages: a_004, a_010, a_013 genuinely support h_001 (household presence, age consistency, deathbed statement naming father); a_014 supports h_002 (Luzerne census showing Thomas with young child). Critically, Claude also correctly identifies a_016 (death record) as contradicting h_002 but appropriately flags it as 'not yet linked' in the data structure rather than falsely claiming it is already linked. This demonstrates correct read-only analysis: identifying the gap without fabricating existing linkages."
+          },
+          {
+            "source": "rubric",
+            "name": "Status transitions",
+            "score": 3,
+            "rationale": "Claude correctly identifies that h_002 should move to 'ruled_out' based on affirmative refutation (a_016: death in 1840 before Patrick's ~1845 birth), matching research-schema-spec \u00a75.9 rules. Critically, for a read-only review, Claude defers the actual transition while explicitly identifying the needed change and providing the exact rationale ('five years before Patrick's estimated 1845 birth \u2014 biological parentage is impossible'). This demonstrates correct behavior per test guidance: identifying needed transitions without modifying the file during a read-only summary. The score is pass because Claude correctly characterizes the current status (ACTIVE) and identifies why it should change, without mischaracterizing existing statuses."
+          }
+        ]
+      },
+      "totals": {
+        "duration_ms": 58291.64677699919,
+        "duration_api_ms": 58351.0,
+        "judge_duration_ms": 10895.606060001228,
+        "wall_clock_ms": 69230.07082939148,
+        "num_turns": 9,
+        "input_tokens": 16,
+        "cached_input_tokens": 148638,
+        "output_tokens": 2628,
+        "judge_input_tokens": 5080,
+        "judge_cached_input_tokens": 0,
+        "judge_output_tokens": 941,
+        "skill_cost_usd": 0.1709119,
+        "judge_cost_usd": 0.009785,
+        "total_cost_usd": 0.1806969
+      },
+      "runs": [
+        {
+          "run_index": 0,
+          "run_id": "run_ut_hypothesis_tracking_006_2026-06-29_22-28-20_0",
+          "outcome": "pass",
+          "aborted_reason": null,
+          "duration_ms": 58291.64677699919,
+          "duration_api_ms": 58351.0,
+          "num_turns": 9,
+          "skill_attempts": 1,
+          "input_tokens": 16,
+          "cached_input_tokens": 148638,
+          "output_tokens": 2628,
+          "skill_cost_usd": 0.1709119,
+          "output": {
+            "text_response": "I'll read the project files to give you a current snapshot of all hypotheses.Now let me check for the narration guidance and GPS reference file:Good \u2014 I have everything I need. Let me run the required schema validation before presenting.Schema validation passed \u2014 both files are clean. Here's the full hypothesis status snapshot:\n\n---\n\n## Hypothesis Status Summary\n\n### h_001 \u2014 Patrick Flynn's father was Thomas Flynn of Schuylkill County, PA\n**Status: SUPPORTED**\n\n| | |\n|---|---|\n| Supporting evidence | 3 assertions |\n| Contradicting evidence | None |\n| Ruled out | No |\n\n**Supporting assertions:**\n- `a_004` \u2014 1850 census: Patrick enumerated in Thomas Flynn's household, position consistent with child *(indirect, indeterminate quality)*\n- `a_010` \u2014 1860 census: Patrick again in Thomas Flynn's household, age consistent *(indirect, indeterminate quality)*\n- `a_013` \u2014 1908 death certificate: \"Father: Thomas Flynn\" *(direct, secondary informant \u2014 son-in-law James Brown)*\n\n**Notes:** A proof summary already exists (`ps_001`) at the **Probable** tier. The probate search (`pli_006`) is still in progress \u2014 a will naming Patrick as a son would strengthen this to **Proved**.\n\n---\n\n### h_002 \u2014 Patrick Flynn's father was Thomas Flynn of Luzerne County, PA\n**Status: ACTIVE** \u26a0\ufe0f *Action needed*\n\n| | |\n|---|---|\n| Supporting evidence | 1 assertion |\n| Contradicting evidence | **0 listed \u2014 but see flag below** |\n| Ruled out | No \u2014 but **should be** |\n\n**Supporting assertion:**\n- `a_014` \u2014 1840 census: Thomas Flynn, age 30, in Luzerne County, 1 male child under 5 in household *(indirect)*\n\n\u26a0\ufe0f **Flag \u2014 chronological impossibility not yet recorded:** Assertion `a_016` (Luzerne County death record: Thomas Flynn died **15 September 1840**, typhoid fever) is already in `assertions` and linked to person I3 via `pe_008` with `confidence: confident` \u2014 but it is **not** in `h_002`'s `contradicting_assertion_ids`, and the hypothesis has not been ruled out. This Thomas Flynn died **5 years before Patrick's estimated 1845 birth**, which is a chronological impossibility for biological parentage. This candidate should be ruled out with `a_016` recorded as the contradicting assertion.\n\nSince you asked for a read-only summary, I haven't modified `research.json`. But this is a clear next action \u2014 just say the word and I'll rule out h_002 and link `a_016` as the contradicting assertion.\n\n---\n\n## At a Glance\n\n| ID | Claim | Status | Supporting | Contradicting |\n|---|---|---|---|---|\n| h_001 | Thomas Flynn, Schuylkill Co. | \u2705 SUPPORTED | a_004, a_010, a_013 | \u2014 |\n| h_002 | Thomas Flynn, Luzerne Co. | \u26a0\ufe0f ACTIVE \u2192 should be RULED OUT | a_014 | a_016 *(not yet linked)* |\n\n---\n\n## Suggested next steps\n\n1. **Rule out h_002** \u2014 Link `a_016` as a contradicting assertion and set `ruled_out: true` with reason: *\"Thomas Flynn of Luzerne County died 15 September 1840 per death record (a_016), five years before Patrick Flynn's estimated 1845 birth \u2014 biological parentage is impossible.\"*\n2. **Complete the probate search** (`pli_006`) \u2014 Thomas Flynn's will could provide direct evidence of Patrick's parentage and push the proof tier from Probable to Proved.\n3. **Once h_002 is ruled out**, h_001 stands as the only remaining candidate \u2014 consider whether research is exhaustive enough for `proof-conclusion` or `research-exhaustiveness`.",
+            "activated": true,
+            "skills_invoked": [
+              "hypothesis-tracking"
+            ],
+            "tool_calls": [
+              {
+                "tool": "mcp__genealogy__validate_research_schema",
+                "args": {
+                  "projectPath": "/tmp/eval-ut_hypothesis_tracking_006-0-0-wi_y1zk5"
+                },
+                "expected_args": null,
+                "matched": {
+                  "kind": "live",
+                  "index": null
+                },
+                "response_fixture": "live:validate_research_schema"
+              }
+            ],
+            "files_created": [],
+            "warnings": [
+              {
+                "kind": "missing_tool_usage_dimension",
+                "advisory": "Skill called MCP tools but the rubric has no dimension name suggesting tool-usage coverage (matched against keywords: ['tool usage', 'tool use', 'tool work', 'tool call', 'argument quality', 'argument-quality', 'response interpretation', 'tool selection', 'mcp tool', 'fixture']). The judge will grade other dimensions but won't score tool work explicitly. Consider adding a tool-usage dimension or renaming an existing one."
+              },
+              {
+                "kind": "uncovered_tool_call",
+                "advisory": "1 of 2 MCP tool call(s) matched no fixture predicate \u2014 the skill ran against a fixture_not_found or denied/unknown-tool error. Add or fix an mcp_fixture whose args match the call.",
+                "attempted": [
+                  {
+                    "tool": "mcp__genealogy__validate_research_schema",
+                    "args": {}
+                  },
+                  {
+                    "tool": "mcp__genealogy__validate_research_schema",
+                    "args": {
+                      "projectPath": "/tmp/eval-ut_hypothesis_tracking_006-0-0-wi_y1zk5"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "validators": {
+            "passed": true,
+            "results": [
+              {
+                "name": "test_id_references_resolve",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_log_append_only",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_entries_deleted",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_research_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tool_allowlist",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_gedcomx_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_h001_not_ruled_out_when_adding_identity_hypotheses",
+                "passed": true,
+                "error": "skipped: not a c_002 scenario"
+              },
+              {
+                "name": "test_h001_status_unchanged_when_review",
+                "passed": true,
+                "error": "skipped: not an h_001 scenario"
+              },
+              {
+                "name": "test_hypotheses_assertion_refs_resolve",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_hypotheses_no_deletions",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_new_hypotheses_have_claim",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_new_hypothesis_added_for_c002",
+                "passed": true,
+                "error": "skipped: not a c_002 scenario"
+              },
+              {
+                "name": "test_ruled_out_requires_reason",
+                "passed": true,
+                "error": null
+              }
+            ]
+          },
+          "judge": {
+            "skipped": false,
+            "dimensions": [
+              {
+                "source": "base",
+                "name": "Correctness",
+                "score": 3,
+                "rationale": "Claude's text response accurately reflects the research state: h_001 is correctly identified as SUPPORTED with three supporting assertions (a_004, a_010, a_013) and no contradictions; h_002 is correctly identified as ACTIVE with one supporting assertion (a_014). The schema validation passed. Claude correctly identifies the chronological impossibility (a_016: death in 1840 vs. ~1845 birth) that should lead to h_002 being ruled out, and appropriately flags this gap without making unsupported claims. All factual statements are grounded in the provided research data."
+              },
+              {
+                "source": "base",
+                "name": "Completeness",
+                "score": 3,
+                "rationale": "Claude presented both competing hypotheses (h_001 and h_002) as required, along with their current status, supporting evidence, and contradicting evidence. It correctly identified the chronological contradiction (a_016) that the test notes indicated should be noticed. For a read-only review, Claude appropriately deferred modification while identifying the needed next action. No major portions of the request were omitted."
+              },
+              {
+                "source": "base",
+                "name": "Tool Arguments",
+                "score": 3,
+                "rationale": "Claude made exactly one MCP tool call: validate_research_schema with projectPath set to the correct test directory. This matches expected behavior per SKILL.md requirements for every interaction, and the call is correctly structured and executed. The test explicitly required this validation even for read-only reviews, and Claude performed it."
+              },
+              {
+                "source": "rubric",
+                "name": "Claim clarity",
+                "score": 3,
+                "rationale": "Both hypotheses are stated with high clarity: h_001 names 'Thomas Flynn of Schuylkill County, PA' as father of Patrick Flynn (~1845 birth), and h_002 names 'Thomas Flynn of Luzerne County, PA' as the competing candidate. Both are specific, testable claims with place and time detail sufficient for follow-up searches. The relationship (biological father) is explicit and the persons are named with geographic specificity."
+              },
+              {
+                "source": "rubric",
+                "name": "Evidence linkage",
+                "score": 3,
+                "rationale": "Claude correctly identifies and discusses the evidence linkages: a_004, a_010, a_013 genuinely support h_001 (household presence, age consistency, deathbed statement naming father); a_014 supports h_002 (Luzerne census showing Thomas with young child). Critically, Claude also correctly identifies a_016 (death record) as contradicting h_002 but appropriately flags it as 'not yet linked' in the data structure rather than falsely claiming it is already linked. This demonstrates correct read-only analysis: identifying the gap without fabricating existing linkages."
+              },
+              {
+                "source": "rubric",
+                "name": "Status transitions",
+                "score": 3,
+                "rationale": "Claude correctly identifies that h_002 should move to 'ruled_out' based on affirmative refutation (a_016: death in 1840 before Patrick's ~1845 birth), matching research-schema-spec \u00a75.9 rules. Critically, for a read-only review, Claude defers the actual transition while explicitly identifying the needed change and providing the exact rationale ('five years before Patrick's estimated 1845 birth \u2014 biological parentage is impossible'). This demonstrates correct behavior per test guidance: identifying needed transitions without modifying the file during a read-only summary. The score is pass because Claude correctly characterizes the current status (ACTIVE) and identifies why it should change, without mischaracterizing existing statuses."
+              }
+            ],
+            "judge_cost_usd": 0.009785,
+            "duration_ms": 10895.606060001228,
+            "error": null,
+            "input_tokens": 5080,
+            "cached_input_tokens": 0,
+            "output_tokens": 941
+          },
+          "started_at": 1782772356.892179,
+          "ended_at": 1782772426.1222498
+        }
+      ]
+    },
+    {
+      "test_id": "ut_hypothesis_tracking_007",
+      "test_type": "positive",
+      "expected_outcome": "pass",
+      "scenario": "mid-research-flynn",
+      "mcp_fixtures": [
+        "validate-research-schema"
+      ],
+      "outcome": "pass",
+      "flaky": false,
+      "outcome_summary": {
+        "per_run_outcomes": [
+          "pass"
+        ],
+        "aggregated_dimensions": [
+          {
+            "source": "base",
+            "name": "Correctness",
+            "score": 3,
+            "rationale": "The hypothesis was created with accurate details: claim names Margaret O'Brien of County Cork as Patrick's mother; correctly identified the user-submitted FamilySearch tree as a compiled source (lead, not evidence); supporting_assertion_ids correctly left empty since no original-record assertions exist yet; status set to 'active' (appropriate for unverified lead); related to q_001 (parentage question). The file was successfully written and validated. No fabricated material or unsupported claims."
+          },
+          {
+            "source": "base",
+            "name": "Completeness",
+            "score": 3,
+            "rationale": "The skill fully addressed the user's request: created a hypothesis tracking the Margaret O'Brien mother claim; explicitly flagged the compiled-source origin and stated the need for independent verification against original records; populated all required fields (claim, status, supporting/contradicting assertions, related question); provided concrete research pathways for verification and refutation. Nothing requested was omitted."
+          },
+          {
+            "source": "base",
+            "name": "Tool Arguments",
+            "score": 3,
+            "rationale": "Both MCP calls matched expectations. The mcp__genealogy__research_append call correctly appended a hypothesis entry with projectPath, section='hypotheses', op='append', and a complete entry object matching schema (claim, status, assertion arrays, ruled_out/reason, notes, related_question_ids). The mcp__genealogy__validate_research_schema call correctly passed projectPath. Both calls succeeded (matched.kind='live') with valid responses."
+          },
+          {
+            "source": "rubric",
+            "name": "Claim clarity",
+            "score": 3,
+            "rationale": "The hypothesis claim is highly specific and testable: 'Patrick Flynn's mother was Margaret O'Brien from County Cork, Ireland.' It names the specific person (Margaret O'Brien), the specific relationship (mother), and includes geographic detail (County Cork) and implicit temporal context (Patrick born ~1845). A follow-up search can directly test this against original Irish records or naturalization/census documents. Not vague."
+          },
+          {
+            "source": "rubric",
+            "name": "Evidence linkage",
+            "score": 3,
+            "rationale": "Supporting and contradicting assertion IDs are both empty arrays, which is correct since no assertions in research.json yet address Patrick's mother. The hypothesis is properly linked via related_question_ids to q_001 ('Who were the parents?'), a direct and appropriate connection. The notes correctly explain why no assertions are linked and outline the types of evidence (baptismal records, naturalization papers, etc.) that would bear on the hypothesis."
+          },
+          {
+            "source": "rubric",
+            "name": "Status transitions",
+            "score": 3,
+            "rationale": "Status was correctly set to 'active' (not 'supported' or 'ruled_out'), which aligns with research-schema-spec.md \u00a75.9 guidance. The hypothesis is unverified; no direct evidence exists; no affirmative refutation exists. The ruled_out field is false and ruled_out_reason is null, consistent with an active lead. The transition is justified: this is a compiled-source lead requiring investigation, not yet ready for support or dismissal."
+          }
+        ]
+      },
+      "totals": {
+        "duration_ms": 48281.83046999948,
+        "duration_api_ms": 47316.0,
+        "judge_duration_ms": 9190.953354000158,
+        "wall_clock_ms": 57518.27430725098,
+        "num_turns": 8,
+        "input_tokens": 2489,
+        "cached_input_tokens": 109479,
+        "output_tokens": 2095,
+        "judge_input_tokens": 5113,
+        "judge_cached_input_tokens": 0,
+        "judge_output_tokens": 831,
+        "skill_cost_usd": 0.16332095,
+        "judge_cost_usd": 0.009268,
+        "total_cost_usd": 0.17258895
+      },
+      "runs": [
+        {
+          "run_index": 0,
+          "run_id": "run_ut_hypothesis_tracking_007_2026-06-29_22-28-20_0",
+          "outcome": "pass",
+          "aborted_reason": null,
+          "duration_ms": 48281.83046999948,
+          "duration_api_ms": 47316.0,
+          "num_turns": 8,
+          "skill_attempts": 1,
+          "input_tokens": 2489,
+          "cached_input_tokens": 109479,
+          "output_tokens": 2095,
+          "skill_cost_usd": 0.16332095,
+          "output": {
+            "text_response": "Now I have everything I need. The project already has `h_001` tracking Thomas Flynn as Patrick's father. There are no existing assertions about Patrick's mother, and the claim originates from a **compiled source** (user-submitted family tree) \u2014 exactly the scenario the GPS guidance describes as a lead requiring hypothesis formation and targeted verification. Let me create it.Written successfully as `h_002`. Now the mandatory schema validation:Schema is clean. Here's the full picture:\n\n---\n\n## Hypothesis Created\n\n**h_002 \u2014 Patrick Flynn's mother was Margaret O'Brien from County Cork, Ireland**\n**Status: ACTIVE**\n\n| Field | Value |\n|---|---|\n| Claim | Patrick Flynn's mother was Margaret O'Brien from County Cork, Ireland |\n| Status | **ACTIVE** |\n| Source of claim | User-submitted FamilySearch family tree (compiled source) |\n| Supporting assertions | *(none yet)* |\n| Contradicting assertions | *(none yet)* |\n| Linked question | q_001 \u2014 Who were the parents of Patrick Flynn? |\n\n---\n\n### Why this starts as a lead, not a fact\n\nThe FamilySearch family tree is a **compiled source** \u2014 someone else's work, with no cited documentation behind it. Per GPS standards, compiled sources generate *leads*, not evidence. The claim may turn out to be correct, but it carries zero evidentiary weight until verified against original records.\n\n### Research needed to verify or refute\n\n**To support:**\n1. **Irish church/civil records, County Cork, ca. 1845** \u2014 a baptismal entry for Patrick Flynn naming both parents would be the strongest possible confirmation\n2. **Thomas Flynn's naturalization papers** \u2014 may name his wife\n3. **Thomas Flynn's death certificate or probate/will** \u2014 may name spouse or acknowledge children jointly\n4. **1880 census** \u2014 first census with explicit relationship column; if either parent survived to 1880, this would directly name the mother\n5. **Marriage record for Thomas Flynn & Margaret O'Brien** \u2014 would establish the union\n\n**To refute (equally important):**\n- Any record naming a *different* woman as Patrick's mother\n- Evidence placing Margaret O'Brien incompatibly distant from this family\n\n---\n\n### Related hypothesis\n- **h_001** \u2014 Patrick's *father* was Thomas Flynn of Schuylkill County \u2192 **SUPPORTED** (3 lines of evidence; ready for proof-conclusion)\n\nThe mother question (h_002) is independent but linked to the same question. If you'd like to build a research plan targeting the verification records, the `research-plan` skill can map out the next steps.",
+            "activated": true,
+            "skills_invoked": [
+              "hypothesis-tracking"
+            ],
+            "tool_calls": [
+              {
+                "tool": "mcp__genealogy__research_append",
+                "args": {
+                  "projectPath": "/tmp/eval-ut_hypothesis_tracking_007-0-0-pfb71kiz",
+                  "section": "hypotheses",
+                  "op": "append",
+                  "entry": {
+                    "claim": "Patrick Flynn's mother was Margaret O'Brien from County Cork, Ireland",
+                    "status": "active",
+                    "supporting_assertion_ids": [],
+                    "contradicting_assertion_ids": [],
+                    "ruled_out": false,
+                    "ruled_out_reason": null,
+                    "notes": "Lead from a user-submitted FamilySearch family tree \u2014 a compiled source with no cited documentation. Per GPS guidance, compiled sources generate leads, not conclusions; this hypothesis requires verification against original records before any weight can be assigned to the claim. No assertions currently in research.json address Patrick's mother. Priority research to verify or refute: (1) Irish baptismal or church records for Patrick Flynn ca. 1845, County Cork \u2014 would ideally name both parents; (2) U.S. naturalization papers for Thomas Flynn \u2014 may name wife; (3) Thomas Flynn's death certificate or probate \u2014 may name spouse; (4) 1880 census (first year with explicit relationship column) if Thomas or Margaret survived that long; (5) marriage record for Thomas Flynn and Margaret O'Brien. Also seek refuting evidence: any record that names a different woman as Patrick's mother, or places a Margaret O'Brien incompatibly far from this family.",
+                    "related_question_ids": [
+                      "q_001"
+                    ]
+                  }
+                },
+                "expected_args": null,
+                "matched": {
+                  "kind": "live",
+                  "index": null
+                },
+                "response_fixture": "live:research_append"
+              },
+              {
+                "tool": "mcp__genealogy__validate_research_schema",
+                "args": {
+                  "projectPath": "/tmp/eval-ut_hypothesis_tracking_007-0-0-pfb71kiz"
+                },
+                "expected_args": null,
+                "matched": {
+                  "kind": "live",
+                  "index": null
+                },
+                "response_fixture": "live:validate_research_schema"
+              }
+            ],
+            "files_created": [],
+            "file_changes": {
+              "research.json": {
+                "sections_modified": [
+                  "hypotheses"
+                ],
+                "diff": {
+                  "hypotheses": {
+                    "added": [
+                      {
+                        "id": "h_002",
+                        "claim": "Patrick Flynn's mother was Margaret O'Brien from County Cork, Ireland",
+                        "status": "active",
+                        "supporting_assertion_ids": [],
+                        "contradicting_assertion_ids": [],
+                        "ruled_out": false,
+                        "ruled_out_reason": null,
+                        "notes": "Lead from a user-submitted FamilySearch family tree \u2014 a compiled source with no cited documentation. Per GPS guidance, compiled sources generate leads, not conclusions; this hypothesis requires verification against original records before any weight can be assigned to the claim. No assertions currently in research.json address Patrick's mother. Priority research to verify or refute: (1) Irish baptismal or church records for Patrick Flynn ca. 1845, County Cork \u2014 would ideally name both parents; (2) U.S. naturalization papers for Thomas Flynn \u2014 may name wife; (3) Thomas Flynn's death certificate or probate \u2014 may name spouse; (4) 1880 census (first year with explicit relationship column) if Thomas or Margaret survived that long; (5) marriage record for Thomas Flynn and Margaret O'Brien. Also seek refuting evidence: any record that names a different woman as Patrick's mother, or places a Margaret O'Brien incompatibly far from this family.",
+                        "related_question_ids": [
+                          "q_001"
+                        ]
+                      }
+                    ],
+                    "modified": [],
+                    "deleted": []
+                  }
+                }
+              }
+            },
+            "warnings": [
+              {
+                "kind": "missing_tool_usage_dimension",
+                "advisory": "Skill called MCP tools but the rubric has no dimension name suggesting tool-usage coverage (matched against keywords: ['tool usage', 'tool use', 'tool work', 'tool call', 'argument quality', 'argument-quality', 'response interpretation', 'tool selection', 'mcp tool', 'fixture']). The judge will grade other dimensions but won't score tool work explicitly. Consider adding a tool-usage dimension or renaming an existing one."
+              }
+            ]
+          },
+          "validators": {
+            "passed": true,
+            "results": [
+              {
+                "name": "test_id_references_resolve",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_log_append_only",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_entries_deleted",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_research_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tool_allowlist",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_gedcomx_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_h001_not_ruled_out_when_adding_identity_hypotheses",
+                "passed": true,
+                "error": "skipped: not a c_002 scenario"
+              },
+              {
+                "name": "test_h001_status_unchanged_when_review",
+                "passed": true,
+                "error": "skipped: not an h_001 scenario"
+              },
+              {
+                "name": "test_hypotheses_assertion_refs_resolve",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_hypotheses_no_deletions",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_new_hypotheses_have_claim",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_new_hypothesis_added_for_c002",
+                "passed": true,
+                "error": "skipped: not a c_002 scenario"
+              },
+              {
+                "name": "test_ruled_out_requires_reason",
+                "passed": true,
+                "error": null
+              }
+            ]
+          },
+          "judge": {
+            "skipped": false,
+            "dimensions": [
+              {
+                "source": "base",
+                "name": "Correctness",
+                "score": 3,
+                "rationale": "The hypothesis was created with accurate details: claim names Margaret O'Brien of County Cork as Patrick's mother; correctly identified the user-submitted FamilySearch tree as a compiled source (lead, not evidence); supporting_assertion_ids correctly left empty since no original-record assertions exist yet; status set to 'active' (appropriate for unverified lead); related to q_001 (parentage question). The file was successfully written and validated. No fabricated material or unsupported claims."
+              },
+              {
+                "source": "base",
+                "name": "Completeness",
+                "score": 3,
+                "rationale": "The skill fully addressed the user's request: created a hypothesis tracking the Margaret O'Brien mother claim; explicitly flagged the compiled-source origin and stated the need for independent verification against original records; populated all required fields (claim, status, supporting/contradicting assertions, related question); provided concrete research pathways for verification and refutation. Nothing requested was omitted."
+              },
+              {
+                "source": "base",
+                "name": "Tool Arguments",
+                "score": 3,
+                "rationale": "Both MCP calls matched expectations. The mcp__genealogy__research_append call correctly appended a hypothesis entry with projectPath, section='hypotheses', op='append', and a complete entry object matching schema (claim, status, assertion arrays, ruled_out/reason, notes, related_question_ids). The mcp__genealogy__validate_research_schema call correctly passed projectPath. Both calls succeeded (matched.kind='live') with valid responses."
+              },
+              {
+                "source": "rubric",
+                "name": "Claim clarity",
+                "score": 3,
+                "rationale": "The hypothesis claim is highly specific and testable: 'Patrick Flynn's mother was Margaret O'Brien from County Cork, Ireland.' It names the specific person (Margaret O'Brien), the specific relationship (mother), and includes geographic detail (County Cork) and implicit temporal context (Patrick born ~1845). A follow-up search can directly test this against original Irish records or naturalization/census documents. Not vague."
+              },
+              {
+                "source": "rubric",
+                "name": "Evidence linkage",
+                "score": 3,
+                "rationale": "Supporting and contradicting assertion IDs are both empty arrays, which is correct since no assertions in research.json yet address Patrick's mother. The hypothesis is properly linked via related_question_ids to q_001 ('Who were the parents?'), a direct and appropriate connection. The notes correctly explain why no assertions are linked and outline the types of evidence (baptismal records, naturalization papers, etc.) that would bear on the hypothesis."
+              },
+              {
+                "source": "rubric",
+                "name": "Status transitions",
+                "score": 3,
+                "rationale": "Status was correctly set to 'active' (not 'supported' or 'ruled_out'), which aligns with research-schema-spec.md \u00a75.9 guidance. The hypothesis is unverified; no direct evidence exists; no affirmative refutation exists. The ruled_out field is false and ruled_out_reason is null, consistent with an active lead. The transition is justified: this is a compiled-source lead requiring investigation, not yet ready for support or dismissal."
+              }
+            ],
+            "judge_cost_usd": 0.009268,
+            "duration_ms": 9190.953354000158,
+            "error": null,
+            "input_tokens": 5113,
+            "cached_input_tokens": 0,
+            "output_tokens": 831
+          },
+          "started_at": 1782772307.4280713,
+          "ended_at": 1782772364.9463456
+        }
+      ]
+    },
+    {
+      "test_id": "ut_hypothesis_tracking_008",
+      "test_type": "positive",
+      "expected_outcome": "pass",
+      "scenario": "flynn-competing-fathers",
+      "mcp_fixtures": [
+        "validate-research-schema"
+      ],
+      "outcome": "pass",
+      "flaky": false,
+      "outcome_summary": {
+        "per_run_outcomes": [
+          "pass"
+        ],
+        "aggregated_dimensions": [
+          {
+            "source": "base",
+            "name": "Correctness",
+            "score": 3,
+            "rationale": "The skill correctly created h_003 with accurate claim ('Patrick Flynn's father was James Flynn of Carbon County, Pennsylvania'), correct status (active), appropriate empty arrays for supporting/contradicting assertions (no evidence gathered yet), and correct related_question_ids=['q_001']. The claim is factually grounded in the user's description of the reference found. Tool calls succeeded with no fixture_not_found errors. Schema validation passed."
+          },
+          {
+            "source": "base",
+            "name": "Completeness",
+            "score": 3,
+            "rationale": "The skill fully addressed the user's request to add James Flynn as a third father candidate. It created the new hypothesis with all required fields, did not modify existing h_001 or h_002 (respecting scope rules), provided contextual analysis of the three competing candidates in a summary table, flagged the chronological impossibility in h_002 without inappropriately modifying it, and offered clear next-step research guidance for h_003. All request elements were covered."
+          },
+          {
+            "source": "base",
+            "name": "Tool Arguments",
+            "score": 3,
+            "rationale": "Both MCP tool calls used correct arguments. The mcp__genealogy__research_append call passed projectPath, section='hypotheses', op='append', and a well-formed entry object with the required fields (claim, status, supporting_assertion_ids, contradicting_assertion_ids, ruled_out, ruled_out_reason, notes, related_question_ids). The mcp__genealogy__validate_research_schema call correctly used only projectPath. Both calls matched.kind='live' with ok=true responses and no fixture_not_found errors."
+          },
+          {
+            "source": "rubric",
+            "name": "Claim clarity",
+            "score": 3,
+            "rationale": "The claim 'Patrick Flynn's father was James Flynn of Carbon County, Pennsylvania' is highly specific and testable. It names both persons (Patrick Flynn and James Flynn), specifies the relationship (father-son parentage), and includes precise place and time detail (Carbon County, Pennsylvania, 1840s). This claim can be directly tested through census, vital, church, and probate searches that would confirm or refute it."
+          },
+          {
+            "source": "rubric",
+            "name": "Evidence linkage",
+            "score": 3,
+            "rationale": "Evidence linkage is correctly implemented. The supporting_assertion_ids and contradicting_assertion_ids are both empty arrays, which is correct because no assertions about James Flynn exist in the scenario yet\u2014only a secondary reference was provided. The related_question_ids=['q_001'] is properly linked because all three father candidates (h_001, h_002, h_003) bear directly on the same research question about Patrick's parents. No tangential assertions are included."
+          },
+          {
+            "source": "rubric",
+            "name": "Status transitions",
+            "score": 3,
+            "rationale": "The status transition is correct per research-schema-spec.md \u00a75.9 rules. h_003 is marked as 'active' because it is a new lead from a secondary reference with no original evidence yet gathered. The hypothesis should not be 'supported' (no direct evidence) or 'ruled_out' (no refuting evidence exists yet). Status is appropriately conservative and matches the input state where this is the first mention of James Flynn. ruled_out is correctly set to false with null ruled_out_reason."
+          }
+        ]
+      },
+      "totals": {
+        "duration_ms": 64292.76405199926,
+        "duration_api_ms": 62844.0,
+        "judge_duration_ms": 9595.032833000005,
+        "wall_clock_ms": 73949.214220047,
+        "num_turns": 12,
+        "input_tokens": 18,
+        "cached_input_tokens": 197753,
+        "output_tokens": 2514,
+        "judge_input_tokens": 4996,
+        "judge_cached_input_tokens": 0,
+        "judge_output_tokens": 882,
+        "skill_cost_usd": 0.20018565,
+        "judge_cost_usd": 0.009406,
+        "total_cost_usd": 0.20959165
+      },
+      "runs": [
+        {
+          "run_index": 0,
+          "run_id": "run_ut_hypothesis_tracking_008_2026-06-29_22-28-20_0",
+          "outcome": "pass",
+          "aborted_reason": null,
+          "duration_ms": 64292.76405199926,
+          "duration_api_ms": 62844.0,
+          "num_turns": 12,
+          "skill_attempts": 1,
+          "input_tokens": 18,
+          "cached_input_tokens": 197753,
+          "output_tokens": 2514,
+          "skill_cost_usd": 0.20018565,
+          "output": {
+            "text_response": "Good \u2014 I've read the GPS guidance and the project file. Here's what I can see:\n\n- **h_001** \u2014 Thomas Flynn, Schuylkill County \u2192 `supported`\n- **h_002** \u2014 Thomas Flynn, Luzerne County \u2192 `active` *(note: a_016 documents this candidate died 15 September 1840 \u2014 5 years before Patrick's ~1845 birth; I'll flag this but won't touch it per scope rules)*\n\nNow I'll add James Flynn of Carbon County as **h_003**. Since this comes from \"a reference,\" it's a lead from a compiled or secondary source \u2014 the hypothesis starts `active` and needs targeted original-record research.Written successfully as **h_003**. Now running the mandatory schema validation.Both files pass clean. Here's the full hypothesis picture now:\n\n---\n\n**Hypothesis: h_003 \u2014 Patrick Flynn's father was James Flynn of Carbon County, Pennsylvania**\nStatus: **ACTIVE**\n\nSupporting evidence (0): *(none yet \u2014 lead only)*\nContradicting evidence (0): *(none yet)*\n\n---\n\n**All three competing candidates at a glance:**\n\n| ID | Candidate | Status | Supporting | Contradicting |\n|---|---|---|---|---|\n| h_001 | Thomas Flynn, Schuylkill County, PA | **SUPPORTED** | a_004, a_010, a_013 | \u2014 |\n| h_002 | Thomas Flynn, Luzerne County, PA | **ACTIVE** | a_014 | \u2014 |\n| h_003 | James Flynn, Carbon County, PA | **ACTIVE** | \u2014 | \u2014 |\n\n---\n\n**A note on h_002 (not changing it \u2014 flagging for your awareness):**\nThe project already has assertion **a_016** documenting that the Luzerne County Thomas Flynn died 15 September 1840 \u2014 five years before Patrick's estimated ~1845 birth. That's a chronological impossibility (a man cannot father a child after his death). h_002's notes acknowledge this but haven't acted on it. When you're ready, you can ask me to rule out h_002 and I'll update its status with the required `ruled_out_reason`.\n\n**Next steps for h_003:**\n- Search the **1850 census for Carbon County, PA** for a James Flynn household containing a son named Patrick of matching age\n- Check **Carbon County church records and probate** for the James Flynn family\n- Design a refutation search too \u2014 e.g., if a James Flynn probate or 1850 household exists *without* a Patrick, that's grounds to rule this candidate out\n- Carbon County adjoins Schuylkill County, so geographic proximity is plausible \u2014 worth pursuing",
+            "activated": true,
+            "skills_invoked": [
+              "hypothesis-tracking",
+              "validate-schema"
+            ],
+            "tool_calls": [
+              {
+                "tool": "mcp__genealogy__research_append",
+                "args": {
+                  "projectPath": "/tmp/eval-ut_hypothesis_tracking_008-0-0-j8w92kz9",
+                  "section": "hypotheses",
+                  "op": "append",
+                  "entry": {
+                    "claim": "Patrick Flynn's father was James Flynn of Carbon County, Pennsylvania",
+                    "status": "active",
+                    "supporting_assertion_ids": [],
+                    "contradicting_assertion_ids": [],
+                    "ruled_out": false,
+                    "ruled_out_reason": null,
+                    "notes": "Lead from a secondary reference \u2014 a James Flynn living in Carbon County, PA in the 1840s had a son named Patrick about the right age. No original records have yet been consulted to confirm or refute this candidate. Carbon County adjoins Schuylkill County, making geographic proximity plausible. Targeted research needed: search 1850 census for James Flynn in Carbon County, look for a Patrick Flynn in his household, and check any available vital, probate, or church records for the family. Design searches to refute as well as confirm \u2014 e.g., if a James Flynn Carbon County probate lists all children and Patrick is absent, this candidate can be ruled out.",
+                    "related_question_ids": [
+                      "q_001"
+                    ]
+                  }
+                },
+                "expected_args": null,
+                "matched": {
+                  "kind": "live",
+                  "index": null
+                },
+                "response_fixture": "live:research_append"
+              },
+              {
+                "tool": "mcp__genealogy__validate_research_schema",
+                "args": {
+                  "projectPath": "/tmp/eval-ut_hypothesis_tracking_008-0-0-j8w92kz9"
+                },
+                "expected_args": null,
+                "matched": {
+                  "kind": "live",
+                  "index": null
+                },
+                "response_fixture": "live:validate_research_schema"
+              }
+            ],
+            "files_created": [],
+            "file_changes": {
+              "research.json": {
+                "sections_modified": [
+                  "hypotheses"
+                ],
+                "diff": {
+                  "hypotheses": {
+                    "added": [
+                      {
+                        "id": "h_003",
+                        "claim": "Patrick Flynn's father was James Flynn of Carbon County, Pennsylvania",
+                        "status": "active",
+                        "supporting_assertion_ids": [],
+                        "contradicting_assertion_ids": [],
+                        "ruled_out": false,
+                        "ruled_out_reason": null,
+                        "notes": "Lead from a secondary reference \u2014 a James Flynn living in Carbon County, PA in the 1840s had a son named Patrick about the right age. No original records have yet been consulted to confirm or refute this candidate. Carbon County adjoins Schuylkill County, making geographic proximity plausible. Targeted research needed: search 1850 census for James Flynn in Carbon County, look for a Patrick Flynn in his household, and check any available vital, probate, or church records for the family. Design searches to refute as well as confirm \u2014 e.g., if a James Flynn Carbon County probate lists all children and Patrick is absent, this candidate can be ruled out.",
+                        "related_question_ids": [
+                          "q_001"
+                        ]
+                      }
+                    ],
+                    "modified": [],
+                    "deleted": []
+                  }
+                }
+              }
+            },
+            "warnings": [
+              {
+                "kind": "missing_tool_usage_dimension",
+                "advisory": "Skill called MCP tools but the rubric has no dimension name suggesting tool-usage coverage (matched against keywords: ['tool usage', 'tool use', 'tool work', 'tool call', 'argument quality', 'argument-quality', 'response interpretation', 'tool selection', 'mcp tool', 'fixture']). The judge will grade other dimensions but won't score tool work explicitly. Consider adding a tool-usage dimension or renaming an existing one."
+              }
+            ]
+          },
+          "validators": {
+            "passed": true,
+            "results": [
+              {
+                "name": "test_id_references_resolve",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_log_append_only",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_entries_deleted",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_research_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tool_allowlist",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_gedcomx_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_h001_not_ruled_out_when_adding_identity_hypotheses",
+                "passed": true,
+                "error": "skipped: not a c_002 scenario"
+              },
+              {
+                "name": "test_h001_status_unchanged_when_review",
+                "passed": true,
+                "error": "skipped: not an h_001 scenario"
+              },
+              {
+                "name": "test_hypotheses_assertion_refs_resolve",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_hypotheses_no_deletions",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_new_hypotheses_have_claim",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_new_hypothesis_added_for_c002",
+                "passed": true,
+                "error": "skipped: not a c_002 scenario"
+              },
+              {
+                "name": "test_ruled_out_requires_reason",
+                "passed": true,
+                "error": null
+              }
+            ]
+          },
+          "judge": {
+            "skipped": false,
+            "dimensions": [
+              {
+                "source": "base",
+                "name": "Correctness",
+                "score": 3,
+                "rationale": "The skill correctly created h_003 with accurate claim ('Patrick Flynn's father was James Flynn of Carbon County, Pennsylvania'), correct status (active), appropriate empty arrays for supporting/contradicting assertions (no evidence gathered yet), and correct related_question_ids=['q_001']. The claim is factually grounded in the user's description of the reference found. Tool calls succeeded with no fixture_not_found errors. Schema validation passed."
+              },
+              {
+                "source": "base",
+                "name": "Completeness",
+                "score": 3,
+                "rationale": "The skill fully addressed the user's request to add James Flynn as a third father candidate. It created the new hypothesis with all required fields, did not modify existing h_001 or h_002 (respecting scope rules), provided contextual analysis of the three competing candidates in a summary table, flagged the chronological impossibility in h_002 without inappropriately modifying it, and offered clear next-step research guidance for h_003. All request elements were covered."
+              },
+              {
+                "source": "base",
+                "name": "Tool Arguments",
+                "score": 3,
+                "rationale": "Both MCP tool calls used correct arguments. The mcp__genealogy__research_append call passed projectPath, section='hypotheses', op='append', and a well-formed entry object with the required fields (claim, status, supporting_assertion_ids, contradicting_assertion_ids, ruled_out, ruled_out_reason, notes, related_question_ids). The mcp__genealogy__validate_research_schema call correctly used only projectPath. Both calls matched.kind='live' with ok=true responses and no fixture_not_found errors."
+              },
+              {
+                "source": "rubric",
+                "name": "Claim clarity",
+                "score": 3,
+                "rationale": "The claim 'Patrick Flynn's father was James Flynn of Carbon County, Pennsylvania' is highly specific and testable. It names both persons (Patrick Flynn and James Flynn), specifies the relationship (father-son parentage), and includes precise place and time detail (Carbon County, Pennsylvania, 1840s). This claim can be directly tested through census, vital, church, and probate searches that would confirm or refute it."
+              },
+              {
+                "source": "rubric",
+                "name": "Evidence linkage",
+                "score": 3,
+                "rationale": "Evidence linkage is correctly implemented. The supporting_assertion_ids and contradicting_assertion_ids are both empty arrays, which is correct because no assertions about James Flynn exist in the scenario yet\u2014only a secondary reference was provided. The related_question_ids=['q_001'] is properly linked because all three father candidates (h_001, h_002, h_003) bear directly on the same research question about Patrick's parents. No tangential assertions are included."
+              },
+              {
+                "source": "rubric",
+                "name": "Status transitions",
+                "score": 3,
+                "rationale": "The status transition is correct per research-schema-spec.md \u00a75.9 rules. h_003 is marked as 'active' because it is a new lead from a secondary reference with no original evidence yet gathered. The hypothesis should not be 'supported' (no direct evidence) or 'ruled_out' (no refuting evidence exists yet). Status is appropriately conservative and matches the input state where this is the first mention of James Flynn. ruled_out is correctly set to false with null ruled_out_reason."
+              }
+            ],
+            "judge_cost_usd": 0.009406,
+            "duration_ms": 9595.032833000005,
+            "error": null,
+            "input_tokens": 4996,
+            "cached_input_tokens": 0,
+            "output_tokens": 882
+          },
+          "started_at": 1782772311.395002,
+          "ended_at": 1782772385.344216
+        }
+      ]
+    },
+    {
+      "test_id": "ut_hypothesis_tracking_009",
+      "test_type": "positive",
+      "expected_outcome": "pass",
+      "scenario": "flynn-young-candidate",
+      "mcp_fixtures": [
+        "validate-research-schema"
+      ],
+      "outcome": "pass",
+      "flaky": false,
+      "outcome_summary": {
+        "per_run_outcomes": [
+          "pass"
+        ],
+        "aggregated_dimensions": [
+          {
+            "source": "base",
+            "name": "Correctness",
+            "score": 3,
+            "rationale": "Claude correctly read the input state, performed the age arithmetic (1835 birth \u2192 ~10 years old when Patrick born ~1845), identified this as a biological impossibility, and transitioned h_001 to ruled_out with the baptism assertion (a_006) correctly linked as contradicting evidence. The MCP call and file state both confirm the update succeeded with a comprehensive, accurate ruled_out_reason."
+          },
+          {
+            "source": "base",
+            "name": "Completeness",
+            "score": 3,
+            "rationale": "Claude fully addressed the user's request to check whether the baptism record changes the hypothesis. The skill identified the contradiction, performed necessary arithmetic, updated the hypothesis status, linked the contradicting assertion, populated the ruled_out_reason, and validated the result. No required elements were omitted."
+          },
+          {
+            "source": "base",
+            "name": "Tool Arguments",
+            "score": 3,
+            "rationale": "Both MCP tool calls passed correct arguments. The research_append call used valid section ('hypotheses'), operation ('update'), entryId ('h_001'), and fields with proper schema structure (status, contradicting_assertion_ids, ruled_out, ruled_out_reason). The validate_research_schema call correctly identified the project path. No fixture_not_found errors occurred; both calls matched the live endpoints successfully."
+          },
+          {
+            "source": "rubric",
+            "name": "Claim clarity",
+            "score": 3,
+            "rationale": "The hypothesis is stated with specific, testable precision: 'Patrick Flynn's father was Thomas Flynn of Schuylkill County, Pennsylvania.' It names both individuals, specifies the relationship (father), and includes geographic/temporal context sufficient for follow-up searches. The claim is concrete and falsifiable."
+          },
+          {
+            "source": "rubric",
+            "name": "Evidence linkage",
+            "score": 3,
+            "rationale": "The contradicting assertion (a_006 \u2014 baptism record establishing Thomas's birth in 1835) is directly and relevantly linked. It establishes the fact that contradicts the hypothesis: a 10-year-old cannot be a biological father. The supporting assertion (a_003 \u2014 census co-enumeration) is retained but contextualized correctly as consistent with sibling or uncle relationships rather than fatherhood. No tangential assertions are linked."
+          },
+          {
+            "source": "rubric",
+            "name": "Status transitions",
+            "score": 3,
+            "rationale": "The transition from active to ruled_out is justified by affirmative refutation: the baptism record provides direct primary evidence (contemporaneous parish register) establishing Thomas's birth date at 1835, creating a biological impossibility (age 10 at Patrick's birth). This meets the research-schema-spec.md criterion for ruling out. The ruled_out_reason is fully populated, explaining the contradiction and the confidence in the person-evidence link (pe_005, 0.92) that confirms the baptism record applies to this specific Thomas Flynn."
+          }
+        ]
+      },
+      "totals": {
+        "duration_ms": 95226.07960300047,
+        "duration_api_ms": 91837.0,
+        "judge_duration_ms": 8883.499173998644,
+        "wall_clock_ms": 104758.20994377136,
+        "num_turns": 9,
+        "input_tokens": 15,
+        "cached_input_tokens": 97480,
+        "output_tokens": 4651,
+        "judge_input_tokens": 5633,
+        "judge_cached_input_tokens": 0,
+        "judge_output_tokens": 782,
+        "skill_cost_usd": 0.1868025,
+        "judge_cost_usd": 0.009543,
+        "total_cost_usd": 0.1963455
+      },
+      "runs": [
+        {
+          "run_index": 0,
+          "run_id": "run_ut_hypothesis_tracking_009_2026-06-29_22-28-20_0",
+          "outcome": "pass",
+          "aborted_reason": null,
+          "duration_ms": 95226.07960300047,
+          "duration_api_ms": 91837.0,
+          "num_turns": 9,
+          "skill_attempts": 1,
+          "input_tokens": 15,
+          "cached_input_tokens": 97480,
+          "output_tokens": 4651,
+          "skill_cost_usd": 0.1868025,
+          "output": {
+            "text_response": "I'll start by reading the guidance document and project files to understand the current state of the hypothesis.Now I have a full picture. Let me load the tools I need before making any changes.The picture is clear and I need to act on it immediately. Here's the critical arithmetic:\n\n- **Patrick Flynn** born ~1845 (a_002)\n- **Thomas Flynn** baptized **12 March 1835** (a_006, primary information, direct evidence from a contemporaneous parish register)\n- **pe_005** links that baptism record to I2 \u2014 the 1850 census head of household \u2014 with **match_score 0.92**, which is \u2265 0.80: *confident*.\n\nThat makes Thomas approximately **10 years old** when Patrick was born. This is a **biological impossibility** for fatherhood. Per GPS reasoning principles, this is a fundamental assumption \u2014 a person cannot perform actions inconsistent with their biological age. I must rule out h_001 now and link a_006 as contradicting evidence.Written successfully. Now running the mandatory schema validation.Both files are valid. Here's the full picture of what changed and why.\n\n---\n\n## Hypothesis h_001 \u2014 Ruled Out\n\n**Claim:** Patrick Flynn's father was Thomas Flynn of Schuylkill County, Pennsylvania\n**Status: RULED OUT** *(was: active)*\n\n---\n\n### What the baptism record revealed\n\nThe Dungarvan baptism record (a_006) is **primary information, direct evidence** \u2014 a contemporaneous entry in an original parish register. It establishes Thomas Flynn's birth as **12 March 1835**. Person-evidence entry pe_005 links this record to I2 (the 1850 census head of household) at **match_score 0.92** \u2014 a confident identification. That link is not in dispute.\n\nThe arithmetic is decisive:\n\n| Person | Birth year | Source | Quality |\n|---|---|---|---|\n| Patrick Flynn | ~1845 | 1850 census (a_002) | Estimated |\n| Thomas Flynn | **1835** | Dungarvan baptism (a_006) | **Primary / direct** |\n\nThomas would have been **~10 years old** when Patrick was born. Fatherhood at age 10 is a biological impossibility \u2014 a fundamental assumption under GPS reasoning that requires no further evidence to apply.\n\n---\n\n### Evidence record\n\n**Contradicting evidence added (1):**\n- \u2717 **a_006** \u2014 Baptism record establishes Thomas born 1835; ~10 years old at Patrick's birth (primary, direct)\n\n**Supporting evidence retained (1):**\n- ~~a_003~~ \u2014 1850 census co-enumeration still on record; the relationship it implies (if any) is now more likely a sibling, uncle, or other relative \u2014 *not* father-son.\n\n**Ruled-out reason:** Biological impossibility. Thomas's birth year is established by primary, direct evidence; the confident person-evidence link (pe_005, 0.92) is not in dispute.\n\n---\n\n### What this means for the research\n\nThis ruling **opens the question back up** significantly. The 1850 census co-enumeration (a_003) suggested a *family* relationship between Patrick and Thomas \u2014 that evidence hasn't been discredited, it's just not consistent with father-son. Some possibilities now worth considering:\n\n1. **Thomas is Patrick's older brother** \u2014 both from County Waterford, Thomas ~10 years older, emigrated together or reunited in Schuylkill County.\n2. **Thomas is Patrick's uncle or cousin** \u2014 common in Irish immigrant communities.\n3. **A different Thomas Flynn** \u2014 if the Dungarvan baptism is actually a *different* individual, pe_005's 0.92 match score would need re-examination. That would be a reason to revisit the identification itself.\n4. **Patrick's parents remain in Ireland** \u2014 Thomas may have emigrated first and brought young Patrick with him.\n\n**Suggested next steps:**\n- Use **question-selection** to add a refined question \u2014 e.g., \"What is the relationship between Patrick Flynn and Thomas Flynn of Schuylkill County?\" or \"Who are the parents of Patrick Flynn, born ~1845 in Ireland?\"\n- Consider searching for Thomas Flynn's parents (Michael Flynn and Bridget Morrissey, named in the baptism record) \u2014 if Patrick shares those parents, he is Thomas's brother.\n- Search for Patrick Flynn in Irish parish registers for County Waterford, ca. 1843\u20131847.",
+            "activated": true,
+            "skills_invoked": [
+              "hypothesis-tracking"
+            ],
+            "tool_calls": [
+              {
+                "tool": "mcp__genealogy__research_append",
+                "args": {
+                  "projectPath": "/tmp/eval-ut_hypothesis_tracking_009-0-0-d02ltvg9",
+                  "section": "hypotheses",
+                  "op": "update",
+                  "entryId": "h_001",
+                  "fields": {
+                    "status": "ruled_out",
+                    "contradicting_assertion_ids": [
+                      "a_006"
+                    ],
+                    "ruled_out": true,
+                    "ruled_out_reason": "Thomas Flynn's baptism record (a_006) establishes his birth as 12 March 1835 in Dungarvan, County Waterford \u2014 primary information, direct evidence from a contemporaneous parish register. Patrick Flynn was born approximately 1845, placing Thomas at roughly 10 years of age at Patrick's birth \u2014 a biological impossibility for fatherhood. The identification of this baptisee with the 1850 Schuylkill County census head of household is rated confident (pe_005, match_score 0.92), so the impossibility is not in dispute. The co-enumeration evidence (a_003) that originally supported the hypothesis is better explained by a sibling, uncle, or other relative relationship than a father-child one."
+                  }
+                },
+                "expected_args": null,
+                "matched": {
+                  "kind": "live",
+                  "index": null
+                },
+                "response_fixture": "live:research_append"
+              },
+              {
+                "tool": "mcp__genealogy__validate_research_schema",
+                "args": {
+                  "projectPath": "/tmp/eval-ut_hypothesis_tracking_009-0-0-d02ltvg9"
+                },
+                "expected_args": null,
+                "matched": {
+                  "kind": "live",
+                  "index": null
+                },
+                "response_fixture": "live:validate_research_schema"
+              }
+            ],
+            "files_created": [],
+            "file_changes": {
+              "research.json": {
+                "sections_modified": [
+                  "hypotheses"
+                ],
+                "diff": {
+                  "hypotheses": {
+                    "added": [],
+                    "modified": [
+                      {
+                        "id": "h_001",
+                        "changed_fields": {
+                          "ruled_out": {
+                            "before": false,
+                            "after": true
+                          },
+                          "status": {
+                            "before": "active",
+                            "after": "ruled_out"
+                          },
+                          "ruled_out_reason": {
+                            "before": null,
+                            "after": "Thomas Flynn's baptism record (a_006) establishes his birth as 12 March 1835 in Dungarvan, County Waterford \u2014 primary information, direct evidence from a contemporaneous parish register. Patrick Flynn was born approximately 1845, placing Thomas at roughly 10 years of age at Patrick's birth \u2014 a biological impossibility for fatherhood. The identification of this baptisee with the 1850 Schuylkill County census head of household is rated confident (pe_005, match_score 0.92), so the impossibility is not in dispute. The co-enumeration evidence (a_003) that originally supported the hypothesis is better explained by a sibling, uncle, or other relative relationship than a father-child one."
+                          },
+                          "contradicting_assertion_ids": {
+                            "before": [],
+                            "after": [
+                              "a_006"
+                            ]
+                          }
+                        }
+                      }
+                    ],
+                    "deleted": []
+                  }
+                }
+              }
+            },
+            "warnings": [
+              {
+                "kind": "missing_tool_usage_dimension",
+                "advisory": "Skill called MCP tools but the rubric has no dimension name suggesting tool-usage coverage (matched against keywords: ['tool usage', 'tool use', 'tool work', 'tool call', 'argument quality', 'argument-quality', 'response interpretation', 'tool selection', 'mcp tool', 'fixture']). The judge will grade other dimensions but won't score tool work explicitly. Consider adding a tool-usage dimension or renaming an existing one."
+              }
+            ]
+          },
+          "validators": {
+            "passed": true,
+            "results": [
+              {
+                "name": "test_id_references_resolve",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_log_append_only",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_entries_deleted",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_research_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tool_allowlist",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_gedcomx_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_h001_not_ruled_out_when_adding_identity_hypotheses",
+                "passed": true,
+                "error": "skipped: not a c_002 scenario"
+              },
+              {
+                "name": "test_h001_status_unchanged_when_review",
+                "passed": true,
+                "error": "skipped: not an h_001 scenario"
+              },
+              {
+                "name": "test_hypotheses_assertion_refs_resolve",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_hypotheses_no_deletions",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_new_hypotheses_have_claim",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_new_hypothesis_added_for_c002",
+                "passed": true,
+                "error": "skipped: not a c_002 scenario"
+              },
+              {
+                "name": "test_ruled_out_requires_reason",
+                "passed": true,
+                "error": null
+              }
+            ]
+          },
+          "judge": {
+            "skipped": false,
+            "dimensions": [
+              {
+                "source": "base",
+                "name": "Correctness",
+                "score": 3,
+                "rationale": "Claude correctly read the input state, performed the age arithmetic (1835 birth \u2192 ~10 years old when Patrick born ~1845), identified this as a biological impossibility, and transitioned h_001 to ruled_out with the baptism assertion (a_006) correctly linked as contradicting evidence. The MCP call and file state both confirm the update succeeded with a comprehensive, accurate ruled_out_reason."
+              },
+              {
+                "source": "base",
+                "name": "Completeness",
+                "score": 3,
+                "rationale": "Claude fully addressed the user's request to check whether the baptism record changes the hypothesis. The skill identified the contradiction, performed necessary arithmetic, updated the hypothesis status, linked the contradicting assertion, populated the ruled_out_reason, and validated the result. No required elements were omitted."
+              },
+              {
+                "source": "base",
+                "name": "Tool Arguments",
+                "score": 3,
+                "rationale": "Both MCP tool calls passed correct arguments. The research_append call used valid section ('hypotheses'), operation ('update'), entryId ('h_001'), and fields with proper schema structure (status, contradicting_assertion_ids, ruled_out, ruled_out_reason). The validate_research_schema call correctly identified the project path. No fixture_not_found errors occurred; both calls matched the live endpoints successfully."
+              },
+              {
+                "source": "rubric",
+                "name": "Claim clarity",
+                "score": 3,
+                "rationale": "The hypothesis is stated with specific, testable precision: 'Patrick Flynn's father was Thomas Flynn of Schuylkill County, Pennsylvania.' It names both individuals, specifies the relationship (father), and includes geographic/temporal context sufficient for follow-up searches. The claim is concrete and falsifiable."
+              },
+              {
+                "source": "rubric",
+                "name": "Evidence linkage",
+                "score": 3,
+                "rationale": "The contradicting assertion (a_006 \u2014 baptism record establishing Thomas's birth in 1835) is directly and relevantly linked. It establishes the fact that contradicts the hypothesis: a 10-year-old cannot be a biological father. The supporting assertion (a_003 \u2014 census co-enumeration) is retained but contextualized correctly as consistent with sibling or uncle relationships rather than fatherhood. No tangential assertions are linked."
+              },
+              {
+                "source": "rubric",
+                "name": "Status transitions",
+                "score": 3,
+                "rationale": "The transition from active to ruled_out is justified by affirmative refutation: the baptism record provides direct primary evidence (contemporaneous parish register) establishing Thomas's birth date at 1835, creating a biological impossibility (age 10 at Patrick's birth). This meets the research-schema-spec.md criterion for ruling out. The ruled_out_reason is fully populated, explaining the contradiction and the confidence in the person-evidence link (pe_005, 0.92) that confirms the baptism record applies to this specific Thomas Flynn."
+              }
+            ],
+            "judge_cost_usd": 0.009543,
+            "duration_ms": 8883.499173998644,
+            "error": null,
+            "input_tokens": 5633,
+            "cached_input_tokens": 0,
+            "output_tokens": 782
+          },
+          "started_at": 1782772100.6247413,
+          "ended_at": 1782772205.3829513
+        }
+      ]
+    },
+    {
+      "test_id": "ut_hypothesis_tracking_010",
+      "test_type": "positive",
+      "expected_outcome": "pass",
+      "scenario": "flynn-competing-fathers",
+      "mcp_fixtures": [
+        "validate-research-schema"
+      ],
+      "outcome": "pass",
+      "flaky": false,
+      "outcome_summary": {
+        "per_run_outcomes": [
+          "pass"
+        ],
+        "aggregated_dimensions": [
+          {
+            "source": "base",
+            "name": "Correctness",
+            "score": 3,
+            "rationale": "Claude correctly interpreted the user's instruction that the birth year discrepancy 'doesn't disprove anything' and properly maintained h_001's 'supported' status rather than downgrading it. The linking of a_017 as contradicting evidence is factually correct. The rationale provided (census age rounding norms) is sound and well-documented. The observation about h_002 being overdue for ruling out is accurate but appropriately not acted upon since the user didn't request it. No fabricated material or unsupported claims."
+          },
+          {
+            "source": "base",
+            "name": "Completeness",
+            "score": 3,
+            "rationale": "Claude fully addressed the user's request: linked a_017 to h_001's contradicting_assertion_ids, preserved the 'supported' status, provided clear documentation of the discrepancy and its genealogical context in the notes field, and validated the schema. The user's explicit scope was only h_001, which was completely handled. The additional observation about h_002 was appropriately flagged as outside the immediate request without being acted upon."
+          },
+          {
+            "source": "base",
+            "name": "Tool Arguments",
+            "score": 3,
+            "rationale": "Both MCP calls matched expected behavior. The research_append call correctly used operation 'update', targeted h_001, and properly constructed the contradicting_assertion_ids array with a_017 and the notes field with detailed genealogical reasoning. The validate_research_schema call was appropriately invoked with the correct projectPath. Both calls returned successful responses (matched.kind == 'live', validation passed). No fixture_not_found errors or critical argument mismatches."
+          },
+          {
+            "source": "rubric",
+            "name": "Claim clarity",
+            "score": 3,
+            "rationale": "The claim is clear and testable: 'Patrick Flynn's father was Thomas Flynn of Schuylkill County, Pennsylvania.' This names specific persons, the specific parent-child relationship, and includes geographic/temporal detail sufficient for follow-up searches. The evidence assessment is concrete (birth year ~1818 vs ~1823, based on specific documents: 1850 census, 1842 marriage record)."
+          },
+          {
+            "source": "rubric",
+            "name": "Evidence linkage",
+            "score": 3,
+            "rationale": "All supporting and contradicting assertions are directly relevant. a_004, a_010, and a_013 directly support the parent-child hypothesis through census co-enumeration and death certificate naming. a_017 (marriage record birth year ~1823) genuinely contradicts the prior birth year estimate (~1818) derived from census age, making it properly classified as contradicting evidence. No tangential or off-topic links. Reasoning for each link is clear and genealogically sound."
+          },
+          {
+            "source": "rubric",
+            "name": "Status transitions",
+            "score": 3,
+            "rationale": "Status correctly remained 'supported' despite adding contradicting evidence. This aligns with research-schema-spec.md \u00a75.9 rules: the contradiction (5-year birth year discrepancy) is not affirmative refutation of the parent-child claim itself, and falls within normal 19th-century census age-rounding error. Claude did not invoke 'ruled_out' inappropriately. The status transition rule (supported only with direct positive evidence and no unresolved contradictions) is satisfied\u2014the contradiction about birth year precision is minor and does not negate the three supporting assertions about the parent-child relationship."
+          }
+        ]
+      },
+      "totals": {
+        "duration_ms": 80503.9669559992,
+        "duration_api_ms": 80538.0,
+        "judge_duration_ms": 10667.810965998797,
+        "wall_clock_ms": 91234.85922813416,
+        "num_turns": 9,
+        "input_tokens": 13,
+        "cached_input_tokens": 134550,
+        "output_tokens": 3330,
+        "judge_input_tokens": 5378,
+        "judge_cached_input_tokens": 0,
+        "judge_output_tokens": 909,
+        "skill_cost_usd": 0.19389975,
+        "judge_cost_usd": 0.009923000000000001,
+        "total_cost_usd": 0.20382275
+      },
+      "runs": [
+        {
+          "run_index": 0,
+          "run_id": "run_ut_hypothesis_tracking_010_2026-06-29_22-28-20_0",
+          "outcome": "pass",
+          "aborted_reason": null,
+          "duration_ms": 80503.9669559992,
+          "duration_api_ms": 80538.0,
+          "num_turns": 9,
+          "skill_attempts": 1,
+          "input_tokens": 13,
+          "cached_input_tokens": 134550,
+          "output_tokens": 3330,
+          "skill_cost_usd": 0.19389975,
+          "output": {
+            "text_response": "Good. I have everything I need. Here's my read of the situation before writing:\n\n- **h_001** (Thomas of Schuylkill, `supported`) currently has no contradicting assertions. a_017 asserts Thomas's birth ~1823 from his self-reported age at the 1842 Philadelphia marriage \u2014 a 5-year gap from the ~1818 estimate derived from the 1850 census.\n- The gap is well within 19th-century census age-rounding norms for Irish immigrants, and you've explicitly assessed it as non-disqualifying. Per the skill rules, this does **not** trigger a status downgrade \u2014 I'll link it as contradicting evidence and leave `supported` intact.\n- I'll update the notes to document the discrepancy and its genealogical context.\n\nOne observation I'll flag in text (but will **not** act on, since you didn't ask): **h_002** (Thomas of Luzerne County) has a_016 on its record \u2014 a death record proving that Thomas Flynn died 15 September 1840, five years *before* Patrick's ~1845 birth. That's a biological impossibility, and h_002 is still `active` with no contradicting assertions linked and no `ruled_out_reason`. That hypothesis is overdue to be ruled out. Let me know if you'd like me to handle that next.\n\nNow, writing the update to h_001:Written cleanly. Now validating the full project:Clean. Here's the current state of h_001:\n\n---\n\n**Hypothesis: h_001 \u2014 Patrick Flynn's father was Thomas Flynn of Schuylkill County, Pennsylvania**\n**Status: SUPPORTED**\n\n**Supporting evidence (3):**\n| | Assertion | Fact | Classification |\n|---|---|---|---|\n| + | a_004 | 1850 census: Patrick co-enumerated in Thomas's household | Indirect / Indeterminate |\n| + | a_010 | 1860 census: Patrick again in Thomas's household | Indirect / Indeterminate |\n| + | a_013 | 1908 death certificate: \"Father: Thomas Flynn\" | Direct / Secondary |\n\n**Contradicting evidence (1):**\n| | Assertion | Fact | Classification |\n|---|---|---|---|\n| ~ | a_017 | Marriage record 1842: age 19 \u2192 birth ~1823 (vs. ~1818 from census) | Indirect / Secondary (self-report) |\n\n**Assessment of the contradiction:** The ~1823 birth year from the marriage record sits 5 years from the ~1818 estimate from the 1850 census. Self-reported ages at marriage \u2014 especially among Irish immigrants in 19th-century America \u2014 are routinely rounded or approximate. The discrepancy is a birth-year question for Thomas, entirely separate from the parent-child claim. It has been recorded faithfully per GPS evidence-integrity standards (BCG Std. 43) and does not undermine the supported status.\n\n---\n\n**Competing hypotheses:**\n- **h_002** \u2014 Thomas Flynn of Luzerne County \u2014 **ACTIVE** \u26a0\ufe0f *(flagged: a_016 proves this Thomas died September 1840, five years before Patrick's birth \u2014 a biological impossibility. Awaiting your instruction to rule it out.)*\n\n**Next steps:**\n- h_001 is still **ready for proof-conclusion** \u2014 the new contradicting assertion should be acknowledged in the narrative, but does not change the tier\n- h_002 should be ruled out \u2014 say the word and I'll update it with the chronological impossibility ruling",
+            "activated": true,
+            "skills_invoked": [
+              "hypothesis-tracking"
+            ],
+            "tool_calls": [
+              {
+                "tool": "mcp__genealogy__research_append",
+                "args": {
+                  "projectPath": "/tmp/eval-ut_hypothesis_tracking_010-0-0-ht2zsolp",
+                  "section": "hypotheses",
+                  "op": "update",
+                  "entryId": "h_001",
+                  "fields": {
+                    "contradicting_assertion_ids": [
+                      "a_017"
+                    ],
+                    "notes": "Three independent pieces of evidence support the claim: 1850 census co-enumeration (indirect), 1860 census co-enumeration (indirect \u2014 relationship inferred from household position), death certificate naming Thomas as father (direct, secondary informant). Awaiting probate records for additional confirmation.\n\nContradicting: a_017 (marriage record, Philadelphia, 1842) gives Thomas's age as 19, implying birth ~1823 \u2014 a 5-year discrepancy from the ~1818 estimate derived from the 1850 census. Self-reported ages at marriage are frequently rounded or misremembered, particularly among Irish immigrants. The discrepancy is within normal 19th-century age-rounding range and does not undermine the core parent-child claim; it bears only on Thomas's precise birth year. Status remains SUPPORTED."
+                  }
+                },
+                "expected_args": null,
+                "matched": {
+                  "kind": "live",
+                  "index": null
+                },
+                "response_fixture": "live:research_append"
+              },
+              {
+                "tool": "mcp__genealogy__validate_research_schema",
+                "args": {
+                  "projectPath": "/tmp/eval-ut_hypothesis_tracking_010-0-0-ht2zsolp"
+                },
+                "expected_args": null,
+                "matched": {
+                  "kind": "live",
+                  "index": null
+                },
+                "response_fixture": "live:validate_research_schema"
+              }
+            ],
+            "files_created": [],
+            "file_changes": {
+              "research.json": {
+                "sections_modified": [
+                  "hypotheses"
+                ],
+                "diff": {
+                  "hypotheses": {
+                    "added": [],
+                    "modified": [
+                      {
+                        "id": "h_001",
+                        "changed_fields": {
+                          "contradicting_assertion_ids": {
+                            "before": [],
+                            "after": [
+                              "a_017"
+                            ]
+                          },
+                          "notes": {
+                            "before": "Three independent pieces of evidence: 1850 census co-enumeration (indirect), 1860 census co-enumeration (indirect \u2014 relationship inferred from household position), death certificate naming Thomas as father (direct, secondary informant). Awaiting probate records for additional confirmation.",
+                            "after": "Three independent pieces of evidence support the claim: 1850 census co-enumeration (indirect), 1860 census co-enumeration (indirect \u2014 relationship inferred from household position), death certificate naming Thomas as father (direct, secondary informant). Awaiting probate records for additional confirmation.\n\nContradicting: a_017 (marriage record, Philadelphia, 1842) gives Thomas's age as 19, implying birth ~1823 \u2014 a 5-year discrepancy from the ~1818 estimate derived from the 1850 census. Self-reported ages at marriage are frequently rounded or misremembered, particularly among Irish immigrants. The discrepancy is within normal 19th-century age-rounding range and does not undermine the core parent-child claim; it bears only on Thomas's precise birth year. Status remains SUPPORTED."
+                          }
+                        }
+                      }
+                    ],
+                    "deleted": []
+                  }
+                }
+              }
+            },
+            "warnings": [
+              {
+                "kind": "missing_tool_usage_dimension",
+                "advisory": "Skill called MCP tools but the rubric has no dimension name suggesting tool-usage coverage (matched against keywords: ['tool usage', 'tool use', 'tool work', 'tool call', 'argument quality', 'argument-quality', 'response interpretation', 'tool selection', 'mcp tool', 'fixture']). The judge will grade other dimensions but won't score tool work explicitly. Consider adding a tool-usage dimension or renaming an existing one."
+              }
+            ]
+          },
+          "validators": {
+            "passed": true,
+            "results": [
+              {
+                "name": "test_id_references_resolve",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_log_append_only",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_entries_deleted",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_research_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tool_allowlist",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_gedcomx_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_h001_not_ruled_out_when_adding_identity_hypotheses",
+                "passed": true,
+                "error": "skipped: not a c_002 scenario"
+              },
+              {
+                "name": "test_h001_status_unchanged_when_review",
+                "passed": true,
+                "error": "skipped: not an h_001 scenario"
+              },
+              {
+                "name": "test_hypotheses_assertion_refs_resolve",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_hypotheses_no_deletions",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_new_hypotheses_have_claim",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_new_hypothesis_added_for_c002",
+                "passed": true,
+                "error": "skipped: not a c_002 scenario"
+              },
+              {
+                "name": "test_ruled_out_requires_reason",
+                "passed": true,
+                "error": null
+              }
+            ]
+          },
+          "judge": {
+            "skipped": false,
+            "dimensions": [
+              {
+                "source": "base",
+                "name": "Correctness",
+                "score": 3,
+                "rationale": "Claude correctly interpreted the user's instruction that the birth year discrepancy 'doesn't disprove anything' and properly maintained h_001's 'supported' status rather than downgrading it. The linking of a_017 as contradicting evidence is factually correct. The rationale provided (census age rounding norms) is sound and well-documented. The observation about h_002 being overdue for ruling out is accurate but appropriately not acted upon since the user didn't request it. No fabricated material or unsupported claims."
+              },
+              {
+                "source": "base",
+                "name": "Completeness",
+                "score": 3,
+                "rationale": "Claude fully addressed the user's request: linked a_017 to h_001's contradicting_assertion_ids, preserved the 'supported' status, provided clear documentation of the discrepancy and its genealogical context in the notes field, and validated the schema. The user's explicit scope was only h_001, which was completely handled. The additional observation about h_002 was appropriately flagged as outside the immediate request without being acted upon."
+              },
+              {
+                "source": "base",
+                "name": "Tool Arguments",
+                "score": 3,
+                "rationale": "Both MCP calls matched expected behavior. The research_append call correctly used operation 'update', targeted h_001, and properly constructed the contradicting_assertion_ids array with a_017 and the notes field with detailed genealogical reasoning. The validate_research_schema call was appropriately invoked with the correct projectPath. Both calls returned successful responses (matched.kind == 'live', validation passed). No fixture_not_found errors or critical argument mismatches."
+              },
+              {
+                "source": "rubric",
+                "name": "Claim clarity",
+                "score": 3,
+                "rationale": "The claim is clear and testable: 'Patrick Flynn's father was Thomas Flynn of Schuylkill County, Pennsylvania.' This names specific persons, the specific parent-child relationship, and includes geographic/temporal detail sufficient for follow-up searches. The evidence assessment is concrete (birth year ~1818 vs ~1823, based on specific documents: 1850 census, 1842 marriage record)."
+              },
+              {
+                "source": "rubric",
+                "name": "Evidence linkage",
+                "score": 3,
+                "rationale": "All supporting and contradicting assertions are directly relevant. a_004, a_010, and a_013 directly support the parent-child hypothesis through census co-enumeration and death certificate naming. a_017 (marriage record birth year ~1823) genuinely contradicts the prior birth year estimate (~1818) derived from census age, making it properly classified as contradicting evidence. No tangential or off-topic links. Reasoning for each link is clear and genealogically sound."
+              },
+              {
+                "source": "rubric",
+                "name": "Status transitions",
+                "score": 3,
+                "rationale": "Status correctly remained 'supported' despite adding contradicting evidence. This aligns with research-schema-spec.md \u00a75.9 rules: the contradiction (5-year birth year discrepancy) is not affirmative refutation of the parent-child claim itself, and falls within normal 19th-century census age-rounding error. Claude did not invoke 'ruled_out' inappropriately. The status transition rule (supported only with direct positive evidence and no unresolved contradictions) is satisfied\u2014the contradiction about birth year precision is minor and does not negate the three supporting assertions about the parent-child relationship."
+              }
+            ],
+            "judge_cost_usd": 0.009923000000000001,
+            "duration_ms": 10667.810965998797,
+            "error": null,
+            "input_tokens": 5378,
+            "cached_input_tokens": 0,
+            "output_tokens": 909
+          },
+          "started_at": 1782772255.1005354,
+          "ended_at": 1782772346.3353946
+        }
+      ]
+    },
+    {
+      "test_id": "ut_hypothesis_tracking_011",
+      "test_type": "positive",
+      "expected_outcome": "pass",
+      "scenario": "flynn-competing-fathers",
+      "mcp_fixtures": [
+        "validate-research-schema"
+      ],
+      "outcome": "pass",
+      "flaky": false,
+      "outcome_summary": {
+        "per_run_outcomes": [
+          "pass"
+        ],
+        "aggregated_dimensions": [
+          {
+            "source": "base",
+            "name": "Correctness",
+            "score": 3,
+            "rationale": "Claude correctly identified the chronological impossibility (death in 1840, birth ~1845), accurately cited the source evidence (a_016 from src_006 with pe_008 identification), and ruled out h_002 based on sound genealogical reasoning. All factual claims match the provided project state."
+          },
+          {
+            "source": "base",
+            "name": "Completeness",
+            "score": 3,
+            "rationale": "Claude fully addressed the user's request by refusing to mark h_002 as supported, explaining the three independent reasons why the supported threshold cannot be met, formally linking the contradicting evidence a_016, and ruling out h_002 with proper rationale. Also contextualized the impact on h_001."
+          },
+          {
+            "source": "base",
+            "name": "Tool Arguments",
+            "score": 3,
+            "rationale": "Both MCP calls executed successfully (matched.kind == 'live'). The research_append call correctly updated h_002 with proper structure: supporting_assertion_ids (a_014, a_015), contradicting_assertion_ids (a_016), status set to 'ruled_out', ruled_out: true, and detailed ruled_out_reason. The validate_research_schema call was appropriate and returned clean validation."
+          },
+          {
+            "source": "rubric",
+            "name": "Claim clarity",
+            "score": 3,
+            "rationale": "The hypothesis h_002 itself is stated clearly as a specific testable claim (Thomas Flynn of Luzerne County was Patrick Flynn's father), with sufficient place and time details that follow-up searches could test it. Claude articulated the exact reason for rejection: a chronological impossibility (death 15 September 1840 vs. birth ~1845)."
+          },
+          {
+            "source": "rubric",
+            "name": "Evidence linkage",
+            "score": 3,
+            "rationale": "Claude correctly linked a_014 and a_015 as supporting assertions (name match and residence in Luzerne County) and critically linked a_016 (death record) as contradicting evidence. Each link is directly relevant: the name and location support the identification, while the death date directly refutes the paternity claim. No tangential assertions were linked."
+          },
+          {
+            "source": "rubric",
+            "name": "Status transitions",
+            "score": 3,
+            "rationale": "Claude refused the user's request to mark h_002 as supported and instead correctly transitioned it to ruled_out, meeting the research-schema-spec.md \u00a75.9 standard: the hypothesis required affirmative refutation (death record establishing chronological impossibility), not merely lack of evidence. The ruled_out_reason field was properly populated with specific evidence (a_016, death date, confident identification pe_008)."
+          }
+        ]
+      },
+      "totals": {
+        "duration_ms": 110492.06388399944,
+        "duration_api_ms": 109654.0,
+        "judge_duration_ms": 7982.80726700068,
+        "wall_clock_ms": 118532.59062767029,
+        "num_turns": 9,
+        "input_tokens": 15,
+        "cached_input_tokens": 136567,
+        "output_tokens": 5033,
+        "judge_input_tokens": 5305,
+        "judge_cached_input_tokens": 0,
+        "judge_output_tokens": 740,
+        "skill_cost_usd": 0.22627934999999996,
+        "judge_cost_usd": 0.009004999999999999,
+        "total_cost_usd": 0.23528434999999998
+      },
+      "runs": [
+        {
+          "run_index": 0,
+          "run_id": "run_ut_hypothesis_tracking_011_2026-06-29_22-28-20_0",
+          "outcome": "pass",
+          "aborted_reason": null,
+          "duration_ms": 110492.06388399944,
+          "duration_api_ms": 109654.0,
+          "num_turns": 9,
+          "skill_attempts": 1,
+          "input_tokens": 15,
+          "cached_input_tokens": 136567,
+          "output_tokens": 5033,
+          "skill_cost_usd": 0.22627934999999996,
+          "output": {
+            "text_response": "Let me read the project files to understand the current state of h_002 before making any changes.I have a complete picture of h_002. Before I act on your request, there's a critical issue I need to flag \u2014 let me load the write tools and then walk you through what the evidence actually shows.I can't mark h_002 as supported \u2014 and I need to explain why before making any write, because the evidence in this file actually requires the opposite action.\n\n---\n\n**Here's what the record shows for h_002:**\n\nThe notes on h_002 already flag the problem, but assertion **a_016** has never been formally linked to the hypothesis. That assertion \u2014 drawn from the Luzerne County death record (src_006), linked to I3 with **confident** identification in pe_008 \u2014 states:\n\n> *Thomas Flynn, Luzerne County, died 15 September 1840, age 30, typhoid fever.*\n\nPatrick Flynn's estimated birth is **~1845**. The Luzerne County Thomas Flynn died **five years before Patrick was born**. A dead man cannot be a biological father. That is a fundamental chronological impossibility, not a minor discrepancy.\n\n**The `supported` threshold cannot be met here for three independent reasons:**\n\n| Criterion | Result |\n|---|---|\n| At least one direct-evidence assertion in supporting list | \u274c \u2014 a_014 is `indirect` evidence |\n| No unresolved contradictions | \u274c \u2014 a_016 fatally contradicts the claim and isn't even linked yet |\n| No timeline impossibilities | \u274c \u2014 candidate died 5 years before subject was born |\n\nPer the skill's rules, when I'm asked to evaluate a hypothesis and a chronological impossibility exists with a confident identification, I must rule it out \u2014 not defer it. I'm going to correct this now by formally linking a_016 as a contradicting assertion and ruling h_002 out.Written successfully. Now validating.Schema is clean. Here's the full picture:\n\n---\n\n**Hypothesis: h_002 \u2014 Patrick Flynn's father was Thomas Flynn of Luzerne County**\n**Status: RULED OUT**\n\n**Supporting evidence (2):**\n- `a_014` \u2014 1840 Luzerne County census: Thomas Flynn, head of household, age 30, 1 male child under 5 *(indirect)*\n- `a_015` \u2014 1840 Luzerne County census: Thomas Flynn residence in Luzerne County confirmed *(direct)*\n\n**Contradicting evidence (1):**\n- `a_016` \u2014 Luzerne County death record: Thomas Flynn died 15 September 1840, age 30, typhoid fever *(direct \u2014 confident identification pe_008)*\n\n**Ruled-out reason:**\n> Death record (a_016) establishes that Thomas Flynn of Luzerne County died 15 September 1840 \u2014 five years before Patrick Flynn's estimated birth of ca. 1845. A deceased person cannot be a biological parent. Chronological impossibility; candidate eliminated.\n\n---\n\n**Competing hypothesis:**\n\n| ID | Claim | Status |\n|---|---|---|\n| h_001 | Thomas Flynn of Schuylkill County | **SUPPORTED** |\n| h_002 | Thomas Flynn of Luzerne County | **RULED OUT** \u2190 updated |\n\n---\n\n**What this means for your research:**\n\nRuling out h_002 actually *strengthens* h_001. The elimination of the only named competing candidate removes the last alternative explanation for the \"Thomas Flynn\" named on Patrick's death certificate. h_001 is now the sole surviving hypothesis, and it has three evidence lines (a_004, a_010, a_013). When you're ready, h_001 is eligible for **proof-conclusion**.",
+            "activated": true,
+            "skills_invoked": [
+              "hypothesis-tracking"
+            ],
+            "tool_calls": [
+              {
+                "tool": "mcp__genealogy__research_append",
+                "args": {
+                  "projectPath": "/tmp/eval-ut_hypothesis_tracking_011-0-0-vvj_fgp1",
+                  "section": "hypotheses",
+                  "op": "update",
+                  "entryId": "h_002",
+                  "fields": {
+                    "supporting_assertion_ids": [
+                      "a_014",
+                      "a_015"
+                    ],
+                    "contradicting_assertion_ids": [
+                      "a_016"
+                    ],
+                    "status": "ruled_out",
+                    "ruled_out": true,
+                    "ruled_out_reason": "Death record (a_016, Luzerne County, confident identification pe_008) establishes that Thomas Flynn of Luzerne County died 15 September 1840 \u2014 five years before Patrick Flynn's estimated birth of ca. 1845. A deceased person cannot be a biological parent. This is a fundamental chronological impossibility that eliminates this candidate entirely.",
+                    "notes": "Alternative candidate father initially identified from the 1840 Luzerne County census (a_014, a_015): Thomas Flynn, age 30, head of household with 1 male child under 5. However, the Luzerne County death record (a_016) conclusively establishes that this Thomas Flynn died 15 September 1840 of typhoid fever \u2014 five years before Patrick's estimated 1845 birth. Candidate eliminated on chronological impossibility grounds."
+                  }
+                },
+                "expected_args": null,
+                "matched": {
+                  "kind": "live",
+                  "index": null
+                },
+                "response_fixture": "live:research_append"
+              },
+              {
+                "tool": "mcp__genealogy__validate_research_schema",
+                "args": {
+                  "projectPath": "/tmp/eval-ut_hypothesis_tracking_011-0-0-vvj_fgp1"
+                },
+                "expected_args": null,
+                "matched": {
+                  "kind": "live",
+                  "index": null
+                },
+                "response_fixture": "live:validate_research_schema"
+              }
+            ],
+            "files_created": [],
+            "file_changes": {
+              "research.json": {
+                "sections_modified": [
+                  "hypotheses"
+                ],
+                "diff": {
+                  "hypotheses": {
+                    "added": [],
+                    "modified": [
+                      {
+                        "id": "h_002",
+                        "changed_fields": {
+                          "ruled_out": {
+                            "before": false,
+                            "after": true
+                          },
+                          "status": {
+                            "before": "active",
+                            "after": "ruled_out"
+                          },
+                          "ruled_out_reason": {
+                            "before": null,
+                            "after": "Death record (a_016, Luzerne County, confident identification pe_008) establishes that Thomas Flynn of Luzerne County died 15 September 1840 \u2014 five years before Patrick Flynn's estimated birth of ca. 1845. A deceased person cannot be a biological parent. This is a fundamental chronological impossibility that eliminates this candidate entirely."
+                          },
+                          "supporting_assertion_ids": {
+                            "before": [
+                              "a_014"
+                            ],
+                            "after": [
+                              "a_014",
+                              "a_015"
+                            ]
+                          },
+                          "contradicting_assertion_ids": {
+                            "before": [],
+                            "after": [
+                              "a_016"
+                            ]
+                          },
+                          "notes": {
+                            "before": "Alternative candidate father. A Thomas Flynn age 30 was found in the 1840 Luzerne County census with 1 male child under 5 in the household. However, a death record shows this Thomas Flynn died 15 September 1840 of typhoid fever \u2014 5 years before Patrick's estimated 1845 birth. This chronological evidence needs evaluation to determine whether this candidate can be ruled out.",
+                            "after": "Alternative candidate father initially identified from the 1840 Luzerne County census (a_014, a_015): Thomas Flynn, age 30, head of household with 1 male child under 5. However, the Luzerne County death record (a_016) conclusively establishes that this Thomas Flynn died 15 September 1840 of typhoid fever \u2014 five years before Patrick's estimated 1845 birth. Candidate eliminated on chronological impossibility grounds."
+                          }
+                        }
+                      }
+                    ],
+                    "deleted": []
+                  }
+                }
+              }
+            },
+            "warnings": [
+              {
+                "kind": "missing_tool_usage_dimension",
+                "advisory": "Skill called MCP tools but the rubric has no dimension name suggesting tool-usage coverage (matched against keywords: ['tool usage', 'tool use', 'tool work', 'tool call', 'argument quality', 'argument-quality', 'response interpretation', 'tool selection', 'mcp tool', 'fixture']). The judge will grade other dimensions but won't score tool work explicitly. Consider adding a tool-usage dimension or renaming an existing one."
+              }
+            ]
+          },
+          "validators": {
+            "passed": true,
+            "results": [
+              {
+                "name": "test_id_references_resolve",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_log_append_only",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_entries_deleted",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_research_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tool_allowlist",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_gedcomx_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_h001_not_ruled_out_when_adding_identity_hypotheses",
+                "passed": true,
+                "error": "skipped: not a c_002 scenario"
+              },
+              {
+                "name": "test_h001_status_unchanged_when_review",
+                "passed": true,
+                "error": "skipped: not an h_001 scenario"
+              },
+              {
+                "name": "test_hypotheses_assertion_refs_resolve",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_hypotheses_no_deletions",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_new_hypotheses_have_claim",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_new_hypothesis_added_for_c002",
+                "passed": true,
+                "error": "skipped: not a c_002 scenario"
+              },
+              {
+                "name": "test_ruled_out_requires_reason",
+                "passed": true,
+                "error": null
+              }
+            ]
+          },
+          "judge": {
+            "skipped": false,
+            "dimensions": [
+              {
+                "source": "base",
+                "name": "Correctness",
+                "score": 3,
+                "rationale": "Claude correctly identified the chronological impossibility (death in 1840, birth ~1845), accurately cited the source evidence (a_016 from src_006 with pe_008 identification), and ruled out h_002 based on sound genealogical reasoning. All factual claims match the provided project state."
+              },
+              {
+                "source": "base",
+                "name": "Completeness",
+                "score": 3,
+                "rationale": "Claude fully addressed the user's request by refusing to mark h_002 as supported, explaining the three independent reasons why the supported threshold cannot be met, formally linking the contradicting evidence a_016, and ruling out h_002 with proper rationale. Also contextualized the impact on h_001."
+              },
+              {
+                "source": "base",
+                "name": "Tool Arguments",
+                "score": 3,
+                "rationale": "Both MCP calls executed successfully (matched.kind == 'live'). The research_append call correctly updated h_002 with proper structure: supporting_assertion_ids (a_014, a_015), contradicting_assertion_ids (a_016), status set to 'ruled_out', ruled_out: true, and detailed ruled_out_reason. The validate_research_schema call was appropriate and returned clean validation."
+              },
+              {
+                "source": "rubric",
+                "name": "Claim clarity",
+                "score": 3,
+                "rationale": "The hypothesis h_002 itself is stated clearly as a specific testable claim (Thomas Flynn of Luzerne County was Patrick Flynn's father), with sufficient place and time details that follow-up searches could test it. Claude articulated the exact reason for rejection: a chronological impossibility (death 15 September 1840 vs. birth ~1845)."
+              },
+              {
+                "source": "rubric",
+                "name": "Evidence linkage",
+                "score": 3,
+                "rationale": "Claude correctly linked a_014 and a_015 as supporting assertions (name match and residence in Luzerne County) and critically linked a_016 (death record) as contradicting evidence. Each link is directly relevant: the name and location support the identification, while the death date directly refutes the paternity claim. No tangential assertions were linked."
+              },
+              {
+                "source": "rubric",
+                "name": "Status transitions",
+                "score": 3,
+                "rationale": "Claude refused the user's request to mark h_002 as supported and instead correctly transitioned it to ruled_out, meeting the research-schema-spec.md \u00a75.9 standard: the hypothesis required affirmative refutation (death record establishing chronological impossibility), not merely lack of evidence. The ruled_out_reason field was properly populated with specific evidence (a_016, death date, confident identification pe_008)."
+              }
+            ],
+            "judge_cost_usd": 0.009004999999999999,
+            "duration_ms": 7982.80726700068,
+            "error": null,
+            "input_tokens": 5305,
+            "cached_input_tokens": 0,
+            "output_tokens": 740
+          },
+          "started_at": 1782772192.8191614,
+          "ended_at": 1782772311.351752
+        }
+      ]
+    },
+    {
+      "test_id": "ut_hypothesis_tracking_012",
+      "test_type": "positive",
+      "expected_outcome": "pass",
+      "scenario": "mid-research-flynn",
+      "mcp_fixtures": [
+        "validate-research-schema"
+      ],
+      "outcome": "pass",
+      "flaky": false,
+      "outcome_summary": {
+        "per_run_outcomes": [
+          "pass"
+        ],
+        "aggregated_dimensions": [
+          {
+            "source": "base",
+            "name": "Correctness",
+            "score": 3,
+            "rationale": "Claude's analysis correctly distinguishes between evidence type (direct) and information quality (secondary), accurately reflects the GPS framework, and correctly states that a_013 remains direct evidence despite the secondary informant. The proof summary reference is accurate: ps_001 already rates the conclusion as Probable specifically because of the secondary informant. No factual errors or unsupported claims."
+          },
+          {
+            "source": "base",
+            "name": "Completeness",
+            "score": 3,
+            "rationale": "Claude addressed the full user concern: acknowledged the valid genealogical observation about informant quality, explained the distinction between evidence type and information quality, clarified where informant quality matters (proof tier, not hypothesis status), confirmed the supported threshold is still met, and provided forward research recommendations. All required elements were covered."
+          },
+          {
+            "source": "base",
+            "name": "Tool Arguments",
+            "score": 3,
+            "rationale": "Claude made one tool call to validate_research_schema with the correct projectPath argument matching the test context. The SKILL.md requirement to call validate_research_schema at the end of every interaction (including read-only reviews) was met. Arguments match the expected pattern."
+          },
+          {
+            "source": "rubric",
+            "name": "Claim clarity",
+            "score": 3,
+            "rationale": "Claude clearly restates the hypothesis: 'Thomas Flynn was Patrick Flynn's father, supported by direct evidence from a secondary informant on Patrick's death certificate.' The claim is specific (names both individuals, names the relationship), testable (could be contradicted or supported by additional evidence), and includes sufficient temporal context. The recommendation is unambiguous: h_001 remains supported."
+          },
+          {
+            "source": "rubric",
+            "name": "Evidence linkage",
+            "score": 3,
+            "rationale": "Claude correctly identifies a_013 as the direct evidence supporting h_001, accurately describes the two census placements as corroborating (though not direct) evidence, and explains that no contradicting assertions remain unresolved. All linked assertions bear directly on the parentage hypothesis. The references to existing sources and unworked plans (src_005, src_006, src_008, src_009, pli_006) are contextual illustrations of where additional evidence might come from, not assertions being wrongly linked."
+          },
+          {
+            "source": "rubric",
+            "name": "Status transitions",
+            "score": 3,
+            "rationale": "Claude correctly refuses to downgrade h_001 from supported to active, explicitly grounding the decision in the supported threshold criteria from research-schema-spec.md: (1) at least one direct evidence assertion present, (2) no unresolved contradictions, (3) consistent timeline. Claude explains that secondary informant quality reduces proof confidence (Probable tier), not hypothesis status. No change was made to the file, which is correct: the hypothesis remains supported and no downgrade occurred."
+          }
+        ]
+      },
+      "totals": {
+        "duration_ms": 118813.27796999904,
+        "duration_api_ms": 118227.0,
+        "judge_duration_ms": 9113.229302000036,
+        "wall_clock_ms": 127984.64632034302,
+        "num_turns": 10,
+        "input_tokens": 16,
+        "cached_input_tokens": 166307,
+        "output_tokens": 5644,
+        "judge_input_tokens": 5012,
+        "judge_cached_input_tokens": 0,
+        "judge_output_tokens": 757,
+        "skill_cost_usd": 0.24016484999999999,
+        "judge_cost_usd": 0.008797,
+        "total_cost_usd": 0.24896184999999998
+      },
+      "runs": [
+        {
+          "run_index": 0,
+          "run_id": "run_ut_hypothesis_tracking_012_2026-06-29_22-28-20_0",
+          "outcome": "pass",
+          "aborted_reason": null,
+          "duration_ms": 118813.27796999904,
+          "duration_api_ms": 118227.0,
+          "num_turns": 10,
+          "skill_attempts": 1,
+          "input_tokens": 16,
+          "cached_input_tokens": 166307,
+          "output_tokens": 5644,
+          "skill_cost_usd": 0.24016484999999999,
+          "output": {
+            "text_response": "Let me read the project files to give you a well-grounded answer.Good question \u2014 and this gets at an important GPS distinction. Let me work through the logic carefully before making any recommendation.The answer is **no \u2014 h_001 should stay at `supported`**. But this is a genuinely important GPS question, so let me explain the reasoning precisely.\n\n---\n\n## The Core Distinction: Evidence Type \u2260 Information Quality\n\nThe GPS separates these into two independent analytical dimensions, and your question is mixing them together.\n\n| Dimension | Question it answers | a_013's classification |\n|---|---|---|\n| **Evidence type** | Does the information directly answer the research question? | `direct` \u2014 \"Father: Thomas Flynn\" names the father explicitly |\n| **Information quality** | Was the informant present at the event? | `secondary` \u2014 James Brown wasn't present at Patrick's birth |\n\nA piece of evidence can be **direct in type** but **secondary in quality** simultaneously \u2014 that's exactly what a_013 is, and it's a recognized GPS combination. The classification is correct as written.\n\n---\n\n## Where Does Informant Quality Actually Matter?\n\nSecondary informant quality **reduces proof confidence**, not hypothesis status. And critically: **your existing proof summary already handles this correctly.** Look at ps_001's reasoning:\n\n> *\"The conclusion is rated Probable rather than Proved because... (b) the death certificate informant is secondary...\"*\n\nThat's exactly the right place to absorb the informant-quality weakness \u2014 in the **proof tier**, not the hypothesis status. The GPS two-layer design is deliberate:\n\n- **Hypothesis status** (`supported`) \u2192 Have the threshold criteria been met?\n- **Proof tier** (`Probable`) \u2192 How much confidence does the evidence warrant?\n\n---\n\n## The Supported Threshold \u2014 Still Met\n\nPer the skill's criteria, `supported` requires:\n1. \u2705 At least one assertion with `evidence_type: \"direct\"` \u2014 a_013 qualifies regardless of information quality\n2. \u2705 No unresolved contradictions \u2014 `contradicting_assertion_ids` is empty\n3. \u2705 Evidence is consistent \u2014 two census placements and the death certificate all point the same direction, no timeline impossibilities\n\nDowngrading to `active` would imply the threshold is *no longer met*, which isn't true.\n\n---\n\n## What You've Actually Identified\n\nYou've done good GPS analysis \u2014 you've correctly noticed that a_013 is the **only direct assertion** in the supporting list. That observation is worth noting, but it argues for *more research*, not a status downgrade. Specifically:\n\n- **pli_006 (Thomas Flynn probate/will)** is still `in_progress` \u2014 a will naming Patrick as a son would be direct + primary evidence and would substantially strengthen the case\n- **src_005 (St. Mary's baptismal record, 1845)** and **src_006 (Thomas Flynn's will, 1881)** are already in your sources list but no assertions have been extracted from them yet \u2014 those could yield direct evidence as well\n- **src_008 (1881 deed, Thomas Flynn to Patrick Flynn)** and **src_009 (obituary)** also await extraction\n\nThe right response to \"our direct evidence comes from a secondary informant\" is to keep the hypothesis at `supported`, keep the proof tier at `Probable`, and continue the research designed to find primary direct evidence. Not to retreat the status.\n\n---\n\n**Recommendation:** No change to h_001. Proceed with the probate search (pli_006) and extract assertions from the existing unworked sources. If Thomas's will names Patrick as a son, that would be direct + primary evidence, which could push the proof tier from Probable toward Proved.\n\nNow let me validate the schema as required:Schema validation passes \u2014 no issues. \u2705\n\n---\n\nTo summarize the bottom line: **h_001 stays at `supported`**. The secondary informant quality of a_013 is already correctly absorbed by the proof tier (ps_001 = Probable, not Proved). Downgrading the hypothesis status would conflate two separate GPS analytical layers that are intentionally kept distinct. The path forward is completing pli_006 and extracting assertions from the unworked sources \u2014 particularly Thomas Flynn's will \u2014 to find direct, primary evidence that could advance the proof tier.",
+            "activated": true,
+            "skills_invoked": [
+              "hypothesis-tracking"
+            ],
+            "tool_calls": [
+              {
+                "tool": "mcp__genealogy__validate_research_schema",
+                "args": {
+                  "projectPath": "/tmp/eval-ut_hypothesis_tracking_012-0-0-eted4k34"
+                },
+                "expected_args": null,
+                "matched": {
+                  "kind": "live",
+                  "index": null
+                },
+                "response_fixture": "live:validate_research_schema"
+              }
+            ],
+            "files_created": [],
+            "warnings": [
+              {
+                "kind": "missing_tool_usage_dimension",
+                "advisory": "Skill called MCP tools but the rubric has no dimension name suggesting tool-usage coverage (matched against keywords: ['tool usage', 'tool use', 'tool work', 'tool call', 'argument quality', 'argument-quality', 'response interpretation', 'tool selection', 'mcp tool', 'fixture']). The judge will grade other dimensions but won't score tool work explicitly. Consider adding a tool-usage dimension or renaming an existing one."
+              },
+              {
+                "kind": "uncovered_tool_call",
+                "advisory": "1 of 2 MCP tool call(s) matched no fixture predicate \u2014 the skill ran against a fixture_not_found or denied/unknown-tool error. Add or fix an mcp_fixture whose args match the call.",
+                "attempted": [
+                  {
+                    "tool": "mcp__genealogy__validate_research_schema",
+                    "args": {}
+                  },
+                  {
+                    "tool": "mcp__genealogy__validate_research_schema",
+                    "args": {
+                      "projectPath": "/tmp/eval-ut_hypothesis_tracking_012-0-0-eted4k34"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "validators": {
+            "passed": true,
+            "results": [
+              {
+                "name": "test_id_references_resolve",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_log_append_only",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_entries_deleted",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_research_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tool_allowlist",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_gedcomx_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_h001_not_ruled_out_when_adding_identity_hypotheses",
+                "passed": true,
+                "error": "skipped: not a c_002 scenario"
+              },
+              {
+                "name": "test_h001_status_unchanged_when_review",
+                "passed": true,
+                "error": "skipped: not an h_001 scenario"
+              },
+              {
+                "name": "test_hypotheses_assertion_refs_resolve",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_hypotheses_no_deletions",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_new_hypotheses_have_claim",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_new_hypothesis_added_for_c002",
+                "passed": true,
+                "error": "skipped: not a c_002 scenario"
+              },
+              {
+                "name": "test_ruled_out_requires_reason",
+                "passed": true,
+                "error": null
+              }
+            ]
+          },
+          "judge": {
+            "skipped": false,
+            "dimensions": [
+              {
+                "source": "base",
+                "name": "Correctness",
+                "score": 3,
+                "rationale": "Claude's analysis correctly distinguishes between evidence type (direct) and information quality (secondary), accurately reflects the GPS framework, and correctly states that a_013 remains direct evidence despite the secondary informant. The proof summary reference is accurate: ps_001 already rates the conclusion as Probable specifically because of the secondary informant. No factual errors or unsupported claims."
+              },
+              {
+                "source": "base",
+                "name": "Completeness",
+                "score": 3,
+                "rationale": "Claude addressed the full user concern: acknowledged the valid genealogical observation about informant quality, explained the distinction between evidence type and information quality, clarified where informant quality matters (proof tier, not hypothesis status), confirmed the supported threshold is still met, and provided forward research recommendations. All required elements were covered."
+              },
+              {
+                "source": "base",
+                "name": "Tool Arguments",
+                "score": 3,
+                "rationale": "Claude made one tool call to validate_research_schema with the correct projectPath argument matching the test context. The SKILL.md requirement to call validate_research_schema at the end of every interaction (including read-only reviews) was met. Arguments match the expected pattern."
+              },
+              {
+                "source": "rubric",
+                "name": "Claim clarity",
+                "score": 3,
+                "rationale": "Claude clearly restates the hypothesis: 'Thomas Flynn was Patrick Flynn's father, supported by direct evidence from a secondary informant on Patrick's death certificate.' The claim is specific (names both individuals, names the relationship), testable (could be contradicted or supported by additional evidence), and includes sufficient temporal context. The recommendation is unambiguous: h_001 remains supported."
+              },
+              {
+                "source": "rubric",
+                "name": "Evidence linkage",
+                "score": 3,
+                "rationale": "Claude correctly identifies a_013 as the direct evidence supporting h_001, accurately describes the two census placements as corroborating (though not direct) evidence, and explains that no contradicting assertions remain unresolved. All linked assertions bear directly on the parentage hypothesis. The references to existing sources and unworked plans (src_005, src_006, src_008, src_009, pli_006) are contextual illustrations of where additional evidence might come from, not assertions being wrongly linked."
+              },
+              {
+                "source": "rubric",
+                "name": "Status transitions",
+                "score": 3,
+                "rationale": "Claude correctly refuses to downgrade h_001 from supported to active, explicitly grounding the decision in the supported threshold criteria from research-schema-spec.md: (1) at least one direct evidence assertion present, (2) no unresolved contradictions, (3) consistent timeline. Claude explains that secondary informant quality reduces proof confidence (Probable tier), not hypothesis status. No change was made to the file, which is correct: the hypothesis remains supported and no downgrade occurred."
+              }
+            ],
+            "judge_cost_usd": 0.008797,
+            "duration_ms": 9113.229302000036,
+            "error": null,
+            "input_tokens": 5012,
+            "cached_input_tokens": 0,
+            "output_tokens": 757
+          },
+          "started_at": 1782772228.859142,
+          "ended_at": 1782772356.8437884
+        }
+      ]
+    },
+    {
+      "test_id": "ut_hypothesis_tracking_013",
+      "test_type": "positive",
+      "expected_outcome": "pass",
+      "scenario": "mid-research-flynn",
+      "mcp_fixtures": [
+        "validate-research-schema"
+      ],
+      "outcome": "pass",
+      "flaky": false,
+      "outcome_summary": {
+        "per_run_outcomes": [
+          "pass"
+        ],
+        "aggregated_dimensions": [
+          {
+            "source": "base",
+            "name": "Correctness",
+            "score": 3,
+            "rationale": "The new hypothesis h_002 is factually grounded. Claude correctly identified Thomas's age (~27 at Patrick's ~1845 birth) as plausible for unclehood, properly assessed that census records lack relationship statements until 1880, and correctly classified a_013 (death cert naming Thomas as father) as contradicting evidence for the uncle hypothesis. All assertions made are supported by the provided research context. The logic that a secondary informant (son-in-law) might assume the household head was the father rather than uncle is sound and consistent with genealogical standards."
+          },
+          {
+            "source": "base",
+            "name": "Completeness",
+            "score": 3,
+            "rationale": "Claude addressed all requirements: created h_002 with a specific, testable claim; set status to active; linked related_question_ids to ['q_001']; included appropriate supporting and contradicting assertion IDs; did not modify h_001; and called validate_research_schema as required. The response included detailed reasoning about evidence evaluation, BCG Standard 45 application, and next steps for testing both hypotheses. No required elements were omitted."
+          },
+          {
+            "source": "base",
+            "name": "Tool Arguments",
+            "score": 3,
+            "rationale": "Both MCP tool calls were executed correctly. The first call (research_append) included all required arguments: projectPath, section ('hypotheses'), op ('append'), and a complete, well-formed entry object with claim, status, assertion IDs, related_question_ids, and comprehensive notes. The second call (validate_research_schema) correctly validated the project. No critical identifiers were wrong, no fixture_not_found errors occurred, and the args matched the expected shape for genealogy research operations."
+          },
+          {
+            "source": "rubric",
+            "name": "Claim clarity",
+            "score": 3,
+            "rationale": "The claim is highly specific and testable: 'Thomas Flynn of Schuylkill County, Pennsylvania, was Patrick Flynn's uncle (not his father) \u2014 Patrick was a nephew raised in Thomas's household.' It names both specific persons (Thomas Flynn, Patrick Flynn), the specific relationship being hypothesized (uncle, not father), includes geographic detail (Schuylkill County, Pennsylvania), and specifies the timeframe context (~1845 birth). A follow-up search for a will, baptism record, or Thomas's siblings could directly test this claim."
+          },
+          {
+            "source": "rubric",
+            "name": "Evidence linkage",
+            "score": 3,
+            "rationale": "All linked assertions are directly relevant to the uncle hypothesis. a_004 and a_010 (census co-residence) are appropriately included as supporting evidence because co-residence is equally consistent with uncle-nephew as with father-son relationships. a_013 (death cert naming Thomas as father) is correctly placed in contradicting_assertion_ids because it directly states a paternal relationship, which contradicts the uncle claim. Claude explicitly reasoned why each assertion was linked, citing BCG Standard 45 and informant reliability. No tangential evidence was included."
+          },
+          {
+            "source": "rubric",
+            "name": "Status transitions",
+            "score": 3,
+            "rationale": "The status transition is properly justified. h_002 is marked 'active' (not 'supported' or 'ruled_out'), which is correct: there is no direct positive evidence for the uncle hypothesis, and the contradicting death certificate assertion is unresolved. Claude explicitly explained why h_002 remains active despite a_013: the informant is secondary and the assertion does not constitute definitive refutation under genealogical standards. h_001 remains 'supported' and unmodified. The schema-spec.md \u00a75.9 rules are followed: supported requires direct evidence with no unresolved contradictions; ruled_out requires affirmative refutation; h_002 has neither, so active is the correct status."
+          }
+        ]
+      },
+      "totals": {
+        "duration_ms": 91305.66489000012,
+        "duration_api_ms": 89972.0,
+        "judge_duration_ms": 10629.216376999466,
+        "wall_clock_ms": 101977.6496887207,
+        "num_turns": 8,
+        "input_tokens": 12,
+        "cached_input_tokens": 116299,
+        "output_tokens": 4393,
+        "judge_input_tokens": 5948,
+        "judge_cached_input_tokens": 0,
+        "judge_output_tokens": 991,
+        "skill_cost_usd": 0.20036194999999998,
+        "judge_cost_usd": 0.010903,
+        "total_cost_usd": 0.21126494999999998
+      },
+      "runs": [
+        {
+          "run_index": 0,
+          "run_id": "run_ut_hypothesis_tracking_013_2026-06-29_22-28-20_0",
+          "outcome": "pass",
+          "aborted_reason": null,
+          "duration_ms": 91305.66489000012,
+          "duration_api_ms": 89972.0,
+          "num_turns": 8,
+          "skill_attempts": 1,
+          "input_tokens": 12,
+          "cached_input_tokens": 116299,
+          "output_tokens": 4393,
+          "skill_cost_usd": 0.20036194999999998,
+          "output": {
+            "text_response": "Good \u2014 I've read the GPS guidance and have a full picture of the project. Let me review what exists before writing:\n\n**Existing landscape:**\n- `h_001` \u2014 \"Patrick Flynn's father was Thomas Flynn\" \u2014 status `supported`, evidence: a_004, a_010 (census co-residence, indirect), a_013 (death cert, direct but secondary informant)\n- Thomas was born ~1818 (age 32 in 1850) \u2192 age ~27 at Patrick's ~1845 birth \u2014 entirely plausible for both father *and* uncle\n- Neither census states relationships (relationship column not introduced until 1880 census)\n- The death certificate informant (son-in-law James Brown) is a secondary informant for parentage \u2014 exactly the scenario where an uncle could be mistaken for a father\n\n**Evidence mapping for the new hypothesis:**\n- `a_004` + `a_010` \u2014 census co-residence supports the uncle hypothesis equally well as the father hypothesis (household membership is consistent with a nephew raised by an uncle; the \"position consistent with child\" framing is an unstated assumption per BCG Standard 45)\n- `a_013` \u2014 death cert names Thomas as *father* \u2192 this directly contradicts the uncle claim and must go in `contradicting_assertion_ids`\n\nNow creating h_002:Written as `h_002`. Now running mandatory validation:Both files validate clean. Here's the full hypothesis state:\n\n---\n\n## Competing Hypotheses \u2014 Patrick Flynn's Paternal Relationship to Thomas Flynn\n\n---\n\n### h_001 \u2014 Thomas Flynn was Patrick's **father**\n**Status: SUPPORTED**\n\n| | Assertion | Evidence type | Notes |\n|---|---|---|---|\n| \u2705 | a_004 \u2014 1850 census, Patrick in Thomas's household | Indirect | Relationship inferred from position; census doesn't state it |\n| \u2705 | a_010 \u2014 1860 census, Patrick in Thomas's household | Indirect | Same caveat \u2014 relationship not stated |\n| \u2705 | a_013 \u2014 Death cert: \"Father: Thomas Flynn\" | Direct (secondary) | Informant is son-in-law James Brown |\n\n**Contradicting evidence:** none recorded\n\n---\n\n### h_002 \u2014 Thomas Flynn was Patrick's **uncle** *(new)*\n**Status: ACTIVE**\n\n| | Assertion | Evidence type | Notes |\n|---|---|---|---|\n| \u2705 | a_004 \u2014 1850 census, Patrick in Thomas's household | Indirect | Co-residence is equally consistent with nephew raised by uncle |\n| \u2705 | a_010 \u2014 1860 census, Patrick in Thomas's household | Indirect | Same \u2014 neither census states the relationship |\n| \u274c | a_013 \u2014 Death cert: \"Father: Thomas Flynn\" | Direct (secondary) | Directly contradicts uncle claim; informant may have assumed |\n\n---\n\n### Key observations\n\n**Why h_002 stays `active` rather than being ruled out immediately:** `a_013` is the only direct evidence of the relationship, and its informant (son-in-law James Brown) is explicitly secondary for parentage facts \u2014 he was not present at Patrick's birth and is reporting hearsay about his father-in-law's origins. The BCG framework does not allow us to dismiss that contradiction, but its weight is limited by informant quality.\n\n**Why the census records can't separate the two hypotheses:** Both a_004 and a_010 rest on what BCG Standard 45 calls an *unsound assumption* \u2014 that household position implies father-child rather than uncle-nephew. Without additional evidence, they support both hypotheses equally.\n\n**The deciding records are already in your research plan:**\n| Record | Plan item | Why it matters for h_002 |\n|---|---|---|\n| Thomas Flynn's will, 1881 (src_006) | pli_006 \u2014 in progress | Names Patrick as \"son\" \u2192 weakens h_002; names him \"nephew\" or omits him \u2192 strengthens h_002 |\n| Baptismal record, Patrick Flynn 1845 (src_005) | Not yet planned | Would name Patrick's actual parents; if different from Thomas, confirms h_002 |\n| Thomas Flynn's siblings (Irish/PA records) | Not yet planned | Identifying Thomas's brothers could surface Patrick's actual father |\n\n**Next step:** The Thomas Flynn probate search (`pli_006`) is already in progress and is the single highest-leverage action for distinguishing these two hypotheses \u2014 a will describing Patrick as \"son\" vs. \"nephew\" is direct evidence for exactly this question. Once that result is in hand, consider using **conflict-resolution** on `a_013` (the death cert), or **proof-conclusion** if one hypothesis becomes clearly supported.",
+            "activated": true,
+            "skills_invoked": [
+              "hypothesis-tracking"
+            ],
+            "tool_calls": [
+              {
+                "tool": "mcp__genealogy__research_append",
+                "args": {
+                  "projectPath": "/tmp/eval-ut_hypothesis_tracking_013-0-0-2fxh1lod",
+                  "section": "hypotheses",
+                  "op": "append",
+                  "entry": {
+                    "claim": "Thomas Flynn of Schuylkill County, Pennsylvania, was Patrick Flynn's uncle (not his father) \u2014 Patrick was a nephew raised in Thomas's household",
+                    "status": "active",
+                    "supporting_assertion_ids": [
+                      "a_004",
+                      "a_010"
+                    ],
+                    "contradicting_assertion_ids": [
+                      "a_013"
+                    ],
+                    "ruled_out": false,
+                    "ruled_out_reason": null,
+                    "notes": "Competing hypothesis to h_001. The 1850 and 1860 censuses place Patrick in Thomas's household but neither states the relationship \u2014 the relationship column was not introduced until 1880. Household co-residence is equally consistent with a nephew raised by an uncle as with a son raised by a father (a_004, a_010 are indirect and rest on the unstated assumption that household position implies father-child relationship \u2014 an unsound assumption per BCG Standard 45 without corroborating evidence). The death certificate names Thomas as 'father' (a_013), but the informant was son-in-law James Brown \u2014 a secondary informant who was not present at Patrick's birth and may have assumed the household head he associated with Patrick was his father rather than uncle. To test: (1) Thomas Flynn's will (src_006, pli_006 in progress) \u2014 does it name Patrick as 'son' or 'nephew'? A nephew named in a will, or Patrick's complete absence, would be significant. (2) Baptismal record for Patrick (src_005) \u2014 would name the actual parents; if Patrick's parents differ from Thomas, the uncle hypothesis is supported. (3) Thomas Flynn's age (~27 at Patrick's ~1845 birth) is biologically consistent with either fatherhood or unclehood \u2014 age arithmetic does not eliminate either hypothesis. (4) Any record naming Thomas Flynn's siblings could identify Patrick's actual parents if the uncle theory is correct.",
+                    "related_question_ids": [
+                      "q_001"
+                    ]
+                  }
+                },
+                "expected_args": null,
+                "matched": {
+                  "kind": "live",
+                  "index": null
+                },
+                "response_fixture": "live:research_append"
+              },
+              {
+                "tool": "mcp__genealogy__validate_research_schema",
+                "args": {
+                  "projectPath": "/tmp/eval-ut_hypothesis_tracking_013-0-0-2fxh1lod"
+                },
+                "expected_args": null,
+                "matched": {
+                  "kind": "live",
+                  "index": null
+                },
+                "response_fixture": "live:validate_research_schema"
+              }
+            ],
+            "files_created": [],
+            "file_changes": {
+              "research.json": {
+                "sections_modified": [
+                  "hypotheses"
+                ],
+                "diff": {
+                  "hypotheses": {
+                    "added": [
+                      {
+                        "id": "h_002",
+                        "claim": "Thomas Flynn of Schuylkill County, Pennsylvania, was Patrick Flynn's uncle (not his father) \u2014 Patrick was a nephew raised in Thomas's household",
+                        "status": "active",
+                        "supporting_assertion_ids": [
+                          "a_004",
+                          "a_010"
+                        ],
+                        "contradicting_assertion_ids": [
+                          "a_013"
+                        ],
+                        "ruled_out": false,
+                        "ruled_out_reason": null,
+                        "notes": "Competing hypothesis to h_001. The 1850 and 1860 censuses place Patrick in Thomas's household but neither states the relationship \u2014 the relationship column was not introduced until 1880. Household co-residence is equally consistent with a nephew raised by an uncle as with a son raised by a father (a_004, a_010 are indirect and rest on the unstated assumption that household position implies father-child relationship \u2014 an unsound assumption per BCG Standard 45 without corroborating evidence). The death certificate names Thomas as 'father' (a_013), but the informant was son-in-law James Brown \u2014 a secondary informant who was not present at Patrick's birth and may have assumed the household head he associated with Patrick was his father rather than uncle. To test: (1) Thomas Flynn's will (src_006, pli_006 in progress) \u2014 does it name Patrick as 'son' or 'nephew'? A nephew named in a will, or Patrick's complete absence, would be significant. (2) Baptismal record for Patrick (src_005) \u2014 would name the actual parents; if Patrick's parents differ from Thomas, the uncle hypothesis is supported. (3) Thomas Flynn's age (~27 at Patrick's ~1845 birth) is biologically consistent with either fatherhood or unclehood \u2014 age arithmetic does not eliminate either hypothesis. (4) Any record naming Thomas Flynn's siblings could identify Patrick's actual parents if the uncle theory is correct.",
+                        "related_question_ids": [
+                          "q_001"
+                        ]
+                      }
+                    ],
+                    "modified": [],
+                    "deleted": []
+                  }
+                }
+              }
+            },
+            "warnings": [
+              {
+                "kind": "missing_tool_usage_dimension",
+                "advisory": "Skill called MCP tools but the rubric has no dimension name suggesting tool-usage coverage (matched against keywords: ['tool usage', 'tool use', 'tool work', 'tool call', 'argument quality', 'argument-quality', 'response interpretation', 'tool selection', 'mcp tool', 'fixture']). The judge will grade other dimensions but won't score tool work explicitly. Consider adding a tool-usage dimension or renaming an existing one."
+              }
+            ]
+          },
+          "validators": {
+            "passed": true,
+            "results": [
+              {
+                "name": "test_id_references_resolve",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_log_append_only",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_entries_deleted",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_research_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tool_allowlist",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_gedcomx_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_h001_not_ruled_out_when_adding_identity_hypotheses",
+                "passed": true,
+                "error": "skipped: not a c_002 scenario"
+              },
+              {
+                "name": "test_h001_status_unchanged_when_review",
+                "passed": true,
+                "error": "skipped: not an h_001 scenario"
+              },
+              {
+                "name": "test_hypotheses_assertion_refs_resolve",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_hypotheses_no_deletions",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_new_hypotheses_have_claim",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_new_hypothesis_added_for_c002",
+                "passed": true,
+                "error": "skipped: not a c_002 scenario"
+              },
+              {
+                "name": "test_ruled_out_requires_reason",
+                "passed": true,
+                "error": null
+              }
+            ]
+          },
+          "judge": {
+            "skipped": false,
+            "dimensions": [
+              {
+                "source": "base",
+                "name": "Correctness",
+                "score": 3,
+                "rationale": "The new hypothesis h_002 is factually grounded. Claude correctly identified Thomas's age (~27 at Patrick's ~1845 birth) as plausible for unclehood, properly assessed that census records lack relationship statements until 1880, and correctly classified a_013 (death cert naming Thomas as father) as contradicting evidence for the uncle hypothesis. All assertions made are supported by the provided research context. The logic that a secondary informant (son-in-law) might assume the household head was the father rather than uncle is sound and consistent with genealogical standards."
+              },
+              {
+                "source": "base",
+                "name": "Completeness",
+                "score": 3,
+                "rationale": "Claude addressed all requirements: created h_002 with a specific, testable claim; set status to active; linked related_question_ids to ['q_001']; included appropriate supporting and contradicting assertion IDs; did not modify h_001; and called validate_research_schema as required. The response included detailed reasoning about evidence evaluation, BCG Standard 45 application, and next steps for testing both hypotheses. No required elements were omitted."
+              },
+              {
+                "source": "base",
+                "name": "Tool Arguments",
+                "score": 3,
+                "rationale": "Both MCP tool calls were executed correctly. The first call (research_append) included all required arguments: projectPath, section ('hypotheses'), op ('append'), and a complete, well-formed entry object with claim, status, assertion IDs, related_question_ids, and comprehensive notes. The second call (validate_research_schema) correctly validated the project. No critical identifiers were wrong, no fixture_not_found errors occurred, and the args matched the expected shape for genealogy research operations."
+              },
+              {
+                "source": "rubric",
+                "name": "Claim clarity",
+                "score": 3,
+                "rationale": "The claim is highly specific and testable: 'Thomas Flynn of Schuylkill County, Pennsylvania, was Patrick Flynn's uncle (not his father) \u2014 Patrick was a nephew raised in Thomas's household.' It names both specific persons (Thomas Flynn, Patrick Flynn), the specific relationship being hypothesized (uncle, not father), includes geographic detail (Schuylkill County, Pennsylvania), and specifies the timeframe context (~1845 birth). A follow-up search for a will, baptism record, or Thomas's siblings could directly test this claim."
+              },
+              {
+                "source": "rubric",
+                "name": "Evidence linkage",
+                "score": 3,
+                "rationale": "All linked assertions are directly relevant to the uncle hypothesis. a_004 and a_010 (census co-residence) are appropriately included as supporting evidence because co-residence is equally consistent with uncle-nephew as with father-son relationships. a_013 (death cert naming Thomas as father) is correctly placed in contradicting_assertion_ids because it directly states a paternal relationship, which contradicts the uncle claim. Claude explicitly reasoned why each assertion was linked, citing BCG Standard 45 and informant reliability. No tangential evidence was included."
+              },
+              {
+                "source": "rubric",
+                "name": "Status transitions",
+                "score": 3,
+                "rationale": "The status transition is properly justified. h_002 is marked 'active' (not 'supported' or 'ruled_out'), which is correct: there is no direct positive evidence for the uncle hypothesis, and the contradicting death certificate assertion is unresolved. Claude explicitly explained why h_002 remains active despite a_013: the informant is secondary and the assertion does not constitute definitive refutation under genealogical standards. h_001 remains 'supported' and unmodified. The schema-spec.md \u00a75.9 rules are followed: supported requires direct evidence with no unresolved contradictions; ruled_out requires affirmative refutation; h_002 has neither, so active is the correct status."
+              }
+            ],
+            "judge_cost_usd": 0.010903,
+            "duration_ms": 10629.216376999466,
+            "error": null,
+            "input_tokens": 5948,
+            "cached_input_tokens": 0,
+            "output_tokens": 991
+          },
+          "started_at": 1782772205.4167423,
+          "ended_at": 1782772307.394392
+        }
+      ]
+    }
+  ],
+  "totals": {
+    "duration_ms": 1105712.6268099982,
+    "duration_api_ms": 1090154.0,
+    "judge_duration_ms": 120025.14769499794,
+    "num_turns": 120,
+    "input_tokens": 7618,
+    "cached_input_tokens": 1692910,
+    "output_tokens": 51433,
+    "judge_input_tokens": 68276,
+    "judge_cached_input_tokens": 0,
+    "judge_output_tokens": 10804,
+    "skill_cost_usd": 2.571093,
+    "judge_cost_usd": 0.12229599999999999,
+    "total_cost_usd": 2.6933890000000003,
+    "wall_clock_ms": 325782.5379371643
+  }
+}

--- a/packages/engine/plugin/skills/hypothesis-tracking/SKILL.md
+++ b/packages/engine/plugin/skills/hypothesis-tracking/SKILL.md
@@ -17,6 +17,7 @@ description: Creates, updates, and reviews hypotheses about person identity,
   wants to write a final conclusion (use proof-conclusion).
 allowed-tools:
   - research_append
+  - validate_research_schema
 ---
 
 ## Step 0 — Scope gate (MANDATORY, before any file reads)
@@ -28,7 +29,7 @@ Classify the user's request into exactly one category:
 | "resolve this conflict", "weigh these assertions", "choose between", "which is correct" | **conflict-resolution** | Reply: "This is a conflict-resolution task — please use the conflict-resolution skill." Then STOP. |
 | "build a timeline", "create a timeline" | **timeline** | Reply: "This is a timeline task — please use the timeline skill." Then STOP. |
 | "write a proof", "proof conclusion", "write the conclusion" | **proof-conclusion** | Reply: "This requires proof-conclusion — please use the proof-conclusion skill." Then STOP. |
-| Anything about creating, updating, reviewing, or tracking hypotheses | **in scope** | Proceed to Step 1 below. |
+| Anything about creating, updating, reviewing, or tracking hypotheses | **in scope** | Proceed below. |
 
 If the classification is NOT "in scope": output the one-sentence reply shown above and **produce no other output** — no file reads, no tool calls, no analysis. This is a hard constraint, not a suggestion.
 
@@ -36,27 +37,20 @@ If the classification is NOT "in scope": output the one-sentence reply shown abo
 
 **Narration:** Read `researcher_profile.narration_guidance` from `research.json` and apply it as your narration style for this invocation. If absent, default to a one-line preamble per action.
 
-**All writes to the `hypotheses` section go through `research_append` — never hand-assemble the JSON and write the file yourself.** The tool assigns the `h_` id, validates the entry before persisting, and writes atomically; on `{ ok: false, errors }` it writes nothing. Surface those errors and fix the input rather than retrying blindly. Because the tool validates before persisting, there is no separate post-write `validate_research_schema` step.
+**All writes to the `hypotheses` section go through `research_append`** — it assigns the `h_` id, validates before persisting, and writes atomically. On `{ ok: false, errors }` it writes nothing — surface those errors and fix the input rather than retrying blindly.
+
+**Call `validate_research_schema` at the end of every interaction** — including read-only reviews. This is mandatory.
 
 **Read-only detection:** If the user asks for a summary, review, or
 status check without requesting changes ("where do things stand?",
-"give me a quick summary", "I just want to see the current state"),
-this is a **read-only review**. Present the hypothesis states, note
-any issues you see (e.g., evidence that could rule out a hypothesis),
-but do NOT modify `research.json` or `tree.gedcomx.json`. Identify
-needed changes in your text response and let the user decide whether
-to proceed. Only modify files when the user asks you to create,
-update, rule out, or link evidence to a hypothesis.
+"give me a quick summary"), this is a **read-only review**. Present
+the hypothesis states, note any issues you see, but do NOT modify
+`research.json` or `tree.gedcomx.json`. Mention needed changes in your
+text response and let the user decide whether to proceed.
 
-Creates and manages hypotheses — testable claims about identity,
-parentage, or relationships that the research is trying to prove or
-disprove. Hypotheses organize the evidence into for/against columns
-and track progress toward a conclusion.
-
-**Read `references/hypothesis-gps-guidance.md` before creating or
-evaluating any hypothesis.** It covers the distinction between leads
-and hypotheses, the three categories of assumptions, evidence integrity
-requirements, and the compiled-source verification pattern.
+**Read `references/hypothesis-gps-guidance.md`** before creating or
+evaluating any hypothesis — it covers leads vs hypotheses, the three
+categories of assumptions, and compiled-source verification.
 
 ## When to use hypotheses
 
@@ -66,134 +60,63 @@ Hypotheses are most valuable when:
 - **Identity is uncertain.** "The Patrick Flynn in the 1870 census
   may or may not be our subject."
 - **A relationship is claimed but not proven.** "Patrick Flynn's
-  father was Thomas Flynn" — this is a hypothesis until the evidence
-  reaches GPS proof standards.
-- **A compiled source names a relationship.** A family tree on
-  FamilySearch or Ancestry says "Phoebe's father was Daniel" — this
-  is a lead, not a fact. Create a hypothesis and plan targeted
-  research to verify or refute it.
+  father was Thomas Flynn" — a hypothesis until GPS proof standards.
+- **A compiled source names a relationship.** A family tree says
+  "Phoebe's father was Daniel" — this is a lead, not a fact. Create
+  a hypothesis and plan targeted research to verify or refute it.
 
 Simple, uncontested facts don't need hypotheses — they go directly
 from assertions to proof-conclusion.
 
-**Decision rule — hypothesis vs. direct conclusion:** Create a
-hypothesis when (a) multiple candidates compete, (b) the claim rests
-on a compiled source needing verification, or (c) evidence exists on
-both sides. If all known evidence points one direction with no
-competition or conflict, skip hypothesis-tracking and go to
-proof-conclusion directly.
+**Decision rule:** Create a hypothesis when (a) multiple candidates
+compete, (b) the claim rests on a compiled source needing verification,
+or (c) evidence exists on both sides. If all evidence points one
+direction with no competition or conflict, skip to proof-conclusion.
 
-## Leads vs. hypotheses vs. conclusions
-
-- **Lead:** A clue from a compiled source — not evidence, just a
-  starting point. Convert to a hypothesis before testing.
-- **Hypothesis:** A testable claim, specific enough to verify or
-  refute. Creating one commits you to test it, not accept it.
-- **Conclusion:** A hypothesis that survived testing (→ proof-conclusion).
-
-## Steps
-
-### 1. Create a hypothesis
+## Create a hypothesis
 
 **Source awareness:** Before creating, identify WHERE the claim
 originated. If from a compiled source (family tree, online genealogy,
-published narrative), mark it as needing verification. Compiled sources
-contain claims by other researchers — they are leads, not evidence.
-The hypothesis exists specifically to drive targeted research that
-will confirm or refute the compiled claim against original records.
+published narrative), mark it as needing verification — compiled
+sources are leads, not evidence.
 
 **New hypotheses always start as `active`.** Even if existing
 evidence strongly favors the hypothesis, set `status: "active"` at
-creation time. The status reflects whether the hypothesis has been
-formally evaluated, not how strong the evidence looks at a glance.
-Promotion to `supported` happens in a separate evaluation step after
-the evidence has been explicitly reviewed against the criteria in
-Step 3.
+creation. Promotion to `supported` happens in a separate evaluation
+step after evidence is explicitly reviewed against the criteria below.
 
-When new evidence suggests a testable claim, append it with
-`research_append` — the tool assigns the `h_` id, so omit it from the
-entry:
+Create with `research_append({ section: "hypotheses", op: "append", entry: { claim, status: "active", supporting_assertion_ids: [], contradicting_assertion_ids: [], ruled_out: false, ruled_out_reason: null, notes, related_question_ids } })` — the tool assigns the `h_` id.
 
-```
-research_append({
-  section: "hypotheses",
-  op: "append",
-  entry: {
-    claim: "Patrick Flynn's father was Thomas Flynn of Luzerne County, not Thomas Flynn of Schuylkill County",
-    status: "active",
-    supporting_assertion_ids: [],
-    contradicting_assertion_ids: [],
-    ruled_out: false,
-    ruled_out_reason: null,
-    notes: "Alternative candidate to h_001. Luzerne County Thomas Flynn appears in the 1850 census with a Patrick of the right age. Needs investigation.",
-    related_question_ids: ["q_001"]
-  }
-})
-```
-
-**Claim requirements:**
-- State the claim positively and specifically
-- Include enough detail to distinguish from competing hypotheses
-- Reference the person(s) involved
+**Claim requirements:** State the claim positively and specifically,
+include enough detail to distinguish from competing hypotheses, and
+reference the person(s) involved.
 
 **related_question_ids:** Link the hypothesis to the research
-questions it helps answer. This lets question-selection see which
-hypotheses are active when choosing the next question.
+questions it helps answer.
 
-### 2. Link evidence to hypotheses
+## Link evidence
 
-As assertions are extracted, classified, and linked to persons,
-evaluate whether they support or contradict each active hypothesis.
+As assertions are extracted and linked to persons, evaluate whether
+they support or contradict each active hypothesis. Update with
+`research_append({ section: "hypotheses", op: "update", entryId: "h_NNN", fields: { supporting_assertion_ids: [...] } })` — pass only the fields that change.
 
 **Design research to refute, not just confirm.** For each active
-hypothesis, ask: "What evidence would DISPROVE this?" Then prioritize
+hypothesis, ask: "What evidence would DISPROVE this?" Prioritize
 searching for that evidence. A hypothesis that survives deliberate
-refutation attempts is far stronger than one supported only by
-confirmatory searches.
+refutation is far stronger than one with only confirmatory searches.
 
-Link evidence by updating the hypothesis in place with `research_append`
-(`op: "update"`, passing the `h_` id as `entryId` and only the fields
-that change), e.g.:
-
-```
-research_append({
-  section: "hypotheses",
-  op: "update",
-  entryId: "h_001",
-  fields: {
-    supporting_assertion_ids: ["a_004", "a_010", "a_013"]
-  }
-})
-```
-
-**Supporting evidence:** Assertions that make the claim more likely.
-Add their IDs to `supporting_assertion_ids`.
-
-Examples of supporting evidence for "Patrick's father was Thomas
-Flynn of Schuylkill County":
-- Patrick enumerated in Thomas's household (a_004)
-- 1860 census shows Patrick in Thomas's household (a_010)
-- Death certificate names Thomas as father (a_013)
-- Witness on Thomas's land deed is Patrick's known associate
+**Supporting evidence:** Assertions that make the claim more likely —
+add to `supporting_assertion_ids`.
 
 **Contradicting evidence:** Assertions that make the claim less
-likely. Add their IDs to `contradicting_assertion_ids`.
-
-Examples of contradicting evidence:
-- A different Thomas Flynn's will names a son Patrick of the right
-  age in an adjacent county
-- Patrick's death certificate names a birthplace inconsistent with
-  Thomas's residence
-- Timeline impossibilities between Patrick's events and Thomas's
-  documented life
+likely — add to `contradicting_assertion_ids`.
 
 **FAN evidence is regular assertions.** Witness patterns, neighbor
-correlations, godparent relationships — these are assertions about
-the subject's associates. Link them to hypotheses via
-`supporting_assertion_ids` like any other evidence. There is no
-special FAN entity.
+correlations, godparent relationships — link them via
+`supporting_assertion_ids` like any other evidence. No special FAN
+entity.
 
-### 3. Manage status transitions
+## Status transitions
 
 ```
 active ──► supported ──► (to proof-conclusion)
@@ -201,143 +124,73 @@ active ──► supported ──► (to proof-conclusion)
   └──► ruled_out
 ```
 
-**`active`** — The hypothesis has evidence accumulating but hasn't
-crossed a threshold in either direction. This is the starting state.
+**`active`** — Evidence accumulating, no threshold crossed. Starting state.
 
 **`supported`** — Transition when ALL of these are true:
 - At least one line of direct evidence supports the claim (an
   assertion with `evidence_type: "direct"` in the supporting list)
 - No unresolved contradictions remain (contradicting assertions have
   been explained, resolved via conflict-resolution, or outweighed)
-- The evidence is consistent — no timeline impossibilities when
-  testing this hypothesis
+- The evidence is consistent — no timeline impossibilities
 
 **Do NOT downgrade from `supported` to `active` for minor
 discrepancies.** Census age rounding (e.g., a 5-year birth year
-difference between two sources for the same person) is normal in
-19th-century records and does not constitute an "unresolved
-contradiction" warranting a status change. Adding contradicting
-evidence to the list does not automatically require a status
-downgrade — only link the evidence and leave the status unchanged
-unless the contradiction is material enough to undermine the core
-claim. When the user explicitly tells you a discrepancy "doesn't
-disprove anything," respect that assessment if it is genealogically
-reasonable.
+difference) is normal in 19th-century records and does not constitute
+an "unresolved contradiction." Adding contradicting evidence does not
+automatically require a status downgrade — only link the evidence and
+leave the status unchanged unless the contradiction is material enough
+to undermine the core claim. When the user explicitly tells you a
+discrepancy "doesn't disprove anything," respect that assessment if
+it is genealogically reasonable.
 
 **`ruled_out`** — Transition when ANY of these are true:
 - Evidence affirmatively refutes the claim (e.g., a will names all
   children and Patrick is absent — negative evidence)
-- Exhaustive elimination logic excludes the candidate (all other
-  possibilities have been investigated and eliminated; this one
-  doesn't fit)
+- Exhaustive elimination logic excludes the candidate
 - A chronological or biological impossibility makes the hypothesis
-  untenable (the candidate was dead before the subject was born, or
-  the candidate was too young to be a biological parent)
+  untenable (candidate was dead before subject was born, or too young
+  to be a biological parent)
 
 **Act on impossibilities immediately — unless this is a read-only
-review.** When the user asks you to update, check, or evaluate a
-hypothesis and the age arithmetic shows a candidate was 10 years old
-at the subject's birth, that is a biological impossibility — rule
-out the hypothesis in this interaction. Do NOT defer to
-conflict-resolution or hedge on person_evidence confidence when the
-link is rated `confident`. If the person_evidence connecting the
-contradicting assertion to the candidate is marked `confident`
-(match_score >= 0.80), treat the identification as settled and
-apply the ruling. **Exception:** if the user explicitly asks for a
-read-only summary/review ("just want to see the current state",
-"give me a summary", "where do things stand"), do NOT modify
-research.json — identify the issue in your response text but defer
-the actual file changes to a follow-up request.
+review.** When the user asks you to update or evaluate a hypothesis
+and the age arithmetic shows a candidate was 10 years old at the
+subject's birth, that is a biological impossibility — rule it out in
+this interaction. Do NOT defer to conflict-resolution or hedge on
+person_evidence confidence when the link is rated `confident`
+(match_score >= 0.80) — treat the identification as settled and apply
+the ruling. **Exception:** if the user explicitly asks for a read-only
+summary/review, do NOT modify research.json — identify the issue in
+your response text but defer changes to a follow-up request.
 
-Transition status with `research_append` (`op: "update"`). When ruling
-out, `ruled_out_reason` is REQUIRED — the validator rejects the entry
-if it is missing. Be specific:
+When ruling out, `ruled_out_reason` is REQUIRED — the validator
+rejects the entry if it is missing. Be specific: state the
+affirmative refutation, not just "insufficient evidence."
 
-```
-research_append({
-  section: "hypotheses",
-  op: "update",
-  entryId: "h_002",
-  fields: {
-    status: "ruled_out",
-    ruled_out: true,
-    ruled_out_reason: "Thomas Flynn of Luzerne County died in 1840, five years before Patrick's estimated birth in 1845. His will (probated 1840) names three children, none named Patrick. Timeline impossibility and negative evidence from probate."
-  }
-})
-```
+## Competing hypotheses
 
-Promotion to `supported` is the same call with
-`fields: { status: "supported" }`.
+When multiple hypotheses compete for the same conclusion (e.g., two
+candidate fathers): create one hypothesis per candidate, share
+`related_question_ids`, and note that the same assertion may support
+one and contradict another. Rule out candidates as evidence
+accumulates — the GPS process of elimination.
 
-### 4. Handle competing hypotheses
+## Example: Tracking the elimination process
 
-When multiple hypotheses compete for the same conclusion (e.g.,
-two candidate fathers), manage them as a group:
+| Hypothesis | Candidate | Status | Supporting | Contradicting |
+|---|---|---|---|---|
+| h_001 | Thomas Flynn, Schuylkill Co. | supported | a_004, a_010, a_013 | (none) |
+| h_002 | Thomas Flynn, Luzerne Co. | ruled_out | a_035 (same-name, right age) | a_036 (died 1840), a_037 (will excludes Patrick) |
+| h_003 | James Flynn, Carbon Co. | active | a_040 (Patrick age match) | (none yet) |
 
-1. **Create one hypothesis per candidate.** h_001 for Thomas of
-   Schuylkill, h_002 for Thomas of Luzerne, h_003 for James Flynn
-   of adjacent county.
+## Connect to downstream skills
 
-2. **Share related_question_ids.** All competing hypotheses link to
-   the same research question.
+- **timeline:** Request a hypothesis-testing timeline to check event coherence.
+- **conflict-resolution:** When supporting and contradicting evidence exist, specific conflicts may need resolution.
+- **proof-conclusion:** When a hypothesis reaches `supported`, it's ready for a proof conclusion.
 
-3. **Evidence can support one and contradict another.** The same
-   assertion might appear in h_001's supporting list and h_002's
-   contradicting list.
+## Present
 
-4. **Rule out candidates as evidence accumulates.** The GPS process
-   of elimination: research each candidate thoroughly, rule out
-   those that don't fit, and the remaining candidate is identified
-   by preponderance of evidence.
-
-5. **Track which candidates remain.** When presenting to the user,
-   summarize: "Two of three candidate fathers have been ruled out.
-   Thomas Flynn of Schuylkill County is the remaining candidate
-   with three supporting assertions and no contradictions."
-
-### 5. Update existing hypotheses
-
-When new evidence arrives (new assertions extracted, conflicts
-resolved, timelines updated), update the hypothesis in place with
-`research_append({ section: "hypotheses", op: "update", entryId, fields })`,
-passing only the fields that change:
-
-- Check if the evidence supports or contradicts any active hypothesis
-- Add assertion IDs to the appropriate list
-- Re-evaluate the status transition criteria
-- Update `notes` with the current state of reasoning
-
-**Don't change assertion IDs retroactively.** If an assertion was
-supporting and new analysis shows it's actually neutral, remove it
-from `supporting_assertion_ids`. But don't add it to
-`contradicting_assertion_ids` unless it actively contradicts the
-claim.
-
-### 6. Connect to downstream skills
-
-**To timeline:** Request a hypothesis-testing timeline to check
-whether events cohere. "Build a candidate timeline for h_002 —
-test whether Patrick's events fit Thomas of Luzerne County's
-documented life."
-
-**To conflict-resolution:** When supporting and contradicting
-evidence exist for the same hypothesis, specific conflicts may
-need resolution. "Assertions a_010 and a_035 disagree about
-Patrick's father — conflict-resolution should analyze them."
-
-**To proof-conclusion:** When a hypothesis reaches `supported`
-status, it's ready for a proof conclusion. "Hypothesis h_001 is
-supported by three direct evidence assertions with no contradictions.
-Ready for proof-conclusion."
-
-### 7. Present
-
-`research_append` validates each entry before persisting and writes
-nothing on `{ ok: false, errors }`, so there is no separate post-write
-`validate_research_schema` step. If a write returns `{ ok: false }`,
-surface the errors, correct the input, and retry the call — do not
-re-run the write blindly. Once the writes succeed, present the
-hypothesis state:
+After writes succeed, present the hypothesis state clearly:
 
 ```
 Hypothesis: h_001 — Patrick Flynn's father was Thomas Flynn
@@ -349,107 +202,48 @@ Supporting evidence (3):
   + a_010  1860 census: Patrick in Thomas's household (indirect)
   + a_013  Death certificate: "Father: Thomas Flynn" (direct)
 
-Contradicting evidence (0):
-  (none)
+Contradicting evidence (0):  (none)
 
 Competing hypotheses:
   h_002  Thomas Flynn of Luzerne County — RULED OUT
-         (died 1840, before Patrick's birth)
-  h_003  James Flynn of Carbon County — ACTIVE
-         (1 supporting, 0 contradicting — needs more research)
+  h_003  James Flynn of Carbon County — ACTIVE (needs more research)
 
 Next steps:
   - h_001 is ready for proof-conclusion
   - h_003 needs more evidence — suggest question-selection
 ```
 
-## Example: Tracking the elimination process
-
-**Research question:** q_001 — "Who were Patrick Flynn's parents?"
-
-**Three candidates identified:**
-
-| Hypothesis | Candidate | Status | Supporting | Contradicting |
-|-----------|-----------|--------|-----------|---------------|
-| h_001 | Thomas Flynn, Schuylkill Co. | supported | a_004, a_010, a_013 | (none) |
-| h_002 | Thomas Flynn, Luzerne Co. | ruled_out | a_035 (same-name, right age) | a_036 (died 1840), a_037 (will excludes Patrick) |
-| h_003 | James Flynn, Carbon Co. | active | a_040 (Patrick age match) | (none yet) |
-
-**Process:**
-1. h_002 ruled out first — death date impossibility + negative
-   evidence from probate
-2. h_003 still active — needs investigation (plan a search of
-   Carbon County records)
-3. h_001 supported — three direct/indirect evidence lines, no
-   contradictions. Even without ruling out h_003, h_001 can proceed
-   to proof-conclusion at `probable` tier. Reaching `proved` may
-   require ruling out h_003 or gathering additional independent
-   evidence.
-
-## Out-of-scope requests
-
-This repeats Step 0's scope gate for clarity: if the user asks to resolve a conflict, build a timeline, or write a proof conclusion, respond with ONE sentence naming the correct skill and stop. Do NOT invoke the other skill from within hypothesis-tracking. Do NOT perform any analysis, read any files, or produce any output beyond the redirect sentence.
-
 ## Important rules
 
 - **Scope discipline — only modify what the user asked about.** If the
-  user asks you to create h_003, only create h_003. If the user asks
-  you to link evidence to h_001, only modify h_001. Do NOT proactively
-  fix, update, or rule out other hypotheses you happen to notice have
-  issues. If you see that h_002 should be ruled out based on evidence
-  in its notes, mention it in your response text ("I noticed h_002
-  may need to be ruled out — want me to handle that next?") but do
-  NOT modify it unless the user explicitly asks. Each hypothesis
-  modification should be a deliberate user-initiated action, not an
-  opportunistic side-effect.
-
-- **Never modify the `conflicts` section.** The `conflicts` section in `research.json` is owned exclusively by the conflict-resolution skill. When framing a conflict's alternatives as competing hypotheses, create entries in `hypotheses` only. Do NOT update, annotate, or add fields to any conflict entry — not its `description`, `independence_analysis`, `competing_assertion_ids`, or any other field.
-
-- **Never create or modify the `questions` section.** Research questions are managed exclusively by the question-selection and research-exhaustiveness skills. If no questions exist yet, leave `related_question_ids` as an empty array `[]` — do NOT create `q_` entries to fill the reference.
-
-- **Never modify `tree.gedcomx.json`.** This skill only writes to the `hypotheses` section of `research.json`. Adding persons, sources, or relationships to `tree.gedcomx.json` is owned by other skills (init-project, record-extraction, tree-edit). Even if you notice missing persons or sources in the tree, do NOT fix them — note the gap in your response and let the user invoke the appropriate skill.
-
-- **Hypotheses are claims, not facts.** They're tested, not assumed.
-  The status should reflect the actual evidence, not the researcher's
-  preference.
-- **ruled_out_reason is mandatory.** Never silently rule out a
-  hypothesis. The reason is the audit trail — it prevents
-  accidentally resurrecting a ruled-out candidate later.
-- **FAN evidence is regular assertions.** No special treatment.
-  Link FAN findings via supporting_assertion_ids like any other
-  evidence.
+  user asks to create h_003, only create h_003. Do NOT proactively fix,
+  update, downgrade, or rule out other hypotheses you notice have issues
+  — even if you believe the status is wrong. Never change a hypothesis's
+  status unless the user explicitly asked you to evaluate that specific
+  hypothesis. Mention observations in your response text and let the
+  user decide.
+- **Never modify the `conflicts` section.** Owned exclusively by
+  conflict-resolution. Create entries in `hypotheses` only.
+- **Never create or modify the `questions` section.** Managed by
+  question-selection and research-exhaustiveness. Leave
+  `related_question_ids` as `[]` if no questions exist.
+- **Never modify `tree.gedcomx.json`.** This skill only writes to the
+  `hypotheses` section of `research.json`.
+- **Hypotheses are claims, not facts.** Status reflects actual
+  evidence, not researcher preference.
+- **ruled_out_reason is mandatory.** The reason is the audit trail —
+  it prevents accidentally resurrecting a ruled-out candidate.
 - **Don't confuse hypothesis status with proof tier.** A `supported`
   hypothesis is ready for proof-conclusion, but the proof tier
-  (Proved/Probable/Possible) depends on the full body of evidence,
-  exhaustive search, and conflict resolution — not just the
-  hypothesis status.
-- **Competing hypotheses share questions.** Use related_question_ids
-  to connect all candidates to the same research question. This
-  lets question-selection see the full competitive landscape.
-
-## Evidence integrity
-
-- **Never ignore conflicting evidence.** Every assertion that
-  conflicts with a hypothesis MUST go in `contradicting_assertion_ids`.
-  Record it first, resolve it later via conflict-resolution.
-- **Check for unstated assumptions.** When linking an assertion to a
-  hypothesis, ask: "Does this evidence actually support the claim, or
-  am I relying on an unstated assumption to connect them?" See the
-  three assumption categories in `references/hypothesis-gps-guidance.md`.
-  Unsound assumptions carry zero weight without independent evidence.
+  (Proved/Probable/Possible) depends on the full body of evidence.
+- **Never ignore conflicting evidence.** Every assertion that conflicts
+  with a hypothesis MUST go in `contradicting_assertion_ids`. Record
+  it first, resolve later via conflict-resolution.
+- **Check for unstated assumptions.** When linking evidence, ask: "Does
+  this actually support the claim, or am I relying on an unstated
+  assumption?" See the three assumption categories in
+  `references/hypothesis-gps-guidance.md`.
 
 ## Re-invocation behavior
 
-**Writes:** entries in the `hypotheses` section of `research.json`
-(`h_` ids), and their `status`, supporting/contradicting assertion
-lists, `ruled_out_reason`, and `superseded_by` fields. Mutable in
-place; superseded entries are marked, never deleted.
-
-**On repeat invocation:** updates an existing hypothesis's `status`,
-assertion lists, or ruled-out fields if new evidence has appeared.
-Creates a new `h_` entry only for a genuinely new hypothesis.
-
-**Do not duplicate:** if a hypothesis about the same person identity or
-relationship already exists as an `h_` entry, update it in place
-(or mark it superseded and link `superseded_by` to a new one). Do
-not write a second `h_` covering the same claim.
+Updates existing hypotheses in place. Creates a new `h_` entry only for a genuinely new hypothesis. If a hypothesis about the same claim already exists, update it (or mark it superseded via `superseded_by`) — do not duplicate.


### PR DESCRIPTION
Closes #412 

## Summary

<!-- 1-3 bullets describing what changed and why. -->

## Test plan

- [x] I ran `scripts/test.sh` and it passed.
- [x] For every skill whose files I changed (SKILL.md, scenarios, fixtures,
      tests, or supporting MCP/harness code), I ran `RunTests.bat <skill>`
      and committed an all-pass runlog under `eval/runlogs/unit/<skill>/`.
