### PR TITLE
gps-mentor: real write path via a research_append verdict composite (#739)

### DIFF
--- a/docs/specs/gps-mentor-agent-spec.md
+++ b/docs/specs/gps-mentor-agent-spec.md
@@ -16,6 +16,14 @@ sections other than `evaluations[]`, and `tree.gedcomx.json`). Its only write ou
 
 - A structured JSON verdict written to `evaluations/` in the project folder
 - A pointer record **appended** to the `evaluations` array in `research.json` (append-only — it does not touch any other section)
+
+Both are produced by a **single `research_append` call** carrying the verdict body as
+the top-level `verdict` argument: the tool writes the sidecar, creates the directory,
+stamps `file_path`, assigns the `ev_NNN` id, and commits both files atomically. The agent
+holds no filesystem write tool and never hand-serializes the verdict — the same division
+of labour as `log[].results_ref`, where research.json holds the pointer and only the host
+writes the payload. Writing pointer and payload in one call is what makes a `file_path`
+naming a nonexistent file structurally impossible.
 - A markdown narrative printed to the conversation
 
 The agent fills the role of the experienced colleague a researcher would be lucky to have
@@ -110,6 +118,7 @@ description: BCG-style senior genealogist who reviews research work and tells th
 model: claude-sonnet-5
 tools:
   - Read
+  - mcp__genealogy__research_append
   - mcp__genealogy__validate_research_schema
   - mcp__genealogy__place_search
   - mcp__genealogy__place_distance
@@ -404,13 +413,20 @@ user-facing output. It must follow this structure:
 
 After completing a review, the agent must:
 
-1. Create the `evaluations/` directory in the project folder if it does not exist.
-2. Write the structured verdict to `evaluations/<focus>-<target_id>-<short_iso>.json`.
-3. Append one pointer record to the `evaluations` array in `research.json` (see §12).
-4. Print the `narrative_for_user` block to the conversation as the final user-facing output.
+1. Make one `research_append` call on `section: "evaluations"`, `op: "append"`, passing
+   the structured verdict body as the top-level `verdict` argument and the pointer record
+   as `entry` (see §12). The tool creates `evaluations/`, writes
+   `evaluations/<focus>-<target_id>-<short_iso>.json`, stamps `file_path`, assigns the
+   `ev_NNN` id, validates, and commits — or writes nothing.
+2. Print the `narrative_for_user` block to the conversation as the final user-facing output.
 
-Steps 2–3 must both complete before step 4. If writing the file fails, the agent must
-report the error explicitly rather than silently proceeding to print the narrative.
+Step 1 must complete before step 2. If the call fails, the agent must report the error
+explicitly rather than silently proceeding to print the narrative.
+
+The agent must NOT write the verdict file itself, set `file_path`, or invent an `id`; the
+tool owns all three, and supplying `file_path` alongside `verdict` is rejected. Note that
+`entry.verdict` (the one-word enum) and the top-level `verdict` argument (the full
+structured body) are different things — the body never goes inside `entry`.
 
 ---
 
@@ -511,6 +527,10 @@ filesystem; the research.json entry is a pointer, not a duplicate.
 
 ### 12.1 Entry shape
 
