### PR TITLE
Fix record-extraction eval timeouts: accept stringified `ops` batches

### DIFF
--- a/docs/specs/research-append-tool-spec.md
+++ b/docs/specs/research-append-tool-spec.md
@@ -181,6 +181,19 @@ The **persisted shape is byte-identical** to the single-op form; `ops` changes o
 the number of write calls, so no `research.json` schema, validator, web-mirror, or
 fixture change is required (the reason batching is low-risk).
 
+**Stringified-argument tolerance.** The model occasionally serializes a large or
+deeply nested argument as a JSON **string** rather than inline JSON — the ~25 KB
+`ops` batch of a full record is exactly the size that triggers it. Because the input
+schema declares `ops` as an array and `entry`/`fields` as objects, a string value is
+unambiguously a mis-serialization. The tool therefore JSON-parses a string-valued
+`ops`/`entry`/`fields` before any shape check (`src/utils/coerce-json-arg.ts`); an
+unparseable string falls through to the normal, specific error (e.g. ``` `ops` must
+be a non-empty array ```). This is not a supported call form — callers should still
+pass real JSON — but it stops a correct-but-stringified batch from being rejected and
+driving the model into a slow one-op-per-call fallback (the root cause of the
+`record-extraction` eval wall-clock timeouts, 2026-06-30). `tree_edit` applies the
+same tolerance to its `ops` and single-op nested objects.
+
 ---
 
 ## 4. Persistence — validate-before-persist, atomic, single-file

--- a/docs/specs/tree-edit-tool-spec.md
+++ b/docs/specs/tree-edit-tool-spec.md
@@ -216,6 +216,18 @@ Semantics (decision: `docs/plan/e2e-research-runtime-speedup-plan.md` §6 Q1):
 
 The persisted tree shape is unchanged — `ops` changes only the number of write calls.
 
+**Stringified-argument tolerance.** The model occasionally serializes a large or
+deeply nested argument as a JSON **string** rather than inline JSON. Since the input
+schema declares `ops` as an array and the single-op payloads (`fact`, `name`,
+`person`, `relationship`, `source`) as objects, a string value is unambiguously a
+mis-serialization. The tool JSON-parses a string-valued `ops` (and those single-op
+nested objects) before any shape check (`src/utils/coerce-json-arg.ts`); an
+unparseable string falls through to the normal error (e.g. ``` `ops` must be a
+non-empty array ```). Not a supported call form — callers should pass real JSON — but
+it stops a correct-but-stringified batch from being rejected into a slow
+one-op-per-call fallback. `research_append` applies the same tolerance to its
+`ops`/`entry`/`fields`; see that spec (§3.3) for the originating rationale.
+
 ---
 
 ## 5. Persistence — validate-before-persist, atomic, tree-only

--- a/eval/harness/harness/skill_runner.py
+++ b/eval/harness/harness/skill_runner.py
@@ -23,6 +23,8 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import re
+import sys
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -103,6 +105,39 @@ def _check_sdk_version() -> str | None:
     except (ValueError, TypeError):
         pass
     return None
+
+
+# When the harness abandons a run mid-stream (wall-clock / silence abort or
+# a routing short-circuit), the SDK tears down the CLI subprocess while it may
+# still be mid-hook. The CLI's hook callback then tries a control-channel
+# `sendRequest` on the already-closed stream, throws "Stream closed", and bun
+# dumps a minified JS stack + code frame to the subprocess's stderr. It is pure
+# teardown noise — the outcome is already recorded — but on any suite with
+# aborts it floods the console (see the `record-extraction` run: four aborts,
+# dozens of stack-trace lines). Registering a `stderr` callback is also the
+# only way to intercept it at all: with `stderr=None` the SDK leaves the
+# subprocess stderr attached to our own fd (subprocess_cli.py pipes it only
+# when a callback is set), so we could not filter it from Python. This callback
+# drops the known-noise lines and forwards everything else, so a genuine CLI
+# diagnostic still reaches the console.
+_CLI_NOISE_PATTERNS = (
+    re.compile(r"Error in hook callback"),
+    re.compile(r"Stream closed"),
+    re.compile(r"^\s*at\s"),  # JS stack frames ("at sendRequest (...)")
+    re.compile(r"^\s*\d+\s*\|"),  # bun code-frame lines ("9403 | ...")
+    re.compile(r"/\$bunfs/"),  # bun bundled-path frames
+)
+
+
+def _filter_cli_stderr(line: str) -> None:
+    """SDK `stderr` callback: swallow CLI teardown noise, forward the rest.
+
+    The SDK strips the trailing newline and skips blank lines before calling
+    us, so `line` is a non-empty, right-stripped string.
+    """
+    if any(p.search(line) for p in _CLI_NOISE_PATTERNS):
+        return
+    sys.stderr.write(line + "\n")
 
 
 class _LimitExceeded(Exception):
