### PR TITLE
eval: make calibrate_judge read eval/.env and fail loudly without a key

### DIFF
--- a/eval/harness/e2e/calibrate_judge.py
+++ b/eval/harness/e2e/calibrate_judge.py
@@ -52,12 +52,14 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
 from e2e import judge as judge_module
+from e2e.env import ENV_FILE, load_env_file
 from e2e.judge import derive_verdict  # shared with apply_avoid_guard; re-exported for our callers
 
 
@@ -500,6 +502,23 @@ def main(argv: list[str] | None = None) -> int:
     if not cases:
         print(
             "\nNothing graded yet — no complete annotations to calibrate against.",
+            file=sys.stderr,
+        )
+        return 2
+
+    # The judge reads ANTHROPIC_API_KEY from the process env; the key normally
+    # lives in eval/.env (Setup.bat writes it there), so load it the way every
+    # other e2e entry point does. Check up front and abort: without a key every
+    # case fails with an auth error, and because case errors block the target
+    # the sweep would report "BELOW target" — an auth problem indistinguishable
+    # from a judge that genuinely missed the gate, on the one number this script
+    # exists to produce. Fail loudly instead of reporting a grade nobody earned.
+    load_env_file()
+    if not os.environ.get("ANTHROPIC_API_KEY"):
+        print(
+            f"\nNo ANTHROPIC_API_KEY. Set it in the environment or in {ENV_FILE} "
+            "(Setup.bat prompts for it). The judge needs it — nothing was "
+            "graded, so this is not a calibration result.",
             file=sys.stderr,
         )
         return 2

