### PR TITLE
Add a Stop button, working/reconnecting indicator, and real interrupt

### DIFF
--- a/apps/server/app/agent/mock_agent.py
+++ b/apps/server/app/agent/mock_agent.py
@@ -80,6 +80,11 @@ class MockAgent:
     def _write_research(self, data: dict) -> None:
         (self.dir / "research.json").write_text(json.dumps(data, indent=2))
 
+    async def interrupt(self) -> bool:
+        """The scripted mock has no external call to abort — it cannot self-stop,
+        so it returns False and the runner cancels the turn task instead."""
+        return False
+
     # ── turn handling ────────────────────────────────────────────
     async def handle_turn(self, text: str) -> AsyncIterator[dict]:
         phase = self.state["phase"]

--- a/apps/server/app/agent/real_agent.py
+++ b/apps/server/app/agent/real_agent.py
@@ -325,6 +325,18 @@ class RealAgent:
             except OSError:
                 pass
 
+    async def interrupt(self) -> bool:
+        """Abort the in-flight turn via the SDK's control channel. The current
+        receive_response() stream then ends on its own, so handle_turn completes
+        and the runner emits turn_done — no task cancellation needed (returning
+        True tells the runner not to cancel). The persistent client stays
+        connected and is reused for the next turn. No live client → nothing to
+        stop, and returning False lets the runner cancel as a fallback."""
+        if self._client is None:
+            return False
+        await self._client.interrupt()
+        return True
+
     async def handle_turn(self, text: str) -> AsyncIterator[dict]:
         try:
             from claude_agent_sdk import ResultMessage

--- a/apps/server/app/agent/runner.py
+++ b/apps/server/app/agent/runner.py
@@ -2,8 +2,13 @@
 process in the E2B microVM when hosted). It owns one user's agent for the life
 of the session and speaks JSON lines over **stdio** (not a WebSocket server):
 
-  stdin  : {"type":"user_msg","text":"..."}   (one per line)
+  stdin  : {"type":"user_msg","text":"..."} | {"type":"interrupt"}  (one per line)
   stdout : {"type":"agent_event","event":{...}}   (one per line)
