### PR TITLE
Add /grade-e2e-run skill, blocking grading gate, and judge-blind interpret

### DIFF
--- a/.claude/skills/grade-e2e-run/SKILL.md
+++ b/.claude/skills/grade-e2e-run/SKILL.md
@@ -1,0 +1,138 @@
+---
+name: grade-e2e-run
+model: claude-sonnet-4-6
+description: Grades an e2e benchmark run into a calibration annotation (run-<ts>.ann.json). Reads ONLY the fixture and the run's final tree/research — never the judge's own grades — so the genealogist labels each expected finding (true/partial/false) blind, then writes the .ann.json. Use when the user says "grade this e2e run", "annotate this run for calibration", "create the .ann.json for run X", or "label the findings for the latest <fixture> run". Do NOT use to explain why a run passed or failed (use interpret-e2e-result, which reads the judge output — this skill must not), to author or modify a fixture (use author-e2e-fixture), or to run the full judge-calibration sweep (that is the maintainer's calibrate_judge step).
+---
+
+# Grade E2E Run
+
+**Narration:** default to concise — this is a developer-facing grading tool, not a research narration.
+
+Turns one e2e run into a **calibration annotation**: a human grade committed
+beside the run log as `eval/runlogs/e2e/<slug>/run-<ts>.ann.json`. The genealogist
+labels whether the agent recovered each expected finding; the maintainer's
+`calibrate_judge` step later compares those human labels to the judge's labels to
+measure judge accuracy.
+
+## The one rule that makes the grade trustworthy: grade blind
+
+You read **only** these files:
+
+| File | Why |
+|------|-----|
+| `eval/tests/e2e/<slug>/expected-findings.json` | the findings to grade, their ids, `required` / `polarity` |
+| `eval/tests/e2e/<slug>/fixture.json` | the `researcher_question` (context) |
+| `eval/runlogs/e2e/<slug>/run-<ts>.final-tree.gedcomx.json` | the agent's final tree — its evidence |
+| `eval/runlogs/e2e/<slug>/run-<ts>.final-research.json` | the agent's `proof_summaries` (optional) |
+
+**Never open `run-<ts>.json`.** That file holds the judge's own `verdict` /
+`per_finding` / `proof_quality`. The whole point of this annotation is to be an
+*independent* human label the judge is measured against; if you see the judge's
+answer first, the human anchors on it and the calibration number becomes a rubber
+stamp. Do not read the run log, and do not report the judge's grades — they are the
+maintainer's calibration output, not part of grading.
+
+## Steps
+
+### 1 — Identify the run (do not read it)
+
+Take the `run-<ts>.json` path (or "the latest run for `<slug>`" → the newest
+`run-*.json` in the slug dir). Derive `slug` (the parent directory) and `stem`
+(`run-<ts>`). You use these only to locate the four files above — you never open
+`run-<ts>.json` itself.
+
+### 2 — Load the fixture and the agent's final state
+
+Read the four blind files. `run-<ts>.final-tree.gedcomx.json` is required — no tree
+means there is nothing to grade, so stop and say so (the run was skipped or crashed
+before producing a tree). `run-<ts>.final-research.json` is optional.
+
+### 3 — For each finding, show the evidence and collect a label
+
+Walk `expected-findings.json` `findings[]` **in order**. For each finding:
+
+- State it neutrally: `id`, `description`, `required`, and `polarity` (default
+  `recover`).
+- Surface the **agent's evidence** from the final tree: find the persons,
+  relationships, and facts relevant to this finding's subject / target and quote
+  what the tree actually contains — birth year and place, the relationship type and
+  its source — or state plainly that it is **absent**. Include any relevant
+  `proof_summaries` text from `final-research.json`. Present facts only; do not
+  suggest a label.
+- Ask the genealogist to label it:
+  - **`true`** — the tree contains the finding (wording or source path may differ).
+  - **`partial`** — partially recovered (right person, weaker or incomplete facts).
+  - **`false`** — not recovered at all.
+  - For a **`polarity: "avoid"`** finding, flip the framing: "did the agent
+    correctly *decline* this wrong candidate?" → **`true`** when the candidate is
+    absent or present only as a rejected hypothesis; **`false`** when the agent
+    over-claimed it.
+
+### 4 — (Optional) proof-quality score
+
+If the agent wrote a `proof_summaries` statement, ask the genealogist to grade its
+**soundness** blind (independent of recall): **3** sound (exhaustive search,
+conflicts resolved, corroborated), **2** thin (single source, an unresolved
+conflict, or an over-stated tier), **1** unsound (asserts more than the narrative
+supports). If no proof summary was written, leave it **null** (omit) — that is
+still a complete grade.
+
+### 5 — (Optional) per-finding notes
+
+Capture a short note for any borderline call — especially `partial` — e.g. "right
+burial place, year-only date — date-precision call." Notes are keyed by finding id
+and are what actually tune the judge prompt later, so they matter most on the
+disagreeable calls.
+
+### 6 — Write the annotation
+
+Write `eval/runlogs/e2e/<slug>/run-<ts>.ann.json` with **only** these keys:
+
+| Key | Required | Shape |
+|-----|----------|-------|
+| `per_finding` | yes | `{ "<finding_id>": "true" \| "partial" \| "false" }` — keys **exactly** the fixture's finding ids (copy them from `expected-findings.json`; do not invent or omit any) |
+| `proof_quality_score` | no | `1` \| `2` \| `3` \| `null` |
+| `notes` | no | `{ "<finding_id>": "text" }` — keys ⊆ `per_finding` keys |
+| `annotator` | no | the grader's team identifier (git blame is the fallback if omitted) |
+
+Do **not** add any other key. The loader hard-errors on unknown keys — in
+particular do **not** write `llm_score`, `corrected_score`, or `verdict`. Those are
+the *unit*-annotation shape and the derived verdict; neither belongs in an e2e
+annotation.
+
+### 7 — Self-check, then hand off for commit
+
+Verify the file you just wrote — you have every input to do this without any tool:
+
+- keys are exactly `per_finding` (+ optional `proof_quality_score` / `notes` /
+  `annotator`), nothing else;
+- every `per_finding` value is `true` / `partial` / `false` — no nulls (a blank
+  label means that finding isn't graded yet; ask the genealogist before writing);
+- `per_finding` keys equal the fixture's finding ids (you copied them from
+  `expected-findings.json`, so this holds by construction — confirm it);
+- any `notes` key is one of those finding ids.
+
+Then tell the user to commit the `.ann.json`. **Do not run `calibrate_judge` — not
+even `--dry-run`.** It classifies *every* annotation in the tree, not just this one.
+The developer and genealogist teams never run it; all `calibrate_judge` use
+(`--dry-run` classification and the full sweep) is the maintainer's step, run
+periodically — documented in `docs/e2e-testing-guide.md` under "Judge calibration."
+
+## What you do not do
+
+- **Never open `run-<ts>.json`** or otherwise surface the judge's grades. Grading is
+  blind; revealing the judge's labels defeats the calibration.
+- Do not run `calibrate_judge` at all — not even `--dry-run`. Self-validate the one
+  file you wrote; whole-set classification and the calibration sweep are the
+  maintainer's job, per the guide.
+- Do not derive or write a `verdict` — the loader derives it from `per_finding`.
+- Do not edit fixtures, skills, the judge prompt, the run log, or the tree.
+- Do not label findings yourself — surface the evidence; the genealogist decides.
+
+## Re-invocation behavior
+
+**Writes:** `eval/runlogs/e2e/<slug>/run-<ts>.ann.json` (one annotation per run).
+
+**On repeat invocation:** re-grading the same run overwrites that one file with the
+new labels — safe. Never carry labels forward from a *different* run's `.ann.json`:
+each run produced a different tree, so a prior run's grade does not apply.

--- a/.claude/skills/interpret-e2e-result/SKILL.md
+++ b/.claude/skills/interpret-e2e-result/SKILL.md
@@ -1,41 +1,59 @@
 ---
 name: interpret-e2e-result
 model: claude-sonnet-4-6
-description: Reads an e2e benchmark run log and explains what happened — verdict, stop reason, which expected findings the agent did and didn't recover, and the most likely failure cause (agent reasoning regression, /research routing regression, sub-skill regression, FamilySearch data drift, or single-run jitter). Points the user at the right transcript section to read next. Use when the user says "what happened in this e2e run", "interpret this e2e result", "why did this fixture fail", or "read the latest e2e runlog". Do NOT use to author or modify a fixture (use author-e2e-fixture), to interpret a unit-test scratch run (those are developer-facing — read the run log directly), or to grade a single research question in a live project (use the relevant analysis skills like timeline or conflict-resolution).
+description: Reads an e2e benchmark run log and explains what happened — which expected findings the agent recovered and which it missed (read from its final tree, not the judge's grade), what proof conclusion it wrote, why it stopped, and the most likely cause (agent reasoning regression, /research routing regression, sub-skill regression, FamilySearch data drift, or single-run jitter). Points the user at the right transcript section to read next. Use when the user says "what happened in this e2e run", "interpret this e2e result", "why did this fixture fail", or "read the latest e2e runlog". Do NOT use to author or modify a fixture (use author-e2e-fixture), to interpret a unit-test scratch run (those are developer-facing — read the run log directly), to grade a single research question in a live project (use the relevant analysis skills like timeline or conflict-resolution), or to grade this run into its calibration annotation (use grade-e2e-run — this skill only explains the result and never writes the .ann.json).
 ---
 
 # Interpret E2E Result
 
 **Narration:** Read `researcher_profile.narration_guidance` from `research.json` if one exists in the working folder; otherwise default to concise narration.
 
-Reads the four files an e2e run produces and tells the user what
-happened in plain language, with pointers to the relevant transcript
-section.
+Reads the files an e2e run produces and tells the user what happened in
+plain language, with pointers to the relevant transcript section.
 
 Each run writes four files to `eval/runlogs/e2e/<test-id>/`:
 
 | File | Content |
 |------|---------|
-| `run-<ts>.json` | Structured result: `verdict`, `stop_reason`, `judge_output`, `usage`, `tool_calls[]`, `blocked_tree_reads[]` |
+| `run-<ts>.json` | Structured result. **Read only the harness facts from it — `stop_reason`, `tool_calls[]`, `usage`, `blocked_tree_reads[]`, `error`. Do NOT read `judge_output` (see "Stay blind to the judge").** |
 | `run-<ts>.transcript.md` | Readable transcript of the agent's turns |
-| `run-<ts>.final-tree.gedcomx.json` | The agent's final tree (what the judge graded) |
-| `run-<ts>.final-research.json` | The agent's final `research.json` |
+| `run-<ts>.final-tree.gedcomx.json` | The agent's final tree — the ground truth for what it recovered |
+| `run-<ts>.final-research.json` | The agent's final `research.json`, including the proof conclusion it wrote |
 
 This skill reads files; it does not call any MCP tools.
 
+## Stay blind to the judge
+
+**Do not read or report `judge_output` — the judge's `verdict`, `per_finding`
+labels, or `proof_quality` score.** Those are the judge's *grades*: the thing
+the maintainer calibrates, and unnecessary for explaining what the agent did.
+The user runs `/grade-e2e-run` right after this to grade the run **blind**; if
+you surface the judge's labels here, that grade is no longer independent and the
+calibration number is corrupted.
+
+You have everything the user needs without the judge:
+
+- **What the agent recovered / missed** — compare the final tree to
+  `expected-findings.json` yourself. The tree is ground truth; report presence
+  or absence as *facts*, not as a verdict.
+- **The proof conclusion** — read what the agent *wrote* in `final-research.json`
+  (`proof_summaries`). That's the agent's own claim, not a grade.
+- **Why it stopped, what it did** — `stop_reason`, `tool_calls`,
+  `blocked_tree_reads`, `usage` are harness facts, not judge output.
+
 ## What to do
 
-**Ground every claim in the run-log files — do not invent specifics.**
-You are reporting what happened, not reconstructing a plausible story.
-Verdict, `matched`, proof-quality fields, `stop_reason`, tool counts, and
-cost come straight from `run-<ts>.json`. Anything more specific — *which*
-collections were searched, *which* records were found, *which* index
-confirmed a date — must come from `tool_calls[].args`/`response_summary`,
-the transcript, or `final-research.json` (the agent's proof summaries and
-log entries name the actual sources, with ARKs — quote/cite those). If a
-specific source name isn't in any of those files, don't assert it; a
-plausible-sounding collection name you didn't actually read is a
-fabrication.
+**Ground every claim in the run-log files — do not invent specifics.** You are
+reporting what happened, not reconstructing a plausible story. `stop_reason`,
+tool counts, and cost come from `run-<ts>.json` (harness fields only). What the
+agent found / missed comes from the final tree vs `expected-findings.json`.
+Anything more specific — *which* collections were searched, *which* records were
+found, *which* index confirmed a date — must come from
+`tool_calls[].args`/`response_summary`, the transcript, or `final-research.json`
+(the agent's proof summaries and log entries name the actual sources, with ARKs
+— quote/cite those). If a specific source name isn't in any of those files,
+don't assert it; a plausible-sounding collection name you didn't actually read
+is a fabrication.
 
 ### Step 1 — Locate the run log
 
@@ -44,53 +62,40 @@ ask which fixture and which timestamp, or take the most recent if
 only one is present.
 
 The fixture's `expected-findings.json` lives in `eval/tests/e2e/<id>/`.
-Read it alongside the run log so you can compare expected vs found.
+Read it alongside the run so you can compare expected vs found yourself.
 
-### Step 2 — Explain the verdict in one sentence
+### Step 2 — Summarize what the agent recovered
 
-The `verdict` is **recall only** — did the agent recover the stripped
-facts? Proof quality is a separate axis (Step 2b); don't conflate them.
-Read `verdict` from `run-<ts>.json` and translate:
+Compare the final tree to each `required: true` finding in
+`expected-findings.json` and state, as facts, which the tree contains and which
+it doesn't. This is recall — *did the tree end up with the stripped facts?* Do
+not quote a judge verdict; describe the outcome:
 
-- `pass` — the agent recovered every `required: true` finding. No
-  further interpretation needed unless the user asks "how cleanly" — but
-  still glance at `proof_quality` (Step 2b): a `pass` with a `score: 1`
-  is a lucky match, not sound research, and that's worth flagging.
-- `partial` — the agent recovered some but not all required findings.
-  Worth investigating which ones it missed.
-- `fail` — the agent recovered no required findings. The run is
-  probably uninformative on agent capability — the agent stalled or
-  went sideways. Stop reason usually explains.
-- `skipped` — the judge didn't run. Agent crashed before producing a
-  tree, or `--skip-judge` was passed. Read the transcript for the
-  crash; the result file has no judge output.
+- **All required findings present** — the run recovered the answer. Say so in a
+  sentence, then describe the proof conclusion (Step 2b): a recovered answer
+  with a thin or missing proof is worth flagging.
+- **Some present** — name which it recovered and which it missed; the misses
+  are what to investigate (Step 4).
+- **None present** — the run recovered nothing. The agent stalled or went
+  sideways; `stop_reason` usually explains.
+- **No tree at all** (`run-<ts>.final-tree.gedcomx.json` missing) — the agent
+  crashed before producing tree state. Read the transcript for the crash.
 
 For a fixture with **negative findings** (`polarity: "avoid"` in
-`expected-findings.json`), a `matched: "true"` on that finding means the
-agent *correctly declined* the wrong candidate. A `false` there is
-over-claiming — call it out specifically; it's the failure that most
-matters.
+`expected-findings.json`), the correct outcome is the tree **not** asserting the
+wrong candidate — absent, or present only as a rejected hypothesis. If the tree
+asserts it, the agent over-claimed; call that out specifically — it's the
+failure that matters most.
 
-### Step 2b — Report the proof-quality score
+### Step 2b — Describe the agent's proof conclusion
 
-Read `judge_output.proof_quality` from `run-<ts>.json`. This grades the
-soundness of the agent's written proof statement (`proof_summaries`),
-independent of recall:
-
-- `score: 3` — sound (exhaustive search, conflicts resolved,
-  independent corroboration, tier matches evidence).
-- `score: 2` — thin (single source, an unresolved conflict, or an
-  over-stated tier).
-- `score: 1` — unsound (asserts a conclusion the narrative doesn't
-  support).
-- `score: null` — no proof summary was written. Note it, but it's not a
-  proof failure — there was simply nothing to grade.
-
-State the score and the one sub-field that drove it (e.g.
-"`corroboration: single_source`"). A high recall verdict with a low
-proof-quality score is the headline finding when it happens: *the agent
-found the answer but didn't prove it.* This score never changes the
-verdict.
+Read the agent's `proof_summaries` from `final-research.json` and summarize the
+conclusion it *wrote* — the claim, the evidence it cites, and the
+confidence/tier it asserted. Report observable characteristics as facts (e.g.
+"rests on a single 1910 census entry," "notes an unresolved date conflict,"
+"claims a `proof_argument` tier"). **Do not score its soundness** (1 / 2 / 3) —
+that's what the user grades blind next. If no proof summary was written, say so;
+it's not itself a failure, just nothing to describe.
 
 ### Step 2c — Note any blocked tree-reads
 
@@ -100,12 +105,11 @@ agent can't read the stripped answer off the live tree (it must research
 from records). Each entry is a denied attempt.
 
 - **Empty** — the agent didn't try to shortcut. Normal; say nothing.
