### PR TITLE
Alpha + skill-improvement guides: worktree setup, viewer, Windows parity

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -436,6 +436,16 @@ eval-ui: $(EVAL_APP_DEPS) ## Launch the Eval CRUD UI dev server — eval/app (Ne
 eval-ui-test: $(EVAL_APP_DEPS) ## Eval CRUD UI tests — eval/app (vitest)
 	cd eval/app && npm test
 
+.PHONY: feedback-case
+feedback-case: ## Unpack a submitted alpha-feedback zip into a working project dir: make feedback-case ZIP=~/Downloads/feedback-….zip [DEST=~/feedback/<slug>] [FORCE=1]
+	# Wraps scripts/setup-feedback-case.sh (contract: docs/specs/feedback-case-spec.md
+	# §11). Unzips the bundle, git-inits it, writes .feedback-repo-root back to this
+	# checkout, and symlinks the plugin + repo skills in — so the result is a live
+	# research project you open in Claude Code and continue, not an archive.
+	# Windows: run scripts\setup-feedback-case.bat instead.
+	@test -n "$(ZIP)" || { echo "ERROR: set ZIP, e.g. make feedback-case ZIP=~/Downloads/feedback-2026-07-21T09-14-22Z.zip" >&2; exit 1; }
+	scripts/setup-feedback-case.sh $(ZIP) $(DEST) $(if $(FORCE),--force,)
+
 # ── Artifacts (the existing Cowork/desktop deliverables) ─────────
 # The build scripts are cross-platform Node (no bash / no `zip`, so the Windows
 # BuildMcpb.bat / BuildPlugin.bat call them too) and self-install + self-build

--- a/docs/alpha-feedback-example.md
+++ b/docs/alpha-feedback-example.md
@@ -19,10 +19,24 @@ For what the alpha tester sees, see [`alpha-user-guide.md`](alpha-user-guide.md)
 | Icon | Place | What it is | Used for |
 |---|---|---|---|
 | 🌐 | **The workbench** | <https://genealogy-workbench.fly.dev> in a browser. Where alpha testers research. | *Noticing* the problem and *reporting* it. |
-| 🤖 | **Claude Code** | A `claude` session at the repo root. | *Reproducing*, *classifying*, *capturing the test*, *improving the skill*. |
-| ⌨️ | **Terminal** | A plain shell for `make …`. | *Unpacking* the case, *running tests*, *gating*. One `make` target opens a **browser** tab — the grading UI. |
+| 🤖 | **Claude Code** | A `claude` session — sometimes in your repo worktree, sometimes in the unpacked case folder. See below. | *Reproducing*, *classifying*, *capturing the test*, *improving the skill*. |
+| ⌨️ | **Terminal** | A plain shell for `make …` (Windows: the matching `.bat`). | *Unpacking* the case, *running tests*, *gating*. One `make` target opens a **browser** tab — the grading UI. |
 
 Alpha testers only ever touch the first one. Everything else is us.
+
+Two of the steps below also want the **Research Viewer** (Electron) open, which is
+how you read the research log, assertions and conflicts the agent is writing rather
+than inferring them from the chat.
+
+### Where to open what
+
+Two directories are in play, and mixing them up is the commonest early mistake:
+
+| | Directory | Why |
+|---|---|---|
+| **Terminal** (`make …`) | the **worktree root** (Step 0) | `make eval-skill` / `make gate-skill` test the working tree, and that's where your skill edit is |
+| **Claude Code**, steps 3–5 | the **case folder** (`~/feedback/<slug>/`) | it *is* the research project; the setup script symlinks the skills in and writes `.feedback-repo-root` pointing back at your checkout, so `mine-unit-test` lands its output in the repo automatically |
+| **Claude Code**, step 7 | the **worktree root** | `skill-improver` reads run logs under `eval/runlogs/` |
 
 ---
 
@@ -63,27 +77,68 @@ reasoning, so the third box carries the whole report.
 That three-part note is the most valuable thing produced all day. Everything
 below is mechanics.
 
+### Step 0 — Branch before you touch anything ⌨️ Terminal
+
+Sam is going to end up editing a skill and writing test files into `eval/`, so the
+first move is a worktree — not the main checkout, whatever branch that happens to be
+on:
+
+```
+make install-hooks                       # once per clone, not once per case
+git worktree add .claude/worktrees/schuster-parent -b schuster-parent origin/main
+```
+
+`install-hooks` matters: its `post-checkout` hook auto-links the shared gitignored
+files (`node_modules`, `eval/.env`, `apps/server/.env`) into each new worktree, so it
+can build and run tests immediately.
+
+Do this **before** Step 2, not after: the setup script stamps `.feedback-repo-root`
+with whichever checkout you run it from, and that marker is what decides where the
+mined test gets written. Run it from the main checkout and your test lands on the
+wrong branch.
+
 ### Step 2 — Unpack the case ⌨️ Terminal
 
