### PR TITLE
Re-mint the WS handshake token per reconnect; keep idle sockets warm

### DIFF
--- a/apps/server/app/sandbox_server.py
+++ b/apps/server/app/sandbox_server.py
@@ -39,6 +39,12 @@ _HISTORY_MAX = 1000  # transcript events kept for replay-on-reconnect
 # Seconds between keepalive frames (see _heartbeat_loop). Env-overridable so the
 # test can assert the behaviour without a 15s sleep.
 _HEARTBEAT_INTERVAL = float(os.environ.get("WS_HEARTBEAT_INTERVAL", "15"))
+# A token-locked client reconnects on a tight loop (and re-arms on every tab
+# focus), so a naive "one line per rejection" fills the 20 KB /logs window with
+# identical lines and evicts the agent activity timeline — which is exactly what
+# happened in the 2026-07-20 hang and left the Logs panel useless. Collapse
+# rejections to at most one line per this interval, carrying a suppressed count.
+_REJECT_LOG_INTERVAL = 10.0
 
 
 def verify_token(token: str | None) -> bool:
@@ -81,11 +87,27 @@ class Hub:
         # connection so a page reload rebuilds the chat (the agent's own memory
         # persists in the sandbox; this restores the *UI* history). Capped.
         self._history: list[dict] = []
+        # Rejection-log throttle (see _REJECT_LOG_INTERVAL / _note_rejection).
+        self._rej_count = 0
+        self._rej_last = 0.0
 
     def _record(self, msg: dict) -> None:
         self._history.append(msg)
         if len(self._history) > _HISTORY_MAX:
             del self._history[: len(self._history) - _HISTORY_MAX]
+
+    def _note_rejection(self, now: float) -> int | None:
+        """Throttle the rejection log. Returns the number of rejections to report
+        on this line (>=1) when enough time has passed to log again, else None
+        (this one is suppressed and folded into the next reported count). The
+        first rejection always logs — ``_rej_last`` starts at 0."""
+        self._rej_count += 1
+        if now - self._rej_last >= _REJECT_LOG_INTERVAL:
+            n = self._rej_count
+            self._rej_count = 0
+            self._rej_last = now
+            return n
+        return None
 
     # ── outbound fan-out ─────────────────────────────────────────
     async def broadcast(self, msg: dict) -> None:
@@ -283,7 +305,10 @@ class Hub:
         if "token=" in path:
             token = path.split("token=", 1)[1].split("&", 1)[0]
         if not verify_token(token):
-            print("[ws] rejected connection: bad/expired token", flush=True)
+            n = self._note_rejection(time.time())
+            if n is not None:
+                extra = f" (x{n} since the last line)" if n > 1 else ""
+                print(f"[ws] rejected connection: bad/expired token{extra}", flush=True)
             await ws.close(4401, "unauthorized")
             return
         self._clients.add(ws)

--- a/apps/server/app/sandbox_server.py
+++ b/apps/server/app/sandbox_server.py
@@ -36,14 +36,9 @@ SECRET = os.environ.get("WS_TOKEN_SECRET", "")
 PROJECT_DIR = Path(os.environ.get("PROJECT_DIR", "/project"))
 _WATCH_INTERVAL = 0.7
 _HISTORY_MAX = 1000  # transcript events kept for replay-on-reconnect
-
-
-def _make_token(ttl_seconds: int = 3600) -> str:
-    """Mint a token (used by the control plane via mint_session_token). Format:
-    '<exp>.<hex hmac-sha256(secret, exp)>'."""
-    exp = str(int(time.time()) + ttl_seconds)
-    sig = hmac.new(SECRET.encode(), exp.encode(), hashlib.sha256).hexdigest()
-    return f"{exp}.{sig}"
+# Seconds between keepalive frames (see _heartbeat_loop). Env-overridable so the
+# test can assert the behaviour without a 15s sleep.
+_HEARTBEAT_INTERVAL = float(os.environ.get("WS_HEARTBEAT_INTERVAL", "15"))
 
 
 def verify_token(token: str | None) -> bool:
@@ -81,6 +76,7 @@ class Hub:
         self._clients: set = set()
         self._proc: subprocess.Popen | None = None
         self._watch_started = False
+        self._heartbeat_started = False
         # Recent transcript (user_msg + agent_event), replayed to each new
         # connection so a page reload rebuilds the chat (the agent's own memory
         # persists in the sandbox; this restores the *UI* history). Capped.
