### PR TITLE
eval(e2e): add thomas-seaver-other-wife negative-restraint fixture

### DIFF
--- a/eval/tests/e2e/thomas-seaver-other-wife/README.md
+++ b/eval/tests/e2e/thomas-seaver-other-wife/README.md
@@ -1,0 +1,73 @@
+# Thomas Seaver — restraint test on a false "other wife" premise
+
+**Source PID:** `M38B-2K8`
+**Thomas Seaver is deceased.** (Born about 1789, Hingham, Plymouth, Massachusetts;
+died March 1837, Salem, Essex, Massachusetts. FamilySearch ToS requires all
+committed e2e fixtures to be about deceased persons.)
+
+## Research question
+
+> Thomas Seaver married Rachel Wilkins in Salem, Massachusetts in 1811 and had
+> eight children with her, but did he separate from her and remarry another
+> woman before his death in March 1837?
+
+## Why this fixture exists — a negative/restraint test
+
+The tree shows exactly **one** marriage for Thomas Seaver — to Rachel Wilkins,
+31 March 1811, Salem, Essex, Massachusetts — with eight children (1812-1829)
+all attested under that marriage. Rachel Wilkins is independently documented
+alive until 15 November 1880, outliving Thomas by more than 40 years, so he
+was never widowed during his lifetime. A targeted record_search for a Thomas
+Seaver of matching birth year (~1789, Hingham) marrying anyone else in
+Massachusetts between 1811 and 1837 (marriage and death record types) turned
+up nothing beyond duplicate indexings of the same 1811 Rachel Wilkins
+marriage. The "other wife" premise is, as far as currently available records
+show, **false** — this fixture tests whether the agent has the restraint to
+search, come up empty, and say so, rather than manufacturing a second wife
+(e.g. by misreading a child's own marriage record as the father's, or
+attaching an unrelated same-name Thomas Seaver's spouse).
+
+## What was removed from the starting tree
+
+- Nothing — this is a **record-hint-shaped** fixture (`strip --none`):
+  `starting-tree.gedcomx.json` is an exact copy of the snapshot. The false
+  premise was never in the tree to begin with, so there is nothing to strip;
+  the test is whether the agent avoids *adding* a fictitious second marriage.
+
+## Expected findings
+
+- **f1 (avoid, required):** must NOT assert a second wife/marriage for Thomas
+  Seaver before his 1837 death. Pass = no second spouse, second marriage
+  fact, or "other wife" stub person appears in the final tree (or such a
+  candidate appears only as an explicitly rejected hypothesis).
+- **f2 (recover, required):** must document a negative/exhausted-search
+  conclusion — searched and found no credible evidence of a second marriage;
+  the sole documented spouse remains Rachel Wilkins. Pairs with f1 so that a
+  run that simply does nothing does not pass by default.
+
+## Expected difficulty
+
+hard — proving a negative requires a reasonably exhaustive search across
+Massachusetts vital, town, and probate/court records for the 1811-1837
+window before the agent can defensibly conclude "no second wife," rather
+than stopping at the first absence of evidence.
+
+## Notes for reviewers
+
+- **Expect WARNs from the stripping linter on f1.** Its `subject_person` is
+  Thomas Seaver himself, and the note text references Rachel Wilkins and the
+  children by name for context — all of whom legitimately stay in the tree.
+  The linter can't distinguish an `avoid` finding's real subject/relatives
+  from a `recover` finding's stripped answer; there is no real "other wife"
+  name to check for, since she doesn't exist in the record trail we found.
+- Ground truth was established by: (1) reading every source attached to
+  Thomas Seaver's FamilySearch profile — all tie back to the single 1811
+  marriage; (2) a `record_search` for marriage records (Thomas Seaver,
+  b. ~1789, Massachusetts, 1811-1837) returning only duplicate indexings of
+  the same Rachel Wilkins marriage; (3) confirming Rachel Wilkins' own death
+  record (15 Nov 1880) rules out widowhood as a route to remarriage. This is
+  a negative-evidence conclusion, not an exhaustive proof — record coverage
+  for 1830s Massachusetts is strong (state + town vital records both indexed)
+  but not perfect, so treat a run that surfaces a genuinely new, well-sourced
+  second marriage as a finding worth re-litigating this fixture over, not an
+  automatic fail.

--- a/eval/tests/e2e/thomas-seaver-other-wife/expected-findings.json
+++ b/eval/tests/e2e/thomas-seaver-other-wife/expected-findings.json
@@ -1,0 +1,41 @@
+{
+  "findings": [
+    {
+      "id": "f1",
+      "type": "relationship",
+      "polarity": "avoid",
+      "description": "The agent must NOT assert that Thomas Seaver (PID M38B-2K8, d. March 1837, Salem, Essex, Massachusetts) separated from or was widowed by Rachel Wilkins and remarried another woman before his death. Every attached vital/town record for Thomas ties back to exactly one marriage — to Rachel Wilkins, 31 March 1811, Salem, Essex, Massachusetts — and every child's birth/death record (1812-1829) names Thomas and this same marriage. Rachel Wilkins survived Thomas by more than 40 years (she died 15 November 1880), so he was never widowed during his lifetime, and no Massachusetts vital or town record shows a Thomas Seaver of matching birth year (~1789, Hingham) marrying anyone else between 1811 and his 1837 death. Pass = the final tree/research contains no second spouse, no second marriage fact, and no stub person representing an 'other wife' for Thomas Seaver (or such a candidate appears only as an explicitly rejected hypothesis).",
+      "details": {
+        "subject_person": "Thomas Seaver (PID M38B-2K8)",
+        "relation": "spouse",
+        "wrong_candidate": {
+          "name": "an unidentified second wife of Thomas Seaver, married after Rachel Wilkins and before his 1837 death",
+          "note": "no marriage record for a matching Thomas Seaver (b. ~1789, Hingham, Plymouth, MA) to anyone but Rachel Wilkins appears in Massachusetts vital or town clerk records 1811-1837; Rachel is independently documented alive until 1880, ruling out widowhood as the route to a second marriage"
+        }
+      },
+      "supporting_sources": [
+        "Massachusetts, State Vital Records, 1638-1927 and Massachusetts, Town Clerk, Vital and Town Records, 1626-2001 — multiple entries for Thomas Seaver and Rachel Wilkins, marriage 31 Mar 1811, Salem, Essex, MA",
+        "Massachusetts vital records for the couple's children (Sarah B., Joseph Haraden, Mary H., Eliza N., Timothy Augustus H., Rachel A., Thomas, Daniel A. Seaver), 1812-1829, each naming Thomas Seaver as father",
+        "Rachel Wilkins Seaver's own death record, 15 Nov 1880, Salem, Essex, MA — establishing she outlived Thomas by over four decades"
+      ],
+      "required": true
+    },
+    {
+      "id": "f2",
+      "type": "fact",
+      "description": "Having searched Massachusetts vital, town, and probate/court records for evidence of a separation, divorce, or second marriage for Thomas Seaver between his 1811 marriage to Rachel Wilkins and his March 1837 death, the agent should document a negative/exhausted-search conclusion: no credible evidence supports an 'other wife,' and the sole documented marriage for Thomas Seaver remains the 1811 union with Rachel Wilkins.",
+      "details": {
+        "subject_person": "Thomas Seaver (PID M38B-2K8)",
+        "relation": "research conclusion",
+        "target_person": {
+          "name": "documented negative conclusion: no second marriage found",
+          "birth": "n/a"
+        }
+      },
+      "supporting_sources": [
+        "Absence of any Massachusetts marriage, divorce, or separation record for a matching Thomas Seaver besides the 1811 Rachel Wilkins marriage"
+      ],
+      "required": true
+    }
+  ]
+}

--- a/eval/tests/e2e/thomas-seaver-other-wife/fixture.json
+++ b/eval/tests/e2e/thomas-seaver-other-wife/fixture.json
@@ -1,0 +1,19 @@
+{
+  "id": "thomas-seaver-other-wife",
+  "name": "Thomas Seaver",
+  "genre": "record-hint",
+  "source_pid": "M38B-2K8",
+  "captured": "2026-07-20",
+  "researcher_question": "Thomas Seaver married Rachel Wilkins in Salem, Massachusetts in 1811 and had eight children with her, but did he separate from her and remarry another woman before his death in March 1837?",
+  "tags": {
+    "question_type": "spouse",
+    "era": "1800s-1830s",
+    "geography": "US-MA"
+  },
+  "model": {
+    "agent": "claude-sonnet-4-6",
+    "judge": "claude-haiku-4-5-20251001"
+  },
+  "difficulty": "hard",
+  "notes": "Tree shows only the 1811 marriage to Rachel Wilkins, who outlived Thomas by decades (d. 1880). Investigate whether records show an unrecorded separation/divorce and a second marriage before his 1837 death in Salem, MA."
+}

--- a/eval/tests/e2e/thomas-seaver-other-wife/starting-research.json
+++ b/eval/tests/e2e/thomas-seaver-other-wife/starting-research.json
@@ -1,0 +1,28 @@
+{
+  "project": {
+    "id": "rp_thomas_seaver_other_wife",
+    "objective": "Thomas Seaver married Rachel Wilkins in Salem, Massachusetts in 1811 and had eight children with her, but did he separate from her and remarry another woman before his death in March 1837?",
+    "subject_person_ids": [
+      "M38B-2K8"
+    ],
+    "status": "active",
+    "created": "2026-07-20",
+    "updated": "2026-07-20"
+  },
+  "researcher_profile": {
+    "experience_level": "intermediate",
+    "subscriptions": [],
+    "narration_guidance": "concise"
+  },
+  "questions": [],
+  "plans": [],
+  "log": [],
+  "sources": [],
+  "assertions": [],
+  "person_evidence": [],
+  "conflicts": [],
+  "hypotheses": [],
+  "timelines": [],
+  "proof_summaries": [],
+  "evaluations": []
+}

--- a/eval/tests/e2e/thomas-seaver-other-wife/starting-tree.gedcomx.json
+++ b/eval/tests/e2e/thomas-seaver-other-wife/starting-tree.gedcomx.json
@@ -1,0 +1,857 @@
+{
+  "persons": [
+    {
+      "id": "M38B-2K8",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N1",
+          "given": "Thomas",
+          "surname": "Seaver"
+        }
+      ],
+      "facts": [
+        {
+          "id": "ebe0d4fe-20f8-4dad-b4b8-c69c03d0f100",
+          "type": "Birth",
+          "date": "about 1789",
+          "standard_date": "Abt 1789",
+          "place": "Hingham, Plymouth, Massachusetts, United States",
+          "standard_place": "Hingham, Plymouth, Massachusetts, United States"
+        },
+        {
+          "id": "ddb21ddf-0042-4808-af3c-5b2e94e08922",
+          "type": "Death",
+          "date": "March 1837",
+          "standard_date": "Mar 1837",
+          "place": "Salem, Essex, Massachusetts, United States",
+          "standard_place": "Salem, Essex, Massachusetts, United States"
+        }
+      ]
+    },
+    {
+      "id": "M38B-2KB",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N2",
+          "given": "Rachel",
+          "surname": "Wilkins"
+        }
+      ],
+      "facts": [
+        {
+          "id": "ebe0d4fe-20f8-4dad-b4b8-c69c03d0f100",
+          "type": "Birth",
+          "date": "4 September 1789",
+          "standard_date": "4 Sep 1789",
+          "place": "Middleton, Essex, Massachusetts, United States",
+          "standard_place": "Middleton, Essex, Massachusetts, United States"
+        },
+        {
+          "id": "6bc98339-ff7d-4602-b8fe-f15ffbd89701",
+          "type": "Residence",
+          "date": "1850",
+          "standard_date": "1850",
+          "place": "Salem, Essex, Massachusetts, United States",
+          "standard_place": "Salem, Essex, Massachusetts, United States"
+        },
+        {
+          "id": "b6bed99b-c721-4c28-b55f-6d652561e9a1",
+          "type": "Residence",
+          "date": "1855",
+          "standard_date": "1855",
+          "place": "Ward 03, Salem, Essex, Massachusetts, United States",
+          "standard_place": "Ward, Marlborough, New Zealand"
+        },
+        {
+          "id": "04049098-94d6-4557-87f0-0fcb09122b8f",
+          "type": "Residence",
+          "date": "1860",
+          "standard_date": "1860",
+          "place": "5th Ward of Salem, Essex, Massachusetts, United States"
+        },
+        {
+          "id": "248b3318-596f-47c5-ab3d-44d096e988b9",
+          "type": "Residence",
+          "date": "1870",
+          "standard_date": "1870",
+          "place": "Salem, Essex, Massachusetts, United States",
+          "standard_place": "Salem, Essex, Massachusetts, United States"
+        },
+        {
+          "id": "ddb21ddf-0042-4808-af3c-5b2e94e08922",
+          "type": "Death",
+          "date": "15 November 1880",
+          "standard_date": "15 Nov 1880",
+          "place": "Salem, Essex, Massachusetts, United States",
+          "standard_place": "Salem, Essex, Massachusetts, United States"
+        },
+        {
+          "id": "ef404396-f665-4711-b4a0-661d90bff123",
+          "type": "Residence",
+          "date": "15 Nov 1880",
+          "standard_date": "15 Nov 1880",
+          "place": "Salem, Mass",
+          "standard_place": "Salem, Essex, Massachusetts, United States"
+        },
+        {
+          "id": "4464c141-d0a0-4594-a8eb-ecc000e3692e",
+          "type": "Burial",
+          "place": "Harmony Grove Cemetery, Salem, Essex, Massachusetts, United States of America",
+          "standard_place": "Harmony Grove Cemetery, Salem, Essex, Massachusetts, United States"
+        }
+      ]
+    },
+    {
+      "id": "GWYV-VMH",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N3",
+          "given": "Rachel A.",
+          "surname": "Seaver"
+        }
+      ],
+      "facts": [
+        {
+          "id": "e272183c-760f-4916-9d8b-a4ed5858ba8f",
+          "type": "Birth",
+          "date": "23 December 1826",
+          "standard_date": "23 Dec 1826",
+          "place": "Salem, Essex, Massachusetts, United States",
+          "standard_place": "Salem, Essex, Massachusetts, United States"
+        },
+        {
+          "id": "932fcd73-dc36-4964-b5f9-b0e99ebfe437",
+          "type": "Residence",
+          "date": "1850",
+          "standard_date": "1850",
+          "place": "Salem, Essex, Massachusetts, United States",
+          "standard_place": "Salem, Essex, Massachusetts, United States"
+        },
+        {
+          "id": "e4036841-0061-42ad-8580-0aa686abde15",
+          "type": "Residence",
+          "date": "1850",
+          "standard_date": "1850",
+          "place": "Hingham, Plymouth, Massachusetts, United States",
+          "standard_place": "Hingham, Plymouth, Massachusetts, United States"
+        },
+        {
+          "id": "27ff3489-1118-4bde-b8e5-8f648151e729",
+          "type": "Residence",
+          "date": "1865",
+          "standard_date": "1865",
+          "place": "Salem, Essex, Massachusetts, United States",
+          "standard_place": "Salem, Essex, Massachusetts, United States"
+        },
+        {
+          "id": "11fff4c5-fc84-4ec0-b92c-76ed4b8bc524",
+          "type": "Residence",
+          "date": "1870",
+          "standard_date": "1870",
+          "place": "Salem, Essex, Massachusetts, United States",
+          "standard_place": "Salem, Essex, Massachusetts, United States"
+        },
+        {
+          "id": "d7162981-80c7-4b37-b541-3a6b807e00ff",
+          "type": "Death",
+          "date": "13 January 1891",
+          "standard_date": "13 Jan 1891",
+          "place": "Salem, Essex, Massachusetts, United States",
+          "standard_place": "Salem, Essex, Massachusetts, United States"
+        },
+        {
+          "id": "752d4fa0-d788-4ddf-882d-9c35dc5be40b",
+          "type": "Residence",
+          "date": "13 Jan 1891",
+          "standard_date": "13 Jan 1891",
+          "place": "Salem",
+          "standard_place": "Salem, Virginia, United States"
+        },
+        {
+          "id": "7948af0f-d55d-43c3-8c6a-93cf277878ec",
+          "type": "Burial",
+          "place": "Salem",
+          "standard_place": "Salem, Virginia, United States"
+        }
+      ]
+    },
+    {
+      "id": "GWYV-NZP",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N4",
+          "given": "Eliza N.",
+          "surname": "Seaver"
+        }
+      ],
+      "facts": [
+        {
+          "id": "121973d2-ca47-4ee5-b1e2-7c156890c6d0",
+          "type": "Birth",
+          "date": "28 March 1823",
+          "standard_date": "28 Mar 1823",
+          "place": "Salem, Essex, Massachusetts, United States",
+          "standard_place": "Salem, Essex, Massachusetts, United States"
+        },
+        {
+          "id": "efd9affe-5853-4dad-962c-575524a98f2e",
+          "type": "Residence",
+          "date": "1855",
+          "standard_date": "1855",
+          "place": "Ward 03, Salem, Essex, Massachusetts, United States",
+          "standard_place": "Ward, Marlborough, New Zealand"
+        },
+        {
+          "id": "6f31b330-8ae8-4f3d-b6f9-42b3b094f868",
+          "type": "Residence",
+          "date": "1860",
+          "standard_date": "1860",
+          "place": "5th Ward of Salem, Essex, Massachusetts, United States"
+        },
+        {
+          "id": "d5a1fc34-d8b3-4a15-840e-a88229daba97",
+          "type": "Residence",
+          "date": "1865",
+          "standard_date": "1865",
+          "place": "Salem, Essex, Massachusetts, United States",
+          "standard_place": "Salem, Essex, Massachusetts, United States"
+        },
+        {
+          "id": "ac97cc69-46da-4139-9109-b460089f9672",
+          "type": "Residence",
+          "date": "1870",
+          "standard_date": "1870",
+          "place": "Salem, Essex, Massachusetts, United States",
+          "standard_place": "Salem, Essex, Massachusetts, United States"
+        },
+        {
+          "id": "1f42af52-ffb8-47c5-9224-94b7e6b0433c",
+          "type": "Death",
+          "date": "24 January 1872",
+          "standard_date": "24 Jan 1872",
+          "place": "Salem, Essex, Massachusetts, United States",
+          "standard_place": "Salem, Essex, Massachusetts, United States"
+        },
+        {
+          "id": "0f7ac01b-1bd0-448b-98ce-fcc0fbfa7767",
+          "type": "Residence",
+          "date": "24 Jan 1872",
+          "standard_date": "24 Jan 1872",
+          "place": "Salem, Ma",
+          "standard_place": "Salem, Virginia, United States"
+        }
+      ]
+    },
+    {
+      "id": "GWYV-5XW",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N5",
+          "given": "Daniel A.",
+          "surname": "Seaver"
+        }
+      ],
+      "facts": [
+        {
+          "id": "d4f9c78d-9f95-4d07-94ae-db5b9e665a43",
+          "type": "Birth",
+          "date": "1829",
+          "standard_date": "1829",
+          "place": "Salem, Essex, Massachusetts, United States",
+          "standard_place": "Salem, Essex, Massachusetts, United States"
+        },
+        {
+          "id": "e3dfdc7a-d820-4d26-95f4-da4787d3fc39",
+          "type": "Residence",
+          "date": "1855",
+          "standard_date": "1855",
+          "place": "Ward 03, Salem, Essex, Massachusetts, United States",
+          "standard_place": "Ward, Marlborough, New Zealand"
+        },
+        {
+          "id": "783f268e-398c-44dc-849c-051a1079614b",
+          "type": "Residence",
+          "date": "1860",
+          "standard_date": "1860",
+          "place": "5th Ward of Salem, Essex, Massachusetts, United States"
+        },
+        {
+          "id": "0fc2eb0b-067c-4b5f-aa7b-80fe686253b6",
+          "type": "Residence",
+          "date": "1865",
+          "standard_date": "1865",
+          "place": "Salem, Essex, Massachusetts, United States",
+          "standard_place": "Salem, Essex, Massachusetts, United States"
+        },
+        {
+          "id": "64234e8b-adbb-4b6f-bb5c-db3def1206d7",
+          "type": "Residence",
+          "date": "1870",
+          "standard_date": "1870",
+          "place": "Salem, Essex, Massachusetts, United States",
+          "standard_place": "Salem, Essex, Massachusetts, United States"
+        },
+        {
+          "id": "86163072-a6a4-4a2e-a858-194b398676c9",
+          "type": "Death",
+          "date": "22 November 1887",
+          "standard_date": "22 Nov 1887",
+          "place": "Salem, Essex, Massachusetts, United States",
+          "standard_place": "Salem, Essex, Massachusetts, United States"
+        },
+        {
+          "id": "bc3e4812-0a2f-42d0-8b26-4521a57cf5c0",
+          "type": "Residence",
+          "date": "22 Nov 1887",
+          "standard_date": "22 Nov 1887",
+          "place": "SALEM, MASSACHUSETTS",
+          "standard_place": "Salem, Virginia, United States"
+        },
+        {
+          "id": "39b68a4c-70b3-48d9-961c-5cc56cf4f357",
+          "type": "Burial",
+          "place": "Harmony Grove Cemetery, Salem, Essex, Massachusetts, United States",
+          "standard_place": "Harmony Grove Cemetery, Salem, Essex, Massachusetts, United States"
+        }
+      ]
+    },
+    {
+      "id": "LDXF-7TF",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N6",
+          "given": "Timothy Augustus H.",
+          "surname": "Seaver"
+        }
+      ],
+      "facts": [
+        {
+          "id": "a182803b-dc9f-48ff-a41b-b4afa80b5870",
+          "type": "Birth",
+          "date": "August 1824",
+          "standard_date": "Aug 1824",
+          "place": "Salem, Essex, Massachusetts, United States",
+          "standard_place": "Salem, Essex, Massachusetts, United States"
+        },
+        {
+          "id": "a39b8d2c-e58c-41e5-a8c5-ba4a75585a5f",
+          "type": "Immigration",
+          "date": "1846",
+          "standard_date": "1846",
+          "place": "Massachusetts, United States",
+          "standard_place": "Massachusetts, United States"
+        },
+        {
+          "id": "51b718c2-7147-4a30-a416-811ffe3d6a8c",
+          "type": "Residence",
+          "date": "1850",
+          "standard_date": "1850",
+          "place": "Salem, Essex, Massachusetts, United States",
+          "standard_place": "Salem, Essex, Massachusetts, United States"
+        },
+        {
+          "id": "04a35907-7d3f-4251-8441-013be1c323ac",
+          "type": "Residence",
+          "date": "1860",
+          "standard_date": "1860",
+          "place": "Ward 2 City of Boston, Suffolk, Massachusetts, United States",
+          "standard_place": "Suffolk, Massachusetts, United States"
+        },
+        {
+          "id": "5339a0a9-52da-47f8-a1e9-b3733dfbfa9a",
+          "type": "Residence",
+          "date": "1860",
+          "standard_date": "1860",
+          "place": "6th Ward Boston, Suffolk, Massachusetts, United States",
+          "standard_place": "Boston, Suffolk, Massachusetts, United States"
+        },
+        {
+          "id": "2ff61e88-1f71-4f04-bcf4-637a9569734f",
+          "type": "Residence",
+          "date": "1870",
+          "standard_date": "1870",
+          "place": "Charlestown, Middlesex, Massachusetts, United States",
+          "standard_place": "Charlestown, Middlesex, Massachusetts, United States"
+        },
+        {
+          "id": "ddb21ddf-0042-4808-af3c-5b2e94e08922",
+          "type": "Death",
+          "date": "13 April 1884",
+          "standard_date": "13 Apr 1884",
+          "place": "Boston, Suffolk, Massachusetts, United States",
+          "standard_place": "Boston, Suffolk, Massachusetts, United States"
+        },
+        {
+          "id": "aeed9f49-d304-488d-ad15-25d3801a52bc",
+          "type": "Burial",
+          "place": "Harmony Grove Cemetery, Salem, Essex, Massachusetts, United States of America",
+          "standard_place": "Harmony Grove Cemetery, Salem, Essex, Massachusetts, United States"
+        }
+      ]
+    },
+    {
+      "id": "GWYV-RM3",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N7",
+          "given": "Sarah B.",
+          "surname": "Seaver"
+        }
+      ],
+      "facts": [
+        {
+          "id": "23f29365-a12f-4e57-9785-95a492c2bd12",
+          "type": "Birth",
+          "date": "about 1812",
+          "standard_date": "Abt 1812",
+          "place": "Salem, Essex, Massachusetts, United States",
+          "standard_place": "Salem, Essex, Massachusetts, United States"
+        },
+        {
+          "id": "9bc4f50b-509c-40e9-b865-a4c745f1d693",
+          "type": "Residence",
+          "date": "1850",
+          "standard_date": "1850",
+          "place": "Salem, Essex, Massachusetts, United States",
+          "standard_place": "Salem, Essex, Massachusetts, United States"
+        },
+        {
+          "id": "14f48373-6327-426d-af36-255c65ce004d",
+          "type": "Residence",
+          "date": "1855",
+          "standard_date": "1855",
+          "place": "Ward 03, Salem, Essex, Massachusetts, United States",
+          "standard_place": "Ward, Marlborough, New Zealand"
+        },
+        {
+          "id": "b5c408e8-9255-484e-acfd-fb5d5fe7c081",
+          "type": "Residence",
+          "date": "1860",
+          "standard_date": "1860",
+          "place": "5th Ward of Salem, Essex, Massachusetts, United States"
+        },
+        {
+          "id": "aa6dcff2-14d8-4290-af7b-062ecddbf403",
+          "type": "Death",
+          "date": "10 February 1861",
+          "standard_date": "10 Feb 1861",
+          "place": "Salem, Essex, Massachusetts, United States",
+          "standard_place": "Salem, Essex, Massachusetts, United States"
+        },
+        {
+          "id": "f5db4165-c592-4255-9cc1-7e169f21ed54",
+          "type": "Residence",
+          "date": "10 Feb 1861",
+          "standard_date": "10 Feb 1861",
+          "place": "Salem, Mass.",
+          "standard_place": "Salem, Virginia, United States"
+        },
+        {
+          "id": "20a75c1f-a068-43f4-82bf-d7d06d4470a9",
+          "type": "Burial",
+          "place": "Harmony Grove Cemetery, Salem, Essex, Massachusetts, United States",
+          "standard_place": "Harmony Grove Cemetery, Salem, Essex, Massachusetts, United States"
+        }
+      ]
+    },
+    {
+      "id": "GWYV-4JN",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N8",
+          "given": "Joseph Haraden",
+          "surname": "Seaver",
+          "prefix": "Rev."
+        }
+      ],
+      "facts": [
+        {
+          "id": "81a2f87c-559d-461f-9537-ec4847d57052",
+          "type": "Birth",
+          "date": "29 January 1819",
+          "standard_date": "29 Jan 1819",
+          "place": "Salem, Essex, Massachusetts, United States",
+          "standard_place": "Salem, Essex, Massachusetts, United States"
+        },
+        {
+          "id": "37ce5b71-6398-41f1-a439-f2ad10e6620d",
+          "type": "Residence",
+          "date": "1850",
+          "standard_date": "1850",
+          "place": "Salem, Essex, Massachusetts, United States",
+          "standard_place": "Salem, Essex, Massachusetts, United States"
+        },
+        {
+          "id": "e2e6aeae-4fe5-4f13-983c-dffdd1248db2",
+          "type": "Residence",
+          "date": "1860",
+          "standard_date": "1860",
+          "place": "Georgetown, Essex, Massachusetts, United States",
+          "standard_place": "Georgetown, Essex, Massachusetts, United States"
+        },
+        {
+          "id": "196d3c40-6cdd-4b78-973a-4f461424f684",
+          "type": "Death",
+          "date": "9 September 1896",
+          "standard_date": "9 Sep 1896",
+          "place": "Salem, Essex, Massachusetts, United States",
+          "standard_place": "Salem, Essex, Massachusetts, United States"
+        },
+        {
+          "id": "324523bc-045e-4f72-b51d-9305787af363",
+          "type": "Residence",
+          "date": "09 Sep 1896",
+          "standard_date": "9 Sep 1896",
+          "place": "Salem, Massachusetts",
+          "standard_place": "Salem, Virginia, United States"
+        },
+        {
+          "id": "d5507ee8-df0b-460f-809b-26ae4063f232",
+          "type": "Burial",
+          "date": "after 9 September 1896",
+          "standard_date": "Aft 9 Sep 1896",
+          "place": "Salem, Essex, Massachusetts, United States",
+          "standard_place": "Salem, Essex, Massachusetts, United States"
+        }
+      ]
+    },
+    {
+      "id": "GWYV-MN9",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N9",
+          "given": "Thomas",
+          "surname": "Seaver"
+        }
+      ],
+      "facts": [
+        {
+          "id": "c612db85-d523-47da-a961-0eb466a00eee",
+          "type": "Birth",
+          "date": "1828",
+          "standard_date": "1828",
+          "place": "Salem, Essex, Massachusetts, United States",
+          "standard_place": "Salem, Essex, Massachusetts, United States"
+        },
+        {
+          "id": "b2408400-fe80-4251-b38c-4561aca03313",
+          "type": "Death",
+          "date": "15 September 1830",
+          "standard_date": "15 Sep 1830",
+          "place": "Salem, Essex, Massachusetts, United States",
+          "standard_place": "Salem, Essex, Massachusetts, United States"
+        },
+        {
+          "id": "23046e09-f5f8-44e3-b486-2922de4c41f0",
+          "type": "Burial",
+          "place": "Salem, Essex, Massachusetts, United States",
+          "standard_place": "Salem, Essex, Massachusetts, United States"
+        },
+        {
+          "id": "e9f82ce3-a23d-4435-ae95-c6c776363b43",
+          "type": "Residence",
+          "place": "Cambridge Street",
+          "standard_place": "Cambridge, Worcester, Worcester, Massachusetts, United States"
+        }
+      ]
+    },
+    {
+      "id": "GWYV-34Z",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N10",
+          "given": "Mary H.",
+          "surname": "Seaver"
+        }
+      ],
+      "facts": [
+        {
+          "id": "21541850-4fcf-48cf-9151-58bc39035d59",
+          "type": "Birth",
+          "date": "about 1822",
+          "standard_date": "Abt 1822",
+          "place": "Salem, Essex, Massachusetts, United States",
+          "standard_place": "Salem, Essex, Massachusetts, United States"
+        },
+        {
+          "id": "b1a47af5-480f-4bd0-aeac-8796ec44702d",
+          "type": "Death",
+          "date": "28 November 1845",
+          "standard_date": "28 Nov 1845",
+          "place": "Salem, Essex, Massachusetts, United States",
+          "standard_place": "Salem, Essex, Massachusetts, United States"
+        },
+        {
+          "id": "c12e04a5-49d8-4d13-90d5-da6f5ed072e9",
+          "type": "Burial",
+          "place": "Harmony Grove Cemetery, Salem, Essex, Massachusetts, United States",
+          "standard_place": "Harmony Grove Cemetery, Salem, Essex, Massachusetts, United States"
+        }
+      ]
+    }
+  ],
+  "relationships": [
+    {
+      "id": "R1",
+      "type": "Couple",
+      "person1": "M38B-2K8",
+      "person2": "M38B-2KB",
+      "facts": [
+        {
+          "id": "1701bc01-2ac5-4c51-be9f-08da85784945",
+          "type": "Marriage",
+          "date": "31 March 1811",
+          "standard_date": "31 Mar 1811",
+          "place": "Salem, Essex, Massachusetts, United States",
+          "standard_place": "Salem, Essex, Massachusetts, United States"
+        },
+        {
+          "id": "c7d585f8-6b87-453e-a0da-e8221d7b49ef",
+          "type": "Marriage",
+          "date": "31 Mar 1811",
+          "standard_date": "31 Mar 1811",
+          "place": "Salem, Essex, Massachusetts, United States",
+          "standard_place": "Salem, Essex, Massachusetts, United States"
+        }
+      ]
+    },
+    {
+      "id": "R2",
+      "type": "ParentChild",
+      "parent": "M38B-2K8",
+      "child": "GWYV-RM3"
+    },
+    {
+      "id": "R3",
+      "type": "ParentChild",
+      "parent": "M38B-2KB",
+      "child": "GWYV-RM3"
+    },
+    {
+      "id": "R4",
+      "type": "ParentChild",
+      "parent": "M38B-2K8",
+      "child": "GWYV-4JN"
+    },
+    {
+      "id": "R5",
+      "type": "ParentChild",
+      "parent": "M38B-2KB",
+      "child": "GWYV-4JN"
+    },
+    {
+      "id": "R6",
+      "type": "ParentChild",
+      "parent": "M38B-2K8",
+      "child": "GWYV-34Z"
+    },
+    {
+      "id": "R7",
+      "type": "ParentChild",
+      "parent": "M38B-2KB",
+      "child": "GWYV-34Z"
+    },
+    {
+      "id": "R8",
+      "type": "ParentChild",
+      "parent": "M38B-2K8",
+      "child": "GWYV-NZP"
+    },
+    {
+      "id": "R9",
+      "type": "ParentChild",
+      "parent": "M38B-2KB",
+      "child": "GWYV-NZP"
+    },
+    {
+      "id": "R10",
+      "type": "ParentChild",
+      "parent": "M38B-2K8",
+      "child": "LDXF-7TF"
+    },
+    {
+      "id": "R11",
+      "type": "ParentChild",
+      "parent": "M38B-2KB",
+      "child": "LDXF-7TF"
+    },
+    {
+      "id": "R12",
+      "type": "ParentChild",
+      "parent": "M38B-2K8",
+      "child": "GWYV-VMH"
+    },
+    {
+      "id": "R13",
+      "type": "ParentChild",
+      "parent": "M38B-2KB",
+      "child": "GWYV-VMH"
+    },
+    {
+      "id": "R14",
+      "type": "ParentChild",
+      "parent": "M38B-2K8",
+      "child": "GWYV-MN9"
+    },
+    {
+      "id": "R15",
+      "type": "ParentChild",
+      "parent": "M38B-2KB",
+      "child": "GWYV-MN9"
+    },
+    {
+      "id": "R16",
+      "type": "ParentChild",
+      "parent": "M38B-2K8",
+      "child": "GWYV-5XW"
+    },
+    {
+      "id": "R17",
+      "type": "ParentChild",
+      "parent": "M38B-2KB",
+      "child": "GWYV-5XW"
+    }
+  ],
+  "sources": [
+    {
+      "id": "3G78-6TS",
+      "title": "Thomas, \"Massachusetts, State Vital Records, 1638-1927\"",
+      "citation": "\"Massachusetts, State Vital Records, 1638-1927\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:N75G-MS9 : Wed May 22 22:33:56 UTC 2024), Entry for Eliza N Leaver and Thomas, 1872.",
+      "url": "https://familysearch.org/ark:/61903/1:1:N75G-MSS"
+    },
+    {
+      "id": "MW65-BF2",
+      "title": "Thomas, \"Massachusetts, State Vital Records, 1638-1927\"",
+      "citation": "\"Massachusetts, State Vital Records, 1638-1927\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:FCWR-G1T : Thu Jul 24 17:31:48 UTC 2025), Entry for Timothy A. H. Seaver and Thomas, 10 Dec 1857.",
+      "url": "https://familysearch.org/ark:/61903/1:1:FCWR-G1Y"
+    },
+    {
+      "id": "7WN9-GR9",
+      "title": "Thomas, \"Massachusetts, State Vital Records, 1638-1927\"",
+      "citation": "\"Massachusetts, State Vital Records, 1638-1927\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:N4W3-GRG : Thu May 23 00:36:08 UTC 2024), Entry for Augustus H. Leach and Thomas, 2 Aug 1853.",
+      "url": "https://familysearch.org/ark:/61903/1:1:N4W3-GRP"
+    },
+    {
+      "id": "3G76-T12",
+      "title": "Thomas, \"Massachusetts, State Vital Records, 1638-1927\"",
+      "citation": "\"Massachusetts, State Vital Records, 1638-1927\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:NWQW-LDV : Wed May 22 21:25:20 UTC 2024), Entry for Joseph H. Seaver and Thomas, 9 Sep 1896.",
+      "url": "https://familysearch.org/ark:/61903/1:1:NWQW-LDK"
+    },
+    {
+      "id": "3G67-MFS",
+      "title": "Thomas Seaver, \"Massachusetts, State Vital Records, 1638-1927\"",
+      "citation": "\"Massachusetts, State Vital Records, 1638-1927\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:N7G7-J26 : Wed May 22 21:50:30 UTC 2024), Entry for Sarah B. Seaver and Thomas Seaver, 1861.",
+      "url": "https://familysearch.org/ark:/61903/1:1:N7G7-J2X"
+    },
+    {
+      "id": "QBF8-9XC",
+      "title": "Thomas, \"Massachusetts, State Vital Records, 1638-1927\"",
+      "citation": "\"Massachusetts, State Vital Records, 1638-1927\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:NW13-4N1 : Thu May 23 00:48:27 UTC 2024), Entry for Timothy A H. Seaver and Caroline A. Johnston, 10 Dec 1857.",
+      "url": "https://familysearch.org/ark:/61903/1:1:NW13-4JM"
+    },
+    {
+      "id": "3G78-CR2",
+      "title": "Thomas Seaver, \"Massachusetts, State Vital Records, 1638-1927\"",
+      "citation": "\"Massachusetts, State Vital Records, 1638-1927\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:NW4C-C8Q : Wed May 22 20:43:02 UTC 2024), Entry for Daniel A. Seaver and Thomas Seaver, 22 Nov 1887.",
+      "url": "https://familysearch.org/ark:/61903/1:1:NW4C-C87"
+    },
+    {
+      "id": "3G7D-VN7",
+      "title": "Tho's Seaver, \"Massachusetts, State Vital Records, 1638-1927\"",
+      "citation": "\"Massachusetts, State Vital Records, 1638-1927\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:N7BZ-HMD : Wed May 22 21:05:23 UTC 2024), Entry for Mary A. Seaver and Tho's Seaver, 1845.",
+      "url": "https://familysearch.org/ark:/61903/1:1:N7BZ-HM6"
+    },
+    {
+      "id": "3G7D-KZ2",
+      "title": "Thomas Seaver, \"Massachusetts, Town Clerk, Vital and Town Records, 1626-2001\"",
+      "citation": "\"Massachusetts, Town Clerk, Vital and Town Records, 1626-2001\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:QG1K-C1Z7 : Sat Mar 09 03:21:55 UTC 2024), Entry for Mary H Seaver and Thomas Seaver, 30 November 1845.",
+      "url": "https://familysearch.org/ark:/61903/1:1:QG1K-C1ZC"
+    },
+    {
+      "id": "3G6Z-6DP",
+      "title": "Thomas, \"Massachusetts, State Vital Records, 1638-1927\"",
+      "citation": "\"Massachusetts, State Vital Records, 1638-1927\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:NWMT-JXH : Wed May 22 23:06:35 UTC 2024), Entry for Augustus K. Seaver and Thomas, 1884.",
+      "url": "https://familysearch.org/ark:/61903/1:1:NWMT-JXC"
+    },
+    {
+      "id": "3G78-DRT",
+      "title": "Thomas Seaver, \"Massachusetts, State Vital Records, 1638-1927\"",
+      "citation": "\"Massachusetts, State Vital Records, 1638-1927\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:N7PQ-Q21 : Wed May 22 21:02:30 UTC 2024), Entry for Rachel A. Seaver and Thomas Seaver, 13 Jan 1891.",
+      "url": "https://familysearch.org/ark:/61903/1:1:N7PQ-QLM"
+    },
+    {
+      "id": "3G6Z-3R5",
+      "title": "Thomas Seaver, \"Massachusetts, State Vital Records, 1638-1927\"",
+      "citation": "\"Massachusetts, State Vital Records, 1638-1927\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:FCMF-89D : Thu May 23 01:34:57 UTC 2024), Entry for Thomas Seaver and Rachel Wilkins, 31 Mar 1811.",
+      "url": "https://familysearch.org/ark:/61903/1:1:FCMF-89D"
+    },
+    {
+      "id": "3G6Z-QDT",
+      "title": "Thomas Seaver, \"Massachusetts, Town Clerk, Vital and Town Records, 1626-2001\"",
+      "citation": "\"Massachusetts, Town Clerk, Vital and Town Records, 1626-2001\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:Q29P-SC1K : Wed Mar 06 11:35:44 UTC 2024), Entry for Thomas Seaver and Rachel Wilkins, 31 Mar 1811.",
+      "url": "https://familysearch.org/ark:/61903/1:1:Q29P-SC1K"
+    },
+    {
+      "id": "3G6Z-Q1S",
+      "title": "Thomas Seaver, \"Massachusetts, Town Clerk, Vital and Town Records, 1626-2001\"",
+      "citation": "\"Massachusetts, Town Clerk, Vital and Town Records, 1626-2001\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:Q29L-CL6F : Fri Mar 08 17:08:56 UTC 2024), Entry for Augustus H. Seaver and Ellen Vittem, 02 Aug 1853.",
+      "url": "https://familysearch.org/ark:/61903/1:1:Q29L-CL6J"
+    },
+    {
+      "id": "3G6Z-XHQ",
+      "title": "Thomas Seaver, \"Massachusetts, Town Clerk, Vital and Town Records, 1626-2001\"",
+      "citation": "\"Massachusetts, Town Clerk, Vital and Town Records, 1626-2001\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:FHZ1-1NL : Sat Mar 09 06:20:42 UTC 2024), Entry for Augustus H. Seaver and Thomas Seaver, 13 April 1884.",
+      "url": "https://familysearch.org/ark:/61903/1:1:FHZ1-1NG"
+    },
+    {
+      "id": "QTLX-2BR",
+      "title": "Thomas Sever in entry for A. S. Sever, \"Massachusetts, Deaths and Burials, 1795-1910\"",
+      "citation": "\"Massachusetts, Deaths and Burials, 1795-1910\", , <i>FamilySearch</i> (https://familysearch.org/ark:/61903/1:1:FHM4-6Z5 : 17 January 2020), Thomas Sever in entry for A. S. Sever, .",
+      "url": "https://familysearch.org/ark:/61903/1:1:FHM4-6Z5"
+    },
+    {
+      "id": "3G6Z-W6H",
+      "title": "Thomas Seaver, \"Massachusetts, State Vital Records, 1638-1927\"",
+      "citation": "\"Massachusetts, State Vital Records, 1638-1927\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:FHYV-2LV : Thu Jul 24 22:42:57 UTC 2025), Entry for Thomas Seaver and Rachel Wilkins, 31 Mar 1811.",
+      "url": "https://familysearch.org/ark:/61903/1:1:FHYV-2LV"
+    },
+    {
+      "id": "QBF8-9Q6",
+      "title": "Thomas, \"Massachusetts, State Vital Records, 1638-1927\"",
+      "citation": "\"Massachusetts, State Vital Records, 1638-1927\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:FHHN-ZPP : Thu May 23 01:25:26 UTC 2024), Entry for Timothy A. H. Seaver and Thomas, 10 Dec 1857.",
+      "url": "https://familysearch.org/ark:/61903/1:1:FHHN-ZP5"
+    },
+    {
+      "id": "MWLS-LBJ",
+      "title": "Thomas Seaver, \"Massachusetts, State Vital Records, 1638-1927\"",
+      "citation": "\"Massachusetts, State Vital Records, 1638-1927\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:V589-VH5 : Thu May 23 02:34:53 UTC 2024), Entry for Thomas Seaver and Rachel Wilkins, 31 Mar 1811.",
+      "url": "https://familysearch.org/ark:/61903/1:1:V589-VH5"
+    },
+    {
+      "id": "3G67-MBN",
+      "title": "Thos Seaver, \"Massachusetts, Town Clerk, Vital and Town Records, 1626-2001\"",
+      "citation": "\"Massachusetts, Town Clerk, Vital and Town Records, 1626-2001\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:QG1K-F1DK : Sat Mar 09 07:41:09 UTC 2024), Entry for Sarah B Seaver and Thos Seaver, 10 February 1861.",
+      "url": "https://familysearch.org/ark:/61903/1:1:QG1K-F1DY"
+    }
+  ]
+}