-- **Non-empty** — the agent *tried* to read the tree but was blocked, so
-  the answer (if recovered) was still earned from records — a `pass` is
-  still valid. But flag it: a healthy `/research` flow shouldn't reach
-  for `person_read` on the subject during an autonomous run. Repeated
-  attempts may indicate the skill is leaning on tree-reading instead of
-  records, which is worth a look at the `/research` primer.
+- **Non-empty** — the agent *tried* to read the tree but was blocked, so the
+  answer, if recovered, was still earned from records. But flag it: a healthy
+  `/research` flow shouldn't reach for `person_read` on the subject during an
+  autonomous run. Repeated attempts may indicate the skill is leaning on
+  tree-reading instead of records, which is worth a look at the `/research` primer.
 
 ### Step 2d — Note whether the answer came from provided documents
 
@@ -152,22 +156,20 @@ Translate `stop_reason` into something a researcher can act on:
 - `error` — SDK or harness exception. Read `result.error` for the
   message and the transcript for the surrounding context.
 
-### Step 4 — Compare expected vs found (when verdict is partial / fail)
+### Step 4 — Compare expected vs found (when the tree is missing some findings)
 
 For each entry in the fixture's `expected-findings.json`, look at the
 agent's `run-<ts>.final-tree.gedcomx.json` and decide:
 
-- **Matched** — the agent's tree contains the expected person /
-  relationship / fact, possibly with different wording or a different
-  source path.
+- **Found** — the agent's tree contains the expected person / relationship /
+  fact, possibly with different wording or a different source path.
 - **Missed** — the agent didn't surface the finding at all. Worth
   asking why: did it search the right collections? Did it find the
   right candidate and then dismiss it? Did it never reach the right
   step?
