### PR TITLE
add runlog

### DIFF
--- a/eval/runlogs/unit/check-warnings/v1_2026-07-05_16-35-38.ann.json
+++ b/eval/runlogs/unit/check-warnings/v1_2026-07-05_16-35-38.ann.json
@@ -1,0 +1,942 @@
+{
+  "run_log": "v1_2026-07-05_16-35-38.json",
+  "annotator": "dallan@quass.org",
+  "corrections": [
+    {
+      "test_id": "ut_check_warnings_001",
+      "dimension_source": "base",
+      "dimension_name": "Correctness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_check_warnings_001",
+      "dimension_source": "base",
+      "dimension_name": "Completeness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_check_warnings_001",
+      "dimension_source": "base",
+      "dimension_name": "Tool Arguments",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_check_warnings_001",
+      "dimension_source": "rubric",
+      "dimension_name": "Detection accuracy",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_check_warnings_001",
+      "dimension_source": "rubric",
+      "dimension_name": "Severity classification",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_check_warnings_001",
+      "dimension_source": "rubric",
+      "dimension_name": "Actionability",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_check_warnings_001",
+      "dimension_source": "rubric",
+      "dimension_name": "FamilySearch quality reporting",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_check_warnings_002",
+      "dimension_source": "base",
+      "dimension_name": "Correctness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_check_warnings_002",
+      "dimension_source": "base",
+      "dimension_name": "Completeness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_check_warnings_002",
+      "dimension_source": "base",
+      "dimension_name": "Tool Arguments",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_check_warnings_002",
+      "dimension_source": "rubric",
+      "dimension_name": "Detection accuracy",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_check_warnings_002",
+      "dimension_source": "rubric",
+      "dimension_name": "Severity classification",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_check_warnings_002",
+      "dimension_source": "rubric",
+      "dimension_name": "Actionability",
+      "llm_score": null,
+      "corrected_score": null,
+      "comment": null
+    },
+    {
+      "test_id": "ut_check_warnings_002",
+      "dimension_source": "rubric",
+      "dimension_name": "FamilySearch quality reporting",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_check_warnings_009",
+      "dimension_source": "base",
+      "dimension_name": "Correctness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_check_warnings_009",
+      "dimension_source": "base",
+      "dimension_name": "Completeness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_check_warnings_009",
+      "dimension_source": "base",
+      "dimension_name": "Tool Arguments",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_check_warnings_009",
+      "dimension_source": "rubric",
+      "dimension_name": "Detection accuracy",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_check_warnings_009",
+      "dimension_source": "rubric",
+      "dimension_name": "Severity classification",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_check_warnings_009",
+      "dimension_source": "rubric",
+      "dimension_name": "Actionability",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_check_warnings_009",
+      "dimension_source": "rubric",
+      "dimension_name": "FamilySearch quality reporting",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_check_warnings_009",
+      "dimension_source": "rubric",
+      "dimension_name": "Cluster verdict recognition",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_check_warnings_009",
+      "dimension_source": "rubric",
+      "dimension_name": "Relative-warning rule",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_check_warnings_009",
+      "dimension_source": "rubric",
+      "dimension_name": "Escalation and handoff",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_check_warnings_007",
+      "dimension_source": "base",
+      "dimension_name": "Correctness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_check_warnings_007",
+      "dimension_source": "base",
+      "dimension_name": "Completeness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_check_warnings_007",
+      "dimension_source": "base",
+      "dimension_name": "Tool Arguments",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_check_warnings_007",
+      "dimension_source": "rubric",
+      "dimension_name": "Detection accuracy",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_check_warnings_007",
+      "dimension_source": "rubric",
+      "dimension_name": "Severity classification",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_check_warnings_007",
+      "dimension_source": "rubric",
+      "dimension_name": "Actionability",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_check_warnings_007",
+      "dimension_source": "rubric",
+      "dimension_name": "FamilySearch quality reporting",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_check_warnings_010",
+      "dimension_source": "base",
+      "dimension_name": "Correctness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_check_warnings_010",
+      "dimension_source": "base",
+      "dimension_name": "Completeness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_check_warnings_010",
+      "dimension_source": "base",
+      "dimension_name": "Tool Arguments",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_check_warnings_010",
+      "dimension_source": "rubric",
+      "dimension_name": "Detection accuracy",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_check_warnings_010",
+      "dimension_source": "rubric",
+      "dimension_name": "Severity classification",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_check_warnings_010",
+      "dimension_source": "rubric",
+      "dimension_name": "Actionability",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_check_warnings_010",
+      "dimension_source": "rubric",
+      "dimension_name": "FamilySearch quality reporting",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_check_warnings_004",
+      "dimension_source": "base",
+      "dimension_name": "Correctness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_check_warnings_004",
+      "dimension_source": "base",
+      "dimension_name": "Completeness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_check_warnings_004",
+      "dimension_source": "base",
+      "dimension_name": "Tool Arguments",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_check_warnings_004",
+      "dimension_source": "rubric",
+      "dimension_name": "Detection accuracy",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_check_warnings_004",
+      "dimension_source": "rubric",
+      "dimension_name": "Severity classification",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_check_warnings_004",
+      "dimension_source": "rubric",
+      "dimension_name": "Actionability",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_check_warnings_004",
+      "dimension_source": "rubric",
+      "dimension_name": "FamilySearch quality reporting",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_check_warnings_005",
+      "dimension_source": "base",
+      "dimension_name": "Correctness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_check_warnings_005",
+      "dimension_source": "base",
+      "dimension_name": "Completeness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_check_warnings_005",
+      "dimension_source": "base",
+      "dimension_name": "Tool Arguments",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_check_warnings_005",
+      "dimension_source": "rubric",
+      "dimension_name": "Detection accuracy",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_check_warnings_005",
+      "dimension_source": "rubric",
+      "dimension_name": "Severity classification",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_check_warnings_005",
+      "dimension_source": "rubric",
+      "dimension_name": "Actionability",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_check_warnings_005",
+      "dimension_source": "rubric",
+      "dimension_name": "FamilySearch quality reporting",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_check_warnings_006",
+      "dimension_source": "base",
+      "dimension_name": "Correctness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_check_warnings_006",
+      "dimension_source": "base",
+      "dimension_name": "Completeness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_check_warnings_006",
+      "dimension_source": "base",
+      "dimension_name": "Tool Arguments",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_check_warnings_006",
+      "dimension_source": "rubric",
+      "dimension_name": "Detection accuracy",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_check_warnings_006",
+      "dimension_source": "rubric",
+      "dimension_name": "Severity classification",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_check_warnings_006",
+      "dimension_source": "rubric",
+      "dimension_name": "Actionability",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_check_warnings_006",
+      "dimension_source": "rubric",
+      "dimension_name": "FamilySearch quality reporting",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_check_warnings_013",
+      "dimension_source": "base",
+      "dimension_name": "Correctness",
+      "llm_score": 2,
+      "corrected_score": 2,
+      "comment": null
+    },
+    {
+      "test_id": "ut_check_warnings_013",
+      "dimension_source": "base",
+      "dimension_name": "Completeness",
+      "llm_score": 2,
+      "corrected_score": 2,
+      "comment": null
+    },
+    {
+      "test_id": "ut_check_warnings_013",
+      "dimension_source": "base",
+      "dimension_name": "Tool Arguments",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_check_warnings_013",
+      "dimension_source": "rubric",
+      "dimension_name": "Detection accuracy",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_check_warnings_013",
+      "dimension_source": "rubric",
+      "dimension_name": "Severity classification",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_check_warnings_013",
+      "dimension_source": "rubric",
+      "dimension_name": "Actionability",
+      "llm_score": 2,
+      "corrected_score": 2,
+      "comment": null
+    },
+    {
+      "test_id": "ut_check_warnings_013",
+      "dimension_source": "rubric",
+      "dimension_name": "FamilySearch quality reporting",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_check_warnings_008",
+      "dimension_source": "base",
+      "dimension_name": "Correctness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_check_warnings_008",
+      "dimension_source": "base",
+      "dimension_name": "Completeness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_check_warnings_008",
+      "dimension_source": "base",
+      "dimension_name": "Tool Arguments",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_check_warnings_008",
+      "dimension_source": "rubric",
+      "dimension_name": "Detection accuracy",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_check_warnings_008",
+      "dimension_source": "rubric",
+      "dimension_name": "Severity classification",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_check_warnings_008",
+      "dimension_source": "rubric",
+      "dimension_name": "Actionability",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_check_warnings_008",
+      "dimension_source": "rubric",
+      "dimension_name": "FamilySearch quality reporting",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_check_warnings_003",
+      "dimension_source": "base",
+      "dimension_name": "Correctness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_check_warnings_003",
+      "dimension_source": "base",
+      "dimension_name": "Completeness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_check_warnings_003",
+      "dimension_source": "base",
+      "dimension_name": "Tool Arguments",
+      "llm_score": null,
+      "corrected_score": null,
+      "comment": null
+    },
+    {
+      "test_id": "ut_check_warnings_012",
+      "dimension_source": "base",
+      "dimension_name": "Correctness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_check_warnings_012",
+      "dimension_source": "base",
+      "dimension_name": "Completeness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_check_warnings_012",
+      "dimension_source": "base",
+      "dimension_name": "Tool Arguments",
+      "llm_score": null,
+      "corrected_score": null,
+      "comment": null
+    },
+    {
+      "test_id": "ut_check_warnings_011",
+      "dimension_source": "base",
+      "dimension_name": "Correctness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_check_warnings_011",
+      "dimension_source": "base",
+      "dimension_name": "Completeness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_check_warnings_011",
+      "dimension_source": "base",
+      "dimension_name": "Tool Arguments",
+      "llm_score": null,
+      "corrected_score": null,
+      "comment": null
+    },
+    {
+      "test_id": "ut_check_warnings_015",
+      "dimension_source": "base",
+      "dimension_name": "Correctness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_check_warnings_015",
+      "dimension_source": "base",
+      "dimension_name": "Completeness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_check_warnings_015",
+      "dimension_source": "base",
+      "dimension_name": "Tool Arguments",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_check_warnings_015",
+      "dimension_source": "rubric",
+      "dimension_name": "Detection accuracy",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_check_warnings_015",
+      "dimension_source": "rubric",
+      "dimension_name": "Severity classification",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_check_warnings_015",
+      "dimension_source": "rubric",
+      "dimension_name": "Actionability",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_check_warnings_015",
+      "dimension_source": "rubric",
+      "dimension_name": "FamilySearch quality reporting",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_check_warnings_016",
+      "dimension_source": "base",
+      "dimension_name": "Correctness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_check_warnings_016",
+      "dimension_source": "base",
+      "dimension_name": "Completeness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_check_warnings_016",
+      "dimension_source": "base",
+      "dimension_name": "Tool Arguments",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_check_warnings_016",
+      "dimension_source": "rubric",
+      "dimension_name": "Detection accuracy",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_check_warnings_016",
+      "dimension_source": "rubric",
+      "dimension_name": "Severity classification",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_check_warnings_016",
+      "dimension_source": "rubric",
+      "dimension_name": "Actionability",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_check_warnings_016",
+      "dimension_source": "rubric",
+      "dimension_name": "FamilySearch quality reporting",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_check_warnings_014",
+      "dimension_source": "base",
+      "dimension_name": "Correctness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_check_warnings_014",
+      "dimension_source": "base",
+      "dimension_name": "Completeness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_check_warnings_014",
+      "dimension_source": "base",
+      "dimension_name": "Tool Arguments",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_check_warnings_014",
+      "dimension_source": "rubric",
+      "dimension_name": "Detection accuracy",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_check_warnings_014",
+      "dimension_source": "rubric",
+      "dimension_name": "Severity classification",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_check_warnings_014",
+      "dimension_source": "rubric",
+      "dimension_name": "Actionability",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_check_warnings_014",
+      "dimension_source": "rubric",
+      "dimension_name": "FamilySearch quality reporting",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_check_warnings_018",
+      "dimension_source": "base",
+      "dimension_name": "Correctness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_check_warnings_018",
+      "dimension_source": "base",
+      "dimension_name": "Completeness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_check_warnings_018",
+      "dimension_source": "base",
+      "dimension_name": "Tool Arguments",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_check_warnings_018",
+      "dimension_source": "rubric",
+      "dimension_name": "Detection accuracy",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_check_warnings_018",
+      "dimension_source": "rubric",
+      "dimension_name": "Severity classification",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_check_warnings_018",
+      "dimension_source": "rubric",
+      "dimension_name": "Actionability",
+      "llm_score": null,
+      "corrected_score": null,
+      "comment": null
+    },
+    {
+      "test_id": "ut_check_warnings_018",
+      "dimension_source": "rubric",
+      "dimension_name": "FamilySearch quality reporting",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_check_warnings_017",
+      "dimension_source": "base",
+      "dimension_name": "Correctness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_check_warnings_017",
+      "dimension_source": "base",
+      "dimension_name": "Completeness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_check_warnings_017",
+      "dimension_source": "base",
+      "dimension_name": "Tool Arguments",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_check_warnings_017",
+      "dimension_source": "rubric",
+      "dimension_name": "Detection accuracy",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_check_warnings_017",
+      "dimension_source": "rubric",
+      "dimension_name": "Severity classification",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_check_warnings_017",
+      "dimension_source": "rubric",
+      "dimension_name": "Actionability",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_check_warnings_017",
+      "dimension_source": "rubric",
+      "dimension_name": "FamilySearch quality reporting",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    }
+  ]
+}

--- a/eval/runlogs/unit/check-warnings/v1_2026-07-05_16-35-38.json
+++ b/eval/runlogs/unit/check-warnings/v1_2026-07-05_16-35-38.json
@@ -1,0 +1,4183 @@
+{
+  "schema_version": 2,
+  "skill": "check-warnings",
+  "version": 1,
+  "released": false,
+  "releasable": true,
+  "invocation": "skill",
+  "timestamp": "2026-07-05_16-35-38",
+  "harness_version": "0.1.0",
+  "model": "claude-sonnet-4-6",
+  "judge_prompt_hash": "adea6e4cb2c9ddf0c436c31e893da766866cc67ed749df0a7c6b8a9df52c6914",
+  "snapshot": {
+    "packages/engine/plugin/skills/check-warnings/SKILL.md": "---\nname: check-warnings\nmodel: claude-sonnet-4-6\ndescription: Genealogical data integrity guardrail \u2014 catches logical\n  impossibilities in a person's data (impossible lifespans, events after death,\n  child born after parent died, burial before death) and retrieves\n  FamilySearch's live quality score. Invoke whenever the user wants to check for\n  warnings, spot data problems, verify consistency before closing research, or\n  get a sanity check on any person's dates and family relationships. Route\n  source conflicts (two records disagreeing about the same fact) to\n  conflict-resolution; route schema validation (malformed data, bad ids, broken\n  references) to validate-schema.\nallowed-tools:\n  - person_warnings\n  - person_quality\n---\n\n# Check Warnings\n\n**Narration:** Read `researcher_profile.narration_guidance` from `research.json` and apply it as your narration style for this invocation. If absent, default to a one-line preamble per action.\n\nThis skill runs two complementary checks and reports both, in separate sections:\n\n- **`person_warnings`** (offline, deterministic) -- logical *impossibilities* in your **local** `tree.gedcomx.json`: death before birth, event after death, impossible ages. Same person, same warnings, every time.\n- **`person_quality`** (online, FamilySearch) -- FamilySearch's own *data-quality score* for the live profile: missing dates/places, untagged sources, consistency and coherence issues, returned as ready-made English sentences.\n\nThey mean different things and must not be merged into one list: warnings are impossibilities in local data; quality issues are FamilySearch's assessment of the live tree profile (suggestions to improve it, not errors). Your job is to decide *whom* to check, run both, present the results clearly, and interpret them.\n\n**Warnings \u2260 conflicts:** Warnings are logical impossibilities in a single person's data. Conflicts are disagreements between two or more sources about the same fact. Use `conflict-resolution` for the latter.\n\n**Phrasing rule (apply everywhere):** Phrase all next-step recommendations as research actions the user can take, not as instructions to run a named skill. Internal names like `timeline`, `person-evidence`, and `conflict-resolution` are routing references only -- do not put them in user-facing text.\n\n## Assumption framework\n\n- **Fundamental** (physical laws) \u2192 tool emits `severity: \"error\"`\n- **Valid** (biological/social norms) \u2192 tool emits `severity: \"warning\"`\n- **Unsound** (unproven premises) \u2192 tool does not fire\n\nFull tag catalog: `references/warning-checks.md`.\n\n## Steps\n\n**Before anything \u2014 is this a warnings task?** If the user is describing a **disagreement between two or more sources** about the same fact (e.g. \"one census says Ireland, the death cert says County Cork \u2014 flag that mismatch\"), that is a **source conflict, not a warning**, and it is **not this skill's job**. **Hand it off silently:**\n\n- **Invoke the `conflict-resolution` skill right away** (the Skill tool) as your first and only action, and let *it* produce the response for the user.\n- **Write no reply of your own** \u2014 no preamble, no explanation, no summary. The handoff runs behind the scenes; conflict-resolution owns the answer the user sees.\n- Do **not** call `person_warnings` or `person_quality`, do **not** read the tree, and do **not** analyze the discrepancy. Any tool call, analysis, or write-up of your own means you wrongly took on conflict-resolution's job.\n\nWarnings are about a *single person's own data* violating physical/biological/temporal limits (death before birth, impossible ages, burial before death). Only run the steps below when the request is genuinely that.\n\n### 1. Identify the person(s) to check\n\n- **Triggered by a writing skill** -- check every person whose assertions or person_evidence changed in that skill's run.\n- **User-directed** -- use the person id from the request. If the user gave a name, read `tree.gedcomx.json` and match on `names[*].given` + `names[*].surname`. If multiple match, ask the user which one before calling the tool.\n- **Batch review before a proof conclusion** -- check the subject person and every person whose evidence is cited in the proof.\n\nThe `personId` is the simplified GedcomX id from `tree.gedcomx.json` (e.g. `I1` or `KWCJ-RN4`).\n\n### 2. Call the tools\n\nOnce you've confirmed this is a warnings task (not a handoff \u2014 see the Handoff rules; a source-vs-source disagreement goes to `conflict-resolution`, not here), then for each person to check:\n\n1. Call `person_warnings({ projectPath, personId })` \u2014 the offline impossibility check that runs for every person you check. `projectPath` is the absolute path of the current working directory. The tool reads `tree.gedcomx.json` itself and returns each warning's `issueType`, `severity`, `personId`, `personName`, and `message`.\n2. **Additionally, when `personId` is a FamilySearch ID** -- four characters, a hyphen, three characters (e.g. `KWCJ-RN4`, `KD96-TV2`) -- also call `person_quality({ personId })`. In projects built from FamilySearch the tree id *is* the FS ID, so the same id feeds both tools. **When the id is synthetic (e.g. `I1`), skip this call silently** -- there is no FamilySearch profile to score, so do not call the tool and do not mention FamilySearch quality at all for that person.\n\n`person_quality` needs the user logged in and calls FamilySearch's live quality service. Handle it gracefully -- it must **never** suppress the offline warnings, which are the guardrail and always appear:\n\n- **Not logged in / auth error** -- skip quality and note it once: \"FamilySearch quality score unavailable -- log in to include it.\" Still report the warnings.\n- **Tool error** (person tombstoned/merged, not found, still calculating, network) -- surface the tool's message as a one-line note in that person's quality section; do not block the warnings report.\n\nThe tool returns `{ personId, segment, overallScore, issueCount, categories: [{ scoreType, count, score }], issues: [{ sentence, conclusionType, conclusionId, scoreType }] }`.\n\n### 3. Report warnings\n\nFor each warning, report:\n\n- Severity icon: `severity: \"error\"` \u2192 `[!] Critical`; `severity: \"warning\"` \u2192 `[!] Note`\n- The `issueType` tag (for traceability)\n- The tool's `message` (already user-friendly)\n- The assumption category violated (Fundamental / Valid)\n- **The facts involved \u2014 only when the tool named them.** If the warning includes a `factIds` field, name those facts. If it doesn't, **do not read `tree.gedcomx.json` to hunt for them** \u2014 report the `message` as-is and don't invent fact ids, dates, or sources the tool didn't return. (Most warnings are about a single constrained event \u2014 Birth, Death, Burial \u2014 so the `message` alone already makes clear which fact is meant.)\n- A concrete next step, phrased from the tool's `message` (e.g. \"verify the recorded death date against the original death record\"). Don't cite a specific fact/source id unless the tool provided it.\n\n**Before listing individual warnings, count.** If 2 or more `severity: \"error\"` warnings fire on the same person, open the report with a cluster verdict: \"2 errors plus N warnings on this one person is a strong signal that records from two different individuals have been merged into one profile.\" Then recommend: \"I'd recommend rebuilding a chronological timeline of every recorded event for this person and going through each one to identify where one person's records end and another's begin -- once we find the split point, we can reassign the records that belong to the other individual.\" List individual warnings *under* that verdict, not above it.\n\n**Special case -- `missingFactsAndRelatives`:** Report with Note severity and add: \"Note: this person has limited data, so most warning checks need dates and relatives to fire. Adding more research may surface additional issues currently hidden.\"\n\n**Special case -- `hasEventAfterDeath1`:** This tag has three legitimate causes. Do NOT default to identity confusion just because the severity is `error`. The corrective action depends on the source type, which this skill cannot determine -- the source must be inspected first.\n\nThe three causes, with cues and recommended actions:\n\n- **Identity confusion** -- the late-dated record actually describes a same-name individual who outlived the deceased. Cue: the source describes events apparently performed BY the deceased (e.g. a later census listing them as head of household, a later marriage record). Recommended action: \"Let's rebuild a full chronological timeline of every recorded event for [person] and go through each record one by one to check whether it actually belongs to this person or to a same-name individual who outlived them.\"\n- **Wrong death date** -- the recorded death date is too early. Cue: a single late-dated record is inconsistent with one earlier death record but consistent with everything else. Recommended action: \"Verify the recorded death date for [person] against the original death record (the certificate or burial register) -- one of the two dates is likely wrong.\"\n- **Posthumous mention** -- the late-dated record was created after the deceased's death and merely references them. Cue: the source is an obituary, a descendant's death certificate, an estate or probate document where the deceased is named as a parent or prior owner but is not performing an action. Recommended action: \"Look at the late-dated record itself -- if it's a record about someone else that just mentions [person] as a parent or relative, it shouldn't be attached to [person]'s profile as one of their own events. Unlink it and treat it as a reference instead.\"\n\nWhen the cause is ambiguous (the most common case), report the warning, list the three candidate causes, and recommend inspecting the source next. Do not recommend a specific corrective action before the source type is known -- recommending an identity split when the record is actually a posthumous mention would damage the data.\n\n**Example output:**\n\n```\nWARNINGS FOR: Patrick Flynn (I1)\n\n[!]  Critical -- Event after death  [hasEventAfterDeath1]\n    [Fundamental: people cannot act after their death -- but a\n    posthumous mention can be misattached to their profile.]\n    An event is dated more than 1 year after this person's latest\n    death-like fact.\n\n    This usually has one of three causes: (a) the recorded death\n    date is wrong, (b) the late-dated record actually belongs to\n    a same-name individual whose records were merged in, OR (c)\n    the late-dated record is a posthumous mention (an obituary,\n    a descendant's death certificate, an estate, probate, or\n    guardianship record that names the deceased without\n    describing actions by them).\n    Next step: take a closer look at the late-dated record\n    itself -- what kind of document is it? The right corrective\n    action depends on what you find.\n\n[!]  Note -- Long lifespan  [hasAgeRangeGreaterThan120]\n    [Valid: people rarely live past 120.]\n    This person's lifespan is greater than 120 years, which is\n    implausible.\n    Next: verify the birth and death dates against their sources.\n\n(2 warnings total)\n\nNote how the report uses the tool's `message` verbatim and names no\nspecific fact ids/dates \u2014 the tool didn't return `factIds`, so none are\ninvented. If a warning *does* carry `factIds`, name them.\n```\n\n### 3b. Report the FamilySearch quality score\n\nWhen `person_quality` returned data, add a separate **FamilySearch quality** section for the person -- kept apart from the impossibilities above, because it's a different source and a different meaning.\n\n- Lead with the overall picture: `overallScore` (0--1) and the per-category counts from `categories` (Completeness / Verifiability / Consistency / Coherence).\n- List each issue's `sentence` **verbatim** -- they are already user-ready English (\"The burial date is missing.\", \"A residence has no tagged sources.\"). Group them by `scoreType`. Collapse identical repeats with a count (e.g. `(x5)`).\n- These are FamilySearch's *suggestions to improve the profile*, not impossibilities. Phrase next steps as optional improvements (\"adding the burial date would raise the completeness score\"), never as urgent errors.\n- **Don't invent a quality label or verdict** (no \"High Quality\" band) -- report the `overallScore` and the sentences as-is. The tool deliberately omits a band.\n- When `issueCount` is 0: \"FamilySearch quality: no issues flagged (overall {overallScore}).\"\n- **Synthetic id (quality not applicable):** the person has no FamilySearch profile, so `person_quality` was never called. Say **nothing** about FamilySearch quality -- do not add a \"not available\" note. (This is the common case for hand-built or record-derived persons; a quality remark there is just noise.)\n- **Quality attempted but failed** (the tool returned an error -- tombstoned/merged, not found, still calculating, or not logged in): add one brief note in the quality section using the tool's message. Never let it abort or suppress the warnings report.\n\n**Example:**\n\n```\nFAMILYSEARCH QUALITY: Patrick Flynn (KD96-TV2)   overall 0.97\n  Completeness 2 - Source tagging 5 - Consistency 0 - Coherence 0\n\n  Completeness\n    - The burial date is missing.\n    - A marriage place is missing a city.\n  Source tagging\n    - A residence has no tagged sources.  (x5)\n```\n\n### 4. Interpret and recommend\n\n- **`severity: \"error\"`** -- Investigate immediately. Almost always indicates data errors or conflated identities (records from two people merged into one profile).\n- **`severity: \"warning\"`** -- Note and recommend verification. May indicate twins, blended families, or transcription errors. Phrase to the user as: \"Let's verify [the specific assertion or fact] against its original source. If the original record genuinely shows that, we'll document it as an exception; if not, we'll correct the fact.\"\n- **Relative warnings (`relatives*` tags)** -- The problem is in the relationship, not the focal person. Verify the relationship link *before* any data fix on the relative. Recommend: \"This warning is about [Patrick]'s relative [Thomas], not [Patrick] directly. The first thing to check is whether [Thomas] is actually [Patrick]'s father, or whether a same-name record was linked here by mistake. Once we confirm the relationship is correct, then we can look at whether [Thomas]'s data needs fixing.\" A \"fix the data\" step on a `relatives*` warning with no link-verification first commits the user to research time on a relationship that may not be real.\n\nLoad `references/warnings-as-identity-signals.md` for the full escalation table.\n\n## When no warnings are found\n\nWhen the tool returns `warningCount: 0`, report: \"No genealogical warnings found for [person]. The tool's checks all passed.\"\n\n## Important rules\n\n- **Warnings are informational, not gates.** They don't block further work.\n- **Don't auto-correct.** Report the warning; let the user or other skills investigate.\n- **The tool is the arbiter; don't re-derive.** The tool's output is ground truth. Do not read the tree to verify whether the tool's verdict is correct. Do not perform your own date arithmetic to explain a warning the tool already explained -- the number \"208 years\" was never in the tool's response; do not invent it. Cite only the `factIds`, sources, and persons the tool's response actually mentions.\n- **Don't speculate about the underlying data or how the tool derived a warning.** Do not claim a fact does or does not exist, or narrate how a date was inferred \u2014 you cannot see that, and guessing produces self-contradictions (e.g. saying \"no death fact is recorded\" while explaining a death-based warning). Report the tool's `message`, the facts it cites, and the *general* reason the warning matters (e.g. \"a father cannot die more than ~300 days before his child is born \u2014 gestation is finite\"). Never make a claim about the tree's contents that the tool's response didn't state, and never one that contradicts the warning you're reporting.\n- **Quality issues are improvements, not impossibilities.** A missing date or untagged source lowers FamilySearch's quality score but is not an error -- never escalate a `person_quality` issue the way you would a `severity: \"error\"` warning. Report its `sentence` verbatim; don't re-derive, re-score, or invent a band.\n- **Historical exceptions exist.** A 13-year-old bride or a 105-year-old death is unusual by modern standards but documented historically. Present warnings with appropriate context.\n- **Surface tool errors verbatim.** If the tool returns an error (e.g. `personId` not found in `tree.gedcomx.json`), surface it as-is. Do not fall back to manual reasoning -- the whole point is determinism.\n\n## Handoff rules\n\n- **Two sources disagreeing** -- hand off to `conflict-resolution`.\n- **Warning suggests identity confusion** -- suggest rebuilding the chronological timeline first, then reassigning records once the split point is found.\n- **User asks to fix a warning** -- do NOT fix it here. Route to `person-evidence`, `conflict-resolution`, or let the user correct manually.\n- **Timeline skill invoked check-warnings** -- return results to timeline's caller; do not start a new investigation.\n\n## Re-invocation behavior\n\nThis skill writes no project state. It reads `tree.gedcomx.json` via\n`person_warnings` (offline, deterministic) and, for FamilySearch-ID\npersons, fetches the live score via `person_quality` (online). Safe to\nre-invoke at any time. The warnings depend only on the current tree\nstate; the quality score reflects the live FamilySearch profile at call\ntime and requires login, so -- unlike the warnings -- it can change\nbetween runs or be temporarily unavailable.\n",
+    "packages/engine/plugin/skills/check-warnings/references/assumption-categories.md": "# Assumption Categories for Warning Detection\n\nGenealogical reasoning relies on assumptions. Not all assumptions\ncarry equal weight. The BCG standards identify three categories that\ndetermine how much trust to place in unproven premises. For warning\ndetection, these categories define what should and should not trigger\nan alert. The `person_warnings` tool's `severity` field reflects\nthis framework: `error` for fundamental violations, `warning` for\nvalid violations, and no emission at all for unsound conditions.\n\n## Fundamental Assumptions\n\nThese are physical, biological, and temporal laws that cannot be\nviolated under any circumstances. They require no evidence to\nsupport them -- they are axiomatic.\n\nExamples relevant to the tool's checks:\n- People cannot perform actions after their death\n- People cannot perform actions before their birth\n- A man cannot father a child long after his own death (gestation\n  is finite)\n- A woman cannot give birth meaningfully after her own death\n- A burial event cannot precede a death event\n- A christening event cannot precede a birth event\n- A recorded lifespan cannot exceed plausible biological limits\n  (~120 years)\n\n**Tool emission:** `severity: \"error\"`. Always investigate -- these\nalmost always indicate data errors or two distinct individuals\nincorrectly merged into one profile.\n\n## Valid Assumptions\n\nThese are expectations about normal human biology and behavior that\nhold true in the vast majority of cases but can be contradicted by\ndocumented evidence. They are reasonable defaults that should be\nassumed true until proven otherwise.\n\nExamples relevant to the tool's checks:\n- Mothers conceive children between approximately ages 12 and 55\n- Fathers conceive children between approximately ages 14 and the\n  late decades\n- Marriage occurs between approximately ages 14 and 90\n- A person has a small number of valid birth and death records;\n  multiple distinct ones usually mean conflated data\n- A person has roughly one biological mother and one biological\n  father\n- A person's recorded surnames usually agree with each other\n- A family's children are born within a reasonable span (under\n  ~40 years between oldest and youngest)\n\n**Tool emission:** `severity: \"warning\"`. Note and recommend\nverification. A 55-year-old mother is rare but documented; a\n13-year-old bride is unusual by modern standards but occurred in\nsome historical contexts.\n\n**Key principle:** Genealogists should seek evidence to invalidate\nvalid assumptions. If no contradicting evidence is found, the\nassumption is incorporated into reasoning. If a warning fires on\na valid assumption, the researcher should check whether the source\nevidence is strong enough to override the default expectation.\n\n## Unsound Assumptions\n\nThese are premises that MIGHT be true but CANNOT be accepted without\nsupporting evidence. They are common mental shortcuts that\nresearchers take -- often unconsciously -- that lead to errors.\n\nExamples:\n- A man's widow was the mother of all his children\n- Migrants followed the most popular route to their destination\n- A bride's surname is the same as her parents' surname\n- A child listed in a household is the biological child of the\n  household head\n- The informant on a death record had accurate knowledge of the\n  deceased's birth details\n- If two people share a surname and lived in the same area, they\n  must be related\n\n**Tool emission:** none. The tool does NOT emit warnings based on\nunsound assumptions. The absence of evidence for these premises is\nnot a problem -- it is the normal state. Unsound assumptions\nrequire positive evidence before they can be accepted; their\nviolation is not a signal of error.\n\n## Applying the Framework\n\nWhen the `person_warnings` tool emits a warning:\n\n1. Look at `severity`:\n   - `\"error\"` -> fundamental violation -> always investigate;\n     almost always indicates a data error or identity confusion.\n   - `\"warning\"` -> valid violation -> note and verify; document\n     the exception if the source evidence supports the unusual\n     condition.\n\n2. Look at the `issueType` tag for the specific condition. See\n   `warning-checks.md` for the full catalog of tags the tool emits.\n\n3. Do NOT manufacture additional warnings from unsound assumptions\n   the tool deliberately skips.\n",
+    "packages/engine/plugin/skills/check-warnings/references/warning-checks.md": "# Warning Checks Reference\n\nComplete catalog of the conditions the `person_warnings` MCP tool\ncurrently checks. Each entry shows the tag emitted in `issueType`,\nthe rule, and what it usually means.\n\nThe tool emits two severities:\n\n- **`error`** -- violates a Fundamental assumption (physical /\n  biological / temporal impossibility). Almost always a data error\n  or two distinct identities merged into one profile.\n- **`warning`** -- violates a Valid assumption (biologically or\n  socially improbable). Exceptions exist; verification recommended.\n\nSee `assumption-categories.md` for the framework these severities\nmap to.\n\n## Fundamental violations (`severity: \"error\"`)\n\nThese conditions are impossible under physical or biological law.\nAlways investigate.\n\n### `hasEventBeforeBirth365_2`\n- Rule: at least one event is dated more than 2 years before the\n  person's earliest birth-like fact.\n- Cause: wrong birth date, wrong event attribution, or identity\n  confusion.\n- Action: verify the birth date and whether the early-dated event\n  really belongs to this person.\n\n### `hasEventAfterDeath1`\n- Rule: at least one event is dated more than 1 year after the\n  person's latest death-like fact.\n- Cause: a same-name individual's records merged in, or wrong\n  death date.\n- Action: check person_evidence links for the post-death event.\n\n### `hasAgeRangeGreaterThan120`\n- Rule: latest possible death year minus latest possible birth\n  year is greater than 120.\n- Cause: wrong birth or death date, or two people merged.\n- Action: verify both vital dates against source documents.\n\n### `hasChristeningBeforeBirth`\n- Rule: the latest Christening day is strictly before the earliest\n  Birth day (year-only dates get a year of slack on each side).\n- Cause: data-entry error or wrong attribution.\n- Action: verify both vital dates.\n\n### `hasEventBeforeChristening365_3`\n- Rule: at least one non-Birth event is dated more than 3 years\n  before the latest Christening.\n- Cause: wrong event attribution or records from two persons\n  merged.\n- Action: verify event ownership.\n\n### `hasBurialBeforeDeath`\n- Rule: every recorded burial day precedes every recorded death\n  day (both must be perfect day-month-year).\n- Cause: data error or transcription mistake.\n- Action: verify burial / death dates against sources.\n\n### `hasDeathBeforeChildBirth30_10` (male anchor)\n- Rule: the father's latest exact Death day was more than 300 days\n  before a child's exact Birth day.\n- Cause: wrong death date or wrong child attribution.\n- Action: verify the death date and the parent-child link.\n\n### `hasDeathBeforeChildBirth365_2` (male anchor)\n- Rule: the father's latest death-like fact is more than 2 years\n  before a child's earliest birth-like fact (family-level looser\n  variant of the above).\n- Cause: as above.\n- Action: verify the parent-child link or vital dates.\n\n### `hasDeathBeforeChildBirthFemale365` (female anchor)\n- Rule: the mother's latest death-like fact is more than 1 year\n  before a child's earliest birth-like fact.\n- Cause: wrong death date or wrong mother attribution.\n- Action: verify the link.\n\n### `hasDeathBeforeChildBirthFemale2` (female anchor)\n- Rule: the mother's latest exact Death day was more than 2 days\n  before a child's exact Birth day. A mother can give birth and\n  die the same day, but not 2+ days before.\n- Cause: data error or wrong mother attribution.\n- Action: verify dates.\n\n## Valid violations (`severity: \"warning\"`)\n\nThese conditions are improbable but not impossible. Exceptions are\ndocumented but rare. Verify against original sources before\ntreating as established.\n\n### Parent at extreme age\n- `earliestChildBirthToBirth12` -- parent had a child before age 12.\n- `earliestChildBirthToBirthMale14` -- father had a child before age 14.\n- `latestChildBirthToBirth80` -- child born 80+ years after this person's birth.\n- `latestChildBirthToBirthFemale55` -- mother was age 55 or older at a child's birth.\n\n### Marriage timing\n- `hasEarlyMarriage14` -- married before age 14.\n- `hasLateMarriage90` -- married more than 90 years after birth.\n- `hasYoungSpouse15` -- a spouse died at age < 15.\n- `earliestChildMarriageToBirth30` -- a child married before this person reached age 30.\n- `latestChildBirthToMarriage35` -- a child was born 35+ years after this person's latest marriage.\n- `childMarriageToMarriage15` -- a child married within 15 years of this person's earliest marriage (implies very young parenthood).\n\n### Multiple records of a unique event\n- `tooManyBirthDates2` -- two or more distinct perfect-DMY birth dates spaced > 30 days apart.\n- `tooManyDeathDates2` -- two or more distinct perfect-DMY death dates spaced > 14 days apart.\n- `deathRangeGreaterThan2` -- death-like dates span more than 2 years.\n- `hasBurialAfterDeath31` -- earliest burial is more than 31 days before the latest death. (Despite the Java name, this fires on \"burial before death\" outliers; preserved for parity.)\n\n### Family structure\n- `tooManyChildren18` -- 18 or more children.\n- `tooManyFathers2` -- multiple fathers (only one biological father is possible).\n- `tooManyMothers2` -- multiple mothers.\n- `childBirthRange40` -- span between earliest and latest child's birth is 40+ years.\n- `missingFactsAndRelatives` -- empty stub record (no facts other than `GenderChange`, no relatives).\n- `hasBlankName` -- no name on the record.\n- `hasDiffSurnameMale` -- male anchor has surnames that don't match each other (similarity <= 0.5). Suggests records from two same-given-name persons were merged.\n\n### Extreme lifetimes after specific events\n- `hasDeathAfterChildBirth90` -- died more than 90 years after the earliest child's birth.\n- `hasChildDeathAfterParentBirth200` -- died more than 200 years after the earliest parent's birth.\n\n## Relative-mob variants\n\nMost checks above have a \"relatives\" variant that fires when the\nsame condition is detected on a parent, spouse, or child of the\nfocal person. They emit `severity: \"warning\"` regardless of the\noriginal severity, because the focal person's own data isn't\nnecessarily wrong -- the issue is in the relationship.\n\nNaming patterns:\n\n- `relatives<CheckName>` -- any relative triggers it.\n- `maleRelatives<CheckName>` -- only male relatives are considered.\n- `femaleRelatives<CheckName>` -- only female relatives are considered.\n\nThe relative being flagged is named in the warning's `personName`\n/ `personId`, not the focal person.\n\nThe current set of relative-mob tags: `relativesDeathRangeGreaterThan2`,\n`relativesEarliestChildBirthToBirth12`,\n`relativesHasEventBeforeChristening365_3`,\n`maleRelativesEarliestChildBirthToBirth14`,\n`femaleRelativesLatestChildBirthToBirth55`,\n`relativesHasDeathBeforeChildBirth365_2`,\n`relativesHasDeathBeforeChildBirth30_10`,\n`relativesEarliestChildMarriageToBirth30`,\n`femaleRelativesHasDeathBeforeChildBirth365`,\n`femaleRelativesHasDeathBeforeChildBirth2`,\n`relativesLatestChildBirthToMarriage35`,\n`relativesLatestChildBirthToBirth80`,\n`relativesChildMarriageToMarriage15`,\n`relativesHasDeathAfterChildBirth90`,\n`relativesHasAgeRangeGreaterThan120`,\n`relativesHasChildDeathAfterParentBirth200`,\n`maleRelativesHasDiffSurname`.\n\n## NOT currently checked\n\nThe tool does NOT currently emit warnings for these. Do NOT\nmanufacture warnings of your own for these conditions; surface\nthem only if the user explicitly asks for an analysis of them.\n\n- Geographic impossibilities (impossible travel, jurisdiction\n  didn't exist, birthplace inconsistencies with parents' residence)\n- Future dates (date is after the current year)\n- Child-spacing (two children born less than 9 months apart)\n- Birth before parents' marriage\n- Sibling age gap at the year-by-year level (the tool covers only\n  40+ year spans via `childBirthRange40`)\n- Same-surname-and-area inferences\n\nThese may be added in later releases. Until then, they are out of\nscope for the tool -- and therefore for this skill.\n",
+    "packages/engine/plugin/skills/check-warnings/references/warnings-as-identity-signals.md": "# Warnings as Identity Signals\n\nThe primary value of warning detection in genealogy is not just\ncatching typos -- it is identifying records that have been incorrectly\nlinked to a person. Timeline impossibilities are among the strongest\nsignals that a profile contains data from multiple distinct\nindividuals.\n\n## Why Identity Confusion Matters\n\nProfessional genealogists regularly encounter pedigrees where\nuntrained researchers merged records from different people into a\nsingle profile. The most common causes:\n\n- Same name, same area, same time period (very common in areas\n  with limited surname variety)\n- Father and son with identical names\n- Cousins with the same name in the same community\n- Clerical errors in compiled databases\n\nWhen records from two people are merged, the resulting profile\nwill exhibit logical impossibilities -- and those impossibilities\nare detectable through warning checks.\n\n## Timeline Impossibilities as Split Points\n\nWhen a warning fires, ask: \"If I split this person into two\nseparate individuals at this point in the timeline, do the\nimpossibilities disappear?\"\n\nExample pattern:\n- Person born 1820\n- Marriage 1842 (consistent)\n- Child born 1845 (consistent)\n- Death 1850 (consistent)\n- Census record 1860 listing this person as living\n  (warning: `hasEventAfterDeath1`)\n\nThe 1860 census record may belong to a different same-name\nindividual. The split point is the death in 1850 -- records dated\nbefore belong to one person, records dated after belong to\nanother.\n\n### Exception -- posthumous mentions are NOT identity signals\n\nA `hasEventAfterDeath1` warning does not always mean identity\nconfusion. A third legitimate cause is the **posthumous mention**:\na record created after the deceased's death that REFERENCES them\nwithout describing actions by them. Examples:\n\n- An obituary for the deceased (or for a descendant) that names\n  the deceased as a parent or family member.\n- A descendant's death certificate listing the deceased as a\n  parent (the certificate's own date is after the deceased's\n  death).\n- An estate, probate, or guardianship record naming the deceased\n  as a prior owner, testator, or parent of a minor heir.\n\nIf a source of this type is attached to the deceased's profile as\na Residence-style fact (rather than as a reference), the tool\nwill correctly flag `hasEventAfterDeath1` -- but the corrective\naction is to unlink the source from the deceased's events and\nre-treat it as a reference, NOT to split the profile. Splitting\non a posthumous mention is a false-positive identity-split that\ndamages the data.\n\nThe rule: before recommending an identity split for\n`hasEventAfterDeath1`, look at the type of the late-dated source.\nIf it is a record about the deceased's life (a census, marriage,\nor vital record purportedly performed by them), identity\nconfusion is likely. If it is a record about someone else where\nthe deceased is merely named, treat it as a posthumous mention\nand recommend re-linking instead.\n\nPhrase all recommendations as research actions the user can\ntake, not as instructions to run a specific skill. The user does\nnot know which skills exist; the orchestrator will route their\nfollow-up question to the right skill automatically. See\nSKILL.md Step 3's special case for `hasEventAfterDeath1`.\n\n## Pedigree Analysis for Error Detection\n\nBefore beginning deep research on any individual, scan their\nprofile for these quick checks. The tool's emitted warnings are\nalready organized around them:\n\n### Date sequence logic\n- Birth must precede every other event (`hasEventBeforeBirth365_2`)\n- Death must follow every other event (`hasEventAfterDeath1`)\n- Burial must follow death (`hasBurialBeforeDeath`)\n- Christening must follow birth (`hasChristeningBeforeBirth`)\n- Each event date should be plausible given the others\n\n### Reasonable age differences\n- Parent-child age gap: typically 12-55 years for mothers, 14+ for\n  fathers -- covered by `earliestChildBirthToBirth12`,\n  `earliestChildBirthToBirthMale14`, `latestChildBirthToBirthFemale55`,\n  `latestChildBirthToBirth80`\n- Marriage age: typically 14-90 -- covered by `hasEarlyMarriage14`\n  and `hasLateMarriage90`\n- Child-spacing across a family: under 40 years between oldest\n  and youngest -- covered by `childBirthRange40`\n\n### One-of-a-kind records\n- A person has one birth and one death -- multiple distinct ones\n  are conflated records (`tooManyBirthDates2`, `tooManyDeathDates2`,\n  `deathRangeGreaterThan2`)\n- A person has one biological mother and one biological father\n  (`tooManyFathers2`, `tooManyMothers2`)\n- A person's surnames usually agree with each other\n  (`hasDiffSurnameMale`)\n\n## Distinguishing Warnings from Conflicts\n\nThis distinction is critical for routing work to the correct skill:\n\n### Warnings (handled by check-warnings)\n- Single person's data violates physical, biological, or temporal\n  constraints\n- Do not require comparing multiple sources -- they can be detected\n  from the assembled profile alone\n- Indicate errors or identity confusion\n- Examples: event before birth (`hasEventBeforeBirth365_2`), event\n  after death (`hasEventAfterDeath1`), child born after mother's\n  death (`hasDeathBeforeChildBirthFemale365`)\n\n### Conflicts (handled by conflict-resolution)\n- Two or more sources disagree about the same fact for the same\n  person\n- Require comparing sources against each other\n- Indicate that at least one source contains inaccurate information\n  (but don't necessarily indicate identity confusion)\n- Examples: one record says born 1845, another says 1847; census\n  says born in Ireland, death record says born in England\n\n### Overlap cases\nSome situations can be analyzed as either warnings or conflicts:\n- A death date that makes the person impossibly old might be a\n  warning (`hasAgeRangeGreaterThan120`) AND a conflict (if\n  multiple sources give different death dates). In these cases,\n  check-warnings flags the impossibility, and conflict-resolution\n  handles the source disagreement.\n\n## Clustered Warnings\n\nA single `severity: \"warning\"` on an otherwise clean profile is\nusually noise. But multiple warnings clustering on the same person\n-- especially mixing error and warning severities -- is a strong\nsignal of systematic problems.\n\nEscalation guidance:\n- 1 `warning` on its own: note and move on\n- 2+ `warning`s on same person: mention the pattern\n- 1 `error` on its own: investigate the specific condition\n- 1 `error` + 1+ `warning`s: likely identity confusion; recommend\n  timeline review\n- 2+ `error`s: almost certainly two people merged; recommend\n  splitting the profile and rebuilding person_evidence links\n- Any `error` involving the death-vs-event sequence\n  (`hasEventAfterDeath1`, `hasEventBeforeBirth365_2`): stop and\n  investigate immediately regardless of other warning count\n\n## Connecting Warnings to Research Actions\n\nWhen warnings are found, they should drive specific research\nactivities:\n\n1. **Build a timeline** if one doesn't exist -- chronological\n   arrangement of all events often reveals the exact point where\n   two identities were merged.\n\n2. **Check person_evidence links** for the assertions involved\n   in the warning -- which sources support linking that record to\n   this person?\n\n3. **Search for same-name individuals** in the same locality and\n   time period -- the \"other person\" whose records were merged is\n   often easily findable.\n\n4. **Examine the specific source** for assertions involved in\n   warnings -- derivative sources (indexes, transcriptions) are\n   more error-prone than originals.\n",
+    "eval/tests/unit/check-warnings/check-flynn-assertions.json": "{\n  \"input\": {\n    \"scenario\": \"mid-research-flynn\",\n    \"user_message\": \"Check Patrick Flynn's evidence for any impossibilities or warnings.\"\n  },\n  \"judge_context\": [\n    \"Should examine all assertions linked to person I1 via person_evidence (a_001-a_005 from 1850 census, a_008-a_010 from 1860 census, a_011-a_013 from death cert)\",\n    \"Should confirm the timeline is consistent: birth ~1845, age 5 in 1850 (consistent with 1845 birth), age 15 in 1860 (consistent), died 1908 -- no chronological impossibilities\",\n    \"Should NOT flag the resolved birthplace conflict c_001 as a current warning -- conflicts that are `status: resolved` are no longer active issues\",\n    \"Should NOT flag the 48-year gap between 1860 and 1908 as an impossibility -- gaps are timeline territory, not check-warnings territory\"\n  ],\n  \"mcp_fixtures\": [\n    \"person-warnings-no-warnings\"\n  ],\n  \"test\": {\n    \"id\": \"ut_check_warnings_001\",\n    \"skill\": \"check-warnings\",\n    \"type\": \"positive\"\n  }\n}\n",
+    "eval/tests/unit/check-warnings/check-resolved-project.json": "{\n  \"input\": {\n    \"scenario\": \"flynn-resolved\",\n    \"user_message\": \"The parentage research is wrapped up. Any final warnings I should know about before I close this project?\"\n  },\n  \"judge_context\": [\n    \"Should verify the timeline is consistent across all assertions (birth ~1845, censuses 1850 and 1860 with ages 5 and 15, death 1908)\",\n    \"Should report cleanly (no warnings) if the resolved project's data is internally consistent -- false positives on completed projects are particularly bad because they prompt unnecessary reopening of resolved questions\",\n    \"Should NOT flag structural or schema issues -- e.g. missing required fields on the resolved conflict c_001, or hypothesis/proof-summary consistency -- those belong to validate-schema, not check-warnings\"\n  ],\n  \"mcp_fixtures\": [\n    \"person-warnings-no-warnings\"\n  ],\n  \"test\": {\n    \"id\": \"ut_check_warnings_002\",\n    \"skill\": \"check-warnings\",\n    \"type\": \"positive\"\n  }\n}\n",
+    "eval/tests/unit/check-warnings/detect-cluster.json": "{\n  \"input\": {\n    \"scenario\": \"mid-research-flynn\",\n    \"user_message\": \"Run a thorough warnings check on Patrick Flynn.\"\n  },\n  \"judge_context\": [\n    \"Should call person_warnings on Patrick (I1) and report all four warnings the tool returned\",\n    \"Should explicitly recognize the cluster of warnings ON PATRICK (2 errors + 1 warning on I1) as a near-certain identity-confusion signal -- not just present four independent items\",\n    \"Should count ONLY Patrick's three warnings toward the cluster verdict, NOT the fourth warning which is on his relative Thomas (I2) -- relativesHasAgeRangeGreaterThan120 is a separate concern about the parent-child link, not another strike against Patrick\",\n    \"Should treat Thomas's relative-warning per the relative-warning rule: recommend verifying the parent-child link via person-evidence BEFORE recommending data fixes on Thomas\",\n    \"Should hand off to the timeline skill to find Patrick's split point, AND to person-evidence to rebuild the assertion-to-person links once the split is identified\",\n    \"Should classify the severities correctly: hasEventAfterDeath1, hasAgeRangeGreaterThan120, and relativesHasAgeRangeGreaterThan120 as Critical (error); tooManyDeathDates2 as Note (warning)\",\n    \"Should NOT recommend fixing individual fields on Patrick when the cluster suggests the whole profile is the wrong thing -- fixing one date won't clear the underlying identity issue\",\n    \"Should reference the escalation rule from warnings-as-identity-signals.md (2+ errors -> split the profile, rebuild person_evidence)\"\n  ],\n  \"mcp_fixtures\": [\n    \"person-warnings-cluster\"\n  ],\n  \"test\": {\n    \"id\": \"ut_check_warnings_009\",\n    \"skill\": \"check-warnings\",\n    \"type\": \"positive\"\n  }\n}\n",
+    "eval/tests/unit/check-warnings/detect-early-marriage.json": "{\n  \"input\": {\n    \"scenario\": \"mid-research-flynn\",\n    \"user_message\": \"Check Patrick for warnings.\"\n  },\n  \"judge_context\": [\n    \"Should call person_warnings on Patrick (I1)\",\n    \"Should report the hasEarlyMarriage14 warning with Note severity, NOT Critical -- this is a Valid-assumption violation, not a Fundamental one (the tool emits severity: 'warning')\",\n    \"Should suggest verifying the marriage record's birth/marriage dates against the original source -- historical child marriages occurred but are rare\",\n    \"Should NOT auto-escalate to 'two persons merged' -- a single Valid violation on an otherwise clean profile is not enough to suggest identity confusion (see references/warnings-as-identity-signals.md cluster rules)\",\n    \"Should note that a documented exception is possible: if the original record genuinely shows a 13-year-old marriage, that needs documenting, not warning\"\n  ],\n  \"mcp_fixtures\": [\n    \"person-warnings-early-marriage\"\n  ],\n  \"test\": {\n    \"id\": \"ut_check_warnings_007\",\n    \"skill\": \"check-warnings\",\n    \"type\": \"positive\"\n  }\n}\n",
+    "eval/tests/unit/check-warnings/detect-empty-stub.json": "{\n  \"input\": {\n    \"scenario\": \"empty-project-just-created\",\n    \"user_message\": \"Check Patrick for warnings.\"\n  },\n  \"judge_context\": [\n    \"Should call person_warnings on Patrick (I1)\",\n    \"Should report the missingFactsAndRelatives warning with Note severity (the tool emits severity: 'warning')\",\n    \"Should include the prescribed wording from SKILL.md Step 3's special case for this tag -- the response must convey both: (a) 'this person has limited data, so most warning checks need dates and relatives to fire' AND (b) 'adding more research may surface additional issues currently hidden.' Minor paraphrasing of the exact words is acceptable, but BOTH ideas (limited data prevents most checks from firing + further research may surface hidden issues) must appear. A response that only says 'limited data' without the 'further research may surface hidden issues' second half is incomplete; a response that omits both is wrong.\",\n    \"Should NOT escalate this to a Critical-level data error -- empty stubs are a known stage of research (just-created persons), not impossibilities\",\n    \"Should NOT suggest fabricating facts to make the record fuller; that would corrupt the data. The right action is to keep researching or accept that this person's profile is intentionally minimal.\"\n  ],\n  \"mcp_fixtures\": [\n    \"person-warnings-empty-stub\"\n  ],\n  \"test\": {\n    \"id\": \"ut_check_warnings_010\",\n    \"skill\": \"check-warnings\",\n    \"type\": \"positive\"\n  }\n}\n",
+    "eval/tests/unit/check-warnings/detect-event-after-death.json": "{\n  \"input\": {\n    \"scenario\": \"mid-research-flynn\",\n    \"user_message\": \"Check Patrick Flynn for any warnings.\"\n  },\n  \"judge_context\": [\n    \"Should call the person_warnings tool with personId: 'I1' (Patrick)\",\n    \"Should report the hasEventAfterDeath1 warning with Critical severity (the tool emits severity: 'error', which maps to a Fundamental-assumption violation)\",\n    \"Should recommend investigating the post-death event before assuming the cause. The skill should suggest checking person_evidence links to identify the late-dated record and what kind of source it is. It should NOT claim that post-death events are 'almost always' a same-name individual's records merged in -- that framing ignores legitimate posthumous mentions (a record naming the deceased that was created after their death, e.g., an obituary or descendant's death certificate). It is acceptable for the skill to name identity confusion + wrong death date as common causes, but it should also acknowledge posthumous mention as a third possibility and let the source type guide the recommendation. See references/warnings-as-identity-signals.md for the identity-confusion case.\",\n    \"Should NOT suggest schema-level fixes (validate-schema) or conflict-resolution -- those are different skills\",\n    \"Should NOT manually re-derive the warning by reasoning over the scenario data; the tool is the source of truth\"\n  ],\n  \"mcp_fixtures\": [\n    \"person-warnings-event-after-death\"\n  ],\n  \"test\": {\n    \"id\": \"ut_check_warnings_004\",\n    \"skill\": \"check-warnings\",\n    \"type\": \"positive\"\n  }\n}\n",
+    "eval/tests/unit/check-warnings/detect-father-died-before-child.json": "{\n  \"input\": {\n    \"scenario\": \"mid-research-flynn\",\n    \"user_message\": \"Check Thomas Flynn for any warnings.\"\n  },\n  \"judge_context\": [\n    \"Should call the person_warnings tool with personId: 'I2' (Thomas)\",\n    \"Should report the hasDeathBeforeChildBirth30_10 warning with Critical severity (severity: 'error', male-gendered Fundamental check)\",\n    \"Should suggest verifying the death date and the Thomas -> Patrick parent-child relationship -- both candidates for being wrong, and only one needs to be off to clear the warning\",\n    \"Should NOT confuse this with hasDeathAfterChildBirth90 (different direction -- about long lifespans after a child's birth)\",\n    \"Should explain why a father dying 300+ days before a child's birth is impossible (gestation is finite) -- the assumption framework's value is in articulating WHY a warning matters\"\n  ],\n  \"mcp_fixtures\": [\n    \"person-warnings-father-died-before-child\"\n  ],\n  \"test\": {\n    \"id\": \"ut_check_warnings_005\",\n    \"skill\": \"check-warnings\",\n    \"type\": \"positive\"\n  }\n}\n",
+    "eval/tests/unit/check-warnings/detect-impossible-lifespan.json": "{\n  \"input\": {\n    \"scenario\": \"mid-research-flynn\",\n    \"user_message\": \"Run a warnings check on Patrick Flynn.\"\n  },\n  \"judge_context\": [\n    \"Should call person_warnings on Patrick (I1)\",\n    \"Should report the hasAgeRangeGreaterThan120 warning with Critical severity\",\n    \"Should recommend verifying both vital dates against source documents -- either could be the wrong one\",\n    \"Should mention the identity-confusion possibility: clustering between very old recorded death and very early recorded birth is one of the classic two-people-merged signatures\",\n    \"Should NOT label this as a minor 'unusually long life' note (Low severity); the tool's >120 threshold is the Fundamental tier, not the Low/Medium tier of biological implausibility\"\n  ],\n  \"mcp_fixtures\": [\n    \"person-warnings-impossible-lifespan\"\n  ],\n  \"test\": {\n    \"id\": \"ut_check_warnings_006\",\n    \"skill\": \"check-warnings\",\n    \"type\": \"positive\"\n  }\n}\n",
+    "eval/tests/unit/check-warnings/detect-posthumous-residence.json": "{\n  \"input\": {\n    \"scenario\": \"flynn-posthumous-residence\",\n    \"user_message\": \"Check Patrick Flynn for any warnings.\"\n  },\n  \"judge_context\": [\n    \"Should call the person_warnings tool with personId: 'I1' (Patrick) and treat the tool as the source of truth -- it should NOT re-derive the warning by reasoning over the scenario data.\",\n    \"Should report the hasEventAfterDeath1 warning with Critical severity (the tool emits severity: 'error', which maps to a Fundamental-assumption violation).\",\n    \"The warning's factIds names F3. The skill should name that fact in its report -- F3 is a Residence dated 1925 citing source S5 (the obituary of Patrick's daughter Mary (Flynn) Brennan). Identifying it as a Residence sourced from a relative's obituary is the key cue.\",\n    \"A Residence dated ~17 years after death, sourced from a relative's obituary, is the signature of a POSTHUMOUS MENTION -- a record created after the deceased's death that merely references them (cf. references/warnings-as-identity-signals.md, which calls out exactly this Residence-style posthumous-mention case). The skill should surface posthumous mention as the most likely cause here, not identity confusion. It is acceptable to acknowledge the other causes (wrong death date, same-name identity confusion) as possibilities, but it must NOT assert or default to identity confusion / 'records of a same-name individual merged in', because the Residence-from-a-relative's-obituary evidence points to a posthumous mention.\",\n    \"The recommended action should be to treat the late-dated record as a reference and unlink it from Patrick's own events (it belongs to the relative's record, not Patrick's), NOT to split the profile or rebuild a chronology to separate a same-name individual.\",\n    \"Should NOT suggest schema-level fixes (validate-schema) or conflict-resolution -- those are different skills. It is fine to phrase the unlink as a research action without naming person-evidence to the user.\"\n  ],\n  \"mcp_fixtures\": [\n    \"person-warnings-posthumous-residence\"\n  ],\n  \"test\": {\n    \"id\": \"ut_check_warnings_013\",\n    \"skill\": \"check-warnings\",\n    \"type\": \"positive\"\n  }\n}\n",
+    "eval/tests/unit/check-warnings/detect-relative-warning.json": "{\n  \"input\": {\n    \"scenario\": \"mid-research-flynn\",\n    \"user_message\": \"Check Patrick Flynn for any warnings.\"\n  },\n  \"judge_context\": [\n    \"Should call person_warnings on Patrick (I1) -- the focal person, not Thomas\",\n    \"Should report the relativesHasAgeRangeGreaterThan120 warning and recognize that personId in the warning is 'I2' (Thomas), not 'I1' (Patrick)\",\n    \"Should frame the report as 'a relative has a problem' rather than 'Patrick has a problem' -- quoting the skill's Step 4 rule on relatives* tags\",\n    \"Should suggest the appropriate handoff: verify the parent-child link is correct via person-evidence, since the issue may be that Thomas was incorrectly linked as Patrick's father\",\n    \"Should NOT recommend investigating Patrick's own data when the warning is on a relative -- that would mislead the user\"\n  ],\n  \"mcp_fixtures\": [\n    \"person-warnings-relative-warning\"\n  ],\n  \"test\": {\n    \"id\": \"ut_check_warnings_008\",\n    \"skill\": \"check-warnings\",\n    \"type\": \"positive\"\n  }\n}\n",
+    "eval/tests/unit/check-warnings/negative-project-status.json": "{\n  \"input\": {\n    \"scenario\": \"mid-research-flynn\",\n    \"user_message\": \"Where is this project at? Give me an overview of what's done and what's pending.\"\n  },\n  \"judge_context\": [\n    \"Should route to project-status rather than running warning detection on a project the user just wants an overview of\"\n  ],\n  \"mcp_fixtures\": [\n    \"person-warnings-no-warnings\"\n  ],\n  \"negative\": {\n    \"correct_skill\": [\n      \"project-status\"\n    ],\n    \"explanation\": \"The user is asking 'where is the project at?' -- a status summary, not a hunt for anomalies. project-status produces the holistic overview (questions, plans, sources, conflicts, hypotheses, proof state). check-warnings is a focused validation that surfaces specific issues; running it here would either return 'no warnings' (unhelpful for the user's actual question) or fabricate warnings to seem responsive.\"\n  },\n  \"test\": {\n    \"id\": \"ut_check_warnings_003\",\n    \"skill\": \"check-warnings\",\n    \"type\": \"negative\"\n  }\n}\n",
+    "eval/tests/unit/check-warnings/negative-schema-validation.json": "{\n  \"input\": {\n    \"scenario\": \"mid-research-flynn\",\n    \"user_message\": \"Make sure all the required fields in research.json are filled in and the file is well-formed.\"\n  },\n  \"judge_context\": [\n    \"Should NOT invoke person_warnings -- the prompt is about file structure, not about a person's data integrity\",\n    \"Should route to validate-schema (or whatever skill owns the validate_research_schema MCP tool)\",\n    \"If the skill is invoked anyway, it should hand off cleanly to validate-schema without running the warning checks\"\n  ],\n  \"mcp_fixtures\": [\n    \"person-warnings-no-warnings\"\n  ],\n  \"negative\": {\n    \"correct_skill\": [\n      \"validate-schema\"\n    ],\n    \"explanation\": \"The user is asking about structural integrity of research.json (required fields, well-formedness), not about whether the data itself is biologically or temporally possible. validate-schema owns structural checks; check-warnings owns semantic-impossibility checks. The skill's own description explicitly says 'Do NOT use for schema validation (use validate-schema)'.\"\n  },\n  \"test\": {\n    \"id\": \"ut_check_warnings_012\",\n    \"skill\": \"check-warnings\",\n    \"type\": \"negative\"\n  }\n}\n",
+    "eval/tests/unit/check-warnings/negative-source-conflict.json": "{\n  \"input\": {\n    \"scenario\": \"mid-research-flynn\",\n    \"user_message\": \"One census says he was born in Ireland, the death cert says County Cork -- flag that mismatch.\"\n  },\n  \"judge_context\": [\n    \"Should NOT invoke person_warnings -- the user isn't asking about a single-person impossibility\",\n    \"Should route to conflict-resolution because the prompt describes two sources disagreeing on the same fact\",\n    \"If the skill is invoked anyway, it should hand off to conflict-resolution without running the warning checks\"\n  ],\n  \"mcp_fixtures\": [\n    \"person-warnings-no-warnings\"\n  ],\n  \"negative\": {\n    \"correct_skill\": [\n      \"conflict-resolution\"\n    ],\n    \"explanation\": \"A source-vs-source disagreement is a conflict, not a warning. Warnings are about a single person's data violating physical/biological/temporal constraints; conflicts are about two sources giving different answers for the same fact. The skills' references/warnings-as-identity-signals.md draws this boundary explicitly: 'Conflicts: two or more sources disagree about the same fact for the same person... handled by conflict-resolution.'\"\n  },\n  \"test\": {\n    \"id\": \"ut_check_warnings_011\",\n    \"skill\": \"check-warnings\",\n    \"type\": \"negative\"\n  }\n}\n",
+    "eval/tests/unit/check-warnings/quality-and-warnings-both-fire.json": "{\n  \"input\": {\n    \"scenario\": \"christian-hole-quality\",\n    \"user_message\": \"Check Ole C. Hole (KD96-TV4) for problems.\"\n  },\n  \"judge_context\": [\n    \"Should call both person_warnings and person_quality with personId 'KD96-TV4'\",\n    \"Should report the hasEventAfterDeath1 warning as Critical (severity 'error') and recommend investigating the cause (identity confusion, wrong death date, or posthumous mention) before assuming one -- per the skill's event-after-death guidance\",\n    \"Should ALSO report the FamilySearch quality issues (~2: the death place missing a city, a residence with no tagged sources) in a SEPARATE section\",\n    \"Must keep the two distinct: the quality issues are improvements to the profile, NOT impossibilities. Must NOT label the quality issues as Critical/error, and must NOT merge them into the impossibility list\",\n    \"Should NOT re-derive either tool's output; report what the tools returned\"\n  ],\n  \"mcp_fixtures\": [\n    \"person-warnings-hole-son-event-after-death\",\n    \"person-quality-hole-son\"\n  ],\n  \"test\": {\n    \"id\": \"ut_check_warnings_015\",\n    \"skill\": \"check-warnings\",\n    \"type\": \"positive\"\n  }\n}\n",
+    "eval/tests/unit/check-warnings/quality-clean.json": "{\n  \"input\": {\n    \"scenario\": \"christian-hole-quality\",\n    \"user_message\": \"Any data problems with Inger Hole (KD96-TV3)?\"\n  },\n  \"judge_context\": [\n    \"Should call both person_warnings and person_quality with personId 'KD96-TV3'\",\n    \"Should report no impossibilities from person_warnings\",\n    \"Should report that FamilySearch flagged no quality issues (issueCount 0, overall ~1.0)\",\n    \"Should NOT fabricate quality issues to seem thorough, and should NOT invent a quality band\"\n  ],\n  \"mcp_fixtures\": [\n    \"person-warnings-hole-wife-none\",\n    \"person-quality-hole-wife-clean\"\n  ],\n  \"test\": {\n    \"id\": \"ut_check_warnings_016\",\n    \"skill\": \"check-warnings\",\n    \"type\": \"positive\"\n  }\n}\n",
+    "eval/tests/unit/check-warnings/quality-reported-with-issues.json": "{\n  \"input\": {\n    \"scenario\": \"christian-hole-quality\",\n    \"user_message\": \"Check Christian P. Hole (KD96-TV2) for any data-quality warnings.\"\n  },\n  \"judge_context\": [\n    \"Should call person_warnings with personId 'KD96-TV2' (projectPath is the working dir)\",\n    \"Should ALSO call person_quality with personId 'KD96-TV2' -- the id is a FamilySearch ID (XXXX-XXX), so quality applies\",\n    \"Should report that person_warnings found no impossibilities/anomalies\",\n    \"Should add a SEPARATE FamilySearch quality section (distinct from the impossibilities check) reporting the overall score (~0.97) and the issue sentences verbatim: 'The burial date is missing.', 'A marriage place is missing a city.', and 'A residence has no tagged sources.' (which appears 5 times -- may be collapsed with a count)\",\n    \"Should frame the quality issues as optional improvements to the FamilySearch profile, NOT as errors or impossibilities to fix urgently\",\n    \"Should NOT invent a quality label/band (e.g. 'High Quality') -- the tool returns overallScore and sentences only\",\n    \"Should NOT merge the quality issues into the impossibilities list, and should NOT re-derive or re-score them\"\n  ],\n  \"mcp_fixtures\": [\n    \"person-warnings-hole-christian-none\",\n    \"person-quality-hole-christian\"\n  ],\n  \"test\": {\n    \"id\": \"ut_check_warnings_014\",\n    \"skill\": \"check-warnings\",\n    \"type\": \"positive\"\n  }\n}\n",
+    "eval/tests/unit/check-warnings/quality-skipped-synthetic-id.json": "{\n  \"input\": {\n    \"scenario\": \"mid-research-flynn\",\n    \"user_message\": \"Check Patrick Flynn for any warnings.\"\n  },\n  \"judge_context\": [\n    \"Should call person_warnings with personId 'I1'\",\n    \"Should NOT call person_quality -- 'I1' is a synthetic id, not a FamilySearch ID (XXXX-XXX), so there is no profile to score\",\n    \"Should report the person_warnings result (no impossibilities)\",\n    \"Should NOT mention FamilySearch quality at all \u2014 the id is synthetic, so quality does not apply and a note would just be noise\"\n  ],\n  \"mcp_fixtures\": [\n    \"person-warnings-no-warnings\"\n  ],\n  \"test\": {\n    \"id\": \"ut_check_warnings_018\",\n    \"skill\": \"check-warnings\",\n    \"type\": \"positive\"\n  }\n}\n",
+    "eval/tests/unit/check-warnings/quality-tombstoned.json": "{\n  \"input\": {\n    \"scenario\": \"christian-hole-quality\",\n    \"user_message\": \"Check KD96-TV5 for any warnings.\"\n  },\n  \"judge_context\": [\n    \"Should call both person_warnings and person_quality with personId 'KD96-TV5'\",\n    \"Should report the offline person_warnings result (no impossibilities) -- this must appear regardless of the quality failure\",\n    \"Should surface the tombstoned state as a brief note in the quality section (the person was deleted or merged on FamilySearch, so there is no quality score) -- using the tool's returned message; do NOT treat it as a fatal error that aborts the report\",\n    \"Should NOT invent a quality score or issues for a person that has none\"\n  ],\n  \"mcp_fixtures\": [\n    \"person-warnings-hole-deleted-none\",\n    \"person-quality-hole-deleted\"\n  ],\n  \"test\": {\n    \"id\": \"ut_check_warnings_017\",\n    \"skill\": \"check-warnings\",\n    \"type\": \"positive\"\n  }\n}\n",
+    "eval/tests/unit/check-warnings/rubric.md": "# Check Warnings Rubric\n\nGrading dimensions for check-warnings unit tests. Evaluated by the LLM judge alongside the base rubric (correctness, completeness).\n\n**Grading constraints (read before scoring any dimension).** When grading a check-warnings test, you do not have direct access to the test scenario's `research.json` or `tree.gedcomx.json` files. The only sources of truth available to you are: the scenario README (a prose summary of the project state), the user message, the skill's tool calls and the tool responses returned, and the skill's final text response.\n\nDo not assert that a specific fact is or is not present in the tree, in `research.json`, or in any source document unless the scenario README or a tool response explicitly says so. Do not infer counts, dates, names, or relationships from the README's summary beyond what it states verbatim. If a deduction or credit you want to give would require inspecting tree or research.json contents you cannot see in your inputs, do not make it.\n\nThis rule applies symmetrically: do not deduct points because the skill missed a tree fact you cannot yourself verify; do not credit the skill for matching a tree fact you cannot yourself verify. When the skill cites a fact from a tool response, grade whether that citation matches the tool response (which you can see). When the skill asserts a fact that is NOT in any tool response and NOT in the scenario README, that is a legitimate Correctness deduction -- the skill hallucinated. Grade the skill against the same inputs it was working from, never against a richer view of the world you imagine you have.\n\n## Detection accuracy\n\nDid the skill detect genuine impossibilities and anomalies (birth after death, marriage before age 14, lifespan over 120 years) without flagging valid edge cases?\n\n- **pass:** All real impossibilities flagged; no false positives on valid edge cases (a marriage at 16 in an 1850s rural community is unusual but valid).\n- **partial:** Real impossibilities flagged but some false positives slip through, OR one impossibility is missed but the false-positive rate is clean.\n- **fail:** Multiple real impossibilities missed, or so many false positives the genealogist would have to triage them manually anyway.\n\n## Severity classification\n\nAre warnings classified appropriately by severity? An impossibility (born after death) is critical. An anomaly (married at 16, which is above the tool's age-14 threshold) is a note, not a warning.\n\n- **pass:** Severity tier matches actual impact: chronological impossibilities are critical/high; unusual-but-possible values are medium or low.\n- **partial:** Severity tiers present but one or two are off by a tier (a critical issue labeled medium, or a low-severity anomaly labeled high).\n- **fail:** All warnings at the same severity, or severity inversions (anomalies labeled critical, impossibilities labeled low).\n\n## Actionability\n\nDoes each warning suggest what to investigate? \"Birth year conflict between census and death certificate\" is more useful than \"possible date error.\"\n\n- **N/A:** No warnings were found (the project is clean). There is nothing to make actionable -- score this dimension as `null`, not as a pass or fail. This avoids mechanically failing close-out reports on resolved projects where the correct response is \"no warnings.\"\n- **pass:** Every warning names the specific records involved and the action a genealogist should take.\n- **partial:** Most warnings are actionable but at least one is generic (\"possible date issue\") without naming records or next steps.\n- **fail:** Warnings are decoupled from records, or suggested actions are too vague to act on.\n\n## FamilySearch quality reporting\n\nDoes the skill handle the `person_quality` tool correctly -- calling it when (and only when) it applies, reporting it as a concern distinct from the offline impossibilities, and degrading gracefully? Judge only from the tool calls, the tool responses, and the skill's text -- not from the tree.\n\n- **N/A:** The person's id is synthetic (not a FamilySearch ID), so quality does not apply and no `person_quality` call is expected. Score this dimension `null` -- **unless** the skill wrongly called `person_quality` on a synthetic id, which is a `fail`.\n- **pass:** `person_quality` was called exactly when the id was a FamilySearch ID (and skipped for a synthetic id). Its issues are reported in a section distinct from the impossibilities, sentences taken from the tool verbatim, framed as optional improvements (never escalated to error/Critical), with no invented quality band. Zero-issue and tombstoned/error responses are reported honestly, and a quality failure never suppresses the `person_warnings` result.\n- **partial:** Quality is reported but with one slip -- merged into the impossibilities list, an issue lightly re-worded or re-scored, a missing overall score, or an over-stated \"fix urgently\" tone -- while the warnings result is still intact.\n- **fail:** `person_quality` called on a synthetic id or skipped on a real FS id; quality issues escalated as impossibilities/errors; a quality failure suppressed or aborted the warnings report; or quality issues were fabricated.\n",
+    "eval/fixtures/scenarios/christian-hole-quality/README.md": "# christian-hole-quality\n\nA scenario for exercising `check-warnings`' FamilySearch **quality-score**\nintegration (`person_quality`), alongside the offline `person_warnings` check.\n\n**Synthetic test data.** These persons are fabricated fixtures, like the Flynn\nscenarios \u2014 *not* real FamilySearch profiles. The person IDs use the real\n`KD96-TV*` shape so the skill's \"is this a FamilySearch ID?\" gate fires and it\nattempts `person_quality`. All tool responses are mocked from\n`eval/fixtures/mcp/`; nothing hits FamilySearch. (The `KD96-TV2` quality fixture\nmirrors a real captured response for authenticity \u2014 Polk County, Minnesota\nNorwegian-immigrant data \u2014 but the tree facts here are authored, not pulled.)\n\n- **Objective:** review data quality for Christian P. Hole and family.\n- **GedcomX persons (all with FamilySearch-style IDs):**\n  - `KD96-TV2` \u2014 **Christian P. Hole** (subject). Completeness/sourcing gaps but\n    no impossibilities: burial has a place (Fairview Cemetery) but **no date**,\n    a marriage place missing its city, two untagged residences. Quality fixture:\n    7 issues, overall 0.97.\n  - `KD96-TV3` \u2014 **Inger Hole** (wife). Fully sourced, clean. Quality fixture:\n    0 issues.\n  - `KD96-TV4` \u2014 **Ole C. Hole** (son). Carries a real impossibility \u2014 a\n    Residence in 1975, **after his 1960 death** \u2014 plus quality gaps. Warnings\n    fixture fires `hasEventAfterDeath1`; quality fixture: 2 issues.\n  - `KD96-TV5` \u2014 a **duplicate** of the son that was **deleted** on FamilySearch\n    after this project last synced. Still present in the local tree as a stub;\n    its `person_quality` fixture returns `TOMBSTONED`.\n- **GedcomX relationships:** rt1 (Couple TV2\u00d7TV3), r1/r2 (ParentChild \u2192 TV4).\n- **research.json:** minimal active project; no questions/plans/assertions yet\n  (this scenario is about the two review tools, not the research record).\n\nUsed by the `person_quality` integration tests in\n`eval/tests/unit/check-warnings/` (quality-reported-with-issues,\nquality-and-warnings-both-fire, quality-clean, quality-tombstoned). The\nsynthetic-id **skip** case is covered separately against the Flynn scenario.\n",
+    "eval/fixtures/scenarios/christian-hole-quality/research.json": "{\n  \"assertions\": [],\n  \"conflicts\": [],\n  \"evaluations\": [],\n  \"hypotheses\": [],\n  \"log\": [],\n  \"person_evidence\": [],\n  \"plans\": [],\n  \"project\": {\n    \"created\": \"2026-07-01\",\n    \"id\": \"rp_001\",\n    \"objective\": \"Review the data quality of Christian P. Hole (KD96-TV2) and his immediate family, Polk County, Minnesota (Norwegian immigrants)\",\n    \"status\": \"active\",\n    \"subject_person_ids\": [\n      \"KD96-TV2\"\n    ],\n    \"updated\": \"2026-07-01\"\n  },\n  \"proof_summaries\": [],\n  \"questions\": [],\n  \"sources\": [],\n  \"timelines\": []\n}\n",
+    "eval/fixtures/scenarios/christian-hole-quality/tree.gedcomx.json": "{\n  \"persons\": [\n    {\n      \"facts\": [\n        {\n          \"date\": \"1875\",\n          \"id\": \"F1\",\n          \"place\": \"Norway\",\n          \"primary\": true,\n          \"sources\": [\n            {\n              \"page\": \"1900 census, Polk Co., ED 112\",\n              \"ref\": \"S1\"\n            }\n          ],\n          \"type\": \"Birth\"\n        },\n        {\n          \"date\": \"1 May 1898\",\n          \"id\": \"F2\",\n          \"place\": \"Polk, Minnesota, United States\",\n          \"sources\": [\n            {\n              \"page\": \"1900 census, Polk Co., ED 112\",\n              \"ref\": \"S1\"\n            }\n          ],\n          \"type\": \"Marriage\"\n        },\n        {\n          \"date\": \"1895\",\n          \"id\": \"F3\",\n          \"place\": \"Reis, Polk, Minnesota, United States\",\n          \"type\": \"Residence\"\n        },\n        {\n          \"date\": \"1900\",\n          \"id\": \"F4\",\n          \"place\": \"Fairview, Polk, Minnesota, United States\",\n          \"type\": \"Residence\"\n        },\n        {\n          \"date\": \"1910\",\n          \"id\": \"F5\",\n          \"place\": \"Fairview, Polk, Minnesota, United States\",\n          \"type\": \"Residence\"\n        },\n        {\n          \"date\": \"1920\",\n          \"id\": \"F6\",\n          \"place\": \"Erskine, Polk, Minnesota, United States\",\n          \"type\": \"Residence\"\n        },\n        {\n          \"date\": \"1930\",\n          \"id\": \"F7\",\n          \"place\": \"Erskine, Polk, Minnesota, United States\",\n          \"type\": \"Residence\"\n        },\n        {\n          \"id\": \"F8\",\n          \"place\": \"Fairview Cemetery, Erskine, Polk County, Minnesota, United States\",\n          \"type\": \"Burial\"\n        },\n        {\n          \"date\": \"1945-06-10\",\n          \"id\": \"F9\",\n          \"place\": \"Erskine, Polk, Minnesota, United States\",\n          \"sources\": [\n            {\n              \"page\": \"MN death index no. 8841\",\n              \"ref\": \"S2\"\n            }\n          ],\n          \"type\": \"Death\"\n        }\n      ],\n      \"gender\": \"Male\",\n      \"id\": \"KD96-TV2\",\n      \"names\": [\n        {\n          \"given\": \"Christian P.\",\n          \"id\": \"N1\",\n          \"preferred\": true,\n          \"surname\": \"Hole\",\n          \"type\": \"BirthName\"\n        }\n      ]\n    },\n    {\n      \"facts\": [\n        {\n          \"date\": \"1878\",\n          \"id\": \"F10\",\n          \"place\": \"Norway\",\n          \"primary\": true,\n          \"sources\": [\n            {\n              \"page\": \"1900 census, Polk Co., ED 112\",\n              \"ref\": \"S1\"\n            }\n          ],\n          \"type\": \"Birth\"\n        },\n        {\n          \"date\": \"1 May 1898\",\n          \"id\": \"F11\",\n          \"place\": \"Fisher, Polk, Minnesota, United States\",\n          \"sources\": [\n            {\n              \"page\": \"1900 census, Polk Co., ED 112\",\n              \"ref\": \"S1\"\n            }\n          ],\n          \"type\": \"Marriage\"\n        },\n        {\n          \"date\": \"1950-02-14\",\n          \"id\": \"F12\",\n          \"place\": \"Erskine, Polk, Minnesota, United States\",\n          \"sources\": [\n            {\n              \"page\": \"MN death index no. 12002\",\n              \"ref\": \"S2\"\n            }\n          ],\n          \"type\": \"Death\"\n        }\n      ],\n      \"gender\": \"Female\",\n      \"id\": \"KD96-TV3\",\n      \"names\": [\n        {\n          \"given\": \"Inger\",\n          \"id\": \"N2\",\n          \"preferred\": true,\n          \"surname\": \"Hole\",\n          \"type\": \"BirthName\"\n        }\n      ]\n    },\n    {\n      \"facts\": [\n        {\n          \"date\": \"1905\",\n          \"id\": \"F13\",\n          \"place\": \"Polk, Minnesota, United States\",\n          \"primary\": true,\n          \"sources\": [\n            {\n              \"page\": \"1910 census, Polk Co., ED 118\",\n              \"ref\": \"S1\"\n            }\n          ],\n          \"type\": \"Birth\"\n        },\n        {\n          \"date\": \"1960-08-03\",\n          \"id\": \"F14\",\n          \"place\": \"Crookston, Polk, Minnesota, United States\",\n          \"sources\": [\n            {\n              \"page\": \"MN death index no. 33417\",\n              \"ref\": \"S2\"\n            }\n          ],\n          \"type\": \"Death\"\n        },\n        {\n          \"date\": \"1975\",\n          \"id\": \"F15\",\n          \"place\": \"Crookston, Polk, Minnesota, United States\",\n          \"type\": \"Residence\"\n        }\n      ],\n      \"gender\": \"Male\",\n      \"id\": \"KD96-TV4\",\n      \"names\": [\n        {\n          \"given\": \"Ole C.\",\n          \"id\": \"N3\",\n          \"preferred\": true,\n          \"surname\": \"Hole\",\n          \"type\": \"BirthName\"\n        }\n      ]\n    },\n    {\n      \"facts\": [\n        {\n          \"date\": \"1905\",\n          \"id\": \"F16\",\n          \"place\": \"Polk, Minnesota, United States\",\n          \"type\": \"Birth\"\n        }\n      ],\n      \"gender\": \"Male\",\n      \"id\": \"KD96-TV5\",\n      \"names\": [\n        {\n          \"given\": \"Ole\",\n          \"id\": \"N4\",\n          \"preferred\": true,\n          \"surname\": \"Hole\",\n          \"type\": \"BirthName\"\n        }\n      ]\n    }\n  ],\n  \"relationships\": [\n    {\n      \"id\": \"R1\",\n      \"person1\": \"KD96-TV2\",\n      \"person2\": \"KD96-TV3\",\n      \"type\": \"Couple\"\n    },\n    {\n      \"child\": \"KD96-TV4\",\n      \"id\": \"R2\",\n      \"parent\": \"KD96-TV2\",\n      \"type\": \"ParentChild\"\n    },\n    {\n      \"child\": \"KD96-TV4\",\n      \"id\": \"R3\",\n      \"parent\": \"KD96-TV3\",\n      \"type\": \"ParentChild\"\n    }\n  ],\n  \"sources\": [\n    {\n      \"author\": \"U.S. Census Bureau\",\n      \"id\": \"S1\",\n      \"title\": \"United States Census, 1900 & 1910\"\n    },\n    {\n      \"author\": \"Minnesota Department of Health\",\n      \"id\": \"S2\",\n      \"title\": \"Minnesota Death Index\"\n    }\n  ]\n}\n",
+    "eval/fixtures/scenarios/empty-project-just-created/README.md": "# empty-project-just-created\n\nProject state immediately after `init-project` runs successfully: the objective is captured, a stub person exists in `tree.gedcomx.json`, but no research work has been done yet.\n\n- **Objective:** Identify the parents of Patrick Flynn (b. ~1845, d. 1908)\n- **Questions:** none\n- **Plans:** none\n- **Log:** empty\n- **Sources:** none\n- **Assertions:** none\n- **GedcomX persons:** I1 (Patrick Flynn \u2014 stub, name only, no facts)\n- **GedcomX relationships:** none\n- **GedcomX sources:** none\n\n## Used by\n\n- `question-selection` tests where the skill must derive a first research question from the objective rather than choose from an existing question list.\n- `research-plan` tests where the skill must produce a plan for a question that has no prior search log.\n- Any skill whose behavior on a freshly-initialized project differs from mid-research behavior.\n\n## What this scenario tests boundary-wise\n\nA skill given this scenario should not pretend prior research exists. If it tries to read assertions, sources, or the log and they're empty, the right behavior is to reason from the objective + stub person alone, or to politely decline if it requires data that doesn't exist yet.\n",
+    "eval/fixtures/scenarios/empty-project-just-created/research.json": "{\n  \"assertions\": [],\n  \"conflicts\": [],\n  \"evaluations\": [],\n  \"hypotheses\": [],\n  \"log\": [],\n  \"person_evidence\": [],\n  \"plans\": [],\n  \"project\": {\n    \"created\": \"2026-05-13\",\n    \"id\": \"rp_001\",\n    \"objective\": \"Identify the parents of Patrick Flynn, born ca. 1845 in Pennsylvania, died 1908 in Schuylkill County, PA\",\n    \"status\": \"active\",\n    \"subject_person_ids\": [\n      \"I1\"\n    ],\n    \"updated\": \"2026-05-13\"\n  },\n  \"proof_summaries\": [],\n  \"questions\": [],\n  \"sources\": [],\n  \"timelines\": []\n}\n",
+    "eval/fixtures/scenarios/empty-project-just-created/tree.gedcomx.json": "{\n  \"persons\": [\n    {\n      \"gender\": \"Male\",\n      \"id\": \"I1\",\n      \"names\": [\n        {\n          \"given\": \"Patrick\",\n          \"id\": \"N1\",\n          \"preferred\": true,\n          \"surname\": \"Flynn\"\n        }\n      ]\n    }\n  ],\n  \"relationships\": [],\n  \"sources\": []\n}\n",
+    "eval/fixtures/scenarios/flynn-posthumous-residence/README.md": "# flynn-posthumous-residence\n\nA check-warnings scenario for the **posthumous-mention** case. Copied from\n`mid-research-flynn`, with one addition: Patrick Flynn (I1, d. 1908) has a\npost-death **Residence** fact `F3` dated 1925, citing source `S5` \u2014 the\nobituary of his daughter Mary (Flynn) Brennan, which names Patrick as her\nlate father and was auto-attached to Patrick's profile as a Residence-style\nfact.\n\nThis reproduces the pattern FamilySearch commonly produces: probate, estate,\nand obituaries of relatives that mention a deceased person get tagged as a\n\"Residence\" on that person's profile, triggering `hasEventAfterDeath1`. The\ncorrect reading is a posthumous mention (unlink and treat as a reference),\n**not** identity confusion / a same-name merge.\n\nUsed by `ut_check_warnings_013` (`detect-posthumous-residence.json`) with the\n`person-warnings-posthumous-residence` MCP fixture.\n",
+    "eval/fixtures/scenarios/flynn-posthumous-residence/research.json": "{\n  \"assertions\": [\n    {\n      \"date\": null,\n      \"date_certainty\": null,\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_002\"\n      ],\n      \"fact_type\": \"name\",\n      \"id\": \"a_001\",\n      \"informant\": \"Unknown household member reporting to census enumerator\",\n      \"informant_bias_notes\": \"Census enumerator is the recorder, not the informant. The household member who provided the name is unknown. Proximity is 'unknown' rather than 'household_member' because for names specifically, the enumerator may have read a sign, heard a neighbor, or made an assumption \u2014 the name fact doesn't necessarily require active reporting the way age/birthplace does.\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_001\",\n      \"place\": null,\n      \"record_id\": \"ark:/61903/1:1:MXYZ\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_001\",\n      \"structured_value\": {\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"value\": \"Patrick Flynn\"\n    },\n    {\n      \"date\": \"~1845\",\n      \"date_certainty\": \"estimated\",\n      \"evidence_type\": \"indirect\",\n      \"extracted_for_question_ids\": [\n        \"q_002\"\n      ],\n      \"fact_type\": \"birth\",\n      \"id\": \"a_002\",\n      \"informant\": \"Unknown household member (likely Thomas Flynn or wife)\",\n      \"informant_bias_notes\": \"Age and birthplace require active reporting by a household member \u2014 someone had to tell the enumerator these facts. Proximity is 'household_member' rather than 'unknown' because these facts could only come from someone in the household.\",\n      \"informant_proximity\": \"household_member\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_001\",\n      \"place\": \"Ireland\",\n      \"record_id\": \"ark:/61903/1:1:MXYZ\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_001\",\n      \"structured_value\": {\n        \"place\": \"Ireland\",\n        \"year\": 1845\n      },\n      \"value\": \"age 5\"\n    },\n    {\n      \"date\": \"1850\",\n      \"date_certainty\": \"exact\",\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_002\"\n      ],\n      \"fact_type\": \"residence\",\n      \"id\": \"a_003\",\n      \"informant\": \"Census enumerator (witness to residence by visiting the dwelling)\",\n      \"informant_bias_notes\": \"For residence facts specifically, the enumerator is a direct witness \u2014 they physically visited the dwelling and recorded who lived there. This distinguishes residence from other census facts where the household member is the true informant.\",\n      \"informant_proximity\": \"witness\",\n      \"information_quality\": \"primary\",\n      \"log_entry_id\": \"log_001\",\n      \"place\": \"Schuylkill County, Pennsylvania\",\n      \"record_id\": \"ark:/61903/1:1:MXYZ\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_001\",\n      \"value\": \"Schuylkill County, Pennsylvania\"\n    },\n    {\n      \"date\": \"1850\",\n      \"date_certainty\": \"exact\",\n      \"evidence_type\": \"indirect\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"relationship\",\n      \"id\": \"a_004\",\n      \"informant\": \"Inferred from household structure \u2014 no explicit informant for relationships in 1850 census\",\n      \"informant_bias_notes\": \"1850 census does not state relationships; this assertion is inferred from household position and shared surname, not directly reported by any informant. The relationship is indirect evidence constructed by the researcher, not information provided by a census informant.\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_001\",\n      \"place\": \"Schuylkill County, Pennsylvania\",\n      \"record_id\": \"ark:/61903/1:1:MXYZ\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_001\",\n      \"structured_value\": {\n        \"related_person_role\": \"head_of_household\",\n        \"relationship_type\": \"child_inferred\"\n      },\n      \"value\": \"Listed in household of Thomas Flynn (head), position consistent with child\"\n    },\n    {\n      \"date\": null,\n      \"date_certainty\": null,\n      \"evidence_type\": \"indirect\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"name\",\n      \"id\": \"a_005\",\n      \"informant\": \"Unknown household member (likely Thomas Flynn himself) reporting to census enumerator\",\n      \"informant_bias_notes\": \"Census enumerator is the recorder, not the informant. As head of household, Thomas likely provided his own name, but the 1850 census does not identify the informant.\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_001\",\n      \"place\": null,\n      \"record_id\": \"ark:/61903/1:1:MXYZ\",\n      \"record_role\": \"head_of_household\",\n      \"source_id\": \"src_001\",\n      \"value\": \"Thomas Flynn\"\n    },\n    {\n      \"date\": null,\n      \"date_certainty\": null,\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_002\"\n      ],\n      \"fact_type\": \"name\",\n      \"id\": \"a_006\",\n      \"informant\": \"Ancestry transcriber (derivative of census enumerator)\",\n      \"informant_bias_notes\": \"Derivative index \u2014 transcription errors possible\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_002\",\n      \"place\": null,\n      \"record_id\": \"ancestry:8054:patrick-flynn-1850\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_002\",\n      \"value\": \"Patrick Flynn\"\n    },\n    {\n      \"date\": \"~1845\",\n      \"date_certainty\": \"estimated\",\n      \"evidence_type\": \"indirect\",\n      \"extracted_for_question_ids\": [\n        \"q_002\"\n      ],\n      \"fact_type\": \"birth\",\n      \"id\": \"a_007\",\n      \"informant\": \"Ancestry transcriber (derivative)\",\n      \"informant_bias_notes\": null,\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_002\",\n      \"place\": \"Ireland\",\n      \"record_id\": \"ancestry:8054:patrick-flynn-1850\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_002\",\n      \"value\": \"age 5\"\n    },\n    {\n      \"date\": null,\n      \"date_certainty\": null,\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"name\",\n      \"id\": \"a_008\",\n      \"informant\": \"Unknown household member reporting to census enumerator\",\n      \"informant_bias_notes\": \"Census enumerator is the recorder, not the informant. Proximity is 'unknown' for names (same reasoning as a_001 \u2014 name facts don't necessarily require active reporting).\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_004\",\n      \"place\": null,\n      \"record_id\": \"ark:/61903/1:1:MABC\",\n      \"record_role\": \"child_2\",\n      \"source_id\": \"src_003\",\n      \"value\": \"Patrick Flynn\"\n    },\n    {\n      \"date\": \"~1845\",\n      \"date_certainty\": \"estimated\",\n      \"evidence_type\": \"indirect\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"birth\",\n      \"id\": \"a_009\",\n      \"informant\": \"Unknown household member (likely Thomas Flynn or wife)\",\n      \"informant_bias_notes\": \"Age and birthplace require active reporting by a household member (same reasoning as a_002).\",\n      \"informant_proximity\": \"household_member\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_004\",\n      \"place\": \"Ireland\",\n      \"record_id\": \"ark:/61903/1:1:MABC\",\n      \"record_role\": \"child_2\",\n      \"source_id\": \"src_003\",\n      \"value\": \"age 15\"\n    },\n    {\n      \"date\": \"1860\",\n      \"date_certainty\": \"exact\",\n      \"evidence_type\": \"indirect\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"relationship\",\n      \"id\": \"a_010\",\n      \"informant\": \"Inferred from household structure \u2014 no explicit informant for relationships in 1860 census\",\n      \"informant_bias_notes\": \"1860 census does not state relationships; like the 1850 census, this assertion is inferred from household position, age, and shared surname. The relationship column was not introduced until the 1880 census.\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_004\",\n      \"place\": \"Schuylkill County, Pennsylvania\",\n      \"record_id\": \"ark:/61903/1:1:MABC\",\n      \"record_role\": \"child_2\",\n      \"source_id\": \"src_003\",\n      \"structured_value\": {\n        \"related_person_role\": \"head_of_household\",\n        \"relationship_type\": \"child_inferred\"\n      },\n      \"value\": \"Listed in household of Thomas Flynn (head), position and age consistent with son\"\n    },\n    {\n      \"date\": \"1908-03-12\",\n      \"date_certainty\": \"exact\",\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [],\n      \"fact_type\": \"death\",\n      \"id\": \"a_011\",\n      \"informant\": \"Attending physician (signature on certificate)\",\n      \"informant_bias_notes\": null,\n      \"informant_proximity\": \"witness\",\n      \"information_quality\": \"primary\",\n      \"log_entry_id\": \"log_005\",\n      \"place\": \"Schuylkill County, Pennsylvania\",\n      \"record_id\": \"ark:/61903/1:1:MDEF\",\n      \"record_role\": \"deceased\",\n      \"source_id\": \"src_004\",\n      \"value\": \"Died 12 March 1908\"\n    },\n    {\n      \"date\": \"1845\",\n      \"date_certainty\": \"approximate\",\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"birth\",\n      \"id\": \"a_012\",\n      \"informant\": \"James Brown (son-in-law)\",\n      \"informant_bias_notes\": \"Son-in-law reporting birth facts decades after the event. Note: death cert says Pennsylvania, but census records say Ireland. Son-in-law may not have known Patrick was born in Ireland.\",\n      \"informant_proximity\": \"family_not_present\",\n      \"information_quality\": \"secondary\",\n      \"log_entry_id\": \"log_005\",\n      \"place\": \"Pennsylvania\",\n      \"record_id\": \"ark:/61903/1:1:MDEF\",\n      \"record_role\": \"deceased\",\n      \"source_id\": \"src_004\",\n      \"structured_value\": {\n        \"place\": \"Pennsylvania\",\n        \"year\": 1845\n      },\n      \"value\": \"Born 1845, Pennsylvania\"\n    },\n    {\n      \"date\": null,\n      \"date_certainty\": null,\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"relationship\",\n      \"id\": \"a_013\",\n      \"informant\": \"James Brown (son-in-law)\",\n      \"informant_bias_notes\": \"Secondary information \u2014 son-in-law reporting what he was told about father-in-law's parentage\",\n      \"informant_proximity\": \"family_not_present\",\n      \"information_quality\": \"secondary\",\n      \"log_entry_id\": \"log_005\",\n      \"place\": null,\n      \"record_id\": \"ark:/61903/1:1:MDEF\",\n      \"record_role\": \"deceased\",\n      \"source_id\": \"src_004\",\n      \"structured_value\": {\n        \"related_person_role\": \"deceased\",\n        \"relationship_type\": \"father\"\n      },\n      \"value\": \"Father: Thomas Flynn\"\n    }\n  ],\n  \"conflicts\": [\n    {\n      \"blocks_question_ids\": [],\n      \"competing_assertion_ids\": [\n        \"a_002\",\n        \"a_009\",\n        \"a_012\"\n      ],\n      \"conflict_type\": \"fact\",\n      \"description\": \"Patrick Flynn's birthplace: Ireland (1850 and 1860 censuses) vs. Pennsylvania (1908 death certificate)\",\n      \"disputed_attribute\": \"birthplace\",\n      \"id\": \"c_001\",\n      \"identity_question\": null,\n      \"independence_analysis\": \"The two census records (1850, 1860) are independent original sources with different enumerators. The death certificate is a third independent original source. However, the census informants are likely the same household member (Thomas Flynn or wife), so the two census assertions may share a single informant \u2014 potentially not fully independent for this fact.\",\n      \"preferred_assertion_id\": \"a_002\",\n      \"resolution_rationale\": \"Ireland is accepted as the birthplace. The 1908 death certificate birthplace of 'Pennsylvania' is rejected as a likely error by the son-in-law informant, who may have confused Patrick's place of residence with his place of birth, or may not have known Patrick was born in Ireland before immigrating as a young child.\",\n      \"status\": \"resolved\",\n      \"weighing_analysis\": \"The census records are contemporary recordings made near the time of Patrick's birth, while the death certificate was created 63 years later. The census informant was likely a household member with firsthand knowledge (primary or indeterminate), while the death certificate informant (son-in-law) is clearly secondary for birth facts. Two contemporary sources outweigh one later recollection by a secondary informant.\"\n    }\n  ],\n  \"evaluations\": [],\n  \"hypotheses\": [\n    {\n      \"claim\": \"Patrick Flynn's father was Thomas Flynn of Schuylkill County, Pennsylvania\",\n      \"contradicting_assertion_ids\": [],\n      \"id\": \"h_001\",\n      \"notes\": \"Three independent pieces of evidence: 1850 census co-enumeration (indirect), 1860 census co-enumeration (indirect \u2014 relationship inferred from household position), death certificate naming Thomas as father (direct, secondary informant). Awaiting probate records for additional confirmation.\",\n      \"related_question_ids\": [\n        \"q_001\"\n      ],\n      \"ruled_out\": false,\n      \"ruled_out_reason\": null,\n      \"status\": \"supported\",\n      \"supporting_assertion_ids\": [\n        \"a_004\",\n        \"a_010\",\n        \"a_013\"\n      ]\n    }\n  ],\n  \"log\": [\n    {\n      \"external_site\": null,\n      \"id\": \"log_001\",\n      \"notes\": \"Found Patrick Flynn age 5 in household of Thomas Flynn, dwelling 84, Schuylkill Co. Three other Flynn results examined \u2014 ages and locations don't match.\",\n      \"outcome\": \"positive\",\n      \"performed\": \"2026-05-01T10:15:00Z\",\n      \"plan_item_id\": \"pli_001\",\n      \"query\": {\n        \"birth_place\": \"Pennsylvania\",\n        \"birth_year\": 1845,\n        \"collection\": \"1850 Census\",\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"results_examined\": 8,\n      \"tool\": \"record_search\"\n    },\n    {\n      \"external_site\": {\n        \"capture_filename\": \"ancestry-1850-flynn-results.pdf\",\n        \"capture_received\": true,\n        \"site\": \"ancestry\",\n        \"url_generated\": \"https://www.ancestry.com/search/collections/8054/?name=Patrick_Flynn&birth=1845&birthplace=Pennsylvania\"\n      },\n      \"id\": \"log_002\",\n      \"notes\": \"Ancestry index confirms same household. Transcription matches FamilySearch except Ancestry reads dwelling as 84, FamilySearch as 84 \u2014 consistent.\",\n      \"outcome\": \"positive\",\n      \"performed\": \"2026-05-01T11:30:00Z\",\n      \"plan_item_id\": \"pli_002\",\n      \"query\": {\n        \"birth_place\": \"Pennsylvania\",\n        \"birth_year\": 1845,\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"results_examined\": 12,\n      \"tool\": \"external_site\"\n    },\n    {\n      \"external_site\": {\n        \"capture_filename\": \"myheritage-1850-flynn-nil.pdf\",\n        \"capture_received\": true,\n        \"site\": \"myheritage\",\n        \"url_generated\": \"https://www.myheritage.com/research?action=query&first=Patrick&last=Flynn&birth_year=1845&birth_place=Pennsylvania\"\n      },\n      \"id\": \"log_003\",\n      \"notes\": \"MyHeritage returned no results for Patrick Flynn in 1850 Schuylkill County. Site may not have this collection indexed. Searched broader Pennsylvania \u2014 still no match.\",\n      \"outcome\": \"negative\",\n      \"performed\": \"2026-05-01T14:00:00Z\",\n      \"plan_item_id\": \"pli_003\",\n      \"query\": {\n        \"birth_place\": \"Pennsylvania\",\n        \"birth_year\": 1845,\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"results_examined\": 0,\n      \"tool\": \"external_site\"\n    },\n    {\n      \"external_site\": null,\n      \"id\": \"log_004\",\n      \"notes\": \"Patrick Flynn age 15 in household of Thomas Flynn, Schuylkill Co. Consistent with 1850 placement.\",\n      \"outcome\": \"positive\",\n      \"performed\": \"2026-05-02T09:00:00Z\",\n      \"plan_item_id\": \"pli_004\",\n      \"query\": {\n        \"birth_place\": \"Pennsylvania\",\n        \"birth_year\": 1845,\n        \"collection\": \"1860 Census\",\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"results_examined\": 5,\n      \"tool\": \"record_search\"\n    },\n    {\n      \"external_site\": null,\n      \"id\": \"log_005\",\n      \"notes\": \"Death certificate found. Names Thomas Flynn as father. Informant was son-in-law James Brown.\",\n      \"outcome\": \"positive\",\n      \"performed\": \"2026-05-03T10:00:00Z\",\n      \"plan_item_id\": \"pli_005\",\n      \"query\": {\n        \"death_place\": \"Schuylkill County, Pennsylvania\",\n        \"death_year\": 1908,\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"results_examined\": 2,\n      \"tool\": \"record_search\"\n    }\n  ],\n  \"person_evidence\": [\n    {\n      \"assertion_id\": \"a_001\",\n      \"confidence\": \"confident\",\n      \"created\": \"2026-05-01\",\n      \"id\": \"pe_001\",\n      \"match_score\": null,\n      \"person_id\": \"I1\",\n      \"rationale\": \"Name matches (Patrick Flynn), age consistent with ~1845 birth, located in Schuylkill County where subject is known to have lived. Only Patrick Flynn of this age in the county in 1850.\",\n      \"superseded_by\": null\n    },\n    {\n      \"assertion_id\": \"a_004\",\n      \"confidence\": \"probable\",\n      \"created\": \"2026-05-01\",\n      \"id\": \"pe_002\",\n      \"match_score\": null,\n      \"person_id\": \"I1\",\n      \"rationale\": \"Same record as pe_001, same person. Household position and shared surname with head Thomas Flynn suggest parent-child relationship, but 1850 census does not state relationships explicitly.\",\n      \"superseded_by\": null\n    },\n    {\n      \"assertion_id\": \"a_004\",\n      \"confidence\": \"probable\",\n      \"created\": \"2026-05-01\",\n      \"id\": \"pe_006\",\n      \"match_score\": null,\n      \"person_id\": \"I2\",\n      \"rationale\": \"Same assertion as pe_002 but linked to Thomas Flynn (I2). The relationship assertion ('position consistent with child') equally bears on the head of household. Thomas Flynn is the other party in the implied parent-child relationship.\",\n      \"superseded_by\": null\n    },\n    {\n      \"assertion_id\": \"a_005\",\n      \"confidence\": \"probable\",\n      \"created\": \"2026-05-01\",\n      \"id\": \"pe_003\",\n      \"match_score\": 0.82,\n      \"person_id\": \"I2\",\n      \"rationale\": \"Thomas Flynn, head of household where Patrick was found. Age (~32 in 1850, born ~1818) is consistent with being Patrick's father. Name matches candidate father.\",\n      \"superseded_by\": null\n    },\n    {\n      \"assertion_id\": \"a_010\",\n      \"confidence\": \"confident\",\n      \"created\": \"2026-05-02\",\n      \"id\": \"pe_004\",\n      \"match_score\": null,\n      \"person_id\": \"I1\",\n      \"rationale\": \"Patrick Flynn age 15 in Thomas Flynn household, 1860 census. Same county, age consistent with 1850 enumeration. Relationship inferred from household position and shared surname (1860 census does not state relationships explicitly).\",\n      \"superseded_by\": null\n    },\n    {\n      \"assertion_id\": \"a_013\",\n      \"confidence\": \"confident\",\n      \"created\": \"2026-05-03\",\n      \"id\": \"pe_005\",\n      \"match_score\": null,\n      \"person_id\": \"I1\",\n      \"rationale\": \"Death certificate for Patrick Flynn, d. 1908, Schuylkill County. Names match, death location matches known residence. Names Thomas Flynn as father.\",\n      \"superseded_by\": null\n    }\n  ],\n  \"plans\": [\n    {\n      \"created\": \"2026-05-01\",\n      \"id\": \"pl_001\",\n      \"items\": [\n        {\n          \"date_range\": \"1850\",\n          \"fallback_for\": null,\n          \"id\": \"pli_001\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"1850 census fully indexed on FamilySearch. Free access, start here.\",\n          \"record_type\": \"census\",\n          \"repository\": \"FamilySearch\",\n          \"sequence\": 1,\n          \"status\": \"completed\"\n        },\n        {\n          \"date_range\": \"1850\",\n          \"fallback_for\": null,\n          \"id\": \"pli_002\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"Ancestry has independent indexing; cross-check for transcription errors.\",\n          \"record_type\": \"census\",\n          \"repository\": \"Ancestry\",\n          \"sequence\": 2,\n          \"status\": \"completed\"\n        },\n        {\n          \"date_range\": \"1850\",\n          \"fallback_for\": null,\n          \"id\": \"pli_003\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"Third independent index for coverage confirmation.\",\n          \"record_type\": \"census\",\n          \"repository\": \"MyHeritage\",\n          \"sequence\": 3,\n          \"status\": \"completed\"\n        }\n      ],\n      \"question_id\": \"q_002\",\n      \"status\": \"completed\"\n    },\n    {\n      \"created\": \"2026-05-02\",\n      \"id\": \"pl_002\",\n      \"items\": [\n        {\n          \"date_range\": \"1860\",\n          \"fallback_for\": null,\n          \"id\": \"pli_004\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"Confirm Patrick still in Thomas Flynn household in 1860. Strengthens parent-child identification.\",\n          \"record_type\": \"census\",\n          \"repository\": \"FamilySearch\",\n          \"sequence\": 1,\n          \"status\": \"completed\"\n        },\n        {\n          \"date_range\": \"1908\",\n          \"fallback_for\": null,\n          \"id\": \"pli_005\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"Death certificate may name parents directly.\",\n          \"record_type\": \"vital_record\",\n          \"repository\": \"FamilySearch\",\n          \"sequence\": 2,\n          \"status\": \"completed\"\n        },\n        {\n          \"date_range\": \"1870-1890\",\n          \"fallback_for\": null,\n          \"id\": \"pli_006\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"Thomas Flynn probate/will may name Patrick as son.\",\n          \"record_type\": \"probate\",\n          \"repository\": \"FamilySearch\",\n          \"sequence\": 3,\n          \"status\": \"in_progress\"\n        }\n      ],\n      \"question_id\": \"q_001\",\n      \"status\": \"active\"\n    }\n  ],\n  \"project\": {\n    \"created\": \"2026-05-01\",\n    \"id\": \"rp_001\",\n    \"objective\": \"Identify the parents of Patrick Flynn, born ca. 1845 in Pennsylvania, died 1908 in Schuylkill County, PA\",\n    \"status\": \"active\",\n    \"subject_person_ids\": [\n      \"I1\"\n    ],\n    \"updated\": \"2026-05-04\"\n  },\n  \"proof_summaries\": [\n    {\n      \"exhaustive_search_summary\": \"Searched 1850 census (FamilySearch, Ancestry, MyHeritage \u2014 log_001, log_002, log_003), 1860 census (FamilySearch \u2014 log_004), and death certificate (FamilySearch \u2014 log_005). Probate search in progress. 1870, 1880, and 1900 censuses not yet searched.\",\n      \"id\": \"ps_001\",\n      \"narrative_markdown\": \"## Parentage of Patrick Flynn (ca. 1845\u20131908)\\n\\nPatrick Flynn is **Probably** the son of Thomas Flynn of Schuylkill County, Pennsylvania.\\n\\n### Evidence Summary\\n\\nThree independent lines of evidence support this conclusion:\\n\\n1. **1850 U.S. Census** (Original Source). Patrick Flynn, age 5, born Ireland, appears in the household of Thomas Flynn, age 32, born Ireland, in Schuylkill County, Pennsylvania (dwelling 84, family 91). The 1850 census does not state relationships, but Patrick's position in the household and shared surname are consistent with a parent-child relationship. The informant is indeterminate but likely a household member. This constitutes indirect evidence of parentage.\\n\\n2. **1860 U.S. Census** (Original Source). Patrick Flynn, age 15, born Ireland, appears in the household of Thomas Flynn in Schuylkill County (dwelling 112, family 119). Like the 1850 census, the 1860 census does not state relationships explicitly (the relationship column was not introduced until 1880). Patrick's position in the household, shared surname, and age consistent with the 1850 enumeration support a parent-child relationship. This constitutes indirect evidence of parentage.\\n\\n3. **1908 Death Certificate** (Original Source). Patrick Flynn's death certificate (no. 4521, Pennsylvania Department of Health) names \\\"Thomas Flynn\\\" as his father. The informant was James Brown, identified as Patrick's son-in-law. As a son-in-law reporting his father-in-law's parentage, Brown is a secondary informant for this fact \u2014 he was not a witness to Patrick's birth and is reporting what he was told. Nevertheless, this is direct evidence naming the father.\\n\\n### Conflict Resolution\\n\\nA birthplace conflict exists: the 1850 and 1860 censuses list Patrick's birthplace as Ireland, while the 1908 death certificate states Pennsylvania. The two census records are contemporary recordings with informants likely present in the household, while the death certificate was created 63 years after Patrick's birth by a son-in-law with no firsthand knowledge of the event. Per the GPS preponderance hierarchy, contemporary recordings by closer informants outweigh later recollections by secondary informants. Ireland is accepted as the birthplace; the death certificate entry is attributed to informant error.\\n\\n### Assessment\\n\\nThe conclusion is rated **Probable** rather than **Proved** because: (a) both census sources (1850 and 1860) provide only indirect evidence of parentage (relationships not stated \u2014 the relationship column was not introduced until 1880), (b) the death certificate informant is secondary, and (c) research is not yet exhaustive \u2014 the 1870, 1880, and 1900 censuses have not been searched, and Thomas Flynn's probate records have not been located. If Thomas Flynn's will names Patrick as a son, or if additional census records confirm the relationship, the conclusion would advance to **Proved**.\\n\\n### Citations\\n\\n1. 1850 U.S. Census, Schuylkill County, Pennsylvania, population schedule, dwelling 84, family 91, Thomas Flynn household; NARA microfilm publication M432, roll 810; digital image, FamilySearch.org, accessed 1 May 2026.\\n2. 1860 U.S. Census, Schuylkill County, Pennsylvania, population schedule, dwelling 112, family 119, Thomas Flynn household; NARA microfilm publication M653, roll 1141; digital image, FamilySearch.org, accessed 2 May 2026.\\n3. Pennsylvania Department of Health, death certificate no. 4521 (1908), Patrick Flynn; Pennsylvania State Archives, Harrisburg; digital image, FamilySearch.org, accessed 3 May 2026.\",\n      \"question_id\": \"q_001\",\n      \"resolved_conflict_ids\": [\n        \"c_001\"\n      ],\n      \"supporting_assertion_ids\": [\n        \"a_004\",\n        \"a_010\",\n        \"a_013\"\n      ],\n      \"tier\": \"probable\",\n      \"vehicle\": \"summary\"\n    }\n  ],\n  \"questions\": [\n    {\n      \"created\": \"2026-05-01\",\n      \"depends_on\": [],\n      \"exhaustive_declaration\": {\n        \"declared\": false,\n        \"justification\": null,\n        \"log_entry_ids\": [],\n        \"stop_criteria\": null\n      },\n      \"id\": \"q_001\",\n      \"priority\": \"high\",\n      \"question\": \"Who were the parents of Patrick Flynn (b. ~1845, PA, d. 1908)?\",\n      \"rationale\": \"This is the primary research objective.\",\n      \"resolution_assertion_ids\": [],\n      \"resolved\": null,\n      \"selection_basis\": \"objective_decomposition\",\n      \"status\": \"in_progress\",\n      \"unblocks\": []\n    },\n    {\n      \"created\": \"2026-05-01\",\n      \"depends_on\": [],\n      \"exhaustive_declaration\": {\n        \"declared\": true,\n        \"justification\": \"Searched 1850 census for Schuylkill County on FamilySearch (indexed and browse), Ancestry (indexed), and MyHeritage (indexed). All three returned the same household. No other Patrick Flynn of matching age found in the county.\",\n        \"log_entry_ids\": [\n          \"log_001\",\n          \"log_002\",\n          \"log_003\"\n        ],\n        \"stop_criteria\": {\n          \"conflict_resolution\": \"No conflicts on the 1850 census placement question.\",\n          \"evidence_class\": \"Yes \u2014 FamilySearch provides original census image with indeterminate-quality information.\",\n          \"goal_alignment\": \"Yes \u2014 Patrick Flynn located in a specific 1850 household, answering the question.\",\n          \"independent_verification\": \"FamilySearch (original) and Ancestry (derivative) both return the same household. Two access paths, one underlying original.\",\n          \"original_substitution\": \"FamilySearch provides the original census image; Ancestry index is derivative but confirmed consistent.\",\n          \"overturn_risk\": \"Low \u2014 all three repositories agree, and no competing Patrick Flynn of matching age exists in the county.\",\n          \"repository_breadth\": \"Three major repositories searched (FamilySearch, Ancestry, MyHeritage). No additional known indexes of the 1850 Schuylkill County census exist.\"\n        }\n      },\n      \"id\": \"q_002\",\n      \"priority\": \"high\",\n      \"question\": \"Where was Patrick Flynn in the 1850 census?\",\n      \"rationale\": \"The 1850 census is the earliest enumeration where Patrick would appear by name (age ~5). Locating him in a household identifies candidate parents.\",\n      \"resolution_assertion_ids\": [\n        \"a_001\",\n        \"a_002\",\n        \"a_003\"\n      ],\n      \"resolved\": \"2026-05-02\",\n      \"selection_basis\": \"objective_decomposition\",\n      \"status\": \"resolved\",\n      \"unblocks\": [\n        \"q_001\"\n      ]\n    }\n  ],\n  \"sources\": [\n    {\n      \"access_date\": \"2026-05-01\",\n      \"citation\": \"1850 U.S. Census, Schuylkill County, Pennsylvania, population schedule, dwelling 84, family 91, Thomas Flynn household; NARA microfilm publication M432, roll 810; digital image, FamilySearch.org, accessed 1 May 2026.\",\n      \"citation_detail\": {\n        \"what\": \"1850 U.S. Federal Census, population schedule\",\n        \"when_accessed\": \"2026-05-01\",\n        \"when_created\": \"1850\",\n        \"where\": \"FamilySearch.org (NARA microfilm M432, roll 810)\",\n        \"where_within\": \"Schuylkill County, dwelling 84, family 91\",\n        \"who\": \"U.S. Census Bureau\"\n      },\n      \"gedcomx_source_description_id\": \"S1\",\n      \"id\": \"src_001\",\n      \"log_entry_id\": \"log_001\",\n      \"notes\": \"Image quality good. Enumerator handwriting clear.\",\n      \"repository\": \"FamilySearch\",\n      \"source_classification\": \"original\",\n      \"url\": \"https://www.familysearch.org/ark:/61903/1:1:MXYZ\",\n      \"url_archived\": null\n    },\n    {\n      \"access_date\": \"2026-05-01\",\n      \"citation\": \"1850 U.S. Census, Schuylkill County, Pennsylvania, population schedule, dwelling 84, Thomas Flynn household; digital image, Ancestry.com, accessed 1 May 2026.\",\n      \"citation_detail\": {\n        \"what\": \"1850 U.S. Federal Census, population schedule (Ancestry index)\",\n        \"when_accessed\": \"2026-05-01\",\n        \"when_created\": \"1850\",\n        \"where\": \"Ancestry.com\",\n        \"where_within\": \"Schuylkill County, dwelling 84\",\n        \"who\": \"U.S. Census Bureau\"\n      },\n      \"gedcomx_source_description_id\": \"S1\",\n      \"id\": \"src_002\",\n      \"log_entry_id\": \"log_002\",\n      \"notes\": \"Ancestry's index of the same original census. Transcription consistent with FamilySearch.\",\n      \"repository\": \"Ancestry\",\n      \"source_classification\": \"derivative\",\n      \"url\": null,\n      \"url_archived\": null\n    },\n    {\n      \"access_date\": \"2026-05-02\",\n      \"citation\": \"1860 U.S. Census, Schuylkill County, Pennsylvania, population schedule, dwelling 112, family 119, Thomas Flynn household; NARA microfilm publication M653, roll 1141; digital image, FamilySearch.org, accessed 2 May 2026.\",\n      \"citation_detail\": {\n        \"what\": \"1860 U.S. Federal Census, population schedule\",\n        \"when_accessed\": \"2026-05-02\",\n        \"when_created\": \"1860\",\n        \"where\": \"FamilySearch.org (NARA microfilm M653, roll 1141)\",\n        \"where_within\": \"Schuylkill County, dwelling 112, family 119\",\n        \"who\": \"U.S. Census Bureau\"\n      },\n      \"gedcomx_source_description_id\": \"S2\",\n      \"id\": \"src_003\",\n      \"log_entry_id\": \"log_004\",\n      \"notes\": null,\n      \"repository\": \"FamilySearch\",\n      \"source_classification\": \"original\",\n      \"url\": \"https://www.familysearch.org/ark:/61903/1:1:MABC\",\n      \"url_archived\": null\n    },\n    {\n      \"access_date\": \"2026-05-03\",\n      \"citation\": \"Pennsylvania Department of Health, death certificate no. 4521 (1908), Patrick Flynn; Pennsylvania State Archives, Harrisburg; digital image, FamilySearch.org, accessed 3 May 2026.\",\n      \"citation_detail\": {\n        \"what\": \"Death certificate no. 4521\",\n        \"when_accessed\": \"2026-05-03\",\n        \"when_created\": \"1908-03-14\",\n        \"where\": \"FamilySearch.org (Pennsylvania State Archives, Harrisburg)\",\n        \"where_within\": \"Certificate no. 4521\",\n        \"who\": \"Pennsylvania Department of Health; informant: James Brown (son-in-law)\"\n      },\n      \"gedcomx_source_description_id\": \"S3\",\n      \"id\": \"src_004\",\n      \"log_entry_id\": \"log_005\",\n      \"notes\": \"Informant is son-in-law James Brown. Primary for death facts, secondary for birth facts.\",\n      \"repository\": \"FamilySearch\",\n      \"source_classification\": \"original\",\n      \"url\": \"https://www.familysearch.org/ark:/61903/1:1:MDEF\",\n      \"url_archived\": null\n    }\n  ],\n  \"timelines\": [\n    {\n      \"events\": [\n        {\n          \"assertion_ids\": [\n            \"a_002\",\n            \"a_009\"\n          ],\n          \"date\": \"~1845\",\n          \"date_certainty\": \"estimated\",\n          \"description\": \"Born in Ireland, estimated from census ages\",\n          \"event_type\": \"birth\",\n          \"place\": \"Ireland\"\n        },\n        {\n          \"assertion_ids\": [\n            \"a_003\",\n            \"a_004\"\n          ],\n          \"date\": \"1850\",\n          \"date_certainty\": \"exact\",\n          \"description\": \"Enumerated age 5 in Thomas Flynn household, dwelling 84\",\n          \"event_type\": \"census\",\n          \"place\": \"Schuylkill County, Pennsylvania\"\n        },\n        {\n          \"assertion_ids\": [\n            \"a_008\",\n            \"a_009\",\n            \"a_010\"\n          ],\n          \"date\": \"1860\",\n          \"date_certainty\": \"exact\",\n          \"description\": \"Enumerated age 15 in Thomas Flynn household, dwelling 112\",\n          \"event_type\": \"census\",\n          \"place\": \"Schuylkill County, Pennsylvania\"\n        },\n        {\n          \"assertion_ids\": [\n            \"a_011\",\n            \"a_013\"\n          ],\n          \"date\": \"1908-03-12\",\n          \"date_certainty\": \"exact\",\n          \"description\": \"Died, death certificate names Thomas Flynn as father\",\n          \"event_type\": \"death\",\n          \"place\": \"Schuylkill County, Pennsylvania\"\n        }\n      ],\n      \"gaps\": [\n        {\n          \"end\": \"1908-03-12\",\n          \"expected_events\": [\n            \"marriage\",\n            \"1870_census\",\n            \"1880_census\",\n            \"1900_census\",\n            \"residence\",\n            \"occupation\"\n          ],\n          \"severity\": \"high\",\n          \"start\": \"1860-01-01\"\n        }\n      ],\n      \"generated\": \"2026-05-03T12:00:00Z\",\n      \"hypothesis_id\": \"h_001\",\n      \"id\": \"t_001\",\n      \"impossibilities\": [],\n      \"label\": \"Patrick Flynn \u2014 assuming Thomas Flynn parentage\",\n      \"person_ids\": [\n        \"I1\"\n      ]\n    }\n  ]\n}\n",
+    "eval/fixtures/scenarios/flynn-posthumous-residence/tree.gedcomx.json": "{\n  \"persons\": [\n    {\n      \"facts\": [\n        {\n          \"date\": \"~1845\",\n          \"id\": \"F1\",\n          \"place\": \"Ireland\",\n          \"primary\": true,\n          \"sources\": [\n            {\n              \"page\": \"1850 Census, Schuylkill Co., dwelling 84\",\n              \"ref\": \"S1\"\n            }\n          ],\n          \"type\": \"Birth\"\n        },\n        {\n          \"date\": \"1908-03-12\",\n          \"id\": \"F2\",\n          \"place\": \"Schuylkill County, Pennsylvania\",\n          \"sources\": [\n            {\n              \"page\": \"Death cert. no. 4521\",\n              \"ref\": \"S3\"\n            }\n          ],\n          \"type\": \"Death\"\n        },\n        {\n          \"date\": \"1925\",\n          \"id\": \"F3\",\n          \"place\": \"Pottsville, Schuylkill County, Pennsylvania\",\n          \"sources\": [\n            {\n              \"page\": \"Obituary of Mary (Flynn) Brennan, naming her late father Patrick Flynn; auto-attached to Patrick as a Residence\",\n              \"ref\": \"S5\"\n            }\n          ],\n          \"type\": \"Residence\"\n        }\n      ],\n      \"gender\": \"Male\",\n      \"id\": \"I1\",\n      \"names\": [\n        {\n          \"given\": \"Patrick\",\n          \"id\": \"N1\",\n          \"preferred\": true,\n          \"surname\": \"Flynn\",\n          \"type\": \"BirthName\"\n        }\n      ]\n    },\n    {\n      \"facts\": [\n        {\n          \"date\": \"~1818\",\n          \"id\": \"F3\",\n          \"place\": \"Ireland\",\n          \"primary\": true,\n          \"type\": \"Birth\"\n        }\n      ],\n      \"gender\": \"Male\",\n      \"id\": \"I2\",\n      \"names\": [\n        {\n          \"given\": \"Thomas\",\n          \"id\": \"N2\",\n          \"preferred\": true,\n          \"surname\": \"Flynn\",\n          \"type\": \"BirthName\"\n        }\n      ]\n    }\n  ],\n  \"relationships\": [\n    {\n      \"child\": \"I1\",\n      \"id\": \"R1\",\n      \"parent\": \"I2\",\n      \"sources\": [\n        {\n          \"page\": \"1850 Census, Schuylkill Co., dwelling 84\",\n          \"quality\": 2,\n          \"ref\": \"S1\"\n        },\n        {\n          \"page\": \"1860 Census, Schuylkill Co., dwelling 112\",\n          \"quality\": 2,\n          \"ref\": \"S2\"\n        },\n        {\n          \"page\": \"Death cert. no. 4521\",\n          \"quality\": 2,\n          \"ref\": \"S3\"\n        }\n      ],\n      \"type\": \"ParentChild\"\n    }\n  ],\n  \"sources\": [\n    {\n      \"author\": \"U.S. Census Bureau\",\n      \"id\": \"S1\",\n      \"title\": \"1850 U.S. Federal Census\"\n    },\n    {\n      \"author\": \"U.S. Census Bureau\",\n      \"id\": \"S2\",\n      \"title\": \"1860 U.S. Federal Census\"\n    },\n    {\n      \"author\": \"Pennsylvania Dept. of Health\",\n      \"id\": \"S3\",\n      \"title\": \"Pennsylvania Death Certificates\"\n    },\n    {\n      \"author\": \"Schuylkill County Register of Wills\",\n      \"id\": \"S4\",\n      \"title\": \"Schuylkill County Probate Records\"\n    },\n    {\n      \"id\": \"S5\",\n      \"title\": \"Pottsville Republican, obituary of Mary (Flynn) Brennan, 1925\"\n    }\n  ]\n}\n",
+    "eval/fixtures/scenarios/flynn-resolved/README.md": "# flynn-resolved\n\nPatrick Flynn parentage research, fully concluded. All planned searches completed; the parentage conclusion has reached `proved`.\n\nDiffers from `mid-research-flynn` in these ways:\n\n- **`project.status`:** `completed` (was `active`).\n- **`questions[q_001]`:** `status: \"resolved\"`, `resolved: \"2026-05-04\"`, `resolution_assertion_ids` populated, `exhaustive_declaration.declared: true` with full `stop_criteria` populated.\n- **`plans[pl_002]`:** `status: \"completed\"` (was `active`).\n- **`plans[pl_002].items[pli_006]`** (probate search): `status: \"completed\"` (was `in_progress`).\n- **`log`:** adds `log_006` \u2014 probate search with negative outcome (no Thomas Flynn probate record in Schuylkill County 1870-1890).\n- **`proof_summaries[ps_001].tier`:** `proved` (was `probable`).\n- **`conflicts[c_001]`:** remains resolved \u2014 same as `mid-research-flynn`.\n- **Everything else:** unchanged.\n\n## Used by\n\n- `project-status` tests where the skill must report on a completed project.\n- `proof-conclusion` tests for a project at `proved` tier (the highest-confidence outcome).\n- `question-selection` tests where all active questions are resolved \u2014 the skill should either propose a follow-on question (e.g., siblings, maternal line) or report \"no open questions.\"\n- Boundary tests verifying that skills meant for active research don't volunteer work on completed projects.\n\n## Note on the probate negative result\n\nThe negative probate (`log_006`) doesn't contradict the parentage conclusion. It does affect what \"reasonably exhaustive\" looks like: with no estate proceedings to consult, the conclusion rests on three other independent sources. The `exhaustive_declaration.stop_criteria` reflects this explicitly.\n",
+    "eval/fixtures/scenarios/flynn-resolved/research.json": "{\n  \"assertions\": [\n    {\n      \"date\": null,\n      \"date_certainty\": null,\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_002\"\n      ],\n      \"fact_type\": \"name\",\n      \"id\": \"a_001\",\n      \"informant\": \"Unknown informant (most likely a household member, possibly a neighbor) reporting to census enumerator\",\n      \"informant_bias_notes\": \"Census enumerator is the recorder, not the informant. The person who provided the name is unknown \u2014 most likely a household member, possibly a neighbor. Proximity is 'unknown' rather than 'household_member' because for names specifically, the enumerator may have heard the name from a neighbor or made an assumption \u2014 the name fact doesn't necessarily require active reporting the way age/birthplace does.\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_001\",\n      \"place\": null,\n      \"record_id\": \"ark:/61903/1:1:MXYZ\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_001\",\n      \"structured_value\": {\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"value\": \"Patrick Flynn\"\n    },\n    {\n      \"date\": \"~1845\",\n      \"date_certainty\": \"estimated\",\n      \"evidence_type\": \"indirect\",\n      \"extracted_for_question_ids\": [\n        \"q_002\"\n      ],\n      \"fact_type\": \"birth\",\n      \"id\": \"a_002\",\n      \"informant\": \"Unknown \u2014 most likely a household member (such as Thomas Flynn or his wife), but possibly a neighbor\",\n      \"informant_bias_notes\": \"Age and birthplace require active reporting by an informant \u2014 someone had to tell the enumerator these facts. That informant was most likely a household member, but enumerators also took information from neighbors when residents were unavailable, and the census does not identify who answered. Proximity is 'unknown' because the informant cannot be established from the record.\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_001\",\n      \"place\": \"Ireland\",\n      \"record_id\": \"ark:/61903/1:1:MXYZ\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_001\",\n      \"structured_value\": {\n        \"place\": \"Ireland\",\n        \"year\": 1845\n      },\n      \"value\": \"age 5\"\n    },\n    {\n      \"date\": \"1850\",\n      \"date_certainty\": \"exact\",\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_002\"\n      ],\n      \"fact_type\": \"residence\",\n      \"id\": \"a_003\",\n      \"informant\": \"Census enumerator (witness to residence by visiting the dwelling)\",\n      \"informant_bias_notes\": \"For residence facts specifically, the enumerator is a direct witness \u2014 they physically visited the dwelling and recorded who lived there. This distinguishes residence from other census facts where an unidentified informant (most likely a household member, possibly a neighbor) supplied the information.\",\n      \"informant_proximity\": \"witness\",\n      \"information_quality\": \"primary\",\n      \"log_entry_id\": \"log_001\",\n      \"place\": \"Schuylkill County, Pennsylvania\",\n      \"record_id\": \"ark:/61903/1:1:MXYZ\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_001\",\n      \"value\": \"Schuylkill County, Pennsylvania\"\n    },\n    {\n      \"date\": \"1850\",\n      \"date_certainty\": \"exact\",\n      \"evidence_type\": \"indirect\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"relationship\",\n      \"id\": \"a_004\",\n      \"informant\": \"Inferred from household structure \u2014 no explicit informant for relationships in 1850 census\",\n      \"informant_bias_notes\": \"1850 census does not state relationships; this assertion is inferred from household position and shared surname, not directly reported by any informant. The relationship is indirect evidence constructed by the researcher, not information provided by a census informant.\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_001\",\n      \"place\": \"Schuylkill County, Pennsylvania\",\n      \"record_id\": \"ark:/61903/1:1:MXYZ\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_001\",\n      \"structured_value\": {\n        \"related_person_role\": \"head_of_household\",\n        \"relationship_type\": \"child_inferred\"\n      },\n      \"value\": \"Listed in household of Thomas Flynn (head), position consistent with child\"\n    },\n    {\n      \"date\": null,\n      \"date_certainty\": null,\n      \"evidence_type\": \"indirect\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"name\",\n      \"id\": \"a_005\",\n      \"informant\": \"Unknown informant (likely Thomas Flynn himself) reporting to census enumerator\",\n      \"informant_bias_notes\": \"Census enumerator is the recorder, not the informant. As head of household, Thomas likely provided his own name, but the 1850 census does not identify the informant.\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_001\",\n      \"place\": null,\n      \"record_id\": \"ark:/61903/1:1:MXYZ\",\n      \"record_role\": \"head_of_household\",\n      \"source_id\": \"src_001\",\n      \"value\": \"Thomas Flynn\"\n    },\n    {\n      \"date\": null,\n      \"date_certainty\": null,\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_002\"\n      ],\n      \"fact_type\": \"name\",\n      \"id\": \"a_006\",\n      \"informant\": \"Ancestry transcriber (derivative of census enumerator)\",\n      \"informant_bias_notes\": \"Derivative index \u2014 transcription errors possible\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_002\",\n      \"place\": null,\n      \"record_id\": \"ancestry:8054:patrick-flynn-1850\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_002\",\n      \"value\": \"Patrick Flynn\"\n    },\n    {\n      \"date\": \"~1845\",\n      \"date_certainty\": \"estimated\",\n      \"evidence_type\": \"indirect\",\n      \"extracted_for_question_ids\": [\n        \"q_002\"\n      ],\n      \"fact_type\": \"birth\",\n      \"id\": \"a_007\",\n      \"informant\": \"Ancestry transcriber (derivative)\",\n      \"informant_bias_notes\": null,\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_002\",\n      \"place\": \"Ireland\",\n      \"record_id\": \"ancestry:8054:patrick-flynn-1850\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_002\",\n      \"value\": \"age 5\"\n    },\n    {\n      \"date\": null,\n      \"date_certainty\": null,\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"name\",\n      \"id\": \"a_008\",\n      \"informant\": \"Unknown informant (most likely a household member, possibly a neighbor) reporting to census enumerator\",\n      \"informant_bias_notes\": \"Census enumerator is the recorder, not the informant. Proximity is 'unknown' for names (same reasoning as a_001 \u2014 name facts don't necessarily require active reporting).\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_004\",\n      \"place\": null,\n      \"record_id\": \"ark:/61903/1:1:MABC\",\n      \"record_role\": \"child_2\",\n      \"source_id\": \"src_003\",\n      \"value\": \"Patrick Flynn\"\n    },\n    {\n      \"date\": \"~1845\",\n      \"date_certainty\": \"estimated\",\n      \"evidence_type\": \"indirect\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"birth\",\n      \"id\": \"a_009\",\n      \"informant\": \"Unknown \u2014 most likely a household member (such as Thomas Flynn or his wife), but possibly a neighbor\",\n      \"informant_bias_notes\": \"Age and birthplace require active reporting by an informant \u2014 most likely a household member, possibly a neighbor (same reasoning as a_002).\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_004\",\n      \"place\": \"Ireland\",\n      \"record_id\": \"ark:/61903/1:1:MABC\",\n      \"record_role\": \"child_2\",\n      \"source_id\": \"src_003\",\n      \"value\": \"age 15\"\n    },\n    {\n      \"date\": \"1860\",\n      \"date_certainty\": \"exact\",\n      \"evidence_type\": \"indirect\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"relationship\",\n      \"id\": \"a_010\",\n      \"informant\": \"Inferred from household structure \u2014 no explicit informant for relationships in 1860 census\",\n      \"informant_bias_notes\": \"1860 census does not state relationships; like the 1850 census, this assertion is inferred from household position, age, and shared surname. The relationship column was not introduced until the 1880 census.\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_004\",\n      \"place\": \"Schuylkill County, Pennsylvania\",\n      \"record_id\": \"ark:/61903/1:1:MABC\",\n      \"record_role\": \"child_2\",\n      \"source_id\": \"src_003\",\n      \"structured_value\": {\n        \"related_person_role\": \"head_of_household\",\n        \"relationship_type\": \"child_inferred\"\n      },\n      \"value\": \"Listed in household of Thomas Flynn (head), position and age consistent with son\"\n    },\n    {\n      \"date\": \"1908-03-12\",\n      \"date_certainty\": \"exact\",\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [],\n      \"fact_type\": \"death\",\n      \"id\": \"a_011\",\n      \"informant\": \"Attending physician (signature on certificate)\",\n      \"informant_bias_notes\": null,\n      \"informant_proximity\": \"witness\",\n      \"information_quality\": \"primary\",\n      \"log_entry_id\": \"log_005\",\n      \"place\": \"Schuylkill County, Pennsylvania\",\n      \"record_id\": \"ark:/61903/1:1:MDEF\",\n      \"record_role\": \"deceased\",\n      \"source_id\": \"src_004\",\n      \"value\": \"Died 12 March 1908\"\n    },\n    {\n      \"date\": \"1845\",\n      \"date_certainty\": \"approximate\",\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"birth\",\n      \"id\": \"a_012\",\n      \"informant\": \"James Brown (son-in-law)\",\n      \"informant_bias_notes\": \"Son-in-law reporting birth facts decades after the event. Note: death cert says Pennsylvania, but census records say Ireland. Son-in-law may not have known Patrick was born in Ireland.\",\n      \"informant_proximity\": \"family_not_present\",\n      \"information_quality\": \"secondary\",\n      \"log_entry_id\": \"log_005\",\n      \"place\": \"Pennsylvania\",\n      \"record_id\": \"ark:/61903/1:1:MDEF\",\n      \"record_role\": \"deceased\",\n      \"source_id\": \"src_004\",\n      \"structured_value\": {\n        \"place\": \"Pennsylvania\",\n        \"year\": 1845\n      },\n      \"value\": \"Born 1845, Pennsylvania\"\n    },\n    {\n      \"date\": null,\n      \"date_certainty\": null,\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"relationship\",\n      \"id\": \"a_013\",\n      \"informant\": \"James Brown (son-in-law)\",\n      \"informant_bias_notes\": \"Secondary information \u2014 son-in-law reporting what he was told about father-in-law's parentage\",\n      \"informant_proximity\": \"family_not_present\",\n      \"information_quality\": \"secondary\",\n      \"log_entry_id\": \"log_005\",\n      \"place\": null,\n      \"record_id\": \"ark:/61903/1:1:MDEF\",\n      \"record_role\": \"deceased\",\n      \"source_id\": \"src_004\",\n      \"structured_value\": {\n        \"related_person_role\": \"deceased\",\n        \"relationship_type\": \"father\"\n      },\n      \"value\": \"Father: Thomas Flynn\"\n    }\n  ],\n  \"conflicts\": [\n    {\n      \"blocks_question_ids\": [],\n      \"competing_assertion_ids\": [\n        \"a_002\",\n        \"a_009\",\n        \"a_012\"\n      ],\n      \"conflict_type\": \"fact\",\n      \"description\": \"Patrick Flynn's birthplace: Ireland (1850 and 1860 censuses) vs. Pennsylvania (1908 death certificate)\",\n      \"disputed_attribute\": \"birthplace\",\n      \"id\": \"c_001\",\n      \"identity_question\": null,\n      \"independence_analysis\": \"The two census records (1850, 1860) are independent original sources with different enumerators. The death certificate is a third independent original source. However, the census informants are likely the same household member (Thomas Flynn or wife), so the two census assertions may share a single informant \u2014 potentially not fully independent for this fact.\",\n      \"preferred_assertion_id\": \"a_002\",\n      \"resolution_rationale\": \"Ireland is accepted as the birthplace. The 1908 death certificate birthplace of 'Pennsylvania' is rejected as a likely error by the son-in-law informant, who may have confused Patrick's place of residence with his place of birth, or may not have known Patrick was born in Ireland before immigrating as a young child.\",\n      \"status\": \"resolved\",\n      \"weighing_analysis\": \"The census records are contemporary recordings made near the time of Patrick's birth, while the death certificate was created 63 years later. The census informant was likely a household member with firsthand knowledge (primary or indeterminate), while the death certificate informant (son-in-law) is clearly secondary for birth facts. Two contemporary sources outweigh one later recollection by a secondary informant.\"\n    }\n  ],\n  \"evaluations\": [],\n  \"hypotheses\": [\n    {\n      \"claim\": \"Patrick Flynn's father was Thomas Flynn of Schuylkill County, Pennsylvania\",\n      \"contradicting_assertion_ids\": [],\n      \"id\": \"h_001\",\n      \"notes\": \"Three independent pieces of evidence: 1850 census co-enumeration (indirect), 1860 census co-enumeration (indirect \u2014 relationship inferred from household position), death certificate naming Thomas as father (direct, secondary informant). Awaiting probate records for additional confirmation.\",\n      \"related_question_ids\": [\n        \"q_001\"\n      ],\n      \"ruled_out\": false,\n      \"ruled_out_reason\": null,\n      \"status\": \"supported\",\n      \"supporting_assertion_ids\": [\n        \"a_004\",\n        \"a_010\",\n        \"a_013\"\n      ]\n    }\n  ],\n  \"log\": [\n    {\n      \"external_site\": null,\n      \"id\": \"log_001\",\n      \"notes\": \"Found Patrick Flynn age 5 in household of Thomas Flynn, dwelling 84, Schuylkill Co. Three other Flynn results examined \u2014 ages and locations don't match.\",\n      \"outcome\": \"positive\",\n      \"performed\": \"2026-05-01T10:15:00Z\",\n      \"plan_item_id\": \"pli_001\",\n      \"query\": {\n        \"birth_place\": \"Pennsylvania\",\n        \"birth_year\": 1845,\n        \"collection\": \"1850 Census\",\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"results_examined\": 8,\n      \"tool\": \"record_search\"\n    },\n    {\n      \"external_site\": {\n        \"capture_filename\": \"ancestry-1850-flynn-results.pdf\",\n        \"capture_received\": true,\n        \"site\": \"ancestry\",\n        \"url_generated\": \"https://www.ancestry.com/search/collections/8054/?name=Patrick_Flynn&birth=1845&birthplace=Pennsylvania\"\n      },\n      \"id\": \"log_002\",\n      \"notes\": \"Ancestry index confirms same household. Transcription matches FamilySearch except Ancestry reads dwelling as 84, FamilySearch as 84 \u2014 consistent.\",\n      \"outcome\": \"positive\",\n      \"performed\": \"2026-05-01T11:30:00Z\",\n      \"plan_item_id\": \"pli_002\",\n      \"query\": {\n        \"birth_place\": \"Pennsylvania\",\n        \"birth_year\": 1845,\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"results_examined\": 12,\n      \"tool\": \"external_site\"\n    },\n    {\n      \"external_site\": {\n        \"capture_filename\": \"myheritage-1850-flynn-nil.pdf\",\n        \"capture_received\": true,\n        \"site\": \"myheritage\",\n        \"url_generated\": \"https://www.myheritage.com/research?action=query&first=Patrick&last=Flynn&birth_year=1845&birth_place=Pennsylvania\"\n      },\n      \"id\": \"log_003\",\n      \"notes\": \"MyHeritage returned no results for Patrick Flynn in 1850 Schuylkill County. Site may not have this collection indexed. Searched broader Pennsylvania \u2014 still no match.\",\n      \"outcome\": \"negative\",\n      \"performed\": \"2026-05-01T14:00:00Z\",\n      \"plan_item_id\": \"pli_003\",\n      \"query\": {\n        \"birth_place\": \"Pennsylvania\",\n        \"birth_year\": 1845,\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"results_examined\": 0,\n      \"tool\": \"external_site\"\n    },\n    {\n      \"external_site\": null,\n      \"id\": \"log_004\",\n      \"notes\": \"Patrick Flynn age 15 in household of Thomas Flynn, Schuylkill Co. Consistent with 1850 placement.\",\n      \"outcome\": \"positive\",\n      \"performed\": \"2026-05-02T09:00:00Z\",\n      \"plan_item_id\": \"pli_004\",\n      \"query\": {\n        \"birth_place\": \"Pennsylvania\",\n        \"birth_year\": 1845,\n        \"collection\": \"1860 Census\",\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"results_examined\": 5,\n      \"tool\": \"record_search\"\n    },\n    {\n      \"external_site\": null,\n      \"id\": \"log_005\",\n      \"notes\": \"Death certificate found. Names Thomas Flynn as father. Informant was son-in-law James Brown.\",\n      \"outcome\": \"positive\",\n      \"performed\": \"2026-05-03T10:00:00Z\",\n      \"plan_item_id\": \"pli_005\",\n      \"query\": {\n        \"death_place\": \"Schuylkill County, Pennsylvania\",\n        \"death_year\": 1908,\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"results_examined\": 2,\n      \"tool\": \"record_search\"\n    },\n    {\n      \"external_site\": null,\n      \"id\": \"log_006\",\n      \"notes\": \"No probate record found for Thomas Flynn in Schuylkill County 1870-1890. Searched FamilySearch probate index and browsed available registers. Negative result is itself meaningful: either Thomas died intestate without estate proceedings, died elsewhere, or his name does not match \u2014 but the absence does not contradict the parentage conclusion.\",\n      \"outcome\": \"negative\",\n      \"performed\": \"2026-05-04T09:00:00Z\",\n      \"plan_item_id\": \"pli_006\",\n      \"query\": {\n        \"collection\": \"Probate Records\",\n        \"date_range\": \"1870-1890\",\n        \"given\": \"Thomas\",\n        \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n        \"surname\": \"Flynn\"\n      },\n      \"results_examined\": 0,\n      \"tool\": \"record_search\"\n    }\n  ],\n  \"person_evidence\": [\n    {\n      \"assertion_id\": \"a_001\",\n      \"confidence\": \"confident\",\n      \"created\": \"2026-05-01\",\n      \"id\": \"pe_001\",\n      \"match_score\": null,\n      \"person_id\": \"I1\",\n      \"rationale\": \"Name matches (Patrick Flynn), age consistent with ~1845 birth, located in Schuylkill County where subject is known to have lived. Only Patrick Flynn of this age in the county in 1850.\",\n      \"superseded_by\": null\n    },\n    {\n      \"assertion_id\": \"a_004\",\n      \"confidence\": \"probable\",\n      \"created\": \"2026-05-01\",\n      \"id\": \"pe_002\",\n      \"match_score\": null,\n      \"person_id\": \"I1\",\n      \"rationale\": \"Same record as pe_001, same person. Household position and shared surname with head Thomas Flynn suggest parent-child relationship, but 1850 census does not state relationships explicitly.\",\n      \"superseded_by\": null\n    },\n    {\n      \"assertion_id\": \"a_004\",\n      \"confidence\": \"probable\",\n      \"created\": \"2026-05-01\",\n      \"id\": \"pe_006\",\n      \"match_score\": null,\n      \"person_id\": \"I2\",\n      \"rationale\": \"Same assertion as pe_002 but linked to Thomas Flynn (I2). The relationship assertion ('position consistent with child') equally bears on the head of household. Thomas Flynn is the other party in the implied parent-child relationship.\",\n      \"superseded_by\": null\n    },\n    {\n      \"assertion_id\": \"a_005\",\n      \"confidence\": \"probable\",\n      \"created\": \"2026-05-01\",\n      \"id\": \"pe_003\",\n      \"match_score\": 0.82,\n      \"person_id\": \"I2\",\n      \"rationale\": \"Thomas Flynn, head of household where Patrick was found. Age (~32 in 1850, born ~1818) is consistent with being Patrick's father. Name matches candidate father.\",\n      \"superseded_by\": null\n    },\n    {\n      \"assertion_id\": \"a_010\",\n      \"confidence\": \"confident\",\n      \"created\": \"2026-05-02\",\n      \"id\": \"pe_004\",\n      \"match_score\": null,\n      \"person_id\": \"I1\",\n      \"rationale\": \"Patrick Flynn age 15 in Thomas Flynn household, 1860 census. Same county, age consistent with 1850 enumeration. Relationship inferred from household position and shared surname (1860 census does not state relationships explicitly).\",\n      \"superseded_by\": null\n    },\n    {\n      \"assertion_id\": \"a_013\",\n      \"confidence\": \"confident\",\n      \"created\": \"2026-05-03\",\n      \"id\": \"pe_005\",\n      \"match_score\": null,\n      \"person_id\": \"I1\",\n      \"rationale\": \"Death certificate for Patrick Flynn, d. 1908, Schuylkill County. Names match, death location matches known residence. Names Thomas Flynn as father.\",\n      \"superseded_by\": null\n    }\n  ],\n  \"plans\": [\n    {\n      \"created\": \"2026-05-01\",\n      \"id\": \"pl_001\",\n      \"items\": [\n        {\n          \"date_range\": \"1850\",\n          \"fallback_for\": null,\n          \"id\": \"pli_001\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"1850 census fully indexed on FamilySearch. Free access, start here.\",\n          \"record_type\": \"census\",\n          \"repository\": \"FamilySearch\",\n          \"sequence\": 1,\n          \"status\": \"completed\"\n        },\n        {\n          \"date_range\": \"1850\",\n          \"fallback_for\": null,\n          \"id\": \"pli_002\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"Ancestry has independent indexing; cross-check for transcription errors.\",\n          \"record_type\": \"census\",\n          \"repository\": \"Ancestry\",\n          \"sequence\": 2,\n          \"status\": \"completed\"\n        },\n        {\n          \"date_range\": \"1850\",\n          \"fallback_for\": null,\n          \"id\": \"pli_003\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"Third independent index for coverage confirmation.\",\n          \"record_type\": \"census\",\n          \"repository\": \"MyHeritage\",\n          \"sequence\": 3,\n          \"status\": \"completed\"\n        }\n      ],\n      \"question_id\": \"q_002\",\n      \"status\": \"completed\"\n    },\n    {\n      \"created\": \"2026-05-02\",\n      \"id\": \"pl_002\",\n      \"items\": [\n        {\n          \"date_range\": \"1860\",\n          \"fallback_for\": null,\n          \"id\": \"pli_004\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"Confirm Patrick still in Thomas Flynn household in 1860. Strengthens parent-child identification.\",\n          \"record_type\": \"census\",\n          \"repository\": \"FamilySearch\",\n          \"sequence\": 1,\n          \"status\": \"completed\"\n        },\n        {\n          \"date_range\": \"1908\",\n          \"fallback_for\": null,\n          \"id\": \"pli_005\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"Death certificate may name parents directly.\",\n          \"record_type\": \"vital_record\",\n          \"repository\": \"FamilySearch\",\n          \"sequence\": 2,\n          \"status\": \"completed\"\n        },\n        {\n          \"date_range\": \"1870-1890\",\n          \"fallback_for\": null,\n          \"id\": \"pli_006\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"Thomas Flynn probate/will may name Patrick as son.\",\n          \"record_type\": \"probate\",\n          \"repository\": \"FamilySearch\",\n          \"sequence\": 3,\n          \"status\": \"completed\"\n        }\n      ],\n      \"question_id\": \"q_001\",\n      \"status\": \"completed\"\n    }\n  ],\n  \"project\": {\n    \"created\": \"2026-05-01\",\n    \"id\": \"rp_001\",\n    \"objective\": \"Identify the parents of Patrick Flynn, born ca. 1845 in Pennsylvania, died 1908 in Schuylkill County, PA\",\n    \"status\": \"completed\",\n    \"subject_person_ids\": [\n      \"I1\"\n    ],\n    \"updated\": \"2026-05-04\"\n  },\n  \"proof_summaries\": [\n    {\n      \"exhaustive_search_summary\": \"Searched 1850 census (FamilySearch, Ancestry, MyHeritage \u2014 log_001, log_002, log_003), 1860 census (FamilySearch \u2014 log_004), death certificate (FamilySearch \u2014 log_005), and Thomas Flynn probate records 1870-1890 (FamilySearch \u2014 log_006, negative result). The 1870, 1880, and 1900 censuses were not searched: three independent sources (1850 + 1860 census + 1908 death certificate) already converge on the same conclusion, and the negative probate search does not contradict it. Per exhaustive_declaration.overturn_risk: Low \u2014 additional positive census records would corroborate but not overturn.\",\n      \"id\": \"ps_001\",\n      \"narrative_markdown\": \"## Parentage of Patrick Flynn (ca. 1845\u20131908)\\n\\nPatrick Flynn is the son of Thomas Flynn of Schuylkill County, Pennsylvania.\\n\\n### Evidence Summary\\n\\nThree independent lines of evidence support this conclusion:\\n\\n1. **1850 U.S. Census** (Original Source). Patrick Flynn, age 5, born Ireland, appears in the household of Thomas Flynn, age 32, born Ireland, in Schuylkill County, Pennsylvania (dwelling 84, family 91). The 1850 census does not state relationships, but Patrick's position in the household and shared surname are consistent with a parent-child relationship. The informant is indeterminate but likely a household member. This constitutes indirect evidence of parentage.\\n\\n2. **1860 U.S. Census** (Original Source). Patrick Flynn, age 15, born Ireland, appears in the household of Thomas Flynn in Schuylkill County (dwelling 112, family 119). Like the 1850 census, the 1860 census does not state relationships explicitly (the relationship column was not introduced until 1880). Patrick's position in the household, shared surname, and age consistent with the 1850 enumeration support a parent-child relationship. This constitutes indirect evidence of parentage.\\n\\n3. **1908 Death Certificate** (Original Source). Patrick Flynn's death certificate (no. 4521, Pennsylvania Department of Health) names \\\"Thomas Flynn\\\" as his father. The informant was James Brown, identified as Patrick's son-in-law. As a son-in-law reporting his father-in-law's parentage, Brown is a secondary informant for this fact \u2014 he was not a witness to Patrick's birth and is reporting what he was told. Nevertheless, this is direct evidence naming the father.\\n\\n### Conflict Resolution\\n\\nA birthplace conflict exists: the 1850 and 1860 censuses list Patrick's birthplace as Ireland, while the 1908 death certificate states Pennsylvania. The two census records are contemporary recordings with informants likely present in the household, while the death certificate was created 63 years after Patrick's birth by a son-in-law with no firsthand knowledge of the event. Per the GPS preponderance hierarchy, contemporary recordings by closer informants outweigh later recollections by secondary informants. Ireland is accepted as the birthplace; the death certificate entry is attributed to informant error.\\n\\n### Assessment\\n\\nThe conclusion is rated **Proved**. Three independent original sources converge on the same parentage: the 1850 and 1860 censuses (indirect evidence from household position and shared surname, consistent across both enumerations), and the 1908 death certificate (direct evidence, secondary informant). The negative probate search of Thomas Flynn's estate records 1870-1890 (log_006) did not contradict the conclusion \u2014 Thomas may have died intestate or moved. The 1870, 1880, and 1900 censuses were not searched: the three converging sources are already sufficient, and the exhaustive_declaration.overturn_risk is rated Low because new evidence would have to undermine all three sources simultaneously. The single conflict (c_001, birthplace) was resolved by source independence and informant proximity per GPS preponderance.\\n\\n### Citations\\n\\n1. 1850 U.S. Census, Schuylkill County, Pennsylvania, population schedule, dwelling 84, family 91, Thomas Flynn household; NARA microfilm publication M432, roll 810; digital image, FamilySearch.org, accessed 1 May 2026.\\n2. 1860 U.S. Census, Schuylkill County, Pennsylvania, population schedule, dwelling 112, family 119, Thomas Flynn household; NARA microfilm publication M653, roll 1141; digital image, FamilySearch.org, accessed 2 May 2026.\\n3. Pennsylvania Department of Health, death certificate no. 4521 (1908), Patrick Flynn; Pennsylvania State Archives, Harrisburg; digital image, FamilySearch.org, accessed 3 May 2026.\",\n      \"question_id\": \"q_001\",\n      \"resolved_conflict_ids\": [\n        \"c_001\"\n      ],\n      \"supporting_assertion_ids\": [\n        \"a_004\",\n        \"a_010\",\n        \"a_013\"\n      ],\n      \"tier\": \"proved\",\n      \"vehicle\": \"summary\"\n    }\n  ],\n  \"questions\": [\n    {\n      \"created\": \"2026-05-01\",\n      \"depends_on\": [],\n      \"exhaustive_declaration\": {\n        \"declared\": true,\n        \"justification\": \"Three independent original sources confirm Thomas Flynn as Patrick's father: 1850 census co-residence (indirect), 1860 census co-residence (indirect \u2014 relationship inferred from household position), and 1908 death certificate (direct, secondary informant). Probate search for Thomas Flynn returned no will or estate records. The birthplace conflict was resolved by weighing source independence and informant proximity. No contradicting evidence was found.\",\n        \"log_entry_ids\": [\n          \"log_001\",\n          \"log_002\",\n          \"log_003\",\n          \"log_004\",\n          \"log_005\",\n          \"log_006\"\n        ],\n        \"stop_criteria\": {\n          \"conflict_resolution\": \"Birthplace conflict (c_001) resolved by weighing source independence and informant proximity. No other conflicts identified.\",\n          \"evidence_class\": \"Yes \u2014 original census records with indirect evidence of relationship (1850, 1860) and an original death certificate with direct evidence (secondary informant).\",\n          \"goal_alignment\": \"Yes \u2014 three independent original sources name or imply Thomas Flynn as Patrick's father.\",\n          \"independent_verification\": \"Three independent sources support parentage: 1850 census (indirect), 1860 census (indirect), 1908 death certificate (direct).\",\n          \"original_substitution\": \"FamilySearch provides original census images, the death certificate, and the probate index. Ancestry index is derivative, used only as a cross-check.\",\n          \"overturn_risk\": \"Low. Three independent lines converge; negative probate does not contradict. New evidence would have to undermine all three sources simultaneously.\",\n          \"repository_breadth\": \"FamilySearch, Ancestry, and MyHeritage searched for census; FamilySearch for vital records and probate. No additional plausible repositories for Schuylkill County records of this era.\"\n        }\n      },\n      \"id\": \"q_001\",\n      \"priority\": \"high\",\n      \"question\": \"Who were the parents of Patrick Flynn (b. ~1845, PA, d. 1908)?\",\n      \"rationale\": \"This is the primary research objective.\",\n      \"resolution_assertion_ids\": [\n        \"a_004\",\n        \"a_010\",\n        \"a_013\"\n      ],\n      \"resolved\": \"2026-05-04\",\n      \"selection_basis\": \"objective_decomposition\",\n      \"status\": \"resolved\",\n      \"unblocks\": []\n    },\n    {\n      \"created\": \"2026-05-01\",\n      \"depends_on\": [],\n      \"exhaustive_declaration\": {\n        \"declared\": true,\n        \"justification\": \"Searched 1850 census for Schuylkill County on FamilySearch (indexed and browse), Ancestry (indexed), and MyHeritage (indexed). All three returned the same household. No other Patrick Flynn of matching age found in the county.\",\n        \"log_entry_ids\": [\n          \"log_001\",\n          \"log_002\",\n          \"log_003\"\n        ],\n        \"stop_criteria\": {\n          \"conflict_resolution\": \"No conflicts on the 1850 census placement question.\",\n          \"evidence_class\": \"Yes \u2014 FamilySearch provides original census image with indeterminate-quality information.\",\n          \"goal_alignment\": \"Yes \u2014 Patrick Flynn located in a specific 1850 household, answering the question.\",\n          \"independent_verification\": \"FamilySearch (original) and Ancestry (derivative) both return the same household. Two access paths, one underlying original.\",\n          \"original_substitution\": \"FamilySearch provides the original census image; Ancestry index is derivative but confirmed consistent.\",\n          \"overturn_risk\": \"Low \u2014 all three repositories agree, and no competing Patrick Flynn of matching age exists in the county.\",\n          \"repository_breadth\": \"Three major repositories searched (FamilySearch, Ancestry, MyHeritage). No additional known indexes of the 1850 Schuylkill County census exist.\"\n        }\n      },\n      \"id\": \"q_002\",\n      \"priority\": \"high\",\n      \"question\": \"Where was Patrick Flynn in the 1850 census?\",\n      \"rationale\": \"The 1850 census is the earliest enumeration where Patrick would appear by name (age ~5). Locating him in a household identifies candidate parents.\",\n      \"resolution_assertion_ids\": [\n        \"a_001\",\n        \"a_002\",\n        \"a_003\"\n      ],\n      \"resolved\": \"2026-05-02\",\n      \"selection_basis\": \"objective_decomposition\",\n      \"status\": \"resolved\",\n      \"unblocks\": [\n        \"q_001\"\n      ]\n    }\n  ],\n  \"sources\": [\n    {\n      \"access_date\": \"2026-05-01\",\n      \"citation\": \"1850 U.S. Census, Schuylkill County, Pennsylvania, population schedule, dwelling 84, family 91, Thomas Flynn household; NARA microfilm publication M432, roll 810; digital image, FamilySearch.org, accessed 1 May 2026.\",\n      \"citation_detail\": {\n        \"what\": \"1850 U.S. Federal Census, population schedule\",\n        \"when_accessed\": \"2026-05-01\",\n        \"when_created\": \"1850\",\n        \"where\": \"FamilySearch.org (NARA microfilm M432, roll 810)\",\n        \"where_within\": \"Schuylkill County, dwelling 84, family 91\",\n        \"who\": \"U.S. Census Bureau\"\n      },\n      \"gedcomx_source_description_id\": \"S1\",\n      \"id\": \"src_001\",\n      \"log_entry_id\": \"log_001\",\n      \"notes\": \"Image quality good. Enumerator handwriting clear.\",\n      \"repository\": \"FamilySearch\",\n      \"source_classification\": \"original\",\n      \"url\": \"https://www.familysearch.org/ark:/61903/1:1:MXYZ\",\n      \"url_archived\": null\n    },\n    {\n      \"access_date\": \"2026-05-01\",\n      \"citation\": \"1850 U.S. Census, Schuylkill County, Pennsylvania, population schedule, dwelling 84, Thomas Flynn household; digital image, Ancestry.com, accessed 1 May 2026.\",\n      \"citation_detail\": {\n        \"what\": \"1850 U.S. Federal Census, population schedule (Ancestry index)\",\n        \"when_accessed\": \"2026-05-01\",\n        \"when_created\": \"1850\",\n        \"where\": \"Ancestry.com\",\n        \"where_within\": \"Schuylkill County, dwelling 84\",\n        \"who\": \"U.S. Census Bureau\"\n      },\n      \"gedcomx_source_description_id\": \"S1\",\n      \"id\": \"src_002\",\n      \"log_entry_id\": \"log_002\",\n      \"notes\": \"Ancestry's index of the same original census. Transcription consistent with FamilySearch.\",\n      \"repository\": \"Ancestry\",\n      \"source_classification\": \"derivative\",\n      \"url\": null,\n      \"url_archived\": null\n    },\n    {\n      \"access_date\": \"2026-05-02\",\n      \"citation\": \"1860 U.S. Census, Schuylkill County, Pennsylvania, population schedule, dwelling 112, family 119, Thomas Flynn household; NARA microfilm publication M653, roll 1141; digital image, FamilySearch.org, accessed 2 May 2026.\",\n      \"citation_detail\": {\n        \"what\": \"1860 U.S. Federal Census, population schedule\",\n        \"when_accessed\": \"2026-05-02\",\n        \"when_created\": \"1860\",\n        \"where\": \"FamilySearch.org (NARA microfilm M653, roll 1141)\",\n        \"where_within\": \"Schuylkill County, dwelling 112, family 119\",\n        \"who\": \"U.S. Census Bureau\"\n      },\n      \"gedcomx_source_description_id\": \"S2\",\n      \"id\": \"src_003\",\n      \"log_entry_id\": \"log_004\",\n      \"notes\": null,\n      \"repository\": \"FamilySearch\",\n      \"source_classification\": \"original\",\n      \"url\": \"https://www.familysearch.org/ark:/61903/1:1:MABC\",\n      \"url_archived\": null\n    },\n    {\n      \"access_date\": \"2026-05-03\",\n      \"citation\": \"Pennsylvania Department of Health, death certificate no. 4521 (1908), Patrick Flynn; Pennsylvania State Archives, Harrisburg; digital image, FamilySearch.org, accessed 3 May 2026.\",\n      \"citation_detail\": {\n        \"what\": \"Death certificate no. 4521\",\n        \"when_accessed\": \"2026-05-03\",\n        \"when_created\": \"1908-03-14\",\n        \"where\": \"FamilySearch.org (Pennsylvania State Archives, Harrisburg)\",\n        \"where_within\": \"Certificate no. 4521\",\n        \"who\": \"Pennsylvania Department of Health; informant: James Brown (son-in-law)\"\n      },\n      \"gedcomx_source_description_id\": \"S3\",\n      \"id\": \"src_004\",\n      \"log_entry_id\": \"log_005\",\n      \"notes\": \"Informant is son-in-law James Brown. Primary for death facts, secondary for birth facts.\",\n      \"repository\": \"FamilySearch\",\n      \"source_classification\": \"original\",\n      \"url\": \"https://www.familysearch.org/ark:/61903/1:1:MDEF\",\n      \"url_archived\": null\n    }\n  ],\n  \"timelines\": [\n    {\n      \"events\": [\n        {\n          \"assertion_ids\": [\n            \"a_002\",\n            \"a_009\"\n          ],\n          \"date\": \"~1845\",\n          \"date_certainty\": \"estimated\",\n          \"description\": \"Born in Ireland, estimated from census ages\",\n          \"event_type\": \"birth\",\n          \"place\": \"Ireland\"\n        },\n        {\n          \"assertion_ids\": [\n            \"a_003\",\n            \"a_004\"\n          ],\n          \"date\": \"1850\",\n          \"date_certainty\": \"exact\",\n          \"description\": \"Enumerated age 5 in Thomas Flynn household, dwelling 84\",\n          \"event_type\": \"census\",\n          \"place\": \"Schuylkill County, Pennsylvania\"\n        },\n        {\n          \"assertion_ids\": [\n            \"a_008\",\n            \"a_009\",\n            \"a_010\"\n          ],\n          \"date\": \"1860\",\n          \"date_certainty\": \"exact\",\n          \"description\": \"Enumerated age 15 in Thomas Flynn household, dwelling 112\",\n          \"event_type\": \"census\",\n          \"place\": \"Schuylkill County, Pennsylvania\"\n        },\n        {\n          \"assertion_ids\": [\n            \"a_011\",\n            \"a_013\"\n          ],\n          \"date\": \"1908-03-12\",\n          \"date_certainty\": \"exact\",\n          \"description\": \"Died, death certificate names Thomas Flynn as father\",\n          \"event_type\": \"death\",\n          \"place\": \"Schuylkill County, Pennsylvania\"\n        }\n      ],\n      \"gaps\": [\n        {\n          \"end\": \"1908-03-12\",\n          \"expected_events\": [\n            \"marriage\",\n            \"1870_census\",\n            \"1880_census\",\n            \"1900_census\",\n            \"residence\",\n            \"occupation\"\n          ],\n          \"severity\": \"high\",\n          \"start\": \"1860-01-01\"\n        }\n      ],\n      \"generated\": \"2026-05-03T12:00:00Z\",\n      \"hypothesis_id\": \"h_001\",\n      \"id\": \"t_001\",\n      \"impossibilities\": [],\n      \"label\": \"Patrick Flynn \u2014 assuming Thomas Flynn parentage\",\n      \"person_ids\": [\n        \"I1\"\n      ]\n    }\n  ]\n}\n",
+    "eval/fixtures/scenarios/flynn-resolved/tree.gedcomx.json": "{\n  \"persons\": [\n    {\n      \"facts\": [\n        {\n          \"date\": \"~1845\",\n          \"id\": \"F1\",\n          \"place\": \"Ireland\",\n          \"primary\": true,\n          \"sources\": [\n            {\n              \"page\": \"1850 Census, Schuylkill Co., dwelling 84\",\n              \"ref\": \"S1\"\n            }\n          ],\n          \"type\": \"Birth\"\n        },\n        {\n          \"date\": \"1908-03-12\",\n          \"id\": \"F2\",\n          \"place\": \"Schuylkill County, Pennsylvania\",\n          \"sources\": [\n            {\n              \"page\": \"Death cert. no. 4521\",\n              \"ref\": \"S3\"\n            }\n          ],\n          \"type\": \"Death\"\n        }\n      ],\n      \"gender\": \"Male\",\n      \"id\": \"I1\",\n      \"names\": [\n        {\n          \"given\": \"Patrick\",\n          \"id\": \"N1\",\n          \"preferred\": true,\n          \"surname\": \"Flynn\",\n          \"type\": \"BirthName\"\n        }\n      ]\n    },\n    {\n      \"facts\": [\n        {\n          \"date\": \"~1818\",\n          \"id\": \"F3\",\n          \"place\": \"Ireland\",\n          \"primary\": true,\n          \"type\": \"Birth\"\n        }\n      ],\n      \"gender\": \"Male\",\n      \"id\": \"I2\",\n      \"names\": [\n        {\n          \"given\": \"Thomas\",\n          \"id\": \"N2\",\n          \"preferred\": true,\n          \"surname\": \"Flynn\",\n          \"type\": \"BirthName\"\n        }\n      ]\n    }\n  ],\n  \"relationships\": [\n    {\n      \"child\": \"I1\",\n      \"id\": \"R1\",\n      \"parent\": \"I2\",\n      \"sources\": [\n        {\n          \"page\": \"1850 Census, Schuylkill Co., dwelling 84\",\n          \"quality\": 2,\n          \"ref\": \"S1\"\n        },\n        {\n          \"page\": \"1860 Census, Schuylkill Co., dwelling 112\",\n          \"quality\": 2,\n          \"ref\": \"S2\"\n        },\n        {\n          \"page\": \"Death cert. no. 4521\",\n          \"quality\": 2,\n          \"ref\": \"S3\"\n        }\n      ],\n      \"type\": \"ParentChild\"\n    }\n  ],\n  \"sources\": [\n    {\n      \"author\": \"U.S. Census Bureau\",\n      \"id\": \"S1\",\n      \"title\": \"1850 U.S. Federal Census\"\n    },\n    {\n      \"author\": \"U.S. Census Bureau\",\n      \"id\": \"S2\",\n      \"title\": \"1860 U.S. Federal Census\"\n    },\n    {\n      \"author\": \"Pennsylvania Dept. of Health\",\n      \"id\": \"S3\",\n      \"title\": \"Pennsylvania Death Certificates\"\n    },\n    {\n      \"author\": \"Schuylkill County Register of Wills\",\n      \"id\": \"S4\",\n      \"title\": \"Schuylkill County Probate Records\"\n    }\n  ]\n}\n",
+    "eval/fixtures/scenarios/mid-research-flynn/README.md": "# mid-research-flynn\n\nPatrick Flynn parentage research, mid-project.\n\n- **Objective:** Identify the parents of Patrick Flynn (b. ~1845, d. 1908)\n- **Questions:** q_001 (parentage, in_progress), q_002 (1850 census placement, resolved)\n- **Plans:** pl_001 (1850 census search, completed), pl_002 (parentage evidence, active)\n- **Log:** 5 entries \u2014 1850 census on FamilySearch/Ancestry/MyHeritage, 1860 census, death cert\n- **Sources:** 4 sources (1850 census FS, 1850 census Ancestry, 1860 census, death cert)\n- **Assertions:** 13 assertions across 4 sources\n- **Person evidence:** 6 links (Patrick \u2192 I1, Thomas \u2192 I2)\n- **Conflicts:** 1 resolved (birthplace: Ireland vs Pennsylvania)\n- **Hypotheses:** h_001 (Thomas is Patrick's father, supported)\n- **Timelines:** t_001 (Patrick, 4 events, 1 gap)\n- **Proof summaries:** ps_001 (parentage, probable)\n- **GedcomX persons:** I1 (Patrick Flynn), I2 (Thomas Flynn), I3 (Mary Flynn, sister), I4 (James Flynn, brother)\n- **GedcomX relationships:** R1 (Thomas \u2192 Patrick), R2 (Thomas \u2192 Mary), R3 (Thomas \u2192 James) \u2014 all ParentChild\n- **Note on siblings:** Mary and James are stub entries (preferred name + gender only, no facts).\n  They represent the canonical shape Dallan called for: when researching Patrick on a household\n  census, the siblings should exist as persons in `tree.gedcomx.json` so warnings like\n  `relativesChildBirthRange40` and skills like `person-evidence` can reach them. Their detailed\n  facts would land later via record-extraction + person-evidence as the user works through the\n  1850 census record.\n",
+    "eval/fixtures/scenarios/mid-research-flynn/research.json": "{\n  \"assertions\": [\n    {\n      \"date\": null,\n      \"date_certainty\": null,\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_002\"\n      ],\n      \"fact_type\": \"name\",\n      \"id\": \"a_001\",\n      \"informant\": \"Unknown informant (most likely a household member, possibly a neighbor) reporting to census enumerator\",\n      \"informant_bias_notes\": \"Census enumerator is the recorder, not the informant. The person who provided the name is unknown \u2014 most likely a household member, possibly a neighbor. Proximity is 'unknown' rather than 'household_member' because for names specifically, the enumerator may have heard the name from a neighbor or made an assumption \u2014 the name fact doesn't necessarily require active reporting the way age/birthplace does.\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_001\",\n      \"place\": null,\n      \"record_id\": \"ark:/61903/1:1:MXYZ\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_001\",\n      \"structured_value\": {\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"value\": \"Patrick Flynn\"\n    },\n    {\n      \"date\": \"~1845\",\n      \"date_certainty\": \"estimated\",\n      \"evidence_type\": \"indirect\",\n      \"extracted_for_question_ids\": [\n        \"q_002\"\n      ],\n      \"fact_type\": \"birth\",\n      \"id\": \"a_002\",\n      \"informant\": \"Unknown \u2014 most likely a household member (such as Thomas Flynn or his wife), but possibly a neighbor\",\n      \"informant_bias_notes\": \"Age and birthplace require active reporting by an informant \u2014 someone had to tell the enumerator these facts. That informant was most likely a household member, but enumerators also took information from neighbors when residents were unavailable, and the census does not identify who answered. Proximity is 'unknown' because the informant cannot be established from the record.\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_001\",\n      \"place\": \"Ireland\",\n      \"record_id\": \"ark:/61903/1:1:MXYZ\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_001\",\n      \"structured_value\": {\n        \"place\": \"Ireland\",\n        \"year\": 1845\n      },\n      \"value\": \"age 5\"\n    },\n    {\n      \"date\": \"1850\",\n      \"date_certainty\": \"exact\",\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_002\"\n      ],\n      \"fact_type\": \"residence\",\n      \"id\": \"a_003\",\n      \"informant\": \"Census enumerator (witness to residence by visiting the dwelling)\",\n      \"informant_bias_notes\": \"For residence facts specifically, the enumerator is a direct witness \u2014 they physically visited the dwelling and recorded who lived there. This distinguishes residence from other census facts where an unidentified informant (most likely a household member, possibly a neighbor) supplied the information.\",\n      \"informant_proximity\": \"witness\",\n      \"information_quality\": \"primary\",\n      \"log_entry_id\": \"log_001\",\n      \"place\": \"Schuylkill County, Pennsylvania\",\n      \"record_id\": \"ark:/61903/1:1:MXYZ\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_001\",\n      \"value\": \"Schuylkill County, Pennsylvania\"\n    },\n    {\n      \"date\": \"1850\",\n      \"date_certainty\": \"exact\",\n      \"evidence_type\": \"indirect\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"relationship\",\n      \"id\": \"a_004\",\n      \"informant\": \"Inferred from household structure \u2014 no explicit informant for relationships in 1850 census\",\n      \"informant_bias_notes\": \"1850 census does not state relationships; this assertion is inferred from household position and shared surname, not directly reported by any informant. The relationship is indirect evidence constructed by the researcher, not information provided by a census informant.\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_001\",\n      \"place\": \"Schuylkill County, Pennsylvania\",\n      \"record_id\": \"ark:/61903/1:1:MXYZ\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_001\",\n      \"structured_value\": {\n        \"related_person_role\": \"head_of_household\",\n        \"relationship_type\": \"child_inferred\"\n      },\n      \"value\": \"Listed in household of Thomas Flynn (head), position consistent with child\"\n    },\n    {\n      \"date\": null,\n      \"date_certainty\": null,\n      \"evidence_type\": \"indirect\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"name\",\n      \"id\": \"a_005\",\n      \"informant\": \"Unknown informant (likely Thomas Flynn himself) reporting to census enumerator\",\n      \"informant_bias_notes\": \"Census enumerator is the recorder, not the informant. As head of household, Thomas likely provided his own name, but the 1850 census does not identify the informant.\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_001\",\n      \"place\": null,\n      \"record_id\": \"ark:/61903/1:1:MXYZ\",\n      \"record_role\": \"head_of_household\",\n      \"source_id\": \"src_001\",\n      \"value\": \"Thomas Flynn\"\n    },\n    {\n      \"date\": null,\n      \"date_certainty\": null,\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_002\"\n      ],\n      \"fact_type\": \"name\",\n      \"id\": \"a_006\",\n      \"informant\": \"Ancestry transcriber (derivative of census enumerator)\",\n      \"informant_bias_notes\": \"Derivative index \u2014 transcription errors possible\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_002\",\n      \"place\": null,\n      \"record_id\": \"ancestry:8054:patrick-flynn-1850\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_002\",\n      \"value\": \"Patrick Flynn\"\n    },\n    {\n      \"date\": \"~1845\",\n      \"date_certainty\": \"estimated\",\n      \"evidence_type\": \"indirect\",\n      \"extracted_for_question_ids\": [\n        \"q_002\"\n      ],\n      \"fact_type\": \"birth\",\n      \"id\": \"a_007\",\n      \"informant\": \"Ancestry transcriber (derivative)\",\n      \"informant_bias_notes\": null,\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_002\",\n      \"place\": \"Ireland\",\n      \"record_id\": \"ancestry:8054:patrick-flynn-1850\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_002\",\n      \"value\": \"age 5\"\n    },\n    {\n      \"date\": null,\n      \"date_certainty\": null,\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"name\",\n      \"id\": \"a_008\",\n      \"informant\": \"Unknown informant (most likely a household member, possibly a neighbor) reporting to census enumerator\",\n      \"informant_bias_notes\": \"Census enumerator is the recorder, not the informant. Proximity is 'unknown' for names (same reasoning as a_001 \u2014 name facts don't necessarily require active reporting).\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_004\",\n      \"place\": null,\n      \"record_id\": \"ark:/61903/1:1:MABC\",\n      \"record_role\": \"child_2\",\n      \"source_id\": \"src_003\",\n      \"value\": \"Patrick Flynn\"\n    },\n    {\n      \"date\": \"~1845\",\n      \"date_certainty\": \"estimated\",\n      \"evidence_type\": \"indirect\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"birth\",\n      \"id\": \"a_009\",\n      \"informant\": \"Unknown \u2014 most likely a household member (such as Thomas Flynn or his wife), but possibly a neighbor\",\n      \"informant_bias_notes\": \"Age and birthplace require active reporting by an informant \u2014 most likely a household member, possibly a neighbor (same reasoning as a_002).\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_004\",\n      \"place\": \"Ireland\",\n      \"record_id\": \"ark:/61903/1:1:MABC\",\n      \"record_role\": \"child_2\",\n      \"source_id\": \"src_003\",\n      \"value\": \"age 15\"\n    },\n    {\n      \"date\": \"1860\",\n      \"date_certainty\": \"exact\",\n      \"evidence_type\": \"indirect\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"relationship\",\n      \"id\": \"a_010\",\n      \"informant\": \"Inferred from household structure \u2014 no explicit informant for relationships in 1860 census\",\n      \"informant_bias_notes\": \"1860 census does not state relationships; like the 1850 census, this assertion is inferred from household position, age, and shared surname. The relationship column was not introduced until the 1880 census.\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_004\",\n      \"place\": \"Schuylkill County, Pennsylvania\",\n      \"record_id\": \"ark:/61903/1:1:MABC\",\n      \"record_role\": \"child_2\",\n      \"source_id\": \"src_003\",\n      \"structured_value\": {\n        \"related_person_role\": \"head_of_household\",\n        \"relationship_type\": \"child_inferred\"\n      },\n      \"value\": \"Listed in household of Thomas Flynn (head), position and age consistent with son\"\n    },\n    {\n      \"date\": \"1908-03-12\",\n      \"date_certainty\": \"exact\",\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [],\n      \"fact_type\": \"death\",\n      \"id\": \"a_011\",\n      \"informant\": \"Attending physician (signature on certificate)\",\n      \"informant_bias_notes\": null,\n      \"informant_proximity\": \"witness\",\n      \"information_quality\": \"primary\",\n      \"log_entry_id\": \"log_005\",\n      \"place\": \"Schuylkill County, Pennsylvania\",\n      \"record_id\": \"ark:/61903/1:1:MDEF\",\n      \"record_role\": \"deceased\",\n      \"source_id\": \"src_004\",\n      \"value\": \"Died 12 March 1908\"\n    },\n    {\n      \"date\": \"1845\",\n      \"date_certainty\": \"approximate\",\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"birth\",\n      \"id\": \"a_012\",\n      \"informant\": \"James Brown (son-in-law)\",\n      \"informant_bias_notes\": \"Son-in-law reporting birth facts decades after the event. Note: death cert says Pennsylvania, but census records say Ireland. Son-in-law may not have known Patrick was born in Ireland.\",\n      \"informant_proximity\": \"family_not_present\",\n      \"information_quality\": \"secondary\",\n      \"log_entry_id\": \"log_005\",\n      \"place\": \"Pennsylvania\",\n      \"record_id\": \"ark:/61903/1:1:MDEF\",\n      \"record_role\": \"deceased\",\n      \"source_id\": \"src_004\",\n      \"structured_value\": {\n        \"place\": \"Pennsylvania\",\n        \"year\": 1845\n      },\n      \"value\": \"Born 1845, Pennsylvania\"\n    },\n    {\n      \"date\": null,\n      \"date_certainty\": null,\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"relationship\",\n      \"id\": \"a_013\",\n      \"informant\": \"James Brown (son-in-law)\",\n      \"informant_bias_notes\": \"Secondary information \u2014 son-in-law reporting what he was told about father-in-law's parentage\",\n      \"informant_proximity\": \"family_not_present\",\n      \"information_quality\": \"secondary\",\n      \"log_entry_id\": \"log_005\",\n      \"place\": null,\n      \"record_id\": \"ark:/61903/1:1:MDEF\",\n      \"record_role\": \"deceased\",\n      \"source_id\": \"src_004\",\n      \"structured_value\": {\n        \"related_person_role\": \"deceased\",\n        \"relationship_type\": \"father\"\n      },\n      \"value\": \"Father: Thomas Flynn\"\n    }\n  ],\n  \"conflicts\": [\n    {\n      \"blocks_question_ids\": [],\n      \"competing_assertion_ids\": [\n        \"a_002\",\n        \"a_009\",\n        \"a_012\"\n      ],\n      \"conflict_type\": \"fact\",\n      \"description\": \"Patrick Flynn's birthplace: Ireland (1850 and 1860 censuses) vs. Pennsylvania (1908 death certificate)\",\n      \"disputed_attribute\": \"birthplace\",\n      \"id\": \"c_001\",\n      \"identity_question\": null,\n      \"independence_analysis\": \"The two census records (1850, 1860) are independent original sources with different enumerators. The death certificate is a third independent original source. However, the census informants are likely the same household member (Thomas Flynn or wife), so the two census assertions may share a single informant \u2014 potentially not fully independent for this fact.\",\n      \"preferred_assertion_id\": \"a_002\",\n      \"resolution_rationale\": \"Ireland is accepted as the birthplace. The 1908 death certificate birthplace of 'Pennsylvania' is rejected as a likely error by the son-in-law informant, who may have confused Patrick's place of residence with his place of birth, or may not have known Patrick was born in Ireland before immigrating as a young child.\",\n      \"status\": \"resolved\",\n      \"weighing_analysis\": \"The census records are contemporary recordings made near the time of Patrick's birth, while the death certificate was created 63 years later. The census informant was likely a household member with firsthand knowledge (primary or indeterminate), while the death certificate informant (son-in-law) is clearly secondary for birth facts. Two contemporary sources outweigh one later recollection by a secondary informant.\"\n    }\n  ],\n  \"evaluations\": [],\n  \"hypotheses\": [\n    {\n      \"claim\": \"Patrick Flynn's father was Thomas Flynn of Schuylkill County, Pennsylvania\",\n      \"contradicting_assertion_ids\": [],\n      \"id\": \"h_001\",\n      \"notes\": \"Three independent pieces of evidence: 1850 census co-enumeration (indirect), 1860 census co-enumeration (indirect \u2014 relationship inferred from household position), death certificate naming Thomas as father (direct, secondary informant). Awaiting probate records for additional confirmation.\",\n      \"related_question_ids\": [\n        \"q_001\"\n      ],\n      \"ruled_out\": false,\n      \"ruled_out_reason\": null,\n      \"status\": \"supported\",\n      \"supporting_assertion_ids\": [\n        \"a_004\",\n        \"a_010\",\n        \"a_013\"\n      ]\n    }\n  ],\n  \"log\": [\n    {\n      \"external_site\": null,\n      \"id\": \"log_001\",\n      \"notes\": \"Found Patrick Flynn age 5 in household of Thomas Flynn, dwelling 84, Schuylkill Co. Three other Flynn results examined \u2014 ages and locations don't match.\",\n      \"outcome\": \"positive\",\n      \"performed\": \"2026-05-01T10:15:00Z\",\n      \"plan_item_id\": \"pli_001\",\n      \"query\": {\n        \"birth_place\": \"Pennsylvania\",\n        \"birth_year\": 1845,\n        \"collection\": \"1850 Census\",\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"results_examined\": 8,\n      \"tool\": \"record_search\"\n    },\n    {\n      \"external_site\": {\n        \"capture_filename\": \"ancestry-1850-flynn-results.pdf\",\n        \"capture_received\": true,\n        \"site\": \"ancestry\",\n        \"url_generated\": \"https://www.ancestry.com/search/collections/8054/?name=Patrick_Flynn&birth=1845&birthplace=Pennsylvania\"\n      },\n      \"id\": \"log_002\",\n      \"notes\": \"Ancestry index confirms same household. Transcription matches FamilySearch except Ancestry reads dwelling as 84, FamilySearch as 84 \u2014 consistent.\",\n      \"outcome\": \"positive\",\n      \"performed\": \"2026-05-01T11:30:00Z\",\n      \"plan_item_id\": \"pli_002\",\n      \"query\": {\n        \"birth_place\": \"Pennsylvania\",\n        \"birth_year\": 1845,\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"results_examined\": 12,\n      \"tool\": \"external_site\"\n    },\n    {\n      \"external_site\": {\n        \"capture_filename\": \"myheritage-1850-flynn-nil.pdf\",\n        \"capture_received\": true,\n        \"site\": \"myheritage\",\n        \"url_generated\": \"https://www.myheritage.com/research?action=query&first=Patrick&last=Flynn&birth_year=1845&birth_place=Pennsylvania\"\n      },\n      \"id\": \"log_003\",\n      \"notes\": \"MyHeritage returned no results for Patrick Flynn in 1850 Schuylkill County. Site may not have this collection indexed. Searched broader Pennsylvania \u2014 still no match.\",\n      \"outcome\": \"negative\",\n      \"performed\": \"2026-05-01T14:00:00Z\",\n      \"plan_item_id\": \"pli_003\",\n      \"query\": {\n        \"birth_place\": \"Pennsylvania\",\n        \"birth_year\": 1845,\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"results_examined\": 0,\n      \"tool\": \"external_site\"\n    },\n    {\n      \"external_site\": null,\n      \"id\": \"log_004\",\n      \"notes\": \"Patrick Flynn age 15 in household of Thomas Flynn, Schuylkill Co. Consistent with 1850 placement.\",\n      \"outcome\": \"positive\",\n      \"performed\": \"2026-05-02T09:00:00Z\",\n      \"plan_item_id\": \"pli_004\",\n      \"query\": {\n        \"birth_place\": \"Pennsylvania\",\n        \"birth_year\": 1845,\n        \"collection\": \"1860 Census\",\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"results_examined\": 5,\n      \"tool\": \"record_search\"\n    },\n    {\n      \"external_site\": null,\n      \"id\": \"log_005\",\n      \"notes\": \"Death certificate found. Names Thomas Flynn as father. Informant was son-in-law James Brown.\",\n      \"outcome\": \"positive\",\n      \"performed\": \"2026-05-03T10:00:00Z\",\n      \"plan_item_id\": \"pli_005\",\n      \"query\": {\n        \"death_place\": \"Schuylkill County, Pennsylvania\",\n        \"death_year\": 1908,\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"results_examined\": 2,\n      \"tool\": \"record_search\"\n    }\n  ],\n  \"person_evidence\": [\n    {\n      \"assertion_id\": \"a_001\",\n      \"confidence\": \"confident\",\n      \"created\": \"2026-05-01\",\n      \"id\": \"pe_001\",\n      \"match_score\": null,\n      \"person_id\": \"I1\",\n      \"rationale\": \"Name matches (Patrick Flynn), age consistent with ~1845 birth, located in Schuylkill County where subject is known to have lived. Only Patrick Flynn of this age in the county in 1850.\",\n      \"superseded_by\": null\n    },\n    {\n      \"assertion_id\": \"a_004\",\n      \"confidence\": \"probable\",\n      \"created\": \"2026-05-01\",\n      \"id\": \"pe_002\",\n      \"match_score\": null,\n      \"person_id\": \"I1\",\n      \"rationale\": \"Same record as pe_001, same person. Household position and shared surname with head Thomas Flynn suggest parent-child relationship, but 1850 census does not state relationships explicitly.\",\n      \"superseded_by\": null\n    },\n    {\n      \"assertion_id\": \"a_004\",\n      \"confidence\": \"probable\",\n      \"created\": \"2026-05-01\",\n      \"id\": \"pe_006\",\n      \"match_score\": null,\n      \"person_id\": \"I2\",\n      \"rationale\": \"Same assertion as pe_002 but linked to Thomas Flynn (I2). The relationship assertion ('position consistent with child') equally bears on the head of household. Thomas Flynn is the other party in the implied parent-child relationship.\",\n      \"superseded_by\": null\n    },\n    {\n      \"assertion_id\": \"a_005\",\n      \"confidence\": \"probable\",\n      \"created\": \"2026-05-01\",\n      \"id\": \"pe_003\",\n      \"match_score\": 0.82,\n      \"person_id\": \"I2\",\n      \"rationale\": \"Thomas Flynn, head of household where Patrick was found. Age (~32 in 1850, born ~1818) is consistent with being Patrick's father. Name matches candidate father.\",\n      \"superseded_by\": null\n    },\n    {\n      \"assertion_id\": \"a_010\",\n      \"confidence\": \"confident\",\n      \"created\": \"2026-05-02\",\n      \"id\": \"pe_004\",\n      \"match_score\": null,\n      \"person_id\": \"I1\",\n      \"rationale\": \"Patrick Flynn age 15 in Thomas Flynn household, 1860 census. Same county, age consistent with 1850 enumeration. Relationship inferred from household position and shared surname (1860 census does not state relationships explicitly).\",\n      \"superseded_by\": null\n    },\n    {\n      \"assertion_id\": \"a_013\",\n      \"confidence\": \"confident\",\n      \"created\": \"2026-05-03\",\n      \"id\": \"pe_005\",\n      \"match_score\": null,\n      \"person_id\": \"I1\",\n      \"rationale\": \"Death certificate for Patrick Flynn, d. 1908, Schuylkill County. Names match, death location matches known residence. Names Thomas Flynn as father.\",\n      \"superseded_by\": null\n    }\n  ],\n  \"plans\": [\n    {\n      \"created\": \"2026-05-01\",\n      \"id\": \"pl_001\",\n      \"items\": [\n        {\n          \"date_range\": \"1850\",\n          \"fallback_for\": null,\n          \"id\": \"pli_001\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"1850 census fully indexed on FamilySearch. Free access, start here.\",\n          \"record_type\": \"census\",\n          \"repository\": \"FamilySearch\",\n          \"sequence\": 1,\n          \"status\": \"completed\"\n        },\n        {\n          \"date_range\": \"1850\",\n          \"fallback_for\": null,\n          \"id\": \"pli_002\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"Ancestry has independent indexing; cross-check for transcription errors.\",\n          \"record_type\": \"census\",\n          \"repository\": \"Ancestry\",\n          \"sequence\": 2,\n          \"status\": \"completed\"\n        },\n        {\n          \"date_range\": \"1850\",\n          \"fallback_for\": null,\n          \"id\": \"pli_003\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"Third independent index for coverage confirmation.\",\n          \"record_type\": \"census\",\n          \"repository\": \"MyHeritage\",\n          \"sequence\": 3,\n          \"status\": \"completed\"\n        }\n      ],\n      \"question_id\": \"q_002\",\n      \"status\": \"completed\"\n    },\n    {\n      \"created\": \"2026-05-02\",\n      \"id\": \"pl_002\",\n      \"items\": [\n        {\n          \"date_range\": \"1860\",\n          \"fallback_for\": null,\n          \"id\": \"pli_004\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"Confirm Patrick still in Thomas Flynn household in 1860. Strengthens parent-child identification.\",\n          \"record_type\": \"census\",\n          \"repository\": \"FamilySearch\",\n          \"sequence\": 1,\n          \"status\": \"completed\"\n        },\n        {\n          \"date_range\": \"1908\",\n          \"fallback_for\": null,\n          \"id\": \"pli_005\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"Death certificate may name parents directly.\",\n          \"record_type\": \"vital_record\",\n          \"repository\": \"FamilySearch\",\n          \"sequence\": 2,\n          \"status\": \"completed\"\n        },\n        {\n          \"date_range\": \"1870-1890\",\n          \"fallback_for\": null,\n          \"id\": \"pli_006\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"Thomas Flynn probate/will may name Patrick as son.\",\n          \"record_type\": \"probate\",\n          \"repository\": \"FamilySearch\",\n          \"sequence\": 3,\n          \"status\": \"in_progress\"\n        }\n      ],\n      \"question_id\": \"q_001\",\n      \"status\": \"active\"\n    }\n  ],\n  \"project\": {\n    \"created\": \"2026-05-01\",\n    \"id\": \"rp_001\",\n    \"objective\": \"Identify the parents of Patrick Flynn, born ca. 1845 in Pennsylvania, died 1908 in Schuylkill County, PA\",\n    \"status\": \"active\",\n    \"subject_person_ids\": [\n      \"I1\"\n    ],\n    \"updated\": \"2026-05-04\"\n  },\n  \"proof_summaries\": [\n    {\n      \"exhaustive_search_summary\": \"Searched 1850 census (FamilySearch, Ancestry, MyHeritage \u2014 log_001, log_002, log_003), 1860 census (FamilySearch \u2014 log_004), and death certificate (FamilySearch \u2014 log_005). Probate search in progress. 1870, 1880, and 1900 censuses not yet searched.\",\n      \"id\": \"ps_001\",\n      \"narrative_markdown\": \"## Parentage of Patrick Flynn (ca. 1845\u20131908)\\n\\nPatrick Flynn is **Probably** the son of Thomas Flynn of Schuylkill County, Pennsylvania.\\n\\n### Evidence Summary\\n\\nThree independent lines of evidence support this conclusion:\\n\\n1. **1850 U.S. Census** (Original Source). Patrick Flynn, age 5, born Ireland, appears in the household of Thomas Flynn, age 32, born Ireland, in Schuylkill County, Pennsylvania (dwelling 84, family 91). The 1850 census does not state relationships, but Patrick's position in the household and shared surname are consistent with a parent-child relationship. The informant is indeterminate but likely a household member. This constitutes indirect evidence of parentage.\\n\\n2. **1860 U.S. Census** (Original Source). Patrick Flynn, age 15, born Ireland, appears in the household of Thomas Flynn in Schuylkill County (dwelling 112, family 119). Like the 1850 census, the 1860 census does not state relationships explicitly (the relationship column was not introduced until 1880). Patrick's position in the household, shared surname, and age consistent with the 1850 enumeration support a parent-child relationship. This constitutes indirect evidence of parentage.\\n\\n3. **1908 Death Certificate** (Original Source). Patrick Flynn's death certificate (no. 4521, Pennsylvania Department of Health) names \\\"Thomas Flynn\\\" as his father. The informant was James Brown, identified as Patrick's son-in-law. As a son-in-law reporting his father-in-law's parentage, Brown is a secondary informant for this fact \u2014 he was not a witness to Patrick's birth and is reporting what he was told. Nevertheless, this is direct evidence naming the father.\\n\\n### Conflict Resolution\\n\\nA birthplace conflict exists: the 1850 and 1860 censuses list Patrick's birthplace as Ireland, while the 1908 death certificate states Pennsylvania. The two census records are contemporary recordings with informants likely present in the household, while the death certificate was created 63 years after Patrick's birth by a son-in-law with no firsthand knowledge of the event. Per the GPS preponderance hierarchy, contemporary recordings by closer informants outweigh later recollections by secondary informants. Ireland is accepted as the birthplace; the death certificate entry is attributed to informant error.\\n\\n### Assessment\\n\\nThe conclusion is rated **Probable** rather than **Proved** because: (a) both census sources (1850 and 1860) provide only indirect evidence of parentage (relationships not stated \u2014 the relationship column was not introduced until 1880), (b) the death certificate informant is secondary, and (c) research is not yet exhaustive \u2014 the 1870, 1880, and 1900 censuses have not been searched, and Thomas Flynn's probate records have not been located. If Thomas Flynn's will names Patrick as a son, or if additional census records confirm the relationship, the conclusion would advance to **Proved**.\\n\\n### Citations\\n\\n1. 1850 U.S. Census, Schuylkill County, Pennsylvania, population schedule, dwelling 84, family 91, Thomas Flynn household; NARA microfilm publication M432, roll 810; digital image, FamilySearch.org, accessed 1 May 2026.\\n2. 1860 U.S. Census, Schuylkill County, Pennsylvania, population schedule, dwelling 112, family 119, Thomas Flynn household; NARA microfilm publication M653, roll 1141; digital image, FamilySearch.org, accessed 2 May 2026.\\n3. Pennsylvania Department of Health, death certificate no. 4521 (1908), Patrick Flynn; Pennsylvania State Archives, Harrisburg; digital image, FamilySearch.org, accessed 3 May 2026.\",\n      \"question_id\": \"q_001\",\n      \"resolved_conflict_ids\": [\n        \"c_001\"\n      ],\n      \"supporting_assertion_ids\": [\n        \"a_004\",\n        \"a_010\",\n        \"a_013\"\n      ],\n      \"tier\": \"probable\",\n      \"vehicle\": \"summary\"\n    }\n  ],\n  \"questions\": [\n    {\n      \"created\": \"2026-05-01\",\n      \"depends_on\": [],\n      \"exhaustive_declaration\": {\n        \"declared\": false,\n        \"justification\": null,\n        \"log_entry_ids\": [],\n        \"stop_criteria\": null\n      },\n      \"id\": \"q_001\",\n      \"priority\": \"high\",\n      \"question\": \"Who were the parents of Patrick Flynn (b. ~1845, PA, d. 1908)?\",\n      \"rationale\": \"This is the primary research objective.\",\n      \"resolution_assertion_ids\": [],\n      \"resolved\": null,\n      \"selection_basis\": \"objective_decomposition\",\n      \"status\": \"in_progress\",\n      \"unblocks\": []\n    },\n    {\n      \"created\": \"2026-05-01\",\n      \"depends_on\": [],\n      \"exhaustive_declaration\": {\n        \"declared\": true,\n        \"justification\": \"Searched 1850 census for Schuylkill County on FamilySearch (indexed and browse), Ancestry (indexed), and MyHeritage (indexed). All three returned the same household. No other Patrick Flynn of matching age found in the county.\",\n        \"log_entry_ids\": [\n          \"log_001\",\n          \"log_002\",\n          \"log_003\"\n        ],\n        \"stop_criteria\": {\n          \"conflict_resolution\": \"No conflicts on the 1850 census placement question.\",\n          \"evidence_class\": \"Yes \u2014 FamilySearch provides original census image with indeterminate-quality information.\",\n          \"goal_alignment\": \"Yes \u2014 Patrick Flynn located in a specific 1850 household, answering the question.\",\n          \"independent_verification\": \"FamilySearch (original) and Ancestry (derivative) both return the same household. Two access paths, one underlying original.\",\n          \"original_substitution\": \"FamilySearch provides the original census image; Ancestry index is derivative but confirmed consistent.\",\n          \"overturn_risk\": \"Low \u2014 all three repositories agree, and no competing Patrick Flynn of matching age exists in the county.\",\n          \"repository_breadth\": \"Three major repositories searched (FamilySearch, Ancestry, MyHeritage). No additional known indexes of the 1850 Schuylkill County census exist.\"\n        }\n      },\n      \"id\": \"q_002\",\n      \"priority\": \"high\",\n      \"question\": \"Where was Patrick Flynn in the 1850 census?\",\n      \"rationale\": \"The 1850 census is the earliest enumeration where Patrick would appear by name (age ~5). Locating him in a household identifies candidate parents.\",\n      \"resolution_assertion_ids\": [\n        \"a_001\",\n        \"a_002\",\n        \"a_003\"\n      ],\n      \"resolved\": \"2026-05-02\",\n      \"selection_basis\": \"objective_decomposition\",\n      \"status\": \"resolved\",\n      \"unblocks\": [\n        \"q_001\"\n      ]\n    }\n  ],\n  \"sources\": [\n    {\n      \"access_date\": \"2026-05-01\",\n      \"citation\": \"1850 U.S. Census, Schuylkill County, Pennsylvania, population schedule, dwelling 84, family 91, Thomas Flynn household; NARA microfilm publication M432, roll 810; digital image, FamilySearch.org, accessed 1 May 2026.\",\n      \"citation_detail\": {\n        \"what\": \"1850 U.S. Federal Census, population schedule\",\n        \"when_accessed\": \"2026-05-01\",\n        \"when_created\": \"1850\",\n        \"where\": \"FamilySearch.org (NARA microfilm M432, roll 810)\",\n        \"where_within\": \"Schuylkill County, dwelling 84, family 91\",\n        \"who\": \"U.S. Census Bureau\"\n      },\n      \"gedcomx_source_description_id\": \"S1\",\n      \"id\": \"src_001\",\n      \"log_entry_id\": \"log_001\",\n      \"notes\": \"Image quality good. Enumerator handwriting clear.\",\n      \"repository\": \"FamilySearch\",\n      \"source_classification\": \"original\",\n      \"url\": \"https://www.familysearch.org/ark:/61903/1:1:MXYZ\",\n      \"url_archived\": null\n    },\n    {\n      \"access_date\": \"2026-05-01\",\n      \"citation\": \"1850 U.S. Census, Schuylkill County, Pennsylvania, population schedule, dwelling 84, Thomas Flynn household; digital image, Ancestry.com, accessed 1 May 2026.\",\n      \"citation_detail\": {\n        \"what\": \"1850 U.S. Federal Census, population schedule (Ancestry index)\",\n        \"when_accessed\": \"2026-05-01\",\n        \"when_created\": \"1850\",\n        \"where\": \"Ancestry.com\",\n        \"where_within\": \"Schuylkill County, dwelling 84\",\n        \"who\": \"U.S. Census Bureau\"\n      },\n      \"gedcomx_source_description_id\": \"S1\",\n      \"id\": \"src_002\",\n      \"log_entry_id\": \"log_002\",\n      \"notes\": \"Ancestry's index of the same original census. Transcription consistent with FamilySearch.\",\n      \"repository\": \"Ancestry\",\n      \"source_classification\": \"derivative\",\n      \"url\": null,\n      \"url_archived\": null\n    },\n    {\n      \"access_date\": \"2026-05-02\",\n      \"citation\": \"1860 U.S. Census, Schuylkill County, Pennsylvania, population schedule, dwelling 112, family 119, Thomas Flynn household; NARA microfilm publication M653, roll 1141; digital image, FamilySearch.org, accessed 2 May 2026.\",\n      \"citation_detail\": {\n        \"what\": \"1860 U.S. Federal Census, population schedule\",\n        \"when_accessed\": \"2026-05-02\",\n        \"when_created\": \"1860\",\n        \"where\": \"FamilySearch.org (NARA microfilm M653, roll 1141)\",\n        \"where_within\": \"Schuylkill County, dwelling 112, family 119\",\n        \"who\": \"U.S. Census Bureau\"\n      },\n      \"gedcomx_source_description_id\": \"S2\",\n      \"id\": \"src_003\",\n      \"log_entry_id\": \"log_004\",\n      \"notes\": null,\n      \"repository\": \"FamilySearch\",\n      \"source_classification\": \"original\",\n      \"url\": \"https://www.familysearch.org/ark:/61903/1:1:MABC\",\n      \"url_archived\": null\n    },\n    {\n      \"access_date\": \"2026-05-03\",\n      \"citation\": \"Pennsylvania Department of Health, death certificate no. 4521 (1908), Patrick Flynn; Pennsylvania State Archives, Harrisburg; digital image, FamilySearch.org, accessed 3 May 2026.\",\n      \"citation_detail\": {\n        \"what\": \"Death certificate no. 4521\",\n        \"when_accessed\": \"2026-05-03\",\n        \"when_created\": \"1908-03-14\",\n        \"where\": \"FamilySearch.org (Pennsylvania State Archives, Harrisburg)\",\n        \"where_within\": \"Certificate no. 4521\",\n        \"who\": \"Pennsylvania Department of Health; informant: James Brown (son-in-law)\"\n      },\n      \"gedcomx_source_description_id\": \"S3\",\n      \"id\": \"src_004\",\n      \"log_entry_id\": \"log_005\",\n      \"notes\": \"Informant is son-in-law James Brown. Primary for death facts, secondary for birth facts.\",\n      \"repository\": \"FamilySearch\",\n      \"source_classification\": \"original\",\n      \"url\": \"https://www.familysearch.org/ark:/61903/1:1:MDEF\",\n      \"url_archived\": null\n    },\n    {\n      \"access_date\": \"2026-05-10\",\n      \"citation\": \"St. Mary's Catholic Church, Pottsville, baptism of Patrick Flynn, 1845\",\n      \"citation_detail\": {\n        \"what\": \"Baptismal register, 1845\",\n        \"when_accessed\": \"2026-05-10\",\n        \"when_created\": \"1845\",\n        \"where\": \"FamilySearch.org\",\n        \"where_within\": \"Patrick Flynn entry\",\n        \"who\": \"St. Mary's Catholic Church, Pottsville\"\n      },\n      \"gedcomx_source_description_id\": \"S5\",\n      \"id\": \"src_005\",\n      \"log_entry_id\": null,\n      \"notes\": \"Rough working citation from record-extraction. Missing volume/page locator and full repository chain.\",\n      \"repository\": \"FamilySearch\",\n      \"source_classification\": \"original\",\n      \"url\": \"https://www.familysearch.org/ark:/61903/3:1:S3HT-D1MQ-NZH\",\n      \"url_archived\": null\n    },\n    {\n      \"access_date\": \"2026-05-10\",\n      \"citation\": \"Schuylkill County will of Thomas Flynn, 1881\",\n      \"citation_detail\": {\n        \"what\": \"Will of Thomas Flynn\",\n        \"when_accessed\": \"2026-05-10\",\n        \"when_created\": \"1881\",\n        \"where\": \"FamilySearch.org\",\n        \"where_within\": \"will of Thomas Flynn\",\n        \"who\": \"Schuylkill County Courthouse\"\n      },\n      \"gedcomx_source_description_id\": \"S4\",\n      \"id\": \"src_006\",\n      \"log_entry_id\": null,\n      \"notes\": \"Rough working citation from record-extraction. Creator should be the court, not the courthouse. Missing Will Book volume and page locator.\",\n      \"repository\": \"FamilySearch\",\n      \"source_classification\": \"original\",\n      \"url\": \"https://www.familysearch.org/ark:/61903/3:1:3Q9M-CS4V-7TXW\",\n      \"url_archived\": null\n    },\n    {\n      \"access_date\": \"2026-05-12\",\n      \"citation\": \"PA birth certificate, Mary Elizabeth Flynn, 1905\",\n      \"citation_detail\": {\n        \"what\": \"Birth certificate\",\n        \"when_accessed\": \"2026-05-12\",\n        \"when_created\": \"1905\",\n        \"where\": \"FamilySearch.org\",\n        \"where_within\": \"Mary Elizabeth Flynn entry\",\n        \"who\": \"FamilySearch\"\n      },\n      \"gedcomx_source_description_id\": \"S6\",\n      \"id\": \"src_007\",\n      \"log_entry_id\": null,\n      \"notes\": \"Rough working citation from record-extraction. who wrongly names the repository; missing certificate number (12455), birth date, and place.\",\n      \"repository\": \"FamilySearch\",\n      \"source_classification\": \"original\",\n      \"url\": \"https://www.familysearch.org/ark:/61903/1:1:6JZX-VKQM\",\n      \"url_archived\": null\n    },\n    {\n      \"access_date\": \"2026-05-12\",\n      \"citation\": \"Deed, Thomas Flynn to Patrick Flynn, 1881\",\n      \"citation_detail\": {\n        \"what\": \"Warranty deed\",\n        \"when_accessed\": \"2026-05-12\",\n        \"when_created\": \"1881\",\n        \"where\": \"FamilySearch.org\",\n        \"where_within\": \"Thomas Flynn to Patrick Flynn\",\n        \"who\": \"Schuylkill County Courthouse\"\n      },\n      \"gedcomx_source_description_id\": \"S7\",\n      \"id\": \"src_008\",\n      \"log_entry_id\": null,\n      \"notes\": \"Rough working citation from record-extraction. who should be the Recorder of Deeds (not the courthouse building); missing grantor/grantee, execution + recording dates, and Deed Book/page locator.\",\n      \"repository\": \"FamilySearch\",\n      \"source_classification\": \"original\",\n      \"url\": \"https://www.familysearch.org/ark:/61903/3:1:3QS7-89WF-9KCT\",\n      \"url_archived\": null\n    },\n    {\n      \"access_date\": \"2026-05-12\",\n      \"citation\": \"Patrick Flynn obituary, Pottsville Republican, 1908\",\n      \"citation_detail\": {\n        \"what\": \"Obituary\",\n        \"when_accessed\": \"2026-05-12\",\n        \"when_created\": \"1908\",\n        \"where\": \"FamilySearch.org\",\n        \"where_within\": \"obituary notice\",\n        \"who\": \"FamilySearch\"\n      },\n      \"gedcomx_source_description_id\": \"S8\",\n      \"id\": \"src_009\",\n      \"log_entry_id\": null,\n      \"notes\": \"Rough working citation from record-extraction. who wrongly names the repository; missing the quoted article title, exact publication date, page, and column number.\",\n      \"repository\": \"FamilySearch\",\n      \"source_classification\": \"original\",\n      \"url\": \"https://www.familysearch.org/ark:/61903/3:1:S3HY-6RKS-MGV\",\n      \"url_archived\": null\n    }\n  ],\n  \"timelines\": [\n    {\n      \"events\": [\n        {\n          \"assertion_ids\": [\n            \"a_002\",\n            \"a_009\"\n          ],\n          \"date\": \"~1845\",\n          \"date_certainty\": \"estimated\",\n          \"description\": \"Born in Ireland, estimated from census ages\",\n          \"event_type\": \"birth\",\n          \"place\": \"Ireland\"\n        },\n        {\n          \"assertion_ids\": [\n            \"a_003\",\n            \"a_004\"\n          ],\n          \"date\": \"1850\",\n          \"date_certainty\": \"exact\",\n          \"description\": \"Enumerated age 5 in Thomas Flynn household, dwelling 84\",\n          \"event_type\": \"census\",\n          \"place\": \"Schuylkill County, Pennsylvania\"\n        },\n        {\n          \"assertion_ids\": [\n            \"a_008\",\n            \"a_009\",\n            \"a_010\"\n          ],\n          \"date\": \"1860\",\n          \"date_certainty\": \"exact\",\n          \"description\": \"Enumerated age 15 in Thomas Flynn household, dwelling 112\",\n          \"event_type\": \"census\",\n          \"place\": \"Schuylkill County, Pennsylvania\"\n        },\n        {\n          \"assertion_ids\": [\n            \"a_011\",\n            \"a_013\"\n          ],\n          \"date\": \"1908-03-12\",\n          \"date_certainty\": \"exact\",\n          \"description\": \"Died, death certificate names Thomas Flynn as father\",\n          \"event_type\": \"death\",\n          \"place\": \"Schuylkill County, Pennsylvania\"\n        }\n      ],\n      \"gaps\": [\n        {\n          \"end\": \"1908-03-12\",\n          \"expected_events\": [\n            \"marriage\",\n            \"1870_census\",\n            \"1880_census\",\n            \"1900_census\",\n            \"residence\",\n            \"occupation\"\n          ],\n          \"severity\": \"high\",\n          \"start\": \"1860-01-01\"\n        }\n      ],\n      \"generated\": \"2026-05-03T12:00:00Z\",\n      \"hypothesis_id\": \"h_001\",\n      \"id\": \"t_001\",\n      \"impossibilities\": [],\n      \"label\": \"Patrick Flynn \u2014 assuming Thomas Flynn parentage\",\n      \"person_ids\": [\n        \"I1\"\n      ]\n    }\n  ]\n}\n",
+    "eval/fixtures/scenarios/mid-research-flynn/tree.gedcomx.json": "{\n  \"persons\": [\n    {\n      \"facts\": [\n        {\n          \"date\": \"~1845\",\n          \"id\": \"F1\",\n          \"place\": \"Ireland\",\n          \"primary\": true,\n          \"sources\": [\n            {\n              \"page\": \"1850 Census, Schuylkill Co., dwelling 84\",\n              \"ref\": \"S1\"\n            }\n          ],\n          \"type\": \"Birth\"\n        },\n        {\n          \"date\": \"1908-03-12\",\n          \"id\": \"F2\",\n          \"place\": \"Schuylkill County, Pennsylvania\",\n          \"sources\": [\n            {\n              \"page\": \"Death cert. no. 4521\",\n              \"ref\": \"S3\"\n            }\n          ],\n          \"type\": \"Death\"\n        }\n      ],\n      \"gender\": \"Male\",\n      \"id\": \"I1\",\n      \"names\": [\n        {\n          \"given\": \"Patrick\",\n          \"id\": \"N1\",\n          \"preferred\": true,\n          \"surname\": \"Flynn\",\n          \"type\": \"BirthName\"\n        }\n      ]\n    },\n    {\n      \"facts\": [\n        {\n          \"date\": \"~1818\",\n          \"id\": \"F3\",\n          \"place\": \"Ireland\",\n          \"primary\": true,\n          \"type\": \"Birth\"\n        }\n      ],\n      \"gender\": \"Male\",\n      \"id\": \"I2\",\n      \"names\": [\n        {\n          \"given\": \"Thomas\",\n          \"id\": \"N2\",\n          \"preferred\": true,\n          \"surname\": \"Flynn\",\n          \"type\": \"BirthName\"\n        }\n      ]\n    },\n    {\n      \"gender\": \"Female\",\n      \"id\": \"I3\",\n      \"names\": [\n        {\n          \"given\": \"Mary\",\n          \"id\": \"N3\",\n          \"preferred\": true,\n          \"surname\": \"Flynn\",\n          \"type\": \"BirthName\"\n        }\n      ]\n    },\n    {\n      \"gender\": \"Male\",\n      \"id\": \"I4\",\n      \"names\": [\n        {\n          \"given\": \"James\",\n          \"id\": \"N4\",\n          \"preferred\": true,\n          \"surname\": \"Flynn\",\n          \"type\": \"BirthName\"\n        }\n      ]\n    }\n  ],\n  \"relationships\": [\n    {\n      \"child\": \"I1\",\n      \"id\": \"R1\",\n      \"parent\": \"I2\",\n      \"sources\": [\n        {\n          \"page\": \"1850 Census, Schuylkill Co., dwelling 84\",\n          \"quality\": 2,\n          \"ref\": \"S1\"\n        },\n        {\n          \"page\": \"1860 Census, Schuylkill Co., dwelling 112\",\n          \"quality\": 2,\n          \"ref\": \"S2\"\n        },\n        {\n          \"page\": \"Death cert. no. 4521\",\n          \"quality\": 2,\n          \"ref\": \"S3\"\n        }\n      ],\n      \"type\": \"ParentChild\"\n    },\n    {\n      \"child\": \"I3\",\n      \"id\": \"R2\",\n      \"parent\": \"I2\",\n      \"sources\": [\n        {\n          \"page\": \"1850 Census, Schuylkill Co., dwelling 84\",\n          \"quality\": 2,\n          \"ref\": \"S1\"\n        }\n      ],\n      \"type\": \"ParentChild\"\n    },\n    {\n      \"child\": \"I4\",\n      \"id\": \"R3\",\n      \"parent\": \"I2\",\n      \"sources\": [\n        {\n          \"page\": \"1850 Census, Schuylkill Co., dwelling 84\",\n          \"quality\": 2,\n          \"ref\": \"S1\"\n        }\n      ],\n      \"type\": \"ParentChild\"\n    }\n  ],\n  \"sources\": [\n    {\n      \"author\": \"U.S. Census Bureau\",\n      \"id\": \"S1\",\n      \"title\": \"1850 U.S. Federal Census\"\n    },\n    {\n      \"author\": \"U.S. Census Bureau\",\n      \"id\": \"S2\",\n      \"title\": \"1860 U.S. Federal Census\"\n    },\n    {\n      \"author\": \"Pennsylvania Department of Health\",\n      \"id\": \"S3\",\n      \"title\": \"Pennsylvania Death Certificates\"\n    },\n    {\n      \"author\": \"Schuylkill County Register of Wills\",\n      \"id\": \"S4\",\n      \"title\": \"Schuylkill County Probate Records\"\n    },\n    {\n      \"author\": \"St. Mary's Catholic Church, Pottsville\",\n      \"id\": \"S5\",\n      \"title\": \"St. Mary's Catholic Church (Pottsville) Baptismal Registers\"\n    },\n    {\n      \"author\": \"Pennsylvania Department of Health\",\n      \"id\": \"S6\",\n      \"title\": \"Pennsylvania Birth Certificates\"\n    },\n    {\n      \"author\": \"Schuylkill County Recorder of Deeds\",\n      \"id\": \"S7\",\n      \"title\": \"Schuylkill County Deed Books\"\n    },\n    {\n      \"author\": \"Pottsville Republican\",\n      \"id\": \"S8\",\n      \"title\": \"Pottsville Republican (newspaper)\"\n    }\n  ]\n}\n",
+    "eval/fixtures/mcp/person-quality-hole-christian.json": "{\n  \"args\": {\n    \"personId\": \"KD96-TV2\"\n  },\n  \"description\": \"person_quality on Christian P. Hole (KD96-TV2) -- the real captured FamilySearch response (Polk Co., Minnesota): overall 0.97 with 7 completeness/verifiability issues (burial missing a date, marriage place missing a city, 5 untagged residences). Used by ut_check_warnings_014 and _015.\",\n  \"response\": {\n    \"categories\": [\n      {\n        \"count\": 2,\n        \"score\": 0.9111111111111111,\n        \"scoreType\": \"COMPLETENESS\"\n      },\n      {\n        \"count\": 5,\n        \"score\": 1,\n        \"scoreType\": \"VERIFIABILITY\"\n      },\n      {\n        \"count\": 0,\n        \"score\": 1,\n        \"scoreType\": \"CONSISTENCY\"\n      },\n      {\n        \"count\": 0,\n        \"score\": 1,\n        \"scoreType\": \"COHERENCE\"\n      }\n    ],\n    \"issueCount\": 7,\n    \"issues\": [\n      {\n        \"conclusionId\": \"d57d443f-d206-44d6-b795-929f74989a17\",\n        \"conclusionType\": \"BURIAL\",\n        \"scoreType\": \"COMPLETENESS\",\n        \"sentence\": \"The burial date is missing.\"\n      },\n      {\n        \"conclusionId\": \"5ced6592-c1b2-44cd-b99f-6b3f21f3d8ec\",\n        \"conclusionType\": \"MARRIAGE\",\n        \"scoreType\": \"COMPLETENESS\",\n        \"sentence\": \"A marriage place is missing a city.\"\n      },\n      {\n        \"conclusionId\": \"e77ececa-810e-4d86-b94d-de371491b97a\",\n        \"conclusionType\": \"RESIDENCE\",\n        \"scoreType\": \"VERIFIABILITY\",\n        \"sentence\": \"A residence has no tagged sources.\"\n      },\n      {\n        \"conclusionId\": \"4f7dd02e-5143-4902-be1e-484ea5821e75\",\n        \"conclusionType\": \"RESIDENCE\",\n        \"scoreType\": \"VERIFIABILITY\",\n        \"sentence\": \"A residence has no tagged sources.\"\n      },\n      {\n        \"conclusionId\": \"ee1e7dbc-81a0-4798-8362-6b57892083d1\",\n        \"conclusionType\": \"RESIDENCE\",\n        \"scoreType\": \"VERIFIABILITY\",\n        \"sentence\": \"A residence has no tagged sources.\"\n      },\n      {\n        \"conclusionId\": \"004a5ddb-dea2-48a4-8416-ed5ce5b59e64\",\n        \"conclusionType\": \"RESIDENCE\",\n        \"scoreType\": \"VERIFIABILITY\",\n        \"sentence\": \"A residence has no tagged sources.\"\n      },\n      {\n        \"conclusionId\": \"8d05ee64-8b61-4a3a-9669-efcb17085ab9\",\n        \"conclusionType\": \"RESIDENCE\",\n        \"scoreType\": \"VERIFIABILITY\",\n        \"sentence\": \"A residence has no tagged sources.\"\n      }\n    ],\n    \"overallScore\": 0.9703703703703703,\n    \"personId\": \"KD96-TV2\",\n    \"segment\": \"Norway 1816 - 1920\"\n  },\n  \"tool\": \"person_quality\"\n}\n",
+    "eval/fixtures/mcp/person-quality-hole-deleted.json": "{\n  \"args\": {\n    \"personId\": \"KD96-TV5\"\n  },\n  \"description\": \"person_quality on KD96-TV5 -- a duplicate of the son that was DELETED on FamilySearch after this project last synced. The tool surfaces the tombstoned state as an error object. The skill must note this in the quality section and still report the offline warnings. Used by ut_check_warnings_017.\",\n  \"response\": {\n    \"error\": \"Person KD96-TV5 is tombstoned in the FamilySearch tree \u2014 it has been deleted or merged into another profile \u2014 so it has no quality score.\"\n  },\n  \"tool\": \"person_quality\"\n}\n",
+    "eval/fixtures/mcp/person-quality-hole-son.json": "{\n  \"args\": {\n    \"personId\": \"KD96-TV4\"\n  },\n  \"description\": \"person_quality on Ole C. Hole (KD96-TV4) -- 2 completeness issues (missing burial date, marriage place missing a city). Paired with a person_warnings fixture that fires hasEventAfterDeath1, so both the impossibility and the quality issues are present at once. Used by ut_check_warnings_015.\",\n  \"response\": {\n    \"categories\": [\n      {\n        \"count\": 1,\n        \"score\": 0.9,\n        \"scoreType\": \"COMPLETENESS\"\n      },\n      {\n        \"count\": 1,\n        \"score\": 0.95,\n        \"scoreType\": \"VERIFIABILITY\"\n      },\n      {\n        \"count\": 0,\n        \"score\": 1,\n        \"scoreType\": \"CONSISTENCY\"\n      },\n      {\n        \"count\": 0,\n        \"score\": 1,\n        \"scoreType\": \"COHERENCE\"\n      }\n    ],\n    \"issueCount\": 2,\n    \"issues\": [\n      {\n        \"conclusionId\": \"b1a2c3d4-0001-4a00-9000-000000000001\",\n        \"conclusionType\": \"DEATH\",\n        \"scoreType\": \"COMPLETENESS\",\n        \"sentence\": \"The death place is missing a city.\"\n      },\n      {\n        \"conclusionId\": \"b1a2c3d4-0002-4a00-9000-000000000002\",\n        \"conclusionType\": \"RESIDENCE\",\n        \"scoreType\": \"VERIFIABILITY\",\n        \"sentence\": \"A residence has no tagged sources.\"\n      }\n    ],\n    \"overallScore\": 0.94,\n    \"personId\": \"KD96-TV4\",\n    \"segment\": \"Norway 1816 - 1920\"\n  },\n  \"tool\": \"person_quality\"\n}\n",
+    "eval/fixtures/mcp/person-quality-hole-wife-clean.json": "{\n  \"args\": {\n    \"personId\": \"KD96-TV3\"\n  },\n  \"description\": \"person_quality on Inger Hole (KD96-TV3) -- a fully-sourced, clean profile: overall 1.0, no issues. Exercises the empty-quality (issueCount 0) reporting path. Used by ut_check_warnings_016.\",\n  \"response\": {\n    \"categories\": [\n      {\n        \"count\": 0,\n        \"score\": 1,\n        \"scoreType\": \"COMPLETENESS\"\n      },\n      {\n        \"count\": 0,\n        \"score\": 1,\n        \"scoreType\": \"VERIFIABILITY\"\n      },\n      {\n        \"count\": 0,\n        \"score\": 1,\n        \"scoreType\": \"CONSISTENCY\"\n      },\n      {\n        \"count\": 0,\n        \"score\": 1,\n        \"scoreType\": \"COHERENCE\"\n      }\n    ],\n    \"issueCount\": 0,\n    \"issues\": [],\n    \"overallScore\": 1,\n    \"personId\": \"KD96-TV3\",\n    \"segment\": \"Norway 1816 - 1920\"\n  },\n  \"tool\": \"person_quality\"\n}\n",
+    "eval/fixtures/mcp/person-warnings-cluster.json": "{\n  \"args\": {\n    \"personId\": \"I1\"\n  },\n  \"description\": \"person_warnings on Patrick (I1) returns 4 warnings: 3 on Patrick himself (hasEventAfterDeath1 error + hasAgeRangeGreaterThan120 error + tooManyDeathDates2 warning) and 1 on his relative Thomas (relativesHasAgeRangeGreaterThan120 error on I2). Multi-warning cluster exercising the 'almost certainly two people merged' escalation rule AND the focal-vs-relative separation requirement: the cluster verdict applies only to Patrick's three warnings, not to all four indiscriminately. Used by ut_check_warnings_009.\",\n  \"response\": {\n    \"warningCount\": 4,\n    \"warnings\": [\n      {\n        \"factIds\": [\n          \"F1\",\n          \"F2\"\n        ],\n        \"issueType\": \"hasEventAfterDeath1\",\n        \"message\": \"An event is dated more than 1 year after this person's latest death-like fact.\",\n        \"personId\": \"I1\",\n        \"personName\": \"Patrick Flynn\",\n        \"scoreType\": \"COHERENCE\",\n        \"severity\": \"error\"\n      },\n      {\n        \"factIds\": [\n          \"F1\",\n          \"F2\"\n        ],\n        \"issueType\": \"hasAgeRangeGreaterThan120\",\n        \"message\": \"This person's lifespan is greater than 120 years, which is implausible.\",\n        \"personId\": \"I1\",\n        \"personName\": \"Patrick Flynn\",\n        \"scoreType\": \"COHERENCE\",\n        \"severity\": \"error\"\n      },\n      {\n        \"factIds\": [\n          \"F2\"\n        ],\n        \"issueType\": \"tooManyDeathDates2\",\n        \"message\": \"Two or more distinct perfect-DMY death dates spaced more than 14 days apart, suggesting unreconciled death records.\",\n        \"personId\": \"I1\",\n        \"personName\": \"Patrick Flynn\",\n        \"scoreType\": \"COHERENCE\",\n        \"severity\": \"warning\"\n      },\n      {\n        \"factIds\": [\n          \"F3\"\n        ],\n        \"issueType\": \"relativesHasAgeRangeGreaterThan120\",\n        \"message\": \"This relative's lifespan is greater than 120 years, which is implausible.\",\n        \"personId\": \"I2\",\n        \"personName\": \"Thomas Flynn\",\n        \"relatedPersonId\": \"I2\",\n        \"scoreType\": \"COHERENCE\",\n        \"severity\": \"error\"\n      }\n    ]\n  },\n  \"tool\": \"person_warnings\"\n}\n",
+    "eval/fixtures/mcp/person-warnings-early-marriage.json": "{\n  \"args\": {\n    \"personId\": \"I1\"\n  },\n  \"description\": \"person_warnings on Patrick (I1) returns hasEarlyMarriage14 -- earliest marriage year is less than 14 years after earliest birth year. Valid (not Fundamental) violation, severity: 'warning'. Used by ut_check_warnings_007 to exercise the severity classification rubric.\",\n  \"response\": {\n    \"warningCount\": 1,\n    \"warnings\": [\n      {\n        \"factIds\": [\n          \"F1\"\n        ],\n        \"issueType\": \"hasEarlyMarriage14\",\n        \"message\": \"This person was married before age 14, which is biologically and socially unusual.\",\n        \"personId\": \"I1\",\n        \"personName\": \"Patrick Flynn\",\n        \"scoreType\": \"COHERENCE\",\n        \"severity\": \"warning\"\n      }\n    ]\n  },\n  \"tool\": \"person_warnings\"\n}\n",
+    "eval/fixtures/mcp/person-warnings-empty-stub.json": "{\n  \"args\": {\n    \"personId\": \"I1\"\n  },\n  \"description\": \"person_warnings on Patrick (I1) returns missingFactsAndRelatives -- an empty stub record with no facts (other than perhaps GenderChange) and no relatives. Severity: 'warning'. Used by ut_check_warnings_010 (the 'limited data' edge case).\",\n  \"response\": {\n    \"warningCount\": 1,\n    \"warnings\": [\n      {\n        \"issueType\": \"missingFactsAndRelatives\",\n        \"message\": \"This person has no recorded facts (other than GenderChange) and no relatives -- an empty stub record.\",\n        \"personId\": \"I1\",\n        \"personName\": \"Patrick Flynn\",\n        \"scoreType\": \"COHERENCE\",\n        \"severity\": \"warning\"\n      }\n    ]\n  },\n  \"tool\": \"person_warnings\"\n}\n",
+    "eval/fixtures/mcp/person-warnings-event-after-death.json": "{\n  \"args\": {\n    \"personId\": \"I1\"\n  },\n  \"description\": \"person_warnings on Patrick (I1) returns hasEventAfterDeath1 -- flagship Fundamental violation (event dated more than 1 year after Patrick's recorded death). Used by ut_check_warnings_004.\",\n  \"response\": {\n    \"warningCount\": 1,\n    \"warnings\": [\n      {\n        \"factIds\": [\n          \"F1\",\n          \"F2\"\n        ],\n        \"issueType\": \"hasEventAfterDeath1\",\n        \"message\": \"An event is dated more than 1 year after this person's latest death-like fact.\",\n        \"personId\": \"I1\",\n        \"personName\": \"Patrick Flynn\",\n        \"scoreType\": \"COHERENCE\",\n        \"severity\": \"error\"\n      }\n    ]\n  },\n  \"tool\": \"person_warnings\"\n}\n",
+    "eval/fixtures/mcp/person-warnings-father-died-before-child.json": "{\n  \"args\": {\n    \"personId\": \"I2\"\n  },\n  \"description\": \"person_warnings on Thomas (I2) returns hasDeathBeforeChildBirth30_10 -- male-gendered Fundamental check: Thomas's death is more than 300 days before Patrick's birth, biologically impossible for a father. The brief's flagship example. Used by ut_check_warnings_005.\",\n  \"response\": {\n    \"warningCount\": 1,\n    \"warnings\": [\n      {\n        \"factIds\": [\n          \"F1\"\n        ],\n        \"issueType\": \"hasDeathBeforeChildBirth30_10\",\n        \"message\": \"This person (male) died more than 300 days before a child's earliest birth-like fact, which is biologically impossible.\",\n        \"personId\": \"I2\",\n        \"personName\": \"Thomas Flynn\",\n        \"relatedPersonId\": \"I1\",\n        \"scoreType\": \"COHERENCE\",\n        \"severity\": \"error\"\n      }\n    ]\n  },\n  \"tool\": \"person_warnings\"\n}\n",
+    "eval/fixtures/mcp/person-warnings-hole-christian-none.json": "{\n  \"args\": {\n    \"personId\": \"KD96-TV2\"\n  },\n  \"description\": \"person_warnings on Christian P. Hole (KD96-TV2) -- no impossibilities in the local tree (his issues are completeness/sourcing, surfaced by person_quality, not logical impossibilities). Used by ut_check_warnings_014.\",\n  \"response\": {\n    \"warningCount\": 0,\n    \"warnings\": []\n  },\n  \"tool\": \"person_warnings\"\n}\n",
+    "eval/fixtures/mcp/person-warnings-hole-deleted-none.json": "{\n  \"args\": {\n    \"personId\": \"KD96-TV5\"\n  },\n  \"description\": \"person_warnings on KD96-TV5 (deleted duplicate, local stub) -- no impossibilities. The point of the test is that the offline warnings still run while person_quality returns tombstoned. Used by ut_check_warnings_017.\",\n  \"response\": {\n    \"warningCount\": 0,\n    \"warnings\": []\n  },\n  \"tool\": \"person_warnings\"\n}\n",
+    "eval/fixtures/mcp/person-warnings-hole-son-event-after-death.json": "{\n  \"args\": {\n    \"personId\": \"KD96-TV4\"\n  },\n  \"description\": \"person_warnings on Ole C. Hole (KD96-TV4) -- fires hasEventAfterDeath1 (a 1975 Residence recorded after his 1960 death). Paired with the son's quality fixture so warnings AND quality both have content. Used by ut_check_warnings_015.\",\n  \"response\": {\n    \"warningCount\": 1,\n    \"warnings\": [\n      {\n        \"factIds\": [\n          \"F13\",\n          \"F14\",\n          \"F15\"\n        ],\n        \"issueType\": \"hasEventAfterDeath1\",\n        \"message\": \"An event is dated more than 1 year after this person's latest death-like fact.\",\n        \"personId\": \"KD96-TV4\",\n        \"personName\": \"Ole C. Hole\",\n        \"scoreType\": \"COHERENCE\",\n        \"severity\": \"error\"\n      }\n    ]\n  },\n  \"tool\": \"person_warnings\"\n}\n",
+    "eval/fixtures/mcp/person-warnings-hole-wife-none.json": "{\n  \"args\": {\n    \"personId\": \"KD96-TV3\"\n  },\n  \"description\": \"person_warnings on Inger Hole (KD96-TV3) -- no warnings. Paired with the clean quality fixture. Used by ut_check_warnings_016.\",\n  \"response\": {\n    \"warningCount\": 0,\n    \"warnings\": []\n  },\n  \"tool\": \"person_warnings\"\n}\n",
+    "eval/fixtures/mcp/person-warnings-impossible-lifespan.json": "{\n  \"args\": {\n    \"personId\": \"I1\"\n  },\n  \"description\": \"person_warnings on Patrick (I1) returns hasAgeRangeGreaterThan120 -- gap between earliest possible birth year and latest possible death year exceeds 120. Used by ut_check_warnings_006 (severity classification dimension).\",\n  \"response\": {\n    \"warningCount\": 1,\n    \"warnings\": [\n      {\n        \"factIds\": [\n          \"F1\",\n          \"F2\"\n        ],\n        \"issueType\": \"hasAgeRangeGreaterThan120\",\n        \"message\": \"This person's lifespan is greater than 120 years, which is implausible.\",\n        \"personId\": \"I1\",\n        \"personName\": \"Patrick Flynn\",\n        \"scoreType\": \"COHERENCE\",\n        \"severity\": \"error\"\n      }\n    ]\n  },\n  \"tool\": \"person_warnings\"\n}\n",
+    "eval/fixtures/mcp/person-warnings-no-warnings.json": "{\n  \"args\": {\n    \"personId\": \"~\"\n  },\n  \"description\": \"person_warnings on a clean, well-formed person returns no warnings. Default fixture for tests that confirm the skill stays quiet when there are no impossibilities. Matches any personId.\",\n  \"response\": {\n    \"warningCount\": 0,\n    \"warnings\": []\n  },\n  \"tool\": \"person_warnings\"\n}\n",
+    "eval/fixtures/mcp/person-warnings-posthumous-residence.json": "{\n  \"args\": {\n    \"personId\": \"I1\"\n  },\n  \"description\": \"person_warnings on Patrick (I1) returns hasEventAfterDeath1 with factIds pointing at F3 -- a Residence fact dated 1925, ~17 years after Patrick's 1908 death. In the flynn-posthumous-residence scenario F3 cites S5, the obituary of his daughter Mary (Flynn) Brennan that names Patrick as her late father and was auto-attached to Patrick as a Residence-style fact. The correct reading is a posthumous mention, not identity confusion. Used by ut_check_warnings_013.\",\n  \"response\": {\n    \"warningCount\": 1,\n    \"warnings\": [\n      {\n        \"factIds\": [\n          \"F1\",\n          \"F2\",\n          \"F3\"\n        ],\n        \"issueType\": \"hasEventAfterDeath1\",\n        \"message\": \"An event is dated more than 1 year after this person's latest death-like fact.\",\n        \"personId\": \"I1\",\n        \"personName\": \"Patrick Flynn\",\n        \"scoreType\": \"COHERENCE\",\n        \"severity\": \"error\"\n      }\n    ]\n  },\n  \"tool\": \"person_warnings\"\n}\n",
+    "eval/fixtures/mcp/person-warnings-relative-warning.json": "{\n  \"args\": {\n    \"personId\": \"I1\"\n  },\n  \"description\": \"person_warnings on Patrick (I1) returns relativesHasAgeRangeGreaterThan120 -- the warning fires because his father Thomas has an implausible lifespan, not Patrick himself. personId in the warning is Thomas's id (I2). Used by ut_check_warnings_008 to test relative-mob handling.\",\n  \"response\": {\n    \"warningCount\": 1,\n    \"warnings\": [\n      {\n        \"factIds\": [\n          \"F3\"\n        ],\n        \"issueType\": \"relativesHasAgeRangeGreaterThan120\",\n        \"message\": \"A relative of this person has a lifespan greater than 120 years, which is implausible.\",\n        \"personId\": \"I2\",\n        \"personName\": \"Thomas Flynn\",\n        \"relatedPersonId\": \"I2\",\n        \"scoreType\": \"COHERENCE\",\n        \"severity\": \"warning\"\n      }\n    ]\n  },\n  \"tool\": \"person_warnings\"\n}\n"
+  },
+  "tests": [
+    {
+      "test_id": "ut_check_warnings_001",
+      "test_type": "positive",
+      "expected_outcome": "pass",
+      "scenario": "mid-research-flynn",
+      "mcp_fixtures": [
+        "person-warnings-no-warnings"
+      ],
+      "outcome": "pass",
+      "flaky": false,
+      "outcome_summary": {
+        "per_run_outcomes": [
+          "pass"
+        ],
+        "aggregated_dimensions": [
+          {
+            "source": "base",
+            "name": "Correctness",
+            "score": 3,
+            "rationale": "The skill correctly identified that Patrick Flynn (I1) is a synthetic ID and appropriately skipped the FamilySearch person_quality call. The response accurately reports that no warnings were found, which matches the tool response showing warningCount: 0. The offline checks are correctly understood to cover lifespan, event sequencing, and age-gap validation."
+          },
+          {
+            "source": "base",
+            "name": "Completeness",
+            "score": 3,
+            "rationale": "The skill fully addressed the user's request to check Patrick Flynn's evidence for impossibilities or warnings. It called the appropriate person_warnings tool with the correct personId (I1), reviewed the zero-warning result, and provided a clear summary of what was checked (lifespans, events after death, burial-before-death, parent/child age gaps)."
+          },
+          {
+            "source": "base",
+            "name": "Tool Arguments",
+            "score": 3,
+            "rationale": "The single MCP call to person_warnings passed the correct personId 'I1' and included projectPath as expected. The call matched the fixture's expected_args predicate and returned successfully (matched.kind = 'predicate'). No fixture_not_found errors occurred."
+          },
+          {
+            "source": "rubric",
+            "name": "Detection accuracy",
+            "score": 3,
+            "rationale": "The skill reported zero warnings from the person_warnings tool, which correctly reflects the test scenario: Patrick's timeline is consistent (birth ~1845, age 5 in 1850, age 15 in 1860, died 1908), with no chronological impossibilities or implausible age gaps. The tool's detection of genuine impossibilities while avoiding false positives on valid edge cases is confirmed by the clean result."
+          },
+          {
+            "source": "rubric",
+            "name": "Severity classification",
+            "score": 3,
+            "rationale": "No warnings were found, so severity classification is not applicable in this case. The skill correctly reported the absence of warnings rather than inventing severity tiers. This is the expected outcome for a clean project."
+          },
+          {
+            "source": "rubric",
+            "name": "Actionability",
+            "score": 3,
+            "rationale": "No warnings were detected, so there are no actionability requirements. The skill correctly reported a clean result without generating spurious or vague warnings. Per the rubric, when no warnings are found, actionability is moot."
+          },
+          {
+            "source": "rubric",
+            "name": "FamilySearch quality reporting",
+            "score": 3,
+            "rationale": "The skill correctly identified that Patrick Flynn (I1) is a synthetic ID and appropriately skipped the person_quality call. It did not make an unnecessary quality call on a synthetic person, and did not suppress the person_warnings result. This handling aligns with the rubric's requirement that quality calls apply only to FamilySearch IDs."
+          }
+        ]
+      },
+      "totals": {
+        "duration_ms": 28690.748833992984,
+        "duration_api_ms": 28640.0,
+        "judge_duration_ms": 6853.300333023071,
+        "wall_clock_ms": 35603.35302352905,
+        "num_turns": 9,
+        "input_tokens": 13,
+        "cached_input_tokens": 84731,
+        "output_tokens": 1183,
+        "judge_input_tokens": 4611,
+        "judge_cached_input_tokens": 0,
+        "judge_output_tokens": 774,
+        "skill_cost_usd": 0.0796308,
+        "judge_cost_usd": 0.008480999999999999,
+        "total_cost_usd": 0.0881118
+      },
+      "runs": [
+        {
+          "run_index": 0,
+          "run_id": "run_ut_check_warnings_001_2026-07-05_16-35-38_0",
+          "outcome": "pass",
+          "aborted_reason": null,
+          "duration_ms": 28690.748833992984,
+          "duration_api_ms": 28640.0,
+          "num_turns": 9,
+          "skill_attempts": 1,
+          "input_tokens": 13,
+          "cached_input_tokens": 84731,
+          "output_tokens": 1183,
+          "skill_cost_usd": 0.0796308,
+          "output": {
+            "text_response": "Patrick Flynn is person `I1` \u2014 a synthetic ID, so I'll run the offline `person_warnings` check only (no FamilySearch quality call applies).No genealogical warnings found for Patrick Flynn (I1). All of the tool's offline checks passed \u2014 no impossible lifespans, no events after death, no burial-before-death issues, and no implausible parent/child age gaps in his immediate family relationships.",
+            "activated": true,
+            "skills_invoked": [
+              "check-warnings"
+            ],
+            "tool_calls": [
+              {
+                "tool": "mcp__genealogy__person_warnings",
+                "args": {
+                  "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/eval-ut_check_warnings_001-0-0-3qe7z_4q",
+                  "personId": "I1"
+                },
+                "expected_args": {
+                  "personId": "~"
+                },
+                "matched": {
+                  "kind": "predicate",
+                  "index": 0
+                },
+                "response_fixture": "person-warnings-no-warnings"
+              }
+            ],
+            "files_created": [],
+            "warnings": [
+              {
+                "kind": "missing_tool_usage_dimension",
+                "advisory": "Skill called MCP tools but the rubric has no dimension name suggesting tool-usage coverage (matched against keywords: ['tool usage', 'tool use', 'tool work', 'tool call', 'argument quality', 'argument-quality', 'response interpretation', 'tool selection', 'mcp tool', 'fixture']). The judge will grade other dimensions but won't score tool work explicitly. Consider adding a tool-usage dimension or renaming an existing one."
+              }
+            ]
+          },
+          "validators": {
+            "passed": true,
+            "results": [
+              {
+                "name": "test_id_references_resolve",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_log_append_only",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_entries_deleted",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_research_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tool_allowlist",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_gedcomx_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_research_json_unmodified",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_gedcomx_unmodified",
+                "passed": true,
+                "error": null
+              }
+            ]
+          },
+          "judge": {
+            "skipped": false,
+            "dimensions": [
+              {
+                "source": "base",
+                "name": "Correctness",
+                "score": 3,
+                "rationale": "The skill correctly identified that Patrick Flynn (I1) is a synthetic ID and appropriately skipped the FamilySearch person_quality call. The response accurately reports that no warnings were found, which matches the tool response showing warningCount: 0. The offline checks are correctly understood to cover lifespan, event sequencing, and age-gap validation."
+              },
+              {
+                "source": "base",
+                "name": "Completeness",
+                "score": 3,
+                "rationale": "The skill fully addressed the user's request to check Patrick Flynn's evidence for impossibilities or warnings. It called the appropriate person_warnings tool with the correct personId (I1), reviewed the zero-warning result, and provided a clear summary of what was checked (lifespans, events after death, burial-before-death, parent/child age gaps)."
+              },
+              {
+                "source": "base",
+                "name": "Tool Arguments",
+                "score": 3,
+                "rationale": "The single MCP call to person_warnings passed the correct personId 'I1' and included projectPath as expected. The call matched the fixture's expected_args predicate and returned successfully (matched.kind = 'predicate'). No fixture_not_found errors occurred."
+              },
+              {
+                "source": "rubric",
+                "name": "Detection accuracy",
+                "score": 3,
+                "rationale": "The skill reported zero warnings from the person_warnings tool, which correctly reflects the test scenario: Patrick's timeline is consistent (birth ~1845, age 5 in 1850, age 15 in 1860, died 1908), with no chronological impossibilities or implausible age gaps. The tool's detection of genuine impossibilities while avoiding false positives on valid edge cases is confirmed by the clean result."
+              },
+              {
+                "source": "rubric",
+                "name": "Severity classification",
+                "score": 3,
+                "rationale": "No warnings were found, so severity classification is not applicable in this case. The skill correctly reported the absence of warnings rather than inventing severity tiers. This is the expected outcome for a clean project."
+              },
+              {
+                "source": "rubric",
+                "name": "Actionability",
+                "score": 3,
+                "rationale": "No warnings were detected, so there are no actionability requirements. The skill correctly reported a clean result without generating spurious or vague warnings. Per the rubric, when no warnings are found, actionability is moot."
+              },
+              {
+                "source": "rubric",
+                "name": "FamilySearch quality reporting",
+                "score": 3,
+                "rationale": "The skill correctly identified that Patrick Flynn (I1) is a synthetic ID and appropriately skipped the person_quality call. It did not make an unnecessary quality call on a synthetic person, and did not suppress the person_warnings result. This handling aligns with the rubric's requirement that quality calls apply only to FamilySearch IDs."
+              }
+            ],
+            "judge_cost_usd": 0.008480999999999999,
+            "duration_ms": 6853.300333023071,
+            "error": null,
+            "input_tokens": 4611,
+            "cached_input_tokens": 0,
+            "output_tokens": 774
+          },
+          "started_at": 1783269385.656841,
+          "ended_at": 1783269421.260194
+        }
+      ]
+    },
+    {
+      "test_id": "ut_check_warnings_002",
+      "test_type": "positive",
+      "expected_outcome": "pass",
+      "scenario": "flynn-resolved",
+      "mcp_fixtures": [
+        "person-warnings-no-warnings"
+      ],
+      "outcome": "pass",
+      "flaky": false,
+      "outcome_summary": {
+        "per_run_outcomes": [
+          "pass"
+        ],
+        "aggregated_dimensions": [
+          {
+            "source": "base",
+            "name": "Correctness",
+            "score": 3,
+            "rationale": "The skill correctly identified both persons (Patrick Flynn I1 and Thomas Flynn I2) and accurately reported the tool responses showing zero warnings for each. The claim that both are synthetic IDs and therefore FamilySearch quality checks do not apply is correct. The conclusion that the project is clear to close aligns with the tool findings."
+          },
+          {
+            "source": "base",
+            "name": "Completeness",
+            "score": 3,
+            "rationale": "The skill addressed the user's request comprehensively. It checked all relevant persons in the resolved project (both the research subject Patrick Flynn and the cited father Thomas Flynn), ran the appropriate offline warnings tool for each, and correctly reported that no quality-check calls were needed since both are synthetic IDs. The final clearance to close was directly responsive to the user's question."
+          },
+          {
+            "source": "base",
+            "name": "Tool Arguments",
+            "score": 3,
+            "rationale": "Both MCP calls used person_warnings with correct personId arguments (I1 and I2), matching the expected_args predicate. The projectPath was populated correctly. Both calls matched the expected fixture ('predicate' kind), confirming valid tool usage with no fixture_not_found errors."
+          },
+          {
+            "source": "rubric",
+            "name": "Detection accuracy",
+            "score": 3,
+            "rationale": "The tool successfully detected zero impossibilities and anomalies across both persons. Given the scenario summary indicating the project is fully resolved with consistent timeline data (birth ~1845, censuses 1850/1860, death 1908) and both persons passed all temporal/biological checks, the absence of flags is correct. No false positives were generated on what should be a clean, resolved project."
+          },
+          {
+            "source": "rubric",
+            "name": "Severity classification",
+            "score": 3,
+            "rationale": "No warnings were generated, so severity classification does not apply. The skill correctly reported zero warnings at any severity level rather than inventing spurious classifications. This is the correct handling when the project is clean."
+          },
+          {
+            "source": "rubric",
+            "name": "Actionability",
+            "score": null,
+            "rationale": "No warnings were found, so actionability is N/A. The project is clean and has no warnings that would require investigation or remediation steps."
+          },
+          {
+            "source": "rubric",
+            "name": "FamilySearch quality reporting",
+            "score": 3,
+            "rationale": "Both persons (I1 and I2) are synthetic project-local IDs, so person_quality calls were correctly not made. The skill explicitly acknowledged this and stated 'there are no FamilySearch profiles to score,' demonstrating proper understanding that quality reporting does not apply to synthetic IDs. The skill did not attempt to call person_quality on either synthetic ID, which is the correct behavior."
+          }
+        ]
+      },
+      "totals": {
+        "duration_ms": 32244.914084032644,
+        "duration_api_ms": 31908.0,
+        "judge_duration_ms": 7738.250750000589,
+        "wall_clock_ms": 40046.84114456177,
+        "num_turns": 9,
+        "input_tokens": 11,
+        "cached_input_tokens": 95367,
+        "output_tokens": 1399,
+        "judge_input_tokens": 4867,
+        "judge_cached_input_tokens": 0,
+        "judge_output_tokens": 755,
+        "skill_cost_usd": 0.1337921,
+        "judge_cost_usd": 0.008642,
+        "total_cost_usd": 0.1424341
+      },
+      "runs": [
+        {
+          "run_index": 0,
+          "run_id": "run_ut_check_warnings_002_2026-07-05_16-35-38_0",
+          "outcome": "pass",
+          "aborted_reason": null,
+          "duration_ms": 32244.914084032644,
+          "duration_api_ms": 31908.0,
+          "num_turns": 9,
+          "skill_attempts": 1,
+          "input_tokens": 11,
+          "cached_input_tokens": 95367,
+          "output_tokens": 1399,
+          "skill_cost_usd": 0.1337921,
+          "output": {
+            "text_response": "Let me start by reading the project files to identify all persons to check.Two persons to check \u2014 Patrick Flynn (I1) and Thomas Flynn (I2), both synthetic IDs, so I'll run the offline warnings tool for each and skip FamilySearch quality. Let me load the tool and run both checks simultaneously.Clean bill of health on both persons. Here's the full report:\n\n---\n\n**WARNINGS FOR: Patrick Flynn (I1)**\nNo genealogical warnings found. All checks passed.\n\n**WARNINGS FOR: Thomas Flynn (I2)**\nNo genealogical warnings found. All checks passed.\n\n---\n\nBoth persons were checked \u2014 Patrick Flynn as the research subject, and Thomas Flynn as the cited father in the proof conclusion. The tool ran its full set of temporal, biological, and relational checks (death before birth, impossible ages, events after death, parent-child age gaps, etc.) and found nothing to flag on either.\n\nSince both IDs are project-local (I1, I2), there are no FamilySearch profiles to score.\n\nYou're clear to close the project. No data integrity issues to resolve before you do.",
+            "activated": true,
+            "skills_invoked": [
+              "check-warnings"
+            ],
+            "tool_calls": [
+              {
+                "tool": "mcp__genealogy__person_warnings",
+                "args": {
+                  "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/eval-ut_check_warnings_002-0-0-7mpdbpk_",
+                  "personId": "I1"
+                },
+                "expected_args": {
+                  "personId": "~"
+                },
+                "matched": {
+                  "kind": "predicate",
+                  "index": 0
+                },
+                "response_fixture": "person-warnings-no-warnings"
+              },
+              {
+                "tool": "mcp__genealogy__person_warnings",
+                "args": {
+                  "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/eval-ut_check_warnings_002-0-0-7mpdbpk_",
+                  "personId": "I2"
+                },
+                "expected_args": {
+                  "personId": "~"
+                },
+                "matched": {
+                  "kind": "predicate",
+                  "index": 0
+                },
+                "response_fixture": "person-warnings-no-warnings"
+              }
+            ],
+            "files_created": [],
+            "warnings": [
+              {
+                "kind": "missing_tool_usage_dimension",
+                "advisory": "Skill called MCP tools but the rubric has no dimension name suggesting tool-usage coverage (matched against keywords: ['tool usage', 'tool use', 'tool work', 'tool call', 'argument quality', 'argument-quality', 'response interpretation', 'tool selection', 'mcp tool', 'fixture']). The judge will grade other dimensions but won't score tool work explicitly. Consider adding a tool-usage dimension or renaming an existing one."
+              }
+            ]
+          },
+          "validators": {
+            "passed": true,
+            "results": [
+              {
+                "name": "test_id_references_resolve",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_log_append_only",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_entries_deleted",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_research_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tool_allowlist",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_gedcomx_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_research_json_unmodified",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_gedcomx_unmodified",
+                "passed": true,
+                "error": null
+              }
+            ]
+          },
+          "judge": {
+            "skipped": false,
+            "dimensions": [
+              {
+                "source": "base",
+                "name": "Correctness",
+                "score": 3,
+                "rationale": "The skill correctly identified both persons (Patrick Flynn I1 and Thomas Flynn I2) and accurately reported the tool responses showing zero warnings for each. The claim that both are synthetic IDs and therefore FamilySearch quality checks do not apply is correct. The conclusion that the project is clear to close aligns with the tool findings."
+              },
+              {
+                "source": "base",
+                "name": "Completeness",
+                "score": 3,
+                "rationale": "The skill addressed the user's request comprehensively. It checked all relevant persons in the resolved project (both the research subject Patrick Flynn and the cited father Thomas Flynn), ran the appropriate offline warnings tool for each, and correctly reported that no quality-check calls were needed since both are synthetic IDs. The final clearance to close was directly responsive to the user's question."
+              },
+              {
+                "source": "base",
+                "name": "Tool Arguments",
+                "score": 3,
+                "rationale": "Both MCP calls used person_warnings with correct personId arguments (I1 and I2), matching the expected_args predicate. The projectPath was populated correctly. Both calls matched the expected fixture ('predicate' kind), confirming valid tool usage with no fixture_not_found errors."
+              },
+              {
+                "source": "rubric",
+                "name": "Detection accuracy",
+                "score": 3,
+                "rationale": "The tool successfully detected zero impossibilities and anomalies across both persons. Given the scenario summary indicating the project is fully resolved with consistent timeline data (birth ~1845, censuses 1850/1860, death 1908) and both persons passed all temporal/biological checks, the absence of flags is correct. No false positives were generated on what should be a clean, resolved project."
+              },
+              {
+                "source": "rubric",
+                "name": "Severity classification",
+                "score": 3,
+                "rationale": "No warnings were generated, so severity classification does not apply. The skill correctly reported zero warnings at any severity level rather than inventing spurious classifications. This is the correct handling when the project is clean."
+              },
+              {
+                "source": "rubric",
+                "name": "Actionability",
+                "score": null,
+                "rationale": "No warnings were found, so actionability is N/A. The project is clean and has no warnings that would require investigation or remediation steps."
+              },
+              {
+                "source": "rubric",
+                "name": "FamilySearch quality reporting",
+                "score": 3,
+                "rationale": "Both persons (I1 and I2) are synthetic project-local IDs, so person_quality calls were correctly not made. The skill explicitly acknowledged this and stated 'there are no FamilySearch profiles to score,' demonstrating proper understanding that quality reporting does not apply to synthetic IDs. The skill did not attempt to call person_quality on either synthetic ID, which is the correct behavior."
+              }
+            ],
+            "judge_cost_usd": 0.008642,
+            "duration_ms": 7738.250750000589,
+            "error": null,
+            "input_tokens": 4867,
+            "cached_input_tokens": 0,
+            "output_tokens": 755
+          },
+          "started_at": 1783269381.1153228,
+          "ended_at": 1783269421.162164
+        }
+      ]
+    },
+    {
+      "test_id": "ut_check_warnings_009",
+      "test_type": "positive",
+      "expected_outcome": "pass",
+      "scenario": "mid-research-flynn",
+      "mcp_fixtures": [
+        "person-warnings-cluster"
+      ],
+      "outcome": "pass",
+      "flaky": false,
+      "outcome_summary": {
+        "per_run_outcomes": [
+          "pass"
+        ],
+        "aggregated_dimensions": [
+          {
+            "source": "base",
+            "name": "Correctness",
+            "score": 3,
+            "rationale": "The skill accurately reported all four warnings returned by person_warnings: two critical errors on Patrick (hasEventAfterDeath1, hasAgeRangeGreaterThan120), one note (tooManyDeathDates2), and one critical relative warning on Thomas (relativesHasAgeRangeGreaterThan120). All severity classifications match the tool's severity field. The skill correctly cited the factIds and messages verbatim from the tool response. No fabricated material."
+          },
+          {
+            "source": "base",
+            "name": "Completeness",
+            "score": 3,
+            "rationale": "The skill fully addressed the user's request to run a thorough warnings check on Patrick Flynn. All four tool-returned warnings were reported and explained. The skill provided: individual warning explanations with root causes and next steps, a cluster verdict recognizing the 2-error pattern as identity confusion signal, explicit handling of the relative warning per the relative-warning rule, actionable guidance for each warning type, and a summary table. No significant omissions."
+          },
+          {
+            "source": "base",
+            "name": "Tool Arguments",
+            "score": 3,
+            "rationale": "The skill called person_warnings with the correct argument: personId='I1' (Patrick Flynn). The test fixture expected exactly this call (expectedArgs: {personId: 'I1'}), and the matched.kind='predicate' confirms the call was found and accepted. No extra or missing critical arguments. Tool call is well-formed."
+          },
+          {
+            "source": "rubric",
+            "name": "Detection accuracy",
+            "score": 3,
+            "rationale": "The skill correctly reported all four impossibilities/anomalies returned by the tool without flagging false positives. Two critical errors on Patrick (event after death, lifespan > 120 years) and one note (multiple distinct death dates) are genuine anomalies. The relative warning about Thomas's lifespan is valid per the tree structure. No valid edge cases were incorrectly flagged as warnings."
+          },
+          {
+            "source": "rubric",
+            "name": "Severity classification",
+            "score": 3,
+            "rationale": "Severity tiers match the tool's severity field perfectly. Two errors (hasEventAfterDeath1, hasAgeRangeGreaterThan120) classified as Critical, one warning (tooManyDeathDates2) as Note, and one error (relativesHasAgeRangeGreaterThan120) as Critical. Chronological impossibilities (event after death, implausible lifespan) correctly labeled Critical; the multiple-death-dates anomaly correctly labeled as lower-severity Note. All mappings accurate."
+          },
+          {
+            "source": "rubric",
+            "name": "Actionability",
+            "score": 3,
+            "rationale": "Every warning names the specific records involved and suggests concrete investigative steps. hasEventAfterDeath1 explains three legitimate root causes (wrong death date, identity confusion, posthumous mention) with cues for each. hasAgeRangeGreaterThan120 recommends verifying dates and mentions cluster verdict as reinforcement. tooManyDeathDates2 directs comparison of sources to identify the authoritative date. relativesHasAgeRangeGreaterThan120 recommends verifying the parent-child relationship before modifying Thomas's data. All warnings are decoupled from generic language and tied to actionable next steps."
+          },
+          {
+            "source": "rubric",
+            "name": "FamilySearch quality reporting",
+            "score": 3,
+            "rationale": "Patrick's ID (I1) is synthetic, not a FamilySearch ID, so person_quality should not be called. The skill correctly did not call person_quality. The skill explicitly stated 'I1 is not a FamilySearch ID, person_quality is not applicable,' demonstrating awareness of the rule. Tool usage is correct and graceful."
+          },
+          {
+            "source": "rubric",
+            "name": "Cluster verdict recognition",
+            "score": 3,
+            "rationale": "The skill explicitly recognized the two-error pattern on Patrick (hasEventAfterDeath1 + hasAgeRangeGreaterThan120) as a cluster signal and articulated the identity-confusion interpretation: 'Two critical errors firing on the same person is a strong signal that records from two different individuals have been merged into one profile.' The skill correctly counted only Patrick's three warnings toward the cluster verdict and excluded the relative warning on Thomas. The escalation rule (2+ errors \u2192 split and rebuild) was applied correctly."
+          },
+          {
+            "source": "rubric",
+            "name": "Relative-warning rule",
+            "score": 3,
+            "rationale": "The skill correctly applied the relative-warning rule to Thomas's warning. It stated: 'This warning is about Patrick's father Thomas, not Patrick himself. The first thing to check is whether Thomas Flynn (I2) is genuinely Patrick's father, or whether a same-name record was linked here by mistake. Verify the relationship link before making any changes to Thomas's data.' This recommends verifying the parent-child link via person-evidence before recommending data fixes on Thomas, exactly as specified in the test context."
+          },
+          {
+            "source": "rubric",
+            "name": "Escalation and handoff",
+            "score": 3,
+            "rationale": "The skill recommended building a full chronological timeline ('the most productive next step is building a full chronological event timeline for Patrick'), which aligns with handoff to the timeline skill. The skill's framing of the issue as identity confusion (not individual field fixes) and the emphasis on finding the split point before reassigning records aligns with the intended escalation path and person-evidence rebuild. The skill did not recommend fixing individual fields on Patrick given the cluster verdict."
+          }
+        ]
+      },
+      "totals": {
+        "duration_ms": 99492.76879202807,
+        "duration_api_ms": 97333.0,
+        "judge_duration_ms": 14828.430416004267,
+        "wall_clock_ms": 114497.82395362854,
+        "num_turns": 6,
+        "input_tokens": 11,
+        "cached_input_tokens": 57871,
+        "output_tokens": 5062,
+        "judge_input_tokens": 6296,
+        "judge_cached_input_tokens": 0,
+        "judge_output_tokens": 1448,
+        "skill_cost_usd": 0.13263979999999997,
+        "judge_cost_usd": 0.013536,
+        "total_cost_usd": 0.14617579999999997
+      },
+      "runs": [
+        {
+          "run_index": 0,
+          "run_id": "run_ut_check_warnings_009_2026-07-05_16-35-38_0",
+          "outcome": "pass",
+          "aborted_reason": null,
+          "duration_ms": 99492.76879202807,
+          "duration_api_ms": 97333.0,
+          "num_turns": 6,
+          "skill_attempts": 1,
+          "input_tokens": 11,
+          "cached_input_tokens": 57871,
+          "output_tokens": 5062,
+          "skill_cost_usd": 0.13263979999999997,
+          "output": {
+            "text_response": "I'll start by locating Patrick Flynn in the tree.Patrick Flynn is `I1` \u2014 a synthetic ID. I'll run the offline warnings check now. Since `I1` is not a FamilySearch ID, `person_quality` is not applicable.The tool returned 4 warnings across Patrick and his father Thomas. Two critical errors fired on Patrick himself, which triggers the cluster verdict. Here is the full report.\n\n---\n\n## WARNINGS FOR: Patrick Flynn (I1)\n\n> **\u26a0 Cluster verdict \u2014 2 errors on this one person**\n> Two critical errors firing on the same person is a strong signal that records from two different individuals have been merged into one profile. I'd recommend rebuilding a full chronological timeline of every recorded event for Patrick and going through each one to identify where one person's records end and another's begin \u2014 once the split point is found, the records belonging to the other individual can be reassigned.\n\nIndividual warnings are listed below.\n\n---\n\n### [!] Critical \u2014 Event after death `[hasEventAfterDeath1]`\n**Fundamental:** people cannot act after their death \u2014 but a posthumous mention can be misattached to their profile.\n\n> *An event is dated more than 1 year after this person's latest death-like fact.*\n> Facts involved: F1 (Birth), F2 (Death)\n\nThis warning has three legitimate causes \u2014 the right corrective action depends on which applies:\n\n- **(a) Wrong death date** \u2014 the recorded death date is too early, and a later record is actually consistent with Patrick still being alive. Cue: a single late-dated record conflicts with one death record but aligns with everything else. \u2192 Verify the recorded death date against the original death certificate or burial register \u2014 one of the two dates is likely wrong.\n- **(b) Identity confusion** \u2014 the late-dated record belongs to a same-name individual who outlived Patrick, and was merged in by mistake. Cue: the source describes actions apparently performed *by* Patrick (e.g., a later census listing him as head of household). \u2192 Rebuild the full chronological timeline and trace each record back to its source to find where the two people diverge.\n- **(c) Posthumous mention** \u2014 the late-dated record was created after Patrick's death and merely references him (an obituary, a descendant's death certificate, an estate or probate document naming him as a parent or prior owner). Cue: he is named in the record but not performing an action. \u2192 Look at the late-dated record itself \u2014 if it's really about someone else and just names Patrick in passing, unlink it from his profile and treat it as a reference.\n\n**Next step:** Inspect the late-dated record first \u2014 what kind of document is it? The right fix depends on what you find.\n\n---\n\n### [!] Critical \u2014 Implausible lifespan `[hasAgeRangeGreaterThan120]`\n**Valid:** people rarely live past 120 years.\n\n> *This person's lifespan is greater than 120 years, which is implausible.*\n> Facts involved: F1 (Birth), F2 (Death)\n\n**Next step:** Verify the birth and death dates against their original sources. If both dates are confirmed correct, this may reinforce the possibility that two individuals' records have been merged (see cluster verdict above).\n\n---\n\n### [!] Note \u2014 Multiple death dates `[tooManyDeathDates2]`\n**Valid:** a person has one death.\n\n> *Two or more distinct perfect day-month-year death dates spaced more than 14 days apart, suggesting unreconciled death records.*\n> Facts involved: F2 (Death)\n\n**Next step:** Compare the sources recording Patrick's death date to identify which is authoritative. Resolve any discrepancy by tracing each date back to its original record, then document which one is retained and why.\n\n---\n\n## RELATIVE WARNING: Thomas Flynn (I2) \u2014 father of Patrick Flynn\n\n### [!] Critical \u2014 Relative's implausible lifespan `[relativesHasAgeRangeGreaterThan120]`\n**Valid:** people rarely live past 120 years. *(Warning is about Thomas Flynn, not Patrick directly.)*\n\n> *This relative's lifespan is greater than 120 years, which is implausible.*\n> Facts involved: F3 (Birth \u2014 Thomas Flynn)\n\n**Important:** This warning is about Patrick's father Thomas, not Patrick himself. The first thing to check is whether Thomas Flynn (I2) is genuinely Patrick's father, or whether a same-name record was linked here by mistake. Verify the relationship link before making any changes to Thomas's data. Once the relationship is confirmed correct, then look at whether Thomas's birth or death dates need correction.\n\n---\n\n## Summary\n\n| Person | Severity | Tag | \n|---|---|---|\n| Patrick Flynn (I1) | \ud83d\udd34 Critical | `hasEventAfterDeath1` |\n| Patrick Flynn (I1) | \ud83d\udd34 Critical | `hasAgeRangeGreaterThan120` |\n| Patrick Flynn (I1) | \ud83d\udfe1 Note | `tooManyDeathDates2` |\n| Thomas Flynn (I2, via relative check) | \ud83d\udd34 Critical | `relativesHasAgeRangeGreaterThan120` |\n\n**4 warnings total \u2014 3 critical errors, 1 note.** The two errors on Patrick himself warrant priority attention; the most productive next step is building a full chronological event timeline for Patrick to assess whether records from two different people are present.",
+            "activated": true,
+            "skills_invoked": [
+              "check-warnings"
+            ],
+            "tool_calls": [
+              {
+                "tool": "mcp__genealogy__person_warnings",
+                "args": {
+                  "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/eval-ut_check_warnings_009-0-0-mhoknf2n",
+                  "personId": "I1"
+                },
+                "expected_args": {
+                  "personId": "I1"
+                },
+                "matched": {
+                  "kind": "predicate",
+                  "index": 0
+                },
+                "response_fixture": "person-warnings-cluster"
+              }
+            ],
+            "files_created": [],
+            "warnings": [
+              {
+                "kind": "missing_tool_usage_dimension",
+                "advisory": "Skill called MCP tools but the rubric has no dimension name suggesting tool-usage coverage (matched against keywords: ['tool usage', 'tool use', 'tool work', 'tool call', 'argument quality', 'argument-quality', 'response interpretation', 'tool selection', 'mcp tool', 'fixture']). The judge will grade other dimensions but won't score tool work explicitly. Consider adding a tool-usage dimension or renaming an existing one."
+              }
+            ]
+          },
+          "validators": {
+            "passed": true,
+            "results": [
+              {
+                "name": "test_id_references_resolve",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_log_append_only",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_entries_deleted",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_research_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tool_allowlist",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_gedcomx_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_research_json_unmodified",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_gedcomx_unmodified",
+                "passed": true,
+                "error": null
+              }
+            ]
+          },
+          "judge": {
+            "skipped": false,
+            "dimensions": [
+              {
+                "source": "base",
+                "name": "Correctness",
+                "score": 3,
+                "rationale": "The skill accurately reported all four warnings returned by person_warnings: two critical errors on Patrick (hasEventAfterDeath1, hasAgeRangeGreaterThan120), one note (tooManyDeathDates2), and one critical relative warning on Thomas (relativesHasAgeRangeGreaterThan120). All severity classifications match the tool's severity field. The skill correctly cited the factIds and messages verbatim from the tool response. No fabricated material."
+              },
+              {
+                "source": "base",
+                "name": "Completeness",
+                "score": 3,
+                "rationale": "The skill fully addressed the user's request to run a thorough warnings check on Patrick Flynn. All four tool-returned warnings were reported and explained. The skill provided: individual warning explanations with root causes and next steps, a cluster verdict recognizing the 2-error pattern as identity confusion signal, explicit handling of the relative warning per the relative-warning rule, actionable guidance for each warning type, and a summary table. No significant omissions."
+              },
+              {
+                "source": "base",
+                "name": "Tool Arguments",
+                "score": 3,
+                "rationale": "The skill called person_warnings with the correct argument: personId='I1' (Patrick Flynn). The test fixture expected exactly this call (expectedArgs: {personId: 'I1'}), and the matched.kind='predicate' confirms the call was found and accepted. No extra or missing critical arguments. Tool call is well-formed."
+              },
+              {
+                "source": "rubric",
+                "name": "Detection accuracy",
+                "score": 3,
+                "rationale": "The skill correctly reported all four impossibilities/anomalies returned by the tool without flagging false positives. Two critical errors on Patrick (event after death, lifespan > 120 years) and one note (multiple distinct death dates) are genuine anomalies. The relative warning about Thomas's lifespan is valid per the tree structure. No valid edge cases were incorrectly flagged as warnings."
+              },
+              {
+                "source": "rubric",
+                "name": "Severity classification",
+                "score": 3,
+                "rationale": "Severity tiers match the tool's severity field perfectly. Two errors (hasEventAfterDeath1, hasAgeRangeGreaterThan120) classified as Critical, one warning (tooManyDeathDates2) as Note, and one error (relativesHasAgeRangeGreaterThan120) as Critical. Chronological impossibilities (event after death, implausible lifespan) correctly labeled Critical; the multiple-death-dates anomaly correctly labeled as lower-severity Note. All mappings accurate."
+              },
+              {
+                "source": "rubric",
+                "name": "Actionability",
+                "score": 3,
+                "rationale": "Every warning names the specific records involved and suggests concrete investigative steps. hasEventAfterDeath1 explains three legitimate root causes (wrong death date, identity confusion, posthumous mention) with cues for each. hasAgeRangeGreaterThan120 recommends verifying dates and mentions cluster verdict as reinforcement. tooManyDeathDates2 directs comparison of sources to identify the authoritative date. relativesHasAgeRangeGreaterThan120 recommends verifying the parent-child relationship before modifying Thomas's data. All warnings are decoupled from generic language and tied to actionable next steps."
+              },
+              {
+                "source": "rubric",
+                "name": "FamilySearch quality reporting",
+                "score": 3,
+                "rationale": "Patrick's ID (I1) is synthetic, not a FamilySearch ID, so person_quality should not be called. The skill correctly did not call person_quality. The skill explicitly stated 'I1 is not a FamilySearch ID, person_quality is not applicable,' demonstrating awareness of the rule. Tool usage is correct and graceful."
+              },
+              {
+                "source": "rubric",
+                "name": "Cluster verdict recognition",
+                "score": 3,
+                "rationale": "The skill explicitly recognized the two-error pattern on Patrick (hasEventAfterDeath1 + hasAgeRangeGreaterThan120) as a cluster signal and articulated the identity-confusion interpretation: 'Two critical errors firing on the same person is a strong signal that records from two different individuals have been merged into one profile.' The skill correctly counted only Patrick's three warnings toward the cluster verdict and excluded the relative warning on Thomas. The escalation rule (2+ errors \u2192 split and rebuild) was applied correctly."
+              },
+              {
+                "source": "rubric",
+                "name": "Relative-warning rule",
+                "score": 3,
+                "rationale": "The skill correctly applied the relative-warning rule to Thomas's warning. It stated: 'This warning is about Patrick's father Thomas, not Patrick himself. The first thing to check is whether Thomas Flynn (I2) is genuinely Patrick's father, or whether a same-name record was linked here by mistake. Verify the relationship link before making any changes to Thomas's data.' This recommends verifying the parent-child link via person-evidence before recommending data fixes on Thomas, exactly as specified in the test context."
+              },
+              {
+                "source": "rubric",
+                "name": "Escalation and handoff",
+                "score": 3,
+                "rationale": "The skill recommended building a full chronological timeline ('the most productive next step is building a full chronological event timeline for Patrick'), which aligns with handoff to the timeline skill. The skill's framing of the issue as identity confusion (not individual field fixes) and the emphasis on finding the split point before reassigning records aligns with the intended escalation path and person-evidence rebuild. The skill did not recommend fixing individual fields on Patrick given the cluster verdict."
+              }
+            ],
+            "judge_cost_usd": 0.013536,
+            "duration_ms": 14828.430416004267,
+            "error": null,
+            "input_tokens": 6296,
+            "cached_input_tokens": 0,
+            "output_tokens": 1448
+          },
+          "started_at": 1783269338.451296,
+          "ended_at": 1783269452.94912
+        }
+      ]
+    },
+    {
+      "test_id": "ut_check_warnings_007",
+      "test_type": "positive",
+      "expected_outcome": "pass",
+      "scenario": "mid-research-flynn",
+      "mcp_fixtures": [
+        "person-warnings-early-marriage"
+      ],
+      "outcome": "pass",
+      "flaky": false,
+      "outcome_summary": {
+        "per_run_outcomes": [
+          "pass"
+        ],
+        "aggregated_dimensions": [
+          {
+            "source": "base",
+            "name": "Correctness",
+            "score": 3,
+            "rationale": "The skill correctly identified Patrick Flynn (I1) as a synthetic ID and ran the offline warnings check only. The tool response reported one warning (hasEarlyMarriage14 with severity 'warning'), and the skill accurately reported this warning with the correct severity level (Note, not Critical). The claim that the person married before age 14 is directly supported by the tool response. No fabricated material or unsupported assertions."
+          },
+          {
+            "source": "base",
+            "name": "Completeness",
+            "score": 3,
+            "rationale": "The skill fully addressed the user's request ('Check Patrick for warnings'). It called person_warnings on I1 (the synthetic ID for Patrick), reported all warnings found (1 warning total), and completed the check with a summary of findings. No omissions or early stopping detected."
+          },
+          {
+            "source": "base",
+            "name": "Tool Arguments",
+            "score": 3,
+            "rationale": "The person_warnings call passed args matching expected_args: personId='I1' was correct. The projectPath was provided (reasonable setup arg for the MCP tool, even though expected_args did not require it). The tool matched successfully (matched.kind='predicate'), confirming correct tool usage. No fixture_not_found errors."
+          },
+          {
+            "source": "rubric",
+            "name": "Detection accuracy",
+            "score": 3,
+            "rationale": "The skill accurately reported the one warning returned by the person_warnings tool: hasEarlyMarriage14 at severity 'warning'. It did not flag false positives or miss any impossibilities. The tool response contained exactly one warning, and the skill reported it faithfully. No extraneous flags or missed detections."
+          },
+          {
+            "source": "rubric",
+            "name": "Severity classification",
+            "score": 3,
+            "rationale": "The skill correctly classified the early marriage warning at Note severity (not Critical). The rubric specified that hasEarlyMarriage14 should be reported with Note severity because it is a Valid-assumption violation, not a Fundamental one. The skill stated '[!] Note \u2014 Early marriage' and explained 'which is unusual but not impossible historically,' matching the appropriate medium-severity tier for valid but anomalous edge cases."
+          },
+          {
+            "source": "rubric",
+            "name": "Actionability",
+            "score": 3,
+            "rationale": "Each warning is actionable and specific. The skill named the fact involved (F1: Birth, ~1845, Ireland), suggested verifying Patrick's birth year against original sources (church baptismal record or contemporaneous document), and explained that if dates are correct, the marriage should be documented as an exception. The next steps are concrete and genealogically sound."
+          },
+          {
+            "source": "rubric",
+            "name": "FamilySearch quality reporting",
+            "score": 3,
+            "rationale": "The person_warnings call was correctly applied to I1, a synthetic ID (not a FamilySearch ID). The skill appropriately reported that only offline warnings apply and did not call person_quality (no FamilySearch quality check was needed or expected). The skill correctly identified the scope of the check and handled it with appropriate degradation to offline-only mode, with no quality issues fabricated or incorrectly escalated."
+          }
+        ]
+      },
+      "totals": {
+        "duration_ms": 38313.153165974654,
+        "duration_api_ms": 36324.0,
+        "judge_duration_ms": 8678.903958003502,
+        "wall_clock_ms": 47182.64818191528,
+        "num_turns": 7,
+        "input_tokens": 12,
+        "cached_input_tokens": 71230,
+        "output_tokens": 1289,
+        "judge_input_tokens": 4879,
+        "judge_cached_input_tokens": 0,
+        "judge_output_tokens": 854,
+        "skill_cost_usd": 0.079183,
+        "judge_cost_usd": 0.009149000000000001,
+        "total_cost_usd": 0.08833200000000001
+      },
+      "runs": [
+        {
+          "run_index": 0,
+          "run_id": "run_ut_check_warnings_007_2026-07-05_16-35-38_0",
+          "outcome": "pass",
+          "aborted_reason": null,
+          "duration_ms": 38313.153165974654,
+          "duration_api_ms": 36324.0,
+          "num_turns": 7,
+          "skill_attempts": 1,
+          "input_tokens": 12,
+          "cached_input_tokens": 71230,
+          "output_tokens": 1289,
+          "skill_cost_usd": 0.079183,
+          "output": {
+            "text_response": "I found Patrick Flynn (`I1`) \u2014 a synthetic ID, so I'll run the offline warnings check only.---\n\n**WARNINGS FOR: Patrick Flynn (I1)**\n\n---\n\n**[!] Note \u2014 Early marriage** `[hasEarlyMarriage14]`\n*Valid: marriage before age 14 is biologically and socially unusual.*\n\nThis person was married before age 14, which is biologically and socially unusual.\n\n**Fact involved:** F1 (Birth, ~1845, Ireland)\n\n**Next step:** Let's verify Patrick's birth year against its original source. If the original record genuinely shows a birth of ~1845 and the marriage record is also correct, we'll document this as an exception with a note \u2014 early marriages did occur historically in some communities. If either date looks like a transcription error, we'll correct the fact that's wrong.\n\n---\n\n*(1 warning total \u2014 no critical errors)*\n\n---\n\nNo impossibilities were found. The single note flags a marriage before age 14, which is unusual but not impossible historically. The birth year (~1845) is an approximation derived from census data, so the most productive check would be to compare it against any church baptismal record or other contemporaneous source that might sharpen or shift the estimated year.",
+            "activated": true,
+            "skills_invoked": [
+              "check-warnings"
+            ],
+            "tool_calls": [
+              {
+                "tool": "mcp__genealogy__person_warnings",
+                "args": {
+                  "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/eval-ut_check_warnings_007-0-0-4xr989a8",
+                  "personId": "I1"
+                },
+                "expected_args": {
+                  "personId": "I1"
+                },
+                "matched": {
+                  "kind": "predicate",
+                  "index": 0
+                },
+                "response_fixture": "person-warnings-early-marriage"
+              }
+            ],
+            "files_created": [],
+            "warnings": [
+              {
+                "kind": "missing_tool_usage_dimension",
+                "advisory": "Skill called MCP tools but the rubric has no dimension name suggesting tool-usage coverage (matched against keywords: ['tool usage', 'tool use', 'tool work', 'tool call', 'argument quality', 'argument-quality', 'response interpretation', 'tool selection', 'mcp tool', 'fixture']). The judge will grade other dimensions but won't score tool work explicitly. Consider adding a tool-usage dimension or renaming an existing one."
+              }
+            ]
+          },
+          "validators": {
+            "passed": true,
+            "results": [
+              {
+                "name": "test_id_references_resolve",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_log_append_only",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_entries_deleted",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_research_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tool_allowlist",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_gedcomx_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_research_json_unmodified",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_gedcomx_unmodified",
+                "passed": true,
+                "error": null
+              }
+            ]
+          },
+          "judge": {
+            "skipped": false,
+            "dimensions": [
+              {
+                "source": "base",
+                "name": "Correctness",
+                "score": 3,
+                "rationale": "The skill correctly identified Patrick Flynn (I1) as a synthetic ID and ran the offline warnings check only. The tool response reported one warning (hasEarlyMarriage14 with severity 'warning'), and the skill accurately reported this warning with the correct severity level (Note, not Critical). The claim that the person married before age 14 is directly supported by the tool response. No fabricated material or unsupported assertions."
+              },
+              {
+                "source": "base",
+                "name": "Completeness",
+                "score": 3,
+                "rationale": "The skill fully addressed the user's request ('Check Patrick for warnings'). It called person_warnings on I1 (the synthetic ID for Patrick), reported all warnings found (1 warning total), and completed the check with a summary of findings. No omissions or early stopping detected."
+              },
+              {
+                "source": "base",
+                "name": "Tool Arguments",
+                "score": 3,
+                "rationale": "The person_warnings call passed args matching expected_args: personId='I1' was correct. The projectPath was provided (reasonable setup arg for the MCP tool, even though expected_args did not require it). The tool matched successfully (matched.kind='predicate'), confirming correct tool usage. No fixture_not_found errors."
+              },
+              {
+                "source": "rubric",
+                "name": "Detection accuracy",
+                "score": 3,
+                "rationale": "The skill accurately reported the one warning returned by the person_warnings tool: hasEarlyMarriage14 at severity 'warning'. It did not flag false positives or miss any impossibilities. The tool response contained exactly one warning, and the skill reported it faithfully. No extraneous flags or missed detections."
+              },
+              {
+                "source": "rubric",
+                "name": "Severity classification",
+                "score": 3,
+                "rationale": "The skill correctly classified the early marriage warning at Note severity (not Critical). The rubric specified that hasEarlyMarriage14 should be reported with Note severity because it is a Valid-assumption violation, not a Fundamental one. The skill stated '[!] Note \u2014 Early marriage' and explained 'which is unusual but not impossible historically,' matching the appropriate medium-severity tier for valid but anomalous edge cases."
+              },
+              {
+                "source": "rubric",
+                "name": "Actionability",
+                "score": 3,
+                "rationale": "Each warning is actionable and specific. The skill named the fact involved (F1: Birth, ~1845, Ireland), suggested verifying Patrick's birth year against original sources (church baptismal record or contemporaneous document), and explained that if dates are correct, the marriage should be documented as an exception. The next steps are concrete and genealogically sound."
+              },
+              {
+                "source": "rubric",
+                "name": "FamilySearch quality reporting",
+                "score": 3,
+                "rationale": "The person_warnings call was correctly applied to I1, a synthetic ID (not a FamilySearch ID). The skill appropriately reported that only offline warnings apply and did not call person_quality (no FamilySearch quality check was needed or expected). The skill correctly identified the scope of the check and handled it with appropriate degradation to offline-only mode, with no quality issues fabricated or incorrectly escalated."
+              }
+            ],
+            "judge_cost_usd": 0.009149000000000001,
+            "duration_ms": 8678.903958003502,
+            "error": null,
+            "input_tokens": 4879,
+            "cached_input_tokens": 0,
+            "output_tokens": 854
+          },
+          "started_at": 1783269338.451583,
+          "ended_at": 1783269385.634231
+        }
+      ]
+    },
+    {
+      "test_id": "ut_check_warnings_010",
+      "test_type": "positive",
+      "expected_outcome": "pass",
+      "scenario": "empty-project-just-created",
+      "mcp_fixtures": [
+        "person-warnings-empty-stub"
+      ],
+      "outcome": "pass",
+      "flaky": false,
+      "outcome_summary": {
+        "per_run_outcomes": [
+          "pass"
+        ],
+        "aggregated_dimensions": [
+          {
+            "source": "base",
+            "name": "Correctness",
+            "score": 3,
+            "rationale": "The skill correctly identified Patrick (I1) as having a synthetic ID and appropriately ran only the offline warnings check, skipping FamilySearch quality checks. It accurately reported the missingFactsAndRelatives warning with severity 'warning' as returned by the tool. The interpretation that this is not a data error but rather an empty stub is factually correct given the scenario state."
+          },
+          {
+            "source": "base",
+            "name": "Completeness",
+            "score": 3,
+            "rationale": "The skill addressed the user's request fully: it checked Patrick for warnings, called the appropriate tool with the correct person ID, reported the warning returned, and provided context about what the warning means for future research. All required elements from the user message and test expectations were covered."
+          },
+          {
+            "source": "base",
+            "name": "Tool Arguments",
+            "score": 3,
+            "rationale": "The person_warnings tool was called with correct arguments: personId 'I1' matches the expected_args exactly. The projectPath was included (not in expected_args but reasonable for context). The tool call matched the predicate (kind: predicate), indicating correct argument usage."
+          },
+          {
+            "source": "rubric",
+            "name": "Detection accuracy",
+            "score": 3,
+            "rationale": "The skill correctly detected and reported the genuine missingFactsAndRelatives warning from the tool response. No false positives were flagged. The detection is accurate because the tool itself determined the issue applies, and the skill correctly reported it without inventing additional warnings."
+          },
+          {
+            "source": "rubric",
+            "name": "Severity classification",
+            "score": 3,
+            "rationale": "The warning was correctly classified as 'Note' severity (matching the tool's 'warning' severity label). This is appropriate because missing facts and relatives in a stub record is an anomaly requiring further research, not a chronological impossibility. The severity tier matches the actual impact."
+          },
+          {
+            "source": "rubric",
+            "name": "Actionability",
+            "score": 3,
+            "rationale": "The warning is actionable and specific. It names Patrick Flynn and his ID (I1), explains the condition (empty stub with no facts/relatives), and suggests the clear next step: continue researching and re-run the check when more data is added. The interpretation section reinforces what to look for as research progresses."
+          },
+          {
+            "source": "rubric",
+            "name": "FamilySearch quality reporting",
+            "score": 3,
+            "rationale": "The skill correctly handled the quality check: it identified I1 as a synthetic ID and explicitly stated no FamilySearch quality check was needed, skipping the person_quality call appropriately. The warnings result from person_warnings is intact and presented clearly. The skill did not call person_quality on a synthetic ID, which would have been an error."
+          }
+        ]
+      },
+      "totals": {
+        "duration_ms": 23587.04808301991,
+        "duration_api_ms": 22806.0,
+        "judge_duration_ms": 7563.2217089878395,
+        "wall_clock_ms": 31219.576120376587,
+        "num_turns": 8,
+        "input_tokens": 12,
+        "cached_input_tokens": 69099,
+        "output_tokens": 1128,
+        "judge_input_tokens": 4720,
+        "judge_cached_input_tokens": 0,
+        "judge_output_tokens": 759,
+        "skill_cost_usd": 0.07191369999999998,
+        "judge_cost_usd": 0.008515,
+        "total_cost_usd": 0.08042869999999998
+      },
+      "runs": [
+        {
+          "run_index": 0,
+          "run_id": "run_ut_check_warnings_010_2026-07-05_16-35-38_0",
+          "outcome": "pass",
+          "aborted_reason": null,
+          "duration_ms": 23587.04808301991,
+          "duration_api_ms": 22806.0,
+          "num_turns": 8,
+          "skill_attempts": 1,
+          "input_tokens": 12,
+          "cached_input_tokens": 69099,
+          "output_tokens": 1128,
+          "skill_cost_usd": 0.07191369999999998,
+          "output": {
+            "text_response": "I found **Patrick Flynn** with ID `I1` \u2014 a synthetic ID, so I'll run the offline warnings check only (no FamilySearch quality check needed).---\n\n**WARNINGS FOR: Patrick Flynn (I1)**\n\n**[!] Note \u2014 Missing Facts and Relatives** `[missingFactsAndRelatives]`\n*[Valid: warning checks need dates and relationships to fire.]*\n\n> This person has no recorded facts (other than GenderChange) and no relatives \u2014 an empty stub record.\n\nNote: Patrick has limited data, so most warning checks need dates and relatives to fire. Adding more research may surface additional issues currently hidden.\n\n*(1 warning total)*\n\n---\n\n**Interpretation:** Patrick Flynn's profile is essentially a bare stub \u2014 just a name and gender. This isn't a data error, but it does mean the offline checks can't evaluate things like impossible ages, events after death, or parent/child relationship timing. As research progresses and birth, death, and family relationship records are added to his profile, it's worth re-running this check to catch any logical inconsistencies that emerge.",
+            "activated": true,
+            "skills_invoked": [
+              "check-warnings"
+            ],
+            "tool_calls": [
+              {
+                "tool": "mcp__genealogy__person_warnings",
+                "args": {
+                  "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/eval-ut_check_warnings_010-0-0-yrohato4",
+                  "personId": "I1"
+                },
+                "expected_args": {
+                  "personId": "I1"
+                },
+                "matched": {
+                  "kind": "predicate",
+                  "index": 0
+                },
+                "response_fixture": "person-warnings-empty-stub"
+              }
+            ],
+            "files_created": [],
+            "warnings": [
+              {
+                "kind": "missing_tool_usage_dimension",
+                "advisory": "Skill called MCP tools but the rubric has no dimension name suggesting tool-usage coverage (matched against keywords: ['tool usage', 'tool use', 'tool work', 'tool call', 'argument quality', 'argument-quality', 'response interpretation', 'tool selection', 'mcp tool', 'fixture']). The judge will grade other dimensions but won't score tool work explicitly. Consider adding a tool-usage dimension or renaming an existing one."
+              }
+            ]
+          },
+          "validators": {
+            "passed": true,
+            "results": [
+              {
+                "name": "test_id_references_resolve",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_log_append_only",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_entries_deleted",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_research_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tool_allowlist",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_gedcomx_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_research_json_unmodified",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_gedcomx_unmodified",
+                "passed": true,
+                "error": null
+              }
+            ]
+          },
+          "judge": {
+            "skipped": false,
+            "dimensions": [
+              {
+                "source": "base",
+                "name": "Correctness",
+                "score": 3,
+                "rationale": "The skill correctly identified Patrick (I1) as having a synthetic ID and appropriately ran only the offline warnings check, skipping FamilySearch quality checks. It accurately reported the missingFactsAndRelatives warning with severity 'warning' as returned by the tool. The interpretation that this is not a data error but rather an empty stub is factually correct given the scenario state."
+              },
+              {
+                "source": "base",
+                "name": "Completeness",
+                "score": 3,
+                "rationale": "The skill addressed the user's request fully: it checked Patrick for warnings, called the appropriate tool with the correct person ID, reported the warning returned, and provided context about what the warning means for future research. All required elements from the user message and test expectations were covered."
+              },
+              {
+                "source": "base",
+                "name": "Tool Arguments",
+                "score": 3,
+                "rationale": "The person_warnings tool was called with correct arguments: personId 'I1' matches the expected_args exactly. The projectPath was included (not in expected_args but reasonable for context). The tool call matched the predicate (kind: predicate), indicating correct argument usage."
+              },
+              {
+                "source": "rubric",
+                "name": "Detection accuracy",
+                "score": 3,
+                "rationale": "The skill correctly detected and reported the genuine missingFactsAndRelatives warning from the tool response. No false positives were flagged. The detection is accurate because the tool itself determined the issue applies, and the skill correctly reported it without inventing additional warnings."
+              },
+              {
+                "source": "rubric",
+                "name": "Severity classification",
+                "score": 3,
+                "rationale": "The warning was correctly classified as 'Note' severity (matching the tool's 'warning' severity label). This is appropriate because missing facts and relatives in a stub record is an anomaly requiring further research, not a chronological impossibility. The severity tier matches the actual impact."
+              },
+              {
+                "source": "rubric",
+                "name": "Actionability",
+                "score": 3,
+                "rationale": "The warning is actionable and specific. It names Patrick Flynn and his ID (I1), explains the condition (empty stub with no facts/relatives), and suggests the clear next step: continue researching and re-run the check when more data is added. The interpretation section reinforces what to look for as research progresses."
+              },
+              {
+                "source": "rubric",
+                "name": "FamilySearch quality reporting",
+                "score": 3,
+                "rationale": "The skill correctly handled the quality check: it identified I1 as a synthetic ID and explicitly stated no FamilySearch quality check was needed, skipping the person_quality call appropriately. The warnings result from person_warnings is intact and presented clearly. The skill did not call person_quality on a synthetic ID, which would have been an error."
+              }
+            ],
+            "judge_cost_usd": 0.008515,
+            "duration_ms": 7563.2217089878395,
+            "error": null,
+            "input_tokens": 4720,
+            "cached_input_tokens": 0,
+            "output_tokens": 759
+          },
+          "started_at": 1783269405.9465249,
+          "ended_at": 1783269437.166101
+        }
+      ]
+    },
+    {
+      "test_id": "ut_check_warnings_004",
+      "test_type": "positive",
+      "expected_outcome": "pass",
+      "scenario": "mid-research-flynn",
+      "mcp_fixtures": [
+        "person-warnings-event-after-death"
+      ],
+      "outcome": "pass",
+      "flaky": false,
+      "outcome_summary": {
+        "per_run_outcomes": [
+          "pass"
+        ],
+        "aggregated_dimensions": [
+          {
+            "source": "base",
+            "name": "Correctness",
+            "score": 3,
+            "rationale": "The skill correctly identified the single hasEventAfterDeath1 warning from the tool response and accurately reported its severity as Critical. The explanation of the three possible causes (wrong death date, identity confusion, posthumous mention) is factually sound and well-grounded. The suggested investigation path (examining the late-dated record to determine if Patrick performed an action or was merely mentioned) directly aligns with the tool output and guidance. No fabricated material or unsupported claims."
+          },
+          {
+            "source": "base",
+            "name": "Completeness",
+            "score": 3,
+            "rationale": "The skill addressed the complete user request to check Patrick Flynn for warnings. It called the appropriate tool with the correct personId (I1), retrieved the single warning, and fully explained it with actionable next steps. The skill also correctly noted that no FamilySearch quality call was needed because I1 is a synthetic ID, demonstrating awareness of the full scope of the check-warnings capability."
+          },
+          {
+            "source": "base",
+            "name": "Tool Arguments",
+            "score": 3,
+            "rationale": "The skill called person_warnings with personId 'I1', which matches the expected_args exactly. The tool call succeeded (matched.kind == 'predicate'), confirming correct argument usage. The projectPath was included in args but not in expected_args; this is a reasonable system parameter addition, not an error."
+          },
+          {
+            "source": "rubric",
+            "name": "Detection accuracy",
+            "score": 3,
+            "rationale": "The tool detected a genuine impossibility (event after death) and the skill correctly reported it. No false positives are evident\u2014the warning is the output of the tool itself, not invented by the skill. The skill appropriately distinguished between impossibilities and anomalies by acknowledging that posthumous mentions are valid and should not automatically be treated as errors."
+          },
+          {
+            "source": "rubric",
+            "name": "Severity classification",
+            "score": 3,
+            "rationale": "The skill correctly classified the hasEventAfterDeath1 warning as Critical, matching the tool's severity 'error' designation. This is appropriate because a fundamental chronological impossibility (events after death) is a critical issue that undermines the person's coherence, even though it may resolve to a legitimate posthumous mention upon investigation."
+          },
+          {
+            "source": "rubric",
+            "name": "Actionability",
+            "score": 3,
+            "rationale": "The warning is highly actionable. The skill names the specific facts involved (F1, F2), provides three concrete causes to investigate, and gives a clear next step: examine the late-dated record to determine whether it describes Patrick performing an action or merely mentions him. This frames a genealogist's immediate investigative action without requiring guesswork."
+          },
+          {
+            "source": "rubric",
+            "name": "FamilySearch quality reporting",
+            "score": 3,
+            "rationale": "The skill correctly identified that I1 is a synthetic ID and therefore did not call person_quality. It explicitly stated this decision ('no FamilySearch quality call for synthetic IDs') and confirmed it in the closing note ('no FamilySearch quality score: I1 is a local synthetic ID'). The skill appropriately skipped the quality check while still delivering the offline warnings result, demonstrating correct handling of the FamilySearch quality tool eligibility rules."
+          }
+        ]
+      },
+      "totals": {
+        "duration_ms": 58233.19162498228,
+        "duration_api_ms": 56321.0,
+        "judge_duration_ms": 9054.148374998476,
+        "wall_clock_ms": 67476.27425193787,
+        "num_turns": 7,
+        "input_tokens": 12,
+        "cached_input_tokens": 71545,
+        "output_tokens": 2094,
+        "judge_input_tokens": 5214,
+        "judge_cached_input_tokens": 0,
+        "judge_output_tokens": 873,
+        "skill_cost_usd": 0.0917345,
+        "judge_cost_usd": 0.009579,
+        "total_cost_usd": 0.1013135
+      },
+      "runs": [
+        {
+          "run_index": 0,
+          "run_id": "run_ut_check_warnings_004_2026-07-05_16-35-38_0",
+          "outcome": "pass",
+          "aborted_reason": null,
+          "duration_ms": 58233.19162498228,
+          "duration_api_ms": 56321.0,
+          "num_turns": 7,
+          "skill_attempts": 1,
+          "input_tokens": 12,
+          "cached_input_tokens": 71545,
+          "output_tokens": 2094,
+          "skill_cost_usd": 0.0917345,
+          "output": {
+            "text_response": "Patrick Flynn is person `I1` \u2014 a synthetic ID, so I'll run the offline warnings check only (no FamilySearch quality call for synthetic IDs).---\n\n## WARNINGS FOR: Patrick Flynn (I1)\n\n**[!] Critical \u2014 Event after death** `[hasEventAfterDeath1]`\n*Fundamental: people cannot act after their death \u2014 but a posthumous mention can be misattached to their profile.*\n\nAn event is dated more than 1 year after this person's latest death-like fact.\n*(Facts involved: F1, F2)*\n\nThis warning has three common causes \u2014 and the right fix depends on which one applies:\n\n- **(a) Wrong death date** \u2014 the recorded death date is too early, and a single late-dated record is inconsistent with one earlier death record but consistent with everything else. \u2192 Verify the recorded death date against the original death certificate or burial register; one of the two dates is likely wrong.\n- **(b) Identity confusion** \u2014 the late-dated record actually belongs to a same-name individual who outlived Patrick. The record appears to describe actions *performed by* Patrick (e.g. a later census listing him as head of household, a later marriage). \u2192 Rebuild a full chronological timeline of every recorded event and go through each record to find where one person's records end and the other's begin, then reassign those that belong to the other individual.\n- **(c) Posthumous mention** \u2014 the late-dated record was created after Patrick's death and merely *references* him (an obituary, a descendant's death certificate, an estate or probate document naming him as a parent or prior owner). \u2192 Check whether the late-dated record is actually about someone else and just names Patrick as a relative or prior owner. If so, it shouldn't be attached to his profile as one of his own events \u2014 unlink it and treat it as a reference instead.\n\n**Next step:** Take a closer look at the late-dated record itself \u2014 what kind of document is it, and does it describe Patrick *doing* something, or merely *mention* him? The right corrective action follows from that.\n\n---\n\n*(1 warning total \u2014 no FamilySearch quality score: I1 is a local synthetic ID with no FamilySearch profile to score.)*",
+            "activated": true,
+            "skills_invoked": [
+              "check-warnings"
+            ],
+            "tool_calls": [
+              {
+                "tool": "mcp__genealogy__person_warnings",
+                "args": {
+                  "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/eval-ut_check_warnings_004-0-0-d3xf6u7z",
+                  "personId": "I1"
+                },
+                "expected_args": {
+                  "personId": "I1"
+                },
+                "matched": {
+                  "kind": "predicate",
+                  "index": 0
+                },
+                "response_fixture": "person-warnings-event-after-death"
+              }
+            ],
+            "files_created": [],
+            "warnings": [
+              {
+                "kind": "missing_tool_usage_dimension",
+                "advisory": "Skill called MCP tools but the rubric has no dimension name suggesting tool-usage coverage (matched against keywords: ['tool usage', 'tool use', 'tool work', 'tool call', 'argument quality', 'argument-quality', 'response interpretation', 'tool selection', 'mcp tool', 'fixture']). The judge will grade other dimensions but won't score tool work explicitly. Consider adding a tool-usage dimension or renaming an existing one."
+              }
+            ]
+          },
+          "validators": {
+            "passed": true,
+            "results": [
+              {
+                "name": "test_id_references_resolve",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_log_append_only",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_entries_deleted",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_research_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tool_allowlist",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_gedcomx_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_research_json_unmodified",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_gedcomx_unmodified",
+                "passed": true,
+                "error": null
+              }
+            ]
+          },
+          "judge": {
+            "skipped": false,
+            "dimensions": [
+              {
+                "source": "base",
+                "name": "Correctness",
+                "score": 3,
+                "rationale": "The skill correctly identified the single hasEventAfterDeath1 warning from the tool response and accurately reported its severity as Critical. The explanation of the three possible causes (wrong death date, identity confusion, posthumous mention) is factually sound and well-grounded. The suggested investigation path (examining the late-dated record to determine if Patrick performed an action or was merely mentioned) directly aligns with the tool output and guidance. No fabricated material or unsupported claims."
+              },
+              {
+                "source": "base",
+                "name": "Completeness",
+                "score": 3,
+                "rationale": "The skill addressed the complete user request to check Patrick Flynn for warnings. It called the appropriate tool with the correct personId (I1), retrieved the single warning, and fully explained it with actionable next steps. The skill also correctly noted that no FamilySearch quality call was needed because I1 is a synthetic ID, demonstrating awareness of the full scope of the check-warnings capability."
+              },
+              {
+                "source": "base",
+                "name": "Tool Arguments",
+                "score": 3,
+                "rationale": "The skill called person_warnings with personId 'I1', which matches the expected_args exactly. The tool call succeeded (matched.kind == 'predicate'), confirming correct argument usage. The projectPath was included in args but not in expected_args; this is a reasonable system parameter addition, not an error."
+              },
+              {
+                "source": "rubric",
+                "name": "Detection accuracy",
+                "score": 3,
+                "rationale": "The tool detected a genuine impossibility (event after death) and the skill correctly reported it. No false positives are evident\u2014the warning is the output of the tool itself, not invented by the skill. The skill appropriately distinguished between impossibilities and anomalies by acknowledging that posthumous mentions are valid and should not automatically be treated as errors."
+              },
+              {
+                "source": "rubric",
+                "name": "Severity classification",
+                "score": 3,
+                "rationale": "The skill correctly classified the hasEventAfterDeath1 warning as Critical, matching the tool's severity 'error' designation. This is appropriate because a fundamental chronological impossibility (events after death) is a critical issue that undermines the person's coherence, even though it may resolve to a legitimate posthumous mention upon investigation."
+              },
+              {
+                "source": "rubric",
+                "name": "Actionability",
+                "score": 3,
+                "rationale": "The warning is highly actionable. The skill names the specific facts involved (F1, F2), provides three concrete causes to investigate, and gives a clear next step: examine the late-dated record to determine whether it describes Patrick performing an action or merely mentions him. This frames a genealogist's immediate investigative action without requiring guesswork."
+              },
+              {
+                "source": "rubric",
+                "name": "FamilySearch quality reporting",
+                "score": 3,
+                "rationale": "The skill correctly identified that I1 is a synthetic ID and therefore did not call person_quality. It explicitly stated this decision ('no FamilySearch quality call for synthetic IDs') and confirmed it in the closing note ('no FamilySearch quality score: I1 is a local synthetic ID'). The skill appropriately skipped the quality check while still delivering the offline warnings result, demonstrating correct handling of the FamilySearch quality tool eligibility rules."
+              }
+            ],
+            "judge_cost_usd": 0.009579,
+            "duration_ms": 9054.148374998476,
+            "error": null,
+            "input_tokens": 5214,
+            "cached_input_tokens": 0,
+            "output_tokens": 873
+          },
+          "started_at": 1783269338.4503198,
+          "ended_at": 1783269405.926594
+        }
+      ]
+    },
+    {
+      "test_id": "ut_check_warnings_005",
+      "test_type": "positive",
+      "expected_outcome": "pass",
+      "scenario": "mid-research-flynn",
+      "mcp_fixtures": [
+        "person-warnings-father-died-before-child"
+      ],
+      "outcome": "pass",
+      "flaky": false,
+      "outcome_summary": {
+        "per_run_outcomes": [
+          "pass"
+        ],
+        "aggregated_dimensions": [
+          {
+            "source": "base",
+            "name": "Correctness",
+            "score": 3,
+            "rationale": "The skill correctly identified the hasDeathBeforeChildBirth30_10 warning from the tool response and accurately explained the biological impossibility: a father cannot die more than ~300 days before a child's birth due to finite gestation. The recommended actions (verify parent-child link, check death date source, look for identity confusion) are all sound. The skill did not fabricate claims \u2014 all assertions are grounded in the tool response."
+          },
+          {
+            "source": "base",
+            "name": "Completeness",
+            "score": 3,
+            "rationale": "The skill addressed all requirements: called person_warnings for personId I2 (Thomas), reported the single warning returned, explained the biological basis for the Critical severity, suggested three distinct corrective actions (wrong death date, wrong relationship, identity confusion), and appropriately noted that FamilySearch quality is N/A for a synthetic ID. No portions of the user request or test expectations were omitted."
+          },
+          {
+            "source": "base",
+            "name": "Tool Arguments",
+            "score": 3,
+            "rationale": "The person_warnings call passed the expected args: personId 'I2'. The call matched the predicate and returned a valid response. The tool was called on a synthetic ID (not a FamilySearch ID), which is the correct and only scenario where person_warnings applies in this test, and the skill did not attempt to call person_quality on the synthetic ID."
+          },
+          {
+            "source": "rubric",
+            "name": "Detection accuracy",
+            "score": 3,
+            "rationale": "The skill correctly detected the genuine impossibility flagged by the tool: Thomas dying 300+ days before Patrick's birth. No false positives were introduced. The detection was accurate to the warning returned and its biological basis (finite gestation prevents a father from dying before conception)."
+          },
+          {
+            "source": "rubric",
+            "name": "Severity classification",
+            "score": 3,
+            "rationale": "The warning is correctly classified as Critical with severity 'error' \u2014 a biological impossibility (death before child's birth) is chronologically impossible and the highest-impact class of problem. The skill framed it as a Fundamental check and explained why it matters, distinguishing it from mere anomalies. Severity matches actual impact."
+          },
+          {
+            "source": "rubric",
+            "name": "Actionability",
+            "score": 3,
+            "rationale": "Each action is specific and tied to the records and relationships involved. The skill named Patrick Flynn (I1) as the related person and fact F1 (the birth), and suggested concrete steps: verify the parent-child link with sources, check Thomas's death date against the original source document, and look for identity confusion. A genealogist could immediately act on these suggestions."
+          },
+          {
+            "source": "rubric",
+            "name": "FamilySearch quality reporting",
+            "score": 3,
+            "rationale": "The skill correctly identified that Thomas Flynn (I2) is a synthetic (locally-assigned) ID, not a FamilySearch ID, so person_quality does not apply. It did not call person_quality. It stated this clearly in a separate note ('FamilySearch quality: Not applicable \u2014 Thomas Flynn (I2) is a locally-assigned ID'). The person_warnings result was reported completely and transparently. No confusion between offline warnings and quality scoring."
+          }
+        ]
+      },
+      "totals": {
+        "duration_ms": 77969.3780419766,
+        "duration_api_ms": 76246.0,
+        "judge_duration_ms": 8701.996500021778,
+        "wall_clock_ms": 86844.67005729675,
+        "num_turns": 11,
+        "input_tokens": 14,
+        "cached_input_tokens": 97590,
+        "output_tokens": 3657,
+        "judge_input_tokens": 5097,
+        "judge_cached_input_tokens": 0,
+        "judge_output_tokens": 868,
+        "skill_cost_usd": 0.12337775,
+        "judge_cost_usd": 0.009437000000000001,
+        "total_cost_usd": 0.13281474999999998
+      },
+      "runs": [
+        {
+          "run_index": 0,
+          "run_id": "run_ut_check_warnings_005_2026-07-05_16-35-38_0",
+          "outcome": "pass",
+          "aborted_reason": null,
+          "duration_ms": 77969.3780419766,
+          "duration_api_ms": 76246.0,
+          "num_turns": 11,
+          "skill_attempts": 1,
+          "input_tokens": 14,
+          "cached_input_tokens": 97590,
+          "output_tokens": 3657,
+          "skill_cost_usd": 0.12337775,
+          "output": {
+            "text_response": "Thomas Flynn has person ID `I2` \u2014 a synthetic ID, so I'll run the offline warnings check only (no FamilySearch quality score).The tool returned a fact ID (`F1`) and a related person (`I1`) \u2014 let me look those up since the tool named them.---\n\n**WARNINGS FOR: Thomas Flynn (I2)**\n\n---\n\n**[!] Critical \u2014 Father died before child's birth** `[hasDeathBeforeChildBirth30_10]`\n*(Fundamental: a biological father cannot die more than ~300 days before his child is born \u2014 gestation is finite.)*\n\n> *\"This person (male) died more than 300 days before a child's earliest birth-like fact, which is biologically impossible.\"*\n\n**Fact involved:** F1 \u2014 the birth of his child **Patrick Flynn (I1)**, recorded as ~1845 in Ireland.\n\nThis error has a few typical causes \u2014 the right corrective action depends on which applies:\n\n- **Thomas's death date is wrong** \u2014 the recorded death date is too early, and the original source should be checked against the actual date.\n- **Wrong relationship link** \u2014 Patrick Flynn (I1) may not actually be Thomas's son; a same-name record may have been linked as a parent by mistake.\n- **Identity confusion** \u2014 the death record attached to Thomas may belong to a different Thomas Flynn, while the actual father survived to father Patrick.\n\n**Recommended next steps:**\n1. First, verify whether the parent-child link between Thomas Flynn and Patrick Flynn is supported by a source \u2014 confirm the relationship before assuming the dates need fixing.\n2. Then, check Thomas's recorded death date against its original source (the death certificate or burial register) to see if it was transcribed incorrectly.\n3. If the relationship and the death date both check out, rebuild a chronological timeline of every recorded event for Thomas to look for signs of two different individuals merged into one profile.\n\n*(1 warning total)*\n\n---\n\n> **FamilySearch quality:** Not applicable \u2014 Thomas Flynn (I2) is a locally-assigned ID with no FamilySearch profile to score.",
+            "activated": true,
+            "skills_invoked": [
+              "check-warnings"
+            ],
+            "tool_calls": [
+              {
+                "tool": "mcp__genealogy__person_warnings",
+                "args": {
+                  "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/eval-ut_check_warnings_005-0-0-lvppzeq5",
+                  "personId": "I2"
+                },
+                "expected_args": {
+                  "personId": "I2"
+                },
+                "matched": {
+                  "kind": "predicate",
+                  "index": 0
+                },
+                "response_fixture": "person-warnings-father-died-before-child"
+              }
+            ],
+            "files_created": [],
+            "warnings": [
+              {
+                "kind": "missing_tool_usage_dimension",
+                "advisory": "Skill called MCP tools but the rubric has no dimension name suggesting tool-usage coverage (matched against keywords: ['tool usage', 'tool use', 'tool work', 'tool call', 'argument quality', 'argument-quality', 'response interpretation', 'tool selection', 'mcp tool', 'fixture']). The judge will grade other dimensions but won't score tool work explicitly. Consider adding a tool-usage dimension or renaming an existing one."
+              }
+            ]
+          },
+          "validators": {
+            "passed": true,
+            "results": [
+              {
+                "name": "test_id_references_resolve",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_log_append_only",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_entries_deleted",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_research_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tool_allowlist",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_gedcomx_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_research_json_unmodified",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_gedcomx_unmodified",
+                "passed": true,
+                "error": null
+              }
+            ]
+          },
+          "judge": {
+            "skipped": false,
+            "dimensions": [
+              {
+                "source": "base",
+                "name": "Correctness",
+                "score": 3,
+                "rationale": "The skill correctly identified the hasDeathBeforeChildBirth30_10 warning from the tool response and accurately explained the biological impossibility: a father cannot die more than ~300 days before a child's birth due to finite gestation. The recommended actions (verify parent-child link, check death date source, look for identity confusion) are all sound. The skill did not fabricate claims \u2014 all assertions are grounded in the tool response."
+              },
+              {
+                "source": "base",
+                "name": "Completeness",
+                "score": 3,
+                "rationale": "The skill addressed all requirements: called person_warnings for personId I2 (Thomas), reported the single warning returned, explained the biological basis for the Critical severity, suggested three distinct corrective actions (wrong death date, wrong relationship, identity confusion), and appropriately noted that FamilySearch quality is N/A for a synthetic ID. No portions of the user request or test expectations were omitted."
+              },
+              {
+                "source": "base",
+                "name": "Tool Arguments",
+                "score": 3,
+                "rationale": "The person_warnings call passed the expected args: personId 'I2'. The call matched the predicate and returned a valid response. The tool was called on a synthetic ID (not a FamilySearch ID), which is the correct and only scenario where person_warnings applies in this test, and the skill did not attempt to call person_quality on the synthetic ID."
+              },
+              {
+                "source": "rubric",
+                "name": "Detection accuracy",
+                "score": 3,
+                "rationale": "The skill correctly detected the genuine impossibility flagged by the tool: Thomas dying 300+ days before Patrick's birth. No false positives were introduced. The detection was accurate to the warning returned and its biological basis (finite gestation prevents a father from dying before conception)."
+              },
+              {
+                "source": "rubric",
+                "name": "Severity classification",
+                "score": 3,
+                "rationale": "The warning is correctly classified as Critical with severity 'error' \u2014 a biological impossibility (death before child's birth) is chronologically impossible and the highest-impact class of problem. The skill framed it as a Fundamental check and explained why it matters, distinguishing it from mere anomalies. Severity matches actual impact."
+              },
+              {
+                "source": "rubric",
+                "name": "Actionability",
+                "score": 3,
+                "rationale": "Each action is specific and tied to the records and relationships involved. The skill named Patrick Flynn (I1) as the related person and fact F1 (the birth), and suggested concrete steps: verify the parent-child link with sources, check Thomas's death date against the original source document, and look for identity confusion. A genealogist could immediately act on these suggestions."
+              },
+              {
+                "source": "rubric",
+                "name": "FamilySearch quality reporting",
+                "score": 3,
+                "rationale": "The skill correctly identified that Thomas Flynn (I2) is a synthetic (locally-assigned) ID, not a FamilySearch ID, so person_quality does not apply. It did not call person_quality. It stated this clearly in a separate note ('FamilySearch quality: Not applicable \u2014 Thomas Flynn (I2) is a locally-assigned ID'). The person_warnings result was reported completely and transparently. No confusion between offline warnings and quality scoring."
+              }
+            ],
+            "judge_cost_usd": 0.009437000000000001,
+            "duration_ms": 8701.996500021778,
+            "error": null,
+            "input_tokens": 5097,
+            "cached_input_tokens": 0,
+            "output_tokens": 868
+          },
+          "started_at": 1783269338.452745,
+          "ended_at": 1783269425.297415
+        }
+      ]
+    },
+    {
+      "test_id": "ut_check_warnings_006",
+      "test_type": "positive",
+      "expected_outcome": "pass",
+      "scenario": "mid-research-flynn",
+      "mcp_fixtures": [
+        "person-warnings-impossible-lifespan"
+      ],
+      "outcome": "pass",
+      "flaky": false,
+      "outcome_summary": {
+        "per_run_outcomes": [
+          "pass"
+        ],
+        "aggregated_dimensions": [
+          {
+            "source": "base",
+            "name": "Correctness",
+            "score": 3,
+            "rationale": "The skill correctly identified the Critical warning (hasAgeRangeGreaterThan120) from the tool response and reported it accurately. The message matches the tool response verbatim. The rationale provided ('misread birth year' or 'death record from same-name relative') aligns with genuine causes of this impossibility. No fabricated claims."
+          },
+          {
+            "source": "base",
+            "name": "Completeness",
+            "score": 3,
+            "rationale": "The skill addressed the user's request fully: ran person_warnings on Patrick Flynn (I1), reported the one warning found, specified facts involved (F1 and F2), and recommended concrete next steps (verify dates against original sources). No silent omissions."
+          },
+          {
+            "source": "base",
+            "name": "Tool Arguments",
+            "score": 3,
+            "rationale": "The person_warnings call used correct arguments: personId='I1' matches expected_args exactly. The projectPath was provided and matched.kind='predicate' confirms successful fixture match. All tool arguments are correct."
+          },
+          {
+            "source": "rubric",
+            "name": "Detection accuracy",
+            "score": 3,
+            "rationale": "The skill correctly detected the hasAgeRangeGreaterThan120 impossibility reported by the tool. No false positives on edge cases appear in the response. The detection matches what the tool returned without adding spurious warnings."
+          },
+          {
+            "source": "rubric",
+            "name": "Severity classification",
+            "score": 3,
+            "rationale": "The skill correctly classified the >120-year lifespan as 'Critical' (labeled as '[!] Critical' and 'error' severity). This matches the test expectation that the Fundamental tier (tool's error level) should be treated as Critical, not downgraded to Low/Medium. Severity assignment is appropriate to the impact."
+          },
+          {
+            "source": "rubric",
+            "name": "Actionability",
+            "score": 3,
+            "rationale": "The warning is highly actionable. It names the specific facts involved (F1 and F2), explains the most common causes (misread birth year like '1745' vs '1845', or death record from same-name relative), and recommends the exact action: 'Verify the birth and death dates recorded in F1 and F2 against their original sources.' A genealogist can immediately act on this."
+          },
+          {
+            "source": "rubric",
+            "name": "FamilySearch quality reporting",
+            "score": 3,
+            "rationale": "The skill correctly identified that I1 is a synthetic ID (not a FamilySearch ID) and explicitly stated 'I'll run person_warnings and skip the FamilySearch quality call.' No person_quality call was made, which is the correct behavior. The warnings result is intact and not suppressed. Quality reporting is handled appropriately."
+          }
+        ]
+      },
+      "totals": {
+        "duration_ms": 34841.35054197395,
+        "duration_api_ms": 33084.0,
+        "judge_duration_ms": 7458.528207964264,
+        "wall_clock_ms": 42638.103008270264,
+        "num_turns": 9,
+        "input_tokens": 13,
+        "cached_input_tokens": 83832,
+        "output_tokens": 1281,
+        "judge_input_tokens": 4883,
+        "judge_cached_input_tokens": 0,
+        "judge_output_tokens": 772,
+        "skill_cost_usd": 0.0802571,
+        "judge_cost_usd": 0.008743,
+        "total_cost_usd": 0.0890001
+      },
+      "runs": [
+        {
+          "run_index": 0,
+          "run_id": "run_ut_check_warnings_006_2026-07-05_16-35-38_0",
+          "outcome": "pass",
+          "aborted_reason": null,
+          "duration_ms": 34841.35054197395,
+          "duration_api_ms": 33084.0,
+          "num_turns": 9,
+          "skill_attempts": 1,
+          "input_tokens": 13,
+          "cached_input_tokens": 83832,
+          "output_tokens": 1281,
+          "skill_cost_usd": 0.0802571,
+          "output": {
+            "text_response": "Patrick Flynn is person `I1` \u2014 a synthetic ID, so I'll run `person_warnings` and skip the FamilySearch quality call. Let me load the tool schema.---\n\n## Warnings for Patrick Flynn (I1)\n\n**[!] Critical \u2014 Implausible lifespan** `[hasAgeRangeGreaterThan120]`\n*Fundamental: a human lifespan cannot exceed ~120 years.*\n\n> \"This person's lifespan is greater than 120 years, which is implausible.\"\n\n**Facts involved:** F1 (Birth) and F2 (Death/end-of-life event)\n\n**Next step:** Verify the birth and death dates recorded in F1 and F2 against their original sources. One of the two dates is almost certainly wrong \u2014 a transcription error, a digit transposed, or a record that may actually belong to a different individual. Correcting whichever date is in error should resolve this warning.\n\n---\n\n*(1 warning total)*\n\nThis is a `severity: \"error\"` finding, so it warrants prompt investigation. The most common causes are a misread birth year (e.g., `1745` instead of `1845`) or a death record that belongs to a same-name relative. Checking the original documents behind F1 and F2 is the right first move.",
+            "activated": true,
+            "skills_invoked": [
+              "check-warnings"
+            ],
+            "tool_calls": [
+              {
+                "tool": "mcp__genealogy__person_warnings",
+                "args": {
+                  "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/eval-ut_check_warnings_006-0-0-cg3n5jom",
+                  "personId": "I1"
+                },
+                "expected_args": {
+                  "personId": "I1"
+                },
+                "matched": {
+                  "kind": "predicate",
+                  "index": 0
+                },
+                "response_fixture": "person-warnings-impossible-lifespan"
+              }
+            ],
+            "files_created": [],
+            "warnings": [
+              {
+                "kind": "missing_tool_usage_dimension",
+                "advisory": "Skill called MCP tools but the rubric has no dimension name suggesting tool-usage coverage (matched against keywords: ['tool usage', 'tool use', 'tool work', 'tool call', 'argument quality', 'argument-quality', 'response interpretation', 'tool selection', 'mcp tool', 'fixture']). The judge will grade other dimensions but won't score tool work explicitly. Consider adding a tool-usage dimension or renaming an existing one."
+              }
+            ]
+          },
+          "validators": {
+            "passed": true,
+            "results": [
+              {
+                "name": "test_id_references_resolve",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_log_append_only",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_entries_deleted",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_research_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tool_allowlist",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_gedcomx_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_research_json_unmodified",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_gedcomx_unmodified",
+                "passed": true,
+                "error": null
+              }
+            ]
+          },
+          "judge": {
+            "skipped": false,
+            "dimensions": [
+              {
+                "source": "base",
+                "name": "Correctness",
+                "score": 3,
+                "rationale": "The skill correctly identified the Critical warning (hasAgeRangeGreaterThan120) from the tool response and reported it accurately. The message matches the tool response verbatim. The rationale provided ('misread birth year' or 'death record from same-name relative') aligns with genuine causes of this impossibility. No fabricated claims."
+              },
+              {
+                "source": "base",
+                "name": "Completeness",
+                "score": 3,
+                "rationale": "The skill addressed the user's request fully: ran person_warnings on Patrick Flynn (I1), reported the one warning found, specified facts involved (F1 and F2), and recommended concrete next steps (verify dates against original sources). No silent omissions."
+              },
+              {
+                "source": "base",
+                "name": "Tool Arguments",
+                "score": 3,
+                "rationale": "The person_warnings call used correct arguments: personId='I1' matches expected_args exactly. The projectPath was provided and matched.kind='predicate' confirms successful fixture match. All tool arguments are correct."
+              },
+              {
+                "source": "rubric",
+                "name": "Detection accuracy",
+                "score": 3,
+                "rationale": "The skill correctly detected the hasAgeRangeGreaterThan120 impossibility reported by the tool. No false positives on edge cases appear in the response. The detection matches what the tool returned without adding spurious warnings."
+              },
+              {
+                "source": "rubric",
+                "name": "Severity classification",
+                "score": 3,
+                "rationale": "The skill correctly classified the >120-year lifespan as 'Critical' (labeled as '[!] Critical' and 'error' severity). This matches the test expectation that the Fundamental tier (tool's error level) should be treated as Critical, not downgraded to Low/Medium. Severity assignment is appropriate to the impact."
+              },
+              {
+                "source": "rubric",
+                "name": "Actionability",
+                "score": 3,
+                "rationale": "The warning is highly actionable. It names the specific facts involved (F1 and F2), explains the most common causes (misread birth year like '1745' vs '1845', or death record from same-name relative), and recommends the exact action: 'Verify the birth and death dates recorded in F1 and F2 against their original sources.' A genealogist can immediately act on this."
+              },
+              {
+                "source": "rubric",
+                "name": "FamilySearch quality reporting",
+                "score": 3,
+                "rationale": "The skill correctly identified that I1 is a synthetic ID (not a FamilySearch ID) and explicitly stated 'I'll run person_warnings and skip the FamilySearch quality call.' No person_quality call was made, which is the correct behavior. The warnings result is intact and not suppressed. Quality reporting is handled appropriately."
+              }
+            ],
+            "judge_cost_usd": 0.008743,
+            "duration_ms": 7458.528207964264,
+            "error": null,
+            "input_tokens": 4883,
+            "cached_input_tokens": 0,
+            "output_tokens": 772
+          },
+          "started_at": 1783269338.4524832,
+          "ended_at": 1783269381.0905862
+        }
+      ]
+    },
+    {
+      "test_id": "ut_check_warnings_013",
+      "test_type": "positive",
+      "expected_outcome": "pass",
+      "scenario": "flynn-posthumous-residence",
+      "mcp_fixtures": [
+        "person-warnings-posthumous-residence"
+      ],
+      "outcome": "partial",
+      "flaky": false,
+      "outcome_summary": {
+        "per_run_outcomes": [
+          "partial"
+        ],
+        "aggregated_dimensions": [
+          {
+            "source": "base",
+            "name": "Correctness",
+            "score": 2,
+            "rationale": "The skill correctly identified the critical warning from the tool and accurately reported the three general causes of events-after-death. However, the skill did not inspect the source behind F3 as recommended, nor did it identify the specific source S5 (Mary Brennan's obituary) that the test author expected to be surfaced. The skill presented all three causes as equally plausible without prioritizing posthumous mention based on the signature evidence of a Residence from a relative's obituary. This is a factual omission \u2014 the tool response message indicates F3 is a Residence, and the scenario README confirms F3 is sourced from the daughter's obituary, which is the key cue for posthumous mention diagnosis."
+          },
+          {
+            "source": "base",
+            "name": "Completeness",
+            "score": 2,
+            "rationale": "The skill detected the warning and explained the three corrective pathways. However, it missed a critical piece: the skill should have identified F3 as a Residence sourced from a relative's obituary (the signature pattern for posthumous mention). The test author expected the skill to name F3 and point specifically to the obituary-of-relative evidence, not leave it as generic 'inspect the source.' The phrase 'Inspect the source behind the Residence fact (F3)' defers the diagnosis rather than performing it, and does not cite the source itself."
+          },
+          {
+            "source": "base",
+            "name": "Tool Arguments",
+            "score": 3,
+            "rationale": "The tool call passed the correct personId 'I1' and projectPath, matching the expected_args. The call succeeded with matched.kind == 'predicate', and the skill correctly treated the tool response as the source of truth for the warning."
+          },
+          {
+            "source": "rubric",
+            "name": "Detection accuracy",
+            "score": 3,
+            "rationale": "The skill correctly detected the genuine impossibility (event after death) flagged by the tool and reported it without false positives. The tool confirmed the warning is real (severity: error), and the skill correctly named all three facts involved (F1, F2, F3)."
+          },
+          {
+            "source": "rubric",
+            "name": "Severity classification",
+            "score": 3,
+            "rationale": "The skill correctly classified the hasEventAfterDeath1 warning as Critical (matching the tool's severity: 'error'), recognizing it as a fundamental-assumption violation per the instruction mapping. The phrasing 'Fundamental: people cannot perform actions after their death' reflects the correct severity tier."
+          },
+          {
+            "source": "rubric",
+            "name": "Actionability",
+            "score": 2,
+            "rationale": "The skill provided three named causes and corresponding investigative steps, which is a strong structure. However, the recommended immediate action ('Inspect the source behind the Residence fact (F3)') is somewhat generic \u2014 it asks the user to inspect first and decide later, rather than surfacing the posthumous-mention diagnosis as the most likely and actionable path based on the evidence (Residence from a relative's obituary). The skill should have identified the source type as the key clue and recommended unlinking as the primary action, not just inspection."
+          },
+          {
+            "source": "rubric",
+            "name": "FamilySearch quality reporting",
+            "score": 3,
+            "rationale": "The skill correctly recognized that Patrick Flynn's ID is synthetic ('I1', not a FamilySearch ID) and did not call person_quality. The statement 'Not applicable \u2014 Patrick Flynn has a local synthetic ID' is accurate and properly distinct from the impossibilities section."
+          }
+        ]
+      },
+      "totals": {
+        "duration_ms": 72532.77458297089,
+        "duration_api_ms": 70024.0,
+        "judge_duration_ms": 9810.637834016234,
+        "wall_clock_ms": 82511.87992095947,
+        "num_turns": 8,
+        "input_tokens": 12,
+        "cached_input_tokens": 93848,
+        "output_tokens": 3132,
+        "judge_input_tokens": 5214,
+        "judge_cached_input_tokens": 0,
+        "judge_output_tokens": 933,
+        "skill_cost_usd": 0.15602165,
+        "judge_cost_usd": 0.009878999999999999,
+        "total_cost_usd": 0.16590065
+      },
+      "runs": [
+        {
+          "run_index": 0,
+          "run_id": "run_ut_check_warnings_013_2026-07-05_16-35-38_0",
+          "outcome": "partial",
+          "aborted_reason": null,
+          "duration_ms": 72532.77458297089,
+          "duration_api_ms": 70024.0,
+          "num_turns": 8,
+          "skill_attempts": 1,
+          "input_tokens": 12,
+          "cached_input_tokens": 93848,
+          "output_tokens": 3132,
+          "skill_cost_usd": 0.15602165,
+          "output": {
+            "text_response": "I've found Patrick Flynn \u2014 he's person `I1`. Since this is a synthetic ID (not a FamilySearch ID), I'll run the offline warnings check only.---\n\n## WARNINGS FOR: Patrick Flynn (I1)\n\n**1 warning found.**\n\n---\n\n**[!] Critical \u2014 Event after death `[hasEventAfterDeath1]`**\n*Fundamental: people cannot perform actions after their death \u2014 though a posthumous mention can be misattached to their profile.*\n\nAn event is dated more than 1 year after this person's latest death-like fact.\n\nThe facts involved (as named by the tool): **F1** (Birth), **F2** (Death), **F3** (Residence).\n\nThis warning has three common causes \u2014 the right corrective action depends on which one applies here:\n\n- **(a) Wrong death date** \u2014 the recorded death date in F2 is too early. Cue: the late-dated record in F3 is inconsistent with F2 but consistent with everything else. *Next step: verify the recorded death date against the original death record (the certificate or burial register) \u2014 one of the two dates is likely wrong.*\n\n- **(b) Identity confusion** \u2014 the record behind F3 actually describes a same-name individual who outlived Patrick. Cue: the source describes events apparently *performed by* the deceased (e.g., a later census listing Patrick as head of household, a later marriage). *Next step: rebuild a full chronological timeline of every recorded event and examine each one to determine whether it belongs to Patrick or to a same-name person whose records were merged in.*\n\n- **(c) Posthumous mention** \u2014 the record behind F3 was created after Patrick's death and merely *references* him (an obituary, a descendant's death certificate, an estate or probate document naming him as a parent or prior owner). Cue: Patrick is not shown performing any action in the record \u2014 he's just named by someone else. *Next step: look at the late-dated record itself \u2014 if it's a record about someone else that simply mentions Patrick as a parent or relative, it shouldn't be attached to his profile as one of his own events. Unlink it and treat it as a reference instead.*\n\n**Recommended immediate action:** Inspect the source behind the Residence fact (F3) to determine what kind of document it is. Once you know which of the three scenarios applies, the correct fix is clear.\n\n---\n\n*(1 warning total)*\n\n---\n\n**FamilySearch quality:** Not applicable \u2014 Patrick Flynn has a local synthetic ID (`I1`) with no corresponding FamilySearch profile to score.",
+            "activated": true,
+            "skills_invoked": [
+              "check-warnings"
+            ],
+            "tool_calls": [
+              {
+                "tool": "mcp__genealogy__person_warnings",
+                "args": {
+                  "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/eval-ut_check_warnings_013-0-0-s2v9qbfc",
+                  "personId": "I1"
+                },
+                "expected_args": {
+                  "personId": "I1"
+                },
+                "matched": {
+                  "kind": "predicate",
+                  "index": 0
+                },
+                "response_fixture": "person-warnings-posthumous-residence"
+              }
+            ],
+            "files_created": [],
+            "warnings": [
+              {
+                "kind": "missing_tool_usage_dimension",
+                "advisory": "Skill called MCP tools but the rubric has no dimension name suggesting tool-usage coverage (matched against keywords: ['tool usage', 'tool use', 'tool work', 'tool call', 'argument quality', 'argument-quality', 'response interpretation', 'tool selection', 'mcp tool', 'fixture']). The judge will grade other dimensions but won't score tool work explicitly. Consider adding a tool-usage dimension or renaming an existing one."
+              }
+            ]
+          },
+          "validators": {
+            "passed": true,
+            "results": [
+              {
+                "name": "test_id_references_resolve",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_log_append_only",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_entries_deleted",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_research_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tool_allowlist",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_gedcomx_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_research_json_unmodified",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_gedcomx_unmodified",
+                "passed": true,
+                "error": null
+              }
+            ]
+          },
+          "judge": {
+            "skipped": false,
+            "dimensions": [
+              {
+                "source": "base",
+                "name": "Correctness",
+                "score": 2,
+                "rationale": "The skill correctly identified the critical warning from the tool and accurately reported the three general causes of events-after-death. However, the skill did not inspect the source behind F3 as recommended, nor did it identify the specific source S5 (Mary Brennan's obituary) that the test author expected to be surfaced. The skill presented all three causes as equally plausible without prioritizing posthumous mention based on the signature evidence of a Residence from a relative's obituary. This is a factual omission \u2014 the tool response message indicates F3 is a Residence, and the scenario README confirms F3 is sourced from the daughter's obituary, which is the key cue for posthumous mention diagnosis."
+              },
+              {
+                "source": "base",
+                "name": "Completeness",
+                "score": 2,
+                "rationale": "The skill detected the warning and explained the three corrective pathways. However, it missed a critical piece: the skill should have identified F3 as a Residence sourced from a relative's obituary (the signature pattern for posthumous mention). The test author expected the skill to name F3 and point specifically to the obituary-of-relative evidence, not leave it as generic 'inspect the source.' The phrase 'Inspect the source behind the Residence fact (F3)' defers the diagnosis rather than performing it, and does not cite the source itself."
+              },
+              {
+                "source": "base",
+                "name": "Tool Arguments",
+                "score": 3,
+                "rationale": "The tool call passed the correct personId 'I1' and projectPath, matching the expected_args. The call succeeded with matched.kind == 'predicate', and the skill correctly treated the tool response as the source of truth for the warning."
+              },
+              {
+                "source": "rubric",
+                "name": "Detection accuracy",
+                "score": 3,
+                "rationale": "The skill correctly detected the genuine impossibility (event after death) flagged by the tool and reported it without false positives. The tool confirmed the warning is real (severity: error), and the skill correctly named all three facts involved (F1, F2, F3)."
+              },
+              {
+                "source": "rubric",
+                "name": "Severity classification",
+                "score": 3,
+                "rationale": "The skill correctly classified the hasEventAfterDeath1 warning as Critical (matching the tool's severity: 'error'), recognizing it as a fundamental-assumption violation per the instruction mapping. The phrasing 'Fundamental: people cannot perform actions after their death' reflects the correct severity tier."
+              },
+              {
+                "source": "rubric",
+                "name": "Actionability",
+                "score": 2,
+                "rationale": "The skill provided three named causes and corresponding investigative steps, which is a strong structure. However, the recommended immediate action ('Inspect the source behind the Residence fact (F3)') is somewhat generic \u2014 it asks the user to inspect first and decide later, rather than surfacing the posthumous-mention diagnosis as the most likely and actionable path based on the evidence (Residence from a relative's obituary). The skill should have identified the source type as the key clue and recommended unlinking as the primary action, not just inspection."
+              },
+              {
+                "source": "rubric",
+                "name": "FamilySearch quality reporting",
+                "score": 3,
+                "rationale": "The skill correctly recognized that Patrick Flynn's ID is synthetic ('I1', not a FamilySearch ID) and did not call person_quality. The statement 'Not applicable \u2014 Patrick Flynn has a local synthetic ID' is accurate and properly distinct from the impossibilities section."
+              }
+            ],
+            "judge_cost_usd": 0.009878999999999999,
+            "duration_ms": 9810.637834016234,
+            "error": null,
+            "input_tokens": 5214,
+            "cached_input_tokens": 0,
+            "output_tokens": 933
+          },
+          "started_at": 1783269338.4521291,
+          "ended_at": 1783269420.964009
+        }
+      ]
+    },
+    {
+      "test_id": "ut_check_warnings_008",
+      "test_type": "positive",
+      "expected_outcome": "pass",
+      "scenario": "mid-research-flynn",
+      "mcp_fixtures": [
+        "person-warnings-relative-warning"
+      ],
+      "outcome": "pass",
+      "flaky": false,
+      "outcome_summary": {
+        "per_run_outcomes": [
+          "pass"
+        ],
+        "aggregated_dimensions": [
+          {
+            "source": "base",
+            "name": "Correctness",
+            "score": 3,
+            "rationale": "The skill correctly identified that Patrick (I1) has a synthetic ID and needs only the offline impossibility check. The warning returned by person_warnings was accurately reported: Thomas Flynn (I2) has an implausible lifespan exceeding 120 years (tied to F3). The skill's text response faithfully matches the tool response without fabrication or mischaracterization."
+          },
+          {
+            "source": "base",
+            "name": "Completeness",
+            "score": 3,
+            "rationale": "The skill fully addressed the user's request to check Patrick Flynn for warnings. It reported the single warning found, clarified the focal person vs. the relative with the issue, and provided actionable next steps. No gaps in coverage."
+          },
+          {
+            "source": "base",
+            "name": "Tool Arguments",
+            "score": 3,
+            "rationale": "The skill called person_warnings with personId='I1' (Patrick, the focal person), which matches the expected_args. The tool call was correct and well-formed. No extra or incorrect arguments."
+          },
+          {
+            "source": "rubric",
+            "name": "Detection accuracy",
+            "score": 3,
+            "rationale": "The skill detected the genuine impossibility flagged by the tool: a 120+ year lifespan for Thomas Flynn. No false positives were generated. The warning directly corresponds to a real data anomaly (F3 on Thomas's record), and the skill correctly recognized it as a legitimate issue."
+          },
+          {
+            "source": "rubric",
+            "name": "Severity classification",
+            "score": 3,
+            "rationale": "The warning (relativesHasAgeRangeGreaterThan120) was classified as a 'Note' level alert (not critical/error), which is appropriate for a chronological impossibility. The tool labeled it 'severity: warning' and the skill framed it as a serious but non-fatal issue requiring verification\u2014the correct tier for an implausible-but-not-absolutely-contradictory lifespan."
+          },
+          {
+            "source": "rubric",
+            "name": "Actionability",
+            "score": 3,
+            "rationale": "The warning is highly actionable. The skill names the specific relative (Thomas Flynn, I2), the specific fact (F3), and the implausible metric (120+ year lifespan). It suggests two concrete next steps: (1) verify the relationship link is correct (per the Step 4 rule on relatives*), and (2) check Thomas's birth/death dates against original sources, with common causes (transposition, century error). These are concrete actions a genealogist can execute."
+          },
+          {
+            "source": "rubric",
+            "name": "FamilySearch quality reporting",
+            "score": 3,
+            "rationale": "The skill correctly identified that Patrick (I1) has a synthetic ID and did not call person_quality\u2014the expected behavior. The skill explicitly stated 'No FamilySearch quality call needed' and explained why. The offline impossibility check (person_warnings) was run and reported cleanly. No inappropriate quality calls or suppressions occurred."
+          }
+        ]
+      },
+      "totals": {
+        "duration_ms": 35325.046583020594,
+        "duration_api_ms": 33189.0,
+        "judge_duration_ms": 7656.501249992289,
+        "wall_clock_ms": 43162.23096847534,
+        "num_turns": 9,
+        "input_tokens": 13,
+        "cached_input_tokens": 84622,
+        "output_tokens": 1414,
+        "judge_input_tokens": 4959,
+        "judge_cached_input_tokens": 0,
+        "judge_output_tokens": 814,
+        "skill_cost_usd": 0.08334185,
+        "judge_cost_usd": 0.009028999999999999,
+        "total_cost_usd": 0.09237084999999999
+      },
+      "runs": [
+        {
+          "run_index": 0,
+          "run_id": "run_ut_check_warnings_008_2026-07-05_16-35-38_0",
+          "outcome": "pass",
+          "aborted_reason": null,
+          "duration_ms": 35325.046583020594,
+          "duration_api_ms": 33189.0,
+          "num_turns": 9,
+          "skill_attempts": 1,
+          "input_tokens": 13,
+          "cached_input_tokens": 84622,
+          "output_tokens": 1414,
+          "skill_cost_usd": 0.08334185,
+          "output": {
+            "text_response": "Patrick Flynn's person ID is `I1` \u2014 a synthetic ID, so I'll run the offline impossibility check. No FamilySearch quality call needed.---\n\n## WARNINGS FOR: Patrick Flynn (I1)\n\n**1 warning found.**\n\n---\n\n**[!] Note \u2014 Relative with implausible lifespan** `[relativesHasAgeRangeGreaterThan120]`\n*[Valid: people rarely live past 120 years.]*\n\nA relative of Patrick Flynn \u2014 **Thomas Flynn (I2)** \u2014 has a recorded lifespan greater than 120 years, which is implausible. The issue is tied to fact **F3** on Thomas's record.\n\n> \u26a0\ufe0f This warning is about **Thomas Flynn**, not Patrick directly. The first thing to check is whether Thomas is actually Patrick's father (or whichever relative he is), or whether a same-name record was linked here by mistake. Once you confirm the relationship is correct, then we can look at whether Thomas's dates need fixing.\n\n**Next step:** Verify Thomas Flynn's birth and/or death dates against their original sources. A 120+ year lifespan almost always means at least one date was transcribed or entered incorrectly \u2014 a digit transposition, an assumed date, or a century error are the most common culprits.\n\n---\n\n*(1 warning total \u2014 no FamilySearch quality score checked, as Patrick Flynn has a synthetic local ID with no FamilySearch profile.)*",
+            "activated": true,
+            "skills_invoked": [
+              "check-warnings"
+            ],
+            "tool_calls": [
+              {
+                "tool": "mcp__genealogy__person_warnings",
+                "args": {
+                  "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/eval-ut_check_warnings_008-0-0-2ul7b0n1",
+                  "personId": "I1"
+                },
+                "expected_args": {
+                  "personId": "I1"
+                },
+                "matched": {
+                  "kind": "predicate",
+                  "index": 0
+                },
+                "response_fixture": "person-warnings-relative-warning"
+              }
+            ],
+            "files_created": [],
+            "warnings": [
+              {
+                "kind": "missing_tool_usage_dimension",
+                "advisory": "Skill called MCP tools but the rubric has no dimension name suggesting tool-usage coverage (matched against keywords: ['tool usage', 'tool use', 'tool work', 'tool call', 'argument quality', 'argument-quality', 'response interpretation', 'tool selection', 'mcp tool', 'fixture']). The judge will grade other dimensions but won't score tool work explicitly. Consider adding a tool-usage dimension or renaming an existing one."
+              }
+            ]
+          },
+          "validators": {
+            "passed": true,
+            "results": [
+              {
+                "name": "test_id_references_resolve",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_log_append_only",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_entries_deleted",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_research_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tool_allowlist",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_gedcomx_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_research_json_unmodified",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_gedcomx_unmodified",
+                "passed": true,
+                "error": null
+              }
+            ]
+          },
+          "judge": {
+            "skipped": false,
+            "dimensions": [
+              {
+                "source": "base",
+                "name": "Correctness",
+                "score": 3,
+                "rationale": "The skill correctly identified that Patrick (I1) has a synthetic ID and needs only the offline impossibility check. The warning returned by person_warnings was accurately reported: Thomas Flynn (I2) has an implausible lifespan exceeding 120 years (tied to F3). The skill's text response faithfully matches the tool response without fabrication or mischaracterization."
+              },
+              {
+                "source": "base",
+                "name": "Completeness",
+                "score": 3,
+                "rationale": "The skill fully addressed the user's request to check Patrick Flynn for warnings. It reported the single warning found, clarified the focal person vs. the relative with the issue, and provided actionable next steps. No gaps in coverage."
+              },
+              {
+                "source": "base",
+                "name": "Tool Arguments",
+                "score": 3,
+                "rationale": "The skill called person_warnings with personId='I1' (Patrick, the focal person), which matches the expected_args. The tool call was correct and well-formed. No extra or incorrect arguments."
+              },
+              {
+                "source": "rubric",
+                "name": "Detection accuracy",
+                "score": 3,
+                "rationale": "The skill detected the genuine impossibility flagged by the tool: a 120+ year lifespan for Thomas Flynn. No false positives were generated. The warning directly corresponds to a real data anomaly (F3 on Thomas's record), and the skill correctly recognized it as a legitimate issue."
+              },
+              {
+                "source": "rubric",
+                "name": "Severity classification",
+                "score": 3,
+                "rationale": "The warning (relativesHasAgeRangeGreaterThan120) was classified as a 'Note' level alert (not critical/error), which is appropriate for a chronological impossibility. The tool labeled it 'severity: warning' and the skill framed it as a serious but non-fatal issue requiring verification\u2014the correct tier for an implausible-but-not-absolutely-contradictory lifespan."
+              },
+              {
+                "source": "rubric",
+                "name": "Actionability",
+                "score": 3,
+                "rationale": "The warning is highly actionable. The skill names the specific relative (Thomas Flynn, I2), the specific fact (F3), and the implausible metric (120+ year lifespan). It suggests two concrete next steps: (1) verify the relationship link is correct (per the Step 4 rule on relatives*), and (2) check Thomas's birth/death dates against original sources, with common causes (transposition, century error). These are concrete actions a genealogist can execute."
+              },
+              {
+                "source": "rubric",
+                "name": "FamilySearch quality reporting",
+                "score": 3,
+                "rationale": "The skill correctly identified that Patrick (I1) has a synthetic ID and did not call person_quality\u2014the expected behavior. The skill explicitly stated 'No FamilySearch quality call needed' and explained why. The offline impossibility check (person_warnings) was run and reported cleanly. No inappropriate quality calls or suppressions occurred."
+              }
+            ],
+            "judge_cost_usd": 0.009028999999999999,
+            "duration_ms": 7656.501249992289,
+            "error": null,
+            "input_tokens": 4959,
+            "cached_input_tokens": 0,
+            "output_tokens": 814
+          },
+          "started_at": 1783269338.451852,
+          "ended_at": 1783269381.614083
+        }
+      ]
+    },
+    {
+      "test_id": "ut_check_warnings_003",
+      "test_type": "negative",
+      "expected_outcome": "pass",
+      "scenario": "mid-research-flynn",
+      "mcp_fixtures": [
+        "person-warnings-no-warnings"
+      ],
+      "outcome": "pass",
+      "flaky": false,
+      "outcome_summary": {
+        "per_run_outcomes": [
+          "pass"
+        ],
+        "aggregated_dimensions": [
+          {
+            "source": "base",
+            "name": "Correctness",
+            "score": 3,
+            "rationale": "The skill correctly declined to run check-warnings and routed the user to project-status as instructed. This is the correct behavior for this negative test scenario where the user requested a project overview rather than warning detection. The routing decision is accurate and appropriate."
+          },
+          {
+            "source": "base",
+            "name": "Completeness",
+            "score": 3,
+            "rationale": "The skill fully addressed the user's request by recognizing that 'give me an overview' is a project-status task rather than a check-warnings task, and routed accordingly. No pieces of the required action (declining and routing) were omitted."
+          },
+          {
+            "source": "base",
+            "name": "Tool Arguments",
+            "score": null,
+            "rationale": "No MCP tool calls were made. The skill correctly routed the user to project-status without attempting to run its own task, so tool invocation was not applicable here. N/A."
+          }
+        ]
+      },
+      "totals": {
+        "duration_ms": 3524.9709589988925,
+        "duration_api_ms": 0.0,
+        "judge_duration_ms": 3202.3950410075486,
+        "wall_clock_ms": 6792.801856994629,
+        "num_turns": 0,
+        "input_tokens": 0,
+        "cached_input_tokens": 0,
+        "output_tokens": 0,
+        "judge_input_tokens": 3114,
+        "judge_cached_input_tokens": 0,
+        "judge_output_tokens": 295,
+        "skill_cost_usd": 0.0,
+        "judge_cost_usd": 0.004589,
+        "total_cost_usd": 0.004589
+      },
+      "runs": [
+        {
+          "run_index": 0,
+          "run_id": "run_ut_check_warnings_003_2026-07-05_16-35-38_0",
+          "outcome": "pass",
+          "aborted_reason": null,
+          "duration_ms": 3524.9709589988925,
+          "duration_api_ms": 0.0,
+          "num_turns": 0,
+          "skill_attempts": 1,
+          "input_tokens": 0,
+          "cached_input_tokens": 0,
+          "output_tokens": 0,
+          "skill_cost_usd": 0.0,
+          "output": {
+            "text_response": "",
+            "activated": false,
+            "skills_invoked": [
+              "project-status"
+            ],
+            "tool_calls": [],
+            "files_created": []
+          },
+          "validators": {
+            "passed": true,
+            "results": [
+              {
+                "name": "test_id_references_resolve",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_log_append_only",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_entries_deleted",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_ownership_table",
+                "passed": true,
+                "error": "skipped: ownership is not checked on negative tests \u2014 writes belong to the routed-to skill, not the skill under test"
+              },
+              {
+                "name": "test_research_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tool_allowlist",
+                "passed": true,
+                "error": "skipped: allowlist is not checked on negative tests \u2014 tool calls belong to the routed-to skill, not the skill under test"
+              },
+              {
+                "name": "test_tree_gedcomx_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_ownership_table",
+                "passed": true,
+                "error": "skipped: ownership is not checked on negative tests \u2014 writes belong to the routed-to skill, not the skill under test"
+              },
+              {
+                "name": "test_research_json_unmodified",
+                "passed": true,
+                "error": "skipped: negative tests don't run the skill body"
+              },
+              {
+                "name": "test_tree_gedcomx_unmodified",
+                "passed": true,
+                "error": "skipped: negative tests don't run the skill body"
+              }
+            ]
+          },
+          "judge": {
+            "skipped": false,
+            "dimensions": [
+              {
+                "source": "base",
+                "name": "Correctness",
+                "score": 3,
+                "rationale": "The skill correctly declined to run check-warnings and routed the user to project-status as instructed. This is the correct behavior for this negative test scenario where the user requested a project overview rather than warning detection. The routing decision is accurate and appropriate."
+              },
+              {
+                "source": "base",
+                "name": "Completeness",
+                "score": 3,
+                "rationale": "The skill fully addressed the user's request by recognizing that 'give me an overview' is a project-status task rather than a check-warnings task, and routed accordingly. No pieces of the required action (declining and routing) were omitted."
+              },
+              {
+                "source": "base",
+                "name": "Tool Arguments",
+                "score": null,
+                "rationale": "No MCP tool calls were made. The skill correctly routed the user to project-status without attempting to run its own task, so tool invocation was not applicable here. N/A."
+              }
+            ],
+            "judge_cost_usd": 0.004589,
+            "duration_ms": 3202.3950410075486,
+            "error": null,
+            "input_tokens": 3114,
+            "cached_input_tokens": 0,
+            "output_tokens": 295
+          },
+          "started_at": 1783269421.177082,
+          "ended_at": 1783269427.969884
+        }
+      ]
+    },
+    {
+      "test_id": "ut_check_warnings_012",
+      "test_type": "negative",
+      "expected_outcome": "pass",
+      "scenario": "mid-research-flynn",
+      "mcp_fixtures": [
+        "person-warnings-no-warnings"
+      ],
+      "outcome": "pass",
+      "flaky": false,
+      "outcome_summary": {
+        "per_run_outcomes": [
+          "pass"
+        ],
+        "aggregated_dimensions": [
+          {
+            "source": "base",
+            "name": "Correctness",
+            "score": 3,
+            "rationale": "The skill correctly identified that this is a negative test case about file structure validation. It properly declined to run check-warnings and routed the user to validate-schema, which is the appropriate skill for schema validation tasks. The routing decision matches the test's expectations."
+          },
+          {
+            "source": "base",
+            "name": "Completeness",
+            "score": 3,
+            "rationale": "The skill fully addressed what was needed: it recognized the user's request about validating research.json structure and completely handled it by declining its own task and routing to the correct downstream skill (validate-schema). No portions of the expected behavior were omitted."
+          },
+          {
+            "source": "base",
+            "name": "Tool Arguments",
+            "score": null,
+            "rationale": "No MCP tool calls were made. This is correct behavior for this negative test case\u2014the skill should decline and route rather than invoke its own tools. N/A per instructions."
+          }
+        ]
+      },
+      "totals": {
+        "duration_ms": 3835.756750020664,
+        "duration_api_ms": 0.0,
+        "judge_duration_ms": 3125.489917001687,
+        "wall_clock_ms": 7029.266119003296,
+        "num_turns": 0,
+        "input_tokens": 0,
+        "cached_input_tokens": 0,
+        "output_tokens": 0,
+        "judge_input_tokens": 3164,
+        "judge_cached_input_tokens": 0,
+        "judge_output_tokens": 292,
+        "skill_cost_usd": 0.0,
+        "judge_cost_usd": 0.004624,
+        "total_cost_usd": 0.004624
+      },
+      "runs": [
+        {
+          "run_index": 0,
+          "run_id": "run_ut_check_warnings_012_2026-07-05_16-35-38_0",
+          "outcome": "pass",
+          "aborted_reason": null,
+          "duration_ms": 3835.756750020664,
+          "duration_api_ms": 0.0,
+          "num_turns": 0,
+          "skill_attempts": 1,
+          "input_tokens": 0,
+          "cached_input_tokens": 0,
+          "output_tokens": 0,
+          "skill_cost_usd": 0.0,
+          "output": {
+            "text_response": "",
+            "activated": false,
+            "skills_invoked": [
+              "validate-schema"
+            ],
+            "tool_calls": [],
+            "files_created": []
+          },
+          "validators": {
+            "passed": true,
+            "results": [
+              {
+                "name": "test_id_references_resolve",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_log_append_only",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_entries_deleted",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_ownership_table",
+                "passed": true,
+                "error": "skipped: ownership is not checked on negative tests \u2014 writes belong to the routed-to skill, not the skill under test"
+              },
+              {
+                "name": "test_research_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tool_allowlist",
+                "passed": true,
+                "error": "skipped: allowlist is not checked on negative tests \u2014 tool calls belong to the routed-to skill, not the skill under test"
+              },
+              {
+                "name": "test_tree_gedcomx_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_ownership_table",
+                "passed": true,
+                "error": "skipped: ownership is not checked on negative tests \u2014 writes belong to the routed-to skill, not the skill under test"
+              },
+              {
+                "name": "test_research_json_unmodified",
+                "passed": true,
+                "error": "skipped: negative tests don't run the skill body"
+              },
+              {
+                "name": "test_tree_gedcomx_unmodified",
+                "passed": true,
+                "error": "skipped: negative tests don't run the skill body"
+              }
+            ]
+          },
+          "judge": {
+            "skipped": false,
+            "dimensions": [
+              {
+                "source": "base",
+                "name": "Correctness",
+                "score": 3,
+                "rationale": "The skill correctly identified that this is a negative test case about file structure validation. It properly declined to run check-warnings and routed the user to validate-schema, which is the appropriate skill for schema validation tasks. The routing decision matches the test's expectations."
+              },
+              {
+                "source": "base",
+                "name": "Completeness",
+                "score": 3,
+                "rationale": "The skill fully addressed what was needed: it recognized the user's request about validating research.json structure and completely handled it by declining its own task and routing to the correct downstream skill (validate-schema). No portions of the expected behavior were omitted."
+              },
+              {
+                "source": "base",
+                "name": "Tool Arguments",
+                "score": null,
+                "rationale": "No MCP tool calls were made. This is correct behavior for this negative test case\u2014the skill should decline and route rather than invoke its own tools. N/A per instructions."
+              }
+            ],
+            "judge_cost_usd": 0.004624,
+            "duration_ms": 3125.489917001687,
+            "error": null,
+            "input_tokens": 3164,
+            "cached_input_tokens": 0,
+            "output_tokens": 292
+          },
+          "started_at": 1783269421.282291,
+          "ended_at": 1783269428.311557
+        }
+      ]
+    },
+    {
+      "test_id": "ut_check_warnings_011",
+      "test_type": "negative",
+      "expected_outcome": "pass",
+      "scenario": "mid-research-flynn",
+      "mcp_fixtures": [
+        "person-warnings-no-warnings"
+      ],
+      "outcome": "pass",
+      "flaky": false,
+      "outcome_summary": {
+        "per_run_outcomes": [
+          "pass"
+        ],
+        "aggregated_dimensions": [
+          {
+            "source": "base",
+            "name": "Correctness",
+            "score": 3,
+            "rationale": "Claude correctly identified that the user's query describes conflicting sources on the same fact (birthplace: Ireland vs County Cork) and appropriately declined to run check-warnings. Instead, it routed to conflict-resolution, which is the correct behavior for this negative test. No fabricated claims were made."
+          },
+          {
+            "source": "base",
+            "name": "Completeness",
+            "score": 3,
+            "rationale": "Claude addressed the core requirement: recognizing the mismatch between sources and routing appropriately. The skill correctly understood that conflict-resolution, not check-warnings, should handle disagreements between sources on the same fact. No required element was omitted."
+          },
+          {
+            "source": "base",
+            "name": "Tool Arguments",
+            "score": null,
+            "rationale": "No MCP tool calls were made. The skill appropriately routed the user to conflict-resolution without invoking any tools, which aligns with the expected negative-test behavior of declining to perform check-warnings's own task."
+          }
+        ]
+      },
+      "totals": {
+        "duration_ms": 28279.373791010585,
+        "duration_api_ms": 0.0,
+        "judge_duration_ms": 3468.6015420011245,
+        "wall_clock_ms": 31819.387197494507,
+        "num_turns": 0,
+        "input_tokens": 0,
+        "cached_input_tokens": 0,
+        "output_tokens": 0,
+        "judge_input_tokens": 3162,
+        "judge_cached_input_tokens": 0,
+        "judge_output_tokens": 310,
+        "skill_cost_usd": 0.0,
+        "judge_cost_usd": 0.004712,
+        "total_cost_usd": 0.004712
+      },
+      "runs": [
+        {
+          "run_index": 0,
+          "run_id": "run_ut_check_warnings_011_2026-07-05_16-35-38_0",
+          "outcome": "pass",
+          "aborted_reason": null,
+          "duration_ms": 28279.373791010585,
+          "duration_api_ms": 0.0,
+          "num_turns": 0,
+          "skill_attempts": 1,
+          "input_tokens": 0,
+          "cached_input_tokens": 0,
+          "output_tokens": 0,
+          "skill_cost_usd": 0.0,
+          "output": {
+            "text_response": "",
+            "activated": false,
+            "skills_invoked": [
+              "check-warnings",
+              "conflict-resolution"
+            ],
+            "tool_calls": [],
+            "files_created": []
+          },
+          "validators": {
+            "passed": true,
+            "results": [
+              {
+                "name": "test_id_references_resolve",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_log_append_only",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_entries_deleted",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_ownership_table",
+                "passed": true,
+                "error": "skipped: ownership is not checked on negative tests \u2014 writes belong to the routed-to skill, not the skill under test"
+              },
+              {
+                "name": "test_research_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tool_allowlist",
+                "passed": true,
+                "error": "skipped: allowlist is not checked on negative tests \u2014 tool calls belong to the routed-to skill, not the skill under test"
+              },
+              {
+                "name": "test_tree_gedcomx_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_ownership_table",
+                "passed": true,
+                "error": "skipped: ownership is not checked on negative tests \u2014 writes belong to the routed-to skill, not the skill under test"
+              },
+              {
+                "name": "test_research_json_unmodified",
+                "passed": true,
+                "error": "skipped: negative tests don't run the skill body"
+              },
+              {
+                "name": "test_tree_gedcomx_unmodified",
+                "passed": true,
+                "error": "skipped: negative tests don't run the skill body"
+              }
+            ]
+          },
+          "judge": {
+            "skipped": false,
+            "dimensions": [
+              {
+                "source": "base",
+                "name": "Correctness",
+                "score": 3,
+                "rationale": "Claude correctly identified that the user's query describes conflicting sources on the same fact (birthplace: Ireland vs County Cork) and appropriately declined to run check-warnings. Instead, it routed to conflict-resolution, which is the correct behavior for this negative test. No fabricated claims were made."
+              },
+              {
+                "source": "base",
+                "name": "Completeness",
+                "score": 3,
+                "rationale": "Claude addressed the core requirement: recognizing the mismatch between sources and routing appropriately. The skill correctly understood that conflict-resolution, not check-warnings, should handle disagreements between sources on the same fact. No required element was omitted."
+              },
+              {
+                "source": "base",
+                "name": "Tool Arguments",
+                "score": null,
+                "rationale": "No MCP tool calls were made. The skill appropriately routed the user to conflict-resolution without invoking any tools, which aligns with the expected negative-test behavior of declining to perform check-warnings's own task."
+              }
+            ],
+            "judge_cost_usd": 0.004712,
+            "duration_ms": 3468.6015420011245,
+            "error": null,
+            "input_tokens": 3162,
+            "cached_input_tokens": 0,
+            "output_tokens": 310
+          },
+          "started_at": 1783269420.995497,
+          "ended_at": 1783269452.8148842
+        }
+      ]
+    },
+    {
+      "test_id": "ut_check_warnings_015",
+      "test_type": "positive",
+      "expected_outcome": "pass",
+      "scenario": "christian-hole-quality",
+      "mcp_fixtures": [
+        "person-warnings-hole-son-event-after-death",
+        "person-quality-hole-son"
+      ],
+      "outcome": "pass",
+      "flaky": false,
+      "outcome_summary": {
+        "per_run_outcomes": [
+          "pass"
+        ],
+        "aggregated_dimensions": [
+          {
+            "source": "base",
+            "name": "Correctness",
+            "score": 3,
+            "rationale": "The skill's output is factually correct and well-supported. The hasEventAfterDeath1 warning is accurately reported as Critical with severity 'error' from the tool response. The three diagnostic causes (wrong death date, identity confusion, posthumous mention) align with real genealogical possibilities. FamilySearch quality issues are reported verbatim from the tool response (death place missing city, untagged residence) without fabrication or mischaracterization. All claims are grounded in the tool responses provided."
+          },
+          {
+            "source": "base",
+            "name": "Completeness",
+            "score": 3,
+            "rationale": "The skill fully addressed the user's request to check Ole C. Hole (KD96-TV4) for problems. It called both required tools (person_warnings and person_quality), reported the Critical impossibility (event after death) with detailed diagnostic guidance, presented the quality issues separately, and provided an actionable summary distinguishing between urgent errors and optional improvements. Nothing obvious was omitted from the user's scope."
+          },
+          {
+            "source": "base",
+            "name": "Tool Arguments",
+            "score": 3,
+            "rationale": "Both MCP tool calls passed arguments matching the fixture's expected_args. The person_warnings call correctly used personId 'KD96-TV4' (expected) and included projectPath (a reasonable non-noisy extra). The person_quality call correctly used personId 'KD96-TV4' (expected). Both calls matched successfully and no fixture_not_found errors occurred. Arguments were correct and complete."
+          },
+          {
+            "source": "rubric",
+            "name": "Detection accuracy",
+            "score": 3,
+            "rationale": "The skill detected the genuine impossibility (event after death in 1975, more than 1 year after 1960 death) as reported by the person_warnings tool. No false positives on valid edge cases appear in the response. The warnings result explicitly identified the anomaly with fact IDs (F13, F14, F15) that would need review. The tool's detection was correctly conveyed without misreporting."
+          },
+          {
+            "source": "rubric",
+            "name": "Severity classification",
+            "score": 3,
+            "rationale": "The event-after-death impossibility is correctly classified as Critical with severity 'error' (as returned by the tool and reported in the response), matching its actual impact as a chronological impossibility. The FamilySearch quality issues (missing city, untagged sources) are appropriately presented as 'optional improvements' and 'minor polish items' rather than critical errors, matching their lower-severity classification. Severity tiers are correct and proportional to impact."
+          },
+          {
+            "source": "rubric",
+            "name": "Actionability",
+            "score": 3,
+            "rationale": "Every warning is actionable and specific. The event-after-death warning names facts F13, F14, F15 and provides three concrete diagnostic paths (verify death date against records, rebuild chronological timeline for identity confusion, unlink posthumous mentions). The quality issues name the specific conclusions involved (death place, residence) and suggest direct actions (add missing city, tag source to residence). The summary ties the next step back to the facts that need inspection."
+          },
+          {
+            "source": "rubric",
+            "name": "FamilySearch quality reporting",
+            "score": 3,
+            "rationale": "The skill handled person_quality correctly for a real FamilySearch ID (KD96-TV4). It called person_quality exactly once and reported its output in a SEPARATE section from the impossibilities, labeled 'FAMILYSEARCH QUALITY' distinct from 'WARNINGS'. Issues are reported verbatim from the tool response ('The death place is missing a city', 'A residence has no tagged sources') without re-derivation or invented quality bands. Quality issues are explicitly framed as 'optional improvements' and 'minor polish items' (never escalated to error/Critical), and the impossibilities section remains intact and unmerged. Zero escalation to impossibilities, honest reporting of the overall score (0.94), and no suppression of the warnings result."
+          }
+        ]
+      },
+      "totals": {
+        "duration_ms": 38309.18883299455,
+        "duration_api_ms": 36033.0,
+        "judge_duration_ms": 11286.003083980177,
+        "wall_clock_ms": 49781.846046447754,
+        "num_turns": 6,
+        "input_tokens": 10,
+        "cached_input_tokens": 41143,
+        "output_tokens": 1600,
+        "judge_input_tokens": 5980,
+        "judge_cached_input_tokens": 0,
+        "judge_output_tokens": 1050,
+        "skill_cost_usd": 0.06967290000000001,
+        "judge_cost_usd": 0.01123,
+        "total_cost_usd": 0.08090290000000001
+      },
+      "runs": [
+        {
+          "run_index": 0,
+          "run_id": "run_ut_check_warnings_015_2026-07-05_16-35-38_0",
+          "outcome": "pass",
+          "aborted_reason": null,
+          "duration_ms": 38309.18883299455,
+          "duration_api_ms": 36033.0,
+          "num_turns": 6,
+          "skill_attempts": 1,
+          "input_tokens": 10,
+          "cached_input_tokens": 41143,
+          "output_tokens": 1600,
+          "skill_cost_usd": 0.06967290000000001,
+          "output": {
+            "text_response": "Checking Ole C. Hole (KD96-TV4) \u2014 running both the offline impossibility check and the live FamilySearch quality score now.---\n\n## WARNINGS FOR: Ole C. Hole (KD96-TV4)\n\n**[!] Critical \u2014 Event after death `[hasEventAfterDeath1]`**\n*(Fundamental: people cannot act after their death \u2014 but a posthumous mention can be misattached to their profile.)*\n\nAn event is dated more than 1 year after this person's latest death-like fact.\n**Facts involved:** F13, F14, F15.\n\nThis warning has three common causes \u2014 the right corrective action depends on which applies:\n\n1. **Wrong death date** \u2014 The recorded death date is too early, and one of the later events is actually consistent with the true death. *If this seems likely:* verify the recorded death date against the original death record (the certificate or burial register) \u2014 one of the two dates may be wrong.\n\n2. **Identity confusion** \u2014 The late-dated record actually belongs to a same-name individual who outlived Ole. *If the late-dated record describes events apparently performed by Ole* (e.g. a later census listing him as head of household, a later marriage): rebuild a full chronological timeline of every recorded event and go through each record to find where one person's records end and another's begin.\n\n3. **Posthumous mention** \u2014 The late-dated record was created after Ole's death and merely references him (e.g. an obituary, a descendant's death certificate, an estate or probate document naming him as a prior owner or parent). *If so:* that record shouldn't be attached as one of Ole's own events \u2014 unlink it and treat it as a reference instead.\n\n**Next step:** Look at facts F13, F14, and F15 \u2014 what kind of documents are they, and is Ole performing an action in them or simply being mentioned? That answer will tell you which of the three causes applies.\n\n*(1 warning total)*\n\n---\n\n## FAMILYSEARCH QUALITY: Ole C. Hole (KD96-TV4) \u2014 overall 0.94\n\n| Category | Issues | Score |\n|---|---|---|\n| Completeness | 1 | 0.90 |\n| Verifiability | 1 | 0.95 |\n| Consistency | 0 | 1.00 |\n| Coherence | 0 | 1.00 |\n\n**Completeness**\n- The death place is missing a city.\n\n**Verifiability (Source tagging)**\n- A residence has no tagged sources.\n\nThese are FamilySearch's suggestions to improve the profile. Adding the missing city to the death place would raise the completeness score, and tagging a source to the residence record would address the verifiability flag \u2014 both are optional improvements rather than urgent errors.\n\n---\n\n**Summary:** The one item that needs attention is the **event-after-death error** on facts F13/F14/F15 \u2014 inspecting those records is the right first step to determine whether it's a date error, a same-name identity mix-up, or a misattached posthumous mention. The quality issues (missing death city, untagged residence) are minor polish items.",
+            "activated": true,
+            "skills_invoked": [
+              "check-warnings"
+            ],
+            "tool_calls": [
+              {
+                "tool": "mcp__genealogy__person_warnings",
+                "args": {
+                  "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/eval-ut_check_warnings_015-0-0-tdxwnc6m",
+                  "personId": "KD96-TV4"
+                },
+                "expected_args": {
+                  "personId": "KD96-TV4"
+                },
+                "matched": {
+                  "kind": "predicate",
+                  "index": 0
+                },
+                "response_fixture": "person-warnings-hole-son-event-after-death"
+              },
+              {
+                "tool": "mcp__genealogy__person_quality",
+                "args": {
+                  "personId": "KD96-TV4"
+                },
+                "expected_args": {
+                  "personId": "KD96-TV4"
+                },
+                "matched": {
+                  "kind": "predicate",
+                  "index": 0
+                },
+                "response_fixture": "person-quality-hole-son"
+              }
+            ],
+            "files_created": [],
+            "warnings": [
+              {
+                "kind": "missing_tool_usage_dimension",
+                "advisory": "Skill called MCP tools but the rubric has no dimension name suggesting tool-usage coverage (matched against keywords: ['tool usage', 'tool use', 'tool work', 'tool call', 'argument quality', 'argument-quality', 'response interpretation', 'tool selection', 'mcp tool', 'fixture']). The judge will grade other dimensions but won't score tool work explicitly. Consider adding a tool-usage dimension or renaming an existing one."
+              }
+            ]
+          },
+          "validators": {
+            "passed": true,
+            "results": [
+              {
+                "name": "test_id_references_resolve",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_log_append_only",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_entries_deleted",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_research_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tool_allowlist",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_gedcomx_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_research_json_unmodified",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_gedcomx_unmodified",
+                "passed": true,
+                "error": null
+              }
+            ]
+          },
+          "judge": {
+            "skipped": false,
+            "dimensions": [
+              {
+                "source": "base",
+                "name": "Correctness",
+                "score": 3,
+                "rationale": "The skill's output is factually correct and well-supported. The hasEventAfterDeath1 warning is accurately reported as Critical with severity 'error' from the tool response. The three diagnostic causes (wrong death date, identity confusion, posthumous mention) align with real genealogical possibilities. FamilySearch quality issues are reported verbatim from the tool response (death place missing city, untagged residence) without fabrication or mischaracterization. All claims are grounded in the tool responses provided."
+              },
+              {
+                "source": "base",
+                "name": "Completeness",
+                "score": 3,
+                "rationale": "The skill fully addressed the user's request to check Ole C. Hole (KD96-TV4) for problems. It called both required tools (person_warnings and person_quality), reported the Critical impossibility (event after death) with detailed diagnostic guidance, presented the quality issues separately, and provided an actionable summary distinguishing between urgent errors and optional improvements. Nothing obvious was omitted from the user's scope."
+              },
+              {
+                "source": "base",
+                "name": "Tool Arguments",
+                "score": 3,
+                "rationale": "Both MCP tool calls passed arguments matching the fixture's expected_args. The person_warnings call correctly used personId 'KD96-TV4' (expected) and included projectPath (a reasonable non-noisy extra). The person_quality call correctly used personId 'KD96-TV4' (expected). Both calls matched successfully and no fixture_not_found errors occurred. Arguments were correct and complete."
+              },
+              {
+                "source": "rubric",
+                "name": "Detection accuracy",
+                "score": 3,
+                "rationale": "The skill detected the genuine impossibility (event after death in 1975, more than 1 year after 1960 death) as reported by the person_warnings tool. No false positives on valid edge cases appear in the response. The warnings result explicitly identified the anomaly with fact IDs (F13, F14, F15) that would need review. The tool's detection was correctly conveyed without misreporting."
+              },
+              {
+                "source": "rubric",
+                "name": "Severity classification",
+                "score": 3,
+                "rationale": "The event-after-death impossibility is correctly classified as Critical with severity 'error' (as returned by the tool and reported in the response), matching its actual impact as a chronological impossibility. The FamilySearch quality issues (missing city, untagged sources) are appropriately presented as 'optional improvements' and 'minor polish items' rather than critical errors, matching their lower-severity classification. Severity tiers are correct and proportional to impact."
+              },
+              {
+                "source": "rubric",
+                "name": "Actionability",
+                "score": 3,
+                "rationale": "Every warning is actionable and specific. The event-after-death warning names facts F13, F14, F15 and provides three concrete diagnostic paths (verify death date against records, rebuild chronological timeline for identity confusion, unlink posthumous mentions). The quality issues name the specific conclusions involved (death place, residence) and suggest direct actions (add missing city, tag source to residence). The summary ties the next step back to the facts that need inspection."
+              },
+              {
+                "source": "rubric",
+                "name": "FamilySearch quality reporting",
+                "score": 3,
+                "rationale": "The skill handled person_quality correctly for a real FamilySearch ID (KD96-TV4). It called person_quality exactly once and reported its output in a SEPARATE section from the impossibilities, labeled 'FAMILYSEARCH QUALITY' distinct from 'WARNINGS'. Issues are reported verbatim from the tool response ('The death place is missing a city', 'A residence has no tagged sources') without re-derivation or invented quality bands. Quality issues are explicitly framed as 'optional improvements' and 'minor polish items' (never escalated to error/Critical), and the impossibilities section remains intact and unmerged. Zero escalation to impossibilities, honest reporting of the overall score (0.94), and no suppression of the warnings result."
+              }
+            ],
+            "judge_cost_usd": 0.01123,
+            "duration_ms": 11286.003083980177,
+            "error": null,
+            "input_tokens": 5980,
+            "cached_input_tokens": 0,
+            "output_tokens": 1050
+          },
+          "started_at": 1783269338.453023,
+          "ended_at": 1783269388.234869
+        }
+      ]
+    },
+    {
+      "test_id": "ut_check_warnings_016",
+      "test_type": "positive",
+      "expected_outcome": "pass",
+      "scenario": "christian-hole-quality",
+      "mcp_fixtures": [
+        "person-warnings-hole-wife-none",
+        "person-quality-hole-wife-clean"
+      ],
+      "outcome": "pass",
+      "flaky": false,
+      "outcome_summary": {
+        "per_run_outcomes": [
+          "pass"
+        ],
+        "aggregated_dimensions": [
+          {
+            "source": "base",
+            "name": "Correctness",
+            "score": 3,
+            "rationale": "All facts reported match the tool responses exactly. The skill correctly reported zero warnings from person_warnings, an overall score of 1.0 from person_quality, zero issues across all categories, and properly cited the segment 'Norway 1816\u20131920' from the response. No fabricated material or unsupported claims."
+          },
+          {
+            "source": "base",
+            "name": "Completeness",
+            "score": 3,
+            "rationale": "The skill fully addressed the user's question ('Any data problems with Inger Hole (KD96-TV3)?) by calling both required tools and reporting both results: person_warnings (no impossibilities) and person_quality (perfect 1.0 score with zero issues). Nothing was omitted."
+          },
+          {
+            "source": "base",
+            "name": "Tool Arguments",
+            "score": 3,
+            "rationale": "Both tool calls matched expected args exactly: person_warnings and person_quality both received the correct personId 'KD96-TV3'. The tool calls had `matched.kind == 'predicate'` (success) and the args align with the test author's expectations. No fixture_not_found errors."
+          },
+          {
+            "source": "rubric",
+            "name": "Detection accuracy",
+            "score": 3,
+            "rationale": "The skill correctly reported zero impossibilities for Inger Hole (KD96-TV3), which matches the tool response showing warningCount of 0 and an empty warnings array. This is a valid case with no false positives or missed impossibilities."
+          },
+          {
+            "source": "rubric",
+            "name": "Severity classification",
+            "score": 3,
+            "rationale": "No warnings were found, so severity classification does not apply in a traditional sense. The skill appropriately reported the clean status and did not invent severity tiers where no issues exist. No severity miscategorization occurred."
+          },
+          {
+            "source": "rubric",
+            "name": "Actionability",
+            "score": 3,
+            "rationale": "No warnings were found, so there are no warnings to make actionable. The skill correctly stated 'Nothing to fix here' and 'No genealogical warnings found,' which is the appropriate actionable result for a clean profile. This aligns with the N/A dimension definition when no warnings are present."
+          },
+          {
+            "source": "rubric",
+            "name": "FamilySearch quality reporting",
+            "score": 3,
+            "rationale": "The skill correctly called person_quality on the FamilySearch ID 'KD96-TV3' (matching the expected behavior from the test author). It reported the overall score (1.0, perfect) exactly as returned, listed zero issues across all four categories, cited the segment directly from the response ('Norway 1816\u20131920'), and framed the result as clean data with no invented quality bands or fabricated issues. Quality was reported as a distinct section separate from warnings."
+          }
+        ]
+      },
+      "totals": {
+        "duration_ms": 21356.12733301241,
+        "duration_api_ms": 21695.0,
+        "judge_duration_ms": 7418.695999949705,
+        "wall_clock_ms": 28838.970184326172,
+        "num_turns": 7,
+        "input_tokens": 11,
+        "cached_input_tokens": 54940,
+        "output_tokens": 894,
+        "judge_input_tokens": 5123,
+        "judge_cached_input_tokens": 0,
+        "judge_output_tokens": 780,
+        "skill_cost_usd": 0.06272124999999999,
+        "judge_cost_usd": 0.009023,
+        "total_cost_usd": 0.07174425
+      },
+      "runs": [
+        {
+          "run_index": 0,
+          "run_id": "run_ut_check_warnings_016_2026-07-05_16-35-38_0",
+          "outcome": "pass",
+          "aborted_reason": null,
+          "duration_ms": 21356.12733301241,
+          "duration_api_ms": 21695.0,
+          "num_turns": 7,
+          "skill_attempts": 1,
+          "input_tokens": 11,
+          "cached_input_tokens": 54940,
+          "output_tokens": 894,
+          "skill_cost_usd": 0.06272124999999999,
+          "output": {
+            "text_response": "Inger Hole (KD96-TV3) is in excellent shape \u2014 both checks came back completely clean.\n\n---\n\n**WARNINGS FOR: Inger Hole (KD96-TV3)**\n\nNo genealogical warnings found. All offline checks passed \u2014 no logical impossibilities in the local data.\n\n---\n\n**FAMILYSEARCH QUALITY: Inger Hole (KD96-TV3)** \u2014 overall score **1.0** (perfect)\n\n| Category | Issues | Score |\n|---|---|---|\n| Completeness | 0 | 1.0 |\n| Verifiability (source tagging) | 0 | 1.0 |\n| Consistency | 0 | 1.0 |\n| Coherence | 0 | 1.0 |\n\nFamilySearch flagged no issues at all for this profile (segment: *Norway 1816\u20131920*). Dates, places, sources, and relationships all appear well-documented and consistent.\n\nNothing to fix here \u2014 Inger Hole's data is solid on both fronts.",
+            "activated": true,
+            "skills_invoked": [
+              "check-warnings"
+            ],
+            "tool_calls": [
+              {
+                "tool": "mcp__genealogy__person_warnings",
+                "args": {
+                  "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/eval-ut_check_warnings_016-0-0-6g5f7e9l",
+                  "personId": "KD96-TV3"
+                },
+                "expected_args": {
+                  "personId": "KD96-TV3"
+                },
+                "matched": {
+                  "kind": "predicate",
+                  "index": 0
+                },
+                "response_fixture": "person-warnings-hole-wife-none"
+              },
+              {
+                "tool": "mcp__genealogy__person_quality",
+                "args": {
+                  "personId": "KD96-TV3"
+                },
+                "expected_args": {
+                  "personId": "KD96-TV3"
+                },
+                "matched": {
+                  "kind": "predicate",
+                  "index": 0
+                },
+                "response_fixture": "person-quality-hole-wife-clean"
+              }
+            ],
+            "files_created": [],
+            "warnings": [
+              {
+                "kind": "missing_tool_usage_dimension",
+                "advisory": "Skill called MCP tools but the rubric has no dimension name suggesting tool-usage coverage (matched against keywords: ['tool usage', 'tool use', 'tool work', 'tool call', 'argument quality', 'argument-quality', 'response interpretation', 'tool selection', 'mcp tool', 'fixture']). The judge will grade other dimensions but won't score tool work explicitly. Consider adding a tool-usage dimension or renaming an existing one."
+              }
+            ]
+          },
+          "validators": {
+            "passed": true,
+            "results": [
+              {
+                "name": "test_id_references_resolve",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_log_append_only",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_entries_deleted",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_research_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tool_allowlist",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_gedcomx_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_research_json_unmodified",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_gedcomx_unmodified",
+                "passed": true,
+                "error": null
+              }
+            ]
+          },
+          "judge": {
+            "skipped": false,
+            "dimensions": [
+              {
+                "source": "base",
+                "name": "Correctness",
+                "score": 3,
+                "rationale": "All facts reported match the tool responses exactly. The skill correctly reported zero warnings from person_warnings, an overall score of 1.0 from person_quality, zero issues across all categories, and properly cited the segment 'Norway 1816\u20131920' from the response. No fabricated material or unsupported claims."
+              },
+              {
+                "source": "base",
+                "name": "Completeness",
+                "score": 3,
+                "rationale": "The skill fully addressed the user's question ('Any data problems with Inger Hole (KD96-TV3)?) by calling both required tools and reporting both results: person_warnings (no impossibilities) and person_quality (perfect 1.0 score with zero issues). Nothing was omitted."
+              },
+              {
+                "source": "base",
+                "name": "Tool Arguments",
+                "score": 3,
+                "rationale": "Both tool calls matched expected args exactly: person_warnings and person_quality both received the correct personId 'KD96-TV3'. The tool calls had `matched.kind == 'predicate'` (success) and the args align with the test author's expectations. No fixture_not_found errors."
+              },
+              {
+                "source": "rubric",
+                "name": "Detection accuracy",
+                "score": 3,
+                "rationale": "The skill correctly reported zero impossibilities for Inger Hole (KD96-TV3), which matches the tool response showing warningCount of 0 and an empty warnings array. This is a valid case with no false positives or missed impossibilities."
+              },
+              {
+                "source": "rubric",
+                "name": "Severity classification",
+                "score": 3,
+                "rationale": "No warnings were found, so severity classification does not apply in a traditional sense. The skill appropriately reported the clean status and did not invent severity tiers where no issues exist. No severity miscategorization occurred."
+              },
+              {
+                "source": "rubric",
+                "name": "Actionability",
+                "score": 3,
+                "rationale": "No warnings were found, so there are no warnings to make actionable. The skill correctly stated 'Nothing to fix here' and 'No genealogical warnings found,' which is the appropriate actionable result for a clean profile. This aligns with the N/A dimension definition when no warnings are present."
+              },
+              {
+                "source": "rubric",
+                "name": "FamilySearch quality reporting",
+                "score": 3,
+                "rationale": "The skill correctly called person_quality on the FamilySearch ID 'KD96-TV3' (matching the expected behavior from the test author). It reported the overall score (1.0, perfect) exactly as returned, listed zero issues across all four categories, cited the segment directly from the response ('Norway 1816\u20131920'), and framed the result as clean data with no invented quality bands or fabricated issues. Quality was reported as a distinct section separate from warnings."
+              }
+            ],
+            "judge_cost_usd": 0.009023,
+            "duration_ms": 7418.695999949705,
+            "error": null,
+            "input_tokens": 5123,
+            "cached_input_tokens": 0,
+            "output_tokens": 780
+          },
+          "started_at": 1783269415.696203,
+          "ended_at": 1783269444.5351732
+        }
+      ]
+    },
+    {
+      "test_id": "ut_check_warnings_014",
+      "test_type": "positive",
+      "expected_outcome": "pass",
+      "scenario": "christian-hole-quality",
+      "mcp_fixtures": [
+        "person-warnings-hole-christian-none",
+        "person-quality-hole-christian"
+      ],
+      "outcome": "pass",
+      "flaky": false,
+      "outcome_summary": {
+        "per_run_outcomes": [
+          "pass"
+        ],
+        "aggregated_dimensions": [
+          {
+            "source": "base",
+            "name": "Correctness",
+            "score": 3,
+            "rationale": "All facts reported match tool responses. Offline check correctly reported zero warnings; quality score, issues, and sentences all taken verbatim from person_quality response. No fabricated material or unsupported claims."
+          },
+          {
+            "source": "base",
+            "name": "Completeness",
+            "score": 3,
+            "rationale": "Addressed the user's request fully: checked Christian P. Hole for warnings, reported results from both offline and FamilySearch quality checks, and included interpretation of findings. No omissions of relevant content from tool responses."
+          },
+          {
+            "source": "base",
+            "name": "Tool Arguments",
+            "score": 3,
+            "rationale": "Both tool calls used correct args matching expected values. person_warnings called with personId 'KD96-TV2' and projectPath; person_quality called with personId 'KD96-TV2'. FamilySearch ID format correctly triggered quality call."
+          },
+          {
+            "source": "rubric",
+            "name": "Detection accuracy",
+            "score": 3,
+            "rationale": "Offline impossibility check correctly detected zero warnings for the subject (Christian P. Hole / KD96-TV2). Per scenario description, this person has no birth-after-death, death-before-event, or age-impossible conditions \u2014 all valid. Detection is accurate."
+          },
+          {
+            "source": "rubric",
+            "name": "Severity classification",
+            "score": 3,
+            "rationale": "Quality issues appropriately classified as optional improvements, not critical/high warnings. Completeness and verifiability gaps (missing burial date, incomplete marriage place, untagged residences) are correctly framed as non-urgent enhancements, distinct from impossibilities."
+          },
+          {
+            "source": "rubric",
+            "name": "Actionability",
+            "score": 3,
+            "rationale": "All quality issues named specific records/facts (burial date, marriage place city, residences) and suggested concrete next steps (add burial register date, complete marriage city, tag census/sources). Each issue has a clear action path."
+          },
+          {
+            "source": "rubric",
+            "name": "FamilySearch quality reporting",
+            "score": 3,
+            "rationale": "Quality handled correctly: person_quality called exactly once with real FamilySearch ID (KD96-TV2). Overall score (0.97) reported without invented labels. Issue sentences taken verbatim: 'The burial date is missing.', 'A marriage place is missing a city.', 'A residence has no tagged sources.' (\u00d75). Quality section kept separate from impossibilities. No re-derivation or re-scoring of issues."
+          }
+        ]
+      },
+      "totals": {
+        "duration_ms": 26835.315375006758,
+        "duration_api_ms": 28243.0,
+        "judge_duration_ms": 7161.0992919886485,
+        "wall_clock_ms": 34047.26815223694,
+        "num_turns": 6,
+        "input_tokens": 10,
+        "cached_input_tokens": 41134,
+        "output_tokens": 1066,
+        "judge_input_tokens": 5739,
+        "judge_cached_input_tokens": 0,
+        "judge_output_tokens": 717,
+        "skill_cost_usd": 0.06245420000000001,
+        "judge_cost_usd": 0.009324,
+        "total_cost_usd": 0.07177820000000001
+      },
+      "runs": [
+        {
+          "run_index": 0,
+          "run_id": "run_ut_check_warnings_014_2026-07-05_16-35-38_0",
+          "outcome": "pass",
+          "aborted_reason": null,
+          "duration_ms": 26835.315375006758,
+          "duration_api_ms": 28243.0,
+          "num_turns": 6,
+          "skill_attempts": 1,
+          "input_tokens": 10,
+          "cached_input_tokens": 41134,
+          "output_tokens": 1066,
+          "skill_cost_usd": 0.06245420000000001,
+          "output": {
+            "text_response": "I'll run both the offline impossibility check and the FamilySearch quality score for Christian P. Hole simultaneously.---\n\n## WARNINGS FOR: Christian P. Hole (KD96-TV2)\n\n**No genealogical warnings found.** All offline impossibility checks passed \u2014 no logical errors (death before birth, event after death, impossible ages, etc.) were detected in the local tree data.\n\n---\n\n## FAMILYSEARCH QUALITY: Christian P. Hole (KD96-TV2) \u2014 overall 0.97\n\n*Segment: Norway 1816\u20131920*\n\n| Category | Issues | Score |\n|---|---|---|\n| Completeness | 2 | 0.91 |\n| Verifiability (source tagging) | 5 | 1.00 |\n| Consistency | 0 | 1.00 |\n| Coherence | 0 | 1.00 |\n\n**Completeness**\n- The burial date is missing.\n- A marriage place is missing a city.\n\n**Verifiability (source tagging)**\n- A residence has no tagged sources. *(\u00d75)*\n\n---\n\n### Interpretation\n\nThe profile is in excellent shape \u2014 a 0.97 overall score with no impossibilities in the local data. The seven FamilySearch suggestions are optional improvements worth addressing when convenient:\n\n- **Burial date** \u2014 if a burial register or death notice is available, adding the date would close this gap.\n- **Marriage place** \u2014 adding the city to the marriage location would complete that fact.\n- **Residence sources** \u2014 five residence facts are currently unsourced. Tagging the census or other records that support each residence would raise the verifiability score to 1.00 across the board.\n\nNone of these are errors \u2014 they're enhancements that would make the profile more complete and verifiable for future researchers.",
+            "activated": true,
+            "skills_invoked": [
+              "check-warnings"
+            ],
+            "tool_calls": [
+              {
+                "tool": "mcp__genealogy__person_warnings",
+                "args": {
+                  "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/eval-ut_check_warnings_014-0-0-mnzgpldv",
+                  "personId": "KD96-TV2"
+                },
+                "expected_args": {
+                  "personId": "KD96-TV2"
+                },
+                "matched": {
+                  "kind": "predicate",
+                  "index": 0
+                },
+                "response_fixture": "person-warnings-hole-christian-none"
+              },
+              {
+                "tool": "mcp__genealogy__person_quality",
+                "args": {
+                  "personId": "KD96-TV2"
+                },
+                "expected_args": {
+                  "personId": "KD96-TV2"
+                },
+                "matched": {
+                  "kind": "predicate",
+                  "index": 0
+                },
+                "response_fixture": "person-quality-hole-christian"
+              }
+            ],
+            "files_created": [],
+            "warnings": [
+              {
+                "kind": "missing_tool_usage_dimension",
+                "advisory": "Skill called MCP tools but the rubric has no dimension name suggesting tool-usage coverage (matched against keywords: ['tool usage', 'tool use', 'tool work', 'tool call', 'argument quality', 'argument-quality', 'response interpretation', 'tool selection', 'mcp tool', 'fixture']). The judge will grade other dimensions but won't score tool work explicitly. Consider adding a tool-usage dimension or renaming an existing one."
+              }
+            ]
+          },
+          "validators": {
+            "passed": true,
+            "results": [
+              {
+                "name": "test_id_references_resolve",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_log_append_only",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_entries_deleted",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_research_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tool_allowlist",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_gedcomx_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_research_json_unmodified",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_gedcomx_unmodified",
+                "passed": true,
+                "error": null
+              }
+            ]
+          },
+          "judge": {
+            "skipped": false,
+            "dimensions": [
+              {
+                "source": "base",
+                "name": "Correctness",
+                "score": 3,
+                "rationale": "All facts reported match tool responses. Offline check correctly reported zero warnings; quality score, issues, and sentences all taken verbatim from person_quality response. No fabricated material or unsupported claims."
+              },
+              {
+                "source": "base",
+                "name": "Completeness",
+                "score": 3,
+                "rationale": "Addressed the user's request fully: checked Christian P. Hole for warnings, reported results from both offline and FamilySearch quality checks, and included interpretation of findings. No omissions of relevant content from tool responses."
+              },
+              {
+                "source": "base",
+                "name": "Tool Arguments",
+                "score": 3,
+                "rationale": "Both tool calls used correct args matching expected values. person_warnings called with personId 'KD96-TV2' and projectPath; person_quality called with personId 'KD96-TV2'. FamilySearch ID format correctly triggered quality call."
+              },
+              {
+                "source": "rubric",
+                "name": "Detection accuracy",
+                "score": 3,
+                "rationale": "Offline impossibility check correctly detected zero warnings for the subject (Christian P. Hole / KD96-TV2). Per scenario description, this person has no birth-after-death, death-before-event, or age-impossible conditions \u2014 all valid. Detection is accurate."
+              },
+              {
+                "source": "rubric",
+                "name": "Severity classification",
+                "score": 3,
+                "rationale": "Quality issues appropriately classified as optional improvements, not critical/high warnings. Completeness and verifiability gaps (missing burial date, incomplete marriage place, untagged residences) are correctly framed as non-urgent enhancements, distinct from impossibilities."
+              },
+              {
+                "source": "rubric",
+                "name": "Actionability",
+                "score": 3,
+                "rationale": "All quality issues named specific records/facts (burial date, marriage place city, residences) and suggested concrete next steps (add burial register date, complete marriage city, tag census/sources). Each issue has a clear action path."
+              },
+              {
+                "source": "rubric",
+                "name": "FamilySearch quality reporting",
+                "score": 3,
+                "rationale": "Quality handled correctly: person_quality called exactly once with real FamilySearch ID (KD96-TV2). Overall score (0.97) reported without invented labels. Issue sentences taken verbatim: 'The burial date is missing.', 'A marriage place is missing a city.', 'A residence has no tagged sources.' (\u00d75). Quality section kept separate from impossibilities. No re-derivation or re-scoring of issues."
+              }
+            ],
+            "judge_cost_usd": 0.009324,
+            "duration_ms": 7161.0992919886485,
+            "error": null,
+            "input_tokens": 5739,
+            "cached_input_tokens": 0,
+            "output_tokens": 717
+          },
+          "started_at": 1783269381.622748,
+          "ended_at": 1783269415.670016
+        }
+      ]
+    },
+    {
+      "test_id": "ut_check_warnings_018",
+      "test_type": "positive",
+      "expected_outcome": "pass",
+      "scenario": "mid-research-flynn",
+      "mcp_fixtures": [
+        "person-warnings-no-warnings"
+      ],
+      "outcome": "pass",
+      "flaky": false,
+      "outcome_summary": {
+        "per_run_outcomes": [
+          "pass"
+        ],
+        "aggregated_dimensions": [
+          {
+            "source": "base",
+            "name": "Correctness",
+            "score": 3,
+            "rationale": "The skill correctly identified that I1 is a synthetic ID and appropriately called person_warnings without attempting a person_quality call. The tool response confirms zero warnings were detected, and the skill accurately reported this finding without fabricating any issues."
+          },
+          {
+            "source": "base",
+            "name": "Completeness",
+            "score": 3,
+            "rationale": "The skill addressed the user's request fully: it checked Patrick Flynn for warnings by calling person_warnings with the correct personId (I1), received the result showing no warnings, and reported that result completely. No required steps were omitted."
+          },
+          {
+            "source": "base",
+            "name": "Tool Arguments",
+            "score": 3,
+            "rationale": "The person_warnings call used personId 'I1', which matches the expected pattern (~). The projectPath argument was correctly set to the test environment path. No arguments were missing or incorrect; the call matched expectations."
+          },
+          {
+            "source": "rubric",
+            "name": "Detection accuracy",
+            "score": 3,
+            "rationale": "The person_warnings tool returned zero warnings for Patrick Flynn. The tool's check for impossibilities (birth after death, chronological conflicts) and anomalies passed with no false positives. No genuine impossibilities were missed; the data is internally consistent."
+          },
+          {
+            "source": "rubric",
+            "name": "Severity classification",
+            "score": 3,
+            "rationale": "Since no warnings were detected, there are no severity tiers to evaluate. The tool output confirms a clean check, and the skill correctly reported that fact. Severity classification is appropriately N/A, but this scores as pass given the complete absence of warnings."
+          },
+          {
+            "source": "rubric",
+            "name": "Actionability",
+            "score": null,
+            "rationale": "No warnings were found in the project. The skill correctly returned a clean bill of health, so there are no warning messages to evaluate for actionability. This dimension is N/A \u2014 the correct response to a warning-free check is to report no warnings, not to invent generic action items."
+          },
+          {
+            "source": "rubric",
+            "name": "FamilySearch quality reporting",
+            "score": 3,
+            "rationale": "The skill correctly recognized that I1 is a synthetic ID (not a FamilySearch XXXX-XXX format) and appropriately skipped the person_quality call. No quality section was added to the report, avoiding noise. The skill's text confirms 'no FamilySearch quality call needed,' which is correct per the test expectations."
+          }
+        ]
+      },
+      "totals": {
+        "duration_ms": 21547.957667033188,
+        "duration_api_ms": 21521.0,
+        "judge_duration_ms": 6849.854750034865,
+        "wall_clock_ms": 28461.19713783264,
+        "num_turns": 6,
+        "input_tokens": 11,
+        "cached_input_tokens": 57886,
+        "output_tokens": 817,
+        "judge_input_tokens": 4552,
+        "judge_cached_input_tokens": 0,
+        "judge_output_tokens": 694,
+        "skill_cost_usd": 0.0676688,
+        "judge_cost_usd": 0.008022,
+        "total_cost_usd": 0.0756908
+      },
+      "runs": [
+        {
+          "run_index": 0,
+          "run_id": "run_ut_check_warnings_018_2026-07-05_16-35-38_0",
+          "outcome": "pass",
+          "aborted_reason": null,
+          "duration_ms": 21547.957667033188,
+          "duration_api_ms": 21521.0,
+          "num_turns": 6,
+          "skill_attempts": 1,
+          "input_tokens": 11,
+          "cached_input_tokens": 57886,
+          "output_tokens": 817,
+          "skill_cost_usd": 0.0676688,
+          "output": {
+            "text_response": "Patrick Flynn is `I1` \u2014 a synthetic ID, so I'll run the offline warnings check only (no FamilySearch quality call needed).---\n\n**WARNINGS FOR: Patrick Flynn (I1)**\n\nNo genealogical warnings found for Patrick Flynn. The tool's checks all passed.\n\nHis recorded data \u2014 birth circa 1845 in Ireland, death 12 March 1908 in Schuylkill County, Pennsylvania, and the parent-child relationship with Thomas Flynn \u2014 contains no logical impossibilities or implausible values. Everything is internally consistent.",
+            "activated": true,
+            "skills_invoked": [
+              "check-warnings"
+            ],
+            "tool_calls": [
+              {
+                "tool": "mcp__genealogy__person_warnings",
+                "args": {
+                  "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/eval-ut_check_warnings_018-0-0-wc1px1n3",
+                  "personId": "I1"
+                },
+                "expected_args": {
+                  "personId": "~"
+                },
+                "matched": {
+                  "kind": "predicate",
+                  "index": 0
+                },
+                "response_fixture": "person-warnings-no-warnings"
+              }
+            ],
+            "files_created": [],
+            "warnings": [
+              {
+                "kind": "missing_tool_usage_dimension",
+                "advisory": "Skill called MCP tools but the rubric has no dimension name suggesting tool-usage coverage (matched against keywords: ['tool usage', 'tool use', 'tool work', 'tool call', 'argument quality', 'argument-quality', 'response interpretation', 'tool selection', 'mcp tool', 'fixture']). The judge will grade other dimensions but won't score tool work explicitly. Consider adding a tool-usage dimension or renaming an existing one."
+              }
+            ]
+          },
+          "validators": {
+            "passed": true,
+            "results": [
+              {
+                "name": "test_id_references_resolve",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_log_append_only",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_entries_deleted",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_research_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tool_allowlist",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_gedcomx_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_research_json_unmodified",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_gedcomx_unmodified",
+                "passed": true,
+                "error": null
+              }
+            ]
+          },
+          "judge": {
+            "skipped": false,
+            "dimensions": [
+              {
+                "source": "base",
+                "name": "Correctness",
+                "score": 3,
+                "rationale": "The skill correctly identified that I1 is a synthetic ID and appropriately called person_warnings without attempting a person_quality call. The tool response confirms zero warnings were detected, and the skill accurately reported this finding without fabricating any issues."
+              },
+              {
+                "source": "base",
+                "name": "Completeness",
+                "score": 3,
+                "rationale": "The skill addressed the user's request fully: it checked Patrick Flynn for warnings by calling person_warnings with the correct personId (I1), received the result showing no warnings, and reported that result completely. No required steps were omitted."
+              },
+              {
+                "source": "base",
+                "name": "Tool Arguments",
+                "score": 3,
+                "rationale": "The person_warnings call used personId 'I1', which matches the expected pattern (~). The projectPath argument was correctly set to the test environment path. No arguments were missing or incorrect; the call matched expectations."
+              },
+              {
+                "source": "rubric",
+                "name": "Detection accuracy",
+                "score": 3,
+                "rationale": "The person_warnings tool returned zero warnings for Patrick Flynn. The tool's check for impossibilities (birth after death, chronological conflicts) and anomalies passed with no false positives. No genuine impossibilities were missed; the data is internally consistent."
+              },
+              {
+                "source": "rubric",
+                "name": "Severity classification",
+                "score": 3,
+                "rationale": "Since no warnings were detected, there are no severity tiers to evaluate. The tool output confirms a clean check, and the skill correctly reported that fact. Severity classification is appropriately N/A, but this scores as pass given the complete absence of warnings."
+              },
+              {
+                "source": "rubric",
+                "name": "Actionability",
+                "score": null,
+                "rationale": "No warnings were found in the project. The skill correctly returned a clean bill of health, so there are no warning messages to evaluate for actionability. This dimension is N/A \u2014 the correct response to a warning-free check is to report no warnings, not to invent generic action items."
+              },
+              {
+                "source": "rubric",
+                "name": "FamilySearch quality reporting",
+                "score": 3,
+                "rationale": "The skill correctly recognized that I1 is a synthetic ID (not a FamilySearch XXXX-XXX format) and appropriately skipped the person_quality call. No quality section was added to the report, avoiding noise. The skill's text confirms 'no FamilySearch quality call needed,' which is correct per the test expectations."
+              }
+            ],
+            "judge_cost_usd": 0.008022,
+            "duration_ms": 6849.854750034865,
+            "error": null,
+            "input_tokens": 4552,
+            "cached_input_tokens": 0,
+            "output_tokens": 694
+          },
+          "started_at": 1783269388.258247,
+          "ended_at": 1783269416.719444
+        }
+      ]
+    },
+    {
+      "test_id": "ut_check_warnings_017",
+      "test_type": "positive",
+      "expected_outcome": "pass",
+      "scenario": "christian-hole-quality",
+      "mcp_fixtures": [
+        "person-warnings-hole-deleted-none",
+        "person-quality-hole-deleted"
+      ],
+      "outcome": "pass",
+      "flaky": false,
+      "outcome_summary": {
+        "per_run_outcomes": [
+          "pass"
+        ],
+        "aggregated_dimensions": [
+          {
+            "source": "base",
+            "name": "Correctness",
+            "score": 3,
+            "rationale": "The skill correctly reported the offline warnings (no impossibilities found) and accurately handled the tombstoned FamilySearch record. Tool response: person_warnings returned 0 warnings; person_quality returned a tombstoned error message that the skill accurately captured and reported verbatim ('Person KD96-TV5 is tombstoned in the FamilySearch tree \u2014 it has been deleted or merged'). No fabricated facts or unsupported claims."
+          },
+          {
+            "source": "base",
+            "name": "Completeness",
+            "score": 3,
+            "rationale": "The skill addressed all that was asked: checked KD96-TV5 for warnings by calling both person_warnings and person_quality with the correct personId. Reported both results: the offline warnings (none) and the quality status (tombstoned). Nothing was silently omitted that the input state required."
+          },
+          {
+            "source": "base",
+            "name": "Tool Arguments",
+            "score": 3,
+            "rationale": "Both tool calls used correct arguments. person_warnings was called with personId 'KD96-TV5' matching expected_args. person_quality was called with personId 'KD96-TV5' matching expected_args. Both calls matched their predicate fixtures (kind: 'predicate'). No wrong identifiers, no fixture_not_found errors. Argument structure and values are exactly as expected."
+          },
+          {
+            "source": "rubric",
+            "name": "Detection accuracy",
+            "score": 3,
+            "rationale": "The skill correctly detected that there were no impossibilities in the offline data for KD96-TV5 (the person_warnings tool returned 0 warnings). No false positives were raised. The skill appropriately reported 'no genealogical warnings found' based on the tool response. Detection is accurate to the data available."
+          },
+          {
+            "source": "rubric",
+            "name": "Severity classification",
+            "score": 3,
+            "rationale": "The skill did not classify any warnings as critical, high, medium, or low because there were no warnings to classify. The offline check returned 0 impossibilities. The tombstoned status was presented as a brief factual note, not escalated as an error or impossibility. Severity classification is appropriate given the absence of flagged issues."
+          },
+          {
+            "source": "rubric",
+            "name": "Actionability",
+            "score": 3,
+            "rationale": "The offline warnings section directly states 'No genealogical warnings found,' which is actionable (no action needed). The quality section identifies the specific reason for lack of a quality score: the person is tombstoned (deleted or merged). The skill then suggests concrete next steps: investigate whether the person was merged (locate surviving profile ID) or deleted (verify local data). These are actionable suggestions tied to the specific status returned."
+          },
+          {
+            "source": "rubric",
+            "name": "FamilySearch quality reporting",
+            "score": 3,
+            "rationale": "The skill correctly called person_quality for FamilySearch ID 'KD96-TV5' (not a synthetic ID, so the call was warranted). The tombstoned error from the tool was reported honestly in a distinct section ('FamilySearch Quality') separate from the offline impossibilities. The exact tool message was used verbatim in the report. No fabricated quality score or invented issues. The person_warnings result (0 warnings) was reported regardless of the quality failure, as required. The tombstoned state was framed appropriately\u2014not as a fatal error, but as a status note with suggested follow-up actions."
+          }
+        ]
+      },
+      "totals": {
+        "duration_ms": 21509.008750028443,
+        "duration_api_ms": 21006.0,
+        "judge_duration_ms": 9470.208540966269,
+        "wall_clock_ms": 31022.539138793945,
+        "num_turns": 6,
+        "input_tokens": 10,
+        "cached_input_tokens": 41031,
+        "output_tokens": 858,
+        "judge_input_tokens": 5021,
+        "judge_cached_input_tokens": 0,
+        "judge_output_tokens": 930,
+        "skill_cost_usd": 0.057366799999999996,
+        "judge_cost_usd": 0.009670999999999999,
+        "total_cost_usd": 0.0670378
+      },
+      "runs": [
+        {
+          "run_index": 0,
+          "run_id": "run_ut_check_warnings_017_2026-07-05_16-35-38_0",
+          "outcome": "pass",
+          "aborted_reason": null,
+          "duration_ms": 21509.008750028443,
+          "duration_api_ms": 21006.0,
+          "num_turns": 6,
+          "skill_attempts": 1,
+          "input_tokens": 10,
+          "cached_input_tokens": 41031,
+          "output_tokens": 858,
+          "skill_cost_usd": 0.057366799999999996,
+          "output": {
+            "text_response": "Here's the full report for **KD96-TV5**:\n\n---\n\n### Warnings for KD96-TV5\n\n**No genealogical warnings found.** All offline impossibility checks passed \u2014 no logical errors in the local data (no death before birth, no events after death, no impossible ages, etc.).\n\n---\n\n### FamilySearch Quality: KD96-TV5\n\n> Person KD96-TV5 is tombstoned in the FamilySearch tree \u2014 it has been deleted or merged into another profile \u2014 so it has no quality score.\n\nThis means the live FamilySearch profile for KD96-TV5 no longer exists as a standalone record. If this person was **merged** into another profile on FamilySearch, it would be worth locating the surviving profile ID (the one KD96-TV5 was merged into) so we can verify the merged data is correct and run a quality check on the new profile. If it was **deleted**, we'd want to confirm the local tree still reflects accurate information.\n\nWould you like to investigate the merge/deletion on FamilySearch, or is there anything else to look into for this person?",
+            "activated": true,
+            "skills_invoked": [
+              "check-warnings"
+            ],
+            "tool_calls": [
+              {
+                "tool": "mcp__genealogy__person_warnings",
+                "args": {
+                  "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/eval-ut_check_warnings_017-0-0-h2b7dsft",
+                  "personId": "KD96-TV5"
+                },
+                "expected_args": {
+                  "personId": "KD96-TV5"
+                },
+                "matched": {
+                  "kind": "predicate",
+                  "index": 0
+                },
+                "response_fixture": "person-warnings-hole-deleted-none"
+              },
+              {
+                "tool": "mcp__genealogy__person_quality",
+                "args": {
+                  "personId": "KD96-TV5"
+                },
+                "expected_args": {
+                  "personId": "KD96-TV5"
+                },
+                "matched": {
+                  "kind": "predicate",
+                  "index": 0
+                },
+                "response_fixture": "person-quality-hole-deleted"
+              }
+            ],
+            "files_created": [],
+            "warnings": [
+              {
+                "kind": "missing_tool_usage_dimension",
+                "advisory": "Skill called MCP tools but the rubric has no dimension name suggesting tool-usage coverage (matched against keywords: ['tool usage', 'tool use', 'tool work', 'tool call', 'argument quality', 'argument-quality', 'response interpretation', 'tool selection', 'mcp tool', 'fixture']). The judge will grade other dimensions but won't score tool work explicitly. Consider adding a tool-usage dimension or renaming an existing one."
+              }
+            ]
+          },
+          "validators": {
+            "passed": true,
+            "results": [
+              {
+                "name": "test_id_references_resolve",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_log_append_only",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_entries_deleted",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_research_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tool_allowlist",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_gedcomx_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_research_json_unmodified",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_gedcomx_unmodified",
+                "passed": true,
+                "error": null
+              }
+            ]
+          },
+          "judge": {
+            "skipped": false,
+            "dimensions": [
+              {
+                "source": "base",
+                "name": "Correctness",
+                "score": 3,
+                "rationale": "The skill correctly reported the offline warnings (no impossibilities found) and accurately handled the tombstoned FamilySearch record. Tool response: person_warnings returned 0 warnings; person_quality returned a tombstoned error message that the skill accurately captured and reported verbatim ('Person KD96-TV5 is tombstoned in the FamilySearch tree \u2014 it has been deleted or merged'). No fabricated facts or unsupported claims."
+              },
+              {
+                "source": "base",
+                "name": "Completeness",
+                "score": 3,
+                "rationale": "The skill addressed all that was asked: checked KD96-TV5 for warnings by calling both person_warnings and person_quality with the correct personId. Reported both results: the offline warnings (none) and the quality status (tombstoned). Nothing was silently omitted that the input state required."
+              },
+              {
+                "source": "base",
+                "name": "Tool Arguments",
+                "score": 3,
+                "rationale": "Both tool calls used correct arguments. person_warnings was called with personId 'KD96-TV5' matching expected_args. person_quality was called with personId 'KD96-TV5' matching expected_args. Both calls matched their predicate fixtures (kind: 'predicate'). No wrong identifiers, no fixture_not_found errors. Argument structure and values are exactly as expected."
+              },
+              {
+                "source": "rubric",
+                "name": "Detection accuracy",
+                "score": 3,
+                "rationale": "The skill correctly detected that there were no impossibilities in the offline data for KD96-TV5 (the person_warnings tool returned 0 warnings). No false positives were raised. The skill appropriately reported 'no genealogical warnings found' based on the tool response. Detection is accurate to the data available."
+              },
+              {
+                "source": "rubric",
+                "name": "Severity classification",
+                "score": 3,
+                "rationale": "The skill did not classify any warnings as critical, high, medium, or low because there were no warnings to classify. The offline check returned 0 impossibilities. The tombstoned status was presented as a brief factual note, not escalated as an error or impossibility. Severity classification is appropriate given the absence of flagged issues."
+              },
+              {
+                "source": "rubric",
+                "name": "Actionability",
+                "score": 3,
+                "rationale": "The offline warnings section directly states 'No genealogical warnings found,' which is actionable (no action needed). The quality section identifies the specific reason for lack of a quality score: the person is tombstoned (deleted or merged). The skill then suggests concrete next steps: investigate whether the person was merged (locate surviving profile ID) or deleted (verify local data). These are actionable suggestions tied to the specific status returned."
+              },
+              {
+                "source": "rubric",
+                "name": "FamilySearch quality reporting",
+                "score": 3,
+                "rationale": "The skill correctly called person_quality for FamilySearch ID 'KD96-TV5' (not a synthetic ID, so the call was warranted). The tombstoned error from the tool was reported honestly in a distinct section ('FamilySearch Quality') separate from the offline impossibilities. The exact tool message was used verbatim in the report. No fabricated quality score or invented issues. The person_warnings result (0 warnings) was reported regardless of the quality failure, as required. The tombstoned state was framed appropriately\u2014not as a fatal error, but as a status note with suggested follow-up actions."
+              }
+            ],
+            "judge_cost_usd": 0.009670999999999999,
+            "duration_ms": 9470.208540966269,
+            "error": null,
+            "input_tokens": 5021,
+            "cached_input_tokens": 0,
+            "output_tokens": 930
+          },
+          "started_at": 1783269416.7275279,
+          "ended_at": 1783269447.750067
+        }
+      ]
+    }
+  ],
+  "totals": {
+    "duration_ms": 666428.0737920781,
+    "duration_api_ms": 614373.0,
+    "judge_duration_ms": 140326.26749994233,
+    "num_turns": 114,
+    "input_tokens": 175,
+    "cached_input_tokens": 1045869,
+    "output_tokens": 26874,
+    "judge_input_tokens": 86595,
+    "judge_cached_input_tokens": 0,
+    "judge_output_tokens": 13918,
+    "skill_cost_usd": 1.3517762,
+    "judge_cost_usd": 0.15618499999999996,
+    "total_cost_usd": 1.5079612000000004,
+    "wall_clock_ms": 114498.80027770996
+  }
+}


### PR DESCRIPTION
## Summary

<!-- 1-3 bullets describing what changed and why. -->

## Test plan

- [ ] I ran `scripts/test.sh` and it passed.
- [ ] For every skill whose files I changed (SKILL.md, scenarios, fixtures,
      tests, or supporting MCP/harness code), I ran `RunTests.bat <skill>`
      and committed an all-pass runlog under `eval/runlogs/unit/<skill>/`.