+This is the entry **as persisted**. The agent supplies only the non-tool-owned fields
+(`focus`, `target_id`, `target_type`, `verdict`, `timestamp`, `superseded_by`); `id` and
+`file_path` are filled in by `research_append` (§8).
+
 ```json
 {
   "id": "ev_001",
@@ -526,12 +546,12 @@ filesystem; the research.json entry is a pointer, not a duplicate.
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `id` | string | yes | `ev_` prefix. Immutable once created. |
+| `id` | string | yes | `ev_` prefix. Immutable once created. **Assigned by `research_append`** — the agent must not supply it. |
 | `focus` | string | yes | Focus mode used |
 | `target_id` | string | yes | `q_` or `ps_` ID evaluated |
 | `target_type` | string | yes | `"question"`, `"proof_summary"`, or `"project"` |
 | `verdict` | string | yes | Verdict value from the evaluation |
-| `file_path` | string | yes | Path to the JSON verdict file, relative to the project folder |
+| `file_path` | string | yes | Path to the JSON verdict file, relative to the project folder. **Stamped by `research_append`** from the `verdict` argument — the agent must not supply it. |
 | `timestamp` | string | yes | UTC ISO 8601 timestamp |
 | `superseded_by` | string \| null | yes | `ev_` ID of a later evaluation for the same focus+target, or null |
 

--- a/docs/specs/research-append-tool-spec.md
+++ b/docs/specs/research-append-tool-spec.md
@@ -117,6 +117,12 @@ research_append({
   // call's single sources append op and stamp its gedcomx_source_description_id.
   sourceDescription?: { title: string, author?: string, url?: string },
 
+  // Composite persist (§3.4.2): the structured verdict body for an
+  // `evaluations` append. The tool writes it to
+  // evaluations/<focus>-<target_id>-<short_iso>.json and stamps the entry's
+  // file_path. Rejected alongside an explicit file_path, or on any other section.
+  verdict?: Record<string, unknown>,
+
   // §3.6: default true — resolve standard_place for assertion appends that
   // carry a `place` but omit `standard_place` (sidecar copy first, then
   // geocoding). false skips only the geocoding lookup.
@@ -340,6 +346,36 @@ call is a research-only write (`filesWritten: ["research.json"]`, no
 path 2: a stamped `S` id must exist in the tree or the batch is rejected
 op-indexed.
 
+### 3.4.2 Composite persist (`verdict`) — evaluations sidecar
+
+`evaluations[].file_path` is the same design as `log[].results_ref`: research.json
+holds a pointer, and the payload lives in a sidecar only the host writes
+(`results-staging.ts` is the precedent). The verdict body is large, structured, and
+would bloat every whole-file read of research.json — which is exactly what the
+orchestrator state diet is trying to shrink — so it does not go inline the way
+`proof_summaries.narrative_markdown` does.
+
+On an `evaluations` append carrying a top-level `verdict`, the tool:
+
+1. derives `evaluations/<focus>-<target_id>-<short_iso>.json` from the entry's
+   `focus`, `target_id` and `timestamp` (colons replaced for filesystem safety),
+2. stamps that path onto the entry as `file_path`,
+3. writes the sidecar **after** whole-document validation passes and **before** the
+   research.json commit, creating `evaluations/` as needed.
+
+Ordering matters in both directions: a rejected call leaves no orphan verdict file,
+and a persisted pointer never names a file that does not exist. Doing it in one call
+is what makes a dangling `file_path` structurally impossible rather than merely
+unlikely — the failure mode the agent-writes-it-itself design could not rule out.
+
+Rejected: `verdict` together with an explicit `entry.file_path` (ambiguous
+ownership), `verdict` on any section other than `evaluations`, `verdict` spanning
+more than one evaluations append in a batch, and an entry missing the `focus` /
+`target_id` the filename is derived from.
+
+The consumer is the `gps-mentor` agent, which holds no filesystem write tool; see
+`docs/specs/gps-mentor-agent-spec.md` §8.
+
 ### 3.5 Persona/record-id enforcement matrix — D2
 
 For every `assertions` append op whose `log_entry_id` resolves to a log entry, the
@@ -488,6 +524,7 @@ audit's recommendation #5):
 | `questions` update → `exhaustive_declared` | `exhaustive_declaration.declared` true ⇒ `log_entry_ids` non-empty and `stop_criteria` non-null; a re-declare on an already-declared question is a **no-op short-circuit** (don't overwrite a settled GPS Component-1 record) | `validator.ts:417–424` + audit |
 | `plans` append | at most **one active plan per question** — a second `active` plan for the same `question_id` is rejected | audit; `research-schema-spec.md:265` |
 | `person_evidence` revision | revision is an `append` of the new entry **plus** an `update` setting `superseded_by` on the old one; never a field-overwrite-in-place that loses the prior link | `research-schema-spec.md:427–431` |
+| `person_evidence` append/update → `confident` | rejected when the linked assertion's `value` carries an uncertain reading (`[?]`) **and** no other live `person_evidence` row ties that `person_id` to a distinct record. Conjunctive on purpose: a `confident` link off a single *clean* record is the ordinary case and stays legal | audit theme 8; `record-extractor.md` epistemic cap |
 | any section | `entry` for `append` must NOT carry an `id`; `update` must NOT change the `id` or the entry's prefix | `research-schema-spec.md:101` |
 
 The LLM still makes every substantive decision and supplies the fields — the tool

--- a/packages/engine/mcp-server/src/tools/research-append-examples.ts
+++ b/packages/engine/mcp-server/src/tools/research-append-examples.ts
@@ -1,0 +1,251 @@
+/**
+ * Worked `research_append` examples, one per writer section.
+ *
+ * Why these live here and not only in SKILL.md prose: a skill-side example
+ * only helps when the skill that owns the section happens to be loaded. The
+ * closing report's T15 row is the proof — `conflicts` has had a good worked
+ * example in conflict-resolution/SKILL.md for months and still drew ~6
+ * rejections in one scenario, because the caller was a different skill. These
+ * are attached to the *rejection*, so the shape arrives exactly when the model
+ * got it wrong, regardless of which caller is driving.
+ *
+ * Field lists are transcribed from docs/specs/schemas/research.schema.json;
+ * enum literals from enums.schema.json. Every example shows the required keys
+ * with explicit `null`s for the not-yet-known optional ones — the explicit
+ * null is what stops the trial-and-error loop, since the validator's
+ * additionalProperties:false rejects invented keys and its `required` rejects
+ * omitted ones.
+ *
+ * None of these carry an `id`: the tool assigns it (research-append.ts rejects
+ * an entry that carries one).
+ */
+
+/** Section → a single worked `entry` payload, as pretty JSON. */
+const EXAMPLES: Record<string, string> = {
+  // No "gedcomx_source_description_id" here on purpose: the composite form
+  // below supplies "sourceDescription", which CREATES the tree's S entry and
+  // fills the id. Carrying both is rejected; carrying neither is rejected
+  // unless the S entry already exists.
+  sources: `{
+  "citation": "\\"Pennsylvania, Death Certificates, 1906-1968,\\" database with images, FamilySearch, Patrick Flynn, 12 Mar 1908; citing Schuylkill County, certificate no. 24601.",
+  "citation_detail": {
+    "who": "Schuylkill County registrar",
+    "what": "Certificate of death no. 24601",
+    "when_created": "1908",
+    "when_accessed": "2026-07-18",
+    "where": "Harrisburg, Pennsylvania",
+    "where_within": "certificate no. 24601"
+  },
+  "source_classification": "original",
+  "repository": "FamilySearch",
+  "access_date": "2026-07-18",
+  "url": "https://www.familysearch.org/ark:/61903/1:1:MDEF",
+  "url_archived": null,
+  "notes": null,
+  "transcription": null,
+  "image_filename": null,
+  "log_entry_id": "log_004"
+}`,
+
+  assertions: `{
+  "source_id": "src_004",
+  "record_id": "ark:/61903/1:1:MDEF",
+  "record_role": "deceased",
+  "record_persona_id": "p1",
+  "fact_type": "death",
+  "value": "12 Mar 1908",
+  "structured_value": null,
+  "date": "1908-03-12",
+  "date_certainty": "exact",
+  "place": "Schuylkill County, Pennsylvania",
+  "standard_place": "Schuylkill, Pennsylvania, United States",
+  "information_quality": "primary",
+  "informant": "Mary Flynn, widow",
+  "informant_proximity": "household_member",
+  "informant_bias_notes": null,
+  "evidence_type": "direct",
+  "log_entry_id": "log_004",
+  "extracted_for_question_ids": ["q_002"]
+}`,
+
+  person_evidence: `{
+  "assertion_id": "a_013",
+  "person_id": "I1",
+  "confidence": "probable",
+  "rationale": "Death certificate names Patrick Flynn, d. 1908 Schuylkill County — name, place and date match the subject. Father's name is a single uncorroborated reading, so the link is probable rather than confident.",
+  "match_score": null,
+  "created": "2026-07-18",
+  "superseded_by": null
+}`,
+
+  questions: `{
+  "question": "Who were the parents of Patrick Flynn (b. abt 1845, Ireland)?",
+  "rationale": "The death certificate names a father (Thomas Flynn) on a single uncorroborated reading; no record yet names the mother.",
+  "selection_basis": "unresolved_conflict",
+  "priority": "high",
+  "status": "open",
+  "depends_on": [],
+  "unblocks": [],
+  "created": "2026-07-18",
+  "resolved": null,
+  "resolution_assertion_ids": [],
+  "exhaustive_declaration": {
+    "declared": false,
+    "justification": null,
+    "log_entry_ids": [],
+    "stop_criteria": null
+  }
+}`,
+
+  plans: `{
+  "question_id": "q_002",
+  "status": "active",
+  "created": "2026-07-18",
+  "items": []
+}`,
+
+  plan_items: `{
+  "sequence": 1,
+  "record_type": "church",
+  "jurisdiction": "County Mayo, Ireland",
+  "date_range": "1840-1850",
+  "repository": "FamilySearch",
+  "rationale": "Catholic baptismal registers are the only pre-civil-registration source naming both parents in this jurisdiction.",
+  "fallback_for": null,
+  "status": "planned"
+}`,
+
+  conflicts: `{
+  "conflict_type": "fact",
+  "description": "Patrick Flynn's birth year: 1845 (1850 census, age 5) vs. 1843 (delayed birth certificate)",
+  "disputed_attribute": "birth_year",
+  "identity_question": null,
+  "competing_assertion_ids": ["a_002", "a_025"],
+  "independence_analysis": null,
+  "weighing_analysis": null,
+  "preferred_assertion_id": null,
+  "resolution_rationale": null,
+  "status": "unresolved",
+  "blocks_question_ids": []
+}`,
+
+  hypotheses: `{
+  "claim": "Patrick Flynn of Schuylkill County is the same man as Patrick Flynn who emigrated from County Mayo in 1863.",
+  "status": "active",
+  "supporting_assertion_ids": ["a_013"],
+  "contradicting_assertion_ids": [],
+  "ruled_out": false,
+  "ruled_out_reason": null,
+  "notes": null,
+  "related_question_ids": ["q_002"]
+}`,
+
+  timelines: `{
+  "label": "Patrick Flynn — life events",
+  "hypothesis_id": null,
+  "person_ids": ["I1"],
+  "generated": "2026-07-18T14:05:00Z",
+  "events": [],
+  "gaps": [],
+  "impossibilities": []
+}`,
+
+  proof_summaries: `{
+  "question_id": "q_002",
+  "tier": "probable",
+  "vehicle": "summary",
+  "supporting_assertion_ids": ["a_013", "a_025"],
+  "resolved_conflict_ids": ["c_001"],
+  "exhaustive_search_summary": "Searched Schuylkill County civil death registers, Catholic parish registers for St. Patrick's, and the 1850-1880 federal censuses; no further records naming Patrick's parents surfaced.",
+  "narrative_markdown": "## Parents of Patrick Flynn\\n\\nThe 1908 death certificate names Thomas Flynn as father..."
+}`,
+
+  // The section that drew the identical rejection in 4+ runs across 4
+  // scenarios. `file_path` and `superseded_by` are BOTH required; the verdict
+  // body (`strengths`, `must_address`, …) is NOT part of this entry — it lives
+  // in the file at `file_path`. This entry is a pointer, not the report.
+  evaluations: `{
+  "focus": "conclusion-readiness",
+  "target_id": "q_002",
+  "target_type": "question",
+  "verdict": "consider_addressing",
+  "file_path": "evaluations/ev-2026-07-18-q002.md",
+  "timestamp": "2026-07-18T14:05:00Z",
+  "superseded_by": null
+}`,
+
+  known_holdings: `{
+  "holding_type": "document",
+  "description": "Great-grandmother's family Bible with births recorded on the flyleaf",
+  "relevant_facts": "Birth dates for six children, 1868-1881",
+  "relates_to_person_ids": ["I1"],
+  "confidence": "confident",
+  "promoted": false,
+  "created": "2026-07-18"
+}`,
+};
+
+/** `project` is a singleton: update-only field writes, no `entry`. */
+const PROJECT_EXAMPLE = `research_append({
+  projectPath: "<absolute-path-to-project-directory>",
+  section: "project",
+  op: "update",
+  fields: { "status": "completed" }
+})`;
+
+/**
+ * A worked `research_append` call for `section`, or null when the section has
+ * no example. `op` selects the call shape (`plan_items` needs a `planId`).
+ */
+export function exampleFor(section: string, op: "append" | "update" = "append"): string | null {
+  if (section === "project") return PROJECT_EXAMPLE;
+  const entry = EXAMPLES[section];
+  if (!entry) return null;
+  const planId = section === "plan_items" ? `\n  planId: "pl_001",` : "";
+  // A source append must either reference an S entry that already exists in the
+  // tree or create one in the same call. The composite form is the norm, so the
+  // example teaches it rather than a bare id that would be rejected.
+  const sourceDescription =
+    section === "sources"
+      ? `\n  sourceDescription: {\n    title: "Pennsylvania Death Certificate — Patrick Flynn (1908)",\n    author: "Pennsylvania Department of Health",\n    url: "https://www.familysearch.org/ark:/61903/1:1:MDEF"\n  },`
+      : "";
+  const indented = entry.split("\n").join("\n  ");
+  if (op === "update") {
+    return `research_append({
+  projectPath: "<absolute-path-to-project-directory>",
+  section: "${section}",
+  op: "update",${planId}
+  entryId: "<existing-id>",
+  fields: { /* only the fields you are changing */ }
+})`;
+  }
+  return `research_append({
+  projectPath: "<absolute-path-to-project-directory>",
+  section: "${section}",
+  op: "append",${planId}${sourceDescription}
+  entry: ${indented}
+})`;
+}
+
+/**
+ * Rejection-time teaching aid: the worked call for each implicated section,
+ * appended to the error list. Capped so a wide batch failure cannot bury the
+ * actual errors under example text.
+ */
+export function exampleHints(
+  sections: Array<{ section: string; op: "append" | "update" }>,
+  max = 2,
+): string[] {
+  const seen = new Set<string>();
+  const hints: string[] = [];
+  for (const { section, op } of sections) {
+    if (hints.length >= max) break;
+    if (seen.has(section)) continue;
+    seen.add(section);
+    const ex = exampleFor(section, op);
+    if (ex) hints.push(`worked example for '${section}':\n${ex}`);
+  }
+  return hints;
+}
+
+export const __testing = { EXAMPLES };

--- a/packages/engine/mcp-server/src/tools/research-append-examples.ts
+++ b/packages/engine/mcp-server/src/tools/research-append-examples.ts
@@ -161,15 +161,16 @@ const EXAMPLES: Record<string, string> = {
 }`,
 
   // The section that drew the identical rejection in 4+ runs across 4
