### PR TITLE
Add Windows .bat wrappers for mcpb/plugin/electron + document the live-debug loop

### DIFF
--- a/.claude/skills/author-e2e-fixture/SKILL.md
+++ b/.claude/skills/author-e2e-fixture/SKILL.md
@@ -356,9 +356,18 @@ You should (path 1 — from a PID):
    chosen subset of the `person_read` tree; the stripped tree by
    removing the parents (and their attesting sources) from that tree.
 6. Validate `starting-research.json` against the schema.
-7. Report the files written (in place under `eval/tests/e2e/<slug>/`)
-   and point the user at the linter, the run (`make e2e-run` /
-   `RunE2E.bat`), and `/interpret-e2e-result`.
+7. Report the files written (in place under `eval/tests/e2e/<slug>/`),
+   then point the user at the next steps — give **both** the `make` target
+   and the Windows `.bat` for each:
+   - **Validate the stripping:** `make e2e-validate TEST=<slug>` /
+     `ValidateFixture.bat`.
+   - **Debug `/research` live (recommended next):** seed an editable Cowork
+     project with `make e2e-project TEST=<slug>` / `SeedProject.bat`, then
+     watch it in the Research Viewer with `make electron` / `Viewer.bat`.
+     (A live run does not block the tree-read tools, so the honest pass/fail
+     is always the headless run below.)
+   - **Score it headless:** `make e2e-run TEST=<slug>` / `RunE2E.bat`, then
+     `/interpret-e2e-result` for the verdict.
 
 *Path 2 (convert a finished project)* differs only at the start: instead
 of a PID + `person_read`, detect an open project whose `research.json`

--- a/eval/BuildMcpb.bat
+++ b/eval/BuildMcpb.bat
@@ -1,0 +1,35 @@
+@echo off
+cd %~dp0
+
+echo === Cowork Genealogy — Build the .mcpb desktop extension ===
+echo.
+echo Compiles the MCP server and packs releases\genealogy-mcp.mcpb, the
+echo Claude Desktop extension. After it builds, install it in Claude Desktop
+echo via Settings -^> Extensions -^> Install Extension, then FULLY QUIT and
+echo reopen Desktop. Rebuild and reinstall whenever the MCP server changes.
+echo.
+echo This runs the same scripts\build-mcpb.sh that "make mcpb" runs, so it
+echo needs a bash environment such as Git Bash or WSL.
+echo.
+
+where bash >nul 2>nul
+if errorlevel 1 (
+  echo ERROR: 'bash' was not found on PATH. Install Git for Windows
+  echo        ^(it includes Git Bash^) or use WSL -- or just install a
+  echo        released genealogy-mcp.mcpb instead of building it yourself.
+  pause
+  exit /b 1
+)
+
+cd ..
+call bash scripts/build-mcpb.sh
+set RC=%errorlevel%
+
+echo.
+if "%RC%"=="0" (
+  echo Built releases\genealogy-mcp.mcpb. Install it in Claude Desktop, then
+  echo fully quit and reopen Desktop.
+) else (
+  echo Build failed ^(exit %RC%^). Scroll up for the error.
+)
+pause

--- a/eval/BuildPlugin.bat
+++ b/eval/BuildPlugin.bat
@@ -1,0 +1,37 @@
+@echo off
+cd %~dp0
+
+echo === Cowork Genealogy — Build the Cowork plugin (.zip) ===
+echo.
+echo Packs releases\genealogy-plugin.zip, the skills and agents Cowork runs.
+echo After it builds, upload it in Claude Desktop -^> Cowork -^> Customize -^>
+echo Browse plugins -^> Upload custom plugin, then FULLY QUIT and reopen
+echo Desktop. Rebuild and reinstall whenever a skill under
+echo packages\engine\plugin changes.
+echo.
+echo This runs the same scripts\package-plugin.sh that "make plugin" runs, so
+echo it needs a bash environment such as Git Bash or WSL with the 'zip' command.
+echo.
+
+where bash >nul 2>nul
+if errorlevel 1 (
+  echo ERROR: 'bash' was not found on PATH. Install Git for Windows
+  echo        ^(it includes Git Bash^) or use WSL -- or just install a
+  echo        released genealogy-plugin.zip instead of building it yourself.
+  pause
+  exit /b 1
+)
+
+cd ..
+call bash scripts/package-plugin.sh
+set RC=%errorlevel%
+
+echo.
+if "%RC%"=="0" (
+  echo Built releases\genealogy-plugin.zip. Upload it in Cowork -^> Customize,
+  echo then fully quit and reopen Desktop.
+) else (
+  echo Build failed ^(exit %RC%^). If it says 'zip: command not found', install
+  echo zip ^(on WSL: sudo apt install zip^) or build on macOS/Linux.
+)
+pause

