### PR TITLE
Re-land cross-platform Node builds (.mcpb + plugin) onto main — fixes Windows bash requirement

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -360,15 +360,16 @@ eval-ui-test: $(EVAL_APP_DEPS) ## Eval CRUD UI tests — eval/app (vitest)
 	cd eval/app && npm test
 
 # ── Artifacts (the existing Cowork/desktop deliverables) ─────────
-# build-mcpb.sh and build-image.sh already self-install + self-build the engine,
-# so these stay as thin wrappers (no hidden dep to surface here).
+# The build scripts are cross-platform Node (no bash / no `zip`, so the Windows
+# BuildMcpb.bat / BuildPlugin.bat call them too) and self-install + self-build
+# the engine, so these stay thin wrappers (no hidden dep to surface here).
 .PHONY: mcpb
 mcpb: ## Build the .mcpb desktop extension
-	bash scripts/build-mcpb.sh
+	node scripts/build-mcpb.mjs
 
 .PHONY: plugin
 plugin: ## Build the Cowork plugin .zip
-	bash scripts/package-plugin.sh
+	node scripts/package-plugin.mjs
 
 # Marker recording the commit `make sandbox-image` last built the E2B template
 # from, so `deploy-preflight` can warn when in-sandbox agent code changed since.

--- a/eval/BuildMcpb.bat
+++ b/eval/BuildMcpb.bat
@@ -1,28 +1,27 @@
 @echo off
 cd %~dp0
 
-echo === Cowork Genealogy — Build the .mcpb desktop extension ===
+echo === Cowork Genealogy - Build the .mcpb desktop extension ===
 echo.
 echo Compiles the MCP server and packs releases\genealogy-mcp.mcpb, the
 echo Claude Desktop extension. After it builds, install it in Claude Desktop
 echo via Settings -^> Extensions -^> Install Extension, then FULLY QUIT and
 echo reopen Desktop. Rebuild and reinstall whenever the MCP server changes.
 echo.
-echo This runs the same scripts\build-mcpb.sh that "make mcpb" runs, so it
-echo needs a bash environment such as Git Bash or WSL.
+echo This runs scripts\build-mcpb.mjs with Node (same as "make mcpb"). No bash
+echo needed -- just Node, which Setup.bat already installs.
 echo.
 
-where bash >nul 2>nul
+where node >nul 2>nul
 if errorlevel 1 (
-  echo ERROR: 'bash' was not found on PATH. Install Git for Windows
-  echo        ^(it includes Git Bash^) or use WSL -- or just install a
-  echo        released genealogy-mcp.mcpb instead of building it yourself.
+  echo ERROR: 'node' was not found on PATH. Install Node.js, or run Setup.bat
+  echo        first -- the eval setup installs the dependencies this needs.
   pause
   exit /b 1
 )
 
 cd ..
-call bash scripts/build-mcpb.sh
+call node scripts\build-mcpb.mjs
 set RC=%errorlevel%
 
 echo.

--- a/eval/BuildPlugin.bat
+++ b/eval/BuildPlugin.bat
@@ -1,7 +1,7 @@
 @echo off
 cd %~dp0
 
-echo === Cowork Genealogy — Build the Cowork plugin (.zip) ===
+echo === Cowork Genealogy - Build the Cowork plugin (.zip) ===
 echo.
 echo Packs releases\genealogy-plugin.zip, the skills and agents Cowork runs.
 echo After it builds, upload it in Claude Desktop -^> Cowork -^> Customize -^>
@@ -9,21 +9,20 @@ echo Browse plugins -^> Upload custom plugin, then FULLY QUIT and reopen
 echo Desktop. Rebuild and reinstall whenever a skill under
 echo packages\engine\plugin changes.
 echo.
-echo This runs the same scripts\package-plugin.sh that "make plugin" runs, so
-echo it needs a bash environment such as Git Bash or WSL with the 'zip' command.
+echo This runs scripts\package-plugin.mjs with Node (same as "make plugin"). No
+echo bash or zip needed -- just Node, which Setup.bat already installs.
 echo.
 
-where bash >nul 2>nul
+where node >nul 2>nul
 if errorlevel 1 (
-  echo ERROR: 'bash' was not found on PATH. Install Git for Windows
-  echo        ^(it includes Git Bash^) or use WSL -- or just install a
-  echo        released genealogy-plugin.zip instead of building it yourself.
+  echo ERROR: 'node' was not found on PATH. Install Node.js, or run Setup.bat
+  echo        first -- the eval setup installs the dependencies this needs.
   pause
   exit /b 1
 )
 
 cd ..