-  // scenarios. `file_path` and `superseded_by` are BOTH required; the verdict
-  // body (`strengths`, `must_address`, …) is NOT part of this entry — it lives
-  // in the file at `file_path`. This entry is a pointer, not the report.
+  // scenarios. This entry is a POINTER, not the report: the verdict body
+  // (`strengths`, `must_address`, …) is not part of it and must not be
+  // appended here. Pass the body as the top-level `verdict` argument instead —
+  // the tool writes the sidecar and stamps `file_path` (hence its absence
+  // below; supplying both is rejected).
   evaluations: `{
   "focus": "conclusion-readiness",
   "target_id": "q_002",
   "target_type": "question",
   "verdict": "consider_addressing",
-  "file_path": "evaluations/ev-2026-07-18-q002.md",
   "timestamp": "2026-07-18T14:05:00Z",
   "superseded_by": null
 }`,
@@ -205,6 +206,12 @@ export function exampleFor(section: string, op: "append" | "update" = "append"):
   // A source append must either reference an S entry that already exists in the
   // tree or create one in the same call. The composite form is the norm, so the
   // example teaches it rather than a bare id that would be rejected.
+  // The evaluations example is a pointer; the verdict body rides alongside it
+  // as the top-level `verdict` argument, which is what fills file_path.
+  const verdictArg =
+    section === "evaluations"
+      ? `\n  verdict: { /* strengths, must_address, consider_addressing, narrative_for_user, ... */ },`
+      : "";
   const sourceDescription =
     section === "sources"
       ? `\n  sourceDescription: {\n    title: "Pennsylvania Death Certificate — Patrick Flynn (1908)",\n    author: "Pennsylvania Department of Health",\n    url: "https://www.familysearch.org/ark:/61903/1:1:MDEF"\n  },`
@@ -222,7 +229,7 @@ export function exampleFor(section: string, op: "append" | "update" = "append"):
   return `research_append({
   projectPath: "<absolute-path-to-project-directory>",
   section: "${section}",
-  op: "append",${planId}${sourceDescription}
+  op: "append",${planId}${sourceDescription}${verdictArg}
   entry: ${indented}
 })`;
 }

--- a/packages/engine/mcp-server/src/tools/research-append.ts
+++ b/packages/engine/mcp-server/src/tools/research-append.ts
@@ -19,7 +19,7 @@
 // sections, the phase-3 sections, and the `project` singleton).
 
 import { join } from "path";
-import { readFile } from "fs/promises";
+import { readFile, mkdir } from "fs/promises";
 import { validateParsed } from "../validation/validator.js";
 import { sanitizeTree } from "../validation/tree-sanitize.js";
 import type { ValidationError } from "../validation/types.js";
@@ -205,6 +205,14 @@ export interface ResearchAppendInput {
   // Composite persist: create the tree.gedcomx.json `S` entry for this call's
   // single sources append op and stamp its `gedcomx_source_description_id`.
   sourceDescription?: SourceDescriptionInput;
+  // Composite persist (evaluations): the structured verdict body. When present
+  // on an `evaluations` append, the tool writes it to
+  // `evaluations/<focus>-<target_id>-<short_iso>.json` and stamps the entry's
+  // `file_path` itself — the same shape as the search-results sidecar, where
+  // `log[].results_ref` points at a file only the host writes. Writing the
+  // pointer and its payload in one call is what makes a dangling `file_path`
+  // structurally impossible; the agent never hand-serializes the verdict.
+  verdict?: Record<string, unknown>;
   // Default true: auto-resolve standard_place for an assertion append that has a
   // `place` but omits `standard_place` (sidecar copy first, then geocoding).
   // Pass false to skip the geocoding network call (sidecar copy still applies).
@@ -786,6 +794,79 @@ interface PreparedOps {
   sourceReuse?: SourceReuseEcho;
   resolvedPlaces: ResolvedPlaceEcho[];
   warnings: string[];
+  /** Verdict sidecar to write iff the whole call validates. */
+  verdictFile?: { relPath: string; body: unknown };
+}
+
+/** `YYYY-MM-DDTHH-MM-SS` — colons replaced for filesystem safety, matching the
+ *  gps-mentor spec's `<short_iso>`. */
+function shortIso(timestamp: unknown): string {
+  const d = typeof timestamp === "string" ? new Date(timestamp) : new Date();
+  const iso = (isNaN(d.getTime()) ? new Date() : d).toISOString();
+  return iso.slice(0, 19).replace(/:/g, "-");
+}
+
+/** Filesystem-safe slug for the focus/target segments of the verdict filename. */
+function fileSlug(v: unknown): string {
+  return String(v ?? "")
+    .trim()
+    .replace(/[^A-Za-z0-9._-]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 64);
+}
+
+/**
+ * Composite verdict persist. On an `evaluations` append carrying `verdict`,
+ * derive the sidecar path, stamp it onto the entry as `file_path`, and hand the
+ * body back for the write phase. Nothing touches disk here — the file is only
+ * written once the whole document validates, so a rejected call leaves no
+ * orphan verdict file behind.
+ */
+function prepareVerdict(
+  input: ResearchAppendInput,
+  ops: ResearchAppendOp[],
+  fmt: (i: number, msg: string) => string,
+  errors: string[],
+): PreparedOps["verdictFile"] {
+  if (input.verdict === undefined) return undefined;
+  const idxs = ops
+    .map((o, i) => ({ o, i }))
+    .filter(({ o }) => o.section === "evaluations" && o.op === "append");
+  if (idxs.length === 0) {
+    errors.push("`verdict` is only valid on an `evaluations` append op");
+    return undefined;
+  }
+  if (idxs.length > 1) {
+    errors.push("`verdict` applies to a single evaluations append; this call has more than one");
+    return undefined;
+  }
+  const { o, i } = idxs[0];
+  if (!input.verdict || typeof input.verdict !== "object" || Array.isArray(input.verdict)) {
+    errors.push(fmt(i, "`verdict` must be an object (the structured verdict body)"));
+    return undefined;
+  }
+  const entry = o.entry as any;
+  if (!entry || typeof entry !== "object") return undefined;
+  if (entry.file_path != null) {
+    errors.push(
+      fmt(
+        i,
+        "entry carries a file_path AND the call supplies `verdict` — use one: pass `verdict` " +
+          "and let the tool write the file and stamp file_path, or write the file yourself and " +
+          "pass file_path alone",
+      ),
+    );
+    return undefined;
+  }
+  const focus = fileSlug(entry.focus);
+  const target = fileSlug(entry.target_id);
+  if (!focus || !target) {
+    errors.push(fmt(i, "`verdict` requires the entry to carry `focus` and `target_id` (they name the file)"));
+    return undefined;
+  }
+  const relPath = `evaluations/${focus}-${target}-${shortIso(entry.timestamp)}.json`;
+  entry.file_path = relPath;
+  return { relPath, body: input.verdict };
 }
 
 /** Normalized-exact repository comparison key (trim + casefold). */
@@ -1257,7 +1338,9 @@ async function prepareOps(
   }
 
   if (errors.length > 0) throw new ResearchAppendError(errors);
-  return { treeMutated, sourceDescriptionId, sourceReuse, resolvedPlaces, warnings };
+  const verdictFile = prepareVerdict(input, ops, fmt, errors);
+  if (errors.length > 0) throw new ResearchAppendError(errors);
+  return { treeMutated, sourceDescriptionId, sourceReuse, resolvedPlaces, warnings, verdictFile };
 }
 
 // ─── Entry point ─────────────────────────────────────────────────────────────