--- a/eval/harness/e2e/env.py
+++ b/eval/harness/e2e/env.py
@@ -1,0 +1,37 @@
+"""Judge auth from eval/.env — shared by every e2e entry point.
+
+eval/.env holds ANTHROPIC_API_KEY (written by Setup.bat). The judge talks to
+the Anthropic API directly via the SDK, which reads ANTHROPIC_API_KEY from the
+process env — so without this the judge fails to authenticate. In run_e2e that
+surfaces as "agent ran, judge skipped"; in calibrate_judge it surfaced as every
+case erroring and the sweep reporting BELOW target (an auth problem wearing a
+judge-quality problem's clothes). A key already set in the shell wins.
+
+This lives in its own module rather than in run_e2e because calibrate_judge
+needs it too, and importing run_e2e would pull in e2e.orchestrator ->
+claude_agent_sdk at import time. Calibration must stay importable and runnable
+offline (see calibrate_judge's module docstring), so the shared piece has to be
+dependency-light: stdlib + dotenv, nothing else.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+# eval/.env — two levels up from eval/harness/e2e/.
+ENV_FILE = Path(__file__).resolve().parents[2] / ".env"
+
+
+def load_env_file(env_file: Path = ENV_FILE) -> None:
+    """Load keys from eval/.env into os.environ without overriding the shell."""
+    if not env_file.exists():
+        return
+    try:
+        from dotenv import dotenv_values
+    except ImportError:
+        return
+    for key, value in dotenv_values(env_file).items():
+        if value is not None and not os.environ.get(key):
+            os.environ[key] = value

--- a/eval/harness/e2e/run_e2e.py
+++ b/eval/harness/e2e/run_e2e.py
@@ -27,30 +27,17 @@ from e2e.orchestrator import (
     DEFAULT_RUNLOG_ROOT,
     run_e2e_test,
 )
+from e2e.env import ENV_FILE, load_env_file
 from e2e.report import print_rollup
 from e2e.result import E2eResult, is_committable_run
 
 
-# eval/.env holds ANTHROPIC_API_KEY (written by Setup.bat). The judge talks
-# to the Anthropic API directly via the SDK, which reads ANTHROPIC_API_KEY
-# from the process env — so without this the judge fails to authenticate
-# and every run comes back verdict=skipped. The agent run itself uses the
-# Claude Agent SDK's own auth and is unaffected, which is why the symptom
-# is "agent ran, judge skipped". A key already set in the shell wins.
-_ENV_FILE = Path(__file__).resolve().parents[2] / ".env"
-
-
-def load_env_file(env_file: Path = _ENV_FILE) -> None:
-    """Load keys from eval/.env into os.environ without overriding the shell."""
-    if not env_file.exists():
-        return
-    try:
-        from dotenv import dotenv_values
-    except ImportError:
-        return
-    for key, value in dotenv_values(env_file).items():
-        if value is not None and not os.environ.get(key):
-            os.environ[key] = value
+# Judge auth from eval/.env. Lives in e2e.env so calibrate_judge can share it
+# without importing this module (which pulls in claude_agent_sdk via
+# e2e.orchestrator). Re-exported here: the agent run uses the Claude Agent SDK's
+# own auth and is unaffected, which is why the symptom of a missing key is
+# "agent ran, judge skipped".
+_ENV_FILE = ENV_FILE  # back-compat alias
 
 
 def _list_fixture_dirs(fixtures_root: Path) -> list[Path]:

--- a/eval/harness/tests/unit/test_e2e_calibrate_env.py
+++ b/eval/harness/tests/unit/test_e2e_calibrate_env.py
@@ -1,0 +1,110 @@
+"""calibrate_judge must read eval/.env, and must fail loudly without a key.
+
+The judge reads ANTHROPIC_API_KEY from the process env; the key normally lives
+in eval/.env. calibrate_judge used to be the only e2e entry point that didn't
+load it, so `make e2e-calibrate` on a machine with the key only in eval/.env
+graded nothing, errored on every case, and — because case errors block the
+target — reported "BELOW target". An auth misconfiguration is not a
+judge-quality result, and must not be reported as one.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+from e2e import calibrate_judge
+
+
+def test_calibrate_judge_does_not_import_agent_sdk():
+    """Calibration stays runnable offline — the shared env helper must not drag
+    in claude_agent_sdk the way importing run_e2e would (calibrate_judge's
+    module docstring depends on this). Checked in a subprocess: under pytest,
+    sibling test modules have already imported the SDK into sys.modules, so an
+    in-process assertion would pass vacuously.
+    """
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import sys; import e2e.calibrate_judge; "
+            "print('claude_agent_sdk' in sys.modules)",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert proc.stdout.strip() == "False", (
+        "calibrate_judge now pulls in claude_agent_sdk at import time — "
+        "it must stay runnable offline"
+    )
+
+
+def test_env_helper_is_shared_with_run_e2e():
+    """One loader, not two copies (the repo's code-reuse rule)."""
+    from e2e.env import load_env_file as shared
+    from e2e.run_e2e import load_env_file as reexported
+
+    assert calibrate_judge.load_env_file is shared
+    assert reexported is shared
+
+
+def test_missing_key_aborts_before_grading(tmp_path, monkeypatch, capsys):
+    """No key -> exit 2 with an auth message, and zero judge calls. The old
+    behavior graded every case into an auth error and printed BELOW target."""
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    # eval/.env may exist on a dev machine — point the loader at an empty dir
+    # so the test measures the no-key path rather than the developer's key.
+    monkeypatch.setattr(calibrate_judge, "load_env_file", lambda *a, **k: None)
+
+    monkeypatch.setattr(
+        calibrate_judge, "load_annotated_runs",
+        lambda *a, **k: ([{"slug": "x"}], []),
+    )
+
+    def _boom(*a, **k):  # pragma: no cover - must never run
+        raise AssertionError("graded a case despite having no API key")
+
+    monkeypatch.setattr(calibrate_judge, "grade_case", _boom)
+
+    runlog_root = tmp_path / "runlogs"
+    runlog_root.mkdir()
+    rc = calibrate_judge.main(["--runlog-root", str(runlog_root)])
+
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "ANTHROPIC_API_KEY" in err
+    assert "not a calibration result" in err
+    assert "BELOW target" not in err
+
+
+def test_key_present_proceeds_to_grading(tmp_path, monkeypatch):
+    """With a key, the sweep runs — the guard must not block the happy path."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+    monkeypatch.setattr(calibrate_judge, "load_env_file", lambda *a, **k: None)
+    monkeypatch.setattr(
+        calibrate_judge, "load_annotated_runs",
+        lambda *a, **k: ([{"slug": "x"}], []),
+    )
+    graded = []
+    monkeypatch.setattr(
+        calibrate_judge, "grade_case",
+        lambda case, model=None: graded.append(case) or _stub_result(),
+    )
+    monkeypatch.setattr(calibrate_judge, "print_report", lambda r: None)
+    monkeypatch.setattr(
+        calibrate_judge.CalibrationReport, "meets_target", property(lambda self: True)
+    )
+
+    runlog_root = tmp_path / "runlogs"
+    runlog_root.mkdir()
+    rc = calibrate_judge.main(["--runlog-root", str(runlog_root)])
+
+    assert graded, "expected the sweep to grade the case"
+    assert rc == 0
+
+
+def _stub_result():
+    from e2e.calibrate_judge import CaseResult
+
+    return CaseResult(case_id="x/run-1")


### PR DESCRIPTION
Found while measuring judge nondeterminism for #712: `make e2e-calibrate` reported the judge **BELOW target** when the real problem was that it never authenticated.

## The bug

`calibrate_judge` is the only e2e entry point that doesn't load `eval/.env`:

| Entry point | Loads `eval/.env`? |
|---|---|
| `run_tests.py` (unit) | ✅ via `harness/auth.py::_load_api_key` |
| `e2e/run_e2e.py` | ✅ via `load_env_file()`, called explicitly for the judge |
| `e2e/preflight.py` | ✅ "Match the harness: a key in eval/.env counts" |
| **`e2e/calibrate_judge.py`** | ❌ |

The judge reads `ANTHROPIC_API_KEY` from the process env and `Setup.bat` writes the key to `eval/.env`, so on a machine where the key lives only there, calibration authenticated on zero cases.

## Why the failure mode is the actual bug

Every case failed with an auth `TypeError`; the broad per-case `except` recorded each one; case errors block `meets_target`; the sweep printed **"BELOW target"**. An auth misconfiguration is indistinguishable from a judge that genuinely missed its ≥80% gate — on the one number this script exists to produce, and for a Windows genealogist team whose key is exactly where the script wasn't looking.

It now loads `eval/.env`, checks for a key up front, and aborts with an auth message stating that nothing was graded, so it can't be read as a calibration result.

## Why a new module

`load_env_file` moves from `e2e/run_e2e.py` to a dependency-light `e2e/env.py`. `calibrate_judge` can't import it from `run_e2e` — that pulls in `e2e.orchestrator` → `claude_agent_sdk` at import time, and calibration must stay importable and runnable offline. That constraint is already load-bearing: `calibrate_judge:64` declines to import `DEFAULT_RUNLOG_ROOT` from the orchestrator for the same reason. `run_e2e` re-exports the name, so its call site and `tests/unit/test_e2e_run_env.py` are untouched. Copying the loader would have violated the code-reuse rule in CLAUDE.md.

## Verification

With **no key in the shell** (so this actually exercises the `.env` path):

- `--dry-run` → classifies 41 annotations, zero API calls.
- Full sweep → authenticates from `eval/.env` and reports **86% (92/107) per-finding agreement, MEETS target**.

Four new tests: the shared-loader identity, the loud-failure path (exit 2, auth message, no `BELOW target`, zero judge calls), the happy path still grading, and the offline-import property. That last one runs in a **subprocess** — under pytest, sibling test modules have already imported `claude_agent_sdk` into `sys.modules`, so an in-process assertion would pass vacuously.

Full harness suite: **990 passed, 2 skipped.**

## Note

Independent of #712 (judge `temperature=0`) and safe to land in either order — that PR touches `harness/judge.py` and docs; this one touches the e2e calibration path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
