### PR TITLE
e2e: spriggs-marriage-1926 fixture + presence-mirror fix for Couple-held facts

### DIFF
--- a/eval/harness/e2e/validate_fixture.py
+++ b/eval/harness/e2e/validate_fixture.py
@@ -84,7 +84,7 @@ class TreePerson:
     person_id: str
     given_tokens: set[str]
     surname_tokens: set[str]
-    fact_types: set[str]  # lowercased fact `type` values on this person
+    fact_types: set[str]  # lowercased fact `type` values on this person or their relationships
 
     @property
     def name_tokens(self) -> set[str]:
@@ -92,7 +92,28 @@ class TreePerson:
 
 
 def index_tree(tree: dict[str, Any]) -> list[TreePerson]:
-    """Collect per-person name tokens (given vs surname) and fact types."""
+    """Collect per-person name tokens (given vs surname) and fact types.
+
+    Relationship-held facts are folded onto both endpoints: a Marriage
+    lives on the Couple relationship, never on either spouse, so without
+    the fold no marriage `fact` finding could ever match a person. (The
+    schema allows facts on Couple only, but the fold reads endpoints
+    generically so a schema change can't silently reopen the gap.)
+    """
+    rel_fact_types: dict[str, set[str]] = {}
+    for rel in tree.get("relationships") or []:
+        types = {
+            str(f.get("type", "")).lower()
+            for f in (rel.get("facts") or [])
+            if f.get("type")
+        }
+        if not types:
+            continue
+        keys = ("parent", "child") if rel.get("type") == "ParentChild" else ("person1", "person2")
+        for key in keys:
+            if rel.get(key) is not None:
+                rel_fact_types.setdefault(str(rel[key]), set()).update(types)
+
     people: list[TreePerson] = []
     for person in tree.get("persons") or []:
         given: set[str] = set()
@@ -104,7 +125,7 @@ def index_tree(tree: dict[str, Any]) -> list[TreePerson]:
             str(f.get("type", "")).lower()
             for f in (person.get("facts") or [])
             if f.get("type")