@@ -1275,6 +1358,7 @@ export async function researchAppend(
   input.entry = coerceJsonArg(input.entry) as Record<string, unknown> | undefined;
   input.fields = coerceJsonArg(input.fields) as Record<string, unknown> | undefined;
   input.sourceDescription = coerceJsonArg(input.sourceDescription) as SourceDescriptionInput | undefined;
+  input.verdict = coerceJsonArg(input.verdict) as Record<string, unknown> | undefined;
 
   const isBatch = input.ops !== undefined;
   const opsReceived = isBatch && Array.isArray(input.ops) ? input.ops.length : undefined;
@@ -1367,6 +1451,13 @@ export async function researchAppend(
         );
       }
       validationWarnings = formatIssues(validation.warnings);
+      // Verdict sidecar first: research.json's file_path pointer must never
+      // name a file that does not exist. Written before the document commit so
+      // a failure here aborts before the pointer is persisted.
+      if (prep.verdictFile) {
+        await mkdir(join(projectPath, "evaluations"), { recursive: true });
+        await atomicWriteJson(join(projectPath, prep.verdictFile.relPath), prep.verdictFile.body);
+      }
       const researchPath = join(projectPath, "research.json");
       if (prep.treeMutated) {
         const treePath = join(projectPath, "tree.gedcomx.json");
@@ -1381,6 +1472,7 @@ export async function researchAppend(
         await atomicWriteJson(researchPath, research);
         filesWritten = ["research.json"];
       }
+      if (prep.verdictFile) filesWritten = [...filesWritten, prep.verdictFile.relPath];
       // GC unreferenced source images (best-effort, TTL-gated) — design B, §8.5:
       // remove images/*.jpg no source cites and older than the TTL, so a
       // just-transcribed-but-unretained scan ages out instead of lingering.
@@ -1587,6 +1679,17 @@ export const researchAppendSchema = {
           url: { type: "string", description: "Optional URL. Omit when not applicable (never null)." },
         },
         required: ["title"],
+      },
+      verdict: {
+        type: "object",
+        description:
+          "Composite persist for an `evaluations` append: the structured verdict body " +
+          "(strengths, must_address, consider_addressing, narrative_for_user, …). The " +
+          "tool writes it to evaluations/<focus>-<target_id>-<short_iso>.json and stamps " +
+          "the entry's `file_path` itself — do NOT write the file yourself, and do NOT " +
+          "set file_path when passing this. The entry stays a pointer record; the verdict " +
+          "body never goes into research.json. Supplying both `verdict` and `file_path` " +
+          "is rejected.",
       },
       resolveStandardPlace: {
         type: "boolean",

--- a/packages/engine/mcp-server/src/tools/research-append.ts
+++ b/packages/engine/mcp-server/src/tools/research-append.ts
@@ -30,6 +30,7 @@ import {
   isInsideProject,
 } from "../utils/project-io.js";
 import { coerceJsonArg } from "../utils/coerce-json-arg.js";
+import { exampleHints } from "./research-append-examples.js";
 import { gcUnreferencedImages } from "../utils/image-store.js";
 import { nextId } from "../utils/gedcomx-ids.js";
 import { arkToBareId } from "../utils/ark.js";
@@ -115,6 +116,56 @@ function planActiveInvariants(entry: any, research: any): string[] {
     ];
   }
   return [];
+}
+
+/** An uncertain transcription rides in the assertion's `value` as `[?]` — the
+ *  record-extractor contract ("Keep the uncertain reading in `value` with
+ *  `[?]`"). Nothing else in the entry marks doubt structurally. */
+function hasUncertainReading(assertion: any): boolean {
+  return typeof assertion?.value === "string" && assertion.value.includes("[?]");
+}
+
+/** Distinct records (falling back to source) that already tie other, still-live
+ *  person_evidence rows to this person — excluding this entry and its own
+ *  record. Size 0 ⇒ the identity rests on this single record alone. */
+function corroboratingRecordCount(entry: any, research: any, byId: Map<string, any>): number {
+  const own = byId.get(entry.assertion_id);
+  const ownRecord = own?.record_id ?? own?.source_id ?? null;
+  const distinct = new Set<string>();
+  for (const pe of research.person_evidence ?? []) {
+    if (pe === entry || pe.id === entry.id) continue;
+    if (pe.person_id !== entry.person_id) continue;
+    if (pe.superseded_by != null) continue;
+    const a = byId.get(pe.assertion_id);
+    const rec = a?.record_id ?? a?.source_id ?? null;
+    if (rec != null && rec !== ownRecord) distinct.add(rec);
+  }
+  return distinct.size;
+}
+
+/** Epistemic gate for identity over-reach (the record-extractor's tentative-cap,
+ *  enforced at the link point rather than left to prose).
+ *
+ *  Deliberately CONJUNCTIVE: an uncertain reading AND no corroborating record.
+ *  A `confident` link off a single *clean* record stays legal — that is the
+ *  ordinary case (a death certificate that plainly names its subject), and
+ *  gating on record-count alone would reject it. Doubt only becomes
+ *  disqualifying when nothing independent backs it up. */
+function personEvidenceInvariants(entry: any, research: any): string[] {
+  if (entry.confidence !== "confident") return [];
+  const assertions: any[] = research.assertions ?? [];
+  const byId = new Map<string, any>(assertions.map((a: any) => [a.id, a]));
+  const linked = byId.get(entry.assertion_id);
+  // Missing FK is already reported by the document validator; don't double-fault.
+  if (!linked || !hasUncertainReading(linked)) return [];
+  if (corroboratingRecordCount(entry, research, byId) > 0) return [];
+  return [
+    `confidence 'confident' is not available here: assertion '${entry.assertion_id}' carries an ` +
+      `uncertain reading ([?]) and no other record independently ties person '${entry.person_id}' ` +
+      `to this identity. Use 'probable' (or 'speculative'), keep the [?] in the assertion value, ` +
+      `and record what would resolve it — a second independent record, or the original image. ` +
+      `A confident wrong parent is worse than a flagged uncertain one.`,
+  ];
 }
 
 export type ResearchAppendSection = keyof typeof SECTIONS | string;
