### PR TITLE
Phase 0: e2e latency measurement + baseline

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -342,6 +342,13 @@ e2e-validate: ## Stripping linter for an e2e fixture (or all): make e2e-validate
 e2e-calibrate: ## Run judge calibration against committed run annotations (maintainer step; needs an API key)
 	cd eval/harness && uv run python -m e2e.calibrate_judge
 
+.PHONY: e2e-latency
+e2e-latency: ## Phase-0 latency breakdown of committed e2e runs: make e2e-latency (all) | TEST=<slug> | MD=1 for a Markdown table
+	# Pure analysis over committed run JSONs — no live run, no API. Answers
+	# "how much of wall-clock is model generation vs tool execution?" (the
+	# Phase 0 gate). See docs/plan/research-latency-reduction-plan.md.
+	cd eval/harness && uv run python -m e2e.latency_report $(if $(TEST),--test $(TEST),--all) $(if $(MD),--markdown,)
+
 .PHONY: e2e-scratch
 e2e-scratch: ## Set up a throwaway dir (outside the repo) to run /research by hand against a fixture: make e2e-scratch TEST=kenneth-quass-death
 	# Seeds the fixture's starting state + plugin skills into a sibling dir

--- a/docs/plan/research-latency-baseline-2026-07-05.md
+++ b/docs/plan/research-latency-baseline-2026-07-05.md
@@ -1,7 +1,7 @@
 # Research-Latency Baseline — 2026-07-05 (Phase 0)
 
-**Status:** measured from committed e2e runs; one canonical fresh run still owed
-(blocked on FamilySearch re-login — see §5).
+**Status:** measured from committed e2e runs; the owed fresh kenneth run is now in
+(§5) — it does not change the §4 conclusions but surfaces a confound worth reading.
 **Feeds:** [`research-latency-reduction-plan.md`](./research-latency-reduction-plan.md) (this is its Phase 0 gate).
 **Tool:** `make e2e-latency` (`eval/harness/e2e/latency_report.py`) — pure analysis
 over committed run JSONs, no live run, no API. Reproduce any number below with it.
@@ -113,23 +113,63 @@ Measured against `research-latency-reduction-plan.md`:
 Net: **stop adding persistence tools for latency; spend the effort on 2a + 2b**,
 both of which are skill-prose changes.
 
-## 5. The one owed measurement (blocked)
+## 5. The owed measurement — done, and its confound
 
-A fresh **post-migration** kenneth-quass-death real run, to sit beside the Jun 16
-pre-migration point (32.5m / 129 turns / 818 tok/turn) and confirm the persistence
-migration's effect on the canonical fixture. Blocked only on an interactive
-FamilySearch re-login (the token is >24h old; `e2e-preflight` is green on
-everything else — built server, `ANTHROPIC_API_KEY`, deps). To run it:
+Fresh kenneth-quass-death run (`run-2026-07-05_20-05-17`, **pass**, proof 2/3),
+beside the Jun 16 point:
 