-        }
+        } | rel_fact_types.get(str(person.get("id", "?")), set())
         people.append(
             TreePerson(
                 person_id=str(person.get("id", "?")),

--- a/eval/harness/tests/unit/test_e2e_author.py
+++ b/eval/harness/tests/unit/test_e2e_author.py
@@ -431,6 +431,16 @@ def test_the_presence_mirror_skips_a_finding_with_no_nameable_target(tree):
     assert presence_mirror({"findings": [{"id": "f1", "type": "fact"}]}, tree) == []
 
 
+def test_the_presence_mirror_sees_a_marriage_fact_held_by_the_couple(tree):
+    # A Marriage lives on the Couple relationship, never on either spouse —
+    # index_tree folds relationship facts onto both endpoints so a marriage
+    # `fact` finding can match. Neither spouse carries a Marriage fact of
+    # their own in the fixture, so without the fold this errored.
+    finding = _finding("f2", "Mary Jones", ftype="fact")
+    finding["details"]["fact_type"] = "Marriage"
+    assert presence_mirror({"findings": [finding]}, tree) == []
+
+
 # --- drift audit -----------------------------------------------------------
 
 

--- a/eval/tests/e2e/spriggs-marriage-1926/README.md
+++ b/eval/tests/e2e/spriggs-marriage-1926/README.md
@@ -1,0 +1,48 @@
+# Reuben Spencer Spriggs
+
+**Source PID:** `L64C-QQX`
+**Reuben Spencer Spriggs is deceased** (1898–1998). (FamilySearch ToS
+requires all committed e2e fixtures to be about deceased persons.) One
+living relative in the fetched tree, LF4F-MFB, was removed from the
+snapshot with `--drop-living` before anything was written.
+
+## Research question
+
+> Who did Reuben Spencer Spriggs marry, and when and where did the
+> marriage take place?
+
+## What was removed from the starting tree
+
+- Removed person L64C-QM1: Nora Alvina Satter
+- Removed relationship R1 (Couple L64C-QQX/L64C-QM1): cascaded from a removed person
+- Removed relationship R6 (ParentChild L64C-QM1/LFT9-PDR): cascaded from a removed person
+- Removed relationship R8 (ParentChild L64C-QM1/LFT9-PXM): cascaded from a removed person
+- Removed source 9KF5-7BY: Mr Reuben Spencer Spriggs, "United States, GenealogyBank Obituaries, 1980-2014"
+- Removed source 9P93-67H: R. Spencer Spriggs, "Find A Grave Index"
+- Removed source MMBK-HKS: Spencer Spriggs, "South Dakota, State Census, 1935"
+- Removed source MMM8-MP6: Spencer R Spriggs, "United States Census, 1930"
+- Removed source MMMK-R73: Spencer Spriggs, "United States Census, 1940"
+- Removed source MS8F-8VD: Legacy NFS Source: Reuben Spencer Spriggs - Funeral program
+- Removed source MSNP-DNF: Legacy NFS Source: Reuben Spencer Spriggs - Funeral program
+
+The children (LFT9-PDR, LFT9-PXM) remain in the tree linked to their
+father only; the pre-marriage sources (1910/1915/1920 censuses, WWI
+draft card, SSDI) were kept. Every removed source names the wife or
+the household with her in it.
+
+## Expected difficulty
+
+medium — Spouse identity is easy to recover (the 1930/1935/1940
+census households list Nora, and the children's records name their
+mother), but the marriage itself took place out-of-state in
+Minneapolis, Minnesota, while the family lived in Beadle County,
+South Dakota, so a South Dakota-scoped search misses the marriage
+record and its date and place.
+
+## Notes for reviewers
+
+Family lived in Beadle County, South Dakota; the 1926 marriage took
+place out-of-state in Minneapolis, Minnesota, so a South
+Dakota-scoped search misses the marriage record. Spouse identity is
+recoverable from the 1930/1935/1940 census households and the
+children's records.

--- a/eval/tests/e2e/spriggs-marriage-1926/expected-findings.json
+++ b/eval/tests/e2e/spriggs-marriage-1926/expected-findings.json
@@ -1,0 +1,55 @@
+{
+  "findings": [
+    {
+      "id": "f1",
+      "type": "relationship",
+      "description": "Reuben Spencer Spriggs married Nora Alvina Satter. The agent should identify her as his wife and add her and the couple relationship to the tree.",
+      "details": {
+        "subject_person": "Reuben Spencer Spriggs (L64C-QQX)",
+        "relation": "spouse",
+        "target_person": {
+          "name": "Nora Alvina Satter",
+          "birth": "7 November 1899, Hartland, Freeborn, Minnesota"
+        }
+      },
+      "supporting_sources": [
+        "1930 United States Census, Belle Prairie Township, Beadle, South Dakota — Spencer R Spriggs household listing wife Nora",
+        "Minnesota marriage record, Hennepin County, 1926"
+      ],
+      "required": true
+    },
+    {
+      "id": "f2",
+      "type": "fact",
+      "description": "The marriage took place on 8 November 1926 in Minneapolis, Hennepin, Minnesota.",
+      "details": {
+        "subject_person": "Reuben Spencer Spriggs (L64C-QQX)",
+        "target_person": {
+          "name": "Nora Alvina Satter"
+        },
+        "fact_type": "Marriage",
+        "date": "8 November 1926",
+        "place": "Minneapolis, Hennepin, Minnesota, United States"
+      },
+      "supporting_sources": [
+        "Minnesota marriage record or index entry, Hennepin County, 1926"
+      ],
+      "required": true
+    },
+    {
+      "id": "f3",
+      "type": "source",
+      "description": "A Minnesota marriage record or index entry for the 1926 Spriggs–Satter marriage is attached as a source for the marriage.",
+      "details": {
+        "subject_person": "Reuben Spencer Spriggs (L64C-QQX)",
+        "target_person": {
+          "name": "Nora Alvina Satter"
+        }
+      },
+      "supporting_sources": [
+        "Minnesota marriage record or index, Hennepin County, 1926"
+      ],
+      "required": false
+    }
+  ]
+}

--- a/eval/tests/e2e/spriggs-marriage-1926/fixture.json
+++ b/eval/tests/e2e/spriggs-marriage-1926/fixture.json
@@ -1,0 +1,18 @@
+{
+  "id": "spriggs-marriage-1926",
+  "name": "Reuben Spencer Spriggs",
+  "source_pid": "L64C-QQX",
+  "captured": "2026-07-10",
+  "researcher_question": "Who did Reuben Spencer Spriggs marry, and when and where did the marriage take place?",
+  "tags": {
+    "question_type": "marriage",
+    "era": "1920s",
+    "geography": "US-MN"
+  },
+  "model": {
+    "agent": "claude-sonnet-4-6",
+    "judge": "claude-haiku-4-5-20251001"
+  },
+  "difficulty": "medium",
+  "notes": "Family lived in Beadle County, South Dakota; the 1926 marriage took place out-of-state in Minneapolis, Minnesota, so a South Dakota-scoped search misses the marriage record. Spouse identity is recoverable from the 1930/1935/1940 census households and the children's records."
+}

--- a/eval/tests/e2e/spriggs-marriage-1926/starting-research.json
+++ b/eval/tests/e2e/spriggs-marriage-1926/starting-research.json
@@ -1,0 +1,28 @@
+{
+  "project": {
+    "id": "rp_spriggs_marriage_1926",
+    "objective": "Who did Reuben Spencer Spriggs marry, and when and where did the marriage take place?",
+    "subject_person_ids": [
+      "L64C-QQX"
+    ],
+    "status": "active",
+    "created": "2026-07-10",
+    "updated": "2026-07-10"
+  },
+  "researcher_profile": {
+    "experience_level": "intermediate",
+    "subscriptions": [],
+    "narration_guidance": "concise"
+  },
+  "questions": [],
+  "plans": [],
+  "log": [],
+  "sources": [],
+  "assertions": [],
+  "person_evidence": [],
+  "conflicts": [],
+  "hypotheses": [],
+  "timelines": [],
+  "proof_summaries": [],
+  "evaluations": []
+}

--- a/eval/tests/e2e/spriggs-marriage-1926/starting-tree.gedcomx.json
+++ b/eval/tests/e2e/spriggs-marriage-1926/starting-tree.gedcomx.json
@@ -1,0 +1,381 @@
+{
+  "persons": [
+    {
+      "id": "L64C-QQX",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N1",
+          "given": "Reuben Spencer",
+          "surname": "Spriggs"
+        }
+      ],
+      "facts": [
+        {
+          "id": "7b67460c-14ec-47bd-8806-6d6adebff86d",
+          "type": "Birth",
+          "date": "6 November 1898",
+          "standard_date": "6 Nov 1898",
+          "place": "Maddock, Benson, North Dakota, United States",
+          "standard_place": "Maddock, Benson, North Dakota, United States"
+        },
+        {
+          "id": "3663d6e2-272a-404b-a366-d430f40eddc6",
+          "type": "Death",
+          "date": "21 May 1998",
+          "standard_date": "21 May 1998",
+          "place": "Riverside, Riverside, California, United States",
+          "standard_place": "Riverside, Riverside, California, United States"
+        },
+        {
+          "id": "a3ca8aea-4b58-4dbf-aecf-8fd8437e7791",
+          "type": "Residence",
+          "date": "1910",
+          "standard_date": "1910",
+          "place": "Belle Prairie Township, Beadle, South Dakota, United States",
+          "standard_place": "Belle Prairie Township, Beadle, South Dakota, United States"
+        },
+        {
+          "id": "5ca751dd-38f3-4bc9-aef2-461fa2d0fc4b",
+          "type": "Residence",
+          "date": "21 May 1998",
+          "standard_date": "21 May 1998",
+          "place": "Riverside, California, United States",
+          "standard_place": "Riverside, California, United States"
+        },
+        {
+          "id": "7f3bdc12-bd2c-4540-bd28-c9191ed9a73c",
+          "type": "Obituary",
+          "date": "29 May 1998",
+          "standard_date": "29 May 1998",
+          "place": "Riverside, California, United States",
+          "standard_place": "Riverside, California, United States"
+        },
+        {
+          "id": "f47723ec-e7d6-4628-8b82-0f1e6194d01e",
+          "type": "Residence",
+          "place": "South Dakota, United States",
+          "standard_place": "South Dakota, United States"
+        },
+        {
+          "id": "5c6530a8-52d2-4be7-be6f-37cad2b1fb81",
+          "type": "Burial",
+          "place": "Maplewood Cemetery, Iroquois, Kingsbury, South Dakota, United States",
+          "standard_place": "Maplewood Cemetery, Iroquois, Kingsbury, South Dakota, United States"
+        }
+      ]
+    },
+    {
+      "id": "KNSQ-3GK",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N2",
+          "given": "Charlotte Marie",
+          "surname": "Westby"
+        }
+      ],
+      "facts": [
+        {
+          "id": "248eaba5-34ae-4182-9874-bfcc07166241",
+          "type": "Birth",
+          "date": "13 June 1876",
+          "standard_date": "13 Jun 1876",
+          "place": "Akershus, Norway",
+          "standard_place": "Akershus, Norway"
+        },
+        {
+          "id": "67639bbb-6380-492f-a281-d2bc75e402cf",
+          "type": "Immigration",
+          "date": "1877",
+          "standard_date": "1877"
+        },
+        {
+          "id": "9059363c-4af1-428f-af31-d888d8b40770",
+          "type": "Residence",
+          "date": "1920",
+          "standard_date": "1920",
+          "place": "Belle Prairie Township, Beadle, South Dakota, United States",
+          "standard_place": "Belle Prairie Township, Beadle, South Dakota, United States"
+        },
+        {
+          "id": "3bb23c7d-a4d2-4aab-be0f-b9ad9345af49",
+          "type": "Residence",
+          "date": "1930",
+          "standard_date": "1930",
+          "place": "Belle Prairie Township, Beadle, South Dakota, United States",
+          "standard_place": "Belle Prairie Township, Beadle, South Dakota, United States"
+        },
+        {
+          "id": "9381f219-2889-4bfc-9b03-5527232282c1",
+          "type": "Death",
+          "date": "16 January 1968",
+          "standard_date": "16 Jan 1968",
+          "place": "Sioux Falls, Minnehaha, South Dakota, United States",
+          "standard_place": "Sioux Falls, Minnehaha, South Dakota, United States"
+        },
+        {
+          "id": "dd317f3a-21bb-40f8-ad9c-fd4c175e57d9",
+          "type": "Burial",
+          "place": "Iroquois, Kingsbury, South Dakota, United States",
+          "standard_place": "Iroquois, Kingsbury, South Dakota, United States"
+        },
+        {
+          "id": "3a405f0d-23f9-4aed-bb30-eec81135926f",
+          "type": "Residence",
+          "place": "Sioux Falls, Minnehaha, South Dakota, United States",
+          "standard_place": "Sioux Falls, Minnehaha, South Dakota, United States"
+        }
+      ]
+    },
+    {
+      "id": "KNSQ-3LB",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N4",
+          "given": "John William",
+          "surname": "Spriggs"
+        }
+      ],
+      "facts": [
+        {
+          "id": "ebe0d4fe-20f8-4dad-b4b8-c69c03d0f100",
+          "type": "Birth",
+          "date": "17 March 1872",
+          "standard_date": "17 Mar 1872",
+          "place": "Decorah Township, Winneshiek, Iowa, United States",
+          "standard_place": "Decorah Township, Winneshiek, Iowa, United States"
+        },
+        {
+          "id": "954933be-453f-4e96-9bc4-a1f40f681213",
+          "type": "Residence",
+          "date": "1920",
+          "standard_date": "1920",
+          "place": "Belle Prairie Township, Beadle, South Dakota, United States",
+          "standard_place": "Belle Prairie Township, Beadle, South Dakota, United States"
+        },
+        {
+          "id": "b9618e89-cc34-4b18-8ead-01c4febcc5f5",
+          "type": "Residence",
+          "date": "1930",
+          "standard_date": "1930",
+          "place": "Belle Prairie Township, Beadle, South Dakota, United States",
+          "standard_place": "Belle Prairie Township, Beadle, South Dakota, United States"
+        },
+        {
+          "id": "ddb21ddf-0042-4808-af3c-5b2e94e08922",
+          "type": "Death",
+          "date": "27 July 1934",
+          "standard_date": "27 Jul 1934",
+          "place": "Canova, Miner, South Dakota, United States",
+          "standard_place": "Canova, Miner, Dakota Territory, United States"
+        },
+        {
+          "id": "c5be31e4-c57a-417a-b672-456ec4e963d8",
+          "type": "Burial",
+          "date": "30 July 1934",
+          "standard_date": "30 Jul 1934",
+          "place": "Maplewood Cemetery, Iroquois, Kingsbury, South Dakota, United States",
+          "standard_place": "Maplewood Cemetery, Iroquois, Kingsbury, South Dakota, United States"
+        }
+      ]
+    },
+    {
+      "id": "LFT9-PXM",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N6",
+          "given": "Donna Jean",
+          "surname": "Spriggs"
+        }
+      ],
+      "facts": [
+        {
+          "id": "ebe0d4fe-20f8-4dad-b4b8-c69c03d0f100",
+          "type": "Birth",
+          "date": "1 November 1931",
+          "standard_date": "1 Nov 1931",
+          "place": "Iroquois, Kingsbury, South Dakota, United States",
+          "standard_place": "Iroquois, Kingsbury, South Dakota, United States"
+        },
+        {
+          "id": "feadeac8-c709-46e5-9683-a41ff506ca9d",
+          "type": "Residence",
+          "date": "1935",
+          "standard_date": "1935",
+          "place": "Belle Prairie Township, Beadle, South Dakota, United States",
+          "standard_place": "Belle Prairie Township, Beadle, South Dakota, United States"
+        },
+        {
+          "id": "2efba19d-5391-4946-a1b3-5921067bebbe",
+          "type": "Residence",
+          "date": "1940",
+          "standard_date": "1940",
+          "place": "Sioux Falls, Minnehaha, South Dakota, United States",
+          "standard_place": "Sioux Falls, Minnehaha, South Dakota, United States"
+        },
+        {
+          "id": "bc02a039-4647-43ef-9f04-8d18aefb89a6",
+          "type": "Residence",
+          "date": "21 May 1998",
+          "standard_date": "21 May 1998",
+          "place": "Riverside, California, United States",
+          "standard_place": "Riverside, California, United States"
+        },
+        {
+          "id": "d4cba096-54ff-4891-957c-6fa34595146d",
+          "type": "Death",
+          "date": "1 May 2022",
+          "standard_date": "1 May 2022",
+          "place": "Riverside, Riverside, California, United States",
+          "standard_place": "Riverside, Riverside, California, United States"
+        }
+      ]
+    },
+    {
+      "id": "LFT9-PDR",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N7",
+          "given": "Reuben Spencer",
+          "surname": "Spriggs",
+          "suffix": "Jr"
+        }
+      ],
+      "facts": [
+        {
+          "id": "ebe0d4fe-20f8-4dad-b4b8-c69c03d0f100",
+          "type": "Birth",
+          "date": "3 October 1928",
+          "standard_date": "3 Oct 1928",
+          "place": "Iroquois, Kingsbury, South Dakota, United States",
+          "standard_place": "Iroquois, Kingsbury, South Dakota, United States"
+        },
+        {
+          "id": "c60127f1-b082-44e0-8495-ff98b2cd416c",
+          "type": "Residence",
+          "date": "1930",
+          "standard_date": "1930",
+          "place": "Belle Prairie Township, Beadle, South Dakota, United States",
+          "standard_place": "Belle Prairie Township, Beadle, South Dakota, United States"
+        },
+        {
+          "id": "a3ca8aea-4b58-4dbf-aecf-8fd8437e7791",
+          "type": "Residence",
+          "date": "1935",
+          "standard_date": "1935",
+          "place": "Belle Prairie Township, Beadle, South Dakota, United States",
+          "standard_place": "Belle Prairie Township, Beadle, South Dakota, United States"
+        },
+        {
+          "id": "272688ba-9db5-4a83-94df-1744d94ed9fd",
+          "type": "Residence",
+          "date": "1940",
+          "standard_date": "1940",
+          "place": "Sioux Falls, Minnehaha, South Dakota, United States",
+          "standard_place": "Sioux Falls, Minnehaha, South Dakota, United States"
+        },
+        {
+          "id": "bedbddae-d120-4954-ac65-ab11905af16b",
+          "type": "Military+Draft+Registration",
+          "date": "3 October 1946",
+          "standard_date": "3 Oct 1946",
+          "place": "Riverside, Riverside, California, United States",
+          "standard_place": "Riverside, Riverside, California, United States"
+        },
+        {
+          "id": "e3157663-21fb-4571-a340-3af655ac5d15",
+          "type": "Death",
+          "date": "16 May 2015",
+          "standard_date": "16 May 2015",
+          "place": "Dana Point, Orange, California, United States",
+          "standard_place": "Dana Point, Orange, California, United States"
+        }
+      ]
+    }
+  ],
+  "relationships": [
+    {
+      "id": "R2",
+      "type": "Couple",
+      "person1": "KNSQ-3LB",
+      "person2": "KNSQ-3GK",
+      "facts": [
+        {
+          "id": "F1",
+          "type": "Marriage",
+          "date": "19 August 1898",
+          "standard_date": "19 Aug 1898",
+          "place": "Spokane, Spokane, Washington, United States",
+          "standard_place": "Spokane, Spokane, Washington, United States"
+        }
+      ]
+    },
+    {
+      "id": "R3",
+      "type": "ParentChild",
+      "parent": "KNSQ-3LB",
+      "child": "L64C-QQX",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R4",
+      "type": "ParentChild",
+      "parent": "KNSQ-3GK",
+      "child": "L64C-QQX",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R5",
+      "type": "ParentChild",
+      "parent": "L64C-QQX",
+      "child": "LFT9-PDR"
+    },
+    {
+      "id": "R7",
+      "type": "ParentChild",
+      "parent": "L64C-QQX",
+      "child": "LFT9-PXM"
+    }
+  ],
+  "sources": [
+    {
+      "id": "9ZX6-HJ9",
+      "title": "Spencer Spriggs, \"South Dakota, State Census, 1915\"",
+      "citation": "\"South Dakota, State Census, 1915\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:MMH5-9TH : Mon Jan 20 19:39:34 UTC 2025), Entry for Spencer Spriggs, 1915.",
+      "url": "https://familysearch.org/ark:/61903/1:1:MMH5-9TH"
+    },
+    {
+      "id": "9ZX6-4LB",
+      "title": "Spencer Spriggs, \"United States, Census, 1920\"",
+      "citation": "\"United States, Census, 1920\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:M6N2-M3W : Mon Oct 13 00:48:40 UTC 2025), Entry for Will Spriggs and Charlott Spriggs, 1920.",
+      "url": "https://familysearch.org/ark:/61903/1:1:M6N2-M3H"
+    },
+    {
+      "id": "M39R-56Y",
+      "title": "Rueben S Spriggs, \"United States, Census, 1910\"",
+      "citation": "\"United States, Census, 1910\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:MPXD-MZ4 : Wed Aug 13 17:11:01 UTC 2025), Entry for John W Spriggs and Charlotte Spriggs, 1910.",
+      "url": "https://familysearch.org/ark:/61903/1:1:MPXD-MZC"
+    },
+    {
+      "id": "MMC9-FL7",
+      "title": "Reuben Spencer Spriggs, \"United States World War I Draft Registration Cards, 1917-1918\"",
+      "citation": "\"United States, World War I Draft Registration Cards, 1917-1918\", database with images, <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:K68M-VHS : 1 July 2024), Reuben Spencer Spriggs, 1917-1918.",
+      "url": "https://familysearch.org/ark:/61903/1:1:K68M-VHS"
+    },
+    {
+      "id": "MMML-NNY",
+      "title": "Reuben S Spriggs, \"United States Social Security Death Index\"",
+      "citation": "\"United States, Social Security Death Index,\" database, <i>FamilySearch</i> (https://familysearch.org/ark:/61903/1:1:V3N4-V2P : 10 January 2021), Reuben S Spriggs, 21 May 1998; citing U.S. Social Security Administration, <i>Death Master File</i>, database (Alexandria, Virginia: National Technical Information Service, ongoing).",
+      "url": "https://familysearch.org/ark:/61903/1:1:V3N4-V2P"
+    }
+  ]
+}