@@ -604,6 +655,11 @@ function applyOne(research: any, op: ResearchAppendOp, appendedThisBatch?: Set<s
   // (re)sets status to "active"; the helper no-ops for non-active entries.
   if (section === "plans") {
     invariantErrors.push(...planActiveInvariants(resultEntry, research));
+  }
+  // Identity over-reach: runs on append AND on an update that raises confidence
+  // to "confident"; the helper no-ops for every other confidence value.
+  if (section === "person_evidence") {
+    invariantErrors.push(...personEvidenceInvariants(resultEntry, research));
   }
   if (invariantErrors.length > 0) {
     throw new ResearchAppendError(invariantErrors);
@@ -1222,8 +1278,16 @@ export async function researchAppend(
 
   const isBatch = input.ops !== undefined;
   const opsReceived = isBatch && Array.isArray(input.ops) ? input.ops.length : undefined;
-  const fail = (errors: string[]): ResearchAppendResult =>
-    opsReceived !== undefined ? { ok: false, errors, opsReceived } : { ok: false, errors };
+  /** `hint` names the op(s) the failure is about; their worked examples are
+   *  appended so a rejected call teaches the shape on the spot instead of
+   *  depending on the right SKILL.md having been loaded. */
+  const fail = (
+    errors: string[],
+    hint?: Array<{ section: string; op: "append" | "update" }>,
+  ): ResearchAppendResult => {
+    const all = hint && hint.length > 0 ? [...errors, ...exampleHints(hint)] : errors;
+    return opsReceived !== undefined ? { ok: false, errors: all, opsReceived } : { ok: false, errors: all };
+  };
 
   try {
     const research = await readJson(projectPath, "research.json");
@@ -1269,7 +1333,10 @@ export async function researchAppend(
       } catch (e) {
         if (e instanceof ResearchAppendError) {
           // Identify the failing op; nothing has been written.
-          return fail(e.errors.map((m) => fmt(i, m)));
+          return fail(
+            e.errors.map((m) => fmt(i, m)),
+            [{ section: String(ops[i].section), op: ops[i].op === "update" ? "update" : "append" }],
+          );
         }
         throw e;
       }
@@ -1284,7 +1351,20 @@ export async function researchAppend(
     if (anyMutation) {
       const validation = await validateParsed(research, tree, { projectPath });
       if (!validation.valid) {
-        return fail(mapValidationErrors(formatIssues(validation.errors), applied, isBatch));
+        // Shape errors surface here (the document validator, not applyOne), so
+        // this is the site the evaluations/known_holdings rejections land on.
+        const mapped = mapValidationErrors(formatIssues(validation.errors), applied, isBatch);
+        // Only hint the sections the errors actually name — in a wide batch,
+        // examples for ops that validated fine would be noise pointing away
+        // from the real problem.
+        const blamed = ops.filter((o) => mapped.some((m) => m.includes(String(o.section))));
+        return fail(
+          mapped,
+          (blamed.length > 0 ? blamed : ops).map((o) => ({
+            section: String(o.section),
+            op: o.op === "update" ? "update" : "append",
+          })),
+        );
       }
       validationWarnings = formatIssues(validation.warnings);
       const researchPath = join(projectPath, "research.json");
@@ -1339,7 +1419,14 @@ export async function researchAppend(
       validation: validationBlock,
     };
   } catch (e) {
-    if (e instanceof ResearchAppendError) return fail(e.errors);
+    if (e instanceof ResearchAppendError) {
+      // Single-op path (and pre-pass throws): the section is only known when
+      // the caller used the non-batch form.
+      return fail(
+        e.errors,
+        input.section ? [{ section: String(input.section), op: input.op === "update" ? "update" : "append" }] : undefined,
+      );
+    }
     throw e;
   }
 }

--- a/packages/engine/mcp-server/tests/tools/research-append.test.ts
+++ b/packages/engine/mcp-server/tests/tools/research-append.test.ts
@@ -17,6 +17,7 @@ vi.mock("../../src/utils/place-resolver.js", () => ({
 }));
 
 import { researchAppend, countryConsistency } from "../../src/tools/research-append.js";
+import { __testing } from "../../src/tools/research-append-examples.js";
 import { resolveStandardPlace } from "../../src/utils/place-resolver.js";
 
 const citationDetail = {
@@ -2086,5 +2087,338 @@ describe("countryConsistency heuristic", () => {
     ["Schuylkill County, Pennsylvania", "Schuylkill, Pennsylvania, United States", "unverifiable"], // no country named
   ])("%s vs %s → %s", (place, standard, expected) => {
     expect(countryConsistency(place as string, standard as string)).toBe(expected);
+  });
+});
+
+// ─── Identity over-reach gate (#700) ────────────────────────────────────────
+//
+// Conjunctive by design: uncertain reading AND no corroborating record. The
+// eval fixture corpus carries no `[?]` at all, so nothing in eval/ exercises
+// this — these tests are the only coverage.
+
+describe("research_append — person_evidence epistemic gate", () => {
+  let dir: string;
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "research-append-pe-gate-"));
+  });
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  /** src_001/a_001 exist from baseResearch(); add the ones each case needs. */
+  function researchWith(assertions: any[], personEvidence: any[] = []) {
+    const r = baseResearch();
+    r.assertions = [...r.assertions, ...assertions] as any;
+    r.person_evidence = personEvidence as any;
+    return r;
+  }
+  const uncertain = (id: string, recordId: string) => ({
+    ...validAssertion(id),
+    record_id: recordId,
+    fact_type: "name",
+    value: "Father: Thomas Fl[?]nn",
+  });
+  const clean = (id: string, recordId: string) => ({
+    ...validAssertion(id),
+    record_id: recordId,
+    fact_type: "name",
+    value: "Father: Thomas Flynn",
+  });
+  async function write(research: any) {
+    await writeFile(join(dir, "research.json"), JSON.stringify(research, null, 2));
+    await writeFile(join(dir, "tree.gedcomx.json"), JSON.stringify(baseTree, null, 2));
+  }
+  const link = (assertionId: string, confidence: string) => ({
+    projectPath: dir,
+    section: "person_evidence",
+    op: "append" as const,
+    entry: {
+      assertion_id: assertionId,
+      person_id: "I1",
+      confidence,
+      rationale: "Names match the subject.",
+      match_score: null,
+      created: "2026-07-18",
+      superseded_by: null,
+    },
+  });
+
+  it("rejects 'confident' on an uncertain reading with no corroborating record", async () => {
+    await write(researchWith([uncertain("a_010", "rec_A")]));
+    const r = await researchAppend(link("a_010", "confident"));
+    expect(r.ok).toBe(false);
+    expect(r.errors?.join(" ")).toMatch(/uncertain reading/i);
+  });
+
+  it("allows 'probable' on the same uncertain, uncorroborated reading", async () => {
+    await write(researchWith([uncertain("a_010", "rec_A")]));
+    const r = await researchAppend(link("a_010", "probable"));
+    expect(r.ok).toBe(true);
+  });
+
+  // The ut_person_evidence_001 shape: a single death certificate that plainly
+  // names its subject. Gating on record-count alone would wrongly reject this.
+  it("allows 'confident' on a single CLEAN record (no [?])", async () => {
+    await write(researchWith([clean("a_011", "rec_A")]));
+    const r = await researchAppend(link("a_011", "confident"));
+    expect(r.ok).toBe(true);
+  });
+
+  it("allows 'confident' on an uncertain reading once a second record corroborates", async () => {
+    await write(
+      researchWith(
+        [uncertain("a_010", "rec_A"), clean("a_012", "rec_B")],
+        [
+          {
+            id: "pe_001",
+            assertion_id: "a_012",
+            person_id: "I1",
+            confidence: "probable",
+            rationale: "Independent record tying the same person.",
+            match_score: null,
+            created: "2026-07-18",
+            superseded_by: null,
+          },
+        ],
+      ),
+    );
+    const r = await researchAppend(link("a_010", "confident"));
+    expect(r.ok).toBe(true);
+  });
+
+  it("does not count a superseded pe row as corroboration", async () => {
+    await write(
+      researchWith(
+        [uncertain("a_010", "rec_A"), clean("a_012", "rec_B")],
+        [
+          {
+            id: "pe_001",
+            assertion_id: "a_012",
+            person_id: "I1",
+            confidence: "probable",
+            rationale: "Superseded link.",
+            match_score: null,
+            created: "2026-07-18",
+            superseded_by: "pe_002",
+          },
+        ],
+      ),
+    );
+    const r = await researchAppend(link("a_010", "confident"));
+    expect(r.ok).toBe(false);
+  });
+
+  it("does not count another record tied to a DIFFERENT person as corroboration", async () => {
+    const r0 = researchWith(
+      [uncertain("a_010", "rec_A"), clean("a_012", "rec_B")],
+      [
+        {
+          id: "pe_001",
+          assertion_id: "a_012",
+          person_id: "I2",
+          confidence: "probable",
+          rationale: "Different person entirely.",
+          match_score: null,
+          created: "2026-07-18",
+          superseded_by: null,
+        },
+      ],
+    );
+    await writeFile(join(dir, "research.json"), JSON.stringify(r0, null, 2));
+    await writeFile(
+      join(dir, "tree.gedcomx.json"),
+      JSON.stringify(
+        {
+          ...baseTree,
+          persons: [
+            ...baseTree.persons,
+            { id: "I2", gender: "Female", names: [{ id: "N2", given: "Mary", surname: "Smith" }] },
+          ],
+        },
+        null,
+        2,
+      ),
+    );
+    const r = await researchAppend(link("a_010", "confident"));
+    expect(r.ok).toBe(false);
+  });
+});
+
+// ─── Worked examples (#697) ─────────────────────────────────────────────────
+//
+// The point of the registry is that a rejected append is handed a shape the
+// model can copy. An example that does not itself validate would teach the
+// wrong shape — worse than no example — so every one is round-tripped through
+// the real tool here. This test is the reason to trust the registry.
+
+describe("research_append — worked examples are themselves valid", () => {
+  let dir: string;
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "research-append-examples-"));
+  });
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  /** A project carrying every id the examples reference as a foreign key. */
+  function exampleFixture() {
+    const r: any = baseResearch();
+    r.log = [
+      {
+        id: "log_004",
+        plan_item_id: null,
+        performed: "2026-07-18",
+        tool: "record_search",
+        query: "Patrick Flynn death 1908 Schuylkill",
+        outcome: "positive",
+        results_examined: 1,
+        results_ref: "results/log_004.json",
+        results_available: 1,
+        notes: null,
+        external_site: null,
+      },
+    ];
+    r.sources = [validSource("src_001"), { ...validSource("src_004") }];
+    r.assertions = [
+      validAssertion("a_001"),
+      { ...validAssertion("a_013", "src_004"), record_id: "ark:/61903/1:1:MDEF" },
+      { ...validAssertion("a_025", "src_004"), record_id: "ark:/61903/1:1:MDEF" },
+    ];
+    r.questions = [
+      {
+        id: "q_002",
+        question: "Who were the parents of Patrick Flynn?",
+        rationale: "Seed question for the example fixture.",
+        selection_basis: "objective_decomposition",
+        priority: "high",
+        status: "open",
+        depends_on: [],
+        unblocks: [],
+        created: "2026-07-18",
+        resolved: null,
+        resolution_assertion_ids: [],
+        exhaustive_declaration: { declared: false, justification: null, log_entry_ids: [], stop_criteria: null },
+      },
+      {
+        id: "q_003",
+        question: "Where was Patrick Flynn born in Ireland?",
+        rationale: "Spare question with no active plan, for the `plans` example.",
+        selection_basis: "objective_decomposition",
+        priority: "medium",
+        status: "open",
+        depends_on: [],
+        unblocks: [],
+        created: "2026-07-18",
+        resolved: null,
+        resolution_assertion_ids: [],
+        exhaustive_declaration: { declared: false, justification: null, log_entry_ids: [], stop_criteria: null },
+      },
+    ];
+    r.plans = [{ id: "pl_001", question_id: "q_002", status: "active", created: "2026-07-18", items: [] }];
+    r.conflicts = [
+      {
+        id: "c_001",
+        conflict_type: "fact",
+        description: "Seed conflict for the example fixture.",
+        disputed_attribute: "birth_year",
+        identity_question: null,
+        competing_assertion_ids: ["a_013", "a_025"],
+        independence_analysis: "Independent sources.",
+        weighing_analysis: "Weighed.",
+        preferred_assertion_id: "a_013",
+        resolution_rationale: "Resolved for the fixture.",
+        status: "resolved",
+        blocks_question_ids: [],
+      },
+    ];
+    return r;
+  }
+
+  /** Staged search results for log_004 — the assertions example names it as its
+   *  log_entry_id, and the #699 staging gate requires the sidecar to exist. */
+  const sidecar = {
+    log_id: "log_004",
+    tool: "record_search",
+    retrieved: "2026-07-18T14:00:00Z",
+    returned_count: 1,
+    payload: {
+      results: [
+        {
+          recordId: "ark:/61903/1:1:MDEF",
+          primaryId: "p1",
+          gedcomx: { persons: [{ id: "p1" }] },
+        },
+      ],
+    },
+  };
+
+  const SECTIONS_WITH_EXAMPLES = [
+    "sources",
+    "assertions",
+    "person_evidence",
+    "questions",
+    "plans",
+    "plan_items",
+    "conflicts",
+    "hypotheses",
+    "timelines",
+    "proof_summaries",
+    "evaluations",
+    "known_holdings",
+  ];
+
+  it.each(SECTIONS_WITH_EXAMPLES)("the '%s' example validates", async (section) => {
+    // A fresh project per case so examples never depend on each other.
+    await writeFile(join(dir, "research.json"), JSON.stringify(exampleFixture(), null, 2));
+    await writeFile(join(dir, "tree.gedcomx.json"), JSON.stringify(baseTree, null, 2));
+    await mkdir(join(dir, "results"), { recursive: true });
+    await writeFile(join(dir, "results", "log_004.json"), JSON.stringify(sidecar, null, 2));
+
+    const entry = JSON.parse(__testing.EXAMPLES[section]);
+    // `plans` already has an active plan for q_002 in the fixture (the
+    // one-active-plan invariant); point the example at a fresh question.
+    if (section === "plans") entry.question_id = "q_003";
+    const r = await researchAppend({
+      projectPath: dir,
+      section,
+      op: "append",
+      entry,
+      ...(section === "plan_items" ? { planId: "pl_001" } : {}),
+      ...(section === "sources"
+        ? {
+            sourceDescription: {
+              title: "Pennsylvania Death Certificate — Patrick Flynn (1908)",
+              author: "Pennsylvania Department of Health",
+              url: "https://www.familysearch.org/ark:/61903/1:1:MDEF",
+            },
+          }
+        : {}),
+    } as any);
+    expect(r.errors ?? []).toEqual([]);
+    expect(r.ok).toBe(true);
+  });
+
+  it("attaches the section's worked example to a rejection", async () => {
+    await writeFile(join(dir, "research.json"), JSON.stringify(exampleFixture(), null, 2));
+    await writeFile(join(dir, "tree.gedcomx.json"), JSON.stringify(baseTree, null, 2));
+    // The exact shape the closing report saw 4+ times: the verdict body
+    // appended instead of the pointer entry.
+    const r = await researchAppend({
+      projectPath: dir,
+      section: "evaluations",
+      op: "append",
+      entry: {
+        focus: "conclusion-readiness",
+        target_id: "q_002",
+        target_type: "question",
+        verdict: "consider_addressing",
+        strengths: ["well sourced"],
+        must_address: ["no parents named"],
+      },
+    } as any);
+    expect(r.ok).toBe(false);
+    const joined = (r.errors ?? []).join("\n");
+    expect(joined).toMatch(/worked example for 'evaluations'/);
+    expect(joined).toMatch(/file_path/);
   });
 });

