### PR TITLE
Dual-spell agent tool names so plugin agents bind in Cowork

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -158,15 +158,52 @@ orchestrator auto-delegates to the agent. Agents run in fresh context
 explicitly specced otherwise. The first such agent is `gps-mentor`
 (spec: `docs/specs/gps-mentor-agent-spec.md`).
 
-**Qualified tool names.** In the `tools:` frontmatter, MCP tools **must**
-be listed under their fully-qualified `mcp__genealogy__*` names, never the
-bare tool name. A bare name leaves the subagent toolless in the
-unit-harness SDK path (only the e2e harness tolerated bare names, via its
-ToolSearch prefix allowlist); qualifying makes an agent behave identically
-across Cowork, the e2e harness, the unit harness, and the hosted web SDK
-path. Built-in Cowork tools that are not MCP tools — `Read` — stay bare.
-All three current agents follow this (`gps-mentor`, `image-reader`,
-`record-extractor`).
+**Dual-spelled tool names.** In `tools:` — and in `disallowedTools:` —
+every MCP tool **must** be listed twice, once under each server spelling:
+
+    - mcp__genealogy__record_read
+    - mcp__remote-devices__Genealogy_Research__record_read
+
+Bare names do not work (they leave the subagent toolless in the
+unit-harness SDK path), but neither does a single qualified name. The MCP
+server's name is chosen by whoever registers it, and the plugin — which
+ships into the VM — cannot control that choice. `.mcp.json`, both
+harnesses, and the hosted web control plane register it under the key
+`genealogy`; Cowork reaches the host-installed `.mcpb` through a
+remote-device bridge that namespaces it by `manifest.json`'s
+`display_name`. No single spelling resolves everywhere.
+
+Entries are matched **exactly** — no prefix fallback, no inherit-on-miss.
+When every `tools:` entry misses, the runtime refuses to spawn the agent at
+all ("would be spawned with zero tools — refusing"). That is how #650/#698
+broke all three agents in Cowork while CI stayed green: they were qualified
+against the *harness's* arbitrary dict key rather than the product's name.
+Listing both spellings is safe because unrecognized entries are ignored so
+long as at least one resolves.
+
+`disallowedTools:` matters more, not less. A deny binds even under
+`bypassPermissions` (the hosted path, issue #695), so it is the last line
+of defence keeping `record-extractor` off the broad `research_append` — and
+a deny naming one spelling silently fails to bind under the other.
+
+Do **not** reach for a server-level prefix grant (`mcp__remote-devices`):
+that namespace also carries `device_bash`, `device_commit_files`, and
+`project_memory_write`, so it would hand a read-only agent shell access to
+the host.
+
+Built-in Cowork tools that are not MCP tools — `Read` — stay bare. Skills'
+`allowed-tools` frontmatter also stays **bare** (it is not an exact-match
+spawn filter); only agent `tools:`/`disallowedTools:` are dual-spelled.
+Enforced by `tests/packaging/agent-tool-names.test.ts`, which derives the
+bridge prefix from `display_name` so renaming the extension fails loudly in
+CI instead of silently in production.
+
+**Never hardcode a qualified name in a ToolSearch query.** Cowork defers
+the ~40 genealogy tool schemas (both harnesses set `ENABLE_TOOL_SEARCH=true`
+to avoid this; Cowork offers no such control), so ToolSearch is the real
+load path there. Search by bare tool name — `query: "+research_append"` —
+which matches whatever prefix the session exposes. The same packaging test
+fails any `select:mcp__…` in a plugin body.
 
 ## Handling user feedback submissions
 

--- a/docs/TODOs.md
+++ b/docs/TODOs.md
@@ -499,14 +499,49 @@ sized by the Phase-0 latency analysis and are not covered by the parent plan's p
   mechanism is sound and only the names are wrong.
   Affects all three agents (`gps-mentor` 7 tools, `record-extractor` 9,
   `image-reader` 1) — pre-existing, not introduced by #695.
-  **Open questions the fix must answer:** is the prefix deployment-dependent
-  (remote/bridged MCP vs a local `.mcpb` install)? If so, no hardcoded string is
-  right everywhere — is a server-level pattern (`mcp__<server>` /
-  `mcp__<server>__*`) viable, or bare names (CLAUDE.md says bare names left the
-  subagent toolless in the unit-harness SDK path, so neither form is currently
-  known-good in both)? The fix must also correct `CLAUDE.md`'s claim that
-  qualified names make an agent "behave identically across Cowork, the e2e
-  harness, the unit harness, and the hosted web SDK path" — that is false.
+  **RESOLVED (2026-07-18) — dual-spelled names.** The open questions are
+  answered: **yes, the prefix is deployment-dependent**, and no hardcoded
+  string is right everywhere. `genealogy` is the arbitrary `mcp_servers` dict
+  key the harnesses/`.mcp.json`/hosted web chose; Cowork reaches the
+  host-installed `.mcpb` through a remote-device *bridge* whose namespace is
+  `remote-devices`, with the tool named `Genealogy_Research__<tool>` after
+  `manifest.json`'s `display_name`. The two can never converge — you cannot
+  register a local stdio server and have the bridge infix synthesized.
+  **A server-level pattern is viable but unsafe here:** `mcp__remote-devices`
+  also carries `device_bash`, `device_commit_files`, and
+  `project_memory_write`, so granting it would hand a read-only agent shell
+  access to the host. **Bare names remain broken** in the unit-harness SDK
+  path, as CLAUDE.md said.
+  Fix: list every MCP tool under **both** spellings in `tools:` *and*
+  `disallowedTools:` — safe because unrecognized entries are ignored so long
+  as one resolves. Guarded by `tests/packaging/agent-tool-names.test.ts`,
+  which derives the bridge prefix from `display_name`. CLAUDE.md's
+  "behave identically" claim is corrected, and the ToolSearch fallback paths
+  (which hardcoded `select:mcp__genealogy__…` and so resolved to nothing in
+  Cowork, where the ~40 schemas *are* deferred) now search by bare tool name.
+
+- [x] **Dual-spelled agent tool names — VERIFIED in Cowork (2026-07-18).**
+  The fix rested on one unproven assumption: that the runtime refuses a spawn
+  only when **every** `tools:` entry is unrecognized ("would be spawned with
+  zero tools — refusing"), so the half that miss in any given environment are
+  harmlessly ignored. Had it instead refused on *any* unrecognized entry,
+  dual-spelling would have failed in all four environments at once.
+  Confirmed by a live Cowork run: `@plugin:image-reader` — 1 of its 2 entries
+  unresolvable there — spawned normally, resolved `image_transcribe` through
+  the bridge (permission prompt showed `ark: 3:2:77P1-FRQ` reaching the host
+  tool), and returned a full transcription of an 1898 German family-register
+  index page. The same run's "loaded tools" step exercised the bare-name
+  ToolSearch path. Ignore-unrecognized-if-one-resolves is therefore the real
+  behavior, and the dual-spelling approach is sound.
+
+- [ ] **Scope the record-extraction outage window.** `record-extractor` could
+  not spawn in Cowork between 2026-07-12 (#650) and this fix. Because the
+  runtime refuses rather than launching a toolless agent, the failure was loud
+  and nothing should have been silently half-persisted — but that assumes
+  Cowork ran a build with the loud refusal for the whole window (it landed in
+  CLI 2.1.208; the VM CLI on disk is 2.1.205, so an earlier silent-toolless
+  window is possible). Spot-check live projects (e.g. `kenneth-quass-parents`)
+  for records with a research-log entry but no corresponding assertions.
 - **The router substitutes for a denied subagent tool — observed in production.**
   In the same Cowork session the `record-extraction` router correctly recited
   that it "cannot call ... `research_append` ... or `image_transcribe`/`image_read`

--- a/docs/specs/gps-mentor-agent-spec.md
+++ b/docs/specs/gps-mentor-agent-spec.md
@@ -126,14 +126,28 @@ tools:
   - mcp__genealogy__external_links_search
   - mcp__genealogy__wiki_place_page
   - mcp__genealogy__wiki_search
+  - mcp__remote-devices__Genealogy_Research__research_append
+  - mcp__remote-devices__Genealogy_Research__validate_research_schema
+  - mcp__remote-devices__Genealogy_Research__place_search
+  - mcp__remote-devices__Genealogy_Research__place_distance
+  - mcp__remote-devices__Genealogy_Research__collections_search
+  - mcp__remote-devices__Genealogy_Research__external_links_search
+  - mcp__remote-devices__Genealogy_Research__wiki_place_page
+  - mcp__remote-devices__Genealogy_Research__wiki_search
 ---
 ```
 
-The MCP tools **must** be listed under their fully-qualified
-`mcp__genealogy__*` names — bare names leave the subagent toolless in the
-unit-harness SDK path (only the e2e harness tolerated them, via its
-ToolSearch prefix allowlist). `Read` is a built-in Cowork tool, not an MCP
-tool, so it stays bare.
+Every MCP tool **must** appear under **both** server spellings. Bare names
+leave the subagent toolless in the unit-harness SDK path, but a single
+qualified name is equally wrong: `mcp__genealogy__*` resolves under
+`.mcp.json`, both harnesses, and hosted web, while Cowork exposes the
+host-installed `.mcpb` through a remote-device bridge as
+`mcp__remote-devices__Genealogy_Research__*`. Entries are matched exactly
+with no fallback, and an agent whose entries all miss is refused a spawn
+outright. Unrecognized entries are ignored so long as one resolves, so
+listing both is safe. Enforced by
+`tests/packaging/agent-tool-names.test.ts`. `Read` is a built-in Cowork
+tool, not an MCP tool, so it stays bare.
 
 **Model requirement:** `claude-sonnet-5`. The gates read and cross-reference large research
 files with careful analytical reasoning. Sonnet 5 — released after this spec was first written —

--- a/docs/specs/image-reader-agent-spec.md
+++ b/docs/specs/image-reader-agent-spec.md
@@ -85,8 +85,12 @@ says so.
   text model (e.g. `claude-haiku-4-5`) would suffice and is a candidate cost
   optimization — left at `claude-sonnet-4-6` (the pre-spike default) for
   safety. Cowork honors the agent `model:` pin.
-- `tools: [image_transcribe]` (qualified as `mcp__genealogy__*` in the
-  frontmatter, per the repo convention) — the agent's sole reader. It does not
+- `tools: [image_transcribe]` — listed in the frontmatter under **both**
+  server spellings (`mcp__genealogy__image_transcribe` and
+  `mcp__remote-devices__Genealogy_Research__image_transcribe`), per the repo
+  convention: the harnesses and Cowork register the MCP server under
+  different names and `tools:` is matched exactly — the agent's sole reader.
+  It does not
   write `research.json` / `tree.gedcomx.json`, create assertions/sources, or
   search indexes; that stays with the caller.
 

--- a/docs/specs/research-append-tool-spec.md
+++ b/docs/specs/research-append-tool-spec.md
@@ -706,20 +706,23 @@ session toolset, resolve the tool under its real name, and work. Only a
 restrictive allow-list can be *broken* by a name that matches nothing. So the
 denial mechanism this section depends on is real in Cowork.
 
-What does not hold is the **naming**. Every agent's `tools:` is written
-`mcp__genealogy__*`, which is correct for the unit and e2e harnesses and appears
-to be wrong for Cowork. Consequences, and they cut opposite ways from
-over-permissioning: an agent is *under*-permissioned to nothing (already true of
-`image-reader` in production), and a `disallowedTools` entry naming a tool that
-does not resolve denies nothing. This is a **pre-existing, repo-wide** issue
-affecting all three agents, not one introduced here, and it is tracked
-separately — see `docs/TODOs.md`. Until it is resolved, treat this section's
-guarantee as holding in the harnesses and the hosted SDK path, and as *pending*
-in Cowork.
+**The naming has since been fixed (2026-07-18).** The prefix is
+deployment-dependent: `mcp__genealogy__*` is the arbitrary `mcp_servers` dict
+key the harnesses, `.mcp.json`, and the hosted web control plane chose, while
+Cowork reaches the host-installed `.mcpb` through a remote-device *bridge* and
+exposes it as `mcp__remote-devices__Genealogy_Research__*` (after
+`manifest.json`'s `display_name`). No single spelling resolves everywhere, so
+every agent now lists each MCP tool under **both** — in `tools:` and in
+`disallowedTools:` alike. The latter matters most here: a deny naming only the
+unresolvable spelling denies nothing, which would have left this section's
+belt-and-braces layer inert in Cowork exactly where `bypassPermissions` makes
+it load-bearing. Enforced by `tests/packaging/agent-tool-names.test.ts`.
 
-Note this also falsifies `CLAUDE.md`'s claim that qualified names make an agent
-"behave identically across Cowork, the e2e harness, the unit harness, and the
-hosted web SDK path." That sentence should be corrected by the naming fix.
+With that in place, this section's guarantee holds in all four environments.
+`CLAUDE.md`'s superseded claim that a single qualified spelling makes an agent
+"behave identically" across them has been corrected accordingly. One residual
+assumption is tracked in `docs/TODOs.md`: that the runtime refuses a spawn only
+when *every* entry is unrecognized, rather than on any one of them.
 
 ### 11.2 The gate
 

--- a/packages/engine/mcp-server/tests/packaging/agent-tool-names.test.ts
+++ b/packages/engine/mcp-server/tests/packaging/agent-tool-names.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync, readdirSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { allToolSchemas } from "../../src/tool-schemas.js";
+
+// Plugin-agent `tools:` / `disallowedTools:` frontmatter must name every MCP
+// tool under BOTH server spellings.
+//
+// The MCP server's name is chosen by whoever registers it, and the plugin —
+// which ships into the Cowork VM — cannot control that choice:
+//
+//   - `.mcp.json`, the unit harness (skill_runner's `mcp_servers={"genealogy": …}`),
+//     the e2e orchestrator, and the hosted web control plane all register it
+//     under the key `genealogy`      → mcp__genealogy__<tool>
+//   - Cowork reaches the host-installed .mcpb through a remote-device bridge,
+//     which namespaces it by the manifest's display_name
+//                                    → mcp__remote-devices__Genealogy_Research__<tool>
+//
+// Entries are matched EXACTLY, with no prefix fallback and no inherit-on-miss.
+// When every `tools:` entry misses, the runtime refuses to spawn the agent
+// outright ("would be spawned with zero tools — refusing"). That is how
+// #650/#698 broke all three agents in Cowork while CI stayed green: they were
+// qualified against the test harness's arbitrary dict key rather than the
+// product's name.
+//
+// `disallowedTools:` needs the same treatment for a sharper reason. A deny is
+// enforced even under `bypassPermissions` (the hosted path — issue #695), so
+// it is the last line of defence keeping record-extractor off the broad
+// `research_append`. A deny naming only one spelling silently fails to bind
+// wherever the server is registered under the other name.
+//
+// Listing both spellings is the only form that resolves everywhere. A
+// server-level prefix grant cannot substitute: Cowork's `remote-devices`
+// namespace also carries device_bash / device_commit_files /
+// project_memory_write, so `mcp__remote-devices` would hand a read-only agent
+// shell access to the host.
+//
+// The bridge spelling derives from manifest.display_name, so renaming the
+// extension would silently re-break production. That is what this test catches.
+
+const here = dirname(fileURLToPath(import.meta.url));
+const mcpRoot = join(here, "..", "..");
+const pluginRoot = join(mcpRoot, "..", "plugin");
+const agentsDir = join(pluginRoot, "agents");
+
+const manifest = JSON.parse(
+  readFileSync(join(mcpRoot, "manifest.json"), "utf8"),
+) as { display_name: string };
+
+/** Non-alphanumeric runs collapse to a single underscore; edges trimmed. */
+function sanitizeServerSegment(name: string): string {
+  return name
+    .replace(/[^A-Za-z0-9]+/g, "_")
+    .replace(/_+/g, "_")
+    .replace(/^_|_$/g, "");
+}
+
+const HARNESS_PREFIX = "mcp__genealogy__";
+const BRIDGE_PREFIX = `mcp__remote-devices__${sanitizeServerSegment(manifest.display_name)}__`;
+
+/** Parse a named block-sequence out of YAML frontmatter. */
+function extractList(text: string, key: string): string[] {
+  const frontmatter = /^---\r?\n([\s\S]*?)\r?\n---/.exec(text);
+  if (!frontmatter) throw new Error("no YAML frontmatter");
+
+  const lines = frontmatter[1].split(/\r?\n/);
+  const start = lines.findIndex((l) => new RegExp(`^${key}:`).test(l));
+  if (start === -1) return [];
+
+  const items: string[] = [];
+  for (let i = start + 1; i < lines.length; i++) {
+    if (/^\S/.test(lines[i]) && !/^\s*#/.test(lines[i])) break; // next top-level key
+    const item = /^\s*-\s+(.+?)\s*$/.exec(lines[i]);
+    if (item) items.push(item[1]);
+  }
+  return items;
+}
+
+function bareName(entry: string): string {
+  return entry.startsWith(BRIDGE_PREFIX)
+    ? entry.slice(BRIDGE_PREFIX.length)
+    : entry.slice(HARNESS_PREFIX.length);
+}
+
+const agentFiles = readdirSync(agentsDir).filter((f) => f.endsWith(".md"));
+const knownTools = new Set(allToolSchemas.map((s) => s.name));
+
+describe("plugin agent tool names", () => {
+  it("finds the plugin agents", () => {
+    expect(agentFiles.length).toBeGreaterThan(0);
+  });
+
+  it("derives the bridge prefix from manifest.display_name", () => {
+    // Pinned so a display_name rename fails loudly here, next to the
+    // explanation, rather than as a mystery spawn failure in Cowork.
+    expect(BRIDGE_PREFIX).toBe("mcp__remote-devices__Genealogy_Research__");
+  });
+
+  for (const file of agentFiles) {
+    describe(file, () => {
+      const text = readFileSync(join(agentsDir, file), "utf8");
+
+      for (const key of ["tools", "disallowedTools"] as const) {
+        const entries = extractList(text, key).filter((t) => t.startsWith("mcp__"));
+        if (key === "disallowedTools" && entries.length === 0) continue;
+
+        describe(key, () => {
+          it("parses at least one MCP entry", () => {
+            // Guards the assertions below against passing vacuously if the
+            // frontmatter parser stops matching the block-sequence form.
+            expect(entries.length).toBeGreaterThan(0);
+          });
+
+          it("uses only recognized server prefixes", () => {
+            for (const entry of entries) {
+              expect(
+                entry.startsWith(HARNESS_PREFIX) || entry.startsWith(BRIDGE_PREFIX),
+                `${entry} uses an unrecognized server prefix`,
+              ).toBe(true);
+            }
+          });
+
+          it("names only tools the server actually registers", () => {
+            for (const entry of entries) {
+              expect(
+                knownTools.has(bareName(entry)),
+                `${entry} is not in allToolSchemas`,
+              ).toBe(true);
+            }
+          });
+
+          it("lists every MCP tool under both spellings", () => {
+            for (const bare of new Set(entries.map(bareName))) {
+              expect(entries, `missing harness spelling for ${bare}`).toContain(
+                `${HARNESS_PREFIX}${bare}`,
+              );
+              expect(entries, `missing Cowork bridge spelling for ${bare}`).toContain(
+                `${BRIDGE_PREFIX}${bare}`,
+              );
+            }
+          });
+        });
+      }
+    });
+  }
+});
+
+describe("plugin agent/skill bodies", () => {
+  // The deferred-schema fallback path. Cowork defers the ~40 genealogy tool
+  // schemas (both harnesses set ENABLE_TOOL_SEARCH=true to avoid this; Cowork
+  // offers no such control), so ToolSearch IS the load path there — and a
+  // hardcoded `select:mcp__genealogy__…` query resolves to nothing. Bodies
+  // must search by bare tool name instead.
+  function walk(dir: string): string[] {
+    return readdirSync(dir, { withFileTypes: true }).flatMap((e) =>
+      e.isDirectory()
+        ? walk(join(dir, e.name))
+        : e.name.endsWith(".md")
+          ? [join(dir, e.name)]
+          : [],
+    );
+  }
+
+  it("never hardcodes a qualified tool name in a ToolSearch select query", () => {
+    const offenders: string[] = [];
+    for (const path of walk(pluginRoot)) {
+      for (const line of readFileSync(path, "utf8").split(/\r?\n/)) {
+        if (/select:\s*mcp__/.test(line)) offenders.push(`${path}: ${line.trim()}`);
+      }
+    }
+    expect(offenders, offenders.join("\n")).toEqual([]);
+  });
+});

--- a/packages/engine/plugin/agents/gps-mentor.md
+++ b/packages/engine/plugin/agents/gps-mentor.md
@@ -18,6 +18,12 @@ description: >-
   proof-conclusion skill, which invokes this mentor.
 model: claude-sonnet-5
 tools:
+  # Every MCP tool appears under BOTH server spellings — `genealogy` (the
+  # harnesses, .mcp.json, hosted web) and the `remote-devices` bridge
+  # namespace Cowork exposes the installed .mcpb under. `tools:` is matched
+  # exactly with no prefix fallback, and the plugin cannot control which name
+  # the host registers. See record-extractor.md for the full rationale;
+  # guarded by tests/packaging/agent-tool-names.test.ts.
   - Read
   - mcp__genealogy__research_append
   - mcp__genealogy__validate_research_schema
@@ -27,6 +33,14 @@ tools:
   - mcp__genealogy__external_links_search
   - mcp__genealogy__wiki_place_page
   - mcp__genealogy__wiki_search
+  - mcp__remote-devices__Genealogy_Research__research_append
+  - mcp__remote-devices__Genealogy_Research__validate_research_schema
+  - mcp__remote-devices__Genealogy_Research__place_search
+  - mcp__remote-devices__Genealogy_Research__place_distance
+  - mcp__remote-devices__Genealogy_Research__collections_search
+  - mcp__remote-devices__Genealogy_Research__external_links_search
+  - mcp__remote-devices__Genealogy_Research__wiki_place_page
+  - mcp__remote-devices__Genealogy_Research__wiki_search
 ---
 
 # GPS Mentor

--- a/packages/engine/plugin/agents/image-reader.md
+++ b/packages/engine/plugin/agents/image-reader.md
@@ -3,7 +3,12 @@ name: image-reader
 description: Reads ONE FamilySearch image scan and returns ONLY a full text transcription. Call this whenever you need the content of a page scan (a `3:1:.../$dist` image ARK or a `dgs:{DGS}_{IMAGE}/dist.jpg` Image Group Number) — e.g. "transcribe this register page", "read this image", "OCR this scan", "what does image 004022578_00190 say". It OCRs the scan cheaply and fast via a hosted model (Qwen3-VL) and returns text. Reads exactly one image per invocation; invoke it once per image. Do NOT use for indexed records (use record_read / record_search), PDFs (read them directly), or to search for which image to read (use image_search / volume_search first, then hand this agent the specific imageId).
 model: claude-sonnet-4-6
 tools:
+  # Listed under both the `genealogy` server key (harnesses, .mcp.json,
+  # hosted web) and the `remote-devices` bridge namespace Cowork exposes the
+  # installed .mcpb under. See record-extractor.md for the full rationale;
+  # guarded by tests/packaging/agent-tool-names.test.ts.
   - mcp__genealogy__image_transcribe
+  - mcp__remote-devices__Genealogy_Research__image_transcribe
 ---
 
 # Image Reader

--- a/packages/engine/plugin/agents/record-extractor.md
+++ b/packages/engine/plugin/agents/record-extractor.md
@@ -15,6 +15,16 @@ description: >-
   citations.
 model: claude-sonnet-4-6
 tools:
+  # Every MCP tool appears under BOTH server spellings: `genealogy` (the key
+  # .mcp.json, both harnesses, and the hosted web control plane register the
+  # server under) and the `remote-devices` bridge namespace Cowork exposes the
+  # host-installed .mcpb under (`Genealogy_Research` is manifest.json's
+  # display_name, spaces → underscores). Entries are matched EXACTLY with no
+  # prefix fallback, and the server name is chosen by whoever registers it —
+  # the VM-side plugin cannot control it — so no single spelling resolves
+  # everywhere. Unrecognized entries are ignored as long as one resolves; when
+  # ALL of them miss, the runtime refuses to spawn the agent at all.
+  # Guarded by tests/packaging/agent-tool-names.test.ts.
   - mcp__genealogy__project_context
   - mcp__genealogy__record_read
   - mcp__genealogy__place_search
@@ -23,12 +33,27 @@ tools:
   - mcp__genealogy__research_log_append
   - mcp__genealogy__record_person_matches
   - mcp__genealogy__record_record_matches
+  - mcp__remote-devices__Genealogy_Research__project_context
+  - mcp__remote-devices__Genealogy_Research__record_read
+  - mcp__remote-devices__Genealogy_Research__place_search
+  - mcp__remote-devices__Genealogy_Research__place_search_all
+  - mcp__remote-devices__Genealogy_Research__extraction_append
+  - mcp__remote-devices__Genealogy_Research__research_log_append
+  - mcp__remote-devices__Genealogy_Research__record_person_matches
+  - mcp__remote-devices__Genealogy_Research__record_record_matches
 # `extraction_append` writes only `sources` + `assertions`. The broad
 # `research_append` is denied both by omission above and explicitly here:
 # a `disallowedTools` deny is enforced even under `bypassPermissions`,
 # which the hosted path runs (issue #695).
+#
+# The deny MUST carry both spellings for the same reason the allow-list does.
+# A deny that names only `mcp__genealogy__research_append` silently fails to
+# bind wherever the server is registered under another name — which is exactly
+# the environment where it matters most, since the deny is the only thing
+# standing between this agent and the broad writer under bypassPermissions.
 disallowedTools:
   - mcp__genealogy__research_append
+  - mcp__remote-devices__Genealogy_Research__research_append
 ---
 
 # Record Extractor
@@ -581,8 +606,10 @@ copy first; check the echoed `resolvedPlaces`), validates once, and
 writes both files. **Never predict an id; never call `tree_edit` for the
 source; never write `research.json` or `tree.gedcomx.json` directly** —
 direct writes bypass validation, id allocation, and the `.bak` safety
-net. If a persistence tool shows as deferred, load it via ToolSearch with
-the fully-qualified name (`mcp__genealogy__extraction_append`) first.
+net. If a persistence tool shows as deferred, load it via ToolSearch
+first — search by **bare** tool name (`query: "+extraction_append"`),
+never by a hardcoded fully-qualified name, since the MCP server prefix
+differs per deployment.
 
 **Source reuse is tool-detected.** Always supply `sourceDescription` —
 the tool detects when this record already has a source (same

--- a/packages/engine/plugin/skills/forget-and-rederive/SKILL.md
+++ b/packages/engine/plugin/skills/forget-and-rederive/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: forget-and-rederive
 description: Set up a practice run by removing information the researcher already has from the project tree, so it must be re-derived from records. Use when the researcher says "forget what you know about X and find it again", "hide his parents and see if you can find them", "I want to test whether you can work this out", "re-derive this from scratch", or seeds a project from a well-documented FamilySearch person specifically to check whether the agent can rediscover a known answer. Do NOT use to correct a wrong fact (use tree_correct), to remove a duplicate person (use merge_tree_persons), or to start a project (use init-project).
-allowed-tools: Bash, Read, mcp__genealogy__validate_research_schema
+allowed-tools: Bash, Read, validate_research_schema
 ---
 
 **Narration:** read `researcher_profile.narration_guidance` in `research.json` and

--- a/packages/engine/plugin/skills/record-extraction/SKILL.md
+++ b/packages/engine/plugin/skills/record-extraction/SKILL.md
@@ -210,10 +210,13 @@ failure — the summary is a progress marker, not a stopping point.
 ## Tool availability
 
 **If `record_read`, `volume_search`, or `research_log_append` are not
-immediately available** (e.g., shown as deferred), call ToolSearch first
-with the fully-qualified names, e.g.
-`query: "select:mcp__genealogy__record_read,mcp__genealogy__volume_search,mcp__genealogy__research_log_append"`
-(adjust the server prefix if yours differs), then proceed. **Never fall
+immediately available** (e.g., shown as deferred), call ToolSearch first.
+**Search by bare tool name, never by a fully-qualified `select:` list** —
+the MCP server prefix differs per deployment (`mcp__genealogy__…` under
+the harnesses, `mcp__remote-devices__Genealogy_Research__…` under Cowork),
+so a hardcoded qualified name resolves to nothing in some environments.
+Use one keyword search per tool, e.g. `query: "+record_read"`, which
+matches whatever prefix this session actually exposes. **Never fall
 back to writing `research.json` or `tree.gedcomx.json` directly** —
 direct writes bypass schema validation, id allocation, and the `.bak`
 safety net; persistence belongs to the record-extractor agent's tools.


### PR DESCRIPTION
## The bug

All three plugin agents were **toolless in Cowork and could not spawn**:

> Agent 'genealogy-research:record-extractor' would be spawned with zero tools — refusing. Its tools list resolved to nothing: unrecognized [mcp__genealogy__project_context, …]

`mcp__genealogy__*` is the arbitrary `mcp_servers` dict key the harnesses, `.mcp.json`, and the hosted web control plane chose — **not the product's name**. Cowork reaches the host-installed `.mcpb` through a remote-device bridge and exposes it as `mcp__remote-devices__Genealogy_Research__*` (from `manifest.json`'s `display_name`). `tools:` is matched exactly — no prefix fallback, no inherit-on-miss — so every entry missed.

Broken since **#650 (2026-07-12)** for `record-extractor` + `image-reader`, **#698 (2026-07-17)** for `gps-mentor` — each the commit that "qualified" that agent's names against the harness rather than the product. CI stayed green throughout, because the harnesses use the spelling they themselves chose.

## The fix

The prefix is deployment-dependent and the two names can never converge — you cannot register a local stdio server and have the bridge segment synthesized. So every MCP tool is listed under **both** spellings. Safe because unrecognized entries are ignored so long as one resolves.

A server-level prefix grant would have been tidier and is **unsafe**: `mcp__remote-devices` also carries `device_bash`, `device_commit_files`, and `project_memory_write`, so it would hand a read-only agent shell access to the host.

### `disallowedTools` — the sharper half

A deny binds even under `bypassPermissions` (#695), making it the last guard keeping `record-extractor` off the broad `research_append`. A deny naming only the unresolvable spelling denies nothing — so that guard was **inert in Cowork**. Now dual-spelled too.

### Deferred schemas

Cowork defers the ~40 tool schemas (both harnesses set `ENABLE_TOOL_SEARCH=true`; Cowork has no such control), so ToolSearch is the real load path there — and the two sites that anticipated this hardcoded `select:mcp__genealogy__…`, resolving to nothing. They now search by **bare** tool name.

## Verified live

`@plugin:image-reader` in Cowork, with 1 of its 2 entries unresolvable there: spawned normally, reached `image_transcribe` through the bridge (`ark: 3:2:77P1-FRQ`), and returned a full transcription of an 1898 German family-register index page.

## Changes

- Dual-spell `tools:` / `disallowedTools:` in all three agents
- ToolSearch by bare name in `record-extraction/SKILL.md` + `record-extractor.md`
- `forget-and-rederive`: bare `allowed-tools`, matching the other 26 skills
- New `tests/packaging/agent-tool-names.test.ts` — derives the bridge prefix from `display_name`, so an extension rename fails in CI rather than silently in production
- Correct CLAUDE.md's *"behave identically across Cowork, the e2e harness, the unit harness, and the hosted web SDK path"* claim, which was false
- Resolve the #736 TODO with answers to its open questions; update `research-append-tool-spec.md` §11, which held its guarantee "pending in Cowork"

## Testing

1567 mcp-server, 1021 harness unit, `tsc` clean.

**Still to check** (tracked in `docs/TODOs.md`): only `image-reader` is directly proven live. `record-extractor` and `gps-mentor` use the identical mechanism but are worth a run — the extractor's `disallowedTools` deny is now live in Cowork for the first time, which is a behavior change, not just a repair. Also open: spot-check live projects for records with a research-log entry but no assertions, in case an earlier Cowork build launched toolless rather than refusing (the loud refusal landed in CLI 2.1.208; the VM CLI on disk is 2.1.205).

🤖 Generated with [Claude Code](https://claude.com/claude-code)