-call bash scripts/package-plugin.sh
+call node scripts\package-plugin.mjs
 set RC=%errorlevel%
 
 echo.
@@ -31,7 +30,6 @@ if "%RC%"=="0" (
   echo Built releases\genealogy-plugin.zip. Upload it in Cowork -^> Customize,
   echo then fully quit and reopen Desktop.
 ) else (
-  echo Build failed ^(exit %RC%^). If it says 'zip: command not found', install
-  echo zip ^(on WSL: sudo apt install zip^) or build on macOS/Linux.
+  echo Build failed ^(exit %RC%^). Scroll up for the error.
 )
 pause

--- a/eval/Viewer.bat
+++ b/eval/Viewer.bat
@@ -1,7 +1,7 @@
 @echo off
 cd %~dp0
 
-echo === Cowork Genealogy — Research Viewer ===
+echo === Cowork Genealogy - Research Viewer ===
 echo.
 echo Launches the Electron Research Viewer. Use its "Open Project" button to
 echo open a project folder:

--- a/scripts/build-mcpb.mjs
+++ b/scripts/build-mcpb.mjs
@@ -1,0 +1,59 @@
+#!/usr/bin/env node
+// Builds the Claude Desktop extension at releases/genealogy-mcp.mcpb.
+// Contract: docs/specs/mcpb-package-spec.md.
+//
+// Cross-platform (Node) replacement for the former build-mcpb.sh, so it runs
+// natively on Windows too (no bash needed). We pack a staged, production-only
+// copy of packages/engine/mcp-server/ (not the dev tree) so the bundle ships
+// compiled JS + prod deps only -- never devDependencies (typescript, vitest,
+// @anthropic-ai/mcpb) or TypeScript source.
+import { execSync } from "node:child_process";
+import { copyFileSync, cpSync, mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+const ENGINE = join(ROOT, "packages", "engine", "mcp-server");
+const RELEASES = join(ROOT, "releases");
+const OUT = join(RELEASES, "genealogy-mcp.mcpb");
+
+const sh = (cmd, cwd = ROOT) => execSync(cmd, { stdio: "inherit", cwd });
+
+console.log("Building MCP server...");
+// Requires npm >=11.12 (engine-strict in .npmrc). On EBADENGINE, upgrade npm
+// to the version in mcp-server/package.json's packageManager field.
+sh("npm install", ENGINE);
+sh("npm run build", ENGINE);
+
+console.log("Staging production-only tree...");
+const stage = mkdtempSync(join(tmpdir(), "genealogy-mcpb-"));
+try {
+  for (const f of ["manifest.json", "package.json", "package-lock.json", ".mcpbignore"]) {
+    copyFileSync(join(ENGINE, f), join(stage, f));
+  }
+  for (const d of ["build", "config"]) {
+    cpSync(join(ENGINE, d), join(stage, d), { recursive: true });
+  }
+
+  console.log("Installing production dependencies into the stage...");
+  sh("npm ci --omit=dev --ignore-scripts", stage);
+
+  // The mcpb CLI is the @anthropic-ai/mcpb devDep's local binary; run from the
+  // engine dir so `npx` resolves node_modules/.bin/mcpb instead of trying to
+  // fetch a (nonexistent) "mcpb" package from the registry.
+  console.log("Validating manifest...");
+  sh(`npx mcpb validate "${stage}"`, ENGINE);
+
+  console.log("Packing .mcpb...");
+  mkdirSync(RELEASES, { recursive: true });
+  sh(`npx mcpb pack "${stage}" "${OUT}"`, ENGINE);
+
+  console.log();
+  sh(`npx mcpb info "${OUT}"`, ENGINE);
+} finally {
+  rmSync(stage, { recursive: true, force: true });
+}
+
+console.log(`\nDone. Created ${OUT}`);
+console.log("Verify it (Mac/Linux) with: ./scripts/verify-mcpb.sh");

--- a/scripts/build-mcpb.sh
+++ b/scripts/build-mcpb.sh
@@ -1,42 +1,6 @@
 #!/usr/bin/env bash
-set -euo pipefail
-
-# Builds the Claude Desktop extension at releases/genealogy-mcp.mcpb.
-# Contract: docs/specs/mcpb-package-spec.md.
-#
-# We pack a staged, production-only copy of packages/engine/mcp-server/ (not the dev tree)
-# so the bundle ships compiled JS + prod deps only — never devDependencies
-# (typescript, vitest, @anthropic-ai/mcpb) or TypeScript source.
-
-cd "$(dirname "$0")/.."
-ROOT="$(pwd)"
-OUT="$ROOT/releases/genealogy-mcp.mcpb"
-
-echo "Building MCP server..."
-cd "$ROOT/packages/engine/mcp-server"
-# Requires npm >=11.12 (engine-strict in .npmrc enforces it). If this hard-fails
-# with EBADENGINE, upgrade: npm i -g npm@<version from packageManager in package.json>.
-npm install
-npm run build
-
-echo "Staging production-only tree..."
-STAGE="$(mktemp -d)"
-trap 'rm -rf "$STAGE"' EXIT
-cp manifest.json package.json package-lock.json .mcpbignore "$STAGE/"
-cp -R build config "$STAGE/"
-
-echo "Installing production dependencies into the stage..."
-( cd "$STAGE" && npm ci --omit=dev --ignore-scripts )
-
-echo "Validating manifest..."
-npx mcpb validate "$STAGE"
-
-echo "Packing .mcpb..."
-mkdir -p "$ROOT/releases"
-npx mcpb pack "$STAGE" "$OUT"
-
-echo
-npx mcpb info "$OUT"
-echo
-echo "Done. Created $OUT"
-echo "Verify it with: ./scripts/verify-mcpb.sh"
+# Shim. The build logic moved to Node (scripts/build-mcpb.mjs) so it runs on
+# Windows without bash. This wrapper keeps `./scripts/build-mcpb.sh` working on
+# macOS/Linux for existing docs and muscle memory; `make mcpb` and the Windows
+# BuildMcpb.bat call node directly. The .mjs is the single source of truth.
+exec node "$(dirname "$0")/build-mcpb.mjs" "$@"

--- a/scripts/package-plugin.mjs
+++ b/scripts/package-plugin.mjs
@@ -1,0 +1,167 @@
+#!/usr/bin/env node
+// Packages the Cowork plugin at releases/genealogy-plugin.zip.
+//
+// Cross-platform (Node) replacement for the former package-plugin.sh, so it
+// runs natively wherever Node does -- no bash, and no `zip` binary (Git Bash
+// on Windows ships neither reliably). The .zip is written with a tiny built-in
+// writer (zlib deflate + a hand-built ZIP container), so there is nothing for
+// a Windows genealogist to install beyond Node itself.
+import { execFileSync } from "node:child_process";
+import { mkdirSync, readFileSync, readdirSync, statSync, writeFileSync } from "node:fs";
+import { dirname, join, relative, sep } from "node:path";
+import { fileURLToPath } from "node:url";
+import { deflateRawSync } from "node:zlib";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+const PLUGIN = join(ROOT, "packages", "engine", "plugin");
+const RELEASES = join(ROOT, "releases");
+const OUT = join(RELEASES, "genealogy-plugin.zip");
+// Mirrors the old `zip -r` include list (and order).
+const INCLUDE = [".claude-plugin", "agents", "skills"];
+
+// Gate: validate skill + agent frontmatter (description <=1024 chars, no angle
+// brackets, valid name) BEFORE building a zip Cowork would reject at install
+// time. Same check the CI gate runs (.github/workflows/check-runlogs.yml).
+// Best-effort: if no Python is available we warn and continue, since CI still
+// enforces it.
+validateFrontmatter();
+
+console.log("Packaging Cowork plugin...");
+const files = INCLUDE.flatMap((d) => walk(join(PLUGIN, d)));
+const entries = files.map((abs) => ({
+  name: relative(PLUGIN, abs).split(sep).join("/"),
+  data: readFileSync(abs),
+  mtime: statSync(abs).mtime,
+}));
+mkdirSync(RELEASES, { recursive: true });
+writeFileSync(OUT, buildZip(entries));
+console.log(`Done. Created ${OUT} (${entries.length} files)`);
+
+// ---- helpers --------------------------------------------------------------
+
+function walk(dir) {
+  const out = [];
+  const sorted = readdirSync(dir, { withFileTypes: true }).sort((a, b) =>
+    a.name < b.name ? -1 : a.name > b.name ? 1 : 0,
+  );
+  for (const e of sorted) {
+    const p = join(dir, e.name);
+    if (e.isDirectory()) out.push(...walk(p));
+    else if (e.isFile()) out.push(p);
+  }
+  return out;
+}
+
+function validateFrontmatter() {
+  const script = join(ROOT, "eval", "harness", "scripts", "check_skill_frontmatter.py");
+  // Try real interpreters in order. The `--version` probe first launches the
+  // candidate harmlessly, which skips the Windows Store `python3` alias (it
+  // "runs" but isn't Python and would otherwise look like a failed check).
+  const candidates = [["python3"], ["python"], ["py", "-3"], ["uv", "run", "python"]];
+  for (const [cmd, ...pre] of candidates) {
+    try {
+      execFileSync(cmd, [...pre, "--version"], { stdio: "ignore" });
+    } catch {
+      continue; // not installed (or Store alias) -> try the next
+    }
+    console.log("Validating skill + agent frontmatter...");
+    try {
+      execFileSync(cmd, [...pre, script], { stdio: "inherit", cwd: ROOT });
+    } catch {
+      console.error("\nPlugin frontmatter validation failed (see above) -- not packaging.");
+      process.exit(1);
+    }
+    return;
+  }
+  console.warn(
+    "WARNING: no Python found -- skipping plugin frontmatter validation (CI still enforces it).",
+  );
+}
+
+// Minimal ZIP writer: method 8 (deflate), no data descriptors, no zip64.
+// Produces a standard archive (verified with `unzip -t`).
+function buildZip(items) {
+  const table = crcTable();
+  const parts = [];
+  const central = [];
+  let offset = 0;
+
+  for (const { name, data, mtime } of items) {
+    const nameBuf = Buffer.from(name, "utf8");
+    const crc = crc32(data, table);
+    const comp = deflateRawSync(data);
+    const [dosTime, dosDate] = dosDateTime(mtime);
+
+    const local = Buffer.alloc(30 + nameBuf.length);
+    local.writeUInt32LE(0x04034b50, 0); // local file header signature
+    local.writeUInt16LE(20, 4); // version needed
+    local.writeUInt16LE(0, 6); // flags
+    local.writeUInt16LE(8, 8); // method: deflate
+    local.writeUInt16LE(dosTime, 10);
+    local.writeUInt16LE(dosDate, 12);
+    local.writeUInt32LE(crc, 14);
+    local.writeUInt32LE(comp.length, 18); // compressed size
+    local.writeUInt32LE(data.length, 22); // uncompressed size
+    local.writeUInt16LE(nameBuf.length, 26);
+    local.writeUInt16LE(0, 28); // extra length
+    nameBuf.copy(local, 30);
+    parts.push(local, comp);
+
+    const cd = Buffer.alloc(46 + nameBuf.length);
+    cd.writeUInt32LE(0x02014b50, 0); // central dir header signature
+    cd.writeUInt16LE(20, 4); // version made by
+    cd.writeUInt16LE(20, 6); // version needed
+    cd.writeUInt16LE(0, 8); // flags
+    cd.writeUInt16LE(8, 10); // method
+    cd.writeUInt16LE(dosTime, 12);
+    cd.writeUInt16LE(dosDate, 14);
+    cd.writeUInt32LE(crc, 16);
+    cd.writeUInt32LE(comp.length, 20);
+    cd.writeUInt32LE(data.length, 24);
+    cd.writeUInt16LE(nameBuf.length, 28);
+    // extra(30), comment(32), disk start(34), internal attrs(36) all 0
+    cd.writeUInt32LE(0, 38); // external attrs
+    cd.writeUInt32LE(offset, 42); // local header offset
+    nameBuf.copy(cd, 46);
+    central.push(cd);
+
+    offset += local.length + comp.length;
+  }
+
+  const centralDir = Buffer.concat(central);
+  const eocd = Buffer.alloc(22);
+  eocd.writeUInt32LE(0x06054b50, 0); // end of central directory signature
+  eocd.writeUInt16LE(0, 4); // disk number
+  eocd.writeUInt16LE(0, 6); // disk with central dir
+  eocd.writeUInt16LE(items.length, 8); // entries on this disk
+  eocd.writeUInt16LE(items.length, 10); // total entries
+  eocd.writeUInt32LE(centralDir.length, 12); // central dir size
+  eocd.writeUInt32LE(offset, 16); // central dir offset
+  eocd.writeUInt16LE(0, 20); // comment length
+
+  return Buffer.concat([...parts, centralDir, eocd]);
+}
+
+function crcTable() {
+  const t = new Uint32Array(256);
+  for (let n = 0; n < 256; n++) {
+    let c = n;
+    for (let k = 0; k < 8; k++) c = c & 1 ? 0xedb88320 ^ (c >>> 1) : c >>> 1;
+    t[n] = c >>> 0;
+  }
+  return t;
+}
+
+function crc32(buf, t) {
+  let c = 0xffffffff;
+  for (let i = 0; i < buf.length; i++) c = t[(c ^ buf[i]) & 0xff] ^ (c >>> 8);
+  return (c ^ 0xffffffff) >>> 0;
+}
+
+function dosDateTime(d) {
+  const y = d.getFullYear();
+  if (y < 1980) return [0, 0x21]; // floor at 1980-01-01
+  const time = (d.getHours() << 11) | (d.getMinutes() << 5) | (d.getSeconds() >> 1);
+  const date = ((y - 1980) << 9) | ((d.getMonth() + 1) << 5) | d.getDate();
+  return [time & 0xffff, date & 0xffff];
+}

--- a/scripts/package-plugin.sh
+++ b/scripts/package-plugin.sh
@@ -1,30 +1,8 @@
 #!/usr/bin/env bash
-set -euo pipefail
-
-cd "$(dirname "$0")/.."
-ROOT="$(pwd)"
-
-# Gate: validate skill + agent frontmatter (description <=1024 chars, no angle
-# brackets, valid name) BEFORE building a zip Cowork would reject at install
-# time. Same check the CI gate runs (.github/workflows/check-runlogs.yml). It
-# is stdlib-only, so plain python3 — no uv. A hard violation exits non-zero and
-# `set -e` aborts the build here. Best-effort: if python3 is somehow absent we
-# warn and continue, since CI still enforces it.
-if command -v python3 >/dev/null 2>&1; then
-  echo "Validating skill + agent frontmatter..."
-  python3 "$ROOT/eval/harness/scripts/check_skill_frontmatter.py"
-else
-  echo "WARNING: python3 not found — skipping plugin frontmatter validation (CI still enforces it)." >&2
-fi
-
-echo "Packaging Cowork plugin..."
-mkdir -p releases
-rm -f releases/genealogy-plugin.zip
-cd packages/engine/plugin
-zip -r ../../../releases/genealogy-plugin.zip \
-  .claude-plugin/ \
-  agents/ \
-  skills/
-cd ..
-
-echo "Done. Created releases/genealogy-plugin.zip"
+# Shim. The packaging logic moved to Node (scripts/package-plugin.mjs) so it
+# runs on Windows without bash or a `zip` binary. This wrapper keeps
+# `./scripts/package-plugin.sh` working on macOS/Linux for existing docs and
+# muscle memory; `make plugin` and the Windows BuildPlugin.bat call node
+# directly. The .mjs is the single source of truth (it also runs the same
+# frontmatter validation gate before zipping).
+exec node "$(dirname "$0")/package-plugin.mjs" "$@"


### PR DESCRIPTION
## What & why

Re-lands the cross-platform Node build scripts (originally **#533**) onto `main`.

**Why they aren't already on main:** #533 was merged with base `plugin-skill-validation` instead of `main`, and `plugin-skill-validation` had already merged to `main` (#520) *before* #533 landed — so the Node conversion was stranded on that branch and never reached `main`. A Windows genealogist pulling `main` still hits `'bash' was not found` from `BuildMcpb.bat`, and `BuildPlugin.bat` can't work at all (Git Bash ships no `zip`).

This cherry-picks the original commit (`96ecc488`, unchanged) onto current `main`; it applied cleanly.

## What it does (from #533)

Rewrites both build scripts in Node, which is already required and runs the same everywhere:

- `scripts/build-mcpb.mjs` — npm install/build → stage prod-only tree → `npx mcpb validate/pack/info`. No new deps.
- `scripts/package-plugin.mjs` — cross-platform frontmatter gate + a zero-dependency zip writer (zlib deflate + a hand-built ZIP container), so a Windows machine needs nothing beyond Node.
- `Makefile` `mcpb`/`plugin` → `node …mjs`.
- `BuildMcpb.bat` / `BuildPlugin.bat` call node (no bash guard); ASCII headers (fixes the mojibake). `Viewer.bat` header fixed too.
- `scripts/*.sh` kept as thin `exec node …mjs` shims so macOS/Linux docs and `verify-mcpb.sh` keep working; the `.mjs` is the single source of truth.

## Verified on macOS

- `node scripts/build-mcpb.mjs` → packs `releases/genealogy-mcp.mcpb` (6.2 MB, devDeps excluded), manifest validates.
- `./scripts/verify-mcpb.sh` → bundle content checks pass, packed server boots, `tools/list` returns all 39 tools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
