### PR TITLE
Fix Windows eval setup (uv PATH, Electron binary) + rename electron app

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -212,7 +212,7 @@ server-e2b: e2b-preflight ## E2B sandboxes + REAL agent + FamilySearch login, :1
 
 .PHONY: electron
 electron: $(JS_DEPS) ## Run the Electron viewer (consumes the shared viewer-ui)
-	pnpm --filter cowork-genealogy-ui dev
+	pnpm --filter @genealogy/electron dev
 
 # ── Quality / tests ──────────────────────────────────────────────
 .PHONY: typecheck

--- a/Makefile
+++ b/Makefile
@@ -9,10 +9,11 @@
 .DEFAULT_GOAL := help
 SHELL := /bin/bash
 
-# Source the Anthropic key (operator key) from the sibling UI repo's .env if
-# present, so `make server-dev` / real-agent runs work without copying secrets
-# into this repo. Override by exporting ANTHROPIC_API_KEY yourself.
-UI_ENV := ../cowork-genealogy-ui/.env
+# Source the Anthropic key (operator key) from this repo's eval/.env if present,
+# so `make server-dev` / real-agent runs work without exporting it. Absolute
+# ($(CURDIR)) so the grep still resolves after the `cd apps/server` below.
+# Override by exporting ANTHROPIC_API_KEY yourself.
+EVAL_ENV := $(CURDIR)/eval/.env
 
 # ── Dependency stamps (make implicit prerequisites explicit) ─────
 # Each run/test target depends on a stamp below instead of silently assuming the
@@ -149,12 +150,12 @@ server-mock: ## MOCK agent, dev-login, local sandboxes, :8000 — zero setup, no
 .PHONY: server-dev
 server-dev: $(ENGINE_BUILD) ## REAL agent, dev-login (no FamilySearch), :8000 — needs ANTHROPIC_API_KEY (web client: make web-dev)
 	# engine-build prereq: the real agent forks `node <packages/engine/mcp-server/build/index.js>`.
-	# Key is sourced from $$ANTHROPIC_API_KEY, else the sibling repo's .env (UI_ENV).
+	# Key is sourced from $$ANTHROPIC_API_KEY, else this repo's eval/.env (EVAL_ENV).
 	# Pin the same dev-friendly values as `server-mock` (local provider, dev-login,
 	# FS front door off) so .env kept for the server/e2b targets doesn't leak in here.
 	cd apps/server && AGENT_MODE=real SANDBOX_PROVIDER=local \
 	  FAMILYSEARCH_WEB_ENABLED=false \
-	  ANTHROPIC_API_KEY="$${ANTHROPIC_API_KEY:-$$(grep -E '^ANTHROPIC_API_KEY=' $(UI_ENV) | cut -d= -f2-)}" \
+	  ANTHROPIC_API_KEY="$${ANTHROPIC_API_KEY:-$$(grep -E '^ANTHROPIC_API_KEY=' $(EVAL_ENV) | cut -d= -f2-)}" \
 	  uv run uvicorn app.main:app --reload --port 8000
 
 .PHONY: server

--- a/apps/electron/electron-builder.yml
+++ b/apps/electron/electron-builder.yml
@@ -26,7 +26,7 @@ mac:
 
 dmg:
   sign: false
-  artifactName: ${name}-${version}-${arch}.${ext}
+  artifactName: research-viewer-${version}-${arch}.${ext}
 
 win:
   executableName: research-viewer
@@ -41,7 +41,7 @@ nsis:
   createDesktopShortcut: true
   createStartMenuShortcut: true
   shortcutName: Research Viewer
-  artifactName: ${name}-${version}-setup.${ext}
+  artifactName: research-viewer-${version}-setup.${ext}
 
 linux:
   target:
@@ -55,7 +55,7 @@ linux:
   icon: build/icon.png
 
 appImage:
-  artifactName: ${name}-${version}.${ext}
+  artifactName: research-viewer-${version}.${ext}
 
 npmRebuild: false
 

--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "cowork-genealogy-ui",
+  "name": "@genealogy/electron",
   "version": "1.0.0",
   "description": "An Electron application with React and TypeScript",
   "main": "./out/main/index.js",

--- a/apps/electron/src/main/menu.ts
+++ b/apps/electron/src/main/menu.ts
@@ -3,7 +3,7 @@ import { is } from '@electron-toolkit/utils'
 
 const isMac = process.platform === 'darwin'
 
