### PR TITLE
Inject the Anthropic key per connect, not once at sandbox create

### DIFF
--- a/apps/server/app/agent/real_agent.py
+++ b/apps/server/app/agent/real_agent.py
@@ -20,10 +20,19 @@ Config (build_options) — two load-bearing choices: do NOT set skills="all" (th
 SDK turns it into `--allowedTools Skill`, restricting to only the Skill tool);
 append the project path via system_prompt so the agent reads research.json from
 cwd, not HOME.
+
+The Anthropic key comes from the per-connect secrets file, NOT from this
+process's env (see current_api_key + app/agent_secrets.py). A sandbox's env is
+fixed at create() and can never be updated, so an env-sourced key goes stale the
+moment the operator rotates it — the persistent client above then holds the dead
+key for the sandbox's whole life. Hence _ensure_client re-reads the file each
+turn and rebuilds the client when it changes.
 """
 from __future__ import annotations
 
+import json
 import os
+import sys
 from collections.abc import AsyncIterator
 from pathlib import Path
 
@@ -31,13 +40,43 @@ from pathlib import Path
 _REPO_ROOT = Path(__file__).resolve().parents[4]
 _MCP_BUILD = os.environ.get("ENGINE_MCP_BUILD", str(_REPO_ROOT / "packages" / "engine" / "mcp-server" / "build" / "index.js"))
 _PLUGIN_DIR = os.environ.get("ENGINE_PLUGIN_DIR", str(_REPO_ROOT / "packages" / "engine" / "plugin"))
+# Per-connect secrets, rewritten by the control plane on every connect (see
+# app/agent_secrets.py). Must equal sandbox.base.SECRETS_PATH — asserted by
+# tests/test_agent_secrets.py, since this module cannot import from the control
+# plane package (it also runs as a loose script in the baked E2B image).
+# AGENT_SECRETS_PATH overrides it for LocalProvider, whose sandbox-absolute
+# paths are mapped under a per-sandbox dir on the dev host.
+_SECRETS_PATH = os.environ.get("AGENT_SECRETS_PATH", "/run/secrets/session.json")
 
 
 def _event(kind: str, **kw) -> dict:
     return {"kind": kind, **kw}
 
 
-def build_options(project_dir: Path, resume: str | None = None):
+def _log(msg: str) -> None:
+    """Diagnostics go to STDERR — stdout is the runner's JSON-lines protocol and
+    a stray line there desynchronizes the pump. Lands in /tmp/agent.log."""
+    print(msg, file=sys.stderr, flush=True)
+
+
+def current_api_key() -> str:
+    """The operator's Anthropic key for the next turn.
+
+    Prefers the per-connect secrets file so a rotated key reaches a long-lived
+    sandbox whose create-time env is frozen (the whole point of the file
+    channel). Falls back to the env var when the file is missing, unreadable, or
+    carries no key — local dev, and any sandbox created before this existed.
+    """
+    env_key = os.environ.get("ANTHROPIC_API_KEY", "")
+    try:
+        doc = json.loads(Path(_SECRETS_PATH).read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return env_key
+    key = doc.get("anthropic_api_key") if isinstance(doc, dict) else None
+    return key if isinstance(key, str) and key else env_key
+
+
+def build_options(project_dir: Path, resume: str | None = None, api_key: str | None = None):
     from claude_agent_sdk import ClaudeAgentOptions
 
     project_note = (
@@ -65,7 +104,7 @@ def build_options(project_dir: Path, resume: str | None = None):
         # ToolSearch re-discovery mid-session. See speedup plan §3a — kept in
         # sync with the e2e orchestrator so hosted-web users get the same win.
         env={
-            "ANTHROPIC_API_KEY": os.environ.get("ANTHROPIC_API_KEY", ""),
+            "ANTHROPIC_API_KEY": current_api_key() if api_key is None else api_key,
             "ENABLE_TOOL_SEARCH": "true",
         },
     )
@@ -125,6 +164,11 @@ class RealAgent:
     def __init__(self, project_dir: Path):
         self.dir = project_dir
         self._client = None
+        # The API key the live client was built with. The SDK reads
+        # ANTHROPIC_API_KEY once, when its subprocess starts, so a client is
+        # pinned to whatever key was current then — we compare against this to
+        # notice a rotation and rebuild (see _ensure_client).
+        self._client_key: str | None = None
         self._session_file = project_dir / ".agent_session"
         self._resume_id: str | None = None
         self._tool_names: dict[str, str] = {}  # tool_use_id → name, for tool_result tagging
@@ -140,14 +184,37 @@ class RealAgent:
             except OSError:
                 self._resume_id = None
 
+    async def _close_client(self) -> None:
+        """Drop the live client. State is cleared FIRST so a disconnect that
+        throws can't leave a half-dead client cached for the next turn."""
+        client, self._client, self._client_key = self._client, None, None
+        if client is None:
+            return
+        try:
+            await client.disconnect()
+        except Exception as exc:  # best-effort teardown; we're replacing it anyway
+            _log(f"[agent] client disconnect failed (ignored): {exc}")
+
     async def _ensure_client(self):
