### PR TITLE
Add ferber-grandparents e2e fixture

### DIFF
--- a/eval/runlogs/e2e/ferber-grandparents/run-2026-07-07_08-10-37.ann.json
+++ b/eval/runlogs/e2e/ferber-grandparents/run-2026-07-07_08-10-37.ann.json
@@ -1,0 +1,14 @@
+{
+  "per_finding": {
+    "f1": "partial",
+    "f2": "true",
+    "f3": "false",
+    "f4": "false"
+  },
+  "notes": {
+    "f1": "Relationship correctly established (I10 Gerhard Ferber linked as father of I2 William, who is father of I1 Charles) via death-certificate assertion a_006 (indeterminate quality, single source). A likely-corroborating 1870 census household (head 'Gerhardt Faerber', b. ~1822 Prussia) was found in the research log (log_005) but the run hit a usage-limit error before extracting it into tree facts. No birth, immigration, naturalization, or death facts are recorded anywhere in the final tree for I10.",
+    "f2": "Relationship correctly established (I11 linked as mother of I2 via R14/R12) via the same death-certificate assertion a_007. No birth or death facts recorded, and the maiden name 'Engermann' was not found (research notes explicitly say maiden name unknown, tree only has married name 'Eva Ferber') — genealogist graded true on the core relationship/identity finding despite the missing maiden name and vital facts.",
+    "f3": "No person, relationship, or research-log entry for John Becker anywhere in the final tree or research.json. The run only ever opened q_001 (William Hubert Ferber's parents); a maternal-line question for Emma Becker's parents was never created before the run stopped on a usage-limit error.",
+    "f4": "Same as f3 — Mary Kramer is entirely absent; the maternal line was never reached before the run stopped."
+  }
+}

--- a/eval/runlogs/e2e/ferber-grandparents/run-2026-07-07_08-10-37.final-research.json
+++ b/eval/runlogs/e2e/ferber-grandparents/run-2026-07-07_08-10-37.final-research.json
@@ -1,0 +1,470 @@
+{
+  "project": {
+    "id": "rp_ferber_grandparents",
+    "objective": "Who were the grandparents of Charles Hubert Ferber, born 22 June 1891 in Cincinnati, Ohio (the parents of his father William Hubert Ferber and his mother Emma Becker)?",
+    "subject_person_ids": [
+      "I1"
+    ],
+    "status": "active",
+    "created": "2026-07-06T00:00:00Z",
+    "updated": "2026-07-06T00:00:00Z"
+  },
+  "researcher_profile": {
+    "experience_level": "intermediate",
+    "subscriptions": [],
+    "narration_guidance": "concise"
+  },
+  "questions": [
+    {
+      "id": "q_001",
+      "question": "Who were the parents of William Hubert Ferber (born December 1869 in Cincinnati, Hamilton County, Ohio; died 11 March 1903 in Cincinnati, Ohio)?",
+      "rationale": "William Hubert Ferber is the father of Charles Hubert Ferber and his parents are one half of the project objective. His 1903 Ohio death certificate, the 1870 and 1880 federal censuses (which would show him as a child in his parents' household), and the 1890 marriage record are all accessible on FamilySearch and represent strong starting-point sources. The death certificate in particular often names parents for this period and jurisdiction.",
+      "selection_basis": "objective_decomposition",
+      "priority": "high",
+      "status": "open",
+      "depends_on": [],
+      "unblocks": [],
+      "resolved": null,
+      "resolution_assertion_ids": [],
+      "exhaustive_declaration": {
+        "declared": false,
+        "justification": null,
+        "log_entry_ids": [],
+        "stop_criteria": null
+      },
+      "created": "2026-07-07"
+    }
+  ],
+  "plans": [
+    {
+      "id": "pl_001",
+      "question_id": "q_001",
+      "status": "active",
+      "created": "2026-07-07",
+      "items": [
+        {
+          "id": "pli_001",
+          "sequence": 1,
+          "record_type": "vital_record",
+          "jurisdiction": "Cincinnati, Hamilton County, Ohio",
+          "date_range": "1903",
+          "repository": "FamilySearch",
+          "rationale": "William Hubert Ferber's death certificate (11 Mar 1903) is already cited in the project as S3 (ark:/61903/1:1:F66M-8JZ, Ohio County Death Records 1840-2001). The certificate image has not yet been examined for parental information. Ohio county death records of this era frequently name the deceased's parents (father's name and mother's maiden name). Examining the image is the fastest possible first step since the source is already in hand.",
+          "fallback_for": null,
+          "status": "completed"
+        },
+        {
+          "id": "pli_002",
+          "sequence": 2,
+          "record_type": "census",
+          "jurisdiction": "Cincinnati, Hamilton County, Ohio",
+          "date_range": "1870",
+          "repository": "FamilySearch",
+          "rationale": "William was born December 1869 in Ohio, so he would appear as an infant (approximately 4\u20136 months old) in his parents' household in the June 1870 federal census. This is the highest-probability source for identifying both parents by name, along with any siblings and possibly the father's birthplace. FamilySearch has an indexed, free collection for 1870.",
+          "fallback_for": null,
+          "status": "in_progress"
+        },
+        {
+          "id": "pli_003",
+          "sequence": 3,
+          "record_type": "census",
+          "jurisdiction": "Cincinnati, Hamilton County, Ohio",
+          "date_range": "1880",
+          "repository": "FamilySearch",
+          "rationale": "In 1880 William would be approximately 10 years old and should appear in his parents' household. The 1880 census is fully indexed on FamilySearch, is free, and \u2014 crucially \u2014 records each household member's relationship to the head, providing a direct parent-child link. It also captures the birthplaces of each person's father and mother, which may reveal the Ferber family's origin.",
+          "fallback_for": null,
+          "status": "planned"
+        },
+        {
+          "id": "pli_004",
+          "sequence": 4,
+          "record_type": "vital_record",
+          "jurisdiction": "Hamilton County, Ohio",
+          "date_range": "1869",
+          "repository": "FamilySearch",
+          "rationale": "Hamilton County began recording births in 1863. A birth registration for William Hubert Ferber in December 1869 may exist in Ohio, County Births, 1841\u20132003 (collection 1932106) on FamilySearch. This record would directly name both parents, including the mother's maiden name \u2014 primary information for the parental question.",
+          "fallback_for": null,
+          "status": "planned"
+        },
+        {
+          "id": "pli_005",
+          "sequence": 5,
+          "record_type": "vital_record",
+          "jurisdiction": "Hamilton County, Ohio",
+          "date_range": "1890",
+          "repository": "FamilySearch",
+          "rationale": "William Hubert Ferber married Emma Becker on 10 September 1890 in Hamilton County (already cited as S1/S3). The marriage license application for this era sometimes recorded the groom's parents' names. Searching Ohio, County Marriages, 1789\u20132016 (collection 1614804) and examining the original image of the license may reveal his father's name and mother's maiden name.",
+          "fallback_for": null,
+          "status": "planned"
+        },
+        {
+          "id": "pli_006",
+          "sequence": 6,
+          "record_type": "immigration",
+          "jurisdiction": "Ohio, United States",
+          "date_range": "1840-1870",
+          "repository": "FamilySearch",
+          "rationale": "The surname Ferber is Germanic, and Cincinnati had one of the largest German immigrant populations in the United States in the mid-19th century. If William's father (or grandfather) immigrated from a German-speaking region, Ohio naturalization records (collection 1987615) or federal passenger arrival records on FamilySearch may name family members or state the origin locality. This could both identify the father and open research into German records if needed.",
+          "fallback_for": null,
+          "status": "planned"
+        },
+        {
+          "id": "pli_007",
+          "sequence": 7,
+          "record_type": "other",
+          "jurisdiction": "Cincinnati, Hamilton County, Ohio",
+          "date_range": "1860-1880",
+          "repository": "other",
+          "rationale": "FAN cluster: Cincinnati city directories (1819\u20131941, available via Fold3 and the Public Library of Cincinnati's digital collection) list heads of household by name and occupation. Searching for Ferber entries in the 1865\u20131880 directories would identify which Ferber households existed in Cincinnati before and after William's 1869 birth, helping to distinguish his family from unrelated Ferbers and potentially naming his father.",
+          "fallback_for": null,
+          "status": "planned"
+        }
+      ]
+    }
+  ],
+  "log": [
+    {
+      "id": "log_001",
+      "plan_item_id": "pli_001",
+      "performed": "2026-07-07T07:52:20.765Z",
+      "tool": "record_read",
+      "query": {
+        "recordId": "ark:/61903/1:1:F66M-8JZ",
+        "collection": "Ohio, County Death Records, 1840-2001",
+        "subject": "Wm. Ferber",
+        "purpose": "Examine death certificate for parental names"
+      },
+      "outcome": "positive",
+      "results_examined": 1,
+      "external_site": null,
+      "results_ref": null,
+      "results_available": 1,
+      "notes": "Death certificate for Wm. Ferber, died 11 Mar 1903, Cincinnati, Hamilton, Ohio. CRITICAL FINDING: record lists father as Gerhard Ferber (ark:/61903/1:1:F66M-8J8) and mother as Eva Ferber (ark:/61903/1:1:F66M-8JD). No maiden name for mother. Birth indexed as 1870 (vs. Dec 1869 per 1900 census \u2014 minor indexing discrepancy). Passing to record-extraction for full assertion write."
+    },
+    {
+      "id": "log_002",
+      "plan_item_id": "pli_002",
+      "performed": "2026-07-07T08:03:35.588Z",
+      "tool": "record_search",
+      "query": {
+        "surname": "Ferber",
+        "givenName": "Gerhard",
+        "residenceYearFrom": 1870,
+        "residenceYearTo": 1870,
+        "residencePlace": "Ohio",
+        "recordType": "census"
+      },
+      "outcome": "partial",
+      "results_examined": 15,
+      "external_site": null,
+      "results_ref": "results/log_002.json",
+      "results_available": 15,
+      "notes": "Collection mismatch: top 3 results are city/business directory entries (collection 3754697) for Gerhard Ferber in Cincinnati 1870 \u2014 confirms presence but not census records. Remaining 12 results are 1870 Federal Census entries for Faber/Fieber/Ferbert variants in Putnam and Montgomery counties, not Hamilton County. No 1870 Federal Census record for Gerhard Ferber in Hamilton County found. Will retry with collectionId=1438024 to target 1870 census specifically."
+    },
+    {
+      "id": "log_003",
+      "plan_item_id": "pli_002",
+      "performed": "2026-07-07T08:04:02.250Z",
+      "tool": "record_search",
+      "query": {
+        "surname": "Ferber",
+        "givenName": "Gerhard",
+        "residenceYearFrom": 1870,
+        "residenceYearTo": 1870,
+        "residencePlace": "Ohio",
+        "collectionId": "1438024"
+      },
+      "outcome": "negative",
+      "results_examined": 4,
+      "external_site": null,
+      "results_ref": "results/log_003.json",
+      "results_available": 4,
+      "notes": "Scoped retry with collectionId=1438024 (1870 Federal Census). Only 4 results returned, all for \"Faber\" variants in Putnam, Montgomery, Carroll, and Shelby counties \u2014 none in Hamilton County (Cincinnati). No index entry for Gerhard Ferber in the 1870 census. Will try surname-only search in Hamilton County to locate the household regardless of given name transcription."
+    },
+    {
+      "id": "log_004",
+      "plan_item_id": "pli_002",
+      "performed": "2026-07-07T08:05:17.977Z",
+      "tool": "record_search",
+      "query": {
+        "surname": "Ferber",
+        "residenceYearFrom": 1870,
+        "residenceYearTo": 1870,
+        "residencePlace": "Hamilton, Ohio",
+        "collectionId": "1438024"
+      },
+      "outcome": "partial",
+      "results_examined": 20,
+      "external_site": null,
+      "results_ref": "results/log_004.json",
+      "results_available": 86,
+      "notes": "Place disambiguation error: \"Hamilton, Ohio\" resolved to Hamilton City, Butler County \u2014 not Hamilton County (Cincinnati). All 20 examined results are from Hamilton, Butler County. Retrying with \"Cincinnati\" as residence place to target Hamilton County."
+    },
+    {
+      "id": "log_005",
+      "plan_item_id": "pli_002",
+      "performed": "2026-07-07T08:06:31.273Z",
+      "tool": "record_search",
+      "query": {
+        "surname": "Ferber",
+        "residenceYearFrom": 1870,
+        "residenceYearTo": 1870,
+        "residencePlace": "Cincinnati, Ohio",
+        "collectionId": "1438024"
+      },
+      "outcome": "positive",
+      "results_examined": 20,
+      "external_site": null,
+      "results_ref": "results/log_005.json",
+      "results_available": 69,
+      "notes": "Strong match: Household of Gerhardt Faerber (I10, born ~1822 Prussia) + Eva Faerber (I11, born ~1832 Bavaria) at Cincinnati, Hamilton, Ohio. Household also contains William Faerber (I2, born 1870 Ohio) plus older children Gustave (~1857), Jacob (~1860), Charles (~1865), Margarette (~1867). Primary person ARK: ark:/61903/1:1:M62Z-87S; household record ARK: ark:/61903/1:2:MHXJ-Y4S. Will proceed to record_read for full extraction."
+    }
+  ],
+  "sources": [
+    {
+      "id": "src_001",
+      "gedcomx_source_description_id": "S3",
+      "citation": "\"Ohio, County Death Records, 1840-2001,\" FamilySearch (https://www.familysearch.org/ark:/61903/1:1:F66M-8JZ : accessed 7 Jul 2026), entry for Wm. Ferber, died 11 Mar 1903; Gerhard Ferber recorded as father, Eva Ferber as mother.",
+      "citation_detail": {
+        "who": "Wm. Ferber (deceased); Gerhard Ferber (father); Eva Ferber (mother)",
+        "what": "Hamilton County, Ohio death certificate, image on FamilySearch",
+        "when_created": "11 Mar 1903",
+        "when_accessed": "2026-07-07",
+        "where": "FamilySearch (https://www.familysearch.org)",
+        "where_within": "ark:/61903/1:1:F66M-8JZ; image ark:/61903/3:1:S3HT-66TS-SCS"
+      },
+      "source_classification": "derivative",
+      "repository": "FamilySearch",
+      "access_date": "2026-07-07",
+      "url": "https://www.familysearch.org/ark:/61903/1:1:F66M-8JZ",
+      "log_entry_id": "log_001"
+    }
+  ],
+  "assertions": [
+    {
+      "id": "a_001",
+      "source_id": "src_001",
+      "record_id": "https://www.familysearch.org/ark:/61903/1:1:F66M-8JZ",
+      "record_persona_id": null,
+      "record_role": "deceased",
+      "fact_type": "name",
+      "value": "Wm. Ferber",
+      "structured_value": {
+        "given": "Wm.",
+        "surname": "Ferber"
+      },
+      "information_quality": "indeterminate",
+      "informant": "unknown personal informant (likely spouse or close family member)",
+      "informant_proximity": "witness",
+      "evidence_type": "direct",
+      "log_entry_id": "log_001",
+      "extracted_for_question_ids": []
+    },
+    {
+      "id": "a_002",
+      "source_id": "src_001",
+      "record_id": "https://www.familysearch.org/ark:/61903/1:1:F66M-8JZ",
+      "record_persona_id": null,
+      "record_role": "deceased",
+      "fact_type": "death",
+      "value": "11 Mar 1903, Cincinnati, Hamilton, Ohio",
+      "date": "1903-03-11",
+      "date_certainty": "exact",
+      "place": "Cincinnati, Hamilton, Ohio",
+      "standard_place": "Cincinnati, Hamilton, Ohio, United States",
+      "information_quality": "primary",
+      "informant": "attending physician (unnamed)",
+      "informant_proximity": "official_duty",
+      "evidence_type": "direct",
+      "log_entry_id": "log_001",
+      "extracted_for_question_ids": []
+    },
+    {
+      "id": "a_003",
+      "source_id": "src_001",
+      "record_id": "https://www.familysearch.org/ark:/61903/1:1:F66M-8JZ",
+      "record_persona_id": null,
+      "record_role": "deceased",
+      "fact_type": "birth",
+      "value": "1870 (year only, per death certificate)",
+      "structured_value": {
+        "year": "1870"
+      },
+      "date": "1870",
+      "date_certainty": "approximate",
+      "information_quality": "indeterminate",
+      "informant": "unknown personal informant (unnamed; likely spouse or family member)",
+      "informant_proximity": "family_not_present",
+      "evidence_type": "direct",
+      "informant_bias_notes": "Death certificate states birth year 1870; the 1900 federal census (S2) records birth month December 1869. Minor discrepancy likely reflects imprecise informant recall. Informant not named on this record; classification cannot be elevated beyond indeterminate without confirming who completed the death certificate.",
+      "log_entry_id": "log_001",
+      "extracted_for_question_ids": []
+    },
+    {
+      "id": "a_004",
+      "source_id": "src_001",
+      "record_id": "https://www.familysearch.org/ark:/61903/1:1:F66M-8JZ",
+      "record_persona_id": null,
+      "record_role": "deceased",
+      "fact_type": "birth",
+      "value": "Cinti., Ham., O. [Cincinnati, Hamilton County, Ohio]",
+      "place": "Cincinnati, Hamilton, Ohio",
+      "standard_place": "Cincinnati, Hamilton, Ohio, United States",
+      "information_quality": "indeterminate",
+      "informant": "unknown personal informant (unnamed; likely spouse or family member)",
+      "informant_proximity": "family_not_present",
+      "evidence_type": "direct",
+      "log_entry_id": "log_001",
+      "extracted_for_question_ids": [],
+      "informant_bias_notes": "Informant not named on this record. Birthplace of deceased is a fact the personal informant would not have witnessed; however, since the informant cannot be identified, classification remains indeterminate rather than secondary."
+    },
+    {
+      "id": "a_005",
+      "source_id": "src_001",
+      "record_id": "https://www.familysearch.org/ark:/61903/1:1:F66M-8JZ",
+      "record_persona_id": null,
+      "record_role": "deceased",
+      "fact_type": "marital_status",
+      "value": "Married",
+      "information_quality": "indeterminate",
+      "informant": "unknown personal informant (unnamed; likely spouse or family member)",
+      "informant_proximity": "witness",
+      "evidence_type": "direct",
+      "log_entry_id": "log_001",
+      "extracted_for_question_ids": [],
+      "informant_bias_notes": "Marital status reported on the death certificate by an unnamed personal informant. Any family member present would have first-hand knowledge of this fact, but without confirming the informant's identity the classification cannot be elevated to primary."
+    },
+    {
+      "id": "a_006",
+      "source_id": "src_001",
+      "record_id": "https://www.familysearch.org/ark:/61903/1:1:F66M-8JZ",
+      "record_persona_id": null,
+      "record_role": "father_of_deceased",
+      "fact_type": "name",
+      "value": "Gerhard Ferber",
+      "structured_value": {
+        "given": "Gerhard",
+        "surname": "Ferber"
+      },
+      "information_quality": "indeterminate",
+      "informant": "unknown personal informant (likely spouse or close family member of deceased)",
+      "informant_proximity": "family_not_present",
+      "evidence_type": "direct",
+      "informant_bias_notes": "Per GPS guidance, parents' names on a death certificate are reported by an unnamed personal informant (no informant named in index). Informant is unknown; cannot confirm they had first-hand knowledge of parentage, so classification is indeterminate. As to evidence type: the record explicitly names 'Gerhard Ferber' in the father role for Wm. Ferber \u2014 this directly answers q_001 without inference. Evidence independence note: this assertion and a_007 share the same unnamed informant and therefore constitute one evidence unit for corroboration purposes.",
+      "log_entry_id": "log_001",
+      "extracted_for_question_ids": [
+        "q_001"
+      ]
+    },
+    {
+      "id": "a_007",
+      "source_id": "src_001",
+      "record_id": "https://www.familysearch.org/ark:/61903/1:1:F66M-8JZ",
+      "record_persona_id": null,
+      "record_role": "mother_of_deceased",
+      "fact_type": "name",
+      "value": "Eva Ferber",
+      "structured_value": {
+        "given": "Eva",
+        "surname": "Ferber"
+      },
+      "information_quality": "indeterminate",
+      "informant": "unknown personal informant (likely spouse or close family member of deceased)",
+      "informant_proximity": "family_not_present",
+      "evidence_type": "direct",
+      "informant_bias_notes": "Per GPS guidance, parents' names on a death certificate are reported by an unnamed personal informant (no informant named in index). Informant is unknown; cannot confirm they had first-hand knowledge of parentage, so classification is indeterminate. Mother's surname 'Ferber' is likely her married name as entered by the record-taker; maiden name is not recorded and remains unknown. Evidence independence note: this assertion and a_006 share the same unnamed informant and therefore constitute one evidence unit for corroboration purposes.",
+      "log_entry_id": "log_001",
+      "extracted_for_question_ids": [
+        "q_001"
+      ]
+    }
+  ],
+  "person_evidence": [
+    {
+      "id": "pe_001",
+      "assertion_id": "a_001",
+      "person_id": "I2",
+      "confidence": "confident",
+      "rationale": "The death certificate names 'Wm. Ferber' as the deceased, died 11 Mar 1903 in Cincinnati, Hamilton, Ohio. 'Wm.' is a standard abbreviation for William. I2 (William Hubert Ferber) has the same death date and place in the tree. The match on death date, place, and name abbreviation is conclusive \u2014 no other William Ferber would share this exact death record.",
+      "match_score": null,
+      "created": "2026-07-07"
+    },
+    {
+      "id": "pe_002",
+      "assertion_id": "a_002",
+      "person_id": "I2",
+      "confidence": "confident",
+      "rationale": "Death date and place (11 Mar 1903, Cincinnati, Hamilton, Ohio) match exactly the facts already established for I2 in the tree. The attending physician's testimony is the highest-quality evidence for this event. No conflict.",
+      "match_score": null,
+      "created": "2026-07-07"
+    },
+    {
+      "id": "pe_003",
+      "assertion_id": "a_003",
+      "person_id": "I2",
+      "confidence": "confident",
+      "rationale": "Birth year stated as '1870' on the death certificate. I2's birth is recorded as December 1869 in tree \u2014 a minor discrepancy (one month) well within the range of informant memory error on a 1903 certificate. Consistent enough to confirm identity.",
+      "match_score": null,
+      "created": "2026-07-07"
+    },
+    {
+      "id": "pe_004",
+      "assertion_id": "a_004",
+      "person_id": "I2",
+      "confidence": "confident",
+      "rationale": "Birth place stated as Cincinnati, Hamilton, Ohio. I2's birth place is listed as Ohio in the tree (from 1900 census). The more specific Cincinnati location is consistent and provides additional detail for I2.",
+      "match_score": null,
+      "created": "2026-07-07"
+    },
+    {
+      "id": "pe_005",
+      "assertion_id": "a_005",
+      "person_id": "I2",
+      "confidence": "confident",
+      "rationale": "Marital status 'Married' is consistent with I2's known marriage to Emma Becker (married 10 Sep 1890). No conflict.",
+      "match_score": null,
+      "created": "2026-07-07"
+    },
+    {
+      "id": "pe_006",
+      "assertion_id": "a_006",
+      "person_id": "I10",
+      "confidence": "probable",
+      "rationale": "I10 (Gerhard Ferber) is a new stub person created from this death certificate. The certificate records 'Gerhard Ferber' in the father role for Wm. Ferber (I2). This is the sole source establishing Gerhard's identity at this stage; confidence capped at probable pending corroboration from census or birth records.",
+      "match_score": null,
+      "created": "2026-07-07"
+    },
+    {
+      "id": "pe_007",
+      "assertion_id": "a_006",
+      "person_id": "I2",
+      "confidence": "probable",
+      "rationale": "The father-of-deceased assertion (naming Gerhard Ferber as father) also establishes William Hubert Ferber's (I2) paternal parentage. Confidence is probable rather than confident because the assertion carries indeterminate information quality (unnamed informant on a derivative death certificate) and this is the sole source for this parentage claim so far.",
+      "match_score": null,
+      "created": "2026-07-07"
+    },
+    {
+      "id": "pe_008",
+      "assertion_id": "a_007",
+      "person_id": "I11",
+      "confidence": "probable",
+      "rationale": "I11 (Eva Ferber) is a new stub person created from this death certificate. The certificate records 'Eva Ferber' in the mother role for Wm. Ferber (I2). 'Ferber' is likely the married name as entered by the record-taker; maiden name unknown. This is the sole source establishing Eva's identity at this stage; confidence capped at probable pending corroboration.",
+      "match_score": null,
+      "created": "2026-07-07"
+    },
+    {
+      "id": "pe_009",
+      "assertion_id": "a_007",
+      "person_id": "I2",
+      "confidence": "probable",
+      "rationale": "The mother-of-deceased assertion (naming Eva Ferber as mother) also establishes William Hubert Ferber's (I2) maternal parentage. Confidence is probable because the assertion carries indeterminate information quality (unnamed informant on a derivative death certificate) and this is the sole source for this parentage claim so far.",
+      "match_score": null,
+      "created": "2026-07-07"
+    }
+  ],
+  "conflicts": [],
+  "hypotheses": [],
+  "timelines": [],
+  "proof_summaries": [],
+  "evaluations": []
+}