--- a/packages/engine/mcp-server/tests/tools/research-append.test.ts
+++ b/packages/engine/mcp-server/tests/tools/research-append.test.ts
@@ -2384,6 +2384,9 @@ describe("research_append — worked examples are themselves valid", () => {
       op: "append",
       entry,
       ...(section === "plan_items" ? { planId: "pl_001" } : {}),
+      // The evaluations example is a pointer with no file_path by design; the
+      // composite `verdict` arg is what fills it.
+      ...(section === "evaluations" ? { verdict: { strengths: [], must_address: [] } } : {}),
       ...(section === "sources"
         ? {
             sourceDescription: {
@@ -2420,5 +2423,155 @@ describe("research_append — worked examples are themselves valid", () => {
     const joined = (r.errors ?? []).join("\n");
     expect(joined).toMatch(/worked example for 'evaluations'/);
     expect(joined).toMatch(/file_path/);
+  });
+});
+
+// ─── Composite verdict persist (gps-mentor write path) ──────────────────────
+//
+// evaluations[].file_path is the same design as log[].results_ref: a pointer in
+// research.json to a sidecar only the host writes. Writing both in one call is
+// what makes a dangling file_path impossible.
+
+describe("research_append — evaluations verdict composite", () => {
+  let dir: string;
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "research-append-verdict-"));
+  });
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  const VERDICT = {
+    focus: "conclusion-readiness",
+    target_id: "q_002",
+    target_type: "question",
+    verdict: "address_first",
+    strengths: ["Independence analysis on c_001 is correct (Standard 46)."],
+    must_address: [
+      {
+        standard: "Standard 14 — topical breadth",
+        issue: "No probate search planned for Schuylkill County 1875-1890.",
+        what_would_change_my_mind: "An executed probate search, even a nil result.",
+        suggested_skill: "research-plan",
+        specific_action: "Add a probate plan item.",
+      },
+    ],
+    narrative_for_user: "You are close. The probate gap is the one thing standing between this and a defensible conclusion.",
+  };
+  const pointer = () => ({
+    focus: "conclusion-readiness",
+    target_id: "q_002",
+    target_type: "question",
+    verdict: "address_first",
+    timestamp: "2026-07-18T14:05:00Z",
+    superseded_by: null,
+  });
+  async function writeProject() {
+    const r: any = baseResearch();
+    r.questions = [
+      {
+        id: "q_002",
+        question: "Who were the parents of Patrick Flynn?",
+        rationale: "Seed.",
+        selection_basis: "objective_decomposition",
+        priority: "high",
+        status: "open",
+        depends_on: [],
+        unblocks: [],
+        created: "2026-07-18",
+        resolved: null,
+        resolution_assertion_ids: [],
+        exhaustive_declaration: { declared: false, justification: null, log_entry_ids: [], stop_criteria: null },
+      },
+    ];
+    await writeFile(join(dir, "research.json"), JSON.stringify(r, null, 2));
+    await writeFile(join(dir, "tree.gedcomx.json"), JSON.stringify(baseTree, null, 2));
+  }
+
+  it("writes the sidecar, stamps file_path, and keeps the body out of research.json", async () => {
+    await writeProject();
+    const r = await researchAppend({
+      projectPath: dir,
+      section: "evaluations",
+      op: "append",
+      entry: pointer(),
+      verdict: VERDICT,
+    } as any);
+    expect(r.errors ?? []).toEqual([]);
+    expect(r.ok).toBe(true);
+
+    const research = JSON.parse(await readFile(join(dir, "research.json"), "utf-8"));
+    const ev = research.evaluations[0];
+    expect(ev.file_path).toBe("evaluations/conclusion-readiness-q_002-2026-07-18T14-05-00.json");
+    // The pointer stays a pointer: no verdict body leaked into research.json.
+    expect(ev.strengths).toBeUndefined();
+    expect(ev.must_address).toBeUndefined();
+
+    // …and the file it names actually exists, with the body.
+    const written = JSON.parse(await readFile(join(dir, ev.file_path), "utf-8"));
+    expect(written.must_address[0].standard).toMatch(/Standard 14/);
+    expect(written.narrative_for_user).toMatch(/probate gap/);
+  });
+
+  it("rejects verdict + an explicit file_path (ambiguous ownership)", async () => {
+    await writeProject();
+    const r = await researchAppend({
+      projectPath: dir,
+      section: "evaluations",
+      op: "append",
+      entry: { ...pointer(), file_path: "evaluations/hand-written.json" },
+      verdict: VERDICT,
+    } as any);
+    expect(r.ok).toBe(false);
+    expect(r.errors?.join(" ")).toMatch(/use one/i);
+  });
+
+  it("rejects verdict on a non-evaluations section", async () => {
+    await writeProject();
+    const r = await researchAppend({
+      projectPath: dir,
+      section: "hypotheses",
+      op: "append",
+      entry: {
+        claim: "Test claim.",
+        status: "active",
+        supporting_assertion_ids: [],
+        contradicting_assertion_ids: [],
+        ruled_out: false,
+        ruled_out_reason: null,
+        notes: null,
+        related_question_ids: [],
+      },
+      verdict: VERDICT,
+    } as any);
+    expect(r.ok).toBe(false);
+    expect(r.errors?.join(" ")).toMatch(/only valid on an `evaluations` append/);
+  });
+
+  // The failure mode the composite exists to prevent: a rejected call must not
+  // leave an orphan verdict file behind for a pointer that was never persisted.
+  it("writes no sidecar when the document fails validation", async () => {
+    await writeProject();
+    const r = await researchAppend({
+      projectPath: dir,
+      section: "evaluations",
+      op: "append",
+      entry: { ...pointer(), target_id: "q_nonexistent" },
+      verdict: VERDICT,
+    } as any);
+    expect(r.ok).toBe(false);
+    await expect(access(join(dir, "evaluations"))).rejects.toThrow();
+  });
+
+  it("still supports the pointer-only form (caller wrote the file itself)", async () => {
+    await writeProject();
+    const r = await researchAppend({
+      projectPath: dir,
+      section: "evaluations",
+      op: "append",
+      entry: { ...pointer(), file_path: "evaluations/hand-written.json" },
+    } as any);
+    expect(r.errors ?? []).toEqual([]);
+    expect(r.ok).toBe(true);
   });
 });