+| | Jun 16 (pre-migration, pre-#578) | Jul 05 (post-migration, post-#578) | Δ |
+|---|---|---|---|
+| wall-clock | 32.5m | 50.3m | **+55%** |
+| model-API % | 99.7% | 99.6% | flat |
+| turns | 129 | 125 | −3% (flat) |
+| output tokens | 105,544 | 131,635 | **+25%** |
+| tok/turn | 818 | 1,053 | **+29%** |
+| cost | $6.47 | $7.88 | +22% |
+| top tools | `Edit:37, validate:15` | `research_append:24, research_log_append:7` | **different workflow** |
+
+The naïve read — "latency *rose*, so the perf work regressed" — is wrong. **These
+two runs are not a clean A/B for any single change**; at least three things moved
+between them, and the confounds dominate:
+
+1. **The persistence architecture migrated.** Jun 16 hand-wrote research.json via
+   `Edit` (37×) + `validate_research_schema` (15×); Jul 05 uses the structured
+   `research_append` (24×) + `research_log_append` (7×) tools. That is a different
+   generation profile, not a prose change. **Hypothesis worth testing before acting:**
+   a batched `research_append` serializes a large assertion payload *as tool-use
+   input* — which counts as **generated output tokens** — so the structured tools
+   may *raise* tok/turn (818→1,053) while cutting hand-edit turns elsewhere. If real,
+   that's a latency cost hiding inside a correctness/UX win. Test it by measuring the
+   tool-use-input token share per turn, not by eyeballing wall-clock.
+2. **Different research path.** The Jul 05 run hit a conflict (`conflicts=yes`,
+   proof 2/3, exhaustiveness=partial) and did conflict-resolution + argument-form
+   proof work the Jun 16 run did not. More work → more tokens, legitimately.
+3. **Single-run variance + gen stalls.** No `temperature=0`; the Jul 05 timeline
+   carries individual 206s / 177s / 164s generation gaps (one turn each) that read
+   as API-side queueing on this run, not a systematic property. n=1 per side.
+
+**So we still do not have a clean e2e measurement of #578 — and can't cheaply get
+one**, because the only pre-#578 kenneth run also predates the migration. This is
+the real lesson: **at e2e, confounds are unavoidable** (architecture, research path,
+stalls, n=1), so e2e wall-clock is a *coarse multi-run trend*, not an attribution
+tool. **Attributing a single SKILL.md edit needs the unit-level instrument**
+(`make skill-latency`, PR #583) — identical test inputs, same skill, isolated. Use
+e2e to watch aggregate drift; use unit to credit a specific edit. A genuine #578
+e2e A/B would require two runs that differ *only* in #578 (both post-migration) —
+worth one focused pair if a hard e2e number is ever needed.
+
+The fresh run JSON is uncommitted at
+`eval/runlogs/e2e/kenneth-quass-death/run-2026-07-05_20-05-17.json` (+ `.final-tree`,
+`.final-research`, `.transcript.md`). It is **not** added to this PR — committing an
+e2e run that produced a final tree triggers the same-PR grading gate
+(`check-e2e-fixtures`), and that `.ann.json` is a calibration judgment for the
+maintainer, not away-block work. Grade + commit it as a second canonical baseline if
+wanted (`/grade-e2e-run`), or discard it — the numbers above are already captured here.
+
+Reproduce the breakdown:
 ```
-make e2e-login                                 # browser OAuth, ~24h-lived
-make e2e-run  TEST=kenneth-quass-death          # ~20–60 min, $3–10
-make e2e-latency TEST=kenneth-quass-death       # breakdown of the fresh run
+make e2e-latency TEST=kenneth-quass-death       # newest committed run
 ```
-
-This does **not** change the §4 conclusions — the model-vs-tool split is already
-unambiguous across seven runs. It refines the canonical before/after for the
-migration, and gives 2a/2b a fixed reference to measure against.
 
 ## 6. Reproduce
 

--- a/docs/plan/research-latency-baseline-2026-07-05.md
+++ b/docs/plan/research-latency-baseline-2026-07-05.md
@@ -1,0 +1,140 @@
+# Research-Latency Baseline — 2026-07-05 (Phase 0)
+
+**Status:** measured from committed e2e runs; one canonical fresh run still owed
+(blocked on FamilySearch re-login — see §5).
+**Feeds:** [`research-latency-reduction-plan.md`](./research-latency-reduction-plan.md) (this is its Phase 0 gate).
+**Tool:** `make e2e-latency` (`eval/harness/e2e/latency_report.py`) — pure analysis
+over committed run JSONs, no live run, no API. Reproduce any number below with it.
+
+## 0. TL;DR
+
+**Tool execution is not the problem. Model generation is the entire problem.**
+
+Across every committed e2e run, tool execution is **0.8–1.9 minutes** — 1.5–3% of a
+30–70 minute run. The other **97–99%** of the active agent loop is the model
+generating (thinking + text + tool-use decisions). So:
+
+- Faster or batched **tools** can reclaim **at most ~2 minutes** per run. Not the lever.
+- The lever is **model-generation time**, which is `turns × output-tokens-per-turn`.
+  Reduce **turns** (fewer round-trips) and **output per turn** (narration precision).
+- This **confirms and sharpens** the roadmap's premise ("make the model generate
+  less, in fewer round-trips") and **reprioritizes** its phases (§4).
+
+## 1. Method
+
+The orchestrator already persists everything needed into each committed result
+JSON (`eval/runlogs/e2e/<slug>/run-*.json`, schema in `e2e/result.py`): SDK
+`duration_ms` / `duration_api_ms`, `num_turns`, token counters, and (for runs
+after ~2026-06) a per-message `timeline` of `[elapsed_s, kind]`. `latency_report.py`
+derives two **independent** decompositions that corroborate each other:
+
+1. **Usage-based** — `duration_api_ms / duration_ms` = fraction of the active SDK
+   loop spent awaiting the model. Always present; SDK-internal, so unaffected by
+   harness overhead.
+2. **Timeline-based** — inter-message gaps split into **tool-execution** (gaps
+   ending at a `tool_result`) vs **everything-else** (model generation, plus any
+   stall/resume idle). Only the tool bucket is cleanly separable from a single
+   session's timeline; we do **not** split model-vs-idle further (an earlier
+   3-bucket attempt mis-scored interim `system:status` messages emitted
+   mid-generation as "overhead"). Wall-clock beyond the timeline span is flagged
+   as **stall/idle** (stall + resume + judge), which is neither model nor tool.
+
+## 2. The data (latest committed run per fixture)
+
+| fixture | verdict | wall | model-API %¹ | tool exec² | turns | out tok | tok/turn | cost |
+|---|---|---|---|---|---|---|---|---|
+| kenneth-quass-death (Jun 16, **pre-migration**) | pass | 32.5m | 99.7% | — ³ | 129 | 105,544 | 818 | $6.47 |
+| morris-jenkins-marriage | pass | 67.6m | 97.5% | 1.9m (2.8%) | 165 | 140,443 | 851 | $9.72 |
+| spriggs-parents-1898 | pass | 70.3m | 99.4% | 0.8m (1.7%) | 59 | 69,566 | 1,179 | $3.44 |
+| teitje-harkema-parents-1833 | pass | 49.2m | 97.7% | 1.9m | 108 | 112,103 | 1,038 | $6.55 |
+| bottemiller-parents | pass | 60.4m (timeout) | n/a⁴ | 1.3m | — | — | — | — |
+| elizabeth-geach-parents | partial | 60.4m (timeout) | n/a⁴ | 1.7m | — | — | — | — |
+| ivyl-greenley-daughter | pass | 43.0m | n/a⁴ | 0.8m | — | — | — | — |
+
+¹ Of the **active SDK loop** (`duration_ms`), not raw wall-clock — see spriggs.
+² Timeline `tool_result` gaps. The reclaimable ceiling for any tool-speed work.
+³ The Jun 16 kenneth run predates the `timeline` field, so no timeline split;
+  its 99.7% usage-based number is the cleanest single "it's all model" data point.
+⁴ These three store a `timeline` but not the ResultMessage usage block, so
+  usage-based %/turns/tokens are absent; their tool-execution time (≈1–1.7m)
+  still confirms the headline.
+
+**spriggs is the instructive outlier:** 70.3m wall, but only 22.0m active SDK loop
+and **27.3m stall/idle** (it stalled once and resumed — a 606s `tool_result →
+system:init` gap). Its wall-clock is inflated by *idle*, not work. Stalls are a
+**reliability** issue (already mitigated by `RESUME_ON_STALL`), not a
+latency-tuning target — no amount of tool or prompt work reclaims idle time.
+
+## 3. What actually drives the model-generation time
+
+Two knobs, both visible above:
+
+- **Output tokens per turn: 818–1,179.** Every token is generated
+  serially — this is the per-turn cost. Directly attacked by **narration/thinking
+  precision** (Phase 2a).
+- **Turns: 59–165.** Each turn is a full model round-trip that re-reads the
+  (cached) context and generates. Fewer turns → fewer generation cycles.
+  Attacked by **round-trip reduction** (Phase 2b).
+
+Round-trip hotspots, from the per-run tool-call histograms (`make e2e-latency`
+prints top tools):
+
+| pattern | typical count / run | nature | lever |
+|---|---|---|---|
+| `Read` | 40–56 | re-reading files often already in context (research.json, tree, templates) | 2b: "you already have X — don't re-Read" (skill prose) |
+| `research_append` + `research_log_append` | 25–45 combined | one-entry-at-a-time appends | 1c is **shipped** (`ops[]` batch) but **under-adopted** — skill prose should batch |
+| `ToolSearch` | 7–22 | deferred MCP-tool loading, one round-trip each | 2b: preload the tools a skill will need |
+
+## 4. Implications for the roadmap (the reprioritization)
+
+Measured against `research-latency-reduction-plan.md`:
+
+- **Phase 1a (`tree_edit add_source`/`update_source`) — SHIPPED.** Verified in
+  `tree-edit.ts` + `SimplifiedSourceDescription.author`.
+- **Phase 1c (`research_append` batch) — SHIPPED as `ops[]`.** But the data shows
+  25–45 append calls/run, so the batch form is **under-adopted in skill prose**.
+  The remaining 1c win is **adoption** (a 2b/2a prose change), not tool code.
+- **Phase 1b (`project`/`researcher_profile` writer) — NOT a latency lever.**
+  It targets a one-time-at-project-creation write; against a budget that is
+  97–99% model generation spread over 59–165 turns, it saves ≈0 latency. Keep it
+  **only** if wanted for ergonomics/consistency (the structured-persistence
+  initiative), not as latency work. **Deprioritized here.**
+- **Phase 1d (`init-project` migration) — depends on 1b; same deprioritization**
+  for latency.
+- **Phase 2 is where the time is** (now un-gated by this measurement):
+  - **2a (narration/thinking precision)** — cuts output-tokens/turn (818–1,179).
+    Highest-leverage single lever. Quality-sensitive → must be verified by
+    per-skill unit-eval re-runs before landing.
+  - **2b (round-trip reduction)** — cuts turns (59–165): stop re-reading files
+    already in context; preload expected tools to kill `ToolSearch` round-trips;
+    adopt the `ops[]` batch-append form.
+  - **2c (auto-chaining)** — still a `plan-design-review` item, not a foregone win.
+
+Net: **stop adding persistence tools for latency; spend the effort on 2a + 2b**,
+both of which are skill-prose changes.
+
+## 5. The one owed measurement (blocked)
+
+A fresh **post-migration** kenneth-quass-death real run, to sit beside the Jun 16
+pre-migration point (32.5m / 129 turns / 818 tok/turn) and confirm the persistence
+migration's effect on the canonical fixture. Blocked only on an interactive
+FamilySearch re-login (the token is >24h old; `e2e-preflight` is green on
+everything else — built server, `ANTHROPIC_API_KEY`, deps). To run it:
+
+```
+make e2e-login                                 # browser OAuth, ~24h-lived
+make e2e-run  TEST=kenneth-quass-death          # ~20–60 min, $3–10
+make e2e-latency TEST=kenneth-quass-death       # breakdown of the fresh run
+```
+
+This does **not** change the §4 conclusions — the model-vs-tool split is already
+unambiguous across seven runs. It refines the canonical before/after for the
+migration, and gives 2a/2b a fixed reference to measure against.
+
+## 6. Reproduce
+
+```
+make e2e-latency            # all fixtures, human blocks
+make e2e-latency MD=1       # Markdown comparison table (§2)
+make e2e-latency TEST=<slug> # one fixture
+```

--- a/eval/harness/e2e/latency_report.py
+++ b/eval/harness/e2e/latency_report.py
@@ -1,0 +1,357 @@
+"""Latency-breakdown analyzer for e2e runs — the Phase 0 measurement tool.
+
+The e2e roadmap's Phase 0 asks one question before any behaviour tuning is
+sized: **of a run's wall-clock, how much is the model generating (thinking +
+text + tool-use decisions — i.e. time inside the Anthropic API) versus tools
+executing versus local orchestration?** The answer decides which levers matter
+(fewer turns / less output per turn vs. faster tools).
+
+The raw material is already captured by the orchestrator and persisted into the
+committed result JSON (see e2e/result.py):
+
+  - ``usage.duration_ms``      — the SDK's own total wall-clock for the agent loop
+  - ``usage.duration_api_ms``  — cumulative time awaiting the model API
+  - ``usage.num_turns``        — assistant turns
+  - ``usage.usage.output_tokens`` (and input / cache counters)
+  - ``usage.timeline``         — ``[[elapsed_s, kind], ...]`` per SDK message,
+                                 kind ∈ {assistant, tool_result, system:*, result}
+                                 (added after 2026-06; older runs lack it)
+
+This module is pure analysis on top of that — it adds **no** instrumentation to
+a run. ``analyze_result`` is a pure function (unit-tested without a live run);
+the CLI locates committed runs and prints a per-run block + a comparison table.
+
+CLI (from eval/harness/):
+  uv run python -m e2e.latency_report --test kenneth-quass-death
+  uv run python -m e2e.latency_report --all
+  uv run python -m e2e.latency_report --all --markdown > table.md
+  uv run python -m e2e.latency_report path/to/run-<ts>.json [more.json ...]
+
+Two independent decompositions are reported so they corroborate:
+  1. usage-based  — duration_api_ms / duration_ms  (SDK-internal, always present)
+  2. timeline-based — sum of inter-message gaps bucketed by the *later* message's
+     kind (assistant → model time, tool_result → tool time, system:* → overhead)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+E2E_RUNLOGS = REPO_ROOT / "eval" / "runlogs" / "e2e"
+
+
+def _bare_tool_name(tool: str) -> str:
+    """`mcp__genealogy__record_search` -> `record_search`; passthrough otherwise."""
+    return tool.split("__")[-1] if tool else tool
+
+
+@dataclass
+class LatencyBreakdown:
+    """Decision-grade latency summary for one e2e run."""
+
+    test_id: str
+    verdict: str
+    stop_reason: str
+    source_file: str | None = None
+
+    # Totals (seconds). wall_clock_s prefers the harness monotonic clock
+    # (excludes system sleep); duration_s is the SDK's own total. They differ
+    # only by orchestration overhead outside the SDK loop.
+    wall_clock_s: float = 0.0
+    duration_s: float = 0.0
+    api_s: float = 0.0
+
+    # The headline: fraction of the SDK's own total spent awaiting the model.
+    # Uses duration_api_ms / duration_ms — both SDK-internal, so internally
+    # consistent regardless of harness-side overhead.
+    api_pct: float | None = None
+
+    num_turns: int | None = None
+    n_tool_calls: int = 0
+
+    # Token counters (from usage.usage).
+    output_tokens: int | None = None
+    input_tokens: int | None = None
+    cache_read_input_tokens: int | None = None
+    cache_creation_input_tokens: int | None = None
+    output_tokens_per_turn: float | None = None
+
+    total_cost_usd: float | None = None
+
+    # Bare-tool-name -> count, most-common first (as a list of pairs so it is
+    # JSON/round-trip friendly).
+    tool_counts: list[tuple[str, int]] = field(default_factory=list)
+
+    # Timeline-derived decomposition (None when the run predates the timeline).
+    #
+    # Only `tool_result`-terminated gaps are reliably tool-execution time. The
+    # rest ("non-tool") is model generation PLUS any stall/resume idle — the two
+    # are indistinguishable inside a single session, so we do not split them
+    # here (an earlier 3-bucket model/overhead split mis-scored interim
+    # `system:status` messages emitted mid-generation as "overhead"). What is
+    # robust and decision-relevant is: tool time is tiny; everything else is not
+    # reclaimable by faster/batched tools.
+    timeline_present: bool = False
+    timeline_span_s: float | None = None
+    tool_time_s: float | None = None
+    non_tool_time_s: float | None = None
+    tool_time_pct: float | None = None
+    # Wall-clock outside the timeline span (stalls/resumes/judge/setup). Large
+    # only for runs that stalled + resumed; idle, not model or tool work.
+    stall_s: float | None = None
+    # Slowest single generation gaps (gaps ending at an assistant message):
+    # [(elapsed_s_at_end, gap_s), ...], longest first — the longest single
+    # model deliberations.
+    slowest_gen_gaps: list[tuple[float, float]] = field(default_factory=list)
+
+
+def _timeline_decomposition(timeline: list[list[Any]]) -> dict[str, Any]:
+    """Split inter-message wall-clock gaps into tool-execution vs everything-else.
+
+    A gap ending at a ``tool_result`` message is a tool executing between the
+    preceding tool-use and its result — the one bucket the timeline measures
+    cleanly. Every other gap (ending at ``assistant`` or ``system:*``) is the
+    model generating or, on a stalled run, idle resume time; those are not
+    separable from a single session's timeline and are lumped as "non-tool".
+    Gaps ending at an ``assistant`` message are additionally surfaced as the
+    longest single model deliberations.
+    """
+    tool = non_tool = 0.0
+    gen_gaps: list[tuple[float, float]] = []
+    prev_t: float | None = None
+    first_t: float | None = None
+    last_t: float | None = None
+    for entry in timeline:
+        # entry is [elapsed_seconds, kind]
+        t = float(entry[0])
+        kind = str(entry[1])
+        if first_t is None:
+            first_t = t
+        last_t = t
+        if prev_t is not None:
+            gap = t - prev_t
+            if gap < 0:
+                gap = 0.0
+            if kind == "tool_result":
+                tool += gap
+            else:
+                non_tool += gap
+                if kind == "assistant":
+                    gen_gaps.append((round(t, 1), round(gap, 1)))
+        prev_t = t
+    span = (last_t - first_t) if (first_t is not None and last_t is not None) else 0.0
+    total = tool + non_tool
+    gen_gaps.sort(key=lambda p: p[1], reverse=True)
+    return {
+        "timeline_span_s": round(span, 1),
+        "tool_time_s": round(tool, 1),
+        "non_tool_time_s": round(non_tool, 1),
+        "tool_time_pct": (tool / total) if total > 0 else None,
+        "slowest_gen_gaps": gen_gaps[:5],
+    }
+
+
+def analyze_result(result: dict[str, Any], source_file: str | None = None) -> LatencyBreakdown:
+    """Derive a LatencyBreakdown from a parsed e2e result dict (pure)."""
+    usage = result.get("usage") or {}
+    inner = usage.get("usage") if isinstance(usage.get("usage"), dict) else {}
+
+    duration_ms = usage.get("duration_ms")
+    duration_api_ms = usage.get("duration_api_ms")
+    duration_s = (duration_ms / 1000.0) if duration_ms else 0.0
+    api_s = (duration_api_ms / 1000.0) if duration_api_ms else 0.0
+    wall_clock_s = usage.get("wall_clock_seconds") or duration_s
+    api_pct = (
+        (duration_api_ms / duration_ms)
+        if (duration_api_ms and duration_ms)
+        else None
+    )
+
+    num_turns = usage.get("num_turns")
+    output_tokens = inner.get("output_tokens")
+    out_per_turn = (
+        (output_tokens / num_turns) if (output_tokens and num_turns) else None
+    )
+
+    tool_calls = result.get("tool_calls") or []
+    counts = Counter(_bare_tool_name(c.get("tool", "")) for c in tool_calls)
+
+    bd = LatencyBreakdown(
+        test_id=result.get("test_id", "?"),
+        verdict=result.get("verdict", "?"),
+        stop_reason=result.get("stop_reason", "?"),
+        source_file=source_file,
+        wall_clock_s=round(float(wall_clock_s), 1),
+        duration_s=round(duration_s, 1),
+        api_s=round(api_s, 1),
+        api_pct=api_pct,
+        num_turns=num_turns,
+        n_tool_calls=len(tool_calls),
+        output_tokens=output_tokens,
+        input_tokens=inner.get("input_tokens"),
+        cache_read_input_tokens=inner.get("cache_read_input_tokens"),
+        cache_creation_input_tokens=inner.get("cache_creation_input_tokens"),
+        output_tokens_per_turn=(round(out_per_turn, 1) if out_per_turn else None),
+        total_cost_usd=usage.get("total_cost_usd"),
+        tool_counts=counts.most_common(),
+    )
+
+    timeline = usage.get("timeline")
+    if isinstance(timeline, list) and timeline:
+        bd.timeline_present = True
+        d = _timeline_decomposition(timeline)
+        bd.timeline_span_s = d["timeline_span_s"]
+        bd.tool_time_s = d["tool_time_s"]
+        bd.non_tool_time_s = d["non_tool_time_s"]
+        bd.tool_time_pct = d["tool_time_pct"]
+        bd.slowest_gen_gaps = d["slowest_gen_gaps"]
+        # Wall-clock beyond the timeline span is stall/resume/judge idle.
+        if bd.timeline_span_s is not None:
+            bd.stall_s = round(max(0.0, bd.wall_clock_s - bd.timeline_span_s), 1)
+
+    return bd
+
+
+# --- Presentation -----------------------------------------------------------
+
+def _fmt_pct(x: float | None) -> str:
+    return f"{x * 100:.1f}%" if x is not None else "n/a"
+
+
+def _fmt_min(seconds: float | None) -> str:
+    return f"{seconds / 60:.1f}m" if seconds else "n/a"
+
+
+def format_breakdown(bd: LatencyBreakdown) -> str:
+    """A per-run human block."""
+    lines = [
+        f"=== {bd.test_id}  ({bd.verdict} / {bd.stop_reason}) ===",
+        f"  wall-clock:      {_fmt_min(bd.wall_clock_s)}  ({bd.wall_clock_s:.0f}s)",
+        f"  model API time:  {_fmt_min(bd.api_s)}  = {_fmt_pct(bd.api_pct)} of active SDK loop",
+        f"  turns:           {bd.num_turns}     tool calls: {bd.n_tool_calls}",
+        f"  output tokens:   {bd.output_tokens}   ({bd.output_tokens_per_turn}/turn)"
+        if bd.output_tokens
+        else "  output tokens:   n/a",
+        f"  cache read:      {bd.cache_read_input_tokens}   cost: ${bd.total_cost_usd}",
+    ]
+    if bd.timeline_present:
+        # tool execution is the only reclaimable-by-tooling bucket; everything
+        # else is model generation (+ any stall idle).
+        lines.append(
+            f"  tool execution:  {_fmt_min(bd.tool_time_s)} "
+            f"({_fmt_pct(bd.tool_time_pct)} of timeline)  <- reclaimable ceiling for faster/batched tools"
+        )
+        lines.append(
+            f"  non-tool time:   {_fmt_min(bd.non_tool_time_s)}  (model generation across turns)"
+        )
+        if bd.stall_s and bd.stall_s > 60:
+            lines.append(
+                f"  stall/idle:      {_fmt_min(bd.stall_s)}  (outside timeline span — stall/resume/judge, not model or tool)"
+            )
+        if bd.slowest_gen_gaps:
+            gaps = ", ".join(f"{g:.0f}s@{t:.0f}s" for t, g in bd.slowest_gen_gaps)
+            lines.append(f"  slowest gen gaps: {gaps}")
+    top = ", ".join(f"{n}:{k}" for n, k in bd.tool_counts[:8])
+    lines.append(f"  top tools:       {top}")
+    return "\n".join(lines)
+
+
+def format_markdown_table(bds: list[LatencyBreakdown]) -> str:
+    """A comparison table across runs (Markdown)."""
+    header = (
+        "| fixture | verdict | wall | model-API % | turns | out tok | tok/turn | cost |\n"
+        "|---|---|---|---|---|---|---|---|"
+    )
+    rows = []
+    for bd in bds:
+        rows.append(
+            f"| {bd.test_id} | {bd.verdict} | {_fmt_min(bd.wall_clock_s)} | "
+            f"{_fmt_pct(bd.api_pct)} | {bd.num_turns} | {bd.output_tokens} | "
+            f"{bd.output_tokens_per_turn} | ${bd.total_cost_usd:.2f} |"
+            if bd.total_cost_usd is not None
+            else f"| {bd.test_id} | {bd.verdict} | {_fmt_min(bd.wall_clock_s)} | "
+            f"{_fmt_pct(bd.api_pct)} | {bd.num_turns} | {bd.output_tokens} | "
+            f"{bd.output_tokens_per_turn} | n/a |"
+        )
+    return "\n".join([header, *rows])
+
+
+# --- Run discovery + CLI ----------------------------------------------------
+
+def _is_result_json(p: Path) -> bool:
+    """A committed structured result, not its tree/research/ann siblings."""
+    name = p.name
+    return (
+        name.startswith("run-")
+        and name.endswith(".json")
+        and not name.endswith(".ann.json")
+        and ".final-" not in name
+    )
+
+
+def latest_run_for(test_slug: str) -> Path | None:
+    d = E2E_RUNLOGS / test_slug
+    if not d.is_dir():
+        return None
+    runs = sorted(p for p in d.iterdir() if _is_result_json(p))
+    return runs[-1] if runs else None
+
+
+def all_latest_runs() -> list[Path]:
+    if not E2E_RUNLOGS.is_dir():
+        return []
+    out = []
+    for d in sorted(E2E_RUNLOGS.iterdir()):
+        if d.is_dir():
+            r = latest_run_for(d.name)
+            if r:
+                out.append(r)
+    return out
+
+
+def _load(path: Path) -> LatencyBreakdown:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    return analyze_result(data, source_file=str(path))
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description="e2e latency breakdown (Phase 0).")
+    ap.add_argument("files", nargs="*", help="explicit result JSON paths")
+    ap.add_argument("--test", help="latest committed run for this fixture slug")
+    ap.add_argument("--all", action="store_true", help="latest run per fixture")
+    ap.add_argument("--markdown", action="store_true", help="emit a Markdown table")
+    args = ap.parse_args(argv)
+
+    paths: list[Path] = [Path(f) for f in args.files]
+    if args.test:
+        r = latest_run_for(args.test)
+        if not r:
+            print(f"No committed run found for '{args.test}'.", file=sys.stderr)
+            return 1
+        paths.append(r)
+    if args.all:
+        paths.extend(all_latest_runs())
+    if not paths:
+        print("Nothing to analyze. Pass files, --test <slug>, or --all.", file=sys.stderr)
+        return 1
+
+    bds = [_load(p) for p in paths]
+
+    if args.markdown:
+        print(format_markdown_table(bds))
+    else:
+        for bd in bds:
+            print(format_breakdown(bd))
+            print()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/eval/harness/e2e/latency_report.py
+++ b/eval/harness/e2e/latency_report.py
@@ -29,8 +29,11 @@ CLI (from eval/harness/):
 
 Two independent decompositions are reported so they corroborate:
   1. usage-based  — duration_api_ms / duration_ms  (SDK-internal, always present)
-  2. timeline-based — sum of inter-message gaps bucketed by the *later* message's
-     kind (assistant → model time, tool_result → tool time, system:* → overhead)
+  2. timeline-based — inter-message gaps split two ways by the *later* message's
+     kind: gaps ending at ``tool_result`` are tool-execution; everything else
+     (``assistant`` + ``system:*``) is non-tool (model generation, plus any
+     stall/resume idle — not separable within one session). Wall-clock beyond the
+     timeline span is flagged separately as stall/idle.
 """
 
 from __future__ import annotations

--- a/eval/harness/tests/unit/test_e2e_latency_report.py
+++ b/eval/harness/tests/unit/test_e2e_latency_report.py
@@ -1,0 +1,150 @@
+"""Unit tests for e2e.latency_report — the Phase 0 latency analyzer.
+
+Pure math over a synthetic result dict (the e2e/result.py schema). No live
+run, no Anthropic API — this runs in `make harness-test`. The synthetic
+timeline is hand-computed so the bucketed model/tool/overhead split is
+checkable by eye.
+"""
+
+from __future__ import annotations
+
+from e2e.latency_report import (
+    LatencyBreakdown,
+    analyze_result,
+    format_breakdown,
+    format_markdown_table,
+    _timeline_decomposition,
+)
+
+
+def _result(**overrides):
+    """A modern (timeline-bearing) result dict; override any key."""
+    base = {
+        "test_id": "kenneth-quass-death",
+        "verdict": "pass",
+        "stop_reason": "completed",
+        "usage": {
+            "duration_ms": 100_000,
+            "duration_api_ms": 98_000,
+            "num_turns": 100,
+            "total_cost_usd": 6.5,
+            "wall_clock_seconds": 101.0,
+            "usage": {
+                "input_tokens": 200,
+                "output_tokens": 80_000,
+                "cache_read_input_tokens": 12_000_000,
+                "cache_creation_input_tokens": 400_000,
+            },
+            # gaps: 8->assistant(=8 model), 8->10 tool_result(=2 tool),
+            # 10->13 assistant(=3 model), 13->14 system(=1 overhead),
+            # 14->20 assistant(=6 model)
+            "timeline": [
+                [8.0, "assistant"],
+                [10.0, "tool_result"],
+                [13.0, "assistant"],
+                [14.0, "system:status"],
+                [20.0, "assistant"],
+            ],
+        },
+        "tool_calls": [
+            {"tool": "mcp__genealogy__record_search", "args": {}},
+            {"tool": "mcp__genealogy__record_search", "args": {}},
+            {"tool": "Read", "args": {}},
+            {"tool": "Edit", "args": {}},
+        ],
+    }
+    base.update(overrides)
+    return base
+
+
+def test_headline_api_percentage():
+    bd = analyze_result(_result())
+    assert bd.api_pct == 98_000 / 100_000
+    assert bd.duration_s == 100.0
+    assert bd.api_s == 98.0
+    assert bd.wall_clock_s == 101.0  # harness clock preferred over duration_ms
+
+
+def test_output_tokens_per_turn():
+    bd = analyze_result(_result())
+    assert bd.output_tokens == 80_000
+    assert bd.num_turns == 100
+    assert bd.output_tokens_per_turn == 800.0
+
+
+def test_tool_counts_bare_names_and_order():
+    bd = analyze_result(_result())
+    # most_common: record_search:2 first, then the singletons.
+    assert bd.tool_counts[0] == ("record_search", 2)
+    names = {n for n, _ in bd.tool_counts}
+    assert names == {"record_search", "Read", "Edit"}
+    assert bd.n_tool_calls == 4
+
+
+def test_timeline_decomposition_math():
+    d = _timeline_decomposition(_result()["usage"]["timeline"])
+    # 5 points -> 4 gaps, bucketed by the *later* entry's kind:
+    #   8->10 tool_result   = 2   (tool)
+    #   10->13 assistant    = 3   (non-tool, gen gap)
+    #   13->14 system:status= 1   (non-tool)
+    #   14->20 assistant    = 6   (non-tool, gen gap)
+    assert d["tool_time_s"] == 2.0
+    assert d["non_tool_time_s"] == 10.0  # 3 + 1 + 6
+    assert d["tool_time_pct"] == 2.0 / 12.0
+    assert d["timeline_span_s"] == 12.0  # 20 - 8
+    # slowest generation gap is the 6s one ending at t=20.
+    assert d["slowest_gen_gaps"][0] == (20.0, 6.0)
+
+
+def test_timeline_present_flag_set():
+    bd = analyze_result(_result())
+    assert bd.timeline_present is True
+    assert bd.tool_time_pct == 2.0 / 12.0
+    # wall_clock (101) exceeds timeline span (12) -> the rest is stall/idle.
+    assert bd.stall_s == 101.0 - 12.0
+
+
+def test_legacy_result_without_timeline():
+    """A pre-2026-06 run: no timeline, no wall_clock_seconds. Must not crash;
+    timeline fields stay None, usage-based headline still computed."""
+    legacy = _result()
+    legacy["usage"].pop("timeline")
+    legacy["usage"].pop("wall_clock_seconds")
+    bd = analyze_result(legacy)
+    assert bd.timeline_present is False
+    assert bd.tool_time_pct is None
+    assert bd.stall_s is None
+    assert bd.api_pct == 0.98
+    assert bd.wall_clock_s == 100.0  # falls back to duration_ms/1000
+
+
+def test_missing_usage_is_safe():
+    """A skipped/crashed run may have an empty usage dict."""
+    bd = analyze_result({"test_id": "x", "verdict": "skipped", "stop_reason": "error"})
+    assert isinstance(bd, LatencyBreakdown)
+    assert bd.api_pct is None
+    assert bd.num_turns is None
+    assert bd.n_tool_calls == 0
+
+
+def test_zero_num_turns_no_divide_by_zero():
+    r = _result()
+    r["usage"]["num_turns"] = 0
+    bd = analyze_result(r)
+    assert bd.output_tokens_per_turn is None
+
+
+def test_format_breakdown_renders_headline():
+    bd = analyze_result(_result())
+    text = format_breakdown(bd)
+    assert "kenneth-quass-death" in text
+    assert "98.0%" in text  # api_pct
+    assert "model" in text
+
+
+def test_markdown_table_has_row_per_run():
+    bds = [analyze_result(_result()), analyze_result(_result(test_id="morris"))]
+    table = format_markdown_table(bds)
+    assert table.count("\n") == 3  # header + separator + 2 rows
+    assert "morris" in table
+    assert "kenneth-quass-death" in table

--- a/eval/harness/tests/unit/test_e2e_latency_report.py
+++ b/eval/harness/tests/unit/test_e2e_latency_report.py
@@ -2,8 +2,7 @@
 
 Pure math over a synthetic result dict (the e2e/result.py schema). No live
 run, no Anthropic API — this runs in `make harness-test`. The synthetic
-timeline is hand-computed so the bucketed model/tool/overhead split is
-checkable by eye.
+timeline is hand-computed so the tool-vs-non-tool split is checkable by eye.
 """
 
 from __future__ import annotations
@@ -35,9 +34,9 @@ def _result(**overrides):
                 "cache_read_input_tokens": 12_000_000,
                 "cache_creation_input_tokens": 400_000,
             },
-            # gaps: 8->assistant(=8 model), 8->10 tool_result(=2 tool),
-            # 10->13 assistant(=3 model), 13->14 system(=1 overhead),
-            # 14->20 assistant(=6 model)
+            # gaps by later-message kind: 8->10 tool_result(=2 tool),
+            # 10->13 assistant(=3 non-tool), 13->14 system(=1 non-tool),
+            # 14->20 assistant(=6 non-tool)  => tool=2, non_tool=10
             "timeline": [
                 [8.0, "assistant"],
                 [10.0, "tool_result"],


### PR DESCRIPTION
## What & why

Phase 0 of the research-latency roadmap: **measure before tuning.** Answers the gate question — *how much of an e2e run's wall-clock is model generation vs tool execution?* — and reprioritizes the roadmap from the answer.

## The finding (from 7 committed runs)

**Tool execution is negligible; model generation is the entire budget.**

- Tool execution: **0.8–1.9 min/run** = 1.5–3% of a 30–70 min run.
- **97–99%** of the active agent loop is the model generating.
- Levers: **turns** (59–165) and **output-tokens/turn** (818–1,179) — both skill-prose changes.

| fixture | wall | model-API % | tool exec | turns | tok/turn |
|---|---|---|---|---|---|
| kenneth (Jun 16, pre-migration) | 32.5m | 99.7% | — | 129 | 818 |
| morris-jenkins | 67.6m | 97.5% | 1.9m (2.8%) | 165 | 851 |
| spriggs | 70.3m | 99.4% | 0.8m (1.7%) | 59 | 1,179 |
| teitje-harkema | 49.2m | 97.7% | 1.9m | 108 | 1,038 |

(spriggs' 70m includes 27m of *stall/idle* from a resume — not model or tool work.)

## What's in the PR

- `eval/harness/e2e/latency_report.py` — pure analysis over committed run JSONs (**no new instrumentation, no live run, no API**). Two independent decompositions corroborate. + `make e2e-latency`.
- 10 unit tests (`tests/unit/test_e2e_latency_report.py`) — run in `make harness-test`. Full harness suite: **670 passed**.
- `docs/plan/research-latency-baseline-2026-07-05.md` — the baseline + roadmap reprioritization.

## Roadmap impact

- **1a / 1c: shipped.** (1c's `ops[]` batch is under-adopted in skill prose — a 2b item.)
- **1b / 1d: not latency levers** (one-time-at-creation) → deprioritized for latency.
- **Phase 2a (narration precision) + 2b (round-trip reduction) is where the time is.**

## Owed (blocked on you)

A fresh post-migration kenneth-quass-death real run — blocked only on interactive FamilySearch re-login (token >24h; preflight green otherwise):
```
make e2e-login && make e2e-run TEST=kenneth-quass-death && make e2e-latency TEST=kenneth-quass-death
```
It refines the canonical before/after but does **not** change the split above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)