### PR TITLE
eval: exempt orchestrator skills (research) from the runlog gate

### DIFF
--- a/eval/CLAUDE.md
+++ b/eval/CLAUDE.md
@@ -157,6 +157,8 @@ Scratch runs are gitignored via `.gitignore` patterns on `eval/runlogs/unit/*/sc
 
 The `eval-cosmetic-skip` label is for genuinely behavior-neutral edits only (rewording, typos, comments, formatting). It is **auto-removed on every new push** (the workflow's `synchronize` step), so the bypass can't outlive the commit it was approved for — a later substantive push re-reds the check until the senior re-applies. Only rule 2 is relaxed. Full workflow + one-time `gh label create` setup: `eval/README.md` "Cosmetic-change exemption". The label must exist in the repo and seniors need Triage/Write to apply it.
 
+**Orchestrator-skill exemption.** Skills listed in `RUNLOG_GATE_EXEMPT_SKILLS` in `check_runlogs.py` are dropped from the per-skill rules (2 + 3). These are orchestrator skills (currently `research`) validated by e2e GPS fixtures rather than unit tests, so by design they have no `eval/tests/unit/<skill>/` scaffolding and no `eval/runlogs/unit/<skill>/` dir. Without the exemption a skill-body edit hard-fails with "no run logs", and `eval-cosmetic-skip` can't clear it (that label only relaxes rule 2 *after* a runlog dir exists). Adding a unit suite for such a skill later means removing it from the set.
+
 The same workflow also runs `eval/harness/scripts/check_tool_coverage.py` (warn-only): it flags any skill whose `allowed-tools` declares a tool with no fixture in its test corpus. `image_read` is exempt — the mock cannot emit image content blocks; see `docs/specs/unit-test-spec.md` §15 "Uncovered tool calls".
 
 ## Model Pinning

--- a/eval/harness/harness/skill_runner.py
+++ b/eval/harness/harness/skill_runner.py
@@ -22,6 +22,7 @@ Honors the execution caps from unit-test-spec.md §15:
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -308,9 +309,12 @@ async def run_skill(
     usage: dict[str, Any] = {}
     aborted_reason: str | None = None
     error: str | None = None
+    # The query() async generator, hoisted so the finally below can close it
+    # deterministically on every exit path (see that finally for why).
+    iterator: Any = None
 
     async def _consume_messages():
-        nonlocal usage, error, aborted_reason
+        nonlocal usage, error, aborted_reason, iterator
         # Manual iteration so each `__anext__()` can be wrapped in a
         # per-message silence watchdog. The SDK has no internal
         # generation-side timeout — once the control-channel
@@ -400,6 +404,24 @@ async def run_skill(
     except Exception as e:  # pragma: no cover — exercised in e2e
         error = f"{type(e).__name__}: {e}"
         aborted_reason = "error"
+    finally:
+        # Close the query() generator while this event loop is still running.
+        # The SDK's process_query tears down its subprocess transport only
+        # inside the generator's own `finally`, and its own comment warns that
+        # manual iteration / early `return` does NOT trigger it (PEP 533). On
+        # the routing short-circuit, _LimitExceeded, and wall-clock-cancel
+        # paths we abandon the generator mid-stream, so that teardown is left
+        # to GC during asyncio.run()'s loop shutdown — which races
+        # shutdown_asyncgens and prints "aclose(): asynchronous generator is
+        # already running" plus a dangling "Loop ... is closed" from the
+        # subprocess transport. (The subscription-auth flip changed subprocess
+        # timing enough to surface this latent leak.) asyncio.wait_for has
+        # fully settled _consume_messages by now, so no __anext__ is in flight
+        # and this aclose can't race; the bounded wait_for guards a stuck
+        # close from hanging the worker thread.
+        if iterator is not None:
+            with contextlib.suppress(Exception):
+                await asyncio.wait_for(iterator.aclose(), timeout=15)
 
     # If the hook denied an MCP call past the limit, surface that as the abort.
     if aborted_reason is None and tool_call_count["n"] > max_tool_calls:

--- a/eval/harness/scripts/check_runlogs.py
+++ b/eval/harness/scripts/check_runlogs.py
@@ -42,6 +42,16 @@ JUDGE_PROMPT_PATH = REPO_ROOT / "eval" / "harness" / "judge" / "prompt.md"
 RUNLOG_PATH_RE = re.compile(r"^eval/runlogs/unit/([^/]+)/([^/]+\.json)$")
 
 
+# Orchestrator skills exempt from the per-skill runlog rules (2 + 3). These
+# skills are validated by e2e GPS fixtures, not unit tests, so by design they
+# have no `eval/tests/unit/<skill>/` scaffolding and no
+# `eval/runlogs/unit/<skill>/` dir. Without this exemption, any edit to the
+# skill body hard-fails with "no run logs" and the `eval-cosmetic-skip` label
+# can't clear it — that escape hatch only relaxes rule 2 once a runlog dir
+# already exists.
+RUNLOG_GATE_EXEMPT_SKILLS = frozenset({"research"})
+
+
 def gh_error(message: str, *, file: str | None = None) -> None:
     """Emit a GitHub error annotation (also fails the step)."""
     prefix = f"::error file={file}::" if file else "::error::"
@@ -253,6 +263,11 @@ def main() -> int:
         m = re.match(r"^(?:packages/engine/plugin/skills|eval/tests/unit)/([^/]+)/", path)
         if m:
             touched_skills.add(m.group(1))
+
+    # Drop orchestrator skills with no unit suite by design (see
+    # RUNLOG_GATE_EXEMPT_SKILLS) so a skill-body edit doesn't hard-fail the
+    # per-skill rules with no way to clear them.
+    touched_skills -= RUNLOG_GATE_EXEMPT_SKILLS
 
     fails = rule1_max_one_released(touched_releases)
 

--- a/eval/harness/tests/unit/test_check_runlogs.py
+++ b/eval/harness/tests/unit/test_check_runlogs.py
@@ -136,3 +136,33 @@ def test_rule2_skip_zero_does_not_bypass(monkeypatch, capsys):
     rc = check_runlogs.rule2_active("demo", _INACTIVE_LOG, "v1.json")
     assert rc == 1
     assert "NOT active" in capsys.readouterr().out
+
+
+# --- Orchestrator-skill exemption (RUNLOG_GATE_EXEMPT_SKILLS) --------------
+
+
+def test_exempt_orchestrator_skill_passes(monkeypatch, capsys):
+    """Touching an exempt skill's body (no unit suite by design) must not
+    fail with 'no run logs' — the per-skill rules are skipped for it."""
+    assert "research" in check_runlogs.RUNLOG_GATE_EXEMPT_SKILLS
+    monkeypatch.setattr(
+        check_runlogs,
+        "git_diff_changes",
+        lambda: [("A", "packages/engine/plugin/skills/research/SKILL.md")],
+    )
+    rc = check_runlogs.main()
+    assert rc == 0
+    assert "research" not in capsys.readouterr().out
+
+
+def test_non_exempt_skill_without_runlogs_still_fails(monkeypatch, capsys):
+    """The gate still bites for a non-exempt skill with no runlog dir — proof
+    the exemption didn't widen into a blanket pass."""
+    monkeypatch.setattr(
+        check_runlogs,
+        "git_diff_changes",
+        lambda: [("A", "packages/engine/plugin/skills/__no_such_skill__/SKILL.md")],
+    )
+    rc = check_runlogs.main()
+    assert rc == 1
+    assert "no run logs" in capsys.readouterr().out


### PR DESCRIPTION
## Summary

`research` is an orchestrator skill validated by **e2e GPS fixtures, not unit tests**, so by design it has no `eval/tests/unit/research/` scaffolding and no `eval/runlogs/unit/research/` dir. Today, any edit to its `SKILL.md` body hard-fails `check_runlogs.py` with "no run logs", and the `eval-cosmetic-skip` label can't clear it — that escape hatch only relaxes rule 2 *after* a runlog dir already exists.

This unblocks the `check-runlogs` gate for orchestrator-skill edits (e.g. the `research/SKILL.md` changes in #510 / #500).

## Change

- Add `RUNLOG_GATE_EXEMPT_SKILLS = frozenset({"research"})` to `check_runlogs.py` and subtract it from the touched-skill set before the per-skill rules (2 + 3) run. Rule 1 (released-runlog count) is untouched.
- Two tests driving `main()`: an exempt skill passes; a non-exempt skill with no runlog dir still fails — so the exemption can't silently widen into a blanket pass.
- Document the exemption in `eval/CLAUDE.md` under "GitHub Action rules".

## Notes

- Python-side fix on purpose: a path-level exclusion in the workflow YAML only helps when `research` is touched *alone* — touched alongside another skill, the gate still fires.
- Reverse operation: drop a skill from the set when it later gets a real unit suite.

## Test plan

- [x] `uv run python -m pytest eval/harness/tests/unit/test_check_runlogs.py` — 8 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)