+
+stdin is drained concurrently with the running turn (a reader task feeds a
+queue), so an interrupt sent mid-turn is acted on immediately rather than read
+only after the turn it was meant to stop has already finished — which is what
+made interrupt a no-op while the loop blocked inside handle_turn.
 
 The in-sandbox WS server (app/sandbox_server.py) spawns this and pumps its stdio
 to/from the browser. Running over stdio (rather than the Agent SDK directly
@@ -45,32 +50,81 @@ def _emit(event: dict) -> None:
     sys.stdout.flush()
 
 
+async def _run_turn(agent, text: str, emit) -> None:
+    """One turn. Always ends with exactly one turn_done — the client keys its
+    busy state on it, so an error or an interrupt-cancellation must still emit it
+    or the UI hangs on a spinner forever."""
+    try:
+        async for event in agent.handle_turn(text):
+            emit(event)
+    except asyncio.CancelledError:
+        # Interrupt path for agents that cannot self-stop (the mock): the turn
+        # task was cancelled. Report the stop, then let turn_done fall through.
+        emit({"kind": "error", "text": "(stopped)"})
+    except Exception as exc:  # never die on an agent error
+        emit({"kind": "error", "text": f"Agent error: {exc}"})
+    emit({"kind": "turn_done"})  # sole source of turn_done (mock + real)
+
+
+async def serve(agent, incoming: "asyncio.Queue", emit) -> None:
+    """Dispatch messages from ``incoming`` (a queue fed concurrently with the
+    running turn; ``None`` = stdin EOF). At most one turn runs at a time —
+    additional user_msgs while busy are dropped (the UI disables Send). An
+    interrupt asks the agent to stop; agents that can't (return falsy) are
+    cancelled instead. Extracted from main() so it is testable without stdio."""
+    turn_task: asyncio.Task | None = None
+    while True:
+        msg = await incoming.get()
+        if msg is None:  # stdin EOF — the control plane closed the connection
+            break
+        mtype = msg.get("type")
+        if mtype == "user_msg":
+            if turn_task and not turn_task.done():
+                continue  # already busy; the UI prevents concurrent sends
+            turn_task = asyncio.create_task(_run_turn(agent, msg.get("text", ""), emit))
+        elif mtype == "interrupt":
+            if turn_task and not turn_task.done():
+                handled = False
+                try:
+                    handled = bool(await agent.interrupt())
+                except Exception as exc:
+                    emit({"kind": "error", "text": f"Interrupt failed: {exc}"})
+                # The real agent tells the SDK to abort and its stream ends on its
+                # own (handled=True). An agent that can't self-stop is cancelled;
+                # _run_turn turns that into (stopped) + turn_done.
+                if not handled:
+                    turn_task.cancel()
+    if turn_task and not turn_task.done():
+        turn_task.cancel()
+
+
 async def main() -> None:
     project_dir = Path(os.environ.get("PROJECT_DIR", "/project"))
     agent = _make_agent(project_dir)
 
-    # Read user messages from stdin (blocking readline off-thread so the event
-    # loop stays free for the agent's async work).
-    while True:
-        line = await asyncio.to_thread(sys.stdin.readline)
-        if not line:  # EOF — the control plane closed the connection
-            break
-        line = line.strip()
-        if not line:
-            continue
-        try:
-            msg = json.loads(line)
-        except json.JSONDecodeError:
-            continue
-        if msg.get("type") != "user_msg":
-            continue  # interrupt/other types: handled in a later pass
+    incoming: asyncio.Queue = asyncio.Queue()
 
-        try:
-            async for event in agent.handle_turn(msg.get("text", "")):
-                _emit(event)
-        except Exception as exc:  # never die on an agent error
-            _emit({"kind": "error", "text": f"Agent error: {exc}"})
-        _emit({"kind": "turn_done"})  # sole source of turn_done (mock + real)
+    async def reader() -> None:
+        # Blocking readline off-thread so the event loop stays free for the
+        # agent's async work and for interrupts arriving mid-turn.
+        while True:
+            line = await asyncio.to_thread(sys.stdin.readline)
+            if not line:  # EOF
+                await incoming.put(None)
+                return
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                await incoming.put(json.loads(line))
+            except json.JSONDecodeError:
+                continue
+
+    reader_task = asyncio.create_task(reader())
+    try:
+        await serve(agent, incoming, _emit)
+    finally:
+        reader_task.cancel()
 
 
 if __name__ == "__main__":

--- a/apps/server/app/sandbox_server.py
+++ b/apps/server/app/sandbox_server.py
@@ -89,6 +89,13 @@ class Hub:
         # connection so a page reload rebuilds the chat (the agent's own memory
         # persists in the sandbox; this restores the *UI* history). Capped.
         self._history: list[dict] = []
+        # Whether a turn is running right now. The client's "working" state is
+        # otherwise purely local to the browser that hit Send, so a reload mid-turn
+        # loses it and the UI looks idle while the agent is still working (the
+        # 2026-07-20 report). This is the Hub — it outlives any one connection — so
+        # a reconnect can be told the turn is still going. Set when a user_msg is
+        # forwarded, cleared on turn_done (and on agent exit).
+        self._turn_active = False
         # Rejection-log throttle (see _REJECT_LOG_INTERVAL / _note_rejection).
         self._rej_count = 0
         self._rej_last = 0.0
@@ -197,6 +204,8 @@ class Hub:
                 else:
                     detail = ""
                 print(f"{_ts()} [agent] {kind} {detail}".rstrip(), flush=True)
+            if kind == "turn_done":
+                self._turn_active = False
             await self.broadcast(msg)
             # Deltas and task_progress are live-only. Recording them would evict
             # the real conversation from the capped replay buffer within a single
@@ -209,6 +218,7 @@ class Hub:
         # a turn that will never finish. A new message re-spawns it (send_input).
         if proc is self._proc:
             self._proc = None
+            self._turn_active = False  # the turn can't finish; unstick reconnects too
             await self.broadcast({"type": "agent_event", "event": {"kind": "error",
                 "text": f"The agent process exited unexpectedly (code {code}). "
                         "Send another message to restart it."}})
@@ -334,6 +344,11 @@ class Hub:
             # (agent already alive → ensure_started returns early) would sit on
             # "Connecting to the agent…" forever (ChatPane gates on chat_ready).
             await self.send_one(ws, {"type": "status", "state": "chat_ready"})
+            # A turn already running when this client connects (a reload mid-turn,
+            # or a second tab) — tell it so, so it shows "working" instead of idle.
+            # turn_done, replayed above and re-broadcast live, clears it.
+            if self._turn_active:
+                await self.send_one(ws, {"type": "status", "state": "turn_active"})
             async for raw in ws:
                 try:
                     msg = json.loads(raw)
@@ -341,6 +356,7 @@ class Hub:
                     continue
                 if msg.get("type") == "user_msg":
                     self._record({"type": "user_msg", "text": msg.get("text", "")})
+                    self._turn_active = True  # a turn is about to run (see connect note)
                     await self.send_input(raw)
                 elif msg.get("type") == "interrupt":
                     await self.send_input(raw)

--- a/apps/server/tests/test_runner_interrupt.py
+++ b/apps/server/tests/test_runner_interrupt.py
@@ -1,0 +1,173 @@
+"""The runner's message loop, focused on interrupt.
+
+Interrupt was a no-op because the old loop blocked inside handle_turn and never
+read stdin until the turn it was meant to stop had already finished. serve() now
+drains messages concurrently with the running turn, so these drive a long turn
+and interrupt it mid-flight.
+
+Two agent shapes, matching the two real ones:
+- an SDK-style agent whose interrupt() ends its own stream (returns True → the
+  runner must NOT cancel; the turn ends on its own),
+- a mock-style agent that cannot self-stop (returns False → the runner cancels,
+  and _run_turn converts that into (stopped) + turn_done).
+"""
+import asyncio
+
+import pytest
+
+from app.agent.runner import serve
+
+
+class SdkStyleAgent:
+    """interrupt() ends the stream itself, like RealAgent telling the SDK to abort."""
+
+    def __init__(self):
+        self._stop = asyncio.Event()
+        self.interrupted = False
+
+    async def handle_turn(self, text):
+        i = 0
+        while not self._stop.is_set():
+            yield {"kind": "text", "text": f"{i}"}
+            i += 1
+            await asyncio.sleep(0.005)
+
+    async def interrupt(self):
+        self.interrupted = True
+        self._stop.set()
+        return True
+
+
+class UnstoppableAgent:
+    """Cannot self-stop (returns False), like the scripted MockAgent."""
+
+    def __init__(self):
+        self.interrupted = False
+
+    async def handle_turn(self, text):
+        i = 0
+        while True:  # never ends on its own — only cancellation stops it
+            yield {"kind": "text", "text": f"{i}"}
+            i += 1
+            await asyncio.sleep(0.005)
+
+    async def interrupt(self):
+        self.interrupted = True
+        return False
+
+
+async def _run(agent, script_delays):
+    """Feed messages to serve() with small gaps, collecting emitted events. The
+    turn runs concurrently; the final None ends the loop."""
+    incoming: asyncio.Queue = asyncio.Queue()
+    events: list[dict] = []
+    serve_task = asyncio.create_task(serve(agent, incoming, events.append))
+
+    await incoming.put({"type": "user_msg", "text": "go"})
+    await asyncio.sleep(0.05)  # let the turn produce a few events
+    await incoming.put({"type": "interrupt"})
+    await asyncio.sleep(0.05)  # let the interrupt take effect
+    await incoming.put(None)  # EOF → serve returns
+    await asyncio.wait_for(serve_task, 2)
+    return events
+
+
+def test_sdk_style_interrupt_ends_the_turn_without_cancellation():
+    agent = SdkStyleAgent()
+    events = asyncio.run(_run(agent, None))
+
+    assert agent.interrupted, "interrupt() was not called"
+    assert events[-1] == {"kind": "turn_done"}, "turn must always end with turn_done"
+    # It stopped: far fewer than an unbounded run, and no (stopped) marker since
+    # the SDK-style stream ended on its own rather than being cancelled.
+    assert not any(e.get("text") == "(stopped)" for e in events)
+
+
+def test_unstoppable_turn_is_cancelled_and_reports_stopped():
+    agent = UnstoppableAgent()
+    events = asyncio.run(_run(agent, None))
+
+    assert agent.interrupted
+    assert {"kind": "error", "text": "(stopped)"} in events
+    assert events[-1] == {"kind": "turn_done"}
+
+
+def test_a_turn_runs_to_completion_when_never_interrupted():
+    """A short, self-completing turn needs no interrupt and still ends cleanly —
+    the interrupt machinery must not change the normal path."""
+
+    class ShortAgent:
+        async def handle_turn(self, text):
+            yield {"kind": "text", "text": "hi"}
+
+        async def interrupt(self):
+            return False
+
+    async def drive():
+        incoming: asyncio.Queue = asyncio.Queue()
+        events: list[dict] = []
+        task = asyncio.create_task(serve(ShortAgent(), incoming, events.append))
+        await incoming.put({"type": "user_msg", "text": "hi"})
+        await asyncio.sleep(0.05)
+        await incoming.put(None)
+        await asyncio.wait_for(task, 2)
+        return events
+
+    events = asyncio.run(drive())
+    assert {"kind": "text", "text": "hi"} in events
+    assert events[-1] == {"kind": "turn_done"}
+
+
+def test_interrupt_while_idle_is_ignored():
+    """An interrupt with no turn running must not crash or emit anything."""
+
+    class Idle:
+        async def handle_turn(self, text):
+            yield {"kind": "text", "text": "x"}
+
+        async def interrupt(self):
+            raise AssertionError("interrupt() must not be called when idle")
+
+    async def drive():
+        incoming: asyncio.Queue = asyncio.Queue()
+        events: list[dict] = []
+        task = asyncio.create_task(serve(Idle(), incoming, events.append))
+        await incoming.put({"type": "interrupt"})  # nothing running
+        await asyncio.sleep(0.02)
+        await incoming.put(None)
+        await asyncio.wait_for(task, 2)
+        return events
+
+    assert asyncio.run(drive()) == []
+
+
+def test_real_agent_interrupt_forwards_to_the_sdk_client():
+    """RealAgent.interrupt() forwards to the persistent SDK client and returns
+    True so the runner does not also cancel; no client → False (runner cancels)."""
+    from app.agent.real_agent import RealAgent
+
+    class FakeClient:
+        def __init__(self):
+            self.called = False
+
+        async def interrupt(self):
+            self.called = True
+
+    async def drive():
+        agent = RealAgent.__new__(RealAgent)  # skip __init__ (no project on disk)
+        agent._client = None
+        assert await agent.interrupt() is False  # nothing to stop
+
+        fake = FakeClient()
+        agent._client = fake
+        assert await agent.interrupt() is True
+        assert fake.called
+
+    asyncio.run(drive())
+
+
+def test_mock_agent_cannot_self_stop():
+    from app.agent.mock_agent import MockAgent
+
+    agent = MockAgent.__new__(MockAgent)
+    assert asyncio.run(agent.interrupt()) is False

--- a/apps/server/tests/test_sandbox_server.py
+++ b/apps/server/tests/test_sandbox_server.py
@@ -187,6 +187,76 @@ def test_token_ttl_outlives_the_sandbox_timeout():
     assert DEFAULT_TTL_SECONDS > _RUNNING_TIMEOUT_S
 
 
+def test_reconnect_is_told_when_a_turn_is_still_running(monkeypatch):
+    """The fix for the 2026-07-20 "no working indicator" report: busy is otherwise
+    local to the browser that hit Send, so a reload mid-turn shows idle while the
+    agent works. The Hub outlives the connection and announces an in-flight turn
+    to every (re)connect; when nothing is running it stays quiet.
+    """
+    import app.sandbox_server as ss
+
+    monkeypatch.setattr(ss, "SECRET", "")  # auth disabled → handshake passes
+
+    sent: list[dict] = []
+
+    class FakeReq:
+        path = "/?token=x"
+
+    class FakeWS:
+        request = FakeReq()
+
+        async def send(self, payload):
+            sent.append(json.loads(payload))
+
+        async def close(self, *a):
+            pass
+
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            raise StopAsyncIteration  # no client→server messages; connection ends
+
+    async def noop(*a, **k):
+        pass
+
+    def states():
+        return [m.get("state") for m in sent if m.get("type") == "status"]
+
+    hub = ss.Hub()
+    hub._turn_active = True
+    monkeypatch.setattr(hub, "ensure_started", noop)
+    monkeypatch.setattr(hub, "send_snapshot", noop)
+    asyncio.run(hub.handle(FakeWS()))
+    assert "chat_ready" in states() and "turn_active" in states()
+
+    sent.clear()
+    idle = ss.Hub()  # nothing running
+    monkeypatch.setattr(idle, "ensure_started", noop)
+    monkeypatch.setattr(idle, "send_snapshot", noop)
+    asyncio.run(idle.handle(FakeWS()))
+    assert "chat_ready" in states() and "turn_active" not in states()
+
+
+def test_turn_active_clears_when_the_turn_finishes():
+    """turn_done in the agent stream ends the in-flight state, so a reconnect
+    after the turn completes is not falsely told a turn is running."""
+    import app.sandbox_server as ss
+
+    class FakeProc:
+        def poll(self):
+            return 0
+
+    hub = ss.Hub()
+    hub._turn_active = True
+    q: asyncio.Queue = asyncio.Queue()
+    q.put_nowait(json.dumps({"type": "agent_event", "event": {"kind": "turn_done"}}))
+    q.put_nowait(None)
+    # proc is not hub._proc, so the crash path is skipped.
+    asyncio.run(hub._pump(q, FakeProc()))
+    assert hub._turn_active is False
+
+
 def test_rejection_log_is_throttled_to_protect_the_timeline():
     """A token-locked client reconnects in a tight loop; without throttling its
     rejections fill the 20 KB /logs window and evict the agent activity timeline

--- a/apps/web/src/components/ChatPane.tsx
+++ b/apps/web/src/components/ChatPane.tsx
@@ -63,6 +63,7 @@ export default function ChatPane({
   const [elapsed, setElapsed] = useState(0)
   const turnStartRef = useRef(0)
   const [activity, setActivity] = useState<AgentActivity | null>(null)
+  const [connState, setConnState] = useState<'open' | 'reconnecting'>('open')
 
   // Append agent_event content onto the last assistant message (the streaming one).
   const applyEvent = (ev: Record<string, unknown>): void => {
@@ -153,8 +154,16 @@ export default function ChatPane({
         // during history replay; live input is added locally in send().
         setMessages((prev) => [...prev, { role: 'user', text: String(msg.text ?? ''), tools: [] }])
       else if (msg.type === 'status' && msg.state === 'chat_ready') setReady(true)
+      // A turn was already running when we (re)connected — a reload mid-turn, or
+      // a second tab. Without this the indicator is idle while the agent works,
+      // because busy is otherwise set only locally in send(). turn_done clears it.
+      else if (msg.type === 'status' && msg.state === 'turn_active') setBusy(true)
+      else if (msg.type === 'conn_state') setConnState(msg.state as 'open' | 'reconnecting')
       else if (msg.type === 'status' && msg.state === 'chat_error') {
         setReady(false)
+        // Reconnect attempts are over — stop the "Reconnecting…" spinner so the
+        // error message below carries the state instead of a stuck indicator.
+        setConnState('open')
         applyEvent({ kind: 'error', text: `Chat unavailable: ${msg.message ?? 'unknown error'}` })
         applyEvent({ kind: 'turn_done' })
       }
@@ -186,6 +195,14 @@ export default function ChatPane({
     conn.send({ type: 'user_msg', text: trimmed })
     setBusy(true)
     setInput('')
+  }
+
+  // Ask the agent to abort the running turn. The runner forwards this to the SDK
+  // (or cancels the mock); either way the turn ends with turn_done, which clears
+  // busy. Fire-and-forget — the button reflects intent, turn_done confirms it.
+  const stop = (): void => {
+    if (!busy) return
+    conn.send({ type: 'interrupt' })
   }
 
   // Upload a document/image, then tell the agent where it landed. The upload
@@ -262,16 +279,24 @@ export default function ChatPane({
             )}
           </div>
         ))}
-        {busy && (
-          <div className="typing">
-            ●●●{' '}
-            {activity
-              ? `${activity.agent}${activity.lastTool ? ` · ${activity.lastTool}` : ''}${
-                  activity.toolUses ? ` · ${activity.toolUses} tools` : ''
-                }`
-              : 'working…'}{' '}
-            {elapsed}s
-          </div>
+        {/* One status line, three distinct states. Reconnecting is shown even
+            when a turn wasn't running, because a dropped socket is worth knowing
+            about; it takes priority over "working" so a stall never masquerades
+            as progress (the failure mode that hid the 2026-07-20 disconnect). */}
+        {connState === 'reconnecting' ? (
+          <div className="typing">●●● Reconnecting…</div>
+        ) : (
+          busy && (
+            <div className="typing">
+              ●●●{' '}
+              {activity
+                ? `${activity.agent}${activity.lastTool ? ` · ${activity.lastTool}` : ''}${
+                    activity.toolUses ? ` · ${activity.toolUses} tools` : ''
+                  }`
+                : 'working…'}{' '}
+              {elapsed}s
+            </div>
+          )
         )}
       </div>
 
@@ -316,9 +341,17 @@ export default function ChatPane({
             }
           }}
         />
-        <button className="chatSend" type="submit" disabled={busy || !input.trim()}>
-          Send
-        </button>
+        {/* While a turn runs, Send becomes Stop — the only escape from a long
+            turn used to be a page reload (interrupt was a no-op end to end). */}
+        {busy ? (
+          <button className="chatStop" type="button" onClick={stop} title="Stop the current turn">
+            Stop
+          </button>
+        ) : (
+          <button className="chatSend" type="submit" disabled={!input.trim()}>
+            Send
+          </button>
+        )}
       </form>
     </div>
   )

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -627,6 +627,23 @@ button {
 .chatSend:disabled {
   opacity: 0.5;
 }
+/* Replaces Send while a turn is running (interrupt). Muted rather than accented
+   so it reads as a secondary "abort", not the primary action. */
+.chatStop {
+  align-self: stretch;
+  background: var(--bg-card);
+  color: var(--ink);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 0 16px;
+  font-weight: 600;
+  font-size: 13px;
+  cursor: pointer;
+}
+.chatStop:hover {
+  border-color: var(--accent-soft);
+  color: var(--accent);
+}
 /* Attach a document/image for the agent to read (uploads/ in the project). */
 .chatAttach {
   align-self: stretch;

--- a/apps/web/src/transport/SessionConnection.ts
+++ b/apps/web/src/transport/SessionConnection.ts
@@ -106,6 +106,10 @@ export class WsSessionConnection implements SessionConnection {
     )
   }
 
+  private emitConn(state: 'open' | 'reconnecting'): void {
+    for (const l of [...this.listeners]) l({ type: 'conn_state', state })
+  }
+
   private scheduleRetry(): void {
     this.attempts += 1
     if (this.attempts > MAX_RETRIES) {
@@ -127,6 +131,10 @@ export class WsSessionConnection implements SessionConnection {
       this.attempts = 0
       for (const m of this.outbox) ws.send(m)
       this.outbox = []
+      // Synthetic, client-only. Lets the UI tell "the agent is working" apart
+      // from "the socket dropped and we're retrying" — otherwise a silent
+      // reconnect looks identical to a busy agent (the 2026-07-20 confusion).
+      this.emitConn('open')
     }
     ws.onmessage = (ev) => {
       let msg: WsMessage
@@ -145,6 +153,7 @@ export class WsSessionConnection implements SessionConnection {
       // paused sandbox, billing compute for a tab nobody is viewing. onVisibility
       // reconnects when the tab is focused again.
       if (this.hidden) return
+      this.emitConn('reconnecting')
       this.scheduleRetry()
     }
     ws.onerror = () => {

--- a/docs/TODOs.md
+++ b/docs/TODOs.md
@@ -61,13 +61,13 @@ recorded so it can be re-examined rather than re-derived.
   derived secret has changed, or a key-id in the token so the sandbox can verify
   against the key that minted it. Not urgent: rotation is rare and the alpha hang
   was TTL expiry, not rotation.
-- [ ] **`working… <N>s` does not distinguish working from disconnected** —
-  the timer is entirely client-side (`ChatPane.tsx`): `send()` starts it and only
-  `turn_done` stops it, so a socket that is closed, retrying, or being rejected
-  looks identical to an agent that is busy. In the 2026-07-20 hang it read
-  "working… 612s" while no socket was open at all, which is what sent the
-  investigation after the agent instead of the transport. `SessionConnection`
-  already knows its state; surface it so the indicator can say "Reconnecting…".
+- [ ] **`tool_result` is correlated to its chip by tool NAME, not id** —
+  `real_agent.map_message` resolves `tool_use_id → name` correctly, then
+  `ChatPane` re-matches with `findIndex((t) => t.tool === ev.tool && !t.done)`.
+  Parallel calls to the same tool (several `mcp__genealogy__*` searches at once,
+  or two subagents both running `Bash`) mark the wrong chip done. The id is
+  available at the boundary and is discarded; carry it into the event and match
+  on it. Cosmetic today, but it misreports which call is still running.
 - [ ] **Operator misconfiguration reaches the user as a raw SDK error string** —
   when the Agent SDK's first call fails auth, `real_agent.handle_turn` wraps the
   exception verbatim (`_event("error", text=f"Agent error: {exc}")`) and


### PR DESCRIPTION
Stacked on #764 (which is stacked on #763). Review those first; the base retargets as they merge.

Addresses the three follow-ups from the hang investigation. The rate-limit ask went into #763; these three are here.

## 1. Interrupt actually stops a turn

It was a no-op **end to end**, for a reason neither earlier note caught: the runner's loop blocked inside `handle_turn` and never read stdin until the turn it was meant to stop had already finished. So the interrupt line sat unread in the pipe.

The loop is now split — a reader task drains stdin into a queue **concurrently** with the running turn — so an interrupt mid-turn is acted on immediately. `agent.interrupt()` forwards to the SDK's control channel (`RealAgent`), whose stream then ends on its own; the mock can't self-stop, so it's cancelled and reports `(stopped)`. Both paths still end in exactly one `turn_done`, which is what clears the client's busy state.

## 2. A Stop button

While a turn runs, **Send becomes Stop** and sends the interrupt. Previously the only escape from a long turn was a page reload.

## 3. The indicator distinguishes working from disconnected — and survives reload

Two bugs here, and the second is your incidental:

- The indicator was purely client-local: `send()` set `busy`, only `turn_done` cleared it. A closed or reconnecting socket looked identical to a busy agent — which is exactly why the hang read `working… 612s` over a socket that wasn't open. `SessionConnection` now emits `conn_state`, and the line shows **"Reconnecting…"** (priority, so a stall never masquerades as progress) vs the working line.
- **`busy` didn't survive a reload** — it lived only in the browser that hit Send. That's why during the actual record-extraction (after you'd reloaded) there was *no* indicator at all; the `612s` you saw was the follow-up you typed. The **Hub** (which outlives any one connection) now tracks whether a turn is running and tells every reconnect, so a reload mid-turn shows "working" instead of idle.

With the streaming PR's task-progress events present, the line reads `record-extractor · person_read · 12 tools`; without them it falls back to `working… Ns`.

## Tests

`make server-test` 87 passed. New: runner interrupt (SDK-style ends itself; unstoppable is cancelled → `(stopped)`; idle interrupt ignored; normal completion unaffected), `RealAgent.interrupt` forwards to the SDK client, the `turn_active` flag is announced on reconnect and cleared on `turn_done`. `pnpm typecheck` 5/5.

## Deploy

Touches `apps/server/app/agent` + `sandbox_server.py` (`SANDBOX_IMAGE_SOURCES`) — needs **`make sandbox-image`**, like #764.

## TODOs removed (now implemented)

Both the `interrupt` no-op and the `working… <N>s` indistinguishability entries.

## Still deferred

`tool_result`→chip correlation is still by tool name, not id (parallel same-tool calls mark the wrong chip done). Independent and cosmetic; left as a TODO.

🤖 Generated with [Claude Code](https://claude.com/claude-code)