### PR TITLE
Share gitignored dev files across git worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
-node_modules/
+# Bare (no trailing slash) so it also ignores a node_modules *symlink* — the
+# form `make worktree-link` creates to share deps from the primary worktree.
+node_modules
 packages/engine/mcp-server/build/
 
 # Local Claude Code MCP-server registration. Machine-specific: it hardcodes

--- a/Makefile
+++ b/Makefile
@@ -94,6 +94,32 @@ clean-deps: ## Remove all node_modules (force a from-scratch install; use after 
 reinstall: clean-deps ## Clean every node_modules, then install EVERYTHING from scratch (the safe path after a Node upgrade)
 	$(MAKE) install
 
+# ── Worktrees ────────────────────────────────────────────────────
+# Git worktrees don't share gitignored files, so a freshly-added worktree lacks
+# the shared secrets (eval/.env) and installed deps (node_modules). These link
+# them to the primary worktree's copies. `install-hooks` makes new worktrees
+# self-link on `git worktree add`; `worktree-link` does it for an existing one.
+.PHONY: worktree-link
+worktree-link: ## Symlink shared gitignored files (secrets, node_modules) from the primary worktree into this one
+	@scripts/link-worktree.sh
+
+# Symlink our post-checkout hook into the shared .git/hooks (covers every
+# worktree of this clone). Opt-in and per-clone: it touches only local .git
+# state, never core.hooksPath, so it can't disable husky/other hook tooling and
+# is invisible to teammates who don't run it. Refuses to clobber a pre-existing
+# non-symlink hook.
+.PHONY: install-hooks
+install-hooks: ## Install the post-checkout hook so new worktrees auto-link shared files (opt-in, per-clone)
+	@common=$$(git rev-parse --path-format=absolute --git-common-dir); \
+	 main=$$(dirname "$$common"); \
+	 dst="$$common/hooks/post-checkout"; \
+	 if [ -e "$$dst" ] && [ ! -L "$$dst" ]; then \
+	   echo "install-hooks: $$dst already exists and is not a symlink — not overwriting. Merge manually." >&2; exit 1; \
+	 fi; \
+	 mkdir -p "$$common/hooks"; \
+	 ln -sfn "$$main/scripts/git-hooks/post-checkout" "$$dst"; \
+	 echo "✓ installed post-checkout hook -> $$dst"
+
 # ── Dev (the POC: run a server + a web client in two terminals) ──
 # See DEVELOPMENT.md for the full matrix. The web target must match the server's
 # port — `web` ↔ :1837 (server / server-e2b, real FamilySearch login), `web-dev`

--- a/scripts/git-hooks/post-checkout
+++ b/scripts/git-hooks/post-checkout
@@ -1,0 +1,18 @@
+#!/bin/sh
+# post-checkout — link shared gitignored dev files into a newly-added worktree.
+#
+# Args: <old-HEAD> <new-HEAD> <is-branch-checkout>. On `git worktree add` (and
+# `git clone`) <old-HEAD> is the null SHA; on an ordinary branch switch it is a
+# real SHA. We act only on the null-SHA case, and link-worktree.sh itself
+# no-ops in the primary worktree — so this hook is inert for clones and normal
+# checkouts and does real work only for a fresh linked worktree.
+#
+# Installed into the shared .git/hooks/ by `make install-hooks` (NOT via
+# core.hooksPath, so it cannot disable husky or other hook tooling). The source
+# of truth is this file, scripts/git-hooks/post-checkout, tracked in the repo.
+[ "$1" = "0000000000000000000000000000000000000000" ] || exit 0
+root=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0
+if [ -x "$root/scripts/link-worktree.sh" ]; then
+  "$root/scripts/link-worktree.sh" || true   # never fail the checkout
+fi
+exit 0

