### PR TITLE
docs(alpha): fix install menu paths, add update flow, retarget fixture handoff

### DIFF
--- a/.claude/skills/author-e2e-fixture/SKILL.md
+++ b/.claude/skills/author-e2e-fixture/SKILL.md
@@ -318,10 +318,19 @@ place under the repo:
 > Next steps (your call — not run yet):
 > 1. **Lint** — `ValidateFixture.bat` (enter `<slug>`) or
 >    `make e2e-validate TEST=<slug>`; resolve any `WARN`.
-> 2. **Run once** — `RunE2E.bat` (enter `<slug>`) or
->    `make e2e-run TEST=<slug>` (live; 20–60 min, $3–10).
-> 3. **Verdict** — `/interpret-e2e-result`.
-> 4. If it passes, commit the fixture (and its run log) and open a PR.
+> 2. **Seed an editable project** — `SeedProject.bat` (enter `<slug>`) or
+>    `make e2e-project TEST=<slug>`. It copies the fixture's starting state
+>    into `eval/e2e-project/<slug>/` (throwaway, never committed).
+> 3. **Watch it run** — open `eval/e2e-project/<slug>/` in the Claude Desktop
+>    **Cowork** tab and run `/research`. Open the same folder in the Research
+>    Viewer (`Viewer.bat` / `make electron`) to follow along.
+> 4. Commit the five fixture files and open a PR.
+
+Do **not** tell the user to run the scored headless test — that is the internal
+team's step, and they run it after the fixture lands. A live `/research` run
+does not block the tree-reading tools, so the agent can read the answer off the
+live tree: the live run tells you the fixture is *sensible and answerable*, it
+is **not** a pass/fail verdict. Say so when you hand off step 3.
 
 (If you wrote to a `<slug>/` subfolder instead, tell the user to move
 `<slug>/` into `eval/tests/e2e/<slug>/` first, then run the linter.)
@@ -361,13 +370,14 @@ You should (path 1 — from a PID):
    and the Windows `.bat` for each:
    - **Validate the stripping:** `make e2e-validate TEST=<slug>` /
      `ValidateFixture.bat`.
