### PR TITLE
eval: recover usage from the message stream when an e2e run aborts

### DIFF
--- a/docs/TODOs.md
+++ b/docs/TODOs.md
@@ -617,3 +617,18 @@ sized by the Phase-0 latency analysis and are not covered by the parent plan's p
   fixed; the missing guard is not. Options: give init-project a writer tool for
   the seed write, or have the validator treat an absent `before_state` as a diff
   against empty rather than a skip.
+
+- **`max_cost_usd` does not cap anything in the e2e harness** — `cost_cap` is
+  applied inside the `ResultMessage` branch of `orchestrator.py`, and that
+  message only arrives once the run has already finished, so the "cap" is a
+  post-hoc label on a completed run. All five `cost_cap` runs in the corpus
+  ended with the SDK's own `end_turn` and `is_error: false` — spend ran to
+  $15.86–$20.84 against a $15 cap with nothing interrupted. Real enforcement
+  needs two pieces the harness lacks: a per-model price table for *agent*
+  models (`judge.py::JUDGE_PRICING` covers judge models only, and a run spans
+  the parent plus each subagent on its own `.md` pin), and a way to see
+  subagent tokens — they never appear in the main SDK message stream, so an
+  in-flight estimate built only from streamed usage under-counts by a margin
+  consistent with the unattributed portion of a real run's cost. Deliberately
+  not half-built: a cap that silently fires late is worse than a documented
+  reporting threshold. The spec (`e2e-test-spec.md` §5) now says so explicitly.

--- a/docs/specs/e2e-test-spec.md
+++ b/docs/specs/e2e-test-spec.md
@@ -430,7 +430,7 @@ loop and a budget decision.
    | Wall-clock cap | `timeout` | **Active** (monotonic) elapsed time > `caps.wall_clock_seconds` |
    | Tool-call cap | `tool_cap` | Total tool calls > `caps.tool_calls` |
    | Turn cap | `max_turns` | SDK turn count > `caps.max_turns` |
-   | Cost cap | `cost_cap` | Cumulative cost > `caps.max_cost_usd` |
+   | Cost cap | `cost_cap` | Final cost > `caps.max_cost_usd`. **Label only — this does not stop a run.** See note below. |
    | SDK natural end | `natural_end` | Voluntary end with `project.status != "completed"` after the continue-nudge budget is exhausted (or a nudge made no progress) — see note below |
    | Harness error | `error` | Unhandled exception in the harness or SDK |
 
@@ -439,6 +439,19 @@ loop and a budget decision.
    fixture, not authored per-fixture. A turn-cap hit the SDK reports as an
    error result (rather than a clean `max_turns`) is reclassified to
    `max_turns`.
+
+   **`cost_cap` is a post-hoc label, not an enforced cap.** The check reads
+   `message.total_cost_usd`, which exists only on the SDK's `ResultMessage` —
+   the message that arrives once the run has *already finished* and the money
+   is already spent. Every `cost_cap` run in the corpus ended with the SDK's
+   own `end_turn` and `is_error: false`; none was interrupted. Two things
+   block real enforcement, so it was left as-is rather than half-built: there
+   is no per-model price table for agent models (a run spans the parent plus
+   each subagent on its own `.md` pin), and subagent tokens never appear in
+   the main message stream at all — so an in-flight estimate would
+   systematically under-count and a `$15` cap would fire somewhere north of
+   `$15` by an unknown margin. Treat `max_cost_usd` as a reporting threshold.
+   Tracked in `docs/TODOs.md`.
 
    **Continue-nudge on premature yield.** An autonomous `/research` run
    must end at `project.status == "completed"`; instead the agent
@@ -843,7 +856,7 @@ Per run, under `eval/runlogs/e2e/<test-id>/`:
 
 | File | Content |
 |------|---------|
