### PR TITLE
research_append: identity over-reach gate + worked-example registry (#700, #697)

### DIFF
--- a/packages/engine/mcp-server/src/tools/research-append-examples.ts
+++ b/packages/engine/mcp-server/src/tools/research-append-examples.ts
@@ -1,0 +1,251 @@
+/**
+ * Worked `research_append` examples, one per writer section.
+ *
+ * Why these live here and not only in SKILL.md prose: a skill-side example
+ * only helps when the skill that owns the section happens to be loaded. The
+ * closing report's T15 row is the proof — `conflicts` has had a good worked
+ * example in conflict-resolution/SKILL.md for months and still drew ~6
+ * rejections in one scenario, because the caller was a different skill. These
+ * are attached to the *rejection*, so the shape arrives exactly when the model
+ * got it wrong, regardless of which caller is driving.
+ *
+ * Field lists are transcribed from docs/specs/schemas/research.schema.json;
+ * enum literals from enums.schema.json. Every example shows the required keys
+ * with explicit `null`s for the not-yet-known optional ones — the explicit
+ * null is what stops the trial-and-error loop, since the validator's
+ * additionalProperties:false rejects invented keys and its `required` rejects
+ * omitted ones.
+ *
+ * None of these carry an `id`: the tool assigns it (research-append.ts rejects
+ * an entry that carries one).
+ */
+
+/** Section → a single worked `entry` payload, as pretty JSON. */
+const EXAMPLES: Record<string, string> = {
+  // No "gedcomx_source_description_id" here on purpose: the composite form
+  // below supplies "sourceDescription", which CREATES the tree's S entry and
+  // fills the id. Carrying both is rejected; carrying neither is rejected
+  // unless the S entry already exists.
+  sources: `{
+  "citation": "\\"Pennsylvania, Death Certificates, 1906-1968,\\" database with images, FamilySearch, Patrick Flynn, 12 Mar 1908; citing Schuylkill County, certificate no. 24601.",
+  "citation_detail": {
+    "who": "Schuylkill County registrar",
+    "what": "Certificate of death no. 24601",
+    "when_created": "1908",
+    "when_accessed": "2026-07-18",
+    "where": "Harrisburg, Pennsylvania",
+    "where_within": "certificate no. 24601"
+  },
+  "source_classification": "original",
+  "repository": "FamilySearch",
+  "access_date": "2026-07-18",
+  "url": "https://www.familysearch.org/ark:/61903/1:1:MDEF",
+  "url_archived": null,
+  "notes": null,
+  "transcription": null,
+  "image_filename": null,
+  "log_entry_id": "log_004"
+}`,
+
+  assertions: `{
+  "source_id": "src_004",
+  "record_id": "ark:/61903/1:1:MDEF",
+  "record_role": "deceased",
+  "record_persona_id": "p1",
+  "fact_type": "death",
+  "value": "12 Mar 1908",
+  "structured_value": null,
+  "date": "1908-03-12",
+  "date_certainty": "exact",
+  "place": "Schuylkill County, Pennsylvania",
+  "standard_place": "Schuylkill, Pennsylvania, United States",
+  "information_quality": "primary",
+  "informant": "Mary Flynn, widow",
+  "informant_proximity": "household_member",
+  "informant_bias_notes": null,
+  "evidence_type": "direct",
+  "log_entry_id": "log_004",
+  "extracted_for_question_ids": ["q_002"]
+}`,
+
+  person_evidence: `{
+  "assertion_id": "a_013",
+  "person_id": "I1",
+  "confidence": "probable",
+  "rationale": "Death certificate names Patrick Flynn, d. 1908 Schuylkill County — name, place and date match the subject. Father's name is a single uncorroborated reading, so the link is probable rather than confident.",
+  "match_score": null,
+  "created": "2026-07-18",
+  "superseded_by": null
+}`,
+
+  questions: `{
+  "question": "Who were the parents of Patrick Flynn (b. abt 1845, Ireland)?",
+  "rationale": "The death certificate names a father (Thomas Flynn) on a single uncorroborated reading; no record yet names the mother.",
+  "selection_basis": "unresolved_conflict",
+  "priority": "high",
+  "status": "open",
+  "depends_on": [],
+  "unblocks": [],
+  "created": "2026-07-18",
+  "resolved": null,
+  "resolution_assertion_ids": [],
+  "exhaustive_declaration": {
+    "declared": false,
+    "justification": null,
+    "log_entry_ids": [],
+    "stop_criteria": null
+  }
+}`,
+
+  plans: `{
+  "question_id": "q_002",
+  "status": "active",
+  "created": "2026-07-18",
+  "items": []
+}`,
+
+  plan_items: `{
+  "sequence": 1,
+  "record_type": "church",
+  "jurisdiction": "County Mayo, Ireland",
+  "date_range": "1840-1850",
+  "repository": "FamilySearch",
+  "rationale": "Catholic baptismal registers are the only pre-civil-registration source naming both parents in this jurisdiction.",
+  "fallback_for": null,
+  "status": "planned"
+}`,
+
+  conflicts: `{
+  "conflict_type": "fact",
+  "description": "Patrick Flynn's birth year: 1845 (1850 census, age 5) vs. 1843 (delayed birth certificate)",
+  "disputed_attribute": "birth_year",
+  "identity_question": null,
+  "competing_assertion_ids": ["a_002", "a_025"],
+  "independence_analysis": null,
+  "weighing_analysis": null,
+  "preferred_assertion_id": null,
+  "resolution_rationale": null,
+  "status": "unresolved",
+  "blocks_question_ids": []
+}`,
+
+  hypotheses: `{
+  "claim": "Patrick Flynn of Schuylkill County is the same man as Patrick Flynn who emigrated from County Mayo in 1863.",
+  "status": "active",
+  "supporting_assertion_ids": ["a_013"],
+  "contradicting_assertion_ids": [],
+  "ruled_out": false,
+  "ruled_out_reason": null,
+  "notes": null,
+  "related_question_ids": ["q_002"]
+}`,
+
+  timelines: `{
+  "label": "Patrick Flynn — life events",
+  "hypothesis_id": null,
+  "person_ids": ["I1"],
+  "generated": "2026-07-18T14:05:00Z",
+  "events": [],
+  "gaps": [],
+  "impossibilities": []
+}`,
+
+  proof_summaries: `{
+  "question_id": "q_002",
+  "tier": "probable",
+  "vehicle": "summary",
+  "supporting_assertion_ids": ["a_013", "a_025"],
+  "resolved_conflict_ids": ["c_001"],
+  "exhaustive_search_summary": "Searched Schuylkill County civil death registers, Catholic parish registers for St. Patrick's, and the 1850-1880 federal censuses; no further records naming Patrick's parents surfaced.",
+  "narrative_markdown": "## Parents of Patrick Flynn\\n\\nThe 1908 death certificate names Thomas Flynn as father..."
+}`,
+
+  // The section that drew the identical rejection in 4+ runs across 4
+  // scenarios. `file_path` and `superseded_by` are BOTH required; the verdict
+  // body (`strengths`, `must_address`, …) is NOT part of this entry — it lives
+  // in the file at `file_path`. This entry is a pointer, not the report.
+  evaluations: `{
+  "focus": "conclusion-readiness",
+  "target_id": "q_002",
+  "target_type": "question",
+  "verdict": "consider_addressing",
+  "file_path": "evaluations/ev-2026-07-18-q002.md",
+  "timestamp": "2026-07-18T14:05:00Z",
+  "superseded_by": null
+}`,
+
+  known_holdings: `{
+  "holding_type": "document",
+  "description": "Great-grandmother's family Bible with births recorded on the flyleaf",
+  "relevant_facts": "Birth dates for six children, 1868-1881",
+  "relates_to_person_ids": ["I1"],
+  "confidence": "confident",
+  "promoted": false,
+  "created": "2026-07-18"
+}`,
+};
+
+/** `project` is a singleton: update-only field writes, no `entry`. */
+const PROJECT_EXAMPLE = `research_append({
+  projectPath: "<absolute-path-to-project-directory>",
+  section: "project",
+  op: "update",
+  fields: { "status": "completed" }
+})`;
+
+/**
+ * A worked `research_append` call for `section`, or null when the section has
+ * no example. `op` selects the call shape (`plan_items` needs a `planId`).
+ */
+export function exampleFor(section: string, op: "append" | "update" = "append"): string | null {
+  if (section === "project") return PROJECT_EXAMPLE;
+  const entry = EXAMPLES[section];
+  if (!entry) return null;
+  const planId = section === "plan_items" ? `\n  planId: "pl_001",` : "";
+  // A source append must either reference an S entry that already exists in the
+  // tree or create one in the same call. The composite form is the norm, so the
+  // example teaches it rather than a bare id that would be rejected.
+  const sourceDescription =
+    section === "sources"
+      ? `\n  sourceDescription: {\n    title: "Pennsylvania Death Certificate — Patrick Flynn (1908)",\n    author: "Pennsylvania Department of Health",\n    url: "https://www.familysearch.org/ark:/61903/1:1:MDEF"\n  },`
+      : "";
+  const indented = entry.split("\n").join("\n  ");
+  if (op === "update") {
+    return `research_append({
+  projectPath: "<absolute-path-to-project-directory>",
+  section: "${section}",
+  op: "update",${planId}
+  entryId: "<existing-id>",
+  fields: { /* only the fields you are changing */ }
+})`;
+  }
+  return `research_append({
+  projectPath: "<absolute-path-to-project-directory>",
+  section: "${section}",
+  op: "append",${planId}${sourceDescription}
+  entry: ${indented}
+})`;
+}
+
+/**
+ * Rejection-time teaching aid: the worked call for each implicated section,
+ * appended to the error list. Capped so a wide batch failure cannot bury the
+ * actual errors under example text.
+ */
+export function exampleHints(
+  sections: Array<{ section: string; op: "append" | "update" }>,
+  max = 2,
+): string[] {
+  const seen = new Set<string>();
+  const hints: string[] = [];
+  for (const { section, op } of sections) {
+    if (hints.length >= max) break;
+    if (seen.has(section)) continue;
+    seen.add(section);
+    const ex = exampleFor(section, op);
+    if (ex) hints.push(`worked example for '${section}':\n${ex}`);
+  }
+  return hints;
+}
+
+export const __testing = { EXAMPLES };

--- a/packages/engine/mcp-server/src/tools/research-append.ts
+++ b/packages/engine/mcp-server/src/tools/research-append.ts
@@ -30,6 +30,7 @@ import {
   isInsideProject,
 } from "../utils/project-io.js";
 import { coerceJsonArg } from "../utils/coerce-json-arg.js";
+import { exampleHints } from "./research-append-examples.js";
 import { gcUnreferencedImages } from "../utils/image-store.js";
 import { nextId } from "../utils/gedcomx-ids.js";
 import { arkToBareId } from "../utils/ark.js";
@@ -115,6 +116,56 @@ function planActiveInvariants(entry: any, research: any): string[] {
     ];
   }
   return [];
