### PR TITLE
Include uploaded media in feedback bundles by default, and align Electron's size budgets with the server

### DIFF
--- a/apps/electron/src/main/__tests__/feedback.test.ts
+++ b/apps/electron/src/main/__tests__/feedback.test.ts
@@ -5,6 +5,7 @@ import { join } from 'node:path'
 import JSZip from 'jszip'
 import {
   buildFeedbackZip,
+  capSessionLog,
   FEEDBACK_SCHEMA_VERSION,
   MAX_FIELD_CHARS,
   type FeedbackOptions
@@ -121,5 +122,80 @@ describe('buildFeedbackZip — feedback.json', () => {
     const zip = await JSZip.loadAsync(Buffer.from(result.zipBase64, 'base64'))
     expect(zip.file('FEEDBACK.md')).not.toBeNull()
     expect(zip.file('_feedback/feedback.json')).not.toBeNull()
+  })
+})
+
+describe('buildFeedbackZip — size budgets follow the server convention', () => {
+  let folder: string
+
+  beforeEach(async () => {
+    folder = await mkdtemp(join(tmpdir(), 'feedback-size-'))
+    await writeFile(join(folder, 'research.json'), '{}', 'utf8')
+  })
+
+  afterEach(async () => {
+    await rm(folder, { recursive: true, force: true })
+  })
+
+  // Incompressible payload: DEFLATE would otherwise shrink repetitive filler
+  // far below the cap and the budget logic would never engage.
+  function noise(bytes: number): Buffer {
+    const buf = Buffer.allocUnsafe(bytes)
+    let x = 123456789
+    for (let i = 0; i < bytes; i++) {
+      x = (x * 1103515245 + 12345) & 0x7fffffff
+      buf[i] = x & 0xff
+    }
+    return buf
+  }
+
+  it('drops the largest files instead of throwing when over the archive budget', async () => {
+    // 3 x 15 MB = 45 MB against a 35 MB budget: the biggest must go, and the
+    // send must still succeed. Previously this threw and produced nothing.
+    await writeFile(join(folder, 'big-a.bin'), noise(15 * 1024 * 1024))
+    await writeFile(join(folder, 'big-b.bin'), noise(15 * 1024 * 1024))
+    await writeFile(join(folder, 'big-c.bin'), noise(15 * 1024 * 1024))
+
+    const result = await buildFeedbackZip({ ...makeOptions(folder), includeMedia: true })
+
+    const zip = await JSZip.loadAsync(Buffer.from(result.zipBase64, 'base64'))
+    const kept = Object.keys(zip.files).filter((n) => n.endsWith('.bin'))
+    expect(kept.length).toBe(2)
+
+    const markdown = await zip.file('FEEDBACK.md')!.async('string')
+    expect(markdown).toContain('archive size limit')
+
+    // research.json — the file that actually matters — always survives.
+    expect(zip.file('research.json')).not.toBeNull()
+  })
+
+  it('keeps a bundle that fits entirely intact', async () => {
+    await writeFile(join(folder, 'small.bin'), noise(1024))
+    const result = await buildFeedbackZip({ ...makeOptions(folder), includeMedia: true })
+    const zip = await JSZip.loadAsync(Buffer.from(result.zipBase64, 'base64'))
+    expect(zip.file('small.bin')).not.toBeNull()
+    expect(zip.file('research.json')).not.toBeNull()
+  })
+})
+
+describe('capSessionLog', () => {
+  it('passes a small log through unchanged', () => {
+    const out = capSessionLog([{ a: 1 }, { b: 2 }])
+    expect(out).toBe('{"a":1}\n{"b":2}\n')
+  })
+
+  it('keeps the NEWEST entries and prepends a truncation note when over cap', () => {
+    // ~600 KB per entry x 64 = ~38 MB against the 20 MB session-log budget.
+    const entries = Array.from({ length: 64 }, (_, i) => ({ i, pad: 'x'.repeat(600_000) }))
+    const lines = capSessionLog(entries).trimEnd().split('\n')
+
+    const note = JSON.parse(lines[0])
+    expect(note.type).toBe('_truncation_note')
+    expect(note.dropped_leading_entries).toBeGreaterThan(0)
+
+    // The tail is what matters — the end of a session is where it went wrong.
+    const last = JSON.parse(lines[lines.length - 1])
+    expect(last.i).toBe(63)
+    expect(note.dropped_leading_entries + (lines.length - 1)).toBe(64)
   })
 })