-| `run-<timestamp>.json` | Structured result: `verdict`, `stop_reason`, `judge_output`, `usage`, a `tool_calls` array — each entry `{ tool, args, response_summary }` — and `blocked_tree_reads` (denied live-tree reads; see §6.1). `usage` carries tokens / cost; `wall_clock_seconds` (active/monotonic — see §6 "Clocks") plus `real_clock_seconds`, `slept_seconds`, and `judge_seconds`; `resumes` + `session_id` (see §6 "Stall-detect + resume"); the **reasoning config actually used** — `agent_model` (effective parent model), `subagent_model_override` (non-null when `--agent-model` forced every staged subagent off its own `.md` pin, e.g. running the sonnet-5 record-extractor under sonnet-4-6; null = each subagent used its pin), `effort_level` (pinned via a project setting, default `high`), `max_output_tokens` (via `CLAUDE_CODE_MAX_OUTPUT_TOKENS`, null = CLI default), and `cli_version` — so an A/B across model × effort × output-budget is self-describing and a harness-vs-Cowork gap can be checked against a CLI-version delta; and a per-message `timeline` (`[elapsed_seconds, kind]`) + the `caps` used, so a run is self-describing for forensics. Also a `subagents` array — one compact summary per plugin subagent (`record-extractor`, `image-reader`, …) captured from the SDK's ephemeral subagent cache: `agent_type`, per-turn `stop_reason` / `output_tokens` / block shape, and a `runaway_thinking` flag (a turn that hit `max_tokens` on thinking alone with no tool call). The runlog otherwise stores no subagent transcript, so this makes a subagent freeze diagnosable from the committed runlog rather than only from the local cache (`subagent_capture.py`) |
+| `run-<timestamp>.json` | Structured result: `verdict`, `stop_reason`, `judge_output`, `usage`, a `tool_calls` array — each entry `{ tool, args, response_summary }` — and `blocked_tree_reads` (denied live-tree reads; see §6.1). `usage` carries tokens / cost; **`usage_source`** — `result_message` when the SDK's `ResultMessage` arrived (authoritative), or `streamed_fallback` when it did not. Every abort path (wall-clock timeout, inactivity silence, no-progress stall) cuts the stream before that message, which used to leave `usage` with no turns, duration or tokens at all — blinding exactly the runs worth investigating. The fallback reconstructs the block from the streamed assistant messages: token counts are **exact** (deduplicated by message id — the SDK re-emits one message per content block, each copy repeating that message's cumulative usage, so summing on arrival multiplies the totals), `duration_ms` comes from the monotonic clock, and the distinct-message count is reported as `assistant_messages`. `num_turns`, `duration_api_ms` and `total_cost_usd` are **null** in a fallback block rather than synthesized — the SDK counts turns differently from distinct assistant messages, only it knows the API/local split, and a run spans several models so one price lookup would be wrong. Never compare a `streamed_fallback` cost against a clean run's; `wall_clock_seconds` (active/monotonic — see §6 "Clocks") plus `real_clock_seconds`, `slept_seconds`, and `judge_seconds`; `resumes` + `session_id` (see §6 "Stall-detect + resume"); the **reasoning config actually used** — `agent_model` (effective parent model), `subagent_model_override` (non-null when `--agent-model` forced every staged subagent off its own `.md` pin, e.g. running the sonnet-5 record-extractor under sonnet-4-6; null = each subagent used its pin), `effort_level` (pinned via a project setting, default `high`), `max_output_tokens` (via `CLAUDE_CODE_MAX_OUTPUT_TOKENS`, null = CLI default), and `cli_version` — so an A/B across model × effort × output-budget is self-describing and a harness-vs-Cowork gap can be checked against a CLI-version delta; and a per-message `timeline` (`[elapsed_seconds, kind]`) + the `caps` used, so a run is self-describing for forensics. Also a `subagents` array — one compact summary per plugin subagent (`record-extractor`, `image-reader`, …) captured from the SDK's ephemeral subagent cache: `agent_type`, per-turn `stop_reason` / `output_tokens` / block shape, and a `runaway_thinking` flag (a turn that hit `max_tokens` on thinking alone with no tool call). The runlog otherwise stores no subagent transcript, so this makes a subagent freeze diagnosable from the committed runlog rather than only from the local cache (`subagent_capture.py`) |
 | `run-<timestamp>.transcript.md` | Human-readable transcript of the agent's turns |
 | `run-<timestamp>.final-tree.gedcomx.json` | The agent's final tree (input to the judge) |
 | `run-<timestamp>.final-research.json` | The agent's final `research.json` |

--- a/eval/harness/e2e/orchestrator.py
+++ b/eval/harness/e2e/orchestrator.py
@@ -404,6 +404,79 @@ def _summarize_tool_response(content: Any) -> str:
     return text
 
 