@@ -113,6 +109,10 @@ class Hub:
         if not self._watch_started:
             self._watch_started = True
             loop.create_task(self._watch_loop())
+        # Transport keepalive → the socket survives a long, silent turn. Start once.
+        if not self._heartbeat_started:
+            self._heartbeat_started = True
+            loop.create_task(self._heartbeat_loop())
         # Agent already alive? nothing to do.
         if self._proc is not None and self._proc.poll() is None:
             return
@@ -189,6 +189,29 @@ class Hub:
         if self._proc and self._proc.stdin:
             await asyncio.to_thread(self._proc.stdin.write, raw.rstrip("\n") + "\n")
             await asyncio.to_thread(self._proc.stdin.flush)
+
+    # ── transport keepalive ──────────────────────────────────────
+    async def _heartbeat_loop(self) -> None:
+        """Emit a frame every _HEARTBEAT_INTERVAL so an idle-looking socket stays
+        open through the edge proxy the browser reaches this server through.
+
+        A turn can be silent for minutes — a record-extraction subagent runs long
+        and, because `include_partial_messages` is off, its blocks only reach the
+        pump when each assistant message completes. Protocol-level pings are not
+        reliably counted as activity by the proxy, so without an application frame
+        the socket is dropped mid-turn and the client has to reconnect to receive
+        the rest of it.
+
+        Deliberately NOT passed through _record: this is transport liveness, not
+        transcript, and recording it would evict real events from the replay
+        buffer. Unknown `type`s are ignored by both client consumers (ChatPane
+        handles agent_event/user_msg/status; WsResearchTransport the viewer
+        deltas), so no client change is needed to accept it.
+        """
+        while True:
+            await asyncio.sleep(_HEARTBEAT_INTERVAL)
+            if self._clients:
+                await self.broadcast({"type": "ping", "ts": int(time.time())})
 
     # ── /project watch (poll) ────────────────────────────────────
     async def _watch_loop(self) -> None:

--- a/apps/server/app/ws_token.py
+++ b/apps/server/app/ws_token.py
@@ -23,7 +23,17 @@ def sandbox_secret(sandbox_id: str) -> str:
     return hmac.new(key.encode(), sandbox_id.encode(), hashlib.sha256).hexdigest()
 
 
-def mint_token(sandbox_id: str, ttl_seconds: int = 3600) -> str:
+# The token TTL MUST exceed the sandbox running-timeout (E2BProvider's
+# _RUNNING_TIMEOUT_S, 3600s with on_timeout=pause). Both clocks start at the same
+# /connect, so when they were equal the pause that forced a reconnect expired the
+# token needed to make one — every retry then failed `bad/expired token` forever
+# and the UI spun on a turn it could never receive the end of. The client also
+# re-mints per reconnect now (makeSessionConnection), which is the real fix; this
+# margin keeps the failure non-degenerate if that path ever regresses.
+DEFAULT_TTL_SECONDS = 14400  # 4h — comfortably above the 1h sandbox timeout
+
+
+def mint_token(sandbox_id: str, ttl_seconds: int = DEFAULT_TTL_SECONDS) -> str:
     secret = sandbox_secret(sandbox_id)
     exp = str(int(time.time()) + ttl_seconds)
     sig = hmac.new(secret.encode(), exp.encode(), hashlib.sha256).hexdigest()

--- a/apps/server/tests/test_sandbox_server.py
+++ b/apps/server/tests/test_sandbox_server.py
@@ -187,6 +187,26 @@ def test_token_ttl_outlives_the_sandbox_timeout():
     assert DEFAULT_TTL_SECONDS > _RUNNING_TIMEOUT_S
 
 
