### PR TITLE
fix(eval): Setup.bat installs pnpm + viewer deps (pinned 9.15.9)

### DIFF
--- a/eval/Setup.bat
+++ b/eval/Setup.bat
@@ -62,6 +62,35 @@ if errorlevel 1 (
 cd ..\..\..\eval
 
 echo.
+echo Installing pnpm (Node package manager for the viewer)...
+REM Pin to the version in package.json "packageManager". pnpm 10 blocks
+REM dependency build scripts by default, which skips electron's binary
+REM download and breaks the viewer; pnpm 9.x runs them. Keep this in sync
+REM with the "packageManager" field in the repo-root package.json.
+call npm install -g pnpm@9.15.9
+if errorlevel 1 (
+  echo.
+  echo ERROR: Could not install pnpm. Setup aborted.
+  echo Re-open cmd as Administrator and rerun Setup.bat, or install pnpm
+  echo manually from https://pnpm.io/installation.
+  pause
+  exit /b 1
+)
+
+echo.
+echo Installing viewer dependencies...
+cd ..
+call pnpm install
+if errorlevel 1 (
+  echo.
+  echo ERROR: pnpm install failed. Setup aborted.
+  cd eval
+  pause
+  exit /b 1
+)
+cd eval
+
+echo.
 echo Installing Claude Code CLI globally (required by the test harness)...
 call npm install -g @anthropic-ai/claude-code
 if errorlevel 1 (


### PR DESCRIPTION
## Problem

`Setup.bat` installed only the npm/uv side of the repo (eval/app, mcp-server, uv, Claude CLI). It never installed **pnpm** or ran `pnpm install`, so when a Windows genealogist launched the Electron Research Viewer via `Viewer.bat`, it failed with:

```
ERROR: 'pnpm' was not found on PATH. Run Setup.bat first to install dependencies...
```

`Viewer.bat` runs `pnpm --filter cowork-genealogy-ui dev`, which needs pnpm **and** the installed pnpm workspace — neither of which `Setup.bat` provided. The error message even pointed back at `Setup.bat`, which couldn't fix it.

## Fix

Add a pnpm step to `Setup.bat` that:
1. Installs pnpm pinned to **9.15.9** via `npm install -g pnpm@9.15.9`.
2. Runs `pnpm install` at the repo root to build the viewer workspace (schema, viewer-ui, apps/electron).

### Why pin the version, and why npm not corepack

- **Pin to 9.15.9** (matching the repo-root `package.json` `packageManager` field): pnpm 10 blocks dependency build scripts by default, which silently skips **electron's binary download** and breaks the viewer at launch (`getElectronPath` / "Electron failed to install"). pnpm 9.x runs build scripts by default, matching the Mac dev setup.
- **npm, not corepack**: `corepack enable` writes shims into `C:\Program Files\nodejs`, which EPERMs on standard (non-admin) Windows installs. `npm install -g` targets the user-writable global prefix.

`Viewer.bat` is intentionally left unchanged — keeping install in `Setup.bat` and launch in `Viewer.bat` is the right split.

## Testing

Static trace only — batch files can't be exercised on macOS. Verified the `cd` navigation stays balanced (every step that leaves `eval\` returns to it) and that the moving parts it depends on are correct (pnpm workspace root, the `cowork-genealogy-ui` filter name, the pinned `pnpm@9.15.9`).

> Note: a separate OneDrive-placeholder issue (repo checked out under `…\OneDrive\…`) was the Windows user's *immediate* blocker and is resolved by moving the repo off a synced path — orthogonal to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)