### PR TITLE
Fix viewer-ui test run: stub scrollIntoView (unimplemented in jsdom)

### DIFF
--- a/packages/viewer-ui/vitest.setup.ts
+++ b/packages/viewer-ui/vitest.setup.ts
@@ -1,6 +1,12 @@
 import '@testing-library/jest-dom/vitest'
-import { afterEach } from 'vitest'
+import { afterEach, vi } from 'vitest'
 import { cleanup } from '@testing-library/react'
+
+// jsdom does not implement Element.prototype.scrollIntoView. Components that
+// call it (e.g. SidecarPanel's auto-scroll to the focused person, fired from a
+// requestAnimationFrame) would otherwise throw an unhandled error that fails the
+// whole test run even though every test passes. Stub it to a no-op.
+window.HTMLElement.prototype.scrollIntoView = vi.fn()
 
 afterEach(() => {
   cleanup()


### PR DESCRIPTION
## Problem

`packages/viewer-ui`'s vitest run exited **1** even though all 118 tests pass. The failure was a single unhandled error:

```
TypeError: node.scrollIntoView is not a function
 ❯ src/components/shared/SidecarPanel.tsx:98
```

`SidecarPanel`'s auto-scroll to the focused person calls `Element.prototype.scrollIntoView` inside a `requestAnimationFrame`. jsdom does not implement `scrollIntoView`, so it threw asynchronously and tripped the whole run.

This had drifted onto `main` because the JS-workspace `pnpm test` isn't wired into any CI workflow.

## Fix

Stub the unimplemented method in the viewer-ui vitest setup (a no-op), rather than adding test-only guards to production code:

```ts
// packages/viewer-ui/vitest.setup.ts
window.HTMLElement.prototype.scrollIntoView = vi.fn()
```

## Verification

- `packages/viewer-ui` vitest now exits **0** — 17 files, 118 tests, no unhandled errors.
- Full sweep also confirmed green: engine vitest (1205), server pytest (45), eval harness pytest (642), eval-ui vitest (118), workspace typecheck (5 pkgs), eslint (electron + eval/app).

🤖 Generated with [Claude Code](https://claude.com/claude-code)