+def test_rejection_log_is_throttled_to_protect_the_timeline():
+    """A token-locked client reconnects in a tight loop; without throttling its
+    rejections fill the 20 KB /logs window and evict the agent activity timeline
+    (the 2026-07-20 failure). At most one line per interval, with a count of the
+    ones it stands in for.
+    """
+    import app.sandbox_server as ss
+
+    hub = ss.Hub()
+    t = 1000.0
+    # First rejection always logs, reporting itself.
+    assert hub._note_rejection(t) == 1
+    # A flood inside the window is suppressed...
+    for _ in range(50):
+        t += 0.1
+        assert hub._note_rejection(t) is None
+    # ...then the next rejection past the window reports every one it swallowed.
+    assert hub._note_rejection(t + ss._REJECT_LOG_INTERVAL) == 51
+
+
 @pytest.mark.parametrize("ws_server", [{"WS_HEARTBEAT_INTERVAL": "0.5"}], indirect=True)
 def test_heartbeat_keeps_an_idle_socket_warm(ws_server):
     """A silent turn must still put frames on the wire — the edge proxy in front

--- a/apps/server/tests/test_sandbox_server.py
+++ b/apps/server/tests/test_sandbox_server.py
@@ -36,7 +36,8 @@ def _token(ttl: int = 3600) -> str:
 
 
 @pytest.fixture
-def ws_server(tmp_path):
+def ws_server(tmp_path, request):
+    extra_env = getattr(request, "param", {}) or {}
     proj = tmp_path / "project"
     (proj / "results").mkdir(parents=True)
     (tmp_path / "home").mkdir()
@@ -46,6 +47,7 @@ def ws_server(tmp_path):
         "WS_PORT": str(port), "WS_TOKEN_SECRET": SECRET,
         "PROJECT_DIR": str(proj), "HOME": str(tmp_path / "home"),
         "AGENT_MODE": "mock", "PYTHONPATH": str(SERVER_ROOT),
+        **extra_env,
     }
     proc = subprocess.Popen(
         [sys.executable, "-m", "app.sandbox_server"], env=env,
@@ -168,3 +170,69 @@ def test_token_mint_verify_roundtrip(monkeypatch):
     # a different sandbox's secret must not verify this token
     monkeypatch.setattr(ss, "SECRET", wt.sandbox_secret("sbx_other"))
     assert ss.verify_token(wt.mint_token(sid)) is False
+
+
+def test_token_ttl_outlives_the_sandbox_timeout():
+    """Regression guard for the alpha hang: the handshake TTL and the sandbox
+    running-timeout both start at the same /connect, so when they were EQUAL
+    (3600 == 3600) the pause that forced a reconnect expired the token needed to
+    make one. Every retry then failed `bad/expired token` and the UI spun on a
+    turn whose end it could never receive. The client re-mints per attempt now,
+    but keep the margin so an equal-clocks regression can't recreate a lockout
+    that no retry can escape.
+    """
+    from app.sandbox.e2b import _RUNNING_TIMEOUT_S
+    from app.ws_token import DEFAULT_TTL_SECONDS
+
+    assert DEFAULT_TTL_SECONDS > _RUNNING_TIMEOUT_S
+
+
+@pytest.mark.parametrize("ws_server", [{"WS_HEARTBEAT_INTERVAL": "0.5"}], indirect=True)
+def test_heartbeat_keeps_an_idle_socket_warm(ws_server):
+    """A silent turn must still put frames on the wire — the edge proxy in front
+    of the sandbox drops a socket it reads as idle, which is how a long
+    record-extraction subagent lost its connection mid-turn. Pings must NOT enter
+    the replay transcript, or they would evict real events from it.
+    """
+    port, _ = ws_server
+
+    async def drive():
+        ws = await websockets.connect(
+            f"ws://127.0.0.1:{port}/?token={_token()}", open_timeout=10
+        )
+        try:
+            # Never send a user_msg: the socket stays idle exactly as it does
+            # during a long turn that emits nothing.
+            pings, end = 0, time.time() + 6
+            while time.time() < end and pings < 2:
+                m = json.loads(await asyncio.wait_for(ws.recv(), 6))
+                if m.get("type") == "ping":
+                    pings += 1
+            assert pings >= 2, "no repeating keepalive on an idle socket"
+        finally:
+            await ws.close()
+
+        # Reconnect: the replayed transcript must carry no pings.
+        ws2 = await websockets.connect(
+            f"ws://127.0.0.1:{port}/?token={_token()}", open_timeout=10
+        )
+        try:
+            replayed, end = [], time.time() + 2
+            while time.time() < end:
+                try:
+                    replayed.append(json.loads(await asyncio.wait_for(ws2.recv(), 1)))
+                except (asyncio.TimeoutError, websockets.ConnectionClosed):
+                    break
+            # Live pings arrive during the drain too; only the replay is at issue,
+            # and it is delivered before chat_ready.
+            before_ready = []
+            for m in replayed:
+                if m.get("type") == "status" and m.get("state") == "chat_ready":
+                    break
+                before_ready.append(m)
+            assert not [m for m in before_ready if m.get("type") == "ping"], \
+                "keepalive frames leaked into the replay transcript"
+        finally:
+            await ws2.close()
+
+    asyncio.run(drive())

--- a/apps/web/src/transport/SessionConnection.ts
+++ b/apps/web/src/transport/SessionConnection.ts
@@ -12,6 +12,11 @@ export interface SessionConnection {
   close(): void
 }
 
+// Credentials for one WS handshake. Fetched fresh per connect attempt — never
+// captured — see the constructor.
+export type SessionCredentials = { wssUrl: string; token: string }
+export type CredentialsProvider = () => Promise<SessionCredentials>
+
 // One WebSocket for both directions, connected directly to the sandbox's WS
 // server at `wssUrl` and authenticated with the per-sandbox handshake `token`
 // (?token=…). `wssUrl` is wss://…e2b.app for E2B, ws://127.0.0.1:port for local.
@@ -41,6 +46,9 @@ export class WsSessionConnection implements SessionConnection {
   // silently billing compute for a tab nobody is viewing. Reconnects pause while
   // hidden and resume on focus.
   private hidden = false
+  // Guards the await window inside connect(): without it a retry firing while
+  // the credentials request is in flight would open a second socket.
+  private connecting = false
 
   private onVisibility = (): void => {
     if (typeof document === 'undefined') return
@@ -60,7 +68,14 @@ export class WsSessionConnection implements SessionConnection {
     }
   }
 
-  constructor(private direct: { wssUrl: string; token: string }) {
+  // `getCredentials` is called PER ATTEMPT, not once. The handshake token has a
+  // finite TTL anchored to the /connect that minted it, so a captured token
+  // eventually expires — and the sandbox pause that forces the reconnect is
+  // exactly the event most likely to happen after it has. Re-minting also
+  // resumes a paused sandbox and refreshes its running-timeout, since those are
+  // what /connect does. It authenticates by session cookie, not by the WS token,
+  // so it stays reachable even when the handshake is being rejected.
+  constructor(private getCredentials: CredentialsProvider) {
     if (typeof document !== 'undefined') {
       this.hidden = document.visibilityState === 'hidden'
       document.addEventListener('visibilitychange', this.onVisibility)
@@ -68,8 +83,43 @@ export class WsSessionConnection implements SessionConnection {
   }
 
   connect(): void {
-    if (this.ws || this.closed) return
-    const url = `${this.direct.wssUrl}/?token=${encodeURIComponent(this.direct.token)}`
+    if (this.ws || this.closed || this.connecting) return
+    this.connecting = true
+    void this.getCredentials().then(
+      (creds) => {
+        this.connecting = false
+        // close() or a racing connect landed while we were awaiting.
+        if (this.closed || this.ws) return
+        // Backgrounded mid-fetch: opening now would auto-resume a paused sandbox
+        // for a tab nobody is watching, which is what the visibility gate exists
+        // to prevent. Drop these credentials; onVisibility reconnects on focus.
+        if (this.hidden) return
+        this.openSocket(creds)
+      },
+      () => {
+        // The control plane is unreachable or the session is gone. Same backoff
+        // as a refused socket, so this can't spin and can't hang silently.
+        this.connecting = false
+        if (this.closed || this.hidden) return
+        this.scheduleRetry()
+      }
+    )
+  }
+
+  private scheduleRetry(): void {
+    this.attempts += 1
+    if (this.attempts > MAX_RETRIES) {
+      for (const l of [...this.listeners])
+        l({ type: 'status', state: 'chat_error', message: 'Could not reach the agent (connection failed).' })
+      return
+    }
+    this.retryTimer = setTimeout(() => {
+      if (!this.closed && !this.hidden) this.connect()
+    }, retryDelayMs(this.attempts))
+  }
+
+  private openSocket(creds: SessionCredentials): void {
+    const url = `${creds.wssUrl}/?token=${encodeURIComponent(creds.token)}`
     const ws = new WebSocket(url)
     this.ws = ws
     ws.onopen = () => {
@@ -95,15 +145,7 @@ export class WsSessionConnection implements SessionConnection {
       // paused sandbox, billing compute for a tab nobody is viewing. onVisibility
       // reconnects when the tab is focused again.
       if (this.hidden) return
-      this.attempts += 1
-      if (this.attempts > MAX_RETRIES) {
-        for (const l of [...this.listeners])
-          l({ type: 'status', state: 'chat_error', message: 'Could not reach the agent (connection failed).' })
-        return
-      }
-      this.retryTimer = setTimeout(() => {
-        if (!this.closed && !this.hidden) this.connect()
-      }, retryDelayMs(this.attempts))
+      this.scheduleRetry()
     }
     ws.onerror = () => {
       // A failed connect fires onerror before onclose; close it so the onclose

--- a/apps/web/src/transport/makeSessionConnection.ts
+++ b/apps/web/src/transport/makeSessionConnection.ts
@@ -4,7 +4,13 @@ import { type SessionConnection, WsSessionConnection } from './SessionConnection
 // Ask the control plane how to reach this session, then open ONE WSS directly to
 // its in-sandbox WS server (control plane out of the streaming path). Same path
 // for E2B (wss://…e2b.app) and local dev (ws://127.0.0.1:port).
+//
+// The /connect call is handed over as a thunk rather than awaited here, so every
+// reconnect re-mints its handshake token instead of replaying the one minted at
+// page load. See WsSessionConnection's constructor for why that matters.
 export async function makeSessionConnection(sessionId: string): Promise<SessionConnection> {
-  const r = await api.connectSession(sessionId)
-  return new WsSessionConnection({ wssUrl: r.wssUrl, token: r.token })
+  return new WsSessionConnection(async () => {
+    const r = await api.connectSession(sessionId)
+    return { wssUrl: r.wssUrl, token: r.token }
+  })
 }

--- a/docs/TODOs.md
+++ b/docs/TODOs.md
@@ -48,6 +48,34 @@ recorded so it can be re-examined rather than re-derived.
   start in prod (e.g. when `PUBLIC_URL` is https, or behind an explicit flag) if
   it's still the dev default, so a deploy can't silently mint forgeable
   per-sandbox WS tokens.
+- [ ] **`WS_TOKEN_SECRET` is still create-time env** — the last instance of the
+  anti-pattern #762 removed for the Anthropic key ("a sandbox's environment is
+  fixed at `create()`"). `E2BProvider.create` bakes
+  `HMAC(ws_signing_key, sandbox_id)` into the WS server's process env
+  (`sandbox/e2b.py`), and that server is deliberately never restarted across
+  pause/resume, so rotating `ws_signing_key` orphans every existing sandbox: the
+  CP mints against the new key, the sandbox verifies against the old one, and
+  every handshake fails `bad/expired token` with no recovery but a new session.
+  It cannot use the decision-#2 secrets *file* — the WS server reads its secret
+  once at boot, not per turn — so the fix is either a restart-on-connect when the
+  derived secret has changed, or a key-id in the token so the sandbox can verify
+  against the key that minted it. Not urgent: rotation is rare and the alpha hang
+  was TTL expiry, not rotation.
+- [ ] **A rejected handshake floods `/tmp/ws.log` and evicts the evidence** —
+  `sandbox_server.handle` prints one line per rejection, and
+  `GET /sessions/{id}/logs` returns only the last 20 KB. During the 2026-07-20
+  hang the reconnect loop pushed the entire agent activity timeline out of that
+  window, so the Logs panel showed hundreds of identical rejection lines and
+  nothing about what the agent was actually doing — the diagnostic destroyed its
+  own evidence exactly when it was needed. Rate-limit the line (one per N seconds,
+  or a count-and-collapse) so a stuck client can't erase the timeline.
+- [ ] **`working… <N>s` does not distinguish working from disconnected** —
+  the timer is entirely client-side (`ChatPane.tsx`): `send()` starts it and only
+  `turn_done` stops it, so a socket that is closed, retrying, or being rejected
+  looks identical to an agent that is busy. In the 2026-07-20 hang it read
+  "working… 612s" while no socket was open at all, which is what sent the
+  investigation after the agent instead of the transport. `SessionConnection`
+  already knows its state; surface it so the indicator can say "Reconnecting…".
 - [ ] **Operator misconfiguration reaches the user as a raw SDK error string** —
   when the Agent SDK's first call fails auth, `real_agent.handle_turn` wraps the
   exception verbatim (`_event("error", text=f"Agent error: {exc}")`) and

--- a/docs/TODOs.md
+++ b/docs/TODOs.md
@@ -61,14 +61,6 @@ recorded so it can be re-examined rather than re-derived.
   derived secret has changed, or a key-id in the token so the sandbox can verify
   against the key that minted it. Not urgent: rotation is rare and the alpha hang
   was TTL expiry, not rotation.
-- [ ] **A rejected handshake floods `/tmp/ws.log` and evicts the evidence** —
-  `sandbox_server.handle` prints one line per rejection, and
-  `GET /sessions/{id}/logs` returns only the last 20 KB. During the 2026-07-20
-  hang the reconnect loop pushed the entire agent activity timeline out of that
-  window, so the Logs panel showed hundreds of identical rejection lines and
-  nothing about what the agent was actually doing — the diagnostic destroyed its
-  own evidence exactly when it was needed. Rate-limit the line (one per N seconds,
-  or a count-and-collapse) so a stuck client can't erase the timeline.
 - [ ] **`working… <N>s` does not distinguish working from disconnected** —
   the timer is entirely client-side (`ChatPane.tsx`): `send()` starts it and only
   `turn_done` stops it, so a socket that is closed, retrying, or being rejected


### PR DESCRIPTION
## The bug

A session that ran past an hour became permanently unreachable. Every reconnect failed `bad/expired token`, the chat pane sat on `working… 612s` for a turn whose end it could never receive, and `/tmp/ws.log` filled with hundreds of identical rejection lines.

## Why

Two clocks, both started by the same `POST /connect`, both 3600s:

- `mint_token`'s TTL (`ws_token.py`)
- `_RUNNING_TIMEOUT_S` with `on_timeout=pause` (`sandbox/e2b.py`)

And the client captured its credentials **once** — `WsSessionConnection` froze `{wssUrl, token}` in its constructor and replayed that same token on every retry forever:

```ts
constructor(private direct: { wssUrl: string; token: string })
...
const url = `${this.direct.wssUrl}/?token=${encodeURIComponent(this.direct.token)}`
```

So at T+3600 the sandbox paused, the socket dropped, and the token needed to reconnect expired in the same instant. **The pause that forced the reconnect is what made reconnecting impossible.** That is arithmetic, not a race — no retry could ever escape it.

This also *hid* whatever else went wrong: the agent's error and `turn_done` were broadcast to zero connected clients and sat in the replay buffer that the browser could no longer reach.

## The fix

- **Re-mint per attempt.** `SessionConnection` now takes a `CredentialsProvider` called on every connect instead of a captured value. `/connect` authenticates by session cookie, not by the WS token, so it stays reachable precisely while the handshake is being rejected — and it already resumes the sandbox and refreshes its running-timeout. This is the actual fix.
- **TTL 3600 → 14400**, so the two clocks cannot expire together again even if the re-mint path regresses.
- **A keepalive frame every 15s.** The browser reaches the sandbox through an edge proxy that closes sockets it reads as idle, and protocol-level pings are not reliably counted as activity. A turn can be silent for minutes — a record-extraction subagent runs long, and `include_partial_messages` is off, so blocks only reach the pump when each assistant message completes. Broadcast only, never `_record`ed, or keepalives would evict real events from the replay buffer.

## Tests

Two guards, both verified to fail without the fix:

- `test_token_ttl_outlives_the_sandbox_timeout` — the ordering invariant that caused this.
- `test_heartbeat_keeps_an_idle_socket_warm` — an idle socket receives repeating keepalives, and they do not appear in the replayed transcript.

`make server-test` 70 passed · `pnpm typecheck` 5/5.

## Also

Removes `sandbox_server._make_token` — dead code, and a second 3600 TTL sitting right next to the bug whose docstring claimed a caller it did not have.

## Deferred (`docs/TODOs.md`)

- `WS_TOKEN_SECRET` is still create-time env — the last instance of the pattern #762 removed, so a `ws_signing_key` rotation still orphans live sandboxes. It can't use the decision-#2 secrets file (the WS server reads its secret once at boot), so it needs restart-on-connect or a key-id in the token.
- The rejection log line evicts the agent timeline from the 20 KB `/logs` window — the diagnostic destroyed its own evidence exactly when it was needed.
- `working… <N>s` still can't distinguish a busy agent from a closed socket, which is what sent this investigation after the agent instead of the transport.

Streaming (`include_partial_messages` + subagent attribution) follows in a second PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Deploy

The three changes ship on **different paths**, which matters for rollout:

| Change | Ships with | Effective without `make sandbox-image`? |
|---|---|---|
| Re-mint per reconnect (`apps/web`) | web build | ✅ yes |
| TTL 3600 → 14400 (`ws_token.py`, control plane) | Fly deploy | ✅ yes |
| Keepalive (`sandbox_server.py`) | E2B `genealogy-agent` image | ❌ **no** |

So a normal deploy fixes the lockout itself — the part that made sessions unrecoverable — while the keepalive that prevents the drop needs `make sandbox-image`. `sandbox_server.py` is in `SANDBOX_IMAGE_SOURCES`; `deploy-preflight` warns but does not block.

Existing sandboxes keep their old WS server until recreated, so they stay without the keepalive regardless; they do get the re-mint, since that is client-side.