+_USAGE_FIELDS = (
+    "input_tokens",
+    "output_tokens",
+    "cache_read_input_tokens",
+    "cache_creation_input_tokens",
+)
+
+
+def _accumulate_usage(acc: dict[str, dict[str, int]], message: Any) -> None:
+    """Record one AssistantMessage's usage, keyed by its message id.
+
+    Do NOT sum on arrival. The SDK re-emits the same assistant message once
+    per content block, and every copy carries the SAME cumulative usage for
+    that message — so adding each time multiplies the totals (verified by
+    replaying a real run: naive summing reported 358,610 output tokens
+    against a true 106,661, and 226 messages against 87 distinct ones).
+    Keying by message id and letting the last write win reproduces the
+    ResultMessage token totals exactly.
+
+    Best-effort by design: the SDK types `usage` loosely (a dict on the
+    observed path, an object on some versions) and a malformed or absent
+    block must never take down a run.
+    """
+    msg_id = getattr(message, "message_id", None)
+    # No id to dedupe on — count it once under a synthetic key rather than
+    # dropping it or letting it collide with another anonymous message.
+    key = msg_id if msg_id else f"__anon_{len(acc)}"
+    usage = getattr(message, "usage", None)
+
+    def _get(field: str) -> int:
+        if usage is None:
+            return 0
+        raw = usage.get(field) if isinstance(usage, dict) else getattr(usage, field, 0)
+        return raw if isinstance(raw, int) else 0
+
+    acc[key] = {field: _get(field) for field in _USAGE_FIELDS}
+
+
+def _fallback_usage(acc: dict[str, dict[str, int]], elapsed_ms: int) -> dict[str, Any]:
+    """Usage block reconstructed from the stream when no ResultMessage came.
+
+    Two fields are deliberately left null rather than synthesized:
+
+    `total_cost_usd` — a run spans several models (the parent plus each
+    subagent on its own `.md` pin), so one price lookup would be wrong, and a
+    plausible-but-wrong dollar figure is worse than a null here: it would be
+    silently compared against real costs from clean runs. Token counts are
+    exact, so cost stays derivable later from a per-model breakdown.
+
+    `num_turns` — the SDK counts turns differently from distinct assistant
+    messages (118 vs 87 on the replayed run), and `latency_report` divides
+    output tokens by it. Publishing the smaller number under the same name
+    would inflate tokens-per-turn by ~1.4x in exactly the metric the latency
+    work depends on. The exact count we DO have is reported separately as
+    `assistant_messages`.
+
+    `duration_api_ms` is absent for the same reason: only the SDK knows the
+    API/local split, and a monotonic clock can't recover it.
+    """
+    return {
+        "duration_ms": elapsed_ms,
+        "duration_api_ms": None,
+        "num_turns": None,
+        "assistant_messages": len(acc),
+        "is_error": True,
+        "stop_reason": None,
+        "total_cost_usd": None,
+        "usage": {
+            field: sum(m[field] for m in acc.values()) for field in _USAGE_FIELDS
+        },
+    }
+
+
 async def _run_agent(
     *,
     fixture: Fixture,
@@ -470,6 +543,17 @@ async def _run_agent(
     cli_version: dict[str, str | None] = {"v": None}
     resumes = {"n": 0}  # how many times we resumed after a stall (capped)
     MAX_RESUME = 2
+
+    # Streamed usage accumulator. The SDK's ResultMessage carries the
+    # authoritative duration/turns/cost, but it only arrives on a CLEAN end —
+    # a wall-clock timeout, an inactivity abort or a no-progress stall cuts the
+    # stream before it, so `usage` stayed {} and the run landed in the runlog
+    # with no turns, no duration and no tokens at all. That silently blinded
+    # every `timeout` run (9 of 9 in the corpus as of 2026-07-20) — exactly the
+    # runs whose cost and turn count you most want to see. Accumulating per
+    # AssistantMessage gives a fallback that is always available. See
+    # _fallback_usage below for what is and isn't recoverable this way.
+    streamed: dict[str, dict[str, int]] = {}
 
     def _emit(line: str) -> None:
         """Live progress to stderr so a long, otherwise-silent run shows
@@ -747,6 +831,9 @@ async def _run_agent(
                             elif block.name.startswith("mcp__"):
                                 _emit(f"   - {_bare_tool_name(block.name)}")
                             progressed = True
+                    # Record before the timeline append so a message that
+                    # arrives moments before a timeout still counts.
+                    _accumulate_usage(streamed, message)
                     timeline.append([round(now - run_started, 1), "assistant"])
                 elif isinstance(message, UserMessage):
                     # Tool results return as UserMessages with ToolResultBlock content.
@@ -858,8 +945,21 @@ async def _run_agent(
         aborted_reason = "max_tool_calls"
         error = f"tool_calls cap ({fixture.caps.tool_calls}) exceeded"
 
+    # A ResultMessage populates `usage` with the SDK's authoritative numbers.
+    # Every abort path (wall-clock timeout, inactivity silence, no-progress
+    # stall) cuts the stream before it, leaving `usage` empty — so fall back to
+    # what the stream already told us. `usage_source` marks which one you're
+    # reading: a fallback block has exact token counts but a null cost, and
+    # must not be compared against a clean run's `total_cost_usd`.
+    result_message_seen = "num_turns" in usage
+    if not result_message_seen:
+        usage = _fallback_usage(
+            streamed, int((time.monotonic() - run_started) * 1000)
+        )
+
     usage = {
         **usage,
+        "usage_source": "result_message" if result_message_seen else "streamed_fallback",
         "continue_nudges": continue_nudges["n"],
         # Stall-resume + forensics (added with the progress watchdog). `timeline`
         # is [elapsed_seconds, kind] per SDK message — split structural vs stall

--- a/eval/harness/tests/unit/test_e2e_orchestrator.py
+++ b/eval/harness/tests/unit/test_e2e_orchestrator.py
@@ -14,12 +14,23 @@ import pytest
 from e2e.orchestrator import (
     PROVIDED_DOCS_DIRNAME,
     FixtureCaps,
+    _accumulate_usage,
+    _fallback_usage,
     _render_user_message,
     _summarize_tool_response,
     build_workspace,
     load_fixture,
     provided_documents,
 )
+
+
+class _FakeAssistantMessage:
+    """Stand-in for the SDK's AssistantMessage — only the two fields the
+    usage accumulator reads."""
+
+    def __init__(self, message_id, usage):
+        self.message_id = message_id
+        self.usage = usage
 
 
 def _make_fixture_dir(tmp_path: Path, *, caps: dict | None = None) -> Path:
@@ -343,3 +354,83 @@ def test_summarize_tool_response_truncates_long_content():
     out = _summarize_tool_response(long)
     assert len(out) <= 500
     assert out.endswith("...")
+
+
+# --- streamed-usage fallback -------------------------------------------------
+# Regression cover for the timeout blind spot: every `timeout` run in the
+# corpus landed with no turns, duration or tokens because the SDK's
+# ResultMessage never arrived. See _fallback_usage.
+
+
+def test_accumulate_usage_sums_distinct_messages():
+    acc: dict = {}
+    _accumulate_usage(acc, _FakeAssistantMessage("msg_a", {
+        "input_tokens": 3,
+        "output_tokens": 274,
+        "cache_read_input_tokens": 0,
+        "cache_creation_input_tokens": 21404,
+    }))
+    _accumulate_usage(acc, _FakeAssistantMessage("msg_b", {
+        "input_tokens": 1,
+        "output_tokens": 110,
+        "cache_read_input_tokens": 21404,
+        "cache_creation_input_tokens": 320,
+    }))
+    usage = _fallback_usage(acc, 1000)
+    assert usage["assistant_messages"] == 2
+    assert usage["usage"]["output_tokens"] == 384
+    assert usage["usage"]["cache_creation_input_tokens"] == 21724
+
+
+def test_accumulate_usage_deduplicates_repeated_message_id():
+    """The regression that made the first cut of this fallback wrong: the SDK
+    re-emits one assistant message per content block, each copy carrying the
+    same cumulative usage. Summing on arrival multiplied the totals ~3x."""
+    acc: dict = {}
+    for _ in range(4):
+        _accumulate_usage(acc, _FakeAssistantMessage("msg_same", {"output_tokens": 376}))
+    usage = _fallback_usage(acc, 1000)
+    assert usage["assistant_messages"] == 1
+    assert usage["usage"]["output_tokens"] == 376
+
+
+def test_accumulate_usage_keeps_anonymous_messages_distinct():
+    acc: dict = {}
+    _accumulate_usage(acc, _FakeAssistantMessage(None, {"output_tokens": 5}))
+    _accumulate_usage(acc, _FakeAssistantMessage(None, {"output_tokens": 7}))
+    usage = _fallback_usage(acc, 1000)
+    assert usage["assistant_messages"] == 2
+    assert usage["usage"]["output_tokens"] == 12
+
+
+def test_accumulate_usage_tolerates_missing_and_malformed_usage():
+    acc: dict = {}
+    _accumulate_usage(acc, _FakeAssistantMessage("msg_a", None))
+    _accumulate_usage(
+        acc, _FakeAssistantMessage("msg_b", {"output_tokens": None, "input_tokens": "lots"})
+    )
+    usage = _fallback_usage(acc, 1000)
+    assert usage["assistant_messages"] == 2
+    assert usage["usage"]["output_tokens"] == 0
+    assert usage["usage"]["input_tokens"] == 0
+
+
+def test_fallback_usage_reports_duration_and_message_count():
+    acc: dict = {}
+    for i in range(42):
+        _accumulate_usage(acc, _FakeAssistantMessage(f"msg_{i}", {"output_tokens": 100}))
+    usage = _fallback_usage(acc, 900_000)
+    assert usage["duration_ms"] == 900_000
+    assert usage["assistant_messages"] == 42
+    assert usage["usage"]["output_tokens"] == 4200
+    assert usage["is_error"] is True
+
+
+def test_fallback_usage_nulls_the_fields_it_cannot_honestly_reconstruct():
+    """Cost spans several models; num_turns has different semantics from the
+    assistant-message count and feeds latency_report's tokens-per-turn. Both
+    stay null rather than shipping a plausible-but-wrong number."""
+    usage = _fallback_usage({}, 1000)
+    assert usage["total_cost_usd"] is None
+    assert usage["num_turns"] is None
+    assert usage["duration_api_ms"] is None


### PR DESCRIPTION
Found while comparing the first `spriggs-marriage-1926` e2e run against the corpus: **10 of 57 runs have no usage data at all** — no `num_turns`, no `duration_ms`, no `total_cost_usd`. Every `timeout` run is in that set.

| stop_reason | usage captured | missing |
|---|---|---|
| `completed` | 40 | 0 |
| `cost_cap` | 5 | 0 |
| `error` | 2 | 1 |
| `timeout` | **0** | **9** |

The runs that ran long enough to time out are exactly the ones whose cost and turn count you most want to see, and they were the unreadable ones.

## Cause

`usage` is populated only inside the `ResultMessage` branch of `_run_agent`. That message arrives only on a clean end — a wall-clock timeout, inactivity silence, or no-progress stall cuts the stream before it, so the `{**usage, ...}` spread contributed nothing and the block held only harness-side keys (`caps`, `resumes`, `slept_seconds`, …).

## Fix

Accumulate per-message usage as the stream arrives; fall back to it when no `ResultMessage` came. A new `usage_source` field marks which a reader is looking at: `result_message` or `streamed_fallback`.

**The first cut was wrong and validating against real data caught it.** Replaying the spriggs session through a summing accumulator gave 226 messages / 358,610 output tokens against a ground truth of 118 turns / 106,661. The SDK re-emits the same assistant message once per content block, each copy repeating that message's *cumulative* usage — 226 rows, 87 distinct ids, identical usage across duplicates. Keying by `message_id` reproduces the totals exactly:

```
output_tokens                106661  ==  106661
cache_read_input_tokens     8422961  == 8422961
cache_creation_input_tokens  356338  ==  356338
input_tokens                    153  ==     153
```

## Three fields deliberately left null

A plausible-but-wrong number here would be silently compared against real values from clean runs.

- **`total_cost_usd`** — a run spans several models (parent + each subagent on its own `.md` pin), so one price lookup would be wrong. Tokens are exact, so cost stays derivable later.
- **`num_turns`** — the SDK counts turns differently from distinct assistant messages (118 vs 87), and `latency_report.py:183` divides output tokens by it. Publishing 87 under that name would inflate tokens-per-turn ~1.4x in exactly the metric the latency work depends on. The exact count ships as `assistant_messages`.
- **`duration_api_ms`** — only the SDK knows the API/local split.

Existing consumers already null-guard cost (`report.py:59`, `latency_report.py:281`), so aborted runs now just appear with real duration and tokens instead of blank.

## Second commit: `cost_cap` is a label, not a cap

Investigating the above surfaced that `max_cost_usd` **never caps anything**. The check reads `message.total_cost_usd`, which only exists on the `ResultMessage` — after the run finished and the money was spent. All five `cost_cap` runs ended with the SDK's own `end_turn` and `is_error: false`; spend ran to \$15.86–\$20.84 against a \$15 cap with nothing interrupted.

Left unenforced rather than half-built: there is no per-model price table for agent models, and subagent tokens never appear in the main message stream, so an in-flight estimate would under-count and a \$15 cap would fire north of \$15 by an unknown margin. The spec (§5) listed it under "Stops on whichever fires first" — now corrected, with the blockers recorded in `docs/TODOs.md`.

## Testing

`1027 passed, 3 skipped` in the harness suite. New cover: token-total accuracy, message-id dedup (the regression above), anonymous-message handling, malformed/missing usage, and the null-rather-than-guess contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)