+}
+
+/** An uncertain transcription rides in the assertion's `value` as `[?]` — the
+ *  record-extractor contract ("Keep the uncertain reading in `value` with
+ *  `[?]`"). Nothing else in the entry marks doubt structurally. */
+function hasUncertainReading(assertion: any): boolean {
+  return typeof assertion?.value === "string" && assertion.value.includes("[?]");
+}
+
+/** Distinct records (falling back to source) that already tie other, still-live
+ *  person_evidence rows to this person — excluding this entry and its own
+ *  record. Size 0 ⇒ the identity rests on this single record alone. */
+function corroboratingRecordCount(entry: any, research: any, byId: Map<string, any>): number {
+  const own = byId.get(entry.assertion_id);
+  const ownRecord = own?.record_id ?? own?.source_id ?? null;
+  const distinct = new Set<string>();
+  for (const pe of research.person_evidence ?? []) {
+    if (pe === entry || pe.id === entry.id) continue;
+    if (pe.person_id !== entry.person_id) continue;
+    if (pe.superseded_by != null) continue;
+    const a = byId.get(pe.assertion_id);
+    const rec = a?.record_id ?? a?.source_id ?? null;
+    if (rec != null && rec !== ownRecord) distinct.add(rec);
+  }
+  return distinct.size;
+}
+
+/** Epistemic gate for identity over-reach (the record-extractor's tentative-cap,
+ *  enforced at the link point rather than left to prose).
+ *
+ *  Deliberately CONJUNCTIVE: an uncertain reading AND no corroborating record.
+ *  A `confident` link off a single *clean* record stays legal — that is the
+ *  ordinary case (a death certificate that plainly names its subject), and
+ *  gating on record-count alone would reject it. Doubt only becomes
+ *  disqualifying when nothing independent backs it up. */
+function personEvidenceInvariants(entry: any, research: any): string[] {
+  if (entry.confidence !== "confident") return [];
+  const assertions: any[] = research.assertions ?? [];
+  const byId = new Map<string, any>(assertions.map((a: any) => [a.id, a]));
+  const linked = byId.get(entry.assertion_id);
+  // Missing FK is already reported by the document validator; don't double-fault.
+  if (!linked || !hasUncertainReading(linked)) return [];
+  if (corroboratingRecordCount(entry, research, byId) > 0) return [];
+  return [
+    `confidence 'confident' is not available here: assertion '${entry.assertion_id}' carries an ` +
+      `uncertain reading ([?]) and no other record independently ties person '${entry.person_id}' ` +
+      `to this identity. Use 'probable' (or 'speculative'), keep the [?] in the assertion value, ` +
+      `and record what would resolve it — a second independent record, or the original image. ` +
+      `A confident wrong parent is worse than a flagged uncertain one.`,
+  ];
 }
 
 export type ResearchAppendSection = keyof typeof SECTIONS | string;
