### PR TITLE
Lint skill/agent description length; trim proof-conclusion under the cap

### DIFF
--- a/packages/engine/mcp-server/tests/packaging/skill-description-length.test.ts
+++ b/packages/engine/mcp-server/tests/packaging/skill-description-length.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync, readdirSync, existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+// Length lint for skill and plugin-agent descriptions. The description drives
+// triggering (skills) and orchestrator auto-delegation (agents), and the
+// runtime caps it at 1024 characters — over the cap the entry fails to load,
+// silently. Most descriptions here sit within a few dozen characters of the
+// cap, so a one-word edit can push one over; this test catches that in CI
+// instead of at install time.
+
+const MAX_DESCRIPTION_LENGTH = 1024;
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(here, "..", "..", "..");
+const skillsDir = join(repoRoot, "plugin", "skills");
+const agentsDir = join(repoRoot, "plugin", "agents");
+
+/**
+ * Pull the `description` value out of YAML frontmatter and return it as the
+ * runtime's YAML parser would — the string whose length is capped.
+ *
+ * Deliberately minimal rather than a YAML dependency: it covers the two forms
+ * these files use — a plain scalar continued across indented lines, and a
+ * `>-` folded block. Both fold to a space-joined single line, so the two
+ * cases differ only in how the first line is read.
+ */
+function extractDescription(text: string): string {
+  const frontmatter = /^---\r?\n([\s\S]*?)\r?\n---/.exec(text);
+  if (!frontmatter) throw new Error("no YAML frontmatter");
+
+  const lines = frontmatter[1].split(/\r?\n/);
+  const start = lines.findIndex((l) => /^description:/.test(l));
+  if (start === -1) throw new Error("no description key");
+
+  const first = lines[start].slice("description:".length).trim();
+
+  // Continuation lines run until the next top-level key (column 0).
+  const continuation: string[] = [];
+  for (let i = start + 1; i < lines.length; i++) {
+    if (/^\S/.test(lines[i])) break;
+    continuation.push(lines[i].trim());
+  }
+
+  // Block scalar: `>`/`|` with optional chomping indicator. The indicator line
+  // carries no content, so the value is the continuation lines alone.
+  if (/^[>|][-+]?$/.test(first)) {
+    const literal = first.startsWith("|");
+    return foldLines(continuation, literal).trim();
+  }
+
+  const plain = foldLines([first, ...continuation], false).trim();
+  // Strip surrounding quotes on a quoted scalar.
+  return plain.length >= 2 && plain[0] === plain[plain.length - 1] && /["']/.test(plain[0])
+    ? plain.slice(1, -1)
+    : plain;
+}
+
+/** Join per YAML block semantics: literal keeps newlines, folded joins with a
+ *  space and turns a blank line into a newline. */
+function foldLines(lines: string[], literal: boolean): string {
+  if (literal) return lines.join("\n");
+  return lines.reduce((acc, line) => {
+    if (acc === "") return line;
+    if (line === "") return acc + "\n";
+    return acc.endsWith("\n") ? acc + line : acc + " " + line;
+  }, "");
+}
+
+const targets: Array<{ label: string; path: string }> = [
+  ...readdirSync(skillsDir)
+    .map((name) => ({ label: `skills/${name}`, path: join(skillsDir, name, "SKILL.md") }))
+    .filter((t) => existsSync(t.path)),
+  ...readdirSync(agentsDir)
+    .filter((name) => name.endsWith(".md"))
+    .map((name) => ({ label: `agents/${name}`, path: join(agentsDir, name) })),
+];
+
+describe("skill and agent description length", () => {
+  it("finds skills and agents to check", () => {
+    expect(targets.length).toBeGreaterThan(0);
+  });
+
+  for (const { label, path } of targets) {
+    it(`${label} description is within ${MAX_DESCRIPTION_LENGTH} characters`, () => {
+      const description = extractDescription(readFileSync(path, "utf8"));
+      expect(description.length, `${label} description is ${description.length} chars`).
+        toBeLessThanOrEqual(MAX_DESCRIPTION_LENGTH);
+    });
+  }
+});

--- a/packages/engine/plugin/skills/proof-conclusion/SKILL.md
+++ b/packages/engine/plugin/skills/proof-conclusion/SKILL.md
@@ -4,10 +4,7 @@ model: claude-sonnet-4-6
 description: Writes GPS-conformant proof conclusions — selects the tier
   (Proved/Probable/Possible/Not Proved/Disproved), chooses the form
   (Statement/Summary/Argument), and writes a self-contained narrative
-  markdown uploadable to FamilySearch. Marks the concluded value in
-  tree.gedcomx.json — sets primary/preferred on the evidence facts already
-  materialized there (via tree_correct, or an additive tree_edit fact for a
-  synthesized conclusion) — and gates FamilySearch upload to concluded facts.
+  markdown uploadable to FamilySearch.
   GPS Step 5 — Soundly Reasoned, Coherently Written Conclusion. Use when
   the user says "write the conclusion", "what's the proof?", "summarize
   the evidence", "write a proof statement", "write a proof argument",


### PR DESCRIPTION
## Why

A skill or plugin-agent `description` over 1024 characters fails to load **silently**. `proof-conclusion` had drifted to **1220**. Nothing in the repo checked this — it surfaced only because I went looking.

Worse, this is not a one-off: eleven descriptions sit within ~25 characters of the cap.

| chars | entry |
|------:|-------|
| 1023 | person-evidence, locality-guide |
| 1021 | gps-mentor (agent) |
| 1020 | record-extraction |
| 1018 | project-status |
| 1016 | citation |
| 1009 | hypothesis-tracking |

Adding a single word to any of those breaks the plugin with no local signal.

## What

**1. Trim `proof-conclusion` 1220 → 968.** Dropped this sentence from the description:

> Marks the concluded value in tree.gedcomx.json — sets primary/preferred on the evidence facts already materialized there (via tree_correct, or an additive tree_edit fact for a synthesized conclusion) — and gates FamilySearch upload to concluded facts.

Nothing is lost. It is pure mechanism with no trigger surface, and the body documents it far more precisely in the tree-write step (both the `tree_correct` common case and the synthesized additive `tree_edit` case). The full `GPS Step 5 — Soundly Reasoned, Coherently Written Conclusion.` marker is kept, staying parallel with `citation`'s Step 2 phrasing.

**2. Add `tests/packaging/skill-description-length.test.ts`** — one case per skill and plugin agent (31 today). It sits beside `skill-guidance.test.ts`, which set the precedent for a packaging test reading `plugin/`.

## On the parser

mcp-server has no YAML dependency, so the test ships a minimal frontmatter extractor for the two forms actually in use — plain multi-line scalars and `>-` folded blocks.

I did not trust it on a green run. Its output was diffed against PyYAML across all 30 entries: **byte-for-byte identical**. That check earned its keep — my first ad-hoc regex over-counted the folded-block files by 3 characters (the `>-` indicator leaking into the value) and falsely flagged `locality-guide` and `person-evidence` at 1026.

Also verified the test *fails* when it should, by padding a description to 1351:

```
skills/validate-schema description is 1351 chars: expected 1351 to be less than or equal to 1024
```

## Testing

`make engine-test` — 67 files, 1504 tests pass.

Note for anyone hitting a `Cannot find package 'open'` failure in `manifest.test.ts`: that is an empty engine `node_modules`, not a code problem. `make engine-test` is self-healing (it runs `npm ci` via the `ENGINE_DEPS` stamp); invoking `npx vitest` directly bypasses that.