@@ -302,6 +337,10 @@ async def run_skill(
         max_turns=max_turns,
         env=env_for_sdk(auth),
         hooks={"PreToolUse": [HookMatcher(matcher=None, hooks=[pretool_hook])]},
+        # Intercept the CLI subprocess stderr so we can drop teardown noise
+        # (see _filter_cli_stderr) instead of letting it flood the console on
+        # aborted runs. Setting this is also what makes the SDK pipe stderr.
+        stderr=_filter_cli_stderr,
     )
 
     text_chunks: list[str] = []

--- a/packages/engine/mcp-server/src/tools/research-append.ts
+++ b/packages/engine/mcp-server/src/tools/research-append.ts
@@ -15,6 +15,7 @@ import { readFile } from "fs/promises";
 import { validateParsed } from "../validation/validator.js";
 import type { ValidationError } from "../validation/types.js";
 import { atomicWriteJson } from "../utils/project-io.js";
+import { coerceJsonArg } from "../utils/coerce-json-arg.js";
 
 // ─── Section configuration (the per-section table phases 2–3 extend) ─────────
 
@@ -358,6 +359,14 @@ export async function researchAppend(
   input: ResearchAppendInput,
 ): Promise<ResearchAppendResult> {
   const { projectPath } = input;
+
+  // Recover object/array args the model serialized as JSON strings (see
+  // coerceJsonArg) before any shape checks, so a correct-but-stringified batch
+  // isn't rejected as "`ops` must be a non-empty array" and driven into a slow
+  // one-op-per-call fallback.
+  input.ops = coerceJsonArg(input.ops) as ResearchAppendOp[] | undefined;
+  input.entry = coerceJsonArg(input.entry) as Record<string, unknown> | undefined;
+  input.fields = coerceJsonArg(input.fields) as Record<string, unknown> | undefined;
 
   try {
     const research = await readJson(projectPath, "research.json");

--- a/packages/engine/mcp-server/src/tools/tree-edit.ts
+++ b/packages/engine/mcp-server/src/tools/tree-edit.ts
@@ -23,6 +23,7 @@ import type { ValidationError } from "../validation/types.js";
 import { atomicWriteJson, backupIfExists } from "../utils/project-io.js";
 import { maxIdNum, nextId } from "../utils/gedcomx-ids.js";
 import { resolveStandardPlace } from "../utils/place-resolver.js";
+import { coerceJsonArg } from "../utils/coerce-json-arg.js";
 
 export type TreeEditOperation =
   | "add_fact"
@@ -301,6 +302,18 @@ async function applyOperation(
 
 export async function treeEdit(input: TreeEditInput): Promise<TreeEditResult> {
   const { projectPath } = input;
+
+  // Recover object/array args the model serialized as JSON strings (see
+  // coerceJsonArg) before any shape checks — the batch `ops` array most
+  // importantly, plus the single-op nested objects — so a correct-but-
+  // stringified payload isn't rejected and driven into a slow fallback.
+  input.ops = coerceJsonArg(input.ops) as TreeEditOp[] | undefined;
+  input.fact = coerceJsonArg(input.fact) as SimplifiedFact | undefined;
+  input.name = coerceJsonArg(input.name) as SimplifiedName | undefined;
+  input.person = coerceJsonArg(input.person) as SimplifiedPerson | undefined;
+  input.relationship = coerceJsonArg(input.relationship) as SimplifiedRelationship | undefined;
+  input.source = coerceJsonArg(input.source) as SimplifiedSourceDescription | undefined;
+
   try {
     const tree = (await readJson(projectPath, "tree.gedcomx.json")) as SimplifiedGedcomX;
     const research = await readJson(projectPath, "research.json");

--- a/packages/engine/mcp-server/src/utils/coerce-json-arg.ts
+++ b/packages/engine/mcp-server/src/utils/coerce-json-arg.ts
@@ -1,0 +1,27 @@
+// Recover a nested object/array tool argument that the model serialized as a
+// JSON *string* instead of inline JSON.
+//
+// LLMs occasionally emit a structured tool argument as an opaque JSON string,
+// most often when the argument is large or deeply nested — a record's full
+// `research_append` / `tree_edit` `ops` batch can be ~25 KB, which is exactly
+// the size that pushes the model toward stringifying. The MCP input schema
+// declares these fields as `array`/`object`, so a string value is
+// unambiguously a mis-serialization of the intended structure, not a legal
+// input. Left unhandled it fails the tool's `Array.isArray` / shape checks
+// ("`ops` must be a non-empty array"), and the model — seeing the rejection —
+// falls back to one entry per call, exploding a single batched write into
+// dozens of sequential turns (the root cause of the record-extraction eval
+// wall-clock timeouts).
+//
+// This helper is deliberately conservative: it only touches strings, and only
+// substitutes the parsed value when the string parses as JSON. A non-string
+// passes through untouched, and an unparseable string is returned as-is so the
+// tool's normal validation still emits the correct, specific error.
+export function coerceJsonArg(value: unknown): unknown {
+  if (typeof value !== "string") return value;
+  try {
+    return JSON.parse(value);
+  } catch {
+    return value;
+  }
+}

--- a/packages/engine/mcp-server/tests/tools/research-append.test.ts
+++ b/packages/engine/mcp-server/tests/tools/research-append.test.ts
@@ -808,4 +808,69 @@ describe("research_append (batch ops)", () => {
     expect(r.ok).toBe(false);
     expect(await readFile(join(dir, "research.json"), "utf-8")).toBe(before);
   });
+
+  // ── String-coercion: the model sometimes serializes a large `ops` batch as a
+  // JSON *string* (see coerce-json-arg.ts). The tool recovers it rather than
+  // rejecting it and driving the model into slow one-op-per-call writes.
+  it("(coerce) applies an ops batch that arrives as a JSON string", async () => {
+    await writeProject(); // seeded with sources [src_001]
+    const opsArray = [
+      { section: "sources", op: "append", entry: noId(validSource("x")) },
+      { section: "sources", op: "append", entry: noId(validSource("y")) },
+    ];
+    const r = await researchAppend({
+      projectPath: dir,
+      ops: JSON.stringify(opsArray) as any,
+    });
+    expect(r.ok).toBe(true);
+    if (!r.ok || !("results" in r)) return;
+    expect(r.results.map((x) => x.entryId)).toEqual(["src_002", "src_003"]);
+    expect((await readResearch()).sources.map((s: any) => s.id)).toEqual(["src_001", "src_002", "src_003"]);
+  });
+
+  it("(coerce) recovers a stringified ops batch even with redundant top-level section/op (the observed record-extraction failure)", async () => {
+    await writeProject();
+    const opsArray = [
+      { section: "sources", op: "append", entry: noId(validSource("x")) }, // → src_002
+      { section: "assertions", op: "append", entry: noId(validAssertion("x", "src_002")) }, // forward ref
+    ];
+    // Exactly what Sonnet emitted: ops as a JSON string AND leftover top-level
+    // section/op (ignored once ops is present).
+    const r = await researchAppend({
+      projectPath: dir,
+      section: "sources",
+      op: "append",
+      ops: JSON.stringify(opsArray) as any,
+    });
+    expect(r.ok).toBe(true);
+    if (!r.ok || !("results" in r)) return;
+    expect(r.results.map((x) => `${x.section}:${x.entryId}`)).toEqual(["sources:src_002", "assertions:a_002"]);
+    expect((await readResearch()).assertions[1].source_id).toBe("src_002");
+  });
+
+  it("(coerce) applies a single-op append whose entry arrives as a JSON string", async () => {
+    await writeProject();
+    const r = await researchAppend({
+      projectPath: dir,
+      section: "sources",
+      op: "append",
+      entry: JSON.stringify(noId(validSource("x"))) as any,
+    });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect((await readResearch()).sources.map((s: any) => s.id)).toEqual(["src_001", "src_002"]);
+  });
+
+  it("(coerce) leaves a non-JSON ops string alone → the existing non-empty-array error, writes nothing", async () => {
+    await writeProject();
+    const before = await readFile(join(dir, "research.json"), "utf-8");
+    const r = await researchAppend({
+      projectPath: dir,
+      ops: "not valid json" as any,
+    });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.errors.join(" ")).toMatch(/non-empty/);
+    expect(await readFile(join(dir, "research.json"), "utf-8")).toBe(before);
+  });
 });

--- a/packages/engine/mcp-server/tests/tools/tree-edit.test.ts
+++ b/packages/engine/mcp-server/tests/tools/tree-edit.test.ts
@@ -437,4 +437,44 @@ describe("tree_edit (batch ops)", () => {
     if (r.ok) return;
     expect(r.errors.join(" ")).toMatch(/non-empty/);
   });
+
+  // ── String-coercion: the model sometimes serializes a large `ops` batch (or a
+  // single-op nested object) as a JSON *string* (see coerce-json-arg.ts). The
+  // tool recovers it rather than rejecting it into a slow one-op-per-call fallback.
+  it("(coerce) applies an ops batch that arrives as a JSON string", async () => {
+    await writeProject(onePerson());
+    const opsArray = [
+      { operation: "add_source", source: { title: "1850 Census" } }, // → S1
+      { operation: "add_person", person: { gender: "Female", names: [{ given: "Mary", surname: "Smith" }] } }, // → I2
+      { operation: "add_fact", personId: "I1", fact: { type: "Death", date: "1899" } }, // → F2
+    ];
+    const r = await treeEdit({ projectPath: dir, ops: JSON.stringify(opsArray) as any });
+    expect(r.ok).toBe(true);
+    if (!r.ok || !("results" in r)) return;
+    expect(r.results.map((x) => x.operation)).toEqual(["add_source", "add_person", "add_fact"]);
+    expect(r.results[1].assignedIds?.person).toBe("I2");
+    expect((await readTree()).persons.map((p: any) => p.id)).toEqual(["I1", "I2"]);
+  });
+
+  it("(coerce) applies a single-op whose nested object arrives as a JSON string", async () => {
+    await writeProject(onePerson());
+    const r = await treeEdit({
+      projectPath: dir,
+      operation: "add_source",
+      source: JSON.stringify({ title: "Stringified source" }) as any,
+    });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect((await readTree()).sources.map((s: any) => s.title)).toEqual(["Stringified source"]);
+  });
+
+  it("(coerce) leaves a non-JSON ops string alone → the existing non-empty-array error, writes nothing", async () => {
+    await writeProject(onePerson());
+    const before = await readFile(join(dir, "tree.gedcomx.json"), "utf-8");
+    const r = await treeEdit({ projectPath: dir, ops: "not valid json" as any });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.errors.join(" ")).toMatch(/non-empty/);
+    expect(await readFile(join(dir, "tree.gedcomx.json"), "utf-8")).toBe(before);
+  });
 });


