### PR TITLE
image_read: accept a document-image ark alongside imageId

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ The MCP server exposes 31 tools.
 | `wikipedia_search` | Wikipedia article summary lookup | None |
 | `place_population` | Historical population data + indexed record counts | None |
 | `place_distance` | Distance between two FamilySearch places | None |
-| `image_read` | Read a FamilySearch image by imageId (NUMBER_NUMBER) and return bytes + metadata | OAuth |
+| `image_read` | Read a FamilySearch image by imageId (NUMBER_NUMBER) or by ark (a document-image ARK, resolver URL, or resolved distribution URL) and return bytes + metadata | OAuth |
 | `person_warnings` | Flags impossible or unlikely facts (death before birth, event after death, implausibly young parent) for a person and their one-hop relatives, reading the local tree — offline | None |
 | `validate_research_schema` | Validate research.json and tree.gedcomx.json against published schemas | None |
 

--- a/docs/specs/image-read-spec.md
+++ b/docs/specs/image-read-spec.md
@@ -2,17 +2,20 @@
 
 ## What it does
 
-Fetches a FamilySearch distribution image (≥200 DPI) by imageId and
-returns the image data so Claude can display it or pass it to OCR
-models. Requires FamilySearch authentication.
+Fetches a FamilySearch distribution image (≥200 DPI) by `imageId` or
+`ark` and returns the image data so Claude can display it or pass it
+to OCR models. Requires FamilySearch authentication.
 
 ## Input
 
 ```typescript
 {
-  imageId: string   // An Image Group Number of the form NUMBER_NUMBER
+  imageId?: string   // An Image Group Number of the form NUMBER_NUMBER
+  ark?: string       // A FamilySearch document-image ARK, resolver URL, or resolved distribution URL
 }
 ```
+
+Exactly one of `imageId` or `ark` must be provided.
 
 ### imageId format
 
@@ -27,8 +30,36 @@ The tool builds the distribution-image URL internally:
 https://familysearch.org/das/v2/dgs:{imageId}/dist.jpg
 ```
 
-The caller never constructs the URL. Fetching requires a valid
-FamilySearch bearer token.
+The caller never constructs the URL.
+
+### ark format
+
+`ark` is for callers that only have a document-image reference code,
+not an `imageId` — e.g. `fulltext_search`'s `id` field (a `3:1:`/
+`3:2:` document-image ARK).
+
+Accepted forms:
+
+- A canonical document-image ARK (`ark:/61903/3:1:...` / `3:2:...`) or
+  a bare type-prefixed id (`3:1:...` / `3:2:...`) — normalized via
+  `src/utils/ark.ts`'s `toArk`/`arkToUrl` and expanded to the full
+  resolver URL (`https://www.familysearch.org/ark:/61903/...`), which
+  is then fetched directly.
+- A full resolver URL for one of the above, passed through unchanged.
+- An already-resolved DeepZoomCloud ARK URL (ending in `/$dist`) or DGS
+  distribution URL (`dgs:.../dist.jpg`), passed through unchanged —
+  the pre-existing shapes from before `imageId` was introduced.
+
+**Verified against a live session (2026-07-07):** fetching a `3:1:`/
+`3:2:` ARK's resolver URL redirects straight to the image bytes
+(confirmed: `image_read({ ark: "ark:/61903/3:1:3Q9M-CSBN-T9CV-F" })`
+returned a 418,782-byte `image/jpeg`). Other FamilySearch ARK types
+(e.g. a `1:2:` record ARK) do not resolve this way — their resolver
+returns an HTML shell, not the image — so `ark` only accepts `3:1:`/
+`3:2:` document-image ARKs; other ARK types are rejected with
+`"Unrecognized ark"` rather than silently attempted.
+
+Fetching requires a valid FamilySearch bearer token.
 
 ## Output
 
@@ -52,10 +83,13 @@ The tool returns two content blocks:
 | Condition | Message |
 |-----------|---------|
 | Not logged in | "Not authenticated. Call the login tool first." |
+| Both imageId and ark provided | "Provide either imageId or ark, not both." |
+| Neither imageId nor ark provided | "image_read requires either imageId or ark." |
 | Invalid imageId format | "Unrecognized imageId. Expected an Image Group Number of the form NUMBER_NUMBER (e.g. 004884748_02613)." |
+| Invalid ark format | "Unrecognized ark. Expected a FamilySearch document-image ARK (ark:/61903/3:1:... or 3:2:..., a bare 3:1:.../3:2:... id, or a resolver URL for one), a DeepZoomCloud ARK URL (ending in /$dist), or a DGS distribution URL (dgs:.../dist.jpg)." |
 | FamilySearch returns non-2xx | "FamilySearch image fetch failed: {status} {statusText}" |
 | Response is not an image | "Expected an image response but got content-type: {type}" |