-- **Recorded elsewhere** — the agent found the right answer but put
-  it in a place the judge didn't read (e.g., wrote it to a stub
-  person rather than the principal). Diagnosis: judge prompt or
-  finding shape, not agent capability.
+- **Recorded off-shape** — the agent found the right answer but put it
+  somewhere the finding's shape doesn't expect (e.g. on a stub person
+  rather than the principal). Diagnosis: finding shape, not agent capability.
 
 For each `missed` finding, search the transcript for the relevant
 person name or place. The agent often *touched* the right evidence
@@ -192,7 +194,7 @@ useful questions are about *this* run:
   finding isn't findable from records (and isn't a `provided-documents/`
   case). The fixture may be unsolvable as authored — a fixture problem,
   not an agent one.
-- **Recorded elsewhere** — see Step 4 (judge/finding-shape issue).
+- **Recorded off-shape** — see Step 4 (finding-shape issue).
 
 **A previously-passing fixture now failing (you have a prior run to diff).**
 These are the regression causes:
@@ -215,8 +217,8 @@ These are the regression causes:
   run. The agent isn't at fault.
 - **Single-run jitter** — Anthropic models are non-deterministic and
   this harness can't pin `temperature=0`. A single finding flipping
-  matched/partial may just be variance. Recommend a re-run before
-  drawing conclusions.
+  recovered / not-recovered may just be variance. Recommend a re-run
+  before drawing conclusions.
 
 If the evidence isn't conclusive, say so — don't force a diagnosis.
 
@@ -235,42 +237,56 @@ ambiguity:
 - File a regression issue if the cause looks like an agent or
   sub-skill regression.
 
+**Then remind the user to grade this run.** Whatever the outcome — the run
+recovered everything, some, or none — it's committed and owes a calibration
+grade: tell the user to run `/grade-e2e-run` next to label the findings blind
+and write `run-<ts>.ann.json`. Because you stayed blind to `judge_output`, that
+grade is still independent. Grading is same-PR, and CI blocks committing a run
+that produced a tree without its `.ann.json` (a treeless skip run is exempt).
+
 ## What you do not do
 
+- Do not read or report `judge_output` (verdict / per_finding / proof_quality).
+  Explain the run from the tree, the agent's proof conclusion, and the harness
+  facts — never the judge's grades.
 - Do not edit fixtures or skills — interpretation only. If the
-  diagnosis points at a fixture problem (e.g., the judge can't match
-  a finding because the description is too literal), tell the user
-  and suggest `/author-e2e-fixture` to revise.
+  diagnosis points at a fixture problem (e.g. a finding's description is
+  too literal to match the tree), tell the user and suggest
+  `/author-e2e-fixture` to revise.
 - Do not run the e2e harness yourself. The user runs the harness
   on the host where FS credentials and the compiled MCP server live;
   you only read the artifacts it produces.
-- Do not pad the output. A passing run gets a one-line summary; a
-  failing run gets the analysis above. Skip sections that don't apply.
+- Do not pad the output. A clean recovery gets a one-line summary; a
+  run with misses gets the analysis above. Skip sections that don't apply.
 
 ## Example
 
 User: "Why did the smith-parents-1850 run fail?"
 
 You should:
-1. Read `eval/runlogs/e2e/smith-parents-1850/run-<latest>.json`.
-2. Read `eval/tests/e2e/smith-parents-1850/expected-findings.json`.
-3. See `verdict: fail`, `stop_reason: tool_cap`.
+1. Read `eval/runlogs/e2e/smith-parents-1850/run-<latest>.json` (harness
+   fields only — skip `judge_output`).
+2. Read `eval/tests/e2e/smith-parents-1850/expected-findings.json` and the
+   final tree; the tree contains **none** of the required findings.
+3. See `stop_reason: tool_cap`.
 4. Skim the last 30 tool calls in the transcript — agent is looping
    on `place_search` for "Augusta County" with three near-duplicate
    queries.
-5. Tell the user: "Failed at the tool cap (200 calls). Agent looped on
-   `place_search` from turn 47 onward — three near-duplicate queries
-   for Augusta County. Likely cause: `/research` skill regression
-   (place-disambiguation guidance is weaker than the last passing
-   run). Recommend diffing `tool_calls[]` against the previous green
-   run for this fixture before changing the skill."
+5. Tell the user: "Recovered none of the required findings; stopped at the
+   tool cap (200 calls). Agent looped on `place_search` from turn 47 onward —
+   three near-duplicate queries for Augusta County. Likely cause: `/research`
+   skill regression (place-disambiguation guidance is weaker than the last
+   passing run). Recommend diffing `tool_calls[]` against the previous green
+   run for this fixture before changing the skill. Then grade this run blind
+   with `/grade-e2e-run`."
 
 ## Re-invocation behavior
 
 **Writes:** nothing. This skill is read-only — it reads an e2e run
-log, the agent's final tree and research files, and the fixture's
-`expected-findings.json`, and explains the result in-session. It calls
-no MCP tools and edits no fixtures, skills, or project files.
+log (harness fields only, never `judge_output`), the agent's final tree and
+research files, and the fixture's `expected-findings.json`, and explains the
+result in-session. It calls no MCP tools and edits no fixtures, skills, or
+project files.
 
 **On repeat invocation:** safe to run as often as needed. Each call is
 a fresh read of the run-log artifacts.

--- a/.github/workflows/check-e2e-fixtures.yml
+++ b/.github/workflows/check-e2e-fixtures.yml
@@ -1,16 +1,18 @@
-name: Report e2e fixture validity (advisory)
+name: Check e2e fixtures + grading
 
-# Reports the e2e fixture-validity gate (docs/specs/e2e-test-spec.md §14):
-# every committed fixture under eval/tests/e2e/<slug>/ should have at least
-# one committed run log under eval/runlogs/e2e/<slug>/run-*.json with
-# verdict=pass, proving the fixture is solvable against live FamilySearch
-# (stripping completeness alone does not).
+# Two e2e discipline checks on committed files (eval/harness/scripts/check_e2e_fixtures.py):
 #
-# This check is ADVISORY and NON-BLOCKING: fixtures missing a passing run
-# log are surfaced as warning annotations, but the job still passes so a
-# draft fixture (e.g. a PID-less fixture authored without FamilySearch
-# access, validity run still owed) can land. Only the unit-test runlog
-# discipline check (check-runlogs.yml) blocks merge.
+# 1. Grading gate (BLOCKING): every run log ADDED in this PR that produced a
+#    final tree must ship its run-<ts>.ann.json in the same PR. Grading is
+#    same-PR (the developer + genealogist teams grade every run they commit).
+#    Treeless runs (crashed/skipped before a tree) are exempt. Scoped to
+#    PR-added run logs via `git diff --diff-filter=A` (needs BASE_SHA/HEAD_SHA
+#    and full history).
+#
+# 2. Fixture-validity gate (ADVISORY, docs/specs/e2e-test-spec.md §14): every
+#    committed fixture under eval/tests/e2e/<slug>/ should have a committed
+#    run log with verdict=pass. Missing ones are warning annotations only, so a
+#    draft fixture (validity run still owed) can land.
 #
 # This check only reads committed files; it does NOT run a live e2e test
 # (those are too expensive to gate PRs — see spec §12).
@@ -26,13 +28,18 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - name: Check out PR
+      - name: Check out PR with full history
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
 
-      - name: Report e2e fixture validity (advisory, non-blocking)
+      - name: Check e2e grading gate (blocking) + fixture validity (advisory)
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: python eval/harness/scripts/check_e2e_fixtures.py

--- a/.gitignore
+++ b/.gitignore
@@ -43,9 +43,11 @@ eval/runlogs/unit/*/scratch_*.ann.json
 eval/runlogs/unit/*/.partial_*.json
 eval/runlogs/unit/*/.partial_*.json.tmp
 
-# Non-passing e2e runs write as scratch_* — only a passing run validates a
-# fixture and is committed (e2e-test-spec.md §14). Keeps a failed run from
-# being committed as if it had validated the fixture.
+# A skipped e2e run (the judge never ran — the agent crashed before producing
+# a tree, so there is nothing to grade) writes as scratch_* and stays out of
+# version control. Gradeable runs (pass/partial/fail) are committed as
+# run-<ts>.* — a committed fail is retained signal (a capability gap to retry).
+# Fixture validity is separate: only a pass validates a fixture (spec §14).
 eval/runlogs/e2e/*/scratch_*
 
 # `make e2e-view` staging folder — the latest run's final state copied in as

--- a/README.md
+++ b/README.md
@@ -209,7 +209,8 @@ Code in this checkout), alongside the other dev skills `compare-state` and
 | Skill | What it does | Say this |
 |-------|-------------|----------|
 | **author-e2e-fixture** | Turns a finished research project into an e2e benchmark fixture — snapshots the resolved state, strips the answer from the tree, records what was stripped as expected findings. Produces the five files in a `<slug>/` subfolder of the working directory, ready to move into `eval/tests/e2e/`. | "Save this research as an e2e test" / "Make a benchmark from this" |
-| **interpret-e2e-result** | Reads an e2e run log and explains the verdict, stop reason, expected-vs-found gaps, and the most likely cause (agent regression, FS data drift, single-run jitter, etc.), pointing at the relevant transcript section. | "Why did this fixture fail?" / "Interpret the latest e2e run" |
+| **interpret-e2e-result** | Reads an e2e run log and explains what the agent recovered and missed (from its final tree), why it stopped, and the most likely cause (agent regression, FS data drift, single-run jitter, etc.) — blind to the judge's own grades — pointing at the relevant transcript section. | "Why did this fixture fail?" / "Interpret the latest e2e run" |
+| **grade-e2e-run** | Grades an e2e run into its calibration annotation: presents each expected finding + the agent's evidence (blind to the judge's grades), collects the genealogist's true/partial/false labels, and writes `run-<ts>.ann.json`. | "Grade this e2e run" / "Annotate this run for calibration" |
 
 ## Agents
 