-   - **Debug `/research` live (recommended next):** seed an editable Cowork
-     project with `make e2e-project TEST=<slug>` / `SeedProject.bat`, then
-     watch it in the Research Viewer with `make electron` / `Viewer.bat`.
-     (A live run does not block the tree-read tools, so the honest pass/fail
-     is always the headless run below.)
-   - **Score it headless:** `make e2e-run TEST=<slug>` / `RunE2E.bat`, then
-     `/interpret-e2e-result` for the verdict.
+   - **Seed an editable project:** `make e2e-project TEST=<slug>` /
+     `SeedProject.bat`, which writes `eval/e2e-project/<slug>/`.
+   - **Watch `/research` run live:** open `eval/e2e-project/<slug>/` in the
+     Cowork tab and run `/research`, following along in the Research Viewer
+     (`make electron` / `Viewer.bat`). A live run does not block the tree-read
+     tools, so it is a sanity check on the fixture, not a pass/fail verdict.
+   - **Then commit and open a PR.** The scored headless run is the internal
+     team's step, not the author's — don't send them to it.
 
 *Path 2 (convert a finished project)* differs only at the start: instead
 of a PID + `person_read`, detect an open project whose `research.json`

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -449,11 +449,11 @@ restart. Order matters:
    ```
 5. **Re-install via the Cowork UI** (same path end users follow — see
    `README.md` § "Installation"):
-   - **MCP:** Claude Desktop → Settings → Extensions → "Install
-     Extension..." → pick the rebuilt `releases/genealogy-mcp.mcpb`.
-   - **Plugin:** Claude Desktop → Cowork tab → Customize → Browse
-     plugins → Upload custom plugin → pick the rebuilt
-     `releases/genealogy-plugin.zip`.
+   - **MCP:** Claude Desktop → Settings → Extensions → Advanced Settings
+     → "Install extension" → pick the rebuilt
+     `releases/genealogy-mcp.mcpb`.
+   - **Plugin:** Claude Desktop → Cowork tab → Customize → Add → Upload
+     Plugin → pick the rebuilt `releases/genealogy-plugin.zip`.
 6. **Fully quit Claude Desktop.** The MCP server is only re-read on a
    real restart — closing the window is not enough:
    - **macOS:** ⌘Q, or right-click the Dock icon → Quit. From a terminal,

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -451,9 +451,13 @@ restart. Order matters:
    `README.md` § "Installation"):
    - **MCP:** Claude Desktop → Settings → Extensions → Advanced Settings
      → "Install extension" → pick the rebuilt
-     `releases/genealogy-mcp.mcpb`.
-   - **Plugin:** Claude Desktop → Cowork tab → Customize → Add → Upload
+     `releases/genealogy-mcp.mcpb`. Installs over the old copy; no
+     uninstall needed.
+   - **Plugin:** Claude Desktop → Cowork tab → Customize → **remove the
+     existing Genealogy Research plugin first**, then Add → Upload
      Plugin → pick the rebuilt `releases/genealogy-plugin.zip`.
+     Uploading on top of the old plugin can leave the old skills in
+     place.
 6. **Fully quit Claude Desktop.** The MCP server is only re-read on a
    real restart — closing the window is not enough:
    - **macOS:** ⌘Q, or right-click the Dock icon → Quit. From a terminal,

--- a/README.md
+++ b/README.md
@@ -330,7 +330,7 @@ You need both pieces.
 
 1. Download `genealogy-mcp.mcpb` from the latest release
 2. Open Claude Desktop → Settings → Extensions
-3. Click "Install Extension..." and select the .mcpb file
+3. Click "Advanced Settings" → "Install extension" and select the .mcpb file
 4. The "Genealogy Research" extension should appear in your list
 
 ### 2. Install the Cowork plugin
@@ -338,7 +338,7 @@ You need both pieces.
 1. Download `genealogy-plugin.zip` from the latest release
 2. Open Claude Desktop → switch to Cowork tab
 3. Click "Customize" in the left sidebar
-4. Click "Browse plugins" → "Upload custom plugin"
+4. Click "Add" → "Upload Plugin"
 5. Select the .zip file
 
 ### Alternative: install in Claude Code

--- a/docs/specs/mcpb-package-spec.md
+++ b/docs/specs/mcpb-package-spec.md
@@ -147,7 +147,7 @@ Output: `releases/genealogy-mcp.mcpb` (gitignored via `releases/*`).
 
 This proves the packed artifact — not just the source tree — boots and
 advertises its tools, which is the closest programmatic stand-in for an
-end-user install (the GUI "Install Extension" step is a manual layer in
+end-user install (the GUI "Install extension" step is a manual layer in
 `docs/testing-guides/mcpb-install-testing-guide.md`).
 
 ---

--- a/docs/testing-guides/gps-mentor-agent-testing-guide.md
+++ b/docs/testing-guides/gps-mentor-agent-testing-guide.md
@@ -271,11 +271,11 @@ Cowork plugin, and registers the agent in the Cowork plugin list.
 ### Steps
 
 1. Open **Claude Desktop → Settings → Extensions**.
-2. Click **Install Extension…** and select
+2. Click **Advanced Settings → Install extension** and select
    `releases/genealogy-mcp.mcpb`.
 3. Confirm **"Genealogy Research"** appears with a green dot.
 4. Switch to the **Cowork tab** in Claude Desktop.
-5. Click **Customize → Browse plugins → Upload custom plugin**.
+5. Click **Customize → Add → Upload Plugin**.
 6. Select `releases/genealogy-plugin.zip`.
 7. Confirm **"Genealogy Research"** appears in the installed plugins
    list and that `gps-mentor` is one of the available agents.

--- a/docs/testing-guides/mcpb-install-testing-guide.md
+++ b/docs/testing-guides/mcpb-install-testing-guide.md
@@ -117,7 +117,8 @@ extension. **Prerequisite:** Claude Desktop installed (Windows or macOS).
 1. Copy `releases/genealogy-mcp.mcpb` to the machine running Claude Desktop
    (if you built in WSL2, copy it to the Windows side).
 2. Open Claude Desktop → **Settings → Extensions**.
-3. Click **Install Extension…** and select `genealogy-mcp.mcpb`.
+3. Click **Advanced Settings → Install extension** and select
+   `genealogy-mcp.mcpb`.
 4. Confirm **"Genealogy Research"** appears in the extensions list.
 
 ### What success looks like

--- a/eval/ALPHA-WALKTHROUGH.md
+++ b/eval/ALPHA-WALKTHROUGH.md
@@ -108,12 +108,15 @@ the build + install:
 1. Double-click **`BuildMcpb.bat`** and **`BuildPlugin.bat`** again. `BuildMcpb`
    re-installs npm dependencies and recompiles the server, so it picks up
    whatever changed.
-2. **Install the new version over the old one** — same menus as step 6. You do
-   **not** need to uninstall first; installing the rebuilt `.mcpb` or uploading
-   the rebuilt `.zip` replaces the version that's there. If the new version
-   doesn't take effect after a restart, *then* remove the old one (Extensions
-   list → remove; Cowork → Customize → remove the plugin) and install again.
-3. **Fully quit and reopen Claude Desktop.** The MCP server is only re-read on a
+2. **The `.mcpb` extension: install straight over the old one.** No uninstall
+   needed — Claude Desktop tracks one copy per extension and replaces it.
+   Settings → Extensions → Advanced Settings → Install extension.
+3. **The plugin: remove the old one first, then upload the new one.** In Cowork
+   → Customize, **remove** the existing Genealogy Research plugin, *then*
+   **Add → Upload Plugin** with the rebuilt `.zip`. Uploading on top of the old
+   plugin may leave you running the old skills; removing first is the reliable
+   way to be sure you got the new ones.
+4. **Fully quit and reopen Claude Desktop.** The MCP server is only re-read on a
    real restart. Skipping this is the single most common reason a "reinstalled"
    extension still runs the old code.
 

--- a/eval/ALPHA-WALKTHROUGH.md
+++ b/eval/ALPHA-WALKTHROUGH.md
@@ -44,7 +44,7 @@ siblings, migration…), eras, and geographies.
 
 ## One-time install (Windows)
 
-You install three things outside the repo, then run one batch file inside it.
+You install a few things outside the repo, then run three batch files inside it.
 You only do this once per machine.
 
 1. **Git + GitHub Desktop.** Git for Windows (<https://git-scm.com/download/win>,
@@ -59,30 +59,67 @@ You only do this once per machine.
    *first*, paste `https://github.com/PioneerAIAcademy/cowork-genealogy`, pick a
    Local path, click **Clone**.
 
-4. **Run `eval\Setup.bat`.** Get an Anthropic API key first from
+4. **Open the repo in Explorer.** Everything you run from here on is a
+   double-clickable batch file inside the repo's `eval\` folder. In GitHub
+   Desktop, with the repo selected, click **Show files in Explorer** (also at
+   **Repository → Show in Explorer**). An Explorer window opens on the repo
+   root — **double-click into the `eval` folder.** Leave that window open; you
+   come back to it for every step below and for every fixture.
+
+5. **Run `eval\Setup.bat`.** Get an Anthropic API key first from
    <https://console.anthropic.com/settings/keys> (looks like `sk-ant-…`; a new
-   key is shown only once — save it) — the script prompts for it. In GitHub
-   Desktop: **Repository → Show in Explorer**, open `eval\`, double-click
-   `Setup.bat`. It installs `uv`, runs the npm installs, **builds the MCP
-   server**, installs the viewer's dependencies, and saves your key to
-   `eval\.env`.
+   key is shown only once — save it) — the script prompts for it. In the `eval\`
+   Explorer window from step 4, double-click `Setup.bat`. It installs `uv`, runs
+   the npm installs, **builds the MCP server**, installs the viewer's
+   dependencies, and saves your key to `eval\.env`.
 
    > If it stops with `'uv' is not recognized`, close the window and run
    > `Setup.bat` again — a known Windows PATH quirk. The completed steps are
    > no-ops the second time.
 
-5. **Build + install the two Cowork artifacts.** These give Cowork the
-   genealogy tools for the live run (steps 7–8 below). In Explorer, from `eval\`:
+6. **Build + install the two Cowork artifacts.** These give Cowork the
+   genealogy tools for the live run (steps 7–8 below). From the same `eval\`
+   Explorer window:
 
    - Double-click **`BuildMcpb.bat`**. Then in Claude Desktop: **Settings →
-     Extensions → Install Extension** → choose `releases\genealogy-mcp.mcpb`.
+     Extensions → Advanced Settings → Install extension** → choose
+     `releases\genealogy-mcp.mcpb`.
    - Double-click **`BuildPlugin.bat`**. Then in Claude Desktop: **Cowork →
-     Customize → Browse plugins → Upload custom plugin** → choose
-     `releases\genealogy-plugin.zip`.
-   - **Fully quit and reopen Claude Desktop** after installing.
+     Customize → Add → Upload Plugin** → choose `releases\genealogy-plugin.zip`.
+   - **Fully quit and reopen Claude Desktop** after installing. Closing the
+     window is not enough — use the system-tray icon → **Quit**, and confirm no
+     `Claude.exe` remains in Task Manager.
 
-   ⚠️ **Whenever you pull repo changes** that touch the MCP server or the
-   skills, **rebuild and reinstall both**, then quit and reopen Desktop again.
+   ⚠️ **Install the plugin from the Cowork tab, not the Code tab.** Cowork and
+   Claude Code have *separate* plugin systems — Cowork loads the uploaded
+   `.zip`, Claude Code loads loose skill folders from `~/.claude/skills/`. A
+   plugin you added through the Code tab will not appear in Cowork, and vice
+   versa. Use **Cowork → Customize** and nothing else.
+
+   (The `.mcpb` extension is different: it installs once under **Settings →
+   Extensions** and is shared by the whole Desktop app, Cowork and Code tabs
+   alike. You install it once, not once per tab.)
+
+### Updating after you pull
+
+Any time you pull repo changes that touch the MCP server or the skills, redo
+the build + install:
+
+1. Double-click **`BuildMcpb.bat`** and **`BuildPlugin.bat`** again. `BuildMcpb`
+   re-installs npm dependencies and recompiles the server, so it picks up
+   whatever changed.
+2. **Install the new version over the old one** — same menus as step 6. You do
+   **not** need to uninstall first; installing the rebuilt `.mcpb` or uploading
+   the rebuilt `.zip` replaces the version that's there. If the new version
+   doesn't take effect after a restart, *then* remove the old one (Extensions
+   list → remove; Cowork → Customize → remove the plugin) and install again.
+3. **Fully quit and reopen Claude Desktop.** The MCP server is only re-read on a
+   real restart. Skipping this is the single most common reason a "reinstalled"
+   extension still runs the old code.
+
+> If a batch file now fails on a missing Python or npm dependency, the pull
+> changed the harness dependencies too — re-run `Setup.bat` (have your Anthropic
+> API key handy; it re-prompts and rewrites `eval\.env`).
 
 ---
 
@@ -223,7 +260,13 @@ follow up.
   tab session.
 - **Cowork has no genealogy tools / `/research` degrades to guessing.** The
   `.mcpb` and/or plugin aren't installed, or Desktop wasn't restarted after
-  installing. Re-do install step 5 and **fully quit and reopen** Desktop.
+  installing. Re-do install step 6 and **fully quit and reopen** Desktop.
+- **The plugin is installed but Cowork can't see it.** You installed it in the
+  **Code** tab. Cowork keeps its own plugin list — reinstall via **Cowork →
+  Customize → Add → Upload Plugin** (install step 6).
+- **You pulled, rebuilt, reinstalled — and Claude still runs the old code.**
+  Desktop wasn't *fully* quit. Quit from the system tray, confirm no
+  `Claude.exe` in Task Manager, then reopen. See "Updating after you pull".
 - **`ValidateFixture.bat` prints `WARN` lines.** Each flags a finding that may
   still be present in the starting tree. Review and confirm it's genuinely
   stripped before committing (see step 5).

--- a/eval/BuildMcpb.bat
+++ b/eval/BuildMcpb.bat
@@ -5,8 +5,9 @@ echo === Cowork Genealogy - Build the .mcpb desktop extension ===
 echo.
 echo Compiles the MCP server and packs releases\genealogy-mcp.mcpb, the
 echo Claude Desktop extension. After it builds, install it in Claude Desktop
-echo via Settings -^> Extensions -^> Install Extension, then FULLY QUIT and
-echo reopen Desktop. Rebuild and reinstall whenever the MCP server changes.
+echo via Settings -^> Extensions -^> Advanced Settings -^> Install extension,
+echo then FULLY QUIT and reopen Desktop. Rebuild and reinstall whenever the
+echo MCP server changes.
 echo.
 echo This runs scripts\build-mcpb.mjs with Node (same as "make mcpb"). No bash
 echo needed -- just Node, which Setup.bat already installs.

--- a/eval/BuildPlugin.bat
+++ b/eval/BuildPlugin.bat
@@ -5,9 +5,11 @@ echo === Cowork Genealogy - Build the Cowork plugin (.zip) ===
 echo.
 echo Packs releases\genealogy-plugin.zip, the skills and agents Cowork runs.
 echo After it builds, upload it in Claude Desktop -^> Cowork -^> Customize -^>
-echo Browse plugins -^> Upload custom plugin, then FULLY QUIT and reopen
-echo Desktop. Rebuild and reinstall whenever a skill under
-echo packages\engine\plugin changes.
+echo Add -^> Upload Plugin, then FULLY QUIT and reopen Desktop. Rebuild and
+echo reinstall whenever a skill under packages\engine\plugin changes.
+echo.
+echo Upload it from the COWORK tab, not the Code tab -- they keep separate
+echo plugin lists, and a plugin added in Code will not appear in Cowork.
 echo.
 echo This runs scripts\package-plugin.mjs with Node (same as "make plugin"). No
 echo bash or zip needed -- just Node, which Setup.bat already installs.

--- a/eval/BuildPlugin.bat
+++ b/eval/BuildPlugin.bat
@@ -8,6 +8,10 @@ echo After it builds, upload it in Claude Desktop -^> Cowork -^> Customize -^>
 echo Add -^> Upload Plugin, then FULLY QUIT and reopen Desktop. Rebuild and
 echo reinstall whenever a skill under packages\engine\plugin changes.
 echo.
+echo Already have an older copy installed? REMOVE it in Cowork -^> Customize
+echo first, then upload the new .zip -- that is the reliable way to be sure
+echo you are running the new skills.
+echo.
 echo Upload it from the COWORK tab, not the Code tab -- they keep separate
 echo plugin lists, and a plugin added in Code will not appear in Cowork.
 echo.

--- a/eval/README.md
+++ b/eval/README.md
@@ -332,11 +332,12 @@ test-improve loop fast: you watch the fix work in minutes instead of waiting
 **First time (and after any skill or MCP-server change):** build and install
 the two artifacts so Cowork has the genealogy tools — `eval\BuildMcpb.bat`
 (`make mcpb`), then install the `.mcpb` in Claude Desktop → Settings →
-Extensions → Advanced Settings → Install extension; and `eval\BuildPlugin.bat`
-(`make plugin`), then upload the plugin in Cowork → Customize → Add → Upload
-Plugin. Upload it from the **Cowork** tab, not the Code tab — they keep
-separate plugin lists. **Fully quit and reopen** Claude Desktop after
-installing. The headless `RunE2E.bat` path doesn't use these (it runs the
+Extensions → Advanced Settings → Install extension (over the old copy — no
+uninstall needed); and `eval\BuildPlugin.bat` (`make plugin`), then **remove any
+existing Genealogy Research plugin** in Cowork → Customize and upload the new
+one via Add → Upload Plugin. Upload it from the **Cowork** tab, not the Code tab
+— they keep separate plugin lists. **Fully quit and reopen** Claude Desktop
+after installing. The headless `RunE2E.bat` path doesn't use these (it runs the
 compiled engine directly), so this is only for the live Cowork loop.
 
 1. `eval\SeedProject.bat` → enter the slug (`make e2e-project TEST=<slug>`).

--- a/eval/README.md
+++ b/eval/README.md
@@ -332,10 +332,12 @@ test-improve loop fast: you watch the fix work in minutes instead of waiting
 **First time (and after any skill or MCP-server change):** build and install
 the two artifacts so Cowork has the genealogy tools — `eval\BuildMcpb.bat`
 (`make mcpb`), then install the `.mcpb` in Claude Desktop → Settings →
-Extensions; and `eval\BuildPlugin.bat` (`make plugin`), then upload the plugin
-in Cowork → Customize → Browse plugins. **Fully quit and reopen** Claude
-Desktop after installing. The headless `RunE2E.bat` path doesn't use these (it
-runs the compiled engine directly), so this is only for the live Cowork loop.
+Extensions → Advanced Settings → Install extension; and `eval\BuildPlugin.bat`
+(`make plugin`), then upload the plugin in Cowork → Customize → Add → Upload
+Plugin. Upload it from the **Cowork** tab, not the Code tab — they keep
+separate plugin lists. **Fully quit and reopen** Claude Desktop after
+installing. The headless `RunE2E.bat` path doesn't use these (it runs the
+compiled engine directly), so this is only for the live Cowork loop.
 
 1. `eval\SeedProject.bat` → enter the slug (`make e2e-project TEST=<slug>`).
    Copies the fixture's starting state into `eval\e2e-project\<slug>\` as a


### PR DESCRIPTION
## Why

Two things drifted out from under the alpha walkthrough:

1. **Claude Desktop's install menus changed.** The `.mcpb` now installs via **Settings → Extensions → Advanced Settings → Install extension**, and the Cowork plugin via **Customize → Add → Upload Plugin**. Every doc and batch-file banner still named the old paths.
2. **`/author-e2e-fixture` pointed authors at the wrong next step** — the scored headless run (`RunE2E.bat` / `make e2e-run` / `/interpret-e2e-result`), which is the internal team's job, not the fixture author's.

And one thing was never written down at all: **how to update either artifact after a pull.**

## What changed

**`eval/ALPHA-WALKTHROUGH.md`**
- New install step 4: click **Show files in Explorer** in GitHub Desktop and navigate into `eval\`. Steps 5–6 refer back to that window. (Renumbers the old steps 4–5; the one cross-reference in troubleshooting is updated.)
- New **"Updating after you pull"** section. The two artifacts do *not* behave the same way, so the guidance splits them:
  - **`.mcpb` — install straight over the old copy, no uninstall.** Claude Desktop keys each extension by an id derived from the manifest author + name (`local.mcpb.pioneer-ai-academy.genealogy-mcp`), unpacks it to a directory named after that id, and stores exactly one entry per id in `extensions-installations.json` alongside a content `hash`. There is nowhere for a second copy of the same id to live, so a re-install replaces in place.
  - **Plugin — remove the old one first, then upload.** Uploaded Cowork plugins live server-side (nothing lands under `~/Library/Application Support/Claude/`), so the replace-in-place claim was never verifiable. Removing first is the reliable way to be sure the new skills are the ones running.
- ⚠️ **Cowork and Claude Code keep separate plugin lists.** Cowork loads the uploaded `.zip`; Claude Code reads loose skill folders from `~/.claude/skills/`. A plugin added in the Code tab never appears in Cowork. The `.mcpb` is the opposite — one Extensions install, shared by both tabs. Two new troubleshooting entries cover this and the "rebuilt but still running old code" case (Desktop wasn't fully quit).

**`.claude/skills/author-e2e-fixture/SKILL.md`**
- Both handoff blocks (the Step 6 output template and the worked example) now go lint → `SeedProject.bat` → open `eval/e2e-project/<slug>/` in the Cowork tab and run `/research` → commit and PR.
- Explicit instruction to the skill: don't send authors to the scored headless run, and tell them a live `/research` run is a sanity check, not a pass/fail verdict (it doesn't block the tree-reading tools).

**Menu paths corrected** in `README.md`, `DEVELOPMENT.md`, `eval/README.md`, `eval/BuildMcpb.bat`, `eval/BuildPlugin.bat`, `docs/testing-guides/gps-mentor-agent-testing-guide.md`, `docs/testing-guides/mcpb-install-testing-guide.md`, and `docs/specs/mcpb-package-spec.md`. A grep for the old strings now comes back empty across every `.md` and `.bat` in the repo. `BuildPlugin.bat` also prints both the remove-first note and the Cowork-vs-Code-tab warning before it builds, so they reach people who never open the docs.

## Notes for review

- Docs and one skill body only — no engine, schema, or harness code. Both `.bat` files stay LF-terminated with `-^>` escaping intact.
- The first-time install (walkthrough step 6) deliberately does *not* carry the remove-first caveat — there's no old plugin on a fresh machine.

## Follow-up worth considering (not in this PR)

`packages/engine/mcp-server/manifest.json` pins `"version": "0.1.0"` and `scripts/build-mcpb.mjs` never bumps it, so every `.mcpb` we've ever built claims to be 0.1.0. Desktop appears to compare the content `hash` rather than the version string, so this likely hasn't bitten anyone — but if it ever gated on version, a re-install would silently no-op and the user would swear the rebuild didn't take. That is exactly the symptom an alpha genealogist would report as "I reinstalled and it's still running the old code." Bumping the manifest version per release would remove the ambiguity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)