--- a/apps/electron/src/main/feedback.ts
+++ b/apps/electron/src/main/feedback.ts
@@ -18,7 +18,14 @@ const MEDIA_EXTS = new Set([
 const TEXT_EXTS = new Set(['.json', '.md', '.txt', '.csv', '.tsv', '.yaml', '.yml'])
 
 const INDIVIDUAL_FILE_CAP_BYTES = 25 * 1024 * 1024
+// Project-file budget. Mirrors apps/server/app/feedback.py `_ZIP_CAP_BYTES`:
+// when the selection exceeds it we drop the largest files until it fits rather
+// than failing the send. Applied to uncompressed bytes, as the server does.
 const ZIP_CAP_BYTES = 35 * 1024 * 1024
+// Session-log budget, separate from the file budget (again matching the
+// server's `_SESSION_LOG_CAP_BYTES`): over cap we keep the newest entries and
+// prepend a truncation note rather than dropping the log.
+const SESSION_LOG_CAP_BYTES = 20 * 1024 * 1024
 
 export const MAX_FIELD_CHARS = 10_000
 export const FEEDBACK_SCHEMA_VERSION = 1
@@ -159,6 +166,38 @@ function normalizeAndValidate(report: FeedbackReport): NormalizedFields {
   return fields
 }
 
+/**
+ * Serialize session-log entries, capped at SESSION_LOG_CAP_BYTES.
+ *
+ * Mirrors `_filter_transcript`'s tail behavior in apps/server/app/feedback.py:
+ * over cap we keep the NEWEST entries that fit and prepend a `_truncation_note`
+ * line. The note is valid JSON so the downstream user/assistant filters skip it
+ * harmlessly, and it records how many leading entries went -- silent truncation
+ * would make a short log indistinguishable from a short session.
+ */
+export function capSessionLog(entries: unknown[]): string {
+  const lines = entries.map((e) => JSON.stringify(e))
+  const total = lines.reduce((n, l) => n + Buffer.byteLength(l) + 1, 0)
+  if (total <= SESSION_LOG_CAP_BYTES) return lines.join('\n') + '\n'
+
+  const tail: string[] = []
+  let size = 0
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const cost = Buffer.byteLength(lines[i]) + 1
+    if (size + cost > SESSION_LOG_CAP_BYTES) break
+    tail.push(lines[i])
+    size += cost
+  }
+  tail.reverse()
+
+  const note = JSON.stringify({
+    type: '_truncation_note',
+    dropped_leading_entries: lines.length - tail.length,
+    reason: `session log exceeded ${SESSION_LOG_CAP_BYTES} bytes; kept newest ${tail.length} entries`
+  })
+  return [note, ...tail].join('\n') + '\n'
+}
+
 export async function buildFeedbackZip(options: FeedbackOptions): Promise<FeedbackResult> {
   const { folderPath, includeMedia, includeSessionLog, report, viewerVersion } = options
   const folderResolved = path.resolve(folderPath)
@@ -169,9 +208,8 @@ export async function buildFeedbackZip(options: FeedbackOptions): Promise<Feedba
   const zip = new JSZip()
   const files = await walkProject(folderResolved)
 
-  let uncompressedBytes = 0
-  let fileCount = 0
   const skipped: string[] = []
+  const selected: { relativePath: string; buf: Buffer }[] = []
 
   for (const f of files) {
     if (f.isMedia && !includeMedia) continue
@@ -187,22 +225,40 @@ export async function buildFeedbackZip(options: FeedbackOptions): Promise<Feedba
     }
 
     try {
-      const buf = await fs.readFile(full)
-      zip.file(f.relativePath, buf)
-      uncompressedBytes += buf.length
-      fileCount++
+      selected.push({ relativePath: f.relativePath, buf: await fs.readFile(full) })
     } catch {
       skipped.push(`${f.relativePath} (read failed)`)
     }
   }
+
+  // Over budget: drop the largest files until the selection fits. Same rule as
+  // the server, so a bundle built here and one built in the hosted app contain
+  // the same thing. Dropping beats throwing -- a too-big project should still
+  // produce a usable report, minus its heaviest attachments.
+  let uncompressedBytes = selected.reduce((n, s) => n + s.buf.length, 0)
+  if (uncompressedBytes > ZIP_CAP_BYTES) {
+    const bySizeDesc = [...selected].sort((a, b) => b.buf.length - a.buf.length)
+    const dropped = new Set<string>()
+    for (const s of bySizeDesc) {
+      if (uncompressedBytes <= ZIP_CAP_BYTES) break
+      dropped.add(s.relativePath)
+      uncompressedBytes -= s.buf.length
+      skipped.push(`${s.relativePath} (dropped — archive size limit)`)
+    }
+    for (let i = selected.length - 1; i >= 0; i--) {
+      if (dropped.has(selected[i].relativePath)) selected.splice(i, 1)
+    }
+  }
+
+  for (const s of selected) zip.file(s.relativePath, s.buf)
+  const fileCount = selected.length
 
   const timestamp = new Date().toISOString()
   let sessionLogIncluded = false
   if (includeSessionLog) {
     const sessionLog = await readSessionLog(folderResolved)
     if (sessionLog.entries.length > 0) {
-      const jsonl = sessionLog.entries.map((e) => JSON.stringify(e)).join('\n') + '\n'
-      zip.file('_feedback/session-log.jsonl', jsonl)
+      zip.file('_feedback/session-log.jsonl', capSessionLog(sessionLog.entries))
       sessionLogIncluded = true
     }
   }
@@ -234,13 +290,6 @@ export async function buildFeedbackZip(options: FeedbackOptions): Promise<Feedba
     compression: 'DEFLATE',
     compressionOptions: { level: 6 }
   })