-| Image exceeds the inline size cap | "FamilySearch image {imageId} is {N} MB — too large to return inline. The MCP transport caps a single response near 1 MB and base64 encoding inflates the image by ~33%, so returning it would crash the session. Read the indexed record for this image with record_read / record_search instead of fetching the page scan, or choose a more specific image." |
+| Image exceeds the inline size cap | "FamilySearch image {imageId or ark} is {N} MB — too large to return inline. The MCP transport caps a single response near 1 MB and base64 encoding inflates the image by ~33%, so returning it would crash the session. Read the indexed record for this image with record_read / record_search instead of fetching the page scan, or choose a more specific image." |
 
 ## Auth
 

--- a/packages/engine/mcp-server/dev/probe-image-read-ark-resolver.ts
+++ b/packages/engine/mcp-server/dev/probe-image-read-ark-resolver.ts
@@ -1,0 +1,43 @@
+/**
+ * Probe: does fetching a FamilySearch ARK resolver URL directly (as
+ * image-read.ts's `arkToImageUrl` does) land on image bytes, or on an HTML
+ * viewer page? Evidence for docs/specs/image-read-spec.md's ark-resolution
+ * caveat.
+ *
+ * Usage:
+ *   npx tsx dev/probe-image-read-ark-resolver.ts <ark>
+ */
+import { getValidToken } from "../src/auth/refresh.js";
+import { BROWSER_USER_AGENT } from "../src/constants.js";
+
+async function main() {
+  const ark = process.argv[2];
+  if (!ark) {
+    console.error("Usage: npx tsx dev/probe-image-read-ark-resolver.ts <ark>");
+    process.exit(1);
+  }
+  const token = await getValidToken();
+  const url = ark.startsWith("http")
+    ? ark
+    : `https://www.familysearch.org/${ark.replace(/^ark:\//, "ark:/")}`;
+
+  for (const accept of ["image/*,*/*", "application/json,*/*;q=0.8"]) {
+    const res = await fetch(url, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: accept,
+        "User-Agent": BROWSER_USER_AGENT,
+      },
+      redirect: "follow",
+    });
+    console.log(`--- Accept: ${accept} ---`);
+    console.log("status:", res.status, res.statusText);
+    console.log("final url:", res.url);
+    console.log("content-type:", res.headers.get("content-type"));
+    const text = await res.text();
+    console.log("body (first 800 chars):", text.slice(0, 800));
+    console.log();
+  }
+}
+
+main();

--- a/packages/engine/mcp-server/dev/try-image-read.ts
+++ b/packages/engine/mcp-server/dev/try-image-read.ts
@@ -3,17 +3,22 @@
  *
  * Usage:
  *   npx tsx dev/try-image-read.ts "<imageId>"   # e.g. 004884748_02613
+ *   npx tsx dev/try-image-read.ts "<ark>"       # e.g. ark:/61903/3:1:3Q9M-CSNL-S98H-M
  */
 
 import { imageReadTool } from "../src/tools/image-read.js";
 
