### PR TITLE
Make e2e seed/view dirs visible in Finder (drop the leading dot)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,11 +48,11 @@ eval/runlogs/e2e/*/scratch_*
 
 # `make e2e-view` staging folder — the latest run's final state copied in as
 # research.json + tree.gedcomx.json for the Research Viewer to open. Throwaway.
-eval/.e2e-view/
+eval/e2e-view/
 
 # `make e2e-project` seeds editable Cowork projects from fixtures' starting
 # state here — debugging workspaces, not committed artifacts.
-eval/.e2e-project/
+eval/e2e-project/
 
 # Raw SDK session transcripts copied next to each e2e runlog. Multi-MB forensic
 # data (per-turn timestamps/tokens/thinking) for local latency+cost analysis —

--- a/Makefile
+++ b/Makefile
@@ -287,8 +287,8 @@ e2e-run: $(ENGINE_BUILD) ## Run ONE e2e benchmark fixture against live FamilySea
 	cd eval/harness && uv run python -m e2e.run_e2e --test $(TEST) $(if $(filter 0 false no off,$(RESUME_ON_STALL)),--no-resume-on-stall,)
 
 .PHONY: e2e-view
-e2e-view: ## Load the latest e2e run into the Research Viewer (eval/.e2e-view): make e2e-view TEST=kenneth-quass-death
-	# Copies the newest run's final tree + research.json into eval/.e2e-view/
+e2e-view: ## Load the latest e2e run into the Research Viewer (eval/e2e-view): make e2e-view TEST=kenneth-quass-death
+	# Copies the newest run's final tree + research.json into eval/e2e-view/
 	# (the shape the viewer opens + live-watches). Open that folder once in
 	# the viewer (its Open Project button, or `make electron`); later runs
 	# refresh it in place. Cheap + instant — and it picks the newest run, so
@@ -299,7 +299,7 @@ e2e-view: ## Load the latest e2e run into the Research Viewer (eval/.e2e-view): 
 .PHONY: e2e-project
 e2e-project: ## Seed an editable Cowork project from a fixture's STARTING state to debug /research live: make e2e-project TEST=kenneth-quass-death
 	# Copies the fixture's starting-research.json + starting-tree.gedcomx.json
-	# into eval/.e2e-project/<slug>/ as research.json + tree.gedcomx.json — a
+	# into eval/e2e-project/<slug>/ as research.json + tree.gedcomx.json — a
 	# fresh, editable project you open in Claude Cowork to run /research
 	# step-by-step (init-project auto-skipped) while watching it live in the
 	# Research Viewer. For DEBUGGING the process, NOT scoring: a live run does

--- a/eval/README.md
+++ b/eval/README.md
@@ -314,7 +314,7 @@ equivalent in parentheses:
 8. `/interpret-e2e-result` → read the verdict.
 9. `eval\ViewE2E.bat` → enter the slug (`make e2e-view TEST=<slug>`) → launch
    the Research Viewer with `eval\Viewer.bat` (`make electron`) and open
-   `eval\.e2e-view` in it (its **Open Project** button) to inspect the agent's
+   `eval\e2e-view` in it (its **Open Project** button) to inspect the agent's
    final tree, research log, and each finding's direct/indirect badge. Keep the
    viewer open — re-running `ViewE2E.bat` refreshes it live.
 10. If it passes, commit the fixture (and optionally its run log), and
@@ -337,7 +337,7 @@ Desktop after installing. The headless `RunE2E.bat` path doesn't use these (it
 runs the compiled engine directly), so this is only for the live Cowork loop.
 
 1. `eval\SeedProject.bat` → enter the slug (`make e2e-project TEST=<slug>`).
-   Copies the fixture's starting state into `eval\.e2e-project\<slug>\` as a
+   Copies the fixture's starting state into `eval\e2e-project\<slug>\` as a
    fresh, editable `research.json` + `tree.gedcomx.json`.
 2. Open that folder in **Claude Cowork** (genealogy plugin installed, logged
    in to FamilySearch) and run `/research`. `init-project` is auto-skipped

--- a/eval/SeedProject.bat
+++ b/eval/SeedProject.bat
@@ -3,7 +3,7 @@ cd %~dp0
 
 echo === Cowork Genealogy E2E — Seed an editable project to debug /research live ===
 echo.
-echo Copies a fixture's STARTING state into eval\.e2e-project\<slug>\ as a fresh,
+echo Copies a fixture's STARTING state into eval\e2e-project\<slug>\ as a fresh,
 echo editable project. Open it in Claude Cowork to run /research step-by-step, and
 echo open the same folder in the Research Viewer to watch it live.
 echo.

--- a/eval/ViewE2E.bat
+++ b/eval/ViewE2E.bat
@@ -3,7 +3,7 @@ cd %~dp0
 
 echo === Cowork Genealogy E2E — Load a run into the Research Viewer ===
 echo.
-echo Copies the latest run's final tree + research into eval\.e2e-view\ so you
+echo Copies the latest run's final tree + research into eval\e2e-view\ so you
 echo can open it in the Research Viewer. Cheap and instant — no rebuild, no login.
 echo.
 set /p SLUG="Which fixture (slug) do you want to view? (e.g. kenneth-quass-death): "
@@ -19,7 +19,7 @@ cd harness
 call uv run python -m e2e.view --test %SLUG%
 
 echo.
-echo Now open the  eval\.e2e-view  folder in the Research Viewer using its
+echo Now open the  eval\e2e-view  folder in the Research Viewer using its
 echo "Open Project" button. Keep the viewer open — run this again after each
 echo e2e run and the viewer refreshes live.
 pause

--- a/eval/Viewer.bat
+++ b/eval/Viewer.bat
@@ -5,8 +5,8 @@ echo === Cowork Genealogy — Research Viewer ===
 echo.
 echo Launches the Electron Research Viewer. Use its "Open Project" button to
 echo open a project folder:
-echo   eval\.e2e-project\^<slug^>   a live debug run  ^(SeedProject.bat^)
-echo   eval\.e2e-view              a scored run       ^(ViewE2E.bat^)
+echo   eval\e2e-project\^<slug^>   a live debug run  ^(SeedProject.bat^)
+echo   eval\e2e-view              a scored run       ^(ViewE2E.bat^)
 echo.
 echo Leave this window open while you work; close it or press Ctrl+C to stop
 echo the viewer.

--- a/eval/harness/e2e/project.py
+++ b/eval/harness/e2e/project.py
@@ -2,7 +2,7 @@
 
 `make e2e-project TEST=<slug>` (Windows: `SeedProject.bat`) copies a fixture's
 `starting-research.json` + `starting-tree.gedcomx.json` into a fresh, editable
-project folder — `eval/.e2e-project/<slug>/` — as `research.json` +
+project folder — `eval/e2e-project/<slug>/` — as `research.json` +
 `tree.gedcomx.json`. Open that folder in Claude Cowork to run `/research`
 step-by-step (init-project is auto-skipped because research.json already
 exists), and open the SAME folder in the Research Viewer to watch the run
@@ -29,7 +29,7 @@ from pathlib import Path
 
 from .orchestrator import DEFAULT_FIXTURES_ROOT, REPO_ROOT
 
-PROJECT_ROOT = REPO_ROOT / "eval" / ".e2e-project"
+PROJECT_ROOT = REPO_ROOT / "eval" / "e2e-project"
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/eval/harness/e2e/view.py
+++ b/eval/harness/e2e/view.py
@@ -2,7 +2,7 @@
 
 `make e2e-view TEST=<slug>` (Windows: `ViewE2E.bat`) copies the newest run's
 `*.final-research.json` + `*.final-tree.gedcomx.json` for a fixture into one
-stable folder — `eval/.e2e-view/` — renamed to `research.json` +
+stable folder — `eval/e2e-view/` — renamed to `research.json` +
 `tree.gedcomx.json`, the shape the Electron Research Viewer opens and
 live-watches.
 
@@ -24,7 +24,7 @@ from pathlib import Path
 
 from .orchestrator import DEFAULT_RUNLOG_ROOT, REPO_ROOT
 
-VIEW_DIR = REPO_ROOT / "eval" / ".e2e-view"
+VIEW_DIR = REPO_ROOT / "eval" / "e2e-view"
 
 
 def latest_final_pair(slug_dir: Path) -> tuple[Path, Path] | None:


### PR DESCRIPTION
## Problem

`make e2e-project` / `SeedProject.bat` seed into `eval/.e2e-project/<slug>/`, and `make e2e-view` / `ViewE2E.bat` stage into `eval/.e2e-view/`. The **leading dot hides these from macOS Finder**, so you can't select them in the file picker when opening the seeded project in Claude Cowork or the scored run in the Research Viewer.

## Fix

Drop the dot — `eval/e2e-project/` and `eval/e2e-view/`. They stay **under `eval/`**, stay **gitignored**, and now their names match the make targets 1:1 (`make e2e-project` ↔ `eval/e2e-project/`). `.e2e-view` had the identical bug, so both are fixed for consistency. (`.e2e-scratch` is unaffected — it's created outside the repo.)

## Scope (8 files, pure rename, no behavior change)

- `eval/harness/e2e/project.py` (`PROJECT_ROOT`) and `eval/harness/e2e/view.py` (`VIEW_DIR`) — the path source of truth — plus each module docstring. Print statements build from the constants, so the on-screen "open this folder" instructions update automatically.
- `.gitignore`, `Makefile` (help + recipe comments), `eval/SeedProject.bat`, `eval/ViewE2E.bat`, `eval/Viewer.bat`, `eval/README.md`.

## Verification

- No tests referenced the old path.
- `e2e.project` / `e2e.view` import; constants resolve to `eval/e2e-project` and `eval/e2e-view` (both visible).

Note: any leftover hidden `eval/.e2e-project/` / `eval/.e2e-view/` dirs from past runs are now orphaned and safe to delete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)