--- a/packages/engine/plugin/agents/gps-mentor.md
+++ b/packages/engine/plugin/agents/gps-mentor.md
@@ -19,6 +19,7 @@ description: >-
 model: claude-sonnet-5
 tools:
   - Read
+  - mcp__genealogy__research_append
   - mcp__genealogy__validate_research_schema
   - mcp__genealogy__place_search
   - mcp__genealogy__place_distance
@@ -86,8 +87,11 @@ State the defaulted focus and target at the top of your narrative.
 ## Existing-verdict skip
 
 Before evaluating, check whether a verdict already exists for the same
-`focus` + `target_id` by scanning for files matching
-`evaluations/<focus>-<target_id>-*.json` in the project folder.
+`focus` + `target_id` by reading `research.json`'s `evaluations[]` and
+looking for an entry matching both with `superseded_by: null`. Read that
+entry's `file_path` for the prior verdict body. (Match on the array, not
+by listing the `evaluations/` directory — the array is the authoritative
+index, and it is what you can actually read.)
 
 If `force_reevaluate: true` was passed in the delegation message, skip
 this check entirely and proceed to a fresh evaluation.
@@ -102,9 +106,9 @@ file is found:
 3. If the user chooses to surface the existing: print the prior
    `narrative_for_user` and stop. Do not write a new file or append a
    new entry to `evaluations[]`.
-4. If the user chooses to re-evaluate: proceed normally and write a
-   new verdict. The new timestamp keeps filenames distinct — do not
-   overwrite the prior file.
+4. If the user chooses to re-evaluate: proceed normally and persist a
+   new verdict. The timestamp in the filename keeps the files distinct,
+   so the prior verdict is never overwritten.
 
 **Autonomous mode (`mode: autonomous`).** If an existing verdict file
 is found:
@@ -157,50 +161,58 @@ is found:
 
 ## Output protocol
 
-After completing your review, perform these steps in order. Steps 1–3
-must all complete before step 4. If any write fails, report the error
-explicitly in the narrative rather than silently proceeding.
+After completing your review, perform these steps in order. Step 1 must
+complete before step 2. If the write fails, report the error explicitly
+in the narrative rather than silently proceeding.
 