+        key = current_api_key()
+        if self._client is not None and key != self._client_key:
+            # The operator rotated the key under a live client. Rebuild so the
+            # new one takes effect without waiting for the sandbox to be
+            # recreated. Conversation survives: the rebuild passes
+            # resume=<session id>, the same path a runner restart takes.
+            _log("[agent] Anthropic key rotated — rebuilding the SDK client")
+            await self._close_client()
         if self._client is None:
             from claude_agent_sdk import ClaudeSDKClient
 
-            self._client = ClaudeSDKClient(
-                options=build_options(self.dir, resume=self._resume_id)
+            client = ClaudeSDKClient(
+                options=build_options(self.dir, resume=self._resume_id, api_key=key)
             )
-            await self._client.connect()
+            # Assign only after a successful connect, so a failed start is
+            # retried next turn instead of caching a client that never opened.
+            await client.connect()
+            self._client = client
+            self._client_key = key
         return self._client
 
     def _usage_delta(self, cost, in_tok, out_tok):

--- a/apps/server/app/agent_secrets.py
+++ b/apps/server/app/agent_secrets.py
@@ -1,0 +1,55 @@
+"""Per-connect agent secrets — the file channel carrying the operator's
+Anthropic key into a sandbox that already exists.
+
+**Why a file and not create-time env.** Neither sandbox SDK can mutate the
+environment of a sandbox that has already been created, so a key injected via
+`envs=` at `create()` is frozen for that sandbox's entire life. Rotating
+`ANTHROPIC_API_KEY` on the control plane therefore fixed only *new* sessions
+while every existing one kept failing with `401 authentication_error` — the
+2026-07-20 alpha outage. Rewriting the current value on every connect makes a
+rotation take effect for every session at its next reconnect.
+
+This restores decision #2 of `docs/plan/sandbox-provider-interface.md` ("per-user
+secrets go in a file, written on every (re)connect — not create-time env"), which
+the implementation had drifted from; `SECRETS_PATH` was already reserved for it
+in `sandbox/base.py` and had no callers.
+
+Scope is deliberately just the Anthropic key: the FamilySearch token and the
+OpenRouter key already have their own file channels (`fs_oauth.write_tokens` /
+`write_config`) and so already survive rotation. This module is their sibling —
+the control plane owns provisioning these files, the agent only reads them.
+
+The reader is `app/agent/real_agent.py`, which prefers this file and falls back
+to the env var when it is absent (local dev, and sandboxes created before the
+file channel existed).
+"""
+from __future__ import annotations
+
+import json
+
+from .config import get_settings
+from .sandbox.base import SECRETS_PATH
+
+
+def secrets_bytes(anthropic_api_key: str | None) -> bytes:
+    """Serialize the secrets document the in-sandbox agent reads.
+
+    A missing key writes `{}` rather than a null: the reader treats absent and
+    empty alike (it falls back to env), and this keeps the file's shape stable.
+    """
+    payload: dict[str, str] = {}
+    if anthropic_api_key:
+        payload["anthropic_api_key"] = anthropic_api_key
+    return json.dumps(payload, indent=2).encode()
+
+
+async def write_secrets(sandbox) -> None:
+    """Write the current operator secrets into `sandbox` at SECRETS_PATH.
+
+    Call on every path that is about to run a turn — session create and each
+    reconnect. Cheap (one small file write) and idempotent, so callers do not
+    need to track whether the value actually changed.
+    """
+    await sandbox.write_file(
+        SECRETS_PATH, secrets_bytes(get_settings().anthropic_api_key)
+    )

--- a/apps/server/app/sandbox/base.py
+++ b/apps/server/app/sandbox/base.py
@@ -17,6 +17,12 @@ from dataclasses import dataclass, field
 from enum import Enum
 
 PROJECT_DIR = "/project"
+# Operator secrets the agent re-reads each turn, rewritten by the control plane
+# on every connect (app/agent_secrets.py writes it; app/agent/real_agent.py
+# reads it). This is the channel for credentials that ROTATE — create-time env
+# cannot be updated on a sandbox that already exists. Under /run deliberately:
+# on a tmpfs it never enters an E2B pause snapshot, and it is rewritten before
+# any turn regardless.
 SECRETS_PATH = "/run/secrets/session.json"
 # Sandbox-absolute HOME for the agent process. The FamilySearch token lands at
 # {HOME_DIR}/.familysearch-mcp/tokens.json (spec §5.2 option a — file on the

--- a/apps/server/app/sandbox/local.py
+++ b/apps/server/app/sandbox/local.py
@@ -21,6 +21,7 @@ from ..config import get_settings
 from ..ws_token import sandbox_secret
 from .base import (
     PROJECT_DIR,
+    SECRETS_PATH,
     ConnectURL,
     DirEntry,
     ExecResult,
@@ -172,6 +173,11 @@ class LocalProvider(SandboxProvider):
         # The in-sandbox WS server per sandbox (the unified transport): (proc, port).
         self._servers: dict[str, tuple[subprocess.Popen, int]] = {}
 
+    def _abs_secrets(self, sandbox_id: str) -> Path:
+        """Host path that LocalSandbox.write_file(SECRETS_PATH) lands on — the
+        same `root / <path minus leading slash>` mapping LocalSandbox._abs uses."""
+        return self._root(sandbox_id) / _sandbox_rel(SECRETS_PATH)
+
     # ── in-sandbox WS server (unified transport) ──────────────────
     def live_server(self, sandbox_id: str) -> tuple[subprocess.Popen, int] | None:
         entry = self._servers.get(sandbox_id)
@@ -201,6 +207,12 @@ class LocalProvider(SandboxProvider):
             "AGENT_MODE": settings.agent_mode,
             "MODEL": model,
             "PYTHONPATH": str(SERVER_ROOT),  # so `-m app.sandbox_server` resolves
+            # LocalProvider maps sandbox-absolute paths under a per-sandbox dir
+            # on the dev host, so the agent can't read the literal SECRETS_PATH
+            # (/run/secrets/... belongs to the real machine). Point it at where
+            # write_file actually put the file. E2B needs no override — there
+            # the path is real inside the microVM.
+            "AGENT_SECRETS_PATH": str(self._abs_secrets(sandbox_id)),
         }
         if settings.anthropic_api_key:
             env["ANTHROPIC_API_KEY"] = settings.anthropic_api_key

--- a/apps/server/app/sessions.py
+++ b/apps/server/app/sessions.py
@@ -12,7 +12,7 @@ from fastapi import APIRouter, Depends, File, HTTPException, Request, Response, 
 from pydantic import BaseModel, Field
 from sqlmodel import Session, select
 
-from . import fs_oauth
+from . import agent_secrets, fs_oauth
 from .auth import get_current_user
 from .config import get_settings
 from .db import get_session
@@ -182,6 +182,10 @@ async def create_project(
         await fs_oauth.write_config(
             sandbox, {"openRouterApiKey": settings.openrouter_api_key}
         )
+    # The Anthropic key the Agent SDK runs on. Written here AND on every connect
+    # (the env copy injected at create() can never be updated afterwards, so it
+    # goes stale the moment the key is rotated). See app/agent_secrets.py.
+    await agent_secrets.write_secrets(sandbox)
     if sample:
         await seed_sample_project(sandbox)
 
@@ -423,6 +427,9 @@ async def connect_session(
     subprocess); each returns its own wss:// or ws:// URL."""
     project = _owned(session, user, session_id)
     sandbox = await provider.resume(project.sandbox_id)
+    # Refresh the operator secrets BEFORE the agent can be handed a turn, so a
+    # rotated Anthropic key reaches sandboxes created under the old one.
+    await agent_secrets.write_secrets(sandbox)
     conn = await sandbox.expose_port(SANDBOX_WS_PORT)
     token = mint_token(project.sandbox_id)
     project.last_active = utcnow()

--- a/apps/server/app/v1.py
+++ b/apps/server/app/v1.py
@@ -39,6 +39,7 @@ from pydantic import BaseModel, Field
 from sqlalchemy import update as sa_update
 from sqlmodel import Session
 
+from . import agent_secrets
 from .auth import get_api_client
 from .config import get_settings
 from .db import get_engine, get_session
@@ -142,6 +143,7 @@ async def _open_ws(provider: SandboxProvider, sandbox_id: str):
     yet — the browser path connects a moment later over the network, but we connect
     in-process immediately — so retry the TCP connect briefly until it is up."""
     sandbox = await provider.resume(sandbox_id)
+    await agent_secrets.write_secrets(sandbox)  # same refresh the browser /connect does
     conn = await sandbox.expose_port(SANDBOX_WS_PORT)
     token = mint_token(sandbox_id)
     url = f"{conn.url}/?token={token}"

--- a/apps/server/tests/test_agent_secrets.py
+++ b/apps/server/tests/test_agent_secrets.py
@@ -1,0 +1,196 @@
+"""Per-connect secret injection — the fix for the create-time-env freeze.
+
+The Anthropic key used to be injected only via `envs=` at sandbox create(),
+which neither sandbox SDK can update afterwards. Rotating the key therefore
+fixed new sessions while every existing one kept 401ing (the 2026-07-20 alpha
+outage). The control plane now rewrites SECRETS_PATH on every connect and the
+agent prefers that file, so a rotation lands at the user's next reconnect.
+"""
+import json
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.agent import real_agent
+from app.agent_secrets import secrets_bytes
+from app.config import get_settings
+from app.main import app
+from app.sandbox.base import SECRETS_PATH
+
+
+# ── the reader (runs inside the sandbox) ─────────────────────────
+
+def _point_at(monkeypatch, path):
+    monkeypatch.setattr(real_agent, "_SECRETS_PATH", str(path))
+
+
+def test_secrets_file_wins_over_stale_create_time_env(tmp_path, monkeypatch):
+    # The exact outage shape: the env copy baked in at create() is the revoked
+    # key, the file carries the rotated one. The file must win.
+    secrets = tmp_path / "session.json"
+    secrets.write_bytes(secrets_bytes("sk-ant-rotated"))
+    _point_at(monkeypatch, secrets)
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-revoked")
+
+    assert real_agent.current_api_key() == "sk-ant-rotated"
+
+
+@pytest.mark.parametrize(
+    "content",
+    [None, b"", b"not json at all", b"{}", b'{"anthropic_api_key": ""}', b"[]"],
+    ids=["missing", "empty", "corrupt", "no-key", "blank-key", "not-an-object"],
+)
+def test_falls_back_to_env_when_file_unusable(tmp_path, monkeypatch, content):
+    # Sandboxes created before this channel existed have no file; a partial or
+    # truncated write must not strand the agent with no key at all.
+    secrets = tmp_path / "session.json"
+    if content is not None:
+        secrets.write_bytes(content)
+    _point_at(monkeypatch, secrets)
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-from-env")
+
+    assert real_agent.current_api_key() == "sk-ant-from-env"
+
+
+def test_build_options_passes_the_current_key_to_the_sdk(tmp_path, monkeypatch):
+    pytest.importorskip("claude_agent_sdk")
+    secrets = tmp_path / "session.json"
+    secrets.write_bytes(secrets_bytes("sk-ant-rotated"))
+    _point_at(monkeypatch, secrets)
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-revoked")
+
+    opts = real_agent.build_options(tmp_path)
+    assert opts.env["ANTHROPIC_API_KEY"] == "sk-ant-rotated"
+
+
+def test_secrets_path_agrees_with_the_control_plane_constant():
+    # real_agent can't import the control-plane package (it also runs as a loose
+    # script in the baked E2B image), so the path is duplicated. Writer and
+    # reader must not drift.
+    assert real_agent._SECRETS_PATH == SECRETS_PATH
+
+
+# ── live-client rotation ─────────────────────────────────────────
+
+class _FakeClient:
+    """Stands in for ClaudeSDKClient: records connect/disconnect only."""
+
+    instances: list["_FakeClient"] = []
+
+    def __init__(self, options=None):
+        self.options = options
+        self.connected = False
+        self.disconnected = False
+        _FakeClient.instances.append(self)
+
+    async def connect(self):
+        self.connected = True
+
+    async def disconnect(self):
+        self.disconnected = True
+
+
+@pytest.fixture
+def fake_sdk(monkeypatch):
+    """Patch the lazily-imported ClaudeSDKClient inside _ensure_client."""
+    import sys
+    import types
+
+    _FakeClient.instances = []
+    mod = types.ModuleType("claude_agent_sdk")
+    mod.ClaudeSDKClient = _FakeClient
+    mod.ClaudeAgentOptions = dict  # build_options is stubbed out below
+    monkeypatch.setitem(sys.modules, "claude_agent_sdk", mod)
+    monkeypatch.setattr(real_agent, "build_options", lambda *a, **kw: kw)
+    return _FakeClient
+
+
+async def test_rotating_the_key_rebuilds_the_live_client(tmp_path, monkeypatch, fake_sdk):
+    # A running agent_runner holds a persistent client. The SDK reads the key
+    # once, at subprocess start, so a rotation only lands if the client is
+    # rebuilt — otherwise the fix would help new sandboxes only.
+    secrets = tmp_path / "session.json"
+    secrets.write_bytes(secrets_bytes("sk-ant-old"))
+    _point_at(monkeypatch, secrets)
+
+    agent = real_agent.RealAgent(tmp_path)
+    first = await agent._ensure_client()
+    assert first.connected and len(fake_sdk.instances) == 1
+
+    # Same key → same client (no needless teardown mid-conversation).
+    assert await agent._ensure_client() is first
+    assert len(fake_sdk.instances) == 1
+
+    # Rotated key → the old client is torn down and a new one built with it.
+    secrets.write_bytes(secrets_bytes("sk-ant-new"))
+    second = await agent._ensure_client()
+    assert second is not first
+    assert first.disconnected
+    assert second.options["api_key"] == "sk-ant-new"
+
+
+async def test_failed_connect_is_not_cached(tmp_path, monkeypatch, fake_sdk):
+    # A client that never opened must not be handed to the next turn — the turn
+    # would hang on a dead transport instead of retrying the connect.
+    secrets = tmp_path / "session.json"
+    secrets.write_bytes(secrets_bytes("sk-ant-key"))
+    _point_at(monkeypatch, secrets)
+
+    async def boom(self):
+        raise RuntimeError("CLI failed to start")
+
+    monkeypatch.setattr(_FakeClient, "connect", boom)
+    agent = real_agent.RealAgent(tmp_path)
+    with pytest.raises(RuntimeError):
+        await agent._ensure_client()
+    assert agent._client is None
+
+
+async def test_disconnect_failure_still_replaces_the_client(tmp_path, monkeypatch, fake_sdk):
+    # Teardown is best-effort: a client whose disconnect throws must not stay
+    # cached, or the rotation would never take.
+    secrets = tmp_path / "session.json"
+    secrets.write_bytes(secrets_bytes("sk-ant-old"))
+    _point_at(monkeypatch, secrets)
+
+    agent = real_agent.RealAgent(tmp_path)
+    first = await agent._ensure_client()
+
+    async def boom(self):
+        raise RuntimeError("transport already gone")
+
+    monkeypatch.setattr(_FakeClient, "disconnect", boom)
+    secrets.write_bytes(secrets_bytes("sk-ant-new"))
+    second = await agent._ensure_client()
+    assert second is not first and agent._client is second
+
+
+# ── the writer (control plane) ───────────────────────────────────
+
+def test_secrets_bytes_omits_an_unset_key():
+    assert json.loads(secrets_bytes(None)) == {}
+    assert json.loads(secrets_bytes("")) == {}
+    assert json.loads(secrets_bytes("sk-ant-x")) == {"anthropic_api_key": "sk-ant-x"}
+
+
+def test_connect_rewrites_the_secrets_file(monkeypatch):
+    # End to end over the real REST surface: /connect must refresh the file so a
+    # key rotated while a session was paused reaches it on reconnect.
+    monkeypatch.setattr(get_settings(), "anthropic_api_key", "sk-ant-at-create")
+    with TestClient(app) as client:
+        client.post("/auth/dev-login", json={"email": "tester@example.com"})
+        proj = client.post("/api/sessions", json={}).json()
+        secrets = (  # LocalProvider maps sandbox-absolute paths under the root
+            app.state.provider._root(proj["sandbox_id"]) / SECRETS_PATH.lstrip("/")
+        )
+        assert json.loads(secrets.read_text(encoding="utf-8")) == {
+            "anthropic_api_key": "sk-ant-at-create"
+        }
+
+        # Rotate on the control plane while the session exists, then reconnect.
+        monkeypatch.setattr(get_settings(), "anthropic_api_key", "sk-ant-rotated")
+        assert client.post(f"/api/sessions/{proj['id']}/connect").status_code == 200
+
+        assert json.loads(secrets.read_text(encoding="utf-8")) == {
+            "anthropic_api_key": "sk-ant-rotated"
+        }

--- a/docs/TODOs.md
+++ b/docs/TODOs.md
@@ -48,6 +48,20 @@ recorded so it can be re-examined rather than re-derived.
   start in prod (e.g. when `PUBLIC_URL` is https, or behind an explicit flag) if
   it's still the dev default, so a deploy can't silently mint forgeable
   per-sandbox WS tokens.
+- [ ] **Operator misconfiguration reaches the user as a raw SDK error string** —
+  when the Agent SDK's first call fails auth, `real_agent.handle_turn` wraps the
+  exception verbatim (`_event("error", text=f"Agent error: {exc}")`) and
+  `ChatPane` renders it as-is, so an alpha tester saw *"Failed to authenticate.
+  API Error: 401 API key is invalid."* after ~90s of waiting — a message about
+  the operator's Anthropic key, phrased as if it were about the tester's own
+  login. Two testers each reported it as a FamilySearch problem, which is the
+  real cost: it sends people to debug the wrong credential. Wanted: classify the
+  failure in `handle_turn` and emit an operator-vs-user framing — 401/403 from
+  the SDK → "This service is misconfigured; the administrator has been notified"
+  (plus a server-side log loud enough to page), while genuinely user-actionable
+  failures (an expired FamilySearch token) keep their current specific wording.
+  Surfaced by the 2026-07-20 outage; the credential-freeze half of that bug is
+  fixed (`app/agent_secrets.py`), this half is not.
 
 ## Engine — image transcription
 - [ ] **User-invoked Opus transcription (`image_transcribe` Flow 2)** — brainstormed,


### PR DESCRIPTION
## The bug

A sandbox's environment is fixed at `create()` — neither the E2B nor the local provider can update it afterwards. The operator's Anthropic key was injected only that way (`E2BProvider._agent_env`, called from `create()` and never from `resume()`), so it was frozen for each sandbox's whole life.

When the key was rotated, new sessions worked while every existing one kept failing with `401 API key is invalid` — today's alpha outage. Both testers read the message as a FamilySearch login problem, since it arrives as an opaque SDK string with no framing.

## The fix

`docs/plan/sandbox-provider-interface.md` decision #2 already specified this — *"per-user secrets go in a file, written on every (re)connect — not create-time env"* — and `base.py` reserved `SECRETS_PATH` for it, but the implementation had drifted to create-time env. This wires up what was planned.

- **`app/agent_secrets.py`** writes the current key to `SECRETS_PATH`, called from `create_project`, browser `/connect`, and v1's `_open_ws` — every path that precedes a turn. Sibling of `fs_oauth.write_tokens`/`write_config`; the FamilySearch and OpenRouter keys already had file channels and already survived rotation, only this one did not.
- **`real_agent.current_api_key()`** prefers the file, falling back to env when it is absent, unreadable, or keyless — local dev, and every sandbox created before the channel existed.
- **`_ensure_client` rebuilds the SDK client when the key changes.** The file alone is not enough: `agent_runner` holds a *persistent* client and the SDK reads `ANTHROPIC_API_KEY` once at subprocess start, so a live client stays pinned to the dead key. The rebuild passes `resume=<session id>`, so the conversation survives exactly as it does across a runner restart.

Two adjacent corrections in the same code: the client is assigned only after `connect()` succeeds (a failed start used to cache a client that never opened, which every later turn then reused), and diagnostics go to stderr since stdout carries the runner's JSON-lines protocol.

## Deploy notes

`AGENT_SECRETS_PATH` overrides the path for `LocalProvider`, whose sandbox-absolute paths map under a per-sandbox dir on the dev host. E2B needs no override, and its `files.write` creates parent directories (verified against the vendored SDK) — **no sandbox image rebuild required**, a normal `make deploy` ships it.

Existing sandboxes have no secrets file until a `/connect` writes one, so a rotated key reaches them only after this ships. Order that unblocks fastest: set the new key → deploy → reconnect.

## Tests

`apps/server/tests/test_agent_secrets.py` (14 cases): file-beats-stale-env, six fallback shapes, live-client rotation, failed-connect not cached, disconnect-throws still replaces, `/connect` rewriting the file end to end, and a parity assert on the path constant (duplicated because `real_agent` also runs as a loose script in the baked image).

Full control-plane suite: 68 passed.

## Not fixed here

Added a `docs/TODOs.md` entry for the other half of the outage — operator misconfiguration still reaches the user as a raw SDK error string, which is what sent two people to debug the wrong credential.

🤖 Generated with [Claude Code](https://claude.com/claude-code)