### PR TITLE
fix(web): stop over-counting the session cost meter

### DIFF
--- a/apps/server/app/agent/real_agent.py
+++ b/apps/server/app/agent/real_agent.py
@@ -128,6 +128,12 @@ class RealAgent:
         self._session_file = project_dir / ".agent_session"
         self._resume_id: str | None = None
         self._tool_names: dict[str, str] = {}  # tool_use_id → name, for tool_result tagging
+        # Running cumulative cost/usage last seen from the SDK, so we can emit
+        # per-turn deltas (see _usage_delta). The SDK's ResultMessage reports
+        # session totals, not per-turn values.
+        self._cum_cost = 0.0
+        self._cum_in = 0
+        self._cum_out = 0
         if self._session_file.exists():
             try:
                 self._resume_id = self._session_file.read_text(encoding="utf-8").strip() or None
@@ -143,6 +149,28 @@ class RealAgent:
             )
             await self._client.connect()
         return self._client
+
+    def _usage_delta(self, cost, in_tok, out_tok):
+        """Convert the SDK's cumulative session totals into per-turn increments.
+
+        ``ResultMessage.total_cost_usd`` and ``.usage`` are cumulative across
+        the whole session — they grow every turn. The client sums the usage
+        events it receives (and gets genuine per-turn values from the mock
+        agent), so it must be handed the increment, not the running total;
+        summing running totals over-counts the session cost by ~(turns+1)/2.
+        A ``None`` field passes through as ``None`` without advancing its
+        baseline, and each delta is floored at 0 so a lower snapshot (e.g. a
+        cumulative counter that reset on resume) can't emit a negative."""
+
+        def step(prev, cur):
+            if cur is None:
+                return prev, None
+            return cur, max(cur - prev, 0)
+
+        self._cum_cost, d_cost = step(self._cum_cost, cost)
+        self._cum_in, d_in = step(self._cum_in, in_tok)
+        self._cum_out, d_out = step(self._cum_out, out_tok)
+        return d_cost, d_in, d_out
 
     def _remember_session(self, message) -> None:
         sid = getattr(message, "session_id", None)
@@ -173,20 +201,24 @@ class RealAgent:
                     self._remember_session(message)  # persist for resume on relaunch
                     # Per-turn cost/usage for the operator cost meter (alpha
                     # mode, web only). The SDK's ResultMessage carries
-                    # total_cost_usd + a usage dict that was otherwise discarded;
-                    # emit one event the client sums. Defensive: fields may be
-                    # absent on older SDKs or partial results.
+                    # total_cost_usd + a usage dict that was otherwise discarded,
+                    # both as CUMULATIVE session totals — so emit the per-turn
+                    # delta the client sums (see _usage_delta). Defensive: fields
+                    # may be absent on older SDKs or partial results.
                     usage = getattr(message, "usage", None)
                     if isinstance(usage, dict):
                         in_tok, out_tok = usage.get("input_tokens"), usage.get("output_tokens")
                     else:
                         in_tok = getattr(usage, "input_tokens", None)
                         out_tok = getattr(usage, "output_tokens", None)
+                    d_cost, d_in, d_out = self._usage_delta(
+                        getattr(message, "total_cost_usd", None), in_tok, out_tok
+                    )
                     yield _event(
                         "usage",
-                        cost_usd=getattr(message, "total_cost_usd", None),
-                        input_tokens=in_tok,
-                        output_tokens=out_tok,
+                        cost_usd=d_cost,
+                        input_tokens=d_in,
+                        output_tokens=d_out,
                     )
                     break  # turn complete; the runner emits turn_done
         except Exception as exc:

