### PR TITLE
Close the simplified-GedcomX drift audit: schema pattern, closed-shape validator, merge/convert format fixes, cross-gate vectors

### DIFF
--- a/docs/plan/gedcomx-schema-drift-audit.md
+++ b/docs/plan/gedcomx-schema-drift-audit.md
@@ -275,7 +275,7 @@ verified. Three deltas:
    top-level `places[]` section (mandated by merge-gedcomx-spec §6.7 rev. 3)
    that the tree schema, TS types, and prose spec all reject — an
    A-rejects-B-accepts drift through a shipped tool.
-3. **Missed drift: `quality`'s type.** gedcomx-convert-spec rule 17 and the
+3. **Missed drift: `quality`'s type.** gedcomx-convert-spec Rule 10 and the
    engine's `SimplifiedSourceReference` said *string*; A, C, and D say
    integer 0–3. `toGedcomX` silently dropped every integer quality on the
    upload path (round-trip loss on the deliverable file).
@@ -319,7 +319,7 @@ Landed by the follow-up PR (branch `gedcomx-schema-drift`):
 - **Re-audit delta 2** — the merge core no longer carries candidate
   `places[]`; merge-gedcomx-spec §5, §5b.2, §6.3, §6.7, §6.8 updated.
 - **Re-audit delta 3** — `quality` is the QUAY integer end-to-end;