-1. **Create the `evaluations/` directory** in the project folder if it
-   does not exist.
+1. **Persist the verdict with ONE `research_append` call.** Pass the
+   structured verdict body as the top-level `verdict` argument and the
+   pointer record as `entry`. The tool writes
+   `evaluations/<focus>-<target_id>-<short_iso>.json`, creates the
+   directory, stamps the entry's `file_path`, assigns the `ev_NNN` id,
+   validates, and writes both — or writes neither.
 
-2. **Write the structured verdict** to
-   `evaluations/<focus>-<target_id>-<short_iso>.json`, where
-   `<short_iso>` is the current UTC timestamp in `YYYY-MM-DDTHH-MM-SS`
-   format (colons replaced with hyphens for filesystem safety).
-
-3. **Append a pointer record to `research.json`'s `evaluations` array.**
-   This is the only mutation you ever make to `research.json` — you are
-   strictly append-only to this one section. Build the entry like so:
-
-   ```json
-   {
-     "id": "ev_<next_sequential_number>",
-     "focus": "<focus>",
-     "target_id": "<target_id>",
-     "target_type": "question" | "proof_summary" | "project",
-     "verdict": "<verdict>",
-     "file_path": "evaluations/<focus>-<target_id>-<short_iso>.json",
-     "timestamp": "<full ISO 8601 UTC timestamp with colons>",
-     "superseded_by": null
-   }
+   ```
+   research_append({
+     projectPath: "<project folder>",
+     section: "evaluations",
+     op: "append",
+     verdict: { /* the full structured verdict from the section below */ },
+     entry: {
+       "focus": "<focus>",
+       "target_id": "<target_id>",
+       "target_type": "question" | "proof_summary" | "project",
+       "verdict": "<verdict>",
+       "timestamp": "<full ISO 8601 UTC timestamp with colons>",
+       "superseded_by": null
+     }
+   })
    ```
 
-   The `id` is the next sequential `ev_NNN` after the highest existing
-   one in `evaluations[]`. Pad to three digits.
+   **Do not** write the verdict file yourself, set `file_path`, or
+   invent an `id` — the tool owns all three, and supplying `file_path`
+   alongside `verdict` is rejected. `evaluations[]` is the only section
+   you ever write to.
+
+   Note the two distinct uses of the word: `entry.verdict` is the
+   one-word enum (`looks_solid` / `consider_addressing` /
+   `address_first` / `refused`); the top-level `verdict` argument is the
+   full structured body (`strengths`, `must_address`, …) defined in the
+   next section. The body never goes inside `entry`.
 
    **Superseded-by update.** If a previous entry exists in
    `evaluations[]` with the same `focus` + `target_id` and
-   `superseded_by: null`, set that entry's `superseded_by` field to the
-   new entry's `id` before appending the new one. Refusals supersede
-   refusals; real verdicts supersede refusals; refusals do not
-   supersede non-refused verdicts (a refusal after a `looks_solid`
-   leaves the prior entry's `superseded_by` as null).
+   `superseded_by: null`, set that entry's `superseded_by` to the new
+   entry's id with a second `op: "update"` op in the same call, once the
+   append has told you the new id. Refusals supersede refusals; real
+   verdicts supersede refusals; refusals do not supersede non-refused
+   verdicts (a refusal after a `looks_solid` leaves the prior entry's
+   `superseded_by` as null).
 
-   A refused verdict is still written to disk and appended to
-   `evaluations[]` so the refusal is part of the audit trail.
+   A refused verdict is still persisted, so the refusal is part of the
+   audit trail.
 
-4. **Print the `narrative_for_user` block** to the conversation as
+2. **Print the `narrative_for_user` block** to the conversation as
    your final user-facing output. The orchestrator surfaces this to
    the researcher.
 


### PR DESCRIPTION
> **Stacked on #740.** Base is `worktree-append-gates-and-examples`; retarget to `main` once #740 merges. Review the second commit only.

## The bug

gps-mentor could not perform its own output protocol. Its frontmatter granted `Read` plus 7 read-only MCP tools — **no `Write`, no `Edit`, no `research_append`** — while steps 1–3 required creating a directory, writing a JSON file, and appending to `research.json`.

The spec didn't catch it because **the spec has the same defect**: §1 requires both write outputs while the canonical frontmatter block lists the same 8 read-only tools. The agent complied with its spec exactly, and the spec described an agent that cannot do what it says it must. This was never drift.

## Why a tool writes the file, not the agent

`evaluations[].file_path` is the same design as `log[].results_ref` — a pointer in research.json to a sidecar only the host writes (`results-staging.ts:149` is the precedent). So *"who writes the verdict JSON"* already had an answer in this repo: the host-side tool that owns the pointer.

Three candidates, and the repo argues for one:

| Approach | Verdict |
|---|---|
| **Extend `research_append`** ✅ | Reuses the `sourceDescription` composite idiom already in the tool. One call → dangling `file_path` **structurally impossible**. Tool count flat; no agent needs `Write`. |
| Dedicated `gps_verdict` tool | Works, but splits the write across two calls, reopening the window where the file exists and the pointer doesn't. Adds a tool to the catalog. |
| Grant the agent `Write` | Would make it the first plugin agent with filesystem write (none has one), has no atomicity, and makes the LLM hand-serialize the verdict JSON. |

Inline-in-research.json — the `proof_summaries.narrative_markdown` pattern — was the other real candidate and is wrong here: research.json is read whole 12/20/28× per run, and verdict bodies inline would worsen precisely what the orchestrator state diet (#693) is trying to shrink. The sidecar exists to keep big payloads out.

## Ordering is the load-bearing detail

The sidecar is written **after** whole-document validation passes and **before** the research.json commit. Both directions matter:

- a rejected call leaves **no orphan verdict file** — covered by a test asserting no `evaluations/` directory survives a failed validation
- a persisted pointer **never names a file that doesn't exist**

That second guarantee is the whole reason for the composite. I'd flagged on #740 that granting only `research_append` would make step 3 succeed while 1–2 failed, producing pointers to files that were never written; this rules that out by construction rather than by convention.

## Also fixed (#739)

- **`"id": "ev_<next_sequential_number>"`** — `research-append.ts` rejects any entry carrying an id. Direct cause of the PLACEHOLDER-id leak in the closing report.
- **The adjacent-blob conflation** — the verdict body and the pointer entry sat next to each other with no `research_append` wrapper on either, so the model appended the body. `strengths`/`must_address` aren't properties of `evaluation_entry` at all. Now one call, with the two senses of "verdict" named explicitly (`entry.verdict` is the enum; top-level `verdict` is the body).
- **The existing-verdict skip** told the agent to scan `evaluations/` for files — impossible with `Read` alone. It now reads `evaluations[]`, which is both readable and the authoritative index. Same class of bug as the write path; would have failed silently.

## Runlog gate: not triggered

`gps-mentor.md` fans out only to skills referencing it via `@plugin:gps-mentor` — that's `research` alone, which is in `RUNLOG_GATE_EXEMPT_SKILLS` and has no runlogs. Verified by running `check_runlogs.py` with CI's own `BASE_SHA`/`HEAD_SHA`: **"All runlog rules satisfied."** (My earlier estimate that proof-conclusion would need a re-run was wrong — it mentions gps-mentor in prose but doesn't delegate to it.)

**init-project's identical `kh_001` defect is deliberately left out.** Its runlog is already stale against main for unrelated reasons — with only `SKILL.md` touched, the gate reports four differing files, three of which this branch never touches (`mid-research-flynn/README.md`, that scenario's `tree.gedcomx.json`, `places-guidance.md`). Bundling a two-line prose fix with a re-run that mostly absorbs pre-existing drift seemed like the wrong trade; it stays on #739.

## Verification

- `npx tsc --noEmit` clean; **1529 tests / 67 files pass** (5 new)
- `check_runlogs.py` — all rules satisfied
- `check_skill_frontmatter.py` — 27 skills + 3 agents clean
- agent and spec tool lists diffed and confirmed identical

Specs updated so the contradiction can't recur: `gps-mentor-agent-spec.md` §1/§7/§8/§12.1 and `research-append-tool-spec.md` §3.4.2 (new) + the §5 invariants table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)