### PR TITLE
gps-mentor: qualify tool names + document plugin-agent convention (#698)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,6 +151,16 @@ orchestrator auto-delegates to the agent. Agents run in fresh context
 explicitly specced otherwise. The first such agent is `gps-mentor`
 (spec: `docs/specs/gps-mentor-agent-spec.md`).
 
+**Qualified tool names.** In the `tools:` frontmatter, MCP tools **must**
+be listed under their fully-qualified `mcp__genealogy__*` names, never the
+bare tool name. A bare name leaves the subagent toolless in the
+unit-harness SDK path (only the e2e harness tolerated bare names, via its
+ToolSearch prefix allowlist); qualifying makes an agent behave identically
+across Cowork, the e2e harness, the unit harness, and the hosted web SDK
+path. Built-in Cowork tools that are not MCP tools — `Read` — stay bare.
+All three current agents follow this (`gps-mentor`, `image-reader`,
+`record-extractor`).
+
 ## Handling user feedback submissions
 
 When a user submits a feedback zip via the Cowork viewer, the workflow

--- a/docs/TODOs.md
+++ b/docs/TODOs.md
@@ -94,12 +94,16 @@ Deferred from `docs/plan/record-extraction-consolidation-plan.md` §7 at wrap.
   `record_persona_id`s nulled because the search never staged a sidecar
   (spriggs). D2 can't auto-fill what was never staged; the fix is
   search-skill-side (always pass `projectPath` / surface the staging failure).
-- [ ] **Bare agent-tool names in gps-mentor.md / image-reader.md** — the
-  agent-mode spike proved bare tool names leave a subagent toolless in the
-  unit-harness SDK path (needs `mcp__genealogy__*`), yet these two agents use
-  bare names and work in Cowork/e2e paths. Reconcile once the PR-3
-  investigation lands: qualify (or dual-list) so all agents work identically
-  in Cowork, the e2e harness, the unit harness, and the hosted web SDK path.
+- [x] **Bare agent-tool names in gps-mentor.md / image-reader.md — DONE
+  (#698).** The agent-mode spike proved bare tool names leave a subagent
+  toolless in the unit-harness SDK path (needs `mcp__genealogy__*`), yet the
+  agents used bare names and worked in Cowork/e2e paths (e2e tolerated them
+  via its ToolSearch prefix allowlist). All three agents now qualify their
+  MCP tools (`image-reader` and `record-extractor` earlier; `gps-mentor` in
+  #698, which also updated `docs/specs/gps-mentor-agent-spec.md`), so they
+  behave identically in Cowork, the e2e harness, the unit harness, and the
+  hosted web SDK path. The convention is documented in CLAUDE.md's "Cowork
+  plugin agents" section (built-in `Read` stays bare).
 
 - [x] **Extractor write authority is too broad (op-level restriction)** —
   **superseded by the `tree_edit`/`tree_correct` split (this commit,

--- a/docs/specs/gps-mentor-agent-spec.md
+++ b/docs/specs/gps-mentor-agent-spec.md
@@ -110,15 +110,21 @@ description: BCG-style senior genealogist who reviews research work and tells th
 model: claude-sonnet-5
 tools:
   - Read
-  - validate_research_schema
-  - place_search
-  - place_distance
-  - collections_search
-  - external_links_search
-  - wiki_place_page
-  - wiki_search
+  - mcp__genealogy__validate_research_schema
+  - mcp__genealogy__place_search
+  - mcp__genealogy__place_distance
+  - mcp__genealogy__collections_search
+  - mcp__genealogy__external_links_search
+  - mcp__genealogy__wiki_place_page
+  - mcp__genealogy__wiki_search
 ---
 ```
+
+The MCP tools **must** be listed under their fully-qualified
+`mcp__genealogy__*` names — bare names leave the subagent toolless in the
+unit-harness SDK path (only the e2e harness tolerated them, via its
+ToolSearch prefix allowlist). `Read` is a built-in Cowork tool, not an MCP
+tool, so it stays bare.
 
 **Model requirement:** `claude-sonnet-5`. The gates read and cross-reference large research
 files with careful analytical reasoning. Sonnet 5 — released after this spec was first written —

--- a/packages/engine/plugin/agents/gps-mentor.md
+++ b/packages/engine/plugin/agents/gps-mentor.md
@@ -19,13 +19,13 @@ description: >-
 model: claude-sonnet-5
 tools:
   - Read
-  - validate_research_schema
-  - place_search
-  - place_distance
-  - collections_search
-  - external_links_search
-  - wiki_place_page
-  - wiki_search
+  - mcp__genealogy__validate_research_schema
+  - mcp__genealogy__place_search
+  - mcp__genealogy__place_distance
+  - mcp__genealogy__collections_search
+  - mcp__genealogy__external_links_search
+  - mcp__genealogy__wiki_place_page
+  - mcp__genealogy__wiki_search
 ---
 
 # GPS Mentor


### PR DESCRIPTION
Closes #698.

## What

Plugin-agent `tools:` frontmatter must list MCP tools under their
fully-qualified `mcp__genealogy__*` names. Bare names leave the subagent
**toolless** in the unit-harness SDK path; only the e2e harness tolerated
them, via its ToolSearch prefix allowlist. `image-reader` and
`record-extractor` were already converted — `gps-mentor` was the last
holdout.

## Changes

- **`packages/engine/plugin/agents/gps-mentor.md`** — qualify the 7 MCP
  tools to `mcp__genealogy__*`. `Read` is a built-in Cowork tool, not MCP,
  so it stays bare (matches the other two agents, which list only
  `mcp__genealogy__*` entries).
- **`docs/specs/gps-mentor-agent-spec.md`** — same frontmatter change in
  the spec's canonical block so `spec-review` sees no drift, plus a note
  stating the rule.
- **`CLAUDE.md`** — document the qualified-name convention in the "Cowork
  plugin agents" section.
- **`docs/TODOs.md`** — mark the tracking item done.

## Verification

- All 7 tool names exist in `tool-schemas.ts` — no typos in the prefixes.
- Agent and spec frontmatter now match byte-for-byte (`Read` + 7 qualified
  names).
- Behavior-neutral frontmatter-key rename.

## CI note

The change touches `packages/engine/plugin/agents/**`, which is **not** a
`check-runlogs.yml` trigger path (that gate watches `skills/**`, not
`agents/**`), so no runlog gate fires. The eval snapshot is built
dynamically from disk, so nothing is pinned to the old frontmatter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)