--- a/eval/README.md
+++ b/eval/README.md
@@ -36,6 +36,9 @@ eval/
   ValidateFixture.bat     Windows: e2e stripping linter
   ScratchResearch.bat     Windows: set up a throwaway dir to debug /research by hand
   SeedProject.bat         Windows: seed an editable Cowork project from a fixture (debug /research live)
+  Viewer.bat              Windows: launch the Research Viewer (Electron)
+  BuildMcpb.bat           Windows: build the .mcpb desktop extension (for the Cowork debug loop)
+  BuildPlugin.bat         Windows: build the Cowork plugin .zip (for the Cowork debug loop)
   RunCalibration.bat      Windows: run judge calibration (maintainer only)
 ```
 
@@ -309,10 +312,11 @@ equivalent in parentheses:
 7. `eval\RunE2E.bat` → enter the slug (`make e2e-run TEST=<slug>`) →
    live run (20–60 min, $3–10).
 8. `/interpret-e2e-result` → read the verdict.
-9. `eval\ViewE2E.bat` → enter the slug (`make e2e-view TEST=<slug>`) → open
-   `eval\.e2e-view` in the Research Viewer (its **Open Project** button) to
-   inspect the agent's final tree, research log, and each finding's
-   direct/indirect badge. Keep the viewer open — re-running refreshes it live.
+9. `eval\ViewE2E.bat` → enter the slug (`make e2e-view TEST=<slug>`) → launch
+   the Research Viewer with `eval\Viewer.bat` (`make electron`) and open
+   `eval\.e2e-view` in it (its **Open Project** button) to inspect the agent's
+   final tree, research log, and each finding's direct/indirect badge. Keep the
+   viewer open — re-running `ViewE2E.bat` refreshes it live.
 10. If it passes, commit the fixture (and optionally its run log), and
    open a PR.
 
@@ -324,6 +328,14 @@ for debugging *why* the agent did or didn't do something, and it keeps the
 test-improve loop fast: you watch the fix work in minutes instead of waiting
 20–60 min for a headless verdict.
 
+**First time (and after any skill or MCP-server change):** build and install
+the two artifacts so Cowork has the genealogy tools — `eval\BuildMcpb.bat`
+(`make mcpb`), then install the `.mcpb` in Claude Desktop → Settings →
+Extensions; and `eval\BuildPlugin.bat` (`make plugin`), then upload the plugin
+in Cowork → Customize → Browse plugins. **Fully quit and reopen** Claude
+Desktop after installing. The headless `RunE2E.bat` path doesn't use these (it
+runs the compiled engine directly), so this is only for the live Cowork loop.
+
 1. `eval\SeedProject.bat` → enter the slug (`make e2e-project TEST=<slug>`).
    Copies the fixture's starting state into `eval\.e2e-project\<slug>\` as a
    fresh, editable `research.json` + `tree.gedcomx.json`.
@@ -331,9 +343,10 @@ test-improve loop fast: you watch the fix work in minutes instead of waiting
    in to FamilySearch) and run `/research`. `init-project` is auto-skipped
    (research.json already exists); question-selection still runs unless the
    fixture seeds a question.
-3. Open the **same folder** in the Research Viewer to watch the research log,
-   assertions, and conflicts appear live — and ask Claude *"why didn't you
-   search X?"*, *"why direct, not indirect?"* as it works.
+3. Launch the Research Viewer — `eval\Viewer.bat` (`make electron`) — and open
+   the **same folder** in it (its **Open Project** button) to watch the
+   research log, assertions, and conflicts appear live — and ask Claude *"why
+   didn't you search X?"*, *"why direct, not indirect?"* as it works.
 
 **For understanding, not scoring.** A live run does **not** block the tree-read
 tools (`person_read` / `person_search` / `person_ancestors`) that the headless

--- a/eval/Viewer.bat
+++ b/eval/Viewer.bat
@@ -1,0 +1,24 @@
+@echo off
+cd %~dp0
+
+echo === Cowork Genealogy — Research Viewer ===
+echo.
+echo Launches the Electron Research Viewer. Use its "Open Project" button to
+echo open a project folder:
+echo   eval\.e2e-project\^<slug^>   a live debug run  ^(SeedProject.bat^)
+echo   eval\.e2e-view              a scored run       ^(ViewE2E.bat^)
+echo.
+echo Leave this window open while you work; close it or press Ctrl+C to stop
+echo the viewer.
+echo.
+
+where pnpm >nul 2>nul
+if errorlevel 1 (
+  echo ERROR: 'pnpm' was not found on PATH. Run Setup.bat first to install
+  echo        dependencies, or install pnpm from https://pnpm.io/installation
+  pause
+  exit /b 1
+)
+
+cd ..
+call pnpm --filter cowork-genealogy-ui dev

--- a/eval/slides/e2e-testing-kickoff.html
+++ b/eval/slides/e2e-testing-kickoff.html
@@ -199,6 +199,12 @@
     <div><span class="os nix">macOS / Linux</span><pre><code>make install
 echo 'ANTHROPIC_API_KEY=sk-...' &gt;&gt; eval/.env</code></pre></div>
   </div>
+  <h3>Build &amp; install the Cowork tools (once; redo when they change)</h3>
+  <div class="cmds">
+    <div><span class="os win">Windows</span><pre><code>BuildMcpb.bat   &amp;   BuildPlugin.bat</code></pre></div>
+    <div><span class="os nix">macOS / Linux</span><pre><code>make mcpb   &amp;&amp;   make plugin</code></pre></div>
+  </div>
+  <p class="sub">Install the <code>.mcpb</code> in Claude Desktop → Settings → Extensions and upload the plugin in Cowork → Customize, then <strong>fully quit + reopen</strong> Desktop. <em>Only the live Cowork loop (next slide) needs these — the headless run uses the compiled engine directly.</em></p>
   <h3>Each day, before running</h3>
   <div class="cmds">
     <div><span class="os win">Windows</span><pre><code>Login.bat        &amp; CheckSetup.bat</code></pre></div>
@@ -228,12 +234,12 @@ echo 'ANTHROPIC_API_KEY=sk-...' &gt;&gt; eval/.env</code></pre></div>
 <section class="slide">
   <h2>Debug live in Cowork — start here</h2>
   <div class="cmds">
-    <div><span class="os win">Windows</span><pre><code>SeedProject.bat</code></pre></div>
-    <div><span class="os nix">macOS / Linux</span><pre><code>make e2e-project TEST=&lt;slug&gt;</code></pre></div>
+    <div><span class="os win">Windows</span><pre><code>SeedProject.bat     then     Viewer.bat</code></pre></div>
+    <div><span class="os nix">macOS / Linux</span><pre><code>make e2e-project TEST=&lt;slug&gt;     then     make electron</code></pre></div>
   </div>
   <ul>
     <li>Seeds an editable project from the fixture's <strong>starting state</strong>. Open it in <strong>Claude Cowork</strong>, run <code>/research</code> — <strong>init-project is auto-skipped</strong>.</li>
-    <li>Open the same folder in the <strong>Research Viewer</strong>: watch the log, assertions, and conflicts appear <strong>live</strong>, and ask Claude <em>"why didn't you search X? why direct, not indirect?"</em></li>
+    <li>Launch the <strong>Research Viewer</strong> (<code>Viewer.bat</code> / <code>make electron</code>) and open the same folder in it: watch the log, assertions, and conflicts appear <strong>live</strong>, and ask Claude <em>"why didn't you search X? why direct, not indirect?"</em></li>
   </ul>
   <div class="card sub"><strong>Watch HOW it gets each answer</strong> — by searching records, not by reading the tree. Live runs don't block tree-reads, so a "find" via the tree won't hold up when you score.</div>
 </section>


### PR DESCRIPTION
## What

Three `make` targets had no Windows batch equivalent — `make mcpb`, `make plugin`, `make electron`. This adds them so the Windows genealogist team has a no-gaps column next to the `make` targets, and updates the docs so every e2e step is explained on both platforms.

### New batch files (in `eval/`, alongside the other e2e entry points)
- **`BuildMcpb.bat`** (= `make mcpb`) and **`BuildPlugin.bat`** (= `make plugin`) — call the same `scripts/build-mcpb.sh` / `scripts/package-plugin.sh` the make targets do (single source of truth, no reimplemented build logic). They guard on a missing `bash` and point at Git Bash/WSL or a released artifact; `BuildPlugin.bat` also calls out the `zip` dependency.
- **`Viewer.bat`** (= `make electron`) — runs `pnpm --filter cowork-genealogy-ui dev` (native, no bash needed), with a `pnpm`-missing guard.

All three are LF + UTF-8 and follow the existing `.bat` house style (`@echo off`, `cd %~dp0`, header, explanation, `pause`).

### Docs
- **`eval/README.md`** — list the three new files; add the build+install prerequisite and the viewer-launch command to the *Cowork live-debug* section; surface `Viewer.bat` in the headless view step.
- **`eval/slides/e2e-testing-kickoff.html`** — build+install the Cowork tools on the Setup slide; launch the viewer on the Debug-live slide.
- **`author-e2e-fixture` `SKILL.md`** — after writing a fixture, point the user at `e2e-project` + `electron` (plus validate/run/interpret), each with **both** the `make` target and the `.bat`.

## Notes
- Branched from `origin/main`, so this PR is scoped to just these changes.
- The build `.bat`s require a bash environment on Windows (same constraint the make targets already have, since they shell out to the `.sh` scripts); the wrappers fail loudly with guidance when `bash`/`pnpm` is absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)