### PR TITLE
feat(web): add a browser favicon

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Genealogy Workbench</title>
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <!-- The "Warm Scholarly" design system (packages/viewer-ui global.css) names
          Cormorant + IBM Plex but the WEB host never loaded the webfonts — so the
          shell alone rendered in Georgia/system fallback. This is the exact same

--- a/apps/web/public/favicon.svg
+++ b/apps/web/public/favicon.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Genealogy Workbench">
+  <!-- A pedigree fan: one person branching to two parents, the smallest glyph
+       that still reads as "genealogy" at 16px. Colors come from the viewer's
+       "Warm Scholarly" palette (packages/viewer-ui/src/styles/global.css): the
+       text-primary brown as the tile, and a lightened accent-gold for the mark
+       (the literal #b8860b only reaches ~4.7:1 on that brown, which muddies at
+       favicon size). Keep this comment free of doubled hyphens: XML forbids
+       them inside comments, and browsers parse image/svg+xml strictly. -->
+  <rect width="64" height="64" rx="13" fill="#2c2419" />
+  <g fill="none" stroke="#d4a24c" stroke-width="5" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M22 32h10V17.5h8.5" />
+    <path d="M22 32h10V46.5h8.5" />
+  </g>
+  <g fill="#d4a24c">
+    <circle cx="17" cy="32" r="6" />
+    <circle cx="47" cy="17.5" r="6" />
+    <circle cx="47" cy="46.5" r="6" />
+  </g>
+</svg>


### PR DESCRIPTION
The web shell had no favicon, so tabs showed the browser's blank-page glyph and every load logged a `/favicon.ico` 404.

## What's here

- **`apps/web/public/favicon.svg`** (new) — an SVG pedigree fan: one person branching to two parents. It's the smallest glyph that still reads as "genealogy" at 16px.
- **`apps/web/index.html`** — one `<link rel="icon" type="image/svg+xml">` line.

## Color

Drawn from the viewer's "Warm Scholarly" palette (`packages/viewer-ui/src/styles/global.css`): the `text-primary` brown `#2c2419` as the tile, gold for the mark.

The glyph uses `#d4a24c` rather than the literal `--accent-gold` `#b8860b` — that value only reaches ~4.7:1 against the brown tile and goes muddy at favicon size. `#d4a24c` is ~6.6:1 and reads as the same gold family.

## Tradeoff: SVG only, no `.ico` fallback

Every browser this app targets supports SVG favicons (Chrome 80+, Firefox 41+, Safari 15+). Legacy Edge/IE would show nothing, and the `/favicon.ico` request still 404s. Happy to add a rasterized PNG fallback if that matters — it needs a rasterizer that isn't installed on my box.

## Verification

- SVG is well-formed XML (checked with `xml.dom.minidom` — worth doing, since an early draft embedded `--text-primary` in a comment and XML forbids `--` inside comments).
- Rendered at 32px and 400px to confirm it holds up at tab size.
- **Not** run: `vite build`. `vite.config.ts` doesn't override `publicDir`, so the default `public/` to dist-root copy applies, and the server's `StaticFiles` mount at `/` (`apps/server/app/main.py:130`) serves the dist root — but I didn't build to confirm end to end.

## Out of scope

`apps/electron/resources/icon.png` is still the stock Electron atom placeholder. Worth a follow-up if you want the two apps to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