--- a/eval/runlogs/e2e/ferber-grandparents/run-2026-07-07_08-10-37.final-tree.gedcomx.json
+++ b/eval/runlogs/e2e/ferber-grandparents/run-2026-07-07_08-10-37.final-tree.gedcomx.json
@@ -1,0 +1,577 @@
+{
+  "persons": [
+    {
+      "id": "I1",
+      "gender": "Male",
+      "names": [
+        {
+          "id": "N1",
+          "given": "Charles Hubert",
+          "surname": "Ferber",
+          "preferred": true
+        }
+      ],
+      "facts": [
+        {
+          "id": "F1",
+          "type": "Birth",
+          "date": "22 June 1891",
+          "standard_date": "22 Jun 1891",
+          "place": "Cincinnati, Hamilton, Ohio, United States",
+          "standard_place": "Cincinnati, Hamilton, Ohio, United States",
+          "sources": [
+            {
+              "ref": "S1",
+              "quality": 1
+            }
+          ]
+        },
+        {
+          "id": "F2",
+          "type": "Death",
+          "date": "12 December 1967",
+          "standard_date": "12 Dec 1967",
+          "place": "Fort Lauderdale, Broward, Florida, United States",
+          "standard_place": "Fort Lauderdale, Broward, Florida, United States",
+          "sources": [
+            {
+              "ref": "S1",
+              "quality": 1
+            },
+            {
+              "ref": "S4",
+              "quality": 2
+            }
+          ]
+        },
+        {
+          "id": "F3",
+          "type": "Residence",
+          "date": "1900",
+          "standard_date": "1900",
+          "place": "Cincinnati, Hamilton, Ohio, United States",
+          "standard_place": "Cincinnati, Hamilton, Ohio, United States",
+          "sources": [
+            {
+              "ref": "S1",
+              "quality": 1
+            },
+            {
+              "ref": "S2",
+              "quality": 2
+            }
+          ]
+        },
+        {
+          "id": "F4",
+          "type": "Residence",
+          "date": "1910",
+          "standard_date": "1910",
+          "place": "Cincinnati Ward 21, Hamilton, Ohio, United States",
+          "standard_place": "Cincinnati, Hamilton, Ohio, United States",
+          "sources": [
+            {
+              "ref": "S1",
+              "quality": 1
+            }
+          ]
+        },
+        {
+          "id": "F5",
+          "type": "Military Draft Registration",
+          "date": "1917-1918",
+          "standard_date": "Bet 1917 and 1918",
+          "place": "Cincinnati, Hamilton, Ohio, United States",
+          "standard_place": "Cincinnati, Hamilton, Ohio, United States",
+          "sources": [
+            {
+              "ref": "S1",
+              "quality": 1
+            }
+          ]
+        },
+        {
+          "id": "F6",
+          "type": "Residence",
+          "date": "1920",
+          "standard_date": "1920",
+          "place": "Cincinnati, Hamilton, Ohio, United States",
+          "standard_place": "Cincinnati, Hamilton, Ohio, United States",
+          "sources": [
+            {
+              "ref": "S1",
+              "quality": 1
+            }
+          ]
+        },
+        {
+          "id": "F7",
+          "type": "Residence",
+          "date": "1930",
+          "standard_date": "1930",
+          "place": "Cincinnati, Hamilton, Ohio, United States",
+          "standard_place": "Cincinnati, Hamilton, Ohio, United States",
+          "sources": [
+            {
+              "ref": "S1",
+              "quality": 1
+            }
+          ]
+        },
+        {
+          "id": "F8",
+          "type": "Residence",
+          "date": "1935",
+          "standard_date": "1935",
+          "place": "Cincinnati, Hamilton, Ohio, United States",
+          "standard_place": "Cincinnati, Hamilton, Ohio, United States",
+          "sources": [
+            {
+              "ref": "S1",
+              "quality": 1
+            }
+          ]
+        },
+        {
+          "id": "F9",
+          "type": "Residence",
+          "date": "1940",
+          "standard_date": "1940",
+          "place": "Columbia Township, Hamilton, Ohio, United States",
+          "standard_place": "Columbia Township, Hamilton, Ohio, United States",
+          "sources": [
+            {
+              "ref": "S1",
+              "quality": 1
+            }
+          ]
+        },
+        {
+          "id": "F10",
+          "type": "Military Draft Registration",
+          "date": "1942",
+          "standard_date": "1942",
+          "place": "Ohio, United States",
+          "standard_place": "Ohio, United States",
+          "sources": [
+            {
+              "ref": "S1",
+              "quality": 1
+            }
+          ]
+        },
+        {
+          "id": "F11",
+          "type": "Residence",
+          "date": "10 April 1950",
+          "standard_date": "10 Apr 1950",
+          "place": "Mariemont, Hamilton, Ohio, United States",
+          "standard_place": "Mariemont, Hamilton, Ohio, United States",
+          "sources": [
+            {
+              "ref": "S1",
+              "quality": 1
+            }
+          ]
+        },
+        {
+          "id": "F12",
+          "type": "Burial",
+          "place": "Spring Grove Cemetery, Cincinnati, Hamilton, Ohio, United States",
+          "standard_place": "Spring Grove Cemetery, Cincinnati, Hamilton, Ohio, United States",
+          "sources": [
+            {
+              "ref": "S1",
+              "quality": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "I2",
+      "gender": "Male",
+      "names": [
+        {
+          "id": "N2",
+          "given": "William Hubert",
+          "surname": "Ferber",
+          "preferred": true
+        }
+      ],
+      "facts": [
+        {
+          "id": "F13",
+          "type": "Birth",
+          "date": "December 1869",
+          "standard_date": "Dec 1869",
+          "place": "Ohio, United States",
+          "standard_place": "Ohio, United States",
+          "sources": [
+            {
+              "ref": "S1",
+              "quality": 1
+            },
+            {
+              "ref": "S2",
+              "quality": 2
+            }
+          ]
+        },
+        {
+          "id": "F14",
+          "type": "Residence",
+          "date": "1870",
+          "standard_date": "1870",
+          "place": "Cincinnati, Hamilton, Ohio, United States",
+          "standard_place": "Cincinnati, Hamilton, Ohio, United States",
+          "sources": [
+            {
+              "ref": "S1",
+              "quality": 1
+            }
+          ]
+        },
+        {
+          "id": "F15",
+          "type": "Residence",
+          "date": "1900",
+          "standard_date": "1900",
+          "place": "Cincinnati, Hamilton, Ohio, United States",
+          "standard_place": "Cincinnati, Hamilton, Ohio, United States",
+          "sources": [
+            {
+              "ref": "S1",
+              "quality": 1
+            },
+            {
+              "ref": "S2",
+              "quality": 2
+            }
+          ]
+        },
+        {
+          "id": "F16",
+          "type": "Death",
+          "date": "11 March 1903",
+          "standard_date": "11 Mar 1903",
+          "place": "Cincinnati, Hamilton, Ohio, United States",
+          "standard_place": "Cincinnati, Hamilton, Ohio, United States",
+          "sources": [
+            {
+              "ref": "S1",
+              "quality": 1
+            },
+            {
+              "ref": "S3",
+              "quality": 2
+            }
+          ]
+        },
+        {
+          "id": "F17",
+          "type": "Burial",
+          "place": "Cincinnati, Hamilton, Ohio, United States",
+          "standard_place": "Cincinnati, Hamilton, Ohio, United States",
+          "sources": [
+            {
+              "ref": "S1",
+              "quality": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "I3",
+      "gender": "Female",
+      "names": [
+        {
+          "id": "N3",
+          "given": "Emma",
+          "surname": "Becker",
+          "preferred": true
+        }
+      ],
+      "facts": [
+        {
+          "id": "F18",
+          "type": "Birth",
+          "date": "25 March 1870",
+          "standard_date": "25 Mar 1870",
+          "place": "Cincinnati, Hamilton, Ohio, United States",
+          "standard_place": "Cincinnati, Hamilton, Ohio, United States",
+          "sources": [
+            {
+              "ref": "S1",
+              "quality": 1
+            }
+          ]
+        },
+        {
+          "id": "F19",
+          "type": "Residence",
+          "date": "1900",
+          "standard_date": "1900",
+          "place": "Cincinnati, Hamilton, Ohio, United States",
+          "standard_place": "Cincinnati, Hamilton, Ohio, United States",
+          "sources": [
+            {
+              "ref": "S1",
+              "quality": 1
+            },
+            {
+              "ref": "S2",
+              "quality": 2
+            }
+          ]
+        },
+        {
+          "id": "F20",
+          "type": "Death",
+          "date": "7 December 1948",
+          "standard_date": "7 Dec 1948",
+          "place": "Dayton, Campbell, Kentucky, United States",
+          "standard_place": "Dayton, Campbell, Kentucky, United States",
+          "sources": [
+            {
+              "ref": "S1",
+              "quality": 1
+            }
+          ]
+        },
+        {
+          "id": "F21",
+          "type": "Burial",
+          "date": "10 December 1948",
+          "standard_date": "10 Dec 1948",
+          "place": "Spring Grove Cemetery, Cincinnati, Hamilton, Ohio, United States",
+          "standard_place": "Spring Grove Cemetery, Cincinnati, Hamilton, Ohio, United States",
+          "sources": [
+            {
+              "ref": "S1",
+              "quality": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "I8",
+      "gender": "Female",
+      "names": [
+        {
+          "id": "N8",
+          "given": "Lydian Inez",
+          "surname": "Hall",
+          "preferred": true
+        }
+      ],
+      "facts": [
+        {
+          "id": "F32",
+          "type": "Birth",
+          "date": "1893",
+          "standard_date": "1893",
+          "sources": [
+            {
+              "ref": "S1",
+              "quality": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "I9",
+      "gender": "Female",
+      "names": [
+        {
+          "id": "N9",
+          "given": "Harriet Helen",
+          "surname": "Bailey",
+          "preferred": true
+        }
+      ],
+      "facts": [
+        {
+          "id": "F33",
+          "type": "Birth",
+          "date": "20 May 1903",
+          "standard_date": "20 May 1903",
+          "place": "Oakley, Cincinnati, Hamilton, Ohio, United States",
+          "standard_place": "Oakley, Cincinnati, Hamilton, Ohio, United States",
+          "sources": [
+            {
+              "ref": "S1",
+              "quality": 1
+            }
+          ]
+        },
+        {
+          "id": "F34",
+          "type": "Death",
+          "date": "7 March 1999",
+          "standard_date": "7 Mar 1999",
+          "place": "Fort Lauderdale, Broward, Florida, United States",
+          "standard_place": "Fort Lauderdale, Broward, Florida, United States",
+          "sources": [
+            {
+              "ref": "S1",
+              "quality": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "gender": "Male",
+      "names": [
+        {
+          "given": "Gerhard",
+          "surname": "Ferber",
+          "preferred": true,
+          "type": "BirthName",
+          "id": "N10"
+        }
+      ],
+      "id": "I10"
+    },
+    {
+      "gender": "Female",
+      "names": [
+        {
+          "given": "Eva",
+          "surname": "Ferber",
+          "preferred": true,
+          "type": "BirthName",
+          "id": "N11"
+        }
+      ],
+      "id": "I11"
+    }
+  ],
+  "relationships": [
+    {
+      "id": "R1",
+      "type": "ParentChild",
+      "parent": "I2",
+      "child": "I1"
+    },
+    {
+      "id": "R2",
+      "type": "ParentChild",
+      "parent": "I3",
+      "child": "I1"
+    },
+    {
+      "id": "R3",
+      "type": "Couple",
+      "person1": "I2",
+      "person2": "I3",
+      "facts": [
+        {
+          "id": "F35",
+          "type": "Marriage",
+          "date": "10 September 1890",
+          "standard_date": "10 Sep 1890",
+          "place": "Hamilton, Ohio, United States",
+          "standard_place": "Hamilton, Ohio, United States",
+          "sources": [
+            {
+              "ref": "S1",
+              "quality": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "R10",
+      "type": "Couple",
+      "person1": "I1",
+      "person2": "I8",
+      "facts": [
+        {
+          "id": "F37",
+          "type": "Marriage",
+          "date": "1 February 1918",
+          "standard_date": "1 Feb 1918",
+          "place": "Chicago, Cook, Illinois, United States",
+          "standard_place": "Chicago, Cook, Illinois, United States",
+          "sources": [
+            {
+              "ref": "S1",
+              "quality": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "R11",
+      "type": "Couple",
+      "person1": "I1",
+      "person2": "I9",
+      "facts": [
+        {
+          "id": "F38",
+          "type": "Marriage",
+          "date": "21 April 1934",
+          "standard_date": "21 Apr 1934",
+          "place": "Williamstown, Grant, Kentucky, United States",
+          "standard_place": "Williamstown, Grant, Kentucky, United States",
+          "sources": [
+            {
+              "ref": "S1",
+              "quality": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "Couple",
+      "person1": "I10",
+      "person2": "I11",
+      "id": "R12"
+    },
+    {
+      "type": "ParentChild",
+      "parent": "I10",
+      "child": "I2",
+      "id": "R13"
+    },
+    {
+      "type": "ParentChild",
+      "parent": "I11",
+      "child": "I2",
+      "id": "R14"
+    }
+  ],
+  "sources": [
+    {
+      "id": "S1",
+      "title": "FamilySearch Family Tree",
+      "author": "FamilySearch contributors"
+    },
+    {
+      "id": "S2",
+      "title": "United States, Census, 1900",
+      "citation": "\"United States, Census, 1900\", FamilySearch (https://www.familysearch.org/ark:/61903/1:1:MM88-DGG), Entry for William Ferber and Emma Ferber, 1900.",
+      "url": "https://www.familysearch.org/ark:/61903/1:1:MM88-DGG"
+    },
+    {
+      "id": "S3",
+      "title": "Ohio, County Death Records, 1840-2001",
+      "citation": "\"Ohio, County Death Records, 1840-2001\", FamilySearch (https://www.familysearch.org/ark:/61903/1:1:F66M-8JZ), Entry for Wm. Ferber, 11 Mar 1903.",
+      "url": "https://www.familysearch.org/ark:/61903/1:1:F66M-8JZ"
+    },
+    {
+      "id": "S4",
+      "title": "Obituary of Charles Ferber",
+      "author": "Fort Lauderdale News",
+      "citation": "Fort Lauderdale News, Fort Lauderdale, FL, 13 Dec 1967 (client-provided clipping)"
+    }
+  ]
+}

--- a/eval/runlogs/e2e/ferber-grandparents/run-2026-07-07_08-10-37.json
+++ b/eval/runlogs/e2e/ferber-grandparents/run-2026-07-07_08-10-37.json
@@ -1,0 +1,2788 @@
+{
+  "test_id": "ferber-grandparents",
+  "captured_at": "2026-07-07_08-10-37",
+  "verdict": "partial",
+  "stop_reason": "error",
+  "judge_output": {
+    "per_finding": [
+      {
+        "finding_id": "f1",
+        "matched": "true",
+        "agent_evidence": "Person I10 (Gerhard Ferber) and I11 (Eva Ferber) are defined in the tree. Relationships R13 and R14 establish I10 and I11 as parents of I2 (William Hubert Ferber). I2 is established as parent of I1 (Charles Hubert Ferber) via R1. This chain correctly establishes Gerhard as paternal grandfather. The tree does not include detailed birth/death facts for Gerhard (no birth date ~1820, no death 31 May 1917, no naturalization 1853), but the relationship structure is semantically correct.",
+        "notes": "The core relationship is present and correct. Detailed biographical facts about Gerhard are missing from the tree, but the relationship claim that he is the paternal grandfather is established."
+      },
+      {
+        "finding_id": "f2",
+        "matched": "partial",
+        "agent_evidence": "Person I11 (Eva Ferber) exists in the tree. Relationship R12 establishes I10 and I11 as a couple, and R14 establishes I11 as parent of I2 (William Hubert Ferber). This makes Eva the paternal grandmother of I1. However, the tree provides no facts for Eva\u2014no birth year (~1834), no birthplace (Bavaria), no death date (1 January 1872). The surname 'Engermann' is also missing; the tree only shows 'Ferber'.",
+        "notes": "The relationship structure correctly identifies Eva as paternal grandmother, but critical identifying details (Engermann maiden name, birth/death dates and places) are absent from the tree. This is a partial match on the relationship but incomplete on person identification."
+      },
+      {
+        "finding_id": "f3",
+        "matched": "false",
+        "agent_evidence": "The tree contains no person matching John Becker as maternal grandfather. Emma Becker (I3) is present in the tree as a parent of Charles Hubert Ferber, but her parents are not represented. No relationship establishes John Becker as Emma's father.",
+        "notes": "The agent did not recover the maternal grandfather relationship. Emma Becker is in the tree, but her parentage is not documented."
+      },
+      {
+        "finding_id": "f4",
+        "matched": "false",
+        "agent_evidence": "The tree contains no person matching Mary Kramer or any maternal grandmother. Emma Becker's parents are not documented in the tree.",
+        "notes": "The agent did not recover the maternal grandmother relationship. Emma Becker is in the tree, but her parentage and her mother are not documented."
+      },
+      {
+        "finding_id": "f5",
+        "matched": "true",
+        "agent_evidence": "William Hubert Ferber (I2) is shown as the father of Charles Hubert Ferber (I1) via relationship R1. Emma Becker (I3) is shown as the mother of Charles Hubert Ferber (I1) via relationship R2. William's birth date of December 1869 and death date of 11 March 1903 in Cincinnati are documented in facts F13 and F16 respectively.",
+        "notes": "This expected finding (if it exists in the set, though not listed above) regarding Charles's parents is fully recovered with proper sourcing to the tree."
+      },
+      {
+        "finding_id": "f6",
+        "matched": "true",
+        "agent_evidence": "Emma Becker (I3) is shown as the mother of Charles Hubert Ferber (I1) via relationship R2. Her birth date (25 March 1870) and death date (7 December 1948) are documented in facts F18 and F20 respectively.",
+        "notes": "Emma Becker's presence and key biographical facts are recovered in the tree."
+      }
+    ],
+    "recall_required": 0.5,
+    "recall_total": 0.5,
+    "verdict": "partial",
+    "rationale": "The agent recovered the paternal grandfather relationship (f1, true) and partially recovered the paternal grandmother relationship (f2, partial\u2014the relationship is correct but identifying details like maiden name and vital dates are missing). However, the agent completely failed to recover the maternal grandparents (f3 and f4, both false)\u2014Emma Becker's parents are not documented in the tree at all. Of the 4 required findings, 1 is fully matched and 1 is partial, yielding a recall_required score of 0.5 (50%). This does not meet the threshold for a 'pass' verdict (which requires all required findings to be 'true'), resulting in a 'partial' verdict.",
+    "proof_quality": {
+      "score": null,
+      "exhaustiveness": "na",
+      "conflicts_addressed": "na",
+      "corroboration": "na",
+      "tier_appropriate": "na",
+      "rationale": "No proof summary exists in the agent's research.json output (the proof_summaries array is empty). Therefore, proof quality cannot be graded. All proof-quality dimensions are marked 'na' and score is null."
+    }
+  },
+  "usage": {
+    "duration_ms": 1485088,
+    "duration_api_ms": 1502489,
+    "num_turns": 81,
+    "is_error": true,
+    "stop_reason": "stop_sequence",
+    "total_cost_usd": 3.5218835,
+    "usage": {
+      "input_tokens": 100,
+      "cache_creation_input_tokens": 222560,
+      "cache_read_input_tokens": 4801774,
+      "output_tokens": 69862,
+      "server_tool_use": {
+        "web_search_requests": 0,
+        "web_fetch_requests": 0
+      },
+      "service_tier": "standard",
+      "cache_creation": {
+        "ephemeral_1h_input_tokens": 222560,
+        "ephemeral_5m_input_tokens": 0
+      },
+      "inference_geo": "",
+      "iterations": [
+        {
+          "input_tokens": 3,
+          "output_tokens": 16040,
+          "cache_read_input_tokens": 85596,
+          "cache_creation_input_tokens": 6517,
+          "cache_creation": {
+            "ephemeral_5m_input_tokens": 0,
+            "ephemeral_1h_input_tokens": 6517
+          },
+          "type": "message"
+        }
+      ],
+      "speed": "standard"
+    },
+    "continue_nudges": 0,
+    "session_id": "fda56b31-2dbb-4137-8429-f73104d08a23",
+    "resumes": 0,
+    "resume_on_stall": true,
+    "timeline": [
+      [
+        7.0,
+        "system:init"
+      ],
+      [
+        7.0,
+        "system:api_retry"
+      ],
+      [
+        7.9,
+        "system:api_retry"
+      ],
+      [
+        9.0,
+        "system:api_retry"
+      ],
+      [
+        11.4,
+        "system:api_retry"
+      ],
+      [
+        16.2,
+        "system:api_retry"
+      ],
+      [
+        25.5,
+        "system:api_retry"
+      ],
+      [
+        43.2,
+        "system:api_retry"
+      ],
+      [
+        76.0,
+        "system:api_retry"
+      ],
+      [
+        119.5,
+        "assistant"
+      ],
+      [
+        119.5,
+        "assistant"
+      ],
+      [
+        119.6,
+        "tool_result"
+      ],
+      [
+        121.9,
+        "assistant"
+      ],
+      [
+        121.9,
+        "assistant"
+      ],
+      [
+        122.1,
+        "tool_result"
+      ],
+      [
+        125.6,
+        "assistant"
+      ],
+      [
+        125.7,
+        "assistant"
+      ],
+      [
+        126.2,
+        "tool_result"
+      ],
+      [
+        126.2,
+        "tool_result"
+      ],
+      [
+        129.1,
+        "assistant"
+      ],
+      [
+        130.4,
+        "assistant"
+      ],
+      [
+        130.8,
+        "tool_result"
+      ],
+      [
+        131.0,
+        "assistant"
+      ],
+      [
+        131.1,
+        "tool_result"
+      ],
+      [
+        143.9,
+        "assistant"
+      ],
+      [
+        144.1,
+        "assistant"
+      ],
+      [
+        144.1,
+        "tool_result"
+      ],
+      [
+        162.5,
+        "assistant"
+      ],
+      [
+        162.5,
+        "assistant"
+      ],
+      [
+        162.6,
+        "tool_result"
+      ],
+      [
+        170.7,
+        "assistant"
+      ],
+      [
+        176.4,
+        "assistant"
+      ],
+      [
+        176.5,
+        "tool_result"
+      ],
+      [
+        181.6,
+        "assistant"
+      ],
+      [
+        184.2,
+        "assistant"
+      ],
+      [
+        184.7,
+        "assistant"
+      ],
+      [
+        184.8,
+        "tool_result"
+      ],
+      [
+        184.8,
+        "tool_result"
+      ],
+      [
+        196.5,
+        "assistant"
+      ],
+      [
+        196.8,
+        "assistant"
+      ],
+      [
+        196.8,
+        "tool_result"
+      ],
+      [
+        200.8,
+        "assistant"
+      ],
+      [
+        201.2,
+        "assistant"
+      ],
+      [
+        201.7,
+        "assistant"
+      ],
+      [
+        205.9,
+        "tool_result"
+      ],
+      [
+        211.3,
+        "tool_result"
+      ],
+      [
+        227.3,
+        "assistant"
+      ],
+      [
+        227.3,
+        "assistant"
+      ],
+      [
+        227.3,
+        "assistant"
+      ],
+      [
+        227.9,
+        "assistant"
+      ],
+      [
+        232.6,
+        "tool_result"
+      ],
+      [
+        245.8,
+        "tool_result"
+      ],
+      [
+        277.0,
+        "assistant"
+      ],
+      [
+        277.1,
+        "assistant"
+      ],
+      [
+        277.6,
+        "tool_result"
+      ],
+      [
+        278.2,
+        "assistant"
+      ],
+      [
+        278.4,
+        "tool_result"
+      ],
+      [
+        314.6,
+        "assistant"
+      ],
+      [
+        316.7,
+        "assistant"
+      ],
+      [
+        340.8,
+        "assistant"
+      ],
+      [
+        340.9,
+        "tool_result"
+      ],
+      [
+        348.3,
+        "assistant"
+      ],
+      [
+        348.5,
+        "assistant"
+      ],
+      [
+        349.1,
+        "assistant"
+      ],
+      [
+        349.2,
+        "tool_result"
+      ],
+      [
+        349.2,
+        "tool_result"
+      ],
+      [
+        354.5,
+        "assistant"
+      ],
+      [
+        355.1,
+        "assistant"
+      ],
+      [
+        355.1,
+        "tool_result"
+      ],
+      [
+        361.2,
+        "assistant"
+      ],
+      [
+        362.1,
+        "assistant"
+      ],
+      [
+        362.2,
+        "assistant"
+      ],
+      [
+        366.3,
+        "tool_result"
+      ],
+      [
+        403.5,
+        "assistant"
+      ],
+      [
+        403.6,
+        "assistant"
+      ],
+      [
+        408.6,
+        "assistant"
+      ],
+      [
+        408.7,
+        "tool_result"
+      ],
+      [
+        412.0,
+        "assistant"
+      ],
+      [
+        413.4,
+        "assistant"
+      ],
+      [
+        413.4,
+        "tool_result"
+      ],
+      [
+        418.8,
+        "assistant"
+      ],
+      [
+        419.5,
+        "assistant"
+      ],
+      [
+        426.8,
+        "assistant"
+      ],
+      [
+        427.5,
+        "tool_result"
+      ],
+      [
+        427.5,
+        "tool_result"
+      ],
+      [
+        609.5,
+        "assistant"
+      ],
+      [
+        609.6,
+        "assistant"
+      ],
+      [
+        609.7,
+        "tool_result"
+      ],
+      [
+        616.6,
+        "assistant"
+      ],
+      [
+        642.9,
+        "assistant"
+      ],
+      [
+        643.0,
+        "tool_result"
+      ],
+      [
+        662.6,
+        "assistant"
+      ],
+      [
+        662.6,
+        "assistant"
+      ],
+      [
+        686.2,
+        "assistant"
+      ],
+      [
+        687.1,
+        "tool_result"
+      ],
+      [
+        700.9,
+        "assistant"
+      ],
+      [
+        700.9,
+        "assistant"
+      ],
+      [
+        702.2,
+        "assistant"
+      ],
+      [
+        702.5,
+        "tool_result"
+      ],
+      [
+        715.8,
+        "assistant"
+      ],
+      [
+        718.4,
+        "assistant"
+      ],
+      [
+        718.7,
+        "assistant"
+      ],
+      [
+        719.2,
+        "tool_result"
+      ],
+      [
+        719.2,
+        "tool_result"
+      ],
+      [
+        783.4,
+        "assistant"
+      ],
+      [
+        783.5,
+        "assistant"
+      ],
+      [
+        783.7,
+        "tool_result"
+      ],
+      [
+        816.3,
+        "assistant"
+      ],
+      [
+        820.8,
+        "assistant"
+      ],
+      [
+        833.8,
+        "assistant"
+      ],
+      [
+        833.9,
+        "tool_result"
+      ],
+      [
+        840.8,
+        "assistant"
+      ],
+      [
+        840.8,
+        "assistant"
+      ],
+      [
+        843.0,
+        "assistant"
+      ],
+      [
+        843.7,
+        "tool_result"
+      ],
+      [
+        843.7,
+        "tool_result"
+      ],
+      [
+        859.6,
+        "assistant"
+      ],
+      [
+        859.6,
+        "assistant"
+      ],
+      [
+        859.7,
+        "tool_result"
+      ],
+      [
+        866.1,
+        "assistant"
+      ],
+      [
+        869.6,
+        "assistant"
+      ],
+      [
+        872.0,
+        "assistant"
+      ],
+      [
+        872.7,
+        "tool_result"
+      ],
+      [
+        877.6,
+        "assistant"
+      ],
+      [
+        878.1,
+        "assistant"
+      ],
+      [
+        879.4,
+        "assistant"
+      ],
+      [
+        879.4,
+        "tool_result"
+      ],
+      [
+        895.3,
+        "assistant"
+      ],
+      [
+        895.5,
+        "assistant"
+      ],
+      [
+        912.5,
+        "assistant"
+      ],
+      [
+        912.6,
+        "tool_result"
+      ],
+      [
+        916.9,
+        "assistant"
+      ],
+      [
+        921.4,
+        "assistant"
+      ],
+      [
+        921.8,
+        "assistant"
+      ],
+      [
+        922.3,
+        "tool_result"
+      ],
+      [
+        922.4,
+        "tool_result"
+      ],
+      [
+        926.8,
+        "assistant"
+      ],
+      [
+        927.5,
+        "assistant"
+      ],
+      [
+        927.5,
+        "tool_result"
+      ],
+      [
+        930.6,
+        "assistant"
+      ],
+      [
+        931.9,
+        "assistant"
+      ],
+      [
+        932.3,
+        "tool_result"
+      ],
+      [
+        932.3,
+        "assistant"
+      ],
+      [
+        932.8,
+        "tool_result"
+      ],
+      [
+        932.9,
+        "assistant"
+      ],
+      [
+        932.9,
+        "tool_result"
+      ],
+      [
+        943.3,
+        "assistant"
+      ],
+      [
+        946.5,
+        "assistant"
+      ],
+      [
+        947.4,
+        "assistant"
+      ],
+      [
+        947.5,
+        "tool_result"
+      ],
+      [
+        947.5,
+        "tool_result"
+      ],
+      [
+        959.3,
+        "assistant"
+      ],
+      [
+        960.1,
+        "assistant"
+      ],
+      [
+        961.7,
+        "assistant"
+      ],
+      [
+        964.7,
+        "tool_result"
+      ],
+      [
+        968.9,
+        "assistant"
+      ],
+      [
+        969.9,
+        "assistant"
+      ],
+      [
+        970.2,
+        "tool_result"
+      ],
+      [
+        970.3,
+        "system:status"
+      ],
+      [
+        1063.5,
+        "system:status"
+      ],
+      [
+        1063.6,
+        "system:compact_boundary"
+      ],
+      [
+        1063.6,
+        "tool_result"
+      ],
+      [
+        1070.8,
+        "assistant"
+      ],
+      [
+        1070.9,
+        "assistant"
+      ],
+      [
+        1070.9,
+        "tool_result"
+      ],
+      [
+        1077.7,
+        "assistant"
+      ],
+      [
+        1083.4,
+        "assistant"
+      ],
+      [
+        1083.5,
+        "tool_result"
+      ],
+      [
+        1086.8,
+        "assistant"
+      ],
+      [
+        1087.3,
+        "assistant"
+      ],
+      [
+        1089.5,
+        "assistant"
+      ],
+      [
+        1090.0,
+        "tool_result"
+      ],
+      [
+        1090.8,
+        "assistant"
+      ],
+      [
+        1092.3,
+        "tool_result"
+      ],
+      [
+        1103.6,
+        "assistant"
+      ],
+      [
+        1104.6,
+        "assistant"
+      ],
+      [
+        1110.1,
+        "assistant"
+      ],
+      [
+        1110.7,
+        "tool_result"
+      ],
+      [
+        1111.6,
+        "assistant"
+      ],
+      [
+        1113.7,
+        "tool_result"
+      ],
+      [
+        1117.6,
+        "assistant"
+      ],
+      [
+        1118.5,
+        "assistant"
+      ],
+      [
+        1119.1,
+        "tool_result"
+      ],
+      [
+        1123.1,
+        "assistant"
+      ],
+      [
+        1123.6,
+        "tool_result"
+      ],
+      [
+        1130.8,
+        "assistant"
+      ],
+      [
+        1130.9,
+        "tool_result"
+      ],
+      [
+        1135.1,
+        "assistant"
+      ],
+      [
+        1135.3,
+        "tool_result"
+      ],
+      [
+        1138.4,
+        "assistant"
+      ],
+      [
+        1138.6,
+        "tool_result"
+      ],
+      [
+        1141.4,
+        "assistant"
+      ],
+      [
+        1142.5,
+        "assistant"
+      ],
+      [
+        1142.9,
+        "tool_result"
+      ],
+      [
+        1150.3,
+        "assistant"
+      ],
+      [
+        1150.3,
+        "assistant"
+      ],
+      [
+        1150.5,
+        "tool_result"
+      ],
+      [
+        1154.6,
+        "assistant"
+      ],
+      [
+        1155.1,
+        "assistant"
+      ],
+      [
+        1155.2,
+        "tool_result"
+      ],
+      [
+        1159.1,
+        "assistant"
+      ],
+      [
+        1159.2,
+        "tool_result"
+      ],
+      [
+        1164.3,
+        "assistant"
+      ],
+      [
+        1166.7,
+        "assistant"
+      ],
+      [
+        1166.7,
+        "tool_result"
+      ],
+      [
+        1180.8,
+        "assistant"
+      ],
+      [
+        1180.8,
+        "assistant"
+      ],
+      [
+        1185.8,
+        "assistant"
+      ],
+      [
+        1186.3,
+        "tool_result"
+      ],
+      [
+        1187.4,
+        "assistant"
+      ],
+      [
+        1191.7,
+        "tool_result"
+      ],
+      [
+        1195.4,
+        "assistant"
+      ],
+      [
+        1195.8,
+        "assistant"
+      ],
+      [
+        1195.9,
+        "tool_result"
+      ],
+      [
+        1198.6,
+        "assistant"
+      ],
+      [
+        1198.7,
+        "tool_result"
+      ],
+      [
+        1202.4,
+        "assistant"
+      ],
+      [
+        1203.3,
+        "assistant"
+      ],
+      [
+        1203.4,
+        "tool_result"
+      ],
+      [
+        1207.1,
+        "assistant"
+      ],
+      [
+        1208.8,
+        "assistant"
+      ],
+      [
+        1208.9,
+        "tool_result"
+      ],
+      [
+        1214.0,
+        "assistant"
+      ],
+      [
+        1214.0,
+        "assistant"
+      ],
+      [
+        1216.4,
+        "assistant"
+      ],
+      [
+        1216.5,
+        "tool_result"
+      ],
+      [
+        1221.6,
+        "assistant"
+      ],
+      [
+        1221.7,
+        "tool_result"
+      ],
+      [
+        1252.6,
+        "assistant"
+      ],
+      [
+        1253.1,
+        "assistant"
+      ],
+      [
+        1259.1,
+        "assistant"
+      ],
+      [
+        1259.3,
+        "tool_result"
+      ],
+      [
+        1259.3,
+        "assistant"
+      ],
+      [
+        1263.0,
+        "tool_result"
+      ],
+      [
+        1451.1,
+        "assistant"
+      ],
+      [
+        1453.3,
+        "assistant"
+      ],
+      [
+        1488.7,
+        "assistant"
+      ],
+      [
+        1489.2,
+        "tool_result"
+      ],
+      [
+        1490.1,
+        "assistant"
+      ],
+      [
+        1490.2,
+        "tool_result"
+      ],
+      [
+        1491.5,
+        "assistant"
+      ],
+      [
+        1491.5,
+        "result"
+      ]
+    ],
+    "caps": {
+      "wall_clock_seconds": 3600,
+      "inactivity_seconds": 600,
+      "progress_stall_seconds": 600,
+      "tool_calls": 200,
+      "max_turns": 100,
+      "max_cost_usd": 15
+    },
+    "wall_clock_seconds": 1506.863343700068,
+    "real_clock_seconds": 1506.8633477687836,
+    "slept_seconds": 4.068715497851372e-06,
+    "judge_seconds": 12.842654000036418
+  },
+  "tool_calls": [
+    {
+      "tool": "Bash",
+      "args": {
+        "command": "ls \"C:\\Users\\User\\AppData\\Local\\Temp\\e2e-ferber-grandparents-wo47ce7l\\\" 2>/dev/null || echo \"Directory not found\"",
+        "description": "List project directory contents"
+      },
+      "response_summary": "Permission to use Bash has been denied because Claude Code is running in don't ask mode. IMPORTANT: You *may* attempt to accomplish this action using other tools that might naturally be used to accomplish this goal, e.g. using head instead of cat. But you *should not* attempt to work around this denial in malicious ways, e.g. do not use your ability to run tests to execute non-test actions. You should only try to work around this restriction in reasonable ways that do not attempt to bypass th..."
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "C:\\Users\\User\\AppData\\Local\\Temp\\e2e-ferber-grandparents-wo47ce7l\\research.json"
+      },
+      "response_summary": "1\t{\n2\t  \"project\": {\n3\t    \"id\": \"rp_ferber_grandparents\",\n4\t    \"objective\": \"Who were the grandparents of Charles Hubert Ferber, born 22 June 1891 in Cincinnati, Ohio (the parents of his father William Hubert Ferber and his mother Emma Becker)?\",\n5\t    \"subject_person_ids\": [\"I1\"],\n6\t    \"status\": \"active\",\n7\t    \"created\": \"2026-07-06T00:00:00Z\",\n8\t    \"updated\": \"2026-07-06T00:00:00Z\"\n9\t  },\n10\t  \"researcher_profile\": {\n11\t    \"experience_level\": \"intermediate\",\n12\t    \"subscriptions\": []..."
+    },
+    {
+      "tool": "Skill",
+      "args": {
+        "skill": "question-selection",
+        "args": "--autonomous"
+      },
+      "response_summary": "Launching skill: question-selection"
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "C:\\Users\\User\\AppData\\Local\\Temp\\e2e-ferber-grandparents-wo47ce7l\\.claude\\skills\\question-selection\\references\\question-formulation.md"
+      },
+      "response_summary": "1\t# Research Question Formulation\n2\t\n3\tGuidance for formulating effective genealogical research questions\n4\tthat satisfy the GPS standard for planned, purposeful research.\n5\t\n6\t## Research Objectives vs. Research Questions\n7\t\n8\tThese are distinct concepts that must not be conflated:\n9\t\n10\t- **Research objective**: The overarching goal of the research effort.\n11\t  It describes what you ultimately want to know (e.g., \"Identify the\n12\t  parents of John Smith born circa 1820 in Greene County, Ohi..."
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "C:\\Users\\User\\AppData\\Local\\Temp\\e2e-ferber-grandparents-wo47ce7l\\.claude\\skills\\question-selection\\references\\pedigree-analysis.md"
+      },
+      "response_summary": "1\t# Pedigree Analysis for Gap Detection\n2\t\n3\tGuidance for evaluating pedigree data to identify research gaps,\n4\terrors, and candidates for new research questions.\n5\t\n6\t## Purpose\n7\t\n8\tPedigree analysis is the process of systematically reviewing the\n9\tindividuals in a family tree to detect missing information, logical\n10\terrors, and inconsistencies. It is a critical first step before\n11\tselecting new research questions \u2014 it reveals where the gaps are\n12\tand which gaps are most significant.\n13\t..."
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "C:\\Users\\User\\AppData\\Local\\Temp\\e2e-ferber-grandparents-wo47ce7l\\tree.gedcomx.json"
+      },
+      "response_summary": "1\t{\n2\t  \"persons\": [\n3\t    {\n4\t      \"id\": \"I1\",\n5\t      \"gender\": \"Male\",\n6\t      \"names\": [\n7\t        { \"id\": \"N1\", \"given\": \"Charles Hubert\", \"surname\": \"Ferber\", \"preferred\": true }\n8\t      ],\n9\t      \"facts\": [\n10\t        { \"id\": \"F1\", \"type\": \"Birth\", \"date\": \"22 June 1891\", \"standard_date\": \"22 Jun 1891\", \"place\": \"Cincinnati, Hamilton, Ohio, United States\", \"standard_place\": \"Cincinnati, Hamilton, Ohio, United States\", \"sources\": [{ \"ref\": \"S1\", \"quality\": 1 }] },\n11\t        { \"id\": \"..."
+    },
+    {
+      "tool": "ToolSearch",
+      "args": {
+        "query": "select:mcp__genealogy__research_append",
+        "max_results": 1
+      },
+      "response_summary": "[{\"type\": \"tool_reference\", \"tool_name\": \"mcp__genealogy__research_append\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__research_append",
+      "args": {
+        "projectPath": "C:\\Users\\User\\AppData\\Local\\Temp\\e2e-ferber-grandparents-wo47ce7l",
+        "section": "questions",
+        "op": "append",
+        "entry": {
+          "question": "Who were the parents of William Hubert Ferber (born December 1869 in Cincinnati, Hamilton County, Ohio; died 11 March 1903 in Cincinnati, Ohio)?",
+          "rationale": "William Hubert Ferber is the father of Charles Hubert Ferber and his parents are one half of the project objective. His 1903 Ohio death certificate, the 1870 and 1880 federal censuses (which would show him as a child in his parents' household), and the 1890 marriage record are all accessible on FamilySearch and represent strong starting-point sources. The death certificate in particular often names parents for this period and jurisdiction.",
+          "selection_basis": "objective_decomposition",
+          "priority": "high",
+          "status": "open",
+          "depends_on": [],
+          "unblocks": [],
+          "resolved": null,
+          "resolution_assertion_ids": [],
+          "exhaustive_declaration": {
+            "declared": false,
+            "justification": null,
+            "log_entry_ids": [],
+            "stop_criteria": null
+          }
+        }
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"section\\\": \\\"questions\\\",\\n  \\\"op\\\": \\\"append\\\",\\n  \\\"entryId\\\": \\\"q_001\\\",\\n  \\\"filesWritten\\\": [\\n    \\\"research.json\\\"\\n  ],\\n  \\\"validation\\\": {\\n    \\\"valid\\\": true,\\n    \\\"warnings\\\": []\\n  }\\n}\"}]"
+    },
+    {
+      "tool": "Skill",
+      "args": {
+        "skill": "research-plan",
+        "args": "--autonomous q_001"
+      },
+      "response_summary": "Launching skill: research-plan"
+    },
+    {
+      "tool": "ToolSearch",
+      "args": {
+        "query": "select:mcp__genealogy__place_search,mcp__genealogy__collections_search,mcp__genealogy__external_links_search,mcp__genealogy__volume_search,mcp__genealogy__wiki_search",
+        "max_results": 5
+      },
+      "response_summary": "[{\"type\": \"tool_reference\", \"tool_name\": \"mcp__genealogy__place_search\"}, {\"type\": \"tool_reference\", \"tool_name\": \"mcp__genealogy__collections_search\"}, {\"type\": \"tool_reference\", \"tool_name\": \"mcp__genealogy__external_links_search\"}, {\"type\": \"tool_reference\", \"tool_name\": \"mcp__genealogy__volume_search\"}, {\"type\": \"tool_reference\", \"tool_name\": \"mcp__genealogy__wiki_search\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__place_search",
+      "args": {
+        "placeName": "Hamilton County",
+        "contextName": "Ohio"
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"results\\\": [\\n    {\\n      \\\"standardPlace\\\": \\\"Hamilton, Ohio, United States\\\",\\n      \\\"type\\\": \\\"County\\\",\\n      \\\"dateRange\\\": \\\"+1803/\\\",\\n      \\\"latitude\\\": 39.2,\\n      \\\"longitude\\\": -84.54,\\n      \\\"familysearchUrl\\\": \\\"https://www.familysearch.org/en/research/places/?text=Hamilton&focusedId=393203\\\",\\n      \\\"wikipediaUrl\\\": \\\"https://en.wikipedia.org/wiki/Hamilton_County,_Ohio\\\"\\n    },\\n    {\\n      \\\"standardPlace\\\": \\\"Hamilton, Butler, Ohio, U..."
+    },
+    {
+      "tool": "mcp__genealogy__wiki_search",
+      "args": {
+        "query": "Ohio Hamilton County Cincinnati genealogy records birth death marriage census"
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"query\\\": \\\"Ohio Hamilton County Cincinnati genealogy records birth death marriage census\\\",\\n  \\\"total_chunks_searched\\\": 1240565,\\n  \\\"results\\\": [\\n    {\\n      \\\"rank\\\": 1,\\n      \\\"relevance_score\\\": 0.894531,\\n      \\\"chunk_text\\\": \\\"# Cincinnati, Hamilton County, Ohio Genealogy  \\\\n[United States](https://www.familysearch.org/en/wiki/United_States_Genealogy \\\\\\\"United States Genealogy\\\\\\\")  \\\\n[Ohio](https://www.familysearch.org/en/wiki/Ohio,_United_Sta..."
+    },
+    {
+      "tool": "mcp__genealogy__collections_search",
+      "args": {
+        "standardPlace": "Hamilton, Ohio, United States",
+        "startYear": 1860,
+        "endYear": 1910
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"query\\\": {\\n    \\\"standardPlace\\\": \\\"Hamilton, Ohio, United States\\\",\\n    \\\"startYear\\\": 1860,\\n    \\\"endYear\\\": 1910\\n  },\\n  \\\"scope\\\": \\\"Ohio\\\",\\n  \\\"totalForPlace\\\": 60,\\n  \\\"results\\\": [\\n    {\\n      \\\"id\\\": \\\"3315268\\\",\\n      \\\"title\\\": \\\"Ohio, Athens County, Deceased Veteran Grave Registration Card File Index, 1819-1936\\\",\\n      \\\"dateRange\\\": \\\"1819-1936\\\",\\n      \\\"recordCount\\\": 5588,\\n      \\\"personCount\\\": 5591,\\n      \\\"imageCount\\\": 5546,\\n ..."
+    },
+    {
+      "tool": "mcp__genealogy__external_links_search",
+      "args": {
+        "standardPlace": "Hamilton, Ohio, United States",
+        "startYear": 1860,
+        "endYear": 1910
+      },
+      "response_summary": "Error: result (322,552 characters) exceeds maximum allowed tokens. Output has been saved to C:\\Users\\User\\.claude\\projects\\C--Users-User-AppData-Local-Temp-e2e-ferber-grandparents-wo47ce7l\\fda56b31-2dbb-4137-8429-f73104d08a23\\tool-results\\mcp-genealogy-external_links_search-1783410577878.txt.\nFormat: JSON array with schema: [{type: string, text: string}]\nUse offset and limit parameters to read specific portions of the file, search within it for specific content, and jq to make structured quer..."
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "C:\\Users\\User\\AppData\\Local\\Temp\\e2e-ferber-grandparents-wo47ce7l\\.claude\\skills\\research-plan\\references\\planning-standards.md"
+      },
+      "response_summary": "1\t# BCG Standards for Research Planning (Standards 9-18)\n2\t\n3\tThese ten standards from the Board for Certification of Genealogists\n4\tgovern how genealogists plan and scope their research. Every research\n5\tplan created by this skill should satisfy all applicable standards.\n6\t\n7\t---\n8\t\n9\t## Standard 9: Planned Research\n10\t\n11\tResearch begins with and follows a dynamic plan for gathering\n12\tinformation. The plan's purpose is to meet stated objectives, usually\n13\tframed as research questions. Hap..."
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "C:\\Users\\User\\AppData\\Local\\Temp\\e2e-ferber-grandparents-wo47ce7l\\.claude\\skills\\research-plan\\references\\record-type-guide.md"
+      },
+      "response_summary": "1\t# Record Type Selection Guide\n2\t\n3\tUse this reference when identifying which record sets to include in a\n4\tresearch plan. Match the research goal to record types, then check the\n5\tcontextual factors that affect availability.\n6\t\n7\t---\n8\t\n9\t## Record types by research goal\n10\t\n11\t| Goal | Primary record types | Secondary/fallback |\n12\t|------|---------------------|-------------------|\n13\t| Identify parents | Census (household), vital records (death/birth cert), probate (will), church (baptism..."
+    },
+    {
+      "tool": "mcp__genealogy__research_append",
+      "args": {
+        "projectPath": "C:\\Users\\User\\AppData\\Local\\Temp\\e2e-ferber-grandparents-wo47ce7l",
+        "ops": [
+          {
+            "section": "plans",
+            "op": "append",
+            "entry": {
+              "question_id": "q_001",
+              "status": "active",
+              "created": "2026-07-07"
+            }
+          },
+          {
+            "section": "plan_items",
+            "op": "append",
+            "planId": "pl_001",
+            "entry": {
+              "sequence": 1,
+              "record_type": "vital_record",
+              "jurisdiction": "Cincinnati, Hamilton County, Ohio",
+              "date_range": "1903",
+              "repository": "FamilySearch",
+              "rationale": "William Hubert Ferber's death certificate (11 Mar 1903) is already cited in the project as S3 (ark:/61903/1:1:F66M-8JZ, Ohio County Death Records 1840-2001). The certificate image has not yet been examined for parental information. Ohio county death records of this era frequently name the deceased's parents (father's name and mother's maiden name). Examining the image is the fastest possible first step since the source is already in hand.",
+              "fallback_for": null,
+              "status": "planned"
+            }
+          },
+          {
+            "section": "plan_items",
+            "op": "append",
+            "planId": "pl_001",
+            "entry": {
+              "sequence": 2,
+              "record_type": "census",
+              "jurisdiction": "Cincinnati, Hamilton County, Ohio",
+              "date_range": "1870",
+              "repository": "FamilySearch",
+              "rationale": "William was born December 1869 in Ohio, so he would appear as an infant (approximately 4\u20136 months old) in his parents' household in the June 1870 federal census. This is the highest-probability source for identifying both parents by name, along with any siblings and possibly the father's birthplace. FamilySearch has an indexed, free collection for 1870.",
+              "fallback_for": null,
+              "status": "planned"
+            }
+          },
+          {
+            "section": "plan_items",
+            "op": "append",
+            "planId": "pl_001",
+            "entry": {
+              "sequence": 3,
+              "record_type": "census",
+              "jurisdiction": "Cincinnati, Hamilton County, Ohio",
+              "date_range": "1880",
+              "repository": "FamilySearch",
+              "rationale": "In 1880 William would be approximately 10 years old and should appear in his parents' household. The 1880 census is fully indexed on FamilySearch, is free, and \u2014 crucially \u2014 records each household member's relationship to the head, providing a direct parent-child link. It also captures the birthplaces of each person's father and mother, which may reveal the Ferber family's origin.",
+              "fallback_for": null,
+              "status": "planned"
+            }
+          },
+          {
+            "section": "plan_items",
+            "op": "append",
+            "planId": "pl_001",
+            "entry": {
+              "sequence": 4,
+              "record_type": "vital_record",
+              "jurisdiction": "Hamilton County, Ohio",
+              "date_range": "1869",
+              "repository": "FamilySearch",
+              "rationale": "Hamilton County began recording births in 1863. A birth registration for William Hubert Ferber in December 1869 may exist in Ohio, County Births, 1841\u20132003 (collection 1932106) on FamilySearch. This record would directly name both parents, including the mother's maiden name \u2014 primary information for the parental question.",
+              "fallback_for": null,
+              "status": "planned"
+            }
+          },
+          {
+            "section": "plan_items",
+            "op": "append",
+            "planId": "pl_001",
+            "entry": {
+              "sequence": 5,
+              "record_type": "vital_record",
+              "jurisdiction": "Hamilton County, Ohio",
+              "date_range": "1890",
+              "repository": "FamilySearch",
+              "rationale": "William Hubert Ferber married Emma Becker on 10 September 1890 in Hamilton County (already cited as S1/S3). The marriage license application for this era sometimes recorded the groom's parents' names. Searching Ohio, County Marriages, 1789\u20132016 (collection 1614804) and examining the original image of the license may reveal his father's name and mother's maiden name.",
+              "fallback_for": null,
+              "status": "planned"
+            }
+          },
+          {
+            "section": "plan_items",
+            "op": "append",
+            "planId": "pl_001",
+            "entry": {
+              "sequence": 6,
+              "record_type": "immigration",
+              "jurisdiction": "Ohio, United States",
+              "date_range": "1840-1870",
+              "repository": "FamilySearch",
+              "rationale": "The surname Ferber is Germanic, and Cincinnati had one of the largest German immigrant populations in the United States in the mid-19th century. If William's father (or grandfather) immigrated from a German-speaking region, Ohio naturalization records (collection 1987615) or federal passenger arrival records on FamilySearch may name family members or state the origin locality. This could both identify the father and open research into German records if needed.",
+              "fallback_for": null,
+              "status": "planned"
+            }
+          },
+          {
+            "section": "plan_items",
+            "op": "append",
+            "planId": "pl_001",
+            "entry": {
+              "sequence": 7,
+              "record_type": "other",
+              "jurisdiction": "Cincinnati, Hamilton County, Ohio",
+              "date_range": "1860-1880",
+              "repository": "other",
+              "rationale": "FAN cluster: Cincinnati city directories (1819\u20131941, available via Fold3 and the Public Library of Cincinnati's digital collection) list heads of household by name and occupation. Searching for Ferber entries in the 1865\u20131880 directories would identify which Ferber households existed in Cincinnati before and after William's 1869 birth, helping to distinguish his family from unrelated Ferbers and potentially naming his father.",
+              "fallback_for": null,
+              "status": "planned"
+            }
+          }
+        ]
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"results\\\": [\\n    {\\n      \\\"section\\\": \\\"plans\\\",\\n      \\\"op\\\": \\\"append\\\",\\n      \\\"entryId\\\": \\\"pl_001\\\"\\n    },\\n    {\\n      \\\"section\\\": \\\"plan_items\\\",\\n      \\\"op\\\": \\\"append\\\",\\n      \\\"entryId\\\": \\\"pli_001\\\"\\n    },\\n    {\\n      \\\"section\\\": \\\"plan_items\\\",\\n      \\\"op\\\": \\\"append\\\",\\n      \\\"entryId\\\": \\\"pli_002\\\"\\n    },\\n    {\\n      \\\"section\\\": \\\"plan_items\\\",\\n      \\\"op\\\": \\\"append\\\",\\n      \\\"entryId\\\": \\\"pli_003\\\"\\n    },..."
+    },
+    {
+      "tool": "Skill",
+      "args": {
+        "skill": "search-records",
+        "args": "--autonomous q_001 pli_001"
+      },
+      "response_summary": "Launching skill: search-records"
+    },
+    {
+      "tool": "ToolSearch",
+      "args": {
+        "query": "select:mcp__genealogy__record_read,mcp__genealogy__research_log_append,mcp__genealogy__record_search",
+        "max_results": 3
+      },
+      "response_summary": "[{\"type\": \"tool_reference\", \"tool_name\": \"mcp__genealogy__record_read\"}, {\"type\": \"tool_reference\", \"tool_name\": \"mcp__genealogy__research_log_append\"}, {\"type\": \"tool_reference\", \"tool_name\": \"mcp__genealogy__record_search\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__record_read",
+      "args": {
+        "recordId": "ark:/61903/1:1:F66M-8JZ"
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"persons\\\": [\\n    {\\n      \\\"id\\\": \\\"p_11261440420\\\",\\n      \\\"ark\\\": \\\"ark:/61903/1:1:F66M-8JZ\\\",\\n      \\\"gender\\\": \\\"Male\\\",\\n      \\\"names\\\": [\\n        {\\n          \\\"id\\\": \\\"dcc3e6a5-da27-4c1c-a9a7-879e9f3c0cbc\\\",\\n          \\\"type\\\": \\\"BirthName\\\",\\n          \\\"surname\\\": \\\"Ferber\\\",\\n          \\\"given\\\": \\\"Wm.\\\"\\n        }\\n      ],\\n      \\\"facts\\\": [\\n        {\\n          \\\"id\\\": \\\"882cd7fe-3b8c-49f9-a672-1be07c1c044c\\\",\\n          \\\"type\\\": \\\"Birth..."
+    },
+    {
+      "tool": "mcp__genealogy__research_log_append",
+      "args": {
+        "projectPath": "C:\\Users\\User\\AppData\\Local\\Temp\\e2e-ferber-grandparents-wo47ce7l",
+        "tool": "record_read",
+        "planItemId": "pli_001",
+        "query": {
+          "recordId": "ark:/61903/1:1:F66M-8JZ",
+          "collection": "Ohio, County Death Records, 1840-2001",
+          "subject": "Wm. Ferber",
+          "purpose": "Examine death certificate for parental names"
+        },
+        "outcome": "positive",
+        "resultsExamined": 1,
+        "resultsAvailable": 1,
+        "notes": "Death certificate for Wm. Ferber, died 11 Mar 1903, Cincinnati, Hamilton, Ohio. CRITICAL FINDING: record lists father as Gerhard Ferber (ark:/61903/1:1:F66M-8J8) and mother as Eva Ferber (ark:/61903/1:1:F66M-8JD). No maiden name for mother. Birth indexed as 1870 (vs. Dec 1869 per 1900 census \u2014 minor indexing discrepancy). Passing to record-extraction for full assertion write."
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"logId\\\": \\\"log_001\\\",\\n  \\\"performed\\\": \\\"2026-07-07T07:52:20.765Z\\\",\\n  \\\"resultsRef\\\": null,\\n  \\\"returnedCount\\\": null,\\n  \\\"filesWritten\\\": [\\n    \\\"research.json\\\"\\n  ],\\n  \\\"validation\\\": {\\n    \\\"valid\\\": true,\\n    \\\"warnings\\\": []\\n  }\\n}\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__research_append",
+      "args": {
+        "projectPath": "C:\\Users\\User\\AppData\\Local\\Temp\\e2e-ferber-grandparents-wo47ce7l",
+        "section": "plan_items",
+        "op": "update",
+        "planId": "pl_001",
+        "entryId": "pli_001",
+        "fields": {
+          "status": "in_progress"
+        }
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"section\\\": \\\"plan_items\\\",\\n  \\\"op\\\": \\\"update\\\",\\n  \\\"entryId\\\": \\\"pli_001\\\",\\n  \\\"filesWritten\\\": [\\n    \\\"research.json\\\"\\n  ],\\n  \\\"validation\\\": {\\n    \\\"valid\\\": true,\\n    \\\"warnings\\\": []\\n  }\\n}\"}]"
+    },
+    {
+      "tool": "Skill",
+      "args": {
+        "skill": "record-extraction",
+        "args": "--autonomous Extract assertions from the death certificate of Wm. Ferber (ark:/61903/1:1:F66M-8JZ), Ohio County Death Records 1840-2001, for plan item pli_001 / log_001. The full GEDCOMX follows:\n\npersons:\n- id: p_11261440420, ark: ark:/61903/1:1:F66M-8JZ, gender: Male, name: Wm. Ferber\n  facts: Birth 1870, Cincinnati, Hamilton, Ohio; Death 11 Mar 1903, Cincinnati, Hamilton, Ohio; Residence Cincinnati, Ohio; MaritalStatus Married\n- id: p_11261440421, ark: ark:/61903/1:1:F66M-8J8, gender: Male, name: Gerhard Ferber\n- id: p_11261440422, ark: ark:/61903/1:1:F66M-8JD, gender: Female, name: Eva Ferber\n\nrelationships:\n- Couple: p_11261440421 (Gerhard) + p_11261440422 (Eva)\n- ParentChild: p_11261440421 (Gerhard) \u2192 p_11261440420 (Wm.)\n- ParentChild: p_11261440422 (Eva) \u2192 p_11261440420 (Wm.)\n\nSource: \"Ohio, County Death Records, 1840-2001\", FamilySearch (https://www.familysearch.org/ark:/61903/1:1:F66M-8JZ), Entry for Wm. Ferber and Gerhard Ferber, 11 Mar 1903. Image: https://www.familysearch.org/ark:/61903/3:1:S3HT-66TS-SCS\n\nTree subject for William Hubert Ferber is I2 in tree.gedcomx.json."
+      },
+      "response_summary": "Launching skill: record-extraction"
+    },
+    {
+      "tool": "ToolSearch",
+      "args": {
+        "query": "select:mcp__genealogy__research_append,mcp__genealogy__tree_edit",
+        "max_results": 2
+      },
+      "response_summary": "[{\"type\": \"tool_reference\", \"tool_name\": \"mcp__genealogy__research_append\"}, {\"type\": \"tool_reference\", \"tool_name\": \"mcp__genealogy__tree_edit\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__research_append",
+      "args": {
+        "projectPath": "C:\\Users\\User\\AppData\\Local\\Temp\\e2e-ferber-grandparents-wo47ce7l",
+        "ops": [
+          {
+            "section": "sources",
+            "op": "append",
+            "entry": {
+              "gedcomx_source_description_id": "S3",
+              "citation": "\"Ohio, County Death Records, 1840-2001,\" FamilySearch (https://www.familysearch.org/ark:/61903/1:1:F66M-8JZ : accessed 7 Jul 2026), entry for Wm. Ferber, died 11 Mar 1903; Gerhard Ferber recorded as father, Eva Ferber as mother.",
+              "citation_detail": {
+                "who": "Wm. Ferber (deceased); Gerhard Ferber (father); Eva Ferber (mother)",
+                "what": "Hamilton County, Ohio death certificate, image on FamilySearch",
+                "when_created": "11 Mar 1903",
+                "when_accessed": "2026-07-07",
+                "where": "FamilySearch (https://www.familysearch.org)",
+                "where_within": "ark:/61903/1:1:F66M-8JZ; image ark:/61903/3:1:S3HT-66TS-SCS"
+              },
+              "source_classification": "derivative",
+              "repository": "FamilySearch",
+              "access_date": "2026-07-07",
+              "url": "https://www.familysearch.org/ark:/61903/1:1:F66M-8JZ",
+              "log_entry_id": "log_001"
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "source_id": "src_001",
+              "record_id": "https://www.familysearch.org/ark:/61903/1:1:F66M-8JZ",
+              "record_persona_id": "p_11261440420",
+              "record_role": "deceased",
+              "fact_type": "name",
+              "value": "Wm. Ferber",
+              "structured_value": {
+                "given": "Wm.",
+                "surname": "Ferber"
+              },
+              "information_quality": "indeterminate",
+              "informant": "unknown personal informant (likely spouse or close family member)",
+              "informant_proximity": "witness",
+              "evidence_type": "direct",
+              "log_entry_id": "log_001",
+              "extracted_for_question_ids": []
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "source_id": "src_001",
+              "record_id": "https://www.familysearch.org/ark:/61903/1:1:F66M-8JZ",
+              "record_persona_id": "p_11261440420",
+              "record_role": "deceased",
+              "fact_type": "death",
+              "value": "11 Mar 1903, Cincinnati, Hamilton, Ohio",
+              "date": "1903-03-11",
+              "date_certainty": "exact",
+              "place": "Cincinnati, Hamilton, Ohio",
+              "standard_place": "Cincinnati, Hamilton, Ohio, United States",
+              "information_quality": "primary",
+              "informant": "attending physician (unnamed)",
+              "informant_proximity": "official_duty",
+              "evidence_type": "direct",
+              "log_entry_id": "log_001",
+              "extracted_for_question_ids": []
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "source_id": "src_001",
+              "record_id": "https://www.familysearch.org/ark:/61903/1:1:F66M-8JZ",
+              "record_persona_id": "p_11261440420",
+              "record_role": "deceased",
+              "fact_type": "birth",
+              "value": "1870 (year only, per death certificate)",
+              "structured_value": {
+                "year": "1870"
+              },
+              "date": "1870",
+              "date_certainty": "approximate",
+              "information_quality": "secondary",
+              "informant": "unknown personal informant (likely spouse or close family member)",
+              "informant_proximity": "family_not_present",
+              "evidence_type": "direct",
+              "informant_bias_notes": "Death certificate states birth year 1870; the 1900 federal census (S2) records birth month December 1869. Minor discrepancy of one month likely reflects imprecise informant recall. The 1900 census, completed during William's lifetime, is the more reliable source for birth month.",
+              "log_entry_id": "log_001",
+              "extracted_for_question_ids": []
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "source_id": "src_001",
+              "record_id": "https://www.familysearch.org/ark:/61903/1:1:F66M-8JZ",
+              "record_persona_id": "p_11261440420",
+              "record_role": "deceased",
+              "fact_type": "birth",
+              "value": "Cinti., Ham., O. [Cincinnati, Hamilton County, Ohio]",
+              "place": "Cincinnati, Hamilton, Ohio",
+              "standard_place": "Cincinnati, Hamilton, Ohio, United States",
+              "information_quality": "secondary",
+              "informant": "unknown personal informant (likely spouse or close family member)",
+              "informant_proximity": "family_not_present",
+              "evidence_type": "direct",
+              "log_entry_id": "log_001",
+              "extracted_for_question_ids": []
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "source_id": "src_001",
+              "record_id": "https://www.familysearch.org/ark:/61903/1:1:F66M-8JZ",
+              "record_persona_id": "p_11261440420",
+              "record_role": "deceased",
+              "fact_type": "marital_status",
+              "value": "Married",
+              "information_quality": "primary",
+              "informant": "unknown personal informant (likely spouse or close family member)",
+              "informant_proximity": "witness",
+              "evidence_type": "direct",
+              "log_entry_id": "log_001",
+              "extracted_for_question_ids": []
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "source_id": "src_001",
+              "record_id": "https://www.familysearch.org/ark:/61903/1:1:F66M-8JZ",
+              "record_persona_id": "p_11261440421",
+              "record_role": "father_of_deceased",
+              "fact_type": "name",
+              "value": "Gerhard Ferber",
+              "structured_value": {
+                "given": "Gerhard",
+                "surname": "Ferber"
+              },
+              "information_quality": "secondary",
+              "informant": "unknown personal informant (likely spouse or close family member of deceased)",
+              "informant_proximity": "family_not_present",
+              "evidence_type": "indirect",
+              "informant_bias_notes": "Per GPS guidance, parents' names on a death certificate are indirect evidence \u2014 the informant reported their knowledge of the decedent's parentage, not an event they witnessed. No informant is named on this record index. Mother's maiden name is not recorded; the 'Ferber' surname on Eva may reflect the record-taker entering the family surname rather than her maiden name.",
+              "log_entry_id": "log_001",
+              "extracted_for_question_ids": [
+                "q_001"
+              ]
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "source_id": "src_001",
+              "record_id": "https://www.familysearch.org/ark:/61903/1:1:F66M-8JZ",
+              "record_persona_id": "p_11261440422",
+              "record_role": "mother_of_deceased",
+              "fact_type": "name",
+              "value": "Eva Ferber",
+              "structured_value": {
+                "given": "Eva",
+                "surname": "Ferber"
+              },
+              "information_quality": "secondary",
+              "informant": "unknown personal informant (likely spouse or close family member of deceased)",
+              "informant_proximity": "family_not_present",
+              "evidence_type": "indirect",
+              "informant_bias_notes": "Parents' names on a death certificate are indirect evidence \u2014 the informant reported their knowledge of the decedent's parentage. Mother's surname 'Ferber' is likely her married name as entered by the record-taker; maiden name is not recorded and remains unknown. This name must be corroborated by other records (census, birth record) to confirm.",
+              "log_entry_id": "log_001",
+              "extracted_for_question_ids": [
+                "q_001"
+              ]
+            }
+          }
+        ]
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": false,\\n  \\\"errors\\\": [\\n    \\\"research.json/assertions[0]: has record_persona_id but its log entry 'log_001' has no sidecar (results_ref is null)\\\",\\n    \\\"research.json/assertions[1]: has record_persona_id but its log entry 'log_001' has no sidecar (results_ref is null)\\\",\\n    \\\"research.json/assertions[2]: has record_persona_id but its log entry 'log_001' has no sidecar (results_ref is null)\\\",\\n    \\\"research.json/assertions[3]: has record_persona_..."
+    },
+    {
+      "tool": "mcp__genealogy__research_append",
+      "args": {
+        "projectPath": "C:\\Users\\User\\AppData\\Local\\Temp\\e2e-ferber-grandparents-wo47ce7l",
+        "ops": [
+          {
+            "section": "sources",
+            "op": "append",
+            "entry": {
+              "gedcomx_source_description_id": "S3",
+              "citation": "\"Ohio, County Death Records, 1840-2001,\" FamilySearch (https://www.familysearch.org/ark:/61903/1:1:F66M-8JZ : accessed 7 Jul 2026), entry for Wm. Ferber, died 11 Mar 1903; Gerhard Ferber recorded as father, Eva Ferber as mother.",
+              "citation_detail": {
+                "who": "Wm. Ferber (deceased); Gerhard Ferber (father); Eva Ferber (mother)",
+                "what": "Hamilton County, Ohio death certificate, image on FamilySearch",
+                "when_created": "11 Mar 1903",
+                "when_accessed": "2026-07-07",
+                "where": "FamilySearch (https://www.familysearch.org)",
+                "where_within": "ark:/61903/1:1:F66M-8JZ; image ark:/61903/3:1:S3HT-66TS-SCS"
+              },
+              "source_classification": "derivative",
+              "repository": "FamilySearch",
+              "access_date": "2026-07-07",
+              "url": "https://www.familysearch.org/ark:/61903/1:1:F66M-8JZ",
+              "log_entry_id": "log_001"
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "source_id": "src_001",
+              "record_id": "https://www.familysearch.org/ark:/61903/1:1:F66M-8JZ",
+              "record_persona_id": null,
+              "record_role": "deceased",
+              "fact_type": "name",
+              "value": "Wm. Ferber",
+              "structured_value": {
+                "given": "Wm.",
+                "surname": "Ferber"
+              },
+              "information_quality": "indeterminate",
+              "informant": "unknown personal informant (likely spouse or close family member)",
+              "informant_proximity": "witness",
+              "evidence_type": "direct",
+              "log_entry_id": "log_001",
+              "extracted_for_question_ids": []
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "source_id": "src_001",
+              "record_id": "https://www.familysearch.org/ark:/61903/1:1:F66M-8JZ",
+              "record_persona_id": null,
+              "record_role": "deceased",
+              "fact_type": "death",
+              "value": "11 Mar 1903, Cincinnati, Hamilton, Ohio",
+              "date": "1903-03-11",
+              "date_certainty": "exact",
+              "place": "Cincinnati, Hamilton, Ohio",
+              "standard_place": "Cincinnati, Hamilton, Ohio, United States",
+              "information_quality": "primary",
+              "informant": "attending physician (unnamed)",
+              "informant_proximity": "official_duty",
+              "evidence_type": "direct",
+              "log_entry_id": "log_001",
+              "extracted_for_question_ids": []
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "source_id": "src_001",
+              "record_id": "https://www.familysearch.org/ark:/61903/1:1:F66M-8JZ",
+              "record_persona_id": null,
+              "record_role": "deceased",
+              "fact_type": "birth",
+              "value": "1870 (year only, per death certificate)",
+              "structured_value": {
+                "year": "1870"
+              },
+              "date": "1870",
+              "date_certainty": "approximate",
+              "information_quality": "secondary",
+              "informant": "unknown personal informant (likely spouse or close family member)",
+              "informant_proximity": "family_not_present",
+              "evidence_type": "direct",
+              "informant_bias_notes": "Death certificate states birth year 1870; the 1900 federal census (S2) records birth month December 1869. Minor discrepancy of one month likely reflects imprecise informant recall. The 1900 census, completed during William's lifetime, is the more reliable source for birth month.",
+              "log_entry_id": "log_001",
+              "extracted_for_question_ids": []
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "source_id": "src_001",
+              "record_id": "https://www.familysearch.org/ark:/61903/1:1:F66M-8JZ",
+              "record_persona_id": null,
+              "record_role": "deceased",
+              "fact_type": "birth",
+              "value": "Cinti., Ham., O. [Cincinnati, Hamilton County, Ohio]",
+              "place": "Cincinnati, Hamilton, Ohio",
+              "standard_place": "Cincinnati, Hamilton, Ohio, United States",
+              "information_quality": "secondary",
+              "informant": "unknown personal informant (likely spouse or close family member)",
+              "informant_proximity": "family_not_present",
+              "evidence_type": "direct",
+              "log_entry_id": "log_001",
+              "extracted_for_question_ids": []
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "source_id": "src_001",
+              "record_id": "https://www.familysearch.org/ark:/61903/1:1:F66M-8JZ",
+              "record_persona_id": null,
+              "record_role": "deceased",
+              "fact_type": "marital_status",
+              "value": "Married",
+              "information_quality": "primary",
+              "informant": "unknown personal informant (likely spouse or close family member)",
+              "informant_proximity": "witness",
+              "evidence_type": "direct",
+              "log_entry_id": "log_001",
+              "extracted_for_question_ids": []
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "source_id": "src_001",
+              "record_id": "https://www.familysearch.org/ark:/61903/1:1:F66M-8JZ",
+              "record_persona_id": null,
+              "record_role": "father_of_deceased",
+              "fact_type": "name",
+              "value": "Gerhard Ferber",
+              "structured_value": {
+                "given": "Gerhard",
+                "surname": "Ferber"
+              },
+              "information_quality": "secondary",
+              "informant": "unknown personal informant (likely spouse or close family member of deceased)",
+              "informant_proximity": "family_not_present",
+              "evidence_type": "indirect",
+              "informant_bias_notes": "Per GPS guidance, parents' names on a death certificate are indirect evidence \u2014 the informant reported their knowledge of the decedent's parentage, not an event they witnessed. No informant is named on this record index.",
+              "log_entry_id": "log_001",
+              "extracted_for_question_ids": [
+                "q_001"
+              ]
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "source_id": "src_001",
+              "record_id": "https://www.familysearch.org/ark:/61903/1:1:F66M-8JZ",
+              "record_persona_id": null,
+              "record_role": "mother_of_deceased",
+              "fact_type": "name",
+              "value": "Eva Ferber",
+              "structured_value": {
+                "given": "Eva",
+                "surname": "Ferber"
+              },
+              "information_quality": "secondary",
+              "informant": "unknown personal informant (likely spouse or close family member of deceased)",
+              "informant_proximity": "family_not_present",
+              "evidence_type": "indirect",
+              "informant_bias_notes": "Parents' names on a death certificate are indirect evidence. Mother's surname 'Ferber' is likely her married name as entered by the record-taker; maiden name is not recorded and remains unknown. Must be corroborated by other records (census, birth record) to confirm identity and maiden name.",
+              "log_entry_id": "log_001",
+              "extracted_for_question_ids": [
+                "q_001"
+              ]
+            }
+          }
+        ]
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"results\\\": [\\n    {\\n      \\\"section\\\": \\\"sources\\\",\\n      \\\"op\\\": \\\"append\\\",\\n      \\\"entryId\\\": \\\"src_001\\\"\\n    },\\n    {\\n      \\\"section\\\": \\\"assertions\\\",\\n      \\\"op\\\": \\\"append\\\",\\n      \\\"entryId\\\": \\\"a_001\\\"\\n    },\\n    {\\n      \\\"section\\\": \\\"assertions\\\",\\n      \\\"op\\\": \\\"append\\\",\\n      \\\"entryId\\\": \\\"a_002\\\"\\n    },\\n    {\\n      \\\"section\\\": \\\"assertions\\\",\\n      \\\"op\\\": \\\"append\\\",\\n      \\\"entryId\\\": \\\"a_003\\\"\\n    },\\n ..."
+    },
+    {
+      "tool": "mcp__genealogy__research_append",
+      "args": {
+        "projectPath": "C:\\Users\\User\\AppData\\Local\\Temp\\e2e-ferber-grandparents-wo47ce7l",
+        "section": "plan_items",
+        "op": "update",
+        "planId": "pl_001",
+        "entryId": "pli_001",
+        "fields": {
+          "status": "completed"
+        }
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"section\\\": \\\"plan_items\\\",\\n  \\\"op\\\": \\\"update\\\",\\n  \\\"entryId\\\": \\\"pli_001\\\",\\n  \\\"filesWritten\\\": [\\n    \\\"research.json\\\"\\n  ],\\n  \\\"validation\\\": {\\n    \\\"valid\\\": true,\\n    \\\"warnings\\\": []\\n  }\\n}\"}]"
+    },
+    {
+      "tool": "Skill",
+      "args": {
+        "skill": "assertion-classification",
+        "args": "--autonomous a_006 a_007"
+      },
+      "response_summary": "Launching skill: assertion-classification"
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "C:\\Users\\User\\AppData\\Local\\Temp\\e2e-ferber-grandparents-wo47ce7l\\.claude\\skills\\assertion-classification\\references\\three-layer-model.md"
+      },
+      "response_summary": "1\t# The Three-Layer Classification Model\n2\t\n3\t## Core Principle: Independence of Layers\n4\t\n5\tThe three layers -- source, information, and evidence -- are evaluated\n6\tindependently. The classification at one layer does NOT determine the\n7\tclassification at another. An original source can contain secondary\n8\tinformation. A derivative source can provide direct evidence. Each\n9\tlayer operates on its own terms.\n10\t\n11\t---\n12\t\n13\t## Layer 1: Source Classification\n14\t\n15\tSource classification addres..."
+    },
+    {
+      "tool": "mcp__genealogy__research_append",
+      "args": {
+        "projectPath": "C:\\Users\\User\\AppData\\Local\\Temp\\e2e-ferber-grandparents-wo47ce7l",
+        "ops": [
+          {
+            "section": "assertions",
+            "op": "update",
+            "entryId": "a_003",
+            "fields": {
+              "information_quality": "indeterminate",
+              "informant": "unknown personal informant (unnamed; likely spouse or family member)",
+              "informant_bias_notes": "Death certificate states birth year 1870; the 1900 federal census (S2) records birth month December 1869. Minor discrepancy likely reflects imprecise informant recall. Informant not named on this record; classification cannot be elevated beyond indeterminate without confirming who completed the death certificate."
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "update",
+            "entryId": "a_004",
+            "fields": {
+              "information_quality": "indeterminate",
+              "informant": "unknown personal informant (unnamed; likely spouse or family member)",
+              "informant_bias_notes": "Informant not named on this record. Birthplace of deceased is a fact the personal informant would not have witnessed; however, since the informant cannot be identified, classification remains indeterminate rather than secondary."
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "update",
+            "entryId": "a_005",
+            "fields": {
+              "information_quality": "indeterminate",
+              "informant": "unknown personal informant (unnamed; likely spouse or family member)",
+              "informant_bias_notes": "Marital status reported on the death certificate by an unnamed personal informant. Any family member present would have first-hand knowledge of this fact, but without confirming the informant's identity the classification cannot be elevated to primary."
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "update",
+            "entryId": "a_006",
+            "fields": {
+              "information_quality": "indeterminate",
+              "informant_bias_notes": "Per GPS guidance, parents' names on a death certificate are reported by an unnamed personal informant (no informant named in index). Informant is unknown; cannot confirm they had first-hand knowledge of parentage, so classification is indeterminate. As to evidence type: the record explicitly names 'Gerhard Ferber' in the father role for Wm. Ferber \u2014 this directly answers q_001 without inference. Evidence independence note: this assertion and a_007 share the same unnamed informant and therefore constitute one evidence unit for corroboration purposes.",
+              "evidence_type": "direct"
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "update",
+            "entryId": "a_007",
+            "fields": {
+              "information_quality": "indeterminate",
+              "informant_bias_notes": "Per GPS guidance, parents' names on a death certificate are reported by an unnamed personal informant (no informant named in index). Informant is unknown; cannot confirm they had first-hand knowledge of parentage, so classification is indeterminate. Mother's surname 'Ferber' is likely her married name as entered by the record-taker; maiden name is not recorded and remains unknown. Evidence independence note: this assertion and a_006 share the same unnamed informant and therefore constitute one evidence unit for corroboration purposes.",
+              "evidence_type": "direct"
+            }
+          }
+        ]
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"results\\\": [\\n    {\\n      \\\"section\\\": \\\"assertions\\\",\\n      \\\"op\\\": \\\"update\\\",\\n      \\\"entryId\\\": \\\"a_003\\\"\\n    },\\n    {\\n      \\\"section\\\": \\\"assertions\\\",\\n      \\\"op\\\": \\\"update\\\",\\n      \\\"entryId\\\": \\\"a_004\\\"\\n    },\\n    {\\n      \\\"section\\\": \\\"assertions\\\",\\n      \\\"op\\\": \\\"update\\\",\\n      \\\"entryId\\\": \\\"a_005\\\"\\n    },\\n    {\\n      \\\"section\\\": \\\"assertions\\\",\\n      \\\"op\\\": \\\"update\\\",\\n      \\\"entryId\\\": \\\"a_006\\\"\\n    },\\n..."
+    },
+    {
+      "tool": "Skill",
+      "args": {
+        "skill": "person-evidence",
+        "args": "--autonomous Link assertions from the death certificate of Wm. Ferber (src_001, a_001\u2013a_007) to tree persons. Deceased role (a_001\u2013a_005) maps to I2 (William Hubert Ferber). Father role a_006 (Gerhard Ferber) and mother role a_007 (Eva Ferber) have no existing tree persons \u2014 create stubs for both and add ParentChild relationships to I2."
+      },
+      "response_summary": "Launching skill: person-evidence"
+    },
+    {
+      "tool": "ToolSearch",
+      "args": {
+        "query": "select:mcp__genealogy__tree_edit,mcp__genealogy__research_append",
+        "max_results": 2
+      },
+      "response_summary": "[{\"type\": \"tool_reference\", \"tool_name\": \"mcp__genealogy__tree_edit\"}, {\"type\": \"tool_reference\", \"tool_name\": \"mcp__genealogy__research_append\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__tree_edit",
+      "args": {
+        "projectPath": "C:\\Users\\User\\AppData\\Local\\Temp\\e2e-ferber-grandparents-wo47ce7l",
+        "ops": [
+          {
+            "operation": "add_person",
+            "person": {
+              "gender": "Male",
+              "names": [
+                {
+                  "given": "Gerhard",
+                  "surname": "Ferber",
+                  "preferred": true,
+                  "type": "BirthName"
+                }
+              ]
+            }
+          },
+          {
+            "operation": "add_person",
+            "person": {
+              "gender": "Female",
+              "names": [
+                {
+                  "given": "Eva",
+                  "surname": "Ferber",
+                  "preferred": true,
+                  "type": "BirthName"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"results\\\": [\\n    {\\n      \\\"operation\\\": \\\"add_person\\\",\\n      \\\"assignedIds\\\": {\\n        \\\"person\\\": \\\"I10\\\",\\n        \\\"names\\\": [\\n          \\\"N10\\\"\\n        ]\\n      }\\n    },\\n    {\\n      \\\"operation\\\": \\\"add_person\\\",\\n      \\\"assignedIds\\\": {\\n        \\\"person\\\": \\\"I11\\\",\\n        \\\"names\\\": [\\n          \\\"N11\\\"\\n        ]\\n      }\\n    }\\n  ],\\n  \\\"filesWritten\\\": [\\n    \\\"tree.gedcomx.json\\\"\\n  ],\\n  \\\"validation\\\": {\\n    \\\"vali..."
+    },
+    {
+      "tool": "mcp__genealogy__tree_edit",
+      "args": {
+        "projectPath": "C:\\Users\\User\\AppData\\Local\\Temp\\e2e-ferber-grandparents-wo47ce7l",
+        "ops": [
+          {
+            "operation": "add_relationship",
+            "relationship": {
+              "type": "Couple",
+              "person1": "I10",
+              "person2": "I11"
+            }
+          },
+          {
+            "operation": "add_relationship",
+            "relationship": {
+              "type": "ParentChild",
+              "parent": "I10",
+              "child": "I2"
+            }
+          },
+          {
+            "operation": "add_relationship",
+            "relationship": {
+              "type": "ParentChild",
+              "parent": "I11",
+              "child": "I2"
+            }
+          }
+        ]
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"results\\\": [\\n    {\\n      \\\"operation\\\": \\\"add_relationship\\\",\\n      \\\"assignedIds\\\": {\\n        \\\"relationship\\\": \\\"R12\\\"\\n      }\\n    },\\n    {\\n      \\\"operation\\\": \\\"add_relationship\\\",\\n      \\\"assignedIds\\\": {\\n        \\\"relationship\\\": \\\"R13\\\"\\n      }\\n    },\\n    {\\n      \\\"operation\\\": \\\"add_relationship\\\",\\n      \\\"assignedIds\\\": {\\n        \\\"relationship\\\": \\\"R14\\\"\\n      }\\n    }\\n  ],\\n  \\\"filesWritten\\\": [\\n    \\\"tree.gedcom..."
+    },
+    {
+      "tool": "mcp__genealogy__research_append",
+      "args": {
+        "projectPath": "C:\\Users\\User\\AppData\\Local\\Temp\\e2e-ferber-grandparents-wo47ce7l",
+        "ops": [
+          {
+            "section": "person_evidence",
+            "op": "append",
+            "entry": {
+              "assertion_id": "a_001",
+              "person_id": "I2",
+              "confidence": "confident",
+              "rationale": "The death certificate names 'Wm. Ferber' as the deceased, died 11 Mar 1903 in Cincinnati, Hamilton, Ohio. 'Wm.' is a standard abbreviation for William. I2 (William Hubert Ferber) has the same death date and place in the tree. The match on death date, place, and name abbreviation is conclusive \u2014 no other William Ferber would share this exact death record.",
+              "match_score": null
+            }
+          },
+          {
+            "section": "person_evidence",
+            "op": "append",
+            "entry": {
+              "assertion_id": "a_002",
+              "person_id": "I2",
+              "confidence": "confident",
+              "rationale": "Death date and place (11 Mar 1903, Cincinnati, Hamilton, Ohio) match exactly the facts already established for I2 in the tree. The attending physician's testimony is the highest-quality evidence for this event. No conflict.",
+              "match_score": null
+            }
+          },
+          {
+            "section": "person_evidence",
+            "op": "append",
+            "entry": {
+              "assertion_id": "a_003",
+              "person_id": "I2",
+              "confidence": "confident",
+              "rationale": "Birth year stated as '1870' on the death certificate. I2's birth is recorded as December 1869 in tree \u2014 a minor discrepancy (one month) well within the range of informant memory error on a 1903 certificate. Consistent enough to confirm identity.",
+              "match_score": null
+            }
+          },
+          {
+            "section": "person_evidence",
+            "op": "append",
+            "entry": {
+              "assertion_id": "a_004",
+              "person_id": "I2",
+              "confidence": "confident",
+              "rationale": "Birth place stated as Cincinnati, Hamilton, Ohio. I2's birth place is listed as Ohio in the tree (from 1900 census). The more specific Cincinnati location is consistent and provides additional detail for I2.",
+              "match_score": null
+            }
+          },
+          {
+            "section": "person_evidence",
+            "op": "append",
+            "entry": {
+              "assertion_id": "a_005",
+              "person_id": "I2",
+              "confidence": "confident",
+              "rationale": "Marital status 'Married' is consistent with I2's known marriage to Emma Becker (married 10 Sep 1890). No conflict.",
+              "match_score": null
+            }
+          },
+          {
+            "section": "person_evidence",
+            "op": "append",
+            "entry": {
+              "assertion_id": "a_006",
+              "person_id": "I10",
+              "confidence": "probable",
+              "rationale": "I10 (Gerhard Ferber) is a new stub person created from this death certificate. The certificate records 'Gerhard Ferber' in the father role for Wm. Ferber (I2). This is the sole source establishing Gerhard's identity at this stage; confidence capped at probable pending corroboration from census or birth records.",
+              "match_score": null
+            }
+          },
+          {
+            "section": "person_evidence",
+            "op": "append",
+            "entry": {
+              "assertion_id": "a_006",
+              "person_id": "I2",
+              "confidence": "probable",
+              "rationale": "The father-of-deceased assertion (naming Gerhard Ferber as father) also establishes William Hubert Ferber's (I2) paternal parentage. Confidence is probable rather than confident because the assertion carries indeterminate information quality (unnamed informant on a derivative death certificate) and this is the sole source for this parentage claim so far.",
+              "match_score": null
+            }
+          },
+          {
+            "section": "person_evidence",
+            "op": "append",
+            "entry": {
+              "assertion_id": "a_007",
+              "person_id": "I11",
+              "confidence": "probable",
+              "rationale": "I11 (Eva Ferber) is a new stub person created from this death certificate. The certificate records 'Eva Ferber' in the mother role for Wm. Ferber (I2). 'Ferber' is likely the married name as entered by the record-taker; maiden name unknown. This is the sole source establishing Eva's identity at this stage; confidence capped at probable pending corroboration.",
+              "match_score": null
+            }
+          },
+          {
+            "section": "person_evidence",
+            "op": "append",
+            "entry": {
+              "assertion_id": "a_007",
+              "person_id": "I2",
+              "confidence": "probable",
+              "rationale": "The mother-of-deceased assertion (naming Eva Ferber as mother) also establishes William Hubert Ferber's (I2) maternal parentage. Confidence is probable because the assertion carries indeterminate information quality (unnamed informant on a derivative death certificate) and this is the sole source for this parentage claim so far.",
+              "match_score": null
+            }
+          }
+        ]
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"results\\\": [\\n    {\\n      \\\"section\\\": \\\"person_evidence\\\",\\n      \\\"op\\\": \\\"append\\\",\\n      \\\"entryId\\\": \\\"pe_001\\\"\\n    },\\n    {\\n      \\\"section\\\": \\\"person_evidence\\\",\\n      \\\"op\\\": \\\"append\\\",\\n      \\\"entryId\\\": \\\"pe_002\\\"\\n    },\\n    {\\n      \\\"section\\\": \\\"person_evidence\\\",\\n      \\\"op\\\": \\\"append\\\",\\n      \\\"entryId\\\": \\\"pe_003\\\"\\n    },\\n    {\\n      \\\"section\\\": \\\"person_evidence\\\",\\n      \\\"op\\\": \\\"append\\\",\\n      \\\"entryId..."
+    },
+    {
+      "tool": "Skill",
+      "args": {
+        "skill": "check-warnings",
+        "args": "I2 I10 I11"
+      },
+      "response_summary": "Launching skill: check-warnings"
+    },
+    {
+      "tool": "ToolSearch",
+      "args": {
+        "query": "select:mcp__genealogy__person_warnings",
+        "max_results": 1
+      },
+      "response_summary": "[{\"type\": \"tool_reference\", \"tool_name\": \"mcp__genealogy__person_warnings\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__person_warnings",
+      "args": {
+        "projectPath": "C:\\Users\\User\\AppData\\Local\\Temp\\e2e-ferber-grandparents-wo47ce7l",
+        "personId": "I2"
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"warningCount\\\": 0,\\n  \\\"warnings\\\": []\\n}\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__person_warnings",
+      "args": {
+        "projectPath": "C:\\Users\\User\\AppData\\Local\\Temp\\e2e-ferber-grandparents-wo47ce7l",
+        "personId": "I10"
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"warningCount\\\": 0,\\n  \\\"warnings\\\": []\\n}\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__person_warnings",
+      "args": {
+        "projectPath": "C:\\Users\\User\\AppData\\Local\\Temp\\e2e-ferber-grandparents-wo47ce7l",
+        "personId": "I11"
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"warningCount\\\": 0,\\n  \\\"warnings\\\": []\\n}\"}]"
+    },
+    {
+      "tool": "Skill",
+      "args": {
+        "skill": "search-records",
+        "args": "--autonomous q_001 pli_002"
+      },
+      "response_summary": "Launching skill: search-records"
+    },
+    {
+      "tool": "mcp__genealogy__record_search",
+      "args": {
+        "surname": "Ferber",
+        "givenName": "Gerhard",
+        "residenceYearFrom": 1870,
+        "residenceYearTo": 1870,
+        "residencePlace": "Ohio",
+        "recordType": "census",
+        "projectPath": "C:\\Users\\User\\AppData\\Local\\Temp\\e2e-ferber-grandparents-wo47ce7l"
+      },
+      "response_summary": "<persisted-output>\nOutput too large (70KB). Full output saved to: C:\\Users\\User\\.claude\\projects\\C--Users-User-AppData-Local-Temp-e2e-ferber-grandparents-wo47ce7l\\fda56b31-2dbb-4137-8429-f73104d08a23\\tool-results\\toolu_01J7h1CtLw4wZYWYGcCMKwU2.json\n\nPreview (first 2KB):\n[\n  {\n    \"type\": \"text\",\n    \"text\": \"{\\n  \\\"query\\\": {\\n    \\\"surname\\\": \\\"Ferber\\\",\\n    \\\"givenName\\\": \\\"Gerhard\\\",\\n    \\\"residenceYearFrom\\\": 1870,\\n    \\\"residenceYearTo\\\": 1870,\\n    \\\"residencePlace\\\": \\\"Ohio\\\",\\n    ..."
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "C:\\Users\\User\\.claude\\projects\\C--Users-User-AppData-Local-Temp-e2e-ferber-grandparents-wo47ce7l\\fda56b31-2dbb-4137-8429-f73104d08a23\\tool-results\\toolu_01J7h1CtLw4wZYWYGcCMKwU2.json"
+      },
+      "response_summary": "1\t[\n2\t  {\n3\t    \"type\": \"text\",\n4\t    \"text\": \"{\\n  \\\"query\\\": {\\n    \\\"surname\\\": \\\"Ferber\\\",\\n    \\\"givenName\\\": \\\"Gerhard\\\",\\n    \\\"residenceYearFrom\\\": 1870,\\n    \\\"residenceYearTo\\\": 1870,\\n    \\\"residencePlace\\\": \\\"Ohio\\\",\\n    \\\"recordType\\\": \\\"census\\\",\\n    \\\"projectPath\\\": \\\"C:\\\\\\\\Users\\\\\\\\User\\\\\\\\AppData\\\\\\\\Local\\\\\\\\Temp\\\\\\\\e2e-ferber-grandparents-wo47ce7l\\\"\\n  },\\n  \\\"totalMatches\\\": 15,\\n  \\\"paginationCappedAt\\\": 4999,\\n  \\\"returned\\\": 15,\\n  \\\"offset\\\": 0,\\n  \\\"hasMore\\\": false,..."
+    },
+    {
+      "tool": "ToolSearch",
+      "args": {
+        "query": "select:mcp__genealogy__research_log_append,mcp__genealogy__research_append,mcp__genealogy__record_search",
+        "max_results": 3
+      },
+      "response_summary": "[{\"type\": \"tool_reference\", \"tool_name\": \"mcp__genealogy__research_log_append\"}, {\"type\": \"tool_reference\", \"tool_name\": \"mcp__genealogy__research_append\"}, {\"type\": \"tool_reference\", \"tool_name\": \"mcp__genealogy__record_search\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__research_log_append",
+      "args": {
+        "projectPath": "C:\\Users\\User\\AppData\\Local\\Temp\\e2e-ferber-grandparents-wo47ce7l",
+        "tool": "record_search",
+        "planItemId": "pli_002",
+        "query": {
+          "surname": "Ferber",
+          "givenName": "Gerhard",
+          "residenceYearFrom": 1870,
+          "residenceYearTo": 1870,
+          "residencePlace": "Ohio",
+          "recordType": "census"
+        },
+        "outcome": "partial",
+        "resultsExamined": 15,
+        "resultsAvailable": 15,
+        "stagedResultsRef": "results/.staging/5e275375-0fc0-49b2-b46f-351c6f3f75f3.json",
+        "notes": "Collection mismatch: top 3 results are city/business directory entries (collection 3754697) for Gerhard Ferber in Cincinnati 1870 \u2014 confirms presence but not census records. Remaining 12 results are 1870 Federal Census entries for Faber/Fieber/Ferbert variants in Putnam and Montgomery counties, not Hamilton County. No 1870 Federal Census record for Gerhard Ferber in Hamilton County found. Will retry with collectionId=1438024 to target 1870 census specifically."
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"logId\\\": \\\"log_002\\\",\\n  \\\"performed\\\": \\\"2026-07-07T08:03:35.588Z\\\",\\n  \\\"resultsRef\\\": \\\"results/log_002.json\\\",\\n  \\\"returnedCount\\\": 15,\\n  \\\"filesWritten\\\": [\\n    \\\"research.json\\\",\\n    \\\"results/log_002.json\\\"\\n  ],\\n  \\\"validation\\\": {\\n    \\\"valid\\\": true,\\n    \\\"warnings\\\": []\\n  }\\n}\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__research_append",
+      "args": {
+        "projectPath": "C:\\Users\\User\\AppData\\Local\\Temp\\e2e-ferber-grandparents-wo47ce7l",
+        "section": "plan_items",
+        "op": "update",
+        "planId": "pl_001",
+        "entryId": "pli_002",
+        "fields": {
+          "status": "in_progress"
+        }
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"section\\\": \\\"plan_items\\\",\\n  \\\"op\\\": \\\"update\\\",\\n  \\\"entryId\\\": \\\"pli_002\\\",\\n  \\\"filesWritten\\\": [\\n    \\\"research.json\\\"\\n  ],\\n  \\\"validation\\\": {\\n    \\\"valid\\\": true,\\n    \\\"warnings\\\": []\\n  }\\n}\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__record_search",
+      "args": {
+        "surname": "Ferber",
+        "givenName": "Gerhard",
+        "residenceYearFrom": 1870,
+        "residenceYearTo": 1870,
+        "residencePlace": "Ohio",
+        "collectionId": "1438024",
+        "projectPath": "C:\\Users\\User\\AppData\\Local\\Temp\\e2e-ferber-grandparents-wo47ce7l"
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"query\\\": {\\n    \\\"surname\\\": \\\"Ferber\\\",\\n    \\\"givenName\\\": \\\"Gerhard\\\",\\n    \\\"residenceYearFrom\\\": 1870,\\n    \\\"residenceYearTo\\\": 1870,\\n    \\\"residencePlace\\\": \\\"Ohio\\\",\\n    \\\"collectionId\\\": \\\"1438024\\\",\\n    \\\"projectPath\\\": \\\"C:\\\\\\\\Users\\\\\\\\User\\\\\\\\AppData\\\\\\\\Local\\\\\\\\Temp\\\\\\\\e2e-ferber-grandparents-wo47ce7l\\\"\\n  },\\n  \\\"totalMatches\\\": 4,\\n  \\\"paginationCappedAt\\\": 4999,\\n  \\\"returned\\\": 4,\\n  \\\"offset\\\": 0,\\n  \\\"hasMore\\\": false,\\n  \\\"results\\\": [\\..."
+    },
+    {
+      "tool": "mcp__genealogy__research_log_append",
+      "args": {
+        "projectPath": "C:\\Users\\User\\AppData\\Local\\Temp\\e2e-ferber-grandparents-wo47ce7l",
+        "tool": "record_search",
+        "planItemId": "pli_002",
+        "query": {
+          "surname": "Ferber",
+          "givenName": "Gerhard",
+          "residenceYearFrom": 1870,
+          "residenceYearTo": 1870,
+          "residencePlace": "Ohio",
+          "collectionId": "1438024"
+        },
+        "outcome": "negative",
+        "resultsExamined": 4,
+        "resultsAvailable": 4,
+        "stagedResultsRef": "results/.staging/c905656d-06e2-47b7-94cf-bc7cdecab688.json",
+        "notes": "Scoped retry with collectionId=1438024 (1870 Federal Census). Only 4 results returned, all for \"Faber\" variants in Putnam, Montgomery, Carroll, and Shelby counties \u2014 none in Hamilton County (Cincinnati). No index entry for Gerhard Ferber in the 1870 census. Will try surname-only search in Hamilton County to locate the household regardless of given name transcription."
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"logId\\\": \\\"log_003\\\",\\n  \\\"performed\\\": \\\"2026-07-07T08:04:02.250Z\\\",\\n  \\\"resultsRef\\\": \\\"results/log_003.json\\\",\\n  \\\"returnedCount\\\": 4,\\n  \\\"filesWritten\\\": [\\n    \\\"research.json\\\",\\n    \\\"results/log_003.json\\\"\\n  ],\\n  \\\"validation\\\": {\\n    \\\"valid\\\": true,\\n    \\\"warnings\\\": []\\n  }\\n}\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__record_search",
+      "args": {
+        "surname": "Ferber",
+        "residenceYearFrom": 1870,
+        "residenceYearTo": 1870,
+        "residencePlace": "Hamilton, Ohio",
+        "collectionId": "1438024",
+        "projectPath": "C:\\Users\\User\\AppData\\Local\\Temp\\e2e-ferber-grandparents-wo47ce7l"
+      },
+      "response_summary": "Error: result (174,281 characters) exceeds maximum allowed tokens. Output has been saved to C:\\Users\\User\\.claude\\projects\\C--Users-User-AppData-Local-Temp-e2e-ferber-grandparents-wo47ce7l\\fda56b31-2dbb-4137-8429-f73104d08a23\\tool-results\\mcp-genealogy-record_search-1783411445748.txt.\nFormat: JSON array with schema: [{type: string, text: string}]\nUse offset and limit parameters to read specific portions of the file, search within it for specific content, and jq to make structured queries.\nREQ..."
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "C:\\Users\\User\\.claude\\projects\\C--Users-User-AppData-Local-Temp-e2e-ferber-grandparents-wo47ce7l\\fda56b31-2dbb-4137-8429-f73104d08a23\\tool-results\\mcp-genealogy-record_search-1783411445748.txt",
+        "limit": 150
+      },
+      "response_summary": "File content (55477 tokens) exceeds maximum allowed tokens (25000). Use offset and limit parameters to read specific portions of the file, or search for specific content instead of reading the whole file."
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "C:\\Users\\User\\.claude\\projects\\C--Users-User-AppData-Local-Temp-e2e-ferber-grandparents-wo47ce7l\\fda56b31-2dbb-4137-8429-f73104d08a23\\tool-results\\mcp-genealogy-record_search-1783411445748.txt",
+        "limit": 100,
+        "offset": 0
+      },
+      "response_summary": "File content (55477 tokens) exceeds maximum allowed tokens (25000). Use offset and limit parameters to read specific portions of the file, or search for specific content instead of reading the whole file."
+    },
+    {
+      "tool": "Bash",
+      "args": {
+        "command": "python3 -c \"\nimport json\nwith open(r'C:\\Users\\User\\.claude\\projects\\C--Users-User-AppData-Local-Temp-e2e-ferber-grandparents-wo47ce7l\\fda56b31-2dbb-4137-8429-f73104d08a23\\tool-results\\mcp-genealogy-record_search-1783411445748.txt', 'r', encoding='utf-8') as f:\n    data = json.load(f)\n\n# Parse the content\ncontent = json.loads(data[0]['text'])\nprint('totalMatches:', content.get('totalMatches'))\nprint('returned:', content.get('returned'))\nprint('staged resultsRef:', content.get('staged', {}).get('resultsRef'))\nprint()\nfor i, r in enumerate(content.get('results', [])[:10]):\n    print(f'Result {i+1}: {r.get(\\\"personName\\\")}, score={r.get(\\\"score\\\"):.2f}, confidence={r.get(\\\"confidence\\\")}')\n    print(f'  Collection: {r.get(\\\"collectionTitle\\\")}')\n    print(f'  Sex: {r.get(\\\"sex\\\")}, Birth: {r.get(\\\"birthDate\\\")} @ {r.get(\\\"birthPlace\\\")}')\n    events = r.get('events', [])\n    for e in events[:3]:\n        print(f'  Event: {e.get(\\\"type\\\")} {e.get(\\\"date\\\",\\\"\\\")} @ {e.get(\\\"place\\\",\\\"\\\")}')\n    print()\n\"\n",
+        "description": "Parse 1870 census Hamilton County search results"
+      },
+      "response_summary": "Permission to use Bash has been denied because Claude Code is running in don't ask mode. IMPORTANT: You *may* attempt to accomplish this action using other tools that might naturally be used to accomplish this goal, e.g. using head instead of cat. But you *should not* attempt to work around this denial in malicious ways, e.g. do not use your ability to run tests to execute non-test actions. You should only try to work around this restriction in reasonable ways that do not attempt to bypass th..."
+    },
+    {
+      "tool": "Grep",
+      "args": {
+        "pattern": "\"personName\"|\"score\"|\"collectionTitle\"|\"totalMatches\"|\"returned\"|\"resultsRef\"",
+        "path": "C:\\Users\\User\\.claude\\projects\\C--Users-User-AppData-Local-Temp-e2e-ferber-grandparents-wo47ce7l\\fda56b31-2dbb-4137-8429-f73104d08a23\\tool-results\\mcp-genealogy-record_search-1783411445748.txt",
+        "output_mode": "content",
+        "head_limit": 60
+      },
+      "response_summary": "No matches found"
+    },
+    {
+      "tool": "Grep",
+      "args": {
+        "pattern": "personName",
+        "path": "C:\\Users\\User\\.claude\\projects\\C--Users-User-AppData-Local-Temp-e2e-ferber-grandparents-wo47ce7l\\fda56b31-2dbb-4137-8429-f73104d08a23\\tool-results\\mcp-genealogy-record_search-1783411445748.txt",
+        "output_mode": "content",
+        "head_limit": 30
+      },
+      "response_summary": "4:[Omitted long matching line]"
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "C:\\Users\\User\\.claude\\projects\\C--Users-User-AppData-Local-Temp-e2e-ferber-grandparents-wo47ce7l\\fda56b31-2dbb-4137-8429-f73104d08a23\\tool-results\\mcp-genealogy-record_search-1783411445748.txt",
+        "limit": 30,
+        "offset": 0
+      },
+      "response_summary": "File content (55477 tokens) exceeds maximum allowed tokens (25000). Use offset and limit parameters to read specific portions of the file, or search for specific content instead of reading the whole file."
+    },
+    {
+      "tool": "Glob",
+      "args": {
+        "pattern": "results/.staging/*.json",
+        "path": "C:\\Users\\User\\AppData\\Local\\Temp\\e2e-ferber-grandparents-wo47ce7l"
+      },
+      "response_summary": "results\\.staging\\a5de0717-3850-4bd1-9050-81f24832a5be.json"
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "C:\\Users\\User\\AppData\\Local\\Temp\\e2e-ferber-grandparents-wo47ce7l\\results\\.staging\\a5de0717-3850-4bd1-9050-81f24832a5be.json",
+        "limit": 100
+      },
+      "response_summary": "1\t{\n2\t  \"tool\": \"record_search\",\n3\t  \"retrieved\": \"2026-07-07T08:04:05.277Z\",\n4\t  \"returned_count\": 20,\n5\t  \"payload\": {\n6\t    \"query\": {\n7\t      \"surname\": \"Ferber\",\n8\t      \"residenceYearFrom\": 1870,\n9\t      \"residenceYearTo\": 1870,\n10\t      \"residencePlace\": \"Hamilton, Ohio\",\n11\t      \"collectionId\": \"1438024\",\n12\t      \"projectPath\": \"C:\\\\Users\\\\User\\\\AppData\\\\Local\\\\Temp\\\\e2e-ferber-grandparents-wo47ce7l\"\n13\t    },\n14\t    \"totalMatches\": 86,\n15\t    \"paginationCappedAt\": 4999,\n16\t    \"ret..."
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "C:\\Users\\User\\AppData\\Local\\Temp\\e2e-ferber-grandparents-wo47ce7l\\results\\.staging\\a5de0717-3850-4bd1-9050-81f24832a5be.json",
+        "limit": 100,
+        "offset": 100
+      },
+      "response_summary": "100\t                  \"standard_date\": \"1833\",\n101\t                  \"place\": \"Baden\",\n102\t                  \"standard_place\": \"Baden, Germany\"\n103\t                },\n104\t                {\n105\t                  \"type\": \"Census\",\n106\t                  \"primary\": true,\n107\t                  \"date\": \"1870\",\n108\t                  \"standard_date\": \"1870\",\n109\t                  \"place\": \"Hamilton, Butler, Ohio, United States\",\n110\t                  \"standard_place\": \"Hamilton, Butler, Ohio, United ..."
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "C:\\Users\\User\\AppData\\Local\\Temp\\e2e-ferber-grandparents-wo47ce7l\\results\\.staging\\a5de0717-3850-4bd1-9050-81f24832a5be.json",
+        "limit": 100,
+        "offset": 200
+      },
+      "response_summary": "200\t            {\n201\t              \"id\": \"sd_da1\",\n202\t              \"url\": \"https://www.familysearch.org/ark:/61903/3:1:S3HY-63NQ-QT4\"\n203\t            },\n204\t            {\n205\t              \"id\": \"src_p_p_331559255\",\n206\t              \"url\": \"#p_331559255\"\n207\t            }\n208\t          ],\n209\t          \"places\": [\n210\t            {\n211\t              \"id\": \"11971870\",\n212\t              \"name\": \"Baden, Germany\",\n213\t              \"latitude\": 48.2355,\n214\t              \"longitude\": 8.0738\n21..."
+    },
+    {
+      "tool": "mcp__genealogy__research_log_append",
+      "args": {
+        "projectPath": "C:\\Users\\User\\AppData\\Local\\Temp\\e2e-ferber-grandparents-wo47ce7l",
+        "tool": "record_search",
+        "planItemId": "pli_002",
+        "query": {
+          "surname": "Ferber",
+          "residenceYearFrom": 1870,
+          "residenceYearTo": 1870,
+          "residencePlace": "Hamilton, Ohio",
+          "collectionId": "1438024"
+        },
+        "outcome": "partial",
+        "resultsExamined": 20,
+        "resultsAvailable": 86,
+        "stagedResultsRef": "results/.staging/a5de0717-3850-4bd1-9050-81f24832a5be.json",
+        "notes": "Place disambiguation error: \"Hamilton, Ohio\" resolved to Hamilton City, Butler County \u2014 not Hamilton County (Cincinnati). All 20 examined results are from Hamilton, Butler County. Retrying with \"Cincinnati\" as residence place to target Hamilton County."
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"logId\\\": \\\"log_004\\\",\\n  \\\"performed\\\": \\\"2026-07-07T08:05:17.977Z\\\",\\n  \\\"resultsRef\\\": \\\"results/log_004.json\\\",\\n  \\\"returnedCount\\\": 20,\\n  \\\"filesWritten\\\": [\\n    \\\"research.json\\\",\\n    \\\"results/log_004.json\\\"\\n  ],\\n  \\\"validation\\\": {\\n    \\\"valid\\\": true,\\n    \\\"warnings\\\": []\\n  }\\n}\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__record_search",
+      "args": {
+        "surname": "Ferber",
+        "residenceYearFrom": 1870,
+        "residenceYearTo": 1870,
+        "residencePlace": "Cincinnati, Ohio",
+        "collectionId": "1438024",
+        "projectPath": "C:\\Users\\User\\AppData\\Local\\Temp\\e2e-ferber-grandparents-wo47ce7l"
+      },
+      "response_summary": "Error: result (167,686 characters) exceeds maximum allowed tokens. Output has been saved to C:\\Users\\User\\.claude\\projects\\C--Users-User-AppData-Local-Temp-e2e-ferber-grandparents-wo47ce7l\\fda56b31-2dbb-4137-8429-f73104d08a23\\tool-results\\mcp-genealogy-record_search-1783411523777.txt.\nFormat: JSON array with schema: [{type: string, text: string}]\nUse offset and limit parameters to read specific portions of the file, search within it for specific content, and jq to make structured queries.\nREQ..."
+    },
+    {
+      "tool": "Glob",
+      "args": {
+        "pattern": "results/.staging/*.json",
+        "path": "C:\\Users\\User\\AppData\\Local\\Temp\\e2e-ferber-grandparents-wo47ce7l"
+      },
+      "response_summary": "results\\.staging\\7632f6f9-ac03-467b-a83d-af35a97c62f3.json"
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "C:\\Users\\User\\AppData\\Local\\Temp\\e2e-ferber-grandparents-wo47ce7l\\results\\.staging\\7632f6f9-ac03-467b-a83d-af35a97c62f3.json",
+        "limit": 50,
+        "offset": 0
+      },
+      "response_summary": "0\t{\n1\t  \"tool\": \"record_search\",\n2\t  \"retrieved\": \"2026-07-07T08:05:23.388Z\",\n3\t  \"returned_count\": 20,\n4\t  \"payload\": {\n5\t    \"query\": {\n6\t      \"surname\": \"Ferber\",\n7\t      \"residenceYearFrom\": 1870,\n8\t      \"residenceYearTo\": 1870,\n9\t      \"residencePlace\": \"Cincinnati, Ohio\",\n10\t      \"collectionId\": \"1438024\",\n11\t      \"projectPath\": \"C:\\\\Users\\\\User\\\\AppData\\\\Local\\\\Temp\\\\e2e-ferber-grandparents-wo47ce7l\"\n12\t    },\n13\t    \"totalMatches\": 69,\n14\t    \"paginationCappedAt\": 4999,\n15\t    \"re..."
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "C:\\Users\\User\\AppData\\Local\\Temp\\e2e-ferber-grandparents-wo47ce7l\\results\\.staging\\7632f6f9-ac03-467b-a83d-af35a97c62f3.json",
+        "limit": 50,
+        "offset": 50
+      },
+      "response_summary": "50\t              \"gender\": \"Female\",\n51\t              \"names\": [\n52\t                {\n53\t                  \"type\": \"BirthName\",\n54\t                  \"given\": \"Mary\",\n55\t                  \"surname\": \"Duc Ferber\"\n56\t                }\n57\t              ],\n58\t              \"facts\": [\n59\t                {\n60\t                  \"type\": \"Race\",\n61\t                  \"value\": \"White\"\n62\t                },\n63\t                {\n64\t                  \"type\": \"Birth\",\n65\t                  \"date\": \"1791\",\n66\t..."
+    },
+    {
+      "tool": "Grep",
+      "args": {
+        "pattern": "personName|score|place.*Cincinnati|place.*Hamilton.*Ohio",
+        "path": "C:\\Users\\User\\AppData\\Local\\Temp\\e2e-ferber-grandparents-wo47ce7l\\results\\.staging\\7632f6f9-ac03-467b-a83d-af35a97c62f3.json",
+        "output_mode": "content",
+        "head_limit": 100
+      },
+      "response_summary": "30:            \"place\": \"Colerain Township, Hamilton, Ohio, United States\"\n34:        \"personName\": \"Mary Duc Ferber\",\n35:        \"score\": 3.3218,\n75:                  \"place\": \"Colerain Township, Hamilton, Ohio, United States\",\n76:                  \"standard_place\": \"Colerain Township, Hamilton, Ohio, United States\"\n102:                  \"place\": \"Colerain Township, Hamilton, Ohio, United States\",\n103:                  \"standard_place\": \"Colerain Township, Hamilton, Ohio, United States\"\n172:..."
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "C:\\Users\\User\\AppData\\Local\\Temp\\e2e-ferber-grandparents-wo47ce7l\\results\\.staging\\7632f6f9-ac03-467b-a83d-af35a97c62f3.json",
+        "limit": 200,
+        "offset": 1340
+      },
+      "response_summary": "1340\t        \"recordId\": \"ark:/61903/1:1:M62Z-87S\",\n1341\t        \"events\": [\n1342\t          {\n1343\t            \"type\": \"Census\",\n1344\t            \"date\": \"1870\",\n1345\t            \"place\": \"Cincinnati, Hamilton, Ohio, United States\"\n1346\t          },\n1347\t          {\n1348\t            \"type\": \"Race\",\n1349\t            \"value\": \"White\"\n1350\t          }\n1351\t        ],\n1352\t        \"treeMatches\": [\n1353\t          {\n1354\t            \"treePersonId\": \"GCD9-9X1\",\n1355\t            \"stars\": 4\n1356\t     ..."
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "C:\\Users\\User\\AppData\\Local\\Temp\\e2e-ferber-grandparents-wo47ce7l\\results\\.staging\\7632f6f9-ac03-467b-a83d-af35a97c62f3.json",
+        "limit": 150,
+        "offset": 1540
+      },
+      "response_summary": "1540\t                {\n1541\t                  \"ref\": \"sd_da1\"\n1542\t                }\n1543\t              ]\n1544\t            },\n1545\t            {\n1546\t              \"id\": \"p_332380057\",\n1547\t              \"ark\": \"ark:/61903/1:1:M62Z-874\",\n1548\t              \"gender\": \"Female\",\n1549\t              \"names\": [\n1550\t                {\n1551\t                  \"type\": \"BirthName\",\n1552\t                  \"surname\": \"Faerber\",\n1553\t                  \"given\": \"Margarette\"\n1554\t                }\n1555\t     ..."
+    },
+    {
+      "tool": "mcp__genealogy__research_log_append",
+      "args": {
+        "projectPath": "C:\\Users\\User\\AppData\\Local\\Temp\\e2e-ferber-grandparents-wo47ce7l",
+        "tool": "record_search",
+        "planItemId": "pli_002",
+        "query": {
+          "surname": "Ferber",
+          "residenceYearFrom": 1870,
+          "residenceYearTo": 1870,
+          "residencePlace": "Cincinnati, Ohio",
+          "collectionId": "1438024"
+        },
+        "outcome": "positive",
+        "resultsExamined": 20,
+        "resultsAvailable": 69,
+        "stagedResultsRef": "results/.staging/7632f6f9-ac03-467b-a83d-af35a97c62f3.json",
+        "notes": "Strong match: Household of Gerhardt Faerber (I10, born ~1822 Prussia) + Eva Faerber (I11, born ~1832 Bavaria) at Cincinnati, Hamilton, Ohio. Household also contains William Faerber (I2, born 1870 Ohio) plus older children Gustave (~1857), Jacob (~1860), Charles (~1865), Margarette (~1867). Primary person ARK: ark:/61903/1:1:M62Z-87S; household record ARK: ark:/61903/1:2:MHXJ-Y4S. Will proceed to record_read for full extraction."
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"logId\\\": \\\"log_005\\\",\\n  \\\"performed\\\": \\\"2026-07-07T08:06:31.273Z\\\",\\n  \\\"resultsRef\\\": \\\"results/log_005.json\\\",\\n  \\\"returnedCount\\\": 20,\\n  \\\"filesWritten\\\": [\\n    \\\"research.json\\\",\\n    \\\"results/log_005.json\\\"\\n  ],\\n  \\\"validation\\\": {\\n    \\\"valid\\\": true,\\n    \\\"warnings\\\": []\\n  }\\n}\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__record_read",
+      "args": {
+        "recordId": "https://www.familysearch.org/ark:/61903/1:1:M62Z-87S"
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"persons\\\": [\\n    {\\n      \\\"id\\\": \\\"p_332380052\\\",\\n      \\\"ark\\\": \\\"ark:/61903/1:1:M62Z-87S\\\",\\n      \\\"gender\\\": \\\"Male\\\",\\n      \\\"names\\\": [\\n        {\\n          \\\"id\\\": \\\"8c3985f2-a1b9-4e51-9e1f-f3109b560d2e\\\",\\n          \\\"type\\\": \\\"BirthName\\\",\\n          \\\"given\\\": \\\"Gerhardt\\\",\\n          \\\"surname\\\": \\\"Faerber\\\"\\n        }\\n      ],\\n      \\\"facts\\\": [\\n        {\\n          \\\"id\\\": \\\"e93678fb-2a88-4994-92d2-d57837c76f89\\\",\\n          \\\"type\\\": \\\"C..."
+    },
+    {
+      "tool": "mcp__genealogy__research_append",
+      "args": {
+        "projectPath": "C:\\Users\\User\\AppData\\Local\\Temp\\e2e-ferber-grandparents-wo47ce7l",
+        "ops": [
+          {
+            "section": "sources",
+            "op": "append",
+            "entry": {
+              "gedcomx_source_description_id": "S5",
+              "citation": "\"United States, Census, 1870\", FamilySearch (https://www.familysearch.org/ark:/61903/1:1:M62Z-87S : Mon Oct 13 21:07:52 UTC 2025), Entry for Gerhardt Faerber and Eva Faerber, 1870.",
+              "citation_detail": {
+                "who": "Gerhardt Faerber household",
+                "what": "United States, Census, 1870",
+                "when_created": "1870",
+                "when_accessed": "2026-07-07",
+                "where": "FamilySearch (familysearch.org)",
+                "where_within": "Cincinnati, Hamilton, Ohio enumeration district"
+              },
+              "source_classification": "original",
+              "repository": "FamilySearch",
+              "access_date": "2026-07-07",
+              "url": "https://www.familysearch.org/ark:/61903/1:2:MHXJ-Y4S",
+              "log_entry_id": "log_005"
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "source_id": "src_002",
+              "record_id": "https://www.familysearch.org/ark:/61903/1:2:MHXJ-Y4S",
+              "record_role": "head_of_household",
+              "fact_type": "name",
+              "value": "Gerhardt Faerber",
+              "structured_value": {
+                "given": "Gerhardt",
+                "surname": "Faerber"
+              },
+              "information_quality": "indeterminate",
+              "informant": "unknown household member",
+              "informant_proximity": "household_member",
+              "informant_bias_notes": "1870 U.S. census; enumerator did not record who answered; likely Gerhardt himself or Eva",
+              "evidence_type": "direct",
+              "extracted_for_question_ids": [
+                "q_001"
+              ],
+              "log_entry_id": "log_005",
+              "record_persona_id": null
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "source_id": "src_002",
+              "record_id": "https://www.familysearch.org/ark:/61903/1:2:MHXJ-Y4S",
+              "record_role": "head_of_household",
+              "fact_type": "birth",
+              "value": "born about 1822 (computed from census age)",
+              "date": "1822",
+              "date_certainty": "estimated",
+              "information_quality": "indeterminate",
+              "informant": "unknown household member",
+              "informant_proximity": "household_member",
+              "informant_bias_notes": "Age computed from 1870 census age column; respondent not recorded",
+              "evidence_type": "indirect",
+              "extracted_for_question_ids": [],
+              "log_entry_id": "log_005",
+              "record_persona_id": null
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "source_id": "src_002",
+              "record_id": "https://www.familysearch.org/ark:/61903/1:2:MHXJ-Y4S",
+              "record_role": "head_of_household",
+              "fact_type": "birth",
+              "value": "born in Prussia",
+              "place": "Prussia",
+              "standard_place": "Prussia, Germany",
+              "information_quality": "indeterminate",
+              "informant": "unknown household member",
+              "informant_proximity": "household_member",
+              "informant_bias_notes": "Birthplace stated in census; if Gerhardt responded, proximity would be self; respondent not recorded",
+              "evidence_type": "direct",
+              "extracted_for_question_ids": [],
+              "log_entry_id": "log_005",
+              "record_persona_id": null
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "source_id": "src_002",
+              "record_id": "https://www.familysearch.org/ark:/61903/1:2:MHXJ-Y4S",
+              "record_role": "head_of_household",
+              "fact_type": "residence",
+              "value": "Cincinnati, Hamilton, Ohio, 1870",
+              "date": "1870",
+              "date_certainty": "approximate",
+              "place": "Cincinnati, Hamilton, Ohio, United States",
+              "standard_place": "Cincinnati, Hamilton, Ohio, United States",
+              "information_quality": "indeterminate",
+              "informant": "census enumerator",
+              "informant_proximity": "witness",
+              "evidence_type": "direct",
+              "extracted_for_question_ids": [
+                "q_001"
+              ],
+              "log_entry_id": "log_005",
+              "record_persona_id": null
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "source_id": "src_002",
+              "record_id": "https://www.familysearch.org/ark:/61903/1:2:MHXJ-Y4S",
+              "record_role": "wife",
+              "fact_type": "name",
+              "value": "Eva Faerber",
+              "structured_value": {
+                "given": "Eva",
+                "surname": "Faerber"
+              },
+              "information_quality": "indeterminate",
+              "informant": "unknown household member",
+              "informant_proximity": "household_member",
+              "informant_bias_notes": "1870 U.S. census; surname recorded as Faerber (husband's surname); maiden name unknown",
+              "evidence_type": "direct",
+              "extracted_for_question_ids": [
+                "q_001"
+              ],
+              "log_entry_id": "log_005",
+              "record_persona_id": null
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "source_id": "src_002",
+              "record_id": "https://www.familysearch.org/ark:/61903/1:2:MHXJ-Y4S",
+              "record_role": "wife",
+              "fact_type": "birth",
+              "value": "born about 1832 (computed from census age)",
+              "date": "1832",
+              "date_certainty": "estimated",
+              "information_quality": "indeterminate",
+              "informant": "unknown household member",
+              "informant_proximity": "household_member",
+              "evidence_type": "indirect",
+              "extracted_for_question_ids": [],
+              "log_entry_id": "log_005",
+              "record_persona_id": null
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "source_id": "src_002",
+              "record_id": "https://www.familysearch.org/ark:/61903/1:2:MHXJ-Y4S",
+              "record_role": "wife",
+              "fact_type": "birth",
+              "value": "born in Bavaria",
+              "place": "Bavaria",
+              "standard_place": "Bavaria, Germany",
+              "information_quality": "indeterminate",
+              "informant": "unknown household member",
+              "informant_proximity": "household_member",
+              "informant_bias_notes": "Birthplace stated in census; if Eva responded, proximity would be self; respondent not recorded",
+              "evidence_type": "direct",
+              "extracted_for_question_ids": [],
+              "log_entry_id": "log_005",
+              "record_persona_id": null
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "source_id": "src_002",
+              "record_id": "https://www.familysearch.org/ark:/61903/1:2:MHXJ-Y4S",
+              "record_role": "wife",
+              "fact_type": "residence",
+              "value": "Cincinnati, Hamilton, Ohio, 1870",
+              "date": "1870",
+              "date_certainty": "approximate",
+              "place": "Cincinnati, Hamilton, Ohio, United States",
+              "standard_place": "Cincinnati, Hamilton, Ohio, United States",
+              "information_quality": "indeterminate",
+              "informant": "census enumerator",
+              "informant_proximity": "witness",
+              "evidence_type": "direct",
+              "extracted_for_question_ids": [
+                "q_001"
+              ],
+              "log_entry_id": "log_005",
+              "record_persona_id": null
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "source_id": "src_002",
+              "record_id": "https://www.familysearch.org/ark:/61903/1:2:MHXJ-Y4S",
+              "record_role": "wife",
+              "fact_type": "relationship",
+              "value": "Listed second in household after Gerhardt Faerber (wife-position; 1870 census has no relationship column \u2014 inferred from household position)",
+              "structured_value": {
+                "relationship_type": "spouse_inferred",
+                "related_person_role": "head_of_household"
+              },
+              "information_quality": "indeterminate",
+              "informant": "census enumerator",
+              "informant_proximity": "witness",
+              "evidence_type": "indirect",
+              "extracted_for_question_ids": [
+                "q_001"
+              ],
+              "log_entry_id": "log_005",
+              "record_persona_id": null
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "source_id": "src_002",
+              "record_id": "https://www.familysearch.org/ark:/61903/1:2:MHXJ-Y4S",
+              "record_role": "child_5",
+              "fact_type": "name",
+              "value": "William Faerber",
+              "structured_value": {
+                "given": "William",
+                "surname": "Faerber"
+              },
+              "information_quality": "indeterminate",
+              "informant": "unknown household member",
+              "informant_proximity": "household_member",
+              "evidence_type": "direct",
+              "extracted_for_question_ids": [
+                "q_001"
+              ],
+              "log_entry_id": "log_005",
+              "record_persona_id": null
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "source_id": "src_002",
+              "record_id": "https://www.familysearch.org/ark:/61903/1:2:MHXJ-Y4S",
+              "record_role": "child_5",
+              "fact_type": "birth",
+              "value": "born 1870, Ohio (census records 1870; other sources give December 1869)",
+              "date": "1870",
+              "date_certainty": "estimated",
+              "place": "Ohio",
+              "standard_place": "Ohio, United States",
+              "information_quality": "indeterminate",
+              "informant": "unknown household member",
+              "informant_proximity": "household_member",
+              "informant_bias_notes": "Census (June 1870) records birth year as 1870 for this infant; other sources give December 1869 \u2014 minor discrepancy likely from rounding age under 1 year",
+              "evidence_type": "direct",
+              "extracted_for_question_ids": [
+                "q_001"
+              ],
+              "log_entry_id": "log_005",
+              "record_persona_id": null
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "source_id": "src_002",
+              "record_id": "https://www.familysearch.org/ark:/61903/1:2:MHXJ-Y4S",
+              "record_role": "child_5",
+              "fact_type": "residence",
+              "value": "Cincinnati, Hamilton, Ohio, 1870",
+              "date": "1870",
+              "date_certainty": "approximate",
+              "place": "Cincinnati, Hamilton, Ohio, United States",
+              "standard_place": "Cincinnati, Hamilton, Ohio, United States",
+              "information_quality": "indeterminate",
+              "informant": "census enumerator",
+              "informant_proximity": "witness",
+              "evidence_type": "direct",
+              "extracted_for_question_ids": [
+                "q_001"
+              ],
+              "log_entry_id": "log_005",
+              "record_persona_id": null
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "source_id": "src_002",
+              "record_id": "https://www.familysearch.org/ark:/61903/1:2:MHXJ-Y4S",
+              "record_role": "child_5",
+              "fact_type": "relationship",
+              "value": "Listed as youngest child-position in household of Gerhardt Faerber (1870 census; relationship to head inferred from position \u2014 no relationship column in 1870)",
+              "structured_value": {
+                "relationship_type": "child_inferred",
+                "related_person_role": "head_of_household"
+              },
+              "information_quality": "indeterminate",
+              "informant": "census enumerator",
+              "informant_proximity": "witness",
+              "evidence_type": "indirect",
+              "extracted_for_question_ids": [
+                "q_001"
+              ],
+              "log_entry_id": "log_005",
+              "record_persona_id": null
+            }
+          }
+        ]
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": false,\\n  \\\"errors\\\": [\\n    \\\"research.json/sources[1]: gedcomx_source_description_id 'S5' not found in tree.gedcomx.json sources\\\"\\n  ]\\n}\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__tree_edit",
+      "args": {
+        "projectPath": "C:\\Users\\User\\AppData\\Local\\Temp\\e2e-ferber-grandparents-wo47ce7l",
+        "operation": "add_source_description",
+        "source": {
+          "id": "S5",
+          "title": "United States, Census, 1870",
+          "url": "https://www.familysearch.org/ark:/61903/1:2:MHXJ-Y4S"
+        }
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": false,\\n  \\\"errors\\\": [\\n    \\\"unknown operation 'add_source_description'\\\"\\n  ]\\n}\"}]"
+    }
+  ],
+  "error": "Exception: Claude Code returned an error result: success",
+  "tags": {
+    "question_type": "parents",
+    "era": "1850s",
+    "geography": "US-OH"
+  },
+  "blocked_tree_reads": []
+}

--- a/eval/runlogs/e2e/ferber-grandparents/run-2026-07-07_08-10-37.transcript.md
+++ b/eval/runlogs/e2e/ferber-grandparents/run-2026-07-07_08-10-37.transcript.md
@@ -1,0 +1,598 @@
+# E2e run: ferber-grandparents
+
+## User message
+
+```
+/research --autonomous Who were the grandparents of Charles Hubert Ferber, born 22 June 1891 in Cincinnati, Ohio (the parents of his father William Hubert Ferber and his mother Emma Becker)?
+```
+
+## Trace
+
+**tool_use** `Bash` — args: {"command": "ls \"C:\\Users\\User\\AppData\\Local\\Temp\\e2e-ferber-grandparents-wo47ce7l\\\" 2>/dev/null || echo \"Directory not found\"", "description": "List project directory contents"}
+
+**tool_result:** Permission to use Bash has been denied because Claude Code is running in don't ask mode. IMPORTANT: You *may* attempt to accomplish this action using other tools that might naturally be used to accomplish this goal, e.g. using head instead of cat. But you *should not* attempt to work around this denial in malicious ways, e.g. do not use your ability to run tests to execute non-test actions. You should only try to work around this restriction in reasonable ways that do not attempt to bypass th...
+
+**tool_use** `Read` — args: {"file_path": "C:\\Users\\User\\AppData\\Local\\Temp\\e2e-ferber-grandparents-wo47ce7l\\research.json"}
+
+**tool_result:** 1	{
+2	  "project": {
+3	    "id": "rp_ferber_grandparents",
+4	    "objective": "Who were the grandparents of Charles Hubert Ferber, born 22 June 1891 in Cincinnati, Ohio (the parents of his father William Hubert Ferber and his mother Emma Becker)?",
+5	    "subject_person_ids": ["I1"],
+6	    "status": "active",
+7	    "created": "2026-07-06T00:00:00Z",
+8	    "updated": "2026-07-06T00:00:00Z"
+9	  },
+10	  "researcher_profile": {
+11	    "experience_level": "intermediate",
+12	    "subscriptions": []...
+
+**tool_use** `Skill` — args: {"skill": "question-selection", "args": "--autonomous"}
+
+**tool_result:** Launching skill: question-selection
+
+**tool_use** `Read` — args: {"file_path": "C:\\Users\\User\\AppData\\Local\\Temp\\e2e-ferber-grandparents-wo47ce7l\\.claude\\skills\\question-selection\\references\\question-formulation.md"}
+
+**tool_result:** 1	# Research Question Formulation
+2	
+3	Guidance for formulating effective genealogical research questions
+4	that satisfy the GPS standard for planned, purposeful research.
+5	
+6	## Research Objectives vs. Research Questions
+7	
+8	These are distinct concepts that must not be conflated:
+9	
+10	- **Research objective**: The overarching goal of the research effort.
+11	  It describes what you ultimately want to know (e.g., "Identify the
+12	  parents of John Smith born circa 1820 in Greene County, Ohi...
+
+**tool_use** `Read` — args: {"file_path": "C:\\Users\\User\\AppData\\Local\\Temp\\e2e-ferber-grandparents-wo47ce7l\\.claude\\skills\\question-selection\\references\\pedigree-analysis.md"}
+
+**tool_result:** 1	# Pedigree Analysis for Gap Detection
+2	
+3	Guidance for evaluating pedigree data to identify research gaps,
+4	errors, and candidates for new research questions.
+5	
+6	## Purpose
+7	
+8	Pedigree analysis is the process of systematically reviewing the
+9	individuals in a family tree to detect missing information, logical
+10	errors, and inconsistencies. It is a critical first step before
+11	selecting new research questions — it reveals where the gaps are
+12	and which gaps are most significant.
+13	...
+
+**tool_use** `Read` — args: {"file_path": "C:\\Users\\User\\AppData\\Local\\Temp\\e2e-ferber-grandparents-wo47ce7l\\tree.gedcomx.json"}
+
+**tool_result:** 1	{
+2	  "persons": [
+3	    {
+4	      "id": "I1",
+5	      "gender": "Male",
+6	      "names": [
+7	        { "id": "N1", "given": "Charles Hubert", "surname": "Ferber", "preferred": true }
+8	      ],
+9	      "facts": [
+10	        { "id": "F1", "type": "Birth", "date": "22 June 1891", "standard_date": "22 Jun 1891", "place": "Cincinnati, Hamilton, Ohio, United States", "standard_place": "Cincinnati, Hamilton, Ohio, United States", "sources": [{ "ref": "S1", "quality": 1 }] },
+11	        { "id": "...
+
+**tool_use** `ToolSearch` — args: {"query": "select:mcp__genealogy__research_append", "max_results": 1}
+
+**tool_result:** [{"type": "tool_reference", "tool_name": "mcp__genealogy__research_append"}]
+
+**tool_use** `mcp__genealogy__research_append` — args: {"projectPath": "C:\\Users\\User\\AppData\\Local\\Temp\\e2e-ferber-grandparents-wo47ce7l", "section": "questions", "op": "append", "entry": {"question": "Who were the parents of William Hubert Ferber (born December 1869 in Cincinnati, Hamilton County, Ohio; died 11 March 1903 in Cincinnati, Ohio)?", "rationale": "William Hubert Ferber is the father of Charles Hubert Ferber and his parents are one half of the project objective. His 1903 Ohio death certificate, the 1870 and 1880 federal censuse...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"section\": \"questions\",\n  \"op\": \"append\",\n  \"entryId\": \"q_001\",\n  \"filesWritten\": [\n    \"research.json\"\n  ],\n  \"validation\": {\n    \"valid\": true,\n    \"warnings\": []\n  }\n}"}]
+
+**assistant:** **Q_001 written.** Focusing first on the paternal line:
+
+> *"Who were the parents of William Hubert Ferber (born December 1869 in Cincinnati, Hamilton County, Ohio; died 11 March 1903 in Cincinnati, Ohio)?"*
+
+**Rationale:** Half of the project objective. His 1903 Ohio death certificate, plus the 1870 and 1880 census records (which would show him as a child in his parents' household), are all accessible on FamilySearch and are strong starting sources. A second question for Emma Becker's parents will follow once this one is planned.
+
+**Next step:** `research-plan` for q_001.
+
+**tool_use** `Skill` — args: {"skill": "research-plan", "args": "--autonomous q_001"}
+
+**tool_result:** Launching skill: research-plan
+
+**tool_use** `ToolSearch` — args: {"query": "select:mcp__genealogy__place_search,mcp__genealogy__collections_search,mcp__genealogy__external_links_search,mcp__genealogy__volume_search,mcp__genealogy__wiki_search", "max_results": 5}
+
+**tool_result:** [{"type": "tool_reference", "tool_name": "mcp__genealogy__place_search"}, {"type": "tool_reference", "tool_name": "mcp__genealogy__collections_search"}, {"type": "tool_reference", "tool_name": "mcp__genealogy__external_links_search"}, {"type": "tool_reference", "tool_name": "mcp__genealogy__volume_search"}, {"type": "tool_reference", "tool_name": "mcp__genealogy__wiki_search"}]
+
+**tool_use** `mcp__genealogy__place_search` — args: {"placeName": "Hamilton County", "contextName": "Ohio"}
+
+**tool_use** `mcp__genealogy__wiki_search` — args: {"query": "Ohio Hamilton County Cincinnati genealogy records birth death marriage census"}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"results\": [\n    {\n      \"standardPlace\": \"Hamilton, Ohio, United States\",\n      \"type\": \"County\",\n      \"dateRange\": \"+1803/\",\n      \"latitude\": 39.2,\n      \"longitude\": -84.54,\n      \"familysearchUrl\": \"https://www.familysearch.org/en/research/places/?text=Hamilton&focusedId=393203\",\n      \"wikipediaUrl\": \"https://en.wikipedia.org/wiki/Hamilton_County,_Ohio\"\n    },\n    {\n      \"standardPlace\": \"Hamilton, Butler, Ohio, U...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"query\": \"Ohio Hamilton County Cincinnati genealogy records birth death marriage census\",\n  \"total_chunks_searched\": 1240565,\n  \"results\": [\n    {\n      \"rank\": 1,\n      \"relevance_score\": 0.894531,\n      \"chunk_text\": \"# Cincinnati, Hamilton County, Ohio Genealogy  \\n[United States](https://www.familysearch.org/en/wiki/United_States_Genealogy \\\"United States Genealogy\\\")  \\n[Ohio](https://www.familysearch.org/en/wiki/Ohio,_United_Sta...
+
+**assistant:** Now let me check FamilySearch collections for Ohio covering this period:
+
+**tool_use** `mcp__genealogy__collections_search` — args: {"standardPlace": "Hamilton, Ohio, United States", "startYear": 1860, "endYear": 1910}
+
+**tool_use** `mcp__genealogy__external_links_search` — args: {"standardPlace": "Hamilton, Ohio, United States", "startYear": 1860, "endYear": 1910}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"query\": {\n    \"standardPlace\": \"Hamilton, Ohio, United States\",\n    \"startYear\": 1860,\n    \"endYear\": 1910\n  },\n  \"scope\": \"Ohio\",\n  \"totalForPlace\": 60,\n  \"results\": [\n    {\n      \"id\": \"3315268\",\n      \"title\": \"Ohio, Athens County, Deceased Veteran Grave Registration Card File Index, 1819-1936\",\n      \"dateRange\": \"1819-1936\",\n      \"recordCount\": 5588,\n      \"personCount\": 5591,\n      \"imageCount\": 5546,\n ...
+
+**tool_result:** Error: result (322,552 characters) exceeds maximum allowed tokens. Output has been saved to C:\Users\User\.claude\projects\C--Users-User-AppData-Local-Temp-e2e-ferber-grandparents-wo47ce7l\fda56b31-2dbb-4137-8429-f73104d08a23\tool-results\mcp-genealogy-external_links_search-1783410577878.txt.
+Format: JSON array with schema: [{type: string, text: string}]
+Use offset and limit parameters to read specific portions of the file, search within it for specific content, and jq to make structured quer...
+
+**tool_use** `Read` — args: {"file_path": "C:\\Users\\User\\AppData\\Local\\Temp\\e2e-ferber-grandparents-wo47ce7l\\.claude\\skills\\research-plan\\references\\planning-standards.md"}
+
+**tool_result:** 1	# BCG Standards for Research Planning (Standards 9-18)
+2	
+3	These ten standards from the Board for Certification of Genealogists
+4	govern how genealogists plan and scope their research. Every research
+5	plan created by this skill should satisfy all applicable standards.
+6	
+7	---
+8	
+9	## Standard 9: Planned Research
+10	
+11	Research begins with and follows a dynamic plan for gathering
+12	information. The plan's purpose is to meet stated objectives, usually
+13	framed as research questions. Hap...
+
+**tool_use** `Read` — args: {"file_path": "C:\\Users\\User\\AppData\\Local\\Temp\\e2e-ferber-grandparents-wo47ce7l\\.claude\\skills\\research-plan\\references\\record-type-guide.md"}
+
+**tool_result:** 1	# Record Type Selection Guide
+2	
+3	Use this reference when identifying which record sets to include in a
+4	research plan. Match the research goal to record types, then check the
+5	contextual factors that affect availability.
+6	
+7	---
+8	
+9	## Record types by research goal
+10	
+11	| Goal | Primary record types | Secondary/fallback |
+12	|------|---------------------|-------------------|
+13	| Identify parents | Census (household), vital records (death/birth cert), probate (will), church (baptism...
+
+**assistant:** Good locality survey complete. I have all the information needed to write the plan. Key findings:
+- Hamilton County birth records start 1863 (collection 1932106)
+- Death records available (collection 2128172) — William's death cert already cited as S3 (need to examine the image for parental names)
+- 1870/1880 censuses on FamilySearch will show William as a child in parents' household
+- 1890 marriage record may list parents
+- Naturalization records available if parents were immigrants (strong possibility given German-sounding Ferber surname in heavily German-immigrant Cincinnati)
+
+**tool_use** `mcp__genealogy__research_append` — args: {"projectPath": "C:\\Users\\User\\AppData\\Local\\Temp\\e2e-ferber-grandparents-wo47ce7l", "ops": [{"section": "plans", "op": "append", "entry": {"question_id": "q_001", "status": "active", "created": "2026-07-07"}}, {"section": "plan_items", "op": "append", "planId": "pl_001", "entry": {"sequence": 1, "record_type": "vital_record", "jurisdiction": "Cincinnati, Hamilton County, Ohio", "date_range": "1903", "repository": "FamilySearch", "rationale": "William Hubert Ferber's death certificate (...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"results\": [\n    {\n      \"section\": \"plans\",\n      \"op\": \"append\",\n      \"entryId\": \"pl_001\"\n    },\n    {\n      \"section\": \"plan_items\",\n      \"op\": \"append\",\n      \"entryId\": \"pli_001\"\n    },\n    {\n      \"section\": \"plan_items\",\n      \"op\": \"append\",\n      \"entryId\": \"pli_002\"\n    },\n    {\n      \"section\": \"plan_items\",\n      \"op\": \"append\",\n      \"entryId\": \"pli_003\"\n    },...
+
+**assistant:** Plan `pl_001` written — 7 items for q_001. Now executing with search-records, starting at pli_001 (William's death certificate image).
+
+**tool_use** `Skill` — args: {"skill": "search-records", "args": "--autonomous q_001 pli_001"}
+
+**tool_result:** Launching skill: search-records
+
+**tool_use** `ToolSearch` — args: {"query": "select:mcp__genealogy__record_read,mcp__genealogy__research_log_append,mcp__genealogy__record_search", "max_results": 3}
+
+**tool_result:** [{"type": "tool_reference", "tool_name": "mcp__genealogy__record_read"}, {"type": "tool_reference", "tool_name": "mcp__genealogy__research_log_append"}, {"type": "tool_reference", "tool_name": "mcp__genealogy__record_search"}]
+
+**assistant:** Fetching William Hubert Ferber's death certificate (already cited as S3 in the project):
+
+**tool_use** `mcp__genealogy__record_read` — args: {"recordId": "ark:/61903/1:1:F66M-8JZ"}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"persons\": [\n    {\n      \"id\": \"p_11261440420\",\n      \"ark\": \"ark:/61903/1:1:F66M-8JZ\",\n      \"gender\": \"Male\",\n      \"names\": [\n        {\n          \"id\": \"dcc3e6a5-da27-4c1c-a9a7-879e9f3c0cbc\",\n          \"type\": \"BirthName\",\n          \"surname\": \"Ferber\",\n          \"given\": \"Wm.\"\n        }\n      ],\n      \"facts\": [\n        {\n          \"id\": \"882cd7fe-3b8c-49f9-a672-1be07c1c044c\",\n          \"type\": \"Birth...
+
+**assistant:** Excellent find — William's death certificate names both parents: **father Gerhard Ferber** and **mother Eva Ferber** (maiden name not yet known). Now logging and passing to extraction.
+
+**tool_use** `mcp__genealogy__research_log_append` — args: {"projectPath": "C:\\Users\\User\\AppData\\Local\\Temp\\e2e-ferber-grandparents-wo47ce7l", "tool": "record_read", "planItemId": "pli_001", "query": {"recordId": "ark:/61903/1:1:F66M-8JZ", "collection": "Ohio, County Death Records, 1840-2001", "subject": "Wm. Ferber", "purpose": "Examine death certificate for parental names"}, "outcome": "positive", "resultsExamined": 1, "resultsAvailable": 1, "notes": "Death certificate for Wm. Ferber, died 11 Mar 1903, Cincinnati, Hamilton, Ohio. CRITICAL FI...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"logId\": \"log_001\",\n  \"performed\": \"2026-07-07T07:52:20.765Z\",\n  \"resultsRef\": null,\n  \"returnedCount\": null,\n  \"filesWritten\": [\n    \"research.json\"\n  ],\n  \"validation\": {\n    \"valid\": true,\n    \"warnings\": []\n  }\n}"}]
+
+**tool_use** `mcp__genealogy__research_append` — args: {"projectPath": "C:\\Users\\User\\AppData\\Local\\Temp\\e2e-ferber-grandparents-wo47ce7l", "section": "plan_items", "op": "update", "planId": "pl_001", "entryId": "pli_001", "fields": {"status": "in_progress"}}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"section\": \"plan_items\",\n  \"op\": \"update\",\n  \"entryId\": \"pli_001\",\n  \"filesWritten\": [\n    \"research.json\"\n  ],\n  \"validation\": {\n    \"valid\": true,\n    \"warnings\": []\n  }\n}"}]
+
+**assistant:** Death certificate fetched (log_001). Father = **Gerhard Ferber**, Mother = **Eva Ferber** (maiden name unknown). Passing to record-extraction now.
+
+**tool_use** `Skill` — args: {"skill": "record-extraction", "args": "--autonomous Extract assertions from the death certificate of Wm. Ferber (ark:/61903/1:1:F66M-8JZ), Ohio County Death Records 1840-2001, for plan item pli_001 / log_001. The full GEDCOMX follows:\n\npersons:\n- id: p_11261440420, ark: ark:/61903/1:1:F66M-8JZ, gender: Male, name: Wm. Ferber\n  facts: Birth 1870, Cincinnati, Hamilton, Ohio; Death 11 Mar 1903, Cincinnati, Hamilton, Ohio; Residence Cincinnati, Ohio; MaritalStatus Married\n- id: p_1126144042...
+
+**tool_result:** Launching skill: record-extraction
+
+**tool_use** `ToolSearch` — args: {"query": "select:mcp__genealogy__research_append,mcp__genealogy__tree_edit", "max_results": 2}
+
+**tool_result:** [{"type": "tool_reference", "tool_name": "mcp__genealogy__research_append"}, {"type": "tool_reference", "tool_name": "mcp__genealogy__tree_edit"}]
+
+**tool_use** `mcp__genealogy__research_append` — args: {"projectPath": "C:\\Users\\User\\AppData\\Local\\Temp\\e2e-ferber-grandparents-wo47ce7l", "ops": [{"section": "sources", "op": "append", "entry": {"gedcomx_source_description_id": "S3", "citation": "\"Ohio, County Death Records, 1840-2001,\" FamilySearch (https://www.familysearch.org/ark:/61903/1:1:F66M-8JZ : accessed 7 Jul 2026), entry for Wm. Ferber, died 11 Mar 1903; Gerhard Ferber recorded as father, Eva Ferber as mother.", "citation_detail": {"who": "Wm. Ferber (deceased); Gerhard Ferbe...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": false,\n  \"errors\": [\n    \"research.json/assertions[0]: has record_persona_id but its log entry 'log_001' has no sidecar (results_ref is null)\",\n    \"research.json/assertions[1]: has record_persona_id but its log entry 'log_001' has no sidecar (results_ref is null)\",\n    \"research.json/assertions[2]: has record_persona_id but its log entry 'log_001' has no sidecar (results_ref is null)\",\n    \"research.json/assertions[3]: has record_persona_...
+
+**assistant:** The validator requires a sidecar for record_persona_ids, but log_001 has none (record_read doesn't stage results). Since the data came via record_read (not record_search), the correct handling is to set record_persona_id to null for all assertions.
+
+**tool_use** `mcp__genealogy__research_append` — args: {"projectPath": "C:\\Users\\User\\AppData\\Local\\Temp\\e2e-ferber-grandparents-wo47ce7l", "ops": [{"section": "sources", "op": "append", "entry": {"gedcomx_source_description_id": "S3", "citation": "\"Ohio, County Death Records, 1840-2001,\" FamilySearch (https://www.familysearch.org/ark:/61903/1:1:F66M-8JZ : accessed 7 Jul 2026), entry for Wm. Ferber, died 11 Mar 1903; Gerhard Ferber recorded as father, Eva Ferber as mother.", "citation_detail": {"who": "Wm. Ferber (deceased); Gerhard Ferbe...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"results\": [\n    {\n      \"section\": \"sources\",\n      \"op\": \"append\",\n      \"entryId\": \"src_001\"\n    },\n    {\n      \"section\": \"assertions\",\n      \"op\": \"append\",\n      \"entryId\": \"a_001\"\n    },\n    {\n      \"section\": \"assertions\",\n      \"op\": \"append\",\n      \"entryId\": \"a_002\"\n    },\n    {\n      \"section\": \"assertions\",\n      \"op\": \"append\",\n      \"entryId\": \"a_003\"\n    },\n ...
+
+**assistant:** Source `src_001` and assertions `a_001`–`a_007` written. Now marking pli_001 complete (assertions created):
+
+**tool_use** `mcp__genealogy__research_append` — args: {"projectPath": "C:\\Users\\User\\AppData\\Local\\Temp\\e2e-ferber-grandparents-wo47ce7l", "section": "plan_items", "op": "update", "planId": "pl_001", "entryId": "pli_001", "fields": {"status": "completed"}}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"section\": \"plan_items\",\n  \"op\": \"update\",\n  \"entryId\": \"pli_001\",\n  \"filesWritten\": [\n    \"research.json\"\n  ],\n  \"validation\": {\n    \"valid\": true,\n    \"warnings\": []\n  }\n}"}]
+
+**assistant:** **Extraction complete.** `src_001`, `a_001`–`a_007` written. `pli_001` completed.
+
+**Key findings:**
+- **Father of Wm. Ferber: Gerhard Ferber** (a_006, indirect/secondary — death cert informant testimony)
+- **Mother of Wm. Ferber: Eva Ferber** — maiden name unknown (a_007, indirect/secondary)
+
+The sibling-stub rule does not apply (subject's role is `deceased`, not `child_N`). S3 already existed in tree.gedcomx.json; no tree-side write needed. Assertions need classification and person-evidence linking next, then continued searching for corroboration.
+
+**tool_use** `Skill` — args: {"skill": "assertion-classification", "args": "--autonomous a_006 a_007"}
+
+**tool_result:** Launching skill: assertion-classification
+
+**tool_use** `Read` — args: {"file_path": "C:\\Users\\User\\AppData\\Local\\Temp\\e2e-ferber-grandparents-wo47ce7l\\.claude\\skills\\assertion-classification\\references\\three-layer-model.md"}
+
+**tool_result:** 1	# The Three-Layer Classification Model
+2	
+3	## Core Principle: Independence of Layers
+4	
+5	The three layers -- source, information, and evidence -- are evaluated
+6	independently. The classification at one layer does NOT determine the
+7	classification at another. An original source can contain secondary
+8	information. A derivative source can provide direct evidence. Each
+9	layer operates on its own terms.
+10	
+11	---
+12	
+13	## Layer 1: Source Classification
+14	
+15	Source classification addres...
+
+**assistant:** Clear analysis. The death certificate's informant for parental and personal facts is unnamed, so the two-question tree says: "Do we know the informant? NO → Indeterminate." Also, per the three-layer model definition, a_006 and a_007 explicitly name the father/mother for q_001 — no inference needed → **direct** (record-extraction over-classified these as `indirect`). Updates needed:
+
+- **a_003 & a_004** (birth year/place): `secondary` → `indeterminate` (informant unnamed)
+- **a_005** (marital status): `primary` → `indeterminate` (personal informant unnamed)
+- **a_006** (Gerhard Ferber, father): `secondary`→`indeterminate`; `indirect`→`direct`
+- **a_007** (Eva Ferber, mother): `secondary`→`indeterminate`; `indirect`→`direct`
+
+Only a_002 (death date/place) stays `primary` — the attending physician's role is structurally implied by this specific fact type on a death certificate even without a personal name.
+
+**tool_use** `mcp__genealogy__research_append` — args: {"projectPath": "C:\\Users\\User\\AppData\\Local\\Temp\\e2e-ferber-grandparents-wo47ce7l", "ops": [{"section": "assertions", "op": "update", "entryId": "a_003", "fields": {"information_quality": "indeterminate", "informant": "unknown personal informant (unnamed; likely spouse or family member)", "informant_bias_notes": "Death certificate states birth year 1870; the 1900 federal census (S2) records birth month December 1869. Minor discrepancy likely reflects imprecise informant recall. Informa...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"results\": [\n    {\n      \"section\": \"assertions\",\n      \"op\": \"update\",\n      \"entryId\": \"a_003\"\n    },\n    {\n      \"section\": \"assertions\",\n      \"op\": \"update\",\n      \"entryId\": \"a_004\"\n    },\n    {\n      \"section\": \"assertions\",\n      \"op\": \"update\",\n      \"entryId\": \"a_005\"\n    },\n    {\n      \"section\": \"assertions\",\n      \"op\": \"update\",\n      \"entryId\": \"a_006\"\n    },\n...
+
+**assistant:** Classifications refined. Now linking assertions to tree persons.
+
+**tool_use** `Skill` — args: {"skill": "person-evidence", "args": "--autonomous Link assertions from the death certificate of Wm. Ferber (src_001, a_001\u2013a_007) to tree persons. Deceased role (a_001\u2013a_005) maps to I2 (William Hubert Ferber). Father role a_006 (Gerhard Ferber) and mother role a_007 (Eva Ferber) have no existing tree persons \u2014 create stubs for both and add ParentChild relationships to I2."}
+
+**tool_result:** Launching skill: person-evidence
+
+**tool_use** `ToolSearch` — args: {"query": "select:mcp__genealogy__tree_edit,mcp__genealogy__research_append", "max_results": 2}
+
+**tool_result:** [{"type": "tool_reference", "tool_name": "mcp__genealogy__tree_edit"}, {"type": "tool_reference", "tool_name": "mcp__genealogy__research_append"}]
+
+**assistant:** **Correlation for deceased role (a_001–a_005):** Name "Wm. Ferber" = William Ferber (I2), death date 11 Mar 1903 Cincinnati matches exactly, marital status Married consistent — **confident** match to I2. No scoring available (record_read sourced, no sidecar).
+
+**Father (a_006) and mother (a_007):** No matching tree persons — creating stubs for Gerhard Ferber and Eva Ferber, then adding relationships.
+
+Batch 1 — add stub persons:
+
+**tool_use** `mcp__genealogy__tree_edit` — args: {"projectPath": "C:\\Users\\User\\AppData\\Local\\Temp\\e2e-ferber-grandparents-wo47ce7l", "ops": [{"operation": "add_person", "person": {"gender": "Male", "names": [{"given": "Gerhard", "surname": "Ferber", "preferred": true, "type": "BirthName"}]}}, {"operation": "add_person", "person": {"gender": "Female", "names": [{"given": "Eva", "surname": "Ferber", "preferred": true, "type": "BirthName"}]}}]}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"results\": [\n    {\n      \"operation\": \"add_person\",\n      \"assignedIds\": {\n        \"person\": \"I10\",\n        \"names\": [\n          \"N10\"\n        ]\n      }\n    },\n    {\n      \"operation\": \"add_person\",\n      \"assignedIds\": {\n        \"person\": \"I11\",\n        \"names\": [\n          \"N11\"\n        ]\n      }\n    }\n  ],\n  \"filesWritten\": [\n    \"tree.gedcomx.json\"\n  ],\n  \"validation\": {\n    \"vali...
+
+**assistant:** Gerhard Ferber → **I10**, Eva Ferber → **I11**. Batch 2 — add relationships:
+
+**tool_use** `mcp__genealogy__tree_edit` — args: {"projectPath": "C:\\Users\\User\\AppData\\Local\\Temp\\e2e-ferber-grandparents-wo47ce7l", "ops": [{"operation": "add_relationship", "relationship": {"type": "Couple", "person1": "I10", "person2": "I11"}}, {"operation": "add_relationship", "relationship": {"type": "ParentChild", "parent": "I10", "child": "I2"}}, {"operation": "add_relationship", "relationship": {"type": "ParentChild", "parent": "I11", "child": "I2"}}]}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"results\": [\n    {\n      \"operation\": \"add_relationship\",\n      \"assignedIds\": {\n        \"relationship\": \"R12\"\n      }\n    },\n    {\n      \"operation\": \"add_relationship\",\n      \"assignedIds\": {\n        \"relationship\": \"R13\"\n      }\n    },\n    {\n      \"operation\": \"add_relationship\",\n      \"assignedIds\": {\n        \"relationship\": \"R14\"\n      }\n    }\n  ],\n  \"filesWritten\": [\n    \"tree.gedcom...
+
+**assistant:** Relationships added (R12 Couple, R13/R14 ParentChild). Now creating all person_evidence links — including both sides of the relationship assertions per the cardinality rule:
+
+**tool_use** `mcp__genealogy__research_append` — args: {"projectPath": "C:\\Users\\User\\AppData\\Local\\Temp\\e2e-ferber-grandparents-wo47ce7l", "ops": [{"section": "person_evidence", "op": "append", "entry": {"assertion_id": "a_001", "person_id": "I2", "confidence": "confident", "rationale": "The death certificate names 'Wm. Ferber' as the deceased, died 11 Mar 1903 in Cincinnati, Hamilton, Ohio. 'Wm.' is a standard abbreviation for William. I2 (William Hubert Ferber) has the same death date and place in the tree. The match on death date, place...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"results\": [\n    {\n      \"section\": \"person_evidence\",\n      \"op\": \"append\",\n      \"entryId\": \"pe_001\"\n    },\n    {\n      \"section\": \"person_evidence\",\n      \"op\": \"append\",\n      \"entryId\": \"pe_002\"\n    },\n    {\n      \"section\": \"person_evidence\",\n      \"op\": \"append\",\n      \"entryId\": \"pe_003\"\n    },\n    {\n      \"section\": \"person_evidence\",\n      \"op\": \"append\",\n      \"entryId...
+
+**assistant:** All 9 `pe_` links written. Now checking for genealogical plausibilities:
+
+**Links created:**
+| pe_ | Assertion | Person | Confidence |
+|-----|-----------|--------|------------|
+| pe_001–005 | a_001–005 (deceased facts) | I2 William Hubert Ferber | confident |
+| pe_006 | a_006 (Gerhard, father role) | I10 Gerhard Ferber (new stub) | probable |
+| pe_007 | a_006 (father → I2 relationship) | I2 William Hubert Ferber | probable |
+| pe_008 | a_007 (Eva, mother role) | I11 Eva Ferber (new stub) | probable |
+| pe_009 | a_007 (mother → I2 relationship) | I2 William Hubert Ferber | probable |
+
+**New stubs:** I10 Gerhard Ferber (Male), I11 Eva Ferber (Female); ParentChild R13 (I10→I2) and R14 (I11→I2), Couple R12 (I10+I11).
+
+**tool_use** `Skill` — args: {"skill": "check-warnings", "args": "I2 I10 I11"}
+
+**tool_result:** Launching skill: check-warnings
+
+**tool_use** `ToolSearch` — args: {"query": "select:mcp__genealogy__person_warnings", "max_results": 1}
+
+**tool_result:** [{"type": "tool_reference", "tool_name": "mcp__genealogy__person_warnings"}]
+
+**tool_use** `mcp__genealogy__person_warnings` — args: {"projectPath": "C:\\Users\\User\\AppData\\Local\\Temp\\e2e-ferber-grandparents-wo47ce7l", "personId": "I2"}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"warningCount\": 0,\n  \"warnings\": []\n}"}]
+
+**tool_use** `mcp__genealogy__person_warnings` — args: {"projectPath": "C:\\Users\\User\\AppData\\Local\\Temp\\e2e-ferber-grandparents-wo47ce7l", "personId": "I10"}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"warningCount\": 0,\n  \"warnings\": []\n}"}]
+
+**tool_use** `mcp__genealogy__person_warnings` — args: {"projectPath": "C:\\Users\\User\\AppData\\Local\\Temp\\e2e-ferber-grandparents-wo47ce7l", "personId": "I11"}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"warningCount\": 0,\n  \"warnings\": []\n}"}]
+
+**assistant:** **No genealogical warnings** for I2, I10, or I11 — the stubs and relationships are logically sound.
+
+**Person-evidence complete.** Summary:
+- Stubs created: **I10 Gerhard Ferber** (Male), **I11 Eva Ferber** (Female)
+- ParentChild edges added: I10→I2, I11→I2; Couple R12 (I10+I11)
+- pe_001–009 written; all assertions linked
+
+Return to orchestrator — pli_002 (1870 census) is the next planned item and will corroborate the parentage finding and potentially reveal additional details about Gerhard and Eva.
+
+**tool_use** `Skill` — args: {"skill": "search-records", "args": "--autonomous q_001 pli_002"}
+
+**tool_result:** Launching skill: search-records
+
+**assistant:** Executing pli_002 — 1870 Federal Census for Gerhard Ferber's household in Cincinnati, Ohio (William would appear as an infant ~4–6 months old). Searching with the now-known father name:
+
+**tool_use** `mcp__genealogy__record_search` — args: {"surname": "Ferber", "givenName": "Gerhard", "residenceYearFrom": 1870, "residenceYearTo": 1870, "residencePlace": "Ohio", "recordType": "census", "projectPath": "C:\\Users\\User\\AppData\\Local\\Temp\\e2e-ferber-grandparents-wo47ce7l"}
+
+**tool_result:** <persisted-output>
+Output too large (70KB). Full output saved to: C:\Users\User\.claude\projects\C--Users-User-AppData-Local-Temp-e2e-ferber-grandparents-wo47ce7l\fda56b31-2dbb-4137-8429-f73104d08a23\tool-results\toolu_01J7h1CtLw4wZYWYGcCMKwU2.json
+
+Preview (first 2KB):
+[
+  {
+    "type": "text",
+    "text": "{\n  \"query\": {\n    \"surname\": \"Ferber\",\n    \"givenName\": \"Gerhard\",\n    \"residenceYearFrom\": 1870,\n    \"residenceYearTo\": 1870,\n    \"residencePlace\": \"Ohio\",\n    ...
+
+**tool_use** `Read` — args: {"file_path": "C:\\Users\\User\\.claude\\projects\\C--Users-User-AppData-Local-Temp-e2e-ferber-grandparents-wo47ce7l\\fda56b31-2dbb-4137-8429-f73104d08a23\\tool-results\\toolu_01J7h1CtLw4wZYWYGcCMKwU2.json"}
+
+**tool_result:** 1	[
+2	  {
+3	    "type": "text",
+4	    "text": "{\n  \"query\": {\n    \"surname\": \"Ferber\",\n    \"givenName\": \"Gerhard\",\n    \"residenceYearFrom\": 1870,\n    \"residenceYearTo\": 1870,\n    \"residencePlace\": \"Ohio\",\n    \"recordType\": \"census\",\n    \"projectPath\": \"C:\\\\Users\\\\User\\\\AppData\\\\Local\\\\Temp\\\\e2e-ferber-grandparents-wo47ce7l\"\n  },\n  \"totalMatches\": 15,\n  \"paginationCappedAt\": 4999,\n  \"returned\": 15,\n  \"offset\": 0,\n  \"hasMore\": false,...
+
+**tool_use** `ToolSearch` — args: {"query": "select:mcp__genealogy__research_log_append,mcp__genealogy__research_append,mcp__genealogy__record_search", "max_results": 3}
+
+**tool_result:** [{"type": "tool_reference", "tool_name": "mcp__genealogy__research_log_append"}, {"type": "tool_reference", "tool_name": "mcp__genealogy__research_append"}, {"type": "tool_reference", "tool_name": "mcp__genealogy__record_search"}]
+
+**tool_use** `mcp__genealogy__research_log_append` — args: {"projectPath": "C:\\Users\\User\\AppData\\Local\\Temp\\e2e-ferber-grandparents-wo47ce7l", "tool": "record_search", "planItemId": "pli_002", "query": {"surname": "Ferber", "givenName": "Gerhard", "residenceYearFrom": 1870, "residenceYearTo": 1870, "residencePlace": "Ohio", "recordType": "census"}, "outcome": "partial", "resultsExamined": 15, "resultsAvailable": 15, "stagedResultsRef": "results/.staging/5e275375-0fc0-49b2-b46f-351c6f3f75f3.json", "notes": "Collection mismatch: top 3 results ar...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"logId\": \"log_002\",\n  \"performed\": \"2026-07-07T08:03:35.588Z\",\n  \"resultsRef\": \"results/log_002.json\",\n  \"returnedCount\": 15,\n  \"filesWritten\": [\n    \"research.json\",\n    \"results/log_002.json\"\n  ],\n  \"validation\": {\n    \"valid\": true,\n    \"warnings\": []\n  }\n}"}]
+
+**assistant:** Logged as log_002. Now updating pli_002 status and retrying with the correct collection filter for the 1870 Federal Census.
+
+**tool_use** `mcp__genealogy__research_append` — args: {"projectPath": "C:\\Users\\User\\AppData\\Local\\Temp\\e2e-ferber-grandparents-wo47ce7l", "section": "plan_items", "op": "update", "planId": "pl_001", "entryId": "pli_002", "fields": {"status": "in_progress"}}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"section\": \"plan_items\",\n  \"op\": \"update\",\n  \"entryId\": \"pli_002\",\n  \"filesWritten\": [\n    \"research.json\"\n  ],\n  \"validation\": {\n    \"valid\": true,\n    \"warnings\": []\n  }\n}"}]
+
+**tool_use** `mcp__genealogy__record_search` — args: {"surname": "Ferber", "givenName": "Gerhard", "residenceYearFrom": 1870, "residenceYearTo": 1870, "residencePlace": "Ohio", "collectionId": "1438024", "projectPath": "C:\\Users\\User\\AppData\\Local\\Temp\\e2e-ferber-grandparents-wo47ce7l"}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"query\": {\n    \"surname\": \"Ferber\",\n    \"givenName\": \"Gerhard\",\n    \"residenceYearFrom\": 1870,\n    \"residenceYearTo\": 1870,\n    \"residencePlace\": \"Ohio\",\n    \"collectionId\": \"1438024\",\n    \"projectPath\": \"C:\\\\Users\\\\User\\\\AppData\\\\Local\\\\Temp\\\\e2e-ferber-grandparents-wo47ce7l\"\n  },\n  \"totalMatches\": 4,\n  \"paginationCappedAt\": 4999,\n  \"returned\": 4,\n  \"offset\": 0,\n  \"hasMore\": false,\n  \"results\": [\...
+
+**assistant:** The 1870 census search scoped to collection 1438024 returned only 4 results — all for "Faber" variants in wrong Ohio counties (Putnam, Montgomery, Carroll, Shelby). No Ferber in Hamilton County. Logging this negative and trying a broader surname-only search in Hamilton County.
+
+**tool_use** `mcp__genealogy__research_log_append` — args: {"projectPath": "C:\\Users\\User\\AppData\\Local\\Temp\\e2e-ferber-grandparents-wo47ce7l", "tool": "record_search", "planItemId": "pli_002", "query": {"surname": "Ferber", "givenName": "Gerhard", "residenceYearFrom": 1870, "residenceYearTo": 1870, "residencePlace": "Ohio", "collectionId": "1438024"}, "outcome": "negative", "resultsExamined": 4, "resultsAvailable": 4, "stagedResultsRef": "results/.staging/c905656d-06e2-47b7-94cf-bc7cdecab688.json", "notes": "Scoped retry with collectionId=1438...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"logId\": \"log_003\",\n  \"performed\": \"2026-07-07T08:04:02.250Z\",\n  \"resultsRef\": \"results/log_003.json\",\n  \"returnedCount\": 4,\n  \"filesWritten\": [\n    \"research.json\",\n    \"results/log_003.json\"\n  ],\n  \"validation\": {\n    \"valid\": true,\n    \"warnings\": []\n  }\n}"}]
+
+**tool_use** `mcp__genealogy__record_search` — args: {"surname": "Ferber", "residenceYearFrom": 1870, "residenceYearTo": 1870, "residencePlace": "Hamilton, Ohio", "collectionId": "1438024", "projectPath": "C:\\Users\\User\\AppData\\Local\\Temp\\e2e-ferber-grandparents-wo47ce7l"}
+
+**tool_result:** Error: result (174,281 characters) exceeds maximum allowed tokens. Output has been saved to C:\Users\User\.claude\projects\C--Users-User-AppData-Local-Temp-e2e-ferber-grandparents-wo47ce7l\fda56b31-2dbb-4137-8429-f73104d08a23\tool-results\mcp-genealogy-record_search-1783411445748.txt.
+Format: JSON array with schema: [{type: string, text: string}]
+Use offset and limit parameters to read specific portions of the file, search within it for specific content, and jq to make structured queries.
+REQ...
+
+**tool_use** `Read` — args: {"file_path": "C:\\Users\\User\\.claude\\projects\\C--Users-User-AppData-Local-Temp-e2e-ferber-grandparents-wo47ce7l\\fda56b31-2dbb-4137-8429-f73104d08a23\\tool-results\\mcp-genealogy-record_search-1783411445748.txt", "limit": 150}
+
+**tool_result:** File content (55477 tokens) exceeds maximum allowed tokens (25000). Use offset and limit parameters to read specific portions of the file, or search for specific content instead of reading the whole file.
+
+**tool_use** `Read` — args: {"file_path": "C:\\Users\\User\\.claude\\projects\\C--Users-User-AppData-Local-Temp-e2e-ferber-grandparents-wo47ce7l\\fda56b31-2dbb-4137-8429-f73104d08a23\\tool-results\\mcp-genealogy-record_search-1783411445748.txt", "limit": 100, "offset": 0}
+
+**tool_result:** File content (55477 tokens) exceeds maximum allowed tokens (25000). Use offset and limit parameters to read specific portions of the file, or search for specific content instead of reading the whole file.
+
+**tool_use** `Bash` — args: {"command": "python3 -c \"\nimport json\nwith open(r'C:\\Users\\User\\.claude\\projects\\C--Users-User-AppData-Local-Temp-e2e-ferber-grandparents-wo47ce7l\\fda56b31-2dbb-4137-8429-f73104d08a23\\tool-results\\mcp-genealogy-record_search-1783411445748.txt', 'r', encoding='utf-8') as f:\n    data = json.load(f)\n\n# Parse the content\ncontent = json.loads(data[0]['text'])\nprint('totalMatches:', content.get('totalMatches'))\nprint('returned:', content.get('returned'))\nprint('staged resultsRef:'...
+
+**tool_result:** Permission to use Bash has been denied because Claude Code is running in don't ask mode. IMPORTANT: You *may* attempt to accomplish this action using other tools that might naturally be used to accomplish this goal, e.g. using head instead of cat. But you *should not* attempt to work around this denial in malicious ways, e.g. do not use your ability to run tests to execute non-test actions. You should only try to work around this restriction in reasonable ways that do not attempt to bypass th...
+
+**tool_use** `Grep` — args: {"pattern": "\"personName\"|\"score\"|\"collectionTitle\"|\"totalMatches\"|\"returned\"|\"resultsRef\"", "path": "C:\\Users\\User\\.claude\\projects\\C--Users-User-AppData-Local-Temp-e2e-ferber-grandparents-wo47ce7l\\fda56b31-2dbb-4137-8429-f73104d08a23\\tool-results\\mcp-genealogy-record_search-1783411445748.txt", "output_mode": "content", "head_limit": 60}
+
+**tool_result:** No matches found
+
+**tool_use** `Grep` — args: {"pattern": "personName", "path": "C:\\Users\\User\\.claude\\projects\\C--Users-User-AppData-Local-Temp-e2e-ferber-grandparents-wo47ce7l\\fda56b31-2dbb-4137-8429-f73104d08a23\\tool-results\\mcp-genealogy-record_search-1783411445748.txt", "output_mode": "content", "head_limit": 30}
+
+**tool_result:** 4:[Omitted long matching line]
+
+**tool_use** `Read` — args: {"file_path": "C:\\Users\\User\\.claude\\projects\\C--Users-User-AppData-Local-Temp-e2e-ferber-grandparents-wo47ce7l\\fda56b31-2dbb-4137-8429-f73104d08a23\\tool-results\\mcp-genealogy-record_search-1783411445748.txt", "limit": 30, "offset": 0}
+
+**tool_result:** File content (55477 tokens) exceeds maximum allowed tokens (25000). Use offset and limit parameters to read specific portions of the file, or search for specific content instead of reading the whole file.
+
+**tool_use** `Glob` — args: {"pattern": "results/.staging/*.json", "path": "C:\\Users\\User\\AppData\\Local\\Temp\\e2e-ferber-grandparents-wo47ce7l"}
+
+**tool_result:** results\.staging\a5de0717-3850-4bd1-9050-81f24832a5be.json
+
+**tool_use** `Read` — args: {"file_path": "C:\\Users\\User\\AppData\\Local\\Temp\\e2e-ferber-grandparents-wo47ce7l\\results\\.staging\\a5de0717-3850-4bd1-9050-81f24832a5be.json", "limit": 100}
+
+**tool_result:** 1	{
+2	  "tool": "record_search",
+3	  "retrieved": "2026-07-07T08:04:05.277Z",
+4	  "returned_count": 20,
+5	  "payload": {
+6	    "query": {
+7	      "surname": "Ferber",
+8	      "residenceYearFrom": 1870,
+9	      "residenceYearTo": 1870,
+10	      "residencePlace": "Hamilton, Ohio",
+11	      "collectionId": "1438024",
+12	      "projectPath": "C:\\Users\\User\\AppData\\Local\\Temp\\e2e-ferber-grandparents-wo47ce7l"
+13	    },
+14	    "totalMatches": 86,
+15	    "paginationCappedAt": 4999,
+16	    "ret...
+
+**tool_use** `Read` — args: {"file_path": "C:\\Users\\User\\AppData\\Local\\Temp\\e2e-ferber-grandparents-wo47ce7l\\results\\.staging\\a5de0717-3850-4bd1-9050-81f24832a5be.json", "limit": 100, "offset": 100}
+
+**tool_result:** 100	                  "standard_date": "1833",
+101	                  "place": "Baden",
+102	                  "standard_place": "Baden, Germany"
+103	                },
+104	                {
+105	                  "type": "Census",
+106	                  "primary": true,
+107	                  "date": "1870",
+108	                  "standard_date": "1870",
+109	                  "place": "Hamilton, Butler, Ohio, United States",
+110	                  "standard_place": "Hamilton, Butler, Ohio, United ...
+
+**tool_use** `Read` — args: {"file_path": "C:\\Users\\User\\AppData\\Local\\Temp\\e2e-ferber-grandparents-wo47ce7l\\results\\.staging\\a5de0717-3850-4bd1-9050-81f24832a5be.json", "limit": 100, "offset": 200}
+
+**tool_result:** 200	            {
+201	              "id": "sd_da1",
+202	              "url": "https://www.familysearch.org/ark:/61903/3:1:S3HY-63NQ-QT4"
+203	            },
+204	            {
+205	              "id": "src_p_p_331559255",
+206	              "url": "#p_331559255"
+207	            }
+208	          ],
+209	          "places": [
+210	            {
+211	              "id": "11971870",
+212	              "name": "Baden, Germany",
+213	              "latitude": 48.2355,
+214	              "longitude": 8.0738
+21...
+
+**assistant:** The "Hamilton, Ohio" place is being resolved as Hamilton City (Butler County), not Hamilton County (Cincinnati). Let me log this and retry with "Cincinnati" as the place.
+
+**tool_use** `mcp__genealogy__research_log_append` — args: {"projectPath": "C:\\Users\\User\\AppData\\Local\\Temp\\e2e-ferber-grandparents-wo47ce7l", "tool": "record_search", "planItemId": "pli_002", "query": {"surname": "Ferber", "residenceYearFrom": 1870, "residenceYearTo": 1870, "residencePlace": "Hamilton, Ohio", "collectionId": "1438024"}, "outcome": "partial", "resultsExamined": 20, "resultsAvailable": 86, "stagedResultsRef": "results/.staging/a5de0717-3850-4bd1-9050-81f24832a5be.json", "notes": "Place disambiguation error: \"Hamilton, Ohio\" r...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"logId\": \"log_004\",\n  \"performed\": \"2026-07-07T08:05:17.977Z\",\n  \"resultsRef\": \"results/log_004.json\",\n  \"returnedCount\": 20,\n  \"filesWritten\": [\n    \"research.json\",\n    \"results/log_004.json\"\n  ],\n  \"validation\": {\n    \"valid\": true,\n    \"warnings\": []\n  }\n}"}]
+
+**tool_use** `mcp__genealogy__record_search` — args: {"surname": "Ferber", "residenceYearFrom": 1870, "residenceYearTo": 1870, "residencePlace": "Cincinnati, Ohio", "collectionId": "1438024", "projectPath": "C:\\Users\\User\\AppData\\Local\\Temp\\e2e-ferber-grandparents-wo47ce7l"}
+
+**tool_result:** Error: result (167,686 characters) exceeds maximum allowed tokens. Output has been saved to C:\Users\User\.claude\projects\C--Users-User-AppData-Local-Temp-e2e-ferber-grandparents-wo47ce7l\fda56b31-2dbb-4137-8429-f73104d08a23\tool-results\mcp-genealogy-record_search-1783411523777.txt.
+Format: JSON array with schema: [{type: string, text: string}]
+Use offset and limit parameters to read specific portions of the file, search within it for specific content, and jq to make structured queries.
+REQ...
+
+**tool_use** `Glob` — args: {"pattern": "results/.staging/*.json", "path": "C:\\Users\\User\\AppData\\Local\\Temp\\e2e-ferber-grandparents-wo47ce7l"}
+
+**tool_result:** results\.staging\7632f6f9-ac03-467b-a83d-af35a97c62f3.json
+
+**tool_use** `Read` — args: {"file_path": "C:\\Users\\User\\AppData\\Local\\Temp\\e2e-ferber-grandparents-wo47ce7l\\results\\.staging\\7632f6f9-ac03-467b-a83d-af35a97c62f3.json", "limit": 50, "offset": 0}
+
+**tool_result:** 0	{
+1	  "tool": "record_search",
+2	  "retrieved": "2026-07-07T08:05:23.388Z",
+3	  "returned_count": 20,
+4	  "payload": {
+5	    "query": {
+6	      "surname": "Ferber",
+7	      "residenceYearFrom": 1870,
+8	      "residenceYearTo": 1870,
+9	      "residencePlace": "Cincinnati, Ohio",
+10	      "collectionId": "1438024",
+11	      "projectPath": "C:\\Users\\User\\AppData\\Local\\Temp\\e2e-ferber-grandparents-wo47ce7l"
+12	    },
+13	    "totalMatches": 69,
+14	    "paginationCappedAt": 4999,
+15	    "re...
+
+**tool_use** `Read` — args: {"file_path": "C:\\Users\\User\\AppData\\Local\\Temp\\e2e-ferber-grandparents-wo47ce7l\\results\\.staging\\7632f6f9-ac03-467b-a83d-af35a97c62f3.json", "limit": 50, "offset": 50}
+
+**tool_result:** 50	              "gender": "Female",
+51	              "names": [
+52	                {
+53	                  "type": "BirthName",
+54	                  "given": "Mary",
+55	                  "surname": "Duc Ferber"
+56	                }
+57	              ],
+58	              "facts": [
+59	                {
+60	                  "type": "Race",
+61	                  "value": "White"
+62	                },
+63	                {
+64	                  "type": "Birth",
+65	                  "date": "1791",
+66	...
+
+**tool_use** `Grep` — args: {"pattern": "personName|score|place.*Cincinnati|place.*Hamilton.*Ohio", "path": "C:\\Users\\User\\AppData\\Local\\Temp\\e2e-ferber-grandparents-wo47ce7l\\results\\.staging\\7632f6f9-ac03-467b-a83d-af35a97c62f3.json", "output_mode": "content", "head_limit": 100}
+
+**tool_result:** 30:            "place": "Colerain Township, Hamilton, Ohio, United States"
+34:        "personName": "Mary Duc Ferber",
+35:        "score": 3.3218,
+75:                  "place": "Colerain Township, Hamilton, Ohio, United States",
+76:                  "standard_place": "Colerain Township, Hamilton, Ohio, United States"
+102:                  "place": "Colerain Township, Hamilton, Ohio, United States",
+103:                  "standard_place": "Colerain Township, Hamilton, Ohio, United States"
+172:...
+
+**assistant:** Found it — "Gerhardt Faerber" at line 1358. Let me read that result in detail.
+
+**tool_use** `Read` — args: {"file_path": "C:\\Users\\User\\AppData\\Local\\Temp\\e2e-ferber-grandparents-wo47ce7l\\results\\.staging\\7632f6f9-ac03-467b-a83d-af35a97c62f3.json", "limit": 200, "offset": 1340}
+
+**tool_result:** 1340	        "recordId": "ark:/61903/1:1:M62Z-87S",
+1341	        "events": [
+1342	          {
+1343	            "type": "Census",
+1344	            "date": "1870",
+1345	            "place": "Cincinnati, Hamilton, Ohio, United States"
+1346	          },
+1347	          {
+1348	            "type": "Race",
+1349	            "value": "White"
+1350	          }
+1351	        ],
+1352	        "treeMatches": [
+1353	          {
+1354	            "treePersonId": "GCD9-9X1",
+1355	            "stars": 4
+1356	     ...
+
+**tool_use** `Read` — args: {"file_path": "C:\\Users\\User\\AppData\\Local\\Temp\\e2e-ferber-grandparents-wo47ce7l\\results\\.staging\\7632f6f9-ac03-467b-a83d-af35a97c62f3.json", "limit": 150, "offset": 1540}
+
+**tool_result:** 1540	                {
+1541	                  "ref": "sd_da1"
+1542	                }
+1543	              ]
+1544	            },
+1545	            {
+1546	              "id": "p_332380057",
+1547	              "ark": "ark:/61903/1:1:M62Z-874",
+1548	              "gender": "Female",
+1549	              "names": [
+1550	                {
+1551	                  "type": "BirthName",
+1552	                  "surname": "Faerber",
+1553	                  "given": "Margarette"
+1554	                }
+1555	     ...
+
+**assistant:** Excellent find! The 1870 census shows **Gerhardt Faerber** (head, born ~1822 Prussia) + **Eva Faerber** (wife, born ~1832 Bavaria) + **William Faerber** (infant, born 1870 Ohio) in Cincinnati, Hamilton County — this is our I10/I11 household with I2 as an infant. Logging the positive result and fetching the full record.
+
+**tool_use** `mcp__genealogy__research_log_append` — args: {"projectPath": "C:\\Users\\User\\AppData\\Local\\Temp\\e2e-ferber-grandparents-wo47ce7l", "tool": "record_search", "planItemId": "pli_002", "query": {"surname": "Ferber", "residenceYearFrom": 1870, "residenceYearTo": 1870, "residencePlace": "Cincinnati, Ohio", "collectionId": "1438024"}, "outcome": "positive", "resultsExamined": 20, "resultsAvailable": 69, "stagedResultsRef": "results/.staging/7632f6f9-ac03-467b-a83d-af35a97c62f3.json", "notes": "Strong match: Household of Gerhardt Faerber (...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"logId\": \"log_005\",\n  \"performed\": \"2026-07-07T08:06:31.273Z\",\n  \"resultsRef\": \"results/log_005.json\",\n  \"returnedCount\": 20,\n  \"filesWritten\": [\n    \"research.json\",\n    \"results/log_005.json\"\n  ],\n  \"validation\": {\n    \"valid\": true,\n    \"warnings\": []\n  }\n}"}]
+
+**tool_use** `mcp__genealogy__record_read` — args: {"recordId": "https://www.familysearch.org/ark:/61903/1:1:M62Z-87S"}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"persons\": [\n    {\n      \"id\": \"p_332380052\",\n      \"ark\": \"ark:/61903/1:1:M62Z-87S\",\n      \"gender\": \"Male\",\n      \"names\": [\n        {\n          \"id\": \"8c3985f2-a1b9-4e51-9e1f-f3109b560d2e\",\n          \"type\": \"BirthName\",\n          \"given\": \"Gerhardt\",\n          \"surname\": \"Faerber\"\n        }\n      ],\n      \"facts\": [\n        {\n          \"id\": \"e93678fb-2a88-4994-92d2-d57837c76f89\",\n          \"type\": \"C...
+
+**assistant:** The full record is confirmed. This is the household: Gerhardt Faerber (head, born ~1822 Prussia) + Eva Faerber (wife, born ~1832 Bavaria) + William Faerber (infant, born 1870 Ohio) in Cincinnati — a strong match for I10, I11, and I2. Now persisting source and assertions, and adding the GedcomX source description.
+
+**tool_use** `mcp__genealogy__research_append` — args: {"projectPath": "C:\\Users\\User\\AppData\\Local\\Temp\\e2e-ferber-grandparents-wo47ce7l", "ops": [{"section": "sources", "op": "append", "entry": {"gedcomx_source_description_id": "S5", "citation": "\"United States, Census, 1870\", FamilySearch (https://www.familysearch.org/ark:/61903/1:1:M62Z-87S : Mon Oct 13 21:07:52 UTC 2025), Entry for Gerhardt Faerber and Eva Faerber, 1870.", "citation_detail": {"who": "Gerhardt Faerber household", "what": "United States, Census, 1870", "when_created": ...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": false,\n  \"errors\": [\n    \"research.json/sources[1]: gedcomx_source_description_id 'S5' not found in tree.gedcomx.json sources\"\n  ]\n}"}]
+
+**tool_use** `mcp__genealogy__tree_edit` — args: {"projectPath": "C:\\Users\\User\\AppData\\Local\\Temp\\e2e-ferber-grandparents-wo47ce7l", "operation": "add_source_description", "source": {"id": "S5", "title": "United States, Census, 1870", "url": "https://www.familysearch.org/ark:/61903/1:2:MHXJ-Y4S"}}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": false,\n  \"errors\": [\n    \"unknown operation 'add_source_description'\"\n  ]\n}"}]
+
+**assistant:** You've hit your limit · resets 2:40pm (Africa/Nairobi)

--- a/eval/tests/e2e/ferber-grandparents/README.md
+++ b/eval/tests/e2e/ferber-grandparents/README.md
@@ -1,0 +1,35 @@
+# Charles Hubert Ferber — grandparents (1820s–1870s)
+
+**Source PID:** `G7JB-Y46`
+**Charles Hubert Ferber is deceased** (b. 22 Jun 1891, d. 12 Dec 1967). (FamilySearch ToS requires
+all committed e2e fixtures to be about deceased persons.)
+
+## Research question
+
+> Who were the grandparents of Charles Hubert Ferber, born 22 June 1891 in Cincinnati, Ohio (the parents of his father William Hubert Ferber and his mother Emma Becker)?
+
+## What was removed from the starting tree
+
+- Removed paternal grandfather **Gerhard Ferber** (b. ~1820 Germany, d. 1917 Cincinnati) and paternal grandmother **Eva Engermann** (b. 1834 Bavaria, d. 1872 Cincinnati), along with the `ParentChild` relationships linking them to William Hubert Ferber and the `Couple` relationship between them.
+- Removed maternal grandfather **John Becker** (b. ~1845 Kentucky) and maternal grandmother **Mary Kramer** (b. Ohio), along with the `ParentChild` relationships linking them to Emma Becker and the `Couple` relationship between them.
+- Edited the Ohio death-record source citation (S3) to drop its mention of "Gerhard Ferber" by name — the original citation text named him directly, which would have leaked the paternal-grandfather answer without the agent doing any lookup. The source is still attached to William's death fact and resolves to the same real FamilySearch record (`ark:/61903/1:1:F66M-8JZ`), which the agent can fetch via `record_read` to discover the parents itself.
+- Kept intact: Charles's own vitals/residences, his two marriages (Lydian Inez Hall, Harriet Helen Bailey), and William & Emma's own vitals and their 1890 marriage.
+
+## Expected difficulty
+
+Moderate — the paternal grandparent link is independently corroborable via two live FamilySearch sources (the compiled tree and a name search + `record_read` on the Ohio death record found by searching William Ferber's death), which is a reasonably direct path. The maternal grandparent link (Becker/Kramer) is only findable via the compiled tree in the live source data — no independent record corroborating it was located during authoring, so it may be harder to recover through record search alone, and person_search on the compiled tree is likely the intended path there.
+
+## Notes for reviewers
+
+This fixture was authored (Path 2: convert a finished research project) from a live client research project (`research.json` objective: circumstances of William Hubert Ferber's death, and extending Charles Hubert Ferber's ancestry). That project's own research surfaced two *unresolved* conflicts about William's and Emma's own birthplaces (Ohio per FamilySearch's 1900 census index vs. Germany/Kentucky per the client's reading of the same census clipping) — those conflicts are about William/Emma's *own* birthplaces, not about who their parents were, so they don't affect this fixture's expected findings, but a very literal-minded agent might get distracted by a birthplace mismatch if it happens to notice the tree's Ohio-birthplace facts while searching. That's expected and shouldn't be graded against the fixture's actual (parentage) findings.
+
+## Reference project
+
+`reference-project/` holds the full source research this fixture's grandparent question was
+distilled from: the complete `research.json` (GPS-classified sources, assertions, person_evidence,
+the two open birthplace conflicts noted above, and both proof summaries — including the
+`not_proved` conclusion for the death-circumstances question, which is why this fixture only
+covers the ancestry-extension half) and the unstripped `tree.gedcomx.json` with all four
+grandparents included. It is provenance/documentation only — not part of the benchmark contract
+that `starting-research.json` / `starting-tree.gedcomx.json` / `expected-findings.json` define, and
+the harness does not read it.

--- a/eval/tests/e2e/ferber-grandparents/expected-findings.json
+++ b/eval/tests/e2e/ferber-grandparents/expected-findings.json
@@ -1,0 +1,82 @@
+{
+  "findings": [
+    {
+      "id": "f1",
+      "type": "relationship",
+      "description": "Gerhard Ferber was the paternal grandfather of Charles Hubert Ferber — that is, the father of William Hubert Ferber. Gerhard was born about 1820 in Germany, immigrated to the United States around 1850, was naturalized in Ohio in 1853, and died 31 May 1917 in Cincinnati, Ohio.",
+      "details": {
+        "subject_person": {
+          "name": "Charles Hubert Ferber"
+        },
+        "relation": "paternal_grandfather",
+        "target_person": {
+          "name": "Gerhard Ferber",
+          "birth": "about 1820, Germany"
+        }
+      },
+      "supporting_sources": [
+        "FamilySearch Family Tree compiled profile for William H Ferber, listing Gerhard Ferber as father.",
+        "Ohio, County Death Records, 1840-2001, entry for Wm. Ferber, died 11 Mar 1903, Cincinnati, Hamilton County, Ohio — separately names Gerhard Ferber as the decedent's father."
+      ],
+      "required": true
+    },
+    {
+      "id": "f2",
+      "type": "relationship",
+      "description": "Eva Engermann was the paternal grandmother of Charles Hubert Ferber — that is, the mother of William Hubert Ferber and wife of Gerhard Ferber. Eva was born about 1834 in Bavaria and died 1 January 1872 in Cincinnati, Ohio.",
+      "details": {
+        "subject_person": {
+          "name": "Charles Hubert Ferber"
+        },
+        "relation": "paternal_grandmother",
+        "target_person": {
+          "name": "Eva Engermann",
+          "birth": "1834, Bavaria"
+        }
+      },
+      "supporting_sources": [
+        "FamilySearch Family Tree compiled profile for William H Ferber, listing Eva (Engermann) Ferber as mother.",
+        "Ohio, County Death Records, 1840-2001, entry for Wm. Ferber, died 11 Mar 1903, Cincinnati, Hamilton County, Ohio — separately names Eva Ferber as the decedent's mother."
+      ],
+      "required": true
+    },
+    {
+      "id": "f3",
+      "type": "relationship",
+      "description": "John Becker was the maternal grandfather of Charles Hubert Ferber — that is, the father of Emma Becker. John was born about January 1845 in Kentucky.",
+      "details": {
+        "subject_person": {
+          "name": "Charles Hubert Ferber"
+        },
+        "relation": "maternal_grandfather",
+        "target_person": {
+          "name": "John Becker",
+          "birth": "about 1845, Kentucky"
+        }
+      },
+      "supporting_sources": [
+        "FamilySearch Family Tree compiled profile for Emma Becker, listing John Becker as father."
+      ],
+      "required": true
+    },
+    {
+      "id": "f4",
+      "type": "relationship",
+      "description": "Mary Kramer was the maternal grandmother of Charles Hubert Ferber — that is, the mother of Emma Becker and wife of John Becker. Mary was born in Ohio (date not established in the compiled tree).",
+      "details": {
+        "subject_person": {
+          "name": "Charles Hubert Ferber"
+        },
+        "relation": "maternal_grandmother",
+        "target_person": {
+          "name": "Mary Kramer",
+          "birth": "Ohio (date unknown)"
+        }
+      },
+      "supporting_sources": [
+        "FamilySearch Family Tree compiled profile for Emma Becker, listing Mary Kramer as mother."
+      ],
+      "required": true
+    }
+  ]
+}

--- a/eval/tests/e2e/ferber-grandparents/fixture.json
+++ b/eval/tests/e2e/ferber-grandparents/fixture.json
@@ -1,0 +1,25 @@
+{
+  "id": "ferber-grandparents",
+  "name": "Charles Hubert Ferber — grandparents (1820s–1870s)",
+  "source_pid": "G7JB-Y46",
+  "captured": "2026-07-06",
+  "researcher_question": "Who were the grandparents of Charles Hubert Ferber, born 22 June 1891 in Cincinnati, Ohio (the parents of his father William Hubert Ferber and his mother Emma Becker)?",
+  "tags": {
+    "question_type": "parents",
+    "era": "1850s",
+    "geography": "US-OH"
+  },
+  "model": {
+    "agent": "claude-sonnet-4-6",
+    "judge": "claude-haiku-4-5-20251001"
+  },
+  "caps": {
+    "wall_clock_seconds": 3600,
+    "inactivity_seconds": 600,
+    "tool_calls": 200,
+    "max_turns": 100,
+    "max_cost_usd": 15
+  },
+  "difficulty": "moderate",
+  "notes": "Paternal grandparents (Gerhard Ferber, b. ~1820 Germany, immigrated ~1850, d. 1917 Cincinnati; and Eva Engermann, b. 1834 Bavaria, d. 1872 Cincinnati) are independently corroborated in the live source data by both FamilySearch's compiled tree and William Ferber's own 1903 Ohio death record, which separately names them as his parents — a good test of whether the agent cross-checks the compiled tree against a record rather than relying on the tree alone. Maternal grandparents (John Becker, b. ~1845 Kentucky; and Mary Kramer, b. Ohio) rest only on the compiled FamilySearch tree in the live source data and were not independently corroborated during authoring — grade findings on this half more leniently and flag if the agent cannot find supporting records beyond the tree profile."
+}

--- a/eval/tests/e2e/ferber-grandparents/reference-project/research.json
+++ b/eval/tests/e2e/ferber-grandparents/reference-project/research.json
@@ -1,0 +1,754 @@
+{
+  "project": {
+    "id": "rp_001",
+    "objective": "Determine the circumstances surrounding the death of William Hubert Ferber (father of Charles Hubert Ferber, b. 22 June 1891, Cincinnati, Ohio), and extend Charles Hubert Ferber's ancestry beyond his parents.",
+    "subject_person_ids": [
+      "I1"
+    ],
+    "status": "active",
+    "created": "2026-07-06",
+    "updated": "2026-07-06",
+    "title": "Ferber death & ancestry"
+  },
+  "researcher_profile": {
+    "experience_level": "intermediate",
+    "subscriptions": [
+      "none"
+    ],
+    "narration_guidance": "One-line preamble per skill invocation explaining what you're about to do. Assume basic GPS vocabulary. Define unusual or specialized terminology inline."
+  },
+  "known_holdings": [
+    {
+      "id": "kh_001",
+      "holding_type": "document",
+      "description": "Obituary of Charles Ferber, Fort Lauderdale News (Fort Lauderdale, FL), 13 Dec 1967 — client-provided clipping",
+      "relevant_facts": "States Charles died at age 76 (implying birth ~1891); died 1967; had moved from Cincinnati, Ohio approximately 13 years earlier; possibly moved to that Florida residence in 1953",
+      "relates_to_person_ids": [
+        "I1"
+      ],
+      "confidence": "confident",
+      "promoted": false,
+      "created": "2026-07-06"
+    },
+    {
+      "id": "kh_002",
+      "holding_type": "document",
+      "description": "1900 U.S. Census clipping for the Ferber family household, Cincinnati, Ohio — client-provided",
+      "relevant_facts": "William Ferber listed age 31, stated born 1869 in Germany (per client's reading of the clipping); Emma Ferber listed age 29, stated born in Kentucky; couple married 10 years as of 1900; Charles Ferber listed as son, age 9",
+      "relates_to_person_ids": [
+        "I1",
+        "I2",
+        "I3"
+      ],
+      "confidence": "confident",
+      "promoted": false,
+      "created": "2026-07-06"
+    }
+  ],
+  "questions": [
+    {
+      "id": "q_001",
+      "question": "What were the circumstances surrounding the death of William Hubert Ferber (b. ~Dec 1869, Ohio; d. 11 Mar 1903, Cincinnati, Hamilton, Ohio)?",
+      "rationale": "This is the primary client research objective. FamilySearch's compiled tree already records the date and place of death, but not the cause or circumstances the client is asking about.",
+      "selection_basis": "objective_decomposition",
+      "priority": "high",
+      "status": "in_progress",
+      "depends_on": [],
+      "unblocks": [],
+      "created": "2026-07-06",
+      "resolved": null,
+      "resolution_assertion_ids": [],
+      "exhaustive_declaration": {
+        "declared": false,
+        "justification": null,
+        "log_entry_ids": [],
+        "stop_criteria": null
+      }
+    },
+    {
+      "id": "q_002",
+      "question": "Who were the ancestors of Charles Hubert Ferber beyond his parents William Hubert Ferber and Emma Becker — extending the pedigree as far back and as fully as records allow?",
+      "rationale": "Second half of the client's research objective. FamilySearch's compiled tree already suggests two more generations (grandparents on both sides); these need independent verification against original records before being treated as established.",
+      "selection_basis": "objective_decomposition",
+      "priority": "high",
+      "status": "in_progress",
+      "depends_on": [],
+      "unblocks": [],
+      "created": "2026-07-06",
+      "resolved": null,
+      "resolution_assertion_ids": [],
+      "exhaustive_declaration": {
+        "declared": false,
+        "justification": null,
+        "log_entry_ids": [],
+        "stop_criteria": null
+      }
+    }
+  ],
+  "plans": [
+    {
+      "id": "pl_001",
+      "question_id": "q_001",
+      "status": "active",
+      "created": "2026-07-06",
+      "items": [
+        {
+          "id": "pli_001",
+          "sequence": 1,
+          "record_type": "vital_record",
+          "jurisdiction": "Hamilton County, Ohio",
+          "date_range": "1903",
+          "repository": "FamilySearch",
+          "rationale": "Check FamilySearch's Ohio County Death Records index for William Ferber's death entry.",
+          "fallback_for": null,
+          "status": "completed"
+        },
+        {
+          "id": "pli_002",
+          "sequence": 2,
+          "record_type": "newspaper",
+          "jurisdiction": "Hamilton County, Ohio",
+          "date_range": "Mar 1903",
+          "repository": "FamilySearch",
+          "rationale": "Search FamilySearch's full-text AI-transcribed document index for a contemporary death notice naming Ferber.",
+          "fallback_for": null,
+          "status": "completed"
+        },
+        {
+          "id": "pli_003",
+          "sequence": 3,
+          "record_type": "newspaper",
+          "jurisdiction": "Hamilton County, Ohio",
+          "date_range": "Mar 1903",
+          "repository": "other",
+          "rationale": "FamilySearch has no indexed Hamilton County newspaper collection for 1903. Chronicling America (Library of Congress, free) is the next resource to check manually for a Cincinnati Enquirer or Cincinnati Post death notice.",
+          "fallback_for": "pli_002",
+          "status": "planned"
+        },
+        {
+          "id": "pli_004",
+          "sequence": 4,
+          "record_type": "probate",
+          "jurisdiction": "Hamilton County, Ohio",
+          "date_range": "1903",
+          "repository": "other",
+          "rationale": "FamilySearch's 'Ohio, Hamilton County Records, 1791-1994' (collection 2141016) holds 1.5M digitized but un-indexed images; a probate or coroner's file could reveal cause of death but would require manual browsing by date/name, which is outside the tools available in this session.",
+          "fallback_for": null,
+          "status": "planned"
+        }
+      ]
+    },
+    {
+      "id": "pl_002",
+      "question_id": "q_002",
+      "status": "active",
+      "created": "2026-07-06",
+      "items": [
+        {
+          "id": "pli_005",
+          "sequence": 1,
+          "record_type": "other",
+          "jurisdiction": "Hamilton County, Ohio",
+          "date_range": "1856-1917",
+          "repository": "FamilySearch",
+          "rationale": "Read FamilySearch's compiled Family Tree two generations beyond Charles's parents (paternal: Gerhard Ferber & Eva Engermann; maternal: John Becker & Mary Kramer).",
+          "fallback_for": null,
+          "status": "completed"
+        },
+        {
+          "id": "pli_006",
+          "sequence": 2,
+          "record_type": "vital_record",
+          "jurisdiction": "Hamilton County, Ohio",
+          "date_range": "1903",
+          "repository": "FamilySearch",
+          "rationale": "Cross-check the paternal grandparent link (Gerhard & Eva Ferber) against William's own 1903 death record, independent of the compiled tree.",
+          "fallback_for": null,
+          "status": "completed"
+        },
+        {
+          "id": "pli_007",
+          "sequence": 3,
+          "record_type": "census",
+          "jurisdiction": "Ohio / Kentucky",
+          "date_range": "1900",
+          "repository": "FamilySearch",
+          "rationale": "Resolve the birthplace conflicts (c_001 William, c_002 Emma) by checking the original 1900 census image directly rather than the index alone.",
+          "fallback_for": null,
+          "status": "planned"
+        },
+        {
+          "id": "pli_008",
+          "sequence": 4,
+          "record_type": "immigration",
+          "jurisdiction": "Germany / Ohio",
+          "date_range": "1849-1853",
+          "repository": "FamilySearch",
+          "rationale": "Searched FamilySearch for Gerhard Ferber's naturalization/immigration (1849-1856, Ohio). No match found — 9 results returned, all unrelated Farber/Faerber individuals in other Ohio counties. The compiled tree's naturalization/immigration facts for Gerhard Ferber remain uncorroborated (quality:1). A more targeted search of the Ohio Southern District Naturalization Index was not attempted.",
+          "fallback_for": null,
+          "status": "completed"
+        },
+        {
+          "id": "pli_009",
+          "sequence": 5,
+          "record_type": "other",
+          "jurisdiction": "Kentucky / Ohio",
+          "date_range": "1840s",
+          "repository": "FamilySearch",
+          "rationale": "John Becker and Mary Kramer's own parents are not yet identified. Deferred until the birthplace conflict for their daughter Emma (c_002) is resolved, since it determines whether to search Kentucky or Ohio records.",
+          "fallback_for": null,
+          "status": "planned"
+        }
+      ]
+    }
+  ],
+  "log": [
+    {
+      "id": "log_001",
+      "plan_item_id": null,
+      "performed": "2026-07-06T07:39:30.184Z",
+      "tool": "person_search",
+      "query": {
+        "surname": "Ferber",
+        "givenName": "Charles Hubert",
+        "birthYearFrom": 1891,
+        "birthYearTo": 1891,
+        "birthPlace": "Cincinnati, Ohio, United States",
+        "fatherGivenName": "William Hubert",
+        "motherGivenName": "Emma"
+      },
+      "outcome": "positive",
+      "results_examined": 9,
+      "external_site": null,
+      "results_ref": null,
+      "results_available": 9,
+      "notes": "Top match G7JB-Y46 (score 10.7, confidence 3) matches the client's obituary exactly: b. 22 Jun 1891 Cincinnati, d. 12 Dec 1967 Fort Lauderdale FL. Selected as the research subject (local I1)."
+    },
+    {
+      "id": "log_002",
+      "plan_item_id": null,
+      "performed": "2026-07-06T07:39:32.838Z",
+      "tool": "person_read",
+      "query": {
+        "personId": "G7JB-Y46",
+        "relatives": true,
+        "sourceDescriptions": true
+      },
+      "outcome": "positive",
+      "results_examined": 1,
+      "external_site": null,
+      "results_ref": null,
+      "notes": "Retrieved Charles Hubert Ferber's FamilySearch Family Tree profile: parents William H Ferber and Emma Becker; two spouses (Lydian Inez Hall m. 1918, divorced 1920; Harriet Helen Bailey m. 1934); FamilySearch's own tree already records William H Ferber's death as 11 Mar 1903, Cincinnati — new information beyond what the client provided."
+    },
+    {
+      "id": "log_003",
+      "plan_item_id": null,
+      "performed": "2026-07-06T07:39:34.618Z",
+      "tool": "person_read",
+      "query": {
+        "personIds": [
+          "GCD9-9X1",
+          "G7J1-QF2",
+          "G69T-T55",
+          "GNJH-SLL"
+        ],
+        "relatives": true
+      },
+      "outcome": "positive",
+      "results_examined": 4,
+      "external_site": null,
+      "results_ref": null,
+      "notes": "Expanded ancestry two generations beyond Charles's parents via FamilySearch's compiled tree: paternal grandparents Gerhard Ferber (b. 1820 Germany, immigrated ~1850, d. 1917 Cincinnati) and Eva Engermann (b. 1834 Bavaria, d. 1872 Cincinnati); maternal grandparents John Becker (b. ~1845 Kentucky) and Mary Kramer (b. Ohio). All quality:1 (compiled tree, not yet independently verified against original records)."
+    },
+    {
+      "id": "log_004",
+      "plan_item_id": null,
+      "performed": "2026-07-06T07:40:04.527Z",
+      "tool": "record_read",
+      "query": {
+        "recordId": "ark:/61903/1:1:F66M-8JZ",
+        "collection": "Ohio, County Death Records, 1840-2001"
+      },
+      "outcome": "partial",
+      "results_examined": 1,
+      "external_site": null,
+      "results_ref": null,
+      "notes": "Confirms William H Ferber's death on 11 Mar 1903, Cincinnati, Hamilton, Ohio, and names his parents as Gerhard Ferber and Eva Ferber — corroborates the tree's grandparent link independently. This is an index-only entry (no cause of death field). Does not answer q_001; a death certificate image or newspaper notice is still needed for circumstances."
+    },
+    {
+      "id": "log_005",
+      "plan_item_id": null,
+      "performed": "2026-07-06T07:40:07.354Z",
+      "tool": "record_read",
+      "query": {
+        "recordId": "ark:/61903/1:1:MM88-DGG",
+        "collection": "United States, Census, 1900"
+      },
+      "outcome": "partial",
+      "results_examined": 1,
+      "external_site": null,
+      "results_ref": null,
+      "notes": "FamilySearch's own index of this 1900 census entry gives William Ferber's birthplace as Ohio (not Germany) and Emma Ferber's birth as March 1871 in Ohio (not Kentucky, and not age 29/b.~1870-71 exactly matching the client's clipping). This conflicts with the client's own reading of the census clipping (William b. 1869 Germany; Emma b. Kentucky). Logged as an open conflict (see conflicts) pending review of the original census image."
+    },
+    {
+      "id": "log_006",
+      "plan_item_id": null,
+      "performed": "2026-07-06T07:46:35.002Z",
+      "tool": "fulltext_search",
+      "query": {
+        "keywords": "+Ferber +died",
+        "recordPlace1": "Ohio",
+        "recordPlace2": "Hamilton",
+        "yearFrom": 1903,
+        "yearTo": 1903
+      },
+      "outcome": "negative",
+      "results_examined": 0,
+      "external_site": null,
+      "results_ref": null,
+      "results_available": 0,
+      "notes": "No hits for Ferber + died in Hamilton County, Ohio, 1903 in FamilySearch's AI-transcribed full-text index. Retried with broader keyword combinations (+Ferber alone; +Ferber +Cincinnati) — all nil. FamilySearch has no dedicated Hamilton County, Ohio newspaper/obituary collection indexed for this period (confirmed via collections_search). Cause of death for William H Ferber is not findable through FamilySearch's tools alone; a free option (Library of Congress Chronicling America) and paid options (Newspapers.com, GenealogyBank — client holds no subscriptions) remain as manual next steps."
+    },
+    {
+      "id": "log_007",
+      "plan_item_id": null,
+      "performed": "2026-07-06T07:47:49.540Z",
+      "tool": "record_search",
+      "query": {
+        "surname": "Ferber",
+        "givenName": "Gerhard",
+        "recordType": "other",
+        "recordCountry": "United States",
+        "recordSubdivision": "Ohio",
+        "anyYearFrom": 1849,
+        "anyYearTo": 1856
+      },
+      "outcome": "negative",
+      "results_examined": 9,
+      "external_site": null,
+      "results_ref": "results/log_007.json",
+      "results_available": 9,
+      "notes": "No match for Gerhard Ferber's 1853 Ohio naturalization or 1849-1850 immigration. All 9 results are unrelated Farber/Faerber/Ferber individuals in Cleveland (Cuyahoga Co.) or Xenia (Greene Co.), not Cincinnati (Hamilton Co.). The Ohio Southern District Naturalization Index (collection 2110749) is untried and may be worth a more targeted search, but that is outside this session's scope."
+    }
+  ],
+  "sources": [
+    {
+      "id": "src_001",
+      "gedcomx_source_description_id": "S1",
+      "citation": "FamilySearch Family Tree, compiled profile for Charles Hubert Ferber (G7JB-Y46) and connected relatives, accessed 6 Jul 2026.",
+      "citation_detail": {
+        "who": "FamilySearch contributors",
+        "what": "Compiled Family Tree profile",
+        "when_created": "unknown (continuously updated compiled tree)",
+        "when_accessed": "2026-07-06",
+        "where": "FamilySearch.org",
+        "where_within": "Person profiles G7JB-Y46, G7JB-YH6, G7JB-2T6, GCD9-9X1, G7J1-QF2, G69T-T55, GNJH-SLL"
+      },
+      "source_classification": "derivative",
+      "repository": "FamilySearch",
+      "access_date": "2026-07-06",
+      "url": "https://www.familysearch.org/tree/person/details/G7JB-Y46",
+      "notes": "Crowd-compiled tree data; uncorroborated facts kept at quality:1 in tree.gedcomx.json until independently verified.",
+      "log_entry_id": "log_002"
+    },
+    {
+      "id": "src_002",
+      "gedcomx_source_description_id": "S2",
+      "citation": "1900 U.S. Federal Census, Cincinnati, Hamilton County, Ohio, household of William Ferber; FamilySearch index, ark:/61903/1:1:MM88-DGG, accessed 6 Jul 2026.",
+      "citation_detail": {
+        "who": "U.S. Census Bureau",
+        "what": "1900 U.S. Federal Census, population schedule (FamilySearch index)",
+        "when_created": "1900",
+        "when_accessed": "2026-07-06",
+        "where": "FamilySearch.org",
+        "where_within": "Cincinnati, Hamilton, Ohio — household of William Ferber"
+      },
+      "source_classification": "derivative",
+      "repository": "FamilySearch",
+      "access_date": "2026-07-06",
+      "url": "https://www.familysearch.org/ark:/61903/1:1:MM88-DGG",
+      "notes": "Only the FamilySearch index was consulted via the record_read tool — no digitized census image was available to check directly. The client separately holds a clipping of this same record (known_holding kh_002) with different birthplace readings; see conflict c_001.",
+      "log_entry_id": "log_004"
+    },
+    {
+      "id": "src_003",
+      "gedcomx_source_description_id": "S3",
+      "citation": "Ohio, County Death Records, 1840-2001, entry for Wm. Ferber, d. 11 Mar 1903, Cincinnati, Hamilton County, Ohio; FamilySearch index, ark:/61903/1:1:F66M-8JZ, accessed 6 Jul 2026.",
+      "citation_detail": {
+        "who": "Hamilton County, Ohio (recording authority)",
+        "what": "County death record (index)",
+        "when_created": "1903-03-11",
+        "when_accessed": "2026-07-06",
+        "where": "FamilySearch.org",
+        "where_within": "Hamilton County, Ohio death records, entry for Wm. Ferber"
+      },
+      "source_classification": "derivative",
+      "repository": "FamilySearch",
+      "access_date": "2026-07-06",
+      "url": "https://www.familysearch.org/ark:/61903/1:1:F66M-8JZ",
+      "notes": "Index-only entry — confirms date/place of death and names both parents (Gerhard Ferber, Eva Ferber), but has no cause-of-death field. Does not resolve q_001; the underlying certificate image or a contemporary newspaper notice is still needed.",
+      "log_entry_id": "log_004"
+    },
+    {
+      "id": "src_004",
+      "gedcomx_source_description_id": "S4",
+      "citation": "\"Charles Ferber\" (obituary), Fort Lauderdale News, Fort Lauderdale, FL, 13 Dec 1967 (client-provided clipping).",
+      "citation_detail": {
+        "who": "Fort Lauderdale News",
+        "what": "Newspaper obituary",
+        "when_created": "1967-12-13",
+        "when_accessed": "2026-07-06",
+        "where": "Client's personal clipping",
+        "where_within": "Not yet located in a digitized newspaper database"
+      },
+      "source_classification": "original",
+      "repository": "other",
+      "access_date": "2026-07-06",
+      "notes": "Provided by the client as known_holding kh_001. Not yet cross-located in an online newspaper archive.",
+      "log_entry_id": null
+    }
+  ],
+  "assertions": [
+    {
+      "id": "a_001",
+      "source_id": "src_002",
+      "record_id": "ark:/61903/1:1:MM88-DGG",
+      "record_role": "head_of_household",
+      "fact_type": "birth",
+      "value": "Ohio",
+      "structured_value": {
+        "place": "Ohio, United States"
+      },
+      "date": "Dec 1869",
+      "date_certainty": "approximate",
+      "place": "Ohio, United States",
+      "information_quality": "secondary",
+      "informant": "Unknown household member reporting to census enumerator",
+      "informant_proximity": "household_member",
+      "informant_bias_notes": "Birthplace requires active reporting by a household member; the census does not name the informant.",
+      "evidence_type": "indirect",
+      "log_entry_id": "log_004",
+      "extracted_for_question_ids": [
+        "q_002"
+      ]
+    },
+    {
+      "id": "a_002",
+      "source_id": "src_002",
+      "record_id": "ark:/61903/1:1:MM88-DGG",
+      "record_role": "wife",
+      "fact_type": "birth",
+      "value": "March 1871, Ohio",
+      "structured_value": {
+        "date": "1871-03",
+        "place": "Ohio, United States"
+      },
+      "date": "Mar 1871",
+      "date_certainty": "approximate",
+      "place": "Ohio, United States",
+      "information_quality": "secondary",
+      "informant": "Unknown household member reporting to census enumerator",
+      "informant_proximity": "household_member",
+      "informant_bias_notes": "Birthplace requires active reporting by a household member; the census does not name the informant.",
+      "evidence_type": "indirect",
+      "log_entry_id": "log_004",
+      "extracted_for_question_ids": [
+        "q_002"
+      ]
+    },
+    {
+      "id": "a_003",
+      "source_id": "src_002",
+      "record_id": "ark:/61903/1:1:MM88-DGG",
+      "record_role": "child_1",
+      "fact_type": "relationship",
+      "value": "Charles Ferber listed as son in the household of William and Emma Ferber, age 9, single",
+      "structured_value": {
+        "relationship_type": "child_inferred",
+        "related_person_role": "head_of_household"
+      },
+      "date": "1900",
+      "date_certainty": "exact",
+      "place": "Cincinnati, Hamilton, Ohio, United States",
+      "information_quality": "primary",
+      "informant": "Census enumerator, witness to household composition",
+      "informant_proximity": "witness",
+      "informant_bias_notes": "Enumerator directly recorded household membership by visiting the dwelling.",
+      "evidence_type": "direct",
+      "log_entry_id": "log_004",
+      "extracted_for_question_ids": [
+        "q_002"
+      ]
+    },
+    {
+      "id": "a_004",
+      "source_id": "src_003",
+      "record_id": "ark:/61903/1:1:F66M-8JZ",
+      "record_role": "deceased",
+      "fact_type": "death",
+      "value": "11 Mar 1903, Cincinnati, Hamilton, Ohio",
+      "structured_value": {
+        "date": "1903-03-11",
+        "place": "Cincinnati, Hamilton, Ohio, United States"
+      },
+      "date": "11 Mar 1903",
+      "date_certainty": "exact",
+      "place": "Cincinnati, Hamilton, Ohio, United States",
+      "information_quality": "primary",
+      "informant": "Unknown (likely a family member or undertaker reporting to the county recorder)",
+      "informant_proximity": "official_duty",
+      "informant_bias_notes": "County death record; the specific informant is not named in the index. No cause-of-death field is present in this index-level source.",
+      "evidence_type": "direct",
+      "log_entry_id": "log_004",
+      "extracted_for_question_ids": [
+        "q_001"
+      ]
+    },
+    {
+      "id": "a_005",
+      "source_id": "src_003",
+      "record_id": "ark:/61903/1:1:F66M-8JZ",
+      "record_role": "deceased",
+      "fact_type": "relationship",
+      "value": "William Ferber's parents recorded as Gerhard Ferber and Eva Ferber",
+      "structured_value": {
+        "father": "Gerhard Ferber",
+        "mother": "Eva Ferber"
+      },
+      "date": "1903",
+      "date_certainty": "exact",
+      "place": "Cincinnati, Hamilton, Ohio, United States",
+      "information_quality": "secondary",
+      "informant": "Unknown informant reporting on the decedent's parentage",
+      "informant_proximity": "household_member",
+      "informant_bias_notes": "Death-record informants are typically family and are secondary (not eyewitness) informants for the decedent's own parentage.",
+      "evidence_type": "direct",
+      "log_entry_id": "log_004",
+      "extracted_for_question_ids": [
+        "q_002"
+      ]
+    },
+    {
+      "id": "a_006",
+      "source_id": "src_004",
+      "record_id": "n/a (newspaper clipping, no FamilySearch record)",
+      "record_role": "deceased",
+      "fact_type": "death",
+      "value": "Died at age 76 in Dec 1967",
+      "structured_value": {
+        "age_at_death": 76
+      },
+      "date": "12 Dec 1967",
+      "date_certainty": "exact",
+      "place": "Fort Lauderdale, Broward, Florida, United States",
+      "information_quality": "secondary",
+      "informant": "Unknown (family-supplied obituary information, typical for newspaper obituaries)",
+      "informant_proximity": "family_not_present",
+      "informant_bias_notes": "Newspaper obituaries are usually compiled from family-supplied information after death; treated as secondary for facts about the deceased's early life (e.g. birth year implied by age).",
+      "evidence_type": "indirect",
+      "extracted_for_question_ids": [
+        "q_002"
+      ]
+    },
+    {
+      "id": "a_007",
+      "source_id": "src_002",
+      "record_id": "ark:/61903/1:1:MM88-DGG",
+      "record_role": "head_of_household",
+      "fact_type": "birth",
+      "value": "Germany",
+      "structured_value": {
+        "place": "Germany"
+      },
+      "date": "1869",
+      "date_certainty": "approximate",
+      "place": "Germany",
+      "information_quality": "indeterminate",
+      "informant": "Client's own transcription of the same 1900 census clipping (known_holding kh_002)",
+      "informant_proximity": "self",
+      "informant_bias_notes": "This is a conflicting reading of the identical 1900 census record already captured as a_001 (FamilySearch index says Ohio). The client's clipping is a firsthand image of the same document, but neither reading has been checked against the actual census image via the tools available here — this is a transcription discrepancy on ONE record, not corroboration between independent sources.",
+      "evidence_type": "indirect",
+      "extracted_for_question_ids": [
+        "q_002"
+      ]
+    },
+    {
+      "id": "a_008",
+      "source_id": "src_002",
+      "record_id": "ark:/61903/1:1:MM88-DGG",
+      "record_role": "wife",
+      "fact_type": "birth",
+      "value": "Kentucky, age 29",
+      "structured_value": {
+        "place": "Kentucky, United States",
+        "age": 29
+      },
+      "date": "~1871",
+      "date_certainty": "estimated",
+      "place": "Kentucky, United States",
+      "information_quality": "indeterminate",
+      "informant": "Client's own transcription of the same 1900 census clipping (known_holding kh_002)",
+      "informant_proximity": "self",
+      "informant_bias_notes": "Conflicting reading of the identical record already captured as a_002 (FamilySearch index says Ohio). Same caveat as a_007 — an image-level check is needed to adjudicate.",
+      "evidence_type": "indirect",
+      "extracted_for_question_ids": [
+        "q_002"
+      ]
+    }
+  ],
+  "person_evidence": [
+    {
+      "id": "pe_001",
+      "assertion_id": "a_001",
+      "person_id": "I2",
+      "confidence": "confident",
+      "rationale": "William Ferber, head of household, matches William Hubert Ferber (I2) by name, household composition (wife Emma, son Charles), and place.",
+      "match_score": null,
+      "created": "2026-07-06",
+      "superseded_by": null
+    },
+    {
+      "id": "pe_002",
+      "assertion_id": "a_002",
+      "person_id": "I3",
+      "confidence": "confident",
+      "rationale": "Emma Ferber, wife, matches Emma Becker (I3) by name, household composition, and place.",
+      "match_score": null,
+      "created": "2026-07-06",
+      "superseded_by": null
+    },
+    {
+      "id": "pe_003",
+      "assertion_id": "a_003",
+      "person_id": "I1",
+      "confidence": "confident",
+      "rationale": "Charles Ferber, son, age 9 in 1900, matches Charles Hubert Ferber (I1, b. 22 Jun 1891) by name, age, and household position.",
+      "match_score": null,
+      "created": "2026-07-06",
+      "superseded_by": null
+    },
+    {
+      "id": "pe_004",
+      "assertion_id": "a_004",
+      "person_id": "I2",
+      "confidence": "confident",
+      "rationale": "Death record for Wm. Ferber, d. 11 Mar 1903 Cincinnati, matches William Hubert Ferber (I2) by name, place, and the FamilySearch tree's existing death fact.",
+      "match_score": null,
+      "created": "2026-07-06",
+      "superseded_by": null
+    },
+    {
+      "id": "pe_005",
+      "assertion_id": "a_005",
+      "person_id": "I2",
+      "confidence": "confident",
+      "rationale": "Death record names the decedent's parents as Gerhard Ferber and Eva Ferber, matching I4 (Gerhard Ferber) and I5 (Eva Engermann/Ferber) — independent corroboration of the tree's grandparent link.",
+      "match_score": null,
+      "created": "2026-07-06",
+      "superseded_by": null
+    },
+    {
+      "id": "pe_006",
+      "assertion_id": "a_006",
+      "person_id": "I1",
+      "confidence": "confident",
+      "rationale": "Obituary age-at-death (76 in Dec 1967) is consistent with Charles Hubert Ferber's (I1) established birth date of 22 Jun 1891.",
+      "match_score": null,
+      "created": "2026-07-06",
+      "superseded_by": null
+    },
+    {
+      "id": "pe_007",
+      "assertion_id": "a_007",
+      "person_id": "I2",
+      "confidence": "speculative",
+      "rationale": "Client's transcription attributes this birthplace to William Ferber (I2); conflicts with a_001 — see conflict c_001. Not confidently resolved.",
+      "match_score": null,
+      "created": "2026-07-06",
+      "superseded_by": null
+    },
+    {
+      "id": "pe_008",
+      "assertion_id": "a_008",
+      "person_id": "I3",
+      "confidence": "speculative",
+      "rationale": "Client's transcription attributes this birthplace to Emma Ferber (I3); conflicts with a_002 — see conflict c_002. Not confidently resolved.",
+      "match_score": null,
+      "created": "2026-07-06",
+      "superseded_by": null
+    }
+  ],
+  "conflicts": [
+    {
+      "id": "c_001",
+      "conflict_type": "fact",
+      "description": "William Hubert Ferber's birthplace: Ohio (FamilySearch's index of the 1900 census, and the compiled Family Tree) vs. Germany (client's own reading of the same 1900 census clipping)",
+      "disputed_attribute": "birthplace",
+      "identity_question": null,
+      "competing_assertion_ids": [
+        "a_001",
+        "a_007"
+      ],
+      "independence_analysis": "These are NOT independent sources — both readings come from the same original 1900 census entry (ark:/61903/1:1:MM88-DGG), just transcribed differently (FamilySearch's index vs. the client's own reading of a clipping). This is a transcription-accuracy question, not corroboration between separate records. Note also that William's father Gerhard Ferber is independently documented as a German immigrant (b. 1820 Germany, immigrated ~1850) — so a Germany birthplace for William (b. ~1869) would be inconsistent with Gerhard's already-established immigration date, unless Gerhard made a return trip. This makes the Ohio reading more plausible on genealogical grounds, but is not conclusive without checking the original image.",
+      "weighing_analysis": "No image-level verification was possible with the tools available in this session. The Ohio reading is corroborated by the FamilySearch index AND is more consistent with the independently-documented immigration timeline of William's father. The Germany reading rests solely on the client's own transcription.",
+      "preferred_assertion_id": "a_001",
+      "resolution_rationale": "Tentatively prefer 'Ohio' given the corroborating immigration-timeline evidence, but this is not a confident resolution — recommend the client or a researcher with access to the digitized 1900 census image (Ancestry or FamilySearch image viewer) re-check the actual entry before treating this as settled.",
+      "status": "unresolved",
+      "blocks_question_ids": [
+        "q_002"
+      ]
+    },
+    {
+      "id": "c_002",
+      "conflict_type": "fact",
+      "description": "Emma (Becker) Ferber's birthplace and birth date: Cincinnati, Ohio, 25 Mar 1870 (compiled Family Tree) / March 1871, Ohio (FamilySearch's index of the 1900 census) vs. Kentucky, age 29 in 1900 (client's own reading of the same census clipping)",
+      "disputed_attribute": "birthplace",
+      "identity_question": null,
+      "competing_assertion_ids": [
+        "a_002",
+        "a_008"
+      ],
+      "independence_analysis": "Same underlying record as c_001 — the FamilySearch index and the client's clipping are two transcriptions of the same 1900 census entry, not independent sources. The compiled Family Tree's 'Cincinnati, Ohio, 25 Mar 1870' birth fact for Emma is itself uncorroborated (quality:1) and does not by itself resolve which census reading is correct.",
+      "weighing_analysis": "No image-level verification was possible in this session. Unlike William's case, there is no independent corroborating fact (like an immigrant father's timeline) to favor either reading here.",
+      "preferred_assertion_id": null,
+      "resolution_rationale": "Left unresolved. Recommend checking the original 1900 census image directly — the discrepancy affects whether Emma's own ancestry (her parents John Becker and Mary Kramer) should be researched in Ohio or Kentucky records.",
+      "status": "unresolved",
+      "blocks_question_ids": [
+        "q_002"
+      ]
+    }
+  ],
+  "hypotheses": [],
+  "timelines": [],
+  "proof_summaries": [
+    {
+      "id": "ps_001",
+      "question_id": "q_001",
+      "tier": "not_proved",
+      "vehicle": "summary",
+      "supporting_assertion_ids": [
+        "a_005"
+      ],
+      "resolved_conflict_ids": [],
+      "exhaustive_search_summary": "Checked FamilySearch's Ohio County Death Records index (log_004) — confirms date/place and parents, no cause field. Searched FamilySearch's full-text AI-transcribed document index for a contemporary death notice (log_006) — nil. Confirmed via collections_search that FamilySearch has no dedicated, indexed Hamilton County, Ohio newspaper/obituary collection for 1903. An un-indexed image-only collection (Ohio, Hamilton County Records, 1791-1994) may hold a probate or coroner's file but requires manual browsing outside this session's tools. Not exhausted: Library of Congress Chronicling America (free), Newspapers.com/GenealogyBank (subscription, client has none), and manual browsing of the Hamilton County image collection remain untried.",
+      "narrative_markdown": "## Circumstances of William Hubert Ferber's Death (d. 11 Mar 1903)\n\n**Not Proved.** The date and place of William Hubert Ferber's death — 11 March 1903, Cincinnati, Hamilton County, Ohio — are well established, independently corroborated by both FamilySearch's compiled Family Tree and the Ohio County Death Records index (which also names his parents, Gerhard and Eva Ferber, matching the tree). However, **the cause or circumstances of death could not be determined** with the tools available in this session.\n\n### What is established\n\n- William Hubert Ferber died 11 March 1903 in Cincinnati, Hamilton County, Ohio, at about age 33 (b. ~Dec 1869) — confirmed by an independent county death record (a_005), not just the compiled tree.\n- He was survived by his wife Emma (Becker) Ferber and at least one son, Charles Hubert Ferber, then about 11 years old.\n\n### What is not established\n\n- No cause-of-death field exists in the FamilySearch death-record index consulted.\n- No contemporary newspaper death notice was found in FamilySearch's full-text index, and FamilySearch has no dedicated indexed newspaper collection for Hamilton County, Ohio covering 1903.\n- The underlying death certificate image, a probate/coroner file, or a period newspaper (e.g. via the free Library of Congress Chronicling America archive, or a paid service like Newspapers.com/GenealogyBank) were not checked — these are the most promising next steps and are outside what this session's tools could reach.\n\n### Recommendation\n\nThis question remains open. Recommended next steps, in order of ease: (1) search Chronicling America (loc.gov, free) for a Cincinnati Enquirer or Cincinnati Post notice in mid-March 1903; (2) if the client has or can obtain Newspapers.com/GenealogyBank access, repeat the search there; (3) request the original Hamilton County death certificate image, which may include a cause-of-death field the index does not capture."
+    },
+    {
+      "id": "ps_002",
+      "question_id": "q_002",
+      "tier": "probable",
+      "vehicle": "summary",
+      "supporting_assertion_ids": [
+        "a_001",
+        "a_002",
+        "a_003",
+        "a_005",
+        "a_006"
+      ],
+      "resolved_conflict_ids": [],
+      "exhaustive_search_summary": "Extended the pedigree two generations beyond Charles Hubert Ferber's parents via FamilySearch's compiled Family Tree (log_003), then independently cross-checked the paternal grandparent link against William Ferber's own 1903 death record (log_004), which names Gerhard and Eva Ferber as his parents — consistent with the tree. Attempted to verify Gerhard Ferber's naturalization/immigration record (log_007) — no match found. Two birthplace conflicts (c_001, c_002) remain unresolved pending an original 1900 census image check. Maternal-line ancestry beyond John Becker and Mary Kramer was not pursued, pending resolution of Emma's birthplace conflict.",
+      "narrative_markdown": "## Extended Ancestry of Charles Hubert Ferber (b. 22 Jun 1891)\n\n**Probable**, for two generations beyond his parents.\n\n### Pedigree established\n\n- **Parents:** William Hubert Ferber (b. ~Dec 1869, Ohio; d. 11 Mar 1903, Cincinnati) and Emma Becker (b. ~1870/71, Ohio).\n- **Paternal grandparents:** Gerhard Ferber (b. 29 Sep 1820, Germany; immigrated ~1850; naturalized 1853, Ohio; d. 31 May 1917, Cincinnati) and Eva Engermann (b. 1834, Bavaria; d. 1 Jan 1872, Cincinnati). This link is corroborated by two independent FamilySearch sources: the compiled Family Tree and William's own 1903 death record, which separately names Gerhard and Eva as his parents (a_005) — the strongest evidence in this project.\n- **Maternal grandparents:** John Becker (b. ~Jan 1845, Kentucky) and Mary Kramer (b. Ohio, date unknown). This link currently rests only on the compiled Family Tree (quality:1, uncorroborated).\n\n### Why \"Probable\" and not \"Proved\"\n\n1. The paternal line (Gerhard & Eva Ferber) has independent corroboration from two sources agreeing on the same parent-child link, but both ultimately trace to FamilySearch as the repository, and Gerhard's own immigration/naturalization facts could not be independently verified (a targeted record search returned no match).\n2. The maternal line (Becker/Kramer) rests solely on the uncorroborated compiled tree.\n3. Two open conflicts (c_001, c_002) affect William's and Emma's birthplaces — if either resolves to Germany or Kentucky respectively (rather than Ohio), it would change which country/state's records the next generation search should target, so it is deferred rather than guessed.\n\n### Recommendation\n\nBefore treating this pedigree as settled: (1) check the original 1900 census image to resolve c_001/c_002; (2) attempt a more targeted naturalization search for Gerhard Ferber (Ohio Southern District Naturalization Index, collection 2110749); (3) once Emma's birthplace is resolved, search for John Becker's and Mary Kramer's own parents in the appropriate state's records."
+    }
+  ],
+  "evaluations": []
+}

--- a/eval/tests/e2e/ferber-grandparents/reference-project/tree.gedcomx.json
+++ b/eval/tests/e2e/ferber-grandparents/reference-project/tree.gedcomx.json
@@ -1,0 +1,146 @@
+{
+  "persons": [
+    {
+      "id": "I1",
+      "gender": "Male",
+      "names": [
+        { "id": "N1", "given": "Charles Hubert", "surname": "Ferber", "preferred": true }
+      ],
+      "facts": [
+        { "id": "F1", "type": "Birth", "date": "22 June 1891", "standard_date": "22 Jun 1891", "place": "Cincinnati, Hamilton, Ohio, United States", "standard_place": "Cincinnati, Hamilton, Ohio, United States", "sources": [{ "ref": "S1", "quality": 1 }] },
+        { "id": "F2", "type": "Death", "date": "12 December 1967", "standard_date": "12 Dec 1967", "place": "Fort Lauderdale, Broward, Florida, United States", "standard_place": "Fort Lauderdale, Broward, Florida, United States", "sources": [{ "ref": "S1", "quality": 1 }, { "ref": "S4", "quality": 2 }] },
+        { "id": "F3", "type": "Residence", "date": "1900", "standard_date": "1900", "place": "Cincinnati, Hamilton, Ohio, United States", "standard_place": "Cincinnati, Hamilton, Ohio, United States", "sources": [{ "ref": "S1", "quality": 1 }, { "ref": "S2", "quality": 2 }] },
+        { "id": "F4", "type": "Residence", "date": "1910", "standard_date": "1910", "place": "Cincinnati Ward 21, Hamilton, Ohio, United States", "standard_place": "Cincinnati, Hamilton, Ohio, United States", "sources": [{ "ref": "S1", "quality": 1 }] },
+        { "id": "F5", "type": "Military Draft Registration", "date": "1917-1918", "standard_date": "Bet 1917 and 1918", "place": "Cincinnati, Hamilton, Ohio, United States", "standard_place": "Cincinnati, Hamilton, Ohio, United States", "sources": [{ "ref": "S1", "quality": 1 }] },
+        { "id": "F6", "type": "Residence", "date": "1920", "standard_date": "1920", "place": "Cincinnati, Hamilton, Ohio, United States", "standard_place": "Cincinnati, Hamilton, Ohio, United States", "sources": [{ "ref": "S1", "quality": 1 }] },
+        { "id": "F7", "type": "Residence", "date": "1930", "standard_date": "1930", "place": "Cincinnati, Hamilton, Ohio, United States", "standard_place": "Cincinnati, Hamilton, Ohio, United States", "sources": [{ "ref": "S1", "quality": 1 }] },
+        { "id": "F8", "type": "Residence", "date": "1935", "standard_date": "1935", "place": "Cincinnati, Hamilton, Ohio, United States", "standard_place": "Cincinnati, Hamilton, Ohio, United States", "sources": [{ "ref": "S1", "quality": 1 }] },
+        { "id": "F9", "type": "Residence", "date": "1940", "standard_date": "1940", "place": "Columbia Township, Hamilton, Ohio, United States", "standard_place": "Columbia Township, Hamilton, Ohio, United States", "sources": [{ "ref": "S1", "quality": 1 }] },
+        { "id": "F10", "type": "Military Draft Registration", "date": "1942", "standard_date": "1942", "place": "Ohio, United States", "standard_place": "Ohio, United States", "sources": [{ "ref": "S1", "quality": 1 }] },
+        { "id": "F11", "type": "Residence", "date": "10 April 1950", "standard_date": "10 Apr 1950", "place": "Mariemont, Hamilton, Ohio, United States", "standard_place": "Mariemont, Hamilton, Ohio, United States", "sources": [{ "ref": "S1", "quality": 1 }] },
+        { "id": "F12", "type": "Burial", "place": "Spring Grove Cemetery, Cincinnati, Hamilton, Ohio, United States", "standard_place": "Spring Grove Cemetery, Cincinnati, Hamilton, Ohio, United States", "sources": [{ "ref": "S1", "quality": 1 }] }
+      ]
+    },
+    {
+      "id": "I2",
+      "gender": "Male",
+      "names": [
+        { "id": "N2", "given": "William Hubert", "surname": "Ferber", "preferred": true }
+      ],
+      "facts": [
+        { "id": "F13", "type": "Birth", "date": "December 1869", "standard_date": "Dec 1869", "place": "Ohio, United States", "standard_place": "Ohio, United States", "sources": [{ "ref": "S1", "quality": 1 }, { "ref": "S2", "quality": 2 }] },
+        { "id": "F14", "type": "Residence", "date": "1870", "standard_date": "1870", "place": "Cincinnati, Hamilton, Ohio, United States", "standard_place": "Cincinnati, Hamilton, Ohio, United States", "sources": [{ "ref": "S1", "quality": 1 }] },
+        { "id": "F15", "type": "Residence", "date": "1900", "standard_date": "1900", "place": "Cincinnati, Hamilton, Ohio, United States", "standard_place": "Cincinnati, Hamilton, Ohio, United States", "sources": [{ "ref": "S1", "quality": 1 }, { "ref": "S2", "quality": 2 }] },
+        { "id": "F16", "type": "Death", "date": "11 March 1903", "standard_date": "11 Mar 1903", "place": "Cincinnati, Hamilton, Ohio, United States", "standard_place": "Cincinnati, Hamilton, Ohio, United States", "sources": [{ "ref": "S1", "quality": 1 }, { "ref": "S3", "quality": 2 }] },
+        { "id": "F17", "type": "Burial", "place": "Cincinnati, Hamilton, Ohio, United States", "standard_place": "Cincinnati, Hamilton, Ohio, United States", "sources": [{ "ref": "S1", "quality": 1 }] }
+      ]
+    },
+    {
+      "id": "I3",
+      "gender": "Female",
+      "names": [
+        { "id": "N3", "given": "Emma", "surname": "Becker", "preferred": true }
+      ],
+      "facts": [
+        { "id": "F18", "type": "Birth", "date": "25 March 1870", "standard_date": "25 Mar 1870", "place": "Cincinnati, Hamilton, Ohio, United States", "standard_place": "Cincinnati, Hamilton, Ohio, United States", "sources": [{ "ref": "S1", "quality": 1 }] },
+        { "id": "F19", "type": "Residence", "date": "1900", "standard_date": "1900", "place": "Cincinnati, Hamilton, Ohio, United States", "standard_place": "Cincinnati, Hamilton, Ohio, United States", "sources": [{ "ref": "S1", "quality": 1 }, { "ref": "S2", "quality": 2 }] },
+        { "id": "F20", "type": "Death", "date": "7 December 1948", "standard_date": "7 Dec 1948", "place": "Dayton, Campbell, Kentucky, United States", "standard_place": "Dayton, Campbell, Kentucky, United States", "sources": [{ "ref": "S1", "quality": 1 }] },
+        { "id": "F21", "type": "Burial", "date": "10 December 1948", "standard_date": "10 Dec 1948", "place": "Spring Grove Cemetery, Cincinnati, Hamilton, Ohio, United States", "standard_place": "Spring Grove Cemetery, Cincinnati, Hamilton, Ohio, United States", "sources": [{ "ref": "S1", "quality": 1 }] }
+      ]
+    },
+    {
+      "id": "I4",
+      "gender": "Male",
+      "names": [
+        { "id": "N4", "given": "Gerhard", "surname": "Ferber", "preferred": true }
+      ],
+      "facts": [
+        { "id": "F22", "type": "Birth", "date": "29 September 1820", "standard_date": "29 Sep 1820", "place": "Germany", "standard_place": "Germany", "sources": [{ "ref": "S1", "quality": 1 }] },
+        { "id": "F23", "type": "Immigration", "date": "1850", "standard_date": "1850", "sources": [{ "ref": "S1", "quality": 1 }] },
+        { "id": "F24", "type": "Naturalization", "date": "1853", "standard_date": "1853", "place": "Ohio, United States", "standard_place": "Ohio, United States", "sources": [{ "ref": "S1", "quality": 1 }] },
+        { "id": "F25", "type": "Death", "date": "31 May 1917", "standard_date": "31 May 1917", "place": "Cincinnati, Hamilton, Ohio, United States", "standard_place": "Cincinnati, Hamilton, Ohio, United States", "sources": [{ "ref": "S1", "quality": 1 }] },
+        { "id": "F26", "type": "Burial", "place": "Cincinnati, Hamilton, Ohio, United States", "standard_place": "Cincinnati, Hamilton, Ohio, United States", "sources": [{ "ref": "S1", "quality": 1 }] }
+      ]
+    },
+    {
+      "id": "I5",
+      "gender": "Female",
+      "names": [
+        { "id": "N5", "given": "Eva", "surname": "Engermann", "preferred": true }
+      ],
+      "facts": [
+        { "id": "F27", "type": "Birth", "date": "1834", "standard_date": "1834", "place": "Bavaria, German Empire", "standard_place": "Bavaria", "sources": [{ "ref": "S1", "quality": 1 }] },
+        { "id": "F28", "type": "Death", "date": "1 January 1872", "standard_date": "1 Jan 1872", "place": "Cincinnati, Hamilton, Ohio, United States", "standard_place": "Cincinnati, Hamilton, Ohio, United States", "sources": [{ "ref": "S1", "quality": 1 }] },
+        { "id": "F29", "type": "Burial", "date": "January 1872", "standard_date": "Jan 1872", "place": "Spring Grove Cemetery, Cincinnati, Hamilton, Ohio, United States", "standard_place": "Spring Grove Cemetery, Cincinnati, Hamilton, Ohio, United States", "sources": [{ "ref": "S1", "quality": 1 }] }
+      ]
+    },
+    {
+      "id": "I6",
+      "gender": "Male",
+      "names": [
+        { "id": "N6", "given": "John", "surname": "Becker", "preferred": true }
+      ],
+      "facts": [
+        { "id": "F30", "type": "Birth", "date": "January 1845", "standard_date": "Jan 1845", "place": "Kentucky, United States", "standard_place": "Kentucky, United States", "sources": [{ "ref": "S1", "quality": 1 }] }
+      ]
+    },
+    {
+      "id": "I7",
+      "gender": "Female",
+      "names": [
+        { "id": "N7", "given": "Mary", "surname": "Kramer", "preferred": true }
+      ],
+      "facts": [
+        { "id": "F31", "type": "Birth", "place": "Ohio, United States", "standard_place": "Ohio, United States", "sources": [{ "ref": "S1", "quality": 1 }] }
+      ]
+    },
+    {
+      "id": "I8",
+      "gender": "Female",
+      "names": [
+        { "id": "N8", "given": "Lydian Inez", "surname": "Hall", "preferred": true }
+      ],
+      "facts": [
+        { "id": "F32", "type": "Birth", "date": "1893", "standard_date": "1893", "sources": [{ "ref": "S1", "quality": 1 }] }
+      ]
+    },
+    {
+      "id": "I9",
+      "gender": "Female",
+      "names": [
+        { "id": "N9", "given": "Harriet Helen", "surname": "Bailey", "preferred": true }
+      ],
+      "facts": [
+        { "id": "F33", "type": "Birth", "date": "20 May 1903", "standard_date": "20 May 1903", "place": "Oakley, Cincinnati, Hamilton, Ohio, United States", "standard_place": "Oakley, Cincinnati, Hamilton, Ohio, United States", "sources": [{ "ref": "S1", "quality": 1 }] },
+        { "id": "F34", "type": "Death", "date": "7 March 1999", "standard_date": "7 Mar 1999", "place": "Fort Lauderdale, Broward, Florida, United States", "standard_place": "Fort Lauderdale, Broward, Florida, United States", "sources": [{ "ref": "S1", "quality": 1 }] }
+      ]
+    }
+  ],
+  "relationships": [
+    { "id": "R1", "type": "ParentChild", "parent": "I2", "child": "I1" },
+    { "id": "R2", "type": "ParentChild", "parent": "I3", "child": "I1" },
+    { "id": "R3", "type": "Couple", "person1": "I2", "person2": "I3", "facts": [
+      { "id": "F35", "type": "Marriage", "date": "10 September 1890", "standard_date": "10 Sep 1890", "place": "Hamilton, Ohio, United States", "standard_place": "Hamilton, Ohio, United States", "sources": [{ "ref": "S1", "quality": 1 }] }
+    ] },
+    { "id": "R4", "type": "ParentChild", "parent": "I4", "child": "I2" },
+    { "id": "R5", "type": "ParentChild", "parent": "I5", "child": "I2" },
+    { "id": "R6", "type": "Couple", "person1": "I4", "person2": "I5", "facts": [
+      { "id": "F36", "type": "Marriage", "date": "21 May 1856", "standard_date": "21 May 1856", "place": "Hamilton, Ohio, United States", "standard_place": "Hamilton, Ohio, United States", "sources": [{ "ref": "S1", "quality": 1 }] }
+    ] },
+    { "id": "R7", "type": "ParentChild", "parent": "I6", "child": "I3" },
+    { "id": "R8", "type": "ParentChild", "parent": "I7", "child": "I3" },
+    { "id": "R9", "type": "Couple", "person1": "I6", "person2": "I7" },
+    { "id": "R10", "type": "Couple", "person1": "I1", "person2": "I8", "facts": [
+      { "id": "F37", "type": "Marriage", "date": "1 February 1918", "standard_date": "1 Feb 1918", "place": "Chicago, Cook, Illinois, United States", "standard_place": "Chicago, Cook, Illinois, United States", "sources": [{ "ref": "S1", "quality": 1 }] }
+    ] },
+    { "id": "R11", "type": "Couple", "person1": "I1", "person2": "I9", "facts": [
+      { "id": "F38", "type": "Marriage", "date": "21 April 1934", "standard_date": "21 Apr 1934", "place": "Williamstown, Grant, Kentucky, United States", "standard_place": "Williamstown, Grant, Kentucky, United States", "sources": [{ "ref": "S1", "quality": 1 }] }
+    ] }
+  ],
+  "sources": [
+    { "id": "S1", "title": "FamilySearch Family Tree", "author": "FamilySearch contributors" },
+    { "id": "S2", "title": "United States, Census, 1900", "citation": "\"United States, Census, 1900\", FamilySearch (https://www.familysearch.org/ark:/61903/1:1:MM88-DGG), Entry for William Ferber and Emma Ferber, 1900.", "url": "https://www.familysearch.org/ark:/61903/1:1:MM88-DGG" },
+    { "id": "S3", "title": "Ohio, County Death Records, 1840-2001", "citation": "\"Ohio, County Death Records, 1840-2001\", FamilySearch (https://www.familysearch.org/ark:/61903/1:1:F66M-8JZ), Entry for Wm. Ferber and Gerhard Ferber, 11 Mar 1903.", "url": "https://www.familysearch.org/ark:/61903/1:1:F66M-8JZ" },
+    { "id": "S4", "title": "Obituary of Charles Ferber", "author": "Fort Lauderdale News", "citation": "Fort Lauderdale News, Fort Lauderdale, FL, 13 Dec 1967 (client-provided clipping)" }
+  ]
+}

--- a/eval/tests/e2e/ferber-grandparents/starting-research.json
+++ b/eval/tests/e2e/ferber-grandparents/starting-research.json
@@ -1,0 +1,26 @@
+{
+  "project": {
+    "id": "rp_ferber_grandparents",
+    "objective": "Who were the grandparents of Charles Hubert Ferber, born 22 June 1891 in Cincinnati, Ohio (the parents of his father William Hubert Ferber and his mother Emma Becker)?",
+    "subject_person_ids": ["I1"],
+    "status": "active",
+    "created": "2026-07-06T00:00:00Z",
+    "updated": "2026-07-06T00:00:00Z"
+  },
+  "researcher_profile": {
+    "experience_level": "intermediate",
+    "subscriptions": [],
+    "narration_guidance": "concise"
+  },
+  "questions": [],
+  "plans": [],
+  "log": [],
+  "sources": [],
+  "assertions": [],
+  "person_evidence": [],
+  "conflicts": [],
+  "hypotheses": [],
+  "timelines": [],
+  "proof_summaries": [],
+  "evaluations": []
+}

--- a/eval/tests/e2e/ferber-grandparents/starting-tree.gedcomx.json
+++ b/eval/tests/e2e/ferber-grandparents/starting-tree.gedcomx.json
@@ -1,0 +1,92 @@
+{
+  "persons": [
+    {
+      "id": "I1",
+      "gender": "Male",
+      "names": [
+        { "id": "N1", "given": "Charles Hubert", "surname": "Ferber", "preferred": true }
+      ],
+      "facts": [
+        { "id": "F1", "type": "Birth", "date": "22 June 1891", "standard_date": "22 Jun 1891", "place": "Cincinnati, Hamilton, Ohio, United States", "standard_place": "Cincinnati, Hamilton, Ohio, United States", "sources": [{ "ref": "S1", "quality": 1 }] },
+        { "id": "F2", "type": "Death", "date": "12 December 1967", "standard_date": "12 Dec 1967", "place": "Fort Lauderdale, Broward, Florida, United States", "standard_place": "Fort Lauderdale, Broward, Florida, United States", "sources": [{ "ref": "S1", "quality": 1 }, { "ref": "S4", "quality": 2 }] },
+        { "id": "F3", "type": "Residence", "date": "1900", "standard_date": "1900", "place": "Cincinnati, Hamilton, Ohio, United States", "standard_place": "Cincinnati, Hamilton, Ohio, United States", "sources": [{ "ref": "S1", "quality": 1 }, { "ref": "S2", "quality": 2 }] },
+        { "id": "F4", "type": "Residence", "date": "1910", "standard_date": "1910", "place": "Cincinnati Ward 21, Hamilton, Ohio, United States", "standard_place": "Cincinnati, Hamilton, Ohio, United States", "sources": [{ "ref": "S1", "quality": 1 }] },
+        { "id": "F5", "type": "Military Draft Registration", "date": "1917-1918", "standard_date": "Bet 1917 and 1918", "place": "Cincinnati, Hamilton, Ohio, United States", "standard_place": "Cincinnati, Hamilton, Ohio, United States", "sources": [{ "ref": "S1", "quality": 1 }] },
+        { "id": "F6", "type": "Residence", "date": "1920", "standard_date": "1920", "place": "Cincinnati, Hamilton, Ohio, United States", "standard_place": "Cincinnati, Hamilton, Ohio, United States", "sources": [{ "ref": "S1", "quality": 1 }] },
+        { "id": "F7", "type": "Residence", "date": "1930", "standard_date": "1930", "place": "Cincinnati, Hamilton, Ohio, United States", "standard_place": "Cincinnati, Hamilton, Ohio, United States", "sources": [{ "ref": "S1", "quality": 1 }] },
+        { "id": "F8", "type": "Residence", "date": "1935", "standard_date": "1935", "place": "Cincinnati, Hamilton, Ohio, United States", "standard_place": "Cincinnati, Hamilton, Ohio, United States", "sources": [{ "ref": "S1", "quality": 1 }] },
+        { "id": "F9", "type": "Residence", "date": "1940", "standard_date": "1940", "place": "Columbia Township, Hamilton, Ohio, United States", "standard_place": "Columbia Township, Hamilton, Ohio, United States", "sources": [{ "ref": "S1", "quality": 1 }] },
+        { "id": "F10", "type": "Military Draft Registration", "date": "1942", "standard_date": "1942", "place": "Ohio, United States", "standard_place": "Ohio, United States", "sources": [{ "ref": "S1", "quality": 1 }] },
+        { "id": "F11", "type": "Residence", "date": "10 April 1950", "standard_date": "10 Apr 1950", "place": "Mariemont, Hamilton, Ohio, United States", "standard_place": "Mariemont, Hamilton, Ohio, United States", "sources": [{ "ref": "S1", "quality": 1 }] },
+        { "id": "F12", "type": "Burial", "place": "Spring Grove Cemetery, Cincinnati, Hamilton, Ohio, United States", "standard_place": "Spring Grove Cemetery, Cincinnati, Hamilton, Ohio, United States", "sources": [{ "ref": "S1", "quality": 1 }] }
+      ]
+    },
+    {
+      "id": "I2",
+      "gender": "Male",
+      "names": [
+        { "id": "N2", "given": "William Hubert", "surname": "Ferber", "preferred": true }
+      ],
+      "facts": [
+        { "id": "F13", "type": "Birth", "date": "December 1869", "standard_date": "Dec 1869", "place": "Ohio, United States", "standard_place": "Ohio, United States", "sources": [{ "ref": "S1", "quality": 1 }, { "ref": "S2", "quality": 2 }] },
+        { "id": "F14", "type": "Residence", "date": "1870", "standard_date": "1870", "place": "Cincinnati, Hamilton, Ohio, United States", "standard_place": "Cincinnati, Hamilton, Ohio, United States", "sources": [{ "ref": "S1", "quality": 1 }] },
+        { "id": "F15", "type": "Residence", "date": "1900", "standard_date": "1900", "place": "Cincinnati, Hamilton, Ohio, United States", "standard_place": "Cincinnati, Hamilton, Ohio, United States", "sources": [{ "ref": "S1", "quality": 1 }, { "ref": "S2", "quality": 2 }] },
+        { "id": "F16", "type": "Death", "date": "11 March 1903", "standard_date": "11 Mar 1903", "place": "Cincinnati, Hamilton, Ohio, United States", "standard_place": "Cincinnati, Hamilton, Ohio, United States", "sources": [{ "ref": "S1", "quality": 1 }, { "ref": "S3", "quality": 2 }] },
+        { "id": "F17", "type": "Burial", "place": "Cincinnati, Hamilton, Ohio, United States", "standard_place": "Cincinnati, Hamilton, Ohio, United States", "sources": [{ "ref": "S1", "quality": 1 }] }
+      ]
+    },
+    {
+      "id": "I3",
+      "gender": "Female",
+      "names": [
+        { "id": "N3", "given": "Emma", "surname": "Becker", "preferred": true }
+      ],
+      "facts": [
+        { "id": "F18", "type": "Birth", "date": "25 March 1870", "standard_date": "25 Mar 1870", "place": "Cincinnati, Hamilton, Ohio, United States", "standard_place": "Cincinnati, Hamilton, Ohio, United States", "sources": [{ "ref": "S1", "quality": 1 }] },
+        { "id": "F19", "type": "Residence", "date": "1900", "standard_date": "1900", "place": "Cincinnati, Hamilton, Ohio, United States", "standard_place": "Cincinnati, Hamilton, Ohio, United States", "sources": [{ "ref": "S1", "quality": 1 }, { "ref": "S2", "quality": 2 }] },
+        { "id": "F20", "type": "Death", "date": "7 December 1948", "standard_date": "7 Dec 1948", "place": "Dayton, Campbell, Kentucky, United States", "standard_place": "Dayton, Campbell, Kentucky, United States", "sources": [{ "ref": "S1", "quality": 1 }] },
+        { "id": "F21", "type": "Burial", "date": "10 December 1948", "standard_date": "10 Dec 1948", "place": "Spring Grove Cemetery, Cincinnati, Hamilton, Ohio, United States", "standard_place": "Spring Grove Cemetery, Cincinnati, Hamilton, Ohio, United States", "sources": [{ "ref": "S1", "quality": 1 }] }
+      ]
+    },
+    {
+      "id": "I8",
+      "gender": "Female",
+      "names": [
+        { "id": "N8", "given": "Lydian Inez", "surname": "Hall", "preferred": true }
+      ],
+      "facts": [
+        { "id": "F32", "type": "Birth", "date": "1893", "standard_date": "1893", "sources": [{ "ref": "S1", "quality": 1 }] }
+      ]
+    },
+    {
+      "id": "I9",
+      "gender": "Female",
+      "names": [
+        { "id": "N9", "given": "Harriet Helen", "surname": "Bailey", "preferred": true }
+      ],
+      "facts": [
+        { "id": "F33", "type": "Birth", "date": "20 May 1903", "standard_date": "20 May 1903", "place": "Oakley, Cincinnati, Hamilton, Ohio, United States", "standard_place": "Oakley, Cincinnati, Hamilton, Ohio, United States", "sources": [{ "ref": "S1", "quality": 1 }] },
+        { "id": "F34", "type": "Death", "date": "7 March 1999", "standard_date": "7 Mar 1999", "place": "Fort Lauderdale, Broward, Florida, United States", "standard_place": "Fort Lauderdale, Broward, Florida, United States", "sources": [{ "ref": "S1", "quality": 1 }] }
+      ]
+    }
+  ],
+  "relationships": [
+    { "id": "R1", "type": "ParentChild", "parent": "I2", "child": "I1" },
+    { "id": "R2", "type": "ParentChild", "parent": "I3", "child": "I1" },
+    { "id": "R3", "type": "Couple", "person1": "I2", "person2": "I3", "facts": [
+      { "id": "F35", "type": "Marriage", "date": "10 September 1890", "standard_date": "10 Sep 1890", "place": "Hamilton, Ohio, United States", "standard_place": "Hamilton, Ohio, United States", "sources": [{ "ref": "S1", "quality": 1 }] }
+    ] },
+    { "id": "R10", "type": "Couple", "person1": "I1", "person2": "I8", "facts": [
+      { "id": "F37", "type": "Marriage", "date": "1 February 1918", "standard_date": "1 Feb 1918", "place": "Chicago, Cook, Illinois, United States", "standard_place": "Chicago, Cook, Illinois, United States", "sources": [{ "ref": "S1", "quality": 1 }] }
+    ] },
+    { "id": "R11", "type": "Couple", "person1": "I1", "person2": "I9", "facts": [
+      { "id": "F38", "type": "Marriage", "date": "21 April 1934", "standard_date": "21 Apr 1934", "place": "Williamstown, Grant, Kentucky, United States", "standard_place": "Williamstown, Grant, Kentucky, United States", "sources": [{ "ref": "S1", "quality": 1 }] }
+    ] }
+  ],
+  "sources": [
+    { "id": "S1", "title": "FamilySearch Family Tree", "author": "FamilySearch contributors" },
+    { "id": "S2", "title": "United States, Census, 1900", "citation": "\"United States, Census, 1900\", FamilySearch (https://www.familysearch.org/ark:/61903/1:1:MM88-DGG), Entry for William Ferber and Emma Ferber, 1900.", "url": "https://www.familysearch.org/ark:/61903/1:1:MM88-DGG" },
+    { "id": "S3", "title": "Ohio, County Death Records, 1840-2001", "citation": "\"Ohio, County Death Records, 1840-2001\", FamilySearch (https://www.familysearch.org/ark:/61903/1:1:F66M-8JZ), Entry for Wm. Ferber, 11 Mar 1903.", "url": "https://www.familysearch.org/ark:/61903/1:1:F66M-8JZ" },
+    { "id": "S4", "title": "Obituary of Charles Ferber", "author": "Fort Lauderdale News", "citation": "Fort Lauderdale News, Fort Lauderdale, FL, 13 Dec 1967 (client-provided clipping)" }
+  ]
+}


### PR DESCRIPTION
## Summary
- New Path-2 e2e fixture (`eval/tests/e2e/ferber-grandparents/`), converted from a finished client research project, testing whether the agent can extend Charles Hubert Ferber's ancestry to his four grandparents (Gerhard Ferber/Eva Engermann paternal, John Becker/Mary Kramer maternal).
- Paternal-line answer is independently corroborable in live FamilySearch data via two sources (compiled tree + Ohio death record); maternal-line rests only on the compiled tree per authoring-time research — noted in the fixture's `notes` for lenient grading.
- Includes `reference-project/` with the full source research (GPS-classified sources/assertions, person-evidence links, two open birthplace conflicts, the research plans/log, and both proof summaries — including the `not_proved` conclusion on William Hubert Ferber's cause of death, which is why this fixture only covers the ancestry-extension half of that project) this fixture was distilled from. For reviewer context only — not part of the benchmark contract (the harness only reads the five standard fixture files).
- The death-circumstances question was researched exhaustively within available tools before concluding `not_proved`: county death record (no cause field, no linked image), post-1908 statewide death collections (out of date range — Ohio's statewide certificates start in 1908, five years after this death), a general deaths/burials index (one hit, but a false-positive fuzzy match on an unrelated person), FamilySearch full-text search (nil, including a hospital-records query), and a digitized-volumes browse for Hamilton County (no death-records volume with a clear image link surfaced).

## Test plan
- [x] `uv run python -m e2e.validate_fixture ferber-grandparents` passes (stripping linter confirms all expected findings are genuinely absent from the starting tree)
- [x] `validate_research_schema` passes against `starting-research.json` + `starting-tree.gedcomx.json`
- [x] Live `make e2e-run TEST=ferber-grandparents` — run before merge (see comment below): first attempt hit a transient API stream-idle timeout (scratch, not committed); second attempt got a partial result (usage-limit error mid-run), graded blind and committed as `run-2026-07-07_08-10-37.json` + `.ann.json`. Paternal line (f1/f2) recovered via the death-certificate assertion; maternal line (f3/f4) never reached. Confirms the fixture is recoverable, not that a full clean pass exists yet — see comment for details.

🤖 Generated with [Claude Code](https://claude.com/claude-code)