-The bundle lands in the shared Drive folder. Sam downloads it and runs:
+The bundle lands in the shared Drive folder. Sam downloads it and, **from the
+worktree root**, runs:
 
 ```
-scripts/setup-feedback-case.sh ~/Downloads/feedback-2026-07-21T09-14-22Z.zip
+make feedback-case ZIP=~/Downloads/feedback-2026-07-21T09-14-22Z.zip
 ```
+
+On Windows, `scripts\setup-feedback-case.bat` takes the same zip path as its first
+argument. Both wrap the same script; add `FORCE=1` (or `--force`) to overwrite a
+case directory you've already unpacked.
 
 That unpacks into `~/feedback/<slug>/` — `research.json`, `tree.gedcomx.json`,
 `results/` (the actual tool responses), `_feedback/feedback.json` with Marta's
-three answers, and the session transcript. It also symlinks the skills in and
-`git init`s the folder, so it's a working project, not an archive.
+three answers, and the session transcript. It also symlinks the skills in, `git
+init`s the folder, and writes `.feedback-repo-root` back to your worktree — so it's
+a working project wired to the right branch, not an archive.
 
 ### Step 3 — Continue the research 🤖 Claude Code
 
-**This is the step that replaces guessing.** Sam opens that folder in Claude Code
-and simply carries on from where Marta stopped:
+**This is the step that replaces guessing.** Sam opens **the case folder**
+(`~/feedback/<slug>/`, not the repo) in Claude Code and simply carries on from where
+Marta stopped:
 
 ```
 /research
 ```
+
+Before typing that, open the **Research Viewer** on the same case folder — from a
+terminal in the worktree:
+
+```
+make electron                            # Windows: eval\Viewer.bat
+```
+
+then **Open Project** → `~/feedback/<slug>/`. The case folder is exactly the shape
+the viewer expects, so you get Marta's project rendered as she saw it, and then watch
+it change live. For this bug in particular that's the whole game: the defect is *an
+unproven relationship written into the tree as settled*, and the viewer shows you
+that assertion and its evidence side by side. The chat will just tell you it found
+John's father.
 
 The project state *is* Marta's state, so the agent picks up mid-flow and Sam
 watches the same reasoning happen live — this time with the ability to interrupt
@@ -130,10 +185,15 @@ value for Step 7.
 
 ### Step 6 — Run it and mark what's wrong ⌨️ Terminal → 🌐 browser
 
+Back in the **worktree root**:
+
 ```
-make eval-skill SKILL=<skill>
-make eval-ui
+make eval-skill SKILL=<skill>            # Windows: eval\RunTests.bat
+make eval-ui                             # Windows: eval\Start.bat
 ```
+
+The batch files prompt for the skill name instead of taking `SKILL=`, and rebuild
+the MCP server first. Run them from `eval\` in the worktree.
 
 In the grading UI, Sam finds the new test, sees which dimension it failed, and
 pastes **Marta's own Did/Should** into that dimension's comment. This isn't
@@ -142,14 +202,17 @@ human comment. The note already exists; it just has to be on the record.
 
 ### Step 7 — Improve, then gate 🤖 Claude Code → ⌨️ Terminal
 
+In a Claude Code session at the **worktree root** (not the case folder — the
+improver reads `eval/runlogs/`):
+
 > *"improve `<skill>` from its eval results"* — the **skill-improver** agent
 > proposes at most 3 small edits and cites the evidence for each. It only
 > proposes; Sam applies them by hand.
 
-Then:
+Then, from a terminal in the same worktree:
 
 ```
