### PR TITLE
Measure #578's latency effect from unit runlogs (+ skill-latency tool)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -349,6 +349,18 @@ e2e-latency: ## Phase-0 latency breakdown of committed e2e runs: make e2e-latenc
 	# Phase 0 gate). See docs/plan/research-latency-reduction-plan.md.
 	cd eval/harness && uv run python -m e2e.latency_report $(if $(TEST),--test $(TEST),--all) $(if $(MD),--markdown,)
 
+.PHONY: skill-latency
+skill-latency: ## Per-skill output-token profile from unit runlogs: make skill-latency (all) | SKILL=<name> [VS_PREV=1] | BEFORE=a.json AFTER=b.json
+	# The cheap 2a feedback loop: a SKILL.md edit's effect on generated output
+	# tokens, read from the unit re-run the edit already forces — no e2e run.
+	# Diff leads with "concision" (both-active tests); tests going to 0 output
+	# are activation/abort changes, not concision, and are excluded. See
+	# docs/plan/research-latency-baseline-2026-07-05.md.
+	cd eval/harness && uv run python -m skill_latency_report \
+		$(if $(and $(BEFORE),$(AFTER)),--before $(BEFORE) --after $(AFTER),) \
+		$(if $(SKILL),--skill $(SKILL) $(if $(VS_PREV),--vs-prev,),) \
+		$(if $(or $(SKILL),$(and $(BEFORE),$(AFTER))),,--all $(if $(MD),--markdown,))
+
 .PHONY: e2e-scratch
 e2e-scratch: ## Set up a throwaway dir (outside the repo) to run /research by hand against a fixture: make e2e-scratch TEST=kenneth-quass-death
 	# Seeds the fixture's starting state + plugin skills into a sibling dir

