### PR TITLE
eval: re-sample judge up to 3x on malformed submit_grading output

### DIFF
--- a/eval/harness/harness/judge.py
+++ b/eval/harness/harness/judge.py
@@ -363,24 +363,36 @@ def grade(
     )
 
     client = _make_client(auth)
-    response = _create_message_with_retry(
-        client=client,
-        model=model,
-        prefix=prefix,
-        suffix=suffix,
-    )
 
-    # If max_tokens clipped the response, the tool_use input may be a
-    # truncated JSON fragment — _extract_dimensions will then fail with a
-    # confusing parse-style error. Surface the truncation directly so the
-    # operator knows to bump max_tokens (or shorten dimensions).
-    if response.stop_reason == "max_tokens":
-        raise JudgeError(
-            "judge response hit max_tokens — tool_use input was clipped. "
-            "Bump max_tokens (currently 4096) or shorten rubric/criteria."
+    # Judge output is non-deterministic: the model occasionally emits a
+    # malformed submit_grading call (dimensions not a list, >1 tool_use, or a
+    # null on a non-nullable base dimension). Those are transient — a fresh
+    # sample almost always parses — so re-sample the create+extract a few times
+    # before giving up rather than failing the whole test on one bad draw.
+    # (A max_tokens clip is NOT transient: re-sampling won't help, so surface
+    # it immediately so the operator bumps the cap.)
+    last_parse_error: JudgeError | None = None
+    for _attempt in range(3):
+        response = _create_message_with_retry(
+            client=client,
+            model=model,
+            prefix=prefix,
+            suffix=suffix,
         )
+        if response.stop_reason == "max_tokens":
+            raise JudgeError(
+                "judge response hit max_tokens — tool_use input was clipped. "
+                "Bump max_tokens (currently 4096) or shorten rubric/criteria."
+            )
+        try:
+            dimensions = _extract_dimensions(response)
+            break
+        except JudgeError as e:
+            last_parse_error = e
+            continue
+    else:
+        raise last_parse_error  # exhausted re-samples on malformed judge output
 
-    dimensions = _extract_dimensions(response)
     cost = _compute_cost(response, model)
     usage = response.usage
     return JudgeOutput(


### PR DESCRIPTION
## What

`grade()` in `eval/harness/harness/judge.py` previously made one judge call and failed the whole test if the `submit_grading` tool_use didn't parse. Judge output is non-deterministic — occasionally the model emits a malformed call (dimensions not a list, >1 tool_use, or a null on a non-nullable base dimension) — and a fresh sample almost always parses. Now the create+extract is re-sampled up to 3 times before the parse error is surfaced.

A `max_tokens` clip still raises immediately: re-sampling can't fix truncation, the operator has to bump the cap.

## Notes

- Rescued from an uncommitted edit sitting in the `skill-latency` worktree (the #578 de-flake work); rebased onto current main.
- Known small gap: `_compute_cost` only counts the successful sample — discarded malformed attempts aren't included in the reported judge cost.

## Testing

- `uv run pytest -m 'not e2e' -q` in `eval/harness`: 891 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)