-make gate-skill SKILL=<skill> TEST=ut_person_evidence_022
+make gate-skill SKILL=<skill> TEST=ut_person_evidence_022  # Windows: eval\GateSkill.bat
 ```
 
 The gate re-runs the new test plus the skill's hold-out tests against the edited
@@ -158,10 +221,30 @@ skill and compares to the pre-edit baseline. **LOOKS GOOD** → carry on.
 re-run. **INCONCLUSIVE** → the bug didn't reproduce on the old skill, so the test
 is too weak — back to Step 5.
 
+> **Why gate instead of re-running `make eval-skill` and diffing the scores?** The
+> gate runs **one side** — the "before" numbers come from the Step-6 run log you
+> already paid for, with your `.ann` corrections overlaid, so you're comparing to
+> human ground truth rather than judge-to-judge. It covers only the mined test plus
+> hold-outs, so it takes seconds and you can iterate. And it distinguishes
+> `INCONCLUSIVE` (the bug never reproduced on the *old* skill, so nothing was
+> proven) from a fix that didn't work — a score diff shows you two passing runs and
+> lets you conclude, wrongly, that you're done. It writes no run logs, which is why
+> the full releasable run still has to happen before the PR.
+
 ### Step 8 — Close the loop 🌐 + GitHub
 
-Sam opens a PR — one skill per PR — with the edit, the mined test, its scenario
-and fixtures, the run record, and the grades.
+Sam opens a PR with the edit, the mined test, its scenario and fixtures, the run
+record, and the grades.
+
+**One *problem* per PR — usually one skill, but not always.** This one is: the fix
+lives in `person-evidence`. But a doctrine change like "two same-named candidates
+means a hypothesis, not a conclusion" may have to land in `person-evidence`,
+`conflict-resolution` **and** `proof-conclusion` at once, because shipping it in one
+and not the others leaves the skills contradicting each other mid-research. When a
+fix genuinely spans skills, edit them together in the same PR — and run
+`make eval-skill` for **each** touched skill, since the runlog CI gate checks every
+skill the PR touches. What to avoid is bundling two *unrelated* fixes that happened
+to share a branch.
 
 **Then tell Marta what changed.** An alpha tester who never hears back stops
 reporting, and the reports are the entire point of the alpha.
@@ -172,13 +255,14 @@ reporting, and the reports are the entire point of the alpha.
 
 | Step | What you do | Where |
 |---|---|---|
+| 0 Branch | `make install-hooks`; `git worktree add .claude/worktrees/<branch> -b <branch> origin/main` | ⌨️ Terminal (worktree) |
 | 1 Notice | research; spot it; write Did/Should | 🌐 Workbench |
-| 2 Unpack | `setup-feedback-case.sh <zip>` | ⌨️ Terminal |
-| 3 Continue | `/research` in the case folder; reproduce it live | 🤖 Claude Code |
-| 4 Classify | skill, tool, or grading fault? | 🤖 Claude Code |
-| 5 Capture | `/mine-unit-test --project <case-dir>` | 🤖 Claude Code |
-| 6 Run + mark | `make eval-skill`, `make eval-ui` | ⌨️ Terminal → 🌐 browser |
-| 7 Improve + gate | `skill-improver`, then `make gate-skill` | 🤖 Claude Code → ⌨️ Terminal |
+| 2 Unpack | `make feedback-case ZIP=<zip>` | ⌨️ Terminal (worktree) |
+| 3 Continue | `/research` in the case folder; viewer open on it; reproduce it live | 🤖 Claude Code (case dir) + Viewer |
+| 4 Classify | skill, tool, or grading fault? | 🤖 Claude Code (case dir) |
+| 5 Capture | `/mine-unit-test --project <case-dir>` | 🤖 Claude Code (case dir) |
+| 6 Run + mark | `make eval-skill`, `make eval-ui` | ⌨️ Terminal (worktree) → 🌐 browser |
+| 7 Improve + gate | `skill-improver`, then `make gate-skill` | 🤖 Claude Code (worktree) → ⌨️ Terminal |
 | 8 PR + reply | submit, and tell the tester | GitHub → 🌐 |
 
 ## When feedback should become an e2e fixture instead

--- a/docs/alpha-user-guide.md
+++ b/docs/alpha-user-guide.md
@@ -51,29 +51,71 @@ after it clearer.
 Click **+ New research session**. The agent opens by asking what you'd like to
 research.
 
-### Put everything in your first reply
+### Choosing what to work on
 
-The setup runs in **one pass** — it won't interview you question by question. So
-your first message should carry everything you already know:
+**Don't hand it your hardest brick wall.** You're a professional; the walls you
+haven't broken in twenty years are almost certainly beyond it, and a failure there
+tells us nothing we can act on — only that a hard problem is hard.
 
-- **Who you're researching.** A FamilySearch person ID (PID) is best. A name
-  with dates and places works too. If the person isn't on FamilySearch at all,
-  just describe them — the agent builds a local tree from what you type.
-- **Everything you already have.** Names, dates, places, relationships, what
-  family members have told you, what you've already searched and ruled out.
+What we need instead is a **research objective that tests a specific ability** and
+whose answer you can already judge. Something with a knowable answer, two or three
+records deep, where you'd recognise sloppy reasoning instantly. There are two ways
+to set one up, and they behave differently — **pick one deliberately**.
+
+#### Path A — your own research, not on FamilySearch
+
+Use this when the answer lives in your files rather than in the FamilySearch tree.
+You supply the starting point and the target, and the agent builds a local tree
+from what you type.
+
+In your first message, give it:
+
+- **The starting point** — names, dates, places, and relationships you're confident
+  in. This is what it reasons *from*.
+- **The objective** — the specific question to answer. "Identify Mary Corrigan's
+  parents"; "establish whether the John Byrne in the 1880 census is the same man as
+  the one in the 1885 land record".
+- **What you've already ruled out**, and why.
+
+You know the answer; the agent has no way to look it up in the tree. That makes
+this the cleanest test of whether it can actually *research*.
+
+#### Path B — a FamilySearch person, with something removed
+
+Use this when the case you want to test is already well documented on FamilySearch.
+Give it a **PID**, and tell it **what to forget**:
+
+> "Research PID KWZX-1AB. Forget who his parents were and see if you can find them
+> from records."
+
+It removes that information from the project's copy of the tree, shows you a count
+of what went, and researches from what's left. Three things to know:
+
+- **Check the count before you say go.** Removing a *person* also removes their
+  other links — forgetting a father can cut the siblings attached to him. Look at
+  what would go before agreeing.
+- **It won't be listed back to you.** The agent deliberately doesn't repeat what it
+  removed; that would put the answer straight back in front of it. Confirm the gap
+  in the viewer instead.
+- **Live FamilySearch still holds the answer**, so it's also instructed not to look
+  it up. That rule holds because it follows it, not because anything enforces it.
+  If you catch it peeking, **that's a great piece of feedback.**
+
+If you give a PID and remove *nothing*, the agent will often just read the answer
+off the tree and you'll learn very little.
+
+### Also tell it about you
+
+Whichever path you take, include these two — the setup runs in **one pass**, so it
+won't come back and ask:
+
 - **Your experience level** — just starting out / some research / experienced /
   professional.
 - **Your subscriptions** — Ancestry, MyHeritage, FindMyPast, Newspapers.com,
   GenealogyBank, FindAGrave-Plus, or none.
 
-If you skip the last two it will quietly assume "intermediate" and "none", which
-changes how much it explains as it works. You can correct it later, but it's
-easier to say up front.
-
-**Pick a real brick wall.** The best test is a question you genuinely haven't
-answered. If you pick someone whose tree is already complete on FamilySearch, the
-agent may simply read the answer off the tree and you'll learn very little about
-whether it can research.
+Skip them and it quietly assumes "intermediate" and "none", which changes how much
+it explains as it works. You can correct it later, but it's easier up front.
 
 ### Bringing in a document
 
@@ -83,26 +125,6 @@ in the project and the agent reads it.
 
 You'll need this for anything **not** on FamilySearch. FamilySearch's own record
 images the agent fetches by itself; you don't need to upload those.
-
-### Practising on a question you've already solved
-
-If you want to test the agent against an answer you already know, ask it to
-**forget** what's in the tree and work it out again:
-
-> "Forget who John's parents were and see if you can find them from records."
-
-It will remove that information from the project's copy of the tree, show you a
-count of what went, and then research it. Two things to know:
-
-- **Check the count before you say go.** Removing a *person* also removes their
-  other links. Forgetting a father can also cut the siblings attached to him.
-  The agent will show you what would go; look before agreeing.
-- **It won't be listed back to you.** The agent deliberately doesn't repeat what
-  it removed — that would put the answer straight back in front of it. Confirm
-  the gap in the viewer instead.
-- Live FamilySearch still holds the answer, so the agent is also instructed not
-  to look it up. That rule holds because it follows it, not because anything
-  enforces it. If you catch it peeking, **that's a great piece of feedback.**
 
 ### Watching it work
 
@@ -163,7 +185,6 @@ Being straight with you, so you don't waste time:
   give a PID.
 - **The cost figure restarts when you reload the page.** It's per page-load, not
   per session.
-- **Only one model.** No model picker during the alpha.
 - **You can't reset a project.** To start over, create a new session.
 - **Living people:** please don't enter information about anyone living. Nothing
   is encrypted at rest yet.
@@ -179,7 +200,6 @@ Being straight with you, so you don't waste time:
 | The agent says it can't reach FamilySearch | Its access may have gone stale on an older session. Start a new session; tell us if it keeps happening. |
 | It stops mid-research | Say "continue". If it stalls again, that's worth reporting. |
 | It's slow | Real research is genuinely slow — it reads records one at a time. Minutes is normal. |
-| A wiki page lookup fails | Known; tell us what you were doing. |
 | It asks who you want to research after you already said | It missed your first message. Repeat it with the details. |
 | Something looks wrong genealogically | **That's the point — submit feedback.** |
 

--- a/docs/e2e-testing-example.md
+++ b/docs/e2e-testing-example.md
@@ -19,16 +19,49 @@ for the whole authoring→release lifecycle, see
 
 ## The three places you'll work
 
-You hop between three surfaces. Keeping them straight is the whole trick:
+You hop between three surfaces (plus the viewer, below). Keeping them straight is
+the whole trick:
 
 | Icon | Place | What it is | You use it to… |
 |---|---|---|---|
 | 🖥️ | **Cowork** | The genealogy app where research actually happens (the plugin + skills run here). | *Notice* the problem, and later *confirm* it's fixed. |
-| 🤖 | **Claude Code** | A `claude` session opened at the repo root (the Code tab of the desktop app, or `claude` in a terminal). You type requests and Claude runs the developer skills/agents. | *Classify*, *capture the test*, *improve the skill*. |
-| ⌨️ | **Terminal** | A plain shell where you type `make …` commands. | *Seed* a project, *run tests*, *gate*, *open the PR*. One `make` command (`make eval-ui`) also opens a **browser** tab — the grading UI. |
+| 🤖 | **Claude Code** | A `claude` session opened at your **worktree** root (the Code tab of the desktop app, or `claude` in a terminal) — see "Where to work" below. You type requests and Claude runs the developer skills/agents. | *Classify*, *capture the test*, *improve the skill*. |
+| ⌨️ | **Terminal** | A plain shell where you type `make …` commands (Windows: double-click the matching `.bat` in `eval\`). | *Seed* a project, *run tests*, *gate*, *open the PR*. One `make` command (`make eval-ui`) also opens a **browser** tab — the grading UI. |
 
 Rule of thumb: **Claude Code = you ask Claude to do something. Terminal = you run a
 command yourself. Cowork = you do genealogy.**
+
+A fourth surface shows up alongside Cowork: the **Research Viewer** (Electron),
+which renders the research log, assertions, conflicts and sources of whichever
+project folder you point it at. It's how you *see* what the agent wrote, so open
+it whenever you open a project in Cowork.
+
+### Where to work: make a worktree first
+
+**Everything below happens on a branch, in a worktree — never in the main
+checkout.** Do this once, before Step 1, from your normal repo:
+
+```
+make install-hooks                       # once per clone, not once per branch
+git worktree add .claude/worktrees/citation-locator -b citation-locator origin/main
+```
+
+The `install-hooks` step matters: its `post-checkout` hook auto-links the shared
+gitignored files (`node_modules`, `eval/.env`, `apps/server/.env`) into every new
+worktree, so the new one can build and run tests immediately. Without it you'll
+get a worktree that can't run anything.
+
+Then, for the rest of this walkthrough:
+
+- **Terminal `make …` commands** run from the **worktree root**
+  (`.claude/worktrees/citation-locator/`), not the main checkout — that's where
+  your skill edit lives, and `make eval-skill` / `make gate-skill` test the
+  working tree.
+- **Claude Code** opens at the **same worktree root**. `mine-unit-test` writes
+  into `eval/` relative to wherever you started it, so starting it in the main
+  checkout would drop your new test on the wrong branch.
+- The one exception is the **project folder** you research in (Step 1) — that's a
+  seeded scratch project under `eval/e2e-project/<slug>/`, not repo source.
 
 ---
 
@@ -61,10 +94,25 @@ permanent fix.
 Ana is working in a practice project. Ben seeded it for her earlier from a terminal:
 
 ```
