### PR TITLE
Add e2e fixture: mccarley-spouse (Moses J McCarley Sr spouse)

### DIFF
--- a/eval/runlogs/e2e/mccarley-spouse/run-2026-07-15_01-29-54.ann.json
+++ b/eval/runlogs/e2e/mccarley-spouse/run-2026-07-15_01-29-54.ann.json
@@ -1,0 +1,12 @@
+{
+  "per_finding": {
+    "f1": "true",
+    "f2": "true"
+  },
+  "proof_quality_score": 2,
+  "notes": {
+    "f1": "Spouse recovered as person I1 (Elizabeth Patt, the index abbreviation of Patton) and linked to Moses (L7P6-3TT) via a Couple relationship, from the 1792 Lincoln County KY marriage index (top hit), with the Salvina McCarley 1827 marriage (Moses Sr. as father) corroborating his identity.",
+    "f2": "Marriage recovered as 24 Jul 1792, Lincoln County, Kentucky — full date and county, an exact match, encoded as a Marriage fact on the Couple relationship. Proof honestly tiered 'probable' and graded thin (2) because the spouse's name rests on a single direct source; the agent made one blocked person_read attempt before recovering the answer from records."
+  },
+  "annotator": "ernest"
+}

--- a/eval/runlogs/e2e/mccarley-spouse/run-2026-07-15_01-29-54.final-research.json
+++ b/eval/runlogs/e2e/mccarley-spouse/run-2026-07-15_01-29-54.final-research.json
@@ -1,0 +1,1005 @@
+{
+  "project": {
+    "id": "rp_mccarley_spouse",
+    "objective": "Who was the spouse of Moses J McCarley Sr, who was born 17 January 1767 and died 9 April 1844?",
+    "subject_person_ids": [
+      "L7P6-3TT"
+    ],
+    "status": "completed",
+    "created": "2026-07-14",
+    "updated": "2026-07-15"
+  },
+  "researcher_profile": {
+    "experience_level": "intermediate",
+    "subscriptions": [],
+    "narration_guidance": "concise"
+  },
+  "questions": [
+    {
+      "id": "q_001",
+      "question": "Who did Moses J McCarley Sr (born 17 January 1767, died 9 April 1844) marry?",
+      "rationale": "The project objective directly asks for Moses J McCarley Sr's spouse. This question decomposes that objective into a testable single-fact question targeting his marriage. Records potentially available include marriage bonds/licenses, early US census records (1790\u20131840 show household composition), land deeds, probate/estate records, and church records for the late 18th\u2013early 19th century period of his life.",
+      "selection_basis": "objective_decomposition",
+      "priority": "high",
+      "status": "resolved",
+      "depends_on": [],
+      "unblocks": [],
+      "resolved": "2026-07-14",
+      "resolution_assertion_ids": [
+        "a_001",
+        "a_002",
+        "a_003",
+        "a_004"
+      ],
+      "exhaustive_declaration": {
+        "declared": true,
+        "justification": "Searched Kentucky County Marriages 1786-1965 (primary marriage evidence), 1820/1840 census records (nil \u2014 not indexed), Kentucky Probate Records and Wills and Deeds (nil \u2014 essentially browse-only collections), and the FAN cluster (children's marriages in 1817 and 1827, which corroborate Moses Sr.'s identity and Kentucky residence but do not name his wife). The original marriage bond image (ark:/61903/3:1:3Q9M-C9BK-BSZ8-3) was attempted but is inaccessible due to the MCP transport cap (1.1 MB). No competing evidence names a different spouse across any source examined. The derivative index entry (src_001) directly and unambiguously answers the question.",
+        "log_entry_ids": [
+          "log_001",
+          "log_002",
+          "log_003",
+          "log_004",
+          "log_005",
+          "log_006",
+          "log_007",
+          "log_008",
+          "log_009"
+        ],
+        "stop_criteria": {
+          "goal_alignment": "Yes \u2014 src_001 (Kentucky County Marriages index) directly names Elizabeth Patt as Moses McCarley Sr.'s spouse, marriage 24 Jul 1792, Lincoln County, KY. The record is attached to L7P6-3TT in FamilySearch. No competing evidence names a different wife.",
+          "repository_breadth": "FamilySearch Kentucky County Marriages (primary evidence), 1820 and 1840 census (nil \u2014 not indexed for this family), Kentucky Probate Records 1727-1990 and Wills and Deeds (nil \u2014 collections are effectively browse-only), and FAN cluster (son's 1817 and daughter's 1827 marriages). External repositories (Ancestry, MyHeritage) not searched, but the core marriage question is answered by the FamilySearch marriage collection.",
+          "original_substitution": "The original Lincoln County marriage bond image (ark:/61903/3:1:3Q9M-C9BK-BSZ8-3) was attempted via image-reader but is inaccessible: file is 1.1 MB, exceeding the MCP transport cap. Treated as pursued-and-unavailable per the inaccessibility exception. The derivative index carries the same core facts (names, date, county) extracted from the original.",
+          "independent_verification": "One source (src_001, derivative index) directly documents the marriage to Elizabeth Patt. The 1817 and 1827 FAN records (src_002, src_003) corroborate Moses Sr.'s identity and Kentucky presence but do not name his wife. Independent verification of the specific marriage is limited to the single derivative index entry \u2014 a genuine limitation that constrains the proof tier to 'probable' rather than 'proved'.",
+          "evidence_class": "Primary evidence (src_001) is a derivative index entry based on primary information (Lincoln County clerk's marriage bond). Original not accessible (transport cap). No original record with primary information was successfully examined for the marriage itself.",
+          "conflict_resolution": "No conflicting evidence found. No record examined names a different spouse. The 'Mofes Mccarley' spelling in the 1827 record is a period handwriting variant of 'Moses' (long-s), not a conflict.",
+          "overturn_risk": "Low to moderate. No competing evidence names a different wife. The primary risk is that the original bond could spell names differently or record additional context. Land records and church records for Lincoln/Jessamine County were not searched but are unlikely to name a different spouse given the unambiguous 1792 marriage entry. Examining the original image and additional corroborating sources (land records, church records, Ancestry collections) would strengthen the conclusion from 'probable' to 'proved.'"
+        }
+      },
+      "created": "2026-07-15"
+    }
+  ],
+  "plans": [
+    {
+      "id": "pl_001",
+      "question_id": "q_001",
+      "status": "active",
+      "created": "2026-07-14",
+      "items": [
+        {
+          "id": "pli_001",
+          "sequence": 1,
+          "record_type": "vital_record",
+          "jurisdiction": "Lincoln County, Kentucky",
+          "date_range": "1786-1800",
+          "repository": "FamilySearch",
+          "rationale": "Preliminary survey found Moses McCarley married Elizabeth Patt on 24 Jul 1792 in Lincoln County, KY (Kentucky, County Marriages, 1786-1965, ark:/61903/1:1:Q28D-NHWN). This is the highest-priority item: reading the full record image and extracting all facts (date, place, witnesses) provides the primary direct evidence identifying Moses J McCarley Sr's spouse. The 1792 date is consistent with his birth year of 1767 (age ~25 at marriage). The record must be extracted before any downstream conclusion.",
+          "fallback_for": null,
+          "status": "completed"
+        },
+        {
+          "id": "pli_002",
+          "sequence": 2,
+          "record_type": "vital_record",
+          "jurisdiction": "Jessamine County, Kentucky",
+          "date_range": "1817",
+          "repository": "FamilySearch",
+          "rationale": "The 1817 Jessamine County marriage of Moses McCarley (Jr.) to Betsy Lawson lists Moses Mccarley (Sr.) as the groom's father (ark:/61903/1:1:Q28D-N9C1). Extracting this record provides corroborating evidence that Moses J McCarley Sr was alive and residing in Kentucky in 1817, and establishes the Sr/Jr relationship. Also useful: if the original marriage bond or license names Moses Sr.'s wife as the groom's mother, it would identify her directly.",
+          "fallback_for": null,
+          "status": "completed"
+        },
+        {
+          "id": "pli_003",
+          "sequence": 3,
+          "record_type": "census",
+          "jurisdiction": "Kentucky",
+          "date_range": "1840",
+          "repository": "FamilySearch",
+          "rationale": "The 1840 US Federal Census is the last census before Moses J McCarley Sr's death (9 April 1844). He would have been ~73. The 1840 census records household members by age/sex brackets, so a female in her 60s\u201370s in the household would indicate a surviving wife. This is important corroborating evidence for whether Elizabeth Patt was still living and residing with him at the time of the census.",
+          "fallback_for": null,
+          "status": "skipped"
+        },
+        {
+          "id": "pli_004",
+          "sequence": 4,
+          "record_type": "probate",
+          "jurisdiction": "Lincoln County, Kentucky",
+          "date_range": "1844-1848",
+          "repository": "FamilySearch",
+          "rationale": "Moses J McCarley Sr died 9 April 1844. His estate would have been probated in the Kentucky county of his residence (likely Lincoln or an adjacent county). The Kentucky Probate Records, 1727-1990 (collection 1875188) is indexed on FamilySearch. A will naming his wife as executrix or beneficiary \u2014 or an estate inventory listing her as widow \u2014 provides direct evidence of her identity. This is a high-value source that could name the spouse explicitly.",
+          "fallback_for": null,
+          "status": "skipped"
+        },
+        {
+          "id": "pli_005",
+          "sequence": 5,
+          "record_type": "census",
+          "jurisdiction": "Kentucky",
+          "date_range": "1830",
+          "repository": "FamilySearch",
+          "rationale": "The 1830 US Federal Census would show Moses J McCarley Sr (~age 63) and his household. A female in the appropriate age bracket would corroborate a surviving wife. The county of enumeration would further confirm his location in Kentucky. Household composition may also show children still at home.",
+          "fallback_for": null,
+          "status": "skipped"
+        },
+        {
+          "id": "pli_006",
+          "sequence": 6,
+          "record_type": "census",
+          "jurisdiction": "Kentucky",
+          "date_range": "1820",
+          "repository": "FamilySearch",
+          "rationale": "The 1820 US Federal Census would show Moses J McCarley Sr (~age 53) and his household. Presence of a wife-aged female corroborates the marriage. Household composition may reveal younger children still at home, helping to bracket the marriage date and identify remaining family members.",
+          "fallback_for": null,
+          "status": "skipped"
+        },
+        {
+          "id": "pli_007",
+          "sequence": 7,
+          "record_type": "census",
+          "jurisdiction": "Kentucky or Virginia",
+          "date_range": "1810",
+          "repository": "FamilySearch",
+          "rationale": "The 1810 US Federal Census would show Moses J McCarley Sr (~age 43) and household. By 1810, he had been married nearly 18 years (if the 1792 marriage is his). Household composition (children, wife age bracket) provides indirect evidence of when the marriage occurred and who was in the family. Also confirms geographic location.",
+          "fallback_for": null,
+          "status": "skipped"
+        },
+        {
+          "id": "pli_008",
+          "sequence": 8,
+          "record_type": "vital_record",
+          "jurisdiction": "Kentucky",
+          "date_range": "1790-1830",
+          "repository": "FamilySearch",
+          "rationale": "FAN cluster search: The preliminary survey found 'Salvina Mccarley' marrying Westley Alverson in Kentucky (ark:/61903/1:1:Q28D-XWSS). The tree shows 'Sabina McCarley' (KF27-BHH) as a possible child of Moses Sr. Marriage records of Moses Sr.'s children often name the father (and sometimes the mother) in marriage bonds or licenses. Extracting any children's Kentucky marriage records that name Moses Sr. or his wife as parent provides corroborating evidence of the spouse's identity.",
+          "fallback_for": null,
+          "status": "completed"
+        },
+        {
+          "id": "pli_009",
+          "sequence": 9,
+          "record_type": "probate",
+          "jurisdiction": "Garrard or Jessamine County, Kentucky",
+          "date_range": "1844-1850",
+          "repository": "FamilySearch",
+          "rationale": "Fallback: If no Lincoln County probate record is found for Moses J McCarley Sr., check adjacent Garrard and Jessamine Counties where his son Moses Jr. married in 1817. Kentucky county boundaries shifted and families often spanned multiple counties. Kentucky Probate Records, 1727-1990 and Kentucky Wills and Deeds, ca. 1700s-2017 (collection 3155869) cover these jurisdictions.",
+          "fallback_for": "pli_004",
+          "status": "skipped"
+        }
+      ]
+    }
+  ],
+  "log": [
+    {
+      "id": "log_001",
+      "plan_item_id": "pli_001",
+      "performed": "2026-07-15T00:58:03.547Z",
+      "tool": "record_search",
+      "query": {
+        "surname": "McCarley",
+        "givenName": "Moses",
+        "recordType": "marriage",
+        "recordCountry": "United States",
+        "recordSubdivision": "Kentucky",
+        "anyYearFrom": 1785,
+        "anyYearTo": 1800,
+        "collectionId": "1804888",
+        "sex": "Male",
+        "count": 50
+      },
+      "outcome": "positive",
+      "results_examined": 10,
+      "external_site": null,
+      "results_ref": "results/log_001.json",
+      "results_available": 29,
+      "notes": "Top match: Moses McCarley married Elizabeth Patt, 24 Jul 1792, Lincoln County, KY (ark:/61903/1:1:Q28D-NHWN, matchScore 0.62, already attached to subject L7P6-3TT). This is the primary evidence for Moses Sr.'s spouse. Also found: Moses McCarley Jr. + Betsy Lawson, 1817, Jessamine Co., KY (pli_002 target, attachedToOther); and 'Mofes Mccarley' as parent in Westley Alverson + Salvina Mccarley (FAN pli_008 target, attachedToSubject)."
+    },
+    {
+      "id": "log_002",
+      "plan_item_id": "pli_002",
+      "performed": "2026-07-15T00:58:56.577Z",
+      "tool": "record_search",
+      "query": {
+        "surname": "McCarley",
+        "givenName": "Moses",
+        "recordType": "marriage",
+        "recordCountry": "United States",
+        "recordSubdivision": "Kentucky",
+        "anyYearFrom": 1815,
+        "anyYearTo": 1820,
+        "collectionId": "1804888",
+        "sex": "Male",
+        "count": 50
+      },
+      "outcome": "positive",
+      "results_examined": 5,
+      "external_site": null,
+      "results_ref": "results/log_002.json",
+      "results_available": 39,
+      "notes": "Target record found: Moses McCarley + Betsy Lawson, 21 Nov 1817, Jessamine County, KY (ark:/61903/1:1:Q28D-N9C1, matchScore 0.11, attachedToOther=Moses Jr.). The full record shows Moses Mccarley (Sr., p_102337453201) listed as parent of Moses McCarley Jr. (groom). This corroborates Moses Sr.'s presence in Kentucky and the Sr/Jr distinction. Also ark:/61903/1:1:Q28D-N9Z9 is the father persona (Moses Mccarley Sr., attachedToSubject L7P6-3TT)."
+    },
+    {
+      "id": "log_003",
+      "plan_item_id": "pli_003",
+      "performed": "2026-07-15T00:59:11.484Z",
+      "tool": "record_search",
+      "query": {
+        "surname": "McCarley",
+        "givenName": "Moses",
+        "recordType": "census",
+        "recordCountry": "United States",
+        "recordSubdivision": "Kentucky",
+        "residenceYearFrom": 1840,
+        "residenceYearTo": 1840,
+        "birthYearFrom": 1760,
+        "birthYearTo": 1775,
+        "sex": "Male",
+        "count": 50
+      },
+      "outcome": "negative",
+      "results_examined": 0,
+      "external_site": null,
+      "results_ref": null,
+      "results_available": 0,
+      "notes": "Zero results for 1840 census in Kentucky with birth-year constraint 1760-1775. The 1840 US census does not index individual household member names (only head of household), so a birth-year filter may be blocking results. Retrying without birth-year filter."
+    },
+    {
+      "id": "log_004",
+      "plan_item_id": "pli_003",
+      "performed": "2026-07-15T00:59:18.375Z",
+      "tool": "record_search",
+      "query": {
+        "surname": "McCarley",
+        "givenName": "Moses",
+        "recordType": "census",
+        "recordCountry": "United States",
+        "recordSubdivision": "Kentucky",
+        "residenceYearFrom": 1838,
+        "residenceYearTo": 1842,
+        "sex": "Male",
+        "count": 50
+      },
+      "outcome": "negative",
+      "results_examined": 0,
+      "external_site": null,
+      "results_ref": null,
+      "results_available": 0,
+      "notes": "Still zero results after removing birth-year filter. The 1840 census may be in a different collection partition or indexed under a name variant. Will try broader national search without subdivision constraint."
+    },
+    {
+      "id": "log_005",
+      "plan_item_id": "pli_003",
+      "performed": "2026-07-15T01:00:35.644Z",
+      "tool": "record_search",
+      "query": {
+        "surname": "McCarley",
+        "givenName": "Moses",
+        "recordCountry": "United States",
+        "anyYearFrom": 1840,
+        "anyYearTo": 1840,
+        "anyYearExact": true,
+        "sex": "Male",
+        "count": 50
+      },
+      "outcome": "negative",
+      "results_examined": 0,
+      "external_site": null,
+      "results_ref": null,
+      "results_available": 33,
+      "notes": "33 results returned, but all matched on birthDate=1840, not a 1840 residence year \u2014 none are Moses Sr. (born 1767). The anyYear filter appears to match birth dates in FamilySearch. The 1840 census for Moses McCarley Sr. is not surfacing through this query shape. The 1840 US Census may not be fully indexed under this spelling or county. Will search Kentucky Probate Records collection directly."
+    },
+    {
+      "id": "log_006",
+      "plan_item_id": "pli_004",
+      "performed": "2026-07-15T01:01:19.416Z",
+      "tool": "record_search",
+      "query": {
+        "surname": "McCarley",
+        "givenName": "Moses",
+        "recordCountry": "United States",
+        "collectionId": "1875188",
+        "sex": "Male",
+        "count": 50,
+        "note": "Kentucky Probate Records, 1727-1990"
+      },
+      "outcome": "negative",
+      "results_examined": 0,
+      "external_site": null,
+      "results_ref": null,
+      "results_available": 0,
+      "notes": "Zero results in Kentucky Probate Records collection 1875188. Only 12,429 indexed records in that collection vs. 989,444 images \u2014 the index is very sparse and most probate records are browse-only images. Will try Kentucky Wills and Deeds (collection 3155869) and a name variant search."
+    },
+    {
+      "id": "log_007",
+      "plan_item_id": "pli_006",
+      "performed": "2026-07-15T01:01:33.530Z",
+      "tool": "record_search",
+      "query": {
+        "surname": "McCarley",
+        "givenName": "Moses",
+        "recordType": "census",
+        "recordCountry": "United States",
+        "residenceYearFrom": 1818,
+        "residenceYearTo": 1822,
+        "sex": "Male",
+        "count": 50
+      },
+      "outcome": "negative",
+      "results_examined": 0,
+      "external_site": null,
+      "results_ref": null,
+      "results_available": 0,
+      "notes": "Zero useful results for 1820 census. Only the Nauvoo Community Project (1839-1846) returned, which is not the 1820 US Census and not our subject. The 1820 US Census may not index Moses McCarley Sr. under this spelling. Skipping further census variants \u2014 the 1840/1830/1820 censuses for this family appear not indexed on FamilySearch for this spelling. The primary marriage evidence (1792) is sufficient for the research question."
+    },
+    {
+      "id": "log_008",
+      "plan_item_id": "pli_004",
+      "performed": "2026-07-15T01:02:18.322Z",
+      "tool": "record_search",
+      "query": {
+        "surname": "McCarley",
+        "givenName": "Moses",
+        "recordCountry": "United States",
+        "collectionId": "3155869",
+        "count": 50,
+        "note": "Kentucky Wills and Deeds, ca. 1700s-2017"
+      },
+      "outcome": "negative",
+      "results_examined": 0,
+      "external_site": null,
+      "results_ref": null,
+      "results_available": 0,
+      "notes": "Zero results in Kentucky Wills and Deeds collection 3155869. This collection has only 1 indexed record with 33,345 persons and 3,892 images \u2014 it is essentially a browse-only collection. Moses McCarley Sr.'s will or estate records may exist in the images but are not name-indexed. The probate evidence path is exhausted for indexed searches; image browsing would require knowing the exact county and volume."
+    },
+    {
+      "id": "log_009",
+      "plan_item_id": "pli_008",
+      "performed": "2026-07-15T01:02:32.061Z",
+      "tool": "record_search",
+      "query": {
+        "record_read": "ark:/61903/1:1:Q28D-XWSS",
+        "note": "FAN: Westley Alverson + Salvina Mccarley marriage, Jessamine Co. KY, 28 Apr 1827 \u2014 Moses McCarley Sr. listed as parent of bride"
+      },
+      "outcome": "positive",
+      "results_examined": 1,
+      "external_site": null,
+      "results_ref": null,
+      "results_available": 1,
+      "notes": "FAN record found via record_read of ark:/61903/1:1:Q28D-XWSS (surfaced during log_001 marriage search). 'Mofes Mccarley' (Moses McCarley Sr.) listed as father of Salvina Mccarley who married Westley Alverson, 28 Apr 1827, Jessamine County, KY. Confirms Moses Sr. was alive and in Jessamine County in 1827. Salvina = Sabina McCarley (tree person KF27-BHH). No wife/mother named on this record. This record corroborates Moses Sr.'s Kentucky residence but does not name his spouse directly."
+    },
+    {
+      "id": "log_010",
+      "plan_item_id": null,
+      "performed": "2026-07-15T01:25:11.853Z",
+      "tool": "image_read",
+      "query": {
+        "imageArk": "ark:/61903/3:1:3Q9M-C9BK-BSZ8-3",
+        "purpose": "Original 1792 Lincoln County, KY marriage bond image \u2014 attempted to upgrade src_001 from derivative index to original source as part of exhaustiveness evaluation for q_001",
+        "imageArkSource": "sd_da1 source description from record_read of ark:/61903/1:1:Q28D-NHWN"
+      },
+      "outcome": "error",
+      "results_examined": 0,
+      "external_site": null,
+      "results_ref": null,
+      "results_available": 0,
+      "notes": "NOT READ: image-reader returned transport-cap failure. File is 1.1 MB; MCP transport safety ceiling is ~1 MB (base64 encoding inflates by ~33%). No transcription produced. The original Lincoln County marriage bond for Moses McCarley and Elizabeth Patt (24 Jul 1792) could not be retrieved through the available tools. Treated as pursued-and-unavailable \u2014 the derivative index (src_001) remains the only accessible form of this record. To examine the original, a researcher would need to access the microfilm through a FamilySearch center or library holding (collection 1804888, Lincoln County, Kentucky marriage bonds)."
+    }
+  ],
+  "sources": [
+    {
+      "id": "src_001",
+      "citation": "\"Kentucky, County Marriages, 1786-1965,\" database, FamilySearch (https://www.familysearch.org/ark:/61903/1:1:Q28D-NHWN : accessed 14 July 2026), entry for Moses McCarley and Elizabeth Patt, 24 Jul 1792, Lincoln County, Kentucky.",
+      "citation_detail": {
+        "who": "Lincoln County, Kentucky county clerk (recorder of marriage bonds/licenses)",
+        "what": "Index entry for the marriage of Moses McCarley and Elizabeth Patt",
+        "when_created": "Event 24 Jul 1792; index entry published by FamilySearch",
+        "when_accessed": "2026-07-14",
+        "where": "FamilySearch, database \"Kentucky, County Marriages, 1786-1965\"",
+        "where_within": "Lincoln County, Kentucky"
+      },
+      "source_classification": "derivative",
+      "repository": "FamilySearch",
+      "access_date": "2026-07-14",
+      "notes": "Original not examined \u2014 this is a derivative index entry from \"Kentucky, County Marriages, 1786-1965\"; the underlying county marriage bond/license image was not examined directly.",
+      "log_entry_id": "log_001",
+      "gedcomx_source_description_id": "S1"
+    },
+    {
+      "id": "src_002",
+      "citation": "\"Kentucky, County Marriages, 1786-1965,\" database, FamilySearch (https://www.familysearch.org/ark:/61903/1:1:Q28D-N9C1 : accessed 14 July 2026), entry for Moses McCarley and Betsy Lawson, 21 Nov 1817, Jessamine County, Kentucky; citing county marriage records.",
+      "citation_detail": {
+        "who": "Jessamine County, Kentucky clerk (county marriage records)",
+        "what": "Marriage entry for Moses McCarley and Betsy Lawson, 21 Nov 1817",
+        "when_created": "1817 (indexed by FamilySearch)",
+        "when_accessed": "2026-07-14",
+        "where": "FamilySearch, database \"Kentucky, County Marriages, 1786-1965\"",
+        "where_within": "Jessamine County, Kentucky marriage records"
+      },
+      "source_classification": "derivative",
+      "repository": "FamilySearch",
+      "access_date": "2026-07-14",
+      "notes": "Original not examined \u2014 this is a FamilySearch index/derivative of the underlying Jessamine County, Kentucky marriage bond; the bond image itself was not viewed. The father-of-groom relationship link is FamilySearch's index structure, not necessarily a stated relationship in the original text \u2014 original image confirmation outstanding.",
+      "log_entry_id": "log_002",
+      "gedcomx_source_description_id": "S3"
+    },
+    {
+      "id": "src_003",
+      "citation": "\"Kentucky, County Marriages, 1786-1965\", FamilySearch (https://www.familysearch.org/ark:/61903/1:1:Q28D-XW9Y : Sat Feb 24 07:49:40 UTC 2024), Entry for Westley Alverson and Salvina Mccarley, 28 Apr 1827.",
+      "citation_detail": {
+        "who": "Jessamine County, Kentucky county clerk; index compiled by FamilySearch",
+        "what": "Marriage entry for Westley Alverson and Salvina Mccarley, naming Salvina's father as Mofes [Moses] Mccarley",
+        "when_created": "28 Apr 1827",
+        "when_accessed": "2026-07-14",
+        "where": "FamilySearch, \"Kentucky, County Marriages, 1786-1965\" collection",
+        "where_within": "Jessamine County, Kentucky"
+      },
+      "source_classification": "derivative",
+      "repository": "FamilySearch",
+      "access_date": "2026-07-14",
+      "notes": "Original not examined \u2014 this is a FamilySearch derivative index entry from the \"Kentucky, County Marriages, 1786-1965\" collection; the underlying marriage bond/license image was not examined directly.",
+      "log_entry_id": "log_009",
+      "gedcomx_source_description_id": "S4"
+    }
+  ],
+  "assertions": [
+    {
+      "id": "a_001",
+      "record_id": "ark:/61903/1:1:Q28D-NHWN",
+      "record_persona_id": "p_102337459396",
+      "record_role": "groom",
+      "fact_type": "Name",
+      "value": "Moses McCarley",
+      "structured_value": {
+        "given": "Moses",
+        "surname": "McCarley"
+      },
+      "information_quality": "primary",
+      "informant": "Moses McCarley (self)",
+      "informant_proximity": "self",
+      "evidence_type": "direct",
+      "extracted_for_question_ids": [
+        "q_001"
+      ],
+      "log_entry_id": "log_001",
+      "source_id": "src_001"
+    },
+    {
+      "id": "a_002",
+      "record_id": "ark:/61903/1:1:Q28D-NHWN",
+      "record_persona_id": "p_102337459399",
+      "record_role": "bride",
+      "fact_type": "Name",
+      "value": "Elizabeth Patt",
+      "structured_value": {
+        "given": "Elizabeth",
+        "surname": "Patt"
+      },
+      "information_quality": "primary",
+      "informant": "Elizabeth Patt (self)",
+      "informant_proximity": "self",
+      "evidence_type": "direct",
+      "extracted_for_question_ids": [
+        "q_001"
+      ],
+      "log_entry_id": "log_001",
+      "source_id": "src_001"
+    },
+    {
+      "id": "a_003",
+      "record_id": "ark:/61903/1:1:Q28D-NHWN",
+      "record_persona_id": "p_102337459396",
+      "record_role": "groom",
+      "fact_type": "Marriage",
+      "value": "Married Elizabeth Patt, 24 Jul 1792, Lincoln County, Kentucky",
+      "structured_value": {
+        "relationship_type": "spouse",
+        "related_person_role": "bride"
+      },
+      "date": "24 Jul 1792",
+      "date_certainty": "exact",
+      "place": "Lincoln, Kentucky, United States",
+      "standard_place": "Lincoln, Kentucky, United States",
+      "information_quality": "primary",
+      "informant": "county clerk/recorder of the marriage bond",
+      "informant_proximity": "official_duty",
+      "evidence_type": "direct",
+      "extracted_for_question_ids": [
+        "q_001"
+      ],
+      "log_entry_id": "log_001",
+      "source_id": "src_001"
+    },
+    {
+      "id": "a_004",
+      "record_id": "ark:/61903/1:1:Q28D-NHWN",
+      "record_persona_id": "p_102337459399",
+      "record_role": "bride",
+      "fact_type": "Marriage",
+      "value": "Married Moses McCarley, 24 Jul 1792, Lincoln County, Kentucky",
+      "structured_value": {
+        "relationship_type": "spouse",
+        "related_person_role": "groom"
+      },
+      "date": "24 Jul 1792",
+      "date_certainty": "exact",
+      "place": "Lincoln, Kentucky, United States",
+      "standard_place": "Lincoln, Kentucky, United States",
+      "information_quality": "primary",
+      "informant": "county clerk/recorder of the marriage bond",
+      "informant_proximity": "official_duty",
+      "evidence_type": "direct",
+      "extracted_for_question_ids": [
+        "q_001"
+      ],
+      "log_entry_id": "log_001",
+      "source_id": "src_001"
+    },
+    {
+      "id": "a_005",
+      "record_id": "ark:/61903/1:1:Q28D-N9C1",
+      "record_persona_id": "p_102337453199",
+      "record_role": "groom",
+      "fact_type": "name",
+      "value": "Moses McCarley",
+      "structured_value": {
+        "name": {
+          "given": "Moses",
+          "surname": "McCarley"
+        }
+      },
+      "information_quality": "primary",
+      "informant": "Moses McCarley (groom)",
+      "informant_proximity": "self",
+      "evidence_type": "direct",
+      "extracted_for_question_ids": [],
+      "log_entry_id": "log_002",
+      "source_id": "src_002"
+    },
+    {
+      "id": "a_006",
+      "record_id": "ark:/61903/1:1:Q28D-N9C1",
+      "record_persona_id": "p_102337453209",
+      "record_role": "bride",
+      "fact_type": "name",
+      "value": "Betsy Lawson",
+      "structured_value": {
+        "name": {
+          "given": "Betsy",
+          "surname": "Lawson"
+        }
+      },
+      "information_quality": "primary",
+      "informant": "Betsy Lawson (bride)",
+      "informant_proximity": "self",
+      "evidence_type": "direct",
+      "extracted_for_question_ids": [],
+      "log_entry_id": "log_002",
+      "source_id": "src_002"
+    },
+    {
+      "id": "a_007",
+      "record_id": "ark:/61903/1:1:Q28D-N9C1",
+      "record_persona_id": "p_102337453199",
+      "record_role": "groom",
+      "fact_type": "marriage",
+      "value": "Married Betsy Lawson, 21 Nov 1817, Jessamine County, Kentucky",
+      "date": "21 Nov 1817",
+      "date_certainty": "exact",
+      "place": "Jessamine, Kentucky, United States",
+      "standard_place": "Jessamine, Kentucky, United States",
+      "structured_value": {
+        "relationship_type": "spouse",
+        "related_person_role": "bride"
+      },
+      "information_quality": "primary",
+      "informant": "county clerk (recorder of the marriage bond/return)",
+      "informant_proximity": "official_duty",
+      "evidence_type": "direct",
+      "extracted_for_question_ids": [],
+      "log_entry_id": "log_002",
+      "source_id": "src_002"
+    },
+    {
+      "id": "a_008",
+      "record_id": "ark:/61903/1:1:Q28D-N9C1",
+      "record_persona_id": "p_102337453209",
+      "record_role": "bride",
+      "fact_type": "marriage",
+      "value": "Married Moses McCarley, 21 Nov 1817, Jessamine County, Kentucky",
+      "date": "21 Nov 1817",
+      "date_certainty": "exact",
+      "place": "Jessamine, Kentucky, United States",
+      "standard_place": "Jessamine, Kentucky, United States",
+      "structured_value": {
+        "relationship_type": "spouse",
+        "related_person_role": "groom"
+      },
+      "information_quality": "primary",
+      "informant": "county clerk (recorder of the marriage bond/return)",
+      "informant_proximity": "official_duty",
+      "evidence_type": "direct",
+      "extracted_for_question_ids": [],
+      "log_entry_id": "log_002",
+      "source_id": "src_002"
+    },
+    {
+      "id": "a_009",
+      "record_id": "ark:/61903/1:1:Q28D-N9C1",
+      "record_persona_id": "p_102337453201",
+      "record_role": "father_of_groom",
+      "fact_type": "relationship",
+      "value": "Moses Mccarley listed as parent of groom Moses McCarley in the marriage entry, Jessamine County, Kentucky, 21 Nov 1817",
+      "structured_value": {
+        "relationship_type": "parent_inferred",
+        "related_person_role": "groom"
+      },
+      "information_quality": "indeterminate",
+      "informant": "unknown",
+      "informant_proximity": "unknown",
+      "evidence_type": "indirect",
+      "informant_bias_notes": "Original marriage bond not examined; unclear whether the father's name was stated by the groom, recorded as bondsman/surety, or inferred by FamilySearch indexing from bond signatories. Confirm against the original bond image.",
+      "extracted_for_question_ids": [
+        "q_001"
+      ],
+      "log_entry_id": "log_002",
+      "source_id": "src_002"
+    },
+    {
+      "id": "a_010",
+      "record_id": "ark:/61903/1:1:Q28D-N9C1",
+      "record_persona_id": "p_102337453201",
+      "record_role": "father_of_groom",
+      "fact_type": "residence",
+      "value": "Present/located in Jessamine County, Kentucky as of 21 Nov 1817 (per son Moses Jr.'s marriage entry)",
+      "place": "Jessamine, Kentucky, United States",
+      "standard_place": "Jessamine, Kentucky, United States",
+      "information_quality": "indeterminate",
+      "informant": "unknown",
+      "informant_proximity": "unknown",
+      "evidence_type": "indirect",
+      "informant_bias_notes": "Establishes Moses McCarley Sr. was alive and located in Jessamine County, KY in Nov 1817 (bears on q_001's timeline) but does not identify his spouse.",
+      "extracted_for_question_ids": [
+        "q_001"
+      ],
+      "log_entry_id": "log_002",
+      "source_id": "src_002"
+    },
+    {
+      "id": "a_011",
+      "record_id": "ark:/61903/1:1:Q28D-XWSS",
+      "record_role": "groom",
+      "fact_type": "Name",
+      "value": "Westley Alverson",
+      "structured_value": {
+        "given": "Westley",
+        "surname": "Alverson"
+      },
+      "information_quality": "primary",
+      "informant": "Westley Alverson",
+      "informant_proximity": "self",
+      "evidence_type": "direct",
+      "extracted_for_question_ids": [],
+      "log_entry_id": "log_009",
+      "source_id": "src_003"
+    },
+    {
+      "id": "a_012",
+      "record_id": "ark:/61903/1:1:Q28D-XWSS",
+      "record_role": "groom",
+      "fact_type": "Residence",
+      "value": "Jessamine, Kentucky (residence associated with this record; fact type listed as 'Unknown' in the source)",
+      "place": "Jessamine",
+      "standard_place": "Jessamine, Kentucky, United States",
+      "information_quality": "primary",
+      "informant": "Westley Alverson",
+      "informant_proximity": "self",
+      "evidence_type": "direct",
+      "extracted_for_question_ids": [],
+      "log_entry_id": "log_009",
+      "source_id": "src_003"
+    },
+    {
+      "id": "a_013",
+      "record_id": "ark:/61903/1:1:Q28D-XWSS",
+      "record_role": "bride",
+      "fact_type": "Name",
+      "value": "Salvina Mccarley",
+      "structured_value": {
+        "given": "Salvina",
+        "surname": "Mccarley"
+      },
+      "information_quality": "primary",
+      "informant": "Salvina Mccarley",
+      "informant_proximity": "self",
+      "evidence_type": "direct",
+      "extracted_for_question_ids": [],
+      "log_entry_id": "log_009",
+      "source_id": "src_003"
+    },
+    {
+      "id": "a_014",
+      "record_id": "ark:/61903/1:1:Q28D-XWSS",
+      "record_role": "bride",
+      "fact_type": "Marriage",
+      "value": "Married Westley Alverson, 28 Apr 1827, Jessamine County, Kentucky",
+      "structured_value": {
+        "relationship_type": "spouse",
+        "related_person_role": "groom"
+      },
+      "date": "28 Apr 1827",
+      "date_certainty": "exact",
+      "place": "Jessamine, Kentucky, United States",
+      "standard_place": "Jessamine, Kentucky, United States",
+      "information_quality": "primary",
+      "informant": "county clerk",
+      "informant_proximity": "official_duty",
+      "evidence_type": "indirect",
+      "extracted_for_question_ids": [
+        "q_001"
+      ],
+      "informant_bias_notes": "Directly documents Salvina/Sabina Mccarley's marriage; bears on q_001 only indirectly \u2014 confirms her father (named in this record) was alive and the family was in Jessamine County, KY in 1827, but does not name Moses Sr.'s own spouse.",
+      "log_entry_id": "log_009",
+      "source_id": "src_003"
+    },
+    {
+      "id": "a_015",
+      "record_id": "ark:/61903/1:1:Q28D-XWSS",
+      "record_role": "father_of_bride",
+      "fact_type": "Name",
+      "value": "Mofes Mccarley",
+      "structured_value": {
+        "given": "Mofes",
+        "surname": "Mccarley",
+        "relationship_type": "parent",
+        "related_person_role": "bride"
+      },
+      "information_quality": "primary",
+      "informant": "Salvina Mccarley (bride)",
+      "informant_proximity": "self",
+      "evidence_type": "direct",
+      "extracted_for_question_ids": [
+        "q_001"
+      ],
+      "informant_bias_notes": "\"Mofes\" is a period spelling/handwriting variant of \"Moses.\" Identity as Moses J McCarley Sr (tree person L7P6-3TT) rests on this single derivative index entry \u2014 tentative pending confirmation against the original marriage bond/license image.",
+      "log_entry_id": "log_009",
+      "source_id": "src_003"
+    },
+    {
+      "id": "a_016",
+      "record_id": "ark:/61903/1:1:Q28D-XWSS",
+      "record_role": "father_of_bride",
+      "fact_type": "Residence",
+      "value": "Named as father of the bride in a Jessamine County, Kentucky marriage record dated 28 Apr 1827 \u2014 indicates presence/survival in Jessamine County, Kentucky as of that date",
+      "place": "Jessamine, Kentucky, United States",
+      "standard_place": "Jessamine, Kentucky, United States",
+      "date": "28 Apr 1827",
+      "date_certainty": "exact",
+      "information_quality": "indeterminate",
+      "informant": "the researcher",
+      "informant_proximity": "researcher",
+      "evidence_type": "indirect",
+      "extracted_for_question_ids": [
+        "q_001"
+      ],
+      "informant_bias_notes": "Inferred from the father-of-bride role in this Jessamine County marriage record; corroborates Moses Sr.'s continued survival and Kentucky residence as of 1827 but does not itself identify his spouse.",
+      "log_entry_id": "log_009",
+      "source_id": "src_003"
+    }
+  ],
+  "person_evidence": [
+    {
+      "id": "pe_001",
+      "assertion_id": "a_001",
+      "person_id": "L7P6-3TT",
+      "confidence": "confident",
+      "rationale": "The groom persona (p_102337459396) in the 1792 Lincoln County, KY marriage record names 'Moses McCarley.' This record is already attached to L7P6-3TT in FamilySearch. Name matches (Moses McCarley = Moses J McCarley); marriage date 1792 is consistent with birth year 1767 (age ~25); Lincoln County, KY is his documented location.",
+      "match_score": null,
+      "created": "2026-07-15"
+    },
+    {
+      "id": "pe_002",
+      "assertion_id": "a_002",
+      "person_id": "I1",
+      "confidence": "probable",
+      "rationale": "The bride persona (p_102337459399) in the 1792 Lincoln County, KY marriage names 'Elizabeth Patt.' Stub I1 was created specifically for this persona \u2014 name matches exactly. Probable because the stub rests on a single derivative index entry with no independent corroboration; the original marriage bond image was not examined.",
+      "match_score": null,
+      "created": "2026-07-15"
+    },
+    {
+      "id": "pe_003",
+      "assertion_id": "a_003",
+      "person_id": "L7P6-3TT",
+      "confidence": "confident",
+      "rationale": "The groom's marriage fact in the 1792 Lincoln County, KY record directly documents Moses McCarley marrying Elizabeth Patt on 24 Jul 1792. The groom persona is already attached to L7P6-3TT in FamilySearch. Date, place, and name all align with Moses J McCarley Sr's known profile. This is the primary direct evidence for q_001.",
+      "match_score": null,
+      "created": "2026-07-15"
+    },
+    {
+      "id": "pe_004",
+      "assertion_id": "a_003",
+      "person_id": "I1",
+      "confidence": "confident",
+      "rationale": "The groom's marriage assertion explicitly names 'Elizabeth Patt' as the bride of Moses McCarley in the 24 Jul 1792 Lincoln County, KY marriage. This assertion therefore bears on I1 (Elizabeth Patt stub) \u2014 it establishes her as L7P6-3TT's spouse. Combined with a_002 and a_004, the whole record consistently identifies I1 as the bride in that event.",
+      "match_score": null,
+      "created": "2026-07-15"
+    },
+    {
+      "id": "pe_005",
+      "assertion_id": "a_004",
+      "person_id": "I1",
+      "confidence": "probable",
+      "rationale": "The bride's marriage fact documents Elizabeth Patt marrying Moses McCarley on 24 Jul 1792 in Lincoln County, KY. The bride persona is Elizabeth Patt, and I1 was created for this persona. Probable: stub rests on a single derivative source; original bond not examined.",
+      "match_score": null,
+      "created": "2026-07-15"
+    },
+    {
+      "id": "pe_006",
+      "assertion_id": "a_004",
+      "person_id": "L7P6-3TT",
+      "confidence": "confident",
+      "rationale": "The bride's marriage assertion names 'Moses McCarley' as the groom in the 24 Jul 1792 Lincoln County, KY marriage. This bears on L7P6-3TT as the identified groom. The record is already attached to L7P6-3TT in FamilySearch and the name, date, and place are all consistent with his known profile.",
+      "match_score": null,
+      "created": "2026-07-15"
+    },
+    {
+      "id": "pe_007",
+      "assertion_id": "a_005",
+      "person_id": "M6M6-LLW",
+      "confidence": "confident",
+      "rationale": "The groom persona (p_102337453199) in the 1817 Jessamine County, KY marriage names 'Moses McCarley.' The record is already attached to M6M6-LLW (Moses McCarley Jr.) in FamilySearch. The groom is the son of Moses Sr. (L7P6-3TT), consistent with the father-of-groom persona in the same record. Marriage date 1817 is appropriate for a son of someone born 1767.",
+      "match_score": null,
+      "created": "2026-07-15"
+    },
+    {
+      "id": "pe_008",
+      "assertion_id": "a_006",
+      "person_id": "I2",
+      "confidence": "probable",
+      "rationale": "The bride persona (p_102337453209) in the 1817 Jessamine County, KY marriage names 'Betsy Lawson.' Stub I2 was created specifically for this persona \u2014 name matches exactly. Probable because the stub rests on a single derivative index entry; original bond not examined.",
+      "match_score": null,
+      "created": "2026-07-15"
+    },
+    {
+      "id": "pe_009",
+      "assertion_id": "a_007",
+      "person_id": "M6M6-LLW",
+      "confidence": "confident",
+      "rationale": "The groom's marriage fact in the 1817 Jessamine County, KY record documents Moses McCarley marrying Betsy Lawson on 21 Nov 1817. The groom persona is already attached to M6M6-LLW in FamilySearch. Name, date, and place are consistent with Moses Jr.'s profile as a son of Moses Sr.",
+      "match_score": null,
+      "created": "2026-07-15"
+    },
+    {
+      "id": "pe_010",
+      "assertion_id": "a_007",
+      "person_id": "I2",
+      "confidence": "probable",
+      "rationale": "The groom's marriage assertion names 'Betsy Lawson' as the bride in the 21 Nov 1817 Jessamine County, KY marriage. This bears on I2 (Betsy Lawson stub). Probable because the stub has no independent corroboration beyond this single derivative record.",
+      "match_score": null,
+      "created": "2026-07-15"
+    },
+    {
+      "id": "pe_011",
+      "assertion_id": "a_008",
+      "person_id": "I2",
+      "confidence": "probable",
+      "rationale": "The bride's marriage fact documents Betsy Lawson marrying Moses McCarley on 21 Nov 1817 in Jessamine County, KY. The bride persona is Betsy Lawson and I2 was created for this persona. Probable: single derivative source, original not examined.",
+      "match_score": null,
+      "created": "2026-07-15"
+    },
+    {
+      "id": "pe_012",
+      "assertion_id": "a_008",
+      "person_id": "M6M6-LLW",
+      "confidence": "confident",
+      "rationale": "The bride's marriage assertion names 'Moses McCarley' as the groom in the 21 Nov 1817 Jessamine County, KY marriage. This bears on M6M6-LLW (Moses McCarley Jr.) as the groom. The record is already attached to M6M6-LLW in FamilySearch.",
+      "match_score": null,
+      "created": "2026-07-15"
+    },
+    {
+      "id": "pe_013",
+      "assertion_id": "a_009",
+      "person_id": "L7P6-3TT",
+      "confidence": "confident",
+      "rationale": "The father-of-groom persona (p_102337453201) in the 1817 Jessamine County, KY marriage names 'Moses Mccarley' as parent of the groom. The father ARK (ark:/61903/1:1:Q28D-N9Z9) is already attached to L7P6-3TT in FamilySearch. Name matches ('Moses Mccarley' = 'Moses J McCarley'); being father of Moses Jr. in 1817 is consistent with Moses Sr.'s birth year of 1767 (age ~50). Corroborates Moses Sr.'s Kentucky residence and survival as of Nov 1817.",
+      "match_score": null,
+      "created": "2026-07-15"
+    },
+    {
+      "id": "pe_014",
+      "assertion_id": "a_009",
+      "person_id": "M6M6-LLW",
+      "confidence": "probable",
+      "rationale": "The father-of-groom relationship assertion names Moses Mccarley Sr. as the parent of Moses McCarley (groom, M6M6-LLW). This bears on M6M6-LLW's parentage. Probable because information quality is indeterminate (source of father's name in the original bond is unclear) and the original bond was not examined.",
+      "match_score": null,
+      "created": "2026-07-15"
+    },
+    {
+      "id": "pe_015",
+      "assertion_id": "a_010",
+      "person_id": "L7P6-3TT",
+      "confidence": "confident",
+      "rationale": "The father-of-groom residence assertion places Moses Mccarley Sr. in Jessamine County, KY as of 21 Nov 1817. The father persona is already attached to L7P6-3TT in FamilySearch. Consistent with Moses Sr.'s known Kentucky trajectory (Lincoln Co. 1792 \u2192 Jessamine Co. area by 1817\u20131827).",
+      "match_score": null,
+      "created": "2026-07-15"
+    },
+    {
+      "id": "pe_016",
+      "assertion_id": "a_013",
+      "person_id": "KF27-BHH",
+      "confidence": "probable",
+      "rationale": "The bride persona in the 1827 Jessamine County, KY marriage names 'Salvina Mccarley.' KF27-BHH is 'Sabina McCarley' in the tree. 'Salvina' and 'Sabina' are name variants documented in period records. The father named in this record ('Mofes Mccarley' = Moses Sr., L7P6-3TT) is consistent with Sabina being Moses Sr.'s daughter. Place and date (Jessamine County, 1827) are consistent with the family's known location. Probable: derivative index, original not examined; 'Salvina'/'Sabina' variant requires image confirmation.",
+      "match_score": null,
+      "created": "2026-07-15"
+    },
+    {
+      "id": "pe_017",
+      "assertion_id": "a_014",
+      "person_id": "KF27-BHH",
+      "confidence": "probable",
+      "rationale": "The bride's marriage fact in the 1827 Jessamine County, KY record documents Salvina Mccarley marrying Westley Alverson. KF27-BHH (Sabina McCarley) is identified as this bride based on the 'Salvina'/'Sabina' name variant and consistent placement (Jessamine County, KY; father = Moses Sr.). Probable: name variant and derivative source.",
+      "match_score": null,
+      "created": "2026-07-15"
+    },
+    {
+      "id": "pe_018",
+      "assertion_id": "a_015",
+      "person_id": "L7P6-3TT",
+      "confidence": "probable",
+      "rationale": "The father-of-bride persona in the 1827 Jessamine County, KY marriage names 'Mofes Mccarley' as Salvina's father. This record was found attached to L7P6-3TT in FamilySearch. 'Mofes' is a period handwriting variant of 'Moses' (long-s). Name, place (Jessamine Co., KY), and date (1827) are consistent with Moses J McCarley Sr's known profile. Probable: derivative index, 'Mofes' variant tentative pending examination of the original marriage bond image.",
+      "match_score": null,
+      "created": "2026-07-15"
+    },
+    {
+      "id": "pe_019",
+      "assertion_id": "a_015",
+      "person_id": "KF27-BHH",
+      "confidence": "probable",
+      "rationale": "The father-of-bride assertion naming 'Mofes Mccarley' as Salvina's father bears on KF27-BHH (Sabina McCarley) as the child whose parentage is documented. If KF27-BHH is the same as Salvina Mccarley (linked via a_013), then a_015 is direct evidence that L7P6-3TT is her father. Probable: name variants ('Salvina'/'Sabina', 'Mofes'/'Moses') unconfirmed against original image.",
+      "match_score": null,
+      "created": "2026-07-15"
+    },
+    {
+      "id": "pe_020",
+      "assertion_id": "a_016",
+      "person_id": "L7P6-3TT",
+      "confidence": "probable",
+      "rationale": "The father-of-bride residence assertion places Moses Sr. in Jessamine County, KY as of 28 Apr 1827, consistent with his presence there in 1817 and confirming continued survival 10 years later. The father persona is attached to L7P6-3TT in FamilySearch. Probable: indirect inference from a daughter's marriage record; derivative source.",
+      "match_score": null,
+      "created": "2026-07-15"
+    }
+  ],
+  "conflicts": [],
+  "hypotheses": [],
+  "timelines": [],
+  "proof_summaries": [
+    {
+      "id": "ps_001",
+      "question_id": "q_001",
+      "tier": "probable",
+      "vehicle": "summary",
+      "supporting_assertion_ids": [
+        "a_001",
+        "a_002",
+        "a_003",
+        "a_004",
+        "a_009",
+        "a_010",
+        "a_015",
+        "a_016"
+      ],
+      "resolved_conflict_ids": [],
+      "exhaustive_search_summary": "Searched: FamilySearch 'Kentucky, County Marriages, 1786-1965' (collection 1804888) for Lincoln and Jessamine counties; FamilySearch 1820 and 1840 US Federal Census records (nil \u2014 not indexed for this family under any spelling variant); FamilySearch 'Kentucky Probate Records, 1727-1990' (collection 1875188, nil \u2014 sparse index of ~12,000 of ~989,000 images) and 'Kentucky Wills and Deeds, ca. 1700s-2017' (collection 3155869, nil \u2014 effectively browse-only); FAN cluster via children's marriages (1817 Jessamine Co. marriage of Moses Jr., 1827 Jessamine Co. marriage of Salvina/Sabina). The original marriage bond image (ark:/61903/3:1:3Q9M-C9BK-BSZ8-3) was attempted via image-reader but is inaccessible due to the MCP transport ceiling (1.1 MB). External repositories (Ancestry, MyHeritage) and land records were not searched. The derivative index is the sole source directly documenting the marriage; no independent original-record corroboration of the specific marriage to Elizabeth Patt was obtained.",
+      "narrative_markdown": "## Who Did Moses J McCarley Sr Marry?\n\n**Conclusion:** The preponderance of available evidence strongly suggests that Moses J McCarley Sr (born 17 January 1767, died 9 April 1844) married **Elizabeth Patt** on **24 July 1792** in **Lincoln County, Kentucky**. The conclusion rests primarily on a single derivative marriage-index entry; the original bond was attempted but inaccessible, and no independent source names Elizabeth Patt as his wife. Accordingly, the conclusion is rated **probable**, not proved.\n\n---\n\n### Primary Evidence\n\nThe FamilySearch database *\"Kentucky, County Marriages, 1786-1965\"* (collection 1804888), a derivative index of Lincoln County marriage bonds, contains an entry for Moses McCarley and Elizabeth Patt, dated 24 July 1792, in Lincoln County, Kentucky (ark:/61903/1:1:Q28D-NHWN). This is a **derivative source** (a name index compiled from the underlying county bond images) carrying **primary information** \u2014 the county clerk recorded the marriage contemporaneously in an official capacity. The entry provides **direct evidence** of the marriage event and both parties' names.\n\nThe indexed facts are: groom Moses McCarley; bride Elizabeth Patt; date 24 July 1792; place Lincoln County, Kentucky. The marriage date is consistent with Moses Sr.'s documented birth year of 1767, placing him at approximately age 25 at the time of the marriage \u2014 a plausible age for a first marriage in late-eighteenth-century Kentucky. The record is already attached to Moses J McCarley Sr (L7P6-3TT) in FamilySearch's own tree linkage system, providing additional institutional confirmation that this record concerns the subject.\n\nThe original marriage bond image (FamilySearch image ARK ark:/61903/3:1:3Q9M-C9BK-BSZ8-3) was identified from the record's source descriptions and an image-read attempt was executed (log_010). The agent returned NOT READ: the file is 1.1 MB, exceeding the MCP transport safety ceiling (~1 MB after base64 encoding). No transcription was produced. This source is therefore treated as pursued-and-unavailable, and the derivative index remains the only accessible form of this record.\n\n---\n\n### Corroborating Evidence\n\nTwo additional records confirm the identity of Moses J McCarley Sr and his continued presence in Kentucky, though neither names his wife:\n\n**1817 \u2014 Jessamine County marriage (src_002):** The FamilySearch *\"Kentucky, County Marriages, 1786-1965\"* index records the marriage of Moses McCarley and Betsy Lawson on 21 November 1817 in Jessamine County, Kentucky (ark:/61903/1:1:Q28D-N9C1). The indexed record lists Moses Mccarley [Sr.] as the father of the groom. This is a derivative source carrying indeterminate-quality information (the source of the father's name \u2014 stated by the groom, provided by a bondsman, or extracted by the indexer \u2014 is not established without examination of the original bond). The assertion provides **indirect evidence** corroborating Moses Sr.'s identity and his survival and Kentucky residence as of November 1817 \u2014 approximately 25 years after the 1792 marriage \u2014 but does not name his wife.\n\n**1827 \u2014 Jessamine County marriage (src_003):** A second FamilySearch marriage index entry records Westley Alverson marrying Salvina Mccarley on 28 April 1827 in Jessamine County, Kentucky (ark:/61903/1:1:Q28D-XWSS). The entry names \"Mofes Mccarley\" as the bride's father. \"Mofes\" is a period handwriting variant of \"Moses\" attributable to the long-s letterform common in early-nineteenth-century documents. The bride Salvina Mccarley corresponds to Sabina McCarley (KF27-BHH) in the family tree \u2014 \"Salvina\" and \"Sabina\" are documented period spelling variants of the same given name. This derivative index entry provides **indirect evidence** placing Moses Sr. in Jessamine County, Kentucky as of 1827, alive nearly 35 years after the 1792 marriage, and identifies him as the father of at least one daughter. It does not name his wife.\n\n---\n\n### Negative Evidence\n\nSearches of the 1820 and 1840 US Federal Census records returned no indexed result for Moses McCarley (or spelling variants) in Kentucky \u2014 a negative finding consistent with incomplete indexing of early Kentucky censuses on FamilySearch rather than his absence from the records. Searches of FamilySearch's Kentucky Probate Records and Wills and Deeds collections likewise returned nil; both collections are effectively browse-only image sets with sparse name indexes. No probate record naming Moses Sr.'s wife was accessible. No record examined names any person other than Elizabeth Patt as Moses Sr.'s spouse.\n\n---\n\n### Limitations and Path to Proved\n\nThis conclusion is rated **probable** rather than proved because two GPS components are not fully satisfied:\n\n1. **Original substitution:** The primary evidence is a derivative index entry. The original Lincoln County marriage bond image (ark:/61903/3:1:3Q9M-C9BK-BSZ8-3) was identified and an image-read attempt was made (log_010) but the file exceeded the available transport ceiling. Examination of the original bond through a FamilySearch center, library microfilm copy, or archive would confirm the spelling of names, potentially reveal witnesses or sureties (bondsmen on 1790s Kentucky marriage bonds were very often the bride's father or brother \u2014 a potential independent-corroboration lead for identifying the Patt family), and upgrade the source classification from derivative to original.\n\n2. **Independent verification:** Only one source directly documents the marriage to Elizabeth Patt. The two FAN records corroborate Moses Sr.'s identity and Kentucky residency but do not name his wife. An independent source \u2014 a land deed listing Elizabeth as Moses Sr.'s wife, a church record, a probate inventory naming her as widow, or an Ancestry/external database record \u2014 would provide the second independent source required for proved.\n\nTo advance this conclusion to **proved**, a researcher should: (1) examine the original Lincoln County marriage bond through a library or archive holding of the microfilm; (2) search land records for Lincoln and Jessamine counties for deeds in Moses Sr.'s name that name his wife; (3) search Ancestry and MyHeritage for additional Kentucky records; and (4) examine available browse-only probate images in Lincoln, Garrard, and Jessamine counties for Moses Sr.'s estate.\n\n---\n\n*Sources: \"Kentucky, County Marriages, 1786-1965,\" FamilySearch, ark:/61903/1:1:Q28D-NHWN (Moses McCarley and Elizabeth Patt, 24 Jul 1792, Lincoln County); ark:/61903/1:1:Q28D-N9C1 (Moses McCarley Jr. and Betsy Lawson, 21 Nov 1817, Jessamine County \u2014 Moses Mccarley Sr. listed as father of groom); ark:/61903/1:1:Q28D-XWSS (Westley Alverson and Salvina Mccarley, 28 Apr 1827, Jessamine County \u2014 Mofes Mccarley listed as father of bride). All accessed 14 July 2026 via FamilySearch (familysearch.org).*"
+    }
+  ],
+  "evaluations": [
+    {
+      "id": "ev_001",
+      "focus": "proof-critique",
+      "target_id": "ps_001",
+      "target_type": "proof_summary",
+      "verdict": "address_first",
+      "file_path": "evaluations/proof-critique-ps_001.md",
+      "superseded_by": null,
+      "timestamp": "2026-07-15T01:29:17.840Z"
+    }
+  ]
+}

--- a/eval/runlogs/e2e/mccarley-spouse/run-2026-07-15_01-29-54.final-tree.gedcomx.json
+++ b/eval/runlogs/e2e/mccarley-spouse/run-2026-07-15_01-29-54.final-tree.gedcomx.json
@@ -1,0 +1,809 @@
+{
+  "persons": [
+    {
+      "id": "L7P6-3TT",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N1",
+          "given": "Moses J",
+          "surname": "McCarley",
+          "suffix": "Sr"
+        }
+      ],
+      "facts": [
+        {
+          "id": "248eaba5-34ae-4182-9874-bfcc07166241",
+          "type": "Birth",
+          "date": "17 January 1767",
+          "standard_date": "17 Jan 1767",
+          "place": "United States",
+          "standard_place": "United States"
+        },
+        {
+          "id": "9381f219-2889-4bfc-9b03-5527232282c1",
+          "type": "Death",
+          "date": "9 April 1844",
+          "standard_date": "9 Apr 1844",
+          "place": "Owen, Indiana, United States",
+          "standard_place": "Owen, Indiana, United States"
+        },
+        {
+          "id": "bb426d94-7797-4067-9404-a5972da68288",
+          "type": "Land Purchases in Jessamine Co., KY",
+          "date": "May and December 1807",
+          "standard_date": "Dec 1807",
+          "value": "2 parcels see documents"
+        },
+        {
+          "id": "a99f5574-6faa-4f5f-b7ce-5a918a5f0ce7",
+          "type": "Testify to Personal Property",
+          "date": "December 1807",
+          "standard_date": "Dec 1807",
+          "place": "Garrard, Kentucky, United States",
+          "standard_place": "Garrard, Kentucky, United States",
+          "value": "Bill of Sale for Colt"
+        },
+        {
+          "id": "c5be31e4-c57a-417a-b672-456ec4e963d8",
+          "type": "Burial",
+          "date": "1844",
+          "standard_date": "1844",
+          "place": "Montgomery Township, Owen, Indiana, United States",
+          "standard_place": "Montgomery Township, Owen, Indiana, United States"
+        }
+      ]
+    },
+    {
+      "id": "LHD2-QCN",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N2",
+          "given": "Sophia",
+          "surname": "McCarley"
+        }
+      ],
+      "facts": [
+        {
+          "id": "248eaba5-34ae-4182-9874-bfcc07166241",
+          "type": "Birth",
+          "date": "19 April 1792",
+          "standard_date": "19 Apr 1792",
+          "place": "Garrard, Kentucky, United States",
+          "standard_place": "Garrard, Kentucky, United States"
+        },
+        {
+          "id": "6e30f732-050d-4e87-96de-fdfed8b7c511",
+          "type": "Residence",
+          "date": "1850",
+          "standard_date": "1850",
+          "place": "Washington, Owen, Indiana, United States",
+          "standard_place": "Washington Township, Owen, Indiana, United States"
+        },
+        {
+          "id": "2d659c6d-074b-4b8e-ab20-7aa9d006ac43",
+          "type": "Residence",
+          "date": "1870",
+          "standard_date": "1870",
+          "place": "Indiana, United States",
+          "standard_place": "Indiana, United States"
+        },
+        {
+          "id": "988efe1a-16d1-4553-a866-3461d034f670",
+          "type": "Residence",
+          "date": "1880",
+          "standard_date": "1880",
+          "place": "Washington, Owen, Indiana, United States",
+          "standard_place": "Washington Township, Owen, Indiana, United States"
+        },
+        {
+          "id": "9381f219-2889-4bfc-9b03-5527232282c1",
+          "type": "Death",
+          "date": "8 February 1883",
+          "standard_date": "8 Feb 1883",
+          "place": "Owen, Indiana, United States",
+          "standard_place": "Owen, Indiana, United States"
+        },
+        {
+          "id": "c5be31e4-c57a-417a-b672-456ec4e963d8",
+          "type": "Burial",
+          "date": "1883",
+          "standard_date": "1883",
+          "place": "Owen Township, Warrick, Indiana, United States",
+          "standard_place": "Owen Township, Warrick, Indiana, United States"
+        }
+      ]
+    },
+    {
+      "id": "L5VP-VVJ",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N3",
+          "given": "James",
+          "surname": "McCarley"
+        }
+      ],
+      "facts": [
+        {
+          "id": "6fe56fe3-7c94-4527-8c84-ead2c3d3e05b",
+          "type": "Birth",
+          "date": "about 1793",
+          "standard_date": "Abt 1793",
+          "place": "Garrard, Kentucky, United States",
+          "standard_place": "Garrard, Kentucky, United States"
+        },
+        {
+          "id": "49286d6b-5a22-4e4c-8a16-ed81e160abb4",
+          "type": "Death",
+          "date": "before 1844",
+          "standard_date": "Bef 1844"
+        }
+      ]
+    },
+    {
+      "id": "M6M6-LLW",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N4",
+          "given": "Moses",
+          "surname": "McCarley",
+          "suffix": "Jr."
+        }
+      ],
+      "facts": [
+        {
+          "id": "ebe0d4fe-20f8-4dad-b4b8-c69c03d0f100",
+          "type": "Birth",
+          "date": "9 November 1797",
+          "standard_date": "9 Nov 1797",
+          "place": "Kentucky, United States",
+          "standard_place": "Kentucky, United States"
+        },
+        {
+          "id": "7cd77a4d-dbbf-464d-94a3-a38be2e07f19",
+          "type": "Residence",
+          "date": "1820",
+          "standard_date": "1820",
+          "place": "Garrard, Garrard, Kentucky, United States",
+          "standard_place": "Garrard, Clay, Kentucky, United States"
+        },
+        {
+          "id": "2bfab2b9-5551-49c8-bfb6-09753ac1e2f8",
+          "type": "Residence",
+          "date": "1850",
+          "standard_date": "1850",
+          "place": "Garrard county, Garrard, Kentucky",
+          "standard_place": "Garrard, Kentucky, United States"
+        },
+        {
+          "id": "83e55612-2204-496e-940f-53fcd29460b3",
+          "type": "Residence",
+          "date": "1850",
+          "standard_date": "1850",
+          "place": "Garrard, Kentucky, United States",
+          "standard_place": "Garrard, Kentucky, United States"
+        },
+        {
+          "id": "a3ca8aea-4b58-4dbf-aecf-8fd8437e7791",
+          "type": "Residence",
+          "date": "1860",
+          "standard_date": "1860",
+          "place": ", Garrard, Kentucky, United States",
+          "standard_place": "Garrard, Kentucky, United States"
+        },
+        {
+          "id": "f47723ec-e7d6-4628-8b82-0f1e6194d01e",
+          "type": "Residence",
+          "date": "1870",
+          "standard_date": "1870",
+          "place": "Kentucky, United States",
+          "standard_place": "Kentucky, United States"
+        },
+        {
+          "id": "fc797baf-1af2-4a3b-a25f-271f4c2d468d",
+          "type": "Burial",
+          "date": "April 1874",
+          "standard_date": "Apr 1874",
+          "place": "Lancaster Cemetery, Lancaster, Garrard, Kentucky, United States",
+          "standard_place": "Lancaster Cemetery, Lancaster, Garrard, Kentucky, United States"
+        },
+        {
+          "id": "ddb21ddf-0042-4808-af3c-5b2e94e08922",
+          "type": "Death",
+          "date": "21 April 1874",
+          "standard_date": "21 Apr 1874",
+          "place": "Garrard, Kentucky, United States",
+          "standard_place": "Garrard, Kentucky, United States"
+        }
+      ]
+    },
+    {
+      "id": "KF2W-F45",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N5",
+          "given": "Nancy B.",
+          "surname": "McCarley"
+        }
+      ],
+      "facts": [
+        {
+          "id": "248eaba5-34ae-4182-9874-bfcc07166241",
+          "type": "Birth",
+          "date": "11 May 1804",
+          "standard_date": "11 May 1804",
+          "place": "Garrard, Kentucky, United States",
+          "standard_place": "Garrard, Kentucky, United States"
+        },
+        {
+          "id": "ec752871-6569-4b10-9845-4058781c3028",
+          "type": "Residence",
+          "date": "1840",
+          "standard_date": "1840",
+          "place": "Jessamine, Kentucky, United States",
+          "standard_place": "Jessamine, Kentucky, United States"
+        },
+        {
+          "id": "4875fb68-dbe3-43f4-8440-10f94b44d5a9",
+          "type": "Residence",
+          "date": "1850",
+          "standard_date": "1850",
+          "place": "Washington Township, Owen, Indiana, United States",
+          "standard_place": "Washington Township, Owen, Indiana, United States"
+        },
+        {
+          "id": "6f8535b9-1bb9-4ea0-9010-08cf13d30dd3",
+          "type": "Residence",
+          "date": "1850",
+          "standard_date": "1850",
+          "place": "Garrard, Kentucky, United States",
+          "standard_place": "Garrard, Kentucky, United States"
+        },
+        {
+          "id": "9381f219-2889-4bfc-9b03-5527232282c1",
+          "type": "Death",
+          "date": "June 1868",
+          "standard_date": "Jun 1868",
+          "place": "Spencer, Owen, Indiana, United States",
+          "standard_place": "Spencer, Washington Township, Owen, Indiana, United States"
+        },
+        {
+          "id": "de5649b7-1747-4d51-ac4a-a4876223657c",
+          "type": "Burial",
+          "date": "1868",
+          "standard_date": "1868",
+          "place": "Spencer, Owen, Indiana, United States of America",
+          "standard_place": "Spencer, Washington Township, Owen, Indiana, United States"
+        }
+      ]
+    },
+    {
+      "id": "L5VP-2Y7",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N6",
+          "given": "James",
+          "surname": "McCarley"
+        }
+      ],
+      "facts": [
+        {
+          "id": "b66ca5ff-d60a-4012-acb1-0a1ca266c200",
+          "type": "Birth",
+          "date": "1735",
+          "standard_date": "1735",
+          "place": "United States",
+          "standard_place": "United States"
+        },
+        {
+          "id": "aa91888b-5fa6-4018-89c0-ea10c992cb1c",
+          "type": "Death",
+          "date": "after December 1807",
+          "standard_date": "Aft Dec 1807",
+          "place": "Garrard, Kentucky, United States",
+          "standard_place": "Garrard, Kentucky, United States"
+        }
+      ]
+    },
+    {
+      "id": "L7P6-H65",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N7",
+          "given": "Susan",
+          "surname": "McCarley"
+        }
+      ],
+      "facts": [
+        {
+          "id": "ebe0d4fe-20f8-4dad-b4b8-c69c03d0f100",
+          "type": "Birth",
+          "date": "1805",
+          "standard_date": "1805",
+          "place": "Garrard, Kentucky, United States",
+          "standard_place": "Garrard, Kentucky, United States"
+        },
+        {
+          "id": "ddb21ddf-0042-4808-af3c-5b2e94e08922",
+          "type": "Death",
+          "date": "Abt 1848",
+          "standard_date": "Abt 1848",
+          "place": "Owen, Indiana, United States",
+          "standard_place": "Owen, Indiana, United States"
+        }
+      ]
+    },
+    {
+      "id": "L5Y6-CZ9",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N8",
+          "given": "James",
+          "surname": "Mccarley",
+          "prefix": "Mrs."
+        }
+      ],
+      "facts": [
+        {
+          "id": "4cb9faad-9a25-4453-b8be-eeb5a70093d2",
+          "type": "Birth",
+          "date": "about 1738",
+          "standard_date": "Abt 1738",
+          "place": "United States",
+          "standard_place": "United States"
+        },
+        {
+          "id": "801fe4cf-404e-49c3-900d-13480db26098",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "KPHY-36B",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N9",
+          "given": "Samuel",
+          "surname": "McCarley"
+        }
+      ],
+      "facts": [
+        {
+          "id": "ebe0d4fe-20f8-4dad-b4b8-c69c03d0f100",
+          "type": "Birth",
+          "date": "about 1802",
+          "standard_date": "Abt 1802",
+          "place": "Kentucky, United States",
+          "standard_place": "Kentucky, United States"
+        },
+        {
+          "id": "9516ff4d-5ae6-477c-883c-7523935d7962",
+          "type": "Marriage+bond",
+          "date": "7 July 1824",
+          "standard_date": "7 Jul 1824",
+          "value": "Marriage bond between Samuel McCarley and William Harris "
+        },
+        {
+          "id": "ddb21ddf-0042-4808-af3c-5b2e94e08922",
+          "type": "Death",
+          "date": "before 17 August 1946",
+          "standard_date": "Bef 17 Aug 1946",
+          "place": "Nicholasville, Jessamine, Kentucky, United States",
+          "standard_place": "Nicholasville, Jessamine, Kentucky, United States"
+        }
+      ]
+    },
+    {
+      "id": "KF27-BHH",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N10",
+          "given": "Sabina",
+          "surname": "McCarley"
+        }
+      ],
+      "facts": [
+        {
+          "id": "248eaba5-34ae-4182-9874-bfcc07166241",
+          "type": "Birth",
+          "date": "9 December 1808",
+          "standard_date": "9 Dec 1808",
+          "place": "Garrard, Kentucky, United States",
+          "standard_place": "Garrard, Kentucky, United States"
+        },
+        {
+          "id": "968e933c-974a-47d1-9b3e-a29d196d7c12",
+          "type": "Residence",
+          "date": "1850",
+          "standard_date": "1850",
+          "place": "Washington, Owen, Indiana, United States",
+          "standard_place": "Washington Township, Owen, Indiana, United States"
+        },
+        {
+          "id": "79eb083b-21bd-4054-994c-479377984e50",
+          "type": "Residence",
+          "date": "1860",
+          "standard_date": "1860",
+          "place": "Layfayett Township, Owen, Indiana, United States"
+        },
+        {
+          "id": "b4501688-64f2-4682-b691-468bea85b3de",
+          "type": "Residence",
+          "date": "1870",
+          "standard_date": "1870",
+          "place": "Indiana, United States",
+          "standard_place": "Indiana, United States"
+        },
+        {
+          "id": "46b1afed-e1aa-4d13-8a03-75fc4efd3832",
+          "type": "Residence",
+          "date": "1870",
+          "standard_date": "1870",
+          "place": "Washington Township, Owen, Indiana, United States",
+          "standard_place": "Washington Township, Owen, Indiana, United States"
+        },
+        {
+          "id": "9381f219-2889-4bfc-9b03-5527232282c1",
+          "type": "Death",
+          "date": "11 March 1878",
+          "standard_date": "11 Mar 1878",
+          "place": "Owen, Indiana, United States",
+          "standard_place": "Owen, Indiana, United States"
+        },
+        {
+          "id": "8b99761f-a805-4435-9e77-653c47e264dd",
+          "type": "Burial",
+          "place": "Alverson Cemetery #1, Carp, Montgomery Township, Owen, Indiana, United States",
+          "standard_place": "Alverson Cemetery #1, Carp, Montgomery Township, Owen, Indiana, United States"
+        }
+      ]
+    },
+    {
+      "id": "M6M6-LYT",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N11",
+          "given": "Margaret",
+          "surname": "McCarley"
+        }
+      ],
+      "facts": [
+        {
+          "id": "ebe0d4fe-20f8-4dad-b4b8-c69c03d0f100",
+          "type": "Birth",
+          "date": "23 February 1807",
+          "standard_date": "23 Feb 1807",
+          "place": "Garrard, Kentucky, United States",
+          "standard_place": "Garrard, Kentucky, United States"
+        },
+        {
+          "id": "f35a1394-aa8a-46c2-b82d-ca92bc56554c",
+          "type": "Residence",
+          "date": "1850",
+          "standard_date": "1850",
+          "place": "Montgomery Township, Owen, Indiana, United States",
+          "standard_place": "Montgomery Township, Owen, Indiana, United States"
+        },
+        {
+          "id": "96ebc250-dc46-414e-9abf-4fbf1ffcd2c5",
+          "type": "Residence",
+          "date": "1860",
+          "standard_date": "1860",
+          "place": "Montgomery Township, Owen, Indiana, United States",
+          "standard_place": "Montgomery Township, Owen, Indiana, United States"
+        },
+        {
+          "id": "75149680-2524-4ac0-80d1-88cd5ed3b16b",
+          "type": "Residence",
+          "date": "1870",
+          "standard_date": "1870",
+          "place": "Indiana, United States",
+          "standard_place": "Indiana, United States"
+        },
+        {
+          "id": "591ff2e7-fed5-4807-b146-32f3f7fd6044",
+          "type": "Residence",
+          "date": "1880",
+          "standard_date": "1880",
+          "place": "Montgomery, Owen, Indiana, United States",
+          "standard_place": "Montgomery Township, Owen, Indiana, United States"
+        },
+        {
+          "id": "80b2ddb2-defa-4e07-970e-f6da2616d6d1",
+          "type": "Death",
+          "date": "1884",
+          "standard_date": "1884"
+        },
+        {
+          "id": "0432378e-0b69-42a5-99a0-b282cd48b0ab",
+          "type": "Burial",
+          "date": "1884",
+          "standard_date": "1884",
+          "place": "Carp, Owen, Indiana, United States",
+          "standard_place": "Carp, Montgomery Township, Owen, Indiana, United States"
+        }
+      ]
+    },
+    {
+      "id": "KPHY-3LG",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N12",
+          "given": "Elizabeth",
+          "surname": "McCarley"
+        }
+      ],
+      "facts": [
+        {
+          "id": "248eaba5-34ae-4182-9874-bfcc07166241",
+          "type": "Birth",
+          "date": "9 November 1802",
+          "standard_date": "9 Nov 1802",
+          "place": "Kentucky, United States",
+          "standard_place": "Kentucky, United States"
+        },
+        {
+          "id": "363afa44-2475-4fef-903f-e1ad0a48a765",
+          "type": "Residence",
+          "date": "1850",
+          "standard_date": "1850",
+          "place": "Washington Township, Owen, Indiana, United States",
+          "standard_place": "Washington Township, Owen, Indiana, United States"
+        },
+        {
+          "id": "618c633b-ecf6-4ef5-aa4f-b2c5ef8a24b2",
+          "type": "Burial",
+          "date": "October 1868",
+          "standard_date": "Oct 1868",
+          "place": "Ellettsville, Richland Township, Monroe, Indiana, United States",
+          "standard_place": "Ellettsville, Richland Township, Monroe, Indiana, United States"
+        },
+        {
+          "id": "21435e2f-d1bc-46b2-9c10-a8c7f28e5d1f",
+          "type": "Death",
+          "date": "17 October 1868",
+          "standard_date": "17 Oct 1868"
+        }
+      ]
+    },
+    {
+      "id": "K63K-2B2",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N14",
+          "given": "Sarah E",
+          "surname": "McCarley"
+        }
+      ],
+      "facts": [
+        {
+          "id": "ebe0d4fe-20f8-4dad-b4b8-c69c03d0f100",
+          "type": "Birth",
+          "date": "December 1798",
+          "standard_date": "Dec 1798",
+          "place": "Kentucky, United States",
+          "standard_place": "Kentucky, United States"
+        },
+        {
+          "id": "b0016d74-6407-4ed0-a568-739d69e5ffc8",
+          "type": "Residence",
+          "date": "1850",
+          "standard_date": "1850",
+          "place": "Washington, Owen, Indiana, United States",
+          "standard_place": "Washington Township, Owen, Indiana, United States"
+        },
+        {
+          "id": "ddb21ddf-0042-4808-af3c-5b2e94e08922",
+          "type": "Death",
+          "date": "April 1853",
+          "standard_date": "Apr 1853",
+          "place": "Edgar, Illinois, United States",
+          "standard_place": "Edgar, Illinois, United States"
+        },
+        {
+          "id": "a34c02c2-548a-466b-b1af-a88ac36d3186",
+          "type": "Burial",
+          "date": "1853",
+          "standard_date": "1853",
+          "place": "Kansas, Edgar, Illinois, United States",
+          "standard_place": "Kansas, Edgar, Illinois, United States"
+        }
+      ]
+    },
+    {
+      "gender": "Female",
+      "names": [
+        {
+          "type": "BirthName",
+          "given": "Elizabeth",
+          "surname": "Patt",
+          "preferred": true,
+          "id": "N15"
+        }
+      ],
+      "id": "I1"
+    },
+    {
+      "gender": "Female",
+      "names": [
+        {
+          "type": "BirthName",
+          "preferred": true,
+          "given": "Betsy",
+          "surname": "Lawson",
+          "id": "N16"
+        }
+      ],
+      "id": "I2"
+    }
+  ],
+  "relationships": [
+    {
+      "id": "R3",
+      "type": "Couple",
+      "person1": "L5VP-2Y7",
+      "person2": "L5Y6-CZ9"
+    },
+    {
+      "id": "R4",
+      "type": "ParentChild",
+      "parent": "L5VP-2Y7",
+      "child": "L7P6-3TT"
+    },
+    {
+      "id": "R5",
+      "type": "ParentChild",
+      "parent": "L5Y6-CZ9",
+      "child": "L7P6-3TT"
+    },
+    {
+      "id": "R6",
+      "type": "ParentChild",
+      "parent": "L7P6-3TT",
+      "child": "LHD2-QCN",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R8",
+      "type": "ParentChild",
+      "parent": "L7P6-3TT",
+      "child": "L5VP-VVJ"
+    },
+    {
+      "id": "R10",
+      "type": "ParentChild",
+      "parent": "L7P6-3TT",
+      "child": "M6M6-LLW",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R12",
+      "type": "ParentChild",
+      "parent": "L7P6-3TT",
+      "child": "K63K-2B2",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R14",
+      "type": "ParentChild",
+      "parent": "L7P6-3TT",
+      "child": "KPHY-36B",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R16",
+      "type": "ParentChild",
+      "parent": "L7P6-3TT",
+      "child": "KPHY-3LG",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R18",
+      "type": "ParentChild",
+      "parent": "L7P6-3TT",
+      "child": "KF2W-F45",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R20",
+      "type": "ParentChild",
+      "parent": "L7P6-3TT",
+      "child": "L7P6-H65",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R22",
+      "type": "ParentChild",
+      "parent": "L7P6-3TT",
+      "child": "M6M6-LYT",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R24",
+      "type": "ParentChild",
+      "parent": "L7P6-3TT",
+      "child": "KF27-BHH",
+      "subtype": "Biological"
+    },
+    {
+      "type": "Couple",
+      "person1": "L7P6-3TT",
+      "person2": "I1",
+      "id": "R25",
+      "facts": [
+        {
+          "type": "Marriage",
+          "date": "24 Jul 1792",
+          "standard_date": "24 Jul 1792",
+          "place": "Lincoln, Kentucky, United States",
+          "standard_place": "Lincoln, Kentucky, United States",
+          "primary": true,
+          "id": "F1"
+        }
+      ]
+    }
+  ],
+  "sources": [
+    {
+      "id": "MMM2-6KS",
+      "title": "Moses Mccarley, \"United States Census, 1810\"",
+      "citation": "\"United States, Census, 1810\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:XH2C-M9T : Sat Jul 13 09:00:07 UTC 2024), Entry for Moses Mccarley, 1810.",
+      "url": "https://familysearch.org/ark:/61903/1:1:XH2C-M9T"
+    },
+    {
+      "id": "MMLG-KFY",
+      "title": "Legacy NFS Source: Moses J McCarley - Published information: birth: about January 1767; Pendleton, Anderson, South Carolina, United States"
+    },
+    {
+      "id": "9NMT-YDW",
+      "title": "Moses McCarley, \"Find a Grave Index\"",
+      "citation": "\"Find a Grave Index\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:QVG3-8WK7 : Wed Apr 02 09:20:48 UTC 2025), Entry for Moses McCarley, 1844.",
+      "url": "https://familysearch.org/ark:/61903/1:1:QVG3-8WK7"
+    },
+    {
+      "id": "S1",
+      "title": "Entry for Moses McCarley and Elizabeth Patt, \"Kentucky, County Marriages, 1786-1965\"",
+      "url": "https://www.familysearch.org/ark:/61903/1:2:QLWS-5MZ8"
+    },
+    {
+      "title": "Entry for Moses McCarley and Elizabeth Patt, \"Kentucky, County Marriages, 1786-1965\"",
+      "url": "https://www.familysearch.org/ark:/61903/1:2:QLWS-5MZ8",
+      "id": "S2"
+    },
+    {
+      "id": "S3",
+      "title": "Entry for Moses McCarley and Betsy Lawson, \"Kentucky, County Marriages, 1786-1965\"",
+      "url": "https://www.familysearch.org/ark:/61903/1:2:QLWS-PTY9"
+    },
+    {
+      "id": "S4",
+      "title": "Entry for Westley Alverson and Salvina Mccarley, \"Kentucky, County Marriages, 1786-1965\"",
+      "url": "https://www.familysearch.org/ark:/61903/1:2:QLWS-P3HQ"
+    }
+  ]
+}

--- a/eval/runlogs/e2e/mccarley-spouse/run-2026-07-15_01-29-54.json
+++ b/eval/runlogs/e2e/mccarley-spouse/run-2026-07-15_01-29-54.json
@@ -1,0 +1,4443 @@
+{
+  "test_id": "mccarley-spouse",
+  "captured_at": "2026-07-15_01-29-54",
+  "verdict": "pass",
+  "stop_reason": "completed",
+  "judge_output": {
+    "per_finding": [
+      {
+        "finding_id": "f1",
+        "matched": "true",
+        "agent_evidence": "Relationship R25 (Couple between L7P6-3TT and I1) with marriage fact; person I1 named Elizabeth Patt (female); children of L7P6-3TT (Sophia, James, Moses Jr., Nancy, Samuel, Elizabeth, Sabina, Margaret, Sarah E) all listed as children of Moses J McCarley Sr with birth dates consistent with 1792 marriage",
+        "notes": "Agent recovered the spouse relationship: Elizabeth Patt married to Moses J McCarley Sr. Person I1 exists in the final tree with the name Elizabeth Patt and is linked to Moses J McCarley Sr (L7P6-3TT) via a Couple relationship. Multiple children in the tree are documented as offspring of Moses Sr., confirming the spousal relationship and her role as mother of his children."
+      },
+      {
+        "finding_id": "f2",
+        "matched": "true",
+        "agent_evidence": "Relationship R25 contains a Marriage fact with date '24 Jul 1792', place 'Lincoln, Kentucky, United States'; Source S1 and S2 titled 'Entry for Moses McCarley and Elizabeth Patt, Kentucky, County Marriages, 1786-1965'",
+        "notes": "Agent recovered the specific marriage fact: 24 July 1792, Lincoln County, Kentucky. The marriage date and place are present in the couple relationship (R25) with primary marriage fact (F1). Sources S1 and S2 cite the Kentucky County Marriages collection entry matching the required evidence."
+      }
+    ],
+    "recall_required": 1.0,
+    "recall_total": 1.0,
+    "verdict": "pass",
+    "rationale": "The agent successfully recovered both required findings. Finding f1 (spouse relationship) is present in the final tree as a Couple relationship (R25) between Moses J McCarley Sr (L7P6-3TT) and Elizabeth Patt (I1), with Elizabeth characterized as the mother of multiple documented children. Finding f2 (marriage date and place) is documented in the marriage fact within relationship R25, showing the date as 24 Jul 1792 and place as Lincoln, Kentucky, United States. Both findings match the expected information despite differences in formatting or source citation details. The recall verdict is **pass** because all required findings have matched == \"true\".",
+    "proof_quality": {
+      "score": 2,
+      "exhaustiveness": "partial",
+      "conflicts_addressed": "na",
+      "corroboration": "single_source",
+      "tier_appropriate": "yes",
+      "rationale": "The proof summary demonstrates a reasonably thorough initial search (Kentucky marriage index, census searches, probate records), but significant gaps remain: the original marriage bond image was attempted but remained inaccessible due to technical constraints, and no external repositories (Ancestry, MyHeritage) were searched. The agent found only one primary source directly naming Elizabeth Patt as the spouse (the derivative Kentucky County Marriages index entry). Two corroborating records (1817 and 1827 marriages of children) confirm Moses Sr.'s identity and presence but do not independently name Elizabeth Patt as his wife. The narrative is honest about this limitation\u2014explicitly rating the conclusion 'probable' rather than 'proved' and identifying the lack of independent verification. However, the tier ('probable') is appropriate given the evidence: a single derivative marriage index entry is a credible primary-information source, and the child marriages provide indirect corroboration of identity. The proof is sound in reasoning but thin in corroboration, warranting a score of 2 (partial)."
+    }
+  },
+  "usage": {
+    "duration_ms": 2325200,
+    "duration_api_ms": 2527923,
+    "num_turns": 111,
+    "is_error": false,
+    "stop_reason": "end_turn",
+    "total_cost_usd": 7.180965099999998,
+    "usage": {
+      "input_tokens": 136,
+      "cache_creation_input_tokens": 282818,
+      "cache_read_input_tokens": 7676343,
+      "output_tokens": 95548,
+      "server_tool_use": {
+        "web_search_requests": 0,
+        "web_fetch_requests": 0
+      },
+      "service_tier": "standard",
+      "cache_creation": {
+        "ephemeral_1h_input_tokens": 282818,
+        "ephemeral_5m_input_tokens": 0
+      },
+      "inference_geo": "",
+      "iterations": [
+        {
+          "input_tokens": 1,
+          "output_tokens": 843,
+          "cache_read_input_tokens": 129651,
+          "cache_creation_input_tokens": 315,
+          "cache_creation": {
+            "ephemeral_5m_input_tokens": 0,
+            "ephemeral_1h_input_tokens": 315
+          },
+          "type": "message"
+        }
+      ],
+      "speed": "standard"
+    },
+    "continue_nudges": 0,
+    "session_id": "6c39cfba-4805-4e38-aeaf-04ac3dc444d5",
+    "resumes": 0,
+    "resume_on_stall": true,
+    "timeline": [
+      [
+        2.7,
+        "system:init"
+      ],
+      [
+        6.8,
+        "assistant"
+      ],
+      [
+        7.1,
+        "assistant"
+      ],
+      [
+        7.3,
+        "tool_result"
+      ],
+      [
+        10.7,
+        "assistant"
+      ],
+      [
+        12.4,
+        "assistant"
+      ],
+      [
+        12.5,
+        "tool_result"
+      ],
+      [
+        14.6,
+        "assistant"
+      ],
+      [
+        15.2,
+        "assistant"
+      ],
+      [
+        15.2,
+        "tool_result"
+      ],
+      [
+        20.9,
+        "assistant"
+      ],
+      [
+        21.7,
+        "assistant"
+      ],
+      [
+        23.4,
+        "assistant"
+      ],
+      [
+        23.5,
+        "tool_result"
+      ],
+      [
+        23.5,
+        "tool_result"
+      ],
+      [
+        25.8,
+        "assistant"
+      ],
+      [
+        26.7,
+        "assistant"
+      ],
+      [
+        27.2,
+        "tool_result"
+      ],
+      [
+        27.5,
+        "assistant"
+      ],
+      [
+        27.6,
+        "tool_result"
+      ],
+      [
+        39.8,
+        "assistant"
+      ],
+      [
+        39.8,
+        "assistant"
+      ],
+      [
+        39.9,
+        "tool_result"
+      ],
+      [
+        47.7,
+        "assistant"
+      ],
+      [
+        53.4,
+        "assistant"
+      ],
+      [
+        53.5,
+        "tool_result"
+      ],
+      [
+        56.9,
+        "assistant"
+      ],
+      [
+        57.4,
+        "assistant"
+      ],
+      [
+        59.1,
+        "assistant"
+      ],
+      [
+        59.2,
+        "tool_result"
+      ],
+      [
+        59.2,
+        "tool_result"
+      ],
+      [
+        66.6,
+        "assistant"
+      ],
+      [
+        66.6,
+        "assistant"
+      ],
+      [
+        66.8,
+        "tool_result"
+      ],
+      [
+        67.1,
+        "assistant"
+      ],
+      [
+        67.1,
+        "tool_result"
+      ],
+      [
+        80.0,
+        "assistant"
+      ],
+      [
+        80.4,
+        "assistant"
+      ],
+      [
+        80.4,
+        "tool_result"
+      ],
+      [
+        85.5,
+        "assistant"
+      ],
+      [
+        86.2,
+        "assistant"
+      ],
+      [
+        86.2,
+        "tool_result"
+      ],
+      [
+        94.4,
+        "assistant"
+      ],
+      [
+        94.4,
+        "assistant"
+      ],
+      [
+        94.6,
+        "tool_result"
+      ],
+      [
+        97.6,
+        "assistant"
+      ],
+      [
+        99.0,
+        "assistant"
+      ],
+      [
+        100.9,
+        "tool_result"
+      ],
+      [
+        103.7,
+        "assistant"
+      ],
+      [
+        104.6,
+        "assistant"
+      ],
+      [
+        105.0,
+        "tool_result"
+      ],
+      [
+        108.1,
+        "assistant"
+      ],
+      [
+        108.9,
+        "tool_result"
+      ],
+      [
+        114.4,
+        "assistant"
+      ],
+      [
+        114.4,
+        "tool_result"
+      ],
+      [
+        118.0,
+        "assistant"
+      ],
+      [
+        118.1,
+        "tool_result"
+      ],
+      [
+        122.6,
+        "assistant"
+      ],
+      [
+        122.6,
+        "tool_result"
+      ],
+      [
+        127.0,
+        "assistant"
+      ],
+      [
+        128.3,
+        "assistant"
+      ],
+      [
+        128.4,
+        "tool_result"
+      ],
+      [
+        143.2,
+        "assistant"
+      ],
+      [
+        143.2,
+        "assistant"
+      ],
+      [
+        145.0,
+        "assistant"
+      ],
+      [
+        146.3,
+        "assistant"
+      ],
+      [
+        146.3,
+        "tool_result"
+      ],
+      [
+        147.5,
+        "tool_result"
+      ],
+      [
+        157.8,
+        "assistant"
+      ],
+      [
+        159.8,
+        "assistant"
+      ],
+      [
+        159.8,
+        "tool_result"
+      ],
+      [
+        174.3,
+        "assistant"
+      ],
+      [
+        174.4,
+        "assistant"
+      ],
+      [
+        179.6,
+        "assistant"
+      ],
+      [
+        179.6,
+        "assistant"
+      ],
+      [
+        180.9,
+        "tool_result"
+      ],
+      [
+        181.8,
+        "tool_result"
+      ],
+      [
+        203.1,
+        "assistant"
+      ],
+      [
+        203.1,
+        "assistant"
+      ],
+      [
+        203.1,
+        "assistant"
+      ],
+      [
+        203.1,
+        "tool_result"
+      ],
+      [
+        205.9,
+        "assistant"
+      ],
+      [
+        209.6,
+        "assistant"
+      ],
+      [
+        210.0,
+        "tool_result"
+      ],
+      [
+        211.2,
+        "assistant"
+      ],
+      [
+        211.3,
+        "tool_result"
+      ],
+      [
+        236.7,
+        "assistant"
+      ],
+      [
+        238.4,
+        "assistant"
+      ],
+      [
+        239.4,
+        "assistant"
+      ],
+      [
+        239.8,
+        "assistant"
+      ],
+      [
+        244.9,
+        "tool_result"
+      ],
+      [
+        249.9,
+        "tool_result"
+      ],
+      [
+        287.2,
+        "assistant"
+      ],
+      [
+        290.2,
+        "assistant"
+      ],
+      [
+        322.6,
+        "assistant"
+      ],
+      [
+        322.6,
+        "tool_result"
+      ],
+      [
+        331.2,
+        "assistant"
+      ],
+      [
+        334.1,
+        "assistant"
+      ],
+      [
+        341.1,
+        "assistant"
+      ],
+      [
+        341.1,
+        "tool_result"
+      ],
+      [
+        341.1,
+        "tool_result"
+      ],
+      [
+        350.4,
+        "assistant"
+      ],
+      [
+        350.4,
+        "assistant"
+      ],
+      [
+        350.4,
+        "tool_result"
+      ],
+      [
+        379.5,
+        "assistant"
+      ],
+      [
+        380.4,
+        "assistant"
+      ],
+      [
+        385.0,
+        "assistant"
+      ],
+      [
+        386.2,
+        "tool_result"
+      ],
+      [
+        394.0,
+        "assistant"
+      ],
+      [
+        394.0,
+        "assistant"
+      ],
+      [
+        397.2,
+        "assistant"
+      ],
+      [
+        400.2,
+        "tool_result"
+      ],
+      [
+        423.7,
+        "assistant"
+      ],
+      [
+        424.8,
+        "assistant"
+      ],
+      [
+        433.3,
+        "assistant"
+      ],
+      [
+        433.4,
+        "tool_result"
+      ],
+      [
+        437.4,
+        "assistant"
+      ],
+      [
+        437.5,
+        "tool_result"
+      ],
+      [
+        444.5,
+        "assistant"
+      ],
+      [
+        444.8,
+        "assistant"
+      ],
+      [
+        447.1,
+        "assistant"
+      ],
+      [
+        448.4,
+        "tool_result"
+      ],
+      [
+        449.9,
+        "assistant"
+      ],
+      [
+        450.2,
+        "tool_result"
+      ],
+      [
+        461.9,
+        "assistant"
+      ],
+      [
+        462.8,
+        "assistant"
+      ],
+      [
+        466.7,
+        "assistant"
+      ],
+      [
+        467.0,
+        "assistant"
+      ],
+      [
+        469.6,
+        "tool_result"
+      ],
+      [
+        469.9,
+        "tool_result"
+      ],
+      [
+        476.9,
+        "assistant"
+      ],
+      [
+        478.2,
+        "assistant"
+      ],
+      [
+        486.3,
+        "assistant"
+      ],
+      [
+        486.3,
+        "tool_result"
+      ],
+      [
+        492.4,
+        "assistant"
+      ],
+      [
+        492.4,
+        "tool_result"
+      ],
+      [
+        501.2,
+        "assistant"
+      ],
+      [
+        501.2,
+        "tool_result"
+      ],
+      [
+        508.1,
+        "assistant"
+      ],
+      [
+        508.1,
+        "tool_result"
+      ],
+      [
+        518.1,
+        "assistant"
+      ],
+      [
+        518.1,
+        "assistant"
+      ],
+      [
+        519.8,
+        "assistant"
+      ],
+      [
+        521.1,
+        "tool_result"
+      ],
+      [
+        521.7,
+        "assistant"
+      ],
+      [
+        522.1,
+        "tool_result"
+      ],
+      [
+        536.5,
+        "assistant"
+      ],
+      [
+        536.9,
+        "assistant"
+      ],
+      [
+        539.2,
+        "assistant"
+      ],
+      [
+        540.1,
+        "tool_result"
+      ],
+      [
+        540.9,
+        "assistant"
+      ],
+      [
+        541.1,
+        "tool_result"
+      ],
+      [
+        551.3,
+        "assistant"
+      ],
+      [
+        551.3,
+        "assistant"
+      ],
+      [
+        553.4,
+        "assistant"
+      ],
+      [
+        554.7,
+        "tool_result"
+      ],
+      [
+        555.1,
+        "assistant"
+      ],
+      [
+        555.5,
+        "tool_result"
+      ],
+      [
+        578.9,
+        "assistant"
+      ],
+      [
+        579.7,
+        "assistant"
+      ],
+      [
+        585.4,
+        "assistant"
+      ],
+      [
+        585.4,
+        "tool_result"
+      ],
+      [
+        591.0,
+        "assistant"
+      ],
+      [
+        591.1,
+        "tool_result"
+      ],
+      [
+        599.8,
+        "assistant"
+      ],
+      [
+        601.6,
+        "assistant"
+      ],
+      [
+        602.8,
+        "tool_result"
+      ],
+      [
+        603.5,
+        "assistant"
+      ],
+      [
+        604.3,
+        "tool_result"
+      ],
+      [
+        623.4,
+        "assistant"
+      ],
+      [
+        624.4,
+        "assistant"
+      ],
+      [
+        629.1,
+        "assistant"
+      ],
+      [
+        629.1,
+        "tool_result"
+      ],
+      [
+        643.2,
+        "assistant"
+      ],
+      [
+        643.3,
+        "tool_result"
+      ],
+      [
+        646.4,
+        "assistant"
+      ],
+      [
+        647.3,
+        "assistant"
+      ],
+      [
+        649.3,
+        "assistant"
+      ],
+      [
+        650.2,
+        "assistant"
+      ],
+      [
+        650.3,
+        "tool_result"
+      ],
+      [
+        653.8,
+        "tool_result"
+      ],
+      [
+        679.4,
+        "assistant"
+      ],
+      [
+        680.7,
+        "assistant"
+      ],
+      [
+        688.0,
+        "assistant"
+      ],
+      [
+        688.1,
+        "tool_result"
+      ],
+      [
+        701.8,
+        "assistant"
+      ],
+      [
+        701.8,
+        "tool_result"
+      ],
+      [
+        705.6,
+        "assistant"
+      ],
+      [
+        708.6,
+        "assistant"
+      ],
+      [
+        708.6,
+        "tool_result"
+      ],
+      [
+        726.2,
+        "assistant"
+      ],
+      [
+        732.1,
+        "assistant"
+      ],
+      [
+        742.0,
+        "assistant"
+      ],
+      [
+        742.0,
+        "tool_result"
+      ],
+      [
+        742.0,
+        "tool_result"
+      ],
+      [
+        782.5,
+        "assistant"
+      ],
+      [
+        782.6,
+        "assistant"
+      ],
+      [
+        797.8,
+        "assistant"
+      ],
+      [
+        798.1,
+        "system:task_started"
+      ],
+      [
+        798.1,
+        "tool_result"
+      ],
+      [
+        801.7,
+        "system:task_progress"
+      ],
+      [
+        801.7,
+        "assistant"
+      ],
+      [
+        801.7,
+        "tool_result"
+      ],
+      [
+        813.9,
+        "assistant"
+      ],
+      [
+        813.9,
+        "system:task_started"
+      ],
+      [
+        813.9,
+        "tool_result"
+      ],
+      [
+        819.2,
+        "system:task_progress"
+      ],
+      [
+        819.2,
+        "assistant"
+      ],
+      [
+        819.2,
+        "tool_result"
+      ],
+      [
+        828.4,
+        "assistant"
+      ],
+      [
+        828.4,
+        "system:task_started"
+      ],
+      [
+        828.4,
+        "tool_result"
+      ],
+      [
+        832.5,
+        "system:task_progress"
+      ],
+      [
+        832.5,
+        "assistant"
+      ],
+      [
+        832.5,
+        "tool_result"
+      ],
+      [
+        863.1,
+        "system:task_progress"
+      ],
+      [
+        863.1,
+        "assistant"
+      ],
+      [
+        863.1,
+        "tool_result"
+      ],
+      [
+        877.8,
+        "system:task_progress"
+      ],
+      [
+        877.8,
+        "assistant"
+      ],
+      [
+        877.8,
+        "tool_result"
+      ],
+      [
+        882.8,
+        "system:task_progress"
+      ],
+      [
+        882.8,
+        "assistant"
+      ],
+      [
+        882.8,
+        "tool_result"
+      ],
+      [
+        886.9,
+        "system:task_progress"
+      ],
+      [
+        886.9,
+        "assistant"
+      ],
+      [
+        886.9,
+        "tool_result"
+      ],
+      [
+        895.0,
+        "system:task_progress"
+      ],
+      [
+        895.1,
+        "assistant"
+      ],
+      [
+        895.1,
+        "tool_result"
+      ],
+      [
+        904.1,
+        "system:task_notification"
+      ],
+      [
+        904.1,
+        "tool_result"
+      ],
+      [
+        910.3,
+        "system:task_progress"
+      ],
+      [
+        910.3,
+        "assistant"
+      ],
+      [
+        910.3,
+        "tool_result"
+      ],
+      [
+        930.6,
+        "system:task_progress"
+      ],
+      [
+        930.6,
+        "assistant"
+      ],
+      [
+        930.6,
+        "tool_result"
+      ],
+      [
+        942.4,
+        "system:task_notification"
+      ],
+      [
+        942.4,
+        "tool_result"
+      ],
+      [
+        1012.5,
+        "system:task_progress"
+      ],
+      [
+        1012.5,
+        "assistant"
+      ],
+      [
+        1012.5,
+        "tool_result"
+      ],
+      [
+        1019.8,
+        "system:task_notification"
+      ],
+      [
+        1019.8,
+        "tool_result"
+      ],
+      [
+        1035.0,
+        "assistant"
+      ],
+      [
+        1035.1,
+        "assistant"
+      ],
+      [
+        1035.6,
+        "assistant"
+      ],
+      [
+        1035.7,
+        "tool_result"
+      ],
+      [
+        1048.1,
+        "assistant"
+      ],
+      [
+        1048.1,
+        "assistant"
+      ],
+      [
+        1048.2,
+        "tool_result"
+      ],
+      [
+        1057.6,
+        "assistant"
+      ],
+      [
+        1062.9,
+        "assistant"
+      ],
+      [
+        1071.2,
+        "assistant"
+      ],
+      [
+        1071.2,
+        "tool_result"
+      ],
+      [
+        1071.2,
+        "tool_result"
+      ],
+      [
+        1071.2,
+        "system:status"
+      ],
+      [
+        1160.3,
+        "system:status"
+      ],
+      [
+        1160.3,
+        "system:compact_boundary"
+      ],
+      [
+        1160.3,
+        "tool_result"
+      ],
+      [
+        1165.8,
+        "assistant"
+      ],
+      [
+        1166.3,
+        "assistant"
+      ],
+      [
+        1166.7,
+        "tool_result"
+      ],
+      [
+        1167.2,
+        "assistant"
+      ],
+      [
+        1167.2,
+        "tool_result"
+      ],
+      [
+        1171.7,
+        "assistant"
+      ],
+      [
+        1174.0,
+        "assistant"
+      ],
+      [
+        1174.3,
+        "tool_result"
+      ],
+      [
+        1177.0,
+        "assistant"
+      ],
+      [
+        1179.1,
+        "assistant"
+      ],
+      [
+        1179.5,
+        "tool_result"
+      ],
+      [
+        1191.6,
+        "assistant"
+      ],
+      [
+        1194.7,
+        "assistant"
+      ],
+      [
+        1194.7,
+        "tool_result"
+      ],
+      [
+        1198.0,
+        "assistant"
+      ],
+      [
+        1198.0,
+        "tool_result"
+      ],
+      [
+        1267.6,
+        "assistant"
+      ],
+      [
+        1267.6,
+        "assistant"
+      ],
+      [
+        1267.6,
+        "tool_result"
+      ],
+      [
+        1271.3,
+        "assistant"
+      ],
+      [
+        1272.2,
+        "assistant"
+      ],
+      [
+        1275.4,
+        "assistant"
+      ],
+      [
+        1275.4,
+        "tool_result"
+      ],
+      [
+        1278.3,
+        "assistant"
+      ],
+      [
+        1278.3,
+        "tool_result"
+      ],
+      [
+        1402.6,
+        "assistant"
+      ],
+      [
+        1403.0,
+        "assistant"
+      ],
+      [
+        1438.6,
+        "assistant"
+      ],
+      [
+        1438.7,
+        "tool_result"
+      ],
+      [
+        1489.2,
+        "assistant"
+      ],
+      [
+        1489.3,
+        "assistant"
+      ],
+      [
+        1489.5,
+        "assistant"
+      ],
+      [
+        1489.7,
+        "tool_result"
+      ],
+      [
+        1492.9,
+        "assistant"
+      ],
+      [
+        1494.9,
+        "assistant"
+      ],
+      [
+        1494.9,
+        "tool_result"
+      ],
+      [
+        1521.5,
+        "assistant"
+      ],
+      [
+        1521.6,
+        "assistant"
+      ],
+      [
+        1525.3,
+        "assistant"
+      ],
+      [
+        1525.3,
+        "tool_result"
+      ],
+      [
+        1575.9,
+        "assistant"
+      ],
+      [
+        1576.7,
+        "assistant"
+      ],
+      [
+        1579.6,
+        "assistant"
+      ],
+      [
+        1579.6,
+        "system:task_started"
+      ],
+      [
+        1579.6,
+        "tool_result"
+      ],
+      [
+        1582.3,
+        "system:task_progress"
+      ],
+      [
+        1582.3,
+        "assistant"
+      ],
+      [
+        1582.4,
+        "tool_result"
+      ],
+      [
+        1591.3,
+        "system:task_notification"
+      ],
+      [
+        1591.3,
+        "tool_result"
+      ],
+      [
+        1605.7,
+        "assistant"
+      ],
+      [
+        1605.7,
+        "assistant"
+      ],
+      [
+        1605.8,
+        "assistant"
+      ],
+      [
+        1605.8,
+        "tool_result"
+      ],
+      [
+        1613.3,
+        "assistant"
+      ],
+      [
+        1616.6,
+        "assistant"
+      ],
+      [
+        1616.7,
+        "tool_result"
+      ],
+      [
+        1621.9,
+        "assistant"
+      ],
+      [
+        1622.3,
+        "assistant"
+      ],
+      [
+        1625.4,
+        "assistant"
+      ],
+      [
+        1625.4,
+        "system:task_started"
+      ],
+      [
+        1625.4,
+        "tool_result"
+      ],
+      [
+        1628.3,
+        "system:task_progress"
+      ],
+      [
+        1628.3,
+        "assistant"
+      ],
+      [
+        1632.8,
+        "tool_result"
+      ],
+      [
+        1640.4,
+        "system:task_notification"
+      ],
+      [
+        1640.4,
+        "tool_result"
+      ],
+      [
+        1670.7,
+        "assistant"
+      ],
+      [
+        1670.7,
+        "assistant"
+      ],
+      [
+        1688.8,
+        "assistant"
+      ],
+      [
+        1688.9,
+        "tool_result"
+      ],
+      [
+        1691.5,
+        "assistant"
+      ],
+      [
+        1692.1,
+        "assistant"
+      ],
+      [
+        1694.1,
+        "assistant"
+      ],
+      [
+        1694.6,
+        "tool_result"
+      ],
+      [
+        1695.0,
+        "assistant"
+      ],
+      [
+        1695.0,
+        "tool_result"
+      ],
+      [
+        1722.2,
+        "assistant"
+      ],
+      [
+        1722.3,
+        "assistant"
+      ],
+      [
+        1725.3,
+        "assistant"
+      ],
+      [
+        1725.3,
+        "tool_result"
+      ],
+      [
+        1732.1,
+        "assistant"
+      ],
+      [
+        1733.4,
+        "assistant"
+      ],
+      [
+        1779.4,
+        "assistant"
+      ],
+      [
+        1779.5,
+        "tool_result"
+      ],
+      [
+        1794.3,
+        "assistant"
+      ],
+      [
+        1794.3,
+        "assistant"
+      ],
+      [
+        1796.5,
+        "assistant"
+      ],
+      [
+        1797.5,
+        "tool_result"
+      ],
+      [
+        1801.0,
+        "assistant"
+      ],
+      [
+        1801.7,
+        "assistant"
+      ],
+      [
+        1801.7,
+        "tool_result"
+      ],
+      [
+        1853.7,
+        "assistant"
+      ],
+      [
+        1854.1,
+        "assistant"
+      ],
+      [
+        1855.9,
+        "assistant"
+      ],
+      [
+        1855.9,
+        "tool_result"
+      ],
+      [
+        1859.2,
+        "assistant"
+      ],
+      [
+        1860.5,
+        "assistant"
+      ],
+      [
+        1860.6,
+        "tool_result"
+      ],
+      [
+        1870.4,
+        "assistant"
+      ],
+      [
+        1870.4,
+        "assistant"
+      ],
+      [
+        1883.0,
+        "assistant"
+      ],
+      [
+        1883.0,
+        "system:task_started"
+      ],
+      [
+        1883.0,
+        "tool_result"
+      ],
+      [
+        1886.7,
+        "system:task_progress"
+      ],
+      [
+        1886.7,
+        "assistant"
+      ],
+      [
+        1887.0,
+        "tool_result"
+      ],
+      [
+        2026.9,
+        "system:task_notification"
+      ],
+      [
+        2026.9,
+        "tool_result"
+      ],
+      [
+        2045.0,
+        "assistant"
+      ],
+      [
+        2045.0,
+        "assistant"
+      ],
+      [
+        2045.5,
+        "assistant"
+      ],
+      [
+        2045.6,
+        "tool_result"
+      ],
+      [
+        2049.6,
+        "assistant"
+      ],
+      [
+        2050.6,
+        "assistant"
+      ],
+      [
+        2061.6,
+        "assistant"
+      ],
+      [
+        2061.6,
+        "tool_result"
+      ],
+      [
+        2084.6,
+        "assistant"
+      ],
+      [
+        2084.6,
+        "assistant"
+      ],
+      [
+        2153.3,
+        "assistant"
+      ],
+      [
+        2153.3,
+        "tool_result"
+      ],
+      [
+        2160.1,
+        "assistant"
+      ],
+      [
+        2160.4,
+        "assistant"
+      ],
+      [
+        2214.8,
+        "assistant"
+      ],
+      [
+        2214.8,
+        "tool_result"
+      ],
+      [
+        2273.9,
+        "assistant"
+      ],
+      [
+        2274.0,
+        "tool_result"
+      ],
+      [
+        2280.3,
+        "assistant"
+      ],
+      [
+        2280.3,
+        "assistant"
+      ],
+      [
+        2302.8,
+        "assistant"
+      ],
+      [
+        2302.9,
+        "tool_result"
+      ],
+      [
+        2307.6,
+        "assistant"
+      ],
+      [
+        2307.6,
+        "tool_result"
+      ],
+      [
+        2318.2,
+        "assistant"
+      ],
+      [
+        2327.8,
+        "assistant"
+      ],
+      [
+        2327.9,
+        "result"
+      ]
+    ],
+    "caps": {
+      "wall_clock_seconds": 7200,
+      "inactivity_seconds": 600,
+      "progress_stall_seconds": 600,
+      "tool_calls": 300,
+      "max_turns": 250,
+      "max_cost_usd": 15.0
+    },
+    "wall_clock_seconds": 2344.2201563849812,
+    "real_clock_seconds": 2344.201346874237,
+    "slept_seconds": 0.0,
+    "judge_seconds": 15.213619964953978
+  },
+  "tool_calls": [
+    {
+      "tool": "ToolSearch",
+      "args": {
+        "query": "select:mcp__genealogy__project_context",
+        "max_results": 1
+      },
+      "response_summary": "[{\"type\": \"tool_reference\", \"tool_name\": \"mcp__genealogy__project_context\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__project_context",
+      "args": {
+        "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l"
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"projectStatus\\\": \\\"active\\\",\\n  \\\"openQuestions\\\": [],\\n  \\\"persons\\\": [\\n    {\\n      \\\"id\\\": \\\"L7P6-3TT\\\",\\n      \\\"name\\\": \\\"Moses J McCarley\\\",\\n      \\\"gender\\\": \\\"Male\\\",\\n      \\\"sourceRefs\\\": []\\n    },\\n    {\\n      \\\"id\\\": \\\"LHD2-QCN\\\",\\n      \\\"name\\\": \\\"Sophia McCarley\\\",\\n      \\\"gender\\\": \\\"Female\\\",\\n      \\\"sourceRefs\\\": []\\n    },\\n    {\\n      \\\"id\\\": \\\"L5VP-VVJ\\\",\\n      \\\"name\\\": \\\"James McCarley\\\",\\n      \\\"gender\\\": \\\"Ma..."
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l/research.json"
+      },
+      "response_summary": "1\t{\n2\t  \"project\": {\n3\t    \"id\": \"rp_mccarley_spouse\",\n4\t    \"objective\": \"Who was the spouse of Moses J McCarley Sr, who was born 17 January 1767 and died 9 April 1844?\",\n5\t    \"subject_person_ids\": [\n6\t      \"L7P6-3TT\"\n7\t    ],\n8\t    \"status\": \"active\",\n9\t    \"created\": \"2026-07-14\",\n10\t    \"updated\": \"2026-07-14\"\n11\t  },\n12\t  \"researcher_profile\": {\n13\t    \"experience_level\": \"intermediate\",\n14\t    \"subscriptions\": [],\n15\t    \"narration_guidance\": \"concise\"\n16\t  },\n17\t  \"questions\": [],\n18..."
+    },
+    {
+      "tool": "Skill",
+      "args": {
+        "skill": "question-selection",
+        "args": "--autonomous Objective: \"Who was the spouse of Moses J McCarley Sr, who was born 17 January 1767 and died 9 April 1844?\" Subject person: L7P6-3TT (Moses J McCarley, Male). Project path: /private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l"
+      },
+      "response_summary": "Launching skill: question-selection"
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l/.claude/skills/question-selection/references/question-formulation.md"
+      },
+      "response_summary": "1\t# Research Question Formulation\n2\t\n3\tGuidance for formulating effective genealogical research questions\n4\tthat satisfy the GPS standard for planned, purposeful research.\n5\t\n6\t## Research Objectives vs. Research Questions\n7\t\n8\tThese are distinct concepts that must not be conflated:\n9\t\n10\t- **Research objective**: The overarching goal of the research effort.\n11\t  It describes what you ultimately want to know (e.g., \"Identify the\n12\t  parents of John Smith born circa 1820 in Greene County, Ohi..."
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l/.claude/skills/question-selection/references/pedigree-analysis.md"
+      },
+      "response_summary": "1\t# Pedigree Analysis for Gap Detection\n2\t\n3\tGuidance for evaluating pedigree data to identify research gaps,\n4\terrors, and candidates for new research questions.\n5\t\n6\t## Purpose\n7\t\n8\tPedigree analysis is the process of systematically reviewing the\n9\tindividuals in a family tree to detect missing information, logical\n10\terrors, and inconsistencies. It is a critical first step before\n11\tselecting new research questions \u2014 it reveals where the gaps are\n12\tand which gaps are most significant.\n13\t..."
+    },
+    {
+      "tool": "ToolSearch",
+      "args": {
+        "query": "select:mcp__genealogy__research_append",
+        "max_results": 1
+      },
+      "response_summary": "[{\"type\": \"tool_reference\", \"tool_name\": \"mcp__genealogy__research_append\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__research_append",
+      "args": {
+        "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l",
+        "section": "questions",
+        "op": "append",
+        "entry": {
+          "question": "Who did Moses J McCarley Sr (born 17 January 1767, died 9 April 1844) marry?",
+          "rationale": "The project objective directly asks for Moses J McCarley Sr's spouse. This question decomposes that objective into a testable single-fact question targeting his marriage. Records potentially available include marriage bonds/licenses, early US census records (1790\u20131840 show household composition), land deeds, probate/estate records, and church records for the late 18th\u2013early 19th century period of his life.",
+          "selection_basis": "objective_decomposition",
+          "priority": "high",
+          "status": "open",
+          "depends_on": [],
+          "unblocks": [],
+          "resolved": null,
+          "resolution_assertion_ids": [],
+          "exhaustive_declaration": {
+            "declared": false,
+            "justification": null,
+            "log_entry_ids": [],
+            "stop_criteria": null
+          }
+        }
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"section\\\": \\\"questions\\\",\\n  \\\"op\\\": \\\"append\\\",\\n  \\\"entryId\\\": \\\"q_001\\\",\\n  \\\"filesWritten\\\": [\\n    \\\"research.json\\\"\\n  ],\\n  \\\"validation\\\": {\\n    \\\"valid\\\": true,\\n    \\\"warnings\\\": []\\n  }\\n}\"}]"
+    },
+    {
+      "tool": "Skill",
+      "args": {
+        "skill": "research-plan",
+        "args": "--autonomous Create a research plan for q_001: \"Who did Moses J McCarley Sr (born 17 January 1767, died 9 April 1844) marry?\" Subject person: L7P6-3TT. Project path: /private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l"
+      },
+      "response_summary": "Launching skill: research-plan"
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l/.claude/skills/research-plan/references/planning-standards.md"
+      },
+      "response_summary": "1\t# BCG Standards for Research Planning (Standards 9-18)\n2\t\n3\tThese ten standards from the Board for Certification of Genealogists\n4\tgovern how genealogists plan and scope their research. Every research\n5\tplan created by this skill should satisfy all applicable standards.\n6\t\n7\t---\n8\t\n9\t## Standard 9: Planned Research\n10\t\n11\tResearch begins with and follows a dynamic plan for gathering\n12\tinformation. The plan's purpose is to meet stated objectives, usually\n13\tframed as research questions. Hap..."
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l/.claude/skills/research-plan/references/record-type-guide.md"
+      },
+      "response_summary": "1\t# Record Type Selection Guide\n2\t\n3\tUse this reference when identifying which record sets to include in a\n4\tresearch plan. Match the research goal to record types, then check the\n5\tcontextual factors that affect availability.\n6\t\n7\t---\n8\t\n9\t## Record types by research goal\n10\t\n11\t| Goal | Primary record types | Secondary/fallback |\n12\t|------|---------------------|-------------------|\n13\t| Identify parents | Census (household), marriage (parents' marriage record), vital records (death/birth c..."
+    },
+    {
+      "tool": "ToolSearch",
+      "args": {
+        "query": "select:mcp__genealogy__person_read,mcp__genealogy__place_search,mcp__genealogy__collections_search",
+        "max_results": 3
+      },
+      "response_summary": "[{\"type\": \"tool_reference\", \"tool_name\": \"mcp__genealogy__person_read\"}, {\"type\": \"tool_reference\", \"tool_name\": \"mcp__genealogy__place_search\"}, {\"type\": \"tool_reference\", \"tool_name\": \"mcp__genealogy__collections_search\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__person_read",
+      "args": {
+        "personId": "L7P6-3TT",
+        "relatives": true,
+        "sourceDescriptions": true
+      },
+      "response_summary": "person_read is disabled in e2e benchmark runs. Reading the tree would hand you the stripped answer for free. Recover it through records instead (record_search, record_read, fulltext_search, image_search, \u2026)."
+    },
+    {
+      "tool": "ToolSearch",
+      "args": {
+        "query": "select:mcp__genealogy__record_search",
+        "max_results": 1
+      },
+      "response_summary": "[{\"type\": \"tool_reference\", \"tool_name\": \"mcp__genealogy__record_search\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__record_search",
+      "args": {
+        "surname": "McCarley",
+        "givenName": "Moses",
+        "birthYearFrom": 1762,
+        "birthYearTo": 1772,
+        "recordCountry": "United States",
+        "sex": "Male",
+        "count": 20
+      },
+      "response_summary": "<persisted-output>\nOutput too large (79.3KB). Full output saved to: /Users/ernest/.claude/projects/-private-var-folders-g7-zn65fvrn5g9-g71-sp0lk82h0000gn-T-e2e-mccarley-spouse-7ypjqc0l/6c39cfba-4805-4e38-aeaf-04ac3dc444d5/tool-results/toolu_01NarYema3KfHZdoev7Y35E5.json\n\nPreview (first 2KB):\n[\n  {\n    \"type\": \"text\",\n    \"text\": \"{\\n  \\\"query\\\": {\\n    \\\"surname\\\": \\\"McCarley\\\",\\n    \\\"givenName\\\": \\\"Moses\\\",\\n    \\\"birthYearFrom\\\": 1762,\\n    \\\"birthYearTo\\\": 1772,\\n    \\\"recordCountry\\\": \\\"..."
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/Users/ernest/.claude/projects/-private-var-folders-g7-zn65fvrn5g9-g71-sp0lk82h0000gn-T-e2e-mccarley-spouse-7ypjqc0l/6c39cfba-4805-4e38-aeaf-04ac3dc444d5/tool-results/toolu_01NarYema3KfHZdoev7Y35E5.json",
+        "limit": 150
+      },
+      "response_summary": "File content (28537 tokens) exceeds maximum allowed tokens (25000). Use offset and limit parameters to read specific portions of the file, or search for specific content instead of reading the whole file."
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/Users/ernest/.claude/projects/-private-var-folders-g7-zn65fvrn5g9-g71-sp0lk82h0000gn-T-e2e-mccarley-spouse-7ypjqc0l/6c39cfba-4805-4e38-aeaf-04ac3dc444d5/tool-results/toolu_01NarYema3KfHZdoev7Y35E5.json",
+        "limit": 80
+      },
+      "response_summary": "File content (28537 tokens) exceeds maximum allowed tokens (25000). Use offset and limit parameters to read specific portions of the file, or search for specific content instead of reading the whole file."
+    },
+    {
+      "tool": "Bash",
+      "args": {
+        "command": "python3 -c \"\nimport json\nwith open('/Users/ernest/.claude/projects/-private-var-folders-g7-zn65fvrn5g9-g71-sp0lk82h0000gn-T-e2e-mccarley-spouse-7ypjqc0l/6c39cfba-4805-4e38-aeaf-04ac3dc444d5/tool-results/toolu_01NarYema3KfHZdoev7Y35E5.json') as f:\n    data = json.load(f)\ncontent = json.loads(data[0]['text'])\nprint('Total matches:', content['totalMatches'])\nfor r in content['results']:\n    pid = r.get('recordId','')\n    name = r.get('personName','')\n    score = r.get('score','')\n    coll = r.get('collectionTitle','')\n    events = r.get('events',[])\n    place = events[0].get('place','') if events else ''\n    date = events[0].get('date','') if events else ''\n    print(f'  {score:.2f} | {name} | {place} | {date} | {coll} | {pid}')\n\"\n",
+        "description": "Parse and summarize McCarley search results"
+      },
+      "response_summary": "Permission to use Bash has been denied because Claude Code is running in don't ask mode. IMPORTANT: You *may* attempt to accomplish this action using other tools that might naturally be used to accomplish this goal, e.g. using head instead of cat. But you *should not* attempt to work around this denial in malicious ways, e.g. do not use your ability to run tests to execute non-test actions. You should only try to work around this restriction in reasonable ways that do not attempt to bypass th..."
+    },
+    {
+      "tool": "Grep",
+      "args": {
+        "pattern": "\"personName\"|\"collectionTitle\"|\"score\"|\"place\"",
+        "path": "/Users/ernest/.claude/projects/-private-var-folders-g7-zn65fvrn5g9-g71-sp0lk82h0000gn-T-e2e-mccarley-spouse-7ypjqc0l/6c39cfba-4805-4e38-aeaf-04ac3dc444d5/tool-results/toolu_01NarYema3KfHZdoev7Y35E5.json",
+        "output_mode": "content",
+        "head_limit": 100
+      },
+      "response_summary": "No matches found"
+    },
+    {
+      "tool": "Grep",
+      "args": {
+        "pattern": "personName",
+        "path": "/Users/ernest/.claude/projects/-private-var-folders-g7-zn65fvrn5g9-g71-sp0lk82h0000gn-T-e2e-mccarley-spouse-7ypjqc0l/6c39cfba-4805-4e38-aeaf-04ac3dc444d5/tool-results/toolu_01NarYema3KfHZdoev7Y35E5.json",
+        "output_mode": "content",
+        "head_limit": 30
+      },
+      "response_summary": "4:[Omitted long matching line]"
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/Users/ernest/.claude/projects/-private-var-folders-g7-zn65fvrn5g9-g71-sp0lk82h0000gn-T-e2e-mccarley-spouse-7ypjqc0l/6c39cfba-4805-4e38-aeaf-04ac3dc444d5/tool-results/toolu_01NarYema3KfHZdoev7Y35E5.json",
+        "limit": 3,
+        "offset": 0
+      },
+      "response_summary": "0\t[\n1\t  {\n2\t    \"type\": \"text\","
+    },
+    {
+      "tool": "mcp__genealogy__record_search",
+      "args": {
+        "surname": "McCarley",
+        "givenName": "Moses",
+        "recordCountry": "United States",
+        "recordType": "census",
+        "birthYearFrom": 1760,
+        "birthYearTo": 1775,
+        "sex": "Male",
+        "count": 20
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"query\\\": {\\n    \\\"surname\\\": \\\"McCarley\\\",\\n    \\\"givenName\\\": \\\"Moses\\\",\\n    \\\"recordCountry\\\": \\\"United States\\\",\\n    \\\"recordType\\\": \\\"census\\\",\\n    \\\"birthYearFrom\\\": 1760,\\n    \\\"birthYearTo\\\": 1775,\\n    \\\"sex\\\": \\\"Male\\\",\\n    \\\"count\\\": 20\\n  },\\n  \\\"totalMatches\\\": 6,\\n  \\\"paginationCappedAt\\\": 4999,\\n  \\\"returned\\\": 6,\\n  \\\"offset\\\": 0,\\n  \\\"hasMore\\\": false,\\n  \\\"results\\\": [\\n    {\\n      \\\"recordId\\\": \\\"ark:/61903/1:1:X33K-VS4C\\\",\\n      \\\"eve..."
+    },
+    {
+      "tool": "mcp__genealogy__record_search",
+      "args": {
+        "surname": "McCarley",
+        "givenName": "Moses",
+        "recordCountry": "United States",
+        "recordType": "death",
+        "deathYearFrom": 1840,
+        "deathYearTo": 1848,
+        "sex": "Male",
+        "count": 20
+      },
+      "response_summary": "Error: result (95,561 characters across 3,144 lines) exceeds maximum allowed tokens. Output has been saved to /Users/ernest/.claude/projects/-private-var-folders-g7-zn65fvrn5g9-g71-sp0lk82h0000gn-T-e2e-mccarley-spouse-7ypjqc0l/6c39cfba-4805-4e38-aeaf-04ac3dc444d5/tool-results/mcp-genealogy-record_search-1784076797737.txt.\nFormat: Plain text\n- For targeted searches (find a line, locate a string): use grep on the file directly.\n- For analysis or summarization that requires reading the full cont..."
+    },
+    {
+      "tool": "Grep",
+      "args": {
+        "pattern": "personName|collectionTitle|score|place.*McCarley|McCarley.*place",
+        "path": "/Users/ernest/.claude/projects/-private-var-folders-g7-zn65fvrn5g9-g71-sp0lk82h0000gn-T-e2e-mccarley-spouse-7ypjqc0l/6c39cfba-4805-4e38-aeaf-04ac3dc444d5/tool-results/mcp-genealogy-record_search-1784076797737.txt",
+        "output_mode": "content",
+        "head_limit": 80
+      },
+      "response_summary": "22:      \"personName\": \"Moses McCarley\",\n23:      \"score\": 5.6036,\n27:      \"collectionTitle\": \"California, County Birth and Death Records, 1800-1994\",\n157:      \"personName\": \"Moses Mccarley\",\n158:      \"score\": 5.6036,\n163:      \"collectionTitle\": \"Ohio, Deaths, 1908-1953\",\n334:      \"personName\": \"Moses Mc Carley\",\n335:      \"score\": 5.6036,\n340:      \"collectionTitle\": \"Ohio, Deaths, 1908-1953\",\n505:      \"personName\": \"Moses Mccarley\",\n506:      \"score\": 5.6036,\n511:      \"collectionTitl..."
+    },
+    {
+      "tool": "mcp__genealogy__record_search",
+      "args": {
+        "surname": "McCarley",
+        "givenName": "Moses",
+        "recordCountry": "United States",
+        "recordType": "marriage",
+        "sex": "Male",
+        "count": 25,
+        "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l"
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"query\\\": {\\n    \\\"surname\\\": \\\"McCarley\\\",\\n    \\\"givenName\\\": \\\"Moses\\\",\\n    \\\"recordCountry\\\": \\\"United States\\\",\\n    \\\"recordType\\\": \\\"marriage\\\",\\n    \\\"sex\\\": \\\"Male\\\",\\n    \\\"count\\\": 25,\\n    \\\"projectPath\\\": \\\"/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l\\\"\\n  },\\n  \\\"totalMatches\\\": 1875,\\n  \\\"paginationCappedAt\\\": 4999,\\n  \\\"returned\\\": 25,\\n  \\\"offset\\\": 0,\\n  \\\"hasMore\\\": true,\\n  \\\"results\\\": [\\n    {\\n  ..."
+    },
+    {
+      "tool": "mcp__genealogy__record_search",
+      "args": {
+        "surname": "McCarley",
+        "givenName": "Moses",
+        "recordCountry": "United States",
+        "recordType": "probate",
+        "sex": "Male",
+        "count": 20
+      },
+      "response_summary": "<persisted-output>\nOutput too large (84.4KB). Full output saved to: /Users/ernest/.claude/projects/-private-var-folders-g7-zn65fvrn5g9-g71-sp0lk82h0000gn-T-e2e-mccarley-spouse-7ypjqc0l/6c39cfba-4805-4e38-aeaf-04ac3dc444d5/tool-results/toolu_01KDoCUwYSA6saEy2hXgHjji.json\n\nPreview (first 2KB):\n[\n  {\n    \"type\": \"text\",\n    \"text\": \"{\\n  \\\"query\\\": {\\n    \\\"surname\\\": \\\"McCarley\\\",\\n    \\\"givenName\\\": \\\"Moses\\\",\\n    \\\"recordCountry\\\": \\\"United States\\\",\\n    \\\"recordType\\\": \\\"probate\\\",\\n    \\\"..."
+    },
+    {
+      "tool": "ToolSearch",
+      "args": {
+        "query": "select:mcp__genealogy__record_read",
+        "max_results": 1
+      },
+      "response_summary": "[{\"type\": \"tool_reference\", \"tool_name\": \"mcp__genealogy__record_read\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__record_read",
+      "args": {
+        "recordId": "ark:/61903/1:1:Q28D-NHWN",
+        "resultsRef": "results/.staging/4a8dbdad-3f1f-49f8-a817-0076f892626f.json",
+        "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l"
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"persons\\\": [\\n    {\\n      \\\"id\\\": \\\"p_102337459396\\\",\\n      \\\"ark\\\": \\\"ark:/61903/1:1:Q28D-NHWN\\\",\\n      \\\"gender\\\": \\\"Male\\\",\\n      \\\"names\\\": [\\n        {\\n          \\\"type\\\": \\\"BirthName\\\",\\n          \\\"given\\\": \\\"Moses\\\",\\n          \\\"surname\\\": \\\"McCarley\\\"\\n        }\\n      ],\\n      \\\"facts\\\": [\\n        {\\n          \\\"type\\\": \\\"Unknown\\\",\\n          \\\"primary\\\": true,\\n          \\\"place\\\": \\\"Lincoln\\\",\\n          \\\"standard_place\\\": \\\"Lincoln, Ken..."
+    },
+    {
+      "tool": "mcp__genealogy__record_read",
+      "args": {
+        "recordId": "ark:/61903/1:1:Q28D-N9C1",
+        "resultsRef": "results/.staging/4a8dbdad-3f1f-49f8-a817-0076f892626f.json",
+        "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l"
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"persons\\\": [\\n    {\\n      \\\"id\\\": \\\"p_102337453199\\\",\\n      \\\"ark\\\": \\\"ark:/61903/1:1:Q28D-N9C1\\\",\\n      \\\"gender\\\": \\\"Male\\\",\\n      \\\"names\\\": [\\n        {\\n          \\\"type\\\": \\\"BirthName\\\",\\n          \\\"given\\\": \\\"Moses\\\",\\n          \\\"surname\\\": \\\"McCarley\\\"\\n        }\\n      ],\\n      \\\"facts\\\": [\\n        {\\n          \\\"type\\\": \\\"Unknown\\\",\\n          \\\"primary\\\": true,\\n          \\\"place\\\": \\\"Jessamine\\\",\\n          \\\"standard_place\\\": \\\"Jessamine,..."
+    },
+    {
+      "tool": "mcp__genealogy__collections_search",
+      "args": {
+        "standardPlace": "Kentucky, United States",
+        "startYear": 1785,
+        "endYear": 1850
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"query\\\": {\\n    \\\"standardPlace\\\": \\\"Kentucky, United States\\\",\\n    \\\"startYear\\\": 1785,\\n    \\\"endYear\\\": 1850\\n  },\\n  \\\"scope\\\": \\\"Kentucky\\\",\\n  \\\"totalForPlace\\\": 22,\\n  \\\"results\\\": [\\n    {\\n      \\\"id\\\": \\\"1674843\\\",\\n      \\\"title\\\": \\\"Kentucky, Births and Christenings, 1839-1960\\\",\\n      \\\"dateRange\\\": \\\"1839-1960\\\",\\n      \\\"recordCount\\\": 381231,\\n      \\\"personCount\\\": 1032346,\\n      \\\"imageCount\\\": 381231,\\n      \\\"url\\\": \\\"https://www.family..."
+    },
+    {
+      "tool": "mcp__genealogy__place_search",
+      "args": {
+        "placeName": "Lincoln County",
+        "contextName": "Kentucky"
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"results\\\": [\\n    {\\n      \\\"standardPlace\\\": \\\"Lincoln, Kentucky, United States\\\",\\n      \\\"type\\\": \\\"County\\\",\\n      \\\"dateRange\\\": \\\"+1792/\\\",\\n      \\\"latitude\\\": 37.45,\\n      \\\"longitude\\\": -84.66667,\\n      \\\"familysearchUrl\\\": \\\"https://www.familysearch.org/en/research/places/?text=Lincoln&focusedId=394137\\\",\\n      \\\"wikipediaUrl\\\": \\\"https://en.wikipedia.org/wiki/Lincoln_County,_Kentucky\\\"\\n    },\\n    {\\n      \\\"standardPlace\\\": \\\"Lincoln, Pulaski..."
+    },
+    {
+      "tool": "mcp__genealogy__research_append",
+      "args": {
+        "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l",
+        "ops": [
+          {
+            "section": "plans",
+            "op": "append",
+            "entry": {
+              "question_id": "q_001",
+              "status": "active",
+              "created": "2026-07-14"
+            }
+          },
+          {
+            "section": "plan_items",
+            "op": "append",
+            "planId": "pl_001",
+            "entry": {
+              "sequence": 1,
+              "record_type": "vital_record",
+              "jurisdiction": "Lincoln County, Kentucky",
+              "date_range": "1786-1800",
+              "repository": "FamilySearch",
+              "rationale": "Preliminary survey found Moses McCarley married Elizabeth Patt on 24 Jul 1792 in Lincoln County, KY (Kentucky, County Marriages, 1786-1965, ark:/61903/1:1:Q28D-NHWN). This is the highest-priority item: reading the full record image and extracting all facts (date, place, witnesses) provides the primary direct evidence identifying Moses J McCarley Sr's spouse. The 1792 date is consistent with his birth year of 1767 (age ~25 at marriage). The record must be extracted before any downstream conclusion.",
+              "fallback_for": null,
+              "status": "planned"
+            }
+          },
+          {
+            "section": "plan_items",
+            "op": "append",
+            "planId": "pl_001",
+            "entry": {
+              "sequence": 2,
+              "record_type": "vital_record",
+              "jurisdiction": "Jessamine County, Kentucky",
+              "date_range": "1817",
+              "repository": "FamilySearch",
+              "rationale": "The 1817 Jessamine County marriage of Moses McCarley (Jr.) to Betsy Lawson lists Moses Mccarley (Sr.) as the groom's father (ark:/61903/1:1:Q28D-N9C1). Extracting this record provides corroborating evidence that Moses J McCarley Sr was alive and residing in Kentucky in 1817, and establishes the Sr/Jr relationship. Also useful: if the original marriage bond or license names Moses Sr.'s wife as the groom's mother, it would identify her directly.",
+              "fallback_for": null,
+              "status": "planned"
+            }
+          },
+          {
+            "section": "plan_items",
+            "op": "append",
+            "planId": "pl_001",
+            "entry": {
+              "sequence": 3,
+              "record_type": "census",
+              "jurisdiction": "Kentucky",
+              "date_range": "1840",
+              "repository": "FamilySearch",
+              "rationale": "The 1840 US Federal Census is the last census before Moses J McCarley Sr's death (9 April 1844). He would have been ~73. The 1840 census records household members by age/sex brackets, so a female in her 60s\u201370s in the household would indicate a surviving wife. This is important corroborating evidence for whether Elizabeth Patt was still living and residing with him at the time of the census.",
+              "fallback_for": null,
+              "status": "planned"
+            }
+          },
+          {
+            "section": "plan_items",
+            "op": "append",
+            "planId": "pl_001",
+            "entry": {
+              "sequence": 4,
+              "record_type": "probate",
+              "jurisdiction": "Lincoln County, Kentucky",
+              "date_range": "1844-1848",
+              "repository": "FamilySearch",
+              "rationale": "Moses J McCarley Sr died 9 April 1844. His estate would have been probated in the Kentucky county of his residence (likely Lincoln or an adjacent county). The Kentucky Probate Records, 1727-1990 (collection 1875188) is indexed on FamilySearch. A will naming his wife as executrix or beneficiary \u2014 or an estate inventory listing her as widow \u2014 provides direct evidence of her identity. This is a high-value source that could name the spouse explicitly.",
+              "fallback_for": null,
+              "status": "planned"
+            }
+          },
+          {
+            "section": "plan_items",
+            "op": "append",
+            "planId": "pl_001",
+            "entry": {
+              "sequence": 5,
+              "record_type": "census",
+              "jurisdiction": "Kentucky",
+              "date_range": "1830",
+              "repository": "FamilySearch",
+              "rationale": "The 1830 US Federal Census would show Moses J McCarley Sr (~age 63) and his household. A female in the appropriate age bracket would corroborate a surviving wife. The county of enumeration would further confirm his location in Kentucky. Household composition may also show children still at home.",
+              "fallback_for": null,
+              "status": "planned"
+            }
+          },
+          {
+            "section": "plan_items",
+            "op": "append",
+            "planId": "pl_001",
+            "entry": {
+              "sequence": 6,
+              "record_type": "census",
+              "jurisdiction": "Kentucky",
+              "date_range": "1820",
+              "repository": "FamilySearch",
+              "rationale": "The 1820 US Federal Census would show Moses J McCarley Sr (~age 53) and his household. Presence of a wife-aged female corroborates the marriage. Household composition may reveal younger children still at home, helping to bracket the marriage date and identify remaining family members.",
+              "fallback_for": null,
+              "status": "planned"
+            }
+          },
+          {
+            "section": "plan_items",
+            "op": "append",
+            "planId": "pl_001",
+            "entry": {
+              "sequence": 7,
+              "record_type": "census",
+              "jurisdiction": "Kentucky or Virginia",
+              "date_range": "1810",
+              "repository": "FamilySearch",
+              "rationale": "The 1810 US Federal Census would show Moses J McCarley Sr (~age 43) and household. By 1810, he had been married nearly 18 years (if the 1792 marriage is his). Household composition (children, wife age bracket) provides indirect evidence of when the marriage occurred and who was in the family. Also confirms geographic location.",
+              "fallback_for": null,
+              "status": "planned"
+            }
+          },
+          {
+            "section": "plan_items",
+            "op": "append",
+            "planId": "pl_001",
+            "entry": {
+              "sequence": 8,
+              "record_type": "vital_record",
+              "jurisdiction": "Kentucky",
+              "date_range": "1790-1830",
+              "repository": "FamilySearch",
+              "rationale": "FAN cluster search: The preliminary survey found 'Salvina Mccarley' marrying Westley Alverson in Kentucky (ark:/61903/1:1:Q28D-XWSS). The tree shows 'Sabina McCarley' (KF27-BHH) as a possible child of Moses Sr. Marriage records of Moses Sr.'s children often name the father (and sometimes the mother) in marriage bonds or licenses. Extracting any children's Kentucky marriage records that name Moses Sr. or his wife as parent provides corroborating evidence of the spouse's identity.",
+              "fallback_for": null,
+              "status": "planned"
+            }
+          },
+          {
+            "section": "plan_items",
+            "op": "append",
+            "planId": "pl_001",
+            "entry": {
+              "sequence": 9,
+              "record_type": "probate",
+              "jurisdiction": "Garrard or Jessamine County, Kentucky",
+              "date_range": "1844-1850",
+              "repository": "FamilySearch",
+              "rationale": "Fallback: If no Lincoln County probate record is found for Moses J McCarley Sr., check adjacent Garrard and Jessamine Counties where his son Moses Jr. married in 1817. Kentucky county boundaries shifted and families often spanned multiple counties. Kentucky Probate Records, 1727-1990 and Kentucky Wills and Deeds, ca. 1700s-2017 (collection 3155869) cover these jurisdictions.",
+              "fallback_for": "pli_004",
+              "status": "planned"
+            }
+          }
+        ]
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"results\\\": [\\n    {\\n      \\\"section\\\": \\\"plans\\\",\\n      \\\"op\\\": \\\"append\\\",\\n      \\\"entryId\\\": \\\"pl_001\\\"\\n    },\\n    {\\n      \\\"section\\\": \\\"plan_items\\\",\\n      \\\"op\\\": \\\"append\\\",\\n      \\\"entryId\\\": \\\"pli_001\\\"\\n    },\\n    {\\n      \\\"section\\\": \\\"plan_items\\\",\\n      \\\"op\\\": \\\"append\\\",\\n      \\\"entryId\\\": \\\"pli_002\\\"\\n    },\\n    {\\n      \\\"section\\\": \\\"plan_items\\\",\\n      \\\"op\\\": \\\"append\\\",\\n      \\\"entryId\\\": \\\"pli_003\\\"\\n    },..."
+    },
+    {
+      "tool": "Skill",
+      "args": {
+        "skill": "search-records",
+        "args": "--autonomous Execute plan pl_001 for q_001 (\"Who did Moses J McCarley Sr (born 17 January 1767, died 9 April 1844) marry?\"). Subject: L7P6-3TT (Moses J McCarley Sr, Male). Start with pli_001: read and log the 1792 Lincoln County, Kentucky marriage record for Moses McCarley + Elizabeth Patt (ark:/61903/1:1:Q28D-NHWN, collection 1804888, Kentucky County Marriages 1786-1965). Then pli_002: log the 1817 Jessamine County marriage (ark:/61903/1:1:Q28D-N9C1) that lists Moses Sr. as father of Moses Jr. Then pli_003: search 1840 US Census for Moses McCarley Sr. in Kentucky. Then pli_004: search Kentucky Probate Records for Moses McCarley estate 1844-1848. Then pli_005-007: 1830, 1820, 1810 censuses. Then pli_008: FAN search for children's Kentucky marriages naming Moses Sr. Project path: /private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l"
+      },
+      "response_summary": "Launching skill: search-records"
+    },
+    {
+      "tool": "ToolSearch",
+      "args": {
+        "query": "select:mcp__genealogy__research_log_append,mcp__genealogy__rank_search_matches",
+        "max_results": 2
+      },
+      "response_summary": "[{\"type\": \"tool_reference\", \"tool_name\": \"mcp__genealogy__research_log_append\"}, {\"type\": \"tool_reference\", \"tool_name\": \"mcp__genealogy__rank_search_matches\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__record_search",
+      "args": {
+        "surname": "McCarley",
+        "givenName": "Moses",
+        "recordType": "marriage",
+        "recordCountry": "United States",
+        "recordSubdivision": "Kentucky",
+        "anyYearFrom": 1785,
+        "anyYearTo": 1800,
+        "collectionId": "1804888",
+        "sex": "Male",
+        "count": 50,
+        "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l"
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"query\\\": {\\n    \\\"surname\\\": \\\"McCarley\\\",\\n    \\\"givenName\\\": \\\"Moses\\\",\\n    \\\"recordType\\\": \\\"marriage\\\",\\n    \\\"recordCountry\\\": \\\"United States\\\",\\n    \\\"recordSubdivision\\\": \\\"Kentucky\\\",\\n    \\\"anyYearFrom\\\": 1785,\\n    \\\"anyYearTo\\\": 1800,\\n    \\\"collectionId\\\": \\\"1804888\\\",\\n    \\\"sex\\\": \\\"Male\\\",\\n    \\\"count\\\": 50,\\n    \\\"projectPath\\\": \\\"/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l\\\"\\n  },\\n  \\\"totalMatches..."
+    },
+    {
+      "tool": "mcp__genealogy__rank_search_matches",
+      "args": {
+        "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l",
+        "stagedResultsRef": "results/.staging/f0f4e2a1-6d3c-4a62-b40b-344e4f723982.json",
+        "subjectId": "L7P6-3TT",
+        "checkAttachments": true,
+        "top": 10
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"subjectId\\\": \\\"L7P6-3TT\\\",\\n  \\\"scoredCount\\\": 29,\\n  \\\"returnedCount\\\": 10,\\n  \\\"scoringErrors\\\": 0,\\n  \\\"scoreLogError\\\": null,\\n  \\\"matches\\\": [\\n    {\\n      \\\"matchRank\\\": 1,\\n      \\\"searchRank\\\": 1,\\n      \\\"recordId\\\": \\\"ark:/61903/1:1:Q28D-NHWN\\\",\\n      \\\"matchScore\\\": 0.62024873,\\n      \\\"primaryId\\\": \\\"p_102337459396\\\",\\n      \\\"personName\\\": \\\"Moses McCarley\\\",\\n      \\\"sex\\\": \\\"Male\\\",\\n      \\\"collectionTitle\\\": \\\"Kentucky, County Marriages, 17..."
+    },
+    {
+      "tool": "mcp__genealogy__research_log_append",
+      "args": {
+        "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l",
+        "tool": "record_search",
+        "planItemId": "pli_001",
+        "query": {
+          "surname": "McCarley",
+          "givenName": "Moses",
+          "recordType": "marriage",
+          "recordCountry": "United States",
+          "recordSubdivision": "Kentucky",
+          "anyYearFrom": 1785,
+          "anyYearTo": 1800,
+          "collectionId": "1804888",
+          "sex": "Male",
+          "count": 50
+        },
+        "outcome": "positive",
+        "resultsExamined": 10,
+        "resultsAvailable": 29,
+        "stagedResultsRef": "results/.staging/f0f4e2a1-6d3c-4a62-b40b-344e4f723982.json",
+        "notes": "Top match: Moses McCarley married Elizabeth Patt, 24 Jul 1792, Lincoln County, KY (ark:/61903/1:1:Q28D-NHWN, matchScore 0.62, already attached to subject L7P6-3TT). This is the primary evidence for Moses Sr.'s spouse. Also found: Moses McCarley Jr. + Betsy Lawson, 1817, Jessamine Co., KY (pli_002 target, attachedToOther); and 'Mofes Mccarley' as parent in Westley Alverson + Salvina Mccarley (FAN pli_008 target, attachedToSubject)."
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"logId\\\": \\\"log_001\\\",\\n  \\\"performed\\\": \\\"2026-07-15T00:58:03.547Z\\\",\\n  \\\"resultsRef\\\": \\\"results/log_001.json\\\",\\n  \\\"returnedCount\\\": 29,\\n  \\\"filesWritten\\\": [\\n    \\\"research.json\\\",\\n    \\\"results/log_001.json\\\"\\n  ],\\n  \\\"validation\\\": {\\n    \\\"valid\\\": true,\\n    \\\"warnings\\\": []\\n  }\\n}\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__research_append",
+      "args": {
+        "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l",
+        "section": "plan_items",
+        "op": "update",
+        "planId": "pl_001",
+        "entryId": "pli_001",
+        "fields": {
+          "status": "in_progress"
+        }
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"section\\\": \\\"plan_items\\\",\\n  \\\"op\\\": \\\"update\\\",\\n  \\\"entryId\\\": \\\"pli_001\\\",\\n  \\\"filesWritten\\\": [\\n    \\\"research.json\\\"\\n  ],\\n  \\\"validation\\\": {\\n    \\\"valid\\\": true,\\n    \\\"warnings\\\": []\\n  }\\n}\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__record_search",
+      "args": {
+        "surname": "McCarley",
+        "givenName": "Moses",
+        "recordType": "marriage",
+        "recordCountry": "United States",
+        "recordSubdivision": "Kentucky",
+        "anyYearFrom": 1815,
+        "anyYearTo": 1820,
+        "collectionId": "1804888",
+        "sex": "Male",
+        "count": 50,
+        "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l"
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"query\\\": {\\n    \\\"surname\\\": \\\"McCarley\\\",\\n    \\\"givenName\\\": \\\"Moses\\\",\\n    \\\"recordType\\\": \\\"marriage\\\",\\n    \\\"recordCountry\\\": \\\"United States\\\",\\n    \\\"recordSubdivision\\\": \\\"Kentucky\\\",\\n    \\\"anyYearFrom\\\": 1815,\\n    \\\"anyYearTo\\\": 1820,\\n    \\\"collectionId\\\": \\\"1804888\\\",\\n    \\\"sex\\\": \\\"Male\\\",\\n    \\\"count\\\": 50,\\n    \\\"projectPath\\\": \\\"/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l\\\"\\n  },\\n  \\\"totalMatches..."
+    },
+    {
+      "tool": "mcp__genealogy__record_search",
+      "args": {
+        "surname": "McCarley",
+        "givenName": "Moses",
+        "recordType": "census",
+        "recordCountry": "United States",
+        "recordSubdivision": "Kentucky",
+        "residenceYearFrom": 1840,
+        "residenceYearTo": 1840,
+        "birthYearFrom": 1760,
+        "birthYearTo": 1775,
+        "sex": "Male",
+        "count": 50,
+        "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l"
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"query\\\": {\\n    \\\"surname\\\": \\\"McCarley\\\",\\n    \\\"givenName\\\": \\\"Moses\\\",\\n    \\\"recordType\\\": \\\"census\\\",\\n    \\\"recordCountry\\\": \\\"United States\\\",\\n    \\\"recordSubdivision\\\": \\\"Kentucky\\\",\\n    \\\"residenceYearFrom\\\": 1840,\\n    \\\"residenceYearTo\\\": 1840,\\n    \\\"birthYearFrom\\\": 1760,\\n    \\\"birthYearTo\\\": 1775,\\n    \\\"sex\\\": \\\"Male\\\",\\n    \\\"count\\\": 50,\\n    \\\"projectPath\\\": \\\"/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7y..."
+    },
+    {
+      "tool": "mcp__genealogy__rank_search_matches",
+      "args": {
+        "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l",
+        "stagedResultsRef": "results/.staging/43a65eac-f0d6-4068-8ed3-f415b3bb309f.json",
+        "subjectId": "L7P6-3TT",
+        "checkAttachments": true,
+        "top": 5
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"subjectId\\\": \\\"L7P6-3TT\\\",\\n  \\\"scoredCount\\\": 39,\\n  \\\"returnedCount\\\": 5,\\n  \\\"scoringErrors\\\": 0,\\n  \\\"scoreLogError\\\": null,\\n  \\\"matches\\\": [\\n    {\\n      \\\"matchRank\\\": 1,\\n      \\\"searchRank\\\": 2,\\n      \\\"recordId\\\": \\\"ark:/61903/1:1:Q28D-NHWN\\\",\\n      \\\"matchScore\\\": 0.62024873,\\n      \\\"primaryId\\\": \\\"p_102337459396\\\",\\n      \\\"personName\\\": \\\"Moses McCarley\\\",\\n      \\\"sex\\\": \\\"Male\\\",\\n      \\\"collectionTitle\\\": \\\"Kentucky, County Marriages, 178..."
+    },
+    {
+      "tool": "mcp__genealogy__record_search",
+      "args": {
+        "surname": "McCarley",
+        "givenName": "Moses",
+        "recordType": "census",
+        "recordCountry": "United States",
+        "recordSubdivision": "Kentucky",
+        "residenceYearFrom": 1838,
+        "residenceYearTo": 1842,
+        "sex": "Male",
+        "count": 50,
+        "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l"
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"query\\\": {\\n    \\\"surname\\\": \\\"McCarley\\\",\\n    \\\"givenName\\\": \\\"Moses\\\",\\n    \\\"recordType\\\": \\\"census\\\",\\n    \\\"recordCountry\\\": \\\"United States\\\",\\n    \\\"recordSubdivision\\\": \\\"Kentucky\\\",\\n    \\\"residenceYearFrom\\\": 1838,\\n    \\\"residenceYearTo\\\": 1842,\\n    \\\"sex\\\": \\\"Male\\\",\\n    \\\"count\\\": 50,\\n    \\\"projectPath\\\": \\\"/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l\\\"\\n  },\\n  \\\"totalMatches\\\": 0,\\n  \\\"paginationCapp..."
+    },
+    {
+      "tool": "mcp__genealogy__research_log_append",
+      "args": {
+        "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l",
+        "tool": "record_search",
+        "planItemId": "pli_002",
+        "query": {
+          "surname": "McCarley",
+          "givenName": "Moses",
+          "recordType": "marriage",
+          "recordCountry": "United States",
+          "recordSubdivision": "Kentucky",
+          "anyYearFrom": 1815,
+          "anyYearTo": 1820,
+          "collectionId": "1804888",
+          "sex": "Male",
+          "count": 50
+        },
+        "outcome": "positive",
+        "resultsExamined": 5,
+        "resultsAvailable": 39,
+        "stagedResultsRef": "results/.staging/43a65eac-f0d6-4068-8ed3-f415b3bb309f.json",
+        "notes": "Target record found: Moses McCarley + Betsy Lawson, 21 Nov 1817, Jessamine County, KY (ark:/61903/1:1:Q28D-N9C1, matchScore 0.11, attachedToOther=Moses Jr.). The full record shows Moses Mccarley (Sr., p_102337453201) listed as parent of Moses McCarley Jr. (groom). This corroborates Moses Sr.'s presence in Kentucky and the Sr/Jr distinction. Also ark:/61903/1:1:Q28D-N9Z9 is the father persona (Moses Mccarley Sr., attachedToSubject L7P6-3TT)."
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"logId\\\": \\\"log_002\\\",\\n  \\\"performed\\\": \\\"2026-07-15T00:58:56.577Z\\\",\\n  \\\"resultsRef\\\": \\\"results/log_002.json\\\",\\n  \\\"returnedCount\\\": 39,\\n  \\\"filesWritten\\\": [\\n    \\\"research.json\\\",\\n    \\\"results/log_002.json\\\"\\n  ],\\n  \\\"validation\\\": {\\n    \\\"valid\\\": true,\\n    \\\"warnings\\\": []\\n  }\\n}\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__research_append",
+      "args": {
+        "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l",
+        "section": "plan_items",
+        "op": "update",
+        "planId": "pl_001",
+        "entryId": "pli_002",
+        "fields": {
+          "status": "in_progress"
+        }
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"section\\\": \\\"plan_items\\\",\\n  \\\"op\\\": \\\"update\\\",\\n  \\\"entryId\\\": \\\"pli_002\\\",\\n  \\\"filesWritten\\\": [\\n    \\\"research.json\\\"\\n  ],\\n  \\\"validation\\\": {\\n    \\\"valid\\\": true,\\n    \\\"warnings\\\": []\\n  }\\n}\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__research_log_append",
+      "args": {
+        "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l",
+        "tool": "record_search",
+        "planItemId": "pli_003",
+        "query": {
+          "surname": "McCarley",
+          "givenName": "Moses",
+          "recordType": "census",
+          "recordCountry": "United States",
+          "recordSubdivision": "Kentucky",
+          "residenceYearFrom": 1840,
+          "residenceYearTo": 1840,
+          "birthYearFrom": 1760,
+          "birthYearTo": 1775,
+          "sex": "Male",
+          "count": 50
+        },
+        "outcome": "negative",
+        "resultsExamined": 0,
+        "resultsAvailable": 0,
+        "notes": "Zero results for 1840 census in Kentucky with birth-year constraint 1760-1775. The 1840 US census does not index individual household member names (only head of household), so a birth-year filter may be blocking results. Retrying without birth-year filter."
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"logId\\\": \\\"log_003\\\",\\n  \\\"performed\\\": \\\"2026-07-15T00:59:11.484Z\\\",\\n  \\\"resultsRef\\\": null,\\n  \\\"returnedCount\\\": null,\\n  \\\"filesWritten\\\": [\\n    \\\"research.json\\\"\\n  ],\\n  \\\"validation\\\": {\\n    \\\"valid\\\": true,\\n    \\\"warnings\\\": []\\n  }\\n}\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__research_log_append",
+      "args": {
+        "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l",
+        "tool": "record_search",
+        "planItemId": "pli_003",
+        "query": {
+          "surname": "McCarley",
+          "givenName": "Moses",
+          "recordType": "census",
+          "recordCountry": "United States",
+          "recordSubdivision": "Kentucky",
+          "residenceYearFrom": 1838,
+          "residenceYearTo": 1842,
+          "sex": "Male",
+          "count": 50
+        },
+        "outcome": "negative",
+        "resultsExamined": 0,
+        "resultsAvailable": 0,
+        "notes": "Still zero results after removing birth-year filter. The 1840 census may be in a different collection partition or indexed under a name variant. Will try broader national search without subdivision constraint."
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"logId\\\": \\\"log_004\\\",\\n  \\\"performed\\\": \\\"2026-07-15T00:59:18.375Z\\\",\\n  \\\"resultsRef\\\": null,\\n  \\\"returnedCount\\\": null,\\n  \\\"filesWritten\\\": [\\n    \\\"research.json\\\"\\n  ],\\n  \\\"validation\\\": {\\n    \\\"valid\\\": true,\\n    \\\"warnings\\\": []\\n  }\\n}\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__record_search",
+      "args": {
+        "surname": "McCarley",
+        "givenName": "Moses",
+        "recordType": "census",
+        "recordCountry": "United States",
+        "residenceYearFrom": 1838,
+        "residenceYearTo": 1842,
+        "sex": "Male",
+        "count": 50,
+        "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l"
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"query\\\": {\\n    \\\"surname\\\": \\\"McCarley\\\",\\n    \\\"givenName\\\": \\\"Moses\\\",\\n    \\\"recordType\\\": \\\"census\\\",\\n    \\\"recordCountry\\\": \\\"United States\\\",\\n    \\\"residenceYearFrom\\\": 1838,\\n    \\\"residenceYearTo\\\": 1842,\\n    \\\"sex\\\": \\\"Male\\\",\\n    \\\"count\\\": 50,\\n    \\\"projectPath\\\": \\\"/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l\\\"\\n  },\\n  \\\"totalMatches\\\": 1,\\n  \\\"paginationCappedAt\\\": 4999,\\n  \\\"returned\\\": 1,\\n  \\\"off..."
+    },
+    {
+      "tool": "mcp__genealogy__record_search",
+      "args": {
+        "surname": "McCarley",
+        "givenName": "Moses",
+        "recordType": "census",
+        "recordCountry": "United States",
+        "residenceYearFrom": 1828,
+        "residenceYearTo": 1832,
+        "sex": "Male",
+        "count": 50,
+        "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l"
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"query\\\": {\\n    \\\"surname\\\": \\\"McCarley\\\",\\n    \\\"givenName\\\": \\\"Moses\\\",\\n    \\\"recordType\\\": \\\"census\\\",\\n    \\\"recordCountry\\\": \\\"United States\\\",\\n    \\\"residenceYearFrom\\\": 1828,\\n    \\\"residenceYearTo\\\": 1832,\\n    \\\"sex\\\": \\\"Male\\\",\\n    \\\"count\\\": 50,\\n    \\\"projectPath\\\": \\\"/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l\\\"\\n  },\\n  \\\"totalMatches\\\": 1,\\n  \\\"paginationCappedAt\\\": 4999,\\n  \\\"returned\\\": 1,\\n  \\\"off..."
+    },
+    {
+      "tool": "mcp__genealogy__record_search",
+      "args": {
+        "surname": "McCurley",
+        "givenName": "Moses",
+        "recordType": "census",
+        "recordCountry": "United States",
+        "residenceYearFrom": 1838,
+        "residenceYearTo": 1842,
+        "sex": "Male",
+        "count": 50,
+        "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l"
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"query\\\": {\\n    \\\"surname\\\": \\\"McCurley\\\",\\n    \\\"givenName\\\": \\\"Moses\\\",\\n    \\\"recordType\\\": \\\"census\\\",\\n    \\\"recordCountry\\\": \\\"United States\\\",\\n    \\\"residenceYearFrom\\\": 1838,\\n    \\\"residenceYearTo\\\": 1842,\\n    \\\"sex\\\": \\\"Male\\\",\\n    \\\"count\\\": 50,\\n    \\\"projectPath\\\": \\\"/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l\\\"\\n  },\\n  \\\"totalMatches\\\": 1,\\n  \\\"paginationCappedAt\\\": 4999,\\n  \\\"returned\\\": 1,\\n  \\\"off..."
+    },
+    {
+      "tool": "mcp__genealogy__record_search",
+      "args": {
+        "surname": "McCarley",
+        "givenName": "Moses",
+        "recordType": "probate",
+        "recordCountry": "United States",
+        "recordSubdivision": "Kentucky",
+        "sex": "Male",
+        "count": 50,
+        "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l"
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"query\\\": {\\n    \\\"surname\\\": \\\"McCarley\\\",\\n    \\\"givenName\\\": \\\"Moses\\\",\\n    \\\"recordType\\\": \\\"probate\\\",\\n    \\\"recordCountry\\\": \\\"United States\\\",\\n    \\\"recordSubdivision\\\": \\\"Kentucky\\\",\\n    \\\"sex\\\": \\\"Male\\\",\\n    \\\"count\\\": 50,\\n    \\\"projectPath\\\": \\\"/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l\\\"\\n  },\\n  \\\"totalMatches\\\": 0,\\n  \\\"paginationCappedAt\\\": 4999,\\n  \\\"returned\\\": 0,\\n  \\\"offset\\\": 0,\\n  \\\"hasMore\\..."
+    },
+    {
+      "tool": "mcp__genealogy__record_search",
+      "args": {
+        "surname": "McCarley",
+        "givenName": "Moses",
+        "recordCountry": "United States",
+        "anyYearFrom": 1840,
+        "anyYearTo": 1840,
+        "anyYearExact": true,
+        "sex": "Male",
+        "count": 50,
+        "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l"
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"query\\\": {\\n    \\\"surname\\\": \\\"McCarley\\\",\\n    \\\"givenName\\\": \\\"Moses\\\",\\n    \\\"recordCountry\\\": \\\"United States\\\",\\n    \\\"anyYearFrom\\\": 1840,\\n    \\\"anyYearTo\\\": 1840,\\n    \\\"anyYearExact\\\": true,\\n    \\\"sex\\\": \\\"Male\\\",\\n    \\\"count\\\": 50,\\n    \\\"projectPath\\\": \\\"/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l\\\"\\n  },\\n  \\\"totalMatches\\\": 33,\\n  \\\"paginationCappedAt\\\": 4999,\\n  \\\"returned\\\": 33,\\n  \\\"offset\\\": 0,\\n  \\..."
+    },
+    {
+      "tool": "mcp__genealogy__record_search",
+      "args": {
+        "surname": "McCarley",
+        "givenName": "Moses",
+        "recordType": "probate",
+        "recordCountry": "United States",
+        "sex": "Male",
+        "anyYearFrom": 1840,
+        "anyYearTo": 1850,
+        "count": 50,
+        "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l"
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"query\\\": {\\n    \\\"surname\\\": \\\"McCarley\\\",\\n    \\\"givenName\\\": \\\"Moses\\\",\\n    \\\"recordType\\\": \\\"probate\\\",\\n    \\\"recordCountry\\\": \\\"United States\\\",\\n    \\\"sex\\\": \\\"Male\\\",\\n    \\\"anyYearFrom\\\": 1840,\\n    \\\"anyYearTo\\\": 1850,\\n    \\\"count\\\": 50,\\n    \\\"projectPath\\\": \\\"/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l\\\"\\n  },\\n  \\\"totalMatches\\\": 1,\\n  \\\"paginationCappedAt\\\": 4999,\\n  \\\"returned\\\": 1,\\n  \\\"offset\\\": 0,\\n..."
+    },
+    {
+      "tool": "mcp__genealogy__research_log_append",
+      "args": {
+        "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l",
+        "tool": "record_search",
+        "planItemId": "pli_003",
+        "query": {
+          "surname": "McCarley",
+          "givenName": "Moses",
+          "recordCountry": "United States",
+          "anyYearFrom": 1840,
+          "anyYearTo": 1840,
+          "anyYearExact": true,
+          "sex": "Male",
+          "count": 50
+        },
+        "outcome": "negative",
+        "resultsExamined": 0,
+        "resultsAvailable": 33,
+        "notes": "33 results returned, but all matched on birthDate=1840, not a 1840 residence year \u2014 none are Moses Sr. (born 1767). The anyYear filter appears to match birth dates in FamilySearch. The 1840 census for Moses McCarley Sr. is not surfacing through this query shape. The 1840 US Census may not be fully indexed under this spelling or county. Will search Kentucky Probate Records collection directly."
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"logId\\\": \\\"log_005\\\",\\n  \\\"performed\\\": \\\"2026-07-15T01:00:35.644Z\\\",\\n  \\\"resultsRef\\\": null,\\n  \\\"returnedCount\\\": null,\\n  \\\"filesWritten\\\": [\\n    \\\"research.json\\\"\\n  ],\\n  \\\"validation\\\": {\\n    \\\"valid\\\": true,\\n    \\\"warnings\\\": []\\n  }\\n}\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__research_append",
+      "args": {
+        "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l",
+        "section": "plan_items",
+        "op": "update",
+        "planId": "pl_001",
+        "entryId": "pli_003",
+        "fields": {
+          "status": "in_progress"
+        }
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"section\\\": \\\"plan_items\\\",\\n  \\\"op\\\": \\\"update\\\",\\n  \\\"entryId\\\": \\\"pli_003\\\",\\n  \\\"filesWritten\\\": [\\n    \\\"research.json\\\"\\n  ],\\n  \\\"validation\\\": {\\n    \\\"valid\\\": true,\\n    \\\"warnings\\\": []\\n  }\\n}\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__record_search",
+      "args": {
+        "surname": "McCarley",
+        "givenName": "Moses",
+        "recordCountry": "United States",
+        "collectionId": "1875188",
+        "sex": "Male",
+        "count": 50,
+        "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l"
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"query\\\": {\\n    \\\"surname\\\": \\\"McCarley\\\",\\n    \\\"givenName\\\": \\\"Moses\\\",\\n    \\\"recordCountry\\\": \\\"United States\\\",\\n    \\\"collectionId\\\": \\\"1875188\\\",\\n    \\\"sex\\\": \\\"Male\\\",\\n    \\\"count\\\": 50,\\n    \\\"projectPath\\\": \\\"/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l\\\"\\n  },\\n  \\\"totalMatches\\\": 0,\\n  \\\"paginationCappedAt\\\": 4999,\\n  \\\"returned\\\": 0,\\n  \\\"offset\\\": 0,\\n  \\\"hasMore\\\": false,\\n  \\\"results\\\": [],\\n  \\\"stage..."
+    },
+    {
+      "tool": "mcp__genealogy__record_search",
+      "args": {
+        "surname": "McCarley",
+        "givenName": "Moses",
+        "recordType": "census",
+        "recordCountry": "United States",
+        "residenceYearFrom": 1818,
+        "residenceYearTo": 1822,
+        "sex": "Male",
+        "count": 50,
+        "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l"
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"query\\\": {\\n    \\\"surname\\\": \\\"McCarley\\\",\\n    \\\"givenName\\\": \\\"Moses\\\",\\n    \\\"recordType\\\": \\\"census\\\",\\n    \\\"recordCountry\\\": \\\"United States\\\",\\n    \\\"residenceYearFrom\\\": 1818,\\n    \\\"residenceYearTo\\\": 1822,\\n    \\\"sex\\\": \\\"Male\\\",\\n    \\\"count\\\": 50,\\n    \\\"projectPath\\\": \\\"/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l\\\"\\n  },\\n  \\\"totalMatches\\\": 1,\\n  \\\"paginationCappedAt\\\": 4999,\\n  \\\"returned\\\": 1,\\n  \\\"off..."
+    },
+    {
+      "tool": "mcp__genealogy__research_log_append",
+      "args": {
+        "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l",
+        "tool": "record_search",
+        "planItemId": "pli_004",
+        "query": {
+          "surname": "McCarley",
+          "givenName": "Moses",
+          "recordCountry": "United States",
+          "collectionId": "1875188",
+          "sex": "Male",
+          "count": 50,
+          "note": "Kentucky Probate Records, 1727-1990"
+        },
+        "outcome": "negative",
+        "resultsExamined": 0,
+        "resultsAvailable": 0,
+        "notes": "Zero results in Kentucky Probate Records collection 1875188. Only 12,429 indexed records in that collection vs. 989,444 images \u2014 the index is very sparse and most probate records are browse-only images. Will try Kentucky Wills and Deeds (collection 3155869) and a name variant search."
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"logId\\\": \\\"log_006\\\",\\n  \\\"performed\\\": \\\"2026-07-15T01:01:19.416Z\\\",\\n  \\\"resultsRef\\\": null,\\n  \\\"returnedCount\\\": null,\\n  \\\"filesWritten\\\": [\\n    \\\"research.json\\\"\\n  ],\\n  \\\"validation\\\": {\\n    \\\"valid\\\": true,\\n    \\\"warnings\\\": []\\n  }\\n}\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__research_log_append",
+      "args": {
+        "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l",
+        "tool": "record_search",
+        "planItemId": "pli_006",
+        "query": {
+          "surname": "McCarley",
+          "givenName": "Moses",
+          "recordType": "census",
+          "recordCountry": "United States",
+          "residenceYearFrom": 1818,
+          "residenceYearTo": 1822,
+          "sex": "Male",
+          "count": 50
+        },
+        "outcome": "negative",
+        "resultsExamined": 0,
+        "resultsAvailable": 0,
+        "notes": "Zero useful results for 1820 census. Only the Nauvoo Community Project (1839-1846) returned, which is not the 1820 US Census and not our subject. The 1820 US Census may not index Moses McCarley Sr. under this spelling. Skipping further census variants \u2014 the 1840/1830/1820 censuses for this family appear not indexed on FamilySearch for this spelling. The primary marriage evidence (1792) is sufficient for the research question."
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"logId\\\": \\\"log_007\\\",\\n  \\\"performed\\\": \\\"2026-07-15T01:01:33.530Z\\\",\\n  \\\"resultsRef\\\": null,\\n  \\\"returnedCount\\\": null,\\n  \\\"filesWritten\\\": [\\n    \\\"research.json\\\"\\n  ],\\n  \\\"validation\\\": {\\n    \\\"valid\\\": true,\\n    \\\"warnings\\\": []\\n  }\\n}\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__record_search",
+      "args": {
+        "surname": "McCarley",
+        "givenName": "Moses",
+        "recordCountry": "United States",
+        "collectionId": "3155869",
+        "count": 50,
+        "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l"
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"query\\\": {\\n    \\\"surname\\\": \\\"McCarley\\\",\\n    \\\"givenName\\\": \\\"Moses\\\",\\n    \\\"recordCountry\\\": \\\"United States\\\",\\n    \\\"collectionId\\\": \\\"3155869\\\",\\n    \\\"count\\\": 50,\\n    \\\"projectPath\\\": \\\"/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l\\\"\\n  },\\n  \\\"totalMatches\\\": 0,\\n  \\\"paginationCappedAt\\\": 4999,\\n  \\\"returned\\\": 0,\\n  \\\"offset\\\": 0,\\n  \\\"hasMore\\\": false,\\n  \\\"results\\\": [],\\n  \\\"staged\\\": null\\n}\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__record_read",
+      "args": {
+        "recordId": "ark:/61903/1:1:Q28D-XWSS"
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"persons\\\": [\\n    {\\n      \\\"id\\\": \\\"p_102337403457\\\",\\n      \\\"ark\\\": \\\"ark:/61903/1:1:Q28D-XW9Y\\\",\\n      \\\"gender\\\": \\\"Male\\\",\\n      \\\"names\\\": [\\n        {\\n          \\\"id\\\": \\\"acc46134-6731-49e3-b7f0-a58e805db3e1\\\",\\n          \\\"type\\\": \\\"BirthName\\\",\\n          \\\"surname\\\": \\\"Alverson\\\",\\n          \\\"given\\\": \\\"Westley\\\"\\n        }\\n      ],\\n      \\\"facts\\\": [\\n        {\\n          \\\"id\\\": \\\"c0afe491-87c6-47b8-a32a-241c1f3e4881\\\",\\n          \\\"type\\\":..."
+    },
+    {
+      "tool": "mcp__genealogy__research_log_append",
+      "args": {
+        "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l",
+        "tool": "record_search",
+        "planItemId": "pli_004",
+        "query": {
+          "surname": "McCarley",
+          "givenName": "Moses",
+          "recordCountry": "United States",
+          "collectionId": "3155869",
+          "count": 50,
+          "note": "Kentucky Wills and Deeds, ca. 1700s-2017"
+        },
+        "outcome": "negative",
+        "resultsExamined": 0,
+        "resultsAvailable": 0,
+        "notes": "Zero results in Kentucky Wills and Deeds collection 3155869. This collection has only 1 indexed record with 33,345 persons and 3,892 images \u2014 it is essentially a browse-only collection. Moses McCarley Sr.'s will or estate records may exist in the images but are not name-indexed. The probate evidence path is exhausted for indexed searches; image browsing would require knowing the exact county and volume."
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"logId\\\": \\\"log_008\\\",\\n  \\\"performed\\\": \\\"2026-07-15T01:02:18.322Z\\\",\\n  \\\"resultsRef\\\": null,\\n  \\\"returnedCount\\\": null,\\n  \\\"filesWritten\\\": [\\n    \\\"research.json\\\"\\n  ],\\n  \\\"validation\\\": {\\n    \\\"valid\\\": true,\\n    \\\"warnings\\\": []\\n  }\\n}\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__research_log_append",
+      "args": {
+        "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l",
+        "tool": "record_search",
+        "planItemId": "pli_008",
+        "query": {
+          "record_read": "ark:/61903/1:1:Q28D-XWSS",
+          "note": "FAN: Westley Alverson + Salvina Mccarley marriage, Jessamine Co. KY, 28 Apr 1827 \u2014 Moses McCarley Sr. listed as parent of bride"
+        },
+        "outcome": "positive",
+        "resultsExamined": 1,
+        "resultsAvailable": 1,
+        "notes": "FAN record found via record_read of ark:/61903/1:1:Q28D-XWSS (surfaced during log_001 marriage search). 'Mofes Mccarley' (Moses McCarley Sr.) listed as father of Salvina Mccarley who married Westley Alverson, 28 Apr 1827, Jessamine County, KY. Confirms Moses Sr. was alive and in Jessamine County in 1827. Salvina = Sabina McCarley (tree person KF27-BHH). No wife/mother named on this record. This record corroborates Moses Sr.'s Kentucky residence but does not name his spouse directly."
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"logId\\\": \\\"log_009\\\",\\n  \\\"performed\\\": \\\"2026-07-15T01:02:32.061Z\\\",\\n  \\\"resultsRef\\\": null,\\n  \\\"returnedCount\\\": null,\\n  \\\"filesWritten\\\": [\\n    \\\"research.json\\\"\\n  ],\\n  \\\"validation\\\": {\\n    \\\"valid\\\": true,\\n    \\\"warnings\\\": []\\n  }\\n}\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__research_append",
+      "args": {
+        "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l",
+        "ops": [
+          {
+            "section": "plan_items",
+            "op": "update",
+            "planId": "pl_001",
+            "entryId": "pli_004",
+            "fields": {
+              "status": "in_progress"
+            }
+          },
+          {
+            "section": "plan_items",
+            "op": "update",
+            "planId": "pl_001",
+            "entryId": "pli_005",
+            "fields": {
+              "status": "skipped"
+            }
+          },
+          {
+            "section": "plan_items",
+            "op": "update",
+            "planId": "pl_001",
+            "entryId": "pli_007",
+            "fields": {
+              "status": "skipped"
+            }
+          },
+          {
+            "section": "plan_items",
+            "op": "update",
+            "planId": "pl_001",
+            "entryId": "pli_008",
+            "fields": {
+              "status": "in_progress"
+            }
+          },
+          {
+            "section": "plan_items",
+            "op": "update",
+            "planId": "pl_001",
+            "entryId": "pli_009",
+            "fields": {
+              "status": "skipped"
+            }
+          }
+        ]
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"results\\\": [\\n    {\\n      \\\"section\\\": \\\"plan_items\\\",\\n      \\\"op\\\": \\\"update\\\",\\n      \\\"entryId\\\": \\\"pli_004\\\"\\n    },\\n    {\\n      \\\"section\\\": \\\"plan_items\\\",\\n      \\\"op\\\": \\\"update\\\",\\n      \\\"entryId\\\": \\\"pli_005\\\"\\n    },\\n    {\\n      \\\"section\\\": \\\"plan_items\\\",\\n      \\\"op\\\": \\\"update\\\",\\n      \\\"entryId\\\": \\\"pli_007\\\"\\n    },\\n    {\\n      \\\"section\\\": \\\"plan_items\\\",\\n      \\\"op\\\": \\\"update\\\",\\n      \\\"entryId\\\": \\\"pli_008\\\"\\n..."
+    },
+    {
+      "tool": "Skill",
+      "args": {
+        "skill": "record-extraction",
+        "args": "--autonomous Extract assertions from the following three records for research question q_001 (\"Who did Moses J McCarley Sr (born 17 January 1767, died 9 April 1844) marry?\"). Subject person: L7P6-3TT (Moses J McCarley Sr, Male, born 17 Jan 1767, died 9 Apr 1844). Project path: /private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l\n\nRECORD 1 (pli_001, log_001): ark:/61903/1:1:Q28D-NHWN \u2014 Moses McCarley married Elizabeth Patt, 24 Jul 1792, Lincoln County, Kentucky. Collection: Kentucky, County Marriages, 1786-1965 (1804888). Record ARK image: ark:/61903/1:2:QLWS-5MZ8. This is the primary direct evidence identifying Moses Sr.'s spouse. Full record read confirms: marriage date 24 Jul 1792, place Lincoln County, KY. Already attached to subject L7P6-3TT in FamilySearch tree.\n\nRECORD 2 (pli_002, log_002): ark:/61903/1:1:Q28D-N9C1 \u2014 Moses McCarley Jr. married Betsy Lawson, 21 Nov 1817, Jessamine County, Kentucky. Collection: Kentucky, County Marriages, 1786-1965 (1804888). Record ARK image: ark:/61903/1:2:QLWS-PTY9. Moses Mccarley (Sr.) is listed as parent/father of the groom (persona ark: ark:/61903/1:1:Q28D-N9Z9). This corroborates Moses Sr.'s existence and Kentucky residence in 1817.\n\nRECORD 3 (pli_008, log_009): ark:/61903/1:1:Q28D-XWSS \u2014 \"Mofes Mccarley\" (Moses Sr.) listed as father of Salvina Mccarley who married Westley Alverson, 28 Apr 1827, Jessamine County, Kentucky. Collection: Kentucky, County Marriages, 1786-1965 (1804888). Record ARK image: ark:/61903/1:2:QLWS-P3HQ. Confirms Moses Sr. alive in Jessamine County in 1827 with daughter Salvina (= Sabina, tree person KF27-BHH)."
+      },
+      "response_summary": "Launching skill: record-extraction"
+    },
+    {
+      "tool": "Agent",
+      "args": {
+        "description": "Extract Record 1: Moses McCarley + Elizabeth Patt marriage 1792",
+        "subagent_type": "record-extractor",
+        "prompt": "Extract all GPS-conformant assertions from this FamilySearch marriage record and persist them to research.json and tree.gedcomx.json.\n\n**projectPath:** /private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l\n\n**recordId:** ark:/61903/1:1:Q28D-NHWN\n\n**logId:** log_001\n\n**Open research question:** q_001 \u2014 \"Who did Moses J McCarley Sr (born 17 January 1767, died 9 April 1844) marry?\"\n\n**Research subject in tree:** L7P6-3TT = Moses J McCarley Sr, Male, born 17 Jan 1767, died 9 Apr 1844.\n\n**Record content (full GEDCOMX from record_read):**\n```json\n{\n  \"persons\": [\n    {\n      \"id\": \"p_102337459396\",\n      \"ark\": \"ark:/61903/1:1:Q28D-NHWN\",\n      \"gender\": \"Male\",\n      \"names\": [{\"type\": \"BirthName\", \"given\": \"Moses\", \"surname\": \"McCarley\"}],\n      \"facts\": [{\"type\": \"Unknown\", \"primary\": true, \"place\": \"Lincoln\", \"standard_place\": \"Lincoln, Kentucky, United States\"}],\n      \"sources\": [{\"ref\": \"sd_da1\"}]\n    },\n    {\n      \"id\": \"p_102337459399\",\n      \"ark\": \"ark:/61903/1:1:Q28D-NHWK\",\n      \"gender\": \"Female\",\n      \"names\": [{\"type\": \"BirthName\", \"given\": \"Elizabeth\", \"surname\": \"Patt\"}],\n      \"sources\": [{\"ref\": \"sd_da1\"}]\n    }\n  ],\n  \"relationships\": [\n    {\n      \"type\": \"Couple\",\n      \"person1\": \"p_102337459396\",\n      \"person2\": \"p_102337459399\",\n      \"facts\": [{\n        \"type\": \"Marriage\",\n        \"primary\": true,\n        \"date\": \"24 Jul 1792\",\n        \"standard_date\": \"24 Jul 1792\",\n        \"place\": \"Lincoln, Kentucky, United States\",\n        \"standard_place\": \"Lincoln, Kentucky, United States\"\n      }]\n    }\n  ],\n  \"sources\": [{\n    \"id\": \"src_r_102937068311\",\n    \"title\": \"Entry for Moses McCarley and Elizabeth Patt, \\\"Kentucky, County Marriages, 1786-1965\\\"\",\n    \"citation\": \"\\\"Kentucky, County Marriages, 1786-1965\\\", FamilySearch (https://www.familysearch.org/ark:/61903/1:1:Q28D-NHWN : Sat Feb 24 07:50:21 UTC 2024), Entry for Moses McCarley and Elizabeth Patt, 24 Jul 1792.\",\n    \"url\": \"https://www.familysearch.org/ark:/61903/1:2:QLWS-5MZ8\"\n  }]\n}\n```\n\n**Context:** This index entry (derivative source) records Moses McCarley marrying Elizabeth Patt on 24 Jul 1792 in Lincoln County, Kentucky. Moses McCarley (persona p_102337459396) is the research subject Moses J McCarley Sr (tree person L7P6-3TT), born 17 Jan 1767 \u2014 age 25 at marriage, fully plausible. Elizabeth Patt (p_102337459399) is an unknown person not yet in the tree. This record is already attached to L7P6-3TT in the FamilySearch tree. The primary collection is \"Kentucky, County Marriages, 1786-1965\" \u2014 a derivative index pointing to original county marriage bonds/licenses. The informant is an official recorder working from original bonds; the marriage date and place are primary information recorded at or near the event.\n\nExtract: marriage event assertion for Moses J McCarley Sr (L7P6-3TT); create a tree stub for Elizabeth Patt as his spouse; create a Couple relationship between them in tree.gedcomx.json. Classify the source as derivative (county marriage index), information as primary (date/place recorded at event), evidence as direct (directly answers who Moses married)."
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"Extraction complete.\\n\\n- **Source:** src_001 / S1 \\u2014 created (`sourceReuse.action: \\\"created\\\"`). Classified `derivative` (county marriage index); notes flag **original not examined** \\u2014 underlying marriage bond/license image not reached.\\n- **Assertions (4):** groom (Moses McCarley, p_102337459396) \\u2014 a_001 Name, a_003 Marriage; bride (Elizabeth Patt, p_102337459399) \\u2014 a_002 Name, a_004 Marriage. All `information_quality: primary`, `evidence_type:..."
+    },
+    {
+      "tool": "mcp__genealogy__project_context",
+      "args": {
+        "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l"
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"projectStatus\\\": \\\"active\\\",\\n  \\\"openQuestions\\\": [\\n    {\\n      \\\"id\\\": \\\"q_001\\\",\\n      \\\"question\\\": \\\"Who did Moses J McCarley Sr (born 17 January 1767, died 9 April 1844) marry?\\\"\\n    }\\n  ],\\n  \\\"persons\\\": [\\n    {\\n      \\\"id\\\": \\\"L7P6-3TT\\\",\\n      \\\"name\\\": \\\"Moses J McCarley\\\",\\n      \\\"gender\\\": \\\"Male\\\",\\n      \\\"sourceRefs\\\": []\\n    },\\n    {\\n      \\\"id\\\": \\\"LHD2-QCN\\\",\\n      \\\"name\\\": \\\"Sophia McCarley\\\",\\n      \\\"gender..."
+    },
+    {
+      "tool": "Agent",
+      "args": {
+        "description": "Extract Record 2: Moses McCarley Jr + Betsy Lawson marriage 1817 (Sr listed as father)",
+        "subagent_type": "record-extractor",
+        "prompt": "Extract all GPS-conformant assertions from this FamilySearch marriage record and persist them to research.json and tree.gedcomx.json.\n\n**projectPath:** /private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l\n\n**recordId:** ark:/61903/1:1:Q28D-N9C1\n\n**logId:** log_002\n\n**Open research question:** q_001 \u2014 \"Who did Moses J McCarley Sr (born 17 January 1767, died 9 April 1844) marry?\"\n\n**Research subject in tree:** L7P6-3TT = Moses J McCarley Sr, Male, born 17 Jan 1767, died 9 Apr 1844.\n\n**Record content (full GEDCOMX from record_read):**\n```json\n{\n  \"persons\": [\n    {\n      \"id\": \"p_102337453199\",\n      \"ark\": \"ark:/61903/1:1:Q28D-N9C1\",\n      \"gender\": \"Male\",\n      \"names\": [{\"type\": \"BirthName\", \"given\": \"Moses\", \"surname\": \"McCarley\"}],\n      \"facts\": [{\"type\": \"Unknown\", \"primary\": true, \"place\": \"Jessamine\", \"standard_place\": \"Jessamine, Kentucky, United States\"}],\n      \"sources\": [{\"ref\": \"sd_da1\"}]\n    },\n    {\n      \"id\": \"p_102337453201\",\n      \"ark\": \"ark:/61903/1:1:Q28D-N9Z9\",\n      \"gender\": \"Male\",\n      \"names\": [{\"type\": \"BirthName\", \"given\": \"Moses\", \"surname\": \"Mccarley\"}],\n      \"sources\": [{\"ref\": \"sd_da1\"}]\n    },\n    {\n      \"id\": \"p_102337453209\",\n      \"ark\": \"ark:/61903/1:1:Q28D-N9ZC\",\n      \"gender\": \"Female\",\n      \"names\": [{\"type\": \"BirthName\", \"given\": \"Betsy\", \"surname\": \"Lawson\"}],\n      \"sources\": [{\"ref\": \"sd_da1\"}]\n    }\n  ],\n  \"relationships\": [\n    {\n      \"type\": \"ParentChild\",\n      \"parent\": \"p_102337453201\",\n      \"child\": \"p_102337453199\"\n    },\n    {\n      \"type\": \"Couple\",\n      \"person1\": \"p_102337453199\",\n      \"person2\": \"p_102337453209\",\n      \"facts\": [{\n        \"type\": \"Marriage\",\n        \"primary\": true,\n        \"date\": \"21 Nov 1817\",\n        \"standard_date\": \"21 Nov 1817\",\n        \"place\": \"Jessamine, Kentucky, United States\",\n        \"standard_place\": \"Jessamine, Kentucky, United States\"\n      }]\n    }\n  ],\n  \"sources\": [{\n    \"id\": \"src_r_102937065211\",\n    \"title\": \"Entry for Moses McCarley and Betsy Lawson, \\\"Kentucky, County Marriages, 1786-1965\\\"\",\n    \"citation\": \"\\\"Kentucky, County Marriages, 1786-1965\\\", FamilySearch (https://www.familysearch.org/ark:/61903/1:1:Q28D-N9C1 : Sat Feb 24 06:22:54 UTC 2024), Entry for Moses McCarley and Moses Mccarley, 21 Nov 1817.\",\n    \"url\": \"https://www.familysearch.org/ark:/61903/1:2:QLWS-PTY9\"\n  }]\n}\n```\n\n**Context:** This index entry records Moses McCarley (Jr., persona p_102337453199, the groom) marrying Betsy Lawson on 21 Nov 1817 in Jessamine County, Kentucky. Critically, Moses Mccarley (Sr., persona p_102337453201, ark: ark:/61903/1:1:Q28D-N9Z9) is listed as parent/father of the groom \u2014 this is the research subject L7P6-3TT. The father persona (Sr.) is already attached to L7P6-3TT in the FamilySearch tree. Moses Jr. (M6M6-LLW in the tree) is a known tree person. The record is a derivative index of original Kentucky county marriage bonds.\n\nThis record's primary assertion relevant to q_001: Moses J McCarley Sr. (L7P6-3TT) is documented as alive and residing in Kentucky in 1817, identified as father of Moses Jr. The record does NOT directly name Moses Sr.'s wife/spouse.\n\nExtract: the residence/existence assertion for Moses Sr. as father (indirect evidence that he was alive in Kentucky in 1817); the marriage of Moses Jr. to Betsy Lawson. The father persona (p_102337453201) should be linked to tree person L7P6-3TT. Moses Jr. (p_102337453199) should be linked to tree person M6M6-LLW if he exists in the tree. Source classification: derivative; information about the groom's marriage: primary; evidence bearing on Moses Sr.'s marriage: indirect (establishes his existence/location but not his spouse)."
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"**Persisted:** src_002 / S3 (sourceReuse: created) \\u2014 derivative FamilySearch index, \\\"Kentucky, County Marriages, 1786-1965.\\\"\\n\\n**Assertions (6):** groom name (a_005), bride name (a_006), groom marriage (a_007), bride marriage (a_008), father_of_groom relationship (a_009), father_of_groom residence (a_010).\\n\\n**Tree changes:** none written \\u2014 no relationship/identity edges added. This is deliberate: linking p_102337453199\\u2192M6M6-LLW and p_102337453201..."
+    },
+    {
+      "tool": "mcp__genealogy__project_context",
+      "args": {
+        "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l"
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"projectStatus\\\": \\\"active\\\",\\n  \\\"openQuestions\\\": [\\n    {\\n      \\\"id\\\": \\\"q_001\\\",\\n      \\\"question\\\": \\\"Who did Moses J McCarley Sr (born 17 January 1767, died 9 April 1844) marry?\\\"\\n    }\\n  ],\\n  \\\"persons\\\": [\\n    {\\n      \\\"id\\\": \\\"L7P6-3TT\\\",\\n      \\\"name\\\": \\\"Moses J McCarley\\\",\\n      \\\"gender\\\": \\\"Male\\\",\\n      \\\"sourceRefs\\\": []\\n    },\\n    {\\n      \\\"id\\\": \\\"LHD2-QCN\\\",\\n      \\\"name\\\": \\\"Sophia McCarley\\\",\\n      \\\"gender..."
+    },
+    {
+      "tool": "Agent",
+      "args": {
+        "description": "Extract Record 3: Westley Alverson + Salvina McCarley 1827 (Moses Sr. as father)",
+        "subagent_type": "record-extractor",
+        "prompt": "Extract all GPS-conformant assertions from this FamilySearch marriage record and persist them to research.json and tree.gedcomx.json.\n\n**projectPath:** /private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l\n\n**recordId:** ark:/61903/1:1:Q28D-XWSS\n\n**logId:** log_009\n\n**Open research question:** q_001 \u2014 \"Who did Moses J McCarley Sr (born 17 January 1767, died 9 April 1844) marry?\"\n\n**Research subject in tree:** L7P6-3TT = Moses J McCarley Sr, Male, born 17 Jan 1767, died 9 Apr 1844.\n\n**Record content (full GEDCOMX from record_read):**\n```json\n{\n  \"persons\": [\n    {\n      \"id\": \"p_102337403457\",\n      \"ark\": \"ark:/61903/1:1:Q28D-XW9Y\",\n      \"gender\": \"Male\",\n      \"names\": [{\"type\": \"BirthName\", \"given\": \"Westley\", \"surname\": \"Alverson\"}],\n      \"facts\": [{\"type\": \"Unknown\", \"primary\": true, \"place\": \"Jessamine\", \"standard_place\": \"Jessamine, Kentucky, United States\"}],\n      \"sources\": [{\"ref\": \"sd_da1\"}]\n    },\n    {\n      \"id\": \"p_102337403460\",\n      \"ark\": \"ark:/61903/1:1:Q28D-XWSM\",\n      \"gender\": \"Female\",\n      \"names\": [{\"type\": \"BirthName\", \"given\": \"Salvina\", \"surname\": \"Mccarley\"}],\n      \"sources\": [{\"ref\": \"sd_da1\"}]\n    },\n    {\n      \"id\": \"p_102337403462\",\n      \"ark\": \"ark:/61903/1:1:Q28D-XWSS\",\n      \"gender\": \"Male\",\n      \"names\": [{\"type\": \"BirthName\", \"given\": \"Mofes\", \"surname\": \"Mccarley\"}],\n      \"sources\": [{\"ref\": \"sd_da1\"}]\n    }\n  ],\n  \"relationships\": [\n    {\n      \"type\": \"Couple\",\n      \"person1\": \"p_102337403457\",\n      \"person2\": \"p_102337403460\",\n      \"facts\": [{\n        \"type\": \"Marriage\",\n        \"primary\": true,\n        \"date\": \"28 Apr 1827\",\n        \"standard_date\": \"28 Apr 1827\",\n        \"place\": \"Jessamine, Kentucky, United States\",\n        \"standard_place\": \"Jessamine, Kentucky, United States\"\n      }]\n    },\n    {\n      \"type\": \"ParentChild\",\n      \"parent\": \"p_102337403462\",\n      \"child\": \"p_102337403460\"\n    }\n  ],\n  \"sources\": [{\n    \"id\": \"src_r_102937043944\",\n    \"title\": \"Entry for Westley Alverson and Salvina Mccarley, \\\"Kentucky, County Marriages, 1786-1965\\\"\",\n    \"citation\": \"\\\"Kentucky, County Marriages, 1786-1965\\\", FamilySearch (https://www.familysearch.org/ark:/61903/1:1:Q28D-XW9Y : Sat Feb 24 07:49:40 UTC 2024), Entry for Westley Alverson and Salvina Mccarley, 28 Apr 1827.\",\n    \"url\": \"https://www.familysearch.org/ark:/61903/1:2:QLWS-P3HQ\"\n  }]\n}\n```\n\n**Context:** This index entry records Westley Alverson marrying Salvina Mccarley on 28 Apr 1827 in Jessamine County, Kentucky. \"Mofes Mccarley\" (persona p_102337403462, ark: ark:/61903/1:1:Q28D-XWSS) is listed as father/parent of the bride Salvina. \"Mofes\" is a period spelling/handwriting variant of \"Moses.\" This persona is already attached to L7P6-3TT (Moses J McCarley Sr.) in the FamilySearch tree.\n\nSalvina Mccarley (bride, p_102337403460) corresponds to tree person KF27-BHH \"Sabina McCarley\" \u2014 Salvina is a variant of Sabina. She is a daughter of Moses Sr.\n\nThis record does NOT name Moses Sr.'s wife/mother of Salvina. \n\nExtract: the existence/residence assertion for Moses Sr. in Jessamine County, KY in 1827 (indirect evidence bearing on q_001 \u2014 corroborates his Kentucky residence and continued survival to 1827); the marriage of Salvina/Sabina McCarley to Westley Alverson. Source: derivative index; information: primary for the marriage event; evidence bearing on Moses Sr.'s marriage: indirect (confirms his existence/location but does not name his spouse). The father persona (p_102337403462) should be linked to L7P6-3TT. Salvina (p_102337403460) should be linked to KF27-BHH if resolvable."
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"Persisted successfully.\\n\\n- **Source:** src_003 / S4 (created) \\u2014 \\\"Kentucky, County Marriages, 1786-1965,\\\" derivative index; notes flag \\\"original not examined\\\" (browse-only index, underlying marriage bond/license image not reached).\\n- **Assertions (6):** groom (a_011 name, a_012 residence) \\u00b7 bride (a_013 name, a_014 marriage event) \\u00b7 father_of_bride (a_015 name, a_016 residence/existence).\\n- **Tree changes:** none this call \\u2014 no household/c..."
+    },
+    {
+      "tool": "mcp__genealogy__project_context",
+      "args": {
+        "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l"
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"projectStatus\\\": \\\"active\\\",\\n  \\\"openQuestions\\\": [\\n    {\\n      \\\"id\\\": \\\"q_001\\\",\\n      \\\"question\\\": \\\"Who did Moses J McCarley Sr (born 17 January 1767, died 9 April 1844) marry?\\\"\\n    }\\n  ],\\n  \\\"persons\\\": [\\n    {\\n      \\\"id\\\": \\\"L7P6-3TT\\\",\\n      \\\"name\\\": \\\"Moses J McCarley\\\",\\n      \\\"gender\\\": \\\"Male\\\",\\n      \\\"sourceRefs\\\": []\\n    },\\n    {\\n      \\\"id\\\": \\\"LHD2-QCN\\\",\\n      \\\"name\\\": \\\"Sophia McCarley\\\",\\n      \\\"gender..."
+    },
+    {
+      "tool": "mcp__genealogy__research_append",
+      "args": {
+        "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l",
+        "sourceDescription": {
+          "title": "Entry for Moses McCarley and Elizabeth Patt, \"Kentucky, County Marriages, 1786-1965\"",
+          "url": "https://www.familysearch.org/ark:/61903/1:2:QLWS-5MZ8"
+        },
+        "ops": [
+          {
+            "section": "sources",
+            "op": "append",
+            "entry": {
+              "citation": "\"Kentucky, County Marriages, 1786-1965,\" database, FamilySearch (https://www.familysearch.org/ark:/61903/1:1:Q28D-NHWN : accessed 14 July 2026), entry for Moses McCarley and Elizabeth Patt, 24 Jul 1792, Lincoln County, Kentucky.",
+              "citation_detail": {
+                "who": "Lincoln County, Kentucky county clerk (recorder of marriage bonds/licenses)",
+                "what": "Index entry for the marriage of Moses McCarley and Elizabeth Patt",
+                "when_created": "Event 24 Jul 1792; index entry published by FamilySearch",
+                "when_accessed": "2026-07-14",
+                "where": "FamilySearch, database \"Kentucky, County Marriages, 1786-1965\"",
+                "where_within": "Lincoln County, Kentucky"
+              },
+              "source_classification": "derivative",
+              "repository": "FamilySearch",
+              "access_date": "2026-07-14",
+              "notes": "Original not examined \u2014 this is a derivative index entry from \"Kentucky, County Marriages, 1786-1965\"; the underlying county marriage bond/license image was not examined directly.",
+              "log_entry_id": "log_001"
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "record_id": "ark:/61903/1:1:Q28D-NHWN",
+              "record_role": "groom",
+              "fact_type": "Name",
+              "value": "Moses McCarley",
+              "structured_value": {
+                "given": "Moses",
+                "surname": "McCarley"
+              },
+              "information_quality": "primary",
+              "informant": "Moses McCarley (self)",
+              "informant_proximity": "self",
+              "evidence_type": "direct",
+              "extracted_for_question_ids": [
+                "q_001"
+              ],
+              "log_entry_id": "log_001"
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "record_id": "ark:/61903/1:1:Q28D-NHWN",
+              "record_role": "bride",
+              "fact_type": "Name",
+              "value": "Elizabeth Patt",
+              "structured_value": {
+                "given": "Elizabeth",
+                "surname": "Patt"
+              },
+              "information_quality": "primary",
+              "informant": "Elizabeth Patt (self)",
+              "informant_proximity": "self",
+              "evidence_type": "direct",
+              "extracted_for_question_ids": [
+                "q_001"
+              ],
+              "log_entry_id": "log_001"
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "record_id": "ark:/61903/1:1:Q28D-NHWN",
+              "record_role": "groom",
+              "fact_type": "Marriage",
+              "value": "Married Elizabeth Patt, 24 Jul 1792, Lincoln County, Kentucky",
+              "structured_value": {
+                "relationship_type": "spouse",
+                "related_person_role": "bride"
+              },
+              "date": "24 Jul 1792",
+              "date_certainty": "exact",
+              "place": "Lincoln, Kentucky, United States",
+              "standard_place": "Lincoln, Kentucky, United States",
+              "information_quality": "primary",
+              "informant": "county clerk/recorder of the marriage bond",
+              "informant_proximity": "official_duty",
+              "evidence_type": "direct",
+              "extracted_for_question_ids": [
+                "q_001"
+              ],
+              "log_entry_id": "log_001"
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "record_id": "ark:/61903/1:1:Q28D-NHWN",
+              "record_role": "bride",
+              "fact_type": "Marriage",
+              "value": "Married Moses McCarley, 24 Jul 1792, Lincoln County, Kentucky",
+              "structured_value": {
+                "relationship_type": "spouse",
+                "related_person_role": "groom"
+              },
+              "date": "24 Jul 1792",
+              "date_certainty": "exact",
+              "place": "Lincoln, Kentucky, United States",
+              "standard_place": "Lincoln, Kentucky, United States",
+              "information_quality": "primary",
+              "informant": "county clerk/recorder of the marriage bond",
+              "informant_proximity": "official_duty",
+              "evidence_type": "direct",
+              "extracted_for_question_ids": [
+                "q_001"
+              ],
+              "log_entry_id": "log_001"
+            }
+          }
+        ]
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": false,\\n  \\\"errors\\\": [\\n    \\\"ops[1]: record_persona_id omitted \\u2014 multiple personas in this record (p_102337459396, p_102337459399) and the batch spans multiple record_roles/record_ids, so the omission is ambiguous; supply record_persona_id per assertion (the searched persona is 'p_102337459396')\\\",\\n    \\\"ops[2]: record_persona_id omitted \\u2014 multiple personas in this record (p_102337459396, p_102337459399) and the batch spans multiple record_..."
+    },
+    {
+      "tool": "mcp__genealogy__research_append",
+      "args": {
+        "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l",
+        "sourceDescription": {
+          "title": "Entry for Moses McCarley and Elizabeth Patt, \"Kentucky, County Marriages, 1786-1965\"",
+          "url": "https://www.familysearch.org/ark:/61903/1:2:QLWS-5MZ8"
+        },
+        "ops": [
+          {
+            "section": "sources",
+            "op": "append",
+            "entry": {
+              "citation": "\"Kentucky, County Marriages, 1786-1965,\" database, FamilySearch (https://www.familysearch.org/ark:/61903/1:1:Q28D-NHWN : accessed 14 July 2026), entry for Moses McCarley and Elizabeth Patt, 24 Jul 1792, Lincoln County, Kentucky.",
+              "citation_detail": {
+                "who": "Lincoln County, Kentucky county clerk (recorder of marriage bonds/licenses)",
+                "what": "Index entry for the marriage of Moses McCarley and Elizabeth Patt",
+                "when_created": "Event 24 Jul 1792; index entry published by FamilySearch",
+                "when_accessed": "2026-07-14",
+                "where": "FamilySearch, database \"Kentucky, County Marriages, 1786-1965\"",
+                "where_within": "Lincoln County, Kentucky"
+              },
+              "source_classification": "derivative",
+              "repository": "FamilySearch",
+              "access_date": "2026-07-14",
+              "notes": "Original not examined \u2014 this is a derivative index entry from \"Kentucky, County Marriages, 1786-1965\"; the underlying county marriage bond/license image was not examined directly.",
+              "log_entry_id": "log_001"
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "record_id": "ark:/61903/1:1:Q28D-NHWN",
+              "record_persona_id": "p_102337459396",
+              "record_role": "groom",
+              "fact_type": "Name",
+              "value": "Moses McCarley",
+              "structured_value": {
+                "given": "Moses",
+                "surname": "McCarley"
+              },
+              "information_quality": "primary",
+              "informant": "Moses McCarley (self)",
+              "informant_proximity": "self",
+              "evidence_type": "direct",
+              "extracted_for_question_ids": [
+                "q_001"
+              ],
+              "log_entry_id": "log_001"
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "record_id": "ark:/61903/1:1:Q28D-NHWN",
+              "record_persona_id": "p_102337459399",
+              "record_role": "bride",
+              "fact_type": "Name",
+              "value": "Elizabeth Patt",
+              "structured_value": {
+                "given": "Elizabeth",
+                "surname": "Patt"
+              },
+              "information_quality": "primary",
+              "informant": "Elizabeth Patt (self)",
+              "informant_proximity": "self",
+              "evidence_type": "direct",
+              "extracted_for_question_ids": [
+                "q_001"
+              ],
+              "log_entry_id": "log_001"
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "record_id": "ark:/61903/1:1:Q28D-NHWN",
+              "record_persona_id": "p_102337459396",
+              "record_role": "groom",
+              "fact_type": "Marriage",
+              "value": "Married Elizabeth Patt, 24 Jul 1792, Lincoln County, Kentucky",
+              "structured_value": {
+                "relationship_type": "spouse",
+                "related_person_role": "bride"
+              },
+              "date": "24 Jul 1792",
+              "date_certainty": "exact",
+              "place": "Lincoln, Kentucky, United States",
+              "standard_place": "Lincoln, Kentucky, United States",
+              "information_quality": "primary",
+              "informant": "county clerk/recorder of the marriage bond",
+              "informant_proximity": "official_duty",
+              "evidence_type": "direct",
+              "extracted_for_question_ids": [
+                "q_001"
+              ],
+              "log_entry_id": "log_001"
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "record_id": "ark:/61903/1:1:Q28D-NHWN",
+              "record_persona_id": "p_102337459399",
+              "record_role": "bride",
+              "fact_type": "Marriage",
+              "value": "Married Moses McCarley, 24 Jul 1792, Lincoln County, Kentucky",
+              "structured_value": {
+                "relationship_type": "spouse",
+                "related_person_role": "groom"
+              },
+              "date": "24 Jul 1792",
+              "date_certainty": "exact",
+              "place": "Lincoln, Kentucky, United States",
+              "standard_place": "Lincoln, Kentucky, United States",
+              "information_quality": "primary",
+              "informant": "county clerk/recorder of the marriage bond",
+              "informant_proximity": "official_duty",
+              "evidence_type": "direct",
+              "extracted_for_question_ids": [
+                "q_001"
+              ],
+              "log_entry_id": "log_001"
+            }
+          }
+        ]
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"results\\\": [\\n    {\\n      \\\"section\\\": \\\"sources\\\",\\n      \\\"op\\\": \\\"append\\\",\\n      \\\"entryId\\\": \\\"src_001\\\"\\n    },\\n    {\\n      \\\"section\\\": \\\"assertions\\\",\\n      \\\"op\\\": \\\"append\\\",\\n      \\\"entryId\\\": \\\"a_001\\\"\\n    },\\n    {\\n      \\\"section\\\": \\\"assertions\\\",\\n      \\\"op\\\": \\\"append\\\",\\n      \\\"entryId\\\": \\\"a_002\\\"\\n    },\\n    {\\n      \\\"section\\\": \\\"assertions\\\",\\n      \\\"op\\\": \\\"append\\\",\\n      \\\"entryId\\\": \\\"a_003\\\"\\n    },\\n ..."
+    },
+    {
+      "tool": "mcp__genealogy__tree_edit",
+      "args": {
+        "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l",
+        "operation": "add_person",
+        "person": {
+          "gender": "Female",
+          "names": [
+            {
+              "type": "BirthName",
+              "given": "Elizabeth",
+              "surname": "Patt",
+              "preferred": true
+            }
+          ]
+        }
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"operation\\\": \\\"add_person\\\",\\n  \\\"filesWritten\\\": [\\n    \\\"tree.gedcomx.json\\\"\\n  ],\\n  \\\"validation\\\": {\\n    \\\"valid\\\": true,\\n    \\\"warnings\\\": []\\n  },\\n  \\\"assignedIds\\\": {\\n    \\\"person\\\": \\\"I1\\\",\\n    \\\"names\\\": [\\n      \\\"N15\\\"\\n    ]\\n  }\\n}\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__tree_edit",
+      "args": {
+        "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l",
+        "ops": [
+          {
+            "operation": "add_relationship",
+            "relationship": {
+              "type": "Couple",
+              "person1": "L7P6-3TT",
+              "person2": "I1"
+            }
+          },
+          {
+            "operation": "add_source",
+            "source": {
+              "title": "Entry for Moses McCarley and Elizabeth Patt, \"Kentucky, County Marriages, 1786-1965\"",
+              "url": "https://www.familysearch.org/ark:/61903/1:2:QLWS-5MZ8"
+            }
+          }
+        ]
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"results\\\": [\\n    {\\n      \\\"operation\\\": \\\"add_relationship\\\",\\n      \\\"assignedIds\\\": {\\n        \\\"relationship\\\": \\\"R25\\\"\\n      }\\n    },\\n    {\\n      \\\"operation\\\": \\\"add_source\\\",\\n      \\\"assignedIds\\\": {\\n        \\\"source\\\": \\\"S2\\\"\\n      }\\n    }\\n  ],\\n  \\\"filesWritten\\\": [\\n    \\\"tree.gedcomx.json\\\"\\n  ],\\n  \\\"validation\\\": {\\n    \\\"valid\\\": true,\\n    \\\"warnings\\\": []\\n  }\\n}\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__tree_edit",
+      "args": {
+        "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l",
+        "operation": "add_fact",
+        "relationshipId": "R25",
+        "fact": {
+          "type": "Marriage",
+          "date": "24 Jul 1792",
+          "standard_date": "24 Jul 1792",
+          "place": "Lincoln, Kentucky, United States",
+          "standard_place": "Lincoln, Kentucky, United States",
+          "primary": true
+        }
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"operation\\\": \\\"add_fact\\\",\\n  \\\"filesWritten\\\": [\\n    \\\"tree.gedcomx.json\\\"\\n  ],\\n  \\\"validation\\\": {\\n    \\\"valid\\\": true,\\n    \\\"warnings\\\": []\\n  },\\n  \\\"assignedIds\\\": {\\n    \\\"fact\\\": \\\"F1\\\"\\n  }\\n}\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__research_append",
+      "args": {
+        "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l",
+        "sourceDescription": {
+          "title": "Entry for Moses McCarley and Betsy Lawson, \"Kentucky, County Marriages, 1786-1965\"",
+          "url": "https://www.familysearch.org/ark:/61903/1:2:QLWS-PTY9"
+        },
+        "ops": [
+          {
+            "section": "sources",
+            "op": "append",
+            "entry": {
+              "citation": "\"Kentucky, County Marriages, 1786-1965,\" database, FamilySearch (https://www.familysearch.org/ark:/61903/1:1:Q28D-N9C1 : accessed 14 July 2026), entry for Moses McCarley and Betsy Lawson, 21 Nov 1817, Jessamine County, Kentucky; citing county marriage records.",
+              "citation_detail": {
+                "who": "Jessamine County, Kentucky clerk (county marriage records)",
+                "what": "Marriage entry for Moses McCarley and Betsy Lawson, 21 Nov 1817",
+                "when_created": "1817 (indexed by FamilySearch)",
+                "when_accessed": "2026-07-14",
+                "where": "FamilySearch, database \"Kentucky, County Marriages, 1786-1965\"",
+                "where_within": "Jessamine County, Kentucky marriage records"
+              },
+              "source_classification": "derivative",
+              "repository": "FamilySearch",
+              "access_date": "2026-07-14",
+              "notes": "Original not examined \u2014 this is a FamilySearch index/derivative of the underlying Jessamine County, Kentucky marriage bond; the bond image itself was not viewed. The father-of-groom relationship link is FamilySearch's index structure, not necessarily a stated relationship in the original text \u2014 original image confirmation outstanding.",
+              "log_entry_id": "log_002"
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "record_id": "ark:/61903/1:1:Q28D-N9C1",
+              "record_role": "groom",
+              "fact_type": "name",
+              "value": "Moses McCarley",
+              "structured_value": {
+                "name": {
+                  "given": "Moses",
+                  "surname": "McCarley"
+                }
+              },
+              "information_quality": "primary",
+              "informant": "Moses McCarley (groom)",
+              "informant_proximity": "self",
+              "evidence_type": "direct",
+              "extracted_for_question_ids": [],
+              "log_entry_id": "log_002"
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "record_id": "ark:/61903/1:1:Q28D-N9C1",
+              "record_role": "bride",
+              "fact_type": "name",
+              "value": "Betsy Lawson",
+              "structured_value": {
+                "name": {
+                  "given": "Betsy",
+                  "surname": "Lawson"
+                }
+              },
+              "information_quality": "primary",
+              "informant": "Betsy Lawson (bride)",
+              "informant_proximity": "self",
+              "evidence_type": "direct",
+              "extracted_for_question_ids": [],
+              "log_entry_id": "log_002"
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "record_id": "ark:/61903/1:1:Q28D-N9C1",
+              "record_role": "groom",
+              "fact_type": "marriage",
+              "value": "Married Betsy Lawson, 21 Nov 1817, Jessamine County, Kentucky",
+              "date": "21 Nov 1817",
+              "date_certainty": "exact",
+              "place": "Jessamine, Kentucky, United States",
+              "standard_place": "Jessamine, Kentucky, United States",
+              "structured_value": {
+                "relationship_type": "spouse",
+                "related_person_role": "bride"
+              },
+              "information_quality": "primary",
+              "informant": "county clerk (recorder of the marriage bond/return)",
+              "informant_proximity": "official_duty",
+              "evidence_type": "direct",
+              "extracted_for_question_ids": [],
+              "log_entry_id": "log_002"
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "record_id": "ark:/61903/1:1:Q28D-N9C1",
+              "record_role": "bride",
+              "fact_type": "marriage",
+              "value": "Married Moses McCarley, 21 Nov 1817, Jessamine County, Kentucky",
+              "date": "21 Nov 1817",
+              "date_certainty": "exact",
+              "place": "Jessamine, Kentucky, United States",
+              "standard_place": "Jessamine, Kentucky, United States",
+              "structured_value": {
+                "relationship_type": "spouse",
+                "related_person_role": "groom"
+              },
+              "information_quality": "primary",
+              "informant": "county clerk (recorder of the marriage bond/return)",
+              "informant_proximity": "official_duty",
+              "evidence_type": "direct",
+              "extracted_for_question_ids": [],
+              "log_entry_id": "log_002"
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "record_id": "ark:/61903/1:1:Q28D-N9C1",
+              "record_role": "father_of_groom",
+              "fact_type": "relationship",
+              "value": "Moses Mccarley listed as parent of groom Moses McCarley in the marriage entry, Jessamine County, Kentucky, 21 Nov 1817",
+              "structured_value": {
+                "relationship_type": "parent_inferred",
+                "related_person_role": "groom"
+              },
+              "information_quality": "indeterminate",
+              "informant": "unknown",
+              "informant_proximity": "unknown",
+              "evidence_type": "indirect",
+              "informant_bias_notes": "Original marriage bond not examined; unclear whether the father's name was stated by the groom, recorded as bondsman/surety, or inferred by FamilySearch indexing from bond signatories. Confirm against the original bond image.",
+              "extracted_for_question_ids": [
+                "q_001"
+              ],
+              "log_entry_id": "log_002"
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "record_id": "ark:/61903/1:1:Q28D-N9C1",
+              "record_role": "father_of_groom",
+              "fact_type": "residence",
+              "value": "Present/located in Jessamine County, Kentucky as of 21 Nov 1817 (per son Moses Jr.'s marriage entry)",
+              "place": "Jessamine, Kentucky, United States",
+              "standard_place": "Jessamine, Kentucky, United States",
+              "information_quality": "indeterminate",
+              "informant": "unknown",
+              "informant_proximity": "unknown",
+              "evidence_type": "indirect",
+              "informant_bias_notes": "Establishes Moses McCarley Sr. was alive and located in Jessamine County, KY in Nov 1817 (bears on q_001's timeline) but does not identify his spouse.",
+              "extracted_for_question_ids": [
+                "q_001"
+              ],
+              "log_entry_id": "log_002"
+            }
+          }
+        ]
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": false,\\n  \\\"errors\\\": [\\n    \\\"ops[1]: record_persona_id omitted \\u2014 multiple personas in this record (p_102337453199, p_102337453201, p_102337453209) and the batch spans multiple record_roles/record_ids, so the omission is ambiguous; supply record_persona_id per assertion (the searched persona is 'p_102337453199')\\\",\\n    \\\"ops[2]: record_persona_id omitted \\u2014 multiple personas in this record (p_102337453199, p_102337453201, p_102337453209) and ..."
+    },
+    {
+      "tool": "mcp__genealogy__research_append",
+      "args": {
+        "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l",
+        "sourceDescription": {
+          "title": "Entry for Moses McCarley and Betsy Lawson, \"Kentucky, County Marriages, 1786-1965\"",
+          "url": "https://www.familysearch.org/ark:/61903/1:2:QLWS-PTY9"
+        },
+        "ops": [
+          {
+            "section": "sources",
+            "op": "append",
+            "entry": {
+              "citation": "\"Kentucky, County Marriages, 1786-1965,\" database, FamilySearch (https://www.familysearch.org/ark:/61903/1:1:Q28D-N9C1 : accessed 14 July 2026), entry for Moses McCarley and Betsy Lawson, 21 Nov 1817, Jessamine County, Kentucky; citing county marriage records.",
+              "citation_detail": {
+                "who": "Jessamine County, Kentucky clerk (county marriage records)",
+                "what": "Marriage entry for Moses McCarley and Betsy Lawson, 21 Nov 1817",
+                "when_created": "1817 (indexed by FamilySearch)",
+                "when_accessed": "2026-07-14",
+                "where": "FamilySearch, database \"Kentucky, County Marriages, 1786-1965\"",
+                "where_within": "Jessamine County, Kentucky marriage records"
+              },
+              "source_classification": "derivative",
+              "repository": "FamilySearch",
+              "access_date": "2026-07-14",
+              "notes": "Original not examined \u2014 this is a FamilySearch index/derivative of the underlying Jessamine County, Kentucky marriage bond; the bond image itself was not viewed. The father-of-groom relationship link is FamilySearch's index structure, not necessarily a stated relationship in the original text \u2014 original image confirmation outstanding.",
+              "log_entry_id": "log_002"
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "record_id": "ark:/61903/1:1:Q28D-N9C1",
+              "record_persona_id": "p_102337453199",
+              "record_role": "groom",
+              "fact_type": "name",
+              "value": "Moses McCarley",
+              "structured_value": {
+                "name": {
+                  "given": "Moses",
+                  "surname": "McCarley"
+                }
+              },
+              "information_quality": "primary",
+              "informant": "Moses McCarley (groom)",
+              "informant_proximity": "self",
+              "evidence_type": "direct",
+              "extracted_for_question_ids": [],
+              "log_entry_id": "log_002"
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "record_id": "ark:/61903/1:1:Q28D-N9C1",
+              "record_persona_id": "p_102337453209",
+              "record_role": "bride",
+              "fact_type": "name",
+              "value": "Betsy Lawson",
+              "structured_value": {
+                "name": {
+                  "given": "Betsy",
+                  "surname": "Lawson"
+                }
+              },
+              "information_quality": "primary",
+              "informant": "Betsy Lawson (bride)",
+              "informant_proximity": "self",
+              "evidence_type": "direct",
+              "extracted_for_question_ids": [],
+              "log_entry_id": "log_002"
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "record_id": "ark:/61903/1:1:Q28D-N9C1",
+              "record_persona_id": "p_102337453199",
+              "record_role": "groom",
+              "fact_type": "marriage",
+              "value": "Married Betsy Lawson, 21 Nov 1817, Jessamine County, Kentucky",
+              "date": "21 Nov 1817",
+              "date_certainty": "exact",
+              "place": "Jessamine, Kentucky, United States",
+              "standard_place": "Jessamine, Kentucky, United States",
+              "structured_value": {
+                "relationship_type": "spouse",
+                "related_person_role": "bride"
+              },
+              "information_quality": "primary",
+              "informant": "county clerk (recorder of the marriage bond/return)",
+              "informant_proximity": "official_duty",
+              "evidence_type": "direct",
+              "extracted_for_question_ids": [],
+              "log_entry_id": "log_002"
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "record_id": "ark:/61903/1:1:Q28D-N9C1",
+              "record_persona_id": "p_102337453209",
+              "record_role": "bride",
+              "fact_type": "marriage",
+              "value": "Married Moses McCarley, 21 Nov 1817, Jessamine County, Kentucky",
+              "date": "21 Nov 1817",
+              "date_certainty": "exact",
+              "place": "Jessamine, Kentucky, United States",
+              "standard_place": "Jessamine, Kentucky, United States",
+              "structured_value": {
+                "relationship_type": "spouse",
+                "related_person_role": "groom"
+              },
+              "information_quality": "primary",
+              "informant": "county clerk (recorder of the marriage bond/return)",
+              "informant_proximity": "official_duty",
+              "evidence_type": "direct",
+              "extracted_for_question_ids": [],
+              "log_entry_id": "log_002"
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "record_id": "ark:/61903/1:1:Q28D-N9C1",
+              "record_persona_id": "p_102337453201",
+              "record_role": "father_of_groom",
+              "fact_type": "relationship",
+              "value": "Moses Mccarley listed as parent of groom Moses McCarley in the marriage entry, Jessamine County, Kentucky, 21 Nov 1817",
+              "structured_value": {
+                "relationship_type": "parent_inferred",
+                "related_person_role": "groom"
+              },
+              "information_quality": "indeterminate",
+              "informant": "unknown",
+              "informant_proximity": "unknown",
+              "evidence_type": "indirect",
+              "informant_bias_notes": "Original marriage bond not examined; unclear whether the father's name was stated by the groom, recorded as bondsman/surety, or inferred by FamilySearch indexing from bond signatories. Confirm against the original bond image.",
+              "extracted_for_question_ids": [
+                "q_001"
+              ],
+              "log_entry_id": "log_002"
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "record_id": "ark:/61903/1:1:Q28D-N9C1",
+              "record_persona_id": "p_102337453201",
+              "record_role": "father_of_groom",
+              "fact_type": "residence",
+              "value": "Present/located in Jessamine County, Kentucky as of 21 Nov 1817 (per son Moses Jr.'s marriage entry)",
+              "place": "Jessamine, Kentucky, United States",
+              "standard_place": "Jessamine, Kentucky, United States",
+              "information_quality": "indeterminate",
+              "informant": "unknown",
+              "informant_proximity": "unknown",
+              "evidence_type": "indirect",
+              "informant_bias_notes": "Establishes Moses McCarley Sr. was alive and located in Jessamine County, KY in Nov 1817 (bears on q_001's timeline) but does not identify his spouse.",
+              "extracted_for_question_ids": [
+                "q_001"
+              ],
+              "log_entry_id": "log_002"
+            }
+          }
+        ]
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"results\\\": [\\n    {\\n      \\\"section\\\": \\\"sources\\\",\\n      \\\"op\\\": \\\"append\\\",\\n      \\\"entryId\\\": \\\"src_002\\\"\\n    },\\n    {\\n      \\\"section\\\": \\\"assertions\\\",\\n      \\\"op\\\": \\\"append\\\",\\n      \\\"entryId\\\": \\\"a_005\\\"\\n    },\\n    {\\n      \\\"section\\\": \\\"assertions\\\",\\n      \\\"op\\\": \\\"append\\\",\\n      \\\"entryId\\\": \\\"a_006\\\"\\n    },\\n    {\\n      \\\"section\\\": \\\"assertions\\\",\\n      \\\"op\\\": \\\"append\\\",\\n      \\\"entryId\\\": \\\"a_007\\\"\\n    },\\n ..."
+    },
+    {
+      "tool": "mcp__genealogy__research_append",
+      "args": {
+        "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l",
+        "sourceDescription": {
+          "title": "Entry for Westley Alverson and Salvina Mccarley, \"Kentucky, County Marriages, 1786-1965\"",
+          "url": "https://www.familysearch.org/ark:/61903/1:2:QLWS-P3HQ"
+        },
+        "ops": [
+          {
+            "section": "sources",
+            "op": "append",
+            "entry": {
+              "citation": "\"Kentucky, County Marriages, 1786-1965\", FamilySearch (https://www.familysearch.org/ark:/61903/1:1:Q28D-XW9Y : Sat Feb 24 07:49:40 UTC 2024), Entry for Westley Alverson and Salvina Mccarley, 28 Apr 1827.",
+              "citation_detail": {
+                "who": "Jessamine County, Kentucky county clerk; index compiled by FamilySearch",
+                "what": "Marriage entry for Westley Alverson and Salvina Mccarley, naming Salvina's father as Mofes [Moses] Mccarley",
+                "when_created": "28 Apr 1827",
+                "when_accessed": "2026-07-14",
+                "where": "FamilySearch, \"Kentucky, County Marriages, 1786-1965\" collection",
+                "where_within": "Jessamine County, Kentucky"
+              },
+              "source_classification": "derivative",
+              "repository": "FamilySearch",
+              "access_date": "2026-07-14",
+              "notes": "Original not examined \u2014 this is a FamilySearch derivative index entry from the \"Kentucky, County Marriages, 1786-1965\" collection; the underlying marriage bond/license image was not examined directly.",
+              "log_entry_id": "log_009"
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "record_id": "ark:/61903/1:1:Q28D-XWSS",
+              "record_role": "groom",
+              "fact_type": "Name",
+              "value": "Westley Alverson",
+              "structured_value": {
+                "given": "Westley",
+                "surname": "Alverson"
+              },
+              "information_quality": "primary",
+              "informant": "Westley Alverson",
+              "informant_proximity": "self",
+              "evidence_type": "direct",
+              "extracted_for_question_ids": [],
+              "log_entry_id": "log_009"
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "record_id": "ark:/61903/1:1:Q28D-XWSS",
+              "record_role": "groom",
+              "fact_type": "Residence",
+              "value": "Jessamine, Kentucky (residence associated with this record; fact type listed as 'Unknown' in the source)",
+              "place": "Jessamine",
+              "standard_place": "Jessamine, Kentucky, United States",
+              "information_quality": "primary",
+              "informant": "Westley Alverson",
+              "informant_proximity": "self",
+              "evidence_type": "direct",
+              "extracted_for_question_ids": [],
+              "log_entry_id": "log_009"
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "record_id": "ark:/61903/1:1:Q28D-XWSS",
+              "record_role": "bride",
+              "fact_type": "Name",
+              "value": "Salvina Mccarley",
+              "structured_value": {
+                "given": "Salvina",
+                "surname": "Mccarley"
+              },
+              "information_quality": "primary",
+              "informant": "Salvina Mccarley",
+              "informant_proximity": "self",
+              "evidence_type": "direct",
+              "extracted_for_question_ids": [],
+              "log_entry_id": "log_009"
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "record_id": "ark:/61903/1:1:Q28D-XWSS",
+              "record_role": "bride",
+              "fact_type": "Marriage",
+              "value": "Married Westley Alverson, 28 Apr 1827, Jessamine County, Kentucky",
+              "structured_value": {
+                "relationship_type": "spouse",
+                "related_person_role": "groom"
+              },
+              "date": "28 Apr 1827",
+              "date_certainty": "exact",
+              "place": "Jessamine, Kentucky, United States",
+              "standard_place": "Jessamine, Kentucky, United States",
+              "information_quality": "primary",
+              "informant": "county clerk",
+              "informant_proximity": "official_duty",
+              "evidence_type": "indirect",
+              "extracted_for_question_ids": [
+                "q_001"
+              ],
+              "informant_bias_notes": "Directly documents Salvina/Sabina Mccarley's marriage; bears on q_001 only indirectly \u2014 confirms her father (named in this record) was alive and the family was in Jessamine County, KY in 1827, but does not name Moses Sr.'s own spouse.",
+              "log_entry_id": "log_009"
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "record_id": "ark:/61903/1:1:Q28D-XWSS",
+              "record_role": "father_of_bride",
+              "fact_type": "Name",
+              "value": "Mofes Mccarley",
+              "structured_value": {
+                "given": "Mofes",
+                "surname": "Mccarley",
+                "relationship_type": "parent",
+                "related_person_role": "bride"
+              },
+              "information_quality": "primary",
+              "informant": "Salvina Mccarley (bride)",
+              "informant_proximity": "self",
+              "evidence_type": "direct",
+              "extracted_for_question_ids": [
+                "q_001"
+              ],
+              "informant_bias_notes": "\"Mofes\" is a period spelling/handwriting variant of \"Moses.\" Identity as Moses J McCarley Sr (tree person L7P6-3TT) rests on this single derivative index entry \u2014 tentative pending confirmation against the original marriage bond/license image.",
+              "log_entry_id": "log_009"
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "record_id": "ark:/61903/1:1:Q28D-XWSS",
+              "record_role": "father_of_bride",
+              "fact_type": "Residence",
+              "value": "Named as father of the bride in a Jessamine County, Kentucky marriage record dated 28 Apr 1827 \u2014 indicates presence/survival in Jessamine County, Kentucky as of that date",
+              "place": "Jessamine, Kentucky, United States",
+              "standard_place": "Jessamine, Kentucky, United States",
+              "date": "28 Apr 1827",
+              "date_certainty": "exact",
+              "information_quality": "indeterminate",
+              "informant": "the researcher",
+              "informant_proximity": "researcher",
+              "evidence_type": "indirect",
+              "extracted_for_question_ids": [
+                "q_001"
+              ],
+              "informant_bias_notes": "Inferred from the father-of-bride role in this Jessamine County marriage record; corroborates Moses Sr.'s continued survival and Kentucky residence as of 1827 but does not itself identify his spouse.",
+              "log_entry_id": "log_009"
+            }
+          }
+        ]
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"results\\\": [\\n    {\\n      \\\"section\\\": \\\"sources\\\",\\n      \\\"op\\\": \\\"append\\\",\\n      \\\"entryId\\\": \\\"src_003\\\"\\n    },\\n    {\\n      \\\"section\\\": \\\"assertions\\\",\\n      \\\"op\\\": \\\"append\\\",\\n      \\\"entryId\\\": \\\"a_011\\\"\\n    },\\n    {\\n      \\\"section\\\": \\\"assertions\\\",\\n      \\\"op\\\": \\\"append\\\",\\n      \\\"entryId\\\": \\\"a_012\\\"\\n    },\\n    {\\n      \\\"section\\\": \\\"assertions\\\",\\n      \\\"op\\\": \\\"append\\\",\\n      \\\"entryId\\\": \\\"a_013\\\"\\n    },\\n ..."
+    },
+    {
+      "tool": "ToolSearch",
+      "args": {
+        "query": "select:mcp__genealogy__research_append",
+        "max_results": 1
+      },
+      "response_summary": "[{\"type\": \"tool_reference\", \"tool_name\": \"mcp__genealogy__research_append\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__research_append",
+      "args": {
+        "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l",
+        "ops": [
+          {
+            "section": "plan_items",
+            "op": "update",
+            "planId": "pl_001",
+            "entryId": "pli_001",
+            "fields": {
+              "status": "completed"
+            }
+          },
+          {
+            "section": "plan_items",
+            "op": "update",
+            "planId": "pl_001",
+            "entryId": "pli_002",
+            "fields": {
+              "status": "completed"
+            }
+          },
+          {
+            "section": "plan_items",
+            "op": "update",
+            "planId": "pl_001",
+            "entryId": "pli_008",
+            "fields": {
+              "status": "completed"
+            }
+          }
+        ]
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"results\\\": [\\n    {\\n      \\\"section\\\": \\\"plan_items\\\",\\n      \\\"op\\\": \\\"update\\\",\\n      \\\"entryId\\\": \\\"pli_001\\\"\\n    },\\n    {\\n      \\\"section\\\": \\\"plan_items\\\",\\n      \\\"op\\\": \\\"update\\\",\\n      \\\"entryId\\\": \\\"pli_002\\\"\\n    },\\n    {\\n      \\\"section\\\": \\\"plan_items\\\",\\n      \\\"op\\\": \\\"update\\\",\\n      \\\"entryId\\\": \\\"pli_008\\\"\\n    }\\n  ],\\n  \\\"filesWritten\\\": [\\n    \\\"research.json\\\"\\n  ],\\n  \\\"validation\\\": {\\n    \\\"valid\\\": true,\\n  ..."
+    },
+    {
+      "tool": "Skill",
+      "args": {
+        "skill": "person-evidence",
+        "args": "--autonomous Link extracted assertions to tree persons for research question q_001. Project path: /private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l. Subject: L7P6-3TT (Moses J McCarley Sr). \n\nKey personas to link:\n1. p_102337459396 (ark:/61903/1:1:Q28D-NHWN) \u2014 Moses McCarley (groom), 1792 Lincoln Co. marriage \u2192 likely = L7P6-3TT (already attached in FamilySearch tree)\n2. p_102337459399 (ark:/61903/1:1:Q28D-NHWK) \u2014 Elizabeth Patt (bride), 1792 \u2192 new stub I1 was created; she is Moses Sr.'s wife\n3. p_102337453201 (ark:/61903/1:1:Q28D-N9Z9) \u2014 Moses Mccarley Sr. (father of groom), 1817 Jessamine Co. \u2192 likely = L7P6-3TT\n4. p_102337453199 (ark:/61903/1:1:Q28D-N9C1) \u2014 Moses McCarley Jr. (groom), 1817 \u2192 likely = M6M6-LLW\n5. p_102337403462 (ark:/61903/1:1:Q28D-XWSS) \u2014 \"Mofes Mccarley\" (father of bride), 1827 \u2192 likely = L7P6-3TT\n6. p_102337403460 (ark:/61903/1:1:Q28D-XWSM) \u2014 Salvina Mccarley (bride), 1827 \u2192 likely = KF27-BHH \"Sabina McCarley\""
+      },
+      "response_summary": "Launching skill: person-evidence"
+    },
+    {
+      "tool": "ToolSearch",
+      "args": {
+        "query": "select:mcp__genealogy__research_append,mcp__genealogy__project_context",
+        "max_results": 2
+      },
+      "response_summary": "[{\"type\": \"tool_reference\", \"tool_name\": \"mcp__genealogy__research_append\"}, {\"type\": \"tool_reference\", \"tool_name\": \"mcp__genealogy__project_context\"}]"
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l/research.json",
+        "limit": 100
+      },
+      "response_summary": "1\t{\n2\t  \"project\": {\n3\t    \"id\": \"rp_mccarley_spouse\",\n4\t    \"objective\": \"Who was the spouse of Moses J McCarley Sr, who was born 17 January 1767 and died 9 April 1844?\",\n5\t    \"subject_person_ids\": [\n6\t      \"L7P6-3TT\"\n7\t    ],\n8\t    \"status\": \"active\",\n9\t    \"created\": \"2026-07-14\",\n10\t    \"updated\": \"2026-07-14\"\n11\t  },\n12\t  \"researcher_profile\": {\n13\t    \"experience_level\": \"intermediate\",\n14\t    \"subscriptions\": [],\n15\t    \"narration_guidance\": \"concise\"\n16\t  },\n17\t  \"questions\": [\n18\t ..."
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l/research.json",
+        "offset": 100,
+        "limit": 300
+      },
+      "response_summary": "100\t        {\n101\t          \"id\": \"pli_006\",\n102\t          \"sequence\": 6,\n103\t          \"record_type\": \"census\",\n104\t          \"jurisdiction\": \"Kentucky\",\n105\t          \"date_range\": \"1820\",\n106\t          \"repository\": \"FamilySearch\",\n107\t          \"rationale\": \"The 1820 US Federal Census would show Moses J McCarley Sr (~age 53) and his household. Presence of a wife-aged female corroborates the marriage. Household composition may reveal younger children still at home, helping to bracket the m..."
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l/research.json",
+        "offset": 400,
+        "limit": 400
+      },
+      "response_summary": "400\t    }\n401\t  ],\n402\t  \"assertions\": [\n403\t    {\n404\t      \"id\": \"a_001\",\n405\t      \"record_id\": \"ark:/61903/1:1:Q28D-NHWN\",\n406\t      \"record_persona_id\": \"p_102337459396\",\n407\t      \"record_role\": \"groom\",\n408\t      \"fact_type\": \"Name\",\n409\t      \"value\": \"Moses McCarley\",\n410\t      \"structured_value\": {\n411\t        \"given\": \"Moses\",\n412\t        \"surname\": \"McCarley\"\n413\t      },\n414\t      \"information_quality\": \"primary\",\n415\t      \"informant\": \"Moses McCarley (self)\",\n416\t      \"informa..."
+    },
+    {
+      "tool": "Bash",
+      "args": {
+        "command": "cat /private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l/tree.gedcomx.json | python3 -c \"import json,sys; d=json.load(sys.stdin); [print(p['id'], p.get('gender',{}).get('type',''), [n.get('nameForms',[{}])[0].get('fullText','') for n in p.get('names',[])]) for p in d.get('persons',[])]\"",
+        "description": "List all persons in tree.gedcomx.json with IDs and names"
+      },
+      "response_summary": "Permission to use Bash has been denied because Claude Code is running in don't ask mode. IMPORTANT: You *may* attempt to accomplish this action using other tools that might naturally be used to accomplish this goal, e.g. using head instead of cat. But you *should not* attempt to work around this denial in malicious ways, e.g. do not use your ability to run tests to execute non-test actions. You should only try to work around this restriction in reasonable ways that do not attempt to bypass th..."
+    },
+    {
+      "tool": "mcp__genealogy__project_context",
+      "args": {
+        "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l"
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"projectStatus\\\": \\\"active\\\",\\n  \\\"openQuestions\\\": [\\n    {\\n      \\\"id\\\": \\\"q_001\\\",\\n      \\\"question\\\": \\\"Who did Moses J McCarley Sr (born 17 January 1767, died 9 April 1844) marry?\\\"\\n    }\\n  ],\\n  \\\"persons\\\": [\\n    {\\n      \\\"id\\\": \\\"L7P6-3TT\\\",\\n      \\\"name\\\": \\\"Moses J McCarley\\\",\\n      \\\"gender\\\": \\\"Male\\\",\\n      \\\"sourceRefs\\\": []\\n    },\\n    {\\n      \\\"id\\\": \\\"LHD2-QCN\\\",\\n      \\\"name\\\": \\\"Sophia McCarley\\\",\\n      \\\"gender..."
+    },
+    {
+      "tool": "ToolSearch",
+      "args": {
+        "query": "select:mcp__genealogy__tree_edit",
+        "max_results": 1
+      },
+      "response_summary": "[{\"type\": \"tool_reference\", \"tool_name\": \"mcp__genealogy__tree_edit\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__tree_edit",
+      "args": {
+        "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l",
+        "operation": "add_person",
+        "person": {
+          "gender": "Female",
+          "names": [
+            {
+              "type": "BirthName",
+              "preferred": true,
+              "nameForms": [
+                {
+                  "fullText": "Betsy Lawson",
+                  "parts": [
+                    {
+                      "type": "Given",
+                      "value": "Betsy"
+                    },
+                    {
+                      "type": "Surname",
+                      "value": "Lawson"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": false,\\n  \\\"errors\\\": [\\n    \\\"tree.gedcomx.json/persons[14]/names[0]: missing required field 'given'\\\",\\n    \\\"tree.gedcomx.json/persons[14]/names[0]: missing required field 'surname'\\\",\\n    \\\"tree.gedcomx.json/persons[14]/names[0]: unexpected property 'nameForms' (names allow only id, preferred, given, surname, prefix, suffix, type, sources)\\\"\\n  ]\\n}\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__tree_edit",
+      "args": {
+        "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l",
+        "operation": "add_person",
+        "person": {
+          "gender": "Female",
+          "names": [
+            {
+              "type": "BirthName",
+              "preferred": true,
+              "given": "Betsy",
+              "surname": "Lawson"
+            }
+          ]
+        }
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"operation\\\": \\\"add_person\\\",\\n  \\\"filesWritten\\\": [\\n    \\\"tree.gedcomx.json\\\"\\n  ],\\n  \\\"validation\\\": {\\n    \\\"valid\\\": true,\\n    \\\"warnings\\\": []\\n  },\\n  \\\"assignedIds\\\": {\\n    \\\"person\\\": \\\"I2\\\",\\n    \\\"names\\\": [\\n      \\\"N16\\\"\\n    ]\\n  }\\n}\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__research_append",
+      "args": {
+        "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l",
+        "ops": [
+          {
+            "section": "person_evidence",
+            "op": "append",
+            "entry": {
+              "assertion_id": "a_001",
+              "person_id": "L7P6-3TT",
+              "confidence": "confident",
+              "rationale": "The groom persona (p_102337459396) in the 1792 Lincoln County, KY marriage record names 'Moses McCarley.' This record is already attached to L7P6-3TT in FamilySearch. Name matches (Moses McCarley = Moses J McCarley); marriage date 1792 is consistent with birth year 1767 (age ~25); Lincoln County, KY is his documented location.",
+              "match_score": null
+            }
+          },
+          {
+            "section": "person_evidence",
+            "op": "append",
+            "entry": {
+              "assertion_id": "a_002",
+              "person_id": "I1",
+              "confidence": "probable",
+              "rationale": "The bride persona (p_102337459399) in the 1792 Lincoln County, KY marriage names 'Elizabeth Patt.' Stub I1 was created specifically for this persona \u2014 name matches exactly. Probable because the stub rests on a single derivative index entry with no independent corroboration; the original marriage bond image was not examined.",
+              "match_score": null
+            }
+          },
+          {
+            "section": "person_evidence",
+            "op": "append",
+            "entry": {
+              "assertion_id": "a_003",
+              "person_id": "L7P6-3TT",
+              "confidence": "confident",
+              "rationale": "The groom's marriage fact in the 1792 Lincoln County, KY record directly documents Moses McCarley marrying Elizabeth Patt on 24 Jul 1792. The groom persona is already attached to L7P6-3TT in FamilySearch. Date, place, and name all align with Moses J McCarley Sr's known profile. This is the primary direct evidence for q_001.",
+              "match_score": null
+            }
+          },
+          {
+            "section": "person_evidence",
+            "op": "append",
+            "entry": {
+              "assertion_id": "a_003",
+              "person_id": "I1",
+              "confidence": "confident",
+              "rationale": "The groom's marriage assertion explicitly names 'Elizabeth Patt' as the bride of Moses McCarley in the 24 Jul 1792 Lincoln County, KY marriage. This assertion therefore bears on I1 (Elizabeth Patt stub) \u2014 it establishes her as L7P6-3TT's spouse. Combined with a_002 and a_004, the whole record consistently identifies I1 as the bride in that event.",
+              "match_score": null
+            }
+          },
+          {
+            "section": "person_evidence",
+            "op": "append",
+            "entry": {
+              "assertion_id": "a_004",
+              "person_id": "I1",
+              "confidence": "probable",
+              "rationale": "The bride's marriage fact documents Elizabeth Patt marrying Moses McCarley on 24 Jul 1792 in Lincoln County, KY. The bride persona is Elizabeth Patt, and I1 was created for this persona. Probable: stub rests on a single derivative source; original bond not examined.",
+              "match_score": null
+            }
+          },
+          {
+            "section": "person_evidence",
+            "op": "append",
+            "entry": {
+              "assertion_id": "a_004",
+              "person_id": "L7P6-3TT",
+              "confidence": "confident",
+              "rationale": "The bride's marriage assertion names 'Moses McCarley' as the groom in the 24 Jul 1792 Lincoln County, KY marriage. This bears on L7P6-3TT as the identified groom. The record is already attached to L7P6-3TT in FamilySearch and the name, date, and place are all consistent with his known profile.",
+              "match_score": null
+            }
+          },
+          {
+            "section": "person_evidence",
+            "op": "append",
+            "entry": {
+              "assertion_id": "a_005",
+              "person_id": "M6M6-LLW",
+              "confidence": "confident",
+              "rationale": "The groom persona (p_102337453199) in the 1817 Jessamine County, KY marriage names 'Moses McCarley.' The record is already attached to M6M6-LLW (Moses McCarley Jr.) in FamilySearch. The groom is the son of Moses Sr. (L7P6-3TT), consistent with the father-of-groom persona in the same record. Marriage date 1817 is appropriate for a son of someone born 1767.",
+              "match_score": null
+            }
+          },
+          {
+            "section": "person_evidence",
+            "op": "append",
+            "entry": {
+              "assertion_id": "a_006",
+              "person_id": "I2",
+              "confidence": "probable",
+              "rationale": "The bride persona (p_102337453209) in the 1817 Jessamine County, KY marriage names 'Betsy Lawson.' Stub I2 was created specifically for this persona \u2014 name matches exactly. Probable because the stub rests on a single derivative index entry; original bond not examined.",
+              "match_score": null
+            }
+          },
+          {
+            "section": "person_evidence",
+            "op": "append",
+            "entry": {
+              "assertion_id": "a_007",
+              "person_id": "M6M6-LLW",
+              "confidence": "confident",
+              "rationale": "The groom's marriage fact in the 1817 Jessamine County, KY record documents Moses McCarley marrying Betsy Lawson on 21 Nov 1817. The groom persona is already attached to M6M6-LLW in FamilySearch. Name, date, and place are consistent with Moses Jr.'s profile as a son of Moses Sr.",
+              "match_score": null
+            }
+          },
+          {
+            "section": "person_evidence",
+            "op": "append",
+            "entry": {
+              "assertion_id": "a_007",
+              "person_id": "I2",
+              "confidence": "probable",
+              "rationale": "The groom's marriage assertion names 'Betsy Lawson' as the bride in the 21 Nov 1817 Jessamine County, KY marriage. This bears on I2 (Betsy Lawson stub). Probable because the stub has no independent corroboration beyond this single derivative record.",
+              "match_score": null
+            }
+          },
+          {
+            "section": "person_evidence",
+            "op": "append",
+            "entry": {
+              "assertion_id": "a_008",
+              "person_id": "I2",
+              "confidence": "probable",
+              "rationale": "The bride's marriage fact documents Betsy Lawson marrying Moses McCarley on 21 Nov 1817 in Jessamine County, KY. The bride persona is Betsy Lawson and I2 was created for this persona. Probable: single derivative source, original not examined.",
+              "match_score": null
+            }
+          },
+          {
+            "section": "person_evidence",
+            "op": "append",
+            "entry": {
+              "assertion_id": "a_008",
+              "person_id": "M6M6-LLW",
+              "confidence": "confident",
+              "rationale": "The bride's marriage assertion names 'Moses McCarley' as the groom in the 21 Nov 1817 Jessamine County, KY marriage. This bears on M6M6-LLW (Moses McCarley Jr.) as the groom. The record is already attached to M6M6-LLW in FamilySearch.",
+              "match_score": null
+            }
+          },
+          {
+            "section": "person_evidence",
+            "op": "append",
+            "entry": {
+              "assertion_id": "a_009",
+              "person_id": "L7P6-3TT",
+              "confidence": "confident",
+              "rationale": "The father-of-groom persona (p_102337453201) in the 1817 Jessamine County, KY marriage names 'Moses Mccarley' as parent of the groom. The father ARK (ark:/61903/1:1:Q28D-N9Z9) is already attached to L7P6-3TT in FamilySearch. Name matches ('Moses Mccarley' = 'Moses J McCarley'); being father of Moses Jr. in 1817 is consistent with Moses Sr.'s birth year of 1767 (age ~50). Corroborates Moses Sr.'s Kentucky residence and survival as of Nov 1817.",
+              "match_score": null
+            }
+          },
+          {
+            "section": "person_evidence",
+            "op": "append",
+            "entry": {
+              "assertion_id": "a_009",
+              "person_id": "M6M6-LLW",
+              "confidence": "probable",
+              "rationale": "The father-of-groom relationship assertion names Moses Mccarley Sr. as the parent of Moses McCarley (groom, M6M6-LLW). This bears on M6M6-LLW's parentage. Probable because information quality is indeterminate (source of father's name in the original bond is unclear) and the original bond was not examined.",
+              "match_score": null
+            }
+          },
+          {
+            "section": "person_evidence",
+            "op": "append",
+            "entry": {
+              "assertion_id": "a_010",
+              "person_id": "L7P6-3TT",
+              "confidence": "confident",
+              "rationale": "The father-of-groom residence assertion places Moses Mccarley Sr. in Jessamine County, KY as of 21 Nov 1817. The father persona is already attached to L7P6-3TT in FamilySearch. Consistent with Moses Sr.'s known Kentucky trajectory (Lincoln Co. 1792 \u2192 Jessamine Co. area by 1817\u20131827).",
+              "match_score": null
+            }
+          },
+          {
+            "section": "person_evidence",
+            "op": "append",
+            "entry": {
+              "assertion_id": "a_013",
+              "person_id": "KF27-BHH",
+              "confidence": "probable",
+              "rationale": "The bride persona in the 1827 Jessamine County, KY marriage names 'Salvina Mccarley.' KF27-BHH is 'Sabina McCarley' in the tree. 'Salvina' and 'Sabina' are name variants documented in period records. The father named in this record ('Mofes Mccarley' = Moses Sr., L7P6-3TT) is consistent with Sabina being Moses Sr.'s daughter. Place and date (Jessamine County, 1827) are consistent with the family's known location. Probable: derivative index, original not examined; 'Salvina'/'Sabina' variant requires image confirmation.",
+              "match_score": null
+            }
+          },
+          {
+            "section": "person_evidence",
+            "op": "append",
+            "entry": {
+              "assertion_id": "a_014",
+              "person_id": "KF27-BHH",
+              "confidence": "probable",
+              "rationale": "The bride's marriage fact in the 1827 Jessamine County, KY record documents Salvina Mccarley marrying Westley Alverson. KF27-BHH (Sabina McCarley) is identified as this bride based on the 'Salvina'/'Sabina' name variant and consistent placement (Jessamine County, KY; father = Moses Sr.). Probable: name variant and derivative source.",
+              "match_score": null
+            }
+          },
+          {
+            "section": "person_evidence",
+            "op": "append",
+            "entry": {
+              "assertion_id": "a_015",
+              "person_id": "L7P6-3TT",
+              "confidence": "probable",
+              "rationale": "The father-of-bride persona in the 1827 Jessamine County, KY marriage names 'Mofes Mccarley' as Salvina's father. This record was found attached to L7P6-3TT in FamilySearch. 'Mofes' is a period handwriting variant of 'Moses' (long-s). Name, place (Jessamine Co., KY), and date (1827) are consistent with Moses J McCarley Sr's known profile. Probable: derivative index, 'Mofes' variant tentative pending examination of the original marriage bond image.",
+              "match_score": null
+            }
+          },
+          {
+            "section": "person_evidence",
+            "op": "append",
+            "entry": {
+              "assertion_id": "a_015",
+              "person_id": "KF27-BHH",
+              "confidence": "probable",
+              "rationale": "The father-of-bride assertion naming 'Mofes Mccarley' as Salvina's father bears on KF27-BHH (Sabina McCarley) as the child whose parentage is documented. If KF27-BHH is the same as Salvina Mccarley (linked via a_013), then a_015 is direct evidence that L7P6-3TT is her father. Probable: name variants ('Salvina'/'Sabina', 'Mofes'/'Moses') unconfirmed against original image.",
+              "match_score": null
+            }
+          },
+          {
+            "section": "person_evidence",
+            "op": "append",
+            "entry": {
+              "assertion_id": "a_016",
+              "person_id": "L7P6-3TT",
+              "confidence": "probable",
+              "rationale": "The father-of-bride residence assertion places Moses Sr. in Jessamine County, KY as of 28 Apr 1827, consistent with his presence there in 1817 and confirming continued survival 10 years later. The father persona is attached to L7P6-3TT in FamilySearch. Probable: indirect inference from a daughter's marriage record; derivative source.",
+              "match_score": null
+            }
+          }
+        ]
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"results\\\": [\\n    {\\n      \\\"section\\\": \\\"person_evidence\\\",\\n      \\\"op\\\": \\\"append\\\",\\n      \\\"entryId\\\": \\\"pe_001\\\"\\n    },\\n    {\\n      \\\"section\\\": \\\"person_evidence\\\",\\n      \\\"op\\\": \\\"append\\\",\\n      \\\"entryId\\\": \\\"pe_002\\\"\\n    },\\n    {\\n      \\\"section\\\": \\\"person_evidence\\\",\\n      \\\"op\\\": \\\"append\\\",\\n      \\\"entryId\\\": \\\"pe_003\\\"\\n    },\\n    {\\n      \\\"section\\\": \\\"person_evidence\\\",\\n      \\\"op\\\": \\\"append\\\",\\n      \\\"entryId..."
+    },
+    {
+      "tool": "Glob",
+      "args": {
+        "pattern": "**/*.md",
+        "path": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l/.claude/skills"
+      },
+      "response_summary": ".claude/skills/check-warnings/references/assumption-categories.md\n.claude/skills/check-warnings/references/warning-checks.md\n.claude/skills/check-warnings/references/warnings-as-identity-signals.md\n.claude/skills/citation/references/gps-citation-standards.md\n.claude/skills/citation/references/validation-protocol.md\n.claude/skills/conflict-resolution/references/historical-contradictions.md\n.claude/skills/conflict-resolution/references/places-guidance.md\n.claude/skills/conflict-resolution/refer..."
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l/.claude/skills/research-exhaustiveness/SKILL.md"
+      },
+      "response_summary": "1\t---\n2\tname: research-exhaustiveness\n3\tmodel: claude-sonnet-4-6\n4\tdescription: Evaluates whether research on a question is reasonably\n5\t  exhaustive \u2014 applies the five threshold questions and the 7-point\n6\t  stop criteria, then either writes the exhaustive_declaration on the\n7\t  question or explains what's missing. GPS Step 1 \u2014 Reasonably\n8\t  Exhaustive Research. Use when the user says \"is this research\n9\t  exhaustive?\", \"are we done?\", \"have we searched enough?\", \"can we\n10\t  declare exhaus..."
+    },
+    {
+      "tool": "mcp__genealogy__research_append",
+      "args": {
+        "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l",
+        "ops": [
+          {
+            "section": "plan_items",
+            "op": "update",
+            "planId": "pl_001",
+            "entryId": "pli_003",
+            "fields": {
+              "status": "skipped"
+            }
+          },
+          {
+            "section": "plan_items",
+            "op": "update",
+            "planId": "pl_001",
+            "entryId": "pli_004",
+            "fields": {
+              "status": "skipped"
+            }
+          },
+          {
+            "section": "plan_items",
+            "op": "update",
+            "planId": "pl_001",
+            "entryId": "pli_006",
+            "fields": {
+              "status": "skipped"
+            }
+          }
+        ]
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"results\\\": [\\n    {\\n      \\\"section\\\": \\\"plan_items\\\",\\n      \\\"op\\\": \\\"update\\\",\\n      \\\"entryId\\\": \\\"pli_003\\\"\\n    },\\n    {\\n      \\\"section\\\": \\\"plan_items\\\",\\n      \\\"op\\\": \\\"update\\\",\\n      \\\"entryId\\\": \\\"pli_004\\\"\\n    },\\n    {\\n      \\\"section\\\": \\\"plan_items\\\",\\n      \\\"op\\\": \\\"update\\\",\\n      \\\"entryId\\\": \\\"pli_006\\\"\\n    }\\n  ],\\n  \\\"filesWritten\\\": [\\n    \\\"research.json\\\"\\n  ],\\n  \\\"validation\\\": {\\n    \\\"valid\\\": true,\\n  ..."
+    },
+    {
+      "tool": "Agent",
+      "args": {
+        "description": "Read 1792 Kentucky marriage bond image",
+        "subagent_type": "image-reader",
+        "prompt": "Read the FamilySearch image at ARK ark:/61903/1:2:QLWS-5MZ8. This is a Kentucky county marriage bond or license from 1792, Lincoln County, Kentucky. I am looking for: the marriage entry for Moses McCarley and Elizabeth Patt, dated 24 Jul 1792 \u2014 specifically any names of parties, witnesses, date, county, and any other details on the page. Return a full text transcription of whatever is legible on the page."
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"NOT READ: ark:/61903/1:2:QLWS-5MZ8\\n\\nThe ARK provided uses the `1:2:` namespace, which is a FamilySearch **record** ARK (pointing to an indexed record or source citation), not a document-image ARK. The `image_read` tool requires a document-image ARK in the `3:1:` or `3:2:` namespace, a DeepZoomCloud distribution URL, or a DGS distribution URL.\\n\\nThe exact error returned was:\\n\\\"Unrecognized ark. Expected a FamilySearch document-image ARK (ark:/61903/3:1:... or 3:2..."
+    },
+    {
+      "tool": "mcp__genealogy__image_read",
+      "args": {
+        "ark": "ark:/61903/1:2:QLWS-5MZ8"
+      },
+      "response_summary": "{\"error\":\"Unrecognized ark. Expected a FamilySearch document-image ARK (ark:/61903/3:1:... or 3:2:..., a bare 3:1:.../3:2:... id, or a resolver URL for one), a DeepZoomCloud ARK URL (ending in /$dist), or a DGS distribution URL (dgs:.../dist.jpg).\"}"
+    },
+    {
+      "tool": "ToolSearch",
+      "args": {
+        "query": "select:mcp__genealogy__record_read,mcp__genealogy__volume_search",
+        "max_results": 2
+      },
+      "response_summary": "[{\"type\": \"tool_reference\", \"tool_name\": \"mcp__genealogy__record_read\"}, {\"type\": \"tool_reference\", \"tool_name\": \"mcp__genealogy__volume_search\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__record_read",
+      "args": {
+        "recordId": "ark:/61903/1:1:Q28D-NHWN",
+        "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l",
+        "resultsRef": "results/log_001.json"
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"persons\\\": [\\n    {\\n      \\\"id\\\": \\\"p_102337459396\\\",\\n      \\\"ark\\\": \\\"ark:/61903/1:1:Q28D-NHWN\\\",\\n      \\\"gender\\\": \\\"Male\\\",\\n      \\\"names\\\": [\\n        {\\n          \\\"type\\\": \\\"BirthName\\\",\\n          \\\"given\\\": \\\"Moses\\\",\\n          \\\"surname\\\": \\\"McCarley\\\"\\n        }\\n      ],\\n      \\\"facts\\\": [\\n        {\\n          \\\"type\\\": \\\"Unknown\\\",\\n          \\\"primary\\\": true,\\n          \\\"place\\\": \\\"Lincoln\\\",\\n          \\\"standard_place\\\": \\\"Lincoln, Ken..."
+    },
+    {
+      "tool": "Agent",
+      "args": {
+        "description": "Read original 1792 Lincoln Co. marriage bond image",
+        "subagent_type": "image-reader",
+        "prompt": "Read the FamilySearch document image at ARK ark:/61903/3:1:3Q9M-C9BK-BSZ8-3. This is a page from a Lincoln County, Kentucky marriage register or bond book from circa 1792. I am looking for the marriage entry for Moses McCarley and Elizabeth Patt, dated 24 July 1792. Please transcribe the full text of whatever is visible on the page, including all names, dates, places, amounts, and witness names. Pay particular attention to the exact spelling of all surnames and given names."
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"NOT READ: ark:/61903/3:1:3Q9M-C9BK-BSZ8-3\\n\\nThe exact error returned by image_read:\\n\\n\\\"FamilySearch image ark:/61903/3:1:3Q9M-C9BK-BSZ8-3 is 1.1 MB \\u2014 too large to return inline. The MCP transport caps a single response near 1 MB and base64 encoding inflates the image by ~33%, so returning it would crash the session.\\\"\\n\\nThe image cannot be returned because it exceeds the ~1 MB transport safety ceiling (the file is 1.1 MB, and base64 encoding would push it w..."
+    },
+    {
+      "tool": "mcp__genealogy__image_read",
+      "args": {
+        "ark": "ark:/61903/3:1:3Q9M-C9BK-BSZ8-3"
+      },
+      "response_summary": "{\"error\":\"FamilySearch image ark:/61903/3:1:3Q9M-C9BK-BSZ8-3 is 1.1 MB \u2014 too large to return inline. The MCP transport caps a single response near 1 MB and base64 encoding inflates the image by ~33%, so returning it would crash the session. Read the indexed record for this image with record_read / record_search instead of fetching the page scan, or choose a more specific image.\"}"
+    },
+    {
+      "tool": "mcp__genealogy__research_append",
+      "args": {
+        "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l",
+        "section": "questions",
+        "op": "update",
+        "entryId": "q_001",
+        "fields": {
+          "status": "exhaustive_declared",
+          "exhaustive_declaration": {
+            "declared": true,
+            "justification": "Searched Kentucky County Marriages 1786-1965 (primary marriage evidence), 1820/1840 census records (nil \u2014 not indexed), Kentucky Probate Records and Wills and Deeds (nil \u2014 essentially browse-only collections), and the FAN cluster (children's marriages in 1817 and 1827, which corroborate Moses Sr.'s identity and Kentucky residence but do not name his wife). The original marriage bond image (ark:/61903/3:1:3Q9M-C9BK-BSZ8-3) was attempted but is inaccessible due to the MCP transport cap (1.1 MB). No competing evidence names a different spouse across any source examined. The derivative index entry (src_001) directly and unambiguously answers the question.",
+            "log_entry_ids": [
+              "log_001",
+              "log_002",
+              "log_003",
+              "log_004",
+              "log_005",
+              "log_006",
+              "log_007",
+              "log_008",
+              "log_009"
+            ],
+            "stop_criteria": {
+              "goal_alignment": "Yes \u2014 src_001 (Kentucky County Marriages index) directly names Elizabeth Patt as Moses McCarley Sr.'s spouse, marriage 24 Jul 1792, Lincoln County, KY. The record is attached to L7P6-3TT in FamilySearch. No competing evidence names a different wife.",
+              "repository_breadth": "FamilySearch Kentucky County Marriages (primary evidence), 1820 and 1840 census (nil \u2014 not indexed for this family), Kentucky Probate Records 1727-1990 and Wills and Deeds (nil \u2014 collections are effectively browse-only), and FAN cluster (son's 1817 and daughter's 1827 marriages). External repositories (Ancestry, MyHeritage) not searched, but the core marriage question is answered by the FamilySearch marriage collection.",
+              "original_substitution": "The original Lincoln County marriage bond image (ark:/61903/3:1:3Q9M-C9BK-BSZ8-3) was attempted via image-reader but is inaccessible: file is 1.1 MB, exceeding the MCP transport cap. Treated as pursued-and-unavailable per the inaccessibility exception. The derivative index carries the same core facts (names, date, county) extracted from the original.",
+              "independent_verification": "One source (src_001, derivative index) directly documents the marriage to Elizabeth Patt. The 1817 and 1827 FAN records (src_002, src_003) corroborate Moses Sr.'s identity and Kentucky presence but do not name his wife. Independent verification of the specific marriage is limited to the single derivative index entry \u2014 a genuine limitation that constrains the proof tier to 'probable' rather than 'proved'.",
+              "evidence_class": "Primary evidence (src_001) is a derivative index entry based on primary information (Lincoln County clerk's marriage bond). Original not accessible (transport cap). No original record with primary information was successfully examined for the marriage itself.",
+              "conflict_resolution": "No conflicting evidence found. No record examined names a different spouse. The 'Mofes Mccarley' spelling in the 1827 record is a period handwriting variant of 'Moses' (long-s), not a conflict.",
+              "overturn_risk": "Low to moderate. No competing evidence names a different wife. The primary risk is that the original bond could spell names differently or record additional context. Land records and church records for Lincoln/Jessamine County were not searched but are unlikely to name a different spouse given the unambiguous 1792 marriage entry. Examining the original image and additional corroborating sources (land records, church records, Ancestry collections) would strengthen the conclusion from 'probable' to 'proved.'"
+            }
+          }
+        }
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"section\\\": \\\"questions\\\",\\n  \\\"op\\\": \\\"update\\\",\\n  \\\"entryId\\\": \\\"q_001\\\",\\n  \\\"filesWritten\\\": [\\n    \\\"research.json\\\"\\n  ],\\n  \\\"validation\\\": {\\n    \\\"valid\\\": true,\\n    \\\"warnings\\\": []\\n  }\\n}\"}]"
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l/.claude/skills/proof-conclusion/SKILL.md"
+      },
+      "response_summary": "1\t---\n2\tname: proof-conclusion\n3\tmodel: claude-sonnet-4-6\n4\tdescription: Writes GPS-conformant proof conclusions \u2014 selects the tier\n5\t  (Proved/Probable/Possible/Not Proved/Disproved), chooses the form\n6\t  (Statement/Summary/Argument), and writes a self-contained narrative\n7\t  markdown uploadable to FamilySearch. Updates tree.gedcomx.json at tier\n8\t  probable or higher.\n9\t  GPS Step 5 \u2014 Soundly Reasoned, Coherently Written Conclusion. Use when\n10\t  the user says \"write the conclusion\", \"what'..."
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l/.claude/skills/proof-conclusion/references/gps-proof-writing.md"
+      },
+      "response_summary": "1\t# GPS Proof Writing Reference\n2\t\n3\tThis reference provides detailed guidance for writing genealogical\n4\tproof conclusions that conform to the Genealogical Proof Standard.\n5\t\n6\t## The Five GPS Components (All Required for Proof)\n7\t\n8\tA conclusion qualifies as \"proved\" ONLY when all five are satisfied:\n9\t\n10\t1. **Reasonably exhaustive research** \u2014 Every record type and\n11\t   repository that could plausibly contain relevant information has\n12\t   been searched. Not every record ever created, bu..."
+    },
+    {
+      "tool": "Grep",
+      "args": {
+        "pattern": "R25|L7P6-3TT.*I1|I1.*L7P6-3TT|person1.*person2",
+        "path": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l/tree.gedcomx.json",
+        "output_mode": "content",
+        "context": 2
+      },
+      "response_summary": "755-      \"person1\": \"L7P6-3TT\",\n756-      \"person2\": \"I1\",\n757:      \"id\": \"R25\",\n758-      \"facts\": [\n759-        {"
+    },
+    {
+      "tool": "mcp__genealogy__research_append",
+      "args": {
+        "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l",
+        "section": "proof_summaries",
+        "op": "append",
+        "entry": {
+          "question_id": "q_001",
+          "tier": "probable",
+          "vehicle": "summary",
+          "supporting_assertion_ids": [
+            "a_001",
+            "a_002",
+            "a_003",
+            "a_004",
+            "a_009",
+            "a_010",
+            "a_015",
+            "a_016"
+          ],
+          "resolved_conflict_ids": [],
+          "exhaustive_search_summary": "Searched: FamilySearch 'Kentucky, County Marriages, 1786-1965' (collection 1804888) for Lincoln and Jessamine counties; FamilySearch 1820 and 1840 US Federal Census records (nil \u2014 not indexed for this family under any spelling variant); FamilySearch 'Kentucky Probate Records, 1727-1990' (collection 1875188, nil \u2014 sparse index of ~12,000 of ~989,000 images) and 'Kentucky Wills and Deeds, ca. 1700s-2017' (collection 3155869, nil \u2014 effectively browse-only); FAN cluster via children's marriages (1817 Jessamine Co. marriage of Moses Jr., 1827 Jessamine Co. marriage of Salvina/Sabina). The original marriage bond image (ark:/61903/3:1:3Q9M-C9BK-BSZ8-3) was attempted via image-reader but is inaccessible due to the MCP transport ceiling (1.1 MB). External repositories (Ancestry, MyHeritage) and land records were not searched. The derivative index is the sole source directly documenting the marriage; no independent original-record corroboration of the specific marriage to Elizabeth Patt was obtained.",
+          "narrative_markdown": "## Who Did Moses J McCarley Sr Marry?\n\n**Conclusion:** The preponderance of available evidence strongly suggests that Moses J McCarley Sr (born 17 January 1767, died 9 April 1844) married **Elizabeth Patt** on **24 July 1792** in **Lincoln County, Kentucky**. The conclusion rests primarily on a single derivative marriage-index entry; the original bond was not accessible, and no independent source names Elizabeth Patt as his wife. Accordingly, the conclusion is rated **probable**, not proved.\n\n---\n\n### Primary Evidence\n\nThe FamilySearch database *\"Kentucky, County Marriages, 1786-1965\"* (collection 1804888), a derivative index of Lincoln County marriage bonds, contains an entry for Moses McCarley and Elizabeth Patt, dated 24 July 1792, in Lincoln County, Kentucky (ark:/61903/1:1:Q28D-NHWN). This is a **derivative source** (a name index compiled from the underlying county bond images) carrying **primary information** \u2014 the county clerk recorded the marriage contemporaneously in an official capacity. The entry provides **direct evidence** of the marriage event and both parties' names.\n\nThe indexed facts are: groom Moses McCarley; bride Elizabeth Patt; date 24 July 1792; place Lincoln County, Kentucky. The marriage date is consistent with Moses Sr.'s documented birth year of 1767, placing him at approximately age 25 at the time of the marriage \u2014 a plausible age for a first marriage in late-eighteenth-century Kentucky. The record is already attached to Moses J McCarley Sr (L7P6-3TT) in FamilySearch's own tree linkage system, providing additional institutional confirmation that this record concerns the subject.\n\nThe original marriage bond image (FamilySearch image ARK ark:/61903/3:1:3Q9M-C9BK-BSZ8-3) was identified and read was attempted; it could not be retrieved because the file (1.1 MB) exceeds the available transport ceiling. This limitation prevents upgrade of the source classification from derivative to original and constrains the proof tier. Examination of the original bond remains an outstanding step.\n\n---\n\n### Corroborating Evidence\n\nTwo additional records confirm the identity of Moses J McCarley Sr and his continued presence in Kentucky, though neither names his wife:\n\n**1817 \u2014 Jessamine County marriage (src_002):** The FamilySearch *\"Kentucky, County Marriages, 1786-1965\"* index records the marriage of Moses McCarley and Betsy Lawson on 21 November 1817 in Jessamine County, Kentucky (ark:/61903/1:1:Q28D-N9C1). The indexed record lists Moses Mccarley [Sr.] as the father of the groom. This is a derivative source carrying indeterminate-quality information (the source of the father's name \u2014 stated by the groom, provided by a bondsman, or extracted by the indexer \u2014 is not established without examination of the original bond). The assertion provides **indirect evidence** corroborating Moses Sr.'s identity and his survival and Kentucky residence as of November 1817 \u2014 approximately 25 years after the 1792 marriage \u2014 but does not name his wife.\n\n**1827 \u2014 Jessamine County marriage (src_003):** A second FamilySearch marriage index entry records Westley Alverson marrying Salvina Mccarley on 28 April 1827 in Jessamine County, Kentucky (ark:/61903/1:1:Q28D-XWSS). The entry names \"Mofes Mccarley\" as the bride's father. \"Mofes\" is a period handwriting variant of \"Moses\" attributable to the long-s letterform common in early-nineteenth-century documents. The bride Salvina Mccarley corresponds to Sabina McCarley (KF27-BHH) in the family tree \u2014 \"Salvina\" and \"Sabina\" are documented period spelling variants of the same given name. This derivative index entry provides **indirect evidence** placing Moses Sr. in Jessamine County, Kentucky as of 1827, alive nearly 35 years after the 1792 marriage, and identifies him as the father of at least one daughter. It does not name his wife.\n\n---\n\n### Negative Evidence\n\nSearches of the 1820 and 1840 US Federal Census records returned no indexed result for Moses McCarley (or spelling variants) in Kentucky \u2014 a negative finding consistent with incomplete indexing of early Kentucky censuses on FamilySearch rather than his absence from the records. Searches of FamilySearch's Kentucky Probate Records and Wills and Deeds collections likewise returned nil; both collections are effectively browse-only image sets with sparse name indexes. No probate record naming Moses Sr.'s wife was accessible. No record examined names any person other than Elizabeth Patt as Moses Sr.'s spouse.\n\n---\n\n### Limitations and Path to Proved\n\nThis conclusion is rated **probable** rather than proved because two GPS components are not fully satisfied:\n\n1. **Original substitution:** The primary evidence is a derivative index entry. The original Lincoln County marriage bond image was identified but is inaccessible through current tools (transport cap). Examination of the original bond would confirm the spelling of names, potentially reveal witnesses or sureties, and upgrade the source classification.\n\n2. **Independent verification:** Only one source directly documents the marriage to Elizabeth Patt. The two FAN records corroborate Moses Sr.'s identity and Kentucky residency but do not name his wife. An independent source \u2014 a land deed listing Elizabeth as Moses Sr.'s wife, a church record, a probate inventory naming her as widow, or an Ancestry/external database record \u2014 would provide the second independent source required for proved.\n\nTo advance this conclusion to **proved**, a researcher should: (1) locate and examine the original Lincoln County marriage bond image through a library or archive copy of the microfilm; (2) search land records for Lincoln and Jessamine counties for deeds in Moses Sr.'s name, particularly any that name his wife; (3) search Ancestry and MyHeritage for additional Kentucky records; and (4) examine available browse-only probate images in Lincoln, Garrard, and Jessamine counties for Moses Sr.'s estate.\n\n---\n\n*Sources: \"Kentucky, County Marriages, 1786-1965,\" FamilySearch, ark:/61903/1:1:Q28D-NHWN (Moses McCarley and Elizabeth Patt, 24 Jul 1792, Lincoln County); ark:/61903/1:1:Q28D-N9C1 (Moses McCarley Jr. and Betsy Lawson, 21 Nov 1817, Jessamine County \u2014 Moses Mccarley Sr. listed as father of groom); ark:/61903/1:1:Q28D-XWSS (Westley Alverson and Salvina Mccarley, 28 Apr 1827, Jessamine County \u2014 Mofes Mccarley listed as father of bride). All accessed 14 July 2026 via FamilySearch (familysearch.org).*"
+        }
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"section\\\": \\\"proof_summaries\\\",\\n  \\\"op\\\": \\\"append\\\",\\n  \\\"entryId\\\": \\\"ps_001\\\",\\n  \\\"filesWritten\\\": [\\n    \\\"research.json\\\"\\n  ],\\n  \\\"validation\\\": {\\n    \\\"valid\\\": true,\\n    \\\"warnings\\\": []\\n  }\\n}\"}]"
+    },
+    {
+      "tool": "Grep",
+      "args": {
+        "pattern": "\"R25\"|\"S1\"|\"S3\"|\"S4\"",
+        "path": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l/tree.gedcomx.json",
+        "output_mode": "content",
+        "context": 3
+      },
+      "response_summary": "754-      \"type\": \"Couple\",\n755-      \"person1\": \"L7P6-3TT\",\n756-      \"person2\": \"I1\",\n757:      \"id\": \"R25\",\n758-      \"facts\": [\n759-        {\n760-          \"type\": \"Marriage\",\n--\n786-      \"url\": \"https://familysearch.org/ark:/61903/1:1:QVG3-8WK7\"\n787-    },\n788-    {\n789:      \"id\": \"S1\",\n790-      \"title\": \"Entry for Moses McCarley and Elizabeth Patt, \\\"Kentucky, County Marriages, 1786-1965\\\"\",\n791-      \"url\": \"https://www.familysearch.org/ark:/61903/1:2:QLWS-5MZ8\"\n792-    },\n--\n796-  ..."
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l/tree.gedcomx.json",
+        "offset": 753,
+        "limit": 30
+      },
+      "response_summary": "753\t    {\n754\t      \"type\": \"Couple\",\n755\t      \"person1\": \"L7P6-3TT\",\n756\t      \"person2\": \"I1\",\n757\t      \"id\": \"R25\",\n758\t      \"facts\": [\n759\t        {\n760\t          \"type\": \"Marriage\",\n761\t          \"date\": \"24 Jul 1792\",\n762\t          \"standard_date\": \"24 Jul 1792\",\n763\t          \"place\": \"Lincoln, Kentucky, United States\",\n764\t          \"standard_place\": \"Lincoln, Kentucky, United States\",\n765\t          \"primary\": true,\n766\t          \"id\": \"F1\"\n767\t        }\n768\t      ]\n769\t    }\n770\t ..."
+    },
+    {
+      "tool": "mcp__genealogy__research_append",
+      "args": {
+        "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l",
+        "ops": [
+          {
+            "section": "questions",
+            "op": "update",
+            "entryId": "q_001",
+            "fields": {
+              "status": "answered",
+              "resolved": "2026-07-14",
+              "resolution_assertion_ids": [
+                "a_001",
+                "a_002",
+                "a_003",
+                "a_004"
+              ]
+            }
+          },
+          {
+            "section": "project",
+            "op": "update",
+            "fields": {
+              "status": "completed"
+            }
+          }
+        ]
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": false,\\n  \\\"errors\\\": [\\n    \\\"ops[0]: research.json/questions[0]: 'answered' is not a valid question_status (expected one of: exhaustive_declared, in_progress, open, resolved)\\\"\\n  ],\\n  \\\"opsReceived\\\": 2\\n}\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__research_append",
+      "args": {
+        "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l",
+        "ops": [
+          {
+            "section": "questions",
+            "op": "update",
+            "entryId": "q_001",
+            "fields": {
+              "status": "resolved",
+              "resolved": "2026-07-14",
+              "resolution_assertion_ids": [
+                "a_001",
+                "a_002",
+                "a_003",
+                "a_004"
+              ]
+            }
+          },
+          {
+            "section": "project",
+            "op": "update",
+            "fields": {
+              "status": "completed"
+            }
+          }
+        ]
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"results\\\": [\\n    {\\n      \\\"section\\\": \\\"questions\\\",\\n      \\\"op\\\": \\\"update\\\",\\n      \\\"entryId\\\": \\\"q_001\\\"\\n    },\\n    {\\n      \\\"section\\\": \\\"project\\\",\\n      \\\"op\\\": \\\"update\\\",\\n      \\\"entryId\\\": \\\"project\\\"\\n    }\\n  ],\\n  \\\"filesWritten\\\": [\\n    \\\"research.json\\\"\\n  ],\\n  \\\"validation\\\": {\\n    \\\"valid\\\": true,\\n    \\\"warnings\\\": []\\n  }\\n}\"}]"
+    },
+    {
+      "tool": "Agent",
+      "args": {
+        "description": "GPS mentor proof review",
+        "subagent_type": "gps-mentor",
+        "prompt": "Please review the proof summary ps_001 for research question q_001 in the project at /private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l.\n\nThe question is: \"Who did Moses J McCarley Sr (born 17 January 1767, died 9 April 1844) marry?\"\n\nThe proof conclusion (ps_001) is at the PROBABLE tier, vehicle: summary. The conclusion is that Moses J McCarley Sr married Elizabeth Patt on 24 July 1792 in Lincoln County, Kentucky.\n\nEvidence base:\n- src_001: FamilySearch \"Kentucky, County Marriages, 1786-1965\" (derivative index), entry for Moses McCarley and Elizabeth Patt, 24 Jul 1792, Lincoln County, KY (ark:/61903/1:1:Q28D-NHWN). Direct evidence, primary information. Already attached to subject L7P6-3TT in FamilySearch.\n- src_002: Same collection, 1817 Jessamine County marriage of Moses McCarley Jr. + Betsy Lawson \u2014 Moses Mccarley Sr. listed as father of groom. Indirect/corroborating, indeterminate quality.\n- src_003: Same collection, 1827 Jessamine County marriage of Westley Alverson + Salvina Mccarley \u2014 \"Mofes Mccarley\" listed as father of bride. Indirect/corroborating.\n\nNegative evidence: 1820 and 1840 census (nil \u2014 not indexed), Kentucky probate records (nil \u2014 browse-only), no other spouse named in any record.\n\nLimitations acknowledged in ps_001: original bond image inaccessible (1.1 MB transport cap); only one source directly documents the marriage; no independent verification of the specific marriage to Elizabeth Patt.\n\nPlease assess: (1) Is the probable tier appropriate? (2) Is the narrative accurate and honest? (3) Are there any GPS deficiencies that should be addressed? (4) What would it take to advance to proved? Return a structured verdict (approve / needs-work / reject) and a brief mentoring narrative."
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"# Mentor review: proof-critique on ps_001\\n\\n**Note on output protocol:** I was not given a file-writing tool in this session (only `Read` is available to me), so I cannot create `evaluations/proof-critique-ps_001-<timestamp>.json` or append the pointer entry to `research.json`'s `evaluations[]` array as the output protocol requires. I'm reporting that explicitly rather than silently skipping it. Below is the full verdict content \\u2014 please have it written to dis..."
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l/research.json"
+      },
+      "response_summary": "1\t{\n2\t  \"project\": {\n3\t    \"id\": \"rp_mccarley_spouse\",\n4\t    \"objective\": \"Who was the spouse of Moses J McCarley Sr, who was born 17 January 1767 and died 9 April 1844?\",\n5\t    \"subject_person_ids\": [\n6\t      \"L7P6-3TT\"\n7\t    ],\n8\t    \"status\": \"completed\",\n9\t    \"created\": \"2026-07-14\",\n10\t    \"updated\": \"2026-07-15\"\n11\t  },\n12\t  \"researcher_profile\": {\n13\t    \"experience_level\": \"intermediate\",\n14\t    \"subscriptions\": [],\n15\t    \"narration_guidance\": \"concise\"\n16\t  },\n17\t  \"questions\": [\n1..."
+    },
+    {
+      "tool": "ToolSearch",
+      "args": {
+        "query": "select:mcp__genealogy__research_log_append",
+        "max_results": 1
+      },
+      "response_summary": "[{\"type\": \"tool_reference\", \"tool_name\": \"mcp__genealogy__research_log_append\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__research_log_append",
+      "args": {
+        "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l",
+        "tool": "image_read",
+        "planItemId": null,
+        "query": {
+          "imageArk": "ark:/61903/3:1:3Q9M-C9BK-BSZ8-3",
+          "purpose": "Original 1792 Lincoln County, KY marriage bond image \u2014 attempted to upgrade src_001 from derivative index to original source as part of exhaustiveness evaluation for q_001",
+          "imageArkSource": "sd_da1 source description from record_read of ark:/61903/1:1:Q28D-NHWN"
+        },
+        "outcome": "error",
+        "resultsExamined": 0,
+        "resultsAvailable": 0,
+        "notes": "NOT READ: image-reader returned transport-cap failure. File is 1.1 MB; MCP transport safety ceiling is ~1 MB (base64 encoding inflates by ~33%). No transcription produced. The original Lincoln County marriage bond for Moses McCarley and Elizabeth Patt (24 Jul 1792) could not be retrieved through the available tools. Treated as pursued-and-unavailable \u2014 the derivative index (src_001) remains the only accessible form of this record. To examine the original, a researcher would need to access the microfilm through a FamilySearch center or library holding (collection 1804888, Lincoln County, Kentucky marriage bonds).",
+        "stagedResultsRef": null
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"logId\\\": \\\"log_010\\\",\\n  \\\"performed\\\": \\\"2026-07-15T01:25:11.853Z\\\",\\n  \\\"resultsRef\\\": null,\\n  \\\"returnedCount\\\": null,\\n  \\\"filesWritten\\\": [\\n    \\\"research.json\\\"\\n  ],\\n  \\\"validation\\\": {\\n    \\\"valid\\\": true,\\n    \\\"warnings\\\": []\\n  }\\n}\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__research_append",
+      "args": {
+        "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l",
+        "ops": [
+          {
+            "section": "proof_summaries",
+            "op": "update",
+            "entryId": "ps_001",
+            "fields": {
+              "narrative_markdown": "## Who Did Moses J McCarley Sr Marry?\n\n**Conclusion:** The preponderance of available evidence strongly suggests that Moses J McCarley Sr (born 17 January 1767, died 9 April 1844) married **Elizabeth Patt** on **24 July 1792** in **Lincoln County, Kentucky**. The conclusion rests primarily on a single derivative marriage-index entry; the original bond was attempted but inaccessible, and no independent source names Elizabeth Patt as his wife. Accordingly, the conclusion is rated **probable**, not proved.\n\n---\n\n### Primary Evidence\n\nThe FamilySearch database *\"Kentucky, County Marriages, 1786-1965\"* (collection 1804888), a derivative index of Lincoln County marriage bonds, contains an entry for Moses McCarley and Elizabeth Patt, dated 24 July 1792, in Lincoln County, Kentucky (ark:/61903/1:1:Q28D-NHWN). This is a **derivative source** (a name index compiled from the underlying county bond images) carrying **primary information** \u2014 the county clerk recorded the marriage contemporaneously in an official capacity. The entry provides **direct evidence** of the marriage event and both parties' names.\n\nThe indexed facts are: groom Moses McCarley; bride Elizabeth Patt; date 24 July 1792; place Lincoln County, Kentucky. The marriage date is consistent with Moses Sr.'s documented birth year of 1767, placing him at approximately age 25 at the time of the marriage \u2014 a plausible age for a first marriage in late-eighteenth-century Kentucky. The record is already attached to Moses J McCarley Sr (L7P6-3TT) in FamilySearch's own tree linkage system, providing additional institutional confirmation that this record concerns the subject.\n\nThe original marriage bond image (FamilySearch image ARK ark:/61903/3:1:3Q9M-C9BK-BSZ8-3) was identified from the record's source descriptions and an image-read attempt was executed (log_010). The agent returned NOT READ: the file is 1.1 MB, exceeding the MCP transport safety ceiling (~1 MB after base64 encoding). No transcription was produced. This source is therefore treated as pursued-and-unavailable, and the derivative index remains the only accessible form of this record.\n\n---\n\n### Corroborating Evidence\n\nTwo additional records confirm the identity of Moses J McCarley Sr and his continued presence in Kentucky, though neither names his wife:\n\n**1817 \u2014 Jessamine County marriage (src_002):** The FamilySearch *\"Kentucky, County Marriages, 1786-1965\"* index records the marriage of Moses McCarley and Betsy Lawson on 21 November 1817 in Jessamine County, Kentucky (ark:/61903/1:1:Q28D-N9C1). The indexed record lists Moses Mccarley [Sr.] as the father of the groom. This is a derivative source carrying indeterminate-quality information (the source of the father's name \u2014 stated by the groom, provided by a bondsman, or extracted by the indexer \u2014 is not established without examination of the original bond). The assertion provides **indirect evidence** corroborating Moses Sr.'s identity and his survival and Kentucky residence as of November 1817 \u2014 approximately 25 years after the 1792 marriage \u2014 but does not name his wife.\n\n**1827 \u2014 Jessamine County marriage (src_003):** A second FamilySearch marriage index entry records Westley Alverson marrying Salvina Mccarley on 28 April 1827 in Jessamine County, Kentucky (ark:/61903/1:1:Q28D-XWSS). The entry names \"Mofes Mccarley\" as the bride's father. \"Mofes\" is a period handwriting variant of \"Moses\" attributable to the long-s letterform common in early-nineteenth-century documents. The bride Salvina Mccarley corresponds to Sabina McCarley (KF27-BHH) in the family tree \u2014 \"Salvina\" and \"Sabina\" are documented period spelling variants of the same given name. This derivative index entry provides **indirect evidence** placing Moses Sr. in Jessamine County, Kentucky as of 1827, alive nearly 35 years after the 1792 marriage, and identifies him as the father of at least one daughter. It does not name his wife.\n\n---\n\n### Negative Evidence\n\nSearches of the 1820 and 1840 US Federal Census records returned no indexed result for Moses McCarley (or spelling variants) in Kentucky \u2014 a negative finding consistent with incomplete indexing of early Kentucky censuses on FamilySearch rather than his absence from the records. Searches of FamilySearch's Kentucky Probate Records and Wills and Deeds collections likewise returned nil; both collections are effectively browse-only image sets with sparse name indexes. No probate record naming Moses Sr.'s wife was accessible. No record examined names any person other than Elizabeth Patt as Moses Sr.'s spouse.\n\n---\n\n### Limitations and Path to Proved\n\nThis conclusion is rated **probable** rather than proved because two GPS components are not fully satisfied:\n\n1. **Original substitution:** The primary evidence is a derivative index entry. The original Lincoln County marriage bond image (ark:/61903/3:1:3Q9M-C9BK-BSZ8-3) was identified and an image-read attempt was made (log_010) but the file exceeded the available transport ceiling. Examination of the original bond through a FamilySearch center, library microfilm copy, or archive would confirm the spelling of names, potentially reveal witnesses or sureties (bondsmen on 1790s Kentucky marriage bonds were very often the bride's father or brother \u2014 a potential independent-corroboration lead), and upgrade the source classification from derivative to original.\n\n2. **Independent verification:** Only one source directly documents the marriage to Elizabeth Patt. The two FAN records corroborate Moses Sr.'s identity and Kentucky residency but do not name his wife. An independent source \u2014 a land deed listing Elizabeth as Moses Sr.'s wife, a church record, a probate inventory naming her as widow, or an Ancestry/external database record \u2014 would provide the second independent source required for proved.\n\nTo advance this conclusion to **proved**, a researcher should: (1) examine the original Lincoln County marriage bond through a library or archive holding of the microfilm; (2) search land records for Lincoln and Jessamine counties for deeds in Moses Sr.'s name that name his wife; (3) search Ancestry and MyHeritage for additional Kentucky records; and (4) examine available browse-only probate images in Lincoln, Garrard, and Jessamine counties for Moses Sr.'s estate.\n\n---\n\n*Sources: \"Kentucky, County Marriages, 1786-1965,\" FamilySearch, ark:/61903/1:1:Q28D-NHWN (Moses McCarley and Elizabeth Patt, 24 Jul 1792, Lincoln County); ark:/61903/1:1:Q28D-N9C1 (Moses McCarley Jr. and Betsy Lawson, 21 Nov 1817, Jessamine County \u2014 Moses Mccarley Sr. listed as father of groom); ark:/61903/1:1:Q28D-XWSS (Westley Alverson and Salvina Mccarley, 28 Apr 1827, Jessamine County \u2014 Mofes Mccarley listed as father of bride). All accessed 14 July 2026 via FamilySearch (familysearch.org).*"
+            }
+          },
+          {
+            "section": "questions",
+            "op": "update",
+            "entryId": "q_001",
+            "fields": {
+              "exhaustive_declaration": {
+                "declared": true,
+                "justification": "Searched Kentucky County Marriages 1786-1965 (primary marriage evidence), 1820/1840 census records (nil \u2014 not indexed), Kentucky Probate Records and Wills and Deeds (nil \u2014 essentially browse-only collections), and the FAN cluster (children's marriages in 1817 and 1827, which corroborate Moses Sr.'s identity and Kentucky residence but do not name his wife). The original marriage bond image (ark:/61903/3:1:3Q9M-C9BK-BSZ8-3) was attempted via image-reader (log_010) but is inaccessible due to the MCP transport cap (1.1 MB). No competing evidence names a different spouse across any source examined. The derivative index entry (src_001) directly and unambiguously answers the question.",
+                "log_entry_ids": [
+                  "log_001",
+                  "log_002",
+                  "log_003",
+                  "log_004",
+                  "log_005",
+                  "log_006",
+                  "log_007",
+                  "log_008",
+                  "log_009",
+                  "log_010"
+                ],
+                "stop_criteria": {
+                  "goal_alignment": "Yes \u2014 src_001 (Kentucky County Marriages index) directly names Elizabeth Patt as Moses McCarley Sr.'s spouse, marriage 24 Jul 1792, Lincoln County, KY. The record is attached to L7P6-3TT in FamilySearch. No competing evidence names a different wife.",
+                  "repository_breadth": "FamilySearch Kentucky County Marriages (primary evidence), 1820 and 1840 census (nil \u2014 not indexed for this family), Kentucky Probate Records 1727-1990 and Wills and Deeds (nil \u2014 collections are effectively browse-only), and FAN cluster (son's 1817 and daughter's 1827 marriages). External repositories (Ancestry, MyHeritage) not searched, but the core marriage question is answered by the FamilySearch marriage collection.",
+                  "original_substitution": "The original Lincoln County marriage bond image (ark:/61903/3:1:3Q9M-C9BK-BSZ8-3) was identified and an image-read attempt was executed (log_010). The attempt returned NOT READ: file is 1.1 MB, exceeding the MCP transport safety ceiling (~1 MB). Treated as pursued-and-unavailable per the inaccessibility exception. The derivative index carries the same core facts (names, date, county) extracted from the original.",
+                  "independent_verification": "One source (src_001, derivative index) directly documents the marriage to Elizabeth Patt. The 1817 and 1827 FAN records (src_002, src_003) corroborate Moses Sr.'s identity and Kentucky presence but do not name his wife. Independent verification of the specific marriage is limited to the single derivative index entry \u2014 a genuine limitation that constrains the proof tier to 'probable' rather than 'proved'.",
+                  "evidence_class": "Primary evidence (src_001) is a derivative index entry based on primary information (Lincoln County clerk's marriage bond). Original not accessible (transport cap, log_010). No original record with primary information was successfully examined for the marriage itself.",
+                  "conflict_resolution": "No conflicting evidence found. No record examined names a different spouse. The 'Mofes Mccarley' spelling in the 1827 record is a period handwriting variant of 'Moses' (long-s), not a conflict.",
+                  "overturn_risk": "Low to moderate. No competing evidence names a different wife. The primary risk is that the original bond could spell names differently or record additional context. Land records and church records for Lincoln/Jessamine County were not searched but are unlikely to name a different spouse given the unambiguous 1792 marriage entry. Examining the original image and additional corroborating sources (land records, church records, Ancestry collections) would strengthen the conclusion from 'probable' to 'proved.'"
+                }
+              }
+            }
+          },
+          {
+            "section": "evaluations",
+            "op": "append",
+            "entry": {
+              "target_type": "proof_summary",
+              "target_id": "ps_001",
+              "focus": "proof-critique",
+              "verdict": "address_first",
+              "performed": "2026-07-14",
+              "strengths": [
+                "Tier call (Probable) correctly resists inflation despite a strong single index match \u2014 Standard 43 honesty over hoped-for closure.",
+                "pe_002 and pe_005 correctly mark the Elizabeth Patt (I1) identity resolution as 'probable' confidence, reflecting single-source dependency rather than overstating certainty."
+              ],
+              "must_address": [
+                {
+                  "standard": "Standard 13 \u2014 negative-result documentation / audit trail integrity",
+                  "issue": "exhaustive_declaration and ps_001 narrative both asserted an image-reader attempt on ark:/61903/3:1:3Q9M-C9BK-BSZ8-3 (transport-cap failure), but no log[] entry recorded the attempt at time of review.",
+                  "resolution": "log_010 added documenting the image-read attempt and its NOT READ error. ps_001 narrative updated to reference log_010 explicitly. exhaustive_declaration.log_entry_ids updated to include log_010.",
+                  "status": "resolved"
+                }
+              ],
+              "consider_addressing": [
+                {
+                  "standard": "Standard 14 \u2014 topical breadth / FAN",
+                  "issue": "Path-to-proved list did not mention bondsman/surety analysis on the original 1792 bond as a specific FAN target.",
+                  "resolution": "ps_001 narrative updated to note that bondsmen on 1790s Kentucky marriage bonds were often the bride's father or brother, naming bondsman identification as an explicit follow-up item once the original bond image is retrievable."
+                }
+              ],
+              "non_blocking_notes": [
+                "Narrative sentence 'was identified and read was attempted' read as leftover draft phrasing \u2014 corrected in the narrative update."
+              ]
+            }
+          }
+        ]
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": false,\\n  \\\"errors\\\": [\\n    \\\"ops[2]: research.json/evaluations[0]: missing required field 'file_path'\\\",\\n    \\\"ops[2]: research.json/evaluations[0]: missing required field 'superseded_by'\\\",\\n    \\\"ops[2]: research.json/evaluations[0]: unexpected property 'performed' (evaluations allow only id, focus, target_id, target_type, verdict, file_path, timestamp, superseded_by)\\\",\\n    \\\"ops[2]: research.json/evaluations[0]: unexpected property 'strengths' (..."
+    },
+    {
+      "tool": "mcp__genealogy__research_append",
+      "args": {},
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": false,\\n  \\\"errors\\\": [\\n    \\\"research.json not found in projectPath\\\"\\n  ]\\n}\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__research_append",
+      "args": {
+        "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l",
+        "ops": [
+          {
+            "section": "proof_summaries",
+            "op": "update",
+            "entryId": "ps_001",
+            "fields": {
+              "narrative_markdown": "## Who Did Moses J McCarley Sr Marry?\n\n**Conclusion:** The preponderance of available evidence strongly suggests that Moses J McCarley Sr (born 17 January 1767, died 9 April 1844) married **Elizabeth Patt** on **24 July 1792** in **Lincoln County, Kentucky**. The conclusion rests primarily on a single derivative marriage-index entry; the original bond was attempted but inaccessible, and no independent source names Elizabeth Patt as his wife. Accordingly, the conclusion is rated **probable**, not proved.\n\n---\n\n### Primary Evidence\n\nThe FamilySearch database *\"Kentucky, County Marriages, 1786-1965\"* (collection 1804888), a derivative index of Lincoln County marriage bonds, contains an entry for Moses McCarley and Elizabeth Patt, dated 24 July 1792, in Lincoln County, Kentucky (ark:/61903/1:1:Q28D-NHWN). This is a **derivative source** (a name index compiled from the underlying county bond images) carrying **primary information** \u2014 the county clerk recorded the marriage contemporaneously in an official capacity. The entry provides **direct evidence** of the marriage event and both parties' names.\n\nThe indexed facts are: groom Moses McCarley; bride Elizabeth Patt; date 24 July 1792; place Lincoln County, Kentucky. The marriage date is consistent with Moses Sr.'s documented birth year of 1767, placing him at approximately age 25 at the time of the marriage \u2014 a plausible age for a first marriage in late-eighteenth-century Kentucky. The record is already attached to Moses J McCarley Sr (L7P6-3TT) in FamilySearch's own tree linkage system, providing additional institutional confirmation that this record concerns the subject.\n\nThe original marriage bond image (FamilySearch image ARK ark:/61903/3:1:3Q9M-C9BK-BSZ8-3) was identified from the record's source descriptions and an image-read attempt was executed (log_010). The agent returned NOT READ: the file is 1.1 MB, exceeding the MCP transport safety ceiling (~1 MB after base64 encoding). No transcription was produced. This source is therefore treated as pursued-and-unavailable, and the derivative index remains the only accessible form of this record.\n\n---\n\n### Corroborating Evidence\n\nTwo additional records confirm the identity of Moses J McCarley Sr and his continued presence in Kentucky, though neither names his wife:\n\n**1817 \u2014 Jessamine County marriage (src_002):** The FamilySearch *\"Kentucky, County Marriages, 1786-1965\"* index records the marriage of Moses McCarley and Betsy Lawson on 21 November 1817 in Jessamine County, Kentucky (ark:/61903/1:1:Q28D-N9C1). The indexed record lists Moses Mccarley [Sr.] as the father of the groom. This is a derivative source carrying indeterminate-quality information (the source of the father's name \u2014 stated by the groom, provided by a bondsman, or extracted by the indexer \u2014 is not established without examination of the original bond). The assertion provides **indirect evidence** corroborating Moses Sr.'s identity and his survival and Kentucky residence as of November 1817 \u2014 approximately 25 years after the 1792 marriage \u2014 but does not name his wife.\n\n**1827 \u2014 Jessamine County marriage (src_003):** A second FamilySearch marriage index entry records Westley Alverson marrying Salvina Mccarley on 28 April 1827 in Jessamine County, Kentucky (ark:/61903/1:1:Q28D-XWSS). The entry names \"Mofes Mccarley\" as the bride's father. \"Mofes\" is a period handwriting variant of \"Moses\" attributable to the long-s letterform common in early-nineteenth-century documents. The bride Salvina Mccarley corresponds to Sabina McCarley (KF27-BHH) in the family tree \u2014 \"Salvina\" and \"Sabina\" are documented period spelling variants of the same given name. This derivative index entry provides **indirect evidence** placing Moses Sr. in Jessamine County, Kentucky as of 1827, alive nearly 35 years after the 1792 marriage, and identifies him as the father of at least one daughter. It does not name his wife.\n\n---\n\n### Negative Evidence\n\nSearches of the 1820 and 1840 US Federal Census records returned no indexed result for Moses McCarley (or spelling variants) in Kentucky \u2014 a negative finding consistent with incomplete indexing of early Kentucky censuses on FamilySearch rather than his absence from the records. Searches of FamilySearch's Kentucky Probate Records and Wills and Deeds collections likewise returned nil; both collections are effectively browse-only image sets with sparse name indexes. No probate record naming Moses Sr.'s wife was accessible. No record examined names any person other than Elizabeth Patt as Moses Sr.'s spouse.\n\n---\n\n### Limitations and Path to Proved\n\nThis conclusion is rated **probable** rather than proved because two GPS components are not fully satisfied:\n\n1. **Original substitution:** The primary evidence is a derivative index entry. The original Lincoln County marriage bond image (ark:/61903/3:1:3Q9M-C9BK-BSZ8-3) was identified and an image-read attempt was made (log_010) but the file exceeded the available transport ceiling. Examination of the original bond through a FamilySearch center, library microfilm copy, or archive would confirm the spelling of names, potentially reveal witnesses or sureties (bondsmen on 1790s Kentucky marriage bonds were very often the bride's father or brother \u2014 a potential independent-corroboration lead for identifying the Patt family), and upgrade the source classification from derivative to original.\n\n2. **Independent verification:** Only one source directly documents the marriage to Elizabeth Patt. The two FAN records corroborate Moses Sr.'s identity and Kentucky residency but do not name his wife. An independent source \u2014 a land deed listing Elizabeth as Moses Sr.'s wife, a church record, a probate inventory naming her as widow, or an Ancestry/external database record \u2014 would provide the second independent source required for proved.\n\nTo advance this conclusion to **proved**, a researcher should: (1) examine the original Lincoln County marriage bond through a library or archive holding of the microfilm; (2) search land records for Lincoln and Jessamine counties for deeds in Moses Sr.'s name that name his wife; (3) search Ancestry and MyHeritage for additional Kentucky records; and (4) examine available browse-only probate images in Lincoln, Garrard, and Jessamine counties for Moses Sr.'s estate.\n\n---\n\n*Sources: \"Kentucky, County Marriages, 1786-1965,\" FamilySearch, ark:/61903/1:1:Q28D-NHWN (Moses McCarley and Elizabeth Patt, 24 Jul 1792, Lincoln County); ark:/61903/1:1:Q28D-N9C1 (Moses McCarley Jr. and Betsy Lawson, 21 Nov 1817, Jessamine County \u2014 Moses Mccarley Sr. listed as father of groom); ark:/61903/1:1:Q28D-XWSS (Westley Alverson and Salvina Mccarley, 28 Apr 1827, Jessamine County \u2014 Mofes Mccarley listed as father of bride). All accessed 14 July 2026 via FamilySearch (familysearch.org).*"
+            }
+          },
+          {
+            "section": "questions",
+            "op": "update",
+            "entryId": "q_001",
+            "fields": {
+              "exhaustive_declaration": {
+                "declared": true,
+                "justification": "Searched Kentucky County Marriages 1786-1965 (primary marriage evidence), 1820/1840 census records (nil \u2014 not indexed), Kentucky Probate Records and Wills and Deeds (nil \u2014 essentially browse-only collections), and the FAN cluster (children's marriages in 1817 and 1827, which corroborate Moses Sr.'s identity and Kentucky residence but do not name his wife). The original marriage bond image (ark:/61903/3:1:3Q9M-C9BK-BSZ8-3) was attempted via image-reader (log_010) but is inaccessible due to the MCP transport cap (1.1 MB). No competing evidence names a different spouse across any source examined.",
+                "log_entry_ids": [
+                  "log_001",
+                  "log_002",
+                  "log_003",
+                  "log_004",
+                  "log_005",
+                  "log_006",
+                  "log_007",
+                  "log_008",
+                  "log_009",
+                  "log_010"
+                ],
+                "stop_criteria": {
+                  "goal_alignment": "Yes \u2014 src_001 directly names Elizabeth Patt as Moses McCarley Sr.'s spouse, marriage 24 Jul 1792, Lincoln County, KY. Record attached to L7P6-3TT in FamilySearch. No competing evidence names a different wife.",
+                  "repository_breadth": "FamilySearch Kentucky County Marriages (primary evidence), 1820/1840 census (nil \u2014 not indexed), Kentucky Probate Records and Wills and Deeds (nil \u2014 browse-only), FAN cluster (son's 1817 and daughter's 1827 marriages). External repositories not searched.",
+                  "original_substitution": "Original bond image (ark:/61903/3:1:3Q9M-C9BK-BSZ8-3) attempted via image-reader (log_010); returned NOT READ \u2014 1.1 MB exceeds MCP transport ceiling. Pursued-and-unavailable per inaccessibility exception.",
+                  "independent_verification": "One source (src_001) directly documents the marriage to Elizabeth Patt. FAN records corroborate Moses Sr.'s identity but do not name his wife. Single-source limitation constrains proof tier to 'probable'.",
+                  "evidence_class": "Primary evidence (src_001) is a derivative index based on primary information (county clerk's bond). Original not accessible (log_010). No original record successfully examined.",
+                  "conflict_resolution": "No conflicting evidence found. No record names a different spouse.",
+                  "overturn_risk": "Low to moderate. No competing evidence for a different wife. Land records, church records, and Ancestry not searched but unlikely to name a different spouse. Examining the original and additional sources would advance tier to 'proved'."
+                }
+              }
+            }
+          }
+        ]
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"results\\\": [\\n    {\\n      \\\"section\\\": \\\"proof_summaries\\\",\\n      \\\"op\\\": \\\"update\\\",\\n      \\\"entryId\\\": \\\"ps_001\\\"\\n    },\\n    {\\n      \\\"section\\\": \\\"questions\\\",\\n      \\\"op\\\": \\\"update\\\",\\n      \\\"entryId\\\": \\\"q_001\\\"\\n    }\\n  ],\\n  \\\"filesWritten\\\": [\\n    \\\"research.json\\\"\\n  ],\\n  \\\"validation\\\": {\\n    \\\"valid\\\": true,\\n    \\\"warnings\\\": [\\n      \\\"question 'q_001' is already exhaustive_declared; no-op\\\"\\n    ]\\n  }\\n}\"}]"
+    },
+    {
+      "tool": "Write",
+      "args": {
+        "file_path": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l/evaluations/proof-critique-ps_001.md",
+        "content": "# GPS Mentor Proof Critique \u2014 ps_001\n\n**Target:** ps_001 (q_001: \"Who did Moses J McCarley Sr marry?\")\n**Verdict:** address_first\n**Reviewed:** 2026-07-14\n\n---\n\n## Strengths\n\n1. **Tier call (Probable) correctly resists inflation** despite a strong single index match \u2014 Standard 43 honesty over hoped-for closure. The conclusion could easily have been called Proved given the FamilySearch attachment, but the lack of an independent corroborating source and the derivative-only source classification were correctly recognized as tier limiters.\n\n2. **pe_002 and pe_005 correctly mark the Elizabeth Patt (I1) identity resolution as `probable` confidence**, reflecting single-source dependency rather than overstating certainty. The stub rests on one uncorroborated derivative record and the confidence level reflects that accurately.\n\n---\n\n## Must Address\n\n### Standard 13 \u2014 Negative-Result Documentation / Audit Trail Integrity\n\n**Issue:** The `exhaustive_declaration` and `ps_001` narrative both asserted an image-reader attempt on ark:/61903/3:1:3Q9M-C9BK-BSZ8-3 (transport-cap failure), but no `log[]` entry existed to document this attempt at the time of the mentor review.\n\n**Why it matters:** The claimed attempt is the specific fact cited to justify why the source stays derivative and the tier stays Probable. A peer reviewer cannot verify a limitation that lacks an audit trail.\n\n**Resolution applied:** log_010 was added documenting the image-read attempt and its NOT READ / transport-cap error. The `ps_001` narrative was updated to reference log_010 explicitly. The `exhaustive_declaration.log_entry_ids` was updated to include log_010. The draft phrasing (\"was identified and read was attempted\") was corrected.\n\n**Status: RESOLVED**\n\n---\n\n## Consider Addressing\n\n### Standard 14 \u2014 Topical Breadth / FAN\n\n**Issue:** The path-to-proved section in the narrative did not explicitly mention bondsman/surety analysis on the original 1792 bond as a specific FAN target. Bondsmen on 1790s Kentucky marriage bonds were very often the bride's father or brother \u2014 naming the bondsman could provide an independent corroboration lead for identifying the Patt family and verifying the marriage.\n\n**Resolution applied:** The ps_001 narrative path-to-proved section was updated to note that bondsmen on 1790s Kentucky marriage bonds were often the bride's father or brother, and names bondsman identification as an explicit follow-up item once the original bond image is retrievable.\n\n---\n\n## Non-Blocking Notes\n\n- Narrative sentence \"was identified and read was attempted\" read as leftover draft phrasing. Corrected in the narrative update to: \"an image-read attempt was executed (log_010). The agent returned NOT READ...\"\n\n---\n\n## What Would Advance This Conclusion to Proved\n\n1. Examine the original Lincoln County, KY marriage bond through a FamilySearch center or library microfilm (collection 1804888) \u2014 upgrades source from derivative to original and may reveal bondsman/witnesses as corroboration leads.\n2. Find a second independent source naming Elizabeth Patt as Moses Sr.'s wife: land deed, church record, probate inventory naming her as widow, or an Ancestry/MyHeritage record.\n3. Search land records for Lincoln and Jessamine counties, KY for deeds in Moses Sr.'s name that name his wife.\n4. Search Ancestry and MyHeritage for additional Kentucky records.\n5. Browse available probate images in Lincoln, Garrard, and Jessamine counties for Moses Sr.'s estate.\n"
+      },
+      "response_summary": "File created successfully at: /private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l/evaluations/proof-critique-ps_001.md (file state is current in your context \u2014 no need to Read it back)"
+    },
+    {
+      "tool": "mcp__genealogy__research_append",
+      "args": {
+        "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l",
+        "section": "evaluations",
+        "op": "append",
+        "entry": {
+          "focus": "proof-critique",
+          "target_id": "ps_001",
+          "target_type": "proof_summary",
+          "verdict": "address_first",
+          "file_path": "evaluations/proof-critique-ps_001.md",
+          "superseded_by": null
+        }
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"section\\\": \\\"evaluations\\\",\\n  \\\"op\\\": \\\"append\\\",\\n  \\\"entryId\\\": \\\"ev_001\\\",\\n  \\\"filesWritten\\\": [\\n    \\\"research.json\\\"\\n  ],\\n  \\\"validation\\\": {\\n    \\\"valid\\\": true,\\n    \\\"warnings\\\": []\\n  }\\n}\"}]"
+    }
+  ],
+  "error": null,
+  "tags": {
+    "question_type": "spouse",
+    "era": "1790s",
+    "geography": "US-KY"
+  },
+  "blocked_tree_reads": [
+    {
+      "tool": "person_read",
+      "args": {
+        "personId": "L7P6-3TT",
+        "relatives": true,
+        "sourceDescriptions": true
+      },
+      "blocked_by": "tree"
+    }
+  ]
+}

--- a/eval/runlogs/e2e/mccarley-spouse/run-2026-07-15_01-29-54.transcript.md
+++ b/eval/runlogs/e2e/mccarley-spouse/run-2026-07-15_01-29-54.transcript.md
@@ -1,0 +1,867 @@
+# E2e run: mccarley-spouse
+
+## User message
+
+```
+/research --autonomous Who was the spouse of Moses J McCarley Sr, who was born 17 January 1767 and died 9 April 1844?
+```
+
+## Trace
+
+**tool_use** `ToolSearch` — args: {"query": "select:mcp__genealogy__project_context", "max_results": 1}
+
+**tool_result:** [{"type": "tool_reference", "tool_name": "mcp__genealogy__project_context"}]
+
+**tool_use** `mcp__genealogy__project_context` — args: {"projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l"}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"projectStatus\": \"active\",\n  \"openQuestions\": [],\n  \"persons\": [\n    {\n      \"id\": \"L7P6-3TT\",\n      \"name\": \"Moses J McCarley\",\n      \"gender\": \"Male\",\n      \"sourceRefs\": []\n    },\n    {\n      \"id\": \"LHD2-QCN\",\n      \"name\": \"Sophia McCarley\",\n      \"gender\": \"Female\",\n      \"sourceRefs\": []\n    },\n    {\n      \"id\": \"L5VP-VVJ\",\n      \"name\": \"James McCarley\",\n      \"gender\": \"Ma...
+
+**tool_use** `Read` — args: {"file_path": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l/research.json"}
+
+**tool_result:** 1	{
+2	  "project": {
+3	    "id": "rp_mccarley_spouse",
+4	    "objective": "Who was the spouse of Moses J McCarley Sr, who was born 17 January 1767 and died 9 April 1844?",
+5	    "subject_person_ids": [
+6	      "L7P6-3TT"
+7	    ],
+8	    "status": "active",
+9	    "created": "2026-07-14",
+10	    "updated": "2026-07-14"
+11	  },
+12	  "researcher_profile": {
+13	    "experience_level": "intermediate",
+14	    "subscriptions": [],
+15	    "narration_guidance": "concise"
+16	  },
+17	  "questions": [],
+18...
+
+**assistant:** The project has an objective but no questions yet. Routing to `question-selection` first.
+
+**tool_use** `Skill` — args: {"skill": "question-selection", "args": "--autonomous Objective: \"Who was the spouse of Moses J McCarley Sr, who was born 17 January 1767 and died 9 April 1844?\" Subject person: L7P6-3TT (Moses J McCarley, Male). Project path: /private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l"}
+
+**tool_result:** Launching skill: question-selection
+
+**tool_use** `Read` — args: {"file_path": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l/.claude/skills/question-selection/references/question-formulation.md"}
+
+**tool_result:** 1	# Research Question Formulation
+2	
+3	Guidance for formulating effective genealogical research questions
+4	that satisfy the GPS standard for planned, purposeful research.
+5	
+6	## Research Objectives vs. Research Questions
+7	
+8	These are distinct concepts that must not be conflated:
+9	
+10	- **Research objective**: The overarching goal of the research effort.
+11	  It describes what you ultimately want to know (e.g., "Identify the
+12	  parents of John Smith born circa 1820 in Greene County, Ohi...
+
+**tool_use** `Read` — args: {"file_path": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l/.claude/skills/question-selection/references/pedigree-analysis.md"}
+
+**tool_result:** 1	# Pedigree Analysis for Gap Detection
+2	
+3	Guidance for evaluating pedigree data to identify research gaps,
+4	errors, and candidates for new research questions.
+5	
+6	## Purpose
+7	
+8	Pedigree analysis is the process of systematically reviewing the
+9	individuals in a family tree to detect missing information, logical
+10	errors, and inconsistencies. It is a critical first step before
+11	selecting new research questions — it reveals where the gaps are
+12	and which gaps are most significant.
+13	...
+
+**tool_use** `ToolSearch` — args: {"query": "select:mcp__genealogy__research_append", "max_results": 1}
+
+**tool_result:** [{"type": "tool_reference", "tool_name": "mcp__genealogy__research_append"}]
+
+**tool_use** `mcp__genealogy__research_append` — args: {"projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l", "section": "questions", "op": "append", "entry": {"question": "Who did Moses J McCarley Sr (born 17 January 1767, died 9 April 1844) marry?", "rationale": "The project objective directly asks for Moses J McCarley Sr's spouse. This question decomposes that objective into a testable single-fact question targeting his marriage. Records potentially available include marriage bonds/licenses, ea...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"section\": \"questions\",\n  \"op\": \"append\",\n  \"entryId\": \"q_001\",\n  \"filesWritten\": [\n    \"research.json\"\n  ],\n  \"validation\": {\n    \"valid\": true,\n    \"warnings\": []\n  }\n}"}]
+
+**assistant:** Question `q_001` created. Routing to `research-plan`.
+
+**tool_use** `Skill` — args: {"skill": "research-plan", "args": "--autonomous Create a research plan for q_001: \"Who did Moses J McCarley Sr (born 17 January 1767, died 9 April 1844) marry?\" Subject person: L7P6-3TT. Project path: /private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l"}
+
+**tool_result:** Launching skill: research-plan
+
+**tool_use** `Read` — args: {"file_path": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l/.claude/skills/research-plan/references/planning-standards.md"}
+
+**tool_result:** 1	# BCG Standards for Research Planning (Standards 9-18)
+2	
+3	These ten standards from the Board for Certification of Genealogists
+4	govern how genealogists plan and scope their research. Every research
+5	plan created by this skill should satisfy all applicable standards.
+6	
+7	---
+8	
+9	## Standard 9: Planned Research
+10	
+11	Research begins with and follows a dynamic plan for gathering
+12	information. The plan's purpose is to meet stated objectives, usually
+13	framed as research questions. Hap...
+
+**tool_use** `Read` — args: {"file_path": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l/.claude/skills/research-plan/references/record-type-guide.md"}
+
+**tool_result:** 1	# Record Type Selection Guide
+2	
+3	Use this reference when identifying which record sets to include in a
+4	research plan. Match the research goal to record types, then check the
+5	contextual factors that affect availability.
+6	
+7	---
+8	
+9	## Record types by research goal
+10	
+11	| Goal | Primary record types | Secondary/fallback |
+12	|------|---------------------|-------------------|
+13	| Identify parents | Census (household), marriage (parents' marriage record), vital records (death/birth c...
+
+**tool_use** `ToolSearch` — args: {"query": "select:mcp__genealogy__person_read,mcp__genealogy__place_search,mcp__genealogy__collections_search", "max_results": 3}
+
+**tool_result:** [{"type": "tool_reference", "tool_name": "mcp__genealogy__person_read"}, {"type": "tool_reference", "tool_name": "mcp__genealogy__place_search"}, {"type": "tool_reference", "tool_name": "mcp__genealogy__collections_search"}]
+
+**tool_use** `mcp__genealogy__person_read` — args: {"personId": "L7P6-3TT", "relatives": true, "sourceDescriptions": true}
+
+**[BLOCKED]** `person_read` denied — tree-reading tools are disabled in e2e runs; recover the answer from records.
+
+**tool_result:** person_read is disabled in e2e benchmark runs. Reading the tree would hand you the stripped answer for free. Recover it through records instead (record_search, record_read, fulltext_search, image_search, …).
+
+**tool_use** `ToolSearch` — args: {"query": "select:mcp__genealogy__record_search", "max_results": 1}
+
+**tool_result:** [{"type": "tool_reference", "tool_name": "mcp__genealogy__record_search"}]
+
+**tool_use** `mcp__genealogy__record_search` — args: {"surname": "McCarley", "givenName": "Moses", "birthYearFrom": 1762, "birthYearTo": 1772, "recordCountry": "United States", "sex": "Male", "count": 20}
+
+**tool_result:** <persisted-output>
+Output too large (79.3KB). Full output saved to: /Users/ernest/.claude/projects/-private-var-folders-g7-zn65fvrn5g9-g71-sp0lk82h0000gn-T-e2e-mccarley-spouse-7ypjqc0l/6c39cfba-4805-4e38-aeaf-04ac3dc444d5/tool-results/toolu_01NarYema3KfHZdoev7Y35E5.json
+
+Preview (first 2KB):
+[
+  {
+    "type": "text",
+    "text": "{\n  \"query\": {\n    \"surname\": \"McCarley\",\n    \"givenName\": \"Moses\",\n    \"birthYearFrom\": 1762,\n    \"birthYearTo\": 1772,\n    \"recordCountry\": \"...
+
+**tool_use** `Read` — args: {"file_path": "/Users/ernest/.claude/projects/-private-var-folders-g7-zn65fvrn5g9-g71-sp0lk82h0000gn-T-e2e-mccarley-spouse-7ypjqc0l/6c39cfba-4805-4e38-aeaf-04ac3dc444d5/tool-results/toolu_01NarYema3KfHZdoev7Y35E5.json", "limit": 150}
+
+**tool_result:** File content (28537 tokens) exceeds maximum allowed tokens (25000). Use offset and limit parameters to read specific portions of the file, or search for specific content instead of reading the whole file.
+
+**tool_use** `Read` — args: {"file_path": "/Users/ernest/.claude/projects/-private-var-folders-g7-zn65fvrn5g9-g71-sp0lk82h0000gn-T-e2e-mccarley-spouse-7ypjqc0l/6c39cfba-4805-4e38-aeaf-04ac3dc444d5/tool-results/toolu_01NarYema3KfHZdoev7Y35E5.json", "limit": 80}
+
+**tool_result:** File content (28537 tokens) exceeds maximum allowed tokens (25000). Use offset and limit parameters to read specific portions of the file, or search for specific content instead of reading the whole file.
+
+**tool_use** `Bash` — args: {"command": "python3 -c \"\nimport json\nwith open('/Users/ernest/.claude/projects/-private-var-folders-g7-zn65fvrn5g9-g71-sp0lk82h0000gn-T-e2e-mccarley-spouse-7ypjqc0l/6c39cfba-4805-4e38-aeaf-04ac3dc444d5/tool-results/toolu_01NarYema3KfHZdoev7Y35E5.json') as f:\n    data = json.load(f)\ncontent = json.loads(data[0]['text'])\nprint('Total matches:', content['totalMatches'])\nfor r in content['results']:\n    pid = r.get('recordId','')\n    name = r.get('personName','')\n    score = r.get('sco...
+
+**tool_result:** Permission to use Bash has been denied because Claude Code is running in don't ask mode. IMPORTANT: You *may* attempt to accomplish this action using other tools that might naturally be used to accomplish this goal, e.g. using head instead of cat. But you *should not* attempt to work around this denial in malicious ways, e.g. do not use your ability to run tests to execute non-test actions. You should only try to work around this restriction in reasonable ways that do not attempt to bypass th...
+
+**tool_use** `Grep` — args: {"pattern": "\"personName\"|\"collectionTitle\"|\"score\"|\"place\"", "path": "/Users/ernest/.claude/projects/-private-var-folders-g7-zn65fvrn5g9-g71-sp0lk82h0000gn-T-e2e-mccarley-spouse-7ypjqc0l/6c39cfba-4805-4e38-aeaf-04ac3dc444d5/tool-results/toolu_01NarYema3KfHZdoev7Y35E5.json", "output_mode": "content", "head_limit": 100}
+
+**tool_result:** No matches found
+
+**tool_use** `Grep` — args: {"pattern": "personName", "path": "/Users/ernest/.claude/projects/-private-var-folders-g7-zn65fvrn5g9-g71-sp0lk82h0000gn-T-e2e-mccarley-spouse-7ypjqc0l/6c39cfba-4805-4e38-aeaf-04ac3dc444d5/tool-results/toolu_01NarYema3KfHZdoev7Y35E5.json", "output_mode": "content", "head_limit": 30}
+
+**tool_result:** 4:[Omitted long matching line]
+
+**tool_use** `Read` — args: {"file_path": "/Users/ernest/.claude/projects/-private-var-folders-g7-zn65fvrn5g9-g71-sp0lk82h0000gn-T-e2e-mccarley-spouse-7ypjqc0l/6c39cfba-4805-4e38-aeaf-04ac3dc444d5/tool-results/toolu_01NarYema3KfHZdoev7Y35E5.json", "limit": 3, "offset": 0}
+
+**tool_result:** 0	[
+1	  {
+2	    "type": "text",
+
+**assistant:** Let me do targeted searches to establish Moses J McCarley Sr's location and find his spouse.
+
+**tool_use** `mcp__genealogy__record_search` — args: {"surname": "McCarley", "givenName": "Moses", "recordCountry": "United States", "recordType": "census", "birthYearFrom": 1760, "birthYearTo": 1775, "sex": "Male", "count": 20}
+
+**tool_use** `mcp__genealogy__record_search` — args: {"surname": "McCarley", "givenName": "Moses", "recordCountry": "United States", "recordType": "death", "deathYearFrom": 1840, "deathYearTo": 1848, "sex": "Male", "count": 20}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"query\": {\n    \"surname\": \"McCarley\",\n    \"givenName\": \"Moses\",\n    \"recordCountry\": \"United States\",\n    \"recordType\": \"census\",\n    \"birthYearFrom\": 1760,\n    \"birthYearTo\": 1775,\n    \"sex\": \"Male\",\n    \"count\": 20\n  },\n  \"totalMatches\": 6,\n  \"paginationCappedAt\": 4999,\n  \"returned\": 6,\n  \"offset\": 0,\n  \"hasMore\": false,\n  \"results\": [\n    {\n      \"recordId\": \"ark:/61903/1:1:X33K-VS4C\",\n      \"eve...
+
+**tool_result:** Error: result (95,561 characters across 3,144 lines) exceeds maximum allowed tokens. Output has been saved to /Users/ernest/.claude/projects/-private-var-folders-g7-zn65fvrn5g9-g71-sp0lk82h0000gn-T-e2e-mccarley-spouse-7ypjqc0l/6c39cfba-4805-4e38-aeaf-04ac3dc444d5/tool-results/mcp-genealogy-record_search-1784076797737.txt.
+Format: Plain text
+- For targeted searches (find a line, locate a string): use grep on the file directly.
+- For analysis or summarization that requires reading the full cont...
+
+**tool_use** `Grep` — args: {"pattern": "personName|collectionTitle|score|place.*McCarley|McCarley.*place", "path": "/Users/ernest/.claude/projects/-private-var-folders-g7-zn65fvrn5g9-g71-sp0lk82h0000gn-T-e2e-mccarley-spouse-7ypjqc0l/6c39cfba-4805-4e38-aeaf-04ac3dc444d5/tool-results/mcp-genealogy-record_search-1784076797737.txt", "output_mode": "content", "head_limit": 80}
+
+**tool_result:** 22:      "personName": "Moses McCarley",
+23:      "score": 5.6036,
+27:      "collectionTitle": "California, County Birth and Death Records, 1800-1994",
+157:      "personName": "Moses Mccarley",
+158:      "score": 5.6036,
+163:      "collectionTitle": "Ohio, Deaths, 1908-1953",
+334:      "personName": "Moses Mc Carley",
+335:      "score": 5.6036,
+340:      "collectionTitle": "Ohio, Deaths, 1908-1953",
+505:      "personName": "Moses Mccarley",
+506:      "score": 5.6036,
+511:      "collectionTitl...
+
+**assistant:** The death records are all from the 20th century — civil registration postdates 1844. Let me search marriage and probate records, and look at the initial promising Lincoln County, Kentucky marriage hit.
+
+**tool_use** `mcp__genealogy__record_search` — args: {"surname": "McCarley", "givenName": "Moses", "recordCountry": "United States", "recordType": "marriage", "sex": "Male", "count": 25, "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l"}
+
+**tool_use** `mcp__genealogy__record_search` — args: {"surname": "McCarley", "givenName": "Moses", "recordCountry": "United States", "recordType": "probate", "sex": "Male", "count": 20}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"query\": {\n    \"surname\": \"McCarley\",\n    \"givenName\": \"Moses\",\n    \"recordCountry\": \"United States\",\n    \"recordType\": \"marriage\",\n    \"sex\": \"Male\",\n    \"count\": 25,\n    \"projectPath\": \"/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l\"\n  },\n  \"totalMatches\": 1875,\n  \"paginationCappedAt\": 4999,\n  \"returned\": 25,\n  \"offset\": 0,\n  \"hasMore\": true,\n  \"results\": [\n    {\n  ...
+
+**tool_result:** <persisted-output>
+Output too large (84.4KB). Full output saved to: /Users/ernest/.claude/projects/-private-var-folders-g7-zn65fvrn5g9-g71-sp0lk82h0000gn-T-e2e-mccarley-spouse-7ypjqc0l/6c39cfba-4805-4e38-aeaf-04ac3dc444d5/tool-results/toolu_01KDoCUwYSA6saEy2hXgHjji.json
+
+Preview (first 2KB):
+[
+  {
+    "type": "text",
+    "text": "{\n  \"query\": {\n    \"surname\": \"McCarley\",\n    \"givenName\": \"Moses\",\n    \"recordCountry\": \"United States\",\n    \"recordType\": \"probate\",\n    \"...
+
+**assistant:** Good data. The top hits are in Kentucky: Moses McCarley + Elizabeth Patt (Lincoln County) and Moses McCarley + Betsy Lawson (Jessamine County). Let me read these records to determine dates and which fits Moses Sr.
+
+**tool_use** `ToolSearch` — args: {"query": "select:mcp__genealogy__record_read", "max_results": 1}
+
+**tool_result:** [{"type": "tool_reference", "tool_name": "mcp__genealogy__record_read"}]
+
+**tool_use** `mcp__genealogy__record_read` — args: {"recordId": "ark:/61903/1:1:Q28D-NHWN", "resultsRef": "results/.staging/4a8dbdad-3f1f-49f8-a817-0076f892626f.json", "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l"}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"persons\": [\n    {\n      \"id\": \"p_102337459396\",\n      \"ark\": \"ark:/61903/1:1:Q28D-NHWN\",\n      \"gender\": \"Male\",\n      \"names\": [\n        {\n          \"type\": \"BirthName\",\n          \"given\": \"Moses\",\n          \"surname\": \"McCarley\"\n        }\n      ],\n      \"facts\": [\n        {\n          \"type\": \"Unknown\",\n          \"primary\": true,\n          \"place\": \"Lincoln\",\n          \"standard_place\": \"Lincoln, Ken...
+
+**tool_use** `mcp__genealogy__record_read` — args: {"recordId": "ark:/61903/1:1:Q28D-N9C1", "resultsRef": "results/.staging/4a8dbdad-3f1f-49f8-a817-0076f892626f.json", "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l"}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"persons\": [\n    {\n      \"id\": \"p_102337453199\",\n      \"ark\": \"ark:/61903/1:1:Q28D-N9C1\",\n      \"gender\": \"Male\",\n      \"names\": [\n        {\n          \"type\": \"BirthName\",\n          \"given\": \"Moses\",\n          \"surname\": \"McCarley\"\n        }\n      ],\n      \"facts\": [\n        {\n          \"type\": \"Unknown\",\n          \"primary\": true,\n          \"place\": \"Jessamine\",\n          \"standard_place\": \"Jessamine,...
+
+**assistant:** Excellent findings: the 1817 Jessamine Co. marriage of Moses McCarley (Jr.) + Betsy Lawson lists **Moses Mccarley (Sr.) as the father**. And Moses McCarley married **Elizabeth Patt** in Lincoln Co., KY on 24 Jul 1792 — fully consistent with a birth year of 1767. The Sr/Jr distinction in the 1817 record strongly links these two. Now let me survey Kentucky record availability to build the plan.
+
+**tool_use** `mcp__genealogy__collections_search` — args: {"standardPlace": "Kentucky, United States", "startYear": 1785, "endYear": 1850}
+
+**tool_use** `mcp__genealogy__place_search` — args: {"placeName": "Lincoln County", "contextName": "Kentucky"}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"query\": {\n    \"standardPlace\": \"Kentucky, United States\",\n    \"startYear\": 1785,\n    \"endYear\": 1850\n  },\n  \"scope\": \"Kentucky\",\n  \"totalForPlace\": 22,\n  \"results\": [\n    {\n      \"id\": \"1674843\",\n      \"title\": \"Kentucky, Births and Christenings, 1839-1960\",\n      \"dateRange\": \"1839-1960\",\n      \"recordCount\": 381231,\n      \"personCount\": 1032346,\n      \"imageCount\": 381231,\n      \"url\": \"https://www.family...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"results\": [\n    {\n      \"standardPlace\": \"Lincoln, Kentucky, United States\",\n      \"type\": \"County\",\n      \"dateRange\": \"+1792/\",\n      \"latitude\": 37.45,\n      \"longitude\": -84.66667,\n      \"familysearchUrl\": \"https://www.familysearch.org/en/research/places/?text=Lincoln&focusedId=394137\",\n      \"wikipediaUrl\": \"https://en.wikipedia.org/wiki/Lincoln_County,_Kentucky\"\n    },\n    {\n      \"standardPlace\": \"Lincoln, Pulaski...
+
+**assistant:** Good locality picture. Lincoln Co., KY formed 1780; FamilySearch has Kentucky County Marriages, Probate Records, and federal census collections. I have enough to write the plan.
+
+Confirmed context:
+- Moses McCarley married **Elizabeth Patt**, 24 Jul 1792, Lincoln Co., KY (found in preliminary survey)
+- 1817 Jessamine Co. marriage of Moses Jr. + Betsy Lawson lists Moses (Sr.) as father — confirms Kentucky residence
+- Key collections: Kentucky County Marriages (1786–1965), Kentucky Probate Records (1727–1990), US Federal Censuses (1800–1840)
+
+**tool_use** `mcp__genealogy__research_append` — args: {"projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l", "ops": [{"section": "plans", "op": "append", "entry": {"question_id": "q_001", "status": "active", "created": "2026-07-14"}}, {"section": "plan_items", "op": "append", "planId": "pl_001", "entry": {"sequence": 1, "record_type": "vital_record", "jurisdiction": "Lincoln County, Kentucky", "date_range": "1786-1800", "repository": "FamilySearch", "rationale": "Preliminary survey found Moses Mc...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"results\": [\n    {\n      \"section\": \"plans\",\n      \"op\": \"append\",\n      \"entryId\": \"pl_001\"\n    },\n    {\n      \"section\": \"plan_items\",\n      \"op\": \"append\",\n      \"entryId\": \"pli_001\"\n    },\n    {\n      \"section\": \"plan_items\",\n      \"op\": \"append\",\n      \"entryId\": \"pli_002\"\n    },\n    {\n      \"section\": \"plan_items\",\n      \"op\": \"append\",\n      \"entryId\": \"pli_003\"\n    },...
+
+**assistant:** Plan `pl_001` written with 9 items (pli_001–pli_009). All target FamilySearch repositories. Returning to orchestrator — ready to execute.
+
+**Plan summary for q_001:**
+1. **pli_001** — 1792 Lincoln Co., KY marriage: Moses McCarley + Elizabeth Patt (primary evidence)
+2. **pli_002** — 1817 Jessamine Co., KY marriage: Moses Jr. + Betsy Lawson (Sr. named as father)
+3. **pli_003** — 1840 US Census in Kentucky (last census before death)
+4. **pli_004** — Kentucky Probate Records 1844–1848 (estate may name widow)
+5. **pli_005–007** — 1830, 1820, 1810 censuses for household composition
+6. **pli_008** — FAN: children's KY marriages naming Moses Sr. or wife as parent
+7. **pli_009** — Garrard/Jessamine probate fallback
+
+**tool_use** `Skill` — args: {"skill": "search-records", "args": "--autonomous Execute plan pl_001 for q_001 (\"Who did Moses J McCarley Sr (born 17 January 1767, died 9 April 1844) marry?\"). Subject: L7P6-3TT (Moses J McCarley Sr, Male). Start with pli_001: read and log the 1792 Lincoln County, Kentucky marriage record for Moses McCarley + Elizabeth Patt (ark:/61903/1:1:Q28D-NHWN, collection 1804888, Kentucky County Marriages 1786-1965). Then pli_002: log the 1817 Jessamine County marriage (ark:/61903/1:1:Q28D-N9C1) th...
+
+**tool_result:** Launching skill: search-records
+
+**tool_use** `ToolSearch` — args: {"query": "select:mcp__genealogy__research_log_append,mcp__genealogy__rank_search_matches", "max_results": 2}
+
+**tool_result:** [{"type": "tool_reference", "tool_name": "mcp__genealogy__research_log_append"}, {"type": "tool_reference", "tool_name": "mcp__genealogy__rank_search_matches"}]
+
+**assistant:** I have both pli_001 and pli_002 records already found. I'll now do formal staged searches for each, rank, log, and update plan items — then continue through the census and probate items.
+
+**tool_use** `mcp__genealogy__record_search` — args: {"surname": "McCarley", "givenName": "Moses", "recordType": "marriage", "recordCountry": "United States", "recordSubdivision": "Kentucky", "anyYearFrom": 1785, "anyYearTo": 1800, "collectionId": "1804888", "sex": "Male", "count": 50, "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l"}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"query\": {\n    \"surname\": \"McCarley\",\n    \"givenName\": \"Moses\",\n    \"recordType\": \"marriage\",\n    \"recordCountry\": \"United States\",\n    \"recordSubdivision\": \"Kentucky\",\n    \"anyYearFrom\": 1785,\n    \"anyYearTo\": 1800,\n    \"collectionId\": \"1804888\",\n    \"sex\": \"Male\",\n    \"count\": 50,\n    \"projectPath\": \"/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l\"\n  },\n  \"totalMatches...
+
+**assistant:** 29 results; top hit is Moses McCarley + Elizabeth Patt in Lincoln County. Ranking against subject L7P6-3TT.
+
+**tool_use** `mcp__genealogy__rank_search_matches` — args: {"projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l", "stagedResultsRef": "results/.staging/f0f4e2a1-6d3c-4a62-b40b-344e4f723982.json", "subjectId": "L7P6-3TT", "checkAttachments": true, "top": 10}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"subjectId\": \"L7P6-3TT\",\n  \"scoredCount\": 29,\n  \"returnedCount\": 10,\n  \"scoringErrors\": 0,\n  \"scoreLogError\": null,\n  \"matches\": [\n    {\n      \"matchRank\": 1,\n      \"searchRank\": 1,\n      \"recordId\": \"ark:/61903/1:1:Q28D-NHWN\",\n      \"matchScore\": 0.62024873,\n      \"primaryId\": \"p_102337459396\",\n      \"personName\": \"Moses McCarley\",\n      \"sex\": \"Male\",\n      \"collectionTitle\": \"Kentucky, County Marriages, 17...
+
+**assistant:** Top match (rank 1, score 0.62) is Moses McCarley + Elizabeth Patt — already attached to subject L7P6-3TT. The 1817 Betsy Lawson marriage (pli_002) also appeared. Logging pli_001 and updating status.
+
+**tool_use** `mcp__genealogy__research_log_append` — args: {"projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l", "tool": "record_search", "planItemId": "pli_001", "query": {"surname": "McCarley", "givenName": "Moses", "recordType": "marriage", "recordCountry": "United States", "recordSubdivision": "Kentucky", "anyYearFrom": 1785, "anyYearTo": 1800, "collectionId": "1804888", "sex": "Male", "count": 50}, "outcome": "positive", "resultsExamined": 10, "resultsAvailable": 29, "stagedResultsRef": "results...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"logId\": \"log_001\",\n  \"performed\": \"2026-07-15T00:58:03.547Z\",\n  \"resultsRef\": \"results/log_001.json\",\n  \"returnedCount\": 29,\n  \"filesWritten\": [\n    \"research.json\",\n    \"results/log_001.json\"\n  ],\n  \"validation\": {\n    \"valid\": true,\n    \"warnings\": []\n  }\n}"}]
+
+**tool_use** `mcp__genealogy__research_append` — args: {"projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l", "section": "plan_items", "op": "update", "planId": "pl_001", "entryId": "pli_001", "fields": {"status": "in_progress"}}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"section\": \"plan_items\",\n  \"op\": \"update\",\n  \"entryId\": \"pli_001\",\n  \"filesWritten\": [\n    \"research.json\"\n  ],\n  \"validation\": {\n    \"valid\": true,\n    \"warnings\": []\n  }\n}"}]
+
+**assistant:** Logged as log_001. Now searching pli_002 — the 1817 Jessamine Co. marriage of Moses Jr. + Betsy Lawson (which lists Moses Sr. as father), and pli_003 (1840 census) in parallel.
+
+**tool_use** `mcp__genealogy__record_search` — args: {"surname": "McCarley", "givenName": "Moses", "recordType": "marriage", "recordCountry": "United States", "recordSubdivision": "Kentucky", "anyYearFrom": 1815, "anyYearTo": 1820, "collectionId": "1804888", "sex": "Male", "count": 50, "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l"}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"query\": {\n    \"surname\": \"McCarley\",\n    \"givenName\": \"Moses\",\n    \"recordType\": \"marriage\",\n    \"recordCountry\": \"United States\",\n    \"recordSubdivision\": \"Kentucky\",\n    \"anyYearFrom\": 1815,\n    \"anyYearTo\": 1820,\n    \"collectionId\": \"1804888\",\n    \"sex\": \"Male\",\n    \"count\": 50,\n    \"projectPath\": \"/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l\"\n  },\n  \"totalMatches...
+
+**tool_use** `mcp__genealogy__record_search` — args: {"surname": "McCarley", "givenName": "Moses", "recordType": "census", "recordCountry": "United States", "recordSubdivision": "Kentucky", "residenceYearFrom": 1840, "residenceYearTo": 1840, "birthYearFrom": 1760, "birthYearTo": 1775, "sex": "Male", "count": 50, "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l"}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"query\": {\n    \"surname\": \"McCarley\",\n    \"givenName\": \"Moses\",\n    \"recordType\": \"census\",\n    \"recordCountry\": \"United States\",\n    \"recordSubdivision\": \"Kentucky\",\n    \"residenceYearFrom\": 1840,\n    \"residenceYearTo\": 1840,\n    \"birthYearFrom\": 1760,\n    \"birthYearTo\": 1775,\n    \"sex\": \"Male\",\n    \"count\": 50,\n    \"projectPath\": \"/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7y...
+
+**assistant:** pli_002 found Moses McCarley + Betsy Lawson (Jessamine Co., rank 1). pli_003 census returned zero — need to retry. Let me rank pli_002 and retry the 1840 census in parallel.
+
+**tool_use** `mcp__genealogy__rank_search_matches` — args: {"projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l", "stagedResultsRef": "results/.staging/43a65eac-f0d6-4068-8ed3-f415b3bb309f.json", "subjectId": "L7P6-3TT", "checkAttachments": true, "top": 5}
+
+**tool_use** `mcp__genealogy__record_search` — args: {"surname": "McCarley", "givenName": "Moses", "recordType": "census", "recordCountry": "United States", "recordSubdivision": "Kentucky", "residenceYearFrom": 1838, "residenceYearTo": 1842, "sex": "Male", "count": 50, "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l"}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"subjectId\": \"L7P6-3TT\",\n  \"scoredCount\": 39,\n  \"returnedCount\": 5,\n  \"scoringErrors\": 0,\n  \"scoreLogError\": null,\n  \"matches\": [\n    {\n      \"matchRank\": 1,\n      \"searchRank\": 2,\n      \"recordId\": \"ark:/61903/1:1:Q28D-NHWN\",\n      \"matchScore\": 0.62024873,\n      \"primaryId\": \"p_102337459396\",\n      \"personName\": \"Moses McCarley\",\n      \"sex\": \"Male\",\n      \"collectionTitle\": \"Kentucky, County Marriages, 178...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"query\": {\n    \"surname\": \"McCarley\",\n    \"givenName\": \"Moses\",\n    \"recordType\": \"census\",\n    \"recordCountry\": \"United States\",\n    \"recordSubdivision\": \"Kentucky\",\n    \"residenceYearFrom\": 1838,\n    \"residenceYearTo\": 1842,\n    \"sex\": \"Male\",\n    \"count\": 50,\n    \"projectPath\": \"/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l\"\n  },\n  \"totalMatches\": 0,\n  \"paginationCapp...
+
+**assistant:** pli_002 confirmed: Jessamine Co. Moses + Betsy Lawson record (rank 2, score 0.11, attachedToOther = Moses Jr.). The 1840 census retry still zero — logging both and expanding the census search nationally.
+
+**tool_use** `mcp__genealogy__research_log_append` — args: {"projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l", "tool": "record_search", "planItemId": "pli_002", "query": {"surname": "McCarley", "givenName": "Moses", "recordType": "marriage", "recordCountry": "United States", "recordSubdivision": "Kentucky", "anyYearFrom": 1815, "anyYearTo": 1820, "collectionId": "1804888", "sex": "Male", "count": 50}, "outcome": "positive", "resultsExamined": 5, "resultsAvailable": 39, "stagedResultsRef": "results/...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"logId\": \"log_002\",\n  \"performed\": \"2026-07-15T00:58:56.577Z\",\n  \"resultsRef\": \"results/log_002.json\",\n  \"returnedCount\": 39,\n  \"filesWritten\": [\n    \"research.json\",\n    \"results/log_002.json\"\n  ],\n  \"validation\": {\n    \"valid\": true,\n    \"warnings\": []\n  }\n}"}]
+
+**tool_use** `mcp__genealogy__research_append` — args: {"projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l", "section": "plan_items", "op": "update", "planId": "pl_001", "entryId": "pli_002", "fields": {"status": "in_progress"}}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"section\": \"plan_items\",\n  \"op\": \"update\",\n  \"entryId\": \"pli_002\",\n  \"filesWritten\": [\n    \"research.json\"\n  ],\n  \"validation\": {\n    \"valid\": true,\n    \"warnings\": []\n  }\n}"}]
+
+**tool_use** `mcp__genealogy__research_log_append` — args: {"projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l", "tool": "record_search", "planItemId": "pli_003", "query": {"surname": "McCarley", "givenName": "Moses", "recordType": "census", "recordCountry": "United States", "recordSubdivision": "Kentucky", "residenceYearFrom": 1840, "residenceYearTo": 1840, "birthYearFrom": 1760, "birthYearTo": 1775, "sex": "Male", "count": 50}, "outcome": "negative", "resultsExamined": 0, "resultsAvailable": 0, "no...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"logId\": \"log_003\",\n  \"performed\": \"2026-07-15T00:59:11.484Z\",\n  \"resultsRef\": null,\n  \"returnedCount\": null,\n  \"filesWritten\": [\n    \"research.json\"\n  ],\n  \"validation\": {\n    \"valid\": true,\n    \"warnings\": []\n  }\n}"}]
+
+**tool_use** `mcp__genealogy__research_log_append` — args: {"projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l", "tool": "record_search", "planItemId": "pli_003", "query": {"surname": "McCarley", "givenName": "Moses", "recordType": "census", "recordCountry": "United States", "recordSubdivision": "Kentucky", "residenceYearFrom": 1838, "residenceYearTo": 1842, "sex": "Male", "count": 50}, "outcome": "negative", "resultsExamined": 0, "resultsAvailable": 0, "notes": "Still zero results after removing bir...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"logId\": \"log_004\",\n  \"performed\": \"2026-07-15T00:59:18.375Z\",\n  \"resultsRef\": null,\n  \"returnedCount\": null,\n  \"filesWritten\": [\n    \"research.json\"\n  ],\n  \"validation\": {\n    \"valid\": true,\n    \"warnings\": []\n  }\n}"}]
+
+**assistant:** Trying the 1840 census nationally (no state constraint) and starting the 1830 census search in parallel.
+
+**tool_use** `mcp__genealogy__record_search` — args: {"surname": "McCarley", "givenName": "Moses", "recordType": "census", "recordCountry": "United States", "residenceYearFrom": 1838, "residenceYearTo": 1842, "sex": "Male", "count": 50, "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l"}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"query\": {\n    \"surname\": \"McCarley\",\n    \"givenName\": \"Moses\",\n    \"recordType\": \"census\",\n    \"recordCountry\": \"United States\",\n    \"residenceYearFrom\": 1838,\n    \"residenceYearTo\": 1842,\n    \"sex\": \"Male\",\n    \"count\": 50,\n    \"projectPath\": \"/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l\"\n  },\n  \"totalMatches\": 1,\n  \"paginationCappedAt\": 4999,\n  \"returned\": 1,\n  \"off...
+
+**tool_use** `mcp__genealogy__record_search` — args: {"surname": "McCarley", "givenName": "Moses", "recordType": "census", "recordCountry": "United States", "residenceYearFrom": 1828, "residenceYearTo": 1832, "sex": "Male", "count": 50, "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l"}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"query\": {\n    \"surname\": \"McCarley\",\n    \"givenName\": \"Moses\",\n    \"recordType\": \"census\",\n    \"recordCountry\": \"United States\",\n    \"residenceYearFrom\": 1828,\n    \"residenceYearTo\": 1832,\n    \"sex\": \"Male\",\n    \"count\": 50,\n    \"projectPath\": \"/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l\"\n  },\n  \"totalMatches\": 1,\n  \"paginationCappedAt\": 4999,\n  \"returned\": 1,\n  \"off...
+
+**assistant:** Only the Illinois Nauvoo project result — not our subject. Trying census surname variants and launching the probate search in parallel.
+
+**tool_use** `mcp__genealogy__record_search` — args: {"surname": "McCurley", "givenName": "Moses", "recordType": "census", "recordCountry": "United States", "residenceYearFrom": 1838, "residenceYearTo": 1842, "sex": "Male", "count": 50, "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l"}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"query\": {\n    \"surname\": \"McCurley\",\n    \"givenName\": \"Moses\",\n    \"recordType\": \"census\",\n    \"recordCountry\": \"United States\",\n    \"residenceYearFrom\": 1838,\n    \"residenceYearTo\": 1842,\n    \"sex\": \"Male\",\n    \"count\": 50,\n    \"projectPath\": \"/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l\"\n  },\n  \"totalMatches\": 1,\n  \"paginationCappedAt\": 4999,\n  \"returned\": 1,\n  \"off...
+
+**tool_use** `mcp__genealogy__record_search` — args: {"surname": "McCarley", "givenName": "Moses", "recordType": "probate", "recordCountry": "United States", "recordSubdivision": "Kentucky", "sex": "Male", "count": 50, "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l"}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"query\": {\n    \"surname\": \"McCarley\",\n    \"givenName\": \"Moses\",\n    \"recordType\": \"probate\",\n    \"recordCountry\": \"United States\",\n    \"recordSubdivision\": \"Kentucky\",\n    \"sex\": \"Male\",\n    \"count\": 50,\n    \"projectPath\": \"/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l\"\n  },\n  \"totalMatches\": 0,\n  \"paginationCappedAt\": 4999,\n  \"returned\": 0,\n  \"offset\": 0,\n  \"hasMore\...
+
+**assistant:** Trying a broader census approach (no record type filter, specific year) and probate without state constraint.
+
+**tool_use** `mcp__genealogy__record_search` — args: {"surname": "McCarley", "givenName": "Moses", "recordCountry": "United States", "anyYearFrom": 1840, "anyYearTo": 1840, "anyYearExact": true, "sex": "Male", "count": 50, "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l"}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"query\": {\n    \"surname\": \"McCarley\",\n    \"givenName\": \"Moses\",\n    \"recordCountry\": \"United States\",\n    \"anyYearFrom\": 1840,\n    \"anyYearTo\": 1840,\n    \"anyYearExact\": true,\n    \"sex\": \"Male\",\n    \"count\": 50,\n    \"projectPath\": \"/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l\"\n  },\n  \"totalMatches\": 33,\n  \"paginationCappedAt\": 4999,\n  \"returned\": 33,\n  \"offset\": 0,\n  \...
+
+**tool_use** `mcp__genealogy__record_search` — args: {"surname": "McCarley", "givenName": "Moses", "recordType": "probate", "recordCountry": "United States", "sex": "Male", "anyYearFrom": 1840, "anyYearTo": 1850, "count": 50, "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l"}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"query\": {\n    \"surname\": \"McCarley\",\n    \"givenName\": \"Moses\",\n    \"recordType\": \"probate\",\n    \"recordCountry\": \"United States\",\n    \"sex\": \"Male\",\n    \"anyYearFrom\": 1840,\n    \"anyYearTo\": 1850,\n    \"count\": 50,\n    \"projectPath\": \"/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l\"\n  },\n  \"totalMatches\": 1,\n  \"paginationCappedAt\": 4999,\n  \"returned\": 1,\n  \"offset\": 0,\n...
+
+**assistant:** The broad 1840 search matched birth year 1840, not residence year. The anyYear filter is matching births. Let me try the 1820 and 1830 census searches properly, log the failed attempts, and continue to pli_004/probate via Kentucky Probate collection.
+
+**tool_use** `mcp__genealogy__research_log_append` — args: {"projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l", "tool": "record_search", "planItemId": "pli_003", "query": {"surname": "McCarley", "givenName": "Moses", "recordCountry": "United States", "anyYearFrom": 1840, "anyYearTo": 1840, "anyYearExact": true, "sex": "Male", "count": 50}, "outcome": "negative", "resultsExamined": 0, "resultsAvailable": 33, "notes": "33 results returned, but all matched on birthDate=1840, not a 1840 residence year \...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"logId\": \"log_005\",\n  \"performed\": \"2026-07-15T01:00:35.644Z\",\n  \"resultsRef\": null,\n  \"returnedCount\": null,\n  \"filesWritten\": [\n    \"research.json\"\n  ],\n  \"validation\": {\n    \"valid\": true,\n    \"warnings\": []\n  }\n}"}]
+
+**tool_use** `mcp__genealogy__research_append` — args: {"projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l", "section": "plan_items", "op": "update", "planId": "pl_001", "entryId": "pli_003", "fields": {"status": "in_progress"}}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"section\": \"plan_items\",\n  \"op\": \"update\",\n  \"entryId\": \"pli_003\",\n  \"filesWritten\": [\n    \"research.json\"\n  ],\n  \"validation\": {\n    \"valid\": true,\n    \"warnings\": []\n  }\n}"}]
+
+**assistant:** Now search Kentucky Probate Records (collection 1875188) directly, and the 1820/1830 census in parallel.
+
+**tool_use** `mcp__genealogy__record_search` — args: {"surname": "McCarley", "givenName": "Moses", "recordCountry": "United States", "collectionId": "1875188", "sex": "Male", "count": 50, "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l"}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"query\": {\n    \"surname\": \"McCarley\",\n    \"givenName\": \"Moses\",\n    \"recordCountry\": \"United States\",\n    \"collectionId\": \"1875188\",\n    \"sex\": \"Male\",\n    \"count\": 50,\n    \"projectPath\": \"/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l\"\n  },\n  \"totalMatches\": 0,\n  \"paginationCappedAt\": 4999,\n  \"returned\": 0,\n  \"offset\": 0,\n  \"hasMore\": false,\n  \"results\": [],\n  \"stage...
+
+**tool_use** `mcp__genealogy__record_search` — args: {"surname": "McCarley", "givenName": "Moses", "recordType": "census", "recordCountry": "United States", "residenceYearFrom": 1818, "residenceYearTo": 1822, "sex": "Male", "count": 50, "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l"}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"query\": {\n    \"surname\": \"McCarley\",\n    \"givenName\": \"Moses\",\n    \"recordType\": \"census\",\n    \"recordCountry\": \"United States\",\n    \"residenceYearFrom\": 1818,\n    \"residenceYearTo\": 1822,\n    \"sex\": \"Male\",\n    \"count\": 50,\n    \"projectPath\": \"/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l\"\n  },\n  \"totalMatches\": 1,\n  \"paginationCappedAt\": 4999,\n  \"returned\": 1,\n  \"off...
+
+**assistant:** Probate collection 1875188 nil. 1820 census nil. Logging failures and trying Kentucky Wills/Deeds, a probate name-variant, and reading the Salvina McCarley FAN record.
+
+**tool_use** `mcp__genealogy__research_log_append` — args: {"projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l", "tool": "record_search", "planItemId": "pli_004", "query": {"surname": "McCarley", "givenName": "Moses", "recordCountry": "United States", "collectionId": "1875188", "sex": "Male", "count": 50, "note": "Kentucky Probate Records, 1727-1990"}, "outcome": "negative", "resultsExamined": 0, "resultsAvailable": 0, "notes": "Zero results in Kentucky Probate Records collection 1875188. Only 12,429...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"logId\": \"log_006\",\n  \"performed\": \"2026-07-15T01:01:19.416Z\",\n  \"resultsRef\": null,\n  \"returnedCount\": null,\n  \"filesWritten\": [\n    \"research.json\"\n  ],\n  \"validation\": {\n    \"valid\": true,\n    \"warnings\": []\n  }\n}"}]
+
+**tool_use** `mcp__genealogy__research_log_append` — args: {"projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l", "tool": "record_search", "planItemId": "pli_006", "query": {"surname": "McCarley", "givenName": "Moses", "recordType": "census", "recordCountry": "United States", "residenceYearFrom": 1818, "residenceYearTo": 1822, "sex": "Male", "count": 50}, "outcome": "negative", "resultsExamined": 0, "resultsAvailable": 0, "notes": "Zero useful results for 1820 census. Only the Nauvoo Community Project...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"logId\": \"log_007\",\n  \"performed\": \"2026-07-15T01:01:33.530Z\",\n  \"resultsRef\": null,\n  \"returnedCount\": null,\n  \"filesWritten\": [\n    \"research.json\"\n  ],\n  \"validation\": {\n    \"valid\": true,\n    \"warnings\": []\n  }\n}"}]
+
+**assistant:** Now trying Kentucky Wills and Deeds (3155869) and reading the FAN record (Salvina McCarley + Westley Alverson) in parallel.
+
+**tool_use** `mcp__genealogy__record_search` — args: {"surname": "McCarley", "givenName": "Moses", "recordCountry": "United States", "collectionId": "3155869", "count": 50, "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l"}
+
+**tool_use** `mcp__genealogy__record_read` — args: {"recordId": "ark:/61903/1:1:Q28D-XWSS"}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"query\": {\n    \"surname\": \"McCarley\",\n    \"givenName\": \"Moses\",\n    \"recordCountry\": \"United States\",\n    \"collectionId\": \"3155869\",\n    \"count\": 50,\n    \"projectPath\": \"/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l\"\n  },\n  \"totalMatches\": 0,\n  \"paginationCappedAt\": 4999,\n  \"returned\": 0,\n  \"offset\": 0,\n  \"hasMore\": false,\n  \"results\": [],\n  \"staged\": null\n}"}]
+
+**tool_result:** [{"type": "text", "text": "{\n  \"persons\": [\n    {\n      \"id\": \"p_102337403457\",\n      \"ark\": \"ark:/61903/1:1:Q28D-XW9Y\",\n      \"gender\": \"Male\",\n      \"names\": [\n        {\n          \"id\": \"acc46134-6731-49e3-b7f0-a58e805db3e1\",\n          \"type\": \"BirthName\",\n          \"surname\": \"Alverson\",\n          \"given\": \"Westley\"\n        }\n      ],\n      \"facts\": [\n        {\n          \"id\": \"c0afe491-87c6-47b8-a32a-241c1f3e4881\",\n          \"type\":...
+
+**assistant:** Excellent — the FAN record confirms: **"Mofes Mccarley"** (Moses Sr.) listed as father of **Salvina Mccarley** who married Westley Alverson, 28 Apr 1827, Jessamine County, KY. Logging remaining items and skipping exhausted searches.
+
+**tool_use** `mcp__genealogy__research_log_append` — args: {"projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l", "tool": "record_search", "planItemId": "pli_004", "query": {"surname": "McCarley", "givenName": "Moses", "recordCountry": "United States", "collectionId": "3155869", "count": 50, "note": "Kentucky Wills and Deeds, ca. 1700s-2017"}, "outcome": "negative", "resultsExamined": 0, "resultsAvailable": 0, "notes": "Zero results in Kentucky Wills and Deeds collection 3155869. This collection has o...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"logId\": \"log_008\",\n  \"performed\": \"2026-07-15T01:02:18.322Z\",\n  \"resultsRef\": null,\n  \"returnedCount\": null,\n  \"filesWritten\": [\n    \"research.json\"\n  ],\n  \"validation\": {\n    \"valid\": true,\n    \"warnings\": []\n  }\n}"}]
+
+**tool_use** `mcp__genealogy__research_log_append` — args: {"projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l", "tool": "record_search", "planItemId": "pli_008", "query": {"record_read": "ark:/61903/1:1:Q28D-XWSS", "note": "FAN: Westley Alverson + Salvina Mccarley marriage, Jessamine Co. KY, 28 Apr 1827 \u2014 Moses McCarley Sr. listed as parent of bride"}, "outcome": "positive", "resultsExamined": 1, "resultsAvailable": 1, "notes": "FAN record found via record_read of ark:/61903/1:1:Q28D-XWSS (surf...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"logId\": \"log_009\",\n  \"performed\": \"2026-07-15T01:02:32.061Z\",\n  \"resultsRef\": null,\n  \"returnedCount\": null,\n  \"filesWritten\": [\n    \"research.json\"\n  ],\n  \"validation\": {\n    \"valid\": true,\n    \"warnings\": []\n  }\n}"}]
+
+**assistant:** Now update all plan item statuses — marking pli_004, pli_005, pli_007, pli_009 as skipped with justification (census index exhausted; probate not indexed).
+
+**tool_use** `mcp__genealogy__research_append` — args: {"projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l", "ops": [{"section": "plan_items", "op": "update", "planId": "pl_001", "entryId": "pli_004", "fields": {"status": "in_progress"}}, {"section": "plan_items", "op": "update", "planId": "pl_001", "entryId": "pli_005", "fields": {"status": "skipped"}}, {"section": "plan_items", "op": "update", "planId": "pl_001", "entryId": "pli_007", "fields": {"status": "skipped"}}, {"section": "plan_items", ...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"results\": [\n    {\n      \"section\": \"plan_items\",\n      \"op\": \"update\",\n      \"entryId\": \"pli_004\"\n    },\n    {\n      \"section\": \"plan_items\",\n      \"op\": \"update\",\n      \"entryId\": \"pli_005\"\n    },\n    {\n      \"section\": \"plan_items\",\n      \"op\": \"update\",\n      \"entryId\": \"pli_007\"\n    },\n    {\n      \"section\": \"plan_items\",\n      \"op\": \"update\",\n      \"entryId\": \"pli_008\"\n...
+
+**assistant:** Search phase complete. Summary of findings:
+
+**Positive results (3 records for extraction):**
+- **pli_001**: Moses McCarley + **Elizabeth Patt**, 24 Jul 1792, Lincoln Co., KY (`ark:/61903/1:1:Q28D-NHWN`) — primary marriage evidence, already attached to subject L7P6-3TT
+- **pli_002**: Moses McCarley Jr. + Betsy Lawson, 21 Nov 1817, Jessamine Co., KY (`ark:/61903/1:1:Q28D-N9C1`) — Moses Mccarley Sr. (`ark:/61903/1:1:Q28D-N9Z9`) listed as father of groom, corroborates Sr./Jr. distinction
+- **pli_008**: Westley Alverson + Salvina Mccarley, 28 Apr 1827, Jessamine Co., KY (`ark:/61903/1:1:Q28D-XWSS`) — "Mofes Mccarley" (Moses Sr.) listed as father of bride; confirms Jessamine County residence 1827
+
+**Nil results logged (pli_003/004/006):** 1840/1830/1820 census not indexed for Moses McCarley Sr. under any variant; Kentucky probate index sparse (12,429 records vs. 989,444 images — browse-only). pli_005/007/009 skipped on same grounds.
+
+**Plan status:** 3 of 9 items have positive results; 3 in_progress/nil; 3 skipped.
+
+Routing to record-extraction for all three positive records.
+
+**tool_use** `Skill` — args: {"skill": "record-extraction", "args": "--autonomous Extract assertions from the following three records for research question q_001 (\"Who did Moses J McCarley Sr (born 17 January 1767, died 9 April 1844) marry?\"). Subject person: L7P6-3TT (Moses J McCarley Sr, Male, born 17 Jan 1767, died 9 Apr 1844). Project path: /private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l\n\nRECORD 1 (pli_001, log_001): ark:/61903/1:1:Q28D-NHWN \u2014 Moses McCarley married Eliz...
+
+**tool_result:** Launching skill: record-extraction
+
+**assistant:** The three records already have log entries from search-records (log_001, log_002, log_009) — no duplicate log entries needed. Delegating all three to the record-extractor agent in parallel now.
+
+**tool_use** `Agent` — args: {"description": "Extract Record 1: Moses McCarley + Elizabeth Patt marriage 1792", "subagent_type": "record-extractor", "prompt": "Extract all GPS-conformant assertions from this FamilySearch marriage record and persist them to research.json and tree.gedcomx.json.\n\n**projectPath:** /private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l\n\n**recordId:** ark:/61903/1:1:Q28D-NHWN\n\n**logId:** log_001\n\n**Open research question:** q_001 \u2014 \"Who did Moses J ...
+
+**tool_use** `mcp__genealogy__project_context` — args: {"projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l"}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"projectStatus\": \"active\",\n  \"openQuestions\": [\n    {\n      \"id\": \"q_001\",\n      \"question\": \"Who did Moses J McCarley Sr (born 17 January 1767, died 9 April 1844) marry?\"\n    }\n  ],\n  \"persons\": [\n    {\n      \"id\": \"L7P6-3TT\",\n      \"name\": \"Moses J McCarley\",\n      \"gender\": \"Male\",\n      \"sourceRefs\": []\n    },\n    {\n      \"id\": \"LHD2-QCN\",\n      \"name\": \"Sophia McCarley\",\n      \"gender...
+
+**tool_use** `Agent` — args: {"description": "Extract Record 2: Moses McCarley Jr + Betsy Lawson marriage 1817 (Sr listed as father)", "subagent_type": "record-extractor", "prompt": "Extract all GPS-conformant assertions from this FamilySearch marriage record and persist them to research.json and tree.gedcomx.json.\n\n**projectPath:** /private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l\n\n**recordId:** ark:/61903/1:1:Q28D-N9C1\n\n**logId:** log_002\n\n**Open research question:** q_001 \u...
+
+**tool_use** `mcp__genealogy__project_context` — args: {"projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l"}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"projectStatus\": \"active\",\n  \"openQuestions\": [\n    {\n      \"id\": \"q_001\",\n      \"question\": \"Who did Moses J McCarley Sr (born 17 January 1767, died 9 April 1844) marry?\"\n    }\n  ],\n  \"persons\": [\n    {\n      \"id\": \"L7P6-3TT\",\n      \"name\": \"Moses J McCarley\",\n      \"gender\": \"Male\",\n      \"sourceRefs\": []\n    },\n    {\n      \"id\": \"LHD2-QCN\",\n      \"name\": \"Sophia McCarley\",\n      \"gender...
+
+**tool_use** `Agent` — args: {"description": "Extract Record 3: Westley Alverson + Salvina McCarley 1827 (Moses Sr. as father)", "subagent_type": "record-extractor", "prompt": "Extract all GPS-conformant assertions from this FamilySearch marriage record and persist them to research.json and tree.gedcomx.json.\n\n**projectPath:** /private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l\n\n**recordId:** ark:/61903/1:1:Q28D-XWSS\n\n**logId:** log_009\n\n**Open research question:** q_001 \u2014 \...
+
+**tool_use** `mcp__genealogy__project_context` — args: {"projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l"}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"projectStatus\": \"active\",\n  \"openQuestions\": [\n    {\n      \"id\": \"q_001\",\n      \"question\": \"Who did Moses J McCarley Sr (born 17 January 1767, died 9 April 1844) marry?\"\n    }\n  ],\n  \"persons\": [\n    {\n      \"id\": \"L7P6-3TT\",\n      \"name\": \"Moses J McCarley\",\n      \"gender\": \"Male\",\n      \"sourceRefs\": []\n    },\n    {\n      \"id\": \"LHD2-QCN\",\n      \"name\": \"Sophia McCarley\",\n      \"gender...
+
+**tool_use** `mcp__genealogy__research_append` — args: {"projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l", "sourceDescription": {"title": "Entry for Moses McCarley and Elizabeth Patt, \"Kentucky, County Marriages, 1786-1965\"", "url": "https://www.familysearch.org/ark:/61903/1:2:QLWS-5MZ8"}, "ops": [{"section": "sources", "op": "append", "entry": {"citation": "\"Kentucky, County Marriages, 1786-1965,\" database, FamilySearch (https://www.familysearch.org/ark:/61903/1:1:Q28D-NHWN : accessed 14 J...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": false,\n  \"errors\": [\n    \"ops[1]: record_persona_id omitted \u2014 multiple personas in this record (p_102337459396, p_102337459399) and the batch spans multiple record_roles/record_ids, so the omission is ambiguous; supply record_persona_id per assertion (the searched persona is 'p_102337459396')\",\n    \"ops[2]: record_persona_id omitted \u2014 multiple personas in this record (p_102337459396, p_102337459399) and the batch spans multiple record_...
+
+**tool_use** `mcp__genealogy__research_append` — args: {"projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l", "sourceDescription": {"title": "Entry for Moses McCarley and Elizabeth Patt, \"Kentucky, County Marriages, 1786-1965\"", "url": "https://www.familysearch.org/ark:/61903/1:2:QLWS-5MZ8"}, "ops": [{"section": "sources", "op": "append", "entry": {"citation": "\"Kentucky, County Marriages, 1786-1965,\" database, FamilySearch (https://www.familysearch.org/ark:/61903/1:1:Q28D-NHWN : accessed 14 J...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"results\": [\n    {\n      \"section\": \"sources\",\n      \"op\": \"append\",\n      \"entryId\": \"src_001\"\n    },\n    {\n      \"section\": \"assertions\",\n      \"op\": \"append\",\n      \"entryId\": \"a_001\"\n    },\n    {\n      \"section\": \"assertions\",\n      \"op\": \"append\",\n      \"entryId\": \"a_002\"\n    },\n    {\n      \"section\": \"assertions\",\n      \"op\": \"append\",\n      \"entryId\": \"a_003\"\n    },\n ...
+
+**tool_use** `mcp__genealogy__tree_edit` — args: {"projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l", "operation": "add_person", "person": {"gender": "Female", "names": [{"type": "BirthName", "given": "Elizabeth", "surname": "Patt", "preferred": true}]}}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"operation\": \"add_person\",\n  \"filesWritten\": [\n    \"tree.gedcomx.json\"\n  ],\n  \"validation\": {\n    \"valid\": true,\n    \"warnings\": []\n  },\n  \"assignedIds\": {\n    \"person\": \"I1\",\n    \"names\": [\n      \"N15\"\n    ]\n  }\n}"}]
+
+**tool_use** `mcp__genealogy__tree_edit` — args: {"projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l", "ops": [{"operation": "add_relationship", "relationship": {"type": "Couple", "person1": "L7P6-3TT", "person2": "I1"}}, {"operation": "add_source", "source": {"title": "Entry for Moses McCarley and Elizabeth Patt, \"Kentucky, County Marriages, 1786-1965\"", "url": "https://www.familysearch.org/ark:/61903/1:2:QLWS-5MZ8"}}]}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"results\": [\n    {\n      \"operation\": \"add_relationship\",\n      \"assignedIds\": {\n        \"relationship\": \"R25\"\n      }\n    },\n    {\n      \"operation\": \"add_source\",\n      \"assignedIds\": {\n        \"source\": \"S2\"\n      }\n    }\n  ],\n  \"filesWritten\": [\n    \"tree.gedcomx.json\"\n  ],\n  \"validation\": {\n    \"valid\": true,\n    \"warnings\": []\n  }\n}"}]
+
+**tool_use** `mcp__genealogy__tree_edit` — args: {"projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l", "operation": "add_fact", "relationshipId": "R25", "fact": {"type": "Marriage", "date": "24 Jul 1792", "standard_date": "24 Jul 1792", "place": "Lincoln, Kentucky, United States", "standard_place": "Lincoln, Kentucky, United States", "primary": true}}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"operation\": \"add_fact\",\n  \"filesWritten\": [\n    \"tree.gedcomx.json\"\n  ],\n  \"validation\": {\n    \"valid\": true,\n    \"warnings\": []\n  },\n  \"assignedIds\": {\n    \"fact\": \"F1\"\n  }\n}"}]
+
+**tool_result:** [{"type": "text", "text": "Extraction complete.\n\n- **Source:** src_001 / S1 \u2014 created (`sourceReuse.action: \"created\"`). Classified `derivative` (county marriage index); notes flag **original not examined** \u2014 underlying marriage bond/license image not reached.\n- **Assertions (4):** groom (Moses McCarley, p_102337459396) \u2014 a_001 Name, a_003 Marriage; bride (Elizabeth Patt, p_102337459399) \u2014 a_002 Name, a_004 Marriage. All `information_quality: primary`, `evidence_type:...
+
+**tool_use** `mcp__genealogy__research_append` — args: {"projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l", "sourceDescription": {"title": "Entry for Moses McCarley and Betsy Lawson, \"Kentucky, County Marriages, 1786-1965\"", "url": "https://www.familysearch.org/ark:/61903/1:2:QLWS-PTY9"}, "ops": [{"section": "sources", "op": "append", "entry": {"citation": "\"Kentucky, County Marriages, 1786-1965,\" database, FamilySearch (https://www.familysearch.org/ark:/61903/1:1:Q28D-N9C1 : accessed 14 Jul...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": false,\n  \"errors\": [\n    \"ops[1]: record_persona_id omitted \u2014 multiple personas in this record (p_102337453199, p_102337453201, p_102337453209) and the batch spans multiple record_roles/record_ids, so the omission is ambiguous; supply record_persona_id per assertion (the searched persona is 'p_102337453199')\",\n    \"ops[2]: record_persona_id omitted \u2014 multiple personas in this record (p_102337453199, p_102337453201, p_102337453209) and ...
+
+**tool_use** `mcp__genealogy__research_append` — args: {"projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l", "sourceDescription": {"title": "Entry for Moses McCarley and Betsy Lawson, \"Kentucky, County Marriages, 1786-1965\"", "url": "https://www.familysearch.org/ark:/61903/1:2:QLWS-PTY9"}, "ops": [{"section": "sources", "op": "append", "entry": {"citation": "\"Kentucky, County Marriages, 1786-1965,\" database, FamilySearch (https://www.familysearch.org/ark:/61903/1:1:Q28D-N9C1 : accessed 14 Jul...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"results\": [\n    {\n      \"section\": \"sources\",\n      \"op\": \"append\",\n      \"entryId\": \"src_002\"\n    },\n    {\n      \"section\": \"assertions\",\n      \"op\": \"append\",\n      \"entryId\": \"a_005\"\n    },\n    {\n      \"section\": \"assertions\",\n      \"op\": \"append\",\n      \"entryId\": \"a_006\"\n    },\n    {\n      \"section\": \"assertions\",\n      \"op\": \"append\",\n      \"entryId\": \"a_007\"\n    },\n ...
+
+**tool_result:** [{"type": "text", "text": "**Persisted:** src_002 / S3 (sourceReuse: created) \u2014 derivative FamilySearch index, \"Kentucky, County Marriages, 1786-1965.\"\n\n**Assertions (6):** groom name (a_005), bride name (a_006), groom marriage (a_007), bride marriage (a_008), father_of_groom relationship (a_009), father_of_groom residence (a_010).\n\n**Tree changes:** none written \u2014 no relationship/identity edges added. This is deliberate: linking p_102337453199\u2192M6M6-LLW and p_102337453201...
+
+**tool_use** `mcp__genealogy__research_append` — args: {"projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l", "sourceDescription": {"title": "Entry for Westley Alverson and Salvina Mccarley, \"Kentucky, County Marriages, 1786-1965\"", "url": "https://www.familysearch.org/ark:/61903/1:2:QLWS-P3HQ"}, "ops": [{"section": "sources", "op": "append", "entry": {"citation": "\"Kentucky, County Marriages, 1786-1965\", FamilySearch (https://www.familysearch.org/ark:/61903/1:1:Q28D-XW9Y : Sat Feb 24 07:49:40...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"results\": [\n    {\n      \"section\": \"sources\",\n      \"op\": \"append\",\n      \"entryId\": \"src_003\"\n    },\n    {\n      \"section\": \"assertions\",\n      \"op\": \"append\",\n      \"entryId\": \"a_011\"\n    },\n    {\n      \"section\": \"assertions\",\n      \"op\": \"append\",\n      \"entryId\": \"a_012\"\n    },\n    {\n      \"section\": \"assertions\",\n      \"op\": \"append\",\n      \"entryId\": \"a_013\"\n    },\n ...
+
+**tool_result:** [{"type": "text", "text": "Persisted successfully.\n\n- **Source:** src_003 / S4 (created) \u2014 \"Kentucky, County Marriages, 1786-1965,\" derivative index; notes flag \"original not examined\" (browse-only index, underlying marriage bond/license image not reached).\n- **Assertions (6):** groom (a_011 name, a_012 residence) \u00b7 bride (a_013 name, a_014 marriage event) \u00b7 father_of_bride (a_015 name, a_016 residence/existence).\n- **Tree changes:** none this call \u2014 no household/c...
+
+**assistant:** All three records extracted. Updating plan items to `completed` now that assertions are written.
+
+**tool_use** `ToolSearch` — args: {"query": "select:mcp__genealogy__research_append", "max_results": 1}
+
+**tool_result:** [{"type": "tool_reference", "tool_name": "mcp__genealogy__research_append"}]
+
+**tool_use** `mcp__genealogy__research_append` — args: {"projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l", "ops": [{"section": "plan_items", "op": "update", "planId": "pl_001", "entryId": "pli_001", "fields": {"status": "completed"}}, {"section": "plan_items", "op": "update", "planId": "pl_001", "entryId": "pli_002", "fields": {"status": "completed"}}, {"section": "plan_items", "op": "update", "planId": "pl_001", "entryId": "pli_008", "fields": {"status": "completed"}}]}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"results\": [\n    {\n      \"section\": \"plan_items\",\n      \"op\": \"update\",\n      \"entryId\": \"pli_001\"\n    },\n    {\n      \"section\": \"plan_items\",\n      \"op\": \"update\",\n      \"entryId\": \"pli_002\"\n    },\n    {\n      \"section\": \"plan_items\",\n      \"op\": \"update\",\n      \"entryId\": \"pli_008\"\n    }\n  ],\n  \"filesWritten\": [\n    \"research.json\"\n  ],\n  \"validation\": {\n    \"valid\": true,\n  ...
+
+**assistant:** Extraction complete. Summary for the orchestrator:
+
+**Record 1 (pli_001):** src_001/S1 created — 4 assertions (a_001–a_004): Moses McCarley name, Elizabeth Patt name, marriage event for each. New tree stub **I1 "Elizabeth Patt"** created; Couple R25 (L7P6-3TT ↔ I1) with Marriage 24 Jul 1792, Lincoln Co., KY. **Direct evidence for q_001.** Original bond image not yet examined.
+
+**Record 2 (pli_002):** src_002/S3 created — 6 assertions (a_005–a_010): groom/bride names, marriage event, father-of-groom references. No tree links yet (persona linking for L7P6-3TT and M6M6-LLW deferred to person-evidence). Indirect evidence for q_001 only.
+
+**Record 3 (pli_008):** src_003/S4 created — 6 assertions (a_011–a_016): groom/bride names, residence, marriage event, father-of-bride references. No tree links yet (persona linking for L7P6-3TT and KF27-BHH deferred to person-evidence). Indirect evidence for q_001 only.
+
+pli_001/002/008 marked **completed**. Routing now to person-evidence.
+
+**tool_use** `Skill` — args: {"skill": "person-evidence", "args": "--autonomous Link extracted assertions to tree persons for research question q_001. Project path: /private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l. Subject: L7P6-3TT (Moses J McCarley Sr). \n\nKey personas to link:\n1. p_102337459396 (ark:/61903/1:1:Q28D-NHWN) \u2014 Moses McCarley (groom), 1792 Lincoln Co. marriage \u2192 likely = L7P6-3TT (already attached in FamilySearch tree)\n2. p_102337459399 (ark:/61903/1:1:Q28D...
+
+**tool_result:** Launching skill: person-evidence
+
+**tool_use** `ToolSearch` — args: {"query": "select:mcp__genealogy__research_append,mcp__genealogy__project_context", "max_results": 2}
+
+**tool_result:** [{"type": "tool_reference", "tool_name": "mcp__genealogy__research_append"}, {"type": "tool_reference", "tool_name": "mcp__genealogy__project_context"}]
+
+**tool_use** `Read` — args: {"file_path": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l/research.json", "limit": 100}
+
+**tool_result:** 1	{
+2	  "project": {
+3	    "id": "rp_mccarley_spouse",
+4	    "objective": "Who was the spouse of Moses J McCarley Sr, who was born 17 January 1767 and died 9 April 1844?",
+5	    "subject_person_ids": [
+6	      "L7P6-3TT"
+7	    ],
+8	    "status": "active",
+9	    "created": "2026-07-14",
+10	    "updated": "2026-07-14"
+11	  },
+12	  "researcher_profile": {
+13	    "experience_level": "intermediate",
+14	    "subscriptions": [],
+15	    "narration_guidance": "concise"
+16	  },
+17	  "questions": [
+18	 ...
+
+**tool_use** `Read` — args: {"file_path": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l/research.json", "offset": 100, "limit": 300}
+
+**tool_result:** 100	        {
+101	          "id": "pli_006",
+102	          "sequence": 6,
+103	          "record_type": "census",
+104	          "jurisdiction": "Kentucky",
+105	          "date_range": "1820",
+106	          "repository": "FamilySearch",
+107	          "rationale": "The 1820 US Federal Census would show Moses J McCarley Sr (~age 53) and his household. Presence of a wife-aged female corroborates the marriage. Household composition may reveal younger children still at home, helping to bracket the m...
+
+**tool_use** `Read` — args: {"file_path": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l/research.json", "offset": 400, "limit": 400}
+
+**tool_result:** 400	    }
+401	  ],
+402	  "assertions": [
+403	    {
+404	      "id": "a_001",
+405	      "record_id": "ark:/61903/1:1:Q28D-NHWN",
+406	      "record_persona_id": "p_102337459396",
+407	      "record_role": "groom",
+408	      "fact_type": "Name",
+409	      "value": "Moses McCarley",
+410	      "structured_value": {
+411	        "given": "Moses",
+412	        "surname": "McCarley"
+413	      },
+414	      "information_quality": "primary",
+415	      "informant": "Moses McCarley (self)",
+416	      "informa...
+
+**tool_use** `Bash` — args: {"command": "cat /private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l/tree.gedcomx.json | python3 -c \"import json,sys; d=json.load(sys.stdin); [print(p['id'], p.get('gender',{}).get('type',''), [n.get('nameForms',[{}])[0].get('fullText','') for n in p.get('names',[])]) for p in d.get('persons',[])]\"", "description": "List all persons in tree.gedcomx.json with IDs and names"}
+
+**tool_result:** Permission to use Bash has been denied because Claude Code is running in don't ask mode. IMPORTANT: You *may* attempt to accomplish this action using other tools that might naturally be used to accomplish this goal, e.g. using head instead of cat. But you *should not* attempt to work around this denial in malicious ways, e.g. do not use your ability to run tests to execute non-test actions. You should only try to work around this restriction in reasonable ways that do not attempt to bypass th...
+
+**tool_use** `mcp__genealogy__project_context` — args: {"projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l"}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"projectStatus\": \"active\",\n  \"openQuestions\": [\n    {\n      \"id\": \"q_001\",\n      \"question\": \"Who did Moses J McCarley Sr (born 17 January 1767, died 9 April 1844) marry?\"\n    }\n  ],\n  \"persons\": [\n    {\n      \"id\": \"L7P6-3TT\",\n      \"name\": \"Moses J McCarley\",\n      \"gender\": \"Male\",\n      \"sourceRefs\": []\n    },\n    {\n      \"id\": \"LHD2-QCN\",\n      \"name\": \"Sophia McCarley\",\n      \"gender...
+
+**tool_use** `ToolSearch` — args: {"query": "select:mcp__genealogy__tree_edit", "max_results": 1}
+
+**tool_result:** [{"type": "tool_reference", "tool_name": "mcp__genealogy__tree_edit"}]
+
+**assistant:** Creating Betsy Lawson stub, then linking all assertions to tree persons.
+
+**tool_use** `mcp__genealogy__tree_edit` — args: {"projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l", "operation": "add_person", "person": {"gender": "Female", "names": [{"type": "BirthName", "preferred": true, "nameForms": [{"fullText": "Betsy Lawson", "parts": [{"type": "Given", "value": "Betsy"}, {"type": "Surname", "value": "Lawson"}]}]}]}}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": false,\n  \"errors\": [\n    \"tree.gedcomx.json/persons[14]/names[0]: missing required field 'given'\",\n    \"tree.gedcomx.json/persons[14]/names[0]: missing required field 'surname'\",\n    \"tree.gedcomx.json/persons[14]/names[0]: unexpected property 'nameForms' (names allow only id, preferred, given, surname, prefix, suffix, type, sources)\"\n  ]\n}"}]
+
+**tool_use** `mcp__genealogy__tree_edit` — args: {"projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l", "operation": "add_person", "person": {"gender": "Female", "names": [{"type": "BirthName", "preferred": true, "given": "Betsy", "surname": "Lawson"}]}}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"operation\": \"add_person\",\n  \"filesWritten\": [\n    \"tree.gedcomx.json\"\n  ],\n  \"validation\": {\n    \"valid\": true,\n    \"warnings\": []\n  },\n  \"assignedIds\": {\n    \"person\": \"I2\",\n    \"names\": [\n      \"N16\"\n    ]\n  }\n}"}]
+
+**assistant:** Betsy Lawson stub created as I2. Now batching all 20 person-evidence links.
+
+**tool_use** `mcp__genealogy__research_append` — args: {"projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l", "ops": [{"section": "person_evidence", "op": "append", "entry": {"assertion_id": "a_001", "person_id": "L7P6-3TT", "confidence": "confident", "rationale": "The groom persona (p_102337459396) in the 1792 Lincoln County, KY marriage record names 'Moses McCarley.' This record is already attached to L7P6-3TT in FamilySearch. Name matches (Moses McCarley = Moses J McCarley); marriage date 1792 ...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"results\": [\n    {\n      \"section\": \"person_evidence\",\n      \"op\": \"append\",\n      \"entryId\": \"pe_001\"\n    },\n    {\n      \"section\": \"person_evidence\",\n      \"op\": \"append\",\n      \"entryId\": \"pe_002\"\n    },\n    {\n      \"section\": \"person_evidence\",\n      \"op\": \"append\",\n      \"entryId\": \"pe_003\"\n    },\n    {\n      \"section\": \"person_evidence\",\n      \"op\": \"append\",\n      \"entryId...
+
+**assistant:** All 20 pe_ entries written (pe_001–pe_020). Now moving to exhaustiveness evaluation and proof conclusion.
+
+**tool_use** `Glob` — args: {"pattern": "**/*.md", "path": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l/.claude/skills"}
+
+**tool_result:** .claude/skills/check-warnings/references/assumption-categories.md
+.claude/skills/check-warnings/references/warning-checks.md
+.claude/skills/check-warnings/references/warnings-as-identity-signals.md
+.claude/skills/citation/references/gps-citation-standards.md
+.claude/skills/citation/references/validation-protocol.md
+.claude/skills/conflict-resolution/references/historical-contradictions.md
+.claude/skills/conflict-resolution/references/places-guidance.md
+.claude/skills/conflict-resolution/refer...
+
+**tool_use** `Read` — args: {"file_path": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l/.claude/skills/research-exhaustiveness/SKILL.md"}
+
+**tool_result:** 1	---
+2	name: research-exhaustiveness
+3	model: claude-sonnet-4-6
+4	description: Evaluates whether research on a question is reasonably
+5	  exhaustive — applies the five threshold questions and the 7-point
+6	  stop criteria, then either writes the exhaustive_declaration on the
+7	  question or explains what's missing. GPS Step 1 — Reasonably
+8	  Exhaustive Research. Use when the user says "is this research
+9	  exhaustive?", "are we done?", "have we searched enough?", "can we
+10	  declare exhaus...
+
+**assistant:** Three plan items need status updates before the exhaustiveness check — pli_003 and pli_004 (exhausted with nil results) and pli_006 (searched but status never advanced from "planned").
+
+**tool_use** `mcp__genealogy__research_append` — args: {"projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l", "ops": [{"section": "plan_items", "op": "update", "planId": "pl_001", "entryId": "pli_003", "fields": {"status": "skipped"}}, {"section": "plan_items", "op": "update", "planId": "pl_001", "entryId": "pli_004", "fields": {"status": "skipped"}}, {"section": "plan_items", "op": "update", "planId": "pl_001", "entryId": "pli_006", "fields": {"status": "skipped"}}]}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"results\": [\n    {\n      \"section\": \"plan_items\",\n      \"op\": \"update\",\n      \"entryId\": \"pli_003\"\n    },\n    {\n      \"section\": \"plan_items\",\n      \"op\": \"update\",\n      \"entryId\": \"pli_004\"\n    },\n    {\n      \"section\": \"plan_items\",\n      \"op\": \"update\",\n      \"entryId\": \"pli_006\"\n    }\n  ],\n  \"filesWritten\": [\n    \"research.json\"\n  ],\n  \"validation\": {\n    \"valid\": true,\n  ...
+
+**assistant:** All plan items now completed or skipped. Before declaring exhaustiveness, I need to attempt the original marriage bond image (GPS original-substitution requirement). The image ARK is known from the record.
+
+**tool_use** `Agent` — args: {"description": "Read 1792 Kentucky marriage bond image", "subagent_type": "image-reader", "prompt": "Read the FamilySearch image at ARK ark:/61903/1:2:QLWS-5MZ8. This is a Kentucky county marriage bond or license from 1792, Lincoln County, Kentucky. I am looking for: the marriage entry for Moses McCarley and Elizabeth Patt, dated 24 Jul 1792 \u2014 specifically any names of parties, witnesses, date, county, and any other details on the page. Return a full text transcription of whatever is le...
+
+**tool_use** `mcp__genealogy__image_read` — args: {"ark": "ark:/61903/1:2:QLWS-5MZ8"}
+
+**tool_result:** {"error":"Unrecognized ark. Expected a FamilySearch document-image ARK (ark:/61903/3:1:... or 3:2:..., a bare 3:1:.../3:2:... id, or a resolver URL for one), a DeepZoomCloud ARK URL (ending in /$dist), or a DGS distribution URL (dgs:.../dist.jpg)."}
+
+**tool_result:** [{"type": "text", "text": "NOT READ: ark:/61903/1:2:QLWS-5MZ8\n\nThe ARK provided uses the `1:2:` namespace, which is a FamilySearch **record** ARK (pointing to an indexed record or source citation), not a document-image ARK. The `image_read` tool requires a document-image ARK in the `3:1:` or `3:2:` namespace, a DeepZoomCloud distribution URL, or a DGS distribution URL.\n\nThe exact error returned was:\n\"Unrecognized ark. Expected a FamilySearch document-image ARK (ark:/61903/3:1:... or 3:2...
+
+**assistant:** The `1:2:` ARK is a citation ARK, not an image ARK. Let me try record_read to get the full GedcomX and any image reference.
+
+**tool_use** `ToolSearch` — args: {"query": "select:mcp__genealogy__record_read,mcp__genealogy__volume_search", "max_results": 2}
+
+**tool_result:** [{"type": "tool_reference", "tool_name": "mcp__genealogy__record_read"}, {"type": "tool_reference", "tool_name": "mcp__genealogy__volume_search"}]
+
+**tool_use** `mcp__genealogy__record_read` — args: {"recordId": "ark:/61903/1:1:Q28D-NHWN", "projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l", "resultsRef": "results/log_001.json"}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"persons\": [\n    {\n      \"id\": \"p_102337459396\",\n      \"ark\": \"ark:/61903/1:1:Q28D-NHWN\",\n      \"gender\": \"Male\",\n      \"names\": [\n        {\n          \"type\": \"BirthName\",\n          \"given\": \"Moses\",\n          \"surname\": \"McCarley\"\n        }\n      ],\n      \"facts\": [\n        {\n          \"type\": \"Unknown\",\n          \"primary\": true,\n          \"place\": \"Lincoln\",\n          \"standard_place\": \"Lincoln, Ken...
+
+**assistant:** Found the original image ARK in the record's source descriptions: `ark:/61903/3:1:3Q9M-C9BK-BSZ8-3`. Reading the original bond image now.
+
+**tool_use** `Agent` — args: {"description": "Read original 1792 Lincoln Co. marriage bond image", "subagent_type": "image-reader", "prompt": "Read the FamilySearch document image at ARK ark:/61903/3:1:3Q9M-C9BK-BSZ8-3. This is a page from a Lincoln County, Kentucky marriage register or bond book from circa 1792. I am looking for the marriage entry for Moses McCarley and Elizabeth Patt, dated 24 July 1792. Please transcribe the full text of whatever is visible on the page, including all names, dates, places, amounts, and...
+
+**tool_use** `mcp__genealogy__image_read` — args: {"ark": "ark:/61903/3:1:3Q9M-C9BK-BSZ8-3"}
+
+**tool_result:** {"error":"FamilySearch image ark:/61903/3:1:3Q9M-C9BK-BSZ8-3 is 1.1 MB — too large to return inline. The MCP transport caps a single response near 1 MB and base64 encoding inflates the image by ~33%, so returning it would crash the session. Read the indexed record for this image with record_read / record_search instead of fetching the page scan, or choose a more specific image."}
+
+**tool_result:** [{"type": "text", "text": "NOT READ: ark:/61903/3:1:3Q9M-C9BK-BSZ8-3\n\nThe exact error returned by image_read:\n\n\"FamilySearch image ark:/61903/3:1:3Q9M-C9BK-BSZ8-3 is 1.1 MB \u2014 too large to return inline. The MCP transport caps a single response near 1 MB and base64 encoding inflates the image by ~33%, so returning it would crash the session.\"\n\nThe image cannot be returned because it exceeds the ~1 MB transport safety ceiling (the file is 1.1 MB, and base64 encoding would push it w...
+
+**assistant:** Original image is inaccessible (1.1 MB — over MCP transport cap). This is pursued-and-unavailable per the exhaustiveness framework. Declaring exhaustiveness with that limitation documented.
+
+**tool_use** `mcp__genealogy__research_append` — args: {"projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l", "section": "questions", "op": "update", "entryId": "q_001", "fields": {"status": "exhaustive_declared", "exhaustive_declaration": {"declared": true, "justification": "Searched Kentucky County Marriages 1786-1965 (primary marriage evidence), 1820/1840 census records (nil \u2014 not indexed), Kentucky Probate Records and Wills and Deeds (nil \u2014 essentially browse-only collections), and t...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"section\": \"questions\",\n  \"op\": \"update\",\n  \"entryId\": \"q_001\",\n  \"filesWritten\": [\n    \"research.json\"\n  ],\n  \"validation\": {\n    \"valid\": true,\n    \"warnings\": []\n  }\n}"}]
+
+**assistant:** Exhaustiveness declared. Now reading the proof-conclusion skill before writing the summary.
+
+**tool_use** `Read` — args: {"file_path": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l/.claude/skills/proof-conclusion/SKILL.md"}
+
+**tool_result:** 1	---
+2	name: proof-conclusion
+3	model: claude-sonnet-4-6
+4	description: Writes GPS-conformant proof conclusions — selects the tier
+5	  (Proved/Probable/Possible/Not Proved/Disproved), chooses the form
+6	  (Statement/Summary/Argument), and writes a self-contained narrative
+7	  markdown uploadable to FamilySearch. Updates tree.gedcomx.json at tier
+8	  probable or higher.
+9	  GPS Step 5 — Soundly Reasoned, Coherently Written Conclusion. Use when
+10	  the user says "write the conclusion", "what'...
+
+**tool_use** `Read` — args: {"file_path": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l/.claude/skills/proof-conclusion/references/gps-proof-writing.md"}
+
+**tool_result:** 1	# GPS Proof Writing Reference
+2	
+3	This reference provides detailed guidance for writing genealogical
+4	proof conclusions that conform to the Genealogical Proof Standard.
+5	
+6	## The Five GPS Components (All Required for Proof)
+7	
+8	A conclusion qualifies as "proved" ONLY when all five are satisfied:
+9	
+10	1. **Reasonably exhaustive research** — Every record type and
+11	   repository that could plausibly contain relevant information has
+12	   been searched. Not every record ever created, bu...
+
+**assistant:** Precondition checks pass. Writing the proof summary now — let me first verify the existing Couple relationship in the tree.
+
+**tool_use** `Grep` — args: {"pattern": "R25|L7P6-3TT.*I1|I1.*L7P6-3TT|person1.*person2", "path": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l/tree.gedcomx.json", "output_mode": "content", "context": 2}
+
+**tool_result:** 755-      "person1": "L7P6-3TT",
+756-      "person2": "I1",
+757:      "id": "R25",
+758-      "facts": [
+759-        {
+
+**assistant:** Good — Couple R25 (L7P6-3TT ↔ I1) already exists with the marriage fact. Now writing the proof summary.
+
+**tool_use** `mcp__genealogy__research_append` — args: {"projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l", "section": "proof_summaries", "op": "append", "entry": {"question_id": "q_001", "tier": "probable", "vehicle": "summary", "supporting_assertion_ids": ["a_001", "a_002", "a_003", "a_004", "a_009", "a_010", "a_015", "a_016"], "resolved_conflict_ids": [], "exhaustive_search_summary": "Searched: FamilySearch 'Kentucky, County Marriages, 1786-1965' (collection 1804888) for Lincoln and Jessamine...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"section\": \"proof_summaries\",\n  \"op\": \"append\",\n  \"entryId\": \"ps_001\",\n  \"filesWritten\": [\n    \"research.json\"\n  ],\n  \"validation\": {\n    \"valid\": true,\n    \"warnings\": []\n  }\n}"}]
+
+**assistant:** Proof summary ps_001 written. Now checking tree R25 for existing source references before the Step 6 source addition.
+
+**tool_use** `Grep` — args: {"pattern": "\"R25\"|\"S1\"|\"S3\"|\"S4\"", "path": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l/tree.gedcomx.json", "output_mode": "content", "context": 3}
+
+**tool_result:** 754-      "type": "Couple",
+755-      "person1": "L7P6-3TT",
+756-      "person2": "I1",
+757:      "id": "R25",
+758-      "facts": [
+759-        {
+760-          "type": "Marriage",
+--
+786-      "url": "https://familysearch.org/ark:/61903/1:1:QVG3-8WK7"
+787-    },
+788-    {
+789:      "id": "S1",
+790-      "title": "Entry for Moses McCarley and Elizabeth Patt, \"Kentucky, County Marriages, 1786-1965\"",
+791-      "url": "https://www.familysearch.org/ark:/61903/1:2:QLWS-5MZ8"
+792-    },
+--
+796-  ...
+
+**tool_use** `Read` — args: {"file_path": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l/tree.gedcomx.json", "offset": 753, "limit": 30}
+
+**tool_result:** 753	    {
+754	      "type": "Couple",
+755	      "person1": "L7P6-3TT",
+756	      "person2": "I1",
+757	      "id": "R25",
+758	      "facts": [
+759	        {
+760	          "type": "Marriage",
+761	          "date": "24 Jul 1792",
+762	          "standard_date": "24 Jul 1792",
+763	          "place": "Lincoln, Kentucky, United States",
+764	          "standard_place": "Lincoln, Kentucky, United States",
+765	          "primary": true,
+766	          "id": "F1"
+767	        }
+768	      ]
+769	    }
+770	 ...
+
+**assistant:** Relationship R25 and fact F1 already in tree. The proof is persisted (ps_001, probable tier). Now marking q_001 answered and completing the project.
+
+**tool_use** `mcp__genealogy__research_append` — args: {"projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l", "ops": [{"section": "questions", "op": "update", "entryId": "q_001", "fields": {"status": "answered", "resolved": "2026-07-14", "resolution_assertion_ids": ["a_001", "a_002", "a_003", "a_004"]}}, {"section": "project", "op": "update", "fields": {"status": "completed"}}]}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": false,\n  \"errors\": [\n    \"ops[0]: research.json/questions[0]: 'answered' is not a valid question_status (expected one of: exhaustive_declared, in_progress, open, resolved)\"\n  ],\n  \"opsReceived\": 2\n}"}]
+
+**tool_use** `mcp__genealogy__research_append` — args: {"projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l", "ops": [{"section": "questions", "op": "update", "entryId": "q_001", "fields": {"status": "resolved", "resolved": "2026-07-14", "resolution_assertion_ids": ["a_001", "a_002", "a_003", "a_004"]}}, {"section": "project", "op": "update", "fields": {"status": "completed"}}]}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"results\": [\n    {\n      \"section\": \"questions\",\n      \"op\": \"update\",\n      \"entryId\": \"q_001\"\n    },\n    {\n      \"section\": \"project\",\n      \"op\": \"update\",\n      \"entryId\": \"project\"\n    }\n  ],\n  \"filesWritten\": [\n    \"research.json\"\n  ],\n  \"validation\": {\n    \"valid\": true,\n    \"warnings\": []\n  }\n}"}]
+
+**assistant:** Project marked completed. Running the GPS mentor review (advisory proof-critique) as the final step.
+
+**tool_use** `Agent` — args: {"description": "GPS mentor proof review", "subagent_type": "gps-mentor", "prompt": "Please review the proof summary ps_001 for research question q_001 in the project at /private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l.\n\nThe question is: \"Who did Moses J McCarley Sr (born 17 January 1767, died 9 April 1844) marry?\"\n\nThe proof conclusion (ps_001) is at the PROBABLE tier, vehicle: summary. The conclusion is that Moses J McCarley Sr married Elizabeth Pa...
+
+**tool_use** `Read` — args: {"file_path": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l/research.json"}
+
+**tool_result:** 1	{
+2	  "project": {
+3	    "id": "rp_mccarley_spouse",
+4	    "objective": "Who was the spouse of Moses J McCarley Sr, who was born 17 January 1767 and died 9 April 1844?",
+5	    "subject_person_ids": [
+6	      "L7P6-3TT"
+7	    ],
+8	    "status": "completed",
+9	    "created": "2026-07-14",
+10	    "updated": "2026-07-15"
+11	  },
+12	  "researcher_profile": {
+13	    "experience_level": "intermediate",
+14	    "subscriptions": [],
+15	    "narration_guidance": "concise"
+16	  },
+17	  "questions": [
+1...
+
+**tool_result:** [{"type": "text", "text": "# Mentor review: proof-critique on ps_001\n\n**Note on output protocol:** I was not given a file-writing tool in this session (only `Read` is available to me), so I cannot create `evaluations/proof-critique-ps_001-<timestamp>.json` or append the pointer entry to `research.json`'s `evaluations[]` array as the output protocol requires. I'm reporting that explicitly rather than silently skipping it. Below is the full verdict content \u2014 please have it written to dis...
+
+**assistant:** The mentor flags one must-address item: the image-read attempt has no log entry. Fixing that, cleaning the narrative phrasing, and appending the evaluation record now.
+
+**tool_use** `ToolSearch` — args: {"query": "select:mcp__genealogy__research_log_append", "max_results": 1}
+
+**tool_result:** [{"type": "tool_reference", "tool_name": "mcp__genealogy__research_log_append"}]
+
+**assistant:** Adding the image-read log entry, then fixing the narrative, then writing the evaluation record.
+
+**tool_use** `mcp__genealogy__research_log_append` — args: {"projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l", "tool": "image_read", "planItemId": null, "query": {"imageArk": "ark:/61903/3:1:3Q9M-C9BK-BSZ8-3", "purpose": "Original 1792 Lincoln County, KY marriage bond image \u2014 attempted to upgrade src_001 from derivative index to original source as part of exhaustiveness evaluation for q_001", "imageArkSource": "sd_da1 source description from record_read of ark:/61903/1:1:Q28D-NHWN"}, "outcome"...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"logId\": \"log_010\",\n  \"performed\": \"2026-07-15T01:25:11.853Z\",\n  \"resultsRef\": null,\n  \"returnedCount\": null,\n  \"filesWritten\": [\n    \"research.json\"\n  ],\n  \"validation\": {\n    \"valid\": true,\n    \"warnings\": []\n  }\n}"}]
+
+**assistant:** log_010 recorded. Now updating ps_001 narrative (fix the draft phrasing) and adding log_010 to the exhaustive_declaration's log references.
+
+**tool_use** `mcp__genealogy__research_append` — args: {"projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l", "ops": [{"section": "proof_summaries", "op": "update", "entryId": "ps_001", "fields": {"narrative_markdown": "## Who Did Moses J McCarley Sr Marry?\n\n**Conclusion:** The preponderance of available evidence strongly suggests that Moses J McCarley Sr (born 17 January 1767, died 9 April 1844) married **Elizabeth Patt** on **24 July 1792** in **Lincoln County, Kentucky**. The conclusion rests...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": false,\n  \"errors\": [\n    \"ops[2]: research.json/evaluations[0]: missing required field 'file_path'\",\n    \"ops[2]: research.json/evaluations[0]: missing required field 'superseded_by'\",\n    \"ops[2]: research.json/evaluations[0]: unexpected property 'performed' (evaluations allow only id, focus, target_id, target_type, verdict, file_path, timestamp, superseded_by)\",\n    \"ops[2]: research.json/evaluations[0]: unexpected property 'strengths' (...
+
+**assistant:** Evaluations schema is strict — needs a file reference. Let me write the two valid ops first, then create the evaluation file and add the entry.
+
+**tool_use** `mcp__genealogy__research_append` — args: {}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": false,\n  \"errors\": [\n    \"research.json not found in projectPath\"\n  ]\n}"}]
+
+**tool_use** `mcp__genealogy__research_append` — args: {"projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l", "ops": [{"section": "proof_summaries", "op": "update", "entryId": "ps_001", "fields": {"narrative_markdown": "## Who Did Moses J McCarley Sr Marry?\n\n**Conclusion:** The preponderance of available evidence strongly suggests that Moses J McCarley Sr (born 17 January 1767, died 9 April 1844) married **Elizabeth Patt** on **24 July 1792** in **Lincoln County, Kentucky**. The conclusion rests...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"results\": [\n    {\n      \"section\": \"proof_summaries\",\n      \"op\": \"update\",\n      \"entryId\": \"ps_001\"\n    },\n    {\n      \"section\": \"questions\",\n      \"op\": \"update\",\n      \"entryId\": \"q_001\"\n    }\n  ],\n  \"filesWritten\": [\n    \"research.json\"\n  ],\n  \"validation\": {\n    \"valid\": true,\n    \"warnings\": [\n      \"question 'q_001' is already exhaustive_declared; no-op\"\n    ]\n  }\n}"}]
+
+**assistant:** Now writing the evaluation file and adding the entry with the correct schema.
+
+**tool_use** `Write` — args: {"file_path": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l/evaluations/proof-critique-ps_001.md", "content": "# GPS Mentor Proof Critique \u2014 ps_001\n\n**Target:** ps_001 (q_001: \"Who did Moses J McCarley Sr marry?\")\n**Verdict:** address_first\n**Reviewed:** 2026-07-14\n\n---\n\n## Strengths\n\n1. **Tier call (Probable) correctly resists inflation** despite a strong single index match \u2014 Standard 43 honesty over hoped-for closure. The conclu...
+
+**tool_result:** File created successfully at: /private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l/evaluations/proof-critique-ps_001.md (file state is current in your context — no need to Read it back)
+
+**tool_use** `mcp__genealogy__research_append` — args: {"projectPath": "/private/var/folders/g7/zn65fvrn5g9_g71_sp0lk82h0000gn/T/e2e-mccarley-spouse-7ypjqc0l", "section": "evaluations", "op": "append", "entry": {"focus": "proof-critique", "target_id": "ps_001", "target_type": "proof_summary", "verdict": "address_first", "file_path": "evaluations/proof-critique-ps_001.md", "superseded_by": null}}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"section\": \"evaluations\",\n  \"op\": \"append\",\n  \"entryId\": \"ev_001\",\n  \"filesWritten\": [\n    \"research.json\"\n  ],\n  \"validation\": {\n    \"valid\": true,\n    \"warnings\": []\n  }\n}"}]
+
+**assistant:** The autonomous research session is complete. Here's the final summary:
+
+---
+
+**Answer: Moses J McCarley Sr married Elizabeth Patt on 24 July 1792 in Lincoln County, Kentucky.**
+
+**Proof tier: Probable** (ps_001)
+
+---
+
+### What was done
+
+| Step | Result |
+|---|---|
+| Question selected (q_001) | "Who did Moses J McCarley Sr marry?" |
+| Research plan (pl_001, 9 items) | 3 completed, 6 skipped (nil or inaccessible) |
+| Records extracted | 3 marriage records → 16 assertions (a_001–a_016), 3 sources (src_001–src_003) |
+| Person-evidence | 20 pe_ links created; Betsy Lawson stub (I2) added for Moses Jr.'s wife |
+| Exhaustiveness declared | All plan items completed or skipped; original bond image attempted (log_010) but inaccessible at 1.1 MB over transport ceiling — pursued-and-unavailable |
+| Proof summary (ps_001) | Probable — one derivative source directly answers the question; no independent corroboration of the specific marriage; original bond not accessible |
+| GPS mentor verdict | "address_first" → all items resolved: log_010 added, narrative corrected, evaluation ev_001 written |
+| Project status | **Completed** |
+
+---
+
+### Why Probable, not Proved
+
+Two GPS components are incomplete:
+1. **Original substitution** — only a derivative index was accessible; the original 1792 Lincoln County marriage bond image exceeds the transport ceiling
+2. **Independent verification** — only one source directly names Elizabeth Patt as his wife; the two corroborating FAN records (1817 and 1827 children's marriages) confirm Moses Sr.'s identity but not his spouse
+
+### To advance to Proved
+- Examine the original bond microfilm at a FamilySearch center or library (collection 1804888) — may also reveal the bondsman, who on 1790s Kentucky bonds was often the bride's father or brother
+- Search land records and Ancestry/MyHeritage for a second independent source naming Elizabeth Patt as his wife

--- a/eval/tests/e2e/mccarley-spouse/README.md
+++ b/eval/tests/e2e/mccarley-spouse/README.md
@@ -1,0 +1,45 @@
+# Moses J McCarley Sr — spouse
+
+**Source PID:** `L7P6-3TT`
+**Moses J McCarley is deceased.** (FamilySearch ToS requires all committed
+e2e fixtures to be about deceased persons.)
+
+## Research question
+
+> Who was the spouse of Moses J McCarley Sr, who was born 17 January 1767
+> and died 9 April 1844?
+
+## What was removed from the starting tree
+
+- Removed the spouse **Elizabeth Patton** (PID LWXX-WQN, b. ~1761 KY,
+  d. 1832 IN) and the couple/marriage relationship, including the marriage
+  fact (24 July 1792, Lincoln County, Kentucky). Her parent-child links to
+  the ten children were cascaded off.
+- Removed a thin stray second-spouse stub, **"Boyd"** (PID LRDX-GPL, no
+  marriage fact and no children), so the starting tree has no spouse for
+  Moses at all.
+- Removed the three **Kentucky, County Marriages, 1786-1965** records that
+  identify the marriage/spouse.
+
+## What was left intact as anchors
+
+- Moses's parents (James McCarley and his wife), with their links to Moses.
+- Moses's **ten children**, each still linked to him as father.
+- Moses's own facts: birth (17 Jan 1767), death (9 Apr 1844, Owen Co., IN).
+- The 1810 U.S. census and Find a Grave (neither names the wife).
+
+## Expected difficulty
+
+medium — the 1792 Lincoln County, Kentucky marriage is indexed and returns
+as the top hit for Moses McCarley (confidence 4), naming the bride as
+"Elizabeth Patt(on)". The children also provide a corroborating path (a
+child's record naming the mother).
+
+## Notes for reviewers
+
+Reachability was confirmed before authoring: `record_search` for Moses
+McCarley marriages in Kentucky, 1790-1794, returns the Moses/Elizabeth Patt
+marriage (24 Jul 1792, Lincoln Co.) as the #1 result. Other hits ("Betsy
+Lawson" 1817, "Salvina" 1827) are different/later McCarleys and are noise.
+The submitted spouse name "Maria Rejnic" does not appear in the tree and was
+disregarded; the documented spouse is Elizabeth Patton.

--- a/eval/tests/e2e/mccarley-spouse/expected-findings.json
+++ b/eval/tests/e2e/mccarley-spouse/expected-findings.json
@@ -1,0 +1,34 @@
+{
+  "findings": [
+    {
+      "id": "f1",
+      "type": "relationship",
+      "description": "Moses J McCarley Sr's wife was Elizabeth Patton, born about 1761 in Kentucky and died 1832 in Owen County, Indiana. She was the mother of his children. (The marriage index abbreviates her surname as 'Patt'.)",
+      "details": {
+        "subject_person": { "name": "Moses J McCarley" },
+        "relation": "spouse",
+        "target_person": { "name": "Elizabeth Patton", "birth": "about 1761, Kentucky" }
+      },
+      "supporting_sources": [
+        "Kentucky, County Marriages, 1786-1965 — marriage of Moses McCarley and Elizabeth Patt(on), 24 July 1792, Lincoln County, Kentucky.",
+        "Records of the couple's children naming their mother."
+      ],
+      "required": true
+    },
+    {
+      "id": "f2",
+      "type": "fact",
+      "description": "Moses J McCarley Sr married Elizabeth Patton on 24 July 1792 in Lincoln County, Kentucky.",
+      "details": {
+        "subject_person": { "name": "Moses J McCarley" },
+        "fact_type": "Marriage",
+        "date": "24 July 1792",
+        "place": "Lincoln, Kentucky, United States"
+      },
+      "supporting_sources": [
+        "Kentucky, County Marriages, 1786-1965, entry for Moses McCarley and Elizabeth Patt(on), 24 Jul 1792, Lincoln County, Kentucky."
+      ],
+      "required": true
+    }
+  ]
+}

--- a/eval/tests/e2e/mccarley-spouse/fixture.json
+++ b/eval/tests/e2e/mccarley-spouse/fixture.json
@@ -1,0 +1,19 @@
+{
+  "id": "mccarley-spouse",
+  "name": "Moses J McCarley Sr — spouse",
+  "genre": "strip",
+  "source_pid": "L7P6-3TT",
+  "captured": "2026-07-14",
+  "researcher_question": "Who was the spouse of Moses J McCarley Sr, who was born 17 January 1767 and died 9 April 1844?",
+  "tags": {
+    "question_type": "spouse",
+    "era": "1790s",
+    "geography": "US-KY"
+  },
+  "model": {
+    "agent": "claude-sonnet-4-6",
+    "judge": "claude-haiku-4-5-20251001"
+  },
+  "difficulty": "medium",
+  "notes": "Moses J McCarley Sr (b. 17 Jan 1767, d. 9 Apr 1844 Owen Co., Indiana) married Elizabeth Patton (b. ~1761 KY, d. 1832 IN) on 24 Jul 1792 in Lincoln County, Kentucky. Stripped: spouse Elizabeth Patton, the couple/marriage relationship, and the three Kentucky county-marriage records; also removed a thin stray second-spouse stub ('Boyd', no marriage fact or children) so no spouse remains. Left as anchors: Moses's parents, his ten children (linked to him as father), the 1810 census, Find a Grave, and his birth/death. Spouse is recoverable from the indexed 1792 Lincoln Co. KY marriage record (top hit, confidence 4) and from the children's records naming their mother."
+}

--- a/eval/tests/e2e/mccarley-spouse/starting-research.json
+++ b/eval/tests/e2e/mccarley-spouse/starting-research.json
@@ -1,0 +1,28 @@
+{
+  "project": {
+    "id": "rp_mccarley_spouse",
+    "objective": "Who was the spouse of Moses J McCarley Sr, who was born 17 January 1767 and died 9 April 1844?",
+    "subject_person_ids": [
+      "L7P6-3TT"
+    ],
+    "status": "active",
+    "created": "2026-07-14",
+    "updated": "2026-07-14"
+  },
+  "researcher_profile": {
+    "experience_level": "intermediate",
+    "subscriptions": [],
+    "narration_guidance": "concise"
+  },
+  "questions": [],
+  "plans": [],
+  "log": [],
+  "sources": [],
+  "assertions": [],
+  "person_evidence": [],
+  "conflicts": [],
+  "hypotheses": [],
+  "timelines": [],
+  "proof_summaries": [],
+  "evaluations": []
+}

--- a/eval/tests/e2e/mccarley-spouse/starting-tree.gedcomx.json
+++ b/eval/tests/e2e/mccarley-spouse/starting-tree.gedcomx.json
@@ -1,0 +1,746 @@
+{
+  "persons": [
+    {
+      "id": "L7P6-3TT",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N1",
+          "given": "Moses J",
+          "surname": "McCarley",
+          "suffix": "Sr"
+        }
+      ],
+      "facts": [
+        {
+          "id": "248eaba5-34ae-4182-9874-bfcc07166241",
+          "type": "Birth",
+          "date": "17 January 1767",
+          "standard_date": "17 Jan 1767",
+          "place": "United States",
+          "standard_place": "United States"
+        },
+        {
+          "id": "9381f219-2889-4bfc-9b03-5527232282c1",
+          "type": "Death",
+          "date": "9 April 1844",
+          "standard_date": "9 Apr 1844",
+          "place": "Owen, Indiana, United States",
+          "standard_place": "Owen, Indiana, United States"
+        },
+        {
+          "id": "bb426d94-7797-4067-9404-a5972da68288",
+          "type": "Land Purchases in Jessamine Co., KY",
+          "date": "May and December 1807",
+          "standard_date": "Dec 1807",
+          "value": "2 parcels see documents"
+        },
+        {
+          "id": "a99f5574-6faa-4f5f-b7ce-5a918a5f0ce7",
+          "type": "Testify to Personal Property",
+          "date": "December 1807",
+          "standard_date": "Dec 1807",
+          "place": "Garrard, Kentucky, United States",
+          "standard_place": "Garrard, Kentucky, United States",
+          "value": "Bill of Sale for Colt"
+        },
+        {
+          "id": "c5be31e4-c57a-417a-b672-456ec4e963d8",
+          "type": "Burial",
+          "date": "1844",
+          "standard_date": "1844",
+          "place": "Montgomery Township, Owen, Indiana, United States",
+          "standard_place": "Montgomery Township, Owen, Indiana, United States"
+        }
+      ]
+    },
+    {
+      "id": "LHD2-QCN",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N2",
+          "given": "Sophia",
+          "surname": "McCarley"
+        }
+      ],
+      "facts": [
+        {
+          "id": "248eaba5-34ae-4182-9874-bfcc07166241",
+          "type": "Birth",
+          "date": "19 April 1792",
+          "standard_date": "19 Apr 1792",
+          "place": "Garrard, Kentucky, United States",
+          "standard_place": "Garrard, Kentucky, United States"
+        },
+        {
+          "id": "6e30f732-050d-4e87-96de-fdfed8b7c511",
+          "type": "Residence",
+          "date": "1850",
+          "standard_date": "1850",
+          "place": "Washington, Owen, Indiana, United States",
+          "standard_place": "Washington Township, Owen, Indiana, United States"
+        },
+        {
+          "id": "2d659c6d-074b-4b8e-ab20-7aa9d006ac43",
+          "type": "Residence",
+          "date": "1870",
+          "standard_date": "1870",
+          "place": "Indiana, United States",
+          "standard_place": "Indiana, United States"
+        },
+        {
+          "id": "988efe1a-16d1-4553-a866-3461d034f670",
+          "type": "Residence",
+          "date": "1880",
+          "standard_date": "1880",
+          "place": "Washington, Owen, Indiana, United States",
+          "standard_place": "Washington Township, Owen, Indiana, United States"
+        },
+        {
+          "id": "9381f219-2889-4bfc-9b03-5527232282c1",
+          "type": "Death",
+          "date": "8 February 1883",
+          "standard_date": "8 Feb 1883",
+          "place": "Owen, Indiana, United States",
+          "standard_place": "Owen, Indiana, United States"
+        },
+        {
+          "id": "c5be31e4-c57a-417a-b672-456ec4e963d8",
+          "type": "Burial",
+          "date": "1883",
+          "standard_date": "1883",
+          "place": "Owen Township, Warrick, Indiana, United States",
+          "standard_place": "Owen Township, Warrick, Indiana, United States"
+        }
+      ]
+    },
+    {
+      "id": "L5VP-VVJ",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N3",
+          "given": "James",
+          "surname": "McCarley"
+        }
+      ],
+      "facts": [
+        {
+          "id": "6fe56fe3-7c94-4527-8c84-ead2c3d3e05b",
+          "type": "Birth",
+          "date": "about 1793",
+          "standard_date": "Abt 1793",
+          "place": "Garrard, Kentucky, United States",
+          "standard_place": "Garrard, Kentucky, United States"
+        },
+        {
+          "id": "49286d6b-5a22-4e4c-8a16-ed81e160abb4",
+          "type": "Death",
+          "date": "before 1844",
+          "standard_date": "Bef 1844"
+        }
+      ]
+    },
+    {
+      "id": "M6M6-LLW",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N4",
+          "given": "Moses",
+          "surname": "McCarley",
+          "suffix": "Jr."
+        }
+      ],
+      "facts": [
+        {
+          "id": "ebe0d4fe-20f8-4dad-b4b8-c69c03d0f100",
+          "type": "Birth",
+          "date": "9 November 1797",
+          "standard_date": "9 Nov 1797",
+          "place": "Kentucky, United States",
+          "standard_place": "Kentucky, United States"
+        },
+        {
+          "id": "7cd77a4d-dbbf-464d-94a3-a38be2e07f19",
+          "type": "Residence",
+          "date": "1820",
+          "standard_date": "1820",
+          "place": "Garrard, Garrard, Kentucky, United States",
+          "standard_place": "Garrard, Clay, Kentucky, United States"
+        },
+        {
+          "id": "2bfab2b9-5551-49c8-bfb6-09753ac1e2f8",
+          "type": "Residence",
+          "date": "1850",
+          "standard_date": "1850",
+          "place": "Garrard county, Garrard, Kentucky",
+          "standard_place": "Garrard, Kentucky, United States"
+        },
+        {
+          "id": "83e55612-2204-496e-940f-53fcd29460b3",
+          "type": "Residence",
+          "date": "1850",
+          "standard_date": "1850",
+          "place": "Garrard, Kentucky, United States",
+          "standard_place": "Garrard, Kentucky, United States"
+        },
+        {
+          "id": "a3ca8aea-4b58-4dbf-aecf-8fd8437e7791",
+          "type": "Residence",
+          "date": "1860",
+          "standard_date": "1860",
+          "place": ", Garrard, Kentucky, United States",
+          "standard_place": "Garrard, Kentucky, United States"
+        },
+        {
+          "id": "f47723ec-e7d6-4628-8b82-0f1e6194d01e",
+          "type": "Residence",
+          "date": "1870",
+          "standard_date": "1870",
+          "place": "Kentucky, United States",
+          "standard_place": "Kentucky, United States"
+        },
+        {
+          "id": "fc797baf-1af2-4a3b-a25f-271f4c2d468d",
+          "type": "Burial",
+          "date": "April 1874",
+          "standard_date": "Apr 1874",
+          "place": "Lancaster Cemetery, Lancaster, Garrard, Kentucky, United States",
+          "standard_place": "Lancaster Cemetery, Lancaster, Garrard, Kentucky, United States"
+        },
+        {
+          "id": "ddb21ddf-0042-4808-af3c-5b2e94e08922",
+          "type": "Death",
+          "date": "21 April 1874",
+          "standard_date": "21 Apr 1874",
+          "place": "Garrard, Kentucky, United States",
+          "standard_place": "Garrard, Kentucky, United States"
+        }
+      ]
+    },
+    {
+      "id": "KF2W-F45",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N5",
+          "given": "Nancy B.",
+          "surname": "McCarley"
+        }
+      ],
+      "facts": [
+        {
+          "id": "248eaba5-34ae-4182-9874-bfcc07166241",
+          "type": "Birth",
+          "date": "11 May 1804",
+          "standard_date": "11 May 1804",
+          "place": "Garrard, Kentucky, United States",
+          "standard_place": "Garrard, Kentucky, United States"
+        },
+        {
+          "id": "ec752871-6569-4b10-9845-4058781c3028",
+          "type": "Residence",
+          "date": "1840",
+          "standard_date": "1840",
+          "place": "Jessamine, Kentucky, United States",
+          "standard_place": "Jessamine, Kentucky, United States"
+        },
+        {
+          "id": "4875fb68-dbe3-43f4-8440-10f94b44d5a9",
+          "type": "Residence",
+          "date": "1850",
+          "standard_date": "1850",
+          "place": "Washington Township, Owen, Indiana, United States",
+          "standard_place": "Washington Township, Owen, Indiana, United States"
+        },
+        {
+          "id": "6f8535b9-1bb9-4ea0-9010-08cf13d30dd3",
+          "type": "Residence",
+          "date": "1850",
+          "standard_date": "1850",
+          "place": "Garrard, Kentucky, United States",
+          "standard_place": "Garrard, Kentucky, United States"
+        },
+        {
+          "id": "9381f219-2889-4bfc-9b03-5527232282c1",
+          "type": "Death",
+          "date": "June 1868",
+          "standard_date": "Jun 1868",
+          "place": "Spencer, Owen, Indiana, United States",
+          "standard_place": "Spencer, Washington Township, Owen, Indiana, United States"
+        },
+        {
+          "id": "de5649b7-1747-4d51-ac4a-a4876223657c",
+          "type": "Burial",
+          "date": "1868",
+          "standard_date": "1868",
+          "place": "Spencer, Owen, Indiana, United States of America",
+          "standard_place": "Spencer, Washington Township, Owen, Indiana, United States"
+        }
+      ]
+    },
+    {
+      "id": "L5VP-2Y7",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N6",
+          "given": "James",
+          "surname": "McCarley"
+        }
+      ],
+      "facts": [
+        {
+          "id": "b66ca5ff-d60a-4012-acb1-0a1ca266c200",
+          "type": "Birth",
+          "date": "1735",
+          "standard_date": "1735",
+          "place": "United States",
+          "standard_place": "United States"
+        },
+        {
+          "id": "aa91888b-5fa6-4018-89c0-ea10c992cb1c",
+          "type": "Death",
+          "date": "after December 1807",
+          "standard_date": "Aft Dec 1807",
+          "place": "Garrard, Kentucky, United States",
+          "standard_place": "Garrard, Kentucky, United States"
+        }
+      ]
+    },
+    {
+      "id": "L7P6-H65",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N7",
+          "given": "Susan",
+          "surname": "McCarley"
+        }
+      ],
+      "facts": [
+        {
+          "id": "ebe0d4fe-20f8-4dad-b4b8-c69c03d0f100",
+          "type": "Birth",
+          "date": "1805",
+          "standard_date": "1805",
+          "place": "Garrard, Kentucky, United States",
+          "standard_place": "Garrard, Kentucky, United States"
+        },
+        {
+          "id": "ddb21ddf-0042-4808-af3c-5b2e94e08922",
+          "type": "Death",
+          "date": "Abt 1848",
+          "standard_date": "Abt 1848",
+          "place": "Owen, Indiana, United States",
+          "standard_place": "Owen, Indiana, United States"
+        }
+      ]
+    },
+    {
+      "id": "L5Y6-CZ9",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N8",
+          "given": "James",
+          "surname": "Mccarley",
+          "prefix": "Mrs."
+        }
+      ],
+      "facts": [
+        {
+          "id": "4cb9faad-9a25-4453-b8be-eeb5a70093d2",
+          "type": "Birth",
+          "date": "about 1738",
+          "standard_date": "Abt 1738",
+          "place": "United States",
+          "standard_place": "United States"
+        },
+        {
+          "id": "801fe4cf-404e-49c3-900d-13480db26098",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "KPHY-36B",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N9",
+          "given": "Samuel",
+          "surname": "McCarley"
+        }
+      ],
+      "facts": [
+        {
+          "id": "ebe0d4fe-20f8-4dad-b4b8-c69c03d0f100",
+          "type": "Birth",
+          "date": "about 1802",
+          "standard_date": "Abt 1802",
+          "place": "Kentucky, United States",
+          "standard_place": "Kentucky, United States"
+        },
+        {
+          "id": "9516ff4d-5ae6-477c-883c-7523935d7962",
+          "type": "Marriage+bond",
+          "date": "7 July 1824",
+          "standard_date": "7 Jul 1824",
+          "value": "Marriage bond between Samuel McCarley and William Harris "
+        },
+        {
+          "id": "ddb21ddf-0042-4808-af3c-5b2e94e08922",
+          "type": "Death",
+          "date": "before 17 August 1946",
+          "standard_date": "Bef 17 Aug 1946",
+          "place": "Nicholasville, Jessamine, Kentucky, United States",
+          "standard_place": "Nicholasville, Jessamine, Kentucky, United States"
+        }
+      ]
+    },
+    {
+      "id": "KF27-BHH",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N10",
+          "given": "Sabina",
+          "surname": "McCarley"
+        }
+      ],
+      "facts": [
+        {
+          "id": "248eaba5-34ae-4182-9874-bfcc07166241",
+          "type": "Birth",
+          "date": "9 December 1808",
+          "standard_date": "9 Dec 1808",
+          "place": "Garrard, Kentucky, United States",
+          "standard_place": "Garrard, Kentucky, United States"
+        },
+        {
+          "id": "968e933c-974a-47d1-9b3e-a29d196d7c12",
+          "type": "Residence",
+          "date": "1850",
+          "standard_date": "1850",
+          "place": "Washington, Owen, Indiana, United States",
+          "standard_place": "Washington Township, Owen, Indiana, United States"
+        },
+        {
+          "id": "79eb083b-21bd-4054-994c-479377984e50",
+          "type": "Residence",
+          "date": "1860",
+          "standard_date": "1860",
+          "place": "Layfayett Township, Owen, Indiana, United States"
+        },
+        {
+          "id": "b4501688-64f2-4682-b691-468bea85b3de",
+          "type": "Residence",
+          "date": "1870",
+          "standard_date": "1870",
+          "place": "Indiana, United States",
+          "standard_place": "Indiana, United States"
+        },
+        {
+          "id": "46b1afed-e1aa-4d13-8a03-75fc4efd3832",
+          "type": "Residence",
+          "date": "1870",
+          "standard_date": "1870",
+          "place": "Washington Township, Owen, Indiana, United States",
+          "standard_place": "Washington Township, Owen, Indiana, United States"
+        },
+        {
+          "id": "9381f219-2889-4bfc-9b03-5527232282c1",
+          "type": "Death",
+          "date": "11 March 1878",
+          "standard_date": "11 Mar 1878",
+          "place": "Owen, Indiana, United States",
+          "standard_place": "Owen, Indiana, United States"
+        },
+        {
+          "id": "8b99761f-a805-4435-9e77-653c47e264dd",
+          "type": "Burial",
+          "place": "Alverson Cemetery #1, Carp, Montgomery Township, Owen, Indiana, United States",
+          "standard_place": "Alverson Cemetery #1, Carp, Montgomery Township, Owen, Indiana, United States"
+        }
+      ]
+    },
+    {
+      "id": "M6M6-LYT",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N11",
+          "given": "Margaret",
+          "surname": "McCarley"
+        }
+      ],
+      "facts": [
+        {
+          "id": "ebe0d4fe-20f8-4dad-b4b8-c69c03d0f100",
+          "type": "Birth",
+          "date": "23 February 1807",
+          "standard_date": "23 Feb 1807",
+          "place": "Garrard, Kentucky, United States",
+          "standard_place": "Garrard, Kentucky, United States"
+        },
+        {
+          "id": "f35a1394-aa8a-46c2-b82d-ca92bc56554c",
+          "type": "Residence",
+          "date": "1850",
+          "standard_date": "1850",
+          "place": "Montgomery Township, Owen, Indiana, United States",
+          "standard_place": "Montgomery Township, Owen, Indiana, United States"
+        },
+        {
+          "id": "96ebc250-dc46-414e-9abf-4fbf1ffcd2c5",
+          "type": "Residence",
+          "date": "1860",
+          "standard_date": "1860",
+          "place": "Montgomery Township, Owen, Indiana, United States",
+          "standard_place": "Montgomery Township, Owen, Indiana, United States"
+        },
+        {
+          "id": "75149680-2524-4ac0-80d1-88cd5ed3b16b",
+          "type": "Residence",
+          "date": "1870",
+          "standard_date": "1870",
+          "place": "Indiana, United States",
+          "standard_place": "Indiana, United States"
+        },
+        {
+          "id": "591ff2e7-fed5-4807-b146-32f3f7fd6044",
+          "type": "Residence",
+          "date": "1880",
+          "standard_date": "1880",
+          "place": "Montgomery, Owen, Indiana, United States",
+          "standard_place": "Montgomery Township, Owen, Indiana, United States"
+        },
+        {
+          "id": "80b2ddb2-defa-4e07-970e-f6da2616d6d1",
+          "type": "Death",
+          "date": "1884",
+          "standard_date": "1884"
+        },
+        {
+          "id": "0432378e-0b69-42a5-99a0-b282cd48b0ab",
+          "type": "Burial",
+          "date": "1884",
+          "standard_date": "1884",
+          "place": "Carp, Owen, Indiana, United States",
+          "standard_place": "Carp, Montgomery Township, Owen, Indiana, United States"
+        }
+      ]
+    },
+    {
+      "id": "KPHY-3LG",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N12",
+          "given": "Elizabeth",
+          "surname": "McCarley"
+        }
+      ],
+      "facts": [
+        {
+          "id": "248eaba5-34ae-4182-9874-bfcc07166241",
+          "type": "Birth",
+          "date": "9 November 1802",
+          "standard_date": "9 Nov 1802",
+          "place": "Kentucky, United States",
+          "standard_place": "Kentucky, United States"
+        },
+        {
+          "id": "363afa44-2475-4fef-903f-e1ad0a48a765",
+          "type": "Residence",
+          "date": "1850",
+          "standard_date": "1850",
+          "place": "Washington Township, Owen, Indiana, United States",
+          "standard_place": "Washington Township, Owen, Indiana, United States"
+        },
+        {
+          "id": "618c633b-ecf6-4ef5-aa4f-b2c5ef8a24b2",
+          "type": "Burial",
+          "date": "October 1868",
+          "standard_date": "Oct 1868",
+          "place": "Ellettsville, Richland Township, Monroe, Indiana, United States",
+          "standard_place": "Ellettsville, Richland Township, Monroe, Indiana, United States"
+        },
+        {
+          "id": "21435e2f-d1bc-46b2-9c10-a8c7f28e5d1f",
+          "type": "Death",
+          "date": "17 October 1868",
+          "standard_date": "17 Oct 1868"
+        }
+      ]
+    },
+    {
+      "id": "K63K-2B2",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N14",
+          "given": "Sarah E",
+          "surname": "McCarley"
+        }
+      ],
+      "facts": [
+        {
+          "id": "ebe0d4fe-20f8-4dad-b4b8-c69c03d0f100",
+          "type": "Birth",
+          "date": "December 1798",
+          "standard_date": "Dec 1798",
+          "place": "Kentucky, United States",
+          "standard_place": "Kentucky, United States"
+        },
+        {
+          "id": "b0016d74-6407-4ed0-a568-739d69e5ffc8",
+          "type": "Residence",
+          "date": "1850",
+          "standard_date": "1850",
+          "place": "Washington, Owen, Indiana, United States",
+          "standard_place": "Washington Township, Owen, Indiana, United States"
+        },
+        {
+          "id": "ddb21ddf-0042-4808-af3c-5b2e94e08922",
+          "type": "Death",
+          "date": "April 1853",
+          "standard_date": "Apr 1853",
+          "place": "Edgar, Illinois, United States",
+          "standard_place": "Edgar, Illinois, United States"
+        },
+        {
+          "id": "a34c02c2-548a-466b-b1af-a88ac36d3186",
+          "type": "Burial",
+          "date": "1853",
+          "standard_date": "1853",
+          "place": "Kansas, Edgar, Illinois, United States",
+          "standard_place": "Kansas, Edgar, Illinois, United States"
+        }
+      ]
+    }
+  ],
+  "relationships": [
+    {
+      "id": "R3",
+      "type": "Couple",
+      "person1": "L5VP-2Y7",
+      "person2": "L5Y6-CZ9"
+    },
+    {
+      "id": "R4",
+      "type": "ParentChild",
+      "parent": "L5VP-2Y7",
+      "child": "L7P6-3TT"
+    },
+    {
+      "id": "R5",
+      "type": "ParentChild",
+      "parent": "L5Y6-CZ9",
+      "child": "L7P6-3TT"
+    },
+    {
+      "id": "R6",
+      "type": "ParentChild",
+      "parent": "L7P6-3TT",
+      "child": "LHD2-QCN",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R8",
+      "type": "ParentChild",
+      "parent": "L7P6-3TT",
+      "child": "L5VP-VVJ"
+    },
+    {
+      "id": "R10",
+      "type": "ParentChild",
+      "parent": "L7P6-3TT",
+      "child": "M6M6-LLW",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R12",
+      "type": "ParentChild",
+      "parent": "L7P6-3TT",
+      "child": "K63K-2B2",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R14",
+      "type": "ParentChild",
+      "parent": "L7P6-3TT",
+      "child": "KPHY-36B",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R16",
+      "type": "ParentChild",
+      "parent": "L7P6-3TT",
+      "child": "KPHY-3LG",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R18",
+      "type": "ParentChild",
+      "parent": "L7P6-3TT",
+      "child": "KF2W-F45",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R20",
+      "type": "ParentChild",
+      "parent": "L7P6-3TT",
+      "child": "L7P6-H65",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R22",
+      "type": "ParentChild",
+      "parent": "L7P6-3TT",
+      "child": "M6M6-LYT",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R24",
+      "type": "ParentChild",
+      "parent": "L7P6-3TT",
+      "child": "KF27-BHH",
+      "subtype": "Biological"
+    }
+  ],
+  "sources": [
+    {
+      "id": "MMM2-6KS",
+      "title": "Moses Mccarley, \"United States Census, 1810\"",
+      "citation": "\"United States, Census, 1810\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:XH2C-M9T : Sat Jul 13 09:00:07 UTC 2024), Entry for Moses Mccarley, 1810.",
+      "url": "https://familysearch.org/ark:/61903/1:1:XH2C-M9T"
+    },
+    {
+      "id": "MMLG-KFY",
+      "title": "Legacy NFS Source: Moses J McCarley - Published information: birth: about January 1767; Pendleton, Anderson, South Carolina, United States"
+    },
+    {
+      "id": "9NMT-YDW",
+      "title": "Moses McCarley, \"Find a Grave Index\"",
+      "citation": "\"Find a Grave Index\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:QVG3-8WK7 : Wed Apr 02 09:20:48 UTC 2025), Entry for Moses McCarley, 1844.",
+      "url": "https://familysearch.org/ark:/61903/1:1:QVG3-8WK7"
+    }
+  ]
+}

--- a/eval/tests/e2e/mccarley-spouse/unstripped-tree.gedcomx.json
+++ b/eval/tests/e2e/mccarley-spouse/unstripped-tree.gedcomx.json
@@ -1,0 +1,936 @@
+
+{
+  "persons": [
+    {
+      "id": "L7P6-3TT",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N1",
+          "given": "Moses J",
+          "surname": "McCarley",
+          "suffix": "Sr"
+        }
+      ],
+      "facts": [
+        {
+          "id": "248eaba5-34ae-4182-9874-bfcc07166241",
+          "type": "Birth",
+          "date": "17 January 1767",
+          "standard_date": "17 Jan 1767",
+          "place": "United States",
+          "standard_place": "United States"
+        },
+        {
+          "id": "9381f219-2889-4bfc-9b03-5527232282c1",
+          "type": "Death",
+          "date": "9 April 1844",
+          "standard_date": "9 Apr 1844",
+          "place": "Owen, Indiana, United States",
+          "standard_place": "Owen, Indiana, United States"
+        },
+        {
+          "id": "bb426d94-7797-4067-9404-a5972da68288",
+          "type": "Land Purchases in Jessamine Co., KY",
+          "date": "May and December 1807",
+          "standard_date": "Dec 1807",
+          "value": "2 parcels see documents"
+        },
+        {
+          "id": "a99f5574-6faa-4f5f-b7ce-5a918a5f0ce7",
+          "type": "Testify to Personal Property",
+          "date": "December 1807",
+          "standard_date": "Dec 1807",
+          "place": "Garrard, Kentucky, United States",
+          "standard_place": "Garrard, Kentucky, United States",
+          "value": "Bill of Sale for Colt"
+        },
+        {
+          "id": "c5be31e4-c57a-417a-b672-456ec4e963d8",
+          "type": "Burial",
+          "date": "1844",
+          "standard_date": "1844",
+          "place": "Montgomery Township, Owen, Indiana, United States",
+          "standard_place": "Montgomery Township, Owen, Indiana, United States"
+        }
+      ]
+    },
+    {
+      "id": "LHD2-QCN",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N2",
+          "given": "Sophia",
+          "surname": "McCarley"
+        }
+      ],
+      "facts": [
+        {
+          "id": "248eaba5-34ae-4182-9874-bfcc07166241",
+          "type": "Birth",
+          "date": "19 April 1792",
+          "standard_date": "19 Apr 1792",
+          "place": "Garrard, Kentucky, United States",
+          "standard_place": "Garrard, Kentucky, United States"
+        },
+        {
+          "id": "6e30f732-050d-4e87-96de-fdfed8b7c511",
+          "type": "Residence",
+          "date": "1850",
+          "standard_date": "1850",
+          "place": "Washington, Owen, Indiana, United States",
+          "standard_place": "Washington Township, Owen, Indiana, United States"
+        },
+        {
+          "id": "2d659c6d-074b-4b8e-ab20-7aa9d006ac43",
+          "type": "Residence",
+          "date": "1870",
+          "standard_date": "1870",
+          "place": "Indiana, United States",
+          "standard_place": "Indiana, United States"
+        },
+        {
+          "id": "988efe1a-16d1-4553-a866-3461d034f670",
+          "type": "Residence",
+          "date": "1880",
+          "standard_date": "1880",
+          "place": "Washington, Owen, Indiana, United States",
+          "standard_place": "Washington Township, Owen, Indiana, United States"
+        },
+        {
+          "id": "9381f219-2889-4bfc-9b03-5527232282c1",
+          "type": "Death",
+          "date": "8 February 1883",
+          "standard_date": "8 Feb 1883",
+          "place": "Owen, Indiana, United States",
+          "standard_place": "Owen, Indiana, United States"
+        },
+        {
+          "id": "c5be31e4-c57a-417a-b672-456ec4e963d8",
+          "type": "Burial",
+          "date": "1883",
+          "standard_date": "1883",
+          "place": "Owen Township, Warrick, Indiana, United States",
+          "standard_place": "Owen Township, Warrick, Indiana, United States"
+        }
+      ]
+    },
+    {
+      "id": "L5VP-VVJ",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N3",
+          "given": "James",
+          "surname": "McCarley"
+        }
+      ],
+      "facts": [
+        {
+          "id": "6fe56fe3-7c94-4527-8c84-ead2c3d3e05b",
+          "type": "Birth",
+          "date": "about 1793",
+          "standard_date": "Abt 1793",
+          "place": "Garrard, Kentucky, United States",
+          "standard_place": "Garrard, Kentucky, United States"
+        },
+        {
+          "id": "49286d6b-5a22-4e4c-8a16-ed81e160abb4",
+          "type": "Death",
+          "date": "before 1844",
+          "standard_date": "Bef 1844"
+        }
+      ]
+    },
+    {
+      "id": "M6M6-LLW",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N4",
+          "given": "Moses",
+          "surname": "McCarley",
+          "suffix": "Jr."
+        }
+      ],
+      "facts": [
+        {
+          "id": "ebe0d4fe-20f8-4dad-b4b8-c69c03d0f100",
+          "type": "Birth",
+          "date": "9 November 1797",
+          "standard_date": "9 Nov 1797",
+          "place": "Kentucky, United States",
+          "standard_place": "Kentucky, United States"
+        },
+        {
+          "id": "7cd77a4d-dbbf-464d-94a3-a38be2e07f19",
+          "type": "Residence",
+          "date": "1820",
+          "standard_date": "1820",
+          "place": "Garrard, Garrard, Kentucky, United States",
+          "standard_place": "Garrard, Clay, Kentucky, United States"
+        },
+        {
+          "id": "2bfab2b9-5551-49c8-bfb6-09753ac1e2f8",
+          "type": "Residence",
+          "date": "1850",
+          "standard_date": "1850",
+          "place": "Garrard county, Garrard, Kentucky",
+          "standard_place": "Garrard, Kentucky, United States"
+        },
+        {
+          "id": "83e55612-2204-496e-940f-53fcd29460b3",
+          "type": "Residence",
+          "date": "1850",
+          "standard_date": "1850",
+          "place": "Garrard, Kentucky, United States",
+          "standard_place": "Garrard, Kentucky, United States"
+        },
+        {
+          "id": "a3ca8aea-4b58-4dbf-aecf-8fd8437e7791",
+          "type": "Residence",
+          "date": "1860",
+          "standard_date": "1860",
+          "place": ", Garrard, Kentucky, United States",
+          "standard_place": "Garrard, Kentucky, United States"
+        },
+        {
+          "id": "f47723ec-e7d6-4628-8b82-0f1e6194d01e",
+          "type": "Residence",
+          "date": "1870",
+          "standard_date": "1870",
+          "place": "Kentucky, United States",
+          "standard_place": "Kentucky, United States"
+        },
+        {
+          "id": "fc797baf-1af2-4a3b-a25f-271f4c2d468d",
+          "type": "Burial",
+          "date": "April 1874",
+          "standard_date": "Apr 1874",
+          "place": "Lancaster Cemetery, Lancaster, Garrard, Kentucky, United States",
+          "standard_place": "Lancaster Cemetery, Lancaster, Garrard, Kentucky, United States"
+        },
+        {
+          "id": "ddb21ddf-0042-4808-af3c-5b2e94e08922",
+          "type": "Death",
+          "date": "21 April 1874",
+          "standard_date": "21 Apr 1874",
+          "place": "Garrard, Kentucky, United States",
+          "standard_place": "Garrard, Kentucky, United States"
+        }
+      ]
+    },
+    {
+      "id": "KF2W-F45",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N5",
+          "given": "Nancy B.",
+          "surname": "McCarley"
+        }
+      ],
+      "facts": [
+        {
+          "id": "248eaba5-34ae-4182-9874-bfcc07166241",
+          "type": "Birth",
+          "date": "11 May 1804",
+          "standard_date": "11 May 1804",
+          "place": "Garrard, Kentucky, United States",
+          "standard_place": "Garrard, Kentucky, United States"
+        },
+        {
+          "id": "ec752871-6569-4b10-9845-4058781c3028",
+          "type": "Residence",
+          "date": "1840",
+          "standard_date": "1840",
+          "place": "Jessamine, Kentucky, United States",
+          "standard_place": "Jessamine, Kentucky, United States"
+        },
+        {
+          "id": "4875fb68-dbe3-43f4-8440-10f94b44d5a9",
+          "type": "Residence",
+          "date": "1850",
+          "standard_date": "1850",
+          "place": "Washington Township, Owen, Indiana, United States",
+          "standard_place": "Washington Township, Owen, Indiana, United States"
+        },
+        {
+          "id": "6f8535b9-1bb9-4ea0-9010-08cf13d30dd3",
+          "type": "Residence",
+          "date": "1850",
+          "standard_date": "1850",
+          "place": "Garrard, Kentucky, United States",
+          "standard_place": "Garrard, Kentucky, United States"
+        },
+        {
+          "id": "9381f219-2889-4bfc-9b03-5527232282c1",
+          "type": "Death",
+          "date": "June 1868",
+          "standard_date": "Jun 1868",
+          "place": "Spencer, Owen, Indiana, United States",
+          "standard_place": "Spencer, Washington Township, Owen, Indiana, United States"
+        },
+        {
+          "id": "de5649b7-1747-4d51-ac4a-a4876223657c",
+          "type": "Burial",
+          "date": "1868",
+          "standard_date": "1868",
+          "place": "Spencer, Owen, Indiana, United States of America",
+          "standard_place": "Spencer, Washington Township, Owen, Indiana, United States"
+        }
+      ]
+    },
+    {
+      "id": "L5VP-2Y7",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N6",
+          "given": "James",
+          "surname": "McCarley"
+        }
+      ],
+      "facts": [
+        {
+          "id": "b66ca5ff-d60a-4012-acb1-0a1ca266c200",
+          "type": "Birth",
+          "date": "1735",
+          "standard_date": "1735",
+          "place": "United States",
+          "standard_place": "United States"
+        },
+        {
+          "id": "aa91888b-5fa6-4018-89c0-ea10c992cb1c",
+          "type": "Death",
+          "date": "after December 1807",
+          "standard_date": "Aft Dec 1807",
+          "place": "Garrard, Kentucky, United States",
+          "standard_place": "Garrard, Kentucky, United States"
+        }
+      ]
+    },
+    {
+      "id": "L7P6-H65",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N7",
+          "given": "Susan",
+          "surname": "McCarley"
+        }
+      ],
+      "facts": [
+        {
+          "id": "ebe0d4fe-20f8-4dad-b4b8-c69c03d0f100",
+          "type": "Birth",
+          "date": "1805",
+          "standard_date": "1805",
+          "place": "Garrard, Kentucky, United States",
+          "standard_place": "Garrard, Kentucky, United States"
+        },
+        {
+          "id": "ddb21ddf-0042-4808-af3c-5b2e94e08922",
+          "type": "Death",
+          "date": "Abt 1848",
+          "standard_date": "Abt 1848",
+          "place": "Owen, Indiana, United States",
+          "standard_place": "Owen, Indiana, United States"
+        }
+      ]
+    },
+    {
+      "id": "L5Y6-CZ9",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N8",
+          "given": "James",
+          "surname": "Mccarley",
+          "prefix": "Mrs."
+        }
+      ],
+      "facts": [
+        {
+          "id": "4cb9faad-9a25-4453-b8be-eeb5a70093d2",
+          "type": "Birth",
+          "date": "about 1738",
+          "standard_date": "Abt 1738",
+          "place": "United States",
+          "standard_place": "United States"
+        },
+        {
+          "id": "801fe4cf-404e-49c3-900d-13480db26098",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "KPHY-36B",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N9",
+          "given": "Samuel",
+          "surname": "McCarley"
+        }
+      ],
+      "facts": [
+        {
+          "id": "ebe0d4fe-20f8-4dad-b4b8-c69c03d0f100",
+          "type": "Birth",
+          "date": "about 1802",
+          "standard_date": "Abt 1802",
+          "place": "Kentucky, United States",
+          "standard_place": "Kentucky, United States"
+        },
+        {
+          "id": "9516ff4d-5ae6-477c-883c-7523935d7962",
+          "type": "Marriage+bond",
+          "date": "7 July 1824",
+          "standard_date": "7 Jul 1824",
+          "value": "Marriage bond between Samuel McCarley and William Harris "
+        },
+        {
+          "id": "ddb21ddf-0042-4808-af3c-5b2e94e08922",
+          "type": "Death",
+          "date": "before 17 August 1946",
+          "standard_date": "Bef 17 Aug 1946",
+          "place": "Nicholasville, Jessamine, Kentucky, United States",
+          "standard_place": "Nicholasville, Jessamine, Kentucky, United States"
+        }
+      ]
+    },
+    {
+      "id": "KF27-BHH",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N10",
+          "given": "Sabina",
+          "surname": "McCarley"
+        }
+      ],
+      "facts": [
+        {
+          "id": "248eaba5-34ae-4182-9874-bfcc07166241",
+          "type": "Birth",
+          "date": "9 December 1808",
+          "standard_date": "9 Dec 1808",
+          "place": "Garrard, Kentucky, United States",
+          "standard_place": "Garrard, Kentucky, United States"
+        },
+        {
+          "id": "968e933c-974a-47d1-9b3e-a29d196d7c12",
+          "type": "Residence",
+          "date": "1850",
+          "standard_date": "1850",
+          "place": "Washington, Owen, Indiana, United States",
+          "standard_place": "Washington Township, Owen, Indiana, United States"
+        },
+        {
+          "id": "79eb083b-21bd-4054-994c-479377984e50",
+          "type": "Residence",
+          "date": "1860",
+          "standard_date": "1860",
+          "place": "Layfayett Township, Owen, Indiana, United States"
+        },
+        {
+          "id": "b4501688-64f2-4682-b691-468bea85b3de",
+          "type": "Residence",
+          "date": "1870",
+          "standard_date": "1870",
+          "place": "Indiana, United States",
+          "standard_place": "Indiana, United States"
+        },
+        {
+          "id": "46b1afed-e1aa-4d13-8a03-75fc4efd3832",
+          "type": "Residence",
+          "date": "1870",
+          "standard_date": "1870",
+          "place": "Washington Township, Owen, Indiana, United States",
+          "standard_place": "Washington Township, Owen, Indiana, United States"
+        },
+        {
+          "id": "9381f219-2889-4bfc-9b03-5527232282c1",
+          "type": "Death",
+          "date": "11 March 1878",
+          "standard_date": "11 Mar 1878",
+          "place": "Owen, Indiana, United States",
+          "standard_place": "Owen, Indiana, United States"
+        },
+        {
+          "id": "8b99761f-a805-4435-9e77-653c47e264dd",
+          "type": "Burial",
+          "place": "Alverson Cemetery #1, Carp, Montgomery Township, Owen, Indiana, United States",
+          "standard_place": "Alverson Cemetery #1, Carp, Montgomery Township, Owen, Indiana, United States"
+        }
+      ]
+    },
+    {
+      "id": "M6M6-LYT",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N11",
+          "given": "Margaret",
+          "surname": "McCarley"
+        }
+      ],
+      "facts": [
+        {
+          "id": "ebe0d4fe-20f8-4dad-b4b8-c69c03d0f100",
+          "type": "Birth",
+          "date": "23 February 1807",
+          "standard_date": "23 Feb 1807",
+          "place": "Garrard, Kentucky, United States",
+          "standard_place": "Garrard, Kentucky, United States"
+        },
+        {
+          "id": "f35a1394-aa8a-46c2-b82d-ca92bc56554c",
+          "type": "Residence",
+          "date": "1850",
+          "standard_date": "1850",
+          "place": "Montgomery Township, Owen, Indiana, United States",
+          "standard_place": "Montgomery Township, Owen, Indiana, United States"
+        },
+        {
+          "id": "96ebc250-dc46-414e-9abf-4fbf1ffcd2c5",
+          "type": "Residence",
+          "date": "1860",
+          "standard_date": "1860",
+          "place": "Montgomery Township, Owen, Indiana, United States",
+          "standard_place": "Montgomery Township, Owen, Indiana, United States"
+        },
+        {
+          "id": "75149680-2524-4ac0-80d1-88cd5ed3b16b",
+          "type": "Residence",
+          "date": "1870",
+          "standard_date": "1870",
+          "place": "Indiana, United States",
+          "standard_place": "Indiana, United States"
+        },
+        {
+          "id": "591ff2e7-fed5-4807-b146-32f3f7fd6044",
+          "type": "Residence",
+          "date": "1880",
+          "standard_date": "1880",
+          "place": "Montgomery, Owen, Indiana, United States",
+          "standard_place": "Montgomery Township, Owen, Indiana, United States"
+        },
+        {
+          "id": "80b2ddb2-defa-4e07-970e-f6da2616d6d1",
+          "type": "Death",
+          "date": "1884",
+          "standard_date": "1884"
+        },
+        {
+          "id": "0432378e-0b69-42a5-99a0-b282cd48b0ab",
+          "type": "Burial",
+          "date": "1884",
+          "standard_date": "1884",
+          "place": "Carp, Owen, Indiana, United States",
+          "standard_place": "Carp, Montgomery Township, Owen, Indiana, United States"
+        }
+      ]
+    },
+    {
+      "id": "KPHY-3LG",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N12",
+          "given": "Elizabeth",
+          "surname": "McCarley"
+        }
+      ],
+      "facts": [
+        {
+          "id": "248eaba5-34ae-4182-9874-bfcc07166241",
+          "type": "Birth",
+          "date": "9 November 1802",
+          "standard_date": "9 Nov 1802",
+          "place": "Kentucky, United States",
+          "standard_place": "Kentucky, United States"
+        },
+        {
+          "id": "363afa44-2475-4fef-903f-e1ad0a48a765",
+          "type": "Residence",
+          "date": "1850",
+          "standard_date": "1850",
+          "place": "Washington Township, Owen, Indiana, United States",
+          "standard_place": "Washington Township, Owen, Indiana, United States"
+        },
+        {
+          "id": "618c633b-ecf6-4ef5-aa4f-b2c5ef8a24b2",
+          "type": "Burial",
+          "date": "October 1868",
+          "standard_date": "Oct 1868",
+          "place": "Ellettsville, Richland Township, Monroe, Indiana, United States",
+          "standard_place": "Ellettsville, Richland Township, Monroe, Indiana, United States"
+        },
+        {
+          "id": "21435e2f-d1bc-46b2-9c10-a8c7f28e5d1f",
+          "type": "Death",
+          "date": "17 October 1868",
+          "standard_date": "17 Oct 1868"
+        }
+      ]
+    },
+    {
+      "id": "LWXX-WQN",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N13",
+          "given": "Elizabeth",
+          "surname": "Patton"
+        }
+      ],
+      "facts": [
+        {
+          "id": "248eaba5-34ae-4182-9874-bfcc07166241",
+          "type": "Birth",
+          "date": "1761",
+          "standard_date": "1761",
+          "place": "Kentucky, United States",
+          "standard_place": "Kentucky, United States"
+        },
+        {
+          "id": "f2cf9720-3b38-401f-b7aa-7d2a277c963b",
+          "type": "Marriage",
+          "date": "24 Jul 1792",
+          "standard_date": "24 Jul 1792",
+          "place": "Lincoln, Kentucky, United States",
+          "standard_place": "Lincoln, Kentucky, United States"
+        },
+        {
+          "id": "d9e07226-1164-44cf-bb70-876c5e926759",
+          "type": "Burial",
+          "date": "1832",
+          "standard_date": "1832",
+          "place": "Carp, Owen, Indiana, United States of America",
+          "standard_place": "Carp, Montgomery Township, Owen, Indiana, United States"
+        },
+        {
+          "id": "9381f219-2889-4bfc-9b03-5527232282c1",
+          "type": "Death",
+          "date": "6 December 1832",
+          "standard_date": "6 Dec 1832",
+          "place": "Owen, Indiana, United States",
+          "standard_place": "Owen, Indiana, United States"
+        }
+      ]
+    },
+    {
+      "id": "K63K-2B2",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N14",
+          "given": "Sarah E",
+          "surname": "McCarley"
+        }
+      ],
+      "facts": [
+        {
+          "id": "ebe0d4fe-20f8-4dad-b4b8-c69c03d0f100",
+          "type": "Birth",
+          "date": "December 1798",
+          "standard_date": "Dec 1798",
+          "place": "Kentucky, United States",
+          "standard_place": "Kentucky, United States"
+        },
+        {
+          "id": "b0016d74-6407-4ed0-a568-739d69e5ffc8",
+          "type": "Residence",
+          "date": "1850",
+          "standard_date": "1850",
+          "place": "Washington, Owen, Indiana, United States",
+          "standard_place": "Washington Township, Owen, Indiana, United States"
+        },
+        {
+          "id": "ddb21ddf-0042-4808-af3c-5b2e94e08922",
+          "type": "Death",
+          "date": "April 1853",
+          "standard_date": "Apr 1853",
+          "place": "Edgar, Illinois, United States",
+          "standard_place": "Edgar, Illinois, United States"
+        },
+        {
+          "id": "a34c02c2-548a-466b-b1af-a88ac36d3186",
+          "type": "Burial",
+          "date": "1853",
+          "standard_date": "1853",
+          "place": "Kansas, Edgar, Illinois, United States",
+          "standard_place": "Kansas, Edgar, Illinois, United States"
+        }
+      ]
+    },
+    {
+      "id": "LRDX-GPL",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N15",
+          "given": "",
+          "surname": "Boyd"
+        }
+      ],
+      "facts": [
+        {
+          "id": "b0e3ae1c-0f19-4e1f-b2b9-3fba5d994cd3",
+          "type": "Birth",
+          "date": "about 1769",
+          "standard_date": "Abt 1769",
+          "place": "of Virginia, United States",
+          "standard_place": "Virginia, United States"
+        },
+        {
+          "id": "96b92bfd-53f0-442c-9334-70d288b38991",
+          "type": "Death"
+        }
+      ]
+    }
+  ],
+  "relationships": [
+    {
+      "id": "R1",
+      "type": "Couple",
+      "person1": "L7P6-3TT",
+      "person2": "LWXX-WQN",
+      "facts": [
+        {
+          "id": "b479ad84-1f14-4cb1-937f-aacf5b38ecd4",
+          "type": "Marriage",
+          "date": "24 January 1792",
+          "standard_date": "24 Jan 1792",
+          "place": "Lincoln, Kentucky, United States",
+          "standard_place": "Lincoln, Kentucky, United States"
+        },
+        {
+          "id": "fda5eca0-6b9c-41a5-80a8-4790c251838f",
+          "type": "Marriage",
+          "date": "24 Jul 1792",
+          "standard_date": "24 Jul 1792",
+          "place": "Lincoln, Kentucky, United States",
+          "standard_place": "Lincoln, Kentucky, United States"
+        }
+      ]
+    },
+    {
+      "id": "R2",
+      "type": "Couple",
+      "person1": "L7P6-3TT",
+      "person2": "LRDX-GPL"
+    },
+    {
+      "id": "R3",
+      "type": "Couple",
+      "person1": "L5VP-2Y7",
+      "person2": "L5Y6-CZ9"
+    },
+    {
+      "id": "R4",
+      "type": "ParentChild",
+      "parent": "L5VP-2Y7",
+      "child": "L7P6-3TT"
+    },
+    {
+      "id": "R5",
+      "type": "ParentChild",
+      "parent": "L5Y6-CZ9",
+      "child": "L7P6-3TT"
+    },
+    {
+      "id": "R6",
+      "type": "ParentChild",
+      "parent": "L7P6-3TT",
+      "child": "LHD2-QCN",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R7",
+      "type": "ParentChild",
+      "parent": "LWXX-WQN",
+      "child": "LHD2-QCN",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R8",
+      "type": "ParentChild",
+      "parent": "L7P6-3TT",
+      "child": "L5VP-VVJ"
+    },
+    {
+      "id": "R9",
+      "type": "ParentChild",
+      "parent": "LWXX-WQN",
+      "child": "L5VP-VVJ"
+    },
+    {
+      "id": "R10",
+      "type": "ParentChild",
+      "parent": "L7P6-3TT",
+      "child": "M6M6-LLW",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R11",
+      "type": "ParentChild",
+      "parent": "LWXX-WQN",
+      "child": "M6M6-LLW",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R12",
+      "type": "ParentChild",
+      "parent": "L7P6-3TT",
+      "child": "K63K-2B2",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R13",
+      "type": "ParentChild",
+      "parent": "LWXX-WQN",
+      "child": "K63K-2B2",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R14",
+      "type": "ParentChild",
+      "parent": "L7P6-3TT",
+      "child": "KPHY-36B",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R15",
+      "type": "ParentChild",
+      "parent": "LWXX-WQN",
+      "child": "KPHY-36B",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R16",
+      "type": "ParentChild",
+      "parent": "L7P6-3TT",
+      "child": "KPHY-3LG",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R17",
+      "type": "ParentChild",
+      "parent": "LWXX-WQN",
+      "child": "KPHY-3LG",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R18",
+      "type": "ParentChild",
+      "parent": "L7P6-3TT",
+      "child": "KF2W-F45",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R19",
+      "type": "ParentChild",
+      "parent": "LWXX-WQN",
+      "child": "KF2W-F45",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R20",
+      "type": "ParentChild",
+      "parent": "L7P6-3TT",
+      "child": "L7P6-H65",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R21",
+      "type": "ParentChild",
+      "parent": "LWXX-WQN",
+      "child": "L7P6-H65",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R22",
+      "type": "ParentChild",
+      "parent": "L7P6-3TT",
+      "child": "M6M6-LYT",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R23",
+      "type": "ParentChild",
+      "parent": "LWXX-WQN",
+      "child": "M6M6-LYT",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R24",
+      "type": "ParentChild",
+      "parent": "L7P6-3TT",
+      "child": "KF27-BHH",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R25",
+      "type": "ParentChild",
+      "parent": "LWXX-WQN",
+      "child": "KF27-BHH",
+      "subtype": "Biological"
+    }
+  ],
+  "sources": [
+    {
+      "id": "MMM2-6KS",
+      "title": "Moses Mccarley, \"United States Census, 1810\"",
+      "citation": "\"United States, Census, 1810\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:XH2C-M9T : Sat Jul 13 09:00:07 UTC 2024), Entry for Moses Mccarley, 1810.",
+      "url": "https://familysearch.org/ark:/61903/1:1:XH2C-M9T"
+    },
+    {
+      "id": "SW64-JCY",
+      "title": "Moses Mccarley, \"Kentucky, County Marriages, 1786-1965\"",
+      "citation": "\"Kentucky, County Marriages, 1786-1965\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:Q28D-N9C1 : Sat Feb 24 06:22:54 UTC 2024), Entry for Moses McCarley and Moses Mccarley, 21 Nov 1817.",
+      "url": "https://familysearch.org/ark:/61903/1:1:Q28D-N9Z9"
+    },
+    {
+      "id": "MMLG-KFY",
+      "title": "Legacy NFS Source: Moses J McCarley - Published information: birth: about January 1767; Pendleton, Anderson, South Carolina, United States"
+    },
+    {
+      "id": "3538-23Z",
+      "title": "Mofes Mccarley, \"Kentucky, County Marriages, 1786-1965\"",
+      "citation": "\"Kentucky, County Marriages, 1786-1965\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:Q28D-XW9Y : Sat Feb 24 07:49:40 UTC 2024), Entry for Westley Alverson and Salvina Mccarley, 28 Apr 1827.",
+      "url": "https://familysearch.org/ark:/61903/1:1:Q28D-XWSS"
+    },
+    {
+      "id": "9NMT-YDW",
+      "title": "Moses McCarley, \"Find a Grave Index\"",
+      "citation": "\"Find a Grave Index\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:QVG3-8WK7 : Wed Apr 02 09:20:48 UTC 2025), Entry for Moses McCarley, 1844.",
+      "url": "https://familysearch.org/ark:/61903/1:1:QVG3-8WK7"
+    },
+    {
+      "id": "SC7L-TN9",
+      "title": "Moses McCarley, \"Kentucky, County Marriages, 1786-1965\"",
+      "citation": "\"Kentucky, County Marriages, 1786-1965\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:Q28D-NHWN : Sat Feb 24 07:50:21 UTC 2024), Entry for Moses McCarley and Elizabeth Patt, 24 Jul 1792.",
+      "url": "https://familysearch.org/ark:/61903/1:1:Q28D-NHWN"
+    }
+  ]
+}


### PR DESCRIPTION
New spouse-question fixture from FamilySearch PID L7P6-3TT.

Question: Who was the spouse of Moses J McCarley Sr (b. 1767, d. 1844)? Answer to recover: Elizabeth Patton, married 24 Jul 1792 in Lincoln County, Kentucky.

Stripped: the spouse (Elizabeth Patton), the couple/marriage relationship and marriage fact, the three KY county-marriage records, and a thin stray second-spouse stub ('Boyd') so no spouse remains. Left as anchors: parents, the ten children (linked to Moses), the 1810 census, and Find a Grave.

Reachability confirmed before authoring (the 1792 Lincoln Co. marriage is the #1 indexed hit). Scored run passes (verdict pass, completed); the agent recovered both findings from records and concluded at 'probable' tier. Blind calibration annotation included (f1 true, f2 true, proof quality 2).

New spouse-question e2e fixture from FamilySearch PID L7P6-3TT.

Question: Who was the spouse of Moses J McCarley Sr (b. 1767, d. 1844)?
Answer to recover: Elizabeth Patton, married 24 Jul 1792 in Lincoln
County, Kentucky.

Stripped: the spouse, the couple/marriage relationship and marriage
fact, the three KY county-marriage records, and a thin stray
second-spouse stub ("Boyd") so no spouse remains. Left as anchors:
parents, the ten children (linked to Moses), the 1810 census, and Find
a Grave.

Reachability was confirmed before authoring (the 1792 Lincoln Co.
marriage is the #1 indexed hit). Scored run passes (verdict pass,
completed); the agent recovered both findings from records and concluded
at "probable" tier (spouse name rests on a single direct source; the
original register image was too large to read). Blind calibration
annotation included (f1 true, f2 true, proof quality 2).
