### PR TITLE
Add eval/InstallHooks.bat — Windows equivalent of make install-hooks

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -27,8 +27,8 @@ ls releases/
 
 ## Git hooks
 
-Once per clone (opt-in, per-clone), run `make install-hooks`. It installs two
-hooks:
+Once per clone (opt-in, per-clone), run `make install-hooks` — or on Windows,
+double-click **`eval\InstallHooks.bat`**. Both install the same two hooks:
 `post-checkout` auto-links shared files into new worktrees, and `commit-msg`
 warns (never blocks) when a commit lacks a **human** `Co-authored-by:` trailer.
 

--- a/README.md
+++ b/README.md
@@ -484,7 +484,7 @@ What's shipped:
 Once per clone (not once per branch), run:
 
 ```bash
-make install-hooks
+make install-hooks          # Windows: double-click eval\InstallHooks.bat
 ```
 
 This installs two hooks: `post-checkout` auto-links shared gitignored files
@@ -494,8 +494,6 @@ This installs two hooks: `post-checkout` auto-links shared gitignored files
 clobbering a hook it didn't write. Details in
 [DEVELOPMENT.md → Git hooks](./DEVELOPMENT.md#git-hooks).
 
-Windows has no one-click equivalent yet, and the hooks are opt-in — the
-`commit-msg` one only warns and never blocks — so nothing is gated on this.
 
 ### Where to read next
 

--- a/eval/InstallHooks.bat
+++ b/eval/InstallHooks.bat
@@ -1,0 +1,82 @@
+@echo off
+REM InstallHooks.bat -- Windows equivalent of "make install-hooks".
+REM
+REM Installs the two shared git hooks into this clone. Opt-in, once per clone
+REM (not once per branch). What lands in .git\hooks\ is a small stub that
+REM re-runs the tracked hook under scripts\git-hooks\, so editing a hook there
+REM takes effect immediately -- there is nothing to reinstall after a pull.
+REM Rerun this only when a NEW hook is added to the list below.
+
+cd %~dp0
+
+echo === Cowork Genealogy - Install shared git hooks ===
+echo.
+echo Installs two hooks into this clone:
+echo   post-checkout  auto-links shared files ^(node_modules, .env^) into new
+echo                  worktrees, so they can build and run tests immediately
+echo   commit-msg     warns -- never blocks -- when a commit is missing a
+echo                  human Co-authored-by: trailer
+echo.
+echo Safe to re-run. It refuses rather than clobbering a hook it did not write.
+echo.
+
+where git >nul 2>nul
+if errorlevel 1 (
+  echo ERROR: 'git' was not found on PATH. Install Git for Windows, or run
+  echo        Setup.bat first.
+  pause
+  exit /b 1
+)
+
+cd ..
+
+REM --git-common-dir points at the SHARED .git of this clone, so this keeps
+REM working when run from inside a worktree.
+for /f "delims=" %%i in ('git rev-parse --path-format^=absolute --git-common-dir 2^>nul') do set "COMMON=%%i"
+if not defined COMMON (
+  echo ERROR: not inside a git repository ^(is this a real clone?^).
+  pause
+  exit /b 1
+)
+
+for %%i in ("%COMMON%\..") do set "MAINDIR=%%~fi"
+set "SHIM=%MAINDIR%\scripts\git-hooks\shim.sh"
+
+if not exist "%SHIM%" (
+  echo ERROR: %SHIM% not found.
+  echo        Check out a branch that has scripts\git-hooks\, then re-run.
+  pause
+  exit /b 1
+)
+
+if not exist "%COMMON%\hooks" mkdir "%COMMON%\hooks"
+
+for %%H in (post-checkout commit-msg) do call :install %%H
+if errorlevel 1 (
+  pause
+  exit /b 1
+)
+
+echo.
+echo Done. Hooks are active for this clone.
+pause
+exit /b 0
+
+:install
+set "DST=%COMMON%\hooks\%~1"
+if exist "%DST%" (
+  findstr /C:"cowork-genealogy managed hook shim" "%DST%" >nul 2>nul
+  if errorlevel 1 (
+    echo ERROR: %DST% already exists and is not ours -- not overwriting.
+    echo        Merge it by hand, then re-run.
+    exit /b 1
+  )
+  del /q "%DST%"
+)
+copy /y "%SHIM%" "%DST%" >nul
+if errorlevel 1 (
+  echo ERROR: could not write %DST%
+  exit /b 1
+)
+echo   installed %~1 hook -^> %DST%
+exit /b 0


### PR DESCRIPTION
Split out of #752 — it's 82 lines of batch, not a docs change.

## Why

`DEVELOPMENT.md:30` has told Windows users to double-click `InstallHooks.bat` since the hooks landed. **The file never existed.** Every other Windows entry point in this repo has a `.bat` in `eval\` (15 of them); this was the gap.

## What it does

Mirrors the `install-hooks` Makefile target:

- resolves the shared `.git` via `git rev-parse --git-common-dir`, so it works from inside a worktree, not just the main checkout
- verifies `scripts/git-hooks/shim.sh` exists before touching anything
- copies the shim over `post-checkout` and `commit-msg`
- **refuses rather than clobbering** a hook it didn't write, detected with the same `cowork-genealogy managed hook shim` marker string the Makefile greps for
- safe to re-run — the shim re-runs the tracked hook, so there's nothing to reinstall after a pull

No `chmod` step: Git for Windows runs hooks through its bundled `sh`, which doesn't need the execute bit.

## ⚠️ Not yet run on Windows

I wrote this on macOS and have not executed it. The two parts most likely to need adjustment:

1. **`git rev-parse --path-format=absolute --git-common-dir`** — the `for /f` capture and the subsequent `%%~fi` normalization of `%COMMON%\..`
2. **The `findstr /C:` marker check** — specifically whether the `errorlevel` handling inside the `:install` subroutine behaves as intended

Worth a double-click from someone on Windows before merge. If it misbehaves, the failure mode is safe — it exits non-zero without writing, and the hooks are opt-in anyway (`commit-msg` only warns, never blocks).

## Stacking

Based on `doc-restructure` (#752), which removes the `InstallHooks.bat` references from `README.md` and `DEVELOPMENT.md`; this PR puts them back alongside the actual file. GitHub will retarget to `main` once #752 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)