-make e2e-project TEST=schuster-census
+make e2e-project TEST=schuster-census        # Windows: eval\SeedProject.bat
 ```
 
-That opens an editable project she opens in **Cowork** next to the Research Viewer.
+That writes an editable project into `eval/e2e-project/schuster-census/`. Ana opens
+that folder in **two** places:
+
+- **Cowork**, to do the research.
+- the **Research Viewer**, to watch what gets written — launch it from a *second*
+  terminal and leave it running:
+
+```
+make electron                                # Windows: eval\Viewer.bat
+```
+
+Then click **Open Project** in the viewer and pick the same
+`eval/e2e-project/schuster-census/` folder. It live-updates as the agent works.
+Skip this and you're judging the research from the chat transcript alone, which is
+exactly how a bad citation slips past.
+
 Mid-research, she spots the bad citation and writes down, in plain words, what's
 wrong — this note becomes important later:
 
@@ -77,9 +125,9 @@ produces all day. Keep it.
 
 ### Step 2 — Is it even the skill's fault? 🤖 Claude Code
 
-Not every problem is the skill's. Ben opens a **Claude Code** session at the repo
-root and they check the project's `results/` files — the actual data the tools
-returned:
+Not every problem is the skill's. Ben opens a **Claude Code** session at the
+**worktree root** he made above and they check the project's `results/` files —
+the actual data the tools returned:
 
 - If the census tool **did** return the page/line and the skill dropped it → it's a
   **skill** problem. Continue. ✅ (This is their case.)
@@ -124,14 +172,18 @@ When it finishes, `mine-unit-test` prints the new test's **id** — a string lik
 Ben runs the skill's tests (which now include the new one) from a **terminal**:
 
 ```