-
-  if (buf.length > ZIP_CAP_BYTES) {
-    const mb = (buf.length / (1024 * 1024)).toFixed(1)
-    throw new Error(
-      `Feedback archive is ${mb} MB, which exceeds the 35 MB limit. Try unchecking media files.`
-    )
-  }
 
   const safeTimestamp = timestamp.replace(/[:.]/g, '-')
   const filename = `feedback-${safeTimestamp}.zip`

--- a/docs/alpha-user-guide.md
+++ b/docs/alpha-user-guide.md
@@ -126,11 +126,9 @@ in the project and the agent reads it.
 You'll need this for anything **not** on FamilySearch. FamilySearch's own record
 images the agent fetches by itself; you don't need to upload those.
 
-> ⚠️ **Uploaded files are not included in feedback unless you ask for them.**
-> The feedback form has an **"Include media files"** checkbox that is **off by
-> default**, so anything you uploaded stays on your machine. If you later report
-> a problem involving one of these documents, tick that box — otherwise we get
-> your report without the thing it's about.
+Anything you upload travels with your feedback by default, so a report about a
+document arrives with the document attached. You can untick **"Include media
+files"** on the feedback form if you'd rather not send it.
 
 ### Watching it work
 
@@ -178,9 +176,10 @@ bundle captures that project's state, which is how we reproduce it.
 >   the agent's replies and its internal reasoning, and every tool call with its
 >   results. The reasoning is the single most useful part for diagnosing *why* it
 >   went wrong. Untick it if a session contains anything you'd rather not share.
-> - **"Include media files"** — **unticked by default.** Any documents or images
->   you uploaded stay behind unless you tick it. If your report is *about* a
->   document you supplied, tick this or we won't be able to see what you saw.
+> - **"Include media files"** — **ticked by default.** Documents and images you
+>   uploaded, so a report about a document arrives with the document. Untick it
+>   to leave them out. Very large bundles are trimmed automatically, largest
+>   files first.
 >
 > Everything goes to a private Drive folder only the Pioneer Academy team can
 > read.

--- a/packages/viewer-ui/src/components/shared/FeedbackDialog.tsx
+++ b/packages/viewer-ui/src/components/shared/FeedbackDialog.tsx
@@ -32,7 +32,11 @@ export default function FeedbackDialog({ onClose }: FeedbackDialogProps): React.
   const [sessionLogSize, setSessionLogSize] = useState(0)
   const [hasSessionLog, setHasSessionLog] = useState(false)
 