--- a/eval/tests/e2e/spriggs-marriage-1926/unstripped-tree.gedcomx.json
+++ b/eval/tests/e2e/spriggs-marriage-1926/unstripped-tree.gedcomx.json
@@ -1,0 +1,503 @@
+{
+  "persons": [
+    {
+      "id": "L64C-QQX",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N1",
+          "given": "Reuben Spencer",
+          "surname": "Spriggs"
+        }
+      ],
+      "facts": [
+        {
+          "id": "7b67460c-14ec-47bd-8806-6d6adebff86d",
+          "type": "Birth",
+          "date": "6 November 1898",
+          "standard_date": "6 Nov 1898",
+          "place": "Maddock, Benson, North Dakota, United States",
+          "standard_place": "Maddock, Benson, North Dakota, United States"
+        },
+        {
+          "id": "3663d6e2-272a-404b-a366-d430f40eddc6",
+          "type": "Death",
+          "date": "21 May 1998",
+          "standard_date": "21 May 1998",
+          "place": "Riverside, Riverside, California, United States",
+          "standard_place": "Riverside, Riverside, California, United States"
+        },
+        {
+          "id": "a3ca8aea-4b58-4dbf-aecf-8fd8437e7791",
+          "type": "Residence",
+          "date": "1910",
+          "standard_date": "1910",
+          "place": "Belle Prairie Township, Beadle, South Dakota, United States",
+          "standard_place": "Belle Prairie Township, Beadle, South Dakota, United States"
+        },
+        {
+          "id": "5ca751dd-38f3-4bc9-aef2-461fa2d0fc4b",
+          "type": "Residence",
+          "date": "21 May 1998",
+          "standard_date": "21 May 1998",
+          "place": "Riverside, California, United States",
+          "standard_place": "Riverside, California, United States"
+        },
+        {
+          "id": "7f3bdc12-bd2c-4540-bd28-c9191ed9a73c",
+          "type": "Obituary",
+          "date": "29 May 1998",
+          "standard_date": "29 May 1998",
+          "place": "Riverside, California, United States",
+          "standard_place": "Riverside, California, United States"
+        },
+        {
+          "id": "f47723ec-e7d6-4628-8b82-0f1e6194d01e",
+          "type": "Residence",
+          "place": "South Dakota, United States",
+          "standard_place": "South Dakota, United States"
+        },
+        {
+          "id": "5c6530a8-52d2-4be7-be6f-37cad2b1fb81",
+          "type": "Burial",
+          "place": "Maplewood Cemetery, Iroquois, Kingsbury, South Dakota, United States",
+          "standard_place": "Maplewood Cemetery, Iroquois, Kingsbury, South Dakota, United States"
+        }
+      ]
+    },
+    {
+      "id": "KNSQ-3GK",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N2",
+          "given": "Charlotte Marie",
+          "surname": "Westby"
+        }
+      ],
+      "facts": [
+        {
+          "id": "248eaba5-34ae-4182-9874-bfcc07166241",
+          "type": "Birth",
+          "date": "13 June 1876",
+          "standard_date": "13 Jun 1876",
+          "place": "Akershus, Norway",
+          "standard_place": "Akershus, Norway"
+        },
+        {
+          "id": "67639bbb-6380-492f-a281-d2bc75e402cf",
+          "type": "Immigration",
+          "date": "1877",
+          "standard_date": "1877"
+        },
+        {
+          "id": "9059363c-4af1-428f-af31-d888d8b40770",
+          "type": "Residence",
+          "date": "1920",
+          "standard_date": "1920",
+          "place": "Belle Prairie Township, Beadle, South Dakota, United States",
+          "standard_place": "Belle Prairie Township, Beadle, South Dakota, United States"
+        },
+        {
+          "id": "3bb23c7d-a4d2-4aab-be0f-b9ad9345af49",
+          "type": "Residence",
+          "date": "1930",
+          "standard_date": "1930",
+          "place": "Belle Prairie Township, Beadle, South Dakota, United States",
+          "standard_place": "Belle Prairie Township, Beadle, South Dakota, United States"
+        },
+        {
+          "id": "9381f219-2889-4bfc-9b03-5527232282c1",
+          "type": "Death",
+          "date": "16 January 1968",
+          "standard_date": "16 Jan 1968",
+          "place": "Sioux Falls, Minnehaha, South Dakota, United States",
+          "standard_place": "Sioux Falls, Minnehaha, South Dakota, United States"
+        },
+        {
+          "id": "dd317f3a-21bb-40f8-ad9c-fd4c175e57d9",
+          "type": "Burial",
+          "place": "Iroquois, Kingsbury, South Dakota, United States",
+          "standard_place": "Iroquois, Kingsbury, South Dakota, United States"
+        },
+        {
+          "id": "3a405f0d-23f9-4aed-bb30-eec81135926f",
+          "type": "Residence",
+          "place": "Sioux Falls, Minnehaha, South Dakota, United States",
+          "standard_place": "Sioux Falls, Minnehaha, South Dakota, United States"
+        }
+      ]
+    },
+    {
+      "id": "KNSQ-3LB",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N4",
+          "given": "John William",
+          "surname": "Spriggs"
+        }
+      ],
+      "facts": [
+        {
+          "id": "ebe0d4fe-20f8-4dad-b4b8-c69c03d0f100",
+          "type": "Birth",
+          "date": "17 March 1872",
+          "standard_date": "17 Mar 1872",
+          "place": "Decorah Township, Winneshiek, Iowa, United States",
+          "standard_place": "Decorah Township, Winneshiek, Iowa, United States"
+        },
+        {
+          "id": "954933be-453f-4e96-9bc4-a1f40f681213",
+          "type": "Residence",
+          "date": "1920",
+          "standard_date": "1920",
+          "place": "Belle Prairie Township, Beadle, South Dakota, United States",
+          "standard_place": "Belle Prairie Township, Beadle, South Dakota, United States"
+        },
+        {
+          "id": "b9618e89-cc34-4b18-8ead-01c4febcc5f5",
+          "type": "Residence",
+          "date": "1930",
+          "standard_date": "1930",
+          "place": "Belle Prairie Township, Beadle, South Dakota, United States",
+          "standard_place": "Belle Prairie Township, Beadle, South Dakota, United States"
+        },
+        {
+          "id": "ddb21ddf-0042-4808-af3c-5b2e94e08922",
+          "type": "Death",
+          "date": "27 July 1934",
+          "standard_date": "27 Jul 1934",
+          "place": "Canova, Miner, South Dakota, United States",
+          "standard_place": "Canova, Miner, Dakota Territory, United States"
+        },
+        {
+          "id": "c5be31e4-c57a-417a-b672-456ec4e963d8",
+          "type": "Burial",
+          "date": "30 July 1934",
+          "standard_date": "30 Jul 1934",
+          "place": "Maplewood Cemetery, Iroquois, Kingsbury, South Dakota, United States",
+          "standard_place": "Maplewood Cemetery, Iroquois, Kingsbury, South Dakota, United States"
+        }
+      ]
+    },
+    {
+      "id": "L64C-QM1",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N5",
+          "given": "Nora Alvina",
+          "surname": "Satter"
+        }
+      ],
+      "facts": [
+        {
+          "id": "377e6373-a54b-4d9c-8dbb-21e46d2d96e2",
+          "type": "Birth",
+          "date": "7 November 1899",
+          "standard_date": "7 Nov 1899",
+          "place": "Hartland, Freeborn, Minnesota, United States",
+          "standard_place": "Hartland, Freeborn, Minnesota, United States"
+        },
+        {
+          "id": "d259590e-3758-4e48-a20e-d4a3c876cf65",
+          "type": "Residence",
+          "date": "1900",
+          "standard_date": "1900",
+          "place": "Hartland Township, Freeborn, Minnesota, United States",
+          "standard_place": "Hartland Township, Freeborn, Minnesota, United States"
+        },
+        {
+          "id": "272688ba-9db5-4a83-94df-1744d94ed9fd",
+          "type": "Residence",
+          "date": "1930",
+          "standard_date": "1930",
+          "place": "Belle Prairie Township, Beadle, South Dakota, United States",
+          "standard_place": "Belle Prairie Township, Beadle, South Dakota, United States"
+        },
+        {
+          "id": "af27bdb3-0190-4145-8100-880432d43893",
+          "type": "Death",
+          "date": "16 May 1959",
+          "standard_date": "16 May 1959",
+          "place": "Riverside, Riverside, California, United States",
+          "standard_place": "Riverside, Riverside, California, United States"
+        },
+        {
+          "id": "a5e188c8-5877-471e-8fbb-878fa980af42",
+          "type": "Burial",
+          "date": "1959",
+          "standard_date": "1959",
+          "place": "Maplewood Cemetery, Iroquois, Kingsbury, South Dakota, United States",
+          "standard_place": "Maplewood Cemetery, Iroquois, Kingsbury, South Dakota, United States"
+        }
+      ]
+    },
+    {
+      "id": "LFT9-PXM",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N6",
+          "given": "Donna Jean",
+          "surname": "Spriggs"
+        }
+      ],
+      "facts": [
+        {
+          "id": "ebe0d4fe-20f8-4dad-b4b8-c69c03d0f100",
+          "type": "Birth",
+          "date": "1 November 1931",
+          "standard_date": "1 Nov 1931",
+          "place": "Iroquois, Kingsbury, South Dakota, United States",
+          "standard_place": "Iroquois, Kingsbury, South Dakota, United States"
+        },
+        {
+          "id": "feadeac8-c709-46e5-9683-a41ff506ca9d",
+          "type": "Residence",
+          "date": "1935",
+          "standard_date": "1935",
+          "place": "Belle Prairie Township, Beadle, South Dakota, United States",
+          "standard_place": "Belle Prairie Township, Beadle, South Dakota, United States"
+        },
+        {
+          "id": "2efba19d-5391-4946-a1b3-5921067bebbe",
+          "type": "Residence",
+          "date": "1940",
+          "standard_date": "1940",
+          "place": "Sioux Falls, Minnehaha, South Dakota, United States",
+          "standard_place": "Sioux Falls, Minnehaha, South Dakota, United States"
+        },
+        {
+          "id": "bc02a039-4647-43ef-9f04-8d18aefb89a6",
+          "type": "Residence",
+          "date": "21 May 1998",
+          "standard_date": "21 May 1998",
+          "place": "Riverside, California, United States",
+          "standard_place": "Riverside, California, United States"
+        },
+        {
+          "id": "d4cba096-54ff-4891-957c-6fa34595146d",
+          "type": "Death",
+          "date": "1 May 2022",
+          "standard_date": "1 May 2022",
+          "place": "Riverside, Riverside, California, United States",
+          "standard_place": "Riverside, Riverside, California, United States"
+        }
+      ]
+    },
+    {
+      "id": "LFT9-PDR",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N7",
+          "given": "Reuben Spencer",
+          "surname": "Spriggs",
+          "suffix": "Jr"
+        }
+      ],
+      "facts": [
+        {
+          "id": "ebe0d4fe-20f8-4dad-b4b8-c69c03d0f100",
+          "type": "Birth",
+          "date": "3 October 1928",
+          "standard_date": "3 Oct 1928",
+          "place": "Iroquois, Kingsbury, South Dakota, United States",
+          "standard_place": "Iroquois, Kingsbury, South Dakota, United States"
+        },
+        {
+          "id": "c60127f1-b082-44e0-8495-ff98b2cd416c",
+          "type": "Residence",
+          "date": "1930",
+          "standard_date": "1930",
+          "place": "Belle Prairie Township, Beadle, South Dakota, United States",
+          "standard_place": "Belle Prairie Township, Beadle, South Dakota, United States"
+        },
+        {
+          "id": "a3ca8aea-4b58-4dbf-aecf-8fd8437e7791",
+          "type": "Residence",
+          "date": "1935",
+          "standard_date": "1935",
+          "place": "Belle Prairie Township, Beadle, South Dakota, United States",
+          "standard_place": "Belle Prairie Township, Beadle, South Dakota, United States"
+        },
+        {
+          "id": "272688ba-9db5-4a83-94df-1744d94ed9fd",
+          "type": "Residence",
+          "date": "1940",
+          "standard_date": "1940",
+          "place": "Sioux Falls, Minnehaha, South Dakota, United States",
+          "standard_place": "Sioux Falls, Minnehaha, South Dakota, United States"
+        },
+        {
+          "id": "bedbddae-d120-4954-ac65-ab11905af16b",
+          "type": "Military+Draft+Registration",
+          "date": "3 October 1946",
+          "standard_date": "3 Oct 1946",
+          "place": "Riverside, Riverside, California, United States",
+          "standard_place": "Riverside, Riverside, California, United States"
+        },
+        {
+          "id": "e3157663-21fb-4571-a340-3af655ac5d15",
+          "type": "Death",
+          "date": "16 May 2015",
+          "standard_date": "16 May 2015",
+          "place": "Dana Point, Orange, California, United States",
+          "standard_place": "Dana Point, Orange, California, United States"
+        }
+      ]
+    }
+  ],
+  "relationships": [
+    {
+      "id": "R1",
+      "type": "Couple",
+      "person1": "L64C-QQX",
+      "person2": "L64C-QM1",
+      "facts": [
+        {
+          "id": "27913e02-f2f7-4653-9bc3-9a13a0896872",
+          "type": "Marriage",
+          "date": "8 November 1926",
+          "standard_date": "8 Nov 1926",
+          "place": "Minneapolis, Hennepin, Minnesota, United States",
+          "standard_place": "Minneapolis, Hennepin, Minnesota, United States"
+        }
+      ]
+    },
+    {
+      "id": "R2",
+      "type": "Couple",
+      "person1": "KNSQ-3LB",
+      "person2": "KNSQ-3GK",
+      "facts": [
+        {
+          "id": "F1",
+          "type": "Marriage",
+          "date": "19 August 1898",
+          "standard_date": "19 Aug 1898",
+          "place": "Spokane, Spokane, Washington, United States",
+          "standard_place": "Spokane, Spokane, Washington, United States"
+        }
+      ]
+    },
+    {
+      "id": "R3",
+      "type": "ParentChild",
+      "parent": "KNSQ-3LB",
+      "child": "L64C-QQX",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R4",
+      "type": "ParentChild",
+      "parent": "KNSQ-3GK",
+      "child": "L64C-QQX",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R5",
+      "type": "ParentChild",
+      "parent": "L64C-QQX",
+      "child": "LFT9-PDR"
+    },
+    {
+      "id": "R6",
+      "type": "ParentChild",
+      "parent": "L64C-QM1",
+      "child": "LFT9-PDR"
+    },
+    {
+      "id": "R7",
+      "type": "ParentChild",
+      "parent": "L64C-QQX",
+      "child": "LFT9-PXM"
+    },
+    {
+      "id": "R8",
+      "type": "ParentChild",
+      "parent": "L64C-QM1",
+      "child": "LFT9-PXM"
+    }
+  ],
+  "sources": [
+    {
+      "id": "9P93-67H",
+      "title": "R. Spencer Spriggs, \"Find A Grave Index\"",
+      "citation": "\"Find a Grave Index\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:Q231-HPSQ : Mon Jul 06 05:23:35 UTC 2026), Entry for Reuben Spencer Spriggs.",
+      "url": "https://familysearch.org/ark:/61903/1:1:Q231-HPSQ"
+    },
+    {
+      "id": "9KF5-7BY",
+      "title": "Mr Reuben Spencer Spriggs, \"United States, GenealogyBank Obituaries, 1980-2014\"",
+      "citation": "\"United States, GenealogyBank Obituaries, Births, and Marriages, 1980-2015\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:QKLM-51PS : Mon Jun 03 18:45:24 UTC 2024), Entry for Mr Reuben Spencer Spriggs and Dona Darwin, 29 May 1998.",
+      "url": "https://familysearch.org/ark:/61903/1:1:QKLM-51PS"
+    },
+    {
+      "id": "9ZX6-HJ9",
+      "title": "Spencer Spriggs, \"South Dakota, State Census, 1915\"",
+      "citation": "\"South Dakota, State Census, 1915\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:MMH5-9TH : Mon Jan 20 19:39:34 UTC 2025), Entry for Spencer Spriggs, 1915.",
+      "url": "https://familysearch.org/ark:/61903/1:1:MMH5-9TH"
+    },
+    {
+      "id": "9ZX6-4LB",
+      "title": "Spencer Spriggs, \"United States, Census, 1920\"",
+      "citation": "\"United States, Census, 1920\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:M6N2-M3W : Mon Oct 13 00:48:40 UTC 2025), Entry for Will Spriggs and Charlott Spriggs, 1920.",
+      "url": "https://familysearch.org/ark:/61903/1:1:M6N2-M3H"
+    },
+    {
+      "id": "M39R-56Y",
+      "title": "Rueben S Spriggs, \"United States, Census, 1910\"",
+      "citation": "\"United States, Census, 1910\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:MPXD-MZ4 : Wed Aug 13 17:11:01 UTC 2025), Entry for John W Spriggs and Charlotte Spriggs, 1910.",
+      "url": "https://familysearch.org/ark:/61903/1:1:MPXD-MZC"
+    },
+    {
+      "id": "MSNP-DNF",
+      "title": "Legacy NFS Source: Reuben Spencer Spriggs - Funeral program",
+      "citation": "Paper, Funeral program"
+    },
+    {
+      "id": "MS8F-8VD",
+      "title": "Legacy NFS Source: Reuben Spencer Spriggs - Funeral program",
+      "citation": "Paper, Funeral program"
+    },
+    {
+      "id": "MMBK-HKS",
+      "title": "Spencer Spriggs, \"South Dakota, State Census, 1935\"",
+      "citation": "\"South Dakota, State Census, 1935\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:MVHW-88P : Mon Jan 20 20:11:13 UTC 2025), Entry for Spencer Spriggs and Norah Salter, 1935.",
+      "url": "https://familysearch.org/ark:/61903/1:1:MVHW-88P"
+    },
+    {
+      "id": "MMC9-FL7",
+      "title": "Reuben Spencer Spriggs, \"United States World War I Draft Registration Cards, 1917-1918\"",
+      "citation": "\"United States, World War I Draft Registration Cards, 1917-1918\", database with images, <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:K68M-VHS : 1 July 2024), Reuben Spencer Spriggs, 1917-1918.",
+      "url": "https://familysearch.org/ark:/61903/1:1:K68M-VHS"
+    },
+    {
+      "id": "MMM8-MP6",
+      "title": "Spencer R Spriggs, \"United States Census, 1930\"",
+      "citation": "\"United States, Census, 1930\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:XQJ5-4QM : Sun Mar 10 06:45:01 UTC 2024), Entry for Spencer R Spriggs and Nora A Spriggs, 1930.",
+      "url": "https://familysearch.org/ark:/61903/1:1:XQJ5-4QM"
+    },
+    {
+      "id": "MMMK-R73",
+      "title": "Spencer Spriggs, \"United States Census, 1940\"",
+      "citation": "\"United States, Census, 1940\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:V19Y-4D7 : Sun Oct 19 15:16:03 UTC 2025), Entry for Spencer Spriggs and Nora Spriggs, 1940.",
+      "url": "https://familysearch.org/ark:/61903/1:1:V19Y-4D7"
+    },
+    {
+      "id": "MMML-NNY",
+      "title": "Reuben S Spriggs, \"United States Social Security Death Index\"",
+      "citation": "\"United States, Social Security Death Index,\" database, <i>FamilySearch</i> (https://familysearch.org/ark:/61903/1:1:V3N4-V2P : 10 January 2021), Reuben S Spriggs, 21 May 1998; citing U.S. Social Security Administration, <i>Death Master File</i>, database (Alexandria, Virginia: National Technical Information Service, ongoing).",
+      "url": "https://familysearch.org/ark:/61903/1:1:V3N4-V2P"
+    }
+  ]
+}