-make eval-skill SKILL=citation
+make eval-skill SKILL=citation               # Windows: eval\RunTests.bat
 ```
 
 Then he opens the grading UI — a **browser** tab — from the terminal:
 
 ```
-make eval-ui
+make eval-ui                                 # Windows: eval\Start.bat
 ```
+
+The batch files do the same thing, prompting for the skill name instead of taking
+`SKILL=`; both rebuild the MCP server first. Run them from `eval\` in your
+worktree, not the main checkout.
 
 He finds the new test, sees which quality dimension it failed, and pastes **Ana's
 Did/Should/Gap note** into that dimension's comment. This matters: the improver in
@@ -160,7 +212,7 @@ Ben pastes the edits into `citation/SKILL.md` himself.
 From a **terminal**, Ben gates the edit:
 
 ```
-make gate-skill SKILL=citation TEST=<the new test's id>
+make gate-skill SKILL=citation TEST=<the new test's id>   # Windows: eval\GateSkill.bat
 ```
 
 The gate re-runs the new test plus the hold-out tests on the edited skill and
@@ -175,11 +227,31 @@ compares to the "before" baseline from Step 4. It prints one of:
   test, but grading isn't deterministic, so it can also be plain run-to-run luck →
   re-run once; if it stays inconclusive, go back to Step 3 for a sharper test.
 
-It's **advice, not a verdict** — Ben still decides. Then he does one full run to
-produce the record the PR needs:
+It's **advice, not a verdict** — Ben still decides.
+
+> **Why not just re-run `make eval-skill` and compare the numbers?** You could, and
+> you'd get a worse answer for more money. Four differences:
+>
+> - **It runs one side, not two.** The "before" numbers come from the Step-4 run log
+>   you already have. A re-run-and-compare pays for a full suite twice and needs you
+>   to grade both.
+> - **The "before" side is human ground truth.** The gate overlays your `.ann`
+>   corrections onto the Step-4 scores. Comparing two raw runs compares judge to
+>   judge, and the judge is the thing you just spent Step 5 not fully trusting.
+> - **It's the mined test + hold-outs, not the whole suite** — seconds, so you can
+>   iterate on the edit instead of committing to it.
+> - **It tells you when the *test* is the problem.** `INCONCLUSIVE` means the bug
+>   never reproduced on the un-edited skill, so nothing was proven either way. A
+>   score diff can't distinguish that from "the fix didn't work" — it just shows two
+>   passing runs and you conclude, wrongly, that you're done.
+>
+> It also writes **no run logs**, so it can't muddy the releasable record. That's
+> why the full run below still has to happen.
+
+Then he does one full run to produce the record the PR needs:
 
 ```
