### PR TITLE
skills: tree-edit date/couple-fact rules + person-evidence degenerate…

### DIFF
--- a/packages/engine/plugin/skills/person-evidence/SKILL.md
+++ b/packages/engine/plugin/skills/person-evidence/SKILL.md
@@ -507,6 +507,13 @@ When multiple candidates share the same name in the same area:
   from a different record matches the same person, still evaluate it
   independently. Consistency across records strengthens the case, but
   each link needs its own rationale.
+- **Degenerate `same_person` score on an unresolvable id:** When the tree
+  candidate is a local stub, or a tree id `same_person` cannot resolve to a
+  full FamilySearch ARK, the tool may return a near-zero score (e.g. `0.005`)
+  that reflects the missing ARK, not a real mismatch. Treat that as **no
+  score available** — fall back to qualitative correlation (Step 3), and do
+  not let the degenerate number drop a match the identifiers otherwise
+  support. Note in the rationale that the score was uninformative and why.
 
 ## Important rules
 

--- a/packages/engine/plugin/skills/tree-edit/SKILL.md
+++ b/packages/engine/plugin/skills/tree-edit/SKILL.md
@@ -61,6 +61,13 @@ tree_edit({
 
 Other operations: `update_fact` (by `factId`) · `update_name` (by `nameId`) · `update_person` (gender/ark) · `add_person` · `add_relationship` · `remove` (factId or relationshipId only — the one permitted deletion, when proof-conclusion withdrew a conclusion; never removes a person). For corrections pass only the changed fields — e.g. fix a wrong death date with `tree_edit({ projectPath, operation: "update_fact", personId: "I1", factId: "F2", fact: { date: "1908-03-12" } })`. When something already exists at that id, use `update_*` rather than adding a duplicate.
 
+### Writing facts correctly
+
+Two rules prevent avoidable `check-warnings` failures and rework:
+
+- **Dates must be GedcomX-parseable.** Write a bare year (`1773`), an ISO date (`1908-03-12`), or a spelled date (`12 March 1908`) — **never** `about 1773`, `abt 1773`, or `c. 1773`. A non-parseable date is silently dropped, so a birth-like fact fails to register and later events then trip birth-order warnings (`hasEventBeforeBirth365_2`). When a source gives only an approximate year, still write the bare year and record the approximation in the source `page` / your reply, not in the `date` string.
+- **Couple-event facts go on the `Couple` relationship, not on a person.** Marriage, Divorce, and other couple events belong in the relationship's `facts` array — supply them in the `add_relationship` call itself: `relationship: { type: "Couple", person1, person2, facts: [{ type: "Marriage", date, place, sources }] }`. A Marriage written as a person `add_fact` misplaces the event and can trip birth-order warnings. See `references/relationship-accuracy.md`.
+
 ## Person merging
 
 When proof-conclusion confirms two persons are the same individual, execute the merge here. The tool does all clerical work (folding names/facts, repointing relationships, repointing every `research.json` reference, removing the collapsed person); your job is to pick the survivor and confirm pairs.

--- a/packages/engine/plugin/skills/tree-edit/references/relationship-accuracy.md
+++ b/packages/engine/plugin/skills/tree-edit/references/relationship-accuracy.md
@@ -26,6 +26,15 @@ relationship without asserting a type rather than defaulting to
 living with adults without clarifying whether the connection is
 genetic, adoptive, or something else.
 
+## Couple-event facts belong on the relationship
+
+Marriage, divorce, and other couple events are facts of the **`Couple`
+relationship**, not of either spouse. Record them in the relationship's
+`facts` array — supplied when you create the relationship — never as a
+person-level fact. A marriage stored on a person record misplaces the
+event and can trigger birth-order warnings; the couple relationship is
+its only correct home.
+
 ## When to create relationships
 
 Create a relationship entry when:


### PR DESCRIPTION
## Summary

- **tree-edit**: dates must be GedcomX-parseable (`1773`, not `about 1773`); couple-events (Marriage/Divorce) go on the `Couple` relationship's `facts`, never on a person — both surfaced as rework in the `birkeland-parents-1817` `/research` debug loop.
- **tree-edit/references/relationship-accuracy.md**: reinforcing section on couple-event fact placement.
- **person-evidence**: a near-zero `same_person` score from an unresolvable/stub id is an artifact → fall back to qualitative correlation.

## Test plan

- [ ] I ran `scripts/test.sh` and it passed.
- [ ] For every skill whose files I changed, I ran `RunTests.bat <skill>` and committed an all-pass runlog under `eval/runlogs/unit/<skill>/` — **`tree-edit`**, **`person-evidence`**.