@@ -604,6 +655,11 @@ function applyOne(research: any, op: ResearchAppendOp, appendedThisBatch?: Set<s
   // (re)sets status to "active"; the helper no-ops for non-active entries.
   if (section === "plans") {
     invariantErrors.push(...planActiveInvariants(resultEntry, research));
+  }
+  // Identity over-reach: runs on append AND on an update that raises confidence
+  // to "confident"; the helper no-ops for every other confidence value.
+  if (section === "person_evidence") {
+    invariantErrors.push(...personEvidenceInvariants(resultEntry, research));
   }
   if (invariantErrors.length > 0) {
     throw new ResearchAppendError(invariantErrors);
@@ -1222,8 +1278,16 @@ export async function researchAppend(
 
   const isBatch = input.ops !== undefined;
   const opsReceived = isBatch && Array.isArray(input.ops) ? input.ops.length : undefined;
-  const fail = (errors: string[]): ResearchAppendResult =>
-    opsReceived !== undefined ? { ok: false, errors, opsReceived } : { ok: false, errors };
+  /** `hint` names the op(s) the failure is about; their worked examples are
+   *  appended so a rejected call teaches the shape on the spot instead of
+   *  depending on the right SKILL.md having been loaded. */
+  const fail = (
+    errors: string[],
+    hint?: Array<{ section: string; op: "append" | "update" }>,
+  ): ResearchAppendResult => {
+    const all = hint && hint.length > 0 ? [...errors, ...exampleHints(hint)] : errors;
+    return opsReceived !== undefined ? { ok: false, errors: all, opsReceived } : { ok: false, errors: all };
+  };
 
   try {
     const research = await readJson(projectPath, "research.json");
@@ -1269,7 +1333,10 @@ export async function researchAppend(
       } catch (e) {
         if (e instanceof ResearchAppendError) {
           // Identify the failing op; nothing has been written.
-          return fail(e.errors.map((m) => fmt(i, m)));
+          return fail(
+            e.errors.map((m) => fmt(i, m)),
+            [{ section: String(ops[i].section), op: ops[i].op === "update" ? "update" : "append" }],
+          );
         }
         throw e;
       }
@@ -1284,7 +1351,20 @@ export async function researchAppend(
     if (anyMutation) {
       const validation = await validateParsed(research, tree, { projectPath });
       if (!validation.valid) {
-        return fail(mapValidationErrors(formatIssues(validation.errors), applied, isBatch));
+        // Shape errors surface here (the document validator, not applyOne), so
+        // this is the site the evaluations/known_holdings rejections land on.
+        const mapped = mapValidationErrors(formatIssues(validation.errors), applied, isBatch);
+        // Only hint the sections the errors actually name — in a wide batch,
+        // examples for ops that validated fine would be noise pointing away
+        // from the real problem.
+        const blamed = ops.filter((o) => mapped.some((m) => m.includes(String(o.section))));
+        return fail(
+          mapped,
+          (blamed.length > 0 ? blamed : ops).map((o) => ({
+            section: String(o.section),
+            op: o.op === "update" ? "update" : "append",
+          })),
+        );
       }
       validationWarnings = formatIssues(validation.warnings);
       const researchPath = join(projectPath, "research.json");
@@ -1339,7 +1419,14 @@ export async function researchAppend(
       validation: validationBlock,
     };
   } catch (e) {
-    if (e instanceof ResearchAppendError) return fail(e.errors);
+    if (e instanceof ResearchAppendError) {
+      // Single-op path (and pre-pass throws): the section is only known when
+      // the caller used the non-batch form.
+      return fail(
+        e.errors,
+        input.section ? [{ section: String(input.section), op: input.op === "update" ? "update" : "append" }] : undefined,
+      );
+    }
     throw e;
   }
 }

--- a/packages/engine/mcp-server/tests/tools/research-append.test.ts
+++ b/packages/engine/mcp-server/tests/tools/research-append.test.ts
@@ -17,6 +17,7 @@ vi.mock("../../src/utils/place-resolver.js", () => ({
 }));
 
 import { researchAppend, countryConsistency } from "../../src/tools/research-append.js";
+import { __testing } from "../../src/tools/research-append-examples.js";
 import { resolveStandardPlace } from "../../src/utils/place-resolver.js";
 
 const citationDetail = {
@@ -2086,5 +2087,338 @@ describe("countryConsistency heuristic", () => {
     ["Schuylkill County, Pennsylvania", "Schuylkill, Pennsylvania, United States", "unverifiable"], // no country named
   ])("%s vs %s → %s", (place, standard, expected) => {
     expect(countryConsistency(place as string, standard as string)).toBe(expected);
+  });
+});
+
+// ─── Identity over-reach gate (#700) ────────────────────────────────────────
+//
+// Conjunctive by design: uncertain reading AND no corroborating record. The
+// eval fixture corpus carries no `[?]` at all, so nothing in eval/ exercises
+// this — these tests are the only coverage.
+
+describe("research_append — person_evidence epistemic gate", () => {
+  let dir: string;
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "research-append-pe-gate-"));
+  });
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  /** src_001/a_001 exist from baseResearch(); add the ones each case needs. */
+  function researchWith(assertions: any[], personEvidence: any[] = []) {
+    const r = baseResearch();
+    r.assertions = [...r.assertions, ...assertions] as any;
+    r.person_evidence = personEvidence as any;
+    return r;
+  }
+  const uncertain = (id: string, recordId: string) => ({
+    ...validAssertion(id),
+    record_id: recordId,
+    fact_type: "name",
+    value: "Father: Thomas Fl[?]nn",
+  });
+  const clean = (id: string, recordId: string) => ({
+    ...validAssertion(id),
+    record_id: recordId,
+    fact_type: "name",
+    value: "Father: Thomas Flynn",
+  });
+  async function write(research: any) {
+    await writeFile(join(dir, "research.json"), JSON.stringify(research, null, 2));
+    await writeFile(join(dir, "tree.gedcomx.json"), JSON.stringify(baseTree, null, 2));
+  }
+  const link = (assertionId: string, confidence: string) => ({
+    projectPath: dir,
+    section: "person_evidence",
+    op: "append" as const,
+    entry: {
+      assertion_id: assertionId,
+      person_id: "I1",
+      confidence,
+      rationale: "Names match the subject.",
+      match_score: null,
+      created: "2026-07-18",
+      superseded_by: null,
+    },
+  });
+
+  it("rejects 'confident' on an uncertain reading with no corroborating record", async () => {
+    await write(researchWith([uncertain("a_010", "rec_A")]));
+    const r = await researchAppend(link("a_010", "confident"));
+    expect(r.ok).toBe(false);
+    expect(r.errors?.join(" ")).toMatch(/uncertain reading/i);
+  });
+
+  it("allows 'probable' on the same uncertain, uncorroborated reading", async () => {
+    await write(researchWith([uncertain("a_010", "rec_A")]));
+    const r = await researchAppend(link("a_010", "probable"));
+    expect(r.ok).toBe(true);
+  });
+
+  // The ut_person_evidence_001 shape: a single death certificate that plainly
+  // names its subject. Gating on record-count alone would wrongly reject this.
+  it("allows 'confident' on a single CLEAN record (no [?])", async () => {
+    await write(researchWith([clean("a_011", "rec_A")]));
+    const r = await researchAppend(link("a_011", "confident"));
+    expect(r.ok).toBe(true);
+  });
+
+  it("allows 'confident' on an uncertain reading once a second record corroborates", async () => {
+    await write(
+      researchWith(
+        [uncertain("a_010", "rec_A"), clean("a_012", "rec_B")],
+        [
+          {
+            id: "pe_001",
+            assertion_id: "a_012",
+            person_id: "I1",
+            confidence: "probable",
+            rationale: "Independent record tying the same person.",
+            match_score: null,
+            created: "2026-07-18",
+            superseded_by: null,
+          },
+        ],
+      ),
+    );
+    const r = await researchAppend(link("a_010", "confident"));
+    expect(r.ok).toBe(true);
+  });
+
+  it("does not count a superseded pe row as corroboration", async () => {
+    await write(
+      researchWith(
+        [uncertain("a_010", "rec_A"), clean("a_012", "rec_B")],
+        [
+          {
+            id: "pe_001",
+            assertion_id: "a_012",
+            person_id: "I1",
+            confidence: "probable",
+            rationale: "Superseded link.",
+            match_score: null,
+            created: "2026-07-18",
+            superseded_by: "pe_002",
+          },
+        ],
+      ),
+    );
+    const r = await researchAppend(link("a_010", "confident"));
+    expect(r.ok).toBe(false);
+  });
+
+  it("does not count another record tied to a DIFFERENT person as corroboration", async () => {
+    const r0 = researchWith(
+      [uncertain("a_010", "rec_A"), clean("a_012", "rec_B")],
+      [
+        {
+          id: "pe_001",
+          assertion_id: "a_012",
+          person_id: "I2",
+          confidence: "probable",
+          rationale: "Different person entirely.",
+          match_score: null,
+          created: "2026-07-18",
+          superseded_by: null,
+        },
+      ],
+    );
+    await writeFile(join(dir, "research.json"), JSON.stringify(r0, null, 2));
+    await writeFile(
+      join(dir, "tree.gedcomx.json"),
+      JSON.stringify(
+        {
+          ...baseTree,
+          persons: [
+            ...baseTree.persons,
+            { id: "I2", gender: "Female", names: [{ id: "N2", given: "Mary", surname: "Smith" }] },
+          ],
+        },
+        null,
+        2,
+      ),
+    );
+    const r = await researchAppend(link("a_010", "confident"));
+    expect(r.ok).toBe(false);
+  });
+});
+
+// ─── Worked examples (#697) ─────────────────────────────────────────────────
+//
+// The point of the registry is that a rejected append is handed a shape the
+// model can copy. An example that does not itself validate would teach the
+// wrong shape — worse than no example — so every one is round-tripped through
+// the real tool here. This test is the reason to trust the registry.
+
+describe("research_append — worked examples are themselves valid", () => {
+  let dir: string;
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "research-append-examples-"));
+  });
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  /** A project carrying every id the examples reference as a foreign key. */
+  function exampleFixture() {
+    const r: any = baseResearch();
+    r.log = [
+      {
+        id: "log_004",
+        plan_item_id: null,
+        performed: "2026-07-18",
+        tool: "record_search",
+        query: "Patrick Flynn death 1908 Schuylkill",
+        outcome: "positive",
+        results_examined: 1,
+        results_ref: "results/log_004.json",
+        results_available: 1,
+        notes: null,
+        external_site: null,
+      },
+    ];
+    r.sources = [validSource("src_001"), { ...validSource("src_004") }];
+    r.assertions = [
+      validAssertion("a_001"),
+      { ...validAssertion("a_013", "src_004"), record_id: "ark:/61903/1:1:MDEF" },
+      { ...validAssertion("a_025", "src_004"), record_id: "ark:/61903/1:1:MDEF" },
+    ];
+    r.questions = [
+      {
+        id: "q_002",
+        question: "Who were the parents of Patrick Flynn?",
+        rationale: "Seed question for the example fixture.",
+        selection_basis: "objective_decomposition",
+        priority: "high",
+        status: "open",
+        depends_on: [],
+        unblocks: [],
+        created: "2026-07-18",
+        resolved: null,
+        resolution_assertion_ids: [],
+        exhaustive_declaration: { declared: false, justification: null, log_entry_ids: [], stop_criteria: null },
+      },
+      {
+        id: "q_003",
+        question: "Where was Patrick Flynn born in Ireland?",
+        rationale: "Spare question with no active plan, for the `plans` example.",
+        selection_basis: "objective_decomposition",
+        priority: "medium",
+        status: "open",
+        depends_on: [],
+        unblocks: [],
+        created: "2026-07-18",
+        resolved: null,
+        resolution_assertion_ids: [],
+        exhaustive_declaration: { declared: false, justification: null, log_entry_ids: [], stop_criteria: null },
+      },
+    ];
+    r.plans = [{ id: "pl_001", question_id: "q_002", status: "active", created: "2026-07-18", items: [] }];
+    r.conflicts = [
+      {
+        id: "c_001",
+        conflict_type: "fact",
+        description: "Seed conflict for the example fixture.",
+        disputed_attribute: "birth_year",
+        identity_question: null,
+        competing_assertion_ids: ["a_013", "a_025"],
+        independence_analysis: "Independent sources.",
+        weighing_analysis: "Weighed.",
+        preferred_assertion_id: "a_013",
+        resolution_rationale: "Resolved for the fixture.",
+        status: "resolved",
+        blocks_question_ids: [],
+      },
+    ];
+    return r;
+  }
+
+  /** Staged search results for log_004 — the assertions example names it as its
+   *  log_entry_id, and the #699 staging gate requires the sidecar to exist. */
+  const sidecar = {
+    log_id: "log_004",
+    tool: "record_search",
+    retrieved: "2026-07-18T14:00:00Z",
+    returned_count: 1,
+    payload: {
+      results: [
+        {
+          recordId: "ark:/61903/1:1:MDEF",
+          primaryId: "p1",
+          gedcomx: { persons: [{ id: "p1" }] },
+        },
+      ],
+    },
+  };
+
+  const SECTIONS_WITH_EXAMPLES = [
+    "sources",
+    "assertions",
+    "person_evidence",
+    "questions",
+    "plans",
+    "plan_items",
+    "conflicts",
+    "hypotheses",
+    "timelines",
+    "proof_summaries",
+    "evaluations",
+    "known_holdings",
+  ];
+
+  it.each(SECTIONS_WITH_EXAMPLES)("the '%s' example validates", async (section) => {
+    // A fresh project per case so examples never depend on each other.
+    await writeFile(join(dir, "research.json"), JSON.stringify(exampleFixture(), null, 2));
+    await writeFile(join(dir, "tree.gedcomx.json"), JSON.stringify(baseTree, null, 2));
+    await mkdir(join(dir, "results"), { recursive: true });
+    await writeFile(join(dir, "results", "log_004.json"), JSON.stringify(sidecar, null, 2));
+
+    const entry = JSON.parse(__testing.EXAMPLES[section]);
+    // `plans` already has an active plan for q_002 in the fixture (the
+    // one-active-plan invariant); point the example at a fresh question.
+    if (section === "plans") entry.question_id = "q_003";
+    const r = await researchAppend({
+      projectPath: dir,
+      section,
+      op: "append",
+      entry,
+      ...(section === "plan_items" ? { planId: "pl_001" } : {}),
+      ...(section === "sources"
+        ? {
+            sourceDescription: {
+              title: "Pennsylvania Death Certificate — Patrick Flynn (1908)",
+              author: "Pennsylvania Department of Health",
+              url: "https://www.familysearch.org/ark:/61903/1:1:MDEF",
+            },
+          }
+        : {}),
+    } as any);
+    expect(r.errors ?? []).toEqual([]);
+    expect(r.ok).toBe(true);
+  });
+
+  it("attaches the section's worked example to a rejection", async () => {
+    await writeFile(join(dir, "research.json"), JSON.stringify(exampleFixture(), null, 2));
+    await writeFile(join(dir, "tree.gedcomx.json"), JSON.stringify(baseTree, null, 2));
+    // The exact shape the closing report saw 4+ times: the verdict body
+    // appended instead of the pointer entry.
+    const r = await researchAppend({
+      projectPath: dir,
+      section: "evaluations",
+      op: "append",
+      entry: {
+        focus: "conclusion-readiness",
+        target_id: "q_002",
+        target_type: "question",
+        verdict: "consider_addressing",
+        strengths: ["well sourced"],
+        must_address: ["no parents named"],
+      },
+    } as any);
+    expect(r.ok).toBe(false);
+    const joined = (r.errors ?? []).join("\n");
+    expect(joined).toMatch(/worked example for 'evaluations'/);
+    expect(joined).toMatch(/file_path/);
   });
 });


