### PR TITLE
Lane rule for skill findings + consolidation TODO ledger (consolidation PR 4)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -336,6 +336,15 @@ The `description` in SKILL.md frontmatter is critical — it determines
 when Claude triggers the skill. Be specific about what kinds of user
 requests should activate it.
 
+**Lane rule for skill findings.** Before editing any SKILL.md (or plugin
+agent body) to fix an e2e/eval/user finding, classify the finding:
+(1) tooling defect → MCP tool PR; (2) eval defect (judge/rubric/fixture
+wrong) → eval PR; (3) record-type craft gap → that type's
+playbook/table; (4) core doctrine → the stewarded prose edit, gated by
+the unit suite. Most findings are lanes 1–2; prose edits never
+compensate for a tool or eval bug. Full version:
+`docs/skill-lifecycle.md` §5.
+
 ### Python file I/O: always pass `encoding="utf-8"`
 
 Every Python `read_text()` / `write_text()` / `open()` on a text file

--- a/docs/TODOs.md
+++ b/docs/TODOs.md
@@ -68,6 +68,49 @@ These MCP tools are shipped, specced, and advertised, but no skill references th
   called by any skill (`tree-edit` uses the match tools + `person_read`, never
   `person_ancestors`). Wire it into the relevant tree/research workflow.
 
+## Record-extraction consolidation follow-ups (2026-07 window)
+Deferred from `docs/plan/record-extraction-consolidation-plan.md` §7 at wrap.
+- [ ] **Record-type playbook files + snapshot carve-out** — per-record-type
+  references (census/death/probate/church/marriage) as the parallel-team
+  ownership surface. Blocked on a design decision: inside the skill dir every
+  playbook edit flips the runlog inactive (full re-run+annotation per edit);
+  outside it agents have no reliable load path. Needs a deliberate, documented
+  snapshot carve-out (e.g. a `playbooks/` subdir exclusion) before creating
+  the files. Until then, compact tables live in the extractor agent body.
+- [ ] **Fan-out extractor agents** — the extractor runs serially per record;
+  the latency plan's P3 full form fans out one agent per record with parent
+  batch-persist. Do after per-record overhead is measured on multi-record e2e
+  runs.
+- [ ] **Negative-evidence `informant_proximity` enum value** — skill, rubric,
+  judge, and human annotators still disagree on the informant contract for
+  `record_role: absent` (ut_002's only human correction went against the
+  codified `unknown`). The likely real fix is a new closed-enum value
+  (`researcher`/`analyst`) — full blast radius per CLAUDE.md enum rules (both
+  schema trees, TS union, validator CLOSED_ENUMS, spec prose).
+- [ ] **Extraction→tree materialization gap ownership** — fact-less sibling
+  stubs are never enriched, the 5d trigger can't fire on a family's first
+  record, and no skill promotes extracted facts onto tree persons (8/27 e2e
+  scenarios; judges penalize the thin tree). Needs an ownership spec:
+  `merge_record_into_tree` grows this, or person-evidence does.
+- [ ] **person-evidence epistemic gate** — identity over-reach: pe links
+  written at `confident` from one uncorroborated record with `[?]` readings
+  (clark-parents). The extractor agent got a tentative-cap line; person-evidence
+  needs the equivalent gate + mandatory conflicts entry.
+- [ ] **Upstream sidecar-staging gap** — one e2e run had all 18
+  `record_persona_id`s nulled because the search never staged a sidecar
+  (spriggs). D2 can't auto-fill what was never staged; the fix is
+  search-skill-side (always pass `projectPath` / surface the staging failure).
+- [ ] **Generate the mock input-schema mirror from compiled schemas** —
+  `eval/harness/harness/mock_mcp.py` hand-maintains tool input schemas and has
+  drifted before (missing `ops`). Generate from the compiled build to kill the
+  drift class.
+- [ ] **Bare agent-tool names in gps-mentor.md / image-reader.md** — the
+  agent-mode spike proved bare tool names leave a subagent toolless in the
+  unit-harness SDK path (needs `mcp__genealogy__*`), yet these two agents use
+  bare names and work in Cowork/e2e paths. Reconcile once the PR-3
+  investigation lands: qualify (or dual-list) so all agents work identically
+  in Cowork, the e2e harness, the unit harness, and the hosted web SDK path.
+
 ## Eval framework
 - [ ] **Revisit recovered-retry Tool Arguments scoring** — the judge policy
   (`eval/harness/judge/prompt.md` + the mirror note in

--- a/docs/skill-lifecycle.md
+++ b/docs/skill-lifecycle.md
@@ -114,6 +114,30 @@ run this periodically and whenever a dimension looks off.
 
 ### 5. Improve the skill body
 
+**The lane rule — classify every finding BEFORE touching skill prose.**
+The 2026-07 record-extraction audit found most of a month's SKILL.md
+edits were tool bugs or eval bugs wearing skill-prose clothing — teams
+patched a 780-line prompt because it was the only lever they held, while
+the real defect lived elsewhere. Every e2e/eval/user finding gets a lane
+first:
+
+1. **Tooling defect** (rejected valid payloads, missing tool capability,
+   silent corruption) → MCP tool PR + vitest; prose never compensates
+   for a tool bug.
+2. **Eval defect** (judge confabulation, rubric contradicting the skill,
+   fixture expecting stale contracts) → rubric / judge-prompt / fixture
+   PR. If the skill followed its instructions and got dinged, the eval
+   is the bug.
+3. **Record-type craft gap** (a death-cert/probate/church nuance) → that
+   record type's playbook/table, not new global prose.
+4. **Core doctrine** (a genuine cross-record-type behavior change) →
+   SKILL.md / agent-body edit, stewarded, gated by the unit suite.
+
+Lanes 1–2 merge conflict-free and in parallel; only lane 4 touches the
+contended prompt. When in doubt between 2 and 4, check whether the
+transcript shows the skill *following* its written instruction — if yes,
+it's lane 2.
+
 **Pair.** Cluster the failures across the skill's tests and revise the
 SKILL.md prose to fix them — explaining the *why*, not bolting on
 another MUST (see the authoring guide). The **skill-improver** agent


### PR DESCRIPTION
PR 4 (final docs PR) of the record-extraction consolidation plan (#646, #647, #648; PR 3 in flight).

- **Lane rule** (`docs/skill-lifecycle.md` §5 + a compact CLAUDE.md pointer): every e2e/eval/user finding is classified — tooling defect → tool PR; eval defect → rubric/judge/fixture PR; record-type craft → playbook; core doctrine → stewarded prose edit — before anyone touches SKILL.md or an agent body. This is the structural fix for the many-teams-edit-one-skill churn: lanes 1–2 merge conflict-free in parallel, and the audit showed most historical edits belonged there.
- **TODO ledger**: all deferred items from the consolidation plan §7 ported to `docs/TODOs.md` (tech debt lives in TODOs.md, not plan docs), plus the newly-discovered bare-agent-tool-names reconciliation item.

Docs-only; no runlog gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)