### PR TITLE
eval-app: offer N/A in annotation picker for any judge-null dimension

### DIFF
--- a/docs/specs/eval-crud-ui-spec.md
+++ b/docs/specs/eval-crud-ui-spec.md
@@ -185,8 +185,8 @@ The Results section opens to a dashboard with two panels:
 
 ### Annotation view
 
-- Each rubric dimension and additional criterion shown with the LLM judge's score (`1` = fail, `2` = partial, `3` = pass, `null` = N/A). N/A is currently used only by the **Tool Arguments** base dimension when zero MCP tool calls happened. The score is read directly from the run log — no enum-to-integer mapping happens at display time.
-- For each dimension, an editable `corrected_score` field defaults to the LLM's score; the junior changes only the dimensions they disagree with. The Tool Arguments picker exposes a fourth `N/A` button so the junior can set or override N/A explicitly.
+- Each rubric dimension and additional criterion shown with the LLM judge's score (`1` = fail, `2` = partial, `3` = pass, `null` = N/A). N/A is emitted by the **Tool Arguments** base dimension when zero MCP tool calls happened, and by any rubric dimension with an N/A criterion (e.g. `check-warnings`' *Actionability* / *Severity classification* when the project is clean). The score is read directly from the run log — no enum-to-integer mapping happens at display time.
+- For each dimension, an editable `corrected_score` field defaults to the LLM's score; the junior changes only the dimensions they disagree with. The picker exposes a fourth `N/A` button whenever the judge scored the dimension `null` (so the junior can *agree* with N/A instead of being forced to pick `3`), plus on the nullable base dimension (Tool Arguments) so N/A can be set or overridden explicitly. See `dimensionAllowsNa` in `eval/app/lib/types.ts`.
 - Optional `comment` text area per dimension — expected on disagreement, omitted on agreement.
 - Save writes `<run-log-timestamp>.ann.json` alongside the run log. Schema: `docs/specs/schemas/ann.schema.json`.
 - Every dimension of every test in the run log gets an entry — agreement (`corrected_score == llm_score`) is computed, not stored as a separate flag. See plan §2.3.

--- a/eval/app/app/results/[...id]/page.tsx
+++ b/eval/app/app/results/[...id]/page.tsx
@@ -39,7 +39,7 @@ import type {
   RunLogFile,
   TestEntry,
 } from '@/lib/types';