-make eval-skill SKILL=citation
+make eval-skill SKILL=citation               # Windows: eval\RunTests.bat
 ```
 
 Then he grades it in the browser UI (`make eval-ui`): click **Agree with all**, then
@@ -189,19 +261,41 @@ reviewed — leaving any un-graded makes the PR's automated check fail.
 ### Step 7 — Confirm it in Cowork 🖥️ Cowork
 
 First rebuild and re-upload the plugin so Cowork runs the *edited* skill, not the old
-one: `make plugin`. (Cowork runs the uploaded plugin `.zip`, not your working tree —
-skip this and the fix will look like it did nothing.) Then Ana redoes the same
-citation in **Cowork** and sees the page/line is now there. This is the real-world
-sanity check; the unit test from Step 3 is the durable guard that stops the bug from
-ever coming back.
+one: `make plugin` (Windows: `eval\BuildPlugin.bat`), then remove the old plugin in
+Cowork → Customize and upload the new `.zip`. (Cowork runs the uploaded plugin
+`.zip`, not your working tree — skip this and the fix will look like it did nothing.)
+
+Then Ana redoes the same citation in **Cowork**, with the **Research Viewer** open on
+the same project folder again:
+
+```
+make electron                                # Windows: eval\Viewer.bat
+```
+
+The viewer is the point here, not a nicety: the fix is a *citation string in the
+research log*, and reading it in the viewer is how you confirm the page/line is
+actually there rather than trusting the chat's summary of what it wrote.
+
+This is the real-world sanity check; the unit test from Step 3 is the durable guard
+that stops the bug from ever coming back.
 
 ### Step 8 — Open the PR ⌨️ Terminal / GitHub
 
-Ben opens a pull request — **one skill per PR** — with the skill edit + the new test
-*and the scenario folder and mock fixtures `mine-unit-test` created for it* (under
-`eval/tests/unit/citation/` and `eval/fixtures/`; commit only the test JSON and it
-can't run) + the run record + the grades. A senior reviewer reads the corrected
-grades and, if it's a real improvement, releases it. Done.
+Ben opens a pull request with the skill edit + the new test *and the scenario folder
+and mock fixtures `mine-unit-test` created for it* (under `eval/tests/unit/citation/`
+and `eval/fixtures/`; commit only the test JSON and it can't run) + the run record +
+the grades. A senior reviewer reads the corrected grades and, if it's a real
+improvement, releases it. Done.
+
+**One *problem* per PR — which is usually, but not always, one skill.** A locator
+rule that belongs in `citation` alone is a one-skill PR. But some fixes genuinely
+span skills: a doctrine change about how evidence is classified may have to land in
+`person-evidence`, `conflict-resolution` and `proof-conclusion` together, because
+shipping it in one and not the others leaves the skills contradicting each other
+mid-research. When that happens, edit them all in the same PR — and run
+`make eval-skill` for **each** touched skill, since the runlog CI gate checks every
+skill the PR touches, not just the first. What you should not do is bundle two
+*unrelated* fixes because they happened to be on your branch at the same time.
 
 ---
 
@@ -209,13 +303,14 @@ grades and, if it's a real improvement, releases it. Done.
 
 | Step | What you do | Where |
 |---|---|---|
-| 1 Notice | research; spot the problem; write Did/Should/Gap | 🖥️ Cowork |
+| 0 Branch | `make install-hooks`, then `git worktree add .claude/worktrees/<branch> -b <branch> origin/main`; open Claude Code + all terminals **there** | ⌨️ Terminal |
+| 1 Notice | research; spot the problem; write Did/Should/Gap | 🖥️ Cowork + Viewer |
 | 2 Classify | skill's fault, or a tool/grading fault? | 🤖 Claude Code |
 | 3 Capture | make a unit test that shows the bug | 🤖 Claude Code |
 | 4 Run + mark | run the test; paste the note on the failing dimension | ⌨️ Terminal → 🌐 browser |
 | 5 Audit + improve | rubric-critic (once), then skill-improver; you apply the edits | 🤖 Claude Code |
 | 6 Gate | check the fix helps and breaks nothing | ⌨️ Terminal |
-| 7 Verify | redo the research; see it fixed | 🖥️ Cowork |
+| 7 Verify | rebuild + re-upload the plugin; redo the research; see it fixed | 🖥️ Cowork + Viewer |
 | 8 PR | submit for review | ⌨️ Terminal / GitHub |
 
 ## Go deeper

--- a/eval/CLAUDE.md
+++ b/eval/CLAUDE.md
@@ -20,6 +20,7 @@ eval/
   Setup.bat              One-time Windows setup (uv, npm, API key)
   Start.bat              Launch the Next.js CRUD UI
   RunTests.bat           Execute the Python test harness
+  GateSkill.bat          Gate a candidate SKILL.md edit against its pre-edit baseline
   app/                   Next.js CRUD UI (test authoring + annotation + comparison)
   harness/               Python test runner (Claude Agent SDK)
     harness/             Implementation modules (snapshot, versioning, runlog, …)

--- a/eval/GateSkill.bat
+++ b/eval/GateSkill.bat
@@ -1,0 +1,65 @@
+@echo off
+cd %~dp0
+
+echo === Cowork Genealogy - Gate a candidate SKILL.md edit ===
+echo.
+echo Runs the mined test plus this skill's holdout tests against the SKILL.md
+echo currently in your working tree, and compares to the baseline from the
+echo RunTests.bat run you did BEFORE editing (with your grading corrections
+echo overlaid). Prints LOOKS GOOD / NEEDS YOUR EYES / INCONCLUSIVE.
+echo.
+echo Advisory, not a verdict -- you decide. It writes no run logs, so it does
+echo NOT replace the full RunTests.bat run you do before opening the PR.
+echo.
+echo Apply the skill-improver's edits to SKILL.md FIRST, then run this.
+echo.
+
+set /p SKILL="Which skill did you edit? (e.g. citation): "
+if "%SKILL%"=="" (
+  echo.
+  echo No skill entered. Aborting.
+  pause
+  exit /b 1
+)
+
+set /p TEST="Which test id did you mine? (e.g. ut_citation_019): "
+if "%TEST%"=="" (
+  echo.
+  echo No test id entered. Aborting.
+  pause
+  exit /b 1
+)
+
+if not exist ..\packages\engine\mcp-server\node_modules\ (
+  echo.
+  echo ERROR: mcp-server dependencies are not installed.
+  echo Please run Setup.bat once to install everything, then retry.
+  pause
+  exit /b 1
+)
+
+echo.
+echo Building MCP server (picks up any code changes from the last git pull)...
+cd ..\packages\engine\mcp-server
+call npm run build
+if errorlevel 1 (
+  echo.
+  echo ERROR: MCP server build failed. Aborting gate run.
+  cd ..\..\..\eval
+  pause
+  exit /b 1
+)
+cd ..\..\..\eval
+
+echo.
+echo Gating %SKILL% on %TEST% ...
+echo.
+
+cd harness
+call uv run python skill_gate.py --skill %SKILL% --test %TEST%
+
+echo.
+echo (INCONCLUSIVE means the bug never showed up on the OLD skill -- usually a
+echo  too-weak test, sometimes just run-to-run luck. Re-run once before
+echo  rewriting the test.)
+pause

--- a/eval/README.md
+++ b/eval/README.md
@@ -27,6 +27,7 @@ eval/
   Setup.bat        Windows: one-time setup
   Start.bat        Windows: launch the CRUD UI
   RunTests.bat     Windows: run the unit harness
+  GateSkill.bat    Windows: gate a candidate SKILL.md edit vs its pre-edit baseline
   Login.bat               Windows: FamilySearch login for e2e (once a day)
   CheckSetup.bat          Windows: e2e preflight (run this first)
   RunE2E.bat              Windows: run one e2e benchmark fixture (live FS)


### PR DESCRIPTION
Three walkthrough docs had drifted from how the loop is actually run. From a read-through with Dallan.

## What changed

**Worktree and working directory.** Neither example said where to stand. Both now open with `make install-hooks` + `git worktree add .claude/worktrees/<branch>`, and state which directory each surface opens in.

This matters most in the feedback loop, where two directories are live at once: terminals and the skill-improver run in the **worktree**, but Claude Code for steps 3–5 runs in the **unpacked case folder**. `setup-feedback-case.sh` stamps `.feedback-repo-root` from wherever it's invoked, and that marker decides where the mined test lands — so the branch has to exist *before* the case is unpacked. Ordered accordingly as a new Step 0.

**Research Viewer.** Both docs described noticing and confirming a defect from the chat transcript alone. The "notice" and "confirm" steps now launch the viewer (`make electron`) on the same project folder, with the reason it matters in each case: the citation defect *is* a string in the research log; the unproven-parent defect *is* an assertion in the tree.

**Windows parity.** The genealogists on the team run the `.bat` files, not `make`. Every make command in both docs now carries its batch equivalent. Two gaps filled:
- `make feedback-case` — a target over the existing `scripts/setup-feedback-case.sh`, which had none
- `eval/GateSkill.bat` — did not exist; added and listed in `eval/README.md` + `eval/CLAUDE.md`

**Why `gate-skill` exists.** The question was whether we could delete it and just re-run `eval-skill` and compare. No — and both docs now say why:
- it runs **one side**, reading the "before" scores from the step-4 run log with human `.ann` corrections overlaid, so the baseline is ground truth rather than a second n=1 judge draw
- it covers the mined test + holdouts, so it's seconds and you can iterate on the edit
- it distinguishes **INCONCLUSIVE** (the bug never reproduced on the un-edited skill, so nothing was proven) from a fix that didn't land. A score diff shows two passing runs and lets you conclude, wrongly, that you're done.

**One skill per PR, softened.** Some fixes genuinely span skills — a doctrine change about evidence classification has to land in `person-evidence`, `conflict-resolution` and `proof-conclusion` together or they contradict each other mid-research. Both docs now say one *problem* per PR, and note the runlog gate checks every skill a PR touches.

**`alpha-user-guide`: "pick a real brick wall" replaced.** Alpha testers are professional genealogists whose actual brick walls are far beyond the agent, and failing one teaches us nothing. Replaced with two explicit paths for choosing a research objective — (A) own research not on FamilySearch, supplying starting point + objective; (B) a FamilySearch PID with something specified to forget. The old "practising on a solved question" section was path B described in passing, so it's folded in rather than left duplicated.

Also drops two stale lines: the model-picker note and the "a wiki page lookup fails" troubleshooting row.

## Verification

Wiki tools smoke-tested live against the hosted `wiki-query-api`, which is what justified dropping that troubleshooting row:

| Tool | Result |
|---|---|
| `wiki_search` | 1,240,565 chunks searched, ranked results at 0.78–0.84 relevance |
| `wiki_read` | `Italy_Civil_Registration`, 59,414 chars |
| `wiki_place_page` | "Italy" + `online_records` resolved to the right page, 12,537 chars |

`make feedback-case` checked both ways (missing-`ZIP` error path and `make -n` expansion). Docs-only otherwise — no code paths touched, and none of the changed `eval/` files are on a `check-runlogs.yml` trigger path.

## Not in this PR

A Sonnet 5 upgrade was drafted and reverted — we want a proper comparison first, particularly because the parent orchestrator has never run on Sonnet 5 in this app and the runaway-thinking failure that got `record-extractor` pinned back to 4.6 was Sonnet-5-specific. Default stays `claude-sonnet-4-6`.

Open question left in the docs: the "Only one model" line is now gone from the alpha guide, but testers still see a single-entry model dropdown. Happy to put a corrected version back if you'd rather name it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)