@@ -453,9 +454,9 @@ What's shipped:
 - **26 shipped skills.** Full GPS research cycle from `init-project`
   through `proof-conclusion`, plus reference skills (locality-guide,
   historical-context, translation, search-familysearch-wiki, search-wikipedia)
-  and guardrails (validate-schema, check-warnings, convert-dates). The two
-  e2e-benchmark skills (author-e2e-fixture, interpret-e2e-result) are
-  repo-local dev tooling under `.claude/skills/`, not shipped in the plugin.
+  and guardrails (validate-schema, check-warnings, convert-dates). The three
+  e2e-benchmark skills (author-e2e-fixture, interpret-e2e-result, grade-e2e-run)
+  are repo-local dev tooling under `.claude/skills/`, not shipped in the plugin.
 - **1 Cowork agent.** `gps-mentor` — a BCG-style senior-genealogist
   review, invoked by `/research` at GPS checkpoints and on demand.
 - **Researcher profile.** `init-project` captures experience level and

--- a/docs/e2e-testing-guide.md
+++ b/docs/e2e-testing-guide.md
@@ -98,15 +98,15 @@ this in order. Each step gates the next.
    cd eval/harness
    uv run python -m e2e.run_e2e --test <slug>      # Windows: RunE2E.bat
    ```
-6. **Grade the run into a calibration annotation.** Ask Claude Code to grade
+6. **Grade the run into a calibration annotation.** Run `/grade-e2e-run` to grade
    this run — it reads the fixture and the run's two `final-*` siblings (not the
    run log itself, so you grade *blind* to the judge's own calls), shows you each
    expected finding + the agent's evidence, and writes `run-<ts>.ann.json` beside
-   the run log with your `per_finding` labels. Validate it with
-   `uv run python -m e2e.calibrate_judge --dry-run`, then commit the `.ann.json`.
-   **Running the full calibration** (no `--dry-run`) — reading agreement and
-   tuning `judge_prompt.md` — is the maintainer's step, done once a batch of
-   grades exists, not per contributor. See "Judge calibration" below.
+   the run log with your `per_finding` labels, and self-checks that file. Then
+   commit the `.ann.json` — you do **not** run `calibrate_judge`. **All
+   `calibrate_judge` use** (`--dry-run` classification and the full agreement
+   sweep, tuning `judge_prompt.md`) is the maintainer's step, done periodically
+   once a batch of grades exists. See "Judge calibration" below.
 7. **Finalize the spec** at `docs/specs/e2e-test-spec.md` based on
    what the first run actually needed (drop the "Provisional" note).
 8. **Add a second fixture** with non-overlapping tags. Verify both
@@ -157,9 +157,9 @@ Before running any e2e test:
 
 ## Creating a new e2e test
 
-> **Where these skills live.** `author-e2e-fixture` and `interpret-e2e-result`
-> are repo-local dev tooling under `.claude/skills/` (alongside `compare-state`
-> and `draft-unit-test`), **not** part of the shipped Cowork plugin. Claude Code
+> **Where these skills live.** `author-e2e-fixture`, `interpret-e2e-result`, and
+> `grade-e2e-run` are repo-local dev tooling under `.claude/skills/` (alongside
+> `compare-state` and `draft-unit-test`), **not** part of the shipped Cowork plugin. Claude Code
 > picks them up automatically when you work in this checkout, so the `/`-commands
 > below just work. See [`docs/plan/e2e-skills.md`](plan/e2e-skills.md) for why
 > they're a distinct class from the research skills.
@@ -631,10 +631,12 @@ Each run writes four files to
 | `run-<ts>.final-tree.gedcomx.json` | The agent's final tree (what the judge graded) |
 | `run-<ts>.final-research.json` | The agent's final `research.json` |
 
-All four are committed for a **passing** run (the `run-<ts>.*` names above). A
-non-passing run writes the same four files with a `scratch_<ts>.*` prefix that's
-gitignored — only a passing run validates a fixture (§14 of the spec), so
-failures aren't committed.
+All four are committed for any **gradeable** run — verdict pass, partial, or
+fail (the `run-<ts>.*` names above). A committed `fail` is retained signal (a
+capability gap to retry later) and must be graded like any committed run. Only a
+**skipped** run — the judge never ran, so there's no tree to grade — writes the
+four files with a gitignored `scratch_<ts>.*` prefix. Fixture *validity* is
+separate: only a passing run validates a fixture (§14 of the spec).
 
 ### Interpreting `verdict`
 
@@ -769,20 +771,16 @@ only the human's recall labels:
 
 ### Grading a run
 
-Ask Claude Code to **grade `run-<ts>.json`**. It reads the fixture and the run's
-two `final-*` siblings — **not the run log itself**, so you grade *blind* to the
+Run **`/grade-e2e-run`** on the run. It reads the fixture and the run's two
+`final-*` siblings — **not the run log itself**, so you grade *blind* to the
 judge's own calls (that independence is what makes the agreement number mean
-something) — shows you each expected finding plus the agent's evidence, and writes
-the `.ann.json` with your labels. Then:
+something) — shows you each expected finding plus the agent's evidence, writes the
+`.ann.json` with your labels, and self-checks that file (labels complete, keys
+match the fixture's finding ids). Then commit the `.ann.json`.
 
-```bash
-cd eval/harness
-uv run python -m e2e.calibrate_judge --dry-run   # classifies; no API calls
-```
-
-`--dry-run` is the safe pre-commit check: it flags an incomplete grade (a `null`
-label), a drifted one (its finding ids no longer match the fixture — re-grade or
-delete), or a malformed file. Commit the `.ann.json` once it's clean.
+You do **not** run `calibrate_judge` — not even `--dry-run`. That tool classifies
+*every* annotation in the tree and is the maintainer's step (below). The skill's
+self-check covers the one file you wrote.
 
 **Grading an `avoid` finding** (negative fixtures, spec §3.4.1): the helper shows
 the *absence* of the wrong candidate as the evidence. Label it `true` when that
@@ -804,9 +802,10 @@ boundary call (the judge called the burial a full match; the human downgraded it
 ### Running calibration (maintainer step)
 
 > **This is the maintainer's step, not the contributors'.** Contributors grade
-> their runs and stop at `--dry-run` (validation only). One person runs the full
-> calibration below once a batch of grades exists, because it makes a judge API
-> call per graded run and the result only means something across the whole
+> their runs with `/grade-e2e-run` and commit — they never run `calibrate_judge`.
+> One person (the maintainer) runs it periodically once a batch of grades exists:
+> `--dry-run` to classify the committed annotations, then the full calibration
+> below — a judge API call per graded run, meaningful only across the whole
 > collected set.
 
 ```bash
@@ -856,18 +855,21 @@ intended bootstrap — you don't need a calibrated judge to start grading.
    --test <slug>`). Commit the fixture and its passing run log.
 4. **Read the result** — the `/interpret-e2e-result` skill explains the
    verdict and proof-quality score.
-5. **Grade it** — ask Claude Code to grade the run (see "Grading a run" above),
-   run `uv run python -m e2e.calibrate_judge --dry-run` to validate, and commit
-   the `run-<ts>.ann.json`. *This is the grade correction:* where you disagree
-   with the judge, your `per_finding` label captures it. **Contributors stop at
-   `--dry-run`** — the full `calibrate_judge` makes API calls and is the
-   maintainer's step.
+5. **Grade it** — run `/grade-e2e-run` on the run (see "Grading a run" above)
+   and commit the `run-<ts>.ann.json`. You label each finding *blind* to the
+   judge's own grades, and the skill self-checks the file before you commit.
+   **Contributors never run `calibrate_judge`** — not even `--dry-run`.
+   Classification and the full agreement sweep are the maintainer's step.
+   CI enforces same-PR grading: the `check-e2e-fixtures` action **blocks** the
+   PR if a run log you added produced a final tree but has no committed
+   `.ann.json` sibling (a treeless crash/skip run is exempt — nothing to grade).
 
 **The maintainer**, once enough grades are collected, runs `RunCalibration.bat`
 (full `calibrate_judge` — the only step that calls the judge API at scale), reads
 the per-finding agreement and every disagreement, and tunes
-`eval/harness/e2e/judge_prompt.md`. The annotation *is* the corrected grade —
-there is no separate annotation UI.
+`eval/harness/e2e/judge_prompt.md`. The annotation *is* the human grade,
+arrived at blind — there is no separate annotation UI, and it is not a
+correction of the judge's own labels.
 
 ---
 

--- a/docs/plan/e2e-annotation-calibration.md
+++ b/docs/plan/e2e-annotation-calibration.md
@@ -1,6 +1,12 @@
 # E2E judge calibration via run-log annotations
 
-**Status:** proposed (for review)
+**Status:** implemented. `calibrate_judge` loads per-run `.ann.json` grades; the
+`/grade-e2e-run` skill produces them (blind); a blocking `check-e2e-fixtures`
+grading gate enforces one per committed run (same-PR). This doc is the original
+design — where it says "ask Claude Code to grade," that is now the
+`/grade-e2e-run` skill, and the deferred "CI `--dry-run` check" shipped as a
+presence gate. Current guidance: `docs/e2e-testing-guide.md` "Judge calibration"
+and `docs/specs/e2e-test-spec.md` §7.4 / §14.
 **Branch:** `e2e-annotation-calibration`
 
 ## Summary

--- a/docs/specs/e2e-test-spec.md
+++ b/docs/specs/e2e-test-spec.md
@@ -593,8 +593,9 @@ There is **no `verdict` field** — the per-run verdict is derived from `per_fin
 
 Three integrity rules make the agreement number trustworthy:
 
