### PR TITLE
fix(deps): patch form-data HIGH advisory; document deferred audit findings

### DIFF
--- a/docs/dependency-security-advisories.md
+++ b/docs/dependency-security-advisories.md
@@ -1,0 +1,47 @@
+# Dependency security advisories
+
+Tracking note for `pnpm audit` / `npm audit` findings across the repo's three JS
+dependency trees (root pnpm workspace, `packages/engine/mcp-server` npm,
+`eval/app` npm). Re-run the audits after any dependency bump and update this file.
+
+Last reviewed: **2026-07-07**.
+
+## Fixed
+- **form-data** (HIGH, GHSA-hmw2-7cc7-3qxx, CRLF injection) — root pnpm
+  workspace, pulled transitively by `electron-builder` → `electron-publish`
+  (build/publish tooling in `apps/electron`; not in the running app or the MCP
+  server). Fixed by a `pnpm.overrides` entry in the root `package.json`
+  (`"form-data@<4.0.6": "^4.0.6"`), bumping 4.0.5 → 4.0.6. The lockfile change is
+  scoped to form-data only.
+
+## Deferred / no clean fix
+
+- **postcss** (MODERATE, GHSA-qx2v-qp2m-jg93, XSS via unescaped `</style>` in CSS
+  stringify) — `eval/app` only, via `next`'s internally pinned `postcss@8.4.31`.
+  **Deferred.** `next` 15.5.18/.19/.20 all pin the vulnerable exact version, so a
+  safe patch bump doesn't help. An npm `overrides` entry *does* fix it (dedupes to
+  the already-present patched 8.5.16 → 0 vulnerabilities), but npm won't apply a
+  new override to an already-locked exact pin without a full re-resolve, which
+  drifts ~113 unrelated dev-toolchain packages (vitest, playwright, rollup,
+  typescript-eslint, tsx…) and rewrites platform-binary entries. Not worth that
+  churn for a moderate CSS-stringify XSS in an internal-only dev tool (the Eval
+  CRUD UI is never shipped or deployed).
+  **Revisit when** `eval/app` needs a routine lockfile refresh anyway, or on the
+  next `next` major bump (16+, which ships a patched postcss natively).
+
+- **tmp** (HIGH, GHSA-52f5-9888-hmc6 + GHSA-ph9p-34f9-6g65, symlink /
+  path-traversal write) — `packages/engine/mcp-server` only, via
+  `@anthropic-ai/mcpb` → `@inquirer/prompts` → `@inquirer/editor` →
+  `external-editor` → `tmp`. **No fix available.** We are already on the newest
+  `@anthropic-ai/mcpb` (2.1.2), whose `@inquirer` chain pins the old `tmp`; no
+  patched release exists. `@anthropic-ai/mcpb` is a devDependency used only to
+  build the `.mcpb` desktop extension — it is not shipped in the MCP server
+  runtime or any deployed artifact.
+  **Revisit when** `@anthropic-ai/mcpb` publishes a release that bumps the
+  `@inquirer`/`tmp` chain.
+
+- **esbuild** (LOW, GHSA-g7r4-m6w7-qqqr, dev-server arbitrary file read,
+  **Windows only**) — root pnpm workspace, bundled by `vite@7.3.5`. **Deferred.**
+  Affects only the running dev server on Windows; `vite` pins its esbuild, so an
+  override risks a vite/esbuild version mismatch for near-zero security gain.
+  **Revisit when** `vite` is upgraded to a release bundling esbuild ≥ 0.28.1.

--- a/package.json
+++ b/package.json
@@ -18,5 +18,10 @@
   "devDependencies": {
     "turbo": "^2.3.3",
     "typescript": "^5.9.3"
+  },
+  "pnpm": {
+    "overrides": {
+      "form-data@<4.0.6": "^4.0.6"
+    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  form-data@<4.0.6: ^4.0.6
+
 importers:
 
   .:
@@ -1981,8 +1984,8 @@ packages:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
 
-  form-data@4.0.5:
-    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
+  form-data@4.0.6:
+    resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
     engines: {node: '>= 6'}
 
   fs-extra@10.1.0:
@@ -5263,7 +5266,7 @@ snapshots:
       builder-util: 26.15.0
       builder-util-runtime: 9.7.0
       chalk: 4.1.2
-      form-data: 4.0.5
+      form-data: 4.0.6
       fs-extra: 10.1.0
       lazy-val: 1.0.5
       mime: 2.6.0
@@ -5695,7 +5698,7 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
-  form-data@4.0.5:
+  form-data@4.0.6:
     dependencies:
       asynckit: 0.4.0
       combined-stream: 1.0.8


### PR DESCRIPTION
## What & why

Triaged the `pnpm audit` / `npm audit` findings across the repo's three JS
dependency trees and patched the one HIGH-severity advisory that has a clean,
minimal fix. Documented the rest.

### Findings (ranked)

| Package | Severity | Tree | Pulled in by | Ships to users? | Action |
|---------|----------|------|--------------|-----------------|--------|
| **form-data** 4.0.5 → 4.0.6 | 🔴 HIGH | root pnpm | `electron-builder` → `electron-publish` (`apps/electron` devDep) | No — build/publish tooling | ✅ **Fixed** |
| **postcss** | 🟠 MODERATE | `eval/app` | `next@15.5.18` (internal pin) | No — internal Eval CRUD UI | ⏸️ Deferred |
| **tmp** | 🔴 HIGH | engine `mcp-server` | `@anthropic-ai/mcpb` (build tool) | No — builds the `.mcpb` | ⛔ No upstream fix |
| **esbuild** | 🟢 LOW | root pnpm | `vite@7.3.5` | No — dev server, Windows-only | ⏸️ Deferred |

## Changes

- **`package.json`** — scoped `pnpm.overrides`: `"form-data@<4.0.6": "^4.0.6"`.
- **`pnpm-lock.yaml`** — diff is form-data 4.0.5 → 4.0.6 **only** (pnpm applies the
  override surgically; no unrelated drift).
- **`docs/dependency-security-advisories.md`** — new tracking note recording the
  fixed advisory and why postcss / tmp / esbuild are deferred or unfixable, each
  with a "revisit when" condition.

## Why the other three were left alone

- **postcss** — `next` 15.5.18/.19/.20 all pin the vulnerable `postcss@8.4.31`
  internally, so a safe patch bump can't fix it. An npm override works but only
  via a full re-resolve that drifts ~113 unrelated dev-toolchain packages — not
  worth it for a moderate CSS-stringify XSS in an internal-only dev tool.
- **tmp** — already on the newest `@anthropic-ai/mcpb`; its `@inquirer` chain
  pins the old `tmp` and no patched release exists. Dev/build-only.
- **esbuild** — LOW, Windows-only dev-server issue; `vite` pins its esbuild, so an
  override risks a version mismatch for near-zero gain.

## Testing

- `make typecheck` → 5/5 tasks pass
- `make test-js` → 3/3 tasks pass (electron viewer 40 tests, viewer-ui 118 tests, + web/schema)

`form-data`'s only consumer is `electron-builder`'s publish path (build-time, not
runtime), so a patch bump is low-risk; the suite confirms the workspace is intact.
The engine (`.mcpb`) and Python trees are untouched by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