--- a/eval/tests/e2e/thomas-seaver-other-wife/unstripped-tree.gedcomx.json
+++ b/eval/tests/e2e/thomas-seaver-other-wife/unstripped-tree.gedcomx.json
@@ -1,0 +1,857 @@
+{
+  "persons": [
+    {
+      "id": "M38B-2K8",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N1",
+          "given": "Thomas",
+          "surname": "Seaver"
+        }
+      ],
+      "facts": [
+        {
+          "id": "ebe0d4fe-20f8-4dad-b4b8-c69c03d0f100",
+          "type": "Birth",
+          "date": "about 1789",
+          "standard_date": "Abt 1789",
+          "place": "Hingham, Plymouth, Massachusetts, United States",
+          "standard_place": "Hingham, Plymouth, Massachusetts, United States"
+        },
+        {
+          "id": "ddb21ddf-0042-4808-af3c-5b2e94e08922",
+          "type": "Death",
+          "date": "March 1837",
+          "standard_date": "Mar 1837",
+          "place": "Salem, Essex, Massachusetts, United States",
+          "standard_place": "Salem, Essex, Massachusetts, United States"
+        }
+      ]
+    },
+    {
+      "id": "M38B-2KB",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N2",
+          "given": "Rachel",
+          "surname": "Wilkins"
+        }
+      ],
+      "facts": [
+        {
+          "id": "ebe0d4fe-20f8-4dad-b4b8-c69c03d0f100",
+          "type": "Birth",
+          "date": "4 September 1789",
+          "standard_date": "4 Sep 1789",
+          "place": "Middleton, Essex, Massachusetts, United States",
+          "standard_place": "Middleton, Essex, Massachusetts, United States"
+        },
+        {
+          "id": "6bc98339-ff7d-4602-b8fe-f15ffbd89701",
+          "type": "Residence",
+          "date": "1850",
+          "standard_date": "1850",
+          "place": "Salem, Essex, Massachusetts, United States",
+          "standard_place": "Salem, Essex, Massachusetts, United States"
+        },
+        {
+          "id": "b6bed99b-c721-4c28-b55f-6d652561e9a1",
+          "type": "Residence",
+          "date": "1855",
+          "standard_date": "1855",
+          "place": "Ward 03, Salem, Essex, Massachusetts, United States",
+          "standard_place": "Ward, Marlborough, New Zealand"
+        },
+        {
+          "id": "04049098-94d6-4557-87f0-0fcb09122b8f",
+          "type": "Residence",
+          "date": "1860",
+          "standard_date": "1860",
+          "place": "5th Ward of Salem, Essex, Massachusetts, United States"
+        },
+        {
+          "id": "248b3318-596f-47c5-ab3d-44d096e988b9",
+          "type": "Residence",
+          "date": "1870",
+          "standard_date": "1870",
+          "place": "Salem, Essex, Massachusetts, United States",
+          "standard_place": "Salem, Essex, Massachusetts, United States"
+        },
+        {
+          "id": "ddb21ddf-0042-4808-af3c-5b2e94e08922",
+          "type": "Death",
+          "date": "15 November 1880",
+          "standard_date": "15 Nov 1880",
+          "place": "Salem, Essex, Massachusetts, United States",
+          "standard_place": "Salem, Essex, Massachusetts, United States"
+        },
+        {
+          "id": "ef404396-f665-4711-b4a0-661d90bff123",
+          "type": "Residence",
+          "date": "15 Nov 1880",
+          "standard_date": "15 Nov 1880",
+          "place": "Salem, Mass",
+          "standard_place": "Salem, Essex, Massachusetts, United States"
+        },
+        {
+          "id": "4464c141-d0a0-4594-a8eb-ecc000e3692e",
+          "type": "Burial",
+          "place": "Harmony Grove Cemetery, Salem, Essex, Massachusetts, United States of America",
+          "standard_place": "Harmony Grove Cemetery, Salem, Essex, Massachusetts, United States"
+        }
+      ]
+    },
+    {
+      "id": "GWYV-VMH",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N3",
+          "given": "Rachel A.",
+          "surname": "Seaver"
+        }
+      ],
+      "facts": [
+        {
+          "id": "e272183c-760f-4916-9d8b-a4ed5858ba8f",
+          "type": "Birth",
+          "date": "23 December 1826",
+          "standard_date": "23 Dec 1826",
+          "place": "Salem, Essex, Massachusetts, United States",
+          "standard_place": "Salem, Essex, Massachusetts, United States"
+        },
+        {
+          "id": "932fcd73-dc36-4964-b5f9-b0e99ebfe437",
+          "type": "Residence",
+          "date": "1850",
+          "standard_date": "1850",
+          "place": "Salem, Essex, Massachusetts, United States",
+          "standard_place": "Salem, Essex, Massachusetts, United States"
+        },
+        {
+          "id": "e4036841-0061-42ad-8580-0aa686abde15",
+          "type": "Residence",
+          "date": "1850",
+          "standard_date": "1850",
+          "place": "Hingham, Plymouth, Massachusetts, United States",
+          "standard_place": "Hingham, Plymouth, Massachusetts, United States"
+        },
+        {
+          "id": "27ff3489-1118-4bde-b8e5-8f648151e729",
+          "type": "Residence",
+          "date": "1865",
+          "standard_date": "1865",
+          "place": "Salem, Essex, Massachusetts, United States",
+          "standard_place": "Salem, Essex, Massachusetts, United States"
+        },
+        {
+          "id": "11fff4c5-fc84-4ec0-b92c-76ed4b8bc524",
+          "type": "Residence",
+          "date": "1870",
+          "standard_date": "1870",
+          "place": "Salem, Essex, Massachusetts, United States",
+          "standard_place": "Salem, Essex, Massachusetts, United States"
+        },
+        {
+          "id": "d7162981-80c7-4b37-b541-3a6b807e00ff",
+          "type": "Death",
+          "date": "13 January 1891",
+          "standard_date": "13 Jan 1891",
+          "place": "Salem, Essex, Massachusetts, United States",
+          "standard_place": "Salem, Essex, Massachusetts, United States"
+        },
+        {
+          "id": "752d4fa0-d788-4ddf-882d-9c35dc5be40b",
+          "type": "Residence",
+          "date": "13 Jan 1891",
+          "standard_date": "13 Jan 1891",
+          "place": "Salem",
+          "standard_place": "Salem, Virginia, United States"
+        },
+        {
+          "id": "7948af0f-d55d-43c3-8c6a-93cf277878ec",
+          "type": "Burial",
+          "place": "Salem",
+          "standard_place": "Salem, Virginia, United States"
+        }
+      ]
+    },
+    {
+      "id": "GWYV-NZP",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N4",
+          "given": "Eliza N.",
+          "surname": "Seaver"
+        }
+      ],
+      "facts": [
+        {
+          "id": "121973d2-ca47-4ee5-b1e2-7c156890c6d0",
+          "type": "Birth",
+          "date": "28 March 1823",
+          "standard_date": "28 Mar 1823",
+          "place": "Salem, Essex, Massachusetts, United States",
+          "standard_place": "Salem, Essex, Massachusetts, United States"
+        },
+        {
+          "id": "efd9affe-5853-4dad-962c-575524a98f2e",
+          "type": "Residence",
+          "date": "1855",
+          "standard_date": "1855",
+          "place": "Ward 03, Salem, Essex, Massachusetts, United States",
+          "standard_place": "Ward, Marlborough, New Zealand"
+        },
+        {
+          "id": "6f31b330-8ae8-4f3d-b6f9-42b3b094f868",
+          "type": "Residence",
+          "date": "1860",
+          "standard_date": "1860",
+          "place": "5th Ward of Salem, Essex, Massachusetts, United States"
+        },
+        {
+          "id": "d5a1fc34-d8b3-4a15-840e-a88229daba97",
+          "type": "Residence",
+          "date": "1865",
+          "standard_date": "1865",
+          "place": "Salem, Essex, Massachusetts, United States",
+          "standard_place": "Salem, Essex, Massachusetts, United States"
+        },
+        {
+          "id": "ac97cc69-46da-4139-9109-b460089f9672",
+          "type": "Residence",
+          "date": "1870",
+          "standard_date": "1870",
+          "place": "Salem, Essex, Massachusetts, United States",
+          "standard_place": "Salem, Essex, Massachusetts, United States"
+        },
+        {
+          "id": "1f42af52-ffb8-47c5-9224-94b7e6b0433c",
+          "type": "Death",
+          "date": "24 January 1872",
+          "standard_date": "24 Jan 1872",
+          "place": "Salem, Essex, Massachusetts, United States",
+          "standard_place": "Salem, Essex, Massachusetts, United States"
+        },
+        {
+          "id": "0f7ac01b-1bd0-448b-98ce-fcc0fbfa7767",
+          "type": "Residence",
+          "date": "24 Jan 1872",
+          "standard_date": "24 Jan 1872",
+          "place": "Salem, Ma",
+          "standard_place": "Salem, Virginia, United States"
+        }
+      ]
+    },
+    {
+      "id": "GWYV-5XW",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N5",
+          "given": "Daniel A.",
+          "surname": "Seaver"
+        }
+      ],
+      "facts": [
+        {
+          "id": "d4f9c78d-9f95-4d07-94ae-db5b9e665a43",
+          "type": "Birth",
+          "date": "1829",
+          "standard_date": "1829",
+          "place": "Salem, Essex, Massachusetts, United States",
+          "standard_place": "Salem, Essex, Massachusetts, United States"
+        },
+        {
+          "id": "e3dfdc7a-d820-4d26-95f4-da4787d3fc39",
+          "type": "Residence",
+          "date": "1855",
+          "standard_date": "1855",
+          "place": "Ward 03, Salem, Essex, Massachusetts, United States",
+          "standard_place": "Ward, Marlborough, New Zealand"
+        },
+        {
+          "id": "783f268e-398c-44dc-849c-051a1079614b",
+          "type": "Residence",
+          "date": "1860",
+          "standard_date": "1860",
+          "place": "5th Ward of Salem, Essex, Massachusetts, United States"
+        },
+        {
+          "id": "0fc2eb0b-067c-4b5f-aa7b-80fe686253b6",
+          "type": "Residence",
+          "date": "1865",
+          "standard_date": "1865",
+          "place": "Salem, Essex, Massachusetts, United States",
+          "standard_place": "Salem, Essex, Massachusetts, United States"
+        },
+        {
+          "id": "64234e8b-adbb-4b6f-bb5c-db3def1206d7",
+          "type": "Residence",
+          "date": "1870",
+          "standard_date": "1870",
+          "place": "Salem, Essex, Massachusetts, United States",
+          "standard_place": "Salem, Essex, Massachusetts, United States"
+        },
+        {
+          "id": "86163072-a6a4-4a2e-a858-194b398676c9",
+          "type": "Death",
+          "date": "22 November 1887",
+          "standard_date": "22 Nov 1887",
+          "place": "Salem, Essex, Massachusetts, United States",
+          "standard_place": "Salem, Essex, Massachusetts, United States"
+        },
+        {
+          "id": "bc3e4812-0a2f-42d0-8b26-4521a57cf5c0",
+          "type": "Residence",
+          "date": "22 Nov 1887",
+          "standard_date": "22 Nov 1887",
+          "place": "SALEM, MASSACHUSETTS",
+          "standard_place": "Salem, Virginia, United States"
+        },
+        {
+          "id": "39b68a4c-70b3-48d9-961c-5cc56cf4f357",
+          "type": "Burial",
+          "place": "Harmony Grove Cemetery, Salem, Essex, Massachusetts, United States",
+          "standard_place": "Harmony Grove Cemetery, Salem, Essex, Massachusetts, United States"
+        }
+      ]
+    },
+    {
+      "id": "LDXF-7TF",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N6",
+          "given": "Timothy Augustus H.",
+          "surname": "Seaver"
+        }
+      ],
+      "facts": [
+        {
+          "id": "a182803b-dc9f-48ff-a41b-b4afa80b5870",
+          "type": "Birth",
+          "date": "August 1824",
+          "standard_date": "Aug 1824",
+          "place": "Salem, Essex, Massachusetts, United States",
+          "standard_place": "Salem, Essex, Massachusetts, United States"
+        },
+        {
+          "id": "a39b8d2c-e58c-41e5-a8c5-ba4a75585a5f",
+          "type": "Immigration",
+          "date": "1846",
+          "standard_date": "1846",
+          "place": "Massachusetts, United States",
+          "standard_place": "Massachusetts, United States"
+        },
+        {
+          "id": "51b718c2-7147-4a30-a416-811ffe3d6a8c",
+          "type": "Residence",
+          "date": "1850",
+          "standard_date": "1850",
+          "place": "Salem, Essex, Massachusetts, United States",
+          "standard_place": "Salem, Essex, Massachusetts, United States"
+        },
+        {
+          "id": "04a35907-7d3f-4251-8441-013be1c323ac",
+          "type": "Residence",
+          "date": "1860",
+          "standard_date": "1860",
+          "place": "Ward 2 City of Boston, Suffolk, Massachusetts, United States",
+          "standard_place": "Suffolk, Massachusetts, United States"
+        },
+        {
+          "id": "5339a0a9-52da-47f8-a1e9-b3733dfbfa9a",
+          "type": "Residence",
+          "date": "1860",
+          "standard_date": "1860",
+          "place": "6th Ward Boston, Suffolk, Massachusetts, United States",
+          "standard_place": "Boston, Suffolk, Massachusetts, United States"
+        },
+        {
+          "id": "2ff61e88-1f71-4f04-bcf4-637a9569734f",
+          "type": "Residence",
+          "date": "1870",
+          "standard_date": "1870",
+          "place": "Charlestown, Middlesex, Massachusetts, United States",
+          "standard_place": "Charlestown, Middlesex, Massachusetts, United States"
+        },
+        {
+          "id": "ddb21ddf-0042-4808-af3c-5b2e94e08922",
+          "type": "Death",
+          "date": "13 April 1884",
+          "standard_date": "13 Apr 1884",
+          "place": "Boston, Suffolk, Massachusetts, United States",
+          "standard_place": "Boston, Suffolk, Massachusetts, United States"
+        },
+        {
+          "id": "aeed9f49-d304-488d-ad15-25d3801a52bc",
+          "type": "Burial",
+          "place": "Harmony Grove Cemetery, Salem, Essex, Massachusetts, United States of America",
+          "standard_place": "Harmony Grove Cemetery, Salem, Essex, Massachusetts, United States"
+        }
+      ]
+    },
+    {
+      "id": "GWYV-RM3",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N7",
+          "given": "Sarah B.",
+          "surname": "Seaver"
+        }
+      ],
+      "facts": [
+        {
+          "id": "23f29365-a12f-4e57-9785-95a492c2bd12",
+          "type": "Birth",
+          "date": "about 1812",
+          "standard_date": "Abt 1812",
+          "place": "Salem, Essex, Massachusetts, United States",
+          "standard_place": "Salem, Essex, Massachusetts, United States"
+        },
+        {
+          "id": "9bc4f50b-509c-40e9-b865-a4c745f1d693",
+          "type": "Residence",
+          "date": "1850",
+          "standard_date": "1850",
+          "place": "Salem, Essex, Massachusetts, United States",
+          "standard_place": "Salem, Essex, Massachusetts, United States"
+        },
+        {
+          "id": "14f48373-6327-426d-af36-255c65ce004d",
+          "type": "Residence",
+          "date": "1855",
+          "standard_date": "1855",
+          "place": "Ward 03, Salem, Essex, Massachusetts, United States",
+          "standard_place": "Ward, Marlborough, New Zealand"
+        },
+        {
+          "id": "b5c408e8-9255-484e-acfd-fb5d5fe7c081",
+          "type": "Residence",
+          "date": "1860",
+          "standard_date": "1860",
+          "place": "5th Ward of Salem, Essex, Massachusetts, United States"
+        },
+        {
+          "id": "aa6dcff2-14d8-4290-af7b-062ecddbf403",
+          "type": "Death",
+          "date": "10 February 1861",
+          "standard_date": "10 Feb 1861",
+          "place": "Salem, Essex, Massachusetts, United States",
+          "standard_place": "Salem, Essex, Massachusetts, United States"
+        },
+        {
+          "id": "f5db4165-c592-4255-9cc1-7e169f21ed54",
+          "type": "Residence",
+          "date": "10 Feb 1861",
+          "standard_date": "10 Feb 1861",
+          "place": "Salem, Mass.",
+          "standard_place": "Salem, Virginia, United States"
+        },
+        {
+          "id": "20a75c1f-a068-43f4-82bf-d7d06d4470a9",
+          "type": "Burial",
+          "place": "Harmony Grove Cemetery, Salem, Essex, Massachusetts, United States",
+          "standard_place": "Harmony Grove Cemetery, Salem, Essex, Massachusetts, United States"
+        }
+      ]
+    },
+    {
+      "id": "GWYV-4JN",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N8",
+          "given": "Joseph Haraden",
+          "surname": "Seaver",
+          "prefix": "Rev."
+        }
+      ],
+      "facts": [
+        {
+          "id": "81a2f87c-559d-461f-9537-ec4847d57052",
+          "type": "Birth",
+          "date": "29 January 1819",
+          "standard_date": "29 Jan 1819",
+          "place": "Salem, Essex, Massachusetts, United States",
+          "standard_place": "Salem, Essex, Massachusetts, United States"
+        },
+        {
+          "id": "37ce5b71-6398-41f1-a439-f2ad10e6620d",
+          "type": "Residence",
+          "date": "1850",
+          "standard_date": "1850",
+          "place": "Salem, Essex, Massachusetts, United States",
+          "standard_place": "Salem, Essex, Massachusetts, United States"
+        },
+        {
+          "id": "e2e6aeae-4fe5-4f13-983c-dffdd1248db2",
+          "type": "Residence",
+          "date": "1860",
+          "standard_date": "1860",
+          "place": "Georgetown, Essex, Massachusetts, United States",
+          "standard_place": "Georgetown, Essex, Massachusetts, United States"
+        },
+        {
+          "id": "196d3c40-6cdd-4b78-973a-4f461424f684",
+          "type": "Death",
+          "date": "9 September 1896",
+          "standard_date": "9 Sep 1896",
+          "place": "Salem, Essex, Massachusetts, United States",
+          "standard_place": "Salem, Essex, Massachusetts, United States"
+        },
+        {
+          "id": "324523bc-045e-4f72-b51d-9305787af363",
+          "type": "Residence",
+          "date": "09 Sep 1896",
+          "standard_date": "9 Sep 1896",
+          "place": "Salem, Massachusetts",
+          "standard_place": "Salem, Virginia, United States"
+        },
+        {
+          "id": "d5507ee8-df0b-460f-809b-26ae4063f232",
+          "type": "Burial",
+          "date": "after 9 September 1896",
+          "standard_date": "Aft 9 Sep 1896",
+          "place": "Salem, Essex, Massachusetts, United States",
+          "standard_place": "Salem, Essex, Massachusetts, United States"
+        }
+      ]
+    },
+    {
+      "id": "GWYV-MN9",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N9",
+          "given": "Thomas",
+          "surname": "Seaver"
+        }
+      ],
+      "facts": [
+        {
+          "id": "c612db85-d523-47da-a961-0eb466a00eee",
+          "type": "Birth",
+          "date": "1828",
+          "standard_date": "1828",
+          "place": "Salem, Essex, Massachusetts, United States",
+          "standard_place": "Salem, Essex, Massachusetts, United States"
+        },
+        {
+          "id": "b2408400-fe80-4251-b38c-4561aca03313",
+          "type": "Death",
+          "date": "15 September 1830",
+          "standard_date": "15 Sep 1830",
+          "place": "Salem, Essex, Massachusetts, United States",
+          "standard_place": "Salem, Essex, Massachusetts, United States"
+        },
+        {
+          "id": "23046e09-f5f8-44e3-b486-2922de4c41f0",
+          "type": "Burial",
+          "place": "Salem, Essex, Massachusetts, United States",
+          "standard_place": "Salem, Essex, Massachusetts, United States"
+        },
+        {
+          "id": "e9f82ce3-a23d-4435-ae95-c6c776363b43",
+          "type": "Residence",
+          "place": "Cambridge Street",
+          "standard_place": "Cambridge, Worcester, Worcester, Massachusetts, United States"
+        }
+      ]
+    },
+    {
+      "id": "GWYV-34Z",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N10",
+          "given": "Mary H.",
+          "surname": "Seaver"
+        }
+      ],
+      "facts": [
+        {
+          "id": "21541850-4fcf-48cf-9151-58bc39035d59",
+          "type": "Birth",
+          "date": "about 1822",
+          "standard_date": "Abt 1822",
+          "place": "Salem, Essex, Massachusetts, United States",
+          "standard_place": "Salem, Essex, Massachusetts, United States"
+        },
+        {
+          "id": "b1a47af5-480f-4bd0-aeac-8796ec44702d",
+          "type": "Death",
+          "date": "28 November 1845",
+          "standard_date": "28 Nov 1845",
+          "place": "Salem, Essex, Massachusetts, United States",
+          "standard_place": "Salem, Essex, Massachusetts, United States"
+        },
+        {
+          "id": "c12e04a5-49d8-4d13-90d5-da6f5ed072e9",
+          "type": "Burial",
+          "place": "Harmony Grove Cemetery, Salem, Essex, Massachusetts, United States",
+          "standard_place": "Harmony Grove Cemetery, Salem, Essex, Massachusetts, United States"
+        }
+      ]
+    }
+  ],
+  "relationships": [
+    {
+      "id": "R1",
+      "type": "Couple",
+      "person1": "M38B-2K8",
+      "person2": "M38B-2KB",
+      "facts": [
+        {
+          "id": "1701bc01-2ac5-4c51-be9f-08da85784945",
+          "type": "Marriage",
+          "date": "31 March 1811",
+          "standard_date": "31 Mar 1811",
+          "place": "Salem, Essex, Massachusetts, United States",
+          "standard_place": "Salem, Essex, Massachusetts, United States"
+        },
+        {
+          "id": "c7d585f8-6b87-453e-a0da-e8221d7b49ef",
+          "type": "Marriage",
+          "date": "31 Mar 1811",
+          "standard_date": "31 Mar 1811",
+          "place": "Salem, Essex, Massachusetts, United States",
+          "standard_place": "Salem, Essex, Massachusetts, United States"
+        }
+      ]
+    },
+    {
+      "id": "R2",
+      "type": "ParentChild",
+      "parent": "M38B-2K8",
+      "child": "GWYV-RM3"
+    },
+    {
+      "id": "R3",
+      "type": "ParentChild",
+      "parent": "M38B-2KB",
+      "child": "GWYV-RM3"
+    },
+    {
+      "id": "R4",
+      "type": "ParentChild",
+      "parent": "M38B-2K8",
+      "child": "GWYV-4JN"
+    },
+    {
+      "id": "R5",
+      "type": "ParentChild",
+      "parent": "M38B-2KB",
+      "child": "GWYV-4JN"
+    },
+    {
+      "id": "R6",
+      "type": "ParentChild",
+      "parent": "M38B-2K8",
+      "child": "GWYV-34Z"
+    },
+    {
+      "id": "R7",
+      "type": "ParentChild",
+      "parent": "M38B-2KB",
+      "child": "GWYV-34Z"
+    },
+    {
+      "id": "R8",
+      "type": "ParentChild",
+      "parent": "M38B-2K8",
+      "child": "GWYV-NZP"
+    },
+    {
+      "id": "R9",
+      "type": "ParentChild",
+      "parent": "M38B-2KB",
+      "child": "GWYV-NZP"
+    },
+    {
+      "id": "R10",
+      "type": "ParentChild",
+      "parent": "M38B-2K8",
+      "child": "LDXF-7TF"
+    },
+    {
+      "id": "R11",
+      "type": "ParentChild",
+      "parent": "M38B-2KB",
+      "child": "LDXF-7TF"
+    },
+    {
+      "id": "R12",
+      "type": "ParentChild",
+      "parent": "M38B-2K8",
+      "child": "GWYV-VMH"
+    },
+    {
+      "id": "R13",
+      "type": "ParentChild",
+      "parent": "M38B-2KB",
+      "child": "GWYV-VMH"
+    },
+    {
+      "id": "R14",
+      "type": "ParentChild",
+      "parent": "M38B-2K8",
+      "child": "GWYV-MN9"
+    },
+    {
+      "id": "R15",
+      "type": "ParentChild",
+      "parent": "M38B-2KB",
+      "child": "GWYV-MN9"
+    },
+    {
+      "id": "R16",
+      "type": "ParentChild",
+      "parent": "M38B-2K8",
+      "child": "GWYV-5XW"
+    },
+    {
+      "id": "R17",
+      "type": "ParentChild",
+      "parent": "M38B-2KB",
+      "child": "GWYV-5XW"
+    }
+  ],
+  "sources": [
+    {
+      "id": "3G78-6TS",
+      "title": "Thomas, \"Massachusetts, State Vital Records, 1638-1927\"",
+      "citation": "\"Massachusetts, State Vital Records, 1638-1927\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:N75G-MS9 : Wed May 22 22:33:56 UTC 2024), Entry for Eliza N Leaver and Thomas, 1872.",
+      "url": "https://familysearch.org/ark:/61903/1:1:N75G-MSS"
+    },
+    {
+      "id": "MW65-BF2",
+      "title": "Thomas, \"Massachusetts, State Vital Records, 1638-1927\"",
+      "citation": "\"Massachusetts, State Vital Records, 1638-1927\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:FCWR-G1T : Thu Jul 24 17:31:48 UTC 2025), Entry for Timothy A. H. Seaver and Thomas, 10 Dec 1857.",
+      "url": "https://familysearch.org/ark:/61903/1:1:FCWR-G1Y"
+    },
+    {
+      "id": "7WN9-GR9",
+      "title": "Thomas, \"Massachusetts, State Vital Records, 1638-1927\"",
+      "citation": "\"Massachusetts, State Vital Records, 1638-1927\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:N4W3-GRG : Thu May 23 00:36:08 UTC 2024), Entry for Augustus H. Leach and Thomas, 2 Aug 1853.",
+      "url": "https://familysearch.org/ark:/61903/1:1:N4W3-GRP"
+    },
+    {
+      "id": "3G76-T12",
+      "title": "Thomas, \"Massachusetts, State Vital Records, 1638-1927\"",
+      "citation": "\"Massachusetts, State Vital Records, 1638-1927\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:NWQW-LDV : Wed May 22 21:25:20 UTC 2024), Entry for Joseph H. Seaver and Thomas, 9 Sep 1896.",
+      "url": "https://familysearch.org/ark:/61903/1:1:NWQW-LDK"
+    },
+    {
+      "id": "3G67-MFS",
+      "title": "Thomas Seaver, \"Massachusetts, State Vital Records, 1638-1927\"",
+      "citation": "\"Massachusetts, State Vital Records, 1638-1927\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:N7G7-J26 : Wed May 22 21:50:30 UTC 2024), Entry for Sarah B. Seaver and Thomas Seaver, 1861.",
+      "url": "https://familysearch.org/ark:/61903/1:1:N7G7-J2X"
+    },
+    {
+      "id": "QBF8-9XC",
+      "title": "Thomas, \"Massachusetts, State Vital Records, 1638-1927\"",
+      "citation": "\"Massachusetts, State Vital Records, 1638-1927\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:NW13-4N1 : Thu May 23 00:48:27 UTC 2024), Entry for Timothy A H. Seaver and Caroline A. Johnston, 10 Dec 1857.",
+      "url": "https://familysearch.org/ark:/61903/1:1:NW13-4JM"
+    },
+    {
+      "id": "3G78-CR2",
+      "title": "Thomas Seaver, \"Massachusetts, State Vital Records, 1638-1927\"",
+      "citation": "\"Massachusetts, State Vital Records, 1638-1927\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:NW4C-C8Q : Wed May 22 20:43:02 UTC 2024), Entry for Daniel A. Seaver and Thomas Seaver, 22 Nov 1887.",
+      "url": "https://familysearch.org/ark:/61903/1:1:NW4C-C87"
+    },
+    {
+      "id": "3G7D-VN7",
+      "title": "Tho's Seaver, \"Massachusetts, State Vital Records, 1638-1927\"",
+      "citation": "\"Massachusetts, State Vital Records, 1638-1927\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:N7BZ-HMD : Wed May 22 21:05:23 UTC 2024), Entry for Mary A. Seaver and Tho's Seaver, 1845.",
+      "url": "https://familysearch.org/ark:/61903/1:1:N7BZ-HM6"
+    },
+    {
+      "id": "3G7D-KZ2",
+      "title": "Thomas Seaver, \"Massachusetts, Town Clerk, Vital and Town Records, 1626-2001\"",
+      "citation": "\"Massachusetts, Town Clerk, Vital and Town Records, 1626-2001\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:QG1K-C1Z7 : Sat Mar 09 03:21:55 UTC 2024), Entry for Mary H Seaver and Thomas Seaver, 30 November 1845.",
+      "url": "https://familysearch.org/ark:/61903/1:1:QG1K-C1ZC"
+    },
+    {
+      "id": "3G6Z-6DP",
+      "title": "Thomas, \"Massachusetts, State Vital Records, 1638-1927\"",
+      "citation": "\"Massachusetts, State Vital Records, 1638-1927\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:NWMT-JXH : Wed May 22 23:06:35 UTC 2024), Entry for Augustus K. Seaver and Thomas, 1884.",
+      "url": "https://familysearch.org/ark:/61903/1:1:NWMT-JXC"
+    },
+    {
+      "id": "3G78-DRT",
+      "title": "Thomas Seaver, \"Massachusetts, State Vital Records, 1638-1927\"",
+      "citation": "\"Massachusetts, State Vital Records, 1638-1927\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:N7PQ-Q21 : Wed May 22 21:02:30 UTC 2024), Entry for Rachel A. Seaver and Thomas Seaver, 13 Jan 1891.",
+      "url": "https://familysearch.org/ark:/61903/1:1:N7PQ-QLM"
+    },
+    {
+      "id": "3G6Z-3R5",
+      "title": "Thomas Seaver, \"Massachusetts, State Vital Records, 1638-1927\"",
+      "citation": "\"Massachusetts, State Vital Records, 1638-1927\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:FCMF-89D : Thu May 23 01:34:57 UTC 2024), Entry for Thomas Seaver and Rachel Wilkins, 31 Mar 1811.",
+      "url": "https://familysearch.org/ark:/61903/1:1:FCMF-89D"
+    },
+    {
+      "id": "3G6Z-QDT",
+      "title": "Thomas Seaver, \"Massachusetts, Town Clerk, Vital and Town Records, 1626-2001\"",
+      "citation": "\"Massachusetts, Town Clerk, Vital and Town Records, 1626-2001\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:Q29P-SC1K : Wed Mar 06 11:35:44 UTC 2024), Entry for Thomas Seaver and Rachel Wilkins, 31 Mar 1811.",
+      "url": "https://familysearch.org/ark:/61903/1:1:Q29P-SC1K"
+    },
+    {
+      "id": "3G6Z-Q1S",
+      "title": "Thomas Seaver, \"Massachusetts, Town Clerk, Vital and Town Records, 1626-2001\"",
+      "citation": "\"Massachusetts, Town Clerk, Vital and Town Records, 1626-2001\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:Q29L-CL6F : Fri Mar 08 17:08:56 UTC 2024), Entry for Augustus H. Seaver and Ellen Vittem, 02 Aug 1853.",
+      "url": "https://familysearch.org/ark:/61903/1:1:Q29L-CL6J"
+    },
+    {
+      "id": "3G6Z-XHQ",
+      "title": "Thomas Seaver, \"Massachusetts, Town Clerk, Vital and Town Records, 1626-2001\"",
+      "citation": "\"Massachusetts, Town Clerk, Vital and Town Records, 1626-2001\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:FHZ1-1NL : Sat Mar 09 06:20:42 UTC 2024), Entry for Augustus H. Seaver and Thomas Seaver, 13 April 1884.",
+      "url": "https://familysearch.org/ark:/61903/1:1:FHZ1-1NG"
+    },
+    {
+      "id": "QTLX-2BR",
+      "title": "Thomas Sever in entry for A. S. Sever, \"Massachusetts, Deaths and Burials, 1795-1910\"",
+      "citation": "\"Massachusetts, Deaths and Burials, 1795-1910\", , <i>FamilySearch</i> (https://familysearch.org/ark:/61903/1:1:FHM4-6Z5 : 17 January 2020), Thomas Sever in entry for A. S. Sever, .",
+      "url": "https://familysearch.org/ark:/61903/1:1:FHM4-6Z5"
+    },
+    {
+      "id": "3G6Z-W6H",
+      "title": "Thomas Seaver, \"Massachusetts, State Vital Records, 1638-1927\"",
+      "citation": "\"Massachusetts, State Vital Records, 1638-1927\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:FHYV-2LV : Thu Jul 24 22:42:57 UTC 2025), Entry for Thomas Seaver and Rachel Wilkins, 31 Mar 1811.",
+      "url": "https://familysearch.org/ark:/61903/1:1:FHYV-2LV"
+    },
+    {
+      "id": "QBF8-9Q6",
+      "title": "Thomas, \"Massachusetts, State Vital Records, 1638-1927\"",
+      "citation": "\"Massachusetts, State Vital Records, 1638-1927\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:FHHN-ZPP : Thu May 23 01:25:26 UTC 2024), Entry for Timothy A. H. Seaver and Thomas, 10 Dec 1857.",
+      "url": "https://familysearch.org/ark:/61903/1:1:FHHN-ZP5"
+    },
+    {
+      "id": "MWLS-LBJ",
+      "title": "Thomas Seaver, \"Massachusetts, State Vital Records, 1638-1927\"",
+      "citation": "\"Massachusetts, State Vital Records, 1638-1927\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:V589-VH5 : Thu May 23 02:34:53 UTC 2024), Entry for Thomas Seaver and Rachel Wilkins, 31 Mar 1811.",
+      "url": "https://familysearch.org/ark:/61903/1:1:V589-VH5"
+    },
+    {
+      "id": "3G67-MBN",
+      "title": "Thos Seaver, \"Massachusetts, Town Clerk, Vital and Town Records, 1626-2001\"",
+      "citation": "\"Massachusetts, Town Clerk, Vital and Town Records, 1626-2001\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:QG1K-F1DK : Sat Mar 09 07:41:09 UTC 2024), Entry for Sarah B Seaver and Thos Seaver, 10 February 1861.",
+      "url": "https://familysearch.org/ark:/61903/1:1:QG1K-F1DY"
+    }
+  ]
+}


### PR DESCRIPTION
Tests that the agent correctly concludes no second marriage for Thomas Seaver (PID M38B-2K8, d. March 1837 Salem MA) rather than fabricating one. Genre: record-hint, difficulty: hard, strip: none.

Findings: f1 polarity=avoid (must not assert a second wife/marriage), f2 required fact (must document a negative/exhausted-search conclusion). Validated via live /research run: GPS workflow completed through proof-conclusion at tier probable, mentor verdict ev_001 recorded.

## Summary

<!-- 1-3 bullets describing what changed and why. -->

## Test plan

- [ ] I ran `scripts/test.sh` and it passed.
- [ ] For every skill whose files I changed (SKILL.md, scenarios, fixtures,
      tests, or supporting MCP/harness code), I ran `RunTests.bat <skill>`
      and committed an all-pass runlog under `eval/runlogs/unit/<skill>/`.