### PR DESCRIPTION
Closes the cheap, well-precedented half of #700 and #697. Both halves are tool-side only — `check-runlogs.yml` deliberately excludes `packages/engine/mcp-server/src/**`, so **no eval re-run or re-annotation is needed to land this.** The expensive halves of each issue are refiled (#738, #739) rather than bundled.

## 1. person_evidence epistemic gate (#700)

Audit theme 8 (identity over-reach) is marked **PERS** in the closing report and is invisible to the current judge — it was found only by transcript reading. Evidence: a fabricated `0.92` match_score (birkeland) and a wrong maiden name attached via a different couple (clark-parents).

The record-extractor already carries the doctrine in prose *and* explicitly hands the decision off — "whether a doubted reading becomes a tree stub … is **person-evidence's call at link time**, not extraction's" (`record-extractor.md:544-546`). Nothing enforced it at that link point. This closes a handoff the code already documents.

`personEvidenceInvariants` joins the existing `conflicts`/`plans` invariants at the same hook in `applyOne`.

**The gate is conjunctive by design** — uncertain reading **AND** no corroborating record:

| assertion | corroboration | `confident`? |
|---|---|---|
| clean read | none | ✅ allowed |
| `[?]` reading | none | ❌ rejected |
| `[?]` reading | ≥1 other record on that person | ✅ allowed |

