### PR TITLE
record-extractor: pin to claude-sonnet-4-6 to fix the high-effort hang

### DIFF
--- a/docs/TODOs.md
+++ b/docs/TODOs.md
@@ -90,6 +90,18 @@ Deferred from `docs/plan/record-extraction-consolidation-plan.md` §7 at wrap.
   written at `confident` from one uncorroborated record with `[?]` readings
   (clark-parents). The extractor agent got a tentative-cap line; person-evidence
   needs the equivalent gate + mandatory conflicts entry.
+- [ ] **Recover the classification-quality drop from the sonnet-4-6 pin.** The
+  extractor was re-pinned sonnet-5 → `claude-sonnet-4-6` (this PR) because sonnet-5
+  hangs at Cowork/e2e `effortLevel: high` (adaptive-thinking runaway); the 8k
+  output-cap alternative is non-viable (starves before any tool call, or runs away
+  across turns — 0 pass, ~20 min/test in a 5-test A/B). Downgrading is the surgical
+  fix (effort is session-wide, model is per-subagent) but costs ~0.24/3 mean judge
+  score, concentrated in GPS classification nuance: 4.6 slips on the **existing**
+  "Blank columns produce no assertions" rule and on `informant_proximity` /
+  `evidence_type` calls. Deferred mitigation: follow the rx-partials pattern of
+  adding concrete point-of-use examples (NOT duplicate rules), then re-run the
+  record-extraction unit suite to confirm recovery. Do **not** target the 009
+  death-cert case — judge noise, not craft (`rx-partials-to-passes-plan.md §1.C`).
 - [x] **Upstream sidecar-staging gap — DONE (#699).** One e2e run had all 18
   `record_persona_id`s nulled because the search never staged a sidecar
   (spriggs). D2 can't auto-fill what was never staged, and — since

--- a/packages/engine/plugin/agents/record-extractor.md
+++ b/packages/engine/plugin/agents/record-extractor.md
@@ -14,7 +14,7 @@ description: >-
   read page-scan images (the caller delegates those to image-reader —
   agents cannot nest agents), to acquire or triage input, or to format
   citations.
-model: claude-sonnet-5
+model: claude-sonnet-4-6
 tools:
   - mcp__genealogy__project_context
   - mcp__genealogy__record_read


### PR DESCRIPTION
## What

Pin the `record-extractor` subagent from `claude-sonnet-5` to `claude-sonnet-4-6`.

## Why

The subagent hangs in e2e harness runs and Cowork. Root cause: **it's a high-effort adaptive-thinking runaway, not a sonnet-5 defect.** e2e/Cowork run `effortLevel: high`; sonnet-5's adaptive thinking then explodes. At *default* effort sonnet-5 is fine.

Because **effort is session-wide** (`.claude/settings.json`; no per-subagent effort knob) but **model is per-subagent** (Cowork honors agent `model:`), downgrading the subagent to 4.6 is the only surgical lever that stops the runaway without dialing down the *main* research agent's reasoning.

## Evidence — 5-test A/B on the hardest record-extraction unit tests, at `effortLevel: high`

| Config | Outcomes (of 5) | Mean judge (of 3) | Runtime/test | Cost/test | Hangs? |
|---|---|---|---|---|---|
| **sonnet-4-6** (this PR) ×3 | 4 pass / 9 partial / 2 fail | **2.76** | **146s** | **$0.35** | **No** |
| sonnet-5 + 8k output cap ×1 | 0 pass / 1 partial / 2 fail / **2 aborted** | 2.67 (n=6) | **764s** (max 1322) | $1.55 | **Yes** |
| sonnet-5 @ default (baseline ref) | 4 pass / 1 fail | ~3.0 | — | — | No |

**The 8k output-cap alternative is non-viable at high effort:** it either *starves* (thinking eats the per-turn budget before any tool call → empty extraction, wall-clock abort) or *runs away across turns* (20+ turns, 20+ min, still fails). One pass = 22 min / \$7.73 / zero passes. (16k cap also fails — known.)

**Cost of the downgrade:** ~0.24/3 lower mean judge score than sonnet-5, concentrated in GPS classification nuance — 4.6 slips on the *existing* "Blank columns produce no assertions" rule and on `informant_proximity` / `evidence_type` calls. This is a **model-capability** gap (identical at default *and* high effort), not a missing-rule gap — so no new prompt rules here (they'd duplicate existing doctrine or target `009`, which `rx-partials-to-passes-plan.md §1.C` classifies as judge noise). Recovery is tracked in `docs/TODOs.md`.

## ⚠️ CI / runlog contract — needs a follow-up before merge

Editing `record-extractor.md` touches the record-extraction skill's runlog snapshot (the agent body is embedded in it), so `check-runlogs` will fail until:

1. **Rule 2** — a fresh **full record-extraction unit runlog on sonnet-4-6** is committed (the change is behavioral, not cosmetic — no skip label). ~\$14.50 / ~10 min; I can run it on request.
2. **Rule 3** — that runlog's `.ann.json` annotation (human calibration step — the maintainer's `grade`/annotate pass).

Holding on both until you say go, so we don't spend on the suite or fabricate an annotation.