-  gedcomx-convert-spec rule 17 updated (string encoding lives only inside
+  gedcomx-convert-spec Rule 10 updated (string encoding lives only inside
   the `fsmcp:quality` qualifier).
 - **Cross-gate agreement** — shared vectors at
   `docs/specs/schemas/tree-gate-vectors.json` (with passes-all and

--- a/docs/plan/gedcomx-schema-drift-audit.md
+++ b/docs/plan/gedcomx-schema-drift-audit.md
@@ -1,0 +1,335 @@
+# Simplified-GedcomX drift audit
+
+**Status:** implemented — see the *Implementation status* appendix at the
+bottom for what landed where, plus the independent re-audit's deltas.
+**Branch:** `gedcomx-schema-drift`, cut from `worktree-optimize-author-e2e`
+(PR #627). Rebase onto `main` once that merges.
+**Date:** 2026-07-09.
+
+## Why this exists
+
+PR #627 discovered that the tree-gedcomx JSON Schema was never enforced
+anywhere, and that 25 of the 26 committed e2e starting trees failed it. It
+fixed that by making the schema describe the documents the producers
+actually emit. The obvious next question is whether the schema now
+describes them *completely* — and whether it agrees with the other four
+descriptions of the same format.
+
+There are five, and they drift:
+
+| | Description | Enforced when? |
+|---|---|---|
+| **A** | `docs/specs/schemas/tree-gedcomx.schema.json` (+ byte-identical mirror at `packages/schema/schemas/`) | fixture lint (`e2e/validate_fixture.py`) |
+| **B** | `packages/engine/mcp-server/src/validation/validator.ts` | **every `tree_edit` call**, hard-fail |
+| **C** | `packages/schema/src/index.ts` (TS interfaces) | `tsc`, for viewer-ui / web / server |
+| **D** | `docs/specs/simplified-gedcomx-spec.md` (prose) | never |
+| **E** | the producers: `person-read.ts`, `gedcomx-convert.ts`, `e2e/author.py` | — |
+
+The dangerous class is **A accepts what B rejects**. A fixture lints clean,
+ships, and then the agent hits a `tree_edit` hard-fail mid-run and has to
+repair our fixture before it can write. That is not hypothetical — it is
+precisely the `person1`/`person2` bug PR #627 fixed, found in two committed
+*passing* transcripts.
+
+**No drift below is tripped by the committed corpus today.** All are latent.
+They are ranked by how likely a hand-authoring genealogist is to trip them.
+
+## Method, and how much to trust it
+
+A 147-agent workflow swept all five descriptions field-by-field, then put
+each candidate drift through a high-effort verifier and three adversarial
+refuters (correctness / reachability / consequence lenses), each instructed
+to default to "refuted" when uncertain. 32 claims in; 6 distinct drifts out.
+
+Two caveats a reader should carry:
+
+- Fifteen refuters died on a structured-output retry cap, so some drifts
+  faced a two-refuter jury. The top findings survived those juries
+  *unanimously* (0 of 2 refuting), which is stronger than a contested 1-of-3.
+- Where the sweeps produced near-duplicate claims for one drift, the
+  refuters sometimes split — `ts-fact-missing-fields` was killed 2/3 while
+  its twin survived. Since refuters default to "refuted," a kill on a
+  types-only drift means *"real but inconsequential,"* not *"does not exist."*
+
+So the votes are a filter, not the evidence. **Everything in Tier 1 below was
+reproduced by hand**, against a deliberately-invalid control document proving
+neither checker was silently no-opping:
+
+```
+                 JSON Schema (A)   validator.ts (B)
+  mononym        SCHEMA OK    →    missing required field 'given'
+                                   fact type 'death' should be PascalCase
+  sane           SCHEMA OK    →    VALIDATOR OK
+  bogus (ctrl)   2 errors     →    3 errors
+```
+
+`validateGedcomx(data, report)` takes **two** arguments. A three-argument
+call silently reports success. Any future audit must include a negative
+control for this reason.
+
+---
+
+## Tier 1 — A accepts, B rejects. Two-line schema tightenings.
+
+### 1. A name with no `given` lints clean and hard-fails `tree_edit`
+
+- **A:** `tree-gedcomx.schema.json:61` — `"required": ["id", "surname"]`
+- **B:** `validator.ts:858` — `checkRequired(name, ["id", "given", "surname"], …)`
+- **Corpus:** not tripped. Every name in all 26 fixtures and all scenario
+  trees has a `given` key. `kenneth-quass` carries `given: ""`, which passes
+  both — `checkRequired` tests key *presence*, not emptiness.
+- **Why it matters:** a mononym is an ordinary genealogical case (early
+  Scottish and Dutch records, enslaved persons in US records). A Path-3
+  fixture built by hand from a research document is exactly where one
+  appears.
+- **Fix:** add `"given"` to `name.required` at line 61, in **both** schema
+  trees. Do **not** add `minLength: 1` — `given: ""` must keep working.
+- **Files:** `docs/specs/schemas/tree-gedcomx.schema.json`,
+  `packages/schema/schemas/tree-gedcomx.schema.json`. Nothing else: B, C and
+  D already agree that `given` is expected.
+
+### 2. A lowercase fact `type` lints clean and hard-fails `tree_edit`
+
+- **A:** `enums.schema.json:179` — `gedcomx_fact_type_recommended` is
+  `{"type": "string", "examples": [...]}`, an open enum with no pattern.
+- **B:** `validator.ts:878` — rejects any type whose first character is not
+  uppercase.
+- **Corpus:** not tripped. Every fact type is upper-initial.
+- **Why it matters:** `research.json` uses lowercase fact types (`birth`).
+  An author copying that convention across into a tree trips this.
+- **Fix:** add `"pattern": "^[A-Z]"` to `gedcomx_fact_type_recommended` in
+  **both** enum trees. Tighten A rather than relax B — PascalCase is
+  deliberate ("preserved from GedcomX URI suffixes") and is already in the
+  prose.
+- **Blast radius:** this is a `pattern` add on an *open* (`recommended`)
+  enum, **not** a new value on a closed one. Per CLAUDE.md the closed-enum
+  rule pulls in `CLOSED_ENUMS` in `validator.ts`, the TS union, and the prose
+  table — none of that applies here. Two files.
+
+### 3. Referential integrity: A is structurally blind, B enforces
+
+- **A** validates `parent` / `child` / `person1` / `person2` and every source
+  `ref` as *non-empty strings only*.
+- **B** resolves each against the document's own `persons[]` and `sources[]`
+  and rejects danglers.
+- **Corpus:** not tripped — all 79 committed trees resolve clean.
+- **This one cannot be fixed in the schema.** JSON Schema 2020-12 has no way
+  to express an intra-document reference. A typo'd `child` id will always
+  lint clean and hard-fail `tree_edit`.
+- **Options, in order of preference:**
+  1. Have the fixture gate call `validateGedcomx` in addition to the JSON
+     Schema. Correct by construction, but crosses a Python→TS boundary.
+  2. Port the person/source existence checks into Python beside
+     `harness/schema_validator.py`. Cheap, and duplicates ~30 lines of logic
+     that must then stay in sync — the exact failure mode this document is
+     about.
+  3. At minimum, state in `simplified-gedcomx-spec.md` that the schema is
+     intentionally weaker than the runtime validator on cross-references and
+     must never be the sole fixture gate.
+
+  Recommend (1). `author.py` already shells out to nothing; adding an
+  `npx tsx` call to the `validate` subcommand is a small, honest dependency,
+  and it makes the fixture gate *identical* to the runtime gate instead of
+  merely similar. If that's unacceptable, (2) plus a shared test vector.
+
+---
+
+## Tier 2 — B accepts, A rejects. Runtime-behavior changes; own PR.
+
+These change what `tree_edit` accepts. They should not ride along with a
+schema or fixture change, and they want their own review and exercise.
+None is tripped by the corpus.
+
+### 4. `validator.ts` never enforces `additionalProperties: false`
+
+A closes person / name / fact / both relationship types / source_reference.
+B closes property sets **only for tree sources** (`TREE_SOURCE_FIELDS`,
+`validator.ts:289`, used at `:822`). So `tree_edit` will cheerfully write a
+person with `standrad_date` on a fact, return `ok: true`, and the document
+then fails the fixture lint later, far from the typo.
+
+The comment above `TREE_SOURCE_FIELDS` says the guard exists to catch
+exactly this. It was never extended past sources.
+
+**Fix:** add closed-key sets for the remaining objects, mirroring A's
+subschemas (and `author.py`'s existing allow-lists, which already encode
+them). One file: `validator.ts`.
+
+### 5. `preferred` / `primary` / source-ref locator fields unvalidated by B
+
+A pins `preferred` and `primary` to `const: true`, constrains `page` to a
+string and `quality` to an integer 0–3. B inspects none of them, so
+`preferred: false` or `quality: 5` passes `tree_edit` and fails the lint.
+
+Bundle with #4 — same file, same character of fix, low priority.
+
+---
+
+## Tier 3 — types-only. Cosmetic; trivial PR whenever.
+
+### 6. `GedcomxFact` is missing three fields the corpus uses heavily
+
+`packages/schema/src/index.ts:370` declares `GedcomxFact` with
+`id / type / primary / date / place / sources`. It omits `standard_date`,
+`standard_place` and `value`, all three of which A, D, `gedcomx-convert.ts`
+and the corpus carry: **587** facts across the 26 fixtures have
+`standard_date`, and **42** have `value`.
+
+No runtime or lint failure — a `tsc` gap for a future viewer/web consumer
+that reads them. None does today.
+
+**Fix:** three optional fields. One file.
+
+### 7. Person-level `sources` — delete from the schema, don't add to the type
+
+A permits `person.sources`. C omits it. D's table omits it. And **zero**
+persons in the corpus use it; source references hang off facts and names.
+
+This is the one place where the right move is to *narrow* A rather than
+widen C. Per the repo's YAGNI convention — when two mechanisms do one job,
+keep the one the real user uses — drop `sources` from `$defs/person` in both
+schema trees. Confirm first that `gedcomx-convert.ts` never emits it.
+
+### 8. `person_read` emits `source.notes`, which every other description rejects
+
+`person-read.ts` emits a `notes` array on sources; A, B, C and D all reject
+it, and `author.py`'s `normalize_tree` strips it. Both gates reject it
+symmetrically, so an agent that copies a `person_read` source verbatim into
+`tree_edit` gets a retry, not a silent ship. Loud, therefore low priority.
+
+**Fix:** either stop emitting `notes` from the persisted-shaped return, or
+document it as a read-only field that must be dropped before persisting.
+
+---
+
+## Not drifts (investigated, dismissed)
+
+- **The two schema trees have diverged.** They have not: `cmp` reports them
+  byte-identical. But nothing enforces it — no test, no Makefile target, no
+  CI job — and `harness/schema_validator.py` reads only the `docs/specs/`
+  copy, so a divergence would be invisible to the harness. **A one-line
+  `cmp` test is worth adding** with whichever PR lands first.
+## One promised test is genuinely missing
+
+The refuters ruled 3/3 that the author-e2e plan's promised golden test was
+implemented. **They were wrong, and I checked by hand.** What exists is
+`test_normalization_is_idempotent` (`test_e2e_author.py:172`), which
+satisfies the plan's separate *determinism* promise. The **corpus
+invariant** — "for every fixture directory that has an
+`unstripped-tree.gedcomx.json`, assert its `starting-tree.gedcomx.json` is a
+strict subset of it, and that both validate" — does not exist. No test
+iterates the fixture corpus at all.
+
+It would be **vacuous today**: zero of the 26 fixtures carry an unstripped
+tree, exactly as the plan anticipated ("Zero fixtures at first, ~50 after
+the new batch lands"). So this is an unimplemented promise, not a
+regression. Write it now anyway, while the reasoning is fresh — it is
+self-populating, and a test that passes vacuously today is what catches the
+first fixture authored next month.
+
+This is also the clearest illustration of the caveat above: a 3/3 refuter
+consensus is not evidence. Check the claim.
+
+## Suggested sequencing
+
+1. Tier 1 items 1 and 2 — two files each, mechanical, no behavior change to
+   any existing document. Land first.
+2. Tier 1 item 3 — the real work, and the one that closes the class of bug
+   that motivated PR #627.
+3. Tier 2 items 4 and 5 as one `validator.ts`-tightening PR.
+4. Tier 3 whenever.
+
+Add the `cmp` mirror test and the corpus-invariant test to whichever lands
+first.
+
+## Files this touches, all told
+
+| File | Items |
+|---|---|
+| `docs/specs/schemas/tree-gedcomx.schema.json` | 1, 7 |
+| `packages/schema/schemas/tree-gedcomx.schema.json` | 1, 7 |
+| `docs/specs/schemas/enums.schema.json` | 2 |
+| `packages/schema/schemas/enums.schema.json` | 2 |
+| `packages/engine/mcp-server/src/validation/validator.ts` | 4, 5 |
+| `packages/schema/src/index.ts` | 6 |
+| `eval/harness/e2e/author.py` or `harness/schema_validator.py` | 3 |
+| `docs/specs/simplified-gedcomx-spec.md` | 3, 6, 7, 8 |
+| `packages/engine/mcp-server/src/tools/person-read.ts` | 8 |
+| `eval/harness/tests/unit/test_e2e_author.py` | corpus invariant |
+
+---
+
+## Independent re-audit (2026-07-09)
+
+A from-scratch re-audit reproduced every finding above by hand (probe
+battery against both validators, with positive and negative controls;
+fresh corpus scan of all 79 committed trees). Line-number cites all
+verified. Three deltas:
+
+1. **Finding #3 overstated B.** `validateGedcomx` had two referential
+   blind spots of its own: it never walked person-level `sources[].ref`,
+   and never validated facts on Couple relationships at all — a dangling
+   source ref inside a Marriage fact passed *both* gates (silent
+   corruption, worse than the Tier-1 class).
+2. **Missed drift: `places`.** `merge_record_into_tree` persisted a
+   top-level `places[]` section (mandated by merge-gedcomx-spec §6.7 rev. 3)
+   that the tree schema, TS types, and prose spec all reject — an
+   A-rejects-B-accepts drift through a shipped tool.
+3. **Missed drift: `quality`'s type.** gedcomx-convert-spec rule 17 and the
+   engine's `SimplifiedSourceReference` said *string*; A, C, and D say
+   integer 0–3. `toGedcomX` silently dropped every integer quality on the
+   upload path (round-trip loss on the deliverable file).
+
+The count in #6 was also low: 616 fixture facts carry `standard_date`
+(587 person facts + 29 Couple facts the sweep missed).
+
+## Implementation status (2026-07-10)
+
+Already on `main` before implementation began (landed with the final
+revisions of PR #627, after this audit's snapshot was taken):
+
+- **#1** — `given` required in both schema trees.
+- **#3** — implemented as option (2): `tree_integrity_errors` in
+  `eval/harness/e2e/validate_fixture.py` (reference integrity, id
+  uniqueness, living-person ToS), wired into the fixture lint, `strip`,
+  and `validate`.
+- The **corpus-invariant test** (`test_e2e_fixture_corpus.py`) and the
+  full-corpus hard-gate test.
+
+Landed by the follow-up PR (branch `gedcomx-schema-drift`):
+
+- **#2** — `pattern: ^[A-Z]` on `gedcomx_fact_type_recommended` (both
+  enum trees); the now-redundant PascalCase mirror deleted from
+  `validate_fixture.py`.
+- **#4/#5 + re-audit delta 1** — `validateGedcomx` mirrors every
+  `additionalProperties: false` subschema (top level, person, name, fact,
+  both relationship types, source refs), pins `preferred`/`primary` to
+  true-or-absent, bounds `quality` to an integer 0–3, type-checks scalars,
+  rejects non-array sections, and fully validates Couple facts including
+  their source refs. The tightening immediately caught a live producer
+  bug: `mergeNames` wrote `preferred: false` on every non-preferred merged
+  name.
+- **#6** — `GedcomxFact` gains `standard_date`/`standard_place`/`value`.
+- **#7** — `sources` removed from `$defs/person` (both trees), from
+  `author.py`'s allow-list, and from the merge core; the merge tools strip
+  person-level refs from candidates with a warning (`sanitizeCandidate`).
+- **#8** — documented in simplified-gedcomx-spec §4.3: `person_read`
+  returns are not directly persistable (source `notes`, id-less
+  names/relationships).
+- **Re-audit delta 2** — the merge core no longer carries candidate
+  `places[]`; merge-gedcomx-spec §5, §5b.2, §6.3, §6.7, §6.8 updated.
+- **Re-audit delta 3** — `quality` is the QUAY integer end-to-end;
+  gedcomx-convert-spec rule 17 updated (string encoding lives only inside
+  the `fsmcp:quality` qualifier).
+- **Cross-gate agreement** — shared vectors at
+  `docs/specs/schemas/tree-gate-vectors.json` (with passes-all and
+  fails-all controls, per the negative-control lesson above), consumed by
+  `eval/harness/tests/unit/test_gate_vectors.py` (schema + integrity
+  gates) and `packages/engine/mcp-server/tests/validation/gate-vectors.test.ts`
+  (runtime gate). Intentional seams (duplicate ids and the living-person
+  rules are fixture-gate-only) are encoded as expectations, not hidden.
+- **The mirror `cmp` test** — `test_schema_mirrors.py`. On its first run it
+  caught two schema files already diverged on `main`
+  (`run-log.schema.json`, `unit-test.schema.json` — the
+  `holdout`/`grade_on_invariant` additions never reached the
+  `packages/schema` mirror); both re-synced from `docs/specs/schemas/`.

--- a/docs/specs/gedcomx-convert-spec.md
+++ b/docs/specs/gedcomx-convert-spec.md
@@ -185,7 +185,7 @@ export type SimplifiedRelationship = {
 export type SimplifiedSourceReference = {
   ref?: string;
   page?: string;
-  quality?: string;          // Raw qualifier value, passed through as-is
+  quality?: number;          // GEDCOM QUAY integer 0–3 (string-encoded in the qualifier)
 };
 
 export type SimplifiedSourceDescription = {
@@ -476,13 +476,18 @@ Strip `#` from both resources. `toGedcomX` re-wraps.
   ]
 }
 ↓
-{ "ref": "S1", "page": "1920 Census, ED 47", "quality": "3" }
+{ "ref": "S1", "page": "1920 Census, ED 47", "quality": 3 }
 ```
 
 - `description: "#S1"` → `ref: "S1"` (strip `#`)
 - Qualifier with `name === "http://gedcomx.org/CitationDetail"` → `page`
-- Qualifier with `name === "fsmcp:quality"` → `quality` as **a string**,
-  passed through as-is (no coercion)
+- Qualifier with `name === "fsmcp:quality"` → `quality` as **an integer**.
+  Qualifier values are strings on the wire, but the persisted tree format
+  (tree-gedcomx.schema.json, the shared TS types, simplified-gedcomx-spec.md
+  §4.4) requires an integer 0–3 — a string here silently violated all three
+  and, worse, the reverse direction dropped every integer quality the tree
+  legally carries. A qualifier value that doesn't parse as an integer is
+  dropped, like any other unrecognized qualifier content.
 - All other qualifiers are dropped
 - When the qualifier is absent, **omit** the field
 
@@ -897,7 +902,7 @@ fall into the `fullText` fallback path and emit a warning.
 | 14 | ParentChild round-trips as `parent`/`child` | Rule 8 |
 | 15 | Couple round-trips as `person1`/`person2` | Rule 9 |
 | 16 | `CitationDetail` qualifier → `page`; other (non-quality) qualifiers dropped | Rule 10 |
-| 17 | `fsmcp:quality` qualifier → `quality` as string; passed through unchanged | Rule 10 |
+| 17 | `fsmcp:quality` qualifier → `quality` as integer; non-integer values dropped | Rule 10 |
 | 18 | Source descriptions round-trip with `title`, `citation`, `url` | Rule 11 |
 | 19 | Top-level `places[]` array round-trips | Rule 12 |
 | 20 | Each of the five subtype URIs (Biological/Adoptive/Step/Foster/Guardian) round-trips correctly | Rule 8 |

--- a/docs/specs/gedcomx-convert-spec.md
+++ b/docs/specs/gedcomx-convert-spec.md
@@ -486,7 +486,7 @@ Strip `#` from both resources. `toGedcomX` re-wraps.
   (tree-gedcomx.schema.json, the shared TS types, simplified-gedcomx-spec.md
   §4.4) requires an integer 0–3 — a string here silently violated all three
   and, worse, the reverse direction dropped every integer quality the tree
-  legally carries. A qualifier value that doesn't parse as an integer is
+  legally carries. A qualifier value outside the QUAY range 0–3 (or that doesn't parse as an integer at all) is
   dropped, like any other unrecognized qualifier content.
 - All other qualifiers are dropped
 - When the qualifier is absent, **omit** the field

--- a/docs/specs/merge-gedcomx-spec.md
+++ b/docs/specs/merge-gedcomx-spec.md
@@ -75,7 +75,7 @@ and child↔child. Whatever isn't paired is simply **carried in as a new relativ
 | Marriage/couple facts live on the **relationship** (`SimplifiedRelationship.facts`), not the person | `packages/engine/mcp-server/src/types/gedcomx.ts:139` |
 | IDs `I/N/F/R/S` unique within their array (restart at 1 per doc → collisions on merge) | `docs/specs/simplified-gedcomx-spec.md` |
 | `gedcomx-convert.ts` exports `toSimplified`/`toGedcomX` (+ `collectFacts`/`standardizePlaces`/`toSimplifiedStandardized`) — **no ID-remap or dedup helper there** | `packages/engine/mcp-server/src/utils/gedcomx-convert.ts` |
-| The pure core `mergeGedcomx` (§5–§7) is **already implemented and unit-tested** — only the §5b tool wrappers remain to build | `src/utils/merge-gedcomx.ts` (728 lines), `tests/utils/merge-gedcomx.test.ts` |
+| The pure core `mergeGedcomx` (§5–§7) is **already implemented and unit-tested** — the §5b tool wrappers are shipped | `src/utils/merge-gedcomx.ts` (728 lines), `tests/utils/merge-gedcomx.test.ts` |
 | The hand-done merge protocol this replaces | `packages/engine/plugin/skills/tree-edit/SKILL.md` §"Person merging" |
 
 Richard attached FamilySearch's **`MobMergeUtil.java`** (the match-system merge)
@@ -369,7 +369,10 @@ format has no top-level `places` section (`tree-gedcomx.schema.json` closes the
 root at `persons`/`relationships`/`sources`; facts carry place **names**), so
 carrying them would persist a document the tree schema rejects. The tool layer
 strips candidate places with a warning before the merge (§5b.2); a legacy
-target's own `places` pass through the core untouched.
+target's own `places` never reach the core: every tool heals the on-disk
+tree at read (`src/validation/tree-sanitize.ts` drops the section with a
+warning), so the merge operates on — and its next write persists — the
+healed document.
 
 > *Changed from rev. 3,* which carried candidate places with id-collision
 > renaming. That behavior wrote trees that failed the tree JSON Schema —
@@ -408,7 +411,9 @@ catalogued in §12.
   letters×10 + diacritics — longer, with diacritics, wins).
 - **Preferred** name = the **largest** equivalence class (most frequent across
   inputs); tie-break by `scoreName`. Mark exactly one `preferred: true`; all other
-  distinct names `preferred: false`.
+  distinct names carry no `preferred` flag at all — absence means false, the
+  schema pins the field to `const: true`, and writing `preferred: false`
+  persists a tree the schema rejects.
 
 ### 7.2 Facts (TS: `factsEquivalent` / `mergeFactGroup` / `mergeFacts`)
 - **Equivalent** when **same `type`** AND **dates compatible** AND **places

--- a/docs/specs/merge-gedcomx-spec.md
+++ b/docs/specs/merge-gedcomx-spec.md
@@ -122,8 +122,11 @@ exposed (§5b explains why).
 The internal, side-effect-free merge. Operates on **SimplifiedGedcomX**
 (`{ persons[], relationships[], sources[], places[] }`); any of
 `relationships`/`sources`/`places` may be absent on an input and is treated as
-empty (never throw on a missing array). It is **not** advertised as an MCP tool on
-its own — the two tools in §5b wrap it.
+empty (never throw on a missing array). Candidate `places[]` and person-level
+`sources[]` are tolerated on input but never enter the result — the persisted
+tree format has neither (see §6.3, §6.7), and the tool layer strips them from
+candidates with a warning before the merge (`sanitizeCandidate`, §5b.2). It is
+**not** advertised as an MCP tool on its own — the two tools in §5b wrap it.
 
 ```typescript
 function mergeGedcomx(
@@ -200,6 +203,13 @@ merge_tree_persons({
 Sequence inside each tool:
 
 1. Read `tree.gedcomx.json` (and, for `merge_tree_persons`, `research.json`).
+   **`merge_record_into_tree` only:** sanitize the inline candidate first —
+   drop top-level `places[]` and person-level `sources[]` (legal in tool
+   output like `record_read`'s `gedcomx`, not in the tree format) with a
+   warning per stripped kind, then validate the sanitized candidate
+   (`sanitizeCandidate` + `validateCandidateGedcomx` in `merge-shared.ts`).
+   `merge_warnings` sanitizes identically so the dry-run merges the same
+   document the writer would.
 2. Run `mergeGedcomx` (§5–§7) to build the new tree in memory.
 3. **`merge_tree_persons` only:** remap `research.json` person-id references from
    each collapsed id → its survivor id (§10).
@@ -322,7 +332,10 @@ survivor (survivor id is kept):
 - **Facts** — union (person facts), then **merge equivalent facts** and **keep
   all distinct facts** (§7.2). For Birth/Death/Christening/Burial, mark the one
   best fact `primary`.
-- **Person source refs** — union, dedup by `ref|page`.
+- **Person source refs** — none. The tree format carries source references on
+  names/facts/relationships, not on persons (`tree-gedcomx.schema.json`
+  `$defs/person` has no `sources`). A candidate persona's person-level refs are
+  stripped by the tool layer with a warning (§5b.2); the core does not fold them.
 
 ### 6.4 Non-paired candidate persons (Mode 1)
 Carried into the result with **remapped** ids — these are the "new relatives."
@@ -351,13 +364,19 @@ Candidate `sources[]` merged into target `sources[]`:
   to the resulting source ids.
 
 ### 6.7 `places[]`
-Candidate `places[]` are carried into the result; a candidate place id that
-collides with a target place id is given a fresh unique id. Nothing references
-place ids in the simplified format (facts carry place **names**), so no ref
-rewriting is needed and v1 does not dedup places by content.
+Candidate `places[]` are **not** carried into the result. The persisted tree
+format has no top-level `places` section (`tree-gedcomx.schema.json` closes the
+root at `persons`/`relationships`/`sources`; facts carry place **names**), so
+carrying them would persist a document the tree schema rejects. The tool layer
+strips candidate places with a warning before the merge (§5b.2); a legacy
+target's own `places` pass through the core untouched.
+
+> *Changed from rev. 3,* which carried candidate places with id-collision
+> renaming. That behavior wrote trees that failed the tree JSON Schema —
+> the `gedcomx-schema-drift` audit's missed-drift finding.
 
 ### 6.8 Result
-`{ persons, relationships, sources, places }` where every merged pair's survivor
+`{ persons, relationships, sources }` where every merged pair's survivor
 id is preserved, all candidate ids are collision-free, every cross-reference
 resolves, and no names/facts were discarded. Because fact/name ids are unique
 only *within their source array*, a final pass re-ids any duplicate fact/name id

--- a/docs/specs/schemas/enums.schema.json
+++ b/docs/specs/schemas/enums.schema.json
@@ -177,8 +177,9 @@
       "enum": ["ParentChild", "Couple"]
     },
     "gedcomx_fact_type_recommended": {
-      "description": "Open enum for tree.gedcomx.json facts. PascalCase preserved from GedcomX URI suffixes.",
+      "description": "Open enum for tree.gedcomx.json facts. PascalCase preserved from GedcomX URI suffixes. The pattern enforces only the upper-initial (the part the runtime validator hard-fails on — a lowercase `birth` copied from research.json would lint clean and then fail tree_edit mid-run); the value list stays open.",
       "type": "string",
+      "pattern": "^[A-Z]",
       "examples": [
         "Birth",
         "Death",

--- a/docs/specs/schemas/tree-gate-vectors.json
+++ b/docs/specs/schemas/tree-gate-vectors.json
@@ -1,10 +1,14 @@
 {
-  "$comment": "Shared test vectors pinning the agreement (and the documented seams) between the three tree.gedcomx.json validity gates: `schema` = the JSON Schema (tree-gedcomx.schema.json, run by harness.schema_validator), `integrity` = the fixture gate's structural mirror (tree_integrity_errors in eval/harness/e2e/validate_fixture.py — reference integrity, id uniqueness, and the fixture-only living-person ToS rule), `runtime` = the engine's validateGedcomx (packages/engine/mcp-server/src/validation/validator.ts, the tree_edit write gate). Each expectation is `true` when that gate reports zero errors. Consumed by eval/harness/tests/unit/test_gate_vectors.py (schema + integrity) and packages/engine/mcp-server/tests/validation/gate-vectors.test.ts (runtime) — one gate relaxing or tightening breaks its consumer, forcing this file (and therefore the other gates' review) to be updated in the same PR. The battery deliberately includes a passes-everything control and a fails-everything control so a silently no-opping checker cannot go unnoticed; any future gate audit should keep both. Note the intentional seams the vectors document rather than hide: duplicate ids and the living-person rules are fixture-gate-only (the runtime validator accepts them), and everything under `living` is invisible to the JSON Schema.",
+  "$comment": "Shared test vectors pinning the agreement (and the documented seams) between the three tree.gedcomx.json validity gates: `schema` = the JSON Schema (tree-gedcomx.schema.json, run by harness.schema_validator), `integrity` = the fixture gate's structural mirror (tree_integrity_errors in eval/harness/e2e/validate_fixture.py — reference integrity, id uniqueness, and the fixture-only living-person ToS rule), `runtime` = the engine's validateGedcomx (packages/engine/mcp-server/src/validation/validator.ts, the tree_edit write gate). Each expectation is `true` when that gate reports zero errors. Consumed by eval/harness/tests/unit/test_gate_vectors.py (schema + integrity) and packages/engine/mcp-server/tests/validation/gate-vectors.test.ts (runtime) — one gate relaxing or tightening breaks its consumer, forcing this file (and therefore the other gates' review) to be updated in the same PR. The battery deliberately includes a passes-everything control and a fails-everything control so a silently no-opping checker cannot go unnoticed; any future gate audit should keep both. Note the intentional seams the vectors document rather than hide: duplicate ids and the living-person rules are fixture-gate-only (the runtime validator accepts them), and everything under `living` is invisible to the JSON Schema. The fact-type pattern is NOT a seam: the runtime check mirrors the schema's ^[A-Z] exactly (digit-initial and empty types fail both).",
   "vectors": [
     {
       "name": "sane-control",
-      "description": "A fully-featured valid tree: names with type/prefix/preferred, facts with standard sidecars + quality, a Couple with a sourced Marriage fact, a ParentChild with subtype and notes. Passes every gate — the positive control.",
-      "expect": { "schema": true, "integrity": true, "runtime": true },
+      "description": "A fully-featured valid tree: names with type/prefix/preferred, facts with standard sidecars, source-ref quality at BOTH QUAY boundaries (0 — the falsy value a truthiness slip would drop — and 3), a Couple with a sourced Marriage fact, a ParentChild with subtype and notes. Passes every gate — the positive control.",
+      "expect": {
+        "schema": true,
+        "integrity": true,
+        "runtime": true
+      },
       "tree": {
         "persons": [
           {
@@ -20,7 +24,11 @@
                 "surname": "Flynn",
                 "prefix": "Rev.",
                 "type": "BirthName",
-                "sources": [{ "ref": "S1" }]
+                "sources": [
+                  {
+                    "ref": "S1"
+                  }
+                ]
               }
             ],
             "facts": [
@@ -32,22 +40,44 @@
                 "standard_date": "Abt 1845",
                 "place": "Ireland",
                 "standard_place": "Ireland",
-                "sources": [{ "ref": "S1", "page": "p. 4", "quality": 2 }]
+                "sources": [
+                  {
+                    "ref": "S1",
+                    "page": "p. 4",
+                    "quality": 0
+                  }
+                ]
               },
-              { "id": "F2", "type": "Occupation", "value": "Miner" }
+              {
+                "id": "F2",
+                "type": "Occupation",
+                "value": "Miner"
+              }
             ]
           },
           {
             "id": "I2",
             "living": false,
             "gender": "Female",
-            "names": [{ "id": "N2", "given": "Mary", "surname": "Flynn" }]
+            "names": [
+              {
+                "id": "N2",
+                "given": "Mary",
+                "surname": "Flynn"
+              }
+            ]
           },
           {
             "id": "I3",
             "living": false,
             "gender": "Male",
-            "names": [{ "id": "N3", "given": "Thomas", "surname": "Flynn" }]
+            "names": [
+              {
+                "id": "N3",
+                "given": "Thomas",
+                "surname": "Flynn"
+              }
+            ]
           }
         ],
         "relationships": [
@@ -57,8 +87,15 @@
             "parent": "I1",
             "child": "I3",
             "subtype": "Biological",
-            "notes": ["Relationship inferred from the 1850 household."],
-            "sources": [{ "ref": "S1", "quality": 2 }]
+            "notes": [
+              "Relationship inferred from the 1850 household."
+            ],
+            "sources": [
+              {
+                "ref": "S1",
+                "quality": 3
+              }
+            ]
           },
           {
             "id": "R2",
@@ -70,37 +107,74 @@
                 "id": "F3",
                 "type": "Marriage",
                 "date": "1867",
-                "sources": [{ "ref": "S1", "page": "line 12" }]
+                "sources": [
+                  {
+                    "ref": "S1",
+                    "page": "line 12"
+                  }
+                ]
               }
             ]
           }
         ],
-        "sources": [{ "id": "S1", "title": "1850 U.S. Federal Census" }]
+        "sources": [
+          {
+            "id": "S1",
+            "title": "1850 U.S. Federal Census"
+          }
+        ]
       }
     },
     {
       "name": "bogus-control",
       "description": "Broken in every dimension: missing sources section, invalid gender, empty names, unknown relationship type, dangling endpoint. Fails every gate — the negative control proving no checker is silently no-opping.",
-      "expect": { "schema": false, "integrity": false, "runtime": false },
+      "expect": {
+        "schema": false,
+        "integrity": false,
+        "runtime": false
+      },
       "tree": {
-        "persons": [{ "id": "I1", "gender": "Hermaphrodite", "names": [] }],
+        "persons": [
+          {
+            "id": "I1",
+            "gender": "Hermaphrodite",
+            "names": []
+          }
+        ],
         "relationships": [
-          { "id": "R1", "type": "Sibling" },
-          { "id": "R2", "type": "ParentChild", "parent": "I1", "child": "I9-GONE" }
+          {
+            "id": "R1",
+            "type": "Sibling"
+          },
+          {
+            "id": "R2",
+            "type": "ParentChild",
+            "parent": "I1",
+            "child": "I9-GONE"
+          }
         ]
       }
     },
     {
       "name": "mononym-no-given",
       "description": "A name with no `given` key. The schema and the runtime validator require `given` (spell an unknown one \"\"); the integrity mirror does not look at names.",
-      "expect": { "schema": false, "integrity": true, "runtime": false },
+      "expect": {
+        "schema": false,
+        "integrity": true,
+        "runtime": false
+      },
       "tree": {
         "persons": [
           {
             "id": "I1",
             "living": false,
             "gender": "Male",
-            "names": [{ "id": "N1", "surname": "Teach" }]
+            "names": [
+              {
+                "id": "N1",
+                "surname": "Teach"
+              }
+            ]
           }
         ],
         "relationships": [],
@@ -110,14 +184,24 @@
     {
       "name": "empty-given",
       "description": "given: \"\" is the documented spelling of an unknown given name (the engine's living-person stub emits it). Valid everywhere.",
-      "expect": { "schema": true, "integrity": true, "runtime": true },
+      "expect": {
+        "schema": true,
+        "integrity": true,
+        "runtime": true
+      },
       "tree": {
         "persons": [
           {
             "id": "I1",
             "living": false,
             "gender": "Unknown",
-            "names": [{ "id": "N1", "given": "", "surname": "Teach" }]
+            "names": [
+              {
+                "id": "N1",
+                "given": "",
+                "surname": "Teach"
+              }
+            ]
           }
         ],
         "relationships": [],
@@ -127,15 +211,31 @@
     {
       "name": "lowercase-fact-type",
       "description": "A research.json-cased fact type ('death'). The schema's pattern and the runtime's PascalCase check both reject it; the integrity mirror leaves fact types to the schema.",
-      "expect": { "schema": false, "integrity": true, "runtime": false },
+      "expect": {
+        "schema": false,
+        "integrity": true,
+        "runtime": false
+      },
       "tree": {
         "persons": [
           {
             "id": "I1",
             "living": false,
             "gender": "Male",
-            "names": [{ "id": "N1", "given": "John", "surname": "Doe" }],
-            "facts": [{ "id": "F1", "type": "death", "date": "1900" }]
+            "names": [
+              {
+                "id": "N1",
+                "given": "John",
+                "surname": "Doe"
+              }
+            ],
+            "facts": [
+              {
+                "id": "F1",
+                "type": "death",
+                "date": "1900"
+              }
+            ]
           }
         ],
         "relationships": [],
@@ -145,18 +245,33 @@
     {
       "name": "dangling-child",
       "description": "A typo'd ParentChild child id. JSON Schema 2020-12 cannot express intra-document references — this is the drift class the integrity mirror and the runtime validator exist to close.",
-      "expect": { "schema": true, "integrity": false, "runtime": false },
+      "expect": {
+        "schema": true,
+        "integrity": false,
+        "runtime": false
+      },
       "tree": {
         "persons": [
           {
             "id": "I1",
             "living": false,
             "gender": "Male",
-            "names": [{ "id": "N1", "given": "John", "surname": "Doe" }]
+            "names": [
+              {
+                "id": "N1",
+                "given": "John",
+                "surname": "Doe"
+              }
+            ]
           }
         ],
         "relationships": [
-          { "id": "R1", "type": "ParentChild", "parent": "I1", "child": "I2-TYPO" }
+          {
+            "id": "R1",
+            "type": "ParentChild",
+            "parent": "I1",
+            "child": "I2-TYPO"
+          }
         ],
         "sources": []
       }
@@ -164,20 +279,36 @@
     {
       "name": "dangling-couple-fact-source-ref",
       "description": "A dangling source ref inside a Couple relationship's Marriage fact — the runtime validator's former blind spot: it once passed both the schema (structurally blind to refs) and validateGedcomx (which never walked Couple facts).",
-      "expect": { "schema": true, "integrity": false, "runtime": false },
+      "expect": {
+        "schema": true,
+        "integrity": false,
+        "runtime": false
+      },
       "tree": {
         "persons": [
           {
             "id": "I1",
             "living": false,
             "gender": "Male",
-            "names": [{ "id": "N1", "given": "John", "surname": "Doe" }]
+            "names": [
+              {
+                "id": "N1",
+                "given": "John",
+                "surname": "Doe"
+              }
+            ]
           },
           {
             "id": "I2",
             "living": false,
             "gender": "Female",
-            "names": [{ "id": "N2", "given": "Mary", "surname": "Doe" }]
+            "names": [
+              {
+                "id": "N2",
+                "given": "Mary",
+                "surname": "Doe"
+              }
+            ]
           }
         ],
         "relationships": [
@@ -187,7 +318,15 @@
             "person1": "I1",
             "person2": "I2",
             "facts": [
-              { "id": "F1", "type": "Marriage", "sources": [{ "ref": "S9-DANGLING" }] }
+              {
+                "id": "F1",
+                "type": "Marriage",
+                "sources": [
+                  {
+                    "ref": "S9-DANGLING"
+                  }
+                ]
+              }
             ]
           }
         ],
@@ -197,15 +336,31 @@
     {
       "name": "typo-fact-key",
       "description": "standrad_date — the closed-shape class: unknown keys must die at write time, not persist and fail a later lint far from the mistake.",
-      "expect": { "schema": false, "integrity": true, "runtime": false },
+      "expect": {
+        "schema": false,
+        "integrity": true,
+        "runtime": false
+      },
       "tree": {
         "persons": [
           {
             "id": "I1",
             "living": false,
             "gender": "Male",
-            "names": [{ "id": "N1", "given": "John", "surname": "Doe" }],
-            "facts": [{ "id": "F1", "type": "Birth", "standrad_date": "2 Oct 1876" }]
+            "names": [
+              {
+                "id": "N1",
+                "given": "John",
+                "surname": "Doe"
+              }
+            ],
+            "facts": [
+              {
+                "id": "F1",
+                "type": "Birth",
+                "standrad_date": "2 Oct 1876"
+              }
+            ]
           }
         ],
         "relationships": [],
@@ -215,7 +370,11 @@
     {
       "name": "preferred-false",
       "description": "preferred is const true — omit rather than setting false (the convention that keeps multi-name persons token-lean).",
-      "expect": { "schema": false, "integrity": true, "runtime": false },
+      "expect": {
+        "schema": false,
+        "integrity": true,
+        "runtime": false
+      },
       "tree": {
         "persons": [
           {
@@ -223,7 +382,12 @@
             "living": false,
             "gender": "Male",
             "names": [
-              { "id": "N1", "given": "John", "surname": "Doe", "preferred": false }
+              {
+                "id": "N1",
+                "given": "John",
+                "surname": "Doe",
+                "preferred": false
+              }
             ]
           }
         ],
@@ -234,85 +398,173 @@
     {
       "name": "quality-out-of-range",
       "description": "quality: 5 — GEDCOM QUAY is 0-3.",
-      "expect": { "schema": false, "integrity": true, "runtime": false },
+      "expect": {
+        "schema": false,
+        "integrity": true,
+        "runtime": false
+      },
       "tree": {
         "persons": [
           {
             "id": "I1",
             "living": false,
             "gender": "Male",
-            "names": [{ "id": "N1", "given": "John", "surname": "Doe" }],
+            "names": [
+              {
+                "id": "N1",
+                "given": "John",
+                "surname": "Doe"
+              }
+            ],
             "facts": [
-              { "id": "F1", "type": "Birth", "sources": [{ "ref": "S1", "quality": 5 }] }
+              {
+                "id": "F1",
+                "type": "Birth",
+                "sources": [
+                  {
+                    "ref": "S1",
+                    "quality": 5
+                  }
+                ]
+              }
             ]
           }
         ],
         "relationships": [],
-        "sources": [{ "id": "S1", "title": "Census" }]
+        "sources": [
+          {
+            "id": "S1",
+            "title": "Census"
+          }
+        ]
       }
     },
     {
       "name": "quality-string",
-      "description": "quality: \"3\" — the persisted format wants the QUAY integer; the string form exists only inside the raw-GedcomX fsmcp:quality qualifier (gedcomx-convert-spec rule 17 parses it).",
-      "expect": { "schema": false, "integrity": true, "runtime": false },
+      "description": "quality: \"3\" — the persisted format wants the QUAY integer; the string form exists only inside the raw-GedcomX fsmcp:quality qualifier (gedcomx-convert-spec Rule 10 parses it).",
+      "expect": {
+        "schema": false,
+        "integrity": true,
+        "runtime": false
+      },
       "tree": {
         "persons": [
           {
             "id": "I1",
             "living": false,
             "gender": "Male",
-            "names": [{ "id": "N1", "given": "John", "surname": "Doe" }],
+            "names": [
+              {
+                "id": "N1",
+                "given": "John",
+                "surname": "Doe"
+              }
+            ],
             "facts": [
-              { "id": "F1", "type": "Birth", "sources": [{ "ref": "S1", "quality": "3" }] }
+              {
+                "id": "F1",
+                "type": "Birth",
+                "sources": [
+                  {
+                    "ref": "S1",
+                    "quality": "3"
+                  }
+                ]
+              }
             ]
           }
         ],
         "relationships": [],
-        "sources": [{ "id": "S1", "title": "Census" }]
+        "sources": [
+          {
+            "id": "S1",
+            "title": "Census"
+          }
+        ]
       }
     },
     {
       "name": "person-level-sources",
       "description": "Source references hang off names/facts/relationships, never persons (simplified-gedcomx-spec §4.4; the merge tools strip these from candidates).",
-      "expect": { "schema": false, "integrity": true, "runtime": false },
+      "expect": {
+        "schema": false,
+        "integrity": true,
+        "runtime": false
+      },
       "tree": {
         "persons": [
           {
             "id": "I1",
             "living": false,
             "gender": "Male",
-            "names": [{ "id": "N1", "given": "John", "surname": "Doe" }],
-            "sources": [{ "ref": "S1" }]
+            "names": [
+              {
+                "id": "N1",
+                "given": "John",
+                "surname": "Doe"
+              }
+            ],
+            "sources": [
+              {
+                "ref": "S1"
+              }
+            ]
           }
         ],
         "relationships": [],
-        "sources": [{ "id": "S1", "title": "Census" }]
+        "sources": [
+          {
+            "id": "S1",
+            "title": "Census"
+          }
+        ]
       }
     },
     {
       "name": "top-level-places",
       "description": "The tree has exactly three sections; a places[] section is record-search context, not tree format (merge-gedcomx-spec §6.7 strips it from candidates).",
-      "expect": { "schema": false, "integrity": true, "runtime": false },
+      "expect": {
+        "schema": false,
+        "integrity": true,
+        "runtime": false
+      },
       "tree": {
         "persons": [
           {
             "id": "I1",
             "living": false,
             "gender": "Male",
-            "names": [{ "id": "N1", "given": "John", "surname": "Doe" }]
+            "names": [
+              {
+                "id": "N1",
+                "given": "John",
+                "surname": "Doe"
+              }
+            ]
           }
         ],
         "relationships": [],
         "sources": [],
-        "places": [{ "id": "PL1", "name": "Ireland" }]
+        "places": [
+          {
+            "id": "PL1",
+            "name": "Ireland"
+          }
+        ]
       }
     },
     {
       "name": "nonarray-persons",
       "description": "A persons section that is an object, not an array. The integrity mirror iterates leniently (sees no persons); the schema and runtime reject the shape.",
-      "expect": { "schema": false, "integrity": true, "runtime": false },
+      "expect": {
+        "schema": false,
+        "integrity": true,
+        "runtime": false
+      },
       "tree": {
-        "persons": { "id": "I1" },
+        "persons": {
+          "id": "I1"
+        },
         "relationships": [],
         "sources": []
       }
@@ -320,20 +572,36 @@
     {
       "name": "duplicate-person-id",
       "description": "Two persons sharing an id. A documented seam: only the fixture gate rejects it (strip's selectors become ambiguous); JSON Schema cannot express cross-item uniqueness and the runtime validator's id set silently collapses the duplicate.",
-      "expect": { "schema": true, "integrity": false, "runtime": true },
+      "expect": {
+        "schema": true,
+        "integrity": false,
+        "runtime": true
+      },
       "tree": {
         "persons": [
           {
             "id": "I1",
             "living": false,
             "gender": "Male",
-            "names": [{ "id": "N1", "given": "John", "surname": "Doe" }]
+            "names": [
+              {
+                "id": "N1",
+                "given": "John",
+                "surname": "Doe"
+              }
+            ]
           },
           {
             "id": "I1",
             "living": false,
             "gender": "Male",
-            "names": [{ "id": "N2", "given": "Jack", "surname": "Doe" }]
+            "names": [
+              {
+                "id": "N2",
+                "given": "Jack",
+                "surname": "Doe"
+              }
+            ]
           }
         ],
         "relationships": [],
@@ -343,14 +611,24 @@
     {
       "name": "living-person",
       "description": "living: true. A documented seam: the FamilySearch-ToS rule is fixture-gate-only — live project trees legitimately hold living people, so the schema and runtime accept them.",
-      "expect": { "schema": true, "integrity": false, "runtime": true },
+      "expect": {
+        "schema": true,
+        "integrity": false,
+        "runtime": true
+      },
       "tree": {
         "persons": [
           {
             "id": "I1",
             "living": true,
             "gender": "Male",
-            "names": [{ "id": "N1", "given": "John", "surname": "Doe" }]
+            "names": [
+              {
+                "id": "N1",
+                "given": "John",
+                "surname": "Doe"
+              }
+            ]
           }
         ],
         "relationships": [],
@@ -360,13 +638,23 @@
     {
       "name": "missing-living",
       "description": "No living field. Same fixture-only seam: absent is not deceased for the ToS gate, while the schema and runtime treat living as optional.",
-      "expect": { "schema": true, "integrity": false, "runtime": true },
+      "expect": {
+        "schema": true,
+        "integrity": false,
+        "runtime": true
+      },
       "tree": {
         "persons": [
           {
             "id": "I1",
             "gender": "Male",
-            "names": [{ "id": "N1", "given": "John", "surname": "Doe" }]
+            "names": [
+              {
+                "id": "N1",
+                "given": "John",
+                "surname": "Doe"
+              }
+            ]
           }
         ],
         "relationships": [],
@@ -376,14 +664,124 @@
     {
       "name": "given-nonstring",
       "description": "given: 42 — scalar type drift between the gates was part of the audit's Tier-2 class; both shape gates reject it now.",
-      "expect": { "schema": false, "integrity": true, "runtime": false },
+      "expect": {
+        "schema": false,
+        "integrity": true,
+        "runtime": false
+      },
       "tree": {
         "persons": [
           {
             "id": "I1",
             "living": false,
             "gender": "Male",
-            "names": [{ "id": "N1", "given": 42, "surname": "Doe" }]
+            "names": [
+              {
+                "id": "N1",
+                "given": 42,
+                "surname": "Doe"
+              }
+            ]
+          }
+        ],
+        "relationships": [],
+        "sources": []
+      }
+    },
+    {
+      "name": "primary-false",
+      "description": "primary: false on a fact — the twin of preferred-false. The schema (const: true) and the runtime reject it; absence is how 'not primary' is spelled. The old merge core wrote preferred: false on every merged non-preferred name, so read-time sanitation (tree-sanitize.ts) heals this in legacy documents before validation.",
+      "expect": {
+        "schema": false,
+        "integrity": true,
+        "runtime": false
+      },
+      "tree": {
+        "persons": [
+          {
+            "id": "I1",
+            "living": false,
+            "gender": "Male",
+            "names": [
+              {
+                "id": "N1",
+                "given": "John",
+                "surname": "Smith"
+              }
+            ],
+            "facts": [
+              {
+                "id": "F1",
+                "type": "Birth",
+                "primary": false
+              }
+            ]
+          }
+        ],
+        "relationships": [],
+        "sources": []
+      }
+    },
+    {
+      "name": "digit-initial-fact-type",
+      "description": "A fact type starting with a digit. Both the schema pattern ^[A-Z] and the runtime's aligned check reject it (the runtime's former first-char toUpperCase comparison accepted digit-initial types — a gate seam closed by aligning the runtime to the pattern).",
+      "expect": {
+        "schema": false,
+        "integrity": true,
+        "runtime": false
+      },
+      "tree": {
+        "persons": [
+          {
+            "id": "I1",
+            "living": false,
+            "gender": "Male",
+            "names": [
+              {
+                "id": "N1",
+                "given": "John",
+                "surname": "Smith"
+              }
+            ],
+            "facts": [
+              {
+                "id": "F1",
+                "type": "1stCommunion"
+              }
+            ]
+          }
+        ],
+        "relationships": [],
+        "sources": []
+      }
+    },
+    {
+      "name": "empty-fact-type",
+      "description": "A present-but-empty fact type. The schema pattern and the aligned runtime check both reject it; the former runtime check skipped empty strings entirely.",
+      "expect": {
+        "schema": false,
+        "integrity": true,
+        "runtime": false
+      },
+      "tree": {
+        "persons": [
+          {
+            "id": "I1",
+            "living": false,
+            "gender": "Male",
+            "names": [
+              {
+                "id": "N1",
+                "given": "John",
+                "surname": "Smith"
+              }
+            ],
+            "facts": [
+              {
+                "id": "F1",
+                "type": ""
+              }
+            ]
           }
         ],
         "relationships": [],

--- a/docs/specs/schemas/tree-gate-vectors.json
+++ b/docs/specs/schemas/tree-gate-vectors.json
@@ -1,0 +1,394 @@
+{
+  "$comment": "Shared test vectors pinning the agreement (and the documented seams) between the three tree.gedcomx.json validity gates: `schema` = the JSON Schema (tree-gedcomx.schema.json, run by harness.schema_validator), `integrity` = the fixture gate's structural mirror (tree_integrity_errors in eval/harness/e2e/validate_fixture.py — reference integrity, id uniqueness, and the fixture-only living-person ToS rule), `runtime` = the engine's validateGedcomx (packages/engine/mcp-server/src/validation/validator.ts, the tree_edit write gate). Each expectation is `true` when that gate reports zero errors. Consumed by eval/harness/tests/unit/test_gate_vectors.py (schema + integrity) and packages/engine/mcp-server/tests/validation/gate-vectors.test.ts (runtime) — one gate relaxing or tightening breaks its consumer, forcing this file (and therefore the other gates' review) to be updated in the same PR. The battery deliberately includes a passes-everything control and a fails-everything control so a silently no-opping checker cannot go unnoticed; any future gate audit should keep both. Note the intentional seams the vectors document rather than hide: duplicate ids and the living-person rules are fixture-gate-only (the runtime validator accepts them), and everything under `living` is invisible to the JSON Schema.",
+  "vectors": [
+    {
+      "name": "sane-control",
+      "description": "A fully-featured valid tree: names with type/prefix/preferred, facts with standard sidecars + quality, a Couple with a sourced Marriage fact, a ParentChild with subtype and notes. Passes every gate — the positive control.",
+      "expect": { "schema": true, "integrity": true, "runtime": true },
+      "tree": {
+        "persons": [
+          {
+            "id": "I1",
+            "ark": "ark:/61903/4:1:KGS8-LY1",
+            "living": false,
+            "gender": "Male",
+            "names": [
+              {
+                "id": "N1",
+                "preferred": true,
+                "given": "Patrick",
+                "surname": "Flynn",
+                "prefix": "Rev.",
+                "type": "BirthName",
+                "sources": [{ "ref": "S1" }]
+              }
+            ],
+            "facts": [
+              {
+                "id": "F1",
+                "type": "Birth",
+                "primary": true,
+                "date": "~1845",
+                "standard_date": "Abt 1845",
+                "place": "Ireland",
+                "standard_place": "Ireland",
+                "sources": [{ "ref": "S1", "page": "p. 4", "quality": 2 }]
+              },
+              { "id": "F2", "type": "Occupation", "value": "Miner" }
+            ]
+          },
+          {
+            "id": "I2",
+            "living": false,
+            "gender": "Female",
+            "names": [{ "id": "N2", "given": "Mary", "surname": "Flynn" }]
+          },
+          {
+            "id": "I3",
+            "living": false,
+            "gender": "Male",
+            "names": [{ "id": "N3", "given": "Thomas", "surname": "Flynn" }]
+          }
+        ],
+        "relationships": [
+          {
+            "id": "R1",
+            "type": "ParentChild",
+            "parent": "I1",
+            "child": "I3",
+            "subtype": "Biological",
+            "notes": ["Relationship inferred from the 1850 household."],
+            "sources": [{ "ref": "S1", "quality": 2 }]
+          },
+          {
+            "id": "R2",
+            "type": "Couple",
+            "person1": "I1",
+            "person2": "I2",
+            "facts": [
+              {
+                "id": "F3",
+                "type": "Marriage",
+                "date": "1867",
+                "sources": [{ "ref": "S1", "page": "line 12" }]
+              }
+            ]
+          }
+        ],
+        "sources": [{ "id": "S1", "title": "1850 U.S. Federal Census" }]
+      }
+    },
+    {
+      "name": "bogus-control",
+      "description": "Broken in every dimension: missing sources section, invalid gender, empty names, unknown relationship type, dangling endpoint. Fails every gate — the negative control proving no checker is silently no-opping.",
+      "expect": { "schema": false, "integrity": false, "runtime": false },
+      "tree": {
+        "persons": [{ "id": "I1", "gender": "Hermaphrodite", "names": [] }],
+        "relationships": [
+          { "id": "R1", "type": "Sibling" },
+          { "id": "R2", "type": "ParentChild", "parent": "I1", "child": "I9-GONE" }
+        ]
+      }
+    },
+    {
+      "name": "mononym-no-given",
+      "description": "A name with no `given` key. The schema and the runtime validator require `given` (spell an unknown one \"\"); the integrity mirror does not look at names.",
+      "expect": { "schema": false, "integrity": true, "runtime": false },
+      "tree": {
+        "persons": [
+          {
+            "id": "I1",
+            "living": false,
+            "gender": "Male",
+            "names": [{ "id": "N1", "surname": "Teach" }]
+          }
+        ],
+        "relationships": [],
+        "sources": []
+      }
+    },
+    {
+      "name": "empty-given",
+      "description": "given: \"\" is the documented spelling of an unknown given name (the engine's living-person stub emits it). Valid everywhere.",
+      "expect": { "schema": true, "integrity": true, "runtime": true },
+      "tree": {
+        "persons": [
+          {
+            "id": "I1",
+            "living": false,
+            "gender": "Unknown",
+            "names": [{ "id": "N1", "given": "", "surname": "Teach" }]
+          }
+        ],
+        "relationships": [],
+        "sources": []
+      }
+    },
+    {
+      "name": "lowercase-fact-type",
+      "description": "A research.json-cased fact type ('death'). The schema's pattern and the runtime's PascalCase check both reject it; the integrity mirror leaves fact types to the schema.",
+      "expect": { "schema": false, "integrity": true, "runtime": false },
+      "tree": {
+        "persons": [
+          {
+            "id": "I1",
+            "living": false,
+            "gender": "Male",
+            "names": [{ "id": "N1", "given": "John", "surname": "Doe" }],
+            "facts": [{ "id": "F1", "type": "death", "date": "1900" }]
+          }
+        ],
+        "relationships": [],
+        "sources": []
+      }
+    },
+    {
+      "name": "dangling-child",
+      "description": "A typo'd ParentChild child id. JSON Schema 2020-12 cannot express intra-document references — this is the drift class the integrity mirror and the runtime validator exist to close.",
+      "expect": { "schema": true, "integrity": false, "runtime": false },
+      "tree": {
+        "persons": [
+          {
+            "id": "I1",
+            "living": false,
+            "gender": "Male",
+            "names": [{ "id": "N1", "given": "John", "surname": "Doe" }]
+          }
+        ],
+        "relationships": [
+          { "id": "R1", "type": "ParentChild", "parent": "I1", "child": "I2-TYPO" }
+        ],
+        "sources": []
+      }
+    },
+    {
+      "name": "dangling-couple-fact-source-ref",
+      "description": "A dangling source ref inside a Couple relationship's Marriage fact — the runtime validator's former blind spot: it once passed both the schema (structurally blind to refs) and validateGedcomx (which never walked Couple facts).",
+      "expect": { "schema": true, "integrity": false, "runtime": false },
+      "tree": {
+        "persons": [
+          {
+            "id": "I1",
+            "living": false,
+            "gender": "Male",
+            "names": [{ "id": "N1", "given": "John", "surname": "Doe" }]
+          },
+          {
+            "id": "I2",
+            "living": false,
+            "gender": "Female",
+            "names": [{ "id": "N2", "given": "Mary", "surname": "Doe" }]
+          }
+        ],
+        "relationships": [
+          {
+            "id": "R1",
+            "type": "Couple",
+            "person1": "I1",
+            "person2": "I2",
+            "facts": [
+              { "id": "F1", "type": "Marriage", "sources": [{ "ref": "S9-DANGLING" }] }
+            ]
+          }
+        ],
+        "sources": []
+      }
+    },
+    {
+      "name": "typo-fact-key",
+      "description": "standrad_date — the closed-shape class: unknown keys must die at write time, not persist and fail a later lint far from the mistake.",
+      "expect": { "schema": false, "integrity": true, "runtime": false },
+      "tree": {
+        "persons": [
+          {
+            "id": "I1",
+            "living": false,
+            "gender": "Male",
+            "names": [{ "id": "N1", "given": "John", "surname": "Doe" }],
+            "facts": [{ "id": "F1", "type": "Birth", "standrad_date": "2 Oct 1876" }]
+          }
+        ],
+        "relationships": [],
+        "sources": []
+      }
+    },
+    {
+      "name": "preferred-false",
+      "description": "preferred is const true — omit rather than setting false (the convention that keeps multi-name persons token-lean).",
+      "expect": { "schema": false, "integrity": true, "runtime": false },
+      "tree": {
+        "persons": [
+          {
+            "id": "I1",
+            "living": false,
+            "gender": "Male",
+            "names": [
+              { "id": "N1", "given": "John", "surname": "Doe", "preferred": false }
+            ]
+          }
+        ],
+        "relationships": [],
+        "sources": []
+      }
+    },
+    {
+      "name": "quality-out-of-range",
+      "description": "quality: 5 — GEDCOM QUAY is 0-3.",
+      "expect": { "schema": false, "integrity": true, "runtime": false },
+      "tree": {
+        "persons": [
+          {
+            "id": "I1",
+            "living": false,
+            "gender": "Male",
+            "names": [{ "id": "N1", "given": "John", "surname": "Doe" }],
+            "facts": [
+              { "id": "F1", "type": "Birth", "sources": [{ "ref": "S1", "quality": 5 }] }
+            ]
+          }
+        ],
+        "relationships": [],
+        "sources": [{ "id": "S1", "title": "Census" }]
+      }
+    },
+    {
+      "name": "quality-string",
+      "description": "quality: \"3\" — the persisted format wants the QUAY integer; the string form exists only inside the raw-GedcomX fsmcp:quality qualifier (gedcomx-convert-spec rule 17 parses it).",
+      "expect": { "schema": false, "integrity": true, "runtime": false },
+      "tree": {
+        "persons": [
+          {
+            "id": "I1",
+            "living": false,
+            "gender": "Male",
+            "names": [{ "id": "N1", "given": "John", "surname": "Doe" }],
+            "facts": [
+              { "id": "F1", "type": "Birth", "sources": [{ "ref": "S1", "quality": "3" }] }
+            ]
+          }
+        ],
+        "relationships": [],
+        "sources": [{ "id": "S1", "title": "Census" }]
+      }
+    },
+    {
+      "name": "person-level-sources",
+      "description": "Source references hang off names/facts/relationships, never persons (simplified-gedcomx-spec §4.4; the merge tools strip these from candidates).",
+      "expect": { "schema": false, "integrity": true, "runtime": false },
+      "tree": {
+        "persons": [
+          {
+            "id": "I1",
+            "living": false,
+            "gender": "Male",
+            "names": [{ "id": "N1", "given": "John", "surname": "Doe" }],
+            "sources": [{ "ref": "S1" }]
+          }
+        ],
+        "relationships": [],
+        "sources": [{ "id": "S1", "title": "Census" }]
+      }
+    },
+    {
+      "name": "top-level-places",
+      "description": "The tree has exactly three sections; a places[] section is record-search context, not tree format (merge-gedcomx-spec §6.7 strips it from candidates).",
+      "expect": { "schema": false, "integrity": true, "runtime": false },
+      "tree": {
+        "persons": [
+          {
+            "id": "I1",
+            "living": false,
+            "gender": "Male",
+            "names": [{ "id": "N1", "given": "John", "surname": "Doe" }]
+          }
+        ],
+        "relationships": [],
+        "sources": [],
+        "places": [{ "id": "PL1", "name": "Ireland" }]
+      }
+    },
+    {
+      "name": "nonarray-persons",
+      "description": "A persons section that is an object, not an array. The integrity mirror iterates leniently (sees no persons); the schema and runtime reject the shape.",
+      "expect": { "schema": false, "integrity": true, "runtime": false },
+      "tree": {
+        "persons": { "id": "I1" },
+        "relationships": [],
+        "sources": []
+      }
+    },
+    {
+      "name": "duplicate-person-id",
+      "description": "Two persons sharing an id. A documented seam: only the fixture gate rejects it (strip's selectors become ambiguous); JSON Schema cannot express cross-item uniqueness and the runtime validator's id set silently collapses the duplicate.",
+      "expect": { "schema": true, "integrity": false, "runtime": true },
+      "tree": {
+        "persons": [
+          {
+            "id": "I1",
+            "living": false,
+            "gender": "Male",
+            "names": [{ "id": "N1", "given": "John", "surname": "Doe" }]
+          },
+          {
+            "id": "I1",
+            "living": false,
+            "gender": "Male",
+            "names": [{ "id": "N2", "given": "Jack", "surname": "Doe" }]
+          }
+        ],
+        "relationships": [],
+        "sources": []
+      }
+    },
+    {
+      "name": "living-person",
+      "description": "living: true. A documented seam: the FamilySearch-ToS rule is fixture-gate-only — live project trees legitimately hold living people, so the schema and runtime accept them.",
+      "expect": { "schema": true, "integrity": false, "runtime": true },
+      "tree": {
+        "persons": [
+          {
+            "id": "I1",
+            "living": true,
+            "gender": "Male",
+            "names": [{ "id": "N1", "given": "John", "surname": "Doe" }]
+          }
+        ],
+        "relationships": [],
+        "sources": []
+      }
+    },
+    {
+      "name": "missing-living",
+      "description": "No living field. Same fixture-only seam: absent is not deceased for the ToS gate, while the schema and runtime treat living as optional.",
+      "expect": { "schema": true, "integrity": false, "runtime": true },
+      "tree": {
+        "persons": [
+          {
+            "id": "I1",
+            "gender": "Male",
+            "names": [{ "id": "N1", "given": "John", "surname": "Doe" }]
+          }
+        ],
+        "relationships": [],
+        "sources": []
+      }
+    },
+    {
+      "name": "given-nonstring",
+      "description": "given: 42 — scalar type drift between the gates was part of the audit's Tier-2 class; both shape gates reject it now.",
+      "expect": { "schema": false, "integrity": true, "runtime": false },
+      "tree": {
+        "persons": [
+          {
+            "id": "I1",
+            "living": false,
+            "gender": "Male",
+            "names": [{ "id": "N1", "given": 42, "surname": "Doe" }]
+          }
+        ],
+        "relationships": [],
+        "sources": []
+      }
+    }
+  ]
+}

--- a/docs/specs/schemas/tree-gedcomx.schema.json
+++ b/docs/specs/schemas/tree-gedcomx.schema.json
@@ -49,10 +49,6 @@
         "facts": {
           "type": "array",
           "items": { "$ref": "#/$defs/fact" }
-        },
-        "sources": {
-          "type": "array",
-          "items": { "$ref": "#/$defs/source_reference" }
         }
       }
     },

--- a/docs/specs/simplified-gedcomx-spec.md
+++ b/docs/specs/simplified-gedcomx-spec.md
@@ -197,6 +197,15 @@ it lands in `tree.gedcomx.json`, drop `notes` and synthesize the missing
 ids — `normalize_tree` in `eval/harness/e2e/author.py` does exactly this
 for fixture authoring, and both validation gates reject a verbatim copy.
 
+**Legacy documents are healed at read, not rejected.** Trees persisted before
+the validator closed these shapes (`preferred: false` written by the old
+merge core, top-level `places[]`, person-level `sources`, unknown keys,
+missing ids, string quality values) are repaired in memory by every engine
+tool that reads `tree.gedcomx.json` (`src/validation/tree-sanitize.ts`), with
+one warning per healed class; the next successful tree write persists the
+healed document. Only unambiguous repairs are made — dangling references,
+swapped relationship endpoint keys, and duplicate ids still fail validation.
+
 ### 4.4 Source References
 
 Source references appear on names, facts, and relationships — deliberately

--- a/docs/specs/simplified-gedcomx-spec.md
+++ b/docs/specs/simplified-gedcomx-spec.md
@@ -4,6 +4,18 @@ This document defines the complete schema for `tree.gedcomx.json`, the deliverab
 
 **Machine-readable schema:** [`docs/specs/schemas/tree-gedcomx.schema.json`](schemas/tree-gedcomx.schema.json). Enum definitions are shared with `research.json` in [`docs/specs/schemas/enums.schema.json`](schemas/enums.schema.json). This prose document is normative for humans; the JSON Schema files are normative for machine validation.
 
+**The JSON Schema is deliberately weaker than the runtime validator on
+cross-references.** JSON Schema 2020-12 cannot express intra-document
+reference integrity — a typo'd relationship endpoint or a source `ref`
+naming no `sources[]` entry lints clean and then hard-fails `tree_edit`
+mid-run. The engine's `validateGedcomx`
+(`packages/engine/mcp-server/src/validation/validator.ts`) and the fixture
+gate's structural mirror (`tree_integrity_errors` in
+`eval/harness/e2e/validate_fixture.py`) both enforce those checks; the
+shared vectors in
+[`schemas/tree-gate-vectors.json`](schemas/tree-gate-vectors.json) pin the
+gates' agreement. **Never use the JSON Schema alone as a validity gate.**
+
 ## 1. Overview
 
 `tree.gedcomx.json` contains resolved persons, relationships, facts, and source descriptions in a simplified GedcomX format. It is the file that eventually uploads to FamilySearch. MCP tools handle conversion between full GedcomX (from FamilySearch APIs) and this simplified format.
@@ -177,9 +189,23 @@ Array of source description objects. These are the simplified equivalents of Ged
 | `author` | string | no | Creator, agency, or author |
 | `url` | string | no | URL to the digital source |
 
+**`person_read` returns are not directly persistable.** The tool's sources
+may additionally carry a `notes` string array (user-attached FamilySearch
+notes — per `person-read-tool-spec.md`, useful context for the reader), and
+its names and relationships arrive without `id`s (Section 3). Before any of
+it lands in `tree.gedcomx.json`, drop `notes` and synthesize the missing
+ids — `normalize_tree` in `eval/harness/e2e/author.py` does exactly this
+for fixture authoring, and both validation gates reject a verbatim copy.
+
 ### 4.4 Source References
 
-Source references appear on names, facts, and relationships. They link an assertion to a source description with a locator.
+Source references appear on names, facts, and relationships — deliberately
+**not** on persons. Full GedcomX allows person-level source references (a
+FamilySearch record persona typically carries one pointing at its record),
+but in the tree format every reference hangs off the specific name, fact, or
+relationship it attests; the merge tools strip person-level refs from
+candidates rather than carry them (see `merge-gedcomx-spec.md` §6.3). They
+link an assertion to a source description with a locator.
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|

--- a/docs/specs/tree-edit-tool-spec.md
+++ b/docs/specs/tree-edit-tool-spec.md
@@ -236,7 +236,15 @@ Sequence (mirrors `merge_record_into_tree`):
 
 1. Read `tree.gedcomx.json` fresh from disk (ids checked against current state;
    a stale `factId`/`personId`/`relationshipId` is a clear error, not a silent
-   no-op). Read `research.json` too — needed for the cross-file validation pass.
+   no-op), then **heal legacy shapes** (`src/validation/tree-sanitize.ts`):
+   trees written before the validator tightening — `preferred:/primary: false`
+   from the old merge core, top-level `places[]`, person-level `sources`,
+   unknown keys, missing ids, string quality — are repaired in memory with one
+   warning per healed class, so a pre-tightening project is never bricked. A
+   successful edit persists the healed document (a one-shot migration).
+   Ambiguous problems (dangling refs, swapped endpoint keys, duplicate ids)
+   are NOT healed and still fail validation. Read `research.json` too — needed
+   for the cross-file validation pass.
 2. Apply the operation **in memory**: allocate ids, run the primary/preferred
    swaps, resolve `standard_place`.
 3. **Validate** the would-be tree with `validateParsed(research, tree, { projectPath })`

--- a/eval/harness/e2e/author.py
+++ b/eval/harness/e2e/author.py
@@ -98,8 +98,9 @@ BIRTH_FACT_TYPES = frozenset({"Birth", "Christening", "Baptism"})
 _YEAR = re.compile(r"\b(1\d{3}|20\d{2})\b")
 
 # Field allow-lists, in the key order we emit. Mirrors
-# docs/specs/schemas/tree-gedcomx.schema.json.
-_PERSON_FIELDS = ("id", "ark", "gender", "living", "names", "facts", "sources")
+# docs/specs/schemas/tree-gedcomx.schema.json. Persons carry no `sources` —
+# in the tree format, source references hang off names/facts/relationships.
+_PERSON_FIELDS = ("id", "ark", "gender", "living", "names", "facts")
 _NAME_FIELDS = ("id", "preferred", "given", "surname", "prefix", "suffix", "type", "sources")
 _FACT_FIELDS = (
     "id", "type", "primary", "date", "standard_date", "place",
@@ -282,8 +283,8 @@ def normalize_tree(raw: dict[str, Any]) -> tuple[dict[str, Any], list[str]]:
       relationships, which `person_read` does not identify, sometimes for
       facts. Ids are never re-minted; nothing reads meaning out of an id's
       shape (simplified-gedcomx-spec §3);
-    * drops fields the schema forbids (`source.notes`, facts on a
-      `ParentChild`);
+    * drops fields the schema forbids (`source.notes`, person-level
+      `sources`, facts on a `ParentChild`);
     * PascalCases fact types (`move` -> `Move`);
     * drops relationships whose endpoints aren't in `persons` — `person_read
       --relatives` returns edges to grandparents and in-laws whose person
@@ -361,7 +362,6 @@ def normalize_tree(raw: dict[str, Any]) -> tuple[dict[str, Any], list[str]]:
         else:
             person.pop("facts", None)
 
-        _fix_source_refs(person, src_map, dropped, f"person {pid}", warnings)
         persons.append({k: person[k] for k in _PERSON_FIELDS if k in person})
 
     known_ids = {str(p.get("id")) for p in persons}
@@ -637,7 +637,7 @@ def render_index(tree: dict[str, Any]) -> str:
     cites: dict[str, list[str]] = {}
     for person in persons:
         pid = str(person.get("id", "?"))
-        holders = [person, *(person.get("names") or []), *(person.get("facts") or [])]
+        holders = [*(person.get("names") or []), *(person.get("facts") or [])]
         for holder in holders:
             for ref in holder.get("sources") or []:
                 bucket = cites.setdefault(str(ref.get("ref")), [])

--- a/eval/harness/e2e/validate_fixture.py
+++ b/eval/harness/e2e/validate_fixture.py
@@ -214,12 +214,13 @@ def tree_integrity_errors(tree: dict[str, Any], filename: str) -> list[str]:
       `living_gate` rules 1-2 in `e2e.author`; kept local to avoid an
       import cycle).
 
-    The runtime's two remaining name/fact checks are handled thus: `given`
-    is required by the JSON Schema itself (now aligned with the runtime, the
-    spec table, and the TS types — spell an unknown given name `""`, the
-    engine's own stub convention), and the runtime's PascalCase fact-type
-    check is mirrored below verbatim. If the runtime ever relaxes either,
-    delete the mirror in the same PR.
+    The runtime's two remaining name/fact checks live in the JSON Schema
+    itself, not here: `given` is required by the schema (spell an unknown
+    given name `""`, the engine's own stub convention), and the fact-type
+    enum carries an upper-initial `pattern` that catches the lowercase types
+    the runtime hard-fails on. Cross-gate agreement is pinned by the shared
+    vectors in docs/specs/schemas/tree-gate-vectors.json, consumed by both
+    this side's test_gate_vectors.py and the engine's gate-vectors.test.ts.
     """
     errors: list[str] = []
     persons = [p for p in tree.get("persons") or [] if isinstance(p, dict)]
@@ -271,7 +272,6 @@ def tree_integrity_errors(tree: dict[str, Any], filename: str) -> list[str]:
 
     for person in persons:
         pid = person.get("id", "?")
-        check_source_refs(person, f"person {pid}")
         for name in person.get("names") or []:
             if isinstance(name, dict):
                 check_source_refs(name, f"person {pid} name {name.get('id', '?')}")
@@ -284,22 +284,6 @@ def tree_integrity_errors(tree: dict[str, Any], filename: str) -> list[str]:
         for fact in rel.get("facts") or []:
             if isinstance(fact, dict):
                 check_source_refs(fact, f"relationship {rid} fact {fact.get('id', '?')}")
-
-    # Mirror of validator.ts's PascalCase check ("fact type 'x' should be
-    # PascalCase") — the schema's fact-type enum is deliberately open, so a
-    # lowercase type lints clean and then hard-fails tree_edit mid-run.
-    for holder in (*persons, *relationships):
-        hid = holder.get("id", "?")
-        for fact in holder.get("facts") or []:
-            if not isinstance(fact, dict):
-                continue
-            ftype = str(fact.get("type") or "")
-            if ftype and ftype[:1] != ftype[:1].upper():
-                errors.append(
-                    f"{filename}: fact {fact.get('id', '?')} on {hid} has type "
-                    f"{ftype!r} — tree_edit requires PascalCase (e.g. 'Birth', "
-                    f"not 'birth')"
-                )
 
     for person in persons:
         pid = person.get("id", "?")

--- a/eval/harness/tests/unit/test_e2e_author.py
+++ b/eval/harness/tests/unit/test_e2e_author.py
@@ -826,3 +826,20 @@ def test_validate_runs_the_integrity_gate_not_just_the_schema(fixtures_root, cap
     )
     assert author.main(["validate", "--slug", "vi"]) == 2
     assert "dangling" in capsys.readouterr().err
+
+
+def test_person_level_sources_are_dropped_with_a_warning():
+    # Persons carry no `sources` in the tree format — references live on
+    # names/facts/relationships. A candidate document that has them (the old
+    # format allowed them) must shed them loudly, not silently.
+    raw = {
+        "persons": [
+            _person("KNDX-MKG", "John", "Smith", living=False,
+                    sources=[{"ref": "7BL6-KLH"}])
+        ],
+        "relationships": [],
+        "sources": [{"id": "7BL6-KLH", "title": "1850 Census"}],
+    }
+    tree, warnings = normalize_tree(raw)
+    assert "sources" not in tree["persons"][0]
+    assert any("'sources'" in w for w in warnings)

--- a/eval/harness/tests/unit/test_e2e_validate_fixture.py
+++ b/eval/harness/tests/unit/test_e2e_validate_fixture.py
@@ -336,10 +336,11 @@ def test_an_empty_given_is_the_unknown_spelling_and_passes(tmp_path):
 
 
 def test_lint_fixture_rejects_a_lowercase_fact_type(tmp_path):
-    # The fact-type enum is deliberately open, so "move" lints clean under
-    # the schema and then hard-fails tree_edit — the gate mirrors the runtime.
+    # The fact-type value list is open, but the enum's `pattern` pins the
+    # upper-initial the runtime hard-fails on — a lowercase "move" copied
+    # from research.json must die at the lint, not mid-run in tree_edit.
     person = _valid_person("I1", "John", "Smith")
     person["facts"] = [{"id": "F1", "type": "move"}]
     _write_fixture(tmp_path, _valid_tree(person))
     _, errors = lint_fixture(tmp_path)
-    assert any("PascalCase" in e for e in errors)
+    assert any("'move'" in e and "[A-Z]" in e for e in errors)

--- a/eval/harness/tests/unit/test_gate_vectors.py
+++ b/eval/harness/tests/unit/test_gate_vectors.py
@@ -1,0 +1,49 @@
+"""Python side of the shared tree-gate vectors.
+
+`docs/specs/schemas/tree-gate-vectors.json` pins the agreement between the
+three tree.gedcomx.json validity gates. This module asserts the two
+Python-side gates — the JSON Schema and the fixture gate's structural
+mirror — behave exactly as each vector declares; the engine's
+`gate-vectors.test.ts` covers the runtime validator against the same file.
+A gate change that shifts any verdict fails here, forcing the vectors (and
+therefore a review of the other gates) to move in the same PR.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from e2e.validate_fixture import tree_integrity_errors
+from harness.schema_validator import SCHEMAS_DIR, validate_tree_gedcomx_json
+
+
+VECTORS = json.loads(
+    (SCHEMAS_DIR / "tree-gate-vectors.json").read_text(encoding="utf-8")
+)["vectors"]
+
+
+def _ids() -> list[str]:
+    return [v["name"] for v in VECTORS]
+
+
+def test_the_battery_carries_both_controls():
+    """A checker that silently no-ops passes everything; one that crashes
+    fails everything. Only a battery holding both a passes-all and a
+    fails-all vector can tell either apart from a working gate."""
+    expectations = {tuple(v["expect"][g] for g in ("schema", "integrity")) for v in VECTORS}
+    assert (True, True) in expectations
+    assert (False, False) in expectations
+
+
+@pytest.mark.parametrize("vector", VECTORS, ids=_ids())
+def test_json_schema_gate_matches_the_vector(vector):
+    errors = validate_tree_gedcomx_json(vector["tree"])
+    assert (not errors) == vector["expect"]["schema"], errors
+
+
+@pytest.mark.parametrize("vector", VECTORS, ids=_ids())
+def test_integrity_gate_matches_the_vector(vector):
+    errors = tree_integrity_errors(vector["tree"], "vector")
+    assert (not errors) == vector["expect"]["integrity"], errors

--- a/eval/harness/tests/unit/test_schema_mirrors.py
+++ b/eval/harness/tests/unit/test_schema_mirrors.py
@@ -1,0 +1,35 @@
+"""The two schema trees must stay byte-identical.
+
+`docs/specs/schemas/` is the source the harness validates against;
+`packages/schema/schemas/` is the mirror the web workbench consumes
+(per CLAUDE.md, every schema change edits both). Nothing else enforced
+that — `harness.schema_validator` reads only the docs copy, so a
+divergence would be invisible to every gate. This test is the audit's
+one-line `cmp`.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from harness.schema_validator import REPO_ROOT, SCHEMAS_DIR
+
+
+MIRROR_DIR = REPO_ROOT / "packages" / "schema" / "schemas"
+
+
+def _schema_names() -> list[str]:
+    return sorted(p.name for p in SCHEMAS_DIR.glob("*.schema.json"))
+
+
+def test_every_schema_is_mirrored():
+    mirrored = sorted(p.name for p in MIRROR_DIR.glob("*.schema.json"))
+    assert _schema_names() == mirrored
+
+
+@pytest.mark.parametrize("name", _schema_names())
+def test_mirror_is_byte_identical(name: str):
+    assert (SCHEMAS_DIR / name).read_bytes() == (MIRROR_DIR / name).read_bytes(), (
+        f"{name} differs between docs/specs/schemas/ and packages/schema/schemas/ — "
+        f"schema changes must edit both trees (see CLAUDE.md)"
+    )

--- a/packages/engine/mcp-server/src/tools/merge-record-into-tree.ts
+++ b/packages/engine/mcp-server/src/tools/merge-record-into-tree.ts
@@ -15,6 +15,7 @@ import { atomicWriteJson } from "../utils/project-io.js";
 import {
   MergeInputError,
   readProjectJson,
+  sanitizeCandidate,
   validateCandidateGedcomx,
   derivePairSummaries,
   personMapByIds,
@@ -42,12 +43,15 @@ export async function mergeRecordIntoTree(
       "tree.gedcomx.json",
     )) as SimplifiedGedcomX;
 
-    // 2. Validate the inline candidate before merging anything.
-    const candidateErrors = validateCandidateGedcomx(input.candidateGedcomx);
+    // 2. Sanitize (drop candidate places / person-level source refs — legal
+    //    in tool output, not in the tree format), then validate the result.
+    const { candidate, warnings: sanitizeWarnings } = sanitizeCandidate(
+      input.candidateGedcomx,
+    );
+    const candidateErrors = validateCandidateGedcomx(candidate);
     if (candidateErrors.length > 0) {
       return { ok: false, errors: candidateErrors };
     }
-    const candidate = input.candidateGedcomx;
 
     // 3. Merge in memory. The core throws on empty/duplicate/unknown merges and
     //    on a survivor id absent from the on-disk tree (a staleness signal).
@@ -90,7 +94,10 @@ export async function mergeRecordIntoTree(
       filesWritten: ["tree.gedcomx.json"],
       pairs,
       newRelatives,
-      validation: { valid: true, warnings: formatIssues(validation.warnings) },
+      validation: {
+        valid: true,
+        warnings: [...sanitizeWarnings, ...formatIssues(validation.warnings)],
+      },
     };
   } catch (e) {
     if (e instanceof MergeInputError) return { ok: false, errors: [e.message] };

--- a/packages/engine/mcp-server/src/tools/merge-record-into-tree.ts
+++ b/packages/engine/mcp-server/src/tools/merge-record-into-tree.ts
@@ -12,6 +12,7 @@ import type { SimplifiedGedcomX } from "../types/gedcomx.js";
 import { mergeGedcomx } from "../utils/merge-gedcomx.js";
 import { validateParsed } from "../validation/validator.js";
 import { atomicWriteJson } from "../utils/project-io.js";
+import { sanitizeTree } from "../validation/tree-sanitize.js";
 import {
   MergeInputError,
   readProjectJson,
@@ -38,10 +39,10 @@ export async function mergeRecordIntoTree(
 
   try {
     // 1. Read the tree fresh from disk (merges checked against current state).
-    const tree = (await readProjectJson(
-      projectPath,
-      "tree.gedcomx.json",
-    )) as SimplifiedGedcomX;
+    const treeSanitized = sanitizeTree(
+      await readProjectJson(projectPath, "tree.gedcomx.json"),
+    );
+    const tree = treeSanitized.tree;
 
     // 2. Sanitize (drop candidate places / person-level source refs — legal
     //    in tool output, not in the tree format), then validate the result.
@@ -96,7 +97,11 @@ export async function mergeRecordIntoTree(
       newRelatives,
       validation: {
         valid: true,
-        warnings: [...sanitizeWarnings, ...formatIssues(validation.warnings)],
+        warnings: [
+          ...treeSanitized.warnings,
+          ...sanitizeWarnings,
+          ...formatIssues(validation.warnings),
+        ],
       },
     };
   } catch (e) {

--- a/packages/engine/mcp-server/src/tools/merge-shared.ts
+++ b/packages/engine/mcp-server/src/tools/merge-shared.ts
@@ -84,10 +84,52 @@ export function formatIssues(issues: ValidationError[]): string[] {
 }
 
 /**
+ * Strip the parts of a candidate document that are legal in tool output
+ * (`record_read`'s `gedcomx`, `toSimplified` results) but not in the persisted
+ * tree format: top-level `places[]` (the tree carries places as names on
+ * facts) and person-level `sources[]` (tree source references hang off
+ * names/facts/relationships). Returns a cleaned deep copy plus one warning
+ * per stripped kind — the input is never mutated, and a candidate that
+ * carries these must not be rejected for it.
+ */
+export function sanitizeCandidate(candidate: SimplifiedGedcomX): {
+  candidate: SimplifiedGedcomX;
+  warnings: string[];
+} {
+  const cleaned = structuredClone(candidate);
+  const warnings: string[] = [];
+
+  if (Array.isArray(cleaned.places) && cleaned.places.length > 0) {
+    warnings.push(
+      `dropped ${cleaned.places.length} candidate place description(s) — ` +
+        `the tree format carries places as names on facts, not as a places[] section`,
+    );
+  }
+  delete cleaned.places;
+
+  let personSourceRefs = 0;
+  for (const person of cleaned.persons ?? []) {
+    if (Array.isArray(person.sources)) personSourceRefs += person.sources.length;
+    delete person.sources;
+  }
+  if (personSourceRefs > 0) {
+    warnings.push(
+      `dropped ${personSourceRefs} person-level source reference(s) — the ` +
+        `tree format carries source references on names/facts/relationships, ` +
+        `not on persons`,
+    );
+  }
+
+  return { candidate: cleaned, warnings };
+}
+
+/**
  * Validate an inline candidate document by reusing the exported `validateGedcomx`.
  * `toSimplified` omits empty sections, so a valid record may legitimately have
  * no `relationships`/`sources` key — normalize absent sections to `[]` first so
- * the section-presence check doesn't spuriously reject it. Returns [] when valid.
+ * the section-presence check doesn't spuriously reject it. Callers pass the
+ * `sanitizeCandidate` output, so no `places` / person `sources` remain by the
+ * time the runtime validator sees it. Returns [] when valid.
  */
 export function validateCandidateGedcomx(candidate: unknown): string[] {
   if (candidate === null || typeof candidate !== "object") {
@@ -98,7 +140,6 @@ export function validateCandidateGedcomx(candidate: unknown): string[] {
     persons: c.persons ?? [],
     relationships: c.relationships ?? [],
     sources: c.sources ?? [],
-    ...(c.places !== undefined ? { places: c.places } : {}),
   };
   const report = createReport();
   validateGedcomx(normalized, report);

--- a/packages/engine/mcp-server/src/tools/merge-tree-persons.ts
+++ b/packages/engine/mcp-server/src/tools/merge-tree-persons.ts
@@ -12,6 +12,7 @@ import type { SimplifiedGedcomX } from "../types/gedcomx.js";
 import { mergeGedcomx } from "../utils/merge-gedcomx.js";
 import { validateParsed } from "../validation/validator.js";
 import { atomicWriteBoth } from "../utils/project-io.js";
+import { sanitizeTree } from "../validation/tree-sanitize.js";
 import {
   MergeInputError,
   readProjectJson,
@@ -36,10 +37,10 @@ export async function mergeTreePersons(
 
   try {
     // 1. Read both files fresh from disk.
-    const tree = (await readProjectJson(
-      projectPath,
-      "tree.gedcomx.json",
-    )) as SimplifiedGedcomX;
+    const treeSanitized = sanitizeTree(
+      await readProjectJson(projectPath, "tree.gedcomx.json"),
+    );
+    const tree = treeSanitized.tree;
     const research = await readProjectJson(projectPath, "research.json");
 
     // 2. Capture pre-merge persons (both sides live in the one tree) for the
@@ -90,7 +91,10 @@ export async function mergeTreePersons(
       pairs,
       newRelatives: [],
       researchRefsUpdated,
-      validation: { valid: true, warnings: formatIssues(validation.warnings) },
+      validation: {
+        valid: true,
+        warnings: [...treeSanitized.warnings, ...formatIssues(validation.warnings)],
+      },
     };
   } catch (e) {
     if (e instanceof MergeInputError) return { ok: false, errors: [e.message] };

--- a/packages/engine/mcp-server/src/tools/merge-warnings.ts
+++ b/packages/engine/mcp-server/src/tools/merge-warnings.ts
@@ -25,6 +25,7 @@ import { calculateWarnings } from "./person-warnings.js";
 import {
   MergeInputError,
   readProjectJson,
+  sanitizeCandidate,
   validateCandidateGedcomx,
   formatIssues,
 } from "./merge-shared.js";
@@ -43,12 +44,13 @@ export async function mergeWarnings(
       "tree.gedcomx.json",
     )) as SimplifiedGedcomX;
 
-    // 2. Validate the inline candidate before touching anything.
-    const candidateErrors = validateCandidateGedcomx(input.candidateGedcomx);
+    // 2. Sanitize + validate the inline candidate exactly as the write path
+    //    does — the dry-run must merge the same document the writer would.
+    const { candidate } = sanitizeCandidate(input.candidateGedcomx);
+    const candidateErrors = validateCandidateGedcomx(candidate);
     if (candidateErrors.length > 0) {
       return { ok: false, errors: candidateErrors };
     }
-    const candidate = input.candidateGedcomx;
 
     // 3. Merge in memory with the SAME core the write path uses. The core
     //    throws on empty/duplicate/unknown/chained merges and on a survivor id

--- a/packages/engine/mcp-server/src/tools/merge-warnings.ts
+++ b/packages/engine/mcp-server/src/tools/merge-warnings.ts
@@ -22,6 +22,7 @@ import { mergeGedcomx } from "../utils/merge-gedcomx.js";
 import { validateParsed } from "../validation/validator.js";
 import { Mob } from "../utils/mob.js";
 import { calculateWarnings } from "./person-warnings.js";
+import { sanitizeTree } from "../validation/tree-sanitize.js";
 import {
   MergeInputError,
   readProjectJson,
@@ -39,14 +40,16 @@ export async function mergeWarnings(
   try {
     // 1. Read the tree fresh (same as merge_record_into_tree, so the dry-run
     //    sees exactly the state a real merge would).
-    const tree = (await readProjectJson(
-      projectPath,
-      "tree.gedcomx.json",
-    )) as SimplifiedGedcomX;
+    const treeSanitized = sanitizeTree(
+      await readProjectJson(projectPath, "tree.gedcomx.json"),
+    );
+    const tree = treeSanitized.tree;
 
     // 2. Sanitize + validate the inline candidate exactly as the write path
     //    does — the dry-run must merge the same document the writer would.
-    const { candidate } = sanitizeCandidate(input.candidateGedcomx);
+    const { candidate, warnings: candidateSanitizeWarnings } = sanitizeCandidate(
+      input.candidateGedcomx,
+    );
     const candidateErrors = validateCandidateGedcomx(candidate);
     if (candidateErrors.length > 0) {
       return { ok: false, errors: candidateErrors };
@@ -107,7 +110,15 @@ export async function mergeWarnings(
       }
     }
 
-    return { ok: true, warningCount: warnings.length, warnings };
+    return {
+      ok: true,
+      warningCount: warnings.length,
+      warnings,
+      // What sanitation did (candidate strips, legacy-tree heals) — surfaced
+      // at the dry-run so the LLM learns about dropped data BEFORE deciding
+      // to write, not after.
+      sanitizeWarnings: [...treeSanitized.warnings, ...candidateSanitizeWarnings],
+    };
   } catch (e) {
     if (e instanceof MergeInputError) return { ok: false, errors: [e.message] };
     throw e;

--- a/packages/engine/mcp-server/src/tools/research-append.ts
+++ b/packages/engine/mcp-server/src/tools/research-append.ts
@@ -13,6 +13,7 @@
 import { join } from "path";
 import { readFile } from "fs/promises";
 import { validateParsed } from "../validation/validator.js";
+import { sanitizeTree } from "../validation/tree-sanitize.js";
 import type { ValidationError } from "../validation/types.js";
 import { atomicWriteJson } from "../utils/project-io.js";
 import { coerceJsonArg } from "../utils/coerce-json-arg.js";
@@ -370,7 +371,10 @@ export async function researchAppend(
 
   try {
     const research = await readJson(projectPath, "research.json");
-    const tree = await readJson(projectPath, "tree.gedcomx.json");
+    // Heal legacy tree shapes in memory only — this tool never writes the
+    // tree, but its whole-project validation must not brick research writes
+    // on a pre-tightening tree the tree tools would heal on their next write.
+    const { tree } = sanitizeTree(await readJson(projectPath, "tree.gedcomx.json"));
 
     // ─── Batch form: apply every op in-memory, then validate + write once ─────
     if (input.ops !== undefined) {

--- a/packages/engine/mcp-server/src/tools/research-log-append.ts
+++ b/packages/engine/mcp-server/src/tools/research-log-append.ts
@@ -11,6 +11,7 @@
 import { join } from "path";
 import { readFile, unlink } from "fs/promises";
 import { validateParsed } from "../validation/validator.js";
+import { sanitizeTree } from "../validation/tree-sanitize.js";
 import type { ValidationError } from "../validation/types.js";
 import { atomicWriteJson } from "../utils/project-io.js";
 import { finalizeStagedResults } from "../utils/results-staging.js";
@@ -165,7 +166,9 @@ export async function researchLogAppend(
     // 2. Read project files (research mutated in memory only; tree read for
     //    cross-file checks during validation).
     const research = await readProjectJson(projectPath, "research.json");
-    const tree = await readProjectJson(projectPath, "tree.gedcomx.json");
+    const { tree } = sanitizeTree(
+      await readProjectJson(projectPath, "tree.gedcomx.json"),
+    );
     if (!Array.isArray(research.log)) {
       return { ok: false, errors: ["research.json `log` is missing or not an array"] };
     }

--- a/packages/engine/mcp-server/src/tools/tree-edit.ts
+++ b/packages/engine/mcp-server/src/tools/tree-edit.ts
@@ -19,6 +19,7 @@ import type {
   SimplifiedSourceDescription,
 } from "../types/gedcomx.js";
 import { validateParsed } from "../validation/validator.js";
+import { sanitizeTree } from "../validation/tree-sanitize.js";
 import type { ValidationError } from "../validation/types.js";
 import { atomicWriteJson, backupIfExists } from "../utils/project-io.js";
 import { maxIdNum, nextId } from "../utils/gedcomx-ids.js";
@@ -120,14 +121,14 @@ function requirePerson(tree: SimplifiedGedcomX, personId: string | undefined): S
 /** Remove the `primary` flag from the person's other facts of the same type. */
 function clearPrimaryOfType(person: SimplifiedPerson, type: string | undefined, exceptId: string | undefined): void {
   for (const f of person.facts ?? []) {
-    if (f.id !== exceptId && f.type === type && f.primary) delete f.primary;
+    if (f.id !== exceptId && f.type === type && "primary" in f) delete f.primary;
   }
 }
 
 /** Remove the `preferred` flag from the person's other names. */
 function clearPreferred(person: SimplifiedPerson, exceptId: string | undefined): void {
   for (const n of person.names ?? []) {
-    if (n.id !== exceptId && n.preferred) delete n.preferred;
+    if (n.id !== exceptId && "preferred" in n) delete n.preferred;
   }
 }
 
@@ -315,7 +316,14 @@ export async function treeEdit(input: TreeEditInput): Promise<TreeEditResult> {
   input.source = coerceJsonArg(input.source) as SimplifiedSourceDescription | undefined;
 
   try {
-    const tree = (await readJson(projectPath, "tree.gedcomx.json")) as SimplifiedGedcomX;
+    // Heal legacy shapes before anything touches the document: the closed
+    // shapes below would otherwise refuse every write on a pre-tightening
+    // tree, with no op able to express the repair. The healed document is
+    // what a successful edit persists — a one-shot migration.
+    const sanitized = sanitizeTree(
+      await readJson(projectPath, "tree.gedcomx.json"),
+    );
+    const tree = sanitized.tree;
     const research = await readJson(projectPath, "research.json");
 
     const treePath = join(projectPath, "tree.gedcomx.json");
@@ -354,7 +362,10 @@ export async function treeEdit(input: TreeEditInput): Promise<TreeEditResult> {
         ok: true,
         results,
         filesWritten: ["tree.gedcomx.json"],
-        validation: { valid: true, warnings: [...formatIssues(validation.warnings), ...opWarnings] },
+        validation: {
+          valid: true,
+          warnings: [...sanitized.warnings, ...formatIssues(validation.warnings), ...opWarnings],
+        },
       };
     }
 
@@ -376,7 +387,10 @@ export async function treeEdit(input: TreeEditInput): Promise<TreeEditResult> {
       ok: true,
       operation: input.operation,
       filesWritten: ["tree.gedcomx.json"],
-      validation: { valid: true, warnings: [...formatIssues(validation.warnings), ...warnings] },
+      validation: {
+        valid: true,
+        warnings: [...sanitized.warnings, ...formatIssues(validation.warnings), ...warnings],
+      },
     };
     if (Object.keys(assignedIds).length > 0) result.assignedIds = assignedIds;
     return result;

--- a/packages/engine/mcp-server/src/types/gedcomx.ts
+++ b/packages/engine/mcp-server/src/types/gedcomx.ts
@@ -153,7 +153,10 @@ export interface SimplifiedRelationship {
 export interface SimplifiedSourceReference {
   ref?: string;
   page?: string;
-  quality?: string;
+  /** GEDCOM QUAY, an integer 0–3 — matching the tree schema, the shared TS
+   * types, and the prose spec. Encoded as a string inside the fsmcp:quality
+   * qualifier on the raw-GedcomX side (qualifier values are strings). */
+  quality?: number;
 }
 
 export interface SimplifiedSourceDescription {

--- a/packages/engine/mcp-server/src/types/merge-warnings.ts
+++ b/packages/engine/mcp-server/src/types/merge-warnings.ts
@@ -15,6 +15,9 @@ export interface MergeWarningsSuccess {
   ok: true;
   warningCount: number;
   warnings: PersonWarning[];
+  /** What sanitation did (candidate strips, legacy-tree heals) — surfaced at
+   *  the dry-run so data drops are known BEFORE the write decision. */
+  sanitizeWarnings: string[];
 }
 
 export interface MergeWarningsFailure {

--- a/packages/engine/mcp-server/src/utils/gedcomx-convert.ts
+++ b/packages/engine/mcp-server/src/utils/gedcomx-convert.ts
@@ -372,9 +372,14 @@ function simplifySourceRef(
     out.page = citationDetail.value;
   }
 
+  // The qualifier carries QUAY as a string (qualifier values are strings);
+  // the simplified format wants the integer the tree schema requires. A
+  // value that doesn't parse as an integer is dropped, like any other
+  // unrecognized qualifier content.
   const quality = qualifiers.find((q) => q.name === QUALITY_QUALIFIER);
-  if (quality && typeof quality.value === "string") {
-    out.quality = quality.value;
+  if (quality && typeof quality.value === "string" && quality.value.trim() !== "") {
+    const parsed = Number(quality.value.trim());
+    if (Number.isInteger(parsed)) out.quality = parsed;
   }
 
   return out;
@@ -590,8 +595,8 @@ function expandSourceRef(
   if (typeof ref.page === "string") {
     qualifiers.push({ name: CITATION_DETAIL, value: ref.page });
   }
-  if (typeof ref.quality === "string") {
-    qualifiers.push({ name: QUALITY_QUALIFIER, value: ref.quality });
+  if (typeof ref.quality === "number" && Number.isInteger(ref.quality)) {
+    qualifiers.push({ name: QUALITY_QUALIFIER, value: String(ref.quality) });
   }
   if (qualifiers.length > 0) out.qualifiers = qualifiers;
 

--- a/packages/engine/mcp-server/src/utils/gedcomx-convert.ts
+++ b/packages/engine/mcp-server/src/utils/gedcomx-convert.ts
@@ -374,12 +374,12 @@ function simplifySourceRef(
 
   // The qualifier carries QUAY as a string (qualifier values are strings);
   // the simplified format wants the integer the tree schema requires. A
-  // value that doesn't parse as an integer is dropped, like any other
-  // unrecognized qualifier content.
+  // value outside the QUAY range 0-3 (or that isn't an integer at all) is
+  // dropped, like any other unrecognized qualifier content — emitting it
+  // would produce a document every validity gate rejects.
   const quality = qualifiers.find((q) => q.name === QUALITY_QUALIFIER);
-  if (quality && typeof quality.value === "string" && quality.value.trim() !== "") {
-    const parsed = Number(quality.value.trim());
-    if (Number.isInteger(parsed)) out.quality = parsed;
+  if (quality && typeof quality.value === "string" && /^[0-3]$/.test(quality.value.trim())) {
+    out.quality = Number(quality.value.trim());
   }
 
   return out;
@@ -595,7 +595,7 @@ function expandSourceRef(
   if (typeof ref.page === "string") {
     qualifiers.push({ name: CITATION_DETAIL, value: ref.page });
   }
-  if (typeof ref.quality === "number" && Number.isInteger(ref.quality)) {
+  if (Number.isInteger(ref.quality) && (ref.quality as number) >= 0 && (ref.quality as number) <= 3) {
     qualifiers.push({ name: QUALITY_QUALIFIER, value: String(ref.quality) });
   }
   if (qualifiers.length > 0) out.qualifiers = qualifiers;

--- a/packages/engine/mcp-server/src/utils/merge-gedcomx.ts
+++ b/packages/engine/mcp-server/src/utils/merge-gedcomx.ts
@@ -364,7 +364,9 @@ function mergeNames(names: SimplifiedName[]): SimplifiedName[] {
     const sources = dedupSourceRefs(members.flatMap((m) => m.sources ?? []));
     if (sources.length > 0) rep.sources = sources;
     else delete rep.sources;
-    rep.preferred = false;
+    // `preferred` is `const: true` in the tree schema — absence means false,
+    // and writing `preferred: false` persists a tree the schema rejects.
+    delete rep.preferred;
     return { rep, size: members.length };
   });
 

--- a/packages/engine/mcp-server/src/utils/merge-gedcomx.ts
+++ b/packages/engine/mcp-server/src/utils/merge-gedcomx.ts
@@ -96,14 +96,12 @@ function mergeCrossDocument(
       if (!surv.gender && content.gender) surv.gender = content.gender;
       if (content.names.length) (surv.names ??= []).push(...content.names);
       if (content.facts.length) (surv.facts ??= []).push(...content.facts);
-      if (content.sources.length) (surv.sources ??= []).push(...content.sources);
     } else {
       const carried: SimplifiedPerson = { id: personIdMap.get(person.id) };
       if (content.ark !== undefined) carried.ark = content.ark;
       if (content.gender !== undefined) carried.gender = content.gender;
       if (content.names.length) carried.names = content.names;
       if (content.facts.length) carried.facts = content.facts;
-      if (content.sources.length) carried.sources = content.sources;
       result.persons.push(carried);
     }
   }
@@ -113,7 +111,6 @@ function mergeCrossDocument(
     const surv = result.persons.find((p) => p.id === survivorId);
     if (surv?.names) surv.names = mergeNames(surv.names);
     if (surv?.facts) surv.facts = mergeFacts(surv.facts);
-    if (surv?.sources) surv.sources = dedupSourceRefs(surv.sources);
   }
 
   const remappedRels = (candidate.relationships ?? []).map((rel) =>
@@ -124,37 +121,13 @@ function mergeCrossDocument(
     result.relationships = dedupRelationships(combinedRels);
   }
 
-  // Carry candidate places, keeping ids unique (places aren't referenced).
-  const candidatePlaces = candidate.places ?? [];
-  if (candidatePlaces.length > 0) {
-    const usedPlaceIds = new Set(
-      (result.places ?? [])
-        .map((p) => p.id)
-        .filter((id): id is string => id !== undefined),
-    );
-    for (const pl of candidatePlaces) {
-      const cloned = structuredClone(pl);
-      if (cloned.id !== undefined && usedPlaceIds.has(cloned.id)) {
-        cloned.id = freshPlaceId(cloned.id, usedPlaceIds);
-      }
-      if (cloned.id !== undefined) usedPlaceIds.add(cloned.id);
-      (result.places ??= []).push(cloned);
-    }
-  }
+  // Candidate `places[]` are NOT carried: the persisted tree format has no
+  // top-level places section (facts carry place names), so carrying them
+  // would persist a document the tree schema rejects. The tool layer strips
+  // them with a warning before the merge (sanitizeCandidate).
 
   ensureUniqueFactAndNameIds(result);
   return result;
-}
-
-/** A unique place id derived from `base` (places aren't referenced by id). */
-function freshPlaceId(base: string, used: Set<string>): string {
-  let n = 2;
-  let id = `${base}-${n}`;
-  while (used.has(id)) {
-    n += 1;
-    id = `${base}-${n}`;
-  }
-  return id;
 }
 
 // ─── Mode 2: same-document merge ────────────────────────────────────────────
@@ -182,7 +155,6 @@ function mergeSameDocument(
     if (!surv.gender && coll.gender) surv.gender = coll.gender;
     if (coll.names?.length) (surv.names ??= []).push(...structuredClone(coll.names));
     if (coll.facts?.length) (surv.facts ??= []).push(...structuredClone(coll.facts));
-    if (coll.sources?.length) (surv.sources ??= []).push(...structuredClone(coll.sources));
   }
 
   const collapsedIds = new Set(merges.map(([, c]) => c));
@@ -206,7 +178,6 @@ function mergeSameDocument(
     const surv = result.persons.find((p) => p.id === survivorId);
     if (surv?.names) surv.names = mergeNames(surv.names);
     if (surv?.facts) surv.facts = mergeFacts(surv.facts);
-    if (surv?.sources) surv.sources = dedupSourceRefs(surv.sources);
   }
 
   ensureUniqueFactAndNameIds(result);
@@ -219,13 +190,14 @@ interface PersonContent {
   gender?: string;
   names: SimplifiedName[];
   facts: SimplifiedFact[];
-  sources: SimplifiedSourceReference[];
 }
 
 /**
- * Clone a candidate person's names/facts/source-refs with fresh N/F ids and
- * source refs rewritten through `sourceIdMap`. The id itself is assigned by
- * the caller (survivor id for a collapse, fresh I id for a carry).
+ * Clone a candidate person's names/facts with fresh N/F ids and source refs
+ * rewritten through `sourceIdMap`. The id itself is assigned by the caller
+ * (survivor id for a collapse, fresh I id for a carry). Person-level
+ * `sources` are not part of the tree format and are not carried (the tool
+ * layer strips them from candidates before the merge).
  */
 function remapPersonContent(
   person: SimplifiedPerson,
@@ -244,10 +216,7 @@ function remapPersonContent(
     if (c.sources) c.sources = remapSourceRefs(c.sources, sourceIdMap);
     return c;
   });
-  const sources = person.sources
-    ? remapSourceRefs(person.sources, sourceIdMap)
-    : [];
-  return { ark: person.ark, gender: person.gender, names, facts, sources };
+  return { ark: person.ark, gender: person.gender, names, facts };
 }
 
 /** Clone a candidate relationship with a fresh R id and all refs repointed. */

--- a/packages/engine/mcp-server/src/validation/tree-sanitize.ts
+++ b/packages/engine/mcp-server/src/validation/tree-sanitize.ts
@@ -1,0 +1,269 @@
+// Read-time healing for legacy tree.gedcomx.json documents.
+//
+// The validator closed every object shape (tree-shape.ts), which means trees
+// written before the tightening — by the old merge core (`preferred: false`
+// on every non-preferred merged name, top-level `places[]` carried per the
+// old spec §6.7), by the old open-shape validator (person-level `sources`,
+// invented fact keys like `date_certainty`), or by hand — no longer validate.
+// Every persistence tool validates the WHOLE project before writing anything,
+// so one legacy shape would otherwise brick every write on that project,
+// including research-log appends, with no tree_edit op able to express the
+// repair.
+//
+// `sanitizeTree` heals exactly the shapes whose repair is unambiguous, and
+// returns one warning per healed class so the LLM can narrate what changed.
+// Ambiguous problems are deliberately NOT healed and still hard-fail
+// validation: dangling references (can't infer the target), swapped
+// relationship endpoint keys (can't infer direction), duplicate ids (can't
+// pick a winner), missing `given` (spelling unknowns as `""` is the agent's
+// call), and non-PascalCase fact types (meaning is the agent's call).
+//
+// Callers: every tool that reads tree.gedcomx.json — tree_edit and the merge
+// tools persist the healed document on their next successful write (one-shot
+// migration); research_append/research_log_append heal in memory only, so
+// their cross-file validation sees the healed tree without touching it.
+// The inline-candidate twin is `sanitizeCandidate` in tools/merge-shared.ts,
+// which strips the record_read-legal shapes (places, person sources) but
+// leaves everything else to hard validation — candidates are fresh tool
+// output, not legacy documents, and junk there should be rejected loudly.
+
+import type { SimplifiedGedcomX } from "../types/gedcomx.js";
+import { nextId } from "../utils/gedcomx-ids.js";
+import {
+  TREE_TOP_LEVEL_FIELDS,
+  TREE_PERSON_FIELDS,
+  TREE_NAME_FIELDS,
+  TREE_FACT_FIELDS,
+  TREE_PARENT_CHILD_FIELDS,
+  TREE_COUPLE_FIELDS,
+  TREE_SOURCE_FIELDS,
+  TREE_SOURCE_REF_FIELDS,
+} from "./tree-shape.js";
+
+export interface SanitizeTreeResult {
+  tree: SimplifiedGedcomX;
+  warnings: string[];
+}
+
+/** Tally of healed shapes, flushed into human-readable warnings at the end. */
+class Tally {
+  droppedKeys = new Map<string, number>(); // "persons.date_certainty" -> n
+  flags = new Map<string, number>(); // "preferred" | "primary" -> n
+  mintedIds = new Map<string, number>(); // prefix -> n
+  qualityCoerced = 0;
+  qualityDropped = 0;
+  placesDropped = 0;
+  personSourcesDropped = 0;
+  nonObjectsDropped = 0;
+
+  key(where: string, key: string): void {
+    const k = `${where}.${key}`;
+    this.droppedKeys.set(k, (this.droppedKeys.get(k) ?? 0) + 1);
+  }
+}
+
+function pruneKeys(obj: any, allowed: Set<string>, where: string, tally: Tally): void {
+  for (const key of Object.keys(obj)) {
+    if (!allowed.has(key)) {
+      // places / person-sources get their own targeted warnings below.
+      if (!(where === "tree" && key === "places") && !(where === "persons" && key === "sources")) {
+        tally.key(where, key);
+      }
+      delete obj[key];
+    }
+  }
+}
+
+/** `preferred`/`primary` are `const: true` — anything else means "not it". */
+function pruneFlag(obj: any, field: string, tally: Tally): void {
+  if (field in obj && obj[field] !== true) {
+    delete obj[field];
+    tally.flags.set(field, (tally.flags.get(field) ?? 0) + 1);
+  }
+}
+
+/** Legacy string QUAY ("0"–"3") becomes the integer; anything else invalid goes. */
+function pruneQuality(sref: any, tally: Tally): void {
+  if (!("quality" in sref)) return;
+  const q = sref.quality;
+  if (Number.isInteger(q) && q >= 0 && q <= 3) return;
+  if (typeof q === "string" && /^[0-3]$/.test(q.trim())) {
+    sref.quality = Number(q.trim());
+    tally.qualityCoerced += 1;
+    return;
+  }
+  delete sref.quality;
+  tally.qualityDropped += 1;
+}
+
+function sanitizeSourceRefs(holder: any, tally: Tally): void {
+  if (!("sources" in holder)) return;
+  if (!Array.isArray(holder.sources)) {
+    delete holder.sources;
+    tally.nonObjectsDropped += 1;
+    return;
+  }
+  holder.sources = holder.sources.filter((s: any) => {
+    if (!s || typeof s !== "object") {
+      tally.nonObjectsDropped += 1;
+      return false;
+    }
+    return true;
+  });
+  for (const sref of holder.sources) {
+    pruneKeys(sref, TREE_SOURCE_REF_FIELDS, "source refs", tally);
+    pruneQuality(sref, tally);
+  }
+  if (holder.sources.length === 0) delete holder.sources;
+}
+
+/**
+ * Filter non-object entries out of an array IN PLACE on `holder[key]`.
+ * Deliberately does nothing when the value is missing or not an array:
+ * inventing an empty section would heal a truncated or corrupt file into a
+ * "valid" empty tree — silent data loss. The validator reports those.
+ */
+function objectEntries(holder: any, key: string, tally: Tally): any[] {
+  if (!Array.isArray(holder[key])) return [];
+  holder[key] = holder[key].filter((x: any) => {
+    if (!x || typeof x !== "object" || Array.isArray(x)) {
+      tally.nonObjectsDropped += 1;
+      return false;
+    }
+    return true;
+  });
+  return holder[key];
+}
+
+function sanitizeFact(fact: any, tree: SimplifiedGedcomX, tally: Tally): void {
+  pruneKeys(fact, TREE_FACT_FIELDS, "facts", tally);
+  pruneFlag(fact, "primary", tally);
+  if (!fact.id) {
+    fact.id = nextId(tree, "F");
+    tally.mintedIds.set("F", (tally.mintedIds.get("F") ?? 0) + 1);
+  }
+  sanitizeSourceRefs(fact, tally);
+}
+
+/**
+ * Heal the legacy shapes in a parsed tree.gedcomx.json whose repair is
+ * unambiguous. Returns a deep copy plus one warning per healed class; the
+ * input is never mutated. A tree with nothing to heal comes back with zero
+ * warnings and deep-equal content.
+ */
+export function sanitizeTree(input: unknown): SanitizeTreeResult {
+  const tally = new Tally();
+  const warnings: string[] = [];
+  if (!input || typeof input !== "object" || Array.isArray(input)) {
+    // Not tree-shaped at all — nothing sane to heal; let validation report it.
+    return { tree: input as SimplifiedGedcomX, warnings };
+  }
+  const tree = structuredClone(input) as any;
+
+  const placeCount = Array.isArray(tree.places) ? tree.places.length : "places" in tree ? 1 : 0;
+  if (placeCount > 0) tally.placesDropped = placeCount;
+  pruneKeys(tree, TREE_TOP_LEVEL_FIELDS, "tree", tally);
+
+  for (const person of objectEntries(tree, "persons", tally)) {
+    if (Array.isArray(person.sources)) tally.personSourcesDropped += person.sources.length;
+    else if ("sources" in person) tally.personSourcesDropped += 1;
+    pruneKeys(person, TREE_PERSON_FIELDS, "persons", tally);
+    if (!person.id) {
+      person.id = nextId(tree, "I");
+      tally.mintedIds.set("I", (tally.mintedIds.get("I") ?? 0) + 1);
+    }
+    for (const name of objectEntries(person, "names", tally)) {
+      pruneKeys(name, TREE_NAME_FIELDS, "names", tally);
+      pruneFlag(name, "preferred", tally);
+      if (!name.id) {
+        name.id = nextId(tree, "N");
+        tally.mintedIds.set("N", (tally.mintedIds.get("N") ?? 0) + 1);
+      }
+      sanitizeSourceRefs(name, tally);
+    }
+    if (Array.isArray(person.facts)) {
+      for (const fact of objectEntries(person, "facts", tally)) {
+        sanitizeFact(fact, tree, tally);
+      }
+      if (person.facts.length === 0) delete person.facts;
+    }
+  }
+
+  for (const rel of objectEntries(tree, "relationships", tally)) {
+    const allowed = rel.type === "Couple" ? TREE_COUPLE_FIELDS : TREE_PARENT_CHILD_FIELDS;
+    // Couple facts are legal; ParentChild facts are not — but a ParentChild's
+    // stray `facts` is an unknown key for its type and prunes with a warning.
+    pruneKeys(rel, allowed, "relationships", tally);
+    if (!rel.id) {
+      rel.id = nextId(tree, "R");
+      tally.mintedIds.set("R", (tally.mintedIds.get("R") ?? 0) + 1);
+    }
+    if (rel.type === "Couple" && Array.isArray(rel.facts)) {
+      for (const fact of objectEntries(rel, "facts", tally)) {
+        sanitizeFact(fact, tree, tally);
+      }
+      if (rel.facts.length === 0) delete rel.facts;
+    }
+    sanitizeSourceRefs(rel, tally);
+  }
+
+  for (const src of objectEntries(tree, "sources", tally)) {
+    pruneKeys(src, TREE_SOURCE_FIELDS, "sources", tally);
+    if (!src.id) {
+      src.id = nextId(tree, "S");
+      tally.mintedIds.set("S", (tally.mintedIds.get("S") ?? 0) + 1);
+    }
+  }
+
+  // ── Flush the tally into narratable warnings ──────────────────────────────
+  if (tally.placesDropped > 0) {
+    warnings.push(
+      `healed legacy tree: dropped the top-level places section ` +
+        `(${tally.placesDropped} entr${tally.placesDropped === 1 ? "y" : "ies"}) — ` +
+        `the tree format carries places as names on facts`,
+    );
+  }
+  if (tally.personSourcesDropped > 0) {
+    warnings.push(
+      `healed legacy tree: dropped ${tally.personSourcesDropped} person-level ` +
+        `source reference(s) — tree source references live on names/facts/relationships`,
+    );
+  }
+  for (const [field, n] of tally.flags) {
+    warnings.push(
+      `healed legacy tree: removed '${field}: false' from ${n} ` +
+        `${field === "preferred" ? "name(s)" : "fact(s)"} — absence means false, ` +
+        `and the schema pins ${field} to true-or-absent`,
+    );
+  }
+  for (const [key, n] of [...tally.droppedKeys].sort()) {
+    const [where, name] = key.split(".");
+    warnings.push(
+      `healed legacy tree: dropped unknown property '${name}' from ${n} ${where} ` +
+        `object(s) — not part of the tree format`,
+    );
+  }
+  for (const [prefix, n] of [...tally.mintedIds].sort()) {
+    warnings.push(`healed legacy tree: assigned ${prefix} ids to ${n} object(s) that had none`);
+  }
+  if (tally.qualityCoerced > 0) {
+    warnings.push(
+      `healed legacy tree: converted ${tally.qualityCoerced} string quality value(s) ` +
+        `to the QUAY integer`,
+    );
+  }
+  if (tally.qualityDropped > 0) {
+    warnings.push(
+      `healed legacy tree: dropped ${tally.qualityDropped} quality value(s) that were ` +
+        `not integers 0-3 (GEDCOM QUAY)`,
+    );
+  }
+  if (tally.nonObjectsDropped > 0) {
+    warnings.push(
+      `healed legacy tree: removed ${tally.nonObjectsDropped} entry(ies) that were ` +
+        `not objects where the format requires them`,
+    );
+  }
+
+  return { tree: tree as SimplifiedGedcomX, warnings };
+}

--- a/packages/engine/mcp-server/src/validation/tree-shape.ts
+++ b/packages/engine/mcp-server/src/validation/tree-shape.ts
@@ -1,0 +1,30 @@
+// The simplified-GedcomX field allow-lists, one set per object type. Each set
+// mirrors the matching `additionalProperties: false` subschema in
+// tree-gedcomx.schema.json. Shared by the runtime validator (which REJECTS
+// unknown keys at the tool boundary) and the read-time sanitizer (which HEALS
+// legacy documents written before the shapes were closed) — one source of
+// truth so the two can never disagree about what the format is.
+
+export const TREE_TOP_LEVEL_FIELDS = new Set(["persons", "relationships", "sources"]);
+export const TREE_PERSON_FIELDS = new Set(["id", "ark", "living", "gender", "names", "facts"]);
+export const TREE_NAME_FIELDS = new Set([
+  "id", "preferred", "given", "surname", "prefix", "suffix", "type", "sources",
+]);
+export const TREE_FACT_FIELDS = new Set([
+  "id", "type", "primary", "date", "standard_date", "place",
+  "standard_place", "value", "sources",
+]);
+// ParentChild/Couple sets include the other type's endpoint keys so the
+// bespoke "should use 'parent'/'child'" style errors stay the single report
+// for a swapped-endpoint mistake (no duplicate unknown-key error), and so the
+// sanitizer never silently deletes an endpoint it cannot re-derive.
+export const TREE_PARENT_CHILD_FIELDS = new Set([
+  "id", "type", "parent", "child", "subtype", "notes", "sources",
+  "person1", "person2",
+]);
+export const TREE_COUPLE_FIELDS = new Set([
+  "id", "type", "person1", "person2", "facts", "notes", "sources",
+  "parent", "child",
+]);
+export const TREE_SOURCE_FIELDS = new Set(["id", "title", "citation", "author", "url"]);
+export const TREE_SOURCE_REF_FIELDS = new Set(["ref", "page", "quality"]);

--- a/packages/engine/mcp-server/src/validation/validator.ts
+++ b/packages/engine/mcp-server/src/validation/validator.ts
@@ -280,13 +280,35 @@ const NULLABLE_FIELDS = new Set([
   "conflict_ids", "conflict_note", "justification",
 ]);
 
-// Allowed properties on a simplified-GedcomX tree source. Mirrors
-// `$defs.source_description` in tree-gedcomx.schema.json, which sets
-// `additionalProperties: false`. The runtime check in validateGedcomx rejects
-// any other key so an op that puts citation text under the wrong field name
-// (e.g. `description` instead of `citation`) fails validation and is not
-// written — instead of persisting a tree that later fails the JSON Schema.
+// Allowed properties per simplified-GedcomX object. Each set mirrors the
+// matching `additionalProperties: false` subschema in tree-gedcomx.schema.json.
+// The runtime checks in validateGedcomx reject any other key so an op that
+// puts data under the wrong field name (e.g. `standrad_date` instead of
+// `standard_date`, or `description` instead of `citation`) fails validation
+// and is not written — instead of persisting a tree that only the fixture
+// lint rejects later, far from the mistake.
+const TREE_TOP_LEVEL_FIELDS = new Set(["persons", "relationships", "sources"]);
+const TREE_PERSON_FIELDS = new Set(["id", "ark", "living", "gender", "names", "facts"]);
+const TREE_NAME_FIELDS = new Set([
+  "id", "preferred", "given", "surname", "prefix", "suffix", "type", "sources",
+]);
+const TREE_FACT_FIELDS = new Set([
+  "id", "type", "primary", "date", "standard_date", "place",
+  "standard_place", "value", "sources",
+]);
+// ParentChild/Couple sets include the other type's endpoint keys so the
+// bespoke "should use 'parent'/'child'" style errors below stay the single
+// report for a swapped-endpoint mistake (no duplicate unknown-key error).
+const TREE_PARENT_CHILD_FIELDS = new Set([
+  "id", "type", "parent", "child", "subtype", "notes", "sources",
+  "person1", "person2",
+]);
+const TREE_COUPLE_FIELDS = new Set([
+  "id", "type", "person1", "person2", "facts", "notes", "sources",
+  "parent", "child",
+]);
 const TREE_SOURCE_FIELDS = new Set(["id", "title", "citation", "author", "url"]);
+const TREE_SOURCE_REF_FIELDS = new Set(["ref", "page", "quality"]);
 
 function validateResearch(data: any, report: ValidationReport): ResearchIds {
   const path = "research.json";
@@ -789,12 +811,137 @@ function validateEvaluations(
   }
 }
 
+function checkTreeKeys(
+  obj: any,
+  allowed: Set<string>,
+  what: string,
+  path: string,
+  report: ValidationReport
+): void {
+  if (!obj || typeof obj !== "object") return;
+  for (const key of Object.keys(obj)) {
+    if (!allowed.has(key)) {
+      addError(
+        report,
+        path,
+        `unexpected property '${key}' (${what} allow only ${Array.from(
+          allowed
+        ).join(", ")})`
+      );
+    }
+  }
+}
+
+function checkTreeStrings(
+  obj: any,
+  fields: string[],
+  path: string,
+  report: ValidationReport
+): void {
+  for (const field of fields) {
+    if (field in obj && typeof obj[field] !== "string") {
+      addError(report, path, `'${field}' must be a string`);
+    }
+  }
+}
+
+/** `preferred` on names and `primary` on facts are `const: true` in the schema. */
+function checkTrueFlag(
+  obj: any,
+  field: string,
+  path: string,
+  report: ValidationReport
+): void {
+  if (field in obj && obj[field] !== true) {
+    addError(
+      report,
+      path,
+      `'${field}' must be true when present — omit it rather than setting false`
+    );
+  }
+}
+
+function checkTreeSourceRefs(
+  holder: any,
+  path: string,
+  sourceIds: Set<string>,
+  report: ValidationReport
+): void {
+  const refs = Array.isArray(holder.sources) ? holder.sources : [];
+  for (let k = 0; k < refs.length; k++) {
+    const sref = refs[k];
+    const srp = `${path}/sources[${k}]`;
+    if (!sref || typeof sref !== "object") {
+      addError(report, srp, "source reference must be an object");
+      continue;
+    }
+    checkTreeKeys(sref, TREE_SOURCE_REF_FIELDS, "source references", srp, report);
+    if (!("ref" in sref)) {
+      addError(report, srp, "source reference missing 'ref'");
+    } else if (!sourceIds.has(sref.ref)) {
+      addError(report, srp, `references source '${sref.ref}' which does not exist`);
+    }
+    checkTreeStrings(sref, ["page"], srp, report);
+    if (
+      "quality" in sref &&
+      !(Number.isInteger(sref.quality) && sref.quality >= 0 && sref.quality <= 3)
+    ) {
+      addError(report, srp, "'quality' must be an integer between 0 and 3 (GEDCOM QUAY)");
+    }
+  }
+}
+
+/** Shared by person facts and Couple-relationship facts — same subschema. */
+function checkTreeFact(
+  fact: any,
+  path: string,
+  sourceIds: Set<string>,
+  report: ValidationReport
+): void {
+  if (!fact || typeof fact !== "object") {
+    addError(report, path, "fact must be an object");
+    return;
+  }
+  checkRequired(fact, ["id", "type"], path, report, NULLABLE_FIELDS);
+  checkTreeKeys(fact, TREE_FACT_FIELDS, "facts", path, report);
+  if ("type" in fact && typeof fact.type !== "string") {
+    addError(report, path, "'type' must be a string");
+  } else {
+    const ftype = fact.type || "";
+    if (ftype && ftype[0] !== ftype[0].toUpperCase()) {
+      addError(report, path, `fact type '${ftype}' should be PascalCase (e.g., 'Birth' not 'birth')`);
+    }
+  }
+  checkTrueFlag(fact, "primary", path, report);
+  checkTreeStrings(
+    fact,
+    ["date", "standard_date", "place", "standard_place", "value"],
+    path,
+    report
+  );
+  checkTreeSourceRefs(fact, path, sourceIds, report);
+}
+
+function checkTreeNotes(rel: any, path: string, report: ValidationReport): void {
+  if (!("notes" in rel)) return;
+  if (!Array.isArray(rel.notes) || rel.notes.some((n: any) => typeof n !== "string")) {
+    addError(report, path, "'notes' must be an array of strings");
+  }
+}
+
 /**
  * Validate a parsed simplified-GedcomX document (tree or a standalone candidate
  * record) against its structural rules, collecting referenced person/source ids
  * into the returned sets. Exported so the merge tools can validate an inline
  * `candidateGedcomx` argument without re-implementing the checks. Errors and
  * warnings are pushed to `report`; read the verdict via `isValid(report)`.
+ *
+ * Mirrors tree-gedcomx.schema.json's `additionalProperties: false` subschemas
+ * (unknown keys are rejected everywhere, not just on sources) and adds the
+ * checks JSON Schema cannot express: intra-document reference integrity for
+ * relationship endpoints and every source `ref` — including the two spots a
+ * prior version missed, person facts' twins on Couple relationships and the
+ * refs inside them.
  */
 export function validateGedcomx(
   data: any,
@@ -808,8 +955,11 @@ export function validateGedcomx(
   for (const section of ["persons", "relationships", "sources"]) {
     if (!(section in data)) {
       addError(report, path, `missing top-level section '${section}'`);
+    } else if (!Array.isArray(data[section])) {
+      addError(report, path, `'${section}' must be an array`);
     }
   }
+  checkTreeKeys(data, TREE_TOP_LEVEL_FIELDS, "tree documents", path, report);
 
   // Sources
   const sources = Array.isArray(data.sources) ? data.sources : [];
@@ -829,6 +979,7 @@ export function validateGedcomx(
           );
         }
       }
+      checkTreeStrings(src, ["title", "citation", "author", "url"], sp, report);
     }
     if ("id" in src) {
       sourceIds.add(src.id);
@@ -841,6 +992,11 @@ export function validateGedcomx(
     const person = persons[i];
     const pp = `${path}/persons[${i}]`;
     checkRequired(person, ["id", "gender", "names"], pp, report, NULLABLE_FIELDS);
+    checkTreeKeys(person, TREE_PERSON_FIELDS, "persons", pp, report);
+    checkTreeStrings(person, ["ark"], pp, report);
+    if ("living" in person && typeof person.living !== "boolean") {
+      addError(report, pp, "'living' must be a boolean");
+    }
     if ("id" in person) {
       personIds.add(person.id);
     }
@@ -856,37 +1012,15 @@ export function validateGedcomx(
       const name = names[j];
       const np = `${pp}/names[${j}]`;
       checkRequired(name, ["id", "given", "surname"], np, report, NULLABLE_FIELDS);
-      const nameSources = Array.isArray(name.sources) ? name.sources : [];
-      for (let k = 0; k < nameSources.length; k++) {
-        const sref = nameSources[k];
-        const srp = `${np}/sources[${k}]`;
-        if (!("ref" in sref)) {
-          addError(report, srp, "source reference missing 'ref'");
-        } else if (!sourceIds.has(sref.ref)) {
-          addError(report, srp, `references source '${sref.ref}' which does not exist`);
-        }
-      }
+      checkTreeKeys(name, TREE_NAME_FIELDS, "names", np, report);
+      checkTrueFlag(name, "preferred", np, report);
+      checkTreeStrings(name, ["given", "surname", "prefix", "suffix", "type"], np, report);
+      checkTreeSourceRefs(name, np, sourceIds, report);
     }
 
     const facts = Array.isArray(person.facts) ? person.facts : [];
     for (let j = 0; j < facts.length; j++) {
-      const fact = facts[j];
-      const fp = `${pp}/facts[${j}]`;
-      checkRequired(fact, ["id", "type"], fp, report, NULLABLE_FIELDS);
-      const ftype = fact.type || "";
-      if (ftype && ftype[0] !== ftype[0].toUpperCase()) {
-        addError(report, fp, `fact type '${ftype}' should be PascalCase (e.g., 'Birth' not 'birth')`);
-      }
-      const factSources = Array.isArray(fact.sources) ? fact.sources : [];
-      for (let k = 0; k < factSources.length; k++) {
-        const sref = factSources[k];
-        const srp = `${fp}/sources[${k}]`;
-        if (!("ref" in sref)) {
-          addError(report, srp, "source reference missing 'ref'");
-        } else if (!sourceIds.has(sref.ref)) {
-          addError(report, srp, `references source '${sref.ref}' which does not exist`);
-        }
-      }
+      checkTreeFact(facts[j], `${pp}/facts[${j}]`, sourceIds, report);
     }
   }
 
@@ -902,6 +1036,7 @@ export function validateGedcomx(
 
     const rtype = rel.type;
     if (rtype === "ParentChild") {
+      checkTreeKeys(rel, TREE_PARENT_CHILD_FIELDS, "ParentChild relationships", rp, report);
       if (!("parent" in rel)) {
         addError(report, rp, "ParentChild relationship missing 'parent'");
       } else if (!personIds.has(rel.parent)) {
@@ -915,7 +1050,10 @@ export function validateGedcomx(
       if ("person1" in rel || "person2" in rel) {
         addError(report, rp, "ParentChild should use 'parent'/'child', not 'person1'/'person2'");
       }
+      checkTreeStrings(rel, ["subtype"], rp, report);
+      checkTreeNotes(rel, rp, report);
     } else if (rtype === "Couple") {
+      checkTreeKeys(rel, TREE_COUPLE_FIELDS, "Couple relationships", rp, report);
       if (!("person1" in rel)) {
         addError(report, rp, "Couple relationship missing 'person1'");
       } else if (!personIds.has(rel.person1)) {
@@ -926,18 +1064,19 @@ export function validateGedcomx(
       } else if (!personIds.has(rel.person2)) {
         addError(report, rp, `person2 '${rel.person2}' not found in persons`);
       }
-    }
-
-    const relSources = Array.isArray(rel.sources) ? rel.sources : [];
-    for (let k = 0; k < relSources.length; k++) {
-      const sref = relSources[k];
-      const srp = `${rp}/sources[${k}]`;
-      if (!("ref" in sref)) {
-        addError(report, srp, "source reference missing 'ref'");
-      } else if (!sourceIds.has(sref.ref)) {
-        addError(report, srp, `references source '${sref.ref}' which does not exist`);
+      if ("parent" in rel || "child" in rel) {
+        addError(report, rp, "Couple should use 'person1'/'person2', not 'parent'/'child'");
+      }
+      checkTreeNotes(rel, rp, report);
+      // Couple facts (Marriage, Divorce, …) share the person-fact subschema —
+      // including reference integrity for their source refs.
+      const relFacts = Array.isArray(rel.facts) ? rel.facts : [];
+      for (let j = 0; j < relFacts.length; j++) {
+        checkTreeFact(relFacts[j], `${rp}/facts[${j}]`, sourceIds, report);
       }
     }
+
+    checkTreeSourceRefs(rel, rp, sourceIds, report);
   }
 
   return { personIds, sourceIds };

--- a/packages/engine/mcp-server/src/validation/validator.ts
+++ b/packages/engine/mcp-server/src/validation/validator.ts
@@ -18,6 +18,16 @@ import {
   isValid,
 } from "./types.js";
 import { isInsideProject } from "../utils/project-io.js";
+import {
+  TREE_TOP_LEVEL_FIELDS,
+  TREE_PERSON_FIELDS,
+  TREE_NAME_FIELDS,
+  TREE_FACT_FIELDS,
+  TREE_PARENT_CHILD_FIELDS,
+  TREE_COUPLE_FIELDS,
+  TREE_SOURCE_FIELDS,
+  TREE_SOURCE_REF_FIELDS,
+} from "./tree-shape.js";
 import { iteratePersonIdRefs } from "./person-id-refs.js";
 import { arkToBareId } from "../utils/ark.js";
 
@@ -280,35 +290,12 @@ const NULLABLE_FIELDS = new Set([
   "conflict_ids", "conflict_note", "justification",
 ]);
 
-// Allowed properties per simplified-GedcomX object. Each set mirrors the
-// matching `additionalProperties: false` subschema in tree-gedcomx.schema.json.
-// The runtime checks in validateGedcomx reject any other key so an op that
-// puts data under the wrong field name (e.g. `standrad_date` instead of
-// `standard_date`, or `description` instead of `citation`) fails validation
-// and is not written — instead of persisting a tree that only the fixture
-// lint rejects later, far from the mistake.
-const TREE_TOP_LEVEL_FIELDS = new Set(["persons", "relationships", "sources"]);
-const TREE_PERSON_FIELDS = new Set(["id", "ark", "living", "gender", "names", "facts"]);
-const TREE_NAME_FIELDS = new Set([
-  "id", "preferred", "given", "surname", "prefix", "suffix", "type", "sources",
-]);
-const TREE_FACT_FIELDS = new Set([
-  "id", "type", "primary", "date", "standard_date", "place",
-  "standard_place", "value", "sources",
-]);
-// ParentChild/Couple sets include the other type's endpoint keys so the
-// bespoke "should use 'parent'/'child'" style errors below stay the single
-// report for a swapped-endpoint mistake (no duplicate unknown-key error).
-const TREE_PARENT_CHILD_FIELDS = new Set([
-  "id", "type", "parent", "child", "subtype", "notes", "sources",
-  "person1", "person2",
-]);
-const TREE_COUPLE_FIELDS = new Set([
-  "id", "type", "person1", "person2", "facts", "notes", "sources",
-  "parent", "child",
-]);
-const TREE_SOURCE_FIELDS = new Set(["id", "title", "citation", "author", "url"]);
-const TREE_SOURCE_REF_FIELDS = new Set(["ref", "page", "quality"]);
+// Allowed properties per simplified-GedcomX object live in tree-shape.ts —
+// shared with the read-time sanitizer (tree-sanitize.ts) so the closed shapes
+// the validator enforces and the legacy shapes the sanitizer heals can never
+// disagree. The runtime checks below reject any other key so an op that puts
+// data under the wrong field name (e.g. `standrad_date` instead of
+// `standard_date`) fails validation and is not written.
 
 function validateResearch(data: any, report: ValidationReport): ResearchIds {
   const path = "research.json";
@@ -906,11 +893,11 @@ function checkTreeFact(
   checkTreeKeys(fact, TREE_FACT_FIELDS, "facts", path, report);
   if ("type" in fact && typeof fact.type !== "string") {
     addError(report, path, "'type' must be a string");
-  } else {
-    const ftype = fact.type || "";
-    if (ftype && ftype[0] !== ftype[0].toUpperCase()) {
-      addError(report, path, `fact type '${ftype}' should be PascalCase (e.g., 'Birth' not 'birth')`);
-    }
+  } else if ("type" in fact && !/^[A-Z]/.test(fact.type)) {
+    // Mirrors the schema's `pattern: ^[A-Z]` exactly (the old first-char
+    // toUpperCase comparison passed digit-initial and empty types the
+    // schema rejects — a gate seam for no benefit).
+    addError(report, path, `fact type '${fact.type}' must start with an uppercase letter (PascalCase, e.g. 'Birth' not 'birth')`);
   }
   checkTrueFlag(fact, "primary", path, report);
   checkTreeStrings(

--- a/packages/engine/mcp-server/tests/tools/merge-record-into-tree.test.ts
+++ b/packages/engine/mcp-server/tests/tools/merge-record-into-tree.test.ts
@@ -87,6 +87,45 @@ describe("merge_record_into_tree", () => {
     ]);
   });
 
+  it("strips candidate places and person-level sources with a warning, and persists neither", async () => {
+    await writeProject({
+      persons: [{ id: "I1", gender: "Male", names: [{ id: "N1", given: "John", surname: "Smith" }] }],
+      relationships: [],
+      sources: [],
+    });
+
+    // A record_read-shaped candidate: persona-level source refs and a
+    // places[] section are legal tool output but not tree format.
+    const result = await mergeRecordIntoTree({
+      projectPath: dir,
+      candidateGedcomx: {
+        persons: [
+          {
+            id: "I1",
+            gender: "Male",
+            names: [{ id: "N1", given: "John", surname: "Smith" }],
+            sources: [{ ref: "S1" }],
+          },
+        ],
+        sources: [{ id: "S1", title: "1850 Census" }],
+        places: [{ id: "PL1", name: "Ireland" }],
+      } as any,
+      merges: [["I1", "I1"]],
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.validation.warnings.some((w) => w.includes("place description"))).toBe(true);
+    expect(result.validation.warnings.some((w) => w.includes("person-level source reference"))).toBe(true);
+
+    const tree = await readJson("tree.gedcomx.json");
+    expect(tree.places).toBeUndefined();
+    expect(tree.persons[0].sources).toBeUndefined();
+    // The candidate's source description still merges in — only the
+    // person-level *reference* is dropped.
+    expect(tree.sources.map((s: any) => s.title)).toContain("1850 Census");
+  });
+
   it("reports name/fact merge counts and primarySet matching the merged tree", async () => {
     await writeProject({
       persons: [

--- a/packages/engine/mcp-server/tests/tools/merge-warnings.test.ts
+++ b/packages/engine/mcp-server/tests/tools/merge-warnings.test.ts
@@ -536,3 +536,65 @@ describe("merge_warnings tool", () => {
     expect(result.errors.length).toBeGreaterThan(0);
   });
 });
+
+// ────────────────────────────────────────────────────────────────────
+// sanitize parity — the dry-run must merge the same document the writer
+// would, and must surface what sanitation dropped BEFORE the write decision
+// ────────────────────────────────────────────────────────────────────
+
+describe("mergeWarnings sanitize parity", () => {
+  let dir: string;
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "merge-warnings-sanitize-"));
+    await writeFile(
+      join(dir, "research.json"),
+      JSON.stringify({
+        project: { id: "rp_001", objective: "Test", status: "active", created: "2026-01-01", updated: "2026-01-01" },
+        questions: [], plans: [], log: [], sources: [], assertions: [],
+        person_evidence: [], conflicts: [], hypotheses: [], timelines: [],
+        proof_summaries: [], evaluations: [],
+      }),
+    );
+    await writeFile(
+      join(dir, "tree.gedcomx.json"),
+      JSON.stringify({
+        persons: [
+          {
+            id: "I1",
+            gender: "Male",
+            names: [{ id: "N1", preferred: false, given: "John", surname: "Smith" }],
+          },
+        ],
+        relationships: [],
+        sources: [],
+      }),
+    );
+  });
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("accepts a record_read-shaped candidate (person sources + places) and surfaces the drops", async () => {
+    const candidate: any = {
+      persons: [
+        {
+          id: "p1",
+          gender: "Male",
+          names: [{ id: "N1", given: "John", surname: "Smith" }],
+          sources: [{ ref: "#S9" }],
+        },
+      ],
+      places: [{ id: "P1", name: "Ogden, Utah" }],
+    };
+    const result: any = await mergeWarnings({
+      projectPath: dir,
+      candidateGedcomx: candidate,
+      merges: [["I1", "p1"]],
+    });
+    expect(result.ok).toBe(true);
+    expect(result.sanitizeWarnings.some((w: string) => w.includes("place"))).toBe(true);
+    expect(result.sanitizeWarnings.some((w: string) => w.includes("person-level source"))).toBe(true);
+    // The legacy preferred:false on the on-disk tree is healed in memory too.
+    expect(result.sanitizeWarnings.some((w: string) => w.includes("'preferred: false'"))).toBe(true);
+  });
+});

--- a/packages/engine/mcp-server/tests/tools/tree-edit-legacy.test.ts
+++ b/packages/engine/mcp-server/tests/tools/tree-edit-legacy.test.ts
@@ -1,0 +1,101 @@
+// The upgrade-compat contract: a project tree written before the validator
+// tightening (preferred:false from the old mergeNames, person-level sources,
+// top-level places, invented fact keys) must not brick the project. The tools
+// heal it at read; the first successful tree write persists the healed
+// document (a one-shot migration); research_append validates against the
+// healed shape without touching the file.
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtemp, writeFile, readFile, rm } from "fs/promises";
+import { join } from "path";
+import { tmpdir } from "os";
+
+import { treeEdit } from "../../src/tools/tree-edit.js";
+import { researchAppend } from "../../src/tools/research-append.js";
+
+const minimalResearch = {
+  project: { id: "rp_001", objective: "Test", status: "active", created: "2026-01-01", updated: "2026-01-01" },
+  questions: [], plans: [], log: [], sources: [], assertions: [],
+  person_evidence: [], conflicts: [], hypotheses: [], timelines: [],
+  proof_summaries: [], evaluations: [],
+};
+
+// What a real pre-tightening project tree looks like (shapes taken from the
+// repo's own runlog final trees): the old merge wrote preferred:false, the
+// old spec carried places[], the open-shape validator let invented keys and
+// person-level sources persist.
+const legacyTree = () => ({
+  persons: [
+    {
+      id: "I1",
+      living: false,
+      gender: "Male",
+      sources: [{ ref: "S1" }],
+      names: [
+        { id: "N1", preferred: true, given: "John", surname: "Smith" },
+        { id: "N2", preferred: false, given: "Jack", surname: "Smith" },
+      ],
+      facts: [{ id: "F1", type: "Birth", date: "1900", date_certainty: "high" }],
+    },
+  ],
+  relationships: [],
+  sources: [{ id: "S1", title: "1900 Census" }],
+  places: [{ id: "P1", name: "Ogden, Utah" }],
+});
+
+describe("tree_edit on a legacy (pre-tightening) tree", () => {
+  let dir: string;
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "tree-edit-legacy-"));
+    await writeFile(join(dir, "research.json"), JSON.stringify(minimalResearch, null, 2));
+    await writeFile(join(dir, "tree.gedcomx.json"), JSON.stringify(legacyTree(), null, 2));
+  });
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("heals the tree, persists the healed document, and narrates the repairs", async () => {
+    const result: any = await treeEdit({
+      operation: "update_person",
+      projectPath: dir,
+      personId: "I1",
+      gender: "Male",
+    });
+    expect(result.ok).toBe(true);
+    expect(result.validation.warnings.some((w: string) => w.includes("'preferred: false'"))).toBe(true);
+    expect(result.validation.warnings.some((w: string) => w.includes("places section"))).toBe(true);
+
+    const persisted = JSON.parse(await readFile(join(dir, "tree.gedcomx.json"), "utf-8"));
+    expect(persisted.places).toBeUndefined();
+    expect(persisted.persons[0].sources).toBeUndefined();
+    expect("preferred" in persisted.persons[0].names[1]).toBe(false);
+    expect("date_certainty" in persisted.persons[0].facts[0]).toBe(false);
+    expect(persisted.persons[0].names[0].preferred).toBe(true); // the true flag survives
+  });
+
+  it("does not brick research_append, and leaves the tree file untouched", async () => {
+    const before = await readFile(join(dir, "tree.gedcomx.json"), "utf-8");
+    const result: any = await researchAppend({
+      projectPath: dir,
+      section: "sources",
+      op: "append",
+      entry: {
+        gedcomx_source_description_id: "S1",
+        citation: "1900 U.S. Census, Weber County, Utah",
+        citation_detail: {
+          who: "John Smith household",
+          what: "census enumeration",
+          when_created: "1900-06-01",
+          when_accessed: "2026-07-10",
+          where: "Weber County, Utah",
+          where_within: "dwelling 84",
+        },
+        source_classification: "original",
+        repository: "NARA",
+        access_date: "2026-07-10",
+      },
+    });
+    expect(result.ok).toBe(true);
+    expect(await readFile(join(dir, "tree.gedcomx.json"), "utf-8")).toBe(before);
+  });
+});

--- a/packages/engine/mcp-server/tests/utils/gedcomx-convert.test.ts
+++ b/packages/engine/mcp-server/tests/utils/gedcomx-convert.test.ts
@@ -1359,3 +1359,62 @@ describe("gedcomx-convert — fact.value preservation", () => {
     expect(fact?.value).toBe("Newpaper Editor");
   });
 });
+
+// ────────────────────────────────────────────────────────────────────
+// Rule 10 boundaries — QUAY survives the round trip at BOTH ends of the
+// range (0 is falsy: the value a truthiness regression silently drops),
+// and out-of-range values die at the boundary instead of producing a
+// document every validity gate rejects.
+// ────────────────────────────────────────────────────────────────────
+
+describe("fsmcp:quality boundaries", () => {
+  const refWithQualifier = (value: string) =>
+    toSimplified({
+      persons: [
+        { id: "p1", sources: [{ description: "#S1", qualifiers: [{ name: "fsmcp:quality", value }] }] },
+      ],
+    }).persons?.[0].sources?.[0];
+
+  it("parses both QUAY boundaries, including falsy 0", () => {
+    expect(refWithQualifier("0")?.quality).toBe(0);
+    expect(refWithQualifier("3")?.quality).toBe(3);
+  });
+
+  it("drops out-of-range and non-decimal qualifier values", () => {
+    expect(refWithQualifier("7")?.quality).toBeUndefined();
+    expect(refWithQualifier("-1")?.quality).toBeUndefined();
+    expect(refWithQualifier("0x1A")?.quality).toBeUndefined();
+  });
+
+  it("round-trips quality 0 and refuses to upload an out-of-range integer", () => {
+    const zero = toGedcomX({
+      persons: [
+        {
+          id: "I1",
+          gender: "Male",
+          names: [{ id: "N1", given: "J", surname: "S" }],
+          facts: [{ id: "F1", type: "Birth", sources: [{ ref: "S1", quality: 0 }] }],
+        },
+      ],
+      relationships: [],
+      sources: [{ id: "S1", title: "T" }],
+    } as any);
+    const zeroJson = JSON.stringify(zero);
+    expect(zeroJson).toContain('"fsmcp:quality"');
+    expect(zeroJson).toContain('"value":"0"');
+
+    const seven = toGedcomX({
+      persons: [
+        {
+          id: "I1",
+          gender: "Male",
+          names: [{ id: "N1", given: "J", surname: "S" }],
+          facts: [{ id: "F1", type: "Birth", sources: [{ ref: "S1", quality: 7 }] }],
+        },
+      ],
+      relationships: [],
+      sources: [{ id: "S1", title: "T" }],
+    } as any);
+    expect(JSON.stringify(seven)).not.toContain('"fsmcp:quality"');
+  });
+});

--- a/packages/engine/mcp-server/tests/utils/gedcomx-convert.test.ts
+++ b/packages/engine/mcp-server/tests/utils/gedcomx-convert.test.ts
@@ -492,9 +492,11 @@ describe("gedcomx-convert — transformation rules", () => {
     expect(result.persons?.[0].sources?.[0].ref).toBe("S1");
   });
 
-  // Test 17 — Rule 10: fsmcp:quality is a string, passed through as-is
-  it("maps fsmcp:quality qualifier to quality as a string, passed through", () => {
-    const numericLike = toSimplified({
+  // Test 17 — Rule 10: fsmcp:quality parses to the integer the tree format
+  // requires; non-integer qualifier content is dropped like any other
+  // unrecognized qualifier.
+  it("maps fsmcp:quality qualifier to quality as an integer; drops non-integer values", () => {
+    const numeric = toSimplified({
       persons: [
         {
           id: "p1",
@@ -507,7 +509,7 @@ describe("gedcomx-convert — transformation rules", () => {
         },
       ],
     });
-    expect(numericLike.persons?.[0].sources?.[0].quality).toBe("3");
+    expect(numeric.persons?.[0].sources?.[0].quality).toBe(3);
 
     const freeText = toSimplified({
       persons: [
@@ -522,12 +524,27 @@ describe("gedcomx-convert — transformation rules", () => {
         },
       ],
     });
-    expect(freeText.persons?.[0].sources?.[0].quality).toBe("high");
+    expect("quality" in (freeText.persons?.[0].sources?.[0] ?? {})).toBe(false);
 
     const absent = toSimplified({
       persons: [{ id: "p1", sources: [{ description: "#S1" }] }],
     });
     expect("quality" in (absent.persons?.[0].sources?.[0] ?? {})).toBe(false);
+  });
+
+  // Rule 10 reverse: an integer quality (the only form the tree schema
+  // accepts) round-trips through the string-valued qualifier — previously it
+  // was silently dropped on toGedcomX, losing QUAY data on the upload path.
+  it("round-trips integer quality through the fsmcp:quality qualifier", () => {
+    const expanded = toGedcomX({
+      persons: [{ id: "p1", sources: [{ ref: "S1", quality: 2 }] }],
+    });
+    expect(expanded.persons?.[0].sources?.[0].qualifiers).toEqual([
+      { name: "fsmcp:quality", value: "2" },
+    ]);
+
+    const back = toSimplified(expanded);
+    expect(back.persons?.[0].sources?.[0].quality).toBe(2);
   });
 
   // Test 18 — Rule 11: source descriptions round-trip
@@ -1112,7 +1129,7 @@ describe("gedcomx-convert — identity round-trips", () => {
               standard_date: "1950",
               place: "Boston",
               sources: [
-                { ref: "S1", page: "p. 7", quality: "3" },
+                { ref: "S1", page: "p. 7", quality: 3 },
               ],
             },
             { id: "f2", type: "Death", date: "2020", standard_date: "2020" },

--- a/packages/engine/mcp-server/tests/utils/merge-gedcomx.test.ts
+++ b/packages/engine/mcp-server/tests/utils/merge-gedcomx.test.ts
@@ -340,6 +340,11 @@ describe("mergeGedcomx — name equivalence", () => {
     expect(p.names).toHaveLength(2);
     expect((p.names ?? []).map((n) => n.given).sort()).toEqual(["James", "Patrick"]);
     expect(preferred(p)).toHaveLength(1);
+    // The non-preferred name must OMIT the flag entirely: `preferred: false`
+    // persists a tree the schema (const: true) rejects — the exact bug the
+    // old mergeNames shipped. Subset matchers can't see a stray key, so pin
+    // the key count itself.
+    expect(p.names!.filter((n) => "preferred" in n)).toHaveLength(1);
   });
 
   it("marks the most frequent name as preferred when one repeats across inputs", () => {

--- a/packages/engine/mcp-server/tests/utils/merge-gedcomx.test.ts
+++ b/packages/engine/mcp-server/tests/utils/merge-gedcomx.test.ts
@@ -549,9 +549,9 @@ describe("mergeGedcomx — mode 2 (same document)", () => {
 // ────────────────────────────────────────────────────────────────────
 
 describe("mergeGedcomx — robustness", () => {
-  it("dedups a survivor's person-level source refs (spec §6.3)", () => {
+  it("does not fold candidate person-level source refs — they are not tree format (spec §6.3)", () => {
     const target: SimplifiedGedcomX = {
-      persons: [{ id: "I1", sources: [{ ref: "S1" }] }],
+      persons: [{ id: "I1" }],
       sources: [{ id: "S1", title: "Census" }],
     };
     const candidate: SimplifiedGedcomX = {
@@ -561,7 +561,9 @@ describe("mergeGedcomx — robustness", () => {
 
     const out = mergeGedcomx(target, candidate, [["I1", "I1"]]);
 
-    expect(out.persons![0].sources).toHaveLength(1);
+    // The tool layer strips person-level sources before merging; the core
+    // must not re-introduce them from an unsanitized candidate either.
+    expect(out.persons![0].sources).toBeUndefined();
     assertIntegrity(out);
   });
 
@@ -594,7 +596,7 @@ describe("mergeGedcomx — robustness", () => {
     assertIntegrity(out);
   });
 
-  it("carries candidate places over, keeping place ids unique on collision (spec §6.7)", () => {
+  it("does not carry candidate places — the tree format has no places[] section (spec §6.7)", () => {
     const target: SimplifiedGedcomX = {
       persons: [{ id: "I1" }],
       places: [{ id: "PL1", name: "Ireland" }],
@@ -606,9 +608,9 @@ describe("mergeGedcomx — robustness", () => {
 
     const out = mergeGedcomx(target, candidate, [["I1", "I1"]]);
 
-    expect((out.places ?? []).map((p) => p.name).sort()).toEqual(["Ireland", "New York"]);
-    const ids = (out.places ?? []).map((p) => p.id);
-    expect(new Set(ids).size).toBe(ids.length); // unique
+    // A legacy target's own places pass through untouched; the candidate's
+    // never enter (the tool layer also strips them before the merge).
+    expect((out.places ?? []).map((p) => p.name)).toEqual(["Ireland"]);
   });
 
   it("handles disjoint ids (no collision) with full referential integrity (spec §9)", () => {

--- a/packages/engine/mcp-server/tests/validation/gate-vectors.test.ts
+++ b/packages/engine/mcp-server/tests/validation/gate-vectors.test.ts
@@ -1,0 +1,54 @@
+// Engine side of the shared tree-gate vectors.
+//
+// docs/specs/schemas/tree-gate-vectors.json pins the agreement between the
+// three tree.gedcomx.json validity gates. This suite asserts validateGedcomx
+// (the tree_edit write gate) behaves exactly as each vector's `runtime`
+// expectation declares; the harness's test_gate_vectors.py covers the JSON
+// Schema and the fixture-gate integrity mirror against the same file. A
+// validator change that shifts any verdict fails here, forcing the vectors
+// (and therefore a review of the other gates) to move in the same PR.
+//
+// NOTE: validateGedcomx takes exactly (data, report). An earlier audit found
+// that a miscalled signature reports success silently — which is why the
+// battery includes a fails-everything control below.
+
+import { readFileSync } from "fs";
+import { dirname, join } from "path";
+import { fileURLToPath } from "url";
+import { describe, it, expect } from "vitest";
+import { validateGedcomx } from "../../src/validation/validator.js";
+import { createReport } from "../../src/validation/types.js";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const vectorsPath = join(
+  here, "..", "..", "..", "..", "..",
+  "docs", "specs", "schemas", "tree-gate-vectors.json",
+);
+
+interface GateVector {
+  name: string;
+  description: string;
+  expect: { schema: boolean; integrity: boolean; runtime: boolean };
+  tree: unknown;
+}
+
+const vectors: GateVector[] = JSON.parse(readFileSync(vectorsPath, "utf-8")).vectors;
+
+describe("tree-gate vectors (runtime validator)", () => {
+  it("the battery carries both controls", () => {
+    const runtimes = vectors.map((v) => v.expect.runtime);
+    expect(runtimes).toContain(true);
+    expect(runtimes).toContain(false);
+  });
+
+  for (const vector of vectors) {
+    it(`${vector.name}: runtime ${vector.expect.runtime ? "accepts" : "rejects"}`, () => {
+      const report = createReport();
+      validateGedcomx(vector.tree, report);
+      expect(
+        report.errors.length === 0,
+        report.errors.map((e) => `${e.path}: ${e.message}`).join("\n"),
+      ).toBe(vector.expect.runtime);
+    });
+  }
+});

--- a/packages/engine/mcp-server/tests/validation/tree-sanitize.test.ts
+++ b/packages/engine/mcp-server/tests/validation/tree-sanitize.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from "vitest";
+
+import { sanitizeTree } from "../../src/validation/tree-sanitize.js";
+import { validateGedcomx } from "../../src/validation/validator.js";
+import { createReport } from "../../src/validation/types.js";
+
+const clean = () => ({
+  persons: [
+    {
+      id: "I1",
+      living: false,
+      gender: "Male",
+      names: [{ id: "N1", preferred: true, given: "John", surname: "Smith" }],
+      facts: [{ id: "F1", type: "Birth", date: "1900", sources: [{ ref: "S1", quality: 0 }] }],
+    },
+  ],
+  relationships: [],
+  sources: [{ id: "S1", title: "1900 Census" }],
+});
+
+const runtimeErrors = (tree: unknown): string[] => {
+  const report = createReport();
+  validateGedcomx(tree, report);
+  return report.errors.map((e) => e.message);
+};
+
+describe("sanitizeTree", () => {
+  it("returns a clean tree untouched, with zero warnings", () => {
+    const input = clean();
+    const { tree, warnings } = sanitizeTree(input);
+    expect(warnings).toEqual([]);
+    expect(tree).toEqual(input);
+    expect(tree).not.toBe(input); // deep copy — the input is never mutated
+  });
+
+  it("heals the legacy shapes main's own pipeline wrote, and the result validates", () => {
+    // A composite of everything found in real run-produced trees: the old
+    // mergeNames' preferred:false, primary:false, person-level sources, the
+    // old spec-mandated top-level places, agent-invented fact keys, a string
+    // quality, and a fact with no id.
+    const legacy: any = clean();
+    legacy.places = [{ id: "P1", name: "Ogden, Utah" }];
+    legacy.persons[0].sources = [{ ref: "S1" }];
+    legacy.persons[0].names.push({
+      id: "N2", preferred: false, given: "Jack", surname: "Smith",
+    });
+    legacy.persons[0].facts.push(
+      { id: "F2", type: "Death", primary: false, date_certainty: "high" },
+      { type: "Burial", sources: [{ ref: "S1", quality: "2" }] },
+    );
+
+    const { tree, warnings } = sanitizeTree(legacy) as any;
+
+    expect(tree.places).toBeUndefined();
+    expect(tree.persons[0].sources).toBeUndefined();
+    expect("preferred" in tree.persons[0].names[1]).toBe(false);
+    expect("primary" in tree.persons[0].facts[1]).toBe(false);
+    expect("date_certainty" in tree.persons[0].facts[1]).toBe(false);
+    expect(tree.persons[0].facts[2].id).toBe("F3"); // minted past F1/F2
+    expect(tree.persons[0].facts[2].sources[0].quality).toBe(2); // "2" -> 2
+
+    expect(runtimeErrors(legacy).length).toBeGreaterThan(0); // was broken
+    expect(runtimeErrors(tree)).toEqual([]); // healed
+
+    // One narratable warning per healed class.
+    expect(warnings.some((w: string) => w.includes("places section"))).toBe(true);
+    expect(warnings.some((w: string) => w.includes("person-level source reference"))).toBe(true);
+    expect(warnings.some((w: string) => w.includes("'preferred: false'"))).toBe(true);
+    expect(warnings.some((w: string) => w.includes("'primary: false'"))).toBe(true);
+    expect(warnings.some((w: string) => w.includes("'date_certainty'"))).toBe(true);
+    expect(warnings.some((w: string) => w.includes("assigned F ids"))).toBe(true);
+    expect(warnings.some((w: string) => w.includes("string quality"))).toBe(true);
+  });
+
+  it("drops quality values that are not QUAY integers 0-3", () => {
+    const legacy: any = clean();
+    legacy.persons[0].facts[0].sources[0].quality = 7;
+    const { tree, warnings } = sanitizeTree(legacy) as any;
+    expect("quality" in tree.persons[0].facts[0].sources[0]).toBe(false);
+    expect(warnings.some((w: string) => w.includes("not integers 0-3"))).toBe(true);
+  });
+
+  it("heals preferred:false inside Couple facts' owners too", () => {
+    const legacy: any = clean();
+    legacy.persons.push({
+      id: "I2", living: false, gender: "Female",
+      names: [{ id: "N9", given: "Mary", surname: "Jones" }],
+    });
+    legacy.relationships = [{
+      id: "R1", type: "Couple", person1: "I1", person2: "I2",
+      facts: [{ id: "F9", type: "Marriage", primary: false, quality: "junk" }],
+    }];
+    const { tree } = sanitizeTree(legacy) as any;
+    const fact = tree.relationships[0].facts[0];
+    expect("primary" in fact).toBe(false);
+    expect("quality" in fact).toBe(false); // unknown fact key, pruned
+    expect(runtimeErrors(tree)).toEqual([]);
+  });
+
+  it("does NOT heal the ambiguous problems — they still fail validation", () => {
+    const broken: any = clean();
+    // dangling ref, swapped endpoint keys, duplicate ids: no safe auto-repair
+    broken.relationships = [
+      { id: "R1", type: "ParentChild", person1: "I1", person2: "I1" },
+      { id: "R2", type: "ParentChild", parent: "I1", child: "GONE-1" },
+    ];
+    broken.persons.push(structuredClone(broken.persons[0]));
+    const { tree } = sanitizeTree(broken) as any;
+    expect(tree.relationships[0].person1).toBe("I1"); // endpoints untouched
+    expect(tree.relationships[1].child).toBe("GONE-1"); // dangler untouched
+    expect(tree.persons).toHaveLength(2); // duplicate untouched
+    expect(runtimeErrors(tree).length).toBeGreaterThan(0);
+  });
+
+  it("never invents a section: a corrupt non-array persons stays broken", () => {
+    // Healing a truncated file into a "valid" empty tree would be silent
+    // data loss — the validator must keep reporting it.
+    const corrupt: any = { persons: "oops", relationships: [], sources: [] };
+    const { tree, warnings } = sanitizeTree(corrupt) as any;
+    expect(tree.persons).toBe("oops");
+    expect(warnings).toEqual([]);
+    expect(runtimeErrors(tree).some((m) => m.includes("must be an array"))).toBe(true);
+  });
+});

--- a/packages/engine/mcp-server/tests/validation/validator.test.ts
+++ b/packages/engine/mcp-server/tests/validation/validator.test.ts
@@ -598,6 +598,118 @@ describe("Project Validator", () => {
       const result = await validateProject(testDir);
       expect(result.valid).toBe(true);
     });
+
+    it("rejects a typo'd fact property, matching the schema's additionalProperties:false", async () => {
+      const tree = {
+        persons: [
+          {
+            id: "P1",
+            gender: "Male",
+            names: [{ id: "N1", given: "John", surname: "Doe" }],
+            facts: [{ id: "F1", type: "Birth", standrad_date: "2 Oct 1876" }],
+          },
+        ],
+        relationships: [],
+        sources: [],
+      };
+      await writeProject(minimalResearch, tree);
+      const result = await validateProject(testDir);
+      expect(result.valid).toBe(false);
+      expect(
+        result.errors.some((e) => e.message.includes("unexpected property 'standrad_date'"))
+      ).toBe(true);
+    });
+
+    it("rejects preferred:false on a name — the schema pins it to const true", async () => {
+      const tree = {
+        persons: [
+          {
+            id: "P1",
+            gender: "Male",
+            names: [{ id: "N1", given: "John", surname: "Doe", preferred: false }],
+          },
+        ],
+        relationships: [],
+        sources: [],
+      };
+      await writeProject(minimalResearch, tree);
+      const result = await validateProject(testDir);
+      expect(result.valid).toBe(false);
+      expect(
+        result.errors.some((e) => e.message.includes("'preferred' must be true when present"))
+      ).toBe(true);
+    });
+
+    it("rejects an out-of-range quality on a source reference", async () => {
+      const tree = {
+        persons: [
+          {
+            id: "P1",
+            gender: "Male",
+            names: [{ id: "N1", given: "John", surname: "Doe" }],
+            facts: [{ id: "F1", type: "Birth", sources: [{ ref: "S1", quality: 5 }] }],
+          },
+        ],
+        relationships: [],
+        sources: [{ id: "S1", title: "Census" }],
+      };
+      await writeProject(minimalResearch, tree);
+      const result = await validateProject(testDir);
+      expect(result.valid).toBe(false);
+      expect(
+        result.errors.some((e) => e.message.includes("'quality' must be an integer between 0 and 3"))
+      ).toBe(true);
+    });
+
+    it("resolves source refs inside Couple-relationship facts — a former blind spot", async () => {
+      const tree = {
+        persons: [
+          { id: "P1", gender: "Male", names: [{ id: "N1", given: "John", surname: "Doe" }] },
+          { id: "P2", gender: "Female", names: [{ id: "N2", given: "Mary", surname: "Doe" }] },
+        ],
+        relationships: [
+          {
+            id: "R1",
+            type: "Couple",
+            person1: "P1",
+            person2: "P2",
+            facts: [{ id: "F1", type: "Marriage", sources: [{ ref: "S9-DANGLING" }] }],
+          },
+        ],
+        sources: [],
+      };
+      await writeProject(minimalResearch, tree);
+      const result = await validateProject(testDir);
+      expect(result.valid).toBe(false);
+      expect(
+        result.errors.some((e) => e.message.includes("references source 'S9-DANGLING'"))
+      ).toBe(true);
+    });
+
+    it("rejects person-level sources and an unknown top-level section", async () => {
+      const tree = {
+        persons: [
+          {
+            id: "P1",
+            gender: "Male",
+            names: [{ id: "N1", given: "John", surname: "Doe" }],
+            sources: [{ ref: "S1" }],
+          },
+        ],
+        relationships: [],
+        sources: [{ id: "S1", title: "Census" }],
+        places: [{ id: "PL1", name: "Ireland" }],
+      };
+      await writeProject(minimalResearch, tree);
+      const result = await validateProject(testDir);
+      expect(result.valid).toBe(false);
+      expect(
+        result.errors.some((e) => e.message.includes("unexpected property 'sources'"))
+      ).toBe(true);
+      expect(
+        result.errors.some((e) => e.message.includes("unexpected property 'places'"))
+      ).toBe(true);
+    });
   });
 
   describe("Sidecar validation", () => {

--- a/packages/engine/mcp-server/tests/validation/validator.test.ts
+++ b/packages/engine/mcp-server/tests/validation/validator.test.ts
@@ -557,7 +557,7 @@ describe("Project Validator", () => {
       const result = await validateProject(testDir);
       expect(result.valid).toBe(false);
       expect(
-        result.errors.some((e) => e.message.includes("should be PascalCase"))
+        result.errors.some((e) => e.message.includes("must start with an uppercase letter"))
       ).toBe(true);
     });
 

--- a/packages/schema/schemas/enums.schema.json
+++ b/packages/schema/schemas/enums.schema.json
@@ -177,8 +177,9 @@
       "enum": ["ParentChild", "Couple"]
     },
     "gedcomx_fact_type_recommended": {
-      "description": "Open enum for tree.gedcomx.json facts. PascalCase preserved from GedcomX URI suffixes.",
+      "description": "Open enum for tree.gedcomx.json facts. PascalCase preserved from GedcomX URI suffixes. The pattern enforces only the upper-initial (the part the runtime validator hard-fails on — a lowercase `birth` copied from research.json would lint clean and then fail tree_edit mid-run); the value list stays open.",
       "type": "string",
+      "pattern": "^[A-Z]",
       "examples": [
         "Birth",
         "Death",

--- a/packages/schema/schemas/run-log.schema.json
+++ b/packages/schema/schemas/run-log.schema.json
@@ -60,7 +60,7 @@
     "snapshot": {
       "type": "object",
       "additionalProperties": { "type": "string" },
-      "description": "{repo-relative-path: normalized-content} of all skill-side files needed to reproduce this run. Includes plugin/skills/<skill>/**, eval/tests/unit/<skill>/**, and referenced scenarios + fixtures."
+      "description": "{repo-relative-path: normalized-content} of all skill-side files needed to reproduce this run. Includes packages/engine/plugin/skills/<skill>/**, eval/tests/unit/<skill>/**, and referenced scenarios + fixtures."
     },
     "tests": {
       "type": "array",

--- a/packages/schema/schemas/tree-gedcomx.schema.json
+++ b/packages/schema/schemas/tree-gedcomx.schema.json
@@ -49,10 +49,6 @@
         "facts": {
           "type": "array",
           "items": { "$ref": "#/$defs/fact" }
-        },
-        "sources": {
-          "type": "array",
-          "items": { "$ref": "#/$defs/source_reference" }
         }
       }
     },

--- a/packages/schema/schemas/unit-test.schema.json
+++ b/packages/schema/schemas/unit-test.schema.json
@@ -19,7 +19,7 @@
         },
         "skill": {
           "type": "string",
-          "description": "Directory name under plugin/skills/. Must match an existing skill."
+          "description": "Directory name under packages/engine/plugin/skills/. Must match an existing skill."
         },
         "name": {
           "type": "string",
@@ -38,6 +38,11 @@
           "type": "array",
           "items": { "type": "string" },
           "description": "Freeform tags for filtering and grouping. May be empty."
+        },
+        "holdout": {
+          "type": "boolean",
+          "default": false,
+          "description": "Reserves this test as a generalization check for the skill-improvement loop. When true, the body-optimizer must not read or tune against this test when proposing SKILL.md edits — it consults holdout tests only to measure whether an edit generalized beyond the cases it was written from. The harness runs holdout tests like any other (they are still graded, annotated, and released); the flag governs only the improver's behavior. See docs/skill-lifecycle.md."
         },
         "expected_outcome": {
           "type": "string",
@@ -102,6 +107,11 @@
         "explanation": {
           "type": "string",
           "description": "Why the tested skill should not activate. Documents the boundary between the two skills."
+        },
+        "grade_on_invariant": {
+          "type": "boolean",
+          "default": false,
+          "description": "When true, this negative test is graded SOLELY on its deterministic invariant validator(s) in eval/harness/validators/test_<skill>.py (gated on a tag) — routing and activation are NOT gated. Use for routing-flaky negatives where every plausible route is state-safe (e.g. citation refuse-new-source: the skill may or may not fire, but no run may fabricate a source). REQUIRES a tag-gated invariant validator that actually runs; without one the pass is vacuous. See docs/plan/invariant-grading.md."
         }
       }
     },
@@ -110,6 +120,16 @@
       "minimum": 1,
       "maximum": 1,
       "description": "POLICY (current stage): ALWAYS 1. Do not set this above 1 when creating or updating a test. We are not addressing single-run variance yet, and multi-run tests make the suite painfully slow (each run is a full skill execution + judge call). The multi-run aggregation machinery (unit-test-spec.md Section 7) exists for future description-optimizer / golden-set work only; until that stage, omit this field (it defaults to 1) or set it to 1."
+    },
+    "intentionally_invalid": {
+      "type": "boolean",
+      "default": false,
+      "description": "When true, the test's scenario files are broken on purpose — e.g. for a validator/guardrail skill (validate-schema) whose job is to detect invalid input. The runnability gate then skips schema validation of the scenario, the post-run file-validity validators are not counted against the test, and the scenario-fixture lint exempts the referenced scenario. Defaults to false; only set it on tests that genuinely need an invalid starting state. See unit-test-spec.md Section 9."
+    },
+    "judge_reads_files": {
+      "type": "boolean",
+      "default": false,
+      "description": "Opt-in. When true, the harness includes the actual content of the entries this run wrote to research.json / tree.gedcomx.json (truncated) in what the LLM judge sees, instead of only change counts. Use for skills whose graded deliverable is written to a file rather than echoed in the chat reply (e.g. proof-conclusion's narrative_markdown). Defaults to false, which preserves the legacy counts-only judge input for every other test/skill, so enabling it for one skill does not affect any other. See unit-test-spec.md Section 5.9."
     },
     "execution": {
       "type": "object",

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -372,7 +372,15 @@ export interface GedcomxFact {
   type: string
   primary?: boolean
   date?: string
+  /** GEDCOM-canonical sidecar of `date` (e.g. `2 Oct 1876`, `Abt 1850`),
+   *  populated by the converter; LLM-authored facts may omit it. */
+  standard_date?: string
   place?: string
+  /** Standardized place-name sidecar of `place`, resolved via place_search. */
+  standard_place?: string
+  /** Qualifier carrying the fact's meaning when type+date+place isn't enough
+   *  (e.g. an Occupation fact's `"Newspaper Editor"`). */
+  value?: string
   sources?: GedcomxSourceRef[]
 }
 


### PR DESCRIPTION
Implements the remaining recommendations from `docs/plan/gedcomx-schema-drift-audit.md` (items 1 and 3, the corpus-invariant test, and the fixture-gate integrity mirror had already landed with the final revisions of #627), plus the three deltas the independent re-audit added. The audit doc's new appendix maps every item to where it landed.

**Commit by commit:**

1. **schema** — `gedcomx_fact_type_recommended` gains `pattern: ^[A-Z]` (open value list, pinned upper-initial), and `$defs/person` loses `sources` — references live on names/facts/relationships; zero of 265 corpus persons used person-level ones. Both schema trees; the now-redundant PascalCase mirror deleted from `validate_fixture.py`.
2. **merge** — the core no longer persists candidate `places[]` (a shipped path that wrote trees the schema rejects, mandated by merge-gedcomx-spec §6.7 rev. 3 — spec amended) nor folds person-level source refs; the tools strip both from `record_read`-shaped candidates with a warning (`sanitizeCandidate`) instead of rejecting them.
3. **validator** — `validateGedcomx` now mirrors every `additionalProperties: false` subschema, pins `preferred`/`primary` to true-or-absent, bounds `quality` to an integer 0–3, type-checks scalars, rejects non-array sections, and fully validates Couple-relationship facts including their source refs (a former blind spot that passed *both* gates). The tightening immediately caught a live bug: `mergeNames` wrote `preferred: false` on every non-preferred merged name — fixed.
4. **convert** — `quality` is the QUAY integer end-to-end; previously `toGedcomX` silently dropped every integer quality on the upload path (spec Rule 10 amended; string encoding lives only inside the `fsmcp:quality` qualifier).
5. **types+spec** — `GedcomxFact` gains `standard_date`/`standard_place`/`value` (616/634/42 uses in the committed fixtures); simplified-gedcomx-spec now states the schema must never be the sole validity gate, that sources never hang off persons, and that `person_read` returns need normalizing before persisting.
6. **tests** — shared cross-gate vectors (`docs/specs/schemas/tree-gate-vectors.json`, with passes-all/fails-all controls and the intentional seams encoded as expectations) consumed by both the harness and the engine suites, plus the mirror-identity test — whose first run caught `run-log.schema.json` and `unit-test.schema.json` already diverged on `main` (both re-synced from the docs side).

## Review follow-up (commit 7)

The pre-merge review found the tightening's one real gap: the closed-shape validator rejects shapes main's own pipeline wrote (`preferred: false` from the old `mergeNames` — present in run-produced trees as recently as 2026-07-08 — plus legacy `places[]`, person-level sources, invented fact keys), and since every persistence tool validates the whole project before writing, one legacy shape bricked **all** writes on that project, research-log appends included, with no `tree_edit` op able to express the repair.

Commit 7 adds read-time healing (`src/validation/tree-sanitize.ts`, wired into every tree reader; unambiguous repairs only, one narratable warning per class, one-shot migration on the next tree write — all 10 committed runlog trees that fail the tightened validator heal to fully valid). It also aligns the runtime fact-type check to the schema's `^[A-Z]` (killing the digit-initial seam), bounds QUAY to 0–3 in convert, surfaces sanitize warnings in the `merge_warnings` dry-run, fixes the `clearPreferred`/`clearPrimaryOfType` truthiness guards, closes the mutation-verified test gaps (a reverted `mergeNames` fix now fails the suite), grows the vectors to 21 with both QUAY boundaries pinned, and amends merge spec §7.1, which still mandated the exact `preferred: false` bug this PR fixes.

**Verification:** engine vitest 1308/1308 (after commit 7); harness pytest green except the 12 pre-existing `test_cli.py` failures (fail identically on clean `main`); JS workspace (turbo) green; all 83 committed trees pass the tightened validator unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
