### PR TITLE
tree_edit: add_person inline-fact ids, Couple-relationship fact targeting, fact-shape validation (consolidation PR 2a)

### DIFF
--- a/docs/specs/tree-edit-tool-spec.md
+++ b/docs/specs/tree-edit-tool-spec.md
@@ -103,10 +103,12 @@ tree_edit({
     | "add_source" | "update_source" | "remove",
 
   // ── targeting (per operation) ──
-  personId?: string,          // add_fact, add_name, update_fact, update_name, update_person
+  personId?: string,          // add_fact/update_fact (person-held facts — exactly one of
+                              //   personId | relationshipId), add_name, update_name, update_person
   factId?: string,            // update_fact, remove
   nameId?: string,            // update_name
-  relationshipId?: string,    // remove
+  relationshipId?: string,    // add_fact/update_fact (Couple-held facts — exactly one of
+                              //   personId | relationshipId), remove
   sourceId?: string,          // update_source
 
   // ── payloads (snake_case, NO id — the tool assigns) ──
@@ -123,25 +125,40 @@ tree_edit({
 
 ### 4.1 Per-operation contract
 
-- **`add_fact`** `{ personId, fact }` — append `fact` to the person's `facts`,
-  assigning the next `F` id above the tree max. If `fact.primary === true`, clear
-  `primary` on every other fact of the **same `type`** on that person. If
+- **`add_fact`** `{ personId | relationshipId, fact }` — append `fact` to the
+  target's `facts`, assigning the next `F` id above the tree max. The target is
+  **exactly one of** `personId` (a person-held fact) or `relationshipId` (a
+  Couple-held fact — Marriage, Divorce, … live on the Couple relationship, never
+  duplicated onto each spouse); supplying both or neither is an input error, and
+  a `relationshipId` that names a `ParentChild` is an input error (the tree
+  schema allows `facts` only on Couples). If `fact.primary === true`, clear
+  `primary` on every other fact of the **same `type`** on that holder. If
   `fact.place` is set and `resolveStandardPlace !== false` and no
   `fact.standard_place` was supplied, resolve it via `resolveStandardPlace` (null
   when nothing resolves).
-- **`update_fact`** `{ personId, factId, fact }` — shallow-merge the provided
-  `fact` fields onto the existing fact (id immutable). If `place` changed (and not
-  explicitly accompanied by `standard_place`), re-resolve `standard_place`. If
-  `primary: true` set, run the same-type swap.
+- **`update_fact`** `{ personId | relationshipId, factId, fact }` — shallow-merge
+  the provided `fact` fields onto the existing fact (id immutable) on the same
+  exactly-one-target contract as `add_fact`; the `factId` must live on the named
+  holder. If `place` changed (and not explicitly accompanied by
+  `standard_place`), re-resolve `standard_place`. If `primary: true` set, run the
+  same-type swap on that holder.
 - **`add_name`** `{ personId, name }` — append, assign next `N`. If
   `name.preferred === true`, clear `preferred` on the person's other names.
 - **`update_name`** `{ personId, nameId, name }` — shallow-merge fields; preferred
   swap if set true.
 - **`update_person`** `{ personId, gender?, ark? }` — set scalar person fields.
-- **`add_person`** `{ person }` — append a new person, assigning the next `I` id
-  and an `N` id for each nested name (exactly-one `preferred`). Synthesized stubs
-  omit `ark` (`simplified-gedcomx-spec.md` §4.6).
-- **`add_relationship`** `{ relationship }` — append, assign next `R`. Endpoint
+- **`add_person`** `{ person }` — append a new person, assigning the next `I` id,
+  an `N` id for each nested name (exactly-one `preferred`), and an `F` id for each
+  nested fact (reported as `assignedIds.facts`). Inline facts follow the same rules
+  as `add_fact`: a caller-supplied fact `id` is rejected ("add_person facts must not
+  carry ids — the tool assigns them"), and each fact's `standard_place` is resolved
+  from `place` when unset. Synthesized stubs omit `ark`
+  (`simplified-gedcomx-spec.md` §4.6).
+- **`add_relationship`** `{ relationship }` — append, assign next `R`. Facts
+  supplied on a new **Couple** relationship (e.g. its Marriage) get the same
+  treatment as `add_fact`: tool-assigned `F` ids (caller-supplied ids rejected),
+  `standard_place` resolution, `assignedIds.facts`. Facts on a `ParentChild` are an
+  input error. Endpoint
   integrity (`parent`/`child` for `ParentChild`, `person1`/`person2` for `Couple`
   reference existing persons — tree persons or FS ids already present) and shape (no
   `person1` on a `ParentChild`) are enforced by the final whole-tree validation pass
@@ -159,6 +176,18 @@ tree_edit({
   facts and relationships** — a `personId` here is an error (person removal is
   `merge_tree_persons`).
 
+**Fact payload shape (all fact write paths).** On every path that writes a fact —
+`add_fact`, `update_fact`, `add_person` inline facts, `add_relationship` facts —
+the scalar fact fields `date`, `standard_date`, `place`, `standard_place`, and
+`value` must be **plain strings** when present (`simplified-gedcomx-spec.md` §4.1, §4.5).
+Anything else (most commonly a raw-GedcomX nested `date: { original, formal }`
+object, but also `null` or an array) is rejected at write time with an input error
+naming the op, the field, and the expected shape, before validation runs. The final
+whole-tree validation would also reject these (`'date' must be a string`), but the
+write-time check attributes the error to the offending op (`ops[i]: …` in a batch)
+instead of a persons-index path — this closed the e2e failure where an accepted
+malformed nested date later crashed `person_warnings` date parsing.
+
 ### 4.2 Return value (compact — never the tree)
 
 ```typescript
@@ -167,7 +196,9 @@ tree_edit({
   operation: string,
   assignedIds?: {                 // ids the tool allocated, for narration
     person?: string, fact?: string, name?: string,
-    relationship?: string, source?: string, names?: string[],
+    relationship?: string, source?: string,
+    names?: string[],             // add_person nested names
+    facts?: string[],             // add_person / add_relationship nested facts
   },
   filesWritten: ["tree.gedcomx.json"],
   validation: { valid: true, warnings: string[] },
@@ -300,6 +331,10 @@ Sequence (mirrors `merge_record_into_tree`):
 | `add_source` / `update_source` payload carries an `id` | rejected (add) / ignored (update — `id` is immutable) |
 | `add_source` with a source missing `title` | validation failure; write nothing (the shared validate-before-persist pass requires `[id, title]`) |
 | `add_relationship` endpoint references a non-existent person, or field shape mismatches the `type` | input error (also caught by validation) |
+| `add_fact` / `update_fact` with both or neither of `personId` / `relationshipId` | input error — "requires exactly one of `personId` or `relationshipId`" |
+| `add_fact` / `update_fact` targeting a `ParentChild` relationship, or `add_relationship` with facts on a `ParentChild` | input error — facts live only on Couple relationships |
+| A fact payload (any write path) with a non-string `date` / `standard_date` / `place` / `standard_place` / `value` — e.g. a nested `{ original, formal }` date object | input error naming the field and expected shape; write nothing (§4.1 "Fact payload shape") |
+| `add_person` inline fact / `add_relationship` fact carries an `id` | input error — the tool assigns `F` ids |
 | `remove` with a `personId` (attempt to delete a person) | input error — use `merge_tree_persons` |
 | `resolveStandardPlace` network call fails | best-effort: set `standard_place: null`, add a warning; never fail the edit on a place-resolution miss |
 | Resulting tree fails project validation | write nothing; return `{ ok: false, errors }` |
@@ -325,14 +360,25 @@ The caller (`tree-edit` skill) still:
 - **add_fact** — appends with the next `F` id; `primary: true` clears the prior
   same-type primary; `place` set → `standard_place` resolved (mock the resolver);
   only `tree.gedcomx.json` written; `.bak` created; project validates.
+  Relationship-targeted: `relationshipId` appends to the Couple's own `facts`
+  (same F id / primary swap / place resolution; nothing lands on either spouse);
+  both/neither of `personId`/`relationshipId` rejected; `ParentChild` target
+  rejected; stale `relationshipId` rejected.
 - **update_fact** — field merge by `factId`; a place change re-resolves
-  `standard_place`; id unchanged.
+  `standard_place`; id unchanged. Also merges by `relationshipId` + `factId` on a
+  Couple-held fact; a `factId` not on the named holder errors.
 - **add_name / update_name** — `N` id assigned; `preferred: true` clears other
   preferred; exactly one preferred remains.
 - **update_person** — gender/ark set; nothing else changed.
-- **add_person** — `I` id + `N` ids assigned; stub omits `ark`.
+- **add_person** — `I` id + `N` ids assigned; stub omits `ark`; inline facts get
+  `F` ids (surfaced as `assignedIds.facts`) with `standard_place` resolution; an
+  inline fact carrying an id is rejected.
 - **add_relationship** — `R` id assigned; endpoints validated; `ParentChild` with
-  `person1` rejected.
+  `person1` rejected; Couple facts get `F` ids, caller-supplied fact ids rejected.
+- **fact payload shape** — a nested `{ original }` date (or non-string
+  place/standard_date/…) is rejected on every fact write path (add_fact person +
+  relationship, update_fact, add_person inline, add_relationship facts) with an
+  error naming the field; nothing written, no `.bak`.
 - **add_source / update_source** — `S` id assigned above the tree max (S-aware
   `nextId`, so `S1`→`S2`); a caller-supplied `id` is rejected on add; `author`/`url`
   round-trip into the written `S` entry; `update_source` merges by `sourceId` (id

--- a/eval/harness/harness/mock_mcp.py
+++ b/eval/harness/harness/mock_mcp.py
@@ -337,14 +337,44 @@ def _live_tool_input_schema(tool_name: str) -> dict[str, Any]:
         ]
         _op_fields = {
             "operation": {"type": "string", "enum": _op_enum},
-            "personId": {"type": "string"},
+            "personId": {
+                "type": "string",
+                "description": (
+                    "Target person id — for add_fact/update_fact (person-held facts; "
+                    "exactly one of personId or relationshipId), add_name, "
+                    "update_name, update_person."
+                ),
+            },
             "factId": {"type": "string"},
             "nameId": {"type": "string"},
-            "relationshipId": {"type": "string"},
+            "relationshipId": {
+                "type": "string",
+                "description": (
+                    "Target relationship id — for add_fact/update_fact on a Couple "
+                    "relationship's own facts (e.g. a Marriage lives on the Couple, "
+                    "not on each spouse; exactly one of personId or relationshipId), "
+                    "and for remove."
+                ),
+            },
             "sourceId": {"type": "string"},
-            "fact": {"type": "object"},
+            "fact": {
+                "type": "object",
+                "description": (
+                    "The fact to add (full, no id) or the fields to set "
+                    "(update_fact). date/standard_date/place/standard_place/value "
+                    'are plain strings (date: "2 October 1876"), never nested '
+                    "objects."
+                ),
+            },
             "name": {"type": "object"},
-            "person": {"type": "object"},
+            "person": {
+                "type": "object",
+                "description": (
+                    "The person to add (gender + at least one name; no ids — the "
+                    "tool assigns I, N, and F ids, including for any inline "
+                    "`facts`)."
+                ),
+            },
             "relationship": {"type": "object"},
             "source": {"type": "object"},
             "gender": {"type": "string"},

--- a/packages/engine/mcp-server/src/tools/tree-edit.ts
+++ b/packages/engine/mcp-server/src/tools/tree-edit.ts
@@ -119,9 +119,57 @@ function requirePerson(tree: SimplifiedGedcomX, personId: string | undefined): S
   return p;
 }
 
-/** Remove the `primary` flag from the person's other facts of the same type. */
-function clearPrimaryOfType(person: SimplifiedPerson, type: string | undefined, exceptId: string | undefined): void {
-  for (const f of person.facts ?? []) {
+/** Anything that holds a `facts` array: a person or a Couple relationship. */
+type FactHolder = SimplifiedPerson | SimplifiedRelationship;
+
+/**
+ * Resolve the target of add_fact/update_fact: exactly one of `personId` or
+ * `relationshipId`. Facts on relationships are legal only on Couples
+ * (Marriage, Divorce, …) — the tree schema rejects `facts` on ParentChild.
+ */
+function requireFactHolder(tree: SimplifiedGedcomX, input: TreeEditInput, op: string): FactHolder {
+  const targets = [input.personId, input.relationshipId].filter(Boolean);
+  if (targets.length !== 1) {
+    throw new TreeEditError(`${op} requires exactly one of \`personId\` or \`relationshipId\``);
+  }
+  if (input.personId) return requirePerson(tree, input.personId);
+  const rel = (tree.relationships ?? []).find((r) => r.id === input.relationshipId);
+  if (!rel) throw new TreeEditError(`relationship '${input.relationshipId}' not found in tree`);
+  if (rel.type !== "Couple") {
+    throw new TreeEditError(
+      `facts live only on Couple relationships — '${input.relationshipId}' is ` +
+        `${rel.type ?? "untyped"}; put person facts on the person instead`,
+    );
+  }
+  return rel;
+}
+
+/**
+ * Reject a fact payload whose scalar fields are not the flat strings the
+ * simplified-GedcomX format requires (simplified-gedcomx-spec.md §4.1, §4.5) — most
+ * commonly a raw-GedcomX nested `date: { original, formal }` object, which
+ * would otherwise surface as an opaque whole-project validation error (or,
+ * historically, crash downstream date parsing). Checked on every fact write
+ * path so the error names the op and the expected shape.
+ */
+const FACT_STRING_FIELDS = ["date", "standard_date", "place", "standard_place", "value"] as const;
+function requireFactShape(fact: SimplifiedFact, op: string): void {
+  for (const field of FACT_STRING_FIELDS) {
+    const v = (fact as Record<string, unknown>)[field];
+    if (v !== undefined && typeof v !== "string") {
+      const got = v === null ? "null" : Array.isArray(v) ? "an array" : `a ${typeof v}`;
+      throw new TreeEditError(
+        `${op}: fact \`${field}\` must be a plain string (e.g. date: "2 October 1876", ` +
+          `place: "Schuylkill County, Pennsylvania"), got ${got} — simplified-GedcomX facts ` +
+          `use flat string fields, not nested GedcomX objects like { original, formal }`,
+      );
+    }
+  }
+}
+
+/** Remove the `primary` flag from the holder's other facts of the same type. */
+function clearPrimaryOfType(holder: FactHolder, type: string | undefined, exceptId: string | undefined): void {
+  for (const f of holder.facts ?? []) {
     if (f.id !== exceptId && f.type === type && "primary" in f) delete f.primary;
   }
 }
@@ -156,28 +204,35 @@ async function applyOperation(
 
   switch (input.operation) {
     case "add_fact": {
-      const person = requirePerson(tree, input.personId);
+      // Target is a person OR an existing Couple relationship (a Marriage
+      // fact lives on the Couple, not duplicated onto each spouse).
+      const holder = requireFactHolder(tree, input, "add_fact");
       if (!input.fact) throw new TreeEditError("add_fact requires a `fact`");
       if (input.fact.id) throw new TreeEditError("add_fact `fact` must not carry an id — the tool assigns it");
+      requireFactShape(input.fact, "add_fact");
       const fact: SimplifiedFact = { ...input.fact, id: nextId(tree, "F") };
       await maybeResolvePlace(fact, input.fact.standard_place !== undefined);
-      if (fact.primary === true) clearPrimaryOfType(person, fact.type, fact.id);
-      person.facts = [...(person.facts ?? []), fact];
+      if (fact.primary === true) clearPrimaryOfType(holder, fact.type, fact.id);
+      holder.facts = [...(holder.facts ?? []), fact];
       assignedIds.fact = fact.id;
       break;
     }
     case "update_fact": {
-      const person = requirePerson(tree, input.personId);
+      const holder = requireFactHolder(tree, input, "update_fact");
       if (!input.factId) throw new TreeEditError("update_fact requires a `factId`");
       if (!input.fact) throw new TreeEditError("update_fact requires `fact` fields to set");
-      const existing = (person.facts ?? []).find((f) => f.id === input.factId);
-      if (!existing) throw new TreeEditError(`fact '${input.factId}' not found on person '${input.personId}'`);
+      requireFactShape(input.fact, "update_fact");
+      const existing = (holder.facts ?? []).find((f) => f.id === input.factId);
+      if (!existing) {
+        const where = input.personId ? `person '${input.personId}'` : `relationship '${input.relationshipId}'`;
+        throw new TreeEditError(`fact '${input.factId}' not found on ${where}`);
+      }
       for (const [k, v] of Object.entries(input.fact)) {
         if (k === "id") continue;
         (existing as any)[k] = v;
       }
       if (input.fact.place !== undefined) await maybeResolvePlace(existing, input.fact.standard_place !== undefined);
-      if (existing.primary === true) clearPrimaryOfType(person, existing.type, existing.id);
+      if (existing.primary === true) clearPrimaryOfType(holder, existing.type, existing.id);
       break;
     }
     case "add_name": {
@@ -230,6 +285,20 @@ async function applyOperation(
       }
       const person: SimplifiedPerson = { ...input.person, id: personId, names };
       tree.persons = [...(tree.persons ?? []), person];
+      // Facts supplied inline on a new person get tool-allocated F ids and
+      // place resolution, exactly as add_fact does — a fact written without
+      // an id fails tree schema validation (fact.id is required).
+      if (person.facts && person.facts.length > 0) {
+        const factIds: string[] = [];
+        for (const f of person.facts) {
+          if (f.id) throw new TreeEditError("add_person facts must not carry ids — the tool assigns them");
+          requireFactShape(f, "add_person");
+          f.id = nextId(tree, "F");
+          await maybeResolvePlace(f, f.standard_place !== undefined);
+          factIds.push(f.id);
+        }
+        assignedIds.facts = factIds;
+      }
       assignedIds.person = personId;
       assignedIds.names = names.map((n) => n.id!).filter(Boolean);
       break;
@@ -245,9 +314,15 @@ async function applyOperation(
       // supply fact ids — a fact written without an id fails tree schema
       // validation (fact.id is required).
       if (rel.facts && rel.facts.length > 0) {
+        if (rel.type !== "Couple") {
+          throw new TreeEditError(
+            "facts live only on Couple relationships — a ParentChild relationship cannot carry facts",
+          );
+        }
         const factIds: string[] = [];
         for (const f of rel.facts) {
           if (f.id) throw new TreeEditError("add_relationship facts must not carry ids — the tool assigns them");
+          requireFactShape(f, "add_relationship");
           f.id = nextId(tree, "F");
           await maybeResolvePlace(f, f.standard_place !== undefined);
           factIds.push(f.id);
@@ -423,9 +498,11 @@ export const treeEditSchema = {
   description:
     "Make a single ad-hoc edit to the project's tree.gedcomx.json — add or correct " +
     "a fact or name, add a person or relationship, add or correct a source, or remove " +
-    "a fact/relationship on a tier downgrade. Use this for direct corrections; use " +
-    "merge_record_into_tree / merge_tree_persons to fold in a record or collapse " +
-    "duplicate persons (this tool never deletes a person).\n" +
+    "a fact/relationship on a tier downgrade. add_fact/update_fact target a person " +
+    "(personId) or an existing Couple relationship (relationshipId) — a Marriage/Divorce " +
+    "fact lives on the Couple, never duplicated onto each spouse. Use this for direct " +
+    "corrections; use merge_record_into_tree / merge_tree_persons to fold in a record or " +
+    "collapse duplicate persons (this tool never deletes a person).\n" +
     "\n" +
     "Pick the `operation` and supply the content (snake_case simplified-GedcomX " +
     "fields) WITHOUT ids — the tool assigns the next F/N/I/R/S id, swaps the " +
@@ -466,15 +543,26 @@ export const treeEditSchema = {
       },
       personId: {
         type: "string",
-        description: "Target person id — for add_fact, add_name, update_fact, update_name, update_person.",
+        description:
+          "Target person id — for add_fact/update_fact (person-held facts; exactly one of personId or " +
+          "relationshipId), add_name, update_name, update_person.",
       },
       factId: { type: "string", description: "Target fact id — for update_fact and remove." },
       nameId: { type: "string", description: "Target name id — for update_name." },
-      relationshipId: { type: "string", description: "Target relationship id — for remove." },
+      relationshipId: {
+        type: "string",
+        description:
+          "Target relationship id — for add_fact/update_fact on a Couple relationship's own facts " +
+          "(e.g. a Marriage lives on the Couple, not on each spouse; exactly one of personId or " +
+          "relationshipId), and for remove.",
+      },
       sourceId: { type: "string", description: "Target source id — for update_source." },
       fact: {
         type: "object",
-        description: "The fact to add (full, no id) or the fields to set (update_fact). Set `primary: true` to make it the primary of its type.",
+        description:
+          "The fact to add (full, no id) or the fields to set (update_fact). date/standard_date/place/" +
+          "standard_place/value are plain strings (date: \"2 October 1876\"), never nested objects. " +
+          "Set `primary: true` to make it the primary of its type.",
       },
       name: {
         type: "object",
@@ -482,7 +570,9 @@ export const treeEditSchema = {
       },
       person: {
         type: "object",
-        description: "The person to add (gender + at least one name; no ids — the tool assigns I and N ids). Omit `ark` for a synthesized stub.",
+        description:
+          "The person to add (gender + at least one name; no ids — the tool assigns I, N, and F ids, " +
+          "including for any inline `facts`). Omit `ark` for a synthesized stub.",
       },
       relationship: {
         type: "object",

--- a/packages/engine/mcp-server/tests/tools/tree-edit.test.ts
+++ b/packages/engine/mcp-server/tests/tools/tree-edit.test.ts
@@ -356,6 +356,221 @@ describe("tree_edit", () => {
     expect(noFields.ok).toBe(false);
   });
 
+  // ── add_person inline facts: F ids assigned like add_relationship's ────────
+  const twoPersonCoupleTree = () => {
+    const tree = onePerson();
+    tree.persons.push({
+      id: "I2",
+      gender: "Female",
+      names: [{ id: "N2", given: "Mary", surname: "Smith", preferred: true }],
+      facts: [],
+    } as any);
+    (tree as any).relationships = [
+      { id: "R1", type: "Couple", person1: "I1", person2: "I2", facts: [{ id: "F2", type: "Marriage", date: "1840", primary: true }] },
+    ];
+    return tree;
+  };
+
+  it("add_person: assigns F ids to inline facts, resolves standard_place, reports them in assignedIds", async () => {
+    await writeProject(onePerson());
+    const r = await treeEdit({
+      projectPath: dir,
+      operation: "add_person",
+      person: {
+        gender: "Female",
+        names: [{ given: "Margaret", surname: "Smith" }],
+        facts: [
+          { type: "Birth", date: "1852", place: "Schuylkill County, Pennsylvania" },
+          { type: "Death", date: "1930" },
+        ],
+      } as any,
+    });
+    expect(r.ok).toBe(true);
+    if (!r.ok || !("assignedIds" in r)) return;
+    // F1 is taken by I1's birth, so the inline facts get F2, F3.
+    expect(r.assignedIds?.facts).toEqual(["F2", "F3"]);
+    expect(r.assignedIds?.person).toBe("I2");
+    const p2 = (await readTree()).persons.find((p: any) => p.id === "I2");
+    expect(p2.facts.map((f: any) => f.id)).toEqual(["F2", "F3"]);
+    expect(p2.facts[0].standard_place).toBe("Schuylkill, Pennsylvania, United States");
+  });
+
+  it("add_person: rejects an inline fact that carries an id", async () => {
+    await writeProject(onePerson());
+    const treeBefore = await readFile(join(dir, "tree.gedcomx.json"), "utf-8");
+    const r = await treeEdit({
+      projectPath: dir,
+      operation: "add_person",
+      person: {
+        gender: "Female",
+        names: [{ given: "Margaret", surname: "Smith" }],
+        facts: [{ id: "F9", type: "Birth", date: "1852" }],
+      } as any,
+    });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.errors.join(" ")).toMatch(/must not carry ids/);
+    expect(await readFile(join(dir, "tree.gedcomx.json"), "utf-8")).toBe(treeBefore);
+  });
+
+  // ── Facts on existing relationships (relationshipId targeting) ─────────────
+  it("add_fact: relationshipId appends to the Couple's own facts with an F id and the primary swap", async () => {
+    await writeProject(twoPersonCoupleTree());
+    const r = await treeEdit({
+      projectPath: dir,
+      operation: "add_fact",
+      relationshipId: "R1",
+      fact: { type: "Marriage", date: "12 May 1843", place: "Schuylkill County, Pennsylvania", primary: true },
+    });
+    expect(r.ok).toBe(true);
+    if (!r.ok || !("assignedIds" in r)) return;
+    expect(r.assignedIds?.fact).toBe("F3"); // F1 birth, F2 existing marriage
+    const rel = (await readTree()).relationships[0];
+    expect(rel.facts.map((f: any) => f.id)).toEqual(["F2", "F3"]);
+    const f3 = rel.facts.find((f: any) => f.id === "F3");
+    expect(f3.standard_place).toBe("Schuylkill, Pennsylvania, United States");
+    expect(f3.primary).toBe(true);
+    // the older Marriage lost its primary (one primary per type per holder)
+    expect(rel.facts.find((f: any) => f.id === "F2").primary).toBeUndefined();
+    // no fact was duplicated onto either spouse
+    expect((await readTree()).persons.find((p: any) => p.id === "I2").facts ?? []).toHaveLength(0);
+  });
+
+  it("update_fact: relationshipId merges fields onto the Couple-held fact by id", async () => {
+    await writeProject(twoPersonCoupleTree());
+    const r = await treeEdit({
+      projectPath: dir,
+      operation: "update_fact",
+      relationshipId: "R1",
+      factId: "F2",
+      fact: { date: "3 June 1841" },
+    });
+    expect(r.ok).toBe(true);
+    const f2 = (await readTree()).relationships[0].facts.find((f: any) => f.id === "F2");
+    expect(f2.date).toBe("3 June 1841");
+    expect(f2.id).toBe("F2");
+  });
+
+  it("add_fact/update_fact: reject when both or neither of personId/relationshipId is given", async () => {
+    await writeProject(twoPersonCoupleTree());
+    const both = await treeEdit({
+      projectPath: dir,
+      operation: "add_fact",
+      personId: "I1",
+      relationshipId: "R1",
+      fact: { type: "Marriage", date: "1843" },
+    });
+    expect(both.ok).toBe(false);
+    if (both.ok) return;
+    expect(both.errors.join(" ")).toMatch(/exactly one of `personId` or `relationshipId`/);
+
+    const neither = await treeEdit({ projectPath: dir, operation: "update_fact", factId: "F2", fact: { date: "1841" } });
+    expect(neither.ok).toBe(false);
+    if (neither.ok) return;
+    expect(neither.errors.join(" ")).toMatch(/exactly one of `personId` or `relationshipId`/);
+  });
+
+  it("add_fact: rejects a ParentChild relationship target and a stale relationshipId", async () => {
+    const tree = twoPersonCoupleTree();
+    (tree as any).relationships.push({ id: "R2", type: "ParentChild", parent: "I1", child: "I2" });
+    await writeProject(tree);
+    const pc = await treeEdit({
+      projectPath: dir,
+      operation: "add_fact",
+      relationshipId: "R2",
+      fact: { type: "Marriage", date: "1843" },
+    });
+    expect(pc.ok).toBe(false);
+    if (pc.ok) return;
+    expect(pc.errors.join(" ")).toMatch(/Couple relationships/);
+
+    const stale = await treeEdit({
+      projectPath: dir,
+      operation: "add_fact",
+      relationshipId: "R404",
+      fact: { type: "Marriage", date: "1843" },
+    });
+    expect(stale.ok).toBe(false);
+    if (stale.ok) return;
+    expect(stale.errors.join(" ")).toMatch(/'R404' not found/);
+  });
+
+  it("update_fact: errors when the factId is not on the targeted relationship", async () => {
+    await writeProject(twoPersonCoupleTree());
+    // F1 exists, but on person I1 — not on R1.
+    const r = await treeEdit({
+      projectPath: dir,
+      operation: "update_fact",
+      relationshipId: "R1",
+      factId: "F1",
+      fact: { date: "1841" },
+    });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.errors.join(" ")).toMatch(/not found on relationship 'R1'/);
+  });
+
+  // ── Date/place shape validation on every fact write path ───────────────────
+  const nestedDate = { original: "2 Oct 1876", formal: "+1876-10-02" };
+
+  it("rejects a nested GedcomX date object on every fact write path, writing nothing", async () => {
+    await writeProject(twoPersonCoupleTree());
+    const treeBefore = await readFile(join(dir, "tree.gedcomx.json"), "utf-8");
+
+    const attempts = [
+      // add_fact on a person
+      treeEdit({ projectPath: dir, operation: "add_fact", personId: "I1", fact: { type: "Death", date: nestedDate } as any }),
+      // add_fact on a relationship
+      treeEdit({ projectPath: dir, operation: "add_fact", relationshipId: "R1", fact: { type: "Marriage", date: nestedDate } as any }),
+      // update_fact
+      treeEdit({ projectPath: dir, operation: "update_fact", personId: "I1", factId: "F1", fact: { date: nestedDate } as any }),
+      // add_person inline fact
+      treeEdit({
+        projectPath: dir,
+        operation: "add_person",
+        person: { gender: "Male", names: [{ given: "Sam", surname: "Smith" }], facts: [{ type: "Birth", date: nestedDate }] } as any,
+      }),
+      // add_relationship fact
+      treeEdit({
+        projectPath: dir,
+        operation: "add_relationship",
+        relationship: { type: "Couple", person1: "I1", person2: "I2", facts: [{ type: "Divorce", date: nestedDate }] } as any,
+      }),
+    ];
+    for (const attempt of attempts) {
+      const r = await attempt;
+      expect(r.ok).toBe(false);
+      if (r.ok) continue;
+      expect(r.errors.join(" ")).toMatch(/`date` must be a plain string/);
+    }
+    expect(await readFile(join(dir, "tree.gedcomx.json"), "utf-8")).toBe(treeBefore);
+    expect(await exists("tree.gedcomx.json.bak")).toBe(false);
+  });
+
+  it("rejects a non-string place/standard_date and names the offending field", async () => {
+    await writeProject(onePerson());
+    const badPlace = await treeEdit({
+      projectPath: dir,
+      operation: "add_fact",
+      personId: "I1",
+      fact: { type: "Death", date: "1899", place: { original: "Pottsville" } } as any,
+    });
+    expect(badPlace.ok).toBe(false);
+    if (badPlace.ok) return;
+    expect(badPlace.errors.join(" ")).toMatch(/`place` must be a plain string/);
+
+    const badStd = await treeEdit({
+      projectPath: dir,
+      operation: "update_fact",
+      personId: "I1",
+      factId: "F1",
+      fact: { standard_date: null } as any,
+    });
+    expect(badStd.ok).toBe(false);
+    if (badStd.ok) return;
+    expect(badStd.errors.join(" ")).toMatch(/`standard_date` must be a plain string.*got null/);
+  });
+
   it("add_source: a source with no title fails validation and writes nothing", async () => {
     await writeProject(onePerson());
     const treeBefore = await readFile(join(dir, "tree.gedcomx.json"), "utf-8");


### PR DESCRIPTION
PR 2a of the record-extraction consolidation plan (`docs/plan/record-extraction-consolidation-plan.md`, merged in #646). Code-only — no skill/test snapshot flip, so no runlog/annotation owed.

## What

1. **`add_person` assigns F ids to inline facts** — previously an inline `facts` array kept no ids, the whole-project validation rejected the batch ("facts[0]: missing required field 'id'"), and e2e agents recovered by *deleting the facts* (observed data loss: zuniga-rojas, bottemiller). Now: same treatment as `add_relationship` facts — caller-supplied ids rejected, tool-assigned F ids, `standard_place` resolution, reported in `assignedIds.facts`. Bug reproduced in a test before fixing.
2. **`add_fact`/`update_fact` target a person OR an existing Couple relationship** (exactly one of `personId`/`relationshipId`, mirroring `remove`). A Marriage/Divorce fact lives on the Couple — agents previously duplicated Marriage facts onto both spouses because relationship targeting didn't exist (#616 added Couple facts only at `add_relationship` time). ParentChild relationships reject facts at write time (the tree schema excludes them).
3. **Fact-shape validation on every write path** — `date`/`standard_date`/`place`/`standard_place`/`value` must be flat strings; a raw-GedcomX nested `{ original, formal }` date now gets an op-attributed error naming the expected shape. Note: the #634 closed-shape validator already rejects these at persist time — this adds early, per-op attribution rather than closing a live hole.

Also: mock schema mirror descriptions in `eval/harness/harness/mock_mcp.py` aligned with the new contract; `docs/specs/tree-edit-tool-spec.md` §4/§4.1/§4.2/§7/§9 updated.

## Verification

Full mcp-server vitest suite green in the implementation worktree (62 files / 1321 tests); tree-edit suite re-run green post-rebase (35 tests); `npm run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)