### PR DESCRIPTION
## Problem

The `record-extraction` eval was timing out ~a third of its tests at the 600s wall-clock cap. Root cause, from the run log:

The skill correctly asks `research_append` to persist a whole record in one batched `ops` call. But the model serializes the ~25 KB `ops` array as a **JSON string** rather than inline JSON — in **10/10** heavy runs. The tool rejects a string `ops` with `"ops must be a non-empty array"`, so the model falls back to **one append per call** — 20–40 sequential turns per record, which blows the 600s cap. The tests that aborted were doing legitimate work; they just crossed the cap mid-write.

## Fix

Coerce at the tool boundary, which fixes both eval and production (both run the real compiled tool):

- **`src/utils/coerce-json-arg.ts`** — `JSON.parse` a string-valued object/array arg; pass non-strings and unparseable strings through unchanged so the normal, specific validation error still fires.
- **`research_append`** coerces `ops`/`entry`/`fields`; **`tree_edit`** coerces `ops` plus the single-op nested objects (`fact`/`name`/`person`/`relationship`/`source`) — it has the identical vulnerability and the skill batches it too.
- Vitests reproduce the exact observed failure (stringified `ops` + redundant top-level `section`/`op`) and the parse-failure path. Both tool specs document the tolerance.

## Verification

- Full mcp-server Vitest suite green (1205 tests).
- A harness run confirms the timeouts are gone end-to-end: the stringified batch is now **accepted** (`research_append` calls drop from 20–40 to ~2, no single-op fallback), durations fall well under cap, and all deterministic validators pass. (Judge-graded quality numbers pending a keyed re-run.)

## Also included

An eval-harness quality-of-life fix: register an SDK `stderr` callback that drops the Claude Code CLI subprocess's teardown noise (hook-callback "Stream closed" stacks emitted when an aborted run is torn down mid-hook), which otherwise floods the console on any suite with aborts. Genuine diagnostics still pass through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
