### PR TITLE
Add commit-msg hook nudging for human co-author trailers

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+# Git hooks must keep LF endings on every platform.
+#
+# Git for Windows defaults core.autocrlf=true, which would otherwise check these
+# out with CRLF. A `#!/bin/sh` script with CRLF endings does not run: the
+# trailing \r turns `exit 0` into `exit $'0\r'` ("numeric argument required"),
+# which exits 255. For commit-msg that non-zero exit makes git REJECT the
+# commit — inverting the hook's "warn, never block" contract for exactly the
+# Windows teammates it is meant to help.
+scripts/git-hooks/** text eol=lf

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -25,6 +25,16 @@ After building, both artifacts land in `releases/`:
 ls releases/
 ```
 
+## Git hooks
+
+Run `make install-hooks` once per clone (opt-in, per-clone) to symlink our
+shared hooks: `post-checkout` auto-links shared files into new worktrees, and
+`commit-msg` warns (never blocks) when a commit lacks a **human**
+`Co-authored-by:` trailer. When you pair, credit the other contributor so it
+survives our squash-merges — `Co-authored-by: Their Name <their-github-email>`
+as the last line of the commit message. Claude/AI co-authors don't satisfy the
+check.
+
 ## Smoke-test tools against live APIs
 
 Bypass the MCP harness to debug a tool in isolation:

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -27,13 +27,33 @@ ls releases/
 
 ## Git hooks
 
-Run `make install-hooks` once per clone (opt-in, per-clone) to symlink our
-shared hooks: `post-checkout` auto-links shared files into new worktrees, and
-`commit-msg` warns (never blocks) when a commit lacks a **human**
-`Co-authored-by:` trailer. When you pair, credit the other contributor so it
-survives our squash-merges — `Co-authored-by: Their Name <their-github-email>`
-as the last line of the commit message. Claude/AI co-authors don't satisfy the
-check.
+Once per clone (opt-in, per-clone), run `make install-hooks` — or on Windows,
+double-click **`InstallHooks.bat`**. Both install the same two hooks:
+`post-checkout` auto-links shared files into new worktrees, and `commit-msg`
+warns (never blocks) when a commit lacks a **human** `Co-authored-by:` trailer.
+
+What gets installed into `.git/hooks/` is a stub (`scripts/git-hooks/shim.sh`)
+that re-runs the tracked hook, so editing anything under `scripts/git-hooks/`
+takes effect immediately — there's nothing to reinstall after a pull. Rerun the
+installer only when a *new* hook is added to the list.
+
+### Crediting a co-author
+
+Nearly every PR here is paired work, but the co-author usually goes unrecorded —
+that's what the `commit-msg` hook is there to catch. We squash-merge, and GitHub
+folds the `Co-authored-by:` trailers from a PR's commits into the squash commit,
+so your local commits are the only place that credit can come from. When you
+pair, add the other contributor's **GitHub username** as the last line of the
+commit message:
+
+```
+Co-authored-by: their-github-username
+```
+
+The bare username is deliberate: it's the key our contribution-evaluation agents
+read out of `git log`, and it keeps personal email addresses out of the repo.
+Don't "fix" it by adding an address. Claude/AI co-authors don't satisfy the
+check — the whole point is recording the human you worked with.
 
 ## Smoke-test tools against live APIs
 

--- a/InstallHooks.bat
+++ b/InstallHooks.bat
@@ -1,0 +1,85 @@
+@echo off
+cd %~dp0
+
+echo === Cowork Genealogy - Install shared git hooks ===
+echo.
+echo The Windows counterpart to 'make install-hooks'. Installs two hooks into
+echo this clone's shared .git\hooks, covering every worktree of the clone:
+echo.
+echo   post-checkout - auto-links shared dev files into a newly-added worktree
+echo   commit-msg    - warns (never blocks) when a commit records no human
+echo                   Co-authored-by trailer
+echo.
+echo Opt-in and per-clone. Touches only local .git state, never core.hooksPath,
+echo so it cannot disable husky or other hook tooling, and is invisible to
+echo teammates who don't run it. Safe to rerun.
+echo.
+
+REM --- Locate the SHARED .git dir (resolves to the primary worktree's, from
+REM     inside any linked worktree) ---
+set "COMMON="
+for /f "delims=" %%i in ('git rev-parse --path-format=absolute --git-common-dir 2^>nul') do set "COMMON=%%i"
+if "%COMMON%"=="" (
+    echo ERROR: not inside a git repository, or git is not on PATH.
+    pause
+    exit /b 1
+)
+REM git prints forward slashes on Windows; normalize.
+set "COMMON=%COMMON:/=\%"
+
+REM --- The primary worktree is the parent of the common .git dir ---
+for %%i in ("%COMMON%") do set "MAIN=%%~dpi"
+if "%MAIN:~-1%"=="\" set "MAIN=%MAIN:~0,-1%"
+
+set "SHIM=%MAIN%\scripts\git-hooks\shim.sh"
+if not exist "%SHIM%" (
+    echo ERROR: %SHIM% not found.
+    echo The hooks live on the primary worktree's checked-out branch. Switch it
+    echo to a branch that has scripts\git-hooks\shim.sh, then rerun.
+    pause
+    exit /b 1
+)
+
+if not exist "%COMMON%\hooks" mkdir "%COMMON%\hooks"
+
+for %%h in (post-checkout commit-msg) do (
+    call :install "%%h"
+    if errorlevel 1 goto :failed
+)
+
+echo.
+echo === Hooks installed ===
+echo Editing scripts\git-hooks\^<name^> takes effect immediately - the installed
+echo file is a stub that re-runs the tracked hook, so there is nothing to
+echo reinstall after a pull.
+echo.
+pause
+exit /b 0
+
+:install
+set "HOOK=%~1"
+set "DST=%COMMON%\hooks\%HOOK%"
+if exist "%DST%" (
+    findstr /c:"cowork-genealogy managed hook shim" "%DST%" >nul 2>nul
+    if errorlevel 1 (
+        echo.
+        echo install-hooks: %DST%
+        echo   already exists and is not ours - not overwriting. Merge it
+        echo   manually, then rerun.
+        exit /b 1
+    )
+    del /q "%DST%"
+)
+copy /y "%SHIM%" "%DST%" >nul
+if errorlevel 1 (
+    echo ERROR: failed to copy the shim to %DST%
+    exit /b 1
+)
+echo   installed %HOOK% hook -^> %DST%
+exit /b 0
+
+:failed
+echo.
+echo === Install aborted ===
+pause
+exit /b 1

--- a/Makefile
+++ b/Makefile
@@ -104,22 +104,25 @@ reinstall: clean-deps ## Clean every node_modules, then install EVERYTHING from 
 worktree-link: ## Symlink shared gitignored files (secrets, node_modules) from the primary worktree into this one
 	@scripts/link-worktree.sh
 
-# Symlink our post-checkout hook into the shared .git/hooks (covers every
-# worktree of this clone). Opt-in and per-clone: it touches only local .git
-# state, never core.hooksPath, so it can't disable husky/other hook tooling and
-# is invisible to teammates who don't run it. Refuses to clobber a pre-existing
-# non-symlink hook.
+# Symlink our shared git hooks into the shared .git/hooks (covers every worktree
+# of this clone): post-checkout auto-links shared files into new worktrees;
+# commit-msg warns when a commit has no human Co-authored-by trailer. Opt-in and
+# per-clone: it touches only local .git state, never core.hooksPath, so it can't
+# disable husky/other hook tooling and is invisible to teammates who don't run
+# it. Refuses to clobber a pre-existing non-symlink hook.
 .PHONY: install-hooks
-install-hooks: ## Install the post-checkout hook so new worktrees auto-link shared files (opt-in, per-clone)
+install-hooks: ## Install shared git hooks (post-checkout, commit-msg) — opt-in, per-clone
 	@common=$$(git rev-parse --path-format=absolute --git-common-dir); \
 	 main=$$(dirname "$$common"); \
-	 dst="$$common/hooks/post-checkout"; \
-	 if [ -e "$$dst" ] && [ ! -L "$$dst" ]; then \
-	   echo "install-hooks: $$dst already exists and is not a symlink — not overwriting. Merge manually." >&2; exit 1; \
-	 fi; \
 	 mkdir -p "$$common/hooks"; \
-	 ln -sfn "$$main/scripts/git-hooks/post-checkout" "$$dst"; \
-	 echo "✓ installed post-checkout hook -> $$dst"
+	 for hook in post-checkout commit-msg; do \
+	   dst="$$common/hooks/$$hook"; \
+	   if [ -e "$$dst" ] && [ ! -L "$$dst" ]; then \
+	     echo "install-hooks: $$dst already exists and is not a symlink — not overwriting. Merge manually." >&2; exit 1; \
+	   fi; \
+	   ln -sfn "$$main/scripts/git-hooks/$$hook" "$$dst"; \
+	   echo "✓ installed $$hook hook -> $$dst"; \
+	 done
 
 # ── Dev (the POC: run a server + a web client in two terminals) ──
 # See DEVELOPMENT.md for the full matrix. The web target must match the server's

--- a/Makefile
+++ b/Makefile
@@ -104,23 +104,38 @@ reinstall: clean-deps ## Clean every node_modules, then install EVERYTHING from 
 worktree-link: ## Symlink shared gitignored files (secrets, node_modules) from the primary worktree into this one
 	@scripts/link-worktree.sh
 
-# Symlink our shared git hooks into the shared .git/hooks (covers every worktree
+# Install our shared git hooks into the shared .git/hooks (covers every worktree
 # of this clone): post-checkout auto-links shared files into new worktrees;
 # commit-msg warns when a commit has no human Co-authored-by trailer. Opt-in and
 # per-clone: it touches only local .git state, never core.hooksPath, so it can't
 # disable husky/other hook tooling and is invisible to teammates who don't run
-# it. Refuses to clobber a pre-existing non-symlink hook.
+# it. Refuses to clobber a hook that isn't ours.
+#
+# We copy scripts/git-hooks/shim.sh (a stub that re-execs the tracked hook)
+# rather than symlink the hook itself, so InstallHooks.bat can do the identical
+# thing on Windows, where file symlinks need admin rights. See shim.sh for why.
+# Keep the two installers in step.
+#
+# The `rm -f` before `cp` is load-bearing, not tidiness: upgrading from the old
+# symlink install, `cp` would follow the symlink and write the shim straight into
+# the tracked scripts/git-hooks/<hook> it points at.
 .PHONY: install-hooks
 install-hooks: ## Install shared git hooks (post-checkout, commit-msg) — opt-in, per-clone
 	@common=$$(git rev-parse --path-format=absolute --git-common-dir); \
 	 main=$$(dirname "$$common"); \
+	 shim="$$main/scripts/git-hooks/shim.sh"; \
+	 [ -f "$$shim" ] || { echo "install-hooks: $$shim not found — check out a branch that has it." >&2; exit 1; }; \
 	 mkdir -p "$$common/hooks"; \
 	 for hook in post-checkout commit-msg; do \
 	   dst="$$common/hooks/$$hook"; \
-	   if [ -e "$$dst" ] && [ ! -L "$$dst" ]; then \
-	     echo "install-hooks: $$dst already exists and is not a symlink — not overwriting. Merge manually." >&2; exit 1; \
+	   if [ -e "$$dst" ] || [ -L "$$dst" ]; then \
+	     if [ ! -L "$$dst" ] && ! grep -q 'cowork-genealogy managed hook shim' "$$dst" 2>/dev/null; then \
+	       echo "install-hooks: $$dst already exists and is not ours — not overwriting. Merge manually." >&2; exit 1; \
+	     fi; \
+	     rm -f "$$dst"; \
 	   fi; \
-	   ln -sfn "$$main/scripts/git-hooks/$$hook" "$$dst"; \
+	   cp "$$shim" "$$dst"; \
+	   chmod +x "$$dst"; \
 	   echo "✓ installed $$hook hook -> $$dst"; \
 	 done
 

--- a/scripts/git-hooks/commit-msg
+++ b/scripts/git-hooks/commit-msg
@@ -1,0 +1,44 @@
+#!/bin/sh
+# commit-msg — nudge for a human Co-authored-by trailer on paired commits.
+#
+# We squash-merge on GitHub, and GitHub folds the Co-authored-by trailers from a
+# PR's commits into the squash commit — so the only place credit gets recorded
+# is on your local commits. This hook reminds you to add the trailer when someone
+# paired with you. It is a WARNING, not a gate: some work is genuinely solo, so a
+# missing trailer never blocks the commit (exit 0 always).
+#
+# "Human" excludes AI co-authors: any `Co-authored-by:` whose email is
+# @anthropic.com (the Claude trailer this repo appends) does not count. Add other
+# AI/bot domains to BOT_RE below if we start using them.
+#
+# Args: <path-to-commit-message-file>. Trailers are extracted with
+# `git interpret-trailers --parse`, which finds the trailer block and skips the
+# `#` comment lines and any --verbose diff, so we don't hand-parse the message.
+#
+# Installed into the shared .git/hooks/ by `make install-hooks` (NOT via
+# core.hooksPath, so it cannot disable husky or other hook tooling). The source
+# of truth is this file, scripts/git-hooks/commit-msg, tracked in the repo.
+
+BOT_RE='@anthropic\.com>'
+
+# Merge commits have no "co-author" concept — don't cry wolf on them.
+git_dir=$(git rev-parse --git-dir 2>/dev/null) || exit 0
+[ -e "$git_dir/MERGE_HEAD" ] && exit 0
+
+human=$(git interpret-trailers --parse "$1" 2>/dev/null \
+  | grep -i '^Co-authored-by:' \
+  | grep -vi "$BOT_RE")
+
+if [ -z "$human" ]; then
+  printf '%s\n' \
+    "commit-msg: ⚠ no human Co-authored-by trailer found." \
+    "  If someone paired with you on this commit, credit them so it survives the" \
+    "  squash-merge:" \
+    "" \
+    "    Co-authored-by: Their Name <their-github-email>" \
+    "" \
+    "  (Claude/AI co-authors don't count.) Solo work? Ignore this — the commit is" \
+    "  proceeding; this is only a reminder." >&2
+fi
+
+exit 0

--- a/scripts/git-hooks/commit-msg
+++ b/scripts/git-hooks/commit-msg
@@ -7,27 +7,37 @@
 # paired with you. It is a WARNING, not a gate: some work is genuinely solo, so a
 # missing trailer never blocks the commit (exit 0 always).
 #
-# "Human" excludes AI co-authors: any `Co-authored-by:` whose email is
-# @anthropic.com (the Claude trailer this repo appends) does not count. Add other
-# AI/bot domains to BOT_RE below if we start using them.
+# "Human" excludes AI co-authors, matched two ways because our trailer format is
+# a bare GitHub username with no email to key on:
+#   - address @anthropic.com — the trailer Claude Code appends automatically
+#   - name field starting with "Claude" — what the bare-username form produces
+# Add further AI/bot names or domains as alternatives. BOT_RE is an ERE (matched
+# with grep -E), so alternatives are separated by `|`. The trailing
+# ([[:space:]]|$) keeps "Claude" from prefix-matching a real person — a
+# co-author named Claudette is human and passes; one named exactly Claude does
+# not, and would need crediting under their GitHub username.
 #
 # Args: <path-to-commit-message-file>. Trailers are extracted with
 # `git interpret-trailers --parse`, which finds the trailer block and skips the
 # `#` comment lines and any --verbose diff, so we don't hand-parse the message.
 #
-# Installed into the shared .git/hooks/ by `make install-hooks` (NOT via
-# core.hooksPath, so it cannot disable husky or other hook tooling). The source
-# of truth is this file, scripts/git-hooks/commit-msg, tracked in the repo.
+# Installed into the shared .git/hooks/ by `make install-hooks` (macOS/Linux) or
+# InstallHooks.bat (Windows) — NOT via core.hooksPath, so it cannot disable husky
+# or other hook tooling. The source of truth is this file,
+# scripts/git-hooks/commit-msg, tracked in the repo.
 
-BOT_RE='@anthropic\.com>'
+BOT_RE='@anthropic\.com>|^Co-authored-by:[[:space:]]*Claude([[:space:]]|$)'
 
 # Merge commits have no "co-author" concept — don't cry wolf on them.
 git_dir=$(git rev-parse --git-dir 2>/dev/null) || exit 0
 [ -e "$git_dir/MERGE_HEAD" ] && exit 0
 
+# Test the OUTPUT, not grep's exit status. `printf '' | grep -qv x` exits 0 on
+# BSD/macOS grep but 1 on GNU grep, so an exit-status version of this check would
+# silently pass every trailer-less commit on a Mac.
 human=$(git interpret-trailers --parse "$1" 2>/dev/null \
   | grep -i '^Co-authored-by:' \
-  | grep -vi "$BOT_RE")
+  | grep -Evi "$BOT_RE")
 
 if [ -z "$human" ]; then
   printf '%s\n' \
@@ -35,7 +45,7 @@ if [ -z "$human" ]; then
     "  If someone paired with you on this commit, credit them so it survives the" \
     "  squash-merge:" \
     "" \
-    "    Co-authored-by: Their Name <their-github-email>" \
+    "    Co-authored-by: their-github-username" \
     "" \
     "  (Claude/AI co-authors don't count.) Solo work? Ignore this — the commit is" \
     "  proceeding; this is only a reminder." >&2

--- a/scripts/git-hooks/shim.sh
+++ b/scripts/git-hooks/shim.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+# cowork-genealogy managed hook shim — do not edit.
+#
+# `make install-hooks` / InstallHooks.bat copies this stub to .git/hooks/<name>
+# for each hook we ship. It dispatches on its own filename, so one file serves
+# every hook: installed as .git/hooks/commit-msg it runs the tracked
+# scripts/git-hooks/commit-msg.
+#
+# Why a copied stub rather than a symlink to the real hook: Windows file
+# symlinks need admin rights or Developer Mode (`mklink /J` junctions sidestep
+# that but only work for directories, not files), so a symlink install has no
+# Windows counterpart. And why a stub rather than copying the hook itself:
+# a copy goes stale — this re-resolves and re-execs the tracked hook on every
+# run, so editing scripts/git-hooks/<name> takes effect with no reinstall.
+#
+# The tracked hooks live in the PRIMARY worktree, so resolve through
+# --git-common-dir (shared by every linked worktree) rather than
+# --show-toplevel (which is whichever worktree we happen to be in).
+#
+# The marker comment on line 2 is how the installers recognize their own work
+# and refuse to clobber a foreign hook. Keep it.
+
+name=$(basename "$0")
+src="$(dirname "$(git rev-parse --path-format=absolute --git-common-dir)")/scripts/git-hooks/$name"
+
+# Absent or non-executable means this branch predates the hook (or someone is
+# mid-rebase on an old commit). Stay silent and let the operation through rather
+# than failing it.
+[ -x "$src" ] || exit 0
+
+exec "$src" "$@"


### PR DESCRIPTION
## Why

A developer and a genealogist pair on nearly every PR, but only one person
submits — and the co-author usually goes unrecorded. Since we **squash-merge**
on GitHub — which folds the per-commit `Co-authored-by:` trailers into the
squash commit — the paired contributor only gets credited if the trailer is on
the local commits. This adds a lightweight, non-blocking nudge so credit is
captured, which downstream contribution-evaluation agents can then read straight
from `git log`.

## The trailer format

Credit the human by **bare GitHub username**, as the last line of the commit
message:

```
Co-authored-by: their-github-username
```

No email address. The username is the key our contribution-evaluation agents
read out of `git log`, and it keeps personal email addresses out of the repo.

Trade-off accepted knowingly: GitHub links a co-author to their account *only*
via the `Name <email>` form, so a bare username produces no avatar and no
contribution-graph credit. `git log` is the record we care about.

## What

- **`scripts/git-hooks/commit-msg`** (new) — warns, never blocks:
  - Extracts trailers with `git interpret-trailers --parse`, so it handles
    lowercase `co-authored-by:`, skips `#` comments and `--verbose` diffs, and
    isn't fooled by a `Co-authored-by:` line inside a diff body.
  - "Human" excludes AI co-authors two ways, since a bare username leaves no
    email to key on: an `@anthropic.com` address, **or** a name field of
    `Claude...`. Anchored with `([[:space:]]|$)` so a real person named
    Claudette still counts as human.
  - Skips merge commits (`MERGE_HEAD`); always `exit 0` — solo work is fine.
- **`scripts/git-hooks/shim.sh`** (new) — what actually gets installed into
  `.git/hooks/<name>`: a self-dispatching stub (keys off `basename "$0"`, so one
  file serves every hook) that re-execs the tracked hook.
  - *Why not a symlink:* Windows file symlinks need admin rights or Developer
    Mode (`mklink /J` junctions sidestep that but are directory-only), so the
    symlink install had no Windows counterpart.
  - *Why not copy the hook itself:* a copy goes stale. The stub re-resolves on
    every run, so editing `scripts/git-hooks/<name>` takes effect with **no
    reinstall**.
- **`InstallHooks.bat`** (new) — the Windows counterpart to `make install-hooks`.
- **`.gitattributes`** (new) — forces LF on `scripts/git-hooks/**`. A
  correctness fix, not hygiene — see below.
- **`Makefile`** — `install-hooks` copies the shim for both hooks, keeping a
  refuse-to-clobber-a-foreign-hook guard.
- **`DEVELOPMENT.md`** — documents the trailer convention + both installers.

## The CRLF landmine

The repo had no `.gitattributes`, and Git for Windows defaults
`core.autocrlf=true`. Simulating a Windows clone of this PR's first draft:

```
no  .gitattributes : CR bytes = 54  -> hook exits 255 -> git REJECTS the commit
with .gitattributes : CR bytes = 0   -> hook exits 0   -> warns only
```

CRLF turns `exit 0` into `exit $'0\r'` ("numeric argument required"), which
returns 255. A non-zero `commit-msg` exit is a rejection — so without this the
hook would have **blocked every commit** for the Windows-based genealogist team,
the exact inverse of its contract.

Note: every `*.sh` in the repo has the same latent exposure
(`link-worktree.sh`, `setup-feedback-case.sh`). Out of scope here; a repo-wide
`*.sh text eol=lf` is a reasonable follow-up.

## Activation

Per-clone and opt-in (unchanged model): each teammate runs `make install-hooks`
once, or double-clicks **`InstallHooks.bat`** on Windows.

No longer "after merge only" — the shim exits 0 when the hook isn't on the
branch yet, so an early install is inert rather than broken.

## Verified

Hook: solo → warns; Claude-only (with *or* without the email) → warns; bare
username → silent; username+email → silent; human+Claude → silent;
`Claudette Dubois` → silent; adversarial messy message (lowercase key / comment /
`--verbose` diff with a spoofed trailer) → warns, not fooled.

Install: clean, idempotent, refuses a foreign hook without touching it, and
survives the upgrade from the old symlink install — the `rm -f` before `cp`
matters, since `cp` through the old symlink would write the shim straight into
the tracked hook. End-to-end real commits land in both the warn and silent
cases, and editing the tracked hook takes effect with no reinstall.

⚠️ **`InstallHooks.bat` is desk-checked but has not been run on Windows.** It
needs a smoke test from a Windows teammate before we rely on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
