### PR TITLE
Exclude .claude from the Docker build context; add make deploy-status

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,13 +1,24 @@
 # Build-context hygiene for deploy/Dockerfile (context = repo root) and the E2B
 # sandbox image. The multi-stage builds install deps and compile fresh, so local
 # installs and build outputs are noise — excluding them shrinks the context that
-# gets uploaded to the (remote) builder from ~1.5 GB to a few MB.
+# gets uploaded to the (remote) builder from ~2.5 GB to a few MB.
 #
 # NOTE: dist/ is built INSIDE the image (stage `web`) and copied via --from=web,
 # so excluding the host's local dist/ is correct — it is never the source.
 
 **/node_modules
 .git
+# Claude Code local state. .claude/worktrees holds full repo checkouts, which
+# `fly deploy` was uploading on every deploy (906 MB of a 915 MB context — and
+# since **/build is deliberately NOT excluded below, every worktree's engine
+# build/ went too). Nothing in the images comes from here; the plugin skills that
+# DO ship live in packages/engine/plugin, not .claude/skills.
+#
+# This matters for the Fly deploy only. The E2B v2 CLI does NOT upload a
+# whole-directory context — it uploads just the paths e2b.Dockerfile COPYs
+# (verified: it logs one upload line per COPY path), so `make sandbox-image` was
+# never carrying this weight.
+.claude
 **/.venv
 **/__pycache__
 **/*.pyc

--- a/Makefile
+++ b/Makefile
@@ -507,3 +507,12 @@ deploy: deploy-preflight ## Deploy the control plane to Fly (builds web+server i
 	fly deploy --config deploy/fly.toml --dockerfile deploy/Dockerfile . --ha=false \
 	  --build-arg GIT_SHA=$$(git rev-parse --short HEAD) \
 	  --build-arg BUILD_DATE=$$(date -u +%Y-%m-%d)
+
+# Public host of the deployed control plane — keep in sync with PUBLIC_URL /
+# WEB_ORIGIN in deploy/fly.toml. Override for a differently-named app:
+#   make deploy-status DEPLOY_URL=https://my-app.fly.dev
+DEPLOY_URL := https://genealogy-workbench.fly.dev
+
+.PHONY: deploy-status
+deploy-status: ## Health-check the deployed control plane (expect "db":"postgres")
+	curl -s $(DEPLOY_URL)/api/health | jq


### PR DESCRIPTION
## Why

`fly deploy` warned that the build context was **915 MB across 15,287 files**, uploaded to the builder on every deploy:

```
.claude/   906 MB
packages/  4.6 MB
docs/      2.1 MB
apps/      1.2 MB
```

`.claude/` is Claude Code local state (gitignored), dominated by `.claude/worktrees` — full repo checkouts. Neither `deploy/Dockerfile` nor `apps/server/sandbox/e2b.Dockerfile` COPYs anything from it, and the plugin skills that *do* ship live in `packages/engine/plugin`, not `.claude/skills`.

It compounded with an existing deliberate choice: `**/build` is intentionally *not* excluded (the E2B image needs `packages/engine/mcp-server/build`), so every worktree's engine build output was being uploaded too.

## What

- **`.dockerignore`**: add `.claude`. Deploy context drops **915 MB → ~9 MB**, ~15,287 → ~900 files. Also corrects the stale "~1.5 GB" figure in the header comment.
- **`Makefile`**: add `deploy-status`, which curls `/api/health` on the deployed control plane and pretty-prints it — the post-deploy check `DEVELOPMENT.md` already prescribes but that had no target. `DEPLOY_URL` is a variable so it's overridable rather than a buried literal.

## The E2B image is unaffected

Worth recording, because it's counterintuitive: `build-image.sh` passes `--path "${ROOT}"`, so it looks like it shares this whole-directory context. It doesn't. The E2B v2 CLI uploads only the paths `e2b.Dockerfile` COPYs — verified by a full `make sandbox-image` run, which logged exactly one upload line per COPY path:

```
Skipping upload of 'packages/engine/mcp-server/build', already cached
Skipping upload of 'packages/engine/mcp-server/package-lock.json', already cached
Skipping upload of 'packages/engine/plugin', already cached
Skipping upload of 'packages/engine/mcp-server/config', already cached
Skipping upload of 'apps/server/app', already cached
Skipping upload of 'packages/engine/mcp-server/package.json', already cached
```

So `make sandbox-image` never carried this weight, and this change neither helps nor hurts it. Captured in the `.dockerignore` comment so it isn't rediscovered.

## Verification

- `make sandbox-image` — template `genealogy-agent` rebuilt and pushed successfully. All 28 layers `CACHED` (nothing in the in-sandbox sources changed), so this validated the cache rather than rebuilding from scratch.
- `make deploy-status` against prod:
  ```json
  { "ok": true, "agentMode": "real", "provider": "e2b", "db": "postgres" }
  ```
- `make help` lists the new target.
- **Not verified:** an actual `fly deploy` with the new `.dockerignore`. The ~9 MB figure is a filesystem walk applying the new exclusions, which independently agrees with Docker's own accounting (915 − 906 = 9 MB). Next real deploy will confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)