-  const [includeMedia, setIncludeMedia] = useState(false)
+  // On by default: a report about an uploaded document is useless without it,
+  // and when the project has no media the flag is a no-op (the checkbox is
+  // disabled at mediaCount === 0). Oversize bundles are handled downstream —
+  // the web path drops the largest files and reports them.
+  const [includeMedia, setIncludeMedia] = useState(true)
   const [includeSessionLog, setIncludeSessionLog] = useState(true)
   const [showFileList, setShowFileList] = useState(false)
 
@@ -334,10 +338,11 @@ export default function FeedbackDialog({ onClose }: FeedbackDialogProps): React.
 
           <div className={styles.privacy}>
             Send packages your project folder as a zip and uploads it to a private Google Drive
-            folder accessible only to the Pioneer Academy team. Audio and image files are excluded
-            unless you check &ldquo;Include media.&rdquo; The session log includes your prompts,
-            Claude&apos;s replies and internal reasoning, and every tool call with its results —
-            the reasoning is what lets us diagnose why the agent did what it did.
+            folder accessible only to the Pioneer Academy team. Documents and images you uploaded
+            are included &mdash; untick &ldquo;Include media files&rdquo; to leave them out. The
+            session log includes your prompts, Claude&apos;s replies and internal reasoning, and
+            every tool call with its results &mdash; the reasoning is what lets us diagnose why the
+            agent did what it did.
           </div>
         </div>
 


### PR DESCRIPTION
Follow-up to the `alpha-user-guide` audit in #752, which found that the **"Include media files"** checkbox defaulted to **off** — so a tester reporting a problem *about* a document they'd uploaded sent us the report without the document.

Two commits: flip the default, then fix what that exposed.

---

## 1. Media on by default

`FeedbackDialog.tsx`: `useState(false)` → `useState(true)` for `includeMedia`.

Always on, not conditional — when the project has no media the flag is a no-op, since the checkbox is already `disabled` at `mediaCount === 0`. So this only changes behavior where media exists and is likely wanted.

Also corrected the dialog's own privacy blurb (*"Audio and image files are excluded unless you check 'Include media'"*), which would have become actively wrong in the direction that matters, and `alpha-user-guide.md` in both places it appears.

The doc change rides in **this** PR rather than #752 deliberately: if the doc said "included by default" while the code still defaulted to off, a tester would trust it, skip the checkbox, and hit exactly the bug being fixed. Docs and behavior land together.

## 2. Electron now follows the server's size-budget convention

Alpha users are on **both** surfaces, so a bundle built in the Electron viewer and one built in the hosted app should contain the same thing. They didn't:

| | Web (`apps/server`) | Electron (before) | Electron (now) |
|---|---|---|---|
| **Over the 35 MB archive budget** | Drops largest files until it fits; reports them | **Threw** — *"Try unchecking media files"* — produced nothing | Drops largest, lists them in `FEEDBACK.md` |
| **Session log over 20 MB** | Keeps newest entries, prepends `_truncation_note` | **No cap at all** | Same as the server, via `capSessionLog()` |

The first row is why this belongs with commit 1: turning media on by default made that throw *reachable* for projects that never hit it before. Shipping the default flip without this would have traded a silent-omission bug for a hard-failure bug.

The second row is an independent divergence found while fixing the first — the tail is the half worth keeping, since the end of a session is where it went wrong, and the note makes truncation visible rather than silent.

Budgets are applied to uncompressed bytes before zipping, as the server does. Both are now enforced by construction, so the final hard failure is gone entirely — matching the server, which has no such path. Total bundle stays bounded (≤35 MB files + ≤20 MB log + metadata).

## Tests

- **4 new cases** in `apps/electron`: drop-largest, intact-bundle, session-log passthrough, session-log truncation. The drop-largest test **fails against the previous code** (it threw), so it's a real regression test.
  - They use incompressible filler — DEFLATE shrinks repetitive bytes far below the cap and the budget logic would never engage otherwise.
- `apps/electron` — 54 passed (5 files)
- `@genealogy/viewer-ui` — 118 passed (17 files)
- `pnpm typecheck` — 5/5 clean

No existing test asserted the old media default, which is why nothing broke when it flipped; the new cases close part of that gap.

## Stacking

Based on `doc-restructure` (#752), because the `alpha-user-guide.md` section it edits is introduced there. GitHub retargets to `main` once #752 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)