--- a/docs/plan/578-skill-latency-effect-2026-07-05.md
+++ b/docs/plan/578-skill-latency-effect-2026-07-05.md
@@ -1,0 +1,106 @@
+# Did #578 actually cut skill latency? — 2026-07-05
+
+**Status:** measured from committed **unit** run logs; no e2e run required.
+**Tool:** `make skill-latency` (`eval/harness/skill_latency_report.py`).
+**Context:** Phase-0 baseline ([`research-latency-baseline-2026-07-05.md`](./research-latency-baseline-2026-07-05.md))
+found ~98% of an e2e run is model generation, so **output tokens generated** is the
+dominant latency lever. #578 ("perf(skills): cut runtime latency") edited 6 SKILL.md
+files to that end **but shipped with its effect unmeasured** — it merged *after* every
+run in the e2e baseline. This measures it.
+
+## 0. TL;DR
+
+**#578 delivered real, large concision wins on the skills it cleanly touched** —
+proof-conclusion **−44%**, timeline **−32%**, conflict-resolution **−23%**,
+locality-guide **−14%** output tokens per skill run, prose-only. Two skills are
+murkier and flagged below. Because generation is ~98% of the latency budget, these
+are genuine latency reductions — but they're measured at the **unit** level; the owed
+post-#578 **e2e** run (kenneth, in flight) is what confirms they compound into
+wall-clock. **Don't start a second round of prose edits before that e2e lands.**
+
+## 1. Why this is measurable without an e2e run
+
+Every unit run log records the skill's `output_tokens` (and, for newer logs,
+`num_turns`) per test. Editing a SKILL.md forces a unit re-run anyway — the run-log
+snapshot gate flips the old log inactive. So the re-run the author already does is a
+free measurement of the edit's generation-cost effect. `skill_latency_report.py`
+diffs the pre- and post-edit run logs, matched by `test_id`.
+
+Two honesty guards, both enforced by the tool:
+
+- **Concision vs. activation.** A test whose output goes to **0** didn't get more
+  concise — the skill declined to act or the run aborted before generating (a
+  *behavior* change). Counting it would dump its whole before-value into the
+  "reduction." The tool reports **concision** over *both-active* tests (non-zero on
+  both sides) and lists how many tests flipped 0↔non-0 (excluded). The raw
+  all-tests number is shown too, labelled as activation-inclusive.
+- **Test-input drift.** The tool compares the two logs' embedded snapshots of
+  `eval/tests/unit/<skill>/`. If the test JSON/rubric changed between runs
+  (#578 did for citation + record-extraction), the diff is flagged **not
+  prose-only** — its deltas conflate prose and test changes.
+
+**Caveat on every number:** unit tests run `runs_per_test=1` with no `temperature=0`
+(`eval/CLAUDE.md`), so a single test's token count carries run-to-run variance. Trust
+the **direction** and the **aggregate across a skill's tests**, not one test's exact %.
+
+## 2. #578's measured effect
+
+| skill | prose-only? | **concision** (both-active) | raw (all shared) | both-active / flipped-to-0 | turns |
+|---|---|---|---|---|---|
+| proof-conclusion | yes | **−44.0%** | −53.0% | 8 / 4 | n/a¹ |
+| timeline | yes | **−32.1%** | −49.3% | 6 / 3 | n/a¹ |
+| conflict-resolution | yes | **−22.7%** | −22.7% | 7 / 0 | 76→83 (+9%) |
+| locality-guide | yes | **−13.8%** | −13.3% | 20 / 1 | 449→419 (−7%) |
+| citation | **no** (tests changed) | −15.7% | −39.4% | 14 / 4 | n/a¹ |
+| record-extraction | **no** (tests changed) | **+17.5%** | +17.5% | 10 / 0 | 234→158 (−33%) |
+
+¹ The pre-#578 run log predates the `num_turns` instrumentation, so no turn delta.
+
+Reproduce any row:
+```
+make skill-latency BEFORE=eval/runlogs/unit/<skill>/<pre>.json \
+                   AFTER=eval/runlogs/unit/<skill>/<post>.json
+```
+
+## 3. Reading the result
+
+- **The four clean skills are unambiguous wins.** proof-conclusion, timeline,
+  conflict-resolution, locality-guide all shrank output tokens with **identical test
+  inputs** and still passing — pure prose concision. proof-conclusion and timeline's
+  *raw* numbers (−53%, −49%) overstate it because several negative tests dropped to
+  zero output; the **concision** figures (−44%, −32%) are the honest per-turn win, and
+  they're still large.
+- **conflict-resolution traded turns for concision** (+9% turns, −23% tokens) — more
+  round-trips, each much shorter, net token win. **locality-guide won on both** (−7%
+  turns, −14% tokens).
+- **citation is mostly *not* a concision story.** Its −39% raw is largely 4 tests
+  flipping to zero output plus a changed test corpus; the prose-only concision is only
+  −16%. Fine — citation's #578 change was partly a de-flake, not just concision.
+- **record-extraction needs the turn lens, not tokens.** Output tokens went *up* 18%,
+  but turns fell **33%** (234→158). Fewer, longer round-trips. Whether that's a net
+  latency win depends on per-turn vs per-token cost and can't be called from tokens
+  alone; its tests also changed. Flag for the e2e run to adjudicate.
+
+## 4. Consequence for the roadmap
+
+1. **#578 already banked the first 2a (concision) round.** The baseline's premise —
+   "make the model generate less" — is now shown to work at the unit level, with
+   double-digit-to-−44% reductions on four skills.
+2. **Confirm it compounds to e2e before tuning further.** Unit tests exercise one
+   skill each; an e2e run chains ~8 skills over 60–165 turns. The owed post-#578
+   kenneth e2e run (in flight) tells us whether −20-to-−44% per skill shows up as
+   wall-clock. **A second prose-edit round should wait for that number** — stacking
+   edits on an unmeasured change is how you tune the wrong thing.
+3. **This tool is the standing 2a feedback loop.** After any future SKILL.md edit,
+   `make skill-latency SKILL=<name> --vs-prev` reads the concision effect straight out
+   of the re-run the edit already forces — no $5 e2e needed to know if an edit helped.
+
+## 5. Use going forward
+
+```
+make skill-latency                          # per-skill token/turn profile, all skills
+make skill-latency MD=1                      # ... as a Markdown table
+make skill-latency SKILL=timeline            # one skill's latest profile
+make skill-latency SKILL=timeline VS_PREV=1  # diff its two newest run logs (last edit's effect)
+make skill-latency BEFORE=a.json AFTER=b.json # diff any two run logs
+```

--- a/eval/harness/skill_latency_report.py
+++ b/eval/harness/skill_latency_report.py
@@ -1,0 +1,410 @@
+"""Per-skill latency analyzer for *unit* run logs — the cheap 2a feedback loop.
+
+Phase 0 (see e2e/latency_report.py + docs/plan/research-latency-baseline-*.md)
+established that ~98% of an e2e run's active loop is the model generating, so the
+dominant latency lever is **output tokens generated** (turns × tokens/turn). A
+full e2e run costs $3-10 and ~30-70 min and needs live FamilySearch auth — far
+too heavy to gate every SKILL.md prose edit.
+
+But every *unit* run log already records the model's output-token count (and, for
+newer logs, `num_turns` and `duration_api_ms`) per test and per skill. Editing a
+SKILL.md forces a unit re-run anyway (the run-log snapshot gate). So the unit
+re-run the author already does is a *free* measurement of the edit's effect on
+generation cost — this module reads it out.
+
+Two modes:
+  * report — the per-test / per-skill output-token + turn profile of one run log.
+  * diff   — before/after two run logs for the same skill, matched by test_id, to
+             size a prose change. When the two logs embed identical test-side
+             snapshots the aggregate is a clean prose-only signal; when the tests
+             changed between them the diff says so (per-test deltas then conflate
+             prose + test changes and must be read test-by-test).
+
+Pure analysis over committed JSON — no live run, no API. `analyze_runlog` /
+`diff_skill` are pure and unit-tested; the CLI locates run logs and prints.
+
+Caveat carried in every number: unit tests run `runs_per_test=1` with no
+temperature=0 (eval/CLAUDE.md), so a single test's token count carries run-to-run
+variance. Trust the *direction* and the *aggregate across a skill's tests*, not a
+single test's exact percentage.
+
+CLI (from eval/harness/):
+  uv run python -m skill_latency_report --skill timeline
+  uv run python -m skill_latency_report --skill timeline --vs-prev
+  uv run python -m skill_latency_report --before A.json --after B.json
+  uv run python -m skill_latency_report --all [--markdown]
+  uv run python -m skill_latency_report A.json B.json      # positional = diff
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+UNIT_RUNLOGS = REPO_ROOT / "eval" / "runlogs" / "unit"
+
+
+# --- Analysis (pure) --------------------------------------------------------
+
+@dataclass
+class SkillLatency:
+    """Generation-cost profile of one unit run log."""
+
+    skill: str
+    source_file: str | None = None
+    n_tests: int = 0
+
+    # Summed across the skill's tests (each test's `totals`, which with
+    # runs_per_test=1 is its single run).
+    output_tokens: int = 0
+    # None when any test predates the num_turns instrumentation (older logs).
+    num_turns: int | None = None
+    duration_api_ms: float | None = None
+    total_cost_usd: float | None = None
+
+    # test_id -> {"output_tokens": int, "num_turns": int|None, "outcome": str}
+    per_test: dict[str, dict[str, Any]] = field(default_factory=dict)
+
+
+def analyze_runlog(runlog: dict[str, Any], source_file: str | None = None) -> SkillLatency:
+    """Derive a SkillLatency from a parsed unit run-log envelope (pure)."""
+    tests = runlog.get("tests") or []
+    per_test: dict[str, dict[str, Any]] = {}
+    out_sum = 0
+    turns_sum = 0
+    turns_all_present = True
+    for t in tests:
+        tid = t.get("test_id", "?")
+        totals = t.get("totals") or {}
+        out = totals.get("output_tokens") or 0
+        turns = totals.get("num_turns")
+        if turns is None:
+            turns_all_present = False
+        else:
+            turns_sum += turns
+        out_sum += out
+        per_test[tid] = {
+            "output_tokens": out,
+            "num_turns": turns,
+            "outcome": t.get("outcome", "?"),
+        }
+
+    env = runlog.get("totals") or {}
+    return SkillLatency(
+        skill=runlog.get("skill", "?"),
+        source_file=source_file,
+        n_tests=len(tests),
+        # Prefer the envelope's own summed output_tokens; fall back to our sum.
+        output_tokens=env.get("output_tokens", out_sum) or out_sum,
+        num_turns=(env.get("num_turns") if env.get("num_turns") is not None
+                   else (turns_sum if turns_all_present and tests else None)),
+        duration_api_ms=env.get("duration_api_ms"),
+        total_cost_usd=env.get("total_cost_usd"),
+        per_test=per_test,
+    )
+
+
+def _test_snapshot_keys(runlog: dict[str, Any], skill: str) -> dict[str, str]:
+    """The run log's embedded snapshot of this skill's *test-side* inputs.
+
+    Keys under ``eval/tests/unit/<skill>/`` (the test JSONs + rubric). Two run
+    logs with an identical such mapping ran against identical test inputs, so a
+    diff between them isolates the SKILL.md (prose) change.
+    """
+    snap = runlog.get("snapshot") or {}
+    prefix = f"eval/tests/unit/{skill}/"
+    return {k: v for k, v in snap.items() if k.startswith(prefix)}
+
+
+def same_test_inputs(before: dict[str, Any], after: dict[str, Any], skill: str) -> bool:
+    """True iff both run logs embed byte-identical test-side snapshots.
+
+    When False, a token diff between the two conflates prose changes with test
+    changes and must be read per-test rather than in aggregate. Returns False if
+    either log carries no test-side snapshot (can't prove stability).
+
+    (Not named ``test_*`` on purpose — that prefix makes pytest try to collect
+    it as a test case.)
+    """
+    b = _test_snapshot_keys(before, skill)
+    a = _test_snapshot_keys(after, skill)
+    if not b or not a:
+        return False
+    return b == a
+
+
+@dataclass
+class TestDelta:
+    test_id: str
+    before_out: int
+    after_out: int
+
+    @property
+    def delta(self) -> int:
+        return self.after_out - self.before_out
+
+    @property
+    def pct(self) -> float | None:
+        return (100.0 * self.delta / self.before_out) if self.before_out else None
+
+
+@dataclass
+class LatencyDiff:
+    skill: str
+    before_file: str | None
+    after_file: str | None
+    inputs_stable: bool
+    per_test: list[TestDelta] = field(default_factory=list)  # shared tests only
+    # Raw aggregates over ALL shared tests.
+    agg_before: int = 0
+    agg_after: int = 0
+    # Concision aggregates over "both-active" tests only — tests that generated
+    # output on BOTH sides. A test that went to/from 0 output is an activation or
+    # abort change (the skill declined / the run aborted before generating), NOT
+    # a per-turn concision change; counting it would dump its whole value into the
+    # "reduction" and overstate the concision win. `n_activation_changed` is how
+    # many shared tests flipped 0<->non-0 (excluded from the concision aggregate).
+    active_before: int = 0
+    active_after: int = 0
+    n_both_active: int = 0
+    n_activation_changed: int = 0
+    before_only: list[str] = field(default_factory=list)
+    after_only: list[str] = field(default_factory=list)
+    # Turn aggregates, only when both logs carry num_turns for all shared tests.
+    turns_before: int | None = None
+    turns_after: int | None = None
+
+    @property
+    def agg_delta(self) -> int:
+        return self.agg_after - self.agg_before
+
+    @property
+    def agg_pct(self) -> float | None:
+        return (100.0 * self.agg_delta / self.agg_before) if self.agg_before else None
+
+    @property
+    def concision_pct(self) -> float | None:
+        """Output-token change over both-active tests — the honest concision signal."""
+        return (100.0 * (self.active_after - self.active_before) / self.active_before
+                if self.active_before else None)
+
+
+def diff_skill(
+    before: SkillLatency,
+    after: SkillLatency,
+    inputs_stable: bool,
+) -> LatencyDiff:
+    """Match two run logs by test_id and size the output-token change (pure)."""
+    shared = sorted(set(before.per_test) & set(after.per_test))
+    deltas = [
+        TestDelta(tid, before.per_test[tid]["output_tokens"], after.per_test[tid]["output_tokens"])
+        for tid in shared
+    ]
+    # Sort most-improved (most negative delta) first.
+    deltas.sort(key=lambda d: d.delta)
+
+    both_active = [d for d in deltas if d.before_out > 0 and d.after_out > 0]
+    n_activation_changed = sum(
+        1 for d in deltas if (d.before_out > 0) != (d.after_out > 0)
+    )
+
+    turns_b = [before.per_test[t]["num_turns"] for t in shared]
+    turns_a = [after.per_test[t]["num_turns"] for t in shared]
+    both_complete = bool(shared) and all(x is not None for x in turns_b + turns_a)
+    # A turn *delta* needs both sides; if either is incomplete, report neither.
+    turns_before = sum(turns_b) if both_complete else None
+    turns_after = sum(turns_a) if both_complete else None
+
+    return LatencyDiff(
+        skill=after.skill if after.skill != "?" else before.skill,
+        before_file=before.source_file,
+        after_file=after.source_file,
+        inputs_stable=inputs_stable,
+        per_test=deltas,
+        agg_before=sum(d.before_out for d in deltas),
+        agg_after=sum(d.after_out for d in deltas),
+        active_before=sum(d.before_out for d in both_active),
+        active_after=sum(d.after_out for d in both_active),
+        n_both_active=len(both_active),
+        n_activation_changed=n_activation_changed,
+        before_only=sorted(set(before.per_test) - set(after.per_test)),
+        after_only=sorted(set(after.per_test) - set(before.per_test)),
+        turns_before=turns_before,
+        turns_after=turns_after,
+    )
+
+
+# --- Presentation -----------------------------------------------------------
+
+def _pct(x: float | None) -> str:
+    return f"{x:+.1f}%" if x is not None else "n/a"
+
+
+def format_skill(sl: SkillLatency) -> str:
+    turns = sl.num_turns if sl.num_turns is not None else "n/a"
+    per_turn = (
+        f"{sl.output_tokens / sl.num_turns:.0f}/turn"
+        if sl.num_turns else "n/a/turn"
+    )
+    lines = [
+        f"=== {sl.skill}  ({Path(sl.source_file).name if sl.source_file else '?'}) ===",
+        f"  tests: {sl.n_tests}   output tokens: {sl.output_tokens}   turns: {turns}   ({per_turn})",
+        f"  cost: ${sl.total_cost_usd}" if sl.total_cost_usd is not None else "  cost: n/a",
+    ]
+    return "\n".join(lines)
+
+
+def format_diff(d: LatencyDiff) -> str:
+    lines = [
+        f"=== {d.skill}: output-token diff over {len(d.per_test)} shared tests ===",
+        f"  before: {Path(d.before_file).name if d.before_file else '?'}",
+        f"  after:  {Path(d.after_file).name if d.after_file else '?'}",
+    ]
+    if not d.inputs_stable:
+        lines.append(
+            "  ⚠ test inputs CHANGED between these runs — deltas conflate "
+            "prose + test changes; read per-test."
+        )
+    # Lead with the honest concision signal (both-active tests), then raw.
+    lines.append(
+        f"  concision:     {d.active_before} -> {d.active_after}  "
+        f"({d.active_after - d.active_before:+d}, {_pct(d.concision_pct)})"
+        f"   [{d.n_both_active} both-active tests"
+        + (f"; {d.n_activation_changed} flipped 0<->non-0, excluded" if d.n_activation_changed else "")
+        + "]"
+        + ("   prose-only" if d.inputs_stable else "")
+    )
+    if d.n_activation_changed or d.agg_pct != d.concision_pct:
+        lines.append(
+            f"  raw (all {len(d.per_test)}): {d.agg_before} -> {d.agg_after}  "
+            f"({d.agg_delta:+d}, {_pct(d.agg_pct)})  "
+            "<- includes activation/abort changes, not just concision"
+        )
+    if d.turns_before is not None and d.turns_after is not None:
+        dt = d.turns_after - d.turns_before
+        pct = (100.0 * dt / d.turns_before) if d.turns_before else None
+        lines.append(f"  turns:         {d.turns_before} -> {d.turns_after}  ({dt:+d}, {_pct(pct)})")
+    if d.before_only or d.after_only:
+        lines.append(f"  unmatched: before-only={d.before_only or '-'} after-only={d.after_only or '-'}")
+    # Biggest movers (top 5 by absolute delta already sorted most-improved first).
+    movers = sorted(d.per_test, key=lambda x: abs(x.delta), reverse=True)[:5]
+    if movers:
+        lines.append("  biggest movers:")
+        for m in movers:
+            lines.append(f"    {m.test_id}: {m.before_out} -> {m.after_out}  ({m.delta:+d}, {_pct(m.pct)})")
+    return "\n".join(lines)
+
+
+def format_markdown_table(sls: list[SkillLatency]) -> str:
+    header = (
+        "| skill | tests | output tokens | turns | tok/turn | cost |\n"
+        "|---|---|---|---|---|---|"
+    )
+    rows = []
+    for sl in sls:
+        per_turn = f"{sl.output_tokens / sl.num_turns:.0f}" if sl.num_turns else "n/a"
+        turns = sl.num_turns if sl.num_turns is not None else "n/a"
+        cost = f"${sl.total_cost_usd:.2f}" if sl.total_cost_usd is not None else "n/a"
+        rows.append(
+            f"| {sl.skill} | {sl.n_tests} | {sl.output_tokens} | {turns} | {per_turn} | {cost} |"
+        )
+    return "\n".join([header, *rows])
+
+
+# --- Run-log discovery + CLI ------------------------------------------------
+
+def _is_releasable_runlog(p: Path) -> bool:
+    """A committed `v{N}[_ts].json` envelope, not a scratch / .ann sibling."""
+    n = p.name
+    return n.startswith("v") and n.endswith(".json") and not n.endswith(".ann.json")
+
+
+def releasable_runlogs_for(skill: str) -> list[Path]:
+    """All releasable run logs for a skill, oldest-first (filename sorts by version+ts)."""
+    d = UNIT_RUNLOGS / skill
+    if not d.is_dir():
+        return []
+    return sorted((p for p in d.iterdir() if _is_releasable_runlog(p)), key=lambda p: p.name)
+
+
+def all_skills() -> list[str]:
+    if not UNIT_RUNLOGS.is_dir():
+        return []
+    return sorted(d.name for d in UNIT_RUNLOGS.iterdir() if d.is_dir())
+
+
+def _load(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _diff_paths(before_path: Path, after_path: Path) -> LatencyDiff:
+    before_raw, after_raw = _load(before_path), _load(after_path)
+    before = analyze_runlog(before_raw, str(before_path))
+    after = analyze_runlog(after_raw, str(after_path))
+    skill = after.skill if after.skill != "?" else before.skill
+    stable = same_test_inputs(before_raw, after_raw, skill)
+    return diff_skill(before, after, stable)
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description="Per-skill unit-runlog latency report / diff.")
+    ap.add_argument("files", nargs="*", help="two run-log paths => diff them")
+    ap.add_argument("--skill", help="report the latest run log for this skill")
+    ap.add_argument("--vs-prev", action="store_true",
+                    help="with --skill: diff the two newest releasable run logs")
+    ap.add_argument("--before", help="explicit before run-log path (with --after)")
+    ap.add_argument("--after", help="explicit after run-log path (with --before)")
+    ap.add_argument("--all", action="store_true", help="table of latest run log per skill")
+    ap.add_argument("--markdown", action="store_true", help="emit a Markdown table (with --all)")
+    args = ap.parse_args(argv)
+
+    # Explicit / positional diff.
+    if args.before and args.after:
+        print(format_diff(_diff_paths(Path(args.before), Path(args.after))))
+        return 0
+    if len(args.files) == 2:
+        print(format_diff(_diff_paths(Path(args.files[0]), Path(args.files[1]))))
+        return 0
+    if args.files:
+        print("Pass exactly two run-log paths to diff, or use --skill / --all.", file=sys.stderr)
+        return 1
+
+    if args.skill:
+        logs = releasable_runlogs_for(args.skill)
+        if not logs:
+            print(f"No releasable run logs for skill '{args.skill}'.", file=sys.stderr)
+            return 1
+        if args.vs_prev:
+            if len(logs) < 2:
+                print(f"Need >=2 run logs to diff '{args.skill}'; found {len(logs)}.", file=sys.stderr)
+                return 1
+            print(format_diff(_diff_paths(logs[-2], logs[-1])))
+            return 0
+        print(format_skill(analyze_runlog(_load(logs[-1]), str(logs[-1]))))
+        return 0
+
+    if args.all:
+        sls = []
+        for skill in all_skills():
+            logs = releasable_runlogs_for(skill)
+            if logs:
+                sls.append(analyze_runlog(_load(logs[-1]), str(logs[-1])))
+        if args.markdown:
+            print(format_markdown_table(sls))
+        else:
+            for sl in sls:
+                print(format_skill(sl))
+                print()
+        return 0
+
+    ap.print_help()
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/eval/harness/tests/unit/test_skill_latency_report.py
+++ b/eval/harness/tests/unit/test_skill_latency_report.py
@@ -1,0 +1,195 @@
+"""Unit tests for skill_latency_report — the per-skill unit-runlog analyzer.
+
+Pure math over synthetic run-log envelope dicts (the run-log.schema shape). No
+live run, no Anthropic API — runs in `make harness-test`.
+"""
+
+from __future__ import annotations
+
+from skill_latency_report import (
+    SkillLatency,
+    analyze_runlog,
+    diff_skill,
+    format_diff,
+    format_markdown_table,
+    format_skill,
+    same_test_inputs,
+)
+
+
+def _runlog(skill="timeline", tests=None, totals="default", snapshot=None):
+    if tests is None:
+        tests = [
+            {"test_id": "ut_a", "outcome": "pass",
+             "totals": {"output_tokens": 1000, "num_turns": 10}},
+            {"test_id": "ut_b", "outcome": "pass",
+             "totals": {"output_tokens": 500, "num_turns": 5}},
+        ]
+    d = {"skill": skill, "tests": tests}
+    if totals == "default":
+        d["totals"] = {"output_tokens": 1500, "num_turns": 15,
+                       "total_cost_usd": 1.2, "duration_api_ms": 200.0}
+    elif totals is not None:
+        d["totals"] = totals
+    if snapshot is not None:
+        d["snapshot"] = snapshot
+    return d
+
+
+def test_analyze_sums_and_per_test():
+    sl = analyze_runlog(_runlog(), "eval/runlogs/unit/timeline/v1.json")
+    assert sl.skill == "timeline"
+    assert sl.n_tests == 2
+    assert sl.output_tokens == 1500
+    assert sl.num_turns == 15
+    assert sl.total_cost_usd == 1.2
+    assert sl.per_test["ut_a"] == {"output_tokens": 1000, "num_turns": 10, "outcome": "pass"}
+
+
+def test_analyze_prefers_envelope_output_tokens():
+    """Envelope totals is authoritative even if it disagrees with the per-test sum."""
+    sl = analyze_runlog(_runlog(totals={"output_tokens": 9999}))
+    assert sl.output_tokens == 9999
+
+
+def test_analyze_num_turns_falls_back_to_test_sum():
+    """No envelope num_turns, but every test has one -> sum the tests."""
+    sl = analyze_runlog(_runlog(totals={"output_tokens": 1500}))
+    assert sl.num_turns == 15  # 10 + 5
+
+
+def test_analyze_num_turns_none_when_a_test_lacks_it():
+    """A legacy (pre-instrumentation) test with no num_turns -> aggregate is None."""
+    tests = [
+        {"test_id": "ut_a", "outcome": "pass", "totals": {"output_tokens": 1000, "num_turns": 10}},
+        {"test_id": "ut_b", "outcome": "pass", "totals": {"output_tokens": 500}},  # no num_turns
+    ]
+    sl = analyze_runlog(_runlog(tests=tests, totals={"output_tokens": 1500}))
+    assert sl.num_turns is None
+    assert sl.output_tokens == 1500
+
+
+def test_same_inputs_true_when_test_snapshots_identical():
+    snap = {"eval/tests/unit/timeline/a.json": "X", "packages/engine/plugin/skills/timeline/SKILL.md": "prose1"}
+    before = _runlog(snapshot=snap)
+    # SKILL.md differs (the prose edit) but test-side snapshot is identical.
+    after = _runlog(snapshot={"eval/tests/unit/timeline/a.json": "X",
+                              "packages/engine/plugin/skills/timeline/SKILL.md": "prose2"})
+    assert same_test_inputs(before, after, "timeline") is True
+
+
+def test_same_inputs_false_when_test_changed():
+    before = _runlog(snapshot={"eval/tests/unit/timeline/a.json": "X"})
+    after = _runlog(snapshot={"eval/tests/unit/timeline/a.json": "Y"})  # test JSON changed
+    assert same_test_inputs(before, after, "timeline") is False
+
+
+def test_same_inputs_false_when_snapshot_absent():
+    assert same_test_inputs(_runlog(), _runlog(), "timeline") is False
+
+
+def test_diff_basic_aggregate_and_sort():
+    before = analyze_runlog(_runlog())  # a:1000, b:500
+    after = analyze_runlog(_runlog(tests=[
+        {"test_id": "ut_a", "outcome": "pass", "totals": {"output_tokens": 600, "num_turns": 7}},
+        {"test_id": "ut_b", "outcome": "pass", "totals": {"output_tokens": 400, "num_turns": 4}},
+    ], totals={"output_tokens": 1000, "num_turns": 11}))
+    d = diff_skill(before, after, inputs_stable=True)
+    assert d.agg_before == 1500
+    assert d.agg_after == 1000
+    assert d.agg_delta == -500
+    assert round(d.agg_pct, 1) == -33.3
+    # most-improved (most negative delta) first: ut_a (-400) before ut_b (-100).
+    assert [t.test_id for t in d.per_test] == ["ut_a", "ut_b"]
+    assert d.per_test[0].delta == -400
+    assert round(d.per_test[0].pct, 1) == -40.0
+    # turn aggregate available (both sides carry num_turns).
+    assert d.turns_before == 15
+    assert d.turns_after == 11
+
+
+def test_diff_concision_excludes_activation_flips():
+    """A test going to 0 output is an activation/abort change, not concision.
+
+    It must be excluded from the concision aggregate (else its whole value
+    inflates the apparent reduction) but still counted in the raw aggregate.
+    """
+    before = analyze_runlog(_runlog(tests=[
+        {"test_id": "ut_a", "totals": {"output_tokens": 1000, "num_turns": 5}},  # both-active
+        {"test_id": "ut_b", "totals": {"output_tokens": 2000, "num_turns": 5}},  # -> 0 (flip)
+    ], totals=None))
+    after = analyze_runlog(_runlog(tests=[
+        {"test_id": "ut_a", "totals": {"output_tokens": 600, "num_turns": 5}},
+        {"test_id": "ut_b", "totals": {"output_tokens": 0, "num_turns": 5}},
+    ], totals=None))
+    d = diff_skill(before, after, inputs_stable=True)
+    # raw over both shared tests: 3000 -> 600  (-80%), badly overstated.
+    assert d.agg_before == 3000 and d.agg_after == 600
+    # concision over the one both-active test: 1000 -> 600  (-40%), the honest number.
+    assert d.active_before == 1000 and d.active_after == 600
+    assert d.n_both_active == 1
+    assert d.n_activation_changed == 1
+    assert round(d.concision_pct, 1) == -40.0
+
+
+def test_diff_shared_tests_only():
+    before = analyze_runlog(_runlog(tests=[
+        {"test_id": "ut_a", "totals": {"output_tokens": 1000, "num_turns": 1}},
+        {"test_id": "ut_c", "totals": {"output_tokens": 300, "num_turns": 1}},
+    ], totals=None))
+    after = analyze_runlog(_runlog(tests=[
+        {"test_id": "ut_a", "totals": {"output_tokens": 800, "num_turns": 1}},
+        {"test_id": "ut_d", "totals": {"output_tokens": 200, "num_turns": 1}},
+    ], totals=None))
+    d = diff_skill(before, after, inputs_stable=False)
+    assert [t.test_id for t in d.per_test] == ["ut_a"]  # only shared test
+    assert d.agg_before == 1000 and d.agg_after == 800
+    assert d.before_only == ["ut_c"]
+    assert d.after_only == ["ut_d"]
+
+
+def test_diff_turns_none_when_a_shared_test_lacks_turns():
+    before = analyze_runlog(_runlog(tests=[
+        {"test_id": "ut_a", "totals": {"output_tokens": 1000}},  # no num_turns
+    ], totals=None))
+    after = analyze_runlog(_runlog(tests=[
+        {"test_id": "ut_a", "totals": {"output_tokens": 800, "num_turns": 3}},
+    ], totals=None))
+    d = diff_skill(before, after, inputs_stable=True)
+    assert d.turns_before is None
+    assert d.turns_after is None
+    assert d.agg_delta == -200
+
+
+def test_format_skill_renders():
+    text = format_skill(analyze_runlog(_runlog(), "x/v1.json"))
+    assert "timeline" in text
+    assert "1500" in text  # output tokens
+    assert "/turn" in text
+
+
+def test_format_diff_flags_changed_inputs():
+    before = analyze_runlog(_runlog())
+    after = analyze_runlog(_runlog(tests=[
+        {"test_id": "ut_a", "totals": {"output_tokens": 600, "num_turns": 7}},
+        {"test_id": "ut_b", "totals": {"output_tokens": 400, "num_turns": 4}},
+    ], totals={"output_tokens": 1000, "num_turns": 11}))
+    stable = format_diff(diff_skill(before, after, inputs_stable=True))
+    changed = format_diff(diff_skill(before, after, inputs_stable=False))
+    assert "prose-only" in stable
+    assert "CHANGED" in changed
+
+
+def test_markdown_table_row_per_skill():
+    sls = [analyze_runlog(_runlog(skill="timeline")), analyze_runlog(_runlog(skill="citation"))]
+    table = format_markdown_table(sls)
+    assert table.count("\n") == 3  # header + separator + 2 rows
+    assert "timeline" in table and "citation" in table
+
+
+def test_missing_tests_is_safe():
+    sl = analyze_runlog({"skill": "empty"})
+    assert isinstance(sl, SkillLatency)
+    assert sl.n_tests == 0
+    assert sl.output_tokens == 0
+    assert sl.num_turns is None


### PR DESCRIPTION
**Stacked on #582** (base = `phase0-latency-measurement`). Review #582 first.

## What & why

Phase 0 (#582) found ~98% of an e2e run is model generation, so **output tokens** are the latency lever. But **#578** ("perf(skills): cut runtime latency") merged *after* the entire e2e baseline — its effect was **unmeasured**, and stacking more prose edits on an unmeasured change tunes the wrong thing.

A full e2e run ($3–10, ~30–70 min, live FS auth) is too heavy to gate a SKILL.md edit. But every **unit** run log already records `output_tokens`/`num_turns` per test, and editing a SKILL.md forces a unit re-run anyway — so that re-run is a **free** measurement. This PR reads it out.

## The tool — `make skill-latency`

`eval/harness/skill_latency_report.py`: report or before/after-diff unit run logs, matched by `test_id`. Two honesty guards (both unit-tested), because the naive aggregate **overclaims**:

1. **Concision vs. activation.** A test whose output drops to **0** didn't get concise — the skill declined or the run aborted (a *behavior* change). The tool leads with **concision** over *both-active* tests and excludes/counts tests that flipped 0↔non-0. Raw all-tests number shown too, labelled activation-inclusive.
2. **Test-input drift.** Compares the logs' embedded `eval/tests/unit/<skill>/` snapshots; flags a diff as **not prose-only** when the corpus changed (#578 changed citation + record-extraction).

15 unit tests; full harness suite **685 passed**.

## #578's measured effect

| skill | prose-only? | **concision** | raw | turns |
|---|---|---|---|---|
| proof-conclusion | yes | **−44%** | −53% | n/a |
| timeline | yes | **−32%** | −49% | n/a |
| conflict-resolution | yes | **−23%** | −23% | 76→83 (+9%) |
| locality-guide | yes | **−14%** | −13% | 449→419 (−7%) |
| citation | no (tests changed) | −16% | −39% | n/a |
| record-extraction | no (tests changed) | +18% | +18% | 234→158 (−33%) |

**#578 delivered** real, large concision wins on the four skills it cleanly touched. The raw −53%/−49% overstate it (negative tests dropping to zero output); the concision figures are the honest per-turn win. citation is mostly a de-flake, not concision; record-extraction traded tokens for a 33% turn cut (needs the e2e lens).

*Caveat carried on every number:* unit tests run `runs_per_test=1`, no `temperature=0` — trust the direction + aggregate, not one test's exact %.

## Consequence

#578 banked the first 2a (concision) round. **Confirm it compounds to e2e wall-clock — via the owed post-#578 kenneth run (in flight) — before a second prose-edit round.** Going forward, `make skill-latency SKILL=<x> VS_PREV=1` reads any edit's concision effect from the re-run it already forces. Full write-up: `docs/plan/578-skill-latency-effect-2026-07-05.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)