### PR TITLE
eval: align LLM judge with human grades on negative tests

### DIFF
--- a/eval/harness/harness/orchestrator.py
+++ b/eval/harness/harness/orchestrator.py
@@ -910,6 +910,10 @@ def _negative_judge_context(spec: TestSpec) -> list[str]:
         f"decline/routing decision: a clear, accurate decline is a full "
         f"pass. Do NOT penalize the response for not carrying out "
         f"{spec.skill}'s task — not doing it is the correct outcome here.",
+        f"Conversely, if {spec.skill} instead carried out its own task, or "
+        f"produced substantive output when it should have declined or stayed "
+        f"silent, score Correctness and Completeness as fail (1) — polished "
+        f"output for the wrong behavior is still a failure, not a pass.",
         *spec.judge_context,
     ]
 

--- a/eval/harness/judge/prompt.md
+++ b/eval/harness/judge/prompt.md
@@ -50,6 +50,36 @@ proves the skill called a tool with wrong arguments (or called a tool that
 doesn't exist). This is always a failure.
 
 ────────────────────────────────────────
+# Critical: Negative tests (decline / routing / non-activation)
+
+Some tests are **negative tests**: the correct behavior is for the skill
+under test to NOT carry out its own task. When this is the case, the
+**Per-test context** section below states it explicitly ("This is a
+NEGATIVE test…") and names what should have happened instead — decline
+and route to a specific other skill, or (for an out-of-scope request)
+produce no output at all.
+
+On a negative test, grade **Correctness** and **Completeness** against
+that expected behavior — NOT against the quality of any task output that
+happens to appear:
+
+- **Correct decline / routing / non-activation → score 3 (pass).** If the
+  skill declined, and/or the request was handled by the skill it was
+  supposed to route to (or, for an out-of-scope request, no skill acted),
+  Correctness and Completeness are a full pass. Do not lower them because
+  the decline was terse, because the skill performed the handoff by
+  invoking the correct skill, or because that other skill's work appears
+  in the transcript below. Not doing the under-test skill's task is the
+  correct outcome — do not both credit the routing and penalize the base
+  dimensions for "not declining thoroughly enough."
+- **Wrongly performing the task → score 1 (fail).** If the skill instead
+  carried out its own task, or produced substantive output when it should
+  have declined or stayed silent, Correctness and Completeness fail —
+  **even when that output is fluent, accurate-looking, and well-organized.**
+  Polished output for the wrong behavior is a failure, not a pass; do not
+  award craft credit for work that should never have been done.
+
+────────────────────────────────────────
 # Base rubric (always applies)
 
 ## Correctness
@@ -62,12 +92,30 @@ doesn't exist). This is always a failure.
 - **fail:** Outputs include fabricated material, contradict the input
   state, or rest on unsupported claims that change the result.
 
+Presentation is not correctness. Do not lower Correctness because the
+response did not re-print a file's full contents, kept its narration
+brief (some skills instruct brevity — "the content is in the file"), or
+did not restate a validation/tool step in prose. Grade the substance of
+what was produced, not whether the response re-displays it — file writes,
+schema validity, and tool-call counts are checked separately by
+validators. Likewise, correctly **surfacing** a conflict or a flagged
+data gap (e.g. "the tool warns X but the tree shows Y — flagging rather
+than resolving"), or a clearly-marked out-of-scope observation, is not a
+correctness defect when the skill's own instructions call for it. This is
+all distinct from work that was never actually done: a tool that returned
+no records, a required write that never happened, or a claimed edit that
+left the file unchanged remain Correctness failures.
+
 ## Completeness
 - **pass:** The skill addressed everything the user message and input
   state required. No silent omissions of items it should have covered.
 - **partial:** Addressed most of what was asked but missed one piece
   the input state made obvious.
 - **fail:** Missed major portions of what was asked, or stopped early.
+
+"Incomplete" means work the input state required was not done — not that
+the response declined to re-print or re-narrate work it did do (see the
+presentation note under Correctness). Judge substance, not display.
 
 ## Tool Arguments
 Grade whether the args Claude passed to each MCP tool call match what


### PR DESCRIPTION
## What & why

Rigorous analysis of the **35 unit-test `.ann.json` files that contain at least one judge-vs-human disagreement** (ignoring the 37 rubber-stamped files) surfaced a clear, prompt-fixable misalignment.

**Findings:**
- The judge is **systematically too harsh** — 87 too-low vs 33 too-high on genuine numeric disagreements (2.6:1), concentrated in Correctness and Completeness.
- The single dominant pattern is **negative / routing / non-activation tests: 58 of 120 genuine disagreements (48%)**, across 12 skills, and it cuts **both ways**:
  - Skill correctly declines+routes → judge **under-scores** it (45 too-low; humans literally wrote *"judge scored backwards," "the judge is wrong"*).
  - Skill **wrongly** activates → judge **over-scores** the polished-looking output (13 too-high, e.g. `research-exhaustiveness ut_008`, `translation ut_005`).

**Root cause:** the negative-test framing reached the judge only via `{judge_context}`, which `prompt.md` labels *"background… to ground your rationales"* — while the authoritative Correctness/Completeness definitions had **no negative-test branch**. So the judge defaulted to grading surface output. The existing framing also stated only the pass case, never the fail case.

## Changes (52 lines, 2 files — no logic/outcome changes)

- **`eval/harness/judge/prompt.md`** — new authoritative **"Critical: Negative tests"** section (correct decline/route/non-activation → pass; polished output for the *wrong* behavior → fail), plus a scoped **"presentation is not correctness"** clause on Correctness/Completeness with an explicit guard that *work never actually done still fails* (targets ~10 more cases: not re-printing files, mandated brevity, correctly-surfaced conflicts).
- **`eval/harness/harness/orchestrator.py`** — adds the missing **converse (fail) clause** to `_negative_judge_context` so the injected framing agrees with the prompt.

## Design notes

- **Deliberately incremental.** No blanket leniency — the too-high content-gap cases (`historical-context`, `question-selection`) prove the judge already *misses* real gaps, so a "be generous" nudge would regress them. No per-skill `rubric.md` edits (rubric-critic territory).
- Both new prompt sections land in the **cacheable prefix** — the prompt-caching split (`# Per-test context`) is intact.
- Expected to align ~57% of the genuine numeric disagreements while *reducing* both over- and under-scoring.

## The null/N-A disagreements are NOT addressed here (by design)

46 of 47 "null" disagreements were `judge=null → human=3`, where the human comment says *"No N/A option in the CRUD UI."* The judge was **correct** per the rubric (no tool calls, or "no warnings found → N/A") — the human was forced to enter 3 because the UI can't store null. That is a CRUD-UI gap, addressed in a **separate follow-up PR**, not a judge-prompt problem.

## Verification

- ✅ 63 harness unit tests pass (`test_judge.py`, `test_orchestrator.py`).
- ✅ Caching split preserved; `judge_prompt_hash` regenerates cleanly. (CI rule 2b — judge-hash match — is warn-only.)
- ✅ `_negative_judge_context` returns 4 lines with the converse clause; the existing `ctx[-1]` preservation assertion still holds.

⚠️ Not yet re-run against the affected runlogs (would require a live judge pass). Happy to validate a few negative-test cases before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)