Gating on record count alone would reject the ordinary case — a death certificate that plainly names its subject — which is exactly what `eval/tests/unit/person-evidence/link-death-cert-to-patrick.json` (`ut_person_evidence_001`) asserts is *correct*. That test is why the gate is conjunctive.

Both signals are already in memory: `[?]` rides the assertion's `value` per the extractor contract, and corroboration is derivable by mapping other `pe` rows for the same `person_id` through to distinct `record_id`s. No schema change, no sidecar reads, no new field.

> ⚠️ **No scenario fixture in `eval/` carries a `[?]` anywhere**, so nothing in the eval corpus exercises this gate. The six vitest cases are its only coverage. Worth knowing when judging its blast radius: it also means this cannot regress any existing eval run.

## 2. Worked-example registry (#697)

`research_append` surfaced `entry: { type: "object" }` plus a bare section enum — **zero** per-section field information anywhere in the tool (`grep -c example` on the tool returned 0; the JSON-Schema `examples` keyword is unused repo-wide). The model recalled shapes from whichever SKILL.md happened to be loaded. The identical `evaluations` rejection (missing `file_path`/`superseded_by`, unexpected `strengths`/`must_address`) hit 4+ runs across 4 scenarios.

**Examples attach to the rejection, not only to prose.** That is the load-bearing choice: `conflicts` has had a good worked example in `conflict-resolution/SKILL.md` for months and still drew ~6 rejections in bottemiller (T15, the one **WORSE** cell) — because the caller was a different skill. A rejected append now teaches its own shape regardless of which caller is driving. On a batch failure, only the sections the errors actually name are hinted, so examples never point away from the real problem.

