### PR TITLE
eval: isolate test_cli from the engine-build preflight

### DIFF
--- a/eval/harness/tests/unit/test_cli.py
+++ b/eval/harness/tests/unit/test_cli.py
@@ -13,6 +13,22 @@ sys.path.insert(0, str(_HARNESS_ROOT))
 import run_tests  # noqa: E402
 
 
+@pytest.fixture(autouse=True)
+def _fresh_mcp_build(monkeypatch):
+    """Isolate these tests from the engine-build preflight.
+
+    Every test here monkeypatches away real execution, so none needs the
+    compiled engine — but main()'s staleness gate checks
+    packages/engine/mcp-server/build/ before anything else. In a checkout
+    without a build (a fresh git worktree; the link-worktree hook links
+    node_modules but not build/), the gate exits 2 and every exit-code
+    assertion fails with `assert 2 == ...` instead of the behavior under
+    test. The gate itself is production behavior, deliberately untested
+    here.
+    """
+    monkeypatch.setattr(run_tests, "_check_mcp_build_fresh", lambda: [])
+
+
 def test_no_args_prints_help_and_exits_zero(capsys):
     rc = run_tests.main([])
     assert rc == 0


### PR DESCRIPTION
The 12 `test_cli.py` tests that drive `run_tests.main()` end-to-end monkeypatch away all real execution — but `main()`'s staleness gate checks `packages/engine/mcp-server/build/` before anything else. In a checkout with no compiled engine (any fresh git worktree: the link-worktree hook links `node_modules` but not the gitignored `build/`), the gate exits 2 first, and all 12 exit-code assertions fail as `assert 2 == 1` / `assert 2 == 130` instead of testing the behavior they're about. This noise showed up on every suite run during the PR #627 review.

Fix: an autouse fixture in `test_cli.py` stubs `_check_mcp_build_fresh` to return "fresh", scoped to that file only. The gate's production behavior is untouched (and deliberately remains untested here — it's a preflight for real runs, not CLI logic).

Verified in a worktree with no `build/`: `test_cli.py` 30/30 (was 18/30), full harness suite 813 pass / 1 skip / 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)