-import { NULLABLE_BASE_DIMENSIONS } from '@/lib/types';
+import { dimensionAllowsNa } from '@/lib/types';
 import { buildArgTableRows, formatArgValue } from '@/lib/argTable';
 
 interface Detail {
@@ -192,8 +192,11 @@ function ScorePicker({
 }: {
   value: ScoreOrNull;
   onChange: (v: ScoreOrNull) => void;
-  /** When true, the picker shows N/A as a fourth option (used for the
-   * Tool Arguments dimension, which is N/A when zero MCP calls happened). */
+  /** When true, the picker shows N/A as a fourth option — so the reviewer
+   * can agree with (or set) a null score. Enabled whenever the judge scored
+   * the dimension null (any base or rubric dimension with an N/A criterion),
+   * plus the nullable base dimensions (Tool Arguments). See
+   * `dimensionAllowsNa`. */
   allowNa?: boolean;
   onFocus?: () => void;
   onBlur?: () => void;
@@ -293,7 +296,7 @@ const DimensionRow = memo(function DimensionRow({
 
   const disagrees = correction != null && correction.corrected_score !== correction.llm_score;
   const needsComment = disagrees && !draft.trim();
-  const allowNa = dim.source === 'base' && NULLABLE_BASE_DIMENSIONS.has(dim.name);
+  const allowNa = dimensionAllowsNa(dim.source, dim.name, dim.score);
 
   const setScore = (s: ScoreOrNull) => {
     onUpdate({

--- a/eval/app/lib/types.ts
+++ b/eval/app/lib/types.ts
@@ -67,6 +67,31 @@ export const NULLABLE_BASE_DIMENSIONS: ReadonlySet<string> = new Set([
   BASE_DIMENSIONS.TOOL_ARGUMENTS,
 ]);
 
+/**
+ * Whether the annotation score picker should offer an `N/A` (null) option
+ * for a dimension. Two independent reasons:
+ *
+ *  1. The judge itself scored the dimension `null` — the reviewer must be
+ *     able to *agree* with that N/A. This is not limited to base dimensions:
+ *     a rubric dimension with an N/A criterion (e.g. check-warnings'
+ *     "Actionability"/"Severity classification" when the project is clean)
+ *     legitimately comes back null. Without this, the picker only offers
+ *     1/2/3 and the reviewer is forced to pick 3, manufacturing a
+ *     null-vs-3 "disagreement" that is really just a UI gap.
+ *  2. It is a nullable base dimension (Tool Arguments) — the reviewer may
+ *     set *or override to* N/A even when the judge emitted a 1/2/3.
+ */
+export function dimensionAllowsNa(
+  source: DimensionSource,
+  name: string,
+  judgeScore: Score,
+): boolean {
+  return (
+    judgeScore === null ||
+    (source === 'base' && NULLABLE_BASE_DIMENSIONS.has(name))
+  );
+}
+
 export interface RunLogDimension {
   source: DimensionSource;
   name: string;

--- a/eval/app/tests/unit/dimensionAllowsNa.test.ts
+++ b/eval/app/tests/unit/dimensionAllowsNa.test.ts
@@ -1,0 +1,42 @@
+/**
+ * Tests for dimensionAllowsNa (lib/types.ts) — decides when the annotation
+ * score picker offers the N/A (null) option.
+ *
+ * Regression: rubric dimensions that the judge legitimately scored null
+ * (e.g. check-warnings' Actionability when the project is clean) used to get
+ * no N/A button, so the reviewer was forced to pick 3 — manufacturing a
+ * null-vs-3 "disagreement" that was really just a UI gap.
+ */
+import { describe, it, expect } from 'vitest';
+import { dimensionAllowsNa } from '../../lib/types';
+
+describe('dimensionAllowsNa', () => {
+  it('offers N/A when the judge scored a RUBRIC dimension null (the bug)', () => {
+    expect(dimensionAllowsNa('rubric', 'Actionability', null)).toBe(true);
+    expect(dimensionAllowsNa('rubric', 'Severity classification', null)).toBe(
+      true,
+    );
+  });
+
+  it('offers N/A when the judge scored a base dimension null', () => {
+    expect(dimensionAllowsNa('base', 'Tool Arguments', null)).toBe(true);
+    expect(dimensionAllowsNa('base', 'Correctness', null)).toBe(true);
+  });
+
+  it('offers N/A on the nullable base dimension even when judge gave 1/2/3', () => {
+    expect(dimensionAllowsNa('base', 'Tool Arguments', 3)).toBe(true);
+    expect(dimensionAllowsNa('base', 'Tool Arguments', 1)).toBe(true);
+  });
+
+  it('does NOT offer N/A for a scored rubric dimension', () => {
+    expect(dimensionAllowsNa('rubric', 'Actionability', 3)).toBe(false);
+    expect(dimensionAllowsNa('rubric', 'Evidence Explained compliance', 2)).toBe(
+      false,
+    );
+  });
+
+  it('does NOT offer N/A for a scored non-nullable base dimension', () => {
+    expect(dimensionAllowsNa('base', 'Correctness', 3)).toBe(false);
+    expect(dimensionAllowsNa('base', 'Completeness', 1)).toBe(false);
+  });
+});


### PR DESCRIPTION
## What & why

Follow-up to #589. While analyzing judge-vs-human disagreements in the unit-test `.ann.json` files, **46 of 47 "null" disagreements were `judge=null → human=3`**, and the human comments literally say *"No N/A option in the CRUD UI."* The judge was **correct** (per each rubric's N/A criterion) — the reviewer was forced to enter `3` because the picker had no way to *agree* with N/A. That's a UI gap manufacturing false disagreements, not judge miscalibration (which #589 handles).

**Root cause** — `eval/app/app/results/[...id]/page.tsx`:
```ts
const allowNa = dim.source === 'base' && NULLABLE_BASE_DIMENSIONS.has(dim.name);
```
The N/A button was offered **only** for the nullable *base* dimension (Tool Arguments). When the judge legitimately scored a **rubric** dimension `null` — e.g. `check-warnings`' *Actionability* / *Severity classification*, whose rubric says *"N/A when the project is clean"* — the picker showed only 1/2/3, forcing the reviewer to pick `3`.

## Fix

Extract the predicate into a pure, tested helper and enable N/A whenever the judge scored the dimension `null` (any source), in addition to the existing nullable-base case:

```ts
export function dimensionAllowsNa(source, name, judgeScore): boolean {
  return judgeScore === null
      || (source === 'base' && NULLABLE_BASE_DIMENSIONS.has(name));
}
```

The **"Agree All"** button and the row default already copy the judge's `null` through correctly (`corrected_score: … ?? d.score`); this only fixes the **manual per-row** review path.

**No schema/save changes needed** — `ann.schema.json` and the save-path zod schema already accept `corrected_score: null`, and `compare.ts` already excludes null from weighted means.

## Changes

- `eval/app/lib/types.ts` — new pure, exported `dimensionAllowsNa` helper.
- `eval/app/app/results/[...id]/page.tsx` — use it; swap the import; generalize the `allowNa` doc comment.
- `docs/specs/eval-crud-ui-spec.md` — document the generalized N/A rule.
- `eval/app/tests/unit/dimensionAllowsNa.test.ts` — cover both enable reasons + the negative cases.

## Verification

- ✅ `npm run typecheck` clean
- ✅ `eslint` clean
- ✅ 123 app tests pass (5 new)

## Follow-up note (not in this PR)

Existing committed `.ann.json` files that already recorded `null → 3` won't retroactively change; on their next re-annotation the reviewer can now record `null → null`. If desired, those historical entries could be back-corrected separately, but per repo policy `.ann.json` files are only ever rewritten through the CRUD UI, not by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)