### The test is the reason to trust the registry

`"worked examples are themselves valid"` round-trips all 12 through the real tool. It rejected **four of my own examples** as first drafted:

- invented `citation_detail` keys (it has a fixed 6-key shape, `additionalProperties: false`)
- `exhaustive_declaration: null` — illegal; all 104 real fixture questions carry an object
- a `sources` entry carrying **both** `gedcomx_source_description_id` and `sourceDescription` (mutually exclusive — the example now teaches the composite form and says why)
- a fixture that tripped the #722 staging gate, which is how the sidecar contract got pinned down

An example that does not itself validate teaches the wrong shape — strictly worse than no example. This test is what keeps that from happening again as sections evolve.

## Verification

- `npx tsc --noEmit` clean
- **1524 tests / 67 files pass** (118 in `research-append.test.ts`, +334 lines)
- Footprint is 3 files, all under `mcp-server/` — confirmed not to touch any `check-runlogs.yml` trigger path

## Deferred, not dropped

- **#738** — mandatory `conflicts` companion for single-uncorroborated identity links. No precedent exists for requiring a companion write to another section, and enforcement would force every `pe` caller into the batch form.
- **#739** — caller-side prose that instructs an illegal shape (`gps-mentor.md:178` `"id": "ev_<next_sequential_number>"`, `init-project/SKILL.md:175` `kh_001`), plus gps-mentor's missing write path. These trip the runlog gate and need an annotation budget.

> While filing #739 I found that gps-mentor's **spec is self-contradictory**: `docs/specs/gps-mentor-agent-spec.md` §1 requires two write outputs, but the spec's own canonical frontmatter (`:111`) grants the same 8 read-only tools as the agent file. The agent matches its spec exactly, and the spec describes an agent that cannot do what it says it must. Repo convention (`record-extractor` writes via `research_append`; **no** plugin agent has filesystem `Write`) splits the fix rather than resolving it, so it is left for a deliberate decision on #739.

🤖 Generated with [Claude Code](https://claude.com/claude-code)