### PR TITLE
search tools: shape oversize results + persist external links to disk (#696)

### DIFF
--- a/docs/plan/search-shaping-and-staging-plan.md
+++ b/docs/plan/search-shaping-and-staging-plan.md
@@ -86,7 +86,7 @@ schema `:178`) and `types/external-links-search.ts` (`ExternalLinksSearchResult`
 `:30-42`), not `tool-schemas.ts` (which only re-exports).
 
 - Add optional **`projectPath`** (camelCase) — when present, stage the full,
-  pre-filter set via `stageSearchResults({ tool: "external_links", response })`
+  pre-filter set via `stageSearchResults({ tool: "external_links_search", response })`
   and return `staged: { resultsRef, returnedCount }`. Additive, best-effort,
   never fails the search (same try/catch as fulltext/record). **Stage the full
   set BEFORE any inline filtering/slicing** — staging serializes `response`
@@ -117,7 +117,7 @@ entry's `tool` (`results-staging.ts:127`; `research-log-append.ts:241` passes
 `expectedTool: input.tool`). Attaching an `external_links` staged ref to the
 existing `tool: "external_site"` entry (option A) would throw a tool-mismatch
 and write nothing. So the `external_links` fetch gets its **own** log entry
-(`tool: "external_links"`, its own `results_ref` sidecar), consistent with how
+(`tool: "external_links_search"`, its own `results_ref` sidecar), consistent with how
 `record_search`/`fulltext_search` log. This validates cleanly with no schema
 change: log `tool` is a free string in both the hand validator (`validator.ts:646-682`,
 no enum on `tool`) and `research.schema.json:307`; `external_site` is

--- a/docs/plan/search-shaping-and-staging-plan.md
+++ b/docs/plan/search-shaping-and-staging-plan.md
@@ -1,0 +1,209 @@
+# Search-tool shaping + sidecar-staging integrity — implementation plan
+
+> Covers GitHub #696 (oversize search-tool results) and #699 (upstream
+> sidecar-staging gap). Two independent PRs, split by issue. Neither depends
+> on the other landing first.
+
+## Problem, verified against the code
+
+### #696 — oversize search-tool results
+`fulltext_search` and `external_links_search` return 79–136 KB payloads that
+overflow the tool-result token cap, spill to files, and cost a reader-subagent
+detour (closing report §3.5, 4 runs).
+
+- **`fulltext_search`** already *stages* when `projectPath` is passed
+  (`fulltext-search.ts:223-234`) but — unlike `record_search` — never strips
+  the inline copy. Every result still carries its full AI-transcribed
+  `textDocument` (`mapEntry`, line 120). `record_search` solved the identical
+  problem by deleting the heavy inline field once staged
+  (`record-search.ts:546-551`, `delete r.gedcomx`). `fulltext` simply never
+  got the parallel treatment.
+- **`external_links_search`** does not stage at all and deliberately returns
+  the *entire* filtered set in one response (`external-links-search.ts:129-176`,
+  "no pagination"). Its overflow is result **count** (each item is a small
+  `{ url, linkText }`), not per-item size. It also retains nothing to disk —
+  the `search-external-sites` skill consumes the links inline and only logs the
+  generated external-site URL (SKILL.md:281-282, "External-site searches retain
+  no result sidecar").
+
+### #699 — sidecar-staging gap
+D2 auto-fill (`research-append.ts:1019-1115`) resolves `record_persona_id` by
+matching each assertion against its log entry's **sidecar**. With no sidecar
+(`results_ref` null) it cannot fill anything: a supplied persona id is
+*rejected* (line 1028-1036), an omitted one is *silently left null*
+(the fall-through past line 1037). One e2e run (spriggs) staged no sidecar, so
+all 18 persona ids came back null and identity was unrecoverable.
+
+Both search skills already *instruct* passing `projectPath`, but nothing
+hard-stops the model from proceeding when the response comes back `staged: null`
+(either `projectPath` omitted, or `stagingError` set). And the null-persona
+outcome at the append boundary is silent.
+
+**Nuance that constrains the fix:** a null `results_ref` is *legitimate* for
+`record_read` / PDF / image / pasted-record log entries — those carry no
+personas by design (comment at `research-append.ts:1026`). So the loud warning
+must fire only on the *anomalous* case (a search that should have staged but
+didn't), never on every sidecar-less assertion.
+
+---
+
+## PR 1 — #696: shape oversize search results + persist external links
+
+Cohesive unit: bound both tools' inline payloads, and give `external_links`
+the same disk-persistence the other search tools have so its results ride along
+in a "submit feedback" zip (which bundles `results/log_*.json`,
+feedback-case-spec.md:367,434).
+
+### 1a. `fulltext_search` — strip inline when staged (tool)
+`fulltext-search.ts`: after staging succeeds (`out.staged` truthy), delete the
+heavy fields from each inline result. Mirror the `record_search` comment +
+guard exactly:
+
+```ts
+if (out.staged) {
+  for (const r of out.results) {
+    delete r.textDocument;   // the 79–136 KB driver; full copy lives in the sidecar
+  }
+}
+```
+
+- Strip **only** `textDocument`. Leave `names`/`places`/`dates`/`highlightTerms`
+  /`title`/`recordType` — those are the triage stubs, small, and what the skill
+  reads inline.
+- Strip **only when staged**, never on an un-staged exploratory search (nothing
+  was retained to re-read) — identical to `record_search`.
+- `record_read` already reads a fulltext record's full text from the sidecar via
+  the staged ref, so no consumer loses access to `textDocument`.
+
+### 1b. `external_links_search` — add staging + host-side filter (tool)
+**Resolved after review: host-side filter, not a blind cap.** The sole
+consumer (`search-external-sites`) filters the flat `results[]` by host *inline*
+(`SKILL.md:157-160`, `result.url.includes("ancestry.com")`) and never reads the
+sidecar during the skill, so a blind first-N cap can drop the target site's link
+on exactly the large places that overflow — regressing the feature. Types to
+edit live in `external-links-search.ts` (interface `ExternalLinksSearchInput:10`,
+schema `:178`) and `types/external-links-search.ts` (`ExternalLinksSearchResult`
+`:30-42`), not `tool-schemas.ts` (which only re-exports).
+
+- Add optional **`projectPath`** (camelCase) — when present, stage the full,
+  pre-filter set via `stageSearchResults({ tool: "external_links", response })`
+  and return `staged: { resultsRef, returnedCount }`. Additive, best-effort,
+  never fails the search (same try/catch as fulltext/record). **Stage the full
+  set BEFORE any inline filtering/slicing** — staging serializes `response`
+  and derives `returned_count` at call time (`results-staging.ts:71-81`), same
+  order as `record-search.ts` (stage `out`, then trim `out.results`).
+- Add optional **`host`** — when present, filter `results[]` to links whose URL
+  contains that host (server-side), returning the small exact set the skill
+  needs. When omitted, behavior is unchanged (return all) but still capped by a
+  generous backstop `INLINE_CAP` for the general/exploratory case. The full,
+  unfiltered set is always what gets staged to disk (for feedback).
+- Add `staged?` and a `returned` count to `ExternalLinksSearchResult`
+  (`types/external-links-search.ts` — currently only `query`/`totalForPlace`/
+  `results`).
+
+### 1c. `search-external-sites` skill — pass `projectPath`, keep the handle (skill)
+`search-external-sites/SKILL.md`:
+
+- Step 2: call `external_links_search({ standardPlace, startYear, endYear,
+  projectPath })`.
+- Wire the returned `staged.resultsRef` into the step-4 `research_log_append`
+  as `stagedResultsRef`, so the curated links finalize into
+  `results/log_NNN.json` and land in feedback zips. Update the "External-site
+  searches retain no result sidecar" note (SKILL.md:281-282) accordingly.
+
+**Resolved after review: option B is the only correct choice.**
+`finalizeStagedResults` hard-checks the staged envelope's `tool` against the log
+entry's `tool` (`results-staging.ts:127`; `research-log-append.ts:241` passes
+`expectedTool: input.tool`). Attaching an `external_links` staged ref to the
+existing `tool: "external_site"` entry (option A) would throw a tool-mismatch
+and write nothing. So the `external_links` fetch gets its **own** log entry
+(`tool: "external_links"`, its own `results_ref` sidecar), consistent with how
+`record_search`/`fulltext_search` log. This validates cleanly with no schema
+change: log `tool` is a free string in both the hand validator (`validator.ts:646-682`,
+no enum on `tool`) and `research.schema.json:307`; `external_site` is
+required-but-nullable; `results_ref` is an allowed nullable key.
+
+### 1d. Tests / wiring (PR 1)
+- Unit tests: fulltext strips `textDocument` when staged, keeps it when not;
+  external_links stages when `projectPath` given, caps inline, best-effort on
+  staging failure.
+- Update `dev/try-fulltext-search.ts` / `dev/try-external-links-search.ts` if
+  they assert on the stripped/added fields.
+- Add `projectPath` + `host` to the `external_links_search` schema and the
+  `ExternalLinksSearchInput` interface — both in **`external-links-search.ts`**
+  (`tool-schemas.ts` only re-exports). **No `manifest.json` change** (params
+  only). **No `packages/schema` mirror / schema blast-radius** — `projectPath`/
+  `host` are MCP tool *input* schema, and the D2 change rides the existing
+  `errors`/`warnings` channels: neither touches `research.schema.json`.
+- Update `docs/specs/search-result-staging-spec.md` to add `external_links` to
+  the list of staging producers, and note the fulltext inline-strip.
+
+---
+
+## PR 2 — #699: staging-integrity gate + loud null at the boundary
+
+### 2a. Hard-gate the two search skills on `staged` (skill)
+`search-records/SKILL.md` and `search-full-text/SKILL.md`: turn the existing
+soft guidance into a hard stop. A results-returning search that comes back with
+`staged: null` (because `projectPath` was omitted, or `stagingError` is set)
+**must not proceed** to ranking / extraction / logging-as-if-staged. Required
+recovery: re-run the identical query **with** `projectPath`; if `stagingError`
+persists, surface it to the user rather than proceeding with unrecoverable
+persona identity. `search-full-text` already has a soft version of this
+(SKILL.md:212-215) — make it a hard gate and mirror the wording in
+`search-records`.
+
+### 2b. Loud failure at the D2 boundary (tool)
+`research-append.ts`, D2 block, the `if (!ref)` branch (`:1025`). Today: a
+supplied `record_persona_id` with no sidecar is *rejected* (`:1028-1036`); an
+omitted one silently falls through and the assertion persists with
+`record_persona_id: null` — the exact silent loss #699 is about.
+
+**Resolved after review: reject (error), not warn.** A bare warning still lets
+the null land on disk, which is precisely #699's complaint, and the D2 block
+already *rejects* the adjacent case one branch over — a warning would be the odd
+exception in a validate-before-persist gate. Push the error via the existing
+`errors` array (same `errors.push(fmt(i, …))` used throughout D2); no new
+response field.
+
+**Condition (finalized):** the log entry's `tool` ∈ {`record_search`,
+`fulltext_search`} **and** `results_ref` is null **and** the search actually
+found something (`outcome` ∈ {`positive`,`partial`} or `results_examined > 0`).
+
+- Drop `external_links` from the producer set — those entries never carry
+  personas, so no assertion resolves against one; it would only add
+  false-positive surface.
+- The outcome/`results_examined` gate is required: a **nil/negative**
+  `record_search` legitimately has `results_ref: null` (`stageSearchResults`
+  returns `null` for zero results, `results-staging.ts:48`), and a
+  negative-evidence assertion citing it must NOT trip the error. Both fields are
+  always present on the entry (`research-log-append.ts:210-211`).
+- `record_read` / PDF / image / pasted entries never match (`tool` not a
+  producer), so they never error. `tool` is reachable — `logById.get(logId)`
+  at `:1022`, and `tool` is a required log-entry field (`validator.ts:647`).
+- Message: names the log id, states persona identity is unrecoverable, and
+  instructs re-running the search **with `projectPath`** to re-stage. This is
+  the tool-side backstop for the skill gate in 2a; when 2a works the model never
+  reaches this error.
+
+### 2c. Tests (PR 2)
+- Unit test: assertions-append against a positive/partial `record_search` log
+  entry with null `results_ref` is **rejected** with the re-stage message; the
+  same against (i) a `record_read` entry and (ii) a nil/negative `record_search`
+  entry is **accepted** (no false positive).
+- Skill-gate behavior is prose; covered by the eval harness, not a unit test.
+
+---
+
+## Sequencing & mechanics
+- Two independent PRs off `origin/main` (verified independent — 2a/2b reference
+  only pre-existing `staged`/`stagingError`/`results_ref` fields).
+- PR 1 on branch `search-shaping-staging` (current worktree). PR 2 on a fresh
+  branch off `origin/main` after PR 1 is committed.
+- Per repo memory: user reviews/merges PRs; I create + push only.
+
+## Out of scope / TODOs to file
+- Optional `site`/`host` filter param on `external_links_search` (1b option B)
+  if the count cap proves insufficient on real runs.
+- Any judge/eval change to detect null-persona regressions (closing report §4
+  notes the judge is blind to provenance nulling) — separate board item.

--- a/docs/specs/search-result-staging-spec.md
+++ b/docs/specs/search-result-staging-spec.md
@@ -34,14 +34,25 @@ than taking it as an argument.
 
 ## 2. Scope
 
-The two sidecar-producing search tools: **`record_search`** and
-**`fulltext_search`** (the only tools whose payloads become `results/` sidecars per
-`research-log-protocol.md`). The staging logic is a shared util so adding a third
-producer later is a one-line opt-in.
+The sidecar-producing search tools: **`record_search`**, **`fulltext_search`**,
+and **`external_links_search`** (`tool: "external_links"`) — the tools whose
+payloads become `results/` sidecars per `research-log-protocol.md`. The staging
+logic is a shared util so adding a producer is a one-line opt-in
+(`external_links_search` was added as the third, 2026-07 — GitHub #696).
 
 The change is **purely additive and back-compatible**: no `projectPath` → the tools
-behave exactly as today. The model-facing results are unchanged in either case
-(staging adds one optional field; it never removes or reshapes results).
+behave exactly as today.
+
+**Inline-payload strip (overflow protection).** Once a producer has staged its
+full payload, it drops the heavy per-result field from the *inline* copy so a
+broad search can't overflow the model's token cap — the bulk lives in the
+sidecar, which `record_read` and `rank_search_matches` read host-side. Each
+producer strips its own heavy field: `record_search` drops `gedcomx`,
+`fulltext_search` drops `textDocument` (the AI-transcribed page), and
+`external_links_search` bounds the inline `results[]` (optional `host` filter +
+a backstop cap) while staging the full year-filtered set. The strip is
+unconditional once staged (so the protection can't be forgotten) and never runs
+on an un-staged search (nothing was retained to re-read).
 
 Out of scope: `research_log_append` itself (its spec), the other search tools
 (image/volume/collections/person — they don't write `results/` sidecars today), and

--- a/docs/specs/search-result-staging-spec.md
+++ b/docs/specs/search-result-staging-spec.md
@@ -35,7 +35,7 @@ than taking it as an argument.
 ## 2. Scope
 
 The sidecar-producing search tools: **`record_search`**, **`fulltext_search`**,
-and **`external_links_search`** (`tool: "external_links"`) — the tools whose
+and **`external_links_search`** (`tool: "external_links_search"`) — the tools whose
 payloads become `results/` sidecars per `research-log-protocol.md`. The staging
 logic is a shared util so adding a producer is a one-line opt-in
 (`external_links_search` was added as the third, 2026-07 — GitHub #696).

--- a/eval/harness/harness/mock_mcp.py
+++ b/eval/harness/harness/mock_mcp.py
@@ -162,7 +162,7 @@ def _load_build_tool_catalog() -> dict[str, dict[str, Any]]:
 # a canned payload, so we materialize the staged file here (via the compiled
 # stager) and inject the handle. Without this, the live log tool has no staged
 # source to finalize and errors ("orphan sidecar" / staging error).
-STAGING_SEARCH_TOOLS: set[str] = {"record_search", "fulltext_search"}
+STAGING_SEARCH_TOOLS: set[str] = {"record_search", "fulltext_search", "external_links_search"}
 
 
 def _stage_search_results(

--- a/eval/runlogs/unit/search-external-sites/v1_2026-07-17_22-54-08.ann.json
+++ b/eval/runlogs/unit/search-external-sites/v1_2026-07-17_22-54-08.ann.json
@@ -1,0 +1,718 @@
+{
+  "run_log": "v1_2026-07-17_22-54-08.json",
+  "annotator": "dallan@quass.org",
+  "corrections": [
+    {
+      "test_id": "ut_search_external_sites_001",
+      "dimension_source": "base",
+      "dimension_name": "Correctness",
+      "llm_score": 2,
+      "corrected_score": 2,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_external_sites_001",
+      "dimension_source": "base",
+      "dimension_name": "Completeness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_external_sites_001",
+      "dimension_source": "base",
+      "dimension_name": "Tool Arguments",
+      "llm_score": 2,
+      "corrected_score": 2,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_external_sites_001",
+      "dimension_source": "rubric",
+      "dimension_name": "URL generation",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_external_sites_001",
+      "dimension_source": "rubric",
+      "dimension_name": "Capture guidance",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_external_sites_001",
+      "dimension_source": "rubric",
+      "dimension_name": "Result triage",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_external_sites_001",
+      "dimension_source": "rubric",
+      "dimension_name": "Tool selection",
+      "llm_score": 2,
+      "corrected_score": 2,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_external_sites_001",
+      "dimension_source": "rubric",
+      "dimension_name": "Log entry",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_external_sites_013",
+      "dimension_source": "base",
+      "dimension_name": "Correctness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_external_sites_013",
+      "dimension_source": "base",
+      "dimension_name": "Completeness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_external_sites_013",
+      "dimension_source": "base",
+      "dimension_name": "Tool Arguments",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_external_sites_013",
+      "dimension_source": "rubric",
+      "dimension_name": "URL generation",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_external_sites_013",
+      "dimension_source": "rubric",
+      "dimension_name": "Capture guidance",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_external_sites_013",
+      "dimension_source": "rubric",
+      "dimension_name": "Result triage",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_external_sites_013",
+      "dimension_source": "rubric",
+      "dimension_name": "Tool selection",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_external_sites_013",
+      "dimension_source": "rubric",
+      "dimension_name": "Log entry",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_external_sites_005",
+      "dimension_source": "base",
+      "dimension_name": "Correctness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_external_sites_005",
+      "dimension_source": "base",
+      "dimension_name": "Completeness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_external_sites_005",
+      "dimension_source": "base",
+      "dimension_name": "Tool Arguments",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_external_sites_005",
+      "dimension_source": "rubric",
+      "dimension_name": "URL generation",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_external_sites_005",
+      "dimension_source": "rubric",
+      "dimension_name": "Capture guidance",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_external_sites_005",
+      "dimension_source": "rubric",
+      "dimension_name": "Result triage",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_external_sites_005",
+      "dimension_source": "rubric",
+      "dimension_name": "Tool selection",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_external_sites_005",
+      "dimension_source": "rubric",
+      "dimension_name": "Log entry",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_external_sites_004",
+      "dimension_source": "base",
+      "dimension_name": "Correctness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_external_sites_004",
+      "dimension_source": "base",
+      "dimension_name": "Completeness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_external_sites_004",
+      "dimension_source": "base",
+      "dimension_name": "Tool Arguments",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_external_sites_004",
+      "dimension_source": "rubric",
+      "dimension_name": "URL generation",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_external_sites_004",
+      "dimension_source": "rubric",
+      "dimension_name": "Capture guidance",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_external_sites_004",
+      "dimension_source": "rubric",
+      "dimension_name": "Result triage",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_external_sites_004",
+      "dimension_source": "rubric",
+      "dimension_name": "Tool selection",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_external_sites_004",
+      "dimension_source": "rubric",
+      "dimension_name": "Log entry",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_external_sites_007",
+      "dimension_source": "base",
+      "dimension_name": "Correctness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_external_sites_007",
+      "dimension_source": "base",
+      "dimension_name": "Completeness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_external_sites_007",
+      "dimension_source": "base",
+      "dimension_name": "Tool Arguments",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_external_sites_007",
+      "dimension_source": "rubric",
+      "dimension_name": "URL generation",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_external_sites_007",
+      "dimension_source": "rubric",
+      "dimension_name": "Capture guidance",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_external_sites_007",
+      "dimension_source": "rubric",
+      "dimension_name": "Result triage",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_external_sites_007",
+      "dimension_source": "rubric",
+      "dimension_name": "Tool selection",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_external_sites_007",
+      "dimension_source": "rubric",
+      "dimension_name": "Log entry",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_external_sites_010",
+      "dimension_source": "base",
+      "dimension_name": "Correctness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_external_sites_010",
+      "dimension_source": "base",
+      "dimension_name": "Completeness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_external_sites_010",
+      "dimension_source": "base",
+      "dimension_name": "Tool Arguments",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_external_sites_010",
+      "dimension_source": "rubric",
+      "dimension_name": "URL generation",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_external_sites_010",
+      "dimension_source": "rubric",
+      "dimension_name": "Capture guidance",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_external_sites_010",
+      "dimension_source": "rubric",
+      "dimension_name": "Result triage",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_external_sites_010",
+      "dimension_source": "rubric",
+      "dimension_name": "Tool selection",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_external_sites_010",
+      "dimension_source": "rubric",
+      "dimension_name": "Log entry",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_external_sites_002",
+      "dimension_source": "base",
+      "dimension_name": "Correctness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_external_sites_002",
+      "dimension_source": "base",
+      "dimension_name": "Completeness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_external_sites_002",
+      "dimension_source": "base",
+      "dimension_name": "Tool Arguments",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_external_sites_002",
+      "dimension_source": "rubric",
+      "dimension_name": "URL generation",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_external_sites_002",
+      "dimension_source": "rubric",
+      "dimension_name": "Capture guidance",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_external_sites_002",
+      "dimension_source": "rubric",
+      "dimension_name": "Result triage",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_external_sites_002",
+      "dimension_source": "rubric",
+      "dimension_name": "Tool selection",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_external_sites_002",
+      "dimension_source": "rubric",
+      "dimension_name": "Log entry",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_external_sites_003",
+      "dimension_source": "base",
+      "dimension_name": "Correctness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_external_sites_003",
+      "dimension_source": "base",
+      "dimension_name": "Completeness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_external_sites_003",
+      "dimension_source": "base",
+      "dimension_name": "Tool Arguments",
+      "llm_score": null,
+      "corrected_score": null,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_external_sites_011",
+      "dimension_source": "base",
+      "dimension_name": "Correctness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_external_sites_011",
+      "dimension_source": "base",
+      "dimension_name": "Completeness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_external_sites_011",
+      "dimension_source": "base",
+      "dimension_name": "Tool Arguments",
+      "llm_score": null,
+      "corrected_score": null,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_external_sites_012",
+      "dimension_source": "base",
+      "dimension_name": "Correctness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_external_sites_012",
+      "dimension_source": "base",
+      "dimension_name": "Completeness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_external_sites_012",
+      "dimension_source": "base",
+      "dimension_name": "Tool Arguments",
+      "llm_score": null,
+      "corrected_score": null,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_external_sites_006",
+      "dimension_source": "base",
+      "dimension_name": "Correctness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_external_sites_006",
+      "dimension_source": "base",
+      "dimension_name": "Completeness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_external_sites_006",
+      "dimension_source": "base",
+      "dimension_name": "Tool Arguments",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_external_sites_006",
+      "dimension_source": "rubric",
+      "dimension_name": "URL generation",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_external_sites_006",
+      "dimension_source": "rubric",
+      "dimension_name": "Capture guidance",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_external_sites_006",
+      "dimension_source": "rubric",
+      "dimension_name": "Result triage",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_external_sites_006",
+      "dimension_source": "rubric",
+      "dimension_name": "Tool selection",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_external_sites_006",
+      "dimension_source": "rubric",
+      "dimension_name": "Log entry",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_external_sites_008",
+      "dimension_source": "base",
+      "dimension_name": "Correctness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_external_sites_008",
+      "dimension_source": "base",
+      "dimension_name": "Completeness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_external_sites_008",
+      "dimension_source": "base",
+      "dimension_name": "Tool Arguments",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_external_sites_008",
+      "dimension_source": "rubric",
+      "dimension_name": "URL generation",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_external_sites_008",
+      "dimension_source": "rubric",
+      "dimension_name": "Capture guidance",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_external_sites_008",
+      "dimension_source": "rubric",
+      "dimension_name": "Result triage",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_external_sites_008",
+      "dimension_source": "rubric",
+      "dimension_name": "Tool selection",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_external_sites_008",
+      "dimension_source": "rubric",
+      "dimension_name": "Log entry",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_external_sites_009",
+      "dimension_source": "base",
+      "dimension_name": "Correctness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_external_sites_009",
+      "dimension_source": "base",
+      "dimension_name": "Completeness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_external_sites_009",
+      "dimension_source": "base",
+      "dimension_name": "Tool Arguments",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_external_sites_009",
+      "dimension_source": "rubric",
+      "dimension_name": "URL generation",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_external_sites_009",
+      "dimension_source": "rubric",
+      "dimension_name": "Capture guidance",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_external_sites_009",
+      "dimension_source": "rubric",
+      "dimension_name": "Result triage",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_external_sites_009",
+      "dimension_source": "rubric",
+      "dimension_name": "Tool selection",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_search_external_sites_009",
+      "dimension_source": "rubric",
+      "dimension_name": "Log entry",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    }
+  ]
+}

--- a/eval/runlogs/unit/search-external-sites/v1_2026-07-17_22-54-08.json
+++ b/eval/runlogs/unit/search-external-sites/v1_2026-07-17_22-54-08.json
@@ -1,0 +1,4930 @@
+{
+  "schema_version": 2,
+  "skill": "search-external-sites",
+  "version": 1,
+  "released": false,
+  "releasable": true,
+  "invocation": "skill",
+  "timestamp": "2026-07-17_22-54-08",
+  "harness_version": "0.1.0",
+  "model": "claude-sonnet-4-6",
+  "judge_prompt_hash": "30747842dbdfcdff202d93d99ea66de1c10b451448690694462a40baa86d2a3e",
+  "snapshot": {
+    "packages/engine/plugin/skills/search-external-sites/SKILL.md": "---\nname: search-external-sites\nmodel: claude-sonnet-4-6\ndescription: Generates search URLs for external genealogy sites (Ancestry,\n  MyHeritage, FindMyPast, FindAGrave, Newspapers.com) and walks the user\n  through the click-capture-analyze workflow. Logs each search to research.json (including nil results) and\n  triages results from captured PDFs before passing records to record-extraction. GPS Step 1 \u2014 Reasonably\n  Exhaustive Research (external site execution). Use when the user says\n  \"search Ancestry\", \"search MyHeritage\", \"search FindMyPast\", \"search\n  FindAGrave\", \"search Newspapers.com\", when a plan item targets a\n  non-FamilySearch repository, or when the user uploads a PDF capture from\n  an external genealogy site. Do NOT use when the target is\n  FamilySearch (use search-records); when the user is still choosing what or\n  where to search \u2014 e.g. \"what should I search next?\" \u2014 which is planning,\n  not execution (use research-plan); or when the user wants to analyze a\n  single record already in context (use record-extraction).\nallowed-tools:\n  - place_search\n  - external_links_search\n  - research_log_append\n  - research_append\n---\n\n# Search External Sites\n\n**Narration:** Read `researcher_profile.narration_guidance` from `research.json` and apply it as your narration style for this invocation. If absent, default to a one-line preamble per action.\n\n**Places:** When resolving or writing places, follow `references/places-guidance.md` \u2014 resolve with `place_search` and record the `standardPlace` (and `standard_place` on persisted facts/assertions/events).\n\nAncestry, MyHeritage, FindMyPast, FindAGrave, and Newspapers.com have no\npublic APIs and prohibit automated access. So this skill never loads a\npage itself \u2014 it builds a pre-filled search URL, the user clicks it in\ntheir own authenticated browser, captures the page as a PDF, and uploads\nit back. The agent supplies the genealogical expertise; the user's\nbrowser supplies the access.\n\nGetting the search **parameters** right is the core of the task: a URL\nwith the wrong name encoding, a missing date window, or the wrong\ncollection sends the user to a dead end.\n\n**This skill executes a search that has already been chosen \u2014 it does not\nchoose searches.** If the user's message is a planning question \u2014 *which*\nsites or record types to search, or in what order (\"what should I search\nnext?\", \"where should I look for Patrick's parents?\") \u2014 don't generate\nURLs. In one line, say that picking and prioritizing searches is planning,\nand hand off to `research-plan`. Only proceed below once a specific\nexternal-site search is named (by the user or a plan item).\n\nReferences to load when the moment arrives:\n- `references/repository-types.md` \u2014 before your first search, so you\n  know why a negative *online* result never proves a record doesn't exist.\n- `references/search-strategy-external.md` \u2014 Boolean techniques, spelling\n  variants, and zero-hit recovery.\n- `references/evaluating-compiled-sources.md` \u2014 the nine criteria for\n  Find A Grave, member trees, and other user-contributed content.\n\n## The loop\n\n1. **Generate** a search URL with pre-filled parameters.\n2. **Click** \u2014 the user opens it in their authenticated browser.\n3. **Capture** \u2014 the user saves the page as PDF and uploads it.\n4. **Analyze** \u2014 you read the PDF, triage results, and hand promising\n   records to record-extraction.\n\nRepeat for each external-site plan item.\n\n## Autonomous mode \u2014 no user to capture\n\nUnder `--autonomous` (the research objective was launched with that flag)\nthere is **no user** to click a link, capture a PDF, or upload it \u2014 so the\nclick-capture-analyze loop above **cannot complete**. Do **not** present a\nURL and wait for a capture, and do **not** end your turn to ask the user to\ncapture it: that stalls an autonomous run (the orchestrator's rule is that\nonly `project.status == \"completed\"` or a logged blocker ends the run).\n\nInstead, for each capture-required external-site plan item:\n\n1. **Prefer a FamilySearch equivalent first.** Many records these sites\n   hold \u2014 UK/Scottish civil registration, censuses, parish registers \u2014 are\n   also indexed on FamilySearch. If `search-records` can reach the record,\n   route there and capture the real thing rather than deferring.\n2. Otherwise, still resolve the place and build the search URL (steps 2\u20133)\n   \u2014 it is a genuine lead worth recording.\n3. **Log it as deferred** in one `research_log_append` call: `outcome:\n   \"negative\"`, `resultsExamined: 0`, `externalSite.captureReceived: false`,\n   and `notes` stating the search was **deferred \u2014 requires an interactive\n   user capture and is not obtainable in an autonomous run**, with the\n   generated URL recorded so a later interactive session can capture it.\n4. Mark the plan item terminal (step 7).\n5. **Return to the orchestrator and keep going** \u2014 do not wait.\n\nThis keeps the audit trail honest \u2014 the external avenue is logged as a\ndeferred lead, not silently dropped, so `research-exhaustiveness` can weigh\nit and proceed on the evidence that *is* obtainable (FamilySearch records,\nprovided documents). It does not lower the bar: in an interactive session\nthe same search would be captured normally.\n\n## Before you search\n\n**Check subscriptions.** Read `researcher_profile.subscriptions` in\n`research.json`. Use it as a tie-breaker, never as a gate.\n\n| Site | Subscription value |\n|------|-------------------|\n| Ancestry.com | `Ancestry` |\n| MyHeritage.com | `MyHeritage` |\n| FindMyPast.com | `FindMyPast` |\n| FindAGrave.com | free to search; `FindAGrave-Plus` adds features |\n| Newspapers.com | `Newspapers.com` |\n\n- If a plan item is repository-agnostic, prefer a site the researcher\n  subscribes to \u2014 that search is immediately actionable.\n- If the user explicitly names an unsubscribed site, **generate the URL\n  anyway** and add one line: \"You don't have a [SITE] subscription on\n  file \u2014 the link will hit a login wall or a limited-results preview.\n  Continue, or pick a subscribed site?\" Flag, don't block.\n- Profile absent or `subscriptions: [\"none\"]` \u2192 treat all sites equally,\n  don't pester about subscriptions.\n- FindAGrave is always worth generating \u2014 basic search is free.\n\n**Classify the target.** Is the collection an index (a pointer, not\nproof), a digitized original (carries evidentiary weight), or\nuser-contributed content (a lead only)? Read the collection description \u2014\ntitles mislead about scope and completeness.\n\n## Supported sites\n\n| Site | URL pattern | Notes |\n|------|------------|-------|\n| Ancestry.com | `ancestry.com/search/collections/{id}/?params` | Largest indexed collection. Paid subscription |\n| MyHeritage.com | `myheritage.com/research?action=query&params` | Independent indexing. Paid subscription |\n| FindMyPast.com | `findmypast.com/search/results?params` | Strong UK/Ireland coverage. Paid subscription |\n| FindAGrave.com | `findagrave.com/memorial/search?params` | Cemetery records. Free. User-contributed \u2014 treat as compiled source |\n| Newspapers.com | `newspapers.com/search/?query=params` | Historical newspapers. Ancestry-owned. Paid subscription |\n\n## Steps\n\n### 1. Find the plan item\n\nRead `research.json` `plans[]` and pick the item(s) targeting an external\nrepository. Note the record type, the place, and the year window \u2014 you'll\nmatch all three against the curated links below.\n\n### 2. Resolve the place and fetch curated links\n\n```\nplace_search({ placeName: \"<place name>\" })\n```\n\nTake the `standardPlace` from the response \u2014 do not guess it \u2014 and pass it\nto `external_links_search` with the plan item's year window, your target\nsite as `host`, and `projectPath` so the full curated set is retained on disk:\n\n```\nexternal_links_search({\n  standardPlace: \"<standardPlace>\",\n  startYear: <year>,\n  endYear: <year>,\n  host: \"<target-site host, e.g. ancestry.com>\",\n  projectPath: \"<absolute path of the current working directory>\"\n})\n```\n\n`host` narrows the returned `results[]` toward your target site (so a\nlink-dense place can't overflow the response); `projectPath` stages the **full**\nyear-filtered set (all sites) to disk and returns a `staged.resultsRef` \u2014 hold\nit for the step-4 log. `results[]` is a flat list of `{ url, linkText }`. Consume\nit:\n1. **Filter to your target site** \u2014 keep only links whose URL is for your site,\n   e.g. `result.url.includes(\"ancestry.com\")`. `host` already narrows this\n   server-side, but filter here too so you stay correct if any off-site links\n   come through.\n2. **Dedupe by URL** \u2014 FS repeats the same URL once per record-type\n   category. Collapse duplicates, and say so in one line when it happens\n   (\"collection 8800 appeared 3\u00d7 under different labels \u2014 collapsed to one\")\n   so the dedup is visible, not silent.\n3. **Match `linkText` to the plan item's record type.** `linkText` names\n   the collection in plain English (\"Pennsylvania Wills and Probate\n   Records\"); the collection ID is embedded in the URL path. This match is\n   what step 3 acts on.\n\n**How many links survived the site filter (call it `matched`):**\n- `matched > 0` \u2192 a curated URL for your site exists; go to Case A.\n- `matched === 0` but `totalForPlace > 0` \u2192 FS curates this place but nothing\n  matches your site + year window; widen the window or fall back (Case B).\n- `totalForPlace === 0` \u2192 no curated links here at all; fall back (Case B).\n\n### 3. Build the URL\n\n**Case A \u2014 a curated URL exists for the target site.**\n\nFirst, confirm the curated link actually fits the plan item. Compare its\n`linkText` record type against what you're searching for: a probate plan\nitem needs a probate/wills/estate collection, not a census or vital-records\none. **If the only curated link is for a different record type, do not\npresent it as the search** \u2014 that silently sends the user to the wrong\ncollection. Either pick a curated link whose `linkText` matches, or, if\nnone matches, fall back to Case B and say which record type you were\nlooking for.\n\nWhen the record type matches, use that URL as the base and append your\nsearch parameters \u2014 it already encodes the collection scope (Ancestry URLs\ncarry `/search/collections/{id}/`), so don't template the collection ID\nseparately:\n\n```\n{returned_url}?name=Patrick_Flynn&birth=1845&birthplace=Pennsylvania\n```\n\nIf the base already has a query string, append with `&` instead of `?`.\n\n**Case B \u2014 no curated URL fits (or none for the site).**\n\nTell the user plainly: \"No FamilySearch-curated link for [site] in\n[year window] \u2014 using the site-wide search instead.\" Then build from the\nsite-wide template. These search the whole site index, not a scoped\ncollection:\n\n#### Ancestry.com\n```\nhttps://www.ancestry.com/search/?name={first}_{last}&birth={year}&birthplace={place}&residence={year}_{place}&father={first}_{last}&mother={first}_{last}&spouse={first}_{last}\n```\n- `name` \u2014 given and surname, underscore-separated\n- `birth`, `death`, `marriage` \u2014 event year\n- `birthplace`, `deathplace` \u2014 location string\n- `residence` \u2014 year and place, underscore-separated\n- `father`, `mother`, `spouse` \u2014 relative names\n\n#### MyHeritage.com\n```\nhttps://www.myheritage.com/research?action=query&first={first}&last={last}&birth_year={year}&birth_place={place}&marriage_year={year}&marriage_place={place}&death_year={year}&death_place={place}&father_first={first}&father_last={last}&mother_first={first}&mother_last={last}\n```\n\n#### FindMyPast.com\n```\nhttps://www.findmypast.com/search/results?firstname={first}&lastname={last}&yearofbirth={year}&keywordsplace={place}&eventyear={year}&fatherfirstname={first}&motherfirstname={first}\n```\n\n#### FindAGrave.com\n```\nhttps://www.findagrave.com/memorial/search?firstname={first}&lastname={last}&birthyear={year}&deathyear={year}&location={place}\n```\n\n#### Newspapers.com\n```\nhttps://www.newspapers.com/search/?query={first}+{last}&dr_year={year}&dr_place={place}\n```\n\n**Parameter strategy** (full guidance in\n`references/search-strategy-external.md`):\n- **Match the parameters to the plan item's event.** A marriage search needs\n  the marriage year window and place; a death search needs death year/place \u2014\n  don't fall back to birth-only fields when the plan item targets another event.\n- Unusual name \u2192 start broad (surname + place only).\n- Common name \u2192 start narrow (add dates, relatives, a specific collection).\n- Include only parameters you're confident about; omit uncertain ones.\n- Add relative names when you have them (Ancestry weights them heavily).\n- Widen with spelling variants or wildcards when a search returns little.\n\n### 4. Log the search, then present the URL\n\n**First, persist the curated-links fetch.** If `external_links_search`\nreturned a `staged.resultsRef` (present whenever the year-filtered set was\nnon-empty), log the fetch as its **own** entry so the full curated set is\nretained on disk \u2014 it rides along when the user submits feedback, and makes the\nfetch part of the research record. This is separate from the external-site log\nbelow:\n\n```\nresearch_log_append({\n  projectPath: <absolute path of the current working directory>,\n  planItemId: \"<pli_XXX or null>\",\n  tool: \"external_links_search\",\n  query: { standardPlace: \"<standardPlace>\", host: \"<host>\", startYear: <year>, endYear: <year> },\n  outcome: \"<positive if returned > 0, else negative>\",\n  resultsExamined: <returned>,\n  notes: \"Curated external links for <place>.\",\n  stagedResultsRef: staged.resultsRef   // omit only when there is no staged handle (empty year-filtered set)\n})\n```\n\nDo **not** pass `externalSite` here \u2014 that field is only for `external_site`\nentries. Then log the site search itself.\n\nThe log entry is what makes the search part of the research record, so\n**write it before you hand over the URL** \u2014 this step is not finished\nuntil both exist. If you present the URL and stop, `research.json` shows\nnothing happened: downstream skills, the user's next session, and the\n\"reasonably exhaustive\" audit trail all go blind. The capture may never\ncome back; the log is the proof the search was launched.\n\nCall `research_log_append` (it assigns the `log_NNN` id and\nvalidates-before-persist; the log is append-only \u2014 append a new entry, never\nedit a prior one):\n\n```\nresearch_log_append({\n  projectPath: <absolute path of the current working directory>,\n  planItemId: \"<pli_XXX or null>\",\n  tool: \"external_site\",\n  query: { /* the params you encoded in the URL */ },\n  outcome: \"partial\",\n  resultsExamined: 0,\n  notes: \"URL generated; awaiting user capture.\",\n  externalSite: {\n    site: \"<ancestry|myheritage|findmypast|findagrave|newspapers>\",\n    urlGenerated: \"<the exact URL you present below>\",\n    captureReceived: false,\n    captureFilename: null\n  }\n})\n```\n\n`projectPath` is the project folder you are already operating in (the\ndirectory that contains `research.json`). Pass its absolute path.\nThis **external-site** entry has no result sidecar (the capture hasn't\narrived yet), so do **not** pass `stagedResultsRef` here \u2014 that handle\nbelongs on the `external_links_search` entry above.\n\n`outcome: \"partial\"` + `captureReceived: false` mark it in-flight. When a\ncapture comes back you append a **new** entry (step 6) \u2014 never edit this\none.\n\nIf the call returns `{ ok: false, errors }`, surface the errors and fix\nthe inputs rather than retrying blindly or hand-writing the entry; nothing\nwas written. On success the response carries the `logId` it assigned.\n\nThen present the URL:\n\n---\n\n**Search: 1850 Census on Ancestry for Patrick Flynn**\n\nClick this link to search:\n[Ancestry \u2014 1850 Census, Patrick Flynn](https://www.ancestry.com/search/collections/8054/?name=Patrick_Flynn&birth=1845&birthplace=Pennsylvania)\n\nAfter the page loads:\n1. Scroll to the bottom of the page and back to the top (forces\n   lazy-loaded results into view)\n2. Press **Cmd+P** (Mac) or **Ctrl+P** (Windows)\n3. Select **\"Save as PDF\"**\n4. Save the file and upload it here\n\nIf the page asks you to log in, please log in first, then click the link\nagain.\n\n---\n\n### 5. Triage the captured PDF\n\nWhen the user uploads a PDF, triage formally before any extraction:\n\n1. **List each result** with its key attributes \u2014 name, age/birth year,\n   location, record type, any visible record ID.\n2. **Classify the source** \u2014 index (flag that the original must be\n   located), digitized original, or user-contributed compiled source\n   (apply `references/evaluating-compiled-sources.md`).\n3. **Rate each match** against the subject's known attributes:\n   - **Strong** \u2014 name matches, age within \u00b13 years, correct jurisdiction.\n   - **Possible** \u2014 name variant, age close, same state / different county.\n   - **No match** \u2014 wrong gender, wrong decade, wrong state.\n4. **Present a numbered list** with the rating and the reason for each, then\n   ask which record to examine. For example:\n\n   > I found 15 results. Three are strong:\n   > 1. **Patrick Flynn**, age 5, in Thomas Flynn's household, Schuylkill\n   >    County, PA \u2014 strong match\n   > 2. **Patrick Flyn**, age 6, Allegheny County, PA \u2014 possible (spelling\n   >    variant, different county)\n   > 3. **P. Flynn**, age 4, Philadelphia, PA \u2014 possible (initial only)\n   >\n   > Results 4\u201315 don't match (wrong ages/locations). Examine record #1?\n\n   For user-contributed sources, add a note separating photographed\n   evidence (a headstone image) from contributor-entered text (dates,\n   family links).\n5. **On selection, request the individual record.** \"Click result #1 to\n   open the full record page, then save it as a PDF and upload it.\" That\n   single-record PDF goes to record-extraction.\n\nDon't send the raw search-results PDF straight to record-extraction \u2014 the\nuser picks which records are worth examining.\n\n### 6. Log results, including nil results\n\nEvery search gets logged in enough detail to reproduce it \u2014 site,\ncollection, all parameters, filters, results examined. When a capture\ncomes back, append a **new** `research_log_append` entry (never edit the\nin-flight one from step 4) \u2014 same `query` params as step 4's call, with\n`externalSite.captureReceived: true` and `externalSite.captureFilename` set to\nthe uploaded PDF's filename when a capture arrived (`false` / `null` for a\nno-access wall where none did), and `outcome` chosen from your triage:\n\n- **Results found** \u2192 `outcome: \"positive\"`, `resultsExamined: <n>`;\n  `notes` summarize the matches.\n- **Nil result** \u2192 `outcome: \"negative\"`. A search that legitimately finds\n  nothing is a *finding*, not a failure. In `notes` record what collection\n  was searched, its known coverage gaps, and whether the absence is\n  conclusive or whether undigitized/unindexed records may still exist\n  (\"not found online\" \u2260 \"does not exist\"). Never skip the log because\n  \"there was nothing to record\" \u2014 **log the nil now, in this turn**, even when\n  the user says \"nothing came up, there's nothing to save.\" If the user\n  *reports* a nil without a capture, still append the `negative` entry\n  immediately, and in `notes` mark the absence **unconfirmed pending a\n  capture**; then give them the click-capture steps (step 4) so a PDF of the\n  empty results page can later upgrade it from \"unconfirmed\" to \"conclusive.\"\n  Logging the search is not the same as declaring the record absent \u2014 never\n  defer the log entry while you wait for the capture.\n- **No access** (subscription/login wall the user can't pass) \u2192\n  `outcome: \"error\"` with the reason; suggest the fallback plan item.\n\nBefore calling a site exhausted on zero results, try at least two\nvariations (name variant, broader place, dropped parameter) \u2014 log each as\nits own entry (`references/search-strategy-external.md`, \"Exit criteria\").\nWhen online avenues are spent, remember undigitized records may still live\nin courthouses, parish archives, and historical societies.\n\n### 7. Update status and suggest the next step\n\nOnce the search is logged, found or not, set the plan item to `completed`\nwith a one-line `research_append` call (`section: \"plan_items\"`,\n`op: \"update\"`, the parent `planId` and the `entryId` you searched,\n`fields: { status: \"completed\" }`). On `{ ok: false }`, surface the errors\nand fix the inputs \u2014 never hand-edit `research.json`. This skill writes only\n`log[]` entries and the plan-item status; record-extraction writes any\nsource/assertion entries when you hand it a single-record capture. Then offer\nthe natural next move:\n- More plan items \u2192 \"Shall I continue with the next search?\"\n- A record worth examining \u2192 \"Capture the full record page for result #1?\"\n- All done \u2192 \"All planned searches are complete \u2014 evaluate whether\n  research is exhaustive?\"\n- Nil result \u2192 \"No matches on [site]; the plan's fallback is [next item].\n  Proceed?\"\n- Index hit \u2192 \"This is an index entry \u2014 shall we locate the original\n  image?\"\n- Compiled source \u2192 \"This is user-contributed; add a plan item to verify\n  it against originals?\"\n\n## Handling capture problems\n\n| Problem | Solution |\n|---------|----------|\n| PDF shows a login page | \"Please log in to [site], then click the link again\" |\n| PDF cuts off results (lazy loading) | \"Scroll to the bottom and back to the top before printing to PDF\" |\n| PDF missing images/thumbnails | \"Record images may not print \u2014 screenshot the document viewer separately\" |\n| PDF links aren't clickable | Construct record URLs from visible record IDs/database names instead of extracted links |\n| User can't access the site | Log `outcome: \"error\"` with the access limitation; move to the fallback plan item |\n\n## User-contributed sources\n\nFind A Grave memorials, public member trees, and crowd-sourced indexes are\ncompiled sources. Apply the nine criteria in\n`references/evaluating-compiled-sources.md`. In short: separate\nphotographed evidence from contributor-entered text, never cite them as\nprimary, and use them as leads \u2014 add a plan item to find the originals\nthey point to.\n\n## Re-invocation behavior\n\nThis skill writes only to `research.json`: a new append-only `log[]` entry\nand the `status` on the matching `plans[].items[]`. It does not write\nsource or assertion entries \u2014 record-extraction does that when the user\nreturns a single-record capture.\n\nRe-running a search is itself a logged event by design (the log is the\nexhaustive-search audit trail), so always append a new `log_` entry and\nupdate the plan item's status. Never modify or delete a prior `log_`\nentry; two runs of the same search correctly produce two entries.\n",
+    "packages/engine/plugin/skills/search-external-sites/references/evaluating-compiled-sources.md": "# Evaluating Compiled Sources\n\n## What is a compiled source?\n\nA compiled source is any source created by assembling, interpreting,\nor deriving information from other sources. This includes:\n\n- Published family histories and genealogies\n- Online family trees (Ancestry, MyHeritage, FamilySearch)\n- Find A Grave memorial pages (the text fields, not headstone photos)\n- Crowd-sourced indexes and transcriptions\n- County biographical volumes and local histories\n- Genealogical periodical articles containing abstracts or\n  transcriptions\n\nCompiled sources are valuable as leads and starting points but are\nnot themselves evidence. They must be verified against original\nrecords before any claim is accepted as established.\n\n## The nine evaluation criteria\n\nBefore relying on any compiled source, assess it against these\ncriteria:\n\n### 1. Completeness\nIs the work thorough, or does it have significant gaps? Does it\ncover the full family across all generations claimed, or does it\nskip individuals or time periods without explanation?\n\n### 2. Documentation present\nDoes the work include source citations? Are sources identified for\neach claim, or are statements made without any supporting reference?\n\n### 3. Citations support claims\nDo the cited sources actually support the specific claims made? A\ncitation that exists but points to irrelevant material is no better\nthan no citation at all.\n\n### 4. Original vs. compiled citations\nDo the citations reference original records (vital records, church\nregisters, court documents) or only other compiled sources? A\ngenealogy that cites only other genealogies has no independent\nfoundation.\n\n### 5. Completeness of citation coverage\nAre all claims cited, or only some? Partially documented work\nrequires extra skepticism for uncited claims.\n\n### 6. Source reliability\nAre the cited sources themselves trustworthy? A pension application\nmay have different reliability than a family Bible, which differs\nfrom a county history published 50 years after events.\n\n### 7. Specificity of dates\nDo dates appear to come from actual records (specific day-month-year)\nor are they rounded estimates (circa years, decade-only)? Specific\ndates suggest documentary evidence; vague dates suggest guesswork.\n\n### 8. Reasoning quality\nDoes the author demonstrate sound logic? Are conclusions supported\nby evidence, or do they rely on assumptions, wishful thinking, or\nlogical leaps (e.g., \"same name + same county = same person\")?\n\n### 9. Author credibility\nWhat is the author's background and track record? A board-certified\ngenealogist's published work carries different weight than an\nanonymous contributor's unsourced tree.\n\n## Applying the criteria in practice\n\nWhen triaging external-site results that come from compiled sources:\n\n**Find A Grave memorials:**\n- The memorial page text is compiled (user-entered, unverified)\n- A headstone photograph is an image of an original artifact\n- Contributor-added family links are the least reliable element\n- Use memorial information as leads; verify all facts against\n  vital records or other originals\n\n**Ancestry/MyHeritage public member trees:**\n- Most entries are unverified copies from other trees\n- Trees that cite specific records are more credible than those\n  with no sources\n- Attached record images provide the most useful information\n- Treat tree data as hypotheses to confirm, never as established\n  facts\n\n**Crowd-sourced indexes:**\n- Volunteer transcription introduces reading errors\n- Spelling normalization may obscure original forms\n- The index entry is a pointer to the original \u2014 always request\n  the original image\n\n## How to handle compiled sources in the workflow\n\n1. **Flag them clearly** in triage output as compiled/derivative\n2. **Note what criteria they meet or fail** (at minimum note\n   whether citations exist and whether originals are referenced)\n3. **Use them to generate plan items** for locating the original\n   records they reference or imply\n4. **Never promote compiled-source claims to assertions** without\n   verification against an original record\n5. **Cite the compiled source itself** if you reference it \u2014 it\n   becomes part of the audit trail showing what was consulted\n",
+    "packages/engine/plugin/skills/search-external-sites/references/places-guidance.md": "<!--\n  CANONICAL SOURCE \u2014 do not edit a copy in isolation.\n  This block is duplicated, byte-for-byte, into each place-using skill's\n  references/places-guidance.md (Claude Code can't reliably load a shared\n  reference across skills \u2014 issue #17741 \u2014 so each skill carries its own copy).\n  A drift lint (packages/engine/mcp-server/tests/packaging/skill-guidance.test.ts) fails if any\n  copy diverges from this source. To change the guidance: edit this file, then\n  re-copy it into every skill listed in that test.\n-->\n\n# Working with places (standard places)\n\nAbove the tool layer, places are always **names**, never IDs. The canonical\nname is the `standardPlace` from `place_search`.\n\n## Resolving a place\n\nCall `place_search` with the place name as `placeName` (optionally a\nhigher-level `contextName` to disambiguate):\n\n```\nplace_search({ placeName: \"Schuylkill County, Pennsylvania\" })\n```\n\nIt returns an array of matches; each match has a **`standardPlace`** field (the\nfully-qualified standardized name) plus `type`, `dateRange`, coordinates, and\nlinks. **Pick the best/first match and use its `standardPlace` verbatim** as the\nhandle for everything downstream. There are no place IDs in the output.\n\nUse **`place_search_all`** instead of `place_search` when jurisdictions or\nboundaries changed across the period you're researching \u2014 it returns *every*\nstandard place a location has belonged to over time, which informs where\nrecords were created and are now held.\n\n## Passing places to other tools\n\nThe place tools all take a `standardPlace` name (not an ID) and resolve it\ninternally \u2014 pass the `standardPlace` you got from `place_search`:\n\n- `place_population({ standardPlace, ... })`\n- `external_links_search({ standardPlace, ... })`\n- `collections_search({ standardPlace })` \u2014 lists record collections; it matches at the state level for the US/Canada/Mexico and the country level elsewhere (derived internally, returned as `scope`)\n- `place_distance({ standardPlace1, standardPlace2 })`\n- `wiki_place_page({ standardPlace, section })` \u2014 `section` is one of `home`, `getting_started`, `online_records`, `research_tips`\n- `volume_search({ standardPlace, ... })`\n\nFor `place_distance`, two events at the **same** `standard_place` are distance 0\n(no call needed); otherwise pass the two names.\n\n## Broadening to a parent jurisdiction\n\nEvery place tool returns results for the **exact** standardPlace you pass.\nA standardPlace is comma-delimited, most-specific-first\n(\"Schuylkill, Pennsylvania, United States\"), so its **parent jurisdiction is\nthe text after the first comma** (\"Pennsylvania, United States\", then\n\"United States\"). To broaden, drop the leading component and call again.\n\n- **Superseding resources** \u2014 `wiki_place_page`, `place_population`. One right\n  answer per place: the most-specific available. If a place has no page / no\n  data, climb to the parent and retry; **stop at the first hit.** A national\n  figure for a village is usually too generic to use \u2014 climb only as far as you\n  must.\n- **Additive resources** \u2014 `external_links_search`, `collections_search`,\n  `volume_search`. Each level holds *different* records (the county courthouse,\n  the state archive, the national index), so fetch the levels your research\n  actually needs and combine them. Bias to the specific end; the national level\n  is mostly generic collections the researcher already knows \u2014 pull it only on\n  first contact with a country or when the local levels are sparse.\n\n## Writing places to research.json / tree.gedcomx.json\n\nWhenever you persist a place on a fact, assertion, or timeline event, also set\nits **`standard_place`** companion (snake_case in the data formats) when one can\nbe found:\n\n- If the place came from a `record_read` / `record_search` / `person_read`\n  result, that fact already carries a converter-resolved `standard_place` \u2014\n  **copy it** (no tool call).\n- Otherwise call `place_search({ placeName: \"<place>\" })` and use the first\n  result's `standardPlace`. Resolve each distinct place once.\n- Leave `standard_place` null when `place` is null or nothing resolves.\n",
+    "packages/engine/plugin/skills/search-external-sites/references/repository-types.md": "# Repository Types: Digital vs. Physical\n\n## Why this matters\n\nReasonably exhaustive research requires searching across multiple\nrepository types \u2014 not just the most convenient online databases.\nMany critical records have never been digitized, exist only in a\nsingle physical location, and may never appear in an online search.\n\n## Digital repositories\n\nOnline platforms that provide searchable indexes, digitized images,\nor both. Examples: FamilySearch, Ancestry, FindMyPast, MyHeritage.\n\n**Strengths:**\n- Searchable from anywhere\n- Cover large geographic areas\n- Continuously expanding collections\n\n**Limitations:**\n- Only a fraction of all historical records have been digitized\n- Indexes contain errors (misread handwriting, typos, name\n  normalization)\n- Coverage varies dramatically by time period, geography, and\n  record type\n- A record not appearing in a digital search does not mean it\n  does not exist\n\n## Physical repositories\n\nInstitutions that hold original records in their facilities.\nExamples: county courthouses, state archives, the National Archives,\nchurch archives, historical societies, university special\ncollections, the Family History Library.\n\n**Key distinctions:**\n- Libraries collect published materials (books, periodicals)\n- Archives collect unpublished records (court records, government\n  documents, personal papers, organizational records)\n- Not all materials held by a physical repository have been\n  microfilmed or digitized\n- Some records are accessible only by visiting in person or\n  by written correspondence\n\n## What this means for search\n\nA negative result in an online database can mean any of:\n1. The record does not exist (the event never occurred or was\n   never recorded)\n2. The record exists but has not been digitized\n3. The record has been digitized but not indexed\n4. The record was indexed but under a different name, spelling,\n   or date (indexing error)\n5. The search parameters were too restrictive\n\nOnly interpretation #1 proves absence. Interpretations #2-5 mean\nthe record might still be findable through other methods.\n\n## When to suggest physical repositories\n\nAfter online searches across multiple sites return negative\nresults, note the possibility of undigitized records and suggest:\n- Checking the FamilySearch Catalog for microfilmed collections\n  that are browsable but not indexed\n- Contacting the relevant county courthouse or church archive\n- Consulting finding aids for archival collections at state or\n  national archives\n- Searching WorldCat for published transcription volumes held in\n  libraries\n\nAlways log the suggestion in the research notes so the user\nknows which physical repositories remain to be explored.\n",
+    "packages/engine/plugin/skills/search-external-sites/references/research-log-protocol.md": "# Research Log Protocol\n\nThis protocol must be followed by every skill that searches for or\nprocesses genealogical records. The research log is the GPS audit trail\nthat makes \"reasonably exhaustive\" claims provable.\n\n## Rules\n\n1. **Every search produces a log entry.** No exceptions. If you called\n   a search tool or generated a search URL, log it.\n\n2. **Nil results are recorded explicitly.** When a search returns no\n   results, write a log entry with `outcome: \"negative\"` and\n   `results_examined: 0`. The absence of a result is itself a finding.\n\n3. **Log entries are append-only.** Never modify or delete an existing\n   log entry. The log is the primary audit trail \u2014 if entries could be\n   edited, the exhaustive search declaration would be unfalsifiable.\n\n4. **Include search parameters.** The `query` object must capture\n   enough detail to reproduce the search: names, dates, places,\n   collection, and any filters used.\n\n5. **Link to plan items.** If the search was part of a research plan,\n   set `plan_item_id` to the `pli_` ID. For ad-hoc searches, use null.\n\n6. **Link outputs back to the search.** The log entry is immutable\n   (Rule 3). When sources and assertions are extracted from a logged\n   search, the extracting skill stamps each new source and assertion\n   with a `log_entry_id` pointing at the log entry. \"What did this\n   search produce\" is a reverse lookup over those fields \u2014 the log\n   entry itself is never revisited.\n\n7. **Retain the raw results.** A log entry records *that* a search ran;\n   the results it returned are retained too, so a later step can\n   re-examine or refute them (GPS Element 1 \u2014 reasonably exhaustive\n   research). External-site searches retain the captured PDF/HTML via\n   `external_site.capture_filename` \u2014 there is no result sidecar. (For\n   tool-payload searches, `research_log_append` finalizes the sidecar\n   itself from the search's staged handle; an external-site search never\n   passes one.)\n\n## What you supply, what the tool owns\n\nYou call `research_log_append` with the analytical fields below; the tool\nassigns the `log_NNN` id, the `performed` timestamp, and `results_ref`,\nvalidates the project, and writes atomically. The persisted entry is\nsnake_case; you pass the camelCase tool parameters.\n\n- `outcome` \u2014 your judgment: `positive` / `negative` / `partial` / `error`.\n- `resultsExamined` \u2014 how many results you actually triaged (0 for a nil\n  search).\n- `resultsAvailable` \u2014 the total hit count the tool reported, or null.\n- `notes` \u2014 a one-line human summary of what the search returned.\n- `externalSite` \u2014 for an external-site search, `{ site, urlGenerated,\n  captureReceived, captureFilename }`. The tool maps this to the persisted\n  `external_site` object.\n\n## When record-extraction writes log entries\n\nrecord-extraction writes a log entry **only** when processing a\nrecord that was not produced by search-records or\nsearch-external-sites \u2014 e.g., a user-provided PDF uploaded directly.\nWhen a search skill already logged the search, link to that log\nentry by setting `log_entry_id` on each new source and assertion,\nrather than creating a duplicate log entry.\n",
+    "packages/engine/plugin/skills/search-external-sites/references/search-strategy-external.md": "# Search Strategy for External Sites\n\n## Two fundamental approaches\n\n### \"Less is more\" (broad start)\nBegin with minimal criteria \u2014 just a surname and a broad location.\nThis casts a wide net and prevents missing results that were indexed\nwith errors, spelling variations, or incomplete data.\n\n**Best for:**\n- Unusual surnames\n- Uncertain details (approximate dates, unknown given name spelling)\n- Initial exploration of what is available\n- Situations where indexing quality is unknown\n\n### \"Kitchen sink\" (narrow start)\nEnter as many known details as possible \u2014 full name, dates, places,\nand relative names \u2014 to filter out false matches immediately.\n\n**Best for:**\n- Very common names (Smith, Johnson, Brown)\n- Well-documented individuals with known dates and places\n- Sites that handle multiple parameters well (Ancestry)\n- Second-pass searches after a broad search returned too many hits\n\n## Choosing a strategy per search\n\nConsider the name's uniqueness and your confidence in the details:\n- Rare name + uncertain details \u2192 broad start\n- Common name + strong details \u2192 narrow start\n- Any name + first time on this site \u2192 broad start to assess what\n  the collection contains\n- Follow-up after too many results \u2192 add parameters incrementally\n\n## Parameter iteration when results are poor\n\n### Too many results (hundreds or thousands)\n1. Add a relative name (spouse, father, or mother)\n2. Narrow the geographic scope (state \u2192 county)\n3. Restrict to a specific collection rather than site-wide\n4. Add a date constraint if not already present\n\n### Zero results\nTry these adjustments in priority order:\n\n1. **Remove the given name** \u2014 keep surname + place + date. The\n   given name may be indexed as an initial, nickname, or in a\n   different language.\n2. **Broaden the date range** \u2014 if the site supports year ranges,\n   widen to \u00b15 or \u00b110 years. Census ages are frequently inaccurate.\n3. **Try spelling variants** \u2014 use wildcards if the site supports\n   them (Sm*th, Eli?abeth), or manually try common variant spellings.\n4. **Broaden the location** \u2014 move from county to state level.\n5. **Remove the location entirely** \u2014 the ancestor may have been\n   recorded in an unexpected jurisdiction.\n6. **Search by a relative instead** \u2014 use the spouse's or parent's\n   name as the primary search subject.\n7. **Try a different event type** \u2014 if searching by birth location,\n   try residence or death location instead.\n\n### Still zero after all variations\nThe records may not exist in this database. Possible explanations:\n- The collection does not cover the relevant time period or place\n- The records exist but have not been digitized or indexed\n- The individual was recorded under a significantly different name\n\nLog the negative result and move to the next repository or suggest\nchecking physical holdings.\n\n## Boolean and advanced search techniques\n\nSome external sites support advanced query syntax:\n\n| Technique | Where supported | Example |\n|-----------|----------------|---------|\n| Exact phrase matching | Newspapers.com, some Ancestry collections | \"Patrick Flynn\" |\n| Wildcard characters | Ancestry (*, ?), FindMyPast | Fl?nn, Sm*th |\n| OR for name variants | Newspapers.com | Flynn OR Flyn OR Flinn |\n| Excluding terms | Newspapers.com | Flynn -advertisement |\n\nNot all sites document their Boolean support clearly. When in doubt,\nuse simple single-term parameters and iterate rather than complex\nqueries that may not parse correctly.\n\n## Research log requirements for search strategy\n\nEvery search URL generated must be logged with enough detail for\nreproduction. The log entry must capture:\n\n- The site searched\n- The collection (if not site-wide)\n- All parameters used (names, dates, places, filters)\n- The strategy rationale (why these parameters were chosen)\n- The result count and match quality summary\n- For zero-hit searches: what variations were attempted and what\n  was learned from the absence\n\nThis documentation proves that the researcher (a) searched\nsystematically rather than randomly, (b) tried reasonable\nvariations before declaring a collection exhausted, and (c)\nunderstands the difference between \"not found here\" and \"does\nnot exist.\"\n\n## Exit criteria: when is an external-site search exhaustive?\n\nA reasonably exhaustive search of a given external site has been\nperformed when:\n\n- Searched under at least two name variants (original spelling\n  plus one plausible alternative)\n- Searched with and without relative names where applicable\n- Searched at both the specific jurisdiction and one level broader\n- Examined the results from each collection that returned hits\n- Read the collection description to understand known coverage gaps\n- Documented every search attempt including zero-hit searches\n- Noted any access limitations (subscription required, collection\n  not available in this region)\n\nMeeting these criteria for one site does not make research\nexhaustive overall \u2014 the same standards apply to each repository\nin the research plan.\n",
+    "packages/engine/plugin/skills/search-external-sites/references/validation-protocol.md": "# Validation Protocol\n\n1. **Structural validation is automatic.** The persistence tools\n   (`research_log_append`, `research_append`, `tree_edit`, the merge\n   tools) validate the whole project *before* writing and persist\n   nothing on `{ ok: false, errors }`. You do not run `validate-schema`\n   after a tool write \u2014 if a call returns `{ ok: false }`, fix the\n   inputs and call again. (`validate-schema` remains available as a\n   manual audit of a project you did not just write through a tool.)\n\n2. **Invoke `check-warnings`** if you added assertions or\n   person_evidence entries. This checks for genealogical\n   impossibilities (married before 12, died after 120, child born\n   after parent's death, etc.) \u2014 structural validation does not cover\n   genealogical plausibility. It is not auto-triggered; invoke it\n   explicitly.\n",
+    "eval/tests/unit/search-external-sites/ancestry-census-search.json": "{\n  \"input\": {\n    \"scenario\": \"mid-research-flynn\",\n    \"user_message\": \"Search for Patrick Flynn on Ancestry's 1870 census.\"\n  },\n  \"judge_context\": [\n    \"Generated URL should target Ancestry.com (or the appropriate ancestry.{tld}) and include search parameters derived from the subject: name 'Patrick Flynn', birth year ~1845, and birthplace Ireland. NOTE: the scenario's birthplace conflict is RESOLVED to Ireland (conflicts[0]: the 1850/1860 censuses are accepted; the 1908 death certificate's 'Pennsylvania' \u2014 which the project objective still echoes \u2014 was rejected as son-in-law informant error). Using 'Ireland' is therefore correct and matches the resolved state; using 'Pennsylvania' would contradict it. Do not penalize 'Ireland' as an unsupported claim\",\n    \"Should provide capture-workflow instructions: tell the user to save matching results as a PDF and paste back the file path or content, with named record-type expectations (1870 census household entry \u2014 Patrick would be ~25 by then, possibly head of household if married)\",\n    \"Should not invent record content or pre-fill captured results \u2014 the analyze phase happens only after the user returns the capture\"\n  ],\n  \"mcp_fixtures\": [\n    \"place-search-schuylkill-county\",\n    \"place-search-schuylkill-by-name\",\n    \"place-search-schuylkill-by-place\",\n    \"external-links-search-schuylkill-1870-census\"\n  ],\n  \"test\": {\n    \"id\": \"ut_search_external_sites_001\",\n    \"skill\": \"search-external-sites\",\n    \"type\": \"positive\"\n  }\n}\n",
+    "eval/tests/unit/search-external-sites/autonomous-defer-external-search.json": "{\n  \"input\": {\n    \"scenario\": \"mid-research-flynn\",\n    \"user_message\": \"--autonomous mode. FamilySearch is already exhausted for this question, so the one remaining avenue is an Ancestry-only capture. Execute the external-site plan item: search Ancestry for Patrick Flynn in the 1880 census (Schuylkill County, Pennsylvania). Keep the run moving \u2014 there is no user available to click the link or upload a capture, so do not pause for user input.\"\n  },\n  \"judge_context\": [\n    \"This is an AUTONOMOUS run (the message contains --autonomous, and states no user is available). Autonomous mode INVERTS the normal click-capture-wait expectation: the correct behavior is NOT to present the URL and wait for a user to capture and upload a PDF.\",\n    \"Correct behavior: build the pre-filled Ancestry search URL (it is a real lead worth recording), then LOG the search as deferred with research_log_append \u2014 outcome 'negative', capture_received false, results_examined 0, and notes stating the search is deferred because it requires an interactive user capture and is not obtainable in an autonomous run, with the generated URL recorded in external_site.url_generated.\",\n    \"The external-site plan item should be marked terminal (status completed) so the autonomous run can proceed to the next step (e.g. research-exhaustiveness).\",\n    \"INCORRECT (fail): presenting the URL with instructions like 'click this link, save as PDF, and upload it' and then ending the turn waiting for the user \u2014 that stalls an autonomous run, which only stops on project.status completed or a logged blocker.\",\n    \"Because this is autonomous, do NOT penalize the ABSENCE of user-facing capture-workflow instructions on the Capture-guidance dimension \u2014 omitting them and deferred-logging instead is exactly right here; this overrides the normal capture-guidance expectation.\",\n    \"Routing to search-records for a FamilySearch equivalent is not applicable here (the message states FamilySearch is already exhausted), so the deferred-log path is the expected outcome.\"\n  ],\n  \"mcp_fixtures\": [\n    \"place-search-schuylkill-county\",\n    \"place-search-schuylkill-by-name\",\n    \"place-search-schuylkill-by-place\",\n    \"external-links-search-schuylkill\"\n  ],\n  \"test\": {\n    \"id\": \"ut_search_external_sites_013\",\n    \"skill\": \"search-external-sites\",\n    \"type\": \"positive\"\n  }\n}\n",
+    "eval/tests/unit/search-external-sites/findagrave-burial-search.json": "{\n  \"input\": {\n    \"scenario\": \"mid-research-flynn\",\n    \"user_message\": \"Look for Patrick Flynn's grave on FindAGrave \u2014 he died in Pennsylvania sometime after 1880.\"\n  },\n  \"judge_context\": [\n    \"Generated URL should target findagrave.com/memorial/search with name and location parameters (first name Patrick, last name Flynn, location Pennsylvania). NOTE: Patrick's death year (1908) is KNOWN from the research state (project objective: died 1908 in Schuylkill County). Using death year 1908 is therefore correct \u2014 it is the known fact and satisfies 'after 1880'; do NOT penalize it as a fabricated exact year or as over-narrowing. An open 'after 1880' bound is also acceptable. The user's vague 'sometime after 1880' does not override the known 1908.\",\n    \"Must include a compiled-source caution: FindAGrave memorials are user-contributed; photographed headstone evidence carries more weight than contributor-entered dates/family links; findings are leads needing verification against original records\",\n    \"FindAGrave basic search is free \u2014 there should be no subscription/paywall warning\",\n    \"A research-log entry must be written in the same turn the URL is generated: site findagrave, outcome partial, capture_received false\"\n  ],\n  \"mcp_fixtures\": [\n    \"place-search-pennsylvania\",\n    \"place-search-pennsylvania-by-name\",\n    \"place-search-pennsylvania-by-place\",\n    \"external-links-search-schuylkill\"\n  ],\n  \"test\": {\n    \"holdout\": true,\n    \"id\": \"ut_search_external_sites_005\",\n    \"skill\": \"search-external-sites\",\n    \"type\": \"positive\"\n  }\n}\n",
+    "eval/tests/unit/search-external-sites/findmypast-irish-birth.json": "{\n  \"input\": {\n    \"scenario\": \"mid-research-flynn\",\n    \"user_message\": \"Search FindMyPast for Patrick Flynn's birth in Ireland, about 1845.\"\n  },\n  \"judge_context\": [\n    \"external_links_search returns totalForPlace 0 \u2014 the skill should recognize FamilySearch curates nothing for this place and fall back to the site-wide FindMyPast template (findmypast.com/search/results) rather than inventing a curated collection URL\",\n    \"Generated URL should carry FindMyPast's parameter names (firstname, lastname, yearofbirth, keywordsplace or equivalent) filled from the subject: Patrick Flynn, birth about 1845, Ireland\",\n    \"Should provide capture-workflow instructions (click, save results as PDF, upload back) and note a login may be required since FindMyPast is a paid site\",\n    \"A research-log entry must be written in the same turn the URL is generated: site findmypast, outcome partial, capture_received false\"\n  ],\n  \"mcp_fixtures\": [\n    \"place-search-ireland\",\n    \"place-search-ireland-by-name\",\n    \"place-search-ireland-by-place\",\n    \"external-links-search-zero-results\"\n  ],\n  \"test\": {\n    \"id\": \"ut_search_external_sites_004\",\n    \"skill\": \"search-external-sites\",\n    \"type\": \"positive\"\n  }\n}\n",
+    "eval/tests/unit/search-external-sites/log-at-url-generation.json": "{\n  \"input\": {\n    \"scenario\": \"mid-research-flynn\",\n    \"user_message\": \"Search Ancestry for Patrick Flynn in the 1880 census.\"\n  },\n  \"judge_context\": [\n    \"The same turn that presents the Ancestry URL must also append the research-log entry \u2014 outcome partial, capture_received false, results_examined 0, with the generated URL recorded in external_site.url_generated\",\n    \"The response is incomplete if it presents the URL and says it will log after the user returns results \u2014 logging is part of the URL-generation step, not the capture step\",\n    \"Log query should capture the search parameters used (name Patrick Flynn, 1880 census, Pennsylvania/Schuylkill)\"\n  ],\n  \"mcp_fixtures\": [\n    \"place-search-schuylkill-county\",\n    \"place-search-schuylkill-by-name\",\n    \"place-search-schuylkill-by-place\",\n    \"external-links-search-schuylkill\"\n  ],\n  \"test\": {\n    \"id\": \"ut_search_external_sites_007\",\n    \"skill\": \"search-external-sites\",\n    \"type\": \"positive\"\n  }\n}\n",
+    "eval/tests/unit/search-external-sites/mixed-sites-filter-dedupe.json": "{\n  \"input\": {\n    \"scenario\": \"mid-research-flynn\",\n    \"user_message\": \"Search Ancestry for Thomas Flynn's probate or will records in Schuylkill County, 1870 to 1890.\"\n  },\n  \"judge_context\": [\n    \"Should use only ancestry.com URLs from the curated list \u2014 the MyHeritage, Find A Grave, FamilySearch-wiki, and Newspapers.com entries are not Ancestry options and should not be presented as such\",\n    \"The same Ancestry probate collection URL (collections/8800) appears three times under different labels \u2014 it should be collapsed to one option, not presented as three different collections\",\n    \"Should pick the probate/wills collection (matching the plan's record type) as the search base, not the 1850 census collection, and append the search parameters to the curated URL rather than rebuilding a site-wide URL from scratch\",\n    \"A research-log entry must be written in the same turn the URL is generated: site ancestry, outcome partial, capture_received false\",\n    \"This test grades host-filtering, deduping, and collection match \u2014 NOT date-encoding style. The 1870\u20131890 window may be encoded as a representative year (e.g. a midpoint plus a note) or as an explicit range; both are acceptable, so do not penalize using a single year (e.g. death=1880) instead of a range as an unsupported claim or over-narrowing.\"\n  ],\n  \"mcp_fixtures\": [\n    \"place-search-schuylkill-county\",\n    \"place-search-schuylkill-by-name\",\n    \"place-search-schuylkill-by-place\",\n    \"external-links-search-mixed-sites\"\n  ],\n  \"test\": {\n    \"id\": \"ut_search_external_sites_010\",\n    \"skill\": \"search-external-sites\",\n    \"type\": \"positive\"\n  }\n}\n",
+    "eval/tests/unit/search-external-sites/myheritage-url-generation.json": "{\n  \"input\": {\n    \"scenario\": \"mid-research-flynn\",\n    \"user_message\": \"Generate a MyHeritage search URL to look for Patrick Flynn in the 1860 census for Schuylkill County.\"\n  },\n  \"judge_context\": [\n    \"Generated URL should target MyHeritage (myheritage.com or appropriate locale) \u2014 not silently substitute Ancestry's URL structure\",\n    \"URL should include Patrick Flynn's search parameters (name, birth year ~1845) using MyHeritage's parameter naming conventions. MyHeritage's URL template only exposes `birth_place` for location encoding (no separate residence/jurisdiction field), so encoding the subject's actual birthplace \u2014 Ireland, per assertions a_002 and a_009 \u2014 is correct. Do not penalize the absence of a county-level location parameter; the template does not support it.\",\n    \"Should not fabricate captured records or pre-populate sources \u2014 the URL-generation step is single-turn; results come back via the multi-turn capture phase which is out of v1 scope\"\n  ],\n  \"mcp_fixtures\": [\n    \"place-search-schuylkill-county\",\n    \"place-search-schuylkill-by-name\",\n    \"place-search-schuylkill-by-place\",\n    \"external-links-search-schuylkill\"\n  ],\n  \"test\": {\n    \"id\": \"ut_search_external_sites_002\",\n    \"skill\": \"search-external-sites\",\n    \"type\": \"positive\"\n  }\n}\n",
+    "eval/tests/unit/search-external-sites/negative-familysearch-search.json": "{\n  \"input\": {\n    \"scenario\": \"mid-research-flynn\",\n    \"user_message\": \"Search FamilySearch for Patrick Flynn in the 1850 census.\"\n  },\n  \"judge_context\": [\n    \"Should route to search-records rather than generate a FamilySearch URL for manual click-through\"\n  ],\n  \"negative\": {\n    \"correct_skill\": [\n      \"search-records\"\n    ],\n    \"explanation\": \"FamilySearch is accessible via the MCP record_search tool \u2014 searching it doesn't require the click-capture-analyze workflow that search-external-sites is designed for. search-external-sites' purpose is bridging the gap to commercial sites (Ancestry, MyHeritage) where automated API search isn't available; FamilySearch has API access.\"\n  },\n  \"test\": {\n    \"id\": \"ut_search_external_sites_003\",\n    \"skill\": \"search-external-sites\",\n    \"type\": \"negative\"\n  }\n}\n",
+    "eval/tests/unit/search-external-sites/negative-planning-question.json": "{\n  \"input\": {\n    \"scenario\": \"mid-research-flynn\",\n    \"user_message\": \"What external sites should I search next to find Patrick's parents?\"\n  },\n  \"judge_context\": [\n    \"Should route to research-plan (or recommend planning) rather than immediately generating external-site search URLs for sites the user never chose\"\n  ],\n  \"negative\": {\n    \"correct_skill\": [\n      \"research-plan\"\n    ],\n    \"explanation\": \"Choosing what to search \u2014 which sites, which record types, in what order \u2014 is planning, owned by research-plan. search-external-sites is the execution arm: it fires when a specific external-site search has been chosen (by the user or a plan item) and a URL needs generating. Answering a 'what next' question with generated URLs skips the prioritization, fallback, and rationale that planning produces.\"\n  },\n  \"test\": {\n    \"id\": \"ut_search_external_sites_011\",\n    \"skill\": \"search-external-sites\",\n    \"type\": \"negative\"\n  }\n}\n",
+    "eval/tests/unit/search-external-sites/negative-record-in-hand.json": "{\n  \"input\": {\n    \"scenario\": \"mid-research-flynn\",\n    \"user_message\": \"I've saved the individual record page for Patrick Flynn from the Ancestry search as a PDF \u2014 extract the names, dates, and places from it into the research files.\"\n  },\n  \"judge_context\": [\n    \"Should route to record-extraction for assertion extraction rather than generating a new search URL or re-triaging\"\n  ],\n  \"negative\": {\n    \"correct_skill\": [\n      \"record-extraction\"\n    ],\n    \"explanation\": \"A single captured record page going into the research files is assertion extraction \u2014 record-extraction's purpose. search-external-sites generates search URLs and triages results lists; its own workflow explicitly passes individual selected records to record-extraction. Re-firing search-external-sites here would either re-search (wrong) or duplicate record-extraction's extraction logic (also wrong).\"\n  },\n  \"test\": {\n    \"id\": \"ut_search_external_sites_012\",\n    \"skill\": \"search-external-sites\",\n    \"type\": \"negative\"\n  }\n}\n",
+    "eval/tests/unit/search-external-sites/newspapers-obituary-search.json": "{\n  \"input\": {\n    \"scenario\": \"mid-research-flynn\",\n    \"user_message\": \"Search Newspapers.com for Patrick Flynn's obituary in Schuylkill County, between 1880 and 1905.\"\n  },\n  \"judge_context\": [\n    \"Generated URL should target newspapers.com/search with the name as the query term and the 1880-1905 window and Pennsylvania/Schuylkill place expressed via its range parameters (dr_year / dr_place or equivalent) \u2014 not the record-site parameter style (no birthplace/birth= parameters)\",\n    \"Should provide capture-workflow instructions (click, save the results page or clipping as PDF, upload back) and note Newspapers.com is a paid site so a login may be required\",\n    \"A research-log entry must be written in the same turn the URL is generated: site newspapers, outcome partial, capture_received false, query capturing name + date range + place\"\n  ],\n  \"mcp_fixtures\": [\n    \"place-search-schuylkill-county\",\n    \"place-search-schuylkill-by-name\",\n    \"place-search-schuylkill-by-place\",\n    \"external-links-search-schuylkill\"\n  ],\n  \"test\": {\n    \"id\": \"ut_search_external_sites_006\",\n    \"skill\": \"search-external-sites\",\n    \"type\": \"positive\"\n  }\n}\n",
+    "eval/tests/unit/search-external-sites/nil-result-logging.json": "{\n  \"input\": {\n    \"scenario\": \"mid-research-flynn\",\n    \"user_message\": \"I ran that Newspapers.com search for Patrick Flynn's obituary in Schuylkill County \u2014 the site says zero results. Nothing came up, so there's nothing to save.\"\n  },\n  \"judge_context\": [\n    \"Must append a research-log entry for the zero-match search with outcome negative \u2014 skipping the log because nothing was found is the failure this test exists to catch\",\n    \"Log notes should state what was searched and its limitations: newspaper digitization coverage is incomplete, the obituary may exist in an undigitized paper or under a name variant \u2014 absence from this collection is not proof of absence\",\n    \"Should suggest a sensible follow-up rather than dead-ending: a search variation (name variant, wider date range, neighboring counties), another site, or physical repositories\",\n    \"Should not fabricate results or treat the nil report as an error\"\n  ],\n  \"mcp_fixtures\": [\n    \"place-search-schuylkill-county\",\n    \"place-search-schuylkill-by-name\",\n    \"place-search-schuylkill-by-place\",\n    \"external-links-search-schuylkill\"\n  ],\n  \"test\": {\n    \"holdout\": true,\n    \"id\": \"ut_search_external_sites_008\",\n    \"skill\": \"search-external-sites\",\n    \"type\": \"positive\"\n  }\n}\n",
+    "eval/tests/unit/search-external-sites/rubric.md": "# Search External Sites Rubric\n\nGrading dimensions for search-external-sites unit tests. Evaluated by the LLM judge alongside the base rubric (correctness, completeness).\n\n**Two kinds of turn.** Most turns **generate** a search (build a pre-filled URL, instruct the capture workflow, log it). But some turns **record a search the user already ran** \u2014 a nil-result report (\"I searched X, zero results\"). On a nil-result-report turn there is no new search to generate, so the URL-generation, Capture-guidance, and Tool-selection dimensions grade the *logging* task: the skill correctly logs the negative result (site, place, date, coverage limits) and may nudge for a confirming capture of the empty results screen. Do **not** mark these dimensions partial/fail on a nil-result-report turn for \"no freshly built URL,\" \"no full capture-workflow instructions,\" or \"didn't call place_search/external_links_search\" \u2014 none of those apply when the user already performed the search. Grade what the nil-report turn requires, not the search-generation flow.\n\n## URL generation\n\nDid the skill generate a correctly pre-filled search URL for the target site (Ancestry, MyHeritage, etc.)? The URL should include the search parameters from the plan item.\n\n- **pass:** Generated URL targets the correct site's search endpoint, includes all relevant search parameters from the plan item (name, date range, place), and is syntactically valid.\n- **partial:** URL targets the right site but is missing a search parameter the plan item specified, or uses a less-effective query encoding.\n- **fail:** URL targets the wrong site, has malformed query parameters, or omits the core search terms entirely.\n\n## Capture guidance\n\nDid the skill provide clear instructions for the click-capture workflow? The user needs to know what to look for and how to return results.\n\n- **pass:** Instructions name what records the user should look for, how to save them (PDF download, copy-paste), and how to return the capture.\n- **partial:** Instructions exist but are generic (\"save anything that looks relevant\") without naming specific result types or saving steps.\n- **fail:** No instructions provided, or instructions assume the user knows the workflow already.\n\n## Result triage\n\nDid the skill handle results correctly **for the phase this turn actually reached**? Triage runs only *after* the user uploads a capture (PDF). Most tests end at URL generation, before any capture exists \u2014 so there is nothing to triage yet, and the correct behavior is to **defer**: don't fabricate or pre-judge results you haven't received, and signal what you'll evaluate once the capture arrives. On a no-capture turn, grade the deferral, not the absence of triage \u2014 a clean deferral is a **pass**, never a partial, because waiting for the capture is exactly what the workflow asks for. Only when a capture is actually present in the turn do you grade the per-record triage itself. (Scoring this dimension `null` / N-A on a no-capture turn is also acceptable; what must never happen is a partial or fail for correctly waiting.)\n\n- **pass:** No capture in the turn \u2192 the skill defers triage without fabricating matches, ideally naming the criteria it will apply (name, age/birth-year, jurisdiction). Capture present \u2192 every result is categorized (relevant / needs review / not relevant) with reasoning that cites specific matching or non-matching attributes.\n- **partial:** A capture is present and most results are triaged correctly, but one near-match is mis-categorized without justification. (A correct deferral on a no-capture turn is **not** a partial.)\n- **fail:** The skill fabricates results or claims matches from a capture that was never provided; or, with a capture present, bulk-accepts or bulk-rejects without per-record reasoning, or silently drops relevant records.\n\n## Tool selection\n\nDid the skill use its MCP tools per the documented flow \u2014 resolve the place, fetch curated links, and consume the response correctly?\n\nThis dimension grades a turn that **generates** a search. When the turn instead **records a search the user already ran** \u2014 a nil-result report (\"I searched X, zero results\") \u2014 no new search is being generated, so the skill correctly logs it with `research_log_append` alone; `place_search`/`external_links_search` are **not** expected and their absence is a pass, not a slip.\n\n- **pass:** For a search-generation turn: `place_search` runs first and the **`standardPlace` it returns** (not a guessed string) feeds `external_links_search` with the plan item's year window \u2014 using that returned value is correct even when it resolves to a broader administrative level (e.g. state) than the place named in the request. The response is consumed per the rules: keep links whose host matches the target site, dedupe repeated URLs, confirm a kept link's record type fits the plan item, and **fall back to the site-wide template whenever no curated link matches the target site or record type** (a correct, expected fallback \u2014 not a slip). The search is persisted via `research_log_append` (which validates before persisting). For a nil-result-report turn: logging the reported search via `research_log_append` alone is the complete, correct tool use.\n- **partial:** On a search-generation turn, right tools but a genuine consumption slip \u2014 fabricated or guessed a `standardPlace` that `place_search` did not return, presented a curated link for the wrong record type as if it fit, or failed to dedupe duplicate curated URLs. (Not calling `place_search`/`external_links_search` on a nil-result-report turn is **not** a slip.)\n- **fail:** Skipped `external_links_search` entirely and hand-built a URL when a *matching* curated link existed, or called tools with fabricated arguments.\n\n## Log entry\n\nDid the skill write the research-log entry for the search \u2014 at URL-generation time, and for nil results?\n\n- **pass:** A new `log[]` entry names the site, person, place, and year/range (in `query`/`notes`), written in the same turn the URL is generated (`outcome: \"partial\"`, `capture_received: false`). A reported zero-match search is logged with `outcome: \"negative\"` and notes on coverage limitations \u2014 never skipped because \"there was nothing to record\".\n- **partial:** Entry present but incomplete or vague (e.g. \"searched records\" without site/year), or written only after results came back instead of at URL generation.\n- **fail:** No log entry, or a misleading one (wrong site, claims results that were not received).\n",
+    "eval/tests/unit/search-external-sites/subscription-aware-warning.json": "{\n  \"input\": {\n    \"scenario\": \"mid-research-flynn-ancestry-sub\",\n    \"user_message\": \"Search MyHeritage for Patrick Flynn's marriage record in Pennsylvania, around 1865 to 1875.\"\n  },\n  \"judge_context\": [\n    \"The researcher profile lists only an Ancestry subscription \u2014 the response should include a brief warning that the MyHeritage link will land on a login wall or limited-results preview, and offer the choice to continue or use a subscribed site\",\n    \"The MyHeritage URL must still be generated (flagged, not blocked) with myheritage.com/research query parameters filled from the subject (first Patrick, last Flynn, marriage window 1865-1875, Pennsylvania)\",\n    \"Should not lecture at length about subscriptions \u2014 the skill specifies one line of context, and FindAGrave-style free alternatives are optional suggestions, not replacements for the explicit request\",\n    \"A research-log entry must be written in the same turn the URL is generated: site myheritage, outcome partial, capture_received false\"\n  ],\n  \"mcp_fixtures\": [\n    \"place-search-pennsylvania\",\n    \"place-search-pennsylvania-by-name\",\n    \"place-search-pennsylvania-by-place\",\n    \"external-links-search-pennsylvania\"\n  ],\n  \"test\": {\n    \"id\": \"ut_search_external_sites_009\",\n    \"skill\": \"search-external-sites\",\n    \"type\": \"positive\"\n  }\n}\n",
+    "eval/fixtures/scenarios/mid-research-flynn/README.md": "# mid-research-flynn\n\nPatrick Flynn parentage research, mid-project.\n\n- **Objective:** Identify the parents of Patrick Flynn (b. ~1845, d. 1908)\n- **Questions:** q_001 (parentage, in_progress), q_002 (1850 census placement, resolved)\n- **Plans:** pl_001 (1850 census search, completed), pl_002 (parentage evidence, active)\n- **Log:** 5 entries \u2014 1850 census on FamilySearch/Ancestry/MyHeritage, 1860 census, death cert\n- **Sources:** 4 sources (1850 census FS, 1850 census Ancestry, 1860 census, death cert)\n- **Assertions:** 13 assertions across 4 sources\n- **Person evidence:** 6 links (Patrick \u2192 I1, Thomas \u2192 I2)\n- **Conflicts:** 1 resolved (birthplace: Ireland vs Pennsylvania)\n- **Hypotheses:** h_001 (Thomas is Patrick's father, supported)\n- **Timelines:** t_001 (Patrick, 4 events, 1 gap)\n- **Proof summaries:** ps_001 (parentage, probable)\n- **GedcomX persons:** I1 (Patrick Flynn), I2 (Thomas Flynn), I3 (Mary Flynn, sister), I4 (James Flynn, brother)\n- **GedcomX relationships:** R1 (Thomas \u2192 Patrick), R2 (Thomas \u2192 Mary), R3 (Thomas \u2192 James) \u2014 all ParentChild\n- **Note on siblings:** Mary and James are stub entries (preferred name + gender only, no facts).\n  They are **prior-research children**: R2/R3 cite the St. Mary's baptismal registers (S5 \u2014\n  baptisms of 1841 and 1847), NOT the 1850 census. They represent the canonical shape Dallan\n  called for: when researching Patrick on a household census, already-documented siblings exist\n  as persons in `tree.gedcomx.json` so warnings like `relativesChildBirthRange40` and skills\n  like `person-evidence` can reach them. Mary and James do not appear in the 1850 census\n  household (which lists Bridget, Patrick, and John as children) \u2014 a record-vs-tree\n  discrepancy that is deliberate: extraction from that census should stub the new children and\n  surface the discrepancy as an identity question, never rename existing persons.\n",
+    "eval/fixtures/scenarios/mid-research-flynn/research.json": "{\n  \"assertions\": [\n    {\n      \"date\": null,\n      \"date_certainty\": null,\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_002\"\n      ],\n      \"fact_type\": \"name\",\n      \"id\": \"a_001\",\n      \"informant\": \"Unknown informant (most likely a household member, possibly a neighbor) reporting to census enumerator\",\n      \"informant_bias_notes\": \"Census enumerator is the recorder, not the informant. The person who provided the name is unknown \u2014 most likely a household member, possibly a neighbor. Proximity is 'unknown' rather than 'household_member' because for names specifically, the enumerator may have heard the name from a neighbor or made an assumption \u2014 the name fact doesn't necessarily require active reporting the way age/birthplace does.\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_001\",\n      \"place\": null,\n      \"record_id\": \"ark:/61903/1:1:MXYZ\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_001\",\n      \"structured_value\": {\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"value\": \"Patrick Flynn\"\n    },\n    {\n      \"date\": \"~1845\",\n      \"date_certainty\": \"estimated\",\n      \"evidence_type\": \"indirect\",\n      \"extracted_for_question_ids\": [\n        \"q_002\"\n      ],\n      \"fact_type\": \"birth\",\n      \"id\": \"a_002\",\n      \"informant\": \"Unknown \u2014 most likely a household member (such as Thomas Flynn or his wife), but possibly a neighbor\",\n      \"informant_bias_notes\": \"Age and birthplace require active reporting by an informant \u2014 someone had to tell the enumerator these facts. That informant was most likely a household member, but enumerators also took information from neighbors when residents were unavailable, and the census does not identify who answered. Proximity is 'unknown' because the informant cannot be established from the record.\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_001\",\n      \"place\": \"Ireland\",\n      \"record_id\": \"ark:/61903/1:1:MXYZ\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_001\",\n      \"structured_value\": {\n        \"place\": \"Ireland\",\n        \"year\": 1845\n      },\n      \"value\": \"age 5\"\n    },\n    {\n      \"date\": \"1850\",\n      \"date_certainty\": \"exact\",\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_002\"\n      ],\n      \"fact_type\": \"residence\",\n      \"id\": \"a_003\",\n      \"informant\": \"Census enumerator (witness to residence by visiting the dwelling)\",\n      \"informant_bias_notes\": \"For residence facts specifically, the enumerator is a direct witness \u2014 they physically visited the dwelling and recorded who lived there. This distinguishes residence from other census facts where an unidentified informant (most likely a household member, possibly a neighbor) supplied the information.\",\n      \"informant_proximity\": \"witness\",\n      \"information_quality\": \"primary\",\n      \"log_entry_id\": \"log_001\",\n      \"place\": \"Schuylkill County, Pennsylvania\",\n      \"record_id\": \"ark:/61903/1:1:MXYZ\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_001\",\n      \"value\": \"Schuylkill County, Pennsylvania\"\n    },\n    {\n      \"date\": \"1850\",\n      \"date_certainty\": \"exact\",\n      \"evidence_type\": \"indirect\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"relationship\",\n      \"id\": \"a_004\",\n      \"informant\": \"Inferred from household structure \u2014 no explicit informant for relationships in 1850 census\",\n      \"informant_bias_notes\": \"1850 census does not state relationships; this assertion is inferred from household position and shared surname, not directly reported by any informant. The relationship is indirect evidence constructed by the researcher, not information provided by a census informant.\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_001\",\n      \"place\": \"Schuylkill County, Pennsylvania\",\n      \"record_id\": \"ark:/61903/1:1:MXYZ\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_001\",\n      \"structured_value\": {\n        \"related_person_role\": \"head_of_household\",\n        \"relationship_type\": \"child_inferred\"\n      },\n      \"value\": \"Listed in household of Thomas Flynn (head), position consistent with child\"\n    },\n    {\n      \"date\": null,\n      \"date_certainty\": null,\n      \"evidence_type\": \"indirect\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"name\",\n      \"id\": \"a_005\",\n      \"informant\": \"Unknown informant (likely Thomas Flynn himself) reporting to census enumerator\",\n      \"informant_bias_notes\": \"Census enumerator is the recorder, not the informant. As head of household, Thomas likely provided his own name, but the 1850 census does not identify the informant.\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_001\",\n      \"place\": null,\n      \"record_id\": \"ark:/61903/1:1:MXYZ\",\n      \"record_role\": \"head_of_household\",\n      \"source_id\": \"src_001\",\n      \"value\": \"Thomas Flynn\"\n    },\n    {\n      \"date\": null,\n      \"date_certainty\": null,\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_002\"\n      ],\n      \"fact_type\": \"name\",\n      \"id\": \"a_006\",\n      \"informant\": \"Ancestry transcriber (derivative of census enumerator)\",\n      \"informant_bias_notes\": \"Derivative index \u2014 transcription errors possible\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_002\",\n      \"place\": null,\n      \"record_id\": \"ancestry:8054:patrick-flynn-1850\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_002\",\n      \"value\": \"Patrick Flynn\"\n    },\n    {\n      \"date\": \"~1845\",\n      \"date_certainty\": \"estimated\",\n      \"evidence_type\": \"indirect\",\n      \"extracted_for_question_ids\": [\n        \"q_002\"\n      ],\n      \"fact_type\": \"birth\",\n      \"id\": \"a_007\",\n      \"informant\": \"Ancestry transcriber (derivative)\",\n      \"informant_bias_notes\": null,\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_002\",\n      \"place\": \"Ireland\",\n      \"record_id\": \"ancestry:8054:patrick-flynn-1850\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_002\",\n      \"value\": \"age 5\"\n    },\n    {\n      \"date\": null,\n      \"date_certainty\": null,\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"name\",\n      \"id\": \"a_008\",\n      \"informant\": \"Unknown informant (most likely a household member, possibly a neighbor) reporting to census enumerator\",\n      \"informant_bias_notes\": \"Census enumerator is the recorder, not the informant. Proximity is 'unknown' for names (same reasoning as a_001 \u2014 name facts don't necessarily require active reporting).\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_004\",\n      \"place\": null,\n      \"record_id\": \"ark:/61903/1:1:MABC\",\n      \"record_role\": \"child_2\",\n      \"source_id\": \"src_003\",\n      \"value\": \"Patrick Flynn\"\n    },\n    {\n      \"date\": \"~1845\",\n      \"date_certainty\": \"estimated\",\n      \"evidence_type\": \"indirect\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"birth\",\n      \"id\": \"a_009\",\n      \"informant\": \"Unknown \u2014 most likely a household member (such as Thomas Flynn or his wife), but possibly a neighbor\",\n      \"informant_bias_notes\": \"Age and birthplace require active reporting by an informant \u2014 most likely a household member, possibly a neighbor (same reasoning as a_002).\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_004\",\n      \"place\": \"Ireland\",\n      \"record_id\": \"ark:/61903/1:1:MABC\",\n      \"record_role\": \"child_2\",\n      \"source_id\": \"src_003\",\n      \"value\": \"age 15\"\n    },\n    {\n      \"date\": \"1860\",\n      \"date_certainty\": \"exact\",\n      \"evidence_type\": \"indirect\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"relationship\",\n      \"id\": \"a_010\",\n      \"informant\": \"Inferred from household structure \u2014 no explicit informant for relationships in 1860 census\",\n      \"informant_bias_notes\": \"1860 census does not state relationships; like the 1850 census, this assertion is inferred from household position, age, and shared surname. The relationship column was not introduced until the 1880 census.\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_004\",\n      \"place\": \"Schuylkill County, Pennsylvania\",\n      \"record_id\": \"ark:/61903/1:1:MABC\",\n      \"record_role\": \"child_2\",\n      \"source_id\": \"src_003\",\n      \"structured_value\": {\n        \"related_person_role\": \"head_of_household\",\n        \"relationship_type\": \"child_inferred\"\n      },\n      \"value\": \"Listed in household of Thomas Flynn (head), position and age consistent with son\"\n    },\n    {\n      \"date\": \"1908-03-12\",\n      \"date_certainty\": \"exact\",\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [],\n      \"fact_type\": \"death\",\n      \"id\": \"a_011\",\n      \"informant\": \"Attending physician (signature on certificate)\",\n      \"informant_bias_notes\": null,\n      \"informant_proximity\": \"witness\",\n      \"information_quality\": \"primary\",\n      \"log_entry_id\": \"log_005\",\n      \"place\": \"Schuylkill County, Pennsylvania\",\n      \"record_id\": \"ark:/61903/1:1:MDEF\",\n      \"record_role\": \"deceased\",\n      \"source_id\": \"src_004\",\n      \"value\": \"Died 12 March 1908\"\n    },\n    {\n      \"date\": \"1845\",\n      \"date_certainty\": \"approximate\",\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"birth\",\n      \"id\": \"a_012\",\n      \"informant\": \"James Brown (son-in-law)\",\n      \"informant_bias_notes\": \"Son-in-law reporting birth facts decades after the event. Note: death cert says Pennsylvania, but census records say Ireland. Son-in-law may not have known Patrick was born in Ireland.\",\n      \"informant_proximity\": \"family_not_present\",\n      \"information_quality\": \"secondary\",\n      \"log_entry_id\": \"log_005\",\n      \"place\": \"Pennsylvania\",\n      \"record_id\": \"ark:/61903/1:1:MDEF\",\n      \"record_role\": \"deceased\",\n      \"source_id\": \"src_004\",\n      \"structured_value\": {\n        \"place\": \"Pennsylvania\",\n        \"year\": 1845\n      },\n      \"value\": \"Born 1845, Pennsylvania\"\n    },\n    {\n      \"date\": null,\n      \"date_certainty\": null,\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"relationship\",\n      \"id\": \"a_013\",\n      \"informant\": \"James Brown (son-in-law)\",\n      \"informant_bias_notes\": \"Secondary information \u2014 son-in-law reporting what he was told about father-in-law's parentage\",\n      \"informant_proximity\": \"family_not_present\",\n      \"information_quality\": \"secondary\",\n      \"log_entry_id\": \"log_005\",\n      \"place\": null,\n      \"record_id\": \"ark:/61903/1:1:MDEF\",\n      \"record_role\": \"deceased\",\n      \"source_id\": \"src_004\",\n      \"structured_value\": {\n        \"related_person_role\": \"deceased\",\n        \"relationship_type\": \"father\"\n      },\n      \"value\": \"Father: Thomas Flynn\"\n    }\n  ],\n  \"conflicts\": [\n    {\n      \"blocks_question_ids\": [],\n      \"competing_assertion_ids\": [\n        \"a_002\",\n        \"a_009\",\n        \"a_012\"\n      ],\n      \"conflict_type\": \"fact\",\n      \"description\": \"Patrick Flynn's birthplace: Ireland (1850 and 1860 censuses) vs. Pennsylvania (1908 death certificate)\",\n      \"disputed_attribute\": \"birthplace\",\n      \"id\": \"c_001\",\n      \"identity_question\": null,\n      \"independence_analysis\": \"The two census records (1850, 1860) are independent original sources with different enumerators. The death certificate is a third independent original source. However, the census informants are likely the same household member (Thomas Flynn or wife), so the two census assertions may share a single informant \u2014 potentially not fully independent for this fact.\",\n      \"preferred_assertion_id\": \"a_002\",\n      \"resolution_rationale\": \"Ireland is accepted as the birthplace. The 1908 death certificate birthplace of 'Pennsylvania' is rejected as a likely error by the son-in-law informant, who may have confused Patrick's place of residence with his place of birth, or may not have known Patrick was born in Ireland before immigrating as a young child.\",\n      \"status\": \"resolved\",\n      \"weighing_analysis\": \"The census records are contemporary recordings made near the time of Patrick's birth, while the death certificate was created 63 years later. The census informant was likely a household member with firsthand knowledge (primary or indeterminate), while the death certificate informant (son-in-law) is clearly secondary for birth facts. Two contemporary sources outweigh one later recollection by a secondary informant.\"\n    }\n  ],\n  \"evaluations\": [],\n  \"hypotheses\": [\n    {\n      \"claim\": \"Patrick Flynn's father was Thomas Flynn of Schuylkill County, Pennsylvania\",\n      \"contradicting_assertion_ids\": [],\n      \"id\": \"h_001\",\n      \"notes\": \"Three independent pieces of evidence: 1850 census co-enumeration (indirect), 1860 census co-enumeration (indirect \u2014 relationship inferred from household position), death certificate naming Thomas as father (direct, secondary informant). Awaiting probate records for additional confirmation.\",\n      \"related_question_ids\": [\n        \"q_001\"\n      ],\n      \"ruled_out\": false,\n      \"ruled_out_reason\": null,\n      \"status\": \"supported\",\n      \"supporting_assertion_ids\": [\n        \"a_004\",\n        \"a_010\",\n        \"a_013\"\n      ]\n    }\n  ],\n  \"log\": [\n    {\n      \"external_site\": null,\n      \"id\": \"log_001\",\n      \"notes\": \"Found Patrick Flynn age 5 in household of Thomas Flynn, dwelling 84, Schuylkill Co. Three other Flynn results examined \u2014 ages and locations don't match.\",\n      \"outcome\": \"positive\",\n      \"performed\": \"2026-05-01T10:15:00Z\",\n      \"plan_item_id\": \"pli_001\",\n      \"query\": {\n        \"birth_place\": \"Pennsylvania\",\n        \"birth_year\": 1845,\n        \"collection\": \"1850 Census\",\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"results_examined\": 8,\n      \"tool\": \"record_search\"\n    },\n    {\n      \"external_site\": {\n        \"capture_filename\": \"ancestry-1850-flynn-results.pdf\",\n        \"capture_received\": true,\n        \"site\": \"ancestry\",\n        \"url_generated\": \"https://www.ancestry.com/search/collections/8054/?name=Patrick_Flynn&birth=1845&birthplace=Pennsylvania\"\n      },\n      \"id\": \"log_002\",\n      \"notes\": \"Ancestry index confirms same household. Transcription matches FamilySearch except Ancestry reads dwelling as 84, FamilySearch as 84 \u2014 consistent.\",\n      \"outcome\": \"positive\",\n      \"performed\": \"2026-05-01T11:30:00Z\",\n      \"plan_item_id\": \"pli_002\",\n      \"query\": {\n        \"birth_place\": \"Pennsylvania\",\n        \"birth_year\": 1845,\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"results_examined\": 12,\n      \"tool\": \"external_site\"\n    },\n    {\n      \"external_site\": {\n        \"capture_filename\": \"myheritage-1850-flynn-nil.pdf\",\n        \"capture_received\": true,\n        \"site\": \"myheritage\",\n        \"url_generated\": \"https://www.myheritage.com/research?action=query&first=Patrick&last=Flynn&birth_year=1845&birth_place=Pennsylvania\"\n      },\n      \"id\": \"log_003\",\n      \"notes\": \"MyHeritage returned no results for Patrick Flynn in 1850 Schuylkill County. Site may not have this collection indexed. Searched broader Pennsylvania \u2014 still no match.\",\n      \"outcome\": \"negative\",\n      \"performed\": \"2026-05-01T14:00:00Z\",\n      \"plan_item_id\": \"pli_003\",\n      \"query\": {\n        \"birth_place\": \"Pennsylvania\",\n        \"birth_year\": 1845,\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"results_examined\": 0,\n      \"tool\": \"external_site\"\n    },\n    {\n      \"external_site\": null,\n      \"id\": \"log_004\",\n      \"notes\": \"Patrick Flynn age 15 in household of Thomas Flynn, Schuylkill Co. Consistent with 1850 placement.\",\n      \"outcome\": \"positive\",\n      \"performed\": \"2026-05-02T09:00:00Z\",\n      \"plan_item_id\": \"pli_004\",\n      \"query\": {\n        \"birth_place\": \"Pennsylvania\",\n        \"birth_year\": 1845,\n        \"collection\": \"1860 Census\",\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"results_examined\": 5,\n      \"tool\": \"record_search\"\n    },\n    {\n      \"external_site\": null,\n      \"id\": \"log_005\",\n      \"notes\": \"Death certificate found. Names Thomas Flynn as father. Informant was son-in-law James Brown.\",\n      \"outcome\": \"positive\",\n      \"performed\": \"2026-05-03T10:00:00Z\",\n      \"plan_item_id\": \"pli_005\",\n      \"query\": {\n        \"death_place\": \"Schuylkill County, Pennsylvania\",\n        \"death_year\": 1908,\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"results_examined\": 2,\n      \"tool\": \"record_search\"\n    }\n  ],\n  \"person_evidence\": [\n    {\n      \"assertion_id\": \"a_001\",\n      \"confidence\": \"confident\",\n      \"created\": \"2026-05-01\",\n      \"id\": \"pe_001\",\n      \"match_score\": null,\n      \"person_id\": \"I1\",\n      \"rationale\": \"Name matches (Patrick Flynn), age consistent with ~1845 birth, located in Schuylkill County where subject is known to have lived. Only Patrick Flynn of this age in the county in 1850.\",\n      \"superseded_by\": null\n    },\n    {\n      \"assertion_id\": \"a_004\",\n      \"confidence\": \"probable\",\n      \"created\": \"2026-05-01\",\n      \"id\": \"pe_002\",\n      \"match_score\": null,\n      \"person_id\": \"I1\",\n      \"rationale\": \"Same record as pe_001, same person. Household position and shared surname with head Thomas Flynn suggest parent-child relationship, but 1850 census does not state relationships explicitly.\",\n      \"superseded_by\": null\n    },\n    {\n      \"assertion_id\": \"a_004\",\n      \"confidence\": \"probable\",\n      \"created\": \"2026-05-01\",\n      \"id\": \"pe_006\",\n      \"match_score\": null,\n      \"person_id\": \"I2\",\n      \"rationale\": \"Same assertion as pe_002 but linked to Thomas Flynn (I2). The relationship assertion ('position consistent with child') equally bears on the head of household. Thomas Flynn is the other party in the implied parent-child relationship.\",\n      \"superseded_by\": null\n    },\n    {\n      \"assertion_id\": \"a_005\",\n      \"confidence\": \"probable\",\n      \"created\": \"2026-05-01\",\n      \"id\": \"pe_003\",\n      \"match_score\": 0.82,\n      \"person_id\": \"I2\",\n      \"rationale\": \"Thomas Flynn, head of household where Patrick was found. Age (~32 in 1850, born ~1818) is consistent with being Patrick's father. Name matches candidate father.\",\n      \"superseded_by\": null\n    },\n    {\n      \"assertion_id\": \"a_010\",\n      \"confidence\": \"confident\",\n      \"created\": \"2026-05-02\",\n      \"id\": \"pe_004\",\n      \"match_score\": null,\n      \"person_id\": \"I1\",\n      \"rationale\": \"Patrick Flynn age 15 in Thomas Flynn household, 1860 census. Same county, age consistent with 1850 enumeration. Relationship inferred from household position and shared surname (1860 census does not state relationships explicitly).\",\n      \"superseded_by\": null\n    },\n    {\n      \"assertion_id\": \"a_013\",\n      \"confidence\": \"confident\",\n      \"created\": \"2026-05-03\",\n      \"id\": \"pe_005\",\n      \"match_score\": null,\n      \"person_id\": \"I1\",\n      \"rationale\": \"Death certificate for Patrick Flynn, d. 1908, Schuylkill County. Names match, death location matches known residence. Names Thomas Flynn as father.\",\n      \"superseded_by\": null\n    }\n  ],\n  \"plans\": [\n    {\n      \"created\": \"2026-05-01\",\n      \"id\": \"pl_001\",\n      \"items\": [\n        {\n          \"date_range\": \"1850\",\n          \"fallback_for\": null,\n          \"id\": \"pli_001\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"1850 census fully indexed on FamilySearch. Free access, start here.\",\n          \"record_type\": \"census\",\n          \"repository\": \"FamilySearch\",\n          \"sequence\": 1,\n          \"status\": \"completed\"\n        },\n        {\n          \"date_range\": \"1850\",\n          \"fallback_for\": null,\n          \"id\": \"pli_002\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"Ancestry has independent indexing; cross-check for transcription errors.\",\n          \"record_type\": \"census\",\n          \"repository\": \"Ancestry\",\n          \"sequence\": 2,\n          \"status\": \"completed\"\n        },\n        {\n          \"date_range\": \"1850\",\n          \"fallback_for\": null,\n          \"id\": \"pli_003\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"Third independent index for coverage confirmation.\",\n          \"record_type\": \"census\",\n          \"repository\": \"MyHeritage\",\n          \"sequence\": 3,\n          \"status\": \"completed\"\n        }\n      ],\n      \"question_id\": \"q_002\",\n      \"status\": \"completed\"\n    },\n    {\n      \"created\": \"2026-05-02\",\n      \"id\": \"pl_002\",\n      \"items\": [\n        {\n          \"date_range\": \"1860\",\n          \"fallback_for\": null,\n          \"id\": \"pli_004\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"Confirm Patrick still in Thomas Flynn household in 1860. Strengthens parent-child identification.\",\n          \"record_type\": \"census\",\n          \"repository\": \"FamilySearch\",\n          \"sequence\": 1,\n          \"status\": \"completed\"\n        },\n        {\n          \"date_range\": \"1908\",\n          \"fallback_for\": null,\n          \"id\": \"pli_005\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"Death certificate may name parents directly.\",\n          \"record_type\": \"vital_record\",\n          \"repository\": \"FamilySearch\",\n          \"sequence\": 2,\n          \"status\": \"completed\"\n        },\n        {\n          \"date_range\": \"1870-1890\",\n          \"fallback_for\": null,\n          \"id\": \"pli_006\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"Thomas Flynn probate/will may name Patrick as son.\",\n          \"record_type\": \"probate\",\n          \"repository\": \"FamilySearch\",\n          \"sequence\": 3,\n          \"status\": \"in_progress\"\n        }\n      ],\n      \"question_id\": \"q_001\",\n      \"status\": \"active\"\n    }\n  ],\n  \"project\": {\n    \"created\": \"2026-05-01\",\n    \"id\": \"rp_001\",\n    \"objective\": \"Identify the parents of Patrick Flynn, born ca. 1845 in Pennsylvania, died 1908 in Schuylkill County, PA\",\n    \"status\": \"active\",\n    \"subject_person_ids\": [\n      \"I1\"\n    ],\n    \"updated\": \"2026-05-04\"\n  },\n  \"proof_summaries\": [\n    {\n      \"exhaustive_search_summary\": \"Searched 1850 census (FamilySearch, Ancestry, MyHeritage \u2014 log_001, log_002, log_003), 1860 census (FamilySearch \u2014 log_004), and death certificate (FamilySearch \u2014 log_005). Probate search in progress. 1870, 1880, and 1900 censuses not yet searched.\",\n      \"id\": \"ps_001\",\n      \"narrative_markdown\": \"## Parentage of Patrick Flynn (ca. 1845\u20131908)\\n\\nPatrick Flynn is **Probably** the son of Thomas Flynn of Schuylkill County, Pennsylvania.\\n\\n### Evidence Summary\\n\\nThree independent lines of evidence support this conclusion:\\n\\n1. **1850 U.S. Census** (Original Source). Patrick Flynn, age 5, born Ireland, appears in the household of Thomas Flynn, age 32, born Ireland, in Schuylkill County, Pennsylvania (dwelling 84, family 91). The 1850 census does not state relationships, but Patrick's position in the household and shared surname are consistent with a parent-child relationship. The informant is indeterminate but likely a household member. This constitutes indirect evidence of parentage.\\n\\n2. **1860 U.S. Census** (Original Source). Patrick Flynn, age 15, born Ireland, appears in the household of Thomas Flynn in Schuylkill County (dwelling 112, family 119). Like the 1850 census, the 1860 census does not state relationships explicitly (the relationship column was not introduced until 1880). Patrick's position in the household, shared surname, and age consistent with the 1850 enumeration support a parent-child relationship. This constitutes indirect evidence of parentage.\\n\\n3. **1908 Death Certificate** (Original Source). Patrick Flynn's death certificate (no. 4521, Pennsylvania Department of Health) names \\\"Thomas Flynn\\\" as his father. The informant was James Brown, identified as Patrick's son-in-law. As a son-in-law reporting his father-in-law's parentage, Brown is a secondary informant for this fact \u2014 he was not a witness to Patrick's birth and is reporting what he was told. Nevertheless, this is direct evidence naming the father.\\n\\n### Conflict Resolution\\n\\nA birthplace conflict exists: the 1850 and 1860 censuses list Patrick's birthplace as Ireland, while the 1908 death certificate states Pennsylvania. The two census records are contemporary recordings with informants likely present in the household, while the death certificate was created 63 years after Patrick's birth by a son-in-law with no firsthand knowledge of the event. Per the GPS preponderance hierarchy, contemporary recordings by closer informants outweigh later recollections by secondary informants. Ireland is accepted as the birthplace; the death certificate entry is attributed to informant error.\\n\\n### Assessment\\n\\nThe conclusion is rated **Probable** rather than **Proved** because: (a) both census sources (1850 and 1860) provide only indirect evidence of parentage (relationships not stated \u2014 the relationship column was not introduced until 1880), (b) the death certificate informant is secondary, and (c) research is not yet exhaustive \u2014 the 1870, 1880, and 1900 censuses have not been searched, and Thomas Flynn's probate records have not been located. If Thomas Flynn's will names Patrick as a son, or if additional census records confirm the relationship, the conclusion would advance to **Proved**.\\n\\n### Citations\\n\\n1. 1850 U.S. Census, Schuylkill County, Pennsylvania, population schedule, dwelling 84, family 91, Thomas Flynn household; NARA microfilm publication M432, roll 810; digital image, FamilySearch.org, accessed 1 May 2026.\\n2. 1860 U.S. Census, Schuylkill County, Pennsylvania, population schedule, dwelling 112, family 119, Thomas Flynn household; NARA microfilm publication M653, roll 1141; digital image, FamilySearch.org, accessed 2 May 2026.\\n3. Pennsylvania Department of Health, death certificate no. 4521 (1908), Patrick Flynn; Pennsylvania State Archives, Harrisburg; digital image, FamilySearch.org, accessed 3 May 2026.\",\n      \"question_id\": \"q_001\",\n      \"resolved_conflict_ids\": [\n        \"c_001\"\n      ],\n      \"supporting_assertion_ids\": [\n        \"a_004\",\n        \"a_010\",\n        \"a_013\"\n      ],\n      \"tier\": \"probable\",\n      \"vehicle\": \"summary\"\n    }\n  ],\n  \"questions\": [\n    {\n      \"created\": \"2026-05-01\",\n      \"depends_on\": [],\n      \"exhaustive_declaration\": {\n        \"declared\": false,\n        \"justification\": null,\n        \"log_entry_ids\": [],\n        \"stop_criteria\": null\n      },\n      \"id\": \"q_001\",\n      \"priority\": \"high\",\n      \"question\": \"Who were the parents of Patrick Flynn (b. ~1845, PA, d. 1908)?\",\n      \"rationale\": \"This is the primary research objective.\",\n      \"resolution_assertion_ids\": [],\n      \"resolved\": null,\n      \"selection_basis\": \"objective_decomposition\",\n      \"status\": \"in_progress\",\n      \"unblocks\": []\n    },\n    {\n      \"created\": \"2026-05-01\",\n      \"depends_on\": [],\n      \"exhaustive_declaration\": {\n        \"declared\": true,\n        \"justification\": \"Searched 1850 census for Schuylkill County on FamilySearch (indexed and browse), Ancestry (indexed), and MyHeritage (indexed). All three returned the same household. No other Patrick Flynn of matching age found in the county.\",\n        \"log_entry_ids\": [\n          \"log_001\",\n          \"log_002\",\n          \"log_003\"\n        ],\n        \"stop_criteria\": {\n          \"conflict_resolution\": \"No conflicts on the 1850 census placement question.\",\n          \"evidence_class\": \"Yes \u2014 FamilySearch provides original census image with indeterminate-quality information.\",\n          \"goal_alignment\": \"Yes \u2014 Patrick Flynn located in a specific 1850 household, answering the question.\",\n          \"independent_verification\": \"FamilySearch (original) and Ancestry (derivative) both return the same household. Two access paths, one underlying original.\",\n          \"original_substitution\": \"FamilySearch provides the original census image; Ancestry index is derivative but confirmed consistent.\",\n          \"overturn_risk\": \"Low \u2014 all three repositories agree, and no competing Patrick Flynn of matching age exists in the county.\",\n          \"repository_breadth\": \"Three major repositories searched (FamilySearch, Ancestry, MyHeritage). No additional known indexes of the 1850 Schuylkill County census exist.\"\n        }\n      },\n      \"id\": \"q_002\",\n      \"priority\": \"high\",\n      \"question\": \"Where was Patrick Flynn in the 1850 census?\",\n      \"rationale\": \"The 1850 census is the earliest enumeration where Patrick would appear by name (age ~5). Locating him in a household identifies candidate parents.\",\n      \"resolution_assertion_ids\": [\n        \"a_001\",\n        \"a_002\",\n        \"a_003\"\n      ],\n      \"resolved\": \"2026-05-02\",\n      \"selection_basis\": \"objective_decomposition\",\n      \"status\": \"resolved\",\n      \"unblocks\": [\n        \"q_001\"\n      ]\n    }\n  ],\n  \"sources\": [\n    {\n      \"access_date\": \"2026-05-01\",\n      \"citation\": \"1850 U.S. Census, Schuylkill County, Pennsylvania, population schedule, dwelling 84, family 91, Thomas Flynn household; NARA microfilm publication M432, roll 810; digital image, FamilySearch.org, accessed 1 May 2026.\",\n      \"citation_detail\": {\n        \"what\": \"1850 U.S. Federal Census, population schedule\",\n        \"when_accessed\": \"2026-05-01\",\n        \"when_created\": \"1850\",\n        \"where\": \"FamilySearch.org (NARA microfilm M432, roll 810)\",\n        \"where_within\": \"Schuylkill County, dwelling 84, family 91\",\n        \"who\": \"U.S. Census Bureau\"\n      },\n      \"gedcomx_source_description_id\": \"S1\",\n      \"id\": \"src_001\",\n      \"log_entry_id\": \"log_001\",\n      \"notes\": \"Image quality good. Enumerator handwriting clear.\",\n      \"repository\": \"FamilySearch\",\n      \"source_classification\": \"original\",\n      \"url\": \"https://www.familysearch.org/ark:/61903/1:1:MXYZ\",\n      \"url_archived\": null\n    },\n    {\n      \"access_date\": \"2026-05-01\",\n      \"citation\": \"1850 U.S. Census, Schuylkill County, Pennsylvania, population schedule, dwelling 84, Thomas Flynn household; digital image, Ancestry.com, accessed 1 May 2026.\",\n      \"citation_detail\": {\n        \"what\": \"1850 U.S. Federal Census, population schedule (Ancestry index)\",\n        \"when_accessed\": \"2026-05-01\",\n        \"when_created\": \"1850\",\n        \"where\": \"Ancestry.com\",\n        \"where_within\": \"Schuylkill County, dwelling 84\",\n        \"who\": \"U.S. Census Bureau\"\n      },\n      \"gedcomx_source_description_id\": \"S1\",\n      \"id\": \"src_002\",\n      \"log_entry_id\": \"log_002\",\n      \"notes\": \"Ancestry's index of the same original census. Transcription consistent with FamilySearch.\",\n      \"repository\": \"Ancestry\",\n      \"source_classification\": \"derivative\",\n      \"url\": null,\n      \"url_archived\": null\n    },\n    {\n      \"access_date\": \"2026-05-02\",\n      \"citation\": \"1860 U.S. Census, Schuylkill County, Pennsylvania, population schedule, dwelling 112, family 119, Thomas Flynn household; NARA microfilm publication M653, roll 1141; digital image, FamilySearch.org, accessed 2 May 2026.\",\n      \"citation_detail\": {\n        \"what\": \"1860 U.S. Federal Census, population schedule\",\n        \"when_accessed\": \"2026-05-02\",\n        \"when_created\": \"1860\",\n        \"where\": \"FamilySearch.org (NARA microfilm M653, roll 1141)\",\n        \"where_within\": \"Schuylkill County, dwelling 112, family 119\",\n        \"who\": \"U.S. Census Bureau\"\n      },\n      \"gedcomx_source_description_id\": \"S2\",\n      \"id\": \"src_003\",\n      \"log_entry_id\": \"log_004\",\n      \"notes\": null,\n      \"repository\": \"FamilySearch\",\n      \"source_classification\": \"original\",\n      \"url\": \"https://www.familysearch.org/ark:/61903/1:1:MABC\",\n      \"url_archived\": null\n    },\n    {\n      \"access_date\": \"2026-05-03\",\n      \"citation\": \"Pennsylvania Department of Health, death certificate no. 4521 (1908), Patrick Flynn; Pennsylvania State Archives, Harrisburg; digital image, FamilySearch.org, accessed 3 May 2026.\",\n      \"citation_detail\": {\n        \"what\": \"Death certificate no. 4521\",\n        \"when_accessed\": \"2026-05-03\",\n        \"when_created\": \"1908-03-14\",\n        \"where\": \"FamilySearch.org (Pennsylvania State Archives, Harrisburg)\",\n        \"where_within\": \"Certificate no. 4521\",\n        \"who\": \"Pennsylvania Department of Health; informant: James Brown (son-in-law)\"\n      },\n      \"gedcomx_source_description_id\": \"S3\",\n      \"id\": \"src_004\",\n      \"log_entry_id\": \"log_005\",\n      \"notes\": \"Informant is son-in-law James Brown. Primary for death facts, secondary for birth facts.\",\n      \"repository\": \"FamilySearch\",\n      \"source_classification\": \"original\",\n      \"url\": \"https://www.familysearch.org/ark:/61903/1:1:MDEF\",\n      \"url_archived\": null\n    },\n    {\n      \"access_date\": \"2026-05-10\",\n      \"citation\": \"St. Mary's Catholic Church, Pottsville, baptism of Patrick Flynn, 1845\",\n      \"citation_detail\": {\n        \"what\": \"Baptismal register, 1845\",\n        \"when_accessed\": \"2026-05-10\",\n        \"when_created\": \"1845\",\n        \"where\": \"FamilySearch.org\",\n        \"where_within\": \"Patrick Flynn entry\",\n        \"who\": \"St. Mary's Catholic Church, Pottsville\"\n      },\n      \"gedcomx_source_description_id\": \"S5\",\n      \"id\": \"src_005\",\n      \"log_entry_id\": null,\n      \"notes\": \"Rough working citation from record-extraction. Missing volume/page locator and full repository chain.\",\n      \"repository\": \"FamilySearch\",\n      \"source_classification\": \"original\",\n      \"url\": \"https://www.familysearch.org/ark:/61903/3:1:S3HT-D1MQ-NZH\",\n      \"url_archived\": null\n    },\n    {\n      \"access_date\": \"2026-05-10\",\n      \"citation\": \"Schuylkill County will of Thomas Flynn, 1881\",\n      \"citation_detail\": {\n        \"what\": \"Will of Thomas Flynn\",\n        \"when_accessed\": \"2026-05-10\",\n        \"when_created\": \"1881\",\n        \"where\": \"FamilySearch.org\",\n        \"where_within\": \"will of Thomas Flynn\",\n        \"who\": \"Schuylkill County Courthouse\"\n      },\n      \"gedcomx_source_description_id\": \"S4\",\n      \"id\": \"src_006\",\n      \"log_entry_id\": null,\n      \"notes\": \"Rough working citation from record-extraction. Creator should be the court, not the courthouse. Missing Will Book volume and page locator.\",\n      \"repository\": \"FamilySearch\",\n      \"source_classification\": \"original\",\n      \"url\": \"https://www.familysearch.org/ark:/61903/3:1:3Q9M-CS4V-7TXW\",\n      \"url_archived\": null\n    },\n    {\n      \"access_date\": \"2026-05-12\",\n      \"citation\": \"PA birth certificate, Mary Elizabeth Flynn, 1905\",\n      \"citation_detail\": {\n        \"what\": \"Birth certificate\",\n        \"when_accessed\": \"2026-05-12\",\n        \"when_created\": \"1905\",\n        \"where\": \"FamilySearch.org\",\n        \"where_within\": \"Mary Elizabeth Flynn entry\",\n        \"who\": \"FamilySearch\"\n      },\n      \"gedcomx_source_description_id\": \"S6\",\n      \"id\": \"src_007\",\n      \"log_entry_id\": null,\n      \"notes\": \"Rough working citation from record-extraction. who wrongly names the repository; missing certificate number (12455), birth date, and place.\",\n      \"repository\": \"FamilySearch\",\n      \"source_classification\": \"original\",\n      \"url\": \"https://www.familysearch.org/ark:/61903/1:1:6JZX-VKQM\",\n      \"url_archived\": null\n    },\n    {\n      \"access_date\": \"2026-05-12\",\n      \"citation\": \"Deed, Thomas Flynn to Patrick Flynn, 1881\",\n      \"citation_detail\": {\n        \"what\": \"Warranty deed\",\n        \"when_accessed\": \"2026-05-12\",\n        \"when_created\": \"1881\",\n        \"where\": \"FamilySearch.org\",\n        \"where_within\": \"Thomas Flynn to Patrick Flynn\",\n        \"who\": \"Schuylkill County Courthouse\"\n      },\n      \"gedcomx_source_description_id\": \"S7\",\n      \"id\": \"src_008\",\n      \"log_entry_id\": null,\n      \"notes\": \"Rough working citation from record-extraction. who should be the Recorder of Deeds (not the courthouse building); missing grantor/grantee, execution + recording dates, and Deed Book/page locator.\",\n      \"repository\": \"FamilySearch\",\n      \"source_classification\": \"original\",\n      \"url\": \"https://www.familysearch.org/ark:/61903/3:1:3QS7-89WF-9KCT\",\n      \"url_archived\": null\n    },\n    {\n      \"access_date\": \"2026-05-12\",\n      \"citation\": \"Patrick Flynn obituary, Pottsville Republican, 1908\",\n      \"citation_detail\": {\n        \"what\": \"Obituary\",\n        \"when_accessed\": \"2026-05-12\",\n        \"when_created\": \"1908\",\n        \"where\": \"FamilySearch.org\",\n        \"where_within\": \"obituary notice\",\n        \"who\": \"FamilySearch\"\n      },\n      \"gedcomx_source_description_id\": \"S8\",\n      \"id\": \"src_009\",\n      \"log_entry_id\": null,\n      \"notes\": \"Rough working citation from record-extraction. who wrongly names the repository; missing the quoted article title, exact publication date, page, and column number.\",\n      \"repository\": \"FamilySearch\",\n      \"source_classification\": \"original\",\n      \"url\": \"https://www.familysearch.org/ark:/61903/3:1:S3HY-6RKS-MGV\",\n      \"url_archived\": null\n    }\n  ],\n  \"timelines\": [\n    {\n      \"events\": [\n        {\n          \"assertion_ids\": [\n            \"a_002\",\n            \"a_009\"\n          ],\n          \"date\": \"~1845\",\n          \"date_certainty\": \"estimated\",\n          \"description\": \"Born in Ireland, estimated from census ages\",\n          \"event_type\": \"birth\",\n          \"place\": \"Ireland\"\n        },\n        {\n          \"assertion_ids\": [\n            \"a_003\",\n            \"a_004\"\n          ],\n          \"date\": \"1850\",\n          \"date_certainty\": \"exact\",\n          \"description\": \"Enumerated age 5 in Thomas Flynn household, dwelling 84\",\n          \"event_type\": \"census\",\n          \"place\": \"Schuylkill County, Pennsylvania\"\n        },\n        {\n          \"assertion_ids\": [\n            \"a_008\",\n            \"a_009\",\n            \"a_010\"\n          ],\n          \"date\": \"1860\",\n          \"date_certainty\": \"exact\",\n          \"description\": \"Enumerated age 15 in Thomas Flynn household, dwelling 112\",\n          \"event_type\": \"census\",\n          \"place\": \"Schuylkill County, Pennsylvania\"\n        },\n        {\n          \"assertion_ids\": [\n            \"a_011\",\n            \"a_013\"\n          ],\n          \"date\": \"1908-03-12\",\n          \"date_certainty\": \"exact\",\n          \"description\": \"Died, death certificate names Thomas Flynn as father\",\n          \"event_type\": \"death\",\n          \"place\": \"Schuylkill County, Pennsylvania\"\n        }\n      ],\n      \"gaps\": [\n        {\n          \"end\": \"1908-03-12\",\n          \"expected_events\": [\n            \"marriage\",\n            \"1870_census\",\n            \"1880_census\",\n            \"1900_census\",\n            \"residence\",\n            \"occupation\"\n          ],\n          \"severity\": \"high\",\n          \"start\": \"1860-01-01\"\n        }\n      ],\n      \"generated\": \"2026-05-03T12:00:00Z\",\n      \"hypothesis_id\": \"h_001\",\n      \"id\": \"t_001\",\n      \"impossibilities\": [],\n      \"label\": \"Patrick Flynn \u2014 assuming Thomas Flynn parentage\",\n      \"person_ids\": [\n        \"I1\"\n      ]\n    }\n  ]\n}\n",
+    "eval/fixtures/scenarios/mid-research-flynn/tree.gedcomx.json": "{\n  \"persons\": [\n    {\n      \"facts\": [\n        {\n          \"date\": \"~1845\",\n          \"id\": \"F1\",\n          \"place\": \"Ireland\",\n          \"primary\": true,\n          \"sources\": [\n            {\n              \"page\": \"1850 Census, Schuylkill Co., dwelling 84\",\n              \"ref\": \"S1\"\n            }\n          ],\n          \"type\": \"Birth\"\n        },\n        {\n          \"date\": \"1908-03-12\",\n          \"id\": \"F2\",\n          \"place\": \"Schuylkill County, Pennsylvania\",\n          \"sources\": [\n            {\n              \"page\": \"Death cert. no. 4521\",\n              \"ref\": \"S3\"\n            }\n          ],\n          \"type\": \"Death\"\n        }\n      ],\n      \"gender\": \"Male\",\n      \"id\": \"I1\",\n      \"names\": [\n        {\n          \"given\": \"Patrick\",\n          \"id\": \"N1\",\n          \"preferred\": true,\n          \"surname\": \"Flynn\",\n          \"type\": \"BirthName\"\n        }\n      ]\n    },\n    {\n      \"facts\": [\n        {\n          \"date\": \"~1818\",\n          \"id\": \"F3\",\n          \"place\": \"Ireland\",\n          \"primary\": true,\n          \"type\": \"Birth\"\n        }\n      ],\n      \"gender\": \"Male\",\n      \"id\": \"I2\",\n      \"names\": [\n        {\n          \"given\": \"Thomas\",\n          \"id\": \"N2\",\n          \"preferred\": true,\n          \"surname\": \"Flynn\",\n          \"type\": \"BirthName\"\n        }\n      ]\n    },\n    {\n      \"gender\": \"Female\",\n      \"id\": \"I3\",\n      \"names\": [\n        {\n          \"given\": \"Mary\",\n          \"id\": \"N3\",\n          \"preferred\": true,\n          \"surname\": \"Flynn\",\n          \"type\": \"BirthName\"\n        }\n      ]\n    },\n    {\n      \"gender\": \"Male\",\n      \"id\": \"I4\",\n      \"names\": [\n        {\n          \"given\": \"James\",\n          \"id\": \"N4\",\n          \"preferred\": true,\n          \"surname\": \"Flynn\",\n          \"type\": \"BirthName\"\n        }\n      ]\n    }\n  ],\n  \"relationships\": [\n    {\n      \"child\": \"I1\",\n      \"id\": \"R1\",\n      \"parent\": \"I2\",\n      \"sources\": [\n        {\n          \"page\": \"1850 Census, Schuylkill Co., dwelling 84\",\n          \"quality\": 2,\n          \"ref\": \"S1\"\n        },\n        {\n          \"page\": \"1860 Census, Schuylkill Co., dwelling 112\",\n          \"quality\": 2,\n          \"ref\": \"S2\"\n        },\n        {\n          \"page\": \"Death cert. no. 4521\",\n          \"quality\": 2,\n          \"ref\": \"S3\"\n        }\n      ],\n      \"type\": \"ParentChild\"\n    },\n    {\n      \"child\": \"I3\",\n      \"id\": \"R2\",\n      \"parent\": \"I2\",\n      \"sources\": [\n        {\n          \"page\": \"Baptism of Mary Flynn, daughter of Thomas Flynn, 1841\",\n          \"quality\": 2,\n          \"ref\": \"S5\"\n        }\n      ],\n      \"type\": \"ParentChild\"\n    },\n    {\n      \"child\": \"I4\",\n      \"id\": \"R3\",\n      \"parent\": \"I2\",\n      \"sources\": [\n        {\n          \"page\": \"Baptism of James Flynn, son of Thomas Flynn, 1847\",\n          \"quality\": 2,\n          \"ref\": \"S5\"\n        }\n      ],\n      \"type\": \"ParentChild\"\n    }\n  ],\n  \"sources\": [\n    {\n      \"author\": \"U.S. Census Bureau\",\n      \"id\": \"S1\",\n      \"title\": \"1850 U.S. Federal Census\"\n    },\n    {\n      \"author\": \"U.S. Census Bureau\",\n      \"id\": \"S2\",\n      \"title\": \"1860 U.S. Federal Census\"\n    },\n    {\n      \"author\": \"Pennsylvania Department of Health\",\n      \"id\": \"S3\",\n      \"title\": \"Pennsylvania Death Certificates\"\n    },\n    {\n      \"author\": \"Schuylkill County Register of Wills\",\n      \"id\": \"S4\",\n      \"title\": \"Schuylkill County Probate Records\"\n    },\n    {\n      \"author\": \"St. Mary's Catholic Church, Pottsville\",\n      \"id\": \"S5\",\n      \"title\": \"St. Mary's Catholic Church (Pottsville) Baptismal Registers\"\n    },\n    {\n      \"author\": \"Pennsylvania Department of Health\",\n      \"id\": \"S6\",\n      \"title\": \"Pennsylvania Birth Certificates\"\n    },\n    {\n      \"author\": \"Schuylkill County Recorder of Deeds\",\n      \"id\": \"S7\",\n      \"title\": \"Schuylkill County Deed Books\"\n    },\n    {\n      \"author\": \"Pottsville Republican\",\n      \"id\": \"S8\",\n      \"title\": \"Pottsville Republican (newspaper)\"\n    }\n  ]\n}\n",
+    "eval/fixtures/scenarios/mid-research-flynn-ancestry-sub/README.md": "# mid-research-flynn\n\nPatrick Flynn parentage research, mid-project.\n\n- **Objective:** Identify the parents of Patrick Flynn (b. ~1845, d. 1908)\n- **Questions:** q_001 (parentage, in_progress), q_002 (1850 census placement, resolved)\n- **Plans:** pl_001 (1850 census search, completed), pl_002 (parentage evidence, active)\n- **Log:** 5 entries \u2014 1850 census on FamilySearch/Ancestry/MyHeritage, 1860 census, death cert\n- **Sources:** 4 sources (1850 census FS, 1850 census Ancestry, 1860 census, death cert)\n- **Assertions:** 13 assertions across 4 sources\n- **Person evidence:** 6 links (Patrick \u2192 I1, Thomas \u2192 I2)\n- **Conflicts:** 1 resolved (birthplace: Ireland vs Pennsylvania)\n- **Hypotheses:** h_001 (Thomas is Patrick's father, supported)\n- **Timelines:** t_001 (Patrick, 4 events, 1 gap)\n- **Proof summaries:** ps_001 (parentage, probable)\n- **GedcomX persons:** I1 (Patrick Flynn), I2 (Thomas Flynn)\n- **GedcomX relationships:** R1 (ParentChild, Thomas \u2192 Patrick)\n\n## Variant: ancestry-sub\n\nIdentical to `mid-research-flynn` except `researcher_profile` is present with\n`subscriptions: [\"Ancestry\"]` (intermediate researcher). Exists to exercise\nsearch-external-sites' subscription-awareness: an explicit ask for an\nunsubscribed site (e.g. MyHeritage) should still produce a URL plus a one-line\nlogin-wall warning.\n",
+    "eval/fixtures/scenarios/mid-research-flynn-ancestry-sub/research.json": "{\n  \"assertions\": [\n    {\n      \"date\": null,\n      \"date_certainty\": null,\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_002\"\n      ],\n      \"fact_type\": \"name\",\n      \"id\": \"a_001\",\n      \"informant\": \"Unknown informant (most likely a household member, possibly a neighbor) reporting to census enumerator\",\n      \"informant_bias_notes\": \"Census enumerator is the recorder, not the informant. The person who provided the name is unknown \u2014 most likely a household member, possibly a neighbor. Proximity is 'unknown' rather than 'household_member' because for names specifically, the enumerator may have read a sign, heard a neighbor, or made an assumption \u2014 the name fact doesn't necessarily require active reporting the way age/birthplace does.\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_001\",\n      \"place\": null,\n      \"record_id\": \"ark:/61903/1:1:MXYZ\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_001\",\n      \"structured_value\": {\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"value\": \"Patrick Flynn\"\n    },\n    {\n      \"date\": \"~1845\",\n      \"date_certainty\": \"estimated\",\n      \"evidence_type\": \"indirect\",\n      \"extracted_for_question_ids\": [\n        \"q_002\"\n      ],\n      \"fact_type\": \"birth\",\n      \"id\": \"a_002\",\n      \"informant\": \"Unknown \u2014 most likely a household member (such as Thomas Flynn or his wife), but possibly a neighbor\",\n      \"informant_bias_notes\": \"Age and birthplace require active reporting by an informant \u2014 someone had to tell the enumerator these facts. That informant was most likely a household member, but enumerators also took information from neighbors when residents were unavailable, and the census does not identify who answered. Proximity is 'unknown' because the informant cannot be established from the record.\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_001\",\n      \"place\": \"Ireland\",\n      \"record_id\": \"ark:/61903/1:1:MXYZ\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_001\",\n      \"structured_value\": {\n        \"place\": \"Ireland\",\n        \"year\": 1845\n      },\n      \"value\": \"age 5\"\n    },\n    {\n      \"date\": \"1850\",\n      \"date_certainty\": \"exact\",\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_002\"\n      ],\n      \"fact_type\": \"residence\",\n      \"id\": \"a_003\",\n      \"informant\": \"Census enumerator (witness to residence by visiting the dwelling)\",\n      \"informant_bias_notes\": \"For residence facts specifically, the enumerator is a direct witness \u2014 they physically visited the dwelling and recorded who lived there. This distinguishes residence from other census facts where an unidentified informant (most likely a household member, possibly a neighbor) supplied the information.\",\n      \"informant_proximity\": \"witness\",\n      \"information_quality\": \"primary\",\n      \"log_entry_id\": \"log_001\",\n      \"place\": \"Schuylkill County, Pennsylvania\",\n      \"record_id\": \"ark:/61903/1:1:MXYZ\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_001\",\n      \"value\": \"Schuylkill County, Pennsylvania\"\n    },\n    {\n      \"date\": \"1850\",\n      \"date_certainty\": \"exact\",\n      \"evidence_type\": \"indirect\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"relationship\",\n      \"id\": \"a_004\",\n      \"informant\": \"Inferred from household structure \u2014 no explicit informant for relationships in 1850 census\",\n      \"informant_bias_notes\": \"1850 census does not state relationships; this assertion is inferred from household position and shared surname, not directly reported by any informant. The relationship is indirect evidence constructed by the researcher, not information provided by a census informant.\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_001\",\n      \"place\": \"Schuylkill County, Pennsylvania\",\n      \"record_id\": \"ark:/61903/1:1:MXYZ\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_001\",\n      \"structured_value\": {\n        \"related_person_role\": \"head_of_household\",\n        \"relationship_type\": \"child_inferred\"\n      },\n      \"value\": \"Listed in household of Thomas Flynn (head), position consistent with child\"\n    },\n    {\n      \"date\": null,\n      \"date_certainty\": null,\n      \"evidence_type\": \"indirect\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"name\",\n      \"id\": \"a_005\",\n      \"informant\": \"Unknown informant (likely Thomas Flynn himself) reporting to census enumerator\",\n      \"informant_bias_notes\": \"Census enumerator is the recorder, not the informant. As head of household, Thomas likely provided his own name, but the 1850 census does not identify the informant.\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_001\",\n      \"place\": null,\n      \"record_id\": \"ark:/61903/1:1:MXYZ\",\n      \"record_role\": \"head_of_household\",\n      \"source_id\": \"src_001\",\n      \"value\": \"Thomas Flynn\"\n    },\n    {\n      \"date\": null,\n      \"date_certainty\": null,\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_002\"\n      ],\n      \"fact_type\": \"name\",\n      \"id\": \"a_006\",\n      \"informant\": \"Ancestry transcriber (derivative of census enumerator)\",\n      \"informant_bias_notes\": \"Derivative index \u2014 transcription errors possible\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_002\",\n      \"place\": null,\n      \"record_id\": \"ancestry:8054:patrick-flynn-1850\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_002\",\n      \"value\": \"Patrick Flynn\"\n    },\n    {\n      \"date\": \"~1845\",\n      \"date_certainty\": \"estimated\",\n      \"evidence_type\": \"indirect\",\n      \"extracted_for_question_ids\": [\n        \"q_002\"\n      ],\n      \"fact_type\": \"birth\",\n      \"id\": \"a_007\",\n      \"informant\": \"Ancestry transcriber (derivative)\",\n      \"informant_bias_notes\": null,\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_002\",\n      \"place\": \"Ireland\",\n      \"record_id\": \"ancestry:8054:patrick-flynn-1850\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_002\",\n      \"value\": \"age 5\"\n    },\n    {\n      \"date\": null,\n      \"date_certainty\": null,\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"name\",\n      \"id\": \"a_008\",\n      \"informant\": \"Unknown informant (most likely a household member, possibly a neighbor) reporting to census enumerator\",\n      \"informant_bias_notes\": \"Census enumerator is the recorder, not the informant. Proximity is 'unknown' for names (same reasoning as a_001 \u2014 name facts don't necessarily require active reporting).\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_004\",\n      \"place\": null,\n      \"record_id\": \"ark:/61903/1:1:MABC\",\n      \"record_role\": \"child_2\",\n      \"source_id\": \"src_003\",\n      \"value\": \"Patrick Flynn\"\n    },\n    {\n      \"date\": \"~1845\",\n      \"date_certainty\": \"estimated\",\n      \"evidence_type\": \"indirect\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"birth\",\n      \"id\": \"a_009\",\n      \"informant\": \"Unknown \u2014 most likely a household member (such as Thomas Flynn or his wife), but possibly a neighbor\",\n      \"informant_bias_notes\": \"Age and birthplace require active reporting by an informant \u2014 most likely a household member, possibly a neighbor (same reasoning as a_002).\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_004\",\n      \"place\": \"Ireland\",\n      \"record_id\": \"ark:/61903/1:1:MABC\",\n      \"record_role\": \"child_2\",\n      \"source_id\": \"src_003\",\n      \"value\": \"age 15\"\n    },\n    {\n      \"date\": \"1860\",\n      \"date_certainty\": \"exact\",\n      \"evidence_type\": \"indirect\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"relationship\",\n      \"id\": \"a_010\",\n      \"informant\": \"Inferred from household structure \u2014 no explicit informant for relationships in 1860 census\",\n      \"informant_bias_notes\": \"1860 census does not state relationships; like the 1850 census, this assertion is inferred from household position, age, and shared surname. The relationship column was not introduced until the 1880 census.\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_004\",\n      \"place\": \"Schuylkill County, Pennsylvania\",\n      \"record_id\": \"ark:/61903/1:1:MABC\",\n      \"record_role\": \"child_2\",\n      \"source_id\": \"src_003\",\n      \"structured_value\": {\n        \"related_person_role\": \"head_of_household\",\n        \"relationship_type\": \"child_inferred\"\n      },\n      \"value\": \"Listed in household of Thomas Flynn (head), position and age consistent with son\"\n    },\n    {\n      \"date\": \"1908-03-12\",\n      \"date_certainty\": \"exact\",\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [],\n      \"fact_type\": \"death\",\n      \"id\": \"a_011\",\n      \"informant\": \"Attending physician (signature on certificate)\",\n      \"informant_bias_notes\": null,\n      \"informant_proximity\": \"witness\",\n      \"information_quality\": \"primary\",\n      \"log_entry_id\": \"log_005\",\n      \"place\": \"Schuylkill County, Pennsylvania\",\n      \"record_id\": \"ark:/61903/1:1:MDEF\",\n      \"record_role\": \"deceased\",\n      \"source_id\": \"src_004\",\n      \"value\": \"Died 12 March 1908\"\n    },\n    {\n      \"date\": \"1845\",\n      \"date_certainty\": \"approximate\",\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"birth\",\n      \"id\": \"a_012\",\n      \"informant\": \"James Brown (son-in-law)\",\n      \"informant_bias_notes\": \"Son-in-law reporting birth facts decades after the event. Note: death cert says Pennsylvania, but census records say Ireland. Son-in-law may not have known Patrick was born in Ireland.\",\n      \"informant_proximity\": \"family_not_present\",\n      \"information_quality\": \"secondary\",\n      \"log_entry_id\": \"log_005\",\n      \"place\": \"Pennsylvania\",\n      \"record_id\": \"ark:/61903/1:1:MDEF\",\n      \"record_role\": \"deceased\",\n      \"source_id\": \"src_004\",\n      \"structured_value\": {\n        \"place\": \"Pennsylvania\",\n        \"year\": 1845\n      },\n      \"value\": \"Born 1845, Pennsylvania\"\n    },\n    {\n      \"date\": null,\n      \"date_certainty\": null,\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"relationship\",\n      \"id\": \"a_013\",\n      \"informant\": \"James Brown (son-in-law)\",\n      \"informant_bias_notes\": \"Secondary information \u2014 son-in-law reporting what he was told about father-in-law's parentage\",\n      \"informant_proximity\": \"family_not_present\",\n      \"information_quality\": \"secondary\",\n      \"log_entry_id\": \"log_005\",\n      \"place\": null,\n      \"record_id\": \"ark:/61903/1:1:MDEF\",\n      \"record_role\": \"deceased\",\n      \"source_id\": \"src_004\",\n      \"structured_value\": {\n        \"related_person_role\": \"deceased\",\n        \"relationship_type\": \"father\"\n      },\n      \"value\": \"Father: Thomas Flynn\"\n    }\n  ],\n  \"conflicts\": [\n    {\n      \"blocks_question_ids\": [],\n      \"competing_assertion_ids\": [\n        \"a_002\",\n        \"a_009\",\n        \"a_012\"\n      ],\n      \"conflict_type\": \"fact\",\n      \"description\": \"Patrick Flynn's birthplace: Ireland (1850 and 1860 censuses) vs. Pennsylvania (1908 death certificate)\",\n      \"disputed_attribute\": \"birthplace\",\n      \"id\": \"c_001\",\n      \"identity_question\": null,\n      \"independence_analysis\": \"The two census records (1850, 1860) are independent original sources with different enumerators. The death certificate is a third independent original source. However, the census informants are likely the same household member (Thomas Flynn or wife), so the two census assertions may share a single informant \u2014 potentially not fully independent for this fact.\",\n      \"preferred_assertion_id\": \"a_002\",\n      \"resolution_rationale\": \"Ireland is accepted as the birthplace. The 1908 death certificate birthplace of 'Pennsylvania' is rejected as a likely error by the son-in-law informant, who may have confused Patrick's place of residence with his place of birth, or may not have known Patrick was born in Ireland before immigrating as a young child.\",\n      \"status\": \"resolved\",\n      \"weighing_analysis\": \"The census records are contemporary recordings made near the time of Patrick's birth, while the death certificate was created 63 years later. The census informant was likely a household member with firsthand knowledge (primary or indeterminate), while the death certificate informant (son-in-law) is clearly secondary for birth facts. Two contemporary sources outweigh one later recollection by a secondary informant.\"\n    }\n  ],\n  \"evaluations\": [],\n  \"hypotheses\": [\n    {\n      \"claim\": \"Patrick Flynn's father was Thomas Flynn of Schuylkill County, Pennsylvania\",\n      \"contradicting_assertion_ids\": [],\n      \"id\": \"h_001\",\n      \"notes\": \"Three independent pieces of evidence: 1850 census co-enumeration (indirect), 1860 census co-enumeration (indirect \u2014 relationship inferred from household position), death certificate naming Thomas as father (direct, secondary informant). Awaiting probate records for additional confirmation.\",\n      \"related_question_ids\": [\n        \"q_001\"\n      ],\n      \"ruled_out\": false,\n      \"ruled_out_reason\": null,\n      \"status\": \"supported\",\n      \"supporting_assertion_ids\": [\n        \"a_004\",\n        \"a_010\",\n        \"a_013\"\n      ]\n    }\n  ],\n  \"log\": [\n    {\n      \"external_site\": null,\n      \"id\": \"log_001\",\n      \"notes\": \"Found Patrick Flynn age 5 in household of Thomas Flynn, dwelling 84, Schuylkill Co. Three other Flynn results examined \u2014 ages and locations don't match.\",\n      \"outcome\": \"positive\",\n      \"performed\": \"2026-05-01T10:15:00Z\",\n      \"plan_item_id\": \"pli_001\",\n      \"query\": {\n        \"birth_place\": \"Pennsylvania\",\n        \"birth_year\": 1845,\n        \"collection\": \"1850 Census\",\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"results_examined\": 8,\n      \"tool\": \"record_search\"\n    },\n    {\n      \"external_site\": {\n        \"capture_filename\": \"ancestry-1850-flynn-results.pdf\",\n        \"capture_received\": true,\n        \"site\": \"ancestry\",\n        \"url_generated\": \"https://www.ancestry.com/search/collections/8054/?name=Patrick_Flynn&birth=1845&birthplace=Pennsylvania\"\n      },\n      \"id\": \"log_002\",\n      \"notes\": \"Ancestry index confirms same household. Transcription matches FamilySearch except Ancestry reads dwelling as 84, FamilySearch as 84 \u2014 consistent.\",\n      \"outcome\": \"positive\",\n      \"performed\": \"2026-05-01T11:30:00Z\",\n      \"plan_item_id\": \"pli_002\",\n      \"query\": {\n        \"birth_place\": \"Pennsylvania\",\n        \"birth_year\": 1845,\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"results_examined\": 12,\n      \"tool\": \"external_site\"\n    },\n    {\n      \"external_site\": {\n        \"capture_filename\": \"myheritage-1850-flynn-nil.pdf\",\n        \"capture_received\": true,\n        \"site\": \"myheritage\",\n        \"url_generated\": \"https://www.myheritage.com/research?action=query&first=Patrick&last=Flynn&birth_year=1845&birth_place=Pennsylvania\"\n      },\n      \"id\": \"log_003\",\n      \"notes\": \"MyHeritage returned no results for Patrick Flynn in 1850 Schuylkill County. Site may not have this collection indexed. Searched broader Pennsylvania \u2014 still no match.\",\n      \"outcome\": \"negative\",\n      \"performed\": \"2026-05-01T14:00:00Z\",\n      \"plan_item_id\": \"pli_003\",\n      \"query\": {\n        \"birth_place\": \"Pennsylvania\",\n        \"birth_year\": 1845,\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"results_examined\": 0,\n      \"tool\": \"external_site\"\n    },\n    {\n      \"external_site\": null,\n      \"id\": \"log_004\",\n      \"notes\": \"Patrick Flynn age 15 in household of Thomas Flynn, Schuylkill Co. Consistent with 1850 placement.\",\n      \"outcome\": \"positive\",\n      \"performed\": \"2026-05-02T09:00:00Z\",\n      \"plan_item_id\": \"pli_004\",\n      \"query\": {\n        \"birth_place\": \"Pennsylvania\",\n        \"birth_year\": 1845,\n        \"collection\": \"1860 Census\",\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"results_examined\": 5,\n      \"tool\": \"record_search\"\n    },\n    {\n      \"external_site\": null,\n      \"id\": \"log_005\",\n      \"notes\": \"Death certificate found. Names Thomas Flynn as father. Informant was son-in-law James Brown.\",\n      \"outcome\": \"positive\",\n      \"performed\": \"2026-05-03T10:00:00Z\",\n      \"plan_item_id\": \"pli_005\",\n      \"query\": {\n        \"death_place\": \"Schuylkill County, Pennsylvania\",\n        \"death_year\": 1908,\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"results_examined\": 2,\n      \"tool\": \"record_search\"\n    }\n  ],\n  \"person_evidence\": [\n    {\n      \"assertion_id\": \"a_001\",\n      \"confidence\": \"confident\",\n      \"created\": \"2026-05-01\",\n      \"id\": \"pe_001\",\n      \"match_score\": null,\n      \"person_id\": \"I1\",\n      \"rationale\": \"Name matches (Patrick Flynn), age consistent with ~1845 birth, located in Schuylkill County where subject is known to have lived. Only Patrick Flynn of this age in the county in 1850.\",\n      \"superseded_by\": null\n    },\n    {\n      \"assertion_id\": \"a_004\",\n      \"confidence\": \"probable\",\n      \"created\": \"2026-05-01\",\n      \"id\": \"pe_002\",\n      \"match_score\": null,\n      \"person_id\": \"I1\",\n      \"rationale\": \"Same record as pe_001, same person. Household position and shared surname with head Thomas Flynn suggest parent-child relationship, but 1850 census does not state relationships explicitly.\",\n      \"superseded_by\": null\n    },\n    {\n      \"assertion_id\": \"a_004\",\n      \"confidence\": \"probable\",\n      \"created\": \"2026-05-01\",\n      \"id\": \"pe_006\",\n      \"match_score\": null,\n      \"person_id\": \"I2\",\n      \"rationale\": \"Same assertion as pe_002 but linked to Thomas Flynn (I2). The relationship assertion ('position consistent with child') equally bears on the head of household. Thomas Flynn is the other party in the implied parent-child relationship.\",\n      \"superseded_by\": null\n    },\n    {\n      \"assertion_id\": \"a_005\",\n      \"confidence\": \"probable\",\n      \"created\": \"2026-05-01\",\n      \"id\": \"pe_003\",\n      \"match_score\": 0.82,\n      \"person_id\": \"I2\",\n      \"rationale\": \"Thomas Flynn, head of household where Patrick was found. Age (~32 in 1850, born ~1818) is consistent with being Patrick's father. Name matches candidate father.\",\n      \"superseded_by\": null\n    },\n    {\n      \"assertion_id\": \"a_010\",\n      \"confidence\": \"confident\",\n      \"created\": \"2026-05-02\",\n      \"id\": \"pe_004\",\n      \"match_score\": null,\n      \"person_id\": \"I1\",\n      \"rationale\": \"Patrick Flynn age 15 in Thomas Flynn household, 1860 census. Same county, age consistent with 1850 enumeration. Relationship inferred from household position and shared surname (1860 census does not state relationships explicitly).\",\n      \"superseded_by\": null\n    },\n    {\n      \"assertion_id\": \"a_013\",\n      \"confidence\": \"confident\",\n      \"created\": \"2026-05-03\",\n      \"id\": \"pe_005\",\n      \"match_score\": null,\n      \"person_id\": \"I1\",\n      \"rationale\": \"Death certificate for Patrick Flynn, d. 1908, Schuylkill County. Names match, death location matches known residence. Names Thomas Flynn as father.\",\n      \"superseded_by\": null\n    }\n  ],\n  \"plans\": [\n    {\n      \"created\": \"2026-05-01\",\n      \"id\": \"pl_001\",\n      \"items\": [\n        {\n          \"date_range\": \"1850\",\n          \"fallback_for\": null,\n          \"id\": \"pli_001\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"1850 census fully indexed on FamilySearch. Free access, start here.\",\n          \"record_type\": \"census\",\n          \"repository\": \"FamilySearch\",\n          \"sequence\": 1,\n          \"status\": \"completed\"\n        },\n        {\n          \"date_range\": \"1850\",\n          \"fallback_for\": null,\n          \"id\": \"pli_002\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"Ancestry has independent indexing; cross-check for transcription errors.\",\n          \"record_type\": \"census\",\n          \"repository\": \"Ancestry\",\n          \"sequence\": 2,\n          \"status\": \"completed\"\n        },\n        {\n          \"date_range\": \"1850\",\n          \"fallback_for\": null,\n          \"id\": \"pli_003\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"Third independent index for coverage confirmation.\",\n          \"record_type\": \"census\",\n          \"repository\": \"MyHeritage\",\n          \"sequence\": 3,\n          \"status\": \"completed\"\n        }\n      ],\n      \"question_id\": \"q_002\",\n      \"status\": \"completed\"\n    },\n    {\n      \"created\": \"2026-05-02\",\n      \"id\": \"pl_002\",\n      \"items\": [\n        {\n          \"date_range\": \"1860\",\n          \"fallback_for\": null,\n          \"id\": \"pli_004\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"Confirm Patrick still in Thomas Flynn household in 1860. Strengthens parent-child identification.\",\n          \"record_type\": \"census\",\n          \"repository\": \"FamilySearch\",\n          \"sequence\": 1,\n          \"status\": \"completed\"\n        },\n        {\n          \"date_range\": \"1908\",\n          \"fallback_for\": null,\n          \"id\": \"pli_005\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"Death certificate may name parents directly.\",\n          \"record_type\": \"vital_record\",\n          \"repository\": \"FamilySearch\",\n          \"sequence\": 2,\n          \"status\": \"completed\"\n        },\n        {\n          \"date_range\": \"1870-1890\",\n          \"fallback_for\": null,\n          \"id\": \"pli_006\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"Thomas Flynn probate/will may name Patrick as son.\",\n          \"record_type\": \"probate\",\n          \"repository\": \"FamilySearch\",\n          \"sequence\": 3,\n          \"status\": \"in_progress\"\n        }\n      ],\n      \"question_id\": \"q_001\",\n      \"status\": \"active\"\n    }\n  ],\n  \"project\": {\n    \"created\": \"2026-05-01\",\n    \"id\": \"rp_001\",\n    \"objective\": \"Identify the parents of Patrick Flynn, born ca. 1845 in Pennsylvania, died 1908 in Schuylkill County, PA\",\n    \"status\": \"active\",\n    \"subject_person_ids\": [\n      \"I1\"\n    ],\n    \"updated\": \"2026-05-04\"\n  },\n  \"proof_summaries\": [\n    {\n      \"exhaustive_search_summary\": \"Searched 1850 census (FamilySearch, Ancestry, MyHeritage \u2014 log_001, log_002, log_003), 1860 census (FamilySearch \u2014 log_004), and death certificate (FamilySearch \u2014 log_005). Probate search in progress. 1870, 1880, and 1900 censuses not yet searched.\",\n      \"id\": \"ps_001\",\n      \"narrative_markdown\": \"## Parentage of Patrick Flynn (ca. 1845\u20131908)\\n\\nPatrick Flynn is **Probably** the son of Thomas Flynn of Schuylkill County, Pennsylvania.\\n\\n### Evidence Summary\\n\\nThree independent lines of evidence support this conclusion:\\n\\n1. **1850 U.S. Census** (Original Source). Patrick Flynn, age 5, born Ireland, appears in the household of Thomas Flynn, age 32, born Ireland, in Schuylkill County, Pennsylvania (dwelling 84, family 91). The 1850 census does not state relationships, but Patrick's position in the household and shared surname are consistent with a parent-child relationship. The informant is indeterminate but likely a household member. This constitutes indirect evidence of parentage.\\n\\n2. **1860 U.S. Census** (Original Source). Patrick Flynn, age 15, born Ireland, appears in the household of Thomas Flynn in Schuylkill County (dwelling 112, family 119). Like the 1850 census, the 1860 census does not state relationships explicitly (the relationship column was not introduced until 1880). Patrick's position in the household, shared surname, and age consistent with the 1850 enumeration support a parent-child relationship. This constitutes indirect evidence of parentage.\\n\\n3. **1908 Death Certificate** (Original Source). Patrick Flynn's death certificate (no. 4521, Pennsylvania Department of Health) names \\\"Thomas Flynn\\\" as his father. The informant was James Brown, identified as Patrick's son-in-law. As a son-in-law reporting his father-in-law's parentage, Brown is a secondary informant for this fact \u2014 he was not a witness to Patrick's birth and is reporting what he was told. Nevertheless, this is direct evidence naming the father.\\n\\n### Conflict Resolution\\n\\nA birthplace conflict exists: the 1850 and 1860 censuses list Patrick's birthplace as Ireland, while the 1908 death certificate states Pennsylvania. The two census records are contemporary recordings with informants likely present in the household, while the death certificate was created 63 years after Patrick's birth by a son-in-law with no firsthand knowledge of the event. Per the GPS preponderance hierarchy, contemporary recordings by closer informants outweigh later recollections by secondary informants. Ireland is accepted as the birthplace; the death certificate entry is attributed to informant error.\\n\\n### Assessment\\n\\nThe conclusion is rated **Probable** rather than **Proved** because: (a) both census sources (1850 and 1860) provide only indirect evidence of parentage (relationships not stated \u2014 the relationship column was not introduced until 1880), (b) the death certificate informant is secondary, and (c) research is not yet exhaustive \u2014 the 1870, 1880, and 1900 censuses have not been searched, and Thomas Flynn's probate records have not been located. If Thomas Flynn's will names Patrick as a son, or if additional census records confirm the relationship, the conclusion would advance to **Proved**.\\n\\n### Citations\\n\\n1. 1850 U.S. Census, Schuylkill County, Pennsylvania, population schedule, dwelling 84, family 91, Thomas Flynn household; NARA microfilm publication M432, roll 810; digital image, FamilySearch.org, accessed 1 May 2026.\\n2. 1860 U.S. Census, Schuylkill County, Pennsylvania, population schedule, dwelling 112, family 119, Thomas Flynn household; NARA microfilm publication M653, roll 1141; digital image, FamilySearch.org, accessed 2 May 2026.\\n3. Pennsylvania Department of Health, death certificate no. 4521 (1908), Patrick Flynn; Pennsylvania State Archives, Harrisburg; digital image, FamilySearch.org, accessed 3 May 2026.\",\n      \"question_id\": \"q_001\",\n      \"resolved_conflict_ids\": [\n        \"c_001\"\n      ],\n      \"supporting_assertion_ids\": [\n        \"a_004\",\n        \"a_010\",\n        \"a_013\"\n      ],\n      \"tier\": \"probable\",\n      \"vehicle\": \"summary\"\n    }\n  ],\n  \"questions\": [\n    {\n      \"created\": \"2026-05-01\",\n      \"depends_on\": [],\n      \"exhaustive_declaration\": {\n        \"declared\": false,\n        \"justification\": null,\n        \"log_entry_ids\": [],\n        \"stop_criteria\": null\n      },\n      \"id\": \"q_001\",\n      \"priority\": \"high\",\n      \"question\": \"Who were the parents of Patrick Flynn (b. ~1845, PA, d. 1908)?\",\n      \"rationale\": \"This is the primary research objective.\",\n      \"resolution_assertion_ids\": [],\n      \"resolved\": null,\n      \"selection_basis\": \"objective_decomposition\",\n      \"status\": \"in_progress\",\n      \"unblocks\": []\n    },\n    {\n      \"created\": \"2026-05-01\",\n      \"depends_on\": [],\n      \"exhaustive_declaration\": {\n        \"declared\": true,\n        \"justification\": \"Searched 1850 census for Schuylkill County on FamilySearch (indexed and browse), Ancestry (indexed), and MyHeritage (indexed). All three returned the same household. No other Patrick Flynn of matching age found in the county.\",\n        \"log_entry_ids\": [\n          \"log_001\",\n          \"log_002\",\n          \"log_003\"\n        ],\n        \"stop_criteria\": {\n          \"conflict_resolution\": \"No conflicts on the 1850 census placement question.\",\n          \"evidence_class\": \"Yes \u2014 FamilySearch provides original census image with indeterminate-quality information.\",\n          \"goal_alignment\": \"Yes \u2014 Patrick Flynn located in a specific 1850 household, answering the question.\",\n          \"independent_verification\": \"FamilySearch (original) and Ancestry (derivative) both return the same household. Two access paths, one underlying original.\",\n          \"original_substitution\": \"FamilySearch provides the original census image; Ancestry index is derivative but confirmed consistent.\",\n          \"overturn_risk\": \"Low \u2014 all three repositories agree, and no competing Patrick Flynn of matching age exists in the county.\",\n          \"repository_breadth\": \"Three major repositories searched (FamilySearch, Ancestry, MyHeritage). No additional known indexes of the 1850 Schuylkill County census exist.\"\n        }\n      },\n      \"id\": \"q_002\",\n      \"priority\": \"high\",\n      \"question\": \"Where was Patrick Flynn in the 1850 census?\",\n      \"rationale\": \"The 1850 census is the earliest enumeration where Patrick would appear by name (age ~5). Locating him in a household identifies candidate parents.\",\n      \"resolution_assertion_ids\": [\n        \"a_001\",\n        \"a_002\",\n        \"a_003\"\n      ],\n      \"resolved\": \"2026-05-02\",\n      \"selection_basis\": \"objective_decomposition\",\n      \"status\": \"resolved\",\n      \"unblocks\": [\n        \"q_001\"\n      ]\n    }\n  ],\n  \"researcher_profile\": {\n    \"experience_level\": \"intermediate\",\n    \"narration_guidance\": null,\n    \"subscriptions\": [\n      \"Ancestry\"\n    ]\n  },\n  \"sources\": [\n    {\n      \"access_date\": \"2026-05-01\",\n      \"citation\": \"1850 U.S. Census, Schuylkill County, Pennsylvania, population schedule, dwelling 84, family 91, Thomas Flynn household; NARA microfilm publication M432, roll 810; digital image, FamilySearch.org, accessed 1 May 2026.\",\n      \"citation_detail\": {\n        \"what\": \"1850 U.S. Federal Census, population schedule\",\n        \"when_accessed\": \"2026-05-01\",\n        \"when_created\": \"1850\",\n        \"where\": \"FamilySearch.org (NARA microfilm M432, roll 810)\",\n        \"where_within\": \"Schuylkill County, dwelling 84, family 91\",\n        \"who\": \"U.S. Census Bureau\"\n      },\n      \"gedcomx_source_description_id\": \"S1\",\n      \"id\": \"src_001\",\n      \"log_entry_id\": \"log_001\",\n      \"notes\": \"Image quality good. Enumerator handwriting clear.\",\n      \"repository\": \"FamilySearch\",\n      \"source_classification\": \"original\",\n      \"url\": \"https://www.familysearch.org/ark:/61903/1:1:MXYZ\",\n      \"url_archived\": null\n    },\n    {\n      \"access_date\": \"2026-05-01\",\n      \"citation\": \"1850 U.S. Census, Schuylkill County, Pennsylvania, population schedule, dwelling 84, Thomas Flynn household; digital image, Ancestry.com, accessed 1 May 2026.\",\n      \"citation_detail\": {\n        \"what\": \"1850 U.S. Federal Census, population schedule (Ancestry index)\",\n        \"when_accessed\": \"2026-05-01\",\n        \"when_created\": \"1850\",\n        \"where\": \"Ancestry.com\",\n        \"where_within\": \"Schuylkill County, dwelling 84\",\n        \"who\": \"U.S. Census Bureau\"\n      },\n      \"gedcomx_source_description_id\": \"S1\",\n      \"id\": \"src_002\",\n      \"log_entry_id\": \"log_002\",\n      \"notes\": \"Ancestry's index of the same original census. Transcription consistent with FamilySearch.\",\n      \"repository\": \"Ancestry\",\n      \"source_classification\": \"derivative\",\n      \"url\": null,\n      \"url_archived\": null\n    },\n    {\n      \"access_date\": \"2026-05-02\",\n      \"citation\": \"1860 U.S. Census, Schuylkill County, Pennsylvania, population schedule, dwelling 112, family 119, Thomas Flynn household; NARA microfilm publication M653, roll 1141; digital image, FamilySearch.org, accessed 2 May 2026.\",\n      \"citation_detail\": {\n        \"what\": \"1860 U.S. Federal Census, population schedule\",\n        \"when_accessed\": \"2026-05-02\",\n        \"when_created\": \"1860\",\n        \"where\": \"FamilySearch.org (NARA microfilm M653, roll 1141)\",\n        \"where_within\": \"Schuylkill County, dwelling 112, family 119\",\n        \"who\": \"U.S. Census Bureau\"\n      },\n      \"gedcomx_source_description_id\": \"S2\",\n      \"id\": \"src_003\",\n      \"log_entry_id\": \"log_004\",\n      \"notes\": null,\n      \"repository\": \"FamilySearch\",\n      \"source_classification\": \"original\",\n      \"url\": \"https://www.familysearch.org/ark:/61903/1:1:MABC\",\n      \"url_archived\": null\n    },\n    {\n      \"access_date\": \"2026-05-03\",\n      \"citation\": \"Pennsylvania Department of Health, death certificate no. 4521 (1908), Patrick Flynn; Pennsylvania State Archives, Harrisburg; digital image, FamilySearch.org, accessed 3 May 2026.\",\n      \"citation_detail\": {\n        \"what\": \"Death certificate no. 4521\",\n        \"when_accessed\": \"2026-05-03\",\n        \"when_created\": \"1908-03-14\",\n        \"where\": \"FamilySearch.org (Pennsylvania State Archives, Harrisburg)\",\n        \"where_within\": \"Certificate no. 4521\",\n        \"who\": \"Pennsylvania Department of Health; informant: James Brown (son-in-law)\"\n      },\n      \"gedcomx_source_description_id\": \"S3\",\n      \"id\": \"src_004\",\n      \"log_entry_id\": \"log_005\",\n      \"notes\": \"Informant is son-in-law James Brown. Primary for death facts, secondary for birth facts.\",\n      \"repository\": \"FamilySearch\",\n      \"source_classification\": \"original\",\n      \"url\": \"https://www.familysearch.org/ark:/61903/1:1:MDEF\",\n      \"url_archived\": null\n    }\n  ],\n  \"timelines\": [\n    {\n      \"events\": [\n        {\n          \"assertion_ids\": [\n            \"a_002\",\n            \"a_009\"\n          ],\n          \"date\": \"~1845\",\n          \"date_certainty\": \"estimated\",\n          \"description\": \"Born in Ireland, estimated from census ages\",\n          \"event_type\": \"birth\",\n          \"place\": \"Ireland\"\n        },\n        {\n          \"assertion_ids\": [\n            \"a_003\",\n            \"a_004\"\n          ],\n          \"date\": \"1850\",\n          \"date_certainty\": \"exact\",\n          \"description\": \"Enumerated age 5 in Thomas Flynn household, dwelling 84\",\n          \"event_type\": \"census\",\n          \"place\": \"Schuylkill County, Pennsylvania\"\n        },\n        {\n          \"assertion_ids\": [\n            \"a_008\",\n            \"a_009\",\n            \"a_010\"\n          ],\n          \"date\": \"1860\",\n          \"date_certainty\": \"exact\",\n          \"description\": \"Enumerated age 15 in Thomas Flynn household, dwelling 112\",\n          \"event_type\": \"census\",\n          \"place\": \"Schuylkill County, Pennsylvania\"\n        },\n        {\n          \"assertion_ids\": [\n            \"a_011\",\n            \"a_013\"\n          ],\n          \"date\": \"1908-03-12\",\n          \"date_certainty\": \"exact\",\n          \"description\": \"Died, death certificate names Thomas Flynn as father\",\n          \"event_type\": \"death\",\n          \"place\": \"Schuylkill County, Pennsylvania\"\n        }\n      ],\n      \"gaps\": [\n        {\n          \"end\": \"1908-03-12\",\n          \"expected_events\": [\n            \"marriage\",\n            \"1870_census\",\n            \"1880_census\",\n            \"1900_census\",\n            \"residence\",\n            \"occupation\"\n          ],\n          \"severity\": \"high\",\n          \"start\": \"1860-01-01\"\n        }\n      ],\n      \"generated\": \"2026-05-03T12:00:00Z\",\n      \"hypothesis_id\": \"h_001\",\n      \"id\": \"t_001\",\n      \"impossibilities\": [],\n      \"label\": \"Patrick Flynn \u2014 assuming Thomas Flynn parentage\",\n      \"person_ids\": [\n        \"I1\"\n      ]\n    }\n  ]\n}\n",
+    "eval/fixtures/scenarios/mid-research-flynn-ancestry-sub/tree.gedcomx.json": "{\n  \"persons\": [\n    {\n      \"facts\": [\n        {\n          \"date\": \"~1845\",\n          \"id\": \"F1\",\n          \"place\": \"Ireland\",\n          \"primary\": true,\n          \"sources\": [\n            {\n              \"page\": \"1850 Census, Schuylkill Co., dwelling 84\",\n              \"ref\": \"S1\"\n            }\n          ],\n          \"type\": \"Birth\"\n        },\n        {\n          \"date\": \"1908-03-12\",\n          \"id\": \"F2\",\n          \"place\": \"Schuylkill County, Pennsylvania\",\n          \"sources\": [\n            {\n              \"page\": \"Death cert. no. 4521\",\n              \"ref\": \"S3\"\n            }\n          ],\n          \"type\": \"Death\"\n        }\n      ],\n      \"gender\": \"Male\",\n      \"id\": \"I1\",\n      \"names\": [\n        {\n          \"given\": \"Patrick\",\n          \"id\": \"N1\",\n          \"preferred\": true,\n          \"surname\": \"Flynn\",\n          \"type\": \"BirthName\"\n        }\n      ]\n    },\n    {\n      \"facts\": [\n        {\n          \"date\": \"~1818\",\n          \"id\": \"F3\",\n          \"place\": \"Ireland\",\n          \"primary\": true,\n          \"type\": \"Birth\"\n        }\n      ],\n      \"gender\": \"Male\",\n      \"id\": \"I2\",\n      \"names\": [\n        {\n          \"given\": \"Thomas\",\n          \"id\": \"N2\",\n          \"preferred\": true,\n          \"surname\": \"Flynn\",\n          \"type\": \"BirthName\"\n        }\n      ]\n    }\n  ],\n  \"relationships\": [\n    {\n      \"child\": \"I1\",\n      \"id\": \"R1\",\n      \"parent\": \"I2\",\n      \"sources\": [\n        {\n          \"page\": \"1850 Census, Schuylkill Co., dwelling 84\",\n          \"quality\": 2,\n          \"ref\": \"S1\"\n        },\n        {\n          \"page\": \"1860 Census, Schuylkill Co., dwelling 112\",\n          \"quality\": 2,\n          \"ref\": \"S2\"\n        },\n        {\n          \"page\": \"Death cert. no. 4521\",\n          \"quality\": 2,\n          \"ref\": \"S3\"\n        }\n      ],\n      \"type\": \"ParentChild\"\n    }\n  ],\n  \"sources\": [\n    {\n      \"author\": \"U.S. Census Bureau\",\n      \"id\": \"S1\",\n      \"title\": \"1850 U.S. Federal Census\"\n    },\n    {\n      \"author\": \"U.S. Census Bureau\",\n      \"id\": \"S2\",\n      \"title\": \"1860 U.S. Federal Census\"\n    },\n    {\n      \"author\": \"Pennsylvania Dept. of Health\",\n      \"id\": \"S3\",\n      \"title\": \"Pennsylvania Death Certificates\"\n    },\n    {\n      \"author\": \"Schuylkill County Register of Wills\",\n      \"id\": \"S4\",\n      \"title\": \"Schuylkill County Probate Records\"\n    }\n  ]\n}\n",
+    "eval/fixtures/mcp/external-links-search-mixed-sites.json": "{\n  \"args\": {\n    \"standardPlace\": \"~\"\n  },\n  \"description\": \"external_links_search \u2014 mixed-site, duplicate-heavy curated links for Schuylkill County. Exercises the skill's host-filter + dedupe consumption rules: the same Ancestry probate URL appears three times under different record-type labels, alongside MyHeritage, Find A Grave, FamilySearch-wiki, and Newspapers.com links.\",\n  \"response\": {\n    \"query\": {\n      \"endYear\": 1890,\n      \"standardPlace\": \"Schuylkill, Pennsylvania, United States\",\n      \"startYear\": 1870\n    },\n    \"results\": [\n      {\n        \"linkText\": \"Pennsylvania, U.S., Wills and Probate Records, 1683-1993\",\n        \"url\": \"https://www.ancestry.com/search/collections/8800/\"\n      },\n      {\n        \"linkText\": \"Pennsylvania Probate Records - Schuylkill County\",\n        \"url\": \"https://www.ancestry.com/search/collections/8800/\"\n      },\n      {\n        \"linkText\": \"1850 United States Federal Census - Schuylkill County\",\n        \"url\": \"https://www.ancestry.com/search/collections/1276/\"\n      },\n      {\n        \"linkText\": \"Pennsylvania Death Records on MyHeritage\",\n        \"url\": \"https://www.myheritage.com/research?action=query\"\n      },\n      {\n        \"linkText\": \"Schuylkill County Cemeteries on Find A Grave\",\n        \"url\": \"https://www.findagrave.com/cemetery/browse?location=Schuylkill\"\n      },\n      {\n        \"linkText\": \"Schuylkill County Genealogy - FamilySearch Wiki\",\n        \"url\": \"https://www.familysearch.org/en/wiki/Schuylkill_County,_Pennsylvania_Genealogy\"\n      },\n      {\n        \"linkText\": \"Wills and Probates 1870-1890\",\n        \"url\": \"https://www.ancestry.com/search/collections/8800/\"\n      },\n      {\n        \"linkText\": \"Pennsylvania Newspapers on Newspapers.com\",\n        \"url\": \"https://www.newspapers.com/papers/?state=pennsylvania\"\n      }\n    ],\n    \"totalForPlace\": 8\n  },\n  \"tool\": \"external_links_search\"\n}\n",
+    "eval/fixtures/mcp/external-links-search-pennsylvania.json": "{\n  \"args\": {\n    \"standardPlace\": \"Pennsylvania, United States\"\n  },\n  \"description\": \"external_links_search \u2014 FS-curated third-party links for Pennsylvania (state level), marriage-era window. No MyHeritage link is curated, so a MyHeritage request falls back to the site-wide MyHeritage template; because the researcher is not subscribed to MyHeritage, the skill should also attach the login-wall warning. Used by the subscription-awareness test (009), which searches Pennsylvania for 1865-1875, so response.query echoes that exact window.\",\n  \"response\": {\n    \"query\": {\n      \"endYear\": 1875,\n      \"standardPlace\": \"Pennsylvania, United States\",\n      \"startYear\": 1865\n    },\n    \"results\": [\n      {\n        \"linkText\": \"Pennsylvania, U.S., County Marriage Records, 1885-1950\",\n        \"url\": \"https://www.ancestry.com/search/collections/2451/\"\n      },\n      {\n        \"linkText\": \"Pennsylvania Marriages on Findmypast\",\n        \"url\": \"https://www.findmypast.com/search-world-records/pennsylvania-marriages\"\n      },\n      {\n        \"linkText\": \"Pennsylvania Vital Records - FamilySearch Wiki\",\n        \"url\": \"https://www.familysearch.org/en/wiki/Pennsylvania_Vital_Records\"\n      }\n    ],\n    \"totalForPlace\": 3\n  },\n  \"tool\": \"external_links_search\"\n}\n",
+    "eval/fixtures/mcp/external-links-search-schuylkill.json": "{\n  \"args\": {\n    \"standardPlace\": \"~\"\n  },\n  \"description\": \"external_links_search \u2014 FS-curated third-party genealogy links for the Schuylkill County / Pennsylvania area. totalForPlace is the pre-filter count for the place; results is the returned set. This is the catch-all external-links fixture for the Flynn tests: the predicate matches any standardPlace because each of these tests loads exactly one external-links fixture, and the Pennsylvania-level tests (e.g. the FindAGrave search) resolve to a state-level place. response.query echoes only the place \u2014 the live tool echoes the caller's startYear/endYear back, but a single static fixture cannot match every test's window. The curated collections here pre-date most tests' target windows, which is exactly why those tests correctly fall back to a site-wide template.\",\n  \"response\": {\n    \"query\": {\n      \"standardPlace\": \"Schuylkill, Pennsylvania, United States\"\n    },\n    \"results\": [\n      {\n        \"linkText\": \"Pennsylvania, U.S., Tax and Exoneration Lists, 1768-1801\",\n        \"url\": \"https://www.ancestry.com/search/collections/7667/\"\n      },\n      {\n        \"linkText\": \"1850 United States Federal Census - Schuylkill County\",\n        \"url\": \"https://www.ancestry.com/search/collections/1276/\"\n      }\n    ],\n    \"totalForPlace\": 2\n  },\n  \"tool\": \"external_links_search\"\n}\n",
+    "eval/fixtures/mcp/external-links-search-schuylkill-1870-census.json": "{\n  \"args\": {\n    \"standardPlace\": \"~\"\n  },\n  \"description\": \"external_links_search \u2014 FS-curated third-party links for Schuylkill County, Pennsylvania, INCLUDING a curated Ancestry 1870 U.S. Federal Census collection that matches the 1870-census test (ut_search_external_sites_001). This is the Case-A fixture: a curated link fits the plan item's record type, so the skill should consume the returned URL directly \u2014 filter to ancestry.com, match the '1870 ... Census' linkText, dedupe, and append search params \u2014 rather than hand-building a collection ID from memory. The 1768-1801 tax list and 1850 census entries are realistic non-matching neighbours the skill must filter past. Contrast with external-links-search-schuylkill, the Case-B fixture whose collections all pre-date the tests' target windows. The predicate matches any standardPlace because each test loads exactly one external-links fixture.\",\n  \"response\": {\n    \"query\": {\n      \"standardPlace\": \"Schuylkill, Pennsylvania, United States\"\n    },\n    \"results\": [\n      {\n        \"linkText\": \"Pennsylvania, U.S., Tax and Exoneration Lists, 1768-1801\",\n        \"url\": \"https://www.ancestry.com/search/collections/7667/\"\n      },\n      {\n        \"linkText\": \"1850 United States Federal Census - Schuylkill County\",\n        \"url\": \"https://www.ancestry.com/search/collections/1276/\"\n      },\n      {\n        \"linkText\": \"1870 United States Federal Census\",\n        \"url\": \"https://www.ancestry.com/search/collections/7163/\"\n      }\n    ],\n    \"totalForPlace\": 3\n  },\n  \"tool\": \"external_links_search\"\n}\n",
+    "eval/fixtures/mcp/external-links-search-zero-results.json": "{\n  \"args\": {\n    \"standardPlace\": \"~\"\n  },\n  \"description\": \"external_links_search \u2014 FamilySearch curates no external links at all for the place (totalForPlace 0). Forces the skill onto the site-wide fallback URL templates.\",\n  \"response\": {\n    \"query\": {\n      \"endYear\": 1850,\n      \"standardPlace\": \"Ireland\",\n      \"startYear\": 1840\n    },\n    \"results\": [],\n    \"totalForPlace\": 0\n  },\n  \"tool\": \"external_links_search\"\n}\n",
+    "eval/fixtures/mcp/place-search-ireland.json": "{\n  \"args\": {\n    \"placeName\": \"~Ireland\"\n  },\n  \"description\": \"FamilySearch place data for Ireland\",\n  \"response\": {\n    \"results\": [\n      {\n        \"dateRange\": \"+1801/\",\n        \"familysearchUrl\": \"https://www.familysearch.org/en/research/places/?text=Ireland&focusedId=10\",\n        \"latitude\": 53.0,\n        \"longitude\": -8.0,\n        \"standardPlace\": \"Ireland\",\n        \"type\": \"Country\"\n      }\n    ]\n  },\n  \"tool\": \"place_search\"\n}\n",
+    "eval/fixtures/mcp/place-search-ireland-by-name.json": "{\n  \"args\": {\n    \"name\": \"~Ireland\"\n  },\n  \"description\": \"Fallback variant: catches place_search calls that use the non-canonical 'name' arg instead of 'placeName'. Same response payload as place-search-ireland.\",\n  \"response\": {\n    \"results\": [\n      {\n        \"dateRange\": \"+1801/\",\n        \"familysearchUrl\": \"https://www.familysearch.org/en/research/places/?text=Ireland&focusedId=10\",\n        \"latitude\": 53.0,\n        \"longitude\": -8.0,\n        \"standardPlace\": \"Ireland\",\n        \"type\": \"Country\"\n      }\n    ]\n  },\n  \"tool\": \"place_search\"\n}\n",
+    "eval/fixtures/mcp/place-search-ireland-by-place.json": "{\n  \"args\": {\n    \"place\": \"~Ireland\"\n  },\n  \"description\": \"Fallback variant: catches place_search calls that use the non-canonical 'place' arg instead of 'placeName'. Same response payload as place-search-ireland.\",\n  \"response\": {\n    \"results\": [\n      {\n        \"dateRange\": \"+1801/\",\n        \"familysearchUrl\": \"https://www.familysearch.org/en/research/places/?text=Ireland&focusedId=10\",\n        \"latitude\": 53.0,\n        \"longitude\": -8.0,\n        \"standardPlace\": \"Ireland\",\n        \"type\": \"Country\"\n      }\n    ]\n  },\n  \"tool\": \"place_search\"\n}\n",
+    "eval/fixtures/mcp/place-search-pennsylvania.json": "{\n  \"args\": {\n    \"placeName\": \"~\"\n  },\n  \"description\": \"FamilySearch place data for Pennsylvania (state-level lookup, used when an assertion's birthplace is just 'Pennsylvania' without a county). Predicate is a catch-all because this is the only place_search-answering fixture in the tests that load it, and the skill may pass 'Pennsylvania' either in placeName or in contextName (e.g. placeName='Schuylkill County', contextName='Pennsylvania') \u2014 both must resolve to this state-level place.\",\n  \"response\": {\n    \"results\": [\n      {\n        \"dateRange\": \"+1787/\",\n        \"familysearchUrl\": \"https://www.familysearch.org/en/research/places/?text=Pennsylvania&focusedId=39\",\n        \"latitude\": 40.5,\n        \"longitude\": -77.5,\n        \"standardPlace\": \"Pennsylvania, United States\",\n        \"type\": \"State\"\n      }\n    ]\n  },\n  \"tool\": \"place_search\"\n}\n",
+    "eval/fixtures/mcp/place-search-pennsylvania-by-name.json": "{\n  \"args\": {\n    \"name\": \"~Pennsylvania\"\n  },\n  \"description\": \"Fallback variant: catches place_search calls that use the non-canonical 'name' arg instead of 'placeName'. Same response payload as place-search-pennsylvania.\",\n  \"response\": {\n    \"results\": [\n      {\n        \"dateRange\": \"+1787/\",\n        \"familysearchUrl\": \"https://www.familysearch.org/en/research/places/?text=Pennsylvania&focusedId=39\",\n        \"latitude\": 40.5,\n        \"longitude\": -77.5,\n        \"standardPlace\": \"Pennsylvania, United States\",\n        \"type\": \"State\"\n      }\n    ]\n  },\n  \"tool\": \"place_search\"\n}\n",
+    "eval/fixtures/mcp/place-search-pennsylvania-by-place.json": "{\n  \"args\": {\n    \"place\": \"~Pennsylvania\"\n  },\n  \"description\": \"Fallback variant: catches place_search calls that use the non-canonical 'place' arg instead of 'placeName'. Same response payload as place-search-pennsylvania.\",\n  \"response\": {\n    \"results\": [\n      {\n        \"dateRange\": \"+1787/\",\n        \"familysearchUrl\": \"https://www.familysearch.org/en/research/places/?text=Pennsylvania&focusedId=39\",\n        \"latitude\": 40.5,\n        \"longitude\": -77.5,\n        \"standardPlace\": \"Pennsylvania, United States\",\n        \"type\": \"State\"\n      }\n    ]\n  },\n  \"tool\": \"place_search\"\n}\n",
+    "eval/fixtures/mcp/place-search-schuylkill-by-name.json": "{\n  \"args\": {\n    \"name\": \"~Schuylkill\"\n  },\n  \"description\": \"FamilySearch place data for Schuylkill County \u2014 variant matching `name` arg (non-canonical; the real tool parameter is `placeName`). Same response payload as place-search-schuylkill-county so the run grades rather than aborts; the Tool Arguments dimension surfaces the wrong arg name.\",\n  \"response\": {\n    \"results\": [\n      {\n        \"dateRange\": \"+1811/\",\n        \"familysearchUrl\": \"https://www.familysearch.org/en/research/places/?text=Schuylkill&focusedId=7042\",\n        \"latitude\": 40.7,\n        \"longitude\": -76.2,\n        \"standardPlace\": \"Schuylkill, Pennsylvania, United States\",\n        \"type\": \"County\"\n      }\n    ]\n  },\n  \"tool\": \"place_search\"\n}\n",
+    "eval/fixtures/mcp/place-search-schuylkill-by-place.json": "{\n  \"args\": {\n    \"place\": \"~Schuylkill\"\n  },\n  \"description\": \"FamilySearch place data for Schuylkill County \u2014 variant matching `place` arg (non-canonical; real parameter is `placeName`). Same response payload as place-search-schuylkill-county so the run grades rather than aborts.\",\n  \"response\": {\n    \"results\": [\n      {\n        \"dateRange\": \"+1811/\",\n        \"familysearchUrl\": \"https://www.familysearch.org/en/research/places/?text=Schuylkill&focusedId=7042\",\n        \"latitude\": 40.7,\n        \"longitude\": -76.2,\n        \"standardPlace\": \"Schuylkill, Pennsylvania, United States\",\n        \"type\": \"County\"\n      }\n    ]\n  },\n  \"tool\": \"place_search\"\n}\n",
+    "eval/fixtures/mcp/place-search-schuylkill-county.json": "{\n  \"args\": {\n    \"placeName\": \"~Schuylkill\"\n  },\n  \"description\": \"FamilySearch place data for Schuylkill County, Pennsylvania\",\n  \"response\": {\n    \"results\": [\n      {\n        \"dateRange\": \"+1811/\",\n        \"familysearchUrl\": \"https://www.familysearch.org/en/research/places/?text=Schuylkill&focusedId=7042\",\n        \"latitude\": 40.7,\n        \"longitude\": -76.2,\n        \"standardPlace\": \"Schuylkill, Pennsylvania, United States\",\n        \"type\": \"County\"\n      }\n    ]\n  },\n  \"tool\": \"place_search\"\n}\n"
+  },
+  "tests": [
+    {
+      "test_id": "ut_search_external_sites_001",
+      "test_type": "positive",
+      "expected_outcome": "pass",
+      "scenario": "mid-research-flynn",
+      "mcp_fixtures": [
+        "place-search-schuylkill-county",
+        "place-search-schuylkill-by-name",
+        "place-search-schuylkill-by-place",
+        "external-links-search-schuylkill-1870-census"
+      ],
+      "outcome": "partial",
+      "flaky": false,
+      "outcome_summary": {
+        "per_run_outcomes": [
+          "partial"
+        ],
+        "aggregated_dimensions": [
+          {
+            "source": "base",
+            "name": "Correctness",
+            "score": 2,
+            "rationale": "The skill generated a correctly pre-filled Ancestry 1870 census URL with appropriate parameters (name, birth year 1845, birthplace Ireland, residence Pennsylvania). However, the first place_search call failed with fixture_not_found (searching for 'United States' instead of the specific county), indicating an initial tool-usage error. The skill recovered by calling place_search again with 'Schuylkill County, Pennsylvania', which succeeded. The final URL and strategy are factually sound \u2014 Ireland as birthplace is correctly resolved per the conflict resolution noted in the scenario. The skill appropriately deferred result triage pending capture, which is correct behavior. The one defect is the erroneous first place_search call, which represents a correctness slip in tool usage even though recovery occurred."
+          },
+          {
+            "source": "base",
+            "name": "Completeness",
+            "score": 3,
+            "rationale": "The skill addressed all required elements: generated a correctly pre-filled Ancestry URL for the 1870 census targeting Patrick Flynn with appropriate parameters (name, birth year ~1845, birthplace Ireland, residence Pennsylvania); provided clear capture-workflow instructions (save as PDF, upload); logged both the curated-links fetch and the search itself; and appropriately deferred result triage pending the user's capture. No required work was omitted."
+          },
+          {
+            "source": "base",
+            "name": "Tool Arguments",
+            "score": 2,
+            "rationale": "The first place_search call with placeName='United States' resulted in fixture_not_found (matched.kind='none'), which is incorrect tool usage \u2014 the skill should have targeted the specific county from the start. The second place_search call with 'Schuylkill County, Pennsylvania' correctly matched the fixture (matched.kind='predicate'). The external_links_search call correctly used the standardPlace returned by the successful place_search, with appropriate year range (1870\u20131870) and host filter (ancestry.com). Both research_log_append calls used correct arguments and succeeded. The erroneous first call is a meaningful defect in tool selection, though recovery was clean."
+          },
+          {
+            "source": "rubric",
+            "name": "URL generation",
+            "score": 3,
+            "rationale": "The generated URL targets Ancestry.com's 1870 Federal Census collection (7163) and includes all relevant search parameters from the scenario: name (Patrick Flynn), birth year (1845), birthplace (Ireland \u2014 correctly resolved per conflict resolution), and residence (Pennsylvania, 1870). The URL is syntactically valid and uses appropriate query encoding (?name=Patrick_Flynn&birth=1845&birthplace=Ireland&residence=1870_Pennsylvania)."
+          },
+          {
+            "source": "rubric",
+            "name": "Capture guidance",
+            "score": 3,
+            "rationale": "The skill provided clear, step-by-step capture-workflow instructions: scroll to load lazy-loaded results, press Cmd+P (Mac) or Ctrl+P (Windows), select 'Save as PDF', save the file, and upload it. The skill also named specific record-type expectations (1870 census household entry, Patrick would be ~25 years old, possibly head of household if married), helping the user identify relevant results."
+          },
+          {
+            "source": "rubric",
+            "name": "Result triage",
+            "score": 3,
+            "rationale": "No capture was provided in this turn \u2014 the user has not yet run the search or uploaded results. The skill correctly deferred triage, stating 'Awaiting user capture' in the log notes and not fabricating or pre-judging results. This is the correct behavior for a no-capture turn: wait for the capture before evaluating individual records. A clean deferral is a pass."
+          },
+          {
+            "source": "rubric",
+            "name": "Tool selection",
+            "score": 2,
+            "rationale": "The skill called place_search twice: first with 'United States' (fixture_not_found \u2014 incorrect), then with 'Schuylkill County, Pennsylvania' (matched correctly). The second call's standardPlace result ('Schuylkill, Pennsylvania, United States') correctly fed external_links_search with the appropriate year window (1870\u20131870) and host filter (ancestry.com). The curated link for the 1870 census (collection 7163) was correctly identified and used to build the search URL. Both research_log_append calls were correct. The first erroneous place_search call is a genuine consumption slip, though recovery was clean and the final tool sequence was correct."
+          },
+          {
+            "source": "rubric",
+            "name": "Log entry",
+            "score": 3,
+            "rationale": "Two log entries were written: log_006 (curated-links fetch, outcome='positive') and log_007 (search in-flight, outcome='partial'). Log_007 names the site (ancestry.com), person (Patrick Flynn), place (Pennsylvania), year (1870), and collection (1870 United States Federal Census, collection 7163). The entry was written at URL-generation time with capture_received=false, correctly indicating the search is in-flight and awaiting user capture. The notes explain the narrow strategy and ad-hoc nature of the search."
+          }
+        ]
+      },
+      "totals": {
+        "duration_ms": 97172.01045900583,
+        "duration_api_ms": 96315.0,
+        "judge_duration_ms": 13671.227457991336,
+        "wall_clock_ms": 110912.21904754639,
+        "num_turns": 14,
+        "input_tokens": 16,
+        "cached_input_tokens": 266421,
+        "output_tokens": 5171,
+        "judge_input_tokens": 5271,
+        "judge_cached_input_tokens": 4778,
+        "judge_output_tokens": 1313,
+        "skill_cost_usd": 0.2906963,
+        "judge_cost_usd": 0.0075358,
+        "total_cost_usd": 0.2982321
+      },
+      "runs": [
+        {
+          "run_index": 0,
+          "run_id": "run_ut_search_external_sites_001_2026-07-17_22-54-08_0",
+          "outcome": "partial",
+          "aborted_reason": null,
+          "duration_ms": 97172.01045900583,
+          "duration_api_ms": 96315.0,
+          "num_turns": 14,
+          "skill_attempts": 1,
+          "input_tokens": 16,
+          "cached_input_tokens": 266421,
+          "output_tokens": 5171,
+          "skill_cost_usd": 0.2906963,
+          "output": {
+            "text_response": "Let me start by reading the project context and the reference files simultaneously.Now let me read the research.json and check for plan items, while simultaneously resolving the place for the 1870 US census.I have a clear picture of the project now. Patrick Flynn (b. ~1845, Ireland; d. 1908, Schuylkill Co., PA) is the subject. No plan item exists for the 1870 census on Ancestry \u2014 this is an ad-hoc search. The timeline explicitly flags `1870_census` as a gap. The researcher has an Ancestry subscription (confirmed by log_002). \"Flynn\" is a common name, so I'll use a narrow strategy \u2014 adding birth year, place, and age.\n\nLet me resolve the place and fetch curated links simultaneously.Good \u2014 standard place is **\"Schuylkill, Pennsylvania, United States\"**. Now fetching curated Ancestry links for 1870.Three links returned; filtering to Ancestry + 1870 census match:\n\n- `Pennsylvania, U.S., Tax and Exoneration Lists, 1768-1801` \u2014 wrong record type and period, excluded.\n- `1850 United States Federal Census - Schuylkill County` \u2014 wrong year, excluded.\n- **`1870 United States Federal Census`** (collection 7163) \u2014 **matches.** \u2713\n\nAll three URLs are distinct \u2014 no deduplication needed.\n\n**Case A** applies. Building the search URL on collection 7163 with a narrow strategy (Flynn is a very common name): name + birth year + Ireland birthplace (confirmed by two census records) + Pennsylvania residence.\n\nNow logging both the curated-links fetch and the search itself, then presenting the URL.Both log entries written (log_006 for the curated-links fetch, log_007 for the search in-flight). Here's the URL:\n\n---\n\n**Search: 1870 US Federal Census on Ancestry for Patrick Flynn**\n\nThis is an ad-hoc search targeting the gap noted in the timeline (1860\u20131908). Patrick would be approximately 25 years old in 1870. I used a narrow strategy (common name) \u2014 birth year 1845, birthplace Ireland (confirmed by both the 1850 and 1860 censuses), Pennsylvania residence.\n\n**Click this link to search:**\n[Ancestry \u2014 1870 United States Federal Census, Patrick Flynn](https://www.ancestry.com/search/collections/7163/?name=Patrick_Flynn&birth=1845&birthplace=Ireland&residence=1870_Pennsylvania)\n\nAfter the page loads:\n1. Scroll to the bottom of the page and back to the top (forces lazy-loaded results into view)\n2. Press **Cmd+P** (Mac) or **Ctrl+P** (Windows)\n3. Select **\"Save as PDF\"**\n4. Save the file and upload it here\n\nIf the page asks you to log in, please log in first, then click the link again.\n\n---\n\n**Strategy note:** If results are too few or zero, the next variation would be to drop the `birthplace=Ireland` parameter (the 1908 death certificate says Pennsylvania for birthplace, and Ancestry's index may reflect that error) or broaden residence to Schuylkill County only. If results are too many, I can add a relative name \u2014 Thomas Flynn was the household head in 1850 and 1860, and would be a strong father filter.",
+            "activated": true,
+            "skills_invoked": [
+              "search-external-sites"
+            ],
+            "tool_calls": [
+              {
+                "tool": "mcp__genealogy__place_search",
+                "args": {
+                  "placeName": "United States"
+                },
+                "expected_args": null,
+                "matched": {
+                  "kind": "none",
+                  "index": null
+                },
+                "response_fixture": null
+              },
+              {
+                "tool": "mcp__genealogy__place_search",
+                "args": {
+                  "placeName": "Schuylkill County, Pennsylvania"
+                },
+                "expected_args": {
+                  "placeName": "~Schuylkill"
+                },
+                "matched": {
+                  "kind": "predicate",
+                  "index": 0
+                },
+                "response_fixture": "place-search-schuylkill-county"
+              },
+              {
+                "tool": "mcp__genealogy__external_links_search",
+                "args": {
+                  "standardPlace": "Schuylkill, Pennsylvania, United States",
+                  "startYear": 1870,
+                  "endYear": 1870,
+                  "host": "ancestry.com",
+                  "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/eval-ut_search_external_sites_001-0-0-8z3jluic"
+                },
+                "expected_args": {
+                  "standardPlace": "~"
+                },
+                "matched": {
+                  "kind": "predicate",
+                  "index": 0
+                },
+                "response_fixture": "external-links-search-schuylkill-1870-census"
+              },
+              {
+                "tool": "mcp__genealogy__research_log_append",
+                "args": {
+                  "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/eval-ut_search_external_sites_001-0-0-8z3jluic",
+                  "planItemId": null,
+                  "tool": "external_links_search",
+                  "query": {
+                    "standardPlace": "Schuylkill, Pennsylvania, United States",
+                    "host": "ancestry.com",
+                    "startYear": 1870,
+                    "endYear": 1870
+                  },
+                  "outcome": "positive",
+                  "resultsExamined": 3,
+                  "notes": "Curated external links for Schuylkill, Pennsylvania, United States. Three links returned; one matches the 1870 census on Ancestry (collection 7163).",
+                  "stagedResultsRef": "results/.staging/e3cb4b30-159a-4611-aaff-a315151f2ecb.json"
+                },
+                "expected_args": null,
+                "matched": {
+                  "kind": "live",
+                  "index": null
+                },
+                "response_fixture": "live:research_log_append"
+              },
+              {
+                "tool": "mcp__genealogy__research_log_append",
+                "args": {
+                  "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/eval-ut_search_external_sites_001-0-0-8z3jluic",
+                  "planItemId": null,
+                  "tool": "external_site",
+                  "query": {
+                    "surname": "Flynn",
+                    "given": "Patrick",
+                    "birth_year": 1845,
+                    "birthplace": "Ireland",
+                    "residence_year": 1870,
+                    "residence_place": "Pennsylvania",
+                    "collection": "1870 United States Federal Census",
+                    "collection_id": "7163",
+                    "site": "ancestry.com"
+                  },
+                  "outcome": "partial",
+                  "resultsExamined": 0,
+                  "notes": "URL generated for Ancestry 1870 US Federal Census (collection 7163). Ad-hoc search \u2014 no plan item. Narrow strategy used because Flynn is a common name: name + birth year 1845 + birthplace Ireland (confirmed by 1850 and 1860 census records) + Pennsylvania residence. Awaiting user capture.",
+                  "externalSite": {
+                    "site": "ancestry",
+                    "urlGenerated": "https://www.ancestry.com/search/collections/7163/?name=Patrick_Flynn&birth=1845&birthplace=Ireland&residence=1870_Pennsylvania",
+                    "captureReceived": false,
+                    "captureFilename": null
+                  }
+                },
+                "expected_args": null,
+                "matched": {
+                  "kind": "live",
+                  "index": null
+                },
+                "response_fixture": "live:research_log_append"
+              }
+            ],
+            "files_created": [
+              "results/log_006.json"
+            ],
+            "file_changes": {
+              "research.json": {
+                "sections_modified": [
+                  "log"
+                ],
+                "diff": {
+                  "log": {
+                    "added": [
+                      {
+                        "id": "log_006",
+                        "plan_item_id": null,
+                        "performed": "2026-07-17T22:57:54.974Z",
+                        "tool": "external_links_search",
+                        "query": {
+                          "standardPlace": "Schuylkill, Pennsylvania, United States",
+                          "host": "ancestry.com",
+                          "startYear": 1870,
+                          "endYear": 1870
+                        },
+                        "outcome": "positive",
+                        "results_examined": 3,
+                        "external_site": null,
+                        "results_ref": "results/log_006.json",
+                        "notes": "Curated external links for Schuylkill, Pennsylvania, United States. Three links returned; one matches the 1870 census on Ancestry (collection 7163)."
+                      },
+                      {
+                        "id": "log_007",
+                        "plan_item_id": null,
+                        "performed": "2026-07-17T22:58:01.213Z",
+                        "tool": "external_site",
+                        "query": {
+                          "surname": "Flynn",
+                          "given": "Patrick",
+                          "birth_year": 1845,
+                          "birthplace": "Ireland",
+                          "residence_year": 1870,
+                          "residence_place": "Pennsylvania",
+                          "collection": "1870 United States Federal Census",
+                          "collection_id": "7163",
+                          "site": "ancestry.com"
+                        },
+                        "outcome": "partial",
+                        "results_examined": 0,
+                        "external_site": {
+                          "site": "ancestry",
+                          "url_generated": "https://www.ancestry.com/search/collections/7163/?name=Patrick_Flynn&birth=1845&birthplace=Ireland&residence=1870_Pennsylvania",
+                          "capture_received": false,
+                          "capture_filename": null
+                        },
+                        "results_ref": null,
+                        "notes": "URL generated for Ancestry 1870 US Federal Census (collection 7163). Ad-hoc search \u2014 no plan item. Narrow strategy used because Flynn is a common name: name + birth year 1845 + birthplace Ireland (confirmed by 1850 and 1860 census records) + Pennsylvania residence. Awaiting user capture."
+                      }
+                    ],
+                    "modified": [],
+                    "deleted": []
+                  }
+                }
+              }
+            },
+            "warnings": [
+              {
+                "kind": "uncovered_tool_call",
+                "advisory": "2 of 6 MCP tool call(s) matched no fixture predicate \u2014 the skill ran against a fixture_not_found or denied/unknown-tool error. Add or fix an mcp_fixture whose args match the call.",
+                "attempted": [
+                  {
+                    "tool": "mcp__genealogy__project_context",
+                    "args": {
+                      "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/eval-ut_search_external_sites_001-0-0-8z3jluic"
+                    }
+                  },
+                  {
+                    "tool": "mcp__genealogy__place_search",
+                    "args": {
+                      "placeName": "United States"
+                    }
+                  },
+                  {
+                    "tool": "mcp__genealogy__place_search",
+                    "args": {
+                      "placeName": "Schuylkill County, Pennsylvania"
+                    }
+                  },
+                  {
+                    "tool": "mcp__genealogy__external_links_search",
+                    "args": {
+                      "standardPlace": "Schuylkill, Pennsylvania, United States",
+                      "startYear": 1870,
+                      "endYear": 1870,
+                      "host": "ancestry.com",
+                      "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/eval-ut_search_external_sites_001-0-0-8z3jluic"
+                    }
+                  },
+                  {
+                    "tool": "mcp__genealogy__research_log_append",
+                    "args": {
+                      "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/eval-ut_search_external_sites_001-0-0-8z3jluic",
+                      "planItemId": null,
+                      "tool": "external_links_search",
+                      "query": {
+                        "standardPlace": "Schuylkill, Pennsylvania, United States",
+                        "host": "ancestry.com",
+                        "startYear": 1870,
+                        "endYear": 1870
+                      },
+                      "outcome": "positive",
+                      "resultsExamined": 3,
+                      "notes": "Curated external links for Schuylkill, Pennsylvania, United States. Three links returned; one matches the 1870 census on Ancestry (collection 7163).",
+                      "stagedResultsRef": "results/.staging/e3cb4b30-159a-4611-aaff-a315151f2ecb.json"
+                    }
+                  },
+                  {
+                    "tool": "mcp__genealogy__research_log_append",
+                    "args": {
+                      "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/eval-ut_search_external_sites_001-0-0-8z3jluic",
+                      "planItemId": null,
+                      "tool": "external_site",
+                      "query": {
+                        "surname": "Flynn",
+                        "given": "Patrick",
+                        "birth_year": 1845,
+                        "birthplace": "Ireland",
+                        "residence_year": 1870,
+                        "residence_place": "Pennsylvania",
+                        "collection": "1870 United States Federal Census",
+                        "collection_id": "7163",
+                        "site": "ancestry.com"
+                      },
+                      "outcome": "partial",
+                      "resultsExamined": 0,
+                      "notes": "URL generated for Ancestry 1870 US Federal Census (collection 7163). Ad-hoc search \u2014 no plan item. Narrow strategy used because Flynn is a common name: name + birth year 1845 + birthplace Ireland (confirmed by 1850 and 1860 census records) + Pennsylvania residence. Awaiting user capture.",
+                      "externalSite": {
+                        "site": "ancestry",
+                        "urlGenerated": "https://www.ancestry.com/search/collections/7163/?name=Patrick_Flynn&birth=1845&birthplace=Ireland&residence=1870_Pennsylvania",
+                        "captureReceived": false,
+                        "captureFilename": null
+                      }
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "validators": {
+            "passed": true,
+            "results": [
+              {
+                "name": "test_id_references_resolve",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_log_append_only",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_entries_deleted",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_main_thread_subagent_only_calls",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_project_file_changes_route_through_writer_tools",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_research_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tool_allowlist",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_gedcomx_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_log_site_ancestry",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_log_site_findagrave",
+                "passed": true,
+                "error": "skipped: not a log-site-findagrave scenario"
+              },
+              {
+                "name": "test_log_site_findmypast",
+                "passed": true,
+                "error": "skipped: not a log-site-findmypast scenario"
+              },
+              {
+                "name": "test_log_site_myheritage",
+                "passed": true,
+                "error": "skipped: not a log-site-myheritage scenario"
+              },
+              {
+                "name": "test_log_site_newspapers",
+                "passed": true,
+                "error": "skipped: not a log-site-newspapers scenario"
+              },
+              {
+                "name": "test_positive_appends_external_site_log_entry",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_url_generation_log_entry_shape",
+                "passed": true,
+                "error": null
+              }
+            ]
+          },
+          "judge": {
+            "skipped": false,
+            "dimensions": [
+              {
+                "source": "base",
+                "name": "Correctness",
+                "score": 2,
+                "rationale": "The skill generated a correctly pre-filled Ancestry 1870 census URL with appropriate parameters (name, birth year 1845, birthplace Ireland, residence Pennsylvania). However, the first place_search call failed with fixture_not_found (searching for 'United States' instead of the specific county), indicating an initial tool-usage error. The skill recovered by calling place_search again with 'Schuylkill County, Pennsylvania', which succeeded. The final URL and strategy are factually sound \u2014 Ireland as birthplace is correctly resolved per the conflict resolution noted in the scenario. The skill appropriately deferred result triage pending capture, which is correct behavior. The one defect is the erroneous first place_search call, which represents a correctness slip in tool usage even though recovery occurred."
+              },
+              {
+                "source": "base",
+                "name": "Completeness",
+                "score": 3,
+                "rationale": "The skill addressed all required elements: generated a correctly pre-filled Ancestry URL for the 1870 census targeting Patrick Flynn with appropriate parameters (name, birth year ~1845, birthplace Ireland, residence Pennsylvania); provided clear capture-workflow instructions (save as PDF, upload); logged both the curated-links fetch and the search itself; and appropriately deferred result triage pending the user's capture. No required work was omitted."
+              },
+              {
+                "source": "base",
+                "name": "Tool Arguments",
+                "score": 2,
+                "rationale": "The first place_search call with placeName='United States' resulted in fixture_not_found (matched.kind='none'), which is incorrect tool usage \u2014 the skill should have targeted the specific county from the start. The second place_search call with 'Schuylkill County, Pennsylvania' correctly matched the fixture (matched.kind='predicate'). The external_links_search call correctly used the standardPlace returned by the successful place_search, with appropriate year range (1870\u20131870) and host filter (ancestry.com). Both research_log_append calls used correct arguments and succeeded. The erroneous first call is a meaningful defect in tool selection, though recovery was clean."
+              },
+              {
+                "source": "rubric",
+                "name": "URL generation",
+                "score": 3,
+                "rationale": "The generated URL targets Ancestry.com's 1870 Federal Census collection (7163) and includes all relevant search parameters from the scenario: name (Patrick Flynn), birth year (1845), birthplace (Ireland \u2014 correctly resolved per conflict resolution), and residence (Pennsylvania, 1870). The URL is syntactically valid and uses appropriate query encoding (?name=Patrick_Flynn&birth=1845&birthplace=Ireland&residence=1870_Pennsylvania)."
+              },
+              {
+                "source": "rubric",
+                "name": "Capture guidance",
+                "score": 3,
+                "rationale": "The skill provided clear, step-by-step capture-workflow instructions: scroll to load lazy-loaded results, press Cmd+P (Mac) or Ctrl+P (Windows), select 'Save as PDF', save the file, and upload it. The skill also named specific record-type expectations (1870 census household entry, Patrick would be ~25 years old, possibly head of household if married), helping the user identify relevant results."
+              },
+              {
+                "source": "rubric",
+                "name": "Result triage",
+                "score": 3,
+                "rationale": "No capture was provided in this turn \u2014 the user has not yet run the search or uploaded results. The skill correctly deferred triage, stating 'Awaiting user capture' in the log notes and not fabricating or pre-judging results. This is the correct behavior for a no-capture turn: wait for the capture before evaluating individual records. A clean deferral is a pass."
+              },
+              {
+                "source": "rubric",
+                "name": "Tool selection",
+                "score": 2,
+                "rationale": "The skill called place_search twice: first with 'United States' (fixture_not_found \u2014 incorrect), then with 'Schuylkill County, Pennsylvania' (matched correctly). The second call's standardPlace result ('Schuylkill, Pennsylvania, United States') correctly fed external_links_search with the appropriate year window (1870\u20131870) and host filter (ancestry.com). The curated link for the 1870 census (collection 7163) was correctly identified and used to build the search URL. Both research_log_append calls were correct. The first erroneous place_search call is a genuine consumption slip, though recovery was clean and the final tool sequence was correct."
+              },
+              {
+                "source": "rubric",
+                "name": "Log entry",
+                "score": 3,
+                "rationale": "Two log entries were written: log_006 (curated-links fetch, outcome='positive') and log_007 (search in-flight, outcome='partial'). Log_007 names the site (ancestry.com), person (Patrick Flynn), place (Pennsylvania), year (1870), and collection (1870 United States Federal Census, collection 7163). The entry was written at URL-generation time with capture_received=false, correctly indicating the search is in-flight and awaiting user capture. The notes explain the narrow strategy and ad-hoc nature of the search."
+              }
+            ],
+            "judge_cost_usd": 0.0075358,
+            "duration_ms": 13671.227457991336,
+            "error": null,
+            "input_tokens": 5271,
+            "cached_input_tokens": 4778,
+            "output_tokens": 1313
+          },
+          "started_at": 1784328995.140967,
+          "ended_at": 1784329106.053186
+        }
+      ]
+    },
+    {
+      "test_id": "ut_search_external_sites_013",
+      "test_type": "positive",
+      "expected_outcome": "pass",
+      "scenario": "mid-research-flynn",
+      "mcp_fixtures": [
+        "place-search-schuylkill-county",
+        "place-search-schuylkill-by-name",
+        "place-search-schuylkill-by-place",
+        "external-links-search-schuylkill"
+      ],
+      "outcome": "pass",
+      "flaky": false,
+      "outcome_summary": {
+        "per_run_outcomes": [
+          "pass"
+        ],
+        "aggregated_dimensions": [
+          {
+            "source": "base",
+            "name": "Correctness",
+            "score": 3,
+            "rationale": "The skill correctly identified that no curated Ancestry link exists for the 1880 census on Schuylkill County, built a valid pre-filled Ancestry search URL using collection 6742 with appropriate parameters (name, birth year, birthplace, residence), and logged the search as deferred with outcome 'negative' and capture_received false. The URL parameters match the available evidence (Patrick Flynn, ~1845, Ireland, Schuylkill County PA). The deferred-log approach is correct for autonomous mode where no user is available to capture and upload results."
+          },
+          {
+            "source": "base",
+            "name": "Completeness",
+            "score": 3,
+            "rationale": "The skill addressed all requirements: resolved the place via place_search, fetched curated links via external_links_search, recognized the mismatch (no 1880 census link), built the fallback URL, logged the curated-links fetch (log_006), and logged the deferred external-site search (log_007) with all required fields (outcome, capture_received, notes with URL). The autonomous-mode constraint was honored by deferring rather than presenting user-facing capture instructions."
+          },
+          {
+            "source": "base",
+            "name": "Tool Arguments",
+            "score": 3,
+            "rationale": "All four tool calls passed correct arguments. place_search received 'Schuylkill County' and 'Pennsylvania' (matching expected ~Schuylkill). external_links_search received the returned standardPlace 'Schuylkill, Pennsylvania, United States', startYear 1880, endYear 1880, and host 'ancestry.com' \u2014 all correct. Both research_log_append calls used valid schemas with appropriate outcome, notes, and externalSite fields. No fixture_not_found errors occurred."
+          },
+          {
+            "source": "rubric",
+            "name": "URL generation",
+            "score": 3,
+            "rationale": "The skill generated a correctly pre-filled Ancestry search URL targeting collection 6742 (1880 U.S. Federal Census). The URL includes all relevant search parameters: name=Patrick_Flynn, birth=1845, birthplace=Ireland, residence=1880_Schuylkill+County%2C+Pennsylvania. The URL is syntactically valid and targets the correct site's search endpoint with proper query encoding."
+          },
+          {
+            "source": "rubric",
+            "name": "Capture guidance",
+            "score": 3,
+            "rationale": "In autonomous mode, capture-guidance instructions are not expected \u2014 the correct behavior is to defer and log, not to present user-facing click-and-upload instructions. The skill correctly omitted such instructions and instead logged the deferred search with a note explaining that the search 'requires an interactive user capture and is not obtainable in an autonomous run' and that 'a later interactive session should open this link, capture the results page as PDF, and return it for triage.' This is the right approach for autonomous mode."
+          },
+          {
+            "source": "rubric",
+            "name": "Result triage",
+            "score": 3,
+            "rationale": "No capture was provided in this turn (autonomous mode, user not available). The skill correctly deferred triage without fabricating results. The log entry (log_007) explicitly states capture_received: false and resultsExamined: 0, signaling that triage will occur once a capture is uploaded in a later interactive session. This is the correct deferral behavior."
+          },
+          {
+            "source": "rubric",
+            "name": "Tool selection",
+            "score": 3,
+            "rationale": "The skill correctly used place_search first, fed its returned standardPlace to external_links_search with the 1880 year window, and consumed the response correctly: recognized that neither returned link (Tax Lists 1768\u20131801, 1850 Census) matched the 1880 census record type, and fell back to the site-wide Ancestry template (collection 6742) as expected. The search was persisted via research_log_append. Tool use follows the documented flow."
+          },
+          {
+            "source": "rubric",
+            "name": "Log entry",
+            "score": 3,
+            "rationale": "Two log entries were written correctly. log_006 documents the curated-links fetch (outcome: negative, resultsExamined: 2, notes explaining the mismatch). log_007 documents the deferred external-site search with outcome: 'negative', capture_received: false, resultsExamined: 0, and comprehensive notes naming the site (Ancestry), person (Patrick Flynn), place (Schuylkill County, PA), year (1880), the generated URL, and the reason for deferral (autonomous mode, no user available). Both entries were written in the same turn the URL was generated."
+          }
+        ]
+      },
+      "totals": {
+        "duration_ms": 131933.81483398844,
+        "duration_api_ms": 130474.0,
+        "judge_duration_ms": 14575.692249985877,
+        "wall_clock_ms": 146728.40189933777,
+        "num_turns": 12,
+        "input_tokens": 17,
+        "cached_input_tokens": 239509,
+        "output_tokens": 7025,
+        "judge_input_tokens": 5341,
+        "judge_cached_input_tokens": 4778,
+        "judge_output_tokens": 1220,
+        "skill_cost_usd": 0.31642970000000004,
+        "judge_cost_usd": 0.007140800000000001,
+        "total_cost_usd": 0.32357050000000004
+      },
+      "runs": [
+        {
+          "run_index": 0,
+          "run_id": "run_ut_search_external_sites_013_2026-07-17_22-54-08_0",
+          "outcome": "pass",
+          "aborted_reason": null,
+          "duration_ms": 131933.81483398844,
+          "duration_api_ms": 130474.0,
+          "num_turns": 12,
+          "skill_attempts": 1,
+          "input_tokens": 17,
+          "cached_input_tokens": 239509,
+          "output_tokens": 7025,
+          "skill_cost_usd": 0.31642970000000004,
+          "output": {
+            "text_response": "I have the project context. Now let me check the references and resolve the place in parallel.Place resolved: **Schuylkill, Pennsylvania, United States**. Now fetching curated Ancestry links for the 1880 census year.Two ancestry.com links returned, but neither matches the 1880 census: one is Tax and Exoneration Lists (1768\u20131801) and the other is the 1850 Census. **Case B** \u2014 no curated link for the 1880 census on Ancestry. I'll note this, build the URL from the known Ancestry 1880 US Federal Census collection (6742), then log both entries as required by autonomous mode.\n\nFirst, log the curated-links fetch; then log the deferred external-site search in one follow-up call.Both log entries are persisted. Here's the complete audit trail:\n\n---\n\n**Autonomous run \u2014 Ancestry 1880 Census search for Patrick Flynn (Schuylkill County, PA)**\n\n**Place resolved:** Schuylkill, Pennsylvania, United States\n\n**Curated links (log_006):** Two Ancestry links returned for this place \u2014 Tax & Exoneration Lists 1768\u20131801 (collection 7667) and the 1850 Census (collection 1276). Neither matches the 1880 census record type. **Case B** applied.\n\n**URL built** (collection 6742 \u2014 Ancestry's 1880 U.S. Federal Census):\n```\nhttps://www.ancestry.com/search/collections/6742/?name=Patrick_Flynn&birth=1845&birthplace=Ireland&residence=1880_Schuylkill+County%2C+Pennsylvania\n```\nParameters: surname Flynn, given Patrick, birth ~1845, birthplace Ireland (confirmed from 1850 and 1860 censuses), residence 1880 Schuylkill County PA.\n\n**Status (log_007):** Logged as **deferred** \u2014 `outcome: negative`, `captureReceived: false`. No user is available to open the link and return a PDF in this autonomous run. The generated URL is recorded in the log so an interactive session can capture it without regenerating the search.\n\n**No plan item to close** \u2014 no `pli_` entry in `pl_002` targets an 1880 Ancestry census search; the deferred lead is recorded ad-hoc against the open question (`q_001`).\n\n**Next avenue in pl_002:** `pli_006` (Thomas Flynn probate, 1870\u20131890, FamilySearch) is still `in_progress` \u2014 the orchestrator should route there to keep research moving.",
+            "activated": true,
+            "skills_invoked": [
+              "search-external-sites"
+            ],
+            "tool_calls": [
+              {
+                "tool": "mcp__genealogy__place_search",
+                "args": {
+                  "placeName": "Schuylkill County",
+                  "contextName": "Pennsylvania"
+                },
+                "expected_args": {
+                  "placeName": "~Schuylkill"
+                },
+                "matched": {
+                  "kind": "predicate",
+                  "index": 0
+                },
+                "response_fixture": "place-search-schuylkill-county"
+              },
+              {
+                "tool": "mcp__genealogy__external_links_search",
+                "args": {
+                  "standardPlace": "Schuylkill, Pennsylvania, United States",
+                  "startYear": 1880,
+                  "endYear": 1880,
+                  "host": "ancestry.com",
+                  "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/eval-ut_search_external_sites_013-0-0-hpky3df6"
+                },
+                "expected_args": {
+                  "standardPlace": "~"
+                },
+                "matched": {
+                  "kind": "predicate",
+                  "index": 0
+                },
+                "response_fixture": "external-links-search-schuylkill"
+              },
+              {
+                "tool": "mcp__genealogy__research_log_append",
+                "args": {
+                  "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/eval-ut_search_external_sites_013-0-0-hpky3df6",
+                  "planItemId": null,
+                  "tool": "external_links_search",
+                  "query": {
+                    "standardPlace": "Schuylkill, Pennsylvania, United States",
+                    "host": "ancestry.com",
+                    "startYear": 1880,
+                    "endYear": 1880
+                  },
+                  "outcome": "negative",
+                  "resultsExamined": 2,
+                  "notes": "Curated external links for Schuylkill, Pennsylvania, United States (1880, ancestry.com). Two ancestry.com links returned: (1) Pennsylvania Tax and Exoneration Lists 1768\u20131801 (collection 7667) and (2) 1850 U.S. Federal Census \u2013 Schuylkill County (collection 1276). Neither matches the 1880 census record type. No FamilySearch-curated link exists for an 1880 census collection on Ancestry for this place.",
+                  "stagedResultsRef": "results/.staging/cc5217df-1c81-4ccc-b491-831ad08caac6.json"
+                },
+                "expected_args": null,
+                "matched": {
+                  "kind": "live",
+                  "index": null
+                },
+                "response_fixture": "live:research_log_append"
+              },
+              {
+                "tool": "mcp__genealogy__research_log_append",
+                "args": {
+                  "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/eval-ut_search_external_sites_013-0-0-hpky3df6",
+                  "planItemId": null,
+                  "tool": "external_site",
+                  "query": {
+                    "site": "ancestry",
+                    "collection": "1880 U.S. Federal Census (collection 6742)",
+                    "surname": "Flynn",
+                    "given": "Patrick",
+                    "birth_year": 1845,
+                    "birthplace": "Ireland",
+                    "residence_year": 1880,
+                    "residence_place": "Schuylkill County, Pennsylvania"
+                  },
+                  "outcome": "negative",
+                  "resultsExamined": 0,
+                  "notes": "Search deferred \u2014 requires an interactive user capture and is not obtainable in an autonomous run. No FamilySearch-curated 1880-census link exists for Ancestry + Schuylkill County (curated set returned only Tax Lists 1768\u20131801 and the 1850 Census). URL built using Ancestry collection 6742 (1880 U.S. Federal Census), scoped to Patrick Flynn born ~1845 in Ireland, residing in Schuylkill County, PA in 1880. Generated URL: https://www.ancestry.com/search/collections/6742/?name=Patrick_Flynn&birth=1845&birthplace=Ireland&residence=1880_Schuylkill+County%2C+Pennsylvania \u2014 a later interactive session should open this link, capture the results page as PDF, and return it for triage.",
+                  "externalSite": {
+                    "site": "ancestry",
+                    "urlGenerated": "https://www.ancestry.com/search/collections/6742/?name=Patrick_Flynn&birth=1845&birthplace=Ireland&residence=1880_Schuylkill+County%2C+Pennsylvania",
+                    "captureReceived": false,
+                    "captureFilename": null
+                  }
+                },
+                "expected_args": null,
+                "matched": {
+                  "kind": "live",
+                  "index": null
+                },
+                "response_fixture": "live:research_log_append"
+              }
+            ],
+            "files_created": [
+              "results/log_006.json"
+            ],
+            "file_changes": {
+              "research.json": {
+                "sections_modified": [
+                  "log"
+                ],
+                "diff": {
+                  "log": {
+                    "added": [
+                      {
+                        "id": "log_006",
+                        "plan_item_id": null,
+                        "performed": "2026-07-17T22:55:55.784Z",
+                        "tool": "external_links_search",
+                        "query": {
+                          "standardPlace": "Schuylkill, Pennsylvania, United States",
+                          "host": "ancestry.com",
+                          "startYear": 1880,
+                          "endYear": 1880
+                        },
+                        "outcome": "negative",
+                        "results_examined": 2,
+                        "external_site": null,
+                        "results_ref": "results/log_006.json",
+                        "notes": "Curated external links for Schuylkill, Pennsylvania, United States (1880, ancestry.com). Two ancestry.com links returned: (1) Pennsylvania Tax and Exoneration Lists 1768\u20131801 (collection 7667) and (2) 1850 U.S. Federal Census \u2013 Schuylkill County (collection 1276). Neither matches the 1880 census record type. No FamilySearch-curated link exists for an 1880 census collection on Ancestry for this place."
+                      },
+                      {
+                        "id": "log_007",
+                        "plan_item_id": null,
+                        "performed": "2026-07-17T22:56:05.852Z",
+                        "tool": "external_site",
+                        "query": {
+                          "site": "ancestry",
+                          "collection": "1880 U.S. Federal Census (collection 6742)",
+                          "surname": "Flynn",
+                          "given": "Patrick",
+                          "birth_year": 1845,
+                          "birthplace": "Ireland",
+                          "residence_year": 1880,
+                          "residence_place": "Schuylkill County, Pennsylvania"
+                        },
+                        "outcome": "negative",
+                        "results_examined": 0,
+                        "external_site": {
+                          "site": "ancestry",
+                          "url_generated": "https://www.ancestry.com/search/collections/6742/?name=Patrick_Flynn&birth=1845&birthplace=Ireland&residence=1880_Schuylkill+County%2C+Pennsylvania",
+                          "capture_received": false,
+                          "capture_filename": null
+                        },
+                        "results_ref": null,
+                        "notes": "Search deferred \u2014 requires an interactive user capture and is not obtainable in an autonomous run. No FamilySearch-curated 1880-census link exists for Ancestry + Schuylkill County (curated set returned only Tax Lists 1768\u20131801 and the 1850 Census). URL built using Ancestry collection 6742 (1880 U.S. Federal Census), scoped to Patrick Flynn born ~1845 in Ireland, residing in Schuylkill County, PA in 1880. Generated URL: https://www.ancestry.com/search/collections/6742/?name=Patrick_Flynn&birth=1845&birthplace=Ireland&residence=1880_Schuylkill+County%2C+Pennsylvania \u2014 a later interactive session should open this link, capture the results page as PDF, and return it for triage."
+                      }
+                    ],
+                    "modified": [],
+                    "deleted": []
+                  }
+                }
+              }
+            },
+            "warnings": [
+              {
+                "kind": "uncovered_tool_call",
+                "advisory": "1 of 5 MCP tool call(s) matched no fixture predicate \u2014 the skill ran against a fixture_not_found or denied/unknown-tool error. Add or fix an mcp_fixture whose args match the call.",
+                "attempted": [
+                  {
+                    "tool": "mcp__genealogy__project_context",
+                    "args": {
+                      "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/eval-ut_search_external_sites_013-0-0-hpky3df6"
+                    }
+                  },
+                  {
+                    "tool": "mcp__genealogy__place_search",
+                    "args": {
+                      "placeName": "Schuylkill County",
+                      "contextName": "Pennsylvania"
+                    }
+                  },
+                  {
+                    "tool": "mcp__genealogy__external_links_search",
+                    "args": {
+                      "standardPlace": "Schuylkill, Pennsylvania, United States",
+                      "startYear": 1880,
+                      "endYear": 1880,
+                      "host": "ancestry.com",
+                      "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/eval-ut_search_external_sites_013-0-0-hpky3df6"
+                    }
+                  },
+                  {
+                    "tool": "mcp__genealogy__research_log_append",
+                    "args": {
+                      "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/eval-ut_search_external_sites_013-0-0-hpky3df6",
+                      "planItemId": null,
+                      "tool": "external_links_search",
+                      "query": {
+                        "standardPlace": "Schuylkill, Pennsylvania, United States",
+                        "host": "ancestry.com",
+                        "startYear": 1880,
+                        "endYear": 1880
+                      },
+                      "outcome": "negative",
+                      "resultsExamined": 2,
+                      "notes": "Curated external links for Schuylkill, Pennsylvania, United States (1880, ancestry.com). Two ancestry.com links returned: (1) Pennsylvania Tax and Exoneration Lists 1768\u20131801 (collection 7667) and (2) 1850 U.S. Federal Census \u2013 Schuylkill County (collection 1276). Neither matches the 1880 census record type. No FamilySearch-curated link exists for an 1880 census collection on Ancestry for this place.",
+                      "stagedResultsRef": "results/.staging/cc5217df-1c81-4ccc-b491-831ad08caac6.json"
+                    }
+                  },
+                  {
+                    "tool": "mcp__genealogy__research_log_append",
+                    "args": {
+                      "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/eval-ut_search_external_sites_013-0-0-hpky3df6",
+                      "planItemId": null,
+                      "tool": "external_site",
+                      "query": {
+                        "site": "ancestry",
+                        "collection": "1880 U.S. Federal Census (collection 6742)",
+                        "surname": "Flynn",
+                        "given": "Patrick",
+                        "birth_year": 1845,
+                        "birthplace": "Ireland",
+                        "residence_year": 1880,
+                        "residence_place": "Schuylkill County, Pennsylvania"
+                      },
+                      "outcome": "negative",
+                      "resultsExamined": 0,
+                      "notes": "Search deferred \u2014 requires an interactive user capture and is not obtainable in an autonomous run. No FamilySearch-curated 1880-census link exists for Ancestry + Schuylkill County (curated set returned only Tax Lists 1768\u20131801 and the 1850 Census). URL built using Ancestry collection 6742 (1880 U.S. Federal Census), scoped to Patrick Flynn born ~1845 in Ireland, residing in Schuylkill County, PA in 1880. Generated URL: https://www.ancestry.com/search/collections/6742/?name=Patrick_Flynn&birth=1845&birthplace=Ireland&residence=1880_Schuylkill+County%2C+Pennsylvania \u2014 a later interactive session should open this link, capture the results page as PDF, and return it for triage.",
+                      "externalSite": {
+                        "site": "ancestry",
+                        "urlGenerated": "https://www.ancestry.com/search/collections/6742/?name=Patrick_Flynn&birth=1845&birthplace=Ireland&residence=1880_Schuylkill+County%2C+Pennsylvania",
+                        "captureReceived": false,
+                        "captureFilename": null
+                      }
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "validators": {
+            "passed": true,
+            "results": [
+              {
+                "name": "test_id_references_resolve",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_log_append_only",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_entries_deleted",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_main_thread_subagent_only_calls",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_project_file_changes_route_through_writer_tools",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_research_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tool_allowlist",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_gedcomx_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_log_site_ancestry",
+                "passed": true,
+                "error": "skipped: not a log-site-ancestry scenario"
+              },
+              {
+                "name": "test_log_site_findagrave",
+                "passed": true,
+                "error": "skipped: not a log-site-findagrave scenario"
+              },
+              {
+                "name": "test_log_site_findmypast",
+                "passed": true,
+                "error": "skipped: not a log-site-findmypast scenario"
+              },
+              {
+                "name": "test_log_site_myheritage",
+                "passed": true,
+                "error": "skipped: not a log-site-myheritage scenario"
+              },
+              {
+                "name": "test_log_site_newspapers",
+                "passed": true,
+                "error": "skipped: not a log-site-newspapers scenario"
+              },
+              {
+                "name": "test_positive_appends_external_site_log_entry",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_url_generation_log_entry_shape",
+                "passed": true,
+                "error": "skipped: no URL-generation (outcome=partial) external_site log entry"
+              }
+            ]
+          },
+          "judge": {
+            "skipped": false,
+            "dimensions": [
+              {
+                "source": "base",
+                "name": "Correctness",
+                "score": 3,
+                "rationale": "The skill correctly identified that no curated Ancestry link exists for the 1880 census on Schuylkill County, built a valid pre-filled Ancestry search URL using collection 6742 with appropriate parameters (name, birth year, birthplace, residence), and logged the search as deferred with outcome 'negative' and capture_received false. The URL parameters match the available evidence (Patrick Flynn, ~1845, Ireland, Schuylkill County PA). The deferred-log approach is correct for autonomous mode where no user is available to capture and upload results."
+              },
+              {
+                "source": "base",
+                "name": "Completeness",
+                "score": 3,
+                "rationale": "The skill addressed all requirements: resolved the place via place_search, fetched curated links via external_links_search, recognized the mismatch (no 1880 census link), built the fallback URL, logged the curated-links fetch (log_006), and logged the deferred external-site search (log_007) with all required fields (outcome, capture_received, notes with URL). The autonomous-mode constraint was honored by deferring rather than presenting user-facing capture instructions."
+              },
+              {
+                "source": "base",
+                "name": "Tool Arguments",
+                "score": 3,
+                "rationale": "All four tool calls passed correct arguments. place_search received 'Schuylkill County' and 'Pennsylvania' (matching expected ~Schuylkill). external_links_search received the returned standardPlace 'Schuylkill, Pennsylvania, United States', startYear 1880, endYear 1880, and host 'ancestry.com' \u2014 all correct. Both research_log_append calls used valid schemas with appropriate outcome, notes, and externalSite fields. No fixture_not_found errors occurred."
+              },
+              {
+                "source": "rubric",
+                "name": "URL generation",
+                "score": 3,
+                "rationale": "The skill generated a correctly pre-filled Ancestry search URL targeting collection 6742 (1880 U.S. Federal Census). The URL includes all relevant search parameters: name=Patrick_Flynn, birth=1845, birthplace=Ireland, residence=1880_Schuylkill+County%2C+Pennsylvania. The URL is syntactically valid and targets the correct site's search endpoint with proper query encoding."
+              },
+              {
+                "source": "rubric",
+                "name": "Capture guidance",
+                "score": 3,
+                "rationale": "In autonomous mode, capture-guidance instructions are not expected \u2014 the correct behavior is to defer and log, not to present user-facing click-and-upload instructions. The skill correctly omitted such instructions and instead logged the deferred search with a note explaining that the search 'requires an interactive user capture and is not obtainable in an autonomous run' and that 'a later interactive session should open this link, capture the results page as PDF, and return it for triage.' This is the right approach for autonomous mode."
+              },
+              {
+                "source": "rubric",
+                "name": "Result triage",
+                "score": 3,
+                "rationale": "No capture was provided in this turn (autonomous mode, user not available). The skill correctly deferred triage without fabricating results. The log entry (log_007) explicitly states capture_received: false and resultsExamined: 0, signaling that triage will occur once a capture is uploaded in a later interactive session. This is the correct deferral behavior."
+              },
+              {
+                "source": "rubric",
+                "name": "Tool selection",
+                "score": 3,
+                "rationale": "The skill correctly used place_search first, fed its returned standardPlace to external_links_search with the 1880 year window, and consumed the response correctly: recognized that neither returned link (Tax Lists 1768\u20131801, 1850 Census) matched the 1880 census record type, and fell back to the site-wide Ancestry template (collection 6742) as expected. The search was persisted via research_log_append. Tool use follows the documented flow."
+              },
+              {
+                "source": "rubric",
+                "name": "Log entry",
+                "score": 3,
+                "rationale": "Two log entries were written correctly. log_006 documents the curated-links fetch (outcome: negative, resultsExamined: 2, notes explaining the mismatch). log_007 documents the deferred external-site search with outcome: 'negative', capture_received: false, resultsExamined: 0, and comprehensive notes naming the site (Ancestry), person (Patrick Flynn), place (Schuylkill County, PA), year (1880), the generated URL, and the reason for deferral (autonomous mode, no user available). Both entries were written in the same turn the URL was generated."
+              }
+            ],
+            "judge_cost_usd": 0.007140800000000001,
+            "duration_ms": 14575.692249985877,
+            "error": null,
+            "input_tokens": 5341,
+            "cached_input_tokens": 4778,
+            "output_tokens": 1220
+          },
+          "started_at": 1784328848.381582,
+          "ended_at": 1784328995.109984
+        }
+      ]
+    },
+    {
+      "test_id": "ut_search_external_sites_005",
+      "test_type": "positive",
+      "expected_outcome": "pass",
+      "scenario": "mid-research-flynn",
+      "mcp_fixtures": [
+        "place-search-pennsylvania",
+        "place-search-pennsylvania-by-name",
+        "place-search-pennsylvania-by-place",
+        "external-links-search-schuylkill"
+      ],
+      "outcome": "pass",
+      "flaky": false,
+      "outcome_summary": {
+        "per_run_outcomes": [
+          "pass"
+        ],
+        "aggregated_dimensions": [
+          {
+            "source": "base",
+            "name": "Correctness",
+            "score": 3,
+            "rationale": "The skill correctly identified Patrick Flynn's known death year (1908) from the research state (death certificate src_004) and used it in the search URL rather than the vague 'after 1880' from the user message. The URL targets findagrave.com/memorial/search with correct parameters: firstname=Patrick, lastname=Flynn, birthyear=1845, deathyear=1908, location=Schuylkill+County%2C+Pennsylvania. The compiled-source caution accurately describes FindAGrave as user-contributed, emphasizes photographed headstone evidence over contributor-entered data, and correctly notes findings are leads needing verification. No fabricated material or unsupported claims."
+          },
+          {
+            "source": "base",
+            "name": "Completeness",
+            "score": 3,
+            "rationale": "The skill addressed all required elements: generated a correctly pre-filled search URL, provided clear capture-workflow instructions (scroll, Cmd+P/Ctrl+P, save as PDF, upload), included the compiled-source caution about user-contributed data and verification requirements, and wrote two research-log entries (one for the curated-links fetch returning no FindAGrave results, one for the generated search). All aspects the input state required were covered."
+          },
+          {
+            "source": "base",
+            "name": "Tool Arguments",
+            "score": 3,
+            "rationale": "All four MCP tool calls passed arguments matching the fixture's expected_args semantically. place_search correctly resolved 'Pennsylvania' to 'Pennsylvania, United States' (state level). external_links_search correctly used the returned standardPlace and specified the 1880\u20131910 window (covering the known 1908 death year) with host='findagrave.com'. Both research_log_append calls used correct arguments: the first logged the negative curated-links result with outcome='negative'; the second logged the generated search with outcome='partial', capture_received=false, and the full query parameters. No critical identifiers were wrong, no fixture_not_found errors, and no fabricated arguments."
+          },
+          {
+            "source": "rubric",
+            "name": "URL generation",
+            "score": 3,
+            "rationale": "The generated URL targets findagrave.com/memorial/search and includes all relevant search parameters from the plan item: firstname=Patrick, lastname=Flynn, birthyear=1845, deathyear=1908, location=Schuylkill+County%2C+Pennsylvania. The URL is syntactically valid with proper query encoding (+ for spaces, %2C for comma). The death year 1908 is the known fact from the research state, not a fabrication, and satisfies the user's 'after 1880' bound."
+          },
+          {
+            "source": "rubric",
+            "name": "Capture guidance",
+            "score": 3,
+            "rationale": "Instructions are clear and specific: scroll to bottom and back to top (forces lazy-loaded memorials into view), press Cmd+P (Mac) or Ctrl+P (Windows), choose 'Save as PDF', and upload the PDF. The instructions name the specific action (PDF save) and the return method (upload here), providing the user with a complete workflow without assuming prior knowledge."
+          },
+          {
+            "source": "rubric",
+            "name": "Result triage",
+            "score": 3,
+            "rationale": "No capture was provided in this turn \u2014 the skill correctly deferred triage without fabricating results. The response signals what will be evaluated once the capture arrives: 'I'll evaluate it against the nine criteria for compiled sources: separating any photographed headstone evidence from contributor-entered dates and family links, and treating it as a lead to verify against originals.' This is a clean deferral, not a partial, because waiting for the capture is exactly what the workflow requires."
+          },
+          {
+            "source": "rubric",
+            "name": "Tool selection",
+            "score": 3,
+            "rationale": "The skill correctly used place_search to resolve Pennsylvania, then fed the returned standardPlace ('Pennsylvania, United States') to external_links_search with the 1880\u20131910 year window. When external_links_search returned no FindAGrave-curated links (only Ancestry results), the skill correctly fell back to the site-wide FindAGrave template and built the URL from it. Both the curated-links fetch and the generated search were persisted via research_log_append with correct arguments and validation. Tool usage follows the documented flow."
+          },
+          {
+            "source": "rubric",
+            "name": "Log entry",
+            "score": 3,
+            "rationale": "Two log entries were written in the same turn the URL was generated. The first (log_006) logs the curated-links fetch with outcome='negative' and notes the fallback to site-wide template. The second (log_007) logs the generated search with outcome='partial', capture_received=false, and includes site (findagrave), person (Patrick Flynn), place (Schuylkill County, Pennsylvania), and year (1908) in the query and notes. Both entries are complete and correctly structured."
+          }
+        ]
+      },
+      "totals": {
+        "duration_ms": 67117.0261669904,
+        "duration_api_ms": 66261.0,
+        "judge_duration_ms": 14050.436041958164,
+        "wall_clock_ms": 81233.37602615356,
+        "num_turns": 11,
+        "input_tokens": 17,
+        "cached_input_tokens": 225781,
+        "output_tokens": 3472,
+        "judge_input_tokens": 4764,
+        "judge_cached_input_tokens": 4778,
+        "judge_output_tokens": 1279,
+        "skill_cost_usd": 0.23164279999999998,
+        "judge_cost_usd": 0.0068588,
+        "total_cost_usd": 0.23850159999999998
+      },
+      "runs": [
+        {
+          "run_index": 0,
+          "run_id": "run_ut_search_external_sites_005_2026-07-17_22-54-08_0",
+          "outcome": "pass",
+          "aborted_reason": null,
+          "duration_ms": 67117.0261669904,
+          "duration_api_ms": 66261.0,
+          "num_turns": 11,
+          "skill_attempts": 1,
+          "input_tokens": 17,
+          "cached_input_tokens": 225781,
+          "output_tokens": 3472,
+          "skill_cost_usd": 0.23164279999999998,
+          "output": {
+            "text_response": "Checking context and loading the tools I need for place resolution and curated-link lookup.Resolving Pennsylvania and fetching curated FindAGrave links simultaneously.Fetching FindAGrave curated links for Pennsylvania (1880\u20131910 window covering Patrick's known death in 1908).No FindAGrave-curated links came back for Pennsylvania (the two results are Ancestry links). Falling back to Case B \u2014 site-wide FindAGrave template. Logging the curated-links fetch first, then the generated search URL.Now logging the FindAGrave search and building the URL.Both log entries written. Here's your search:\n\n---\n\n**Search: Find A Grave \u2014 Patrick Flynn, Schuylkill County, Pennsylvania, d. 1908**\n\nNo FamilySearch-curated FindAGrave link exists for Pennsylvania in this period, so I've built from the site-wide template using Patrick's known death year (1908, from the death certificate) and Schuylkill County location.\n\nClick this link to search:\n[FindAGrave \u2014 Patrick Flynn, Schuylkill County, PA](https://www.findagrave.com/memorial/search?firstname=Patrick&lastname=Flynn&birthyear=1845&deathyear=1908&location=Schuylkill+County%2C+Pennsylvania)\n\nAfter the page loads:\n1. Scroll to the bottom and back to the top (forces lazy-loaded memorials into view)\n2. Press **Cmd+P** (Mac) or **Ctrl+P** (Windows)\n3. Choose **\"Save as PDF\"**\n4. Upload the PDF here\n\n---\n\n**A note on this source type:** Find A Grave is a user-contributed compiled source \u2014 memorials are created by volunteers, not from official records. If we find Patrick, I'll evaluate it against the nine criteria for compiled sources: separating any photographed headstone evidence from contributor-entered dates and family links, and treating it as a lead to verify against originals (cemetery sexton records, death certificate, newspaper obituary) rather than as proof in itself.",
+            "activated": true,
+            "skills_invoked": [
+              "search-external-sites"
+            ],
+            "tool_calls": [
+              {
+                "tool": "mcp__genealogy__place_search",
+                "args": {
+                  "placeName": "Pennsylvania"
+                },
+                "expected_args": {
+                  "placeName": "~"
+                },
+                "matched": {
+                  "kind": "predicate",
+                  "index": 0
+                },
+                "response_fixture": "place-search-pennsylvania"
+              },
+              {
+                "tool": "mcp__genealogy__external_links_search",
+                "args": {
+                  "standardPlace": "Pennsylvania, United States",
+                  "startYear": 1880,
+                  "endYear": 1910,
+                  "host": "findagrave.com",
+                  "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/eval-ut_search_external_sites_005-0-0-wkodzi5n"
+                },
+                "expected_args": {
+                  "standardPlace": "~"
+                },
+                "matched": {
+                  "kind": "predicate",
+                  "index": 0
+                },
+                "response_fixture": "external-links-search-schuylkill"
+              },
+              {
+                "tool": "mcp__genealogy__research_log_append",
+                "args": {
+                  "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/eval-ut_search_external_sites_005-0-0-wkodzi5n",
+                  "planItemId": null,
+                  "tool": "external_links_search",
+                  "query": {
+                    "standardPlace": "Pennsylvania, United States",
+                    "host": "findagrave.com",
+                    "startYear": 1880,
+                    "endYear": 1910
+                  },
+                  "outcome": "negative",
+                  "resultsExamined": 0,
+                  "notes": "Curated external links for Pennsylvania, United States (1880\u20131910), filtered to findagrave.com. No FindAGrave links returned \u2014 falling back to FindAGrave site-wide search template.",
+                  "stagedResultsRef": "results/.staging/d476c4d8-6f04-4204-a125-2752851a7bd1.json"
+                },
+                "expected_args": null,
+                "matched": {
+                  "kind": "live",
+                  "index": null
+                },
+                "response_fixture": "live:research_log_append"
+              },
+              {
+                "tool": "mcp__genealogy__research_log_append",
+                "args": {
+                  "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/eval-ut_search_external_sites_005-0-0-wkodzi5n",
+                  "planItemId": null,
+                  "tool": "external_site",
+                  "query": {
+                    "firstname": "Patrick",
+                    "lastname": "Flynn",
+                    "birthyear": 1845,
+                    "deathyear": 1908,
+                    "location": "Schuylkill County, Pennsylvania"
+                  },
+                  "outcome": "partial",
+                  "resultsExamined": 0,
+                  "notes": "URL generated; awaiting user capture. No FamilySearch-curated FindAGrave link for Pennsylvania 1880\u20131910 \u2014 using site-wide FindAGrave search. Parameters target Patrick Flynn's known death year (1908 death certificate, src_004) and Schuylkill County location.",
+                  "externalSite": {
+                    "site": "findagrave",
+                    "urlGenerated": "https://www.findagrave.com/memorial/search?firstname=Patrick&lastname=Flynn&birthyear=1845&deathyear=1908&location=Schuylkill+County%2C+Pennsylvania",
+                    "captureReceived": false,
+                    "captureFilename": null
+                  }
+                },
+                "expected_args": null,
+                "matched": {
+                  "kind": "live",
+                  "index": null
+                },
+                "response_fixture": "live:research_log_append"
+              }
+            ],
+            "files_created": [
+              "results/log_006.json"
+            ],
+            "file_changes": {
+              "research.json": {
+                "sections_modified": [
+                  "log"
+                ],
+                "diff": {
+                  "log": {
+                    "added": [
+                      {
+                        "id": "log_006",
+                        "plan_item_id": null,
+                        "performed": "2026-07-17T22:56:51.366Z",
+                        "tool": "external_links_search",
+                        "query": {
+                          "standardPlace": "Pennsylvania, United States",
+                          "host": "findagrave.com",
+                          "startYear": 1880,
+                          "endYear": 1910
+                        },
+                        "outcome": "negative",
+                        "results_examined": 0,
+                        "external_site": null,
+                        "results_ref": "results/log_006.json",
+                        "notes": "Curated external links for Pennsylvania, United States (1880\u20131910), filtered to findagrave.com. No FindAGrave links returned \u2014 falling back to FindAGrave site-wide search template."
+                      },
+                      {
+                        "id": "log_007",
+                        "plan_item_id": null,
+                        "performed": "2026-07-17T22:57:00.481Z",
+                        "tool": "external_site",
+                        "query": {
+                          "firstname": "Patrick",
+                          "lastname": "Flynn",
+                          "birthyear": 1845,
+                          "deathyear": 1908,
+                          "location": "Schuylkill County, Pennsylvania"
+                        },
+                        "outcome": "partial",
+                        "results_examined": 0,
+                        "external_site": {
+                          "site": "findagrave",
+                          "url_generated": "https://www.findagrave.com/memorial/search?firstname=Patrick&lastname=Flynn&birthyear=1845&deathyear=1908&location=Schuylkill+County%2C+Pennsylvania",
+                          "capture_received": false,
+                          "capture_filename": null
+                        },
+                        "results_ref": null,
+                        "notes": "URL generated; awaiting user capture. No FamilySearch-curated FindAGrave link for Pennsylvania 1880\u20131910 \u2014 using site-wide FindAGrave search. Parameters target Patrick Flynn's known death year (1908 death certificate, src_004) and Schuylkill County location."
+                      }
+                    ],
+                    "modified": [],
+                    "deleted": []
+                  }
+                }
+              }
+            }
+          },
+          "validators": {
+            "passed": true,
+            "results": [
+              {
+                "name": "test_id_references_resolve",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_log_append_only",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_entries_deleted",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_main_thread_subagent_only_calls",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_project_file_changes_route_through_writer_tools",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_research_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tool_allowlist",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_gedcomx_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_log_site_ancestry",
+                "passed": true,
+                "error": "skipped: not a log-site-ancestry scenario"
+              },
+              {
+                "name": "test_log_site_findagrave",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_log_site_findmypast",
+                "passed": true,
+                "error": "skipped: not a log-site-findmypast scenario"
+              },
+              {
+                "name": "test_log_site_myheritage",
+                "passed": true,
+                "error": "skipped: not a log-site-myheritage scenario"
+              },
+              {
+                "name": "test_log_site_newspapers",
+                "passed": true,
+                "error": "skipped: not a log-site-newspapers scenario"
+              },
+              {
+                "name": "test_positive_appends_external_site_log_entry",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_url_generation_log_entry_shape",
+                "passed": true,
+                "error": null
+              }
+            ]
+          },
+          "judge": {
+            "skipped": false,
+            "dimensions": [
+              {
+                "source": "base",
+                "name": "Correctness",
+                "score": 3,
+                "rationale": "The skill correctly identified Patrick Flynn's known death year (1908) from the research state (death certificate src_004) and used it in the search URL rather than the vague 'after 1880' from the user message. The URL targets findagrave.com/memorial/search with correct parameters: firstname=Patrick, lastname=Flynn, birthyear=1845, deathyear=1908, location=Schuylkill+County%2C+Pennsylvania. The compiled-source caution accurately describes FindAGrave as user-contributed, emphasizes photographed headstone evidence over contributor-entered data, and correctly notes findings are leads needing verification. No fabricated material or unsupported claims."
+              },
+              {
+                "source": "base",
+                "name": "Completeness",
+                "score": 3,
+                "rationale": "The skill addressed all required elements: generated a correctly pre-filled search URL, provided clear capture-workflow instructions (scroll, Cmd+P/Ctrl+P, save as PDF, upload), included the compiled-source caution about user-contributed data and verification requirements, and wrote two research-log entries (one for the curated-links fetch returning no FindAGrave results, one for the generated search). All aspects the input state required were covered."
+              },
+              {
+                "source": "base",
+                "name": "Tool Arguments",
+                "score": 3,
+                "rationale": "All four MCP tool calls passed arguments matching the fixture's expected_args semantically. place_search correctly resolved 'Pennsylvania' to 'Pennsylvania, United States' (state level). external_links_search correctly used the returned standardPlace and specified the 1880\u20131910 window (covering the known 1908 death year) with host='findagrave.com'. Both research_log_append calls used correct arguments: the first logged the negative curated-links result with outcome='negative'; the second logged the generated search with outcome='partial', capture_received=false, and the full query parameters. No critical identifiers were wrong, no fixture_not_found errors, and no fabricated arguments."
+              },
+              {
+                "source": "rubric",
+                "name": "URL generation",
+                "score": 3,
+                "rationale": "The generated URL targets findagrave.com/memorial/search and includes all relevant search parameters from the plan item: firstname=Patrick, lastname=Flynn, birthyear=1845, deathyear=1908, location=Schuylkill+County%2C+Pennsylvania. The URL is syntactically valid with proper query encoding (+ for spaces, %2C for comma). The death year 1908 is the known fact from the research state, not a fabrication, and satisfies the user's 'after 1880' bound."
+              },
+              {
+                "source": "rubric",
+                "name": "Capture guidance",
+                "score": 3,
+                "rationale": "Instructions are clear and specific: scroll to bottom and back to top (forces lazy-loaded memorials into view), press Cmd+P (Mac) or Ctrl+P (Windows), choose 'Save as PDF', and upload the PDF. The instructions name the specific action (PDF save) and the return method (upload here), providing the user with a complete workflow without assuming prior knowledge."
+              },
+              {
+                "source": "rubric",
+                "name": "Result triage",
+                "score": 3,
+                "rationale": "No capture was provided in this turn \u2014 the skill correctly deferred triage without fabricating results. The response signals what will be evaluated once the capture arrives: 'I'll evaluate it against the nine criteria for compiled sources: separating any photographed headstone evidence from contributor-entered dates and family links, and treating it as a lead to verify against originals.' This is a clean deferral, not a partial, because waiting for the capture is exactly what the workflow requires."
+              },
+              {
+                "source": "rubric",
+                "name": "Tool selection",
+                "score": 3,
+                "rationale": "The skill correctly used place_search to resolve Pennsylvania, then fed the returned standardPlace ('Pennsylvania, United States') to external_links_search with the 1880\u20131910 year window. When external_links_search returned no FindAGrave-curated links (only Ancestry results), the skill correctly fell back to the site-wide FindAGrave template and built the URL from it. Both the curated-links fetch and the generated search were persisted via research_log_append with correct arguments and validation. Tool usage follows the documented flow."
+              },
+              {
+                "source": "rubric",
+                "name": "Log entry",
+                "score": 3,
+                "rationale": "Two log entries were written in the same turn the URL was generated. The first (log_006) logs the curated-links fetch with outcome='negative' and notes the fallback to site-wide template. The second (log_007) logs the generated search with outcome='partial', capture_received=false, and includes site (findagrave), person (Patrick Flynn), place (Schuylkill County, Pennsylvania), and year (1908) in the query and notes. Both entries are complete and correctly structured."
+              }
+            ],
+            "judge_cost_usd": 0.0068588,
+            "duration_ms": 14050.436041958164,
+            "error": null,
+            "input_tokens": 4764,
+            "cached_input_tokens": 4778,
+            "output_tokens": 1279
+          },
+          "started_at": 1784328961.787033,
+          "ended_at": 1784329043.020409
+        }
+      ]
+    },
+    {
+      "test_id": "ut_search_external_sites_004",
+      "test_type": "positive",
+      "expected_outcome": "pass",
+      "scenario": "mid-research-flynn",
+      "mcp_fixtures": [
+        "place-search-ireland",
+        "place-search-ireland-by-name",
+        "place-search-ireland-by-place",
+        "external-links-search-zero-results"
+      ],
+      "outcome": "pass",
+      "flaky": false,
+      "outcome_summary": {
+        "per_run_outcomes": [
+          "pass"
+        ],
+        "aggregated_dimensions": [
+          {
+            "source": "base",
+            "name": "Correctness",
+            "score": 3,
+            "rationale": "The skill correctly identified that no FamilySearch-curated FindMyPast link exists for Ireland 1835\u20131855 (totalForPlace: 0), properly fell back to the site-wide template, and generated a syntactically valid FindMyPast URL with correct parameter names (firstname, lastname, yearofbirth, keywordsplace) populated from the subject (Patrick Flynn, b. 1845, Ireland). The research log entry was written with accurate metadata (site: findmypast, outcome: partial, capture_received: false). All factual claims about Irish civil registration (began 1864) and likely record types (parish baptisms, Church of Ireland registers) are accurate and well-sourced."
+          },
+          {
+            "source": "base",
+            "name": "Completeness",
+            "score": 3,
+            "rationale": "The skill addressed all required elements: generated a pre-filled search URL, provided clear capture-workflow instructions (scroll, Cmd+P/Ctrl+P, save as PDF, upload), noted that login may be required (FindMyPast is a paid site), and wrote the research log entry in the same turn the URL was generated. The skill also provided helpful context on Irish birth record coverage and offered to narrow results by county if needed."
+          },
+          {
+            "source": "base",
+            "name": "Tool Arguments",
+            "score": 3,
+            "rationale": "All three MCP tool calls passed correct arguments. place_search received 'Ireland' (matches expected ~Ireland). external_links_search received the standardPlace returned by place_search ('Ireland'), correct year window (1835\u20131855, adjusted to 1840\u20131850 by the tool), and host 'findmypast.com'. research_log_append received all required fields with accurate metadata including the generated URL, outcome 'partial', and capture_received false. No fixture_not_found errors; all calls matched successfully."
+          },
+          {
+            "source": "rubric",
+            "name": "URL generation",
+            "score": 3,
+            "rationale": "The generated URL (https://www.findmypast.com/search/results?firstname=Patrick&lastname=Flynn&yearofbirth=1845&keywordsplace=Ireland) targets the correct FindMyPast search endpoint, includes all relevant search parameters from the context (name, birth year, place), and is syntactically valid. The skill correctly used FindMyPast's parameter names (firstname, lastname, yearofbirth, keywordsplace) rather than inventing or guessing."
+          },
+          {
+            "source": "rubric",
+            "name": "Capture guidance",
+            "score": 3,
+            "rationale": "Instructions are clear and specific: scroll to bottom and back to top (forces lazy-loaded results), press Cmd+P (Mac) or Ctrl+P (Windows), select 'Save as PDF', save and upload. The skill explicitly noted that login may be required since FindMyPast is a paid site. Instructions name the specific action (PDF save) and how to return the capture (upload here)."
+          },
+          {
+            "source": "rubric",
+            "name": "Result triage",
+            "score": 3,
+            "rationale": "No capture was provided in this turn (capture_received: false), so the correct behavior is to defer triage. The skill deferred appropriately without fabricating or pre-judging results, and signaled what it will evaluate once the capture arrives (matching Patrick Flynns by name, age/birth year, and jurisdiction). This is a clean deferral, which is a pass."
+          },
+          {
+            "source": "rubric",
+            "name": "Tool selection",
+            "score": 3,
+            "rationale": "The skill correctly used place_search first to resolve 'Ireland' to its standardPlace, then fed that returned value ('Ireland') to external_links_search with the correct year window (1835\u20131855). When external_links_search returned totalForPlace: 0 (no curated FindMyPast links), the skill correctly fell back to the site-wide FindMyPast template (findmypast.com/search/results) rather than inventing a curated collection URL. The search was persisted via research_log_append with validation passing."
+          },
+          {
+            "source": "rubric",
+            "name": "Log entry",
+            "score": 3,
+            "rationale": "A new research log entry (log_006) was written in the same turn the URL was generated. It names the site (findmypast), person (Patrick Flynn), place (Ireland), year (1845), and outcome ('partial' with capture_received: false). The entry includes the generated URL and notes on coverage limitations (civil registration began 1864, likely hits from parish baptisms). The log entry was written before presenting the URL to the user, as required."
+          }
+        ]
+      },
+      "totals": {
+        "duration_ms": 75078.16620799713,
+        "duration_api_ms": 75888.0,
+        "judge_duration_ms": 12180.985582992435,
+        "wall_clock_ms": 87326.43604278564,
+        "num_turns": 13,
+        "input_tokens": 17,
+        "cached_input_tokens": 233314,
+        "output_tokens": 3489,
+        "judge_input_tokens": 4220,
+        "judge_cached_input_tokens": 4778,
+        "judge_output_tokens": 1209,
+        "skill_cost_usd": 0.2544587,
+        "judge_cost_usd": 0.0059648,
+        "total_cost_usd": 0.2604235
+      },
+      "runs": [
+        {
+          "run_index": 0,
+          "run_id": "run_ut_search_external_sites_004_2026-07-17_22-54-08_0",
+          "outcome": "pass",
+          "aborted_reason": null,
+          "duration_ms": 75078.16620799713,
+          "duration_api_ms": 75888.0,
+          "num_turns": 13,
+          "skill_attempts": 1,
+          "input_tokens": 17,
+          "cached_input_tokens": 233314,
+          "output_tokens": 3489,
+          "skill_cost_usd": 0.2544587,
+          "output": {
+            "text_response": "Now I have the full project context. Patrick Flynn was born in Ireland ca. 1845 and is the subject of this research. There's no existing plan item for this FindMyPast search, so it's ad-hoc. Let me resolve Ireland and pull the curated links.No FamilySearch-curated links exist for FindMyPast + Ireland in the 1835\u20131855 window, so I'll fall back to Case B (site-wide search). Building the URL now, then logging before presenting it.Logged as `log_006`. Here's your search:\n\n---\n\n**Search: FindMyPast \u2014 Patrick Flynn, Birth in Ireland, ca. 1845**\n\nNo FamilySearch-curated FindMyPast link exists for Ireland in this date window \u2014 using the site-wide search instead.\n\nClick this link to search:\n**[FindMyPast \u2014 Patrick Flynn, Ireland, birth ca. 1845](https://www.findmypast.com/search/results?firstname=Patrick&lastname=Flynn&yearofbirth=1845&keywordsplace=Ireland)**\n\nAfter the page loads:\n1. Scroll to the bottom of the page and back to the top (forces lazy-loaded results into view)\n2. Press **Cmd+P** (Mac) or **Ctrl+P** (Windows)\n3. Select **\"Save as PDF\"**\n4. Save the file and upload it here\n\nIf the page asks you to log in, please log in first, then click the link again.\n\n---\n\n**A note on Irish birth coverage at FindMyPast:** Civil registration in Ireland didn't begin until 1 January 1864, so a ca. 1845 birth won't appear in civil records. FindMyPast's most likely hits for this search will come from:\n- **Catholic parish baptism registers** (coverage is uneven \u2014 many parishes have gaps in the 1840s, and the Famine years saw record-keeping disruptions)\n- **Church of Ireland baptism registers**\n- **Compiled indexes** such as the Ireland, Catholic Baptisms collection\n\nIf the results page returns many Patrick Flynns, we can narrow by adding a county \u2014 do you know which county in Ireland Thomas Flynn's family came from? (The 1850 census lists birthplace as \"Ireland\" without further detail, but sometimes a county can be inferred from where the family settled in Pennsylvania.)",
+            "activated": true,
+            "skills_invoked": [
+              "search-external-sites"
+            ],
+            "tool_calls": [
+              {
+                "tool": "mcp__genealogy__place_search",
+                "args": {
+                  "placeName": "Ireland"
+                },
+                "expected_args": {
+                  "placeName": "~Ireland"
+                },
+                "matched": {
+                  "kind": "predicate",
+                  "index": 0
+                },
+                "response_fixture": "place-search-ireland"
+              },
+              {
+                "tool": "mcp__genealogy__external_links_search",
+                "args": {
+                  "standardPlace": "Ireland",
+                  "startYear": 1835,
+                  "endYear": 1855,
+                  "host": "findmypast.com",
+                  "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/eval-ut_search_external_sites_004-0-0-bt1sgjx0"
+                },
+                "expected_args": {
+                  "standardPlace": "~"
+                },
+                "matched": {
+                  "kind": "predicate",
+                  "index": 0
+                },
+                "response_fixture": "external-links-search-zero-results"
+              },
+              {
+                "tool": "mcp__genealogy__research_log_append",
+                "args": {
+                  "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/eval-ut_search_external_sites_004-0-0-bt1sgjx0",
+                  "planItemId": null,
+                  "tool": "external_site",
+                  "query": {
+                    "firstname": "Patrick",
+                    "lastname": "Flynn",
+                    "yearofbirth": 1845,
+                    "keywordsplace": "Ireland",
+                    "site": "FindMyPast",
+                    "strategy": "Site-wide search \u2014 no FamilySearch-curated FindMyPast link for Ireland 1835\u20131855. Common Irish surname; birth year 1845 included to narrow results. Father/mother names omitted as those are the unknowns under investigation."
+                  },
+                  "outcome": "partial",
+                  "resultsExamined": 0,
+                  "notes": "URL generated; awaiting user capture. No FamilySearch-curated FindMyPast link exists for Ireland in this date window. Using site-wide search template. FindMyPast has strong Ireland coverage, particularly Catholic parish registers, civil registration (from 1864), and Griffith's Valuation \u2014 though civil birth registration began only in 1864, so a ca. 1845 birth would fall under Catholic/Church of Ireland baptism registers.",
+                  "externalSite": {
+                    "site": "findmypast",
+                    "urlGenerated": "https://www.findmypast.com/search/results?firstname=Patrick&lastname=Flynn&yearofbirth=1845&keywordsplace=Ireland",
+                    "captureReceived": false,
+                    "captureFilename": null
+                  }
+                },
+                "expected_args": null,
+                "matched": {
+                  "kind": "live",
+                  "index": null
+                },
+                "response_fixture": "live:research_log_append"
+              }
+            ],
+            "files_created": [],
+            "file_changes": {
+              "research.json": {
+                "sections_modified": [
+                  "log"
+                ],
+                "diff": {
+                  "log": {
+                    "added": [
+                      {
+                        "id": "log_006",
+                        "plan_item_id": null,
+                        "performed": "2026-07-17T22:58:26.961Z",
+                        "tool": "external_site",
+                        "query": {
+                          "firstname": "Patrick",
+                          "lastname": "Flynn",
+                          "yearofbirth": 1845,
+                          "keywordsplace": "Ireland",
+                          "site": "FindMyPast",
+                          "strategy": "Site-wide search \u2014 no FamilySearch-curated FindMyPast link for Ireland 1835\u20131855. Common Irish surname; birth year 1845 included to narrow results. Father/mother names omitted as those are the unknowns under investigation."
+                        },
+                        "outcome": "partial",
+                        "results_examined": 0,
+                        "external_site": {
+                          "site": "findmypast",
+                          "url_generated": "https://www.findmypast.com/search/results?firstname=Patrick&lastname=Flynn&yearofbirth=1845&keywordsplace=Ireland",
+                          "capture_received": false,
+                          "capture_filename": null
+                        },
+                        "results_ref": null,
+                        "notes": "URL generated; awaiting user capture. No FamilySearch-curated FindMyPast link exists for Ireland in this date window. Using site-wide search template. FindMyPast has strong Ireland coverage, particularly Catholic parish registers, civil registration (from 1864), and Griffith's Valuation \u2014 though civil birth registration began only in 1864, so a ca. 1845 birth would fall under Catholic/Church of Ireland baptism registers."
+                      }
+                    ],
+                    "modified": [],
+                    "deleted": []
+                  }
+                }
+              }
+            },
+            "warnings": [
+              {
+                "kind": "uncovered_tool_call",
+                "advisory": "1 of 4 MCP tool call(s) matched no fixture predicate \u2014 the skill ran against a fixture_not_found or denied/unknown-tool error. Add or fix an mcp_fixture whose args match the call.",
+                "attempted": [
+                  {
+                    "tool": "mcp__genealogy__project_context",
+                    "args": {
+                      "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/eval-ut_search_external_sites_004-0-0-bt1sgjx0"
+                    }
+                  },
+                  {
+                    "tool": "mcp__genealogy__place_search",
+                    "args": {
+                      "placeName": "Ireland"
+                    }
+                  },
+                  {
+                    "tool": "mcp__genealogy__external_links_search",
+                    "args": {
+                      "standardPlace": "Ireland",
+                      "startYear": 1835,
+                      "endYear": 1855,
+                      "host": "findmypast.com",
+                      "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/eval-ut_search_external_sites_004-0-0-bt1sgjx0"
+                    }
+                  },
+                  {
+                    "tool": "mcp__genealogy__research_log_append",
+                    "args": {
+                      "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/eval-ut_search_external_sites_004-0-0-bt1sgjx0",
+                      "planItemId": null,
+                      "tool": "external_site",
+                      "query": {
+                        "firstname": "Patrick",
+                        "lastname": "Flynn",
+                        "yearofbirth": 1845,
+                        "keywordsplace": "Ireland",
+                        "site": "FindMyPast",
+                        "strategy": "Site-wide search \u2014 no FamilySearch-curated FindMyPast link for Ireland 1835\u20131855. Common Irish surname; birth year 1845 included to narrow results. Father/mother names omitted as those are the unknowns under investigation."
+                      },
+                      "outcome": "partial",
+                      "resultsExamined": 0,
+                      "notes": "URL generated; awaiting user capture. No FamilySearch-curated FindMyPast link exists for Ireland in this date window. Using site-wide search template. FindMyPast has strong Ireland coverage, particularly Catholic parish registers, civil registration (from 1864), and Griffith's Valuation \u2014 though civil birth registration began only in 1864, so a ca. 1845 birth would fall under Catholic/Church of Ireland baptism registers.",
+                      "externalSite": {
+                        "site": "findmypast",
+                        "urlGenerated": "https://www.findmypast.com/search/results?firstname=Patrick&lastname=Flynn&yearofbirth=1845&keywordsplace=Ireland",
+                        "captureReceived": false,
+                        "captureFilename": null
+                      }
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "validators": {
+            "passed": true,
+            "results": [
+              {
+                "name": "test_id_references_resolve",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_log_append_only",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_entries_deleted",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_main_thread_subagent_only_calls",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_project_file_changes_route_through_writer_tools",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_research_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tool_allowlist",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_gedcomx_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_log_site_ancestry",
+                "passed": true,
+                "error": "skipped: not a log-site-ancestry scenario"
+              },
+              {
+                "name": "test_log_site_findagrave",
+                "passed": true,
+                "error": "skipped: not a log-site-findagrave scenario"
+              },
+              {
+                "name": "test_log_site_findmypast",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_log_site_myheritage",
+                "passed": true,
+                "error": "skipped: not a log-site-myheritage scenario"
+              },
+              {
+                "name": "test_log_site_newspapers",
+                "passed": true,
+                "error": "skipped: not a log-site-newspapers scenario"
+              },
+              {
+                "name": "test_positive_appends_external_site_log_entry",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_url_generation_log_entry_shape",
+                "passed": true,
+                "error": null
+              }
+            ]
+          },
+          "judge": {
+            "skipped": false,
+            "dimensions": [
+              {
+                "source": "base",
+                "name": "Correctness",
+                "score": 3,
+                "rationale": "The skill correctly identified that no FamilySearch-curated FindMyPast link exists for Ireland 1835\u20131855 (totalForPlace: 0), properly fell back to the site-wide template, and generated a syntactically valid FindMyPast URL with correct parameter names (firstname, lastname, yearofbirth, keywordsplace) populated from the subject (Patrick Flynn, b. 1845, Ireland). The research log entry was written with accurate metadata (site: findmypast, outcome: partial, capture_received: false). All factual claims about Irish civil registration (began 1864) and likely record types (parish baptisms, Church of Ireland registers) are accurate and well-sourced."
+              },
+              {
+                "source": "base",
+                "name": "Completeness",
+                "score": 3,
+                "rationale": "The skill addressed all required elements: generated a pre-filled search URL, provided clear capture-workflow instructions (scroll, Cmd+P/Ctrl+P, save as PDF, upload), noted that login may be required (FindMyPast is a paid site), and wrote the research log entry in the same turn the URL was generated. The skill also provided helpful context on Irish birth record coverage and offered to narrow results by county if needed."
+              },
+              {
+                "source": "base",
+                "name": "Tool Arguments",
+                "score": 3,
+                "rationale": "All three MCP tool calls passed correct arguments. place_search received 'Ireland' (matches expected ~Ireland). external_links_search received the standardPlace returned by place_search ('Ireland'), correct year window (1835\u20131855, adjusted to 1840\u20131850 by the tool), and host 'findmypast.com'. research_log_append received all required fields with accurate metadata including the generated URL, outcome 'partial', and capture_received false. No fixture_not_found errors; all calls matched successfully."
+              },
+              {
+                "source": "rubric",
+                "name": "URL generation",
+                "score": 3,
+                "rationale": "The generated URL (https://www.findmypast.com/search/results?firstname=Patrick&lastname=Flynn&yearofbirth=1845&keywordsplace=Ireland) targets the correct FindMyPast search endpoint, includes all relevant search parameters from the context (name, birth year, place), and is syntactically valid. The skill correctly used FindMyPast's parameter names (firstname, lastname, yearofbirth, keywordsplace) rather than inventing or guessing."
+              },
+              {
+                "source": "rubric",
+                "name": "Capture guidance",
+                "score": 3,
+                "rationale": "Instructions are clear and specific: scroll to bottom and back to top (forces lazy-loaded results), press Cmd+P (Mac) or Ctrl+P (Windows), select 'Save as PDF', save and upload. The skill explicitly noted that login may be required since FindMyPast is a paid site. Instructions name the specific action (PDF save) and how to return the capture (upload here)."
+              },
+              {
+                "source": "rubric",
+                "name": "Result triage",
+                "score": 3,
+                "rationale": "No capture was provided in this turn (capture_received: false), so the correct behavior is to defer triage. The skill deferred appropriately without fabricating or pre-judging results, and signaled what it will evaluate once the capture arrives (matching Patrick Flynns by name, age/birth year, and jurisdiction). This is a clean deferral, which is a pass."
+              },
+              {
+                "source": "rubric",
+                "name": "Tool selection",
+                "score": 3,
+                "rationale": "The skill correctly used place_search first to resolve 'Ireland' to its standardPlace, then fed that returned value ('Ireland') to external_links_search with the correct year window (1835\u20131855). When external_links_search returned totalForPlace: 0 (no curated FindMyPast links), the skill correctly fell back to the site-wide FindMyPast template (findmypast.com/search/results) rather than inventing a curated collection URL. The search was persisted via research_log_append with validation passing."
+              },
+              {
+                "source": "rubric",
+                "name": "Log entry",
+                "score": 3,
+                "rationale": "A new research log entry (log_006) was written in the same turn the URL was generated. It names the site (findmypast), person (Patrick Flynn), place (Ireland), year (1845), and outcome ('partial' with capture_received: false). The entry includes the generated URL and notes on coverage limitations (civil registration began 1864, likely hits from parish baptisms). The log entry was written before presenting the URL to the user, as required."
+              }
+            ],
+            "judge_cost_usd": 0.0059648,
+            "duration_ms": 12180.985582992435,
+            "error": null,
+            "input_tokens": 4220,
+            "cached_input_tokens": 4778,
+            "output_tokens": 1209
+          },
+          "started_at": 1784329043.049769,
+          "ended_at": 1784329130.376205
+        }
+      ]
+    },
+    {
+      "test_id": "ut_search_external_sites_007",
+      "test_type": "positive",
+      "expected_outcome": "pass",
+      "scenario": "mid-research-flynn",
+      "mcp_fixtures": [
+        "place-search-schuylkill-county",
+        "place-search-schuylkill-by-name",
+        "place-search-schuylkill-by-place",
+        "external-links-search-schuylkill"
+      ],
+      "outcome": "pass",
+      "flaky": false,
+      "outcome_summary": {
+        "per_run_outcomes": [
+          "pass"
+        ],
+        "aggregated_dimensions": [
+          {
+            "source": "base",
+            "name": "Correctness",
+            "score": 3,
+            "rationale": "The skill correctly identified that no curated Ancestry link exists for the 1880 census in Schuylkill County, properly fell back to the collection-scoped URL (collection 6742), and generated a syntactically valid search URL with appropriate parameters (name, birth year, birthplace, residence). The place resolution was correct (Schuylkill, Pennsylvania, United States). All claims about the search strategy and the 1880 census's value (relationship column) are factually accurate. No fabricated material."
+          },
+          {
+            "source": "base",
+            "name": "Completeness",
+            "score": 3,
+            "rationale": "The skill addressed the user's request to search Ancestry for Patrick Flynn in the 1880 census. It resolved the place, fetched curated links, correctly handled the fallback when no matching link existed, generated the URL, provided capture instructions, and logged both the curated-links fetch and the search itself in the same turn. All required steps were completed."
+          },
+          {
+            "source": "base",
+            "name": "Tool Arguments",
+            "score": 3,
+            "rationale": "All four MCP tool calls passed correct arguments. place_search received 'Schuylkill County' and 'Pennsylvania' (matched predicate). external_links_search received the standardPlace returned by place_search, correct year window (1880\u20131880), and host 'ancestry.com' (matched predicate). Both research_log_append calls used correct structure and arguments (matched live). No fixture_not_found errors. Arguments were semantically correct throughout."
+          },
+          {
+            "source": "rubric",
+            "name": "URL generation",
+            "score": 3,
+            "rationale": "The skill generated a correctly pre-filled Ancestry search URL targeting collection 6742 (1880 U.S. Federal Census). The URL includes all relevant search parameters: name (Patrick_Flynn), birth year (1845), birthplace (Ireland), and residence (1880_Schuylkill+County%2C+Pennsylvania). The URL is syntactically valid and targets the correct site's search endpoint."
+          },
+          {
+            "source": "rubric",
+            "name": "Capture guidance",
+            "score": 3,
+            "rationale": "The skill provided clear, step-by-step instructions for the click-capture workflow: scroll to load lazy-loaded entries, press Cmd+P or Ctrl+P, select 'Save as PDF', and upload the PDF. It also explained why the 1880 census matters (relationship column, potential upgrade from Probable to Proved) and noted the common-name issue. Instructions name specific result types (household members with relationships) and saving steps (PDF download)."
+          },
+          {
+            "source": "rubric",
+            "name": "Result triage",
+            "score": 3,
+            "rationale": "No capture was provided in this turn \u2014 the user has not yet uploaded a PDF. The skill correctly deferred triage, stating 'Once you upload the PDF I'll triage the results and identify the strongest matches for you.' This is the correct behavior for a no-capture turn: wait for the capture without fabricating or pre-judging results. A clean deferral is a pass."
+          },
+          {
+            "source": "rubric",
+            "name": "Tool selection",
+            "score": 3,
+            "rationale": "The skill correctly used place_search first, fed its returned standardPlace ('Schuylkill, Pennsylvania, United States') to external_links_search with the correct year window (1880\u20131880), and properly consumed the response: identified that neither curated link matched the 1880 census target, and correctly fell back to the site-wide template (collection 6742 URL) as expected. The search was persisted via research_log_append with outcome 'partial' and capture_received false. Tool use follows the documented flow."
+          },
+          {
+            "source": "rubric",
+            "name": "Log entry",
+            "score": 3,
+            "rationale": "Two log entries were written in the same turn the URL was generated. log_006 records the curated-links fetch (outcome 'negative', noting the mismatch). log_007 records the search itself with outcome 'partial', capture_received false, results_examined 0, and the generated URL in externalSite.urlGenerated. The query field captures search parameters (given, surname, birth_year, birthplace, residence_year, residence_place, collection). Both entries were written at URL-generation time, not deferred."
+          }
+        ]
+      },
+      "totals": {
+        "duration_ms": 91092.05375000602,
+        "duration_api_ms": 94810.0,
+        "judge_duration_ms": 12477.956583024934,
+        "wall_clock_ms": 103833.60290527344,
+        "num_turns": 12,
+        "input_tokens": 18,
+        "cached_input_tokens": 261312,
+        "output_tokens": 4638,
+        "judge_input_tokens": 4995,
+        "judge_cached_input_tokens": 0,
+        "judge_output_tokens": 1148,
+        "skill_cost_usd": 0.2632021,
+        "judge_cost_usd": 0.010735000000000001,
+        "total_cost_usd": 0.2739371
+      },
+      "runs": [
+        {
+          "run_index": 0,
+          "run_id": "run_ut_search_external_sites_007_2026-07-17_22-54-08_0",
+          "outcome": "pass",
+          "aborted_reason": null,
+          "duration_ms": 91092.05375000602,
+          "duration_api_ms": 94810.0,
+          "num_turns": 12,
+          "skill_attempts": 1,
+          "input_tokens": 18,
+          "cached_input_tokens": 261312,
+          "output_tokens": 4638,
+          "skill_cost_usd": 0.2632021,
+          "output": {
+            "text_response": "I can see the project: identifying the parents of Patrick Flynn (b. ~1845, Ireland, d. 1908, Schuylkill County, PA). The timeline shows an 1880 census gap \u2014 a good search. No explicit plan item exists for this search, so I'll proceed with `planItemId: null`. Let me resolve the place and fetch curated Ancestry links.Good \u2014 `standardPlace: \"Schuylkill, Pennsylvania, United States\"`. Now fetching curated Ancestry links for the 1880 year window.Two curated links came back for Schuylkill County on Ancestry, but neither is an 1880 census link \u2014 one is a tax list (1768\u20131801) and one is the 1850 census. Neither fits this search. Falling back to Case B.\n\nSince the Ancestry 1880 U.S. Federal Census has a well-known collection ID (6742), I'll scope the URL to that collection for a much tighter search than site-wide. Now logging the curated-links fetch, then the search itself.Now logging the search itself before presenting the URL.Both entries logged (log_006 for the curated-links fetch, log_007 for the search in flight). Here's the URL:\n\n---\n\n**Search: 1880 Census on Ancestry for Patrick Flynn**\n\nNo FamilySearch-curated Ancestry link for the 1880 census in Schuylkill County \u2014 using **Ancestry collection 6742** (1880 U.S. Federal Census) directly, which is more targeted than site-wide. Patrick Flynn is a common name, so I've included birth year, birthplace, and 1880 residence to reduce noise.\n\n**Click to search:**\n[Ancestry \u2014 1880 U.S. Federal Census, Patrick Flynn](https://www.ancestry.com/search/collections/6742/?name=Patrick_Flynn&birth=1845&birthplace=Ireland&residence=1880_Schuylkill+County%2C+Pennsylvania)\n\nAfter the page loads:\n1. Scroll to the bottom of the results and back to the top (forces lazy-loaded entries into view)\n2. Press **Cmd+P** (Mac) or **Ctrl+P** (Windows)\n3. Select **\"Save as PDF\"**\n4. Upload the PDF here\n\n> **Why the 1880 census matters here:** The 1880 census is the first to record each household member's *relationship to the head* \u2014 unlike 1850 and 1860, it states \"son,\" \"father,\" etc. explicitly. If Thomas Flynn (Patrick's presumed father, b. ~1818) is still living and enumerated with or near Patrick, the relationship column could upgrade the conclusion from *Probable* to *Proved*. If Patrick is the head of his own household, his wife and children's ages will help fill the 1860\u20131908 gap.\n\nIf the page asks you to log in, do so first, then click the link again.\n\n---\n\nOnce you upload the PDF I'll triage the results and identify the strongest matches for you.",
+            "activated": true,
+            "skills_invoked": [
+              "search-external-sites"
+            ],
+            "tool_calls": [
+              {
+                "tool": "mcp__genealogy__place_search",
+                "args": {
+                  "placeName": "Schuylkill County",
+                  "contextName": "Pennsylvania"
+                },
+                "expected_args": {
+                  "placeName": "~Schuylkill"
+                },
+                "matched": {
+                  "kind": "predicate",
+                  "index": 0
+                },
+                "response_fixture": "place-search-schuylkill-county"
+              },
+              {
+                "tool": "mcp__genealogy__external_links_search",
+                "args": {
+                  "standardPlace": "Schuylkill, Pennsylvania, United States",
+                  "startYear": 1880,
+                  "endYear": 1880,
+                  "host": "ancestry.com",
+                  "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/eval-ut_search_external_sites_007-0-0-i9f8ons_"
+                },
+                "expected_args": {
+                  "standardPlace": "~"
+                },
+                "matched": {
+                  "kind": "predicate",
+                  "index": 0
+                },
+                "response_fixture": "external-links-search-schuylkill"
+              },
+              {
+                "tool": "mcp__genealogy__research_log_append",
+                "args": {
+                  "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/eval-ut_search_external_sites_007-0-0-i9f8ons_",
+                  "planItemId": null,
+                  "tool": "external_links_search",
+                  "query": {
+                    "standardPlace": "Schuylkill, Pennsylvania, United States",
+                    "host": "ancestry.com",
+                    "startYear": 1880,
+                    "endYear": 1880
+                  },
+                  "outcome": "negative",
+                  "resultsExamined": 2,
+                  "notes": "Curated external links for Schuylkill, Pennsylvania, United States. Returned 2 Ancestry links \u2014 a tax list (1768\u20131801) and the 1850 census \u2014 neither matches the 1880 census target. Falling back to collection-scoped URL for Ancestry collection 6742 (1880 U.S. Federal Census).",
+                  "stagedResultsRef": "results/.staging/47f0156d-eabb-4a5d-bc9c-612d61313706.json"
+                },
+                "expected_args": null,
+                "matched": {
+                  "kind": "live",
+                  "index": null
+                },
+                "response_fixture": "live:research_log_append"
+              },
+              {
+                "tool": "mcp__genealogy__research_log_append",
+                "args": {
+                  "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/eval-ut_search_external_sites_007-0-0-i9f8ons_",
+                  "planItemId": null,
+                  "tool": "external_site",
+                  "query": {
+                    "given": "Patrick",
+                    "surname": "Flynn",
+                    "birth_year": 1845,
+                    "birthplace": "Ireland",
+                    "residence_year": 1880,
+                    "residence_place": "Schuylkill County, Pennsylvania",
+                    "collection": "1880 U.S. Federal Census (Ancestry collection 6742)"
+                  },
+                  "outcome": "partial",
+                  "resultsExamined": 0,
+                  "notes": "URL generated; awaiting user capture. No FamilySearch-curated Ancestry link for 1880 census in Schuylkill County \u2014 using Ancestry collection 6742 (1880 U.S. Federal Census). Patrick Flynn born ~1845 in Ireland; age ~35 in 1880. Common name \u2014 narrowed with birth year, birthplace, and residence to reduce noise.",
+                  "externalSite": {
+                    "site": "ancestry",
+                    "urlGenerated": "https://www.ancestry.com/search/collections/6742/?name=Patrick_Flynn&birth=1845&birthplace=Ireland&residence=1880_Schuylkill+County%2C+Pennsylvania",
+                    "captureReceived": false,
+                    "captureFilename": null
+                  }
+                },
+                "expected_args": null,
+                "matched": {
+                  "kind": "live",
+                  "index": null
+                },
+                "response_fixture": "live:research_log_append"
+              }
+            ],
+            "files_created": [
+              "results/log_006.json"
+            ],
+            "file_changes": {
+              "research.json": {
+                "sections_modified": [
+                  "log"
+                ],
+                "diff": {
+                  "log": {
+                    "added": [
+                      {
+                        "id": "log_006",
+                        "plan_item_id": null,
+                        "performed": "2026-07-17T22:55:17.822Z",
+                        "tool": "external_links_search",
+                        "query": {
+                          "standardPlace": "Schuylkill, Pennsylvania, United States",
+                          "host": "ancestry.com",
+                          "startYear": 1880,
+                          "endYear": 1880
+                        },
+                        "outcome": "negative",
+                        "results_examined": 2,
+                        "external_site": null,
+                        "results_ref": "results/log_006.json",
+                        "notes": "Curated external links for Schuylkill, Pennsylvania, United States. Returned 2 Ancestry links \u2014 a tax list (1768\u20131801) and the 1850 census \u2014 neither matches the 1880 census target. Falling back to collection-scoped URL for Ancestry collection 6742 (1880 U.S. Federal Census)."
+                      },
+                      {
+                        "id": "log_007",
+                        "plan_item_id": null,
+                        "performed": "2026-07-17T22:55:27.027Z",
+                        "tool": "external_site",
+                        "query": {
+                          "given": "Patrick",
+                          "surname": "Flynn",
+                          "birth_year": 1845,
+                          "birthplace": "Ireland",
+                          "residence_year": 1880,
+                          "residence_place": "Schuylkill County, Pennsylvania",
+                          "collection": "1880 U.S. Federal Census (Ancestry collection 6742)"
+                        },
+                        "outcome": "partial",
+                        "results_examined": 0,
+                        "external_site": {
+                          "site": "ancestry",
+                          "url_generated": "https://www.ancestry.com/search/collections/6742/?name=Patrick_Flynn&birth=1845&birthplace=Ireland&residence=1880_Schuylkill+County%2C+Pennsylvania",
+                          "capture_received": false,
+                          "capture_filename": null
+                        },
+                        "results_ref": null,
+                        "notes": "URL generated; awaiting user capture. No FamilySearch-curated Ancestry link for 1880 census in Schuylkill County \u2014 using Ancestry collection 6742 (1880 U.S. Federal Census). Patrick Flynn born ~1845 in Ireland; age ~35 in 1880. Common name \u2014 narrowed with birth year, birthplace, and residence to reduce noise."
+                      }
+                    ],
+                    "modified": [],
+                    "deleted": []
+                  }
+                }
+              }
+            }
+          },
+          "validators": {
+            "passed": true,
+            "results": [
+              {
+                "name": "test_id_references_resolve",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_log_append_only",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_entries_deleted",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_main_thread_subagent_only_calls",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_project_file_changes_route_through_writer_tools",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_research_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tool_allowlist",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_gedcomx_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_log_site_ancestry",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_log_site_findagrave",
+                "passed": true,
+                "error": "skipped: not a log-site-findagrave scenario"
+              },
+              {
+                "name": "test_log_site_findmypast",
+                "passed": true,
+                "error": "skipped: not a log-site-findmypast scenario"
+              },
+              {
+                "name": "test_log_site_myheritage",
+                "passed": true,
+                "error": "skipped: not a log-site-myheritage scenario"
+              },
+              {
+                "name": "test_log_site_newspapers",
+                "passed": true,
+                "error": "skipped: not a log-site-newspapers scenario"
+              },
+              {
+                "name": "test_positive_appends_external_site_log_entry",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_url_generation_log_entry_shape",
+                "passed": true,
+                "error": null
+              }
+            ]
+          },
+          "judge": {
+            "skipped": false,
+            "dimensions": [
+              {
+                "source": "base",
+                "name": "Correctness",
+                "score": 3,
+                "rationale": "The skill correctly identified that no curated Ancestry link exists for the 1880 census in Schuylkill County, properly fell back to the collection-scoped URL (collection 6742), and generated a syntactically valid search URL with appropriate parameters (name, birth year, birthplace, residence). The place resolution was correct (Schuylkill, Pennsylvania, United States). All claims about the search strategy and the 1880 census's value (relationship column) are factually accurate. No fabricated material."
+              },
+              {
+                "source": "base",
+                "name": "Completeness",
+                "score": 3,
+                "rationale": "The skill addressed the user's request to search Ancestry for Patrick Flynn in the 1880 census. It resolved the place, fetched curated links, correctly handled the fallback when no matching link existed, generated the URL, provided capture instructions, and logged both the curated-links fetch and the search itself in the same turn. All required steps were completed."
+              },
+              {
+                "source": "base",
+                "name": "Tool Arguments",
+                "score": 3,
+                "rationale": "All four MCP tool calls passed correct arguments. place_search received 'Schuylkill County' and 'Pennsylvania' (matched predicate). external_links_search received the standardPlace returned by place_search, correct year window (1880\u20131880), and host 'ancestry.com' (matched predicate). Both research_log_append calls used correct structure and arguments (matched live). No fixture_not_found errors. Arguments were semantically correct throughout."
+              },
+              {
+                "source": "rubric",
+                "name": "URL generation",
+                "score": 3,
+                "rationale": "The skill generated a correctly pre-filled Ancestry search URL targeting collection 6742 (1880 U.S. Federal Census). The URL includes all relevant search parameters: name (Patrick_Flynn), birth year (1845), birthplace (Ireland), and residence (1880_Schuylkill+County%2C+Pennsylvania). The URL is syntactically valid and targets the correct site's search endpoint."
+              },
+              {
+                "source": "rubric",
+                "name": "Capture guidance",
+                "score": 3,
+                "rationale": "The skill provided clear, step-by-step instructions for the click-capture workflow: scroll to load lazy-loaded entries, press Cmd+P or Ctrl+P, select 'Save as PDF', and upload the PDF. It also explained why the 1880 census matters (relationship column, potential upgrade from Probable to Proved) and noted the common-name issue. Instructions name specific result types (household members with relationships) and saving steps (PDF download)."
+              },
+              {
+                "source": "rubric",
+                "name": "Result triage",
+                "score": 3,
+                "rationale": "No capture was provided in this turn \u2014 the user has not yet uploaded a PDF. The skill correctly deferred triage, stating 'Once you upload the PDF I'll triage the results and identify the strongest matches for you.' This is the correct behavior for a no-capture turn: wait for the capture without fabricating or pre-judging results. A clean deferral is a pass."
+              },
+              {
+                "source": "rubric",
+                "name": "Tool selection",
+                "score": 3,
+                "rationale": "The skill correctly used place_search first, fed its returned standardPlace ('Schuylkill, Pennsylvania, United States') to external_links_search with the correct year window (1880\u20131880), and properly consumed the response: identified that neither curated link matched the 1880 census target, and correctly fell back to the site-wide template (collection 6742 URL) as expected. The search was persisted via research_log_append with outcome 'partial' and capture_received false. Tool use follows the documented flow."
+              },
+              {
+                "source": "rubric",
+                "name": "Log entry",
+                "score": 3,
+                "rationale": "Two log entries were written in the same turn the URL was generated. log_006 records the curated-links fetch (outcome 'negative', noting the mismatch). log_007 records the search itself with outcome 'partial', capture_received false, results_examined 0, and the generated URL in externalSite.urlGenerated. The query field captures search parameters (given, surname, birth_year, birthplace, residence_year, residence_place, collection). Both entries were written at URL-generation time, not deferred."
+              }
+            ],
+            "judge_cost_usd": 0.010735000000000001,
+            "duration_ms": 12477.956583024934,
+            "error": null,
+            "input_tokens": 4995,
+            "cached_input_tokens": 0,
+            "output_tokens": 1148
+          },
+          "started_at": 1784328848.380707,
+          "ended_at": 1784328952.21431
+        }
+      ]
+    },
+    {
+      "test_id": "ut_search_external_sites_010",
+      "test_type": "positive",
+      "expected_outcome": "pass",
+      "scenario": "mid-research-flynn",
+      "mcp_fixtures": [
+        "place-search-schuylkill-county",
+        "place-search-schuylkill-by-name",
+        "place-search-schuylkill-by-place",
+        "external-links-search-mixed-sites"
+      ],
+      "outcome": "pass",
+      "flaky": false,
+      "outcome_summary": {
+        "per_run_outcomes": [
+          "pass"
+        ],
+        "aggregated_dimensions": [
+          {
+            "source": "base",
+            "name": "Correctness",
+            "score": 3,
+            "rationale": "The skill correctly resolved the place to Schuylkill, Pennsylvania, fetched curated Ancestry links, identified and collapsed the three duplicate collection 8800 entries into one, excluded the non-matching 1850 census collection, and generated a valid pre-filled Ancestry URL with appropriate search parameters (name, birth year ~1818 derived from census, death year 1880 as midpoint of 1870\u20131890 window, birthplace and deathplace). Two research log entries were written correctly: one for the curated-links fetch (log_006) and one for the search URL generation (log_007) with outcome 'partial' and capture_received false. All facts are supported by tool responses and prior sources."
+          },
+          {
+            "source": "base",
+            "name": "Completeness",
+            "score": 3,
+            "rationale": "The skill addressed all requirements: resolved the place, fetched and filtered curated links (keeping only Ancestry, deduping collection 8800, excluding non-matching census), generated a pre-filled search URL for the probate collection with all relevant parameters from the plan item (name, date range, place), provided clear capture instructions, and wrote both required log entries in the same turn. No omissions of required work."
+          },
+          {
+            "source": "base",
+            "name": "Tool Arguments",
+            "score": 3,
+            "rationale": "All four MCP tool calls passed correct arguments. place_search received 'Schuylkill County' and 'Pennsylvania' context, matching expected args. external_links_search received the standardPlace returned by place_search ('Schuylkill, Pennsylvania, United States'), correct year range (1870\u20131890), and host filter ('ancestry.com'). Both research_log_append calls used correct planItemId (pli_006), tool names, query structures, and outcome values. No fixture_not_found errors; all calls matched successfully."
+          },
+          {
+            "source": "rubric",
+            "name": "URL generation",
+            "score": 3,
+            "rationale": "The generated URL targets the correct Ancestry probate collection (8800), includes all relevant search parameters from the plan item: name (Thomas Flynn), birth year (~1818 derived from census evidence), birthplace (Pennsylvania), death year (1880 as midpoint of 1870\u20131890 window), and deathplace (Schuylkill, Pennsylvania). The URL is syntactically valid and properly encodes query parameters. The skill correctly appended parameters to the curated collection URL rather than rebuilding from scratch."
+          },
+          {
+            "source": "rubric",
+            "name": "Capture guidance",
+            "score": 3,
+            "rationale": "Instructions are clear and specific: click the link in an authenticated Ancestry session, scroll to load lazy-loaded results, use Cmd+P (Mac) or Ctrl+P (Windows) to save as PDF, and upload the PDF. The skill also provides a helpful tip about removing the death-year filter if results are sparse. Instructions name the specific saving method (PDF) and how to return the capture, and explain what to do if login is required."
+          },
+          {
+            "source": "rubric",
+            "name": "Result triage",
+            "score": 3,
+            "rationale": "No capture was provided in this turn \u2014 the user has not yet run the search or uploaded results. The skill correctly defers triage, stating 'Once you upload the PDF I'll triage the results, rate each hit for fit, and route any strong match to record-extraction for a full single-record capture.' This is the correct behavior for a no-capture turn: wait for the capture before fabricating or pre-judging results. A clean deferral is a pass."
+          },
+          {
+            "source": "rubric",
+            "name": "Tool selection",
+            "score": 3,
+            "rationale": "The skill correctly followed the documented flow: place_search resolved the place first, returning 'Schuylkill, Pennsylvania, United States' as the standardPlace. This returned value (not a guessed string) was then fed to external_links_search with the correct year window (1870\u20131890) and host filter (ancestry.com). The response was consumed correctly: kept only Ancestry links (host filter applied), deduped the three identical collection 8800 URLs into one, excluded the non-matching 1850 census collection (collection 1276), and used the curated link for the correct record type (probate/wills). The search was persisted via research_log_append with validation passing. No fabricated arguments or skipped steps."
+          },
+          {
+            "source": "rubric",
+            "name": "Log entry",
+            "score": 3,
+            "rationale": "Two research log entries were written in the same turn the URL was generated. log_006 documents the curated-links fetch (tool: external_links_search, outcome: positive, notes coverage and dedup). log_007 documents the search URL generation (tool: external_site, outcome: partial, capture_received: false, notes site, person, place, year range, and derivation of birth year from census). Both entries include the required metadata (planItemId, query details, outcome, notes). Neither entry was skipped or deferred."
+          }
+        ]
+      },
+      "totals": {
+        "duration_ms": 105968.29704102129,
+        "duration_api_ms": 104451.0,
+        "judge_duration_ms": 14495.981457992457,
+        "wall_clock_ms": 120679.87608909607,
+        "num_turns": 11,
+        "input_tokens": 17,
+        "cached_input_tokens": 235542,
+        "output_tokens": 5863,
+        "judge_input_tokens": 5308,
+        "judge_cached_input_tokens": 4778,
+        "judge_output_tokens": 1308,
+        "skill_cost_usd": 0.28566035,
+        "judge_cost_usd": 0.0075478,
+        "total_cost_usd": 0.29320815
+      },
+      "runs": [
+        {
+          "run_index": 0,
+          "run_id": "run_ut_search_external_sites_010_2026-07-17_22-54-08_0",
+          "outcome": "pass",
+          "aborted_reason": null,
+          "duration_ms": 105968.29704102129,
+          "duration_api_ms": 104451.0,
+          "num_turns": 11,
+          "skill_attempts": 1,
+          "input_tokens": 17,
+          "cached_input_tokens": 235542,
+          "output_tokens": 5863,
+          "skill_cost_usd": 0.28566035,
+          "output": {
+            "text_response": "I can see plan item `pli_006` targets probate records for Thomas Flynn in Schuylkill County, 1870\u20131890 \u2014 though it's listed as FamilySearch, you're now directing this search to Ancestry. I have no researcher profile with subscriptions on file, so I'll treat all sites equally. Let me resolve the place and fetch curated links.Standard place confirmed: **Schuylkill, Pennsylvania, United States**. Now fetching curated Ancestry links for 1870\u20131890.Two Ancestry hits for probate: collection 8800 appeared **3\u00d7** under different labels (\"Pennsylvania, U.S., Wills and Probate Records, 1683-1993\", \"Pennsylvania Probate Records - Schuylkill County\", \"Wills and Probates 1870-1890\") \u2014 collapsed to one. Collection 1276 (1850 census) doesn't match the record type and is excluded. I'll now log the curated-links fetch and the Ancestry search, then present the URL.Both log entries written (log_006 for the curated-links fetch, log_007 for the Ancestry search). Here's your search:\n\n---\n\n**Search: Pennsylvania Wills & Probate Records (Ancestry, Collection 8800) \u2014 Thomas Flynn**\n\nA FamilySearch-curated link exists for this exact record type and county: **Pennsylvania, U.S., Wills and Probate Records, 1683-1993** (Ancestry collection 8800). Parameters used:\n- **Name:** Thomas Flynn\n- **Birth year:** ~1818 (derived from 1850 census, where he was age ~32)\n- **Birthplace:** Pennsylvania\n- **Death year:** 1880 (midpoint of 1870\u20131890 window; Ancestry applies \u00b12-year fuzzy matching)\n- **Death place:** Schuylkill, Pennsylvania\n\n**Click to search:**\n[Ancestry \u2014 Pennsylvania Wills & Probate Records, Thomas Flynn](https://www.ancestry.com/search/collections/8800/?name=Thomas_Flynn&birth=1818&birthplace=Pennsylvania&death=1880&deathplace=Schuylkill%2C+Pennsylvania)\n\n**To capture the results:**\n1. Click the link in your authenticated Ancestry browser session\n2. Scroll to the bottom of the results page, then back to the top (forces lazy-loaded results into view)\n3. Press **Cmd+P** (Mac) or **Ctrl+P** (Windows) \u2192 **Save as PDF**\n4. Upload the PDF here\n\n> If Ancestry asks you to log in, do so first, then click the link again.\n\n> **Tip:** If results are sparse, try removing the death year from the on-screen filters to widen to all years in the collection \u2014 the 1870\u20131890 window is an estimate of when Thomas would have died, not a hard cutoff.\n\n---\n\nOnce you upload the PDF I'll triage the results, rate each hit for fit, and route any strong match to record-extraction for a full single-record capture.",
+            "activated": true,
+            "skills_invoked": [
+              "search-external-sites"
+            ],
+            "tool_calls": [
+              {
+                "tool": "mcp__genealogy__place_search",
+                "args": {
+                  "placeName": "Schuylkill County",
+                  "contextName": "Pennsylvania"
+                },
+                "expected_args": {
+                  "placeName": "~Schuylkill"
+                },
+                "matched": {
+                  "kind": "predicate",
+                  "index": 0
+                },
+                "response_fixture": "place-search-schuylkill-county"
+              },
+              {
+                "tool": "mcp__genealogy__external_links_search",
+                "args": {
+                  "standardPlace": "Schuylkill, Pennsylvania, United States",
+                  "startYear": 1870,
+                  "endYear": 1890,
+                  "host": "ancestry.com",
+                  "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/eval-ut_search_external_sites_010-0-0-redii_aw"
+                },
+                "expected_args": {
+                  "standardPlace": "~"
+                },
+                "matched": {
+                  "kind": "predicate",
+                  "index": 0
+                },
+                "response_fixture": "external-links-search-mixed-sites"
+              },
+              {
+                "tool": "mcp__genealogy__research_log_append",
+                "args": {
+                  "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/eval-ut_search_external_sites_010-0-0-redii_aw",
+                  "planItemId": "pli_006",
+                  "tool": "external_links_search",
+                  "query": {
+                    "standardPlace": "Schuylkill, Pennsylvania, United States",
+                    "host": "ancestry.com",
+                    "startYear": 1870,
+                    "endYear": 1890
+                  },
+                  "outcome": "positive",
+                  "resultsExamined": 3,
+                  "notes": "Curated external links for Schuylkill County, PA, 1870\u20131890. Three Ancestry links returned, all pointing to collection 8800 (Pennsylvania Wills and Probate Records, 1683-1993) \u2014 collapsed to one after dedup. One census link (collection 1276) excluded as non-matching record type.",
+                  "stagedResultsRef": "results/.staging/f02743b6-1db4-4e1c-992a-0cda53bf0e8c.json"
+                },
+                "expected_args": null,
+                "matched": {
+                  "kind": "live",
+                  "index": null
+                },
+                "response_fixture": "live:research_log_append"
+              },
+              {
+                "tool": "mcp__genealogy__research_log_append",
+                "args": {
+                  "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/eval-ut_search_external_sites_010-0-0-redii_aw",
+                  "planItemId": "pli_006",
+                  "tool": "external_site",
+                  "query": {
+                    "surname": "Flynn",
+                    "given": "Thomas",
+                    "birth_year": 1818,
+                    "birthplace": "Pennsylvania",
+                    "death_year": 1880,
+                    "deathplace": "Schuylkill, Pennsylvania",
+                    "collection": "Pennsylvania, U.S., Wills and Probate Records, 1683-1993",
+                    "collection_id": "8800"
+                  },
+                  "outcome": "partial",
+                  "resultsExamined": 0,
+                  "notes": "URL generated for Ancestry collection 8800 (Pennsylvania Wills and Probate Records, 1683-1993), scoped to Thomas Flynn in Schuylkill County, PA, 1870\u20131890. Birth year ~1818 derived from 1850 census (age ~32). Death year 1880 used as midpoint of the 1870\u20131890 window; Ancestry applies fuzzy \u00b12-year matching. Awaiting user capture.",
+                  "externalSite": {
+                    "site": "ancestry",
+                    "urlGenerated": "https://www.ancestry.com/search/collections/8800/?name=Thomas_Flynn&birth=1818&birthplace=Pennsylvania&death=1880&deathplace=Schuylkill%2C+Pennsylvania",
+                    "captureReceived": false,
+                    "captureFilename": null
+                  }
+                },
+                "expected_args": null,
+                "matched": {
+                  "kind": "live",
+                  "index": null
+                },
+                "response_fixture": "live:research_log_append"
+              }
+            ],
+            "files_created": [
+              "results/log_006.json"
+            ],
+            "file_changes": {
+              "research.json": {
+                "sections_modified": [
+                  "log"
+                ],
+                "diff": {
+                  "log": {
+                    "added": [
+                      {
+                        "id": "log_006",
+                        "plan_item_id": "pli_006",
+                        "performed": "2026-07-17T22:55:35.065Z",
+                        "tool": "external_links_search",
+                        "query": {
+                          "standardPlace": "Schuylkill, Pennsylvania, United States",
+                          "host": "ancestry.com",
+                          "startYear": 1870,
+                          "endYear": 1890
+                        },
+                        "outcome": "positive",
+                        "results_examined": 3,
+                        "external_site": null,
+                        "results_ref": "results/log_006.json",
+                        "notes": "Curated external links for Schuylkill County, PA, 1870\u20131890. Three Ancestry links returned, all pointing to collection 8800 (Pennsylvania Wills and Probate Records, 1683-1993) \u2014 collapsed to one after dedup. One census link (collection 1276) excluded as non-matching record type."
+                      },
+                      {
+                        "id": "log_007",
+                        "plan_item_id": "pli_006",
+                        "performed": "2026-07-17T22:55:44.412Z",
+                        "tool": "external_site",
+                        "query": {
+                          "surname": "Flynn",
+                          "given": "Thomas",
+                          "birth_year": 1818,
+                          "birthplace": "Pennsylvania",
+                          "death_year": 1880,
+                          "deathplace": "Schuylkill, Pennsylvania",
+                          "collection": "Pennsylvania, U.S., Wills and Probate Records, 1683-1993",
+                          "collection_id": "8800"
+                        },
+                        "outcome": "partial",
+                        "results_examined": 0,
+                        "external_site": {
+                          "site": "ancestry",
+                          "url_generated": "https://www.ancestry.com/search/collections/8800/?name=Thomas_Flynn&birth=1818&birthplace=Pennsylvania&death=1880&deathplace=Schuylkill%2C+Pennsylvania",
+                          "capture_received": false,
+                          "capture_filename": null
+                        },
+                        "results_ref": null,
+                        "notes": "URL generated for Ancestry collection 8800 (Pennsylvania Wills and Probate Records, 1683-1993), scoped to Thomas Flynn in Schuylkill County, PA, 1870\u20131890. Birth year ~1818 derived from 1850 census (age ~32). Death year 1880 used as midpoint of the 1870\u20131890 window; Ancestry applies fuzzy \u00b12-year matching. Awaiting user capture."
+                      }
+                    ],
+                    "modified": [],
+                    "deleted": []
+                  }
+                }
+              }
+            }
+          },
+          "validators": {
+            "passed": true,
+            "results": [
+              {
+                "name": "test_id_references_resolve",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_log_append_only",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_entries_deleted",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_main_thread_subagent_only_calls",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_project_file_changes_route_through_writer_tools",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_research_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tool_allowlist",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_gedcomx_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_log_site_ancestry",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_log_site_findagrave",
+                "passed": true,
+                "error": "skipped: not a log-site-findagrave scenario"
+              },
+              {
+                "name": "test_log_site_findmypast",
+                "passed": true,
+                "error": "skipped: not a log-site-findmypast scenario"
+              },
+              {
+                "name": "test_log_site_myheritage",
+                "passed": true,
+                "error": "skipped: not a log-site-myheritage scenario"
+              },
+              {
+                "name": "test_log_site_newspapers",
+                "passed": true,
+                "error": "skipped: not a log-site-newspapers scenario"
+              },
+              {
+                "name": "test_positive_appends_external_site_log_entry",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_url_generation_log_entry_shape",
+                "passed": true,
+                "error": null
+              }
+            ]
+          },
+          "judge": {
+            "skipped": false,
+            "dimensions": [
+              {
+                "source": "base",
+                "name": "Correctness",
+                "score": 3,
+                "rationale": "The skill correctly resolved the place to Schuylkill, Pennsylvania, fetched curated Ancestry links, identified and collapsed the three duplicate collection 8800 entries into one, excluded the non-matching 1850 census collection, and generated a valid pre-filled Ancestry URL with appropriate search parameters (name, birth year ~1818 derived from census, death year 1880 as midpoint of 1870\u20131890 window, birthplace and deathplace). Two research log entries were written correctly: one for the curated-links fetch (log_006) and one for the search URL generation (log_007) with outcome 'partial' and capture_received false. All facts are supported by tool responses and prior sources."
+              },
+              {
+                "source": "base",
+                "name": "Completeness",
+                "score": 3,
+                "rationale": "The skill addressed all requirements: resolved the place, fetched and filtered curated links (keeping only Ancestry, deduping collection 8800, excluding non-matching census), generated a pre-filled search URL for the probate collection with all relevant parameters from the plan item (name, date range, place), provided clear capture instructions, and wrote both required log entries in the same turn. No omissions of required work."
+              },
+              {
+                "source": "base",
+                "name": "Tool Arguments",
+                "score": 3,
+                "rationale": "All four MCP tool calls passed correct arguments. place_search received 'Schuylkill County' and 'Pennsylvania' context, matching expected args. external_links_search received the standardPlace returned by place_search ('Schuylkill, Pennsylvania, United States'), correct year range (1870\u20131890), and host filter ('ancestry.com'). Both research_log_append calls used correct planItemId (pli_006), tool names, query structures, and outcome values. No fixture_not_found errors; all calls matched successfully."
+              },
+              {
+                "source": "rubric",
+                "name": "URL generation",
+                "score": 3,
+                "rationale": "The generated URL targets the correct Ancestry probate collection (8800), includes all relevant search parameters from the plan item: name (Thomas Flynn), birth year (~1818 derived from census evidence), birthplace (Pennsylvania), death year (1880 as midpoint of 1870\u20131890 window), and deathplace (Schuylkill, Pennsylvania). The URL is syntactically valid and properly encodes query parameters. The skill correctly appended parameters to the curated collection URL rather than rebuilding from scratch."
+              },
+              {
+                "source": "rubric",
+                "name": "Capture guidance",
+                "score": 3,
+                "rationale": "Instructions are clear and specific: click the link in an authenticated Ancestry session, scroll to load lazy-loaded results, use Cmd+P (Mac) or Ctrl+P (Windows) to save as PDF, and upload the PDF. The skill also provides a helpful tip about removing the death-year filter if results are sparse. Instructions name the specific saving method (PDF) and how to return the capture, and explain what to do if login is required."
+              },
+              {
+                "source": "rubric",
+                "name": "Result triage",
+                "score": 3,
+                "rationale": "No capture was provided in this turn \u2014 the user has not yet run the search or uploaded results. The skill correctly defers triage, stating 'Once you upload the PDF I'll triage the results, rate each hit for fit, and route any strong match to record-extraction for a full single-record capture.' This is the correct behavior for a no-capture turn: wait for the capture before fabricating or pre-judging results. A clean deferral is a pass."
+              },
+              {
+                "source": "rubric",
+                "name": "Tool selection",
+                "score": 3,
+                "rationale": "The skill correctly followed the documented flow: place_search resolved the place first, returning 'Schuylkill, Pennsylvania, United States' as the standardPlace. This returned value (not a guessed string) was then fed to external_links_search with the correct year window (1870\u20131890) and host filter (ancestry.com). The response was consumed correctly: kept only Ancestry links (host filter applied), deduped the three identical collection 8800 URLs into one, excluded the non-matching 1850 census collection (collection 1276), and used the curated link for the correct record type (probate/wills). The search was persisted via research_log_append with validation passing. No fabricated arguments or skipped steps."
+              },
+              {
+                "source": "rubric",
+                "name": "Log entry",
+                "score": 3,
+                "rationale": "Two research log entries were written in the same turn the URL was generated. log_006 documents the curated-links fetch (tool: external_links_search, outcome: positive, notes coverage and dedup). log_007 documents the search URL generation (tool: external_site, outcome: partial, capture_received: false, notes site, person, place, year range, and derivation of birth year from census). Both entries include the required metadata (planItemId, query details, outcome, notes). Neither entry was skipped or deferred."
+              }
+            ],
+            "judge_cost_usd": 0.0075478,
+            "duration_ms": 14495.981457992457,
+            "error": null,
+            "input_tokens": 5308,
+            "cached_input_tokens": 4778,
+            "output_tokens": 1308
+          },
+          "started_at": 1784328848.381608,
+          "ended_at": 1784328969.061484
+        }
+      ]
+    },
+    {
+      "test_id": "ut_search_external_sites_002",
+      "test_type": "positive",
+      "expected_outcome": "pass",
+      "scenario": "mid-research-flynn",
+      "mcp_fixtures": [
+        "place-search-schuylkill-county",
+        "place-search-schuylkill-by-name",
+        "place-search-schuylkill-by-place",
+        "external-links-search-schuylkill"
+      ],
+      "outcome": "pass",
+      "flaky": false,
+      "outcome_summary": {
+        "per_run_outcomes": [
+          "pass"
+        ],
+        "aggregated_dimensions": [
+          {
+            "source": "base",
+            "name": "Correctness",
+            "score": 3,
+            "rationale": "The skill correctly generated a MyHeritage search URL with all required parameters: Patrick Flynn's name, birth year ~1845 (derived from census ages), birthplace Ireland (from 1850/1860 census records), and father Thomas Flynn (from death certificate and census co-enumeration). The URL targets the correct site (myheritage.com) and uses valid MyHeritage parameter syntax. The skill accurately reported that no curated MyHeritage links existed for this place/year and correctly fell back to the site-wide template. All claims are supported by the input state and tool responses."
+          },
+          {
+            "source": "base",
+            "name": "Completeness",
+            "score": 3,
+            "rationale": "The skill addressed all requirements: resolved the place name via place_search, fetched curated links via external_links_search, generated a properly-formatted MyHeritage URL with all relevant search parameters from the plan item (name, birth year, birthplace, father's name), provided clear capture-workflow instructions (scroll, print-to-PDF, upload), and logged both the curated-links fetch and the in-flight search via research_log_append. No required elements were omitted."
+          },
+          {
+            "source": "base",
+            "name": "Tool Arguments",
+            "score": 3,
+            "rationale": "All four MCP tool calls passed arguments matching the fixture's expected_args semantically. place_search received 'Schuylkill County' and 'Pennsylvania' (matching ~Schuylkill expectation). external_links_search received the standardPlace returned by place_search ('Schuylkill, Pennsylvania, United States'), correct year range (1860), and host 'myheritage.com'. Both research_log_append calls used valid schemas with appropriate outcome values ('negative' for curated-links fetch, 'partial' for in-flight search). No critical identifiers were wrong, no fixture_not_found errors occurred, and no fabricated arguments were passed."
+          },
+          {
+            "source": "rubric",
+            "name": "URL generation",
+            "score": 3,
+            "rationale": "The generated URL targets myheritage.com's search endpoint and includes all relevant search parameters from the plan item: first=Patrick, last=Flynn, birth_year=1845 (derived from census ages), birth_place=Ireland (from census records per assertions a_002 and a_009), father_first=Thomas, father_last=Flynn. The URL is syntactically valid and uses MyHeritage's parameter naming conventions correctly. The skill correctly encoded Ireland as the birthplace (the only location parameter MyHeritage's template exposes) rather than the county level, which the template does not support."
+          },
+          {
+            "source": "rubric",
+            "name": "Capture guidance",
+            "score": 3,
+            "rationale": "The skill provided clear, step-by-step instructions for the click-capture workflow: (1) scroll to bottom and back to top to force lazy-loaded results into view, (2) press Cmd+P (Mac) or Ctrl+P (Windows), (3) choose 'Save as PDF', (4) upload the PDF. Instructions also address the login-wall scenario (log in first, then click again) and note that no MyHeritage subscription is on file. The user knows exactly what to do and how to return results."
+          },
+          {
+            "source": "rubric",
+            "name": "Result triage",
+            "score": 3,
+            "rationale": "This turn generated a search URL but no capture was provided by the user \u2014 the correct behavior is to defer triage. The skill explicitly deferred: 'Upload the PDF and I'll triage the results and identify any strong matches worth pulling as individual records.' This is a clean deferral without fabrication or pre-judgment of results. No triage was attempted on non-existent results, which is exactly what the workflow requires at this phase."
+          },
+          {
+            "source": "rubric",
+            "name": "Tool selection",
+            "score": 3,
+            "rationale": "The skill correctly executed the search-generation flow: (1) called place_search first with 'Schuylkill County' and 'Pennsylvania', (2) fed the returned standardPlace ('Schuylkill, Pennsylvania, United States') to external_links_search with the plan item's year window (1860), (3) correctly consumed the response by filtering for myheritage.com host (found none, only Ancestry URLs), (4) correctly fell back to the site-wide MyHeritage template when no curated link matched, (5) persisted the search via research_log_append with outcome='partial' and capture_received=false. All tool usage follows the documented flow."
+          },
+          {
+            "source": "rubric",
+            "name": "Log entry",
+            "score": 3,
+            "rationale": "The skill wrote two log entries at URL-generation time (not deferred): log_006 for the curated-links fetch (outcome='negative', notes on coverage) and log_007 for the in-flight search (outcome='partial', capture_received=false). Both entries name the site (MyHeritage), person (Patrick Flynn), place (Schuylkill County, Pennsylvania), and year (1860). The log entries were written in the same turn the URL was generated, per the required workflow. Neither entry was skipped or misleading."
+          }
+        ]
+      },
+      "totals": {
+        "duration_ms": 89959.68958403682,
+        "duration_api_ms": 89347.0,
+        "judge_duration_ms": 14366.154916991945,
+        "wall_clock_ms": 104380.85198402405,
+        "num_turns": 12,
+        "input_tokens": 20,
+        "cached_input_tokens": 260889,
+        "output_tokens": 4469,
+        "judge_input_tokens": 4921,
+        "judge_cached_input_tokens": 4778,
+        "judge_output_tokens": 1345,
+        "skill_cost_usd": 0.2598687,
+        "judge_cost_usd": 0.0073458,
+        "total_cost_usd": 0.2672145
+      },
+      "runs": [
+        {
+          "run_index": 0,
+          "run_id": "run_ut_search_external_sites_002_2026-07-17_22-54-08_0",
+          "outcome": "pass",
+          "aborted_reason": null,
+          "duration_ms": 89959.68958403682,
+          "duration_api_ms": 89347.0,
+          "num_turns": 12,
+          "skill_attempts": 1,
+          "input_tokens": 20,
+          "cached_input_tokens": 260889,
+          "output_tokens": 4469,
+          "skill_cost_usd": 0.2598687,
+          "output": {
+            "text_response": "No `researcher_profile` found \u2014 using default one-line narration. Resolving the place and fetching curated MyHeritage links for Schuylkill County, 1860.Resolving the place name for Schuylkill County, Pennsylvania.Got `standardPlace: \"Schuylkill, Pennsylvania, United States\"`. Now fetching curated MyHeritage links for 1860.No MyHeritage links came back from the curated set (both results are Ancestry URLs). Falling back to **Case B** \u2014 site-wide MyHeritage template. Now logging the curated-links fetch, then the search itself.Logging the curated-links fetch, then the in-flight MyHeritage search entry.Curated-links fetch logged as `log_006`. Now logging the in-flight MyHeritage search.Both log entries written. Here's the search:\n\n---\n\n**No FamilySearch-curated MyHeritage link exists for Schuylkill County, PA in the 1860 window** \u2014 using the site-wide MyHeritage search template instead.\n\n---\n\n**Search: 1860 Census on MyHeritage for Patrick Flynn**\n\nClick this link to search:\n[MyHeritage \u2014 1860 Census, Patrick Flynn](https://www.myheritage.com/research?action=query&first=Patrick&last=Flynn&birth_year=1845&birth_place=Ireland&father_first=Thomas&father_last=Flynn)\n\n**Parameters encoded:**\n| Parameter | Value | Source |\n|-----------|-------|--------|\n| first / last | Patrick Flynn | Subject name |\n| birth_year | 1845 | Estimated from age 5 in 1850 census & age 15 in 1860 census |\n| birth_place | Ireland | 1850 and 1860 census records |\n| father_first / father_last | Thomas Flynn | 1908 death certificate; census co-enumeration |\n\nAfter the page loads:\n1. Scroll to the bottom and back to the top (forces lazy-loaded results into view)\n2. Press **Cmd+P** (Mac) or **Ctrl+P** (Windows)\n3. Choose **\"Save as PDF\"**\n4. Upload the PDF here\n\nIf the page hits a login wall, log in to MyHeritage first, then click the link again. (No MyHeritage subscription is on file \u2014 you may land on a limited-preview page.)\n\n---\n\nUpload the PDF and I'll triage the results and identify any strong matches worth pulling as individual records.",
+            "activated": true,
+            "skills_invoked": [
+              "search-external-sites"
+            ],
+            "tool_calls": [
+              {
+                "tool": "mcp__genealogy__place_search",
+                "args": {
+                  "placeName": "Schuylkill County",
+                  "contextName": "Pennsylvania"
+                },
+                "expected_args": {
+                  "placeName": "~Schuylkill"
+                },
+                "matched": {
+                  "kind": "predicate",
+                  "index": 0
+                },
+                "response_fixture": "place-search-schuylkill-county"
+              },
+              {
+                "tool": "mcp__genealogy__external_links_search",
+                "args": {
+                  "standardPlace": "Schuylkill, Pennsylvania, United States",
+                  "startYear": 1860,
+                  "endYear": 1860,
+                  "host": "myheritage.com",
+                  "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/eval-ut_search_external_sites_002-0-0-6yl7k6a3"
+                },
+                "expected_args": {
+                  "standardPlace": "~"
+                },
+                "matched": {
+                  "kind": "predicate",
+                  "index": 0
+                },
+                "response_fixture": "external-links-search-schuylkill"
+              },
+              {
+                "tool": "mcp__genealogy__research_log_append",
+                "args": {
+                  "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/eval-ut_search_external_sites_002-0-0-6yl7k6a3",
+                  "tool": "external_links_search",
+                  "query": {
+                    "standardPlace": "Schuylkill, Pennsylvania, United States",
+                    "host": "myheritage.com",
+                    "startYear": 1860,
+                    "endYear": 1860
+                  },
+                  "outcome": "negative",
+                  "resultsExamined": 2,
+                  "notes": "Curated external links for Schuylkill, Pennsylvania, United States. No MyHeritage links returned for this place and year range; 2 Ancestry links found (both off-target). Falling back to site-wide MyHeritage template for the 1860 census search.",
+                  "stagedResultsRef": "results/.staging/4571e9a0-ed0f-4df8-abe7-147bc2e14f97.json",
+                  "planItemId": null
+                },
+                "expected_args": null,
+                "matched": {
+                  "kind": "live",
+                  "index": null
+                },
+                "response_fixture": "live:research_log_append"
+              },
+              {
+                "tool": "mcp__genealogy__research_log_append",
+                "args": {
+                  "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/eval-ut_search_external_sites_002-0-0-6yl7k6a3",
+                  "tool": "external_site",
+                  "query": {
+                    "first": "Patrick",
+                    "last": "Flynn",
+                    "birth_year": 1845,
+                    "birth_place": "Ireland",
+                    "father_first": "Thomas",
+                    "father_last": "Flynn",
+                    "collection": "1860 census",
+                    "jurisdiction": "Schuylkill County, Pennsylvania"
+                  },
+                  "outcome": "partial",
+                  "resultsExamined": 0,
+                  "notes": "URL generated; awaiting user capture. No FamilySearch-curated MyHeritage link found for Schuylkill County, PA in 1860 \u2014 using site-wide MyHeritage search template. Parameters include known birth year (~1845), birthplace (Ireland from census records), and father's name (Thomas Flynn).",
+                  "externalSite": {
+                    "site": "myheritage",
+                    "urlGenerated": "https://www.myheritage.com/research?action=query&first=Patrick&last=Flynn&birth_year=1845&birth_place=Ireland&father_first=Thomas&father_last=Flynn",
+                    "captureReceived": false,
+                    "captureFilename": null
+                  },
+                  "planItemId": null
+                },
+                "expected_args": null,
+                "matched": {
+                  "kind": "live",
+                  "index": null
+                },
+                "response_fixture": "live:research_log_append"
+              }
+            ],
+            "files_created": [
+              "results/log_006.json"
+            ],
+            "file_changes": {
+              "research.json": {
+                "sections_modified": [
+                  "log"
+                ],
+                "diff": {
+                  "log": {
+                    "added": [
+                      {
+                        "id": "log_006",
+                        "plan_item_id": null,
+                        "performed": "2026-07-17T22:56:58.062Z",
+                        "tool": "external_links_search",
+                        "query": {
+                          "standardPlace": "Schuylkill, Pennsylvania, United States",
+                          "host": "myheritage.com",
+                          "startYear": 1860,
+                          "endYear": 1860
+                        },
+                        "outcome": "negative",
+                        "results_examined": 2,
+                        "external_site": null,
+                        "results_ref": "results/log_006.json",
+                        "notes": "Curated external links for Schuylkill, Pennsylvania, United States. No MyHeritage links returned for this place and year range; 2 Ancestry links found (both off-target). Falling back to site-wide MyHeritage template for the 1860 census search."
+                      },
+                      {
+                        "id": "log_007",
+                        "plan_item_id": null,
+                        "performed": "2026-07-17T22:57:10.011Z",
+                        "tool": "external_site",
+                        "query": {
+                          "first": "Patrick",
+                          "last": "Flynn",
+                          "birth_year": 1845,
+                          "birth_place": "Ireland",
+                          "father_first": "Thomas",
+                          "father_last": "Flynn",
+                          "collection": "1860 census",
+                          "jurisdiction": "Schuylkill County, Pennsylvania"
+                        },
+                        "outcome": "partial",
+                        "results_examined": 0,
+                        "external_site": {
+                          "site": "myheritage",
+                          "url_generated": "https://www.myheritage.com/research?action=query&first=Patrick&last=Flynn&birth_year=1845&birth_place=Ireland&father_first=Thomas&father_last=Flynn",
+                          "capture_received": false,
+                          "capture_filename": null
+                        },
+                        "results_ref": null,
+                        "notes": "URL generated; awaiting user capture. No FamilySearch-curated MyHeritage link found for Schuylkill County, PA in 1860 \u2014 using site-wide MyHeritage search template. Parameters include known birth year (~1845), birthplace (Ireland from census records), and father's name (Thomas Flynn)."
+                      }
+                    ],
+                    "modified": [],
+                    "deleted": []
+                  }
+                }
+              }
+            }
+          },
+          "validators": {
+            "passed": true,
+            "results": [
+              {
+                "name": "test_id_references_resolve",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_log_append_only",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_entries_deleted",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_main_thread_subagent_only_calls",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_project_file_changes_route_through_writer_tools",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_research_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tool_allowlist",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_gedcomx_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_log_site_ancestry",
+                "passed": true,
+                "error": "skipped: not a log-site-ancestry scenario"
+              },
+              {
+                "name": "test_log_site_findagrave",
+                "passed": true,
+                "error": "skipped: not a log-site-findagrave scenario"
+              },
+              {
+                "name": "test_log_site_findmypast",
+                "passed": true,
+                "error": "skipped: not a log-site-findmypast scenario"
+              },
+              {
+                "name": "test_log_site_myheritage",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_log_site_newspapers",
+                "passed": true,
+                "error": "skipped: not a log-site-newspapers scenario"
+              },
+              {
+                "name": "test_positive_appends_external_site_log_entry",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_url_generation_log_entry_shape",
+                "passed": true,
+                "error": null
+              }
+            ]
+          },
+          "judge": {
+            "skipped": false,
+            "dimensions": [
+              {
+                "source": "base",
+                "name": "Correctness",
+                "score": 3,
+                "rationale": "The skill correctly generated a MyHeritage search URL with all required parameters: Patrick Flynn's name, birth year ~1845 (derived from census ages), birthplace Ireland (from 1850/1860 census records), and father Thomas Flynn (from death certificate and census co-enumeration). The URL targets the correct site (myheritage.com) and uses valid MyHeritage parameter syntax. The skill accurately reported that no curated MyHeritage links existed for this place/year and correctly fell back to the site-wide template. All claims are supported by the input state and tool responses."
+              },
+              {
+                "source": "base",
+                "name": "Completeness",
+                "score": 3,
+                "rationale": "The skill addressed all requirements: resolved the place name via place_search, fetched curated links via external_links_search, generated a properly-formatted MyHeritage URL with all relevant search parameters from the plan item (name, birth year, birthplace, father's name), provided clear capture-workflow instructions (scroll, print-to-PDF, upload), and logged both the curated-links fetch and the in-flight search via research_log_append. No required elements were omitted."
+              },
+              {
+                "source": "base",
+                "name": "Tool Arguments",
+                "score": 3,
+                "rationale": "All four MCP tool calls passed arguments matching the fixture's expected_args semantically. place_search received 'Schuylkill County' and 'Pennsylvania' (matching ~Schuylkill expectation). external_links_search received the standardPlace returned by place_search ('Schuylkill, Pennsylvania, United States'), correct year range (1860), and host 'myheritage.com'. Both research_log_append calls used valid schemas with appropriate outcome values ('negative' for curated-links fetch, 'partial' for in-flight search). No critical identifiers were wrong, no fixture_not_found errors occurred, and no fabricated arguments were passed."
+              },
+              {
+                "source": "rubric",
+                "name": "URL generation",
+                "score": 3,
+                "rationale": "The generated URL targets myheritage.com's search endpoint and includes all relevant search parameters from the plan item: first=Patrick, last=Flynn, birth_year=1845 (derived from census ages), birth_place=Ireland (from census records per assertions a_002 and a_009), father_first=Thomas, father_last=Flynn. The URL is syntactically valid and uses MyHeritage's parameter naming conventions correctly. The skill correctly encoded Ireland as the birthplace (the only location parameter MyHeritage's template exposes) rather than the county level, which the template does not support."
+              },
+              {
+                "source": "rubric",
+                "name": "Capture guidance",
+                "score": 3,
+                "rationale": "The skill provided clear, step-by-step instructions for the click-capture workflow: (1) scroll to bottom and back to top to force lazy-loaded results into view, (2) press Cmd+P (Mac) or Ctrl+P (Windows), (3) choose 'Save as PDF', (4) upload the PDF. Instructions also address the login-wall scenario (log in first, then click again) and note that no MyHeritage subscription is on file. The user knows exactly what to do and how to return results."
+              },
+              {
+                "source": "rubric",
+                "name": "Result triage",
+                "score": 3,
+                "rationale": "This turn generated a search URL but no capture was provided by the user \u2014 the correct behavior is to defer triage. The skill explicitly deferred: 'Upload the PDF and I'll triage the results and identify any strong matches worth pulling as individual records.' This is a clean deferral without fabrication or pre-judgment of results. No triage was attempted on non-existent results, which is exactly what the workflow requires at this phase."
+              },
+              {
+                "source": "rubric",
+                "name": "Tool selection",
+                "score": 3,
+                "rationale": "The skill correctly executed the search-generation flow: (1) called place_search first with 'Schuylkill County' and 'Pennsylvania', (2) fed the returned standardPlace ('Schuylkill, Pennsylvania, United States') to external_links_search with the plan item's year window (1860), (3) correctly consumed the response by filtering for myheritage.com host (found none, only Ancestry URLs), (4) correctly fell back to the site-wide MyHeritage template when no curated link matched, (5) persisted the search via research_log_append with outcome='partial' and capture_received=false. All tool usage follows the documented flow."
+              },
+              {
+                "source": "rubric",
+                "name": "Log entry",
+                "score": 3,
+                "rationale": "The skill wrote two log entries at URL-generation time (not deferred): log_006 for the curated-links fetch (outcome='negative', notes on coverage) and log_007 for the in-flight search (outcome='partial', capture_received=false). Both entries name the site (MyHeritage), person (Patrick Flynn), place (Schuylkill County, Pennsylvania), and year (1860). The log entries were written in the same turn the URL was generated, per the required workflow. Neither entry was skipped or misleading."
+              }
+            ],
+            "judge_cost_usd": 0.0073458,
+            "duration_ms": 14366.154916991945,
+            "error": null,
+            "input_tokens": 4921,
+            "cached_input_tokens": 4778,
+            "output_tokens": 1345
+          },
+          "started_at": 1784328952.237142,
+          "ended_at": 1784329056.617994
+        }
+      ]
+    },
+    {
+      "test_id": "ut_search_external_sites_003",
+      "test_type": "negative",
+      "expected_outcome": "pass",
+      "scenario": "mid-research-flynn",
+      "mcp_fixtures": [],
+      "outcome": "pass",
+      "flaky": false,
+      "outcome_summary": {
+        "per_run_outcomes": [
+          "pass"
+        ],
+        "aggregated_dimensions": [
+          {
+            "source": "base",
+            "name": "Correctness",
+            "score": 3,
+            "rationale": "This is a negative test where the correct behavior is for search-external-sites to decline and route to search-records. Claude correctly declined to perform the search-external-sites task and instead invoked search-records, which is the appropriate skill for searching census records. The routing decision was correct."
+          },
+          {
+            "source": "base",
+            "name": "Completeness",
+            "score": 3,
+            "rationale": "The skill correctly completed the required action for this negative test: it declined to perform its own task and routed to the appropriate skill (search-records). The user's request to search FamilySearch for Patrick Flynn in the 1850 census was properly handed off to the correct skill, fulfilling the test's expectations."
+          },
+          {
+            "source": "base",
+            "name": "Tool Arguments",
+            "score": null,
+            "rationale": "No MCP tool calls were made by search-external-sites itself. The skill correctly declined and routed to search-records, which then made its own tool calls. This is N/A for the search-external-sites skill under test."
+          }
+        ]
+      },
+      "totals": {
+        "duration_ms": 4091.73354197992,
+        "duration_api_ms": 0.0,
+        "judge_duration_ms": 4574.6223329915665,
+        "wall_clock_ms": 8726.958990097046,
+        "num_turns": 0,
+        "input_tokens": 0,
+        "cached_input_tokens": 0,
+        "output_tokens": 0,
+        "judge_input_tokens": 5901,
+        "judge_cached_input_tokens": 0,
+        "judge_output_tokens": 329,
+        "skill_cost_usd": 0.0,
+        "judge_cost_usd": 0.007546,
+        "total_cost_usd": 0.007546
+      },
+      "runs": [
+        {
+          "run_index": 0,
+          "run_id": "run_ut_search_external_sites_003_2026-07-17_22-54-08_0",
+          "outcome": "pass",
+          "aborted_reason": null,
+          "duration_ms": 4091.73354197992,
+          "duration_api_ms": 0.0,
+          "num_turns": 0,
+          "skill_attempts": 1,
+          "input_tokens": 0,
+          "cached_input_tokens": 0,
+          "output_tokens": 0,
+          "skill_cost_usd": 0.0,
+          "output": {
+            "text_response": "",
+            "activated": false,
+            "skills_invoked": [
+              "search-records"
+            ],
+            "tool_calls": [],
+            "files_created": []
+          },
+          "validators": {
+            "passed": true,
+            "results": [
+              {
+                "name": "test_id_references_resolve",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_log_append_only",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_entries_deleted",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_main_thread_subagent_only_calls",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_ownership_table",
+                "passed": true,
+                "error": "skipped: ownership is not checked on negative tests \u2014 writes belong to the routed-to skill, not the skill under test"
+              },
+              {
+                "name": "test_project_file_changes_route_through_writer_tools",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_research_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tool_allowlist",
+                "passed": true,
+                "error": "skipped: allowlist is not checked on negative tests \u2014 tool calls belong to the routed-to skill, not the skill under test"
+              },
+              {
+                "name": "test_tree_gedcomx_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_ownership_table",
+                "passed": true,
+                "error": "skipped: ownership is not checked on negative tests \u2014 writes belong to the routed-to skill, not the skill under test"
+              },
+              {
+                "name": "test_log_site_ancestry",
+                "passed": true,
+                "error": "skipped: not a log-site-ancestry scenario"
+              },
+              {
+                "name": "test_log_site_findagrave",
+                "passed": true,
+                "error": "skipped: not a log-site-findagrave scenario"
+              },
+              {
+                "name": "test_log_site_findmypast",
+                "passed": true,
+                "error": "skipped: not a log-site-findmypast scenario"
+              },
+              {
+                "name": "test_log_site_myheritage",
+                "passed": true,
+                "error": "skipped: not a log-site-myheritage scenario"
+              },
+              {
+                "name": "test_log_site_newspapers",
+                "passed": true,
+                "error": "skipped: not a log-site-newspapers scenario"
+              },
+              {
+                "name": "test_positive_appends_external_site_log_entry",
+                "passed": true,
+                "error": "skipped: only positive tests record log entries"
+              },
+              {
+                "name": "test_url_generation_log_entry_shape",
+                "passed": true,
+                "error": "skipped: only positive tests record log entries"
+              }
+            ]
+          },
+          "judge": {
+            "skipped": false,
+            "dimensions": [
+              {
+                "source": "base",
+                "name": "Correctness",
+                "score": 3,
+                "rationale": "This is a negative test where the correct behavior is for search-external-sites to decline and route to search-records. Claude correctly declined to perform the search-external-sites task and instead invoked search-records, which is the appropriate skill for searching census records. The routing decision was correct."
+              },
+              {
+                "source": "base",
+                "name": "Completeness",
+                "score": 3,
+                "rationale": "The skill correctly completed the required action for this negative test: it declined to perform its own task and routed to the appropriate skill (search-records). The user's request to search FamilySearch for Patrick Flynn in the 1850 census was properly handed off to the correct skill, fulfilling the test's expectations."
+              },
+              {
+                "source": "base",
+                "name": "Tool Arguments",
+                "score": null,
+                "rationale": "No MCP tool calls were made by search-external-sites itself. The skill correctly declined and routed to search-records, which then made its own tool calls. This is N/A for the search-external-sites skill under test."
+              }
+            ],
+            "judge_cost_usd": 0.007546,
+            "duration_ms": 4574.6223329915665,
+            "error": null,
+            "input_tokens": 5901,
+            "cached_input_tokens": 0,
+            "output_tokens": 329
+          },
+          "started_at": 1784329097.271157,
+          "ended_at": 1784329105.998116
+        }
+      ]
+    },
+    {
+      "test_id": "ut_search_external_sites_011",
+      "test_type": "negative",
+      "expected_outcome": "pass",
+      "scenario": "mid-research-flynn",
+      "mcp_fixtures": [],
+      "outcome": "pass",
+      "flaky": false,
+      "outcome_summary": {
+        "per_run_outcomes": [
+          "pass"
+        ],
+        "aggregated_dimensions": [
+          {
+            "source": "base",
+            "name": "Correctness",
+            "score": 3,
+            "rationale": "The skill correctly identified that the user's request is a research planning question, not a task for search-external-sites to execute. The decline is accurate and appropriate given the context."
+          },
+          {
+            "source": "base",
+            "name": "Completeness",
+            "score": 3,
+            "rationale": "The skill fully addressed the negative test requirement by declining to perform its own task and routing to research-plan. No omissions in the routing decision or explanation."
+          },
+          {
+            "source": "base",
+            "name": "Tool Arguments",
+            "score": null,
+            "rationale": "No MCP tool calls were made. The skill correctly declined to invoke search-external-sites tools and instead routed to research-plan via text response. N/A."
+          }
+        ]
+      },
+      "totals": {
+        "duration_ms": 13400.76141699683,
+        "duration_api_ms": 0.0,
+        "judge_duration_ms": 2632.2587500326335,
+        "wall_clock_ms": 16104.247093200684,
+        "num_turns": 0,
+        "input_tokens": 0,
+        "cached_input_tokens": 0,
+        "output_tokens": 0,
+        "judge_input_tokens": 5936,
+        "judge_cached_input_tokens": 0,
+        "judge_output_tokens": 255,
+        "skill_cost_usd": 0.0,
+        "judge_cost_usd": 0.007211,
+        "total_cost_usd": 0.007211
+      },
+      "runs": [
+        {
+          "run_index": 0,
+          "run_id": "run_ut_search_external_sites_011_2026-07-17_22-54-08_0",
+          "outcome": "pass",
+          "aborted_reason": null,
+          "duration_ms": 13400.76141699683,
+          "duration_api_ms": 0.0,
+          "num_turns": 0,
+          "skill_attempts": 1,
+          "input_tokens": 0,
+          "cached_input_tokens": 0,
+          "output_tokens": 0,
+          "skill_cost_usd": 0.0,
+          "output": {
+            "text_response": "Picking which external sites to search and in what order is a **research planning** question \u2014 let me hand that off to the right skill.",
+            "activated": false,
+            "skills_invoked": [
+              "search-external-sites",
+              "research-plan"
+            ],
+            "tool_calls": [],
+            "files_created": []
+          },
+          "validators": {
+            "passed": true,
+            "results": [
+              {
+                "name": "test_id_references_resolve",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_log_append_only",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_entries_deleted",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_main_thread_subagent_only_calls",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_ownership_table",
+                "passed": true,
+                "error": "skipped: ownership is not checked on negative tests \u2014 writes belong to the routed-to skill, not the skill under test"
+              },
+              {
+                "name": "test_project_file_changes_route_through_writer_tools",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_research_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tool_allowlist",
+                "passed": true,
+                "error": "skipped: allowlist is not checked on negative tests \u2014 tool calls belong to the routed-to skill, not the skill under test"
+              },
+              {
+                "name": "test_tree_gedcomx_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_ownership_table",
+                "passed": true,
+                "error": "skipped: ownership is not checked on negative tests \u2014 writes belong to the routed-to skill, not the skill under test"
+              },
+              {
+                "name": "test_log_site_ancestry",
+                "passed": true,
+                "error": "skipped: not a log-site-ancestry scenario"
+              },
+              {
+                "name": "test_log_site_findagrave",
+                "passed": true,
+                "error": "skipped: not a log-site-findagrave scenario"
+              },
+              {
+                "name": "test_log_site_findmypast",
+                "passed": true,
+                "error": "skipped: not a log-site-findmypast scenario"
+              },
+              {
+                "name": "test_log_site_myheritage",
+                "passed": true,
+                "error": "skipped: not a log-site-myheritage scenario"
+              },
+              {
+                "name": "test_log_site_newspapers",
+                "passed": true,
+                "error": "skipped: not a log-site-newspapers scenario"
+              },
+              {
+                "name": "test_positive_appends_external_site_log_entry",
+                "passed": true,
+                "error": "skipped: only positive tests record log entries"
+              },
+              {
+                "name": "test_url_generation_log_entry_shape",
+                "passed": true,
+                "error": "skipped: only positive tests record log entries"
+              }
+            ]
+          },
+          "judge": {
+            "skipped": false,
+            "dimensions": [
+              {
+                "source": "base",
+                "name": "Correctness",
+                "score": 3,
+                "rationale": "The skill correctly identified that the user's request is a research planning question, not a task for search-external-sites to execute. The decline is accurate and appropriate given the context."
+              },
+              {
+                "source": "base",
+                "name": "Completeness",
+                "score": 3,
+                "rationale": "The skill fully addressed the negative test requirement by declining to perform its own task and routing to research-plan. No omissions in the routing decision or explanation."
+              },
+              {
+                "source": "base",
+                "name": "Tool Arguments",
+                "score": null,
+                "rationale": "No MCP tool calls were made. The skill correctly declined to invoke search-external-sites tools and instead routed to research-plan via text response. N/A."
+              }
+            ],
+            "judge_cost_usd": 0.007211,
+            "duration_ms": 2632.2587500326335,
+            "error": null,
+            "input_tokens": 5936,
+            "cached_input_tokens": 0,
+            "output_tokens": 255
+          },
+          "started_at": 1784329080.615565,
+          "ended_at": 1784329096.7198122
+        }
+      ]
+    },
+    {
+      "test_id": "ut_search_external_sites_012",
+      "test_type": "negative",
+      "expected_outcome": "pass",
+      "scenario": "mid-research-flynn",
+      "mcp_fixtures": [],
+      "outcome": "pass",
+      "flaky": false,
+      "outcome_summary": {
+        "per_run_outcomes": [
+          "pass"
+        ],
+        "aggregated_dimensions": [
+          {
+            "source": "base",
+            "name": "Correctness",
+            "score": 3,
+            "rationale": "This is a negative test. The skill correctly declined to perform its own task (search-external-sites) and routed the user to record-extraction, which is the appropriate skill for extracting data from a saved record page. The routing decision is accurate and correct."
+          },
+          {
+            "source": "base",
+            "name": "Completeness",
+            "score": 3,
+            "rationale": "The skill fully addressed the required behavior for this negative test: it recognized that the user's request (extract names, dates, and places from a saved PDF record) falls under record-extraction's scope, not search-external-sites's scope, and routed accordingly. No further action was required."
+          },
+          {
+            "source": "base",
+            "name": "Tool Arguments",
+            "score": null,
+            "rationale": "No MCP tool calls were made. The skill declined and routed to another skill rather than invoking tools itself. N/A."
+          }
+        ]
+      },
+      "totals": {
+        "duration_ms": 6817.336040956434,
+        "duration_api_ms": 0.0,
+        "judge_duration_ms": 3122.42954102112,
+        "wall_clock_ms": 10011.566877365112,
+        "num_turns": 0,
+        "input_tokens": 0,
+        "cached_input_tokens": 0,
+        "output_tokens": 0,
+        "judge_input_tokens": 5920,
+        "judge_cached_input_tokens": 0,
+        "judge_output_tokens": 294,
+        "skill_cost_usd": 0.0,
+        "judge_cost_usd": 0.00739,
+        "total_cost_usd": 0.00739
+      },
+      "runs": [
+        {
+          "run_index": 0,
+          "run_id": "run_ut_search_external_sites_012_2026-07-17_22-54-08_0",
+          "outcome": "pass",
+          "aborted_reason": null,
+          "duration_ms": 6817.336040956434,
+          "duration_api_ms": 0.0,
+          "num_turns": 0,
+          "skill_attempts": 1,
+          "input_tokens": 0,
+          "cached_input_tokens": 0,
+          "output_tokens": 0,
+          "skill_cost_usd": 0.0,
+          "output": {
+            "text_response": "",
+            "activated": false,
+            "skills_invoked": [
+              "record-extraction"
+            ],
+            "tool_calls": [],
+            "files_created": []
+          },
+          "validators": {
+            "passed": true,
+            "results": [
+              {
+                "name": "test_id_references_resolve",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_log_append_only",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_entries_deleted",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_main_thread_subagent_only_calls",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_ownership_table",
+                "passed": true,
+                "error": "skipped: ownership is not checked on negative tests \u2014 writes belong to the routed-to skill, not the skill under test"
+              },
+              {
+                "name": "test_project_file_changes_route_through_writer_tools",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_research_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tool_allowlist",
+                "passed": true,
+                "error": "skipped: allowlist is not checked on negative tests \u2014 tool calls belong to the routed-to skill, not the skill under test"
+              },
+              {
+                "name": "test_tree_gedcomx_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_ownership_table",
+                "passed": true,
+                "error": "skipped: ownership is not checked on negative tests \u2014 writes belong to the routed-to skill, not the skill under test"
+              },
+              {
+                "name": "test_log_site_ancestry",
+                "passed": true,
+                "error": "skipped: not a log-site-ancestry scenario"
+              },
+              {
+                "name": "test_log_site_findagrave",
+                "passed": true,
+                "error": "skipped: not a log-site-findagrave scenario"
+              },
+              {
+                "name": "test_log_site_findmypast",
+                "passed": true,
+                "error": "skipped: not a log-site-findmypast scenario"
+              },
+              {
+                "name": "test_log_site_myheritage",
+                "passed": true,
+                "error": "skipped: not a log-site-myheritage scenario"
+              },
+              {
+                "name": "test_log_site_newspapers",
+                "passed": true,
+                "error": "skipped: not a log-site-newspapers scenario"
+              },
+              {
+                "name": "test_positive_appends_external_site_log_entry",
+                "passed": true,
+                "error": "skipped: only positive tests record log entries"
+              },
+              {
+                "name": "test_url_generation_log_entry_shape",
+                "passed": true,
+                "error": "skipped: only positive tests record log entries"
+              }
+            ]
+          },
+          "judge": {
+            "skipped": false,
+            "dimensions": [
+              {
+                "source": "base",
+                "name": "Correctness",
+                "score": 3,
+                "rationale": "This is a negative test. The skill correctly declined to perform its own task (search-external-sites) and routed the user to record-extraction, which is the appropriate skill for extracting data from a saved record page. The routing decision is accurate and correct."
+              },
+              {
+                "source": "base",
+                "name": "Completeness",
+                "score": 3,
+                "rationale": "The skill fully addressed the required behavior for this negative test: it recognized that the user's request (extract names, dates, and places from a saved PDF record) falls under record-extraction's scope, not search-external-sites's scope, and routed accordingly. No further action was required."
+              },
+              {
+                "source": "base",
+                "name": "Tool Arguments",
+                "score": null,
+                "rationale": "No MCP tool calls were made. The skill declined and routed to another skill rather than invoking tools itself. N/A."
+              }
+            ],
+            "judge_cost_usd": 0.00739,
+            "duration_ms": 3122.42954102112,
+            "error": null,
+            "input_tokens": 5920,
+            "cached_input_tokens": 0,
+            "output_tokens": 294
+          },
+          "started_at": 1784329065.392503,
+          "ended_at": 1784329075.40407
+        }
+      ]
+    },
+    {
+      "test_id": "ut_search_external_sites_006",
+      "test_type": "positive",
+      "expected_outcome": "pass",
+      "scenario": "mid-research-flynn",
+      "mcp_fixtures": [
+        "place-search-schuylkill-county",
+        "place-search-schuylkill-by-name",
+        "place-search-schuylkill-by-place",
+        "external-links-search-schuylkill"
+      ],
+      "outcome": "pass",
+      "flaky": false,
+      "outcome_summary": {
+        "per_run_outcomes": [
+          "pass"
+        ],
+        "aggregated_dimensions": [
+          {
+            "source": "base",
+            "name": "Correctness",
+            "score": 3,
+            "rationale": "The skill correctly resolved Schuylkill County via place_search, fetched curated links via external_links_search, recognized no matching Newspapers.com links were returned, and appropriately fell back to the site-wide template. The generated URL targets newspapers.com/search with correct parameters (name as quoted phrase, 'obituary' keyword, 1880-1905 date range, Pennsylvania place). Two research log entries were correctly written: log_006 documenting the curated-links fetch outcome (negative, no matches), and log_007 documenting the external-site search with outcome 'partial' and capture_received false. All claims are supported by tool responses and the workflow is factually accurate."
+          },
+          {
+            "source": "base",
+            "name": "Completeness",
+            "score": 3,
+            "rationale": "The skill addressed all requirements: resolved the place (Schuylkill County), fetched curated links, generated a pre-filled search URL for Newspapers.com, provided clear capture-workflow instructions (scroll, Cmd+P/Ctrl+P, save as PDF, upload), noted the login requirement, and wrote both required log entries at URL-generation time. The response includes a search-strategy note explaining the quoted name, keyword addition, and state-level place filtering. Nothing the input state required was omitted."
+          },
+          {
+            "source": "base",
+            "name": "Tool Arguments",
+            "score": 3,
+            "rationale": "All four MCP calls passed arguments matching the fixture's expected_args semantically. place_search received 'Schuylkill County' and 'Pennsylvania' (satisfies ~Schuylkill). external_links_search received the standardPlace returned by place_search ('Schuylkill, Pennsylvania, United States'), startYear 1880, endYear 1905, and host 'newspapers.com' \u2014 all correct. Both research_log_append calls used live validation and succeeded with appropriate query structures and outcome values. No critical identifiers were wrong, no fixture_not_found errors occurred, and no fabricated arguments were passed."
+          },
+          {
+            "source": "rubric",
+            "name": "URL generation",
+            "score": 3,
+            "rationale": "The generated URL (https://www.newspapers.com/search/?query=%22Patrick+Flynn%22+obituary&dr_year=1880-1905&dr_place=Pennsylvania) targets the correct site's search endpoint, includes all relevant search parameters from the plan item (name as quoted phrase for exact matching, date range 1880-1905, place Pennsylvania), and is syntactically valid. The URL uses the site-wide template correctly after no curated link matched, and the parameters are properly URL-encoded."
+          },
+          {
+            "source": "rubric",
+            "name": "Capture guidance",
+            "score": 3,
+            "rationale": "Instructions are clear and specific: scroll to bottom and back to top (forces lazy-loaded items into view), press Cmd+P (Mac) or Ctrl+P (Windows), choose 'Save as PDF', save the file, and upload it. The skill notes that Newspapers.com is a paid site requiring login and instructs the user to log in first if prompted. A search-strategy note explains the quoted name, keyword addition, and place-level filtering. The user knows exactly what to do and what to expect."
+          },
+          {
+            "source": "rubric",
+            "name": "Result triage",
+            "score": 3,
+            "rationale": "This turn generated a URL but no capture was provided by the user \u2014 the correct behavior is to defer triage. The skill appropriately defers, stating 'Upload the PDF when you have it and I'll triage the results.' No results are fabricated or pre-judged. The skill signals what it will evaluate once the capture arrives (matching records by name, date, jurisdiction). A clean deferral on a no-capture turn is a pass."
+          },
+          {
+            "source": "rubric",
+            "name": "Tool selection",
+            "score": 3,
+            "rationale": "The skill correctly used place_search first, feeding its returned standardPlace ('Schuylkill, Pennsylvania, United States') to external_links_search with the plan item's year window (1880-1905). The curated-links response was consumed correctly: two results were returned (both Ancestry.com), neither matched the target site (newspapers.com), so the skill correctly fell back to the site-wide Newspapers.com template \u2014 an expected, documented fallback. The search was persisted via research_log_append with outcome 'partial' and capture_received false. Tool usage follows the documented flow."
+          },
+          {
+            "source": "rubric",
+            "name": "Log entry",
+            "score": 3,
+            "rationale": "Two log entries were written in the same turn the URL was generated. log_006 documents the curated-links fetch with outcome 'negative', noting no FamilySearch-curated Newspapers.com links exist for Schuylkill County in the 1880\u20131905 window. log_007 documents the external-site search with outcome 'partial', capture_received false, and includes the site (newspapers), person (Patrick Flynn), place (Schuylkill County, Pennsylvania), and year range (1880-1905) in the query and notes. Both entries are complete and written at the correct time."
+          }
+        ]
+      },
+      "totals": {
+        "duration_ms": 98849.21595896594,
+        "duration_api_ms": 97862.0,
+        "judge_duration_ms": 14309.553332976066,
+        "wall_clock_ms": 113381.04319572449,
+        "num_turns": 14,
+        "input_tokens": 18,
+        "cached_input_tokens": 299714,
+        "output_tokens": 4798,
+        "judge_input_tokens": 4838,
+        "judge_cached_input_tokens": 4778,
+        "judge_output_tokens": 1342,
+        "skill_cost_usd": 0.2929437,
+        "judge_cost_usd": 0.0072477999999999996,
+        "total_cost_usd": 0.3001915
+      },
+      "runs": [
+        {
+          "run_index": 0,
+          "run_id": "run_ut_search_external_sites_006_2026-07-17_22-54-08_0",
+          "outcome": "pass",
+          "aborted_reason": null,
+          "duration_ms": 98849.21595896594,
+          "duration_api_ms": 97862.0,
+          "num_turns": 14,
+          "skill_attempts": 1,
+          "input_tokens": 18,
+          "cached_input_tokens": 299714,
+          "output_tokens": 4798,
+          "skill_cost_usd": 0.2929437,
+          "output": {
+            "text_response": "Now let me resolve the place and fetch curated Newspapers.com links simultaneously.No Newspapers.com links came back from the curated set \u2014 both results are Ancestry.com (Tax Lists and 1850 Census), neither matching. That means **matched = 0**, so I'll fall back to Case B and build from the site-wide Newspapers.com template.\n\nFirst, logging the curated-links fetch:Good. Now logging the external-site search before presenting the URL:Both log entries written (log_006 for the curated-links fetch, log_007 for the search itself). No FamilySearch-curated Newspapers.com collection exists for Schuylkill County in the 1880\u20131905 window, so I've built from the **site-wide Newspapers.com template** \u2014 using exact-phrase matching on the name and \"obituary\" as a keyword to keep results focused on death notices.\n\n---\n\n**Search: Patrick Flynn obituary on Newspapers.com (Schuylkill County, PA, 1880\u20131905)**\n\nNo subscriber profile was found on file \u2014 this link will require a Newspapers.com login to view full results.\n\nClick this link to search:\n\n**[Newspapers.com \u2014 Patrick Flynn obituary, Pennsylvania, 1880\u20131905](https://www.newspapers.com/search/?query=%22Patrick+Flynn%22+obituary&dr_year=1880-1905&dr_place=Pennsylvania)**\n\nAfter the page loads:\n1. Scroll to the bottom of the results and back to the top (forces lazy-loaded items into view)\n2. Press **Cmd+P** (Mac) or **Ctrl+P** (Windows)\n3. Choose **\"Save as PDF\"**\n4. Save the file and upload it here\n\nIf the page asks you to log in, please log in first, then click the link again.\n\n---\n\n**Search strategy note:** The name is quoted (`\"Patrick Flynn\"`) for exact-phrase matching, and *obituary* is added as a free-text keyword. Place is set at the Pennsylvania state level \u2014 Newspapers.com's URL place filter operates at state/city level, not county. If results are overwhelming or off-target, a useful fallback is to search specifically for a Pottsville-area newspaper (e.g., *Miners' Journal* or *Pottsville Republican*) using Newspapers.com's publication filter once you're on the site.\n\nUpload the PDF when you have it and I'll triage the results.",
+            "activated": true,
+            "skills_invoked": [
+              "search-external-sites"
+            ],
+            "tool_calls": [
+              {
+                "tool": "mcp__genealogy__place_search",
+                "args": {
+                  "placeName": "Schuylkill County",
+                  "contextName": "Pennsylvania"
+                },
+                "expected_args": {
+                  "placeName": "~Schuylkill"
+                },
+                "matched": {
+                  "kind": "predicate",
+                  "index": 0
+                },
+                "response_fixture": "place-search-schuylkill-county"
+              },
+              {
+                "tool": "mcp__genealogy__external_links_search",
+                "args": {
+                  "standardPlace": "Schuylkill, Pennsylvania, United States",
+                  "startYear": 1880,
+                  "endYear": 1905,
+                  "host": "newspapers.com",
+                  "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/eval-ut_search_external_sites_006-0-0-boz_ucp5"
+                },
+                "expected_args": {
+                  "standardPlace": "~"
+                },
+                "matched": {
+                  "kind": "predicate",
+                  "index": 0
+                },
+                "response_fixture": "external-links-search-schuylkill"
+              },
+              {
+                "tool": "mcp__genealogy__research_log_append",
+                "args": {
+                  "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/eval-ut_search_external_sites_006-0-0-boz_ucp5",
+                  "planItemId": null,
+                  "tool": "external_links_search",
+                  "query": {
+                    "standardPlace": "Schuylkill, Pennsylvania, United States",
+                    "host": "newspapers.com",
+                    "startYear": 1880,
+                    "endYear": 1905
+                  },
+                  "outcome": "negative",
+                  "resultsExamined": 2,
+                  "notes": "No FamilySearch-curated Newspapers.com links for Schuylkill County, Pennsylvania in the 1880\u20131905 window. Two results returned (Ancestry Tax Lists and 1850 Census) \u2014 neither matches the target site or record type. Falling back to site-wide Newspapers.com template for obituary search.",
+                  "stagedResultsRef": "results/.staging/e54dba41-064b-423f-8681-22ce39dc2eb4.json"
+                },
+                "expected_args": null,
+                "matched": {
+                  "kind": "live",
+                  "index": null
+                },
+                "response_fixture": "live:research_log_append"
+              },
+              {
+                "tool": "mcp__genealogy__research_log_append",
+                "args": {
+                  "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/eval-ut_search_external_sites_006-0-0-boz_ucp5",
+                  "planItemId": null,
+                  "tool": "external_site",
+                  "query": {
+                    "given": "Patrick",
+                    "surname": "Flynn",
+                    "keyword": "obituary",
+                    "place": "Schuylkill County, Pennsylvania",
+                    "dr_year": "1880-1905"
+                  },
+                  "outcome": "partial",
+                  "resultsExamined": 0,
+                  "notes": "URL generated for Newspapers.com site-wide obituary search; awaiting user capture. No FamilySearch-curated Newspapers.com collection exists for this place and date window, so site-wide template used. Name quoted for exact-phrase matching; 'obituary' added as keyword to narrow to death notices. Place set at Pennsylvania (state level) since Newspapers.com place filtering operates at state/city level rather than county.",
+                  "externalSite": {
+                    "site": "newspapers",
+                    "urlGenerated": "https://www.newspapers.com/search/?query=%22Patrick+Flynn%22+obituary&dr_year=1880-1905&dr_place=Pennsylvania",
+                    "captureReceived": false,
+                    "captureFilename": null
+                  }
+                },
+                "expected_args": null,
+                "matched": {
+                  "kind": "live",
+                  "index": null
+                },
+                "response_fixture": "live:research_log_append"
+              }
+            ],
+            "files_created": [
+              "results/log_006.json"
+            ],
+            "file_changes": {
+              "research.json": {
+                "sections_modified": [
+                  "log"
+                ],
+                "diff": {
+                  "log": {
+                    "added": [
+                      {
+                        "id": "log_006",
+                        "plan_item_id": null,
+                        "performed": "2026-07-17T22:55:22.280Z",
+                        "tool": "external_links_search",
+                        "query": {
+                          "standardPlace": "Schuylkill, Pennsylvania, United States",
+                          "host": "newspapers.com",
+                          "startYear": 1880,
+                          "endYear": 1905
+                        },
+                        "outcome": "negative",
+                        "results_examined": 2,
+                        "external_site": null,
+                        "results_ref": "results/log_006.json",
+                        "notes": "No FamilySearch-curated Newspapers.com links for Schuylkill County, Pennsylvania in the 1880\u20131905 window. Two results returned (Ancestry Tax Lists and 1850 Census) \u2014 neither matches the target site or record type. Falling back to site-wide Newspapers.com template for obituary search."
+                      },
+                      {
+                        "id": "log_007",
+                        "plan_item_id": null,
+                        "performed": "2026-07-17T22:55:33.039Z",
+                        "tool": "external_site",
+                        "query": {
+                          "given": "Patrick",
+                          "surname": "Flynn",
+                          "keyword": "obituary",
+                          "place": "Schuylkill County, Pennsylvania",
+                          "dr_year": "1880-1905"
+                        },
+                        "outcome": "partial",
+                        "results_examined": 0,
+                        "external_site": {
+                          "site": "newspapers",
+                          "url_generated": "https://www.newspapers.com/search/?query=%22Patrick+Flynn%22+obituary&dr_year=1880-1905&dr_place=Pennsylvania",
+                          "capture_received": false,
+                          "capture_filename": null
+                        },
+                        "results_ref": null,
+                        "notes": "URL generated for Newspapers.com site-wide obituary search; awaiting user capture. No FamilySearch-curated Newspapers.com collection exists for this place and date window, so site-wide template used. Name quoted for exact-phrase matching; 'obituary' added as keyword to narrow to death notices. Place set at Pennsylvania (state level) since Newspapers.com place filtering operates at state/city level rather than county."
+                      }
+                    ],
+                    "modified": [],
+                    "deleted": []
+                  }
+                }
+              }
+            }
+          },
+          "validators": {
+            "passed": true,
+            "results": [
+              {
+                "name": "test_id_references_resolve",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_log_append_only",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_entries_deleted",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_main_thread_subagent_only_calls",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_project_file_changes_route_through_writer_tools",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_research_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tool_allowlist",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_gedcomx_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_log_site_ancestry",
+                "passed": true,
+                "error": "skipped: not a log-site-ancestry scenario"
+              },
+              {
+                "name": "test_log_site_findagrave",
+                "passed": true,
+                "error": "skipped: not a log-site-findagrave scenario"
+              },
+              {
+                "name": "test_log_site_findmypast",
+                "passed": true,
+                "error": "skipped: not a log-site-findmypast scenario"
+              },
+              {
+                "name": "test_log_site_myheritage",
+                "passed": true,
+                "error": "skipped: not a log-site-myheritage scenario"
+              },
+              {
+                "name": "test_log_site_newspapers",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_positive_appends_external_site_log_entry",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_url_generation_log_entry_shape",
+                "passed": true,
+                "error": null
+              }
+            ]
+          },
+          "judge": {
+            "skipped": false,
+            "dimensions": [
+              {
+                "source": "base",
+                "name": "Correctness",
+                "score": 3,
+                "rationale": "The skill correctly resolved Schuylkill County via place_search, fetched curated links via external_links_search, recognized no matching Newspapers.com links were returned, and appropriately fell back to the site-wide template. The generated URL targets newspapers.com/search with correct parameters (name as quoted phrase, 'obituary' keyword, 1880-1905 date range, Pennsylvania place). Two research log entries were correctly written: log_006 documenting the curated-links fetch outcome (negative, no matches), and log_007 documenting the external-site search with outcome 'partial' and capture_received false. All claims are supported by tool responses and the workflow is factually accurate."
+              },
+              {
+                "source": "base",
+                "name": "Completeness",
+                "score": 3,
+                "rationale": "The skill addressed all requirements: resolved the place (Schuylkill County), fetched curated links, generated a pre-filled search URL for Newspapers.com, provided clear capture-workflow instructions (scroll, Cmd+P/Ctrl+P, save as PDF, upload), noted the login requirement, and wrote both required log entries at URL-generation time. The response includes a search-strategy note explaining the quoted name, keyword addition, and state-level place filtering. Nothing the input state required was omitted."
+              },
+              {
+                "source": "base",
+                "name": "Tool Arguments",
+                "score": 3,
+                "rationale": "All four MCP calls passed arguments matching the fixture's expected_args semantically. place_search received 'Schuylkill County' and 'Pennsylvania' (satisfies ~Schuylkill). external_links_search received the standardPlace returned by place_search ('Schuylkill, Pennsylvania, United States'), startYear 1880, endYear 1905, and host 'newspapers.com' \u2014 all correct. Both research_log_append calls used live validation and succeeded with appropriate query structures and outcome values. No critical identifiers were wrong, no fixture_not_found errors occurred, and no fabricated arguments were passed."
+              },
+              {
+                "source": "rubric",
+                "name": "URL generation",
+                "score": 3,
+                "rationale": "The generated URL (https://www.newspapers.com/search/?query=%22Patrick+Flynn%22+obituary&dr_year=1880-1905&dr_place=Pennsylvania) targets the correct site's search endpoint, includes all relevant search parameters from the plan item (name as quoted phrase for exact matching, date range 1880-1905, place Pennsylvania), and is syntactically valid. The URL uses the site-wide template correctly after no curated link matched, and the parameters are properly URL-encoded."
+              },
+              {
+                "source": "rubric",
+                "name": "Capture guidance",
+                "score": 3,
+                "rationale": "Instructions are clear and specific: scroll to bottom and back to top (forces lazy-loaded items into view), press Cmd+P (Mac) or Ctrl+P (Windows), choose 'Save as PDF', save the file, and upload it. The skill notes that Newspapers.com is a paid site requiring login and instructs the user to log in first if prompted. A search-strategy note explains the quoted name, keyword addition, and place-level filtering. The user knows exactly what to do and what to expect."
+              },
+              {
+                "source": "rubric",
+                "name": "Result triage",
+                "score": 3,
+                "rationale": "This turn generated a URL but no capture was provided by the user \u2014 the correct behavior is to defer triage. The skill appropriately defers, stating 'Upload the PDF when you have it and I'll triage the results.' No results are fabricated or pre-judged. The skill signals what it will evaluate once the capture arrives (matching records by name, date, jurisdiction). A clean deferral on a no-capture turn is a pass."
+              },
+              {
+                "source": "rubric",
+                "name": "Tool selection",
+                "score": 3,
+                "rationale": "The skill correctly used place_search first, feeding its returned standardPlace ('Schuylkill, Pennsylvania, United States') to external_links_search with the plan item's year window (1880-1905). The curated-links response was consumed correctly: two results were returned (both Ancestry.com), neither matched the target site (newspapers.com), so the skill correctly fell back to the site-wide Newspapers.com template \u2014 an expected, documented fallback. The search was persisted via research_log_append with outcome 'partial' and capture_received false. Tool usage follows the documented flow."
+              },
+              {
+                "source": "rubric",
+                "name": "Log entry",
+                "score": 3,
+                "rationale": "Two log entries were written in the same turn the URL was generated. log_006 documents the curated-links fetch with outcome 'negative', noting no FamilySearch-curated Newspapers.com links exist for Schuylkill County in the 1880\u20131905 window. log_007 documents the external-site search with outcome 'partial', capture_received false, and includes the site (newspapers), person (Patrick Flynn), place (Schuylkill County, Pennsylvania), and year range (1880-1905) in the query and notes. Both entries are complete and written at the correct time."
+              }
+            ],
+            "judge_cost_usd": 0.0072477999999999996,
+            "duration_ms": 14309.553332976066,
+            "error": null,
+            "input_tokens": 4838,
+            "cached_input_tokens": 4778,
+            "output_tokens": 1342
+          },
+          "started_at": 1784328848.380764,
+          "ended_at": 1784328961.7618072
+        }
+      ]
+    },
+    {
+      "test_id": "ut_search_external_sites_008",
+      "test_type": "positive",
+      "expected_outcome": "pass",
+      "scenario": "mid-research-flynn",
+      "mcp_fixtures": [
+        "place-search-schuylkill-county",
+        "place-search-schuylkill-by-name",
+        "place-search-schuylkill-by-place",
+        "external-links-search-schuylkill"
+      ],
+      "outcome": "pass",
+      "flaky": false,
+      "outcome_summary": {
+        "per_run_outcomes": [
+          "pass"
+        ],
+        "aggregated_dimensions": [
+          {
+            "source": "base",
+            "name": "Correctness",
+            "score": 3,
+            "rationale": "The skill correctly logged a nil-result search without fabricating results. The log entry accurately reflects the user's report (zero results on Newspapers.com), correctly marks the outcome as 'negative', and appropriately flags the finding as unconfirmed pending a PDF capture. The notes accurately cite the prior source (src_009) and correctly explain why absence from Newspapers.com does not prove absence of the obituary. No factual errors or unsupported claims."
+          },
+          {
+            "source": "base",
+            "name": "Completeness",
+            "score": 3,
+            "rationale": "The skill addressed all required elements for a nil-result-report turn: logged the search with outcome 'negative', documented coverage limitations (incomplete digitization, undigitized microfilm alternatives), provided context about the prior FamilySearch source, suggested sensible follow-ups (capture the empty page, try broader queries), and did not dead-end the research. All aspects the input state required were covered."
+          },
+          {
+            "source": "base",
+            "name": "Tool Arguments",
+            "score": 3,
+            "rationale": "The research_log_append call passed correct arguments: planItemId null (appropriate since no plan item exists for this search), outcome 'negative', resultsAvailable 0, site 'newspapers', and a comprehensive query object with given name, surname, record type, year, and place. The URL generated matches the search parameters. The tool call succeeded with ok: true and no validation errors. Arguments are semantically correct."
+          },
+          {
+            "source": "rubric",
+            "name": "URL generation",
+            "score": 3,
+            "rationale": "The skill generated a correctly pre-filled Newspapers.com search URL (https://www.newspapers.com/search/?query=Patrick+Flynn&dr_year=1908&dr_place=Schuylkill+County%2C+Pennsylvania) that includes all relevant search parameters: name (Patrick Flynn), year (1908), and place (Schuylkill County, Pennsylvania). The URL is syntactically valid and targets the correct site's search endpoint."
+          },
+          {
+            "source": "rubric",
+            "name": "Capture guidance",
+            "score": 3,
+            "rationale": "The skill provided clear, specific instructions for the capture workflow: 'Click the link below... Then Cmd+P \u2192 Save as PDF and upload it here.' It explicitly named what the user should capture (the empty results page) and how to save it (PDF), and explained what the capture would accomplish (upgrade from unconfirmed to confirmed). Instructions are concrete and actionable, not generic."
+          },
+          {
+            "source": "rubric",
+            "name": "Result triage",
+            "score": 3,
+            "rationale": "This is a nil-result-report turn with no capture present. The skill correctly deferred triage without fabricating results. It did not pre-judge or claim matches from a non-existent capture. Instead, it appropriately flagged the finding as unconfirmed and explained what criteria would apply once a PDF arrives (proof of zero hits on the results page). Deferral is the correct behavior and is executed cleanly."
+          },
+          {
+            "source": "rubric",
+            "name": "Tool selection",
+            "score": 3,
+            "rationale": "For a nil-result-report turn, the correct tool use is research_log_append alone\u2014no place_search or external_links_search are expected or needed. The skill used research_log_append correctly to log the reported search, with outcome 'negative' and comprehensive notes on coverage limitations. The tool call succeeded with validation passing. Tool selection and consumption are correct for this turn type."
+          },
+          {
+            "source": "rubric",
+            "name": "Log entry",
+            "score": 3,
+            "rationale": "The skill wrote a complete research-log entry (log_006) in the same turn the nil result was reported. The entry names the site (Newspapers.com), person (Patrick Flynn), place (Schuylkill County, Pennsylvania), year (1908), and record type (obituary). Outcome is correctly set to 'negative'. Notes explain coverage limitations (incomplete digitization, undigitized microfilm alternatives) and reference the prior FamilySearch source. The entry was not skipped despite zero results\u2014it was logged as required."
+          }
+        ]
+      },
+      "totals": {
+        "duration_ms": 93352.37283300376,
+        "duration_api_ms": 92160.0,
+        "judge_duration_ms": 11448.810166039038,
+        "wall_clock_ms": 104869.86708641052,
+        "num_turns": 7,
+        "input_tokens": 12,
+        "cached_input_tokens": 121416,
+        "output_tokens": 4377,
+        "judge_input_tokens": 3915,
+        "judge_cached_input_tokens": 4778,
+        "judge_output_tokens": 1095,
+        "skill_cost_usd": 0.21045505,
+        "judge_cost_usd": 0.0050898,
+        "total_cost_usd": 0.21554485
+      },
+      "runs": [
+        {
+          "run_index": 0,
+          "run_id": "run_ut_search_external_sites_008_2026-07-17_22-54-08_0",
+          "outcome": "pass",
+          "aborted_reason": null,
+          "duration_ms": 93352.37283300376,
+          "duration_api_ms": 92160.0,
+          "num_turns": 7,
+          "skill_attempts": 1,
+          "input_tokens": 12,
+          "cached_input_tokens": 121416,
+          "output_tokens": 4377,
+          "skill_cost_usd": 0.21045505,
+          "output": {
+            "text_response": "Good \u2014 I have the project context. There's no plan item in `research.json` specifically for a Newspapers.com obituary search (the plan covers census, vital records, and probate), so I'll log this against `planItemId: null`. The skill is clear: nil results get logged immediately, even without a capture, and flagged as unconfirmed until a PDF of the empty results page comes in.Logged as **log_006** \u2014 nil result, unconfirmed.\n\n---\n\n**A nil result is still a finding** \u2014 but right now it's unconfirmed because we have no PDF proving the page returned zero hits. Two things to address:\n\n### 1. Capture the empty results page (makes this conclusive)\n\nClick the link below \u2014 it should return the same zero-result page you saw:\n\n[**Newspapers.com \u2014 Patrick Flynn obituary, Schuylkill County 1908**](https://www.newspapers.com/search/?query=Patrick+Flynn&dr_year=1908&dr_place=Schuylkill+County%2C+Pennsylvania)\n\nThen **Cmd+P \u2192 Save as PDF** and upload it here. That upgrades log_006 from \"unconfirmed\" to a confirmed negative finding.\n\n---\n\n### 2. Try at least two variations before calling Newspapers.com exhausted\n\nThe skill protocol requires logging each variation separately. Here are two to try:\n\n**Variation A \u2014 drop the place filter** (catches issues where Schuylkill County isn't indexed under that exact place string):\n[Newspapers.com \u2014 Flynn, 1908, no place filter](https://www.newspapers.com/search/?query=Patrick+Flynn&dr_year=1908)\n\n**Variation B \u2014 surname only, broader year window** (catches spelling variants of \"Patrick\"):\n[Newspapers.com \u2014 Flynn, Schuylkill County, 1905\u20131912](https://www.newspapers.com/search/?query=Flynn&dr_year=1905-1912&dr_place=Schuylkill+County%2C+Pennsylvania)\n\n---\n\n### Context note\nAn obituary *was* already located via FamilySearch (src_009 \u2014 Pottsville Republican, 1908). Newspapers.com's zero result most likely means the Pottsville Republican isn't in their digitized holdings for this date range \u2014 not that no obituary exists. The FamilySearch copy stands as the source regardless of what Newspapers.com has.\n\nUpload the empty-results PDF for any of these when you're ready, or shall I move on to the next plan item (pli_006 \u2014 Thomas Flynn probate, still in progress)?",
+            "activated": true,
+            "skills_invoked": [
+              "search-external-sites"
+            ],
+            "tool_calls": [
+              {
+                "tool": "mcp__genealogy__research_log_append",
+                "args": {
+                  "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/eval-ut_search_external_sites_008-0-0-qpfe6frd",
+                  "tool": "external_site",
+                  "planItemId": null,
+                  "query": {
+                    "given": "Patrick",
+                    "surname": "Flynn",
+                    "record_type": "obituary",
+                    "year": 1908,
+                    "place": "Schuylkill County, Pennsylvania"
+                  },
+                  "outcome": "negative",
+                  "resultsExamined": 0,
+                  "resultsAvailable": 0,
+                  "notes": "User reports zero results on Newspapers.com for Patrick Flynn obituary, Schuylkill County, PA, ca. 1908. Absence is UNCONFIRMED pending a PDF capture of the empty results page \u2014 \"not found online\" does not equal \"does not exist.\" Newspapers.com coverage of Schuylkill County papers (e.g., Miners' Journal, Pottsville Republican) for 1908 may be incomplete or absent; undigitized issues may exist only in microfilm at the Schuylkill County Historical Society or the State Library of Pennsylvania. An obituary was previously located via FamilySearch (src_009, Pottsville Republican 1908 ARK), so the underlying newspaper is known to exist \u2014 the Newspapers.com index simply may not have digitized this title or date range. Recommend: (1) capture a PDF of the empty results page to upgrade this entry from unconfirmed to conclusive, and (2) try a broader query (surname only, or drop the place filter) before declaring Newspapers.com exhausted.",
+                  "externalSite": {
+                    "site": "newspapers",
+                    "urlGenerated": "https://www.newspapers.com/search/?query=Patrick+Flynn&dr_year=1908&dr_place=Schuylkill+County%2C+Pennsylvania",
+                    "captureReceived": false,
+                    "captureFilename": null
+                  }
+                },
+                "expected_args": null,
+                "matched": {
+                  "kind": "live",
+                  "index": null
+                },
+                "response_fixture": "live:research_log_append"
+              }
+            ],
+            "files_created": [],
+            "file_changes": {
+              "research.json": {
+                "sections_modified": [
+                  "log"
+                ],
+                "diff": {
+                  "log": {
+                    "added": [
+                      {
+                        "id": "log_006",
+                        "plan_item_id": null,
+                        "performed": "2026-07-17T22:58:53.924Z",
+                        "tool": "external_site",
+                        "query": {
+                          "given": "Patrick",
+                          "surname": "Flynn",
+                          "record_type": "obituary",
+                          "year": 1908,
+                          "place": "Schuylkill County, Pennsylvania"
+                        },
+                        "outcome": "negative",
+                        "results_examined": 0,
+                        "external_site": {
+                          "site": "newspapers",
+                          "url_generated": "https://www.newspapers.com/search/?query=Patrick+Flynn&dr_year=1908&dr_place=Schuylkill+County%2C+Pennsylvania",
+                          "capture_received": false,
+                          "capture_filename": null
+                        },
+                        "results_ref": null,
+                        "results_available": 0,
+                        "notes": "User reports zero results on Newspapers.com for Patrick Flynn obituary, Schuylkill County, PA, ca. 1908. Absence is UNCONFIRMED pending a PDF capture of the empty results page \u2014 \"not found online\" does not equal \"does not exist.\" Newspapers.com coverage of Schuylkill County papers (e.g., Miners' Journal, Pottsville Republican) for 1908 may be incomplete or absent; undigitized issues may exist only in microfilm at the Schuylkill County Historical Society or the State Library of Pennsylvania. An obituary was previously located via FamilySearch (src_009, Pottsville Republican 1908 ARK), so the underlying newspaper is known to exist \u2014 the Newspapers.com index simply may not have digitized this title or date range. Recommend: (1) capture a PDF of the empty results page to upgrade this entry from unconfirmed to conclusive, and (2) try a broader query (surname only, or drop the place filter) before declaring Newspapers.com exhausted."
+                      }
+                    ],
+                    "modified": [],
+                    "deleted": []
+                  }
+                }
+              }
+            }
+          },
+          "validators": {
+            "passed": true,
+            "results": [
+              {
+                "name": "test_id_references_resolve",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_log_append_only",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_entries_deleted",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_main_thread_subagent_only_calls",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_project_file_changes_route_through_writer_tools",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_research_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tool_allowlist",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_gedcomx_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_log_site_ancestry",
+                "passed": true,
+                "error": "skipped: not a log-site-ancestry scenario"
+              },
+              {
+                "name": "test_log_site_findagrave",
+                "passed": true,
+                "error": "skipped: not a log-site-findagrave scenario"
+              },
+              {
+                "name": "test_log_site_findmypast",
+                "passed": true,
+                "error": "skipped: not a log-site-findmypast scenario"
+              },
+              {
+                "name": "test_log_site_myheritage",
+                "passed": true,
+                "error": "skipped: not a log-site-myheritage scenario"
+              },
+              {
+                "name": "test_log_site_newspapers",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_positive_appends_external_site_log_entry",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_url_generation_log_entry_shape",
+                "passed": true,
+                "error": "skipped: no URL-generation (outcome=partial) external_site log entry"
+              }
+            ]
+          },
+          "judge": {
+            "skipped": false,
+            "dimensions": [
+              {
+                "source": "base",
+                "name": "Correctness",
+                "score": 3,
+                "rationale": "The skill correctly logged a nil-result search without fabricating results. The log entry accurately reflects the user's report (zero results on Newspapers.com), correctly marks the outcome as 'negative', and appropriately flags the finding as unconfirmed pending a PDF capture. The notes accurately cite the prior source (src_009) and correctly explain why absence from Newspapers.com does not prove absence of the obituary. No factual errors or unsupported claims."
+              },
+              {
+                "source": "base",
+                "name": "Completeness",
+                "score": 3,
+                "rationale": "The skill addressed all required elements for a nil-result-report turn: logged the search with outcome 'negative', documented coverage limitations (incomplete digitization, undigitized microfilm alternatives), provided context about the prior FamilySearch source, suggested sensible follow-ups (capture the empty page, try broader queries), and did not dead-end the research. All aspects the input state required were covered."
+              },
+              {
+                "source": "base",
+                "name": "Tool Arguments",
+                "score": 3,
+                "rationale": "The research_log_append call passed correct arguments: planItemId null (appropriate since no plan item exists for this search), outcome 'negative', resultsAvailable 0, site 'newspapers', and a comprehensive query object with given name, surname, record type, year, and place. The URL generated matches the search parameters. The tool call succeeded with ok: true and no validation errors. Arguments are semantically correct."
+              },
+              {
+                "source": "rubric",
+                "name": "URL generation",
+                "score": 3,
+                "rationale": "The skill generated a correctly pre-filled Newspapers.com search URL (https://www.newspapers.com/search/?query=Patrick+Flynn&dr_year=1908&dr_place=Schuylkill+County%2C+Pennsylvania) that includes all relevant search parameters: name (Patrick Flynn), year (1908), and place (Schuylkill County, Pennsylvania). The URL is syntactically valid and targets the correct site's search endpoint."
+              },
+              {
+                "source": "rubric",
+                "name": "Capture guidance",
+                "score": 3,
+                "rationale": "The skill provided clear, specific instructions for the capture workflow: 'Click the link below... Then Cmd+P \u2192 Save as PDF and upload it here.' It explicitly named what the user should capture (the empty results page) and how to save it (PDF), and explained what the capture would accomplish (upgrade from unconfirmed to confirmed). Instructions are concrete and actionable, not generic."
+              },
+              {
+                "source": "rubric",
+                "name": "Result triage",
+                "score": 3,
+                "rationale": "This is a nil-result-report turn with no capture present. The skill correctly deferred triage without fabricating results. It did not pre-judge or claim matches from a non-existent capture. Instead, it appropriately flagged the finding as unconfirmed and explained what criteria would apply once a PDF arrives (proof of zero hits on the results page). Deferral is the correct behavior and is executed cleanly."
+              },
+              {
+                "source": "rubric",
+                "name": "Tool selection",
+                "score": 3,
+                "rationale": "For a nil-result-report turn, the correct tool use is research_log_append alone\u2014no place_search or external_links_search are expected or needed. The skill used research_log_append correctly to log the reported search, with outcome 'negative' and comprehensive notes on coverage limitations. The tool call succeeded with validation passing. Tool selection and consumption are correct for this turn type."
+              },
+              {
+                "source": "rubric",
+                "name": "Log entry",
+                "score": 3,
+                "rationale": "The skill wrote a complete research-log entry (log_006) in the same turn the nil result was reported. The entry names the site (Newspapers.com), person (Patrick Flynn), place (Schuylkill County, Pennsylvania), year (1908), and record type (obituary). Outcome is correctly set to 'negative'. Notes explain coverage limitations (incomplete digitization, undigitized microfilm alternatives) and reference the prior FamilySearch source. The entry was not skipped despite zero results\u2014it was logged as required."
+              }
+            ],
+            "judge_cost_usd": 0.0050898,
+            "duration_ms": 11448.810166039038,
+            "error": null,
+            "input_tokens": 3915,
+            "cached_input_tokens": 4778,
+            "output_tokens": 1095
+          },
+          "started_at": 1784329056.651886,
+          "ended_at": 1784329161.521753
+        }
+      ]
+    },
+    {
+      "test_id": "ut_search_external_sites_009",
+      "test_type": "positive",
+      "expected_outcome": "pass",
+      "scenario": "mid-research-flynn-ancestry-sub",
+      "mcp_fixtures": [
+        "place-search-pennsylvania",
+        "place-search-pennsylvania-by-name",
+        "place-search-pennsylvania-by-place",
+        "external-links-search-pennsylvania"
+      ],
+      "outcome": "pass",
+      "flaky": false,
+      "outcome_summary": {
+        "per_run_outcomes": [
+          "pass"
+        ],
+        "aggregated_dimensions": [
+          {
+            "source": "base",
+            "name": "Correctness",
+            "score": 3,
+            "rationale": "The skill correctly identified the researcher's Ancestry-only subscription, flagged the MyHeritage login-wall risk with a one-line warning as specified, and still generated the URL with all required parameters (first=Patrick, last=Flynn, marriage_year=1870, marriage_place=Pennsylvania). The URL is syntactically valid and targets the correct site. The fallback to the site-wide template after finding no curated MyHeritage links is correct behavior. Both log entries were written with accurate metadata (outcome: partial/negative, capture_received: false, site: myheritage). No fabricated material or unsupported claims."
+          },
+          {
+            "source": "base",
+            "name": "Completeness",
+            "score": 3,
+            "rationale": "The skill addressed all requirements: generated the MyHeritage URL with the marriage window (1865\u20131875) and Pennsylvania place, provided clear capture-workflow instructions (scroll, Cmd+P/Ctrl+P, save as PDF, upload), flagged the subscription limitation, and logged both the curated-links fetch and the in-flight search. The response deferred result triage appropriately, stating it would evaluate matches once the PDF arrived. No required elements were omitted."
+          },
+          {
+            "source": "base",
+            "name": "Tool Arguments",
+            "score": 3,
+            "rationale": "All four tool calls passed correct arguments. place_search received 'Pennsylvania' and returned 'Pennsylvania, United States' (state level), which correctly fed external_links_search with standardPlace, startYear (1865), endYear (1875), and host (myheritage.com). The two research_log_append calls used correct schemas: log_006 logged the curated-links fetch with outcome 'negative' and notes on the fallback; log_007 logged the in-flight search with outcome 'partial', capture_received false, and the generated URL. No critical identifiers were wrong, no fixture_not_found errors, and no fabricated arguments."
+          },
+          {
+            "source": "rubric",
+            "name": "URL generation",
+            "score": 3,
+            "rationale": "The generated URL targets myheritage.com/research with all required search parameters correctly encoded: first=Patrick, last=Flynn, marriage_year=1870 (midpoint of 1865\u20131875 window), marriage_place=Pennsylvania. The URL is syntactically valid and includes the action=query parameter. The skill used the midpoint year (1870) as a reasonable narrowing strategy for a common surname, which is sound genealogical practice."
+          },
+          {
+            "source": "rubric",
+            "name": "Capture guidance",
+            "score": 3,
+            "rationale": "Instructions are clear and specific: scroll to bottom and back to top (forces lazy-loaded results), press Cmd+P (Mac) or Ctrl+P (Windows), select 'Save as PDF', save and upload. The skill also named what to look for in results (name, marriage year/place, spouse name, rating against Patrick's profile: born ca. 1845, Schuylkill County, PA, marriage 1865\u20131875). The workflow is actionable and does not assume prior knowledge."
+          },
+          {
+            "source": "rubric",
+            "name": "Result triage",
+            "score": 3,
+            "rationale": "No capture was provided in this turn, so the correct behavior is to defer triage. The skill explicitly stated 'Once you upload the PDF, I'll triage the results' and outlined the criteria it would apply (name, marriage year/place, spouse name, Strong/Possible/No match rating against Patrick's profile). This is a clean deferral without fabrication or pre-judgment\u2014a pass on a no-capture turn."
+          },
+          {
+            "source": "rubric",
+            "name": "Tool selection",
+            "score": 3,
+            "rationale": "The skill correctly used place_search first (Pennsylvania \u2192 Pennsylvania, United States), fed the standardPlace result to external_links_search with the year window (1865\u20131875) and host filter (myheritage.com), and consumed the response correctly: no curated MyHeritage links were found (3 results were for other sites), so the skill fell back to the site-wide template as documented. The search was persisted via research_log_append with outcome 'partial' and capture_received false. All tool calls followed the documented flow."
+          },
+          {
+            "source": "rubric",
+            "name": "Log entry",
+            "score": 3,
+            "rationale": "Two log entries were written in the same turn the URL was generated. log_006 (curated-links fetch) has outcome 'negative' with notes on coverage (no MyHeritage links for Pennsylvania 1865\u20131875, fallback to site-wide). log_007 (in-flight search) has outcome 'partial', capture_received false, site 'myheritage', and the generated URL. Both entries include query metadata (place, year range, site). The entries were not deferred or skipped; they were written immediately as required."
+          }
+        ]
+      },
+      "totals": {
+        "duration_ms": 82357.73229197366,
+        "duration_api_ms": 81818.0,
+        "judge_duration_ms": 13874.616667046212,
+        "wall_clock_ms": 96289.40296173096,
+        "num_turns": 12,
+        "input_tokens": 16,
+        "cached_input_tokens": 195745,
+        "output_tokens": 4606,
+        "judge_input_tokens": 4759,
+        "judge_cached_input_tokens": 4778,
+        "judge_output_tokens": 1272,
+        "skill_cost_usd": 0.25188099999999997,
+        "judge_cost_usd": 0.0068188,
+        "total_cost_usd": 0.2586998
+      },
+      "runs": [
+        {
+          "run_index": 0,
+          "run_id": "run_ut_search_external_sites_009_2026-07-17_22-54-08_0",
+          "outcome": "pass",
+          "aborted_reason": null,
+          "duration_ms": 82357.73229197366,
+          "duration_api_ms": 81818.0,
+          "num_turns": 12,
+          "skill_attempts": 1,
+          "input_tokens": 16,
+          "cached_input_tokens": 195745,
+          "output_tokens": 4606,
+          "skill_cost_usd": 0.25188099999999997,
+          "output": {
+            "text_response": "Let me read the project context and reference files to get started.Now let me read the research.json to check the researcher profile and any existing plan items, and simultaneously resolve the place Pennsylvania.I can see the researcher's profile has only an **Ancestry** subscription \u2014 no MyHeritage on file. I'll flag that and still generate the URL as instructed. Now let me fetch curated links for Pennsylvania on MyHeritage in that date window.No curated MyHeritage links came back for Pennsylvania 1865\u20131875 \u2014 the 3 results are all for Ancestry, FindMyPast, and the FamilySearch Wiki. I'll fall back to the MyHeritage site-wide template. Now logging both entries before presenting the URL.Both entries logged (log_006 for the curated-links fetch, log_007 for the in-flight search). Here's the URL:\n\n---\n\n> \u26a0\ufe0f **No MyHeritage subscription on file** \u2014 this link may hit a login wall or show a limited-results preview. If so, log in first, then click the link again.\n\n> \u2139\ufe0f **No FamilySearch-curated MyHeritage link for Pennsylvania 1865\u20131875** \u2014 using the MyHeritage site-wide search instead.\n\n---\n\n**Search: MyHeritage \u2014 Patrick Flynn, Pennsylvania Marriage, ca. 1865\u20131875**\n\nClick this link to search:\n[MyHeritage \u2014 Patrick Flynn, Pennsylvania Marriage](https://www.myheritage.com/research?action=query&first=Patrick&last=Flynn&marriage_year=1870&marriage_place=Pennsylvania)\n\n**Search parameters used:**\n- First name: Patrick\n- Last name: Flynn\n- Marriage year: 1870 (midpoint of 1865\u20131875 window)\n- Marriage place: Pennsylvania\n\n*Note: \"Flynn\" is a common Irish-American surname in Pennsylvania, so expect a sizable result set. The marriage year and place are included to narrow it from the outset.*\n\n**After the page loads:**\n1. Scroll to the bottom of the page and back to the top (forces lazy-loaded results into view)\n2. Press **Cmd+P** (Mac) or **Ctrl+P** (Windows)\n3. Select **\"Save as PDF\"**\n4. Save the file and upload it here\n\n---\n\nOnce you upload the PDF, I'll triage the results \u2014 listing each match with name, marriage year/place, spouse name if shown, and a **Strong / Possible / No match** rating against Patrick's known profile (born ca. 1845, Schuylkill County, PA). We'd be looking for a bride record from roughly 1865\u20131875 in Pennsylvania.",
+            "activated": true,
+            "skills_invoked": [
+              "search-external-sites"
+            ],
+            "tool_calls": [
+              {
+                "tool": "mcp__genealogy__place_search",
+                "args": {
+                  "placeName": "Pennsylvania"
+                },
+                "expected_args": {
+                  "placeName": "~"
+                },
+                "matched": {
+                  "kind": "predicate",
+                  "index": 0
+                },
+                "response_fixture": "place-search-pennsylvania"
+              },
+              {
+                "tool": "mcp__genealogy__external_links_search",
+                "args": {
+                  "standardPlace": "Pennsylvania, United States",
+                  "startYear": 1865,
+                  "endYear": 1875,
+                  "host": "myheritage.com",
+                  "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/eval-ut_search_external_sites_009-0-0-yttand81"
+                },
+                "expected_args": {
+                  "standardPlace": "Pennsylvania, United States"
+                },
+                "matched": {
+                  "kind": "predicate",
+                  "index": 0
+                },
+                "response_fixture": "external-links-search-pennsylvania"
+              },
+              {
+                "tool": "mcp__genealogy__research_log_append",
+                "args": {
+                  "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/eval-ut_search_external_sites_009-0-0-yttand81",
+                  "planItemId": null,
+                  "tool": "external_links_search",
+                  "query": {
+                    "standardPlace": "Pennsylvania, United States",
+                    "host": "myheritage.com",
+                    "startYear": 1865,
+                    "endYear": 1875
+                  },
+                  "outcome": "negative",
+                  "resultsExamined": 0,
+                  "notes": "Curated external links for Pennsylvania, United States (1865\u20131875). No MyHeritage links found for this place and year window. 3 total curated links exist for the place but all are for other sites (Ancestry county marriage records 1885\u20131950, FindMyPast Pennsylvania marriages, and FamilySearch Wiki). Falling back to MyHeritage site-wide search template.",
+                  "stagedResultsRef": "results/.staging/e8162262-64ce-4cda-a399-1c70cfe1ed13.json"
+                },
+                "expected_args": null,
+                "matched": {
+                  "kind": "live",
+                  "index": null
+                },
+                "response_fixture": "live:research_log_append"
+              },
+              {
+                "tool": "mcp__genealogy__research_log_append",
+                "args": {
+                  "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/eval-ut_search_external_sites_009-0-0-yttand81",
+                  "planItemId": null,
+                  "tool": "external_site",
+                  "query": {
+                    "first": "Patrick",
+                    "last": "Flynn",
+                    "marriage_year": 1870,
+                    "marriage_place": "Pennsylvania",
+                    "year_range": "1865\u20131875"
+                  },
+                  "outcome": "partial",
+                  "resultsExamined": 0,
+                  "notes": "URL generated; awaiting user capture. Ad-hoc marriage search \u2014 no matching plan item. \"Flynn\" is a common surname, so marriage year (midpoint 1870) and place (Pennsylvania) included to narrow results. No MyHeritage subscription on file for this researcher \u2014 link may hit a login wall or limited preview.",
+                  "externalSite": {
+                    "site": "myheritage",
+                    "urlGenerated": "https://www.myheritage.com/research?action=query&first=Patrick&last=Flynn&marriage_year=1870&marriage_place=Pennsylvania",
+                    "captureReceived": false,
+                    "captureFilename": null
+                  }
+                },
+                "expected_args": null,
+                "matched": {
+                  "kind": "live",
+                  "index": null
+                },
+                "response_fixture": "live:research_log_append"
+              }
+            ],
+            "files_created": [
+              "results/log_006.json"
+            ],
+            "file_changes": {
+              "research.json": {
+                "sections_modified": [
+                  "log"
+                ],
+                "diff": {
+                  "log": {
+                    "added": [
+                      {
+                        "id": "log_006",
+                        "plan_item_id": null,
+                        "performed": "2026-07-17T22:57:14.015Z",
+                        "tool": "external_links_search",
+                        "query": {
+                          "standardPlace": "Pennsylvania, United States",
+                          "host": "myheritage.com",
+                          "startYear": 1865,
+                          "endYear": 1875
+                        },
+                        "outcome": "negative",
+                        "results_examined": 0,
+                        "external_site": null,
+                        "results_ref": "results/log_006.json",
+                        "notes": "Curated external links for Pennsylvania, United States (1865\u20131875). No MyHeritage links found for this place and year window. 3 total curated links exist for the place but all are for other sites (Ancestry county marriage records 1885\u20131950, FindMyPast Pennsylvania marriages, and FamilySearch Wiki). Falling back to MyHeritage site-wide search template."
+                      },
+                      {
+                        "id": "log_007",
+                        "plan_item_id": null,
+                        "performed": "2026-07-17T22:57:19.096Z",
+                        "tool": "external_site",
+                        "query": {
+                          "first": "Patrick",
+                          "last": "Flynn",
+                          "marriage_year": 1870,
+                          "marriage_place": "Pennsylvania",
+                          "year_range": "1865\u20131875"
+                        },
+                        "outcome": "partial",
+                        "results_examined": 0,
+                        "external_site": {
+                          "site": "myheritage",
+                          "url_generated": "https://www.myheritage.com/research?action=query&first=Patrick&last=Flynn&marriage_year=1870&marriage_place=Pennsylvania",
+                          "capture_received": false,
+                          "capture_filename": null
+                        },
+                        "results_ref": null,
+                        "notes": "URL generated; awaiting user capture. Ad-hoc marriage search \u2014 no matching plan item. \"Flynn\" is a common surname, so marriage year (midpoint 1870) and place (Pennsylvania) included to narrow results. No MyHeritage subscription on file for this researcher \u2014 link may hit a login wall or limited preview."
+                      }
+                    ],
+                    "modified": [],
+                    "deleted": []
+                  }
+                }
+              }
+            },
+            "warnings": [
+              {
+                "kind": "uncovered_tool_call",
+                "advisory": "1 of 5 MCP tool call(s) matched no fixture predicate \u2014 the skill ran against a fixture_not_found or denied/unknown-tool error. Add or fix an mcp_fixture whose args match the call.",
+                "attempted": [
+                  {
+                    "tool": "mcp__genealogy__project_context",
+                    "args": {
+                      "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/eval-ut_search_external_sites_009-0-0-yttand81"
+                    }
+                  },
+                  {
+                    "tool": "mcp__genealogy__place_search",
+                    "args": {
+                      "placeName": "Pennsylvania"
+                    }
+                  },
+                  {
+                    "tool": "mcp__genealogy__external_links_search",
+                    "args": {
+                      "standardPlace": "Pennsylvania, United States",
+                      "startYear": 1865,
+                      "endYear": 1875,
+                      "host": "myheritage.com",
+                      "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/eval-ut_search_external_sites_009-0-0-yttand81"
+                    }
+                  },
+                  {
+                    "tool": "mcp__genealogy__research_log_append",
+                    "args": {
+                      "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/eval-ut_search_external_sites_009-0-0-yttand81",
+                      "planItemId": null,
+                      "tool": "external_links_search",
+                      "query": {
+                        "standardPlace": "Pennsylvania, United States",
+                        "host": "myheritage.com",
+                        "startYear": 1865,
+                        "endYear": 1875
+                      },
+                      "outcome": "negative",
+                      "resultsExamined": 0,
+                      "notes": "Curated external links for Pennsylvania, United States (1865\u20131875). No MyHeritage links found for this place and year window. 3 total curated links exist for the place but all are for other sites (Ancestry county marriage records 1885\u20131950, FindMyPast Pennsylvania marriages, and FamilySearch Wiki). Falling back to MyHeritage site-wide search template.",
+                      "stagedResultsRef": "results/.staging/e8162262-64ce-4cda-a399-1c70cfe1ed13.json"
+                    }
+                  },
+                  {
+                    "tool": "mcp__genealogy__research_log_append",
+                    "args": {
+                      "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/eval-ut_search_external_sites_009-0-0-yttand81",
+                      "planItemId": null,
+                      "tool": "external_site",
+                      "query": {
+                        "first": "Patrick",
+                        "last": "Flynn",
+                        "marriage_year": 1870,
+                        "marriage_place": "Pennsylvania",
+                        "year_range": "1865\u20131875"
+                      },
+                      "outcome": "partial",
+                      "resultsExamined": 0,
+                      "notes": "URL generated; awaiting user capture. Ad-hoc marriage search \u2014 no matching plan item. \"Flynn\" is a common surname, so marriage year (midpoint 1870) and place (Pennsylvania) included to narrow results. No MyHeritage subscription on file for this researcher \u2014 link may hit a login wall or limited preview.",
+                      "externalSite": {
+                        "site": "myheritage",
+                        "urlGenerated": "https://www.myheritage.com/research?action=query&first=Patrick&last=Flynn&marriage_year=1870&marriage_place=Pennsylvania",
+                        "captureReceived": false,
+                        "captureFilename": null
+                      }
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "validators": {
+            "passed": true,
+            "results": [
+              {
+                "name": "test_id_references_resolve",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_log_append_only",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_entries_deleted",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_main_thread_subagent_only_calls",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_project_file_changes_route_through_writer_tools",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_research_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tool_allowlist",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_gedcomx_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_log_site_ancestry",
+                "passed": true,
+                "error": "skipped: not a log-site-ancestry scenario"
+              },
+              {
+                "name": "test_log_site_findagrave",
+                "passed": true,
+                "error": "skipped: not a log-site-findagrave scenario"
+              },
+              {
+                "name": "test_log_site_findmypast",
+                "passed": true,
+                "error": "skipped: not a log-site-findmypast scenario"
+              },
+              {
+                "name": "test_log_site_myheritage",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_log_site_newspapers",
+                "passed": true,
+                "error": "skipped: not a log-site-newspapers scenario"
+              },
+              {
+                "name": "test_positive_appends_external_site_log_entry",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_url_generation_log_entry_shape",
+                "passed": true,
+                "error": null
+              }
+            ]
+          },
+          "judge": {
+            "skipped": false,
+            "dimensions": [
+              {
+                "source": "base",
+                "name": "Correctness",
+                "score": 3,
+                "rationale": "The skill correctly identified the researcher's Ancestry-only subscription, flagged the MyHeritage login-wall risk with a one-line warning as specified, and still generated the URL with all required parameters (first=Patrick, last=Flynn, marriage_year=1870, marriage_place=Pennsylvania). The URL is syntactically valid and targets the correct site. The fallback to the site-wide template after finding no curated MyHeritage links is correct behavior. Both log entries were written with accurate metadata (outcome: partial/negative, capture_received: false, site: myheritage). No fabricated material or unsupported claims."
+              },
+              {
+                "source": "base",
+                "name": "Completeness",
+                "score": 3,
+                "rationale": "The skill addressed all requirements: generated the MyHeritage URL with the marriage window (1865\u20131875) and Pennsylvania place, provided clear capture-workflow instructions (scroll, Cmd+P/Ctrl+P, save as PDF, upload), flagged the subscription limitation, and logged both the curated-links fetch and the in-flight search. The response deferred result triage appropriately, stating it would evaluate matches once the PDF arrived. No required elements were omitted."
+              },
+              {
+                "source": "base",
+                "name": "Tool Arguments",
+                "score": 3,
+                "rationale": "All four tool calls passed correct arguments. place_search received 'Pennsylvania' and returned 'Pennsylvania, United States' (state level), which correctly fed external_links_search with standardPlace, startYear (1865), endYear (1875), and host (myheritage.com). The two research_log_append calls used correct schemas: log_006 logged the curated-links fetch with outcome 'negative' and notes on the fallback; log_007 logged the in-flight search with outcome 'partial', capture_received false, and the generated URL. No critical identifiers were wrong, no fixture_not_found errors, and no fabricated arguments."
+              },
+              {
+                "source": "rubric",
+                "name": "URL generation",
+                "score": 3,
+                "rationale": "The generated URL targets myheritage.com/research with all required search parameters correctly encoded: first=Patrick, last=Flynn, marriage_year=1870 (midpoint of 1865\u20131875 window), marriage_place=Pennsylvania. The URL is syntactically valid and includes the action=query parameter. The skill used the midpoint year (1870) as a reasonable narrowing strategy for a common surname, which is sound genealogical practice."
+              },
+              {
+                "source": "rubric",
+                "name": "Capture guidance",
+                "score": 3,
+                "rationale": "Instructions are clear and specific: scroll to bottom and back to top (forces lazy-loaded results), press Cmd+P (Mac) or Ctrl+P (Windows), select 'Save as PDF', save and upload. The skill also named what to look for in results (name, marriage year/place, spouse name, rating against Patrick's profile: born ca. 1845, Schuylkill County, PA, marriage 1865\u20131875). The workflow is actionable and does not assume prior knowledge."
+              },
+              {
+                "source": "rubric",
+                "name": "Result triage",
+                "score": 3,
+                "rationale": "No capture was provided in this turn, so the correct behavior is to defer triage. The skill explicitly stated 'Once you upload the PDF, I'll triage the results' and outlined the criteria it would apply (name, marriage year/place, spouse name, Strong/Possible/No match rating against Patrick's profile). This is a clean deferral without fabrication or pre-judgment\u2014a pass on a no-capture turn."
+              },
+              {
+                "source": "rubric",
+                "name": "Tool selection",
+                "score": 3,
+                "rationale": "The skill correctly used place_search first (Pennsylvania \u2192 Pennsylvania, United States), fed the standardPlace result to external_links_search with the year window (1865\u20131875) and host filter (myheritage.com), and consumed the response correctly: no curated MyHeritage links were found (3 results were for other sites), so the skill fell back to the site-wide template as documented. The search was persisted via research_log_append with outcome 'partial' and capture_received false. All tool calls followed the documented flow."
+              },
+              {
+                "source": "rubric",
+                "name": "Log entry",
+                "score": 3,
+                "rationale": "Two log entries were written in the same turn the URL was generated. log_006 (curated-links fetch) has outcome 'negative' with notes on coverage (no MyHeritage links for Pennsylvania 1865\u20131875, fallback to site-wide). log_007 (in-flight search) has outcome 'partial', capture_received false, site 'myheritage', and the generated URL. Both entries include query metadata (place, year range, site). The entries were not deferred or skipped; they were written immediately as required."
+              }
+            ],
+            "judge_cost_usd": 0.0068188,
+            "duration_ms": 13874.616667046212,
+            "error": null,
+            "input_tokens": 4759,
+            "cached_input_tokens": 4778,
+            "output_tokens": 1272
+          },
+          "started_at": 1784328969.076823,
+          "ended_at": 1784329065.366226
+        }
+      ]
+    }
+  ],
+  "totals": {
+    "duration_ms": 957190.2101269225,
+    "duration_api_ms": 929386.0,
+    "judge_duration_ms": 145780.72508104378,
+    "num_turns": 118,
+    "input_tokens": 168,
+    "cached_input_tokens": 2339643,
+    "output_tokens": 47908,
+    "judge_input_tokens": 66089,
+    "judge_cached_input_tokens": 43002,
+    "judge_output_tokens": 13409,
+    "skill_cost_usd": 2.6572384000000002,
+    "judge_cost_usd": 0.0944322,
+    "total_cost_usd": 2.7516706000000006,
+    "wall_clock_ms": 313141.0460472107
+  }
+}

--- a/packages/engine/mcp-server/src/tools/external-links-search.ts
+++ b/packages/engine/mcp-server/src/tools/external-links-search.ts
@@ -1,5 +1,6 @@
 import { BROWSER_USER_AGENT } from "../constants.js";
 import { standardPlaceToPlaceId } from "../utils/place-resolver.js";
+import { stageSearchResults } from "../utils/results-staging.js";
 import type {
   PlaceExternalLink,
   ExternalLinksSearchResult,
@@ -11,12 +12,21 @@ export interface ExternalLinksSearchInput {
   standardPlace: string;
   startYear?: number;
   endYear?: number;
+  host?: string;
+  projectPath?: string;
 }
 
 const FS_EXTERNAL_URL =
   "https://www.familysearch.org/service/search/hr/external/collections/search";
 
 const PAGE_SIZE = 100;
+
+// Backstop cap on the inline `results[]`, applied only once the full set has
+// been staged to disk (so nothing dropped is unrecoverable). A link-dense place
+// (US counties carry several hundred curated resources) with no `host` filter
+// would otherwise overflow the tool-result token cap even after staging. With a
+// `host` filter the matched set is small and the cap effectively never bites.
+const INLINE_CAP = 50;
 
 function parseYear(raw: string | undefined): number | null {
   if (!raw) return null;
@@ -157,7 +167,9 @@ export async function externalLinksSearchTool(
           )
         );
 
-  const results: PlaceExternalLink[] = matched
+  // The full year-filtered set (all hosts). This is what gets staged to disk —
+  // host filtering and the inline cap narrow only the inline copy.
+  const allLinks: PlaceExternalLink[] = matched
     .filter((c) => typeof c.url === "string" && c.url.length > 0)
     .map((c) => ({
       url: c.url as string,
@@ -168,11 +180,51 @@ export async function externalLinksSearchTool(
   if (startYear != null) query.startYear = startYear;
   if (endYear != null) query.endYear = endYear;
 
-  return {
+  const out: ExternalLinksSearchResult = {
     query,
     totalForPlace,
-    results,
+    returned: 0,
+    results: [],
   };
+
+  // Host-side result staging (search-result-staging-spec.md). Stage the FULL
+  // year-filtered set BEFORE any host filter or inline cap, so the complete link
+  // list is retained on disk (research record + feedback bundles) even when the
+  // inline copy is narrowed. Purely additive and best-effort: a staging failure
+  // never fails a successful search.
+  if (input.projectPath !== undefined) {
+    try {
+      out.staged = await stageSearchResults({
+        projectPath: input.projectPath,
+        tool: "external_links",
+        response: { results: allLinks },
+      });
+    } catch (error) {
+      out.staged = null;
+      out.stagingError = error instanceof Error ? error.message : String(error);
+    }
+  }
+
+  // Narrow the inline copy. The `host` filter is the caller's explicit query
+  // narrowing (return only their target site's links), so it always applies.
+  const host =
+    typeof input.host === "string" ? input.host.trim().toLowerCase() : "";
+  let inline = host
+    ? allLinks.filter((r) => r.url.toLowerCase().includes(host))
+    : allLinks;
+
+  // The backstop cap only bites once the full set is safely staged — mirroring
+  // record_search/fulltext_search, which reshape the inline copy only when
+  // staged so nothing dropped is unrecoverable. An un-staged caller gets the
+  // full (optionally host-filtered) set, exactly as before this change; the
+  // skill always passes projectPath + host, so the staged path is the norm.
+  if (out.staged && inline.length > INLINE_CAP) {
+    inline = inline.slice(0, INLINE_CAP);
+  }
+
+  out.results = inline;
+  out.returned = inline.length;
+  return out;
 }
 
 export const externalLinksSearchToolSchema = {
@@ -184,8 +236,13 @@ export const externalLinksSearchToolSchema = {
     "covering a specific place by standard place name. Pass a standardPlace from " +
     "place_search; add startYear/endYear to keep only collections whose date range " +
     "overlaps that window. Undated wiki/website resources for the place are always " +
-    "included. With no years, every resource for the place is returned. The full " +
-    "filtered set comes back in one response (no pagination).",
+    "included. With no years, every resource for the place is returned. " +
+    "Pass `host` to filter to a single target site (e.g. 'ancestry.com'); the " +
+    "response returns only matching links plus `returned` (their count). Pass " +
+    "`projectPath` to stage the full year-filtered set to disk and get a " +
+    "`staged.resultsRef` handle (pass it to research_log_append as " +
+    "`stagedResultsRef` so the complete link list is retained). The inline " +
+    "`results[]` is capped for safety; the staged sidecar always holds the full set.",
   inputSchema: {
     type: "object" as const,
     properties: {
@@ -207,6 +264,23 @@ export const externalLinksSearchToolSchema = {
         maximum: 2100,
         description:
           "Latest year of interest (inclusive). Must be >= startYear. Omit for all periods.",
+      },
+      host: {
+        type: "string",
+        description:
+          "Optional target-site host substring (e.g. 'ancestry.com', 'findagrave.com'). " +
+          "When supplied, the inline `results[]` is filtered to links whose URL contains it — " +
+          "returning the small exact set you need instead of every curated site for the place. " +
+          "The full unfiltered set is still what gets staged to disk when `projectPath` is passed.",
+      },
+      projectPath: {
+        type: "string",
+        description:
+          "Absolute path to the active project directory. When supplied, the tool stages the full " +
+          "year-filtered link set host-side and returns a `staged.resultsRef` handle — pass that to " +
+          "research_log_append as `stagedResultsRef` so the complete list is retained in the log " +
+          "sidecar (and rides along in a feedback bundle) without you re-serializing it. Omit only " +
+          "for a throwaway exploratory lookup you will not log.",
       },
     },
     required: ["standardPlace"],

--- a/packages/engine/mcp-server/src/tools/external-links-search.ts
+++ b/packages/engine/mcp-server/src/tools/external-links-search.ts
@@ -196,7 +196,7 @@ export async function externalLinksSearchTool(
     try {
       out.staged = await stageSearchResults({
         projectPath: input.projectPath,
-        tool: "external_links",
+        tool: "external_links_search",
         response: { results: allLinks },
       });
     } catch (error) {

--- a/packages/engine/mcp-server/src/tools/fulltext-search.ts
+++ b/packages/engine/mcp-server/src/tools/fulltext-search.ts
@@ -233,6 +233,21 @@ export async function fulltextSearchTool(
     }
   }
 
+  // Whenever results were staged, drop the heavy inline `textDocument` (the full
+  // AI-transcribed page, 79–136 KB across a result set — the overflow driver).
+  // The full text lives in the staged sidecar; record_read reads it back from
+  // there via the staged ref, and the remaining flat fields (names/places/dates/
+  // highlightTerms/title/recordType) still carry the triage stubs. Mirrors
+  // record_search's inline-gedcomx strip: unconditional once staged so the
+  // overflow protection can't be forgotten, and safe because the staged file is
+  // already serialized to disk. Never strip when `staged` is null (an un-staged
+  // exploratory search — nothing was retained to re-read from).
+  if (out.staged) {
+    for (const r of out.results) {
+      delete r.textDocument;
+    }
+  }
+
   return out;
 }
 

--- a/packages/engine/mcp-server/src/tools/research-log-append.ts
+++ b/packages/engine/mcp-server/src/tools/research-log-append.ts
@@ -313,7 +313,7 @@ export const researchLogAppendSchema = {
         type: "string",
         description:
           "The tool/source that produced this entry, e.g. 'record_search', " +
-          "'fulltext_search', 'external_links', 'image_search', 'person_read', or " +
+          "'fulltext_search', 'external_links_search', 'image_search', 'person_read', or " +
           "'external_site'. Must match the staged file's tool when stagedResultsRef is given.",
       },
       query: {

--- a/packages/engine/mcp-server/src/tools/research-log-append.ts
+++ b/packages/engine/mcp-server/src/tools/research-log-append.ts
@@ -313,8 +313,8 @@ export const researchLogAppendSchema = {
         type: "string",
         description:
           "The tool/source that produced this entry, e.g. 'record_search', " +
-          "'fulltext_search', 'image_search', 'person_read', or 'external_site'. " +
-          "Must match the staged file's tool when stagedResultsRef is given.",
+          "'fulltext_search', 'external_links', 'image_search', 'person_read', or " +
+          "'external_site'. Must match the staged file's tool when stagedResultsRef is given.",
       },
       query: {
         type: "object",

--- a/packages/engine/mcp-server/src/types/external-links-search.ts
+++ b/packages/engine/mcp-server/src/types/external-links-search.ts
@@ -38,5 +38,17 @@ export interface ExternalLinksSearchResult {
   // "resources exist here, just not in your years". results.length is the
   // matched count, so there is no separate matchedCount field.
   totalForPlace: number;
+  // Number of links in `results` after year + host filtering and the inline
+  // cap. Equal to `results.length`; surfaced explicitly so a capped/filtered
+  // response is self-describing alongside `totalForPlace`.
+  returned: number;
   results: PlaceExternalLink[];
+  // Host-side staging handle (search-result-staging-spec.md). Present only when
+  // `projectPath` was supplied and the pre-filter set was non-empty. The staged
+  // sidecar holds the FULL year-filtered set (before any host filter or inline
+  // cap), so the complete link list is retained on disk for the research record
+  // and feedback bundles even when `results` is narrowed. `null` when staging
+  // was attempted but failed; absent when `projectPath` was not supplied.
+  staged?: { resultsRef: string; returnedCount: number } | null;
+  stagingError?: string;
 }

--- a/packages/engine/mcp-server/tests/tools/external-links-search.test.ts
+++ b/packages/engine/mcp-server/tests/tools/external-links-search.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { externalLinksSearchTool } from "../../src/tools/external-links-search.js";
 import { BROWSER_USER_AGENT } from "../../src/constants.js";
+import { stageSearchResults } from "../../src/utils/results-staging.js";
 
 const mockFetch = vi.fn();
 vi.stubGlobal("fetch", mockFetch);
@@ -10,11 +11,19 @@ vi.mock("../../src/utils/place-resolver.js", () => ({
   standardPlaceToPlaceId: mockStandardPlaceToPlaceId,
 }));
 
+// The staging util is exercised by tests/utils/results-staging.test.ts; here we
+// only assert the tool calls it correctly and shapes the inline copy around it.
+vi.mock("../../src/utils/results-staging.js", () => ({
+  stageSearchResults: vi.fn(),
+}));
+const mockedStage = vi.mocked(stageSearchResults);
+
 // Runs before every test (in addition to the per-describe fetch resets);
 // default the resolver to a successful placeId so existing cases reach fetch.
 beforeEach(() => {
   mockStandardPlaceToPlaceId.mockReset();
   mockStandardPlaceToPlaceId.mockResolvedValue("1927089");
+  mockedStage.mockReset();
 });
 
 function jsonResponse(body: unknown, status = 200): Response {
@@ -323,5 +332,130 @@ describe("externalLinksSearchTool — User-Agent contract", () => {
     const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
     const headers = init.headers as Record<string, string>;
     expect(headers["User-Agent"]).toBe(BROWSER_USER_AGENT);
+  });
+});
+
+describe("externalLinksSearchTool — staging, host filter, and inline cap", () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  const twoHostCollections = [
+    { url: "https://www.ancestry.com/search/collections/1/", linkText: "PA Wills" },
+    { url: "https://www.findagrave.com/cemetery/22", linkText: "PA Graves" },
+    { url: "https://www.ancestry.com/search/collections/2/", linkText: "PA Census" },
+  ];
+
+  it("stages the full pre-filter set with tool 'external_links' when projectPath is supplied", async () => {
+    mockFetch.mockResolvedValueOnce(singlePage(twoHostCollections));
+    mockedStage.mockResolvedValueOnce({
+      resultsRef: "results/.staging/abc.json",
+      returnedCount: 3,
+    });
+
+    const result = await externalLinksSearchTool({
+      standardPlace: "Pennsylvania, United States",
+      projectPath: "/tmp/project",
+    });
+
+    expect(mockedStage).toHaveBeenCalledTimes(1);
+    const stageArg = mockedStage.mock.calls[0][0];
+    expect(stageArg).toMatchObject({
+      projectPath: "/tmp/project",
+      tool: "external_links",
+    });
+    // The staged payload is the FULL set (all hosts), before any host filter.
+    expect(stageArg.response.results).toHaveLength(3);
+    expect(result.staged).toEqual({
+      resultsRef: "results/.staging/abc.json",
+      returnedCount: 3,
+    });
+    expect(result.stagingError).toBeUndefined();
+  });
+
+  it("host filter narrows the inline results while the full set is still staged", async () => {
+    mockFetch.mockResolvedValueOnce(singlePage(twoHostCollections));
+    mockedStage.mockResolvedValueOnce({
+      resultsRef: "results/.staging/abc.json",
+      returnedCount: 3,
+    });
+
+    const result = await externalLinksSearchTool({
+      standardPlace: "Pennsylvania, United States",
+      host: "ancestry.com",
+      projectPath: "/tmp/project",
+    });
+
+    // Inline: only the two ancestry links, and `returned` reflects that.
+    expect(result.results).toHaveLength(2);
+    expect(result.returned).toBe(2);
+    expect(result.results.every((r) => r.url.includes("ancestry.com"))).toBe(true);
+    // Staged: still the full 3-link set (host filter never touches the sidecar).
+    expect(mockedStage.mock.calls[0][0].response.results).toHaveLength(3);
+  });
+
+  it("applies the host filter even when not staged (explicit query narrowing)", async () => {
+    mockFetch.mockResolvedValueOnce(singlePage(twoHostCollections));
+    const result = await externalLinksSearchTool({
+      standardPlace: "Pennsylvania, United States",
+      host: "findagrave.com",
+    });
+    expect(mockedStage).not.toHaveBeenCalled();
+    expect(result.results).toHaveLength(1);
+    expect(result.results[0]?.url).toContain("findagrave.com");
+    expect(result.staged).toBeUndefined();
+  });
+
+  it("caps the inline set to 50 only when staged; returns the full set un-staged", async () => {
+    const many = Array.from({ length: 120 }, (_, i) => ({
+      url: `https://example.com/c${i}`,
+      linkText: `Collection ${i}`,
+    }));
+
+    // Un-staged: full set comes back (back-compat; nothing retained to recover).
+    mockFetch.mockResolvedValueOnce(singlePage(many));
+    const unstaged = await externalLinksSearchTool({
+      standardPlace: "Pennsylvania, United States",
+    });
+    expect(unstaged.results).toHaveLength(120);
+    expect(unstaged.returned).toBe(120);
+
+    // Staged: inline capped at 50, full 120 staged to disk.
+    mockFetch.mockResolvedValueOnce(singlePage(many));
+    mockedStage.mockResolvedValueOnce({
+      resultsRef: "results/.staging/def.json",
+      returnedCount: 120,
+    });
+    const staged = await externalLinksSearchTool({
+      standardPlace: "Pennsylvania, United States",
+      projectPath: "/tmp/project",
+    });
+    expect(staged.results).toHaveLength(50);
+    expect(staged.returned).toBe(50);
+    expect(mockedStage.mock.calls[0][0].response.results).toHaveLength(120);
+  });
+
+  it("never fails the search when staging throws", async () => {
+    mockFetch.mockResolvedValueOnce(singlePage(twoHostCollections));
+    mockedStage.mockRejectedValueOnce(new Error("disk full"));
+
+    const result = await externalLinksSearchTool({
+      standardPlace: "Pennsylvania, United States",
+      projectPath: "/tmp/project",
+    });
+
+    expect(result.staged).toBeNull();
+    expect(result.stagingError).toBe("disk full");
+    expect(result.results).toHaveLength(3); // search result intact
+  });
+
+  it("does not stage when projectPath is omitted", async () => {
+    mockFetch.mockResolvedValueOnce(singlePage(twoHostCollections));
+    const result = await externalLinksSearchTool({
+      standardPlace: "Pennsylvania, United States",
+    });
+    expect(mockedStage).not.toHaveBeenCalled();
+    expect(result.staged).toBeUndefined();
+    expect(result.returned).toBe(3);
   });
 });

--- a/packages/engine/mcp-server/tests/tools/external-links-search.test.ts
+++ b/packages/engine/mcp-server/tests/tools/external-links-search.test.ts
@@ -346,7 +346,7 @@ describe("externalLinksSearchTool — staging, host filter, and inline cap", () 
     { url: "https://www.ancestry.com/search/collections/2/", linkText: "PA Census" },
   ];
 
-  it("stages the full pre-filter set with tool 'external_links' when projectPath is supplied", async () => {
+  it("stages the full pre-filter set with tool 'external_links_search' when projectPath is supplied", async () => {
     mockFetch.mockResolvedValueOnce(singlePage(twoHostCollections));
     mockedStage.mockResolvedValueOnce({
       resultsRef: "results/.staging/abc.json",
@@ -362,7 +362,7 @@ describe("externalLinksSearchTool — staging, host filter, and inline cap", () 
     const stageArg = mockedStage.mock.calls[0][0];
     expect(stageArg).toMatchObject({
       projectPath: "/tmp/project",
-      tool: "external_links",
+      tool: "external_links_search",
     });
     // The staged payload is the FULL set (all hosts), before any host filter.
     expect(stageArg.response.results).toHaveLength(3);

--- a/packages/engine/mcp-server/tests/tools/fulltext-search.test.ts
+++ b/packages/engine/mcp-server/tests/tools/fulltext-search.test.ts
@@ -540,6 +540,37 @@ describe("fulltextSearchTool result staging", () => {
     expect(result.stagingError).toBeUndefined();
   });
 
+  it("34b. strips inline textDocument once staged, keeping triage stubs", async () => {
+    mockFetch.mockResolvedValueOnce(
+      makeOk({ results: 1, index: 0, entries: [flynnEntry()] })
+    );
+    mockedStage.mockResolvedValueOnce({
+      resultsRef: "results/abc123.json",
+      returnedCount: 1,
+    });
+    const result = await fulltextSearchTool({
+      keywords: "Flynn",
+      projectPath: "/tmp/project",
+    });
+    // The 79–136 KB overflow driver is gone from the inline copy...
+    expect(result.results[0]?.textDocument).toBeUndefined();
+    // ...but the light triage fields survive for in-context ranking.
+    expect(result.results[0]?.names).toContain("Patrick Flynn");
+    expect(result.results[0]?.title).toBe(
+      "Last Will and Testament of Patrick Flynn"
+    );
+    expect(result.results[0]?.recordType).toBe("Probate");
+  });
+
+  it("34c. keeps inline textDocument when staging did not run", async () => {
+    mockFetch.mockResolvedValueOnce(
+      makeOk({ results: 1, index: 0, entries: [flynnEntry()] })
+    );
+    const result = await fulltextSearchTool({ keywords: "Flynn" });
+    expect(result.staged).toBeUndefined();
+    expect(result.results[0]?.textDocument).toBe("...full transcript text...");
+  });
+
   it("35. never fails the search when staging throws", async () => {
     mockFetch.mockResolvedValueOnce(
       makeOk({ results: 1, index: 0, entries: [flynnEntry()] })

--- a/packages/engine/plugin/skills/search-external-sites/SKILL.md
+++ b/packages/engine/plugin/skills/search-external-sites/SKILL.md
@@ -148,30 +148,42 @@ place_search({ placeName: "<place name>" })
 ```
 
 Take the `standardPlace` from the response — do not guess it — and pass it
-to `external_links_search` with the plan item's year window:
+to `external_links_search` with the plan item's year window, your target
+site as `host`, and `projectPath` so the full curated set is retained on disk:
 
 ```
-external_links_search({ standardPlace: "<standardPlace>", startYear: <year>, endYear: <year> })
+external_links_search({
+  standardPlace: "<standardPlace>",
+  startYear: <year>,
+  endYear: <year>,
+  host: "<target-site host, e.g. ancestry.com>",
+  projectPath: "<absolute path of the current working directory>"
+})
 ```
 
-It returns a flat `results[]` of `{ url, linkText }` mixing every curated
-site for the place — ungrouped, unclassified, undeduped. Consume it:
-1. **Filter by host** — keep links for your target site, e.g.
-   `result.url.includes("ancestry.com")`.
-2. **Dedupe by URL** — FS repeats the same URL once per record-type
+`host` filters the results to your target site **server-side**, so `results[]`
+comes back as just that site's `{ url, linkText }` links — not every curated
+site for the place. `projectPath` stages the **full** year-filtered set (all
+sites) to disk and returns a `staged.resultsRef`; hold it for the step-4 log.
+Then consume `results[]`:
+1. **Dedupe by URL** — FS repeats the same URL once per record-type
    category. Collapse duplicates, and say so in one line when it happens
    ("collection 8800 appeared 3× under different labels — collapsed to one")
    so the dedup is visible, not silent.
-3. **Match `linkText` to the plan item's record type.** `linkText` names
+2. **Match `linkText` to the plan item's record type.** `linkText` names
    the collection in plain English ("Pennsylvania Wills and Probate
    Records"); the collection ID is embedded in the URL path. This match is
    what step 3 acts on.
 
-**`totalForPlace` vs `results.length`:**
-- `results.length > 0` → a curated URL exists; go to Case A.
-- empty but `totalForPlace > 0` → FS curates this place but nothing
-  overlaps your year window; widen the window or fall back (Case B).
+**`totalForPlace` vs `returned`:**
+- `returned > 0` → a curated URL for your site exists; go to Case A.
+- `returned === 0` but `totalForPlace > 0` → FS curates this place but nothing
+  matches your `host` + year window. Drop `host` to see which other sites are
+  curated, widen the window, or fall back (Case B).
 - `totalForPlace === 0` → no curated links here at all; fall back (Case B).
+
+`returned` is the count after the `host` filter and a safety cap; the full,
+uncapped set is what got staged, so nothing is lost.
 
 ### 3. Build the URL
 
@@ -247,6 +259,29 @@ https://www.newspapers.com/search/?query={first}+{last}&dr_year={year}&dr_place=
 
 ### 4. Log the search, then present the URL
 
+**First, persist the curated-links fetch.** If `external_links_search`
+returned a `staged.resultsRef` (present whenever the year-filtered set was
+non-empty), log the fetch as its **own** entry so the full curated set is
+retained on disk — it rides along when the user submits feedback, and makes the
+fetch part of the research record. This is separate from the external-site log
+below:
+
+```
+research_log_append({
+  projectPath: <absolute path of the current working directory>,
+  planItemId: "<pli_XXX or null>",
+  tool: "external_links",
+  query: { standardPlace: "<standardPlace>", host: "<host>", startYear: <year>, endYear: <year> },
+  outcome: "<positive if returned > 0, else negative>",
+  resultsExamined: <returned>,
+  notes: "Curated external links for <place>.",
+  stagedResultsRef: staged.resultsRef   // omit only when there is no staged handle (empty year-filtered set)
+})
+```
+
+Do **not** pass `externalSite` here — that field is only for `external_site`
+entries. Then log the site search itself.
+
 The log entry is what makes the search part of the research record, so
 **write it before you hand over the URL** — this step is not finished
 until both exist. If you present the URL and stop, `research.json` shows
@@ -278,8 +313,9 @@ research_log_append({
 
 `projectPath` is the project folder you are already operating in (the
 directory that contains `research.json`). Pass its absolute path.
-External-site searches retain no result sidecar, so do **not** pass
-`stagedResultsRef`.
+This **external-site** entry has no result sidecar (the capture hasn't
+arrived yet), so do **not** pass `stagedResultsRef` here — that handle
+belongs on the `external_links` entry above.
 
 `outcome: "partial"` + `captureReceived: false` mark it in-flight. When a
 capture comes back you append a **new** entry (step 6) — never edit this

--- a/packages/engine/plugin/skills/search-external-sites/SKILL.md
+++ b/packages/engine/plugin/skills/search-external-sites/SKILL.md
@@ -161,29 +161,29 @@ external_links_search({
 })
 ```
 
-`host` filters the results to your target site **server-side**, so `results[]`
-comes back as just that site's `{ url, linkText }` links — not every curated
-site for the place. `projectPath` stages the **full** year-filtered set (all
-sites) to disk and returns a `staged.resultsRef`; hold it for the step-4 log.
-Then consume `results[]`:
-1. **Dedupe by URL** — FS repeats the same URL once per record-type
+`host` narrows the returned `results[]` toward your target site (so a
+link-dense place can't overflow the response); `projectPath` stages the **full**
+year-filtered set (all sites) to disk and returns a `staged.resultsRef` — hold
+it for the step-4 log. `results[]` is a flat list of `{ url, linkText }`. Consume
+it:
+1. **Filter to your target site** — keep only links whose URL is for your site,
+   e.g. `result.url.includes("ancestry.com")`. `host` already narrows this
+   server-side, but filter here too so you stay correct if any off-site links
+   come through.
+2. **Dedupe by URL** — FS repeats the same URL once per record-type
    category. Collapse duplicates, and say so in one line when it happens
    ("collection 8800 appeared 3× under different labels — collapsed to one")
    so the dedup is visible, not silent.
-2. **Match `linkText` to the plan item's record type.** `linkText` names
+3. **Match `linkText` to the plan item's record type.** `linkText` names
    the collection in plain English ("Pennsylvania Wills and Probate
    Records"); the collection ID is embedded in the URL path. This match is
    what step 3 acts on.
 
-**`totalForPlace` vs `returned`:**
-- `returned > 0` → a curated URL for your site exists; go to Case A.
-- `returned === 0` but `totalForPlace > 0` → FS curates this place but nothing
-  matches your `host` + year window. Drop `host` to see which other sites are
-  curated, widen the window, or fall back (Case B).
+**How many links survived the site filter (call it `matched`):**
+- `matched > 0` → a curated URL for your site exists; go to Case A.
+- `matched === 0` but `totalForPlace > 0` → FS curates this place but nothing
+  matches your site + year window; widen the window or fall back (Case B).
 - `totalForPlace === 0` → no curated links here at all; fall back (Case B).
-
-`returned` is the count after the `host` filter and a safety cap; the full,
-uncapped set is what got staged, so nothing is lost.
 
 ### 3. Build the URL
 
@@ -270,7 +270,7 @@ below:
 research_log_append({
   projectPath: <absolute path of the current working directory>,
   planItemId: "<pli_XXX or null>",
-  tool: "external_links",
+  tool: "external_links_search",
   query: { standardPlace: "<standardPlace>", host: "<host>", startYear: <year>, endYear: <year> },
   outcome: "<positive if returned > 0, else negative>",
   resultsExamined: <returned>,
@@ -315,7 +315,7 @@ research_log_append({
 directory that contains `research.json`). Pass its absolute path.
 This **external-site** entry has no result sidecar (the capture hasn't
 arrived yet), so do **not** pass `stagedResultsRef` here — that handle
-belongs on the `external_links` entry above.
+belongs on the `external_links_search` entry above.
 
 `outcome: "partial"` + `captureReceived: false` mark it in-flight. When a
 capture comes back you append a **new** entry (step 6) — never edit this


### PR DESCRIPTION
Closes #696.

`fulltext_search` and `external_links_search` returned 79–136 KB payloads that overflowed the tool-result token cap, spilled to files, and cost a reader-subagent detour (closing report §3.5).

## Changes
- **`fulltext_search`** — once staged, strip the heavy inline `textDocument` (the AI-transcribed page — the overflow driver) from each result, mirroring `record_search`'s inline-`gedcomx` strip. The full text stays in the sidecar (`record_read` reads it back host-side); the light triage stubs (`names`/`places`/`dates`/`title`/`recordType`) survive for in-context ranking.
- **`external_links_search`** — add two optional params:
  - `projectPath` → stages the **full** year-filtered set to disk (so the complete curated-link list is retained) and returns a `staged.resultsRef`.
  - `host` → server-side filter to the caller's target site, returning the small exact set the skill needs instead of every curated site for the place.
  - The inline `results[]` is capped (`INLINE_CAP = 50`) **only once the full set is staged**, mirroring the other producers — nothing dropped is unrecoverable, and an un-staged caller still gets the full (optionally host-filtered) set.
- **`search-external-sites` skill** — pass `host` + `projectPath`, and log the fetch as its **own** `tool: "external_links"` entry with the staged handle, so the curated links land in `results/log_NNN.json` and ride along when a user clicks "submit feedback".
- **Spec/docs** — register `external_links` as a staging producer in `search-result-staging-spec.md`; add it to `research_log_append`'s tool description.

## Design notes for review
- **`host` filter over a blind count cap.** The plan initially proposed a blind first-N cap; the plan-review subagent flagged that the sole consumer filters by host *inline* and never reads the sidecar during the skill, so a blind cap could drop the target site's link on exactly the large places that overflow. A server-side `host` filter returns the exact set and can't drop it. Cap is retained only as a staged-conditional backstop.
- **Own log entry, not attached to the `external_site` entry.** `finalizeStagedResults` hard-checks the staged `tool` against the log entry's `tool`, so an `external_links` sidecar can only attach to an `external_links` entry.
- No schema-mirror / manifest change (tool *input* params only; log `tool` is a free string).

## Tests
- fulltext: strips `textDocument` when staged, keeps it when not (2 new).
- external_links: staging with `tool:"external_links"`, host filter narrows inline while the full set is staged, cap bites only when staged, best-effort staging-failure (6 new).
- Full mcp-server suite green (1438).

Plan + resolved plan-review: `docs/plan/search-shaping-and-staging-plan.md`. #699 (staging-integrity gate + loud D2 boundary) follows in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)