### PR DESCRIPTION
## New fixture: `spriggs-marriage-1926`

PID-path fixture for **Reuben Spencer Spriggs (L64C-QQX)**, 1898 ND – 1998 CA (deceased): *who, when, and where did he marry?* Answer to recover: **Nora Alvina Satter, 8 November 1926, Minneapolis, Hennepin, Minnesota.**

- **Stripped:** Nora (person), cascading the Couple relationship with the marriage fact and her two ParentChild links; plus the 7 sources that name her or her household (obituary, Find A Grave, both funeral programs, 1930/1935/1940 censuses). Pre-marriage sources kept. Clean strip — no linter warnings.
- **Living-person gate:** one living relative (LF4F-MFB) removed from the snapshot with `--drop-living`; every remaining person is marked deceased.
- **Difficulty:** medium — spouse identity is easy from census households, but the marriage happened out-of-state (Minneapolis) while the family lived in Beadle County, SD, so an SD-scoped search misses the marriage record.
- Findings: 2 required (spouse identity; marriage date+place) + 1 bonus (attach a MN marriage record source).

## Validator fix: presence mirror couldn't see Couple-held facts

This is the first **PID-path** marriage fixture, and it exposed a gap: `index_tree` in `eval/harness/e2e/validate_fixture.py` collected fact types from persons only, but a Marriage fact lives on the **Couple relationship** — so `validate`'s presence mirror rejected every marriage `fact` finding with a false "was never in the tree" (the two existing marriage fixtures are PID-less, where the check is skipped).

`index_tree` now folds relationship-held fact types onto both endpoint persons. ParentChild needs nothing in principle (the schema allows `facts` on Couple only), but the fold reads endpoints generically so a schema change can't silently reopen the gap. Side benefit: the stripping linter can now catch a marriage answer left behind on a Couple. Regression test added; all 873 harness unit tests pass, and the fixture validates clean.

The fixture and the validator fix land together deliberately — the fixture only validates with the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)