-const imageId = process.argv[2];
-if (!imageId) {
-  console.error("Usage: npx tsx dev/try-image-read.ts <imageId>");
+const value = process.argv[2];
+if (!value) {
+  console.error("Usage: npx tsx dev/try-image-read.ts <imageId | ark>");
   process.exit(1);
 }
 
-const result = await imageReadTool({ imageId });
+// Rough heuristic: an imageId is bare NUMBER_NUMBER; anything else (an ARK,
+// a resolver URL, or a resolved distribution URL) goes through `ark`.
+const result = /^\d+_\d+$/.test(value)
+  ? await imageReadTool({ imageId: value })
+  : await imageReadTool({ ark: value });
 
 // Print metadata only — printing base64 would flood the terminal
 console.log("Metadata:", JSON.stringify(result.metadata, null, 2));

--- a/packages/engine/mcp-server/src/tools/image-read.ts
+++ b/packages/engine/mcp-server/src/tools/image-read.ts
@@ -1,10 +1,24 @@
 import { getValidToken } from "../auth/refresh.js";
 import { BROWSER_USER_AGENT } from "../constants.js";
+import { toArk, arkToUrl } from "../utils/ark.js";
 
 // An imageId is a digitized-image identifier of the form NUMBER_NUMBER
 // (an image group number, an underscore, and an image sequence number,
 // e.g. "004884748_02613").
 const IMAGE_ID_PATTERN = /^\d+_\d+$/;
+
+// `ark` accepts either an already-resolved distribution URL (the pre-#267
+// input shapes, restored here for callers that already have one) or a
+// FamilySearch document-image ARK (3:1:/3:2:, e.g. fulltext_search's `id`),
+// which has no other resolver in this codebase. Verified live
+// (2026-07-07): fetching a 3:1:/3:2: ARK's resolver URL redirects straight
+// to the image bytes. A 1:2: record ARK (e.g. record_search's `recordArk`)
+// does not — its resolver returns an HTML shell, not an image — so that
+// shape is deliberately not accepted here; only 3:1:/3:2: are.
+const ARK_PATTERN = /^https:\/\/sg30p0\.familysearch\.org\/.+\/\$dist$/;
+const DGS_URL_PATTERN =
+  /^https:\/\/(www\.)?familysearch\.org\/das\/v2\/dgs:[^/]+\/dist\.jpg$/;
+const DOCUMENT_IMAGE_ARK_PATTERN = /^ark:\/61903\/3:[12]:[A-Za-z0-9.-]+$/;
 
 // Ceiling on the raw image bytes we will base64-encode and return inline.
 // The MCP stdio transport decodes one JSON message at a time with a hard
@@ -20,7 +34,8 @@ const IMAGE_ID_PATTERN = /^\d+_\d+$/;
 const MAX_INLINE_IMAGE_BYTES = 700_000;
 
 export interface ImageReadInput {
-  imageId: string;
+  imageId?: string;
+  ark?: string;
 }
 
 export interface ImageReadResult {
@@ -39,11 +54,40 @@ function imageIdToUrl(imageId: string): string {
   return `https://familysearch.org/das/v2/dgs:${imageId}/dist.jpg`;
 }
 
+function arkToImageUrl(ark: string): string {
+  if (ARK_PATTERN.test(ark) || DGS_URL_PATTERN.test(ark)) {
+    return ark;
+  }
+  const canonical = toArk(ark);
+  if (DOCUMENT_IMAGE_ARK_PATTERN.test(canonical)) {
+    return arkToUrl(canonical);
+  }
+  throw new Error(
+    "Unrecognized ark. Expected a FamilySearch document-image ARK " +
+      "(ark:/61903/3:1:... or 3:2:..., a bare 3:1:.../3:2:... id, or a " +
+      "resolver URL for one), a DeepZoomCloud ARK URL (ending in /$dist), " +
+      "or a DGS distribution URL (dgs:.../dist.jpg)."
+  );
+}
+
+function resolveInput(input: ImageReadInput): { url: string; label: string } {
+  if (input.imageId !== undefined && input.ark !== undefined) {
+    throw new Error("Provide either imageId or ark, not both.");
+  }
+  if (input.imageId !== undefined) {
+    return { url: imageIdToUrl(input.imageId), label: input.imageId };
+  }
+  if (input.ark !== undefined) {
+    return { url: arkToImageUrl(input.ark), label: input.ark };
+  }
+  throw new Error("image_read requires either imageId or ark.");
+}
+
 export async function imageReadTool(input: ImageReadInput): Promise<{
   imageData: string;
   metadata: ImageReadResult;
 }> {
-  const url = imageIdToUrl(input.imageId);
+  const { url, label } = resolveInput(input);
 
   const token = await getValidToken();
 
@@ -75,7 +119,7 @@ export async function imageReadTool(input: ImageReadInput): Promise<{
   if (buffer.byteLength > MAX_INLINE_IMAGE_BYTES) {
     const mb = (buffer.byteLength / 1_000_000).toFixed(1);
     throw new Error(
-      `FamilySearch image ${input.imageId} is ${mb} MB — too large to return inline. ` +
+      `FamilySearch image ${label} is ${mb} MB — too large to return inline. ` +
         `The MCP transport caps a single response near 1 MB and base64 encoding inflates ` +
         `the image by ~33%, so returning it would crash the session. Read the indexed ` +
         `record for this image with record_read / record_search instead of fetching the ` +
@@ -105,9 +149,11 @@ export async function imageReadTool(input: ImageReadInput): Promise<{
 export const imageReadToolSchema = {
   name: "image_read",
   description:
-    "Fetch a FamilySearch distribution image by imageId and return it as image data. " +
-    "Takes an Image Group Number of the form NUMBER_NUMBER (e.g. 004884748_02613), " +
-    "such as an imageId returned by image_search, and builds the distribution URL internally. " +
+    "Fetch a FamilySearch distribution image and return it as image data. " +
+    "Provide exactly one of imageId or ark. Use imageId (from image_search) " +
+    "when you have one; use ark when you only have a document-image ARK " +
+    "(e.g. from fulltext_search's id field), a resolver URL for one, or an " +
+    "already-resolved distribution URL. " +
     "Requires authentication — call the login tool first if not logged in.",
   inputSchema: {
     type: "object",
@@ -119,7 +165,15 @@ export const imageReadToolSchema = {
           "(an image group number, an underscore, and an image sequence " +
           "number), e.g. 004884748_02613. Feed an imageId from image_search directly.",
       },
+      ark: {
+        type: "string",
+        description:
+          "A FamilySearch document-image ARK, when no imageId is available " +
+          "— ark:/61903/3:1:... or 3:2:... (e.g. from fulltext_search's " +
+          "`id`), a bare 3:1:.../3:2:... id, a full resolver URL for one, " +
+          "or an already-resolved DeepZoomCloud (ending in /$dist) or DGS " +
+          "(dgs:.../dist.jpg) distribution URL.",
+      },
     },
-    required: ["imageId"],
   },
 };

--- a/packages/engine/mcp-server/tests/tools/image-read.test.ts
+++ b/packages/engine/mcp-server/tests/tools/image-read.test.ts
@@ -103,3 +103,107 @@ describe("imageReadTool — imageId input", () => {
     expect(mockFetch).not.toHaveBeenCalled();
   });
 });
+
+describe("imageReadTool — ark input", () => {
+  it("fetches an ARK URL (ending in /$dist) directly", async () => {
+    mockImageResponse();
+    const ark =
+      "https://sg30p0.familysearch.org/service/records/storage/deepzoomcloud/dz/v1/3:1:3Q9M-CSNL-S98H-M/$dist";
+
+    const result = await imageReadTool({ ark });
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const [url] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe(ark);
+    expect(result.metadata.url).toBe(ark);
+  });
+
+  it("fetches a DGS distribution URL directly", async () => {
+    mockImageResponse();
+    const url = "https://familysearch.org/das/v2/dgs:004884748_02613/dist.jpg";
+
+    await imageReadTool({ ark: url });
+
+    const [fetchedUrl] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(fetchedUrl).toBe(url);
+  });
+
+  it("expands a canonical document-image ARK (3:1:) to a resolver URL", async () => {
+    mockImageResponse();
+
+    await imageReadTool({ ark: "ark:/61903/3:1:3Q9M-CSNL-S98H-M" });
+
+    const [fetchedUrl] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(fetchedUrl).toBe(
+      "https://www.familysearch.org/ark:/61903/3:1:3Q9M-CSNL-S98H-M"
+    );
+  });
+
+  it("rejects a record ARK (1:2:, e.g. record_search's recordArk) without fetching", async () => {
+    // Verified live (2026-07-07): a 1:2: ARK's resolver returns an HTML
+    // shell, not the image, so this shape is deliberately unsupported —
+    // only 3:1:/3:2: document-image ARKs resolve to bytes.
+    await expect(
+      imageReadTool({ ark: "ark:/61903/1:2:HSJG-CLNF" })
+    ).rejects.toThrow(/Unrecognized ark/i);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("expands a bare n:n:id ARK to a resolver URL", async () => {
+    mockImageResponse();
+
+    await imageReadTool({ ark: "3:2:3Q9M-CSNL-S98H-M" });
+
+    const [fetchedUrl] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(fetchedUrl).toBe(
+      "https://www.familysearch.org/ark:/61903/3:2:3Q9M-CSNL-S98H-M"
+    );
+  });
+
+  it("passes a full resolver URL through unchanged", async () => {
+    mockImageResponse();
+    const url = "https://www.familysearch.org/ark:/61903/3:1:3Q9M-CSNL-S98H-M";
+
+    await imageReadTool({ ark: url });
+
+    const [fetchedUrl] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(fetchedUrl).toBe(url);
+  });
+
+  it("rejects an unrecognized ark value without fetching", async () => {
+    await expect(imageReadTool({ ark: "not-an-ark" })).rejects.toThrow(
+      /Unrecognized ark/i
+    );
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a non-image resolver response as an error rather than misinterpreting it", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      headers: { get: (name: string) => (name.toLowerCase() === "content-type" ? "text/html" : null) },
+      arrayBuffer: async () => new ArrayBuffer(0),
+    });
+
+    await expect(
+      imageReadTool({ ark: "ark:/61903/3:1:3Q9M-CSNL-S98H-M" })
+    ).rejects.toThrow(/Expected an image response/i);
+  });
+});
+
+describe("imageReadTool — input validation", () => {
+  it("rejects when both imageId and ark are provided", async () => {
+    await expect(
+      imageReadTool({ imageId: "004884748_02613", ark: "ark:/61903/1:2:HSJG-CLNF" })
+    ).rejects.toThrow(/either imageId or ark, not both/i);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("rejects when neither imageId nor ark is provided", async () => {
+    await expect(imageReadTool({})).rejects.toThrow(
+      /requires either imageId or ark/i
+    );
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Adds an optional `ark` input that accepts a 3:1:/3:2: document-image ARK (canonical, bare, or resolver-URL form) plus the pre-#267 resolved DeepZoomCloud/DGS distribution URLs, normalizing via src/utils/ark.ts and fetching directly.

Verified live: a 3:1: ARK's resolver redirects straight to image bytes. A 1:2: record ARK does not (its resolver returns an HTML shell) and is rejected at validation rather than accepted and left to fail downstream.