-- **Never auto-created.** A run does not emit an annotation; a human grades the
-  runs worth grading.
+- **Never auto-created.** A run does not emit an annotation; a human grades it
+  with the `/grade-e2e-run` skill (which reads the fixture + the two `final-*`
+  siblings, writes the `.ann.json`, and self-checks it before commit).
 - **Graded blind.** The grade flow reads the fixture and the run's two `final-*`
   siblings, **never `run-<ts>.json`** (where the judge's own labels live), so the
   human label is independent of the judge under test.
@@ -607,8 +608,13 @@ calibration-case directory. `calibrate_judge` discovers every
 reports **per-finding agreement (the ≥80% gate)**, proof-quality agreement
 (advisory), and a per-slug breakdown. A drifted annotation (its `per_finding` keys
 no longer match the fixture's finding ids — i.e. `expected-findings.json` was
-edited after grading) is a hard error: re-grade or delete it. Run
-`uv run python -m e2e.calibrate_judge` (`--dry-run` lints without API calls).
+edited after grading) is a hard error: re-grade or delete it. Grading is
+**same-PR**: every committed run is graded in the PR that commits it (all
+gradeable runs — pass/partial/fail — are committed; §8), enforced by the blocking
+`check-e2e-fixtures`
+grading gate (§14). Contributors run only `/grade-e2e-run`; the **maintainer**
+runs `uv run python -m e2e.calibrate_judge` periodically (`--dry-run` lints
+without API calls) — contributors never do.
 
 ---
 
@@ -624,11 +630,14 @@ Per run, under `eval/runlogs/e2e/<test-id>/`:
 | `run-<timestamp>.final-research.json` | The agent's final `research.json` |
 | `run-<timestamp>.ann.json` | *Optional.* A human's calibration grade of this run — present only when someone grades it, never auto-emitted (see §7.4) |
 
-A **passing** run is the fixture's validity artifact and is committed under the
-`run-<timestamp>.*` names above; any other outcome (partial / fail / skipped) is
-written with a `scratch_<timestamp>.*` prefix that `.gitignore` keeps out of
-version control, so a non-passing run can't be committed as if it validated the
-fixture (§14). The `.ann.json` is committed when a run is graded. To investigate
+Any **gradeable** run — verdict `pass`, `partial`, or `fail` — is committed
+under the `run-<timestamp>.*` names above and must be graded (§7.4). A committed
+`fail` is deliberately retained signal: a capability gap to retry later, exactly
+as a failing unit test is committed. Only a `skipped` run (the judge never ran —
+no tree to grade) is written with a `scratch_<timestamp>.*` prefix that
+`.gitignore` keeps out of version control. Fixture *validity* is a separate axis
+(§14): only a `pass` validates a fixture, so a committed `fail` does not count as
+validation. The `.ann.json` is committed when a run is graded. To investigate
 a regression — a test that previously passed and now fails
 — diff the old and new `tool_calls` arrays: each entry's `response_summary`
 captures the FS result inline, so collection-hit changes, hint-count shifts, or
@@ -689,7 +698,8 @@ acting.
   axis (§7) is a single rubric-graded score, not the multi-layer
   human-verified grading of `gps-test-spec.md`
 - CI integration of the *live run* — e2e runs are too expensive to gate
-  PRs. (A cheap advisory artifact check runs in CI — non-blocking; see §14.)
+  PRs. (Cheap artifact checks do run in CI — a blocking grading gate plus an
+  advisory fixture-validity report; see §14.)
 - Multi-run statistical scoring (N=3) — single run, accepted noise.
   **At project start this is a deliberate "good enough to catch the big
   issues" call, not a permanent one.** Because N=1 + live-FS drift
@@ -737,15 +747,15 @@ This is surfaced two ways:
 - **Documentation requirement** — the author runs the fixture for real
   and commits the passing run log alongside it (testing guide §5,
   first-time-setup step 6).
-- **CI artifact report** (cheap, no live run, **advisory / non-blocking**)
-  — the `check-e2e-fixtures` workflow flags any committed
-  `eval/tests/e2e/<slug>/` lacking a committed
-  `eval/runlogs/e2e/<slug>/run-*.json` with `verdict: pass`, as a warning
-  annotation. It reads only committed files and does **not** trigger a
-  live e2e run (those stay out of CI per §12). It **does not block merge**
-  — unlike the unit-test runlog discipline check (`check_runlogs.py`,
-  `check-runlogs.yml`), which is blocking. The advisory framing lets draft
-  fixtures land — notably PID-less fixtures authored without FamilySearch
-  access (`author-e2e-fixture` Path 3) whose validity run can only happen
-  on an FS-enabled host — while still surfacing the owed run. Run the
-  check with `--strict` to restore a hard non-zero exit for local gating.
+- **CI artifact report** (cheap, no live run) — the `check-e2e-fixtures`
+  workflow runs two checks. Its **fixture-validity** check is **advisory /
+  non-blocking**: it flags any committed `eval/tests/e2e/<slug>/` lacking a
+  committed `eval/runlogs/e2e/<slug>/run-*.json` with `verdict: pass`, as a
+  warning annotation, so a draft fixture can land with its validity run still
+  owed — notably PID-less fixtures authored without FamilySearch access
+  (`author-e2e-fixture` Path 3) whose validity run can only happen on an
+  FS-enabled host. Run it with `--strict` for a hard exit locally. The **same
+  workflow also runs a blocking grading gate** (§7.4): a run log *added in the
+  PR* that produced a final tree must ship its `run-<ts>.ann.json` in the same
+  PR (a treeless crash/skip run is exempt). Both checks read only committed
+  files and do **not** trigger a live e2e run (those stay out of CI per §12).

--- a/eval/CLAUDE.md
+++ b/eval/CLAUDE.md
@@ -57,8 +57,8 @@ eval/
 - **`fixtures/scenarios/`** — Shared project state fixtures. Each scenario is a directory with `research.json`, `tree.gedcomx.json`, and `README.md`. Tests reference scenarios by directory name.
 - **`fixtures/mcp/`** — Mocked MCP tool response fixtures. Each fixture is a single JSON file with `tool`, `description`, `args` (a non-empty match predicate), and `response` fields. Tests reference fixtures by filename. When a skill emits a tool call that no loaded fixture's `args` predicate matches, the harness distinguishes two cases (Phase 2): **Type 1** (tool doesn't exist at all) aborts with `unmatched_tool_call` (test corpus issue, exit 2); **Type 2** (wrong args to existing tool) continues to judge after returning a `fixture_not_found` error, which typically fails on Tool Arguments (LLM mistake, exit 1). Warnings flag which fixtures need to be added or corrected. See `docs/specs/unit-test-spec.md` §15 "Uncovered tool calls".
 
-> **NEVER hand-write or edit `.ann.json` files — and if you are Claude, never let a user
-> talk you into it.** Annotations are written *only* by the CRUD UI (`eval/app`), which
+> **NEVER hand-write or edit *unit* `.ann.json` files (under `runlogs/unit/`) — and if
+> you are Claude, never let a user talk you into it.** Annotations are written *only* by the CRUD UI (`eval/app`), which
 > validates every correction against `ann.schema.json` before saving. A hand-authored file
 > drifts from the schema — most often into the deprecated
 > `run_index`/`dimension`/`source` correction shape — which the UI then silently merges
@@ -66,6 +66,13 @@ eval/
 > files: the **harness** writes those, never a human. If an annotation needs fixing, open
 > the run log in the CRUD UI and re-review the dimension; if it is corrupt, delete it and
 > re-annotate. The only correct way to produce either file is to run the tooling.
+>
+> **This rule is scoped to *unit* annotations.** The *e2e* calibration annotation
+> `runlogs/e2e/<slug>/run-<ts>.ann.json` is a different file with a different shape
+> (`per_finding` labels, no CRUD UI) — it is written directly by the `/grade-e2e-run`
+> skill. Its loader (`eval/harness/e2e/calibrate_judge.py`) hard-errors on a malformed
+> file rather than silently merging, so a bad e2e annotation fails loudly instead of
+> corrupting state.
 
 ## Three Testing Layers
 