--- a/apps/server/tests/test_real_agent_usage.py
+++ b/apps/server/tests/test_real_agent_usage.py
@@ -1,0 +1,52 @@
+"""RealAgent cost/usage accounting.
+
+The Claude Agent SDK's ResultMessage reports total_cost_usd and token usage as
+CUMULATIVE session totals (they grow every turn). The web cost meter sums the
+usage events it receives, so RealAgent must emit the per-turn *delta*, not the
+running total — otherwise a long session's cost is over-counted by roughly
+(turns+1)/2 (the bug that showed a ~$150 meter for a ~$15 session).
+"""
+
+import pytest
+
+from app.agent.real_agent import RealAgent
+
+
+def test_usage_delta_emits_per_turn_increments(tmp_path):
+    agent = RealAgent(tmp_path)
+    # Cumulative snapshots as the SDK reports them across three turns.
+    snapshots = [(0.10, 1000, 200), (0.25, 2500, 500), (0.45, 4000, 900)]
+    deltas = [agent._usage_delta(*snap) for snap in snapshots]
+
+    # First turn's delta equals the first cumulative snapshot.
+    assert deltas[0] == (0.10, 1000, 200)
+    # Later deltas are increments, not the running total.
+    assert deltas[1][1] == 1500 and deltas[2][1] == 1500
+    assert deltas[1][2] == 300 and deltas[2][2] == 400
+
+    # Summing the emitted deltas reconstructs the true session total — the
+    # property the client relies on. (Summing the raw cumulative snapshots
+    # would have given cost 0.80 / input 7500 — the over-count.)
+    assert round(sum(d[0] for d in deltas), 6) == 0.45
+    assert sum(d[1] for d in deltas) == 4000
+    assert sum(d[2] for d in deltas) == 900
+
+
+def test_usage_delta_passes_through_none_without_advancing_baseline(tmp_path):
+    agent = RealAgent(tmp_path)
+    assert agent._usage_delta(None, None, None) == (None, None, None)
+    assert agent._usage_delta(0.10, 1000, 200) == (0.10, 1000, 200)
+    # A None field emits None and leaves its baseline untouched, so the next
+    # real snapshot still deltas against the last real value.
+    assert agent._usage_delta(None, 1500, None) == (None, 500, None)
+
+
+def test_usage_delta_floors_negative_at_zero(tmp_path):
+    agent = RealAgent(tmp_path)
+    agent._usage_delta(1.00, 5000, 900)
+    # A lower snapshot (e.g. a cumulative counter that reset on resume) must
+    # not emit a negative increment; it rebaselines instead.
+    assert agent._usage_delta(0.20, 1000, 100) == (0.0, 0, 0)
+    d_cost, d_in, d_out = agent._usage_delta(0.50, 1400, 250)
+    assert d_cost == pytest.approx(0.30)
+    assert (d_in, d_out) == (400, 150)


### PR DESCRIPTION
## Problem

The web app's alpha cost meter showed **~\$150 for a session that actually cost <\$15** on the Anthropic bill — a ~10× over-count.

## Root cause

`SessionView.tsx` accumulates each turn's usage event (`usd: c.usd + u.costUsd`), and `RealAgent` emitted `ResultMessage.total_cost_usd` per turn. But the Claude Agent SDK reports `total_cost_usd` **and** token usage as **cumulative session totals**, not per-turn values. Summing running totals over-counts by ~`(turns+1)/2`, so a ~20-turn research session shows ~10× — exactly the observed \$15 → \$150.

Evidence it's cumulative (not a pricing bug — the meter shows the SDK value verbatim, no rate math):
- The e2e harness already treats a single `message.total_cost_usd` as the whole-run budget cap (`eval/harness/e2e/orchestrator.py:803-808`), never summing across turns.
- An e2e runlog (`anders-monsen-ancestry`) reports `usage.cache_read_input_tokens` = **4.69M** over 74 turns — far above the 1M context window, impossible for one turn — and those cumulative tokens reconcile with the reported `total_cost_usd`. So **tokens are cumulative too.**

## Fix

Emit the **per-turn delta** from `RealAgent` (`_usage_delta`) so the usage-event contract is uniformly "increment per turn." The client keeps summing (unchanged) and the mock agent — which already emits genuine per-turn values — stays correct. Deltas floor at 0 so a cumulative counter that resets (e.g. on resume) can't emit a negative.

Per the maintainer's call, per-session-from-\$0 vs cross-session accumulation is left to whatever falls out simplest; this keeps the client/mock untouched and is correct under both.

## Tests

- New `apps/server/tests/test_real_agent_usage.py` — asserts summed deltas reconstruct the true session total (the property the client relies on), None pass-through, and the negative-floor.
- Full `apps/server` suite green (49 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)