### PR TITLE
Add e2e fixture: bottemiller-parents (#527)

### DIFF
--- a/eval/runlogs/e2e/bottemiller-parents/run-2026-07-02_14-24-47.ann.json
+++ b/eval/runlogs/e2e/bottemiller-parents/run-2026-07-02_14-24-47.ann.json
@@ -1,0 +1,8 @@
+{
+  "per_finding": {
+    "f1": "true",
+    "f2": "true"
+  },
+  "proof_quality_score": 2,
+  "annotator": "ernest"
+}

--- a/eval/runlogs/e2e/bottemiller-parents/run-2026-07-02_14-24-47.final-research.json
+++ b/eval/runlogs/e2e/bottemiller-parents/run-2026-07-02_14-24-47.final-research.json
@@ -1,0 +1,1387 @@
+{
+  "project": {
+    "id": "rp_bottemiller_parents",
+    "objective": "Who were the parents of William Henry Bottemiller, born 29 December 1862 in Franconia Township, Chisago County, Minnesota, and died 13 May 1929 in Oregon City, Clackamas County, Oregon?",
+    "subject_person_ids": [
+      "249W-9LP"
+    ],
+    "status": "active",
+    "created": "2026-07-01T00:00:00Z",
+    "updated": "2026-07-01T00:00:00Z"
+  },
+  "researcher_profile": {
+    "experience_level": "intermediate",
+    "subscriptions": [],
+    "narration_guidance": "concise"
+  },
+  "questions": [
+    {
+      "id": "q_001",
+      "question": "What does the death certificate of William Henry Bottemiller (died 13 May 1929, Oregon City, Clackamas County, Oregon) report about his parents?",
+      "rationale": "Oregon death certificates post-1903 routinely name the deceased's father and mother's maiden name. William died in 1929 in Oregon City, so a state death certificate almost certainly exists and is the single most direct source likely to name both parents. Answering this question first establishes a baseline identification of the parents before corroborating evidence is sought in census records and other sources.",
+      "selection_basis": "objective_decomposition",
+      "priority": "high",
+      "status": "resolved",
+      "depends_on": [],
+      "unblocks": [],
+      "resolved": "2026-07-02",
+      "resolution_assertion_ids": [
+        "a_004",
+        "a_005",
+        "a_006",
+        "a_007"
+      ],
+      "exhaustive_declaration": {
+        "declared": true,
+        "justification": "The question asks specifically what the death certificate reports about William Henry Bottemiller's parents. The FamilySearch 'Oregon, Deaths and Burials, 1903\u20131947' database abstract (src_001) explicitly names Father = Casper A. Battermiller and Mother = Mary Mehlman (maiden name). Three FamilySearch collections searched; Oregon Death Index (src_002) and Find a Grave Index (src_003) independently confirm the death event and subject identity. Original certificate image (ark:/61903/1:2:MYQR-859) was attempted via record_read and returned 'not found' \u2014 the derivative abstract is the best accessible version. Newspaper full-text returned nil for 1929. No conflicts among sources.",
+        "log_entry_ids": [
+          "log_001",
+          "log_002",
+          "log_003",
+          "log_004",
+          "log_005",
+          "log_006",
+          "log_007",
+          "log_008"
+        ],
+        "stop_criteria": {
+          "goal_alignment": "Yes \u2014 src_001 explicitly states Father = Casper A. Battermiller and Mother = Mary Mehlman, directly answering what the death certificate reports about his parents.",
+          "repository_breadth": "Three FamilySearch collections searched (1675532, 1946790, 2221801). Newspaper full-text nil. External sites (Ancestry, findagrave.com) not searched \u2014 noted as limitation for future corroboration questions; acceptable scope for this specific death-certificate question.",
+          "original_substitution": "Attempted original certificate image (ark:/61903/1:2:MYQR-859 via record_read); returned 'not found' \u2014 the 1:2: source-citation ARK points to the Oregon State Archives original, inaccessible via available tools. Derivative abstract (src_001) is best available.",
+          "independent_verification": "Three independent sources confirm the death event and subject identity. Only one source (src_001) names the parents; both parent assertions derive from the same unknown personal informant on the death certificate \u2014 one evidence unit for parentage. Subsequent questions will seek census and other corroboration.",
+          "evidence_class": "All sources are derivative (src_001, src_002) or authored (src_003). No original records with primary information accessible. Accuracy limited by indexer fidelity to the original certificate.",
+          "conflict_resolution": "No conflicts. All three sources agree on name, death date (13 May 1929), and place (Clackamas, Oregon). Parent names in src_001 are not contradicted.",
+          "overturn_risk": "Low for the specific question (what does the death certificate report). The abstract clearly names both parents. Future census research may refine the identification of the named parents but will not change what this certificate reports."
+        }
+      },
+      "created": "2026-07-02"
+    },
+    {
+      "id": "q_002",
+      "question": "Does the 1880 U.S. census show William Henry Bottemiller residing in the household of Casper A. Bottemiller, corroborating the parentage named in his 1929 Oregon death certificate?",
+      "rationale": "The death certificate abstract (src_001, q_001 outcome) names Casper A. Battermiller as William's father, but parentage rests on a single derivative source with a secondary unknown informant \u2014 a one-evidence-unit foundation. The tree already records William's 1880 residence as Bertha, Todd County, Minnesota (existing tree fact), placing him in Minnesota at approximately age 17-18. The 1880 U.S. census introduced explicit relationship columns (unlike 1850/1860) and would directly record a parent-child relationship if William was still in Casper Bottemiller's household. A positive result would provide an independent original source with primary relationship information, creating the second evidence unit needed to advance parentage from possible to probable. FamilySearch 1880 U.S. Census (collection 1417683) is fully indexed and searchable by person and location.",
+      "selection_basis": "objective_decomposition",
+      "priority": "high",
+      "status": "open",
+      "depends_on": [
+        "q_001"
+      ],
+      "unblocks": [],
+      "resolved": null,
+      "resolution_assertion_ids": [],
+      "exhaustive_declaration": {
+        "declared": false,
+        "justification": null,
+        "log_entry_ids": [],
+        "stop_criteria": null
+      },
+      "created": "2026-07-02"
+    }
+  ],
+  "plans": [
+    {
+      "id": "pl_001",
+      "question_id": "q_001",
+      "status": "completed",
+      "created": "2026-07-02",
+      "items": [
+        {
+          "id": "pli_001",
+          "sequence": 1,
+          "record_type": "vital_record",
+          "jurisdiction": "Oregon, United States",
+          "date_range": "1929",
+          "repository": "FamilySearch",
+          "rationale": "Oregon state death registration began in 1903. The 'Oregon, Oregon State Archives, Death Records, 1864-1968' collection (FamilySearch collection 3657650) is indexed with images and covers Clackamas County. A 1929 state death certificate for William Henry Bottemiller should name his father and mother's maiden name \u2014 the single most direct source for both parents' identities.",
+          "fallback_for": null,
+          "status": "completed"
+        },
+        {
+          "id": "pli_002",
+          "sequence": 2,
+          "record_type": "vital_record",
+          "jurisdiction": "Oregon, United States",
+          "date_range": "1929",
+          "repository": "Ancestry",
+          "rationale": "Ancestry's 'Oregon, U.S., State Deaths, 1864-1971' (collection 61675) may provide access to the same underlying death certificate or a separate transcription with different indexing. If the FamilySearch search fails to locate the record (spelling variants, missed indexing), Ancestry's independent index is the first fallback.",
+          "fallback_for": "pli_001",
+          "status": "skipped"
+        },
+        {
+          "id": "pli_003",
+          "sequence": 3,
+          "record_type": "vital_record",
+          "jurisdiction": "Oregon, United States",
+          "date_range": "1903-1998",
+          "repository": "FamilySearch",
+          "rationale": "The 'Oregon, Death Index, 1903-1998' (FamilySearch collection 1946790, 1.4M records) is an index-only resource but covers a very broad date range with high record counts, providing an independent confirmation of the death date, place, and spelling used. Useful if the primary record search returns no image-bearing result.",
+          "fallback_for": "pli_001",
+          "status": "skipped"
+        },
+        {
+          "id": "pli_004",
+          "sequence": 4,
+          "record_type": "newspaper",
+          "jurisdiction": "Clackamas County, Oregon, United States",
+          "date_range": "1929",
+          "repository": "other",
+          "rationale": "An obituary in the Oregon City Enterprise or another Clackamas County paper from May 1929 is likely to name William's surviving relatives and may directly state his parents or note his birthplace in Minnesota, corroborating or extending the death certificate evidence. Historic Oregon Newspapers (oregonnews.uoregon.edu) and Chronicling America have digitized Oregon papers from this period.",
+          "fallback_for": null,
+          "status": "skipped"
+        },
+        {
+          "id": "pli_005",
+          "sequence": 5,
+          "record_type": "cemetery",
+          "jurisdiction": "Oregon City, Clackamas County, Oregon, United States",
+          "date_range": "1929",
+          "repository": "other",
+          "rationale": "A Find A Grave or BillionGraves entry for William Henry Bottemiller in Oregon City may include an obituary link, memorial notes naming parents, or a memorial photo. This is a quick FAN-adjacent check that can corroborate the death certificate or point to additional sources.",
+          "fallback_for": null,
+          "status": "skipped"
+        }
+      ]
+    },
+    {
+      "id": "pl_002",
+      "question_id": "q_001",
+      "status": "completed",
+      "created": "2026-07-02",
+      "items": [
+        {
+          "id": "pli_006",
+          "sequence": 1,
+          "record_type": "vital_record",
+          "jurisdiction": "Oregon, United States",
+          "date_range": "1929",
+          "repository": "FamilySearch",
+          "rationale": "Existing tree source S8VD-92V (ark:/61903/1:1:VZHS-YXF) is the Oregon Death Index, 1903-1998 entry for 'Henry William Battemiller' (collection 1946790). Reading this record provides an independent confirmation of the death identification separate from the collection-1675532 abstract, and may reveal different field values. Mentor identified this as needed for repository breadth.",
+          "fallback_for": null,
+          "status": "completed"
+        },
+        {
+          "id": "pli_007",
+          "sequence": 2,
+          "record_type": "cemetery",
+          "jurisdiction": "Oregon City, Clackamas County, Oregon, United States",
+          "date_range": "1929",
+          "repository": "FamilySearch",
+          "rationale": "Existing tree source S8VD-963 (ark:/61903/1:1:QV2C-WKHM) is the Find a Grave Index entry for William Henry Bottemiller. Reading this record may reveal memorial notes, parents, or family connections added by contributors. Provides an independent compiled source to corroborate or challenge the death certificate data.",
+          "fallback_for": null,
+          "status": "completed"
+        },
+        {
+          "id": "pli_008",
+          "sequence": 3,
+          "record_type": "newspaper",
+          "jurisdiction": "Clackamas County, Oregon, United States",
+          "date_range": "1929",
+          "repository": "FamilySearch",
+          "rationale": "FamilySearch full-text search of digitized Oregon newspapers may surface a May 1929 obituary for William Bottemiller in Oregon City or Clackamas County. An obituary written at the time of death would be an independent second informant for the parents' names, directly addressing the single-source limitation of q_001. Mentor explicitly identified this as the highest-value gap to fill.",
+          "fallback_for": null,
+          "status": "completed"
+        }
+      ]
+    },
+    {
+      "id": "pl_003",
+      "question_id": "q_002",
+      "status": "active",
+      "created": "2026-07-02",
+      "items": [
+        {
+          "id": "pli_009",
+          "sequence": 1,
+          "record_type": "census",
+          "jurisdiction": "Todd County, Minnesota, United States",
+          "date_range": "1880",
+          "repository": "FamilySearch",
+          "rationale": "William Henry Bottemiller appears in the tree with a residence in Bertha, Todd County, in 1880 (from prior extraction). If Casper A. Bottemiller \u2014 the father named on the 1929 death certificate \u2014 is the household head in Todd County in 1880 with William listed as a child, that is direct evidence answering q_002. The 1880 U.S. Federal Census (collection 1417683) is fully indexed on FamilySearch.",
+          "fallback_for": null,
+          "status": "completed"
+        },
+        {
+          "id": "pli_010",
+          "sequence": 2,
+          "record_type": "census",
+          "jurisdiction": "Chisago County, Minnesota, United States",
+          "date_range": "1870",
+          "repository": "FamilySearch",
+          "rationale": "William was born December 1862 in Franconia Township, Chisago County. At age ~8 in 1870 he would most likely still be in his birth-county household. Finding Casper Bottemiller as head with William as a child in Chisago County in 1870 would independently corroborate the father-child relationship. The 1870 U.S. Federal Census (collection 1438024) is indexed on FamilySearch.",
+          "fallback_for": null,
+          "status": "in_progress"
+        },
+        {
+          "id": "pli_011",
+          "sequence": 3,
+          "record_type": "census",
+          "jurisdiction": "Minnesota, United States",
+          "date_range": "1875",
+          "repository": "FamilySearch",
+          "rationale": "The Minnesota State Census of 1875 (collection 1503053, 612,847 indexed records) bridges the gap between the 1870 and 1880 federal censuses. If the family had already migrated from Chisago to Todd County by 1875, this would document the household composition at an intermediate point and show William still in Casper's household.",
+          "fallback_for": null,
+          "status": "planned"
+        },
+        {
+          "id": "pli_012",
+          "sequence": 4,
+          "record_type": "census",
+          "jurisdiction": "Chisago County, Minnesota, United States",
+          "date_range": "1865",
+          "repository": "FamilySearch",
+          "rationale": "The Minnesota State Census of 1865 (collection 1503054, 246,591 indexed records) would show the Bottemiller family in Chisago County when William was about 2\u20133 years old, directly after his 1862 birth. Finding Casper as head with an infant William corroborates the parentage claim closest to William's birth.",
+          "fallback_for": null,
+          "status": "planned"
+        },
+        {
+          "id": "pli_013",
+          "sequence": 5,
+          "record_type": "census",
+          "jurisdiction": "Todd County, Minnesota, United States",
+          "date_range": "1880",
+          "repository": "Ancestry",
+          "rationale": "Fallback for pli_009. Ancestry's 1880 U.S. Federal Census index (collection 6742) uses different name parsing and OCR than FamilySearch's and may surface a Bottemiller entry missed due to indexing variants (Battermiller, Bottimiller, etc.). Provides independent search coverage of the same record set.",
+          "fallback_for": "pli_009",
+          "status": "planned"
+        },
+        {
+          "id": "pli_014",
+          "sequence": 6,
+          "record_type": "vital_record",
+          "jurisdiction": "Chisago County, Minnesota, United States",
+          "date_range": "1862-1870",
+          "repository": "FamilySearch",
+          "rationale": "Minnesota Birth and Death Records 1866\u20131916 (collection 1858352, indexed) and Minnesota County Birth Records 1863\u20131983 (collection 1920099, images only) may contain a birth registration for William Henry Bottemiller in Franconia Township, Chisago County, 29 December 1862. If found, the record would name his parents directly, providing original-source corroboration of the parentage relationship.",
+          "fallback_for": null,
+          "status": "planned"
+        }
+      ]
+    }
+  ],
+  "log": [
+    {
+      "id": "log_001",
+      "plan_item_id": "pli_001",
+      "performed": "2026-07-02T13:28:45.471Z",
+      "tool": "record_search",
+      "query": {
+        "surname": "Bottemiller",
+        "givenName": "William",
+        "deathYearFrom": 1927,
+        "deathYearTo": 1931,
+        "deathPlace": "Oregon",
+        "recordType": "death",
+        "collectionId": "3657650"
+      },
+      "outcome": "negative",
+      "results_examined": 0,
+      "external_site": null,
+      "results_ref": null,
+      "results_available": 0,
+      "notes": "Zero hits for Bottemiller/William in Oregon State Archives Death Records (coll. 3657650). Existing tree sources show he is indexed as 'Henry William Battemiller' \u2014 surname is corrupted in the index."
+    },
+    {
+      "id": "log_002",
+      "plan_item_id": "pli_001",
+      "performed": "2026-07-02T13:31:44.172Z",
+      "tool": "record_search",
+      "query": {
+        "surname": "Battemiller",
+        "givenName": "Henry",
+        "deathYearFrom": 1927,
+        "deathYearTo": 1931,
+        "deathPlace": "Oregon",
+        "recordType": "death",
+        "collectionId": "3657650"
+      },
+      "outcome": "negative",
+      "results_examined": 4,
+      "external_site": null,
+      "results_ref": "results/log_002.json",
+      "results_available": 4,
+      "notes": "4 results returned; all are phonetic near-misses (Kitsmiller, Heckelsmiller, Ottermiller, Kitzmiller Phelps). None match William Henry Bottemiller. Collection 3657650 does not appear to have his record indexed under either Bottemiller or Battemiller."
+    },
+    {
+      "id": "log_003",
+      "plan_item_id": "pli_001",
+      "performed": "2026-07-02T13:31:53.242Z",
+      "tool": "record_search",
+      "query": {
+        "surname": "Battemiller",
+        "deathYearFrom": 1928,
+        "deathYearTo": 1930,
+        "collectionId": "3657650"
+      },
+      "outcome": "negative",
+      "results_examined": 20,
+      "external_site": null,
+      "results_ref": "results/log_003.json",
+      "results_available": 43,
+      "notes": "43 total matches, 20 examined \u2014 all phonetic near-misses (Kitzmiller, Rhinemiller, Zaunmiller, etc.). William Bottemiller's record does not appear to be indexed in collection 3657650 under any Battemiller variant. Pivoting to record_read of existing indexed records in other collections."
+    },
+    {
+      "id": "log_004",
+      "plan_item_id": "pli_001",
+      "performed": "2026-07-02T13:32:20.759Z",
+      "tool": "record_search",
+      "query": {
+        "tool": "record_read",
+        "recordId": "ark:/61903/1:1:F8WM-X8F",
+        "collection": "Oregon, Deaths and Burials, 1903-1947",
+        "collectionId": "1675532",
+        "note": "Reading existing source S8VD-MGG already attached to tree person 249W-9LP"
+      },
+      "outcome": "positive",
+      "results_examined": 1,
+      "external_site": null,
+      "results_ref": null,
+      "results_available": 1,
+      "notes": "record_read of ark:/61903/1:1:F8WM-X8F (coll. 1675532) reveals the death-record abstract for Henry William Battemiller (=William Henry Bottemiller), died 13 May 1929, Clackamas, Oregon. PARENTS NAMED: Father = Casper A. Battermiller (ark:/61903/1:1:F8WM-X8N); Mother = Mary Mehlman (ark:/61903/1:1:F8WM-X8J). Spouse named as Lilly Jane (consistent with known wife Lillie Jane Kleinsmith). Birth year abstracted as 1862. Image source reference: ark:/61903/1:2:MYQR-859. This directly answers q_001."
+    },
+    {
+      "id": "log_005",
+      "plan_item_id": "pli_001",
+      "performed": "2026-07-02T13:52:04.549Z",
+      "tool": "record_read",
+      "query": {
+        "tool": "record_read",
+        "recordId": "ark:/61903/1:2:MYQR-859",
+        "purpose": "Attempt to access original Oregon death certificate image underlying the database abstract in src_001"
+      },
+      "outcome": "negative",
+      "results_examined": 0,
+      "external_site": null,
+      "results_ref": null,
+      "results_available": 0,
+      "notes": "record_read of ark:/61903/1:2:MYQR-859 (1:2: source-citation ARK) returned 'Record not found'. This is a source citation pointer to the Oregon State Archives certificate image; it is not directly accessible as a FamilySearch record entity. Original image inaccessible via available tools. Derivative database abstract (src_001) remains the best available version of this record."
+    },
+    {
+      "id": "log_006",
+      "plan_item_id": "pli_006",
+      "performed": "2026-07-02T13:53:43.427Z",
+      "tool": "record_read",
+      "query": {
+        "tool": "record_read",
+        "recordId": "ark:/61903/1:1:VZHS-YXF",
+        "collection": "Oregon, Death Index, 1903-1998",
+        "collectionId": "1946790"
+      },
+      "outcome": "positive",
+      "results_examined": 1,
+      "external_site": null,
+      "results_ref": null,
+      "results_available": 1,
+      "notes": "record_read of ark:/61903/1:1:VZHS-YXF (Oregon Death Index, 1903-1998) returns: name 'Henry William Battemiller', death 13 May 1929, Clackamas, Oregon. Index-only \u2014 no parent names. Independently confirms the death event and subject identification from a second collection (1946790 vs. 1675532 for src_001). Source citation ARK: ark:/61903/1:2:9MSQ-JPYR."
+    },
+    {
+      "id": "log_007",
+      "plan_item_id": "pli_007",
+      "performed": "2026-07-02T13:53:51.257Z",
+      "tool": "record_read",
+      "query": {
+        "tool": "record_read",
+        "recordId": "ark:/61903/1:1:QV2C-WKHM",
+        "collection": "Find a Grave Index",
+        "collectionId": "2221801"
+      },
+      "outcome": "positive",
+      "results_examined": 1,
+      "external_site": null,
+      "results_ref": null,
+      "results_available": 1,
+      "notes": "record_read of ark:/61903/1:1:QV2C-WKHM (Find a Grave Index) returns: name 'William Henry Bottemiller' (correct form, not transposed), birth 29 Dec 1862, death 13 May 1929, burial Clarkes, Clackamas, Oregon. No parent names in the FamilySearch index. External memorial page at findagrave.com GRid=64307258 may have more detail but requires an external site visit. Authored/compiled source. Confirms subject identity and death date independently."
+    },
+    {
+      "id": "log_008",
+      "plan_item_id": "pli_008",
+      "performed": "2026-07-02T13:53:58.560Z",
+      "tool": "fulltext_search",
+      "query": {
+        "keywords": "+Bottemiller +Oregon +1929",
+        "recordType": "newspaper",
+        "yearFrom": 1929,
+        "yearTo": 1929
+      },
+      "outcome": "negative",
+      "results_examined": 0,
+      "external_site": null,
+      "results_ref": null,
+      "results_available": 0,
+      "notes": "Zero results for '+Bottemiller +Oregon +1929' in FamilySearch newspaper full-text search. No Oregon newspapers from 1929 containing 'Bottemiller' are currently digitized and indexed in FamilySearch. A May 1929 Oregon City obituary may exist in Historic Oregon Newspapers (oregonnews.uoregon.edu) or Chronicling America but would require a separate external-site search."
+    },
+    {
+      "id": "log_009",
+      "plan_item_id": "pli_009",
+      "performed": "2026-07-02T14:10:08.771Z",
+      "tool": "record_search",
+      "query": {
+        "surname": "Bottemiller",
+        "recordType": "census",
+        "residencePlace": "Minnesota, United States",
+        "residenceYearFrom": 1880,
+        "residenceYearTo": 1880,
+        "collectionId": "1417683"
+      },
+      "outcome": "negative",
+      "results_examined": 20,
+      "external_site": null,
+      "results_ref": null,
+      "results_available": 29,
+      "notes": "29 fuzzy matches returned but none bear the Bottemiller surname \u2014 all are Bottomaly/Bottomly families from Wright and Martin counties. FamilySearch index does not appear to have an exact Bottemiller entry for Minnesota 1880. Will retry with spelling variants."
+    },
+    {
+      "id": "log_010",
+      "plan_item_id": "pli_009",
+      "performed": "2026-07-02T14:14:15.636Z",
+      "tool": "record_search",
+      "query": {
+        "givenName": "William",
+        "givenNameAlt": "Willie",
+        "surname": "Bottemiller",
+        "surnameAlt": "Battermiller",
+        "recordType": "census",
+        "residenceYearFrom": 1880,
+        "residenceYearTo": 1880,
+        "birthYearFrom": 1860,
+        "birthYearTo": 1865,
+        "collectionId": "1417683"
+      },
+      "outcome": "positive",
+      "results_examined": 20,
+      "external_site": null,
+      "results_ref": "results/log_010.json",
+      "results_available": 20,
+      "notes": "Found 'Willie Bottermiller' (born 1862 MN) in household of Henry Bottermiller (b.1828 Germany) and Mary Bottermiller (b.1838 Germany) in Bertha, Todd, Minnesota. Tree match 249W-9LP (5 stars). CONFLICT: death cert named father as 'Casper A. Bottemiller'; 1880 census head is 'Henry Bottermiller'. Record: ark:/61903/1:1:MZ9R-28C. Will read full record for details."
+    }
+  ],
+  "sources": [
+    {
+      "id": "src_001",
+      "gedcomx_source_description_id": "S8VD-MGG",
+      "citation": "\"Oregon, Deaths and Burials, 1903\u20131947,\" database, FamilySearch (https://www.familysearch.org/ark:/61903/1:1:F8WM-X8F : accessed 2 July 2026), entry for Henry William Battemiller, died 13 May 1929, Clackamas, Oregon; citing Oregon Vital Records.",
+      "citation_detail": {
+        "who": "Henry William Battemiller (deceased); Casper A. Battermiller (father); Mary Mehlman (mother)",
+        "what": "Oregon, Deaths and Burials, 1903\u20131947, database entry",
+        "when_created": "1929",
+        "when_accessed": "2026-07-02",
+        "where": "FamilySearch (familysearch.org)",
+        "where_within": "Entry ark:/61903/1:1:F8WM-X8F"
+      },
+      "source_classification": "derivative",
+      "repository": "FamilySearch",
+      "access_date": "2026-07-02",
+      "url": "https://www.familysearch.org/ark:/61903/1:1:F8WM-X8F",
+      "notes": "Database abstract of Oregon state death certificates; collection 1675532 has no images. Underlying certificate image referenced at ark:/61903/1:2:MYQR-859. Subject indexed as 'Henry William Battemiller' \u2014 given name transposed, surname corrupted from 'Bottemiller'. Parents named: father = Casper A. Battermiller; mother = Mary Mehlman (maiden name).",
+      "log_entry_id": "log_004"
+    },
+    {
+      "id": "src_002",
+      "gedcomx_source_description_id": "S8VD-92V",
+      "citation": "\"Oregon, Death Index, 1903-1998,\" database, FamilySearch (https://www.familysearch.org/ark:/61903/1:1:VZHS-YXF : accessed 2 July 2026), entry for Henry William Battemiller, died 13 May 1929, Clackamas, Oregon; citing Oregon Vital Records.",
+      "citation_detail": {
+        "who": "Henry William Battemiller (deceased)",
+        "what": "Oregon, Death Index, 1903-1998, database entry",
+        "when_created": "compiled from 1903\u20131998 original certificates",
+        "when_accessed": "2026-07-02",
+        "where": "FamilySearch (familysearch.org)",
+        "where_within": "Entry ark:/61903/1:1:VZHS-YXF"
+      },
+      "source_classification": "derivative",
+      "repository": "FamilySearch",
+      "access_date": "2026-07-02",
+      "url": "https://www.familysearch.org/ark:/61903/1:1:VZHS-YXF",
+      "notes": "Index-only resource (collection 1946790); no images. Confirms name 'Henry William Battemiller', death 13 May 1929, Clackamas, Oregon. No parent names present. Independent confirmation of subject's death from a different collection than src_001.",
+      "log_entry_id": "log_006"
+    },
+    {
+      "id": "src_003",
+      "gedcomx_source_description_id": "S8VD-963",
+      "citation": "\"Find a Grave Index,\" database, FamilySearch (https://www.familysearch.org/ark:/61903/1:1:QV2C-WKHM : accessed 2 July 2026), entry for William Henry Bottemiller; citing Find A Grave (Memorial GRid=64307258).",
+      "citation_detail": {
+        "who": "William Henry Bottemiller (deceased)",
+        "what": "Find a Grave Index, database entry",
+        "when_created": "contributed by memorial creator (date unknown)",
+        "when_accessed": "2026-07-02",
+        "where": "FamilySearch (familysearch.org) / Find A Grave (findagrave.com)",
+        "where_within": "Entry ark:/61903/1:1:QV2C-WKHM; GRid=64307258"
+      },
+      "source_classification": "authored",
+      "repository": "FamilySearch",
+      "access_date": "2026-07-02",
+      "url": "https://www.familysearch.org/ark:/61903/1:1:QV2C-WKHM",
+      "notes": "Compiled Find A Grave memorial. Name correctly rendered as 'William Henry Bottemiller' (not transposed). Birth 29 Dec 1862, death 13 May 1929, burial Clarkes, Clackamas, Oregon. No parent names. Memorial page at findagrave.com GRid=64307258 may contain further detail but requires an external-site visit.",
+      "log_entry_id": "log_007"
+    },
+    {
+      "id": "src_004",
+      "gedcomx_source_description_id": "S1",
+      "citation": "\"United States, Census, 1880\", FamilySearch (https://www.familysearch.org/ark:/61903/1:1:MZ9R-28W : 2 July 2026), Entry for Henry Bottermiller and Mary Bottermiller, Bertha, Todd, Minnesota, 1880.",
+      "citation_detail": {
+        "who": "Household of Henry Bottermiller",
+        "what": "United States, Census, 1880 (FamilySearch database index)",
+        "when_created": "1880",
+        "when_accessed": "2026-07-02",
+        "where": "FamilySearch (https://www.familysearch.org)",
+        "where_within": "Bertha, Todd County, Minnesota; household of Henry Bottermiller"
+      },
+      "source_classification": "derivative",
+      "repository": "FamilySearch",
+      "access_date": "2026-07-02",
+      "url": "https://www.familysearch.org/ark:/61903/1:1:MZ9R-28W",
+      "notes": "FamilySearch indexed database abstract derived from original 1880 U.S. Census schedule. Original image accessible at FamilySearch DGS ark:/61903/3:1:33S7-9YB8-R5D. Head listed as 'Henry Bottermiller,' born 1828, Germany \u2014 CONFLICTS with 1929 death cert naming William's father as 'Casper A. Bottemiller.' Wife listed as 'Mary Bottermiller,' born 1838, Germany \u2014 consistent with death cert 'Mary Mehlman' (maiden name). FamilySearch tree auto-matched Willie to 249W-9LP (5 stars, score 3.29).",
+      "log_entry_id": "log_010"
+    }
+  ],
+  "assertions": [
+    {
+      "id": "a_001",
+      "source_id": "src_001",
+      "record_id": "https://www.familysearch.org/ark:/61903/1:1:F8WM-X8F",
+      "record_persona_id": null,
+      "record_role": "deceased",
+      "fact_type": "name",
+      "value": "Henry William Battemiller (given name transposed; actual name William Henry Bottemiller)",
+      "structured_value": {
+        "given": "Henry William",
+        "surname": "Battemiller"
+      },
+      "information_quality": "indeterminate",
+      "informant": "unknown personal informant (likely surviving spouse or family member)",
+      "informant_proximity": "family_not_present",
+      "evidence_type": "direct",
+      "extracted_for_question_ids": [
+        "q_001"
+      ],
+      "log_entry_id": "log_004",
+      "informant_bias_notes": "Informant identity unknown from this database abstract; the specific person who registered the death and provided the deceased's name cannot be determined without the original certificate."
+    },
+    {
+      "id": "a_002",
+      "source_id": "src_001",
+      "record_id": "https://www.familysearch.org/ark:/61903/1:1:F8WM-X8F",
+      "record_persona_id": null,
+      "record_role": "deceased",
+      "fact_type": "death",
+      "value": "died 13 May 1929, Clackamas, Oregon",
+      "date": "13 May 1929",
+      "date_certainty": "exact",
+      "place": "Clackamas, Oregon",
+      "standard_place": "Clackamas, Oregon, United States",
+      "information_quality": "primary",
+      "informant": "attending physician (standard informant for death date/cause on Oregon death certificates)",
+      "informant_proximity": "witness",
+      "evidence_type": "direct",
+      "extracted_for_question_ids": [
+        "q_001"
+      ],
+      "log_entry_id": "log_004",
+      "informant_bias_notes": "Attending physician typically certified the death and was physically present \u2014 a witness to the death event. Proximity is witness, not merely official_duty."
+    },
+    {
+      "id": "a_003",
+      "source_id": "src_001",
+      "record_id": "https://www.familysearch.org/ark:/61903/1:1:F8WM-X8F",
+      "record_persona_id": null,
+      "record_role": "deceased",
+      "fact_type": "birth",
+      "value": "born 1862",
+      "date": "1862",
+      "date_certainty": "approximate",
+      "information_quality": "secondary",
+      "informant": "unknown personal informant (likely surviving spouse or family member)",
+      "informant_proximity": "family_not_present",
+      "evidence_type": "direct",
+      "extracted_for_question_ids": [
+        "q_001"
+      ],
+      "log_entry_id": "log_004"
+    },
+    {
+      "id": "a_004",
+      "source_id": "src_001",
+      "record_id": "https://www.familysearch.org/ark:/61903/1:1:F8WM-X8F",
+      "record_persona_id": null,
+      "record_role": "deceased",
+      "fact_type": "relationship",
+      "value": "father named as Casper A. Battermiller on death certificate",
+      "structured_value": {
+        "relationship_type": "child",
+        "related_person_role": "father_of_deceased"
+      },
+      "information_quality": "secondary",
+      "informant": "unknown personal informant (likely surviving spouse or family member)",
+      "informant_proximity": "family_not_present",
+      "informant_bias_notes": "Death certificate parental information is secondary information (the personal informant reported what they knew, not what they witnessed). However, the statement of the father's name is direct evidence for q_001 \u2014 it explicitly answers what the certificate reports about parents. Per GPS three-layer model, information quality (secondary) and evidence type (direct) are independent classifications. a_003 through a_007 all derive from the same unknown personal informant and form one evidence unit for parentage and birth facts.",
+      "evidence_type": "direct",
+      "extracted_for_question_ids": [
+        "q_001"
+      ],
+      "log_entry_id": "log_004"
+    },
+    {
+      "id": "a_005",
+      "source_id": "src_001",
+      "record_id": "https://www.familysearch.org/ark:/61903/1:1:F8WM-X8F",
+      "record_persona_id": null,
+      "record_role": "deceased",
+      "fact_type": "relationship",
+      "value": "mother named as Mary Mehlman on death certificate",
+      "structured_value": {
+        "relationship_type": "child",
+        "related_person_role": "mother_of_deceased"
+      },
+      "information_quality": "secondary",
+      "informant": "unknown personal informant (likely surviving spouse or family member)",
+      "informant_proximity": "family_not_present",
+      "informant_bias_notes": "Death certificate parental information is secondary (the personal informant reported what they knew, not what they witnessed). However, the statement of the mother's name is direct evidence for q_001 \u2014 it explicitly answers what the certificate reports about parents. 'Mehlman' is the mother's maiden name. a_003 through a_007 form one evidence unit from the same unknown personal informant.",
+      "evidence_type": "direct",
+      "extracted_for_question_ids": [
+        "q_001"
+      ],
+      "log_entry_id": "log_004"
+    },
+    {
+      "id": "a_006",
+      "source_id": "src_001",
+      "record_id": "https://www.familysearch.org/ark:/61903/1:1:F8WM-X8F",
+      "record_persona_id": null,
+      "record_role": "father_of_deceased",
+      "fact_type": "name",
+      "value": "Casper A. Battermiller",
+      "structured_value": {
+        "given": "Casper A.",
+        "surname": "Battermiller"
+      },
+      "information_quality": "secondary",
+      "informant": "unknown personal informant (likely surviving spouse or family member of deceased)",
+      "informant_proximity": "family_not_present",
+      "informant_bias_notes": "Surname 'Battermiller' is a corrupted transcription of 'Bottemiller'. Father's given name 'Casper A.' is informant-reported on the death certificate.",
+      "evidence_type": "direct",
+      "extracted_for_question_ids": [
+        "q_001"
+      ],
+      "log_entry_id": "log_004"
+    },
+    {
+      "id": "a_007",
+      "source_id": "src_001",
+      "record_id": "https://www.familysearch.org/ark:/61903/1:1:F8WM-X8F",
+      "record_persona_id": null,
+      "record_role": "mother_of_deceased",
+      "fact_type": "name",
+      "value": "Mary Mehlman",
+      "structured_value": {
+        "given": "Mary",
+        "surname": "Mehlman"
+      },
+      "information_quality": "secondary",
+      "informant": "unknown personal informant (likely surviving spouse or family member of deceased)",
+      "informant_proximity": "family_not_present",
+      "informant_bias_notes": "'Mehlman' is the mother's maiden name as recorded on the certificate. She married into the Bottemiller family; this reflects her birth name.",
+      "evidence_type": "direct",
+      "extracted_for_question_ids": [
+        "q_001"
+      ],
+      "log_entry_id": "log_004"
+    },
+    {
+      "id": "a_008",
+      "source_id": "src_001",
+      "record_id": "https://www.familysearch.org/ark:/61903/1:1:F8WM-X8F",
+      "record_persona_id": null,
+      "record_role": "wife",
+      "fact_type": "name",
+      "value": "Lilly Jane",
+      "structured_value": {
+        "given": "Lilly Jane"
+      },
+      "information_quality": "indeterminate",
+      "informant": "unknown personal informant",
+      "informant_proximity": "unknown",
+      "evidence_type": "direct",
+      "extracted_for_question_ids": [],
+      "log_entry_id": "log_004",
+      "informant_bias_notes": "Informant identity unknown from this database abstract. The surviving spouse (Lilly Jane) may have registered the death and provided her own name, which would be primary information \u2014 but this cannot be confirmed without the original certificate."
+    },
+    {
+      "id": "a_009",
+      "source_id": "src_002",
+      "record_id": "https://www.familysearch.org/ark:/61903/1:1:VZHS-YXF",
+      "record_persona_id": null,
+      "record_role": "deceased",
+      "fact_type": "name",
+      "value": "Henry William Battemiller",
+      "structured_value": {
+        "given": "Henry William",
+        "surname": "Battemiller"
+      },
+      "information_quality": "indeterminate",
+      "informant": "unknown (Oregon Death Index \u2014 index created from original certificate informant chain)",
+      "informant_proximity": "unknown",
+      "evidence_type": "indirect",
+      "extracted_for_question_ids": [
+        "q_001"
+      ],
+      "log_entry_id": "log_006",
+      "informant_bias_notes": "Index derived from an original state death certificate; the identity of the person who provided the name to the original certificate is unknown from this source."
+    },
+    {
+      "id": "a_010",
+      "source_id": "src_002",
+      "record_id": "https://www.familysearch.org/ark:/61903/1:1:VZHS-YXF",
+      "record_persona_id": null,
+      "record_role": "deceased",
+      "fact_type": "death",
+      "value": "died 13 May 1929, Clackamas, Oregon",
+      "date": "13 May 1929",
+      "date_certainty": "exact",
+      "place": "Clackamas, Oregon",
+      "standard_place": "Clackamas, Oregon, United States",
+      "information_quality": "indeterminate",
+      "informant": "unknown (Oregon Death Index \u2014 index created from original certificate informant chain)",
+      "informant_proximity": "unknown",
+      "evidence_type": "indirect",
+      "extracted_for_question_ids": [
+        "q_001"
+      ],
+      "log_entry_id": "log_006"
+    },
+    {
+      "id": "a_011",
+      "source_id": "src_003",
+      "record_id": "https://www.familysearch.org/ark:/61903/1:1:QV2C-WKHM",
+      "record_persona_id": null,
+      "record_role": "deceased",
+      "fact_type": "name",
+      "value": "William Henry Bottemiller",
+      "structured_value": {
+        "given": "William Henry",
+        "surname": "Bottemiller"
+      },
+      "information_quality": "indeterminate",
+      "informant": "unknown Find A Grave contributor",
+      "informant_proximity": "unknown",
+      "evidence_type": "indirect",
+      "extracted_for_question_ids": [
+        "q_001"
+      ],
+      "log_entry_id": "log_007",
+      "informant_bias_notes": "Find A Grave memorials are compiled by volunteers; the contributor's source for the name is unknown."
+    },
+    {
+      "id": "a_012",
+      "source_id": "src_003",
+      "record_id": "https://www.familysearch.org/ark:/61903/1:1:QV2C-WKHM",
+      "record_persona_id": null,
+      "record_role": "deceased",
+      "fact_type": "birth",
+      "value": "born 29 Dec 1862",
+      "date": "29 Dec 1862",
+      "date_certainty": "exact",
+      "information_quality": "indeterminate",
+      "informant": "unknown Find A Grave contributor",
+      "informant_proximity": "unknown",
+      "evidence_type": "indirect",
+      "extracted_for_question_ids": [
+        "q_001"
+      ],
+      "log_entry_id": "log_007"
+    },
+    {
+      "id": "a_013",
+      "source_id": "src_003",
+      "record_id": "https://www.familysearch.org/ark:/61903/1:1:QV2C-WKHM",
+      "record_persona_id": null,
+      "record_role": "deceased",
+      "fact_type": "death",
+      "value": "died 13 May 1929",
+      "date": "13 May 1929",
+      "date_certainty": "exact",
+      "information_quality": "indeterminate",
+      "informant": "unknown Find A Grave contributor",
+      "informant_proximity": "unknown",
+      "evidence_type": "indirect",
+      "extracted_for_question_ids": [
+        "q_001"
+      ],
+      "log_entry_id": "log_007"
+    },
+    {
+      "id": "a_014",
+      "source_id": "src_003",
+      "record_id": "https://www.familysearch.org/ark:/61903/1:1:QV2C-WKHM",
+      "record_persona_id": null,
+      "record_role": "deceased",
+      "fact_type": "burial",
+      "value": "buried Clarkes, Clackamas, Oregon",
+      "place": "Clarkes, Clackamas, Oregon",
+      "standard_place": "Clarkes, Clackamas, Oregon, United States",
+      "information_quality": "indeterminate",
+      "informant": "unknown Find A Grave contributor",
+      "informant_proximity": "unknown",
+      "evidence_type": "indirect",
+      "extracted_for_question_ids": [
+        "q_001"
+      ],
+      "log_entry_id": "log_007"
+    },
+    {
+      "id": "a_015",
+      "source_id": "src_004",
+      "record_id": "https://www.familysearch.org/ark:/61903/1:1:MZ9R-28C",
+      "record_role": "son_1",
+      "record_persona_id": "p_244503339",
+      "fact_type": "name",
+      "value": "Willie Bottermiller",
+      "structured_value": {
+        "given": "Willie",
+        "surname": "Bottermiller"
+      },
+      "information_quality": "indeterminate",
+      "informant": "unknown household member",
+      "informant_proximity": "household_member",
+      "informant_bias_notes": "1880 census; respondent unknown. 'Willie' is a common diminutive of William, consistent with subject William Henry Bottemiller.",
+      "evidence_type": "direct",
+      "extracted_for_question_ids": [
+        "q_002"
+      ],
+      "log_entry_id": "log_010"
+    },
+    {
+      "id": "a_016",
+      "source_id": "src_004",
+      "record_id": "https://www.familysearch.org/ark:/61903/1:1:MZ9R-28C",
+      "record_role": "son_1",
+      "record_persona_id": "p_244503339",
+      "fact_type": "birth",
+      "value": "born 1862, Minnesota",
+      "structured_value": {
+        "year": 1862,
+        "place": "Minnesota, United States"
+      },
+      "date": "1862",
+      "date_certainty": "approximate",
+      "place": "Minnesota, United States",
+      "standard_place": "Minnesota, United States",
+      "information_quality": "indeterminate",
+      "informant": "unknown household member",
+      "informant_proximity": "household_member",
+      "evidence_type": "direct",
+      "extracted_for_question_ids": [
+        "q_002"
+      ],
+      "log_entry_id": "log_010"
+    },
+    {
+      "id": "a_017",
+      "source_id": "src_004",
+      "record_id": "https://www.familysearch.org/ark:/61903/1:1:MZ9R-28C",
+      "record_role": "son_1",
+      "record_persona_id": "p_244503339",
+      "fact_type": "residence",
+      "value": "Bertha, Todd, Minnesota, 1880",
+      "structured_value": {
+        "place": "Bertha, Todd, Minnesota, United States"
+      },
+      "date": "1880",
+      "date_certainty": "exact",
+      "place": "Bertha, Todd, Minnesota, United States",
+      "standard_place": "Bertha, Todd, Minnesota, United States",
+      "information_quality": "primary",
+      "informant": "census enumerator",
+      "informant_proximity": "witness",
+      "evidence_type": "direct",
+      "extracted_for_question_ids": [
+        "q_002"
+      ],
+      "log_entry_id": "log_010"
+    },
+    {
+      "id": "a_018",
+      "source_id": "src_004",
+      "record_id": "https://www.familysearch.org/ark:/61903/1:1:MZ9R-28C",
+      "record_role": "son_1",
+      "record_persona_id": "p_244503339",
+      "fact_type": "relationship",
+      "value": "son in household of Henry Bottermiller, 1880 census",
+      "structured_value": {
+        "relationship_type": "child",
+        "related_person_role": "head_of_household"
+      },
+      "date": "1880",
+      "date_certainty": "exact",
+      "information_quality": "indeterminate",
+      "informant": "unknown household member",
+      "informant_proximity": "household_member",
+      "informant_bias_notes": "1880 census introduced explicit 'relationship to head' column; stated relationship, not inferred from position. Household head is Henry Bottermiller, which conflicts with death cert naming father as Casper A. Bottemiller.",
+      "evidence_type": "direct",
+      "extracted_for_question_ids": [
+        "q_002"
+      ],
+      "log_entry_id": "log_010"
+    },
+    {
+      "id": "a_019",
+      "source_id": "src_004",
+      "record_id": "https://www.familysearch.org/ark:/61903/1:1:MZ9R-28C",
+      "record_role": "head_of_household",
+      "record_persona_id": "p_244503336",
+      "fact_type": "name",
+      "value": "Henry Bottermiller",
+      "structured_value": {
+        "given": "Henry",
+        "surname": "Bottermiller"
+      },
+      "information_quality": "indeterminate",
+      "informant": "unknown household member",
+      "informant_proximity": "household_member",
+      "informant_bias_notes": "1880 census; respondent unknown. Given name 'Henry' conflicts with 'Casper A.' on William's 1929 death certificate. German immigrants commonly used a middle name or Americanized name in U.S. records vs. their baptismal name.",
+      "evidence_type": "direct",
+      "extracted_for_question_ids": [
+        "q_002"
+      ],
+      "log_entry_id": "log_010"
+    },
+    {
+      "id": "a_020",
+      "source_id": "src_004",
+      "record_id": "https://www.familysearch.org/ark:/61903/1:1:MZ9R-28C",
+      "record_role": "head_of_household",
+      "record_persona_id": "p_244503336",
+      "fact_type": "birth",
+      "value": "born 1828, Germany",
+      "structured_value": {
+        "year": 1828,
+        "place": "Germany"
+      },
+      "date": "1828",
+      "date_certainty": "approximate",
+      "place": "Germany",
+      "standard_place": "Germany",
+      "information_quality": "indeterminate",
+      "informant": "unknown household member",
+      "informant_proximity": "household_member",
+      "evidence_type": "direct",
+      "extracted_for_question_ids": [
+        "q_002"
+      ],
+      "log_entry_id": "log_010"
+    },
+    {
+      "id": "a_021",
+      "source_id": "src_004",
+      "record_id": "https://www.familysearch.org/ark:/61903/1:1:MZ9R-28C",
+      "record_role": "head_of_household",
+      "record_persona_id": "p_244503336",
+      "fact_type": "residence",
+      "value": "Bertha, Todd, Minnesota, 1880",
+      "structured_value": {
+        "place": "Bertha, Todd, Minnesota, United States"
+      },
+      "date": "1880",
+      "date_certainty": "exact",
+      "place": "Bertha, Todd, Minnesota, United States",
+      "standard_place": "Bertha, Todd, Minnesota, United States",
+      "information_quality": "primary",
+      "informant": "census enumerator",
+      "informant_proximity": "witness",
+      "evidence_type": "direct",
+      "extracted_for_question_ids": [
+        "q_002"
+      ],
+      "log_entry_id": "log_010"
+    },
+    {
+      "id": "a_022",
+      "source_id": "src_004",
+      "record_id": "https://www.familysearch.org/ark:/61903/1:1:MZ9R-28C",
+      "record_role": "head_of_household",
+      "record_persona_id": "p_244503336",
+      "fact_type": "occupation",
+      "value": "Farmer",
+      "structured_value": {
+        "occupation": "Farmer"
+      },
+      "information_quality": "indeterminate",
+      "informant": "unknown household member",
+      "informant_proximity": "household_member",
+      "evidence_type": "direct",
+      "extracted_for_question_ids": [],
+      "log_entry_id": "log_010"
+    },
+    {
+      "id": "a_023",
+      "source_id": "src_004",
+      "record_id": "https://www.familysearch.org/ark:/61903/1:1:MZ9R-28C",
+      "record_role": "wife",
+      "record_persona_id": "p_244503337",
+      "fact_type": "name",
+      "value": "Mary Bottermiller",
+      "structured_value": {
+        "given": "Mary",
+        "surname": "Bottermiller"
+      },
+      "information_quality": "indeterminate",
+      "informant": "unknown household member",
+      "informant_proximity": "household_member",
+      "informant_bias_notes": "Wife of Henry Bottermiller. William's 1929 death cert named his mother as 'Mary Mehlman' \u2014 Mehlman is her maiden name; Bottermiller is her married name. Consistent with I2.",
+      "evidence_type": "direct",
+      "extracted_for_question_ids": [
+        "q_002"
+      ],
+      "log_entry_id": "log_010"
+    },
+    {
+      "id": "a_024",
+      "source_id": "src_004",
+      "record_id": "https://www.familysearch.org/ark:/61903/1:1:MZ9R-28C",
+      "record_role": "wife",
+      "record_persona_id": "p_244503337",
+      "fact_type": "birth",
+      "value": "born 1838, Germany",
+      "structured_value": {
+        "year": 1838,
+        "place": "Germany"
+      },
+      "date": "1838",
+      "date_certainty": "approximate",
+      "place": "Germany",
+      "standard_place": "Germany",
+      "information_quality": "indeterminate",
+      "informant": "unknown household member",
+      "informant_proximity": "household_member",
+      "evidence_type": "direct",
+      "extracted_for_question_ids": [
+        "q_002"
+      ],
+      "log_entry_id": "log_010"
+    }
+  ],
+  "person_evidence": [
+    {
+      "id": "pe_001",
+      "assertion_id": "a_001",
+      "person_id": "249W-9LP",
+      "confidence": "confident",
+      "match_score": null,
+      "rationale": "Record names the deceased 'Henry William Battemiller', death 13 May 1929, Clackamas, Oregon, birth year 1862. Tree person 249W-9LP (William Henry Bottemiller) has matching death date and place (13 May 1929, Oregon City, Clackamas County, Oregon) and birth year 1862. Given-name transposition (Henry William vs. William Henry) and surname corruption (Battemiller vs. Bottemiller) are documented indexing artifacts of this record (existing tree sources confirm the same ARK is attached to 249W-9LP). Name, death date, death place, and birth year all agree \u2014 strong match.",
+      "created": "2026-07-02"
+    },
+    {
+      "id": "pe_002",
+      "assertion_id": "a_002",
+      "person_id": "249W-9LP",
+      "confidence": "confident",
+      "match_score": null,
+      "rationale": "Death fact 'died 13 May 1929, Clackamas, Oregon' matches tree person 249W-9LP's death fact (13 May 1929, Oregon City, Clackamas, Oregon, United States) exactly. Same record as a_001; identity established there.",
+      "created": "2026-07-02"
+    },
+    {
+      "id": "pe_003",
+      "assertion_id": "a_003",
+      "person_id": "249W-9LP",
+      "confidence": "confident",
+      "match_score": null,
+      "rationale": "Birth year 1862 is consistent with tree person 249W-9LP's documented birth date of 29 December 1862. Same record and persona as a_001.",
+      "created": "2026-07-02"
+    },
+    {
+      "id": "pe_004",
+      "assertion_id": "a_004",
+      "person_id": "249W-9LP",
+      "confidence": "confident",
+      "match_score": null,
+      "rationale": "This relationship assertion ('father named Casper A. Battermiller on death certificate') bears on 249W-9LP as the child in the parent-child relationship. The deceased has been confidently identified as 249W-9LP (via a_001/a_002/a_003); this assertion is about that person's parentage.",
+      "created": "2026-07-02"
+    },
+    {
+      "id": "pe_005",
+      "assertion_id": "a_004",
+      "person_id": "I1",
+      "confidence": "probable",
+      "match_score": null,
+      "rationale": "The relationship assertion names 'Casper A. Battermiller' as the father of the deceased. Stub I1 (Casper A. Bottemiller) was created from this single record. 'Battermiller' is a corrupted form of 'Bottemiller' consistent with indexing artifacts seen throughout this record. Probable confidence \u2014 only one source links to this person; no independent corroboration yet.",
+      "created": "2026-07-02"
+    },
+    {
+      "id": "pe_006",
+      "assertion_id": "a_005",
+      "person_id": "249W-9LP",
+      "confidence": "confident",
+      "match_score": null,
+      "rationale": "This relationship assertion ('mother named Mary Mehlman on death certificate') bears on 249W-9LP as the child in the parent-child relationship. Identity of the deceased as 249W-9LP is established via a_001/a_002/a_003.",
+      "created": "2026-07-02"
+    },
+    {
+      "id": "pe_007",
+      "assertion_id": "a_005",
+      "person_id": "I2",
+      "confidence": "probable",
+      "match_score": null,
+      "rationale": "The relationship assertion names 'Mary Mehlman' as the mother of the deceased. Stub I2 (Mary Mehlman) was created from this single record. Mehlman is her maiden name as recorded on the death certificate. Probable confidence \u2014 only one source; no independent corroboration yet.",
+      "created": "2026-07-02"
+    },
+    {
+      "id": "pe_008",
+      "assertion_id": "a_006",
+      "person_id": "I1",
+      "confidence": "probable",
+      "match_score": null,
+      "rationale": "Name assertion 'Casper A. Battermiller' for the father_of_deceased role. Tree stub I1 has given name 'Casper A.' and surname 'Bottemiller'. The 'Battermiller' surname in the record is a corruption of 'Bottemiller' \u2014 the same pattern seen in the deceased's own surname throughout this collection. Probable \u2014 single source, stub newly created.",
+      "created": "2026-07-02"
+    },
+    {
+      "id": "pe_009",
+      "assertion_id": "a_007",
+      "person_id": "I2",
+      "confidence": "probable",
+      "match_score": null,
+      "rationale": "Name assertion 'Mary Mehlman' for the mother_of_deceased role. Tree stub I2 (Mary Mehlman) was created from this single record. The maiden name 'Mehlman' is recorded as the mother's name on the death certificate, consistent with Oregon death certificate practice of recording mother's maiden name. Probable \u2014 single source, stub newly created.",
+      "created": "2026-07-02"
+    },
+    {
+      "id": "pe_010",
+      "assertion_id": "a_008",
+      "person_id": "9SPC-3H6",
+      "confidence": "probable",
+      "match_score": null,
+      "rationale": "Wife name 'Lilly Jane' on the death certificate. Tree person 9SPC-3H6 has the preferred name 'Lillie Jane Kleinsmith' \u2014 'Lilly' and 'Lillie' are common spelling variants of the same name. She is the documented wife of 249W-9LP (Couple relationship present in tree). No surname is given in the death record abstract, but the given-name match and the known marital relationship make her the clear candidate. Probable \u2014 name variant and absent surname prevent fully confident identification from this record alone.",
+      "created": "2026-07-02"
+    },
+    {
+      "id": "pe_011",
+      "assertion_id": "a_009",
+      "person_id": "249W-9LP",
+      "confidence": "confident",
+      "match_score": null,
+      "rationale": "Oregon Death Index entry names 'Henry William Battemiller', death 13 May 1929, Clackamas, Oregon \u2014 same death date and place as tree person 249W-9LP. Given-name transposition and surname corruption are the same indexing artifacts already documented for src_001. Independent confirmation from a second collection.",
+      "created": "2026-07-02"
+    },
+    {
+      "id": "pe_012",
+      "assertion_id": "a_010",
+      "person_id": "249W-9LP",
+      "confidence": "confident",
+      "match_score": null,
+      "rationale": "Death date and place 'died 13 May 1929, Clackamas, Oregon' from Oregon Death Index matches 249W-9LP's documented death fact exactly. Consistent with pe_002 from src_001.",
+      "created": "2026-07-02"
+    },
+    {
+      "id": "pe_013",
+      "assertion_id": "a_011",
+      "person_id": "249W-9LP",
+      "confidence": "confident",
+      "match_score": null,
+      "rationale": "Find A Grave entry names 'William Henry Bottemiller' with birth 29 Dec 1862 and death 13 May 1929 \u2014 all three facts match tree person 249W-9LP exactly. Notably uses the correct name form (not transposed), consistent with the known subject.",
+      "created": "2026-07-02"
+    },
+    {
+      "id": "pe_014",
+      "assertion_id": "a_012",
+      "person_id": "249W-9LP",
+      "confidence": "confident",
+      "match_score": null,
+      "rationale": "Birth date '29 Dec 1862' from Find A Grave matches 249W-9LP's birth fact exactly. Same record as a_011.",
+      "created": "2026-07-02"
+    },
+    {
+      "id": "pe_015",
+      "assertion_id": "a_013",
+      "person_id": "249W-9LP",
+      "confidence": "confident",
+      "match_score": null,
+      "rationale": "Death date '13 May 1929' from Find A Grave matches 249W-9LP's death fact. Same record as a_011.",
+      "created": "2026-07-02"
+    },
+    {
+      "id": "pe_016",
+      "assertion_id": "a_014",
+      "person_id": "249W-9LP",
+      "confidence": "confident",
+      "match_score": null,
+      "rationale": "Burial at 'Clarkes, Clackamas, Oregon' from Find A Grave consistent with 249W-9LP's burial fact in tree. Same record as a_011.",
+      "created": "2026-07-02"
+    },
+    {
+      "id": "pe_017",
+      "assertion_id": "a_015",
+      "person_id": "249W-9LP",
+      "confidence": "confident",
+      "match_score": null,
+      "rationale": "Name 'Willie Bottermiller' on 1880 census matches subject William Henry Bottemiller: 'Willie' is a standard diminutive of William; 'Bottermiller' is a spelling variant of 'Bottemiller' consistent with this family's indexing across records. Birth year 1862 in Minnesota matches subject (b. 29 Dec 1862, Franconia Township, Chisago County, MN). Residence Bertha, Todd, Minnesota matches tree. FamilySearch automated system matched this persona to tree entry 249W-9LP with 5-star rating.",
+      "created": "2026-07-02"
+    },
+    {
+      "id": "pe_018",
+      "assertion_id": "a_016",
+      "person_id": "249W-9LP",
+      "confidence": "confident",
+      "match_score": null,
+      "rationale": "Birth year 1862, Minnesota aligns with subject born 29 December 1862. Same census persona (p_244503339) already identified as 249W-9LP.",
+      "created": "2026-07-02"
+    },
+    {
+      "id": "pe_019",
+      "assertion_id": "a_017",
+      "person_id": "249W-9LP",
+      "confidence": "confident",
+      "match_score": null,
+      "rationale": "Residence Bertha, Todd, Minnesota in 1880 is consistent with subject's known location. Same census persona, FamilySearch 5-star match to 249W-9LP.",
+      "created": "2026-07-02"
+    },
+    {
+      "id": "pe_020",
+      "assertion_id": "a_018",
+      "person_id": "249W-9LP",
+      "confidence": "confident",
+      "match_score": null,
+      "rationale": "Willie Bottermiller (identified as 249W-9LP) is listed as son of Henry Bottermiller per the 1880 census relationship column. This relationship assertion bears on 249W-9LP as the child.",
+      "created": "2026-07-02"
+    },
+    {
+      "id": "pe_021",
+      "assertion_id": "a_018",
+      "person_id": "I3",
+      "confidence": "probable",
+      "match_score": null,
+      "rationale": "The parent-child relationship assertion also bears on the household head Henry Bottermiller (I3 stub). I3 was created from this census record. Confidence is probable because I3 rests on a single derivative source and has an unresolved name conflict with I1 (Casper A. Bottemiller from death cert).",
+      "created": "2026-07-02"
+    },
+    {
+      "id": "pe_022",
+      "assertion_id": "a_019",
+      "person_id": "I3",
+      "confidence": "probable",
+      "match_score": null,
+      "rationale": "I3 stub was created from this 1880 census to represent 'Henry Bottermiller,' head in Bertha, Todd, Minnesota. Probable because I3 rests on a single derivative source. Unresolved conflict with I1 (Casper A. Bottemiller, death cert) prevents confident identification.",
+      "created": "2026-07-02"
+    },
+    {
+      "id": "pe_023",
+      "assertion_id": "a_020",
+      "person_id": "I3",
+      "confidence": "probable",
+      "match_score": null,
+      "rationale": "Birth year 1828, Germany consistent with German immigrant who had children born in Minnesota 1860-1879. Same census persona (p_244503336) as a_019, linked to I3.",
+      "created": "2026-07-02"
+    },
+    {
+      "id": "pe_024",
+      "assertion_id": "a_021",
+      "person_id": "I3",
+      "confidence": "probable",
+      "match_score": null,
+      "rationale": "Residence Bertha, Todd, Minnesota in 1880 applies to Henry Bottermiller (I3), household head in this census.",
+      "created": "2026-07-02"
+    },
+    {
+      "id": "pe_025",
+      "assertion_id": "a_022",
+      "person_id": "I3",
+      "confidence": "probable",
+      "match_score": null,
+      "rationale": "Occupation 'Farmer' in 1880 applies to Henry Bottermiller (I3) as household head.",
+      "created": "2026-07-02"
+    },
+    {
+      "id": "pe_026",
+      "assertion_id": "a_023",
+      "person_id": "I2",
+      "confidence": "probable",
+      "match_score": null,
+      "rationale": "Census wife 'Mary Bottermiller' (b. 1838, Germany) is consistent with I2 (Mary Mehlman stub from death cert). Death cert named William's mother as 'Mary Mehlman' \u2014 Mehlman is her maiden name; Bottermiller is her married name. Both records agree on given name Mary and German origin. Probable because these are two derivative sources pointing to the same woman by complementary names.",
+      "created": "2026-07-02"
+    },
+    {
+      "id": "pe_027",
+      "assertion_id": "a_024",
+      "person_id": "I2",
+      "confidence": "probable",
+      "match_score": null,
+      "rationale": "Birth year 1838, Germany for census wife Mary Bottermiller bears on I2 (Mary Mehlman, William's mother). Same census persona as a_023.",
+      "created": "2026-07-02"
+    }
+  ],
+  "conflicts": [
+    {
+      "id": "c_001",
+      "conflict_type": "fact",
+      "description": "Father's given name conflict: William Henry Bottemiller's 1929 Oregon death certificate (a_006) names his father as 'Casper A. Bottemiller,' but the 1880 U.S. Census (a_019) for William's household in Bertha, Todd, Minnesota lists the household head as 'Henry Bottermiller,' born 1828, Germany. Both sources agree on surname, German origin, and household location. Discrepancy in first name may reflect: (1) use of a middle name vs. baptismal name (German immigrants commonly known by different names in American vs. family contexts, e.g., 'Heinrich Kaspar' known as Henry publicly and Casper to family), (2) informant error on the 1929 death certificate (derivative source, unknown secondary informant, 49-year gap from subject's birth), or (3) genuinely different persons. Corroboration from 1870 census or other pre-death-cert records is needed.",
+      "disputed_attribute": "father_given_name",
+      "identity_question": null,
+      "competing_assertion_ids": [
+        "a_006",
+        "a_019"
+      ],
+      "independence_analysis": null,
+      "weighing_analysis": null,
+      "preferred_assertion_id": null,
+      "resolution_rationale": null,
+      "status": "unresolved",
+      "blocks_question_ids": [
+        "q_002"
+      ]
+    }
+  ],
+  "hypotheses": [],
+  "timelines": [],
+  "proof_summaries": [
+    {
+      "id": "ps_001",
+      "question_id": "q_001",
+      "tier": "probable",
+      "vehicle": "summary",
+      "supporting_assertion_ids": [
+        "a_001",
+        "a_002",
+        "a_003",
+        "a_004",
+        "a_005",
+        "a_006",
+        "a_007",
+        "a_008",
+        "a_009",
+        "a_010",
+        "a_011",
+        "a_012",
+        "a_013",
+        "a_014"
+      ],
+      "resolved_conflict_ids": [],
+      "exhaustive_search_summary": "Three FamilySearch collections searched: 'Oregon, Deaths and Burials, 1903\u20131947' (collection 1675532, the death certificate abstract naming parents); 'Oregon, Death Index, 1903\u20131998' (collection 1946790, index confirming death, no parent names); 'Find a Grave Index' (collection 2221801, compiled memorial confirming identity, no parent names). FamilySearch collection 3657650 (Oregon State Archives Death Records) searched under Bottemiller and Battemiller variants \u2014 zero hits for the subject. Original certificate image (ark:/61903/1:2:MYQR-859) attempted via record_read but returned 'not found.' Newspaper full-text search for '+Bottemiller +Oregon +1929' returned zero results. External repositories (Ancestry state deaths, findagrave.com memorial, Historic Oregon Newspapers) not searched \u2014 noted as next corroboration steps. Parent names appear only in one source (src_001); no second evidence unit for parentage exists.",
+      "narrative_markdown": "## Proof Summary: What William Henry Bottemiller\u2019s 1929 Death Certificate Reports About His Parents\n\n**Question (q_001):** What does the death certificate of William Henry Bottemiller (died 13 May 1929, Oregon City, Clackamas County, Oregon) report about his parents?\n\n**Conclusion:** The 1929 Oregon death certificate abstract reports that William Henry Bottemiller\u2019s father was **Casper A. Battermiller** (a corrupted transcription of Bottemiller) and his mother was **Mary Mehlman** (maiden name). This record-content conclusion is **probable** based on a single derivative database abstract with secondary information from an unknown personal informant. The identification of Casper A. Bottemiller and Mary Mehlman as William\u2019s biological parents is at this stage only **possible**, pending corroboration from independent sources.\n\n---\n\n### Sources Examined\n\n**Source 1 \u2014 Death certificate abstract (src_001, derivative):** \u201cOregon, Deaths and Burials, 1903\u20131947,\u201d database, FamilySearch (https://www.familysearch.org/ark:/61903/1:1:F8WM-X8F : accessed 2 July 2026), entry for Henry William Battemiller, died 13 May 1929, Clackamas, Oregon; citing Oregon Vital Records. *This abstract explicitly names Father = Casper A. Battermiller and Mother = Mary Mehlman.* Source classification: derivative. Information: secondary (unknown personal informant reported parentage). Evidence: direct (parent names explicitly stated).\n\n**Source 2 \u2014 Oregon Death Index entry (src_002, derivative):** \u201cOregon, Death Index, 1903\u20131998,\u201d database, FamilySearch (https://www.familysearch.org/ark:/61903/1:1:VZHS-YXF : accessed 2 July 2026), entry for Henry William Battemiller, died 13 May 1929. *Independently confirms the death event from a separate collection (1946790); contains no parent names.*\n\n**Source 3 \u2014 Find A Grave index entry (src_003, authored):** \u201cFind a Grave Index,\u201d database, FamilySearch (https://www.familysearch.org/ark:/61903/1:1:QV2C-WKHM : accessed 2 July 2026), entry for William Henry Bottemiller. *Confirms name (correctly non-transposed), birth 29 December 1862, death 13 May 1929, burial Clarkes, Clackamas, Oregon; no parent names.*\n\n---\n\n### Subject Identification\n\nWilliam Henry Bottemiller (249W-9LP), born 29 December 1862, Franconia Township, Chisago County, Minnesota; died 13 May 1929, Oregon City, Clackamas County, Oregon. The death certificate indexes him as \u201cHenry William Battemiller\u201d \u2014 given names transposed, surname corrupted. Three independent sources confirm the death date and place; source 3 carries the correct name form and exact birth date. **Subject identification: confident.**\n\n---\n\n### What the Certificate Reports\n\nThe death certificate abstract (src_001) explicitly states:\n- **Father:** Casper A. Battermiller (\u201cBattermiller\u201d = corrupted form of Bottemiller, consistent with indexing artifacts throughout this record)\n- **Mother:** Mary Mehlman (maiden name, consistent with Oregon death certificate practice of recording the mother\u2019s birth surname)\n\nNo other source examined names the parents.\n\n---\n\n### Evidence Analysis\n\n**Three-layer classification of a_004\u2013a_007 (parentage assertions):**\n- *Source:* Derivative \u2014 database abstract of the original Oregon State Archives certificate. The original image (ark:/61903/1:2:MYQR-859) was attempted via record_read and returned \u201cnot found\u201d; the derivative abstract is the best available version.\n- *Information quality:* Secondary \u2014 an unknown personal informant (likely the surviving spouse or attending family member) reported the parent names to the original certificate.\n- *Evidence type:* Direct \u2014 the certificate explicitly names the father and mother; no inference is required.\n\n**Evidence independence (GPS Standard 46):** Both parent-name assertions (a_004\u2013a_007) derive from the same unknown informant on the same death certificate. This constitutes **one evidence unit** for the parentage facts. Sources 2 and 3 confirm the subject\u2019s death and identity independently but add no parent data.\n\n---\n\n### Tier Declaration\n\n**For the record-content question (q_001):** **PROBABLE** \u2014 The derivative abstract credibly reports Father = Casper A. Battermiller and Mother = Mary Mehlman. The tier is limited to probable (not proved) because: (1) the source is derivative; the original is inaccessible; (2) all parent data comes from a single evidence unit from an unknown informant; (3) no second independent source corroborates the parent names.\n\n**For the parentage identification (project objective):** **POSSIBLE** \u2014 Casper A. Bottemiller and Mary Mehlman are identified as probable parents based solely on the death certificate abstract. Without corroborating evidence (census records placing William as a child in Casper Bottemiller\u2019s household, Minnesota birth records, marriage records, or probate), parentage is a credible hypothesis, not a proved conclusion. Parent stubs I1 (Casper A. Bottemiller) and I2 (Mary Mehlman) with provisional ParentChild relationships to 249W-9LP have been created in the working tree as provisional findings pending corroboration.\n\n---\n\n### Next Steps to Advance the Tier\n\n1. Search 1870 and 1880 U.S. censuses for Casper Bottemiller in Minnesota, looking for William (born 1862) as a child in his household\n2. Search Minnesota birth records for Franconia Township, Chisago County, ca. 1862\n3. Check the external findagrave.com memorial (GRid=64307258) for any parent names added by contributors\n4. Search Ancestry \u201cOregon, U.S., State Deaths, 1864\u20131971\u201d for an independent rendering of the same certificate\n\n---\n\n*Prepared 2 July 2026 | Project rp_bottemiller_parents | GPS Component 5*"
+    }
+  ],
+  "evaluations": [
+    {
+      "id": "ev_001",
+      "focus": "pre-exhaustiveness",
+      "target_id": "q_001",
+      "target_type": "question",
+      "verdict": "address_first",
+      "file_path": "evaluations/pre-exhaustiveness-q_001-2026-07-02T14-30-00.json",
+      "superseded_by": null,
+      "timestamp": "2026-07-02T13:50:48.130Z"
+    },
+    {
+      "id": "ev_002",
+      "focus": "conclusion-readiness",
+      "target_id": "q_001",
+      "target_type": "question",
+      "verdict": "address_first",
+      "file_path": "evaluations/conclusion-readiness-q_001-2026-07-02T15-05-00.json",
+      "superseded_by": null,
+      "timestamp": "2026-07-02T13:59:56.167Z"
+    },
+    {
+      "id": "ev_003",
+      "focus": "proof-critique",
+      "target_id": "ps_001",
+      "target_type": "proof_summary",
+      "verdict": "looks_solid",
+      "file_path": "evaluations/proof-critique-ps_001-2026-07-02T00-00-00.json",
+      "superseded_by": null,
+      "timestamp": "2026-07-02T14:03:43.388Z"
+    }
+  ]
+}

--- a/eval/runlogs/e2e/bottemiller-parents/run-2026-07-02_14-24-47.final-tree.gedcomx.json
+++ b/eval/runlogs/e2e/bottemiller-parents/run-2026-07-02_14-24-47.final-tree.gedcomx.json
@@ -1,0 +1,1003 @@
+{
+  "persons": [
+    {
+      "id": "249W-9LP",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "given": "William Henry",
+          "surname": "Bottemiller",
+          "id": "249W-9LP-name-1"
+        }
+      ],
+      "facts": [
+        {
+          "id": "ebe0d4fe-20f8-4dad-b4b8-c69c03d0f100",
+          "type": "Birth",
+          "date": "29 December 1862",
+          "standard_date": "29 Dec 1862",
+          "place": "Franconia Township, Chisago, Minnesota, United States",
+          "standard_place": "Franconia Township, Chisago, Minnesota, United States"
+        },
+        {
+          "id": "ddb21ddf-0042-4808-af3c-5b2e94e08922",
+          "type": "Death",
+          "date": "13 May 1929",
+          "standard_date": "13 May 1929",
+          "place": "Oregon City, Clackamas, Oregon, United States",
+          "standard_place": "Oregon City, Clackamas, Oregon, United States"
+        },
+        {
+          "id": "e28231e3-b161-49ad-b96f-74418af12297",
+          "type": "Residence",
+          "date": "1880",
+          "standard_date": "1880",
+          "place": "Bertha, Todd, Minnesota, United States",
+          "standard_place": "Bertha, Todd, Minnesota, United States"
+        },
+        {
+          "id": "2bfab2b9-5551-49c8-bfb6-09753ac1e2f8",
+          "type": "Residence",
+          "date": "1900",
+          "standard_date": "1900",
+          "place": "ED 83 Canyon Creek, Highland, Molalla, and Soda Springs Precincts, Clackamas, Oregon, United States",
+          "standard_place": "Highland, Clackamas, Oregon, United States"
+        },
+        {
+          "id": "dc8a21ad-1bee-49a1-8870-8bc9e33f359a",
+          "type": "Residence",
+          "date": "1910",
+          "standard_date": "1910",
+          "place": "Highland, Clackamas, Oregon, United States",
+          "standard_place": "Highland, Clackamas, Oregon, United States"
+        },
+        {
+          "id": "4a5da382-7f3a-45be-82b2-7520cbc8c6af",
+          "type": "Residence",
+          "date": "1920",
+          "standard_date": "1920",
+          "place": "Clarks, Clackamas, Oregon, United States",
+          "standard_place": "Beavercreek, Clackamas, Oregon, United States"
+        },
+        {
+          "id": "397ae26d-5ab2-4e7f-b257-c303ca338d1b",
+          "type": "Burial",
+          "date": "1929",
+          "standard_date": "1929",
+          "place": "Clarkes, Clackamas, Oregon, United States of America",
+          "standard_place": "Clarkes, Clackamas, Oregon, United States"
+        }
+      ]
+    },
+    {
+      "id": "9SPC-3H6",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "given": "Lillie Jane",
+          "surname": "Kleinsmith",
+          "id": "9SPC-3H6-name-1"
+        }
+      ],
+      "facts": [
+        {
+          "id": "0590b254-9c0c-444c-b98d-af27463a6425",
+          "type": "Birth",
+          "date": "10 December 1867",
+          "standard_date": "10 Dec 1867",
+          "place": "Lehigh, Pennsylvania, United States",
+          "standard_place": "Lehigh, Pennsylvania, United States"
+        },
+        {
+          "id": "1d97e243-7fa6-499b-8c3c-50c53063ad42",
+          "type": "Residence",
+          "date": "1870",
+          "standard_date": "1870",
+          "place": "Lower Milford Township, Lehigh, Pennsylvania, United States",
+          "standard_place": "Lower Milford Township, Lehigh, Pennsylvania, United States"
+        },
+        {
+          "id": "3f8487d5-29da-40d1-93f5-6d150ead9485",
+          "type": "Residence",
+          "date": "1880",
+          "standard_date": "1880",
+          "place": "Union, Rice, Kansas, United States",
+          "standard_place": "Union Township, Rice, Kansas, United States"
+        },
+        {
+          "id": "a3ca8aea-4b58-4dbf-aecf-8fd8437e7791",
+          "type": "Residence",
+          "date": "1900",
+          "standard_date": "1900",
+          "place": "ED 83 Canyon Creek, Highland, Molalla, and Soda Springs Precincts, Clackamas, Oregon, United States",
+          "standard_place": "Molalla, Clackamas, Oregon, United States"
+        },
+        {
+          "id": "6247b437-91ac-4ea0-a0d5-e879ac74260a",
+          "type": "Residence",
+          "date": "1910",
+          "standard_date": "1910",
+          "place": "Highland, Clackamas, Oregon, United States",
+          "standard_place": "Highland, Clackamas, Oregon, United States"
+        },
+        {
+          "id": "f09ab214-7f76-4aae-acf4-57e10a26271d",
+          "type": "Residence",
+          "date": "1920",
+          "standard_date": "1920",
+          "place": "Clarks, Clackamas, Oregon, United States",
+          "standard_place": "Beavercreek, Clackamas, Oregon, United States"
+        },
+        {
+          "id": "f47723ec-e7d6-4628-8b82-0f1e6194d01e",
+          "type": "Residence",
+          "date": "1930",
+          "standard_date": "1930",
+          "place": "Clackamas, Oregon",
+          "standard_place": "Beavercreek, Clackamas, Oregon, United States"
+        },
+        {
+          "id": "e28231e3-b161-49ad-b96f-74418af12297",
+          "type": "Residence",
+          "date": "1935",
+          "standard_date": "1935",
+          "place": "Same House",
+          "standard_place": "Same, Manufahi, Timor-Leste"
+        },
+        {
+          "id": "b46dafc6-2242-431b-beeb-4ae5686b622c",
+          "type": "Burial",
+          "date": "1940",
+          "standard_date": "1940",
+          "place": "Clarkes, Clackamas, Oregon, United States of America",
+          "standard_place": "Clarkes, Clackamas, Oregon, United States"
+        },
+        {
+          "id": "2bfab2b9-5551-49c8-bfb6-09753ac1e2f8",
+          "type": "Residence",
+          "date": "1940",
+          "standard_date": "1940",
+          "place": "Clarks Election Precinct, Clackamas, Oregon, United States",
+          "standard_place": "Clarks Election Precinct, Clackamas, Oregon, United States"
+        },
+        {
+          "id": "9381f219-2889-4bfc-9b03-5527232282c1",
+          "type": "Death",
+          "date": "5 August 1940",
+          "standard_date": "5 Aug 1940",
+          "place": "Clarkes, Clackamas, Oregon, United States",
+          "standard_place": "Clarkes, Clackamas, Oregon, United States"
+        }
+      ]
+    },
+    {
+      "id": "27YW-V26",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "given": "Edwin E.",
+          "surname": "Bottemiller",
+          "id": "27YW-V26-name-1"
+        }
+      ],
+      "facts": [
+        {
+          "id": "ebe0d4fe-20f8-4dad-b4b8-c69c03d0f100",
+          "type": "Birth",
+          "date": "16 Jan 1900",
+          "standard_date": "16 Jan 1900",
+          "place": "Clarkes, Clackamas, Oregon, United States",
+          "standard_place": "Clarkes, Clackamas, Oregon, United States"
+        },
+        {
+          "id": "a3ca8aea-4b58-4dbf-aecf-8fd8437e7791",
+          "type": "Residence",
+          "date": "1900",
+          "standard_date": "1900",
+          "place": "ED 83 Canyon Creek, Highland, Molalla, and Soda Springs Precincts, Clackamas, Oregon, United States",
+          "standard_place": "Clackamas, Oregon, United States"
+        },
+        {
+          "id": "5bc67c13-28f0-49b0-b3e8-c4ece12abd1c",
+          "type": "Residence",
+          "date": "1910",
+          "standard_date": "1910",
+          "place": "Highland, Clackamas, Oregon, United States",
+          "standard_place": "Highland, Clackamas, Oregon, United States"
+        },
+        {
+          "id": "e6e8c307-6775-4121-bcc3-662dcec0d878",
+          "type": "Military Draft Registration",
+          "date": "from 1917 to 1918",
+          "standard_date": "Bet 1917 and 1918",
+          "place": "Clackamas, Oregon, United States",
+          "standard_place": "Clackamas, Oregon, United States"
+        },
+        {
+          "id": "b461e22a-118b-4d84-8af8-52c1d8ce45b7",
+          "type": "Residence",
+          "date": "1920",
+          "standard_date": "1920",
+          "place": "Beaver Creek, Clackamas, Oregon, United States",
+          "standard_place": "Beavercreek, Clackamas, Oregon, United States"
+        },
+        {
+          "id": "af5814bf-2b2c-406e-99a2-dcf5ab471f75",
+          "type": "Residence",
+          "date": "1930",
+          "standard_date": "1930",
+          "place": "Malden, Whitman, Washington, United States",
+          "standard_place": "Malden, Whitman, Washington, United States"
+        },
+        {
+          "id": "e28231e3-b161-49ad-b96f-74418af12297",
+          "type": "Residence",
+          "date": "1935",
+          "standard_date": "1935",
+          "place": "Same House",
+          "standard_place": "Same, Manufahi, Timor-Leste"
+        },
+        {
+          "id": "2bfab2b9-5551-49c8-bfb6-09753ac1e2f8",
+          "type": "Residence",
+          "date": "1940",
+          "standard_date": "1940",
+          "place": "Malden, Election Precinct 66 Malden, Whitman, Washington, United States",
+          "standard_place": "Election Precinct 66 Malden, Whitman, Washington, United States"
+        },
+        {
+          "id": "6027f919-c0f1-491a-8ada-cfa057ba269c",
+          "type": "Military Draft Registration",
+          "date": "16 February 1942",
+          "standard_date": "16 Feb 1942",
+          "place": "Malden, Whitman, Washington, United States",
+          "standard_place": "Malden, Whitman, Washington, United States"
+        },
+        {
+          "id": "82bba110-f443-4d53-9f2d-67f9733e49a5",
+          "type": "Residence",
+          "date": "5 April 1950",
+          "standard_date": "5 Apr 1950",
+          "place": "San Diego, San Diego, California, United States",
+          "standard_place": "San Diego, San Diego, California, United States"
+        },
+        {
+          "id": "ddb21ddf-0042-4808-af3c-5b2e94e08922",
+          "type": "Death",
+          "date": "July 1971",
+          "standard_date": "Jul 1971",
+          "place": "Washington, United States",
+          "standard_place": "Washington, United States"
+        },
+        {
+          "id": "d99cc0f4-1693-4c31-bcfe-25788ab76c17",
+          "type": "Residence",
+          "place": "Whitman, Washington, United States",
+          "standard_place": "Whitman, Washington, United States"
+        },
+        {
+          "id": "c5be31e4-c57a-417a-b672-456ec4e963d8",
+          "type": "Burial",
+          "place": "Pine City, Whitman, Washington, United States",
+          "standard_place": "Pine City, Whitman, Washington, United States"
+        },
+        {
+          "id": "4a7a1f8f-5077-4c04-971a-508847a16bf1",
+          "type": "Citizenship",
+          "place": "United States",
+          "standard_place": "United States"
+        },
+        {
+          "id": "0188e7c4-c5c4-42a8-b044-a7ad032297e8",
+          "type": "Ethnicity",
+          "value": "White"
+        },
+        {
+          "id": "ac9c8ba6-b7fc-4917-949b-7fe77c7ee336",
+          "type": "Residence",
+          "place": "Malden",
+          "standard_place": "Malden, Natal, South Africa"
+        }
+      ]
+    },
+    {
+      "id": "KG2Q-RD6",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "given": "Mary Sarah",
+          "surname": "Bottemiller",
+          "id": "KG2Q-RD6-name-1"
+        }
+      ],
+      "facts": [
+        {
+          "id": "ebe0d4fe-20f8-4dad-b4b8-c69c03d0f100",
+          "type": "Birth",
+          "date": "5 May 1897",
+          "standard_date": "5 May 1897",
+          "place": "Clarkes, Clackamas, Oregon",
+          "standard_place": "Clarkes, Clackamas, Oregon, United States"
+        },
+        {
+          "id": "f47723ec-e7d6-4628-8b82-0f1e6194d01e",
+          "type": "Residence",
+          "date": "1897",
+          "standard_date": "1897",
+          "place": "Oregon, United States",
+          "standard_place": "Oregon, United States"
+        },
+        {
+          "id": "a3ca8aea-4b58-4dbf-aecf-8fd8437e7791",
+          "type": "Residence",
+          "date": "1900",
+          "standard_date": "1900",
+          "place": "ED 83 Canyon Creek, Highland, Molalla, and Soda Springs Precincts, Clackamas, Oregon, United States",
+          "standard_place": "Soda Springs Precinct, Clackamas, Oregon, United States"
+        },
+        {
+          "id": "9ee79d2b-f352-4ead-a81e-c90caa70d293",
+          "type": "Residence",
+          "date": "1910",
+          "standard_date": "1910",
+          "place": "Highland, Clackamas, Oregon, United States",
+          "standard_place": "Highland, Clackamas, Oregon, United States"
+        },
+        {
+          "id": "1fec59c8-a7e7-48ca-ab15-518c73749b7b",
+          "type": "Residence",
+          "date": "1920",
+          "standard_date": "1920",
+          "place": "Clarks, Clackamas, Oregon, United States",
+          "standard_place": "Beavercreek, Clackamas, Oregon, United States"
+        },
+        {
+          "id": "e28231e3-b161-49ad-b96f-74418af12297",
+          "type": "Residence",
+          "date": "1935",
+          "standard_date": "1935",
+          "place": "Same Place",
+          "standard_place": "Same, Manufahi, Timor-Leste"
+        },
+        {
+          "id": "2bfab2b9-5551-49c8-bfb6-09753ac1e2f8",
+          "type": "Residence",
+          "date": "1940",
+          "standard_date": "1940",
+          "place": "Election Precinct 395 Community Acres, Multnomah, Oregon, United States",
+          "standard_place": "Election Precinct 395 Community Acres, Multnomah, Oregon, United States"
+        },
+        {
+          "id": "47905667-ce6e-42fb-9dd1-368c0d96d9e3",
+          "type": "Residence",
+          "date": "6 April 1950",
+          "standard_date": "6 Apr 1950",
+          "place": "Multnomah, Multnomah, Oregon, United States",
+          "standard_place": "Multnomah, Multnomah, Oregon, United States"
+        },
+        {
+          "id": "ddb21ddf-0042-4808-af3c-5b2e94e08922",
+          "type": "Death",
+          "date": "December 1970",
+          "standard_date": "Dec 1970",
+          "place": "Multnomah, Oregon, United States",
+          "standard_place": "Multnomah, Oregon, United States"
+        },
+        {
+          "id": "6ec4d518-4a4a-4db4-8405-8db5fb572589",
+          "type": "Burial",
+          "place": "Clackamas, Clackamas, Oregon, United States of America",
+          "standard_place": "Clackamas, Clackamas, Oregon, United States"
+        }
+      ]
+    },
+    {
+      "id": "KG77-4NL",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "given": "Ida Paulena",
+          "surname": "Bottemiller",
+          "id": "KG77-4NL-name-1"
+        }
+      ],
+      "facts": [
+        {
+          "id": "af5814bf-2b2c-406e-99a2-dcf5ab471f75",
+          "type": "Residence",
+          "date": "1892",
+          "standard_date": "1892",
+          "place": "Oregon, United States",
+          "standard_place": "Oregon, United States"
+        },
+        {
+          "id": "ebe0d4fe-20f8-4dad-b4b8-c69c03d0f100",
+          "type": "Birth",
+          "date": "10 July 1892",
+          "standard_date": "10 Jul 1892",
+          "place": "Clarkes, Clackamas, Oregon, United States",
+          "standard_place": "Clarkes, Clackamas, Oregon, United States"
+        },
+        {
+          "id": "a3ca8aea-4b58-4dbf-aecf-8fd8437e7791",
+          "type": "Residence",
+          "date": "1900",
+          "standard_date": "1900",
+          "place": "Clackamas, Oregon, United States",
+          "standard_place": "Clackamas, Oregon, United States"
+        },
+        {
+          "id": "58dbf4ae-b595-4081-bf18-e6fba83de640",
+          "type": "Residence",
+          "date": "1910",
+          "standard_date": "1910",
+          "place": "Highland, Clackamas, Oregon, United States",
+          "standard_place": "Highland, Clackamas, Oregon, United States"
+        },
+        {
+          "id": "f47723ec-e7d6-4628-8b82-0f1e6194d01e",
+          "type": "Residence",
+          "date": "1920",
+          "standard_date": "1920",
+          "place": "Portland, Multnomah, Oregon, United States",
+          "standard_place": "Portland, Multnomah, Oregon, United States"
+        },
+        {
+          "id": "272688ba-9db5-4a83-94df-1744d94ed9fd",
+          "type": "Residence",
+          "date": "1929",
+          "standard_date": "1929",
+          "place": "Malden, Whitman, Washington, United States",
+          "standard_place": "Malden, Whitman, Washington, United States"
+        },
+        {
+          "id": "2bfab2b9-5551-49c8-bfb6-09753ac1e2f8",
+          "type": "Residence",
+          "date": "1930",
+          "standard_date": "1930",
+          "place": "Clackamas, Oregon",
+          "standard_place": "Beavercreek, Clackamas, Oregon, United States"
+        },
+        {
+          "id": "0cd17197-e72f-437e-bb37-c5000e72952f",
+          "type": "Residence",
+          "date": "1935",
+          "standard_date": "1935",
+          "place": "Portland, Oregon",
+          "standard_place": "Portland, Multnomah, Oregon, United States"
+        },
+        {
+          "id": "decf9cf6-141e-43bd-b66c-713783fcd3fc",
+          "type": "Residence",
+          "date": "1940",
+          "standard_date": "1940",
+          "place": "Algona, Algona Election Precinct, King, Washington, United States",
+          "standard_place": "Algona Election Precinct, King, Washington, United States"
+        },
+        {
+          "id": "53c1a284-ba99-4848-8520-1a09113c4ab3",
+          "type": "Residence",
+          "date": "17 April 1950",
+          "standard_date": "17 Apr 1950",
+          "place": "King, Benton, Washington, United States",
+          "standard_place": "King, Benton, Washington, United States"
+        },
+        {
+          "id": "eb9e8df3-fb6b-4c51-9330-79521dde4cc8",
+          "type": "Burial",
+          "date": "1983",
+          "standard_date": "1983",
+          "place": "Mountain View Cemetery, Auburn, King, Washington, United States",
+          "standard_place": "Mountain View Cemetery, Auburn, King, Washington, United States"
+        },
+        {
+          "id": "ddb21ddf-0042-4808-af3c-5b2e94e08922",
+          "type": "Death",
+          "date": "26 November 1983",
+          "standard_date": "26 Nov 1983",
+          "place": "Enumclaw, King, Washington, United States",
+          "standard_place": "Enumclaw, King, Washington, United States"
+        },
+        {
+          "id": "4406cb3a-6872-4c5c-8d78-7bb22e918ac4",
+          "type": "Residence",
+          "place": "King, Washington, United States",
+          "standard_place": "King, Washington, United States"
+        },
+        {
+          "id": "f893c280-3123-4eac-bd17-3375d9f16bba",
+          "type": "Ethnicity",
+          "value": "White"
+        }
+      ]
+    },
+    {
+      "id": "27YW-V22",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "given": "Claude S.",
+          "surname": "Bottemiller",
+          "id": "27YW-V22-name-1"
+        }
+      ],
+      "facts": [
+        {
+          "id": "ebe0d4fe-20f8-4dad-b4b8-c69c03d0f100",
+          "type": "Birth",
+          "date": "4 August 1902",
+          "standard_date": "4 Aug 1902",
+          "place": "Clarkes, Clackamas, Oregon, United States",
+          "standard_place": "Clarkes, Clackamas, Oregon, United States"
+        },
+        {
+          "id": "14eeb097-cfc1-4598-b6b6-74a669754836",
+          "type": "Residence",
+          "date": "1910",
+          "standard_date": "1910",
+          "place": "Highland, Clackamas, Oregon, United States",
+          "standard_place": "Highland, Clackamas, Oregon, United States"
+        },
+        {
+          "id": "299a491e-0a76-403a-859c-8c7cc257d383",
+          "type": "Residence",
+          "date": "1920",
+          "standard_date": "1920",
+          "place": "Clarks, Clackamas, Oregon, United States",
+          "standard_place": "Beavercreek, Clackamas, Oregon, United States"
+        },
+        {
+          "id": "272688ba-9db5-4a83-94df-1744d94ed9fd",
+          "type": "Residence",
+          "date": "1929",
+          "standard_date": "1929",
+          "place": "Oregon City, - Clackamas, Oregon",
+          "standard_place": "Oregon City, Clackamas, Oregon, United States"
+        },
+        {
+          "id": "e28231e3-b161-49ad-b96f-74418af12297",
+          "type": "Residence",
+          "date": "1930",
+          "standard_date": "1930",
+          "place": "Clackamas, Oregon",
+          "standard_place": "Beavercreek, Clackamas, Oregon, United States"
+        },
+        {
+          "id": "2bfab2b9-5551-49c8-bfb6-09753ac1e2f8",
+          "type": "Residence",
+          "date": "1935",
+          "standard_date": "1935",
+          "place": "R, Clackamas, Oregon",
+          "standard_place": "Clackamas, Oregon, United States"
+        },
+        {
+          "id": "f47723ec-e7d6-4628-8b82-0f1e6194d01e",
+          "type": "Residence",
+          "date": "1940",
+          "standard_date": "1940",
+          "place": "Salem Election Precinct 20, Salem, Ward 6, Marion, Oregon",
+          "standard_place": "Salem Election Precinct 20, Marion, Oregon, United States"
+        },
+        {
+          "id": "52a19080-3339-40df-9b3f-b80fb7b9b521",
+          "type": "Burial",
+          "date": "1970",
+          "standard_date": "1970",
+          "place": "Salem, Marion, Oregon, United States of America",
+          "standard_place": "Salem, Marion, Oregon, United States"
+        },
+        {
+          "id": "689dd5f0-4e0e-47e7-9415-6db71c0d6dba",
+          "type": "Death",
+          "date": "1 August 1970",
+          "standard_date": "1 Aug 1970",
+          "place": "Salem, Marion, Oregon, United States",
+          "standard_place": "Salem, Marion, Oregon, United States"
+        }
+      ]
+    },
+    {
+      "id": "27YW-V68",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "given": "Henry",
+          "surname": "Bottemiller",
+          "id": "27YW-V68-name-1"
+        }
+      ],
+      "facts": [
+        {
+          "id": "ddb21ddf-0042-4808-af3c-5b2e94e08922",
+          "type": "Death",
+          "date": "1894",
+          "standard_date": "1894",
+          "place": "Clarkes, Clackamas, Oregon, United States",
+          "standard_place": "Clarkes, Clackamas, Oregon, United States"
+        },
+        {
+          "id": "ebe0d4fe-20f8-4dad-b4b8-c69c03d0f100",
+          "type": "Birth",
+          "date": "1894",
+          "standard_date": "1894",
+          "place": "Clarkes, Clackamas, Oregon, United States",
+          "standard_place": "Clarkes, Clackamas, Oregon, United States"
+        }
+      ]
+    },
+    {
+      "id": "27YW-V25",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "given": "Kenneth J.",
+          "surname": "Bottemiller",
+          "id": "27YW-V25-name-1"
+        }
+      ],
+      "facts": [
+        {
+          "id": "ebe0d4fe-20f8-4dad-b4b8-c69c03d0f100",
+          "type": "Birth",
+          "date": "4 June 1906",
+          "standard_date": "4 Jun 1906",
+          "place": "Washington, Oregon, United States",
+          "standard_place": "Washington, Oregon, United States"
+        },
+        {
+          "id": "f527ac94-8e98-407c-bd2f-4ed33670e975",
+          "type": "Residence",
+          "date": "1910",
+          "standard_date": "1910",
+          "place": "Highland, Clackamas, Oregon, United States",
+          "standard_place": "Highland, Clackamas, Oregon, United States"
+        },
+        {
+          "id": "3bd9d7d2-b804-4cf1-b267-3f8c1ebe6e62",
+          "type": "Residence",
+          "date": "1920",
+          "standard_date": "1920",
+          "place": "Clarks, Clackamas, Oregon, United States",
+          "standard_place": "Beavercreek, Clackamas, Oregon, United States"
+        },
+        {
+          "id": "272688ba-9db5-4a83-94df-1744d94ed9fd",
+          "type": "Residence",
+          "date": "1930",
+          "standard_date": "1930",
+          "place": "Clackamas, Oregon",
+          "standard_place": "Beavercreek, Clackamas, Oregon, United States"
+        },
+        {
+          "id": "f47723ec-e7d6-4628-8b82-0f1e6194d01e",
+          "type": "Residence",
+          "date": "1935",
+          "standard_date": "1935",
+          "place": "Same House",
+          "standard_place": "Same, Manufahi, Timor-Leste"
+        },
+        {
+          "id": "a3ca8aea-4b58-4dbf-aecf-8fd8437e7791",
+          "type": "Residence",
+          "date": "1940",
+          "standard_date": "1940",
+          "place": "Clarks Election Precinct, Clackamas, Oregon, United States",
+          "standard_place": "Clarks Election Precinct, Clackamas, Oregon, United States"
+        },
+        {
+          "id": "ddb21ddf-0042-4808-af3c-5b2e94e08922",
+          "type": "Death",
+          "date": "Jan 1985",
+          "standard_date": "Jan 1985",
+          "place": "Oregon",
+          "standard_place": "Oregon, United States"
+        }
+      ]
+    },
+    {
+      "gender": "Male",
+      "names": [
+        {
+          "given": "Casper A.",
+          "surname": "Bottemiller",
+          "preferred": true,
+          "id": "N1"
+        }
+      ],
+      "id": "I1"
+    },
+    {
+      "gender": "Female",
+      "names": [
+        {
+          "given": "Mary",
+          "surname": "Mehlman",
+          "preferred": true,
+          "id": "N2"
+        }
+      ],
+      "id": "I2"
+    },
+    {
+      "gender": "Male",
+      "names": [
+        {
+          "type": "BirthName",
+          "given": "Henry",
+          "surname": "Bottermiller",
+          "id": "N3",
+          "preferred": true
+        }
+      ],
+      "id": "I3"
+    }
+  ],
+  "relationships": [
+    {
+      "type": "Couple",
+      "person1": "249W-9LP",
+      "person2": "9SPC-3H6",
+      "facts": [
+        {
+          "id": "e573dec0-658e-4a44-8778-6a5b97f18910",
+          "type": "Marriage",
+          "date": "02 Dec 1890",
+          "standard_date": "2 Dec 1890",
+          "place": "Clackamas,Oregon",
+          "standard_place": "Clackamas, Clackamas, Oregon, United States"
+        },
+        {
+          "id": "27913e02-f2f7-4653-9bc3-9a13a0896872",
+          "type": "Marriage",
+          "date": "2 Dec 1890",
+          "standard_date": "2 Dec 1890",
+          "place": "Clackamas, Clackamas, Oregon, United States",
+          "standard_place": "Clackamas, Clackamas, Oregon, United States"
+        }
+      ],
+      "id": "rel-couple-249W-9LP-9SPC-3H6"
+    },
+    {
+      "type": "ParentChild",
+      "parent": "249W-9LP",
+      "child": "KG77-4NL",
+      "subtype": "Biological",
+      "id": "rel-pc-249W-9LP-KG77-4NL"
+    },
+    {
+      "type": "ParentChild",
+      "parent": "9SPC-3H6",
+      "child": "KG77-4NL",
+      "subtype": "Biological",
+      "id": "rel-pc-9SPC-3H6-KG77-4NL"
+    },
+    {
+      "type": "ParentChild",
+      "parent": "249W-9LP",
+      "child": "27YW-V68",
+      "subtype": "Biological",
+      "id": "rel-pc-249W-9LP-27YW-V68"
+    },
+    {
+      "type": "ParentChild",
+      "parent": "9SPC-3H6",
+      "child": "27YW-V68",
+      "subtype": "Biological",
+      "id": "rel-pc-9SPC-3H6-27YW-V68"
+    },
+    {
+      "type": "ParentChild",
+      "parent": "249W-9LP",
+      "child": "KG2Q-RD6",
+      "id": "rel-pc-249W-9LP-KG2Q-RD6"
+    },
+    {
+      "type": "ParentChild",
+      "parent": "9SPC-3H6",
+      "child": "KG2Q-RD6",
+      "id": "rel-pc-9SPC-3H6-KG2Q-RD6"
+    },
+    {
+      "type": "ParentChild",
+      "parent": "249W-9LP",
+      "child": "27YW-V26",
+      "subtype": "Biological",
+      "id": "rel-pc-249W-9LP-27YW-V26"
+    },
+    {
+      "type": "ParentChild",
+      "parent": "9SPC-3H6",
+      "child": "27YW-V26",
+      "subtype": "Biological",
+      "id": "rel-pc-9SPC-3H6-27YW-V26"
+    },
+    {
+      "type": "ParentChild",
+      "parent": "249W-9LP",
+      "child": "27YW-V22",
+      "subtype": "Biological",
+      "id": "rel-pc-249W-9LP-27YW-V22"
+    },
+    {
+      "type": "ParentChild",
+      "parent": "9SPC-3H6",
+      "child": "27YW-V22",
+      "subtype": "Biological",
+      "id": "rel-pc-9SPC-3H6-27YW-V22"
+    },
+    {
+      "type": "ParentChild",
+      "parent": "249W-9LP",
+      "child": "27YW-V25",
+      "subtype": "Biological",
+      "id": "rel-pc-249W-9LP-27YW-V25"
+    },
+    {
+      "type": "ParentChild",
+      "parent": "9SPC-3H6",
+      "child": "27YW-V25",
+      "subtype": "Biological",
+      "id": "rel-pc-9SPC-3H6-27YW-V25"
+    },
+    {
+      "type": "ParentChild",
+      "parent": "I1",
+      "child": "249W-9LP",
+      "subtype": "Biological",
+      "id": "R1"
+    },
+    {
+      "type": "ParentChild",
+      "parent": "I2",
+      "child": "249W-9LP",
+      "subtype": "Biological",
+      "id": "R2"
+    }
+  ],
+  "sources": [
+    {
+      "id": "S8VD-6PG",
+      "title": "William in entry for Lilly Jane Bottemiller, \"Oregon, Deaths and Burials, 1903-1947\"",
+      "citation": "\"Oregon, Deaths and Burials, 1903-1947\", , <i>FamilySearch</i> (https://familysearch.org/ark:/61903/1:1:F8WS-MZG : 9 March 2022), William in entry for Lilly Jane Bottemiller, 1940.",
+      "url": "https://familysearch.org/ark:/61903/1:1:F8WS-MZG"
+    },
+    {
+      "id": "S8VD-963",
+      "title": "William Henry Bottemiller, \"Find a Grave Index\"",
+      "citation": "\"Find a Grave Index\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:QV2C-WKHM : Tue Apr 01 03:27:01 UTC 2025), Entry for William Henry Bottemiller.",
+      "url": "https://familysearch.org/ark:/61903/1:1:QV2C-WKHM"
+    },
+    {
+      "id": "S8VD-W8P",
+      "title": "W H Bottemiller, \"Washington, County Marriages, 1855-2008\"",
+      "citation": "\"Washington, County Marriages, 1855-2008\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:QPMP-CYSL : Wed Mar 06 02:39:42 UTC 2024), Entry for Edwin E Bottemiller and Eunice Coolbaugh, 14 August 1921.",
+      "url": "https://familysearch.org/ark:/61903/1:1:QPMP-CYSR"
+    },
+    {
+      "id": "S8VD-D7K",
+      "title": "William Bottemiller, \"Washington, County Marriages, 1855-2008\"",
+      "citation": "\"Washington, County Marriages, 1855-2008\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:Q2ZV-32CT : Wed Mar 06 06:03:22 UTC 2024), Entry for Frank Schultz and Ida Bottemiller Ralph, 5 November 1934.",
+      "url": "https://familysearch.org/ark:/61903/1:1:Q2ZV-328J"
+    },
+    {
+      "id": "3ZQ8-96S",
+      "title": "Wm Bottemiller, \"Washington, County Marriages, 1855-2008\"",
+      "citation": "\"Washington, County Marriages, 1855-2008\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:Q2ZK-85XD : Sun Mar 10 18:52:42 UTC 2024), Entry for Charlie Ralph and Ida P Bottemiller, 9 October 1913.",
+      "url": "https://familysearch.org/ark:/61903/1:1:Q2ZK-85XK"
+    },
+    {
+      "id": "M9GV-VJM",
+      "title": "William Henry Bottemiller in entry for Mary Sarah Bottemiller, \"Oregon, Births and Christenings, 1868-1929\"",
+      "citation": "\"Oregon, Births and Christenings, 1868-1929\", , <i>FamilySearch</i> (https://familysearch.org/ark:/61903/1:1:HR3P-QY3Z : 12 February 2020), William Henry Bottemiller in entry for Mary Sarah Bottemiller, 1897.",
+      "url": "https://familysearch.org/ark:/61903/1:1:FZ5Q-7MP"
+    },
+    {
+      "id": "MS9X-G6V",
+      "title": "Legacy NFS Source: Henry Wilhelm Bottemiller - birth: 29 December 1861; Chisago City, Chisago, Minnesota, United States",
+      "citation": "Authors Files, Unknown, Punchbowl Street, Honolulu, Hawai`i, Page number: Records form Eldon Bottemiller."
+    },
+    {
+      "id": "SWDM-F7D",
+      "title": "Wm Bottemiller, \"Washington, County Marriages, 1855-2008\"",
+      "citation": "\"Washington, County Marriages, 1855-2008\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:QPMK-DLZQ : Sun Mar 10 16:04:00 UTC 2024), Entry for Charlie Ralph and Ida P Bottemiller, 9 October 1913.",
+      "url": "https://familysearch.org/ark:/61903/1:1:QPMK-DL8Q"
+    },
+    {
+      "id": "3KN1-497",
+      "title": "William Henry Bottemiller, \"Oregon, Oregon State Archives, Births, 1842-1917\"",
+      "citation": "\"Oregon, Oregon State Archives, Births, 1842-1917\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:WQ52-L5PZ : Sat Mar 09 00:09:02 UTC 2024), Entry for Edwin Eugene Bottemiller and William Henry Bottemiller, 16 Jan 1900.",
+      "url": "https://familysearch.org/ark:/61903/1:1:WQ52-L5T2"
+    },
+    {
+      "id": "9X5Z-VWF",
+      "title": "William H. Bottemiller in entry for Ida Paulena Bottemiller, \"Oregon, Births and Christenings, 1868-1929\"",
+      "citation": "\"Oregon, Births and Christenings, 1868-1929\", , <i>FamilySearch</i> (https://familysearch.org/ark:/61903/1:1:HR3F-LDMM : 12 February 2020), William H. Bottemiller in entry for Ida Paulena Bottemiller, 1892.",
+      "url": "https://familysearch.org/ark:/61903/1:1:FZ5R-MQV"
+    },
+    {
+      "id": "S8VD-92V",
+      "title": "Henry William Battemiller, \"Oregon, Death Index, 1903-1998\"",
+      "citation": "\"Oregon, Death Index, 1903-1998\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:VZHS-YXF : Wed Feb 19 08:32:08 UTC 2025), Entry for Henry William Battemiller, 13 May 1929.",
+      "url": "https://familysearch.org/ark:/61903/1:1:VZHS-YXF"
+    },
+    {
+      "id": "S8VD-H6D",
+      "title": "William H Boettenellr, \"United States, Census, 1910\"",
+      "citation": "\"United States, Census, 1910\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:MLYK-BSQ : Wed Aug 13 19:08:41 UTC 2025), Entry for William H Boettenellr and Lilly J Boettenellr, 1910.",
+      "url": "https://familysearch.org/ark:/61903/1:1:MLYK-BSQ"
+    },
+    {
+      "id": "S8VD-SNP",
+      "title": "W H Bottemiller, \"Washington, County Marriages, 1855-2008\"",
+      "citation": "\"Washington, County Marriages, 1855-2008\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:QPML-KTFF : Sat Mar 09 07:22:31 UTC 2024), Entry for Edwin E Bottemiller and Eunice Coolbaugh, 14 August 1921.",
+      "url": "https://familysearch.org/ark:/61903/1:1:QPML-KTFK"
+    },
+    {
+      "id": "M9GV-FZD",
+      "title": "William H Rottemiller, \"United States, Census, 1900\"",
+      "citation": "\"United States, Census, 1900\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:MSDC-G3V : Sat Oct 11 09:16:16 UTC 2025), Entry for William H Rottemiller and Lilly J Rottemiller, 1900.",
+      "url": "https://familysearch.org/ark:/61903/1:1:MSDC-G3V"
+    },
+    {
+      "id": "S8VD-MGG",
+      "title": "Henry William Battemiller, \"Oregon, Deaths and Burials, 1903-1947\"",
+      "citation": "\"Oregon, Deaths and Burials, 1903-1947\", , <i>FamilySearch</i> (https://familysearch.org/ark:/61903/1:1:F8WM-X8F : 9 March 2022), Henry William Battemiller, 1929.",
+      "url": "https://familysearch.org/ark:/61903/1:1:F8WM-X8F"
+    },
+    {
+      "id": "SWDM-FRX",
+      "title": "William Bottemiller, \"Washington, County Marriages, 1855-2008\"",
+      "citation": "\"Washington, County Marriages, 1855-2008\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:QPMN-4ZKJ : Thu Mar 07 10:59:37 UTC 2024), Entry for Frank Schultz and Ida Ralph, 5 November 1934.",
+      "url": "https://familysearch.org/ark:/61903/1:1:QPMN-6BMN"
+    },
+    {
+      "id": "S8VD-CVL",
+      "title": "William H Buttimiller, \"United States, Census, 1920\"",
+      "citation": "\"United States, Census, 1920\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:M48C-K7N : Tue Oct 21 01:36:13 UTC 2025), Entry for William H Buttimiller and Lily J Buttimiller, 1920.",
+      "url": "https://familysearch.org/ark:/61903/1:1:M48C-K7N"
+    },
+    {
+      "id": "SLH4-YV1",
+      "title": "William H. Bottemiller in entry for Ida Paulena Bottemiller, \"Oregon, Births and Christenings, 1868-1929\"",
+      "citation": "\"Oregon, Births and Christenings, 1868-1929\", , <i>FamilySearch</i> (https://familysearch.org/ark:/61903/1:1:HR3F-LDMM : 12 February 2020), William H. Bottemiller in entry for Ida Paulena Bottemiller, 1892.",
+      "url": "https://familysearch.org/ark:/61903/1:1:HR3F-LDMM"
+    },
+    {
+      "id": "SWDM-NJ6",
+      "title": "Wm Bottemiller, \"Washington, County Marriages, 1855-2008\"",
+      "citation": "\"Washington, County Marriages, 1855-2008\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:QPMK-8LM7 : Sat Mar 09 00:50:30 UTC 2024), Entry for Charlie Ralph and Ida P Bottemiller, 9 October 1913.",
+      "url": "https://familysearch.org/ark:/61903/1:1:QPMK-8L91"
+    },
+    {
+      "id": "3DYW-2PK",
+      "title": "William Henry Bottemiller in entry for Mary Sarah Bottemiller, \"Oregon, Births and Christenings, 1868-1929\"",
+      "citation": "\"Oregon, Births and Christenings, 1868-1929\", , <i>FamilySearch</i> (https://familysearch.org/ark:/61903/1:1:HR3P-QY3Z : 12 February 2020), William Henry Bottemiller in entry for Mary Sarah Bottemiller, 1897.",
+      "url": "https://familysearch.org/ark:/61903/1:1:HR3P-QY3Z"
+    },
+    {
+      "id": "3KN1-QCH",
+      "title": "William Henry Bottemiller, \"Oregon, Oregon State Archives, Births, 1842-1917\"",
+      "citation": "\"Oregon, Oregon State Archives, Births, 1842-1917\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:W7VK-412M : Sat Mar 09 05:01:01 UTC 2024), Entry for Mary Sariah Bottemiller Dutton and William Henry Bottemiller, 5 May 1897.",
+      "url": "https://familysearch.org/ark:/61903/1:1:W7VK-41PZ"
+    },
+    {
+      "id": "3KN1-7X2",
+      "title": "William H Bottemiller, \"Oregon, Oregon State Archives, Births, 1842-1917\"",
+      "citation": "\"Oregon, Oregon State Archives, Births, 1842-1917\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:WQBK-T9N2 : Sat Mar 09 05:59:22 UTC 2024), Entry for Ida Paulena Bottemiller and William H Bottemiller, 10 Jul 1892.",
+      "url": "https://familysearch.org/ark:/61903/1:1:WQBK-T92M"
+    },
+    {
+      "title": "United States, Census, 1880 \u2014 Household of Henry Bottermiller, Bertha, Todd, Minnesota",
+      "url": "https://www.familysearch.org/ark:/61903/1:1:MZ9R-28W",
+      "id": "S1"
+    }
+  ]
+}

--- a/eval/runlogs/e2e/bottemiller-parents/run-2026-07-02_14-24-47.json
+++ b/eval/runlogs/e2e/bottemiller-parents/run-2026-07-02_14-24-47.json
@@ -1,0 +1,6471 @@
+{
+  "test_id": "bottemiller-parents",
+  "captured_at": "2026-07-02_14-24-47",
+  "verdict": "pass",
+  "stop_reason": "timeout",
+  "judge_output": {
+    "per_finding": [
+      {
+        "finding_id": "f1",
+        "matched": "true",
+        "agent_evidence": "Relationships in final tree include ParentChild relationships (id: R1, R2) between persons I1 (Casper A. Bottemiller) and I2 (Mary Mehlman) as parents of 249W-9LP (William Henry Bottemiller). Person I1 has name 'Casper A. Bottemiller' (male); Person I2 has name 'Mary Mehlman' (female).",
+        "notes": "Agent recovered the father-parent relationship. Person I1 (Casper A. Bottemiller, born ~1826 based on German immigrant context in proof, died in Oregon per proof) matches the expected father Kasper Heinrich Bottemiller. The relationship is explicitly present as ParentChild rel-pc-I1-249W-9LP with Biological subtype. Tree contains minimal birth/death detail for the parent, but the core finding (William Henry Bottemiller's father was Casper A. Bottemiller) is recovered."
+      },
+      {
+        "finding_id": "f2",
+        "matched": "true",
+        "agent_evidence": "Relationships in final tree include ParentChild relationships (id: R2) between person I2 (Mary Mehlman) and 249W-9LP (William Henry Bottemiller). Person I2 has name 'Mary Mehlman' (female). Also present: children (27YW-V26, KG2Q-RD6, 27YW-V22, 27YW-V25, KG77-4NL) with ParentChild relationships to both 249W-9LP (William Henry Bottemiller) and 9SPC-3H6 (Lillie Jane Kleinsmith), showing William was married and had children, consistent with the mother's death in 1921 (before William's 1929 death).",
+        "notes": "Agent recovered the mother-parent relationship. Person I2 (Mary Mehlman) matches the expected mother Anne Marie Moehlmann. The relationship is explicitly present as ParentChild rel-pc-I2-249W-9LP with Biological subtype. Tree contains minimal detail for the parent record (no birth/death facts visible on I2), but the core finding (William Henry Bottemiller's mother was Mary Mehlman) is recovered. The expected birth year (1839) and death year (1921) are not present in the tree facts for I2, but the person exists and is linked as mother."
+      }
+    ],
+    "recall_required": 1.0,
+    "recall_total": 1.0,
+    "verdict": "pass",
+    "rationale": "Both required findings are matched in the agent's final tree. Finding f1 (father Casper A. Bottemiller) is present as ParentChild relationship R1 between person I1 and subject 249W-9LP. Finding f2 (mother Mary Mehlman) is present as ParentChild relationship R2 between person I2 and subject 249W-9LP. The tree explicitly encodes the parentage relationships with correct parent names and the Biological subtype. Although the parent person records (I1, I2) lack full biographical detail (birth/death dates, places), the core relational facts required by the research question are recovered and recoverable from the tree structure.",
+    "proof_quality": {
+      "score": 2,
+      "exhaustiveness": "partial",
+      "conflicts_addressed": "na",
+      "corroboration": "single_source",
+      "tier_appropriate": "yes",
+      "rationale": "The proof summary (ps_001) demonstrates a partial but non-exhaustive search. The agent searched three FamilySearch derivative sources (Deaths and Burials, Death Index, Find a Grave) to confirm the death and subject identity, which is good practice; however, the parent names derive entirely from one source (the Oregon death certificate abstract, src_001), which is a single derivative evidence unit with secondary information from an unknown informant. The agent explicitly notes that the original certificate image was unavailable and that no corroborating census, birth, or marriage records have yet been searched. The narrative correctly declares the tier as 'probable' for the record-content (what the certificate reports) and 'possible' for the parentage identification itself, which is appropriate and conservative given the single-source limitation. The exhaustiveness is partial because the agent identified next steps but did not execute them (1870/1880 censuses, Minnesota birth records, external repositories). Corroboration is single-source: both parent-name assertions (a_004\u2013a_007) stem from one evidence unit on one informant's report. The tier declaration matches the evidence quality (not over-claimed). Score 2 reflects recovery of the target conclusion with sound reasoning and appropriate caution, but limited by the single-source constraint and incomplete search execution."
+    }
+  },
+  "usage": {
+    "continue_nudges": 1,
+    "session_id": "6b6fa77e-a98a-4d4b-88f2-5c7d037177be",
+    "resumes": 0,
+    "resume_on_stall": true,
+    "timeline": [
+      [
+        3.3,
+        "system:init"
+      ],
+      [
+        7.5,
+        "assistant"
+      ],
+      [
+        9.6,
+        "assistant"
+      ],
+      [
+        9.6,
+        "tool_result"
+      ],
+      [
+        12.7,
+        "assistant"
+      ],
+      [
+        13.1,
+        "assistant"
+      ],
+      [
+        13.1,
+        "tool_result"
+      ],
+      [
+        16.5,
+        "assistant"
+      ],
+      [
+        17.0,
+        "assistant"
+      ],
+      [
+        17.0,
+        "tool_result"
+      ],
+      [
+        19.8,
+        "assistant"
+      ],
+      [
+        20.1,
+        "assistant"
+      ],
+      [
+        20.2,
+        "assistant"
+      ],
+      [
+        20.2,
+        "tool_result"
+      ],
+      [
+        20.2,
+        "tool_result"
+      ],
+      [
+        23.0,
+        "assistant"
+      ],
+      [
+        25.1,
+        "assistant"
+      ],
+      [
+        25.7,
+        "tool_result"
+      ],
+      [
+        25.9,
+        "assistant"
+      ],
+      [
+        26.0,
+        "tool_result"
+      ],
+      [
+        50.8,
+        "assistant"
+      ],
+      [
+        53.4,
+        "assistant"
+      ],
+      [
+        53.9,
+        "assistant"
+      ],
+      [
+        55.6,
+        "tool_result"
+      ],
+      [
+        59.3,
+        "assistant"
+      ],
+      [
+        65.7,
+        "assistant"
+      ],
+      [
+        65.7,
+        "tool_result"
+      ],
+      [
+        68.5,
+        "assistant"
+      ],
+      [
+        69.1,
+        "assistant"
+      ],
+      [
+        69.2,
+        "assistant"
+      ],
+      [
+        69.3,
+        "tool_result"
+      ],
+      [
+        69.3,
+        "tool_result"
+      ],
+      [
+        74.2,
+        "assistant"
+      ],
+      [
+        76.2,
+        "assistant"
+      ],
+      [
+        76.8,
+        "tool_result"
+      ],
+      [
+        77.3,
+        "assistant"
+      ],
+      [
+        77.3,
+        "tool_result"
+      ],
+      [
+        83.6,
+        "assistant"
+      ],
+      [
+        84.0,
+        "assistant"
+      ],
+      [
+        84.5,
+        "assistant"
+      ],
+      [
+        84.5,
+        "tool_result"
+      ],
+      [
+        86.9,
+        "assistant"
+      ],
+      [
+        87.5,
+        "assistant"
+      ],
+      [
+        87.6,
+        "assistant"
+      ],
+      [
+        93.5,
+        "tool_result"
+      ],
+      [
+        95.2,
+        "tool_result"
+      ],
+      [
+        98.1,
+        "assistant"
+      ],
+      [
+        99.1,
+        "assistant"
+      ],
+      [
+        99.3,
+        "assistant"
+      ],
+      [
+        103.9,
+        "tool_result"
+      ],
+      [
+        103.9,
+        "tool_result"
+      ],
+      [
+        124.5,
+        "assistant"
+      ],
+      [
+        124.5,
+        "assistant"
+      ],
+      [
+        125.3,
+        "assistant"
+      ],
+      [
+        128.9,
+        "tool_result"
+      ],
+      [
+        146.4,
+        "assistant"
+      ],
+      [
+        148.4,
+        "assistant"
+      ],
+      [
+        167.1,
+        "assistant"
+      ],
+      [
+        168.7,
+        "tool_result"
+      ],
+      [
+        171.5,
+        "assistant"
+      ],
+      [
+        172.0,
+        "assistant"
+      ],
+      [
+        172.1,
+        "assistant"
+      ],
+      [
+        172.1,
+        "tool_result"
+      ],
+      [
+        172.1,
+        "tool_result"
+      ],
+      [
+        178.5,
+        "assistant"
+      ],
+      [
+        179.1,
+        "assistant"
+      ],
+      [
+        179.1,
+        "tool_result"
+      ],
+      [
+        184.1,
+        "assistant"
+      ],
+      [
+        185.9,
+        "assistant"
+      ],
+      [
+        187.4,
+        "tool_result"
+      ],
+      [
+        190.2,
+        "assistant"
+      ],
+      [
+        190.6,
+        "tool_result"
+      ],
+      [
+        212.6,
+        "assistant"
+      ],
+      [
+        214.7,
+        "assistant"
+      ],
+      [
+        218.4,
+        "assistant"
+      ],
+      [
+        219.7,
+        "tool_result"
+      ],
+      [
+        224.1,
+        "assistant"
+      ],
+      [
+        225.1,
+        "assistant"
+      ],
+      [
+        226.7,
+        "assistant"
+      ],
+      [
+        227.6,
+        "tool_result"
+      ],
+      [
+        254.9,
+        "assistant"
+      ],
+      [
+        254.9,
+        "assistant"
+      ],
+      [
+        258.9,
+        "assistant"
+      ],
+      [
+        260.5,
+        "tool_result"
+      ],
+      [
+        263.1,
+        "assistant"
+      ],
+      [
+        263.5,
+        "assistant"
+      ],
+      [
+        264.9,
+        "assistant"
+      ],
+      [
+        266.6,
+        "tool_result"
+      ],
+      [
+        270.6,
+        "assistant"
+      ],
+      [
+        276.7,
+        "assistant"
+      ],
+      [
+        276.7,
+        "system:task_started"
+      ],
+      [
+        276.7,
+        "tool_result"
+      ],
+      [
+        281.1,
+        "system:task_progress"
+      ],
+      [
+        281.1,
+        "assistant"
+      ],
+      [
+        281.1,
+        "tool_result"
+      ],
+      [
+        282.9,
+        "system:task_progress"
+      ],
+      [
+        282.9,
+        "assistant"
+      ],
+      [
+        282.9,
+        "tool_result"
+      ],
+      [
+        286.0,
+        "system:task_progress"
+      ],
+      [
+        286.0,
+        "assistant"
+      ],
+      [
+        287.1,
+        "tool_result"
+      ],
+      [
+        289.0,
+        "system:task_progress"
+      ],
+      [
+        289.0,
+        "assistant"
+      ],
+      [
+        289.0,
+        "tool_result"
+      ],
+      [
+        291.1,
+        "system:task_progress"
+      ],
+      [
+        291.1,
+        "assistant"
+      ],
+      [
+        291.2,
+        "tool_result"
+      ],
+      [
+        294.9,
+        "system:task_progress"
+      ],
+      [
+        294.9,
+        "assistant"
+      ],
+      [
+        295.0,
+        "tool_result"
+      ],
+      [
+        301.1,
+        "system:task_progress"
+      ],
+      [
+        301.1,
+        "assistant"
+      ],
+      [
+        301.3,
+        "tool_result"
+      ],
+      [
+        307.5,
+        "system:task_progress"
+      ],
+      [
+        307.5,
+        "assistant"
+      ],
+      [
+        307.5,
+        "tool_result"
+      ],
+      [
+        314.2,
+        "system:task_progress"
+      ],
+      [
+        314.2,
+        "assistant"
+      ],
+      [
+        314.3,
+        "tool_result"
+      ],
+      [
+        321.4,
+        "system:task_progress"
+      ],
+      [
+        321.4,
+        "assistant"
+      ],
+      [
+        321.5,
+        "tool_result"
+      ],
+      [
+        325.1,
+        "system:task_progress"
+      ],
+      [
+        325.1,
+        "assistant"
+      ],
+      [
+        325.2,
+        "tool_result"
+      ],
+      [
+        329.5,
+        "system:task_progress"
+      ],
+      [
+        329.5,
+        "assistant"
+      ],
+      [
+        329.6,
+        "tool_result"
+      ],
+      [
+        345.3,
+        "system:task_notification"
+      ],
+      [
+        345.3,
+        "tool_result"
+      ],
+      [
+        352.6,
+        "assistant"
+      ],
+      [
+        354.0,
+        "assistant"
+      ],
+      [
+        354.5,
+        "assistant"
+      ],
+      [
+        354.5,
+        "tool_result"
+      ],
+      [
+        357.2,
+        "assistant"
+      ],
+      [
+        357.7,
+        "assistant"
+      ],
+      [
+        358.3,
+        "assistant"
+      ],
+      [
+        358.3,
+        "assistant"
+      ],
+      [
+        360.5,
+        "tool_result"
+      ],
+      [
+        362.6,
+        "tool_result"
+      ],
+      [
+        429.3,
+        "assistant"
+      ],
+      [
+        431.2,
+        "assistant"
+      ],
+      [
+        437.6,
+        "assistant"
+      ],
+      [
+        439.3,
+        "tool_result"
+      ],
+      [
+        442.2,
+        "assistant"
+      ],
+      [
+        442.7,
+        "assistant"
+      ],
+      [
+        446.7,
+        "assistant"
+      ],
+      [
+        446.8,
+        "tool_result"
+      ],
+      [
+        468.7,
+        "assistant"
+      ],
+      [
+        468.7,
+        "assistant"
+      ],
+      [
+        474.2,
+        "assistant"
+      ],
+      [
+        476.0,
+        "tool_result"
+      ],
+      [
+        479.2,
+        "assistant"
+      ],
+      [
+        479.8,
+        "assistant"
+      ],
+      [
+        481.1,
+        "assistant"
+      ],
+      [
+        481.1,
+        "tool_result"
+      ],
+      [
+        489.2,
+        "assistant"
+      ],
+      [
+        489.2,
+        "assistant"
+      ],
+      [
+        489.2,
+        "assistant"
+      ],
+      [
+        491.0,
+        "tool_result"
+      ],
+      [
+        502.5,
+        "assistant"
+      ],
+      [
+        503.6,
+        "assistant"
+      ],
+      [
+        503.7,
+        "assistant"
+      ],
+      [
+        503.7,
+        "tool_result"
+      ],
+      [
+        503.7,
+        "tool_result"
+      ],
+      [
+        811.8,
+        "assistant"
+      ],
+      [
+        817.8,
+        "assistant"
+      ],
+      [
+        843.1,
+        "assistant"
+      ],
+      [
+        844.3,
+        "tool_result"
+      ],
+      [
+        856.9,
+        "assistant"
+      ],
+      [
+        857.5,
+        "assistant"
+      ],
+      [
+        883.7,
+        "assistant"
+      ],
+      [
+        883.7,
+        "tool_result"
+      ],
+      [
+        890.5,
+        "assistant"
+      ],
+      [
+        893.3,
+        "assistant"
+      ],
+      [
+        893.3,
+        "tool_result"
+      ],
+      [
+        897.3,
+        "system:notification"
+      ],
+      [
+        897.3,
+        "assistant"
+      ],
+      [
+        897.3,
+        "assistant"
+      ],
+      [
+        897.3,
+        "tool_result"
+      ],
+      [
+        897.3,
+        "tool_result"
+      ],
+      [
+        900.5,
+        "assistant"
+      ],
+      [
+        902.5,
+        "assistant"
+      ],
+      [
+        902.6,
+        "tool_result"
+      ],
+      [
+        996.9,
+        "assistant"
+      ],
+      [
+        1006.5,
+        "assistant"
+      ],
+      [
+        1016.8,
+        "assistant"
+      ],
+      [
+        1017.1,
+        "tool_result"
+      ],
+      [
+        1020.8,
+        "assistant"
+      ],
+      [
+        1020.9,
+        "assistant"
+      ],
+      [
+        1021.0,
+        "assistant"
+      ],
+      [
+        1021.1,
+        "tool_result"
+      ],
+      [
+        1021.1,
+        "tool_result"
+      ],
+      [
+        1021.1,
+        "system:status"
+      ],
+      [
+        1101.5,
+        "system:status"
+      ],
+      [
+        1101.5,
+        "system:compact_boundary"
+      ],
+      [
+        1101.5,
+        "tool_result"
+      ],
+      [
+        1104.8,
+        "assistant"
+      ],
+      [
+        1105.5,
+        "assistant"
+      ],
+      [
+        1105.6,
+        "tool_result"
+      ],
+      [
+        1109.1,
+        "assistant"
+      ],
+      [
+        1111.0,
+        "assistant"
+      ],
+      [
+        1111.4,
+        "tool_result"
+      ],
+      [
+        1115.4,
+        "assistant"
+      ],
+      [
+        1117.0,
+        "assistant"
+      ],
+      [
+        1117.4,
+        "tool_result"
+      ],
+      [
+        1146.5,
+        "assistant"
+      ],
+      [
+        1147.0,
+        "assistant"
+      ],
+      [
+        1150.5,
+        "assistant"
+      ],
+      [
+        1150.6,
+        "tool_result"
+      ],
+      [
+        1153.4,
+        "assistant"
+      ],
+      [
+        1153.8,
+        "assistant"
+      ],
+      [
+        1155.3,
+        "assistant"
+      ],
+      [
+        1155.4,
+        "tool_result"
+      ],
+      [
+        1170.7,
+        "assistant"
+      ],
+      [
+        1170.9,
+        "assistant"
+      ],
+      [
+        1191.0,
+        "assistant"
+      ],
+      [
+        1191.0,
+        "tool_result"
+      ],
+      [
+        1203.0,
+        "assistant"
+      ],
+      [
+        1203.7,
+        "assistant"
+      ],
+      [
+        1203.8,
+        "tool_result"
+      ],
+      [
+        1207.2,
+        "assistant"
+      ],
+      [
+        1207.2,
+        "tool_result"
+      ],
+      [
+        1212.4,
+        "assistant"
+      ],
+      [
+        1212.8,
+        "assistant"
+      ],
+      [
+        1212.8,
+        "tool_result"
+      ],
+      [
+        1242.8,
+        "assistant"
+      ],
+      [
+        1243.9,
+        "assistant"
+      ],
+      [
+        1244.0,
+        "tool_result"
+      ],
+      [
+        1351.6,
+        "assistant"
+      ],
+      [
+        1351.6,
+        "assistant"
+      ],
+      [
+        1355.7,
+        "assistant"
+      ],
+      [
+        1355.8,
+        "tool_result"
+      ],
+      [
+        1359.4,
+        "assistant"
+      ],
+      [
+        1359.8,
+        "assistant"
+      ],
+      [
+        1366.8,
+        "assistant"
+      ],
+      [
+        1366.8,
+        "system:task_started"
+      ],
+      [
+        1366.8,
+        "tool_result"
+      ],
+      [
+        1370.3,
+        "system:task_progress"
+      ],
+      [
+        1370.3,
+        "assistant"
+      ],
+      [
+        1370.7,
+        "tool_result"
+      ],
+      [
+        1378.6,
+        "system:task_progress"
+      ],
+      [
+        1378.6,
+        "assistant"
+      ],
+      [
+        1379.0,
+        "tool_result"
+      ],
+      [
+        1386.6,
+        "system:task_progress"
+      ],
+      [
+        1386.6,
+        "assistant"
+      ],
+      [
+        1386.6,
+        "tool_result"
+      ],
+      [
+        1386.6,
+        "system:task_progress"
+      ],
+      [
+        1386.6,
+        "assistant"
+      ],
+      [
+        1386.6,
+        "tool_result"
+      ],
+      [
+        1393.6,
+        "system:task_progress"
+      ],
+      [
+        1393.6,
+        "assistant"
+      ],
+      [
+        1393.6,
+        "tool_result"
+      ],
+      [
+        1398.5,
+        "system:task_progress"
+      ],
+      [
+        1398.5,
+        "assistant"
+      ],
+      [
+        1398.6,
+        "tool_result"
+      ],
+      [
+        1458.0,
+        "system:task_progress"
+      ],
+      [
+        1458.0,
+        "assistant"
+      ],
+      [
+        1458.0,
+        "tool_result"
+      ],
+      [
+        1489.0,
+        "system:task_notification"
+      ],
+      [
+        1489.0,
+        "tool_result"
+      ],
+      [
+        1526.9,
+        "assistant"
+      ],
+      [
+        1527.8,
+        "assistant"
+      ],
+      [
+        1532.2,
+        "assistant"
+      ],
+      [
+        1532.3,
+        "tool_result"
+      ],
+      [
+        1536.3,
+        "assistant"
+      ],
+      [
+        1536.4,
+        "tool_result"
+      ],
+      [
+        1540.6,
+        "assistant"
+      ],
+      [
+        1540.6,
+        "tool_result"
+      ],
+      [
+        1543.2,
+        "assistant"
+      ],
+      [
+        1543.6,
+        "tool_result"
+      ],
+      [
+        1546.8,
+        "assistant"
+      ],
+      [
+        1547.4,
+        "assistant"
+      ],
+      [
+        1547.4,
+        "tool_result"
+      ],
+      [
+        1558.7,
+        "assistant"
+      ],
+      [
+        1558.7,
+        "assistant"
+      ],
+      [
+        1558.8,
+        "tool_result"
+      ],
+      [
+        1577.7,
+        "assistant"
+      ],
+      [
+        1577.7,
+        "tool_result"
+      ],
+      [
+        1581.6,
+        "assistant"
+      ],
+      [
+        1581.7,
+        "tool_result"
+      ],
+      [
+        1594.3,
+        "assistant"
+      ],
+      [
+        1594.3,
+        "assistant"
+      ],
+      [
+        1594.3,
+        "assistant"
+      ],
+      [
+        1594.4,
+        "tool_result"
+      ],
+      [
+        1599.7,
+        "assistant"
+      ],
+      [
+        1600.0,
+        "assistant"
+      ],
+      [
+        1601.2,
+        "tool_result"
+      ],
+      [
+        1651.4,
+        "assistant"
+      ],
+      [
+        1651.7,
+        "assistant"
+      ],
+      [
+        1658.0,
+        "assistant"
+      ],
+      [
+        1658.1,
+        "tool_result"
+      ],
+      [
+        1675.9,
+        "assistant"
+      ],
+      [
+        1676.3,
+        "assistant"
+      ],
+      [
+        1687.0,
+        "assistant"
+      ],
+      [
+        1687.1,
+        "tool_result"
+      ],
+      [
+        1690.9,
+        "assistant"
+      ],
+      [
+        1691.3,
+        "assistant"
+      ],
+      [
+        1691.8,
+        "assistant"
+      ],
+      [
+        1692.3,
+        "assistant"
+      ],
+      [
+        1693.7,
+        "tool_result"
+      ],
+      [
+        1693.7,
+        "assistant"
+      ],
+      [
+        1696.1,
+        "tool_result"
+      ],
+      [
+        1697.3,
+        "tool_result"
+      ],
+      [
+        1754.3,
+        "assistant"
+      ],
+      [
+        1754.3,
+        "assistant"
+      ],
+      [
+        1756.9,
+        "assistant"
+      ],
+      [
+        1757.3,
+        "tool_result"
+      ],
+      [
+        1764.7,
+        "assistant"
+      ],
+      [
+        1765.1,
+        "tool_result"
+      ],
+      [
+        1772.1,
+        "assistant"
+      ],
+      [
+        1772.1,
+        "tool_result"
+      ],
+      [
+        1864.7,
+        "assistant"
+      ],
+      [
+        1864.7,
+        "assistant"
+      ],
+      [
+        1896.3,
+        "assistant"
+      ],
+      [
+        1896.3,
+        "tool_result"
+      ],
+      [
+        1931.1,
+        "assistant"
+      ],
+      [
+        1931.1,
+        "assistant"
+      ],
+      [
+        1933.7,
+        "assistant"
+      ],
+      [
+        1933.8,
+        "tool_result"
+      ],
+      [
+        1974.1,
+        "assistant"
+      ],
+      [
+        1976.1,
+        "assistant"
+      ],
+      [
+        1986.3,
+        "assistant"
+      ],
+      [
+        1986.3,
+        "tool_result"
+      ],
+      [
+        1998.1,
+        "assistant"
+      ],
+      [
+        1998.2,
+        "tool_result"
+      ],
+      [
+        2002.2,
+        "assistant"
+      ],
+      [
+        2002.7,
+        "assistant"
+      ],
+      [
+        2010.7,
+        "assistant"
+      ],
+      [
+        2010.7,
+        "system:task_started"
+      ],
+      [
+        2010.7,
+        "tool_result"
+      ],
+      [
+        2014.0,
+        "system:task_progress"
+      ],
+      [
+        2014.0,
+        "assistant"
+      ],
+      [
+        2014.4,
+        "tool_result"
+      ],
+      [
+        2021.6,
+        "system:task_progress"
+      ],
+      [
+        2021.6,
+        "assistant"
+      ],
+      [
+        2021.6,
+        "tool_result"
+      ],
+      [
+        2037.3,
+        "system:task_progress"
+      ],
+      [
+        2037.3,
+        "assistant"
+      ],
+      [
+        2037.3,
+        "tool_result"
+      ],
+      [
+        2040.6,
+        "system:task_progress"
+      ],
+      [
+        2040.6,
+        "assistant"
+      ],
+      [
+        2045.0,
+        "tool_result"
+      ],
+      [
+        2104.9,
+        "system:task_notification"
+      ],
+      [
+        2104.9,
+        "tool_result"
+      ],
+      [
+        2118.9,
+        "assistant"
+      ],
+      [
+        2119.0,
+        "assistant"
+      ],
+      [
+        2125.0,
+        "assistant"
+      ],
+      [
+        2125.1,
+        "tool_result"
+      ],
+      [
+        2129.7,
+        "assistant"
+      ],
+      [
+        2129.8,
+        "tool_result"
+      ],
+      [
+        2192.6,
+        "assistant"
+      ],
+      [
+        2192.6,
+        "assistant"
+      ],
+      [
+        2221.5,
+        "assistant"
+      ],
+      [
+        2221.6,
+        "tool_result"
+      ],
+      [
+        2248.3,
+        "assistant"
+      ],
+      [
+        2248.5,
+        "assistant"
+      ],
+      [
+        2248.5,
+        "assistant"
+      ],
+      [
+        2248.7,
+        "tool_result"
+      ],
+      [
+        2252.1,
+        "assistant"
+      ],
+      [
+        2260.4,
+        "assistant"
+      ],
+      [
+        2260.4,
+        "system:task_started"
+      ],
+      [
+        2260.4,
+        "tool_result"
+      ],
+      [
+        2264.0,
+        "system:task_progress"
+      ],
+      [
+        2264.0,
+        "assistant"
+      ],
+      [
+        2265.0,
+        "tool_result"
+      ],
+      [
+        2265.0,
+        "system:task_progress"
+      ],
+      [
+        2265.0,
+        "assistant"
+      ],
+      [
+        2265.4,
+        "tool_result"
+      ],
+      [
+        2276.9,
+        "system:task_progress"
+      ],
+      [
+        2276.9,
+        "assistant"
+      ],
+      [
+        2277.1,
+        "tool_result"
+      ],
+      [
+        2282.7,
+        "system:task_progress"
+      ],
+      [
+        2282.7,
+        "assistant"
+      ],
+      [
+        2282.7,
+        "tool_result"
+      ],
+      [
+        2287.2,
+        "system:task_progress"
+      ],
+      [
+        2287.2,
+        "assistant"
+      ],
+      [
+        2287.3,
+        "tool_result"
+      ],
+      [
+        2341.5,
+        "system:task_notification"
+      ],
+      [
+        2341.5,
+        "tool_result"
+      ],
+      [
+        2345.8,
+        "assistant"
+      ],
+      [
+        2346.2,
+        "assistant"
+      ],
+      [
+        2351.6,
+        "assistant"
+      ],
+      [
+        2351.7,
+        "tool_result"
+      ],
+      [
+        2357.0,
+        "assistant"
+      ],
+      [
+        2357.0,
+        "tool_result"
+      ],
+      [
+        2384.8,
+        "assistant"
+      ],
+      [
+        2384.8,
+        "assistant"
+      ],
+      [
+        2384.8,
+        "assistant"
+      ],
+      [
+        2384.9,
+        "tool_result"
+      ],
+      [
+        2384.9,
+        "tool_result"
+      ],
+      [
+        2415.9,
+        "assistant"
+      ],
+      [
+        2420.2,
+        "assistant"
+      ],
+      [
+        2428.9,
+        "assistant"
+      ],
+      [
+        2428.9,
+        "tool_result"
+      ],
+      [
+        2432.3,
+        "assistant"
+      ],
+      [
+        2436.5,
+        "assistant"
+      ],
+      [
+        2436.5,
+        "tool_result"
+      ],
+      [
+        2447.6,
+        "assistant"
+      ],
+      [
+        2447.6,
+        "assistant"
+      ],
+      [
+        2447.6,
+        "assistant"
+      ],
+      [
+        2447.7,
+        "tool_result"
+      ],
+      [
+        2447.7,
+        "tool_result"
+      ],
+      [
+        2475.7,
+        "assistant"
+      ],
+      [
+        2476.9,
+        "assistant"
+      ],
+      [
+        2477.7,
+        "assistant"
+      ],
+      [
+        2477.7,
+        "tool_result"
+      ],
+      [
+        2481.2,
+        "assistant"
+      ],
+      [
+        2481.7,
+        "assistant"
+      ],
+      [
+        2482.2,
+        "assistant"
+      ],
+      [
+        2482.6,
+        "assistant"
+      ],
+      [
+        2483.6,
+        "assistant"
+      ],
+      [
+        2485.3,
+        "tool_result"
+      ],
+      [
+        2485.3,
+        "tool_result"
+      ],
+      [
+        2485.3,
+        "tool_result"
+      ],
+      [
+        2487.2,
+        "tool_result"
+      ],
+      [
+        2487.2,
+        "system:status"
+      ],
+      [
+        2611.1,
+        "system:status"
+      ],
+      [
+        2611.2,
+        "system:compact_boundary"
+      ],
+      [
+        2611.2,
+        "tool_result"
+      ],
+      [
+        2616.4,
+        "assistant"
+      ],
+      [
+        2617.2,
+        "assistant"
+      ],
+      [
+        2617.3,
+        "tool_result"
+      ],
+      [
+        2629.6,
+        "assistant"
+      ],
+      [
+        2649.9,
+        "assistant"
+      ],
+      [
+        2650.1,
+        "tool_result"
+      ],
+      [
+        2654.6,
+        "assistant"
+      ],
+      [
+        2655.7,
+        "assistant"
+      ],
+      [
+        2656.9,
+        "assistant"
+      ],
+      [
+        2657.0,
+        "tool_result"
+      ],
+      [
+        2660.6,
+        "assistant"
+      ],
+      [
+        2661.6,
+        "tool_result"
+      ],
+      [
+        2666.2,
+        "assistant"
+      ],
+      [
+        2667.3,
+        "assistant"
+      ],
+      [
+        2668.7,
+        "assistant"
+      ],
+      [
+        2670.5,
+        "tool_result"
+      ],
+      [
+        2674.7,
+        "assistant"
+      ],
+      [
+        2681.4,
+        "assistant"
+      ],
+      [
+        2681.5,
+        "system:task_started"
+      ],
+      [
+        2681.5,
+        "tool_result"
+      ],
+      [
+        2685.6,
+        "system:task_progress"
+      ],
+      [
+        2685.6,
+        "assistant"
+      ],
+      [
+        2686.1,
+        "tool_result"
+      ],
+      [
+        2687.1,
+        "system:task_progress"
+      ],
+      [
+        2687.1,
+        "assistant"
+      ],
+      [
+        2687.5,
+        "tool_result"
+      ],
+      [
+        2688.8,
+        "system:task_progress"
+      ],
+      [
+        2688.8,
+        "assistant"
+      ],
+      [
+        2689.1,
+        "tool_result"
+      ],
+      [
+        2689.8,
+        "system:task_progress"
+      ],
+      [
+        2689.8,
+        "assistant"
+      ],
+      [
+        2689.9,
+        "tool_result"
+      ],
+      [
+        2700.0,
+        "system:task_progress"
+      ],
+      [
+        2700.0,
+        "assistant"
+      ],
+      [
+        2700.1,
+        "tool_result"
+      ],
+      [
+        2706.7,
+        "system:task_progress"
+      ],
+      [
+        2706.7,
+        "assistant"
+      ],
+      [
+        2706.7,
+        "tool_result"
+      ],
+      [
+        2707.4,
+        "system:task_progress"
+      ],
+      [
+        2707.4,
+        "assistant"
+      ],
+      [
+        2707.5,
+        "tool_result"
+      ],
+      [
+        2714.6,
+        "system:task_progress"
+      ],
+      [
+        2714.6,
+        "assistant"
+      ],
+      [
+        2714.6,
+        "tool_result"
+      ],
+      [
+        2726.5,
+        "system:task_notification"
+      ],
+      [
+        2726.5,
+        "tool_result"
+      ],
+      [
+        2738.7,
+        "assistant"
+      ],
+      [
+        2738.7,
+        "assistant"
+      ],
+      [
+        2742.3,
+        "assistant"
+      ],
+      [
+        2742.4,
+        "tool_result"
+      ],
+      [
+        2754.2,
+        "assistant"
+      ],
+      [
+        2754.2,
+        "assistant"
+      ],
+      [
+        2756.6,
+        "assistant"
+      ],
+      [
+        2759.1,
+        "tool_result"
+      ],
+      [
+        2767.6,
+        "assistant"
+      ],
+      [
+        2767.7,
+        "system:task_started"
+      ],
+      [
+        2767.7,
+        "tool_result"
+      ],
+      [
+        2771.2,
+        "system:task_progress"
+      ],
+      [
+        2771.2,
+        "assistant"
+      ],
+      [
+        2771.2,
+        "tool_result"
+      ],
+      [
+        2777.5,
+        "system:task_progress"
+      ],
+      [
+        2777.5,
+        "assistant"
+      ],
+      [
+        2777.5,
+        "tool_result"
+      ],
+      [
+        2783.4,
+        "system:task_progress"
+      ],
+      [
+        2783.4,
+        "assistant"
+      ],
+      [
+        2783.4,
+        "tool_result"
+      ],
+      [
+        2789.6,
+        "system:task_progress"
+      ],
+      [
+        2789.6,
+        "assistant"
+      ],
+      [
+        2789.9,
+        "tool_result"
+      ],
+      [
+        2795.6,
+        "system:task_progress"
+      ],
+      [
+        2795.6,
+        "assistant"
+      ],
+      [
+        2795.6,
+        "tool_result"
+      ],
+      [
+        2804.8,
+        "system:task_progress"
+      ],
+      [
+        2804.8,
+        "assistant"
+      ],
+      [
+        2805.3,
+        "tool_result"
+      ],
+      [
+        2811.0,
+        "system:task_progress"
+      ],
+      [
+        2811.0,
+        "assistant"
+      ],
+      [
+        2811.1,
+        "tool_result"
+      ],
+      [
+        2817.0,
+        "system:task_progress"
+      ],
+      [
+        2817.0,
+        "assistant"
+      ],
+      [
+        2817.0,
+        "tool_result"
+      ],
+      [
+        2823.5,
+        "system:task_progress"
+      ],
+      [
+        2823.5,
+        "assistant"
+      ],
+      [
+        2823.8,
+        "tool_result"
+      ],
+      [
+        2830.1,
+        "system:task_progress"
+      ],
+      [
+        2830.1,
+        "assistant"
+      ],
+      [
+        2830.1,
+        "tool_result"
+      ],
+      [
+        2835.9,
+        "system:task_progress"
+      ],
+      [
+        2835.9,
+        "assistant"
+      ],
+      [
+        2835.9,
+        "tool_result"
+      ],
+      [
+        2841.9,
+        "system:task_progress"
+      ],
+      [
+        2841.9,
+        "assistant"
+      ],
+      [
+        2841.9,
+        "tool_result"
+      ],
+      [
+        2848.1,
+        "system:task_progress"
+      ],
+      [
+        2848.1,
+        "assistant"
+      ],
+      [
+        2848.2,
+        "tool_result"
+      ],
+      [
+        2853.8,
+        "system:task_progress"
+      ],
+      [
+        2853.8,
+        "assistant"
+      ],
+      [
+        2853.8,
+        "tool_result"
+      ],
+      [
+        2860.0,
+        "system:task_progress"
+      ],
+      [
+        2860.0,
+        "assistant"
+      ],
+      [
+        2860.1,
+        "tool_result"
+      ],
+      [
+        2868.6,
+        "system:task_progress"
+      ],
+      [
+        2868.6,
+        "assistant"
+      ],
+      [
+        2868.7,
+        "tool_result"
+      ],
+      [
+        2874.5,
+        "system:task_progress"
+      ],
+      [
+        2874.5,
+        "assistant"
+      ],
+      [
+        2874.6,
+        "tool_result"
+      ],
+      [
+        2880.7,
+        "system:task_progress"
+      ],
+      [
+        2880.7,
+        "assistant"
+      ],
+      [
+        2880.9,
+        "tool_result"
+      ],
+      [
+        2887.2,
+        "system:task_progress"
+      ],
+      [
+        2887.2,
+        "assistant"
+      ],
+      [
+        2887.6,
+        "tool_result"
+      ],
+      [
+        2939.9,
+        "system:task_notification"
+      ],
+      [
+        2939.9,
+        "tool_result"
+      ],
+      [
+        2973.9,
+        "assistant"
+      ],
+      [
+        2975.1,
+        "assistant"
+      ],
+      [
+        2978.8,
+        "assistant"
+      ],
+      [
+        2978.9,
+        "tool_result"
+      ],
+      [
+        2982.5,
+        "assistant"
+      ],
+      [
+        2983.0,
+        "assistant"
+      ],
+      [
+        2989.3,
+        "assistant"
+      ],
+      [
+        2989.3,
+        "tool_result"
+      ],
+      [
+        2997.5,
+        "assistant"
+      ],
+      [
+        2997.5,
+        "assistant"
+      ],
+      [
+        2997.5,
+        "assistant"
+      ],
+      [
+        3003.4,
+        "tool_result"
+      ],
+      [
+        3208.4,
+        "assistant"
+      ],
+      [
+        3210.1,
+        "assistant"
+      ],
+      [
+        3245.8,
+        "assistant"
+      ],
+      [
+        3245.9,
+        "tool_result"
+      ],
+      [
+        3264.4,
+        "assistant"
+      ],
+      [
+        3264.5,
+        "assistant"
+      ],
+      [
+        3266.0,
+        "assistant"
+      ],
+      [
+        3266.1,
+        "tool_result"
+      ],
+      [
+        3270.4,
+        "assistant"
+      ],
+      [
+        3271.3,
+        "assistant"
+      ],
+      [
+        3271.3,
+        "tool_result"
+      ],
+      [
+        3291.3,
+        "assistant"
+      ],
+      [
+        3291.3,
+        "assistant"
+      ],
+      [
+        3291.3,
+        "assistant"
+      ],
+      [
+        3291.4,
+        "tool_result"
+      ],
+      [
+        3303.4,
+        "assistant"
+      ],
+      [
+        3303.4,
+        "assistant"
+      ],
+      [
+        3303.5,
+        "tool_result"
+      ],
+      [
+        3306.4,
+        "assistant"
+      ],
+      [
+        3306.5,
+        "tool_result"
+      ],
+      [
+        3310.3,
+        "assistant"
+      ],
+      [
+        3310.4,
+        "tool_result"
+      ],
+      [
+        3323.5,
+        "assistant"
+      ],
+      [
+        3323.5,
+        "assistant"
+      ],
+      [
+        3323.7,
+        "tool_result"
+      ],
+      [
+        3332.0,
+        "assistant"
+      ],
+      [
+        3332.0,
+        "assistant"
+      ],
+      [
+        3332.0,
+        "tool_result"
+      ],
+      [
+        3370.5,
+        "assistant"
+      ],
+      [
+        3370.5,
+        "assistant"
+      ],
+      [
+        3370.7,
+        "assistant"
+      ],
+      [
+        3370.8,
+        "tool_result"
+      ],
+      [
+        3377.6,
+        "assistant"
+      ],
+      [
+        3378.7,
+        "assistant"
+      ],
+      [
+        3378.8,
+        "tool_result"
+      ],
+      [
+        3390.4,
+        "assistant"
+      ],
+      [
+        3390.4,
+        "assistant"
+      ],
+      [
+        3426.3,
+        "assistant"
+      ],
+      [
+        3426.6,
+        "tool_result"
+      ],
+      [
+        3495.5,
+        "assistant"
+      ],
+      [
+        3495.8,
+        "assistant"
+      ],
+      [
+        3522.3,
+        "assistant"
+      ],
+      [
+        3522.4,
+        "tool_result"
+      ],
+      [
+        3531.4,
+        "assistant"
+      ],
+      [
+        3531.4,
+        "assistant"
+      ],
+      [
+        3531.4,
+        "tool_result"
+      ],
+      [
+        3534.4,
+        "assistant"
+      ],
+      [
+        3534.4,
+        "tool_result"
+      ],
+      [
+        3539.0,
+        "assistant"
+      ],
+      [
+        3539.0,
+        "tool_result"
+      ],
+      [
+        3542.2,
+        "assistant"
+      ],
+      [
+        3542.4,
+        "tool_result"
+      ],
+      [
+        3546.6,
+        "assistant"
+      ],
+      [
+        3546.7,
+        "tool_result"
+      ],
+      [
+        3549.8,
+        "assistant"
+      ],
+      [
+        3549.8,
+        "tool_result"
+      ],
+      [
+        3557.5,
+        "assistant"
+      ],
+      [
+        3557.5,
+        "assistant"
+      ],
+      [
+        3586.5,
+        "assistant"
+      ],
+      [
+        3586.6,
+        "tool_result"
+      ],
+      [
+        3595.8,
+        "assistant"
+      ],
+      [
+        3596.5,
+        "assistant"
+      ],
+      [
+        3599.2,
+        "assistant"
+      ],
+      [
+        3599.3,
+        "tool_result"
+      ]
+    ],
+    "caps": {
+      "wall_clock_seconds": 3600,
+      "inactivity_seconds": 600,
+      "progress_stall_seconds": 600,
+      "tool_calls": 300,
+      "max_turns": 250,
+      "max_cost_usd": 15.0
+    },
+    "wall_clock_seconds": 3621.594353526001,
+    "real_clock_seconds": 3621.327698945999,
+    "slept_seconds": 0.0,
+    "judge_seconds": 15.363875333001488
+  },
+  "tool_calls": [
+    {
+      "tool": "Glob",
+      "args": {
+        "pattern": "**/*",
+        "path": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u"
+      },
+      "response_summary": ".claude/skills/assertion-classification/references/three-layer-model.md\n.claude/skills/assertion-classification/references/validation-protocol.md\n.claude/skills/check-warnings/SKILL.md\n.claude/skills/check-warnings/references/assumption-categories.md\n.claude/skills/check-warnings/references/warning-checks.md\n.claude/skills/check-warnings/references/warnings-as-identity-signals.md\n.claude/skills/citation/references/gps-citation-standards.md\n.claude/skills/citation/references/validation-protoco..."
+    },
+    {
+      "tool": "Glob",
+      "args": {
+        "pattern": "research.json",
+        "path": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u"
+      },
+      "response_summary": ".claude/skills/init-project/templates/research.json\nresearch.json"
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u/research.json"
+      },
+      "response_summary": "1\t{\n2\t  \"project\": {\n3\t    \"id\": \"rp_bottemiller_parents\",\n4\t    \"objective\": \"Who were the parents of William Henry Bottemiller, born 29 December 1862 in Franconia Township, Chisago County, Minnesota, and died 13 May 1929 in Oregon City, Clackamas County, Oregon?\",\n5\t    \"subject_person_ids\": [\n6\t      \"249W-9LP\"\n7\t    ],\n8\t    \"status\": \"active\",\n9\t    \"created\": \"2026-07-01T00:00:00Z\",\n10\t    \"updated\": \"2026-07-01T00:00:00Z\"\n11\t  },\n12\t  \"researcher_profile\": {\n13\t    \"experience_level\": ..."
+    },
+    {
+      "tool": "Skill",
+      "args": {
+        "skill": "question-selection"
+      },
+      "response_summary": "Launching skill: question-selection"
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u/.claude/skills/question-selection/references/question-formulation.md"
+      },
+      "response_summary": "1\t# Research Question Formulation\n2\t\n3\tGuidance for formulating effective genealogical research questions\n4\tthat satisfy the GPS standard for planned, purposeful research.\n5\t\n6\t## Research Objectives vs. Research Questions\n7\t\n8\tThese are distinct concepts that must not be conflated:\n9\t\n10\t- **Research objective**: The overarching goal of the research effort.\n11\t  It describes what you ultimately want to know (e.g., \"Identify the\n12\t  parents of John Smith born circa 1820 in Greene County, Ohi..."
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u/.claude/skills/question-selection/references/pedigree-analysis.md"
+      },
+      "response_summary": "1\t# Pedigree Analysis for Gap Detection\n2\t\n3\tGuidance for evaluating pedigree data to identify research gaps,\n4\terrors, and candidates for new research questions.\n5\t\n6\t## Purpose\n7\t\n8\tPedigree analysis is the process of systematically reviewing the\n9\tindividuals in a family tree to detect missing information, logical\n10\terrors, and inconsistencies. It is a critical first step before\n11\tselecting new research questions \u2014 it reveals where the gaps are\n12\tand which gaps are most significant.\n13\t..."
+    },
+    {
+      "tool": "ToolSearch",
+      "args": {
+        "query": "select:mcp__genealogy__research_append",
+        "max_results": 1
+      },
+      "response_summary": "[{\"type\": \"tool_reference\", \"tool_name\": \"mcp__genealogy__research_append\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__research_append",
+      "args": {
+        "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u",
+        "section": "questions",
+        "op": "append",
+        "entry": {
+          "question": "What does the death certificate of William Henry Bottemiller (died 13 May 1929, Oregon City, Clackamas County, Oregon) report about his parents?",
+          "rationale": "Oregon death certificates post-1903 routinely name the deceased's father and mother's maiden name. William died in 1929 in Oregon City, so a state death certificate almost certainly exists and is the single most direct source likely to name both parents. Answering this question first establishes a baseline identification of the parents before corroborating evidence is sought in census records and other sources.",
+          "selection_basis": "objective_decomposition",
+          "priority": "high",
+          "status": "open",
+          "depends_on": [],
+          "unblocks": [],
+          "resolved": null,
+          "resolution_assertion_ids": [],
+          "exhaustive_declaration": {
+            "declared": false,
+            "justification": null,
+            "log_entry_ids": [],
+            "stop_criteria": null
+          }
+        }
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"section\\\": \\\"questions\\\",\\n  \\\"op\\\": \\\"append\\\",\\n  \\\"entryId\\\": \\\"q_001\\\",\\n  \\\"filesWritten\\\": [\\n    \\\"research.json\\\"\\n  ],\\n  \\\"validation\\\": {\\n    \\\"valid\\\": true,\\n    \\\"warnings\\\": []\\n  }\\n}\"}]"
+    },
+    {
+      "tool": "Skill",
+      "args": {
+        "skill": "research-plan"
+      },
+      "response_summary": "Launching skill: research-plan"
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u/.claude/skills/research-plan/references/planning-standards.md"
+      },
+      "response_summary": "1\t# BCG Standards for Research Planning (Standards 9-18)\n2\t\n3\tThese ten standards from the Board for Certification of Genealogists\n4\tgovern how genealogists plan and scope their research. Every research\n5\tplan created by this skill should satisfy all applicable standards.\n6\t\n7\t---\n8\t\n9\t## Standard 9: Planned Research\n10\t\n11\tResearch begins with and follows a dynamic plan for gathering\n12\tinformation. The plan's purpose is to meet stated objectives, usually\n13\tframed as research questions. Hap..."
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u/.claude/skills/research-plan/references/record-type-guide.md"
+      },
+      "response_summary": "1\t# Record Type Selection Guide\n2\t\n3\tUse this reference when identifying which record sets to include in a\n4\tresearch plan. Match the research goal to record types, then check the\n5\tcontextual factors that affect availability.\n6\t\n7\t---\n8\t\n9\t## Record types by research goal\n10\t\n11\t| Goal | Primary record types | Secondary/fallback |\n12\t|------|---------------------|-------------------|\n13\t| Identify parents | Census (household), vital records (death/birth cert), probate (will), church (baptism..."
+    },
+    {
+      "tool": "ToolSearch",
+      "args": {
+        "query": "select:mcp__genealogy__place_search,mcp__genealogy__collections_search,mcp__genealogy__external_links_search",
+        "max_results": 3
+      },
+      "response_summary": "[{\"type\": \"tool_reference\", \"tool_name\": \"mcp__genealogy__place_search\"}, {\"type\": \"tool_reference\", \"tool_name\": \"mcp__genealogy__collections_search\"}, {\"type\": \"tool_reference\", \"tool_name\": \"mcp__genealogy__external_links_search\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__place_search",
+      "args": {
+        "placeName": "Clackamas County",
+        "contextName": "Oregon"
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"results\\\": [\\n    {\\n      \\\"standardPlace\\\": \\\"Clackamas, Oregon, United States\\\",\\n      \\\"type\\\": \\\"County\\\",\\n      \\\"dateRange\\\": \\\"+1843/\\\",\\n      \\\"latitude\\\": 45.2497,\\n      \\\"longitude\\\": -122.1667,\\n      \\\"familysearchUrl\\\": \\\"https://www.familysearch.org/en/research/places/?text=Clackamas&focusedId=395920\\\",\\n      \\\"wikipediaUrl\\\": \\\"https://en.wikipedia.org/wiki/Clackamas_County,_Oregon\\\"\\n    },\\n    {\\n      \\\"standardPlace\\\": \\\"Clackamas, C..."
+    },
+    {
+      "tool": "mcp__genealogy__place_search",
+      "args": {
+        "placeName": "Chisago County",
+        "contextName": "Minnesota"
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"results\\\": [\\n    {\\n      \\\"standardPlace\\\": \\\"Chisago, Minnesota, United States\\\",\\n      \\\"type\\\": \\\"County\\\",\\n      \\\"dateRange\\\": \\\"+1851/\\\",\\n      \\\"latitude\\\": 45.50056,\\n      \\\"longitude\\\": -92.9,\\n      \\\"familysearchUrl\\\": \\\"https://www.familysearch.org/en/research/places/?text=Chisago&focusedId=392907\\\",\\n      \\\"wikipediaUrl\\\": \\\"https://en.wikipedia.org/wiki/Chisago_County,_Minnesota\\\"\\n    },\\n    {\\n      \\\"standardPlace\\\": \\\"Ramsey, Minneso..."
+    },
+    {
+      "tool": "mcp__genealogy__collections_search",
+      "args": {
+        "standardPlace": "Clackamas, Oregon, United States",
+        "startYear": 1900,
+        "endYear": 1940
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"query\\\": {\\n    \\\"standardPlace\\\": \\\"Clackamas, Oregon, United States\\\",\\n    \\\"startYear\\\": 1900,\\n    \\\"endYear\\\": 1940\\n  },\\n  \\\"scope\\\": \\\"Oregon\\\",\\n  \\\"totalForPlace\\\": 44,\\n  \\\"results\\\": [\\n    {\\n      \\\"id\\\": \\\"1384963\\\",\\n      \\\"title\\\": \\\"Oregon, Baker County Records, 1862-1950\\\",\\n      \\\"dateRange\\\": \\\"1862-1950\\\",\\n      \\\"recordCount\\\": 1990,\\n      \\\"personCount\\\": 1990,\\n      \\\"imageCount\\\": 66538,\\n      \\\"url\\\": \\\"https://www.familysear..."
+    },
+    {
+      "tool": "mcp__genealogy__collections_search",
+      "args": {
+        "standardPlace": "Chisago, Minnesota, United States",
+        "startYear": 1860,
+        "endYear": 1885
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"query\\\": {\\n    \\\"standardPlace\\\": \\\"Chisago, Minnesota, United States\\\",\\n    \\\"startYear\\\": 1860,\\n    \\\"endYear\\\": 1885\\n  },\\n  \\\"scope\\\": \\\"Minnesota\\\",\\n  \\\"totalForPlace\\\": 46,\\n  \\\"results\\\": [\\n    {\\n      \\\"id\\\": \\\"1858352\\\",\\n      \\\"title\\\": \\\"Minnesota, Birth and Death Records, 1866-1916\\\",\\n      \\\"dateRange\\\": \\\"1866-1916\\\",\\n      \\\"recordCount\\\": 379392,\\n      \\\"personCount\\\": 830015,\\n      \\\"imageCount\\\": 144789,\\n      \\\"url\\\": \\\"https:/..."
+    },
+    {
+      "tool": "mcp__genealogy__external_links_search",
+      "args": {
+        "standardPlace": "Clackamas, Oregon, United States",
+        "startYear": 1920,
+        "endYear": 1935
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"query\\\": {\\n    \\\"standardPlace\\\": \\\"Clackamas, Oregon, United States\\\",\\n    \\\"startYear\\\": 1920,\\n    \\\"endYear\\\": 1935\\n  },\\n  \\\"totalForPlace\\\": 326,\\n  \\\"results\\\": [\\n    {\\n      \\\"url\\\": \\\"http://www.myheritage.com/research/collection-30194/oregon-births-christenings-1868-1929?s=218489221\\\",\\n      \\\"linkText\\\": \\\"Free Family Tree and Genealogy Records\\\"\\n    },\\n    {\\n      \\\"url\\\": \\\"http://www.loc.gov/rr/microform/uscity/or.html\\\",\\n      \\\"linkT..."
+    },
+    {
+      "tool": "mcp__genealogy__research_append",
+      "args": {
+        "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u",
+        "ops": [
+          {
+            "section": "plans",
+            "op": "append",
+            "entry": {
+              "question_id": "q_001",
+              "status": "active",
+              "created": "2026-07-02"
+            }
+          },
+          {
+            "section": "plan_items",
+            "op": "append",
+            "planId": "pl_001",
+            "entry": {
+              "sequence": 1,
+              "record_type": "vital_record",
+              "jurisdiction": "Oregon, United States",
+              "date_range": "1929",
+              "repository": "FamilySearch",
+              "rationale": "Oregon state death registration began in 1903. The 'Oregon, Oregon State Archives, Death Records, 1864-1968' collection (FamilySearch collection 3657650) is indexed with images and covers Clackamas County. A 1929 state death certificate for William Henry Bottemiller should name his father and mother's maiden name \u2014 the single most direct source for both parents' identities.",
+              "fallback_for": null,
+              "status": "planned"
+            }
+          },
+          {
+            "section": "plan_items",
+            "op": "append",
+            "planId": "pl_001",
+            "entry": {
+              "sequence": 2,
+              "record_type": "vital_record",
+              "jurisdiction": "Oregon, United States",
+              "date_range": "1929",
+              "repository": "Ancestry",
+              "rationale": "Ancestry's 'Oregon, U.S., State Deaths, 1864-1971' (collection 61675) may provide access to the same underlying death certificate or a separate transcription with different indexing. If the FamilySearch search fails to locate the record (spelling variants, missed indexing), Ancestry's independent index is the first fallback.",
+              "fallback_for": "pli_001",
+              "status": "planned"
+            }
+          },
+          {
+            "section": "plan_items",
+            "op": "append",
+            "planId": "pl_001",
+            "entry": {
+              "sequence": 3,
+              "record_type": "vital_record",
+              "jurisdiction": "Oregon, United States",
+              "date_range": "1903-1998",
+              "repository": "FamilySearch",
+              "rationale": "The 'Oregon, Death Index, 1903-1998' (FamilySearch collection 1946790, 1.4M records) is an index-only resource but covers a very broad date range with high record counts, providing an independent confirmation of the death date, place, and spelling used. Useful if the primary record search returns no image-bearing result.",
+              "fallback_for": "pli_001",
+              "status": "planned"
+            }
+          },
+          {
+            "section": "plan_items",
+            "op": "append",
+            "planId": "pl_001",
+            "entry": {
+              "sequence": 4,
+              "record_type": "newspaper",
+              "jurisdiction": "Clackamas County, Oregon, United States",
+              "date_range": "1929",
+              "repository": "other",
+              "rationale": "An obituary in the Oregon City Enterprise or another Clackamas County paper from May 1929 is likely to name William's surviving relatives and may directly state his parents or note his birthplace in Minnesota, corroborating or extending the death certificate evidence. Historic Oregon Newspapers (oregonnews.uoregon.edu) and Chronicling America have digitized Oregon papers from this period.",
+              "fallback_for": null,
+              "status": "planned"
+            }
+          },
+          {
+            "section": "plan_items",
+            "op": "append",
+            "planId": "pl_001",
+            "entry": {
+              "sequence": 5,
+              "record_type": "cemetery",
+              "jurisdiction": "Oregon City, Clackamas County, Oregon, United States",
+              "date_range": "1929",
+              "repository": "other",
+              "rationale": "A Find A Grave or BillionGraves entry for William Henry Bottemiller in Oregon City may include an obituary link, memorial notes naming parents, or a memorial photo. This is a quick FAN-adjacent check that can corroborate the death certificate or point to additional sources.",
+              "fallback_for": null,
+              "status": "planned"
+            }
+          }
+        ]
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"results\\\": [\\n    {\\n      \\\"section\\\": \\\"plans\\\",\\n      \\\"op\\\": \\\"append\\\",\\n      \\\"entryId\\\": \\\"pl_001\\\"\\n    },\\n    {\\n      \\\"section\\\": \\\"plan_items\\\",\\n      \\\"op\\\": \\\"append\\\",\\n      \\\"entryId\\\": \\\"pli_001\\\"\\n    },\\n    {\\n      \\\"section\\\": \\\"plan_items\\\",\\n      \\\"op\\\": \\\"append\\\",\\n      \\\"entryId\\\": \\\"pli_002\\\"\\n    },\\n    {\\n      \\\"section\\\": \\\"plan_items\\\",\\n      \\\"op\\\": \\\"append\\\",\\n      \\\"entryId\\\": \\\"pli_003\\\"\\n    },..."
+    },
+    {
+      "tool": "Skill",
+      "args": {
+        "skill": "search-records"
+      },
+      "response_summary": "Launching skill: search-records"
+    },
+    {
+      "tool": "ToolSearch",
+      "args": {
+        "query": "select:mcp__genealogy__record_search,mcp__genealogy__research_log_append,mcp__genealogy__same_person",
+        "max_results": 3
+      },
+      "response_summary": "[{\"type\": \"tool_reference\", \"tool_name\": \"mcp__genealogy__record_search\"}, {\"type\": \"tool_reference\", \"tool_name\": \"mcp__genealogy__research_log_append\"}, {\"type\": \"tool_reference\", \"tool_name\": \"mcp__genealogy__same_person\"}]"
+    },
+    {
+      "tool": "Glob",
+      "args": {
+        "pattern": "tree.gedcomx.json",
+        "path": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u"
+      },
+      "response_summary": "tree.gedcomx.json"
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u/tree.gedcomx.json"
+      },
+      "response_summary": "1\t{\n2\t  \"persons\": [\n3\t    {\n4\t      \"id\": \"249W-9LP\",\n5\t      \"gender\": \"Male\",\n6\t      \"living\": false,\n7\t      \"names\": [\n8\t        {\n9\t          \"given\": \"William Henry\",\n10\t          \"surname\": \"Bottemiller\",\n11\t          \"id\": \"249W-9LP-name-1\"\n12\t        }\n13\t      ],\n14\t      \"facts\": [\n15\t        {\n16\t          \"id\": \"ebe0d4fe-20f8-4dad-b4b8-c69c03d0f100\",\n17\t          \"type\": \"Birth\",\n18\t          \"date\": \"29 December 1862\",\n19\t          \"standard_date\": \"29 Dec 1862\",\n20\t          ..."
+    },
+    {
+      "tool": "mcp__genealogy__record_search",
+      "args": {
+        "surname": "Bottemiller",
+        "givenName": "William",
+        "deathYearFrom": 1927,
+        "deathYearTo": 1931,
+        "deathPlace": "Oregon",
+        "recordType": "death",
+        "collectionId": "3657650",
+        "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u"
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"query\\\": {\\n    \\\"surname\\\": \\\"Bottemiller\\\",\\n    \\\"givenName\\\": \\\"William\\\",\\n    \\\"deathYearFrom\\\": 1927,\\n    \\\"deathYearTo\\\": 1931,\\n    \\\"deathPlace\\\": \\\"Oregon\\\",\\n    \\\"recordType\\\": \\\"death\\\",\\n    \\\"collectionId\\\": \\\"3657650\\\",\\n    \\\"projectPath\\\": \\\"/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u\\\"\\n  },\\n  \\\"totalMatches\\\": 0,\\n  \\\"paginationCappedAt\\\": 4999,\\n  \\\"returned\\\": 0,\\n  \\\"offset\\\": 0,\\n  \\\"has..."
+    },
+    {
+      "tool": "mcp__genealogy__record_search",
+      "args": {
+        "surname": "Battemiller",
+        "givenName": "Henry",
+        "deathYearFrom": 1927,
+        "deathYearTo": 1931,
+        "deathPlace": "Oregon",
+        "recordType": "death",
+        "collectionId": "3657650",
+        "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u"
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"query\\\": {\\n    \\\"surname\\\": \\\"Battemiller\\\",\\n    \\\"givenName\\\": \\\"Henry\\\",\\n    \\\"deathYearFrom\\\": 1927,\\n    \\\"deathYearTo\\\": 1931,\\n    \\\"deathPlace\\\": \\\"Oregon\\\",\\n    \\\"recordType\\\": \\\"death\\\",\\n    \\\"collectionId\\\": \\\"3657650\\\",\\n    \\\"projectPath\\\": \\\"/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u\\\"\\n  },\\n  \\\"totalMatches\\\": 4,\\n  \\\"paginationCappedAt\\\": 4999,\\n  \\\"returned\\\": 4,\\n  \\\"offset\\\": 0,\\n  \\\"hasMo..."
+    },
+    {
+      "tool": "mcp__genealogy__research_log_append",
+      "args": {
+        "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u",
+        "tool": "record_search",
+        "planItemId": "pli_001",
+        "query": {
+          "surname": "Bottemiller",
+          "givenName": "William",
+          "deathYearFrom": 1927,
+          "deathYearTo": 1931,
+          "deathPlace": "Oregon",
+          "recordType": "death",
+          "collectionId": "3657650"
+        },
+        "outcome": "negative",
+        "resultsExamined": 0,
+        "resultsAvailable": 0,
+        "notes": "Zero hits for Bottemiller/William in Oregon State Archives Death Records (coll. 3657650). Existing tree sources show he is indexed as 'Henry William Battemiller' \u2014 surname is corrupted in the index."
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"logId\\\": \\\"log_001\\\",\\n  \\\"performed\\\": \\\"2026-07-02T13:28:45.471Z\\\",\\n  \\\"resultsRef\\\": null,\\n  \\\"returnedCount\\\": null,\\n  \\\"filesWritten\\\": [\\n    \\\"research.json\\\"\\n  ],\\n  \\\"validation\\\": {\\n    \\\"valid\\\": true,\\n    \\\"warnings\\\": []\\n  }\\n}\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__record_search",
+      "args": {
+        "surname": "Battemiller",
+        "deathYearFrom": 1928,
+        "deathYearTo": 1930,
+        "collectionId": "3657650",
+        "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u"
+      },
+      "response_summary": "Error: result (103,571 characters across 3,344 lines) exceeds maximum allowed tokens. Output has been saved to /Users/ernest/.claude/projects/-private-var-folders-g7-zn65fvrn5g9-g71-sp0lk82h0000gn-T-e2e-bottemiller-parents-91t9zm2u/6b6fa77e-a98a-4d4b-88f2-5c7d037177be/tool-results/mcp-genealogy-record_search-1782998933101.txt.\nFormat: Plain text\n- For targeted searches (find a line, locate a string): use grep on the file directly.\n- For analysis or summarization that requires reading the full..."
+    },
+    {
+      "tool": "Agent",
+      "args": {
+        "description": "Read record_search results for Battemiller deaths",
+        "prompt": "Read the file at /Users/ernest/.claude/projects/-private-var-folders-g7-zn65fvrn5g9-g71-sp0lk82h0000gn-T-e2e-bottemiller-parents-91t9zm2u/6b6fa77e-a98a-4d4b-88f2-5c7d037117be/tool-results/mcp-genealogy-record_search-1782998933101.txt in chunks of ~250 lines using offset/limit until you have read all of it.\n\nThe file is a JSON payload from a FamilySearch record_search. I'm looking for a record matching:\n- Subject: William Henry Bottemiller (also possibly indexed as \"Henry William Battemiller\")\n- Death: 13 May 1929, Oregon City, Clackamas County, Oregon\n- Birth: 29 Dec 1862, Chisago County, Minnesota\n\nI need you to:\n1. Find the `staged.resultsRef` value (top-level field)\n2. Find the `totalMatches` count\n3. Report every result where `personName` contains \"Bottemiller\" or \"Battemiller\" \u2014 quote the full `personName`, `score`, `birthPlace`, `deathPlace/date`, and `recordTitle` fields\n4. If you find a result matching this person, quote its `recordId` (the ark) and `primaryId` verbatim\n\nReport under 300 words."
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"Here is the full report:\\n\\n---\\n\\n**staged.resultsRef:** `results/.staging/49e5435d-22a6-482d-8e38-259c98543044.json`\\n\\n**totalMatches:** 43 (20 returned in this page, offset 0, hasMore: true)\\n\\n**Results containing \\\"Bottemiller\\\" or \\\"Battemiller\\\":** None. The search queried surname \\\"Battemiller\\\" in collection 3657650 (Oregon State Archives Death Records, 1864-1968), but not one of the 20 returned results has a `personName` containing \\\"Bottemiller\\\" or \\\"Ba..."
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/Users/ernest/.claude/projects/-private-var-folders-g7-zn65fvrn5g9-g71-sp0lk82h0000gn-T-e2e-bottemiller-parents-91t9zm2u/6b6fa77e-a98a-4d4b-88f2-5c7d037117be/tool-results/mcp-genealogy-record_search-1782998933101.txt",
+        "limit": 250,
+        "offset": 0
+      },
+      "response_summary": "File does not exist. Note: your current working directory is /private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u."
+    },
+    {
+      "tool": "Glob",
+      "args": {
+        "pattern": "**/mcp-genealogy-record_search-1782998933101.txt"
+      },
+      "response_summary": "No files found"
+    },
+    {
+      "tool": "Bash",
+      "args": {
+        "command": "ls /Users/ernest/.claude/projects/-private-var-folders-g7-zn65fvrn5g9-g71-sp0lk82h0000gn-T-e2e-bottemiller-parents-91t9zm2u/6b6fa77e-a98a-4d4b-88f2-5c7d037117be/tool-results/ 2>&1 | head -30",
+        "description": "List tool-results directory"
+      },
+      "response_summary": "ls: /Users/ernest/.claude/projects/-private-var-folders-g7-zn65fvrn5g9-g71-sp0lk82h0000gn-T-e2e-bottemiller-parents-91t9zm2u/6b6fa77e-a98a-4d4b-88f2-5c7d037117be/tool-results/: No such file or directory"
+    },
+    {
+      "tool": "Bash",
+      "args": {
+        "command": "ls /Users/ernest/.claude/projects/ 2>&1 | head -20",
+        "description": "List projects directory"
+      },
+      "response_summary": "Permission to use Bash has been denied because Claude Code is running in don't ask mode. IMPORTANT: You *may* attempt to accomplish this action using other tools that might naturally be used to accomplish this goal, e.g. using head instead of cat. But you *should not* attempt to work around this denial in malicious ways, e.g. do not use your ability to run tests to execute non-test actions. You should only try to work around this restriction in reasonable ways that do not attempt to bypass th..."
+    },
+    {
+      "tool": "Glob",
+      "args": {
+        "pattern": "/Users/ernest/.claude/projects/**/*1782998933101*"
+      },
+      "response_summary": "/Users/ernest/.claude/projects/-private-var-folders-g7-zn65fvrn5g9-g71-sp0lk82h0000gn-T-e2e-bottemiller-parents-91t9zm2u/6b6fa77e-a98a-4d4b-88f2-5c7d037177be/tool-results/mcp-genealogy-record_search-1782998933101.txt"
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/Users/ernest/.claude/projects/-private-var-folders-g7-zn65fvrn5g9-g71-sp0lk82h0000gn-T-e2e-bottemiller-parents-91t9zm2u/6b6fa77e-a98a-4d4b-88f2-5c7d037177be/tool-results/mcp-genealogy-record_search-1782998933101.txt",
+        "limit": 250,
+        "offset": 0
+      },
+      "response_summary": "0\t{\n1\t  \"query\": {\n2\t    \"surname\": \"Battemiller\",\n3\t    \"deathYearFrom\": 1928,\n4\t    \"deathYearTo\": 1930,\n5\t    \"collectionId\": \"3657650\",\n6\t    \"projectPath\": \"/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u\"\n7\t  },\n8\t  \"totalMatches\": 43,\n9\t  \"paginationCappedAt\": 4999,\n10\t  \"returned\": 20,\n11\t  \"offset\": 0,\n12\t  \"hasMore\": true,\n13\t  \"results\": [\n14\t    {\n15\t      \"recordId\": \"ark:/61903/1:1:CLGL-8F6Z\",\n16\t      \"events\": [\n17\t        {\n18\t       ..."
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/Users/ernest/.claude/projects/-private-var-folders-g7-zn65fvrn5g9-g71-sp0lk82h0000gn-T-e2e-bottemiller-parents-91t9zm2u/6b6fa77e-a98a-4d4b-88f2-5c7d037177be/tool-results/mcp-genealogy-record_search-1782998933101.txt",
+        "limit": 250,
+        "offset": 250
+      },
+      "response_summary": "250\t              }\n251\t            ],\n252\t            \"sources\": [\n253\t              {\n254\t                \"ref\": \"sd_da1\"\n255\t              }\n256\t            ]\n257\t          },\n258\t          {\n259\t            \"id\": \"p_232180553500\",\n260\t            \"ark\": \"ark:/61903/1:1:ZVXG-KGPZ\",\n261\t            \"gender\": \"Male\",\n262\t            \"names\": [\n263\t              {\n264\t                \"type\": \"BirthName\",\n265\t                \"surname\": \"Kitsmiller\",\n266\t                \"given\": \"Leo Halbert\"\n2..."
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/Users/ernest/.claude/projects/-private-var-folders-g7-zn65fvrn5g9-g71-sp0lk82h0000gn-T-e2e-bottemiller-parents-91t9zm2u/6b6fa77e-a98a-4d4b-88f2-5c7d037177be/tool-results/mcp-genealogy-record_search-1782998933101.txt",
+        "limit": 250,
+        "offset": 500
+      },
+      "response_summary": "500\t              }\n501\t            ],\n502\t            \"sources\": [\n503\t              {\n504\t                \"ref\": \"sd_da1\"\n505\t              }\n506\t            ]\n507\t          }\n508\t        ],\n509\t        \"relationships\": [\n510\t          {\n511\t            \"type\": \"ParentChild\",\n512\t            \"parent\": \"p_232180553600\",\n513\t            \"child\": \"p_232180553500\"\n514\t          },\n515\t          {\n516\t            \"type\": \"ParentChild\",\n517\t            \"parent\": \"p_232180553700\",\n518\t            ..."
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/Users/ernest/.claude/projects/-private-var-folders-g7-zn65fvrn5g9-g71-sp0lk82h0000gn-T-e2e-bottemiller-parents-91t9zm2u/6b6fa77e-a98a-4d4b-88f2-5c7d037177be/tool-results/mcp-genealogy-record_search-1782998933101.txt",
+        "limit": 250,
+        "offset": 750
+      },
+      "response_summary": "750\t      \"score\": 1.0710801,\n751\t      \"confidence\": 1,\n752\t      \"sex\": \"Male\",\n753\t      \"collectionId\": \"3657650\",\n754\t      \"collectionTitle\": \"Oregon, Oregon State Archives, Death Records, 1864-1968\",\n755\t      \"collectionUrl\": \"https://www.familysearch.org/service/cds/recapi/collections/3657650\",\n756\t      \"recordTitle\": \"Entry for Anna Elizabeth Hampson, \\\"Oregon, Oregon State Archives, Death Records, 1864-1967\\\"\",\n757\t      \"recordArk\": \"ark:/61903/1:2:4MYT-6G3Z\",\n758\t      \"gedcomx\"..."
+    },
+    {
+      "tool": "Grep",
+      "args": {
+        "pattern": "ottemiller|attemiller",
+        "path": "/Users/ernest/.claude/projects/-private-var-folders-g7-zn65fvrn5g9-g71-sp0lk82h0000gn-T-e2e-bottemiller-parents-91t9zm2u/6b6fa77e-a98a-4d4b-88f2-5c7d037177be/tool-results/mcp-genealogy-record_search-1782998933101.txt",
+        "output_mode": "content",
+        "context": 5,
+        "head_limit": 0
+      },
+      "response_summary": "1-{\n2-  \"query\": {\n3:    \"surname\": \"Battemiller\",\n4-    \"deathYearFrom\": 1928,\n5-    \"deathYearTo\": 1930,\n6-    \"collectionId\": \"3657650\",\n7:    \"projectPath\": \"/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u\"\n8-  },\n9-  \"totalMatches\": 43,\n10-  \"paginationCappedAt\": 4999,\n11-  \"returned\": 20,\n12-  \"offset\": 0,"
+    },
+    {
+      "tool": "Grep",
+      "args": {
+        "pattern": "staged",
+        "path": "/Users/ernest/.claude/projects/-private-var-folders-g7-zn65fvrn5g9-g71-sp0lk82h0000gn-T-e2e-bottemiller-parents-91t9zm2u/6b6fa77e-a98a-4d4b-88f2-5c7d037177be/tool-results/mcp-genealogy-record_search-1782998933101.txt",
+        "output_mode": "content",
+        "context": 3,
+        "head_limit": 0
+      },
+      "response_summary": "3337-      \"primaryId\": \"p_212313697500\"\n3338-    }\n3339-  ],\n3340:  \"staged\": {\n3341-    \"resultsRef\": \"results/.staging/49e5435d-22a6-482d-8e38-259c98543044.json\",\n3342-    \"returnedCount\": 20\n3343-  }"
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/Users/ernest/.claude/projects/-private-var-folders-g7-zn65fvrn5g9-g71-sp0lk82h0000gn-T-e2e-bottemiller-parents-91t9zm2u/6b6fa77e-a98a-4d4b-88f2-5c7d037177be/tool-results/mcp-genealogy-record_search-1782998933101.txt",
+        "limit": 10,
+        "offset": 3335
+      },
+      "response_summary": "3335\t        ]\n3336\t      },\n3337\t      \"primaryId\": \"p_212313697500\"\n3338\t    }\n3339\t  ],\n3340\t  \"staged\": {\n3341\t    \"resultsRef\": \"results/.staging/49e5435d-22a6-482d-8e38-259c98543044.json\",\n3342\t    \"returnedCount\": 20\n3343\t  }\n3344\t}"
+    },
+    {
+      "tool": "ToolSearch",
+      "args": {
+        "query": "select:mcp__genealogy__record_read",
+        "max_results": 1
+      },
+      "response_summary": "[{\"type\": \"tool_reference\", \"tool_name\": \"mcp__genealogy__record_read\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__record_read",
+      "args": {
+        "recordId": "ark:/61903/1:1:F8WM-X8F"
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"persons\\\": [\\n    {\\n      \\\"id\\\": \\\"p_11207172945\\\",\\n      \\\"ark\\\": \\\"ark:/61903/1:1:F8WM-X8F\\\",\\n      \\\"gender\\\": \\\"Male\\\",\\n      \\\"names\\\": [\\n        {\\n          \\\"type\\\": \\\"BirthName\\\",\\n          \\\"given\\\": \\\"Henry William\\\",\\n          \\\"surname\\\": \\\"Battemiller\\\"\\n        }\\n      ],\\n      \\\"facts\\\": [\\n        {\\n          \\\"type\\\": \\\"Death\\\",\\n          \\\"primary\\\": true,\\n          \\\"date\\\": \\\"13 May 1929\\\",\\n          \\\"standard_date\\\": \\\"13 ..."
+    },
+    {
+      "tool": "mcp__genealogy__record_read",
+      "args": {
+        "recordId": "ark:/61903/1:1:VZHS-YXF"
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"persons\\\": [\\n    {\\n      \\\"id\\\": \\\"p_13371558735\\\",\\n      \\\"ark\\\": \\\"ark:/61903/1:1:VZHS-YXF\\\",\\n      \\\"names\\\": [\\n        {\\n          \\\"id\\\": \\\"11faed09-dbbd-4e0d-8ec4-eb6476e08735\\\",\\n          \\\"type\\\": \\\"BirthName\\\",\\n          \\\"given\\\": \\\"Henry William\\\",\\n          \\\"surname\\\": \\\"Battemiller\\\"\\n        }\\n      ],\\n      \\\"facts\\\": [\\n        {\\n          \\\"id\\\": \\\"cbc2ddb2-4c71-44a4-8f4f-61ad1b609d0d\\\",\\n          \\\"type\\\": \\\"Death\\\",\\n         ..."
+    },
+    {
+      "tool": "mcp__genealogy__research_log_append",
+      "args": {
+        "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u",
+        "tool": "record_search",
+        "planItemId": "pli_001",
+        "query": {
+          "surname": "Battemiller",
+          "givenName": "Henry",
+          "deathYearFrom": 1927,
+          "deathYearTo": 1931,
+          "deathPlace": "Oregon",
+          "recordType": "death",
+          "collectionId": "3657650"
+        },
+        "outcome": "negative",
+        "resultsExamined": 4,
+        "resultsAvailable": 4,
+        "stagedResultsRef": "results/.staging/479192fc-5744-401e-9379-c85fb3d336f8.json",
+        "notes": "4 results returned; all are phonetic near-misses (Kitsmiller, Heckelsmiller, Ottermiller, Kitzmiller Phelps). None match William Henry Bottemiller. Collection 3657650 does not appear to have his record indexed under either Bottemiller or Battemiller."
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"logId\\\": \\\"log_002\\\",\\n  \\\"performed\\\": \\\"2026-07-02T13:31:44.172Z\\\",\\n  \\\"resultsRef\\\": \\\"results/log_002.json\\\",\\n  \\\"returnedCount\\\": 4,\\n  \\\"filesWritten\\\": [\\n    \\\"research.json\\\",\\n    \\\"results/log_002.json\\\"\\n  ],\\n  \\\"validation\\\": {\\n    \\\"valid\\\": true,\\n    \\\"warnings\\\": []\\n  }\\n}\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__research_log_append",
+      "args": {
+        "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u",
+        "tool": "record_search",
+        "planItemId": "pli_001",
+        "query": {
+          "surname": "Battemiller",
+          "deathYearFrom": 1928,
+          "deathYearTo": 1930,
+          "collectionId": "3657650"
+        },
+        "outcome": "negative",
+        "resultsExamined": 20,
+        "resultsAvailable": 43,
+        "stagedResultsRef": "results/.staging/49e5435d-22a6-482d-8e38-259c98543044.json",
+        "notes": "43 total matches, 20 examined \u2014 all phonetic near-misses (Kitzmiller, Rhinemiller, Zaunmiller, etc.). William Bottemiller's record does not appear to be indexed in collection 3657650 under any Battemiller variant. Pivoting to record_read of existing indexed records in other collections."
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"logId\\\": \\\"log_003\\\",\\n  \\\"performed\\\": \\\"2026-07-02T13:31:53.242Z\\\",\\n  \\\"resultsRef\\\": \\\"results/log_003.json\\\",\\n  \\\"returnedCount\\\": 20,\\n  \\\"filesWritten\\\": [\\n    \\\"research.json\\\",\\n    \\\"results/log_003.json\\\"\\n  ],\\n  \\\"validation\\\": {\\n    \\\"valid\\\": true,\\n    \\\"warnings\\\": []\\n  }\\n}\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__research_log_append",
+      "args": {
+        "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u",
+        "tool": "record_search",
+        "planItemId": "pli_001",
+        "query": {
+          "tool": "record_read",
+          "recordId": "ark:/61903/1:1:F8WM-X8F",
+          "collection": "Oregon, Deaths and Burials, 1903-1947",
+          "collectionId": "1675532",
+          "note": "Reading existing source S8VD-MGG already attached to tree person 249W-9LP"
+        },
+        "outcome": "positive",
+        "resultsExamined": 1,
+        "resultsAvailable": 1,
+        "notes": "record_read of ark:/61903/1:1:F8WM-X8F (coll. 1675532) reveals the death-record abstract for Henry William Battemiller (=William Henry Bottemiller), died 13 May 1929, Clackamas, Oregon. PARENTS NAMED: Father = Casper A. Battermiller (ark:/61903/1:1:F8WM-X8N); Mother = Mary Mehlman (ark:/61903/1:1:F8WM-X8J). Spouse named as Lilly Jane (consistent with known wife Lillie Jane Kleinsmith). Birth year abstracted as 1862. Image source reference: ark:/61903/1:2:MYQR-859. This directly answers q_001."
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"logId\\\": \\\"log_004\\\",\\n  \\\"performed\\\": \\\"2026-07-02T13:32:20.759Z\\\",\\n  \\\"resultsRef\\\": null,\\n  \\\"returnedCount\\\": null,\\n  \\\"filesWritten\\\": [\\n    \\\"research.json\\\"\\n  ],\\n  \\\"validation\\\": {\\n    \\\"valid\\\": true,\\n    \\\"warnings\\\": []\\n  }\\n}\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__research_append",
+      "args": {
+        "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u",
+        "section": "plan_items",
+        "op": "update",
+        "planId": "pl_001",
+        "entryId": "pli_001",
+        "fields": {
+          "status": "in_progress"
+        }
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"section\\\": \\\"plan_items\\\",\\n  \\\"op\\\": \\\"update\\\",\\n  \\\"entryId\\\": \\\"pli_001\\\",\\n  \\\"filesWritten\\\": [\\n    \\\"research.json\\\"\\n  ],\\n  \\\"validation\\\": {\\n    \\\"valid\\\": true,\\n    \\\"warnings\\\": []\\n  }\\n}\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__record_read",
+      "args": {
+        "recordId": "ark:/61903/1:2:MYQR-859"
+      },
+      "response_summary": "{\"error\":\"Record MYQR-859 was not found in FamilySearch historical records.\"}"
+    },
+    {
+      "tool": "Skill",
+      "args": {
+        "skill": "record-extraction"
+      },
+      "response_summary": "Launching skill: record-extraction"
+    },
+    {
+      "tool": "mcp__genealogy__research_append",
+      "args": {
+        "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u",
+        "ops": [
+          {
+            "section": "sources",
+            "op": "append",
+            "entry": {
+              "gedcomx_source_description_id": "S8VD-MGG",
+              "citation": "\"Oregon, Deaths and Burials, 1903\u20131947,\" database, FamilySearch (https://www.familysearch.org/ark:/61903/1:1:F8WM-X8F : accessed 2 July 2026), entry for Henry William Battemiller, died 13 May 1929, Clackamas, Oregon; citing Oregon Vital Records.",
+              "citation_detail": {
+                "who": "Henry William Battemiller (deceased); Casper A. Battermiller (father); Mary Mehlman (mother)",
+                "what": "Oregon, Deaths and Burials, 1903\u20131947, database entry",
+                "when_created": "1929",
+                "when_accessed": "2026-07-02",
+                "where": "FamilySearch (familysearch.org)",
+                "where_within": "Entry ark:/61903/1:1:F8WM-X8F"
+              },
+              "source_classification": "derivative",
+              "repository": "FamilySearch",
+              "access_date": "2026-07-02",
+              "url": "https://www.familysearch.org/ark:/61903/1:1:F8WM-X8F",
+              "notes": "Database abstract of Oregon state death certificates; collection 1675532 has no images. Underlying certificate image is at ark:/61903/1:2:MYQR-859 (not accessible via record_read). Subject indexed as 'Henry William Battemiller' \u2014 given name transposed, surname corrupted from 'Bottemiller'. Collection 3657650 (Oregon State Archives, with images) did not return this record by indexed name search. Parents named on the abstract: father = Casper A. Battermiller; mother = Mary Mehlman (maiden name).",
+              "log_entry_id": "log_004"
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "source_id": "src_001",
+              "record_id": "https://www.familysearch.org/ark:/61903/1:1:F8WM-X8F",
+              "record_persona_id": "p_11207172945",
+              "record_role": "deceased",
+              "fact_type": "name",
+              "value": "Henry William Battemiller (given name transposed; actual name William Henry Bottemiller)",
+              "structured_value": {
+                "given": "Henry William",
+                "surname": "Battemiller"
+              },
+              "information_quality": "primary",
+              "informant": "unknown personal informant (likely surviving spouse or family member)",
+              "informant_proximity": "family_not_present",
+              "evidence_type": "direct",
+              "extracted_for_question_ids": [
+                "q_001"
+              ],
+              "log_entry_id": "log_004"
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "source_id": "src_001",
+              "record_id": "https://www.familysearch.org/ark:/61903/1:1:F8WM-X8F",
+              "record_persona_id": "p_11207172945",
+              "record_role": "deceased",
+              "fact_type": "death",
+              "value": "died 13 May 1929, Clackamas, Oregon",
+              "date": "13 May 1929",
+              "date_certainty": "exact",
+              "place": "Clackamas, Oregon",
+              "standard_place": "Clackamas, Oregon, United States",
+              "information_quality": "primary",
+              "informant": "county registrar or attending physician",
+              "informant_proximity": "official_duty",
+              "evidence_type": "direct",
+              "extracted_for_question_ids": [
+                "q_001"
+              ],
+              "log_entry_id": "log_004"
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "source_id": "src_001",
+              "record_id": "https://www.familysearch.org/ark:/61903/1:1:F8WM-X8F",
+              "record_persona_id": "p_11207172945",
+              "record_role": "deceased",
+              "fact_type": "birth",
+              "value": "born 1862",
+              "date": "1862",
+              "date_certainty": "approximate",
+              "information_quality": "secondary",
+              "informant": "unknown personal informant (likely surviving spouse or family member)",
+              "informant_proximity": "family_not_present",
+              "evidence_type": "direct",
+              "extracted_for_question_ids": [
+                "q_001"
+              ],
+              "log_entry_id": "log_004"
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "source_id": "src_001",
+              "record_id": "https://www.familysearch.org/ark:/61903/1:1:F8WM-X8F",
+              "record_persona_id": "p_11207172945",
+              "record_role": "deceased",
+              "fact_type": "relationship",
+              "value": "father named as Casper A. Battermiller on death certificate",
+              "structured_value": {
+                "relationship_type": "child",
+                "related_person_role": "father_of_deceased"
+              },
+              "information_quality": "secondary",
+              "informant": "unknown personal informant (likely surviving spouse or family member)",
+              "informant_proximity": "family_not_present",
+              "informant_bias_notes": "Death certificate parental information is indirect evidence per GPS standards \u2014 the personal informant reported what they knew about the deceased's parentage, not something they personally witnessed. The informant may not have known the parents directly.",
+              "evidence_type": "indirect",
+              "extracted_for_question_ids": [
+                "q_001"
+              ],
+              "log_entry_id": "log_004"
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "source_id": "src_001",
+              "record_id": "https://www.familysearch.org/ark:/61903/1:1:F8WM-X8F",
+              "record_persona_id": "p_11207172945",
+              "record_role": "deceased",
+              "fact_type": "relationship",
+              "value": "mother named as Mary Mehlman on death certificate",
+              "structured_value": {
+                "relationship_type": "child",
+                "related_person_role": "mother_of_deceased"
+              },
+              "information_quality": "secondary",
+              "informant": "unknown personal informant (likely surviving spouse or family member)",
+              "informant_proximity": "family_not_present",
+              "informant_bias_notes": "Death certificate parental information is indirect evidence \u2014 the personal informant reported what they knew. 'Mehlman' appears to be the mother's maiden name; she married into the Battermiller/Bottemiller family. The informant may not have known the mother directly.",
+              "evidence_type": "indirect",
+              "extracted_for_question_ids": [
+                "q_001"
+              ],
+              "log_entry_id": "log_004"
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "source_id": "src_001",
+              "record_id": "https://www.familysearch.org/ark:/61903/1:1:F8WM-X8F",
+              "record_persona_id": "p_11207172946",
+              "record_role": "father_of_deceased",
+              "fact_type": "name",
+              "value": "Casper A. Battermiller",
+              "structured_value": {
+                "given": "Casper A.",
+                "surname": "Battermiller"
+              },
+              "information_quality": "secondary",
+              "informant": "unknown personal informant (likely surviving spouse or family member of deceased)",
+              "informant_proximity": "family_not_present",
+              "informant_bias_notes": "The surname 'Battermiller' is a corrupted transcription of 'Bottemiller' \u2014 consistent with the general indexing errors in this collection. Father's given name 'Casper A.' is informant-reported on the death certificate.",
+              "evidence_type": "direct",
+              "extracted_for_question_ids": [
+                "q_001"
+              ],
+              "log_entry_id": "log_004"
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "source_id": "src_001",
+              "record_id": "https://www.familysearch.org/ark:/61903/1:1:F8WM-X8F",
+              "record_persona_id": "p_11207172947",
+              "record_role": "mother_of_deceased",
+              "fact_type": "name",
+              "value": "Mary Mehlman",
+              "structured_value": {
+                "given": "Mary",
+                "surname": "Mehlman"
+              },
+              "information_quality": "secondary",
+              "informant": "unknown personal informant (likely surviving spouse or family member of deceased)",
+              "informant_proximity": "family_not_present",
+              "informant_bias_notes": "'Mehlman' is the mother's maiden name as recorded on the certificate. She married Battermiller/Bottemiller and this name reflects her birth name, not her married name. Informant may not have known the mother personally.",
+              "evidence_type": "direct",
+              "extracted_for_question_ids": [
+                "q_001"
+              ],
+              "log_entry_id": "log_004"
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "source_id": "src_001",
+              "record_id": "https://www.familysearch.org/ark:/61903/1:1:F8WM-X8F",
+              "record_persona_id": "p_11207172948",
+              "record_role": "wife",
+              "fact_type": "name",
+              "value": "Lilly Jane",
+              "structured_value": {
+                "given": "Lilly Jane"
+              },
+              "information_quality": "primary",
+              "informant": "unknown personal informant",
+              "informant_proximity": "unknown",
+              "evidence_type": "direct",
+              "extracted_for_question_ids": [],
+              "log_entry_id": "log_004"
+            }
+          }
+        ]
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": false,\\n  \\\"errors\\\": [\\n    \\\"research.json/assertions[0]: has record_persona_id but its log entry 'log_004' has no sidecar (results_ref is null)\\\",\\n    \\\"research.json/assertions[1]: has record_persona_id but its log entry 'log_004' has no sidecar (results_ref is null)\\\",\\n    \\\"research.json/assertions[2]: has record_persona_id but its log entry 'log_004' has no sidecar (results_ref is null)\\\",\\n    \\\"research.json/assertions[3]: has record_persona_..."
+    },
+    {
+      "tool": "mcp__genealogy__research_append",
+      "args": {
+        "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u",
+        "ops": [
+          {
+            "section": "sources",
+            "op": "append",
+            "entry": {
+              "gedcomx_source_description_id": "S8VD-MGG",
+              "citation": "\"Oregon, Deaths and Burials, 1903\u20131947,\" database, FamilySearch (https://www.familysearch.org/ark:/61903/1:1:F8WM-X8F : accessed 2 July 2026), entry for Henry William Battemiller, died 13 May 1929, Clackamas, Oregon; citing Oregon Vital Records.",
+              "citation_detail": {
+                "who": "Henry William Battemiller (deceased); Casper A. Battermiller (father); Mary Mehlman (mother)",
+                "what": "Oregon, Deaths and Burials, 1903\u20131947, database entry",
+                "when_created": "1929",
+                "when_accessed": "2026-07-02",
+                "where": "FamilySearch (familysearch.org)",
+                "where_within": "Entry ark:/61903/1:1:F8WM-X8F"
+              },
+              "source_classification": "derivative",
+              "repository": "FamilySearch",
+              "access_date": "2026-07-02",
+              "url": "https://www.familysearch.org/ark:/61903/1:1:F8WM-X8F",
+              "notes": "Database abstract of Oregon state death certificates; collection 1675532 has no images. Underlying certificate image referenced at ark:/61903/1:2:MYQR-859. Subject indexed as 'Henry William Battemiller' \u2014 given name transposed, surname corrupted from 'Bottemiller'. Parents named: father = Casper A. Battermiller; mother = Mary Mehlman (maiden name).",
+              "log_entry_id": "log_004"
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "source_id": "src_001",
+              "record_id": "https://www.familysearch.org/ark:/61903/1:1:F8WM-X8F",
+              "record_persona_id": null,
+              "record_role": "deceased",
+              "fact_type": "name",
+              "value": "Henry William Battemiller (given name transposed; actual name William Henry Bottemiller)",
+              "structured_value": {
+                "given": "Henry William",
+                "surname": "Battemiller"
+              },
+              "information_quality": "primary",
+              "informant": "unknown personal informant (likely surviving spouse or family member)",
+              "informant_proximity": "family_not_present",
+              "evidence_type": "direct",
+              "extracted_for_question_ids": [
+                "q_001"
+              ],
+              "log_entry_id": "log_004"
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "source_id": "src_001",
+              "record_id": "https://www.familysearch.org/ark:/61903/1:1:F8WM-X8F",
+              "record_persona_id": null,
+              "record_role": "deceased",
+              "fact_type": "death",
+              "value": "died 13 May 1929, Clackamas, Oregon",
+              "date": "13 May 1929",
+              "date_certainty": "exact",
+              "place": "Clackamas, Oregon",
+              "standard_place": "Clackamas, Oregon, United States",
+              "information_quality": "primary",
+              "informant": "county registrar or attending physician",
+              "informant_proximity": "official_duty",
+              "evidence_type": "direct",
+              "extracted_for_question_ids": [
+                "q_001"
+              ],
+              "log_entry_id": "log_004"
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "source_id": "src_001",
+              "record_id": "https://www.familysearch.org/ark:/61903/1:1:F8WM-X8F",
+              "record_persona_id": null,
+              "record_role": "deceased",
+              "fact_type": "birth",
+              "value": "born 1862",
+              "date": "1862",
+              "date_certainty": "approximate",
+              "information_quality": "secondary",
+              "informant": "unknown personal informant (likely surviving spouse or family member)",
+              "informant_proximity": "family_not_present",
+              "evidence_type": "direct",
+              "extracted_for_question_ids": [
+                "q_001"
+              ],
+              "log_entry_id": "log_004"
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "source_id": "src_001",
+              "record_id": "https://www.familysearch.org/ark:/61903/1:1:F8WM-X8F",
+              "record_persona_id": null,
+              "record_role": "deceased",
+              "fact_type": "relationship",
+              "value": "father named as Casper A. Battermiller on death certificate",
+              "structured_value": {
+                "relationship_type": "child",
+                "related_person_role": "father_of_deceased"
+              },
+              "information_quality": "secondary",
+              "informant": "unknown personal informant (likely surviving spouse or family member)",
+              "informant_proximity": "family_not_present",
+              "informant_bias_notes": "Death certificate parental information is indirect evidence per GPS \u2014 the personal informant reported what they knew about the deceased's parentage, not something they personally witnessed.",
+              "evidence_type": "indirect",
+              "extracted_for_question_ids": [
+                "q_001"
+              ],
+              "log_entry_id": "log_004"
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "source_id": "src_001",
+              "record_id": "https://www.familysearch.org/ark:/61903/1:1:F8WM-X8F",
+              "record_persona_id": null,
+              "record_role": "deceased",
+              "fact_type": "relationship",
+              "value": "mother named as Mary Mehlman on death certificate",
+              "structured_value": {
+                "relationship_type": "child",
+                "related_person_role": "mother_of_deceased"
+              },
+              "information_quality": "secondary",
+              "informant": "unknown personal informant (likely surviving spouse or family member)",
+              "informant_proximity": "family_not_present",
+              "informant_bias_notes": "Death certificate parental information is indirect evidence. 'Mehlman' appears to be the mother's maiden name; she married into the Bottemiller family. Informant may not have known the mother directly.",
+              "evidence_type": "indirect",
+              "extracted_for_question_ids": [
+                "q_001"
+              ],
+              "log_entry_id": "log_004"
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "source_id": "src_001",
+              "record_id": "https://www.familysearch.org/ark:/61903/1:1:F8WM-X8F",
+              "record_persona_id": null,
+              "record_role": "father_of_deceased",
+              "fact_type": "name",
+              "value": "Casper A. Battermiller",
+              "structured_value": {
+                "given": "Casper A.",
+                "surname": "Battermiller"
+              },
+              "information_quality": "secondary",
+              "informant": "unknown personal informant (likely surviving spouse or family member of deceased)",
+              "informant_proximity": "family_not_present",
+              "informant_bias_notes": "Surname 'Battermiller' is a corrupted transcription of 'Bottemiller'. Father's given name 'Casper A.' is informant-reported on the death certificate.",
+              "evidence_type": "direct",
+              "extracted_for_question_ids": [
+                "q_001"
+              ],
+              "log_entry_id": "log_004"
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "source_id": "src_001",
+              "record_id": "https://www.familysearch.org/ark:/61903/1:1:F8WM-X8F",
+              "record_persona_id": null,
+              "record_role": "mother_of_deceased",
+              "fact_type": "name",
+              "value": "Mary Mehlman",
+              "structured_value": {
+                "given": "Mary",
+                "surname": "Mehlman"
+              },
+              "information_quality": "secondary",
+              "informant": "unknown personal informant (likely surviving spouse or family member of deceased)",
+              "informant_proximity": "family_not_present",
+              "informant_bias_notes": "'Mehlman' is the mother's maiden name as recorded on the certificate. She married into the Bottemiller family; this reflects her birth name.",
+              "evidence_type": "direct",
+              "extracted_for_question_ids": [
+                "q_001"
+              ],
+              "log_entry_id": "log_004"
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "source_id": "src_001",
+              "record_id": "https://www.familysearch.org/ark:/61903/1:1:F8WM-X8F",
+              "record_persona_id": null,
+              "record_role": "wife",
+              "fact_type": "name",
+              "value": "Lilly Jane",
+              "structured_value": {
+                "given": "Lilly Jane"
+              },
+              "information_quality": "primary",
+              "informant": "unknown personal informant",
+              "informant_proximity": "unknown",
+              "evidence_type": "direct",
+              "extracted_for_question_ids": [],
+              "log_entry_id": "log_004"
+            }
+          }
+        ]
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"results\\\": [\\n    {\\n      \\\"section\\\": \\\"sources\\\",\\n      \\\"op\\\": \\\"append\\\",\\n      \\\"entryId\\\": \\\"src_001\\\"\\n    },\\n    {\\n      \\\"section\\\": \\\"assertions\\\",\\n      \\\"op\\\": \\\"append\\\",\\n      \\\"entryId\\\": \\\"a_001\\\"\\n    },\\n    {\\n      \\\"section\\\": \\\"assertions\\\",\\n      \\\"op\\\": \\\"append\\\",\\n      \\\"entryId\\\": \\\"a_002\\\"\\n    },\\n    {\\n      \\\"section\\\": \\\"assertions\\\",\\n      \\\"op\\\": \\\"append\\\",\\n      \\\"entryId\\\": \\\"a_003\\\"\\n    },\\n ..."
+    },
+    {
+      "tool": "Skill",
+      "args": {
+        "skill": "assertion-classification"
+      },
+      "response_summary": "Launching skill: assertion-classification"
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u/.claude/skills/assertion-classification/references/three-layer-model.md"
+      },
+      "response_summary": "1\t# The Three-Layer Classification Model\n2\t\n3\t## Core Principle: Independence of Layers\n4\t\n5\tThe three layers -- source, information, and evidence -- are evaluated\n6\tindependently. The classification at one layer does NOT determine the\n7\tclassification at another. An original source can contain secondary\n8\tinformation. A derivative source can provide direct evidence. Each\n9\tlayer operates on its own terms.\n10\t\n11\t---\n12\t\n13\t## Layer 1: Source Classification\n14\t\n15\tSource classification addres..."
+    },
+    {
+      "tool": "mcp__genealogy__research_append",
+      "args": {
+        "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u",
+        "ops": [
+          {
+            "section": "assertions",
+            "op": "update",
+            "entryId": "a_001",
+            "fields": {
+              "information_quality": "indeterminate",
+              "informant_bias_notes": "Informant identity unknown from this database abstract; the specific person who registered the death and provided the deceased's name cannot be determined without the original certificate."
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "update",
+            "entryId": "a_002",
+            "fields": {
+              "informant": "attending physician (standard informant for death date/cause on Oregon death certificates)",
+              "informant_proximity": "witness",
+              "informant_bias_notes": "Attending physician typically certified the death and was physically present \u2014 a witness to the death event. Proximity is witness, not merely official_duty."
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "update",
+            "entryId": "a_004",
+            "fields": {
+              "evidence_type": "direct",
+              "informant_bias_notes": "Death certificate parental information is secondary information (the personal informant reported what they knew, not what they witnessed). However, the statement of the father's name is direct evidence for q_001 \u2014 it explicitly answers what the certificate reports about parents. Per GPS three-layer model, information quality (secondary) and evidence type (direct) are independent classifications. a_003 through a_007 all derive from the same unknown personal informant and form one evidence unit for parentage and birth facts."
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "update",
+            "entryId": "a_005",
+            "fields": {
+              "evidence_type": "direct",
+              "informant_bias_notes": "Death certificate parental information is secondary (the personal informant reported what they knew, not what they witnessed). However, the statement of the mother's name is direct evidence for q_001 \u2014 it explicitly answers what the certificate reports about parents. 'Mehlman' is the mother's maiden name. a_003 through a_007 form one evidence unit from the same unknown personal informant."
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "update",
+            "entryId": "a_008",
+            "fields": {
+              "information_quality": "indeterminate",
+              "informant_bias_notes": "Informant identity unknown from this database abstract. The surviving spouse (Lilly Jane) may have registered the death and provided her own name, which would be primary information \u2014 but this cannot be confirmed without the original certificate."
+            }
+          }
+        ]
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"results\\\": [\\n    {\\n      \\\"section\\\": \\\"assertions\\\",\\n      \\\"op\\\": \\\"update\\\",\\n      \\\"entryId\\\": \\\"a_001\\\"\\n    },\\n    {\\n      \\\"section\\\": \\\"assertions\\\",\\n      \\\"op\\\": \\\"update\\\",\\n      \\\"entryId\\\": \\\"a_002\\\"\\n    },\\n    {\\n      \\\"section\\\": \\\"assertions\\\",\\n      \\\"op\\\": \\\"update\\\",\\n      \\\"entryId\\\": \\\"a_004\\\"\\n    },\\n    {\\n      \\\"section\\\": \\\"assertions\\\",\\n      \\\"op\\\": \\\"update\\\",\\n      \\\"entryId\\\": \\\"a_005\\\"\\n    },\\n..."
+    },
+    {
+      "tool": "Skill",
+      "args": {
+        "skill": "person-evidence"
+      },
+      "response_summary": "Launching skill: person-evidence"
+    },
+    {
+      "tool": "ToolSearch",
+      "args": {
+        "query": "select:mcp__genealogy__tree_edit,mcp__genealogy__research_append",
+        "max_results": 2
+      },
+      "response_summary": "[{\"type\": \"tool_reference\", \"tool_name\": \"mcp__genealogy__tree_edit\"}, {\"type\": \"tool_reference\", \"tool_name\": \"mcp__genealogy__research_append\"}]"
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u/research.json"
+      },
+      "response_summary": "1\t{\n2\t  \"project\": {\n3\t    \"id\": \"rp_bottemiller_parents\",\n4\t    \"objective\": \"Who were the parents of William Henry Bottemiller, born 29 December 1862 in Franconia Township, Chisago County, Minnesota, and died 13 May 1929 in Oregon City, Clackamas County, Oregon?\",\n5\t    \"subject_person_ids\": [\n6\t      \"249W-9LP\"\n7\t    ],\n8\t    \"status\": \"active\",\n9\t    \"created\": \"2026-07-01T00:00:00Z\",\n10\t    \"updated\": \"2026-07-01T00:00:00Z\"\n11\t  },\n12\t  \"researcher_profile\": {\n13\t    \"experience_level\": ..."
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u/tree.gedcomx.json"
+      },
+      "response_summary": "1\t{\n2\t  \"persons\": [\n3\t    {\n4\t      \"id\": \"249W-9LP\",\n5\t      \"gender\": \"Male\",\n6\t      \"living\": false,\n7\t      \"names\": [\n8\t        {\n9\t          \"given\": \"William Henry\",\n10\t          \"surname\": \"Bottemiller\",\n11\t          \"id\": \"249W-9LP-name-1\"\n12\t        }\n13\t      ],\n14\t      \"facts\": [\n15\t        {\n16\t          \"id\": \"ebe0d4fe-20f8-4dad-b4b8-c69c03d0f100\",\n17\t          \"type\": \"Birth\",\n18\t          \"date\": \"29 December 1862\",\n19\t          \"standard_date\": \"29 Dec 1862\",\n20\t          ..."
+    },
+    {
+      "tool": "mcp__genealogy__tree_edit",
+      "args": {
+        "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u",
+        "ops": [
+          {
+            "operation": "add_person",
+            "person": {
+              "gender": "Male",
+              "names": [
+                {
+                  "given": "Casper A.",
+                  "surname": "Bottemiller",
+                  "preferred": true
+                }
+              ]
+            }
+          },
+          {
+            "operation": "add_person",
+            "person": {
+              "gender": "Female",
+              "names": [
+                {
+                  "given": "Mary",
+                  "surname": "Mehlman",
+                  "preferred": true
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"results\\\": [\\n    {\\n      \\\"operation\\\": \\\"add_person\\\",\\n      \\\"assignedIds\\\": {\\n        \\\"person\\\": \\\"I1\\\",\\n        \\\"names\\\": [\\n          \\\"N1\\\"\\n        ]\\n      }\\n    },\\n    {\\n      \\\"operation\\\": \\\"add_person\\\",\\n      \\\"assignedIds\\\": {\\n        \\\"person\\\": \\\"I2\\\",\\n        \\\"names\\\": [\\n          \\\"N2\\\"\\n        ]\\n      }\\n    }\\n  ],\\n  \\\"filesWritten\\\": [\\n    \\\"tree.gedcomx.json\\\"\\n  ],\\n  \\\"validation\\\": {\\n    \\\"valid\\\":..."
+    },
+    {
+      "tool": "mcp__genealogy__tree_edit",
+      "args": {
+        "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u",
+        "ops": [
+          {
+            "operation": "add_relationship",
+            "relationship": {
+              "type": "ParentChild",
+              "parent": "I1",
+              "child": "249W-9LP",
+              "subtype": "Biological"
+            }
+          },
+          {
+            "operation": "add_relationship",
+            "relationship": {
+              "type": "ParentChild",
+              "parent": "I2",
+              "child": "249W-9LP",
+              "subtype": "Biological"
+            }
+          }
+        ]
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"results\\\": [\\n    {\\n      \\\"operation\\\": \\\"add_relationship\\\",\\n      \\\"assignedIds\\\": {\\n        \\\"relationship\\\": \\\"R1\\\"\\n      }\\n    },\\n    {\\n      \\\"operation\\\": \\\"add_relationship\\\",\\n      \\\"assignedIds\\\": {\\n        \\\"relationship\\\": \\\"R2\\\"\\n      }\\n    }\\n  ],\\n  \\\"filesWritten\\\": [\\n    \\\"tree.gedcomx.json\\\"\\n  ],\\n  \\\"validation\\\": {\\n    \\\"valid\\\": true,\\n    \\\"warnings\\\": []\\n  }\\n}\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__research_append",
+      "args": {
+        "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u",
+        "ops": [
+          {
+            "section": "person_evidence",
+            "op": "append",
+            "entry": {
+              "assertion_id": "a_001",
+              "person_id": "249W-9LP",
+              "confidence": "confident",
+              "match_score": null,
+              "rationale": "Record names the deceased 'Henry William Battemiller', death 13 May 1929, Clackamas, Oregon, birth year 1862. Tree person 249W-9LP (William Henry Bottemiller) has matching death date and place (13 May 1929, Oregon City, Clackamas County, Oregon) and birth year 1862. Given-name transposition (Henry William vs. William Henry) and surname corruption (Battemiller vs. Bottemiller) are documented indexing artifacts of this record (existing tree sources confirm the same ARK is attached to 249W-9LP). Name, death date, death place, and birth year all agree \u2014 strong match."
+            }
+          },
+          {
+            "section": "person_evidence",
+            "op": "append",
+            "entry": {
+              "assertion_id": "a_002",
+              "person_id": "249W-9LP",
+              "confidence": "confident",
+              "match_score": null,
+              "rationale": "Death fact 'died 13 May 1929, Clackamas, Oregon' matches tree person 249W-9LP's death fact (13 May 1929, Oregon City, Clackamas, Oregon, United States) exactly. Same record as a_001; identity established there."
+            }
+          },
+          {
+            "section": "person_evidence",
+            "op": "append",
+            "entry": {
+              "assertion_id": "a_003",
+              "person_id": "249W-9LP",
+              "confidence": "confident",
+              "match_score": null,
+              "rationale": "Birth year 1862 is consistent with tree person 249W-9LP's documented birth date of 29 December 1862. Same record and persona as a_001."
+            }
+          },
+          {
+            "section": "person_evidence",
+            "op": "append",
+            "entry": {
+              "assertion_id": "a_004",
+              "person_id": "249W-9LP",
+              "confidence": "confident",
+              "match_score": null,
+              "rationale": "This relationship assertion ('father named Casper A. Battermiller on death certificate') bears on 249W-9LP as the child in the parent-child relationship. The deceased has been confidently identified as 249W-9LP (via a_001/a_002/a_003); this assertion is about that person's parentage."
+            }
+          },
+          {
+            "section": "person_evidence",
+            "op": "append",
+            "entry": {
+              "assertion_id": "a_004",
+              "person_id": "I1",
+              "confidence": "probable",
+              "match_score": null,
+              "rationale": "The relationship assertion names 'Casper A. Battermiller' as the father of the deceased. Stub I1 (Casper A. Bottemiller) was created from this single record. 'Battermiller' is a corrupted form of 'Bottemiller' consistent with indexing artifacts seen throughout this record. Probable confidence \u2014 only one source links to this person; no independent corroboration yet."
+            }
+          },
+          {
+            "section": "person_evidence",
+            "op": "append",
+            "entry": {
+              "assertion_id": "a_005",
+              "person_id": "249W-9LP",
+              "confidence": "confident",
+              "match_score": null,
+              "rationale": "This relationship assertion ('mother named Mary Mehlman on death certificate') bears on 249W-9LP as the child in the parent-child relationship. Identity of the deceased as 249W-9LP is established via a_001/a_002/a_003."
+            }
+          },
+          {
+            "section": "person_evidence",
+            "op": "append",
+            "entry": {
+              "assertion_id": "a_005",
+              "person_id": "I2",
+              "confidence": "probable",
+              "match_score": null,
+              "rationale": "The relationship assertion names 'Mary Mehlman' as the mother of the deceased. Stub I2 (Mary Mehlman) was created from this single record. Mehlman is her maiden name as recorded on the death certificate. Probable confidence \u2014 only one source; no independent corroboration yet."
+            }
+          },
+          {
+            "section": "person_evidence",
+            "op": "append",
+            "entry": {
+              "assertion_id": "a_006",
+              "person_id": "I1",
+              "confidence": "probable",
+              "match_score": null,
+              "rationale": "Name assertion 'Casper A. Battermiller' for the father_of_deceased role. Tree stub I1 has given name 'Casper A.' and surname 'Bottemiller'. The 'Battermiller' surname in the record is a corruption of 'Bottemiller' \u2014 the same pattern seen in the deceased's own surname throughout this collection. Probable \u2014 single source, stub newly created."
+            }
+          },
+          {
+            "section": "person_evidence",
+            "op": "append",
+            "entry": {
+              "assertion_id": "a_007",
+              "person_id": "I2",
+              "confidence": "probable",
+              "match_score": null,
+              "rationale": "Name assertion 'Mary Mehlman' for the mother_of_deceased role. Tree stub I2 (Mary Mehlman) was created from this single record. The maiden name 'Mehlman' is recorded as the mother's name on the death certificate, consistent with Oregon death certificate practice of recording mother's maiden name. Probable \u2014 single source, stub newly created."
+            }
+          },
+          {
+            "section": "person_evidence",
+            "op": "append",
+            "entry": {
+              "assertion_id": "a_008",
+              "person_id": "9SPC-3H6",
+              "confidence": "probable",
+              "match_score": null,
+              "rationale": "Wife name 'Lilly Jane' on the death certificate. Tree person 9SPC-3H6 has the preferred name 'Lillie Jane Kleinsmith' \u2014 'Lilly' and 'Lillie' are common spelling variants of the same name. She is the documented wife of 249W-9LP (Couple relationship present in tree). No surname is given in the death record abstract, but the given-name match and the known marital relationship make her the clear candidate. Probable \u2014 name variant and absent surname prevent fully confident identification from this record alone."
+            }
+          }
+        ]
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"results\\\": [\\n    {\\n      \\\"section\\\": \\\"person_evidence\\\",\\n      \\\"op\\\": \\\"append\\\",\\n      \\\"entryId\\\": \\\"pe_001\\\"\\n    },\\n    {\\n      \\\"section\\\": \\\"person_evidence\\\",\\n      \\\"op\\\": \\\"append\\\",\\n      \\\"entryId\\\": \\\"pe_002\\\"\\n    },\\n    {\\n      \\\"section\\\": \\\"person_evidence\\\",\\n      \\\"op\\\": \\\"append\\\",\\n      \\\"entryId\\\": \\\"pe_003\\\"\\n    },\\n    {\\n      \\\"section\\\": \\\"person_evidence\\\",\\n      \\\"op\\\": \\\"append\\\",\\n      \\\"entryId..."
+    },
+    {
+      "tool": "Glob",
+      "args": {
+        "pattern": ".claude/skills/*/skill.md",
+        "path": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u"
+      },
+      "response_summary": "No files found"
+    },
+    {
+      "tool": "Glob",
+      "args": {
+        "pattern": ".claude/skills/**/*.md",
+        "path": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u"
+      },
+      "response_summary": ".claude/skills/assertion-classification/references/three-layer-model.md\n.claude/skills/assertion-classification/references/validation-protocol.md\n.claude/skills/check-warnings/SKILL.md\n.claude/skills/check-warnings/references/assumption-categories.md\n.claude/skills/check-warnings/references/warning-checks.md\n.claude/skills/check-warnings/references/warnings-as-identity-signals.md\n.claude/skills/citation/references/gps-citation-standards.md\n.claude/skills/citation/references/validation-protoco..."
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u/.claude/skills/research-exhaustiveness/SKILL.md"
+      },
+      "response_summary": "1\t---\n2\tname: research-exhaustiveness\n3\tmodel: claude-sonnet-4-6\n4\tdescription: Evaluates whether research on a question is reasonably\n5\t  exhaustive \u2014 applies the five threshold questions and the 7-point\n6\t  stop criteria, then either writes the exhaustive_declaration on the\n7\t  question or explains what's missing. GPS Step 1 \u2014 Reasonably\n8\t  Exhaustive Research. Use when the user says \"is this research\n9\t  exhaustive?\", \"are we done?\", \"have we searched enough?\", \"can we\n10\t  declare exhaus..."
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u/.claude/skills/research-exhaustiveness/references/research-exhaustiveness.md"
+      },
+      "response_summary": "1\t# Exhaustiveness Evaluation\n2\t\n3\tGuidance for determining when research on a question qualifies as\n4\t\"reasonably exhaustive\" under GPS Component 1.\n5\t\n6\t## What \"Reasonably Exhaustive\" Means\n7\t\n8\tReasonably exhaustive research is systematic investigation that\n9\tsearches all available and relevant sources \u2014 not just the ones\n10\tthat are easiest to access or most popular. The standard requires\n11\tlooking broadly across record types, repositories, and time periods\n12\tto ensure no significant s..."
+    },
+    {
+      "tool": "mcp__genealogy__research_append",
+      "args": {
+        "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u",
+        "ops": [
+          {
+            "section": "plan_items",
+            "op": "update",
+            "planId": "pl_001",
+            "entryId": "pli_001",
+            "fields": {
+              "status": "completed"
+            }
+          },
+          {
+            "section": "plan_items",
+            "op": "update",
+            "planId": "pl_001",
+            "entryId": "pli_002",
+            "fields": {
+              "status": "skipped"
+            }
+          },
+          {
+            "section": "plan_items",
+            "op": "update",
+            "planId": "pl_001",
+            "entryId": "pli_003",
+            "fields": {
+              "status": "skipped"
+            }
+          },
+          {
+            "section": "plan_items",
+            "op": "update",
+            "planId": "pl_001",
+            "entryId": "pli_004",
+            "fields": {
+              "status": "skipped"
+            }
+          },
+          {
+            "section": "plan_items",
+            "op": "update",
+            "planId": "pl_001",
+            "entryId": "pli_005",
+            "fields": {
+              "status": "skipped"
+            }
+          }
+        ]
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"results\\\": [\\n    {\\n      \\\"section\\\": \\\"plan_items\\\",\\n      \\\"op\\\": \\\"update\\\",\\n      \\\"entryId\\\": \\\"pli_001\\\"\\n    },\\n    {\\n      \\\"section\\\": \\\"plan_items\\\",\\n      \\\"op\\\": \\\"update\\\",\\n      \\\"entryId\\\": \\\"pli_002\\\"\\n    },\\n    {\\n      \\\"section\\\": \\\"plan_items\\\",\\n      \\\"op\\\": \\\"update\\\",\\n      \\\"entryId\\\": \\\"pli_003\\\"\\n    },\\n    {\\n      \\\"section\\\": \\\"plan_items\\\",\\n      \\\"op\\\": \\\"update\\\",\\n      \\\"entryId\\\": \\\"pli_004\\\"\\n..."
+    },
+    {
+      "tool": "Agent",
+      "args": {
+        "description": "GPS mentor pre-exhaustiveness review for q_001",
+        "subagent_type": "gps-mentor",
+        "prompt": "You are the gps-mentor agent. Please perform a pre-exhaustiveness checkpoint review for question q_001 in the project at /private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u.\n\nContext: This is a /research autonomous session. All plan items for q_001 have been marked completed or skipped. The research gathered one derivative source \u2014 the FamilySearch \"Oregon, Deaths and Burials, 1903-1947\" database abstract (src_001, collection 1675532) for William Henry Bottemiller's death record (indexed as \"Henry William Battemiller\"). It names Father = Casper A. Battermiller, Mother = Mary Mehlman. Eight assertions were extracted (a_001\u2013a_008) and all have been classified and linked to persons.\n\nPlease review the current state of the project and tell me:\n1. Is there anything that must be addressed before declaring q_001 exhaustive?\n2. Are there any GPS compliance issues (evidence quality, classification accuracy, person-evidence links) that need to be fixed first?\n3. Is this ready to proceed to research-exhaustiveness and then proof-conclusion?\n\nThis is checkpoint 1 of 3 (before research-exhaustiveness). Return a concise verdict plus any required corrective actions."
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"The Write tool is not available in this environment \\u2014 only Read is enabled. This means I cannot complete the output protocol's file-write and research.json append steps. Per the operating rules, I must report this explicitly rather than proceed silently as if the writes succeeded. I will surface the full verdict content in my narrative so the audit trail can be reconstructed by the orchestrator.\\n\\n---\\n\\n# Mentor review: pre-exhaustiveness on q_001\\n\\n**Focus:..."
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u/research.json"
+      },
+      "response_summary": "1\t{\n2\t  \"project\": {\n3\t    \"id\": \"rp_bottemiller_parents\",\n4\t    \"objective\": \"Who were the parents of William Henry Bottemiller, born 29 December 1862 in Franconia Township, Chisago County, Minnesota, and died 13 May 1929 in Oregon City, Clackamas County, Oregon?\",\n5\t    \"subject_person_ids\": [\n6\t      \"249W-9LP\"\n7\t    ],\n8\t    \"status\": \"active\",\n9\t    \"created\": \"2026-07-01T00:00:00Z\",\n10\t    \"updated\": \"2026-07-01T00:00:00Z\"\n11\t  },\n12\t  \"researcher_profile\": {\n13\t    \"experience_level\": ..."
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u/results/log_002.json"
+      },
+      "response_summary": "1\t{\n2\t  \"log_id\": \"log_002\",\n3\t  \"tool\": \"record_search\",\n4\t  \"retrieved\": \"2026-07-02T13:28:14.125Z\",\n5\t  \"returned_count\": 4,\n6\t  \"payload\": {\n7\t    \"query\": {\n8\t      \"surname\": \"Battemiller\",\n9\t      \"givenName\": \"Henry\",\n10\t      \"deathYearFrom\": 1927,\n11\t      \"deathYearTo\": 1931,\n12\t      \"deathPlace\": \"Oregon\",\n13\t      \"recordType\": \"death\",\n14\t      \"collectionId\": \"3657650\",\n15\t      \"projectPath\": \"/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91..."
+    },
+    {
+      "tool": "collections_search",
+      "args": {
+        "query": "Oregon death records Clackamas",
+        "place": "Oregon, United States"
+      },
+      "response_summary": "<tool_use_error>Error: No such tool available: collections_search</tool_use_error>"
+    },
+    {
+      "tool": "wiki_place_page",
+      "args": {
+        "place": "Clackamas County, Oregon",
+        "section": "online_records"
+      },
+      "response_summary": "<tool_use_error>Error: No such tool available: wiki_place_page</tool_use_error>"
+    },
+    {
+      "tool": "validate_research_schema",
+      "args": {
+        "project_path": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u"
+      },
+      "response_summary": "<tool_use_error>Error: No such tool available: validate_research_schema</tool_use_error>"
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u/evaluations/pre-exhaustiveness-q_001-2026-07-02T00-00-00.json"
+      },
+      "response_summary": "File does not exist. Note: your current working directory is /private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u."
+    },
+    {
+      "tool": "Write",
+      "args": {
+        "file_path": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u/evaluations/pre-exhaustiveness-q_001-2026-07-02T14-30-00.json",
+        "content": "{\n  \"focus\": \"pre-exhaustiveness\",\n  \"target_id\": \"q_001\",\n  \"target_type\": \"question\",\n  \"verdict\": \"address_first\",\n  \"strengths\": [\n    \"Excellent recovery on the indexing corruption. When the planned collection 3657650 returned zero hits for 'Bottemiller' (log_001) and only phonetic near-misses for 'Battemiller' (log_002, log_003), you did not stop \u2014 you pivoted to record_read of the record already attached to the tree person (log_004) and correctly recognized 'Henry William Battemiller' as the transposed, mis-surnamed index entry for William Henry Bottemiller. That is exactly the persistence Standard 19 (skillful use of finding aids and indexes) rewards.\",\n    \"Sound three-layer discipline on a_004 and a_005. You correctly held information quality (secondary) and evidence type (direct) apart: the informant reported parentage they did not witness (secondary information), yet the statement explicitly answers what the certificate reports about the parents (direct evidence). The informant_bias_notes articulate this cleanly and cite the single-evidence-unit reasoning (Standards 38-39).\",\n    \"Honest confidence calibration on the person-evidence links. Assigning 'probable' rather than 'confident' to pe_005/pe_007/pe_008/pe_009 (the parent stubs I1 and I2) because only one source links to them, while reserving 'confident' for the well-corroborated deceased (pe_001-pe_003), shows you are letting the evidence set the confidence rather than the hope (Standard 43).\",\n    \"The negative searches that WERE run are logged with rigor. log_001, log_002, and log_003 each record the exact query, results examined, results available, and the reasoning for the negative outcome. That is model nil-search documentation (Standard 13) \u2014 the problem below is that most of the plan was skipped rather than searched this way.\"\n  ],\n  \"must_address\": [\n    {\n      \"standard\": \"Standard 32 \u2014 original records preferred over derivatives; Standard 38 \u2014 thoroughness in source use\",\n      \"issue\": \"The entire question rests on one derivative source (src_001), a FamilySearch database abstract with no image (collection 1675532). Your own log_004 and src_001 notes identify the underlying original certificate image at ark:/61903/1:2:MYQR-859 \u2014 and it was never consulted. The abstract is where the surname corruption ('Battermiller'/'Battemiller') and given-name transposition originate; the original certificate would confirm the parents' names as actually written, and \u2014 critically \u2014 would reveal the informant's identity, which every parentage assertion (a_004-a_007) currently lists as 'unknown.' An accessible original this directly referenced cannot be left unexamined before declaring exhaustive.\",\n      \"what_would_change_my_mind\": \"Consult the original certificate image at ark:/61903/1:2:MYQR-859 (a record_read on that image ARK) and extract from it: the informant's name and relationship, and the parents' names as written on the certificate. If the image genuinely cannot be accessed, log that attempt as a documented nil so the audit trail shows the original was sought.\",\n      \"suggested_skill\": \"research-execute\",\n      \"specific_action\": \"Execute a record_read on the underlying certificate image ark:/61903/1:2:MYQR-859 referenced in src_001; capture the informant identity and the parent names as written, then update assertions a_004-a_007 (and their informant/informant_proximity fields).\"\n    },\n    {\n      \"standard\": \"Standard 13 \u2014 data collection is extensive and its results are documented; skipped is not the same as searched-nil\",\n      \"issue\": \"Four of five plan items (pli_002 Ancestry state deaths, pli_003 Oregon Death Index 1903-1998, pli_004 Clackamas County obituary, pli_005 Find A Grave / cemetery) are marked 'skipped', not executed. The GPS audit trail requires the distinction between an unsearched record type and a searched-but-nil one. pli_004 and pli_005 in particular are independent, FAN-relevant sources: a May 1929 Oregon City obituary or a Find A Grave memorial could name surviving relatives and corroborate \u2014 or contradict \u2014 the single abstract's 'Casper' and 'Mary Mehlman' with an INDEPENDENT informant. Right now the parents' identities depend on one informant of unknown identity in one derivative record.\",\n      \"what_would_change_my_mind\": \"Execute pli_004 (obituary) and pli_005 (cemetery/Find A Grave) and log the results \u2014 positive or nil. If nil, a documented nil-search closes the gap and the single-source dependency is at least tested. At minimum, run one of the two independent-index confirmations (pli_002 or pli_003) so the death identification does not rest solely on the record you had to reach by pivoting.\",\n      \"suggested_skill\": \"research-execute\",\n      \"specific_action\": \"Execute pli_004 (Historic Oregon Newspapers / Chronicling America obituary search, Oregon City, May 1929) and pli_005 (Find A Grave, Oregon City, William Henry Bottemiller), logging each result including nil outcomes; then reconcile any parent names found against a_006 and a_007.\"\n    }\n  ],\n  \"consider_addressing\": [\n    {\n      \"standard\": \"Standard 14 \u2014 topical breadth\",\n      \"issue\": \"The plan is scoped tightly to the death event, which is appropriate for a question phrased as 'what does the death certificate report.' But note the parents 'Casper A.' and 'Mary Mehlman' are currently uncorroborated by any other record type. This is fine for THIS narrow question, but flag it now so it is not lost: the project objective (identifying the parents) will need census, marriage, and Minnesota-birth-era sources in subsequent questions. Ensure a follow-on question captures that breadth.\",\n      \"specific_action\": \"Confirm the research design includes downstream questions targeting the 1870/1880 census (Chisago County, Minnesota) and any Bottemiller marriage/land records that would corroborate Casper and Mary independently.\"\n    },\n    {\n      \"standard\": \"Standard 8 \u2014 mother's maiden name treated with care\",\n      \"issue\": \"a_007 records the mother as 'Mary Mehlman' and treats 'Mehlman' as her maiden name. That is the standard Oregon-certificate convention, and your note says so \u2014 but it rests on an assumption until the original is read. The original certificate (see must_address 1) will confirm whether 'Mehlman' is captioned as maiden name.\"\n    }\n  ],\n  \"non_blocking_notes\": [\n    \"a_008 (wife 'Lilly Jane') has extracted_for_question_ids empty, which is correct since it does not bear on parentage \u2014 no action needed, just confirming that was intentional and not an omission.\",\n    \"src_001's citation is well-formed and follows Evidence Explained structure (who/what/when/where/where-within). Nicely done.\"\n  ],\n  \"narrative_for_user\": \"# Mentor review: pre-exhaustiveness on q_001\\n\\n**Focus:** pre-exhaustiveness | **Target:** q_001 | **Verdict:** address_first\\n\\nThis is checkpoint 1 of 3. You are close, and the analytical work you *have* done is genuinely good. But I cannot in good conscience wave this through to research-exhaustiveness yet, and I want to walk you through why \u2014 because the reason is a teaching moment about the difference between 'the plan is finished' and 'the research is reasonably exhaustive.'\\n\\n## What you've done well\\n\\n- **Excellent recovery on the indexing corruption.** When collection 3657650 returned zero hits for 'Bottemiller' (log_001) and only phonetic near-misses for 'Battemiller' (log_002, log_003 \u2014 Kitsmiller, Heckelsmiller, Ottermiller), you pivoted to reading the record already attached to the tree (log_004) and correctly identified 'Henry William Battemiller' as the transposed, mis-surnamed entry for your subject. That is exactly the finding-aid persistence Standard 19 rewards.\\n- **Sound three-layer discipline on a_004 and a_005.** You held information quality (secondary \u2014 the informant reported parentage they did not witness) apart from evidence type (direct \u2014 the statement explicitly answers the question). That independence is the single most-often-botched call in the craft, and you got it right and documented your reasoning (Standards 38-39).\\n- **Honest confidence calibration.** 'Probable' on the parent stubs I1/I2 (pe_005, pe_007, pe_008, pe_009) because only one source supports them, while reserving 'confident' for the well-corroborated deceased \u2014 that is letting the evidence set the confidence, not the hope (Standard 43).\\n- **Rigorous nil-logging where you actually searched.** log_001 through log_003 record query, results examined, results available, and reasoning. Model documentation (Standard 13).\\n\\n## What to address before moving on\\n\\n1. **Consult the original certificate \u2014 you already found where it lives.** Everything here rests on one derivative database abstract (src_001, collection 1675532, no image). Your own notes in log_004 and src_001 point to the underlying original certificate image at **ark:/61903/1:2:MYQR-859**, and it was never read. That original is where the surname corruption originates, and it is the one place that will tell you *who the informant was* \u2014 right now every parentage assertion (a_004-a_007) lists the informant as 'unknown,' which weakens the whole conclusion. Standard 32 asks for the original when it is accessible, and this one is one record_read away.\\n\\n2. **Skipped is not the same as searched-nil.** Four of five plan items \u2014 pli_002 (Ancestry state deaths), pli_003 (Oregon Death Index), pli_004 (Clackamas County obituary), pli_005 (Find A Grave) \u2014 are marked 'skipped,' not executed. The GPS audit trail needs the distinction. pli_004 and pli_005 matter most: a May 1929 Oregon City obituary or a Find A Grave memorial would give you an *independent informant* for the parents' names, testing the single-source dependency you currently have. At minimum, run one independent index confirmation and the two FAN-adjacent sources, logging nil results as nil (Standard 13).\\n\\n## Worth considering\\n\\n- **Topical breadth for the objective, not just this question (Standard 14).** This question is narrowly and correctly scoped to the death certificate. Just make sure your research design carries forward to census (Chisago County, Minnesota, 1870/1880) and marriage/land records that would corroborate Casper and Mary independently in later questions \u2014 the parents are uncorroborated by any other record type right now.\\n- **Mother's maiden name (Standard 8).** a_007 treats 'Mehlman' as the maiden name per Oregon convention; reading the original (item 1 above) will confirm whether the certificate captions it that way.\\n\\n## What would change my mind\\n\\n- **On the original:** a record_read of ark:/61903/1:2:MYQR-859 that captures the informant's identity and the parents' names as written \u2014 or, if it truly cannot be accessed, a logged nil documenting the attempt.\\n- **On the skipped items:** executed searches for pli_004 and pli_005 (and ideally one of pli_002/pli_003) with results logged, positive or nil. If they come back nil, that is a *documented* nil and the single-source exposure is at least tested rather than unexamined.\\n\\nAddress these two, re-run this checkpoint, and I expect you will be clear for research-exhaustiveness. The bones of this are strong \u2014 you just stopped one record short of the original and left most of the plan unsearched rather than searched-nil.\"\n}\n"
+      },
+      "response_summary": "<tool_use_error>Error: No such tool available: Write. Write exists but is not enabled in this context. Use one of the available tools instead.</tool_use_error>"
+    },
+    {
+      "tool": "mcp__genealogy__research_append",
+      "args": {
+        "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u",
+        "section": "evaluations",
+        "op": "append",
+        "entry": {
+          "focus": "pre-exhaustiveness",
+          "target_id": "q_001",
+          "target_type": "question",
+          "verdict": "address_first",
+          "findings": "Mentor found two issues: (1) original certificate image at ark:/61903/1:2:MYQR-859 not accessed \u2014 rely on derivative abstract only; (2) pli_002\u2013pli_005 marked skipped rather than executed, leaving no logged nil results for independent confirmation and no FAN-adjacent corroboration. Informant on a_004\u2013a_007 remains 'unknown' because the original was not read. Recommended: attempt record_read of image ARK; execute pli_003 (Oregon Death Index) and pli_004/pli_005 (obituary / Find A Grave) as searched-nil or positive outcomes.",
+          "superseded_by": null
+        }
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": false,\\n  \\\"errors\\\": [\\n    \\\"research.json/evaluations[0]: missing required field 'file_path'\\\"\\n  ]\\n}\"}]"
+    },
+    {
+      "tool": "Glob",
+      "args": {
+        "pattern": "docs/specs/research-schema-spec.md",
+        "path": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u"
+      },
+      "response_summary": "No files found"
+    },
+    {
+      "tool": "Glob",
+      "args": {
+        "pattern": "docs/**/*.md",
+        "path": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u"
+      },
+      "response_summary": "No files found"
+    },
+    {
+      "tool": "Glob",
+      "args": {
+        "pattern": "**/*.md",
+        "path": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u"
+      },
+      "response_summary": ".claude/skills/assertion-classification/references/three-layer-model.md\n.claude/skills/assertion-classification/references/validation-protocol.md\n.claude/skills/check-warnings/SKILL.md\n.claude/skills/check-warnings/references/assumption-categories.md\n.claude/skills/check-warnings/references/warning-checks.md\n.claude/skills/check-warnings/references/warnings-as-identity-signals.md\n.claude/skills/citation/references/gps-citation-standards.md\n.claude/skills/citation/references/validation-protoco..."
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u/.claude/skills/proof-conclusion/SKILL.md"
+      },
+      "response_summary": "1\t---\n2\tname: proof-conclusion\n3\tmodel: claude-sonnet-4-6\n4\tdescription: Writes GPS-conformant proof conclusions \u2014 selects the\n5\t  confidence tier (Proved/Probable/Possible/Not Proved/Disproved), chooses\n6\t  the proof conclusion form (Statement/Summary/Argument), and produces a\n7\t  self-contained narrative markdown that can be uploaded to FamilySearch.\n8\t  Updates tree.gedcomx.json when the tier reaches probable or higher.\n9\t  GPS Step 5 \u2014 Soundly Reasoned, Coherently Written Conclusion. Use ..."
+    },
+    {
+      "tool": "Bash",
+      "args": {
+        "command": "ls /private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u/"
+      },
+      "response_summary": "research.json\nresults\ntree.gedcomx.json\ntree.gedcomx.json.bak"
+    },
+    {
+      "tool": "Write",
+      "args": {
+        "file_path": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u/evaluations/pre-exhaustiveness-q_001-2026-07-02T14-30-00.json",
+        "content": "{\n  \"focus\": \"pre-exhaustiveness\",\n  \"target_id\": \"q_001\",\n  \"target_type\": \"question\",\n  \"verdict\": \"address_first\",\n  \"checkpoint\": 1,\n  \"evaluator\": \"gps-mentor\",\n  \"evaluated_at\": \"2026-07-02T14:30:00Z\",\n  \"findings\": {\n    \"strengths\": [\n      \"Correct recovery when collection 3657650 returned zero hits \u2014 pivoted to record_read of existing tree source.\",\n      \"Correct independent classification of information_quality (secondary) and evidence_type (direct) on a_004 and a_005.\",\n      \"Appropriate confidence calibration: confident on deceased assertions, probable on parent stubs.\",\n      \"Complete nil logging for log_001 through log_003 with query, results examined, and reasoning.\"\n    ],\n    \"must_address\": [\n      {\n        \"issue\": \"Original certificate image not accessed\",\n        \"detail\": \"Everything rests on one derivative database abstract (src_001, collection 1675532). Original image at ark:/61903/1:2:MYQR-859 was referenced but never read. Informant on a_004-a_007 remains 'unknown', weakening the conclusion.\",\n        \"standard\": \"Standards 32, 38\",\n        \"action\": \"Attempt record_read on ark:/61903/1:2:MYQR-859; if accessible, update informant fields on a_004-a_007.\"\n      },\n      {\n        \"issue\": \"Skipped items not converted to searched-nil\",\n        \"detail\": \"pli_002-pli_005 marked skipped, not executed. pli_004 (newspaper obituary) and pli_005 (Find A Grave) could provide independent informant for parent names. pli_003 (Oregon Death Index) would confirm the death identification.\",\n        \"standard\": \"Standard 13\",\n        \"action\": \"Execute pli_003 (FamilySearch Oregon Death Index), pli_004 (Historic Oregon Newspapers / Chronicling America), and pli_005 (Find A Grave) with logged outcomes.\"\n      }\n    ]\n  },\n  \"answers\": {\n    \"ready_for_exhaustiveness\": false,\n    \"ready_for_proof_conclusion\": false,\n    \"corrective_actions_required\": true\n  }\n}\n"
+      },
+      "response_summary": "File created successfully at: /private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u/evaluations/pre-exhaustiveness-q_001-2026-07-02T14-30-00.json (file state is current in your context \u2014 no need to Read it back)"
+    },
+    {
+      "tool": "mcp__genealogy__research_append",
+      "args": {
+        "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u",
+        "section": "evaluations",
+        "op": "append",
+        "entry": {
+          "focus": "pre-exhaustiveness",
+          "target_id": "q_001",
+          "target_type": "question",
+          "verdict": "address_first",
+          "file_path": "evaluations/pre-exhaustiveness-q_001-2026-07-02T14-30-00.json",
+          "superseded_by": null
+        }
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"section\\\": \\\"evaluations\\\",\\n  \\\"op\\\": \\\"append\\\",\\n  \\\"entryId\\\": \\\"ev_001\\\",\\n  \\\"filesWritten\\\": [\\n    \\\"research.json\\\"\\n  ],\\n  \\\"validation\\\": {\\n    \\\"valid\\\": true,\\n    \\\"warnings\\\": []\\n  }\\n}\"}]"
+    },
+    {
+      "tool": "ToolSearch",
+      "args": {
+        "query": "select:mcp__genealogy__record_read,mcp__genealogy__fulltext_search,mcp__genealogy__research_log_append",
+        "max_results": 3
+      },
+      "response_summary": "[{\"type\": \"tool_reference\", \"tool_name\": \"mcp__genealogy__record_read\"}, {\"type\": \"tool_reference\", \"tool_name\": \"mcp__genealogy__fulltext_search\"}, {\"type\": \"tool_reference\", \"tool_name\": \"mcp__genealogy__research_log_append\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__record_read",
+      "args": {
+        "recordId": "ark:/61903/1:2:MYQR-859"
+      },
+      "response_summary": "{\"error\":\"Record MYQR-859 was not found in FamilySearch historical records.\"}"
+    },
+    {
+      "tool": "mcp__genealogy__research_log_append",
+      "args": {
+        "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u",
+        "tool": "record_read",
+        "planItemId": "pli_001",
+        "query": {
+          "tool": "record_read",
+          "recordId": "ark:/61903/1:2:MYQR-859",
+          "purpose": "Attempt to access original Oregon death certificate image underlying the database abstract in src_001"
+        },
+        "outcome": "negative",
+        "resultsExamined": 0,
+        "resultsAvailable": 0,
+        "notes": "record_read of ark:/61903/1:2:MYQR-859 (1:2: source-citation ARK) returned 'Record not found'. This is a source citation pointer to the Oregon State Archives certificate image; it is not directly accessible as a FamilySearch record entity. Original image inaccessible via available tools. Derivative database abstract (src_001) remains the best available version of this record."
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"logId\\\": \\\"log_005\\\",\\n  \\\"performed\\\": \\\"2026-07-02T13:52:04.549Z\\\",\\n  \\\"resultsRef\\\": null,\\n  \\\"returnedCount\\\": null,\\n  \\\"filesWritten\\\": [\\n    \\\"research.json\\\"\\n  ],\\n  \\\"validation\\\": {\\n    \\\"valid\\\": true,\\n    \\\"warnings\\\": []\\n  }\\n}\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__research_append",
+      "args": {
+        "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u",
+        "ops": [
+          {
+            "section": "plans",
+            "op": "update",
+            "entryId": "pl_001",
+            "fields": {
+              "status": "completed"
+            }
+          },
+          {
+            "section": "plans",
+            "op": "append",
+            "entry": {
+              "question_id": "q_001",
+              "status": "active",
+              "created": "2026-07-02"
+            }
+          },
+          {
+            "section": "plan_items",
+            "op": "append",
+            "planId": "pl_002",
+            "entry": {
+              "sequence": 1,
+              "record_type": "vital_record",
+              "jurisdiction": "Oregon, United States",
+              "date_range": "1929",
+              "repository": "FamilySearch",
+              "rationale": "Existing tree source S8VD-92V (ark:/61903/1:1:VZHS-YXF) is the Oregon Death Index, 1903-1998 entry for 'Henry William Battemiller' (collection 1946790). Reading this record provides an independent confirmation of the death identification separate from the collection-1675532 abstract, and may reveal different field values. Mentor identified this as needed for repository breadth.",
+              "fallback_for": null,
+              "status": "planned"
+            }
+          },
+          {
+            "section": "plan_items",
+            "op": "append",
+            "planId": "pl_002",
+            "entry": {
+              "sequence": 2,
+              "record_type": "cemetery",
+              "jurisdiction": "Oregon City, Clackamas County, Oregon, United States",
+              "date_range": "1929",
+              "repository": "FamilySearch",
+              "rationale": "Existing tree source S8VD-963 (ark:/61903/1:1:QV2C-WKHM) is the Find a Grave Index entry for William Henry Bottemiller. Reading this record may reveal memorial notes, parents, or family connections added by contributors. Provides an independent compiled source to corroborate or challenge the death certificate data.",
+              "fallback_for": null,
+              "status": "planned"
+            }
+          },
+          {
+            "section": "plan_items",
+            "op": "append",
+            "planId": "pl_002",
+            "entry": {
+              "sequence": 3,
+              "record_type": "newspaper",
+              "jurisdiction": "Clackamas County, Oregon, United States",
+              "date_range": "1929",
+              "repository": "FamilySearch",
+              "rationale": "FamilySearch full-text search of digitized Oregon newspapers may surface a May 1929 obituary for William Bottemiller in Oregon City or Clackamas County. An obituary written at the time of death would be an independent second informant for the parents' names, directly addressing the single-source limitation of q_001. Mentor explicitly identified this as the highest-value gap to fill.",
+              "fallback_for": null,
+              "status": "planned"
+            }
+          }
+        ]
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"results\\\": [\\n    {\\n      \\\"section\\\": \\\"plans\\\",\\n      \\\"op\\\": \\\"update\\\",\\n      \\\"entryId\\\": \\\"pl_001\\\"\\n    },\\n    {\\n      \\\"section\\\": \\\"plans\\\",\\n      \\\"op\\\": \\\"append\\\",\\n      \\\"entryId\\\": \\\"pl_002\\\"\\n    },\\n    {\\n      \\\"section\\\": \\\"plan_items\\\",\\n      \\\"op\\\": \\\"append\\\",\\n      \\\"entryId\\\": \\\"pli_006\\\"\\n    },\\n    {\\n      \\\"section\\\": \\\"plan_items\\\",\\n      \\\"op\\\": \\\"append\\\",\\n      \\\"entryId\\\": \\\"pli_007\\\"\\n    },\\n    ..."
+    },
+    {
+      "tool": "mcp__genealogy__record_read",
+      "args": {
+        "recordId": "ark:/61903/1:1:VZHS-YXF"
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"persons\\\": [\\n    {\\n      \\\"id\\\": \\\"p_13371558735\\\",\\n      \\\"ark\\\": \\\"ark:/61903/1:1:VZHS-YXF\\\",\\n      \\\"names\\\": [\\n        {\\n          \\\"id\\\": \\\"11faed09-dbbd-4e0d-8ec4-eb6476e08735\\\",\\n          \\\"type\\\": \\\"BirthName\\\",\\n          \\\"given\\\": \\\"Henry William\\\",\\n          \\\"surname\\\": \\\"Battemiller\\\"\\n        }\\n      ],\\n      \\\"facts\\\": [\\n        {\\n          \\\"id\\\": \\\"cbc2ddb2-4c71-44a4-8f4f-61ad1b609d0d\\\",\\n          \\\"type\\\": \\\"Death\\\",\\n         ..."
+    },
+    {
+      "tool": "mcp__genealogy__record_read",
+      "args": {
+        "recordId": "ark:/61903/1:1:QV2C-WKHM"
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"persons\\\": [\\n    {\\n      \\\"id\\\": \\\"p_101095469340\\\",\\n      \\\"ark\\\": \\\"ark:/61903/1:1:QV2C-WKHM\\\",\\n      \\\"names\\\": [\\n        {\\n          \\\"id\\\": \\\"e13c8ca1-aa4b-4bd4-b3fe-8dcbf18e1931\\\",\\n          \\\"type\\\": \\\"BirthName\\\",\\n          \\\"given\\\": \\\"William Henry\\\",\\n          \\\"surname\\\": \\\"Bottemiller\\\"\\n        }\\n      ],\\n      \\\"facts\\\": [\\n        {\\n          \\\"id\\\": \\\"24f5d151-6433-4998-aa07-29bdfe0580ff\\\",\\n          \\\"type\\\": \\\"Burial\\\",\\n      ..."
+    },
+    {
+      "tool": "mcp__genealogy__fulltext_search",
+      "args": {
+        "keywords": "+Bottemiller +Oregon +1929",
+        "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u",
+        "recordType": "newspaper",
+        "yearFrom": 1929,
+        "yearTo": 1929
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"query\\\": {\\n    \\\"keywords\\\": \\\"+Bottemiller +Oregon +1929\\\",\\n    \\\"projectPath\\\": \\\"/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u\\\",\\n    \\\"recordType\\\": \\\"newspaper\\\",\\n    \\\"yearFrom\\\": 1929,\\n    \\\"yearTo\\\": 1929\\n  },\\n  \\\"totalResults\\\": 0,\\n  \\\"returned\\\": 0,\\n  \\\"offset\\\": 0,\\n  \\\"hasMore\\\": false,\\n  \\\"results\\\": [],\\n  \\\"staged\\\": null\\n}\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__research_log_append",
+      "args": {
+        "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u",
+        "tool": "record_read",
+        "planItemId": "pli_006",
+        "query": {
+          "tool": "record_read",
+          "recordId": "ark:/61903/1:1:VZHS-YXF",
+          "collection": "Oregon, Death Index, 1903-1998",
+          "collectionId": "1946790"
+        },
+        "outcome": "positive",
+        "resultsExamined": 1,
+        "resultsAvailable": 1,
+        "notes": "record_read of ark:/61903/1:1:VZHS-YXF (Oregon Death Index, 1903-1998) returns: name 'Henry William Battemiller', death 13 May 1929, Clackamas, Oregon. Index-only \u2014 no parent names. Independently confirms the death event and subject identification from a second collection (1946790 vs. 1675532 for src_001). Source citation ARK: ark:/61903/1:2:9MSQ-JPYR."
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"logId\\\": \\\"log_006\\\",\\n  \\\"performed\\\": \\\"2026-07-02T13:53:43.427Z\\\",\\n  \\\"resultsRef\\\": null,\\n  \\\"returnedCount\\\": null,\\n  \\\"filesWritten\\\": [\\n    \\\"research.json\\\"\\n  ],\\n  \\\"validation\\\": {\\n    \\\"valid\\\": true,\\n    \\\"warnings\\\": []\\n  }\\n}\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__research_log_append",
+      "args": {
+        "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u",
+        "tool": "record_read",
+        "planItemId": "pli_007",
+        "query": {
+          "tool": "record_read",
+          "recordId": "ark:/61903/1:1:QV2C-WKHM",
+          "collection": "Find a Grave Index",
+          "collectionId": "2221801"
+        },
+        "outcome": "positive",
+        "resultsExamined": 1,
+        "resultsAvailable": 1,
+        "notes": "record_read of ark:/61903/1:1:QV2C-WKHM (Find a Grave Index) returns: name 'William Henry Bottemiller' (correct form, not transposed), birth 29 Dec 1862, death 13 May 1929, burial Clarkes, Clackamas, Oregon. No parent names in the FamilySearch index. External memorial page at findagrave.com GRid=64307258 may have more detail but requires an external site visit. Authored/compiled source. Confirms subject identity and death date independently."
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"logId\\\": \\\"log_007\\\",\\n  \\\"performed\\\": \\\"2026-07-02T13:53:51.257Z\\\",\\n  \\\"resultsRef\\\": null,\\n  \\\"returnedCount\\\": null,\\n  \\\"filesWritten\\\": [\\n    \\\"research.json\\\"\\n  ],\\n  \\\"validation\\\": {\\n    \\\"valid\\\": true,\\n    \\\"warnings\\\": []\\n  }\\n}\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__research_log_append",
+      "args": {
+        "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u",
+        "tool": "fulltext_search",
+        "planItemId": "pli_008",
+        "query": {
+          "keywords": "+Bottemiller +Oregon +1929",
+          "recordType": "newspaper",
+          "yearFrom": 1929,
+          "yearTo": 1929
+        },
+        "outcome": "negative",
+        "resultsExamined": 0,
+        "resultsAvailable": 0,
+        "notes": "Zero results for '+Bottemiller +Oregon +1929' in FamilySearch newspaper full-text search. No Oregon newspapers from 1929 containing 'Bottemiller' are currently digitized and indexed in FamilySearch. A May 1929 Oregon City obituary may exist in Historic Oregon Newspapers (oregonnews.uoregon.edu) or Chronicling America but would require a separate external-site search."
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"logId\\\": \\\"log_008\\\",\\n  \\\"performed\\\": \\\"2026-07-02T13:53:58.560Z\\\",\\n  \\\"resultsRef\\\": null,\\n  \\\"returnedCount\\\": null,\\n  \\\"filesWritten\\\": [\\n    \\\"research.json\\\"\\n  ],\\n  \\\"validation\\\": {\\n    \\\"valid\\\": true,\\n    \\\"warnings\\\": []\\n  }\\n}\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__research_append",
+      "args": {
+        "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u",
+        "ops": [
+          {
+            "section": "sources",
+            "op": "append",
+            "entry": {
+              "gedcomx_source_description_id": "S8VD-92V",
+              "citation": "\"Oregon, Death Index, 1903-1998,\" database, FamilySearch (https://www.familysearch.org/ark:/61903/1:1:VZHS-YXF : accessed 2 July 2026), entry for Henry William Battemiller, died 13 May 1929, Clackamas, Oregon; citing Oregon Vital Records.",
+              "citation_detail": {
+                "who": "Henry William Battemiller (deceased)",
+                "what": "Oregon, Death Index, 1903-1998, database entry",
+                "when_created": "compiled from 1903\u20131998 original certificates",
+                "when_accessed": "2026-07-02",
+                "where": "FamilySearch (familysearch.org)",
+                "where_within": "Entry ark:/61903/1:1:VZHS-YXF"
+              },
+              "source_classification": "derivative",
+              "repository": "FamilySearch",
+              "access_date": "2026-07-02",
+              "url": "https://www.familysearch.org/ark:/61903/1:1:VZHS-YXF",
+              "notes": "Index-only resource (collection 1946790); no images. Confirms name 'Henry William Battemiller', death 13 May 1929, Clackamas, Oregon. No parent names present. Independent confirmation of subject's death from a different collection than src_001.",
+              "log_entry_id": "log_006"
+            }
+          },
+          {
+            "section": "sources",
+            "op": "append",
+            "entry": {
+              "gedcomx_source_description_id": "S8VD-963",
+              "citation": "\"Find a Grave Index,\" database, FamilySearch (https://www.familysearch.org/ark:/61903/1:1:QV2C-WKHM : accessed 2 July 2026), entry for William Henry Bottemiller; citing Find A Grave (Memorial GRid=64307258).",
+              "citation_detail": {
+                "who": "William Henry Bottemiller (deceased)",
+                "what": "Find a Grave Index, database entry",
+                "when_created": "contributed by memorial creator (date unknown)",
+                "when_accessed": "2026-07-02",
+                "where": "FamilySearch (familysearch.org) / Find A Grave (findagrave.com)",
+                "where_within": "Entry ark:/61903/1:1:QV2C-WKHM; GRid=64307258"
+              },
+              "source_classification": "authored",
+              "repository": "FamilySearch",
+              "access_date": "2026-07-02",
+              "url": "https://www.familysearch.org/ark:/61903/1:1:QV2C-WKHM",
+              "notes": "Compiled Find A Grave memorial. Name correctly rendered as 'William Henry Bottemiller' (not transposed). Birth 29 Dec 1862, death 13 May 1929, burial Clarkes, Clackamas, Oregon. No parent names. Memorial page at findagrave.com GRid=64307258 may contain further detail but requires an external-site visit.",
+              "log_entry_id": "log_007"
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "source_id": "src_002",
+              "record_id": "https://www.familysearch.org/ark:/61903/1:1:VZHS-YXF",
+              "record_persona_id": null,
+              "record_role": "deceased",
+              "fact_type": "name",
+              "value": "Henry William Battemiller",
+              "structured_value": {
+                "given": "Henry William",
+                "surname": "Battemiller"
+              },
+              "information_quality": "indeterminate",
+              "informant": "unknown (Oregon Death Index \u2014 index created from original certificate informant chain)",
+              "informant_proximity": "unknown",
+              "evidence_type": "indirect",
+              "extracted_for_question_ids": [
+                "q_001"
+              ],
+              "log_entry_id": "log_006",
+              "informant_bias_notes": "Index derived from an original state death certificate; the identity of the person who provided the name to the original certificate is unknown from this source."
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "source_id": "src_002",
+              "record_id": "https://www.familysearch.org/ark:/61903/1:1:VZHS-YXF",
+              "record_persona_id": null,
+              "record_role": "deceased",
+              "fact_type": "death",
+              "value": "died 13 May 1929, Clackamas, Oregon",
+              "date": "13 May 1929",
+              "date_certainty": "exact",
+              "place": "Clackamas, Oregon",
+              "standard_place": "Clackamas, Oregon, United States",
+              "information_quality": "indeterminate",
+              "informant": "unknown (Oregon Death Index \u2014 index created from original certificate informant chain)",
+              "informant_proximity": "unknown",
+              "evidence_type": "indirect",
+              "extracted_for_question_ids": [
+                "q_001"
+              ],
+              "log_entry_id": "log_006"
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "source_id": "src_003",
+              "record_id": "https://www.familysearch.org/ark:/61903/1:1:QV2C-WKHM",
+              "record_persona_id": null,
+              "record_role": "deceased",
+              "fact_type": "name",
+              "value": "William Henry Bottemiller",
+              "structured_value": {
+                "given": "William Henry",
+                "surname": "Bottemiller"
+              },
+              "information_quality": "indeterminate",
+              "informant": "unknown Find A Grave contributor",
+              "informant_proximity": "unknown",
+              "evidence_type": "indirect",
+              "extracted_for_question_ids": [
+                "q_001"
+              ],
+              "log_entry_id": "log_007",
+              "informant_bias_notes": "Find A Grave memorials are compiled by volunteers; the contributor's source for the name is unknown."
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "source_id": "src_003",
+              "record_id": "https://www.familysearch.org/ark:/61903/1:1:QV2C-WKHM",
+              "record_persona_id": null,
+              "record_role": "deceased",
+              "fact_type": "birth",
+              "value": "born 29 Dec 1862",
+              "date": "29 Dec 1862",
+              "date_certainty": "exact",
+              "information_quality": "indeterminate",
+              "informant": "unknown Find A Grave contributor",
+              "informant_proximity": "unknown",
+              "evidence_type": "indirect",
+              "extracted_for_question_ids": [
+                "q_001"
+              ],
+              "log_entry_id": "log_007"
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "source_id": "src_003",
+              "record_id": "https://www.familysearch.org/ark:/61903/1:1:QV2C-WKHM",
+              "record_persona_id": null,
+              "record_role": "deceased",
+              "fact_type": "death",
+              "value": "died 13 May 1929",
+              "date": "13 May 1929",
+              "date_certainty": "exact",
+              "information_quality": "indeterminate",
+              "informant": "unknown Find A Grave contributor",
+              "informant_proximity": "unknown",
+              "evidence_type": "indirect",
+              "extracted_for_question_ids": [
+                "q_001"
+              ],
+              "log_entry_id": "log_007"
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "source_id": "src_003",
+              "record_id": "https://www.familysearch.org/ark:/61903/1:1:QV2C-WKHM",
+              "record_persona_id": null,
+              "record_role": "deceased",
+              "fact_type": "burial",
+              "value": "buried Clarkes, Clackamas, Oregon",
+              "place": "Clarkes, Clackamas, Oregon",
+              "standard_place": "Clarkes, Clackamas, Oregon, United States",
+              "information_quality": "indeterminate",
+              "informant": "unknown Find A Grave contributor",
+              "informant_proximity": "unknown",
+              "evidence_type": "indirect",
+              "extracted_for_question_ids": [
+                "q_001"
+              ],
+              "log_entry_id": "log_007"
+            }
+          },
+          {
+            "section": "person_evidence",
+            "op": "append",
+            "entry": {
+              "assertion_id": "a_009",
+              "person_id": "249W-9LP",
+              "confidence": "confident",
+              "match_score": null,
+              "rationale": "Oregon Death Index entry names 'Henry William Battemiller', death 13 May 1929, Clackamas, Oregon \u2014 same death date and place as tree person 249W-9LP. Given-name transposition and surname corruption are the same indexing artifacts already documented for src_001. Independent confirmation from a second collection."
+            }
+          },
+          {
+            "section": "person_evidence",
+            "op": "append",
+            "entry": {
+              "assertion_id": "a_010",
+              "person_id": "249W-9LP",
+              "confidence": "confident",
+              "match_score": null,
+              "rationale": "Death date and place 'died 13 May 1929, Clackamas, Oregon' from Oregon Death Index matches 249W-9LP's documented death fact exactly. Consistent with pe_002 from src_001."
+            }
+          },
+          {
+            "section": "person_evidence",
+            "op": "append",
+            "entry": {
+              "assertion_id": "a_011",
+              "person_id": "249W-9LP",
+              "confidence": "confident",
+              "match_score": null,
+              "rationale": "Find A Grave entry names 'William Henry Bottemiller' with birth 29 Dec 1862 and death 13 May 1929 \u2014 all three facts match tree person 249W-9LP exactly. Notably uses the correct name form (not transposed), consistent with the known subject."
+            }
+          },
+          {
+            "section": "person_evidence",
+            "op": "append",
+            "entry": {
+              "assertion_id": "a_012",
+              "person_id": "249W-9LP",
+              "confidence": "confident",
+              "match_score": null,
+              "rationale": "Birth date '29 Dec 1862' from Find A Grave matches 249W-9LP's birth fact exactly. Same record as a_011."
+            }
+          },
+          {
+            "section": "person_evidence",
+            "op": "append",
+            "entry": {
+              "assertion_id": "a_013",
+              "person_id": "249W-9LP",
+              "confidence": "confident",
+              "match_score": null,
+              "rationale": "Death date '13 May 1929' from Find A Grave matches 249W-9LP's death fact. Same record as a_011."
+            }
+          },
+          {
+            "section": "person_evidence",
+            "op": "append",
+            "entry": {
+              "assertion_id": "a_014",
+              "person_id": "249W-9LP",
+              "confidence": "confident",
+              "match_score": null,
+              "rationale": "Burial at 'Clarkes, Clackamas, Oregon' from Find A Grave consistent with 249W-9LP's burial fact in tree. Same record as a_011."
+            }
+          },
+          {
+            "section": "plan_items",
+            "op": "update",
+            "planId": "pl_002",
+            "entryId": "pli_006",
+            "fields": {
+              "status": "completed"
+            }
+          },
+          {
+            "section": "plan_items",
+            "op": "update",
+            "planId": "pl_002",
+            "entryId": "pli_007",
+            "fields": {
+              "status": "completed"
+            }
+          },
+          {
+            "section": "plan_items",
+            "op": "update",
+            "planId": "pl_002",
+            "entryId": "pli_008",
+            "fields": {
+              "status": "completed"
+            }
+          }
+        ]
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"results\\\": [\\n    {\\n      \\\"section\\\": \\\"sources\\\",\\n      \\\"op\\\": \\\"append\\\",\\n      \\\"entryId\\\": \\\"src_002\\\"\\n    },\\n    {\\n      \\\"section\\\": \\\"sources\\\",\\n      \\\"op\\\": \\\"append\\\",\\n      \\\"entryId\\\": \\\"src_003\\\"\\n    },\\n    {\\n      \\\"section\\\": \\\"assertions\\\",\\n      \\\"op\\\": \\\"append\\\",\\n      \\\"entryId\\\": \\\"a_009\\\"\\n    },\\n    {\\n      \\\"section\\\": \\\"assertions\\\",\\n      \\\"op\\\": \\\"append\\\",\\n      \\\"entryId\\\": \\\"a_010\\\"\\n    },\\n  ..."
+    },
+    {
+      "tool": "mcp__genealogy__research_append",
+      "args": {
+        "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u",
+        "section": "plans",
+        "op": "update",
+        "entryId": "pl_002",
+        "fields": {
+          "status": "completed"
+        }
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"section\\\": \\\"plans\\\",\\n  \\\"op\\\": \\\"update\\\",\\n  \\\"entryId\\\": \\\"pl_002\\\",\\n  \\\"filesWritten\\\": [\\n    \\\"research.json\\\"\\n  ],\\n  \\\"validation\\\": {\\n    \\\"valid\\\": true,\\n    \\\"warnings\\\": []\\n  }\\n}\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__research_append",
+      "args": {},
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": false,\\n  \\\"errors\\\": [\\n    \\\"research.json not found in projectPath\\\"\\n  ]\\n}\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__research_append",
+      "args": {
+        "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u",
+        "section": "questions",
+        "op": "update",
+        "entryId": "q_001",
+        "fields": {
+          "status": "exhaustive_declared",
+          "exhaustive_declaration": {
+            "declared": true,
+            "justification": "The question asks specifically what the death certificate reports about William Henry Bottemiller's parents. The FamilySearch 'Oregon, Deaths and Burials, 1903\u20131947' database abstract (src_001) explicitly names Father = Casper A. Battermiller and Mother = Mary Mehlman (maiden name). Three FamilySearch collections searched; Oregon Death Index (src_002) and Find a Grave Index (src_003) independently confirm the death event and subject identity. Original certificate image (ark:/61903/1:2:MYQR-859) was attempted via record_read and returned 'not found' \u2014 the derivative abstract is the best accessible version. Newspaper full-text returned nil for 1929. No conflicts among sources.",
+            "log_entry_ids": [
+              "log_001",
+              "log_002",
+              "log_003",
+              "log_004",
+              "log_005",
+              "log_006",
+              "log_007",
+              "log_008"
+            ],
+            "stop_criteria": {
+              "goal_alignment": "Yes \u2014 src_001 explicitly states Father = Casper A. Battermiller and Mother = Mary Mehlman, directly answering what the death certificate reports about his parents.",
+              "repository_breadth": "Three FamilySearch collections searched (1675532, 1946790, 2221801). Newspaper full-text nil. External sites (Ancestry, findagrave.com) not searched \u2014 noted as limitation for future corroboration questions; acceptable scope for this specific death-certificate question.",
+              "original_substitution": "Attempted original certificate image (ark:/61903/1:2:MYQR-859 via record_read); returned 'not found' \u2014 the 1:2: source-citation ARK points to the Oregon State Archives original, inaccessible via available tools. Derivative abstract (src_001) is best available.",
+              "independent_verification": "Three independent sources confirm the death event and subject identity. Only one source (src_001) names the parents; both parent assertions derive from the same unknown personal informant on the death certificate \u2014 one evidence unit for parentage. Subsequent questions will seek census and other corroboration.",
+              "evidence_class": "All sources are derivative (src_001, src_002) or authored (src_003). No original records with primary information accessible. Accuracy limited by indexer fidelity to the original certificate.",
+              "conflict_resolution": "No conflicts. All three sources agree on name, death date (13 May 1929), and place (Clackamas, Oregon). Parent names in src_001 are not contradicted.",
+              "overturn_risk": "Low for the specific question (what does the death certificate report). The abstract clearly names both parents. Future census research may refine the identification of the named parents but will not change what this certificate reports."
+            }
+          }
+        }
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"section\\\": \\\"questions\\\",\\n  \\\"op\\\": \\\"update\\\",\\n  \\\"entryId\\\": \\\"q_001\\\",\\n  \\\"filesWritten\\\": [\\n    \\\"research.json\\\"\\n  ],\\n  \\\"validation\\\": {\\n    \\\"valid\\\": true,\\n    \\\"warnings\\\": []\\n  }\\n}\"}]"
+    },
+    {
+      "tool": "Agent",
+      "args": {
+        "description": "GPS mentor pre-proof-conclusion review for q_001",
+        "subagent_type": "gps-mentor",
+        "prompt": "You are the gps-mentor agent. Please perform a pre-proof-conclusion checkpoint review (checkpoint 2 of 3) for question q_001 in the project at /private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u.\n\nContext:\n- q_001: \"What does the death certificate of William Henry Bottemiller (died 13 May 1929, Oregon City, Clackamas County, Oregon) report about his parents?\"\n- Research is now exhaustive_declared\n- Evidence: Three FamilySearch sources (src_001: death certificate abstract naming Father=Casper A. Battermiller, Mother=Mary Mehlman; src_002: Oregon Death Index confirming death; src_003: Find A Grave Index confirming identity)\n- Assertions a_001\u2013a_014 extracted and classified; person_evidence pe_001\u2013pe_016 all linked\n- Parent stubs created: I1 (Casper A. Bottemiller, Male) and I2 (Mary Mehlman, Female) with ParentChild relationships to 249W-9LP\n\nPlease review the project state and advise:\n1. Is the evidence base adequate to support a proof conclusion for q_001?\n2. What tier (probable/possible/not proved) is appropriate given the single-source limitation for parent names?\n3. Are the classifications and person-evidence links sound?\n4. Any GPS compliance issues to address before proof-conclusion runs?\n\nThis is checkpoint 2 of 3 (before proof-conclusion). Return a concise verdict."
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"The `evaluations/` directory exists. Now let me write the verdict file. The current UTC time is 2026-07-02; I'll use a timestamp of 2026-07-02T15-05-00.\\n\\nI don't have a Write tool available in my toolkit as listed, but I need to write files per the output protocol. Let me check \\u2014 the tools available to me are Read only in the function list. The output protocol requires writing files. Since I only have Read, I must report this constraint honestly. However, re-..."
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u/research.json"
+      },
+      "response_summary": "1\t{\n2\t  \"project\": {\n3\t    \"id\": \"rp_bottemiller_parents\",\n4\t    \"objective\": \"Who were the parents of William Henry Bottemiller, born 29 December 1862 in Franconia Township, Chisago County, Minnesota, and died 13 May 1929 in Oregon City, Clackamas County, Oregon?\",\n5\t    \"subject_person_ids\": [\n6\t      \"249W-9LP\"\n7\t    ],\n8\t    \"status\": \"active\",\n9\t    \"created\": \"2026-07-01T00:00:00Z\",\n10\t    \"updated\": \"2026-07-01T00:00:00Z\"\n11\t  },\n12\t  \"researcher_profile\": {\n13\t    \"experience_level\": ..."
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u/evaluations/pre-exhaustiveness-q_001-2026-07-02T14-30-00.json"
+      },
+      "response_summary": "1\t{\n2\t  \"focus\": \"pre-exhaustiveness\",\n3\t  \"target_id\": \"q_001\",\n4\t  \"target_type\": \"question\",\n5\t  \"verdict\": \"address_first\",\n6\t  \"checkpoint\": 1,\n7\t  \"evaluator\": \"gps-mentor\",\n8\t  \"evaluated_at\": \"2026-07-02T14:30:00Z\",\n9\t  \"findings\": {\n10\t    \"strengths\": [\n11\t      \"Correct recovery when collection 3657650 returned zero hits \u2014 pivoted to record_read of existing tree source.\",\n12\t      \"Correct independent classification of information_quality (secondary) and evidence_type (direct) on a..."
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u/tree.gedcomx.json",
+        "limit": 5
+      },
+      "response_summary": "1\t{\n2\t  \"persons\": [\n3\t    {\n4\t      \"id\": \"249W-9LP\",\n5\t      \"gender\": \"Male\","
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u/evaluations"
+      },
+      "response_summary": "EISDIR: illegal operation on a directory, read '/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u/evaluations'"
+    },
+    {
+      "tool": "Write",
+      "args": {
+        "file_path": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u/evaluations/conclusion-readiness-q_001-2026-07-02T15-05-00.json",
+        "content": "{\n  \"focus\": \"conclusion-readiness\",\n  \"target_id\": \"q_001\",\n  \"target_type\": \"question\",\n  \"verdict\": \"address_first\",\n  \"checkpoint\": 2,\n  \"evaluator\": \"gps-mentor\",\n  \"evaluated_at\": \"2026-07-02T15:05:00Z\",\n  \"must_address\": [\n    {\n      \"standard\": \"Standard 43; Standards 64-67\",\n      \"issue\": \"Parentage identification (I1/I2 stubs + ParentChild relationships to 249W-9LP) rests on one derivative source, secondary information, unknown informant, no corroboration. Supports Possible, not Proved or Probable. Only the narrow record-content claim can tier higher.\",\n      \"action\": \"In proof-conclusion, assign tier to the record-content claim (Probable) and explicitly label the parentage identification as Possible with corroboration still owed.\"\n    },\n    {\n      \"standard\": \"Standard 43 \u2014 conclusion scope\",\n      \"issue\": \"Parent stubs and ParentChild relationships already created reach past the tightly scoped question to the project objective. Proof must not let a record-content proof be read as a parentage proof.\",\n      \"action\": \"State scope explicitly in narrative_markdown: the certificate reports these names; parentage identification remains Possible pending independent corroboration.\"\n    }\n  ],\n  \"consider_addressing\": [\n    {\n      \"issue\": \"a_009/a_010 and a_011-a_014 evidence_type 'indirect' may be better read as 'direct' for the death-event facts \u2014 they are explicitly stated in those records.\",\n      \"action\": \"Non-blocking; does not change any conclusion.\"\n    },\n    {\n      \"issue\": \"findagrave.com memorial GRid=64307258 not visited \u2014 may carry parent names from independent contributor.\",\n      \"action\": \"Low-cost corroboration check for future questions.\"\n    }\n  ]\n}\n"
+      },
+      "response_summary": "File created successfully at: /private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u/evaluations/conclusion-readiness-q_001-2026-07-02T15-05-00.json (file state is current in your context \u2014 no need to Read it back)"
+    },
+    {
+      "tool": "mcp__genealogy__research_append",
+      "args": {
+        "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u",
+        "section": "evaluations",
+        "op": "append",
+        "entry": {
+          "focus": "conclusion-readiness",
+          "target_id": "q_001",
+          "target_type": "question",
+          "verdict": "address_first",
+          "file_path": "evaluations/conclusion-readiness-q_001-2026-07-02T15-05-00.json",
+          "superseded_by": null
+        }
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"section\\\": \\\"evaluations\\\",\\n  \\\"op\\\": \\\"append\\\",\\n  \\\"entryId\\\": \\\"ev_002\\\",\\n  \\\"filesWritten\\\": [\\n    \\\"research.json\\\"\\n  ],\\n  \\\"validation\\\": {\\n    \\\"valid\\\": true,\\n    \\\"warnings\\\": []\\n  }\\n}\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__research_append",
+      "args": {
+        "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u",
+        "section": "proof_summaries",
+        "op": "append",
+        "entry": {
+          "question_id": "q_001",
+          "tier": "probable",
+          "vehicle": "summary",
+          "supporting_assertion_ids": [
+            "a_001",
+            "a_002",
+            "a_003",
+            "a_004",
+            "a_005",
+            "a_006",
+            "a_007",
+            "a_008",
+            "a_009",
+            "a_010",
+            "a_011",
+            "a_012",
+            "a_013",
+            "a_014"
+          ],
+          "resolved_conflict_ids": [],
+          "exhaustive_search_summary": "Three FamilySearch collections searched: 'Oregon, Deaths and Burials, 1903\u20131947' (collection 1675532, the death certificate abstract naming parents); 'Oregon, Death Index, 1903\u20131998' (collection 1946790, index confirming death, no parent names); 'Find a Grave Index' (collection 2221801, compiled memorial confirming identity, no parent names). FamilySearch collection 3657650 (Oregon State Archives Death Records) searched under Bottemiller and Battemiller variants \u2014 zero hits for the subject. Original certificate image (ark:/61903/1:2:MYQR-859) attempted via record_read but returned 'not found.' Newspaper full-text search for '+Bottemiller +Oregon +1929' returned zero results. External repositories (Ancestry state deaths, findagrave.com memorial, Historic Oregon Newspapers) not searched \u2014 noted as next corroboration steps. Parent names appear only in one source (src_001); no second evidence unit for parentage exists.",
+          "narrative_markdown": "## Proof Summary: What William Henry Bottemiller\u2019s 1929 Death Certificate Reports About His Parents\n\n**Question (q_001):** What does the death certificate of William Henry Bottemiller (died 13 May 1929, Oregon City, Clackamas County, Oregon) report about his parents?\n\n**Conclusion:** The 1929 Oregon death certificate abstract reports that William Henry Bottemiller\u2019s father was **Casper A. Battermiller** (a corrupted transcription of Bottemiller) and his mother was **Mary Mehlman** (maiden name). This record-content conclusion is **probable** based on a single derivative database abstract with secondary information from an unknown personal informant. The identification of Casper A. Bottemiller and Mary Mehlman as William\u2019s biological parents is at this stage only **possible**, pending corroboration from independent sources.\n\n---\n\n### Sources Examined\n\n**Source 1 \u2014 Death certificate abstract (src_001, derivative):** \u201cOregon, Deaths and Burials, 1903\u20131947,\u201d database, FamilySearch (https://www.familysearch.org/ark:/61903/1:1:F8WM-X8F : accessed 2 July 2026), entry for Henry William Battemiller, died 13 May 1929, Clackamas, Oregon; citing Oregon Vital Records. *This abstract explicitly names Father = Casper A. Battermiller and Mother = Mary Mehlman.* Source classification: derivative. Information: secondary (unknown personal informant reported parentage). Evidence: direct (parent names explicitly stated).\n\n**Source 2 \u2014 Oregon Death Index entry (src_002, derivative):** \u201cOregon, Death Index, 1903\u20131998,\u201d database, FamilySearch (https://www.familysearch.org/ark:/61903/1:1:VZHS-YXF : accessed 2 July 2026), entry for Henry William Battemiller, died 13 May 1929. *Independently confirms the death event from a separate collection (1946790); contains no parent names.*\n\n**Source 3 \u2014 Find A Grave index entry (src_003, authored):** \u201cFind a Grave Index,\u201d database, FamilySearch (https://www.familysearch.org/ark:/61903/1:1:QV2C-WKHM : accessed 2 July 2026), entry for William Henry Bottemiller. *Confirms name (correctly non-transposed), birth 29 December 1862, death 13 May 1929, burial Clarkes, Clackamas, Oregon; no parent names.*\n\n---\n\n### Subject Identification\n\nWilliam Henry Bottemiller (249W-9LP), born 29 December 1862, Franconia Township, Chisago County, Minnesota; died 13 May 1929, Oregon City, Clackamas County, Oregon. The death certificate indexes him as \u201cHenry William Battemiller\u201d \u2014 given names transposed, surname corrupted. Three independent sources confirm the death date and place; source 3 carries the correct name form and exact birth date. **Subject identification: confident.**\n\n---\n\n### What the Certificate Reports\n\nThe death certificate abstract (src_001) explicitly states:\n- **Father:** Casper A. Battermiller (\u201cBattermiller\u201d = corrupted form of Bottemiller, consistent with indexing artifacts throughout this record)\n- **Mother:** Mary Mehlman (maiden name, consistent with Oregon death certificate practice of recording the mother\u2019s birth surname)\n\nNo other source examined names the parents.\n\n---\n\n### Evidence Analysis\n\n**Three-layer classification of a_004\u2013a_007 (parentage assertions):**\n- *Source:* Derivative \u2014 database abstract of the original Oregon State Archives certificate. The original image (ark:/61903/1:2:MYQR-859) was attempted via record_read and returned \u201cnot found\u201d; the derivative abstract is the best available version.\n- *Information quality:* Secondary \u2014 an unknown personal informant (likely the surviving spouse or attending family member) reported the parent names to the original certificate.\n- *Evidence type:* Direct \u2014 the certificate explicitly names the father and mother; no inference is required.\n\n**Evidence independence (GPS Standard 46):** Both parent-name assertions (a_004\u2013a_007) derive from the same unknown informant on the same death certificate. This constitutes **one evidence unit** for the parentage facts. Sources 2 and 3 confirm the subject\u2019s death and identity independently but add no parent data.\n\n---\n\n### Tier Declaration\n\n**For the record-content question (q_001):** **PROBABLE** \u2014 The derivative abstract credibly reports Father = Casper A. Battermiller and Mother = Mary Mehlman. The tier is limited to probable (not proved) because: (1) the source is derivative; the original is inaccessible; (2) all parent data comes from a single evidence unit from an unknown informant; (3) no second independent source corroborates the parent names.\n\n**For the parentage identification (project objective):** **POSSIBLE** \u2014 Casper A. Bottemiller and Mary Mehlman are identified as probable parents based solely on the death certificate abstract. Without corroborating evidence (census records placing William as a child in Casper Bottemiller\u2019s household, Minnesota birth records, marriage records, or probate), parentage is a credible hypothesis, not a proved conclusion. Parent stubs I1 (Casper A. Bottemiller) and I2 (Mary Mehlman) with provisional ParentChild relationships to 249W-9LP have been created in the working tree as provisional findings pending corroboration.\n\n---\n\n### Next Steps to Advance the Tier\n\n1. Search 1870 and 1880 U.S. censuses for Casper Bottemiller in Minnesota, looking for William (born 1862) as a child in his household\n2. Search Minnesota birth records for Franconia Township, Chisago County, ca. 1862\n3. Check the external findagrave.com memorial (GRid=64307258) for any parent names added by contributors\n4. Search Ancestry \u201cOregon, U.S., State Deaths, 1864\u20131971\u201d for an independent rendering of the same certificate\n\n---\n\n*Prepared 2 July 2026 | Project rp_bottemiller_parents | GPS Component 5*"
+        }
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"section\\\": \\\"proof_summaries\\\",\\n  \\\"op\\\": \\\"append\\\",\\n  \\\"entryId\\\": \\\"ps_001\\\",\\n  \\\"filesWritten\\\": [\\n    \\\"research.json\\\"\\n  ],\\n  \\\"validation\\\": {\\n    \\\"valid\\\": true,\\n    \\\"warnings\\\": []\\n  }\\n}\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__research_append",
+      "args": {
+        "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u",
+        "section": "project",
+        "op": "update",
+        "fields": {
+          "updated": "2026-07-02"
+        }
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": false,\\n  \\\"errors\\\": [\\n    \\\"field(s) not updatable on 'project': updated (allowed: status)\\\"\\n  ]\\n}\"}]"
+    },
+    {
+      "tool": "Agent",
+      "args": {
+        "description": "GPS mentor post-proof review for q_001",
+        "subagent_type": "gps-mentor",
+        "prompt": "You are the gps-mentor agent. Please perform a post-proof-conclusion checkpoint review (checkpoint 3 of 3) for question q_001 in the project at /private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u.\n\nContext:\n- q_001: \"What does the death certificate of William Henry Bottemiller (died 13 May 1929, Oregon City, Clackamas County, Oregon) report about his parents?\"\n- A proof summary (ps_001) has just been written at tier \"probable\" with vehicle \"summary\"\n- The proof states: death certificate reports Father=Casper A. Battermiller, Mother=Mary Mehlman; parentage identification is explicitly noted as \"possible\" pending census corroboration\n- Parent stubs I1 (Casper A. Bottemiller) and I2 (Mary Mehlman) are in tree.gedcomx.json with provisional ParentChild relationships to 249W-9LP\n- Three evaluations (ev_001 pre-exhaustiveness, ev_002 pre-proof) are recorded\n\nPlease review ps_001 and the overall state of q_001 and advise:\n1. Is the proof summary defensible as written?\n2. Is the \"probable\" tier for the record-content question appropriate?\n3. Is the explicit distinction between probable (record-content) and possible (parentage identification) appropriately stated?\n4. Any final corrections needed before moving on to question-selection for the next research question?\n\nThis is checkpoint 3 of 3 (post-proof). Return a concise verdict and note if this question is ready for question-selection to mark as resolved."
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"Directory confirmed to exist. I do not have a Write tool in my available toolkit \\u2014 my toolkit is read-only plus the research tools described. Let me re-check: the output protocol requires me to write the verdict file and append to research.json. I only have Read available among file tools in this session. I must report this honestly rather than pretend the write succeeded.\\n\\nLet me verify by checking whether there is a write mechanism I have. My available func..."
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u/research.json"
+      },
+      "response_summary": "1\t{\n2\t  \"project\": {\n3\t    \"id\": \"rp_bottemiller_parents\",\n4\t    \"objective\": \"Who were the parents of William Henry Bottemiller, born 29 December 1862 in Franconia Township, Chisago County, Minnesota, and died 13 May 1929 in Oregon City, Clackamas County, Oregon?\",\n5\t    \"subject_person_ids\": [\n6\t      \"249W-9LP\"\n7\t    ],\n8\t    \"status\": \"active\",\n9\t    \"created\": \"2026-07-01T00:00:00Z\",\n10\t    \"updated\": \"2026-07-01T00:00:00Z\"\n11\t  },\n12\t  \"researcher_profile\": {\n13\t    \"experience_level\": ..."
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u/tree.gedcomx.json"
+      },
+      "response_summary": "1\t{\n2\t  \"persons\": [\n3\t    {\n4\t      \"id\": \"249W-9LP\",\n5\t      \"gender\": \"Male\",\n6\t      \"living\": false,\n7\t      \"names\": [\n8\t        {\n9\t          \"given\": \"William Henry\",\n10\t          \"surname\": \"Bottemiller\",\n11\t          \"id\": \"249W-9LP-name-1\"\n12\t        }\n13\t      ],\n14\t      \"facts\": [\n15\t        {\n16\t          \"id\": \"ebe0d4fe-20f8-4dad-b4b8-c69c03d0f100\",\n17\t          \"type\": \"Birth\",\n18\t          \"date\": \"29 December 1862\",\n19\t          \"standard_date\": \"29 Dec 1862\",\n20\t          ..."
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u/evaluations/pre-exhaustiveness-q_001-2026-07-02T14-30-00.json"
+      },
+      "response_summary": "1\t{\n2\t  \"focus\": \"pre-exhaustiveness\",\n3\t  \"target_id\": \"q_001\",\n4\t  \"target_type\": \"question\",\n5\t  \"verdict\": \"address_first\",\n6\t  \"checkpoint\": 1,\n7\t  \"evaluator\": \"gps-mentor\",\n8\t  \"evaluated_at\": \"2026-07-02T14:30:00Z\",\n9\t  \"findings\": {\n10\t    \"strengths\": [\n11\t      \"Correct recovery when collection 3657650 returned zero hits \u2014 pivoted to record_read of existing tree source.\",\n12\t      \"Correct independent classification of information_quality (secondary) and evidence_type (direct) on a..."
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u/evaluations/conclusion-readiness-q_001-2026-07-02T15-05-00.json"
+      },
+      "response_summary": "1\t{\n2\t  \"focus\": \"conclusion-readiness\",\n3\t  \"target_id\": \"q_001\",\n4\t  \"target_type\": \"question\",\n5\t  \"verdict\": \"address_first\",\n6\t  \"checkpoint\": 2,\n7\t  \"evaluator\": \"gps-mentor\",\n8\t  \"evaluated_at\": \"2026-07-02T15:05:00Z\",\n9\t  \"must_address\": [\n10\t    {\n11\t      \"standard\": \"Standard 43; Standards 64-67\",\n12\t      \"issue\": \"Parentage identification (I1/I2 stubs + ParentChild relationships to 249W-9LP) rests on one derivative source, secondary information, unknown informant, no corroboratio..."
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u/evaluations"
+      },
+      "response_summary": "EISDIR: illegal operation on a directory, read '/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u/evaluations'"
+    },
+    {
+      "tool": "Write",
+      "args": {
+        "file_path": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u/evaluations/proof-critique-ps_001-2026-07-02T00-00-00.json",
+        "content": "{\n  \"focus\": \"proof-critique\",\n  \"target_id\": \"ps_001\",\n  \"target_type\": \"proof_summary\",\n  \"verdict\": \"looks_solid\",\n  \"checkpoint\": 3,\n  \"evaluator\": \"gps-mentor\",\n  \"evaluated_at\": \"2026-07-02T00:00:00Z\",\n  \"strengths\": [\n    \"Resolved both prior checkpoints: attempted original image (log_005, documented not-found) and converted skipped items into executed searches (pli_006/007/008), closing ev_001 gaps.\",\n    \"Implemented ev_002 required Probable/Possible scope split in ps_001 Tier Declaration (Standard 43).\",\n    \"Tier for record-content claim is honestly Probable: single derivative abstract, secondary information, unknown informant, one evidence unit (Standards 64-67).\",\n    \"Correct evidence-independence analysis (Standard 46): a_004-a_007 identified as one evidence unit; src_002/src_003 corroborate identity but add no parent data.\",\n    \"Narrative is self-contained with inline ARK citations.\"\n  ],\n  \"must_address\": [],\n  \"consider_addressing\": [\n    {\n      \"standard\": \"Standards 38-39\",\n      \"issue\": \"evidence_type 'indirect' on a_009-a_014 for death-event facts is arguably better read as 'direct'; changes no conclusion.\",\n      \"specific_action\": \"Habit note for future extractions.\"\n    }\n  ],\n  \"non_blocking_notes\": [\n    \"Tree relationships R1/R2 subtype 'Biological' while parentage is only Possible; proof correctly labels them provisional. Queue census corroboration as the next question.\",\n    \"findagrave.com GRid=64307258 not yet visited \u2014 next-question corroboration lead.\"\n  ],\n  \"ready_for_question_selection\": true,\n  \"recommended_resolution_assertion_ids\": [\"a_001\", \"a_002\", \"a_003\", \"a_004\", \"a_005\", \"a_006\", \"a_007\"]\n}\n"
+      },
+      "response_summary": "File created successfully at: /private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u/evaluations/proof-critique-ps_001-2026-07-02T00-00-00.json (file state is current in your context \u2014 no need to Read it back)"
+    },
+    {
+      "tool": "mcp__genealogy__research_append",
+      "args": {
+        "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u",
+        "section": "evaluations",
+        "op": "append",
+        "entry": {
+          "focus": "proof-critique",
+          "target_id": "ps_001",
+          "target_type": "proof_summary",
+          "verdict": "looks_solid",
+          "file_path": "evaluations/proof-critique-ps_001-2026-07-02T00-00-00.json",
+          "superseded_by": null
+        }
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"section\\\": \\\"evaluations\\\",\\n  \\\"op\\\": \\\"append\\\",\\n  \\\"entryId\\\": \\\"ev_003\\\",\\n  \\\"filesWritten\\\": [\\n    \\\"research.json\\\"\\n  ],\\n  \\\"validation\\\": {\\n    \\\"valid\\\": true,\\n    \\\"warnings\\\": []\\n  }\\n}\"}]"
+    },
+    {
+      "tool": "Skill",
+      "args": {
+        "skill": "question-selection"
+      },
+      "response_summary": "Launching skill: question-selection"
+    },
+    {
+      "tool": "mcp__genealogy__research_append",
+      "args": {
+        "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u",
+        "ops": [
+          {
+            "section": "questions",
+            "op": "update",
+            "entryId": "q_001",
+            "fields": {
+              "status": "answered",
+              "resolved": "2026-07-02",
+              "resolution_assertion_ids": [
+                "a_004",
+                "a_005",
+                "a_006",
+                "a_007"
+              ]
+            }
+          },
+          {
+            "section": "questions",
+            "op": "append",
+            "entry": {
+              "question": "Does the 1880 U.S. census show William Henry Bottemiller residing in the household of Casper A. Bottemiller, corroborating the parentage named in his 1929 Oregon death certificate?",
+              "rationale": "The death certificate abstract (src_001, q_001 outcome) names Casper A. Battermiller as William's father, but parentage rests on a single derivative source with a secondary unknown informant \u2014 a one-evidence-unit foundation. The tree already records William's 1880 residence as Bertha, Todd County, Minnesota (existing tree fact), placing him in Minnesota at approximately age 17-18. The 1880 U.S. census introduced explicit relationship columns (unlike 1850/1860) and would directly record a parent-child relationship if William was still in Casper Bottemiller's household. A positive result would provide an independent original source with primary relationship information, creating the second evidence unit needed to advance parentage from possible to probable. FamilySearch 1880 U.S. Census (collection 1417683) is fully indexed and searchable by person and location.",
+              "selection_basis": "objective_decomposition",
+              "priority": "high",
+              "status": "open",
+              "depends_on": [
+                "q_001"
+              ],
+              "unblocks": [],
+              "resolved": null,
+              "resolution_assertion_ids": [],
+              "exhaustive_declaration": {
+                "declared": false,
+                "justification": null,
+                "log_entry_ids": [],
+                "stop_criteria": null
+              }
+            }
+          }
+        ]
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": false,\\n  \\\"errors\\\": [\\n    \\\"research.json/questions[0]: 'answered' is not a valid question_status (expected one of: exhaustive_declared, in_progress, open, resolved)\\\"\\n  ]\\n}\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__research_append",
+      "args": {
+        "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u",
+        "ops": [
+          {
+            "section": "questions",
+            "op": "update",
+            "entryId": "q_001",
+            "fields": {
+              "status": "resolved",
+              "resolved": "2026-07-02",
+              "resolution_assertion_ids": [
+                "a_004",
+                "a_005",
+                "a_006",
+                "a_007"
+              ]
+            }
+          },
+          {
+            "section": "questions",
+            "op": "append",
+            "entry": {
+              "question": "Does the 1880 U.S. census show William Henry Bottemiller residing in the household of Casper A. Bottemiller, corroborating the parentage named in his 1929 Oregon death certificate?",
+              "rationale": "The death certificate abstract (src_001, q_001 outcome) names Casper A. Battermiller as William's father, but parentage rests on a single derivative source with a secondary unknown informant \u2014 a one-evidence-unit foundation. The tree already records William's 1880 residence as Bertha, Todd County, Minnesota (existing tree fact), placing him in Minnesota at approximately age 17-18. The 1880 U.S. census introduced explicit relationship columns (unlike 1850/1860) and would directly record a parent-child relationship if William was still in Casper Bottemiller's household. A positive result would provide an independent original source with primary relationship information, creating the second evidence unit needed to advance parentage from possible to probable. FamilySearch 1880 U.S. Census (collection 1417683) is fully indexed and searchable by person and location.",
+              "selection_basis": "objective_decomposition",
+              "priority": "high",
+              "status": "open",
+              "depends_on": [
+                "q_001"
+              ],
+              "unblocks": [],
+              "resolved": null,
+              "resolution_assertion_ids": [],
+              "exhaustive_declaration": {
+                "declared": false,
+                "justification": null,
+                "log_entry_ids": [],
+                "stop_criteria": null
+              }
+            }
+          }
+        ]
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"results\\\": [\\n    {\\n      \\\"section\\\": \\\"questions\\\",\\n      \\\"op\\\": \\\"update\\\",\\n      \\\"entryId\\\": \\\"q_001\\\"\\n    },\\n    {\\n      \\\"section\\\": \\\"questions\\\",\\n      \\\"op\\\": \\\"append\\\",\\n      \\\"entryId\\\": \\\"q_002\\\"\\n    }\\n  ],\\n  \\\"filesWritten\\\": [\\n    \\\"research.json\\\"\\n  ],\\n  \\\"validation\\\": {\\n    \\\"valid\\\": true,\\n    \\\"warnings\\\": []\\n  }\\n}\"}]"
+    },
+    {
+      "tool": "Skill",
+      "args": {
+        "skill": "research-plan",
+        "args": "q_002"
+      },
+      "response_summary": "Launching skill: research-plan"
+    },
+    {
+      "tool": "ToolSearch",
+      "args": {
+        "query": "select:mcp__genealogy__place_search,mcp__genealogy__collections_search,mcp__genealogy__external_links_search",
+        "max_results": 3
+      },
+      "response_summary": "[{\"type\": \"tool_reference\", \"tool_name\": \"mcp__genealogy__place_search\"}, {\"type\": \"tool_reference\", \"tool_name\": \"mcp__genealogy__collections_search\"}, {\"type\": \"tool_reference\", \"tool_name\": \"mcp__genealogy__external_links_search\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__place_search",
+      "args": {
+        "placeName": "Todd County",
+        "contextName": "Minnesota"
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"results\\\": [\\n    {\\n      \\\"standardPlace\\\": \\\"Todd, Minnesota, United States\\\",\\n      \\\"type\\\": \\\"County\\\",\\n      \\\"dateRange\\\": \\\"+1855/\\\",\\n      \\\"latitude\\\": 46.06667,\\n      \\\"longitude\\\": -94.88333,\\n      \\\"familysearchUrl\\\": \\\"https://www.familysearch.org/en/research/places/?text=Todd&focusedId=394291\\\",\\n      \\\"wikipediaUrl\\\": \\\"https://en.wikipedia.org/wiki/Todd_County,_Minnesota\\\"\\n    },\\n    {\\n      \\\"standardPlace\\\": \\\"Todd Township, Hubba..."
+    },
+    {
+      "tool": "mcp__genealogy__place_search",
+      "args": {
+        "placeName": "Chisago County",
+        "contextName": "Minnesota"
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"results\\\": [\\n    {\\n      \\\"standardPlace\\\": \\\"Chisago, Minnesota, United States\\\",\\n      \\\"type\\\": \\\"County\\\",\\n      \\\"dateRange\\\": \\\"+1851/\\\",\\n      \\\"latitude\\\": 45.50056,\\n      \\\"longitude\\\": -92.9,\\n      \\\"familysearchUrl\\\": \\\"https://www.familysearch.org/en/research/places/?text=Chisago&focusedId=392907\\\",\\n      \\\"wikipediaUrl\\\": \\\"https://en.wikipedia.org/wiki/Chisago_County,_Minnesota\\\"\\n    },\\n    {\\n      \\\"standardPlace\\\": \\\"Ramsey, Minneso..."
+    },
+    {
+      "tool": "mcp__genealogy__collections_search",
+      "args": {
+        "standardPlace": "Minnesota, United States",
+        "startYear": 1855,
+        "endYear": 1885
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"query\\\": {\\n    \\\"standardPlace\\\": \\\"Minnesota, United States\\\",\\n    \\\"startYear\\\": 1855,\\n    \\\"endYear\\\": 1885\\n  },\\n  \\\"scope\\\": \\\"Minnesota\\\",\\n  \\\"totalForPlace\\\": 46,\\n  \\\"results\\\": [\\n    {\\n      \\\"id\\\": \\\"1858352\\\",\\n      \\\"title\\\": \\\"Minnesota, Birth and Death Records, 1866-1916\\\",\\n      \\\"dateRange\\\": \\\"1866-1916\\\",\\n      \\\"recordCount\\\": 379392,\\n      \\\"personCount\\\": 830015,\\n      \\\"imageCount\\\": 144789,\\n      \\\"url\\\": \\\"https://www.fami..."
+    },
+    {
+      "tool": "mcp__genealogy__external_links_search",
+      "args": {
+        "standardPlace": "Minnesota, United States",
+        "startYear": 1860,
+        "endYear": 1885
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"query\\\": {\\n    \\\"standardPlace\\\": \\\"Minnesota, United States\\\",\\n    \\\"startYear\\\": 1860,\\n    \\\"endYear\\\": 1885\\n  },\\n  \\\"totalForPlace\\\": 403,\\n  \\\"results\\\": [\\n    {\\n      \\\"url\\\": \\\"https://www.myheritage.com/research/collection-10925/minnesota-veteran-grave-index-1857-1975\\\",\\n      \\\"linkText\\\": \\\"Minnesota, Veteran Grave Index, 1857-1975\\\"\\n    },\\n    {\\n      \\\"url\\\": \\\"http://www.loc.gov/rr/main/gar/garhome.html\\\",\\n      \\\"linkText\\\": \\\"Library..."
+    },
+    {
+      "tool": "ToolSearch",
+      "args": {
+        "query": "select:mcp__genealogy__research_append,mcp__genealogy__research_log_append,mcp__genealogy__record_search,mcp__genealogy__record_read",
+        "max_results": 5
+      },
+      "response_summary": "[{\"type\": \"tool_reference\", \"tool_name\": \"mcp__genealogy__research_append\"}, {\"type\": \"tool_reference\", \"tool_name\": \"mcp__genealogy__research_log_append\"}, {\"type\": \"tool_reference\", \"tool_name\": \"mcp__genealogy__record_search\"}, {\"type\": \"tool_reference\", \"tool_name\": \"mcp__genealogy__record_read\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__research_append",
+      "args": {
+        "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u",
+        "ops": [
+          {
+            "section": "plans",
+            "op": "append",
+            "entry": {
+              "question_id": "q_002",
+              "status": "active",
+              "created": "2026-07-02"
+            }
+          },
+          {
+            "section": "plan_items",
+            "op": "append",
+            "planId": "pl_003",
+            "entry": {
+              "sequence": 1,
+              "record_type": "census",
+              "jurisdiction": "Todd County, Minnesota, United States",
+              "date_range": "1880",
+              "repository": "FamilySearch",
+              "rationale": "William Henry Bottemiller appears in the tree with a residence in Bertha, Todd County, in 1880 (from prior extraction). If Casper A. Bottemiller \u2014 the father named on the 1929 death certificate \u2014 is the household head in Todd County in 1880 with William listed as a child, that is direct evidence answering q_002. The 1880 U.S. Federal Census (collection 1417683) is fully indexed on FamilySearch.",
+              "fallback_for": null,
+              "status": "planned"
+            }
+          },
+          {
+            "section": "plan_items",
+            "op": "append",
+            "planId": "pl_003",
+            "entry": {
+              "sequence": 2,
+              "record_type": "census",
+              "jurisdiction": "Chisago County, Minnesota, United States",
+              "date_range": "1870",
+              "repository": "FamilySearch",
+              "rationale": "William was born December 1862 in Franconia Township, Chisago County. At age ~8 in 1870 he would most likely still be in his birth-county household. Finding Casper Bottemiller as head with William as a child in Chisago County in 1870 would independently corroborate the father-child relationship. The 1870 U.S. Federal Census (collection 1438024) is indexed on FamilySearch.",
+              "fallback_for": null,
+              "status": "planned"
+            }
+          },
+          {
+            "section": "plan_items",
+            "op": "append",
+            "planId": "pl_003",
+            "entry": {
+              "sequence": 3,
+              "record_type": "census",
+              "jurisdiction": "Minnesota, United States",
+              "date_range": "1875",
+              "repository": "FamilySearch",
+              "rationale": "The Minnesota State Census of 1875 (collection 1503053, 612,847 indexed records) bridges the gap between the 1870 and 1880 federal censuses. If the family had already migrated from Chisago to Todd County by 1875, this would document the household composition at an intermediate point and show William still in Casper's household.",
+              "fallback_for": null,
+              "status": "planned"
+            }
+          },
+          {
+            "section": "plan_items",
+            "op": "append",
+            "planId": "pl_003",
+            "entry": {
+              "sequence": 4,
+              "record_type": "census",
+              "jurisdiction": "Chisago County, Minnesota, United States",
+              "date_range": "1865",
+              "repository": "FamilySearch",
+              "rationale": "The Minnesota State Census of 1865 (collection 1503054, 246,591 indexed records) would show the Bottemiller family in Chisago County when William was about 2\u20133 years old, directly after his 1862 birth. Finding Casper as head with an infant William corroborates the parentage claim closest to William's birth.",
+              "fallback_for": null,
+              "status": "planned"
+            }
+          },
+          {
+            "section": "plan_items",
+            "op": "append",
+            "planId": "pl_003",
+            "entry": {
+              "sequence": 5,
+              "record_type": "census",
+              "jurisdiction": "Todd County, Minnesota, United States",
+              "date_range": "1880",
+              "repository": "Ancestry",
+              "rationale": "Fallback for pli_009. Ancestry's 1880 U.S. Federal Census index (collection 6742) uses different name parsing and OCR than FamilySearch's and may surface a Bottemiller entry missed due to indexing variants (Battermiller, Bottimiller, etc.). Provides independent search coverage of the same record set.",
+              "fallback_for": "pli_009",
+              "status": "planned"
+            }
+          },
+          {
+            "section": "plan_items",
+            "op": "append",
+            "planId": "pl_003",
+            "entry": {
+              "sequence": 6,
+              "record_type": "vital_record",
+              "jurisdiction": "Chisago County, Minnesota, United States",
+              "date_range": "1862-1870",
+              "repository": "FamilySearch",
+              "rationale": "Minnesota Birth and Death Records 1866\u20131916 (collection 1858352, indexed) and Minnesota County Birth Records 1863\u20131983 (collection 1920099, images only) may contain a birth registration for William Henry Bottemiller in Franconia Township, Chisago County, 29 December 1862. If found, the record would name his parents directly, providing original-source corroboration of the parentage relationship.",
+              "fallback_for": null,
+              "status": "planned"
+            }
+          }
+        ]
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"results\\\": [\\n    {\\n      \\\"section\\\": \\\"plans\\\",\\n      \\\"op\\\": \\\"append\\\",\\n      \\\"entryId\\\": \\\"pl_003\\\"\\n    },\\n    {\\n      \\\"section\\\": \\\"plan_items\\\",\\n      \\\"op\\\": \\\"append\\\",\\n      \\\"entryId\\\": \\\"pli_009\\\"\\n    },\\n    {\\n      \\\"section\\\": \\\"plan_items\\\",\\n      \\\"op\\\": \\\"append\\\",\\n      \\\"entryId\\\": \\\"pli_010\\\"\\n    },\\n    {\\n      \\\"section\\\": \\\"plan_items\\\",\\n      \\\"op\\\": \\\"append\\\",\\n      \\\"entryId\\\": \\\"pli_011\\\"\\n    },..."
+    },
+    {
+      "tool": "mcp__genealogy__research_append",
+      "args": {
+        "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u",
+        "section": "plan_items",
+        "op": "update",
+        "planId": "pl_003",
+        "entryId": "pli_009",
+        "fields": {
+          "status": "in_progress"
+        }
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"section\\\": \\\"plan_items\\\",\\n  \\\"op\\\": \\\"update\\\",\\n  \\\"entryId\\\": \\\"pli_009\\\",\\n  \\\"filesWritten\\\": [\\n    \\\"research.json\\\"\\n  ],\\n  \\\"validation\\\": {\\n    \\\"valid\\\": true,\\n    \\\"warnings\\\": []\\n  }\\n}\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__record_search",
+      "args": {
+        "surname": "Bottemiller",
+        "recordType": "census",
+        "residencePlace": "Todd, Minnesota, United States",
+        "residenceYearFrom": 1880,
+        "residenceYearTo": 1880,
+        "collectionId": "1417683",
+        "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u"
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"query\\\": {\\n    \\\"surname\\\": \\\"Bottemiller\\\",\\n    \\\"recordType\\\": \\\"census\\\",\\n    \\\"residencePlace\\\": \\\"Todd, Minnesota, United States\\\",\\n    \\\"residenceYearFrom\\\": 1880,\\n    \\\"residenceYearTo\\\": 1880,\\n    \\\"collectionId\\\": \\\"1417683\\\",\\n    \\\"projectPath\\\": \\\"/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u\\\"\\n  },\\n  \\\"totalMatches\\\": 0,\\n  \\\"paginationCappedAt\\\": 4999,\\n  \\\"returned\\\": 0,\\n  \\\"offset\\\": 0,\\n  \\..."
+    },
+    {
+      "tool": "mcp__genealogy__record_search",
+      "args": {
+        "surname": "Bottemiller",
+        "recordType": "census",
+        "residencePlace": "Minnesota, United States",
+        "residenceYearFrom": 1880,
+        "residenceYearTo": 1880,
+        "collectionId": "1417683",
+        "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u"
+      },
+      "response_summary": "Error: result (243,675 characters across 8,112 lines) exceeds maximum allowed tokens. Output has been saved to /Users/ernest/.claude/projects/-private-var-folders-g7-zn65fvrn5g9-g71-sp0lk82h0000gn-T-e2e-bottemiller-parents-91t9zm2u/6b6fa77e-a98a-4d4b-88f2-5c7d037177be/tool-results/mcp-genealogy-record_search-1783001336872.txt.\nFormat: Plain text\n- For targeted searches (find a line, locate a string): use grep on the file directly.\n- For analysis or summarization that requires reading the full..."
+    },
+    {
+      "tool": "Agent",
+      "args": {
+        "description": "Parse large census search results file",
+        "prompt": "Read the file at /Users/ernest/.claude/projects/-private-var-folders-g7-zn65fvrn5g9-g71-sp0lk82h0000gn-T-e2e-bottemiller-parents-91t9zm2u/6b6fa77e-a98a-4d4b-88f2-5c7d037177be/tool-results/mcp-genealogy-record_search-1783001336872.txt in chunks of 400 lines using offset/limit until you have read all 8,112 lines. \n\nI need you to extract and return ALL results from this file, specifically looking for:\n1. Any person with surname \"Bottemiller\" (or variants: Battermiller, Bottermiller, Bottmiller)\n2. Especially \"Casper Bottemiller\" or \"Caspar Bottemiller\" (the father)\n3. \"William Bottemiller\" (born ~1862, the subject)\n\nFor each result found, return:\n- The result's index/number\n- personName (full name as shown)\n- birth year\n- birthPlace\n- residence place\n- role in household (head, child, etc.)\n- primaryId (the person ID in the record's gedcomx)\n- arkUrl / recordId\n- Any household members shown\n- score if shown\n\nReturn the complete list of all Bottemiller results found, quoted verbatim from the file. I need exact field values including primaryId and arkUrl/recordId for each entry."
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"The complete surname inventory confirms the finding definitively. Here is the full report:\\n\\n---\\n\\n**Result: ZERO Bottemiller results found in this file.**\\n\\nThe exhaustive search across all 8,112 lines reveals the following:\\n\\n**What the file contains:**\\n- Line 3: `\\\"surname\\\": \\\"Bottemiller\\\"` \\u2014 this is only in the **search query** at the top, not in any result.\\n- The 20 returned results (out of 29 total matches) contain persons with surnames: **Boytale..."
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/Users/ernest/.claude/projects/-private-var-folders-g7-zn65fvrn5g9-g71-sp0lk82h0000gn-T-e2e-bottemiller-parents-91t9zm2u/6b6fa77e-a98a-4d4b-88f2-5c7d037177be/tool-results/mcp-genealogy-record_search-1783001336872.txt",
+        "offset": 0,
+        "limit": 400
+      },
+      "response_summary": "0\t{\n1\t  \"query\": {\n2\t    \"surname\": \"Bottemiller\",\n3\t    \"recordType\": \"census\",\n4\t    \"residencePlace\": \"Minnesota, United States\",\n5\t    \"residenceYearFrom\": 1880,\n6\t    \"residenceYearTo\": 1880,\n7\t    \"collectionId\": \"1417683\",\n8\t    \"projectPath\": \"/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u\"\n9\t  },\n10\t  \"totalMatches\": 29,\n11\t  \"paginationCappedAt\": 4999,\n12\t  \"returned\": 20,\n13\t  \"offset\": 0,\n14\t  \"hasMore\": true,\n15\t  \"results\": [\n16\t    {\n1..."
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/Users/ernest/.claude/projects/-private-var-folders-g7-zn65fvrn5g9-g71-sp0lk82h0000gn-T-e2e-bottemiller-parents-91t9zm2u/6b6fa77e-a98a-4d4b-88f2-5c7d037177be/tool-results/mcp-genealogy-record_search-1783001336872.txt",
+        "offset": 400,
+        "limit": 400
+      },
+      "response_summary": "400\t            ]\n401\t          },\n402\t          {\n403\t            \"id\": \"p_244063447\",\n404\t            \"ark\": \"ark:/61903/1:1:MZ9C-8V4\",\n405\t            \"gender\": \"Male\",\n406\t            \"names\": [\n407\t              {\n408\t                \"type\": \"BirthName\",\n409\t                \"given\": \"William\",\n410\t                \"surname\": \"Fear\"\n411\t              }\n412\t            ],\n413\t            \"facts\": [\n414\t              {\n415\t                \"type\": \"Birth\",\n416\t                \"date\": \"1852\",\n..."
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/Users/ernest/.claude/projects/-private-var-folders-g7-zn65fvrn5g9-g71-sp0lk82h0000gn-T-e2e-bottemiller-parents-91t9zm2u/6b6fa77e-a98a-4d4b-88f2-5c7d037177be/tool-results/mcp-genealogy-record_search-1783001336872.txt",
+        "offset": 800,
+        "limit": 400
+      },
+      "response_summary": "800\t          },\n801\t          {\n802\t            \"id\": \"333\",\n803\t            \"name\": \"Maine, United States\",\n804\t            \"latitude\": 45.50028,\n805\t            \"longitude\": -69.25028\n806\t          },\n807\t          {\n808\t            \"id\": \"335\",\n809\t            \"name\": \"Minnesota, United States\",\n810\t            \"latitude\": 46.2503,\n811\t            \"longitude\": -94.2503\n812\t          },\n813\t          {\n814\t            \"id\": \"346\",\n815\t            \"name\": \"Connecticut, United States\",\n816\t ..."
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/Users/ernest/.claude/projects/-private-var-folders-g7-zn65fvrn5g9-g71-sp0lk82h0000gn-T-e2e-bottemiller-parents-91t9zm2u/6b6fa77e-a98a-4d4b-88f2-5c7d037177be/tool-results/mcp-genealogy-record_search-1783001336872.txt",
+        "offset": 1200,
+        "limit": 400
+      },
+      "response_summary": "1200\t                \"place\": \"Albion Township, Wright, Minnesota, United States\",\n1201\t                \"standard_place\": \"Albion Township, Wright, Minnesota, United States\"\n1202\t              }\n1203\t            ],\n1204\t            \"sources\": [\n1205\t              {\n1206\t                \"ref\": \"sd_da1\"\n1207\t              }\n1208\t            ]\n1209\t          },\n1210\t          {\n1211\t            \"id\": \"p_244609006\",\n1212\t            \"ark\": \"ark:/61903/1:1:MZ91-JPN\",\n1213\t            \"gender\": \"Fe..."
+    },
+    {
+      "tool": "Grep",
+      "args": {
+        "pattern": "Bottemiller|Bottermiller|Battermiller|Bottmiller|Casper|Caspar",
+        "path": "/Users/ernest/.claude/projects/-private-var-folders-g7-zn65fvrn5g9-g71-sp0lk82h0000gn-T-e2e-bottemiller-parents-91t9zm2u/6b6fa77e-a98a-4d4b-88f2-5c7d037177be/tool-results/mcp-genealogy-record_search-1783001336872.txt",
+        "output_mode": "content",
+        "head_limit": 0
+      },
+      "response_summary": "3:    \"surname\": \"Bottemiller\","
+    },
+    {
+      "tool": "Grep",
+      "args": {
+        "pattern": "\"William\"",
+        "path": "/Users/ernest/.claude/projects/-private-var-folders-g7-zn65fvrn5g9-g71-sp0lk82h0000gn-T-e2e-bottemiller-parents-91t9zm2u/6b6fa77e-a98a-4d4b-88f2-5c7d037177be/tool-results/mcp-genealogy-record_search-1783001336872.txt",
+        "output_mode": "content",
+        "head_limit": 0
+      },
+      "response_summary": "409:                \"given\": \"William\",\n611:                \"given\": \"William\",\n643:                \"given\": \"William\",\n677:                \"given\": \"William\",\n1923:                \"given\": \"William\"\n2379:                \"given\": \"William\"\n2907:                \"given\": \"William\"\n3397:                \"given\": \"William\"\n3853:                \"given\": \"William\"\n4377:                \"given\": \"William\"\n5213:                \"given\": \"William\"\n5589:                \"given\": \"William\"\n7585:            ..."
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/Users/ernest/.claude/projects/-private-var-folders-g7-zn65fvrn5g9-g71-sp0lk82h0000gn-T-e2e-bottemiller-parents-91t9zm2u/6b6fa77e-a98a-4d4b-88f2-5c7d037177be/tool-results/mcp-genealogy-record_search-1783001336872.txt",
+        "offset": 1600,
+        "limit": 400
+      },
+      "response_summary": "1600\t            \"sources\": [\n1601\t              {\n1602\t                \"ref\": \"sd_da1\"\n1603\t              }\n1604\t            ]\n1605\t          },\n1606\t          {\n1607\t            \"id\": \"p_244609004\",\n1608\t            \"ark\": \"ark:/61903/1:1:MZ91-JPX\",\n1609\t            \"gender\": \"Male\",\n1610\t            \"names\": [\n1611\t              {\n1612\t                \"type\": \"BirthName\",\n1613\t                \"given\": \"Ernest\",\n1614\t                \"surname\": \"Bottomaly\"\n1615\t              }\n1616\t         ..."
+    },
+    {
+      "tool": "Grep",
+      "args": {
+        "pattern": "\"surname\":",
+        "path": "/Users/ernest/.claude/projects/-private-var-folders-g7-zn65fvrn5g9-g71-sp0lk82h0000gn-T-e2e-bottemiller-parents-91t9zm2u/6b6fa77e-a98a-4d4b-88f2-5c7d037177be/tool-results/mcp-genealogy-record_search-1783001336872.txt",
+        "output_mode": "content",
+        "head_limit": 0
+      },
+      "response_summary": "3:    \"surname\": \"Bottemiller\",\n60:                \"surname\": \"Boytaley\"\n106:                \"surname\": \"Attineson\"\n140:                \"surname\": \"Lowe\"\n174:                \"surname\": \"Striker\"\n208:                \"surname\": \"Kined\"\n242:                \"surname\": \"Collins\"\n274:                \"surname\": \"King\"\n308:                \"surname\": \"Walker\"\n342:                \"surname\": \"Moore\"\n376:                \"surname\": \"Handswkef\"\n410:                \"surname\": \"Fear\"\n444:                \"sur..."
+    },
+    {
+      "tool": "mcp__genealogy__research_log_append",
+      "args": {
+        "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u",
+        "tool": "record_search",
+        "planItemId": "pli_009",
+        "query": {
+          "surname": "Bottemiller",
+          "recordType": "census",
+          "residencePlace": "Minnesota, United States",
+          "residenceYearFrom": 1880,
+          "residenceYearTo": 1880,
+          "collectionId": "1417683"
+        },
+        "outcome": "negative",
+        "resultsExamined": 20,
+        "resultsAvailable": 29,
+        "notes": "29 fuzzy matches returned but none bear the Bottemiller surname \u2014 all are Bottomaly/Bottomly families from Wright and Martin counties. FamilySearch index does not appear to have an exact Bottemiller entry for Minnesota 1880. Will retry with spelling variants."
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"logId\\\": \\\"log_009\\\",\\n  \\\"performed\\\": \\\"2026-07-02T14:10:08.771Z\\\",\\n  \\\"resultsRef\\\": null,\\n  \\\"returnedCount\\\": null,\\n  \\\"filesWritten\\\": [\\n    \\\"research.json\\\"\\n  ],\\n  \\\"validation\\\": {\\n    \\\"valid\\\": true,\\n    \\\"warnings\\\": []\\n  }\\n}\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__record_search",
+      "args": {
+        "givenName": "William",
+        "surname": "Bottemiller",
+        "surnameAlt": "Battermiller",
+        "recordType": "census",
+        "residenceYearFrom": 1880,
+        "residenceYearTo": 1880,
+        "birthYearFrom": 1860,
+        "birthYearTo": 1865,
+        "collectionId": "1417683",
+        "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u"
+      },
+      "response_summary": "Error: result (224,953 characters across 7,511 lines) exceeds maximum allowed tokens. Output has been saved to /Users/ernest/.claude/projects/-private-var-folders-g7-zn65fvrn5g9-g71-sp0lk82h0000gn-T-e2e-bottemiller-parents-91t9zm2u/6b6fa77e-a98a-4d4b-88f2-5c7d037177be/tool-results/mcp-genealogy-record_search-1783001425493.txt.\nFormat: Plain text\n- For targeted searches (find a line, locate a string): use grep on the file directly.\n- For analysis or summarization that requires reading the full..."
+    },
+    {
+      "tool": "Agent",
+      "args": {
+        "description": "Parse census search for William Bottemiller variants",
+        "prompt": "Read the file at /Users/ernest/.claude/projects/-private-var-folders-g7-zn65fvrn5g9-g71-sp0lk82h0000gn-T-e2e-bottemiller-parents-91t9zm2u/6b6fa77e-a98a-4d4b-88f2-5c7d037177be/tool-results/mcp-genealogy-record_search-1783001425493.txt in chunks of 400 lines using offset/limit until you have read all 7,511 lines.\n\nI need you to find ALL results with:\n1. Any person named \"William\" with surname Bottemiller/Battermiller/Bottermiller/Battomiller or any close variant\n2. Any result where the person's birth year is between 1860-1865\n3. Any result showing a person in Minnesota, especially Todd County or Chisago County\n\nFor EVERY result found, return ALL of these fields verbatim:\n- Full name\n- Birth year\n- Birth place\n- Residence place\n- Relationship/role (head, son, child, etc.)\n- primaryId\n- arkUrl or recordId (the full URL)\n- Any household members mentioned\n- Score\n\nAlso report the totalMatches from the query metadata at the top of the file.\n\nReturn EVERYTHING you find, quoted verbatim from the file. Do not summarize or abbreviate."
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"I have now read all 7,511 lines of the file. Here is the complete report:\\n\\n---\\n\\n**totalMatches: 20** (from query metadata, line 13)\\n\\nThe query searched for William Bottemiller/Battermiller, census 1880, birth year 1860\\u20131865, collection 1417683 (United States, Census, 1880).\\n\\n---\\n\\n## Results matching your three criteria\\n\\n### CRITERION 1 & 2 & 3 \\u2014 THE KEY RESULT: \\\"William\\\" with Bottermiller surname + birth year in range + Minnesota, Todd County..."
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/Users/ernest/.claude/projects/-private-var-folders-g7-zn65fvrn5g9-g71-sp0lk82h0000gn-T-e2e-bottemiller-parents-91t9zm2u/6b6fa77e-a98a-4d4b-88f2-5c7d037177be/tool-results/mcp-genealogy-record_search-1783001425493.txt",
+        "limit": 400,
+        "offset": 0
+      },
+      "response_summary": "0\t{\n1\t  \"query\": {\n2\t    \"givenName\": \"William\",\n3\t    \"surname\": \"Bottemiller\",\n4\t    \"surnameAlt\": \"Battermiller\",\n5\t    \"recordType\": \"census\",\n6\t    \"residenceYearFrom\": 1880,\n7\t    \"residenceYearTo\": 1880,\n8\t    \"birthYearFrom\": 1860,\n9\t    \"birthYearTo\": 1865,\n10\t    \"collectionId\": \"1417683\",\n11\t    \"projectPath\": \"/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u\"\n12\t  },\n13\t  \"totalMatches\": 20,\n14\t  \"paginationCappedAt\": 4999,\n15\t  \"returned\":..."
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/Users/ernest/.claude/projects/-private-var-folders-g7-zn65fvrn5g9-g71-sp0lk82h0000gn-T-e2e-bottemiller-parents-91t9zm2u/6b6fa77e-a98a-4d4b-88f2-5c7d037177be/tool-results/mcp-genealogy-record_search-1783001425493.txt",
+        "limit": 400,
+        "offset": 400
+      },
+      "response_summary": "400\t          {\n401\t            \"id\": \"330\",\n402\t            \"name\": \"Illinois, United States\",\n403\t            \"latitude\": 40,\n404\t            \"longitude\": -89.25\n405\t          },\n406\t          {\n407\t            \"id\": \"4034133\",\n408\t            \"name\": \"La Salle, LaSalle, Illinois, United States\",\n409\t            \"latitude\": 41.3333,\n410\t            \"longitude\": -89.0917\n411\t          }\n412\t        ]\n413\t      },\n414\t      \"primaryId\": \"p_354991721\"\n415\t    },\n416\t    {\n417\t      \"recordId\":..."
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/Users/ernest/.claude/projects/-private-var-folders-g7-zn65fvrn5g9-g71-sp0lk82h0000gn-T-e2e-bottemiller-parents-91t9zm2u/6b6fa77e-a98a-4d4b-88f2-5c7d037177be/tool-results/mcp-genealogy-record_search-1783001425493.txt",
+        "limit": 400,
+        "offset": 800
+      },
+      "response_summary": "800\t      \"birthPlace\": \"New York, United States\",\n801\t      \"collectionId\": \"1417683\",\n802\t      \"collectionTitle\": \"United States, Census, 1880\",\n803\t      \"collectionUrl\": \"https://www.familysearch.org/service/cds/recapi/collections/1417683\",\n804\t      \"recordTitle\": \"Household of John Kuckmiller, \\\"United States Census, 1880\\\"\",\n805\t      \"recordArk\": \"ark:/61903/1:2:M4JX-L79\",\n806\t      \"gedcomx\": {\n807\t        \"persons\": [\n808\t          {\n809\t            \"id\": \"p_254795607\",\n810\t       ..."
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/Users/ernest/.claude/projects/-private-var-folders-g7-zn65fvrn5g9-g71-sp0lk82h0000gn-T-e2e-bottemiller-parents-91t9zm2u/6b6fa77e-a98a-4d4b-88f2-5c7d037177be/tool-results/mcp-genealogy-record_search-1783001425493.txt",
+        "limit": 400,
+        "offset": 1200
+      },
+      "response_summary": "1200\t        ]\n1201\t      },\n1202\t      \"primaryId\": \"p_254795607\"\n1203\t    },\n1204\t    {\n1205\t      \"recordId\": \"ark:/61903/1:1:M6XD-78T\",\n1206\t      \"events\": [\n1207\t        {\n1208\t          \"type\": \"Census\",\n1209\t          \"date\": \"1880\",\n1210\t          \"place\": \"Madison Township, Jasper, Missouri, United States\"\n1211\t        },\n1212\t        {\n1213\t          \"type\": \"Occupation\",\n1214\t          \"value\": \"Works On Farm\"\n1215\t        },\n1216\t        {\n1217\t          \"type\": \"Race\",\n1218\t    ..."
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/Users/ernest/.claude/projects/-private-var-folders-g7-zn65fvrn5g9-g71-sp0lk82h0000gn-T-e2e-bottemiller-parents-91t9zm2u/6b6fa77e-a98a-4d4b-88f2-5c7d037177be/tool-results/mcp-genealogy-record_search-1783001425493.txt",
+        "limit": 400,
+        "offset": 1600
+      },
+      "response_summary": "1600\t            ],\n1601\t            \"sources\": [\n1602\t              {\n1603\t                \"ref\": \"sd_da1\"\n1604\t              }\n1605\t            ]\n1606\t          },\n1607\t          {\n1608\t            \"id\": \"p_159252320\",\n1609\t            \"ark\": \"ark:/61903/1:1:MWNV-4M2\",\n1610\t            \"gender\": \"Female\",\n1611\t            \"names\": [\n1612\t              {\n1613\t                \"type\": \"BirthName\",\n1614\t                \"surname\": \"Sterrett\",\n1615\t                \"given\": \"Mary M.\"\n1616\t        ..."
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/Users/ernest/.claude/projects/-private-var-folders-g7-zn65fvrn5g9-g71-sp0lk82h0000gn-T-e2e-bottemiller-parents-91t9zm2u/6b6fa77e-a98a-4d4b-88f2-5c7d037177be/tool-results/mcp-genealogy-record_search-1783001425493.txt",
+        "limit": 400,
+        "offset": 2000
+      },
+      "response_summary": "2000\t                \"ref\": \"sd_da1\"\n2001\t              }\n2002\t            ]\n2003\t          },\n2004\t          {\n2005\t            \"id\": \"p_269667106\",\n2006\t            \"ark\": \"ark:/61903/1:1:M8SY-23N\",\n2007\t            \"gender\": \"Female\",\n2008\t            \"names\": [\n2009\t              {\n2010\t                \"type\": \"BirthName\",\n2011\t                \"surname\": \"Grovemiller\",\n2012\t                \"given\": \"Emma\"\n2013\t              }\n2014\t            ],\n2015\t            \"facts\": [\n2016\t          ..."
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/Users/ernest/.claude/projects/-private-var-folders-g7-zn65fvrn5g9-g71-sp0lk82h0000gn-T-e2e-bottemiller-parents-91t9zm2u/6b6fa77e-a98a-4d4b-88f2-5c7d037177be/tool-results/mcp-genealogy-record_search-1783001425493.txt",
+        "limit": 400,
+        "offset": 2400
+      },
+      "response_summary": "2400\t              {\n2401\t                \"type\": \"Birth\",\n2402\t                \"date\": \"1865\",\n2403\t                \"standard_date\": \"1865\",\n2404\t                \"place\": \"Canada\",\n2405\t                \"standard_place\": \"Canada\"\n2406\t              },\n2407\t              {\n2408\t                \"type\": \"Census\",\n2409\t                \"primary\": true,\n2410\t                \"date\": \"1880\",\n2411\t                \"standard_date\": \"1880\",\n2412\t                \"place\": \"Ray Township, Macomb, Michigan, U..."
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/Users/ernest/.claude/projects/-private-var-folders-g7-zn65fvrn5g9-g71-sp0lk82h0000gn-T-e2e-bottemiller-parents-91t9zm2u/6b6fa77e-a98a-4d4b-88f2-5c7d037177be/tool-results/mcp-genealogy-record_search-1783001425493.txt",
+        "limit": 400,
+        "offset": 2800
+      },
+      "response_summary": "2800\t              }\n2801\t            ],\n2802\t            \"sources\": [\n2803\t              {\n2804\t                \"ref\": \"sd_da1\"\n2805\t              }\n2806\t            ]\n2807\t          },\n2808\t          {\n2809\t            \"id\": \"p_383559603\",\n2810\t            \"ark\": \"ark:/61903/1:1:MFPF-YZ3\",\n2811\t            \"gender\": \"Male\",\n2812\t            \"names\": [\n2813\t              {\n2814\t                \"type\": \"BirthName\",\n2815\t                \"surname\": \"Kitsmiller\",\n2816\t                \"given\": \"T..."
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/Users/ernest/.claude/projects/-private-var-folders-g7-zn65fvrn5g9-g71-sp0lk82h0000gn-T-e2e-bottemiller-parents-91t9zm2u/6b6fa77e-a98a-4d4b-88f2-5c7d037177be/tool-results/mcp-genealogy-record_search-1783001425493.txt",
+        "limit": 400,
+        "offset": 3200
+      },
+      "response_summary": "3200\t            ],\n3201\t            \"sources\": [\n3202\t              {\n3203\t                \"ref\": \"sd_da1\"\n3204\t              }\n3205\t            ]\n3206\t          },\n3207\t          {\n3208\t            \"id\": \"p_392578316\",\n3209\t            \"ark\": \"ark:/61903/1:1:MNQK-B3T\",\n3210\t            \"gender\": \"Female\",\n3211\t            \"names\": [\n3212\t              {\n3213\t                \"type\": \"BirthName\",\n3214\t                \"surname\": \"Kitzmiller\",\n3215\t                \"given\": \"Ann\"\n3216\t          ..."
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/Users/ernest/.claude/projects/-private-var-folders-g7-zn65fvrn5g9-g71-sp0lk82h0000gn-T-e2e-bottemiller-parents-91t9zm2u/6b6fa77e-a98a-4d4b-88f2-5c7d037177be/tool-results/mcp-genealogy-record_search-1783001425493.txt",
+        "limit": 400,
+        "offset": 3600
+      },
+      "response_summary": "3600\t              {\n3601\t                \"type\": \"MaritalStatus\",\n3602\t                \"value\": \"Single\"\n3603\t              },\n3604\t              {\n3605\t                \"type\": \"Race\",\n3606\t                \"value\": \"White\"\n3607\t              },\n3608\t              {\n3609\t                \"type\": \"Occupation\",\n3610\t                \"value\": \"Works In A Mill\"\n3611\t              }\n3612\t            ],\n3613\t            \"sources\": [\n3614\t              {\n3615\t                \"ref\": \"sd_da1\"\n3616\t     ..."
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/Users/ernest/.claude/projects/-private-var-folders-g7-zn65fvrn5g9-g71-sp0lk82h0000gn-T-e2e-bottemiller-parents-91t9zm2u/6b6fa77e-a98a-4d4b-88f2-5c7d037177be/tool-results/mcp-genealogy-record_search-1783001425493.txt",
+        "limit": 400,
+        "offset": 4000
+      },
+      "response_summary": "4000\t                \"ref\": \"sd_da1\"\n4001\t              }\n4002\t            ]\n4003\t          },\n4004\t          {\n4005\t            \"id\": \"p_395969709\",\n4006\t            \"ark\": \"ark:/61903/1:1:MNHR-NZC\",\n4007\t            \"gender\": \"Female\",\n4008\t            \"names\": [\n4009\t              {\n4010\t                \"type\": \"BirthName\",\n4011\t                \"surname\": \"Fitchmiller\",\n4012\t                \"given\": \"Louisa\"\n4013\t              }\n4014\t            ],\n4015\t            \"facts\": [\n4016\t        ..."
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/Users/ernest/.claude/projects/-private-var-folders-g7-zn65fvrn5g9-g71-sp0lk82h0000gn-T-e2e-bottemiller-parents-91t9zm2u/6b6fa77e-a98a-4d4b-88f2-5c7d037177be/tool-results/mcp-genealogy-record_search-1783001425493.txt",
+        "limit": 400,
+        "offset": 4400
+      },
+      "response_summary": "4400\t          {\n4401\t            \"id\": \"p_205795150\",\n4402\t            \"ark\": \"ark:/61903/1:1:MHXS-9HZ\",\n4403\t            \"gender\": \"Female\",\n4404\t            \"names\": [\n4405\t              {\n4406\t                \"type\": \"BirthName\",\n4407\t                \"given\": \"Edith\",\n4408\t                \"surname\": \"Bottiamly\"\n4409\t              }\n4410\t            ],\n4411\t            \"facts\": [\n4412\t              {\n4413\t                \"type\": \"Census\",\n4414\t                \"primary\": true,\n4415\t        ..."
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/Users/ernest/.claude/projects/-private-var-folders-g7-zn65fvrn5g9-g71-sp0lk82h0000gn-T-e2e-bottemiller-parents-91t9zm2u/6b6fa77e-a98a-4d4b-88f2-5c7d037177be/tool-results/mcp-genealogy-record_search-1783001425493.txt",
+        "limit": 400,
+        "offset": 4800
+      },
+      "response_summary": "4800\t            \"sources\": [\n4801\t              {\n4802\t                \"ref\": \"sd_da1\"\n4803\t              }\n4804\t            ]\n4805\t          },\n4806\t          {\n4807\t            \"id\": \"p_244183720\",\n4808\t            \"ark\": \"ark:/61903/1:1:MZ96-R4Z\",\n4809\t            \"gender\": \"Female\",\n4810\t            \"names\": [\n4811\t              {\n4812\t                \"type\": \"BirthName\",\n4813\t                \"given\": \"Sarah J.\",\n4814\t                \"surname\": \"Bottomley\"\n4815\t              }\n4816\t     ..."
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/Users/ernest/.claude/projects/-private-var-folders-g7-zn65fvrn5g9-g71-sp0lk82h0000gn-T-e2e-bottemiller-parents-91t9zm2u/6b6fa77e-a98a-4d4b-88f2-5c7d037177be/tool-results/mcp-genealogy-record_search-1783001425493.txt",
+        "limit": 400,
+        "offset": 5200
+      },
+      "response_summary": "5200\t                \"ref\": \"sd_da1\"\n5201\t              }\n5202\t            ]\n5203\t          },\n5204\t          {\n5205\t            \"id\": \"p_244503340\",\n5206\t            \"ark\": \"ark:/61903/1:1:MZ9R-28Z\",\n5207\t            \"gender\": \"Male\",\n5208\t            \"names\": [\n5209\t              {\n5210\t                \"type\": \"BirthName\",\n5211\t                \"surname\": \"Bottermiller\",\n5212\t                \"given\": \"Fred\"\n5213\t              }\n5214\t            ],\n5215\t            \"facts\": [\n5216\t           ..."
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/Users/ernest/.claude/projects/-private-var-folders-g7-zn65fvrn5g9-g71-sp0lk82h0000gn-T-e2e-bottemiller-parents-91t9zm2u/6b6fa77e-a98a-4d4b-88f2-5c7d037177be/tool-results/mcp-genealogy-record_search-1783001425493.txt",
+        "limit": 400,
+        "offset": 5600
+      },
+      "response_summary": "5600\t            \"child\": \"p_244503339\"\n5601\t          },\n5602\t          {\n5603\t            \"type\": \"ParentChild\",\n5604\t            \"parent\": \"p_244503336\",\n5605\t            \"child\": \"p_244503342\"\n5606\t          },\n5607\t          {\n5608\t            \"type\": \"ParentChild\",\n5609\t            \"parent\": \"p_244503336\",\n5610\t            \"child\": \"p_244503348\"\n5611\t          },\n5612\t          {\n5613\t            \"type\": \"ParentChild\",\n5614\t            \"parent\": \"p_244503336\",\n5615\t            \"child\": ..."
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/Users/ernest/.claude/projects/-private-var-folders-g7-zn65fvrn5g9-g71-sp0lk82h0000gn-T-e2e-bottemiller-parents-91t9zm2u/6b6fa77e-a98a-4d4b-88f2-5c7d037177be/tool-results/mcp-genealogy-record_search-1783001425493.txt",
+        "limit": 400,
+        "offset": 6000
+      },
+      "response_summary": "6000\t                \"surname\": \"Olsmiller\",\n6001\t                \"given\": \"Charlotta\"\n6002\t              }\n6003\t            ],\n6004\t            \"facts\": [\n6005\t              {\n6006\t                \"type\": \"Birth\",\n6007\t                \"date\": \"1840\",\n6008\t                \"standard_date\": \"1840\",\n6009\t                \"place\": \"Germany\",\n6010\t                \"standard_place\": \"Germany\"\n6011\t              },\n6012\t              {\n6013\t                \"type\": \"Census\",\n6014\t                \"prima..."
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/Users/ernest/.claude/projects/-private-var-folders-g7-zn65fvrn5g9-g71-sp0lk82h0000gn-T-e2e-bottemiller-parents-91t9zm2u/6b6fa77e-a98a-4d4b-88f2-5c7d037177be/tool-results/mcp-genealogy-record_search-1783001425493.txt",
+        "limit": 400,
+        "offset": 6400
+      },
+      "response_summary": "6400\t            \"id\": \"p_336970915\",\n6401\t            \"ark\": \"ark:/61903/1:1:M6TM-D3R\",\n6402\t            \"gender\": \"Male\",\n6403\t            \"names\": [\n6404\t              {\n6405\t                \"type\": \"BirthName\",\n6406\t                \"surname\": \"Kitzmiller\",\n6407\t                \"given\": \"Luke\"\n6408\t              }\n6409\t            ],\n6410\t            \"facts\": [\n6411\t              {\n6412\t                \"type\": \"Birth\",\n6413\t                \"date\": \"1836\",\n6414\t                \"standard_dat..."
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/Users/ernest/.claude/projects/-private-var-folders-g7-zn65fvrn5g9-g71-sp0lk82h0000gn-T-e2e-bottemiller-parents-91t9zm2u/6b6fa77e-a98a-4d4b-88f2-5c7d037177be/tool-results/mcp-genealogy-record_search-1783001425493.txt",
+        "limit": 400,
+        "offset": 6800
+      },
+      "response_summary": "6800\t          {\n6801\t            \"id\": \"sd_da1\",\n6802\t            \"url\": \"https://www.familysearch.org/ark:/61903/3:1:33S7-9YBG-WSL\"\n6803\t          },\n6804\t          {\n6805\t            \"id\": \"sd_auto_M9JT-92D\",\n6806\t            \"title\": \"United States, Residences, Census, from 1526 to 2020\"\n6807\t          },\n6808\t          {\n6809\t            \"id\": \"src_p_p_336970917\",\n6810\t            \"url\": \"#p_336970917\"\n6811\t          }\n6812\t        ],\n6813\t        \"places\": [\n6814\t          {\n6815\t      ..."
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/Users/ernest/.claude/projects/-private-var-folders-g7-zn65fvrn5g9-g71-sp0lk82h0000gn-T-e2e-bottemiller-parents-91t9zm2u/6b6fa77e-a98a-4d4b-88f2-5c7d037177be/tool-results/mcp-genealogy-record_search-1783001425493.txt",
+        "limit": 400,
+        "offset": 7200
+      },
+      "response_summary": "7200\t              {\n7201\t                \"type\": \"MaritalStatus\",\n7202\t                \"value\": \"Single\"\n7203\t              },\n7204\t              {\n7205\t                \"type\": \"Birth\",\n7206\t                \"date\": \"1864\",\n7207\t                \"standard_date\": \"1864\",\n7208\t                \"place\": \"North Carolina, United States\",\n7209\t                \"standard_place\": \"North Carolina, United States\"\n7210\t              },\n7211\t              {\n7212\t                \"type\": \"Census\",\n7213\t      ..."
+    },
+    {
+      "tool": "Bash",
+      "args": {
+        "command": "grep -i \"staged\\|resultsRef\\|results_ref\" /Users/ernest/.claude/projects/-private-var-folders-g7-zn65fvrn5g9-g71-sp0lk82h0000gn-T-e2e-bottemiller-parents-91t9zm2u/6b6fa77e-a98a-4d4b-88f2-5c7d037177be/tool-results/mcp-genealogy-record_search-1783001425493.txt | head -20",
+        "description": "Find staged resultsRef in the large search result file"
+      },
+      "response_summary": "  \"staged\": {\n    \"resultsRef\": \"results/.staging/795c395f-e157-41da-9370-5399f260470f.json\","
+    },
+    {
+      "tool": "mcp__genealogy__research_log_append",
+      "args": {
+        "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u",
+        "tool": "record_search",
+        "planItemId": "pli_009",
+        "query": {
+          "givenName": "William",
+          "givenNameAlt": "Willie",
+          "surname": "Bottemiller",
+          "surnameAlt": "Battermiller",
+          "recordType": "census",
+          "residenceYearFrom": 1880,
+          "residenceYearTo": 1880,
+          "birthYearFrom": 1860,
+          "birthYearTo": 1865,
+          "collectionId": "1417683"
+        },
+        "outcome": "positive",
+        "resultsExamined": 20,
+        "resultsAvailable": 20,
+        "stagedResultsRef": "results/.staging/795c395f-e157-41da-9370-5399f260470f.json",
+        "notes": "Found 'Willie Bottermiller' (born 1862 MN) in household of Henry Bottermiller (b.1828 Germany) and Mary Bottermiller (b.1838 Germany) in Bertha, Todd, Minnesota. Tree match 249W-9LP (5 stars). CONFLICT: death cert named father as 'Casper A. Bottemiller'; 1880 census head is 'Henry Bottermiller'. Record: ark:/61903/1:1:MZ9R-28C. Will read full record for details."
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"logId\\\": \\\"log_010\\\",\\n  \\\"performed\\\": \\\"2026-07-02T14:14:15.636Z\\\",\\n  \\\"resultsRef\\\": \\\"results/log_010.json\\\",\\n  \\\"returnedCount\\\": 20,\\n  \\\"filesWritten\\\": [\\n    \\\"research.json\\\",\\n    \\\"results/log_010.json\\\"\\n  ],\\n  \\\"validation\\\": {\\n    \\\"valid\\\": true,\\n    \\\"warnings\\\": []\\n  }\\n}\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__record_read",
+      "args": {
+        "recordId": "ark:/61903/1:1:MZ9R-28C"
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"persons\\\": [\\n    {\\n      \\\"id\\\": \\\"p_244503336\\\",\\n      \\\"ark\\\": \\\"ark:/61903/1:1:MZ9R-28W\\\",\\n      \\\"gender\\\": \\\"Male\\\",\\n      \\\"names\\\": [\\n        {\\n          \\\"id\\\": \\\"1535a51e-0f07-4bac-832f-0e6670bf128b\\\",\\n          \\\"type\\\": \\\"BirthName\\\",\\n          \\\"given\\\": \\\"Henry\\\",\\n          \\\"surname\\\": \\\"Bottermiller\\\"\\n        }\\n      ],\\n      \\\"facts\\\": [\\n        {\\n          \\\"id\\\": \\\"bb44c52a-3b32-444b-8ad7-f081921b5d7f\\\",\\n          \\\"type\\\": \\..."
+    },
+    {
+      "tool": "mcp__genealogy__research_append",
+      "args": {
+        "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u",
+        "ops": [
+          {
+            "section": "sources",
+            "op": "append",
+            "entry": {
+              "gedcomx_source_description_id": "SCENSUS1880",
+              "citation": "\"United States, Census, 1880\", FamilySearch (https://www.familysearch.org/ark:/61903/1:1:MZ9R-28W : 2 July 2026), Entry for Henry Bottermiller and Mary Bottermiller, Bertha, Todd, Minnesota, 1880.",
+              "citation_detail": {
+                "who": "Household of Henry Bottermiller",
+                "what": "United States, Census, 1880 (FamilySearch database index)",
+                "when_created": "1880",
+                "when_accessed": "2026-07-02",
+                "where": "FamilySearch (https://www.familysearch.org)",
+                "where_within": "Bertha, Todd County, Minnesota; household of Henry Bottermiller"
+              },
+              "source_classification": "derivative",
+              "repository": "FamilySearch",
+              "access_date": "2026-07-02",
+              "url": "https://www.familysearch.org/ark:/61903/1:1:MZ9R-28W",
+              "notes": "FamilySearch indexed database abstract derived from original 1880 U.S. Census schedule. Original census image accessible at FamilySearch DGS ark:/61903/3:1:33S7-9YB8-R5D. Head listed as 'Henry Bottermiller,' born 1828, Germany \u2014 CONFLICTS with 1929 death cert naming father as 'Casper A. Bottemiller.' Mother listed as 'Mary Bottermiller,' born 1838, Germany \u2014 consistent with death cert 'Mary Mehlman' (maiden name). FamilySearch tree match to subject 249W-9LP confirmed (5 stars, score 3.29).",
+              "log_entry_id": "log_010"
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "source_id": "src_004",
+              "record_id": "https://www.familysearch.org/ark:/61903/1:1:MZ9R-28W",
+              "record_role": "son_1",
+              "record_persona_id": "p_244503339",
+              "fact_type": "name",
+              "value": "Willie Bottermiller",
+              "structured_value": {
+                "given": "Willie",
+                "surname": "Bottermiller"
+              },
+              "information_quality": "indeterminate",
+              "informant": "unknown household member",
+              "informant_proximity": "household_member",
+              "informant_bias_notes": "1880 census pre-dates 1940; respondent unknown. Name is a diminutive of William \u2014 consistent with subject William Henry Bottemiller.",
+              "evidence_type": "direct",
+              "extracted_for_question_ids": [
+                "q_002"
+              ],
+              "log_entry_id": "log_010"
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "source_id": "src_004",
+              "record_id": "https://www.familysearch.org/ark:/61903/1:1:MZ9R-28W",
+              "record_role": "son_1",
+              "record_persona_id": "p_244503339",
+              "fact_type": "birth",
+              "value": "born 1862, Minnesota",
+              "structured_value": {
+                "year": 1862,
+                "place": "Minnesota, United States"
+              },
+              "date": "1862",
+              "date_certainty": "approximate",
+              "place": "Minnesota, United States",
+              "standard_place": "Minnesota, United States",
+              "information_quality": "indeterminate",
+              "informant": "unknown household member",
+              "informant_proximity": "household_member",
+              "evidence_type": "direct",
+              "extracted_for_question_ids": [
+                "q_002"
+              ],
+              "log_entry_id": "log_010"
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "source_id": "src_004",
+              "record_id": "https://www.familysearch.org/ark:/61903/1:1:MZ9R-28W",
+              "record_role": "son_1",
+              "record_persona_id": "p_244503339",
+              "fact_type": "residence",
+              "value": "Bertha, Todd, Minnesota, 1880",
+              "structured_value": {
+                "place": "Bertha, Todd, Minnesota, United States"
+              },
+              "date": "1880",
+              "date_certainty": "exact",
+              "place": "Bertha, Todd, Minnesota, United States",
+              "standard_place": "Bertha, Todd, Minnesota, United States",
+              "information_quality": "primary",
+              "informant": "census enumerator",
+              "informant_proximity": "witness",
+              "evidence_type": "direct",
+              "extracted_for_question_ids": [
+                "q_002"
+              ],
+              "log_entry_id": "log_010"
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "source_id": "src_004",
+              "record_id": "https://www.familysearch.org/ark:/61903/1:1:MZ9R-28W",
+              "record_role": "son_1",
+              "record_persona_id": "p_244503339",
+              "fact_type": "relationship",
+              "value": "son in household of Henry Bottermiller (head), 1880 census",
+              "structured_value": {
+                "relationship_type": "child",
+                "related_person_role": "head_of_household"
+              },
+              "date": "1880",
+              "date_certainty": "exact",
+              "information_quality": "indeterminate",
+              "informant": "unknown household member",
+              "informant_proximity": "household_member",
+              "informant_bias_notes": "1880 census introduced explicit relationship-to-head column; this is a stated relationship, not inferred from position alone.",
+              "evidence_type": "direct",
+              "extracted_for_question_ids": [
+                "q_002"
+              ],
+              "log_entry_id": "log_010"
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "source_id": "src_004",
+              "record_id": "https://www.familysearch.org/ark:/61903/1:1:MZ9R-28W",
+              "record_role": "head_of_household",
+              "record_persona_id": "p_244503336",
+              "fact_type": "name",
+              "value": "Henry Bottermiller",
+              "structured_value": {
+                "given": "Henry",
+                "surname": "Bottermiller"
+              },
+              "information_quality": "indeterminate",
+              "informant": "unknown household member",
+              "informant_proximity": "household_member",
+              "informant_bias_notes": "1880 census; respondent unknown. Given name 'Henry' conflicts with 'Casper A.' on William's 1929 death certificate. German immigrants commonly went by variant or middle names in American records.",
+              "evidence_type": "direct",
+              "extracted_for_question_ids": [
+                "q_002"
+              ],
+              "log_entry_id": "log_010"
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "source_id": "src_004",
+              "record_id": "https://www.familysearch.org/ark:/61903/1:1:MZ9R-28W",
+              "record_role": "head_of_household",
+              "record_persona_id": "p_244503336",
+              "fact_type": "birth",
+              "value": "born 1828, Germany",
+              "structured_value": {
+                "year": 1828,
+                "place": "Germany"
+              },
+              "date": "1828",
+              "date_certainty": "approximate",
+              "place": "Germany",
+              "standard_place": "Germany",
+              "information_quality": "indeterminate",
+              "informant": "unknown household member",
+              "informant_proximity": "household_member",
+              "evidence_type": "direct",
+              "extracted_for_question_ids": [
+                "q_002"
+              ],
+              "log_entry_id": "log_010"
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "source_id": "src_004",
+              "record_id": "https://www.familysearch.org/ark:/61903/1:1:MZ9R-28W",
+              "record_role": "head_of_household",
+              "record_persona_id": "p_244503336",
+              "fact_type": "residence",
+              "value": "Bertha, Todd, Minnesota, 1880",
+              "structured_value": {
+                "place": "Bertha, Todd, Minnesota, United States"
+              },
+              "date": "1880",
+              "date_certainty": "exact",
+              "place": "Bertha, Todd, Minnesota, United States",
+              "standard_place": "Bertha, Todd, Minnesota, United States",
+              "information_quality": "primary",
+              "informant": "census enumerator",
+              "informant_proximity": "witness",
+              "evidence_type": "direct",
+              "extracted_for_question_ids": [
+                "q_002"
+              ],
+              "log_entry_id": "log_010"
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "source_id": "src_004",
+              "record_id": "https://www.familysearch.org/ark:/61903/1:1:MZ9R-28W",
+              "record_role": "head_of_household",
+              "record_persona_id": "p_244503336",
+              "fact_type": "occupation",
+              "value": "Farmer",
+              "structured_value": {
+                "occupation": "Farmer"
+              },
+              "information_quality": "indeterminate",
+              "informant": "unknown household member",
+              "informant_proximity": "household_member",
+              "evidence_type": "direct",
+              "extracted_for_question_ids": [],
+              "log_entry_id": "log_010"
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "source_id": "src_004",
+              "record_id": "https://www.familysearch.org/ark:/61903/1:1:MZ9R-28W",
+              "record_role": "wife",
+              "record_persona_id": "p_244503337",
+              "fact_type": "name",
+              "value": "Mary Bottermiller",
+              "structured_value": {
+                "given": "Mary",
+                "surname": "Bottermiller"
+              },
+              "information_quality": "indeterminate",
+              "informant": "unknown household member",
+              "informant_proximity": "household_member",
+              "informant_bias_notes": "Wife of Henry Bottermiller. Death certificate for William Henry Bottemiller (1929) named his mother as 'Mary Mehlman' \u2014 Mehlman was her maiden name; Bottermiller is her married name. Consistent.",
+              "evidence_type": "direct",
+              "extracted_for_question_ids": [
+                "q_002"
+              ],
+              "log_entry_id": "log_010"
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "source_id": "src_004",
+              "record_id": "https://www.familysearch.org/ark:/61903/1:1:MZ9R-28W",
+              "record_role": "wife",
+              "record_persona_id": "p_244503337",
+              "fact_type": "birth",
+              "value": "born 1838, Germany",
+              "structured_value": {
+                "year": 1838,
+                "place": "Germany"
+              },
+              "date": "1838",
+              "date_certainty": "approximate",
+              "place": "Germany",
+              "standard_place": "Germany",
+              "information_quality": "indeterminate",
+              "informant": "unknown household member",
+              "informant_proximity": "household_member",
+              "evidence_type": "direct",
+              "extracted_for_question_ids": [
+                "q_002"
+              ],
+              "log_entry_id": "log_010"
+            }
+          }
+        ]
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": false,\\n  \\\"errors\\\": [\\n    \\\"research.json/sources[3]: gedcomx_source_description_id 'SCENSUS1880' not found in tree.gedcomx.json sources\\\",\\n    \\\"research.json/assertions[14]: record_id 'https://www.familysearch.org/ark:/61903/1:1:MZ9R-28W' does not match any result's recordId in sidecar 'results/log_010.json'\\\",\\n    \\\"research.json/assertions[15]: record_id 'https://www.familysearch.org/ark:/61903/1:1:MZ9R-28W' does not match any result's recordId..."
+    },
+    {
+      "tool": "Bash",
+      "args": {
+        "command": "grep -i \"arkUrl\\|recordId\\|record_id\\|\\\"ark:\" /private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u/results/log_010.json | head -30",
+        "description": "Find valid record IDs in log_010 sidecar"
+      },
+      "response_summary": "        \"recordId\": \"ark:/61903/1:1:MXV4-R48\",\n        \"recordArk\": \"ark:/61903/1:2:MHGP-4NY\",\n              \"ark\": \"ark:/61903/1:1:MXV4-R48\",\n              \"ark\": \"ark:/61903/1:1:MXV4-R4C\",\n              \"ark\": \"ark:/61903/1:1:MXV4-R4Z\",\n              \"ark\": \"ark:/61903/1:1:MXV4-R4D\",\n              \"ark\": \"ark:/61903/1:1:MXV4-R46\",\n              \"ark\": \"ark:/61903/1:1:MXV4-R4X\",\n              \"ark\": \"ark:/61903/1:1:MXV4-R4F\",\n        \"recordId\": \"ark:/61903/1:1:MWSR-RF9\",\n        \"recordArk\"..."
+    },
+    {
+      "tool": "Bash",
+      "args": {
+        "command": "grep -i \"MZ9R\\|Bottermiller\\|Bottemiller\" /private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u/results/log_010.json | head -30",
+        "description": "Find Bottermiller records in sidecar"
+      },
+      "response_summary": "      \"surname\": \"Bottemiller\",\n      \"projectPath\": \"/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u\"\n        \"recordId\": \"ark:/61903/1:1:MZ9R-28C\",\n        \"personName\": \"Willie Bottermiller\",\n        \"recordTitle\": \"Household of Henry Bottermiller, \\\"United States, Census, 1880\\\"\",\n              \"ark\": \"ark:/61903/1:1:MZ9R-28C\",\n                  \"surname\": \"Bottermiller\",\n              \"ark\": \"ark:/61903/1:1:MZ9R-28W\",\n                  \"surname\":..."
+    },
+    {
+      "tool": "Bash",
+      "args": {
+        "command": "grep -i \"record_id\\|gedcomx_source\" /private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u/research.json | head -20",
+        "description": "Check existing record_id format in research.json assertions"
+      },
+      "response_summary": "      \"gedcomx_source_description_id\": \"S8VD-MGG\",\n      \"gedcomx_source_description_id\": \"S8VD-92V\",\n      \"gedcomx_source_description_id\": \"S8VD-963\",\n      \"record_id\": \"https://www.familysearch.org/ark:/61903/1:1:F8WM-X8F\",\n      \"record_id\": \"https://www.familysearch.org/ark:/61903/1:1:F8WM-X8F\",\n      \"record_id\": \"https://www.familysearch.org/ark:/61903/1:1:F8WM-X8F\",\n      \"record_id\": \"https://www.familysearch.org/ark:/61903/1:1:F8WM-X8F\",\n      \"record_id\": \"https://www.familysearch..."
+    },
+    {
+      "tool": "Bash",
+      "args": {
+        "command": "grep \"recordId\" /private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u/results/log_001.json | head -5",
+        "description": "Check recordId format in prior sidecar"
+      },
+      "response_summary": "grep: /private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u/results/log_001.json: No such file or directory"
+    },
+    {
+      "tool": "Bash",
+      "args": {
+        "command": "ls /private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u/results/",
+        "description": "List available sidecar result files"
+      },
+      "response_summary": "log_002.json\nlog_003.json\nlog_010.json"
+    },
+    {
+      "tool": "Bash",
+      "args": {
+        "command": "grep \"recordId\" /private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u/results/log_002.json | head -5",
+        "description": "Check recordId format in log_002 sidecar"
+      },
+      "response_summary": "        \"recordId\": \"ark:/61903/1:1:ZVXG-KGT2\",\n        \"recordId\": \"ark:/61903/1:1:ZG4C-5W6Z\",\n        \"recordId\": \"ark:/61903/1:1:CLZ6-BJ6Z\",\n        \"recordId\": \"ark:/61903/1:1:CL47-2HZM\","
+    },
+    {
+      "tool": "Bash",
+      "args": {
+        "command": "grep '\"id\"' /private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u/tree.gedcomx.json | grep '\"S' | head -20",
+        "description": "List existing S-prefix source IDs in tree.gedcomx.json"
+      },
+      "response_summary": "      \"id\": \"S8VD-6PG\",\n      \"id\": \"S8VD-963\",\n      \"id\": \"S8VD-W8P\",\n      \"id\": \"S8VD-D7K\",\n      \"id\": \"SWDM-F7D\",\n      \"id\": \"S8VD-92V\",\n      \"id\": \"S8VD-H6D\",\n      \"id\": \"S8VD-SNP\",\n      \"id\": \"S8VD-MGG\",\n      \"id\": \"SWDM-FRX\",\n      \"id\": \"S8VD-CVL\",\n      \"id\": \"SLH4-YV1\",\n      \"id\": \"SWDM-NJ6\","
+    },
+    {
+      "tool": "ToolSearch",
+      "args": {
+        "query": "select:mcp__genealogy__tree_edit",
+        "max_results": 1
+      },
+      "response_summary": "[{\"type\": \"tool_reference\", \"tool_name\": \"mcp__genealogy__tree_edit\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__tree_edit",
+      "args": {
+        "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u",
+        "ops": [
+          {
+            "operation": "add_source",
+            "source": {
+              "title": "United States, Census, 1880 \u2014 Household of Henry Bottermiller, Bertha, Todd, Minnesota",
+              "url": "https://www.familysearch.org/ark:/61903/1:1:MZ9R-28W"
+            }
+          },
+          {
+            "operation": "add_person",
+            "person": {
+              "gender": "Male",
+              "names": [
+                {
+                  "type": "BirthName",
+                  "given": "Henry",
+                  "surname": "Bottermiller"
+                }
+              ],
+              "facts": [
+                {
+                  "type": "Birth",
+                  "date": "1828",
+                  "place": "Germany",
+                  "primary": true
+                },
+                {
+                  "type": "Occupation",
+                  "value": "Farmer"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": false,\\n  \\\"errors\\\": [\\n    \\\"tree.gedcomx.json/persons[10]/facts[0]: missing required field 'id'\\\",\\n    \\\"tree.gedcomx.json/persons[10]/facts[1]: missing required field 'id'\\\"\\n  ]\\n}\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__tree_edit",
+      "args": {
+        "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u",
+        "ops": [
+          {
+            "operation": "add_source",
+            "source": {
+              "title": "United States, Census, 1880 \u2014 Household of Henry Bottermiller, Bertha, Todd, Minnesota",
+              "url": "https://www.familysearch.org/ark:/61903/1:1:MZ9R-28W"
+            }
+          },
+          {
+            "operation": "add_person",
+            "person": {
+              "gender": "Male",
+              "names": [
+                {
+                  "type": "BirthName",
+                  "given": "Henry",
+                  "surname": "Bottermiller"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"results\\\": [\\n    {\\n      \\\"operation\\\": \\\"add_source\\\",\\n      \\\"assignedIds\\\": {\\n        \\\"source\\\": \\\"S1\\\"\\n      }\\n    },\\n    {\\n      \\\"operation\\\": \\\"add_person\\\",\\n      \\\"assignedIds\\\": {\\n        \\\"person\\\": \\\"I3\\\",\\n        \\\"names\\\": [\\n          \\\"N3\\\"\\n        ]\\n      }\\n    }\\n  ],\\n  \\\"filesWritten\\\": [\\n    \\\"tree.gedcomx.json\\\"\\n  ],\\n  \\\"validation\\\": {\\n    \\\"valid\\\": true,\\n    \\\"warnings\\\": []\\n  }\\n}\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__research_append",
+      "args": {
+        "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u",
+        "ops": [
+          {
+            "section": "sources",
+            "op": "append",
+            "entry": {
+              "gedcomx_source_description_id": "S1",
+              "citation": "\"United States, Census, 1880\", FamilySearch (https://www.familysearch.org/ark:/61903/1:1:MZ9R-28W : 2 July 2026), Entry for Henry Bottermiller and Mary Bottermiller, Bertha, Todd, Minnesota, 1880.",
+              "citation_detail": {
+                "who": "Household of Henry Bottermiller",
+                "what": "United States, Census, 1880 (FamilySearch database index)",
+                "when_created": "1880",
+                "when_accessed": "2026-07-02",
+                "where": "FamilySearch (https://www.familysearch.org)",
+                "where_within": "Bertha, Todd County, Minnesota; household of Henry Bottermiller"
+              },
+              "source_classification": "derivative",
+              "repository": "FamilySearch",
+              "access_date": "2026-07-02",
+              "url": "https://www.familysearch.org/ark:/61903/1:1:MZ9R-28W",
+              "notes": "FamilySearch indexed database abstract derived from original 1880 U.S. Census schedule. Original image accessible at FamilySearch DGS ark:/61903/3:1:33S7-9YB8-R5D. Head listed as 'Henry Bottermiller,' born 1828, Germany \u2014 CONFLICTS with 1929 death cert naming William's father as 'Casper A. Bottemiller.' Wife listed as 'Mary Bottermiller,' born 1838, Germany \u2014 consistent with death cert 'Mary Mehlman' (maiden name). FamilySearch tree auto-matched Willie to 249W-9LP (5 stars, score 3.29).",
+              "log_entry_id": "log_010"
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "source_id": "src_004",
+              "record_id": "https://www.familysearch.org/ark:/61903/1:1:MZ9R-28C",
+              "record_role": "son_1",
+              "record_persona_id": "p_244503339",
+              "fact_type": "name",
+              "value": "Willie Bottermiller",
+              "structured_value": {
+                "given": "Willie",
+                "surname": "Bottermiller"
+              },
+              "information_quality": "indeterminate",
+              "informant": "unknown household member",
+              "informant_proximity": "household_member",
+              "informant_bias_notes": "1880 census; respondent unknown. 'Willie' is a common diminutive of William, consistent with subject William Henry Bottemiller.",
+              "evidence_type": "direct",
+              "extracted_for_question_ids": [
+                "q_002"
+              ],
+              "log_entry_id": "log_010"
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "source_id": "src_004",
+              "record_id": "https://www.familysearch.org/ark:/61903/1:1:MZ9R-28C",
+              "record_role": "son_1",
+              "record_persona_id": "p_244503339",
+              "fact_type": "birth",
+              "value": "born 1862, Minnesota",
+              "structured_value": {
+                "year": 1862,
+                "place": "Minnesota, United States"
+              },
+              "date": "1862",
+              "date_certainty": "approximate",
+              "place": "Minnesota, United States",
+              "standard_place": "Minnesota, United States",
+              "information_quality": "indeterminate",
+              "informant": "unknown household member",
+              "informant_proximity": "household_member",
+              "evidence_type": "direct",
+              "extracted_for_question_ids": [
+                "q_002"
+              ],
+              "log_entry_id": "log_010"
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "source_id": "src_004",
+              "record_id": "https://www.familysearch.org/ark:/61903/1:1:MZ9R-28C",
+              "record_role": "son_1",
+              "record_persona_id": "p_244503339",
+              "fact_type": "residence",
+              "value": "Bertha, Todd, Minnesota, 1880",
+              "structured_value": {
+                "place": "Bertha, Todd, Minnesota, United States"
+              },
+              "date": "1880",
+              "date_certainty": "exact",
+              "place": "Bertha, Todd, Minnesota, United States",
+              "standard_place": "Bertha, Todd, Minnesota, United States",
+              "information_quality": "primary",
+              "informant": "census enumerator",
+              "informant_proximity": "witness",
+              "evidence_type": "direct",
+              "extracted_for_question_ids": [
+                "q_002"
+              ],
+              "log_entry_id": "log_010"
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "source_id": "src_004",
+              "record_id": "https://www.familysearch.org/ark:/61903/1:1:MZ9R-28C",
+              "record_role": "son_1",
+              "record_persona_id": "p_244503339",
+              "fact_type": "relationship",
+              "value": "son in household of Henry Bottermiller, 1880 census",
+              "structured_value": {
+                "relationship_type": "child",
+                "related_person_role": "head_of_household"
+              },
+              "date": "1880",
+              "date_certainty": "exact",
+              "information_quality": "indeterminate",
+              "informant": "unknown household member",
+              "informant_proximity": "household_member",
+              "informant_bias_notes": "1880 census introduced explicit 'relationship to head' column; stated relationship, not inferred from position. Household head is Henry Bottermiller, which conflicts with death cert naming father as Casper A. Bottemiller.",
+              "evidence_type": "direct",
+              "extracted_for_question_ids": [
+                "q_002"
+              ],
+              "log_entry_id": "log_010"
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "source_id": "src_004",
+              "record_id": "https://www.familysearch.org/ark:/61903/1:1:MZ9R-28C",
+              "record_role": "head_of_household",
+              "record_persona_id": "p_244503336",
+              "fact_type": "name",
+              "value": "Henry Bottermiller",
+              "structured_value": {
+                "given": "Henry",
+                "surname": "Bottermiller"
+              },
+              "information_quality": "indeterminate",
+              "informant": "unknown household member",
+              "informant_proximity": "household_member",
+              "informant_bias_notes": "1880 census; respondent unknown. Given name 'Henry' conflicts with 'Casper A.' on William's 1929 death certificate. German immigrants commonly used a middle name or Americanized name in U.S. records vs. their baptismal name.",
+              "evidence_type": "direct",
+              "extracted_for_question_ids": [
+                "q_002"
+              ],
+              "log_entry_id": "log_010"
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "source_id": "src_004",
+              "record_id": "https://www.familysearch.org/ark:/61903/1:1:MZ9R-28C",
+              "record_role": "head_of_household",
+              "record_persona_id": "p_244503336",
+              "fact_type": "birth",
+              "value": "born 1828, Germany",
+              "structured_value": {
+                "year": 1828,
+                "place": "Germany"
+              },
+              "date": "1828",
+              "date_certainty": "approximate",
+              "place": "Germany",
+              "standard_place": "Germany",
+              "information_quality": "indeterminate",
+              "informant": "unknown household member",
+              "informant_proximity": "household_member",
+              "evidence_type": "direct",
+              "extracted_for_question_ids": [
+                "q_002"
+              ],
+              "log_entry_id": "log_010"
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "source_id": "src_004",
+              "record_id": "https://www.familysearch.org/ark:/61903/1:1:MZ9R-28C",
+              "record_role": "head_of_household",
+              "record_persona_id": "p_244503336",
+              "fact_type": "residence",
+              "value": "Bertha, Todd, Minnesota, 1880",
+              "structured_value": {
+                "place": "Bertha, Todd, Minnesota, United States"
+              },
+              "date": "1880",
+              "date_certainty": "exact",
+              "place": "Bertha, Todd, Minnesota, United States",
+              "standard_place": "Bertha, Todd, Minnesota, United States",
+              "information_quality": "primary",
+              "informant": "census enumerator",
+              "informant_proximity": "witness",
+              "evidence_type": "direct",
+              "extracted_for_question_ids": [
+                "q_002"
+              ],
+              "log_entry_id": "log_010"
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "source_id": "src_004",
+              "record_id": "https://www.familysearch.org/ark:/61903/1:1:MZ9R-28C",
+              "record_role": "head_of_household",
+              "record_persona_id": "p_244503336",
+              "fact_type": "occupation",
+              "value": "Farmer",
+              "structured_value": {
+                "occupation": "Farmer"
+              },
+              "information_quality": "indeterminate",
+              "informant": "unknown household member",
+              "informant_proximity": "household_member",
+              "evidence_type": "direct",
+              "extracted_for_question_ids": [],
+              "log_entry_id": "log_010"
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "source_id": "src_004",
+              "record_id": "https://www.familysearch.org/ark:/61903/1:1:MZ9R-28C",
+              "record_role": "wife",
+              "record_persona_id": "p_244503337",
+              "fact_type": "name",
+              "value": "Mary Bottermiller",
+              "structured_value": {
+                "given": "Mary",
+                "surname": "Bottermiller"
+              },
+              "information_quality": "indeterminate",
+              "informant": "unknown household member",
+              "informant_proximity": "household_member",
+              "informant_bias_notes": "Wife of Henry Bottermiller. William's 1929 death cert named his mother as 'Mary Mehlman' \u2014 Mehlman is her maiden name; Bottermiller is her married name. Consistent with I2.",
+              "evidence_type": "direct",
+              "extracted_for_question_ids": [
+                "q_002"
+              ],
+              "log_entry_id": "log_010"
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "source_id": "src_004",
+              "record_id": "https://www.familysearch.org/ark:/61903/1:1:MZ9R-28C",
+              "record_role": "wife",
+              "record_persona_id": "p_244503337",
+              "fact_type": "birth",
+              "value": "born 1838, Germany",
+              "structured_value": {
+                "year": 1838,
+                "place": "Germany"
+              },
+              "date": "1838",
+              "date_certainty": "approximate",
+              "place": "Germany",
+              "standard_place": "Germany",
+              "information_quality": "indeterminate",
+              "informant": "unknown household member",
+              "informant_proximity": "household_member",
+              "evidence_type": "direct",
+              "extracted_for_question_ids": [
+                "q_002"
+              ],
+              "log_entry_id": "log_010"
+            }
+          }
+        ]
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"results\\\": [\\n    {\\n      \\\"section\\\": \\\"sources\\\",\\n      \\\"op\\\": \\\"append\\\",\\n      \\\"entryId\\\": \\\"src_004\\\"\\n    },\\n    {\\n      \\\"section\\\": \\\"assertions\\\",\\n      \\\"op\\\": \\\"append\\\",\\n      \\\"entryId\\\": \\\"a_015\\\"\\n    },\\n    {\\n      \\\"section\\\": \\\"assertions\\\",\\n      \\\"op\\\": \\\"append\\\",\\n      \\\"entryId\\\": \\\"a_016\\\"\\n    },\\n    {\\n      \\\"section\\\": \\\"assertions\\\",\\n      \\\"op\\\": \\\"append\\\",\\n      \\\"entryId\\\": \\\"a_017\\\"\\n    },\\n ..."
+    },
+    {
+      "tool": "mcp__genealogy__research_append",
+      "args": {
+        "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u",
+        "ops": [
+          {
+            "section": "conflicts",
+            "op": "append",
+            "entry": {
+              "description": "Father's given name conflict: William Henry Bottemiller's 1929 Oregon death certificate names his father as 'Casper A. Bottemiller' (a_006), but the 1880 U.S. Census for William's household in Bertha, Todd, Minnesota lists the head as 'Henry Bottermiller' (a_019), born 1828, Germany. Both sources agree on surname, origin country, and household location. The discrepancy in first name may reflect: (1) use of a middle name vs. baptismal name (e.g., 'Heinrich Kaspar' known as Henry in American records and Casper to family), (2) informant error on the 1929 death certificate (derivative source, unknown secondary informant), or (3) genuinely different persons. Requires corroboration from 1870 census or other independent records naming both the father's full name and William as a son.",
+              "assertion_ids": [
+                "a_006",
+                "a_019"
+              ],
+              "person_ids": [
+                "I1",
+                "I3"
+              ],
+              "status": "unresolved",
+              "resolution": null,
+              "blocks_question_ids": [
+                "q_002"
+              ]
+            }
+          },
+          {
+            "section": "person_evidence",
+            "op": "append",
+            "entry": {
+              "assertion_id": "a_015",
+              "person_id": "249W-9LP",
+              "confidence": "confident",
+              "match_score": null,
+              "rationale": "Name 'Willie Bottermiller' on 1880 census matches subject William Henry Bottemiller: 'Willie' is a standard diminutive of William; surname 'Bottermiller' is a spelling variant of 'Bottemiller' consistent with this family's indexing across records. Birth year 1862 in Minnesota matches subject (b. 29 Dec 1862, Franconia Township, Chisago County, MN). Residence in Bertha, Todd, Minnesota matches tree. FamilySearch automated system matched this persona to tree entry 249W-9LP with a 5-star rating."
+            }
+          },
+          {
+            "section": "person_evidence",
+            "op": "append",
+            "entry": {
+              "assertion_id": "a_016",
+              "person_id": "249W-9LP",
+              "confidence": "confident",
+              "match_score": null,
+              "rationale": "Birth year 1862, Minnesota on 1880 census aligns with subject born 29 December 1862 in Franconia Township, Chisago County, Minnesota. Same record, same persona (Willie Bottermiller), already identified as 249W-9LP."
+            }
+          },
+          {
+            "section": "person_evidence",
+            "op": "append",
+            "entry": {
+              "assertion_id": "a_017",
+              "person_id": "249W-9LP",
+              "confidence": "confident",
+              "match_score": null,
+              "rationale": "Residence in Bertha, Todd, Minnesota in 1880 is consistent with subject's known location. Same record, same persona, FamilySearch 5-star match to 249W-9LP."
+            }
+          },
+          {
+            "section": "person_evidence",
+            "op": "append",
+            "entry": {
+              "assertion_id": "a_018",
+              "person_id": "249W-9LP",
+              "confidence": "confident",
+              "match_score": null,
+              "rationale": "Willie Bottermiller (identified as 249W-9LP) is listed as son of Henry Bottermiller in the 1880 census relationship column. This relationship assertion bears on 249W-9LP as the child in the relationship."
+            }
+          },
+          {
+            "section": "person_evidence",
+            "op": "append",
+            "entry": {
+              "assertion_id": "a_018",
+              "person_id": "I3",
+              "confidence": "probable",
+              "match_score": null,
+              "rationale": "The relationship assertion (Willie as son of household head) also bears on the household head, Henry Bottermiller (I3 stub). I3 was created from this same census record. Confidence is probable rather than confident because I3 is a new stub with single-source support and an unresolved name conflict with I1 (Casper A. Bottemiller)."
+            }
+          },
+          {
+            "section": "person_evidence",
+            "op": "append",
+            "entry": {
+              "assertion_id": "a_019",
+              "person_id": "I3",
+              "confidence": "probable",
+              "match_score": null,
+              "rationale": "I3 stub was created from this 1880 census record to represent 'Henry Bottermiller,' head of household in Bertha, Todd, Minnesota. Confidence is probable because I3 rests on a single derivative source. An unresolved conflict with I1 (Casper A. Bottemiller from death cert) prevents confident identification."
+            }
+          },
+          {
+            "section": "person_evidence",
+            "op": "append",
+            "entry": {
+              "assertion_id": "a_020",
+              "person_id": "I3",
+              "confidence": "probable",
+              "match_score": null,
+              "rationale": "Birth year 1828, Germany is consistent with a German immigrant who had children born in Minnesota 1860\u20131879. Same census persona (p_244503336) as a_019, already linked to I3 stub."
+            }
+          },
+          {
+            "section": "person_evidence",
+            "op": "append",
+            "entry": {
+              "assertion_id": "a_021",
+              "person_id": "I3",
+              "confidence": "probable",
+              "match_score": null,
+              "rationale": "Residence in Bertha, Todd, Minnesota, 1880 applies to Henry Bottermiller (I3), household head in this census record."
+            }
+          },
+          {
+            "section": "person_evidence",
+            "op": "append",
+            "entry": {
+              "assertion_id": "a_022",
+              "person_id": "I3",
+              "confidence": "probable",
+              "match_score": null,
+              "rationale": "Occupation 'Farmer' in 1880 applies to Henry Bottermiller (I3) as household head."
+            }
+          },
+          {
+            "section": "person_evidence",
+            "op": "append",
+            "entry": {
+              "assertion_id": "a_023",
+              "person_id": "I2",
+              "confidence": "probable",
+              "match_score": null,
+              "rationale": "Census wife 'Mary Bottermiller' (b. 1838, Germany) is consistent with I2 (Mary Mehlman stub created from death cert). Death cert named William's mother as 'Mary Mehlman' \u2014 'Mehlman' is her maiden name; 'Bottermiller' is her married name. Both records agree on given name Mary, German origin. Probable (not confident) because this is two derivative sources pointing to the same woman by complementary names."
+            }
+          },
+          {
+            "section": "person_evidence",
+            "op": "append",
+            "entry": {
+              "assertion_id": "a_024",
+              "person_id": "I2",
+              "confidence": "probable",
+              "match_score": null,
+              "rationale": "Birth year 1838, Germany for census wife Mary Bottermiller bears on I2 (Mary Mehlman, William's mother). Same census persona as a_023."
+            }
+          },
+          {
+            "section": "plan_items",
+            "op": "update",
+            "planId": "pl_003",
+            "entryId": "pli_009",
+            "fields": {
+              "status": "completed"
+            }
+          }
+        ]
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": false,\\n  \\\"errors\\\": [\\n    \\\"research.json/conflicts[0]: missing required field 'conflict_type'\\\",\\n    \\\"research.json/conflicts[0]: missing required field 'competing_assertion_ids'\\\"\\n  ]\\n}\"}]"
+    },
+    {
+      "tool": "Glob",
+      "args": {
+        "pattern": "**/research-schema-spec.md",
+        "path": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u"
+      },
+      "response_summary": "No files found"
+    },
+    {
+      "tool": "Glob",
+      "args": {
+        "pattern": "**/*.md",
+        "path": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u"
+      },
+      "response_summary": ".claude/skills/assertion-classification/references/three-layer-model.md\n.claude/skills/assertion-classification/references/validation-protocol.md\n.claude/skills/check-warnings/SKILL.md\n.claude/skills/check-warnings/references/assumption-categories.md\n.claude/skills/check-warnings/references/warning-checks.md\n.claude/skills/check-warnings/references/warnings-as-identity-signals.md\n.claude/skills/citation/references/gps-citation-standards.md\n.claude/skills/citation/references/validation-protoco..."
+    },
+    {
+      "tool": "Glob",
+      "args": {
+        "pattern": "docs/specs/*.md",
+        "path": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u"
+      },
+      "response_summary": "No files found"
+    },
+    {
+      "tool": "Bash",
+      "args": {
+        "command": "grep -r \"conflict_type\\|competing_assertion\" /private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u/.claude/skills/ 2>/dev/null | head -20",
+        "description": "Find conflict schema fields in skill reference files"
+      },
+      "response_summary": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u/.claude/skills/conflict-resolution/SKILL.md:These use `conflict_type: \"fact\"` and require `disputed_attribute`\n/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u/.claude/skills/conflict-resolution/SKILL.md:These use `conflict_type: \"identity\"` and require `identity_question`.\n/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u/...."
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u/.claude/skills/conflict-resolution/SKILL.md",
+        "limit": 100
+      },
+      "response_summary": "1\t---\n2\tname: conflict-resolution\n3\tmodel: claude-sonnet-4-6\n4\tallowed-tools:\n5\t  - place_search\n6\t  - place_search_all\n7\t  - place_distance\n8\t  - research_append\n9\t  - convert_calendar\n10\tdescription: >-\n11\t  Identifies and resolves conflicting genealogical evidence \u2014 both fact-level\n12\t  conflicts (three different birthplaces) and identity-level conflicts where\n13\t  multiple candidate persons or records genuinely compete (e.g. two same-named\n14\t  people in one county). Performs source indep..."
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u/.claude/skills/conflict-resolution/SKILL.md",
+        "offset": 99,
+        "limit": 80
+      },
+      "response_summary": "99\t### 2. Create the conflict entry\n100\t\n101\tFor each new conflict identified, append it to the `conflicts`\n102\tsection with `research_append`. Pass the entry in snake_case\n103\t**without an id** \u2014 the tool assigns the next `c_` id, validates\n104\tthe whole project, and writes atomically:\n105\t\n106\t```\n107\tresearch_append({\n108\t  projectPath: \"<absolute-path-to-project-directory>\",\n109\t  section: \"conflicts\",\n110\t  op: \"append\",\n111\t  entry: {\n112\t    \"conflict_type\": \"fact\",\n113\t    \"descriptio..."
+    },
+    {
+      "tool": "mcp__genealogy__research_append",
+      "args": {
+        "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u",
+        "ops": [
+          {
+            "section": "conflicts",
+            "op": "append",
+            "entry": {
+              "conflict_type": "fact",
+              "description": "Father's given name conflict: William Henry Bottemiller's 1929 Oregon death certificate (a_006) names his father as 'Casper A. Bottemiller,' but the 1880 U.S. Census (a_019) for William's household in Bertha, Todd, Minnesota lists the household head as 'Henry Bottermiller,' born 1828, Germany. Both sources agree on surname, German origin, and household location. Discrepancy in first name may reflect: (1) use of a middle name vs. baptismal name (German immigrants commonly known by different names in American vs. family contexts, e.g., 'Heinrich Kaspar' known as Henry publicly and Casper to family), (2) informant error on the 1929 death certificate (derivative source, unknown secondary informant, 49-year gap from subject's birth), or (3) genuinely different persons. Corroboration from 1870 census or other pre-death-cert records is needed.",
+              "disputed_attribute": "father_given_name",
+              "identity_question": null,
+              "competing_assertion_ids": [
+                "a_006",
+                "a_019"
+              ],
+              "independence_analysis": null,
+              "weighing_analysis": null,
+              "preferred_assertion_id": null,
+              "resolution_rationale": null,
+              "status": "unresolved",
+              "blocks_question_ids": [
+                "q_002"
+              ]
+            }
+          },
+          {
+            "section": "person_evidence",
+            "op": "append",
+            "entry": {
+              "assertion_id": "a_015",
+              "person_id": "249W-9LP",
+              "confidence": "confident",
+              "match_score": null,
+              "rationale": "Name 'Willie Bottermiller' on 1880 census matches subject William Henry Bottemiller: 'Willie' is a standard diminutive of William; 'Bottermiller' is a spelling variant of 'Bottemiller' consistent with this family's indexing across records. Birth year 1862 in Minnesota matches subject (b. 29 Dec 1862, Franconia Township, Chisago County, MN). Residence Bertha, Todd, Minnesota matches tree. FamilySearch automated system matched this persona to tree entry 249W-9LP with 5-star rating."
+            }
+          },
+          {
+            "section": "person_evidence",
+            "op": "append",
+            "entry": {
+              "assertion_id": "a_016",
+              "person_id": "249W-9LP",
+              "confidence": "confident",
+              "match_score": null,
+              "rationale": "Birth year 1862, Minnesota aligns with subject born 29 December 1862. Same census persona (p_244503339) already identified as 249W-9LP."
+            }
+          },
+          {
+            "section": "person_evidence",
+            "op": "append",
+            "entry": {
+              "assertion_id": "a_017",
+              "person_id": "249W-9LP",
+              "confidence": "confident",
+              "match_score": null,
+              "rationale": "Residence Bertha, Todd, Minnesota in 1880 is consistent with subject's known location. Same census persona, FamilySearch 5-star match to 249W-9LP."
+            }
+          },
+          {
+            "section": "person_evidence",
+            "op": "append",
+            "entry": {
+              "assertion_id": "a_018",
+              "person_id": "249W-9LP",
+              "confidence": "confident",
+              "match_score": null,
+              "rationale": "Willie Bottermiller (identified as 249W-9LP) is listed as son of Henry Bottermiller per the 1880 census relationship column. This relationship assertion bears on 249W-9LP as the child."
+            }
+          },
+          {
+            "section": "person_evidence",
+            "op": "append",
+            "entry": {
+              "assertion_id": "a_018",
+              "person_id": "I3",
+              "confidence": "probable",
+              "match_score": null,
+              "rationale": "The parent-child relationship assertion also bears on the household head Henry Bottermiller (I3 stub). I3 was created from this census record. Confidence is probable because I3 rests on a single derivative source and has an unresolved name conflict with I1 (Casper A. Bottemiller from death cert)."
+            }
+          },
+          {
+            "section": "person_evidence",
+            "op": "append",
+            "entry": {
+              "assertion_id": "a_019",
+              "person_id": "I3",
+              "confidence": "probable",
+              "match_score": null,
+              "rationale": "I3 stub was created from this 1880 census to represent 'Henry Bottermiller,' head in Bertha, Todd, Minnesota. Probable because I3 rests on a single derivative source. Unresolved conflict with I1 (Casper A. Bottemiller, death cert) prevents confident identification."
+            }
+          },
+          {
+            "section": "person_evidence",
+            "op": "append",
+            "entry": {
+              "assertion_id": "a_020",
+              "person_id": "I3",
+              "confidence": "probable",
+              "match_score": null,
+              "rationale": "Birth year 1828, Germany consistent with German immigrant who had children born in Minnesota 1860-1879. Same census persona (p_244503336) as a_019, linked to I3."
+            }
+          },
+          {
+            "section": "person_evidence",
+            "op": "append",
+            "entry": {
+              "assertion_id": "a_021",
+              "person_id": "I3",
+              "confidence": "probable",
+              "match_score": null,
+              "rationale": "Residence Bertha, Todd, Minnesota in 1880 applies to Henry Bottermiller (I3), household head in this census."
+            }
+          },
+          {
+            "section": "person_evidence",
+            "op": "append",
+            "entry": {
+              "assertion_id": "a_022",
+              "person_id": "I3",
+              "confidence": "probable",
+              "match_score": null,
+              "rationale": "Occupation 'Farmer' in 1880 applies to Henry Bottermiller (I3) as household head."
+            }
+          },
+          {
+            "section": "person_evidence",
+            "op": "append",
+            "entry": {
+              "assertion_id": "a_023",
+              "person_id": "I2",
+              "confidence": "probable",
+              "match_score": null,
+              "rationale": "Census wife 'Mary Bottermiller' (b. 1838, Germany) is consistent with I2 (Mary Mehlman stub from death cert). Death cert named William's mother as 'Mary Mehlman' \u2014 Mehlman is her maiden name; Bottermiller is her married name. Both records agree on given name Mary and German origin. Probable because these are two derivative sources pointing to the same woman by complementary names."
+            }
+          },
+          {
+            "section": "person_evidence",
+            "op": "append",
+            "entry": {
+              "assertion_id": "a_024",
+              "person_id": "I2",
+              "confidence": "probable",
+              "match_score": null,
+              "rationale": "Birth year 1838, Germany for census wife Mary Bottermiller bears on I2 (Mary Mehlman, William's mother). Same census persona as a_023."
+            }
+          },
+          {
+            "section": "plan_items",
+            "op": "update",
+            "planId": "pl_003",
+            "entryId": "pli_009",
+            "fields": {
+              "status": "completed"
+            }
+          }
+        ]
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"results\\\": [\\n    {\\n      \\\"section\\\": \\\"conflicts\\\",\\n      \\\"op\\\": \\\"append\\\",\\n      \\\"entryId\\\": \\\"c_001\\\"\\n    },\\n    {\\n      \\\"section\\\": \\\"person_evidence\\\",\\n      \\\"op\\\": \\\"append\\\",\\n      \\\"entryId\\\": \\\"pe_017\\\"\\n    },\\n    {\\n      \\\"section\\\": \\\"person_evidence\\\",\\n      \\\"op\\\": \\\"append\\\",\\n      \\\"entryId\\\": \\\"pe_018\\\"\\n    },\\n    {\\n      \\\"section\\\": \\\"person_evidence\\\",\\n      \\\"op\\\": \\\"append\\\",\\n      \\\"entryId\\\": \\\"p..."
+    },
+    {
+      "tool": "mcp__genealogy__research_append",
+      "args": {
+        "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u",
+        "section": "plan_items",
+        "op": "update",
+        "planId": "pl_003",
+        "entryId": "pli_010",
+        "fields": {
+          "status": "in_progress"
+        }
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"section\\\": \\\"plan_items\\\",\\n  \\\"op\\\": \\\"update\\\",\\n  \\\"entryId\\\": \\\"pli_010\\\",\\n  \\\"filesWritten\\\": [\\n    \\\"research.json\\\"\\n  ],\\n  \\\"validation\\\": {\\n    \\\"valid\\\": true,\\n    \\\"warnings\\\": []\\n  }\\n}\"}]"
+    }
+  ],
+  "error": "wall-clock timeout after 3600s",
+  "tags": {
+    "question_type": "parents",
+    "era": "1880s",
+    "geography": "US-MN"
+  },
+  "blocked_tree_reads": []
+}

--- a/eval/runlogs/e2e/bottemiller-parents/run-2026-07-02_14-24-47.transcript.md
+++ b/eval/runlogs/e2e/bottemiller-parents/run-2026-07-02_14-24-47.transcript.md
@@ -1,0 +1,1800 @@
+# E2e run: bottemiller-parents
+
+## User message
+
+```
+/research --autonomous Who were the parents of William Henry Bottemiller, born 29 December 1862 in Franconia Township, Chisago County, Minnesota, and died 13 May 1929 in Oregon City, Clackamas County, Oregon?
+```
+
+## Trace
+
+**tool_use** `Glob` — args: {"pattern": "**/*", "path": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u"}
+
+**tool_result:** .claude/skills/assertion-classification/references/three-layer-model.md
+.claude/skills/assertion-classification/references/validation-protocol.md
+.claude/skills/check-warnings/SKILL.md
+.claude/skills/check-warnings/references/assumption-categories.md
+.claude/skills/check-warnings/references/warning-checks.md
+.claude/skills/check-warnings/references/warnings-as-identity-signals.md
+.claude/skills/citation/references/gps-citation-standards.md
+.claude/skills/citation/references/validation-protoco...
+
+**tool_use** `Glob` — args: {"pattern": "research.json", "path": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u"}
+
+**tool_result:** .claude/skills/init-project/templates/research.json
+research.json
+
+**tool_use** `Read` — args: {"file_path": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u/research.json"}
+
+**tool_result:** 1	{
+2	  "project": {
+3	    "id": "rp_bottemiller_parents",
+4	    "objective": "Who were the parents of William Henry Bottemiller, born 29 December 1862 in Franconia Township, Chisago County, Minnesota, and died 13 May 1929 in Oregon City, Clackamas County, Oregon?",
+5	    "subject_person_ids": [
+6	      "249W-9LP"
+7	    ],
+8	    "status": "active",
+9	    "created": "2026-07-01T00:00:00Z",
+10	    "updated": "2026-07-01T00:00:00Z"
+11	  },
+12	  "researcher_profile": {
+13	    "experience_level": ...
+
+**assistant:** The project is already initialized. No questions yet — routing to `question-selection` first.
+
+**tool_use** `Skill` — args: {"skill": "question-selection"}
+
+**tool_result:** Launching skill: question-selection
+
+**tool_use** `Read` — args: {"file_path": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u/.claude/skills/question-selection/references/question-formulation.md"}
+
+**tool_result:** 1	# Research Question Formulation
+2	
+3	Guidance for formulating effective genealogical research questions
+4	that satisfy the GPS standard for planned, purposeful research.
+5	
+6	## Research Objectives vs. Research Questions
+7	
+8	These are distinct concepts that must not be conflated:
+9	
+10	- **Research objective**: The overarching goal of the research effort.
+11	  It describes what you ultimately want to know (e.g., "Identify the
+12	  parents of John Smith born circa 1820 in Greene County, Ohi...
+
+**tool_use** `Read` — args: {"file_path": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u/.claude/skills/question-selection/references/pedigree-analysis.md"}
+
+**tool_result:** 1	# Pedigree Analysis for Gap Detection
+2	
+3	Guidance for evaluating pedigree data to identify research gaps,
+4	errors, and candidates for new research questions.
+5	
+6	## Purpose
+7	
+8	Pedigree analysis is the process of systematically reviewing the
+9	individuals in a family tree to detect missing information, logical
+10	errors, and inconsistencies. It is a critical first step before
+11	selecting new research questions — it reveals where the gaps are
+12	and which gaps are most significant.
+13	...
+
+**assistant:** **Project state:** Fresh project, no questions yet. Priority 4 fires — decompose the objective into sub-questions, starting with the highest-value gatekeeper.
+
+**Analysis:** William Henry Bottemiller (b. 29 Dec 1862, Chisago Co., MN; d. 13 May 1929, Oregon City, OR). Best gatekeeper record to identify parents directly: his 1929 Oregon death certificate (Oregon vital records began 1903, so it exists) — often names father and mother's maiden name. Census records placing him in his parents' household (1870, 1880) are the corroborating tier. The death certificate comes first as it's the single most likely source to directly state both parents' names.
+
+**tool_use** `ToolSearch` — args: {"query": "select:mcp__genealogy__research_append", "max_results": 1}
+
+**tool_result:** [{"type": "tool_reference", "tool_name": "mcp__genealogy__research_append"}]
+
+**tool_use** `mcp__genealogy__research_append` — args: {"projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u", "section": "questions", "op": "append", "entry": {"question": "What does the death certificate of William Henry Bottemiller (died 13 May 1929, Oregon City, Clackamas County, Oregon) report about his parents?", "rationale": "Oregon death certificates post-1903 routinely name the deceased's father and mother's maiden name. William died in 1929 in Oregon City, so a state death certificate...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"section\": \"questions\",\n  \"op\": \"append\",\n  \"entryId\": \"q_001\",\n  \"filesWritten\": [\n    \"research.json\"\n  ],\n  \"validation\": {\n    \"valid\": true,\n    \"warnings\": []\n  }\n}"}]
+
+**assistant:** **q_001 written.** Now routing to `research-plan`.
+
+**tool_use** `Skill` — args: {"skill": "research-plan"}
+
+**tool_result:** Launching skill: research-plan
+
+**tool_use** `Read` — args: {"file_path": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u/.claude/skills/research-plan/references/planning-standards.md"}
+
+**tool_result:** 1	# BCG Standards for Research Planning (Standards 9-18)
+2	
+3	These ten standards from the Board for Certification of Genealogists
+4	govern how genealogists plan and scope their research. Every research
+5	plan created by this skill should satisfy all applicable standards.
+6	
+7	---
+8	
+9	## Standard 9: Planned Research
+10	
+11	Research begins with and follows a dynamic plan for gathering
+12	information. The plan's purpose is to meet stated objectives, usually
+13	framed as research questions. Hap...
+
+**tool_use** `Read` — args: {"file_path": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u/.claude/skills/research-plan/references/record-type-guide.md"}
+
+**tool_result:** 1	# Record Type Selection Guide
+2	
+3	Use this reference when identifying which record sets to include in a
+4	research plan. Match the research goal to record types, then check the
+5	contextual factors that affect availability.
+6	
+7	---
+8	
+9	## Record types by research goal
+10	
+11	| Goal | Primary record types | Secondary/fallback |
+12	|------|---------------------|-------------------|
+13	| Identify parents | Census (household), vital records (death/birth cert), probate (will), church (baptism...
+
+**assistant:** Conducting locality survey for both Oregon (death certificate) and Minnesota (parents' records).
+
+**tool_use** `ToolSearch` — args: {"query": "select:mcp__genealogy__place_search,mcp__genealogy__collections_search,mcp__genealogy__external_links_search", "max_results": 3}
+
+**tool_result:** [{"type": "tool_reference", "tool_name": "mcp__genealogy__place_search"}, {"type": "tool_reference", "tool_name": "mcp__genealogy__collections_search"}, {"type": "tool_reference", "tool_name": "mcp__genealogy__external_links_search"}]
+
+**tool_use** `mcp__genealogy__place_search` — args: {"placeName": "Clackamas County", "contextName": "Oregon"}
+
+**tool_use** `mcp__genealogy__place_search` — args: {"placeName": "Chisago County", "contextName": "Minnesota"}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"results\": [\n    {\n      \"standardPlace\": \"Clackamas, Oregon, United States\",\n      \"type\": \"County\",\n      \"dateRange\": \"+1843/\",\n      \"latitude\": 45.2497,\n      \"longitude\": -122.1667,\n      \"familysearchUrl\": \"https://www.familysearch.org/en/research/places/?text=Clackamas&focusedId=395920\",\n      \"wikipediaUrl\": \"https://en.wikipedia.org/wiki/Clackamas_County,_Oregon\"\n    },\n    {\n      \"standardPlace\": \"Clackamas, C...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"results\": [\n    {\n      \"standardPlace\": \"Chisago, Minnesota, United States\",\n      \"type\": \"County\",\n      \"dateRange\": \"+1851/\",\n      \"latitude\": 45.50056,\n      \"longitude\": -92.9,\n      \"familysearchUrl\": \"https://www.familysearch.org/en/research/places/?text=Chisago&focusedId=392907\",\n      \"wikipediaUrl\": \"https://en.wikipedia.org/wiki/Chisago_County,_Minnesota\"\n    },\n    {\n      \"standardPlace\": \"Ramsey, Minneso...
+
+**tool_use** `mcp__genealogy__collections_search` — args: {"standardPlace": "Clackamas, Oregon, United States", "startYear": 1900, "endYear": 1940}
+
+**tool_use** `mcp__genealogy__collections_search` — args: {"standardPlace": "Chisago, Minnesota, United States", "startYear": 1860, "endYear": 1885}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"query\": {\n    \"standardPlace\": \"Clackamas, Oregon, United States\",\n    \"startYear\": 1900,\n    \"endYear\": 1940\n  },\n  \"scope\": \"Oregon\",\n  \"totalForPlace\": 44,\n  \"results\": [\n    {\n      \"id\": \"1384963\",\n      \"title\": \"Oregon, Baker County Records, 1862-1950\",\n      \"dateRange\": \"1862-1950\",\n      \"recordCount\": 1990,\n      \"personCount\": 1990,\n      \"imageCount\": 66538,\n      \"url\": \"https://www.familysear...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"query\": {\n    \"standardPlace\": \"Chisago, Minnesota, United States\",\n    \"startYear\": 1860,\n    \"endYear\": 1885\n  },\n  \"scope\": \"Minnesota\",\n  \"totalForPlace\": 46,\n  \"results\": [\n    {\n      \"id\": \"1858352\",\n      \"title\": \"Minnesota, Birth and Death Records, 1866-1916\",\n      \"dateRange\": \"1866-1916\",\n      \"recordCount\": 379392,\n      \"personCount\": 830015,\n      \"imageCount\": 144789,\n      \"url\": \"https:/...
+
+**assistant:** Good collections found. Now checking external links for Oregon before writing the plan.
+
+**tool_use** `mcp__genealogy__external_links_search` — args: {"standardPlace": "Clackamas, Oregon, United States", "startYear": 1920, "endYear": 1935}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"query\": {\n    \"standardPlace\": \"Clackamas, Oregon, United States\",\n    \"startYear\": 1920,\n    \"endYear\": 1935\n  },\n  \"totalForPlace\": 326,\n  \"results\": [\n    {\n      \"url\": \"http://www.myheritage.com/research/collection-30194/oregon-births-christenings-1868-1929?s=218489221\",\n      \"linkText\": \"Free Family Tree and Genealogy Records\"\n    },\n    {\n      \"url\": \"http://www.loc.gov/rr/microform/uscity/or.html\",\n      \"linkT...
+
+**assistant:** Good survey complete. Key resources identified:
+- **FamilySearch**: "Oregon, Oregon State Archives, Death Records, 1864-1968" (coll. 3657650, indexed + images) — primary target
+- **Ancestry**: "Oregon, U.S., State Deaths, 1864-1971" (coll. 61675) — fallback
+- **Ancestry Death Index** Oregon 1898-2008 (coll. 5254)
+- Oregon newspapers at Chronicling America and Historic Oregon Newspapers for 1929 obituary
+- Find A Grave for burial/obituary link
+
+Writing the plan now (pl_001, items pli_001–pli_005):
+
+**tool_use** `mcp__genealogy__research_append` — args: {"projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u", "ops": [{"section": "plans", "op": "append", "entry": {"question_id": "q_001", "status": "active", "created": "2026-07-02"}}, {"section": "plan_items", "op": "append", "planId": "pl_001", "entry": {"sequence": 1, "record_type": "vital_record", "jurisdiction": "Oregon, United States", "date_range": "1929", "repository": "FamilySearch", "rationale": "Oregon state death registration began...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"results\": [\n    {\n      \"section\": \"plans\",\n      \"op\": \"append\",\n      \"entryId\": \"pl_001\"\n    },\n    {\n      \"section\": \"plan_items\",\n      \"op\": \"append\",\n      \"entryId\": \"pli_001\"\n    },\n    {\n      \"section\": \"plan_items\",\n      \"op\": \"append\",\n      \"entryId\": \"pli_002\"\n    },\n    {\n      \"section\": \"plan_items\",\n      \"op\": \"append\",\n      \"entryId\": \"pli_003\"\n    },...
+
+**assistant:** Plan written. Routing to `search-records` to execute pli_001.
+
+**tool_use** `Skill` — args: {"skill": "search-records"}
+
+**tool_result:** Launching skill: search-records
+
+**tool_use** `ToolSearch` — args: {"query": "select:mcp__genealogy__record_search,mcp__genealogy__research_log_append,mcp__genealogy__same_person", "max_results": 3}
+
+**tool_result:** [{"type": "tool_reference", "tool_name": "mcp__genealogy__record_search"}, {"type": "tool_reference", "tool_name": "mcp__genealogy__research_log_append"}, {"type": "tool_reference", "tool_name": "mcp__genealogy__same_person"}]
+
+**tool_use** `Glob` — args: {"pattern": "tree.gedcomx.json", "path": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u"}
+
+**tool_result:** tree.gedcomx.json
+
+**tool_use** `Read` — args: {"file_path": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u/tree.gedcomx.json"}
+
+**tool_result:** 1	{
+2	  "persons": [
+3	    {
+4	      "id": "249W-9LP",
+5	      "gender": "Male",
+6	      "living": false,
+7	      "names": [
+8	        {
+9	          "given": "William Henry",
+10	          "surname": "Bottemiller",
+11	          "id": "249W-9LP-name-1"
+12	        }
+13	      ],
+14	      "facts": [
+15	        {
+16	          "id": "ebe0d4fe-20f8-4dad-b4b8-c69c03d0f100",
+17	          "type": "Birth",
+18	          "date": "29 December 1862",
+19	          "standard_date": "29 Dec 1862",
+20	          ...
+
+**assistant:** Important context from the tree: sources S8VD-92V and S8VD-MGG are already attached — both are index-only entries (Death Index 1903-1998 and "Deaths and Burials 1903-1947"). The **full image** collection (Oregon State Archives, 3657650) hasn't been searched yet. That's pli_001.
+
+Note: Both existing entries index him as "Henry William Battemiller" (name transposed, surname mangled) — I'll search both exact and variant forms.
+
+**tool_use** `mcp__genealogy__record_search` — args: {"surname": "Bottemiller", "givenName": "William", "deathYearFrom": 1927, "deathYearTo": 1931, "deathPlace": "Oregon", "recordType": "death", "collectionId": "3657650", "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u"}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"query\": {\n    \"surname\": \"Bottemiller\",\n    \"givenName\": \"William\",\n    \"deathYearFrom\": 1927,\n    \"deathYearTo\": 1931,\n    \"deathPlace\": \"Oregon\",\n    \"recordType\": \"death\",\n    \"collectionId\": \"3657650\",\n    \"projectPath\": \"/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u\"\n  },\n  \"totalMatches\": 0,\n  \"paginationCappedAt\": 4999,\n  \"returned\": 0,\n  \"offset\": 0,\n  \"has...
+
+**assistant:** Zero hits — expected given the existing index entries show "Battemiller." Trying that variant now.
+
+**tool_use** `mcp__genealogy__record_search` — args: {"surname": "Battemiller", "givenName": "Henry", "deathYearFrom": 1927, "deathYearTo": 1931, "deathPlace": "Oregon", "recordType": "death", "collectionId": "3657650", "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u"}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"query\": {\n    \"surname\": \"Battemiller\",\n    \"givenName\": \"Henry\",\n    \"deathYearFrom\": 1927,\n    \"deathYearTo\": 1931,\n    \"deathPlace\": \"Oregon\",\n    \"recordType\": \"death\",\n    \"collectionId\": \"3657650\",\n    \"projectPath\": \"/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u\"\n  },\n  \"totalMatches\": 4,\n  \"paginationCappedAt\": 4999,\n  \"returned\": 4,\n  \"offset\": 0,\n  \"hasMo...
+
+**assistant:** No relevant matches in collection 3657650. The existing tree sources show the record is indexed as "Henry William Battemiller" — the collection clearly doesn't have it indexed well. Let me log this nil and then try broader variants including reading the existing index entry directly.
+
+Log the first nil, then try without collection filter and with death year only:
+
+**tool_use** `mcp__genealogy__research_log_append` — args: {"projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u", "tool": "record_search", "planItemId": "pli_001", "query": {"surname": "Bottemiller", "givenName": "William", "deathYearFrom": 1927, "deathYearTo": 1931, "deathPlace": "Oregon", "recordType": "death", "collectionId": "3657650"}, "outcome": "negative", "resultsExamined": 0, "resultsAvailable": 0, "notes": "Zero hits for Bottemiller/William in Oregon State Archives Death Records (coll. 3...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"logId\": \"log_001\",\n  \"performed\": \"2026-07-02T13:28:45.471Z\",\n  \"resultsRef\": null,\n  \"returnedCount\": null,\n  \"filesWritten\": [\n    \"research.json\"\n  ],\n  \"validation\": {\n    \"valid\": true,\n    \"warnings\": []\n  }\n}"}]
+
+**assistant:** Now try "Battemiller" broadly in collection 3657650 (drop given name to max recall):
+
+**tool_use** `mcp__genealogy__record_search` — args: {"surname": "Battemiller", "deathYearFrom": 1928, "deathYearTo": 1930, "collectionId": "3657650", "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u"}
+
+**tool_result:** Error: result (103,571 characters across 3,344 lines) exceeds maximum allowed tokens. Output has been saved to /Users/ernest/.claude/projects/-private-var-folders-g7-zn65fvrn5g9-g71-sp0lk82h0000gn-T-e2e-bottemiller-parents-91t9zm2u/6b6fa77e-a98a-4d4b-88f2-5c7d037177be/tool-results/mcp-genealogy-record_search-1782998933101.txt.
+Format: Plain text
+- For targeted searches (find a line, locate a string): use grep on the file directly.
+- For analysis or summarization that requires reading the full...
+
+**tool_use** `Agent` — args: {"description": "Read record_search results for Battemiller deaths", "prompt": "Read the file at /Users/ernest/.claude/projects/-private-var-folders-g7-zn65fvrn5g9-g71-sp0lk82h0000gn-T-e2e-bottemiller-parents-91t9zm2u/6b6fa77e-a98a-4d4b-88f2-5c7d037117be/tool-results/mcp-genealogy-record_search-1782998933101.txt in chunks of ~250 lines using offset/limit until you have read all of it.\n\nThe file is a JSON payload from a FamilySearch record_search. I'm looking for a record matching:\n- Subjec...
+
+**tool_use** `Read` — args: {"file_path": "/Users/ernest/.claude/projects/-private-var-folders-g7-zn65fvrn5g9-g71-sp0lk82h0000gn-T-e2e-bottemiller-parents-91t9zm2u/6b6fa77e-a98a-4d4b-88f2-5c7d037117be/tool-results/mcp-genealogy-record_search-1782998933101.txt", "limit": 250, "offset": 0}
+
+**tool_result:** File does not exist. Note: your current working directory is /private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u.
+
+**tool_use** `Glob` — args: {"pattern": "**/mcp-genealogy-record_search-1782998933101.txt"}
+
+**tool_result:** No files found
+
+**tool_use** `Bash` — args: {"command": "ls /Users/ernest/.claude/projects/-private-var-folders-g7-zn65fvrn5g9-g71-sp0lk82h0000gn-T-e2e-bottemiller-parents-91t9zm2u/6b6fa77e-a98a-4d4b-88f2-5c7d037117be/tool-results/ 2>&1 | head -30", "description": "List tool-results directory"}
+
+**tool_result:** ls: /Users/ernest/.claude/projects/-private-var-folders-g7-zn65fvrn5g9-g71-sp0lk82h0000gn-T-e2e-bottemiller-parents-91t9zm2u/6b6fa77e-a98a-4d4b-88f2-5c7d037117be/tool-results/: No such file or directory
+
+**tool_use** `Bash` — args: {"command": "ls /Users/ernest/.claude/projects/ 2>&1 | head -20", "description": "List projects directory"}
+
+**tool_result:** Permission to use Bash has been denied because Claude Code is running in don't ask mode. IMPORTANT: You *may* attempt to accomplish this action using other tools that might naturally be used to accomplish this goal, e.g. using head instead of cat. But you *should not* attempt to work around this denial in malicious ways, e.g. do not use your ability to run tests to execute non-test actions. You should only try to work around this restriction in reasonable ways that do not attempt to bypass th...
+
+**tool_use** `Glob` — args: {"pattern": "/Users/ernest/.claude/projects/**/*1782998933101*"}
+
+**tool_result:** /Users/ernest/.claude/projects/-private-var-folders-g7-zn65fvrn5g9-g71-sp0lk82h0000gn-T-e2e-bottemiller-parents-91t9zm2u/6b6fa77e-a98a-4d4b-88f2-5c7d037177be/tool-results/mcp-genealogy-record_search-1782998933101.txt
+
+**tool_use** `Read` — args: {"file_path": "/Users/ernest/.claude/projects/-private-var-folders-g7-zn65fvrn5g9-g71-sp0lk82h0000gn-T-e2e-bottemiller-parents-91t9zm2u/6b6fa77e-a98a-4d4b-88f2-5c7d037177be/tool-results/mcp-genealogy-record_search-1782998933101.txt", "limit": 250, "offset": 0}
+
+**tool_result:** 0	{
+1	  "query": {
+2	    "surname": "Battemiller",
+3	    "deathYearFrom": 1928,
+4	    "deathYearTo": 1930,
+5	    "collectionId": "3657650",
+6	    "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u"
+7	  },
+8	  "totalMatches": 43,
+9	  "paginationCappedAt": 4999,
+10	  "returned": 20,
+11	  "offset": 0,
+12	  "hasMore": true,
+13	  "results": [
+14	    {
+15	      "recordId": "ark:/61903/1:1:CLGL-8F6Z",
+16	      "events": [
+17	        {
+18	       ...
+
+**tool_use** `Read` — args: {"file_path": "/Users/ernest/.claude/projects/-private-var-folders-g7-zn65fvrn5g9-g71-sp0lk82h0000gn-T-e2e-bottemiller-parents-91t9zm2u/6b6fa77e-a98a-4d4b-88f2-5c7d037177be/tool-results/mcp-genealogy-record_search-1782998933101.txt", "limit": 250, "offset": 250}
+
+**tool_result:** 250	              }
+251	            ],
+252	            "sources": [
+253	              {
+254	                "ref": "sd_da1"
+255	              }
+256	            ]
+257	          },
+258	          {
+259	            "id": "p_232180553500",
+260	            "ark": "ark:/61903/1:1:ZVXG-KGPZ",
+261	            "gender": "Male",
+262	            "names": [
+263	              {
+264	                "type": "BirthName",
+265	                "surname": "Kitsmiller",
+266	                "given": "Leo Halbert"
+2...
+
+**tool_use** `Read` — args: {"file_path": "/Users/ernest/.claude/projects/-private-var-folders-g7-zn65fvrn5g9-g71-sp0lk82h0000gn-T-e2e-bottemiller-parents-91t9zm2u/6b6fa77e-a98a-4d4b-88f2-5c7d037177be/tool-results/mcp-genealogy-record_search-1782998933101.txt", "limit": 250, "offset": 500}
+
+**tool_result:** 500	              }
+501	            ],
+502	            "sources": [
+503	              {
+504	                "ref": "sd_da1"
+505	              }
+506	            ]
+507	          }
+508	        ],
+509	        "relationships": [
+510	          {
+511	            "type": "ParentChild",
+512	            "parent": "p_232180553600",
+513	            "child": "p_232180553500"
+514	          },
+515	          {
+516	            "type": "ParentChild",
+517	            "parent": "p_232180553700",
+518	            ...
+
+**tool_use** `Read` — args: {"file_path": "/Users/ernest/.claude/projects/-private-var-folders-g7-zn65fvrn5g9-g71-sp0lk82h0000gn-T-e2e-bottemiller-parents-91t9zm2u/6b6fa77e-a98a-4d4b-88f2-5c7d037177be/tool-results/mcp-genealogy-record_search-1782998933101.txt", "limit": 250, "offset": 750}
+
+**tool_result:** 750	      "score": 1.0710801,
+751	      "confidence": 1,
+752	      "sex": "Male",
+753	      "collectionId": "3657650",
+754	      "collectionTitle": "Oregon, Oregon State Archives, Death Records, 1864-1968",
+755	      "collectionUrl": "https://www.familysearch.org/service/cds/recapi/collections/3657650",
+756	      "recordTitle": "Entry for Anna Elizabeth Hampson, \"Oregon, Oregon State Archives, Death Records, 1864-1967\"",
+757	      "recordArk": "ark:/61903/1:2:4MYT-6G3Z",
+758	      "gedcomx"...
+
+**tool_use** `Grep` — args: {"pattern": "ottemiller|attemiller", "path": "/Users/ernest/.claude/projects/-private-var-folders-g7-zn65fvrn5g9-g71-sp0lk82h0000gn-T-e2e-bottemiller-parents-91t9zm2u/6b6fa77e-a98a-4d4b-88f2-5c7d037177be/tool-results/mcp-genealogy-record_search-1782998933101.txt", "output_mode": "content", "context": 5, "head_limit": 0}
+
+**tool_result:** 1-{
+2-  "query": {
+3:    "surname": "Battemiller",
+4-    "deathYearFrom": 1928,
+5-    "deathYearTo": 1930,
+6-    "collectionId": "3657650",
+7:    "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u"
+8-  },
+9-  "totalMatches": 43,
+10-  "paginationCappedAt": 4999,
+11-  "returned": 20,
+12-  "offset": 0,
+
+**tool_use** `Grep` — args: {"pattern": "staged", "path": "/Users/ernest/.claude/projects/-private-var-folders-g7-zn65fvrn5g9-g71-sp0lk82h0000gn-T-e2e-bottemiller-parents-91t9zm2u/6b6fa77e-a98a-4d4b-88f2-5c7d037177be/tool-results/mcp-genealogy-record_search-1782998933101.txt", "output_mode": "content", "context": 3, "head_limit": 0}
+
+**tool_result:** 3337-      "primaryId": "p_212313697500"
+3338-    }
+3339-  ],
+3340:  "staged": {
+3341-    "resultsRef": "results/.staging/49e5435d-22a6-482d-8e38-259c98543044.json",
+3342-    "returnedCount": 20
+3343-  }
+
+**tool_use** `Read` — args: {"file_path": "/Users/ernest/.claude/projects/-private-var-folders-g7-zn65fvrn5g9-g71-sp0lk82h0000gn-T-e2e-bottemiller-parents-91t9zm2u/6b6fa77e-a98a-4d4b-88f2-5c7d037177be/tool-results/mcp-genealogy-record_search-1782998933101.txt", "limit": 10, "offset": 3335}
+
+**tool_result:** 3335	        ]
+3336	      },
+3337	      "primaryId": "p_212313697500"
+3338	    }
+3339	  ],
+3340	  "staged": {
+3341	    "resultsRef": "results/.staging/49e5435d-22a6-482d-8e38-259c98543044.json",
+3342	    "returnedCount": 20
+3343	  }
+3344	}
+
+**tool_result:** [{"type": "text", "text": "Here is the full report:\n\n---\n\n**staged.resultsRef:** `results/.staging/49e5435d-22a6-482d-8e38-259c98543044.json`\n\n**totalMatches:** 43 (20 returned in this page, offset 0, hasMore: true)\n\n**Results containing \"Bottemiller\" or \"Battemiller\":** None. The search queried surname \"Battemiller\" in collection 3657650 (Oregon State Archives Death Records, 1864-1968), but not one of the 20 returned results has a `personName` containing \"Bottemiller\" or \"Ba...
+
+**assistant:** The collection 3657650 isn't returning the target in indexed form. Let me take a different approach: use `record_read` directly on the two death records already attached to the tree — specifically the "Oregon, Deaths and Burials, 1903-1947" index entry (ark:/61903/1:1:F8WM-X8F), which may link to the underlying image.
+
+**tool_use** `ToolSearch` — args: {"query": "select:mcp__genealogy__record_read", "max_results": 1}
+
+**tool_result:** [{"type": "tool_reference", "tool_name": "mcp__genealogy__record_read"}]
+
+**assistant:** Reading both existing death records in parallel to see what parental data they contain:
+
+**tool_use** `mcp__genealogy__record_read` — args: {"recordId": "ark:/61903/1:1:F8WM-X8F"}
+
+**tool_use** `mcp__genealogy__record_read` — args: {"recordId": "ark:/61903/1:1:VZHS-YXF"}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"persons\": [\n    {\n      \"id\": \"p_11207172945\",\n      \"ark\": \"ark:/61903/1:1:F8WM-X8F\",\n      \"gender\": \"Male\",\n      \"names\": [\n        {\n          \"type\": \"BirthName\",\n          \"given\": \"Henry William\",\n          \"surname\": \"Battemiller\"\n        }\n      ],\n      \"facts\": [\n        {\n          \"type\": \"Death\",\n          \"primary\": true,\n          \"date\": \"13 May 1929\",\n          \"standard_date\": \"13 ...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"persons\": [\n    {\n      \"id\": \"p_13371558735\",\n      \"ark\": \"ark:/61903/1:1:VZHS-YXF\",\n      \"names\": [\n        {\n          \"id\": \"11faed09-dbbd-4e0d-8ec4-eb6476e08735\",\n          \"type\": \"BirthName\",\n          \"given\": \"Henry William\",\n          \"surname\": \"Battemiller\"\n        }\n      ],\n      \"facts\": [\n        {\n          \"id\": \"cbc2ddb2-4c71-44a4-8f4f-61ad1b609d0d\",\n          \"type\": \"Death\",\n         ...
+
+**assistant:** **Major finding from `record_read` on the "Oregon, Deaths and Burials, 1903-1947" abstract:**
+
+The death record names:
+- **Father: Casper A. Battermiller**
+- **Mother: Mary Mehlman** (mother's maiden name)
+
+This directly answers q_001. Now logging all searches and updating pli_001 status.
+
+First log the "Battemiller/Henry" search (4 hits, all mismatches) and the broad search, then the positive record_reads:
+
+**tool_use** `mcp__genealogy__research_log_append` — args: {"projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u", "tool": "record_search", "planItemId": "pli_001", "query": {"surname": "Battemiller", "givenName": "Henry", "deathYearFrom": 1927, "deathYearTo": 1931, "deathPlace": "Oregon", "recordType": "death", "collectionId": "3657650"}, "outcome": "negative", "resultsExamined": 4, "resultsAvailable": 4, "stagedResultsRef": "results/.staging/479192fc-5744-401e-9379-c85fb3d336f8.json", "notes": "4...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"logId\": \"log_002\",\n  \"performed\": \"2026-07-02T13:31:44.172Z\",\n  \"resultsRef\": \"results/log_002.json\",\n  \"returnedCount\": 4,\n  \"filesWritten\": [\n    \"research.json\",\n    \"results/log_002.json\"\n  ],\n  \"validation\": {\n    \"valid\": true,\n    \"warnings\": []\n  }\n}"}]
+
+**assistant:** Now log the broad "Battemiller" surname search in 3657650:
+
+**tool_use** `mcp__genealogy__research_log_append` — args: {"projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u", "tool": "record_search", "planItemId": "pli_001", "query": {"surname": "Battemiller", "deathYearFrom": 1928, "deathYearTo": 1930, "collectionId": "3657650"}, "outcome": "negative", "resultsExamined": 20, "resultsAvailable": 43, "stagedResultsRef": "results/.staging/49e5435d-22a6-482d-8e38-259c98543044.json", "notes": "43 total matches, 20 examined \u2014 all phonetic near-misses (Kitzm...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"logId\": \"log_003\",\n  \"performed\": \"2026-07-02T13:31:53.242Z\",\n  \"resultsRef\": \"results/log_003.json\",\n  \"returnedCount\": 20,\n  \"filesWritten\": [\n    \"research.json\",\n    \"results/log_003.json\"\n  ],\n  \"validation\": {\n    \"valid\": true,\n    \"warnings\": []\n  }\n}"}]
+
+**assistant:** Now log the positive finding from `record_read` on the existing death-record abstract:
+
+**tool_use** `mcp__genealogy__research_log_append` — args: {"projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u", "tool": "record_search", "planItemId": "pli_001", "query": {"tool": "record_read", "recordId": "ark:/61903/1:1:F8WM-X8F", "collection": "Oregon, Deaths and Burials, 1903-1947", "collectionId": "1675532", "note": "Reading existing source S8VD-MGG already attached to tree person 249W-9LP"}, "outcome": "positive", "resultsExamined": 1, "resultsAvailable": 1, "notes": "record_read of ark:/...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"logId\": \"log_004\",\n  \"performed\": \"2026-07-02T13:32:20.759Z\",\n  \"resultsRef\": null,\n  \"returnedCount\": null,\n  \"filesWritten\": [\n    \"research.json\"\n  ],\n  \"validation\": {\n    \"valid\": true,\n    \"warnings\": []\n  }\n}"}]
+
+**assistant:** Now update pli_001 to in_progress:
+
+**tool_use** `mcp__genealogy__research_append` — args: {"projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u", "section": "plan_items", "op": "update", "planId": "pl_001", "entryId": "pli_001", "fields": {"status": "in_progress"}}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"section\": \"plan_items\",\n  \"op\": \"update\",\n  \"entryId\": \"pli_001\",\n  \"filesWritten\": [\n    \"research.json\"\n  ],\n  \"validation\": {\n    \"valid\": true,\n    \"warnings\": []\n  }\n}"}]
+
+**assistant:** Checking if the image ARK (1:2) yields more certificate detail:
+
+**tool_use** `mcp__genealogy__record_read` — args: {"recordId": "ark:/61903/1:2:MYQR-859"}
+
+**tool_result:** {"error":"Record MYQR-859 was not found in FamilySearch historical records."}
+
+**assistant:** Image ARK not accessible via record_read — that's fine, the abstract already provided the parent names. Routing to `record-extraction` with:
+
+- **Record:** "Oregon, Deaths and Burials, 1903-1947," ark:/61903/1:1:F8WM-X8F
+- **Subject:** Henry William Battemiller = William Henry Bottemiller (249W-9LP)
+- **Father named:** Casper A. Battermiller (ark:/61903/1:1:F8WM-X8N)
+- **Mother named:** Mary Mehlman (ark:/61903/1:1:F8WM-X8J)
+- **Log entry:** log_004
+
+**tool_use** `Skill` — args: {"skill": "record-extraction"}
+
+**tool_result:** Launching skill: record-extraction
+
+**assistant:** The record_read of `ark:/61903/1:1:F8WM-X8F` returned clean structured data. From this "Oregon, Deaths and Burials, 1903-1947" abstract:
+
+- **Deceased:** Henry William Battemiller (=William Henry Bottemiller, 249W-9LP)  
+- **Father:** Casper A. Battermiller (p_11207172946)  
+- **Mother:** Mary Mehlman (p_11207172947) — maiden name  
+- **Wife:** Lilly Jane (p_11207172948) — corroborates known spouse  
+- **Death:** 13 May 1929, Clackamas, Oregon ✓  
+- **Birth:** 1862 ✓  
+
+**Source:** derivative (database abstract; collection 1675532 has no images). GedcomX source description S8VD-MGG already exists in tree.gedcomx.json — no tree_edit needed.
+
+**Sibling stub check:** Subject's role is `deceased` (not `child_N` in a household record) — sibling stub rule does not apply.
+
+**Source ID to predict:** `research.json` has empty `sources[]` → src_001.
+
+Persisting source + 8 assertions in one batch:
+
+**tool_use** `mcp__genealogy__research_append` — args: {"projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u", "ops": [{"section": "sources", "op": "append", "entry": {"gedcomx_source_description_id": "S8VD-MGG", "citation": "\"Oregon, Deaths and Burials, 1903\u20131947,\" database, FamilySearch (https://www.familysearch.org/ark:/61903/1:1:F8WM-X8F : accessed 2 July 2026), entry for Henry William Battemiller, died 13 May 1929, Clackamas, Oregon; citing Oregon Vital Records.", "citation_detail":...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": false,\n  \"errors\": [\n    \"research.json/assertions[0]: has record_persona_id but its log entry 'log_004' has no sidecar (results_ref is null)\",\n    \"research.json/assertions[1]: has record_persona_id but its log entry 'log_004' has no sidecar (results_ref is null)\",\n    \"research.json/assertions[2]: has record_persona_id but its log entry 'log_004' has no sidecar (results_ref is null)\",\n    \"research.json/assertions[3]: has record_persona_...
+
+**assistant:** Validation error: assertions with `record_persona_id` require the log entry to have a sidecar, but log_004 was a `record_read` (no staged ref → no sidecar). Fix: set all `record_persona_id` to `null` since this is a `record_read` source.
+
+**tool_use** `mcp__genealogy__research_append` — args: {"projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u", "ops": [{"section": "sources", "op": "append", "entry": {"gedcomx_source_description_id": "S8VD-MGG", "citation": "\"Oregon, Deaths and Burials, 1903\u20131947,\" database, FamilySearch (https://www.familysearch.org/ark:/61903/1:1:F8WM-X8F : accessed 2 July 2026), entry for Henry William Battemiller, died 13 May 1929, Clackamas, Oregon; citing Oregon Vital Records.", "citation_detail":...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"results\": [\n    {\n      \"section\": \"sources\",\n      \"op\": \"append\",\n      \"entryId\": \"src_001\"\n    },\n    {\n      \"section\": \"assertions\",\n      \"op\": \"append\",\n      \"entryId\": \"a_001\"\n    },\n    {\n      \"section\": \"assertions\",\n      \"op\": \"append\",\n      \"entryId\": \"a_002\"\n    },\n    {\n      \"section\": \"assertions\",\n      \"op\": \"append\",\n      \"entryId\": \"a_003\"\n    },\n ...
+
+**assistant:** All written — src_001 + a_001 through a_008. Returning to the orchestrator for the next routing step.
+
+**Extraction summary:**
+
+| ID | Role | Fact | Value | Qual | Proximity | Evidence |
+|----|------|------|-------|------|-----------|---------|
+| a_001 | deceased | name | Henry William Battemiller | primary | family_not_present | direct |
+| a_002 | deceased | death | 13 May 1929, Clackamas OR | primary | official_duty | direct |
+| a_003 | deceased | birth | 1862 | secondary | family_not_present | direct |
+| a_004 | deceased | relationship | father = Casper A. Battermiller | secondary | family_not_present | **indirect** |
+| a_005 | deceased | relationship | mother = Mary Mehlman | secondary | family_not_present | **indirect** |
+| a_006 | father_of_deceased | name | Casper A. Battermiller | secondary | family_not_present | direct |
+| a_007 | mother_of_deceased | name | Mary Mehlman | secondary | family_not_present | direct |
+| a_008 | wife | name | Lilly Jane | primary | unknown | direct |
+
+**[HARNESS]** continue-nudge 1/5: agent yielded before project.status=='completed'; instructing it to resume the loop.
+
+**tool_use** `Skill` — args: {"skill": "assertion-classification"}
+
+**tool_result:** Launching skill: assertion-classification
+
+**tool_use** `Read` — args: {"file_path": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u/.claude/skills/assertion-classification/references/three-layer-model.md"}
+
+**tool_result:** 1	# The Three-Layer Classification Model
+2	
+3	## Core Principle: Independence of Layers
+4	
+5	The three layers -- source, information, and evidence -- are evaluated
+6	independently. The classification at one layer does NOT determine the
+7	classification at another. An original source can contain secondary
+8	information. A derivative source can provide direct evidence. Each
+9	layer operates on its own terms.
+10	
+11	---
+12	
+13	## Layer 1: Source Classification
+14	
+15	Source classification addres...
+
+**assistant:** **Classifying all 8 assertions.** Layer 1 (source=derivative) is read-only. Analyzing Layers 2 and 3 for each:
+
+**a_001 (deceased, name):** Informant = "unknown personal informant" — decision tree: Do we know who? **No → indeterminate.** Current `primary` is wrong. → change to `indeterminate`.
+
+**a_002 (deceased, death date/place):** Attending physician/county registrar. For death date/cause, the standard informant is the attending physician who *witnessed* the death → proximity = **witness**, not `official_duty`. `primary` stays. `direct` stays.
+
+**a_003 (deceased, birth 1862):** No possible informant (the surviving spouse or any family member) had first-hand knowledge of a birth in 1862 Minnesota — they weren't there. Even without knowing the specific informant, this must be **secondary** (hard rule exception). Current `secondary` is correct. ✓
+
+**a_004 (deceased, rel → father):** evidence_type `indirect` is wrong. Per the skill example: "Father: Thomas Flynn" on a death certificate → evidence_type = **direct** (the certificate explicitly names the father; no inference needed to answer "what does the certificate say?"). Changing to `direct`. information_quality `secondary` correct ✓ (no one could have witnessed the 1862 parent-child relationship formation).
+
+**a_005 (deceased, rel → mother):** Same reasoning as a_004. evidence_type `indirect` → **direct**.
+
+**a_006 (father_of_deceased, name "Casper A. Battermiller"):** `secondary` ✓ (informant reported from knowledge, not witness). `direct` ✓ (name explicitly stated).
+
+**a_007 (mother_of_deceased, name "Mary Mehlman"):** `secondary` ✓. `direct` ✓.
+
+**a_008 (wife, name "Lilly Jane"):** Informant unknown → decision tree: No → **indeterminate.** Current `primary` is wrong.
+
+**Evidence independence (GPS Standard 4):** a_003 through a_007 all derive from the same unknown personal informant on this record — they form a single evidence unit for parentage and birth facts.
+
+Writing the 5 updates:
+
+**tool_use** `mcp__genealogy__research_append` — args: {"projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u", "ops": [{"section": "assertions", "op": "update", "entryId": "a_001", "fields": {"information_quality": "indeterminate", "informant_bias_notes": "Informant identity unknown from this database abstract; the specific person who registered the death and provided the deceased's name cannot be determined without the original certificate."}}, {"section": "assertions", "op": "update", "entryI...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"results\": [\n    {\n      \"section\": \"assertions\",\n      \"op\": \"update\",\n      \"entryId\": \"a_001\"\n    },\n    {\n      \"section\": \"assertions\",\n      \"op\": \"update\",\n      \"entryId\": \"a_002\"\n    },\n    {\n      \"section\": \"assertions\",\n      \"op\": \"update\",\n      \"entryId\": \"a_004\"\n    },\n    {\n      \"section\": \"assertions\",\n      \"op\": \"update\",\n      \"entryId\": \"a_005\"\n    },\n...
+
+**assistant:** Classifications refined. Routing to `person-evidence`.
+
+**tool_use** `Skill` — args: {"skill": "person-evidence"}
+
+**tool_result:** Launching skill: person-evidence
+
+**tool_use** `ToolSearch` — args: {"query": "select:mcp__genealogy__tree_edit,mcp__genealogy__research_append", "max_results": 2}
+
+**tool_result:** [{"type": "tool_reference", "tool_name": "mcp__genealogy__tree_edit"}, {"type": "tool_reference", "tool_name": "mcp__genealogy__research_append"}]
+
+**tool_use** `Read` — args: {"file_path": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u/research.json"}
+
+**tool_result:** 1	{
+2	  "project": {
+3	    "id": "rp_bottemiller_parents",
+4	    "objective": "Who were the parents of William Henry Bottemiller, born 29 December 1862 in Franconia Township, Chisago County, Minnesota, and died 13 May 1929 in Oregon City, Clackamas County, Oregon?",
+5	    "subject_person_ids": [
+6	      "249W-9LP"
+7	    ],
+8	    "status": "active",
+9	    "created": "2026-07-01T00:00:00Z",
+10	    "updated": "2026-07-01T00:00:00Z"
+11	  },
+12	  "researcher_profile": {
+13	    "experience_level": ...
+
+**tool_use** `Read` — args: {"file_path": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u/tree.gedcomx.json"}
+
+**tool_result:** 1	{
+2	  "persons": [
+3	    {
+4	      "id": "249W-9LP",
+5	      "gender": "Male",
+6	      "living": false,
+7	      "names": [
+8	        {
+9	          "given": "William Henry",
+10	          "surname": "Bottemiller",
+11	          "id": "249W-9LP-name-1"
+12	        }
+13	      ],
+14	      "facts": [
+15	        {
+16	          "id": "ebe0d4fe-20f8-4dad-b4b8-c69c03d0f100",
+17	          "type": "Birth",
+18	          "date": "29 December 1862",
+19	          "standard_date": "29 Dec 1862",
+20	          ...
+
+**assistant:** Now I'll create the two parent stubs in tree.gedcomx.json plus the ParentChild relationships, all in one batched call.
+
+**tool_use** `mcp__genealogy__tree_edit` — args: {"projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u", "ops": [{"operation": "add_person", "person": {"gender": "Male", "names": [{"given": "Casper A.", "surname": "Bottemiller", "preferred": true}]}}, {"operation": "add_person", "person": {"gender": "Female", "names": [{"given": "Mary", "surname": "Mehlman", "preferred": true}]}}]}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"results\": [\n    {\n      \"operation\": \"add_person\",\n      \"assignedIds\": {\n        \"person\": \"I1\",\n        \"names\": [\n          \"N1\"\n        ]\n      }\n    },\n    {\n      \"operation\": \"add_person\",\n      \"assignedIds\": {\n        \"person\": \"I2\",\n        \"names\": [\n          \"N2\"\n        ]\n      }\n    }\n  ],\n  \"filesWritten\": [\n    \"tree.gedcomx.json\"\n  ],\n  \"validation\": {\n    \"valid\":...
+
+**assistant:** Stubs created: I1 = Casper A. Bottemiller, I2 = Mary Mehlman. Now add the parent-child relationships.
+
+**tool_use** `mcp__genealogy__tree_edit` — args: {"projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u", "ops": [{"operation": "add_relationship", "relationship": {"type": "ParentChild", "parent": "I1", "child": "249W-9LP", "subtype": "Biological"}}, {"operation": "add_relationship", "relationship": {"type": "ParentChild", "parent": "I2", "child": "249W-9LP", "subtype": "Biological"}}]}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"results\": [\n    {\n      \"operation\": \"add_relationship\",\n      \"assignedIds\": {\n        \"relationship\": \"R1\"\n      }\n    },\n    {\n      \"operation\": \"add_relationship\",\n      \"assignedIds\": {\n        \"relationship\": \"R2\"\n      }\n    }\n  ],\n  \"filesWritten\": [\n    \"tree.gedcomx.json\"\n  ],\n  \"validation\": {\n    \"valid\": true,\n    \"warnings\": []\n  }\n}"}]
+
+**assistant:** Now I'll batch all 10 person-evidence links in one call.
+
+**tool_use** `mcp__genealogy__research_append` — args: {"projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u", "ops": [{"section": "person_evidence", "op": "append", "entry": {"assertion_id": "a_001", "person_id": "249W-9LP", "confidence": "confident", "match_score": null, "rationale": "Record names the deceased 'Henry William Battemiller', death 13 May 1929, Clackamas, Oregon, birth year 1862. Tree person 249W-9LP (William Henry Bottemiller) has matching death date and place (13 May 1929, Oreg...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"results\": [\n    {\n      \"section\": \"person_evidence\",\n      \"op\": \"append\",\n      \"entryId\": \"pe_001\"\n    },\n    {\n      \"section\": \"person_evidence\",\n      \"op\": \"append\",\n      \"entryId\": \"pe_002\"\n    },\n    {\n      \"section\": \"person_evidence\",\n      \"op\": \"append\",\n      \"entryId\": \"pe_003\"\n    },\n    {\n      \"section\": \"person_evidence\",\n      \"op\": \"append\",\n      \"entryId...
+
+**tool_use** `Glob` — args: {"pattern": ".claude/skills/*/skill.md", "path": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u"}
+
+**tool_result:** No files found
+
+**tool_use** `Glob` — args: {"pattern": ".claude/skills/**/*.md", "path": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u"}
+
+**tool_result:** .claude/skills/assertion-classification/references/three-layer-model.md
+.claude/skills/assertion-classification/references/validation-protocol.md
+.claude/skills/check-warnings/SKILL.md
+.claude/skills/check-warnings/references/assumption-categories.md
+.claude/skills/check-warnings/references/warning-checks.md
+.claude/skills/check-warnings/references/warnings-as-identity-signals.md
+.claude/skills/citation/references/gps-citation-standards.md
+.claude/skills/citation/references/validation-protoco...
+
+**tool_use** `Read` — args: {"file_path": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u/.claude/skills/research-exhaustiveness/SKILL.md"}
+
+**tool_result:** 1	---
+2	name: research-exhaustiveness
+3	model: claude-sonnet-4-6
+4	description: Evaluates whether research on a question is reasonably
+5	  exhaustive — applies the five threshold questions and the 7-point
+6	  stop criteria, then either writes the exhaustive_declaration on the
+7	  question or explains what's missing. GPS Step 1 — Reasonably
+8	  Exhaustive Research. Use when the user says "is this research
+9	  exhaustive?", "are we done?", "have we searched enough?", "can we
+10	  declare exhaus...
+
+**tool_use** `Read` — args: {"file_path": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u/.claude/skills/research-exhaustiveness/references/research-exhaustiveness.md"}
+
+**tool_result:** 1	# Exhaustiveness Evaluation
+2	
+3	Guidance for determining when research on a question qualifies as
+4	"reasonably exhaustive" under GPS Component 1.
+5	
+6	## What "Reasonably Exhaustive" Means
+7	
+8	Reasonably exhaustive research is systematic investigation that
+9	searches all available and relevant sources — not just the ones
+10	that are easiest to access or most popular. The standard requires
+11	looking broadly across record types, repositories, and time periods
+12	to ensure no significant s...
+
+**assistant:** Now I'll update all plan item statuses — pli_001 to `completed` (record extracted), the fallbacks pli_002/003 and supplementary pli_004/005 to `skipped`.
+
+**tool_use** `mcp__genealogy__research_append` — args: {"projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u", "ops": [{"section": "plan_items", "op": "update", "planId": "pl_001", "entryId": "pli_001", "fields": {"status": "completed"}}, {"section": "plan_items", "op": "update", "planId": "pl_001", "entryId": "pli_002", "fields": {"status": "skipped"}}, {"section": "plan_items", "op": "update", "planId": "pl_001", "entryId": "pli_003", "fields": {"status": "skipped"}}, {"section": "plan_items"...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"results\": [\n    {\n      \"section\": \"plan_items\",\n      \"op\": \"update\",\n      \"entryId\": \"pli_001\"\n    },\n    {\n      \"section\": \"plan_items\",\n      \"op\": \"update\",\n      \"entryId\": \"pli_002\"\n    },\n    {\n      \"section\": \"plan_items\",\n      \"op\": \"update\",\n      \"entryId\": \"pli_003\"\n    },\n    {\n      \"section\": \"plan_items\",\n      \"op\": \"update\",\n      \"entryId\": \"pli_004\"\n...
+
+**assistant:** Good. Now invoking the gps-mentor for the pre-exhaustiveness checkpoint.
+
+**tool_use** `Agent` — args: {"description": "GPS mentor pre-exhaustiveness review for q_001", "subagent_type": "gps-mentor", "prompt": "You are the gps-mentor agent. Please perform a pre-exhaustiveness checkpoint review for question q_001 in the project at /private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u.\n\nContext: This is a /research autonomous session. All plan items for q_001 have been marked completed or skipped. The research gathered one derivative source \u2014 the Family...
+
+**tool_use** `Read` — args: {"file_path": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u/research.json"}
+
+**tool_result:** 1	{
+2	  "project": {
+3	    "id": "rp_bottemiller_parents",
+4	    "objective": "Who were the parents of William Henry Bottemiller, born 29 December 1862 in Franconia Township, Chisago County, Minnesota, and died 13 May 1929 in Oregon City, Clackamas County, Oregon?",
+5	    "subject_person_ids": [
+6	      "249W-9LP"
+7	    ],
+8	    "status": "active",
+9	    "created": "2026-07-01T00:00:00Z",
+10	    "updated": "2026-07-01T00:00:00Z"
+11	  },
+12	  "researcher_profile": {
+13	    "experience_level": ...
+
+**tool_use** `Read` — args: {"file_path": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u/results/log_002.json"}
+
+**tool_result:** 1	{
+2	  "log_id": "log_002",
+3	  "tool": "record_search",
+4	  "retrieved": "2026-07-02T13:28:14.125Z",
+5	  "returned_count": 4,
+6	  "payload": {
+7	    "query": {
+8	      "surname": "Battemiller",
+9	      "givenName": "Henry",
+10	      "deathYearFrom": 1927,
+11	      "deathYearTo": 1931,
+12	      "deathPlace": "Oregon",
+13	      "recordType": "death",
+14	      "collectionId": "3657650",
+15	      "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91...
+
+**tool_use** `collections_search` — args: {"query": "Oregon death records Clackamas", "place": "Oregon, United States"}
+
+**tool_result:** <tool_use_error>Error: No such tool available: collections_search</tool_use_error>
+
+**tool_use** `wiki_place_page` — args: {"place": "Clackamas County, Oregon", "section": "online_records"}
+
+**tool_result:** <tool_use_error>Error: No such tool available: wiki_place_page</tool_use_error>
+
+**tool_use** `validate_research_schema` — args: {"project_path": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u"}
+
+**tool_result:** <tool_use_error>Error: No such tool available: validate_research_schema</tool_use_error>
+
+**tool_use** `Read` — args: {"file_path": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u/evaluations/pre-exhaustiveness-q_001-2026-07-02T00-00-00.json"}
+
+**tool_result:** File does not exist. Note: your current working directory is /private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u.
+
+**tool_use** `Write` — args: {"file_path": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u/evaluations/pre-exhaustiveness-q_001-2026-07-02T14-30-00.json", "content": "{\n  \"focus\": \"pre-exhaustiveness\",\n  \"target_id\": \"q_001\",\n  \"target_type\": \"question\",\n  \"verdict\": \"address_first\",\n  \"strengths\": [\n    \"Excellent recovery on the indexing corruption. When the planned collection 3657650 returned zero hits for 'Bottemiller' (log_001) and only phonetic nea...
+
+**tool_result:** <tool_use_error>Error: No such tool available: Write. Write exists but is not enabled in this context. Use one of the available tools instead.</tool_use_error>
+
+**tool_result:** [{"type": "text", "text": "The Write tool is not available in this environment \u2014 only Read is enabled. This means I cannot complete the output protocol's file-write and research.json append steps. Per the operating rules, I must report this explicitly rather than proceed silently as if the writes succeeded. I will surface the full verdict content in my narrative so the audit trail can be reconstructed by the orchestrator.\n\n---\n\n# Mentor review: pre-exhaustiveness on q_001\n\n**Focus:...
+
+**assistant:** The mentor flagged two issues: (1) original image not accessed, (2) skipped items not searched-nil. Let me first persist the evaluation, then address both.
+
+**tool_use** `mcp__genealogy__research_append` — args: {"projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u", "section": "evaluations", "op": "append", "entry": {"focus": "pre-exhaustiveness", "target_id": "q_001", "target_type": "question", "verdict": "address_first", "findings": "Mentor found two issues: (1) original certificate image at ark:/61903/1:2:MYQR-859 not accessed \u2014 rely on derivative abstract only; (2) pli_002\u2013pli_005 marked skipped rather than executed, leaving no logge...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": false,\n  \"errors\": [\n    \"research.json/evaluations[0]: missing required field 'file_path'\"\n  ]\n}"}]
+
+**tool_use** `Glob` — args: {"pattern": "docs/specs/research-schema-spec.md", "path": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u"}
+
+**tool_result:** No files found
+
+**tool_use** `Glob` — args: {"pattern": "docs/**/*.md", "path": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u"}
+
+**tool_result:** No files found
+
+**tool_use** `Glob` — args: {"pattern": "**/*.md", "path": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u"}
+
+**tool_result:** .claude/skills/assertion-classification/references/three-layer-model.md
+.claude/skills/assertion-classification/references/validation-protocol.md
+.claude/skills/check-warnings/SKILL.md
+.claude/skills/check-warnings/references/assumption-categories.md
+.claude/skills/check-warnings/references/warning-checks.md
+.claude/skills/check-warnings/references/warnings-as-identity-signals.md
+.claude/skills/citation/references/gps-citation-standards.md
+.claude/skills/citation/references/validation-protoco...
+
+**tool_use** `Read` — args: {"file_path": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u/.claude/skills/proof-conclusion/SKILL.md"}
+
+**tool_result:** 1	---
+2	name: proof-conclusion
+3	model: claude-sonnet-4-6
+4	description: Writes GPS-conformant proof conclusions — selects the
+5	  confidence tier (Proved/Probable/Possible/Not Proved/Disproved), chooses
+6	  the proof conclusion form (Statement/Summary/Argument), and produces a
+7	  self-contained narrative markdown that can be uploaded to FamilySearch.
+8	  Updates tree.gedcomx.json when the tier reaches probable or higher.
+9	  GPS Step 5 — Soundly Reasoned, Coherently Written Conclusion. Use ...
+
+**tool_use** `Bash` — args: {"command": "ls /private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u/"}
+
+**tool_result:** research.json
+results
+tree.gedcomx.json
+tree.gedcomx.json.bak
+
+**tool_use** `Write` — args: {"file_path": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u/evaluations/pre-exhaustiveness-q_001-2026-07-02T14-30-00.json", "content": "{\n  \"focus\": \"pre-exhaustiveness\",\n  \"target_id\": \"q_001\",\n  \"target_type\": \"question\",\n  \"verdict\": \"address_first\",\n  \"checkpoint\": 1,\n  \"evaluator\": \"gps-mentor\",\n  \"evaluated_at\": \"2026-07-02T14:30:00Z\",\n  \"findings\": {\n    \"strengths\": [\n      \"Correct recovery when col...
+
+**tool_result:** File created successfully at: /private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u/evaluations/pre-exhaustiveness-q_001-2026-07-02T14-30-00.json (file state is current in your context — no need to Read it back)
+
+**tool_use** `mcp__genealogy__research_append` — args: {"projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u", "section": "evaluations", "op": "append", "entry": {"focus": "pre-exhaustiveness", "target_id": "q_001", "target_type": "question", "verdict": "address_first", "file_path": "evaluations/pre-exhaustiveness-q_001-2026-07-02T14-30-00.json", "superseded_by": null}}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"section\": \"evaluations\",\n  \"op\": \"append\",\n  \"entryId\": \"ev_001\",\n  \"filesWritten\": [\n    \"research.json\"\n  ],\n  \"validation\": {\n    \"valid\": true,\n    \"warnings\": []\n  }\n}"}]
+
+**assistant:** Now addressing the mentor's issues. First, attempt to access the original certificate image.
+
+**tool_use** `ToolSearch` — args: {"query": "select:mcp__genealogy__record_read,mcp__genealogy__fulltext_search,mcp__genealogy__research_log_append", "max_results": 3}
+
+**tool_result:** [{"type": "tool_reference", "tool_name": "mcp__genealogy__record_read"}, {"type": "tool_reference", "tool_name": "mcp__genealogy__fulltext_search"}, {"type": "tool_reference", "tool_name": "mcp__genealogy__research_log_append"}]
+
+**tool_use** `mcp__genealogy__record_read` — args: {"recordId": "ark:/61903/1:2:MYQR-859"}
+
+**tool_result:** {"error":"Record MYQR-859 was not found in FamilySearch historical records."}
+
+**assistant:** Original image at `ark:/61903/1:2:MYQR-859` is not accessible — confirmed by record_read (not found). Log that attempt, then create a supplementary plan (pl_002) to address the mentor's gaps.
+
+**tool_use** `mcp__genealogy__research_log_append` — args: {"projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u", "tool": "record_read", "planItemId": "pli_001", "query": {"tool": "record_read", "recordId": "ark:/61903/1:2:MYQR-859", "purpose": "Attempt to access original Oregon death certificate image underlying the database abstract in src_001"}, "outcome": "negative", "resultsExamined": 0, "resultsAvailable": 0, "notes": "record_read of ark:/61903/1:2:MYQR-859 (1:2: source-citation ARK) returne...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"logId\": \"log_005\",\n  \"performed\": \"2026-07-02T13:52:04.549Z\",\n  \"resultsRef\": null,\n  \"returnedCount\": null,\n  \"filesWritten\": [\n    \"research.json\"\n  ],\n  \"validation\": {\n    \"valid\": true,\n    \"warnings\": []\n  }\n}"}]
+
+**assistant:** Now mark pl_001 completed and create a supplementary pl_002 for the three mentor-identified gaps.
+
+**tool_use** `mcp__genealogy__research_append` — args: {"projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u", "ops": [{"section": "plans", "op": "update", "entryId": "pl_001", "fields": {"status": "completed"}}, {"section": "plans", "op": "append", "entry": {"question_id": "q_001", "status": "active", "created": "2026-07-02"}}, {"section": "plan_items", "op": "append", "planId": "pl_002", "entry": {"sequence": 1, "record_type": "vital_record", "jurisdiction": "Oregon, United States", "date_ran...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"results\": [\n    {\n      \"section\": \"plans\",\n      \"op\": \"update\",\n      \"entryId\": \"pl_001\"\n    },\n    {\n      \"section\": \"plans\",\n      \"op\": \"append\",\n      \"entryId\": \"pl_002\"\n    },\n    {\n      \"section\": \"plan_items\",\n      \"op\": \"append\",\n      \"entryId\": \"pli_006\"\n    },\n    {\n      \"section\": \"plan_items\",\n      \"op\": \"append\",\n      \"entryId\": \"pli_007\"\n    },\n    ...
+
+**assistant:** Now execute all three new searches in parallel.
+
+**tool_use** `mcp__genealogy__record_read` — args: {"recordId": "ark:/61903/1:1:VZHS-YXF"}
+
+**tool_use** `mcp__genealogy__record_read` — args: {"recordId": "ark:/61903/1:1:QV2C-WKHM"}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"persons\": [\n    {\n      \"id\": \"p_13371558735\",\n      \"ark\": \"ark:/61903/1:1:VZHS-YXF\",\n      \"names\": [\n        {\n          \"id\": \"11faed09-dbbd-4e0d-8ec4-eb6476e08735\",\n          \"type\": \"BirthName\",\n          \"given\": \"Henry William\",\n          \"surname\": \"Battemiller\"\n        }\n      ],\n      \"facts\": [\n        {\n          \"id\": \"cbc2ddb2-4c71-44a4-8f4f-61ad1b609d0d\",\n          \"type\": \"Death\",\n         ...
+
+**tool_use** `mcp__genealogy__fulltext_search` — args: {"keywords": "+Bottemiller +Oregon +1929", "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u", "recordType": "newspaper", "yearFrom": 1929, "yearTo": 1929}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"persons\": [\n    {\n      \"id\": \"p_101095469340\",\n      \"ark\": \"ark:/61903/1:1:QV2C-WKHM\",\n      \"names\": [\n        {\n          \"id\": \"e13c8ca1-aa4b-4bd4-b3fe-8dcbf18e1931\",\n          \"type\": \"BirthName\",\n          \"given\": \"William Henry\",\n          \"surname\": \"Bottemiller\"\n        }\n      ],\n      \"facts\": [\n        {\n          \"id\": \"24f5d151-6433-4998-aa07-29bdfe0580ff\",\n          \"type\": \"Burial\",\n      ...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"query\": {\n    \"keywords\": \"+Bottemiller +Oregon +1929\",\n    \"projectPath\": \"/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u\",\n    \"recordType\": \"newspaper\",\n    \"yearFrom\": 1929,\n    \"yearTo\": 1929\n  },\n  \"totalResults\": 0,\n  \"returned\": 0,\n  \"offset\": 0,\n  \"hasMore\": false,\n  \"results\": [],\n  \"staged\": null\n}"}]
+
+**assistant:** Good results. Oregon Death Index confirms death independently; Find A Grave confirms name/dates; newspaper search returned zero hits. Now log all three searches.
+
+**tool_use** `mcp__genealogy__research_log_append` — args: {"projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u", "tool": "record_read", "planItemId": "pli_006", "query": {"tool": "record_read", "recordId": "ark:/61903/1:1:VZHS-YXF", "collection": "Oregon, Death Index, 1903-1998", "collectionId": "1946790"}, "outcome": "positive", "resultsExamined": 1, "resultsAvailable": 1, "notes": "record_read of ark:/61903/1:1:VZHS-YXF (Oregon Death Index, 1903-1998) returns: name 'Henry William Battemiller', ...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"logId\": \"log_006\",\n  \"performed\": \"2026-07-02T13:53:43.427Z\",\n  \"resultsRef\": null,\n  \"returnedCount\": null,\n  \"filesWritten\": [\n    \"research.json\"\n  ],\n  \"validation\": {\n    \"valid\": true,\n    \"warnings\": []\n  }\n}"}]
+
+**tool_use** `mcp__genealogy__research_log_append` — args: {"projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u", "tool": "record_read", "planItemId": "pli_007", "query": {"tool": "record_read", "recordId": "ark:/61903/1:1:QV2C-WKHM", "collection": "Find a Grave Index", "collectionId": "2221801"}, "outcome": "positive", "resultsExamined": 1, "resultsAvailable": 1, "notes": "record_read of ark:/61903/1:1:QV2C-WKHM (Find a Grave Index) returns: name 'William Henry Bottemiller' (correct form, not tra...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"logId\": \"log_007\",\n  \"performed\": \"2026-07-02T13:53:51.257Z\",\n  \"resultsRef\": null,\n  \"returnedCount\": null,\n  \"filesWritten\": [\n    \"research.json\"\n  ],\n  \"validation\": {\n    \"valid\": true,\n    \"warnings\": []\n  }\n}"}]
+
+**tool_use** `mcp__genealogy__research_log_append` — args: {"projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u", "tool": "fulltext_search", "planItemId": "pli_008", "query": {"keywords": "+Bottemiller +Oregon +1929", "recordType": "newspaper", "yearFrom": 1929, "yearTo": 1929}, "outcome": "negative", "resultsExamined": 0, "resultsAvailable": 0, "notes": "Zero results for '+Bottemiller +Oregon +1929' in FamilySearch newspaper full-text search. No Oregon newspapers from 1929 containing 'Bottemiller...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"logId\": \"log_008\",\n  \"performed\": \"2026-07-02T13:53:58.560Z\",\n  \"resultsRef\": null,\n  \"returnedCount\": null,\n  \"filesWritten\": [\n    \"research.json\"\n  ],\n  \"validation\": {\n    \"valid\": true,\n    \"warnings\": []\n  }\n}"}]
+
+**assistant:** Now batch-extract sources, assertions, person-evidence links, and mark the new plan items completed in one call.
+
+**tool_use** `mcp__genealogy__research_append` — args: {"projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u", "ops": [{"section": "sources", "op": "append", "entry": {"gedcomx_source_description_id": "S8VD-92V", "citation": "\"Oregon, Death Index, 1903-1998,\" database, FamilySearch (https://www.familysearch.org/ark:/61903/1:1:VZHS-YXF : accessed 2 July 2026), entry for Henry William Battemiller, died 13 May 1929, Clackamas, Oregon; citing Oregon Vital Records.", "citation_detail": {"who": "He...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"results\": [\n    {\n      \"section\": \"sources\",\n      \"op\": \"append\",\n      \"entryId\": \"src_002\"\n    },\n    {\n      \"section\": \"sources\",\n      \"op\": \"append\",\n      \"entryId\": \"src_003\"\n    },\n    {\n      \"section\": \"assertions\",\n      \"op\": \"append\",\n      \"entryId\": \"a_009\"\n    },\n    {\n      \"section\": \"assertions\",\n      \"op\": \"append\",\n      \"entryId\": \"a_010\"\n    },\n  ...
+
+**assistant:** All items done. Mark pl_002 completed, then run research-exhaustiveness for q_001.
+
+**tool_use** `mcp__genealogy__research_append` — args: {"projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u", "section": "plans", "op": "update", "entryId": "pl_002", "fields": {"status": "completed"}}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"section\": \"plans\",\n  \"op\": \"update\",\n  \"entryId\": \"pl_002\",\n  \"filesWritten\": [\n    \"research.json\"\n  ],\n  \"validation\": {\n    \"valid\": true,\n    \"warnings\": []\n  }\n}"}]
+
+**assistant:** Now applying the research-exhaustiveness evaluation. All items for q_001 are done. Evaluating the 7-point stop criteria:
+
+- **goal_alignment**: ✓ src_001 explicitly names Father=Casper A. Battermiller, Mother=Mary Mehlman
+- **repository_breadth**: Reasonable for this specific death-cert question; three FS collections + nil newspaper; external sites noted as future work
+- **original_substitution**: Attempted but inaccessible (1:2: ARK not found via record_read) — best available version used
+- **independent_verification**: Three sources confirm the death; only one names parents (one-evidence-unit limitation; future questions address this)
+- **evidence_class**: Derivative/authored only; original inaccessible
+- **conflict_resolution**: No conflicts
+- **overturn_risk**: Low for this narrow question
+
+**tool_use** `mcp__genealogy__research_append` — args: {}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": false,\n  \"errors\": [\n    \"research.json not found in projectPath\"\n  ]\n}"}]
+
+**tool_use** `mcp__genealogy__research_append` — args: {"projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u", "section": "questions", "op": "update", "entryId": "q_001", "fields": {"status": "exhaustive_declared", "exhaustive_declaration": {"declared": true, "justification": "The question asks specifically what the death certificate reports about William Henry Bottemiller's parents. The FamilySearch 'Oregon, Deaths and Burials, 1903\u20131947' database abstract (src_001) explicitly names Fathe...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"section\": \"questions\",\n  \"op\": \"update\",\n  \"entryId\": \"q_001\",\n  \"filesWritten\": [\n    \"research.json\"\n  ],\n  \"validation\": {\n    \"valid\": true,\n    \"warnings\": []\n  }\n}"}]
+
+**assistant:** q_001 declared exhaustive. Now invoking gps-mentor for checkpoint 2 (pre-proof-conclusion).
+
+**tool_use** `Agent` — args: {"description": "GPS mentor pre-proof-conclusion review for q_001", "subagent_type": "gps-mentor", "prompt": "You are the gps-mentor agent. Please perform a pre-proof-conclusion checkpoint review (checkpoint 2 of 3) for question q_001 in the project at /private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u.\n\nContext:\n- q_001: \"What does the death certificate of William Henry Bottemiller (died 13 May 1929, Oregon City, Clackamas County, Oregon) report abo...
+
+**tool_use** `Read` — args: {"file_path": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u/research.json"}
+
+**tool_result:** 1	{
+2	  "project": {
+3	    "id": "rp_bottemiller_parents",
+4	    "objective": "Who were the parents of William Henry Bottemiller, born 29 December 1862 in Franconia Township, Chisago County, Minnesota, and died 13 May 1929 in Oregon City, Clackamas County, Oregon?",
+5	    "subject_person_ids": [
+6	      "249W-9LP"
+7	    ],
+8	    "status": "active",
+9	    "created": "2026-07-01T00:00:00Z",
+10	    "updated": "2026-07-01T00:00:00Z"
+11	  },
+12	  "researcher_profile": {
+13	    "experience_level": ...
+
+**tool_use** `Read` — args: {"file_path": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u/evaluations/pre-exhaustiveness-q_001-2026-07-02T14-30-00.json"}
+
+**tool_result:** 1	{
+2	  "focus": "pre-exhaustiveness",
+3	  "target_id": "q_001",
+4	  "target_type": "question",
+5	  "verdict": "address_first",
+6	  "checkpoint": 1,
+7	  "evaluator": "gps-mentor",
+8	  "evaluated_at": "2026-07-02T14:30:00Z",
+9	  "findings": {
+10	    "strengths": [
+11	      "Correct recovery when collection 3657650 returned zero hits — pivoted to record_read of existing tree source.",
+12	      "Correct independent classification of information_quality (secondary) and evidence_type (direct) on a...
+
+**tool_use** `Read` — args: {"file_path": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u/tree.gedcomx.json", "limit": 5}
+
+**tool_result:** 1	{
+2	  "persons": [
+3	    {
+4	      "id": "249W-9LP",
+5	      "gender": "Male",
+
+**tool_use** `Read` — args: {"file_path": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u/evaluations"}
+
+**tool_result:** EISDIR: illegal operation on a directory, read '/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u/evaluations'
+
+**tool_result:** [{"type": "text", "text": "The `evaluations/` directory exists. Now let me write the verdict file. The current UTC time is 2026-07-02; I'll use a timestamp of 2026-07-02T15-05-00.\n\nI don't have a Write tool available in my toolkit as listed, but I need to write files per the output protocol. Let me check \u2014 the tools available to me are Read only in the function list. The output protocol requires writing files. Since I only have Read, I must report this constraint honestly. However, re-...
+
+**assistant:** Mentor verdict: `address_first` — proof should tier at Probable for the record-content claim, mark parentage identification as Possible, and state scope explicitly. First persist the evaluation.
+
+**tool_use** `Write` — args: {"file_path": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u/evaluations/conclusion-readiness-q_001-2026-07-02T15-05-00.json", "content": "{\n  \"focus\": \"conclusion-readiness\",\n  \"target_id\": \"q_001\",\n  \"target_type\": \"question\",\n  \"verdict\": \"address_first\",\n  \"checkpoint\": 2,\n  \"evaluator\": \"gps-mentor\",\n  \"evaluated_at\": \"2026-07-02T15:05:00Z\",\n  \"must_address\": [\n    {\n      \"standard\": \"Standard 43; Stand...
+
+**tool_result:** File created successfully at: /private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u/evaluations/conclusion-readiness-q_001-2026-07-02T15-05-00.json (file state is current in your context — no need to Read it back)
+
+**tool_use** `mcp__genealogy__research_append` — args: {"projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u", "section": "evaluations", "op": "append", "entry": {"focus": "conclusion-readiness", "target_id": "q_001", "target_type": "question", "verdict": "address_first", "file_path": "evaluations/conclusion-readiness-q_001-2026-07-02T15-05-00.json", "superseded_by": null}}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"section\": \"evaluations\",\n  \"op\": \"append\",\n  \"entryId\": \"ev_002\",\n  \"filesWritten\": [\n    \"research.json\"\n  ],\n  \"validation\": {\n    \"valid\": true,\n    \"warnings\": []\n  }\n}"}]
+
+**assistant:** Now invoking proof-conclusion for q_001. Based on mentor guidance: tier = probable (record-content claim); narrative must note parentage identification is possible pending corroboration.
+
+**tool_use** `mcp__genealogy__research_append` — args: {"projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u", "section": "proof_summaries", "op": "append", "entry": {"question_id": "q_001", "tier": "probable", "vehicle": "summary", "supporting_assertion_ids": ["a_001", "a_002", "a_003", "a_004", "a_005", "a_006", "a_007", "a_008", "a_009", "a_010", "a_011", "a_012", "a_013", "a_014"], "resolved_conflict_ids": [], "exhaustive_search_summary": "Three FamilySearch collections searched: 'Oregon, D...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"section\": \"proof_summaries\",\n  \"op\": \"append\",\n  \"entryId\": \"ps_001\",\n  \"filesWritten\": [\n    \"research.json\"\n  ],\n  \"validation\": {\n    \"valid\": true,\n    \"warnings\": []\n  }\n}"}]
+
+**assistant:** ps_001 written. Update project timestamp, then run gps-mentor checkpoint 3 (post-proof).
+
+**tool_use** `mcp__genealogy__research_append` — args: {"projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u", "section": "project", "op": "update", "fields": {"updated": "2026-07-02"}}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": false,\n  \"errors\": [\n    \"field(s) not updatable on 'project': updated (allowed: status)\"\n  ]\n}"}]
+
+**tool_use** `Agent` — args: {"description": "GPS mentor post-proof review for q_001", "subagent_type": "gps-mentor", "prompt": "You are the gps-mentor agent. Please perform a post-proof-conclusion checkpoint review (checkpoint 3 of 3) for question q_001 in the project at /private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u.\n\nContext:\n- q_001: \"What does the death certificate of William Henry Bottemiller (died 13 May 1929, Oregon City, Clackamas County, Oregon) report about his pa...
+
+**tool_use** `Read` — args: {"file_path": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u/research.json"}
+
+**tool_result:** 1	{
+2	  "project": {
+3	    "id": "rp_bottemiller_parents",
+4	    "objective": "Who were the parents of William Henry Bottemiller, born 29 December 1862 in Franconia Township, Chisago County, Minnesota, and died 13 May 1929 in Oregon City, Clackamas County, Oregon?",
+5	    "subject_person_ids": [
+6	      "249W-9LP"
+7	    ],
+8	    "status": "active",
+9	    "created": "2026-07-01T00:00:00Z",
+10	    "updated": "2026-07-01T00:00:00Z"
+11	  },
+12	  "researcher_profile": {
+13	    "experience_level": ...
+
+**tool_use** `Read` — args: {"file_path": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u/tree.gedcomx.json"}
+
+**tool_result:** 1	{
+2	  "persons": [
+3	    {
+4	      "id": "249W-9LP",
+5	      "gender": "Male",
+6	      "living": false,
+7	      "names": [
+8	        {
+9	          "given": "William Henry",
+10	          "surname": "Bottemiller",
+11	          "id": "249W-9LP-name-1"
+12	        }
+13	      ],
+14	      "facts": [
+15	        {
+16	          "id": "ebe0d4fe-20f8-4dad-b4b8-c69c03d0f100",
+17	          "type": "Birth",
+18	          "date": "29 December 1862",
+19	          "standard_date": "29 Dec 1862",
+20	          ...
+
+**tool_use** `Read` — args: {"file_path": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u/evaluations/pre-exhaustiveness-q_001-2026-07-02T14-30-00.json"}
+
+**tool_result:** 1	{
+2	  "focus": "pre-exhaustiveness",
+3	  "target_id": "q_001",
+4	  "target_type": "question",
+5	  "verdict": "address_first",
+6	  "checkpoint": 1,
+7	  "evaluator": "gps-mentor",
+8	  "evaluated_at": "2026-07-02T14:30:00Z",
+9	  "findings": {
+10	    "strengths": [
+11	      "Correct recovery when collection 3657650 returned zero hits — pivoted to record_read of existing tree source.",
+12	      "Correct independent classification of information_quality (secondary) and evidence_type (direct) on a...
+
+**tool_use** `Read` — args: {"file_path": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u/evaluations/conclusion-readiness-q_001-2026-07-02T15-05-00.json"}
+
+**tool_result:** 1	{
+2	  "focus": "conclusion-readiness",
+3	  "target_id": "q_001",
+4	  "target_type": "question",
+5	  "verdict": "address_first",
+6	  "checkpoint": 2,
+7	  "evaluator": "gps-mentor",
+8	  "evaluated_at": "2026-07-02T15:05:00Z",
+9	  "must_address": [
+10	    {
+11	      "standard": "Standard 43; Standards 64-67",
+12	      "issue": "Parentage identification (I1/I2 stubs + ParentChild relationships to 249W-9LP) rests on one derivative source, secondary information, unknown informant, no corroboratio...
+
+**tool_use** `Read` — args: {"file_path": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u/evaluations"}
+
+**tool_result:** EISDIR: illegal operation on a directory, read '/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u/evaluations'
+
+**tool_result:** [{"type": "text", "text": "Directory confirmed to exist. I do not have a Write tool in my available toolkit \u2014 my toolkit is read-only plus the research tools described. Let me re-check: the output protocol requires me to write the verdict file and append to research.json. I only have Read available among file tools in this session. I must report this honestly rather than pretend the write succeeded.\n\nLet me verify by checking whether there is a write mechanism I have. My available func...
+
+**assistant:** Verdict: `looks_solid`. Persist the checkpoint 3 evaluation, then proceed to question-selection.
+
+**tool_use** `Write` — args: {"file_path": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u/evaluations/proof-critique-ps_001-2026-07-02T00-00-00.json", "content": "{\n  \"focus\": \"proof-critique\",\n  \"target_id\": \"ps_001\",\n  \"target_type\": \"proof_summary\",\n  \"verdict\": \"looks_solid\",\n  \"checkpoint\": 3,\n  \"evaluator\": \"gps-mentor\",\n  \"evaluated_at\": \"2026-07-02T00:00:00Z\",\n  \"strengths\": [\n    \"Resolved both prior checkpoints: attempted original...
+
+**tool_result:** File created successfully at: /private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u/evaluations/proof-critique-ps_001-2026-07-02T00-00-00.json (file state is current in your context — no need to Read it back)
+
+**tool_use** `mcp__genealogy__research_append` — args: {"projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u", "section": "evaluations", "op": "append", "entry": {"focus": "proof-critique", "target_id": "ps_001", "target_type": "proof_summary", "verdict": "looks_solid", "file_path": "evaluations/proof-critique-ps_001-2026-07-02T00-00-00.json", "superseded_by": null}}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"section\": \"evaluations\",\n  \"op\": \"append\",\n  \"entryId\": \"ev_003\",\n  \"filesWritten\": [\n    \"research.json\"\n  ],\n  \"validation\": {\n    \"valid\": true,\n    \"warnings\": []\n  }\n}"}]
+
+**assistant:** Now invoking question-selection to mark q_001 resolved and select the next question.
+
+**tool_use** `Skill` — args: {"skill": "question-selection"}
+
+**tool_result:** Launching skill: question-selection
+
+**assistant:** Reading the project state from context. q_001 is `exhaustive_declared` with proof summary ps_001 (tier: probable). No open questions remain, no in-progress plan items. Next action: mark q_001 answered and select the next question.
+
+**Priority analysis:**
+- No conflicts → skip priority 1
+- No active hypothesis → skip priority 2
+- No high-severity timeline gaps → skip priority 3
+- **Priority 4 fires:** q_001 answered one sub-question of the objective ("what does the death certificate report"). The broader objective ("who were the parents") requires decomposition into corroboration questions — the census sub-question is the logical next decomposition.
+
+The tree already shows William residing in Bertha, Todd County, Minnesota in 1880. That residence predates migration to Oregon (first Oregon census: 1900). The 1880 census has explicit relationship columns and should show William still in his parents' household at age ~17. If Casper A. Bottemiller also appears in Todd County in 1880, that would be the independent second evidence unit needed to lift parentage from possible to probable.
+
+Formulated question: **"Does the 1880 U.S. census show William Henry Bottemiller residing in the household of Casper A. Bottemiller?"**
+
+**tool_use** `mcp__genealogy__research_append` — args: {"projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u", "ops": [{"section": "questions", "op": "update", "entryId": "q_001", "fields": {"status": "answered", "resolved": "2026-07-02", "resolution_assertion_ids": ["a_004", "a_005", "a_006", "a_007"]}}, {"section": "questions", "op": "append", "entry": {"question": "Does the 1880 U.S. census show William Henry Bottemiller residing in the household of Casper A. Bottemiller, corroborating the p...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": false,\n  \"errors\": [\n    \"research.json/questions[0]: 'answered' is not a valid question_status (expected one of: exhaustive_declared, in_progress, open, resolved)\"\n  ]\n}"}]
+
+**tool_use** `mcp__genealogy__research_append` — args: {"projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u", "ops": [{"section": "questions", "op": "update", "entryId": "q_001", "fields": {"status": "resolved", "resolved": "2026-07-02", "resolution_assertion_ids": ["a_004", "a_005", "a_006", "a_007"]}}, {"section": "questions", "op": "append", "entry": {"question": "Does the 1880 U.S. census show William Henry Bottemiller residing in the household of Casper A. Bottemiller, corroborating the p...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"results\": [\n    {\n      \"section\": \"questions\",\n      \"op\": \"update\",\n      \"entryId\": \"q_001\"\n    },\n    {\n      \"section\": \"questions\",\n      \"op\": \"append\",\n      \"entryId\": \"q_002\"\n    }\n  ],\n  \"filesWritten\": [\n    \"research.json\"\n  ],\n  \"validation\": {\n    \"valid\": true,\n    \"warnings\": []\n  }\n}"}]
+
+**assistant:** q_002 opened. Now invoking research-plan for q_002.
+
+**tool_use** `Skill` — args: {"skill": "research-plan", "args": "q_002"}
+
+**tool_result:** Launching skill: research-plan
+
+**assistant:** **Step 1 — Context from memory:** William Henry Bottemiller (249W-9LP), born 29 Dec 1862, Franconia Township, Chisago County, Minnesota. Tree has his 1880 residence as Bertha, Todd County, Minnesota. Parent hypothesis from q_001: Father = Casper A. Bottemiller, Mother = Mary Mehlman. No plans for q_002 exist yet. → **New plan mode.**
+
+**Step 2 — Locality survey.** Running targeted MCP calls for Todd County and Chisago County, Minnesota, 1860–1880.
+
+**tool_use** `ToolSearch` — args: {"query": "select:mcp__genealogy__place_search,mcp__genealogy__collections_search,mcp__genealogy__external_links_search", "max_results": 3}
+
+**tool_result:** [{"type": "tool_reference", "tool_name": "mcp__genealogy__place_search"}, {"type": "tool_reference", "tool_name": "mcp__genealogy__collections_search"}, {"type": "tool_reference", "tool_name": "mcp__genealogy__external_links_search"}]
+
+**tool_use** `mcp__genealogy__place_search` — args: {"placeName": "Todd County", "contextName": "Minnesota"}
+
+**tool_use** `mcp__genealogy__place_search` — args: {"placeName": "Chisago County", "contextName": "Minnesota"}
+
+**tool_use** `mcp__genealogy__collections_search` — args: {"standardPlace": "Minnesota, United States", "startYear": 1855, "endYear": 1885}
+
+**tool_use** `mcp__genealogy__external_links_search` — args: {"standardPlace": "Minnesota, United States", "startYear": 1860, "endYear": 1885}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"results\": [\n    {\n      \"standardPlace\": \"Todd, Minnesota, United States\",\n      \"type\": \"County\",\n      \"dateRange\": \"+1855/\",\n      \"latitude\": 46.06667,\n      \"longitude\": -94.88333,\n      \"familysearchUrl\": \"https://www.familysearch.org/en/research/places/?text=Todd&focusedId=394291\",\n      \"wikipediaUrl\": \"https://en.wikipedia.org/wiki/Todd_County,_Minnesota\"\n    },\n    {\n      \"standardPlace\": \"Todd Township, Hubba...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"results\": [\n    {\n      \"standardPlace\": \"Chisago, Minnesota, United States\",\n      \"type\": \"County\",\n      \"dateRange\": \"+1851/\",\n      \"latitude\": 45.50056,\n      \"longitude\": -92.9,\n      \"familysearchUrl\": \"https://www.familysearch.org/en/research/places/?text=Chisago&focusedId=392907\",\n      \"wikipediaUrl\": \"https://en.wikipedia.org/wiki/Chisago_County,_Minnesota\"\n    },\n    {\n      \"standardPlace\": \"Ramsey, Minneso...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"query\": {\n    \"standardPlace\": \"Minnesota, United States\",\n    \"startYear\": 1855,\n    \"endYear\": 1885\n  },\n  \"scope\": \"Minnesota\",\n  \"totalForPlace\": 46,\n  \"results\": [\n    {\n      \"id\": \"1858352\",\n      \"title\": \"Minnesota, Birth and Death Records, 1866-1916\",\n      \"dateRange\": \"1866-1916\",\n      \"recordCount\": 379392,\n      \"personCount\": 830015,\n      \"imageCount\": 144789,\n      \"url\": \"https://www.fami...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"query\": {\n    \"standardPlace\": \"Minnesota, United States\",\n    \"startYear\": 1860,\n    \"endYear\": 1885\n  },\n  \"totalForPlace\": 403,\n  \"results\": [\n    {\n      \"url\": \"https://www.myheritage.com/research/collection-10925/minnesota-veteran-grave-index-1857-1975\",\n      \"linkText\": \"Minnesota, Veteran Grave Index, 1857-1975\"\n    },\n    {\n      \"url\": \"http://www.loc.gov/rr/main/gar/garhome.html\",\n      \"linkText\": \"Library...
+
+**tool_use** `ToolSearch` — args: {"query": "select:mcp__genealogy__research_append,mcp__genealogy__research_log_append,mcp__genealogy__record_search,mcp__genealogy__record_read", "max_results": 5}
+
+**tool_result:** [{"type": "tool_reference", "tool_name": "mcp__genealogy__research_append"}, {"type": "tool_reference", "tool_name": "mcp__genealogy__research_log_append"}, {"type": "tool_reference", "tool_name": "mcp__genealogy__record_search"}, {"type": "tool_reference", "tool_name": "mcp__genealogy__record_read"}]
+
+**tool_use** `mcp__genealogy__research_append` — args: {"projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u", "ops": [{"section": "plans", "op": "append", "entry": {"question_id": "q_002", "status": "active", "created": "2026-07-02"}}, {"section": "plan_items", "op": "append", "planId": "pl_003", "entry": {"sequence": 1, "record_type": "census", "jurisdiction": "Todd County, Minnesota, United States", "date_range": "1880", "repository": "FamilySearch", "rationale": "William Henry Bottemiller a...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"results\": [\n    {\n      \"section\": \"plans\",\n      \"op\": \"append\",\n      \"entryId\": \"pl_003\"\n    },\n    {\n      \"section\": \"plan_items\",\n      \"op\": \"append\",\n      \"entryId\": \"pli_009\"\n    },\n    {\n      \"section\": \"plan_items\",\n      \"op\": \"append\",\n      \"entryId\": \"pli_010\"\n    },\n    {\n      \"section\": \"plan_items\",\n      \"op\": \"append\",\n      \"entryId\": \"pli_011\"\n    },...
+
+**assistant:** Plan pl_003 written (pli_009–pli_014). Now executing pli_009 — 1880 U.S. Census search for Bottemiller in Todd County, Minnesota.
+
+**tool_use** `mcp__genealogy__research_append` — args: {"projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u", "section": "plan_items", "op": "update", "planId": "pl_003", "entryId": "pli_009", "fields": {"status": "in_progress"}}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"section\": \"plan_items\",\n  \"op\": \"update\",\n  \"entryId\": \"pli_009\",\n  \"filesWritten\": [\n    \"research.json\"\n  ],\n  \"validation\": {\n    \"valid\": true,\n    \"warnings\": []\n  }\n}"}]
+
+**tool_use** `mcp__genealogy__record_search` — args: {"surname": "Bottemiller", "recordType": "census", "residencePlace": "Todd, Minnesota, United States", "residenceYearFrom": 1880, "residenceYearTo": 1880, "collectionId": "1417683", "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u"}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"query\": {\n    \"surname\": \"Bottemiller\",\n    \"recordType\": \"census\",\n    \"residencePlace\": \"Todd, Minnesota, United States\",\n    \"residenceYearFrom\": 1880,\n    \"residenceYearTo\": 1880,\n    \"collectionId\": \"1417683\",\n    \"projectPath\": \"/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u\"\n  },\n  \"totalMatches\": 0,\n  \"paginationCappedAt\": 4999,\n  \"returned\": 0,\n  \"offset\": 0,\n  \...
+
+**assistant:** Zero hits with exact county. Trying without county restriction — all of Minnesota in the 1880 census.
+
+**tool_use** `mcp__genealogy__record_search` — args: {"surname": "Bottemiller", "recordType": "census", "residencePlace": "Minnesota, United States", "residenceYearFrom": 1880, "residenceYearTo": 1880, "collectionId": "1417683", "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u"}
+
+**tool_result:** Error: result (243,675 characters across 8,112 lines) exceeds maximum allowed tokens. Output has been saved to /Users/ernest/.claude/projects/-private-var-folders-g7-zn65fvrn5g9-g71-sp0lk82h0000gn-T-e2e-bottemiller-parents-91t9zm2u/6b6fa77e-a98a-4d4b-88f2-5c7d037177be/tool-results/mcp-genealogy-record_search-1783001336872.txt.
+Format: Plain text
+- For targeted searches (find a line, locate a string): use grep on the file directly.
+- For analysis or summarization that requires reading the full...
+
+**tool_use** `Agent` — args: {"description": "Parse large census search results file", "prompt": "Read the file at /Users/ernest/.claude/projects/-private-var-folders-g7-zn65fvrn5g9-g71-sp0lk82h0000gn-T-e2e-bottemiller-parents-91t9zm2u/6b6fa77e-a98a-4d4b-88f2-5c7d037177be/tool-results/mcp-genealogy-record_search-1783001336872.txt in chunks of 400 lines using offset/limit until you have read all 8,112 lines. \n\nI need you to extract and return ALL results from this file, specifically looking for:\n1. Any person with surn...
+
+**tool_use** `Read` — args: {"file_path": "/Users/ernest/.claude/projects/-private-var-folders-g7-zn65fvrn5g9-g71-sp0lk82h0000gn-T-e2e-bottemiller-parents-91t9zm2u/6b6fa77e-a98a-4d4b-88f2-5c7d037177be/tool-results/mcp-genealogy-record_search-1783001336872.txt", "offset": 0, "limit": 400}
+
+**tool_result:** 0	{
+1	  "query": {
+2	    "surname": "Bottemiller",
+3	    "recordType": "census",
+4	    "residencePlace": "Minnesota, United States",
+5	    "residenceYearFrom": 1880,
+6	    "residenceYearTo": 1880,
+7	    "collectionId": "1417683",
+8	    "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u"
+9	  },
+10	  "totalMatches": 29,
+11	  "paginationCappedAt": 4999,
+12	  "returned": 20,
+13	  "offset": 0,
+14	  "hasMore": true,
+15	  "results": [
+16	    {
+1...
+
+**tool_use** `Read` — args: {"file_path": "/Users/ernest/.claude/projects/-private-var-folders-g7-zn65fvrn5g9-g71-sp0lk82h0000gn-T-e2e-bottemiller-parents-91t9zm2u/6b6fa77e-a98a-4d4b-88f2-5c7d037177be/tool-results/mcp-genealogy-record_search-1783001336872.txt", "offset": 400, "limit": 400}
+
+**tool_result:** 400	            ]
+401	          },
+402	          {
+403	            "id": "p_244063447",
+404	            "ark": "ark:/61903/1:1:MZ9C-8V4",
+405	            "gender": "Male",
+406	            "names": [
+407	              {
+408	                "type": "BirthName",
+409	                "given": "William",
+410	                "surname": "Fear"
+411	              }
+412	            ],
+413	            "facts": [
+414	              {
+415	                "type": "Birth",
+416	                "date": "1852",
+...
+
+**tool_use** `Read` — args: {"file_path": "/Users/ernest/.claude/projects/-private-var-folders-g7-zn65fvrn5g9-g71-sp0lk82h0000gn-T-e2e-bottemiller-parents-91t9zm2u/6b6fa77e-a98a-4d4b-88f2-5c7d037177be/tool-results/mcp-genealogy-record_search-1783001336872.txt", "offset": 800, "limit": 400}
+
+**tool_result:** 800	          },
+801	          {
+802	            "id": "333",
+803	            "name": "Maine, United States",
+804	            "latitude": 45.50028,
+805	            "longitude": -69.25028
+806	          },
+807	          {
+808	            "id": "335",
+809	            "name": "Minnesota, United States",
+810	            "latitude": 46.2503,
+811	            "longitude": -94.2503
+812	          },
+813	          {
+814	            "id": "346",
+815	            "name": "Connecticut, United States",
+816	 ...
+
+**tool_use** `Read` — args: {"file_path": "/Users/ernest/.claude/projects/-private-var-folders-g7-zn65fvrn5g9-g71-sp0lk82h0000gn-T-e2e-bottemiller-parents-91t9zm2u/6b6fa77e-a98a-4d4b-88f2-5c7d037177be/tool-results/mcp-genealogy-record_search-1783001336872.txt", "offset": 1200, "limit": 400}
+
+**tool_result:** 1200	                "place": "Albion Township, Wright, Minnesota, United States",
+1201	                "standard_place": "Albion Township, Wright, Minnesota, United States"
+1202	              }
+1203	            ],
+1204	            "sources": [
+1205	              {
+1206	                "ref": "sd_da1"
+1207	              }
+1208	            ]
+1209	          },
+1210	          {
+1211	            "id": "p_244609006",
+1212	            "ark": "ark:/61903/1:1:MZ91-JPN",
+1213	            "gender": "Fe...
+
+**tool_use** `Grep` — args: {"pattern": "Bottemiller|Bottermiller|Battermiller|Bottmiller|Casper|Caspar", "path": "/Users/ernest/.claude/projects/-private-var-folders-g7-zn65fvrn5g9-g71-sp0lk82h0000gn-T-e2e-bottemiller-parents-91t9zm2u/6b6fa77e-a98a-4d4b-88f2-5c7d037177be/tool-results/mcp-genealogy-record_search-1783001336872.txt", "output_mode": "content", "head_limit": 0}
+
+**tool_result:** 3:    "surname": "Bottemiller",
+
+**tool_use** `Grep` — args: {"pattern": "\"William\"", "path": "/Users/ernest/.claude/projects/-private-var-folders-g7-zn65fvrn5g9-g71-sp0lk82h0000gn-T-e2e-bottemiller-parents-91t9zm2u/6b6fa77e-a98a-4d4b-88f2-5c7d037177be/tool-results/mcp-genealogy-record_search-1783001336872.txt", "output_mode": "content", "head_limit": 0}
+
+**tool_result:** 409:                "given": "William",
+611:                "given": "William",
+643:                "given": "William",
+677:                "given": "William",
+1923:                "given": "William"
+2379:                "given": "William"
+2907:                "given": "William"
+3397:                "given": "William"
+3853:                "given": "William"
+4377:                "given": "William"
+5213:                "given": "William"
+5589:                "given": "William"
+7585:            ...
+
+**tool_use** `Read` — args: {"file_path": "/Users/ernest/.claude/projects/-private-var-folders-g7-zn65fvrn5g9-g71-sp0lk82h0000gn-T-e2e-bottemiller-parents-91t9zm2u/6b6fa77e-a98a-4d4b-88f2-5c7d037177be/tool-results/mcp-genealogy-record_search-1783001336872.txt", "offset": 1600, "limit": 400}
+
+**tool_result:** 1600	            "sources": [
+1601	              {
+1602	                "ref": "sd_da1"
+1603	              }
+1604	            ]
+1605	          },
+1606	          {
+1607	            "id": "p_244609004",
+1608	            "ark": "ark:/61903/1:1:MZ91-JPX",
+1609	            "gender": "Male",
+1610	            "names": [
+1611	              {
+1612	                "type": "BirthName",
+1613	                "given": "Ernest",
+1614	                "surname": "Bottomaly"
+1615	              }
+1616	         ...
+
+**tool_use** `Grep` — args: {"pattern": "\"surname\":", "path": "/Users/ernest/.claude/projects/-private-var-folders-g7-zn65fvrn5g9-g71-sp0lk82h0000gn-T-e2e-bottemiller-parents-91t9zm2u/6b6fa77e-a98a-4d4b-88f2-5c7d037177be/tool-results/mcp-genealogy-record_search-1783001336872.txt", "output_mode": "content", "head_limit": 0}
+
+**tool_result:** 3:    "surname": "Bottemiller",
+60:                "surname": "Boytaley"
+106:                "surname": "Attineson"
+140:                "surname": "Lowe"
+174:                "surname": "Striker"
+208:                "surname": "Kined"
+242:                "surname": "Collins"
+274:                "surname": "King"
+308:                "surname": "Walker"
+342:                "surname": "Moore"
+376:                "surname": "Handswkef"
+410:                "surname": "Fear"
+444:                "sur...
+
+**tool_result:** [{"type": "text", "text": "The complete surname inventory confirms the finding definitively. Here is the full report:\n\n---\n\n**Result: ZERO Bottemiller results found in this file.**\n\nThe exhaustive search across all 8,112 lines reveals the following:\n\n**What the file contains:**\n- Line 3: `\"surname\": \"Bottemiller\"` \u2014 this is only in the **search query** at the top, not in any result.\n- The 20 returned results (out of 29 total matches) contain persons with surnames: **Boytale...
+
+**assistant:** The fuzzy matches are all "Bottomly" families — no actual Bottemiller in those results. Logging the nil and trying spelling variants.
+
+**tool_use** `mcp__genealogy__research_log_append` — args: {"projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u", "tool": "record_search", "planItemId": "pli_009", "query": {"surname": "Bottemiller", "recordType": "census", "residencePlace": "Minnesota, United States", "residenceYearFrom": 1880, "residenceYearTo": 1880, "collectionId": "1417683"}, "outcome": "negative", "resultsExamined": 20, "resultsAvailable": 29, "notes": "29 fuzzy matches returned but none bear the Bottemiller surname \u2014 a...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"logId\": \"log_009\",\n  \"performed\": \"2026-07-02T14:10:08.771Z\",\n  \"resultsRef\": null,\n  \"returnedCount\": null,\n  \"filesWritten\": [\n    \"research.json\"\n  ],\n  \"validation\": {\n    \"valid\": true,\n    \"warnings\": []\n  }\n}"}]
+
+**assistant:** Trying variant spellings. First, searching for "William" Bottemiller/variants in 1880 census — he'd be ~17, his household head would be Casper.
+
+**tool_use** `mcp__genealogy__record_search` — args: {"givenName": "William", "surname": "Bottemiller", "surnameAlt": "Battermiller", "recordType": "census", "residenceYearFrom": 1880, "residenceYearTo": 1880, "birthYearFrom": 1860, "birthYearTo": 1865, "collectionId": "1417683", "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u"}
+
+**tool_result:** Error: result (224,953 characters across 7,511 lines) exceeds maximum allowed tokens. Output has been saved to /Users/ernest/.claude/projects/-private-var-folders-g7-zn65fvrn5g9-g71-sp0lk82h0000gn-T-e2e-bottemiller-parents-91t9zm2u/6b6fa77e-a98a-4d4b-88f2-5c7d037177be/tool-results/mcp-genealogy-record_search-1783001425493.txt.
+Format: Plain text
+- For targeted searches (find a line, locate a string): use grep on the file directly.
+- For analysis or summarization that requires reading the full...
+
+**tool_use** `Agent` — args: {"description": "Parse census search for William Bottemiller variants", "prompt": "Read the file at /Users/ernest/.claude/projects/-private-var-folders-g7-zn65fvrn5g9-g71-sp0lk82h0000gn-T-e2e-bottemiller-parents-91t9zm2u/6b6fa77e-a98a-4d4b-88f2-5c7d037177be/tool-results/mcp-genealogy-record_search-1783001425493.txt in chunks of 400 lines using offset/limit until you have read all 7,511 lines.\n\nI need you to find ALL results with:\n1. Any person named \"William\" with surname Bottemiller/Bat...
+
+**tool_use** `Read` — args: {"file_path": "/Users/ernest/.claude/projects/-private-var-folders-g7-zn65fvrn5g9-g71-sp0lk82h0000gn-T-e2e-bottemiller-parents-91t9zm2u/6b6fa77e-a98a-4d4b-88f2-5c7d037177be/tool-results/mcp-genealogy-record_search-1783001425493.txt", "limit": 400, "offset": 0}
+
+**tool_result:** 0	{
+1	  "query": {
+2	    "givenName": "William",
+3	    "surname": "Bottemiller",
+4	    "surnameAlt": "Battermiller",
+5	    "recordType": "census",
+6	    "residenceYearFrom": 1880,
+7	    "residenceYearTo": 1880,
+8	    "birthYearFrom": 1860,
+9	    "birthYearTo": 1865,
+10	    "collectionId": "1417683",
+11	    "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u"
+12	  },
+13	  "totalMatches": 20,
+14	  "paginationCappedAt": 4999,
+15	  "returned":...
+
+**tool_use** `Read` — args: {"file_path": "/Users/ernest/.claude/projects/-private-var-folders-g7-zn65fvrn5g9-g71-sp0lk82h0000gn-T-e2e-bottemiller-parents-91t9zm2u/6b6fa77e-a98a-4d4b-88f2-5c7d037177be/tool-results/mcp-genealogy-record_search-1783001425493.txt", "limit": 400, "offset": 400}
+
+**tool_result:** 400	          {
+401	            "id": "330",
+402	            "name": "Illinois, United States",
+403	            "latitude": 40,
+404	            "longitude": -89.25
+405	          },
+406	          {
+407	            "id": "4034133",
+408	            "name": "La Salle, LaSalle, Illinois, United States",
+409	            "latitude": 41.3333,
+410	            "longitude": -89.0917
+411	          }
+412	        ]
+413	      },
+414	      "primaryId": "p_354991721"
+415	    },
+416	    {
+417	      "recordId":...
+
+**tool_use** `Read` — args: {"file_path": "/Users/ernest/.claude/projects/-private-var-folders-g7-zn65fvrn5g9-g71-sp0lk82h0000gn-T-e2e-bottemiller-parents-91t9zm2u/6b6fa77e-a98a-4d4b-88f2-5c7d037177be/tool-results/mcp-genealogy-record_search-1783001425493.txt", "limit": 400, "offset": 800}
+
+**tool_result:** 800	      "birthPlace": "New York, United States",
+801	      "collectionId": "1417683",
+802	      "collectionTitle": "United States, Census, 1880",
+803	      "collectionUrl": "https://www.familysearch.org/service/cds/recapi/collections/1417683",
+804	      "recordTitle": "Household of John Kuckmiller, \"United States Census, 1880\"",
+805	      "recordArk": "ark:/61903/1:2:M4JX-L79",
+806	      "gedcomx": {
+807	        "persons": [
+808	          {
+809	            "id": "p_254795607",
+810	       ...
+
+**tool_use** `Read` — args: {"file_path": "/Users/ernest/.claude/projects/-private-var-folders-g7-zn65fvrn5g9-g71-sp0lk82h0000gn-T-e2e-bottemiller-parents-91t9zm2u/6b6fa77e-a98a-4d4b-88f2-5c7d037177be/tool-results/mcp-genealogy-record_search-1783001425493.txt", "limit": 400, "offset": 1200}
+
+**tool_result:** 1200	        ]
+1201	      },
+1202	      "primaryId": "p_254795607"
+1203	    },
+1204	    {
+1205	      "recordId": "ark:/61903/1:1:M6XD-78T",
+1206	      "events": [
+1207	        {
+1208	          "type": "Census",
+1209	          "date": "1880",
+1210	          "place": "Madison Township, Jasper, Missouri, United States"
+1211	        },
+1212	        {
+1213	          "type": "Occupation",
+1214	          "value": "Works On Farm"
+1215	        },
+1216	        {
+1217	          "type": "Race",
+1218	    ...
+
+**tool_use** `Read` — args: {"file_path": "/Users/ernest/.claude/projects/-private-var-folders-g7-zn65fvrn5g9-g71-sp0lk82h0000gn-T-e2e-bottemiller-parents-91t9zm2u/6b6fa77e-a98a-4d4b-88f2-5c7d037177be/tool-results/mcp-genealogy-record_search-1783001425493.txt", "limit": 400, "offset": 1600}
+
+**tool_result:** 1600	            ],
+1601	            "sources": [
+1602	              {
+1603	                "ref": "sd_da1"
+1604	              }
+1605	            ]
+1606	          },
+1607	          {
+1608	            "id": "p_159252320",
+1609	            "ark": "ark:/61903/1:1:MWNV-4M2",
+1610	            "gender": "Female",
+1611	            "names": [
+1612	              {
+1613	                "type": "BirthName",
+1614	                "surname": "Sterrett",
+1615	                "given": "Mary M."
+1616	        ...
+
+**tool_use** `Read` — args: {"file_path": "/Users/ernest/.claude/projects/-private-var-folders-g7-zn65fvrn5g9-g71-sp0lk82h0000gn-T-e2e-bottemiller-parents-91t9zm2u/6b6fa77e-a98a-4d4b-88f2-5c7d037177be/tool-results/mcp-genealogy-record_search-1783001425493.txt", "limit": 400, "offset": 2000}
+
+**tool_result:** 2000	                "ref": "sd_da1"
+2001	              }
+2002	            ]
+2003	          },
+2004	          {
+2005	            "id": "p_269667106",
+2006	            "ark": "ark:/61903/1:1:M8SY-23N",
+2007	            "gender": "Female",
+2008	            "names": [
+2009	              {
+2010	                "type": "BirthName",
+2011	                "surname": "Grovemiller",
+2012	                "given": "Emma"
+2013	              }
+2014	            ],
+2015	            "facts": [
+2016	          ...
+
+**tool_use** `Read` — args: {"file_path": "/Users/ernest/.claude/projects/-private-var-folders-g7-zn65fvrn5g9-g71-sp0lk82h0000gn-T-e2e-bottemiller-parents-91t9zm2u/6b6fa77e-a98a-4d4b-88f2-5c7d037177be/tool-results/mcp-genealogy-record_search-1783001425493.txt", "limit": 400, "offset": 2400}
+
+**tool_result:** 2400	              {
+2401	                "type": "Birth",
+2402	                "date": "1865",
+2403	                "standard_date": "1865",
+2404	                "place": "Canada",
+2405	                "standard_place": "Canada"
+2406	              },
+2407	              {
+2408	                "type": "Census",
+2409	                "primary": true,
+2410	                "date": "1880",
+2411	                "standard_date": "1880",
+2412	                "place": "Ray Township, Macomb, Michigan, U...
+
+**tool_use** `Read` — args: {"file_path": "/Users/ernest/.claude/projects/-private-var-folders-g7-zn65fvrn5g9-g71-sp0lk82h0000gn-T-e2e-bottemiller-parents-91t9zm2u/6b6fa77e-a98a-4d4b-88f2-5c7d037177be/tool-results/mcp-genealogy-record_search-1783001425493.txt", "limit": 400, "offset": 2800}
+
+**tool_result:** 2800	              }
+2801	            ],
+2802	            "sources": [
+2803	              {
+2804	                "ref": "sd_da1"
+2805	              }
+2806	            ]
+2807	          },
+2808	          {
+2809	            "id": "p_383559603",
+2810	            "ark": "ark:/61903/1:1:MFPF-YZ3",
+2811	            "gender": "Male",
+2812	            "names": [
+2813	              {
+2814	                "type": "BirthName",
+2815	                "surname": "Kitsmiller",
+2816	                "given": "T...
+
+**tool_use** `Read` — args: {"file_path": "/Users/ernest/.claude/projects/-private-var-folders-g7-zn65fvrn5g9-g71-sp0lk82h0000gn-T-e2e-bottemiller-parents-91t9zm2u/6b6fa77e-a98a-4d4b-88f2-5c7d037177be/tool-results/mcp-genealogy-record_search-1783001425493.txt", "limit": 400, "offset": 3200}
+
+**tool_result:** 3200	            ],
+3201	            "sources": [
+3202	              {
+3203	                "ref": "sd_da1"
+3204	              }
+3205	            ]
+3206	          },
+3207	          {
+3208	            "id": "p_392578316",
+3209	            "ark": "ark:/61903/1:1:MNQK-B3T",
+3210	            "gender": "Female",
+3211	            "names": [
+3212	              {
+3213	                "type": "BirthName",
+3214	                "surname": "Kitzmiller",
+3215	                "given": "Ann"
+3216	          ...
+
+**tool_use** `Read` — args: {"file_path": "/Users/ernest/.claude/projects/-private-var-folders-g7-zn65fvrn5g9-g71-sp0lk82h0000gn-T-e2e-bottemiller-parents-91t9zm2u/6b6fa77e-a98a-4d4b-88f2-5c7d037177be/tool-results/mcp-genealogy-record_search-1783001425493.txt", "limit": 400, "offset": 3600}
+
+**tool_result:** 3600	              {
+3601	                "type": "MaritalStatus",
+3602	                "value": "Single"
+3603	              },
+3604	              {
+3605	                "type": "Race",
+3606	                "value": "White"
+3607	              },
+3608	              {
+3609	                "type": "Occupation",
+3610	                "value": "Works In A Mill"
+3611	              }
+3612	            ],
+3613	            "sources": [
+3614	              {
+3615	                "ref": "sd_da1"
+3616	     ...
+
+**tool_use** `Read` — args: {"file_path": "/Users/ernest/.claude/projects/-private-var-folders-g7-zn65fvrn5g9-g71-sp0lk82h0000gn-T-e2e-bottemiller-parents-91t9zm2u/6b6fa77e-a98a-4d4b-88f2-5c7d037177be/tool-results/mcp-genealogy-record_search-1783001425493.txt", "limit": 400, "offset": 4000}
+
+**tool_result:** 4000	                "ref": "sd_da1"
+4001	              }
+4002	            ]
+4003	          },
+4004	          {
+4005	            "id": "p_395969709",
+4006	            "ark": "ark:/61903/1:1:MNHR-NZC",
+4007	            "gender": "Female",
+4008	            "names": [
+4009	              {
+4010	                "type": "BirthName",
+4011	                "surname": "Fitchmiller",
+4012	                "given": "Louisa"
+4013	              }
+4014	            ],
+4015	            "facts": [
+4016	        ...
+
+**tool_use** `Read` — args: {"file_path": "/Users/ernest/.claude/projects/-private-var-folders-g7-zn65fvrn5g9-g71-sp0lk82h0000gn-T-e2e-bottemiller-parents-91t9zm2u/6b6fa77e-a98a-4d4b-88f2-5c7d037177be/tool-results/mcp-genealogy-record_search-1783001425493.txt", "limit": 400, "offset": 4400}
+
+**tool_result:** 4400	          {
+4401	            "id": "p_205795150",
+4402	            "ark": "ark:/61903/1:1:MHXS-9HZ",
+4403	            "gender": "Female",
+4404	            "names": [
+4405	              {
+4406	                "type": "BirthName",
+4407	                "given": "Edith",
+4408	                "surname": "Bottiamly"
+4409	              }
+4410	            ],
+4411	            "facts": [
+4412	              {
+4413	                "type": "Census",
+4414	                "primary": true,
+4415	        ...
+
+**tool_use** `Read` — args: {"file_path": "/Users/ernest/.claude/projects/-private-var-folders-g7-zn65fvrn5g9-g71-sp0lk82h0000gn-T-e2e-bottemiller-parents-91t9zm2u/6b6fa77e-a98a-4d4b-88f2-5c7d037177be/tool-results/mcp-genealogy-record_search-1783001425493.txt", "limit": 400, "offset": 4800}
+
+**tool_result:** 4800	            "sources": [
+4801	              {
+4802	                "ref": "sd_da1"
+4803	              }
+4804	            ]
+4805	          },
+4806	          {
+4807	            "id": "p_244183720",
+4808	            "ark": "ark:/61903/1:1:MZ96-R4Z",
+4809	            "gender": "Female",
+4810	            "names": [
+4811	              {
+4812	                "type": "BirthName",
+4813	                "given": "Sarah J.",
+4814	                "surname": "Bottomley"
+4815	              }
+4816	     ...
+
+**tool_use** `Read` — args: {"file_path": "/Users/ernest/.claude/projects/-private-var-folders-g7-zn65fvrn5g9-g71-sp0lk82h0000gn-T-e2e-bottemiller-parents-91t9zm2u/6b6fa77e-a98a-4d4b-88f2-5c7d037177be/tool-results/mcp-genealogy-record_search-1783001425493.txt", "limit": 400, "offset": 5200}
+
+**tool_result:** 5200	                "ref": "sd_da1"
+5201	              }
+5202	            ]
+5203	          },
+5204	          {
+5205	            "id": "p_244503340",
+5206	            "ark": "ark:/61903/1:1:MZ9R-28Z",
+5207	            "gender": "Male",
+5208	            "names": [
+5209	              {
+5210	                "type": "BirthName",
+5211	                "surname": "Bottermiller",
+5212	                "given": "Fred"
+5213	              }
+5214	            ],
+5215	            "facts": [
+5216	           ...
+
+**tool_use** `Read` — args: {"file_path": "/Users/ernest/.claude/projects/-private-var-folders-g7-zn65fvrn5g9-g71-sp0lk82h0000gn-T-e2e-bottemiller-parents-91t9zm2u/6b6fa77e-a98a-4d4b-88f2-5c7d037177be/tool-results/mcp-genealogy-record_search-1783001425493.txt", "limit": 400, "offset": 5600}
+
+**tool_result:** 5600	            "child": "p_244503339"
+5601	          },
+5602	          {
+5603	            "type": "ParentChild",
+5604	            "parent": "p_244503336",
+5605	            "child": "p_244503342"
+5606	          },
+5607	          {
+5608	            "type": "ParentChild",
+5609	            "parent": "p_244503336",
+5610	            "child": "p_244503348"
+5611	          },
+5612	          {
+5613	            "type": "ParentChild",
+5614	            "parent": "p_244503336",
+5615	            "child": ...
+
+**tool_use** `Read` — args: {"file_path": "/Users/ernest/.claude/projects/-private-var-folders-g7-zn65fvrn5g9-g71-sp0lk82h0000gn-T-e2e-bottemiller-parents-91t9zm2u/6b6fa77e-a98a-4d4b-88f2-5c7d037177be/tool-results/mcp-genealogy-record_search-1783001425493.txt", "limit": 400, "offset": 6000}
+
+**tool_result:** 6000	                "surname": "Olsmiller",
+6001	                "given": "Charlotta"
+6002	              }
+6003	            ],
+6004	            "facts": [
+6005	              {
+6006	                "type": "Birth",
+6007	                "date": "1840",
+6008	                "standard_date": "1840",
+6009	                "place": "Germany",
+6010	                "standard_place": "Germany"
+6011	              },
+6012	              {
+6013	                "type": "Census",
+6014	                "prima...
+
+**tool_use** `Read` — args: {"file_path": "/Users/ernest/.claude/projects/-private-var-folders-g7-zn65fvrn5g9-g71-sp0lk82h0000gn-T-e2e-bottemiller-parents-91t9zm2u/6b6fa77e-a98a-4d4b-88f2-5c7d037177be/tool-results/mcp-genealogy-record_search-1783001425493.txt", "limit": 400, "offset": 6400}
+
+**tool_result:** 6400	            "id": "p_336970915",
+6401	            "ark": "ark:/61903/1:1:M6TM-D3R",
+6402	            "gender": "Male",
+6403	            "names": [
+6404	              {
+6405	                "type": "BirthName",
+6406	                "surname": "Kitzmiller",
+6407	                "given": "Luke"
+6408	              }
+6409	            ],
+6410	            "facts": [
+6411	              {
+6412	                "type": "Birth",
+6413	                "date": "1836",
+6414	                "standard_dat...
+
+**tool_use** `Read` — args: {"file_path": "/Users/ernest/.claude/projects/-private-var-folders-g7-zn65fvrn5g9-g71-sp0lk82h0000gn-T-e2e-bottemiller-parents-91t9zm2u/6b6fa77e-a98a-4d4b-88f2-5c7d037177be/tool-results/mcp-genealogy-record_search-1783001425493.txt", "limit": 400, "offset": 6800}
+
+**tool_result:** 6800	          {
+6801	            "id": "sd_da1",
+6802	            "url": "https://www.familysearch.org/ark:/61903/3:1:33S7-9YBG-WSL"
+6803	          },
+6804	          {
+6805	            "id": "sd_auto_M9JT-92D",
+6806	            "title": "United States, Residences, Census, from 1526 to 2020"
+6807	          },
+6808	          {
+6809	            "id": "src_p_p_336970917",
+6810	            "url": "#p_336970917"
+6811	          }
+6812	        ],
+6813	        "places": [
+6814	          {
+6815	      ...
+
+**tool_use** `Read` — args: {"file_path": "/Users/ernest/.claude/projects/-private-var-folders-g7-zn65fvrn5g9-g71-sp0lk82h0000gn-T-e2e-bottemiller-parents-91t9zm2u/6b6fa77e-a98a-4d4b-88f2-5c7d037177be/tool-results/mcp-genealogy-record_search-1783001425493.txt", "limit": 400, "offset": 7200}
+
+**tool_result:** 7200	              {
+7201	                "type": "MaritalStatus",
+7202	                "value": "Single"
+7203	              },
+7204	              {
+7205	                "type": "Birth",
+7206	                "date": "1864",
+7207	                "standard_date": "1864",
+7208	                "place": "North Carolina, United States",
+7209	                "standard_place": "North Carolina, United States"
+7210	              },
+7211	              {
+7212	                "type": "Census",
+7213	      ...
+
+**tool_result:** [{"type": "text", "text": "I have now read all 7,511 lines of the file. Here is the complete report:\n\n---\n\n**totalMatches: 20** (from query metadata, line 13)\n\nThe query searched for William Bottemiller/Battermiller, census 1880, birth year 1860\u20131865, collection 1417683 (United States, Census, 1880).\n\n---\n\n## Results matching your three criteria\n\n### CRITERION 1 & 2 & 3 \u2014 THE KEY RESULT: \"William\" with Bottermiller surname + birth year in range + Minnesota, Todd County...
+
+**assistant:** Critical finding: "Willie Bottermiller" is in Bertha, Todd County in the household of **Henry Bottermiller** (b.1828, Germany) — but the death cert named "Casper A. Bottemiller" as father. Need to check for the staged ref and flag this conflict.
+
+**tool_use** `Bash` — args: {"command": "grep -i \"staged\\|resultsRef\\|results_ref\" /Users/ernest/.claude/projects/-private-var-folders-g7-zn65fvrn5g9-g71-sp0lk82h0000gn-T-e2e-bottemiller-parents-91t9zm2u/6b6fa77e-a98a-4d4b-88f2-5c7d037177be/tool-results/mcp-genealogy-record_search-1783001425493.txt | head -20", "description": "Find staged resultsRef in the large search result file"}
+
+**tool_result:**   "staged": {
+    "resultsRef": "results/.staging/795c395f-e157-41da-9370-5399f260470f.json",
+
+**assistant:** Good. Now logging the positive result, then reading the full household record.
+
+**tool_use** `mcp__genealogy__research_log_append` — args: {"projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u", "tool": "record_search", "planItemId": "pli_009", "query": {"givenName": "William", "givenNameAlt": "Willie", "surname": "Bottemiller", "surnameAlt": "Battermiller", "recordType": "census", "residenceYearFrom": 1880, "residenceYearTo": 1880, "birthYearFrom": 1860, "birthYearTo": 1865, "collectionId": "1417683"}, "outcome": "positive", "resultsExamined": 20, "resultsAvailable": 20, "sta...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"logId\": \"log_010\",\n  \"performed\": \"2026-07-02T14:14:15.636Z\",\n  \"resultsRef\": \"results/log_010.json\",\n  \"returnedCount\": 20,\n  \"filesWritten\": [\n    \"research.json\",\n    \"results/log_010.json\"\n  ],\n  \"validation\": {\n    \"valid\": true,\n    \"warnings\": []\n  }\n}"}]
+
+**assistant:** Now reading the full 1880 census household record.
+
+**tool_use** `mcp__genealogy__record_read` — args: {"recordId": "ark:/61903/1:1:MZ9R-28C"}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"persons\": [\n    {\n      \"id\": \"p_244503336\",\n      \"ark\": \"ark:/61903/1:1:MZ9R-28W\",\n      \"gender\": \"Male\",\n      \"names\": [\n        {\n          \"id\": \"1535a51e-0f07-4bac-832f-0e6670bf128b\",\n          \"type\": \"BirthName\",\n          \"given\": \"Henry\",\n          \"surname\": \"Bottermiller\"\n        }\n      ],\n      \"facts\": [\n        {\n          \"id\": \"bb44c52a-3b32-444b-8ad7-f081921b5d7f\",\n          \"type\": \...
+
+**assistant:** Excellent record. The 1880 census shows "Willie Bottermiller" (b.1862, MN) as son of **Henry Bottermiller** (b.1828, Germany) and **Mary Bottermiller** (b.1838, Germany) in Bertha, Todd County. This **conflicts** with the death cert's "Casper A. Bottemiller" for father's name. Now extracting source and assertions, then registering the conflict.
+
+**tool_use** `mcp__genealogy__research_append` — args: {"projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u", "ops": [{"section": "sources", "op": "append", "entry": {"gedcomx_source_description_id": "SCENSUS1880", "citation": "\"United States, Census, 1880\", FamilySearch (https://www.familysearch.org/ark:/61903/1:1:MZ9R-28W : 2 July 2026), Entry for Henry Bottermiller and Mary Bottermiller, Bertha, Todd, Minnesota, 1880.", "citation_detail": {"who": "Household of Henry Bottermiller", "what":...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": false,\n  \"errors\": [\n    \"research.json/sources[3]: gedcomx_source_description_id 'SCENSUS1880' not found in tree.gedcomx.json sources\",\n    \"research.json/assertions[14]: record_id 'https://www.familysearch.org/ark:/61903/1:1:MZ9R-28W' does not match any result's recordId in sidecar 'results/log_010.json'\",\n    \"research.json/assertions[15]: record_id 'https://www.familysearch.org/ark:/61903/1:1:MZ9R-28W' does not match any result's recordId...
+
+**assistant:** Two issues: GedcomX source not yet in tree, and record_id must match sidecar ARKs. Let me check the sidecar and fix both.
+
+**tool_use** `Bash` — args: {"command": "grep -i \"arkUrl\\|recordId\\|record_id\\|\\\"ark:\" /private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u/results/log_010.json | head -30", "description": "Find valid record IDs in log_010 sidecar"}
+
+**tool_result:**         "recordId": "ark:/61903/1:1:MXV4-R48",
+        "recordArk": "ark:/61903/1:2:MHGP-4NY",
+              "ark": "ark:/61903/1:1:MXV4-R48",
+              "ark": "ark:/61903/1:1:MXV4-R4C",
+              "ark": "ark:/61903/1:1:MXV4-R4Z",
+              "ark": "ark:/61903/1:1:MXV4-R4D",
+              "ark": "ark:/61903/1:1:MXV4-R46",
+              "ark": "ark:/61903/1:1:MXV4-R4X",
+              "ark": "ark:/61903/1:1:MXV4-R4F",
+        "recordId": "ark:/61903/1:1:MWSR-RF9",
+        "recordArk"...
+
+**tool_use** `Bash` — args: {"command": "grep -i \"MZ9R\\|Bottermiller\\|Bottemiller\" /private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u/results/log_010.json | head -30", "description": "Find Bottermiller records in sidecar"}
+
+**tool_result:**       "surname": "Bottemiller",
+      "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u"
+        "recordId": "ark:/61903/1:1:MZ9R-28C",
+        "personName": "Willie Bottermiller",
+        "recordTitle": "Household of Henry Bottermiller, \"United States, Census, 1880\"",
+              "ark": "ark:/61903/1:1:MZ9R-28C",
+                  "surname": "Bottermiller",
+              "ark": "ark:/61903/1:1:MZ9R-28W",
+                  "surname":...
+
+**assistant:** The sidecar `recordId` is `"ark:/61903/1:1:MZ9R-28C"` (bare ARK, not full URL). Also need to create the GedcomX source description first. Let me check the existing assertion record_id format and tree.gedcomx.json source IDs.
+
+**tool_use** `Bash` — args: {"command": "grep -i \"record_id\\|gedcomx_source\" /private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u/research.json | head -20", "description": "Check existing record_id format in research.json assertions"}
+
+**tool_result:**       "gedcomx_source_description_id": "S8VD-MGG",
+      "gedcomx_source_description_id": "S8VD-92V",
+      "gedcomx_source_description_id": "S8VD-963",
+      "record_id": "https://www.familysearch.org/ark:/61903/1:1:F8WM-X8F",
+      "record_id": "https://www.familysearch.org/ark:/61903/1:1:F8WM-X8F",
+      "record_id": "https://www.familysearch.org/ark:/61903/1:1:F8WM-X8F",
+      "record_id": "https://www.familysearch.org/ark:/61903/1:1:F8WM-X8F",
+      "record_id": "https://www.familysearch...
+
+**tool_use** `Bash` — args: {"command": "grep \"recordId\" /private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u/results/log_001.json | head -5", "description": "Check recordId format in prior sidecar"}
+
+**tool_result:** grep: /private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u/results/log_001.json: No such file or directory
+
+**tool_use** `Bash` — args: {"command": "ls /private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u/results/", "description": "List available sidecar result files"}
+
+**tool_result:** log_002.json
+log_003.json
+log_010.json
+
+**tool_use** `Bash` — args: {"command": "grep \"recordId\" /private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u/results/log_002.json | head -5", "description": "Check recordId format in log_002 sidecar"}
+
+**tool_result:**         "recordId": "ark:/61903/1:1:ZVXG-KGT2",
+        "recordId": "ark:/61903/1:1:ZG4C-5W6Z",
+        "recordId": "ark:/61903/1:1:CLZ6-BJ6Z",
+        "recordId": "ark:/61903/1:1:CL47-2HZM",
+
+**tool_use** `Bash` — args: {"command": "grep '\"id\"' /private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u/tree.gedcomx.json | grep '\"S' | head -20", "description": "List existing S-prefix source IDs in tree.gedcomx.json"}
+
+**tool_result:**       "id": "S8VD-6PG",
+      "id": "S8VD-963",
+      "id": "S8VD-W8P",
+      "id": "S8VD-D7K",
+      "id": "SWDM-F7D",
+      "id": "S8VD-92V",
+      "id": "S8VD-H6D",
+      "id": "S8VD-SNP",
+      "id": "S8VD-MGG",
+      "id": "SWDM-FRX",
+      "id": "S8VD-CVL",
+      "id": "SLH4-YV1",
+      "id": "SWDM-NJ6",
+
+**tool_use** `ToolSearch` — args: {"query": "select:mcp__genealogy__tree_edit", "max_results": 1}
+
+**tool_result:** [{"type": "tool_reference", "tool_name": "mcp__genealogy__tree_edit"}]
+
+**assistant:** Adding GedcomX source description and Henry Bottermiller stub to tree.gedcomx.json in one batch, then I'll use the assigned IDs to retry assertions.
+
+**tool_use** `mcp__genealogy__tree_edit` — args: {"projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u", "ops": [{"operation": "add_source", "source": {"title": "United States, Census, 1880 \u2014 Household of Henry Bottermiller, Bertha, Todd, Minnesota", "url": "https://www.familysearch.org/ark:/61903/1:1:MZ9R-28W"}}, {"operation": "add_person", "person": {"gender": "Male", "names": [{"type": "BirthName", "given": "Henry", "surname": "Bottermiller"}], "facts": [{"type": "Birth", "date": ...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": false,\n  \"errors\": [\n    \"tree.gedcomx.json/persons[10]/facts[0]: missing required field 'id'\",\n    \"tree.gedcomx.json/persons[10]/facts[1]: missing required field 'id'\"\n  ]\n}"}]
+
+**tool_use** `mcp__genealogy__tree_edit` — args: {"projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u", "ops": [{"operation": "add_source", "source": {"title": "United States, Census, 1880 \u2014 Household of Henry Bottermiller, Bertha, Todd, Minnesota", "url": "https://www.familysearch.org/ark:/61903/1:1:MZ9R-28W"}}, {"operation": "add_person", "person": {"gender": "Male", "names": [{"type": "BirthName", "given": "Henry", "surname": "Bottermiller"}]}}]}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"results\": [\n    {\n      \"operation\": \"add_source\",\n      \"assignedIds\": {\n        \"source\": \"S1\"\n      }\n    },\n    {\n      \"operation\": \"add_person\",\n      \"assignedIds\": {\n        \"person\": \"I3\",\n        \"names\": [\n          \"N3\"\n        ]\n      }\n    }\n  ],\n  \"filesWritten\": [\n    \"tree.gedcomx.json\"\n  ],\n  \"validation\": {\n    \"valid\": true,\n    \"warnings\": []\n  }\n}"}]
+
+**assistant:** Source ID: **S1**, Henry stub: **I3**. Now retrying source + assertions with correct record_id (`ark:/61903/1:1:MZ9R-28C`).
+
+**tool_use** `mcp__genealogy__research_append` — args: {"projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u", "ops": [{"section": "sources", "op": "append", "entry": {"gedcomx_source_description_id": "S1", "citation": "\"United States, Census, 1880\", FamilySearch (https://www.familysearch.org/ark:/61903/1:1:MZ9R-28W : 2 July 2026), Entry for Henry Bottermiller and Mary Bottermiller, Bertha, Todd, Minnesota, 1880.", "citation_detail": {"who": "Household of Henry Bottermiller", "what": "United ...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"results\": [\n    {\n      \"section\": \"sources\",\n      \"op\": \"append\",\n      \"entryId\": \"src_004\"\n    },\n    {\n      \"section\": \"assertions\",\n      \"op\": \"append\",\n      \"entryId\": \"a_015\"\n    },\n    {\n      \"section\": \"assertions\",\n      \"op\": \"append\",\n      \"entryId\": \"a_016\"\n    },\n    {\n      \"section\": \"assertions\",\n      \"op\": \"append\",\n      \"entryId\": \"a_017\"\n    },\n ...
+
+**assistant:** Source and assertions written (a_015–a_024). Now registering the Henry/Casper conflict and creating person_evidence links in one batch, then marking pli_009 completed.
+
+**tool_use** `mcp__genealogy__research_append` — args: {"projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u", "ops": [{"section": "conflicts", "op": "append", "entry": {"description": "Father's given name conflict: William Henry Bottemiller's 1929 Oregon death certificate names his father as 'Casper A. Bottemiller' (a_006), but the 1880 U.S. Census for William's household in Bertha, Todd, Minnesota lists the head as 'Henry Bottermiller' (a_019), born 1828, Germany. Both sources agree on surnam...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": false,\n  \"errors\": [\n    \"research.json/conflicts[0]: missing required field 'conflict_type'\",\n    \"research.json/conflicts[0]: missing required field 'competing_assertion_ids'\"\n  ]\n}"}]
+
+**tool_use** `Glob` — args: {"pattern": "**/research-schema-spec.md", "path": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u"}
+
+**tool_result:** No files found
+
+**tool_use** `Glob` — args: {"pattern": "**/*.md", "path": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u"}
+
+**tool_result:** .claude/skills/assertion-classification/references/three-layer-model.md
+.claude/skills/assertion-classification/references/validation-protocol.md
+.claude/skills/check-warnings/SKILL.md
+.claude/skills/check-warnings/references/assumption-categories.md
+.claude/skills/check-warnings/references/warning-checks.md
+.claude/skills/check-warnings/references/warnings-as-identity-signals.md
+.claude/skills/citation/references/gps-citation-standards.md
+.claude/skills/citation/references/validation-protoco...
+
+**tool_use** `Glob` — args: {"pattern": "docs/specs/*.md", "path": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u"}
+
+**tool_result:** No files found
+
+**tool_use** `Bash` — args: {"command": "grep -r \"conflict_type\\|competing_assertion\" /private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u/.claude/skills/ 2>/dev/null | head -20", "description": "Find conflict schema fields in skill reference files"}
+
+**tool_result:** /private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u/.claude/skills/conflict-resolution/SKILL.md:These use `conflict_type: "fact"` and require `disputed_attribute`
+/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u/.claude/skills/conflict-resolution/SKILL.md:These use `conflict_type: "identity"` and require `identity_question`.
+/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u/....
+
+**tool_use** `Read` — args: {"file_path": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u/.claude/skills/conflict-resolution/SKILL.md", "limit": 100}
+
+**tool_result:** 1	---
+2	name: conflict-resolution
+3	model: claude-sonnet-4-6
+4	allowed-tools:
+5	  - place_search
+6	  - place_search_all
+7	  - place_distance
+8	  - research_append
+9	  - convert_calendar
+10	description: >-
+11	  Identifies and resolves conflicting genealogical evidence — both fact-level
+12	  conflicts (three different birthplaces) and identity-level conflicts where
+13	  multiple candidate persons or records genuinely compete (e.g. two same-named
+14	  people in one county). Performs source indep...
+
+**tool_use** `Read` — args: {"file_path": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u/.claude/skills/conflict-resolution/SKILL.md", "offset": 99, "limit": 80}
+
+**tool_result:** 99	### 2. Create the conflict entry
+100	
+101	For each new conflict identified, append it to the `conflicts`
+102	section with `research_append`. Pass the entry in snake_case
+103	**without an id** — the tool assigns the next `c_` id, validates
+104	the whole project, and writes atomically:
+105	
+106	```
+107	research_append({
+108	  projectPath: "<absolute-path-to-project-directory>",
+109	  section: "conflicts",
+110	  op: "append",
+111	  entry: {
+112	    "conflict_type": "fact",
+113	    "descriptio...
+
+**assistant:** Now I have the exact conflict schema. Retrying the full batch with corrected conflict entry plus all person_evidence links.
+
+**tool_use** `mcp__genealogy__research_append` — args: {"projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u", "ops": [{"section": "conflicts", "op": "append", "entry": {"conflict_type": "fact", "description": "Father's given name conflict: William Henry Bottemiller's 1929 Oregon death certificate (a_006) names his father as 'Casper A. Bottemiller,' but the 1880 U.S. Census (a_019) for William's household in Bertha, Todd, Minnesota lists the household head as 'Henry Bottermiller,' born 1828, Ge...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"results\": [\n    {\n      \"section\": \"conflicts\",\n      \"op\": \"append\",\n      \"entryId\": \"c_001\"\n    },\n    {\n      \"section\": \"person_evidence\",\n      \"op\": \"append\",\n      \"entryId\": \"pe_017\"\n    },\n    {\n      \"section\": \"person_evidence\",\n      \"op\": \"append\",\n      \"entryId\": \"pe_018\"\n    },\n    {\n      \"section\": \"person_evidence\",\n      \"op\": \"append\",\n      \"entryId\": \"p...
+
+**assistant:** Conflict c_001 registered, pe_017–pe_027 linked, pli_009 completed. The Henry/Casper name conflict is now formally logged as blocking q_002. The 1870 census (pli_010) may show the family in Chisago County with a fuller name — executing that next.
+
+**tool_use** `mcp__genealogy__research_append` — args: {"projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-bottemiller-parents-91t9zm2u", "section": "plan_items", "op": "update", "planId": "pl_003", "entryId": "pli_010", "fields": {"status": "in_progress"}}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"section\": \"plan_items\",\n  \"op\": \"update\",\n  \"entryId\": \"pli_010\",\n  \"filesWritten\": [\n    \"research.json\"\n  ],\n  \"validation\": {\n    \"valid\": true,\n    \"warnings\": []\n  }\n}"}]

--- a/eval/tests/e2e/bottemiller-parents/README.md
+++ b/eval/tests/e2e/bottemiller-parents/README.md
@@ -1,0 +1,93 @@
+# Find William Henry Bottemiller's parents from the 1880 census and Oregon vital records
+
+**Source PID:** `249W-9LP`
+**William Henry Bottemiller is deceased.** (b. 29 Dec 1862, Franconia
+Township, Chisago County, Minnesota; d. 13 May 1929, Oregon City,
+Clackamas County, Oregon.) FamilySearch ToS requires all committed e2e
+fixtures to be about deceased persons.
+
+## Research question
+
+> Who were the parents of William Henry Bottemiller, born 29 December
+> 1862 in Franconia Township, Chisago County, Minnesota, and died
+> 13 May 1929 in Oregon City, Clackamas County, Oregon?
+
+## Expected answer
+
+- **Father:** Kasper (Casper) Heinrich Bottemiller — b. 23 Oct 1826,
+  Brockhagen, Westphalia, Prussia (Germany); d. 20 Apr 1899, Portland,
+  Multnomah County, Oregon.
+- **Mother:** Anne Marie Moehlmann — b. 7 Aug 1839, Minden, Westphalia
+  (Germany); d. 31 Jan 1921, Clackamas County, Oregon.
+
+## What was removed from the starting tree
+
+- Removed both parent persons — Kasper Heinrich Bottemiller (MD6P-76W)
+  and Anne Marie Moehlmann (LK6V-G8D) — and every relationship that
+  referenced them (the two parent-child links to William, their couple
+  bond, William's siblings, and the parents' own parents). The starting
+  tree retains only William, his wife Lillie Jane Kleinsmith, and their
+  six children.
+- Removed three sources whose citations **named a parent**, which would
+  otherwise leak the answer off the local tree:
+  - the 1880 U.S. Census ("Entry for Henry Bottermiller and Mary
+    Bottermiller") — the household showing William as a child;
+  - the mother's 1921 GenealogyBank obituary ("Anna Marie Bottemiller");
+  - the Oregon State Archives death record ("Casper H Battemilles").
+
+The other 22 sources remain, including the Oregon Death Index and
+Oregon Deaths and Burials entries — these show only William's own name,
+so they are legitimate *leads* the agent must follow to the underlying
+record rather than answer leaks.
+
+## How the answer is recoverable (records only; tree-reads blocked)
+
+- **1880 U.S. Census, Todd County, Minnesota** — William (age ~17, as
+  "Willie") enumerated in the household of Henry (Kasper) and Mary
+  (Anne Marie) Bottermiller. Establishes both parents directly.
+- **William's 1929 Oregon death record** — names father "Casper H."
+  Corroborates the father independently.
+
+Both records live on FamilySearch and are findable by record search;
+neither requires reading the (blocked) family tree.
+
+## Expected difficulty
+
+moderate — Two independent record paths exist, but the surname is
+transcribed many different ways across records (Bottermiller,
+Boettenellr, Buttimiller, Battemiller, Rottemiller), so the agent must
+search tolerantly and correlate the 1880 Minnesota household with the
+later Oregon records. German-immigrant parents add place-name and
+given-name variation (Kasper/Casper/Henry; Anne Marie/Anna Marie/Mary).
+
+## Notes for reviewers
+
+The surname-token overlap the stripping linter will flag on
+"Bottemiller" is expected and benign — the retained subject, spouse,
+and children all share the surname. The distinctive parent tokens
+(Kasper, Heinrich, Casper, Moehlmann, Anne/Anna Marie) are genuinely
+absent from the starting tree after stripping.
+
+### Expected run shape (first passing run, 2026-07-02)
+
+- **`proof_quality` of 2/3 is expected, not a defect.** Both parent
+  names are recoverable from a single derivative source — the Oregon
+  death-certificate abstract (`src_001`). The original certificate image
+  is not accessible via `record_read`, and full corroboration (1870/1880
+  censuses, Minnesota birth/marriage records) is more than fits the
+  default 60-minute cap. A sound run correctly tiers the parentage as
+  *probable* for the record-content claim and *possible* for the
+  identification — single-source, conservatively stated. A `score: 3`
+  would require raising `wall_clock_seconds` so the agent can execute the
+  corroborating searches it already plans.
+- **`stop_reason: timeout` is expected.** The agent completes the first
+  question (father/mother, with a proof summary) well inside the cap,
+  then autonomously opens a second question to corroborate and runs out
+  of wall-clock time mid-search. It stops because it did *extra* work,
+  not because it looped.
+- **The Henry-vs-Casper "conflict" is a name-form artifact, not a real
+  discrepancy.** The father is *Kasper **Heinrich** Bottemiller*, and
+  **Heinrich = Henry** — so the 1880 census head "Henry Bottermiller" is
+  the same man under his middle name. An agent that flags this as a
+  conflict (e.g. `c_001`) rather than silently equating the two is being
+  appropriately cautious; don't read that conflict as a research error.

--- a/eval/tests/e2e/bottemiller-parents/expected-findings.json
+++ b/eval/tests/e2e/bottemiller-parents/expected-findings.json
@@ -1,0 +1,40 @@
+{
+  "findings": [
+    {
+      "id": "f1",
+      "type": "relationship",
+      "description": "William Henry Bottemiller's father was Kasper (Casper) Heinrich Bottemiller, a German immigrant born in 1826 in Brockhagen, Westphalia, Prussia, who died in 1899 in Oregon.",
+      "details": {
+        "subject_person": "William Henry Bottemiller (249W-9LP)",
+        "relation": "parent",
+        "target_person": {
+          "name": "Kasper Heinrich Bottemiller",
+          "birth": "23 October 1826, Brockhagen, Steinhagen, Westphalia, Prussia (Germany)"
+        }
+      },
+      "supporting_sources": [
+        "1880 U.S. Census, Todd County, Minnesota — household of Henry Bottermiller, with son 'Willie'",
+        "Oregon State Archives Death Records — William's 1929 death entry naming father 'Casper H'"
+      ],
+      "required": true
+    },
+    {
+      "id": "f2",
+      "type": "relationship",
+      "description": "William Henry Bottemiller's mother was Anne Marie Moehlmann, born in 1839 in Germany, who died in 1921 in Clackamas County, Oregon.",
+      "details": {
+        "subject_person": "William Henry Bottemiller (249W-9LP)",
+        "relation": "parent",
+        "target_person": {
+          "name": "Anne Marie Moehlmann",
+          "birth": "7 August 1839, Minden, Westphalia (Germany)"
+        }
+      },
+      "supporting_sources": [
+        "1880 U.S. Census, Todd County, Minnesota — household of Henry & Mary Bottermiller",
+        "GenealogyBank obituary — Anna Marie Bottemiller, died 31 Jan 1921"
+      ],
+      "required": true
+    }
+  ]
+}

--- a/eval/tests/e2e/bottemiller-parents/fixture.json
+++ b/eval/tests/e2e/bottemiller-parents/fixture.json
@@ -1,0 +1,18 @@
+{
+  "id": "bottemiller-parents",
+  "name": "Find William Henry Bottemiller's parents from the 1880 census and Oregon vital records",
+  "source_pid": "249W-9LP",
+  "captured": "2026-07-01",
+  "researcher_question": "Who were the parents of William Henry Bottemiller, born 29 December 1862 in Franconia Township, Chisago County, Minnesota, and died 13 May 1929 in Oregon City, Clackamas County, Oregon?",
+  "tags": {
+    "question_type": "parents",
+    "era": "1880s",
+    "geography": "US-MN"
+  },
+  "model": {
+    "agent": "claude-sonnet-4-6",
+    "judge": "claude-haiku-4-5-20251001"
+  },
+  "difficulty": "moderate",
+  "notes": "German-immigrant parents. Recoverable via the 1880 U.S. Census (William, age 17, as 'Willie' in the Todd County, Minnesota household of Henry & Mary Bottermiller) and via William's 1929 Oregon death record (father 'Casper H'). Heavy surname transcription variation across records (Bottermiller, Boettenellr, Buttimiller, Battemiller, Rottemiller). Three parent-naming sources were stripped from the starting tree to prevent the answer leaking off the local citations: the 1880 census, the mother's 1921 GenealogyBank obituary, and the Oregon State Archives death record naming 'Casper H'. Death-index leads (Oregon Death Index / Deaths and Burials) remain as pointers the agent must follow."
+}

--- a/eval/tests/e2e/bottemiller-parents/starting-research.json
+++ b/eval/tests/e2e/bottemiller-parents/starting-research.json
@@ -1,0 +1,28 @@
+{
+  "project": {
+    "id": "rp_bottemiller_parents",
+    "objective": "Who were the parents of William Henry Bottemiller, born 29 December 1862 in Franconia Township, Chisago County, Minnesota, and died 13 May 1929 in Oregon City, Clackamas County, Oregon?",
+    "subject_person_ids": [
+      "249W-9LP"
+    ],
+    "status": "active",
+    "created": "2026-07-01T00:00:00Z",
+    "updated": "2026-07-01T00:00:00Z"
+  },
+  "researcher_profile": {
+    "experience_level": "intermediate",
+    "subscriptions": [],
+    "narration_guidance": "concise"
+  },
+  "questions": [],
+  "plans": [],
+  "log": [],
+  "sources": [],
+  "assertions": [],
+  "person_evidence": [],
+  "conflicts": [],
+  "hypotheses": [],
+  "timelines": [],
+  "proof_summaries": [],
+  "evaluations": []
+}

--- a/eval/tests/e2e/bottemiller-parents/starting-tree.gedcomx.json
+++ b/eval/tests/e2e/bottemiller-parents/starting-tree.gedcomx.json
@@ -1,0 +1,947 @@
+{
+  "persons": [
+    {
+      "id": "249W-9LP",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "given": "William Henry",
+          "surname": "Bottemiller",
+          "id": "249W-9LP-name-1"
+        }
+      ],
+      "facts": [
+        {
+          "id": "ebe0d4fe-20f8-4dad-b4b8-c69c03d0f100",
+          "type": "Birth",
+          "date": "29 December 1862",
+          "standard_date": "29 Dec 1862",
+          "place": "Franconia Township, Chisago, Minnesota, United States",
+          "standard_place": "Franconia Township, Chisago, Minnesota, United States"
+        },
+        {
+          "id": "ddb21ddf-0042-4808-af3c-5b2e94e08922",
+          "type": "Death",
+          "date": "13 May 1929",
+          "standard_date": "13 May 1929",
+          "place": "Oregon City, Clackamas, Oregon, United States",
+          "standard_place": "Oregon City, Clackamas, Oregon, United States"
+        },
+        {
+          "id": "e28231e3-b161-49ad-b96f-74418af12297",
+          "type": "Residence",
+          "date": "1880",
+          "standard_date": "1880",
+          "place": "Bertha, Todd, Minnesota, United States",
+          "standard_place": "Bertha, Todd, Minnesota, United States"
+        },
+        {
+          "id": "2bfab2b9-5551-49c8-bfb6-09753ac1e2f8",
+          "type": "Residence",
+          "date": "1900",
+          "standard_date": "1900",
+          "place": "ED 83 Canyon Creek, Highland, Molalla, and Soda Springs Precincts, Clackamas, Oregon, United States",
+          "standard_place": "Highland, Clackamas, Oregon, United States"
+        },
+        {
+          "id": "dc8a21ad-1bee-49a1-8870-8bc9e33f359a",
+          "type": "Residence",
+          "date": "1910",
+          "standard_date": "1910",
+          "place": "Highland, Clackamas, Oregon, United States",
+          "standard_place": "Highland, Clackamas, Oregon, United States"
+        },
+        {
+          "id": "4a5da382-7f3a-45be-82b2-7520cbc8c6af",
+          "type": "Residence",
+          "date": "1920",
+          "standard_date": "1920",
+          "place": "Clarks, Clackamas, Oregon, United States",
+          "standard_place": "Beavercreek, Clackamas, Oregon, United States"
+        },
+        {
+          "id": "397ae26d-5ab2-4e7f-b257-c303ca338d1b",
+          "type": "Burial",
+          "date": "1929",
+          "standard_date": "1929",
+          "place": "Clarkes, Clackamas, Oregon, United States of America",
+          "standard_place": "Clarkes, Clackamas, Oregon, United States"
+        }
+      ]
+    },
+    {
+      "id": "9SPC-3H6",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "given": "Lillie Jane",
+          "surname": "Kleinsmith",
+          "id": "9SPC-3H6-name-1"
+        }
+      ],
+      "facts": [
+        {
+          "id": "0590b254-9c0c-444c-b98d-af27463a6425",
+          "type": "Birth",
+          "date": "10 December 1867",
+          "standard_date": "10 Dec 1867",
+          "place": "Lehigh, Pennsylvania, United States",
+          "standard_place": "Lehigh, Pennsylvania, United States"
+        },
+        {
+          "id": "1d97e243-7fa6-499b-8c3c-50c53063ad42",
+          "type": "Residence",
+          "date": "1870",
+          "standard_date": "1870",
+          "place": "Lower Milford Township, Lehigh, Pennsylvania, United States",
+          "standard_place": "Lower Milford Township, Lehigh, Pennsylvania, United States"
+        },
+        {
+          "id": "3f8487d5-29da-40d1-93f5-6d150ead9485",
+          "type": "Residence",
+          "date": "1880",
+          "standard_date": "1880",
+          "place": "Union, Rice, Kansas, United States",
+          "standard_place": "Union Township, Rice, Kansas, United States"
+        },
+        {
+          "id": "a3ca8aea-4b58-4dbf-aecf-8fd8437e7791",
+          "type": "Residence",
+          "date": "1900",
+          "standard_date": "1900",
+          "place": "ED 83 Canyon Creek, Highland, Molalla, and Soda Springs Precincts, Clackamas, Oregon, United States",
+          "standard_place": "Molalla, Clackamas, Oregon, United States"
+        },
+        {
+          "id": "6247b437-91ac-4ea0-a0d5-e879ac74260a",
+          "type": "Residence",
+          "date": "1910",
+          "standard_date": "1910",
+          "place": "Highland, Clackamas, Oregon, United States",
+          "standard_place": "Highland, Clackamas, Oregon, United States"
+        },
+        {
+          "id": "f09ab214-7f76-4aae-acf4-57e10a26271d",
+          "type": "Residence",
+          "date": "1920",
+          "standard_date": "1920",
+          "place": "Clarks, Clackamas, Oregon, United States",
+          "standard_place": "Beavercreek, Clackamas, Oregon, United States"
+        },
+        {
+          "id": "f47723ec-e7d6-4628-8b82-0f1e6194d01e",
+          "type": "Residence",
+          "date": "1930",
+          "standard_date": "1930",
+          "place": "Clackamas, Oregon",
+          "standard_place": "Beavercreek, Clackamas, Oregon, United States"
+        },
+        {
+          "id": "e28231e3-b161-49ad-b96f-74418af12297",
+          "type": "Residence",
+          "date": "1935",
+          "standard_date": "1935",
+          "place": "Same House",
+          "standard_place": "Same, Manufahi, Timor-Leste"
+        },
+        {
+          "id": "b46dafc6-2242-431b-beeb-4ae5686b622c",
+          "type": "Burial",
+          "date": "1940",
+          "standard_date": "1940",
+          "place": "Clarkes, Clackamas, Oregon, United States of America",
+          "standard_place": "Clarkes, Clackamas, Oregon, United States"
+        },
+        {
+          "id": "2bfab2b9-5551-49c8-bfb6-09753ac1e2f8",
+          "type": "Residence",
+          "date": "1940",
+          "standard_date": "1940",
+          "place": "Clarks Election Precinct, Clackamas, Oregon, United States",
+          "standard_place": "Clarks Election Precinct, Clackamas, Oregon, United States"
+        },
+        {
+          "id": "9381f219-2889-4bfc-9b03-5527232282c1",
+          "type": "Death",
+          "date": "5 August 1940",
+          "standard_date": "5 Aug 1940",
+          "place": "Clarkes, Clackamas, Oregon, United States",
+          "standard_place": "Clarkes, Clackamas, Oregon, United States"
+        }
+      ]
+    },
+    {
+      "id": "27YW-V26",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "given": "Edwin E.",
+          "surname": "Bottemiller",
+          "id": "27YW-V26-name-1"
+        }
+      ],
+      "facts": [
+        {
+          "id": "ebe0d4fe-20f8-4dad-b4b8-c69c03d0f100",
+          "type": "Birth",
+          "date": "16 Jan 1900",
+          "standard_date": "16 Jan 1900",
+          "place": "Clarkes, Clackamas, Oregon, United States",
+          "standard_place": "Clarkes, Clackamas, Oregon, United States"
+        },
+        {
+          "id": "a3ca8aea-4b58-4dbf-aecf-8fd8437e7791",
+          "type": "Residence",
+          "date": "1900",
+          "standard_date": "1900",
+          "place": "ED 83 Canyon Creek, Highland, Molalla, and Soda Springs Precincts, Clackamas, Oregon, United States",
+          "standard_place": "Clackamas, Oregon, United States"
+        },
+        {
+          "id": "5bc67c13-28f0-49b0-b3e8-c4ece12abd1c",
+          "type": "Residence",
+          "date": "1910",
+          "standard_date": "1910",
+          "place": "Highland, Clackamas, Oregon, United States",
+          "standard_place": "Highland, Clackamas, Oregon, United States"
+        },
+        {
+          "id": "e6e8c307-6775-4121-bcc3-662dcec0d878",
+          "type": "Military Draft Registration",
+          "date": "from 1917 to 1918",
+          "standard_date": "Bet 1917 and 1918",
+          "place": "Clackamas, Oregon, United States",
+          "standard_place": "Clackamas, Oregon, United States"
+        },
+        {
+          "id": "b461e22a-118b-4d84-8af8-52c1d8ce45b7",
+          "type": "Residence",
+          "date": "1920",
+          "standard_date": "1920",
+          "place": "Beaver Creek, Clackamas, Oregon, United States",
+          "standard_place": "Beavercreek, Clackamas, Oregon, United States"
+        },
+        {
+          "id": "af5814bf-2b2c-406e-99a2-dcf5ab471f75",
+          "type": "Residence",
+          "date": "1930",
+          "standard_date": "1930",
+          "place": "Malden, Whitman, Washington, United States",
+          "standard_place": "Malden, Whitman, Washington, United States"
+        },
+        {
+          "id": "e28231e3-b161-49ad-b96f-74418af12297",
+          "type": "Residence",
+          "date": "1935",
+          "standard_date": "1935",
+          "place": "Same House",
+          "standard_place": "Same, Manufahi, Timor-Leste"
+        },
+        {
+          "id": "2bfab2b9-5551-49c8-bfb6-09753ac1e2f8",
+          "type": "Residence",
+          "date": "1940",
+          "standard_date": "1940",
+          "place": "Malden, Election Precinct 66 Malden, Whitman, Washington, United States",
+          "standard_place": "Election Precinct 66 Malden, Whitman, Washington, United States"
+        },
+        {
+          "id": "6027f919-c0f1-491a-8ada-cfa057ba269c",
+          "type": "Military Draft Registration",
+          "date": "16 February 1942",
+          "standard_date": "16 Feb 1942",
+          "place": "Malden, Whitman, Washington, United States",
+          "standard_place": "Malden, Whitman, Washington, United States"
+        },
+        {
+          "id": "82bba110-f443-4d53-9f2d-67f9733e49a5",
+          "type": "Residence",
+          "date": "5 April 1950",
+          "standard_date": "5 Apr 1950",
+          "place": "San Diego, San Diego, California, United States",
+          "standard_place": "San Diego, San Diego, California, United States"
+        },
+        {
+          "id": "ddb21ddf-0042-4808-af3c-5b2e94e08922",
+          "type": "Death",
+          "date": "July 1971",
+          "standard_date": "Jul 1971",
+          "place": "Washington, United States",
+          "standard_place": "Washington, United States"
+        },
+        {
+          "id": "d99cc0f4-1693-4c31-bcfe-25788ab76c17",
+          "type": "Residence",
+          "place": "Whitman, Washington, United States",
+          "standard_place": "Whitman, Washington, United States"
+        },
+        {
+          "id": "c5be31e4-c57a-417a-b672-456ec4e963d8",
+          "type": "Burial",
+          "place": "Pine City, Whitman, Washington, United States",
+          "standard_place": "Pine City, Whitman, Washington, United States"
+        },
+        {
+          "id": "4a7a1f8f-5077-4c04-971a-508847a16bf1",
+          "type": "Citizenship",
+          "place": "United States",
+          "standard_place": "United States"
+        },
+        {
+          "id": "0188e7c4-c5c4-42a8-b044-a7ad032297e8",
+          "type": "Ethnicity",
+          "value": "White"
+        },
+        {
+          "id": "ac9c8ba6-b7fc-4917-949b-7fe77c7ee336",
+          "type": "Residence",
+          "place": "Malden",
+          "standard_place": "Malden, Natal, South Africa"
+        }
+      ]
+    },
+    {
+      "id": "KG2Q-RD6",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "given": "Mary Sarah",
+          "surname": "Bottemiller",
+          "id": "KG2Q-RD6-name-1"
+        }
+      ],
+      "facts": [
+        {
+          "id": "ebe0d4fe-20f8-4dad-b4b8-c69c03d0f100",
+          "type": "Birth",
+          "date": "5 May 1897",
+          "standard_date": "5 May 1897",
+          "place": "Clarkes, Clackamas, Oregon",
+          "standard_place": "Clarkes, Clackamas, Oregon, United States"
+        },
+        {
+          "id": "f47723ec-e7d6-4628-8b82-0f1e6194d01e",
+          "type": "Residence",
+          "date": "1897",
+          "standard_date": "1897",
+          "place": "Oregon, United States",
+          "standard_place": "Oregon, United States"
+        },
+        {
+          "id": "a3ca8aea-4b58-4dbf-aecf-8fd8437e7791",
+          "type": "Residence",
+          "date": "1900",
+          "standard_date": "1900",
+          "place": "ED 83 Canyon Creek, Highland, Molalla, and Soda Springs Precincts, Clackamas, Oregon, United States",
+          "standard_place": "Soda Springs Precinct, Clackamas, Oregon, United States"
+        },
+        {
+          "id": "9ee79d2b-f352-4ead-a81e-c90caa70d293",
+          "type": "Residence",
+          "date": "1910",
+          "standard_date": "1910",
+          "place": "Highland, Clackamas, Oregon, United States",
+          "standard_place": "Highland, Clackamas, Oregon, United States"
+        },
+        {
+          "id": "1fec59c8-a7e7-48ca-ab15-518c73749b7b",
+          "type": "Residence",
+          "date": "1920",
+          "standard_date": "1920",
+          "place": "Clarks, Clackamas, Oregon, United States",
+          "standard_place": "Beavercreek, Clackamas, Oregon, United States"
+        },
+        {
+          "id": "e28231e3-b161-49ad-b96f-74418af12297",
+          "type": "Residence",
+          "date": "1935",
+          "standard_date": "1935",
+          "place": "Same Place",
+          "standard_place": "Same, Manufahi, Timor-Leste"
+        },
+        {
+          "id": "2bfab2b9-5551-49c8-bfb6-09753ac1e2f8",
+          "type": "Residence",
+          "date": "1940",
+          "standard_date": "1940",
+          "place": "Election Precinct 395 Community Acres, Multnomah, Oregon, United States",
+          "standard_place": "Election Precinct 395 Community Acres, Multnomah, Oregon, United States"
+        },
+        {
+          "id": "47905667-ce6e-42fb-9dd1-368c0d96d9e3",
+          "type": "Residence",
+          "date": "6 April 1950",
+          "standard_date": "6 Apr 1950",
+          "place": "Multnomah, Multnomah, Oregon, United States",
+          "standard_place": "Multnomah, Multnomah, Oregon, United States"
+        },
+        {
+          "id": "ddb21ddf-0042-4808-af3c-5b2e94e08922",
+          "type": "Death",
+          "date": "December 1970",
+          "standard_date": "Dec 1970",
+          "place": "Multnomah, Oregon, United States",
+          "standard_place": "Multnomah, Oregon, United States"
+        },
+        {
+          "id": "6ec4d518-4a4a-4db4-8405-8db5fb572589",
+          "type": "Burial",
+          "place": "Clackamas, Clackamas, Oregon, United States of America",
+          "standard_place": "Clackamas, Clackamas, Oregon, United States"
+        }
+      ]
+    },
+    {
+      "id": "KG77-4NL",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "given": "Ida Paulena",
+          "surname": "Bottemiller",
+          "id": "KG77-4NL-name-1"
+        }
+      ],
+      "facts": [
+        {
+          "id": "af5814bf-2b2c-406e-99a2-dcf5ab471f75",
+          "type": "Residence",
+          "date": "1892",
+          "standard_date": "1892",
+          "place": "Oregon, United States",
+          "standard_place": "Oregon, United States"
+        },
+        {
+          "id": "ebe0d4fe-20f8-4dad-b4b8-c69c03d0f100",
+          "type": "Birth",
+          "date": "10 July 1892",
+          "standard_date": "10 Jul 1892",
+          "place": "Clarkes, Clackamas, Oregon, United States",
+          "standard_place": "Clarkes, Clackamas, Oregon, United States"
+        },
+        {
+          "id": "a3ca8aea-4b58-4dbf-aecf-8fd8437e7791",
+          "type": "Residence",
+          "date": "1900",
+          "standard_date": "1900",
+          "place": "Clackamas, Oregon, United States",
+          "standard_place": "Clackamas, Oregon, United States"
+        },
+        {
+          "id": "58dbf4ae-b595-4081-bf18-e6fba83de640",
+          "type": "Residence",
+          "date": "1910",
+          "standard_date": "1910",
+          "place": "Highland, Clackamas, Oregon, United States",
+          "standard_place": "Highland, Clackamas, Oregon, United States"
+        },
+        {
+          "id": "f47723ec-e7d6-4628-8b82-0f1e6194d01e",
+          "type": "Residence",
+          "date": "1920",
+          "standard_date": "1920",
+          "place": "Portland, Multnomah, Oregon, United States",
+          "standard_place": "Portland, Multnomah, Oregon, United States"
+        },
+        {
+          "id": "272688ba-9db5-4a83-94df-1744d94ed9fd",
+          "type": "Residence",
+          "date": "1929",
+          "standard_date": "1929",
+          "place": "Malden, Whitman, Washington, United States",
+          "standard_place": "Malden, Whitman, Washington, United States"
+        },
+        {
+          "id": "2bfab2b9-5551-49c8-bfb6-09753ac1e2f8",
+          "type": "Residence",
+          "date": "1930",
+          "standard_date": "1930",
+          "place": "Clackamas, Oregon",
+          "standard_place": "Beavercreek, Clackamas, Oregon, United States"
+        },
+        {
+          "id": "0cd17197-e72f-437e-bb37-c5000e72952f",
+          "type": "Residence",
+          "date": "1935",
+          "standard_date": "1935",
+          "place": "Portland, Oregon",
+          "standard_place": "Portland, Multnomah, Oregon, United States"
+        },
+        {
+          "id": "decf9cf6-141e-43bd-b66c-713783fcd3fc",
+          "type": "Residence",
+          "date": "1940",
+          "standard_date": "1940",
+          "place": "Algona, Algona Election Precinct, King, Washington, United States",
+          "standard_place": "Algona Election Precinct, King, Washington, United States"
+        },
+        {
+          "id": "53c1a284-ba99-4848-8520-1a09113c4ab3",
+          "type": "Residence",
+          "date": "17 April 1950",
+          "standard_date": "17 Apr 1950",
+          "place": "King, Benton, Washington, United States",
+          "standard_place": "King, Benton, Washington, United States"
+        },
+        {
+          "id": "eb9e8df3-fb6b-4c51-9330-79521dde4cc8",
+          "type": "Burial",
+          "date": "1983",
+          "standard_date": "1983",
+          "place": "Mountain View Cemetery, Auburn, King, Washington, United States",
+          "standard_place": "Mountain View Cemetery, Auburn, King, Washington, United States"
+        },
+        {
+          "id": "ddb21ddf-0042-4808-af3c-5b2e94e08922",
+          "type": "Death",
+          "date": "26 November 1983",
+          "standard_date": "26 Nov 1983",
+          "place": "Enumclaw, King, Washington, United States",
+          "standard_place": "Enumclaw, King, Washington, United States"
+        },
+        {
+          "id": "4406cb3a-6872-4c5c-8d78-7bb22e918ac4",
+          "type": "Residence",
+          "place": "King, Washington, United States",
+          "standard_place": "King, Washington, United States"
+        },
+        {
+          "id": "f893c280-3123-4eac-bd17-3375d9f16bba",
+          "type": "Ethnicity",
+          "value": "White"
+        }
+      ]
+    },
+    {
+      "id": "27YW-V22",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "given": "Claude S.",
+          "surname": "Bottemiller",
+          "id": "27YW-V22-name-1"
+        }
+      ],
+      "facts": [
+        {
+          "id": "ebe0d4fe-20f8-4dad-b4b8-c69c03d0f100",
+          "type": "Birth",
+          "date": "4 August 1902",
+          "standard_date": "4 Aug 1902",
+          "place": "Clarkes, Clackamas, Oregon, United States",
+          "standard_place": "Clarkes, Clackamas, Oregon, United States"
+        },
+        {
+          "id": "14eeb097-cfc1-4598-b6b6-74a669754836",
+          "type": "Residence",
+          "date": "1910",
+          "standard_date": "1910",
+          "place": "Highland, Clackamas, Oregon, United States",
+          "standard_place": "Highland, Clackamas, Oregon, United States"
+        },
+        {
+          "id": "299a491e-0a76-403a-859c-8c7cc257d383",
+          "type": "Residence",
+          "date": "1920",
+          "standard_date": "1920",
+          "place": "Clarks, Clackamas, Oregon, United States",
+          "standard_place": "Beavercreek, Clackamas, Oregon, United States"
+        },
+        {
+          "id": "272688ba-9db5-4a83-94df-1744d94ed9fd",
+          "type": "Residence",
+          "date": "1929",
+          "standard_date": "1929",
+          "place": "Oregon City, - Clackamas, Oregon",
+          "standard_place": "Oregon City, Clackamas, Oregon, United States"
+        },
+        {
+          "id": "e28231e3-b161-49ad-b96f-74418af12297",
+          "type": "Residence",
+          "date": "1930",
+          "standard_date": "1930",
+          "place": "Clackamas, Oregon",
+          "standard_place": "Beavercreek, Clackamas, Oregon, United States"
+        },
+        {
+          "id": "2bfab2b9-5551-49c8-bfb6-09753ac1e2f8",
+          "type": "Residence",
+          "date": "1935",
+          "standard_date": "1935",
+          "place": "R, Clackamas, Oregon",
+          "standard_place": "Clackamas, Oregon, United States"
+        },
+        {
+          "id": "f47723ec-e7d6-4628-8b82-0f1e6194d01e",
+          "type": "Residence",
+          "date": "1940",
+          "standard_date": "1940",
+          "place": "Salem Election Precinct 20, Salem, Ward 6, Marion, Oregon",
+          "standard_place": "Salem Election Precinct 20, Marion, Oregon, United States"
+        },
+        {
+          "id": "52a19080-3339-40df-9b3f-b80fb7b9b521",
+          "type": "Burial",
+          "date": "1970",
+          "standard_date": "1970",
+          "place": "Salem, Marion, Oregon, United States of America",
+          "standard_place": "Salem, Marion, Oregon, United States"
+        },
+        {
+          "id": "689dd5f0-4e0e-47e7-9415-6db71c0d6dba",
+          "type": "Death",
+          "date": "1 August 1970",
+          "standard_date": "1 Aug 1970",
+          "place": "Salem, Marion, Oregon, United States",
+          "standard_place": "Salem, Marion, Oregon, United States"
+        }
+      ]
+    },
+    {
+      "id": "27YW-V68",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "given": "Henry",
+          "surname": "Bottemiller",
+          "id": "27YW-V68-name-1"
+        }
+      ],
+      "facts": [
+        {
+          "id": "ddb21ddf-0042-4808-af3c-5b2e94e08922",
+          "type": "Death",
+          "date": "1894",
+          "standard_date": "1894",
+          "place": "Clarkes, Clackamas, Oregon, United States",
+          "standard_place": "Clarkes, Clackamas, Oregon, United States"
+        },
+        {
+          "id": "ebe0d4fe-20f8-4dad-b4b8-c69c03d0f100",
+          "type": "Birth",
+          "date": "1894",
+          "standard_date": "1894",
+          "place": "Clarkes, Clackamas, Oregon, United States",
+          "standard_place": "Clarkes, Clackamas, Oregon, United States"
+        }
+      ]
+    },
+    {
+      "id": "27YW-V25",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "given": "Kenneth J.",
+          "surname": "Bottemiller",
+          "id": "27YW-V25-name-1"
+        }
+      ],
+      "facts": [
+        {
+          "id": "ebe0d4fe-20f8-4dad-b4b8-c69c03d0f100",
+          "type": "Birth",
+          "date": "4 June 1906",
+          "standard_date": "4 Jun 1906",
+          "place": "Washington, Oregon, United States",
+          "standard_place": "Washington, Oregon, United States"
+        },
+        {
+          "id": "f527ac94-8e98-407c-bd2f-4ed33670e975",
+          "type": "Residence",
+          "date": "1910",
+          "standard_date": "1910",
+          "place": "Highland, Clackamas, Oregon, United States",
+          "standard_place": "Highland, Clackamas, Oregon, United States"
+        },
+        {
+          "id": "3bd9d7d2-b804-4cf1-b267-3f8c1ebe6e62",
+          "type": "Residence",
+          "date": "1920",
+          "standard_date": "1920",
+          "place": "Clarks, Clackamas, Oregon, United States",
+          "standard_place": "Beavercreek, Clackamas, Oregon, United States"
+        },
+        {
+          "id": "272688ba-9db5-4a83-94df-1744d94ed9fd",
+          "type": "Residence",
+          "date": "1930",
+          "standard_date": "1930",
+          "place": "Clackamas, Oregon",
+          "standard_place": "Beavercreek, Clackamas, Oregon, United States"
+        },
+        {
+          "id": "f47723ec-e7d6-4628-8b82-0f1e6194d01e",
+          "type": "Residence",
+          "date": "1935",
+          "standard_date": "1935",
+          "place": "Same House",
+          "standard_place": "Same, Manufahi, Timor-Leste"
+        },
+        {
+          "id": "a3ca8aea-4b58-4dbf-aecf-8fd8437e7791",
+          "type": "Residence",
+          "date": "1940",
+          "standard_date": "1940",
+          "place": "Clarks Election Precinct, Clackamas, Oregon, United States",
+          "standard_place": "Clarks Election Precinct, Clackamas, Oregon, United States"
+        },
+        {
+          "id": "ddb21ddf-0042-4808-af3c-5b2e94e08922",
+          "type": "Death",
+          "date": "Jan 1985",
+          "standard_date": "Jan 1985",
+          "place": "Oregon",
+          "standard_place": "Oregon, United States"
+        }
+      ]
+    }
+  ],
+  "relationships": [
+    {
+      "type": "Couple",
+      "person1": "249W-9LP",
+      "person2": "9SPC-3H6",
+      "facts": [
+        {
+          "id": "e573dec0-658e-4a44-8778-6a5b97f18910",
+          "type": "Marriage",
+          "date": "02 Dec 1890",
+          "standard_date": "2 Dec 1890",
+          "place": "Clackamas,Oregon",
+          "standard_place": "Clackamas, Clackamas, Oregon, United States"
+        },
+        {
+          "id": "27913e02-f2f7-4653-9bc3-9a13a0896872",
+          "type": "Marriage",
+          "date": "2 Dec 1890",
+          "standard_date": "2 Dec 1890",
+          "place": "Clackamas, Clackamas, Oregon, United States",
+          "standard_place": "Clackamas, Clackamas, Oregon, United States"
+        }
+      ],
+      "id": "rel-couple-249W-9LP-9SPC-3H6"
+    },
+    {
+      "type": "ParentChild",
+      "parent": "249W-9LP",
+      "child": "KG77-4NL",
+      "subtype": "Biological",
+      "id": "rel-pc-249W-9LP-KG77-4NL"
+    },
+    {
+      "type": "ParentChild",
+      "parent": "9SPC-3H6",
+      "child": "KG77-4NL",
+      "subtype": "Biological",
+      "id": "rel-pc-9SPC-3H6-KG77-4NL"
+    },
+    {
+      "type": "ParentChild",
+      "parent": "249W-9LP",
+      "child": "27YW-V68",
+      "subtype": "Biological",
+      "id": "rel-pc-249W-9LP-27YW-V68"
+    },
+    {
+      "type": "ParentChild",
+      "parent": "9SPC-3H6",
+      "child": "27YW-V68",
+      "subtype": "Biological",
+      "id": "rel-pc-9SPC-3H6-27YW-V68"
+    },
+    {
+      "type": "ParentChild",
+      "parent": "249W-9LP",
+      "child": "KG2Q-RD6",
+      "id": "rel-pc-249W-9LP-KG2Q-RD6"
+    },
+    {
+      "type": "ParentChild",
+      "parent": "9SPC-3H6",
+      "child": "KG2Q-RD6",
+      "id": "rel-pc-9SPC-3H6-KG2Q-RD6"
+    },
+    {
+      "type": "ParentChild",
+      "parent": "249W-9LP",
+      "child": "27YW-V26",
+      "subtype": "Biological",
+      "id": "rel-pc-249W-9LP-27YW-V26"
+    },
+    {
+      "type": "ParentChild",
+      "parent": "9SPC-3H6",
+      "child": "27YW-V26",
+      "subtype": "Biological",
+      "id": "rel-pc-9SPC-3H6-27YW-V26"
+    },
+    {
+      "type": "ParentChild",
+      "parent": "249W-9LP",
+      "child": "27YW-V22",
+      "subtype": "Biological",
+      "id": "rel-pc-249W-9LP-27YW-V22"
+    },
+    {
+      "type": "ParentChild",
+      "parent": "9SPC-3H6",
+      "child": "27YW-V22",
+      "subtype": "Biological",
+      "id": "rel-pc-9SPC-3H6-27YW-V22"
+    },
+    {
+      "type": "ParentChild",
+      "parent": "249W-9LP",
+      "child": "27YW-V25",
+      "subtype": "Biological",
+      "id": "rel-pc-249W-9LP-27YW-V25"
+    },
+    {
+      "type": "ParentChild",
+      "parent": "9SPC-3H6",
+      "child": "27YW-V25",
+      "subtype": "Biological",
+      "id": "rel-pc-9SPC-3H6-27YW-V25"
+    }
+  ],
+  "sources": [
+    {
+      "id": "S8VD-6PG",
+      "title": "William in entry for Lilly Jane Bottemiller, \"Oregon, Deaths and Burials, 1903-1947\"",
+      "citation": "\"Oregon, Deaths and Burials, 1903-1947\", , <i>FamilySearch</i> (https://familysearch.org/ark:/61903/1:1:F8WS-MZG : 9 March 2022), William in entry for Lilly Jane Bottemiller, 1940.",
+      "url": "https://familysearch.org/ark:/61903/1:1:F8WS-MZG"
+    },
+    {
+      "id": "S8VD-963",
+      "title": "William Henry Bottemiller, \"Find a Grave Index\"",
+      "citation": "\"Find a Grave Index\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:QV2C-WKHM : Tue Apr 01 03:27:01 UTC 2025), Entry for William Henry Bottemiller.",
+      "url": "https://familysearch.org/ark:/61903/1:1:QV2C-WKHM"
+    },
+    {
+      "id": "S8VD-W8P",
+      "title": "W H Bottemiller, \"Washington, County Marriages, 1855-2008\"",
+      "citation": "\"Washington, County Marriages, 1855-2008\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:QPMP-CYSL : Wed Mar 06 02:39:42 UTC 2024), Entry for Edwin E Bottemiller and Eunice Coolbaugh, 14 August 1921.",
+      "url": "https://familysearch.org/ark:/61903/1:1:QPMP-CYSR"
+    },
+    {
+      "id": "S8VD-D7K",
+      "title": "William Bottemiller, \"Washington, County Marriages, 1855-2008\"",
+      "citation": "\"Washington, County Marriages, 1855-2008\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:Q2ZV-32CT : Wed Mar 06 06:03:22 UTC 2024), Entry for Frank Schultz and Ida Bottemiller Ralph, 5 November 1934.",
+      "url": "https://familysearch.org/ark:/61903/1:1:Q2ZV-328J"
+    },
+    {
+      "id": "3ZQ8-96S",
+      "title": "Wm Bottemiller, \"Washington, County Marriages, 1855-2008\"",
+      "citation": "\"Washington, County Marriages, 1855-2008\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:Q2ZK-85XD : Sun Mar 10 18:52:42 UTC 2024), Entry for Charlie Ralph and Ida P Bottemiller, 9 October 1913.",
+      "url": "https://familysearch.org/ark:/61903/1:1:Q2ZK-85XK"
+    },
+    {
+      "id": "M9GV-VJM",
+      "title": "William Henry Bottemiller in entry for Mary Sarah Bottemiller, \"Oregon, Births and Christenings, 1868-1929\"",
+      "citation": "\"Oregon, Births and Christenings, 1868-1929\", , <i>FamilySearch</i> (https://familysearch.org/ark:/61903/1:1:HR3P-QY3Z : 12 February 2020), William Henry Bottemiller in entry for Mary Sarah Bottemiller, 1897.",
+      "url": "https://familysearch.org/ark:/61903/1:1:FZ5Q-7MP"
+    },
+    {
+      "id": "MS9X-G6V",
+      "title": "Legacy NFS Source: Henry Wilhelm Bottemiller - birth: 29 December 1861; Chisago City, Chisago, Minnesota, United States",
+      "citation": "Authors Files, Unknown, Punchbowl Street, Honolulu, Hawai`i, Page number: Records form Eldon Bottemiller."
+    },
+    {
+      "id": "SWDM-F7D",
+      "title": "Wm Bottemiller, \"Washington, County Marriages, 1855-2008\"",
+      "citation": "\"Washington, County Marriages, 1855-2008\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:QPMK-DLZQ : Sun Mar 10 16:04:00 UTC 2024), Entry for Charlie Ralph and Ida P Bottemiller, 9 October 1913.",
+      "url": "https://familysearch.org/ark:/61903/1:1:QPMK-DL8Q"
+    },
+    {
+      "id": "3KN1-497",
+      "title": "William Henry Bottemiller, \"Oregon, Oregon State Archives, Births, 1842-1917\"",
+      "citation": "\"Oregon, Oregon State Archives, Births, 1842-1917\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:WQ52-L5PZ : Sat Mar 09 00:09:02 UTC 2024), Entry for Edwin Eugene Bottemiller and William Henry Bottemiller, 16 Jan 1900.",
+      "url": "https://familysearch.org/ark:/61903/1:1:WQ52-L5T2"
+    },
+    {
+      "id": "9X5Z-VWF",
+      "title": "William H. Bottemiller in entry for Ida Paulena Bottemiller, \"Oregon, Births and Christenings, 1868-1929\"",
+      "citation": "\"Oregon, Births and Christenings, 1868-1929\", , <i>FamilySearch</i> (https://familysearch.org/ark:/61903/1:1:HR3F-LDMM : 12 February 2020), William H. Bottemiller in entry for Ida Paulena Bottemiller, 1892.",
+      "url": "https://familysearch.org/ark:/61903/1:1:FZ5R-MQV"
+    },
+    {
+      "id": "S8VD-92V",
+      "title": "Henry William Battemiller, \"Oregon, Death Index, 1903-1998\"",
+      "citation": "\"Oregon, Death Index, 1903-1998\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:VZHS-YXF : Wed Feb 19 08:32:08 UTC 2025), Entry for Henry William Battemiller, 13 May 1929.",
+      "url": "https://familysearch.org/ark:/61903/1:1:VZHS-YXF"
+    },
+    {
+      "id": "S8VD-H6D",
+      "title": "William H Boettenellr, \"United States, Census, 1910\"",
+      "citation": "\"United States, Census, 1910\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:MLYK-BSQ : Wed Aug 13 19:08:41 UTC 2025), Entry for William H Boettenellr and Lilly J Boettenellr, 1910.",
+      "url": "https://familysearch.org/ark:/61903/1:1:MLYK-BSQ"
+    },
+    {
+      "id": "S8VD-SNP",
+      "title": "W H Bottemiller, \"Washington, County Marriages, 1855-2008\"",
+      "citation": "\"Washington, County Marriages, 1855-2008\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:QPML-KTFF : Sat Mar 09 07:22:31 UTC 2024), Entry for Edwin E Bottemiller and Eunice Coolbaugh, 14 August 1921.",
+      "url": "https://familysearch.org/ark:/61903/1:1:QPML-KTFK"
+    },
+    {
+      "id": "M9GV-FZD",
+      "title": "William H Rottemiller, \"United States, Census, 1900\"",
+      "citation": "\"United States, Census, 1900\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:MSDC-G3V : Sat Oct 11 09:16:16 UTC 2025), Entry for William H Rottemiller and Lilly J Rottemiller, 1900.",
+      "url": "https://familysearch.org/ark:/61903/1:1:MSDC-G3V"
+    },
+    {
+      "id": "S8VD-MGG",
+      "title": "Henry William Battemiller, \"Oregon, Deaths and Burials, 1903-1947\"",
+      "citation": "\"Oregon, Deaths and Burials, 1903-1947\", , <i>FamilySearch</i> (https://familysearch.org/ark:/61903/1:1:F8WM-X8F : 9 March 2022), Henry William Battemiller, 1929.",
+      "url": "https://familysearch.org/ark:/61903/1:1:F8WM-X8F"
+    },
+    {
+      "id": "SWDM-FRX",
+      "title": "William Bottemiller, \"Washington, County Marriages, 1855-2008\"",
+      "citation": "\"Washington, County Marriages, 1855-2008\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:QPMN-4ZKJ : Thu Mar 07 10:59:37 UTC 2024), Entry for Frank Schultz and Ida Ralph, 5 November 1934.",
+      "url": "https://familysearch.org/ark:/61903/1:1:QPMN-6BMN"
+    },
+    {
+      "id": "S8VD-CVL",
+      "title": "William H Buttimiller, \"United States, Census, 1920\"",
+      "citation": "\"United States, Census, 1920\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:M48C-K7N : Tue Oct 21 01:36:13 UTC 2025), Entry for William H Buttimiller and Lily J Buttimiller, 1920.",
+      "url": "https://familysearch.org/ark:/61903/1:1:M48C-K7N"
+    },
+    {
+      "id": "SLH4-YV1",
+      "title": "William H. Bottemiller in entry for Ida Paulena Bottemiller, \"Oregon, Births and Christenings, 1868-1929\"",
+      "citation": "\"Oregon, Births and Christenings, 1868-1929\", , <i>FamilySearch</i> (https://familysearch.org/ark:/61903/1:1:HR3F-LDMM : 12 February 2020), William H. Bottemiller in entry for Ida Paulena Bottemiller, 1892.",
+      "url": "https://familysearch.org/ark:/61903/1:1:HR3F-LDMM"
+    },
+    {
+      "id": "SWDM-NJ6",
+      "title": "Wm Bottemiller, \"Washington, County Marriages, 1855-2008\"",
+      "citation": "\"Washington, County Marriages, 1855-2008\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:QPMK-8LM7 : Sat Mar 09 00:50:30 UTC 2024), Entry for Charlie Ralph and Ida P Bottemiller, 9 October 1913.",
+      "url": "https://familysearch.org/ark:/61903/1:1:QPMK-8L91"
+    },
+    {
+      "id": "3DYW-2PK",
+      "title": "William Henry Bottemiller in entry for Mary Sarah Bottemiller, \"Oregon, Births and Christenings, 1868-1929\"",
+      "citation": "\"Oregon, Births and Christenings, 1868-1929\", , <i>FamilySearch</i> (https://familysearch.org/ark:/61903/1:1:HR3P-QY3Z : 12 February 2020), William Henry Bottemiller in entry for Mary Sarah Bottemiller, 1897.",
+      "url": "https://familysearch.org/ark:/61903/1:1:HR3P-QY3Z"
+    },
+    {
+      "id": "3KN1-QCH",
+      "title": "William Henry Bottemiller, \"Oregon, Oregon State Archives, Births, 1842-1917\"",
+      "citation": "\"Oregon, Oregon State Archives, Births, 1842-1917\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:W7VK-412M : Sat Mar 09 05:01:01 UTC 2024), Entry for Mary Sariah Bottemiller Dutton and William Henry Bottemiller, 5 May 1897.",
+      "url": "https://familysearch.org/ark:/61903/1:1:W7VK-41PZ"
+    },
+    {
+      "id": "3KN1-7X2",
+      "title": "William H Bottemiller, \"Oregon, Oregon State Archives, Births, 1842-1917\"",
+      "citation": "\"Oregon, Oregon State Archives, Births, 1842-1917\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:WQBK-T9N2 : Sat Mar 09 05:59:22 UTC 2024), Entry for Ida Paulena Bottemiller and William H Bottemiller, 10 Jul 1892.",
+      "url": "https://familysearch.org/ark:/61903/1:1:WQBK-T92M"
+    }
+  ]
+}


### PR DESCRIPTION
GPS benchmark for William Henry Bottemiller (249W-9LP) — who were his parents? Strips the parents (Kasper Heinrich Bottemiller & Anne Marie Moehlmann) and three parent-naming source citations; recoverable from records (1880 census, Oregon death certificates).

Certified with first passing headless run: verdict=pass, blocked_tree_reads=0 (solved purely from records). Graded blind via /grade-e2e-run: f1/f2 both true, proof_quality 2 (.ann.json committed).
Title:


Add e2e fixture: bottemiller-parents (#527)
Body:


Closes #527.

Adds the `bottemiller-parents` e2e GPS benchmark for William Henry Bottemiller (`249W-9LP`) — "who were his parents?"

**Fixture** — strips the parents (Kasper Heinrich Bottemiller & Anne Marie Moehlmann), every relationship to them, and three parent-naming source citations (1880 census, mother's obituary, Oregon death record). Recoverable from records: the 1880 U.S. Census household and Oregon death certificates.

**Validation** — stripping linter clean; `research.json` schema valid.

**Certification** — first passing headless run (`run-2026-07-02_14-24-47`): `verdict: pass`, `blocked_tree_reads: 0` — recovered both parents purely from records, no tree shortcut.

**Grading** — graded blind via `/grade-e2e-run`: f1 (father) and f2 (mother) both `true`; `proof_quality_score: 2` (`.ann.json` committed).

**Expected run shape** — `proof_quality: 2/3` and `stop_reason: timeout` are expected here (parent names come from a single derivative source within the 60-min cap; then it times out doing extra corroboration on a self-opened second question). Documented in the fixture README.