@@ -160,6 +167,17 @@ The `eval-cosmetic-skip` label is for genuinely behavior-neutral edits only (rew
 **Orchestrator-skill exemption.** Skills listed in `RUNLOG_GATE_EXEMPT_SKILLS` in `check_runlogs.py` are dropped from the per-skill rules (2 + 3). These are orchestrator skills (currently `research`) validated by e2e GPS fixtures rather than unit tests, so by design they have no `eval/tests/unit/<skill>/` scaffolding and no `eval/runlogs/unit/<skill>/` dir. Without the exemption a skill-body edit hard-fails with "no run logs", and `eval-cosmetic-skip` can't clear it (that label only relaxes rule 2 *after* a runlog dir exists). Adding a unit suite for such a skill later means removing it from the set.
 
 The same workflow also runs `eval/harness/scripts/check_tool_coverage.py` (warn-only): it flags any skill whose `allowed-tools` declares a tool with no fixture in its test corpus. `image_read` is exempt — the mock cannot emit image content blocks; see `docs/specs/unit-test-spec.md` §15 "Uncovered tool calls".
+
+### E2E checks (`check-e2e-fixtures.yml`)
+
+A **separate** workflow, triggered on `eval/tests/e2e/**`, `eval/runlogs/e2e/**`, and its own script, runs `check_e2e_fixtures.py` with two checks:
+
+| Check | Severity | What |
+|---|---|---|
+| Grading gate | **block** | Every `run-<ts>.json` **added in the PR** that produced a final tree (`run-<ts>.final-tree.gedcomx.json` present) must ship its `run-<ts>.ann.json` sibling in the same PR. Grading is same-PR. Treeless runs (crash/skip before a tree) are exempt. Scoped to PR-added logs via `git diff --diff-filter=A` (`BASE_SHA`/`HEAD_SHA`); presence only — content validity is the maintainer's `calibrate_judge --dry-run`, not CI. |
+| Fixture validity | warn | Every fixture under `eval/tests/e2e/<slug>/` should have a committed `run-*.json` with `verdict=pass` (spec §14). Advisory so draft/PID-less fixtures can land with the validity run still owed; `--strict` hard-fails locally. |
+
+The e2e `.ann.json` is written by the `/grade-e2e-run` skill (blind grading), **not** the CRUD UI — see the "never hand-write" note above, which is scoped to *unit* annotations.
 
 ## Model Pinning
 

--- a/eval/README.md
+++ b/eval/README.md
@@ -276,7 +276,7 @@ run on demand.
 - **Spec:** [`../docs/specs/e2e-test-spec.md`](../docs/specs/e2e-test-spec.md) — fixture format, judge contract, result schema.
 - **Code:** `harness/e2e/` — orchestrator, judge, CLI.
 - **Fixtures:** `tests/e2e/<test-id>/` (added incrementally).
-- **Runlogs:** a passing run commits as `runlogs/e2e/<test-id>/run-<timestamp>.*`; non-passing runs write as gitignored `scratch_<timestamp>.*`.
+- **Runlogs:** a gradeable run (pass/partial/fail) commits as `runlogs/e2e/<test-id>/run-<timestamp>.*` and must be graded (`/grade-e2e-run`); only a skipped run (no tree) writes as gitignored `scratch_<timestamp>.*`. A committed fail is retained signal; only a pass validates the fixture (spec §14).
 
 ### Authoring a new fixture
 

--- a/eval/harness/e2e/result.py
+++ b/eval/harness/e2e/result.py
@@ -3,11 +3,14 @@
 A run produces four artifacts under eval/runlogs/e2e/<test-id>/, named by
 outcome (see runlog_prefix):
 
-- a PASSING run uses the committable `run-<timestamp>.*` prefix — it is the
-  fixture's validity artifact and is committed (e2e-test-spec.md §14).
-- any other outcome (partial / fail / skipped) uses `scratch_<timestamp>.*`,
-  which `.gitignore` keeps out of version control so a non-passing run can't
-  be committed as if it validated the fixture.
+- a gradeable run (verdict pass / partial / fail) uses the committable
+  `run-<timestamp>.*` prefix and is committed. A committed `fail` is retained
+  signal — "the system can't solve this yet; retry later" — exactly as a failing
+  unit test is committed. Fixture *validity* is a separate axis: only a `pass`
+  proves the fixture solvable (e2e-test-spec.md §14).
+- a `skipped` run (the judge never ran — the agent crashed before producing any
+  tree, so there is nothing to grade) uses `scratch_<timestamp>.*`, which
+  `.gitignore` keeps out of version control.
 
 The four files per run ({prefix} = `run-` or `scratch_`):
 
@@ -77,18 +80,28 @@ def timestamp_slug(now: datetime | None = None) -> str:
     return t.strftime("%Y-%m-%d_%H-%M-%S")
 
 
-def is_committable_run(verdict: str) -> bool:
-    """Whether a run is the fixture's *validity* artifact (committed).
+_GRADED_VERDICTS = frozenset({"pass", "partial", "fail"})
 
-    Only a `pass` validates a fixture (e2e-test-spec.md §14); every other
-    outcome is a scratch run that `.gitignore` keeps out of version control,
-    so a failed run can't be committed as if it had validated the fixture.
+
+def is_committable_run(verdict: str) -> bool:
+    """Whether a run produced a gradeable tree worth committing.
+
+    A judge verdict of pass / partial / fail means the run produced a final
+    tree, so it is committed as `run-<ts>.*` and must be graded (§7.4) —
+    including a `fail`, which is retained signal: a capability gap to retry
+    later, exactly as a failing unit test is committed. Only a `skipped` (or
+    otherwise non-graded) run — the judge never ran, so there is no tree to
+    grade — stays a gitignored `scratch_` run.
+
+    Fixture *validity* is a separate axis (e2e-test-spec.md §14): only a `pass`
+    proves the fixture solvable. A committed `fail` does NOT validate the
+    fixture — check_e2e_fixtures.py looks specifically for verdict==pass.
     """
-    return verdict == "pass"
+    return verdict in _GRADED_VERDICTS
 
 
 def runlog_prefix(verdict: str) -> str:
-    """`run-` for a committable (passing) run, otherwise `scratch_`."""
+    """`run-` for a gradeable run (pass/partial/fail), else `scratch_` (skipped)."""
     return "run-" if is_committable_run(verdict) else "scratch_"
 
 

--- a/eval/harness/e2e/run_e2e.py
+++ b/eval/harness/e2e/run_e2e.py
@@ -28,7 +28,7 @@ from e2e.orchestrator import (
     run_e2e_test,
 )
 from e2e.report import print_rollup
-from e2e.result import E2eResult
+from e2e.result import E2eResult, is_committable_run
 
 
 # eval/.env holds ANTHROPIC_API_KEY (written by Setup.bat). The judge talks
@@ -103,10 +103,15 @@ async def _run_one(fixture_dir: Path, **kwargs) -> E2eResult:
     print(f"  verdict: {result.verdict}    stop_reason: {result.stop_reason}")
     _print_proof_quality(result)
     print(f"  result: {paths['result']}")
-    if result.verdict != "pass":
+    if not is_committable_run(result.verdict):
         print(
-            "  (scratch run — gitignored; only a passing run validates the "
-            "fixture and is committed)"
+            "  (scratch run — gitignored; the judge didn't run, so there's "
+            "nothing to grade or commit)"
+        )
+    elif result.verdict != "pass":
+        print(
+            f"  (written as a committable {result.verdict} run — retained signal; "
+            "grade it with /grade-e2e-run, then commit it + the .ann.json before landing)"
         )
     return result
 

--- a/eval/harness/e2e/view.py
+++ b/eval/harness/e2e/view.py
@@ -11,8 +11,8 @@ viewer with `make electron`); every later `make e2e-view` overwrites the two
 files in place, so an already-open viewer refreshes live across the
 run -> interpret -> grade -> improve -> re-run loop.
 
-Picks the newest run by mtime, so it works on a failing `scratch_*` run (the
-usual thing to inspect) as well as a committed passing `run-*` one.
+Picks the newest run by mtime across both prefixes, so it works on a gitignored
+`scratch_*` skipped run as well as a committed `run-*` (pass/partial/fail) one.
 """
 
 from __future__ import annotations

--- a/eval/harness/scripts/check_e2e_fixtures.py
+++ b/eval/harness/scripts/check_e2e_fixtures.py
@@ -1,5 +1,22 @@
 #!/usr/bin/env python3
-"""GH Action: report the e2e fixture-validity gate (e2e-test-spec.md §14).
+"""GH Action: two e2e discipline checks on committed files.
+
+## 1. Grading gate (BLOCKING)
+
+Every run log ADDED in this PR that produced a final tree must ship its
+``run-<ts>.ann.json`` in the same PR — grading is same-PR (the developer +
+genealogist teams grade every run they commit; docs/e2e-testing-guide.md
+"Grading a run"). A treeless run (crashed or skipped before a final tree) is
+exempt: there is nothing to grade. Scoped to PR-added run logs via
+``git diff --diff-filter=A`` (BASE_SHA / HEAD_SHA), mirroring check_runlogs.py
+rule 1; skipped when run outside a PR (env unset), so local runs still work.
+
+This gate checks annotation *presence*, not content. Content validity (drift /
+incomplete / malformed) is the maintainer's ``calibrate_judge --dry-run`` step
+and the loader's own classification — kept out of CI so this check stays
+stdlib-only and never needs the harness venv.
+
+## 2. Fixture-validity gate (advisory — e2e-test-spec.md §14)
 
 A fixture the agent can never solve is worthless — every failure is a
 false negative on agent capability. Stripping completeness proves the
@@ -10,13 +27,12 @@ Recommendation: every committed fixture under eval/tests/e2e/<slug>/
 should have at least one committed run log under
 eval/runlogs/e2e/<slug>/run-*.json whose `verdict` is `pass`.
 
-This check is **advisory** in CI: it reports any fixture lacking a
-passing run log as a non-blocking warning, but does NOT fail the PR.
-Only the unit-test runlog discipline check (check_runlogs.py) blocks
-merge. The advisory framing lets draft fixtures — e.g. PID-less
-fixtures authored without FamilySearch access, with their validity run
-still owed — land while still surfacing the owed run. Pass `--strict`
-to turn violations back into a hard non-zero exit (for local gating).
+The fixture-validity check is **advisory** in CI: it reports any fixture
+lacking a passing run log as a non-blocking warning, but does NOT fail the PR
+(the grading gate above is the blocking part). The advisory framing lets draft
+fixtures — e.g. PID-less fixtures authored without FamilySearch access, with
+their validity run still owed — land while still surfacing the owed run. Pass
+`--strict` to turn fixture-validity violations into a hard exit too (local).
 
 It is cheap and CI-safe: it only reads committed files. It does NOT
 trigger a live e2e run (those stay out of CI — too expensive).
@@ -28,6 +44,8 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
+import subprocess
 import sys
 from pathlib import Path
 
@@ -36,6 +54,85 @@ REPO_ROOT = HERE.parents[2]
 FIXTURES_DIR = REPO_ROOT / "eval" / "tests" / "e2e"
 RUNLOGS_DIR = REPO_ROOT / "eval" / "runlogs" / "e2e"
 
+
+# --------------------------------------------------------------------------- #
+# Grading gate (blocking): PR-added run logs with a tree must ship their ann
+# --------------------------------------------------------------------------- #
+
+def _is_primary_runlog(name: str) -> bool:
+    """True for a ``run-<ts>.json`` result file, excluding its siblings
+    (``.ann.json``, ``.final-tree.gedcomx.json``, ``.final-research.json``,
+    ``.transcript.md``)."""
+    return (
+        name.startswith("run-")
+        and name.endswith(".json")
+        and not name.endswith(".ann.json")
+        and ".final-" not in name
+    )
+
+
+def git_added_e2e_runlogs() -> list[Path] | None:
+    """PR-added primary run logs under eval/runlogs/e2e/, as repo-relative Paths.
+
+    Returns ``None`` when not running in a PR context (BASE_SHA / HEAD_SHA
+    unset) — the grading gate only applies to files added in the PR, mirroring
+    check_runlogs.py rule 1 (``git diff --diff-filter=A``). Local runs skip it.
+    """
+    base = os.environ.get("BASE_SHA")
+    head = os.environ.get("HEAD_SHA")
+    if not base or not head:
+        return None
+    out = subprocess.check_output(
+        ["git", "diff", "--name-only", "--diff-filter=A", base, head],
+        text=True,
+        cwd=REPO_ROOT,
+    )
+    added: list[Path] = []
+    for line in out.splitlines():
+        path = line.strip()
+        if not path:
+            continue
+        p = Path(path)
+        if (
+            len(p.parts) >= 4
+            and p.parts[:3] == ("eval", "runlogs", "e2e")
+            and _is_primary_runlog(p.name)
+        ):
+            added.append(p)
+    return added
+
+
+def check_added_runlogs_graded(added: list[Path]) -> list[str]:
+    """Blocking gate: every PR-added run log that produced a tree must ship its
+    committed ``run-<ts>.ann.json`` in the same PR.
+
+    A treeless run (crashed / skipped before a final tree) is exempt — the
+    loader can't grade it and neither can a human, so no annotation is owed.
+    Detected by the absence of the ``run-<ts>.final-tree.gedcomx.json`` sibling,
+    which is exactly the file the grade loader requires.
+    """
+    violations: list[str] = []
+    for rel in added:
+        runlog = REPO_ROOT / rel
+        stem = rel.name[: -len(".json")]  # run-<ts>
+        slug_dir = runlog.parent
+        tree = slug_dir / f"{stem}.final-tree.gedcomx.json"
+        ann = slug_dir / f"{stem}.ann.json"
+        if not tree.exists():
+            continue  # treeless run — nothing to grade
+        if not ann.exists():
+            violations.append(
+                f"run log '{rel}' produced a final tree but no committed "
+                f"'{stem}.ann.json'. Grade it in this PR with /grade-e2e-run and "
+                "commit the annotation (grading is same-PR; "
+                "docs/e2e-testing-guide.md 'Grading a run')."
+            )
+    return violations
+
+
+# --------------------------------------------------------------------------- #
+# Fixture-validity gate (advisory)
+# --------------------------------------------------------------------------- #
 
 def _fixture_slugs(fixtures_dir: Path) -> list[str]:
     """Committed fixtures — dirs with a fixture.json (skips .gitkeep etc.)."""
@@ -54,6 +151,8 @@ def _has_passing_runlog(runlogs_dir: Path, slug: str) -> bool:
     if not slug_dir.is_dir():
         return False
     for runlog in slug_dir.glob("run-*.json"):
+        if not _is_primary_runlog(runlog.name):
+            continue
         try:
             data = json.loads(runlog.read_text(encoding="utf-8"))
         except (json.JSONDecodeError, OSError):
@@ -79,48 +178,72 @@ def check(
     return violations
 
 
+# --------------------------------------------------------------------------- #
+# CLI
+# --------------------------------------------------------------------------- #
+
 def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(description="Report the e2e fixture-validity gate.")
+    parser = argparse.ArgumentParser(
+        description="E2E discipline checks: grading gate (blocking) + "
+        "fixture-validity gate (advisory)."
+    )
     parser.add_argument(
         "--strict",
         action="store_true",
-        help="Exit non-zero on violations (hard gate). Default is advisory: "
-        "violations are reported as warnings and the check still passes.",
+        help="Also exit non-zero on fixture-validity violations (hard gate). "
+        "Default is advisory for validity: those are warnings and still pass. "
+        "The grading gate is always blocking.",
     )
     args = parser.parse_args(argv)
 
+    exit_code = 0
+
+    # --- Grading gate (blocking) — PR-added run logs with a tree need an ann ---
+    added = git_added_e2e_runlogs()
+    if added is None:
+        print("E2E grading gate skipped (no PR context: BASE_SHA/HEAD_SHA unset).")
+    else:
+        grade_violations = check_added_runlogs_graded(added)
+        if grade_violations:
+            print(
+                "E2E grading gate — PR-added run logs missing their annotation:",
+                file=sys.stderr,
+            )
+            for v in grade_violations:
+                print(f"::error::{v}")
+                print(f"  - {v}", file=sys.stderr)
+            exit_code = 1
+        else:
+            print(f"E2E grading gate OK ({len(added)} added run log(s) checked).")
+
+    # --- Fixture-validity gate (advisory unless --strict) ---
     violations = check()
     slugs = _fixture_slugs(FIXTURES_DIR)
-
     if not violations:
         print(f"E2E fixture-validity check OK ({len(slugs)} fixture(s) checked).")
-        return 0
-
-    # Advisory by default: surface which fixtures still lack a committed
-    # passing run log, but do NOT fail the PR. The e2e validity gate is a
-    # landing recommendation (e2e-test-spec.md §14), not a merge blocker —
-    # only the unit-test runlog discipline check (check_runlogs.py) blocks.
-    print(
-        "E2E fixture-validity check — fixtures without a committed passing run log:",
-        file=sys.stderr,
-    )
-    for v in violations:
-        # GitHub Actions warning annotation (surfaced on the PR, non-blocking).
-        print(f"::warning::{v}")
-        print(f"  - {v}", file=sys.stderr)
-
-    if args.strict:
+    else:
         print(
-            f"{len(violations)} fixture(s) failed the validity gate (--strict).",
+            "E2E fixture-validity check — fixtures without a committed passing run log:",
             file=sys.stderr,
         )
-        return 1
-    print(
-        f"{len(violations)} fixture(s) advisory-flagged (run still owed); "
-        "not blocking the PR.",
-        file=sys.stderr,
-    )
-    return 0
+        for v in violations:
+            # GitHub Actions warning annotation (surfaced on the PR, non-blocking).
+            print(f"::warning::{v}")
+            print(f"  - {v}", file=sys.stderr)
+        if args.strict:
+            print(
+                f"{len(violations)} fixture(s) failed the validity gate (--strict).",
+                file=sys.stderr,
+            )
+            exit_code = 1
+        else:
+            print(
+                f"{len(violations)} fixture(s) advisory-flagged (run still owed); "
+                "not blocking the PR.",
+                file=sys.stderr,
+            )
+
+    return exit_code
 
 
 if __name__ == "__main__":

--- a/eval/harness/tests/unit/test_check_e2e_fixtures.py
+++ b/eval/harness/tests/unit/test_check_e2e_fixtures.py
@@ -119,3 +119,96 @@ def test_main_passes_on_clean_corpus(monkeypatch):
     monkeypatch.setattr(check_e2e_fixtures, "_fixture_slugs", lambda d: [])
     assert check_e2e_fixtures.main([]) == 0
     assert check_e2e_fixtures.main(["--strict"]) == 0
+
+
+# --- Grading gate (blocking): PR-added run logs with a tree must ship an ann ---
+
+
+def _make_e2e_run(repo_root: Path, slug: str, ts: str, *, tree: bool, ann: bool) -> Path:
+    """Create a run log (+ optional tree/ann siblings) under repo_root and
+    return its repo-relative Path (as git diff would report it)."""
+    d = repo_root / "eval" / "runlogs" / "e2e" / slug
+    d.mkdir(parents=True, exist_ok=True)
+    (d / f"run-{ts}.json").write_text(json.dumps({"verdict": "pass"}), encoding="utf-8")
+    if tree:
+        (d / f"run-{ts}.final-tree.gedcomx.json").write_text("{}", encoding="utf-8")
+    if ann:
+        (d / f"run-{ts}.ann.json").write_text("{}", encoding="utf-8")
+    return Path("eval/runlogs/e2e") / slug / f"run-{ts}.json"
+
+
+def test_is_primary_runlog_excludes_siblings():
+    ok = check_e2e_fixtures._is_primary_runlog
+    assert ok("run-2026-06-15_10-00-00.json")
+    assert not ok("run-2026-06-15_10-00-00.ann.json")
+    assert not ok("run-2026-06-15_10-00-00.final-tree.gedcomx.json")
+    assert not ok("run-2026-06-15_10-00-00.final-research.json")
+    assert not ok("run-2026-06-15_10-00-00.transcript.md")
+
+
+def test_graded_run_with_tree_and_ann_passes(tmp_path, monkeypatch):
+    monkeypatch.setattr(check_e2e_fixtures, "REPO_ROOT", tmp_path)
+    rel = _make_e2e_run(tmp_path, "smith", "2026-06-15_10-00-00", tree=True, ann=True)
+    assert check_e2e_fixtures.check_added_runlogs_graded([rel]) == []
+
+
+def test_run_with_tree_missing_ann_is_violation(tmp_path, monkeypatch):
+    monkeypatch.setattr(check_e2e_fixtures, "REPO_ROOT", tmp_path)
+    rel = _make_e2e_run(tmp_path, "smith", "2026-06-15_10-00-00", tree=True, ann=False)
+    violations = check_e2e_fixtures.check_added_runlogs_graded([rel])
+    assert len(violations) == 1
+    assert "run-2026-06-15_10-00-00.ann.json" in violations[0]
+
+
+def test_treeless_run_is_exempt(tmp_path, monkeypatch):
+    """A crashed/skipped run with no final tree owes no annotation."""
+    monkeypatch.setattr(check_e2e_fixtures, "REPO_ROOT", tmp_path)
+    rel = _make_e2e_run(tmp_path, "smith", "2026-06-15_10-00-00", tree=False, ann=False)
+    assert check_e2e_fixtures.check_added_runlogs_graded([rel]) == []
+
+
+def test_git_added_returns_none_without_pr_env(monkeypatch):
+    monkeypatch.delenv("BASE_SHA", raising=False)
+    monkeypatch.delenv("HEAD_SHA", raising=False)
+    assert check_e2e_fixtures.git_added_e2e_runlogs() is None
+
+
+def test_git_added_filters_to_primary_e2e_runlogs(monkeypatch):
+    monkeypatch.setenv("BASE_SHA", "aaa")
+    monkeypatch.setenv("HEAD_SHA", "bbb")
+    diff = "\n".join(
+        [
+            "eval/runlogs/e2e/smith/run-2026-06-15_10-00-00.json",
+            "eval/runlogs/e2e/smith/run-2026-06-15_10-00-00.ann.json",
+            "eval/runlogs/e2e/smith/run-2026-06-15_10-00-00.final-tree.gedcomx.json",
+            "eval/runlogs/unit/citation/v1.json",
+            "eval/tests/e2e/smith/fixture.json",
+            "",
+        ]
+    )
+    monkeypatch.setattr(
+        check_e2e_fixtures.subprocess, "check_output", lambda *a, **k: diff
+    )
+    assert check_e2e_fixtures.git_added_e2e_runlogs() == [
+        Path("eval/runlogs/e2e/smith/run-2026-06-15_10-00-00.json")
+    ]
+
+
+def test_main_grading_gate_blocks_missing_ann(tmp_path, monkeypatch):
+    """A PR-added run log with a tree but no ann fails main() even when
+    fixture-validity is clean."""
+    monkeypatch.setattr(check_e2e_fixtures, "REPO_ROOT", tmp_path)
+    rel = _make_e2e_run(tmp_path, "smith", "2026-06-15_10-00-00", tree=True, ann=False)
+    monkeypatch.setattr(check_e2e_fixtures, "git_added_e2e_runlogs", lambda: [rel])
+    monkeypatch.setattr(check_e2e_fixtures, "check", lambda: [])
+    monkeypatch.setattr(check_e2e_fixtures, "_fixture_slugs", lambda d: [])
+    assert check_e2e_fixtures.main([]) == 1
+
+
+def test_main_grading_gate_passes_when_graded(tmp_path, monkeypatch):
+    monkeypatch.setattr(check_e2e_fixtures, "REPO_ROOT", tmp_path)
+    rel = _make_e2e_run(tmp_path, "smith", "2026-06-15_10-00-00", tree=True, ann=True)
+    monkeypatch.setattr(check_e2e_fixtures, "git_added_e2e_runlogs", lambda: [rel])
+    monkeypatch.setattr(check_e2e_fixtures, "check", lambda: [])
+    monkeypatch.setattr(check_e2e_fixtures, "_fixture_slugs", lambda d: [])
+    assert check_e2e_fixtures.main([]) == 0

--- a/eval/harness/tests/unit/test_e2e_result.py
+++ b/eval/harness/tests/unit/test_e2e_result.py
@@ -85,15 +85,18 @@ def test_write_result_files_handles_missing_tree_and_research(tmp_path: Path):
     assert not paths["research"].exists()
 
 
-def test_is_committable_run_only_pass():
-    assert is_committable_run("pass") is True
-    for v in ("partial", "fail", "skipped", "aborted", ""):
+def test_is_committable_run_graded_verdicts():
+    for v in ("pass", "partial", "fail"):
+        assert is_committable_run(v) is True
+    for v in ("skipped", "aborted", ""):
         assert is_committable_run(v) is False
 
 
-def test_runlog_prefix_pass_vs_scratch():
+def test_runlog_prefix_graded_vs_scratch():
     assert runlog_prefix("pass") == "run-"
-    assert runlog_prefix("fail") == "scratch_"
+    assert runlog_prefix("partial") == "run-"
+    assert runlog_prefix("fail") == "run-"
+    assert runlog_prefix("skipped") == "scratch_"
 
 
 def test_passing_run_uses_committable_run_prefix(tmp_path: Path):
@@ -109,10 +112,10 @@ def test_passing_run_uses_committable_run_prefix(tmp_path: Path):
     assert paths["result"].exists()
 
 
-def test_non_passing_run_uses_gitignored_scratch_prefix(tmp_path: Path):
-    """A non-passing run is named scratch_* so .gitignore keeps it out of
-    version control — it can't be committed as a fixture's validity run."""
-    for verdict in ("partial", "fail", "skipped"):
+def test_gradeable_non_pass_run_uses_committable_run_prefix(tmp_path: Path):
+    """partial and fail produced a tree, so they commit as run-<ts>.* (retained
+    signal, and gradeable) — not scratch."""
+    for verdict in ("partial", "fail"):
         result = E2eResult(
             test_id="t", captured_at="2026-05-26_14-30-45",
             verdict=verdict, stop_reason="natural_end",
@@ -121,8 +124,22 @@ def test_non_passing_run_uses_gitignored_scratch_prefix(tmp_path: Path):
             result=result, runlog_dir=tmp_path, transcript="",
             final_tree=None, final_research=None, timestamp="2026-05-26_14-30-45",
         )
-        assert paths["result"].name == "scratch_2026-05-26_14-30-45.json", verdict
-        assert paths["transcript"].name == "scratch_2026-05-26_14-30-45.transcript.md"
+        assert paths["result"].name == "run-2026-05-26_14-30-45.json", verdict
+
+
+def test_skipped_run_uses_gitignored_scratch_prefix(tmp_path: Path):
+    """A skipped run (judge never ran, no tree to grade) is named scratch_* so
+    .gitignore keeps it out of version control."""
+    result = E2eResult(
+        test_id="t", captured_at="2026-05-26_14-30-45",
+        verdict="skipped", stop_reason="error",
+    )
+    paths = write_result_files(
+        result=result, runlog_dir=tmp_path, transcript="",
+        final_tree=None, final_research=None, timestamp="2026-05-26_14-30-45",
+    )
+    assert paths["result"].name == "scratch_2026-05-26_14-30-45.json"
+    assert paths["transcript"].name == "scratch_2026-05-26_14-30-45.transcript.md"
 
 
 def test_write_result_files_creates_runlog_dir(tmp_path: Path):

--- a/eval/runlogs/e2e/spriggs-parents-1898/run-2026-06-24_13-47-25.ann.json
+++ b/eval/runlogs/e2e/spriggs-parents-1898/run-2026-06-24_13-47-25.ann.json
@@ -1,0 +1,7 @@
+{
+  "per_finding": {
+    "f1": "true",
+    "f2": "true"
+  },
+  "proof_quality_score": 3
+}


### PR DESCRIPTION
## Summary

Adds the producer + CI gate for the e2e judge-calibration `.ann.json` files that `calibrate_judge` already consumes, plus two design corrections surfaced while building it.

**New skill — `/grade-e2e-run`** (`.claude/skills/grade-e2e-run/`): presents each expected finding + the agent's tree evidence, collects the genealogist's blind `true`/`partial`/`false` labels, and writes `run-<ts>.ann.json`. It reads **only** the fixture + the run's `final-*` siblings (never `run-<ts>.json`/`judge_output`), so the human label is arrived at independently of the judge under test. Self-checks the file it writes; never runs `calibrate_judge` (maintainer-only).

**Blocking grading gate** (`check_e2e_fixtures.py` + `check-e2e-fixtures.yml`): every run log **added in a PR** that produced a final tree must ship its `run-<ts>.ann.json` in the same PR. Treeless/skipped runs are exempt; scoped to PR-added logs via `git diff --diff-filter=A`. The fixture-validity check stays advisory. Presence-only — content validity remains the maintainer's `calibrate_judge --dry-run`.

**Commit model — fail runs are now retained.** Previously only `pass` runs were committed (others gitignored `scratch_`). Now `pass`/`partial`/`fail` all commit as `run-<ts>.*` and must be graded — a committed `fail` is important signal (a capability gap to retry later), exactly like a committed failing unit test. Only `skipped` runs (judge never ran, no tree to grade) stay gitignored scratch.

**`interpret-e2e-result` is now blind to `judge_output`.** It determines found/missed from the final tree vs `expected-findings.json` and describes the agent's *own* proof conclusion — never the judge's `verdict`/`per_finding`/`proof_quality`. This keeps interpret → grade independent, since interpret naturally runs first.

**First calibration annotation** included: `spriggs-parents-1898/run-2026-06-24_13-47-25` (f1/f2 = true/true, proof 3), verified via `calibrate_judge --dry-run` ("1 graded annotation ready; 0 errors").

## Tests

- `test_check_e2e_fixtures.py` (+9 grading-gate cases) and `test_e2e_result.py` (commit-model) green.
- Full non-e2e harness suite: the only failures are **pre-existing** `test_cli.py` cases (cost-cap / concurrency / scheduling) unrelated to this change — verified by stashing these edits and re-running.

## Docs

`eval/CLAUDE.md` (hand-write rule scoped to unit + new e2e-gate table), `docs/e2e-testing-guide.md`, `docs/specs/e2e-test-spec.md` §7.4/§8/§14, `README.md` skill catalog, and the `e2e-annotation-calibration` plan marked implemented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