-const REPO_URL = 'https://github.com/pioneeracademy/cowork-genealogy-ui'
+const REPO_URL = 'https://github.com/PioneerAIAcademy/cowork-genealogy'
 
 const template: Electron.MenuItemConstructorOptions[] = [
   ...(isMac

--- a/eval/Setup.bat
+++ b/eval/Setup.bat
@@ -24,6 +24,11 @@ if errorlevel 1 (
   exit /b 1
 )
 
+REM The uv installer updates the *persistent* user PATH, but this already-
+REM running cmd session won't see it. Add uv's install dir to PATH for the
+REM rest of this script so the "uv sync" step below can find it.
+set "PATH=%USERPROFILE%\.local\bin;%PATH%"
+
 echo.
 echo Installing Node.js dependencies...
 cd app
@@ -84,6 +89,23 @@ call pnpm install
 if errorlevel 1 (
   echo.
   echo ERROR: pnpm install failed. Setup aborted.
+  cd eval
+  pause
+  exit /b 1
+)
+
+REM A warm pnpm store can skip electron's postinstall (the binary download +
+REM path.txt write), so "pnpm install" alone doesn't guarantee a launchable
+REM viewer -- electron-vite then dies with "Error: Electron uninstall". Force
+REM the rebuild so the binary is always materialized in this checkout.
+echo.
+echo Ensuring the Electron viewer binary is installed...
+call pnpm --filter @genealogy/electron rebuild electron
+if errorlevel 1 (
+  echo.
+  echo ERROR: Could not install the Electron binary. Setup aborted.
+  echo Re-run Setup.bat, or from the repo root run:
+  echo   pnpm --filter @genealogy/electron rebuild electron
   cd eval
   pause
   exit /b 1

--- a/eval/Viewer.bat
+++ b/eval/Viewer.bat
@@ -21,4 +21,24 @@ if errorlevel 1 (
 )
 
 cd ..
-call pnpm --filter cowork-genealogy-ui dev
+
+REM A warm pnpm store can skip electron's postinstall (the binary download +
+REM path.txt write), so a checkout can have every JS dep yet no launchable
+REM Electron -- electron-vite then dies with "Error: Electron uninstall".
+REM require('electron') throws when path.txt is missing, so this is a
+REM path-independent presence check. If it's missing, install it and retry.
+call pnpm --filter @genealogy/electron exec node -e "require('electron')" >nul 2>nul
+if errorlevel 1 (
+  echo Electron binary not found -- installing it now ^(one-time, ~30s^)...
+  call pnpm --filter @genealogy/electron rebuild electron
+  if errorlevel 1 (
+    echo.
+    echo ERROR: Could not install the Electron binary. Re-run Setup.bat, or
+    echo        from the repo root run:
+    echo          pnpm --filter @genealogy/electron rebuild electron
+    pause
+    exit /b 1
+  )
+)
+
+call pnpm --filter @genealogy/electron dev

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "typecheck": "turbo run typecheck",
     "test": "turbo run test",
     "dev:web": "pnpm --filter web dev",
-    "dev:electron": "pnpm --filter cowork-genealogy-ui dev",
+    "dev:electron": "pnpm --filter @genealogy/electron dev",
     "server": "bash apps/server/run-dev.sh"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

Fixes two setup failures Windows users hit when running the eval `Setup.bat` / `Viewer.bat`, renames the Electron app package to end the stale-name confusion, and folds in the two stale-name cleanups originally deferred here.

### Windows setup robustness
- **uv PATH.** The uv installer only updates the *persistent* user PATH, which the already-running cmd session can't see, so the later `uv sync` aborts with `'uv' is not recognized` / `uv sync failed`. Prepend `%USERPROFILE%\.local\bin` to `PATH` right after the install step.
- **Electron binary.** A warm pnpm store can skip electron's postinstall (binary download + `path.txt`), so a checkout can have every JS dep yet no launchable Electron — `electron-vite` then dies with `Error: Electron uninstall`. `Setup.bat` now forces `rebuild electron` after `pnpm install`, and `Viewer.bat` does a path-independent `require('electron')` presence check that auto-remedies (or prints the exact fix) before launching.

### Package rename `cowork-genealogy-ui` → `@genealogy/electron`
Matches the `@genealogy/*` scope already used by `schema` and `viewer-ui` (bare `electron` would collide with the dependency and risk pnpm self-linking). Updated the `pnpm --filter` usages in `package.json`, `Makefile`, `Setup.bat`, and `Viewer.bat`. Switched `electron-builder.yml`'s artifact templates off `${name}` to the literal `research-viewer` (matching the existing `win.executableName` / `productName`) so the scoped name can't produce invalid artifact filenames. `appId`/`productName` were already hardcoded, so installed-app identity is unchanged.

### Stale-name follow-ups (now included — commit f9e0f64c)
The two items this PR originally deferred are now folded in:
- **`menu.ts` `REPO_URL`.** Was `pioneeracademy/cowork-genealogy-ui` (wrong org *and* wrong repo name). Repointed to the real remote `PioneerAIAcademy/cowork-genealogy`. Feeds Help→Releases, the About dialog, and the repo link — all shipped-app behavior, hence the earlier split-out.
- **`Makefile` `server-dev` key source.** Sourced `ANTHROPIC_API_KEY` (the no-export fallback) from a sibling `../cowork-genealogy-ui/.env` that no longer exists — that repo folded into `apps/electron`. Repointed to this repo's own `eval/.env`, renamed `UI_ENV` → `EVAL_ENV`, and made it absolute via `$(CURDIR)` so the `grep` still resolves after the `cd apps/server` in `server-dev` (the old relative path silently missed after that `cd` too — a latent bug).

## Testing
- Live-verified `pnpm --filter @genealogy/electron exec node -e "require('electron')"` resolves the new filter and returns the binary path — confirming both the rename and Viewer.bat's detection command.
- `make -np | grep '^EVAL_ENV'` confirms `EVAL_ENV` expands to the absolute repo-root `eval/.env`, so the `server-dev` key fallback resolves regardless of the `cd apps/server`.
- `security-invariants` skill re-run on `apps/electron` after the `menu.ts` change: core invariants 10/10 hold (the `REPO_URL` change is a lone `https://` constant behind `shell.openExternal`, inert to every invariant).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
