### PR TITLE
ci: bump actions/checkout from v4 to v5 across all workflows

### DIFF
--- a/.github/workflows/check-e2e-fixtures.yml
+++ b/.github/workflows/check-e2e-fixtures.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out PR with full history
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/check-engine-lockfile.yml
+++ b/.github/workflows/check-engine-lockfile.yml
@@ -26,7 +26,7 @@ jobs:
   lockfile-drift:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Node
         uses: actions/setup-node@v4

--- a/.github/workflows/check-runlogs.yml
+++ b/.github/workflows/check-runlogs.yml
@@ -84,7 +84,7 @@ jobs:
           fi
 
       - name: Check out PR with full history
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/electron-release.yml
+++ b/.github/workflows/electron-release.yml
@@ -42,7 +42,7 @@ jobs:
     timeout-minutes: 60
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       # pnpm BEFORE setup-node so the npm-cache step can find it. Version is read
       # from the root package.json `packageManager` field.

--- a/.github/workflows/eval-harness-tests.yml
+++ b/.github/workflows/eval-harness-tests.yml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out PR
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Node
         uses: actions/setup-node@v4

--- a/.github/workflows/payload-guard.yml
+++ b/.github/workflows/payload-guard.yml
@@ -12,7 +12,7 @@ jobs:
   scan:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Scan for known malware indicators
         shell: bash
         run: |


### PR DESCRIPTION
## What

Bumps `actions/checkout` from **v4 → v5** in the six workflows on `main`:

- `check-e2e-fixtures.yml`
- `check-engine-lockfile.yml`
- `eval-harness-tests.yml`
- `electron-release.yml`
- `payload-guard.yml`
- `check-runlogs.yml`

## Why

GitHub's runners now force `actions/checkout@v4` (Node 20) to run on Node 24 and
emit a deprecation warning on every workflow run. `checkout@v5` targets Node 24
natively, clearing the notice. Pure version bump — no behavior change.

## Note

The new `check-coauthor.yml` workflow isn't on `main` yet, so its bump rides in
its own PR (#726), where that file is introduced. Once both merge, all seven
workflows are on v5.

(`checkout` v7 is the latest overall; this stays on **v5** per the request, which
is the minimum that resolves the Node 20 deprecation.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)