### PR TITLE
fix(electron/security): tighten renderer CSP connect-src to 'self'

### DIFF
--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -58,7 +58,10 @@ function setupCSP(): void {
           "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com;",
           "img-src 'self' data:;",
           "font-src 'self' data: https://fonts.gstatic.com;",
-          "connect-src 'self' http://localhost:3000 https://script.google.com https://script.googleusercontent.com;",
+          // Renderer reaches the network only through main-process IPC (the
+          // feedback POST is a main-process fetch, unaffected by CSP), so the
+          // renderer needs no external connect origins.
+          "connect-src 'self';",
           "object-src 'none';",
           "base-uri 'none';",
           "frame-ancestors 'none';"

--- a/apps/electron/src/renderer/index.html
+++ b/apps/electron/src/renderer/index.html
@@ -5,7 +5,7 @@
     <title>Research Viewer</title>
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' data: https://fonts.gstatic.com; img-src 'self' data:; connect-src 'self' http://localhost:3000 https://script.google.com https://script.googleusercontent.com"
+      content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' data: https://fonts.gstatic.com; img-src 'self' data:; connect-src 'self'"
     />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />


### PR DESCRIPTION
## Summary

Tightens the Electron renderer's CSP `connect-src` from three unused external origins down to `'self'`. This is the code fix for the gap that #610 flagged (and documented) in the `security-invariants` skill.

## Why these origins are safe to remove
The renderer CSP allowed `http://localhost:3000`, `https://script.google.com`, and `https://script.googleusercontent.com` in `connect-src`, but **nothing in the renderer uses them**:
- The feedback submission POST is a **main-process** `fetch` (`src/main/index.ts` `feedback:submit` handler) — `connect-src` governs the *renderer*, not the main process, so it never applied.
- `viewer-ui` (the renderer) makes **no direct external `fetch`/XHR/WebSocket**; in Electron it talks to main over the IPC transport.

The three origins were inherited from the shared hosted-web CSP when the workbench landed (#293). Removing them — especially the plain-HTTP `localhost:3000` — closes an unused external-egress allowance.

## Changes
- `src/main/index.ts` — `connect-src 'self' <3 origins>` → `connect-src 'self'` (this is the **authoritative** header CSP), with a comment explaining why the renderer needs no external connect origins.
- `src/renderer/index.html` — same narrowing in the `<meta>` CSP so the two stay in sync.

**Unchanged:** `style-src`/`font-src` Google Fonts origins (the renderer *does* load them), and the feedback endpoint URL itself (a main-process fetch target, not a CSP directive).

## Testing / verification
- Both CSPs verified in sync (`connect-src 'self'` in header + meta); no external origin remains in either.
- All other CSP directives and every other `security-invariants` item are untouched — this diff only narrows one directive, so it's a pure tightening (no `webPreferences`, IPC, dependency, or entitlement change).
- Not runtime-launched: fonts resolve via `style-src`/`font-src` and feedback posts from the main process, so neither is affected by narrowing `connect-src`.

## Follow-up
Once this lands, #610's §2 "tracked follow-up (not yet done)" note in the skill doc can flip to done — a one-line doc tweak (happy to push it to that branch or as a trailer).

Relates to #606, #610. Origin of the stale directive: #293.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