--- a/scripts/link-worktree.sh
+++ b/scripts/link-worktree.sh
@@ -1,0 +1,51 @@
+#!/bin/sh
+# Symlink shared, gitignored dev files from the primary worktree into the
+# current linked worktree.
+#
+# Git worktrees deliberately do NOT share the working tree, so per-worktree
+# secrets (eval/.env, apps/server/.env) and installed deps (node_modules) are
+# absent in a freshly-added worktree. This links them to the primary worktree's
+# copies: one source of truth, nothing copied, no secrets in the environment.
+#
+# Idempotent and safe to re-run. A no-op in the primary worktree. Run by hand
+# (`make worktree-link`) or automatically from the post-checkout hook that
+# `make install-hooks` installs.
+set -eu
+
+# Files/dirs to link, repo-relative. A path missing in the primary worktree is
+# skipped; a real (non-symlink) file already present here is left untouched, so
+# a worktree can still hold its own override.
+SHARED_PATHS='
+eval/.env
+apps/server/.env
+packages/engine/mcp-server/node_modules
+'
+
+common=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null) || {
+  echo "link-worktree: not inside a git repository" >&2
+  exit 1
+}
+# The primary worktree is the parent of the shared common .git directory.
+main=$(dirname "$common")
+here=$(git rev-parse --show-toplevel)
+
+if [ "$main" = "$here" ]; then
+  echo "link-worktree: in the primary worktree ($here) — nothing to link."
+  exit 0
+fi
+
+linked=0
+for rel in $SHARED_PATHS; do
+  src="$main/$rel"
+  dst="$here/$rel"
+  [ -e "$src" ] || continue                  # primary doesn't have it → skip
+  if [ -e "$dst" ] && [ ! -L "$dst" ]; then   # real file/dir already here → keep
+    echo "link-worktree: keeping existing $rel (not a symlink)"
+    continue
+  fi
+  mkdir -p "$(dirname "$dst")"
+  ln -sfn "$src" "$dst"
+  echo "link-worktree: linked $rel -> $src"
+  linked=$((linked + 1))
+done
+echo "link-worktree: done ($linked linked) in $here"


### PR DESCRIPTION
## Problem

Git worktrees don't share the working tree, so a freshly-added worktree lacks per-worktree gitignored files — secrets (`eval/.env`) and installed deps (`node_modules`). The eval and e2e harnesses load `eval/.env` **relative to their own worktree**, so in any worktree but the primary they silently skip the judge (every test then defaults to `fail` for lack of grading) and lack the mcp-server build deps.

All three harness env-loaders (`auth.py`, `e2e/run_e2e.py`, `e2e/preflight.py`) are worktree-local *and* let a shell-set key win — but exporting the key to the shell puts it in every process's environment, which we don't want. Symlinking from the primary keeps the secret a file (one source of truth), never copied, never in the environment.

## What this adds

- **`scripts/link-worktree.sh`** — symlink `eval/.env`, `apps/server/.env`, and `packages/engine/mcp-server/node_modules` from the primary worktree into the current one. Idempotent, no-ops in the primary, skips files the primary lacks, won't clobber a real (non-symlink) file.
- **`scripts/git-hooks/post-checkout`** — runs the link script automatically on `git worktree add` (guarded on the null-SHA prev HEAD, so it's inert for clones and ordinary branch switches).
- **`make worktree-link`** — link the current worktree by hand.
- **`make install-hooks`** — symlink the hook into the shared `.git/hooks` (opt-in, per-clone). Deliberately **not** `core.hooksPath`, so it can't disable husky/other hook tooling; refuses to clobber a foreign hook.
- **`.gitignore`**: `node_modules/` → `node_modules` so the shared-deps *symlink* form is ignored too.

## Usage

Once per clone, after this lands on `main`:

```
make install-hooks
```

Then every `git worktree add` self-links. For a worktree created before installing the hook: `make worktree-link`.

## Non-worktree users: zero impact

The hook lives in local `.git/` (never distributed), is opt-in, and is a no-op on clone / branch-switch. Nobody who doesn't run `make install-hooks` is affected, and it can't clobber existing hook tooling.

## Testing

Verified: linking + idempotency, hook dispatch (null vs. real SHA), `install-hooks` symlink + clobber-guard, and that the node_modules symlink is now gitignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
