### PR TITLE
docs: correct when research data reaches the tree

### DIFF
--- a/docs/gps-research-flow.md
+++ b/docs/gps-research-flow.md
@@ -207,9 +207,12 @@ paleography first. It is not guessed at.
 
 Extraction records what a document says about a person *in that document*.
 Deciding that this person is the same individual as one in your tree is a
-separate, later, revisable judgment. Keeping the two apart is deliberate: it
-stops an identity assumption made in the first minute of reading a record
-from hardening into tree data.
+separate, later, revisable judgment. Keeping the two apart is deliberate:
+the identity decision is what carries a record's facts onto a person in your
+tree, so it is made once, explicitly, with its reasoning recorded — never
+assumed in the first minute of reading the record. It stays revisable, and
+when later evidence shows a record was attached to the wrong person the
+correction is added rather than the original link quietly erased.
 
 Correlation across name, dates, places, relationships, and associates sets
 one of three confidence levels:
@@ -299,14 +302,18 @@ Two hard limits:
 
 - An unresolved conflict blocks a *proved* conclusion outright.
 - A conflict disputing the concluded fact itself **caps the conclusion at
-  *possible***, which sits below the threshold for writing to the tree. A
-  disputed conclusion never becomes tree data.
+  *possible***, which sits below the threshold for concluding it in the tree.
 
-At *probable* or better, the conclusion is written into the tree — the
-relationship and the fact, carrying their source citations, with the
-concluded fact marked preferred rather than piled on as another alternative.
-A conclusion that never reaches the tree is a result found and then lost, so
-the system verifies the write happened.
+The tree already holds the evidence by this point: each record's facts were
+written onto the people it names when that record was linked to them,
+carrying their source citations, with no value yet marked as the right one.
+Writing the conclusion is what settles that. At *probable* or better, the
+concluded relationship is added and the concluded value is marked preferred
+over the competing ones — not piled on as another alternative. Below that
+threshold the evidence stays in the tree unranked, and nothing is uploaded
+to FamilySearch: only concluded facts leave the working tree. A conclusion
+that never reaches the tree is a result found and then lost, so the system
+verifies the write happened.
 
 ### Critique of the conclusion
 


### PR DESCRIPTION
## What

`docs/gps-research-flow.md` claimed under **Writing the conclusion** that a disputed conclusion "never becomes tree data," and that at *probable* or better "the conclusion is written into the tree." That describes an older flow.

## Why it's wrong

- `person-evidence` calls `materialize_facts` at **link** time (`SKILL.md:368`), writing each persona's assertions as sourced facts/names onto the tree person — and writes the household `ParentChild`/`Couple` edges via `tree_edit` (§7 step 4). This happens at any link confidence, including `probable`/`speculative`. It explicitly never sets `primary`/`preferred`: "concluding the preferred value stays proof-conclusion's job" (`SKILL.md:375`).
- `proof-conclusion` §6 is gated at tier ≥ probable and lands the *conclusion* on top: the concluded relationship, plus `primary: true` on the concluded value — via `tree_correct update_fact` on the existing evidence fact, explicitly "do NOT add a second fact."
- What the tier actually gates end-to-end is upload: "only `primary`/proof-backed facts upload to FamilySearch — un-concluded evidence stays out" (`proof-conclusion/SKILL.md` §6 step 3).

The `possible` cap on a disputed conclusion (`proof-conclusion/SKILL.md:98`) is unchanged and still correct — only its stated consequence was stale.

## Changes

- **Writing the conclusion** — the threshold now governs whether a value is *marked concluded* (and eligible to upload), not whether data reaches the tree at all.
- **Deciding who the record is about** — dropped the matching "stops an identity assumption from hardening into tree data" claim; linking is now precisely where a record's facts land, so the paragraph instead says why that makes the identity decision explicit and revisable.

Docs only — no code, skill, or spec changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)