### PR TITLE
Force LF on shell scripts so they run on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,16 @@
+# Shell scripts must keep LF endings on every platform.
+#
+# Git for Windows defaults core.autocrlf=true, so without this these files check
+# out with CRLF on a Windows clone — and a `#!/bin/sh` script with CRLF does not
+# run under Git Bash. The trailing \r becomes part of the last token on every
+# line: `set -eu` parses as `set -eu<CR>` ("invalid option", exit 2), `exit 0` as
+# `exit $'0\r'` ("numeric argument required", exit 255).
+#
+# Not hypothetical. The post-checkout hook runs scripts/link-worktree.sh on
+# `git worktree add`, and calls it with `|| true` so as never to fail a
+# checkout — meaning on Windows it fails *silently*, leaving the new worktree
+# with no linked node_modules or .env and no clue why.
+#
+# Extensionless scripts (git hooks) are covered separately, next to the hooks
+# themselves.
+*.sh text eol=lf


### PR DESCRIPTION
## Why

Git for Windows defaults `core.autocrlf=true`, and this repo has no
`.gitattributes` — so every tracked `*.sh` currently checks out with **CRLF** on
a Windows clone. A `#!/bin/sh` script with CRLF does not run under Git Bash: the
trailing `\r` joins the last token on every line, so `set -eu` parses as
`set -eu<CR>` → `set: -: invalid option`.

## Reachable today, not theoretical

The `post-checkout` hook runs `scripts/link-worktree.sh` on `git worktree add`,
and calls it with `|| true` so it can never fail a checkout. On Windows that
means it fails **silently** — the new worktree comes up with no linked
`node_modules` and no `.env`, and nothing says why.

## Verified

Simulated a Git-for-Windows clone (`core.autocrlf=true`) of
`scripts/link-worktree.sh`:

```
main today   : CR bytes = 51 -> sh exits 2, "set: -: invalid option" — never runs
with this PR : CR bytes = 0  -> runs, and reports its own guard as designed
```

The distinction matters: on `main` the shell dies in the parser, so the script
never executes. With the fix it executes and behaves normally.

## Scope

Covers the 8 tracked shell scripts:

```
apps/server/run-dev.sh          scripts/package-plugin.sh
apps/server/sandbox/build-image.sh   scripts/setup-feedback-case.sh
scripts/build-mcpb.sh           scripts/test.sh
scripts/link-worktree.sh        scripts/verify-mcpb.sh
```

Extensionless git hooks (`commit-msg`, `post-checkout`) are **not** matched by
`*.sh`. They're covered separately by #687, which adds
`scripts/git-hooks/** text eol=lf` — there the same CRLF bug made `exit 0` parse
as `exit $'0\r'` → exit 255, which turned the warn-only `commit-msg` hook into
one that blocked every commit on Windows.

Tracked `*.py` scripts carry shebangs too, but they're invoked via
`uv run python -m ...` rather than executed directly, and Python tolerates CRLF
in source — so they're deliberately left alone.

## ⚠️ Merge note

**Both this PR and #687 create `.gitattributes`.** Whichever lands second takes a
trivial add/add conflict; the resolution is to keep both lines. Happy to rebase
this once #687 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
